### PR TITLE
Vitest batch 20: test-changelog (78 asserts split)

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -20,7 +20,10 @@ const TEST_FILES = [
   'tests/test-openrouter.js',
   'tests/test-tour.js',
   'tests/test-custom-personality.js',
-  'tests/test-changelog.js',
+  // test-changelog.js source-inspection + hasCardContent behavioral ported
+  // to Vitest (batch 20). DOM-runtime sections (modal open/close, forceShow
+  // behavior, inline-tag rendering) live in test-changelog-dom.js below.
+  'tests/test-changelog-dom.js',
   'tests/test-audit.js',
   // test-image-utils.js source-inspection + module-export checks ported to
   // Vitest (PR for batch 19). DOM-runtime assertions (sections 6 + 7) live

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -117,6 +117,9 @@ const LEGACY_TESTS = [
   // in the puppeteer runner).
   './test-dna-recommendations.js',
   './test-image-utils.js',
+  // Batch 20 — changelog modal source-inspection + hasCardContent
+  // (DOM-runtime sections in test-changelog-dom.js stay on puppeteer).
+  './test-changelog.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-changelog-dom.js
+++ b/tests/test-changelog-dom.js
@@ -1,0 +1,100 @@
+// test-changelog-dom.js — DOM-runtime assertions extracted from test-changelog.js.
+// Stays in the puppeteer runner because it needs a live browser DOM: real
+// modal elements, classList toggling, innerHTML inspection after openChangelog()
+// renders, and localStorage-backed forceShow behavior. The source-string +
+// hasCardContent behavioral tests live in test-changelog.js (Vitest).
+//
+// Run: fetch('tests/test-changelog-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Changelog DOM Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  // ═══════════════════════════════════════
+  // HTML modal DOM presence
+  // ═══════════════════════════════════════
+  console.log('%c HTML Modal in DOM ', 'font-weight:bold;color:#f59e0b');
+
+  const overlayEl = document.getElementById('changelog-modal-overlay');
+  const modalEl = document.getElementById('changelog-modal');
+  assert('changelog-modal-overlay in DOM', !!overlayEl);
+  assert('changelog-modal in DOM', !!modalEl);
+
+  // ═══════════════════════════════════════
+  // Open/close behavior
+  // ═══════════════════════════════════════
+  console.log('%c Open/Close Behavior ', 'font-weight:bold;color:#f59e0b');
+
+  window.openChangelog(true);
+  const ovAfterOpen = document.getElementById('changelog-modal-overlay');
+  assert('openChangelog adds show class', ovAfterOpen && ovAfterOpen.classList.contains('show'));
+  const modalContent = document.getElementById('changelog-modal');
+  assert('Modal has close button', modalContent && modalContent.innerHTML.includes('modal-close'));
+  assert("Modal has What's New heading", modalContent && modalContent.innerHTML.includes("What's New"));
+
+  window.closeChangelog();
+  const ovAfterClose = document.getElementById('changelog-modal-overlay');
+  assert('closeChangelog removes show class', ovAfterClose && !ovAfterClose.classList.contains('show'));
+  assert('closeChangelog marks version as seen', localStorage.getItem('labcharts-changelog-seen') !== null);
+
+  // ── forceShow behavioral: seen=1.7.0 must auto-open even when later
+  // non-forceShow patches have shipped on top of v1.7.1. ──
+  console.log('%c forceShow Behavior ', 'font-weight:bold;color:#f59e0b');
+
+  const _origSeen = localStorage.getItem('labcharts-changelog-seen');
+  try {
+    localStorage.setItem('labcharts-changelog-seen', '1.7.0');
+    ovAfterClose?.classList.remove('show');
+    window.maybeShowChangelog();
+    assert('maybeShowChangelog auto-opens when a forceShow entry is newer than seen',
+      ovAfterClose?.classList.contains('show') === true);
+    window.closeChangelog();
+    // Re-fire idempotency: after closeChangelog markChangelogSeen wrote the
+    // current APP_VERSION as seen, so no entry is newer → modal must NOT re-open.
+    window.maybeShowChangelog();
+    assert('maybeShowChangelog stays closed once user has seen the latest version',
+      ovAfterClose?.classList.contains('show') === false);
+    // No-forceShow-ahead defense: when seen is newer than every forceShow entry,
+    // modal must NOT auto-open even if other non-forceShow entries exist.
+    localStorage.setItem('labcharts-changelog-seen', window.APP_VERSION);
+    ovAfterClose?.classList.remove('show');
+    window.maybeShowChangelog();
+    assert('maybeShowChangelog stays closed when no forceShow entry is newer than seen',
+      ovAfterClose?.classList.contains('show') === false);
+  } finally {
+    if (_origSeen !== null) localStorage.setItem('labcharts-changelog-seen', _origSeen);
+    else localStorage.removeItem('labcharts-changelog-seen');
+  }
+
+  // ═══════════════════════════════════════
+  // Inline-tag whitelist (rendered output)
+  // ═══════════════════════════════════════
+  // Items use <b>/<i>/<em>/<strong>/<code> for emphasis. Verify the renderer
+  // both renders those AND keeps escaping anything else.
+  console.log('%c Inline-Tag Rendering ', 'font-weight:bold;color:#f59e0b');
+
+  window.openChangelog(true);
+  const tagModal = document.getElementById('changelog-modal');
+  const itemsHTML = tagModal?.innerHTML || '';
+  assert('changelog renders <b> as bold (not literal text)',
+    itemsHTML.includes('<b>') && !itemsHTML.includes('&lt;b&gt;'));
+  assert('expected bold span "Medical History" present',
+    /<b>The Medical Conditions card is now Medical History<\/b>/.test(itemsHTML));
+  assert('changelog renders <code> as code (not literal text)',
+    !itemsHTML.includes('&lt;code&gt;'));
+  assert('changelog renders safe https <a> as a real link',
+    /<a href="https:\/\/getbased\.health[^"]*" target="_blank" rel="noopener noreferrer">[^<]+<\/a>/.test(itemsHTML));
+  window.closeChangelog();
+
+  // Clean up
+  localStorage.removeItem('labcharts-changelog-seen');
+
+  console.log(`\n%c Changelog DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-changelog-dom'] = { pass, fail };
+})();

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -1,268 +1,207 @@
-// test-changelog.js — Verify What's New modal + hasCardContent auto-gating
-// Run: fetch('tests/test-changelog.js').then(r=>r.text()).then(s=>Function(s)())
+#!/usr/bin/env node
+// test-changelog.js — Changelog modal source structure + hasCardContent auto-gating.
+//
+// Run: node tests/test-changelog.js  (or via npm test)
+//
+// DOM-runtime assertions (modal open/close, classList toggling, innerHTML
+// rendering, forceShow behavior) live in tests/test-changelog-dom.js and
+// stay on the puppeteer runner — they need a real browser DOM.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-  }
+import './_node-shim.js';
 
-  console.log('%c What\'s New + Auto-Gating Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-  const changelogSrc = await fetchWithRetry('js/changelog.js');
-  const chatSrc = await fetchWithRetry('js/chat.js');
-  const utilsSrc = await fetchWithRetry('js/utils.js');
-  const mainSrc = await fetchWithRetry('js/main.js');
-  const settingsSrc = await fetchWithRetry('js/settings.js');
-  const swSrc = await fetchWithRetry('service-worker.js');
-  const indexSrc = await fetchWithRetry('/app');
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+function fetchWithRetry(rel) { return Promise.resolve(read(rel)); }
 
-  const versionSrc = await fetchWithRetry('version.js');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  // ═══════════════════════════════════════
-  // 1. changelog.js module structure
-  // ═══════════════════════════════════════
-  console.log('%c 1. Changelog Module Structure ', 'font-weight:bold;color:#f59e0b');
+console.log("=== What's New + Auto-Gating Tests ===\n");
 
-  assert('changelog.js uses window.APP_VERSION', changelogSrc.includes('window.APP_VERSION'));
-  assert('changelog.js has CHANGELOG array', changelogSrc.includes('const CHANGELOG'));
-  assert('changelog.js exports openChangelog', changelogSrc.includes('export function openChangelog'));
-  assert('changelog.js exports closeChangelog', changelogSrc.includes('export function closeChangelog'));
-  assert('changelog.js exports maybeShowChangelog', changelogSrc.includes('export function maybeShowChangelog'));
-  assert('changelog.js has getMajorMinor helper', changelogSrc.includes('function getMajorMinor'));
-  assert('maybeShowChangelog compares major.minor only', changelogSrc.includes('getMajorMinor(seen) !== getMajorMinor('));
-  // forceShow patch-bump escape hatch — when a maintainer flags an entry as
-  // critical (e.g. v1.7.1 "re-export your encrypted backup"), the modal
-  // must auto-fire even on a same-major.minor patch bump. Logic must scan
-  // ALL entries (not just CHANGELOG[0]) — otherwise a later non-forceShow
-  // patch silently shadows an earlier critical entry.
-  assert('changelog.js has _semverGt helper for forceShow gate',
-    /function\s+_semverGt\s*\(/.test(changelogSrc));
-  assert('maybeShowChangelog scans all entries for forceShow (not just [0])',
-    /CHANGELOG\.some\s*\(\s*e\s*=>\s*e[\s\S]{0,80}forceShow[\s\S]{0,80}_semverGt\(e\.version,\s*seen\)/.test(changelogSrc));
-  // The v1.7.1 entry itself must carry forceShow — its body asks users to
-  // re-export their encrypted backup. Lock this in so a future copy edit
-  // doesn't silently drop the flag and break the call-to-action.
-  assert("v1.7.1 entry carries forceShow: true",
-    /version:\s*'1\.7\.1'[\s\S]{0,400}forceShow:\s*true/.test(changelogSrc));
+// utils.js exposes hasCardContent via Object.assign(window, ...).
+// changelog.js exposes openChangelog / closeChangelog / maybeShowChangelog.
+await import('../js/state.js');
+await import('../js/utils.js');
+await import('../js/changelog.js');
 
-  // ═══════════════════════════════════════
-  // 2. Unified semver versioning
-  // ═══════════════════════════════════════
-  console.log('%c 2. Unified Semver Versioning ', 'font-weight:bold;color:#f59e0b');
+const changelogSrc = await fetchWithRetry('js/changelog.js');
+const chatSrc = await fetchWithRetry('js/chat.js');
+const utilsSrc = await fetchWithRetry('js/utils.js');
+const mainSrc = await fetchWithRetry('js/main.js');
+const settingsSrc = await fetchWithRetry('js/settings.js');
+const swSrc = await fetchWithRetry('service-worker.js');
+// Original test fetched '/app' (dev-server alias for index.html); read
+// index.html directly in Node.
+const indexSrc = await fetchWithRetry('index.html');
+const versionSrc = await fetchWithRetry('version.js');
 
-  const versionMatch = versionSrc.match(/APP_VERSION\s*=\s*'([^']+)'/);
-  assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${versionMatch[1]}'` : 'not found');
-  assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
-  assert('SW imports version.js', swSrc.includes("importScripts('/version.js')"));
-  assert('SW CACHE_NAME uses template literal', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
-  assert('SW APP_SHELL includes version.js', swSrc.includes("'/version.js'"));
-  assert('index.html loads version.js', indexSrc.includes('src="version.js"'));
+// ═══════════════════════════════════════
+// 1. changelog.js module structure
+// ═══════════════════════════════════════
+console.log('1. Changelog Module Structure');
 
-  // ═══════════════════════════════════════
-  // 3. HTML: changelog modal exists
-  // ═══════════════════════════════════════
-  console.log('%c 3. HTML Modal Structure ', 'font-weight:bold;color:#f59e0b');
+assert('changelog.js uses window.APP_VERSION', changelogSrc.includes('window.APP_VERSION'));
+assert('changelog.js has CHANGELOG array', changelogSrc.includes('const CHANGELOG'));
+assert('changelog.js exports openChangelog', changelogSrc.includes('export function openChangelog'));
+assert('changelog.js exports closeChangelog', changelogSrc.includes('export function closeChangelog'));
+assert('changelog.js exports maybeShowChangelog', changelogSrc.includes('export function maybeShowChangelog'));
+assert('changelog.js has getMajorMinor helper', changelogSrc.includes('function getMajorMinor'));
+assert('maybeShowChangelog compares major.minor only', changelogSrc.includes('getMajorMinor(seen) !== getMajorMinor('));
+// forceShow patch-bump escape hatch — when a maintainer flags an entry as
+// critical (e.g. v1.7.1 "re-export your encrypted backup"), the modal
+// must auto-fire even on a same-major.minor patch bump. Logic must scan
+// ALL entries (not just CHANGELOG[0]) — otherwise a later non-forceShow
+// patch silently shadows an earlier critical entry.
+assert('changelog.js has _semverGt helper for forceShow gate',
+  /function\s+_semverGt\s*\(/.test(changelogSrc));
+assert('maybeShowChangelog scans all entries for forceShow (not just [0])',
+  /CHANGELOG\.some\s*\(\s*e\s*=>\s*e[\s\S]{0,80}forceShow[\s\S]{0,80}_semverGt\(e\.version,\s*seen\)/.test(changelogSrc));
+// The v1.7.1 entry itself must carry forceShow — its body asks users to
+// re-export their encrypted backup. Lock this in so a future copy edit
+// doesn't silently drop the flag and break the call-to-action.
+assert("v1.7.1 entry carries forceShow: true",
+  /version:\s*'1\.7\.1'[\s\S]{0,400}forceShow:\s*true/.test(changelogSrc));
 
-  assert('changelog-modal-overlay exists in HTML', indexSrc.includes('id="changelog-modal-overlay"'));
-  assert('changelog-modal exists in HTML', indexSrc.includes('id="changelog-modal"'));
-  assert('changelog modal has role=dialog', indexSrc.includes('changelog-modal') && indexSrc.includes('role="dialog"'));
-  assert('changelog modal has aria-label', indexSrc.includes('aria-label="What\'s New"'));
+// ═══════════════════════════════════════
+// 2. Unified semver versioning
+// ═══════════════════════════════════════
+console.log('2. Unified Semver Versioning');
 
-  const overlayEl = document.getElementById('changelog-modal-overlay');
-  const modalEl = document.getElementById('changelog-modal');
-  assert('changelog-modal-overlay in DOM', !!overlayEl);
-  assert('changelog-modal in DOM', !!modalEl);
+const versionMatch = versionSrc.match(/APP_VERSION\s*=\s*'([^']+)'/);
+assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${versionMatch[1]}'` : 'not found');
+assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
+assert('SW imports version.js', swSrc.includes("importScripts('/version.js')"));
+assert('SW CACHE_NAME uses template literal', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
+assert('SW APP_SHELL includes version.js', swSrc.includes("'/version.js'"));
+assert('index.html loads version.js', indexSrc.includes('src="version.js"'));
 
-  // ═══════════════════════════════════════
-  // 4. main.js wiring
-  // ═══════════════════════════════════════
-  console.log('%c 4. main.js Wiring ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 3. HTML: changelog modal exists in source
+// ═══════════════════════════════════════
+// (Source-string checks here. The live-DOM verification — that the
+// elements are actually present after page load — runs in
+// test-changelog-dom.js on the puppeteer side.)
+console.log('3. HTML Modal Structure');
 
-  assert('main.js imports maybeShowChangelog', mainSrc.includes("import { maybeShowChangelog } from './changelog.js'"));
-  assert('main.js calls maybeShowChangelog', mainSrc.includes('maybeShowChangelog()'));
-  assert('main.js has changelog overlay click handler', mainSrc.includes('changelog-modal-overlay') && mainSrc.includes('closeChangelog'));
-  assert('main.js has changelog Escape handler', mainSrc.includes('changelogOverlay'));
-  assert('main.js focus trap includes changelog', mainSrc.includes('"changelog-modal-overlay"'));
+assert('changelog-modal-overlay defined in index.html', indexSrc.includes('id="changelog-modal-overlay"'));
+assert('changelog-modal defined in index.html', indexSrc.includes('id="changelog-modal"'));
+assert('changelog modal has role=dialog', indexSrc.includes('changelog-modal') && indexSrc.includes('role="dialog"'));
+assert('changelog modal has aria-label', indexSrc.includes('aria-label="What\'s New"'));
 
-  // ═══════════════════════════════════════
-  // 5. Settings: What's New button
-  // ═══════════════════════════════════════
-  console.log('%c 5. Settings Integration ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 4. main.js wiring
+// ═══════════════════════════════════════
+console.log('4. main.js Wiring');
 
-  assert('Settings references openChangelog', settingsSrc.includes('openChangelog'));
-  assert('Settings has What\'s New button', settingsSrc.includes("What's New"));
+assert('main.js imports maybeShowChangelog', mainSrc.includes("import { maybeShowChangelog } from './changelog.js'"));
+assert('main.js calls maybeShowChangelog', mainSrc.includes('maybeShowChangelog()'));
+assert('main.js has changelog overlay click handler', mainSrc.includes('changelog-modal-overlay') && mainSrc.includes('closeChangelog'));
+assert('main.js has changelog Escape handler', mainSrc.includes('changelogOverlay'));
+assert('main.js focus trap includes changelog', mainSrc.includes('"changelog-modal-overlay"'));
 
-  // ═══════════════════════════════════════
-  // 6. hasCardContent utility
-  // ═══════════════════════════════════════
-  console.log('%c 6. hasCardContent Utility ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 5. Settings: What's New button
+// ═══════════════════════════════════════
+console.log('5. Settings Integration');
 
-  assert('hasCardContent exported from utils.js', utilsSrc.includes('export function hasCardContent'));
-  assert('hasCardContent on window', typeof window.hasCardContent === 'function');
+assert('Settings references openChangelog', settingsSrc.includes('openChangelog'));
+assert("Settings has What's New button", settingsSrc.includes("What's New"));
 
-  // Behavioral tests
-  if (typeof window.hasCardContent === 'function') {
-    const hcc = window.hasCardContent;
-    assert('hasCardContent(null) => false', hcc(null) === false);
-    assert('hasCardContent(undefined) => false', hcc(undefined) === false);
-    assert('hasCardContent({}) => false', hcc({}) === false);
-    assert('hasCardContent({note: ""}) => false', hcc({ note: '' }) === false);
-    assert('hasCardContent({note: "  "}) => false', hcc({ note: '  ' }) === false);
-    assert('hasCardContent({note: "hi"}) => true', hcc({ note: 'hi' }) === true);
-    assert('hasCardContent({type: ""}) => false', hcc({ type: '' }) === false);
-    assert('hasCardContent({type: null}) => false', hcc({ type: null }) === false);
-    assert('hasCardContent({type: "vegan"}) => true', hcc({ type: 'vegan' }) === true);
-    assert('hasCardContent({items: []}) => false', hcc({ items: [] }) === false);
-    assert('hasCardContent({items: ["x"]}) => true', hcc({ items: ['x'] }) === true);
-    assert('hasCardContent({a: null, b: "", note: ""}) => false', hcc({ a: null, b: '', note: '' }) === false);
-    assert('hasCardContent({a: null, b: "val"}) => true', hcc({ a: null, b: 'val' }) === true);
-  }
+// ═══════════════════════════════════════
+// 6. hasCardContent utility
+// ═══════════════════════════════════════
+console.log('6. hasCardContent Utility');
 
-  // ═══════════════════════════════════════
-  // 7. lab-context.js uses hasCardContent for 7 gates
-  // ═══════════════════════════════════════
-  console.log('%c 7. Auto-Gating in lab-context.js ', 'font-weight:bold;color:#f59e0b');
+assert('hasCardContent exported from utils.js', utilsSrc.includes('export function hasCardContent'));
+assert('hasCardContent on window', typeof window.hasCardContent === 'function');
 
-  const labCtxSrc = await fetchWithRetry('js/lab-context.js');
-  const hccMatches = (labCtxSrc.match(/hasCardContent\(/g) || []).length;
-  assert('lab-context.js has 7+ hasCardContent calls', hccMatches >= 7, `found ${hccMatches}`);
-  assert('lab-context.js imports hasCardContent', labCtxSrc.includes('hasCardContent'));
-  assert('Diagnoses gate: hasCardContent(diag)', labCtxSrc.includes('hasCardContent(diag)'));
-  assert('Diet gate: hasCardContent(diet)', labCtxSrc.includes('hasCardContent(diet)'));
-  assert('Exercise gate: hasCardContent(ex)', labCtxSrc.includes('hasCardContent(ex)'));
-  assert('Sleep gate: hasCardContent(sl)', labCtxSrc.includes('hasCardContent(sl)'));
-  assert('Stress gate: hasCardContent(st)', labCtxSrc.includes('hasCardContent(st)'));
-  assert('LoveLife gate: hasCardContent(ll)', labCtxSrc.includes('hasCardContent(ll)'));
-  assert('Environment gate: hasCardContent(env)', labCtxSrc.includes('hasCardContent(env)'));
+// Behavioral tests — pure-logic, run anywhere.
+const hcc = window.hasCardContent;
+assert('hasCardContent(null) => false', hcc(null) === false);
+assert('hasCardContent(undefined) => false', hcc(undefined) === false);
+assert('hasCardContent({}) => false', hcc({}) === false);
+assert('hasCardContent({note: ""}) => false', hcc({ note: '' }) === false);
+assert('hasCardContent({note: "  "}) => false', hcc({ note: '  ' }) === false);
+assert('hasCardContent({note: "hi"}) => true', hcc({ note: 'hi' }) === true);
+assert('hasCardContent({type: ""}) => false', hcc({ type: '' }) === false);
+assert('hasCardContent({type: null}) => false', hcc({ type: null }) === false);
+assert('hasCardContent({type: "vegan"}) => true', hcc({ type: 'vegan' }) === true);
+assert('hasCardContent({items: []}) => false', hcc({ items: [] }) === false);
+assert('hasCardContent({items: ["x"]}) => true', hcc({ items: ['x'] }) === true);
+assert('hasCardContent({a: null, b: "", note: ""}) => false', hcc({ a: null, b: '', note: '' }) === false);
+assert('hasCardContent({a: null, b: "val"}) => true', hcc({ a: null, b: 'val' }) === true);
 
-  // ═══════════════════════════════════════
-  // 8. Light & Circadian still uses custom gate
-  // ═══════════════════════════════════════
-  console.log('%c 8. Custom Gates Preserved ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 7. lab-context.js uses hasCardContent for 7 gates
+// ═══════════════════════════════════════
+console.log('7. Auto-Gating in lab-context.js');
 
-  assert('Light & Circadian uses lc || autoLat', labCtxSrc.includes('lc || autoLat'));
-  assert('No hasCardContent(lc)', !labCtxSrc.includes('hasCardContent(lc)'));
+const labCtxSrc = await fetchWithRetry('js/lab-context.js');
+const hccMatches = (labCtxSrc.match(/hasCardContent\(/g) || []).length;
+assert('lab-context.js has 7+ hasCardContent calls', hccMatches >= 7, `found ${hccMatches}`);
+assert('lab-context.js imports hasCardContent', labCtxSrc.includes('hasCardContent'));
+assert('Diagnoses gate: hasCardContent(diag)', labCtxSrc.includes('hasCardContent(diag)'));
+assert('Diet gate: hasCardContent(diet)', labCtxSrc.includes('hasCardContent(diet)'));
+assert('Exercise gate: hasCardContent(ex)', labCtxSrc.includes('hasCardContent(ex)'));
+assert('Sleep gate: hasCardContent(sl)', labCtxSrc.includes('hasCardContent(sl)'));
+assert('Stress gate: hasCardContent(st)', labCtxSrc.includes('hasCardContent(st)'));
+assert('LoveLife gate: hasCardContent(ll)', labCtxSrc.includes('hasCardContent(ll)'));
+assert('Environment gate: hasCardContent(env)', labCtxSrc.includes('hasCardContent(env)'));
 
-  // ═══════════════════════════════════════
-  // 9. SW includes changelog.js
-  // ═══════════════════════════════════════
-  console.log('%c 9. Service Worker ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 8. Light & Circadian still uses custom gate
+// ═══════════════════════════════════════
+console.log('8. Custom Gates Preserved');
 
-  assert('APP_SHELL includes /js/changelog.js', swSrc.includes('/js/changelog.js'));
+assert('Light & Circadian uses lc || autoLat', labCtxSrc.includes('lc || autoLat'));
+assert('No hasCardContent(lc)', !labCtxSrc.includes('hasCardContent(lc)'));
 
-  // ═══════════════════════════════════════
-  // 10. Changelog data integrity
-  // ═══════════════════════════════════════
-  console.log('%c 10. Changelog Data ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 9. SW includes changelog.js
+// ═══════════════════════════════════════
+console.log('9. Service Worker');
 
-  assert('CHANGELOG has version field', changelogSrc.includes('version:'));
-  assert('CHANGELOG has date field', changelogSrc.includes('date:'));
-  assert('CHANGELOG has title field', changelogSrc.includes('title:'));
-  assert('CHANGELOG has items array', changelogSrc.includes('items:'));
+assert('APP_SHELL includes /js/changelog.js', swSrc.includes('/js/changelog.js'));
 
-  // ═══════════════════════════════════════
-  // 11. Window exports
-  // ═══════════════════════════════════════
-  console.log('%c 11. Window Exports ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 10. Changelog data integrity
+// ═══════════════════════════════════════
+console.log('10. Changelog Data');
 
-  assert('closeChangelog on window', typeof window.closeChangelog === 'function');
-  assert('openChangelog on window', typeof window.openChangelog === 'function');
-  assert('maybeShowChangelog on window', typeof window.maybeShowChangelog === 'function');
+assert('CHANGELOG has version field', changelogSrc.includes('version:'));
+assert('CHANGELOG has date field', changelogSrc.includes('date:'));
+assert('CHANGELOG has title field', changelogSrc.includes('title:'));
+assert('CHANGELOG has items array', changelogSrc.includes('items:'));
 
-  // ═══════════════════════════════════════
-  // 12. Open/close behavior
-  // ═══════════════════════════════════════
-  console.log('%c 12. Open/Close Behavior ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 11. Window exports
+// ═══════════════════════════════════════
+console.log('11. Window Exports');
 
-  // Test open
-  window.openChangelog(true);
-  const ovAfterOpen = document.getElementById('changelog-modal-overlay');
-  assert('openChangelog adds show class', ovAfterOpen && ovAfterOpen.classList.contains('show'));
-  const modalContent = document.getElementById('changelog-modal');
-  assert('Modal has close button', modalContent && modalContent.innerHTML.includes('modal-close'));
-  assert('Modal has What\'s New heading', modalContent && modalContent.innerHTML.includes("What's New"));
+assert('closeChangelog on window', typeof window.closeChangelog === 'function');
+assert('openChangelog on window', typeof window.openChangelog === 'function');
+assert('maybeShowChangelog on window', typeof window.maybeShowChangelog === 'function');
 
-  // Test close
-  window.closeChangelog();
-  const ovAfterClose = document.getElementById('changelog-modal-overlay');
-  assert('closeChangelog removes show class', ovAfterClose && !ovAfterClose.classList.contains('show'));
-  assert('closeChangelog marks version as seen', localStorage.getItem('labcharts-changelog-seen') !== null);
+// ═══════════════════════════════════════
+// 12. Source-code regex defenses (inline-tag whitelist + href safety)
+// ═══════════════════════════════════════
+// Live-DOM verification of the rendered output lives in test-changelog-dom.js;
+// here we lock in the source-code regex that enforces the whitelist.
+console.log('12. Renderer Source-Code Defenses');
 
-  // ── forceShow behavioral: seen=1.7.0 must auto-open even when later
-  // non-forceShow patches have shipped on top of v1.7.1. Otherwise a
-  // routine later patch shadows the critical "re-export your backup"
-  // notice from v1.7.1. ──
-  const _origSeen = localStorage.getItem('labcharts-changelog-seen');
-  try {
-    localStorage.setItem('labcharts-changelog-seen', '1.7.0');
-    // Prove overlay starts hidden
-    ovAfterClose?.classList.remove('show');
-    window.maybeShowChangelog();
-    assert('maybeShowChangelog auto-opens when a forceShow entry is newer than seen',
-      ovAfterClose?.classList.contains('show') === true);
-    window.closeChangelog();
-    // Re-fire idempotency: after closeChangelog markChangelogSeen wrote the
-    // current APP_VERSION as seen, so no entry is newer → modal must NOT
-    // re-open on subsequent maybeShowChangelog calls.
-    window.maybeShowChangelog();
-    assert('maybeShowChangelog stays closed once user has seen the latest version',
-      ovAfterClose?.classList.contains('show') === false);
-    // No-forceShow-ahead defense: when seen is newer than every forceShow
-    // entry in CHANGELOG (so no critical user-action notice is pending), the
-    // modal must NOT auto-open even if other non-forceShow entries exist.
-    // Easiest way to guarantee that without parsing the changelog source: set
-    // seen = current APP_VERSION. No entry is newer, so no forceShow is newer.
-    // This survives future bumps where any new patch ships as forceShow.
-    localStorage.setItem('labcharts-changelog-seen', window.APP_VERSION);
-    ovAfterClose?.classList.remove('show');
-    window.maybeShowChangelog();
-    assert('maybeShowChangelog stays closed when no forceShow entry is newer than seen',
-      ovAfterClose?.classList.contains('show') === false);
-  } finally {
-    if (_origSeen !== null) localStorage.setItem('labcharts-changelog-seen', _origSeen);
-    else localStorage.removeItem('labcharts-changelog-seen');
-  }
+assert('renderChangelogItem inline-tag whitelist limited to b/i/em/strong/code',
+  /\(b\|i\|em\|strong\|code\)/.test(changelogSrc));
+assert('renderChangelogItem rejects non-http(s)/mailto hrefs',
+  /\^\(https\?:\|mailto:\)/.test(changelogSrc));
+assert('renderChangelogItem adds target="_blank" rel="noopener noreferrer" to external links',
+  /target="_blank" rel="noopener noreferrer"/.test(changelogSrc));
 
-  // ═══════════════════════════════════════
-  // Inline-tag whitelist in changelog items
-  // ═══════════════════════════════════════
-  // Items use <b>/<i>/<em>/<strong>/<code> for emphasis. Verify the renderer
-  // both renders those AND keeps escaping anything else.
-  window.openChangelog(true);
-  const tagModal = document.getElementById('changelog-modal');
-  const itemsHTML = tagModal?.innerHTML || '';
-  assert('changelog renders <b> as bold (not literal text)',
-    itemsHTML.includes('<b>') && !itemsHTML.includes('&lt;b&gt;'));
-  // Sanity that <b> rendering works on a known current-changelog bullet.
-  assert('expected bold span "Medical History" present',
-    /<b>The Medical Conditions card is now Medical History<\/b>/.test(itemsHTML));
-  assert('changelog renders <code> as code (not literal text)',
-    !itemsHTML.includes('&lt;code&gt;'));
-  // Defense: source-code regex limits the inline-tag whitelist. A wildcard
-  // or a direct innerHTML on the raw item would be a security regression.
-  const renderSrc = await fetch('js/changelog.js').then(r => r.text());
-  assert('renderChangelogItem inline-tag whitelist limited to b/i/em/strong/code',
-    /\(b\|i\|em\|strong\|code\)/.test(renderSrc));
-  // Anchor tags also pass through with safe-protocol enforcement. Inject a
-  // few synthetic items into the live module via window.CHANGELOG isn't
-  // safe (module-private const) — instead drive the renderer indirectly
-  // via the whitelisted v1.3.0 entry which carries an https://getbased link.
-  assert('changelog renders safe https <a> as a real link',
-    /<a href="https:\/\/getbased\.health[^"]*" target="_blank" rel="noopener noreferrer">[^<]+<\/a>/.test(itemsHTML));
-  // Source-code regex defenses: protocol allowlist + target/rel.
-  assert('renderChangelogItem rejects non-http(s)/mailto hrefs',
-    /\^\(https\?:\|mailto:\)/.test(renderSrc));
-  assert('renderChangelogItem adds target="_blank" rel="noopener noreferrer" to external links',
-    /target="_blank" rel="noopener noreferrer"/.test(renderSrc));
-  window.closeChangelog();
-
-  // Clean up
-  localStorage.removeItem('labcharts-changelog-seen');
-
-  // ═══════════════════════════════════════
-  // Results
-  // ═══════════════════════════════════════
-  console.log(`\n%c Results: ${pass} passed, ${fail} failed `, `background:${fail?'#ef4444':'#22c55e'};color:#fff;font-size:14px;padding:4px 12px;border-radius:4px`);
-})();
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -32,7 +32,6 @@ await import('../js/utils.js');
 await import('../js/changelog.js');
 
 const changelogSrc = await fetchWithRetry('js/changelog.js');
-const chatSrc = await fetchWithRetry('js/chat.js');
 const utilsSrc = await fetchWithRetry('js/utils.js');
 const mainSrc = await fetchWithRetry('js/main.js');
 const settingsSrc = await fetchWithRetry('js/settings.js');
@@ -122,21 +121,27 @@ console.log('6. hasCardContent Utility');
 assert('hasCardContent exported from utils.js', utilsSrc.includes('export function hasCardContent'));
 assert('hasCardContent on window', typeof window.hasCardContent === 'function');
 
-// Behavioral tests — pure-logic, run anywhere.
+// Behavioral tests — pure-logic, run anywhere. Guard the call site so
+// that if `hasCardContent` ever fails to attach to window the rest of
+// the file still runs (the existence assertion above already records
+// the failure — without the guard, hcc(null) throws TypeError and
+// sections 7–12 silently skip).
 const hcc = window.hasCardContent;
-assert('hasCardContent(null) => false', hcc(null) === false);
-assert('hasCardContent(undefined) => false', hcc(undefined) === false);
-assert('hasCardContent({}) => false', hcc({}) === false);
-assert('hasCardContent({note: ""}) => false', hcc({ note: '' }) === false);
-assert('hasCardContent({note: "  "}) => false', hcc({ note: '  ' }) === false);
-assert('hasCardContent({note: "hi"}) => true', hcc({ note: 'hi' }) === true);
-assert('hasCardContent({type: ""}) => false', hcc({ type: '' }) === false);
-assert('hasCardContent({type: null}) => false', hcc({ type: null }) === false);
-assert('hasCardContent({type: "vegan"}) => true', hcc({ type: 'vegan' }) === true);
-assert('hasCardContent({items: []}) => false', hcc({ items: [] }) === false);
-assert('hasCardContent({items: ["x"]}) => true', hcc({ items: ['x'] }) === true);
-assert('hasCardContent({a: null, b: "", note: ""}) => false', hcc({ a: null, b: '', note: '' }) === false);
-assert('hasCardContent({a: null, b: "val"}) => true', hcc({ a: null, b: 'val' }) === true);
+if (typeof hcc === 'function') {
+  assert('hasCardContent(null) => false', hcc(null) === false);
+  assert('hasCardContent(undefined) => false', hcc(undefined) === false);
+  assert('hasCardContent({}) => false', hcc({}) === false);
+  assert('hasCardContent({note: ""}) => false', hcc({ note: '' }) === false);
+  assert('hasCardContent({note: "  "}) => false', hcc({ note: '  ' }) === false);
+  assert('hasCardContent({note: "hi"}) => true', hcc({ note: 'hi' }) === true);
+  assert('hasCardContent({type: ""}) => false', hcc({ type: '' }) === false);
+  assert('hasCardContent({type: null}) => false', hcc({ type: null }) === false);
+  assert('hasCardContent({type: "vegan"}) => true', hcc({ type: 'vegan' }) === true);
+  assert('hasCardContent({items: []}) => false', hcc({ items: [] }) === false);
+  assert('hasCardContent({items: ["x"]}) => true', hcc({ items: ['x'] }) === true);
+  assert('hasCardContent({a: null, b: "", note: ""}) => false', hcc({ a: null, b: '', note: '' }) === false);
+  assert('hasCardContent({a: null, b: "val"}) => true', hcc({ a: null, b: 'val' }) === true);
+}
 
 // ═══════════════════════════════════════
 // 7. lab-context.js uses hasCardContent for 7 gates


### PR DESCRIPTION
## Summary

Single port off the puppeteer runner via the same Vitest+DOM-split pattern from batch 19:

- **`test-changelog.js`** (64 asserts) → Vitest. Source-inspection of changelog.js / utils.js / main.js / settings.js / service-worker.js / version.js / lab-context.js / index.html, plus the **hasCardContent() 13 behavioral cases** and the **renderChangelogItem source-code regex defenses** (inline-tag whitelist + href safety).
- **`test-changelog-dom.js`** (14 asserts, new) → puppeteer. Live-DOM only: modal-overlay / -content presence, openChangelog/closeChangelog classList toggling, **forceShow behavioral** (seen=1.7.0 must auto-open even when later non-forceShow patches have shipped on top), and rendered inline-tag inspection (`<b>`, `<code>`, safe-https `<a>`).

## Pattern (carry-over from batches 18 + 19)

- `import './_node-shim.js';` as the first import (no inline shim block)
- `fetch('/app')` → `fs.readFileSync('index.html')` since the dev-server aliases `/app` to `index.html`
- The puppeteer-side file is IIFE-shaped (`return (async function() { ... })()`) — same shape `test-image-utils-dom.js` and `test-all-sessions-modal.js` use.

## Tests skipped this batch

- `test-coverage-stragglers.js` — img.onerror / mammoth DOCX / canvas error paths only fire in a real browser. Worth its own jsdom-backed batch later.
- `test-family-history.js` — heavy DOM mutation (createElement + appendChild + dispatchEvent) plus modal innerHTML round-tripping. Same jsdom-or-skip dependency.

## Test plan

- [x] `node tests/test-changelog.js` — **64/64** standalone
- [x] `npx vitest run tests/_vitest-legacy.test.js` — **63 tests / 4.22s** (was 62 / 4.05s)
- [x] `./run-tests.sh` — full suite green; `test-changelog-dom.js` ran in puppeteer (14/14)

## Numbers after this PR

- **Vitest**: 63 tests (was 62)
- **Puppeteer remaining**: 37 (was 38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)