### PR TITLE
fix(test): wearables-series time-bomb on a hardcoded date

### DIFF
--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1153,7 +1153,13 @@ return (async function() {
     window._labState.currentProfile = TEST_PROFILE_S;
     try {
       const storeM = await import('/js/wearables-store.js?bust=' + Date.now());
-      await storeM.upsertDaily(TEST_PROFILE_S, { source: 'oura', date: '2026-04-23', hrv_rmssd: 38 });
+      // Date must fall inside buildWearableSeriesSection's 7-day window
+      // (today − 6 .. today). A hardcoded literal goes stale with time —
+      // 2026-04-23 was the original value, which silently dropped out of
+      // the window after April 29, breaking CI deterministically until
+      // someone reran. Pin to (today − 1) instead.
+      const testDate = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+      await storeM.upsertDaily(TEST_PROFILE_S, { source: 'oura', date: testDate, hrv_rmssd: 38 });
       const block = await labCtxMcp.buildWearableSeriesSection(7);
       assert('Series section opens with [section:wearables-series-7d]',
         block.startsWith('[section:wearables-series-7d]'));


### PR DESCRIPTION
## Summary

`tests/test-wearables.js:1156` had a hardcoded date (`'2026-04-23'`) on the L1 IDB row that feeds `buildWearableSeriesSection(7)`. That function builds a 7-day window ending today; the hardcoded date silently dropped out of the window on **2026-04-30**, after which the four assertions about the section opening tag, closing tag, line format, and `→` separator all fail deterministically (block becomes `''`).

## Verification

- Locally on `main` HEAD: 4 failures (reproduced today's CI breakage exactly).
- Locally with the fix: full suite green.
- Remote-side check: I dispatched the test workflow on `main` HEAD before the fix and it failed with the same 4 tests — proves the bug was on `main`, not introduced by any open PR.

## Fix

```js
const testDate = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
```

(today − 1 day, formatted as YYYY-MM-DD). Always inside the 7-day window.

## Why this matters now

7 Dependabot PRs (#154–#160) opened on the repo since the security stack landed. Every one will show CI red on the test job until this is merged. Merging this first turns the rest green.