### PR TITLE
fix(oura): RHR uses sleep-window minimum, matches Oura app

### DIFF
--- a/js/wearables-oura.js
+++ b/js/wearables-oura.js
@@ -220,13 +220,15 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
       ?? timeSeriesMean(s?.hrv)
       ?? meanOrNull(s?.hrv_samples) // legacy field name on older sessions
       ?? null;
-    // RHR: prefer the night's average (matches Oura's "Average HR" / what
-    // their app labels as "Resting"), then the lowest scalar, then fall
-    // back to per-sample time series. Same fresh-session lag applies —
-    // scalars may be unfilled while heart_rate.items is already present.
-    row.rhr = s?.average_heart_rate
-      ?? s?.lowest_heart_rate
-      ?? timeSeriesMean(s?.heart_rate)
+    // RHR: sleep-window minimum is the true overnight RHR — this is what
+    // Oura's app shows on the "Resting Heart Rate" card and trend graph
+    // (the lowest 5-min average during sleep, typically hit in deep sleep).
+    // average_heart_rate is the night-long mean and runs 5-10 bpm higher
+    // than the user's RHR; using it here made our number disagree with
+    // Oura's. Same fresh-session lag applies — scalars may be unfilled
+    // while heart_rate.items is already present, so fall back to the
+    // per-sample minimum before giving up.
+    row.rhr = s?.lowest_heart_rate
       ?? timeSeriesMin(s?.heart_rate)
       ?? null;
   }

--- a/tests/test-wearables-fetchers.js
+++ b/tests/test-wearables-fetchers.js
@@ -94,7 +94,7 @@ return (async function() {
     const r = rows.find(x => x.date === '2026-04-23');
     assert('Oura row tagged source: oura', r?.source === 'oura');
     assert('Oura hrv_rmssd from sleep average_hrv', r?.hrv_rmssd === 42);
-    assert('Oura rhr from sleep average_heart_rate (not lowest)', r?.rhr === 58);
+    assert('Oura rhr from sleep lowest_heart_rate (matches Oura app RHR card)', r?.rhr === 54);
     assert('Oura hr_day from heartrate awake-tagged samples (mean of 72+88=80)', r?.hr_day === 80);
     assert('Oura sleep_score from daily_sleep.score', r?.sleep_score === 78);
     assert('Oura readiness_score from daily_readiness.score', r?.readiness_score === 82);
@@ -160,9 +160,9 @@ return (async function() {
     assert('Oura time-series HRV filters zero-valued samples (gaps in recording)',
       r?.hrv_rmssd > 40, // would be 28.something if zeros were included
       `got ${r?.hrv_rmssd}`);
-    // RHR mean of [62,60,56,54,52,53,55,58,60] = 510/9 ≈ 56.67
-    assert('Oura rhr falls back to time-series mean when scalar null',
-      r?.rhr != null && Math.abs(r.rhr - 56.67) < 0.5,
+    // RHR is the minimum of [62,60,56,54,52,53,55,58,60] (zeros filtered) = 52
+    assert('Oura rhr falls back to time-series min when scalar null',
+      r?.rhr === 52,
       `got ${r?.rhr}`);
   } finally { restoreFetch(); }
 
@@ -185,7 +185,7 @@ return (async function() {
     const rows = await oura.fetchOuraDailyRange('test-token', '2026-04-23', '2026-04-23');
     const r = rows.find(x => x.date === '2026-04-23');
     assert('Oura prefers scalar average_hrv over hrv.items when both present', r?.hrv_rmssd === 42);
-    assert('Oura prefers scalar average_heart_rate over heart_rate.items when both present', r?.rhr === 58);
+    assert('Oura prefers scalar lowest_heart_rate over heart_rate.items when both present', r?.rhr === 54);
   } finally { restoreFetch(); }
 
   // ═══════════════════════════════════════

--- a/tests/test-wearables-sync-flow.js
+++ b/tests/test-wearables-sync-flow.js
@@ -89,9 +89,9 @@ return (async function() {
     installRoutes([
       { matcher: 'usercollection/sleep', body: {
         data: [
-          { day: '2026-04-20', total_sleep_duration: 26000, average_hrv: 38, average_heart_rate: 60 },
-          { day: '2026-04-21', total_sleep_duration: 25000, average_hrv: 42, average_heart_rate: 58 },
-          { day: '2026-04-22', total_sleep_duration: 27000, average_hrv: 40, average_heart_rate: 59 },
+          { day: '2026-04-20', total_sleep_duration: 26000, average_hrv: 38, average_heart_rate: 60, lowest_heart_rate: 54 },
+          { day: '2026-04-21', total_sleep_duration: 25000, average_hrv: 42, average_heart_rate: 58, lowest_heart_rate: 52 },
+          { day: '2026-04-22', total_sleep_duration: 27000, average_hrv: 40, average_heart_rate: 59, lowest_heart_rate: 53 },
         ], next_token: null,
       }},
       { matcher: 'usercollection/daily_sleep', body: { data: [
@@ -113,7 +113,7 @@ return (async function() {
     assert('Oura rows persisted to L1 IDB', rows.length >= 3);
     const day20 = rows.find(r => r.date === '2026-04-20');
     assert('Persisted row carries hrv_rmssd from sleep payload', day20?.hrv_rmssd === 38);
-    assert('Persisted row carries rhr from sleep payload', day20?.rhr === 60);
+    assert('Persisted row carries rhr from sleep lowest_heart_rate', day20?.rhr === 54);
     assert('Persisted row carries sleep_score from daily_sleep', day20?.sleep_score === 78);
 
     const meta = await store.getMeta(TEST_PROFILE_ID, 'last-sync:oura');


### PR DESCRIPTION
## Summary

- Oura's RHR field now sources from `sleep.lowest_heart_rate` (the sleep-window minimum) instead of `sleep.average_heart_rate` (the night-long mean).
- Brings getbased in line with what the Oura app shows on its **Resting Heart Rate** card and trend graph — those use the lowest 5-min average during sleep (typically hit in deep sleep), not the overnight mean.
- Also consistent with the existing Withings + Polar adapters, both of which already take the sleep-window minimum and carry comments saying so:
  - `wearable-adapters.js:328` (Withings): `hr_min`
  - `wearable-adapters.js:372` (Polar): `heart-rate-samples.min`

## Why

User report: Oura's app showed RHR ~5–10 bpm **lower** than the getbased card for the same source / same day. The night-long average is consistently higher than the true RHR.

The v1.30.4 fix (`02f4cfd`) that added time-series fallbacks for fresh-session lag deliberately kept `average_heart_rate` at the front of the chain to preserve a pinned test assertion. The pin itself was the bug.

## Behavior on next sync

Existing Oura rows get re-fetched and overwritten with the corrected (lower) values. No migration needed — the L2 summary recomputes on the next gate trigger.

## Test updates

- `test-wearables-fetchers.js`: three Oura assertions retargeted from `average_heart_rate` (58) to `lowest_heart_rate` (54). The time-series fallback test now asserts min-of-items (52) instead of mean (56.67).
- `test-wearables-sync-flow.js`: mock sleep payloads carry `lowest_heart_rate`, and the persisted-row assertion checks that field.

## Test plan

- [x] `./run-tests.sh` — `test-wearables-fetchers.js` and `test-wearables-sync-flow.js` both green
- [x] Verify in production: connect Oura → wait one sync → RHR on dashboard now matches Oura app