### PR TITLE
Vitest batch 18: consolidate node-side shims into _node-shim.js

### DIFF
--- a/tests/_node-shim.js
+++ b/tests/_node-shim.js
@@ -1,0 +1,104 @@
+// Shared Node-side browser-global shim for the legacy test suite.
+//
+// Tests originally written to run via `node tests/foo.js` need a
+// minimal set of browser globals (window, localStorage, addEventListener,
+// CSS.escape, document) because the imported `js/*.js` modules touch
+// them at module load. Each ported test used to inline ~25 lines of
+// shim boilerplate; this file consolidates them.
+//
+// Usage — one line at the top of each test file (before any
+// `import '../js/...'` that needs the shims):
+//
+//   import './_node-shim.js';
+//
+// Side-effect import is intentional: every install is guarded by a
+// `typeof === 'undefined'` check so it's idempotent and a no-op when
+// the real browser globals (or the Vitest setup file) already provided
+// them. Safe to re-import.
+//
+// The Vitest setup file (_vitest-setup.js) is a near-superset of this
+// — it adds `process.exit` interception and a richer document stub —
+// but the duplication is intentional so tests still run standalone
+// via `node tests/foo.js`. Keep the two in sync if you extend either.
+
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = globalThis;
+}
+
+function _makeStorage() {
+  const store = new Map();
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => { store.set(k, String(v)); },
+    removeItem: (k) => { store.delete(k); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (i) => Array.from(store.keys())[i] ?? null,
+  };
+}
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = _makeStorage();
+}
+if (typeof globalThis.sessionStorage === 'undefined') {
+  globalThis.sessionStorage = _makeStorage();
+}
+
+if (typeof globalThis.addEventListener !== 'function') {
+  const _listeners = new Map();
+  globalThis.addEventListener = (type, fn) => {
+    if (!_listeners.has(type)) _listeners.set(type, new Set());
+    _listeners.get(type).add(fn);
+  };
+  globalThis.removeEventListener = (type, fn) => {
+    _listeners.get(type)?.delete(fn);
+  };
+  globalThis.dispatchEvent = (ev) => {
+    const fns = _listeners.get(ev?.type);
+    if (fns) for (const fn of fns) {
+      // Surface listener errors via console.error so the test runner
+      // picks them up; don't re-throw (browser dispatchEvent doesn't).
+      try { fn(ev); } catch (e) { console.error('listener error:', e); }
+    }
+    return true;
+  };
+}
+
+if (typeof globalThis.CSS === 'undefined') {
+  globalThis.CSS = { escape: (s) => String(s).replace(/[^\w-]/g, (c) => '\\' + c) };
+}
+
+if (typeof globalThis.navigator === 'undefined') {
+  globalThis.navigator = {};
+}
+
+function _stubEl() {
+  return {
+    style: {}, dataset: {},
+    classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+    appendChild: () => {}, removeChild: () => {}, replaceChild: () => {},
+    insertBefore: () => {}, remove: () => {},
+    setAttribute: () => {}, getAttribute: () => null, removeAttribute: () => {},
+    addEventListener: () => {}, removeEventListener: () => {},
+    querySelector: () => null, querySelectorAll: () => [],
+    getBoundingClientRect: () => ({ top: 0, left: 0, width: 0, height: 0, right: 0, bottom: 0 }),
+    focus: () => {}, blur: () => {}, click: () => {},
+    children: [], childNodes: [],
+    innerHTML: '', textContent: '', value: '',
+    parentElement: null, parentNode: null,
+  };
+}
+if (typeof globalThis.document === 'undefined') {
+  globalThis.document = {
+    addEventListener: () => {}, removeEventListener: () => {},
+    createElement: () => _stubEl(),
+    createDocumentFragment: () => _stubEl(),
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    body: _stubEl(),
+    head: _stubEl(),
+    documentElement: _stubEl(),
+    createTextNode: (t) => ({ textContent: t }),
+    styleSheets: [],
+  };
+}

--- a/tests/_vitest-setup.js
+++ b/tests/_vitest-setup.js
@@ -95,6 +95,10 @@ if (typeof globalThis.document === 'undefined') {
     head: _stubEl(),
     documentElement: _stubEl(),
     createTextNode: (t) => ({ textContent: t }),
+    // Match _node-shim.js — some standalone-runnable tests probe
+    // `document.styleSheets.length`; absent here it would be undefined
+    // in Vitest workers but [] in `node tests/foo.js`. Greptile #207 P2.
+    styleSheets: [],
   };
 }
 

--- a/tests/test-ai-verdict-engine-instance.js
+++ b/tests/test-ai-verdict-engine-instance.js
@@ -9,20 +9,7 @@
 //
 // Run: node tests/test-ai-verdict-engine-instance.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-// CSS.escape is a browser global; engine.js calls it when building scroll
-// anchors. Minimal polyfill covers the chars used in our IDs.
-if (typeof globalThis.CSS === 'undefined') {
-  globalThis.CSS = { escape: (s) => String(s).replace(/[^\w-]/g, (c) => '\\' + c) };
-}
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 const assert = (n, c, d) => {

--- a/tests/test-biometrics.js
+++ b/tests/test-biometrics.js
@@ -3,22 +3,7 @@
 //
 // Run: node tests/test-biometrics.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-calculated-markers.js
+++ b/tests/test-calculated-markers.js
@@ -3,15 +3,7 @@
 //
 // Run: node tests/test-calculated-markers.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/tests/test-change-history.js
+++ b/tests/test-change-history.js
@@ -7,22 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-change-history.js
+++ b/tests/test-change-history.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-change-history.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -7,22 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-cycle-improvements.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-cycle-tour.js
+++ b/tests/test-cycle-tour.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-cycle-tour.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-cycle-tour.js
+++ b/tests/test-cycle-tour.js
@@ -7,22 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-dashboard-genetics-empty.js
+++ b/tests/test-dashboard-genetics-empty.js
@@ -3,22 +3,7 @@
 //
 // Run: node tests/test-dashboard-genetics-empty.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-data-pipeline.js
+++ b/tests/test-data-pipeline.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-data-pipeline.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const _ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const _realFetch = globalThis.fetch;

--- a/tests/test-data-pipeline.js
+++ b/tests/test-data-pipeline.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const _ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const _realFetch = globalThis.fetch;

--- a/tests/test-demo.js
+++ b/tests/test-demo.js
@@ -7,51 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
-// document shim — same shape as _vitest-setup.js _stubEl pattern.
-function _stubEl() {
-  return {
-    style: {}, dataset: {},
-    classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
-    appendChild: () => {}, removeChild: () => {}, replaceChild: () => {},
-    insertBefore: () => {}, remove: () => {},
-    setAttribute: () => {}, getAttribute: () => null, removeAttribute: () => {},
-    addEventListener: () => {}, removeEventListener: () => {},
-    querySelector: () => null, querySelectorAll: () => [],
-    getBoundingClientRect: () => ({ top: 0, left: 0, width: 0, height: 0, right: 0, bottom: 0 }),
-    focus: () => {}, blur: () => {}, click: () => {},
-    children: [], childNodes: [],
-    innerHTML: '', textContent: '', value: '',
-    parentElement: null, parentNode: null,
-  };
-}
-if (typeof globalThis.document === 'undefined') {
-  globalThis.document = {
-    addEventListener: () => {}, removeEventListener: () => {},
-    createElement: () => _stubEl(),
-    createDocumentFragment: () => _stubEl(),
-    getElementById: () => null,
-    querySelector: () => null,
-    querySelectorAll: () => [],
-    body: _stubEl(), head: _stubEl(), documentElement: _stubEl(),
-    createTextNode: (t) => ({ textContent: t }),
-  };
-}
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-demo.js
+++ b/tests/test-demo.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-demo.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-dna-mtdna-subclades.js
+++ b/tests/test-dna-mtdna-subclades.js
@@ -15,15 +15,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-dna-mtdna-subclades.js
+++ b/tests/test-dna-mtdna-subclades.js
@@ -11,11 +11,11 @@
 //
 // Run: node tests/test-dna-mtdna-subclades.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-folder-backup.js
+++ b/tests/test-folder-backup.js
@@ -3,22 +3,7 @@
 //
 // Run: node tests/test-folder-backup.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 const results = [];

--- a/tests/test-hardware.js
+++ b/tests/test-hardware.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-hardware.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-hardware.js
+++ b/tests/test-hardware.js
@@ -7,19 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-// Node 21+ has navigator as a global; Node 18/20 does not. js/hardware.js
-// reads navigator.deviceMemory / hardwareConcurrency and tolerates
-// undefined fields, just needs the object to exist.
-if (typeof globalThis.navigator === 'undefined') globalThis.navigator = {};
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-integration-batch2.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -7,22 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-lens-multi-query.js
+++ b/tests/test-lens-multi-query.js
@@ -16,15 +16,7 @@
 // lens.js transitively pulls in state.js, which does `window._labState
 // = state` at module load. Vitest's setup file handles this globally;
 // for standalone `node` runs we shim inline.
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-lens-parsers.js
+++ b/tests/test-lens-parsers.js
@@ -14,7 +14,7 @@
 //
 // Run: node tests/test-lens-parsers.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
+import './_node-shim.js';
 
 let passed = 0, failed = 0;
 const results = [];

--- a/tests/test-light-ai-renders.js
+++ b/tests/test-light-ai-renders.js
@@ -5,22 +5,7 @@
 //
 // Run: node tests/test-light-ai-renders.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, cond, detail) {

--- a/tests/test-light-device-ai-analysis.js
+++ b/tests/test-light-device-ai-analysis.js
@@ -5,22 +5,7 @@
 //
 // Run: node tests/test-light-device-ai-analysis.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -5,22 +5,7 @@
 //
 // Run: node tests/test-light-devices.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 // addDeviceFromPreset fetches `data/light-device-presets.json` relatively;
 // Node fetch needs absolute URLs, so route relative paths to fs.

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -5,22 +5,7 @@
 //
 // Run: node tests/test-light-env.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-light-tools-flow.js
+++ b/tests/test-light-tools-flow.js
@@ -6,22 +6,7 @@
 //
 // Run: node tests/test-light-tools-flow.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 const assert = (name, cond, detail) => {

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -5,22 +5,7 @@
 //
 // Run: node tests/test-light-tools.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-markdown.js
+++ b/tests/test-markdown.js
@@ -7,9 +7,8 @@
 
 // utils.js does an Object.assign(window, ...) at module load to expose
 // handlers to inline-onclick attributes — markdown.js imports escapeHTML
-// from utils.js, so we shim window first. localStorage isn't touched at
-// module-eval time so no stub needed there.
-globalThis.window = globalThis.window || {};
+// from utils.js, so we shim window first via the shared shim.
+import './_node-shim.js';
 
 const { applyInlineMarkdown, renderMarkdown } = await import('../js/markdown.js');
 

--- a/tests/test-marker-key-safety.js
+++ b/tests/test-marker-key-safety.js
@@ -10,7 +10,7 @@
 // module load to expose handlers to inline-onclick attributes. Other
 // node-side tests sidestep this by reading source as text; we want to
 // exercise the actual exported functions, so a dummy window suffices.
-globalThis.window = globalThis.window || {};
+import './_node-shim.js';
 const { safeMarkerId, sanitizeMarkerKey } = await import('../js/utils.js');
 
 let passed = 0, failed = 0;

--- a/tests/test-marker-value-notes.js
+++ b/tests/test-marker-value-notes.js
@@ -11,15 +11,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-marker-value-notes.js
+++ b/tests/test-marker-value-notes.js
@@ -7,11 +7,11 @@
 //
 // Run: node tests/test-marker-value-notes.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-multi-unit.js
+++ b/tests/test-multi-unit.js
@@ -12,7 +12,7 @@
 //
 // Run: node tests/test-multi-unit.js
 
-globalThis.window = globalThis.window || {};
+import './_node-shim.js';
 const { UNIT_CONVERSIONS, MARKER_SCHEMA, getAlternateUnit, convertUserInputToSI } = await import('../js/schema.js');
 
 let passed = 0, failed = 0;

--- a/tests/test-normalize-units.js
+++ b/tests/test-normalize-units.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-normalize-units.js
+++ b/tests/test-normalize-units.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-normalize-units.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-phase-ranges.js
+++ b/tests/test-phase-ranges.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-phase-ranges.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-phase-ranges.js
+++ b/tests/test-phase-ranges.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-pii.js
+++ b/tests/test-pii.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-pii.js
+++ b/tests/test-pii.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-pii.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-recommendations.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -7,26 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
-function _stubEl() { return { style:{}, dataset:{}, classList:{add:()=>{},remove:()=>{},contains:()=>false,toggle:()=>{}}, appendChild:()=>{},removeChild:()=>{},replaceChild:()=>{},insertBefore:()=>{},remove:()=>{}, setAttribute:()=>{},getAttribute:()=>null,removeAttribute:()=>{}, addEventListener:()=>{},removeEventListener:()=>{}, querySelector:()=>null,querySelectorAll:()=>[], getBoundingClientRect:()=>({top:0,left:0,width:0,height:0,right:0,bottom:0}), focus:()=>{},blur:()=>{},click:()=>{}, children:[],childNodes:[], innerHTML:'',textContent:'',value:'', parentElement:null,parentNode:null }; }
-if (typeof globalThis.document === 'undefined') {
-  globalThis.document = { addEventListener:()=>{},removeEventListener:()=>{}, createElement:()=>_stubEl(),createDocumentFragment:()=>_stubEl(), getElementById:()=>null,querySelector:()=>null,querySelectorAll:()=>[], body:_stubEl(),head:_stubEl(),documentElement:_stubEl(), createTextNode:(t)=>({textContent:t}), styleSheets:[] };
-}
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-schema.js
+++ b/tests/test-schema.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-schema.js
+++ b/tests/test-schema.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-schema.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-sun-ai-analysis.js
+++ b/tests/test-sun-ai-analysis.js
@@ -4,22 +4,7 @@
 //
 // Run: node tests/test-sun-ai-analysis.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-sun-context.js
+++ b/tests/test-sun-context.js
@@ -5,22 +5,7 @@
 //
 // Run: node tests/test-sun-context.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-sun-correlations.js
+++ b/tests/test-sun-correlations.js
@@ -4,22 +4,7 @@
 //
 // Run: node tests/test-sun-correlations.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-sun-defaults.js
+++ b/tests/test-sun-defaults.js
@@ -5,22 +5,7 @@
 //
 // Run: node tests/test-sun-defaults.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-sun-uvdata-flow.js
+++ b/tests/test-sun-uvdata-flow.js
@@ -8,22 +8,7 @@
 //
 // Run: node tests/test-sun-uvdata-flow.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 const assert = (name, cond, detail) => {

--- a/tests/test-sun-uvdata.js
+++ b/tests/test-sun-uvdata.js
@@ -4,22 +4,7 @@
 //
 // Run: node tests/test-sun-uvdata.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -4,22 +4,7 @@
 //
 // Run: node tests/test-sun.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-supplement-impact.js
+++ b/tests/test-supplement-impact.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-supplement-impact.js
+++ b/tests/test-supplement-impact.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-supplement-impact.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-sync.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -7,26 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
-function _stubEl() { return { style:{}, dataset:{}, classList:{add:()=>{},remove:()=>{},contains:()=>false,toggle:()=>{}}, appendChild:()=>{},removeChild:()=>{},replaceChild:()=>{},insertBefore:()=>{},remove:()=>{}, setAttribute:()=>{},getAttribute:()=>null,removeAttribute:()=>{}, addEventListener:()=>{},removeEventListener:()=>{}, querySelector:()=>null,querySelectorAll:()=>[], getBoundingClientRect:()=>({top:0,left:0,width:0,height:0,right:0,bottom:0}), focus:()=>{},blur:()=>{},click:()=>{}, children:[],childNodes:[], innerHTML:'',textContent:'',value:'', parentElement:null,parentNode:null }; }
-if (typeof globalThis.document === 'undefined') {
-  globalThis.document = { addEventListener:()=>{},removeEventListener:()=>{}, createElement:()=>_stubEl(),createDocumentFragment:()=>_stubEl(), getElementById:()=>null,querySelector:()=>null,querySelectorAll:()=>[], body:_stubEl(),head:_stubEl(),documentElement:_stubEl(), createTextNode:(t)=>({textContent:t}) };
-}
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-table-heatmap-empty.js
+++ b/tests/test-table-heatmap-empty.js
@@ -7,59 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-// views.js imports many things and reads `document` at module load.
-// `document` shim — same shape as tests/_vitest-setup.js's _stubEl() pattern.
-// Greptile #202 P2: the previous narrow stub (only style/appendChild/setAttribute
-// on createElement) would silently break if a future views.js init touched a
-// missing method like classList.add() — error would point at app code, not the
-// shim. Mirror the full _stubEl shape so standalone runs stay in sync with the
-// Vitest setup shim.
-function _stubEl() {
-  return {
-    style: {}, dataset: {},
-    classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
-    appendChild: () => {}, removeChild: () => {}, replaceChild: () => {},
-    insertBefore: () => {}, remove: () => {},
-    setAttribute: () => {}, getAttribute: () => null, removeAttribute: () => {},
-    addEventListener: () => {}, removeEventListener: () => {},
-    querySelector: () => null, querySelectorAll: () => [],
-    getBoundingClientRect: () => ({ top: 0, left: 0, width: 0, height: 0, right: 0, bottom: 0 }),
-    focus: () => {}, blur: () => {}, click: () => {},
-    children: [], childNodes: [],
-    innerHTML: '', textContent: '', value: '',
-    parentElement: null, parentNode: null,
-  };
-}
-if (typeof globalThis.document === 'undefined') {
-  globalThis.document = {
-    addEventListener: () => {}, removeEventListener: () => {},
-    createElement: () => _stubEl(),
-    createDocumentFragment: () => _stubEl(),
-    getElementById: () => null,
-    querySelector: () => null,
-    querySelectorAll: () => [],
-    body: _stubEl(),
-    head: _stubEl(),
-    documentElement: _stubEl(),
-    createTextNode: (t) => ({ textContent: t }),
-  };
-}
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-table-heatmap-empty.js
+++ b/tests/test-table-heatmap-empty.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-table-heatmap-empty.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');

--- a/tests/test-trend-alerts.js
+++ b/tests/test-trend-alerts.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-trend-alerts.js
+++ b/tests/test-trend-alerts.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-trend-alerts.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-unit-import.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -7,26 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
-if (typeof globalThis.addEventListener !== 'function') {
-  const _l = new Map();
-  globalThis.addEventListener = (t, f) => { (_l.get(t) || _l.set(t, new Set()).get(t)).add(f); };
-  globalThis.removeEventListener = (t, f) => { _l.get(t)?.delete(f); };
-  globalThis.dispatchEvent = (ev) => { const fns = _l.get(ev?.type); if (fns) for (const fn of fns) { try { fn(ev); } catch (e) { console.error(e); } } return true; };
-}
-if (typeof globalThis.CSS === 'undefined') globalThis.CSS = { escape: s => String(s).replace(/[^\w-]/g, c => '\\' + c) };
-function _stubEl() { return { style:{}, dataset:{}, classList:{add:()=>{},remove:()=>{},contains:()=>false,toggle:()=>{}}, appendChild:()=>{},removeChild:()=>{},replaceChild:()=>{},insertBefore:()=>{},remove:()=>{}, setAttribute:()=>{},getAttribute:()=>null,removeAttribute:()=>{}, addEventListener:()=>{},removeEventListener:()=>{}, querySelector:()=>null,querySelectorAll:()=>[], getBoundingClientRect:()=>({top:0,left:0,width:0,height:0,right:0,bottom:0}), focus:()=>{},blur:()=>{},click:()=>{}, children:[],childNodes:[], innerHTML:'',textContent:'',value:'', parentElement:null,parentNode:null }; }
-if (typeof globalThis.document === 'undefined') {
-  globalThis.document = { addEventListener:()=>{},removeEventListener:()=>{}, createElement:()=>_stubEl(),createDocumentFragment:()=>_stubEl(), getElementById:()=>null,querySelector:()=>null,querySelectorAll:()=>[], body:_stubEl(),head:_stubEl(),documentElement:_stubEl(), createTextNode:(t)=>({textContent:t}) };
-}
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const _isNode = typeof process !== 'undefined' && !!process.versions?.node;

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-v1-6-shipped.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const _isNode = typeof process !== 'undefined' && !!process.versions?.node;

--- a/tests/test-vendor-personal-info.js
+++ b/tests/test-vendor-personal-info.js
@@ -14,15 +14,7 @@
 //
 // Run: node tests/test-vendor-personal-info.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -7,15 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -3,11 +3,11 @@
 //
 // Run: node tests/test-venice-e2ee.js  (or via npm test)
 
+import './_node-shim.js';
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import './_node-shim.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');

--- a/tests/test-wearables-fetchers.js
+++ b/tests/test-wearables-fetchers.js
@@ -5,15 +5,7 @@
 //
 // Run: node tests/test-wearables-fetchers.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {

--- a/tests/test-wearables-runtime-config.js
+++ b/tests/test-wearables-runtime-config.js
@@ -8,15 +8,7 @@
 //
 // Run: node tests/test-wearables-runtime-config.js  (or via npm test)
 
-globalThis.window = globalThis.window || globalThis;
-function _ls() {
-  const s = new Map();
-  return { getItem: k => s.has(k) ? s.get(k) : null, setItem: (k, v) => s.set(k, String(v)),
-    removeItem: k => s.delete(k), clear: () => s.clear(),
-    get length() { return s.size; }, key: i => Array.from(s.keys())[i] ?? null };
-}
-if (typeof globalThis.localStorage === 'undefined') globalThis.localStorage = _ls();
-if (typeof globalThis.sessionStorage === 'undefined') globalThis.sessionStorage = _ls();
+import './_node-shim.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {


### PR DESCRIPTION
## Summary

- Extract the duplicated ~25-line shim block from every ported test into a single shared `tests/_node-shim.js`
- Each test goes from inline boilerplate to one line — `import './_node-shim.js';`
- Addresses the recurring Greptile P2 ("duplicated shim boilerplate across 30+ files") flagged since PR #199

## What changed

- **New**: `tests/_node-shim.js` (105 lines) — installs `window`, `localStorage`/`sessionStorage`, `addEventListener`/`removeEventListener`/`dispatchEvent`, `CSS.escape`, `navigator`, and a `document` stub via `_stubEl()`. All installs guarded by `typeof === 'undefined'`, so the module is idempotent and a no-op when the real browser globals (or `_vitest-setup.js`) already provided them.
- **Migrated**: 47 test files now use one-line side-effect import instead of inline shim. Net diff: **+152 / -655**.
- **Behavior**: unchanged. Standalone `node tests/foo.js` still works (the shim is required, not optional). Vitest still runs the legacy suite via `_vitest-legacy.test.js`. `_vitest-setup.js` is left in place as a near-superset (it also patches `process.exit`, which is Vitest-specific).

## How the migration was done

A Python script (`/tmp/migrate-shims.py`, not committed) walked each test file, found the contiguous shim region starting at `globalThis.window = ...`, and replaced it with the one-line import. Brace-depth tracking handled multi-line `function _stubEl()` and `if (typeof globalThis.document === 'undefined') { ... }` blocks; comment-only and blank lines were bridged when sandwiched between shim starters.

Spot-checked five shape variants (window-only / minimal / standard / plus-doc / table-heatmap's reordered shim) to confirm boundaries before bulk applying.

## Test plan

- [x] `npx vitest run tests/_vitest-legacy.test.js` — **60 tests, all green, 4.28s** (no regression vs main's 4.3s)
- [x] `node tests/test-marker-key-safety.js` (window-only shape) — green
- [x] `node tests/test-pii.js` (minimal shape) — green
- [x] `node tests/test-sun-defaults.js` (standard shape) — green
- [x] `node tests/test-recommendations.js` (plus-doc shape) — green
- [x] `node tests/test-table-heatmap-empty.js` (reordered-shim shape) — green
- [x] `node tests/test-multi-unit.js` (window-only standalone) — green
- [x] `./run-tests.sh` — full suite (Vitest + 39 remaining puppeteer + a11y axe) all passed

## Follow-ups (not in this PR)

- The other recurring Greptile P2 — residual 2-space indentation from IIFE-stripping in ported tests — is purely cosmetic and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)