### PR TITLE
feat(apple-health): ingest VO₂max from HKQuantityTypeIdentifierVO2Max

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -118,6 +118,9 @@ export const DEFAULT_METRIC_ORDER = [
   // Daytime companions are summarised so the AI / detail modal can read them,
   // but intentionally placed AFTER the overnight cards — the strip stays calm.
   'hrv_day', 'hr_day',
+  // Apple Health VO₂max — placed near cardio_fitness conceptually but at the
+  // tail so existing wearableCardOrder arrays aren't reshuffled for users.
+  'vo2max',
 ];
 
 export const ADAPTERS = [

--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -60,6 +60,7 @@ export const CANONICAL_METRICS = {
   spo2_avg:         { id: 'spo2_avg',         label: 'SpO₂',        sub: '',      unit: '%',     worseWhen: 'down'   },
   body_temp_delta:  { id: 'body_temp_delta',  label: 'Body temp',   sub: 'Δ',     unit: '°C',    worseWhen: 'either' },
   glucose_avg:      { id: 'glucose_avg',      label: 'Glucose',     sub: 'avg',   unit: 'mg/dL', worseWhen: 'either' },
+  vo2max:           { id: 'vo2max',           label: 'VO₂max',      sub: '',      unit: 'mL/kg/min', worseWhen: 'down' }, // Apple Watch / chest-strap derived — physiological aerobic capacity (distinct from Withings cardio_fitness 0-100 score)
   // Withings Body Scan / BPM extras (#5 follow-up). All of these are the raw
   // measurements; AI context collapses the body-comp cluster into a single
   // roll-up line to keep the token budget honest. Only populates for users
@@ -420,6 +421,7 @@ export const ADAPTERS = [
       steps:           { hkType: 'HKQuantityTypeIdentifierStepCount' },
       spo2_avg:        { hkType: 'HKQuantityTypeIdentifierOxygenSaturation' },
       body_temp_delta: { hkType: 'HKQuantityTypeIdentifierBodyTemperature' },
+      vo2max:          { hkType: 'HKQuantityTypeIdentifierVO2Max' },
     },
   },
 ];

--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -221,6 +221,7 @@ export function parseAppleHealthXml(xmlText) {
       stress_high_min: null, resilience_level: null, cardio_age: null,
       weight: null, bp_systolic: null, bp_diastolic: null,
       spo2_avg: null, body_temp_delta: null, glucose_avg: null,
+      vo2max: null,
     };
 
     // HRV SDNN — hour-window split. Day samples → hrv_day, night samples →
@@ -270,6 +271,13 @@ export function parseAppleHealthXml(xmlText) {
     if (Array.isArray(bucket.body_temp_delta) && bucket.body_temp_delta.length) {
       row.body_temp_delta = Math.round(mean(bucket.body_temp_delta.map(s => s.v)) * 100) / 100;
     }
+    // VO2max — Apple Watch writes one measurement per outdoor walk/run, so
+    // a given day may carry 0, 1, or multiple samples. Mean smooths out
+    // back-to-back walks on the same day; the gaps between days are
+    // expected and handled by the chart's span-gaps.
+    if (Array.isArray(bucket.vo2max) && bucket.vo2max.length) {
+      row.vo2max = Math.round(mean(bucket.vo2max.map(s => s.v)) * 100) / 100;
+    }
 
     rows.push(row);
   }
@@ -303,6 +311,10 @@ function normaliseUnit(metricId, value, unit) {
       // misleading number. Canonical is degC; if we wanted to populate this
       // the math is: value_celsius - profile_baseline_celsius.
       return null;
+    case 'vo2max':
+      // Apple ships VO₂max in "mL/min·kg" (their formatting). Canonical is
+      // mL/kg/min — same physiological quantity, just transposed factors.
+      return (!unit || unit === 'mL/min·kg' || unit === 'mL/kg/min') ? value : null;
     default:
       // If canonical declares a unit string and Apple disagrees, refuse.
       return (!unit || unit === canonUnit) ? value : null;

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -311,10 +311,10 @@ return (async function() {
   }
   // Total canonicals: 14 (pre-#143) + 8 Body Scan body-comp + 6
   // additional /measure (fat_mass, spo2, body_temp, skin_temp,
-  // vascular_age, cardio_fitness) + 9 sleep-arch = 37. Each new
-  // canonical metric bumps this assertion intentionally so count
-  // drift surfaces in code review.
-  assert('DEFAULT_METRIC_ORDER is 36 metrics (full Withings coverage round)', reg.DEFAULT_METRIC_ORDER.length === 36);
+  // vascular_age, cardio_fitness) + 9 sleep-arch + 1 (vo2max from
+  // Apple Health) = 37. Each new canonical metric bumps this
+  // assertion intentionally so count drift surfaces in code review.
+  assert('DEFAULT_METRIC_ORDER is 37 metrics (Withings + Apple VO₂max)', reg.DEFAULT_METRIC_ORDER.length === 37);
   // Biometric metrics must be in the default order so the summary pipeline
   // iterates them for manual / Withings / Fitbit rows.
   assert('DEFAULT_METRIC_ORDER includes weight', reg.DEFAULT_METRIC_ORDER.includes('weight'));
@@ -639,6 +639,33 @@ return (async function() {
   const hostileRows = ah.parseAppleHealthXml(hostileXml);
   assert('Hostile unit ("furlongs" for steps) is refused, not ingested',
     hostileRows.length === 0 || hostileRows[0].steps === null);
+
+  // ── VO₂max ingestion (HKQuantityTypeIdentifierVO2Max) ──
+  // Apple Watch writes VO₂max during outdoor walks/runs. Apple's unit string
+  // is "mL/min·kg" — semantically the canonical mL/kg/min (same dimensional
+  // quantity, transposed factors). Distinct from Withings cardio_fitness
+  // (proprietary 0-100 score) — different scales, different cards.
+  // Aggregator means same-day samples (rare but possible: back-to-back walks).
+  const vo2Xml = '<?xml version="1.0"?><HealthData>' +
+    '<Record type="HKQuantityTypeIdentifierVO2Max" unit="mL/min·kg" startDate="2026-04-20 09:00:00 +0200" value="42.5"/>' +
+    '<Record type="HKQuantityTypeIdentifierVO2Max" unit="mL/min·kg" startDate="2026-04-20 18:00:00 +0200" value="43.5"/>' +
+    '<Record type="HKQuantityTypeIdentifierVO2Max" unit="mL/kg/min" startDate="2026-04-21 08:00:00 +0200" value="44.2"/>' +
+    '</HealthData>';
+  const vo2Rows = ah.parseAppleHealthXml(vo2Xml);
+  const vo2Day1 = vo2Rows.find(r => r.date === '2026-04-20');
+  const vo2Day2 = vo2Rows.find(r => r.date === '2026-04-21');
+  assert('VO₂max ingested from HKQuantityTypeIdentifierVO2Max (Apple "mL/min·kg" notation, same-day mean)',
+    vo2Day1?.vo2max === 43);
+  assert('VO₂max accepts canonical "mL/kg/min" notation as identity',
+    vo2Day2?.vo2max === 44.2);
+  // Hostile-unit guard parity with steps — a bogus unit must NOT silently
+  // land on the canonical mL/kg/min scale.
+  const vo2HostileXml = '<?xml version="1.0"?><HealthData>' +
+    '<Record type="HKQuantityTypeIdentifierVO2Max" unit="furlongs/s" startDate="2026-04-22 09:00:00 +0200" value="42"/>' +
+    '</HealthData>';
+  const vo2HostileRows = ah.parseAppleHealthXml(vo2HostileXml);
+  assert('VO₂max rejects unknown unit (no canonical-scale silent fallback)',
+    vo2HostileRows.length === 0 || vo2HostileRows[0].vo2max === null);
 
   // ═══════════════════════════════════════
   // 15. Withings OAuth2 + measure-type decoding


### PR DESCRIPTION
## Summary

Apple Watch records VO₂max during outdoor walks/runs and writes the value to HealthKit. A typical multi-year export holds hundreds of data points — my own carries 422. The Apple Health adapter currently doesn't read them, so users on Apple ecosystem have no canonical aerobic-capacity metric.

Reusing the existing `cardio_fitness` metric isn't right: it's Withings-specific (a proprietary 0–100 score), not real VO₂max in mL/kg/min. Mixing the scales on one card would mislead. So this PR adds a distinct `vo2max` canonical metric and leaves `cardio_fitness` untouched.

## Changes

- `CANONICAL_METRICS.vo2max` — `{ label: 'VO₂max', unit: 'mL/kg/min', worseWhen: 'down' }`.
- `apple_health.metrics.vo2max` → `HKQuantityTypeIdentifierVO2Max`.
- Parser:
  - Row template gains `vo2max: null`.
  - Aggregator: mean across same-day samples (Apple writes one per outdoor session, so multi-per-day is rare but possible).
  - `normaliseUnit` accepts Apple's `"mL/min·kg"` formatting and the canonical `"mL/kg/min"` (same quantity, different notation).

## Test plan

- [x] `node --check` passes on both touched files.
- [x] Existing wearables tests pass (additive change — fixtures without VO₂max records get `vo2max: null`).
- [ ] Drop an `export.xml` containing `HKQuantityTypeIdentifierVO2Max` records → dashboard shows a VO₂max card with year-spanning history.
- [ ] Withings users see no change to their `cardio_fitness` card.

## Notes

This adds a dashboard card. If the maintainer wants additional metric-card placement / chart wiring (`worseWhen` colors, focus-card eligibility, etc.) I'm happy to follow up — the canonical-metric registry entry should already drive most surfaces by convention, but I haven't audited every surface.