### PR TITLE
Retro review: IPv4-mapped IPv6 SSRF fix (14c1303)

### DIFF
--- a/js/url-safety.js
+++ b/js/url-safety.js
@@ -54,14 +54,21 @@ export function isValidExternalUrl(raw, { requireHttps = true, allowLocalhost = 
     if (v4Embed) return isValidExternalUrl(`${u.protocol}//${v4Embed[1]}${u.pathname || ''}`, { requireHttps, allowLocalhost });
 
     if (host.startsWith('::ffff:')) {
+      // IPv4-mapped IPv6 = `::ffff:HHHH:HHHH` — exactly two colon-separated
+      // 16-bit hex groups. Parse each group independently. Earlier draft
+      // concatenated the raw hex and left-padded — when leading zeros were
+      // omitted (e.g. `c0a8:101` instead of `c0a8:0101`), the byte boundaries
+      // mis-aligned and `::ffff:c0a8:101` mis-parsed as `12.10.129.1` instead
+      // of `192.168.1.1`, bypassing the RFC-1918 block (Greptile P1 PR #193).
       const tail = host.slice(7);
-      const hex = tail.replace(/:/g, '');
-      if (/^[0-9a-f]{1,8}$/.test(hex)) {
-        const padded = hex.padStart(8, '0');
-        const a = parseInt(padded.slice(0, 2), 16);
-        const b = parseInt(padded.slice(2, 4), 16);
-        const c = parseInt(padded.slice(4, 6), 16);
-        const d = parseInt(padded.slice(6, 8), 16);
+      const groups = tail.split(':');
+      if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
+        const g0 = parseInt(groups[0], 16);
+        const g1 = parseInt(groups[1], 16);
+        const a = (g0 >> 8) & 0xff;
+        const b = g0 & 0xff;
+        const c = (g1 >> 8) & 0xff;
+        const d = g1 & 0xff;
         return isValidExternalUrl(`${u.protocol}//${a}.${b}.${c}.${d}${u.pathname || ''}`, { requireHttps, allowLocalhost });
       }
     }

--- a/run-tests.js
+++ b/run-tests.js
@@ -385,7 +385,10 @@ function writeCoverageReport(entries) {
   }
 
   const rows = [...perFile.entries()].map(([file, m]) => {
-    const fnRow = fnSummary.get(file) || fnSummary.get('/' + file) || { total: 0, called: 0, names: [] };
+    // perFile keys are stripped paths like `js/emf.js`; fnSummary keys
+    // come from `cleanUrl()` which keeps the leading slash. Always look
+    // up with the slash form.
+    const fnRow = fnSummary.get('/' + file) || { total: 0, called: 0, names: [] };
     return {
       file, total: m.total, covered: m.covered,
       pct: m.total > 0 ? (m.covered / m.total) * 100 : 0,

--- a/styles.css
+++ b/styles.css
@@ -3807,7 +3807,7 @@ select.chat-onboard-input option { background: var(--bg-secondary); color: var(-
 /* Detail Modal Genetics Inline */
 .detail-genetics { margin: 12px 0; padding: 10px 12px; background: var(--bg-hover); border-radius: var(--radius-sm); border: 1px solid var(--border); }
 .detail-genetics-ref { color: var(--text-secondary); font-size: 10px; text-decoration: none; border-bottom: 1px dotted currentColor; margin-left: 4px; }
-.detail-genetics-ref:hover { opacity: 1; color: var(--accent); border-bottom-color: var(--accent); }
+.detail-genetics-ref:hover { color: var(--accent); border-bottom-color: var(--accent); }
 
 /* Marker Notes in Detail Modal */
 .marker-note-section { margin: 12px 0; padding: 10px 12px; background: var(--bg-hover); border-radius: var(--radius-sm); border: 1px solid var(--border); }

--- a/tests/test-cashu-wallet.js
+++ b/tests/test-cashu-wallet.js
@@ -270,6 +270,14 @@ return (async function() {
   await expectMintRejection('https://169.254.169.254/mint', 'cloud metadata');
   await expectMintRejection('http://example.com/mint', 'non-HTTPS public host');
   await expectMintRejection('not a url', 'unparseable');
+  // Regression: IPv4-mapped IPv6 with omitted leading zeros (Greptile P1
+  // PR #193). `::ffff:c0a8:101` is a valid abbreviation for 192.168.1.1
+  // but the earlier hex-concatenate-and-pad logic mis-aligned byte
+  // boundaries to 12.10.129.1, bypassing the RFC-1918 block.
+  await expectMintRejection('https://[::ffff:c0a8:101]/mint', 'IPv4-mapped IPv6 abbreviated → 192.168.1.1');
+  await expectMintRejection('https://[::ffff:c0a8:0101]/mint', 'IPv4-mapped IPv6 padded → 192.168.1.1');
+  await expectMintRejection('https://[::ffff:7f00:1]/mint',  'IPv4-mapped IPv6 abbreviated → 127.0.0.1');
+  await expectMintRejection('https://[::ffff:a9fe:a9fe]/mint', 'IPv4-mapped IPv6 → 169.254.169.254 (cloud metadata)');
 
   // setSelectedNodeUrl — silent no-op on rejection (Nostr/backup-restore
   // paths route here unconditionally, throwing would surface as unhandled


### PR DESCRIPTION
## Why this PR exists

PR #193 (v1.7.5) was reviewed by Greptile, who flagged a **P1 security bug** in the IPv4-mapped IPv6 parsing inside `js/url-safety.js`. I authored the fix but accidentally committed it on `main` instead of switching to the PR branch first, then pushed — bypassing the branch-protection rule. PR #193 auto-merged once main contained all its commits.

The fix landed as `14c1303` directly on main, **without going through review.** This PR exists so a second pair of eyes can sign off retroactively.

**Don't merge this PR** — the change is already on main. The base branch (`review/pre-ssrf-fix`) is just a snapshot of `main` at SHA `160326d` (where it was before `14c1303` landed) so the diff renders correctly. Close after review.

## The fix in one sentence

The `::ffff:HHHH:HHHH` IPv4-mapped IPv6 parser now reads each colon-separated 16-bit hex group independently instead of concatenating them into a string and left-padding — the old approach mis-aligned byte boundaries when leading zeros were omitted.

## The bug, concretely

```
host = '::ffff:c0a8:101'   // valid abbreviated form for 192.168.1.1
tail = 'c0a8:101'          // host.slice(7)
hex  = 'c0a8101'           // tail.replace(/:/g, '') — only 7 chars
padded = '0c0a8101'        // padStart(8, '0') — leading zero added on the WRONG side
octets = 0c.0a.81.01       // = 12.10.129.1, NOT 192.168.1.1
```

`new URL('https://[::ffff:c0a8:101]/')` parses cleanly (it IS a valid abbreviated IPv6 literal), so a Nostr relay payload or wallet-backup file could supply this form to **bypass the RFC-1918 / cloud-metadata block** and pin the Cashu mint or Routstr node to an internal target.

## The fix

```js
const groups = tail.split(':');
if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
  const g0 = parseInt(groups[0], 16);
  const g1 = parseInt(groups[1], 16);
  const a = (g0 >> 8) & 0xff;
  const b = g0 & 0xff;
  const c = (g1 >> 8) & 0xff;
  const d = g1 & 0xff;
  return isValidExternalUrl(`${u.protocol}//${a}.${b}.${c}.${d}${u.pathname || ''}`, ...);
}
```

Each 16-bit group parses independently. Bit-shifting extracts the four octets correctly regardless of zero-padding.

## Two P2 cleanups bundled in the same commit

* `styles.css` — removed dead `opacity: 1` from `.detail-genetics-ref:hover` (base rule no longer sets opacity, so :1 was a no-op).
* `run-tests.js` — `fnSummary.get(file)` first lookup was always a miss (perFile keys are stripped paths; fnSummary keys keep the leading slash). Removed the dead first lookup.

## Test coverage

`tests/test-cashu-wallet.js` gains 4 regression cases for the IPv4-mapped IPv6 form:
- `::ffff:c0a8:101` (abbreviated → 192.168.1.1)
- `::ffff:c0a8:0101` (padded → 192.168.1.1)
- `::ffff:7f00:1` (abbreviated → 127.0.0.1)
- `::ffff:a9fe:a9fe` (→ 169.254.169.254 cloud metadata)

All pass with the fix. With the old logic, the first three would have **incorrectly** been treated as external (RFC-1918 block bypassed).

## Process note

I'm saving a feedback memory ("when addressing PR review comments, FIRST `git checkout <pr-branch>`") so this doesn't happen again. Apologies for the bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)