### PR TITLE
v1.5.4: optional wearables + editable import dates (closes #165, #166)

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,12 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.5.4', date: '2026-05-07', title: 'Optional wearables',
+    items: [
+      '<b>Don\'t want wearables?</b> Settings → Wearables → "Wearable integrations" toggles them off. The strip stays for your manual weight, BP, and pulse entries.',
+    ]
+  },
+  {
     version: '1.5.2', date: '2026-05-02', title: 'Bugfixes & improvements',
     items: [
       'Internal hardening pass — small fixes across input sanitization and worker isolation.',

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,9 +5,11 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
-    version: '1.5.4', date: '2026-05-07', title: 'Optional wearables',
+    version: '1.5.4', date: '2026-05-07', title: 'Bugfixes & improvements',
     items: [
       '<b>Don\'t want wearables?</b> Settings → Wearables → "Wearable integrations" toggles them off. The strip stays for your manual weight, BP, and pulse entries.',
+      '<b>Edit a misread import date.</b> Settings → Data → "Edit date" on any imported entry — useful when the AI guessed wrong on an ambiguous numeric date like "12/7/2025".',
+      '<b>Region-aware date parsing.</b> Set your country in the client editor and the PDF importer disambiguates DD/MM vs MM/DD correctly for new imports.',
     ]
   },
   {

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -3,12 +3,13 @@
 import { state } from './state.js';
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS, UNIT_CONVERSIONS, calculateCost, formatCost, trackUsage } from './schema.js';
 import { IMPORT_STEPS } from './constants.js';
-import { escapeHTML, showNotification, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
+import { escapeHTML, showNotification, isDebugMode, isPIIReviewEnabled, hashString, showPromptDialog } from './utils.js';
 import { saveImportedData, recalculateHOMAIR } from './data.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, setAIProvider, setVeniceModel, setOpenRouterModel, getOllamaMainModel, setOllamaMainModel, getVeniceModelDisplay, getOpenRouterModelDisplay, getActiveModelId, getActiveModelDisplay, getOllamaPIIModel, setCustomApiModel, setPpqModel, setRoutstrModel } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { detectProduct, normalizeWithAdapter, getAdapterByTestType } from './adapters.js';
 import { getPdfDocument } from './pdfjs-loader.js';
+import { getProfileLocation, getActiveProfileId } from './profile.js';
 
 
 // ═══════════════════════════════════════════════
@@ -398,6 +399,10 @@ export function tryParseJSON(str) {
 
 export async function parseLabPDFWithAI(pdfText, fileName, onProgress) {
   const markerRef = buildMarkerReference();
+  const country = (getProfileLocation(getActiveProfileId())?.country || '').trim();
+  const dateHint = country
+    ? `   IMPORTANT — the user's region is ${country}. Disambiguate ambiguous numeric dates like "12/7/2025" using the format common to that region (US, Philippines = MM/DD/YYYY; UK, EU, India, Australia, most of Canada = DD/MM/YYYY). Do not assume MM/DD by default.`
+    : `   IMPORTANT — for ambiguous numeric dates like "12/7/2025", look for context (other dates, a printed format like "DD/MM/YYYY" in the report header, or month names elsewhere) before deciding. Do not assume MM/DD by default — most of the world uses DD/MM/YYYY.`;
   const system = `You are a lab report data extraction assistant. You extract biomarker results from lab report text and map them to a known set of marker keys.
 
 Here is the complete list of known markers with their keys, expected units, and reference ranges:
@@ -405,6 +410,7 @@ ${JSON.stringify(markerRef)}
 
 Your task:
 1. Find the sample collection date in the text. Return it as YYYY-MM-DD. Look for dates near keywords like "collection", "collected", "date", "odběr", "datum", or similar in any language.
+${dateHint}
 2. For each biomarker result found in the text, extract:
    - rawName: the test name exactly as it appears in the PDF
    - value: the numeric result (parse comma as decimal point). For "< X" or "> X" results, use X as the value (the detection limit) — these are still clinically meaningful for trend tracking
@@ -953,6 +959,44 @@ export function removeImportedEntry(date) {
   showNotification(`Removed imported data from ${date}`, "info");
 }
 
+export async function renameImportedEntryDate(oldDate) {
+  const entries = state.importedData?.entries;
+  const entry = entries?.find(e => e.date === oldDate);
+  if (!entry) return;
+  const newDate = await showPromptDialog(
+    `Edit collection date (was ${oldDate})`,
+    { defaultValue: oldDate, inputType: 'date', okLabel: 'Save' }
+  );
+  if (!newDate || newDate === oldDate) return;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(newDate)) {
+    showNotification('Date must be YYYY-MM-DD', 'error');
+    return;
+  }
+  if (entries.some(e => e.date === newDate)) {
+    showNotification(`Another entry already exists on ${newDate} — remove it first, then try again.`, 'error', 5000);
+    return;
+  }
+  entry.date = newDate;
+  // manualValues are keyed `markerKey:date` — remap to keep manual-vs-imported provenance correct
+  const manualValues = state.importedData.manualValues;
+  if (manualValues) {
+    const suffixOld = ':' + oldDate;
+    const suffixNew = ':' + newDate;
+    for (const k of Object.keys(manualValues)) {
+      if (k.endsWith(suffixOld)) {
+        manualValues[k.slice(0, -suffixOld.length) + suffixNew] = manualValues[k];
+        delete manualValues[k];
+      }
+    }
+  }
+  saveImportedData();
+  window.buildSidebar();
+  window.updateHeaderDates();
+  const activeNav = document.querySelector(".nav-item.active");
+  window.navigate(activeNav ? activeNav.dataset.category : "dashboard");
+  showNotification(`Date changed from ${oldDate} to ${newDate}`, 'success');
+}
+
 // ═══════════════════════════════════════════════
 // DROP ZONE
 // ═══════════════════════════════════════════════
@@ -1133,6 +1177,10 @@ export async function extractPDFImages(file, maxPages = 8) {
 
 export async function parseLabPDFWithAIImages(images, fileName, onProgress) {
   const markerRef = buildMarkerReference();
+  const country = (getProfileLocation(getActiveProfileId())?.country || '').trim();
+  const dateHint = country
+    ? `   IMPORTANT — the user's region is ${country}. Disambiguate ambiguous numeric dates like "12/7/2025" using the format common to that region (US, Philippines = MM/DD/YYYY; UK, EU, India, Australia, most of Canada = DD/MM/YYYY). Do not assume MM/DD by default.`
+    : `   IMPORTANT — for ambiguous numeric dates like "12/7/2025", look for context (other dates, a printed format like "DD/MM/YYYY" in the report header, or month names elsewhere) before deciding. Do not assume MM/DD by default — most of the world uses DD/MM/YYYY.`;
   // Same system prompt as text-based parsing
   const system = `You are a lab report data extraction assistant. You extract biomarker results from lab report images and map them to a known set of marker keys.
 
@@ -1141,6 +1189,7 @@ ${JSON.stringify(markerRef)}
 
 Your task:
 1. Read the lab report page images carefully. Find the sample collection date. Return it as YYYY-MM-DD.
+${dateHint}
 2. For each biomarker result found, extract:
    - rawName: the test name exactly as it appears
    - value: the numeric result (parse comma as decimal point). For "< X" or "> X" results, use X as the value (the detection limit) — these are still clinically meaningful for trend tracking
@@ -1814,6 +1863,7 @@ Object.assign(window, {
   closeImportModal,
   confirmImport,
   removeImportedEntry,
+  renameImportedEntryDate,
   setupDropZone,
   showImportProgress,
   hideImportProgress,

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -972,6 +972,15 @@ export async function renameImportedEntryDate(oldDate) {
     showNotification('Date must be YYYY-MM-DD', 'error');
     return;
   }
+  // Format-only regex accepts logically invalid dates (Feb 30, month 13).
+  // Round-trip through Date to reject those — `<input type="date">` already
+  // guards in modern browsers, but free-text fallbacks and programmatic
+  // values can still slip through.
+  const parsed = new Date(newDate + 'T00:00:00');
+  if (isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== newDate) {
+    showNotification('That date doesn\'t exist on the calendar.', 'error');
+    return;
+  }
   if (entries.some(e => e.date === newDate)) {
     showNotification(`Another entry already exists on ${newDate} — remove it first, then try again.`, 'error', 5000);
     return;

--- a/js/settings.js
+++ b/js/settings.js
@@ -1053,6 +1053,7 @@ export function renderDataEntriesSection() {
     html += `<div class="imported-entry">
       <span class="ie-info"><span class="ie-date">${d}</span><span class="ie-count">${cnt} markers</span>${fileLabel}${sourceLabel}</span>
       <div class="ie-actions">
+        <button class="ie-remove" onclick="renameImportedEntryDate('${entry.date}').then(refreshDataEntriesSection)" title="Edit collection date">Edit date</button>
         <button class="ie-remove" onclick="removeImportedEntry('${entry.date}');refreshDataEntriesSection()">Remove</button>
       </div>
     </div>`;

--- a/js/settings.js
+++ b/js/settings.js
@@ -1053,7 +1053,7 @@ export function renderDataEntriesSection() {
     html += `<div class="imported-entry">
       <span class="ie-info"><span class="ie-date">${d}</span><span class="ie-count">${cnt} markers</span>${fileLabel}${sourceLabel}</span>
       <div class="ie-actions">
-        <button class="ie-remove" onclick="renameImportedEntryDate('${entry.date}').then(refreshDataEntriesSection)" title="Edit collection date">Edit date</button>
+        <button class="ie-edit" onclick="renameImportedEntryDate('${entry.date}').then(refreshDataEntriesSection)" title="Edit collection date">Edit date</button>
         <button class="ie-remove" onclick="removeImportedEntry('${entry.date}');refreshDataEntriesSection()">Remove</button>
       </div>
     </div>`;

--- a/js/utils.js
+++ b/js/utils.js
@@ -204,7 +204,7 @@ export function showConfirmDialog(message, onConfirm) {
 /// nature makes it awkward inside async flows. This helper reuses the
 /// confirm-dialog CSS so both dialogs look consistent; resolves to the
 /// trimmed string on OK, or null on Cancel / Esc / backdrop-click.
-export function showPromptDialog(message, { defaultValue = '', okLabel = 'OK', cancelLabel = 'Cancel', placeholder = '' } = {}) {
+export function showPromptDialog(message, { defaultValue = '', okLabel = 'OK', cancelLabel = 'Cancel', placeholder = '', inputType = 'text' } = {}) {
   return new Promise((resolve) => {
     let overlay = document.getElementById('prompt-dialog-overlay');
     if (!overlay) {
@@ -215,7 +215,7 @@ export function showPromptDialog(message, { defaultValue = '', okLabel = 'OK', c
     }
     overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-label="Prompt">
       <p class="confirm-message">${escapeHTML(message)}</p>
-      <input type="text" id="prompt-dialog-input" class="api-key-input"
+      <input type="${escapeAttr(inputType)}" id="prompt-dialog-input" class="api-key-input"
              value="${escapeAttr(defaultValue)}"
              placeholder="${escapeAttr(placeholder)}"
              style="width:100%;margin:8px 0 14px;box-sizing:border-box"

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -103,13 +103,21 @@ function isMockAllowed() {
   return true;
 }
 
+// Per-profile so a practitioner can disable wearables for a labs-only client
+// without affecting their own profile. Mirrors the per-profile pattern used
+// by `labcharts-wearable-stub-dismissed-${profile}` further down.
+function _wearableStripHiddenKey() {
+  return `wearables-strip-hidden-${state.currentProfile || 'default'}`;
+}
+
 export function isWearableStripHidden() {
-  return localStorage.getItem('wearables-strip-hidden') === '1';
+  return localStorage.getItem(_wearableStripHiddenKey()) === '1';
 }
 
 export function setWearableStripHidden(hidden) {
-  if (hidden) localStorage.setItem('wearables-strip-hidden', '1');
-  else localStorage.removeItem('wearables-strip-hidden');
+  const key = _wearableStripHiddenKey();
+  if (hidden) localStorage.setItem(key, '1');
+  else localStorage.removeItem(key);
   if (window.navigate) window.navigate('dashboard');
 }
 
@@ -384,13 +392,17 @@ export function renderWearableStrip() {
   // BP, and pulse cards still render — wearable vendor cards (Oura, etc.)
   // drop out.
   if (wearablesHidden) sourceIds = sourceIds.filter(s => s === 'manual');
-  if (sourceIds.length === 0) {
-    if (wearablesHidden) return '';
-    return renderWearableStripStub();
-  }
+  // In wearables-off mode, fall through to the render path even if the user
+  // has no 'manual' source yet — the MANUAL_EMPTY_METRICS placeholders below
+  // give them a way to discover hand-logging weight / BP / RHR. Synthesize
+  // a virtual 'manual' source id; the chrome that uses summary.sources[s]
+  // (last-synced label, sync button, demo pill) is hidden in manualOnly mode
+  // anyway, and null-safe access protects what's left.
+  if (wearablesHidden && sourceIds.length === 0) sourceIds = ['manual'];
+  if (sourceIds.length === 0) return renderWearableStripStub();
   if (!summary.metrics || Object.keys(summary.metrics).length === 0) {
-    if (wearablesHidden) return '';
-    return renderWearableStripStub();
+    if (!wearablesHidden) return renderWearableStripStub();
+    // else: wearables-off + no metrics — keep going so MANUAL_EMPTY_METRICS render.
   }
 
   const collapsed = localStorage.getItem('wearables-strip-collapsed') === '1';
@@ -398,12 +410,12 @@ export function renderWearableStrip() {
   // with no recent device sync) shouldn't headline the strip — they make
   // "Wearables: Oura + Polar · 15d" read like Polar contributed half the data.
   // Surface them in the footer instead.
-  const sourcesWithData = sourceIds.filter(s => (summary.sources[s].coverageDays || 0) > 0);
+  const sourcesWithData = sourceIds.filter(s => (summary.sources?.[s]?.coverageDays || 0) > 0);
   // 'manual' is user-authored data — it's not a device that can be "waiting
   // on a device sync", so exclude it from the waiting footer note even when
   // coverageDays is zero (e.g. user touched the manual adapter without
   // saving anything yet).
-  const sourcesWaiting  = sourceIds.filter(s => s !== 'manual' && (summary.sources[s].coverageDays || 0) === 0);
+  const sourcesWaiting  = sourceIds.filter(s => s !== 'manual' && (summary.sources?.[s]?.coverageDays || 0) === 0);
   const headerSourceIds = sourcesWithData.length ? sourcesWithData : sourceIds;
   const baseMetricOrder = metricsForSources(headerSourceIds);
   const showSourceBadges = headerSourceIds.length > 1;
@@ -463,8 +475,8 @@ export function renderWearableStrip() {
   }
 
   // Header meta: most recent sync across connected sources + a short coverage label.
-  const lastSyncAt = Math.max(0, ...sourceIds.map(s => summary.sources[s].lastSyncAt || 0));
-  const coverageDays = Math.max(0, ...headerSourceIds.map(s => summary.sources[s].coverageDays || 0));
+  const lastSyncAt = Math.max(0, ...sourceIds.map(s => summary.sources?.[s]?.lastSyncAt || 0));
+  const coverageDays = Math.max(0, ...headerSourceIds.map(s => summary.sources?.[s]?.coverageDays || 0));
   const sourceLabel = headerSourceIds.map(id => adapterById(id)?.displayName || id).join(' + ');
   const coverageLabel = coverageDays > 0 ? ` · ${coverageDays}d` : '';
   const waitingLabel = sourcesWaiting

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -103,6 +103,16 @@ function isMockAllowed() {
   return true;
 }
 
+export function isWearableStripHidden() {
+  return localStorage.getItem('wearables-strip-hidden') === '1';
+}
+
+export function setWearableStripHidden(hidden) {
+  if (hidden) localStorage.setItem('wearables-strip-hidden', '1');
+  else localStorage.removeItem('wearables-strip-hidden');
+  if (window.navigate) window.navigate('dashboard');
+}
+
 function getWearableSummary() {
   const real = state.importedData?.wearableSummary;
   if (real && real.sources && Object.keys(real.sources).length > 0) return real;
@@ -347,10 +357,17 @@ function dismissWearableStub() {
 }
 
 export function renderWearableStrip() {
-  const summary = getWearableSummary();
+  const wearablesHidden = isWearableStripHidden();
+  let summary = getWearableSummary();
+  // Wearables-off mode: drop the demo summary (no mock vendor cards) so
+  // we only render real data the user actually logged.
+  if (wearablesHidden && summary === MOCK_SUMMARY) summary = null;
   if (!summary) {
     // No real summary AND mock is suppressed (or off). Surface the stub
-    // so users who skipped the welcome flow still discover the feature.
+    // so users who skipped the welcome flow still discover the feature —
+    // unless wearables are explicitly off, in which case the user has
+    // opted out of vendor integrations entirely.
+    if (wearablesHidden) return '';
     return renderWearableStripStub();
   }
   // Sort by ADAPTERS registry order (Oura first, Apple Health last) instead
@@ -361,10 +378,20 @@ export function renderWearableStrip() {
     const idx = ADAPTERS.findIndex(a => a.id === sid);
     return idx === -1 ? 999 : idx;
   };
-  const sourceIds = Object.keys(summary.sources || {})
+  let sourceIds = Object.keys(summary.sources || {})
     .sort((a, b) => adapterOrderIndex(a) - adapterOrderIndex(b));
-  if (sourceIds.length === 0) return renderWearableStripStub();
-  if (!summary.metrics || Object.keys(summary.metrics).length === 0) return renderWearableStripStub();
+  // Wearables-off mode: keep only the manual pseudo-source. Manual weight,
+  // BP, and pulse cards still render — wearable vendor cards (Oura, etc.)
+  // drop out.
+  if (wearablesHidden) sourceIds = sourceIds.filter(s => s === 'manual');
+  if (sourceIds.length === 0) {
+    if (wearablesHidden) return '';
+    return renderWearableStripStub();
+  }
+  if (!summary.metrics || Object.keys(summary.metrics).length === 0) {
+    if (wearablesHidden) return '';
+    return renderWearableStripStub();
+  }
 
   const collapsed = localStorage.getItem('wearables-strip-collapsed') === '1';
   // Connected vendors that haven't returned any rows yet (e.g. Polar account
@@ -372,7 +399,11 @@ export function renderWearableStrip() {
   // "Wearables: Oura + Polar · 15d" read like Polar contributed half the data.
   // Surface them in the footer instead.
   const sourcesWithData = sourceIds.filter(s => (summary.sources[s].coverageDays || 0) > 0);
-  const sourcesWaiting  = sourceIds.filter(s => (summary.sources[s].coverageDays || 0) === 0);
+  // 'manual' is user-authored data — it's not a device that can be "waiting
+  // on a device sync", so exclude it from the waiting footer note even when
+  // coverageDays is zero (e.g. user touched the manual adapter without
+  // saving anything yet).
+  const sourcesWaiting  = sourceIds.filter(s => s !== 'manual' && (summary.sources[s].coverageDays || 0) === 0);
   const headerSourceIds = sourcesWithData.length ? sourcesWithData : sourceIds;
   const baseMetricOrder = metricsForSources(headerSourceIds);
   const showSourceBadges = headerSourceIds.length > 1;
@@ -388,7 +419,14 @@ export function renderWearableStrip() {
   const seenDisplay = new Set();
   for (const id of baseMetricOrder) {
     if (STRIP_HIDDEN_METRICS.has(id)) continue;
-    if (summary.metrics?.[id]) { displayOrder.push({ id, empty: false }); seenDisplay.add(id); }
+    const m = summary.metrics?.[id];
+    if (!m) continue;
+    // Wearables-off mode: only manual-sourced cards survive. Vendor metrics
+    // (HRV, sleep score, etc.) hide; the stored data stays untouched so
+    // flipping the toggle back on restores them instantly.
+    if (wearablesHidden && m.primarySource !== 'manual') continue;
+    displayOrder.push({ id, empty: false });
+    seenDisplay.add(id);
   }
   for (const id of MANUAL_EMPTY_METRICS) {
     if (!seenDisplay.has(id) && canonicalMetric(id)) {
@@ -448,20 +486,33 @@ export function renderWearableStrip() {
     ? `${waitingLabel} connected — waiting on first device sync.`
     : '';
 
+  // When wearables are off the strip is purely manual entries — drop the
+  // "Wearables: Oura · 15d" header, the sync button (nothing remote to
+  // sync), and the demo pill / waiting note.
+  const manualOnly = wearablesHidden;
+  const titleHTML = manualOnly
+    ? '<span>Biometrics</span>'
+    : `<span>Wearables: <span class="wearable-source-label">${escapeHTML(sourceLabel)}${coverageLabel}</span></span>`;
+  const lastSyncHTML = manualOnly ? '' : `<span class="wearable-strip-lastsync">last synced ${formatAgo(lastSyncAt)}</span>`;
+  const syncBtnHTML = manualOnly ? '' : `<button type="button" class="wearable-strip-sync" aria-label="Sync wearables now" onclick="event.stopPropagation();syncWearableNow(this);return false">
+    <svg class="wearable-strip-sync-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><polyline points="21 4 21 12 13 12"/></svg>
+    <span>Sync</span>
+  </button>`;
+  const ariaLabel = manualOnly
+    ? (collapsed ? 'Expand biometrics strip' : 'Collapse biometrics strip')
+    : (collapsed ? 'Expand wearables strip' : 'Collapse wearables strip');
+
   let html = `<section class="wearable-strip" id="wearable-strip">
-    <div class="wearable-strip-header" role="button" tabindex="0" aria-expanded="${!collapsed}" aria-label="${collapsed ? 'Expand wearables strip' : 'Collapse wearables strip'}" onclick="toggleWearableStrip()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleWearableStrip()}">
+    <div class="wearable-strip-header" role="button" tabindex="0" aria-expanded="${!collapsed}" aria-label="${ariaLabel}" onclick="toggleWearableStrip()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleWearableStrip()}">
       <div class="wearable-strip-title">
         <span class="wearable-strip-icon" aria-hidden="true">⌬</span>
-        <span>Wearables: <span class="wearable-source-label">${escapeHTML(sourceLabel)}${coverageLabel}</span></span>
-        ${isMock ? '<button type="button" class="wearable-strip-demo-pill" onclick="event.stopPropagation();window.openSettingsModal(\'wearables\')" title="This is a sample. Connect your own wearable to see real data here.">demo data — connect yours</button>' : ''}
+        ${titleHTML}
+        ${!manualOnly && isMock ? '<button type="button" class="wearable-strip-demo-pill" onclick="event.stopPropagation();window.openSettingsModal(\'wearables\')" title="This is a sample. Connect your own wearable to see real data here.">demo data — connect yours</button>' : ''}
         ${reorderMode ? '<span class="wearable-strip-reorder-pill">⇄ Reorder mode — use ◀ ▶ on each card</span>' : ''}
       </div>
       <div class="wearable-strip-meta">
-        <span class="wearable-strip-lastsync">last synced ${formatAgo(lastSyncAt)}</span>
-        <button type="button" class="wearable-strip-sync" aria-label="Sync wearables now" onclick="event.stopPropagation();syncWearableNow(this);return false">
-          <svg class="wearable-strip-sync-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><polyline points="21 4 21 12 13 12"/></svg>
-          <span>Sync</span>
-        </button>
+        ${lastSyncHTML}
+        ${syncBtnHTML}
         <button type="button" class="wearable-strip-reorder${reorderMode ? ' active' : ''}" aria-label="${reorderMode ? 'Done reordering' : 'Reorder cards'}" title="${reorderMode ? 'Done reordering' : 'Reorder cards'}" onclick="event.stopPropagation();toggleWearableReorder()">
           ${reorderMode ? 'Done' : '⇄ Reorder'}
         </button>
@@ -1097,9 +1148,20 @@ export function renderWearablesSettingsSection() {
   const connected = listConnectedSources();
   const rows = visibleAdapters(Object.keys(connected))
     .map(a => renderAdapterRow(a, !!connected[a.id])).join('');
+  const hidden = isWearableStripHidden();
   // BETA badge moves out of every row to a single section-level note. Every
   // wearable adapter is currently beta — the per-row chip was redundant.
-  return `<div class="settings-section-header" style="display:block">
+  return `<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px">
+    <div style="flex:1;min-width:0">
+      <div style="font-size:13px;color:var(--text-secondary)">Wearable integrations</div>
+      <div style="font-size:11px;color:var(--text-muted);margin-top:2px">Show data from connected wearables (Oura, Withings, Fitbit, etc.) on the dashboard. Off keeps the strip as a Biometrics strip — your manual weight, BP, and pulse entries still appear.</div>
+    </div>
+    <label class="toggle-switch">
+      <input type="checkbox" id="wearables-strip-hidden-toggle" ${hidden ? '' : 'checked'} onchange="window.setWearableStripHidden(!this.checked)">
+      <span class="toggle-slider"></span>
+    </label>
+  </div>
+  <div class="settings-section-header" style="display:block">
     <div class="settings-section-title" style="display:block;margin-bottom:4px">Connected devices</div>
     <div class="settings-section-hint" style="display:block">Data stays on this device; a compact summary + anomaly events sync to your other devices. All integrations are <em>beta</em> — please report issues.</div>
   </div>
@@ -1806,6 +1868,8 @@ function cancelManualLog(event) {
 
 Object.assign(window, {
   renderWearableStrip,
+  setWearableStripHidden,
+  isWearableStripHidden,
   dismissWearableStub,
   toggleWearableStrip,
   openWearableDetail,

--- a/styles.css
+++ b/styles.css
@@ -765,11 +765,13 @@ body.chat-open.chat-fullscreen .main { padding-right: 32px; }
 .imported-entry .ie-date { color: var(--text-primary); font-weight: 500; }
 .imported-entry .ie-count { color: var(--text-muted); margin-left: 8px; }
 .imported-entry .ie-actions { display: flex; align-items: center; gap: 4px; }
-.imported-entry .ie-remove {
+.imported-entry .ie-remove,
+.imported-entry .ie-edit {
   background: none; border: none; color: var(--text-muted); cursor: pointer;
   font-size: 12px; padding: 4px 10px; border-radius: 4px; transition: all 0.15s; font-family: inherit;
 }
 .imported-entry .ie-remove:hover { color: var(--red); background: var(--red-bg); }
+.imported-entry .ie-edit:hover { color: var(--text-primary); background: var(--bg-hover); }
 /* Standalone note row */
 /* Note cards (dashboard) */
 .notes-section { margin-bottom: 20px; }

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1430,7 +1430,8 @@ return (async function() {
     /aria-label="\$\{escapeHTML\(ariaText\)\}"/.test(wearablesSrcP2) &&
     /Delete\s+\$\{metricLabel\.toLowerCase\(\)\}\s+reading\s+from/.test(wearablesSrcP2));
   assert('Strip-header role="button" carries an aria-label distinct from the live source list',
-    /aria-label="\$\{collapsed\s*\?\s*'Expand wearables strip'\s*:\s*'Collapse wearables strip'\}"/.test(wearablesSrcP2));
+    /'(Expand|Collapse) wearables strip'/.test(wearablesSrcP2)
+    && /aria-label="\$\{ariaLabel\}"/.test(wearablesSrcP2));
 
   // (Niche-disclosure copy assertion was here. The disclosure was removed in
   // v1.30.1 — see the matching "STRIP_NICHE_METRICS / disclosure / nicheDeferred

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.5.3';
+self.APP_VERSION = '1.5.4';


### PR DESCRIPTION
Closes #165 and #166. Two small features bundled under v1.5.4 — they're touching the same `version.js` and `changelog.js` so a single PR avoids rebase pain.

---

## #165 — Optional wearables (`js/wearables.js`)

User asked for a way to disable wearables in settings. The wearables strip already shows manual weight/BP/RHR cards (via the `manual` first-class pseudo-source), so hiding the whole strip would have taken those cards away too. Reframed as a data-layer toggle.

Settings → Wearables → **"Wearable integrations"** (default ON). When OFF:
- Vendor cards (Oura HRV, Withings body comp, Fitbit sleep, etc.) hide.
- Demo / mock summary suppressed.
- "Connect a wearable" hint hidden.
- Header drops `Wearables: Oura · 15d` → `Biometrics`.
- Sync button + `last synced` label hidden (nothing remote to sync).
- Manual cards (`primarySource === 'manual'`) keep rendering.
- Empty manual placeholders for weight / BP / RHR keep their entry-point role.
- If user has neither manual nor wearable data, strip is hidden entirely.

Stored connections + IndexedDB rows untouched — flipping back ON restores everything instantly. Also fixes a pre-existing copy bug where `manual` could land in `sourcesWaiting` and render `Manual connected — waiting on first device sync.`

## #166 — Editable import dates + region-aware date parsing (`js/pdf-import.js`, `js/utils.js`, `js/settings.js`)

Indian-format PDF date "12/7/2025" (12-July) was being parsed as 7-Dec. User suggested allowing the date to be edited.

- Settings → Data → each imported entry gets an **"Edit date"** button. Native `<input type="date">` picker, validates `YYYY-MM-DD`, refuses date collisions with explicit toast, remaps `manualValues[markerKey:date]` so manual-vs-imported provenance survives the rename.
- `parseLabPDFWithAI` / `parseLabPDFWithAIImages` inject the active profile's country into the system prompt as a date-format hint (US/PH = MM/DD; UK/EU/IN/AU/CA = DD/MM). Falls back to a "look for context, don't assume MM/DD" hint when country isn't set.
- `showPromptDialog` extended with optional `inputType` so we can use `type="date"` instead of free-text.
- Sync rides on existing `saveImportedData()`; CRDT sees the rename as delete + insert, which is correct.

## Files changed

- `js/wearables.js` — toggle accessors, source/metric filter, header swap, hidden chrome, manual-not-waiting fix.
- `js/pdf-import.js` — `renameImportedEntryDate`, country-aware date hint in both text + image parsers.
- `js/settings.js` — Edit-date button in the imported-data list.
- `js/utils.js` — `showPromptDialog` accepts `inputType`.
- `js/changelog.js` — three compact bullets under v1.5.4.
- `version.js` — 1.5.3 → 1.5.4 (SW cache bust).
- `tests/test-wearables.js` — a11y assertion updated for new `ariaLabel` variable.

## Test plan

- [x] Full test suite passes (552 asserts, all suites green).
- [x] **#166** in Chrome on Demo Sarah: rename Aug 5 → Sep 10 succeeds (cycle phase recalculates, sidebar updates); collision case (Apr 10 → Dec 15) refused with explicit toast.
- [x] **#165** filter logic line-walked; toggle round-trip in Chrome with synthetic mixed-source data confirmed wearables ON renders HRV+RHR+Weight cards.
- [ ] Reviewer for #165: log a real manual weight via the wearables strip, then toggle off → confirm weight card stays + Oura/Withings cards disappear. Synthetic test data didn't survive the per-row IDB re-derivation, so end-to-end manual verification needs persisted manual entries.
- [ ] Reviewer for #166: import a non-trivial PDF with an ambiguous date — verify the country hint nudges the AI correctly. Verify Edit-date button in Settings → Data works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)