### PR TITLE
fix(wearables): treat 0 as missing for HR / HRV / weight metrics

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -92,6 +92,24 @@ export const CANONICAL_METRICS = {
   sleep_breath_disturb: { id: 'sleep_breath_disturb', label: 'Apnea',       sub: 'level', unit: '',    worseWhen: 'up'     }, // breathing-disturbances intensity 0-100 (Withings' apnea-class signal)
 };
 
+// For most wearable metrics, 0 is a sentinel for "no measurement" — the
+// vendor emits 0 when the device wasn't worn, signal was lost, or the
+// session was sub-threshold. Biologically nonsense for HR, HRV, weight,
+// body temp, etc. We treat these as gaps so charts don't plot misleading
+// dots at the floor and L2 means/baselines aren't dragged down by them.
+// A handful of metrics legitimately can be 0 (no steps on a rest day,
+// no high-stress minutes, no snoring, perfect sleep with no awake time,
+// body-temp deviation centered at 0) — those keep their zero values.
+const ZERO_IS_LEGITIMATE_METRICS = new Set([
+  'steps', 'stress_high_min', 'body_temp_delta',
+  'sleep_snoring_min', 'sleep_awake_min',
+]);
+export function isMetricValueMeaningful(metricId, v) {
+  if (typeof v !== 'number' || !isFinite(v)) return false;
+  if (ZERO_IS_LEGITIMATE_METRICS.has(metricId)) return true;
+  return v > 0;
+}
+
 // Default display order for the dashboard strip. A canonical metric not listed
 // here still renders (appended in registry order) — the list just pins priority.
 // Also used as METRICS_FOR_SUMMARY in wearables-summary.js, so any metric that

--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -100,9 +100,16 @@ export const CANONICAL_METRICS = {
 // A handful of metrics legitimately can be 0 (no steps on a rest day,
 // no high-stress minutes, no snoring, perfect sleep with no awake time,
 // body-temp deviation centered at 0) — those keep their zero values.
+//
+// activity_score is also allowlisted: Oura suppresses it to 0 while Rest
+// Mode is on, and we have a dedicated "Rest Mode" hint that fires from
+// the detail modal to explain this. Filtering it out drops the card from
+// the strip entirely, hiding the hint from the exact users it's for. Keep
+// the 0s so the card renders and the hint stays reachable.
 const ZERO_IS_LEGITIMATE_METRICS = new Set([
   'steps', 'stress_high_min', 'body_temp_delta',
   'sleep_snoring_min', 'sleep_awake_min',
+  'activity_score',
 ]);
 export function isMetricValueMeaningful(metricId, v) {
   if (typeof v !== 'number' || !isFinite(v)) return false;

--- a/js/wearables-oura.js
+++ b/js/wearables-oura.js
@@ -152,6 +152,15 @@ function timeSeriesMin(obj) {
   return Math.min(...nums);
 }
 
+// Oura emits literal 0 for HRV/HR scalars when a sleep session has no usable
+// data (ring not worn, signal lost, sub-threshold session). 0 is biologically
+// nonsense for these metrics, and `??` doesn't catch it because 0 is not
+// nullish — so it flows through to L1 and pollutes the chart as a real
+// reading. Treat ≤ 0 as missing so the next fallback can run.
+function gtZero(v) {
+  return typeof v === 'number' && isFinite(v) && v > 0 ? v : null;
+}
+
 // Returns canonical L1 rows for the inclusive date range [startDate, endDate].
 // Each row is keyed by date; missing metrics are null (not omitted) so consumers
 // can see "no spo2 today" vs "spo2 not yet fetched."
@@ -216,7 +225,7 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
     // `average_hrv` only appears once their analysis pipeline finishes a few
     // hours later. Without this fallback today's HRV reads as null even when
     // the cloud shows data.
-    row.hrv_rmssd = s?.average_hrv
+    row.hrv_rmssd = gtZero(s?.average_hrv)
       ?? timeSeriesMean(s?.hrv)
       ?? meanOrNull(s?.hrv_samples) // legacy field name on older sessions
       ?? null;
@@ -225,10 +234,10 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
     // (the lowest 5-min average during sleep, typically hit in deep sleep).
     // average_heart_rate is the night-long mean and runs 5-10 bpm higher
     // than the user's RHR; using it here made our number disagree with
-    // Oura's. Same fresh-session lag applies — scalars may be unfilled
-    // while heart_rate.items is already present, so fall back to the
-    // per-sample minimum before giving up.
-    row.rhr = s?.lowest_heart_rate
+    // Oura's. gtZero() guards against the literal-0 sentinel Oura emits
+    // when the session has no usable data; same fresh-session lag applies,
+    // so fall back to per-sample minimum before giving up.
+    row.rhr = gtZero(s?.lowest_heart_rate)
       ?? timeSeriesMin(s?.heart_rate)
       ?? null;
   }
@@ -276,7 +285,7 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
   const hrDayBuckets = new Map(); // day → number[]
   for (const sample of (heartrateSamples || [])) {
     if (sample?.source !== 'awake') continue;
-    if (typeof sample?.bpm !== 'number' || !isFinite(sample.bpm)) continue;
+    if (typeof sample?.bpm !== 'number' || !isFinite(sample.bpm) || sample.bpm <= 0) continue;
     const day = String(sample?.timestamp || '').slice(0, 10);
     if (!day) continue;
     if (!hrDayBuckets.has(day)) hrDayBuckets.set(day, []);

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -9,7 +9,7 @@
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
 import { getDailyRange } from './wearables-store.js';
-import { DEFAULT_METRIC_ORDER } from './wearable-adapters.js';
+import { DEFAULT_METRIC_ORDER, isMetricValueMeaningful } from './wearable-adapters.js';
 import { isDebugMode } from './utils.js';
 import { isoDay } from './wearables-oura.js';
 
@@ -61,7 +61,7 @@ function seriesFor(rowsByDate, metricId) {
   const out = [];
   for (const row of rowsByDate) {
     const v = row[metricId];
-    if (typeof v === 'number' && isFinite(v)) out.push({ date: row.date, v });
+    if (isMetricValueMeaningful(metricId, v)) out.push({ date: row.date, v });
   }
   return out;
 }
@@ -189,14 +189,14 @@ export function computeWearableSummary(rowsBySource, connectedSources, primaryOv
       const overRows = rowsBySource[overrideSrc];
       for (let i = overRows.length - 1; i >= 0; i--) {
         const v = overRows[i]?.[metricId];
-        if (typeof v === 'number' && isFinite(v)) { bestSrc = overrideSrc; break; }
+        if (isMetricValueMeaningful(metricId, v)) { bestSrc = overrideSrc; break; }
       }
     }
     if (!bestSrc) {
       for (const [sid, rows] of Object.entries(rowsBySource)) {
         for (let i = rows.length - 1; i >= 0; i--) {
           const v = rows[i]?.[metricId];
-          if (typeof v === 'number' && isFinite(v)) {
+          if (isMetricValueMeaningful(metricId, v)) {
             if (rows[i].date > bestDate) { bestDate = rows[i].date; bestSrc = sid; }
             break;
           }

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -17,7 +17,7 @@
 
 import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { state } from './state.js';
-import { ADAPTERS, adapterById, canonicalMetric, metricsForSources, visibleAdapters, getOAuthClientId } from './wearable-adapters.js';
+import { ADAPTERS, adapterById, canonicalMetric, metricsForSources, visibleAdapters, getOAuthClientId, isMetricValueMeaningful } from './wearable-adapters.js';
 import { brandMarkMono } from './brand-assets.js';
 
 // Vendor logo / mark beside the adapter name. Backed by brands/<vendor>/
@@ -675,6 +675,7 @@ function toggleWearableStrip() {
 // that resolves with a stale token aborts before touching the DOM.
 let _detailOp = 0;
 
+
 async function openWearableDetail(metricId) {
   const op = ++_detailOp;
   const canon = canonicalMetric(metricId);
@@ -704,8 +705,19 @@ async function openWearableDetail(metricId) {
 
   const series = rows
     .map(r => ({ date: r.date, v: r[metricId] }))
-    .filter(p => typeof p.v === 'number' && isFinite(p.v))
+    .filter(p => isMetricValueMeaningful(metricId, p.v))
     .sort((a, b) => a.date.localeCompare(b.date));
+
+  // Activity-score Rest Mode hint: Oura emits a literal 0 for activity_score
+  // while Rest Mode is on. Our chart filter treats those as gaps, so by the
+  // time `series` is built they're gone — detect the all-zero pattern from
+  // the raw rows so the hint still fires.
+  const rawActivityValues = rows
+    .map(r => r[metricId])
+    .filter(v => typeof v === 'number' && isFinite(v));
+  const allZeroActivity = metricId === 'activity_score'
+    && rawActivityValues.length > 0
+    && rawActivityValues.every(v => v === 0);
 
   // Separately pull ALL manual rows (not just primary-source rows) so the
   // detail modal's "Manual entries" list shows manual readings even when
@@ -721,7 +733,7 @@ async function openWearableDetail(metricId) {
   }
   const manualEntries = manualRows
     .map(r => ({ date: r.date, v: r[metricId], tags: r.tags, note: r.note }))
-    .filter(p => typeof p.v === 'number' && isFinite(p.v))
+    .filter(p => isMetricValueMeaningful(metricId, p.v))
     .sort((a, b) => b.date.localeCompare(a.date)); // reverse-chron for display
 
   const modal = document.getElementById('detail-modal');
@@ -734,7 +746,7 @@ async function openWearableDetail(metricId) {
     delete state.chartInstances['modal'];
   }
 
-  modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries);
+  modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries, { allZeroActivity });
   overlay.classList.add('show');
   // Move focus to the close button so keyboard users land inside the modal.
   modal.querySelector('.modal-close')?.focus?.();
@@ -852,7 +864,7 @@ function buildManualEntriesSection(metricId, manualEntries, primarySource) {
   </section>`;
 }
 
-function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = []) {
+function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [], opts = {}) {
   const adapter = adapterById(m.primarySource);
   const sourceName = adapter?.displayName || m.primarySource;
   const unit = canon.unit || '';
@@ -961,10 +973,10 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [])
       ${sub ? `<div class="wearable-detail-stat-sub">${escapeHTML(sub)}</div>` : ''}
     </div>`).join('');
 
-  const emptyHint = series.length === 0
-    ? `<div class="wearable-detail-empty">No daily samples for this metric in the last 90 days. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`
-    : (metricId === 'activity_score' && series.every(p => p.v === 0))
-      ? `<div class="wearable-detail-empty">Every day shows 0 — Oura suppresses the Activity composite score while Rest Mode is on. Check the <b>Steps</b> card for raw movement data, or disable Rest Mode in the Oura app.</div>`
+  const emptyHint = opts.allZeroActivity
+    ? `<div class="wearable-detail-empty">Every day shows 0 — Oura suppresses the Activity composite score while Rest Mode is on. Check the <b>Steps</b> card for raw movement data, or disable Rest Mode in the Oura app.</div>`
+    : series.length === 0
+      ? `<div class="wearable-detail-empty">No daily samples for this metric in the last 90 days. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`
       : '';
 
   // Show the source-swap button whenever ≥2 wearables are connected — the

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -675,7 +675,6 @@ function toggleWearableStrip() {
 // that resolves with a stale token aborts before touching the DOM.
 let _detailOp = 0;
 
-
 async function openWearableDetail(metricId) {
   const op = ++_detailOp;
   const canon = canonicalMetric(metricId);
@@ -708,16 +707,13 @@ async function openWearableDetail(metricId) {
     .filter(p => isMetricValueMeaningful(metricId, p.v))
     .sort((a, b) => a.date.localeCompare(b.date));
 
-  // Activity-score Rest Mode hint: Oura emits a literal 0 for activity_score
-  // while Rest Mode is on. Our chart filter treats those as gaps, so by the
-  // time `series` is built they're gone — detect the all-zero pattern from
-  // the raw rows so the hint still fires.
-  const rawActivityValues = rows
-    .map(r => r[metricId])
-    .filter(v => typeof v === 'number' && isFinite(v));
+  // activity_score is allowlisted in isMetricValueMeaningful, so 0s pass
+  // through into `series` — that lets us detect Oura Rest Mode here and
+  // fire the dedicated hint from the detail modal instead of hiding the
+  // metric entirely.
   const allZeroActivity = metricId === 'activity_score'
-    && rawActivityValues.length > 0
-    && rawActivityValues.every(v => v === 0);
+    && series.length > 0
+    && series.every(p => p.v === 0);
 
   // Separately pull ALL manual rows (not just primary-source rows) so the
   // detail modal's "Manual entries" list shows manual readings even when


### PR DESCRIPTION
## Summary

Oura emits a literal `0` for HRV/HR scalars when a sleep session has no usable data (ring not worn, signal lost, sub-threshold session). `0` is biologically nonsense for these metrics — but `??` doesn't short-circuit on it, so the `0` flowed through to L1 and:
- pulled the history chart down to a floor dot on bad-night days
- pulled the L2 baseline toward 0
- dragged the weekly mean lower than reality

User report: history chart shows two dates with `rhr = 0`. After this fix those render as gaps (and never get persisted in the first place going forward).

## Three-layer fix

1. **Ingestion** (`js/wearables-oura.js`) — new `gtZero()` helper wraps `average_heart_rate`, `lowest_heart_rate`, `average_hrv` so zeros fall through to the next fallback (time-series min/mean → null). Per-sample awake-HR filter also rejects `bpm <= 0` so a stray zero sample can't pull the daily mean down.

2. **L2 derivation** (`js/wearables-summary.js`) — `seriesFor()` and the primary-source pickers go through a shared `isMetricValueMeaningful()` helper. A source with all-zero readings won't be picked as primary, and weekly/baseline math excludes the bogus zeros.

3. **Display** (`js/wearables.js`) — chart series + manual-entries list filter through the same helper. **This handles legacy zeros already sitting in IDB without forcing a backfill.**

## Allowlist of metrics where 0 is legitimate

Five metrics keep their zero values:

| Metric | Why 0 is real |
|---|---|
| `steps` | Rest day, fully sedentary |
| `stress_high_min` | Low-stress day |
| `body_temp_delta` | Baseline temp = 0 deviation |
| `sleep_snoring_min` | Didn't snore |
| `sleep_awake_min` | Perfect sleep, no wake time |

Everything else (HR, HRV, weight, body comp, scores, sleep durations) treats `0` as a sentinel.

## Rest-mode hint preserved

`activity_score` legitimately reads 0 every day when Oura's Rest Mode is on — there's an existing hint that explains this. The detector previously read the post-filter `series` (now empty when all values are 0); moved upstream to read the raw rows so the hint still fires.

## Test plan

- [x] `./run-tests.sh` — wearables suite green, including the Rest Mode hint test
- [x] No new failures vs. baseline (remaining failures are pre-existing environmental issues — EMF catalog symlink, axe a11y, etc.)
- [x] Verify in production: open RHR detail modal → previous zero-spike dates render as gaps instead of dots at the floor

## Related

Spotted while testing #195 (Oura RHR uses sleep-window minimum). The two PRs are independent — this one stands alone on `main`.