### PR TITLE
Add CodeQL static analysis + Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # npm — devDependencies only (the app itself is no-bundler / no-runtime-npm;
+  # vendor/ ships pinned bundled copies refreshed via update-vendor.sh, NOT
+  # tracked by Dependabot).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly catch-up so newly-published rules surface against quiet weeks.
+    - cron: "27 5 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended adds taint-flow + injection rules beyond the
+          # default set. Worth it for an app that handles user health data,
+          # E2EE crypto (crypto.js / venice-e2ee.js), markdown rendering,
+          # and PDF/AI input parsing.
+          queries: security-extended
+          # Skip vendored libraries (Chart.js, pdf.js, mammoth, JSZip,
+          # cashu-ts, evolu, transformers via CDN, etc.) — findings inside
+          # those are upstream, not our code, and produce a flood of noise
+          # on first run. Same for built docs.
+          config: |
+            paths-ignore:
+              - vendor/**
+              - dist-docs/**
+              - docs/.vitepress/cache/**
+              - node_modules/**
+              - brands/**
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- New `.github/workflows/codeql.yml` runs CodeQL with the `security-extended` query suite on push, PR, and a weekly cron.
- New `.github/dependabot.yml` for weekly npm + monthly actions updates, types-only patches grouped.
- Repo-level GitHub security toggles enabled out-of-band: Dependabot vulnerability alerts, automated security updates, private vulnerability reporting. Secret scanning + push protection were already on.

## Why CodeQL specifically

getbased handles user health data, runs E2EE crypto (`crypto.js` + `venice-e2ee.js`), parses untrusted PDFs through `pdf.js`, renders markdown from AI responses, and stores everything client-side. The `security-extended` query suite's taint-flow + injection rules are exactly the shape of bugs that would matter most in this app.

## Path exclusions

The CodeQL config skips `vendor/` (bundled Chart.js, pdf.js, mammoth, JSZip, cashu-ts, etc. — pinned upstream copies refreshed via `update-vendor.sh`, not our code), `dist-docs/`, `docs/.vitepress/cache/`, `brands/`, `node_modules/`. Findings inside those would be upstream's to fix and would flood the Security tab on first run.

`vendor/` is also intentionally NOT in Dependabot's scope — those are manually-pinned bundled copies, not npm-tracked dependencies. The `update-vendor.sh` script remains the upstream-version-bump path.

## What's NOT in this PR

The two GitHub security toggles that need GitHub Advanced Security (paid tier):
- `secret_scanning_non_provider_patterns` — generic-token patterns
- `secret_scanning_validity_checks` — live-check found tokens

If GHAS ever flips on for this repo, those toggle without a code change.

## Expected after merge

- CodeQL run on `main` completes ~5–10 min after merge. First run on a 50-module surface will likely surface a handful of low/info findings — worth a triage pass once they appear in Security → Code scanning.
- Dependabot will fire a wave of update PRs for outdated devDeps (puppeteer, @types/*, etc.). Most are safe-to-merge minor/patch.

## Test plan

- [ ] Existing Tests workflow stays green on this PR.
- [ ] CodeQL job runs to completion on the PR (timing: ~5–10 min).
- [ ] After merge, confirm Security tab shows: Code scanning enabled · Dependabot enabled · Secret scanning enabled · Private vulnerability reporting enabled.
- [ ] Triage initial CodeQL findings (≤ a few P1+ expected; if more, tighten path-ignores or query suite).
- [ ] Triage the wave of Dependabot PRs that lands once alerts are processed.