### PR TITLE
fix(apple-health): show progress bar on re-import

### DIFF
--- a/js/wearables.js
+++ b/js/wearables.js
@@ -1392,6 +1392,10 @@ function renderRowDetail(adapter, conn, { isPendingClient, isFileImport }) {
         <button class="wearable-action wearable-action-primary" onclick="document.getElementById('apple-health-file-input').click()">Re-import new export</button>
         <button class="wearable-action wearable-action-danger" onclick="handleWearableDisconnect('${escapeHTML(adapter.id)}')">Remove data</button>
       </div>
+      <div id="apple-health-progress" class="apple-health-progress" style="display:none">
+        <div class="apple-health-progress-bar"><div class="apple-health-progress-fill"></div></div>
+        <div class="apple-health-progress-text"></div>
+      </div>
       <input type="file" id="apple-health-file-input" accept=".zip,.xml,application/zip,application/xml" style="display:none" onchange="handleAppleHealthFilePick(this)">`;
   }
   // Apple Health disconnected — full how-to-export + dropzone

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -640,6 +640,17 @@ return (async function() {
   assert('Hostile unit ("furlongs" for steps) is refused, not ingested',
     hostileRows.length === 0 || hostileRows[0].steps === null);
 
+  // ── progress-bar markup must render in BOTH row branches ──
+  // importAppleHealthFlow queries #apple-health-progress by id; before this
+  // fix only the disconnected-state branch of renderRowDetail rendered that
+  // element, so re-imports on already-connected rows ran without any UI
+  // feedback (the `if (wrap)` / `if (bar)` / `if (text)` guards no-op'd).
+  // Pin both branches so a future refactor can't silently drop one again.
+  const appleProgressSrc = await fetch('/js/wearables.js').then(r => r.text());
+  const progressIdMatches = (appleProgressSrc.match(/id="apple-health-progress"/g) || []).length;
+  assert('renderRowDetail renders #apple-health-progress in BOTH connected and disconnected branches',
+    progressIdMatches >= 2);
+
   // ═══════════════════════════════════════
   // 15. Withings OAuth2 + measure-type decoding
   // ═══════════════════════════════════════


### PR DESCRIPTION
## Summary

When a user clicks **Re-import new export** on an already-connected Apple Health row, the import runs invisibly — no progress bar, no status text. Easy to mistake for a wedged app, especially with large exports that legitimately take 30–60 seconds (or minutes for multi-GB files).

## Root cause

The `#apple-health-progress` element is rendered only inside the **disconnected-state** template (the dropzone branch starting around line 1398 in `js/wearables.js`). After the first successful import, the row flips to the **connected-state** template which omits that element entirely.

`importAppleHealthFlow` (the function the Re-import button triggers) starts with:

```js
const wrap = document.getElementById('apple-health-progress');
const bar  = document.querySelector('.apple-health-progress-fill');
const text = document.querySelector('.apple-health-progress-text');
if (wrap) wrap.style.display = 'block';
```

All three lookups return `null` in the connected branch, and every subsequent `if (wrap)` / `if (bar)` / `if (text)` silently no-ops. The import runs to completion without a single pixel of feedback.

## Fix

Include the same `#apple-health-progress` markup in the connected-state template. No JS changes — `importAppleHealthFlow` already addresses the right ids.

## Test plan

- [ ] First-time import (disconnected state): progress bar renders as before — no regression.
- [ ] Click **Re-import new export** on a connected row: progress bar appears immediately, fills as parsing/writing/summarising stages emit, hides cleanly on success.
- [ ] Same row, click Re-import again on a small file: the bar renders and disappears as expected (no lingering 100% state from prior import).

Discovered while testing #183 with my own 2 GB export — re-imports felt frozen until the success toast fired. With #183 merged, multi-GB streaming parses run for 30s+ so the missing progress bar gets noticed; pre-#183 the parse was bounded by the V8 string limit so re-imports were either fast or failed quickly.