### PR TITLE
fix(backup): re-enumerate profiles when labcharts-profiles is encrypted

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -201,6 +201,45 @@ export function buildBackupSnapshot() {
 export async function buildFullBackupSnapshot() {
   const snap = buildBackupSnapshot();
   if (!snap) return null;
+
+  // buildBackupSnapshot is sync — when the profile list is encrypted (v1:),
+  // it can't enumerate IDs, and the localStorage fallback finds nothing
+  // because v1.6.x stores `*-imported` in IDB. Re-enumerate from the
+  // decrypted profile list here.
+  if (snap.profiles.length === 0 && snap.profileList && isEncryptedValue(snap.profileList)) {
+    let profileList = null;
+    try {
+      const decrypted = await window.encryptedGetItem?.('labcharts-profiles');
+      if (decrypted) profileList = JSON.parse(decrypted);
+    } catch {}
+    if (Array.isArray(profileList)) {
+      for (const p of profileList) {
+        const keys = {};
+        const imported = localStorage.getItem(profileStorageKey(p.id, 'imported'));
+        if (imported) keys.imported = imported;
+        const chat = localStorage.getItem(`labcharts-${p.id}-chat`);
+        if (chat) keys.chat = chat;
+        const threadIndex = localStorage.getItem(`labcharts-${p.id}-chat-threads`);
+        if (threadIndex) {
+          keys['chat-threads'] = threadIndex;
+          try {
+            const threads = JSON.parse(threadIndex);
+            for (const t of threads) {
+              const tk = `labcharts-${p.id}-chat-t_${t.id}`;
+              const tv = localStorage.getItem(tk);
+              if (tv !== null) keys[`chat-t_${t.id}`] = tv;
+            }
+          } catch {}
+        }
+        for (const suffix of PER_PROFILE_PREF_SUFFIXES) {
+          const v = localStorage.getItem(`labcharts-${p.id}-${suffix}`);
+          if (v !== null) keys[suffix] = v;
+        }
+        snap.profiles.push({ profileId: p.id, name: p.name, keys });
+      }
+    }
+  }
+
   for (const p of snap.profiles || []) {
     if (p.keys && p.keys.imported == null) {
       const key = profileStorageKey(p.profileId, 'imported');


### PR DESCRIPTION
## Summary

For users with **encryption-at-rest enabled**, every backup since v1.6.x silently lost ALL profile data — the exported JSON contained `profiles: []` and only global settings (API keys, theme, etc.). A previously ~160 KB backup collapsed to ~1 KB. This affects manual export, auto-backup, *and* folder-backup.

**Root cause (two unfortunate interactions):**

1. `buildBackupSnapshot()` is synchronous (line 103, kept for tests). When encryption is on, `localStorage.getItem('labcharts-profiles')` returns a `v1:` envelope. Line 109 detects this and parses it as `[]`.
2. The fallback at lines 141-170 then scans localStorage for `labcharts-{id}-imported` keys to recover profile IDs the hard way. But in v1.6.x those big blobs moved to **IndexedDB** (`blob-storage.js`). The fallback finds nothing → `backupProfiles: []`.

End user sees a successful "Backup saved" notification with a JSON file containing essentially nothing.

**Fix:**

In `buildFullBackupSnapshot()` (the async wrapper used by every real caller), detect the empty-profiles-with-encrypted-list case and re-enumerate from the decrypted profile list via `window.encryptedGetItem('labcharts-profiles')`. The existing IDB-blob-patching loop further down then fills in each profile's `imported` blob.

The encrypted envelope on each `*-imported` blob is preserved as-stored — same E2E-encrypted round-trip as before for unlocked users, just with the profile IDs the enumerator needed. Sync `buildBackupSnapshot` is left untouched (tests depend on its sync signature). Pre-encryption installs and unencrypted backups are unaffected.

## Test plan

- [ ] Manual: with encryption ON and a profile that has lab data, **Settings → Data → Export backup** → file size matches `*-imported` blob size (~160 KB+ for normal users; was ~1 KB before).
- [ ] Restore that backup into a fresh browser profile → all labs, notes, supplements, context cards reappear.
- [ ] With encryption OFF: backup still works exactly as before (regression check).
- [ ] Auto-backup (IndexedDB) and folder-backup snapshots also pick up the patched path since they both go through `buildFullBackupSnapshot`.
- [ ] Existing `tests/test-export-import.js` etc. still pass.