### PR TITLE
feat(lens): collapse Knowledge Base external-server setup to one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Opt-in feature that lets AI agents query your lab context — coding agents (Cla
 - Enable in **Settings → Data → Agent Access** to generate a read-only token
 - Context is pushed to a lightweight gateway on every save and profile switch
 - Per-profile: each profile's context is stored separately; agents can query any profile by ID
-- Install via `pipx install "getbased-agent-stack[full]"` — [getbased-agents](https://github.com/elkimek/getbased-agents) bundles the MCP adapter, local RAG knowledge server, and browser setup dashboard. Works with [Hermes Agent](https://github.com/hermes-agent/hermes-agent), [OpenClaw](https://openclaw.ai), Claude Code, Claude Desktop, Cursor, Cline, or any MCP-compatible agent
+- Install on Linux with one command: `curl -sSL https://getbased.health/install.sh | bash` (`pipx install --include-deps "getbased-agent-stack[full]"` for manual / cross-platform installs). [getbased-agents](https://github.com/elkimek/getbased-agents) bundles the MCP adapter, local RAG knowledge server, and browser setup dashboard. Works with [Hermes Agent](https://github.com/hermes-agent/hermes-agent), [OpenClaw](https://openclaw.ai), Claude Code, Claude Desktop, Cursor, Cline, or any MCP-compatible agent
 - Only the AI-readable context text is shared — never your mnemonic or raw lab data
 - Token is revocable at any time from the same settings panel
 
@@ -119,7 +119,7 @@ Open `index.html` (or start `node dev-server.js` for development) and the dashbo
 ### Related repos
 
 - [**getbased-relay**](https://github.com/elkimek/getbased-relay) — Evolu sync relay for opt-in cross-device sync.
-- [**getbased-agents**](https://github.com/elkimek/getbased-agents) — `pipx install "getbased-agent-stack[full]"` installs the MCP adapter for AI clients (Claude Desktop, Hermes, Cursor, etc.), a local RAG knowledge server backing the "External server" Knowledge Base, and a browser setup dashboard in one command.
+- [**getbased-agents**](https://github.com/elkimek/getbased-agents) — the MCP adapter for AI clients (Claude Desktop, Hermes, Cursor, etc.), a local RAG knowledge server backing the "External server" Knowledge Base, and a browser setup dashboard. Install on Linux with `curl -sSL https://getbased.health/install.sh | bash`, or manually with `pipx install --include-deps "getbased-agent-stack[full]"` on any platform.
 
 ## Testing
 

--- a/docs/guide/interpretive-lens.md
+++ b/docs/guide/interpretive-lens.md
@@ -64,16 +64,52 @@ Good for: typical use — a few dozen to a few hundred documents. No install, no
 
 Connect to a knowledge server you run (or one run by someone you trust). Useful for larger corpora, shared libraries, or when you want hardware-accelerated retrieval that your browser can't match.
 
-One command stands one up — the [**getbased-agent-stack**](https://github.com/elkimek/getbased-agents) bundles the RAG server, the browser dashboard, and the MCP adapter for AI clients:
+**One command on Linux** — the [**getbased-agent-stack**](https://github.com/elkimek/getbased-agents) bundles the RAG server, the browser dashboard, and the MCP adapter:
 
 ```bash
-pipx install "getbased-agent-stack[full]"       # install (once)
-
-lens serve                                      # RAG engine → http://127.0.0.1:8322
-getbased-dashboard serve                        # web UI     → http://127.0.0.1:8323
+curl -sSL https://getbased.health/install.sh | bash
 ```
 
-Leave both terminals open (or drop them into systemd user units). The dashboard handles library management, drag-drop ingest, embedding-model selection, MCP config generation, and agent-activity inspection. Any server speaking the same `POST /query` protocol also works — see the endpoint contract below to roll your own.
+The script auto-detects `uv` or `pipx` (install one first if you have neither), pulls `getbased-agent-stack[full]`, and starts the RAG server (`:8322`) and dashboard (`:8323`) as systemd user services. On non-systemd hosts (macOS, Docker, WSL1) the install succeeds but the services don't auto-start — see the manual alternative below.
+
+**Linux only for auto-start.** macOS and Windows users can install the package, but need to run the services manually (or wait for launchd / Windows Service support).
+
+#### Cautious? Review or verify first
+
+```bash
+# Read the script
+curl -sSL https://getbased.health/install.sh | less
+
+# Or download and verify against the published hash
+curl -sSL https://getbased.health/install.sh       -o install.sh
+curl -sSL https://getbased.health/install.sh.sha256 | sha256sum -c
+bash install.sh
+```
+
+Source: [github.com/elkimek/get-based-site/blob/main/install.sh](https://github.com/elkimek/get-based-site/blob/main/install.sh).
+
+#### Manual install (macOS, Windows, WSL1, or if you'd rather not run a shell script from the internet)
+
+```bash
+# pipx — --include-deps exposes lens + getbased-dashboard on PATH
+pipx install --include-deps "getbased-agent-stack[full]"
+
+# or uv
+uv tool install \
+  --with-executables-from getbased-rag \
+  --with-executables-from getbased-dashboard \
+  --with-executables-from getbased-mcp \
+  "getbased-agent-stack[full]"
+
+# One-shot configuration (non-interactive)
+getbased-stack init --yes
+
+# On non-systemd hosts, run the services in two terminals
+lens serve                # RAG engine → http://127.0.0.1:8322
+getbased-dashboard serve  # web UI     → http://127.0.0.1:8323
+```
+
+The dashboard handles library management, drag-drop ingest, embedding-model selection, MCP config generation, and agent-activity inspection. Any server speaking the same `POST /query` protocol also works — see the endpoint contract below to roll your own.
 
 #### One-click login {#one-click-login}
 
@@ -93,13 +129,15 @@ Lost the URL?
 
 ### Setup (external server)
 
-1. Open **Settings → AI → Knowledge Base → External server**
-2. Toggle **Enable Knowledge Source**
-3. Enter a display name (e.g., *Functional Medicine Library*)
-4. Enter your server URL (HTTPS, or `http://127.0.0.1:8322/query` for a local `lens serve`)
-5. Enter your API key — paste from the dashboard's **MCP → Environment** panel, or run `lens key` on the server. Encrypted at rest on your device
-6. Set how many passages to retrieve per query (1–10, default 5)
-7. Click **Save + connect** — a test query runs to confirm the connection works
+After the installer (or manual install) finishes, open the dashboard — the installer prints a one-click login URL at the end. Then:
+
+1. Dashboard → **Knowledge** tab — create a library, drop your files in, wait for indexing.
+2. Dashboard → **MCP** → **Environment** → copy the `LENS_API_KEY`.
+3. In the app: **Settings → AI → Knowledge Base → External server**.
+4. Toggle **Enable Knowledge Source**, enter a display name (e.g., *Functional Medicine Library*), paste the API key.
+5. Endpoint URL defaults to `http://127.0.0.1:8322/query` — leave it alone for a local install, or point at an HTTPS endpoint if you're hosting the server elsewhere.
+6. Set how many passages to retrieve per query (1–10, default 5).
+7. Click **Save + connect** — a test query runs to confirm the connection works.
 
 When active, a **badge** appears in the chat header showing the knowledge source is being used.
 

--- a/docs/guide/personal-agents.md
+++ b/docs/guide/personal-agents.md
@@ -35,18 +35,36 @@ Go to **Settings → Data → Agent Access** and toggle it on. A read-only token
 
 ### 2. Install the agent stack
 
+Linux, one command:
+
 ```bash
-pipx install "getbased-agent-stack[full]"
+curl -sSL https://getbased.health/install.sh | bash
 ```
 
-One command — installs the MCP adapter, a local RAG knowledge server, and a browser setup dashboard. (If you only want the MCP adapter and nothing else, `pipx install getbased-mcp` is a smaller ~10 MB alternative with no RAG dependencies.)
+Installs the MCP adapter, the local RAG knowledge server, and the browser setup dashboard; starts the latter two as systemd user services. [Read the script first](https://github.com/elkimek/get-based-site/blob/main/install.sh) if you prefer to audit before running — the [Interpretive Lens guide](./interpretive-lens.md#external-server) lists the `sha256sum -c` verification command.
+
+macOS / Windows / WSL1, or prefer a manual path:
+
+```bash
+pipx install --include-deps "getbased-agent-stack[full]"
+# or with uv:
+# uv tool install --with-executables-from getbased-rag \
+#                 --with-executables-from getbased-dashboard \
+#                 --with-executables-from getbased-mcp \
+#                 "getbased-agent-stack[full]"
+getbased-stack init --yes      # writes config, generates API key
+```
+
+If you only want the MCP adapter and nothing else (no RAG), `pipx install getbased-mcp` is a smaller ~10 MB alternative.
 
 ### 3. Generate client config
 
-Easiest path — launch the dashboard and copy a paste-ready config block for your client:
+Launch the dashboard (or open it via the one-click login URL the installer prints at the end) and copy a paste-ready config block for your client:
 
 ```bash
-getbased-dashboard serve   # http://127.0.0.1:8323
+# Already running via systemd after install.sh — visit http://127.0.0.1:8323
+# Manual install? run:
+getbased-dashboard serve       # http://127.0.0.1:8323
 ```
 
 Open it in a browser, paste your bearer key at the auth gate, switch to the **MCP** tab, pick your client from the dropdown (Claude Desktop / Claude Code / Cursor / Cline / Hermes / OpenClaw), click **copy**. Paste into the client's config file (path shown in the dashboard).
@@ -70,13 +88,15 @@ In your agent, ask anything about your labs. The adapter exposes these tools:
 
 ## Running a local knowledge base
 
-`getbased-agent-stack[full]` includes `lens serve` — a local RAG server. Run it and you get `knowledge_search` grounded in your own document corpus (research papers, clinical guides, personal notes):
+`getbased-agent-stack[full]` includes `lens serve` — a local RAG server. `install.sh` already starts it as a systemd user service on Linux; on other platforms, run it manually:
 
 ```bash
 lens serve                   # starts on 127.0.0.1:8322
 # ingest via the dashboard's Knowledge tab, or CLI:
 lens ingest ~/Documents/research
 ```
+
+With `lens serve` running, `knowledge_search` is grounded in your own document corpus (research papers, clinical guides, personal notes).
 
 See [Interpretive Lens](./interpretive-lens.md#external-server) for the full RAG setup — including per-library embedding models (MiniLM for speed, BGE-M3 for quality) and connecting the same server to the in-app AI chat via the External server backend.
 

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,14 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.21.3', date: '2026-04-20', title: 'One-command Knowledge Base setup',
+    items: [
+      'External server setup collapsed from 4 steps to 1 terminal command — <code>curl -sSL https://getbased.health/install.sh | bash</code> installs the agent stack, starts the services, prints a one-click dashboard login URL.',
+      'Honest security footer in the setup panel: review the script before running, verify against the published SHA256, and a link to the public source on GitHub.',
+      'Linux-only for now (macOS and Windows install the package but can\'t auto-start the services). Explicitly noted in the panel so Mac users aren\'t left guessing.',
+    ]
+  },
+  {
     version: '1.21.2', date: '2026-04-20', title: 'Sync fix on Chrome for Android',
     items: [
       'Cross-device sync now works on Chrome for Android — the pre-flight check was wrongly gating on the SharedWorker API, which Evolu doesn\'t actually use (it uses dedicated Workers + BroadcastChannel + navigator.locks). Removing the spurious gate restores sync for any browser that has the real primitives.',

--- a/js/lens.js
+++ b/js/lens.js
@@ -442,38 +442,41 @@ export function renderCustomLensSection() {
     ` : ''}
 
     <div id="lens-remote-fields" style="${externalFieldsStyle}">
-      <!-- Integrated setup flow. The agent-stack bundles rag + dashboard
-           + MCP — one install, three services — so the narrative below
-           tells users exactly the steps they'd follow in order on a
-           fresh machine. Much better than the old two disconnected hint
-           boxes (top "here's the install", bottom "oh also there's a
-           dashboard") that forced users to stitch the story together
-           themselves. Dashboard 0.6.0 shipped a one-click login URL
-           + show/copy API key, so the terminal-only "lens key" path is
-           now the fallback, not the default flow. -->
+      <!-- One-command install via curl | bash, served from the landing
+           site's Vercel deploy. Hits the same pipx/uv → agent-stack →
+           systemd-user-services flow a user would do by hand, just
+           scripted. Linux-only for now — the installer degrades on
+           macOS/containers (unit files land but don't activate) but
+           auto-start is a systemd-only feature. Source is public so
+           security-conscious users can audit before running. -->
       <details class="lens-setup-details" style="margin-top:8px;padding:12px 14px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;font-size:12px;color:var(--text-muted);line-height:1.6" open>
-        <summary style="cursor:pointer;color:var(--text-primary);font-weight:600;font-size:13px;user-select:none;list-style:none">🚀 New here? 3-minute setup</summary>
+        <summary style="cursor:pointer;color:var(--text-primary);font-weight:600;font-size:13px;user-select:none;list-style:none">🚀 New here? One-command setup (Linux)</summary>
         <div style="margin-top:10px">
-          <div style="margin-bottom:10px"><strong style="color:var(--text-primary)">1. Install (once):</strong></div>
-          <div style="font-family:var(--font-mono,monospace);font-size:11.5px;background:var(--bg-primary);padding:8px 12px;border-radius:4px;color:var(--text-primary);line-height:1.8">pipx install "getbased-agent-stack[full]"</div>
-          <div style="font-size:11px;margin-top:4px;opacity:0.85"><code style="font-family:var(--font-mono,monospace);font-size:11px">[full]</code> adds PDF/DOCX parsers + ONNX acceleration (~500 MB).</div>
+          <div style="margin-bottom:10px"><strong style="color:var(--text-primary)">1. Install the agent stack:</strong></div>
+          <div style="font-family:var(--font-mono,monospace);font-size:11.5px;background:var(--bg-primary);padding:8px 12px;border-radius:4px;color:var(--text-primary);line-height:1.8;overflow-wrap:anywhere">curl -sSL https://getbased.health/install.sh | bash</div>
+          <div style="font-size:11px;margin-top:4px;opacity:0.85">Installs via <code style="font-family:var(--font-mono,monospace);font-size:11px">pipx</code> or <code style="font-family:var(--font-mono,monospace);font-size:11px">uv</code> (auto-detected), starts rag + dashboard as systemd user services. <strong>Linux only</strong> — macOS and Windows aren't supported yet (the script installs but services won't auto-start).</div>
         </div>
         <div style="margin-top:14px">
-          <div style="margin-bottom:10px"><strong style="color:var(--text-primary)">2. Start both services</strong> (leave both terminals open):</div>
-          <div style="font-family:var(--font-mono,monospace);font-size:11.5px;background:var(--bg-primary);padding:8px 12px;border-radius:4px;color:var(--text-primary);line-height:1.8">lens serve&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:var(--text-muted)"># RAG engine → http://127.0.0.1:8322</span><br>getbased-dashboard serve&nbsp;&nbsp;<span style="color:var(--text-muted)"># web UI     → http://127.0.0.1:8323</span></div>
-          <div style="font-size:11px;margin-top:4px;opacity:0.85">The dashboard prints a <a href="/docs/guide/interpretive-lens.html#one-click-login" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline">one-click login URL</a> at startup — click it to open the UI. Running unattended? Drop both into systemd user units.</div>
-        </div>
-        <div style="margin-top:14px">
-          <div style="margin-bottom:10px"><strong style="color:var(--text-primary)">3. In the dashboard:</strong></div>
+          <div style="margin-bottom:10px"><strong style="color:var(--text-primary)">2. Open the dashboard</strong> — the script prints a <a href="/docs/guide/interpretive-lens.html#one-click-login" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline">one-click login URL</a> at the end.</div>
           <div style="font-size:12px;line-height:1.7">
             • <strong>Knowledge</strong> tab — create a library, drop files in, wait for indexing<br>
-            • <strong>MCP</strong> tab → <strong>Environment</strong> panel — copy <code style="font-family:var(--font-mono,monospace);font-size:11px">LENS_API_KEY</code> (show/copy button)
+            • <strong>MCP</strong> tab → <strong>Environment</strong> panel — copy <code style="font-family:var(--font-mono,monospace);font-size:11px">LENS_API_KEY</code>
           </div>
         </div>
         <div style="margin-top:14px">
-          <div style="margin-bottom:6px"><strong style="color:var(--text-primary)">4. Back here</strong> — paste the bearer into <em>API key</em> below, hit <em>Save + connect</em>.</div>
+          <div><strong style="color:var(--text-primary)">3. Paste the bearer</strong> into <em>API key</em> below, hit <em>Save + connect</em>.</div>
         </div>
-        <div style="margin-top:14px;font-size:11px;padding-top:10px;border-top:1px dashed var(--border)">Already have a server? Skip this and fill in the fields below.</div>
+        <!-- Audit/verification block — the audience is security-conscious
+             by definition (they care about grounding health data on their
+             own RAG), so curl | bash deserves an honest review-first path
+             rather than pretending HTTPS is all anyone needs. -->
+        <div style="margin-top:14px;font-size:11px;padding-top:10px;border-top:1px dashed var(--border);line-height:1.55">
+          <strong style="color:var(--text-primary)">Cautious?</strong> Read the script first or verify its hash:<br>
+          <code style="font-family:var(--font-mono,monospace);font-size:11px;display:inline-block;margin-top:4px">curl -sSL https://getbased.health/install.sh | less</code><br>
+          <code style="font-family:var(--font-mono,monospace);font-size:11px;display:inline-block;margin-top:2px">curl -sSL https://getbased.health/install.sh.sha256 | sha256sum -c</code><br>
+          <a href="https://github.com/elkimek/get-based-site/blob/main/install.sh" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:underline">Source on GitHub →</a>
+        </div>
+        <div style="margin-top:10px;font-size:11px">Already have a server? Skip this and fill in the fields below.</div>
       </details>
       <!-- Display name: only meaningful for external-server, which is a
            remote endpoint rather than a named library. in-browser derives

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -58,6 +58,24 @@ return (async function() {
     !/['"]vitamin D deficiency supplementation['"][\s\S]{0,100}_doQuery/.test(lensSrc),
     'the probe should be read from config, not passed literally to _doQuery');
   assert('renderCustomLensSection includes lens-test-probe-input field', lensSrc.includes('lens-test-probe-input'));
+  // Setup copy uses the one-command curl installer. If someone ever
+  // regresses this back to the two-terminal `lens serve` flow without
+  // also updating the landing-site installer, users would be left with
+  // install instructions that don't match what the Vercel-hosted script
+  // does. Pin both the curl line and the Linux-only caveat.
+  assert('Setup block uses one-command curl | bash install',
+    lensSrc.includes('curl -sSL https://getbased.health/install.sh | bash'));
+  assert('Setup block no longer instructs "lens serve" or "getbased-dashboard serve" manually',
+    !/lens serve\s*&nbsp;|getbased-dashboard serve\s*&nbsp;/.test(lensSrc),
+    'manual two-terminal flow was replaced by install.sh');
+  assert('Setup block notes the Linux-only constraint',
+    /Linux only|Linux-only|\(Linux\)/.test(lensSrc),
+    'macOS/Windows users need to know services won\'t auto-start');
+  assert('Setup block links to install.sh source for audit',
+    lensSrc.includes('github.com/elkimek/get-based-site/blob/main/install.sh'));
+  assert('Setup block documents the SHA256 verification path',
+    lensSrc.includes('install.sh.sha256') && lensSrc.includes('sha256sum -c'),
+    'security-conscious users should have a pre-run verification option');
   assert('handleSaveLensConfig persists testProbe', lensSrc.includes('saveLensConfig({ name, url, enabled, topK, testProbe, backend })'));
   assert('Connected toast distinguishes zero-result case',
     lensSrc.includes("the test query didn't find any close matches") && lensSrc.includes('your endpoint works'),

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.21.2';
+self.APP_VERSION = '1.21.3';


### PR DESCRIPTION
## Summary

- Setup flow for Knowledge Base → External server collapses from 4 steps (pipx install, two terminals for `lens serve` + `getbased-dashboard serve`, copy bearer, paste) down to **one terminal command**: `curl -sSL https://getbased.health/install.sh | bash`, followed by the usual bearer paste.
- Explicit **Linux-only** caveat in the setup panel so macOS / Windows users aren't left guessing why services don't auto-start (pipx install works cross-platform; systemd unit activation is Linux-only).
- **Honest security footer** for curl | bash: review-before-running command, SHA256 verification command, and a direct link to the public script source on GitHub. The April 2026 Vercel incident made this trust model worth addressing openly rather than hiding behind "it's HTTPS".

## Why

The agent-stack already existed as a PyPI meta-package. The missing piece was the one-shot installer. With `getbased-agent-stack 0.5.0` adding a `--yes` flag for non-interactive init, and `0.5.1` adding graceful fallback when systemctl is absent, the installer can now run end-to-end from a fresh machine without prompts or ugly tracebacks.

## How it was validated

| Path | Platform | Result |
|---|---|---|
| `uv tool install` (fresh) | Hermes VM, real systemd | Services up on :8322 / :8323 |
| `uv tool install` (reinstall) | Hermes, with prior manual setup | Idempotent, services stayed up |
| `pipx install --include-deps` (fresh) | Ubuntu 24.04 Docker, no systemd | Graceful fallback, exit 0 |
| `init --yes` | all three | No prompts, no getpass warning |

Stack package changes that made this possible (already merged on monorepo main):
- [elkimek/getbased-agents@0bf1433](https://github.com/elkimek/getbased-agents/commit/0bf1433) — `--yes` flag on init
- [elkimek/getbased-agents@08a61f7](https://github.com/elkimek/getbased-agents/commit/08a61f7) — graceful fallback when systemctl is absent
- Both live on PyPI as `getbased-agent-stack==0.5.1`.

Landing-site changes (already merged on get-based-site main):
- [elkimek/get-based-site@e2264be](https://github.com/elkimek/get-based-site/commit/e2264be) — add `install.sh` + `install.sh.sha256`. Live at `https://getbased.health/install.sh`.

## Test plan

- [x] Full test suite green (new assertions pin install command, Linux caveat, source link, SHA256 verification commands)
- [x] Localhost screenshot review (panel renders cleanly in dark theme)
- [x] Load Vercel preview on desktop — confirm panel copy matches expectation, link to GitHub source resolves
- [x] Spot-check on mobile — no layout overflow on the long curl command (CSS has `overflow-wrap:anywhere`, but worth eyeballing)
- [x] Optional: run `curl -sSL https://getbased.health/install.sh | bash` end-to-end on a fresh Ubuntu VPS and confirm dashboard comes up

## Version

1.21.2 → 1.21.3 (patch, no What's New modal — UI polish, not a feature walkthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)