### PR TITLE
Vitest batch 35: DNA adapter tests + synchronous Worker shim

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -50,8 +50,10 @@ const TEST_FILES = [
   // test-emf.js fully ported to Vitest (batch 26) — pure-logic + module
   // imports, no DOM-runtime sections.
   'tests/test-emf-flow.js',
-  'tests/test-dna.js',
-  'tests/test-dna-illumina-and-valence.js',
+  // test-dna.js + test-dna-illumina-and-valence.js fully ported to Vitest
+  // (batch 35) — parseDNAFile's Blob-backed Worker runs via the synchronous
+  // Worker shim in _node-shim.js; renderGeneticsSection is a pure HTML-string
+  // builder.
   // test-wearables.js (~549 asserts) ported to Vitest (batch 32) — IDB CRUD
   // runs via fake-indexeddb. The openWearableDetail Chart.js modal islands +
   // JSZip script-injection smoke live in test-wearables-dom.js below.

--- a/tests/_node-shim.js
+++ b/tests/_node-shim.js
@@ -112,3 +112,42 @@ if (typeof globalThis.document === 'undefined') {
 if (typeof globalThis.indexedDB === 'undefined') {
   await import('fake-indexeddb/auto');
 }
+
+// Synchronous Worker shim — for self-contained pure-JS workers whose
+// source is passed as a Blob (e.g. the DNA parser worker in js/dna.js,
+// created via `new Worker(URL.createObjectURL(blob))`). Runs the worker
+// source in-process: `worker.postMessage` invokes the worker's
+// `self.onmessage` handler and routes its `self.postMessage` back to the
+// main-side `worker.onmessage`. Does NOT support importScripts, network,
+// or WASM workers — test-lens-local-worker.js stays on puppeteer.
+if (typeof globalThis.Worker === 'undefined') {
+  const _blobRegistry = new Map();
+  const _origCreateObjectURL = globalThis.URL.createObjectURL;
+  globalThis.URL.createObjectURL = (blob) => {
+    let url;
+    try { url = _origCreateObjectURL.call(globalThis.URL, blob); }
+    catch { url = `blob:nodeshim/${_blobRegistry.size}`; }
+    _blobRegistry.set(url, blob);
+    return url;
+  };
+  globalThis.Worker = class NodeWorker {
+    constructor(url) {
+      const blob = _blobRegistry.get(url);
+      this._self = {
+        postMessage: (data) => {
+          queueMicrotask(() => { if (this.onmessage) this.onmessage({ data }); });
+        },
+      };
+      this._ready = (async () => {
+        if (!blob) throw new Error(`NodeWorker: no Blob registered for ${url}`);
+        new Function('self', await blob.text())(this._self);
+      })();
+    }
+    postMessage(data) {
+      this._ready
+        .then(() => this._self.onmessage({ data }))
+        .catch((err) => { if (this.onerror) this.onerror({ message: err.message }); });
+    }
+    terminate() {}
+  };
+}

--- a/tests/_node-shim.js
+++ b/tests/_node-shim.js
@@ -145,7 +145,9 @@ if (typeof globalThis.Worker === 'undefined') {
     }
     postMessage(data) {
       this._ready
-        .then(() => this._self.onmessage({ data }))
+        // Match browser semantics — a worker that never assigns
+        // self.onmessage simply drops the message rather than throwing.
+        .then(() => { if (this._self.onmessage) this._self.onmessage({ data }); })
         .catch((err) => { if (this.onerror) this.onerror({ message: err.message }); });
     }
     terminate() {}

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -190,6 +190,12 @@ const LEGACY_TESTS = [
   // doesn't. Left puppeteer-side until the engine exposes a state reset.
   './test-crypto.js',
   './test-cashu-wallet.js',
+  // Batch 35 — DNA adapter + Illumina/valence. parseDNAFile spins a
+  // Blob-backed Worker; the synchronous Worker shim added to _node-shim.js
+  // (+ _vitest-setup.js) runs self-contained pure-JS workers in-process.
+  // renderGeneticsSection returns an HTML string with no DOM dependency.
+  './test-dna.js',
+  './test-dna-illumina-and-valence.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/_vitest-setup.js
+++ b/tests/_vitest-setup.js
@@ -153,6 +153,42 @@ if (typeof globalThis.indexedDB === 'undefined') {
   await import('fake-indexeddb/auto');
 }
 
+// Worker shim — kept in sync with _node-shim.js. Synchronous in-process
+// runner for self-contained pure-JS workers whose source is a Blob (the
+// DNA parser worker in js/dna.js). No importScripts/network/WASM support
+// — test-lens-local-worker.js stays on puppeteer.
+if (typeof globalThis.Worker === 'undefined') {
+  const _blobRegistry = new Map();
+  const _origCreateObjectURL = globalThis.URL.createObjectURL;
+  globalThis.URL.createObjectURL = (blob) => {
+    let url;
+    try { url = _origCreateObjectURL.call(globalThis.URL, blob); }
+    catch { url = `blob:nodeshim/${_blobRegistry.size}`; }
+    _blobRegistry.set(url, blob);
+    return url;
+  };
+  globalThis.Worker = class NodeWorker {
+    constructor(url) {
+      const blob = _blobRegistry.get(url);
+      this._self = {
+        postMessage: (data) => {
+          queueMicrotask(() => { if (this.onmessage) this.onmessage({ data }); });
+        },
+      };
+      this._ready = (async () => {
+        if (!blob) throw new Error(`NodeWorker: no Blob registered for ${url}`);
+        new Function('self', await blob.text())(this._self);
+      })();
+    }
+    postMessage(data) {
+      this._ready
+        .then(() => this._self.onmessage({ data }))
+        .catch((err) => { if (this.onerror) this.onerror({ message: err.message }); });
+    }
+    terminate() {}
+  };
+}
+
 // Per-test console.log capture for FAIL detection lives in
 // _vitest-legacy.test.js — scoped to the dynamic import call rather
 // than the global, so concurrent test workers don't trample each other.

--- a/tests/_vitest-setup.js
+++ b/tests/_vitest-setup.js
@@ -182,7 +182,9 @@ if (typeof globalThis.Worker === 'undefined') {
     }
     postMessage(data) {
       this._ready
-        .then(() => this._self.onmessage({ data }))
+        // Match browser semantics — a worker that never assigns
+        // self.onmessage simply drops the message rather than throwing.
+        .then(() => { if (this._self.onmessage) this._self.onmessage({ data }); })
         .catch((err) => { if (this.onerror) this.onerror({ message: err.message }); });
     }
     terminate() {}

--- a/tests/test-dna-illumina-and-valence.js
+++ b/tests/test-dna-illumina-and-valence.js
@@ -1,370 +1,398 @@
+#!/usr/bin/env node
 // test-dna-illumina-and-valence.js — covers everything shipped 2026-04-24:
 //   - Illumina GenomeStudio (DNAEra) format support + probe-name prefix strip
 //   - CETP TaqIB (rs708272) strand fix (forward-strand G/A keys)
 //   - Effect-label recalibration across MTHFR A1298C / MTR / VDR / FUT2 / ADIPOQ
 //   - 5 new SNPs across alcohol / caffeine / bodyComposition categories
 //   - Valence-aware dot rendering + legend block + catLabels coverage
-// Run: fetch('tests/test-dna-illumina-and-valence.js').then(r=>r.text()).then(s=>Function(s)())
+//
+// Run: node tests/test-dna-illumina-and-valence.js  (or via npm test)
+//
+// Full port — parseDNAFile spins a Blob-backed Worker (synchronous Worker
+// shim in _node-shim.js); renderGeneticsSection returns an HTML string with
+// no DOM dependency. snp-health.json + dna.js source go through the
+// fs-backed fetch shim; window._labState comes from state.js.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+import './_node-shim.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+
+// fs-backed fetch shim for the source-inspection + JSON reads.
+const _realFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  if (typeof url === 'string' && !/^https?:/.test(url)) {
+    try { return new Response(read(url), { status: 200 }); }
+    catch (_) { return new Response('', { status: 404 }); }
   }
+  return _realFetch(url, opts);
+};
 
-  console.log('%c DNA: Illumina + valence + recalibration ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const dna = await import('../js/dna.js');
-  const snpTable = await fetch('data/snp-health.json').then(r => r.json());
-  const dnaSrc = await fetch('js/dna.js').then(r => r.text());
+console.log('=== DNA: Illumina + valence + recalibration ===\n');
 
-  // ═══════════════════════════════════════
-  // 1. Illumina GSGT format detection
-  // ═══════════════════════════════════════
-  console.log('%c 1. Illumina Format Detection ', 'font-weight:bold;color:#f59e0b');
+// state.js sets window._labState; dna.js's Object.assign(window, …) runs on import.
+await import('../js/state.js');
+await import('../js/utils.js');
+await import('../js/data.js');
+const dna = await import('../js/dna.js');
+const snpTable = await fetch('data/snp-health.json').then(r => r.json());
+const dnaSrc = await fetch('js/dna.js').then(r => r.text());
 
-  const illuminaHeader = '﻿[Header]\nGSGT Version,2.0.5\nProcessing Date,8/14/2023 10:59 PM\nContent,,GSAMD-24v3-0-EA_20034606_A1.bpm\nNum SNPs,730059\n[Data]\nSample Name,SNP Name,Chr,Position,Allele1 - Plus,Allele2 - Plus\n';
-  assert('Detects Illumina GSGT (BOM + [Header])', dna.detectDNAFile(illuminaHeader) === 'illumina-gsgt');
-  assert('Detects Illumina GSGT without BOM', dna.detectDNAFile('[Header]\nGSGT Version,2.0.5\n[Data]\n') === 'illumina-gsgt');
-  assert('Does NOT match plain [Header] without GSGT', dna.detectDNAFile('[Header]\nSomething Else,1.0\n') === null);
-  assert('Does NOT trigger on Ancestry/23andMe', dna.detectDNAFile('#AncestryDNA raw data download\n') === 'ancestry');
+// ═══════════════════════════════════════
+// 1. Illumina GSGT format detection
+// ═══════════════════════════════════════
+console.log('1. Illumina Format Detection');
 
-  // Filename hint includes dnaera
-  assert('Filename "DNAEra-orig-XXX.csv" recognized', dna.isDNAFile({ name: 'DNAEra-orig-41220311706341.csv' }));
-  assert('Filename without dnaera/ancestry/etc not recognized', !dna.isDNAFile({ name: 'random-data.csv' }));
+const illuminaHeader = '﻿[Header]\nGSGT Version,2.0.5\nProcessing Date,8/14/2023 10:59 PM\nContent,,GSAMD-24v3-0-EA_20034606_A1.bpm\nNum SNPs,730059\n[Data]\nSample Name,SNP Name,Chr,Position,Allele1 - Plus,Allele2 - Plus\n';
+assert('Detects Illumina GSGT (BOM + [Header])', dna.detectDNAFile(illuminaHeader) === 'illumina-gsgt');
+assert('Detects Illumina GSGT without BOM', dna.detectDNAFile('[Header]\nGSGT Version,2.0.5\n[Data]\n') === 'illumina-gsgt');
+assert('Does NOT match plain [Header] without GSGT', dna.detectDNAFile('[Header]\nSomething Else,1.0\n') === null);
+assert('Does NOT trigger on Ancestry/23andMe', dna.detectDNAFile('#AncestryDNA raw data download\n') === 'ancestry');
 
-  // Regression guard: the worker's [Data]-block detection regex must use
-  // double-escaped brackets in the template literal (\\[Data\\]) so the
-  // worker source has a regex matching the literal string [Data]. A single
-  // escape would silently render `/^[Data]/i` (a character class matching
-  // D/a/t) — the parser would never advance past the [Header] block. This
-  // bit us once during development. The dna.js source must contain `\\[Data\\]`.
-  const dnaSrcForRegex = await fetch('js/dna.js').then(r => r.text());
-  assert('Worker [Data] regex uses double-escaped brackets',
-    dnaSrcForRegex.includes('/^\\\\[Data\\\\]/i'),
-    'should match `\\\\[Data\\\\]` in source so worker sees \\[Data\\]');
-  // Sanity: prove the rendered worker-source regex does match the literal "[Data]".
-  // /^\[Data\]/i matches "[Data]"; /^[Data]/i (the broken version) does NOT.
-  assert('Properly-escaped regex matches literal [Data]', /^\[Data\]/i.test('[Data]'));
-  assert('Single-escape would NOT match (proves the bug is real)', !/^[Data]/i.test('[Data]'));
+// Filename hint includes dnaera
+assert('Filename "DNAEra-orig-XXX.csv" recognized', dna.isDNAFile({ name: 'DNAEra-orig-41220311706341.csv' }));
+assert('Filename without dnaera/ancestry/etc not recognized', !dna.isDNAFile({ name: 'random-data.csv' }));
 
-  // ═══════════════════════════════════════
-  // 2. Illumina GSGT parser end-to-end
-  // ═══════════════════════════════════════
-  console.log('%c 2. Illumina GSGT Parser ', 'font-weight:bold;color:#f59e0b');
+// Regression guard: the worker's [Data]-block detection regex must use
+// double-escaped brackets in the template literal (\\[Data\\]) so the
+// worker source has a regex matching the literal string [Data]. A single
+// escape would silently render `/^[Data]/i` (a character class matching
+// D/a/t) — the parser would never advance past the [Header] block. This
+// bit us once during development. The dna.js source must contain `\\[Data\\]`.
+const dnaSrcForRegex = await fetch('js/dna.js').then(r => r.text());
+assert('Worker [Data] regex uses double-escaped brackets',
+  dnaSrcForRegex.includes('/^\\\\[Data\\\\]/i'),
+  'should match `\\\\[Data\\\\]` in source so worker sees \\[Data\\]');
+// Sanity: prove the rendered worker-source regex does match the literal "[Data]".
+// /^\[Data\]/i matches "[Data]"; /^[Data]/i (the broken version) does NOT.
+assert('Properly-escaped regex matches literal [Data]', /^\[Data\]/i.test('[Data]'));
+assert('Single-escape would NOT match (proves the bug is real)', !/^[Data]/i.test('[Data]'));
 
-  // Synthetic file mirroring real DNAEra structure: BOM + [Header] block,
-  // [Data] marker, column header, then 6-col rows. Mix bare rsids, prefixed
-  // probes, missing calls, and chip-internal IDs to test all parser branches.
-  const illuminaContent = '﻿[Header]\n' +
-    'GSGT Version,2.0.5\n' +
-    'Processing Date,8/14/2023 10:59 PM\n' +
-    'Content,,GSAMD-24v3-0-EA.bpm\n' +
-    'Num SNPs,8\n' +
-    '[Data]\n' +
-    'Sample Name,SNP Name,Chr,Position,Allele1 - Plus,Allele2 - Plus\n' +
-    'sample1,rs1801133,1,11856378,A,A\n' +              // bare rsid, MTHFR C677T
-    'sample1,seq-rs1815739,11,66328095,T,C\n' +          // wrapped: seq- prefix
-    'sample1,GSA-rs1800562,6,26093141,G,G\n' +           // wrapped: GSA- prefix
-    'sample1,ilmnseq_rs7412_ilmnTOP_5AT,19,45412079,T,C\n' + // wrapped: ilmnseq_ + suffix
-    'sample1,BOT-rs429358,19,45411941,T,T\n' +           // wrapped: BOT- prefix
-    'sample1,rs9999999,1,100,-,-\n' +                    // missing-call row (filtered)
-    'sample1,1:103380393,1,103380393,G,G\n' +            // chip-internal ID (no rs, filtered)
-    'sample1,seq-rs2228570,12,48272895,A,A\n' +          // wrapped VDR FokI (recovers a real SNP)
-    'sample1,seq-rs2228570.1,12,48272895,G,G\n' +        // duplicate probe — first-wins should keep AA
-    '';
-  const illuminaFile = new File([illuminaContent], 'DNAEra-test.csv', { type: 'text/csv' });
-  const iResult = await dna.parseDNAFile(illuminaFile);
+// ═══════════════════════════════════════
+// 2. Illumina GSGT parser end-to-end
+// ═══════════════════════════════════════
+console.log('2. Illumina GSGT Parser');
 
-  assert('Illumina: source detected', iResult.source === 'Illumina GenomeStudio (DNAEra)');
-  assert('Illumina: bare rs1801133 matched', iResult.matches.rs1801133 != null);
-  assert('Illumina: rs1801133 genotype is AA', iResult.matches.rs1801133?.genotype === 'AA');
-  assert('Illumina: seq-rs1815739 prefix stripped → match', iResult.matches.rs1815739 == null || iResult.matches.rs1815739?.genotype === 'TC');
-  // rs1815739 may not be in snp-health.json (we know it isn't) — test prefix strip via known rsid instead
-  assert('Illumina: GSA-rs1800562 prefix stripped → HFE matched', iResult.matches.rs1800562 != null);
-  assert('Illumina: GSA-rs1800562 genotype GG', iResult.matches.rs1800562?.genotype === 'GG');
-  assert('Illumina: ilmnseq_rs7412_* prefix+suffix stripped → match', iResult.matches.rs7412 != null);
-  assert('Illumina: ilmnseq rs7412 genotype TC', iResult.matches.rs7412?.genotype === 'TC');
-  assert('Illumina: BOT-rs429358 prefix stripped → match', iResult.matches.rs429358 != null);
-  assert('Illumina: seq-rs2228570 → VDR FokI matched (recovery test)', iResult.matches.rs2228570 != null);
-  assert('Illumina: first-wins kept AA (duplicate probe was GG)', iResult.matches.rs2228570?.genotype === 'AA');
-  assert('Illumina: missing-call row filtered (rs9999999 not present)', iResult.matches.rs9999999 == null);
-  assert('Illumina: chip-internal ID filtered (1:103380393 not in matches)', !Object.keys(iResult.matches).some(k => k.startsWith('1:')));
+// Synthetic file mirroring real DNAEra structure: BOM + [Header] block,
+// [Data] marker, column header, then 6-col rows. Mix bare rsids, prefixed
+// probes, missing calls, and chip-internal IDs to test all parser branches.
+const illuminaContent = '﻿[Header]\n' +
+  'GSGT Version,2.0.5\n' +
+  'Processing Date,8/14/2023 10:59 PM\n' +
+  'Content,,GSAMD-24v3-0-EA.bpm\n' +
+  'Num SNPs,8\n' +
+  '[Data]\n' +
+  'Sample Name,SNP Name,Chr,Position,Allele1 - Plus,Allele2 - Plus\n' +
+  'sample1,rs1801133,1,11856378,A,A\n' +              // bare rsid, MTHFR C677T
+  'sample1,seq-rs1815739,11,66328095,T,C\n' +          // wrapped: seq- prefix
+  'sample1,GSA-rs1800562,6,26093141,G,G\n' +           // wrapped: GSA- prefix
+  'sample1,ilmnseq_rs7412_ilmnTOP_5AT,19,45412079,T,C\n' + // wrapped: ilmnseq_ + suffix
+  'sample1,BOT-rs429358,19,45411941,T,T\n' +           // wrapped: BOT- prefix
+  'sample1,rs9999999,1,100,-,-\n' +                    // missing-call row (filtered)
+  'sample1,1:103380393,1,103380393,G,G\n' +            // chip-internal ID (no rs, filtered)
+  'sample1,seq-rs2228570,12,48272895,A,A\n' +          // wrapped VDR FokI (recovers a real SNP)
+  'sample1,seq-rs2228570.1,12,48272895,G,G\n' +        // duplicate probe — first-wins should keep AA
+  '';
+const illuminaFile = new File([illuminaContent], 'DNAEra-test.csv', { type: 'text/csv' });
+const iResult = await dna.parseDNAFile(illuminaFile);
 
-  // ═══════════════════════════════════════
-  // 3. CETP TaqIB strand fix (rs708272)
-  // ═══════════════════════════════════════
-  console.log('%c 3. CETP TaqIB Strand Fix ', 'font-weight:bold;color:#f59e0b');
+assert('Illumina: source detected', iResult.source === 'Illumina GenomeStudio (DNAEra)');
+assert('Illumina: bare rs1801133 matched', iResult.matches.rs1801133 != null);
+assert('Illumina: rs1801133 genotype is AA', iResult.matches.rs1801133?.genotype === 'AA');
+assert('Illumina: seq-rs1815739 prefix stripped → match', iResult.matches.rs1815739 == null || iResult.matches.rs1815739?.genotype === 'TC');
+// rs1815739 may not be in snp-health.json (we know it isn't) — test prefix strip via known rsid instead
+assert('Illumina: GSA-rs1800562 prefix stripped → HFE matched', iResult.matches.rs1800562 != null);
+assert('Illumina: GSA-rs1800562 genotype GG', iResult.matches.rs1800562?.genotype === 'GG');
+assert('Illumina: ilmnseq_rs7412_* prefix+suffix stripped → match', iResult.matches.rs7412 != null);
+assert('Illumina: ilmnseq rs7412 genotype TC', iResult.matches.rs7412?.genotype === 'TC');
+assert('Illumina: BOT-rs429358 prefix stripped → match', iResult.matches.rs429358 != null);
+assert('Illumina: seq-rs2228570 → VDR FokI matched (recovery test)', iResult.matches.rs2228570 != null);
+assert('Illumina: first-wins kept AA (duplicate probe was GG)', iResult.matches.rs2228570?.genotype === 'AA');
+assert('Illumina: missing-call row filtered (rs9999999 not present)', iResult.matches.rs9999999 == null);
+assert('Illumina: chip-internal ID filtered (1:103380393 not in matches)', !Object.keys(iResult.matches).some(k => k.startsWith('1:')));
 
-  const cetp = snpTable.rs708272;
-  assert('rs708272 exists in SNP table', cetp != null);
-  assert('rs708272 has GG key (forward strand)', cetp.genotypes.GG != null);
-  assert('rs708272 has GA key (forward strand)', cetp.genotypes.GA != null);
-  assert('rs708272 has AA key (forward strand)', cetp.genotypes.AA != null);
-  assert('rs708272 does NOT have old GT reverse-strand key', cetp.genotypes.GT == null);
-  assert('rs708272 does NOT have old TT reverse-strand key', cetp.genotypes.TT == null);
-  assert('rs708272 has strandNote acknowledging old G/T notation', /reverse strand|G\/T/i.test(cetp.strandNote || ''));
-  assert('rs708272 AA marked protective (B1B1 = lower MI risk)', cetp.genotypes.AA.valence === 'protective');
+// ═══════════════════════════════════════
+// 3. CETP TaqIB strand fix (rs708272)
+// ═══════════════════════════════════════
+console.log('3. CETP TaqIB Strand Fix');
 
-  // ═══════════════════════════════════════
-  // 4. Effect-label recalibration (Part B)
-  // ═══════════════════════════════════════
-  console.log('%c 4. Recalibration Findings ', 'font-weight:bold;color:#f59e0b');
+const cetp = snpTable.rs708272;
+assert('rs708272 exists in SNP table', cetp != null);
+assert('rs708272 has GG key (forward strand)', cetp.genotypes.GG != null);
+assert('rs708272 has GA key (forward strand)', cetp.genotypes.GA != null);
+assert('rs708272 has AA key (forward strand)', cetp.genotypes.AA != null);
+assert('rs708272 does NOT have old GT reverse-strand key', cetp.genotypes.GT == null);
+assert('rs708272 does NOT have old TT reverse-strand key', cetp.genotypes.TT == null);
+assert('rs708272 has strandNote acknowledging old G/T notation', /reverse strand|G\/T/i.test(cetp.strandNote || ''));
+assert('rs708272 AA marked protective (B1B1 = lower MI risk)', cetp.genotypes.AA.valence === 'protective');
 
-  assert('rs1801131 MTHFR A1298C TG recalibrated to mild', snpTable.rs1801131?.genotypes?.TG?.effect === 'mild');
-  assert('rs1801131 MTHFR A1298C GG recalibrated to mild', snpTable.rs1801131?.genotypes?.GG?.effect === 'mild');
-  assert('rs1805087 MTR A2756G AG recalibrated to mild', snpTable.rs1805087?.genotypes?.AG?.effect === 'mild');
-  assert('rs1805087 MTR GG kept at moderate', snpTable.rs1805087?.genotypes?.GG?.effect === 'moderate');
-  assert('rs2228570 VDR FokI AA recalibrated to mild', snpTable.rs2228570?.genotypes?.AA?.effect === 'mild');
-  assert('rs2241766 ADIPOQ TG recalibrated to mild', snpTable.rs2241766?.genotypes?.TG?.effect === 'mild');
-  assert('rs2241766 ADIPOQ GG recalibrated to mild', snpTable.rs2241766?.genotypes?.GG?.effect === 'mild');
+// ═══════════════════════════════════════
+// 4. Effect-label recalibration (Part B)
+// ═══════════════════════════════════════
+console.log('4. Recalibration Findings');
 
-  // FUT2 logic-bug fix: GG was wrongly "moderate" with a hint, should be "none"
-  assert('rs601338 FUT2 GG fixed to none (wild-type secretor)', snpTable.rs601338?.genotypes?.GG?.effect === 'none');
-  assert('rs601338 FUT2 GG has NO snpHint (wild-type shouldn\'t have one)', snpTable.rs601338?.snpHints?.GG == null);
-  assert('rs601338 FUT2 GA marked neutral (lab artifact)', snpTable.rs601338?.genotypes?.GA?.valence === 'neutral');
-  assert('rs601338 FUT2 AA marked neutral (lab artifact)', snpTable.rs601338?.genotypes?.AA?.valence === 'neutral');
+assert('rs1801131 MTHFR A1298C TG recalibrated to mild', snpTable.rs1801131?.genotypes?.TG?.effect === 'mild');
+assert('rs1801131 MTHFR A1298C GG recalibrated to mild', snpTable.rs1801131?.genotypes?.GG?.effect === 'mild');
+assert('rs1805087 MTR A2756G AG recalibrated to mild', snpTable.rs1805087?.genotypes?.AG?.effect === 'mild');
+assert('rs1805087 MTR GG kept at moderate', snpTable.rs1805087?.genotypes?.GG?.effect === 'moderate');
+assert('rs2228570 VDR FokI AA recalibrated to mild', snpTable.rs2228570?.genotypes?.AA?.effect === 'mild');
+assert('rs2241766 ADIPOQ TG recalibrated to mild', snpTable.rs2241766?.genotypes?.TG?.effect === 'mild');
+assert('rs2241766 ADIPOQ GG recalibrated to mild', snpTable.rs2241766?.genotypes?.GG?.effect === 'mild');
 
-  // ═══════════════════════════════════════
-  // 5. New SNPs (Part A — 5 additions)
-  // ═══════════════════════════════════════
-  console.log('%c 5. New SNPs (v1.22.0) ', 'font-weight:bold;color:#f59e0b');
+// FUT2 logic-bug fix: GG was wrongly "moderate" with a hint, should be "none"
+assert('rs601338 FUT2 GG fixed to none (wild-type secretor)', snpTable.rs601338?.genotypes?.GG?.effect === 'none');
+assert('rs601338 FUT2 GG has NO snpHint (wild-type shouldn\'t have one)', snpTable.rs601338?.snpHints?.GG == null);
+assert('rs601338 FUT2 GA marked neutral (lab artifact)', snpTable.rs601338?.genotypes?.GA?.valence === 'neutral');
+assert('rs601338 FUT2 AA marked neutral (lab artifact)', snpTable.rs601338?.genotypes?.AA?.valence === 'neutral');
 
-  const newSnps = {
-    rs671:       { gene: 'ALDH2',  category: 'alcohol',         keys: ['GG', 'GA', 'AA'] },
-    rs762551:    { gene: 'CYP1A2', category: 'caffeine',        keys: ['AA', 'AC', 'CC'] },
-    rs10830963:  { gene: 'MTNR1B', category: 'bloodSugar',      keys: ['CC', 'CG', 'GG'] },
-    rs9939609:   { gene: 'FTO',    category: 'bodyComposition', keys: ['TT', 'AT', 'AA'] },
-    rs5882:      { gene: 'CETP',   category: 'lipids',          keys: ['AA', 'AG', 'GG'] },
-  };
-  for (const [rsid, expected] of Object.entries(newSnps)) {
-    const entry = snpTable[rsid];
-    assert(`${rsid} exists in SNP table`, entry != null);
-    if (!entry) continue;
-    assert(`${rsid} gene = ${expected.gene}`, entry.gene === expected.gene);
-    assert(`${rsid} category = ${expected.category}`, entry.category === expected.category);
-    for (const k of expected.keys) {
-      assert(`${rsid} has forward-strand key "${k}"`, entry.genotypes?.[k] != null);
-    }
+// ═══════════════════════════════════════
+// 5. New SNPs (Part A — 5 additions)
+// ═══════════════════════════════════════
+console.log('5. New SNPs (v1.22.0)');
+
+const newSnps = {
+  rs671:       { gene: 'ALDH2',  category: 'alcohol',         keys: ['GG', 'GA', 'AA'] },
+  rs762551:    { gene: 'CYP1A2', category: 'caffeine',        keys: ['AA', 'AC', 'CC'] },
+  rs10830963:  { gene: 'MTNR1B', category: 'bloodSugar',      keys: ['CC', 'CG', 'GG'] },
+  rs9939609:   { gene: 'FTO',    category: 'bodyComposition', keys: ['TT', 'AT', 'AA'] },
+  rs5882:      { gene: 'CETP',   category: 'lipids',          keys: ['AA', 'AG', 'GG'] },
+};
+for (const [rsid, expected] of Object.entries(newSnps)) {
+  const entry = snpTable[rsid];
+  assert(`${rsid} exists in SNP table`, entry != null);
+  if (!entry) continue;
+  assert(`${rsid} gene = ${expected.gene}`, entry.gene === expected.gene);
+  assert(`${rsid} category = ${expected.category}`, entry.category === expected.category);
+  for (const k of expected.keys) {
+    assert(`${rsid} has forward-strand key "${k}"`, entry.genotypes?.[k] != null);
   }
+}
 
-  // ALDH2 strong effect on heterozygote (cancer risk)
-  assert('rs671 GA marked significant (dominant-negative tetramer)', snpTable.rs671?.genotypes?.GA?.effect === 'significant');
-  // FTO has no snpHints (no bodyFatPct slot in catalog, exercise not a supplement)
-  assert('rs9939609 FTO has no snpHints (no catalog slot)', snpTable.rs9939609?.snpHints == null);
+// ALDH2 strong effect on heterozygote (cancer risk)
+assert('rs671 GA marked significant (dominant-negative tetramer)', snpTable.rs671?.genotypes?.GA?.effect === 'significant');
+// FTO has no snpHints (no bodyFatPct slot in catalog, exercise not a supplement)
+assert('rs9939609 FTO has no snpHints (no catalog slot)', snpTable.rs9939609?.snpHints == null);
 
-  // ═══════════════════════════════════════
-  // 6. Valence field — protective + neutral marks
-  // ═══════════════════════════════════════
-  console.log('%c 6. Valence Field ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 6. Valence field — protective + neutral marks
+// ═══════════════════════════════════════
+console.log('6. Valence Field');
 
-  // Confirmed protective genotypes
-  const protective = [
-    ['rs11591147', 'GT', 'PCSK9 R46L'],
-    ['rs11591147', 'TT', 'PCSK9 R46L'],
-    ['rs5882',     'AG', 'CETP I405V'],
-    ['rs5882',     'GG', 'CETP I405V'],
-    ['rs708272',   'AA', 'CETP TaqIB B1B1'],
-    ['rs1800588',  'CT', 'LIPC -514T'],
-    ['rs1800588',  'TT', 'LIPC -514T'],
-    ['rs1801282',  'CG', 'PPARG Pro/Ala'],
-    ['rs1801282',  'GG', 'PPARG Ala/Ala'],
-  ];
-  for (const [rsid, gen, label] of protective) {
-    assert(`${label} (${rsid} ${gen}) marked valence:protective`, snpTable[rsid]?.genotypes?.[gen]?.valence === 'protective');
-  }
+// Confirmed protective genotypes
+const protective = [
+  ['rs11591147', 'GT', 'PCSK9 R46L'],
+  ['rs11591147', 'TT', 'PCSK9 R46L'],
+  ['rs5882',     'AG', 'CETP I405V'],
+  ['rs5882',     'GG', 'CETP I405V'],
+  ['rs708272',   'AA', 'CETP TaqIB B1B1'],
+  ['rs1800588',  'CT', 'LIPC -514T'],
+  ['rs1800588',  'TT', 'LIPC -514T'],
+  ['rs1801282',  'CG', 'PPARG Pro/Ala'],
+  ['rs1801282',  'GG', 'PPARG Ala/Ala'],
+];
+for (const [rsid, gen, label] of protective) {
+  assert(`${label} (${rsid} ${gen}) marked valence:protective`, snpTable[rsid]?.genotypes?.[gen]?.valence === 'protective');
+}
 
-  // Neutral (lab-artifact / informational)
-  assert('FUT2 GA marked valence:neutral', snpTable.rs601338?.genotypes?.GA?.valence === 'neutral');
-  assert('FUT2 AA marked valence:neutral', snpTable.rs601338?.genotypes?.AA?.valence === 'neutral');
+// Neutral (lab-artifact / informational)
+assert('FUT2 GA marked valence:neutral', snpTable.rs601338?.genotypes?.GA?.valence === 'neutral');
+assert('FUT2 AA marked valence:neutral', snpTable.rs601338?.genotypes?.AA?.valence === 'neutral');
 
-  // Risk genotypes have no explicit valence (implicit default = 'risk')
-  assert('MTHFR C677T AA has no valence field (defaults to risk)', snpTable.rs1801133?.genotypes?.AA?.valence == null);
-  assert('HFE C282Y AA has no valence field (defaults to risk)', snpTable.rs1800562?.genotypes?.AA?.valence == null);
+// Risk genotypes have no explicit valence (implicit default = 'risk')
+assert('MTHFR C677T AA has no valence field (defaults to risk)', snpTable.rs1801133?.genotypes?.AA?.valence == null);
+assert('HFE C282Y AA has no valence field (defaults to risk)', snpTable.rs1800562?.genotypes?.AA?.valence == null);
 
-  // ═══════════════════════════════════════
-  // 7. dotFor() icon mapping (via rendered HTML)
-  // ═══════════════════════════════════════
-  console.log('%c 7. Dot Rendering ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 7. dotFor() icon mapping (via rendered HTML)
+// ═══════════════════════════════════════
+console.log('7. Dot Rendering');
 
-  // dotFor is a local fn inside renderGeneticsSection — verify behavior by
-  // mocking genetics state for known genotypes and inspecting rendered HTML.
-  const origGenetics = window._labState.importedData.genetics;
+// dotFor is a local fn inside renderGeneticsSection — verify behavior by
+// mocking genetics state for known genotypes and inspecting rendered HTML.
+const origGenetics = window._labState.importedData.genetics;
 
-  function mockAndRender(snps) {
-    window._labState.importedData.genetics = {
-      source: 'TestSource', importDate: '2026-04-24',
-      coverage: { found: Object.keys(snps).length, total: Object.keys(snps).length },
-      effects: { significant: 0, moderate: 0, normal: 0 },
-      snps
-    };
-    return dna.renderGeneticsSection();
-  }
-
-  // Helper: extract just the finding-row HTML (excludes the legend, which always
-  // contains every dot character for explanatory purposes).
-  const findingRowDots = (html) => {
-    const rows = html.match(/<div class="genetics-finding-row[^"]*"[^>]*>[\s\S]*?<\/div>/g) || [];
-    return rows.join('').match(/[🔴🟡🟠🟢⚪]/g)?.join('') || '';
-  };
-
-  // Protective: PCSK9 GT → green dot in the finding row, no red dot in the row
-  let html = mockAndRender({ rs11591147: { genotype: 'GT', gene: 'PCSK9', variant: 'R46L' } });
-  assert('Protective finding row has green dot', findingRowDots(html).includes('🟢'));
-  assert('Protective finding row has NO red dot', !findingRowDots(html).includes('🔴'));
-
-  // Significant risk: MTHFR C677T AA → red dot
-  html = mockAndRender({ rs1801133: { genotype: 'AA', gene: 'MTHFR', variant: 'C677T' } });
-  assert('Significant risk renders red dot', html.includes('🔴'));
-
-  // Moderate risk: MTHFR A1298C GG... wait we recalibrated that to mild. Use HFE C282Y heterozygote → moderate
-  html = mockAndRender({ rs1800562: { genotype: 'GA', gene: 'HFE', variant: 'C282Y' } });
-  assert('Moderate risk renders yellow dot', html.includes('🟡'));
-
-  // Mild risk: MTR A2756G AG → orange dot (🟠 = D83D DFE0)
-  html = mockAndRender({ rs1805087: { genotype: 'AG', gene: 'MTR', variant: 'A2756G' } });
-  assert('Mild risk renders orange dot', html.includes('🟠'));
-
-  // Neutral: FUT2 AA → white circle (⚪ = U+26AA)
-  html = mockAndRender({ rs601338: { genotype: 'AA', gene: 'FUT2', variant: 'W154X' } });
-  assert('Neutral genotype renders white circle', html.includes('⚪'));
-
-  // None: FUT2 GG (wild-type) → no finding row at all (filtered before render)
-  html = mockAndRender({ rs601338: { genotype: 'GG', gene: 'FUT2', variant: 'W154X' } });
-  assert('None-effect genotype produces no finding row', !html.includes('genetics-finding-row'));
-
-  // Restore genetics state
-  window._labState.importedData.genetics = origGenetics;
-
-  // ═══════════════════════════════════════
-  // 8. Legend block + catLabels coverage
-  // ═══════════════════════════════════════
-  console.log('%c 8. Legend & Category Labels ', 'font-weight:bold;color:#f59e0b');
-
-  // Legend renders when there's at least one finding
+function mockAndRender(snps) {
   window._labState.importedData.genetics = {
     source: 'TestSource', importDate: '2026-04-24',
-    coverage: { found: 1, total: 1 }, effects: {},
-    snps: { rs1801133: { genotype: 'AA', gene: 'MTHFR', variant: 'C677T' } }
+    coverage: { found: Object.keys(snps).length, total: Object.keys(snps).length },
+    effects: { significant: 0, moderate: 0, normal: 0 },
+    snps
   };
-  const legendHtml = dna.renderGeneticsSection();
-  assert('Legend block renders', legendHtml.includes('genetics-legend'));
-  assert('Legend has "significant risk" label', legendHtml.includes('significant risk'));
-  assert('Legend has "mild risk" label', legendHtml.includes('mild risk'));
-  assert('Legend has "beneficial" label', legendHtml.includes('beneficial'));
-  assert('Legend has "informational" label', legendHtml.includes('informational'));
-  assert('Legend has "moderate risk" label', legendHtml.includes('moderate risk'));
-  window._labState.importedData.genetics = origGenetics;
+  return dna.renderGeneticsSection();
+}
 
-  // Every category used in snp-health.json must have a display label in catLabels
-  const catLabelsMatch = dnaSrc.match(/const catLabels = \{([^}]+)\}/);
-  assert('catLabels object found in dna.js source', catLabelsMatch != null);
-  const catLabelsKeys = (catLabelsMatch?.[1] || '').match(/(\w+):/g)?.map(s => s.replace(':', '')) || [];
-  const usedCats = new Set();
-  for (const [rsid, entry] of Object.entries(snpTable)) {
-    if (rsid.startsWith('rs') && entry.category) usedCats.add(entry.category);
+// Helper: extract just the finding-row HTML (excludes the legend, which always
+// contains every dot character for explanatory purposes).
+const findingRowDots = (html) => {
+  const rows = html.match(/<div class="genetics-finding-row[^"]*"[^>]*>[\s\S]*?<\/div>/g) || [];
+  return rows.join('').match(/[🔴🟡🟠🟢⚪]/g)?.join('') || '';
+};
+
+// Protective: PCSK9 GT → green dot in the finding row, no red dot in the row
+let html = mockAndRender({ rs11591147: { genotype: 'GT', gene: 'PCSK9', variant: 'R46L' } });
+assert('Protective finding row has green dot', findingRowDots(html).includes('🟢'));
+assert('Protective finding row has NO red dot', !findingRowDots(html).includes('🔴'));
+
+// Significant risk: MTHFR C677T AA → red dot
+html = mockAndRender({ rs1801133: { genotype: 'AA', gene: 'MTHFR', variant: 'C677T' } });
+assert('Significant risk renders red dot', html.includes('🔴'));
+
+// Moderate risk: MTHFR A1298C GG... wait we recalibrated that to mild. Use HFE C282Y heterozygote → moderate
+html = mockAndRender({ rs1800562: { genotype: 'GA', gene: 'HFE', variant: 'C282Y' } });
+assert('Moderate risk renders yellow dot', html.includes('🟡'));
+
+// Mild risk: MTR A2756G AG → orange dot (🟠 = D83D DFE0)
+html = mockAndRender({ rs1805087: { genotype: 'AG', gene: 'MTR', variant: 'A2756G' } });
+assert('Mild risk renders orange dot', html.includes('🟠'));
+
+// Neutral: FUT2 AA → white circle (⚪ = U+26AA)
+html = mockAndRender({ rs601338: { genotype: 'AA', gene: 'FUT2', variant: 'W154X' } });
+assert('Neutral genotype renders white circle', html.includes('⚪'));
+
+// None: FUT2 GG (wild-type) → no finding row at all (filtered before render)
+html = mockAndRender({ rs601338: { genotype: 'GG', gene: 'FUT2', variant: 'W154X' } });
+assert('None-effect genotype produces no finding row', !html.includes('genetics-finding-row'));
+
+// Restore genetics state
+window._labState.importedData.genetics = origGenetics;
+
+// ═══════════════════════════════════════
+// 8. Legend block + catLabels coverage
+// ═══════════════════════════════════════
+console.log('8. Legend & Category Labels');
+
+// Legend renders when there's at least one finding
+window._labState.importedData.genetics = {
+  source: 'TestSource', importDate: '2026-04-24',
+  coverage: { found: 1, total: 1 }, effects: {},
+  snps: { rs1801133: { genotype: 'AA', gene: 'MTHFR', variant: 'C677T' } }
+};
+const legendHtml = dna.renderGeneticsSection();
+assert('Legend block renders', legendHtml.includes('genetics-legend'));
+assert('Legend has "significant risk" label', legendHtml.includes('significant risk'));
+assert('Legend has "mild risk" label', legendHtml.includes('mild risk'));
+assert('Legend has "beneficial" label', legendHtml.includes('beneficial'));
+assert('Legend has "informational" label', legendHtml.includes('informational'));
+assert('Legend has "moderate risk" label', legendHtml.includes('moderate risk'));
+window._labState.importedData.genetics = origGenetics;
+
+// Every category used in snp-health.json must have a display label in catLabels
+const catLabelsMatch = dnaSrc.match(/const catLabels = \{([^}]+)\}/);
+assert('catLabels object found in dna.js source', catLabelsMatch != null);
+const catLabelsKeys = (catLabelsMatch?.[1] || '').match(/(\w+):/g)?.map(s => s.replace(':', '')) || [];
+const usedCats = new Set();
+for (const [rsid, entry] of Object.entries(snpTable)) {
+  if (rsid.startsWith('rs') && entry.category) usedCats.add(entry.category);
+}
+for (const cat of usedCats) {
+  assert(`catLabels has display label for "${cat}"`, catLabelsKeys.includes(cat));
+}
+
+// Specifically the new categories from v1.22.0
+assert('catLabels has "alcohol"', catLabelsKeys.includes('alcohol'));
+assert('catLabels has "caffeine"', catLabelsKeys.includes('caffeine'));
+assert('catLabels has "bodyComposition"', catLabelsKeys.includes('bodyComposition'));
+
+// ═══════════════════════════════════════
+// 9. End-to-end Illumina → render
+// ═══════════════════════════════════════
+console.log('9. End-to-End: Illumina file → render dashboard');
+
+// Build a small Illumina file with rsids that exercise all 5 dot states:
+//   PCSK9 GT (protective)            → 🟢
+//   MTHFR C677T AA (significant)     → 🔴
+//   HFE C282Y GA (moderate)          → 🟡
+//   MTR A2756G AG (mild)             → 🟠
+//   FUT2 W154X AA (neutral)          → ⚪
+const e2eContent = '﻿[Header]\nGSGT Version,2.0.5\n[Data]\n' +
+  'Sample Name,SNP Name,Chr,Position,Allele1 - Plus,Allele2 - Plus\n' +
+  'sample1,rs11591147,1,55505647,G,T\n' +
+  'sample1,rs1801133,1,11856378,A,A\n' +
+  'sample1,rs1800562,6,26093141,G,A\n' +
+  'sample1,rs1805087,1,237048500,A,G\n' +
+  'sample1,rs601338,19,49206674,A,A\n' +
+  '';
+const e2eFile = new File([e2eContent], 'DNAEra-e2e.csv', { type: 'text/csv' });
+const e2eResult = await dna.parseDNAFile(e2eFile);
+
+assert('E2E: 5 expected matches found', Object.keys(e2eResult.matches).length === 5);
+assert('E2E: PCSK9 GT matched', e2eResult.matches.rs11591147?.genotype === 'GT');
+assert('E2E: MTHFR C677T AA matched', e2eResult.matches.rs1801133?.genotype === 'AA');
+assert('E2E: HFE C282Y heterozygous matched', e2eResult.matches.rs1800562 != null);
+assert('E2E: MTR AG matched', e2eResult.matches.rs1805087?.genotype === 'AG');
+assert('E2E: FUT2 AA matched', e2eResult.matches.rs601338?.genotype === 'AA');
+
+// Now save the parsed result and render the dashboard, asserting all 5 dots
+// are present in the rendered HTML.
+const e2eOrig = window._labState.importedData.genetics;
+const e2eState = { source: e2eResult.source, importDate: '2026-04-24', coverage: e2eResult.coverage, effects: {}, snps: {} };
+for (const [rsid, m] of Object.entries(e2eResult.matches)) {
+  e2eState.snps[rsid] = { genotype: m.genotype, gene: m.gene, variant: m.variant };
+}
+window._labState.importedData.genetics = e2eState;
+const e2eHtml = dna.renderGeneticsSection();
+assert('E2E render: green dot present (PCSK9 protective)', e2eHtml.includes('🟢'));
+assert('E2E render: red dot present (MTHFR significant)', e2eHtml.includes('🔴'));
+assert('E2E render: yellow dot present (HFE moderate)', e2eHtml.includes('🟡'));
+assert('E2E render: orange dot present (MTR mild)', e2eHtml.includes('🟠'));
+assert('E2E render: white circle present (FUT2 neutral)', e2eHtml.includes('⚪'));
+assert('E2E render: legend visible', e2eHtml.includes('genetics-legend'));
+assert('E2E render: source name "Illumina GenomeStudio (DNAEra)" visible', e2eHtml.includes('Illumina GenomeStudio'));
+window._labState.importedData.genetics = e2eOrig;
+
+// ═══════════════════════════════════════
+// 10. Severity ordering (categories + within-category)
+// ═══════════════════════════════════════
+// After the v1.7.6 mild-tier addition, the category sort and within-category
+// sort each promote a full rank (significant > moderate > mild) instead of a
+// binary "has significant?" / "is significant?". A category of moderate
+// findings must out-rank a category of only mild findings, and inside a
+// category mild rows must follow moderate rows.
+console.log('10. Severity Ordering');
+
+const sortOrig = window._labState.importedData.genetics;
+window._labState.importedData.genetics = {
+  source: 'TestSource', importDate: '2026-04-24',
+  coverage: { found: 4, total: 4 }, effects: {},
+  snps: {
+    // vitaminB12 cat → only mild (FUT2 GA = mild/neutral)
+    rs601338: { genotype: 'GA', gene: 'FUT2', variant: 'W154X' },
+    // iron cat → only moderate (HFE GA = moderate/risk)
+    rs1800562: { genotype: 'GA', gene: 'HFE', variant: 'C282Y' },
+    // methylation cat → both moderate (MTHFR GA) AND mild (MTR AG) — proves within-category ordering
+    rs1801133: { genotype: 'GA', gene: 'MTHFR', variant: 'C677T' },
+    rs1805087: { genotype: 'AG', gene: 'MTR',   variant: 'A2756G' },
   }
-  for (const cat of usedCats) {
-    assert(`catLabels has display label for "${cat}"`, catLabelsKeys.includes(cat));
-  }
+};
+const sortHtml = dna.renderGeneticsSection();
+// Strip whitespace for stable substring comparisons.
+const sortFlat = sortHtml.replace(/\s+/g, ' ');
+const ironPos        = sortFlat.indexOf('>Iron<');
+const vitaminB12Pos  = sortFlat.indexOf('>Vitamin B12<');
+const methylationPos = sortFlat.indexOf('>Methylation<');
+assert('Category sort: iron (moderate) renders before vitaminB12 (mild only)', ironPos > 0 && vitaminB12Pos > ironPos);
+assert('Category sort: methylation (has moderate) renders before vitaminB12 (mild only)', methylationPos > 0 && vitaminB12Pos > methylationPos);
 
-  // Specifically the new categories from v1.22.0
-  assert('catLabels has "alcohol"', catLabelsKeys.includes('alcohol'));
-  assert('catLabels has "caffeine"', catLabelsKeys.includes('caffeine'));
-  assert('catLabels has "bodyComposition"', catLabelsKeys.includes('bodyComposition'));
+// Within methylation: MTHFR (moderate) must appear before MTR (mild).
+const methylationBlock = sortFlat.slice(methylationPos, sortFlat.indexOf('genetics-cat-group', methylationPos + 1));
+const mthfrPos = methylationBlock.indexOf('MTHFR');
+const mtrPos   = methylationBlock.indexOf('MTR ');
+assert('Within-category sort: MTHFR (moderate) before MTR (mild) inside methylation', mthfrPos > 0 && mtrPos > mthfrPos);
 
-  // ═══════════════════════════════════════
-  // 9. End-to-end Illumina → render
-  // ═══════════════════════════════════════
-  console.log('%c 9. End-to-End: Illumina file → render dashboard ', 'font-weight:bold;color:#f59e0b');
+window._labState.importedData.genetics = sortOrig;
 
-  // Build a small Illumina file with rsids that exercise all 5 dot states:
-  //   PCSK9 GT (protective)            → 🟢
-  //   MTHFR C677T AA (significant)     → 🔴
-  //   HFE C282Y GA (moderate)          → 🟡
-  //   MTR A2756G AG (mild)             → 🟠
-  //   FUT2 W154X AA (neutral)          → ⚪
-  const e2eContent = '﻿[Header]\nGSGT Version,2.0.5\n[Data]\n' +
-    'Sample Name,SNP Name,Chr,Position,Allele1 - Plus,Allele2 - Plus\n' +
-    'sample1,rs11591147,1,55505647,G,T\n' +
-    'sample1,rs1801133,1,11856378,A,A\n' +
-    'sample1,rs1800562,6,26093141,G,A\n' +
-    'sample1,rs1805087,1,237048500,A,G\n' +
-    'sample1,rs601338,19,49206674,A,A\n' +
-    '';
-  const e2eFile = new File([e2eContent], 'DNAEra-e2e.csv', { type: 'text/csv' });
-  const e2eResult = await dna.parseDNAFile(e2eFile);
-
-  assert('E2E: 5 expected matches found', Object.keys(e2eResult.matches).length === 5);
-  assert('E2E: PCSK9 GT matched', e2eResult.matches.rs11591147?.genotype === 'GT');
-  assert('E2E: MTHFR C677T AA matched', e2eResult.matches.rs1801133?.genotype === 'AA');
-  assert('E2E: HFE C282Y heterozygous matched', e2eResult.matches.rs1800562 != null);
-  assert('E2E: MTR AG matched', e2eResult.matches.rs1805087?.genotype === 'AG');
-  assert('E2E: FUT2 AA matched', e2eResult.matches.rs601338?.genotype === 'AA');
-
-  // Now save the parsed result and render the dashboard, asserting all 5 dots
-  // are present in the rendered HTML.
-  const e2eOrig = window._labState.importedData.genetics;
-  const e2eState = { source: e2eResult.source, importDate: '2026-04-24', coverage: e2eResult.coverage, effects: {}, snps: {} };
-  for (const [rsid, m] of Object.entries(e2eResult.matches)) {
-    e2eState.snps[rsid] = { genotype: m.genotype, gene: m.gene, variant: m.variant };
-  }
-  window._labState.importedData.genetics = e2eState;
-  const e2eHtml = dna.renderGeneticsSection();
-  assert('E2E render: green dot present (PCSK9 protective)', e2eHtml.includes('🟢'));
-  assert('E2E render: red dot present (MTHFR significant)', e2eHtml.includes('🔴'));
-  assert('E2E render: yellow dot present (HFE moderate)', e2eHtml.includes('🟡'));
-  assert('E2E render: orange dot present (MTR mild)', e2eHtml.includes('🟠'));
-  assert('E2E render: white circle present (FUT2 neutral)', e2eHtml.includes('⚪'));
-  assert('E2E render: legend visible', e2eHtml.includes('genetics-legend'));
-  assert('E2E render: source name "Illumina GenomeStudio (DNAEra)" visible', e2eHtml.includes('Illumina GenomeStudio'));
-  window._labState.importedData.genetics = e2eOrig;
-
-  // ═══════════════════════════════════════
-  // 10. Severity ordering (categories + within-category)
-  // ═══════════════════════════════════════
-  // After the v1.7.6 mild-tier addition, the category sort and within-category
-  // sort each promote a full rank (significant > moderate > mild) instead of a
-  // binary "has significant?" / "is significant?". A category of moderate
-  // findings must out-rank a category of only mild findings, and inside a
-  // category mild rows must follow moderate rows.
-  console.log('%c 10. Severity Ordering ', 'font-weight:bold;color:#f59e0b');
-
-  const sortOrig = window._labState.importedData.genetics;
-  window._labState.importedData.genetics = {
-    source: 'TestSource', importDate: '2026-04-24',
-    coverage: { found: 4, total: 4 }, effects: {},
-    snps: {
-      // vitaminB12 cat → only mild (FUT2 GA = mild/neutral)
-      rs601338: { genotype: 'GA', gene: 'FUT2', variant: 'W154X' },
-      // iron cat → only moderate (HFE GA = moderate/risk)
-      rs1800562: { genotype: 'GA', gene: 'HFE', variant: 'C282Y' },
-      // methylation cat → both moderate (MTHFR GA) AND mild (MTR AG) — proves within-category ordering
-      rs1801133: { genotype: 'GA', gene: 'MTHFR', variant: 'C677T' },
-      rs1805087: { genotype: 'AG', gene: 'MTR',   variant: 'A2756G' },
-    }
-  };
-  const sortHtml = dna.renderGeneticsSection();
-  // Strip whitespace for stable substring comparisons.
-  const sortFlat = sortHtml.replace(/\s+/g, ' ');
-  const ironPos        = sortFlat.indexOf('>Iron<');
-  const vitaminB12Pos  = sortFlat.indexOf('>Vitamin B12<');
-  const methylationPos = sortFlat.indexOf('>Methylation<');
-  assert('Category sort: iron (moderate) renders before vitaminB12 (mild only)', ironPos > 0 && vitaminB12Pos > ironPos);
-  assert('Category sort: methylation (has moderate) renders before vitaminB12 (mild only)', methylationPos > 0 && vitaminB12Pos > methylationPos);
-
-  // Within methylation: MTHFR (moderate) must appear before MTR (mild).
-  const methylationBlock = sortFlat.slice(methylationPos, sortFlat.indexOf('genetics-cat-group', methylationPos + 1));
-  const mthfrPos = methylationBlock.indexOf('MTHFR');
-  const mtrPos   = methylationBlock.indexOf('MTR ');
-  assert('Within-category sort: MTHFR (moderate) before MTR (mild) inside methylation', mthfrPos > 0 && mtrPos > mthfrPos);
-
-  window._labState.importedData.genetics = sortOrig;
-
-  // ═══════════════════════════════════════
-  // Results
-  // ═══════════════════════════════════════
-  console.log(`\n%c Tests complete: ${pass} passed, ${fail} failed `, fail ? 'background:#ef4444;color:#fff;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;padding:4px 12px;border-radius:4px');
-  if (typeof window.__TEST_RESULTS !== 'undefined') window.__TEST_RESULTS = { pass, fail };
-})();
+// ═══════════════════════════════════════
+// Results
+// ═══════════════════════════════════════
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-dna-illumina-and-valence.js
+++ b/tests/test-dna-illumina-and-valence.js
@@ -69,7 +69,7 @@ assert('Filename without dnaera/ancestry/etc not recognized', !dna.isDNAFile({ n
 // escape would silently render `/^[Data]/i` (a character class matching
 // D/a/t) — the parser would never advance past the [Header] block. This
 // bit us once during development. The dna.js source must contain `\\[Data\\]`.
-const dnaSrcForRegex = await fetch('js/dna.js').then(r => r.text());
+const dnaSrcForRegex = dnaSrc; // identical read — reuse the section-0 fetch
 assert('Worker [Data] regex uses double-escaped brackets',
   dnaSrcForRegex.includes('/^\\\\[Data\\\\]/i'),
   'should match `\\\\[Data\\\\]` in source so worker sees \\[Data\\]');

--- a/tests/test-dna.js
+++ b/tests/test-dna.js
@@ -1,80 +1,120 @@
-// test-dna.js — DNA adapter: parser, storage, context assembly
-// Run: fetch('tests/test-dna.js').then(r=>r.text()).then(s=>Function(s)())
+#!/usr/bin/env node
+// test-dna.js — DNA adapter: parser, storage, context assembly.
+// Format detection, per-vendor parsers (Ancestry / 23andMe / CSV / MyHeritage
+// Low-pass WGS), genotype reversal + strand-flip handling, findGenotypeInfo,
+// APOE haplotype resolution, storage round-trip, context assembly, mtDNA
+// detection + haplogroup data, plus a source-integration sweep.
+//
+// Run: node tests/test-dna.js  (or via npm test)
+//
+// Full port — parseDNAFile spins a Blob-backed Worker; the synchronous
+// Worker shim in _node-shim.js runs it in-process. window-export checks
+// need state.js + dna.js loaded; haplogroups.json + source reads go
+// through the fs-backed fetch shim (`/app` aliases index.html).
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+import './_node-shim.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => {
+  let r = rel.replace(/^\//, '');
+  if (r === 'app' || r === '') r = 'index.html'; // dev-server alias
+  return fs.readFileSync(path.join(ROOT, r), 'utf-8');
+};
+function fetchWithRetry(rel) { return Promise.resolve(read(rel)); }
+
+// fs-backed fetch shim: relative URLs read from disk (read() handles the
+// dev-server `/app` → index.html alias).
+const _realFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  if (typeof url === 'string' && !/^https?:/.test(url)) {
+    try { return new Response(read(url), { status: 200 }); }
+    catch (_) { return new Response('', { status: 404 }); }
   }
+  return _realFetch(url, opts);
+};
 
-  console.log('%c DNA Adapter Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const dna = await import('../js/dna.js');
+console.log('=== DNA Adapter Tests ===\n');
 
-  // ═══════════════════════════════════════
-  // 1. Module exports
-  // ═══════════════════════════════════════
-  console.log('%c 1. Module Exports ', 'font-weight:bold;color:#f59e0b');
+// Load the app module surface so dna.js's Object.assign(window, …) runs
+// and window._labState is set by state.js.
+await import('../js/state.js');
+await import('../js/utils.js');
+await import('../js/data.js');
+const dna = await import('../js/dna.js');
 
-  assert('detectDNAFile exported', typeof dna.detectDNAFile === 'function');
-  assert('isDNAFile exported', typeof dna.isDNAFile === 'function');
-  assert('parseDNAFile exported', typeof dna.parseDNAFile === 'function');
-  assert('saveGeneticsData exported', typeof dna.saveGeneticsData === 'function');
-  assert('deleteGeneticsData exported', typeof dna.deleteGeneticsData === 'function');
-  assert('buildGeneticsContext exported', typeof dna.buildGeneticsContext === 'function');
-  assert('buildFullGeneticsContext exported', typeof dna.buildFullGeneticsContext === 'function');
-  assert('handleDNAFile exported', typeof dna.handleDNAFile === 'function');
-  assert('findGenotypeInfo exported', typeof dna.findGenotypeInfo === 'function');
-  assert('findSnpHint exported', typeof dna.findSnpHint === 'function');
+// ═══════════════════════════════════════
+// 1. Module exports
+// ═══════════════════════════════════════
+console.log('1. Module Exports');
 
-  // ═══════════════════════════════════════
-  // 2. Format detection
-  // ═══════════════════════════════════════
-  console.log('%c 2. Format Detection ', 'font-weight:bold;color:#f59e0b');
+assert('detectDNAFile exported', typeof dna.detectDNAFile === 'function');
+assert('isDNAFile exported', typeof dna.isDNAFile === 'function');
+assert('parseDNAFile exported', typeof dna.parseDNAFile === 'function');
+assert('saveGeneticsData exported', typeof dna.saveGeneticsData === 'function');
+assert('deleteGeneticsData exported', typeof dna.deleteGeneticsData === 'function');
+assert('buildGeneticsContext exported', typeof dna.buildGeneticsContext === 'function');
+assert('buildFullGeneticsContext exported', typeof dna.buildFullGeneticsContext === 'function');
+assert('handleDNAFile exported', typeof dna.handleDNAFile === 'function');
+assert('findGenotypeInfo exported', typeof dna.findGenotypeInfo === 'function');
+assert('findSnpHint exported', typeof dna.findSnpHint === 'function');
 
-  assert('Detects Ancestry', dna.detectDNAFile('#AncestryDNA raw data download\n') === 'ancestry');
-  assert('Detects 23andMe', dna.detectDNAFile('# This data file generated by 23andMe at: 2024-01-01\n') === '23andme');
-  assert('Detects Living DNA', dna.detectDNAFile('# Living DNA customer genotype data download file version: 1.0.1\n') === 'livingdna');
-  assert('Detects CSV (MyHeritage/FTDNA)', dna.detectDNAFile('RSID,CHROMOSOME,POSITION,RESULT\n') === 'csv');
-  assert('Detects quoted CSV', dna.detectDNAFile('"RSID","CHROMOSOME","POSITION","RESULT"\n') === 'csv');
-  // 2025+ MyHeritage Low-pass WGS export prepends a ##fileformat block before
-  // the column header. The detector used to read only line 0 and miss the
-  // RSID,CHROMOSOME,POSITION,RESULT line buried below ~12 comment rows.
-  const myHeritageWGSHeader =
-    '##fileformat=MyHeritage\n' +
-    '##format=MHv1.0\n' +
-    '##method=Low-pass Whole Genome Sequencing\n' +
-    '##timestamp=2026-05-12 13:09:09 UTC\n' +
-    '##reference=build37\n' +
-    '#\n' +
-    '# MyHeritage DNA raw data.\n' +
-    'RSID,CHROMOSOME,POSITION,RESULT\n' +
-    '"rs3131972","1","752721","AA"\n';
-  assert('Detects MyHeritage Low-pass WGS (##fileformat header)', dna.detectDNAFile(myHeritageWGSHeader) === 'csv');
-  assert('Returns null for JSON', dna.detectDNAFile('{"entries": []}') === null);
-  assert('Returns null for PDF header', dna.detectDNAFile('%PDF-1.4') === null);
+// ═══════════════════════════════════════
+// 2. Format detection
+// ═══════════════════════════════════════
+console.log('2. Format Detection');
 
-  // ═══════════════════════════════════════
-  // 3. isDNAFile by filename
-  // ═══════════════════════════════════════
-  console.log('%c 3. isDNAFile ', 'font-weight:bold;color:#f59e0b');
+assert('Detects Ancestry', dna.detectDNAFile('#AncestryDNA raw data download\n') === 'ancestry');
+assert('Detects 23andMe', dna.detectDNAFile('# This data file generated by 23andMe at: 2024-01-01\n') === '23andme');
+assert('Detects Living DNA', dna.detectDNAFile('# Living DNA customer genotype data download file version: 1.0.1\n') === 'livingdna');
+assert('Detects CSV (MyHeritage/FTDNA)', dna.detectDNAFile('RSID,CHROMOSOME,POSITION,RESULT\n') === 'csv');
+assert('Detects quoted CSV', dna.detectDNAFile('"RSID","CHROMOSOME","POSITION","RESULT"\n') === 'csv');
+// 2025+ MyHeritage Low-pass WGS export prepends a ##fileformat block before
+// the column header. The detector used to read only line 0 and miss the
+// RSID,CHROMOSOME,POSITION,RESULT line buried below ~12 comment rows.
+const myHeritageWGSHeader =
+  '##fileformat=MyHeritage\n' +
+  '##format=MHv1.0\n' +
+  '##method=Low-pass Whole Genome Sequencing\n' +
+  '##timestamp=2026-05-12 13:09:09 UTC\n' +
+  '##reference=build37\n' +
+  '#\n' +
+  '# MyHeritage DNA raw data.\n' +
+  'RSID,CHROMOSOME,POSITION,RESULT\n' +
+  '"rs3131972","1","752721","AA"\n';
+assert('Detects MyHeritage Low-pass WGS (##fileformat header)', dna.detectDNAFile(myHeritageWGSHeader) === 'csv');
+assert('Returns null for JSON', dna.detectDNAFile('{"entries": []}') === null);
+assert('Returns null for PDF header', dna.detectDNAFile('%PDF-1.4') === null);
 
-  assert('Recognizes AncestryDNA.txt', dna.isDNAFile({ name: 'AncestryDNA.txt' }));
-  assert('Recognizes 23andMe file', dna.isDNAFile({ name: 'genome_23andme_Full_20240101.txt' }));
-  assert('Recognizes MyHeritage', dna.isDNAFile({ name: 'MyHeritage_raw_dna_data.csv' }));
-  assert('Recognizes Family Finder', dna.isDNAFile({ name: 'Family_Finder_Results.csv' }));
-  assert('Recognizes Living DNA', dna.isDNAFile({ name: 'livingdna_results.txt' }));
-  assert('Rejects random PDF', !dna.isDNAFile({ name: 'lab-results.pdf' }));
-  assert('Rejects JSON', !dna.isDNAFile({ name: 'backup.json' }));
-  assert('Handles null', !dna.isDNAFile(null));
+// ═══════════════════════════════════════
+// 3. isDNAFile by filename
+// ═══════════════════════════════════════
+console.log('3. isDNAFile');
 
-  // ═══════════════════════════════════════
-  // 4. Ancestry parser
-  // ═══════════════════════════════════════
-  console.log('%c 4. Ancestry Parser ', 'font-weight:bold;color:#f59e0b');
+assert('Recognizes AncestryDNA.txt', dna.isDNAFile({ name: 'AncestryDNA.txt' }));
+assert('Recognizes 23andMe file', dna.isDNAFile({ name: 'genome_23andme_Full_20240101.txt' }));
+assert('Recognizes MyHeritage', dna.isDNAFile({ name: 'MyHeritage_raw_dna_data.csv' }));
+assert('Recognizes Family Finder', dna.isDNAFile({ name: 'Family_Finder_Results.csv' }));
+assert('Recognizes Living DNA', dna.isDNAFile({ name: 'livingdna_results.txt' }));
+assert('Rejects random PDF', !dna.isDNAFile({ name: 'lab-results.pdf' }));
+assert('Rejects JSON', !dna.isDNAFile({ name: 'backup.json' }));
+assert('Handles null', !dna.isDNAFile(null));
 
-  const ancestryContent = `#AncestryDNA raw data download
+// ═══════════════════════════════════════
+// 4. Ancestry parser
+// ═══════════════════════════════════════
+console.log('4. Ancestry Parser');
+
+const ancestryContent = `#AncestryDNA raw data download
 #This file was generated by AncestryDNA
 rsid\tchromosome\tposition\tallele1\tallele2
 rs1801133\t1\t11856378\tG\tA
@@ -85,313 +125,312 @@ rs7412\t19\t45412079\tC\tC
 rs174546\t11\t61569830\tC\tT
 rs999999\t1\t100000\tA\tG
 `;
-  const ancestryFile = new File([ancestryContent], 'AncestryDNA.txt', { type: 'text/plain' });
-  const aResult = await dna.parseDNAFile(ancestryFile);
+const ancestryFile = new File([ancestryContent], 'AncestryDNA.txt', { type: 'text/plain' });
+const aResult = await dna.parseDNAFile(ancestryFile);
 
-  assert('Ancestry: source detected', aResult.source === 'AncestryDNA');
-  assert('Ancestry: found matches', Object.keys(aResult.matches).length > 0, `found ${Object.keys(aResult.matches).length}`);
-  assert('Ancestry: MTHFR C677T matched', aResult.matches.rs1801133 != null);
-  assert('Ancestry: MTHFR genotype GA', aResult.matches.rs1801133?.genotype === 'GA');
-  assert('Ancestry: MTHFR effect moderate', aResult.matches.rs1801133?.effect === 'moderate');
-  assert('Ancestry: HFE matched', aResult.matches.rs1800562 != null);
-  assert('Ancestry: HFE effect none', aResult.matches.rs1800562?.effect === 'none');
-  assert('Ancestry: unknown rsid not in matches', aResult.matches.rs999999 == null);
-  assert('Ancestry: coverage reported', aResult.coverage.found > 0 && aResult.coverage.total > 0);
+assert('Ancestry: source detected', aResult.source === 'AncestryDNA');
+assert('Ancestry: found matches', Object.keys(aResult.matches).length > 0, `found ${Object.keys(aResult.matches).length}`);
+assert('Ancestry: MTHFR C677T matched', aResult.matches.rs1801133 != null);
+assert('Ancestry: MTHFR genotype GA', aResult.matches.rs1801133?.genotype === 'GA');
+assert('Ancestry: MTHFR effect moderate', aResult.matches.rs1801133?.effect === 'moderate');
+assert('Ancestry: HFE matched', aResult.matches.rs1800562 != null);
+assert('Ancestry: HFE effect none', aResult.matches.rs1800562?.effect === 'none');
+assert('Ancestry: unknown rsid not in matches', aResult.matches.rs999999 == null);
+assert('Ancestry: coverage reported', aResult.coverage.found > 0 && aResult.coverage.total > 0);
 
-  // ═══════════════════════════════════════
-  // 5. 23andMe parser
-  // ═══════════════════════════════════════
-  console.log('%c 5. 23andMe Parser ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 5. 23andMe parser
+// ═══════════════════════════════════════
+console.log('5. 23andMe Parser');
 
-  const me23Content = `# This data file generated by 23andMe at: 2024-01-01
+const me23Content = `# This data file generated by 23andMe at: 2024-01-01
 # rsid\tchromosome\tposition\tgenotype
 rs1801133\t1\t11856378\tGA
 rs1800562\t6\t26093141\tGG
 rs174546\t11\t61569830\tCT
 i123456\t1\t100\tAA
 `;
-  const me23File = new File([me23Content], '23andme.txt', { type: 'text/plain' });
-  const me23Result = await dna.parseDNAFile(me23File);
+const me23File = new File([me23Content], '23andme.txt', { type: 'text/plain' });
+const me23Result = await dna.parseDNAFile(me23File);
 
-  assert('23andMe: source detected', me23Result.source === '23andMe');
-  assert('23andMe: MTHFR matched', me23Result.matches.rs1801133?.genotype === 'GA');
-  assert('23andMe: internal ID skipped', me23Result.matches.i123456 == null);
+assert('23andMe: source detected', me23Result.source === '23andMe');
+assert('23andMe: MTHFR matched', me23Result.matches.rs1801133?.genotype === 'GA');
+assert('23andMe: internal ID skipped', me23Result.matches.i123456 == null);
 
-  // ═══════════════════════════════════════
-  // 6. CSV parser (MyHeritage/FTDNA)
-  // ═══════════════════════════════════════
-  console.log('%c 6. CSV Parser ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 6. CSV parser (MyHeritage/FTDNA)
+// ═══════════════════════════════════════
+console.log('6. CSV Parser');
 
-  const csvContent = `RSID,CHROMOSOME,POSITION,RESULT
+const csvContent = `RSID,CHROMOSOME,POSITION,RESULT
 "rs1801133","1","11856378","GA"
 "rs1800562","6","26093141","GG"
 `;
-  const csvFile = new File([csvContent], 'MyHeritage_raw_dna_data.csv', { type: 'text/csv' });
-  const csvResult = await dna.parseDNAFile(csvFile);
+const csvFile = new File([csvContent], 'MyHeritage_raw_dna_data.csv', { type: 'text/csv' });
+const csvResult = await dna.parseDNAFile(csvFile);
 
-  assert('CSV: source detected', csvResult.source === 'MyHeritage/FTDNA');
-  assert('CSV: MTHFR matched', csvResult.matches.rs1801133?.genotype === 'GA');
-  assert('CSV: handles quoted fields', csvResult.matches.rs1800562?.genotype === 'GG');
+assert('CSV: source detected', csvResult.source === 'MyHeritage/FTDNA');
+assert('CSV: MTHFR matched', csvResult.matches.rs1801133?.genotype === 'GA');
+assert('CSV: handles quoted fields', csvResult.matches.rs1800562?.genotype === 'GG');
 
-  // CSV with MyHeritage Low-pass WGS ##fileformat header block (the format
-  // shipped after the 2025 export refresh — the detector used to miss it).
-  const myHeritageWGSContent =
-    '##fileformat=MyHeritage\n' +
-    '##format=MHv1.0\n' +
-    '##method=Low-pass Whole Genome Sequencing\n' +
-    '##timestamp=2026-05-12 13:09:09 UTC\n' +
-    '##reference=build37\n' +
-    '#\n' +
-    '# MyHeritage DNA raw data.\n' +
-    'RSID,CHROMOSOME,POSITION,RESULT\n' +
-    '"rs1801133","1","11856378","GA"\n' +
-    '"rs1800562","6","26093141","GG"\n';
-  const mhFile = new File([myHeritageWGSContent], 'MyHeritage_raw_dna_data_adj.csv', { type: 'text/csv' });
-  const mhResult = await dna.parseDNAFile(mhFile);
-  assert('MyHeritage WGS: source detected', mhResult.source === 'MyHeritage/FTDNA');
-  assert('MyHeritage WGS: comment lines skipped, MTHFR matched', mhResult.matches.rs1801133?.genotype === 'GA');
-  assert('MyHeritage WGS: HFE matched (past comment block)', mhResult.matches.rs1800562?.genotype === 'GG');
+// CSV with MyHeritage Low-pass WGS ##fileformat header block (the format
+// shipped after the 2025 export refresh — the detector used to miss it).
+const myHeritageWGSContent =
+  '##fileformat=MyHeritage\n' +
+  '##format=MHv1.0\n' +
+  '##method=Low-pass Whole Genome Sequencing\n' +
+  '##timestamp=2026-05-12 13:09:09 UTC\n' +
+  '##reference=build37\n' +
+  '#\n' +
+  '# MyHeritage DNA raw data.\n' +
+  'RSID,CHROMOSOME,POSITION,RESULT\n' +
+  '"rs1801133","1","11856378","GA"\n' +
+  '"rs1800562","6","26093141","GG"\n';
+const mhFile = new File([myHeritageWGSContent], 'MyHeritage_raw_dna_data_adj.csv', { type: 'text/csv' });
+const mhResult = await dna.parseDNAFile(mhFile);
+assert('MyHeritage WGS: source detected', mhResult.source === 'MyHeritage/FTDNA');
+assert('MyHeritage WGS: comment lines skipped, MTHFR matched', mhResult.matches.rs1801133?.genotype === 'GA');
+assert('MyHeritage WGS: HFE matched (past comment block)', mhResult.matches.rs1800562?.genotype === 'GG');
 
-  // ═══════════════════════════════════════
-  // 7. Genotype reversal (CT ↔ TC)
-  // ═══════════════════════════════════════
-  console.log('%c 7. Genotype Reversal ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 7. Genotype reversal (CT ↔ TC)
+// ═══════════════════════════════════════
+console.log('7. Genotype Reversal');
 
-  // FADS1 table has TC but Ancestry gives CT — should still match via reversal
-  assert('FADS1 CT matched as TC', aResult.matches.rs174546?.effect === 'moderate', aResult.matches.rs174546?.note);
+// FADS1 table has TC but Ancestry gives CT — should still match via reversal
+assert('FADS1 CT matched as TC', aResult.matches.rs174546?.effect === 'moderate', aResult.matches.rs174546?.note);
 
-  // ═══════════════════════════════════════
-  // 7b. Strand-flip + sequencing-noise handling
-  // ═══════════════════════════════════════
-  // MyHeritage 2025 Low-pass WGS reports build37 forward strand. For a handful
-  // of catalog loci (PCSK9 R46L, MTR A2756G, UGT1A1 G71R, MTRR A66G, BHMT
-  // R239Q, FADS1 coding, LIPC -514, MC1R R160W) the catalog keys live on the
-  // opposite strand, so a raw "AC" call must resolve to a catalog "GT" via
-  // reverse-complement fallback. Independently, low-pass imputation noise can
-  // emit alleles that aren't valid for the locus at all (e.g. "CG" on a C/T
-  // SNP) — those must be dropped, not surfaced as "Genotype not in lookup".
-  console.log('%c 7b. Strand-flip + sequencing-noise ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 7b. Strand-flip + sequencing-noise handling
+// ═══════════════════════════════════════
+// MyHeritage 2025 Low-pass WGS reports build37 forward strand. For a handful
+// of catalog loci (PCSK9 R46L, MTR A2756G, UGT1A1 G71R, MTRR A66G, BHMT
+// R239Q, FADS1 coding, LIPC -514, MC1R R160W) the catalog keys live on the
+// opposite strand, so a raw "AC" call must resolve to a catalog "GT" via
+// reverse-complement fallback. Independently, low-pass imputation noise can
+// emit alleles that aren't valid for the locus at all (e.g. "CG" on a C/T
+// SNP) — those must be dropped, not surfaced as "Genotype not in lookup".
+console.log('7b. Strand-flip + sequencing-noise');
 
-  const wgsEdgeContent =
-    '##fileformat=MyHeritage\n' +
-    '##method=Low-pass Whole Genome Sequencing\n' +
-    'RSID,CHROMOSOME,POSITION,RESULT\n' +
-    '"rs5882","16","57016092","AG"\n' +        // direct catalog AG, effect mild — must NOT be dropped
-    '"rs762551","15","75041917","AC"\n' +      // direct catalog AC, effect mild — must NOT be dropped
-    '"rs11591147","1","55505647","AC"\n' +     // RC of GT — must resolve to significant
-    '"rs1801394","5","7870973","TT"\n' +       // RC of AA — must resolve to none (MTRR wild-type)
-    '"rs1805087","1","237048500","CC"\n' +     // RC of GG — must resolve to moderate
-    '"rs11206244","1","54375701","CG"\n' +     // invalid call on C/T locus — must be dropped
-    '"rs1801198","22","31011610","AA"\n';      // invalid call on C/G palindromic locus — must be dropped (RC of AA is TT, also invalid)
-  const wgsEdgeFile = new File([wgsEdgeContent], 'wgs-edge.csv', { type: 'text/csv' });
-  const wgsEdgeResult = await dna.parseDNAFile(wgsEdgeFile);
+const wgsEdgeContent =
+  '##fileformat=MyHeritage\n' +
+  '##method=Low-pass Whole Genome Sequencing\n' +
+  'RSID,CHROMOSOME,POSITION,RESULT\n' +
+  '"rs5882","16","57016092","AG"\n' +        // direct catalog AG, effect mild — must NOT be dropped
+  '"rs762551","15","75041917","AC"\n' +      // direct catalog AC, effect mild — must NOT be dropped
+  '"rs11591147","1","55505647","AC"\n' +     // RC of GT — must resolve to significant
+  '"rs1801394","5","7870973","TT"\n' +       // RC of AA — must resolve to none (MTRR wild-type)
+  '"rs1805087","1","237048500","CC"\n' +     // RC of GG — must resolve to moderate
+  '"rs11206244","1","54375701","CG"\n' +     // invalid call on C/T locus — must be dropped
+  '"rs1801198","22","31011610","AA"\n';      // invalid call on C/G palindromic locus — must be dropped (RC of AA is TT, also invalid)
+const wgsEdgeFile = new File([wgsEdgeContent], 'wgs-edge.csv', { type: 'text/csv' });
+const wgsEdgeResult = await dna.parseDNAFile(wgsEdgeFile);
 
-  assert('WGS edge: effect "mild" kept on rs5882 (was being dropped as unknown)', wgsEdgeResult.matches.rs5882?.effect === 'mild');
-  assert('WGS edge: effect "mild" kept on rs762551 (was being dropped as unknown)', wgsEdgeResult.matches.rs762551?.effect === 'mild');
-  assert('WGS edge: strand-flipped AC → GT resolves to significant (PCSK9 R46L)', wgsEdgeResult.matches.rs11591147?.effect === 'significant');
-  assert('WGS edge: strand-flipped TT → AA resolves to none (MTRR A66G wild-type)', wgsEdgeResult.matches.rs1801394?.effect === 'none');
-  assert('WGS edge: strand-flipped CC → GG resolves to moderate (MTR A2756G)', wgsEdgeResult.matches.rs1805087?.effect === 'moderate');
-  assert('WGS edge: invalid CG call on C/T locus dropped (not surfaced as unknown)', wgsEdgeResult.matches.rs11206244 == null);
-  assert('WGS edge: invalid AA call on C/G palindromic locus dropped (RC guard prevents false positive)', wgsEdgeResult.matches.rs1801198 == null);
+assert('WGS edge: effect "mild" kept on rs5882 (was being dropped as unknown)', wgsEdgeResult.matches.rs5882?.effect === 'mild');
+assert('WGS edge: effect "mild" kept on rs762551 (was being dropped as unknown)', wgsEdgeResult.matches.rs762551?.effect === 'mild');
+assert('WGS edge: strand-flipped AC → GT resolves to significant (PCSK9 R46L)', wgsEdgeResult.matches.rs11591147?.effect === 'significant');
+assert('WGS edge: strand-flipped TT → AA resolves to none (MTRR A66G wild-type)', wgsEdgeResult.matches.rs1801394?.effect === 'none');
+assert('WGS edge: strand-flipped CC → GG resolves to moderate (MTR A2756G)', wgsEdgeResult.matches.rs1805087?.effect === 'moderate');
+assert('WGS edge: invalid CG call on C/T locus dropped (not surfaced as unknown)', wgsEdgeResult.matches.rs11206244 == null);
+assert('WGS edge: invalid AA call on C/G palindromic locus dropped (RC guard prevents false positive)', wgsEdgeResult.matches.rs1801198 == null);
 
-  // ═══════════════════════════════════════
-  // 7c. findGenotypeInfo strand-aware lookup
-  // ═══════════════════════════════════════
-  console.log('%c 7c. findGenotypeInfo helper ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 7c. findGenotypeInfo strand-aware lookup
+// ═══════════════════════════════════════
+console.log('7c. findGenotypeInfo helper');
 
-  // Non-palindromic SNP: A/G alleles → RC fallback should resolve CT→AG, TT→AA, CC→GG
-  const nonPalEntry = { genotypes: { AA: { effect: 'none' }, AG: { effect: 'moderate' }, GG: { effect: 'significant' } } };
-  assert('Non-palindromic: direct AG → moderate', dna.findGenotypeInfo(nonPalEntry, 'AG')?.effect === 'moderate');
-  assert('Non-palindromic: reversed GA → moderate', dna.findGenotypeInfo(nonPalEntry, 'GA')?.effect === 'moderate');
-  assert('Non-palindromic: RC of TT → AA → none', dna.findGenotypeInfo(nonPalEntry, 'TT')?.effect === 'none');
-  assert('Non-palindromic: RC of CC → GG → significant', dna.findGenotypeInfo(nonPalEntry, 'CC')?.effect === 'significant');
-  assert('Non-palindromic: RC of CT → AG → moderate', dna.findGenotypeInfo(nonPalEntry, 'CT')?.effect === 'moderate');
-  assert('Non-palindromic: unrelated alleles → null', dna.findGenotypeInfo(nonPalEntry, 'NN') == null);
+// Non-palindromic SNP: A/G alleles → RC fallback should resolve CT→AG, TT→AA, CC→GG
+const nonPalEntry = { genotypes: { AA: { effect: 'none' }, AG: { effect: 'moderate' }, GG: { effect: 'significant' } } };
+assert('Non-palindromic: direct AG → moderate', dna.findGenotypeInfo(nonPalEntry, 'AG')?.effect === 'moderate');
+assert('Non-palindromic: reversed GA → moderate', dna.findGenotypeInfo(nonPalEntry, 'GA')?.effect === 'moderate');
+assert('Non-palindromic: RC of TT → AA → none', dna.findGenotypeInfo(nonPalEntry, 'TT')?.effect === 'none');
+assert('Non-palindromic: RC of CC → GG → significant', dna.findGenotypeInfo(nonPalEntry, 'CC')?.effect === 'significant');
+assert('Non-palindromic: RC of CT → AG → moderate', dna.findGenotypeInfo(nonPalEntry, 'CT')?.effect === 'moderate');
+assert('Non-palindromic: unrelated alleles → null', dna.findGenotypeInfo(nonPalEntry, 'NN') == null);
 
-  // Palindromic SNP: C/G alleles → RC of CC is GG, both in catalog with different effects.
-  // RC fallback must be SUPPRESSED, else we'd silently equate CC and GG.
-  const palEntry = { genotypes: { CC: { effect: 'none' }, CG: { effect: 'moderate' }, GG: { effect: 'significant' } } };
-  assert('Palindromic: CC stays CC (not RC-flipped to GG)', dna.findGenotypeInfo(palEntry, 'CC')?.effect === 'none');
-  assert('Palindromic: GG stays GG (not RC-flipped to CC)', dna.findGenotypeInfo(palEntry, 'GG')?.effect === 'significant');
-  assert('Palindromic: invalid AA returns null (no RC fallback to TT either)', dna.findGenotypeInfo(palEntry, 'AA') == null);
-  assert('Palindromic: invalid TT returns null', dna.findGenotypeInfo(palEntry, 'TT') == null);
+// Palindromic SNP: C/G alleles → RC of CC is GG, both in catalog with different effects.
+// RC fallback must be SUPPRESSED, else we'd silently equate CC and GG.
+const palEntry = { genotypes: { CC: { effect: 'none' }, CG: { effect: 'moderate' }, GG: { effect: 'significant' } } };
+assert('Palindromic: CC stays CC (not RC-flipped to GG)', dna.findGenotypeInfo(palEntry, 'CC')?.effect === 'none');
+assert('Palindromic: GG stays GG (not RC-flipped to CC)', dna.findGenotypeInfo(palEntry, 'GG')?.effect === 'significant');
+assert('Palindromic: invalid AA returns null (no RC fallback to TT either)', dna.findGenotypeInfo(palEntry, 'AA') == null);
+assert('Palindromic: invalid TT returns null', dna.findGenotypeInfo(palEntry, 'TT') == null);
 
-  // Empty / malformed inputs
-  assert('findGenotypeInfo: null entry → null', dna.findGenotypeInfo(null, 'AG') == null);
-  assert('findGenotypeInfo: missing genotype → null', dna.findGenotypeInfo(nonPalEntry, '') == null);
-  assert('findGenotypeInfo: entry without genotypes → null', dna.findGenotypeInfo({}, 'AG') == null);
+// Empty / malformed inputs
+assert('findGenotypeInfo: null entry → null', dna.findGenotypeInfo(null, 'AG') == null);
+assert('findGenotypeInfo: missing genotype → null', dna.findGenotypeInfo(nonPalEntry, '') == null);
+assert('findGenotypeInfo: entry without genotypes → null', dna.findGenotypeInfo({}, 'AG') == null);
 
-  // ═══════════════════════════════════════
-  // 8. APOE haplotype
-  // ═══════════════════════════════════════
-  console.log('%c 8. APOE Haplotype ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 8. APOE haplotype
+// ═══════════════════════════════════════
+console.log('8. APOE Haplotype');
 
-  const profileData = {};
-  dna.saveGeneticsData(profileData, aResult);
-  assert('APOE resolved', profileData.genetics?.apoe != null, profileData.genetics?.apoe);
-  assert('APOE is ε3/ε4', profileData.genetics?.apoe === 'ε3/ε4');
+const profileData = {};
+dna.saveGeneticsData(profileData, aResult);
+assert('APOE resolved', profileData.genetics?.apoe != null, profileData.genetics?.apoe);
+assert('APOE is ε3/ε4', profileData.genetics?.apoe === 'ε3/ε4');
 
-  // ═══════════════════════════════════════
-  // 9. Storage
-  // ═══════════════════════════════════════
-  console.log('%c 9. Storage ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 9. Storage
+// ═══════════════════════════════════════
+console.log('9. Storage');
 
-  assert('genetics.source saved', profileData.genetics?.source === 'AncestryDNA');
-  assert('genetics.importDate saved', typeof profileData.genetics?.importDate === 'string');
-  assert('genetics.coverage saved', profileData.genetics?.coverage?.found > 0);
-  assert('genetics.snps is object', typeof profileData.genetics?.snps === 'object');
-  assert('SNP has genotype', profileData.genetics?.snps?.rs1801133?.genotype === 'GA');
-  assert('SNP has gene', profileData.genetics?.snps?.rs1801133?.gene === 'MTHFR');
-  assert('SNP has variant', profileData.genetics?.snps?.rs1801133?.variant === 'C677T');
+assert('genetics.source saved', profileData.genetics?.source === 'AncestryDNA');
+assert('genetics.importDate saved', typeof profileData.genetics?.importDate === 'string');
+assert('genetics.coverage saved', profileData.genetics?.coverage?.found > 0);
+assert('genetics.snps is object', typeof profileData.genetics?.snps === 'object');
+assert('SNP has genotype', profileData.genetics?.snps?.rs1801133?.genotype === 'GA');
+assert('SNP has gene', profileData.genetics?.snps?.rs1801133?.gene === 'MTHFR');
+assert('SNP has variant', profileData.genetics?.snps?.rs1801133?.variant === 'C677T');
 
-  // Delete
-  dna.deleteGeneticsData(profileData);
-  assert('deleteGeneticsData removes genetics', profileData.genetics === undefined);
+// Delete
+dna.deleteGeneticsData(profileData);
+assert('deleteGeneticsData removes genetics', profileData.genetics === undefined);
 
-  // ═══════════════════════════════════════
-  // 10. Context assembly
-  // ═══════════════════════════════════════
-  console.log('%c 10. Context Assembly ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 10. Context assembly
+// ═══════════════════════════════════════
+console.log('10. Context Assembly');
 
-  // Re-save for context tests
-  dna.saveGeneticsData(profileData, aResult);
+// Re-save for context tests
+dna.saveGeneticsData(profileData, aResult);
 
-  const fullCtx = dna.buildFullGeneticsContext(profileData.genetics);
-  assert('Full context includes GENETICS header', fullCtx.startsWith('GENETICS ('));
-  assert('Full context includes APOE', fullCtx.includes('APOE: ε3/ε4'));
-  assert('Full context includes MTHFR', fullCtx.includes('MTHFR C677T'));
-  assert('Full context excludes none-effect SNPs', !fullCtx.includes('Normal MTHFR'));
-  assert('Full context excludes APOE component SNPs', !fullCtx.includes('APOE-part1'));
+const fullCtx = dna.buildFullGeneticsContext(profileData.genetics);
+assert('Full context includes GENETICS header', fullCtx.startsWith('GENETICS ('));
+assert('Full context includes APOE', fullCtx.includes('APOE: ε3/ε4'));
+assert('Full context includes MTHFR', fullCtx.includes('MTHFR C677T'));
+assert('Full context excludes none-effect SNPs', !fullCtx.includes('Normal MTHFR'));
+assert('Full context excludes APOE component SNPs', !fullCtx.includes('APOE-part1'));
 
-  // Filtered context — only SNPs relevant to specific markers
-  const filteredCtx = dna.buildGeneticsContext(profileData.genetics, ['coagulation.homocysteine']);
-  assert('Filtered context includes MTHFR (maps to homocysteine)', filteredCtx.includes('MTHFR'));
-  assert('Filtered context excludes FADS1 (not in filter)', !filteredCtx.includes('FADS1'));
-  assert('Filtered context always includes APOE', filteredCtx.includes('APOE'));
+// Filtered context — only SNPs relevant to specific markers
+const filteredCtx = dna.buildGeneticsContext(profileData.genetics, ['coagulation.homocysteine']);
+assert('Filtered context includes MTHFR (maps to homocysteine)', filteredCtx.includes('MTHFR'));
+assert('Filtered context excludes FADS1 (not in filter)', !filteredCtx.includes('FADS1'));
+assert('Filtered context always includes APOE', filteredCtx.includes('APOE'));
 
-  // Empty genetics
-  const emptyCtx = dna.buildGeneticsContext(null, []);
-  assert('Null genetics = empty string', emptyCtx === '');
+// Empty genetics
+const emptyCtx = dna.buildGeneticsContext(null, []);
+assert('Null genetics = empty string', emptyCtx === '');
 
-  // ═══════════════════════════════════════
-  // 11. Window exports
-  // ═══════════════════════════════════════
-  console.log('%c 11. Window Exports ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 11. Window exports
+// ═══════════════════════════════════════
+console.log('11. Window Exports');
 
-  assert('window.isDNAFile exists', typeof window.isDNAFile === 'function');
-  assert('window.handleDNAFile exists', typeof window.handleDNAFile === 'function');
-  assert('window.confirmDNAImport exists', typeof window.confirmDNAImport === 'function');
-  assert('window.closeDNAImportPreview exists', typeof window.closeDNAImportPreview === 'function');
-  assert('window.deleteGeneticsData exists', typeof window.deleteGeneticsData === 'function');
-  assert('window._buildGeneticsContext exists', typeof window._buildGeneticsContext === 'function');
+assert('window.isDNAFile exists', typeof window.isDNAFile === 'function');
+assert('window.handleDNAFile exists', typeof window.handleDNAFile === 'function');
+assert('window.confirmDNAImport exists', typeof window.confirmDNAImport === 'function');
+assert('window.closeDNAImportPreview exists', typeof window.closeDNAImportPreview === 'function');
+assert('window.deleteGeneticsData exists', typeof window.deleteGeneticsData === 'function');
+assert('window._buildGeneticsContext exists', typeof window._buildGeneticsContext === 'function');
 
-  // ═══════════════════════════════════════
-  // 12. Source integration
-  // ═══════════════════════════════════════
-  console.log('%c 12. Source Integration ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 12. Source integration
+// ═══════════════════════════════════════
+console.log('12. Source Integration');
 
-  const mainSrc = await fetchWithRetry('js/main.js');
-  assert('main.js imports dna.js', mainSrc.includes("'./dna.js'"));
-  // DNA detection in the file-input path is now delegated to
-  // classifyImportFiles (pdf-import.js); main.js consumes the returned
-  // dnaFiles bucket. The downstream isDNAFile check still lives in the
-  // classifier and is asserted below.
-  assert('main.js routes DNA files via classifier', mainSrc.includes('classifyImportFiles') && mainSrc.includes('dnaFiles'));
-  assert('main.js calls handleDNAFile', mainSrc.includes('handleDNAFile'));
+const mainSrc = await fetchWithRetry('js/main.js');
+assert('main.js imports dna.js', mainSrc.includes("'./dna.js'"));
+// DNA detection in the file-input path is now delegated to
+// classifyImportFiles (pdf-import.js); main.js consumes the returned
+// dnaFiles bucket. The downstream isDNAFile check still lives in the
+// classifier and is asserted below.
+assert('main.js routes DNA files via classifier', mainSrc.includes('classifyImportFiles') && mainSrc.includes('dnaFiles'));
+assert('main.js calls handleDNAFile', mainSrc.includes('handleDNAFile'));
 
-  const pdfSrc = await fetchWithRetry('js/pdf-import.js');
-  assert('pdf-import.js checks isDNAFile in drop', pdfSrc.includes('isDNAFile'));
+const pdfSrc = await fetchWithRetry('js/pdf-import.js');
+assert('pdf-import.js checks isDNAFile in drop', pdfSrc.includes('isDNAFile'));
 
-  const labCtxSrc = await fetchWithRetry('js/lab-context.js');
-  assert('lab-context.js includes genetics in context', labCtxSrc.includes('_buildGeneticsContext'));
+const labCtxSrc = await fetchWithRetry('js/lab-context.js');
+assert('lab-context.js includes genetics in context', labCtxSrc.includes('_buildGeneticsContext'));
 
-  const indexSrc = await fetchWithRetry('/app');
-  assert('File input accepts .txt', indexSrc.includes('.txt'));
+const indexSrc = await fetchWithRetry('/app');
+assert('File input accepts .txt', indexSrc.includes('.txt'));
 
-  // ═══════════════════════════════════════
-  // 13. mtDNA Format Detection
-  // ═══════════════════════════════════════
-  console.log('%c 13. mtDNA Format Detection ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 13. mtDNA Format Detection
+// ═══════════════════════════════════════
+console.log('13. mtDNA Format Detection');
 
-  const mtdnaSample = '263G\n462T\n1438G\n2706G\n3010A\n4216C\n4769G\n7028T\n10398G\n11251G\n11719A\n12612G\n13708A\n15326G\n16069T\n16126C';
-  assert('detectDNAFile returns mtdna for mtDNA CSV', dna.detectDNAFile(mtdnaSample) === 'mtdna');
-  assert('isDNAFile recognizes mtdna.csv', dna.isDNAFile({ name: 'mtdna.csv' }));
-  assert('Autosomal still detects as 23andme', dna.detectDNAFile('# This data file generated by 23andMe\nrs123\t1\t100\tAG') === '23andme');
+const mtdnaSample = '263G\n462T\n1438G\n2706G\n3010A\n4216C\n4769G\n7028T\n10398G\n11251G\n11719A\n12612G\n13708A\n15326G\n16069T\n16126C';
+assert('detectDNAFile returns mtdna for mtDNA CSV', dna.detectDNAFile(mtdnaSample) === 'mtdna');
+assert('isDNAFile recognizes mtdna.csv', dna.isDNAFile({ name: 'mtdna.csv' }));
+assert('Autosomal still detects as 23andme', dna.detectDNAFile('# This data file generated by 23andMe\nrs123\t1\t100\tAG') === '23andme');
 
-  // ═══════════════════════════════════════
-  // 14. Haplogroup Functions
-  // ═══════════════════════════════════════
-  console.log('%c 14. Haplogroup Functions ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 14. Haplogroup Functions
+// ═══════════════════════════════════════
+console.log('14. Haplogroup Functions');
 
-  assert('handleMtDNAFile exists on window', typeof window.handleMtDNAFile === 'function');
-  assert('detectMtDNAMismatch exists on window', typeof window.detectMtDNAMismatch === 'function');
-  assert('ensureHaplogroupTable exists on window', typeof window.ensureHaplogroupTable === 'function');
-  assert('closeMtDNAPreview exists on window', typeof window.closeMtDNAPreview === 'function');
-  assert('confirmMtDNAImport exists on window', typeof window.confirmMtDNAImport === 'function');
-  assert('deleteMtDNAData exists on window', typeof window.deleteMtDNAData === 'function');
+assert('handleMtDNAFile exists on window', typeof window.handleMtDNAFile === 'function');
+assert('detectMtDNAMismatch exists on window', typeof window.detectMtDNAMismatch === 'function');
+assert('ensureHaplogroupTable exists on window', typeof window.ensureHaplogroupTable === 'function');
+assert('closeMtDNAPreview exists on window', typeof window.closeMtDNAPreview === 'function');
+assert('confirmMtDNAImport exists on window', typeof window.confirmMtDNAImport === 'function');
+assert('deleteMtDNAData exists on window', typeof window.deleteMtDNAData === 'function');
 
-  // ═══════════════════════════════════════
-  // 15. Haplogroup Data File
-  // ═══════════════════════════════════════
-  console.log('%c 15. Haplogroup Data File ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 15. Haplogroup Data File
+// ═══════════════════════════════════════
+console.log('15. Haplogroup Data File');
 
-  const hapData = await fetch('data/haplogroups.json').then(r => r.json());
-  assert('haplogroups.json loads', hapData != null);
-  assert('Has _meta', hapData._meta != null);
-  assert('Has haplogroups object', typeof hapData.haplogroups === 'object');
-  assert('Has couplingLevels', typeof hapData.couplingLevels === 'object');
-  const hgCount = Object.keys(hapData.haplogroups).length;
-  assert('Has 26+ haplogroups', hgCount >= 26, `got ${hgCount}`);
-  assert('Has J haplogroup', hapData.haplogroups.J != null);
-  assert('J has mutations array', Array.isArray(hapData.haplogroups.J.mutations));
-  assert('J coupling is uncoupled', hapData.haplogroups.J.coupling === 'uncoupled');
-  assert('H has isReference flag', hapData.haplogroups.H.isReference === true);
-  assert('All haplogroups have valid coupling keys', Object.values(hapData.haplogroups).every(h => hapData.couplingLevels[h.coupling]));
-  assert('References include Wallace 2015', hapData._meta.references.some(r => r.pmid === 26406369));
+const hapData = await fetch('data/haplogroups.json').then(r => r.json());
+assert('haplogroups.json loads', hapData != null);
+assert('Has _meta', hapData._meta != null);
+assert('Has haplogroups object', typeof hapData.haplogroups === 'object');
+assert('Has couplingLevels', typeof hapData.couplingLevels === 'object');
+const hgCount = Object.keys(hapData.haplogroups).length;
+assert('Has 26+ haplogroups', hgCount >= 26, `got ${hgCount}`);
+assert('Has J haplogroup', hapData.haplogroups.J != null);
+assert('J has mutations array', Array.isArray(hapData.haplogroups.J.mutations));
+assert('J coupling is uncoupled', hapData.haplogroups.J.coupling === 'uncoupled');
+assert('H has isReference flag', hapData.haplogroups.H.isReference === true);
+assert('All haplogroups have valid coupling keys', Object.values(hapData.haplogroups).every(h => hapData.couplingLevels[h.coupling]));
+assert('References include Wallace 2015', hapData._meta.references.some(r => r.pmid === 26406369));
 
-  // ═══════════════════════════════════════
-  // 16. mtDNA Storage and Context
-  // ═══════════════════════════════════════
-  console.log('%c 16. mtDNA Storage & Context ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 16. mtDNA Storage and Context
+// ═══════════════════════════════════════
+console.log('16. mtDNA Storage & Context');
 
-  // Save original genetics
-  const origGenetics = window._labState.importedData.genetics;
+// Save original genetics
+const origGenetics = window._labState.importedData.genetics;
 
-  // Simulate mtDNA import
-  const testGenetics = origGenetics ? JSON.parse(JSON.stringify(origGenetics)) : { source: null, importDate: null, coverage: { found: 0, total: 0 }, effects: {}, snps: {} };
-  testGenetics.mtdna = {
-    haplogroup: 'J', confidence: 0.78,
-    coupling: { level: 'uncoupled', label: 'Uncoupled (more heat, less ATP)', shortLabel: 'uncoupled', climate: 'Cold (Northern European)', matchedLatBands: [3, 4] },
-    mutations: ['295T', '4216C', '10398G', '13708A', '16069T', '16126C', '11251G'],
-    source: 'mtDNA CSV', importDate: '2026-03-26'
-  };
-  window._labState.importedData.genetics = testGenetics;
+// Simulate mtDNA import
+const testGenetics = origGenetics ? JSON.parse(JSON.stringify(origGenetics)) : { source: null, importDate: null, coverage: { found: 0, total: 0 }, effects: {}, snps: {} };
+testGenetics.mtdna = {
+  haplogroup: 'J', confidence: 0.78,
+  coupling: { level: 'uncoupled', label: 'Uncoupled (more heat, less ATP)', shortLabel: 'uncoupled', climate: 'Cold (Northern European)', matchedLatBands: [3, 4] },
+  mutations: ['295T', '4216C', '10398G', '13708A', '16069T', '16126C', '11251G'],
+  source: 'mtDNA CSV', importDate: '2026-03-26'
+};
+window._labState.importedData.genetics = testGenetics;
 
-  // Test context includes haplogroup
-  const ctx = window._buildGeneticsContext(testGenetics, null);
-  assert('Context includes mtDNA haplogroup', ctx.includes('mtDNA Haplogroup: J'));
-  assert('Context includes coupling label', ctx.includes('Uncoupled'));
+// Test context includes haplogroup
+const ctx = window._buildGeneticsContext(testGenetics, null);
+assert('Context includes mtDNA haplogroup', ctx.includes('mtDNA Haplogroup: J'));
+assert('Context includes coupling label', ctx.includes('Uncoupled'));
 
-  // Test mismatch with no location → null
-  const noLocMismatch = window.detectMtDNAMismatch(testGenetics);
-  // May be null if no location, or may have a result — just check it doesn't throw
-  assert('detectMtDNAMismatch does not throw', true);
+// Test mismatch with no location → null
+const noLocMismatch = window.detectMtDNAMismatch(testGenetics);
+// May be null if no location, or may have a result — just check it doesn't throw
+assert('detectMtDNAMismatch does not throw', true);
 
-  // Test storage merge — mtdna doesn't wipe existing snps
-  const hasSnps = testGenetics.snps && Object.keys(testGenetics.snps).length > 0;
-  const hasMtdna = testGenetics.mtdna != null;
-  assert('mtDNA coexists with autosomal SNPs', hasMtdna && (hasSnps || !origGenetics?.snps));
+// Test storage merge — mtdna doesn't wipe existing snps
+const hasSnps = testGenetics.snps && Object.keys(testGenetics.snps).length > 0;
+const hasMtdna = testGenetics.mtdna != null;
+assert('mtDNA coexists with autosomal SNPs', hasMtdna && (hasSnps || !origGenetics?.snps));
 
-  // Test delete
-  delete testGenetics.mtdna;
-  assert('mtDNA deletable without affecting snps', testGenetics.snps != null && testGenetics.mtdna == null);
+// Test delete
+delete testGenetics.mtdna;
+assert('mtDNA deletable without affecting snps', testGenetics.snps != null && testGenetics.mtdna == null);
 
-  // Restore
-  window._labState.importedData.genetics = origGenetics;
+// Restore
+window._labState.importedData.genetics = origGenetics;
 
-  // ═══════════════════════════════════════
-  // Results
-  // ═══════════════════════════════════════
-  console.log(`\n%c Tests complete: ${pass} passed, ${fail} failed `, fail ? 'background:#ef4444;color:#fff;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;padding:4px 12px;border-radius:4px');
-  if (typeof window.__TEST_RESULTS !== 'undefined') window.__TEST_RESULTS = { pass, fail };
-})();
+// ═══════════════════════════════════════
+// Results
+// ═══════════════════════════════════════
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Ports `test-dna.js` (121 asserts) and `test-dna-illumina-and-valence.js` (133 asserts) from the Puppeteer runner to Vitest — 254 asserts total. Both are pure parser/storage/context tests: `parseDNAFile` spins a Blob-backed Worker, `renderGeneticsSection` returns an HTML string with no DOM dependency.
- Adds a **synchronous Worker shim** to `_node-shim.js` (+ `_vitest-setup.js`, kept in sync). It runs self-contained pure-JS workers in-process: registers the Blob passed to `URL.createObjectURL`, executes the worker source with a `self` object on first `postMessage`, and routes the worker's `self.postMessage` back to the main-side `onmessage`. **No** `importScripts`/network/WASM support — `test-lens-local-worker.js` (transformers.js WASM) stays on Puppeteer.
- Vitest: 81 → 83 tests. Puppeteer originals: 32 → 30.

## Test plan
- [x] `node tests/test-dna.js` → 121/121
- [x] `node tests/test-dna-illumina-and-valence.js` → 133/133
- [x] `npx vitest run` → 83 tests pass
- [x] `./run-tests.sh` → all green (node-side + Puppeteer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)