### PR TITLE
fix(changelog): render <b>/<i>/<code> tags instead of escaping them

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -807,6 +807,18 @@ function markChangelogSeen() {
   localStorage.setItem('labcharts-changelog-seen', String(window.APP_VERSION));
 }
 
+// Changelog items are authored in source code (CHANGELOG above) — trusted.
+// We escape everything by default and then re-allow a small whitelist of
+// inline emphasis tags so <b>/<i>/<em>/<strong>/<code> render as styling
+// instead of literal text. Anything else (script, img, links, etc.) stays
+// escaped — defense-in-depth in case an entry ever incorporates user content.
+function renderChangelogItem(item) {
+  return escapeHTML(item).replace(
+    /&lt;(\/?)(b|i|em|strong|code)&gt;/g,
+    '<$1$2>'
+  );
+}
+
 export function openChangelog(showAll) {
   const overlay = document.getElementById('changelog-modal-overlay');
   const modal = document.getElementById('changelog-modal');
@@ -822,7 +834,7 @@ export function openChangelog(showAll) {
     html += `<div class="changelog-header"><span class="changelog-version">v${escapeHTML(entry.version)} — ${escapeHTML(entry.title)}</span><span class="changelog-date">${escapeHTML(entry.date)}</span></div>`;
     html += '<ul class="changelog-items">';
     for (const item of entry.items) {
-      html += `<li class="changelog-item">${escapeHTML(item)}</li>`;
+      html += `<li class="changelog-item">${renderChangelogItem(item)}</li>`;
     }
     html += '</ul></div>';
   }

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -176,6 +176,27 @@ return (async function() {
   assert('closeChangelog removes show class', ovAfterClose && !ovAfterClose.classList.contains('show'));
   assert('closeChangelog marks version as seen', localStorage.getItem('labcharts-changelog-seen') !== null);
 
+  // ═══════════════════════════════════════
+  // Inline-tag whitelist in changelog items
+  // ═══════════════════════════════════════
+  // Items use <b>/<i>/<em>/<strong>/<code> for emphasis. Verify the renderer
+  // both renders those AND keeps escaping anything else.
+  window.openChangelog(true);
+  const tagModal = document.getElementById('changelog-modal');
+  const itemsHTML = tagModal?.innerHTML || '';
+  assert('changelog renders <b> as bold (not literal text)',
+    itemsHTML.includes('<b>') && !itemsHTML.includes('&lt;b&gt;'));
+  assert('expected bold span "5 new SNPs" present',
+    /<b>5 new SNPs<\/b>/.test(itemsHTML));
+  assert('changelog renders <code> as code (not literal text)',
+    !itemsHTML.includes('&lt;code&gt;'));
+  // Defense: source-code regex limits the whitelist. A wildcard or a
+  // direct innerHTML on the raw item would be a security regression.
+  const renderSrc = await fetch('js/changelog.js').then(r => r.text());
+  assert('renderChangelogItem whitelist limited to b/i/em/strong/code',
+    /\(b\|i\|em\|strong\|code\)/.test(renderSrc));
+  window.closeChangelog();
+
   // Clean up
   localStorage.removeItem('labcharts-changelog-seen');
 


### PR DESCRIPTION
## Summary

Follow-up to #141 — the inline-emphasis tags in changelog entries (<b>, <i>, <code>) were being escaped and rendering as literal angle-bracket text. Pre-existing bug since the changelog was first introduced (commit `30f2572`), but only surfaced now because v1.23.0 is heavy on inline emphasis.

## The fix

Tiny safe-tag whitelist renderer. Escapes the whole item first, then re-allows just these five tag patterns: `<b>`, `<i>`, `<em>`, `<strong>`, `<code>`. Anything else (script, img, links) stays escaped.

Authored items are trusted (they live in source code) so the security surface here is zero by design, but the whitelist keeps the convention safe-by-default in case an entry ever incorporates user content.

## Tests

- Opens the modal and verifies `<b>5 new SNPs</b>` appears as a real tag in the live DOM (not `&lt;b&gt;`).
- Verifies `<code>` is not escaped.
- Source-code regex check: whitelist must be limited to the five named tags (catches accidental wildcard edits in review).

## Test plan

- [x] Tests green in CI
- [x] Hard-refresh the app, open What's New — every `<b>`/`<i>`/`<code>` tag in v1.23.0 (and all earlier entries that used them) renders as styling instead of literal text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)