### PR TITLE
Vitest batch 33: the IDB tail — blob-storage + wearables-manual + sync-flow

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -57,8 +57,6 @@ const TEST_FILES = [
   // runs via fake-indexeddb. The openWearableDetail Chart.js modal islands +
   // JSZip script-injection smoke live in test-wearables-dom.js below.
   'tests/test-wearables-dom.js',
-  'tests/test-wearables-manual.js',
-  'tests/test-wearables-sync-flow.js',
   'tests/test-wearables-ui-flows.js',
   // test-dashboard-knowledge-base.js HTML-string rendering checks ported to
   // Vitest (batch 27). Section 5 (picker open/dismiss — live DOM overlay +
@@ -87,7 +85,6 @@ const TEST_FILES = [
   'tests/test-silhouette-picker.js',
   'tests/test-silhouette-region-map.js',
   'tests/test-sun-ui-flow.js',
-  'tests/test-blob-storage.js',
   'tests/test-audit-fixes.js',
   'tests/test-family-history.js',
   // Extracted from test-v1-6-shipped.js (PR #204) — the live-DOM

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -169,6 +169,13 @@ const LEGACY_TESTS = [
   // Apple Health parser, source-inspection sweep). The openWearableDetail
   // Chart.js modal islands stay on puppeteer in test-wearables-dom.js.
   './test-wearables.js',
+  // Batch 33 — the remaining IDB tail, full ports (no DOM): blob-storage
+  // (IDB k/v + localStorage→IDB migration), wearables-manual (manual-source
+  // logging + biometrics migration), wearables-sync-flow (backfill /
+  // incremental / disconnect orchestration with a mocked /api/proxy fetch).
+  './test-blob-storage.js',
+  './test-wearables-manual.js',
+  './test-wearables-sync-flow.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-blob-storage.js
+++ b/tests/test-blob-storage.js
@@ -1,98 +1,103 @@
+#!/usr/bin/env node
 // test-blob-storage.js — IDB-backed key/value store + the localStorage→IDB
 // migration path that runs on first read of an `*-imported` key.
-// Run: fetch('tests/test-blob-storage.js').then(r=>r.text()).then(s=>Function(s)())
+//
+// Run: node tests/test-blob-storage.js  (or via npm test)
+//
+// Full port — no DOM, no network. IndexedDB runs via fake-indexeddb (wired
+// into the shim in batch 31).
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-  }
+import './_node-shim.js';
 
-  console.log('%c Blob Storage Tests ', 'background:#f59e0b;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const blob = await import('/js/blob-storage.js?bust=' + Date.now());
-  const { getBlob, setBlob, deleteBlob, getBlobStorageSize, shouldUseBlob } = blob;
+console.log('=== Blob Storage Tests ===\n');
 
-  // ─── 1. shouldUseBlob routing ─────────────────────────────────────────
-  console.log('%c 1. shouldUseBlob ', 'font-weight:bold;color:#f59e0b');
-  assert('routes labcharts-foo-imported', shouldUseBlob('labcharts-foo-imported'));
-  assert('routes labcharts-default-imported', shouldUseBlob('labcharts-default-imported'));
-  assert('does NOT route -chat', !shouldUseBlob('labcharts-foo-chat'));
-  assert('does NOT route -threads', !shouldUseBlob('labcharts-foo-chat-threads'));
-  assert('does NOT route api keys', !shouldUseBlob('labcharts-api-key'));
-  assert('does NOT route undefined', !shouldUseBlob(undefined));
+const blob = await import('../js/blob-storage.js');
+const { getBlob, setBlob, deleteBlob, getBlobStorageSize, shouldUseBlob } = blob;
 
-  // ─── 2. set / get / delete round-trip ─────────────────────────────────
-  console.log('%c 2. set/get/delete round-trip ', 'font-weight:bold;color:#f59e0b');
-  const testKey = `labcharts-_test_${Date.now()}-imported`;
-  const testValue = JSON.stringify({ entries: [{ id: 1, v: 'x'.repeat(1000) }] });
+// ─── 1. shouldUseBlob routing ─────────────────────────────────────────
+console.log('1. shouldUseBlob');
+assert('routes labcharts-foo-imported', shouldUseBlob('labcharts-foo-imported'));
+assert('routes labcharts-default-imported', shouldUseBlob('labcharts-default-imported'));
+assert('does NOT route -chat', !shouldUseBlob('labcharts-foo-chat'));
+assert('does NOT route -threads', !shouldUseBlob('labcharts-foo-chat-threads'));
+assert('does NOT route api keys', !shouldUseBlob('labcharts-api-key'));
+assert('does NOT route undefined', !shouldUseBlob(undefined));
 
-  await setBlob(testKey, testValue);
-  const got = await getBlob(testKey);
-  assert('getBlob returns the stored value', got === testValue);
+// ─── 2. set / get / delete round-trip ─────────────────────────────────
+console.log('2. set/get/delete round-trip');
+const testKey = `labcharts-_test_${Date.now()}-imported`;
+const testValue = JSON.stringify({ entries: [{ id: 1, v: 'x'.repeat(1000) }] });
 
-  // Round-trip a 2 MB string — way past the localStorage 5 MB cap when
-  // accumulated across keys, well within IDB.
-  const bigValue = 'a'.repeat(2 * 1024 * 1024);
-  const bigKey = `labcharts-_bigtest_${Date.now()}-imported`;
-  await setBlob(bigKey, bigValue);
-  const bigGot = await getBlob(bigKey);
-  assert('round-trips 2 MB string', bigGot === bigValue, `expected ${bigValue.length} bytes, got ${bigGot?.length ?? 0}`);
+await setBlob(testKey, testValue);
+const got = await getBlob(testKey);
+assert('getBlob returns the stored value', got === testValue);
 
-  await deleteBlob(testKey);
-  await deleteBlob(bigKey);
-  assert('deleteBlob removes the value', (await getBlob(testKey)) === null);
+// Round-trip a 2 MB string — way past the localStorage 5 MB cap when
+// accumulated across keys, well within IDB.
+const bigValue = 'a'.repeat(2 * 1024 * 1024);
+const bigKey = `labcharts-_bigtest_${Date.now()}-imported`;
+await setBlob(bigKey, bigValue);
+const bigGot = await getBlob(bigKey);
+assert('round-trips 2 MB string', bigGot === bigValue, `expected ${bigValue.length} bytes, got ${bigGot?.length ?? 0}`);
 
-  // ─── 3. getBlobStorageSize ────────────────────────────────────────────
-  console.log('%c 3. getBlobStorageSize ', 'font-weight:bold;color:#f59e0b');
-  const before = await getBlobStorageSize();
-  const sizeKey = `labcharts-_sizetest_${Date.now()}-imported`;
-  await setBlob(sizeKey, 'x'.repeat(50000));
-  const after = await getBlobStorageSize();
-  assert('size grows by stored payload', after - before >= 50000, `before=${before}, after=${after}, delta=${after - before}`);
-  await deleteBlob(sizeKey);
+await deleteBlob(testKey);
+await deleteBlob(bigKey);
+assert('deleteBlob removes the value', (await getBlob(testKey)) === null);
 
-  // ─── 4. encryptedGetItem migration from localStorage → IDB ────────────
-  console.log('%c 4. localStorage→IDB migration ', 'font-weight:bold;color:#f59e0b');
-  const crypto = await import('/js/crypto.js?bust=' + Date.now());
-  const { encryptedGetItem, encryptedSetItem, encryptedRemoveItem } = crypto;
-  const migKey = `labcharts-_migtest_${Date.now()}-imported`;
-  const migValue = JSON.stringify({ entries: [{ id: 'mig-1' }] });
+// ─── 3. getBlobStorageSize ────────────────────────────────────────────
+console.log('3. getBlobStorageSize');
+const before = await getBlobStorageSize();
+const sizeKey = `labcharts-_sizetest_${Date.now()}-imported`;
+await setBlob(sizeKey, 'x'.repeat(50000));
+const after = await getBlobStorageSize();
+assert('size grows by stored payload', after - before >= 50000, `before=${before}, after=${after}, delta=${after - before}`);
+await deleteBlob(sizeKey);
 
-  // Seed localStorage as if from a pre-IDB install
-  localStorage.setItem(migKey, migValue);
-  // First read should detect the localStorage value, copy to IDB, clear localStorage
-  const got1 = await encryptedGetItem(migKey);
-  assert('first read returns the seeded value', got1 === migValue);
-  assert('localStorage value cleared after migration', localStorage.getItem(migKey) === null);
-  const idbAfter = await getBlob(migKey);
-  assert('IDB has the migrated value', idbAfter === migValue);
+// ─── 4. encryptedGetItem migration from localStorage → IDB ────────────
+console.log('4. localStorage→IDB migration');
+const crypto = await import('../js/crypto.js');
+const { encryptedGetItem, encryptedSetItem, encryptedRemoveItem } = crypto;
+const migKey = `labcharts-_migtest_${Date.now()}-imported`;
+const migValue = JSON.stringify({ entries: [{ id: 'mig-1' }] });
 
-  // Subsequent reads come from IDB only
-  const got2 = await encryptedGetItem(migKey);
-  assert('second read still returns same value (from IDB)', got2 === migValue);
+// Seed localStorage as if from a pre-IDB install
+localStorage.setItem(migKey, migValue);
+// First read should detect the localStorage value, copy to IDB, clear localStorage
+const got1 = await encryptedGetItem(migKey);
+assert('first read returns the seeded value', got1 === migValue);
+assert('localStorage value cleared after migration', localStorage.getItem(migKey) === null);
+const idbAfter = await getBlob(migKey);
+assert('IDB has the migrated value', idbAfter === migValue);
 
-  // encryptedSetItem of an `-imported` key should land in IDB, not localStorage
-  const newValue = JSON.stringify({ entries: [{ id: 'new' }] });
-  await encryptedSetItem(migKey, newValue);
-  assert('after encryptedSetItem, IDB has the new value', (await getBlob(migKey)) === newValue);
-  assert('after encryptedSetItem, localStorage stays empty', localStorage.getItem(migKey) === null);
+// Subsequent reads come from IDB only
+const got2 = await encryptedGetItem(migKey);
+assert('second read still returns same value (from IDB)', got2 === migValue);
 
-  // encryptedRemoveItem wipes both backends
-  localStorage.setItem(migKey, 'leftover'); // simulate a stale localStorage residue
-  await encryptedRemoveItem(migKey);
-  assert('encryptedRemoveItem clears IDB', (await getBlob(migKey)) === null);
-  assert('encryptedRemoveItem clears localStorage', localStorage.getItem(migKey) === null);
+// encryptedSetItem of an `-imported` key should land in IDB, not localStorage
+const newValue = JSON.stringify({ entries: [{ id: 'new' }] });
+await encryptedSetItem(migKey, newValue);
+assert('after encryptedSetItem, IDB has the new value', (await getBlob(migKey)) === newValue);
+assert('after encryptedSetItem, localStorage stays empty', localStorage.getItem(migKey) === null);
 
-  // ─── 5. non-blob keys still go through localStorage unchanged ─────────
-  console.log('%c 5. non-blob keys stay in localStorage ', 'font-weight:bold;color:#f59e0b');
-  const lsKey = `labcharts-_lstest_${Date.now()}-prefs`;
-  await encryptedSetItem(lsKey, 'plain-value');
-  assert('non-blob value is in localStorage', localStorage.getItem(lsKey) === 'plain-value');
-  assert('non-blob value NOT in IDB', (await getBlob(lsKey)) === null);
-  localStorage.removeItem(lsKey);
+// encryptedRemoveItem wipes both backends
+localStorage.setItem(migKey, 'leftover'); // simulate a stale localStorage residue
+await encryptedRemoveItem(migKey);
+assert('encryptedRemoveItem clears IDB', (await getBlob(migKey)) === null);
+assert('encryptedRemoveItem clears localStorage', localStorage.getItem(migKey) === null);
 
-  console.log(`%c Blob Storage: ${pass} passed, ${fail} failed `,
-    `background:${fail ? '#ef4444' : '#22c55e'};color:#fff;font-weight:bold;padding:4px 12px;border-radius:3px`);
-})();
+// ─── 5. non-blob keys still go through localStorage unchanged ─────────
+console.log('5. non-blob keys stay in localStorage');
+const lsKey = `labcharts-_lstest_${Date.now()}-prefs`;
+await encryptedSetItem(lsKey, 'plain-value');
+assert('non-blob value is in localStorage', localStorage.getItem(lsKey) === 'plain-value');
+assert('non-blob value NOT in IDB', (await getBlob(lsKey)) === null);
+localStorage.removeItem(lsKey);
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -115,6 +115,9 @@ assert('manual has no apiHost', manualAdapter?.apiHost === null);
 console.log('3. logManualMetric');
 
 const TEST_PROFILE = 'test-manual-' + Math.random().toString(36).slice(2, 8);
+// Every sub-profile that gets real IDB writes — torn down in the finally
+// so a reused Vitest worker (or a standalone re-run) doesn't accumulate.
+const _idbProfiles = [TEST_PROFILE];
 const origProfile = window._labState.currentProfile;
 const origImported = window._labState.importedData;
 window._labState.currentProfile = TEST_PROFILE;
@@ -175,6 +178,7 @@ try {
   console.log('6. Biometrics Migration');
 
   const MIGRATE_PROFILE = 'test-mig-' + Math.random().toString(36).slice(2, 8);
+  _idbProfiles.push(MIGRATE_PROFILE);
   window._labState.currentProfile = MIGRATE_PROFILE;
   window._labState.importedData = { wearableConnections: {} };
   const legacyBiometrics = {
@@ -218,6 +222,7 @@ try {
   console.log('7. deleteManualMetric');
 
   const DEL_PROFILE = 'test-del-' + Math.random().toString(36).slice(2, 8);
+  _idbProfiles.push(DEL_PROFILE);
   window._labState.currentProfile = DEL_PROFILE;
   window._labState.importedData = { wearableConnections: {} };
   await manual.logManualMetric(DEL_PROFILE, 'weight', { date: '2026-04-24', value: 82 });
@@ -248,6 +253,7 @@ try {
   console.log('8. Context Tags');
 
   const TAG_PROFILE = 'test-tags-' + Math.random().toString(36).slice(2, 8);
+  _idbProfiles.push(TAG_PROFILE);
   window._labState.currentProfile = TAG_PROFILE;
   window._labState.importedData = { wearableConnections: {} };
   await manual.logManualBP(TAG_PROFILE, {
@@ -274,8 +280,8 @@ try {
   assert('wearables.js renders tag chips on bp form', wearablesSrc.includes('_renderTagChips'));
   assert('toggleManualLogChip on window', typeof window.toggleManualLogChip === 'function');
 
-  const saveFn = wearablesSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}/)?.[0] || '';
-  const delFn = wearablesSrc.match(/async function deleteManualEntryFromDetail[\s\S]*?\n\}/)?.[0] || '';
+  const saveFn = wearablesSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';
+  const delFn = wearablesSrc.match(/async function deleteManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';
   assert('saveManualEntryFromDetail re-renders dashboard strip',
     /window\.navigate\([^)]*\)/.test(saveFn) && /['"]dashboard['"]/.test(saveFn));
   assert('deleteManualEntryFromDetail re-renders dashboard strip',
@@ -315,6 +321,7 @@ try {
 
   // Live behavior: write + read a manual metric with note, verify persistence.
   const probeProfile = 'test-note-' + Date.now();
+  _idbProfiles.push(probeProfile);
   window._labState.currentProfile = probeProfile;
   await manual.logManualMetric(probeProfile, 'rhr', {
     date: '2099-05-12', value: 60, tags: ['resting'], note: 'morning, just woke'
@@ -423,6 +430,11 @@ try {
     /if \(lines\.length === 0 && !contextBlock\) return ''[\s\S]{0,200}if \(lines\.length === 0\)/.test(labCtxSrc));
 
 } finally {
+  // Tear down every test sub-profile's IDB (consistent with
+  // test-wearables-sync-flow.js — keeps a reused worker clean).
+  for (const pid of _idbProfiles) {
+    try { await store.deleteWearablesDB(pid); } catch {}
+  }
   // Restore live profile
   window._labState.currentProfile = origProfile;
   window._labState.importedData = origImported;

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -1,458 +1,432 @@
-// test-wearables-manual.js — manual entry as a first-class wearable source
-// Run: fetch('tests/test-wearables-manual.js').then(r=>r.text()).then(s=>Function(s)())
+#!/usr/bin/env node
+// test-wearables-manual.js — manual entry as a first-class wearable source.
+// Module exports, the 'manual' adapter registry entry, logManualMetric /
+// logManualBP IDB writes, hasManualData, migrateBiometricsToManual
+// (idempotent + lb→kg), deleteManualMetric, context tags + notes, plus a
+// source-inspection sweep of wearables.js / client-list.js / styles.css /
+// lab-context.js.
+//
+// Run: node tests/test-wearables-manual.js  (or via npm test)
+//
+// Full port — no DOM rendering. The window-export checks rely on wearables.js
+// registering its handlers on window; IndexedDB runs via fake-indexeddb.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+import './_node-shim.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+
+// Source-inspection sweep uses `await fetch('js/X').then(r => r.text())` —
+// fs-backed fetch shim so the relative URLs resolve in Node.
+const _realFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  if (typeof url === 'string' && !/^https?:/.test(url)) {
+    const rel = url.replace(/^\//, '');
+    try { return new Response(read(rel), { status: 200 }); }
+    catch (_) { return new Response('', { status: 404 }); }
   }
+  return _realFetch(url, opts);
+};
 
-  console.log('%c Manual-as-wearable-source Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const manual = await import('../js/wearables-manual.js');
-  const store = await import('../js/wearables-store.js');
-  const adapters = await import('../js/wearable-adapters.js');
+console.log('=== Manual-as-wearable-source Tests ===\n');
+
+// state.js → window._labState; wearables.js registers the openManualLogForm /
+// saveManualLog / toggleManualLogChip window handlers the export checks probe.
+await import('../js/state.js');
+const manual = await import('../js/wearables-manual.js');
+const store = await import('../js/wearables-store.js');
+const adapters = await import('../js/wearable-adapters.js');
+await import('../js/wearables.js');
+
+// ═══════════════════════════════════════
+// 1. Module exports
+// ═══════════════════════════════════════
+console.log('1. Module Exports');
+
+assert('logManualMetric exported', typeof manual.logManualMetric === 'function');
+assert('logManualBP exported', typeof manual.logManualBP === 'function');
+assert('migrateBiometricsToManual exported', typeof manual.migrateBiometricsToManual === 'function');
+assert('hasManualData exported', typeof manual.hasManualData === 'function');
+assert('ensureManualConnection exported', typeof manual.ensureManualConnection === 'function');
+assert('MANUAL_METRICS exported', Array.isArray(manual.MANUAL_METRICS));
+assert('MANUAL_METRICS covers weight/bp/rhr',
+  manual.MANUAL_METRICS.includes('weight') &&
+  manual.MANUAL_METRICS.includes('bp_systolic') &&
+  manual.MANUAL_METRICS.includes('bp_diastolic') &&
+  manual.MANUAL_METRICS.includes('rhr'));
+assert('MANUAL_TAGS exported', Array.isArray(manual.MANUAL_TAGS));
+assert('MANUAL_TAGS includes core context set',
+  manual.MANUAL_TAGS.includes('resting') &&
+  manual.MANUAL_TAGS.includes('morning-fasted') &&
+  manual.MANUAL_TAGS.includes('post-workout') &&
+  manual.MANUAL_TAGS.includes('stress'));
+assert('deleteManualMetric exported', typeof manual.deleteManualMetric === 'function');
+assert('refreshManualSummary exported', typeof manual.refreshManualSummary === 'function');
+
+assert('openManualLogForm on window', typeof window.openManualLogForm === 'function');
+assert('saveManualLog on window', typeof window.saveManualLog === 'function');
+assert('cancelManualLog on window', typeof window.cancelManualLog === 'function');
+
+const wearablesSrc = await fetch('js/wearables.js').then(r => r.text());
+assert('wearables.js renders empty manual cards',
+  wearablesSrc.includes('renderEmptyManualCard') && wearablesSrc.includes('wearable-card-empty'));
+assert('wearables.js MANUAL_EMPTY_METRICS covers weight/bp/rhr',
+  /MANUAL_EMPTY_METRICS\s*=\s*\[[^\]]*weight[^\]]*bp_systolic[^\]]*rhr/.test(wearablesSrc));
+
+const clSrc = await fetch('js/client-list.js').then(r => r.text());
+assert('Edit Client modal no longer renders the cl-bio-weight container',
+  !clSrc.includes('id="cl-bio-weight"'));
+assert('Edit Client modal no longer renders the cl-bio-bp container',
+  !clSrc.includes('id="cl-bio-bp"'));
+assert('Edit Client modal no longer renders the cl-bio-pulse container',
+  !clSrc.includes('id="cl-bio-pulse"'));
+assert('Edit Client modal links out to Health Metrics on the dashboard',
+  clSrc.includes('_clGoToHealthMetrics'));
+assert('_clUpdateBMI reads weight from wearableSummary (single source of truth)',
+  clSrc.includes('wearableSummary?.metrics?.weight'));
+
+// ═══════════════════════════════════════
+// 2. 'manual' adapter registered
+// ═══════════════════════════════════════
+console.log('2. Adapter Registry');
+
+const manualAdapter = adapters.ADAPTERS.find(a => a.id === 'manual');
+assert('manual adapter present in ADAPTERS', manualAdapter != null);
+assert('manual authType = "manual"', manualAdapter?.authType === 'manual');
+assert('manual has weight metric', !!manualAdapter?.metrics?.weight);
+assert('manual has bp_systolic metric', !!manualAdapter?.metrics?.bp_systolic);
+assert('manual has bp_diastolic metric', !!manualAdapter?.metrics?.bp_diastolic);
+assert('manual has rhr metric', !!manualAdapter?.metrics?.rhr);
+assert('manual has no apiHost', manualAdapter?.apiHost === null);
+
+// ═══════════════════════════════════════
+// 3. logManualMetric writes to IDB + flips connection
+// ═══════════════════════════════════════
+console.log('3. logManualMetric');
+
+const TEST_PROFILE = 'test-manual-' + Math.random().toString(36).slice(2, 8);
+const origProfile = window._labState.currentProfile;
+const origImported = window._labState.importedData;
+window._labState.currentProfile = TEST_PROFILE;
+window._labState.importedData = { wearableConnections: {} };
+
+try {
+  await manual.logManualMetric(TEST_PROFILE, 'weight', { date: '2026-04-24', value: 82.1 });
+  const row = await store.getDaily(TEST_PROFILE, 'manual', '2026-04-24');
+  assert('weight row written with source=manual', row?.source === 'manual');
+  assert('weight row has correct date', row?.date === '2026-04-24');
+  assert('weight row has correct value', row?.weight === 82.1);
+  assert('ensureManualConnection populated wearableConnections.manual',
+    window._labState.importedData.wearableConnections?.manual != null);
+  assert('manual connection has connectedAt',
+    !!window._labState.importedData.wearableConnections.manual.connectedAt);
 
   // ═══════════════════════════════════════
-  // 1. Module exports
+  // 4. logManualBP writes combined row
   // ═══════════════════════════════════════
-  console.log('%c 1. Module Exports ', 'font-weight:bold;color:#f59e0b');
+  console.log('4. logManualBP');
 
-  assert('logManualMetric exported', typeof manual.logManualMetric === 'function');
-  assert('logManualBP exported', typeof manual.logManualBP === 'function');
-  assert('migrateBiometricsToManual exported', typeof manual.migrateBiometricsToManual === 'function');
-  assert('hasManualData exported', typeof manual.hasManualData === 'function');
-  assert('ensureManualConnection exported', typeof manual.ensureManualConnection === 'function');
-  assert('MANUAL_METRICS exported', Array.isArray(manual.MANUAL_METRICS));
-  assert('MANUAL_METRICS covers weight/bp/rhr',
-    manual.MANUAL_METRICS.includes('weight') &&
-    manual.MANUAL_METRICS.includes('bp_systolic') &&
-    manual.MANUAL_METRICS.includes('bp_diastolic') &&
-    manual.MANUAL_METRICS.includes('rhr'));
-  assert('MANUAL_TAGS exported', Array.isArray(manual.MANUAL_TAGS));
-  assert('MANUAL_TAGS includes core context set',
-    manual.MANUAL_TAGS.includes('resting') &&
-    manual.MANUAL_TAGS.includes('morning-fasted') &&
-    manual.MANUAL_TAGS.includes('post-workout') &&
-    manual.MANUAL_TAGS.includes('stress'));
-  assert('deleteManualMetric exported', typeof manual.deleteManualMetric === 'function');
-  assert('refreshManualSummary exported', typeof manual.refreshManualSummary === 'function');
+  await manual.logManualBP(TEST_PROFILE, { date: '2026-04-24', systolic: 118, diastolic: 76, pulse: 64 });
+  const bpRow = await store.getDaily(TEST_PROFILE, 'manual', '2026-04-24');
+  assert('BP row merges with same-day weight row',
+    bpRow?.weight === 82.1 && bpRow?.bp_systolic === 118);
+  assert('BP row has diastolic', bpRow?.bp_diastolic === 76);
+  assert('BP row has pulse (rhr)', bpRow?.rhr === 64);
 
-  // Dashboard strip inline-log form wiring (Phase 3). These are window
-  // globals defined in wearables.js; the onclick attrs on empty cards call
-  // them directly. Regression-guard the names so a future refactor can't
-  // break the attrs silently.
-  assert('openManualLogForm on window', typeof window.openManualLogForm === 'function');
-  assert('saveManualLog on window', typeof window.saveManualLog === 'function');
-  assert('cancelManualLog on window', typeof window.cancelManualLog === 'function');
+  await manual.logManualBP(TEST_PROFILE, { date: '2026-04-25', systolic: 120 });
+  const partialBP = await store.getDaily(TEST_PROFILE, 'manual', '2026-04-25');
+  assert('partial BP (syst only) writes just that field', partialBP?.bp_systolic === 120 && partialBP?.bp_diastolic == null);
 
-  // Source-level check that the empty-card state is wired up.
-  const wearablesSrc = await fetch('js/wearables.js').then(r => r.text());
-  assert('wearables.js renders empty manual cards',
-    wearablesSrc.includes('renderEmptyManualCard') && wearablesSrc.includes('wearable-card-empty'));
-  assert('wearables.js MANUAL_EMPTY_METRICS covers weight/bp/rhr',
-    /MANUAL_EMPTY_METRICS\s*=\s*\[[^\]]*weight[^\]]*bp_systolic[^\]]*rhr/.test(wearablesSrc));
+  let threw = false;
+  try { await manual.logManualMetric(TEST_PROFILE, 'bogus_metric', { value: 1 }); }
+  catch { threw = true; }
+  assert('logManualMetric rejects unknown metric', threw);
 
-  // Phase 4 retired the Edit Client modal's weight/BP/pulse inputs — the
-  // dashboard strip is now the single entry point. Regression-guard that
-  // the old form elements are gone and the "go to Health Metrics" link
-  // replaced them. BMI calc must read weight from the wearables summary,
-  // not from the legacy biometrics store.
-  const clSrc = await fetch('js/client-list.js').then(r => r.text());
-  assert('Edit Client modal no longer renders the cl-bio-weight container',
-    !clSrc.includes('id="cl-bio-weight"'));
-  assert('Edit Client modal no longer renders the cl-bio-bp container',
-    !clSrc.includes('id="cl-bio-bp"'));
-  assert('Edit Client modal no longer renders the cl-bio-pulse container',
-    !clSrc.includes('id="cl-bio-pulse"'));
-  assert('Edit Client modal links out to Health Metrics on the dashboard',
-    clSrc.includes('_clGoToHealthMetrics'));
-  assert('_clUpdateBMI reads weight from wearableSummary (single source of truth)',
-    clSrc.includes('wearableSummary?.metrics?.weight'));
+  threw = false;
+  try { await manual.logManualMetric(TEST_PROFILE, 'weight', { value: NaN }); }
+  catch { threw = true; }
+  assert('logManualMetric rejects NaN', threw);
 
   // ═══════════════════════════════════════
-  // 2. 'manual' adapter registered
+  // 5. hasManualData
   // ═══════════════════════════════════════
-  console.log('%c 2. Adapter Registry ', 'font-weight:bold;color:#f59e0b');
+  console.log('5. hasManualData');
 
-  const manualAdapter = adapters.ADAPTERS.find(a => a.id === 'manual');
-  assert('manual adapter present in ADAPTERS', manualAdapter != null);
-  assert('manual authType = "manual"', manualAdapter?.authType === 'manual');
-  assert('manual has weight metric', !!manualAdapter?.metrics?.weight);
-  assert('manual has bp_systolic metric', !!manualAdapter?.metrics?.bp_systolic);
-  assert('manual has bp_diastolic metric', !!manualAdapter?.metrics?.bp_diastolic);
-  assert('manual has rhr metric', !!manualAdapter?.metrics?.rhr);
-  assert('manual has no apiHost', manualAdapter?.apiHost === null);
+  const has = await manual.hasManualData(TEST_PROFILE);
+  assert('hasManualData returns true after log', has === true);
+
+  const MISSING_PROFILE = 'test-missing-' + Math.random().toString(36).slice(2, 8);
+  const hasNone = await manual.hasManualData(MISSING_PROFILE);
+  assert('hasManualData returns false for empty profile', hasNone === false);
 
   // ═══════════════════════════════════════
-  // 3. logManualMetric writes to IDB + flips connection
+  // 6. migrateBiometricsToManual — idempotent + shape
   // ═══════════════════════════════════════
-  console.log('%c 3. logManualMetric ', 'font-weight:bold;color:#f59e0b');
+  console.log('6. Biometrics Migration');
 
-  const TEST_PROFILE = 'test-manual-' + Math.random().toString(36).slice(2, 8);
-  // Temporarily point state at the test profile so ensureManualConnection
-  // writes to a safe slot and doesn't pollute the live profile.
-  const origProfile = window._labState.currentProfile;
-  const origImported = window._labState.importedData;
-  window._labState.currentProfile = TEST_PROFILE;
+  const MIGRATE_PROFILE = 'test-mig-' + Math.random().toString(36).slice(2, 8);
+  window._labState.currentProfile = MIGRATE_PROFILE;
   window._labState.importedData = { wearableConnections: {} };
+  const legacyBiometrics = {
+    weight: [
+      { date: '2026-04-20', value: 82.5, unit: 'kg', source: 'manual' },
+      { date: '2026-04-22', value: 81.9, unit: 'kg', source: 'manual' },
+      { date: '2026-04-23', value: 180, unit: 'lb', source: 'manual' }, // lb → kg
+    ],
+    bp: [
+      { date: '2026-04-22', systolic: 120, diastolic: 78, source: 'manual' },
+    ],
+    pulse: [
+      { date: '2026-04-22', value: 68, source: 'manual' },
+    ],
+  };
+  const result = await manual.migrateBiometricsToManual(MIGRATE_PROFILE, legacyBiometrics);
+  assert('migration runs (not skipped)', result.migrated === true);
+  assert('migration counted 3 weight + 1 bp + 1 pulse entries',
+    result.counts.weight === 3 && result.counts.bp === 1 && result.counts.pulse === 1);
+  assert('migration wrote 3 rows (by-date dedup)', result.counts.rows === 3);
 
-  try {
-    await manual.logManualMetric(TEST_PROFILE, 'weight', { date: '2026-04-24', value: 82.1 });
-    const row = await store.getDaily(TEST_PROFILE, 'manual', '2026-04-24');
-    assert('weight row written with source=manual', row?.source === 'manual');
-    assert('weight row has correct date', row?.date === '2026-04-24');
-    assert('weight row has correct value', row?.weight === 82.1);
-    assert('ensureManualConnection populated wearableConnections.manual',
-      window._labState.importedData.wearableConnections?.manual != null);
-    assert('manual connection has connectedAt',
-      !!window._labState.importedData.wearableConnections.manual.connectedAt);
+  const migRow22 = await store.getDaily(MIGRATE_PROFILE, 'manual', '2026-04-22');
+  assert('migrated 04-22 row has weight + BP + pulse merged',
+    migRow22?.weight === 81.9 && migRow22?.bp_systolic === 120 && migRow22?.rhr === 68);
 
-    // ═══════════════════════════════════════
-    // 4. logManualBP writes combined row
-    // ═══════════════════════════════════════
-    console.log('%c 4. logManualBP ', 'font-weight:bold;color:#f59e0b');
+  const migRow23 = await store.getDaily(MIGRATE_PROFILE, 'manual', '2026-04-23');
+  const lbInKg = 180 / 2.20462;
+  assert('lb → kg unit conversion on migration',
+    Math.abs((migRow23?.weight || 0) - lbInKg) < 0.01);
 
-    await manual.logManualBP(TEST_PROFILE, { date: '2026-04-24', systolic: 118, diastolic: 76, pulse: 64 });
-    const bpRow = await store.getDaily(TEST_PROFILE, 'manual', '2026-04-24');
-    assert('BP row merges with same-day weight row',
-      bpRow?.weight === 82.1 && bpRow?.bp_systolic === 118);
-    assert('BP row has diastolic', bpRow?.bp_diastolic === 76);
-    assert('BP row has pulse (rhr)', bpRow?.rhr === 64);
+  const rerun = await manual.migrateBiometricsToManual(MIGRATE_PROFILE, legacyBiometrics);
+  assert('migration is idempotent (second run skipped)', rerun.skipped === 'already-migrated');
 
-    // BP logging with only partial data
-    await manual.logManualBP(TEST_PROFILE, { date: '2026-04-25', systolic: 120 });
-    const partialBP = await store.getDaily(TEST_PROFILE, 'manual', '2026-04-25');
-    assert('partial BP (syst only) writes just that field', partialBP?.bp_systolic === 120 && partialBP?.bp_diastolic == null);
-
-    // Validation
-    let threw = false;
-    try { await manual.logManualMetric(TEST_PROFILE, 'bogus_metric', { value: 1 }); }
-    catch { threw = true; }
-    assert('logManualMetric rejects unknown metric', threw);
-
-    threw = false;
-    try { await manual.logManualMetric(TEST_PROFILE, 'weight', { value: NaN }); }
-    catch { threw = true; }
-    assert('logManualMetric rejects NaN', threw);
-
-    // ═══════════════════════════════════════
-    // 5. hasManualData
-    // ═══════════════════════════════════════
-    console.log('%c 5. hasManualData ', 'font-weight:bold;color:#f59e0b');
-
-    const has = await manual.hasManualData(TEST_PROFILE);
-    assert('hasManualData returns true after log', has === true);
-
-    const MISSING_PROFILE = 'test-missing-' + Math.random().toString(36).slice(2, 8);
-    const hasNone = await manual.hasManualData(MISSING_PROFILE);
-    assert('hasManualData returns false for empty profile', hasNone === false);
-
-    // ═══════════════════════════════════════
-    // 6. migrateBiometricsToManual — idempotent + shape
-    // ═══════════════════════════════════════
-    console.log('%c 6. Biometrics Migration ', 'font-weight:bold;color:#f59e0b');
-
-    const MIGRATE_PROFILE = 'test-mig-' + Math.random().toString(36).slice(2, 8);
-    // Switch state's profile so ensureManualConnection inside migration
-    // writes to the correct slot.
-    window._labState.currentProfile = MIGRATE_PROFILE;
-    window._labState.importedData = { wearableConnections: {} };
-    const legacyBiometrics = {
-      weight: [
-        { date: '2026-04-20', value: 82.5, unit: 'kg', source: 'manual' },
-        { date: '2026-04-22', value: 81.9, unit: 'kg', source: 'manual' },
-        { date: '2026-04-23', value: 180, unit: 'lb', source: 'manual' }, // lb → kg
-      ],
-      bp: [
-        { date: '2026-04-22', systolic: 120, diastolic: 78, source: 'manual' },
-      ],
-      pulse: [
-        { date: '2026-04-22', value: 68, source: 'manual' },
-      ],
-    };
-    const result = await manual.migrateBiometricsToManual(MIGRATE_PROFILE, legacyBiometrics);
-    assert('migration runs (not skipped)', result.migrated === true);
-    assert('migration counted 3 weight + 1 bp + 1 pulse entries',
-      result.counts.weight === 3 && result.counts.bp === 1 && result.counts.pulse === 1);
-    assert('migration wrote 3 rows (by-date dedup)', result.counts.rows === 3);
-
-    const migRow22 = await store.getDaily(MIGRATE_PROFILE, 'manual', '2026-04-22');
-    assert('migrated 04-22 row has weight + BP + pulse merged',
-      migRow22?.weight === 81.9 && migRow22?.bp_systolic === 120 && migRow22?.rhr === 68);
-
-    const migRow23 = await store.getDaily(MIGRATE_PROFILE, 'manual', '2026-04-23');
-    const lbInKg = 180 / 2.20462;
-    assert('lb → kg unit conversion on migration',
-      Math.abs((migRow23?.weight || 0) - lbInKg) < 0.01);
-
-    // Idempotence — re-running should be a no-op
-    const rerun = await manual.migrateBiometricsToManual(MIGRATE_PROFILE, legacyBiometrics);
-    assert('migration is idempotent (second run skipped)', rerun.skipped === 'already-migrated');
-
-    // No biometrics at all
-    const EMPTY_PROFILE = 'test-empty-' + Math.random().toString(36).slice(2, 8);
-    const emptyRes = await manual.migrateBiometricsToManual(EMPTY_PROFILE, null);
-    assert('migration handles null biometrics', emptyRes.skipped === 'no-biometrics');
-
-    // ═══════════════════════════════════════
-    // 7. deleteManualMetric
-    // ═══════════════════════════════════════
-    console.log('%c 7. deleteManualMetric ', 'font-weight:bold;color:#f59e0b');
-
-    const DEL_PROFILE = 'test-del-' + Math.random().toString(36).slice(2, 8);
-    window._labState.currentProfile = DEL_PROFILE;
-    window._labState.importedData = { wearableConnections: {} };
-    // Seed: weight + BP + pulse on same date
-    await manual.logManualMetric(DEL_PROFILE, 'weight', { date: '2026-04-24', value: 82 });
-    await manual.logManualBP(DEL_PROFILE, { date: '2026-04-24', systolic: 118, diastolic: 76, pulse: 64 });
-
-    // Delete just weight — BP + pulse must remain
-    await manual.deleteManualMetric(DEL_PROFILE, 'weight', '2026-04-24');
-    const afterWeightDel = await store.getDaily(DEL_PROFILE, 'manual', '2026-04-24');
-    assert('weight deleted but row kept (BP remains)',
-      afterWeightDel?.weight == null && afterWeightDel?.bp_systolic === 118);
-
-    // Delete remaining metrics — last delete should nuke the row outright
-    // (not stub it) so IDB quota + summary coverageDays stay accurate.
-    // Tags on the row are also gone — they annotated a reading that no
-    // longer exists.
-    await manual.deleteManualMetric(DEL_PROFILE, 'bp_systolic', '2026-04-24');
-    await manual.deleteManualMetric(DEL_PROFILE, 'bp_diastolic', '2026-04-24');
-    await manual.deleteManualMetric(DEL_PROFILE, 'rhr', '2026-04-24');
-    const afterAllDel = await store.getDaily(DEL_PROFILE, 'manual', '2026-04-24');
-    assert('all-metrics-deleted row is removed from IDB (no stub)',
-      afterAllDel == null);
-
-    // Unknown-metric and no-row cases
-    let threwDel = false;
-    try { await manual.deleteManualMetric(DEL_PROFILE, 'bogus', '2026-04-24'); }
-    catch { threwDel = true; }
-    assert('deleteManualMetric rejects unknown metric', threwDel);
-    await manual.deleteManualMetric(DEL_PROFILE, 'weight', '2099-01-01'); // no-op
-    assert('deleteManualMetric on missing date is a no-op', true);
-
-    // ═══════════════════════════════════════
-    // 8. Context tags
-    // ═══════════════════════════════════════
-    console.log('%c 8. Context Tags ', 'font-weight:bold;color:#f59e0b');
-
-    const TAG_PROFILE = 'test-tags-' + Math.random().toString(36).slice(2, 8);
-    window._labState.currentProfile = TAG_PROFILE;
-    window._labState.importedData = { wearableConnections: {} };
-    await manual.logManualBP(TAG_PROFILE, {
-      date: '2026-04-24', systolic: 145, diastolic: 92,
-      tags: ['post-workout', 'stress']
-    });
-    const taggedRow = await store.getDaily(TAG_PROFILE, 'manual', '2026-04-24');
-    assert('BP row persists tags array', Array.isArray(taggedRow?.tags));
-    assert('tags contain post-workout + stress',
-      taggedRow?.tags?.includes('post-workout') && taggedRow?.tags?.includes('stress'));
-
-    // Unknown / typo'd tags get silently stripped — never throw, just don't persist them.
-    await manual.logManualMetric(TAG_PROFILE, 'weight', {
-      date: '2026-04-25', value: 81,
-      tags: ['morning-fasted', 'bogus-tag', 'resting', 'post-workout']
-    });
-    const weightRow = await store.getDaily(TAG_PROFILE, 'manual', '2026-04-25');
-    assert('unknown tags are filtered out',
-      !weightRow?.tags?.includes('bogus-tag'));
-    assert('valid tags survive the filter',
-      weightRow?.tags?.includes('morning-fasted') &&
-      weightRow?.tags?.includes('resting') &&
-      weightRow?.tags?.includes('post-workout'));
-
-    // Dashboard strip form wiring for chips
-    assert('wearables.js renders tag chips on bp form', wearablesSrc.includes('_renderTagChips'));
-    assert('toggleManualLogChip on window', typeof window.toggleManualLogChip === 'function');
-
-    // Detail-modal save/delete handlers must re-render the dashboard strip,
-    // not just the modal. Before the audit fix, they only re-opened the
-    // detail modal — the strip card stayed stale until the user happened to
-    // re-navigate. Regression guard with a source-grep scoped to each
-    // function so a future refactor can't silently drop the render call.
-    const saveFn = wearablesSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}/)?.[0] || '';
-    const delFn = wearablesSrc.match(/async function deleteManualEntryFromDetail[\s\S]*?\n\}/)?.[0] || '';
-    assert('saveManualEntryFromDetail re-renders dashboard strip',
-      /window\.navigate\([^)]*\)/.test(saveFn) && /['"]dashboard['"]/.test(saveFn));
-    assert('deleteManualEntryFromDetail re-renders dashboard strip',
-      /window\.navigate\([^)]*\)/.test(delFn) && /['"]dashboard['"]/.test(delFn));
-    assert('deleteManualEntryFromDetail closes modal when last reading is removed',
-      /closeModal/.test(delFn));
-
-    // showConfirmDialog is promise-based (returns Promise<boolean>). The v1.24.1
-    // regression (537bec4) was caused by a 4-arg call where the body string
-    // landed in the onConfirm slot. Both call sites now use await showConfirmDialog().
-    const handleDisconnectFn = wearablesSrc.match(/async function handleManualDisconnect[\s\S]*?\n\}\s*\n/)?.[0] || '';
-    assert('deleteManualEntryFromDetail uses promise-style showConfirmDialog',
-      /await\s+window\.showConfirmDialog\(/.test(delFn));
-    assert('handleManualDisconnect uses promise-style showConfirmDialog',
-      /await\s+window\.showConfirmDialog\(/.test(handleDisconnectFn));
-
-    // ═══════════════════════════════════════
-    // Note + chip parity (this-branch additions)
-    // ═══════════════════════════════════════
-    console.log('%c Note + chip parity ', 'font-weight:bold;color:#f59e0b');
-
-    const manualLibSrc = await fetch('js/wearables-manual.js').then(r => r.text());
-
-    // 1. logManualMetric / logManualBP accept note param + sanitize
-    assert('logManualMetric signature accepts note param',
-      /export async function logManualMetric\(profileId, metric, \{ date, value, tags, note \}\)/.test(manualLibSrc));
-    assert('logManualBP signature accepts note param',
-      /export async function logManualBP\(profileId, \{ date, systolic, diastolic, pulse, tags, note \}\)/.test(manualLibSrc));
-    assert('Both helpers write the note onto the row patch via _sanitizeNote',
-      /const noteClean = _sanitizeNote\(note\);[\s\S]{0,200}if \(noteClean\) patch\.note = noteClean/.test(manualLibSrc) &&
-      /const noteClean = _sanitizeNote\(note\);[\s\S]{0,200}if \(noteClean\) row\.note = noteClean/.test(manualLibSrc));
-
-    // _sanitizeNote behavior (trim + 500-char cap + non-string → '')
-    assert('_sanitizeNote function defined',
-      /function _sanitizeNote\(note\)/.test(manualLibSrc));
-    assert('_sanitizeNote trims whitespace',
-      /const trimmed = note\.trim\(\)/.test(manualLibSrc));
-    assert('_sanitizeNote caps at 500 chars',
-      /trimmed\.length > 500 \? trimmed\.slice\(0, 500\)/.test(manualLibSrc));
-    assert("_sanitizeNote returns '' for non-string",
-      /if \(typeof note !== 'string'\) return ''/.test(manualLibSrc));
-
-    // Live behavior: write + read a manual metric with note, verify persistence.
-    // Uses the isolated profile fixture already set up above.
-    try {
-      const probeProfile = 'test-note-' + Date.now();
-      window._labState.currentProfile = probeProfile;
-      await manual.logManualMetric(probeProfile, 'rhr', {
-        date: '2099-05-12', value: 60, tags: ['resting'], note: 'morning, just woke'
-      });
-      const rows = await store.getDailyRange(probeProfile, 'manual', '2099-05-12', '2099-05-12');
-      assert('logManualMetric persists note on the row',
-        rows.length === 1 && rows[0].note === 'morning, just woke');
-      assert('logManualMetric still persists tags alongside note',
-        Array.isArray(rows[0].tags) && rows[0].tags.includes('resting'));
-      // 500-char cap
-      const longNote = 'x'.repeat(800);
-      await manual.logManualMetric(probeProfile, 'weight', {
-        date: '2099-05-13', value: 70, note: longNote
-      });
-      const rows2 = await store.getDailyRange(probeProfile, 'manual', '2099-05-13', '2099-05-13');
-      assert('Note capped at 500 chars',
-        rows2[0].note && rows2[0].note.length === 500);
-      // Empty/whitespace note → no `note` field on the row
-      await manual.logManualMetric(probeProfile, 'weight', {
-        date: '2099-05-14', value: 71, note: '   '
-      });
-      const rows3 = await store.getDailyRange(probeProfile, 'manual', '2099-05-14', '2099-05-14');
-      assert('Whitespace-only note is dropped (no note field on row)',
-        rows3[0].note === undefined);
-
-      // logManualBP with note
-      await manual.logManualBP(probeProfile, {
-        date: '2099-05-15', systolic: 120, diastolic: 80, tags: ['post-workout'], note: 'after run'
-      });
-      const rows4 = await store.getDailyRange(probeProfile, 'manual', '2099-05-15', '2099-05-15');
-      assert('logManualBP persists note on the row',
-        rows4[0].note === 'after run' && rows4[0].tags?.includes('post-workout'));
-    } catch (e) {
-      console.warn('Manual note-persistence sub-test threw — IDB may not be available in this context', e?.message || e);
-    }
-
-    // 2. Detail-modal form has chips for rhr + bp (parity with empty-card form).
-    // Count occurrences across the whole file: empty-card form has one of
-    // each, detail-modal has the other. Both pairs => ≥2 occurrences each.
-    const rhrChipMatches = (wearablesSrc.match(/_renderTagChips\('rhr'\)/g) || []).length;
-    const bpChipMatches = (wearablesSrc.match(/_renderTagChips\('bp_systolic'\)/g) || []).length;
-    assert('_renderTagChips(\'rhr\') called from both empty-card AND detail-modal forms',
-      rhrChipMatches >= 2, `count=${rhrChipMatches}`);
-    assert('_renderTagChips(\'bp_systolic\') called from both empty-card AND detail-modal forms',
-      bpChipMatches >= 2, `count=${bpChipMatches}`);
-    // Scoped check that the detail-modal kind branches each call _renderTagChips.
-    // Slice between two reliable anchors so this isn't relying on greedy regex.
-    const openDetailStart = wearablesSrc.indexOf('function openManualAddFromDetail');
-    const closeManualFnStart = wearablesSrc.indexOf('function closeManualAddFromDetail');
-    const openDetailFn = (openDetailStart !== -1 && closeManualFnStart !== -1)
-      ? wearablesSrc.slice(openDetailStart, closeManualFnStart) : '';
-    assert('Detail-modal RHR branch renders tag chips',
-      /kind === 'rhr'[\s\S]{0,800}_renderTagChips\('rhr'\)/.test(openDetailFn));
-    assert('Detail-modal BP branch renders tag chips',
-      /kind === 'bp'[\s\S]{0,1500}_renderTagChips\('bp_systolic'\)/.test(openDetailFn));
-    assert('Detail-modal weight branch does NOT render tag chips (matches empty-card convention)',
-      !/kind === 'weight'[\s\S]{0,400}_renderTagChips/.test(openDetailFn));
-
-    // 3. Both forms have the note textarea (id wlad-note for detail-modal,
-    //    id wl-{kind}-note for empty-card)
-    assert('Detail-modal form renders the wlad-note textarea',
-      /openManualAddFromDetail[\s\S]{0,3000}_renderNoteField\('wlad-note'\)/.test(wearablesSrc));
-    assert('Empty-card weight form renders wl-weight-note textarea',
-      /metricId === 'weight'[\s\S]{0,1000}_renderNoteField\('wl-weight-note'\)/.test(wearablesSrc));
-    assert('Empty-card BP form renders wl-bp-note textarea',
-      /metricId === 'bp_systolic'[\s\S]{0,1500}_renderNoteField\('wl-bp-note'\)/.test(wearablesSrc));
-    assert('Empty-card RHR form renders wl-rhr-note textarea',
-      /metricId === 'rhr'[\s\S]{0,1000}_renderNoteField\('wl-rhr-note'\)/.test(wearablesSrc));
-
-    // _renderNoteField helper produces a textarea with the required class
-    assert('_renderNoteField helper defined',
-      /function _renderNoteField\(idSuffix = 'wl-note'\)/.test(wearablesSrc));
-    assert('_renderNoteField outputs a wearable-log-note textarea',
-      /<textarea class="wearable-log-note"/.test(wearablesSrc));
-
-    // 4. Save flows collect note + tags
-    const saveLogFn = wearablesSrc.match(/async function saveManualLog[\s\S]*?\n\}\s*\n/)?.[0] || '';
-    assert('saveManualLog reads note from `wl-${kind}-note` (or `wl-bp-note`)',
-      /document\.getElementById\(`wl-\$\{kind === 'bp' \? 'bp' : kind\}-note`\)/.test(saveLogFn));
-    assert('saveManualLog passes note to logManualMetric (weight + rhr) and logManualBP',
-      /logManualMetric\(profileId, 'weight', \{[^}]*note\s*\}\)/.test(saveLogFn) &&
-      /logManualMetric\(profileId, 'rhr', \{[^}]*note\s*\}\)/.test(saveLogFn) &&
-      /logManualBP\(profileId, \{[^}]*note\s*\}\)/.test(saveLogFn));
-
-    const saveFromDetailFn = wearablesSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';
-    assert('saveManualEntryFromDetail reads wlad-note from the detail-modal form',
-      /document\.getElementById\('wlad-note'\)/.test(saveFromDetailFn));
-    assert('saveManualEntryFromDetail scopes chip collection to the form element',
-      /const formEl = document\.querySelector\('\.wearable-manual-add-form'\)[\s\S]{0,200}_collectActiveChips\(formEl\)/.test(saveFromDetailFn));
-    assert('saveManualEntryFromDetail passes tags + note to log helpers',
-      /logManualMetric\(profileId, 'weight', \{[^}]*tags, note\s*\}\)/.test(saveFromDetailFn) &&
-      /logManualMetric\(profileId, 'rhr', \{[^}]*tags, note\s*\}\)/.test(saveFromDetailFn) &&
-      /logManualBP\(profileId, \{[^}]*tags, note\s*\}\)/.test(saveFromDetailFn));
-
-    // 5. Entries list shows note when present
-    const entriesSectionFn = wearablesSrc.match(/function buildManualEntriesSection[\s\S]*?\n\}\s*\n/)?.[0] || '';
-    assert('manualEntries map pulls note: r.note from the IDB row',
-      /\.map\(r => \(\{ date: r\.date, v: r\[metricId\], tags: r\.tags, note: r\.note \}\)\)/.test(wearablesSrc));
-    assert('Entries-list row renders the note (.wearable-manual-entry-note) when present',
-      /typeof e\.note === 'string' && e\.note\.trim\(\)[\s\S]{0,200}wearable-manual-entry-note/.test(entriesSectionFn));
-    assert("Row gains 'has-note' modifier class for layout when note is present",
-      /wearable-manual-entry\$\{noteRow \? ' has-note' : ''\}/.test(entriesSectionFn));
-
-    // 6. CSS hooks
-    const stylesSrc = await fetch('styles.css').then(r => r.text());
-    assert('CSS defines .wearable-log-note',
-      /\.wearable-log-note\s*\{/.test(stylesSrc));
-    assert('CSS defines .wearable-manual-entry-note',
-      /\.wearable-manual-entry-note\s*\{/.test(stylesSrc));
-    assert('CSS defines .wearable-manual-entry.has-note { flex-wrap: wrap }',
-      /\.wearable-manual-entry\.has-note\s*\{[^}]*flex-wrap:\s*wrap/.test(stylesSrc));
-
-    // 7. AI context — wearable manual context block (tags + notes) within series section
-    const labCtxSrc = await fetch('js/lab-context.js').then(r => r.text());
-    assert('buildWearableSeriesSection emits a "Manual-entry context" sub-block',
-      /### Manual-entry context \(qualifies same-day values above\)/.test(labCtxSrc));
-    assert('Context sub-block filters to manual rows with tags or notes in the date window',
-      /const manualRows = rowsBySource\['manual'\] \|\| \[\];[\s\S]{0,600}hasTags \|\| hasNote/.test(labCtxSrc));
-    assert('Context sub-block surfaces tags + note text per row',
-      /tags: \$\{r\.tags\.join\(', '\)\}/.test(labCtxSrc) &&
-      /note: "\$\{r\.note\.trim\(\)\}"/.test(labCtxSrc));
-    assert('Wearable series section degrades gracefully when only context rows exist',
-      /if \(lines\.length === 0 && !contextBlock\) return ''[\s\S]{0,200}if \(lines\.length === 0\)/.test(labCtxSrc));
-
-  } finally {
-    // Restore live profile
-    window._labState.currentProfile = origProfile;
-    window._labState.importedData = origImported;
-  }
+  const EMPTY_PROFILE = 'test-empty-' + Math.random().toString(36).slice(2, 8);
+  const emptyRes = await manual.migrateBiometricsToManual(EMPTY_PROFILE, null);
+  assert('migration handles null biometrics', emptyRes.skipped === 'no-biometrics');
 
   // ═══════════════════════════════════════
-  // Results
+  // 7. deleteManualMetric
   // ═══════════════════════════════════════
-  console.log(`\n%c Tests complete: ${pass} passed, ${fail} failed `, fail ? 'background:#ef4444;color:#fff;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;padding:4px 12px;border-radius:4px');
-  if (typeof window.__TEST_RESULTS !== 'undefined') window.__TEST_RESULTS = { pass, fail };
-})();
+  console.log('7. deleteManualMetric');
+
+  const DEL_PROFILE = 'test-del-' + Math.random().toString(36).slice(2, 8);
+  window._labState.currentProfile = DEL_PROFILE;
+  window._labState.importedData = { wearableConnections: {} };
+  await manual.logManualMetric(DEL_PROFILE, 'weight', { date: '2026-04-24', value: 82 });
+  await manual.logManualBP(DEL_PROFILE, { date: '2026-04-24', systolic: 118, diastolic: 76, pulse: 64 });
+
+  await manual.deleteManualMetric(DEL_PROFILE, 'weight', '2026-04-24');
+  const afterWeightDel = await store.getDaily(DEL_PROFILE, 'manual', '2026-04-24');
+  assert('weight deleted but row kept (BP remains)',
+    afterWeightDel?.weight == null && afterWeightDel?.bp_systolic === 118);
+
+  await manual.deleteManualMetric(DEL_PROFILE, 'bp_systolic', '2026-04-24');
+  await manual.deleteManualMetric(DEL_PROFILE, 'bp_diastolic', '2026-04-24');
+  await manual.deleteManualMetric(DEL_PROFILE, 'rhr', '2026-04-24');
+  const afterAllDel = await store.getDaily(DEL_PROFILE, 'manual', '2026-04-24');
+  assert('all-metrics-deleted row is removed from IDB (no stub)',
+    afterAllDel == null);
+
+  let threwDel = false;
+  try { await manual.deleteManualMetric(DEL_PROFILE, 'bogus', '2026-04-24'); }
+  catch { threwDel = true; }
+  assert('deleteManualMetric rejects unknown metric', threwDel);
+  await manual.deleteManualMetric(DEL_PROFILE, 'weight', '2099-01-01'); // no-op
+  assert('deleteManualMetric on missing date is a no-op', true);
+
+  // ═══════════════════════════════════════
+  // 8. Context tags
+  // ═══════════════════════════════════════
+  console.log('8. Context Tags');
+
+  const TAG_PROFILE = 'test-tags-' + Math.random().toString(36).slice(2, 8);
+  window._labState.currentProfile = TAG_PROFILE;
+  window._labState.importedData = { wearableConnections: {} };
+  await manual.logManualBP(TAG_PROFILE, {
+    date: '2026-04-24', systolic: 145, diastolic: 92,
+    tags: ['post-workout', 'stress']
+  });
+  const taggedRow = await store.getDaily(TAG_PROFILE, 'manual', '2026-04-24');
+  assert('BP row persists tags array', Array.isArray(taggedRow?.tags));
+  assert('tags contain post-workout + stress',
+    taggedRow?.tags?.includes('post-workout') && taggedRow?.tags?.includes('stress'));
+
+  await manual.logManualMetric(TAG_PROFILE, 'weight', {
+    date: '2026-04-25', value: 81,
+    tags: ['morning-fasted', 'bogus-tag', 'resting', 'post-workout']
+  });
+  const weightRow = await store.getDaily(TAG_PROFILE, 'manual', '2026-04-25');
+  assert('unknown tags are filtered out',
+    !weightRow?.tags?.includes('bogus-tag'));
+  assert('valid tags survive the filter',
+    weightRow?.tags?.includes('morning-fasted') &&
+    weightRow?.tags?.includes('resting') &&
+    weightRow?.tags?.includes('post-workout'));
+
+  assert('wearables.js renders tag chips on bp form', wearablesSrc.includes('_renderTagChips'));
+  assert('toggleManualLogChip on window', typeof window.toggleManualLogChip === 'function');
+
+  const saveFn = wearablesSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}/)?.[0] || '';
+  const delFn = wearablesSrc.match(/async function deleteManualEntryFromDetail[\s\S]*?\n\}/)?.[0] || '';
+  assert('saveManualEntryFromDetail re-renders dashboard strip',
+    /window\.navigate\([^)]*\)/.test(saveFn) && /['"]dashboard['"]/.test(saveFn));
+  assert('deleteManualEntryFromDetail re-renders dashboard strip',
+    /window\.navigate\([^)]*\)/.test(delFn) && /['"]dashboard['"]/.test(delFn));
+  assert('deleteManualEntryFromDetail closes modal when last reading is removed',
+    /closeModal/.test(delFn));
+
+  const handleDisconnectFn = wearablesSrc.match(/async function handleManualDisconnect[\s\S]*?\n\}\s*\n/)?.[0] || '';
+  assert('deleteManualEntryFromDetail uses promise-style showConfirmDialog',
+    /await\s+window\.showConfirmDialog\(/.test(delFn));
+  assert('handleManualDisconnect uses promise-style showConfirmDialog',
+    /await\s+window\.showConfirmDialog\(/.test(handleDisconnectFn));
+
+  // ═══════════════════════════════════════
+  // Note + chip parity (this-branch additions)
+  // ═══════════════════════════════════════
+  console.log('Note + chip parity');
+
+  const manualLibSrc = await fetch('js/wearables-manual.js').then(r => r.text());
+
+  assert('logManualMetric signature accepts note param',
+    /export async function logManualMetric\(profileId, metric, \{ date, value, tags, note \}\)/.test(manualLibSrc));
+  assert('logManualBP signature accepts note param',
+    /export async function logManualBP\(profileId, \{ date, systolic, diastolic, pulse, tags, note \}\)/.test(manualLibSrc));
+  assert('Both helpers write the note onto the row patch via _sanitizeNote',
+    /const noteClean = _sanitizeNote\(note\);[\s\S]{0,200}if \(noteClean\) patch\.note = noteClean/.test(manualLibSrc) &&
+    /const noteClean = _sanitizeNote\(note\);[\s\S]{0,200}if \(noteClean\) row\.note = noteClean/.test(manualLibSrc));
+
+  assert('_sanitizeNote function defined',
+    /function _sanitizeNote\(note\)/.test(manualLibSrc));
+  assert('_sanitizeNote trims whitespace',
+    /const trimmed = note\.trim\(\)/.test(manualLibSrc));
+  assert('_sanitizeNote caps at 500 chars',
+    /trimmed\.length > 500 \? trimmed\.slice\(0, 500\)/.test(manualLibSrc));
+  assert("_sanitizeNote returns '' for non-string",
+    /if \(typeof note !== 'string'\) return ''/.test(manualLibSrc));
+
+  // Live behavior: write + read a manual metric with note, verify persistence.
+  const probeProfile = 'test-note-' + Date.now();
+  window._labState.currentProfile = probeProfile;
+  await manual.logManualMetric(probeProfile, 'rhr', {
+    date: '2099-05-12', value: 60, tags: ['resting'], note: 'morning, just woke'
+  });
+  const rows = await store.getDailyRange(probeProfile, 'manual', '2099-05-12', '2099-05-12');
+  assert('logManualMetric persists note on the row',
+    rows.length === 1 && rows[0].note === 'morning, just woke');
+  assert('logManualMetric still persists tags alongside note',
+    Array.isArray(rows[0].tags) && rows[0].tags.includes('resting'));
+  const longNote = 'x'.repeat(800);
+  await manual.logManualMetric(probeProfile, 'weight', {
+    date: '2099-05-13', value: 70, note: longNote
+  });
+  const rows2 = await store.getDailyRange(probeProfile, 'manual', '2099-05-13', '2099-05-13');
+  assert('Note capped at 500 chars',
+    rows2[0].note && rows2[0].note.length === 500);
+  await manual.logManualMetric(probeProfile, 'weight', {
+    date: '2099-05-14', value: 71, note: '   '
+  });
+  const rows3 = await store.getDailyRange(probeProfile, 'manual', '2099-05-14', '2099-05-14');
+  assert('Whitespace-only note is dropped (no note field on row)',
+    rows3[0].note === undefined);
+
+  await manual.logManualBP(probeProfile, {
+    date: '2099-05-15', systolic: 120, diastolic: 80, tags: ['post-workout'], note: 'after run'
+  });
+  const rows4 = await store.getDailyRange(probeProfile, 'manual', '2099-05-15', '2099-05-15');
+  assert('logManualBP persists note on the row',
+    rows4[0].note === 'after run' && rows4[0].tags?.includes('post-workout'));
+
+  // Detail-modal form has chips for rhr + bp (parity with empty-card form).
+  const rhrChipMatches = (wearablesSrc.match(/_renderTagChips\('rhr'\)/g) || []).length;
+  const bpChipMatches = (wearablesSrc.match(/_renderTagChips\('bp_systolic'\)/g) || []).length;
+  assert("_renderTagChips('rhr') called from both empty-card AND detail-modal forms",
+    rhrChipMatches >= 2, `count=${rhrChipMatches}`);
+  assert("_renderTagChips('bp_systolic') called from both empty-card AND detail-modal forms",
+    bpChipMatches >= 2, `count=${bpChipMatches}`);
+  const openDetailStart = wearablesSrc.indexOf('function openManualAddFromDetail');
+  const closeManualFnStart = wearablesSrc.indexOf('function closeManualAddFromDetail');
+  const openDetailFn = (openDetailStart !== -1 && closeManualFnStart !== -1)
+    ? wearablesSrc.slice(openDetailStart, closeManualFnStart) : '';
+  assert('Detail-modal RHR branch renders tag chips',
+    /kind === 'rhr'[\s\S]{0,800}_renderTagChips\('rhr'\)/.test(openDetailFn));
+  assert('Detail-modal BP branch renders tag chips',
+    /kind === 'bp'[\s\S]{0,1500}_renderTagChips\('bp_systolic'\)/.test(openDetailFn));
+  assert('Detail-modal weight branch does NOT render tag chips (matches empty-card convention)',
+    !/kind === 'weight'[\s\S]{0,400}_renderTagChips/.test(openDetailFn));
+
+  assert('Detail-modal form renders the wlad-note textarea',
+    /openManualAddFromDetail[\s\S]{0,3000}_renderNoteField\('wlad-note'\)/.test(wearablesSrc));
+  assert('Empty-card weight form renders wl-weight-note textarea',
+    /metricId === 'weight'[\s\S]{0,1000}_renderNoteField\('wl-weight-note'\)/.test(wearablesSrc));
+  assert('Empty-card BP form renders wl-bp-note textarea',
+    /metricId === 'bp_systolic'[\s\S]{0,1500}_renderNoteField\('wl-bp-note'\)/.test(wearablesSrc));
+  assert('Empty-card RHR form renders wl-rhr-note textarea',
+    /metricId === 'rhr'[\s\S]{0,1000}_renderNoteField\('wl-rhr-note'\)/.test(wearablesSrc));
+
+  assert('_renderNoteField helper defined',
+    /function _renderNoteField\(idSuffix = 'wl-note'\)/.test(wearablesSrc));
+  assert('_renderNoteField outputs a wearable-log-note textarea',
+    /<textarea class="wearable-log-note"/.test(wearablesSrc));
+
+  const saveLogFn = wearablesSrc.match(/async function saveManualLog[\s\S]*?\n\}\s*\n/)?.[0] || '';
+  assert('saveManualLog reads note from `wl-${kind}-note` (or `wl-bp-note`)',
+    /document\.getElementById\(`wl-\$\{kind === 'bp' \? 'bp' : kind\}-note`\)/.test(saveLogFn));
+  assert('saveManualLog passes note to logManualMetric (weight + rhr) and logManualBP',
+    /logManualMetric\(profileId, 'weight', \{[^}]*note\s*\}\)/.test(saveLogFn) &&
+    /logManualMetric\(profileId, 'rhr', \{[^}]*note\s*\}\)/.test(saveLogFn) &&
+    /logManualBP\(profileId, \{[^}]*note\s*\}\)/.test(saveLogFn));
+
+  const saveFromDetailFn = wearablesSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';
+  assert('saveManualEntryFromDetail reads wlad-note from the detail-modal form',
+    /document\.getElementById\('wlad-note'\)/.test(saveFromDetailFn));
+  assert('saveManualEntryFromDetail scopes chip collection to the form element',
+    /const formEl = document\.querySelector\('\.wearable-manual-add-form'\)[\s\S]{0,200}_collectActiveChips\(formEl\)/.test(saveFromDetailFn));
+  assert('saveManualEntryFromDetail passes tags + note to log helpers',
+    /logManualMetric\(profileId, 'weight', \{[^}]*tags, note\s*\}\)/.test(saveFromDetailFn) &&
+    /logManualMetric\(profileId, 'rhr', \{[^}]*tags, note\s*\}\)/.test(saveFromDetailFn) &&
+    /logManualBP\(profileId, \{[^}]*tags, note\s*\}\)/.test(saveFromDetailFn));
+
+  const entriesSectionFn = wearablesSrc.match(/function buildManualEntriesSection[\s\S]*?\n\}\s*\n/)?.[0] || '';
+  assert('manualEntries map pulls note: r.note from the IDB row',
+    /\.map\(r => \(\{ date: r\.date, v: r\[metricId\], tags: r\.tags, note: r\.note \}\)\)/.test(wearablesSrc));
+  assert('Entries-list row renders the note (.wearable-manual-entry-note) when present',
+    /typeof e\.note === 'string' && e\.note\.trim\(\)[\s\S]{0,200}wearable-manual-entry-note/.test(entriesSectionFn));
+  assert("Row gains 'has-note' modifier class for layout when note is present",
+    /wearable-manual-entry\$\{noteRow \? ' has-note' : ''\}/.test(entriesSectionFn));
+
+  const stylesSrc = await fetch('styles.css').then(r => r.text());
+  assert('CSS defines .wearable-log-note',
+    /\.wearable-log-note\s*\{/.test(stylesSrc));
+  assert('CSS defines .wearable-manual-entry-note',
+    /\.wearable-manual-entry-note\s*\{/.test(stylesSrc));
+  assert('CSS defines .wearable-manual-entry.has-note { flex-wrap: wrap }',
+    /\.wearable-manual-entry\.has-note\s*\{[^}]*flex-wrap:\s*wrap/.test(stylesSrc));
+
+  const labCtxSrc = await fetch('js/lab-context.js').then(r => r.text());
+  assert('buildWearableSeriesSection emits a "Manual-entry context" sub-block',
+    /### Manual-entry context \(qualifies same-day values above\)/.test(labCtxSrc));
+  assert('Context sub-block filters to manual rows with tags or notes in the date window',
+    /const manualRows = rowsBySource\['manual'\] \|\| \[\];[\s\S]{0,600}hasTags \|\| hasNote/.test(labCtxSrc));
+  assert('Context sub-block surfaces tags + note text per row',
+    /tags: \$\{r\.tags\.join\(', '\)\}/.test(labCtxSrc) &&
+    /note: "\$\{r\.note\.trim\(\)\}"/.test(labCtxSrc));
+  assert('Wearable series section degrades gracefully when only context rows exist',
+    /if \(lines\.length === 0 && !contextBlock\) return ''[\s\S]{0,200}if \(lines\.length === 0\)/.test(labCtxSrc));
+
+} finally {
+  // Restore live profile
+  window._labState.currentProfile = origProfile;
+  window._labState.importedData = origImported;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-wearables-sync-flow.js
+++ b/tests/test-wearables-sync-flow.js
@@ -1,386 +1,375 @@
-// test-wearables-sync-flow.js — orchestration end-to-end
-// Mocks the proxy fetch + a fake connection record, drives the actual
-// backfillWearable / incrementalSyncWearable / syncNow paths, and asserts
-// the IDB / state side-effects + L2 summary recompute + last-sync meta.
+#!/usr/bin/env node
+// test-wearables-sync-flow.js — orchestration end-to-end. Mocks the proxy
+// fetch + a fake connection record, drives the actual backfillWearable /
+// incrementalSyncWearable / syncWearableSummary / disconnectWearable paths,
+// and asserts the IDB / state side-effects + L2 summary recompute + last-sync
+// meta.
+//
+// Run: node tests/test-wearables-sync-flow.js  (or via npm test)
+//
+// Full port — no DOM. IndexedDB runs via fake-indexeddb; the test mocks
+// window.fetch for the /api/proxy path and falls through to the fs-backed
+// fetch shim for source-inspection reads.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+import './_node-shim.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+
+// fs-backed fetch shim — installed BEFORE the test body so the test's
+// `realFetch = window.fetch` snapshot captures it, and mockFetch's
+// non-/api/proxy fall-through resolves `fetch('/js/X')` source reads.
+const _nodeFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  if (typeof url === 'string' && !/^https?:/.test(url) && url !== '/api/proxy') {
+    const rel = url.replace(/^\//, '');
+    try { return new Response(read(rel), { status: 200 }); }
+    catch (_) { return new Response('', { status: 404 }); }
   }
+  return _nodeFetch(url, opts);
+};
 
-  console.log('%c Wearables Sync-Flow Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const bust = '?bust=' + Date.now();
-  const connect  = await import('../js/wearables-connect.js' + bust);
-  const store    = await import('../js/wearables-store.js' + bust);
-  const summary  = await import('../js/wearables-summary.js' + bust);
+console.log('=== Wearables Sync-Flow Tests ===\n');
 
-  // ─────────────────────────────────────────────────────────
-  // Test profile + harness — isolate state so the live profile is untouched.
-  // ─────────────────────────────────────────────────────────
-  const TEST_PROFILE_ID = 'sync-flow-test-' + Date.now().toString(36);
-  const origActiveProfile = localStorage.getItem('labcharts-active-profile');
-  // CRITICAL: saveImportedData() keys off state.currentProfile, NOT the
-  // localStorage active-profile entry. If we only swap the localStorage
-  // value, any save inside the test (e.g. backfillWearable's saveConnection)
-  // writes the test's fake state to the USER'S real profile storage key.
-  // Snapshot AND restore both.
-  const origCurrentProfile = window._labState.currentProfile;
-  localStorage.setItem('labcharts-active-profile', TEST_PROFILE_ID);
-  window._labState.currentProfile = TEST_PROFILE_ID;
+await import('../js/state.js');
+const connect = await import('../js/wearables-connect.js');
+const store = await import('../js/wearables-store.js');
+const summary = await import('../js/wearables-summary.js');
+await import('../js/sync.js'); // registers window.pushContextToGateway
 
-  const origState = window._labState.importedData;
-  window._labState.importedData = {
-    entries: [],
-    wearableConnections: {},
-    wearableSummary: null,
-    changeHistory: [],
-  };
+// ─────────────────────────────────────────────────────────
+// Test profile + harness — isolate state so the live profile is untouched.
+// ─────────────────────────────────────────────────────────
+const TEST_PROFILE_ID = 'sync-flow-test-' + Date.now().toString(36);
+const origActiveProfile = localStorage.getItem('labcharts-active-profile');
+// CRITICAL: saveImportedData() keys off state.currentProfile, NOT the
+// localStorage active-profile entry. Snapshot AND restore both.
+const origCurrentProfile = window._labState.currentProfile;
+localStorage.setItem('labcharts-active-profile', TEST_PROFILE_ID);
+window._labState.currentProfile = TEST_PROFILE_ID;
 
-  const realFetch = window.fetch;
-  let routes = [];
-  let calls = [];
-  function mockFetch(input, init) {
-    const url = (typeof input === 'string') ? input : input?.url;
-    if (url !== '/api/proxy') return realFetch.call(window, input, init);
-    let body = {};
-    try { body = JSON.parse(init?.body || '{}'); } catch {}
-    calls.push({ url: body.url, method: body.method });
-    for (const r of routes) {
-      const ok = (typeof r.matcher === 'string') ? body.url?.includes(r.matcher) : r.matcher.test(body.url || '');
-      if (ok) {
-        return Promise.resolve(new Response(JSON.stringify(r.body), {
-          status: r.status || 200,
-          headers: { 'Content-Type': 'application/json' },
-        }));
-      }
+const origState = window._labState.importedData;
+window._labState.importedData = {
+  entries: [],
+  wearableConnections: {},
+  wearableSummary: null,
+  changeHistory: [],
+};
+
+const realFetch = window.fetch;
+let routes = [];
+let calls = [];
+function mockFetch(input, init) {
+  const url = (typeof input === 'string') ? input : input?.url;
+  if (url !== '/api/proxy') return realFetch.call(window, input, init);
+  let body = {};
+  try { body = JSON.parse(init?.body || '{}'); } catch {}
+  calls.push({ url: body.url, method: body.method });
+  for (const r of routes) {
+    const ok = (typeof r.matcher === 'string') ? body.url?.includes(r.matcher) : r.matcher.test(body.url || '');
+    if (ok) {
+      return Promise.resolve(new Response(JSON.stringify(r.body), {
+        status: r.status || 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
     }
-    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }));
   }
-  function installRoutes(rs) { routes = rs; calls = []; window.fetch = mockFetch; }
-  function restore() { window.fetch = realFetch; }
+  return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }));
+}
+function installRoutes(rs) { routes = rs; calls = []; window.fetch = mockFetch; }
+function restore() { window.fetch = realFetch; }
 
-  // Fake-connect Oura so wearables-connect.js sees an authenticated state.
-  function fakeConnect(adapterId) {
-    window._labState.importedData.wearableConnections[adapterId] = {
-      accessToken: 'test-' + adapterId + '-token',
-      refreshToken: 'test-' + adapterId + '-refresh',
-      expiresAt: Date.now() + 24 * 60 * 60 * 1000, // 24h fresh — withFreshToken sees no need to refresh
-      connectedAt: new Date().toISOString(),
-      lastSyncAt: 0,
-      account: { email: 'test@example.invalid' },
-    };
-  }
-
-  async function wipeWearableIDB() {
-    try { await store.clearSource(TEST_PROFILE_ID, 'oura'); } catch {}
-    try { await store.clearSource(TEST_PROFILE_ID, 'fitbit'); } catch {}
-  }
-  await wipeWearableIDB();
-
-  // ═══════════════════════════════════════
-  // 1. backfillWearable — full pull populates IDB + meta
-  // ═══════════════════════════════════════
-  console.log('%c 1. Backfill ', 'font-weight:bold;color:#f59e0b');
-  fakeConnect('oura');
-  try {
-    installRoutes([
-      { matcher: 'usercollection/sleep', body: {
-        data: [
-          { day: '2026-04-20', total_sleep_duration: 26000, average_hrv: 38, average_heart_rate: 60, lowest_heart_rate: 54 },
-          { day: '2026-04-21', total_sleep_duration: 25000, average_hrv: 42, average_heart_rate: 58, lowest_heart_rate: 52 },
-          { day: '2026-04-22', total_sleep_duration: 27000, average_hrv: 40, average_heart_rate: 59, lowest_heart_rate: 53 },
-        ], next_token: null,
-      }},
-      { matcher: 'usercollection/daily_sleep', body: { data: [
-        { day: '2026-04-20', score: 78 },
-        { day: '2026-04-21', score: 82 },
-        { day: '2026-04-22', score: 75 },
-      ], next_token: null }},
-      { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
-      { matcher: /usercollection\//, body: { data: [], next_token: null }},
-    ]);
-
-    const result = await connect.backfillWearable('oura', 90);
-    assert('backfillWearable returns rows count', typeof result.rows === 'number');
-    assert('backfillWearable returns startDate', !!result.startDate);
-    assert('backfillWearable returns endDate', !!result.endDate);
-    assert('backfillWearable produced ≥3 rows from the sleep payload', result.rows >= 3);
-
-    const rows = await store.getDailyRange(TEST_PROFILE_ID, 'oura', '2026-04-19', '2026-04-25');
-    assert('Oura rows persisted to L1 IDB', rows.length >= 3);
-    const day20 = rows.find(r => r.date === '2026-04-20');
-    assert('Persisted row carries hrv_rmssd from sleep payload', day20?.hrv_rmssd === 38);
-    assert('Persisted row carries rhr from sleep lowest_heart_rate', day20?.rhr === 54);
-    assert('Persisted row carries sleep_score from daily_sleep', day20?.sleep_score === 78);
-
-    const meta = await store.getMeta(TEST_PROFILE_ID, 'last-sync:oura');
-    assert('last-sync meta written after backfill', !!meta);
-    assert('last-sync meta carries rows count', typeof meta?.rows === 'number');
-    assert('last-sync meta carries startDate + endDate', !!meta?.startDate && !!meta?.endDate);
-
-    const conn = window._labState.importedData.wearableConnections.oura;
-    assert('Connection.lastSyncAt updated post-backfill', conn?.lastSyncAt > 0);
-  } finally { restore(); }
-
-  // ═══════════════════════════════════════
-  // 2. syncWearableSummary — recomputes L2 from L1 rows
-  // ═══════════════════════════════════════
-  console.log('%c 2. L2 Recompute ', 'font-weight:bold;color:#f59e0b');
-  const sync2 = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
-  assert('syncWearableSummary writes on first call (initial summary, no prior)',
-    sync2.wrote === true && sync2.reason === 'initial');
-  const sumState = window._labState.importedData?.wearableSummary;
-  assert('wearableSummary persisted into state.importedData', !!sumState);
-  assert('wearableSummary.metrics carries hrv_rmssd entry from IDB rows',
-    !!sumState?.metrics?.hrv_rmssd);
-  assert('hrv_rmssd primarySource is oura (auto-picker)',
-    sumState?.metrics?.hrv_rmssd?.primarySource === 'oura');
-  assert('hrv_rmssd weekly array has at least one bucket',
-    Array.isArray(sumState?.metrics?.hrv_rmssd?.weekly) &&
-    sumState.metrics.hrv_rmssd.weekly.length >= 1);
-  assert('summary.sources.oura.coverageDays > 0 after backfill',
-    sumState?.sources?.oura?.coverageDays > 0);
-
-  // ═══════════════════════════════════════
-  // 3. incrementalSyncWearable — uses lastSync.endDate as start
-  // ═══════════════════════════════════════
-  console.log('%c 3. Incremental Sync ', 'font-weight:bold;color:#f59e0b');
-  try {
-    let observedStart = null;
-    installRoutes([
-      { matcher: 'usercollection/sleep', body: { data: [], next_token: null }},
-      { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
-      { matcher: /usercollection\//, body: { data: [], next_token: null }},
-    ]);
-    const origMockFetch = window.fetch;
-    window.fetch = (input, init) => {
-      if (input === '/api/proxy' && observedStart === null) {
-        try {
-          const body = JSON.parse(init.body);
-          const m = body.url?.match(/start_date=(\d{4}-\d{2}-\d{2})/);
-          if (m) observedStart = m[1];
-        } catch {}
-      }
-      return origMockFetch.call(window, input, init);
-    };
-    await connect.incrementalSyncWearable('oura');
-    assert('incrementalSync requests start_date ≥ 2026-01-01 (no full re-pull)',
-      observedStart !== null && observedStart >= '2026-01-01',
-      `observed start_date=${observedStart}`);
-  } finally { restore(); }
-
-  // 3b. Force-mode incrementalSync — when the user clicks "Sync now" we
-  // pass force:true so the window is at least 7 days back. Without this,
-  // a same-day re-sync collapsed to [today, today] and Oura's /sleep
-  // sometimes returned no rows (observed bug: strip "Sync now" did
-  // nothing while Settings → "Re-sync 90 days" caught the missing data).
-  try {
-    let observedStartForce = null;
-    installRoutes([
-      { matcher: 'usercollection/sleep', body: { data: [], next_token: null }},
-      { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
-      { matcher: /usercollection\//, body: { data: [], next_token: null }},
-    ]);
-    // Pretend user already synced today — lastSync.endDate is today, so
-    // the non-force window would be [today, today].
-    const todayIso = new Date().toISOString().slice(0, 10);
-    await store.setMeta(TEST_PROFILE_ID, 'last-sync:oura', { at: Date.now(), rows: 5, startDate: todayIso, endDate: todayIso });
-    const origMockFetch2 = window.fetch;
-    window.fetch = (input, init) => {
-      if (input === '/api/proxy' && observedStartForce === null) {
-        try {
-          const body = JSON.parse(init.body);
-          const m = body.url?.match(/start_date=(\d{4}-\d{2}-\d{2})/);
-          if (m) observedStartForce = m[1];
-        } catch {}
-      }
-      return origMockFetch2.call(window, input, init);
-    };
-    await connect.incrementalSyncWearable('oura', { force: true });
-    // 7 days back from today (UTC). Allow a 1-day fudge for runs spanning midnight.
-    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    assert('Force-mode expands start_date to ≥ 7 days back even when lastSync.endDate is today',
-      observedStartForce !== null && observedStartForce <= sevenDaysAgo,
-      `observed start_date=${observedStartForce}, expected ≤ ${sevenDaysAgo}`);
-  } finally { restore(); }
-
-  // ═══════════════════════════════════════
-  // 4. backfill error recovery — rows write even when one endpoint 500s
-  // ═══════════════════════════════════════
-  console.log('%c 4. Partial Failure ', 'font-weight:bold;color:#f59e0b');
-  try {
-    installRoutes([
-      { matcher: 'usercollection/sleep', body: {
-        data: [{ day: '2026-04-23', total_sleep_duration: 26000, average_hrv: 35, average_heart_rate: 62 }],
-        next_token: null,
-      }},
-      { matcher: 'usercollection/daily_readiness', status: 500, body: { error: 'server' }},
-      { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
-      { matcher: /usercollection\//, body: { data: [], next_token: null }},
-    ]);
-    let err = null;
-    try { await connect.backfillWearable('oura', 7); }
-    catch (e) { err = e; }
-    assert('Backfill swallows per-endpoint 5xx and continues with the rest',
-      err === null);
-    const rows = await store.getDailyRange(TEST_PROFILE_ID, 'oura', '2026-04-23', '2026-04-23');
-    assert('Sleep-derived row persists even when daily_readiness 500s',
-      rows.some(r => r.date === '2026-04-23' && r.hrv_rmssd === 35));
-  } finally { restore(); }
-
-  // ═══════════════════════════════════════
-  // 5. L2 gate — minimum-cadence force-write after 14d silence
-  // ═══════════════════════════════════════
-  console.log('%c 5. Gate Min-Cadence ', 'font-weight:bold;color:#f59e0b');
-  const old = window._labState.importedData.wearableSummary;
-  if (old) {
-    const fortnightAgo = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
-    old.summaryUpdatedAt = fortnightAgo;
-    window._labState.importedData.wearableSummary = old;
-    const result = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
-    assert('Gate force-writes after 14d silence (min-cadence)',
-      result.wrote === true && result.reason === 'min-cadence');
-  } else {
-    assert('skip min-cadence test (no prior summary)', true);
-  }
-
-  // ═══════════════════════════════════════
-  // 6. Disconnect — wipes IDB + summary entry
-  // ═══════════════════════════════════════
-  console.log('%c 6. Disconnect ', 'font-weight:bold;color:#f59e0b');
-  await connect.disconnectWearable('oura');
-  const remainingRows = await store.getDailyRange(TEST_PROFILE_ID, 'oura', '2026-01-01', '2099-12-31');
-  assert('disconnectWearable clears L1 rows for that source',
-    remainingRows.length === 0);
-  assert('disconnectWearable removes wearableConnections entry',
-    !window._labState.importedData?.wearableConnections?.oura);
-  assert('disconnectWearable removes the source from wearableSummary.sources',
-    !window._labState.importedData?.wearableSummary?.sources?.oura);
-
-  // ═══════════════════════════════════════
-  // 7. Push-to-gateway — exposed function + toggle helpers
-  // ═══════════════════════════════════════
-  console.log('%c 7. Gateway Push ', 'font-weight:bold;color:#f59e0b');
-  // Minimal smoke test on the toggle path. Full POST-body assertion would
-  // require waiting out the 5s debounce; this validates the public surface.
-  fakeConnect('oura');
-  try {
-    localStorage.setItem('labcharts-messenger-enabled', 'true');
-    localStorage.setItem('labcharts-messenger-token', 'test-mock-token-12345');
-
-    const labContextSrc = await fetch('/js/lab-context.js').then(r => r.text());
-    assert('buildLabContext emits [section:wearables] block', /\[section:wearables\]/.test(labContextSrc));
-    assert('buildLabContext emits [section:wearables-series-{N}d] block', /wearables-series-\$\{days\}d/.test(labContextSrc));
-
-    const syncMod = await import('/js/sync.js?bust=' + Date.now());
-    assert('isMessengerEnabled returns true after enabling',
-      syncMod.isMessengerEnabled() === true);
-    assert('getMessengerToken returns the test token',
-      syncMod.getMessengerToken() === 'test-mock-token-12345');
-    assert('window.pushContextToGateway exposed (toggle handler can fire it)',
-      typeof window.pushContextToGateway === 'function');
-  } finally {
-    localStorage.removeItem('labcharts-messenger-enabled');
-    localStorage.removeItem('labcharts-messenger-token');
-  }
-
-  // ═══════════════════════════════════════
-  // 8. stripWearableCredentials — token leak prevention
-  // ═══════════════════════════════════════
-  console.log('%c 8. stripWearableCredentials ', 'font-weight:bold;color:#f59e0b');
-  // The most security-load-bearing function in the wearables surface.
-  // Direct test rather than relying on grep guards that pass on string
-  // presence.
-  const sync8 = await import('/js/sync.js?bust=' + Date.now());
-  const stripFn = sync8._testStripWearableCredentials || null;
-  // Function is module-private. Use buildSyncPayload as the public surface
-  // — push a snapshot + assert no token strings leak in.
-  const TEST_PROFILE_2 = 'strip-creds-test-' + Date.now().toString(36);
-  const sentinelToken = 'SENTINEL-TOKEN-' + Math.random().toString(36).slice(2);
-  const sentinelRefresh = 'SENTINEL-REFRESH-' + Math.random().toString(36).slice(2);
-  window._labState.importedData = {
-    entries: [],
-    wearableConnections: {
-      oura: {
-        accessToken: sentinelToken,
-        refreshToken: sentinelRefresh,
-        expiresAt: Date.now() + 86400000,
-        connectedAt: new Date().toISOString(),
-      },
-    },
-    wearableSummary: {
-      summaryUpdatedAt: new Date().toISOString(),
-      sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 }},
-      metrics: { hrv_rmssd: { primarySource: 'oura', latest: 38, baseline: 36, baselineP25: 32, baselineP75: 40, rolling: { d7: 37, d30: 36, d90: 36 }, trend30d: 'flat', weekly: [36, 37, 38] }},
-    },
-    changeHistory: [],
+// Fake-connect Oura so wearables-connect.js sees an authenticated state.
+function fakeConnect(adapterId) {
+  window._labState.importedData.wearableConnections[adapterId] = {
+    accessToken: 'test-' + adapterId + '-token',
+    refreshToken: 'test-' + adapterId + '-refresh',
+    expiresAt: Date.now() + 24 * 60 * 60 * 1000, // 24h fresh
+    connectedAt: new Date().toISOString(),
+    lastSyncAt: 0,
+    account: { email: 'test@example.invalid' },
   };
-  // Trigger a push payload build by inspecting buildSyncPayload's output —
-  // it's also private, but pushProfile (exported) writes the payload
-  // through the same path. Without a real Evolu setup we can't drive
-  // that, so capture the payload via a fetch shim.
-  let observedPayload = null;
-  const origFetch = window.fetch;
+}
+
+async function wipeWearableIDB() {
+  try { await store.clearSource(TEST_PROFILE_ID, 'oura'); } catch {}
+  try { await store.clearSource(TEST_PROFILE_ID, 'fitbit'); } catch {}
+}
+await wipeWearableIDB();
+
+// ═══════════════════════════════════════
+// 1. backfillWearable — full pull populates IDB + meta
+// ═══════════════════════════════════════
+console.log('1. Backfill');
+fakeConnect('oura');
+try {
+  installRoutes([
+    { matcher: 'usercollection/sleep', body: {
+      data: [
+        { day: '2026-04-20', total_sleep_duration: 26000, average_hrv: 38, average_heart_rate: 60, lowest_heart_rate: 54 },
+        { day: '2026-04-21', total_sleep_duration: 25000, average_hrv: 42, average_heart_rate: 58, lowest_heart_rate: 52 },
+        { day: '2026-04-22', total_sleep_duration: 27000, average_hrv: 40, average_heart_rate: 59, lowest_heart_rate: 53 },
+      ], next_token: null,
+    }},
+    { matcher: 'usercollection/daily_sleep', body: { data: [
+      { day: '2026-04-20', score: 78 },
+      { day: '2026-04-21', score: 82 },
+      { day: '2026-04-22', score: 75 },
+    ], next_token: null }},
+    { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
+    { matcher: /usercollection\//, body: { data: [], next_token: null }},
+  ]);
+
+  const result = await connect.backfillWearable('oura', 90);
+  assert('backfillWearable returns rows count', typeof result.rows === 'number');
+  assert('backfillWearable returns startDate', !!result.startDate);
+  assert('backfillWearable returns endDate', !!result.endDate);
+  assert('backfillWearable produced ≥3 rows from the sleep payload', result.rows >= 3);
+
+  const rows = await store.getDailyRange(TEST_PROFILE_ID, 'oura', '2026-04-19', '2026-04-25');
+  assert('Oura rows persisted to L1 IDB', rows.length >= 3);
+  const day20 = rows.find(r => r.date === '2026-04-20');
+  assert('Persisted row carries hrv_rmssd from sleep payload', day20?.hrv_rmssd === 38);
+  assert('Persisted row carries rhr from sleep lowest_heart_rate', day20?.rhr === 54);
+  assert('Persisted row carries sleep_score from daily_sleep', day20?.sleep_score === 78);
+
+  const meta = await store.getMeta(TEST_PROFILE_ID, 'last-sync:oura');
+  assert('last-sync meta written after backfill', !!meta);
+  assert('last-sync meta carries rows count', typeof meta?.rows === 'number');
+  assert('last-sync meta carries startDate + endDate', !!meta?.startDate && !!meta?.endDate);
+
+  const conn = window._labState.importedData.wearableConnections.oura;
+  assert('Connection.lastSyncAt updated post-backfill', conn?.lastSyncAt > 0);
+} finally { restore(); }
+
+// ═══════════════════════════════════════
+// 2. syncWearableSummary — recomputes L2 from L1 rows
+// ═══════════════════════════════════════
+console.log('2. L2 Recompute');
+const sync2 = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
+assert('syncWearableSummary writes on first call (initial summary, no prior)',
+  sync2.wrote === true && sync2.reason === 'initial');
+const sumState = window._labState.importedData?.wearableSummary;
+assert('wearableSummary persisted into state.importedData', !!sumState);
+assert('wearableSummary.metrics carries hrv_rmssd entry from IDB rows',
+  !!sumState?.metrics?.hrv_rmssd);
+assert('hrv_rmssd primarySource is oura (auto-picker)',
+  sumState?.metrics?.hrv_rmssd?.primarySource === 'oura');
+assert('hrv_rmssd weekly array has at least one bucket',
+  Array.isArray(sumState?.metrics?.hrv_rmssd?.weekly) &&
+  sumState.metrics.hrv_rmssd.weekly.length >= 1);
+assert('summary.sources.oura.coverageDays > 0 after backfill',
+  sumState?.sources?.oura?.coverageDays > 0);
+
+// ═══════════════════════════════════════
+// 3. incrementalSyncWearable — uses lastSync.endDate as start
+// ═══════════════════════════════════════
+console.log('3. Incremental Sync');
+try {
+  let observedStart = null;
+  installRoutes([
+    { matcher: 'usercollection/sleep', body: { data: [], next_token: null }},
+    { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
+    { matcher: /usercollection\//, body: { data: [], next_token: null }},
+  ]);
+  const origMockFetch = window.fetch;
   window.fetch = (input, init) => {
-    if ((typeof input === 'string' && input.includes('/api/context')) ||
-        (init?.body && typeof init.body === 'string' && init.body.includes(sentinelToken))) {
-      observedPayload = init?.body || '';
+    if (input === '/api/proxy' && observedStart === null) {
+      try {
+        const body = JSON.parse(init.body);
+        const m = body.url?.match(/start_date=(\d{4}-\d{2}-\d{2})/);
+        if (m) observedStart = m[1];
+      } catch {}
     }
-    return origFetch.call(window, input, init);
+    return origMockFetch.call(window, input, init);
   };
-  try {
-    // Direct test: read the payload that pushContextToGateway WOULD produce
-    // by calling buildLabContext (it's the same string, agent-or-Evolu).
-    const labCtx = await import('/js/lab-context.js?bust=' + Date.now());
-    const ctx = labCtx.buildLabContext({ skipGroupFilter: true });
-    assert('buildLabContext output does NOT contain accessToken sentinel',
-      !ctx.includes(sentinelToken));
-    assert('buildLabContext output does NOT contain refreshToken sentinel',
-      !ctx.includes(sentinelRefresh));
-    // Also: the export function shouldn't leak tokens into the JSON export.
-    const exportSrc = await fetch('/js/export.js').then(r => r.text());
-    assert('exportClientJSON shape does NOT include wearableConnections (token-bearing field)',
-      !/wearableConnections:\s*data\.wearableConnections/.test(exportSrc));
-  } finally {
-    window.fetch = origFetch;
-  }
+  await connect.incrementalSyncWearable('oura');
+  assert('incrementalSync requests start_date ≥ 2026-01-01 (no full re-pull)',
+    observedStart !== null && observedStart >= '2026-01-01',
+    `observed start_date=${observedStart}`);
+} finally { restore(); }
 
-  // ═══════════════════════════════════════
-  // 9. wearableConnections preserve on Evolu pull
-  // ═══════════════════════════════════════
-  console.log('%c 9. Pull-Side Token Preserve ', 'font-weight:bold;color:#f59e0b');
-  // This is the silent-disconnect-everyone branch. The pull merge must NOT
-  // overwrite local wearableConnections with the (token-stripped) remote.
-  const syncSrcPath = '/js/sync.js';
-  const syncSrcContent = await fetch(syncSrcPath).then(r => r.text());
-  // Two source-grep checks for the preserve logic — these stay because the
-  // pull path is a behavior we'd need a fully-mocked Evolu engine to
-  // exercise end-to-end, which we don't have.
-  assert('Sync pull preserves localWearableConnections by reading from disk first',
-    /localWearableConnections\s*=\s*state\.importedData\?\.wearableConnections/.test(syncSrcContent));
-  assert('Sync pull writes localWearableConnections back into the merged importedData',
-    /importedData\.wearableConnections\s*=\s*localWearableConnections/.test(syncSrcContent));
-  assert('Sync pull falls back to disk read when state.importedData is for a different profile',
-    /parsed\?\.wearableConnections/.test(syncSrcContent));
+// 3b. Force-mode incrementalSync — when the user clicks "Sync now" we pass
+// force:true so the window is at least 7 days back.
+try {
+  let observedStartForce = null;
+  installRoutes([
+    { matcher: 'usercollection/sleep', body: { data: [], next_token: null }},
+    { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
+    { matcher: /usercollection\//, body: { data: [], next_token: null }},
+  ]);
+  const todayIso = new Date().toISOString().slice(0, 10);
+  await store.setMeta(TEST_PROFILE_ID, 'last-sync:oura', { at: Date.now(), rows: 5, startDate: todayIso, endDate: todayIso });
+  const origMockFetch2 = window.fetch;
+  window.fetch = (input, init) => {
+    if (input === '/api/proxy' && observedStartForce === null) {
+      try {
+        const body = JSON.parse(init.body);
+        const m = body.url?.match(/start_date=(\d{4}-\d{2}-\d{2})/);
+        if (m) observedStartForce = m[1];
+      } catch {}
+    }
+    return origMockFetch2.call(window, input, init);
+  };
+  await connect.incrementalSyncWearable('oura', { force: true });
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  assert('Force-mode expands start_date to ≥ 7 days back even when lastSync.endDate is today',
+    observedStartForce !== null && observedStartForce <= sevenDaysAgo,
+    `observed start_date=${observedStartForce}, expected ≤ ${sevenDaysAgo}`);
+} finally { restore(); }
 
-  // ─────────────────────────────────────────────────────────
-  // Cleanup — restore live state.
-  // ─────────────────────────────────────────────────────────
-  await wipeWearableIDB();
-  // Drop the test profile's storage keys before restoring active-profile so
-  // a partial write during the test can't survive.
-  localStorage.removeItem(`labcharts-${TEST_PROFILE_ID}-imported`);
-  if (origActiveProfile) localStorage.setItem('labcharts-active-profile', origActiveProfile);
-  else localStorage.removeItem('labcharts-active-profile');
-  window._labState.currentProfile = origCurrentProfile;
-  window._labState.importedData = origState;
-  // Wipe the test wearable IDB outright so deleted-test-profile data
-  // doesn't accumulate.
-  try { const { deleteWearablesDB } = await import('/js/wearables-store.js'); await deleteWearablesDB(TEST_PROFILE_ID); } catch {}
+// ═══════════════════════════════════════
+// 4. backfill error recovery — rows write even when one endpoint 500s
+// ═══════════════════════════════════════
+console.log('4. Partial Failure');
+try {
+  installRoutes([
+    { matcher: 'usercollection/sleep', body: {
+      data: [{ day: '2026-04-23', total_sleep_duration: 26000, average_hrv: 35, average_heart_rate: 62 }],
+      next_token: null,
+    }},
+    { matcher: 'usercollection/daily_readiness', status: 500, body: { error: 'server' }},
+    { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
+    { matcher: /usercollection\//, body: { data: [], next_token: null }},
+  ]);
+  let err = null;
+  try { await connect.backfillWearable('oura', 7); }
+  catch (e) { err = e; }
+  assert('Backfill swallows per-endpoint 5xx and continues with the rest',
+    err === null);
+  const rows = await store.getDailyRange(TEST_PROFILE_ID, 'oura', '2026-04-23', '2026-04-23');
+  assert('Sleep-derived row persists even when daily_readiness 500s',
+    rows.some(r => r.date === '2026-04-23' && r.hrv_rmssd === 35));
+} finally { restore(); }
 
-  console.log(`\n%c Tests complete: ${pass} passed, ${fail} failed `, fail ? 'background:#ef4444;color:#fff;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;padding:4px 12px;border-radius:4px');
-  if (typeof window.__TEST_RESULTS !== 'undefined') window.__TEST_RESULTS = { pass, fail };
-})();
+// ═══════════════════════════════════════
+// 5. L2 gate — minimum-cadence force-write after 14d silence
+// ═══════════════════════════════════════
+console.log('5. Gate Min-Cadence');
+const old = window._labState.importedData.wearableSummary;
+if (old) {
+  const fortnightAgo = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
+  old.summaryUpdatedAt = fortnightAgo;
+  window._labState.importedData.wearableSummary = old;
+  const result = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
+  assert('Gate force-writes after 14d silence (min-cadence)',
+    result.wrote === true && result.reason === 'min-cadence');
+} else {
+  assert('skip min-cadence test (no prior summary)', true);
+}
+
+// ═══════════════════════════════════════
+// 6. Disconnect — wipes IDB + summary entry
+// ═══════════════════════════════════════
+console.log('6. Disconnect');
+await connect.disconnectWearable('oura');
+const remainingRows = await store.getDailyRange(TEST_PROFILE_ID, 'oura', '2026-01-01', '2099-12-31');
+assert('disconnectWearable clears L1 rows for that source',
+  remainingRows.length === 0);
+assert('disconnectWearable removes wearableConnections entry',
+  !window._labState.importedData?.wearableConnections?.oura);
+assert('disconnectWearable removes the source from wearableSummary.sources',
+  !window._labState.importedData?.wearableSummary?.sources?.oura);
+
+// ═══════════════════════════════════════
+// 7. Push-to-gateway — exposed function + toggle helpers
+// ═══════════════════════════════════════
+console.log('7. Gateway Push');
+fakeConnect('oura');
+try {
+  localStorage.setItem('labcharts-messenger-enabled', 'true');
+  localStorage.setItem('labcharts-messenger-token', 'test-mock-token-12345');
+
+  const labContextSrc = await fetch('/js/lab-context.js').then(r => r.text());
+  assert('buildLabContext emits [section:wearables] block', /\[section:wearables\]/.test(labContextSrc));
+  assert('buildLabContext emits [section:wearables-series-{N}d] block', /wearables-series-\$\{days\}d/.test(labContextSrc));
+
+  const syncMod = await import('../js/sync.js');
+  assert('isMessengerEnabled returns true after enabling',
+    syncMod.isMessengerEnabled() === true);
+  assert('getMessengerToken returns the test token',
+    syncMod.getMessengerToken() === 'test-mock-token-12345');
+  assert('window.pushContextToGateway exposed (toggle handler can fire it)',
+    typeof window.pushContextToGateway === 'function');
+} finally {
+  localStorage.removeItem('labcharts-messenger-enabled');
+  localStorage.removeItem('labcharts-messenger-token');
+}
+
+// ═══════════════════════════════════════
+// 8. stripWearableCredentials — token leak prevention
+// ═══════════════════════════════════════
+console.log('8. stripWearableCredentials');
+const TEST_PROFILE_2 = 'strip-creds-test-' + Date.now().toString(36);
+const sentinelToken = 'SENTINEL-TOKEN-' + Math.random().toString(36).slice(2);
+const sentinelRefresh = 'SENTINEL-REFRESH-' + Math.random().toString(36).slice(2);
+window._labState.importedData = {
+  entries: [],
+  wearableConnections: {
+    oura: {
+      accessToken: sentinelToken,
+      refreshToken: sentinelRefresh,
+      expiresAt: Date.now() + 86400000,
+      connectedAt: new Date().toISOString(),
+    },
+  },
+  wearableSummary: {
+    summaryUpdatedAt: new Date().toISOString(),
+    sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 }},
+    metrics: { hrv_rmssd: { primarySource: 'oura', latest: 38, baseline: 36, baselineP25: 32, baselineP75: 40, rolling: { d7: 37, d30: 36, d90: 36 }, trend30d: 'flat', weekly: [36, 37, 38] }},
+  },
+  changeHistory: [],
+};
+const origFetch = window.fetch;
+window.fetch = (input, init) => {
+  return origFetch.call(window, input, init);
+};
+try {
+  const labCtx = await import('../js/lab-context.js');
+  const ctx = labCtx.buildLabContext({ skipGroupFilter: true });
+  assert('buildLabContext output does NOT contain accessToken sentinel',
+    !ctx.includes(sentinelToken));
+  assert('buildLabContext output does NOT contain refreshToken sentinel',
+    !ctx.includes(sentinelRefresh));
+  const exportSrc = await fetch('/js/export.js').then(r => r.text());
+  assert('exportClientJSON shape does NOT include wearableConnections (token-bearing field)',
+    !/wearableConnections:\s*data\.wearableConnections/.test(exportSrc));
+} finally {
+  window.fetch = origFetch;
+}
+
+// ═══════════════════════════════════════
+// 9. wearableConnections preserve on Evolu pull
+// ═══════════════════════════════════════
+console.log('9. Pull-Side Token Preserve');
+const syncSrcContent = await fetch('/js/sync.js').then(r => r.text());
+assert('Sync pull preserves localWearableConnections by reading from disk first',
+  /localWearableConnections\s*=\s*state\.importedData\?\.wearableConnections/.test(syncSrcContent));
+assert('Sync pull writes localWearableConnections back into the merged importedData',
+  /importedData\.wearableConnections\s*=\s*localWearableConnections/.test(syncSrcContent));
+assert('Sync pull falls back to disk read when state.importedData is for a different profile',
+  /parsed\?\.wearableConnections/.test(syncSrcContent));
+
+// ─────────────────────────────────────────────────────────
+// Cleanup — restore live state.
+// ─────────────────────────────────────────────────────────
+await wipeWearableIDB();
+localStorage.removeItem(`labcharts-${TEST_PROFILE_ID}-imported`);
+if (origActiveProfile) localStorage.setItem('labcharts-active-profile', origActiveProfile);
+else localStorage.removeItem('labcharts-active-profile');
+window._labState.currentProfile = origCurrentProfile;
+window._labState.importedData = origState;
+try { const { deleteWearablesDB } = await import('../js/wearables-store.js'); await deleteWearablesDB(TEST_PROFILE_ID); } catch {}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-wearables-sync-flow.js
+++ b/tests/test-wearables-sync-flow.js
@@ -330,10 +330,11 @@ window._labState.importedData = {
   },
   changeHistory: [],
 };
+// buildLabContext + the export.js source read use whatever window.fetch is —
+// here that's the fs-backed shim (no /api/proxy routes installed). No wrapper
+// needed; the original test had a payload-capture wrapper that was never
+// asserted on, so it's just dropped.
 const origFetch = window.fetch;
-window.fetch = (input, init) => {
-  return origFetch.call(window, input, init);
-};
 try {
   const labCtx = await import('../js/lab-context.js');
   const ctx = labCtx.buildLabContext({ skipGroupFilter: true });


### PR DESCRIPTION
## Summary

Three **full ports** (no DOM split — all clean), unlocked by the `fake-indexeddb` shim wiring from batch 31. All three were `0 DOM markers` — plain IndexedDB + state + module imports.

| Test | asserts | Covers |
|------|---------|--------|
| **`test-blob-storage.js`** | 20 | IDB-backed k/v store, the localStorage→IDB migration path on first read of an `*-imported` key, `getBlobStorageSize`, non-blob keys staying in localStorage |
| **`test-wearables-manual.js`** | 101 | manual entry as a first-class wearable source: module exports, the `'manual'` adapter registry entry, `logManualMetric` / `logManualBP` IDB writes, `hasManualData`, `migrateBiometricsToManual` (idempotent + lb→kg), `deleteManualMetric`, context tags + notes, source-inspection sweep |
| **`test-wearables-sync-flow.js`** | 37 | orchestration end-to-end: `backfillWearable` / `incrementalSyncWearable` / `syncWearableSummary` / `disconnectWearable` driven against a mocked `/api/proxy` fetch, IDB side-effects, L2 recompute, last-sync meta, token-leak prevention |

## Notes

- **sync-flow's fetch mocking**: the test snapshots `realFetch = window.fetch` and falls through to it for non-`/api/proxy` URLs. The fs-backed fetch shim is installed *first* so that snapshot captures it — source-inspection `fetch('/js/X')` reads still resolve.
- **wearables-manual's window-export checks** rely on `wearables.js` registering its handlers on window — confirmed it loads cleanly in Node (batch 32).

## Test plan

- [x] `node tests/test-blob-storage.js` — **20/20** · `test-wearables-manual.js` — **101/101** · `test-wearables-sync-flow.js` — **37/37**
- [x] `npx vitest run tests/_vitest-legacy.test.js` — **79 tests / ~7.9s** (was 76 / ~5.3s — the IDB-heavy tests add load, still far under the original 53s)
- [x] `./run-tests.sh` — full suite green

## Numbers after this PR

- **Vitest**: 79 tests (was 76) — ~158 net asserts moved to the fast loop
- **Puppeteer originals remaining**: 21 (was 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)