### PR TITLE
chore: dead-code cleanup (v1.21.7)

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,7 +1,7 @@
 // api.js — AI provider management, API calls (OpenRouter, Venice, Routstr, PPQ, Local, Custom)
 
 import { getModelPricing } from './schema.js';
-import { isDebugMode, showNotification } from './utils.js';
+import { isDebugMode } from './utils.js';
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
 
 // ═══════════════════════════════════════════════
@@ -864,10 +864,6 @@ export async function fetchRoutstrModels() {
     return models;
   } catch (e) { return []; }
 }
-export function getRoutstrPricing(modelId) {
-  let cached = {}; try { cached = JSON.parse(localStorage.getItem('labcharts-routstr-pricing') || '{}'); } catch(e) {}
-  return cached[modelId] || null;
-}
 export async function validateRoutstrKey(key) {
   // Routstr uses Cashu tokens or session keys — format check, then save optimistically.
   // Models endpoint is public (no auth), so we can't validate keys via model fetch.
@@ -924,46 +920,6 @@ export async function getRoutstrBalance() {
     if (json.balance != null) return { sats: Math.floor(json.balance / 1000), msats: json.balance, totalRequests: json.total_requests || 0, totalSpent: json.total_spent || 0 };
     return null;
   } catch { return null; }
-}
-export async function createRoutstrLightningInvoice(amountSats) {
-  const key = getRoutstrKey();
-  if (!key) throw new Error('No Routstr key');
-  const res = await fetch(_requireNodeUrl() + '/v1/balance/lightning/invoice', {
-    method: 'POST',
-    headers: { 'Authorization': 'Bearer ' + key, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ amount_sats: amountSats, purpose: 'topup', api_key: key })
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => null);
-    const detail = err?.detail;
-    const msg = typeof detail === 'string' ? detail : Array.isArray(detail) ? detail.map(d => d.msg || JSON.stringify(d)).join('; ') : err?.message;
-    throw new Error(msg || 'Invoice creation failed: ' + res.status);
-  }
-  return res.json(); // { invoice_id, bolt11, amount_sats, expires_at, payment_hash }
-}
-export async function checkRoutstrInvoiceStatus(invoiceId) {
-  const key = getRoutstrKey();
-  const res = await fetch(_requireNodeUrl() + '/v1/balance/lightning/invoice/' + encodeURIComponent(invoiceId) + '/status', {
-    headers: key ? { 'Authorization': 'Bearer ' + key } : {}
-  });
-  if (!res.ok) return null;
-  return res.json(); // { status: 'pending'|'paid'|'expired', ... }
-}
-export async function topupRoutstrCashu(cashuToken) {
-  const key = getRoutstrKey();
-  if (!key) throw new Error('No Routstr key');
-  const res = await fetch(_requireNodeUrl() + '/v1/balance/topup', {
-    method: 'POST',
-    headers: { 'Authorization': 'Bearer ' + key, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ cashu_token: cashuToken })
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => null);
-    const detail = err?.detail;
-    const msg = typeof detail === 'string' ? detail : Array.isArray(detail) ? detail.map(d => d.msg || JSON.stringify(d)).join('; ') : err?.message;
-    throw new Error(msg || 'Cashu topup failed: ' + res.status);
-  }
-  return res.json(); // { balance, amount_added, currency }
 }
 
 // ═══════════════════════════════════════════════
@@ -1058,10 +1014,6 @@ export async function fetchPpqModels(key) {
     }
     return models;
   } catch (e) { return []; }
-}
-export function getPpqPricing(modelId) {
-  let cached = {}; try { cached = JSON.parse(localStorage.getItem('labcharts-ppq-pricing') || '{}'); } catch(e) {}
-  return cached[modelId] || null;
 }
 export async function validatePpqKey(key) {
   try {
@@ -1193,8 +1145,8 @@ Object.assign(window, {
   getOpenRouterBalance,
   getVeniceBalance,
   fetchVeniceModels, fetchOpenRouterModels, getOpenRouterPricing,
-  fetchRoutstrModels, getRoutstrPricing, createRoutstrAccount, getRoutstrBalance, createRoutstrLightningInvoice, checkRoutstrInvoiceStatus, topupRoutstrCashu,
-  fetchPpqModels, getPpqPricing, createPpqAccount, getPpqBalance, createPpqTopup, checkPpqTopupStatus,
+  fetchRoutstrModels, createRoutstrAccount, getRoutstrBalance,
+  fetchPpqModels, createPpqAccount, getPpqBalance, createPpqTopup, checkPpqTopupStatus,
   generatePKCE, startOpenRouterOAuth, exchangeOpenRouterCode,
   deduplicateModels,
   isRecommendedModel,

--- a/js/cashu-wallet.js
+++ b/js/cashu-wallet.js
@@ -2,7 +2,7 @@
 // Uses cashu-ts (vendored IIFE → global `cashuts`) for protocol operations.
 // Proofs stored in IndexedDB, included in backup/sync.
 
-import { isDebugMode, showConfirmDialog } from './utils.js';
+import { isDebugMode } from './utils.js';
 import { encryptedSetItem, encryptedGetItem } from './crypto.js';
 
 // ═══════════════════════════════════════════════

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,13 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.21.7', date: '2026-04-20', title: 'Dead-code cleanup',
+    items: [
+      'Removed ~140 lines of unreachable code — five unused Routstr/PPQ wallet helpers, four stale lens-library aliases, and a handful of debug/migration helpers with zero callers. No user-visible change; faster loads and a smaller codebase to reason about.',
+      'Dropped 19 unused imports across the module tree. Makes it easier to see what each file actually depends on.',
+    ]
+  },
+  {
     version: '1.21.6', date: '2026-04-20', title: 'Docs accuracy sweep',
     items: [
       'README provider table now lists all 6 AI providers (Custom API was missing from the table, though it\'s been supported since v1.16.1).',

--- a/js/chat.js
+++ b/js/chat.js
@@ -3,14 +3,14 @@
 import { state } from './state.js';
 import { CHAT_PERSONALITIES, CHAT_SYSTEM_PROMPT, LATITUDE_BANDS } from './constants.js';
 import { calculateCost, formatCost, trackUsage } from './schema.js';
-import { escapeHTML, showNotification, showConfirmDialog, isDebugMode, formatValue, getStatus, hasCardContent } from './utils.js';
+import { escapeHTML, showNotification, showConfirmDialog, formatValue, getStatus, hasCardContent } from './utils.js';
 import { getActiveData, getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, saveImportedData } from './data.js';
 import { encryptedSetItem, encryptedGetItem, getEncryptionEnabled } from './crypto.js';
 import { getProfileLocation, setProfileLocation, getLatitudeFromLocation, getLocationCache, latitudeToBand, detectLatitudeWithAI, getProfiles, renameProfile, setProfileSex, setProfileDob } from './profile.js';
 import { callClaudeAPI, hasAIProvider, isAIPaused, setAIPaused, getAIProvider, getActiveModelId, getActiveModelDisplay, supportsVision, supportsWebSearch, isVeniceE2EEActive } from './api.js';
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
 import { onChatSaved } from './sync.js';
-import { buildLabContext, invalidateLabContextCache, getContextSummary, isGroupInAIContext, injectLensChunks } from './lab-context.js';
+import { buildLabContext, getContextSummary, injectLensChunks } from './lab-context.js';
 import { hasLens, queryLens, updateLensIndicator } from './lens.js';
 import { applyInlineMarkdown, renderMarkdown } from './markdown.js';
 
@@ -1398,18 +1398,6 @@ async function _generateSummary() {
   } finally {
     _summaryAbortController = null;
   }
-}
-
-export function regenerateSummary() {
-  const thread = state.chatThreads.find(t => t.id === state.currentThreadId);
-  if (thread) {
-    delete thread.summary;
-    delete thread.summaryDate;
-    delete thread.summaryModel;
-    delete thread.summaryCost;
-    saveChatThreadIndex();
-  }
-  _generateSummary();
 }
 
 // ── Standalone summary storage ──
@@ -3333,7 +3321,6 @@ Object.assign(window, {
   saveChatHistory,
   clearChatHistory,
   summarizeThread,
-  regenerateSummary,
   closeSummaryModal,
   updateSummaryButton,
   viewSavedSummary,

--- a/js/client-list.js
+++ b/js/client-list.js
@@ -1,8 +1,8 @@
 // client-list.js — Client List modal for managing profiles
 
 import { state } from './state.js';
-import { escapeHTML, escapeAttr, hashString } from './utils.js';
-import { getProfiles, getActiveProfileId, createProfile, switchProfile, deleteProfile, updateProfileMeta, getAllTags, getLocationCache, latitudeToBand, getLatitudeFromLocation, detectLatitudeWithAI, getProfileHeight, setProfileHeight } from './profile.js';
+import { escapeHTML, escapeAttr } from './utils.js';
+import { getProfiles, getActiveProfileId, createProfile, switchProfile, deleteProfile, updateProfileMeta, getAllTags, getLocationCache, latitudeToBand, getLatitudeFromLocation, detectLatitudeWithAI, getProfileHeight } from './profile.js';
 import { LATITUDE_BANDS } from './constants.js';
 import { getAvatarColor } from './nav.js';
 

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -658,7 +658,7 @@ export async function changePassphrase() {
 
 // ═══════════════════════════════════════════════
 // Backup/restore, auto-backup, folder backup extracted to js/backup.js
-import { buildBackupSnapshot, exportEncryptedBackup, importEncryptedBackup, scheduleAutoBackup, getAutoBackupSnapshots, restoreAutoBackup, openBackupDB, initFolderBackup, pickFolderForBackup, reauthorizeFolderBackup, removeFolderBackup, getFolderBackupState, renderFolderBackupSection, MAX_SNAPSHOTS } from './backup.js';
+import { buildBackupSnapshot, exportEncryptedBackup, importEncryptedBackup, scheduleAutoBackup, getAutoBackupSnapshots, restoreAutoBackup, openBackupDB, initFolderBackup, getFolderBackupState, renderFolderBackupSection, MAX_SNAPSHOTS } from './backup.js';
 export { buildBackupSnapshot, scheduleAutoBackup, openBackupDB, initFolderBackup };
 
 // ═══════════════════════════════════════════════

--- a/js/lens.js
+++ b/js/lens.js
@@ -1172,12 +1172,6 @@ export function handleLibraryDelete() {
   });
 }
 
-// Legacy aliases for any outstanding callsites.
-export const handleLocalLensActivate = handleLibraryActivate;
-export const handleLocalLensNewLibrary = handleLibraryNew;
-export const handleLocalLensRenameLibrary = handleLibraryRename;
-export const handleLocalLensDeleteLibrary = handleLibraryDelete;
-
 export function handleToggleLens(checked) {
   saveLensConfig({ enabled: checked });
   _updateLensStatusChip();
@@ -1223,6 +1217,4 @@ Object.assign(window, {
   handleLensBackendChange,
   handleLocalLensDeleteDoc, handleLocalLensClear,
   handleLibraryActivate, handleLibraryNew, handleLibraryRename, handleLibraryDelete,
-  handleLocalLensActivate, handleLocalLensNewLibrary,
-  handleLocalLensRenameLibrary, handleLocalLensDeleteLibrary,
 });

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -4,8 +4,8 @@ import { state } from './state.js';
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS, UNIT_CONVERSIONS, calculateCost, formatCost, trackUsage } from './schema.js';
 import { IMPORT_STEPS } from './constants.js';
 import { escapeHTML, showNotification, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
-import { saveImportedData, getActiveData, recalculateHOMAIR } from './data.js';
-import { callClaudeAPI, hasAIProvider, getAIProvider, setAIProvider, getVeniceModel, setVeniceModel, getOpenRouterModel, setOpenRouterModel, getOllamaMainModel, setOllamaMainModel, getVeniceModelDisplay, getOpenRouterModelDisplay, getActiveModelId, getActiveModelDisplay, getOllamaPIIModel, setCustomApiModel, setPpqModel, setRoutstrModel } from './api.js';
+import { saveImportedData, recalculateHOMAIR } from './data.js';
+import { callClaudeAPI, hasAIProvider, getAIProvider, setAIProvider, setVeniceModel, setOpenRouterModel, getOllamaMainModel, setOllamaMainModel, getVeniceModelDisplay, getOpenRouterModelDisplay, getActiveModelId, getActiveModelDisplay, getOllamaPIIModel, setCustomApiModel, setPpqModel, setRoutstrModel } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { detectProduct, normalizeWithAdapter, getAdapterByTestType } from './adapters.js';
 

--- a/js/pii.js
+++ b/js/pii.js
@@ -1,6 +1,6 @@
 // pii.js — PII obfuscation (Ollama + regex), diff viewer
 
-import { isDebugMode, showNotification, escapeHTML } from './utils.js';
+import { showNotification, escapeHTML } from './utils.js';
 import { getOllamaPIIModel, getOllamaPIIUrl } from './api.js';
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
 import { state } from './state.js';

--- a/js/profile.js
+++ b/js/profile.js
@@ -469,46 +469,6 @@ export function getLocationCache() { try { return JSON.parse(localStorage.getIte
 export function setLocationCache(key, lat) { var c = getLocationCache(); c[key] = lat; try { localStorage.setItem('labcharts-location-cache', JSON.stringify(c)); } catch(e) {} }
 export function latitudeToBand(lat) { var a = Math.abs(lat); if (a < 25) return 0; if (a < 40) return 1; if (a < 50) return 2; if (a < 60) return 3; return 4; }
 
-var _locationDebounceTimer = null;
-export function updateLocationLat() {
-  const country = (document.getElementById('loc-country') || {}).value || '';
-  const zip = (document.getElementById('loc-zip') || {}).value || '';
-  setProfileLocation(state.currentProfile, country, zip);
-  const el = document.getElementById('loc-lat-display');
-  if (!el) return;
-  const ct = country.trim(), zt = zip.trim();
-  if (!ct) { el.textContent = ''; return; }
-
-  // Check AI cache first (most accurate)
-  var cacheKey = (ct + '|' + zt).toLowerCase();
-  var cached = getLocationCache()[cacheKey];
-  if (cached !== undefined) {
-    var band = latitudeToBand(cached);
-    el.style.color = 'var(--green)';
-    el.textContent = '\u2713 ' + Math.abs(Math.round(cached)) + '\u00b0' + (cached >= 0 ? 'N' : 'S') + ' \u2014 ' + LATITUDE_BANDS[band];
-    return;
-  }
-
-  // Hardcoded fallback (instant)
-  var lat = getLatitudeFromLocation();
-  if (lat) {
-    el.style.color = 'var(--green)';
-    el.textContent = '\u2713 ' + lat;
-  } else if (window.hasAIProvider()) {
-    el.style.color = 'var(--text-muted)';
-    el.textContent = 'Detecting\u2026';
-  } else {
-    el.style.color = 'var(--text-muted)';
-    el.textContent = 'Country not recognized \u2014 try the full name';
-  }
-
-  // Debounced AI refinement
-  if (_locationDebounceTimer) clearTimeout(_locationDebounceTimer);
-  if (window.hasAIProvider()) {
-    _locationDebounceTimer = setTimeout(function() { detectLatitudeWithAI(ct, zt); }, 1500);
-  }
-}
-
 export async function detectLatitudeWithAI(country, zip) {
   var cacheKey = (country + '|' + zip).toLowerCase();
   if (getLocationCache()[cacheKey] !== undefined) return;

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -2,7 +2,7 @@
 
 import { escapeHTML, escapeAttr, showNotification, showConfirmDialog } from './utils.js';
 import {
-  getVeniceKey, saveVeniceKey, getOpenRouterKey, saveOpenRouterKey, getAIProvider, setAIProvider,
+  getVeniceKey, saveVeniceKey, getOpenRouterKey, saveOpenRouterKey, setAIProvider,
   getVeniceModel, setVeniceModel, getOpenRouterModel, setOpenRouterModel,
   getOllamaMainModel, setOllamaMainModel, getOllamaPIIModel, setOllamaPIIModel,
   getOllamaPIIUrl, setOllamaPIIUrl,

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,12 +1,12 @@
 // settings.js — Settings modal (profile, display, AI provider, privacy)
 
 import { state } from './state.js';
-import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isDebugMode, setDebugMode, isPIIReviewEnabled, setPIIReviewEnabled, isAnalyticsEnabled, setAnalyticsEnabled } from './utils.js';
+import { escapeHTML, escapeAttr, showNotification, isDebugMode, setDebugMode, isPIIReviewEnabled, setPIIReviewEnabled, isAnalyticsEnabled, setAnalyticsEnabled } from './utils.js';
 import { getTheme, setTheme, getTimeFormat, setTimeFormat } from './theme.js';
 import { formatCost, getProfileUsage, getGlobalUsage, resetProfileUsage } from './schema.js';
 import { getAIProvider, isAIPaused, getOllamaPIIUrl, getOllamaPIIModel } from './api.js';
 import { isOllamaPIIEnabled, setOllamaPIIEnabled, getOllamaConfig, checkOpenAICompatible } from './pii.js';
-import { renderEncryptionSection, renderBackupSection, loadBackupSnapshots, updateKeyCache } from './crypto.js';
+import { renderEncryptionSection, renderBackupSection, loadBackupSnapshots } from './crypto.js';
 import { isSyncEnabled, enableSync, disableSync, getMnemonic, getMnemonicResolutionError, getSyncBlocker, restoreFromMnemonic, getSyncRelay, setSyncRelay, checkRelayConnection, isMessengerEnabled, getMessengerToken, generateMessengerToken, revokeMessengerToken, pushContextToGateway } from './sync.js';
 import './provider-panels.js';
 

--- a/js/sync.js
+++ b/js/sync.js
@@ -45,8 +45,6 @@ function updateSyncStatus(partial) {
   for (const fn of _syncStatusListeners) fn(_syncStatus);
 }
 
-export function getSyncStatus() { return { ..._syncStatus }; }
-
 export function subscribeSyncStatus(fn) {
   _syncStatusListeners.add(fn);
   return () => _syncStatusListeners.delete(fn);
@@ -974,7 +972,6 @@ Object.assign(window, {
   revokeMessengerToken,
   _syncDiag,
   _forcePull,
-  getSyncStatus,
   renderSyncIndicator,
   updateSyncIndicator,
   toggleSyncDetail,

--- a/js/views.js
+++ b/js/views.js
@@ -6,14 +6,14 @@ import { escapeHTML, getStatus, getRangePosition, formatValue, getTrend, showNot
 import { getChartColors } from './theme.js';
 import { getActiveData, filterDatesByRange, destroyAllCharts, getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, getAllFlaggedMarkers, statusIcon, detectTrendAlerts, getKeyTrendMarkers, getFocusCardFingerprint, saveImportedData, recalculateHOMAIR, updateHeaderDates, renderDateRangeFilter, renderChartLayersDropdown, convertDisplayToSI } from './data.js';
 import { profileStorageKey } from './profile.js';
-import { createLineChart, getMarkerDescription, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin, phaseBandPlugin } from './charts.js';
+import { createLineChart, getMarkerDescription, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin } from './charts.js';
 import { renderSupplementsSection } from './supplements.js';
 import { renderGeneticsSection } from './dna.js';
 import { renderMenstrualCycleSection } from './cycle.js';
 import { renderProfileContextCards, renderInterpretiveLensSection, loadContextHealthDots, closeSuggestionsOnClickOutside } from './context-cards.js';
 import { callClaudeAPI, hasAIProvider, isAIPaused, getAIProvider, getActiveModelId } from './api.js';
 import { setupDropZone } from './pdf-import.js';
-import { buildLabContext, injectLensChunks } from './lab-context.js';
+import { injectLensChunks } from './lab-context.js';
 import { hasLens, queryLens } from './lens.js';
 import { applyInlineMarkdown } from './markdown.js';
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.21.6';
+self.APP_VERSION = '1.21.7';


### PR DESCRIPTION
## Summary

Phase 2c of the 2026-04-20 audit. Zero behavior changes — 15 files touched, **net -105 lines**, every deletion grep-verified to have zero callers across `js/`, `tests/`, and `index.html`.

### Removed (5 unused functions, 4 stale aliases, ~140 lines)

- **api.js** — 5 Routstr/PPQ helpers that were never wired up (`getRoutstrPricing`, `createRoutstrLightningInvoice`, `checkRoutstrInvoiceStatus`, `topupRoutstrCashu`, `getPpqPricing`). The Routstr invoice/topup helpers predate the in-app Cashu wallet (v1.16.0); the pricing getters read caches that nothing reads.
- **lens.js** — 4 `handleLocalLens*` aliases pointing at `handleLibrary*`. HTML onclicks call the real names directly; aliases had no callers.
- **sync.js** — `getSyncStatus` (superseded by `subscribeSyncStatus` listener pattern). Debug hooks `_syncDiag` / `_forcePull` kept — intentional `window.*` devtools handles.
- **chat.js** — `regenerateSummary` (thread-summary path with zero callers).
- **profile.js** — `updateLocationLat` + debounce timer (replaced by inline logic in context-cards).

### Removed (19 unused imports, ~19 lines)

Verified each via `grep -c '\bX\b' js/<file>` == 1 (only the import line itself).

Files touched: api.js, cashu-wallet.js, chat.js, client-list.js, crypto.js, pdf-import.js, pii.js, provider-panels.js, settings.js, views.js.

### Test safety net

Full suite green (5,200+ assertions). A real consumer of any removed symbol would have been caught — `window.X` tests, source-inspection regex tests, and module-integrity tests would all have failed.

## What's NOT in this PR (audit backlog)

- Phase 2d: CLAUDE.md trim to 15 KB target
- Phase 2e: `chat.js` refactor (3400 lines × 112 commits — the big one)