### PR TITLE
Vitest batch 27: test-dashboard-knowledge-base (31 asserts split)

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -49,7 +49,10 @@ const TEST_FILES = [
   'tests/test-wearables-manual.js',
   'tests/test-wearables-sync-flow.js',
   'tests/test-wearables-ui-flows.js',
-  'tests/test-dashboard-knowledge-base.js',
+  // test-dashboard-knowledge-base.js HTML-string rendering checks ported to
+  // Vitest (batch 27). Section 5 (picker open/dismiss — live DOM overlay +
+  // click) lives in test-dashboard-knowledge-base-dom.js below.
+  'tests/test-dashboard-knowledge-base-dom.js',
   'tests/test-dashboard-data-protection.js',
   'tests/test-chat-panel-ux.js',
   'tests/test-cashu-wallet.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -138,6 +138,10 @@ const LEGACY_TESTS = [
   // Batch 26 — EMF assessment (full port, no DOM split — pure-logic +
   // module imports: SBM-2015 thresholds, severity tiers, affiliate catalog).
   './test-emf.js',
+  // Batch 27 — dashboard KB / Personalize-AI CTA HTML-string rendering
+  // (section 5 picker open/dismiss in test-dashboard-knowledge-base-dom.js
+  // stays on puppeteer).
+  './test-dashboard-knowledge-base.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-dashboard-knowledge-base-dom.js
+++ b/tests/test-dashboard-knowledge-base-dom.js
@@ -1,0 +1,49 @@
+// test-dashboard-knowledge-base-dom.js — section 5 (picker open/dismiss)
+// extracted from test-dashboard-knowledge-base.js. Stays in the puppeteer
+// runner: openPersonalizeAIPicker() attaches a real overlay to the document,
+// the assertions read back classList/querySelectorAll on it, and dismissal
+// goes through a real click handler. The HTML-string rendering checks
+// (sections 1-4, 6, 7) live in test-dashboard-knowledge-base.js (Vitest).
+//
+// Run: fetch('tests/test-dashboard-knowledge-base-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Dashboard KB Picker DOM Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const cards = await import('../js/context-cards.js');
+
+  // ─── 5. Picker opens + dismisses ───
+  const before = document.getElementById('ai-personalize-picker-overlay');
+  assert('picker overlay not present before open', !before || !before.classList.contains('show'));
+
+  cards.openPersonalizeAIPicker();
+  const overlay = document.getElementById('ai-personalize-picker-overlay');
+  assert('picker overlay attached on open',
+    !!overlay && overlay.classList.contains('show'));
+  // v1.3.28 reverted to 2 cards — DNA was a category mistake (it's
+  // biological data, not a personalization preference).
+  assert('picker has two option cards (Lens + KB)',
+    overlay && overlay.querySelectorAll('.ai-picker-card').length === 2);
+  const titles = overlay
+    ? Array.from(overlay.querySelectorAll('.ai-picker-title')).map(t => t.textContent.trim())
+    : [];
+  assert('picker offers Interpretive Lens and Knowledge Base',
+    titles.includes('Interpretive Lens') && titles.includes('Knowledge Base'));
+  assert('picker does NOT offer DNA Data', !titles.includes('DNA Data'));
+  assert('picker has cancel button',
+    !!(overlay && overlay.querySelector('#ai-personalize-picker-cancel')));
+
+  // Dismiss via the Cancel button click handler.
+  overlay?.querySelector('#ai-personalize-picker-cancel')?.click();
+  assert('cancel dismisses overlay', !!overlay && !overlay.classList.contains('show'));
+
+  console.log(`\n%c Dashboard KB Picker DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-dashboard-knowledge-base-dom'] = { pass, fail };
+})();

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -31,39 +31,49 @@ console.log('=== Dashboard KB / Personalize-AI Tests ===\n');
 // pure-synchronous (reads cfg + the localStorage count-shadow, never the
 // worker), so stubbing these capabilities lets the real count-driven
 // visibility logic run in Node. Section 5's live picker test stays on
-// puppeteer where these are genuinely present. Both are restored in the
-// finally block so they don't leak into later legacy tests.
+// puppeteer where these are genuinely present.
+//
+// The stub install + module imports happen INSIDE the try block so the
+// finally cleanup runs even if an import throws — otherwise a stub Worker
+// / empty navigator.storage would leak into later legacy tests.
 const _hadNavStorage = !!(globalThis.navigator && globalThis.navigator.storage);
 const _hadWorker = typeof globalThis.Worker !== 'undefined';
-if (globalThis.navigator && !globalThis.navigator.storage) {
-  globalThis.navigator.storage = {};
-}
-if (typeof globalThis.Worker === 'undefined') {
-  globalThis.Worker = class { constructor() {} postMessage() {} terminate() {} };
-}
 
-const lens = await import('../js/lens.js');
-const cards = await import('../js/context-cards.js');
-const { state } = await import('../js/state.js');
-
-// Snapshot everything we touch + restore in finally.
-const savedCfg = localStorage.getItem('labcharts-lens-config');
-const savedCount = localStorage.getItem('labcharts-lens-local-count');
-const savedLens = state.importedData?.interpretiveLens;
+// Snapshot vars are assigned inside the try once `state` is imported;
+// declared here so the finally-scoped restore() can see them.
+let savedCfg = null, savedCount = null, savedLens;
+let _state = null;
 const restore = () => {
   if (savedCfg === null) localStorage.removeItem('labcharts-lens-config');
   else localStorage.setItem('labcharts-lens-config', savedCfg);
   if (savedCount === null) localStorage.removeItem('labcharts-lens-local-count');
   else localStorage.setItem('labcharts-lens-local-count', savedCount);
-  if (state.importedData) state.importedData.interpretiveLens = savedLens;
+  if (_state && _state.importedData) _state.importedData.interpretiveLens = savedLens;
   // Undo the capability stubs so they don't leak into later legacy tests.
   if (!_hadNavStorage && globalThis.navigator) delete globalThis.navigator.storage;
   if (!_hadWorker) delete globalThis.Worker;
 };
 
-if (!state.importedData) state.importedData = {};
-
 try {
+  if (globalThis.navigator && !globalThis.navigator.storage) {
+    globalThis.navigator.storage = {};
+  }
+  if (typeof globalThis.Worker === 'undefined') {
+    globalThis.Worker = class { constructor() {} postMessage() {} terminate() {} };
+  }
+
+  const lens = await import('../js/lens.js');
+  const cards = await import('../js/context-cards.js');
+  const { state } = await import('../js/state.js');
+  _state = state;
+
+  // Snapshot everything we touch + restore in finally.
+  savedCfg = localStorage.getItem('labcharts-lens-config');
+  savedCount = localStorage.getItem('labcharts-lens-local-count');
+  savedLens = state.importedData?.interpretiveLens;
+
+  if (!state.importedData) state.importedData = {};
+
   // ─── 1. Both unset → only the picker CTA renders ───
   {
     localStorage.removeItem('labcharts-lens-config');

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // test-dashboard-knowledge-base.js — KB row + Personalize-AI CTA on the dashboard
 //
 // UX contract (v1.3.23):
@@ -9,163 +10,158 @@
 //       · only lens unset → "+ Set an interpretive lens", direct
 //   - Both set              → no pill, just two compact rows
 //
-// Empty UI should ask for one click, not stretch full-width — the heavy
-// dashed stubs from the first iteration are gone.
+// Run: node tests/test-dashboard-knowledge-base.js  (or via npm test)
+//
+// Section 5 (picker open/dismiss — needs a live DOM overlay + click events)
+// lives in tests/test-dashboard-knowledge-base-dom.js on the puppeteer runner.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+import './_node-shim.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+console.log('=== Dashboard KB / Personalize-AI Tests ===\n');
+
+// hasLens() gates the in-browser backend on navigator.storage + Worker —
+// a capability check so the dashboard never shows "active" on a browser
+// that can't run the embedding worker. The KB-row *render* path itself is
+// pure-synchronous (reads cfg + the localStorage count-shadow, never the
+// worker), so stubbing these capabilities lets the real count-driven
+// visibility logic run in Node. Section 5's live picker test stays on
+// puppeteer where these are genuinely present. Both are restored in the
+// finally block so they don't leak into later legacy tests.
+const _hadNavStorage = !!(globalThis.navigator && globalThis.navigator.storage);
+const _hadWorker = typeof globalThis.Worker !== 'undefined';
+if (globalThis.navigator && !globalThis.navigator.storage) {
+  globalThis.navigator.storage = {};
+}
+if (typeof globalThis.Worker === 'undefined') {
+  globalThis.Worker = class { constructor() {} postMessage() {} terminate() {} };
+}
+
+const lens = await import('../js/lens.js');
+const cards = await import('../js/context-cards.js');
+const { state } = await import('../js/state.js');
+
+// Snapshot everything we touch + restore in finally.
+const savedCfg = localStorage.getItem('labcharts-lens-config');
+const savedCount = localStorage.getItem('labcharts-lens-local-count');
+const savedLens = state.importedData?.interpretiveLens;
+const restore = () => {
+  if (savedCfg === null) localStorage.removeItem('labcharts-lens-config');
+  else localStorage.setItem('labcharts-lens-config', savedCfg);
+  if (savedCount === null) localStorage.removeItem('labcharts-lens-local-count');
+  else localStorage.setItem('labcharts-lens-local-count', savedCount);
+  if (state.importedData) state.importedData.interpretiveLens = savedLens;
+  // Undo the capability stubs so they don't leak into later legacy tests.
+  if (!_hadNavStorage && globalThis.navigator) delete globalThis.navigator.storage;
+  if (!_hadWorker) delete globalThis.Worker;
+};
+
+if (!state.importedData) state.importedData = {};
+
+try {
+  // ─── 1. Both unset → only the picker CTA renders ───
+  {
+    localStorage.removeItem('labcharts-lens-config');
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = '';
+    const html = cards.renderInterpretiveLensSection();
+    assert('both unset: no Interpretive Lens row',
+      !/lens-section-label[^>]*>Interpretive Lens/.test(html), html);
+    assert('both unset: no Knowledge Base row',
+      !/lens-section-label[^>]*>Knowledge Base/.test(html));
+    assert('both unset: CTA pill present', html.includes('dashboard-cta'));
+    assert('both unset: picker opener wired',
+      html.includes('openPersonalizeAIPicker()'));
+    assert('both unset: generic copy used',
+      /Personalize how AI answers/i.test(html));
   }
 
-  console.log('%c Dashboard KB / Personalize-AI tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
-
-  const lens = await import('../js/lens.js');
-  const cards = await import('../js/context-cards.js');
-  const { state } = await import('../js/state.js');
-
-  // Snapshot everything we touch + restore in finally.
-  const savedCfg = localStorage.getItem('labcharts-lens-config');
-  const savedCount = localStorage.getItem('labcharts-lens-local-count');
-  const savedLens = state.importedData?.interpretiveLens;
-  const restore = () => {
-    if (savedCfg === null) localStorage.removeItem('labcharts-lens-config');
-    else localStorage.setItem('labcharts-lens-config', savedCfg);
-    if (savedCount === null) localStorage.removeItem('labcharts-lens-local-count');
-    else localStorage.setItem('labcharts-lens-local-count', savedCount);
-    if (state.importedData) state.importedData.interpretiveLens = savedLens;
-  };
-
-  if (!state.importedData) state.importedData = {};
-
-  try {
-    // ─── 1. Both unset → only the picker CTA renders ───
-    {
-      localStorage.removeItem('labcharts-lens-config');
-      localStorage.removeItem('labcharts-lens-local-count');
-      state.importedData.interpretiveLens = '';
-      const html = cards.renderInterpretiveLensSection();
-      assert('both unset: no Interpretive Lens row',
-        !/lens-section-label[^>]*>Interpretive Lens/.test(html), html);
-      assert('both unset: no Knowledge Base row',
-        !/lens-section-label[^>]*>Knowledge Base/.test(html));
-      assert('both unset: CTA pill present', html.includes('dashboard-cta'));
-      assert('both unset: picker opener wired',
-        html.includes('openPersonalizeAIPicker()'));
-      assert('both unset: generic copy used',
-        /Personalize how AI answers/i.test(html));
-    }
-
-    // ─── 2. Only Lens set → KB-direct CTA ───
-    {
-      localStorage.removeItem('labcharts-lens-config');
-      localStorage.removeItem('labcharts-lens-local-count');
-      state.importedData.interpretiveLens = 'Functional endocrinology';
-      const html = cards.renderInterpretiveLensSection();
-      assert('only lens: lens row present',
-        /lens-section-label[^>]*>Interpretive Lens/.test(html));
-      assert('only lens: KB row absent',
-        !/lens-section-label[^>]*>Knowledge Base/.test(html));
-      assert('only lens: CTA opens KB modal directly',
-        html.includes('dashboard-cta') && html.includes('openKnowledgeBaseModal()'));
-      assert('only lens: CTA copy is KB-specific',
-        /Connect a knowledge base/i.test(html));
-      assert('only lens: CTA does NOT open picker',
-        !html.includes('openPersonalizeAIPicker()'));
-    }
-
-    // ─── 3. Only KB set → Lens-direct CTA ───
-    {
-      lens.saveLensConfig({
-        backend: 'in-browser', enabled: true, name: 'Research Notes', topK: 5, multiQuery: true,
-      });
-      localStorage.setItem('labcharts-lens-local-count', '12');
-      state.importedData.interpretiveLens = '';
-      const html = cards.renderInterpretiveLensSection();
-      assert('only KB: lens row absent',
-        !/lens-section-label[^>]*>Interpretive Lens/.test(html));
-      assert('only KB: KB row present', /lens-section-label[^>]*>Knowledge Base/.test(html));
-      assert('only KB: KB row shows library name', html.includes('Research Notes'));
-      assert('only KB: CTA opens lens editor directly',
-        html.includes('dashboard-cta') && html.includes('openInterpretiveLensEditor()'));
-      assert('only KB: CTA copy is lens-specific',
-        /Set an interpretive lens/i.test(html));
-    }
-
-    // ─── 4. Both Lens + KB set → no AI-personalize CTA ───
-    // (v1.3.28 reverted DNA from this picker — DNA is data, not a
-    // personalization preference. DNA discovery now lives in the
-    // genetics dashboard section's empty-state stub instead.)
-    {
-      lens.saveLensConfig({
-        backend: 'in-browser', enabled: true, name: 'My Library', topK: 5, multiQuery: true,
-      });
-      localStorage.setItem('labcharts-lens-local-count', '99');
-      state.importedData.interpretiveLens = 'Longevity medicine';
-      const html = cards.renderInterpretiveLensSection();
-      assert('both set: lens row present',
-        /lens-section-label[^>]*>Interpretive Lens/.test(html));
-      assert('both set: KB row present',
-        /lens-section-label[^>]*>Knowledge Base/.test(html));
-      // AI-personalize CTA must be gone. Data-protection CTA may still appear.
-      assert('both set: AI-personalize CTA absent',
-        !html.includes('openPersonalizeAIPicker') &&
-        // Only the KB row's onclick should reference the modal opener.
-        !/dashboard-cta[^>]*onclick="openKnowledgeBaseModal/.test(html));
-    }
-
-    // ─── 5. Picker opens + dismisses on Escape ───
-    {
-      // First the existing overlay should not be there.
-      const before = document.getElementById('ai-personalize-picker-overlay');
-      assert('picker overlay not present before open', !before || !before.classList.contains('show'));
-
-      cards.openPersonalizeAIPicker();
-      const overlay = document.getElementById('ai-personalize-picker-overlay');
-      assert('picker overlay attached on open',
-        !!overlay && overlay.classList.contains('show'));
-      // v1.3.28 reverted to 2 cards — DNA was a category mistake (it's
-      // biological data, not a personalization preference).
-      assert('picker has two option cards (Lens + KB)',
-        overlay.querySelectorAll('.ai-picker-card').length === 2);
-      const titles = Array.from(overlay.querySelectorAll('.ai-picker-title')).map(t => t.textContent.trim());
-      assert('picker offers Interpretive Lens and Knowledge Base',
-        titles.includes('Interpretive Lens') && titles.includes('Knowledge Base'));
-      assert('picker does NOT offer DNA Data', !titles.includes('DNA Data'));
-      assert('picker has cancel button',
-        !!overlay.querySelector('#ai-personalize-picker-cancel'));
-
-      // Dismiss via the Cancel button click handler.
-      overlay.querySelector('#ai-personalize-picker-cancel').click();
-      assert('cancel dismisses overlay', !overlay.classList.contains('show'));
-    }
-
-    // ─── 6. Window exports ───
-    {
-      assert('window.openPersonalizeAIPicker exists',
-        typeof window.openPersonalizeAIPicker === 'function');
-      assert('window.openKnowledgeBaseModal exists',
-        typeof window.openKnowledgeBaseModal === 'function');
-      assert('window.closeKnowledgeBaseModal exists',
-        typeof window.closeKnowledgeBaseModal === 'function');
-      assert('window.renderKnowledgeBaseSection exists',
-        typeof window.renderKnowledgeBaseSection === 'function');
-      assert('window.triggerDNAFilePicker exists (used by genetics empty stub)',
-        typeof window.triggerDNAFilePicker === 'function');
-    }
-
-    // ─── 7. renderKnowledgeBaseSection still empty when not configured ───
-    {
-      localStorage.removeItem('labcharts-lens-config');
-      localStorage.removeItem('labcharts-lens-local-count');
-      const html = cards.renderKnowledgeBaseSection();
-      assert('renderKnowledgeBaseSection() returns empty string when no library',
-        html === '', JSON.stringify(html));
-    }
-  } finally {
-    restore();
+  // ─── 2. Only Lens set → KB-direct CTA ───
+  {
+    localStorage.removeItem('labcharts-lens-config');
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = 'Functional endocrinology';
+    const html = cards.renderInterpretiveLensSection();
+    assert('only lens: lens row present',
+      /lens-section-label[^>]*>Interpretive Lens/.test(html));
+    assert('only lens: KB row absent',
+      !/lens-section-label[^>]*>Knowledge Base/.test(html));
+    assert('only lens: CTA opens KB modal directly',
+      html.includes('dashboard-cta') && html.includes('openKnowledgeBaseModal()'));
+    assert('only lens: CTA copy is KB-specific',
+      /Connect a knowledge base/i.test(html));
+    assert('only lens: CTA does NOT open picker',
+      !html.includes('openPersonalizeAIPicker()'));
   }
 
-  console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
-})();
+  // ─── 3. Only KB set → Lens-direct CTA ───
+  {
+    lens.saveLensConfig({
+      backend: 'in-browser', enabled: true, name: 'Research Notes', topK: 5, multiQuery: true,
+    });
+    localStorage.setItem('labcharts-lens-local-count', '12');
+    state.importedData.interpretiveLens = '';
+    const html = cards.renderInterpretiveLensSection();
+    assert('only KB: lens row absent',
+      !/lens-section-label[^>]*>Interpretive Lens/.test(html));
+    assert('only KB: KB row present', /lens-section-label[^>]*>Knowledge Base/.test(html));
+    assert('only KB: KB row shows library name', html.includes('Research Notes'));
+    assert('only KB: CTA opens lens editor directly',
+      html.includes('dashboard-cta') && html.includes('openInterpretiveLensEditor()'));
+    assert('only KB: CTA copy is lens-specific',
+      /Set an interpretive lens/i.test(html));
+  }
+
+  // ─── 4. Both Lens + KB set → no AI-personalize CTA ───
+  {
+    lens.saveLensConfig({
+      backend: 'in-browser', enabled: true, name: 'My Library', topK: 5, multiQuery: true,
+    });
+    localStorage.setItem('labcharts-lens-local-count', '99');
+    state.importedData.interpretiveLens = 'Longevity medicine';
+    const html = cards.renderInterpretiveLensSection();
+    assert('both set: lens row present',
+      /lens-section-label[^>]*>Interpretive Lens/.test(html));
+    assert('both set: KB row present',
+      /lens-section-label[^>]*>Knowledge Base/.test(html));
+    assert('both set: AI-personalize CTA absent',
+      !html.includes('openPersonalizeAIPicker') &&
+      !/dashboard-cta[^>]*onclick="openKnowledgeBaseModal/.test(html));
+  }
+
+  // Section 5 (picker open/dismiss — live DOM) lives in
+  // test-dashboard-knowledge-base-dom.js.
+
+  // ─── 6. Window exports ───
+  {
+    assert('window.openPersonalizeAIPicker exists',
+      typeof window.openPersonalizeAIPicker === 'function');
+    assert('window.openKnowledgeBaseModal exists',
+      typeof window.openKnowledgeBaseModal === 'function');
+    assert('window.closeKnowledgeBaseModal exists',
+      typeof window.closeKnowledgeBaseModal === 'function');
+    assert('window.renderKnowledgeBaseSection exists',
+      typeof window.renderKnowledgeBaseSection === 'function');
+    assert('window.triggerDNAFilePicker exists (used by genetics empty stub)',
+      typeof window.triggerDNAFilePicker === 'function');
+  }
+
+  // ─── 7. renderKnowledgeBaseSection still empty when not configured ───
+  {
+    localStorage.removeItem('labcharts-lens-config');
+    localStorage.removeItem('labcharts-lens-local-count');
+    const html = cards.renderKnowledgeBaseSection();
+    assert('renderKnowledgeBaseSection() returns empty string when no library',
+      html === '', JSON.stringify(html));
+  }
+} finally {
+  restore();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Single port off the puppeteer runner, same Vitest+DOM-split pattern:

- **`test-dashboard-knowledge-base.js`** (24 asserts) → Vitest. The four CTA-contract scenarios (both-unset / only-lens / only-KB / both-set) assert against the HTML string from `renderInterpretiveLensSection()`, plus window-export checks and the `renderKnowledgeBaseSection()` empty-string case.
- **`test-dashboard-knowledge-base-dom.js`** (7 asserts, new) → puppeteer. Section 5: `openPersonalizeAIPicker()` attaching a live overlay, `classList`/`querySelectorAll` readback, and Cancel-button click dismissal.

## Capability stub

`hasLens()` gates the in-browser backend on `navigator.storage` + `Worker` — a real-browser capability check so the dashboard never shows "active" on a browser that can't run the embedding worker. The KB-row **render** path itself is pure-synchronous (reads cfg + the localStorage count-shadow, never the worker), so the test stubs those two capabilities before importing lens.js, letting the real count-driven visibility logic run in Node. Both stubs are **captured-and-restored in the `finally` block** so they don't leak into later legacy tests.

## Test plan

- [x] `node tests/test-dashboard-knowledge-base.js` — **24/24** standalone
- [x] `npx vitest run tests/_vitest-legacy.test.js` — **70 tests / 4.44s** (was 69 / 4.50s)
- [x] `./run-tests.sh` — full suite green; `test-dashboard-knowledge-base-dom.js` ran in puppeteer (**7/7**)

## Numbers after this PR

- **Vitest**: 70 tests (was 69)
- **Puppeteer remaining**: 30 (was 31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)