### PR TITLE
Vitest batch 21: test-openrouter (134 asserts split)

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -17,7 +17,11 @@ const TEST_FILES = [
   'tests/test-chat-threads.js',
   'tests/test-chat-actions.js',
   'tests/test-mobile.js',
-  'tests/test-openrouter.js',
+  // test-openrouter.js source-inspection + behavioral ported to Vitest
+  // (batch 21). DOM-runtime section (Settings modal openSettingsModal,
+  // querySelectorAll on rendered provider cards) lives in
+  // test-openrouter-dom.js below.
+  'tests/test-openrouter-dom.js',
   'tests/test-tour.js',
   'tests/test-custom-personality.js',
   // test-changelog.js source-inspection + hasCardContent behavioral ported

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -120,6 +120,9 @@ const LEGACY_TESTS = [
   // Batch 20 — changelog modal source-inspection + hasCardContent
   // (DOM-runtime sections in test-changelog-dom.js stay on puppeteer).
   './test-changelog.js',
+  // Batch 21 — OpenRouter integration source-inspection + behavioral
+  // (DOM section in test-openrouter-dom.js stays on puppeteer).
+  './test-openrouter.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-openrouter-dom.js
+++ b/tests/test-openrouter-dom.js
@@ -1,0 +1,48 @@
+// test-openrouter-dom.js — Settings-modal DOM assertions extracted from
+// test-openrouter.js's section 10. Stays in the puppeteer runner because
+// it needs a live DOM: openSettingsModal renders cards, querySelectorAll
+// + getElementById run against real elements. Source-string + behavioral
+// checks (everything else from test-openrouter.js) live in Vitest.
+//
+// Run: fetch('tests/test-openrouter-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c OpenRouter Settings-Modal DOM Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  // Provider panel cards rendered by Settings modal.
+  const oldProvider = localStorage.getItem('labcharts-ai-provider');
+  window.openSettingsModal('ai');
+  await new Promise(r => setTimeout(r, 100));
+
+  const providerBtns = document.querySelectorAll('.ai-provider-btn');
+  assert('6 provider buttons in settings', providerBtns.length === 6, `found ${providerBtns.length}`);
+  const providerValues = Array.from(providerBtns).map(b => b.dataset.provider);
+  assert('provider buttons include ppq', providerValues.includes('ppq'));
+  assert('provider buttons include routstr', providerValues.includes('routstr'));
+  assert('provider buttons include venice', providerValues.includes('venice'));
+  assert('provider buttons include ollama', providerValues.includes('ollama'));
+  assert('provider buttons include openrouter', providerValues.includes('openrouter'));
+  assert('button order: OpenRouter before Venice',
+    providerValues.indexOf('openrouter') < providerValues.indexOf('venice'),
+    `openrouter@${providerValues.indexOf('openrouter')}, venice@${providerValues.indexOf('venice')}`);
+
+  window.switchAIProvider('openrouter');
+  await new Promise(r => setTimeout(r, 100));
+  assert('openrouter-key-input exists in DOM', !!document.getElementById('openrouter-key-input'));
+  assert('openrouter-key-status exists in DOM', !!document.getElementById('openrouter-key-status'));
+  assert('openrouter-model-area exists in DOM', !!document.getElementById('openrouter-model-area'));
+  assert('save-openrouter-key-btn exists in DOM', !!document.getElementById('save-openrouter-key-btn'));
+
+  if (oldProvider) window.setAIProvider(oldProvider);
+  window.closeSettingsModal();
+
+  console.log(`\n%c OpenRouter DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-openrouter-dom'] = { pass, fail };
+})();

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -17,7 +17,6 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
-function fetchWithRetry(rel) { return Promise.resolve(read(rel)); }
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -34,7 +33,7 @@ await import('../js/provider-panels.js');
 
 // ─── 1. api.js source inspection ───
 console.log('1. api.js source inspection');
-const apiSrc = await fetchWithRetry('js/api.js');
+const apiSrc = read('js/api.js');
 assert('getOpenRouterKey exists', apiSrc.includes('function getOpenRouterKey()'));
 assert('saveOpenRouterKey exists', apiSrc.includes('function saveOpenRouterKey('));
 assert('hasOpenRouterKey exists', apiSrc.includes('function hasOpenRouterKey()'));
@@ -50,13 +49,17 @@ assert('hasAIProvider handles openrouter', apiSrc.includes("provider === 'openro
 assert('callClaudeAPI handles openrouter', apiSrc.includes("provider === 'openrouter') return callOpenRouterAPI("));
 assert('callOpenRouterAPI sends HTTP-Referer', apiSrc.includes("'HTTP-Referer'"));
 assert('callOpenRouterAPI sends X-Title', apiSrc.includes("'X-Title': 'getbased'"));
-assert('OpenRouter default model is claude-sonnet-4-6', apiSrc.includes("'anthropic/claude-sonnet-4-6'"));
+// api.js carries the hyphenated 'anthropic/claude-sonnet-4-6' string as the
+// legacy-ID it migrates FROM — getOpenRouterModel() rewrites it to the dotted
+// canonical 'anthropic/claude-sonnet-4.6' (verified by the section-8 default
+// assertion). This checks the legacy-migration source string is still present.
+assert('api.js still references legacy hyphenated ID for migration', apiSrc.includes("'anthropic/claude-sonnet-4-6'"));
 assert('OpenRouter API endpoint', apiSrc.includes('openrouter.ai/api/v1/chat/completions'));
 assert('OpenRouter models endpoint', apiSrc.includes('openrouter.ai/api/v1/models'));
 
 // ─── 2. schema.js + api.js: curated models + dynamic pricing ───
 console.log('\n2. Curated models + dynamic pricing');
-const schemaSrc = await fetchWithRetry('js/schema.js');
+const schemaSrc = read('js/schema.js');
 assert('MODEL_PRICING has openrouter block', schemaSrc.includes('openrouter:'));
 assert('Has openrouter _default fallback', schemaSrc.includes("'_default':") && schemaSrc.includes('approx: true'));
 assert('getModelPricing checks openrouter-pricing cache', schemaSrc.includes('labcharts-openrouter-pricing'));
@@ -92,7 +95,7 @@ else localStorage.removeItem('labcharts-openrouter-pricing');
 
 // ─── 3. provider-panels.js source inspection (extracted from settings.js) ───
 console.log('\n3. provider-panels.js source inspection');
-const ppSrc = await fetchWithRetry('js/provider-panels.js');
+const ppSrc = read('js/provider-panels.js');
 assert('imports getOpenRouterKey', ppSrc.includes('getOpenRouterKey'));
 assert('imports saveOpenRouterKey', ppSrc.includes('saveOpenRouterKey'));
 assert('imports getOpenRouterModel', ppSrc.includes('getOpenRouterModel'));
@@ -100,7 +103,7 @@ assert('imports setOpenRouterModel', ppSrc.includes('setOpenRouterModel'));
 assert('imports getOpenRouterModelDisplay', ppSrc.includes('getOpenRouterModelDisplay'));
 assert('imports validateOpenRouterKey', ppSrc.includes('validateOpenRouterKey'));
 assert('imports fetchOpenRouterModels', ppSrc.includes('fetchOpenRouterModels'));
-const settingsSrc = await fetchWithRetry('js/settings.js');
+const settingsSrc = read('js/settings.js');
 assert('provider button with data-provider="openrouter"', settingsSrc.includes('data-provider="openrouter"'));
 assert("switchAIProvider('openrouter') in onclick", settingsSrc.includes("switchAIProvider('openrouter')"));
 assert('renderAIProviderPanel handles openrouter', ppSrc.includes("provider === 'openrouter'"));
@@ -123,12 +126,12 @@ assert('window exports updateOpenRouterModelPricing', ppSrc.includes('updateOpen
 
 // ─── 4. chat.js source inspection ───
 console.log('\n4. chat.js source inspection');
-const chatSrc = await fetchWithRetry('js/chat.js');
+const chatSrc = read('js/chat.js');
 assert('chat.js uses getActiveModelId for model resolution', chatSrc.includes('getActiveModelId'));
 
 // ─── 5. pdf-import.js source inspection ───
 console.log('\n5. pdf-import.js source inspection');
-const pdfSrc = await fetchWithRetry('js/pdf-import.js');
+const pdfSrc = read('js/pdf-import.js');
 assert('pdf-import imports getOpenRouterModel', pdfSrc.includes('getOpenRouterModel'));
 assert('pdf-import imports getOpenRouterModelDisplay', pdfSrc.includes('getOpenRouterModelDisplay'));
 assert('pdf-import has openrouter model-label case (costInfo display)', pdfSrc.includes("'openrouter' ? getOpenRouterModelDisplay()"));
@@ -136,7 +139,7 @@ assert('pdf-import uses getActiveModelId for model resolution', pdfSrc.includes(
 
 // ─── 6. service-worker.js ───
 console.log('\n6. service-worker.js');
-const swSrc = await fetchWithRetry('service-worker.js');
+const swSrc = read('service-worker.js');
 assert('SW uses importScripts for version', swSrc.includes("importScripts('/version.js')"));
 assert('SW CACHE_NAME uses semver', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
 assert('SW bypasses openrouter.ai', swSrc.includes('openrouter.ai'));
@@ -230,11 +233,11 @@ assert('startOpenRouterOAuth stores verifier in sessionStorage', apiSrc.includes
 assert('exchangeOpenRouterCode reads verifier from sessionStorage', apiSrc.includes("sessionStorage.getItem('or_pkce_verifier'"));
 assert('startOpenRouterOAuth redirects to openrouter.ai/auth', apiSrc.includes('openrouter.ai/auth?callback_url='));
 assert('exchangeOpenRouterCode posts to auth/keys endpoint', apiSrc.includes('openrouter.ai/api/v1/auth/keys'));
-const mainSrc = await fetchWithRetry('js/main.js');
+const mainSrc = read('js/main.js');
 assert('main.js checks for code URL param', mainSrc.includes("urlParams.get('code')") || mainSrc.includes("get('code')"));
 assert('main.js calls exchangeOpenRouterCode', mainSrc.includes('exchangeOpenRouterCode('));
 assert('main.js cleans URL via replaceState', mainSrc.includes('history.replaceState'));
-const cssSrc = await fetchWithRetry('styles.css');
+const cssSrc = read('styles.css');
 assert('CSS: .or-oauth-btn defined', cssSrc.includes('.or-oauth-btn'));
 assert('CSS: .or-oauth-divider defined', cssSrc.includes('.or-oauth-divider'));
 assert('provider-panels renders or-oauth-btn in OpenRouter panel', ppSrc.includes('or-oauth-btn'));

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -1,274 +1,247 @@
-// test-openrouter.js — Verify OpenRouter as 4th AI provider
-// Run: fetch('tests/test-openrouter.js').then(r=>r.text()).then(s=>Function(s)())
-return (async function() {
-  const results = [];
-  let passed = 0, failed = 0;
-  function assert(name, condition, detail) {
-    if (condition) { passed++; results.push(`  PASS: ${name}`); }
-    else { failed++; results.push(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
-  }
+#!/usr/bin/env node
+// test-openrouter.js — OpenRouter as 4th AI provider. Source inspection of
+// api.js / schema.js / provider-panels.js / chat.js / pdf-import.js /
+// service-worker.js + module-level behavioral tests (localStorage helpers,
+// hasAIProvider gating, model pricing, PKCE generation).
+//
+// Run: node tests/test-openrouter.js  (or via npm test)
+//
+// DOM-runtime assertions (Settings modal rendering — section 10) live in
+// tests/test-openrouter-dom.js on the puppeteer runner.
 
-  console.log('=== OpenRouter Integration Tests ===\n');
+import './_node-shim.js';
 
-  // ─── 1. api.js source inspection ───
-  console.log('1. api.js source inspection');
-  const apiSrc = await fetchWithRetry('js/api.js');
-  assert('getOpenRouterKey exists', apiSrc.includes('function getOpenRouterKey()'));
-  assert('saveOpenRouterKey exists', apiSrc.includes('function saveOpenRouterKey('));
-  assert('hasOpenRouterKey exists', apiSrc.includes('function hasOpenRouterKey()'));
-  assert('getOpenRouterModel exists', apiSrc.includes('function getOpenRouterModel()'));
-  assert('setOpenRouterModel exists', apiSrc.includes('function setOpenRouterModel('));
-  assert('getOpenRouterModelDisplay exists', apiSrc.includes('function getOpenRouterModelDisplay()'));
-  assert('fetchOpenRouterModels exists', apiSrc.includes('function fetchOpenRouterModels('));
-  assert('validateOpenRouterKey exists', apiSrc.includes('function validateOpenRouterKey('));
-  assert('callOpenRouterAPI exists', apiSrc.includes('function callOpenRouterAPI('));
-  assert('extraHeaders in helper signature', apiSrc.includes('extraHeaders = {}'));
-  assert('extraHeaders spread in fetch headers', apiSrc.includes('...extraHeaders'));
-  assert('hasAIProvider handles openrouter', apiSrc.includes("provider === 'openrouter') return hasOpenRouterKey()"));
-  assert('callClaudeAPI handles openrouter', apiSrc.includes("provider === 'openrouter') return callOpenRouterAPI("));
-  assert('callOpenRouterAPI sends HTTP-Referer', apiSrc.includes("'HTTP-Referer'"));
-  assert('callOpenRouterAPI sends X-Title', apiSrc.includes("'X-Title': 'getbased'"));
-  assert('OpenRouter default model is claude-sonnet-4-6', apiSrc.includes("'anthropic/claude-sonnet-4-6'"));
-  assert('OpenRouter API endpoint', apiSrc.includes('openrouter.ai/api/v1/chat/completions'));
-  assert('OpenRouter models endpoint', apiSrc.includes('openrouter.ai/api/v1/models'));
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-  // ─── 2. schema.js + api.js: curated models + dynamic pricing ───
-  console.log('\n2. Curated models + dynamic pricing');
-  const schemaSrc = await fetchWithRetry('js/schema.js');
-  assert('MODEL_PRICING has openrouter block', schemaSrc.includes('openrouter:'));
-  assert('Has openrouter _default fallback', schemaSrc.includes("'_default':") && schemaSrc.includes('approx: true'));
-  assert('getModelPricing checks openrouter-pricing cache', schemaSrc.includes('labcharts-openrouter-pricing'));
-  // Curated whitelist in api.js
-  assert('OPENROUTER_CURATED whitelist exists', apiSrc.includes('OPENROUTER_CURATED'));
-  assert('Curated: anthropic/claude-sonnet prefix', apiSrc.includes("'anthropic/claude-sonnet-4'"));
-  assert('Curated: anthropic/claude-opus prefix', apiSrc.includes("'anthropic/claude-opus-4'"));
-  assert('Curated: openai/gpt prefix', apiSrc.includes("'openai/gpt-5'"));
-  assert('Curated: google/gemini-3 prefix', apiSrc.includes("'google/gemini-3'"));
-  assert('Curated: google/gemini-2 prefix', apiSrc.includes("'google/gemini-2'"));
-  assert('Curated: deepseek prefix', apiSrc.includes("'deepseek/deepseek'"));
-  assert('Curated: qwen prefix', apiSrc.includes("'qwen/qwen'"));
-  assert('Curated: x-ai/grok prefix', apiSrc.includes("'x-ai/grok'"));
-  // Exclusion list
-  assert('OPENROUTER_EXCLUDE exists', apiSrc.includes('OPENROUTER_EXCLUDE'));
-  assert('Excludes codex variants', apiSrc.includes("'codex'"));
-  assert('Excludes audio variants', apiSrc.includes("'audio'"));
-  assert('Excludes image variants', apiSrc.includes("'image'"));
-  assert('Exclude filter applied in fetch', apiSrc.includes('OPENROUTER_EXCLUDE.some'));
-  // Dynamic pricing extraction
-  assert('fetchOpenRouterModels extracts pricing.prompt', apiSrc.includes('m.pricing.prompt'));
-  assert('fetchOpenRouterModels converts to per-million', apiSrc.includes('* 1_000_000'));
-  assert('fetchOpenRouterModels caches pricing', apiSrc.includes("'labcharts-openrouter-pricing'"));
-  assert('getOpenRouterPricing function exists', apiSrc.includes('function getOpenRouterPricing('));
-  assert('window.getOpenRouterPricing is function', typeof window.getOpenRouterPricing === 'function');
-  // Dynamic pricing localStorage integration
-  const oldPricing = localStorage.getItem('labcharts-openrouter-pricing');
-  localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify({
-    'anthropic/claude-sonnet-4-6': { input: 3.00, output: 15.00 }
-  }));
-  const dynResult = window.getOpenRouterPricing('anthropic/claude-sonnet-4-6');
-  assert('getOpenRouterPricing reads cached pricing', dynResult && dynResult.input === 3.00 && dynResult.output === 15.00);
-  assert('getOpenRouterPricing returns null for unknown', window.getOpenRouterPricing('unknown/model') === null);
-  if (oldPricing) localStorage.setItem('labcharts-openrouter-pricing', oldPricing);
-  else localStorage.removeItem('labcharts-openrouter-pricing');
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+function fetchWithRetry(rel) { return Promise.resolve(read(rel)); }
 
-  // ─── 3. provider-panels.js source inspection (extracted from settings.js) ───
-  console.log('\n3. provider-panels.js source inspection');
-  const ppSrc = await fetchWithRetry('js/provider-panels.js');
-  assert('imports getOpenRouterKey', ppSrc.includes('getOpenRouterKey'));
-  assert('imports saveOpenRouterKey', ppSrc.includes('saveOpenRouterKey'));
-  assert('imports getOpenRouterModel', ppSrc.includes('getOpenRouterModel'));
-  assert('imports setOpenRouterModel', ppSrc.includes('setOpenRouterModel'));
-  assert('imports getOpenRouterModelDisplay', ppSrc.includes('getOpenRouterModelDisplay'));
-  assert('imports validateOpenRouterKey', ppSrc.includes('validateOpenRouterKey'));
-  assert('imports fetchOpenRouterModels', ppSrc.includes('fetchOpenRouterModels'));
-  const settingsSrc = await fetchWithRetry('js/settings.js');
-  assert('provider button with data-provider="openrouter"', settingsSrc.includes('data-provider="openrouter"'));
-  assert('switchAIProvider(\'openrouter\') in onclick', settingsSrc.includes("switchAIProvider('openrouter')"));
-  assert('renderAIProviderPanel handles openrouter', ppSrc.includes("provider === 'openrouter'"));
-  assert('handleSaveOpenRouterKey exists', ppSrc.includes('function handleSaveOpenRouterKey()'));
-  assert('handleRemoveOpenRouterKey exists', ppSrc.includes('function handleRemoveOpenRouterKey()'));
-  assert('renderOpenRouterModelDropdown exists', ppSrc.includes('function renderOpenRouterModelDropdown('));
-  assert('updateOpenRouterModelPricing exists', ppSrc.includes('function updateOpenRouterModelPricing('));
-  assert('openrouter-key-input element', ppSrc.includes('openrouter-key-input'));
-  assert('openrouter-model-area element', ppSrc.includes('openrouter-model-area'));
-  assert('openrouter-model-pricing element', ppSrc.includes('openrouter-model-pricing'));
-  assert('OpenRouter link to openrouter.ai/keys', ppSrc.includes('openrouter.ai/keys'));
-  assert('initSettingsModelFetch fetches OpenRouter', ppSrc.includes('fetchOpenRouterModels(orKey)'));
-  // Ordering: OpenRouter panel check before Venice in renderAIProviderPanel
-  const orPanelIdx = ppSrc.indexOf("provider === 'openrouter'");
-  const venicePanelIdx = ppSrc.indexOf("provider === 'venice'");
-  assert('renderAIProviderPanel: openrouter before venice', orPanelIdx < venicePanelIdx, `openrouter@${orPanelIdx}, venice@${venicePanelIdx}`);
-  assert('window exports handleSaveOpenRouterKey', ppSrc.includes('handleSaveOpenRouterKey,'));
-  assert('window exports handleRemoveOpenRouterKey', ppSrc.includes('handleRemoveOpenRouterKey,'));
-  assert('window exports renderOpenRouterModelDropdown', ppSrc.includes('renderOpenRouterModelDropdown,'));
-  assert('window exports updateOpenRouterModelPricing', ppSrc.includes('updateOpenRouterModelPricing,'));
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  // ─── 4. chat.js source inspection ───
-  console.log('\n4. chat.js source inspection');
-  const chatSrc = await fetchWithRetry('js/chat.js');
-  assert('chat.js uses getActiveModelId for model resolution', chatSrc.includes('getActiveModelId'));
-  assert('chat.js imports getActiveModelId', chatSrc.includes('getActiveModelId'));
+console.log('=== OpenRouter Integration Tests ===\n');
 
-  // ─── 5. pdf-import.js source inspection ───
-  console.log('\n5. pdf-import.js source inspection');
-  const pdfSrc = await fetchWithRetry('js/pdf-import.js');
-  assert('pdf-import imports getOpenRouterModel', pdfSrc.includes('getOpenRouterModel'));
-  assert('pdf-import imports getOpenRouterModelDisplay', pdfSrc.includes('getOpenRouterModelDisplay'));
-  assert('pdf-import has openrouter model-label case (costInfo display)', pdfSrc.includes("'openrouter' ? getOpenRouterModelDisplay()"));
-  assert('pdf-import has openrouter debug model-label', pdfSrc.includes("'openrouter' ? getOpenRouterModelDisplay()"));
-  assert('pdf-import uses getActiveModelId for model resolution', pdfSrc.includes('getActiveModelId'));
+// api.js + provider-panels.js expose helpers via Object.assign(window, ...).
+await import('../js/state.js');
+await import('../js/api.js');
+await import('../js/provider-panels.js');
 
-  // ─── 6. service-worker.js ───
-  console.log('\n6. service-worker.js');
-  const swSrc = await fetchWithRetry('service-worker.js');
-  assert('SW uses importScripts for version', swSrc.includes("importScripts('/version.js')"));
-  assert('SW CACHE_NAME uses semver', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
-  assert('SW bypasses openrouter.ai', swSrc.includes("openrouter.ai"));
+// ─── 1. api.js source inspection ───
+console.log('1. api.js source inspection');
+const apiSrc = await fetchWithRetry('js/api.js');
+assert('getOpenRouterKey exists', apiSrc.includes('function getOpenRouterKey()'));
+assert('saveOpenRouterKey exists', apiSrc.includes('function saveOpenRouterKey('));
+assert('hasOpenRouterKey exists', apiSrc.includes('function hasOpenRouterKey()'));
+assert('getOpenRouterModel exists', apiSrc.includes('function getOpenRouterModel()'));
+assert('setOpenRouterModel exists', apiSrc.includes('function setOpenRouterModel('));
+assert('getOpenRouterModelDisplay exists', apiSrc.includes('function getOpenRouterModelDisplay()'));
+assert('fetchOpenRouterModels exists', apiSrc.includes('function fetchOpenRouterModels('));
+assert('validateOpenRouterKey exists', apiSrc.includes('function validateOpenRouterKey('));
+assert('callOpenRouterAPI exists', apiSrc.includes('function callOpenRouterAPI('));
+assert('extraHeaders in helper signature', apiSrc.includes('extraHeaders = {}'));
+assert('extraHeaders spread in fetch headers', apiSrc.includes('...extraHeaders'));
+assert('hasAIProvider handles openrouter', apiSrc.includes("provider === 'openrouter') return hasOpenRouterKey()"));
+assert('callClaudeAPI handles openrouter', apiSrc.includes("provider === 'openrouter') return callOpenRouterAPI("));
+assert('callOpenRouterAPI sends HTTP-Referer', apiSrc.includes("'HTTP-Referer'"));
+assert('callOpenRouterAPI sends X-Title', apiSrc.includes("'X-Title': 'getbased'"));
+assert('OpenRouter default model is claude-sonnet-4-6', apiSrc.includes("'anthropic/claude-sonnet-4-6'"));
+assert('OpenRouter API endpoint', apiSrc.includes('openrouter.ai/api/v1/chat/completions'));
+assert('OpenRouter models endpoint', apiSrc.includes('openrouter.ai/api/v1/models'));
 
-  // ─── 7. Window function exports ───
-  console.log('\n7. Window function exports');
-  assert('window.getOpenRouterKey is function', typeof window.getOpenRouterKey === 'function');
-  assert('window.saveOpenRouterKey is function', typeof window.saveOpenRouterKey === 'function');
-  assert('window.hasOpenRouterKey is function', typeof window.hasOpenRouterKey === 'function');
-  assert('window.getOpenRouterModel is function', typeof window.getOpenRouterModel === 'function');
-  assert('window.setOpenRouterModel is function', typeof window.setOpenRouterModel === 'function');
-  assert('window.getOpenRouterModelDisplay is function', typeof window.getOpenRouterModelDisplay === 'function');
-  assert('window.fetchOpenRouterModels is function', typeof window.fetchOpenRouterModels === 'function');
-  assert('window.validateOpenRouterKey is function', typeof window.validateOpenRouterKey === 'function');
-  assert('window.callOpenRouterAPI is function', typeof window.callOpenRouterAPI === 'function');
-  assert('window.handleSaveOpenRouterKey is function', typeof window.handleSaveOpenRouterKey === 'function');
-  assert('window.handleRemoveOpenRouterKey is function', typeof window.handleRemoveOpenRouterKey === 'function');
-  assert('window.renderOpenRouterModelDropdown is function', typeof window.renderOpenRouterModelDropdown === 'function');
-  assert('window.updateOpenRouterModelPricing is function', typeof window.updateOpenRouterModelPricing === 'function');
+// ─── 2. schema.js + api.js: curated models + dynamic pricing ───
+console.log('\n2. Curated models + dynamic pricing');
+const schemaSrc = await fetchWithRetry('js/schema.js');
+assert('MODEL_PRICING has openrouter block', schemaSrc.includes('openrouter:'));
+assert('Has openrouter _default fallback', schemaSrc.includes("'_default':") && schemaSrc.includes('approx: true'));
+assert('getModelPricing checks openrouter-pricing cache', schemaSrc.includes('labcharts-openrouter-pricing'));
+assert('OPENROUTER_CURATED whitelist exists', apiSrc.includes('OPENROUTER_CURATED'));
+assert('Curated: anthropic/claude-sonnet prefix', apiSrc.includes("'anthropic/claude-sonnet-4'"));
+assert('Curated: anthropic/claude-opus prefix', apiSrc.includes("'anthropic/claude-opus-4'"));
+assert('Curated: openai/gpt prefix', apiSrc.includes("'openai/gpt-5'"));
+assert('Curated: google/gemini-3 prefix', apiSrc.includes("'google/gemini-3'"));
+assert('Curated: google/gemini-2 prefix', apiSrc.includes("'google/gemini-2'"));
+assert('Curated: deepseek prefix', apiSrc.includes("'deepseek/deepseek'"));
+assert('Curated: qwen prefix', apiSrc.includes("'qwen/qwen'"));
+assert('Curated: x-ai/grok prefix', apiSrc.includes("'x-ai/grok'"));
+assert('OPENROUTER_EXCLUDE exists', apiSrc.includes('OPENROUTER_EXCLUDE'));
+assert('Excludes codex variants', apiSrc.includes("'codex'"));
+assert('Excludes audio variants', apiSrc.includes("'audio'"));
+assert('Excludes image variants', apiSrc.includes("'image'"));
+assert('Exclude filter applied in fetch', apiSrc.includes('OPENROUTER_EXCLUDE.some'));
+assert('fetchOpenRouterModels extracts pricing.prompt', apiSrc.includes('m.pricing.prompt'));
+assert('fetchOpenRouterModels converts to per-million', apiSrc.includes('* 1_000_000'));
+assert('fetchOpenRouterModels caches pricing', apiSrc.includes("'labcharts-openrouter-pricing'"));
+assert('getOpenRouterPricing function exists', apiSrc.includes('function getOpenRouterPricing('));
+assert('window.getOpenRouterPricing is function', typeof window.getOpenRouterPricing === 'function');
 
-  // ─── 8. Key/model management (localStorage) ───
-  console.log('\n8. Key/model management');
-  // Save and retrieve key
-  const oldKey = localStorage.getItem('labcharts-openrouter-key');
-  window.saveOpenRouterKey('test-key-123');
-  assert('saveOpenRouterKey stores to localStorage', localStorage.getItem('labcharts-openrouter-key') === 'test-key-123');
-  assert('getOpenRouterKey returns saved key', window.getOpenRouterKey() === 'test-key-123');
-  assert('hasOpenRouterKey returns true with key', window.hasOpenRouterKey() === true);
-  // Remove key
-  localStorage.removeItem('labcharts-openrouter-key');
-  assert('hasOpenRouterKey returns false without key', window.hasOpenRouterKey() === false);
-  assert('getOpenRouterKey returns empty without key', window.getOpenRouterKey() === '');
-  // Restore original
-  if (oldKey) localStorage.setItem('labcharts-openrouter-key', oldKey);
+const oldPricing = localStorage.getItem('labcharts-openrouter-pricing');
+localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify({
+  'anthropic/claude-sonnet-4-6': { input: 3.00, output: 15.00 }
+}));
+const dynResult = window.getOpenRouterPricing('anthropic/claude-sonnet-4-6');
+assert('getOpenRouterPricing reads cached pricing', dynResult && dynResult.input === 3.00 && dynResult.output === 15.00);
+assert('getOpenRouterPricing returns null for unknown', window.getOpenRouterPricing('unknown/model') === null);
+if (oldPricing) localStorage.setItem('labcharts-openrouter-pricing', oldPricing);
+else localStorage.removeItem('labcharts-openrouter-pricing');
 
-  // Model defaults
-  const oldModel = localStorage.getItem('labcharts-openrouter-model');
-  localStorage.removeItem('labcharts-openrouter-model');
-  assert('getOpenRouterModel defaults to anthropic/claude-sonnet-4.6', window.getOpenRouterModel() === 'anthropic/claude-sonnet-4.6');
-  window.setOpenRouterModel('openai/gpt-4o');
-  assert('setOpenRouterModel persists', window.getOpenRouterModel() === 'openai/gpt-4o');
-  // Restore
-  if (oldModel) localStorage.setItem('labcharts-openrouter-model', oldModel);
-  else localStorage.removeItem('labcharts-openrouter-model');
+// ─── 3. provider-panels.js source inspection (extracted from settings.js) ───
+console.log('\n3. provider-panels.js source inspection');
+const ppSrc = await fetchWithRetry('js/provider-panels.js');
+assert('imports getOpenRouterKey', ppSrc.includes('getOpenRouterKey'));
+assert('imports saveOpenRouterKey', ppSrc.includes('saveOpenRouterKey'));
+assert('imports getOpenRouterModel', ppSrc.includes('getOpenRouterModel'));
+assert('imports setOpenRouterModel', ppSrc.includes('setOpenRouterModel'));
+assert('imports getOpenRouterModelDisplay', ppSrc.includes('getOpenRouterModelDisplay'));
+assert('imports validateOpenRouterKey', ppSrc.includes('validateOpenRouterKey'));
+assert('imports fetchOpenRouterModels', ppSrc.includes('fetchOpenRouterModels'));
+const settingsSrc = await fetchWithRetry('js/settings.js');
+assert('provider button with data-provider="openrouter"', settingsSrc.includes('data-provider="openrouter"'));
+assert("switchAIProvider('openrouter') in onclick", settingsSrc.includes("switchAIProvider('openrouter')"));
+assert('renderAIProviderPanel handles openrouter', ppSrc.includes("provider === 'openrouter'"));
+assert('handleSaveOpenRouterKey exists', ppSrc.includes('function handleSaveOpenRouterKey()'));
+assert('handleRemoveOpenRouterKey exists', ppSrc.includes('function handleRemoveOpenRouterKey()'));
+assert('renderOpenRouterModelDropdown exists', ppSrc.includes('function renderOpenRouterModelDropdown('));
+assert('updateOpenRouterModelPricing exists', ppSrc.includes('function updateOpenRouterModelPricing('));
+assert('openrouter-key-input element', ppSrc.includes('openrouter-key-input'));
+assert('openrouter-model-area element', ppSrc.includes('openrouter-model-area'));
+assert('openrouter-model-pricing element', ppSrc.includes('openrouter-model-pricing'));
+assert('OpenRouter link to openrouter.ai/keys', ppSrc.includes('openrouter.ai/keys'));
+assert('initSettingsModelFetch fetches OpenRouter', ppSrc.includes('fetchOpenRouterModels(orKey)'));
+const orPanelIdx = ppSrc.indexOf("provider === 'openrouter'");
+const venicePanelIdx = ppSrc.indexOf("provider === 'venice'");
+assert('renderAIProviderPanel: openrouter before venice', orPanelIdx < venicePanelIdx, `openrouter@${orPanelIdx}, venice@${venicePanelIdx}`);
+assert('window exports handleSaveOpenRouterKey', ppSrc.includes('handleSaveOpenRouterKey,'));
+assert('window exports handleRemoveOpenRouterKey', ppSrc.includes('handleRemoveOpenRouterKey,'));
+assert('window exports renderOpenRouterModelDropdown', ppSrc.includes('renderOpenRouterModelDropdown,'));
+assert('window exports updateOpenRouterModelPricing', ppSrc.includes('updateOpenRouterModelPricing,'));
 
-  // ─── 9. hasAIProvider with openrouter ───
-  console.log('\n9. hasAIProvider integration');
-  const oldProvider = localStorage.getItem('labcharts-ai-provider');
-  const oldORKey = localStorage.getItem('labcharts-openrouter-key');
-  window.setAIProvider('openrouter');
-  localStorage.removeItem('labcharts-openrouter-key');
-  assert('hasAIProvider false for openrouter without key', window.hasAIProvider() === false);
-  window.saveOpenRouterKey('sk-or-test');
-  assert('hasAIProvider true for openrouter with key', window.hasAIProvider() === true);
-  // Restore
-  if (oldProvider) localStorage.setItem('labcharts-ai-provider', oldProvider);
-  else localStorage.removeItem('labcharts-ai-provider');
-  if (oldORKey) localStorage.setItem('labcharts-openrouter-key', oldORKey);
-  else localStorage.removeItem('labcharts-openrouter-key');
+// ─── 4. chat.js source inspection ───
+console.log('\n4. chat.js source inspection');
+const chatSrc = await fetchWithRetry('js/chat.js');
+assert('chat.js uses getActiveModelId for model resolution', chatSrc.includes('getActiveModelId'));
 
-  // ─── 10. Settings modal DOM ───
-  console.log('\n10. Settings modal DOM');
-  window.openSettingsModal('ai');
-  await new Promise(r => setTimeout(r, 100));
-  const providerBtns = document.querySelectorAll('.ai-provider-btn');
-  assert('6 provider buttons in settings', providerBtns.length === 6, `found ${providerBtns.length}`);
-  const providerValues = Array.from(providerBtns).map(b => b.dataset.provider);
-  assert('provider buttons include ppq', providerValues.includes('ppq'));
-  assert('provider buttons include routstr', providerValues.includes('routstr'));
-  assert('provider buttons include venice', providerValues.includes('venice'));
-  assert('provider buttons include ollama', providerValues.includes('ollama'));
-  assert('provider buttons include openrouter', providerValues.includes('openrouter'));
-  assert('button order: OpenRouter before Venice', providerValues.indexOf('openrouter') < providerValues.indexOf('venice'), `openrouter@${providerValues.indexOf('openrouter')}, venice@${providerValues.indexOf('venice')}`);
-  // Switch to OpenRouter panel
-  window.switchAIProvider('openrouter');
-  await new Promise(r => setTimeout(r, 100));
-  assert('openrouter-key-input exists in DOM', !!document.getElementById('openrouter-key-input'));
-  assert('openrouter-key-status exists in DOM', !!document.getElementById('openrouter-key-status'));
-  assert('openrouter-model-area exists in DOM', !!document.getElementById('openrouter-model-area'));
-  assert('save-openrouter-key-btn exists in DOM', !!document.getElementById('save-openrouter-key-btn'));
-  // Restore provider and close settings
-  if (oldProvider) window.setAIProvider(oldProvider);
-  window.closeSettingsModal();
+// ─── 5. pdf-import.js source inspection ───
+console.log('\n5. pdf-import.js source inspection');
+const pdfSrc = await fetchWithRetry('js/pdf-import.js');
+assert('pdf-import imports getOpenRouterModel', pdfSrc.includes('getOpenRouterModel'));
+assert('pdf-import imports getOpenRouterModelDisplay', pdfSrc.includes('getOpenRouterModelDisplay'));
+assert('pdf-import has openrouter model-label case (costInfo display)', pdfSrc.includes("'openrouter' ? getOpenRouterModelDisplay()"));
+assert('pdf-import uses getActiveModelId for model resolution', pdfSrc.includes('getActiveModelId'));
 
-  // ─── 11. Model pricing ───
-  console.log('\n11. Model pricing');
-  // Seed dynamic pricing so hint shows exact values
-  const savedPr = localStorage.getItem('labcharts-openrouter-pricing');
-  localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify({
-    'anthropic/claude-sonnet-4-6': { input: 3.00, output: 15.00 }
-  }));
-  const pricing = window.renderModelPricingHint('openrouter', 'anthropic/claude-sonnet-4-6');
-  assert('renderModelPricingHint returns content for openrouter', pricing.length > 0);
-  assert('pricing includes dollar amounts', pricing.includes('$'));
-  assert('pricing is not approximate with cached data', !pricing.includes('~'));
-  // Unknown model falls back to _default (approximate)
-  const unknownPricing = window.renderModelPricingHint('openrouter', 'unknown/model-xyz');
-  assert('unknown model pricing is approximate', unknownPricing.includes('~'));
-  // Restore
-  if (savedPr) localStorage.setItem('labcharts-openrouter-pricing', savedPr);
-  else localStorage.removeItem('labcharts-openrouter-pricing');
-  const ollamaPricing = window.renderModelPricingHint('ollama', '');
-  assert('ollama pricing still says Free', ollamaPricing.includes('Free'));
+// ─── 6. service-worker.js ───
+console.log('\n6. service-worker.js');
+const swSrc = await fetchWithRetry('service-worker.js');
+assert('SW uses importScripts for version', swSrc.includes("importScripts('/version.js')"));
+assert('SW CACHE_NAME uses semver', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
+assert('SW bypasses openrouter.ai', swSrc.includes('openrouter.ai'));
 
-  // ─── 12. Key removal clears pricing cache ───
-  console.log('\n12. Key removal clears pricing cache');
-  assert('handleRemoveOpenRouterKey clears pricing cache', ppSrc.includes("removeItem('labcharts-openrouter-pricing')"));
+// ─── 7. Window function exports ───
+console.log('\n7. Window function exports');
+assert('window.getOpenRouterKey is function', typeof window.getOpenRouterKey === 'function');
+assert('window.saveOpenRouterKey is function', typeof window.saveOpenRouterKey === 'function');
+assert('window.hasOpenRouterKey is function', typeof window.hasOpenRouterKey === 'function');
+assert('window.getOpenRouterModel is function', typeof window.getOpenRouterModel === 'function');
+assert('window.setOpenRouterModel is function', typeof window.setOpenRouterModel === 'function');
+assert('window.getOpenRouterModelDisplay is function', typeof window.getOpenRouterModelDisplay === 'function');
+assert('window.fetchOpenRouterModels is function', typeof window.fetchOpenRouterModels === 'function');
+assert('window.validateOpenRouterKey is function', typeof window.validateOpenRouterKey === 'function');
+assert('window.callOpenRouterAPI is function', typeof window.callOpenRouterAPI === 'function');
+assert('window.handleSaveOpenRouterKey is function', typeof window.handleSaveOpenRouterKey === 'function');
+assert('window.handleRemoveOpenRouterKey is function', typeof window.handleRemoveOpenRouterKey === 'function');
+assert('window.renderOpenRouterModelDropdown is function', typeof window.renderOpenRouterModelDropdown === 'function');
+assert('window.updateOpenRouterModelPricing is function', typeof window.updateOpenRouterModelPricing === 'function');
 
-  // ─── 13. OAuth PKCE flow ───
-  console.log('\n13. OAuth PKCE flow');
-  // Window exports
-  assert('window.generatePKCE is function', typeof window.generatePKCE === 'function');
-  assert('window.startOpenRouterOAuth is function', typeof window.startOpenRouterOAuth === 'function');
-  assert('window.exchangeOpenRouterCode is function', typeof window.exchangeOpenRouterCode === 'function');
-  // generatePKCE returns valid PKCE params
-  const pkce = await window.generatePKCE();
-  assert('generatePKCE returns codeVerifier (43+ chars)', typeof pkce.codeVerifier === 'string' && pkce.codeVerifier.length >= 43);
-  assert('generatePKCE returns codeChallenge (43+ chars)', typeof pkce.codeChallenge === 'string' && pkce.codeChallenge.length >= 43);
-  assert('codeVerifier is base64url (no +/=)', !/[+=\/]/.test(pkce.codeVerifier));
-  assert('codeChallenge is base64url (no +/=)', !/[+=\/]/.test(pkce.codeChallenge));
-  // Source: sessionStorage usage for verifier
-  assert('startOpenRouterOAuth stores verifier in sessionStorage', apiSrc.includes("sessionStorage.setItem('or_pkce_verifier'"));
-  assert('exchangeOpenRouterCode reads verifier from sessionStorage', apiSrc.includes("sessionStorage.getItem('or_pkce_verifier'"));
-  // Source: correct OpenRouter auth URL and exchange endpoint
-  assert('startOpenRouterOAuth redirects to openrouter.ai/auth', apiSrc.includes('openrouter.ai/auth?callback_url='));
-  assert('exchangeOpenRouterCode posts to auth/keys endpoint', apiSrc.includes('openrouter.ai/api/v1/auth/keys'));
-  // Source: main.js checks for ?code= param
-  const mainSrc = await fetchWithRetry('js/main.js');
-  assert('main.js checks for code URL param', mainSrc.includes("urlParams.get('code')") || mainSrc.includes("get('code')"));
-  assert('main.js calls exchangeOpenRouterCode', mainSrc.includes('exchangeOpenRouterCode('));
-  assert('main.js cleans URL via replaceState', mainSrc.includes('history.replaceState'));
-  // CSS: .or-oauth-btn and .or-oauth-divider exist
-  const cssSrc = await fetchWithRetry('styles.css');
-  assert('CSS: .or-oauth-btn defined', cssSrc.includes('.or-oauth-btn'));
-  assert('CSS: .or-oauth-divider defined', cssSrc.includes('.or-oauth-divider'));
-  // Provider panels source: OAuth button rendered in OpenRouter panel
-  assert('provider-panels renders or-oauth-btn in OpenRouter panel', ppSrc.includes('or-oauth-btn'));
-  assert('provider-panels renders or-oauth-divider', ppSrc.includes('or-oauth-divider'));
-  // Provider panels: OAuth button hidden when key exists
-  assert('OAuth button conditional on !currentKey', ppSrc.includes("currentKey ? '' : '<button class=\"or-oauth-btn\""));
-  // Chat setup guide includes OAuth button
-  const chatSrc2 = await fetchWithRetry('js/chat.js');
-  assert('Chat setup guide has or-oauth-btn', chatSrc2.includes('or-oauth-btn'));
-  assert('Chat setup guide has startOpenRouterOAuth onclick', chatSrc2.includes("onclick=\"startOpenRouterOAuth()\""));
+// ─── 8. Key/model management (localStorage) ───
+console.log('\n8. Key/model management');
+const oldKey = localStorage.getItem('labcharts-openrouter-key');
+window.saveOpenRouterKey('test-key-123');
+assert('saveOpenRouterKey stores to localStorage', localStorage.getItem('labcharts-openrouter-key') === 'test-key-123');
+assert('getOpenRouterKey returns saved key', window.getOpenRouterKey() === 'test-key-123');
+assert('hasOpenRouterKey returns true with key', window.hasOpenRouterKey() === true);
+localStorage.removeItem('labcharts-openrouter-key');
+assert('hasOpenRouterKey returns false without key', window.hasOpenRouterKey() === false);
+assert('getOpenRouterKey returns empty without key', window.getOpenRouterKey() === '');
+if (oldKey) localStorage.setItem('labcharts-openrouter-key', oldKey);
 
-  // ═══ SUMMARY ═══
-  console.log('\n' + results.join('\n'));
-  console.log(`\n=== ${passed} passed, ${failed} failed, ${passed + failed} total ===`);
-  if (failed === 0) console.log('ALL TESTS PASSED');
-  else console.warn(`${failed} test(s) failed`);
-})();
+const oldModel = localStorage.getItem('labcharts-openrouter-model');
+localStorage.removeItem('labcharts-openrouter-model');
+assert('getOpenRouterModel defaults to anthropic/claude-sonnet-4.6', window.getOpenRouterModel() === 'anthropic/claude-sonnet-4.6');
+window.setOpenRouterModel('openai/gpt-4o');
+assert('setOpenRouterModel persists', window.getOpenRouterModel() === 'openai/gpt-4o');
+if (oldModel) localStorage.setItem('labcharts-openrouter-model', oldModel);
+else localStorage.removeItem('labcharts-openrouter-model');
+
+// ─── 9. hasAIProvider with openrouter ───
+console.log('\n9. hasAIProvider integration');
+const oldProvider = localStorage.getItem('labcharts-ai-provider');
+const oldORKey = localStorage.getItem('labcharts-openrouter-key');
+window.setAIProvider('openrouter');
+localStorage.removeItem('labcharts-openrouter-key');
+assert('hasAIProvider false for openrouter without key', window.hasAIProvider() === false);
+window.saveOpenRouterKey('sk-or-test');
+assert('hasAIProvider true for openrouter with key', window.hasAIProvider() === true);
+if (oldProvider) localStorage.setItem('labcharts-ai-provider', oldProvider);
+else localStorage.removeItem('labcharts-ai-provider');
+if (oldORKey) localStorage.setItem('labcharts-openrouter-key', oldORKey);
+else localStorage.removeItem('labcharts-openrouter-key');
+
+// Section 10 (Settings modal DOM) lives in test-openrouter-dom.js — needs a
+// live browser DOM (openSettingsModal renders, querySelectorAll on rendered
+// .ai-provider-btn cards, getElementById on openrouter-* form fields).
+
+// ─── 11. Model pricing (pure-logic string return) ───
+console.log('\n11. Model pricing');
+const savedPr = localStorage.getItem('labcharts-openrouter-pricing');
+localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify({
+  'anthropic/claude-sonnet-4-6': { input: 3.00, output: 15.00 }
+}));
+const pricing = window.renderModelPricingHint('openrouter', 'anthropic/claude-sonnet-4-6');
+assert('renderModelPricingHint returns content for openrouter', pricing.length > 0);
+assert('pricing includes dollar amounts', pricing.includes('$'));
+assert('pricing is not approximate with cached data', !pricing.includes('~'));
+const unknownPricing = window.renderModelPricingHint('openrouter', 'unknown/model-xyz');
+assert('unknown model pricing is approximate', unknownPricing.includes('~'));
+if (savedPr) localStorage.setItem('labcharts-openrouter-pricing', savedPr);
+else localStorage.removeItem('labcharts-openrouter-pricing');
+const ollamaPricing = window.renderModelPricingHint('ollama', '');
+assert('ollama pricing still says Free', ollamaPricing.includes('Free'));
+
+// ─── 12. Key removal clears pricing cache ───
+console.log('\n12. Key removal clears pricing cache');
+assert('handleRemoveOpenRouterKey clears pricing cache', ppSrc.includes("removeItem('labcharts-openrouter-pricing')"));
+
+// ─── 13. OAuth PKCE flow ───
+console.log('\n13. OAuth PKCE flow');
+assert('window.generatePKCE is function', typeof window.generatePKCE === 'function');
+assert('window.startOpenRouterOAuth is function', typeof window.startOpenRouterOAuth === 'function');
+assert('window.exchangeOpenRouterCode is function', typeof window.exchangeOpenRouterCode === 'function');
+const pkce = await window.generatePKCE();
+assert('generatePKCE returns codeVerifier (43+ chars)', typeof pkce.codeVerifier === 'string' && pkce.codeVerifier.length >= 43);
+assert('generatePKCE returns codeChallenge (43+ chars)', typeof pkce.codeChallenge === 'string' && pkce.codeChallenge.length >= 43);
+assert('codeVerifier is base64url (no +/=)', !/[+=\/]/.test(pkce.codeVerifier));
+assert('codeChallenge is base64url (no +/=)', !/[+=\/]/.test(pkce.codeChallenge));
+assert('startOpenRouterOAuth stores verifier in sessionStorage', apiSrc.includes("sessionStorage.setItem('or_pkce_verifier'"));
+assert('exchangeOpenRouterCode reads verifier from sessionStorage', apiSrc.includes("sessionStorage.getItem('or_pkce_verifier'"));
+assert('startOpenRouterOAuth redirects to openrouter.ai/auth', apiSrc.includes('openrouter.ai/auth?callback_url='));
+assert('exchangeOpenRouterCode posts to auth/keys endpoint', apiSrc.includes('openrouter.ai/api/v1/auth/keys'));
+const mainSrc = await fetchWithRetry('js/main.js');
+assert('main.js checks for code URL param', mainSrc.includes("urlParams.get('code')") || mainSrc.includes("get('code')"));
+assert('main.js calls exchangeOpenRouterCode', mainSrc.includes('exchangeOpenRouterCode('));
+assert('main.js cleans URL via replaceState', mainSrc.includes('history.replaceState'));
+const cssSrc = await fetchWithRetry('styles.css');
+assert('CSS: .or-oauth-btn defined', cssSrc.includes('.or-oauth-btn'));
+assert('CSS: .or-oauth-divider defined', cssSrc.includes('.or-oauth-divider'));
+assert('provider-panels renders or-oauth-btn in OpenRouter panel', ppSrc.includes('or-oauth-btn'));
+assert('provider-panels renders or-oauth-divider', ppSrc.includes('or-oauth-divider'));
+assert('OAuth button conditional on !currentKey', ppSrc.includes("currentKey ? '' : '<button class=\"or-oauth-btn\""));
+assert('Chat setup guide has or-oauth-btn', chatSrc.includes('or-oauth-btn'));
+assert('Chat setup guide has startOpenRouterOAuth onclick', chatSrc.includes("onclick=\"startOpenRouterOAuth()\""));
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Single port off the puppeteer runner using the now-familiar Vitest+DOM-split pattern:

- **`test-openrouter.js`** (123 asserts) → Vitest. Source-inspection of `api.js`, `schema.js`, `provider-panels.js`, `chat.js`, `pdf-import.js`, `service-worker.js`, `main.js`, `styles.css`. Plus localStorage round-trips (key + model helpers), `hasAIProvider` gating, pure-logic `renderModelPricingHint`, and **generatePKCE behavioral** (Node 19+ has `crypto.subtle.digest` + `crypto.getRandomValues` + `TextEncoder` + `btoa`, so the verifier/challenge generation runs fine outside a browser).
- **`test-openrouter-dom.js`** (11 asserts, new) → puppeteer. Live-DOM only: `openSettingsModal('ai')` rendering 6 provider cards, `querySelectorAll('.ai-provider-btn')` + button order, `getElementById` on OpenRouter panel form fields (`openrouter-key-input`, `openrouter-key-status`, `openrouter-model-area`, `save-openrouter-key-btn`).

## Test plan

- [x] `node tests/test-openrouter.js` — **123/123** standalone
- [x] `npx vitest run tests/_vitest-legacy.test.js` — **64 tests / 4.53s** (was 63 / 4.21s)
- [x] `./run-tests.sh` — full suite green; `test-openrouter-dom.js` ran in puppeteer (**11/11**)

## Numbers after this PR

- **Vitest**: 64 tests (was 63)
- **Puppeteer remaining**: 36 (was 37 — test-openrouter swapped for slim DOM variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)