### PR TITLE
Vitest batch 28: test-dashboard-data-protection (17 asserts split)

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -53,7 +53,10 @@ const TEST_FILES = [
   // Vitest (batch 27). Section 5 (picker open/dismiss — live DOM overlay +
   // click) lives in test-dashboard-knowledge-base-dom.js below.
   'tests/test-dashboard-knowledge-base-dom.js',
-  'tests/test-dashboard-data-protection.js',
+  // test-dashboard-data-protection.js HTML-string rendering checks ported to
+  // Vitest (batch 28). Section 6 (picker open/dismiss — live DOM overlay +
+  // click) lives in test-dashboard-data-protection-dom.js below.
+  'tests/test-dashboard-data-protection-dom.js',
   'tests/test-chat-panel-ux.js',
   'tests/test-cashu-wallet.js',
   // test-custom-api.js source-inspection + behavioral ported to Vitest

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -142,6 +142,10 @@ const LEGACY_TESTS = [
   // (section 5 picker open/dismiss in test-dashboard-knowledge-base-dom.js
   // stays on puppeteer).
   './test-dashboard-knowledge-base.js',
+  // Batch 28 — dashboard data-protection CTA HTML-string rendering
+  // (section 6 picker open/dismiss in test-dashboard-data-protection-dom.js
+  // stays on puppeteer).
+  './test-dashboard-data-protection.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-dashboard-data-protection-dom.js
+++ b/tests/test-dashboard-data-protection-dom.js
@@ -1,0 +1,35 @@
+// test-dashboard-data-protection-dom.js — section 6 (picker open/dismiss)
+// extracted from test-dashboard-data-protection.js. Stays in the puppeteer
+// runner: openDataProtectionPicker() attaches a real overlay to the
+// document, the assertions read back classList/querySelectorAll on it, and
+// dismissal goes through a real click handler. The HTML-string rendering
+// checks (sections 1-5, 7) live in test-dashboard-data-protection.js (Vitest).
+//
+// Run: fetch('tests/test-dashboard-data-protection-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Data Protection Picker DOM Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const cards = await import('../js/context-cards.js');
+
+  // ─── 6. Picker behavior ──────────────────────────────────
+  cards.openDataProtectionPicker();
+  const overlay = document.getElementById('data-protection-picker-overlay');
+  assert('picker overlay attached', !!overlay && overlay.classList.contains('show'));
+  assert('picker has 3 cards (encryption/sync/backup) when backup supported',
+    overlay && overlay.querySelectorAll('.dashboard-picker-card').length === 3);
+  assert('cancel button present',
+    !!(overlay && overlay.querySelector('#data-protection-picker-cancel')));
+  overlay?.querySelector('#data-protection-picker-cancel')?.click();
+  assert('cancel dismisses overlay', !!overlay && !overlay.classList.contains('show'));
+
+  console.log(`\n%c Data Protection Picker DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-dashboard-data-protection-dom'] = { pass, fail };
+})();

--- a/tests/test-dashboard-data-protection.js
+++ b/tests/test-dashboard-data-protection.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // test-dashboard-data-protection.js — Data protection CTA + picker (v1.3.26)
 //
 // Surfaces three Settings → Data features (Encryption, Sync, Auto-backup)
@@ -10,97 +11,98 @@
 // renderDataProtectionCta() accepts a state override so we don't have
 // to stub module-level state-checkers (which can't be reassigned on
 // frozen ES module namespaces).
+//
+// Run: node tests/test-dashboard-data-protection.js  (or via npm test)
+//
+// Section 6 (picker open/dismiss — needs a live DOM overlay + click events)
+// lives in tests/test-dashboard-data-protection-dom.js on the puppeteer runner.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-  }
+import './_node-shim.js';
 
-  console.log('%c Data protection dashboard tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const cards = await import('../js/context-cards.js');
+console.log('=== Data Protection Dashboard Tests ===\n');
 
-  const make = (overrides) => ({
-    encryption: false,
-    sync: false,
-    backup: false,
-    backupSupported: true,
-    ...overrides,
-  });
+// context-cards.js exposes renderDataProtectionCta + openDataProtectionPicker +
+// showEnableEncryptionModal + pickFolderForBackup; showSyncSetupModal is
+// exported from settings.js (puppeteer gets it for free via main.js — in Node
+// we import it explicitly so the section-7 window-export check sees it).
+const cards = await import('../js/context-cards.js');
+await import('../js/settings.js');
 
-  // ─── 1. All configured → no pill ─────────────────────────
-  {
-    const html = cards.renderDataProtectionCta(make({ encryption: true, sync: true, backup: true }));
-    assert('all configured: empty string returned', html === '', JSON.stringify(html));
-  }
+const make = (overrides) => ({
+  encryption: false,
+  sync: false,
+  backup: false,
+  backupSupported: true,
+  ...overrides,
+});
 
-  // ─── 2. Backup unsupported (Safari) → treat as configured ─
-  {
-    const html = cards.renderDataProtectionCta(make({ encryption: true, sync: true, backup: false, backupSupported: false }));
-    assert('unsupported backup is not nagged', html === '', JSON.stringify(html));
-  }
+// ─── 1. All configured → no pill ─────────────────────────
+{
+  const html = cards.renderDataProtectionCta(make({ encryption: true, sync: true, backup: true }));
+  assert('all configured: empty string returned', html === '', JSON.stringify(html));
+}
 
-  // ─── 3. Single missing → direct CTA with feature-specific copy
-  {
-    const html = cards.renderDataProtectionCta(make({ encryption: false, sync: true, backup: true }));
-    assert('only encryption missing: direct CTA',
-      /Enable encryption/.test(html) && /showEnableEncryptionModal/.test(html));
-    assert('direct CTA does NOT open picker',
-      !/openDataProtectionPicker/.test(html));
-  }
-  {
-    const html = cards.renderDataProtectionCta(make({ encryption: true, sync: false, backup: true }));
-    assert('only sync missing: direct Sync to other devices CTA',
-      /Sync to other devices/.test(html) && /showSyncSetupModal/.test(html));
-  }
-  {
-    const html = cards.renderDataProtectionCta(make({ encryption: true, sync: true, backup: false }));
-    assert('only backup missing: direct Set up auto-backup CTA',
-      /Set up auto-backup/.test(html) && /pickFolderForBackup/.test(html));
-  }
+// ─── 2. Backup unsupported (Safari) → treat as configured ─
+{
+  const html = cards.renderDataProtectionCta(make({ encryption: true, sync: true, backup: false, backupSupported: false }));
+  assert('unsupported backup is not nagged', html === '', JSON.stringify(html));
+}
 
-  // ─── 4. Two missing → generic picker CTA ─────────────────
-  {
-    const html = cards.renderDataProtectionCta(make({ encryption: false, sync: false, backup: true }));
-    assert('two missing: generic Protect your data CTA',
-      /Protect your data/.test(html) && /openDataProtectionPicker/.test(html));
-    assert('two missing: NOT a feature-specific direct CTA',
-      !/onclick="showEnableEncryptionModal\(\)"/.test(html) && !/onclick="showSyncSetupModal\(\)"/.test(html));
-  }
+// ─── 3. Single missing → direct CTA with feature-specific copy ─
+{
+  const html = cards.renderDataProtectionCta(make({ encryption: false, sync: true, backup: true }));
+  assert('only encryption missing: direct CTA',
+    /Enable encryption/.test(html) && /showEnableEncryptionModal/.test(html));
+  assert('direct CTA does NOT open picker',
+    !/openDataProtectionPicker/.test(html));
+}
+{
+  const html = cards.renderDataProtectionCta(make({ encryption: true, sync: false, backup: true }));
+  assert('only sync missing: direct Sync to other devices CTA',
+    /Sync to other devices/.test(html) && /showSyncSetupModal/.test(html));
+}
+{
+  const html = cards.renderDataProtectionCta(make({ encryption: true, sync: true, backup: false }));
+  assert('only backup missing: direct Set up auto-backup CTA',
+    /Set up auto-backup/.test(html) && /pickFolderForBackup/.test(html));
+}
 
-  // ─── 5. All missing → picker CTA ─────────────────────────
-  {
-    const html = cards.renderDataProtectionCta(make({ encryption: false, sync: false, backup: false }));
-    assert('all missing: picker CTA renders',
-      /Protect your data/.test(html) && /openDataProtectionPicker/.test(html));
-  }
+// ─── 4. Two missing → generic picker CTA ─────────────────
+{
+  const html = cards.renderDataProtectionCta(make({ encryption: false, sync: false, backup: true }));
+  assert('two missing: generic Protect your data CTA',
+    /Protect your data/.test(html) && /openDataProtectionPicker/.test(html));
+  assert('two missing: NOT a feature-specific direct CTA',
+    !/onclick="showEnableEncryptionModal\(\)"/.test(html) && !/onclick="showSyncSetupModal\(\)"/.test(html));
+}
 
-  // ─── 6. Picker behavior ──────────────────────────────────
-  {
-    cards.openDataProtectionPicker();
-    const overlay = document.getElementById('data-protection-picker-overlay');
-    assert('picker overlay attached', !!overlay && overlay.classList.contains('show'));
-    assert('picker has 3 cards (encryption/sync/backup) when backup supported',
-      overlay.querySelectorAll('.dashboard-picker-card').length === 3);
-    assert('cancel button present',
-      !!overlay.querySelector('#data-protection-picker-cancel'));
-    overlay.querySelector('#data-protection-picker-cancel').click();
-    assert('cancel dismisses overlay', !overlay.classList.contains('show'));
-  }
+// ─── 5. All missing → picker CTA ─────────────────────────
+{
+  const html = cards.renderDataProtectionCta(make({ encryption: false, sync: false, backup: false }));
+  assert('all missing: picker CTA renders',
+    /Protect your data/.test(html) && /openDataProtectionPicker/.test(html));
+}
 
-  // ─── 7. Window exports ───────────────────────────────────
-  {
-    assert('window.openDataProtectionPicker exists',
-      typeof window.openDataProtectionPicker === 'function');
-    assert('window.showSyncSetupModal exists',
-      typeof window.showSyncSetupModal === 'function');
-    assert('window.showEnableEncryptionModal exists',
-      typeof window.showEnableEncryptionModal === 'function');
-    assert('window.pickFolderForBackup exists',
-      typeof window.pickFolderForBackup === 'function');
-  }
+// Section 6 (picker open/dismiss — live DOM) lives in
+// test-dashboard-data-protection-dom.js.
 
-  console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
-})();
+// ─── 7. Window exports ───────────────────────────────────
+{
+  assert('window.openDataProtectionPicker exists',
+    typeof window.openDataProtectionPicker === 'function');
+  assert('window.showSyncSetupModal exists',
+    typeof window.showSyncSetupModal === 'function');
+  assert('window.showEnableEncryptionModal exists',
+    typeof window.showEnableEncryptionModal === 'function');
+  assert('window.pickFolderForBackup exists',
+    typeof window.pickFolderForBackup === 'function');
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Single port off the puppeteer runner, same Vitest+DOM-split pattern:

- **`test-dashboard-data-protection.js`** (13 asserts) → Vitest. The five CTA-contract scenarios (all-configured / backup-unsupported / single-missing direct CTA ×3 / two-missing / all-missing) assert against the HTML string from `renderDataProtectionCta()` — which takes an **explicit state override**, so no capability stub needed — plus the section-7 window-export checks.
- **`test-dashboard-data-protection-dom.js`** (4 asserts, new) → puppeteer. Section 6: `openDataProtectionPicker()` attaching a live overlay, 3-card count, Cancel-button click dismissal.

## Note

`settings.js` is imported alongside `context-cards.js` so the section-7 window-export check for `showSyncSetupModal` (exported from settings.js, not context-cards.js) resolves — puppeteer gets it for free via main.js.

## Test plan

- [x] `node tests/test-dashboard-data-protection.js` — **13/13** standalone
- [x] `npx vitest run tests/_vitest-legacy.test.js` — **71 tests / 4.40s** (was 70 / 4.44s)
- [x] `./run-tests.sh` — full suite green; `test-dashboard-data-protection-dom.js` ran in puppeteer (**4/4**)

## Numbers after this PR

- **Vitest**: 71 tests (was 70)
- **Puppeteer remaining**: 29 (was 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)