### PR TITLE
v1.7.2 — readable changelog links + forceShow shadowing fix

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,12 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.7.2', date: '2026-05-12', title: 'Readable changelog links',
+    items: [
+      '<b>Hyperlinks in the What\'s New modal are now visible.</b> Links rendered as the browser-default blue and disappeared into the dark-theme background. They now use the same accent-blue + underline as chat-message and summary-modal links.',
+    ]
+  },
+  {
     version: '1.7.1', date: '2026-05-12', title: 'Apple Health ZIP fix, encrypted-backup recovery, security hardening',
     // Carries a critical user action (re-export the encrypted backup), so
     // override the patch-skip in maybeShowChangelog and force the modal
@@ -242,13 +248,14 @@ export function maybeShowChangelog() {
   }
   // Patch-level bumps normally don't auto-show, but a maintainer can flag
   // an entry as forceShow when it carries a critical user-action notice
-  // (e.g. "re-export your encrypted backup" in v1.7.1). Fire only if the
-  // latest entry actually advances past the user's seen version, so users
-  // who already opened the modal don't see it again on every page load.
-  const latest = CHANGELOG[0];
-  if (latest && latest.forceShow && _semverGt(latest.version, seen)) {
-    openChangelog(false);
-  }
+  // (e.g. "re-export your encrypted backup" in v1.7.1). Scan all entries
+  // newer than the user's seen version — a later non-forceShow patch must
+  // not shadow an earlier critical entry. Idempotent because closeChangelog
+  // advances seen to the current APP_VERSION.
+  const hasForceShowAheadOfSeen = CHANGELOG.some(
+    e => e && e.forceShow && _semverGt(e.version, seen)
+  );
+  if (hasForceShowAheadOfSeen) openChangelog(false);
 }
 
 Object.assign(window, { openChangelog, closeChangelog, maybeShowChangelog });

--- a/styles.css
+++ b/styles.css
@@ -426,6 +426,8 @@ body.chat-open.chat-fullscreen .main { padding-right: 32px; }
   font-size: 14px; color: var(--text-secondary); line-height: 1.5;
 }
 .changelog-item::before { content: '–'; position: absolute; left: 0; color: var(--accent); font-weight: 600; }
+.changelog-item a { color: var(--accent); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+.changelog-item a:hover { text-decoration-thickness: 2px; }
 .modal .modal-unit {
   color: var(--text-muted); font-size: 14px; margin-bottom: 8px;
   /* Source-name + delta + trend separated by middle-dots; let them wrap

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -34,13 +34,13 @@ return (async function() {
   assert('maybeShowChangelog compares major.minor only', changelogSrc.includes('getMajorMinor(seen) !== getMajorMinor('));
   // forceShow patch-bump escape hatch — when a maintainer flags an entry as
   // critical (e.g. v1.7.1 "re-export your encrypted backup"), the modal
-  // must auto-fire even on a same-major.minor patch bump.
+  // must auto-fire even on a same-major.minor patch bump. Logic must scan
+  // ALL entries (not just CHANGELOG[0]) — otherwise a later non-forceShow
+  // patch silently shadows an earlier critical entry.
   assert('changelog.js has _semverGt helper for forceShow gate',
     /function\s+_semverGt\s*\(/.test(changelogSrc));
-  assert('maybeShowChangelog has forceShow branch on latest entry',
-    /CHANGELOG\[0\][\s\S]{0,120}forceShow[\s\S]{0,120}_semverGt/.test(changelogSrc));
-  assert('forceShow only fires when latest entry advances past seen version',
-    /_semverGt\(latest\.version,\s*seen\)/.test(changelogSrc));
+  assert('maybeShowChangelog scans all entries for forceShow (not just [0])',
+    /CHANGELOG\.some\s*\(\s*e\s*=>\s*e[\s\S]{0,80}forceShow[\s\S]{0,80}_semverGt\(e\.version,\s*seen\)/.test(changelogSrc));
   // The v1.7.1 entry itself must carry forceShow — its body asks users to
   // re-export their encrypted backup. Lock this in so a future copy edit
   // doesn't silently drop the flag and break the call-to-action.
@@ -190,24 +190,32 @@ return (async function() {
   assert('closeChangelog removes show class', ovAfterClose && !ovAfterClose.classList.contains('show'));
   assert('closeChangelog marks version as seen', localStorage.getItem('labcharts-changelog-seen') !== null);
 
-  // ── forceShow behavioral: seen=1.7.0 + APP_VERSION=1.7.1 must auto-open ──
-  // Patch bumps normally skip auto-open; forceShow on the latest entry has
-  // to override that. Stash the seen value, set it to 1.7.0, fire
-  // maybeShowChangelog, assert overlay opened.
+  // ── forceShow behavioral: seen=1.7.0 must auto-open even when later
+  // non-forceShow patches have shipped on top of v1.7.1. Otherwise a
+  // routine later patch shadows the critical "re-export your backup"
+  // notice from v1.7.1. ──
   const _origSeen = localStorage.getItem('labcharts-changelog-seen');
   try {
     localStorage.setItem('labcharts-changelog-seen', '1.7.0');
     // Prove overlay starts hidden
     ovAfterClose?.classList.remove('show');
     window.maybeShowChangelog();
-    assert('maybeShowChangelog auto-opens on 1.7.0→1.7.1 patch bump (forceShow branch)',
+    assert('maybeShowChangelog auto-opens when a forceShow entry is newer than seen',
       ovAfterClose?.classList.contains('show') === true);
     window.closeChangelog();
     // Re-fire idempotency: after closeChangelog markChangelogSeen wrote the
-    // current APP_VERSION as seen, so _semverGt(latest.version, seen) is now
-    // false → modal must NOT re-open on subsequent maybeShowChangelog calls.
+    // current APP_VERSION as seen, so no entry is newer → modal must NOT
+    // re-open on subsequent maybeShowChangelog calls.
     window.maybeShowChangelog();
     assert('maybeShowChangelog stays closed once user has seen the latest version',
+      ovAfterClose?.classList.contains('show') === false);
+    // Shadowing defense: if seen is newer than the forceShow entry but
+    // older than a non-forceShow patch on top, modal must NOT auto-open
+    // (no critical action is pending).
+    localStorage.setItem('labcharts-changelog-seen', '1.7.1');
+    ovAfterClose?.classList.remove('show');
+    window.maybeShowChangelog();
+    assert('maybeShowChangelog stays closed when only non-forceShow patches are newer',
       ovAfterClose?.classList.contains('show') === false);
   } finally {
     if (_origSeen !== null) localStorage.setItem('labcharts-changelog-seen', _origSeen);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.7.1';
+self.APP_VERSION = '1.7.2';


### PR DESCRIPTION
## Summary

Two related fixes, bundled because both flow from the v1.7.1 ship:

### 1. Hyperlinks in the What's New modal were unreadable

`styles.css` had no rule for `.changelog-item a`, so anchors fell through to browser-default \`rgb(0, 0, 238)\` blue — near-invisible on the dark theme. v1.7.1 was the first changelog entry to include in-content anchors that mattered (the \`@Savi-1\` contributor credits), so the latent CSS gap surfaced now.

Fix: add the same anchor treatment used by \`.summary-modal-body a\` and \`.chat-msg a\` — \`color: var(--accent); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px\`. Reads as \`#4f8cff\` dark / \`#3b7cf5\` light.

### 2. forceShow logic shadowed by later non-forceShow patches

The forceShow override I added in #184 only checked \`CHANGELOG[0].forceShow\` — meaning the moment a routine non-forceShow patch shipped on top of v1.7.1, the critical "re-export your encrypted backup" notice would silently stop auto-firing. Adding the v1.7.2 entry triggered exactly this scenario in the test suite, surfacing the bug.

Fix: \`maybeShowChangelog\` now scans **all** entries with \`Array.some(e => e.forceShow && _semverGt(e.version, seen))\`. A forceShow entry stays sticky until the user's seen version advances past it, regardless of how many non-forceShow patches accumulate on top.

Test extended with a shadowing-defense assertion: with seen=\`'1.7.1'\`, modal must NOT auto-open on \`'1.7.2'\` (no critical action pending).

### 3. version.js → 1.7.2

\`styles.css\` is in the SW precache list, so the cache key has to bump for users to actually receive the link-color fix.

## Test plan

- [x] \`bash run-tests.sh\` — full suite green (incl. new shadowing assertion in test-changelog.js)
- [x] Browser smoke: opened changelog modal in dark theme → @Savi-1 link renders accent-blue with underline (was browser-default invisible blue)
- [x] CSS variable resolves correctly: \`var(--accent)\` is theme-aware, \`#4f8cff\` dark / \`#3b7cf5\` light
- [ ] Post-deploy: confirm SW picks up \`labcharts-v1.7.2\` cache key

🤖 Generated with [Claude Code](https://claude.com/claude-code)