### PR TITLE
refactor: promisify showConfirmDialog (returns Promise<boolean>)

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -235,7 +235,7 @@ export async function exportEncryptedBackup() {
 
 export function importEncryptedBackup(file) {
   const reader = new FileReader();
-  reader.onload = (e) => {
+  reader.onload = async (e) => {
     try {
       const backup = JSON.parse(e.target.result);
       if (backup.format !== 'labcharts-backup' || !backup.profileList) {
@@ -246,50 +246,44 @@ export function importEncryptedBackup(file) {
       const profileCount = backup.profiles ? backup.profiles.length : 0;
       const encMsg = backup.encrypted ? ' This backup is encrypted \u2014 you\'ll need the same passphrase.' : '';
 
-      showConfirmDialog(
-        `Restore backup from ${new Date(backup.createdAt).toLocaleDateString()}? This will overwrite ${profileCount} profile(s).${encMsg}`,
-        () => {
-          if (backup.encrypted && backup.encryptionSalt) {
-            localStorage.setItem('labcharts-encryption-enabled', 'true');
-            localStorage.setItem('labcharts-encryption-salt', backup.encryptionSalt);
-          } else {
-            localStorage.removeItem('labcharts-encryption-enabled');
-            localStorage.removeItem('labcharts-encryption-salt');
-          }
-
-          if (backup.settings && typeof backup.settings === 'object') {
-            for (const [k, v] of Object.entries(backup.settings)) {
-              localStorage.setItem(k, v);
-            }
-          }
-
-          localStorage.setItem('labcharts-profiles', backup.profileList);
-
-          // Restore each profile's keys. Big-blob keys (`-imported`)
-          // route to IndexedDB; everything else stays in localStorage.
-          // writeRawStoredItem is async because of the IDB path \u2014 wrap
-          // the whole restore in a Promise.all chain so the wearable
-          // restore + reload only fires after all profile keys are
-          // actually written.
-          const writeAll = (async () => {
-            if (backup.profiles) {
-              for (const p of backup.profiles) {
-                for (const [suffix, value] of Object.entries(p.keys)) {
-                  const key = `labcharts-${p.profileId}-${suffix}`;
-                  await writeRawStoredItem(key, value);
-                }
-              }
-            }
-          })();
-
-          writeAll
-            .then(() => restoreWearableIDB(backup.wearableIDB))
-            .finally(() => {
-              showNotification('Backup restored \u2014 reloading...', 'success');
-              setTimeout(() => location.reload(), 1000);
-            });
+      if (await showConfirmDialog(
+        `Restore backup from ${new Date(backup.createdAt).toLocaleDateString()}? This will overwrite ${profileCount} profile(s).${encMsg}`
+      )) {
+        if (backup.encrypted && backup.encryptionSalt) {
+          localStorage.setItem('labcharts-encryption-enabled', 'true');
+          localStorage.setItem('labcharts-encryption-salt', backup.encryptionSalt);
+        } else {
+          localStorage.removeItem('labcharts-encryption-enabled');
+          localStorage.removeItem('labcharts-encryption-salt');
         }
-      );
+
+        if (backup.settings && typeof backup.settings === 'object') {
+          for (const [k, v] of Object.entries(backup.settings)) {
+            localStorage.setItem(k, v);
+          }
+        }
+
+        localStorage.setItem('labcharts-profiles', backup.profileList);
+
+        // Restore each profile's keys. Big-blob keys (`-imported`)
+        // route to IndexedDB; everything else stays in localStorage.
+        // writeRawStoredItem is async because of the IDB path \u2014 await
+        // each so the wearable restore + reload only fires after all
+        // profile keys are actually written.
+        if (backup.profiles) {
+          for (const p of backup.profiles) {
+            for (const [suffix, value] of Object.entries(p.keys)) {
+              const key = `labcharts-${p.profileId}-${suffix}`;
+              await writeRawStoredItem(key, value);
+            }
+          }
+        }
+
+        restoreWearableIDB(backup.wearableIDB).finally(() => {
+          showNotification('Backup restored \u2014 reloading...', 'success');
+          setTimeout(() => location.reload(), 1000);
+        });
+      }
     } catch (err) {
       showNotification('Error reading backup: ' + err.message, 'error');
     }
@@ -404,38 +398,37 @@ export async function restoreAutoBackup(id) {
   }
   const backup = record.snapshot;
 
-  showConfirmDialog(
-    `Restore auto-backup from ${new Date(backup.createdAt).toLocaleString()}? This will overwrite all current data.`,
-    () => {
-      if (backup.encrypted && backup.encryptionSalt) {
-        localStorage.setItem('labcharts-encryption-enabled', 'true');
-        localStorage.setItem('labcharts-encryption-salt', backup.encryptionSalt);
-      } else {
-        localStorage.removeItem('labcharts-encryption-enabled');
-        localStorage.removeItem('labcharts-encryption-salt');
-      }
-      if (backup.settings && typeof backup.settings === 'object') {
-        for (const [k, v] of Object.entries(backup.settings)) {
-          localStorage.setItem(k, v);
-        }
-      }
-      localStorage.setItem('labcharts-profiles', backup.profileList);
-      if (backup.profiles) {
-        for (const p of backup.profiles) {
-          for (const [suffix, value] of Object.entries(p.keys)) {
-            localStorage.setItem(`labcharts-${p.profileId}-${suffix}`, value);
-          }
-        }
-      }
-      // Wearable L1 IDB rows live outside localStorage \u2014 restore them
-      // separately so the strip's detail-modal chart history is preserved
-      // along with everything else.
-      restoreWearableIDB(backup.wearableIDB).finally(() => {
-        showNotification('Backup restored \u2014 reloading...', 'success');
-        setTimeout(() => location.reload(), 1000);
-      });
+  if (await showConfirmDialog(
+    `Restore auto-backup from ${new Date(backup.createdAt).toLocaleString()}? This will overwrite all current data.`
+  )) {
+    if (backup.encrypted && backup.encryptionSalt) {
+      localStorage.setItem('labcharts-encryption-enabled', 'true');
+      localStorage.setItem('labcharts-encryption-salt', backup.encryptionSalt);
+    } else {
+      localStorage.removeItem('labcharts-encryption-enabled');
+      localStorage.removeItem('labcharts-encryption-salt');
     }
-  );
+    if (backup.settings && typeof backup.settings === 'object') {
+      for (const [k, v] of Object.entries(backup.settings)) {
+        localStorage.setItem(k, v);
+      }
+    }
+    localStorage.setItem('labcharts-profiles', backup.profileList);
+    if (backup.profiles) {
+      for (const p of backup.profiles) {
+        for (const [suffix, value] of Object.entries(p.keys)) {
+          localStorage.setItem(`labcharts-${p.profileId}-${suffix}`, value);
+        }
+      }
+    }
+    // Wearable L1 IDB rows live outside localStorage \u2014 restore them
+    // separately so the strip's detail-modal chart history is preserved
+    // along with everything else.
+    restoreWearableIDB(backup.wearableIDB).finally(() => {
+      showNotification('Backup restored \u2014 reloading...', 'success');
+      setTimeout(() => location.reload(), 1000);
+    });
+  }
 }
 
 // ═══════════════════════════════════════════════
@@ -537,15 +530,15 @@ export async function reauthorizeFolderBackup() {
   }
 }
 
-export function removeFolderBackup() {
-  showConfirmDialog('Stop backing up to this folder?', async () => {
+export async function removeFolderBackup() {
+  if (await showConfirmDialog('Stop backing up to this folder?')) {
     _folderHandle = null;
     _folderPermissionLost = false;
     await clearFolderHandle();
     localStorage.removeItem('labcharts-folder-backup-last');
     showNotification('Folder backup removed', 'info');
     refreshFolderBackupUI();
-  });
+  }
 }
 
 export function getFolderBackupState() {

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,12 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.6.1', date: '2026-05-10', title: 'Bugfixes & improvements',
+    items: [
+      '<b>PDF image import:</b> clicking Cancel on the AI-provider privacy warning aborts cleanly now (was hanging).',
+    ]
+  },
+  {
     version: '1.6.0', date: '2026-05-04', title: '☀ Light & Sun — the lens for everything sunlight does to you',
     items: [
       '<b>☀ Light & Sun lens.</b> Sunlight does a lot more than make vitamin D. Track your exposure across six biological channels — Vitamin D, Body clock, Cardiovascular, Mood & hormones, Cellular repair, and Outdoor eye light — and correlate them with your labs and wearable data over time. One-tap session logging: tap when you go outside, tap again when you come back. Plain-English summary on stop with computed vit-D yield and burn-dose status.',

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -153,8 +153,8 @@ export async function switchToThread(threadId) {
   renderThreadList();
 }
 
-export function deleteThread(threadId) {
-  showConfirmDialog('Delete this conversation? This cannot be undone.', () => {
+export async function deleteThread(threadId) {
+  if (await showConfirmDialog('Delete this conversation? This cannot be undone.')) {
     invalidateThreadContentCache();
     // Remove from index
     state.chatThreads = state.chatThreads.filter(t => t.id !== threadId);
@@ -178,7 +178,7 @@ export function deleteThread(threadId) {
     }
     renderThreadList();
     showNotification('Conversation deleted', 'info');
-  });
+  }
 }
 
 export function renameThread(threadId, newName) {

--- a/js/chat.js
+++ b/js/chat.js
@@ -977,9 +977,9 @@ ${html}
   w.print();
 }
 
-export function clearChatHistory() {
+export async function clearChatHistory() {
   // Sister "delete thread" confirms; this one used to wipe immediately.
-  showConfirmDialog("Clear all messages in this conversation? This can't be undone.", () => {
+  if (await showConfirmDialog("Clear all messages in this conversation? This can't be undone.")) {
     state.chatHistory = [];
     if (state.currentThreadId) {
       localStorage.removeItem(getChatThreadKey(state.currentThreadId));
@@ -1006,7 +1006,7 @@ export function clearChatHistory() {
     updateChatHeaderTitle();
     updateDiscussButton();
     showNotification('Chat history cleared', 'info');
-  });
+  }
 }
 
 // ═══════════════════════════════════════════════

--- a/js/chat.js
+++ b/js/chat.js
@@ -546,11 +546,11 @@ export function editCustomPersonality(id) {
   updatePersonalityBar();
 }
 
-export function deleteCustomPersonality(id) {
+export async function deleteCustomPersonality(id) {
   const customs = getCustomPersonalities();
   const cp = customs.find(p => p.id === id);
   const name = cp ? cp.name : 'personality';
-  showConfirmDialog(`Delete "${name}"? This cannot be undone.`, () => {
+  if (await showConfirmDialog(`Delete "${name}"? This cannot be undone.`)) {
     const updated = customs.filter(p => p.id !== id);
     saveCustomPersonalities(updated);
     if (state.currentChatPersonality === id) {
@@ -561,7 +561,7 @@ export function deleteCustomPersonality(id) {
     updatePersonalityBar();
     updateChatHeaderTitle();
     renderChatMessages();
-  });
+  }
 }
 
 export async function generateCustomPersonality() {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -703,7 +703,7 @@ async function _walkWearableIDB(mode) {
 }
 
 export async function disableEncryption() {
-  showConfirmDialog('Disable encryption? Your data will be stored in plaintext.', async () => {
+  if (await showConfirmDialog('Disable encryption? Your data will be stored in plaintext.')) {
     try {
       // CRITICAL ORDER: walk wearable IDB BEFORE clearing _sessionKey, so
       // rows can decrypt under the current key. Then localStorage walk,
@@ -722,7 +722,7 @@ export async function disableEncryption() {
     } catch (err) {
       showNotification('Failed to disable encryption: ' + err.message, 'error');
     }
-  });
+  }
 }
 
 export async function changePassphrase() {

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -438,8 +438,8 @@ export function saveMenstrualCycle() {
   setTimeout(() => { if (window.startCycleTour) window.startCycleTour(true); }, 600);
 }
 
-export function clearMenstrualCycle() {
-  showConfirmDialog('Clear all menstrual cycle data? This cannot be undone.', () => {
+export async function clearMenstrualCycle() {
+  if (await showConfirmDialog('Clear all menstrual cycle data? This cannot be undone.')) {
     state.importedData.menstrualCycle = null;
     window.recordChange('menstrualCycle');
     saveImportedData();
@@ -447,7 +447,7 @@ export function clearMenstrualCycle() {
     const activeNav = document.querySelector(".nav-item.active");
     window.navigate(activeNav ? activeNav.dataset.category : "dashboard");
     showNotification('Menstrual cycle data cleared', 'info');
-  });
+  }
 }
 
 function _toggleCycleEditorFields() {

--- a/js/dna.js
+++ b/js/dna.js
@@ -1102,11 +1102,11 @@ export { HAPLOGROUP_LIST };
 /// card matches the rest of the app's modal styling and respects the
 /// PWA / file:// contexts where the native window.confirm prompt
 /// would feel out of place.
-function confirmDeleteDNA() {
-  window.showConfirmDialog('Delete genetic data? This cannot be undone.', () => {
+async function confirmDeleteDNA() {
+  if (await window.showConfirmDialog('Delete genetic data? This cannot be undone.')) {
     deleteGeneticsData(window._getState().importedData);
     window._saveAndRefresh();
-  });
+  }
 }
 
 // ═══════════════════════════════════════════════

--- a/js/emf.js
+++ b/js/emf.js
@@ -412,8 +412,8 @@ export function removeEMFRoom(assessmentId, roomIdx) {
   renderEMFEditor(document.getElementById('detail-modal'));
 }
 
-export function deleteEMFAssessment(id) {
-  showConfirmDialog('Delete this EMF assessment? This cannot be undone.', () => {
+export async function deleteEMFAssessment(id) {
+  if (await showConfirmDialog('Delete this EMF assessment? This cannot be undone.')) {
     const assessments = ensureAssessments();
     const idx = assessments.findIndex(x => x.id === id);
     if (idx === -1) return;
@@ -423,7 +423,7 @@ export function deleteEMFAssessment(id) {
     saveImportedData();
     renderEMFEditor(document.getElementById('detail-modal'));
     showNotification('Assessment deleted', 'info');
-  });
+  }
 }
 
 export function updateEMFField(assessmentId, field, value) {

--- a/js/export.js
+++ b/js/export.js
@@ -1057,12 +1057,12 @@ async function _importDatabaseBundle(json) {
   showNotification(`Imported ${total} profile${total !== 1 ? 's' : ''} (${created} new, ${merged} merged)`, 'success');
 }
 
-export function clearAllData() {
+export async function clearAllData() {
   const profiles = getProfiles();
   const msg = profiles.length > 1
     ? `Clear ALL data across ${profiles.length} profiles? This cannot be undone.`
     : 'Are you sure you want to clear all imported data? This cannot be undone.';
-  showConfirmDialog(msg, async () => {
+  if (await showConfirmDialog(msg)) {
     // Wipe storage for every profile
     for (const p of profiles) {
       const id = p.id;
@@ -1118,7 +1118,7 @@ export function clearAllData() {
     window.renderProfileButton();
     window.navigate('dashboard');
     showNotification('All data cleared', 'info');
-  });
+  }
 }
 
 export async function loadDemoData(sex = 'male') {

--- a/js/lens.js
+++ b/js/lens.js
@@ -1135,9 +1135,9 @@ async function _handleLocalLensIngest(fileList) {
   }
 }
 
-export function handleLocalLensDeleteDoc(source) {
+export async function handleLocalLensDeleteDoc(source) {
   if (!source) return;
-  showConfirmDialog(`Remove "${source}" from your knowledge base?`, async () => {
+  if (await showConfirmDialog(`Remove "${source}" from your knowledge base?`)) {
     try {
       const lens = await _getLocalLens();
       const deleted = await lens.deleteDocument(source);
@@ -1146,11 +1146,11 @@ export function handleLocalLensDeleteDoc(source) {
     } catch (e) {
       showNotification(`Couldn't delete that document: ${e?.message || e}.`, 'error');
     }
-  });
+  }
 }
 
-export function handleLocalLensClear() {
-  showConfirmDialog('Clear every document from your knowledge base? This can\'t be undone.', async () => {
+export async function handleLocalLensClear() {
+  if (await showConfirmDialog('Clear every document from your knowledge base? This can\'t be undone.')) {
     try {
       const lens = await _getLocalLens();
       await lens.clear();
@@ -1160,7 +1160,7 @@ export function handleLocalLensClear() {
     } catch (e) {
       showNotification(`Couldn't clear the knowledge base: ${e?.message || e}.`, 'error');
     }
-  });
+  }
 }
 
 // ── Library management handlers ────────────────────────────────
@@ -1426,8 +1426,8 @@ export async function handleLibraryRename() {
   }
 }
 
-export function handleLibraryDelete() {
-  showConfirmDialog('Delete the active library? Every document in it will be removed. This can\'t be undone.', async () => {
+export async function handleLibraryDelete() {
+  if (await showConfirmDialog('Delete the active library? Every document in it will be removed. This can\'t be undone.')) {
     try {
       const { libraries, activeId } = await _libList();
       if (!activeId) return;
@@ -1448,7 +1448,7 @@ export function handleLibraryDelete() {
     } catch (e) {
       showNotification(`Couldn't delete library: ${e?.message || e}.`, 'error');
     }
-  });
+  }
 }
 
 export function handleToggleLens(checked) {
@@ -1462,13 +1462,13 @@ export function handleClearLensCache() {
   showNotification('Lens cache cleared', 'info');
 }
 
-export function handleRemoveLens() {
+export async function handleRemoveLens() {
   const cfg = getLensConfig();
   const isBrowser = cfg.backend === 'in-browser';
   const prompt = isBrowser
     ? 'Remove Knowledge Source? This also deletes every document you indexed in the browser. This can\'t be undone.'
     : 'Remove Knowledge Source? Your server URL and API key will be deleted.';
-  showConfirmDialog(prompt, async () => {
+  if (await showConfirmDialog(prompt)) {
     await removeLens();
     if (isBrowser) {
       try {
@@ -1484,7 +1484,7 @@ export function handleRemoveLens() {
       : 'Knowledge Source removed.',
       'info',
     );
-  });
+  }
 }
 
 Object.assign(window, {

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -1798,11 +1798,11 @@ if (typeof window !== 'undefined') {
       }
       if (window.navigate && state.currentView === 'light') window.navigate('light');
     },
-    deleteDeviceSession: (id) => {
-      showConfirmDialog("Delete this device session? This can't be undone.", async () => {
+    deleteDeviceSession: async (id) => {
+      if (await showConfirmDialog("Delete this device session? This can't be undone.")) {
         await deleteDeviceSession(id);
         if (window.navigate && state.currentView === 'light') window.navigate('light');
-      });
+      }
     },
     rollingDeviceTotals,
     renderDevicesSection,

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -1710,12 +1710,12 @@ if (typeof window !== 'undefined') {
     // Confirm-dialog wrapped delete — reachable from the expanded
     // room's footer. The bare delete handler stays in case anything
     // else wires it up without confirmation.
-    deleteLightEnvRoomConfirm: (id) => {
-      showConfirmDialog('Delete this room? Measurements stay but lose their room link.', async () => {
+    deleteLightEnvRoomConfirm: async (id) => {
+      if (await showConfirmDialog('Delete this room? Measurements stay but lose their room link.')) {
         await deleteRoom(id);
         if (readActiveRoomId() === id) writeActiveRoomId(null);
         if (window.navigate && state.currentView === 'light') window.navigate('light');
-      });
+      }
     },
     setActiveLightEnvRoom: (id) => {
       writeActiveRoomId(id);
@@ -1758,12 +1758,12 @@ if (typeof window !== 'undefined') {
       await deleteScreen(id);
       if (window.navigate && state.currentView === 'light') window.navigate('light');
     },
-    deleteLightEnvScreenConfirm: (id) => {
-      showConfirmDialog('Delete this screen?', async () => {
+    deleteLightEnvScreenConfirm: async (id) => {
+      if (await showConfirmDialog('Delete this screen?')) {
         await deleteScreen(id);
         if (_expandedScreenId === id) _expandedScreenId = null;
         if (window.navigate && state.currentView === 'light') window.navigate('light');
-      });
+      }
     },
     // Disclosure toggle for screen cards — same event-target gating as
     // the room toggle so clicks on inner controls don't double-fire.
@@ -1844,12 +1844,12 @@ if (typeof window !== 'undefined') {
     updateLightAuditField: async (id, field, value) => {
       await updateLightAudit(id, { [field]: value });
     },
-    deleteLightAuditConfirm: (id) => {
-      showConfirmDialog('Delete this audit? This cannot be undone.', async () => {
+    deleteLightAuditConfirm: async (id) => {
+      if (await showConfirmDialog('Delete this audit? This cannot be undone.')) {
         await deleteLightAudit(id);
         if (_expandedAuditId === id) _expandedAuditId = null;
         if (window.navigate && state.currentView === 'light') window.navigate('light');
-      });
+      }
     },
     // "Interpret changes" — pre-fills the chat panel with a comparison
     // summary so the AI can reason about what shifted and what to try

--- a/js/notes.js
+++ b/js/notes.js
@@ -51,16 +51,16 @@ export function saveNote(idx) {
   showNotification('Note saved', 'success');
 }
 
-export function deleteNote(idx) {
+export async function deleteNote(idx) {
   if (!state.importedData.notes) return;
-  showConfirmDialog("Delete this note? This can't be undone.", () => {
+  if (await showConfirmDialog("Delete this note? This can't be undone.")) {
     state.importedData.notes.splice(idx, 1);
     saveImportedData();
     window.closeModal();
     const activeNav = document.querySelector(".nav-item.active");
     window.navigate(activeNav ? activeNav.dataset.category : "dashboard");
     showNotification('Note deleted', 'info');
-  });
+  }
 }
 
 Object.assign(window, { openNoteEditor, saveNote, deleteNote });

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -1800,13 +1800,9 @@ export async function handleImageFile(file) {
   // PII warning — images cannot be scrubbed
   const provider = getAIProvider();
   if (provider !== 'ollama') {
-    const confirmed = await new Promise(resolve => {
-      showConfirmDialog(
-        'This image will be sent directly to the AI provider. Personal details visible in the image cannot be scrubbed before upload. Continue?',
-        () => resolve(true), () => resolve(false)
-      );
-    });
-    if (!confirmed) return;
+    if (!await showConfirmDialog(
+      'This image will be sent directly to the AI provider. Personal details visible in the image cannot be scrubbed before upload. Continue?'
+    )) return;
   }
   const _startProfileId = state.currentProfile;
   try {

--- a/js/profile.js
+++ b/js/profile.js
@@ -442,10 +442,10 @@ export function touchProfileTimestamp(profileId) {
   if (p) { p.lastUpdated = Date.now(); saveProfiles(profiles); }
 }
 
-export function deleteProfile(profileId, onComplete) {
+export async function deleteProfile(profileId, onComplete) {
   const profiles = getProfiles();
   if (profiles.length <= 1) { showNotification("Cannot delete the last profile", "error"); return; }
-  window.showConfirmDialog('Delete this profile and all its data? This cannot be undone.', async () => {
+  if (await window.showConfirmDialog('Delete this profile and all its data? This cannot be undone.')) {
     const updated = profiles.filter(p => p.id !== profileId);
     saveProfiles(updated);
     // The `-imported` blob lives in IndexedDB now → encryptedRemoveItem
@@ -494,7 +494,7 @@ export function deleteProfile(profileId, onComplete) {
     }
     showNotification('Profile deleted', 'info');
     if (onComplete) onComplete();
-  });
+  }
 }
 
 export async function switchProfile(profileId) {

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -1906,7 +1906,7 @@ export async function handleRemovePpqKey() {
   const msg = hasFunds
     ? `This account has $${parseFloat(balance).toFixed(2)} remaining. Removing this key will permanently lose access to those funds unless you\u2019ve saved the key elsewhere.\n\nRemove PPQ key?`
     : 'Remove PPQ key? Make sure you\u2019ve saved it if you want to reuse this account later.';
-  showConfirmDialog(msg, function() {
+  if (await showConfirmDialog(msg)) {
     localStorage.removeItem('labcharts-ppq-key');
     updateKeyCache('labcharts-ppq-key', null);
     localStorage.removeItem('labcharts-ppq-models');
@@ -1916,7 +1916,7 @@ export async function handleRemovePpqKey() {
     localStorage.removeItem('labcharts-ppq-credit-id');
     showNotification('PPQ key removed', 'info');
     window.openSettingsModal?.();
-  });
+  }
 }
 
 export function renderPpqModelDropdown(models) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -1188,7 +1188,7 @@ function resetCurrentProfileUsage() {
 // Disable confirmation for the PII review toggle. On→off shows a one-time
 // warning so users don't silently lose visibility into what's leaving their
 // device. On→on (re-enabling) and the initial setup are silent.
-export function confirmDisablePIIReview(checkbox) {
+export async function confirmDisablePIIReview(checkbox) {
   if (checkbox.checked) {
     setPIIReviewEnabled(true);
     return;
@@ -1201,14 +1201,13 @@ export function confirmDisablePIIReview(checkbox) {
   }
   // Restore the toggle while the dialog is open; commit only on confirm
   checkbox.checked = true;
-  showConfirmDialog(
-    "Turn off the obfuscation review?\n\nWith this off, getbased's PII detector runs but you won't see the result before it's sent to the AI provider. Recommended only after you've verified the obfuscation works on your data.",
-    () => {
-      localStorage.setItem('labcharts-pii-review-disable-ack', '1');
-      setPIIReviewEnabled(false);
-      checkbox.checked = false;
-    }
-  );
+  if (await showConfirmDialog(
+    "Turn off the obfuscation review?\n\nWith this off, getbased's PII detector runs but you won't see the result before it's sent to the AI provider. Recommended only after you've verified the obfuscation works on your data."
+  )) {
+    localStorage.setItem('labcharts-pii-review-disable-ack', '1');
+    setPIIReviewEnabled(false);
+    checkbox.checked = false;
+  }
 }
 
 Object.assign(window, {

--- a/js/sun.js
+++ b/js/sun.js
@@ -674,15 +674,14 @@ export async function _forgotStopPrompt(id) {
   const sess = getSessions().find(s => s.id === id);
   if (!sess || sess.endedAt) return;
   const hours = ((Date.now() - sess.startedAt) / 3600000).toFixed(1);
-  showConfirmDialog(
-    `End this session that's been running ${hours} hours? Best-guess end time: now. The recorded duration will still reflect this — please trim it from the session detail if you ended earlier.`,
-    async () => {
-      await stopSession(sess.id);
-      await _hydrateFromProfileCoords(sess.id);
-      _refreshSurfaces();
-      showNotification('Session ended. Open the session detail to adjust the duration if needed.', 'success', 4500);
-    }
-  );
+  if (await showConfirmDialog(
+    `End this session that's been running ${hours} hours? Best-guess end time: now. The recorded duration will still reflect this — please trim it from the session detail if you ended earlier.`
+  )) {
+    await stopSession(sess.id);
+    await _hydrateFromProfileCoords(sess.id);
+    _refreshSurfaces();
+    showNotification('Session ended. Open the session detail to adjust the duration if needed.', 'success', 4500);
+  }
 }
 
 // Edit fields on a saved session. Bumps `updatedAt` so the cross-device
@@ -3735,10 +3734,10 @@ export function openDetailedSessionDialog() {
 
 // Delete from window for inline onclick
 async function deleteSunSession(id) {
-  showConfirmDialog('Delete this sun session?', async () => {
+  if (await showConfirmDialog('Delete this sun session?')) {
     await deleteSession(id);
     _refreshSurfaces();
-  });
+  }
 }
 
 // ─── Window export ─────────────────────────────────────────────────────

--- a/js/sync.js
+++ b/js/sync.js
@@ -3852,34 +3852,34 @@ async function copySyncDiagnose(btn) {
 // row for this owner and zeroes storedBytes; devices re-establish their
 // state on the next push. Replaces the old "I just compacted" runbook
 // flow that required SSH access and a manual local-counter reset.
-function confirmCompactRelay(btn) {
+async function confirmCompactRelay(btn) {
   const q = getRelayQuotaEstimate();
   const mb = q ? (q.bytes / 1024 / 1024).toFixed(1) : '?';
   const message = `Compact this owner's storage on the relay (currently ~${mb} MB)? Drops the Evolu message log; every device re-establishes its CRDT state on the next push (a few seconds). Your local data is untouched.`;
-  const doCompact = async () => {
-    if (btn) { btn.disabled = true; btn.textContent = 'Compacting…'; }
-    try {
-      const result = await compactOwnerSelfServe();
-      const after = typeof result?.afterStoredBytes === 'number'
-        ? `${(result.afterStoredBytes / (1024 * 1024)).toFixed(2)} MB`
-        : '0 MB';
-      showNotification(`Relay storage compacted · ${result?.deletedMessages ?? '?'} rows dropped · ${after}`, 'success');
-      if (btn) {
-        const overlay = btn.closest?.('.modal-overlay');
-        if (overlay) overlay.remove();
-      }
-      if (document.getElementById('sync-popover')) {
-        toggleSyncDetail(); toggleSyncDetail();
-      }
-    } catch (e) {
-      showNotification(`Compact failed: ${e?.message || e}`, 'error');
-      if (btn) { btn.disabled = false; btn.textContent = 'Compact storage'; }
+  // Helper unavailable (utils.js failed to load) → proceed without
+  // confirmation rather than dead-end the user. Safety net mirrors the
+  // pattern in the four sibling confirm* helpers below.
+  const proceed = (typeof window.showConfirmDialog === 'function')
+    ? await window.showConfirmDialog(message)
+    : true;
+  if (!proceed) return;
+  if (btn) { btn.disabled = true; btn.textContent = 'Compacting…'; }
+  try {
+    const result = await compactOwnerSelfServe();
+    const after = typeof result?.afterStoredBytes === 'number'
+      ? `${(result.afterStoredBytes / (1024 * 1024)).toFixed(2)} MB`
+      : '0 MB';
+    showNotification(`Relay storage compacted · ${result?.deletedMessages ?? '?'} rows dropped · ${after}`, 'success');
+    if (btn) {
+      const overlay = btn.closest?.('.modal-overlay');
+      if (overlay) overlay.remove();
     }
-  };
-  if (typeof window.showConfirmDialog === 'function') {
-    window.showConfirmDialog(message, doCompact);
-  } else {
-    doCompact();
+    if (document.getElementById('sync-popover')) {
+      toggleSyncDetail(); toggleSyncDetail();
+    }
+  } catch (e) {
+    showNotification(`Compact failed: ${e?.message || e}`, 'error');
+    if (btn) { btn.disabled = false; btn.textContent = 'Compact storage'; }
   }
 }
 
@@ -3921,23 +3921,23 @@ async function refreshRelayStorage(btn) {
 // can start a fresh measurement window (e.g. after a backfill push that
 // would skew the ratio for days). Confirms via the same dialog helper
 // as the relay-quota reset.
-function confirmResetDeltaTelemetry(btn) {
+async function confirmResetDeltaTelemetry(btn) {
   const t = state.currentProfile ? getDeltaTelemetry(state.currentProfile) : null;
   const n = t?.summary?.count || 0;
   const message = `Reset the push-efficiency log? Drops the ${n} recent push entries used to compute the percentage. Your data and relay state aren't touched.`;
-  const doReset = () => {
-    if (state.currentProfile && resetDeltaTelemetry(state.currentProfile)) {
-      try { showNotification('Telemetry window reset', 'success'); } catch {}
-      if (btn) {
-        const overlay = btn.closest?.('.modal-overlay');
-        if (overlay) overlay.remove();
-      }
-    } else {
-      try { showNotification('Could not reset telemetry (no active profile?)', 'error'); } catch {}
+  const proceed = (typeof window.showConfirmDialog === 'function')
+    ? await window.showConfirmDialog(message)
+    : true;
+  if (!proceed) return;
+  if (state.currentProfile && resetDeltaTelemetry(state.currentProfile)) {
+    try { showNotification('Telemetry window reset', 'success'); } catch {}
+    if (btn) {
+      const overlay = btn.closest?.('.modal-overlay');
+      if (overlay) overlay.remove();
     }
-  };
-  if (typeof window.showConfirmDialog === 'function') window.showConfirmDialog(message, doReset);
-  else doReset();
+  } else {
+    try { showNotification('Could not reset telemetry (no active profile?)', 'error'); } catch {}
+  }
 }
 
 // "Enable Phase 2" — flips the fat-blob off for this profile on this
@@ -3946,7 +3946,7 @@ function confirmResetDeltaTelemetry(btn) {
 // defence-in-depth in case the modal HTML was tampered with). Uses
 // showConfirmDialog because this is a meaningful behaviour change with
 // a (deliberate) impact on what other devices see when pulling.
-function confirmEnablePhase2(btn) {
+async function confirmEnablePhase2(btn) {
   if (!state.currentProfile) return;
   const r = getDeltaCutoverReadiness(state.currentProfile);
   if (!r?.ready) {
@@ -3954,21 +3954,21 @@ function confirmEnablePhase2(btn) {
     return;
   }
   const message = `Switch this device to lean sync mode?\n\nFrom now on, this device will only push per-row deltas instead of the full data blob. Other devices keep working normally.\n\nReversible any time via Disable.`;
-  const doEnable = () => {
-    const result = enablePhase2Cutover(state.currentProfile);
-    if (result.ok) {
-      try { showNotification('Phase 2 enabled — next push will use per-row only', 'success'); } catch {}
-      _logSyncEvent('cutover', `Phase 2 enabled for ${state.currentProfile.slice(0, 8)}`);
-      if (btn) {
-        const overlay = btn.closest?.('.modal-overlay');
-        if (overlay) overlay.remove();
-      }
-    } else {
-      try { showNotification(`Could not enable Phase 2 (${result.reason})`, 'error'); } catch {}
+  const proceed = (typeof window.showConfirmDialog === 'function')
+    ? await window.showConfirmDialog(message)
+    : true;
+  if (!proceed) return;
+  const result = enablePhase2Cutover(state.currentProfile);
+  if (result.ok) {
+    try { showNotification('Phase 2 enabled — next push will use per-row only', 'success'); } catch {}
+    _logSyncEvent('cutover', `Phase 2 enabled for ${state.currentProfile.slice(0, 8)}`);
+    if (btn) {
+      const overlay = btn.closest?.('.modal-overlay');
+      if (overlay) overlay.remove();
     }
-  };
-  if (typeof window.showConfirmDialog === 'function') window.showConfirmDialog(message, doEnable);
-  else doEnable();
+  } else {
+    try { showNotification(`Could not enable Phase 2 (${result.reason})`, 'error'); } catch {}
+  }
 }
 
 // "Backfill blockers" — wipes the per-array snapshot for every surface
@@ -3976,7 +3976,7 @@ function confirmEnablePhase2(btn) {
 // item from scratch (instead of diffing against a snapshot that thinks
 // they were already shipped — the usual reason rowCount is stuck at 0
 // despite localCount > 0). Then forces a push.
-function confirmBackfillBlockers(btn) {
+async function confirmBackfillBlockers(btn) {
   if (!state.currentProfile) return;
   const profileId = state.currentProfile;
   const r = getDeltaCutoverReadiness(profileId);
@@ -3986,47 +3986,47 @@ function confirmBackfillBlockers(btn) {
     return;
   }
   const message = `Force a push for ${blockers.length} item${blockers.length === 1 ? '' : 's'} that haven't synced as deltas yet?\n\n${blockers.join(', ')}\n\nSafe — this just re-sends data that should already be on the relay.`;
-  const doBackfill = async () => {
-    let cleared = 0;
-    for (const name of blockers) {
-      try {
-        localStorage.removeItem(_deltaSnapshotKey(profileId, name));
-        localStorage.removeItem(`${_deltaSnapshotKey(profileId, name)}-meta`);
-        cleared++;
-      } catch {}
-    }
-    try { await pushProfile(profileId, state.importedData, { force: true }); } catch (e) {
-      try { showNotification(`Backfill push failed: ${e?.message || e}`, 'error'); } catch {}
-      return;
-    }
-    try { showNotification(`Backfilled ${cleared} surface${cleared === 1 ? '' : 's'} — re-open Diagnose to verify`, 'success'); } catch {}
-    _logSyncEvent('backfill', `Backfilled ${cleared} surface(s) for ${profileId.slice(0, 8)}: ${blockers.join(',')}`);
+  const proceed = (typeof window.showConfirmDialog === 'function')
+    ? await window.showConfirmDialog(message)
+    : true;
+  if (!proceed) return;
+  let cleared = 0;
+  for (const name of blockers) {
+    try {
+      localStorage.removeItem(_deltaSnapshotKey(profileId, name));
+      localStorage.removeItem(`${_deltaSnapshotKey(profileId, name)}-meta`);
+      cleared++;
+    } catch {}
+  }
+  try { await pushProfile(profileId, state.importedData, { force: true }); } catch (e) {
+    try { showNotification(`Backfill push failed: ${e?.message || e}`, 'error'); } catch {}
+    return;
+  }
+  try { showNotification(`Backfilled ${cleared} surface${cleared === 1 ? '' : 's'} — re-open Diagnose to verify`, 'success'); } catch {}
+  _logSyncEvent('backfill', `Backfilled ${cleared} surface(s) for ${profileId.slice(0, 8)}: ${blockers.join(',')}`);
+  if (btn) {
+    const overlay = btn.closest?.('.modal-overlay');
+    if (overlay) overlay.remove();
+  }
+}
+
+async function confirmDisablePhase2(btn) {
+  if (!state.currentProfile) return;
+  const message = `Switch this device back to full-blob sync?\n\nPushes will include the full data blob again as a safety net. Use this if a peer device is missing data after going lean.\n\nNo data loss either way.`;
+  const proceed = (typeof window.showConfirmDialog === 'function')
+    ? await window.showConfirmDialog(message)
+    : true;
+  if (!proceed) return;
+  if (disablePhase2Cutover(state.currentProfile)) {
+    try { showNotification('Phase 2 disabled — back to dual-write', 'success'); } catch {}
+    _logSyncEvent('cutover', `Phase 2 disabled for ${state.currentProfile.slice(0, 8)}`);
     if (btn) {
       const overlay = btn.closest?.('.modal-overlay');
       if (overlay) overlay.remove();
     }
-  };
-  if (typeof window.showConfirmDialog === 'function') window.showConfirmDialog(message, doBackfill);
-  else doBackfill();
-}
-
-function confirmDisablePhase2(btn) {
-  if (!state.currentProfile) return;
-  const message = `Switch this device back to full-blob sync?\n\nPushes will include the full data blob again as a safety net. Use this if a peer device is missing data after going lean.\n\nNo data loss either way.`;
-  const doDisable = () => {
-    if (disablePhase2Cutover(state.currentProfile)) {
-      try { showNotification('Phase 2 disabled — back to dual-write', 'success'); } catch {}
-      _logSyncEvent('cutover', `Phase 2 disabled for ${state.currentProfile.slice(0, 8)}`);
-      if (btn) {
-        const overlay = btn.closest?.('.modal-overlay');
-        if (overlay) overlay.remove();
-      }
-    } else {
-      try { showNotification('Could not disable Phase 2', 'error'); } catch {}
-    }
-  };
-  if (typeof window.showConfirmDialog === 'function') window.showConfirmDialog(message, doDisable);
-  else doDisable();
+  } else {
+    try { showNotification('Could not disable Phase 2', 'error'); } catch {}
+  }
 }
 
 // Toast users when they cross the 80% / 95% threshold the first time.

--- a/js/utils.js
+++ b/js/utils.js
@@ -177,25 +177,27 @@ export function showNotification(message, type, duration) {
   }, duration || 3000);
 }
 
-export function showConfirmDialog(message, onConfirm) {
-  let overlay = document.getElementById("confirm-dialog-overlay");
-  if (!overlay) {
-    overlay = document.createElement("div");
-    overlay.id = "confirm-dialog-overlay";
-    overlay.className = "confirm-overlay";
-    document.body.appendChild(overlay);
-  }
-  overlay.innerHTML = `<div class="confirm-dialog" role="alertdialog" aria-modal="true" aria-label="Confirmation">
+export function showConfirmDialog(message) {
+  return new Promise((resolve) => {
+    let overlay = document.getElementById("confirm-dialog-overlay");
+    if (!overlay) {
+      overlay = document.createElement("div");
+      overlay.id = "confirm-dialog-overlay";
+      overlay.className = "confirm-overlay";
+      document.body.appendChild(overlay);
+    }
+    overlay.innerHTML = `<div class="confirm-dialog" role="alertdialog" aria-modal="true" aria-label="Confirmation">
     <p class="confirm-message">${escapeHTML(message)}</p>
     <div class="confirm-actions">
       <button class="confirm-btn confirm-btn-cancel" id="confirm-cancel">Cancel</button>
       <button class="confirm-btn confirm-btn-danger" id="confirm-ok">Confirm</button>
     </div></div>`;
-  overlay.classList.add("show");
-  document.getElementById("confirm-ok").onclick = () => { overlay.classList.remove("show"); onConfirm(); };
-  document.getElementById("confirm-cancel").onclick = () => { overlay.classList.remove("show"); };
-  overlay.onclick = (e) => { if (e.target === overlay) { const d = overlay.querySelector('.confirm-dialog'); if (d) { d.classList.add('modal-nudge'); d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true }); } } };
-  document.getElementById("confirm-cancel").focus();
+    overlay.classList.add("show");
+    document.getElementById("confirm-ok").onclick = () => { overlay.classList.remove("show"); resolve(true); };
+    document.getElementById("confirm-cancel").onclick = () => { overlay.classList.remove("show"); resolve(false); };
+    overlay.onclick = (e) => { if (e.target === overlay) { const d = overlay.querySelector('.confirm-dialog'); if (d) { d.classList.add('modal-nudge'); d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true }); } } };
+    document.getElementById("confirm-cancel").focus();
+  });
 }
 
 /// Promise-based replacement for `window.prompt()`. Browsers block the

--- a/js/views.js
+++ b/js/views.js
@@ -4107,12 +4107,12 @@ export function saveCustomMarker() {
   setTimeout(() => openManualEntryForm(id), 100);
 }
 
-export function deleteMarkerValue(id, date) {
+export async function deleteMarkerValue(id, date) {
   const dotKey = id.replace('_', '.');
   if (!state.importedData.entries) return;
   const entry = state.importedData.entries.find(e => e.date === date);
   if (!entry || entry.markers[dotKey] === undefined) return;
-  showConfirmDialog(`Delete this value (${date})? This can't be undone.`, () => {
+  if (await showConfirmDialog(`Delete this value (${date})? This can't be undone.`)) {
     delete entry.markers[dotKey];
     // Clean up provenance and manual tracking
     if (entry.markerSources) delete entry.markerSources[dotKey];
@@ -4131,7 +4131,7 @@ export function deleteMarkerValue(id, date) {
     navigate(activeNav ? activeNav.dataset.category : "dashboard");
     showDetailModal(id);
     showNotification(`Removed value from ${date}`, 'info');
-  });
+  }
 }
 
 export async function deleteCustomMarker(id) {

--- a/js/views.js
+++ b/js/views.js
@@ -4134,7 +4134,7 @@ export function deleteMarkerValue(id, date) {
   });
 }
 
-export function deleteCustomMarker(id) {
+export async function deleteCustomMarker(id) {
   const dotKey = id.replace('_', '.');
   const catKey = dotKey.split('.')[0];
   const def = state.importedData?.customMarkers?.[dotKey];
@@ -4145,7 +4145,7 @@ export function deleteCustomMarker(id) {
   const msg = isLastInCat
     ? `Delete "${def.name}" and the entire "${def.categoryLabel || catKey}" category? This cannot be undone.`
     : `Delete "${def.name}" and all its values? This cannot be undone.`;
-  showConfirmDialog(msg, () => {
+  if (await showConfirmDialog(msg)) {
     // Determine which keys to delete — just this marker, or all in category
     const keysToDelete = isLastInCat ? siblingsInCat : [dotKey];
     for (const key of keysToDelete) {
@@ -4176,7 +4176,7 @@ export function deleteCustomMarker(id) {
     updateHeaderDates();
     navigate('dashboard');
     showNotification(`Deleted "${def.name}"${isLastInCat && siblingsInCat.length > 1 ? ` and ${siblingsInCat.length - 1} other marker(s)` : ''}`, 'info');
-  });
+  }
 }
 
 export function editMarkerValue(id, date, currentValue, event) {

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -1579,8 +1579,7 @@ async function deleteManualEntryFromDetail(metricId, date) {
   if (typeof window.showConfirmDialog !== 'function') return;
   const canon = canonicalMetric(metricId);
   const label = canon?.label || metricId;
-  // showConfirmDialog is callback-style: (message, onConfirm). Cancel is a no-op.
-  window.showConfirmDialog(`Delete this ${label.toLowerCase()} reading from ${date}?`, async () => {
+  if (await window.showConfirmDialog(`Delete this ${label.toLowerCase()} reading from ${date}?`)) {
     try {
       const { deleteManualMetric, refreshManualSummary } = await import('./wearables-manual.js');
       const profileId = getActiveProfileId();
@@ -1610,7 +1609,7 @@ async function deleteManualEntryFromDetail(metricId, date) {
     } catch (e) {
       showNotification?.(`Couldn't delete: ${e.message}`, 'error', 4000);
     }
-  });
+  }
 }
 
 // Manual source — UI handlers. Settings → Integrations → Manual exposes a
@@ -1629,34 +1628,32 @@ function handleManualOpenDashboard() {
 
 async function handleManualDisconnect() {
   if (typeof window.showConfirmDialog !== 'function') return;
-  // showConfirmDialog is callback-style: (message, onConfirm). Cancel is a no-op.
-  window.showConfirmDialog(
-    'Delete all manual entries? This removes every weight / BP / pulse entry you\'ve logged manually. Data from connected wearables (Oura, Withings, etc.) is untouched. Can\'t be undone.',
-    async () => {
-      try {
-        const { clearSource } = await import('./wearables-store.js');
-        const { refreshManualSummary } = await import('./wearables-manual.js');
-        const profileId = getActiveProfileId();
-        await clearSource(profileId, 'manual');
-        // Drop the connection record too — the row disappears from the strip
-        // source header and the Settings integrations list.
-        if (state.importedData.wearableConnections) {
-          delete state.importedData.wearableConnections.manual;
-          const { saveImportedData } = await import('./data.js');
-          await saveImportedData();
-        }
-        await refreshManualSummary(profileId);
-        showNotification?.('All manual entries deleted', 'success');
-        // Re-render the Settings section + dashboard strip.
-        const section = document.querySelector('[data-wearables-settings-host]') ||
-                        document.querySelector('.wearables-adapter-list')?.parentElement;
-        if (section) section.innerHTML = renderWearablesSettingsSection();
-        if (window.navigate) window.navigate('dashboard');
-      } catch (e) {
-        showNotification?.(`Couldn't delete: ${e.message}`, 'error', 4000);
+  if (await window.showConfirmDialog(
+    'Delete all manual entries? This removes every weight / BP / pulse entry you\'ve logged manually. Data from connected wearables (Oura, Withings, etc.) is untouched. Can\'t be undone.'
+  )) {
+    try {
+      const { clearSource } = await import('./wearables-store.js');
+      const { refreshManualSummary } = await import('./wearables-manual.js');
+      const profileId = getActiveProfileId();
+      await clearSource(profileId, 'manual');
+      // Drop the connection record too — the row disappears from the strip
+      // source header and the Settings integrations list.
+      if (state.importedData.wearableConnections) {
+        delete state.importedData.wearableConnections.manual;
+        const { saveImportedData } = await import('./data.js');
+        await saveImportedData();
       }
+      await refreshManualSummary(profileId);
+      showNotification?.('All manual entries deleted', 'success');
+      // Re-render the Settings section + dashboard strip.
+      const section = document.querySelector('[data-wearables-settings-host]') ||
+                      document.querySelector('.wearables-adapter-list')?.parentElement;
+      if (section) section.innerHTML = renderWearablesSettingsSection();
+      if (window.navigate) window.navigate('dashboard');
+    } catch (e) {
+      showNotification?.(`Couldn't delete: ${e.message}`, 'error', 4000);
     }
-  );
+  }
 }
 
 // Populate the "X weight, Y BP, Z pulse" counts line in the manual
@@ -1771,14 +1768,14 @@ async function handleWearableBackfill(adapterId) {
   }
 }
 
-function handleWearableDisconnect(adapterId) {
+async function handleWearableDisconnect(adapterId) {
   const name = adapterById(adapterId)?.displayName || adapterId;
-  showConfirmDialog(`Disconnect ${name} and delete its local data?`, async () => {
+  if (await showConfirmDialog(`Disconnect ${name} and delete its local data?`)) {
     await disconnectWearable(adapterId, { deleteData: true });
     showNotification?.(`${name} disconnected`, 'success');
     refreshSettingsWearables();
     if (window.navigate) window.navigate('dashboard');
-  });
+  }
 }
 
 function refreshSettingsWearables() {

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -389,10 +389,10 @@ return (async function() {
   assert('styles include active state', cssSrc.includes('.chat-lens-indicator.active'));
   assert('styles include error state', cssSrc.includes('.chat-lens-indicator.error'));
 
-  // ─── 19. BUG 1 regression: handleRemoveLens uses callback form ───
-  console.log('\n19. handleRemoveLens callback form');
-  assert('handleRemoveLens is not async (uses callback)', !/async function handleRemoveLens/.test(lensSrc));
-  assert('handleRemoveLens passes callback to showConfirmDialog', /showConfirmDialog\([^)]+,\s*async\s*\(\)\s*=>/.test(lensSrc));
+  // ─── 19. BUG 1 regression: handleRemoveLens uses promise-based showConfirmDialog ───
+  console.log('\n19. handleRemoveLens promise form');
+  assert('handleRemoveLens is async (uses promise-based showConfirmDialog)', /async function handleRemoveLens/.test(lensSrc));
+  assert('handleRemoveLens awaits showConfirmDialog', /await\s+showConfirmDialog\(/.test(lensSrc.split('async function handleRemoveLens')[1] || ''));
 
   // ─── 20. BUG 2 regression: testLensConnection works when disabled ───
   console.log('\n20. testLensConnection disabled-toggle flow');

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -281,18 +281,14 @@ return (async function() {
     assert('deleteManualEntryFromDetail closes modal when last reading is removed',
       /closeModal/.test(delFn));
 
-    // showConfirmDialog is callback-style: (message, onConfirm). Earlier code
-    // mistakenly called it with a 4-arg promise-style signature, which made
-    // the second string land as `onConfirm` — clicking Confirm threw
-    // `TypeError: onConfirm is not a function` and the await never resolved,
-    // so the delete silently no-op'd. Pin both call sites to the callback shape.
+    // showConfirmDialog is promise-based (returns Promise<boolean>). The v1.24.1
+    // regression (537bec4) was caused by a 4-arg call where the body string
+    // landed in the onConfirm slot. Both call sites now use await showConfirmDialog().
     const handleDisconnectFn = wearablesSrc.match(/async function handleManualDisconnect[\s\S]*?\n\}\s*\n/)?.[0] || '';
-    assert('deleteManualEntryFromDetail uses callback-style showConfirmDialog (not 4-arg promise)',
-      /showConfirmDialog\([^,]+,\s*async\s*\(\s*\)\s*=>/.test(delFn) &&
-      !/await\s+window\.showConfirmDialog/.test(delFn));
-    assert('handleManualDisconnect uses callback-style showConfirmDialog',
-      /showConfirmDialog\(\s*[\s\S]*?,\s*async\s*\(\s*\)\s*=>/.test(handleDisconnectFn) &&
-      !/await\s+window\.showConfirmDialog/.test(handleDisconnectFn));
+    assert('deleteManualEntryFromDetail uses promise-style showConfirmDialog',
+      /await\s+window\.showConfirmDialog\(/.test(delFn));
+    assert('handleManualDisconnect uses promise-style showConfirmDialog',
+      /await\s+window\.showConfirmDialog\(/.test(handleDisconnectFn));
 
   } finally {
     // Restore live profile

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -71,7 +71,7 @@ return (async function() {
   console.log('%c 2. Confirm Dialog Delete ', 'font-weight:bold;color:#f59e0b');
   delBtn.click();
   await new Promise(r => setTimeout(r, 200));
-  // showConfirmDialog (callback-style) renders #confirm-ok / #confirm-cancel.
+  // showConfirmDialog (promise-based) renders #confirm-ok / #confirm-cancel.
   // Assert the dialog appeared (not as a no-op TypeError swallowed silently).
   const confirmOk = document.getElementById('confirm-ok');
   assert('Confirm dialog renders an OK button on entry-delete click',

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1642,7 +1642,7 @@ return (async function() {
   // dispatched as a fire-and-forget dynamic import — guard the call site.
   const profileSrc = await fetch('/js/profile.js').then(r => r.text());
   assert('deleteProfile dispatches deleteWearablesDB(profileId) for the deleted profile',
-    /export function deleteProfile[\s\S]*?deleteWearablesDB\(profileId\)/.test(profileSrc));
+    /export (?:async )?function deleteProfile[\s\S]*?deleteWearablesDB\(profileId\)/.test(profileSrc));
 
   // P0-B: auto-backup carries wearable L1 rows. buildFullBackupSnapshot
   // exists, populates `wearableIDB`, and is called from auto-backup +

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.6.0';
+self.APP_VERSION = '1.6.1';


### PR DESCRIPTION
## Summary

- `showConfirmDialog` in `js/utils.js` now returns `Promise<boolean>` instead of accepting an `onConfirm` callback, matching the existing API of the sibling `showPromptDialog`
- All 22 call sites across 14 files migrated to `if (await showConfirmDialog(msg)) { … }`
- Fixes a live bug in `pdf-import.js` where a three-arg call `(message, onConfirm, onCancel)` silently dropped the `onCancel` path — clicking Cancel left the import `Promise` pending forever
- Three tests that pinned the old callback shape updated to verify the promise shape instead

## Motivation

The asymmetry between `showConfirmDialog` (callback) and `showPromptDialog` (promise) was the direct footgun behind the v1.24.1 regression fixed in 537bec4. Every future contributor's autocomplete suggests `await showConfirmDialog(…)` because that's how `showPromptDialog` works; the old signature silently accepted extra args and did the wrong thing.

## Audit — all 22 call sites

| File | Function | Was already async? |
|---|---|---|
| `js/backup.js` | `importEncryptedBackup` (reader.onload) | no → async |
| `js/backup.js` | `restoreAutoBackup` | already async |
| `js/backup.js` | `removeFolderBackup` | no → async |
| `js/chat-threads.js` | `deleteThread` | no → async |
| `js/chat.js` | `deleteCustomPersonality` | no → async |
| `js/crypto.js` | `disableEncryption` | already async |
| `js/cycle.js` | `clearMenstrualCycle` | no → async |
| `js/dna.js` | `confirmDeleteDNA` | no → async |
| `js/emf.js` | `deleteEMFAssessment` | no → async |
| `js/export.js` | `clearAllData` | no → async |
| `js/lens.js` | `handleLocalLensDeleteDoc` | no → async |
| `js/lens.js` | `handleLocalLensClear` | no → async |
| `js/lens.js` | `handleLibraryDelete` | no → async |
| `js/lens.js` | `handleRemoveLens` | no → async |
| `js/pdf-import.js` | image PII gate (inline) | already async — also removes manual Promise wrapper |
| `js/profile.js` | `deleteProfile` | no → async |
| `js/provider-panels.js` | `handleRemovePpqKey` | already async |
| `js/settings.js` | `confirmDisablePIIReview` | no → async |
| `js/views.js` | `deleteCustomMarker` | no → async |
| `js/wearables.js` | `deleteManualEntryFromDetail` | already async |
| `js/wearables.js` | `handleManualDisconnect` | already async |
| `js/wearables.js` | `handleWearableDisconnect` | no → async |

All callers of the affected functions are event handlers or fire-and-forget onclick dispatches; making them `async` does not change their observable contract.

## Tests

Node-side tests: 105 passed, 0 failed. Puppeteer suite: all failures are pre-existing (recommendations catalog absent in dev environment, CDN inaccessible in sandbox). The two tests that previously asserted callback shape (`test-wearables-manual.js`, `test-custom-lens.js`) now assert the promise shape. The `test-wearables.js` regex for `deleteProfile` was relaxed to accept `async function`.

## Test plan

- [ ] Open the app locally and trigger each destructive action (delete profile, delete thread, clear data, disable encryption, remove wearable) — confirm the dialog appears, Confirm proceeds, Cancel aborts cleanly
- [ ] Import an image PDF with a non-Ollama provider and click Cancel on the PII warning — confirm the import does not proceed and no error is thrown
- [ ] Run `./run-tests.sh` — all node-side and Puppeteer tests that were passing before remain passing

https://claude.ai/code/session_01QjaT8FVUjpkSGyU1vBy4UE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjaT8FVUjpkSGyU1vBy4UE)_