### PR TITLE
fix(client-list): preserve form progress on new-client form

### DIFF
--- a/js/client-list.js
+++ b/js/client-list.js
@@ -347,13 +347,15 @@ export function openClientForm(profileId) {
           <input type="number" class="cl-form-input" id="cl-height" value="${escapeHTML(String(heightDisplay))}" step="0.1" placeholder="${heightUnit === 'in' ? 'inches' : 'cm'}" oninput="window._clUpdateBMI()">
           <input type="hidden" id="cl-height-unit" value="${heightUnit}">
         </div>
-        <div class="cl-form-col">
+        ${p ? `<div class="cl-form-col">
           <label style="font-size:11px;color:var(--text-muted)">BMI</label>
           <div class="mc-auto-value" id="cl-bmi-display"></div>
-        </div>
+        </div>` : ''}
       </div>
       <div style="font-size:11px;color:var(--text-muted);margin-top:2px">
-        <a href="#" onclick="window._clGoToHealthMetrics(event)" style="color:var(--text-muted);text-decoration:underline">Log weight, blood pressure &amp; pulse on the dashboard &rarr;</a>
+        ${p
+          ? '<a href="#" onclick="window._clGoToHealthMetrics(event)" style="color:var(--text-muted);text-decoration:underline">Log weight, blood pressure &amp; pulse on the dashboard &rarr;</a>'
+          : 'Log weight, blood pressure &amp; pulse on the dashboard after creating the client.'}
       </div>
     </div>
     <div class="cl-form-row">
@@ -396,13 +398,10 @@ export function openClientForm(profileId) {
   });
 }
 
-// Close the Edit Client modal and navigate to the dashboard — the anchor in
-// the Height & BMI row tells the user weight/BP/pulse live there now.
 function _clGoToHealthMetrics(event) {
   if (event) event.preventDefault();
   if (window.closeClientList) window.closeClientList();
   if (window.navigate) window.navigate('dashboard');
-  // Scroll to the wearable strip so the user lands on the metric cards.
   requestAnimationFrame(() => {
     document.getElementById('wearable-strip')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   });

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.5.2';
+self.APP_VERSION = '1.5.3';


### PR DESCRIPTION
## Summary

The "Log weight, blood pressure & pulse on the dashboard →" link in the Height & BMI row of the client form closes the modal and navigates to the dashboard on click. When the form is for an existing client (already persisted) that's helpful. When it's the new-client form, it silently wipes everything the user has typed.

Hit this myself filling out a new client and losing all my progress.

## Changes

- `js/client-list.js`
  - Render the "Log weight…" line as a link **only when editing** (`p` truthy). On the new-client form, render it as static informational text: *"Log weight, blood pressure & pulse on the dashboard after creating the client."*
  - Hide the BMI display column on the new-client form. BMI is derived from a saved weight measurement (`wearableSummary.metrics.weight.latest`), which doesn't exist yet for a new client, so the field always renders empty and reads as broken. The Height field then takes the full row width (parent uses `display: flex` with `flex: 1` children).
  - `_clGoToHealthMetrics` handler kept as-is (still wired to the link in the edit case) and still exported on `window`.
- `version.js`: 1.5.2 → 1.5.3 (cache bust per CONTRIBUTING.md).

## Test plan

- [x] `./run-tests.sh` — node-side suites all pass (105 PASS, 0 FAIL). Browser tests skipped locally because Puppeteer isn't installed globally; CI will cover them. The change is HTML-only (conditional rendering), no logic changes.
- [ ] Reviewer: open the new-client form, type into Name/Sex/etc., confirm the "Log weight…" line renders as plain text and the BMI column is gone. Open an existing client → link is back, BMI column shows, click still navigates to the dashboard wearable strip.