### PR TITLE
v1.20.1 — Robert bug batch 2 (#119, #123, #124)

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -58,8 +58,9 @@ const server = http.createServer((req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   let pathname = decodeURIComponent(url.pathname);
 
-  // Same-origin guard for proxy/API endpoints
-  if (pathname.startsWith('/api/') && !isSameOrigin(req)) {
+  // Same-origin guard for proxy/API endpoints. Blocks SSRF via forged
+  // Origin/Referer from browser tabs on malicious sites. See #119.
+  if ((pathname.startsWith('/api/') || pathname === '/proxy') && !isSameOrigin(req)) {
     res.writeHead(403); res.end('Forbidden'); return;
   }
 

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,14 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.20.1', date: '2026-04-16', title: 'Bug Fixes',
+    items: [
+      'Custom API key now works after page reload — previously the encrypted blob was sent as the Bearer token, breaking requests until the key was re-entered (#124)',
+      'Context cards (diet, sleep, stress, exercise, light, love, environment, diagnoses) now update on screen immediately after saving, no reload needed (#123)',
+      'Closed SSRF bypass on the legacy /proxy dev-server route — the same-origin guard from #119 now covers both /api/* and /proxy (#119 follow-up)',
+    ]
+  },
+  {
     version: '1.20.0', date: '2026-04-15', title: 'Custom Knowledge Source',
     items: [
       'Connect a RAG knowledge endpoint to your Interpretive Lens — the AI grounds its analysis in your own research, clinical guides, or documents',

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -499,13 +499,21 @@ export function recordChange(field) {
 export function saveAndRefresh(msg, field) {
   if (field) recordChange(field);
   saveImportedData();
-  // Preserve details open state before closeModal re-renders the dashboard
+  // Preserve details open state across the re-render below
   const details = document.querySelector('.welcome-context-details');
   if (details?.open) sessionStorage.setItem('welcome-details-open', '1');
   window.closeModal();
   showNotification(msg, 'success');
   if (window.onContextCardSaved) window.onContextCardSaved();
-  // Refresh health dots for the saved card (fingerprint will have changed)
+  // Re-render the current view so the saved values appear on the card
+  // immediately. BroadcastChannel notifies other tabs but never delivers
+  // back to the sender, so a single-tab user would otherwise see no UI
+  // update until a reload or navigation. Mirrors the BroadcastChannel
+  // handler in crypto.js:initBroadcastChannel. See #123.
+  const activeNav = document.querySelector('.nav-item.active');
+  if (window.navigate) window.navigate(activeNav ? activeNav.dataset.category : 'dashboard');
+  // Refresh health dots for the saved card (fingerprint will have changed).
+  // Must run after navigate() so the ctx-dot-* elements exist in the new DOM.
   loadContextHealthDots();
 }
 

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -36,7 +36,7 @@ let _sessionKey = null;
 // ═══════════════════════════════════════════════
 // API KEY CACHE — sync access to decrypted API keys
 // ═══════════════════════════════════════════════
-const API_KEY_LS_KEYS = ['labcharts-api-key', 'labcharts-venice-key', 'labcharts-openrouter-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-lens-key', 'labcharts-ollama', 'labcharts-cashu-wallet-mnemonic'];
+const API_KEY_LS_KEYS = ['labcharts-api-key', 'labcharts-venice-key', 'labcharts-openrouter-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-lens-key', 'labcharts-custom-key', 'labcharts-ollama', 'labcharts-cashu-wallet-mnemonic'];
 const _keyCache = new Map();
 
 export async function decryptKeyCache() {

--- a/run-tests.js
+++ b/run-tests.js
@@ -70,10 +70,21 @@ const PORT = process.env.PORT || 8000;
     const clean = text.replace(/%c/g, '').replace(/(?:color|background|font-weight|font-size|font-family|padding|border-radius|margin|display)\s*:[^;]+;?/g, '').trim();
     if (!clean) return;
 
-    if (clean.startsWith('FAIL ') || clean.startsWith('PAGE ERROR') || clean.includes('\u274C')) {
+    // Per-assert failure line (both "FAIL " and "FAIL:" formats)
+    if (clean.startsWith('FAIL ') || clean.startsWith('FAIL:') || clean.startsWith('PAGE ERROR') || clean.includes('\u274C')) {
       fails.push(clean);
       console.log('\x1b[31m' + clean + '\x1b[0m');
-    } else if (clean.includes('passed') || clean.includes('Results')) {
+      return;
+    }
+    // Summary lines like "115 passed, 25 failed, 140 total" — flag if any failed
+    const summaryMatch = clean.match(/(\d+)\s+passed[,\s]+(\d+)\s+failed/i);
+    if (summaryMatch && parseInt(summaryMatch[2], 10) > 0) {
+      const failedCount = parseInt(summaryMatch[2], 10);
+      fails.push(`SUMMARY: ${failedCount} failed — ${clean}`);
+      console.log('\x1b[31m' + clean + '\x1b[0m');
+      return;
+    }
+    if (clean.includes('passed') || clean.includes('Results')) {
       console.log('\x1b[36m' + clean + '\x1b[0m');
     } else if (clean.startsWith('\u25B6')) {
       console.log('\x1b[1m' + clean + '\x1b[0m');

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -202,41 +202,47 @@ return (async function() {
   const pricing = window.renderModelPricingHint('custom', 'any-model');
   assert('custom pricing returns empty (unknown endpoint)', pricing === '');
 
-  // ─── 12. settings.js source inspection ───
-  console.log('\n12. settings.js source inspection');
+  // ─── 12. settings.js + provider-panels.js source inspection ───
+  // Provider UI (including Custom) was extracted from settings.js into
+  // provider-panels.js during v1.18.5 refactor. settings.js still holds the
+  // provider-button row and the switchAIProvider wiring.
+  console.log('\n12. settings.js + provider-panels.js source inspection');
   const settingsSrc = await fetch('js/settings.js').then(r => r.text());
-  assert('imports getCustomApiUrl', settingsSrc.includes('getCustomApiUrl'));
-  assert('imports setCustomApiUrl', settingsSrc.includes('setCustomApiUrl'));
-  assert('imports getCustomApiKey', settingsSrc.includes('getCustomApiKey'));
-  assert('imports saveCustomApiKey', settingsSrc.includes('saveCustomApiKey'));
-  assert('imports hasCustomApiKey', settingsSrc.includes('hasCustomApiKey'));
-  assert('imports getCustomApiModel', settingsSrc.includes('getCustomApiModel'));
-  assert('imports setCustomApiModel', settingsSrc.includes('setCustomApiModel'));
-  assert('imports getCustomApiModelDisplay', settingsSrc.includes('getCustomApiModelDisplay'));
-  assert('imports fetchCustomApiModels', settingsSrc.includes('fetchCustomApiModels'));
-  assert('imports validateCustomApiKey', settingsSrc.includes('validateCustomApiKey'));
-  assert('6th provider button with data-provider="custom"', settingsSrc.includes('data-provider="custom"'));
-  assert('switchAIProvider(\'custom\') in onclick', settingsSrc.includes("switchAIProvider('custom')"));
-  assert('renderAIProviderPanel handles custom', settingsSrc.includes("provider === 'custom'"));
-  assert('handleSaveCustomApi exists', settingsSrc.includes('function handleSaveCustomApi()'));
-  assert('handleRemoveCustomApi exists', settingsSrc.includes('function handleRemoveCustomApi()'));
-  assert('renderCustomApiModelDropdown exists', settingsSrc.includes('function renderCustomApiModelDropdown('));
-  assert('applyCustomApiManualModel exists', settingsSrc.includes('function applyCustomApiManualModel()'));
-  assert('custom-url-input element', settingsSrc.includes('custom-url-input'));
-  assert('custom-key-input element', settingsSrc.includes('custom-key-input'));
-  assert('custom-model-area element', settingsSrc.includes('custom-model-area'));
-  assert('custom-model-select element', settingsSrc.includes('custom-model-select'));
-  assert('custom-manual-model element', settingsSrc.includes('custom-manual-model'));
-  assert('initSettingsModelFetch handles custom', settingsSrc.includes('fetchCustomApiModels(customUrl, customKey)'));
-  // Window exports
-  assert('window exports handleSaveCustomApi', settingsSrc.includes('handleSaveCustomApi,'));
-  assert('window exports handleRemoveCustomApi', settingsSrc.includes('handleRemoveCustomApi,'));
-  assert('window exports renderCustomApiModelDropdown', settingsSrc.includes('renderCustomApiModelDropdown,'));
-  assert('window exports applyCustomApiManualModel', settingsSrc.includes('applyCustomApiManualModel,'));
-  // Custom panel before Local AI
-  const customPanelIdx = settingsSrc.indexOf("// Custom API panel");
-  const localPanelIdx = settingsSrc.indexOf("// Local AI panel");
-  assert('Custom API panel before Local AI panel', customPanelIdx < localPanelIdx, `custom@${customPanelIdx}, local@${localPanelIdx}`);
+  const panelsSrc = await fetch('js/provider-panels.js').then(r => r.text());
+  // settings.js still owns the provider switcher row
+  assert('settings.js has data-provider="custom" button', settingsSrc.includes('data-provider="custom"'));
+  assert('settings.js wires switchAIProvider(\'custom\')', settingsSrc.includes("switchAIProvider('custom')"));
+  // provider-panels.js owns the Custom panel: getters/setters + handlers
+  assert('provider-panels imports getCustomApiUrl', panelsSrc.includes('getCustomApiUrl'));
+  assert('provider-panels imports setCustomApiUrl', panelsSrc.includes('setCustomApiUrl'));
+  assert('provider-panels imports getCustomApiKey', panelsSrc.includes('getCustomApiKey'));
+  assert('provider-panels imports saveCustomApiKey', panelsSrc.includes('saveCustomApiKey'));
+  // hasCustomApiKey / getCustomApiModelDisplay stay in api.js (covered by section 1);
+  // the panel uses local `currentKey`/`customModel` vars directly.
+  assert('provider-panels imports getCustomApiModel', panelsSrc.includes('getCustomApiModel'));
+  assert('provider-panels imports setCustomApiModel', panelsSrc.includes('setCustomApiModel'));
+  assert('provider-panels imports fetchCustomApiModels', panelsSrc.includes('fetchCustomApiModels'));
+  assert('provider-panels imports validateCustomApiKey', panelsSrc.includes('validateCustomApiKey'));
+  assert('renderAIProviderPanel handles custom', panelsSrc.includes("provider === 'custom'"));
+  assert('handleSaveCustomApi exists', panelsSrc.includes('function handleSaveCustomApi()'));
+  assert('handleRemoveCustomApi exists', panelsSrc.includes('function handleRemoveCustomApi()'));
+  assert('renderCustomApiModelDropdown exists', panelsSrc.includes('function renderCustomApiModelDropdown('));
+  assert('applyCustomApiManualModel exists', panelsSrc.includes('function applyCustomApiManualModel()'));
+  assert('custom-url-input element', panelsSrc.includes('custom-url-input'));
+  assert('custom-key-input element', panelsSrc.includes('custom-key-input'));
+  assert('custom-model-area element', panelsSrc.includes('custom-model-area'));
+  assert('custom-model-select element', panelsSrc.includes('custom-model-select'));
+  assert('custom-manual-model element', panelsSrc.includes('custom-manual-model'));
+  assert('initSettingsModelFetch handles custom', panelsSrc.includes('fetchCustomApiModels(customUrl, customKey)'));
+  // Window exports (provider-panels.js)
+  assert('window exports handleSaveCustomApi', panelsSrc.includes('handleSaveCustomApi,'));
+  assert('window exports handleRemoveCustomApi', panelsSrc.includes('handleRemoveCustomApi,'));
+  assert('window exports renderCustomApiModelDropdown', panelsSrc.includes('renderCustomApiModelDropdown,'));
+  assert('window exports applyCustomApiManualModel', panelsSrc.includes('applyCustomApiManualModel,'));
+  // Custom panel before Local AI (in provider-panels.js)
+  const customPanelIdx = panelsSrc.indexOf('// Custom API panel');
+  const localPanelIdx = panelsSrc.indexOf('// Local AI panel');
+  assert('Custom API panel before Local AI panel', customPanelIdx >= 0 && localPanelIdx >= 0 && customPanelIdx < localPanelIdx, `custom@${customPanelIdx}, local@${localPanelIdx}`);
 
   // ─── 13. Settings modal DOM ───
   console.log('\n13. Settings modal DOM');

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -354,6 +354,45 @@ return (async function() {
   assert('body uses dynamic tokenLimitField', apiSrc.includes('[tokenLimitField]:'));
   assert('tokenLimitField defaults to max_tokens', apiSrc.includes("? 'max_completion_tokens' : 'max_tokens'"));
 
+  // ─── 19. Startup cache decrypts Custom API key (#124) ───
+  // Regression: API_KEY_LS_KEYS must include 'labcharts-custom-key' so
+  // decryptKeyCache() populates the in-memory cache on page reload. Without
+  // this, getCachedKey falls back to localStorage.getItem, which returns the
+  // raw encrypted blob — and callCustomAPI sends that as the Bearer token.
+  console.log('\n19. Startup cache decrypts Custom API key (#124)');
+  const cryptoSrc = await fetch('js/crypto.js').then(r => r.text());
+  const apiKeyListMatch = cryptoSrc.match(/const\s+API_KEY_LS_KEYS\s*=\s*\[([^\]]*)\]/);
+  assert('API_KEY_LS_KEYS array exists in crypto.js', !!apiKeyListMatch);
+  if (apiKeyListMatch) {
+    const listBody = apiKeyListMatch[1];
+    assert('API_KEY_LS_KEYS includes labcharts-custom-key', listBody.includes("'labcharts-custom-key'"),
+      'Custom API key must be decrypted into in-memory cache at startup (issue #124)');
+  }
+  // Runtime check: after a round-trip through decryptKeyCache, the cached key
+  // should match what was originally stored (not the encrypted ciphertext blob).
+  if (typeof window.decryptKeyCache === 'function' && typeof window.isUnlocked === 'function' && window.isUnlocked() && typeof window.getCustomApiKey === 'function') {
+    const sv_key = localStorage.getItem('labcharts-custom-key');
+    try {
+      await window.saveCustomApiKey('sk-roundtrip-test-124');
+      // Confirm stored form is encrypted
+      const storedRaw = localStorage.getItem('labcharts-custom-key');
+      const looksEncrypted = !!storedRaw && storedRaw.startsWith('enc_v1:');
+      assert('saveCustomApiKey stores encrypted ciphertext', looksEncrypted,
+        `got: ${storedRaw ? storedRaw.slice(0, 20) + '…' : 'null'}`);
+      // Clear cache, then re-decrypt from localStorage (simulates page reload)
+      window.updateKeyCache('labcharts-custom-key', null);
+      await window.decryptKeyCache();
+      assert('decryptKeyCache rehydrates custom key from encrypted storage', window.getCustomApiKey() === 'sk-roundtrip-test-124',
+        `got: ${window.getCustomApiKey()}`);
+    } finally {
+      if (sv_key) localStorage.setItem('labcharts-custom-key', sv_key);
+      else localStorage.removeItem('labcharts-custom-key');
+      window.updateKeyCache('labcharts-custom-key', null);
+    }
+  } else {
+    console.log('  (skipped runtime rehydrate — encryption not unlocked in this session)');
+  }
+
   // ═══ SUMMARY ═══
   console.log('\n' + results.join('\n'));
   console.log(`\n=== ${passed} passed, ${failed} failed, ${passed + failed} total ===`);

--- a/tests/test-custom-personality.js
+++ b/tests/test-custom-personality.js
@@ -241,12 +241,13 @@ return (async function() {
   assert('saveChatHistory has personalityIcon', saveSrc.includes('personalityIcon'));
 
   // ── 15. Backup compat ──
+  // PER_PROFILE_PREF_SUFFIXES moved from crypto.js to backup.js in the v1.18.5 extraction.
   console.log('%c▶ 15. Backup compat', 'font-weight:bold');
   try {
-    const cryptoSrc = await fetchWithRetry('js/crypto.js');
-    assert('PER_PROFILE_PREF_SUFFIXES has chatPersonalityCustom', cryptoSrc.includes('chatPersonalityCustom'));
+    const backupSrc = await fetchWithRetry('js/backup.js');
+    assert('PER_PROFILE_PREF_SUFFIXES has chatPersonalityCustom', backupSrc.includes('chatPersonalityCustom'));
   } catch {
-    assert('Could read crypto.js', false);
+    assert('Could read backup.js', false);
   }
 
   // ── 16. Service worker cache version ──

--- a/tests/test-dev-server-origin.js
+++ b/tests/test-dev-server-origin.js
@@ -107,6 +107,57 @@ function probe(method, pathStr, headers) {
   assert('isSameOrigin no longer uses .includes() for origin', !/origin\.includes\(`localhost:/.test(src));
   assert('isSameOrigin parses Referer via new URL().origin', /new URL\(req\.headers\.referer\)\.origin/.test(src));
   assert('ALLOWED_ORIGINS Set defined', /ALLOWED_ORIGINS = new Set/.test(src));
+  // Guard must cover /proxy too — this was missed in the original #119 fix and
+  // re-reported by Robert as an SSRF bypass via the legacy /proxy route. The
+  // behavior test below is the real check; this catches silent regressions
+  // even if the server happens to be down when tests run.
+  assert('same-origin guard covers /proxy at route level',
+    /\/api\/.*\|\|.*pathname\s*===\s*['"]\/proxy['"]|pathname\s*===\s*['"]\/proxy['"].*\|\|.*\/api\//.test(src) &&
+    /!isSameOrigin\(req\)/.test(src));
+
+  // ─── /proxy SSRF guard (#119 follow-up) ───
+  // Legacy GET /proxy?url=... was unguarded. Without the fix, an evil tab could
+  // cross-origin fetch /proxy?url=http://192.168.1.1/admin and read the
+  // response (Access-Control-Allow-Origin: *). The exact-origin guard must
+  // reject foreign/forged headers here too.
+
+  // 8. No headers on /proxy → 403
+  try {
+    const status = await probe('GET', '/proxy?url=http://example.com', {});
+    assert('/proxy no headers → 403', status === 403, `got ${status}`);
+  } catch (e) { assert('/proxy no headers → 403', false, e.message); }
+
+  // 9. Forged foreign Origin containing local URL → 403 (the original repro)
+  try {
+    const status = await probe('GET', '/proxy?url=http://example.com', {
+      'Origin': 'https://evil.example',
+    });
+    assert('/proxy forged foreign Origin → 403', status === 403, `got ${status} (SSRF bypass present)`);
+  } catch (e) { assert('/proxy forged foreign Origin → 403', false, e.message); }
+
+  // 10. Forged foreign Referer with substring → 403
+  try {
+    const status = await probe('GET', '/proxy?url=http://example.com', {
+      'Referer': `https://evil.example/?next=http://${HOST}:${PORT}/`,
+    });
+    assert('/proxy forged Referer substring → 403', status === 403, `got ${status}`);
+  } catch (e) { assert('/proxy forged Referer substring → 403', false, e.message); }
+
+  // 11. Lookalike origin → 403
+  try {
+    const status = await probe('GET', '/proxy?url=http://example.com', {
+      'Origin': `http://localhost:${PORT}.evil.example`,
+    });
+    assert('/proxy lookalike Origin → 403', status === 403, `got ${status}`);
+  } catch (e) { assert('/proxy lookalike Origin → 403', false, e.message); }
+
+  // 12. Legitimate same-origin Origin → not 403 (handler runs)
+  try {
+    const status = await probe('GET', '/proxy?url=http://example.com', {
+      'Origin': `http://${HOST}:${PORT}`,
+    });
+    assert('/proxy legitimate Origin → not 403', status !== 403, `got ${status}`);
+  } catch (e) { assert('/proxy legitimate Origin → not 403', false, e.message); }
 
   console.log(results.join('\n'));
   console.log(`\n=== ${passed} passed, ${failed} failed ===`);

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -192,6 +192,49 @@ return (async function() {
   assert('refreshAllHealthDots exposed on window', ctxSrc.includes('refreshAllHealthDots'));
   assert('Refresh button in renderProfileContextCards', ctxSrc.includes('ctx-refresh-all-btn'));
 
+  // saveAndRefresh must trigger a re-render of the current view — BroadcastChannel
+  // does not deliver postMessage back to the sender, so single-tab users see no
+  // UI update without an explicit navigate() call. Issue #123.
+  const saveRefreshMatch = ctxSrc.match(/export function saveAndRefresh\([^)]*\)\s*\{([\s\S]*?)^\}/m);
+  assert('saveAndRefresh body found', !!saveRefreshMatch);
+  if (saveRefreshMatch) {
+    const body = saveRefreshMatch[1];
+    assert('saveAndRefresh calls navigate for in-tab re-render (#123)',
+      /window\.navigate\s*\(/.test(body) || /\bnavigate\s*\(/.test(body),
+      'without this, saved context card values stay hidden until reload');
+  }
+
+  // Runtime check: save mutates state → re-render → summary text appears in DOM.
+  const _rtState = window._labState;
+  if (typeof window.saveAndRefresh === 'function' && typeof window.navigate === 'function' && _rtState) {
+    const sv_stress = _rtState.importedData?.stress;
+    try {
+      window.navigate('dashboard');
+      await new Promise(r => setTimeout(r, 50));
+      // Stress card should exist (context cards always render on dashboard)
+      const stressCardBefore = document.querySelector('.profile-context-cards');
+      if (stressCardBefore) {
+        // Simulate a save: mutate state then call saveAndRefresh (same path as saveStress)
+        _rtState.importedData.stress = { level: 'moderate', sources: ['work'], management: ['exercise'], note: '' };
+        window.saveAndRefresh('Stress profile saved', 'stress');
+        await new Promise(r => setTimeout(r, 50));
+        // After re-render, the stress card body should contain the summary text
+        // produced by getStressSummary: "moderate stress — work — manages: exercise"
+        const cardsAfter = document.querySelector('.profile-context-cards');
+        const cardsText = cardsAfter ? cardsAfter.textContent : '';
+        assert('card body reflects saved stress level after saveAndRefresh (#123)',
+          cardsText.includes('moderate stress') && cardsText.includes('work'),
+          `cards text was: ${cardsText.slice(0, 200)}`);
+      }
+    } finally {
+      // Restore pre-test state
+      if (_rtState?.importedData) {
+        if (sv_stress !== undefined) _rtState.importedData.stress = sv_stress;
+        else delete _rtState.importedData.stress;
+      }
+    }
+  }
+
   // ═══════════════════════════════════════
   // 12. PDF filename storage
   // ═══════════════════════════════════════

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.20.0';
+self.APP_VERSION = '1.20.1';


### PR DESCRIPTION
## Summary
Patch release bundling three bugs Robert reported:

- **#124 Custom API key broken after reload** — `labcharts-custom-key` was missing from `API_KEY_LS_KEYS` in `crypto.js`, so `decryptKeyCache()` never rehydrated the in-memory cache on page load. `getCachedKey()` fell through to `localStorage.getItem`, which returned the raw encrypted blob — and `callCustomAPI` sent that verbatim as the Bearer token. UI still showed "Connected" because `hasCustomApiKey()` only checks truthiness. One-line fix.
- **#123 Context cards don't re-render after save** — `saveAndRefresh()` relied on `BroadcastChannel` to trigger a re-render, but `postMessage` never delivers back to the sender, so single-tab users saw no UI update until reload. Added an explicit `navigate()` call that mirrors the BroadcastChannel handler in `crypto.js`. Affected 8 cards (diagnoses, diet, sleep, light, exercise, stress, loveLife, environment); Health Goals and Interpretive Lens already called `navigate()` in their own save paths.
- **#119 follow-up: SSRF bypass on legacy `/proxy`** — the exact-origin guard from #119 covered `/api/*` but missed the legacy `GET /proxy?url=...` route. A browser tab on a malicious site could fetch `/proxy?url=<internal-host>` and read the response. One-char extension to the guard condition.

Bonus: test-runner fix — the runner only detected `FAIL ` (space), not `FAIL:` (colon), hiding 26 pre-existing failures for multiple releases. Fixed + updated source-grep targets in `test-custom-api.js` and `test-custom-personality.js` that had gone stale after the v1.18.5 extractions (Custom API UI moved to `provider-panels.js`, `PER_PROFILE_PREF_SUFFIXES` moved to `backup.js`).

Version bumped to **1.20.1**.

## Test plan
- [x] Full suite: 42 files, 0 failures
- [x] #124 — round-trip regression in `test-custom-api.js §19`: save key → clear cache → `decryptKeyCache` → verify cached key matches (not ciphertext)
- [x] #123 — runtime regression in `test-integration-batch2.js §11`: mutate `state.stress` → `saveAndRefresh` → assert card body reflects `getStressSummary()` output without reload
- [x] #119 follow-up — 5 new probes in `test-dev-server-origin.js`: no headers, forged foreign Origin (Robert's exact repro), forged Referer substring, lookalike `localhost:PORT.evil`, legitimate Origin
- [x] Manual verify: Robert's curl repro for #119 now returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)