### PR TITLE
Vitest batch 24: test-custom-api (138 asserts split)

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -52,7 +52,11 @@ const TEST_FILES = [
   'tests/test-dashboard-data-protection.js',
   'tests/test-chat-panel-ux.js',
   'tests/test-cashu-wallet.js',
-  'tests/test-custom-api.js',
+  // test-custom-api.js source-inspection + behavioral ported to Vitest
+  // (batch 24). DOM-runtime sections (13/14 — Settings modal rendering,
+  // Custom panel form fields, connected-state model dropdown) live in
+  // test-custom-api-dom.js below.
+  'tests/test-custom-api-dom.js',
   'tests/test-custom-lens.js',
   'tests/test-export-import.js',
   'tests/test-ui-flows.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -129,6 +129,9 @@ const LEGACY_TESTS = [
   // Batch 23 — custom personality behavioral + source-inspection
   // (DOM sections 11/12/17/21 in test-custom-personality-dom.js stay on puppeteer).
   './test-custom-personality.js',
+  // Batch 24 — custom API provider behavioral + source-inspection
+  // (DOM sections 13/14 in test-custom-api-dom.js stay on puppeteer).
+  './test-custom-api.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-custom-api-dom.js
+++ b/tests/test-custom-api-dom.js
@@ -1,0 +1,75 @@
+// test-custom-api-dom.js — Settings-modal DOM assertions extracted from
+// test-custom-api.js (sections 13, 14). Stays in the puppeteer runner:
+// openSettingsModal renders the provider grid, switchAIProvider renders the
+// Custom panel, and the connected-state model dropdown is a real <select>
+// with .options. Source-string + behavioral checks live in test-custom-api.js
+// (Vitest).
+//
+// Run: fetch('tests/test-custom-api-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Custom API Settings-Modal DOM Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  // ─── 13. Settings modal DOM ───
+  console.log('%c 13. Settings modal DOM ', 'font-weight:bold;color:#f59e0b');
+  window.openSettingsModal('ai');
+  await new Promise(r => setTimeout(r, 100));
+  const providerBtns = document.querySelectorAll('.ai-provider-btn');
+  assert('6 provider buttons in settings', providerBtns.length === 6, `found ${providerBtns.length}`);
+  const providerValues = Array.from(providerBtns).map(b => b.dataset.provider);
+  assert('provider buttons include custom', providerValues.includes('custom'));
+  assert('custom button before local', providerValues.indexOf('custom') < providerValues.indexOf('ollama'));
+  window.switchAIProvider('custom');
+  await new Promise(r => setTimeout(r, 100));
+  assert('custom-url-input exists in DOM', !!document.getElementById('custom-url-input'));
+  assert('custom-key-input exists in DOM', !!document.getElementById('custom-key-input'));
+  assert('panel has Save & Validate button', !!document.querySelector('.ai-provider-panel .import-btn-primary'));
+  assert('panel has OpenAI-compatible description', document.querySelector('.ai-provider-desc')?.textContent.includes('OpenAI-compatible'));
+  window.closeSettingsModal();
+
+  // ─── 14. Settings DOM with connected state ───
+  console.log('%c 14. Settings DOM with connected state ', 'font-weight:bold;color:#f59e0b');
+  const sv_url = localStorage.getItem('labcharts-custom-url');
+  const sv_key = localStorage.getItem('labcharts-custom-key');
+  const sv_model = localStorage.getItem('labcharts-custom-model');
+  const sv_models = localStorage.getItem('labcharts-custom-models');
+  const sv_prov = localStorage.getItem('labcharts-ai-provider');
+  window.setCustomApiUrl('https://api.test.com/v1');
+  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'sk-test');
+  window.setCustomApiModel('test-model');
+  localStorage.setItem('labcharts-custom-models', JSON.stringify([
+    { id: 'test-model', name: 'Test Model' },
+    { id: 'other-model', name: 'Other Model' }
+  ]));
+  window.setAIProvider('custom');
+  window.openSettingsModal('ai');
+  await new Promise(r => setTimeout(r, 100));
+  window.switchAIProvider('custom');
+  await new Promise(r => setTimeout(r, 100));
+  assert('connected status shown', document.getElementById('custom-key-status')?.textContent?.includes('Connected'));
+  assert('model dropdown exists in connected state', !!document.getElementById('custom-model-select'));
+  const select = document.getElementById('custom-model-select');
+  if (select) {
+    assert('model dropdown has 2 options', select.options.length === 2, `found ${select.options.length}`);
+    assert('selected model is test-model', select.value === 'test-model');
+  }
+  assert('manual model input exists in connected state', !!document.getElementById('custom-manual-model'));
+  assert('Remove button shown in connected state', document.querySelector('.ai-provider-panel').innerHTML.includes('handleRemoveCustomApi'));
+  window.closeSettingsModal();
+  if (sv_url) localStorage.setItem('labcharts-custom-url', sv_url); else localStorage.removeItem('labcharts-custom-url');
+  if (sv_key) localStorage.setItem('labcharts-custom-key', sv_key); else localStorage.removeItem('labcharts-custom-key');
+  if (sv_model) localStorage.setItem('labcharts-custom-model', sv_model); else localStorage.removeItem('labcharts-custom-model');
+  if (sv_models) localStorage.setItem('labcharts-custom-models', sv_models); else localStorage.removeItem('labcharts-custom-models');
+  if (sv_prov) localStorage.setItem('labcharts-ai-provider', sv_prov); else localStorage.removeItem('labcharts-ai-provider');
+  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+
+  console.log(`\n%c Custom API DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-custom-api-dom'] = { pass, fail };
+})();

--- a/tests/test-custom-api-dom.js
+++ b/tests/test-custom-api-dom.js
@@ -60,7 +60,7 @@ return (async function() {
     assert('selected model is test-model', select.value === 'test-model');
   }
   assert('manual model input exists in connected state', !!document.getElementById('custom-manual-model'));
-  assert('Remove button shown in connected state', document.querySelector('.ai-provider-panel').innerHTML.includes('handleRemoveCustomApi'));
+  assert('Remove button shown in connected state', document.querySelector('.ai-provider-panel')?.innerHTML.includes('handleRemoveCustomApi'));
   window.closeSettingsModal();
   if (sv_url) localStorage.setItem('labcharts-custom-url', sv_url); else localStorage.removeItem('labcharts-custom-url');
   if (sv_key) localStorage.setItem('labcharts-custom-key', sv_key); else localStorage.removeItem('labcharts-custom-key');

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -1,407 +1,319 @@
-// test-custom-api.js — Verify Custom API as 6th AI provider
-// Run: fetch('tests/test-custom-api.js').then(r=>r.text()).then(s=>Function(s)())
-return (async function() {
-  const results = [];
-  let passed = 0, failed = 0;
-  function assert(name, condition, detail) {
-    if (condition) { passed++; results.push(`  PASS: ${name}`); }
-    else { failed++; results.push(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
-  }
+#!/usr/bin/env node
+// test-custom-api.js — Custom API as 6th AI provider. Source inspection of
+// api.js / settings.js / provider-panels.js / pdf-import.js / service-worker.js
+// / api/proxy.js / crypto.js, plus behavioral tests (URL/key/model management,
+// hasAIProvider gating, callCustomAPI error paths, needsMaxCompletionTokens
+// detection).
+//
+// Run: node tests/test-custom-api.js  (or via npm test)
+//
+// DOM-runtime assertions (sections 13, 14 — Settings modal rendering, the
+// Custom panel form fields + connected-state model dropdown) live in
+// tests/test-custom-api-dom.js on the puppeteer runner.
 
-  console.log('=== Custom API Provider Tests ===\n');
+import './_node-shim.js';
 
-  // ─── 1. api.js source inspection ───
-  console.log('1. api.js source inspection');
-  const apiSrc = await fetch('js/api.js').then(r => r.text());
-  assert('getCustomApiUrl exists', apiSrc.includes('function getCustomApiUrl()'));
-  assert('setCustomApiUrl exists', apiSrc.includes('function setCustomApiUrl('));
-  assert('getCustomApiKey exists', apiSrc.includes('function getCustomApiKey()'));
-  assert('saveCustomApiKey exists', apiSrc.includes('function saveCustomApiKey('));
-  assert('hasCustomApiKey exists', apiSrc.includes('function hasCustomApiKey()'));
-  assert('getCustomApiModel exists', apiSrc.includes('function getCustomApiModel()'));
-  assert('setCustomApiModel exists', apiSrc.includes('function setCustomApiModel('));
-  assert('getCustomApiModelDisplay exists', apiSrc.includes('function getCustomApiModelDisplay()'));
-  assert('fetchCustomApiModels exists', apiSrc.includes('function fetchCustomApiModels('));
-  assert('validateCustomApiKey exists', apiSrc.includes('function validateCustomApiKey('));
-  assert('callCustomAPI exists', apiSrc.includes('function callCustomAPI('));
-  // Dispatcher integration
-  assert('hasAIProvider handles custom', apiSrc.includes("provider === 'custom') return hasCustomApiKey()"));
-  assert('hasAIProvider custom requires URL', apiSrc.includes("hasCustomApiKey() && !!getCustomApiUrl()"));
-  assert('getActiveModelId handles custom', apiSrc.includes("provider === 'custom') return getCustomApiModel()"));
-  assert('getActiveModelDisplay handles custom', apiSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
-  assert('callClaudeAPI handles custom', apiSrc.includes("provider === 'custom') return callCustomAPI("));
-  assert('supportsWebSearch false for custom', apiSrc.includes("provider === 'custom') return false"));
-  assert('supportsVision true for custom', apiSrc.includes("provider === 'custom') return true"));
-  // callCustomAPI uses proxy (CORS bypass for hosted version)
-  assert('callCustomAPI routes through proxy', apiSrc.includes("'Custom', opts,\n    {}"));
-  // Encrypted key storage
-  assert('saveCustomApiKey uses encryptedSetItem', apiSrc.includes("encryptedSetItem('labcharts-custom-key'"));
-  assert('getCustomApiKey uses getCachedKey', apiSrc.includes("getCachedKey('labcharts-custom-key')"));
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-  // ─── 2. Window function exports ───
-  console.log('\n2. Window function exports');
-  assert('window.getCustomApiUrl is function', typeof window.getCustomApiUrl === 'function');
-  assert('window.setCustomApiUrl is function', typeof window.setCustomApiUrl === 'function');
-  assert('window.getCustomApiKey is function', typeof window.getCustomApiKey === 'function');
-  assert('window.saveCustomApiKey is function', typeof window.saveCustomApiKey === 'function');
-  assert('window.hasCustomApiKey is function', typeof window.hasCustomApiKey === 'function');
-  assert('window.getCustomApiModel is function', typeof window.getCustomApiModel === 'function');
-  assert('window.setCustomApiModel is function', typeof window.setCustomApiModel === 'function');
-  assert('window.getCustomApiModelDisplay is function', typeof window.getCustomApiModelDisplay === 'function');
-  assert('window.fetchCustomApiModels is function', typeof window.fetchCustomApiModels === 'function');
-  assert('window.validateCustomApiKey is function', typeof window.validateCustomApiKey === 'function');
-  assert('window.callCustomAPI is function', typeof window.callCustomAPI === 'function');
-  assert('window.handleSaveCustomApi is function', typeof window.handleSaveCustomApi === 'function');
-  assert('window.handleRemoveCustomApi is function', typeof window.handleRemoveCustomApi === 'function');
-  assert('window.renderCustomApiModelDropdown is function', typeof window.renderCustomApiModelDropdown === 'function');
-  assert('window.applyCustomApiManualModel is function', typeof window.applyCustomApiManualModel === 'function');
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
 
-  // ─── 3. URL management ───
-  console.log('\n3. URL management');
-  const oldUrl = localStorage.getItem('labcharts-custom-url');
-  localStorage.removeItem('labcharts-custom-url');
-  assert('getCustomApiUrl returns empty by default', window.getCustomApiUrl() === '');
-  window.setCustomApiUrl('https://api.example.com/v1');
-  assert('setCustomApiUrl persists', window.getCustomApiUrl() === 'https://api.example.com/v1');
-  assert('localStorage has labcharts-custom-url', localStorage.getItem('labcharts-custom-url') === 'https://api.example.com/v1');
-  // Restore
-  if (oldUrl) localStorage.setItem('labcharts-custom-url', oldUrl);
-  else localStorage.removeItem('labcharts-custom-url');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  // ─── 4. Key management ───
-  console.log('\n4. Key management');
-  const oldKey = localStorage.getItem('labcharts-custom-key');
-  localStorage.removeItem('labcharts-custom-key');
-  // Force clear the cache too
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
-  assert('getCustomApiKey returns empty by default', window.getCustomApiKey() === '');
-  assert('hasCustomApiKey returns false without key', window.hasCustomApiKey() === false);
-  // Restore
-  if (oldKey) localStorage.setItem('labcharts-custom-key', oldKey);
+console.log('=== Custom API Provider Tests ===\n');
 
-  // ─── 5. Model management ───
-  console.log('\n5. Model management');
-  const oldModel = localStorage.getItem('labcharts-custom-model');
-  const oldModels = localStorage.getItem('labcharts-custom-models');
-  localStorage.removeItem('labcharts-custom-model');
-  assert('getCustomApiModel returns empty by default', window.getCustomApiModel() === '');
-  assert('getCustomApiModelDisplay with no model', window.getCustomApiModelDisplay() === '(no model selected)');
-  window.setCustomApiModel('gpt-4o');
-  assert('setCustomApiModel persists', window.getCustomApiModel() === 'gpt-4o');
-  // Model display with cached models
-  localStorage.setItem('labcharts-custom-models', JSON.stringify([
-    { id: 'gpt-4o', name: 'GPT-4o' },
-    { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' }
-  ]));
-  assert('getCustomApiModelDisplay resolves name from cache', window.getCustomApiModelDisplay() === 'GPT-4o');
-  window.setCustomApiModel('claude-sonnet-4-6');
-  assert('getCustomApiModelDisplay resolves second model', window.getCustomApiModelDisplay() === 'Claude Sonnet 4.6');
-  // Unknown model falls back to ID
-  window.setCustomApiModel('unknown-model-xyz');
-  assert('getCustomApiModelDisplay falls back to model ID', window.getCustomApiModelDisplay() === 'unknown-model-xyz');
-  // Restore
-  if (oldModel) localStorage.setItem('labcharts-custom-model', oldModel);
-  else localStorage.removeItem('labcharts-custom-model');
-  if (oldModels) localStorage.setItem('labcharts-custom-models', oldModels);
-  else localStorage.removeItem('labcharts-custom-models');
+// api.js + provider-panels.js expose the Custom-provider helpers via
+// Object.assign(window, ...).
+await import('../js/state.js');
+await import('../js/api.js');
+await import('../js/provider-panels.js');
 
-  // ─── 6. hasAIProvider integration ───
-  console.log('\n6. hasAIProvider integration');
-  const oldProvider = localStorage.getItem('labcharts-ai-provider');
-  const savedUrl = localStorage.getItem('labcharts-custom-url');
-  const savedKey = localStorage.getItem('labcharts-custom-key');
-  window.setAIProvider('custom');
-  // No URL, no key
-  localStorage.removeItem('labcharts-custom-url');
-  localStorage.removeItem('labcharts-custom-key');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
-  assert('hasAIProvider false without URL or key', window.hasAIProvider() === false);
-  // Key only, no URL
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'test-key');
-  assert('hasAIProvider false with key but no URL', window.hasAIProvider() === false);
-  // URL only, no key
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
-  window.setCustomApiUrl('https://api.example.com/v1');
-  assert('hasAIProvider false with URL but no key', window.hasAIProvider() === false);
-  // Both URL and key
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'test-key');
-  assert('hasAIProvider true with both URL and key', window.hasAIProvider() === true);
-  // Restore
-  if (oldProvider) localStorage.setItem('labcharts-ai-provider', oldProvider);
-  else localStorage.removeItem('labcharts-ai-provider');
-  if (savedUrl) localStorage.setItem('labcharts-custom-url', savedUrl);
-  else localStorage.removeItem('labcharts-custom-url');
-  if (savedKey) localStorage.setItem('labcharts-custom-key', savedKey);
-  else localStorage.removeItem('labcharts-custom-key');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+// ─── 1. api.js source inspection ───
+console.log('1. api.js source inspection');
+const apiSrc = read('js/api.js');
+assert('getCustomApiUrl exists', apiSrc.includes('function getCustomApiUrl()'));
+assert('setCustomApiUrl exists', apiSrc.includes('function setCustomApiUrl('));
+assert('getCustomApiKey exists', apiSrc.includes('function getCustomApiKey()'));
+assert('saveCustomApiKey exists', apiSrc.includes('function saveCustomApiKey('));
+assert('hasCustomApiKey exists', apiSrc.includes('function hasCustomApiKey()'));
+assert('getCustomApiModel exists', apiSrc.includes('function getCustomApiModel()'));
+assert('setCustomApiModel exists', apiSrc.includes('function setCustomApiModel('));
+assert('getCustomApiModelDisplay exists', apiSrc.includes('function getCustomApiModelDisplay()'));
+assert('fetchCustomApiModels exists', apiSrc.includes('function fetchCustomApiModels('));
+assert('validateCustomApiKey exists', apiSrc.includes('function validateCustomApiKey('));
+assert('callCustomAPI exists', apiSrc.includes('function callCustomAPI('));
+assert('hasAIProvider handles custom', apiSrc.includes("provider === 'custom') return hasCustomApiKey()"));
+assert('hasAIProvider custom requires URL', apiSrc.includes("hasCustomApiKey() && !!getCustomApiUrl()"));
+assert('getActiveModelId handles custom', apiSrc.includes("provider === 'custom') return getCustomApiModel()"));
+assert('getActiveModelDisplay handles custom', apiSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
+assert('callClaudeAPI handles custom', apiSrc.includes("provider === 'custom') return callCustomAPI("));
+assert('supportsWebSearch false for custom', apiSrc.includes("provider === 'custom') return false"));
+assert('supportsVision true for custom', apiSrc.includes("provider === 'custom') return true"));
+assert('callCustomAPI routes through proxy', apiSrc.includes("'Custom', opts,\n    {}"));
+assert('saveCustomApiKey uses encryptedSetItem', apiSrc.includes("encryptedSetItem('labcharts-custom-key'"));
+assert('getCustomApiKey uses getCachedKey', apiSrc.includes("getCachedKey('labcharts-custom-key')"));
 
-  // ─── 7. getActiveModelId / getActiveModelDisplay ───
-  console.log('\n7. getActiveModelId / getActiveModelDisplay');
-  const savedProvider2 = localStorage.getItem('labcharts-ai-provider');
-  const savedModel2 = localStorage.getItem('labcharts-custom-model');
-  const savedModels2 = localStorage.getItem('labcharts-custom-models');
-  window.setAIProvider('custom');
-  window.setCustomApiModel('my-custom-model');
-  assert('getActiveModelId returns custom model', window.getActiveModelId() === 'my-custom-model');
-  localStorage.setItem('labcharts-custom-models', JSON.stringify([{ id: 'my-custom-model', name: 'My Custom Model' }]));
-  assert('getActiveModelDisplay returns display name', window.getActiveModelDisplay() === 'My Custom Model');
-  // Restore
-  if (savedProvider2) localStorage.setItem('labcharts-ai-provider', savedProvider2);
-  else localStorage.removeItem('labcharts-ai-provider');
-  if (savedModel2) localStorage.setItem('labcharts-custom-model', savedModel2);
-  else localStorage.removeItem('labcharts-custom-model');
-  if (savedModels2) localStorage.setItem('labcharts-custom-models', savedModels2);
-  else localStorage.removeItem('labcharts-custom-models');
+// ─── 2. Window function exports ───
+console.log('\n2. Window function exports');
+assert('window.getCustomApiUrl is function', typeof window.getCustomApiUrl === 'function');
+assert('window.setCustomApiUrl is function', typeof window.setCustomApiUrl === 'function');
+assert('window.getCustomApiKey is function', typeof window.getCustomApiKey === 'function');
+assert('window.saveCustomApiKey is function', typeof window.saveCustomApiKey === 'function');
+assert('window.hasCustomApiKey is function', typeof window.hasCustomApiKey === 'function');
+assert('window.getCustomApiModel is function', typeof window.getCustomApiModel === 'function');
+assert('window.setCustomApiModel is function', typeof window.setCustomApiModel === 'function');
+assert('window.getCustomApiModelDisplay is function', typeof window.getCustomApiModelDisplay === 'function');
+assert('window.fetchCustomApiModels is function', typeof window.fetchCustomApiModels === 'function');
+assert('window.validateCustomApiKey is function', typeof window.validateCustomApiKey === 'function');
+assert('window.callCustomAPI is function', typeof window.callCustomAPI === 'function');
+assert('window.handleSaveCustomApi is function', typeof window.handleSaveCustomApi === 'function');
+assert('window.handleRemoveCustomApi is function', typeof window.handleRemoveCustomApi === 'function');
+assert('window.renderCustomApiModelDropdown is function', typeof window.renderCustomApiModelDropdown === 'function');
+assert('window.applyCustomApiManualModel is function', typeof window.applyCustomApiManualModel === 'function');
 
-  // ─── 8. supportsWebSearch / supportsVision ───
-  console.log('\n8. supportsWebSearch / supportsVision');
-  const savedProvider3 = localStorage.getItem('labcharts-ai-provider');
-  window.setAIProvider('custom');
-  assert('supportsWebSearch returns false for custom', window.supportsWebSearch() === false);
-  assert('supportsVision returns true for custom', window.supportsVision() === true);
-  // Restore
-  if (savedProvider3) localStorage.setItem('labcharts-ai-provider', savedProvider3);
-  else localStorage.removeItem('labcharts-ai-provider');
+// ─── 3. URL management ───
+console.log('\n3. URL management');
+const oldUrl = localStorage.getItem('labcharts-custom-url');
+localStorage.removeItem('labcharts-custom-url');
+assert('getCustomApiUrl returns empty by default', window.getCustomApiUrl() === '');
+window.setCustomApiUrl('https://api.example.com/v1');
+assert('setCustomApiUrl persists', window.getCustomApiUrl() === 'https://api.example.com/v1');
+assert('localStorage has labcharts-custom-url', localStorage.getItem('labcharts-custom-url') === 'https://api.example.com/v1');
+if (oldUrl) localStorage.setItem('labcharts-custom-url', oldUrl);
+else localStorage.removeItem('labcharts-custom-url');
 
-  // ─── 9. callCustomAPI error handling ───
-  console.log('\n9. callCustomAPI error handling');
-  const savedUrlErr = localStorage.getItem('labcharts-custom-url');
-  const savedKeyErr = localStorage.getItem('labcharts-custom-key');
-  localStorage.removeItem('labcharts-custom-url');
-  localStorage.removeItem('labcharts-custom-key');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
-  try {
-    await window.callCustomAPI({ system: '', messages: [{ role: 'user', content: 'test' }] });
-    assert('callCustomAPI throws without URL', false, 'did not throw');
-  } catch (e) {
-    assert('callCustomAPI throws without URL', e.message.includes('No Custom API URL'));
-  }
-  window.setCustomApiUrl('https://api.example.com/v1');
-  try {
-    await window.callCustomAPI({ system: '', messages: [{ role: 'user', content: 'test' }] });
-    assert('callCustomAPI throws without key', false, 'did not throw');
-  } catch (e) {
-    assert('callCustomAPI throws without key', e.message.includes('No Custom API key'));
-  }
-  // Restore
-  if (savedUrlErr) localStorage.setItem('labcharts-custom-url', savedUrlErr);
-  else localStorage.removeItem('labcharts-custom-url');
-  if (savedKeyErr) localStorage.setItem('labcharts-custom-key', savedKeyErr);
-  else localStorage.removeItem('labcharts-custom-key');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+// ─── 4. Key management ───
+console.log('\n4. Key management');
+const oldKey = localStorage.getItem('labcharts-custom-key');
+localStorage.removeItem('labcharts-custom-key');
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+assert('getCustomApiKey returns empty by default', window.getCustomApiKey() === '');
+assert('hasCustomApiKey returns false without key', window.hasCustomApiKey() === false);
+if (oldKey) localStorage.setItem('labcharts-custom-key', oldKey);
 
-  // ─── 10. fetchCustomApiModels returns empty without config ───
-  console.log('\n10. fetchCustomApiModels edge cases');
-  const emptyResult = await window.fetchCustomApiModels('', '');
-  assert('fetchCustomApiModels returns [] with empty args', Array.isArray(emptyResult) && emptyResult.length === 0);
-  const noKeyResult = await window.fetchCustomApiModels('https://api.example.com/v1', '');
-  assert('fetchCustomApiModels returns [] without key', Array.isArray(noKeyResult) && noKeyResult.length === 0);
+// ─── 5. Model management ───
+console.log('\n5. Model management');
+const oldModel = localStorage.getItem('labcharts-custom-model');
+const oldModels = localStorage.getItem('labcharts-custom-models');
+localStorage.removeItem('labcharts-custom-model');
+assert('getCustomApiModel returns empty by default', window.getCustomApiModel() === '');
+assert('getCustomApiModelDisplay with no model', window.getCustomApiModelDisplay() === '(no model selected)');
+window.setCustomApiModel('gpt-4o');
+assert('setCustomApiModel persists', window.getCustomApiModel() === 'gpt-4o');
+localStorage.setItem('labcharts-custom-models', JSON.stringify([
+  { id: 'gpt-4o', name: 'GPT-4o' },
+  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6' }
+]));
+assert('getCustomApiModelDisplay resolves name from cache', window.getCustomApiModelDisplay() === 'GPT-4o');
+window.setCustomApiModel('claude-sonnet-4-6');
+assert('getCustomApiModelDisplay resolves second model', window.getCustomApiModelDisplay() === 'Claude Sonnet 4.6');
+window.setCustomApiModel('unknown-model-xyz');
+assert('getCustomApiModelDisplay falls back to model ID', window.getCustomApiModelDisplay() === 'unknown-model-xyz');
+if (oldModel) localStorage.setItem('labcharts-custom-model', oldModel);
+else localStorage.removeItem('labcharts-custom-model');
+if (oldModels) localStorage.setItem('labcharts-custom-models', oldModels);
+else localStorage.removeItem('labcharts-custom-models');
 
-  // ─── 11. Model pricing ───
-  console.log('\n11. Model pricing');
-  const pricing = window.renderModelPricingHint('custom', 'any-model');
-  assert('custom pricing returns empty (unknown endpoint)', pricing === '');
+// ─── 6. hasAIProvider integration ───
+console.log('\n6. hasAIProvider integration');
+const oldProvider = localStorage.getItem('labcharts-ai-provider');
+const savedUrl = localStorage.getItem('labcharts-custom-url');
+const savedKey = localStorage.getItem('labcharts-custom-key');
+window.setAIProvider('custom');
+localStorage.removeItem('labcharts-custom-url');
+localStorage.removeItem('labcharts-custom-key');
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+assert('hasAIProvider false without URL or key', window.hasAIProvider() === false);
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'test-key');
+assert('hasAIProvider false with key but no URL', window.hasAIProvider() === false);
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+window.setCustomApiUrl('https://api.example.com/v1');
+assert('hasAIProvider false with URL but no key', window.hasAIProvider() === false);
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'test-key');
+assert('hasAIProvider true with both URL and key', window.hasAIProvider() === true);
+if (oldProvider) localStorage.setItem('labcharts-ai-provider', oldProvider);
+else localStorage.removeItem('labcharts-ai-provider');
+if (savedUrl) localStorage.setItem('labcharts-custom-url', savedUrl);
+else localStorage.removeItem('labcharts-custom-url');
+if (savedKey) localStorage.setItem('labcharts-custom-key', savedKey);
+else localStorage.removeItem('labcharts-custom-key');
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
 
-  // ─── 12. settings.js + provider-panels.js source inspection ───
-  // Provider UI (including Custom) was extracted from settings.js into
-  // provider-panels.js during v1.18.5 refactor. settings.js still holds the
-  // provider-button row and the switchAIProvider wiring.
-  console.log('\n12. settings.js + provider-panels.js source inspection');
-  const settingsSrc = await fetch('js/settings.js').then(r => r.text());
-  const panelsSrc = await fetch('js/provider-panels.js').then(r => r.text());
-  // settings.js still owns the provider switcher row
-  assert('settings.js has data-provider="custom" button', settingsSrc.includes('data-provider="custom"'));
-  assert('settings.js wires switchAIProvider(\'custom\')', settingsSrc.includes("switchAIProvider('custom')"));
-  // provider-panels.js owns the Custom panel: getters/setters + handlers
-  assert('provider-panels imports getCustomApiUrl', panelsSrc.includes('getCustomApiUrl'));
-  assert('provider-panels imports setCustomApiUrl', panelsSrc.includes('setCustomApiUrl'));
-  assert('provider-panels imports getCustomApiKey', panelsSrc.includes('getCustomApiKey'));
-  assert('provider-panels imports saveCustomApiKey', panelsSrc.includes('saveCustomApiKey'));
-  // hasCustomApiKey / getCustomApiModelDisplay stay in api.js (covered by section 1);
-  // the panel uses local `currentKey`/`customModel` vars directly.
-  assert('provider-panels imports getCustomApiModel', panelsSrc.includes('getCustomApiModel'));
-  assert('provider-panels imports setCustomApiModel', panelsSrc.includes('setCustomApiModel'));
-  assert('provider-panels imports fetchCustomApiModels', panelsSrc.includes('fetchCustomApiModels'));
-  assert('provider-panels imports validateCustomApiKey', panelsSrc.includes('validateCustomApiKey'));
-  assert('renderAIProviderPanel handles custom', panelsSrc.includes("provider === 'custom'"));
-  assert('handleSaveCustomApi exists', panelsSrc.includes('function handleSaveCustomApi()'));
-  assert('handleRemoveCustomApi exists', panelsSrc.includes('function handleRemoveCustomApi()'));
-  assert('renderCustomApiModelDropdown exists', panelsSrc.includes('function renderCustomApiModelDropdown('));
-  assert('applyCustomApiManualModel exists', panelsSrc.includes('function applyCustomApiManualModel()'));
-  assert('custom-url-input element', panelsSrc.includes('custom-url-input'));
-  assert('custom-key-input element', panelsSrc.includes('custom-key-input'));
-  assert('custom-model-area element', panelsSrc.includes('custom-model-area'));
-  assert('custom-model-select element', panelsSrc.includes('custom-model-select'));
-  assert('custom-manual-model element', panelsSrc.includes('custom-manual-model'));
-  assert('initSettingsModelFetch handles custom', panelsSrc.includes('fetchCustomApiModels(customUrl, customKey)'));
-  // Window exports (provider-panels.js)
-  assert('window exports handleSaveCustomApi', panelsSrc.includes('handleSaveCustomApi,'));
-  assert('window exports handleRemoveCustomApi', panelsSrc.includes('handleRemoveCustomApi,'));
-  assert('window exports renderCustomApiModelDropdown', panelsSrc.includes('renderCustomApiModelDropdown,'));
-  assert('window exports applyCustomApiManualModel', panelsSrc.includes('applyCustomApiManualModel,'));
-  // Custom panel before Local AI (in provider-panels.js)
-  const customPanelIdx = panelsSrc.indexOf('// Custom API panel');
-  const localPanelIdx = panelsSrc.indexOf('// Local AI panel');
-  assert('Custom API panel before Local AI panel', customPanelIdx >= 0 && localPanelIdx >= 0 && customPanelIdx < localPanelIdx, `custom@${customPanelIdx}, local@${localPanelIdx}`);
+// ─── 7. getActiveModelId / getActiveModelDisplay ───
+console.log('\n7. getActiveModelId / getActiveModelDisplay');
+const savedProvider2 = localStorage.getItem('labcharts-ai-provider');
+const savedModel2 = localStorage.getItem('labcharts-custom-model');
+const savedModels2 = localStorage.getItem('labcharts-custom-models');
+window.setAIProvider('custom');
+window.setCustomApiModel('my-custom-model');
+assert('getActiveModelId returns custom model', window.getActiveModelId() === 'my-custom-model');
+localStorage.setItem('labcharts-custom-models', JSON.stringify([{ id: 'my-custom-model', name: 'My Custom Model' }]));
+assert('getActiveModelDisplay returns display name', window.getActiveModelDisplay() === 'My Custom Model');
+if (savedProvider2) localStorage.setItem('labcharts-ai-provider', savedProvider2);
+else localStorage.removeItem('labcharts-ai-provider');
+if (savedModel2) localStorage.setItem('labcharts-custom-model', savedModel2);
+else localStorage.removeItem('labcharts-custom-model');
+if (savedModels2) localStorage.setItem('labcharts-custom-models', savedModels2);
+else localStorage.removeItem('labcharts-custom-models');
 
-  // ─── 13. Settings modal DOM ───
-  console.log('\n13. Settings modal DOM');
-  window.openSettingsModal('ai');
-  await new Promise(r => setTimeout(r, 100));
-  const providerBtns = document.querySelectorAll('.ai-provider-btn');
-  assert('6 provider buttons in settings', providerBtns.length === 6, `found ${providerBtns.length}`);
-  const providerValues = Array.from(providerBtns).map(b => b.dataset.provider);
-  assert('provider buttons include custom', providerValues.includes('custom'));
-  assert('custom button before local', providerValues.indexOf('custom') < providerValues.indexOf('ollama'));
-  // Switch to Custom panel
-  window.switchAIProvider('custom');
-  await new Promise(r => setTimeout(r, 100));
-  assert('custom-url-input exists in DOM', !!document.getElementById('custom-url-input'));
-  assert('custom-key-input exists in DOM', !!document.getElementById('custom-key-input'));
-  assert('panel has Save & Validate button', !!document.querySelector('.ai-provider-panel .import-btn-primary'));
-  assert('panel has OpenAI-compatible description', document.querySelector('.ai-provider-desc').textContent.includes('OpenAI-compatible'));
-  // Close settings
-  window.closeSettingsModal();
+// ─── 8. supportsWebSearch / supportsVision ───
+console.log('\n8. supportsWebSearch / supportsVision');
+const savedProvider3 = localStorage.getItem('labcharts-ai-provider');
+window.setAIProvider('custom');
+assert('supportsWebSearch returns false for custom', window.supportsWebSearch() === false);
+assert('supportsVision returns true for custom', window.supportsVision() === true);
+if (savedProvider3) localStorage.setItem('labcharts-ai-provider', savedProvider3);
+else localStorage.removeItem('labcharts-ai-provider');
 
-  // ─── 14. Settings DOM with connected state ───
-  console.log('\n14. Settings DOM with connected state');
-  const sv_url = localStorage.getItem('labcharts-custom-url');
-  const sv_key = localStorage.getItem('labcharts-custom-key');
-  const sv_model = localStorage.getItem('labcharts-custom-model');
-  const sv_models = localStorage.getItem('labcharts-custom-models');
-  const sv_prov = localStorage.getItem('labcharts-ai-provider');
-  // Set up connected state
-  window.setCustomApiUrl('https://api.test.com/v1');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'sk-test');
-  window.setCustomApiModel('test-model');
-  localStorage.setItem('labcharts-custom-models', JSON.stringify([
-    { id: 'test-model', name: 'Test Model' },
-    { id: 'other-model', name: 'Other Model' }
-  ]));
-  window.setAIProvider('custom');
-  window.openSettingsModal('ai');
-  await new Promise(r => setTimeout(r, 100));
-  window.switchAIProvider('custom');
-  await new Promise(r => setTimeout(r, 100));
-  assert('connected status shown', document.getElementById('custom-key-status')?.textContent?.includes('Connected'));
-  assert('model dropdown exists in connected state', !!document.getElementById('custom-model-select'));
-  const select = document.getElementById('custom-model-select');
-  if (select) {
-    assert('model dropdown has 2 options', select.options.length === 2, `found ${select.options.length}`);
-    assert('selected model is test-model', select.value === 'test-model');
-  }
-  assert('manual model input exists in connected state', !!document.getElementById('custom-manual-model'));
-  assert('Remove button shown in connected state', document.querySelector('.ai-provider-panel').innerHTML.includes('handleRemoveCustomApi'));
-  window.closeSettingsModal();
-  // Restore
-  if (sv_url) localStorage.setItem('labcharts-custom-url', sv_url); else localStorage.removeItem('labcharts-custom-url');
-  if (sv_key) localStorage.setItem('labcharts-custom-key', sv_key); else localStorage.removeItem('labcharts-custom-key');
-  if (sv_model) localStorage.setItem('labcharts-custom-model', sv_model); else localStorage.removeItem('labcharts-custom-model');
-  if (sv_models) localStorage.setItem('labcharts-custom-models', sv_models); else localStorage.removeItem('labcharts-custom-models');
-  if (sv_prov) localStorage.setItem('labcharts-ai-provider', sv_prov); else localStorage.removeItem('labcharts-ai-provider');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+// ─── 9. callCustomAPI error handling ───
+console.log('\n9. callCustomAPI error handling');
+const savedUrlErr = localStorage.getItem('labcharts-custom-url');
+const savedKeyErr = localStorage.getItem('labcharts-custom-key');
+localStorage.removeItem('labcharts-custom-url');
+localStorage.removeItem('labcharts-custom-key');
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+try {
+  await window.callCustomAPI({ system: '', messages: [{ role: 'user', content: 'test' }] });
+  assert('callCustomAPI throws without URL', false, 'did not throw');
+} catch (e) {
+  assert('callCustomAPI throws without URL', e.message.includes('No Custom API URL'));
+}
+window.setCustomApiUrl('https://api.example.com/v1');
+try {
+  await window.callCustomAPI({ system: '', messages: [{ role: 'user', content: 'test' }] });
+  assert('callCustomAPI throws without key', false, 'did not throw');
+} catch (e) {
+  assert('callCustomAPI throws without key', e.message.includes('No Custom API key'));
+}
+if (savedUrlErr) localStorage.setItem('labcharts-custom-url', savedUrlErr);
+else localStorage.removeItem('labcharts-custom-url');
+if (savedKeyErr) localStorage.setItem('labcharts-custom-key', savedKeyErr);
+else localStorage.removeItem('labcharts-custom-key');
+window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
 
-  // ─── 15. pdf-import.js model switch ───
-  console.log('\n15. pdf-import.js model switch');
-  const pdfSrc = await fetch('js/pdf-import.js').then(r => r.text());
-  assert('pdf-import imports setCustomApiModel', pdfSrc.includes('setCustomApiModel'));
-  assert('pdf-import handles custom in tryAutoSwitchModel', pdfSrc.includes("provider === 'custom') setCustomApiModel("));
+// ─── 10. fetchCustomApiModels returns empty without config ───
+console.log('\n10. fetchCustomApiModels edge cases');
+const emptyResult = await window.fetchCustomApiModels('', '');
+assert('fetchCustomApiModels returns [] with empty args', Array.isArray(emptyResult) && emptyResult.length === 0);
+const noKeyResult = await window.fetchCustomApiModels('https://api.example.com/v1', '');
+assert('fetchCustomApiModels returns [] without key', Array.isArray(noKeyResult) && noKeyResult.length === 0);
 
-  // ─── 16. Service worker bypass ───
-  console.log('\n16. Service worker');
-  const swSrc = await fetch('service-worker.js').then(r => r.text());
-  assert('SW bypasses cross-origin GETs', swSrc.includes('url.hostname !== self.location.hostname'));
+// ─── 11. Model pricing ───
+console.log('\n11. Model pricing');
+const pricing = window.renderModelPricingHint('custom', 'any-model');
+assert('custom pricing returns empty (unknown endpoint)', pricing === '');
 
-  // ─── 17. Proxy supports GET passthrough ───
-  console.log('\n17. Proxy GET support');
-  const proxySrc = await fetch('api/proxy.js').then(r => r.text());
-  assert('proxy extracts method field', proxySrc.includes('method: upstreamMethod'));
-  assert('proxy defaults to POST', proxySrc.includes("upstreamMethod || 'POST'"));
-  assert('proxy skips body for GET', proxySrc.includes("fetchMethod !== 'GET'"));
-  // api.js uses proxy-aware fetch for models
-  assert('_customApiFetchModels uses proxy', apiSrc.includes('function _customApiFetchModels('));
-  assert('_customApiFetchModels sends method GET via proxy', apiSrc.includes("method: 'GET'"));
+// ─── 12. settings.js + provider-panels.js source inspection ───
+// Provider UI (including Custom) was extracted from settings.js into
+// provider-panels.js during v1.18.5 refactor. settings.js still holds the
+// provider-button row and the switchAIProvider wiring.
+console.log('\n12. settings.js + provider-panels.js source inspection');
+const settingsSrc = read('js/settings.js');
+const panelsSrc = read('js/provider-panels.js');
+assert('settings.js has data-provider="custom" button', settingsSrc.includes('data-provider="custom"'));
+assert("settings.js wires switchAIProvider('custom')", settingsSrc.includes("switchAIProvider('custom')"));
+assert('provider-panels imports getCustomApiUrl', panelsSrc.includes('getCustomApiUrl'));
+assert('provider-panels imports setCustomApiUrl', panelsSrc.includes('setCustomApiUrl'));
+assert('provider-panels imports getCustomApiKey', panelsSrc.includes('getCustomApiKey'));
+assert('provider-panels imports saveCustomApiKey', panelsSrc.includes('saveCustomApiKey'));
+assert('provider-panels imports getCustomApiModel', panelsSrc.includes('getCustomApiModel'));
+assert('provider-panels imports setCustomApiModel', panelsSrc.includes('setCustomApiModel'));
+assert('provider-panels imports fetchCustomApiModels', panelsSrc.includes('fetchCustomApiModels'));
+assert('provider-panels imports validateCustomApiKey', panelsSrc.includes('validateCustomApiKey'));
+assert('renderAIProviderPanel handles custom', panelsSrc.includes("provider === 'custom'"));
+assert('handleSaveCustomApi exists', panelsSrc.includes('function handleSaveCustomApi()'));
+assert('handleRemoveCustomApi exists', panelsSrc.includes('function handleRemoveCustomApi()'));
+assert('renderCustomApiModelDropdown exists', panelsSrc.includes('function renderCustomApiModelDropdown('));
+assert('applyCustomApiManualModel exists', panelsSrc.includes('function applyCustomApiManualModel()'));
+assert('custom-url-input element', panelsSrc.includes('custom-url-input'));
+assert('custom-key-input element', panelsSrc.includes('custom-key-input'));
+assert('custom-model-area element', panelsSrc.includes('custom-model-area'));
+assert('custom-model-select element', panelsSrc.includes('custom-model-select'));
+assert('custom-manual-model element', panelsSrc.includes('custom-manual-model'));
+assert('initSettingsModelFetch handles custom', panelsSrc.includes('fetchCustomApiModels(customUrl, customKey)'));
+assert('window exports handleSaveCustomApi', panelsSrc.includes('handleSaveCustomApi,'));
+assert('window exports handleRemoveCustomApi', panelsSrc.includes('handleRemoveCustomApi,'));
+assert('window exports renderCustomApiModelDropdown', panelsSrc.includes('renderCustomApiModelDropdown,'));
+assert('window exports applyCustomApiManualModel', panelsSrc.includes('applyCustomApiManualModel,'));
+const customPanelIdx = panelsSrc.indexOf('// Custom API panel');
+const localPanelIdx = panelsSrc.indexOf('// Local AI panel');
+assert('Custom API panel before Local AI panel', customPanelIdx >= 0 && localPanelIdx >= 0 && customPanelIdx < localPanelIdx, `custom@${customPanelIdx}, local@${localPanelIdx}`);
 
-  // ─── 18. needsMaxCompletionTokens — GPT-5 / o-series detection (#114) ───
-  console.log('\n18. needsMaxCompletionTokens (#114)');
-  assert('needsMaxCompletionTokens exists', typeof window.needsMaxCompletionTokens === 'function');
-  // Positive: GPT-5 family
-  assert('detects gpt-5', window.needsMaxCompletionTokens('gpt-5') === true);
-  assert('detects gpt-5.4', window.needsMaxCompletionTokens('gpt-5.4') === true);
-  assert('detects gpt-5-codex', window.needsMaxCompletionTokens('gpt-5-codex') === true);
-  assert('detects openai/gpt-5 (prefixed)', window.needsMaxCompletionTokens('openai/gpt-5') === true);
-  assert('detects openai/gpt-5.4 (prefixed)', window.needsMaxCompletionTokens('openai/gpt-5.4') === true);
-  // Positive: o-series reasoning models
-  assert('detects o1', window.needsMaxCompletionTokens('o1') === true);
-  assert('detects o1-mini', window.needsMaxCompletionTokens('o1-mini') === true);
-  assert('detects o3', window.needsMaxCompletionTokens('o3') === true);
-  assert('detects o3-mini', window.needsMaxCompletionTokens('o3-mini') === true);
-  assert('detects o4-mini', window.needsMaxCompletionTokens('o4-mini') === true);
-  assert('detects openai/o3 (prefixed)', window.needsMaxCompletionTokens('openai/o3') === true);
-  // Negative: older models that still use max_tokens
-  assert('rejects gpt-4', window.needsMaxCompletionTokens('gpt-4') === false);
-  assert('rejects gpt-4o', window.needsMaxCompletionTokens('gpt-4o') === false);
-  assert('rejects gpt-4-turbo', window.needsMaxCompletionTokens('gpt-4-turbo') === false);
-  assert('rejects gpt-3.5-turbo', window.needsMaxCompletionTokens('gpt-3.5-turbo') === false);
-  assert('rejects claude-opus-4-6', window.needsMaxCompletionTokens('claude-opus-4-6') === false);
-  assert('rejects llama-3.3-70b', window.needsMaxCompletionTokens('llama-3.3-70b') === false);
-  assert('rejects gemini-3-pro', window.needsMaxCompletionTokens('gemini-3-pro') === false);
-  assert('rejects deepseek-r1', window.needsMaxCompletionTokens('deepseek-r1') === false);
-  // Edge cases
-  assert('rejects empty string', window.needsMaxCompletionTokens('') === false);
-  assert('rejects null', window.needsMaxCompletionTokens(null) === false);
-  assert('rejects undefined', window.needsMaxCompletionTokens(undefined) === false);
-  // False-positive guards: must not match "gpt-5x" style malformed substrings or "ox" identifiers
-  assert('rejects gpt-50 (not GPT-5)', window.needsMaxCompletionTokens('gpt-50') === false);
-  assert('rejects ozone (no o[1-9] at start)', window.needsMaxCompletionTokens('ozone') === false);
-  assert('rejects openai/gpt-50', window.needsMaxCompletionTokens('openai/gpt-50') === false);
-  // callOpenAICompatibleAPI uses the helper to pick the field
-  assert('callOpenAICompatibleAPI uses needsMaxCompletionTokens', apiSrc.includes('needsMaxCompletionTokens(model)'));
-  assert('body uses dynamic tokenLimitField', apiSrc.includes('[tokenLimitField]:'));
-  assert('tokenLimitField defaults to max_tokens', apiSrc.includes("? 'max_completion_tokens' : 'max_tokens'"));
+// Sections 13, 14 (Settings modal DOM) live in test-custom-api-dom.js.
 
-  // ─── 19. Startup cache decrypts Custom API key (#124) ───
-  // Regression: API_KEY_LS_KEYS must include 'labcharts-custom-key' so
-  // decryptKeyCache() populates the in-memory cache on page reload. Without
-  // this, getCachedKey falls back to localStorage.getItem, which returns the
-  // raw encrypted blob — and callCustomAPI sends that as the Bearer token.
-  console.log('\n19. Startup cache decrypts Custom API key (#124)');
-  const cryptoSrc = await fetch('js/crypto.js').then(r => r.text());
-  const apiKeyListMatch = cryptoSrc.match(/const\s+API_KEY_LS_KEYS\s*=\s*\[([^\]]*)\]/);
-  assert('API_KEY_LS_KEYS array exists in crypto.js', !!apiKeyListMatch);
-  if (apiKeyListMatch) {
-    const listBody = apiKeyListMatch[1];
-    assert('API_KEY_LS_KEYS includes labcharts-custom-key', listBody.includes("'labcharts-custom-key'"),
-      'Custom API key must be decrypted into in-memory cache at startup (issue #124)');
-  }
-  // Runtime check: after a round-trip through decryptKeyCache, the cached key
-  // should match what was originally stored (not the encrypted ciphertext blob).
-  if (typeof window.decryptKeyCache === 'function' && typeof window.isUnlocked === 'function' && window.isUnlocked() && typeof window.getCustomApiKey === 'function') {
-    const sv_key = localStorage.getItem('labcharts-custom-key');
-    try {
-      await window.saveCustomApiKey('sk-roundtrip-test-124');
-      // Confirm stored form is encrypted
-      const storedRaw = localStorage.getItem('labcharts-custom-key');
-      const looksEncrypted = !!storedRaw && storedRaw.startsWith('enc_v1:');
-      assert('saveCustomApiKey stores encrypted ciphertext', looksEncrypted,
-        `got: ${storedRaw ? storedRaw.slice(0, 20) + '…' : 'null'}`);
-      // Clear cache, then re-decrypt from localStorage (simulates page reload)
-      window.updateKeyCache('labcharts-custom-key', null);
-      await window.decryptKeyCache();
-      assert('decryptKeyCache rehydrates custom key from encrypted storage', window.getCustomApiKey() === 'sk-roundtrip-test-124',
-        `got: ${window.getCustomApiKey()}`);
-    } finally {
-      if (sv_key) localStorage.setItem('labcharts-custom-key', sv_key);
-      else localStorage.removeItem('labcharts-custom-key');
-      window.updateKeyCache('labcharts-custom-key', null);
-    }
-  } else {
-    console.log('  (skipped runtime rehydrate — encryption not unlocked in this session)');
-  }
+// ─── 15. pdf-import.js model switch ───
+console.log('\n15. pdf-import.js model switch');
+const pdfSrc = read('js/pdf-import.js');
+assert('pdf-import imports setCustomApiModel', pdfSrc.includes('setCustomApiModel'));
+assert('pdf-import handles custom in tryAutoSwitchModel', pdfSrc.includes("provider === 'custom') setCustomApiModel("));
 
-  // ═══ SUMMARY ═══
-  console.log('\n' + results.join('\n'));
-  console.log(`\n=== ${passed} passed, ${failed} failed, ${passed + failed} total ===`);
-  if (failed === 0) console.log('ALL TESTS PASSED');
-  else console.warn(`${failed} test(s) failed`);
-})();
+// ─── 16. Service worker bypass ───
+console.log('\n16. Service worker');
+const swSrc = read('service-worker.js');
+assert('SW bypasses cross-origin GETs', swSrc.includes('url.hostname !== self.location.hostname'));
+
+// ─── 17. Proxy supports GET passthrough ───
+console.log('\n17. Proxy GET support');
+const proxySrc = read('api/proxy.js');
+assert('proxy extracts method field', proxySrc.includes('method: upstreamMethod'));
+assert('proxy defaults to POST', proxySrc.includes("upstreamMethod || 'POST'"));
+assert('proxy skips body for GET', proxySrc.includes("fetchMethod !== 'GET'"));
+assert('_customApiFetchModels uses proxy', apiSrc.includes('function _customApiFetchModels('));
+assert('_customApiFetchModels sends method GET via proxy', apiSrc.includes("method: 'GET'"));
+
+// ─── 18. needsMaxCompletionTokens — GPT-5 / o-series detection (#114) ───
+console.log('\n18. needsMaxCompletionTokens (#114)');
+assert('needsMaxCompletionTokens exists', typeof window.needsMaxCompletionTokens === 'function');
+assert('detects gpt-5', window.needsMaxCompletionTokens('gpt-5') === true);
+assert('detects gpt-5.4', window.needsMaxCompletionTokens('gpt-5.4') === true);
+assert('detects gpt-5-codex', window.needsMaxCompletionTokens('gpt-5-codex') === true);
+assert('detects openai/gpt-5 (prefixed)', window.needsMaxCompletionTokens('openai/gpt-5') === true);
+assert('detects openai/gpt-5.4 (prefixed)', window.needsMaxCompletionTokens('openai/gpt-5.4') === true);
+assert('detects o1', window.needsMaxCompletionTokens('o1') === true);
+assert('detects o1-mini', window.needsMaxCompletionTokens('o1-mini') === true);
+assert('detects o3', window.needsMaxCompletionTokens('o3') === true);
+assert('detects o3-mini', window.needsMaxCompletionTokens('o3-mini') === true);
+assert('detects o4-mini', window.needsMaxCompletionTokens('o4-mini') === true);
+assert('detects openai/o3 (prefixed)', window.needsMaxCompletionTokens('openai/o3') === true);
+assert('rejects gpt-4', window.needsMaxCompletionTokens('gpt-4') === false);
+assert('rejects gpt-4o', window.needsMaxCompletionTokens('gpt-4o') === false);
+assert('rejects gpt-4-turbo', window.needsMaxCompletionTokens('gpt-4-turbo') === false);
+assert('rejects gpt-3.5-turbo', window.needsMaxCompletionTokens('gpt-3.5-turbo') === false);
+assert('rejects claude-opus-4-6', window.needsMaxCompletionTokens('claude-opus-4-6') === false);
+assert('rejects llama-3.3-70b', window.needsMaxCompletionTokens('llama-3.3-70b') === false);
+assert('rejects gemini-3-pro', window.needsMaxCompletionTokens('gemini-3-pro') === false);
+assert('rejects deepseek-r1', window.needsMaxCompletionTokens('deepseek-r1') === false);
+assert('rejects empty string', window.needsMaxCompletionTokens('') === false);
+assert('rejects null', window.needsMaxCompletionTokens(null) === false);
+assert('rejects undefined', window.needsMaxCompletionTokens(undefined) === false);
+assert('rejects gpt-50 (not GPT-5)', window.needsMaxCompletionTokens('gpt-50') === false);
+assert('rejects ozone (no o[1-9] at start)', window.needsMaxCompletionTokens('ozone') === false);
+assert('rejects openai/gpt-50', window.needsMaxCompletionTokens('openai/gpt-50') === false);
+assert('callOpenAICompatibleAPI uses needsMaxCompletionTokens', apiSrc.includes('needsMaxCompletionTokens(model)'));
+assert('body uses dynamic tokenLimitField', apiSrc.includes('[tokenLimitField]:'));
+assert('tokenLimitField defaults to max_tokens', apiSrc.includes("? 'max_completion_tokens' : 'max_tokens'"));
+
+// ─── 19. Startup cache decrypts Custom API key (#124) ───
+// Regression: API_KEY_LS_KEYS must include 'labcharts-custom-key' so
+// decryptKeyCache() populates the in-memory cache on page reload.
+console.log('\n19. Startup cache decrypts Custom API key (#124)');
+const cryptoSrc = read('js/crypto.js');
+const apiKeyListMatch = cryptoSrc.match(/const\s+API_KEY_LS_KEYS\s*=\s*\[([^\]]*)\]/);
+assert('API_KEY_LS_KEYS array exists in crypto.js', !!apiKeyListMatch);
+if (apiKeyListMatch) {
+  const listBody = apiKeyListMatch[1];
+  assert('API_KEY_LS_KEYS includes labcharts-custom-key', listBody.includes("'labcharts-custom-key'"),
+    'Custom API key must be decrypted into in-memory cache at startup (issue #124)');
+}
+// Runtime rehydrate check is gated on encryption being unlocked — in Node
+// it isn't, so only the source-string check above runs. The puppeteer
+// suite (which has the full crypto stack) exercises the runtime path.
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Single port off the puppeteer runner, same Vitest+DOM-split pattern as batches 19–23:

- **`test-custom-api.js`** (125 asserts) → Vitest. Source-inspection of api.js / settings.js / provider-panels.js / pdf-import.js / service-worker.js / api/proxy.js / crypto.js; behavioral tests for URL/key/model management, `hasAIProvider` gating (URL **and** key both required), `callCustomAPI` error paths (throws before any fetch), `fetchCustomApiModels` empty-arg early-returns, and the full **`needsMaxCompletionTokens` GPT-5 / o-series detection matrix** (#114 — ~27 cases).
- **`test-custom-api-dom.js`** (13 asserts, new) → puppeteer. Sections 13/14: `openSettingsModal` provider grid, `switchAIProvider` rendering the Custom panel form fields, and the connected-state model dropdown (`<select>` with `.options`).

## Note on section 19

The section-19 runtime key-rehydrate probe was already gated on `window.isUnlocked()` — in Node that's false, so only the crypto.js source-string check (`API_KEY_LS_KEYS` includes `labcharts-custom-key`) runs in Vitest. The puppeteer suite still has the full crypto stack and exercises the runtime rehydrate path via the other tests.

## Test plan

- [x] `node tests/test-custom-api.js` — **125/125** standalone
- [x] `npx vitest run tests/_vitest-legacy.test.js` — **67 tests / 4.45s** (was 66 / 5.0s)
- [x] `./run-tests.sh` — full suite green; `test-custom-api-dom.js` ran in puppeteer (**13/13**)

## Numbers after this PR

- **Vitest**: 67 tests (was 66)
- **Puppeteer remaining**: 33 (was 34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)