### PR TITLE
Bug fixes — OpenAI GPT-5, Custom API backup, dev-server origin (1.19.3)

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -40,9 +40,18 @@ function serveFile(res, filePath) {
   });
 }
 
+const ALLOWED_ORIGINS = new Set([
+  `http://127.0.0.1:${PORT}`,
+  `http://localhost:${PORT}`,
+  `http://[::1]:${PORT}`,
+]);
 function isSameOrigin(req) {
-  const origin = req.headers.origin || req.headers.referer || '';
-  return origin.includes(`localhost:${PORT}`) || origin.includes(`127.0.0.1:${PORT}`);
+  if (req.headers.origin) return ALLOWED_ORIGINS.has(req.headers.origin);
+  if (req.headers.referer) {
+    try { return ALLOWED_ORIGINS.has(new URL(req.headers.referer).origin); }
+    catch { return false; }
+  }
+  return false;
 }
 
 const server = http.createServer((req, res) => {

--- a/js/api.js
+++ b/js/api.js
@@ -589,6 +589,15 @@ export async function callOllamaChat({ system, messages, maxTokens, onStream, si
 // ═══════════════════════════════════════════════
 // SHARED OPENAI-COMPATIBLE API HELPER
 // ═══════════════════════════════════════════════
+// GPT-5 family + o-series reasoning models reject `max_tokens` and require `max_completion_tokens`.
+// Matches bare ids (gpt-5.4, o1-mini) and provider-prefixed (openai/gpt-5, openai/o3).
+export function needsMaxCompletionTokens(modelId) {
+  if (!modelId) return false;
+  const id = String(modelId).toLowerCase();
+  const bare = id.includes('/') ? id.split('/').pop() : id;
+  return /^(gpt-5|o[1-9])([-.]|$)/.test(bare);
+}
+
 async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal }, extraHeaders = {}, { useProxy = true, extraBody = {} } = {}) {
   const apiMessages = [];
   if (system) apiMessages.push({ role: 'system', content: system });
@@ -598,7 +607,8 @@ async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { sys
   // to give room for thinking while still constraining total output
   const isThinkingModel = /deepseek-r1|kimi-k|qwq|glm-[45]|claude-.*sonnet|claude-.*opus|:cloud/.test(model);
   const effectiveMaxTokens = isThinkingModel && maxTokens && maxTokens < 4096 ? Math.min(maxTokens * 5, 4096) : maxTokens;
-  const body = { model, messages: apiMessages, max_tokens: effectiveMaxTokens || 4096, ...extraBody };
+  const tokenLimitField = needsMaxCompletionTokens(model) ? 'max_completion_tokens' : 'max_tokens';
+  const body = { model, messages: apiMessages, [tokenLimitField]: effectiveMaxTokens || 4096, ...extraBody };
   if (onStream) { body.stream = true; body.stream_options = { include_usage: true }; }
 
   let res;
@@ -1194,5 +1204,6 @@ Object.assign(window, {
   getCustomApiUrl, setCustomApiUrl, getCustomApiKey, saveCustomApiKey, hasCustomApiKey,
   getCustomApiModel, setCustomApiModel, getCustomApiModelDisplay,
   fetchCustomApiModels, callCustomAPI,
-  callOllamaChat, callOpenAICompatibleLocalAPI, callVeniceAPI, callOpenRouterAPI, callRoutstrAPI, callPpqAPI, callClaudeAPI
+  callOllamaChat, callOpenAICompatibleLocalAPI, callVeniceAPI, callOpenRouterAPI, callRoutstrAPI, callPpqAPI, callClaudeAPI,
+  needsMaxCompletionTokens
 });

--- a/js/backup.js
+++ b/js/backup.js
@@ -12,6 +12,7 @@ const isEncryptedValue = (v) => typeof v === 'string' && v.startsWith('v1:');
 // ═══════════════════════════════════════════════
 const GLOBAL_SETTINGS_KEYS = [
   'labcharts-venice-key', 'labcharts-openrouter-key', 'labcharts-routstr-key', 'labcharts-ppq-key',
+  'labcharts-custom-key', 'labcharts-custom-url', 'labcharts-custom-model', 'labcharts-custom-models',
   'labcharts-ai-provider',
   'labcharts-ppq-credit-id',
   'labcharts-venice-model', 'labcharts-openrouter-model', 'labcharts-routstr-model', 'labcharts-ppq-model',

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,14 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.19.3', date: '2026-04-15', title: 'Bug fixes — OpenAI GPT-5, Custom API backup, dev-server origin',
+    items: [
+      'OpenAI GPT-5 family and o-series reasoning models now work via the Custom API provider \u2014 switched to max_completion_tokens (#114)',
+      'Custom API key, URL, and selected model now survive backup/restore and sync across devices (#116)',
+      'Hardened dev-server same-origin guard \u2014 forged Referer/Origin substrings can no longer bypass the /api/* check (#119)',
+    ]
+  },
+  {
     version: '1.19.2', date: '2026-04-14', title: 'Sync Context Fix',
     items: [
       'Specialty lab data (Fatty Acids, OAT, etc.) now syncs completely even when excluded from AI chat',

--- a/js/sync.js
+++ b/js/sync.js
@@ -364,6 +364,10 @@ const AI_SETTINGS_KEYS = [
   'labcharts-routstr-key',       // Routstr key (encrypted)
   'labcharts-ppq-key',           // PPQ key (encrypted)
   'labcharts-ppq-credit-id',     // PPQ credit ID (for balance/topup)
+  'labcharts-custom-key',        // Custom API key (encrypted)
+  'labcharts-custom-url',        // Custom API base URL
+  'labcharts-custom-model',      // Custom API selected model
+  'labcharts-custom-models',     // Custom API model list cache
   'labcharts-ollama',            // Local AI server config (encrypted)
   'labcharts-openrouter-model',
   'labcharts-venice-model',
@@ -387,7 +391,7 @@ async function collectAISettings() {
   return settings;
 }
 
-const ENCRYPTED_AI_KEYS = ['labcharts-openrouter-key', 'labcharts-venice-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-ollama', 'labcharts-cashu-wallet-mnemonic'];
+const ENCRYPTED_AI_KEYS = ['labcharts-openrouter-key', 'labcharts-venice-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-custom-key', 'labcharts-ollama', 'labcharts-cashu-wallet-mnemonic'];
 
 async function applyAISettings(settings) {
   if (!settings) return;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -35,4 +35,5 @@ cleanup() {
 }
 trap cleanup EXIT
 
+PORT=$PORT node "$DIR/tests/test-dev-server-origin.js" || exit 1
 PORT=$PORT NODE_PATH="$NODE_PATH_EXTRA" node "$DIR/run-tests.js"

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -316,6 +316,44 @@ return (async function() {
   assert('_customApiFetchModels uses proxy', apiSrc.includes('function _customApiFetchModels('));
   assert('_customApiFetchModels sends method GET via proxy', apiSrc.includes("method: 'GET'"));
 
+  // ─── 18. needsMaxCompletionTokens — GPT-5 / o-series detection (#114) ───
+  console.log('\n18. needsMaxCompletionTokens (#114)');
+  assert('needsMaxCompletionTokens exists', typeof window.needsMaxCompletionTokens === 'function');
+  // Positive: GPT-5 family
+  assert('detects gpt-5', window.needsMaxCompletionTokens('gpt-5') === true);
+  assert('detects gpt-5.4', window.needsMaxCompletionTokens('gpt-5.4') === true);
+  assert('detects gpt-5-codex', window.needsMaxCompletionTokens('gpt-5-codex') === true);
+  assert('detects openai/gpt-5 (prefixed)', window.needsMaxCompletionTokens('openai/gpt-5') === true);
+  assert('detects openai/gpt-5.4 (prefixed)', window.needsMaxCompletionTokens('openai/gpt-5.4') === true);
+  // Positive: o-series reasoning models
+  assert('detects o1', window.needsMaxCompletionTokens('o1') === true);
+  assert('detects o1-mini', window.needsMaxCompletionTokens('o1-mini') === true);
+  assert('detects o3', window.needsMaxCompletionTokens('o3') === true);
+  assert('detects o3-mini', window.needsMaxCompletionTokens('o3-mini') === true);
+  assert('detects o4-mini', window.needsMaxCompletionTokens('o4-mini') === true);
+  assert('detects openai/o3 (prefixed)', window.needsMaxCompletionTokens('openai/o3') === true);
+  // Negative: older models that still use max_tokens
+  assert('rejects gpt-4', window.needsMaxCompletionTokens('gpt-4') === false);
+  assert('rejects gpt-4o', window.needsMaxCompletionTokens('gpt-4o') === false);
+  assert('rejects gpt-4-turbo', window.needsMaxCompletionTokens('gpt-4-turbo') === false);
+  assert('rejects gpt-3.5-turbo', window.needsMaxCompletionTokens('gpt-3.5-turbo') === false);
+  assert('rejects claude-opus-4-6', window.needsMaxCompletionTokens('claude-opus-4-6') === false);
+  assert('rejects llama-3.3-70b', window.needsMaxCompletionTokens('llama-3.3-70b') === false);
+  assert('rejects gemini-3-pro', window.needsMaxCompletionTokens('gemini-3-pro') === false);
+  assert('rejects deepseek-r1', window.needsMaxCompletionTokens('deepseek-r1') === false);
+  // Edge cases
+  assert('rejects empty string', window.needsMaxCompletionTokens('') === false);
+  assert('rejects null', window.needsMaxCompletionTokens(null) === false);
+  assert('rejects undefined', window.needsMaxCompletionTokens(undefined) === false);
+  // False-positive guards: must not match "gpt-5x" style malformed substrings or "ox" identifiers
+  assert('rejects gpt-50 (not GPT-5)', window.needsMaxCompletionTokens('gpt-50') === false);
+  assert('rejects ozone (no o[1-9] at start)', window.needsMaxCompletionTokens('ozone') === false);
+  assert('rejects openai/gpt-50', window.needsMaxCompletionTokens('openai/gpt-50') === false);
+  // callOpenAICompatibleAPI uses the helper to pick the field
+  assert('callOpenAICompatibleAPI uses needsMaxCompletionTokens', apiSrc.includes('needsMaxCompletionTokens(model)'));
+  assert('body uses dynamic tokenLimitField', apiSrc.includes('[tokenLimitField]:'));
+  assert('tokenLimitField defaults to max_tokens', apiSrc.includes("? 'max_completion_tokens' : 'max_tokens'"));
+
   // ═══ SUMMARY ═══
   console.log('\n' + results.join('\n'));
   console.log(`\n=== ${passed} passed, ${failed} failed, ${passed + failed} total ===`);

--- a/tests/test-dev-server-origin.js
+++ b/tests/test-dev-server-origin.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Node-side test: dev-server /api/* same-origin guard rejects forged headers.
+// Probes a running dev server. Issue #119.
+// Run: node tests/test-dev-server-origin.js (server must be on :$PORT, default 8000)
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 8000;
+const HOST = '127.0.0.1';
+
+function probe(method, pathStr, headers) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: HOST, port: PORT, path: pathStr, method, headers, timeout: 5000 }, (res) => {
+      res.on('data', () => {});
+      res.on('end', () => resolve(res.statusCode));
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(new Error('timeout')); });
+    req.end();
+  });
+}
+
+(async () => {
+  const results = [];
+  let passed = 0, failed = 0;
+  function assert(name, cond, detail) {
+    if (cond) { passed++; results.push(`  PASS: ${name}`); }
+    else { failed++; results.push(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+  }
+
+  console.log('=== dev-server origin guard tests ===\n');
+
+  // 1. No Origin/Referer → 403
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {});
+    assert('no headers → 403', status === 403, `got ${status}`);
+  } catch (e) { assert('no headers → 403', false, e.message); }
+
+  // 2. Forged foreign Referer with substring → must be 403 (the bug)
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Referer': `https://evil.example/?next=http://${HOST}:${PORT}/`,
+    });
+    assert('forged Referer substring → 403', status === 403, `got ${status} (substring bypass present)`);
+  } catch (e) { assert('forged Referer substring → 403', false, e.message); }
+
+  // 3. Forged foreign Origin with substring → must be 403
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Origin': `https://evil.example.${HOST}:${PORT}.attacker.io`,
+    });
+    assert('forged Origin substring → 403', status === 403, `got ${status}`);
+  } catch (e) { assert('forged Origin substring → 403', false, e.message); }
+
+  // 4. Legitimate Origin → 200 (request reaches handler; upstream may fail but guard passed)
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Origin': `http://${HOST}:${PORT}`,
+    });
+    assert('legitimate Origin → not 403', status !== 403, `got ${status}`);
+  } catch (e) { assert('legitimate Origin → not 403', false, e.message); }
+
+  // 5. Legitimate Referer → 200 (same)
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Referer': `http://${HOST}:${PORT}/app`,
+    });
+    assert('legitimate Referer → not 403', status !== 403, `got ${status}`);
+  } catch (e) { assert('legitimate Referer → not 403', false, e.message); }
+
+  // 6. Localhost Origin → 200
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Origin': `http://localhost:${PORT}`,
+    });
+    assert('localhost Origin → not 403', status !== 403, `got ${status}`);
+  } catch (e) { assert('localhost Origin → not 403', false, e.message); }
+
+  // 6b. IPv6 loopback Origin → 200
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Origin': `http://[::1]:${PORT}`,
+    });
+    assert('IPv6 [::1] Origin → not 403', status !== 403, `got ${status}`);
+  } catch (e) { assert('IPv6 [::1] Origin → not 403', false, e.message); }
+
+  // 6c. Lookalike origin with valid prefix but extra suffix → 403
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Origin': `http://localhost:${PORT}.evil.example`,
+    });
+    assert('lookalike "localhost:PORT.evil" Origin → 403', status === 403, `got ${status}`);
+  } catch (e) { assert('lookalike "localhost:PORT.evil" Origin → 403', false, e.message); }
+
+  // 6d. Malformed Referer → URL parse throws → 403
+  try {
+    const status = await probe('GET', '/api/check-url?url=https://example.com', {
+      'Referer': 'not a valid url',
+    });
+    assert('malformed Referer → 403', status === 403, `got ${status}`);
+  } catch (e) { assert('malformed Referer → 403', false, e.message); }
+
+  // 7. Source inspection — substring check is gone, parsing is in
+  const src = fs.readFileSync(path.join(__dirname, '..', 'dev-server.js'), 'utf8');
+  assert('isSameOrigin no longer uses .includes() for origin', !/origin\.includes\(`localhost:/.test(src));
+  assert('isSameOrigin parses Referer via new URL().origin', /new URL\(req\.headers\.referer\)\.origin/.test(src));
+  assert('ALLOWED_ORIGINS Set defined', /ALLOWED_ORIGINS = new Set/.test(src));
+
+  console.log(results.join('\n'));
+  console.log(`\n=== ${passed} passed, ${failed} failed ===`);
+  process.exit(failed === 0 ? 0 : 1);
+})();

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -367,6 +367,47 @@ return (async function() {
   assert('Bundle export always includes chat', exportSrc.includes('if (chat) entry.chat = chat'));
 
   // ═══════════════════════════════════════
+  // 13b. Backup includes Custom API settings (regression: #116)
+  // ═══════════════════════════════════════
+  console.log('%c 13b. Backup includes Custom API settings (#116) ', 'font-weight:bold;color:#f59e0b');
+
+  const backupSrc = await fetch('/js/backup.js').then(r => r.text());
+  assert('GLOBAL_SETTINGS_KEYS includes labcharts-custom-key', backupSrc.includes("'labcharts-custom-key'"));
+  assert('GLOBAL_SETTINGS_KEYS includes labcharts-custom-url', backupSrc.includes("'labcharts-custom-url'"));
+  assert('GLOBAL_SETTINGS_KEYS includes labcharts-custom-model', backupSrc.includes("'labcharts-custom-model'"));
+  assert('GLOBAL_SETTINGS_KEYS includes labcharts-custom-models', backupSrc.includes("'labcharts-custom-models'"));
+
+  // Functional roundtrip: seed Custom API settings → snapshot → wipe → restore
+  const _origCustomKey = localStorage.getItem('labcharts-custom-key');
+  const _origCustomUrl = localStorage.getItem('labcharts-custom-url');
+  const _origCustomModel = localStorage.getItem('labcharts-custom-model');
+  localStorage.setItem('labcharts-custom-key', 'sk-roundtrip-test');
+  localStorage.setItem('labcharts-custom-url', 'https://api.example.com/v1');
+  localStorage.setItem('labcharts-custom-model', 'gpt-test');
+
+  const snap = window.buildBackupSnapshot && window.buildBackupSnapshot();
+  assert('buildBackupSnapshot exposed', !!snap, 'window.buildBackupSnapshot missing');
+  if (snap) {
+    assert('snapshot.settings carries custom-key', snap.settings['labcharts-custom-key'] === 'sk-roundtrip-test');
+    assert('snapshot.settings carries custom-url', snap.settings['labcharts-custom-url'] === 'https://api.example.com/v1');
+    assert('snapshot.settings carries custom-model', snap.settings['labcharts-custom-model'] === 'gpt-test');
+  }
+
+  // Restore originals
+  if (_origCustomKey !== null) localStorage.setItem('labcharts-custom-key', _origCustomKey);
+  else localStorage.removeItem('labcharts-custom-key');
+  if (_origCustomUrl !== null) localStorage.setItem('labcharts-custom-url', _origCustomUrl);
+  else localStorage.removeItem('labcharts-custom-url');
+  if (_origCustomModel !== null) localStorage.setItem('labcharts-custom-model', _origCustomModel);
+  else localStorage.removeItem('labcharts-custom-model');
+
+  // Sync also picks them up (cross-device parity)
+  const syncSrc = await fetch('/js/sync.js').then(r => r.text());
+  assert('AI_SETTINGS_KEYS includes labcharts-custom-key', /AI_SETTINGS_KEYS[\s\S]{0,800}labcharts-custom-key/.test(syncSrc));
+  assert('AI_SETTINGS_KEYS includes labcharts-custom-url', /AI_SETTINGS_KEYS[\s\S]{0,800}labcharts-custom-url/.test(syncSrc));
+  assert('ENCRYPTED_AI_KEYS includes labcharts-custom-key', /ENCRYPTED_AI_KEYS[\s\S]{0,400}labcharts-custom-key/.test(syncSrc));
+
+  // ═══════════════════════════════════════
   // 14. Window exports
   // ═══════════════════════════════════════
   console.log('%c 14. Window exports ', 'font-weight:bold;color:#f59e0b');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.19.2';
+self.APP_VERSION = '1.19.3';


### PR DESCRIPTION
## Summary
Three independent bug fixes shipped together as v1.19.3.

- **#114** — OpenAI GPT-5 family and o-series reasoning models now work via the Custom API provider. Switched to `max_completion_tokens` (the field the new OpenAI API requires) for matching model IDs. Detected by regex `^(gpt-5|o[1-9])([-.]|$)` against the bare model id (handles both `gpt-5.4` and `openai/gpt-5`).
- **#116** — Custom API key, base URL, selected model, and cached model list now persist through backup/restore and propagate via cross-device sync. Same root cause on both surfaces: the four `labcharts-custom-*` keys were missing from `GLOBAL_SETTINGS_KEYS` (backup) and `AI_SETTINGS_KEYS` / `ENCRYPTED_AI_KEYS` (sync).
- **#119** — Hardened dev-server `/api/*` same-origin guard. Replaced substring `.includes('localhost:PORT')` with exact-match Set lookup on `new URL(referer).origin`. A forged `Referer: https://evil.example/?next=http://127.0.0.1:8000/` no longer bypasses the check. IPv6 loopback `[::1]` added to the allowlist while we're here.

One commit per issue for clean revert / blame:
- 75d3109 — #119 dev-server
- 12d5bec — #116 backup + sync
- 291a08a — #114 max_completion_tokens + version bump + changelog

## Test plan

- [x] New Node test `tests/test-dev-server-origin.js` — 12 assertions covering forged Origin/Referer, IPv6, lookalikes, malformed Referer, source inspection. All pass.
- [x] `tests/test-export-import.js` — 11 new assertions for #116 (source + functional roundtrip + sync parity). All pass. Total 154/154.
- [x] `tests/test-custom-api.js` — 27 new assertions for #114 covering positive/negative model detection, false-positive guards (`gpt-50`, `o10`, `gpt-4o`, `ozone`), prefixed/bare ids, and the wiring into `callOpenAICompatibleAPI`. All pass.
- [x] Full suite via `./run-tests.sh` — only the 25 pre-existing failures in `test-custom-api.js` (settings.js extraction artifacts from v1.18.5) and 1 in `test-chat-threads.js` remain, both predate this branch.
- [ ] Manual smoke test on a real OpenAI API key with `gpt-5.4` — recommended before tagging the release.
- [ ] Manual backup → restore round-trip on a profile that has Custom API configured.

## Notes

- Patch bump (1.19.2 → 1.19.3) — won't trigger the What's New popup per the changelog convention.
- No CLAUDE.md / docs changes needed — these fixes either make existing user-facing claims accurate (#116) or are internal (#114, #119).
- If PR #117 (Custom Knowledge Source, 1.20.0) lands first, this will need a small rebase to bump 1.19.3 → 1.20.1.