### PR TITLE
fix(apple-health): lazy-load JSZip on first ZIP import

### DIFF
--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -82,13 +82,23 @@ export async function importAppleHealthFile(file, onProgress) {
 // ZIP extraction
 // ─────────────────────────────────────────────────────────
 
+let _jszipLoad = null;
+function loadJSZip() {
+  if (window.JSZip) return Promise.resolve(window.JSZip);
+  if (_jszipLoad) return _jszipLoad;
+  _jszipLoad = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = '/vendor/jszip.min.js';
+    s.onload = () => window.JSZip ? resolve(window.JSZip) : reject(new Error('JSZip failed to load'));
+    s.onerror = () => reject(new Error('Failed to load /vendor/jszip.min.js'));
+    document.head.appendChild(s);
+  });
+  return _jszipLoad;
+}
+
 async function extractExportXml(zipFile, onProgress) {
-  if (typeof window.JSZip === 'undefined') {
-    // Local vendor bundle exposes JSZip on window. Fall back to dynamic import
-    // if the build changed how it loads.
-    throw new Error('JSZip not loaded — Apple Health ZIP import needs vendor/jszip.min.js');
-  }
-  const zip = await window.JSZip.loadAsync(zipFile, {
+  const JSZip = await loadJSZip();
+  const zip = await JSZip.loadAsync(zipFile, {
     // Progress for large exports — Apple zips can be 500 MB+ compressed.
     onUpdate: m => onProgress?.({ stage: 'unzipping', pct: Math.round(m.percent * 0.4) }),
   });


### PR DESCRIPTION
## Summary

- Dropping an Apple Health `export.zip` onto **Settings → Wearables → Apple Health** failed with `Failed: JSZip not loaded — Apple Health ZIP import needs vendor/jszip.min.js`.
- `vendor/jszip.min.js` exists but `index.html` never loads it; `js/wearables-apple-health.js` assumed `window.JSZip` was global.
- This patch lazy-loads the vendor bundle on first ZIP import, matching the existing pattern in `js/lens-local-parsers.js` (memoized `loadScript` style). Direct `.xml` drops are unaffected (that code path didn't touch JSZip).

## Test plan

- [ ] Hard-reload the app after pulling, drop an `export.zip` on the Apple Health row → import completes (no JSZip error).
- [ ] Drop a raw `export.xml` → still works as before.
- [ ] First import on a fresh browser session triggers a single fetch of `/vendor/jszip.min.js`; subsequent imports hit the memoized promise.