### PR TITLE
Vitest batch 31: wire fake-indexeddb into the test shims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "getbased",
       "version": "1.3.8",
       "devDependencies": {
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^25.0.1",
         "puppeteer": "^24.42.0",
         "vite": "^8.0.10",
@@ -2661,6 +2662,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-fifo": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^25.0.1",
     "puppeteer": "^24.42.0",
     "vite": "^8.0.10",

--- a/tests/_node-shim.js
+++ b/tests/_node-shim.js
@@ -102,3 +102,13 @@ if (typeof globalThis.document === 'undefined') {
     styleSheets: [],
   };
 }
+
+// IndexedDB — wearables-store.js + blob-storage.js use plain IndexedDB
+// (per CLAUDE.md). `fake-indexeddb/auto` is a faithful pure-JS impl that
+// patches globalThis.indexedDB + IDBKeyRange + the IDB* constructors.
+// Side-effect import, guarded so a real browser IDB (or the Vitest setup
+// file) isn't clobbered. Top-level await is fine here — every test file
+// already `import './_node-shim.js'` ahead of its own top-level awaits.
+if (typeof globalThis.indexedDB === 'undefined') {
+  await import('fake-indexeddb/auto');
+}

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -13,6 +13,7 @@
 // To add a file to the Vitest suite, append it to LEGACY_TESTS.
 
 import { it, expect, beforeEach } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
 
 // Capture the canonical globalThis.fetch at module-load time, BEFORE
 // any LEGACY_TEST has a chance to overwrite it. Some ported tests
@@ -27,10 +28,18 @@ const _origFetch = globalThis.fetch;
 // sessionStorage / fetch / addEventListener listeners are all wired up
 // on globalThis in _vitest-setup.js — if one legacy test sets a key
 // (or overwrites fetch) and the next test reads it, results leak.
+//
+// IndexedDB: fake-indexeddb/auto installs ONE global IDBFactory for the
+// whole worker lifetime, so without a reset, an IDB-backed test (batch
+// 32+: test-wearables, test-blob-storage, …) could read stale databases
+// a prior test wrote. Swapping in a fresh IDBFactory each time gives
+// every legacy test an empty IDB. No-op for the current suite (nothing
+// touches IDB yet) — this just makes the shim ready for the IDB ports.
 beforeEach(() => {
   if (typeof globalThis.localStorage?.clear === 'function') globalThis.localStorage.clear();
   if (typeof globalThis.sessionStorage?.clear === 'function') globalThis.sessionStorage.clear();
   globalThis.fetch = _origFetch;
+  globalThis.indexedDB = new IDBFactory();
 });
 
 const LEGACY_TESTS = [

--- a/tests/_vitest-setup.js
+++ b/tests/_vitest-setup.js
@@ -144,6 +144,15 @@ if (!process.exit._vitestPatched) {
   process.exit._original = _origExit;
 }
 
+// IndexedDB — kept in sync with _node-shim.js. wearables-store.js +
+// blob-storage.js use plain IndexedDB; `fake-indexeddb/auto` patches
+// globalThis.indexedDB + IDBKeyRange + the IDB* constructors. Guarded so
+// a real browser IDB isn't clobbered. Top-level await in a Vitest setup
+// file is supported.
+if (typeof globalThis.indexedDB === 'undefined') {
+  await import('fake-indexeddb/auto');
+}
+
 // Per-test console.log capture for FAIL detection lives in
 // _vitest-legacy.test.js — scoped to the dynamic import call rather
 // than the global, so concurrent test workers don't trample each other.


### PR DESCRIPTION
## Summary

Enabling step for the IndexedDB-backed test ports. Adds `fake-indexeddb` as a devDependency and wires `fake-indexeddb/auto` into **both** shim files:

- **`_node-shim.js`** — for standalone `node tests/foo.js` runs
- **`_vitest-setup.js`** — for the Vitest worker

Both guarded on `typeof globalThis.indexedDB === 'undefined'`, so a real browser IDB is never clobbered. Top-level await is fine in both — every test file already `import './_node-shim.js'` ahead of its own top-level awaits, and Vitest setup files support TLA.

## Why

`wearables-store.js` and `blob-storage.js` use **plain IndexedDB** (per CLAUDE.md) — exactly what `fake-indexeddb` models faithfully. With IDB available in Node, the remaining IDB-bound tests become portable:

- `test-wearables.js` (2074 lines, ~510 asserts — its own batch)
- `test-blob-storage.js`
- `test-wearables-manual.js`
- `test-wearables-sync-flow.js`

That's 4 of the ~25 remaining puppeteer originals — the biggest coverage chunk left. The marginal mostly-DOM tests (audit-fixes / chat-panel-ux / sun-ui-flow) are **deliberately not** being ported — they're DOM tests and puppeteer is their correct home.

## Scope

**Shim-only — no test ports in this PR.** Kept deliberately small so the shim wiring lands verified before the big `test-wearables` port in batch 32.

## Test plan

- [x] `npx vitest run tests/_vitest-legacy.test.js` — **75 tests still pass, ~5.0s** (unchanged)
- [x] standalone `node` runs (test-markdown, test-chat-threads) — green
- [x] `import './_node-shim.js'` now exposes `indexedDB` + `IDBKeyRange`
- [x] `./run-tests.sh` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)