### PR TITLE
Vitest batch 34: test-crypto + test-cashu-wallet (348 asserts)

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -13,7 +13,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const TEST_FILES = [
-  'tests/test-crypto.js',
   // test-chat-threads.js behavioral + source-inspection ported to Vitest
   // (batch 30). DOM sections (3/10/11) live in test-chat-threads-dom.js below.
   'tests/test-chat-threads-dom.js',
@@ -67,7 +66,6 @@ const TEST_FILES = [
   // click) lives in test-dashboard-data-protection-dom.js below.
   'tests/test-dashboard-data-protection-dom.js',
   'tests/test-chat-panel-ux.js',
-  'tests/test-cashu-wallet.js',
   // test-custom-api.js source-inspection + behavioral ported to Vitest
   // (batch 24). DOM-runtime sections (13/14 — Settings modal rendering,
   // Custom panel form fields, connected-state model dropdown) live in
@@ -80,7 +78,6 @@ const TEST_FILES = [
   'tests/test-export-import.js',
   'tests/test-ui-flows.js',
   'tests/test-lens-local-worker.js',
-  'tests/test-ai-verdict-engine.js',
   'tests/test-coverage-stragglers.js',
   'tests/test-silhouette-picker.js',
   'tests/test-silhouette-region-map.js',

--- a/run-tests.js
+++ b/run-tests.js
@@ -78,6 +78,12 @@ const TEST_FILES = [
   'tests/test-export-import.js',
   'tests/test-ui-flows.js',
   'tests/test-lens-local-worker.js',
+  // test-ai-verdict-engine.js stays on the puppeteer runner — the engine has
+  // process-global concurrency-slot + inflight state shared with the
+  // per-feature AI-verdict tests already in Vitest, which leaves its slots
+  // dirty in the legacy worker. See tests/_vitest-legacy.test.js for the
+  // full rationale.
+  'tests/test-ai-verdict-engine.js',
   'tests/test-coverage-stragglers.js',
   'tests/test-silhouette-picker.js',
   'tests/test-silhouette-region-map.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -176,6 +176,20 @@ const LEGACY_TESTS = [
   './test-blob-storage.js',
   './test-wearables-manual.js',
   './test-wearables-sync-flow.js',
+  // Batch 34 — full ports, no DOM: crypto (encryption/backup/cross-tab — IDB
+  // via fake-indexeddb, app module surface loaded for window-export checks),
+  // cashu-wallet (wallet + Nostr discovery + BIP-39 + SSRF wiring; cashu-ts
+  // IIFE loaded via indirect eval, bip39-minimal self-assigns).
+  //
+  // test-ai-verdict-engine.js deliberately stays on the puppeteer runner:
+  // the engine has process-global concurrency-slot + inflight state that the
+  // per-feature AI-verdict tests (test-sun-ai-analysis et al., already in
+  // Vitest) share. Ported in isolation it's 35/35 green, but in the legacy
+  // runner's shared worker the earlier tests leave the engine's global slots
+  // dirty → hangs. Puppeteer's real async timing releases them; Node's
+  // doesn't. Left puppeteer-side until the engine exposes a state reset.
+  './test-crypto.js',
+  './test-cashu-wallet.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-cashu-wallet.js
+++ b/tests/test-cashu-wallet.js
@@ -1,318 +1,335 @@
-// test-cashu-wallet.js — Verify Cashu wallet module, Nostr discovery, and integration points
-// Run: fetch('tests/test-cashu-wallet.js').then(r=>r.text()).then(s=>Function(s)())
+#!/usr/bin/env node
+// test-cashu-wallet.js — Cashu wallet module, Nostr discovery, integration
+// points. Module + window exports, wallet security/proof-management/recovery/
+// fee-mechanism source inspection, Nostr protocol + node parsing, API node-URL
+// guard, sync + export/import + service-worker wiring, BIP-39 seed generation,
+// and SSRF-validation wiring on setMintUrl / setSelectedNodeUrl.
+//
+// Run: node tests/test-cashu-wallet.js  (or via npm test)
+//
+// Full port — no DOM. vendor/cashu-ts.js is an IIFE that `var cashuts = …`
+// (module-scoped under import(), global under a browser <script>); indirect
+// eval replicates the script-tag global assignment. vendor/bip39-minimal.js
+// self-assigns to globalThis. Source-inspection reads via an fs-backed shim.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+import './_node-shim.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+function fetchWithRetry(rel) { return Promise.resolve(read(rel)); }
+
+const _realFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  if (typeof url === 'string' && !/^https?:/.test(url)) {
+    const rel = url.replace(/^\//, '');
+    try { return new Response(read(rel), { status: 200 }); }
+    catch (_) { return new Response('', { status: 404 }); }
   }
+  return _realFetch(url, opts);
+};
 
-  console.log('%c Cashu Wallet + Nostr Discovery Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const walletSrc = await fetchWithRetry('js/cashu-wallet.js');
-  const discoverySrc = await fetchWithRetry('js/nostr-discovery.js');
-  const apiSrc = await fetchWithRetry('js/api.js');
-  const ppSrc = await fetchWithRetry('js/provider-panels.js');
-  const syncSrc = await fetchWithRetry('js/sync.js');
-  const cryptoSrc = await fetchWithRetry('js/crypto.js');
-  const backupSrc = await fetchWithRetry('js/backup.js');
-  const exportSrc = await fetchWithRetry('js/export.js');
-  const swSrc = await fetchWithRetry('service-worker.js');
+console.log('=== Cashu Wallet + Nostr Discovery Tests ===\n');
 
-  // ═══════════════════════════════════════
-  // 1. CASHU WALLET — MODULE EXPORTS
-  // ═══════════════════════════════════════
-  console.log('%c 1. Cashu Wallet Module Exports ', 'font-weight:bold;color:#f59e0b');
+await import('../js/state.js');
+await import('../js/crypto.js');
+// vendor/cashu-ts.js is an IIFE-style bundle (`var cashuts = (…)()`). Under
+// ES-module import() the `var` is module-scoped and never reaches the global;
+// indirect eval runs it in global scope, exactly as a browser <script> does.
+(0, eval)(read('vendor/cashu-ts.js'));
+// bip39-minimal.js self-assigns to globalThis.bip39.
+await import('../vendor/bip39-minimal.js');
+await import('../js/cashu-wallet.js');
+await import('../js/nostr-discovery.js');
 
-  const walletExports = [
-    'getMintUrl', 'setMintUrl', 'generateWalletSeed', 'getWalletMnemonic',
-    'hasWalletSeed', 'restoreWalletFromSeed', 'getWalletBalance',
-    'createFundingInvoice', 'checkFundingStatus', 'receiveToken',
-    'depositToNode', 'recoverPendingDeposit', 'clearPendingDeposit',
-    'recoverPendingWithdraw', 'clearPendingWithdraw',
-    'createWithdrawQuote', 'executeWithdraw', 'withdrawToAddress',
-    'getMaxWithdrawable', 'sendAsToken', 'exportWallet', 'importWallet',
-    'clearWallet', 'destroyWalletDB', 'getFeePct',
-    'getFeeBalance', 'redeemFees', 'retryFeeAutoMelt'
-  ];
-  for (const fn of walletExports) {
-    assert(`cashu-wallet.js exports ${fn}`, walletSrc.includes(`export function ${fn}`) || walletSrc.includes(`export async function ${fn}`));
-  }
+const walletSrc = await fetchWithRetry('js/cashu-wallet.js');
+const discoverySrc = await fetchWithRetry('js/nostr-discovery.js');
+const apiSrc = await fetchWithRetry('js/api.js');
+const ppSrc = await fetchWithRetry('js/provider-panels.js');
+const syncSrc = await fetchWithRetry('js/sync.js');
+const cryptoSrc = await fetchWithRetry('js/crypto.js');
+const backupSrc = await fetchWithRetry('js/backup.js');
+const exportSrc = await fetchWithRetry('js/export.js');
+const swSrc = await fetchWithRetry('service-worker.js');
 
-  // ═══════════════════════════════════════
-  // 2. CASHU WALLET — WINDOW EXPORTS
-  // ═══════════════════════════════════════
-  console.log('%c 2. Cashu Wallet Window Exports ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 1. CASHU WALLET — MODULE EXPORTS
+// ═══════════════════════════════════════
+console.log('1. Cashu Wallet Module Exports');
 
-  const windowExports = [
-    'cashuGetBalance', 'cashuCreateFundingInvoice', 'cashuCheckFundingStatus',
-    'cashuReceiveToken', 'cashuDepositToNode', 'cashuExportWallet',
-    'cashuImportWallet', 'cashuClearWallet', 'cashuDestroyWalletDB',
-    'cashuRecoverPendingDeposit', 'cashuClearPendingDeposit',
-    'cashuRecoverPendingWithdraw', 'cashuClearPendingWithdraw',
-    'cashuSendAsToken', 'cashuCreateWithdrawQuote', 'cashuExecuteWithdraw',
-    'cashuWithdrawToAddress', 'cashuGetMaxWithdrawable',
-    'cashuRetryFeeAutoMelt', 'cashuGetFeeBalance', 'cashuRedeemFees',
-    'cashuGenerateWalletSeed', 'cashuGetWalletMnemonic', 'cashuHasWalletSeed',
-    'cashuRestoreWalletFromSeed', 'cashuGetMintUrl', 'cashuSetMintUrl',
-    'cashuGetFeePct'
-  ];
-  for (const fn of windowExports) {
-    assert(`window.${fn} exists`, typeof window[fn] === 'function');
-  }
+const walletExports = [
+  'getMintUrl', 'setMintUrl', 'generateWalletSeed', 'getWalletMnemonic',
+  'hasWalletSeed', 'restoreWalletFromSeed', 'getWalletBalance',
+  'createFundingInvoice', 'checkFundingStatus', 'receiveToken',
+  'depositToNode', 'recoverPendingDeposit', 'clearPendingDeposit',
+  'recoverPendingWithdraw', 'clearPendingWithdraw',
+  'createWithdrawQuote', 'executeWithdraw', 'withdrawToAddress',
+  'getMaxWithdrawable', 'sendAsToken', 'exportWallet', 'importWallet',
+  'clearWallet', 'destroyWalletDB', 'getFeePct',
+  'getFeeBalance', 'redeemFees', 'retryFeeAutoMelt'
+];
+for (const fn of walletExports) {
+  assert(`cashu-wallet.js exports ${fn}`, walletSrc.includes(`export function ${fn}`) || walletSrc.includes(`export async function ${fn}`));
+}
 
-  // ═══════════════════════════════════════
-  // 3. CASHU WALLET — SECURITY
-  // ═══════════════════════════════════════
-  console.log('%c 3. Wallet Security ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 2. CASHU WALLET — WINDOW EXPORTS
+// ═══════════════════════════════════════
+console.log('2. Cashu Wallet Window Exports');
 
-  assert('Mnemonic uses encrypted storage', walletSrc.includes('encryptedSetItem') && walletSrc.includes('encryptedGetItem'));
-  assert('Mnemonic key in SENSITIVE_PATTERNS', cryptoSrc.includes('labcharts-cashu-wallet-mnemonic'));
-  assert('Mnemonic in API_KEY_LS_KEYS cache', cryptoSrc.includes("'labcharts-cashu-wallet-mnemonic'"));
-  assert('Legacy plaintext mnemonic migration', walletSrc.includes("_setMeta('walletMnemonic', null)"));
-  assert('Wallet has global lock', walletSrc.includes('_withWalletLock'));
-  assert('Fee operations have separate lock', walletSrc.includes('_withFeeLock'));
-  assert('MAX_WALLET_BALANCE safety cap', walletSrc.includes('MAX_WALLET_BALANCE'));
+const windowExports = [
+  'cashuGetBalance', 'cashuCreateFundingInvoice', 'cashuCheckFundingStatus',
+  'cashuReceiveToken', 'cashuDepositToNode', 'cashuExportWallet',
+  'cashuImportWallet', 'cashuClearWallet', 'cashuDestroyWalletDB',
+  'cashuRecoverPendingDeposit', 'cashuClearPendingDeposit',
+  'cashuRecoverPendingWithdraw', 'cashuClearPendingWithdraw',
+  'cashuSendAsToken', 'cashuCreateWithdrawQuote', 'cashuExecuteWithdraw',
+  'cashuWithdrawToAddress', 'cashuGetMaxWithdrawable',
+  'cashuRetryFeeAutoMelt', 'cashuGetFeeBalance', 'cashuRedeemFees',
+  'cashuGenerateWalletSeed', 'cashuGetWalletMnemonic', 'cashuHasWalletSeed',
+  'cashuRestoreWalletFromSeed', 'cashuGetMintUrl', 'cashuSetMintUrl',
+  'cashuGetFeePct'
+];
+for (const fn of windowExports) {
+  assert(`window.${fn} exists`, typeof window[fn] === 'function');
+}
 
-  // ═══════════════════════════════════════
-  // 4. CASHU WALLET — PROOF MANAGEMENT
-  // ═══════════════════════════════════════
-  console.log('%c 4. Proof Management ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 3. CASHU WALLET — SECURITY
+// ═══════════════════════════════════════
+console.log('3. Wallet Security');
 
-  assert('Proofs stored in IndexedDB', walletSrc.includes("indexedDB.open("));
-  assert('Proofs tagged with _mint for namespacing', walletSrc.includes('_mint: mintUrl') || walletSrc.includes("_mint"));
-  assert('Legacy untagged proofs migrated', walletSrc.includes('_migrateUntaggedProofs'));
-  assert('Fee proofs stored separately', walletSrc.includes('STORE_FEES'));
-  assert('Fee proofs migrated from localStorage', walletSrc.includes("localStorage.getItem('cashu-fee-proofs')"));
-  assert('Counter source persisted for deterministic wallet', walletSrc.includes('counterSource') && walletSrc.includes("'counter:'"));
-  assert('Counter has per-keyset locking', walletSrc.includes('withLock(keysetId'));
+assert('Mnemonic uses encrypted storage', walletSrc.includes('encryptedSetItem') && walletSrc.includes('encryptedGetItem'));
+assert('Mnemonic key in SENSITIVE_PATTERNS', cryptoSrc.includes('labcharts-cashu-wallet-mnemonic'));
+assert('Mnemonic in API_KEY_LS_KEYS cache', cryptoSrc.includes("'labcharts-cashu-wallet-mnemonic'"));
+assert('Legacy plaintext mnemonic migration', walletSrc.includes("_setMeta('walletMnemonic', null)"));
+assert('Wallet has global lock', walletSrc.includes('_withWalletLock'));
+assert('Fee operations have separate lock', walletSrc.includes('_withFeeLock'));
+assert('MAX_WALLET_BALANCE safety cap', walletSrc.includes('MAX_WALLET_BALANCE'));
 
-  // ═══════════════════════════════════════
-  // 5. CASHU WALLET — DEPOSIT RECOVERY
-  // ═══════════════════════════════════════
-  console.log('%c 5. Deposit/Withdraw Recovery ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 4. CASHU WALLET — PROOF MANAGEMENT
+// ═══════════════════════════════════════
+console.log('4. Proof Management');
 
-  assert('Pending deposit saved BEFORE node call', walletSrc.includes("_setMeta('pendingDeposit', token)"));
-  assert('Pending deposit cleared after success', walletSrc.includes("_setMeta('pendingDeposit', null)"));
-  assert('Pending withdraw saved before melt', walletSrc.includes("_setMeta('pendingWithdraw',"));
-  assert('Pending withdraw cleared after success', walletSrc.includes("_setMeta('pendingWithdraw', null)"));
-  assert('Recovery UI shows for pending deposits', ppSrc.includes('Pending deposit recovery'));
-  assert('Recovery UI shows for pending withdrawals', ppSrc.includes('Pending withdraw recovery'));
+assert('Proofs stored in IndexedDB', walletSrc.includes('indexedDB.open('));
+assert('Proofs tagged with _mint for namespacing', walletSrc.includes('_mint: mintUrl') || walletSrc.includes('_mint'));
+assert('Legacy untagged proofs migrated', walletSrc.includes('_migrateUntaggedProofs'));
+assert('Fee proofs stored separately', walletSrc.includes('STORE_FEES'));
+assert('Fee proofs migrated from localStorage', walletSrc.includes("localStorage.getItem('cashu-fee-proofs')"));
+assert('Counter source persisted for deterministic wallet', walletSrc.includes('counterSource') && walletSrc.includes("'counter:'"));
+assert('Counter has per-keyset locking', walletSrc.includes('withLock(keysetId'));
 
-  // ═══════════════════════════════════════
-  // 6. CASHU WALLET — FEE MECHANISM
-  // ═══════════════════════════════════════
-  console.log('%c 6. Fee Mechanism ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 5. CASHU WALLET — DEPOSIT RECOVERY
+// ═══════════════════════════════════════
+console.log('5. Deposit/Withdraw Recovery');
 
-  assert('Fee percentage constant exists', walletSrc.includes('WALLET_FEE_PCT'));
-  assert('Fee collected on Lightning deposits', walletSrc.includes('Lightning deposit fee collected'));
-  assert('Fee minimum threshold for melt', walletSrc.includes('FEE_MELT_MIN_SATS'));
-  assert('Fee auto-melt is fire-and-forget', walletSrc.includes("}).catch(() => {}); // fire-and-forget"));
-  assert('Fee Lightning address configured', walletSrc.includes('FEE_LN_ADDRESS'));
-  assert('LNURL-pay resolution', walletSrc.includes('.well-known/lnurlp/'));
-  // Fee text gated on constant
-  assert('Fee text gated on cashuGetFeePct', ppSrc.includes('cashuGetFeePct'));
+assert('Pending deposit saved BEFORE node call', walletSrc.includes("_setMeta('pendingDeposit', token)"));
+assert('Pending deposit cleared after success', walletSrc.includes("_setMeta('pendingDeposit', null)"));
+assert('Pending withdraw saved before melt', walletSrc.includes("_setMeta('pendingWithdraw',"));
+assert('Pending withdraw cleared after success', walletSrc.includes("_setMeta('pendingWithdraw', null)"));
+assert('Recovery UI shows for pending deposits', ppSrc.includes('Pending deposit recovery'));
+assert('Recovery UI shows for pending withdrawals', ppSrc.includes('Pending withdraw recovery'));
 
-  // ═══════════════════════════════════════
-  // 7. NOSTR DISCOVERY — MODULE EXPORTS
-  // ═══════════════════════════════════════
-  console.log('%c 7. Nostr Discovery Module Exports ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 6. CASHU WALLET — FEE MECHANISM
+// ═══════════════════════════════════════
+console.log('6. Fee Mechanism');
 
-  const discoveryExports = ['discoverNodes', 'getSelectedNodeUrl', 'setSelectedNodeUrl', 'clearNodeCache'];
-  for (const fn of discoveryExports) {
-    assert(`nostr-discovery.js exports ${fn}`, discoverySrc.includes(`export function ${fn}`) || discoverySrc.includes(`export async function ${fn}`));
-  }
+assert('Fee percentage constant exists', walletSrc.includes('WALLET_FEE_PCT'));
+assert('Fee collected on Lightning deposits', walletSrc.includes('Lightning deposit fee collected'));
+assert('Fee minimum threshold for melt', walletSrc.includes('FEE_MELT_MIN_SATS'));
+assert('Fee auto-melt is fire-and-forget', walletSrc.includes('}).catch(() => {}); // fire-and-forget'));
+assert('Fee Lightning address configured', walletSrc.includes('FEE_LN_ADDRESS'));
+assert('LNURL-pay resolution', walletSrc.includes('.well-known/lnurlp/'));
+assert('Fee text gated on cashuGetFeePct', ppSrc.includes('cashuGetFeePct'));
 
-  const discoveryWindowExports = ['nostrDiscoverNodes', 'nostrGetSelectedNode', 'nostrSetSelectedNode', 'nostrClearNodeCache'];
-  for (const fn of discoveryWindowExports) {
-    assert(`window.${fn} exists`, typeof window[fn] === 'function');
-  }
+// ═══════════════════════════════════════
+// 7. NOSTR DISCOVERY — MODULE EXPORTS
+// ═══════════════════════════════════════
+console.log('7. Nostr Discovery Module Exports');
 
-  // ═══════════════════════════════════════
-  // 8. NOSTR DISCOVERY — PROTOCOL
-  // ═══════════════════════════════════════
-  console.log('%c 8. Nostr Protocol ', 'font-weight:bold;color:#f59e0b');
+const discoveryExports = ['discoverNodes', 'getSelectedNodeUrl', 'setSelectedNodeUrl', 'clearNodeCache'];
+for (const fn of discoveryExports) {
+  assert(`nostr-discovery.js exports ${fn}`, discoverySrc.includes(`export function ${fn}`) || discoverySrc.includes(`export async function ${fn}`));
+}
 
-  assert('Uses Kind 38421', discoverySrc.includes('38421'));
-  assert('Queries multiple relays', discoverySrc.includes('DEFAULT_RELAYS') && discoverySrc.includes('relay.damus.io'));
-  assert('Deduplicates by d tag', discoverySrc.includes('_deduplicateNodes'));
-  assert('Health checks /v1/models', discoverySrc.includes("/v1/models'"));
-  assert('Skips .onion URLs in health check', discoverySrc.includes('.onion'));
-  assert('Caches results with TTL', discoverySrc.includes('CACHE_TTL'));
-  assert('Sorts online first', discoverySrc.includes('a.online !== b.online'));
+const discoveryWindowExports = ['nostrDiscoverNodes', 'nostrGetSelectedNode', 'nostrSetSelectedNode', 'nostrClearNodeCache'];
+for (const fn of discoveryWindowExports) {
+  assert(`window.${fn} exists`, typeof window[fn] === 'function');
+}
 
-  // ═══════════════════════════════════════
-  // 9. NOSTR DISCOVERY — NODE PARSING
-  // ═══════════════════════════════════════
-  console.log('%c 9. Node Event Parsing ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 8. NOSTR DISCOVERY — PROTOCOL
+// ═══════════════════════════════════════
+console.log('8. Nostr Protocol');
 
-  assert('Parses u tags for URLs', discoverySrc.includes("t[0] === 'u'"));
-  assert('Parses mint tags', discoverySrc.includes("t[0] === 'mint'"));
-  assert('Parses d tag for ID', discoverySrc.includes("t[0] === 'd'"));
-  assert('Parses version tag', discoverySrc.includes("t[0] === 'version'"));
-  assert('Parses content JSON for name/about', discoverySrc.includes('content.name') && discoverySrc.includes('content.about'));
+assert('Uses Kind 38421', discoverySrc.includes('38421'));
+assert('Queries multiple relays', discoverySrc.includes('DEFAULT_RELAYS') && discoverySrc.includes('relay.damus.io'));
+assert('Deduplicates by d tag', discoverySrc.includes('_deduplicateNodes'));
+assert('Health checks /v1/models', discoverySrc.includes("/v1/models'"));
+assert('Skips .onion URLs in health check', discoverySrc.includes('.onion'));
+assert('Caches results with TTL', discoverySrc.includes('CACHE_TTL'));
+assert('Sorts online first', discoverySrc.includes('a.online !== b.online'));
 
-  // ═══════════════════════════════════════
-  // 10. API.JS — NODE URL GUARD
-  // ═══════════════════════════════════════
-  console.log('%c 10. API Node URL Guard ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 9. NOSTR DISCOVERY — NODE PARSING
+// ═══════════════════════════════════════
+console.log('9. Node Event Parsing');
 
-  assert('getRoutstrNodeUrl exported', apiSrc.includes('export function getRoutstrNodeUrl'));
-  assert('_requireNodeUrl guard exists', apiSrc.includes('function _requireNodeUrl'));
-  assert('_requireNodeUrl throws on empty', apiSrc.includes("'No Routstr node selected"));
-  assert('fetchRoutstrModels uses _requireNodeUrl', apiSrc.includes('const nodeUrl = _requireNodeUrl()'));
-  assert('callRoutstrAPI uses _requireNodeUrl', apiSrc.includes("const nodeUrl = _requireNodeUrl();\n  return callOpenAICompatibleAPI") || apiSrc.includes('_requireNodeUrl()'));
-  // Verify no remaining unguarded getRoutstrNodeUrl().replace patterns in API calls
-  const rawNodeUrlCalls = (apiSrc.match(/getRoutstrNodeUrl\(\)\.replace/g) || []).length;
-  assert('No unguarded getRoutstrNodeUrl().replace in API calls', rawNodeUrlCalls === 0, `found ${rawNodeUrlCalls} unguarded calls`);
+assert('Parses u tags for URLs', discoverySrc.includes("t[0] === 'u'"));
+assert('Parses mint tags', discoverySrc.includes("t[0] === 'mint'"));
+assert('Parses d tag for ID', discoverySrc.includes("t[0] === 'd'"));
+assert('Parses version tag', discoverySrc.includes("t[0] === 'version'"));
+assert('Parses content JSON for name/about', discoverySrc.includes('content.name') && discoverySrc.includes('content.about'));
 
-  // ═══════════════════════════════════════
-  // 11. SYNC INTEGRATION
-  // ═══════════════════════════════════════
-  console.log('%c 11. Sync Integration ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 10. API.JS — NODE URL GUARD
+// ═══════════════════════════════════════
+console.log('10. API Node URL Guard');
 
-  assert('Wallet mnemonic in AI_SETTINGS_KEYS', syncSrc.includes("'labcharts-cashu-wallet-mnemonic'"));
-  assert('Wallet mint in AI_SETTINGS_KEYS', syncSrc.includes("'labcharts-cashu-wallet-mint'"));
-  assert('Node URL in AI_SETTINGS_KEYS', syncSrc.includes("'labcharts-routstr-node'"));
-  assert('Mnemonic in ENCRYPTED_AI_KEYS', syncSrc.includes("'labcharts-cashu-wallet-mnemonic'"));
-  assert('Wallet keys in GLOBAL_SETTINGS_KEYS', backupSrc.includes("'labcharts-cashu-wallet-mint'") && backupSrc.includes("'labcharts-routstr-node'"));
+assert('getRoutstrNodeUrl exported', apiSrc.includes('export function getRoutstrNodeUrl'));
+assert('_requireNodeUrl guard exists', apiSrc.includes('function _requireNodeUrl'));
+assert('_requireNodeUrl throws on empty', apiSrc.includes("'No Routstr node selected"));
+assert('fetchRoutstrModels uses _requireNodeUrl', apiSrc.includes('const nodeUrl = _requireNodeUrl()'));
+assert('callRoutstrAPI uses _requireNodeUrl', apiSrc.includes("const nodeUrl = _requireNodeUrl();\n  return callOpenAICompatibleAPI") || apiSrc.includes('_requireNodeUrl()'));
+const rawNodeUrlCalls = (apiSrc.match(/getRoutstrNodeUrl\(\)\.replace/g) || []).length;
+assert('No unguarded getRoutstrNodeUrl().replace in API calls', rawNodeUrlCalls === 0, `found ${rawNodeUrlCalls} unguarded calls`);
 
-  // ═══════════════════════════════════════
-  // 12. EXPORT/IMPORT INTEGRATION
-  // ═══════════════════════════════════════
-  console.log('%c 12. Export/Import Integration ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 11. SYNC INTEGRATION
+// ═══════════════════════════════════════
+console.log('11. Sync Integration');
 
-  assert('Bundle includes wallet settings', exportSrc.includes('bundle.wallet'));
-  assert('Bundle restores mint URL', exportSrc.includes('wallet.mintUrl') && exportSrc.includes('cashuSetMintUrl'));
-  assert('Bundle restores node URL', exportSrc.includes('wallet.nodeUrl') && exportSrc.includes('nostrSetSelectedNode'));
-  assert('clearAllData destroys wallet DB', exportSrc.includes('cashuDestroyWalletDB'));
-  assert('clearAllData removes wallet localStorage keys', exportSrc.includes("'labcharts-cashu-wallet-mint'") && exportSrc.includes("'labcharts-cashu-wallet-mnemonic'") && exportSrc.includes("'labcharts-routstr-node'"));
+assert('Wallet mnemonic in AI_SETTINGS_KEYS', syncSrc.includes("'labcharts-cashu-wallet-mnemonic'"));
+assert('Wallet mint in AI_SETTINGS_KEYS', syncSrc.includes("'labcharts-cashu-wallet-mint'"));
+assert('Node URL in AI_SETTINGS_KEYS', syncSrc.includes("'labcharts-routstr-node'"));
+assert('Mnemonic in ENCRYPTED_AI_KEYS', syncSrc.includes("'labcharts-cashu-wallet-mnemonic'"));
+assert('Wallet keys in GLOBAL_SETTINGS_KEYS', backupSrc.includes("'labcharts-cashu-wallet-mint'") && backupSrc.includes("'labcharts-routstr-node'"));
 
-  // ═══════════════════════════════════════
-  // 13. SERVICE WORKER CACHE
-  // ═══════════════════════════════════════
-  console.log('%c 13. Service Worker Cache ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 12. EXPORT/IMPORT INTEGRATION
+// ═══════════════════════════════════════
+console.log('12. Export/Import Integration');
 
-  assert('SW caches cashu-wallet.js', swSrc.includes('/js/cashu-wallet.js'));
-  assert('SW caches nostr-discovery.js', swSrc.includes('/js/nostr-discovery.js'));
-  assert('SW caches vendor/cashu-ts.js', swSrc.includes('/vendor/cashu-ts.js'));
-  assert('SW caches vendor/bip39-minimal.js', swSrc.includes('/vendor/bip39-minimal.js'));
+assert('Bundle includes wallet settings', exportSrc.includes('bundle.wallet'));
+assert('Bundle restores mint URL', exportSrc.includes('wallet.mintUrl') && exportSrc.includes('cashuSetMintUrl'));
+assert('Bundle restores node URL', exportSrc.includes('wallet.nodeUrl') && exportSrc.includes('nostrSetSelectedNode'));
+assert('clearAllData destroys wallet DB', exportSrc.includes('cashuDestroyWalletDB'));
+assert('clearAllData removes wallet localStorage keys', exportSrc.includes("'labcharts-cashu-wallet-mint'") && exportSrc.includes("'labcharts-cashu-wallet-mnemonic'") && exportSrc.includes("'labcharts-routstr-node'"));
 
-  // ═══════════════════════════════════════
-  // 14. VENDOR LIBRARIES
-  // ═══════════════════════════════════════
-  console.log('%c 14. Vendor Libraries ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 13. SERVICE WORKER CACHE
+// ═══════════════════════════════════════
+console.log('13. Service Worker Cache');
 
-  assert('cashuts global available', typeof window.cashuts === 'object' || typeof window.cashuts === 'function');
-  assert('bip39 global available', typeof window.bip39 === 'object');
-  assert('bip39.generateMnemonic exists', typeof window.bip39?.generateMnemonic === 'function');
-  assert('bip39.validateMnemonic exists', typeof window.bip39?.validateMnemonic === 'function');
-  assert('bip39.mnemonicToSeed exists', typeof window.bip39?.mnemonicToSeed === 'function');
+assert('SW caches cashu-wallet.js', swSrc.includes('/js/cashu-wallet.js'));
+assert('SW caches nostr-discovery.js', swSrc.includes('/js/nostr-discovery.js'));
+assert('SW caches vendor/cashu-ts.js', swSrc.includes('/vendor/cashu-ts.js'));
+assert('SW caches vendor/bip39-minimal.js', swSrc.includes('/vendor/bip39-minimal.js'));
 
-  // ═══════════════════════════════════════
-  // 15. SETTINGS UI — WALLET PANEL
-  // ═══════════════════════════════════════
-  console.log('%c 15. Settings UI ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 14. VENDOR LIBRARIES
+// ═══════════════════════════════════════
+console.log('14. Vendor Libraries');
 
-  assert('Wallet section in Routstr panel', ppSrc.includes('routstr-wallet-balance'));
-  assert('Mint label display', ppSrc.includes('routstr-mint-label'));
-  assert('Mint edit UI', ppSrc.includes('showRoutstrMintEdit'));
-  assert('Node picker UI', ppSrc.includes('showRoutstrNodePicker'));
-  assert('Deposit amount picker', ppSrc.includes('routstr-deposit-amount'));
-  assert('Node withdraw handler', ppSrc.includes('doRoutstrNodeWithdraw'));
-  assert('Seed onboarding gate', ppSrc.includes('_ensureWalletSeed'));
-  assert('Seed acknowledgment checkbox', ppSrc.includes('routstr-seed-ack'));
-  assert('Wallet action buttons', ppSrc.includes('_walletActionButtons'));
-  assert('Wallet backup (export token)', ppSrc.includes('showRoutstrWalletBackup'));
-  assert('Lightning withdraw UI', ppSrc.includes('showRoutstrWithdrawLightning'));
-  assert('Cashu token withdraw UI', ppSrc.includes('showRoutstrWithdrawToken'));
+assert('cashuts global available', typeof window.cashuts === 'object' || typeof window.cashuts === 'function');
+assert('bip39 global available', typeof window.bip39 === 'object');
+assert('bip39.generateMnemonic exists', typeof window.bip39?.generateMnemonic === 'function');
+assert('bip39.validateMnemonic exists', typeof window.bip39?.validateMnemonic === 'function');
+assert('bip39.mnemonicToSeed exists', typeof window.bip39?.mnemonicToSeed === 'function');
 
-  // ═══════════════════════════════════════
-  // 16. BIP-39 SEED GENERATION
-  // ═══════════════════════════════════════
-  console.log('%c 16. BIP-39 Seed Generation ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 15. SETTINGS UI — WALLET PANEL
+// ═══════════════════════════════════════
+console.log('15. Settings UI');
 
-  const mnemonic = await window.bip39.generateMnemonic(128);
-  const words = mnemonic.split(' ');
-  assert('Generates 12 words', words.length === 12, `got ${words.length} words`);
-  assert('All words are valid BIP-39', words.every(w => w.length >= 3));
-  assert('Mnemonic validates', await window.bip39.validateMnemonic(mnemonic));
-  assert('Invalid mnemonic rejected', !(await window.bip39.validateMnemonic('not a valid mnemonic phrase at all here nope')));
-  assert('Seed derivation produces bytes', (await window.bip39.mnemonicToSeed(mnemonic)).byteLength === 64);
+assert('Wallet section in Routstr panel', ppSrc.includes('routstr-wallet-balance'));
+assert('Mint label display', ppSrc.includes('routstr-mint-label'));
+assert('Mint edit UI', ppSrc.includes('showRoutstrMintEdit'));
+assert('Node picker UI', ppSrc.includes('showRoutstrNodePicker'));
+assert('Deposit amount picker', ppSrc.includes('routstr-deposit-amount'));
+assert('Node withdraw handler', ppSrc.includes('doRoutstrNodeWithdraw'));
+assert('Seed onboarding gate', ppSrc.includes('_ensureWalletSeed'));
+assert('Seed acknowledgment checkbox', ppSrc.includes('routstr-seed-ack'));
+assert('Wallet action buttons', ppSrc.includes('_walletActionButtons'));
+assert('Wallet backup (export token)', ppSrc.includes('showRoutstrWalletBackup'));
+assert('Lightning withdraw UI', ppSrc.includes('showRoutstrWithdrawLightning'));
+assert('Cashu token withdraw UI', ppSrc.includes('showRoutstrWithdrawToken'));
 
-  // Two generations produce different mnemonics (entropy test)
-  const mnemonic2 = await window.bip39.generateMnemonic(128);
-  assert('Two generations differ', mnemonic !== mnemonic2);
+// ═══════════════════════════════════════
+// 16. BIP-39 SEED GENERATION
+// ═══════════════════════════════════════
+console.log('16. BIP-39 Seed Generation');
 
-  // ═══════════════════════════════════════
-  // 9. SSRF VALIDATION WIRING (cashu-wallet.setMintUrl + nostr.setSelectedNodeUrl)
-  // ═══════════════════════════════════════
-  // The shared validator (js/url-safety.js) is exhaustively unit-tested via
-  // test-sun-uvdata.js (14 SSRF asserts). This section verifies that the
-  // *wiring* at the two new call sites actually invokes it — text-grep alone
-  // would miss e.g. an accidental refactor that swallows the throw.
-  console.log('%c 9. SSRF Validation Wiring ', 'font-weight:bold;color:#f59e0b');
+const mnemonic = await window.bip39.generateMnemonic(128);
+const words = mnemonic.split(' ');
+assert('Generates 12 words', words.length === 12, `got ${words.length} words`);
+assert('All words are valid BIP-39', words.every(w => w.length >= 3));
+assert('Mnemonic validates', await window.bip39.validateMnemonic(mnemonic));
+assert('Invalid mnemonic rejected', !(await window.bip39.validateMnemonic('not a valid mnemonic phrase at all here nope')));
+assert('Seed derivation produces bytes', (await window.bip39.mnemonicToSeed(mnemonic)).byteLength === 64);
 
-  const wallet = await import('/js/cashu-wallet.js?bust=' + Date.now());
-  const discovery = await import('/js/nostr-discovery.js?bust=' + Date.now());
+const mnemonic2 = await window.bip39.generateMnemonic(128);
+assert('Two generations differ', mnemonic !== mnemonic2);
 
-  // setMintUrl — throws on rejection (so backup-restore + node-mint-switch
-  // paths fail-closed instead of silently pinning the wallet to a hostile mint)
-  async function expectMintRejection(url, label) {
-    let threw = false;
-    try { await wallet.setMintUrl(url); } catch (e) { threw = /https/i.test(e.message) || /loopback|RFC1918|link-local|public/i.test(e.message); }
-    assert(`setMintUrl rejects: ${label}`, threw, `url=${url}`);
-  }
-  await expectMintRejection('http://localhost/mint', 'localhost');
-  await expectMintRejection('http://127.0.0.1/mint', 'IPv4 loopback');
-  await expectMintRejection('https://192.168.1.1/mint', 'RFC1918 192.168.x.x');
-  await expectMintRejection('https://169.254.169.254/mint', 'cloud metadata');
-  await expectMintRejection('http://example.com/mint', 'non-HTTPS public host');
-  await expectMintRejection('not a url', 'unparseable');
-  // Regression: IPv4-mapped IPv6 with omitted leading zeros (Greptile P1
-  // PR #193). `::ffff:c0a8:101` is a valid abbreviation for 192.168.1.1
-  // but the earlier hex-concatenate-and-pad logic mis-aligned byte
-  // boundaries to 12.10.129.1, bypassing the RFC-1918 block.
-  await expectMintRejection('https://[::ffff:c0a8:101]/mint', 'IPv4-mapped IPv6 abbreviated → 192.168.1.1');
-  await expectMintRejection('https://[::ffff:c0a8:0101]/mint', 'IPv4-mapped IPv6 padded → 192.168.1.1');
-  await expectMintRejection('https://[::ffff:7f00:1]/mint',  'IPv4-mapped IPv6 abbreviated → 127.0.0.1');
-  await expectMintRejection('https://[::ffff:a9fe:a9fe]/mint', 'IPv4-mapped IPv6 → 169.254.169.254 (cloud metadata)');
-  // Greptile follow-up on PR #194: 10/8 + 172.16/12 also bypassable under
-  // the old `hex.padStart(8,'0')` logic. `::ffff:a00:1` produced
-  // `0.0.160.1` (not 10.0.0.1); `::ffff:ac10:1` produced `0.10.193.1`
-  // (not 172.16.0.1). Both ranges are RFC-1918; the fix handles them
-  // mathematically — these asserts pin the regression coverage explicit.
-  await expectMintRejection('https://[::ffff:a00:1]/mint',   'IPv4-mapped IPv6 abbreviated → 10.0.0.1 (RFC-1918 10/8)');
-  await expectMintRejection('https://[::ffff:ac10:1]/mint',  'IPv4-mapped IPv6 abbreviated → 172.16.0.1 (RFC-1918 172.16/12)');
+// ═══════════════════════════════════════
+// 17. SSRF VALIDATION WIRING (setMintUrl + setSelectedNodeUrl)
+// ═══════════════════════════════════════
+// The shared validator (js/url-safety.js) is exhaustively unit-tested via
+// test-sun-uvdata.js. This section verifies the *wiring* at the two new call
+// sites actually invokes it.
+console.log('17. SSRF Validation Wiring');
 
-  // setSelectedNodeUrl — silent no-op on rejection (Nostr/backup-restore
-  // paths route here unconditionally, throwing would surface as unhandled
-  // rejections at WS-message-handler scope which the user can't act on).
-  // We probe via getSelectedNodeUrl round-trip.
-  const origNode = discovery.getSelectedNodeUrl();
-  function expectNodeRejection(url, label) {
-    const sentinel = 'https://known-good-node.example.com/v1';
-    discovery.setSelectedNodeUrl(sentinel);
-    discovery.setSelectedNodeUrl(url); // should silently fail
-    assert(`setSelectedNodeUrl ignores: ${label}`,
-      discovery.getSelectedNodeUrl() === sentinel,
-      `expected sentinel preserved, got ${discovery.getSelectedNodeUrl()}`);
-  }
-  expectNodeRejection('http://127.0.0.1:8080', 'IPv4 loopback');
-  expectNodeRejection('https://10.0.0.5/api', 'RFC1918 10.x');
-  expectNodeRejection('http://[fe80::1]/api', 'IPv6 link-local');
-  expectNodeRejection('javascript:alert(1)', 'javascript: pseudo-URL');
-  // Round-trip a valid URL to confirm wiring isn't accidentally rejecting everything
-  discovery.setSelectedNodeUrl('https://valid-routstr.example.com');
-  assert('setSelectedNodeUrl accepts public HTTPS',
-    discovery.getSelectedNodeUrl() === 'https://valid-routstr.example.com');
-  // Restore prior state
-  if (origNode) discovery.setSelectedNodeUrl(origNode);
-  else localStorage.removeItem('labcharts-routstr-node');
+const wallet = await import('../js/cashu-wallet.js');
+const discovery = await import('../js/nostr-discovery.js');
 
-  // ═══════════════════════════════════════
-  // Results
-  // ═══════════════════════════════════════
-  console.log(`\n%c Results: ${pass} passed, ${fail} failed `, `background:${fail?'#ef4444':'#22c55e'};color:#fff;font-size:14px;padding:4px 12px;border-radius:4px`);
-})();
+async function expectMintRejection(url, label) {
+  let threw = false;
+  try { await wallet.setMintUrl(url); } catch (e) { threw = /https/i.test(e.message) || /loopback|RFC1918|link-local|public/i.test(e.message); }
+  assert(`setMintUrl rejects: ${label}`, threw, `url=${url}`);
+}
+await expectMintRejection('http://localhost/mint', 'localhost');
+await expectMintRejection('http://127.0.0.1/mint', 'IPv4 loopback');
+await expectMintRejection('https://192.168.1.1/mint', 'RFC1918 192.168.x.x');
+await expectMintRejection('https://169.254.169.254/mint', 'cloud metadata');
+await expectMintRejection('http://example.com/mint', 'non-HTTPS public host');
+await expectMintRejection('not a url', 'unparseable');
+await expectMintRejection('https://[::ffff:c0a8:101]/mint', 'IPv4-mapped IPv6 abbreviated → 192.168.1.1');
+await expectMintRejection('https://[::ffff:c0a8:0101]/mint', 'IPv4-mapped IPv6 padded → 192.168.1.1');
+await expectMintRejection('https://[::ffff:7f00:1]/mint', 'IPv4-mapped IPv6 abbreviated → 127.0.0.1');
+await expectMintRejection('https://[::ffff:a9fe:a9fe]/mint', 'IPv4-mapped IPv6 → 169.254.169.254 (cloud metadata)');
+await expectMintRejection('https://[::ffff:a00:1]/mint', 'IPv4-mapped IPv6 abbreviated → 10.0.0.1 (RFC-1918 10/8)');
+await expectMintRejection('https://[::ffff:ac10:1]/mint', 'IPv4-mapped IPv6 abbreviated → 172.16.0.1 (RFC-1918 172.16/12)');
+
+const origNode = discovery.getSelectedNodeUrl();
+function expectNodeRejection(url, label) {
+  const sentinel = 'https://known-good-node.example.com/v1';
+  discovery.setSelectedNodeUrl(sentinel);
+  discovery.setSelectedNodeUrl(url); // should silently fail
+  assert(`setSelectedNodeUrl ignores: ${label}`,
+    discovery.getSelectedNodeUrl() === sentinel,
+    `expected sentinel preserved, got ${discovery.getSelectedNodeUrl()}`);
+}
+expectNodeRejection('http://127.0.0.1:8080', 'IPv4 loopback');
+expectNodeRejection('https://10.0.0.5/api', 'RFC1918 10.x');
+expectNodeRejection('http://[fe80::1]/api', 'IPv6 link-local');
+expectNodeRejection('javascript:alert(1)', 'javascript: pseudo-URL');
+discovery.setSelectedNodeUrl('https://valid-routstr.example.com');
+assert('setSelectedNodeUrl accepts public HTTPS',
+  discovery.getSelectedNodeUrl() === 'https://valid-routstr.example.com');
+if (origNode) discovery.setSelectedNodeUrl(origNode);
+else localStorage.removeItem('labcharts-routstr-node');
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -564,18 +564,18 @@ try {
 console.log('27. buildBackupSnapshot');
 try {
   const snapshot = window.buildBackupSnapshot();
-  if (snapshot) {
-    assert('buildBackupSnapshot has format field', snapshot.format === 'labcharts-backup');
-    assert('buildBackupSnapshot has version field', snapshot.version === 1);
-    assert('buildBackupSnapshot has createdAt', typeof snapshot.createdAt === 'string');
-    assert('buildBackupSnapshot has profiles array', Array.isArray(snapshot.profiles));
-    assert('buildBackupSnapshot has settings object', typeof snapshot.settings === 'object');
-    if (snapshot.profiles.length > 0) {
-      const firstProfile = snapshot.profiles[0];
-      assert('buildBackupSnapshot profile has keys', typeof firstProfile.keys === 'object');
-    }
-  } else {
-    assert('buildBackupSnapshot returns object (no profiles)', true);
+  // The profile registry is seeded at test startup, so a falsy return
+  // means a runtime error, not an empty profile list — assert the object
+  // type directly rather than letting a falsy value pass silently.
+  assert('buildBackupSnapshot returns an object', snapshot != null && typeof snapshot === 'object');
+  assert('buildBackupSnapshot has format field', snapshot.format === 'labcharts-backup');
+  assert('buildBackupSnapshot has version field', snapshot.version === 1);
+  assert('buildBackupSnapshot has createdAt', typeof snapshot.createdAt === 'string');
+  assert('buildBackupSnapshot has profiles array', Array.isArray(snapshot.profiles));
+  assert('buildBackupSnapshot has settings object', typeof snapshot.settings === 'object');
+  if (snapshot.profiles.length > 0) {
+    const firstProfile = snapshot.profiles[0];
+    assert('buildBackupSnapshot profile has keys', typeof firstProfile.keys === 'object');
   }
 } catch (e) {
   assert('buildBackupSnapshot', false, e.message);

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -1,530 +1,585 @@
-// test-crypto.js — Browser-based verification for encryption, backup, and cross-tab sync
-// Run: fetch('tests/test-crypto.js').then(r=>r.text()).then(s=>Function(s)())
+#!/usr/bin/env node
+// test-crypto.js — encryption, backup, and cross-tab sync verification.
+// Module/window exports, sensitive-key detection, Web Crypto PBKDF2/AES-GCM
+// round-trip, the v1: ciphertext format, encryptedSetItem/GetItem routing,
+// BroadcastChannel no-self-notify, encryption-state rendering, the key cache,
+// the labcharts-backups IndexedDB, buildBackupSnapshot, plus a source sweep.
+//
+// Run: node tests/test-crypto.js  (or via npm test)
+//
+// Full port — the window-export checks need the app modules loaded (data.js,
+// profile.js, nav.js, views.js, export.js, settings.js, chat.js, utils.js,
+// backup.js — all confirmed to load cleanly in Node); IndexedDB runs via
+// fake-indexeddb; Web Crypto + BroadcastChannel are Node built-ins.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  const results = [];
-  function assert(name, condition, detail) {
-    if (condition) { pass++; results.push(`  PASS: ${name}`); }
-    else { fail++; results.push(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+import './_node-shim.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+function fetchWithRetry(rel) { return Promise.resolve(read(rel)); }
+
+// fs-backed fetch shim for the source-inspection sweep's `fetch('X')` reads.
+const _realFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  if (typeof url === 'string' && !/^https?:/.test(url)) {
+    const rel = url.replace(/^\//, '');
+    try { return new Response(read(rel), { status: 200 }); }
+    catch (_) { return new Response('', { status: 404 }); }
   }
+  return _realFetch(url, opts);
+};
 
-  console.log('%c[test-crypto] Starting crypto verification...', 'color:#6366f1;font-weight:bold');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  // ═══════════════════════════════════════════════
-  // 1. Module & window exports exist
-  // ═══════════════════════════════════════════════
-  assert('window.initEncryption exists', typeof window.initEncryption === 'function');
-  assert('window.initBroadcastChannel exists', typeof window.initBroadcastChannel === 'function');
-  assert('window.getEncryptionEnabled exists', typeof window.getEncryptionEnabled === 'function');
-  assert('window.isUnlocked exists', typeof window.isUnlocked === 'function');
-  assert('window.encryptedSetItem exists', typeof window.encryptedSetItem === 'function');
-  assert('window.encryptedGetItem exists', typeof window.encryptedGetItem === 'function');
-  assert('window.showEnableEncryptionModal exists', typeof window.showEnableEncryptionModal === 'function');
-  assert('window.disableEncryption exists', typeof window.disableEncryption === 'function');
-  assert('window.changePassphrase exists', typeof window.changePassphrase === 'function');
-  assert('window.exportEncryptedBackup exists', typeof window.exportEncryptedBackup === 'function');
-  assert('window.importEncryptedBackup exists', typeof window.importEncryptedBackup === 'function');
-  assert('window.broadcastDataChanged exists', typeof window.broadcastDataChanged === 'function');
-  assert('window.renderEncryptionSection exists', typeof window.renderEncryptionSection === 'function');
-  assert('window.renderBackupSection exists', typeof window.renderBackupSection === 'function');
-  assert('window.isSensitiveKey exists', typeof window.isSensitiveKey === 'function');
-  assert('window.getCachedKey exists', typeof window.getCachedKey === 'function');
-  assert('window.updateKeyCache exists', typeof window.updateKeyCache === 'function');
-  assert('window.decryptKeyCache exists', typeof window.decryptKeyCache === 'function');
-  assert('window.initProfilesCache exists', typeof window.initProfilesCache === 'function');
+console.log('=== Crypto / Encryption / Backup Tests ===\n');
 
-  // ═══════════════════════════════════════════════
-  // 2. Sensitive key detection
-  // ═══════════════════════════════════════════════
-  assert('labcharts-default-imported is sensitive', window.isSensitiveKey('labcharts-default-imported'));
-  assert('labcharts-abc123-imported is sensitive', window.isSensitiveKey('labcharts-abc123-imported'));
-  assert('labcharts-default-chat is sensitive', window.isSensitiveKey('labcharts-default-chat'));
-  assert('labcharts-profiles is sensitive', window.isSensitiveKey('labcharts-profiles'));
-  assert('labcharts-api-key IS sensitive', window.isSensitiveKey('labcharts-api-key'));
-  assert('labcharts-venice-key IS sensitive', window.isSensitiveKey('labcharts-venice-key'));
-  assert('labcharts-openrouter-key IS sensitive', window.isSensitiveKey('labcharts-openrouter-key'));
-  assert('labcharts-ollama IS sensitive', window.isSensitiveKey('labcharts-ollama'));
-  assert('labcharts-ai-provider is NOT sensitive', !window.isSensitiveKey('labcharts-ai-provider'));
-  assert('labcharts-default-units is NOT sensitive', !window.isSensitiveKey('labcharts-default-units'));
-  assert('labcharts-encryption-enabled is NOT sensitive', !window.isSensitiveKey('labcharts-encryption-enabled'));
-  assert('labcharts-time-format is NOT sensitive', !window.isSensitiveKey('labcharts-time-format'));
-  assert('labcharts-default-focusCard is NOT sensitive', !window.isSensitiveKey('labcharts-default-focusCard'));
+// Load the app module surface so the Object.assign(window, …) blocks run and
+// the window-export checks below resolve.
+await import('../js/state.js');
+await import('../js/crypto.js');
+await import('../js/pii.js');
+await import('../js/data.js');
+await import('../js/profile.js');
+await import('../js/nav.js');
+await import('../js/views.js');
+await import('../js/export.js');
+await import('../js/settings.js');
+await import('../js/chat.js');
+await import('../js/utils.js');
+await import('../js/backup.js');
 
-  // ═══════════════════════════════════════════════
-  // 3. Web Crypto API key derivation round-trip
-  // ═══════════════════════════════════════════════
+// Seed a minimal profile registry — the app bootstraps one via
+// initProfilesCache() on page load; in Node we seed it so the section-15
+// getProfiles() check has something to read.
+if (!localStorage.getItem('labcharts-profiles')) {
+  localStorage.setItem('labcharts-profiles', JSON.stringify([{ id: 'default', name: 'Test Profile' }]));
+}
+if (typeof window.initProfilesCache === 'function') await window.initProfilesCache();
+
+// ═══════════════════════════════════════════════
+// 1. Module & window exports exist
+// ═══════════════════════════════════════════════
+console.log('1. Module & window exports');
+assert('window.initEncryption exists', typeof window.initEncryption === 'function');
+assert('window.initBroadcastChannel exists', typeof window.initBroadcastChannel === 'function');
+assert('window.getEncryptionEnabled exists', typeof window.getEncryptionEnabled === 'function');
+assert('window.isUnlocked exists', typeof window.isUnlocked === 'function');
+assert('window.encryptedSetItem exists', typeof window.encryptedSetItem === 'function');
+assert('window.encryptedGetItem exists', typeof window.encryptedGetItem === 'function');
+assert('window.showEnableEncryptionModal exists', typeof window.showEnableEncryptionModal === 'function');
+assert('window.disableEncryption exists', typeof window.disableEncryption === 'function');
+assert('window.changePassphrase exists', typeof window.changePassphrase === 'function');
+assert('window.exportEncryptedBackup exists', typeof window.exportEncryptedBackup === 'function');
+assert('window.importEncryptedBackup exists', typeof window.importEncryptedBackup === 'function');
+assert('window.broadcastDataChanged exists', typeof window.broadcastDataChanged === 'function');
+assert('window.renderEncryptionSection exists', typeof window.renderEncryptionSection === 'function');
+assert('window.renderBackupSection exists', typeof window.renderBackupSection === 'function');
+assert('window.isSensitiveKey exists', typeof window.isSensitiveKey === 'function');
+assert('window.getCachedKey exists', typeof window.getCachedKey === 'function');
+assert('window.updateKeyCache exists', typeof window.updateKeyCache === 'function');
+assert('window.decryptKeyCache exists', typeof window.decryptKeyCache === 'function');
+assert('window.initProfilesCache exists', typeof window.initProfilesCache === 'function');
+
+// ═══════════════════════════════════════════════
+// 2. Sensitive key detection
+// ═══════════════════════════════════════════════
+console.log('2. Sensitive key detection');
+assert('labcharts-default-imported is sensitive', window.isSensitiveKey('labcharts-default-imported'));
+assert('labcharts-abc123-imported is sensitive', window.isSensitiveKey('labcharts-abc123-imported'));
+assert('labcharts-default-chat is sensitive', window.isSensitiveKey('labcharts-default-chat'));
+assert('labcharts-profiles is sensitive', window.isSensitiveKey('labcharts-profiles'));
+assert('labcharts-api-key IS sensitive', window.isSensitiveKey('labcharts-api-key'));
+assert('labcharts-venice-key IS sensitive', window.isSensitiveKey('labcharts-venice-key'));
+assert('labcharts-openrouter-key IS sensitive', window.isSensitiveKey('labcharts-openrouter-key'));
+assert('labcharts-ollama IS sensitive', window.isSensitiveKey('labcharts-ollama'));
+assert('labcharts-ai-provider is NOT sensitive', !window.isSensitiveKey('labcharts-ai-provider'));
+assert('labcharts-default-units is NOT sensitive', !window.isSensitiveKey('labcharts-default-units'));
+assert('labcharts-encryption-enabled is NOT sensitive', !window.isSensitiveKey('labcharts-encryption-enabled'));
+assert('labcharts-time-format is NOT sensitive', !window.isSensitiveKey('labcharts-time-format'));
+assert('labcharts-default-focusCard is NOT sensitive', !window.isSensitiveKey('labcharts-default-focusCard'));
+
+// ═══════════════════════════════════════════════
+// 3. Web Crypto API key derivation round-trip
+// ═══════════════════════════════════════════════
+console.log('3. Web Crypto round-trip');
+try {
+  const enc = new TextEncoder();
+  const dec = new TextDecoder();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const passphrase = 'test-passphrase-123';
+  const iterations = 600000;
+
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']
+  );
+  const key = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+  assert('Key derivation succeeds', key instanceof CryptoKey);
+
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = 'Hello, Get Based!';
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv }, key, enc.encode(plaintext)
+  );
+  assert('Encryption produces ArrayBuffer', ciphertext instanceof ArrayBuffer);
+  assert('Ciphertext differs from plaintext', new Uint8Array(ciphertext).length !== enc.encode(plaintext).length || new Uint8Array(ciphertext)[0] !== enc.encode(plaintext)[0]);
+
+  const decrypted = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv }, key, ciphertext
+  );
+  assert('Decryption round-trip succeeds', dec.decode(decrypted) === plaintext, `got: ${dec.decode(decrypted)}`);
+
+  const wrongKeyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode('wrong-passphrase'), 'PBKDF2', false, ['deriveKey']
+  );
+  const wrongKey = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    wrongKeyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
   try {
-    const enc = new TextEncoder();
-    const dec = new TextDecoder();
-    const salt = crypto.getRandomValues(new Uint8Array(16));
-    const passphrase = 'test-passphrase-123';
-    const iterations = 600000;
-
-    // Derive key
-    const keyMaterial = await crypto.subtle.importKey(
-      'raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']
-    );
-    const key = await crypto.subtle.deriveKey(
-      { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
-      keyMaterial,
-      { name: 'AES-GCM', length: 256 },
-      false,
-      ['encrypt', 'decrypt']
-    );
-    assert('Key derivation succeeds', key instanceof CryptoKey);
-
-    // Encrypt
-    const iv = crypto.getRandomValues(new Uint8Array(12));
-    const plaintext = 'Hello, Get Based!';
-    const ciphertext = await crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv }, key, enc.encode(plaintext)
-    );
-    assert('Encryption produces ArrayBuffer', ciphertext instanceof ArrayBuffer);
-    assert('Ciphertext differs from plaintext', new Uint8Array(ciphertext).length !== enc.encode(plaintext).length || new Uint8Array(ciphertext)[0] !== enc.encode(plaintext)[0]);
-
-    // Decrypt
-    const decrypted = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv }, key, ciphertext
-    );
-    assert('Decryption round-trip succeeds', dec.decode(decrypted) === plaintext, `got: ${dec.decode(decrypted)}`);
-
-    // Wrong passphrase should fail
-    const wrongKeyMaterial = await crypto.subtle.importKey(
-      'raw', enc.encode('wrong-passphrase'), 'PBKDF2', false, ['deriveKey']
-    );
-    const wrongKey = await crypto.subtle.deriveKey(
-      { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
-      wrongKeyMaterial,
-      { name: 'AES-GCM', length: 256 },
-      false,
-      ['encrypt', 'decrypt']
-    );
-    try {
-      await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, wrongKey, ciphertext);
-      assert('Wrong passphrase throws on decrypt', false, 'should have thrown');
-    } catch (e) {
-      assert('Wrong passphrase throws on decrypt', true);
-    }
+    await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, wrongKey, ciphertext);
+    assert('Wrong passphrase throws on decrypt', false, 'should have thrown');
   } catch (e) {
-    assert('Web Crypto round-trip', false, e.message);
+    assert('Wrong passphrase throws on decrypt', true);
   }
+} catch (e) {
+  assert('Web Crypto round-trip', false, e.message);
+}
 
-  // ═══════════════════════════════════════════════
-  // 4. v1: prefix format verification
-  // ═══════════════════════════════════════════════
+// ═══════════════════════════════════════════════
+// 4. v1: prefix format verification
+// ═══════════════════════════════════════════════
+console.log('4. v1: prefix format');
+try {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = crypto.getRandomValues(new Uint8Array(32));
+  const b64 = (arr) => btoa(String.fromCharCode(...arr));
+  const formatted = `v1:${b64(iv)}:${b64(ct)}`;
+  assert('v1: prefix format starts with v1:', formatted.startsWith('v1:'));
+  assert('v1: prefix format has 3 parts', formatted.split(':').length >= 3);
+  const parts = formatted.split(':');
+  assert('v1: prefix version is v1', parts[0] === 'v1');
+  const decodedIv = Uint8Array.from(atob(parts[1]), c => c.charCodeAt(0));
+  assert('v1: prefix IV round-trips', decodedIv.length === 12);
+} catch (e) {
+  assert('v1: prefix format', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 5. Non-sensitive keys stored as plaintext
+// ═══════════════════════════════════════════════
+console.log('5. Non-sensitive keys plaintext');
+try {
+  const testKey = 'labcharts-test-nonsensitive';
+  const testVal = 'plain-value-123';
+  await window.encryptedSetItem(testKey, testVal);
+  const stored = localStorage.getItem(testKey);
+  assert('Non-sensitive key stored as plaintext', stored === testVal, `got: ${stored}`);
+  assert('Non-sensitive key has no v1: prefix', !stored.startsWith('v1:'));
+  const retrieved = await window.encryptedGetItem(testKey);
+  assert('Non-sensitive key retrieved correctly', retrieved === testVal, `got: ${retrieved}`);
+  localStorage.removeItem(testKey);
+} catch (e) {
+  assert('Non-sensitive key plaintext storage', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 6. encryptedGetItem handles null
+// ═══════════════════════════════════════════════
+console.log('6. encryptedGetItem null handling');
+try {
+  const result = await window.encryptedGetItem('labcharts-nonexistent-key-xyz');
+  assert('encryptedGetItem returns null for missing key', result === null);
+} catch (e) {
+  assert('encryptedGetItem null handling', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 7. BroadcastChannel does not self-notify
+// ═══════════════════════════════════════════════
+console.log('7. BroadcastChannel no-self-notify');
+if (typeof BroadcastChannel !== 'undefined') {
   try {
-    // Simulate the v1 format manually
-    const iv = crypto.getRandomValues(new Uint8Array(12));
-    const ct = crypto.getRandomValues(new Uint8Array(32));
-    const b64 = (arr) => btoa(String.fromCharCode(...arr));
-    const formatted = `v1:${b64(iv)}:${b64(ct)}`;
-    assert('v1: prefix format starts with v1:', formatted.startsWith('v1:'));
-    assert('v1: prefix format has 3 parts', formatted.split(':').length >= 3);
-    const parts = formatted.split(':');
-    assert('v1: prefix version is v1', parts[0] === 'v1');
-    // Verify base64 IV decodes correctly
-    const decodedIv = Uint8Array.from(atob(parts[1]), c => c.charCodeAt(0));
-    assert('v1: prefix IV round-trips', decodedIv.length === 12);
+    let selfNotified = false;
+    const testBC = new BroadcastChannel('labcharts-test-bc');
+    testBC.onmessage = () => { selfNotified = true; };
+    testBC.postMessage({ test: true });
+    await new Promise(r => setTimeout(r, 100));
+    assert('BroadcastChannel does not self-notify', !selfNotified);
+    testBC.close();
   } catch (e) {
-    assert('v1: prefix format', false, e.message);
+    assert('BroadcastChannel test', false, e.message);
   }
+} else {
+  assert('BroadcastChannel API available', false, 'BroadcastChannel not supported');
+}
 
-  // ═══════════════════════════════════════════════
-  // 5. Non-sensitive keys stored as plaintext
-  // ═══════════════════════════════════════════════
-  try {
-    const testKey = 'labcharts-test-nonsensitive';
-    const testVal = 'plain-value-123';
-    await window.encryptedSetItem(testKey, testVal);
-    const stored = localStorage.getItem(testKey);
-    assert('Non-sensitive key stored as plaintext', stored === testVal, `got: ${stored}`);
-    assert('Non-sensitive key has no v1: prefix', !stored.startsWith('v1:'));
-    const retrieved = await window.encryptedGetItem(testKey);
-    assert('Non-sensitive key retrieved correctly', retrieved === testVal, `got: ${retrieved}`);
-    localStorage.removeItem(testKey);
-  } catch (e) {
-    assert('Non-sensitive key plaintext storage', false, e.message);
-  }
+// ═══════════════════════════════════════════════
+// 8. Service worker includes crypto.js
+// ═══════════════════════════════════════════════
+console.log('8. Service worker');
+try {
+  const swText = read('service-worker.js');
+  assert('Service worker contains /js/crypto.js', swText.includes('/js/crypto.js'));
+  assert('SW uses importScripts for version', swText.includes("importScripts('/version.js')"));
+  assert('SW CACHE_NAME uses semver', swText.includes('`labcharts-v${self.APP_VERSION}`'));
+} catch (e) {
+  assert('Service worker check', false, e.message);
+}
 
-  // ═══════════════════════════════════════════════
-  // 6. encryptedGetItem handles null
-  // ═══════════════════════════════════════════════
-  try {
-    const result = await window.encryptedGetItem('labcharts-nonexistent-key-xyz');
-    assert('encryptedGetItem returns null for missing key', result === null);
-  } catch (e) {
-    assert('encryptedGetItem null handling', false, e.message);
-  }
+// ═══════════════════════════════════════════════
+// 9. Settings modal shows Security section
+// ═══════════════════════════════════════════════
+console.log('9. Security section rendering');
+try {
+  const html = window.renderEncryptionSection();
+  assert('renderEncryptionSection returns HTML', typeof html === 'string' && html.length > 50);
+  assert('Encryption section has status card', html.includes('encryption-status-card'));
+  const backupHtml = window.renderBackupSection();
+  assert('renderBackupSection returns HTML', typeof backupHtml === 'string' && backupHtml.length > 50);
+  assert('Backup section has download button', backupHtml.includes('Download Backup'));
+  assert('Backup section has restore button', backupHtml.includes('Restore Backup'));
+} catch (e) {
+  assert('Settings section rendering', false, e.message);
+}
 
-  // ═══════════════════════════════════════════════
-  // 7. BroadcastChannel does not self-notify
-  // ═══════════════════════════════════════════════
-  if (typeof BroadcastChannel !== 'undefined') {
-    try {
-      let selfNotified = false;
-      const testBC = new BroadcastChannel('labcharts-test-bc');
-      testBC.onmessage = () => { selfNotified = true; };
-      testBC.postMessage({ test: true });
-      // BroadcastChannel should NOT fire to the same tab
-      await new Promise(r => setTimeout(r, 100));
-      assert('BroadcastChannel does not self-notify', !selfNotified);
-      testBC.close();
-    } catch (e) {
-      assert('BroadcastChannel test', false, e.message);
+// ═══════════════════════════════════════════════
+// 10. Encryption enabled state
+// ═══════════════════════════════════════════════
+console.log('10. Encryption enabled state');
+{
+  const wasEnabled = localStorage.getItem('labcharts-encryption-enabled');
+  localStorage.removeItem('labcharts-encryption-enabled');
+  assert('getEncryptionEnabled returns false when disabled', window.getEncryptionEnabled() === false);
+  localStorage.setItem('labcharts-encryption-enabled', 'true');
+  assert('getEncryptionEnabled returns true when enabled', window.getEncryptionEnabled() === true);
+  if (wasEnabled) localStorage.setItem('labcharts-encryption-enabled', wasEnabled);
+  else localStorage.removeItem('labcharts-encryption-enabled');
+}
+
+// ═══════════════════════════════════════════════
+// 11. Encryption section reflects state
+// ═══════════════════════════════════════════════
+console.log('11. Encryption section reflects state');
+{
+  const wasEnabled = localStorage.getItem('labcharts-encryption-enabled');
+  localStorage.removeItem('labcharts-encryption-enabled');
+  const offHtml = window.renderEncryptionSection();
+  assert('OFF state shows Enable button', offHtml.includes('Enable Encryption'));
+  assert('OFF state shows encryption-status-off', offHtml.includes('encryption-status-off'));
+
+  localStorage.setItem('labcharts-encryption-enabled', 'true');
+  const onHtml = window.renderEncryptionSection();
+  assert('ON state shows Change Passphrase', onHtml.includes('Change Passphrase'));
+  assert('ON state shows Disable Encryption', onHtml.includes('Disable Encryption'));
+  assert('ON state shows encryption-status-on', onHtml.includes('encryption-status-on'));
+  assert('ON state mentions API keys encrypted', onHtml.includes('API keys are encrypted'));
+
+  if (wasEnabled) localStorage.setItem('labcharts-encryption-enabled', wasEnabled);
+  else localStorage.removeItem('labcharts-encryption-enabled');
+}
+
+// ═══════════════════════════════════════════════
+// 11b. Key cache sync access
+// ═══════════════════════════════════════════════
+console.log('11b. Key cache sync access');
+{
+  const testKey = 'labcharts-test-cache-key';
+  localStorage.setItem(testKey, 'test-value');
+  assert('getCachedKey falls back to localStorage', window.getCachedKey(testKey) === 'test-value');
+  window.updateKeyCache(testKey, 'cached-value');
+  assert('getCachedKey returns cached value after updateKeyCache', window.getCachedKey(testKey) === 'cached-value');
+  window.updateKeyCache(testKey, null);
+  localStorage.removeItem(testKey);
+  assert('getCachedKey returns null after cleanup', window.getCachedKey(testKey) === null);
+}
+
+// ═══════════════════════════════════════════════
+// 12. All existing window exports still present (regression)
+// ═══════════════════════════════════════════════
+console.log('12. Window exports regression');
+const expectedExports = [
+  // data.js
+  'saveImportedData', 'getActiveData', 'filterDatesByRange', 'destroyAllCharts',
+  'detectTrendAlerts', 'switchUnitSystem', 'switchRangeMode', 'updateHeaderDates',
+  // profile.js
+  'getProfiles', 'saveProfiles', 'loadProfile', 'switchProfile', 'createProfile',
+  'deleteProfile', 'getProfileSex', 'setProfileSex', 'getProfileDob',
+  // nav.js
+  'buildSidebar', 'renderProfileDropdown',
+  // views.js
+  'navigate', 'showDashboard',
+  // export.js
+  'exportPDFReport', 'exportDataJSON', 'importDataJSON', 'clearAllData',
+  // settings.js
+  'openSettingsModal', 'closeSettingsModal',
+  // chat.js
+  'toggleChatPanel', 'closeChatPanel',
+  // utils.js
+  'showNotification', 'showConfirmDialog',
+];
+for (const name of expectedExports) {
+  assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
+}
+
+// ═══════════════════════════════════════════════
+// 13. CSS classes for passphrase modal exist
+// ═══════════════════════════════════════════════
+console.log('13. Passphrase modal CSS');
+try {
+  const cssText = read('styles.css');
+  assert('CSS has .passphrase-overlay', cssText.includes('.passphrase-overlay'));
+  assert('CSS has .passphrase-dialog', cssText.includes('.passphrase-dialog'));
+  assert('CSS has .passphrase-input', cssText.includes('.passphrase-input'));
+  assert('CSS has .passphrase-btn', cssText.includes('.passphrase-btn'));
+  assert('CSS has .passphrase-btn-primary', cssText.includes('.passphrase-btn-primary'));
+  assert('CSS has .encryption-status-card', cssText.includes('.encryption-status-card'));
+  assert('CSS has .encryption-status-on', cssText.includes('.encryption-status-on'));
+  assert('CSS has .encryption-status-off', cssText.includes('.encryption-status-off'));
+} catch (e) {
+  assert('CSS verification', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 14. crypto.js source inspection
+// ═══════════════════════════════════════════════
+console.log('14. crypto.js source inspection');
+try {
+  const src = await fetchWithRetry('js/crypto.js');
+  assert('crypto.js uses PBKDF2', src.includes('PBKDF2'));
+  assert('crypto.js uses AES-GCM', src.includes('AES-GCM'));
+  assert('crypto.js has 600000 iterations', src.includes('600000'));
+  assert('crypto.js uses 12-byte IV', src.includes('Uint8Array(12)'));
+  assert('crypto.js uses 16-byte salt', src.includes('Uint8Array(16)'));
+  assert('crypto.js has BroadcastChannel', src.includes('BroadcastChannel'));
+  assert('crypto.js has backup format', src.includes('labcharts-backup'));
+  assert('crypto.js has v1: prefix', src.includes("'v1:'") || src.includes('`v1:'));
+  assert('crypto.js never stores passphrase', !src.includes('localStorage') || (!src.includes('setItem') && !src.includes('passphrase')) || !src.match(/localStorage\.setItem\([^)]*passphrase/));
+  assert('Forgot passphrase does NOT use showConfirmDialog', !src.includes("forgotBtn.addEventListener('click', () => {\n    showConfirmDialog"));
+  assert('Forgot passphrase has inline confirm UI', src.includes('passphrase-forgot-confirm'));
+  assert('Forgot passphrase has Go Back button', src.includes('passphrase-forgot-cancel'));
+  const bkSrc0 = await fetchWithRetry('js/backup.js');
+  assert('Backup includes encryptionSalt field', bkSrc0.includes('encryptionSalt'));
+  assert('Restore sets labcharts-encryption-enabled', bkSrc0.includes("localStorage.setItem('labcharts-encryption-enabled'"));
+  assert('Restore sets labcharts-encryption-salt', bkSrc0.includes("localStorage.setItem('labcharts-encryption-salt'"));
+  assert('Backup includes labcharts-api-key', src.includes("'labcharts-api-key'") || bkSrc0.includes("'labcharts-api-key'"));
+  assert('Backup includes labcharts-venice-key', src.includes("'labcharts-venice-key'") || bkSrc0.includes("'labcharts-venice-key'"));
+  assert('Backup includes labcharts-ai-provider', bkSrc0.includes("'labcharts-ai-provider'"));
+  assert('Backup includes settings field', bkSrc0.includes('settings,') || bkSrc0.includes('settings:'));
+  assert('Restore writes global settings', bkSrc0.includes('backup.settings'));
+} catch (e) {
+  assert('crypto.js source inspection', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 15. Profiles cache (state.profiles)
+// ═══════════════════════════════════════════════
+console.log('15. Profiles cache');
+try {
+  const profiles = window.getProfiles();
+  assert('getProfiles returns array', Array.isArray(profiles));
+  assert('getProfiles has at least one profile', profiles.length >= 1);
+  assert('First profile has id', profiles[0] && typeof profiles[0].id === 'string');
+} catch (e) {
+  assert('Profiles cache', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 16. saveImportedData is async
+// ═══════════════════════════════════════════════
+console.log('16. saveImportedData async');
+try {
+  const src = await fetchWithRetry('js/data.js');
+  assert('saveImportedData is async', src.includes('async function saveImportedData'));
+  assert('saveImportedData calls broadcastDataChanged', src.includes('broadcastDataChanged'));
+  assert('saveImportedData calls encryptedSetItem', src.includes('encryptedSetItem'));
+} catch (e) {
+  assert('saveImportedData async check', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 17. Profile loadProfile is async
+// ═══════════════════════════════════════════════
+console.log('17. profile.js async');
+try {
+  const src = await fetchWithRetry('js/profile.js');
+  assert('loadProfile is async', src.includes('async function loadProfile'));
+  assert('saveProfiles is async', src.includes('async function saveProfiles'));
+  assert('initProfilesCache exists', src.includes('async function initProfilesCache'));
+  assert('loadProfile uses encryptedGetItem', src.includes('encryptedGetItem'));
+} catch (e) {
+  assert('profile.js async check', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 18. main.js async init
+// ═══════════════════════════════════════════════
+console.log('18. main.js async init');
+try {
+  const src = await fetchWithRetry('js/main.js');
+  assert('DOMContentLoaded is async', src.includes('async ()'));
+  assert('main.js awaits initEncryption', src.includes('await initEncryption()'));
+  assert('main.js calls initBroadcastChannel', src.includes('initBroadcastChannel()'));
+  assert('main.js awaits initProfilesCache', src.includes('await initProfilesCache()'));
+  assert('main.js awaits encryptedGetItem', src.includes('await encryptedGetItem'));
+  assert('main.js imports from crypto.js', src.includes("from './crypto.js'"));
+} catch (e) {
+  assert('main.js async check', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 19. Settings modal includes security + backup
+// ═══════════════════════════════════════════════
+console.log('19. settings.js security + backup');
+try {
+  const src = await fetchWithRetry('js/settings.js');
+  assert('settings.js imports renderEncryptionSection', src.includes('renderEncryptionSection'));
+  assert('settings.js imports renderBackupSection', src.includes('renderBackupSection'));
+  assert('settings.js has Security group', src.includes('Security'));
+  assert('settings.js has Backup group', src.includes('Backup'));
+  assert('settings.js has encryption-section id', src.includes('encryption-section'));
+  assert('settings.js has backup-section id', src.includes('backup-section'));
+} catch (e) {
+  assert('settings.js security check', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 20. Auto-backup window exports
+// ═══════════════════════════════════════════════
+console.log('20. Auto-backup window exports');
+assert('window.scheduleAutoBackup exists', typeof window.scheduleAutoBackup === 'function');
+assert('window.getAutoBackupSnapshots exists', typeof window.getAutoBackupSnapshots === 'function');
+assert('window.restoreAutoBackup exists', typeof window.restoreAutoBackup === 'function');
+assert('window.openBackupDB exists', typeof window.openBackupDB === 'function');
+assert('window.buildBackupSnapshot exists', typeof window.buildBackupSnapshot === 'function');
+assert('window.loadBackupSnapshots exists', typeof window.loadBackupSnapshots === 'function');
+
+// ═══════════════════════════════════════════════
+// 21. IndexedDB labcharts-backups can be opened
+// ═══════════════════════════════════════════════
+console.log('21. labcharts-backups IndexedDB');
+try {
+  const db = await window.openBackupDB();
+  assert('IndexedDB opens successfully', db instanceof IDBDatabase);
+  assert('IndexedDB has snapshots store', db.objectStoreNames.contains('snapshots'));
+} catch (e) {
+  assert('IndexedDB open', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 22. buildBackupSnapshot includes per-profile prefs
+// ═══════════════════════════════════════════════
+console.log('22. buildBackupSnapshot per-profile prefs');
+try {
+  const bkSrc = await fetchWithRetry('js/backup.js');
+  assert('backup.js has PER_PROFILE_PREF_SUFFIXES', bkSrc.includes('PER_PROFILE_PREF_SUFFIXES'));
+  assert('backup.js includes units in prefs', bkSrc.includes("'units'"));
+  assert('backup.js includes rangeMode in prefs', bkSrc.includes("'rangeMode'"));
+  assert('backup.js includes suppOverlay in prefs', bkSrc.includes("'suppOverlay'"));
+  assert('backup.js includes noteOverlay in prefs', bkSrc.includes("'noteOverlay'"));
+  assert('backup.js includes chatPersonality in prefs', bkSrc.includes("'chatPersonality'"));
+  assert('backup.js includes chatPersonalityCustom in prefs', bkSrc.includes("'chatPersonalityCustom'"));
+  assert('backup.js has openBackupDB function', bkSrc.includes('function openBackupDB'));
+  assert('backup.js has performAutoBackup function', bkSrc.includes('async function performAutoBackup'));
+  assert('backup.js has scheduleAutoBackup function', bkSrc.includes('function scheduleAutoBackup'));
+  assert('backup.js has getAutoBackupSnapshots function', bkSrc.includes('async function getAutoBackupSnapshots'));
+  assert('backup.js has restoreAutoBackup function', bkSrc.includes('async function restoreAutoBackup'));
+  assert('backup.js has MAX_SNAPSHOTS = 5', bkSrc.includes('MAX_SNAPSHOTS = 5'));
+  assert('backup.js has AUTO_BACKUP_COOLDOWN = 300000', bkSrc.includes('AUTO_BACKUP_COOLDOWN = 300000'));
+  const cryptoSrc = await fetchWithRetry('js/crypto.js');
+  assert('crypto.js has labcharts-last-autobackup', cryptoSrc.includes('labcharts-last-autobackup'));
+} catch (e) {
+  assert('buildBackupSnapshot prefs check', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 23. data.js calls scheduleAutoBackup
+// ═══════════════════════════════════════════════
+console.log('23. data.js auto-backup trigger');
+try {
+  const src = await fetchWithRetry('js/data.js');
+  assert('data.js imports scheduleAutoBackup', src.includes('scheduleAutoBackup'));
+  assert('data.js calls scheduleAutoBackup in saveImportedData', src.includes('scheduleAutoBackup()'));
+} catch (e) {
+  assert('data.js auto-backup trigger', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 24. Backup section UI shows auto-backup status
+// ═══════════════════════════════════════════════
+console.log('24. Backup section auto-backup UI');
+try {
+  const html = window.renderBackupSection();
+  assert('Backup section has auto-backup status', html.includes('backup-auto-status'));
+  assert('Backup section has snapshot list container', html.includes('backup-snapshot-list'));
+} catch (e) {
+  assert('Backup section auto-backup UI', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 25. CSS has auto-backup styles
+// ═══════════════════════════════════════════════
+console.log('25. Auto-backup CSS');
+try {
+  const cssText = read('styles.css');
+  assert('CSS has .backup-auto-status', cssText.includes('.backup-auto-status'));
+  assert('CSS has .backup-snapshot-list', cssText.includes('.backup-snapshot-list'));
+  assert('CSS has .backup-snapshot-item', cssText.includes('.backup-snapshot-item'));
+  assert('CSS has .backup-snapshot-date', cssText.includes('.backup-snapshot-date'));
+  assert('CSS has .backup-snapshot-meta', cssText.includes('.backup-snapshot-meta'));
+} catch (e) {
+  assert('CSS auto-backup styles', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 26. getAutoBackupSnapshots returns array
+// ═══════════════════════════════════════════════
+console.log('26. getAutoBackupSnapshots');
+try {
+  const snapshots = await window.getAutoBackupSnapshots();
+  assert('getAutoBackupSnapshots returns array', Array.isArray(snapshots));
+} catch (e) {
+  assert('getAutoBackupSnapshots', false, e.message);
+}
+
+// ═══════════════════════════════════════════════
+// 27. buildBackupSnapshot returns valid object
+// ═══════════════════════════════════════════════
+console.log('27. buildBackupSnapshot');
+try {
+  const snapshot = window.buildBackupSnapshot();
+  if (snapshot) {
+    assert('buildBackupSnapshot has format field', snapshot.format === 'labcharts-backup');
+    assert('buildBackupSnapshot has version field', snapshot.version === 1);
+    assert('buildBackupSnapshot has createdAt', typeof snapshot.createdAt === 'string');
+    assert('buildBackupSnapshot has profiles array', Array.isArray(snapshot.profiles));
+    assert('buildBackupSnapshot has settings object', typeof snapshot.settings === 'object');
+    if (snapshot.profiles.length > 0) {
+      const firstProfile = snapshot.profiles[0];
+      assert('buildBackupSnapshot profile has keys', typeof firstProfile.keys === 'object');
     }
   } else {
-    assert('BroadcastChannel API available', false, 'BroadcastChannel not supported in this browser');
+    assert('buildBackupSnapshot returns object (no profiles)', true);
   }
+} catch (e) {
+  assert('buildBackupSnapshot', false, e.message);
+}
 
-  // ═══════════════════════════════════════════════
-  // 8. Service worker includes crypto.js
-  // ═══════════════════════════════════════════════
-  try {
-    const swResponse = await fetch('service-worker.js');
-    const swText = await swResponse.text();
-    assert('Service worker contains /js/crypto.js', swText.includes('/js/crypto.js'));
-    assert('SW uses importScripts for version', swText.includes("importScripts('/version.js')"));
-    assert('SW CACHE_NAME uses semver', swText.includes('`labcharts-v${self.APP_VERSION}`'));
-  } catch (e) {
-    assert('Service worker check', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 9. Settings modal shows Security section
-  // ═══════════════════════════════════════════════
-  try {
-    const html = window.renderEncryptionSection();
-    assert('renderEncryptionSection returns HTML', typeof html === 'string' && html.length > 50);
-    assert('Encryption section has status card', html.includes('encryption-status-card'));
-    const backupHtml = window.renderBackupSection();
-    assert('renderBackupSection returns HTML', typeof backupHtml === 'string' && backupHtml.length > 50);
-    assert('Backup section has download button', backupHtml.includes('Download Backup'));
-    assert('Backup section has restore button', backupHtml.includes('Restore Backup'));
-  } catch (e) {
-    assert('Settings section rendering', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 10. Encryption enabled state
-  // ═══════════════════════════════════════════════
-  {
-    const wasEnabled = localStorage.getItem('labcharts-encryption-enabled');
-    // Test disabled state
-    localStorage.removeItem('labcharts-encryption-enabled');
-    assert('getEncryptionEnabled returns false when disabled', window.getEncryptionEnabled() === false);
-    // Test enabled state
-    localStorage.setItem('labcharts-encryption-enabled', 'true');
-    assert('getEncryptionEnabled returns true when enabled', window.getEncryptionEnabled() === true);
-    // Restore
-    if (wasEnabled) localStorage.setItem('labcharts-encryption-enabled', wasEnabled);
-    else localStorage.removeItem('labcharts-encryption-enabled');
-  }
-
-  // ═══════════════════════════════════════════════
-  // 11. Encryption section reflects state
-  // ═══════════════════════════════════════════════
-  {
-    const wasEnabled = localStorage.getItem('labcharts-encryption-enabled');
-    localStorage.removeItem('labcharts-encryption-enabled');
-    const offHtml = window.renderEncryptionSection();
-    assert('OFF state shows Enable button', offHtml.includes('Enable Encryption'));
-    assert('OFF state shows encryption-status-off', offHtml.includes('encryption-status-off'));
-
-    localStorage.setItem('labcharts-encryption-enabled', 'true');
-    const onHtml = window.renderEncryptionSection();
-    assert('ON state shows Change Passphrase', onHtml.includes('Change Passphrase'));
-    assert('ON state shows Disable Encryption', onHtml.includes('Disable Encryption'));
-    assert('ON state shows encryption-status-on', onHtml.includes('encryption-status-on'));
-    assert('ON state mentions API keys encrypted', onHtml.includes('API keys are encrypted'));
-
-    if (wasEnabled) localStorage.setItem('labcharts-encryption-enabled', wasEnabled);
-    else localStorage.removeItem('labcharts-encryption-enabled');
-  }
-
-  // ═══════════════════════════════════════════════
-  // 11b. Key cache sync access
-  // ═══════════════════════════════════════════════
-  {
-    // getCachedKey falls back to raw localStorage when cache not populated
-    const testKey = 'labcharts-test-cache-key';
-    localStorage.setItem(testKey, 'test-value');
-    assert('getCachedKey falls back to localStorage', window.getCachedKey(testKey) === 'test-value');
-    // updateKeyCache populates cache, getCachedKey returns it
-    window.updateKeyCache(testKey, 'cached-value');
-    assert('getCachedKey returns cached value after updateKeyCache', window.getCachedKey(testKey) === 'cached-value');
-    // Clean up
-    window.updateKeyCache(testKey, null);
-    localStorage.removeItem(testKey);
-    assert('getCachedKey returns null after cleanup', window.getCachedKey(testKey) === null);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 12. All existing window exports still present (regression)
-  // ═══════════════════════════════════════════════
-  const expectedExports = [
-    // data.js
-    'saveImportedData', 'getActiveData', 'filterDatesByRange', 'destroyAllCharts',
-    'detectTrendAlerts', 'switchUnitSystem', 'switchRangeMode', 'updateHeaderDates',
-    // profile.js
-    'getProfiles', 'saveProfiles', 'loadProfile', 'switchProfile', 'createProfile',
-    'deleteProfile', 'getProfileSex', 'setProfileSex', 'getProfileDob',
-    // nav.js
-    'buildSidebar', 'renderProfileDropdown',
-    // views.js
-    'navigate', 'showDashboard',
-    // export.js
-    'exportPDFReport', 'exportDataJSON', 'importDataJSON', 'clearAllData',
-    // settings.js
-    'openSettingsModal', 'closeSettingsModal',
-    // chat.js
-    'toggleChatPanel', 'closeChatPanel',
-    // utils.js
-    'showNotification', 'showConfirmDialog',
-  ];
-  for (const name of expectedExports) {
-    assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 13. CSS classes for passphrase modal exist
-  // ═══════════════════════════════════════════════
-  try {
-    const cssResponse = await fetch('styles.css');
-    const cssText = await cssResponse.text();
-    assert('CSS has .passphrase-overlay', cssText.includes('.passphrase-overlay'));
-    assert('CSS has .passphrase-dialog', cssText.includes('.passphrase-dialog'));
-    assert('CSS has .passphrase-input', cssText.includes('.passphrase-input'));
-    assert('CSS has .passphrase-btn', cssText.includes('.passphrase-btn'));
-    assert('CSS has .passphrase-btn-primary', cssText.includes('.passphrase-btn-primary'));
-    assert('CSS has .encryption-status-card', cssText.includes('.encryption-status-card'));
-    assert('CSS has .encryption-status-on', cssText.includes('.encryption-status-on'));
-    assert('CSS has .encryption-status-off', cssText.includes('.encryption-status-off'));
-  } catch (e) {
-    assert('CSS verification', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 14. crypto.js source inspection
-  // ═══════════════════════════════════════════════
-  try {
-    const src = await fetchWithRetry('js/crypto.js');
-    assert('crypto.js uses PBKDF2', src.includes('PBKDF2'));
-    assert('crypto.js uses AES-GCM', src.includes('AES-GCM'));
-    assert('crypto.js has 600000 iterations', src.includes('600000'));
-    assert('crypto.js uses 12-byte IV', src.includes('Uint8Array(12)'));
-    assert('crypto.js uses 16-byte salt', src.includes('Uint8Array(16)'));
-    assert('crypto.js has BroadcastChannel', src.includes('BroadcastChannel'));
-    assert('crypto.js has backup format', src.includes('labcharts-backup'));
-    assert('crypto.js has v1: prefix', src.includes("'v1:'") || src.includes('`v1:'));
-    assert('crypto.js never stores passphrase', !src.includes('localStorage') || (!src.includes('setItem') && !src.includes('passphrase')) || !src.match(/localStorage\.setItem\([^)]*passphrase/));
-    // Fix 1: forgot-passphrase uses inline confirm, not showConfirmDialog
-    assert('Forgot passphrase does NOT use showConfirmDialog', !src.includes("forgotBtn.addEventListener('click', () => {\n    showConfirmDialog"));
-    assert('Forgot passphrase has inline confirm UI', src.includes('passphrase-forgot-confirm'));
-    assert('Forgot passphrase has Go Back button', src.includes('passphrase-forgot-cancel'));
-    // Fix 2: backup includes encryption salt + global settings (now in backup.js)
-    const bkSrc0 = await fetchWithRetry('js/backup.js');
-    assert('Backup includes encryptionSalt field', bkSrc0.includes('encryptionSalt'));
-    assert('Restore sets labcharts-encryption-enabled', bkSrc0.includes("localStorage.setItem('labcharts-encryption-enabled'"));
-    assert('Restore sets labcharts-encryption-salt', bkSrc0.includes("localStorage.setItem('labcharts-encryption-salt'"));
-    // API keys in backup (now in backup.js)
-    assert('Backup includes labcharts-api-key', src.includes("'labcharts-api-key'") || bkSrc0.includes("'labcharts-api-key'"));
-    assert('Backup includes labcharts-venice-key', src.includes("'labcharts-venice-key'") || bkSrc0.includes("'labcharts-venice-key'"));
-    assert('Backup includes labcharts-ai-provider', bkSrc0.includes("'labcharts-ai-provider'"));
-    assert('Backup includes settings field', bkSrc0.includes('settings,') || bkSrc0.includes('settings:'));
-    assert('Restore writes global settings', bkSrc0.includes('backup.settings'));
-  } catch (e) {
-    assert('crypto.js source inspection', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 15. Profiles cache (state.profiles)
-  // ═══════════════════════════════════════════════
-  try {
-    const profiles = window.getProfiles();
-    assert('getProfiles returns array', Array.isArray(profiles));
-    assert('getProfiles has at least one profile', profiles.length >= 1);
-    assert('First profile has id', profiles[0] && typeof profiles[0].id === 'string');
-  } catch (e) {
-    assert('Profiles cache', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 16. saveImportedData is async
-  // ═══════════════════════════════════════════════
-  try {
-    const src = await fetchWithRetry('js/data.js');
-    assert('saveImportedData is async', src.includes('async function saveImportedData'));
-    assert('saveImportedData calls broadcastDataChanged', src.includes('broadcastDataChanged'));
-    assert('saveImportedData calls encryptedSetItem', src.includes('encryptedSetItem'));
-  } catch (e) {
-    assert('saveImportedData async check', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 17. Profile loadProfile is async
-  // ═══════════════════════════════════════════════
-  try {
-    const src = await fetchWithRetry('js/profile.js');
-    assert('loadProfile is async', src.includes('async function loadProfile'));
-    assert('saveProfiles is async', src.includes('async function saveProfiles'));
-    assert('initProfilesCache exists', src.includes('async function initProfilesCache'));
-    assert('loadProfile uses encryptedGetItem', src.includes('encryptedGetItem'));
-  } catch (e) {
-    assert('profile.js async check', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 18. main.js async init
-  // ═══════════════════════════════════════════════
-  try {
-    const src = await fetchWithRetry('js/main.js');
-    assert('DOMContentLoaded is async', src.includes('async ()'));
-    assert('main.js awaits initEncryption', src.includes('await initEncryption()'));
-    assert('main.js calls initBroadcastChannel', src.includes('initBroadcastChannel()'));
-    assert('main.js awaits initProfilesCache', src.includes('await initProfilesCache()'));
-    assert('main.js awaits encryptedGetItem', src.includes('await encryptedGetItem'));
-    assert('main.js imports from crypto.js', src.includes("from './crypto.js'"));
-  } catch (e) {
-    assert('main.js async check', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 19. Settings modal includes security + backup
-  // ═══════════════════════════════════════════════
-  try {
-    const src = await fetchWithRetry('js/settings.js');
-    assert('settings.js imports renderEncryptionSection', src.includes('renderEncryptionSection'));
-    assert('settings.js imports renderBackupSection', src.includes('renderBackupSection'));
-    assert('settings.js has Security group', src.includes('Security'));
-    assert('settings.js has Backup group', src.includes('Backup'));
-    assert('settings.js has encryption-section id', src.includes('encryption-section'));
-    assert('settings.js has backup-section id', src.includes('backup-section'));
-  } catch (e) {
-    assert('settings.js security check', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 20. Auto-backup window exports
-  // ═══════════════════════════════════════════════
-  assert('window.scheduleAutoBackup exists', typeof window.scheduleAutoBackup === 'function');
-  assert('window.getAutoBackupSnapshots exists', typeof window.getAutoBackupSnapshots === 'function');
-  assert('window.restoreAutoBackup exists', typeof window.restoreAutoBackup === 'function');
-  assert('window.openBackupDB exists', typeof window.openBackupDB === 'function');
-  assert('window.buildBackupSnapshot exists', typeof window.buildBackupSnapshot === 'function');
-  assert('window.loadBackupSnapshots exists', typeof window.loadBackupSnapshots === 'function');
-
-  // ═══════════════════════════════════════════════
-  // 21. IndexedDB labcharts-backups can be opened
-  // ═══════════════════════════════════════════════
-  try {
-    const db = await window.openBackupDB();
-    assert('IndexedDB opens successfully', db instanceof IDBDatabase);
-    assert('IndexedDB has snapshots store', db.objectStoreNames.contains('snapshots'));
-  } catch (e) {
-    assert('IndexedDB open', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 22. buildBackupSnapshot includes per-profile prefs
-  // ═══════════════════════════════════════════════
-  try {
-    const bkSrc = await fetchWithRetry('js/backup.js');
-    assert('backup.js has PER_PROFILE_PREF_SUFFIXES', bkSrc.includes('PER_PROFILE_PREF_SUFFIXES'));
-    assert('backup.js includes units in prefs', bkSrc.includes("'units'"));
-    assert('backup.js includes rangeMode in prefs', bkSrc.includes("'rangeMode'"));
-    assert('backup.js includes suppOverlay in prefs', bkSrc.includes("'suppOverlay'"));
-    assert('backup.js includes noteOverlay in prefs', bkSrc.includes("'noteOverlay'"));
-    assert('backup.js includes chatPersonality in prefs', bkSrc.includes("'chatPersonality'"));
-    assert('backup.js includes chatPersonalityCustom in prefs', bkSrc.includes("'chatPersonalityCustom'"));
-    assert('backup.js has openBackupDB function', bkSrc.includes('function openBackupDB'));
-    assert('backup.js has performAutoBackup function', bkSrc.includes('async function performAutoBackup'));
-    assert('backup.js has scheduleAutoBackup function', bkSrc.includes('function scheduleAutoBackup'));
-    assert('backup.js has getAutoBackupSnapshots function', bkSrc.includes('async function getAutoBackupSnapshots'));
-    assert('backup.js has restoreAutoBackup function', bkSrc.includes('async function restoreAutoBackup'));
-    assert('backup.js has MAX_SNAPSHOTS = 5', bkSrc.includes('MAX_SNAPSHOTS = 5'));
-    assert('backup.js has AUTO_BACKUP_COOLDOWN = 300000', bkSrc.includes('AUTO_BACKUP_COOLDOWN = 300000'));
-    const cryptoSrc = await fetchWithRetry('js/crypto.js');
-    assert('crypto.js has labcharts-last-autobackup', cryptoSrc.includes('labcharts-last-autobackup'));
-  } catch (e) {
-    assert('buildBackupSnapshot prefs check', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 23. data.js calls scheduleAutoBackup
-  // ═══════════════════════════════════════════════
-  try {
-    const src = await fetchWithRetry('js/data.js');
-    assert('data.js imports scheduleAutoBackup', src.includes('scheduleAutoBackup'));
-    assert('data.js calls scheduleAutoBackup in saveImportedData', src.includes('scheduleAutoBackup()'));
-  } catch (e) {
-    assert('data.js auto-backup trigger', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 24. Backup section UI shows auto-backup status
-  // ═══════════════════════════════════════════════
-  try {
-    const html = window.renderBackupSection();
-    assert('Backup section has auto-backup status', html.includes('backup-auto-status'));
-    assert('Backup section has snapshot list container', html.includes('backup-snapshot-list'));
-  } catch (e) {
-    assert('Backup section auto-backup UI', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 25. CSS has auto-backup styles
-  // ═══════════════════════════════════════════════
-  try {
-    const cssResponse = await fetch('styles.css');
-    const cssText = await cssResponse.text();
-    assert('CSS has .backup-auto-status', cssText.includes('.backup-auto-status'));
-    assert('CSS has .backup-snapshot-list', cssText.includes('.backup-snapshot-list'));
-    assert('CSS has .backup-snapshot-item', cssText.includes('.backup-snapshot-item'));
-    assert('CSS has .backup-snapshot-date', cssText.includes('.backup-snapshot-date'));
-    assert('CSS has .backup-snapshot-meta', cssText.includes('.backup-snapshot-meta'));
-  } catch (e) {
-    assert('CSS auto-backup styles', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 26. getAutoBackupSnapshots returns array
-  // ═══════════════════════════════════════════════
-  try {
-    const snapshots = await window.getAutoBackupSnapshots();
-    assert('getAutoBackupSnapshots returns array', Array.isArray(snapshots));
-  } catch (e) {
-    assert('getAutoBackupSnapshots', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // 27. buildBackupSnapshot returns valid object
-  // ═══════════════════════════════════════════════
-  try {
-    const snapshot = window.buildBackupSnapshot();
-    if (snapshot) {
-      assert('buildBackupSnapshot has format field', snapshot.format === 'labcharts-backup');
-      assert('buildBackupSnapshot has version field', snapshot.version === 1);
-      assert('buildBackupSnapshot has createdAt', typeof snapshot.createdAt === 'string');
-      assert('buildBackupSnapshot has profiles array', Array.isArray(snapshot.profiles));
-      assert('buildBackupSnapshot has settings object', typeof snapshot.settings === 'object');
-      // Check per-profile prefs are captured
-      if (snapshot.profiles.length > 0) {
-        const firstProfile = snapshot.profiles[0];
-        assert('buildBackupSnapshot profile has keys', typeof firstProfile.keys === 'object');
-      }
-    } else {
-      assert('buildBackupSnapshot returns object (no profiles)', true);
-    }
-  } catch (e) {
-    assert('buildBackupSnapshot', false, e.message);
-  }
-
-  // ═══════════════════════════════════════════════
-  // SUMMARY
-  // ═══════════════════════════════════════════════
-  console.log(results.join('\n'));
-  const color = fail === 0 ? '#22c55e' : '#ef4444';
-  console.log(`%c[test-crypto] ${pass} passed, ${fail} failed (${pass + fail} total)`, `color:${color};font-weight:bold`);
-  if (fail > 0) console.warn('[test-crypto] Some tests failed — check above for details');
-})();
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Two full ports off the puppeteer runner — no DOM split, both clean:

| Test | asserts | Covers |
|------|---------|--------|
| **`test-crypto.js`** | 185 | encryption/backup/cross-tab sync — module+window exports, sensitive-key detection, Web Crypto PBKDF2/AES-GCM round-trip, the `v1:` ciphertext format, `encryptedSetItem`/`GetItem` routing, BroadcastChannel no-self-notify, encryption-state rendering, key cache, the `labcharts-backups` IndexedDB, `buildBackupSnapshot`, source sweep |
| **`test-cashu-wallet.js`** | 163 | Cashu wallet + Nostr discovery — module+window exports, wallet security/proof/recovery/fee source inspection, Nostr protocol + node parsing, API node-URL guard, sync/export/SW wiring, BIP-39 seed generation, SSRF-validation wiring on `setMintUrl`/`setSelectedNodeUrl` |

## Notes

- **test-crypto** — the migration memo's old worry ("needs ~30 window-handler checks needing real DOM") is moot: views.js/settings.js/chat.js etc. all load cleanly in Node now, so the app-module surface is just imported to populate the window exports. Seeds a minimal `labcharts-profiles` registry for the `getProfiles()` check.
- **test-cashu-wallet** — `vendor/cashu-ts.js` is an IIFE (`var cashuts = …`, module-scoped under `import()`). Loaded via **indirect `eval`** to replicate the browser `<script>` global assignment; `vendor/bip39-minimal.js` self-assigns to `globalThis`.
- **test-ai-verdict-engine** was also ported (35/35 green **in isolation**) but **deliberately stays on puppeteer**: the engine has process-global concurrency-slot + inflight state shared with the per-feature AI-verdict tests (test-sun-ai-analysis et al., already in Vitest). In the legacy runner's shared worker those earlier tests leave the engine's global slots dirty → it hangs. Puppeteer's real async timing releases them; Node's doesn't. Left puppeteer-side with an inline note until the engine exposes a state reset.

## Test plan

- [x] `node tests/test-crypto.js` — **185/185** · `node tests/test-cashu-wallet.js` — **163/163** standalone
- [x] `npx vitest run tests/_vitest-legacy.test.js` — **81 tests / 6.2s** (was 79 / 7.9s)
- [x] `./run-tests.sh` — full suite green; test-ai-verdict-engine still passes on the puppeteer runner

## Numbers after this PR

- **Vitest**: 81 tests (was 79)
- **Puppeteer originals remaining**: 19 (was 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)