### PR TITLE
Vitest batch 36: family-history (DOM-split) + emf-flow

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -49,7 +49,10 @@ const TEST_FILES = [
   'tests/test-image-utils-dom.js',
   // test-emf.js fully ported to Vitest (batch 26) — pure-logic + module
   // imports, no DOM-runtime sections.
-  'tests/test-emf-flow.js',
+  // test-emf-flow.js fully ported to Vitest (batch 36) — CRUD/state asserts
+  // are pure mutations; render/modal/photo/interpretation paths are
+  // coverage-only (try/catch + "X ran") and degrade gracefully against the
+  // Node DOM stub.
   // test-dna.js + test-dna-illumina-and-valence.js fully ported to Vitest
   // (batch 35) — parseDNAFile's Blob-backed Worker runs via the synchronous
   // Worker shim in _node-shim.js; renderGeneticsSection is a pure HTML-string
@@ -91,7 +94,11 @@ const TEST_FILES = [
   'tests/test-silhouette-region-map.js',
   'tests/test-sun-ui-flow.js',
   'tests/test-audit-fixes.js',
-  'tests/test-family-history.js',
+  // test-family-history.js source-inspection + getConditionsSummary ported
+  // to Vitest (batch 36). DOM-runtime sections — the apostrophe round-trip
+  // probe + the live add/delete handler test against #detail-modal — live
+  // in test-family-history-dom.js below.
+  'tests/test-family-history-dom.js',
   // Extracted from test-v1-6-shipped.js (PR #204) — the live-DOM
   // assertion can't run in Node + ES modules can't run via the
   // puppeteer `Function(s)()` evaluator, so the modal-render check

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -196,6 +196,13 @@ const LEGACY_TESTS = [
   // renderGeneticsSection returns an HTML string with no DOM dependency.
   './test-dna.js',
   './test-dna-illumina-and-valence.js',
+  // Batch 36 — family-history (source-inspection + getConditionsSummary;
+  // the apostrophe round-trip probe + live add/delete handler test stay on
+  // puppeteer in test-family-history-dom.js) and emf-flow (CRUD/state
+  // assertions are pure mutations; render/modal/photo/interpretation paths
+  // are coverage-only behind try/catch + "X ran").
+  './test-family-history.js',
+  './test-emf-flow.js',
 ];
 
 for (const path of LEGACY_TESTS) {

--- a/tests/test-emf-flow.js
+++ b/tests/test-emf-flow.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // test-emf-flow.js — Behavioral coverage of the EMF module (js/emf.js).
 //
 // Complements test-emf.js, which exercises the SBM-2015 threshold schema in
@@ -7,201 +8,225 @@
 // facade so V8 records every function as called, AND asserts the state
 // mutations a user would observe.
 //
-// Every async window function is wrapped in a hard 1.5s timeout — the
-// interpret/PDF flows open modals that wait for user input and would block
-// the runner indefinitely otherwise.
+// Run: node tests/test-emf-flow.js  (or via npm test)
+//
+// Full port — the CRUD/state assertions are pure object mutations; the
+// render / modal / photo / interpretation paths are coverage-only (wrapped
+// in try/catch or withTimeout, asserting only "X ran"), so they degrade
+// gracefully against the Node DOM stub. Every async window function is
+// wrapped in a hard 1.5s timeout — the interpret/PDF flows open modals that
+// wait for user input and would block the runner indefinitely otherwise.
 
-return (async () => {
-  let pass = 0, fail = 0;
-  const assert = (name, cond, detail) => {
-    if (cond) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-  };
-  const withTimeout = (fn, ms = 1500) => Promise.race([
-    Promise.resolve().then(fn).catch(() => {}),
-    new Promise(r => setTimeout(r, ms)),
-  ]);
+import './_node-shim.js';
 
-  console.log('%c EMF Flow Tests ', 'background:#8b5cf6;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+// emf.js's render functions write into #detail-modal / #modal-overlay,
+// which exist in index.html's skeleton but not in the Node DOM stub. Hand
+// back a persistent stub element for those two IDs so renderEMFEditor's
+// `modal.innerHTML = html` doesn't throw on null — the render output is
+// coverage-only; every assertion here checks state mutations or "X ran".
+const _modalStub = () => ({
+  style: {}, classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+  appendChild() {}, remove() {}, setAttribute() {}, getAttribute() { return null; },
+  addEventListener() {}, removeEventListener() {},
+  querySelector() { return null; }, querySelectorAll() { return []; },
+  children: [], childNodes: [], innerHTML: '', textContent: '', value: '',
+});
+const _stubsById = {};
+const _origGetById = document.getElementById.bind(document);
+document.getElementById = (id) =>
+  (id === 'detail-modal' || id === 'modal-overlay')
+    ? (_stubsById[id] || (_stubsById[id] = _modalStub()))
+    : _origGetById(id);
 
-  // Bring in the actual modules — dynamic import forces parse + top-level
-  // execution, which is what registers the window facade.
-  const { state } = await import('/js/state.js');
-  await import('/js/emf.js?bust=' + Date.now());
-  await import('/js/data.js?bust=' + Date.now()); // saveImportedData lives here
+let pass = 0, fail = 0;
+const assert = (name, cond, detail) => {
+  if (cond) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+};
+const withTimeout = (fn, ms = 1500) => Promise.race([
+  Promise.resolve().then(fn).catch(() => {}),
+  new Promise(r => setTimeout(r, ms)),
+]);
 
-  assert('emf.js window facade loaded', typeof window.addEMFAssessment === 'function');
+console.log('=== EMF Flow Tests ===\n');
 
-  // Snapshot the existing emfAssessment subtree so we can restore it at the
-  // end and not pollute downstream tests (test-wearables-bp-merge has been
-  // observed to fail when state from this test bleeds over).
-  const _origEmf = state.importedData?.emfAssessment
-    ? JSON.parse(JSON.stringify(state.importedData.emfAssessment))
-    : null;
+// Bring in the actual modules — dynamic import forces parse + top-level
+// execution, which is what registers the window facade.
+const { state } = await import('../js/state.js');
+await import('../js/emf.js');
+await import('../js/data.js'); // saveImportedData lives here
 
-  state.importedData = state.importedData || {};
-  state.importedData.emfAssessment = { assessments: [], compareMode: false };
+assert('emf.js window facade loaded', typeof window.addEMFAssessment === 'function');
 
-  // ── 1. Assessment CRUD ────────────────────────────────────────────────
-  const beforeAdd = state.importedData.emfAssessment.assessments.length;
-  window.addEMFAssessment();
-  const afterAdd = state.importedData.emfAssessment.assessments.length;
-  assert('addEMFAssessment appends one assessment', afterAdd === beforeAdd + 1);
+// Snapshot the existing emfAssessment subtree so we can restore it at the
+// end and not pollute downstream tests (test-wearables-bp-merge has been
+// observed to fail when state from this test bleeds over).
+const _origEmf = state.importedData?.emfAssessment
+  ? JSON.parse(JSON.stringify(state.importedData.emfAssessment))
+  : null;
 
-  const asmId = state.importedData.emfAssessment.assessments[afterAdd - 1].id;
-  assert('New assessment has a string id', typeof asmId === 'string' && asmId.length > 0);
+state.importedData = state.importedData || {};
+state.importedData.emfAssessment = { assessments: [], compareMode: false };
 
-  window.updateEMFField(asmId, 'name', 'Coverage Probe');
-  const asm = state.importedData.emfAssessment.assessments.find(a => a.id === asmId);
-  assert('updateEMFField writes name', asm.name === 'Coverage Probe');
+// ── 1. Assessment CRUD ────────────────────────────────────────────────
+const beforeAdd = state.importedData.emfAssessment.assessments.length;
+window.addEMFAssessment();
+const afterAdd = state.importedData.emfAssessment.assessments.length;
+assert('addEMFAssessment appends one assessment', afterAdd === beforeAdd + 1);
 
-  window.updateEMFField(asmId, 'notes', 'Multi-line\nnotes here');
-  assert('updateEMFField writes notes', asm.notes === 'Multi-line\nnotes here');
+const asmId = state.importedData.emfAssessment.assessments[afterAdd - 1].id;
+assert('New assessment has a string id', typeof asmId === 'string' && asmId.length > 0);
 
-  // ── 2. Room CRUD ──────────────────────────────────────────────────────
-  // A new assessment ships with one default room (newRoom() inside emf.js).
-  const startingRooms = asm.rooms.length;
-  assert('New assessment has a default room', startingRooms >= 1);
+window.updateEMFField(asmId, 'name', 'Coverage Probe');
+const asm = state.importedData.emfAssessment.assessments.find(a => a.id === asmId);
+assert('updateEMFField writes name', asm.name === 'Coverage Probe');
 
-  window.addEMFRoom(asmId);
-  assert('addEMFRoom adds room', asm.rooms.length === startingRooms + 1);
+window.updateEMFField(asmId, 'notes', 'Multi-line\nnotes here');
+assert('updateEMFField writes notes', asm.notes === 'Multi-line\nnotes here');
 
-  window.updateEMFRoom(asmId, 0, 'name', 'Bedroom');
-  assert('updateEMFRoom updates name', asm.rooms[0].name === 'Bedroom');
+// ── 2. Room CRUD ──────────────────────────────────────────────────────
+// A new assessment ships with one default room (newRoom() inside emf.js).
+const startingRooms = asm.rooms.length;
+assert('New assessment has a default room', startingRooms >= 1);
 
-  window.updateEMFRoom(asmId, 0, 'location', 'east-facing wall');
-  assert('updateEMFRoom updates location', asm.rooms[0].location === 'east-facing wall');
+window.addEMFRoom(asmId);
+assert('addEMFRoom adds room', asm.rooms.length === startingRooms + 1);
 
-  // ── 3. Measurement + meter flow ──────────────────────────────────────
-  // updateEMFMeasurement stores `{ value, unit, meter }` — not the raw number.
-  // updateEMFMeter writes into the SAME nested object's `.meter` field, so
-  // the measurement must exist first.
-  window.updateEMFMeasurement(asmId, 0, 'acElectric', 12);
-  assert('updateEMFMeasurement stores nested value object',
-    asm.rooms[0].measurements?.acElectric?.value === 12);
-  assert('updateEMFMeasurement also tags the unit',
-    typeof asm.rooms[0].measurements.acElectric.unit === 'string');
+window.updateEMFRoom(asmId, 0, 'name', 'Bedroom');
+assert('updateEMFRoom updates name', asm.rooms[0].name === 'Bedroom');
 
-  window.updateEMFMeasurement(asmId, 0, 'rfMicrowave', 250);
-  window.updateEMFMeasurement(asmId, 0, 'acMagnetic', 80);
-  window.updateEMFMeasurement(asmId, 0, 'dirtyElectricity', 40);
-  assert('Multiple measurement types coexist',
-    Object.keys(asm.rooms[0].measurements).length >= 4);
+window.updateEMFRoom(asmId, 0, 'location', 'east-facing wall');
+assert('updateEMFRoom updates location', asm.rooms[0].location === 'east-facing wall');
 
-  window.updateEMFMeter(asmId, 0, 'acElectric', 'Safe and Sound EM3');
-  assert('updateEMFMeter writes into measurement.meter',
-    asm.rooms[0].measurements.acElectric.meter === 'Safe and Sound EM3');
+// ── 3. Measurement + meter flow ──────────────────────────────────────
+// updateEMFMeasurement stores `{ value, unit, meter }` — not the raw number.
+// updateEMFMeter writes into the SAME nested object's `.meter` field, so
+// the measurement must exist first.
+window.updateEMFMeasurement(asmId, 0, 'acElectric', 12);
+assert('updateEMFMeasurement stores nested value object',
+  asm.rooms[0].measurements?.acElectric?.value === 12);
+assert('updateEMFMeasurement also tags the unit',
+  typeof asm.rooms[0].measurements.acElectric.unit === 'string');
 
-  // Clear path: passing '' deletes the measurement.
-  window.updateEMFMeasurement(asmId, 0, 'dirtyElectricity', '');
-  assert('updateEMFMeasurement with empty value clears',
-    asm.rooms[0].measurements.dirtyElectricity === undefined);
+window.updateEMFMeasurement(asmId, 0, 'rfMicrowave', 250);
+window.updateEMFMeasurement(asmId, 0, 'acMagnetic', 80);
+window.updateEMFMeasurement(asmId, 0, 'dirtyElectricity', 40);
+assert('Multiple measurement types coexist',
+  Object.keys(asm.rooms[0].measurements).length >= 4);
 
-  // ── 4. Selection + render (need minimal modal DOM) ───────────────────
-  for (const id of ['modal-overlay', 'detail-modal']) {
-    if (!document.getElementById(id)) {
-      const el = document.createElement('div'); el.id = id; el.style.display = 'none'; document.body.appendChild(el);
-    }
+window.updateEMFMeter(asmId, 0, 'acElectric', 'Safe and Sound EM3');
+assert('updateEMFMeter writes into measurement.meter',
+  asm.rooms[0].measurements.acElectric.meter === 'Safe and Sound EM3');
+
+// Clear path: passing '' deletes the measurement.
+window.updateEMFMeasurement(asmId, 0, 'dirtyElectricity', '');
+assert('updateEMFMeasurement with empty value clears',
+  asm.rooms[0].measurements.dirtyElectricity === undefined);
+
+// ── 4. Selection + render (need minimal modal DOM) ───────────────────
+for (const id of ['modal-overlay', 'detail-modal']) {
+  if (!document.getElementById(id)) {
+    const el = document.createElement('div'); el.id = id; el.style.display = 'none'; document.body.appendChild(el);
   }
+}
 
-  try { window.openEMFAssessmentEditor(); } catch (_) {}
-  assert('openEMFAssessmentEditor ran', true);
+try { window.openEMFAssessmentEditor(); } catch (_) {}
+assert('openEMFAssessmentEditor ran', true);
 
-  try { window.toggleEMFAssessment(asmId); } catch (_) {}
-  assert('toggleEMFAssessment ran', true);
+try { window.toggleEMFAssessment(asmId); } catch (_) {}
+assert('toggleEMFAssessment ran', true);
 
-  try { window.selectEMFRoom(asmId, 0); } catch (_) {}
-  assert('selectEMFRoom ran', true);
+try { window.selectEMFRoom(asmId, 0); } catch (_) {}
+assert('selectEMFRoom ran', true);
 
-  await withTimeout(() => window.handleEMFRoomDropdown(asmId, 0, '0', { value: '0' }));
-  assert('handleEMFRoomDropdown ran', true);
+await withTimeout(() => window.handleEMFRoomDropdown(asmId, 0, '0', { value: '0' }));
+assert('handleEMFRoomDropdown ran', true);
 
-  // Compare view: needs ≥ 2 assessments. Add a second.
-  window.addEMFAssessment();
-  const secondId = state.importedData.emfAssessment.assessments.at(-1).id;
-  try { window.toggleEMFCompare(); } catch (_) {}
-  assert('toggleEMFCompare ran (with 2 assessments)', true);
-  try { window.toggleEMFCompare(); } catch (_) {} // toggle off
+// Compare view: needs ≥ 2 assessments. Add a second.
+window.addEMFAssessment();
+const secondId = state.importedData.emfAssessment.assessments.at(-1).id;
+try { window.toggleEMFCompare(); } catch (_) {}
+assert('toggleEMFCompare ran (with 2 assessments)', true);
+try { window.toggleEMFCompare(); } catch (_) {} // toggle off
 
-  // ── 5. Photos (FileReader path) ──────────────────────────────────────
-  // 1×1 PNG so the read actually succeeds (otherwise the photo never lands
-  // and removeEMFPhoto's index would be invalid).
-  const tinyPng = new Uint8Array([
-    0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a, 0x00,0x00,0x00,0x0d,0x49,0x48,0x44,0x52,
-    0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01, 0x08,0x06,0x00,0x00,0x00,0x1f,0x15,0xc4,
-    0x89,0x00,0x00,0x00,0x0a,0x49,0x44,0x41, 0x54,0x78,0x9c,0x63,0x00,0x01,0x00,0x00,
-    0x05,0x00,0x01,0x0d,0x0a,0x2d,0xb4,0x00, 0x00,0x00,0x00,0x49,0x45,0x4e,0x44,0xae,
-    0x42,0x60,0x82,
-  ]);
-  const photoFile = new File([tinyPng], 'probe.png', { type: 'image/png' });
-  await withTimeout(() => window.addEMFPhotos(asmId, 0, [photoFile]));
-  assert('addEMFPhotos ran', true);
+// ── 5. Photos (FileReader path) ──────────────────────────────────────
+// 1×1 PNG so the read actually succeeds (otherwise the photo never lands
+// and removeEMFPhoto's index would be invalid).
+const tinyPng = new Uint8Array([
+  0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a, 0x00,0x00,0x00,0x0d,0x49,0x48,0x44,0x52,
+  0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01, 0x08,0x06,0x00,0x00,0x00,0x1f,0x15,0xc4,
+  0x89,0x00,0x00,0x00,0x0a,0x49,0x44,0x41, 0x54,0x78,0x9c,0x63,0x00,0x01,0x00,0x00,
+  0x05,0x00,0x01,0x0d,0x0a,0x2d,0xb4,0x00, 0x00,0x00,0x00,0x49,0x45,0x4e,0x44,0xae,
+  0x42,0x60,0x82,
+]);
+const photoFile = new File([tinyPng], 'probe.png', { type: 'image/png' });
+await withTimeout(() => window.addEMFPhotos(asmId, 0, [photoFile]));
+assert('addEMFPhotos ran', true);
 
-  try { window.viewEMFPhoto(asmId, 0, 0); } catch (_) {}
-  assert('viewEMFPhoto ran', true);
+try { window.viewEMFPhoto(asmId, 0, 0); } catch (_) {}
+assert('viewEMFPhoto ran', true);
 
-  try { window.removeEMFPhoto(asmId, 0, 0); } catch (_) {}
-  assert('removeEMFPhoto ran', true);
+try { window.removeEMFPhoto(asmId, 0, 0); } catch (_) {}
+assert('removeEMFPhoto ran', true);
 
-  // ── 6. Interpretation flow (stub the AI; bound with a timeout) ───────
-  // streamInterpretation calls window.callClaudeAPI internally. interpret*
-  // functions open modals that wait on user clicks — they don't return
-  // promises, but their internal streamInterpretation IS async. Stub the AI
-  // so it resolves immediately; the modal stays open until we don't care
-  // anymore (closed by closeEMFInterpretation below).
-  const origCallAI = window.callClaudeAPI;
-  window.callClaudeAPI = async () => ({ text: 'Stub interpretation', usage: { inputTokens: 1, outputTokens: 1 } });
-  try { window.interpretEMFAssessment(asmId); } catch (_) {}
-  assert('interpretEMFAssessment ran', true);
-  try { window.interpretEMFComparison(); } catch (_) {}
-  assert('interpretEMFComparison ran', true);
-  // Drain microtasks so the stubbed AI promises resolve.
-  await new Promise(r => setTimeout(r, 50));
-  window.callClaudeAPI = origCallAI;
+// ── 6. Interpretation flow (stub the AI; bound with a timeout) ───────
+// streamInterpretation calls window.callClaudeAPI internally. interpret*
+// functions open modals that wait on user clicks — they don't return
+// promises, but their internal streamInterpretation IS async. Stub the AI
+// so it resolves immediately; the modal stays open until we don't care
+// anymore (closed by closeEMFInterpretation below).
+const origCallAI = window.callClaudeAPI;
+window.callClaudeAPI = async () => ({ text: 'Stub interpretation', usage: { inputTokens: 1, outputTokens: 1 } });
+try { window.interpretEMFAssessment(asmId); } catch (_) {}
+assert('interpretEMFAssessment ran', true);
+try { window.interpretEMFComparison(); } catch (_) {}
+assert('interpretEMFComparison ran', true);
+// Drain microtasks so the stubbed AI promises resolve.
+await new Promise(r => setTimeout(r, 50));
+window.callClaudeAPI = origCallAI;
 
-  try { window.closeEMFInterpretation(); } catch (_) {}
-  assert('closeEMFInterpretation ran', true);
+try { window.closeEMFInterpretation(); } catch (_) {}
+assert('closeEMFInterpretation ran', true);
 
-  try { window.discussEMFInterpretation(); } catch (_) {}
-  assert('discussEMFInterpretation ran', true);
+try { window.discussEMFInterpretation(); } catch (_) {}
+assert('discussEMFInterpretation ran', true);
 
-  // ── 7. PDF import path (stubbed) ─────────────────────────────────────
-  const origParsePDF = window.parsePDFFile;
-  window.parsePDFFile = async () => 'EMF assessment\nBedroom\nacElectric: 12 V/m\n';
-  window.callClaudeAPI = async () => ({ text: JSON.stringify({ assessments: [] }), usage: { inputTokens: 1, outputTokens: 1 } });
-  const fakePdf = new File([new Uint8Array(10)], 'probe.pdf', { type: 'application/pdf' });
-  await withTimeout(() => window.handleEMFPDF(fakePdf));
-  assert('handleEMFPDF ran', true);
-  window.parsePDFFile = origParsePDF;
-  window.callClaudeAPI = origCallAI;
+// ── 7. PDF import path (stubbed) ─────────────────────────────────────
+const origParsePDF = window.parsePDFFile;
+window.parsePDFFile = async () => 'EMF assessment\nBedroom\nacElectric: 12 V/m\n';
+window.callClaudeAPI = async () => ({ text: JSON.stringify({ assessments: [] }), usage: { inputTokens: 1, outputTokens: 1 } });
+const fakePdf = new File([new Uint8Array(10)], 'probe.pdf', { type: 'application/pdf' });
+await withTimeout(() => window.handleEMFPDF(fakePdf));
+assert('handleEMFPDF ran', true);
+window.parsePDFFile = origParsePDF;
+window.callClaudeAPI = origCallAI;
 
-  // ── 8. removeEMFRoom + deleteEMFAssessment ───────────────────────────
-  window.addEMFRoom(asmId);
-  const beforeRm = asm.rooms.length;
-  try { window.removeEMFRoom(asmId, asm.rooms.length - 1); } catch (_) {}
-  assert('removeEMFRoom decrements room count', asm.rooms.length === beforeRm - 1);
+// ── 8. removeEMFRoom + deleteEMFAssessment ───────────────────────────
+window.addEMFRoom(asmId);
+const beforeRm = asm.rooms.length;
+try { window.removeEMFRoom(asmId, asm.rooms.length - 1); } catch (_) {}
+assert('removeEMFRoom decrements room count', asm.rooms.length === beforeRm - 1);
 
-  // deleteEMFAssessment awaits showConfirmDialog (imported directly from
-  // utils.js — ES module bindings are read-only, so we can't stub it
-  // post-import). The fn opens a real overlay dialog that nobody clicks;
-  // the await hangs until withTimeout cancels. The function IS entered
-  // (V8 marks it called), which is the coverage goal. We just need an
-  // assertion that doesn't depend on the actual delete happening.
-  await withTimeout(() => window.deleteEMFAssessment(secondId));
-  await withTimeout(() => window.deleteEMFAssessment(asmId));
-  assert('deleteEMFAssessment called without throwing', true);
+// deleteEMFAssessment awaits showConfirmDialog (imported directly from
+// utils.js — ES module bindings are read-only, so we can't stub it
+// post-import). The fn opens a real overlay dialog that nobody clicks;
+// the await hangs until withTimeout cancels. The function IS entered
+// (V8 marks it called), which is the coverage goal. We just need an
+// assertion that doesn't depend on the actual delete happening.
+await withTimeout(() => window.deleteEMFAssessment(secondId));
+await withTimeout(() => window.deleteEMFAssessment(asmId));
+assert('deleteEMFAssessment called without throwing', true);
 
-  // ── 9. saveEMFExplicit ───────────────────────────────────────────────
-  try { window.saveEMFExplicit(); } catch (_) {}
-  assert('saveEMFExplicit ran', true);
+// ── 9. saveEMFExplicit ───────────────────────────────────────────────
+try { window.saveEMFExplicit(); } catch (_) {}
+assert('saveEMFExplicit ran', true);
 
-  // Restore the snapshot so downstream tests see the same emfAssessment
-  // they expected. This is the load-bearing cleanup — without it,
-  // test-wearables-bp-merge has been observed to fail because saveEMFExplicit
-  // persisted our probe data over its expected fixtures.
-  if (_origEmf) state.importedData.emfAssessment = _origEmf;
-  else delete state.importedData.emfAssessment;
+// Restore the snapshot so downstream tests see the same emfAssessment
+// they expected. This is the load-bearing cleanup — without it,
+// test-wearables-bp-merge has been observed to fail because saveEMFExplicit
+// persisted our probe data over its expected fixtures.
+if (_origEmf) state.importedData.emfAssessment = _origEmf;
+else delete state.importedData.emfAssessment;
 
-  console.log(`\n%c EMF Flow Result: ${pass} passed, ${fail} failed `,
-    `background:${fail ? '#ef4444' : '#22c55e'};color:#fff;font-size:13px;padding:3px 10px;border-radius:3px`);
-})();
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-emf-flow.js
+++ b/tests/test-emf-flow.js
@@ -123,13 +123,7 @@ window.updateEMFMeasurement(asmId, 0, 'dirtyElectricity', '');
 assert('updateEMFMeasurement with empty value clears',
   asm.rooms[0].measurements.dirtyElectricity === undefined);
 
-// ── 4. Selection + render (need minimal modal DOM) ───────────────────
-for (const id of ['modal-overlay', 'detail-modal']) {
-  if (!document.getElementById(id)) {
-    const el = document.createElement('div'); el.id = id; el.style.display = 'none'; document.body.appendChild(el);
-  }
-}
-
+// ── 4. Selection + render (modal stub provided by the top-level getElementById patch) ───
 try { window.openEMFAssessmentEditor(); } catch (_) {}
 assert('openEMFAssessmentEditor ran', true);
 
@@ -227,6 +221,14 @@ assert('saveEMFExplicit ran', true);
 // persisted our probe data over its expected fixtures.
 if (_origEmf) state.importedData.emfAssessment = _origEmf;
 else delete state.importedData.emfAssessment;
+
+// Restore the original getElementById — the patch is installed at module
+// top-level, and the legacy runner's beforeEach doesn't reset `document`.
+// Leaving it in place would hand the #detail-modal / #modal-overlay stub
+// to any later test that queries those IDs (the PR #199 fetch-shim leak
+// pattern). All assertions above are collected, never thrown, so
+// execution always reaches here.
+document.getElementById = _origGetById;
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-family-history-dom.js
+++ b/tests/test-family-history-dom.js
@@ -1,0 +1,128 @@
+// test-family-history-dom.js — DOM-runtime slice of test-family-history.js.
+//
+// The source-inspection + pure-function coverage (COMMON_CONDITIONS,
+// getConditionsSummary, the rename strings, CSS hooks, the regex guards)
+// lives in tests/test-family-history.js on the Vitest runner. This file
+// keeps only what genuinely needs a browser DOM:
+//   - the apostrophe-condition round-trip probe (innerHTML parsing of an
+//     inline onmousedown handler + dispatchEvent)
+//   - the live addFamilyHistoryEntry / deleteFamilyHistoryEntry handler
+//     test, which reads #fh-* inputs and re-renders renderDiagnosesModal
+//     against a live #detail-modal
+//
+// Run: fetch('tests/test-family-history-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Family History — DOM-runtime Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const cards = await import('../js/context-cards.js');
+  const state = (await import('../js/state.js')).state;
+
+  // ═══════════════════════════════════════
+  // 1. Apostrophe-condition click round-trip
+  // ═══════════════════════════════════════
+  console.log('%c 1. Apostrophe click round-trip ', 'font-weight:bold;color:#f59e0b');
+
+  // Simulate the round-trip in-page: build a tiny DOM, click, observe.
+  const probe = document.createElement('div');
+  probe.innerHTML = `<input id="probe-cond-input"><div id="probe-target"></div>`;
+  document.body.appendChild(probe);
+  try {
+    // Synthesize the suggestion HTML the same way filterConditionSuggestions does.
+    const m = "Alzheimer's Disease";
+    // The library escapeHTML lives in utils.js — re-implement minimally for the probe.
+    const escapeHTML = (s) => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    const target = document.getElementById('probe-target');
+    target.innerHTML = `<div class="ctx-suggestion-item" id="probe-suggest" onmousedown="document.getElementById('probe-cond-input').value = ${escapeHTML(JSON.stringify(m))}">${escapeHTML(m)}</div>`;
+    // Simulate the click.
+    const evt = new MouseEvent('mousedown', { bubbles: true });
+    document.getElementById('probe-suggest').dispatchEvent(evt);
+    const result = document.getElementById('probe-cond-input').value;
+    assert("Apostrophe condition (Alzheimer's Disease) round-trips through inline onmousedown",
+      result === "Alzheimer's Disease", `got: "${result}"`);
+  } finally {
+    probe.remove();
+  }
+
+  // ═══════════════════════════════════════
+  // 2. Live addFamilyHistoryEntry / deleteFamilyHistoryEntry
+  // ═══════════════════════════════════════
+  console.log('%c 2. Live add/delete handler ', 'font-weight:bold;color:#f59e0b');
+
+  // State-manipulation: live-call the handler against fake DOM inputs, verify
+  // mutation. Wrap in try/catch because addFamilyHistoryEntry re-renders the
+  // modal via renderDiagnosesModal(document.getElementById("detail-modal"))
+  // and that node might not be visible in every test-runner state. We care
+  // about the data mutation; the render is exercised separately.
+  const savedDiag = state.importedData?.diagnoses;
+  state.importedData = state.importedData || {};
+  state.importedData.diagnoses = { conditions: [], note: '', familyHistory: [] };
+  // Ensure the modal exists so renderDiagnosesModal's `modal.innerHTML = …`
+  // doesn't throw. Detach + re-attach if necessary.
+  let detachedModal = null;
+  if (!document.getElementById('detail-modal')) {
+    detachedModal = document.createElement('div');
+    detachedModal.id = 'detail-modal';
+    document.body.appendChild(detachedModal);
+  }
+
+  const probe2 = document.createElement('div');
+  probe2.innerHTML = `
+    <select id="fh-relative"><option value="mother" selected>Mother</option></select>
+    <input id="fh-condition" value="Type 2 Diabetes">
+    <input id="fh-age" value="45">
+    <input id="fh-note" value="on metformin">
+    <textarea id="ctx-note-input"></textarea>`;
+  document.body.appendChild(probe2);
+  try {
+    cards.addFamilyHistoryEntry();
+    const fh = state.importedData.diagnoses.familyHistory;
+    assert('addFamilyHistoryEntry pushed one entry', fh && fh.length === 1);
+    const entry = fh && fh[0];
+    assert('Entry has relative=mother', entry && entry.relative === 'mother');
+    assert('Entry has condition=Type 2 Diabetes', entry && entry.condition === 'Type 2 Diabetes');
+    assert('Entry has onsetAge=45', entry && entry.onsetAge === 45);
+    assert('Entry preserves note', entry && entry.note === 'on metformin');
+
+    // Reset state for the reject-path test — renderDiagnosesModal replaced
+    // probe2's #fh-relative with the modal's, but probe2 still exists and
+    // duplicate IDs are tree-order-resolved. Re-inject a fresh probe with a
+    // unique-id workaround: nuke the modal contents first so probe2's
+    // elements win the getElementById lookup.
+    const modalEl = document.getElementById('detail-modal');
+    if (modalEl) modalEl.innerHTML = '';
+    // Re-render probe2 inputs (in case rendering mutated the DOM elsewhere).
+    probe2.innerHTML = `
+      <select id="fh-relative"><option value="__evil_relative" selected>x</option></select>
+      <input id="fh-condition" value="something">
+      <input id="fh-age" value="50">
+      <input id="fh-note" value="">
+      <textarea id="ctx-note-input"></textarea>`;
+    const before = state.importedData.diagnoses.familyHistory.length;
+    cards.addFamilyHistoryEntry();
+    assert('Tampered relative is rejected silently (no push)',
+      state.importedData.diagnoses.familyHistory.length === before);
+
+    // deleteFamilyHistoryEntry removes by index
+    const lenBeforeDelete = state.importedData.diagnoses.familyHistory.length;
+    cards.deleteFamilyHistoryEntry(0);
+    assert('deleteFamilyHistoryEntry removes by index',
+      state.importedData.diagnoses.familyHistory.length === lenBeforeDelete - 1);
+  } catch (e) {
+    console.warn('Live handler test threw:', e?.message || e);
+    assert('Live addFamilyHistoryEntry test ran without throwing', false, e?.message);
+  } finally {
+    probe2.remove();
+    if (detachedModal) detachedModal.remove();
+    state.importedData.diagnoses = savedDiag;
+  }
+
+  console.log(`\n%c ${pass} passed, ${fail} failed `, fail === 0 ? 'background:#22c55e;color:#fff;padding:4px 12px' : 'background:#ef4444;color:#fff;padding:4px 12px');
+  console.log(`Result: ${pass} passed, ${fail} failed`);
+})();

--- a/tests/test-family-history.js
+++ b/tests/test-family-history.js
@@ -1,291 +1,229 @@
-// test-family-history.js — Medical History card + family-history subsection
-// Covers: addFamilyHistoryEntry / deleteFamilyHistoryEntry, FAMILY_RELATIVES
-// allowlist, onsetAge bounds, saveDiagnoses null-guard with familyHistory-only,
-// getConditionsSummary inclusion, AI context emission, areas-list counting,
-// expanded COMMON_CONDITIONS, apostrophe-condition click fix, and the
-// "Medical History" rename.
-// Run: fetch('tests/test-family-history.js').then(r=>r.text()).then(s=>Function(s)())
+#!/usr/bin/env node
+// test-family-history.js — Medical History card + family-history subsection.
+// Covers: COMMON_CONDITIONS coverage, the apostrophe-condition click fix
+// (source guard), FAMILY_RELATIVES allowlist + addFamilyHistoryEntry guards
+// (source), saveDiagnoses null-guard, getConditionsSummary family inclusion,
+// AI context emission, areas-list counting, the "Medical History" rename, UI
+// subsection markers, and CSS hooks.
+//
+// Run: node tests/test-family-history.js  (or via npm test)
+//
+// Source-inspection + pure-function port. The DOM-runtime sections — the
+// apostrophe round-trip probe and the live addFamilyHistoryEntry /
+// deleteFamilyHistoryEntry handler test (both need real innerHTML parsing,
+// dispatchEvent, and renderDiagnosesModal against a live #detail-modal) —
+// live in test-family-history-dom.js on the puppeteer runner.
 
-return (async function() {
-  let pass = 0, fail = 0;
-  function assert(name, condition, detail) {
-    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
-    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+import './_node-shim.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+
+// fs-backed fetch shim for the source-inspection reads.
+const _realFetch = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  if (typeof url === 'string' && !/^https?:/.test(url)) {
+    try { return new Response(read(url), { status: 200 }); }
+    catch (_) { return new Response('', { status: 404 }); }
   }
+  return _realFetch(url, opts);
+};
 
-  console.log('%c Family History + Medical History Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
 
-  const cards = await import('../js/context-cards.js');
-  const state = (await import('../js/state.js')).state;
-  const constants = await import('../js/constants.js');
+console.log('=== Family History + Medical History Tests ===\n');
 
-  // ═══════════════════════════════════════
-  // 1. Expanded COMMON_CONDITIONS
-  // ═══════════════════════════════════════
-  console.log('%c 1. COMMON_CONDITIONS coverage ', 'font-weight:bold;color:#f59e0b');
+const cards = await import('../js/context-cards.js');
+const constants = await import('../js/constants.js');
 
-  const conditions = constants.COMMON_CONDITIONS;
-  assert('COMMON_CONDITIONS is an array', Array.isArray(conditions));
-  assert('COMMON_CONDITIONS expanded beyond original 27 entries',
-    conditions.length >= 100, `length=${conditions.length}`);
-  // Specific items the user flagged as missing
-  assert("COMMON_CONDITIONS includes Psoriasis", conditions.includes('Psoriasis'));
-  assert("COMMON_CONDITIONS includes Epilepsy", conditions.includes('Epilepsy'));
-  assert("COMMON_CONDITIONS includes Alzheimer's Disease",
-    conditions.includes("Alzheimer's Disease"));
-  // Major categories that should be covered
-  assert("COMMON_CONDITIONS includes Parkinson's Disease",
-    conditions.includes("Parkinson's Disease"));
-  assert('COMMON_CONDITIONS includes Heart Attack (MI)',
-    conditions.includes('Heart Attack (MI)'));
-  assert('COMMON_CONDITIONS includes Stroke', conditions.includes('Stroke'));
-  assert('COMMON_CONDITIONS includes Breast Cancer', conditions.includes('Breast Cancer'));
-  assert('COMMON_CONDITIONS includes Prostate Cancer', conditions.includes('Prostate Cancer'));
-  assert('COMMON_CONDITIONS includes Multiple Sclerosis', conditions.includes('Multiple Sclerosis'));
-  assert('COMMON_CONDITIONS includes Bipolar Disorder', conditions.includes('Bipolar Disorder'));
-  assert('COMMON_CONDITIONS includes Osteoporosis', conditions.includes('Osteoporosis'));
-  // No duplicates
-  const dupSet = new Set(conditions);
-  assert('COMMON_CONDITIONS has no duplicates', dupSet.size === conditions.length);
+// ═══════════════════════════════════════
+// 1. Expanded COMMON_CONDITIONS
+// ═══════════════════════════════════════
+console.log('1. COMMON_CONDITIONS coverage');
 
-  // ═══════════════════════════════════════
-  // 2. Apostrophe-condition click fix
-  // ═══════════════════════════════════════
-  console.log('%c 2. Apostrophe click fix ', 'font-weight:bold;color:#f59e0b');
+const conditions = constants.COMMON_CONDITIONS;
+assert('COMMON_CONDITIONS is an array', Array.isArray(conditions));
+assert('COMMON_CONDITIONS expanded beyond original 27 entries',
+  conditions.length >= 100, `length=${conditions.length}`);
+// Specific items the user flagged as missing
+assert("COMMON_CONDITIONS includes Psoriasis", conditions.includes('Psoriasis'));
+assert("COMMON_CONDITIONS includes Epilepsy", conditions.includes('Epilepsy'));
+assert("COMMON_CONDITIONS includes Alzheimer's Disease",
+  conditions.includes("Alzheimer's Disease"));
+// Major categories that should be covered
+assert("COMMON_CONDITIONS includes Parkinson's Disease",
+  conditions.includes("Parkinson's Disease"));
+assert('COMMON_CONDITIONS includes Heart Attack (MI)',
+  conditions.includes('Heart Attack (MI)'));
+assert('COMMON_CONDITIONS includes Stroke', conditions.includes('Stroke'));
+assert('COMMON_CONDITIONS includes Breast Cancer', conditions.includes('Breast Cancer'));
+assert('COMMON_CONDITIONS includes Prostate Cancer', conditions.includes('Prostate Cancer'));
+assert('COMMON_CONDITIONS includes Multiple Sclerosis', conditions.includes('Multiple Sclerosis'));
+assert('COMMON_CONDITIONS includes Bipolar Disorder', conditions.includes('Bipolar Disorder'));
+assert('COMMON_CONDITIONS includes Osteoporosis', conditions.includes('Osteoporosis'));
+// No duplicates
+const dupSet = new Set(conditions);
+assert('COMMON_CONDITIONS has no duplicates', dupSet.size === conditions.length);
 
-  const ctxSrc = await fetch('js/context-cards.js').then(r => r.text());
-  // filterConditionSuggestions must wrap the inline call arg in JSON.stringify
-  // so apostrophes survive the HTML-attribute → JS-string round-trip.
-  assert("filterConditionSuggestions uses JSON.stringify(m) for inline onclick arg",
-    /selectConditionSuggestion\(\$\{escapeHTML\(JSON\.stringify\(m\)\)\}\)/.test(ctxSrc));
-  assert("filterFamilyConditionSuggestions uses JSON.stringify(m) for inline onclick arg",
-    /selectFamilyConditionSuggestion\(\$\{escapeHTML\(JSON\.stringify\(m\)\)\}\)/.test(ctxSrc));
-  // Simulate the round-trip in-page to be sure: build a tiny DOM, click, observe.
-  const probe = document.createElement('div');
-  probe.innerHTML = `<input id="probe-cond-input"><div id="probe-target"></div>`;
-  document.body.appendChild(probe);
-  try {
-    // Synthesize the suggestion HTML the same way filterConditionSuggestions does.
-    const m = "Alzheimer's Disease";
-    // The library escapeHTML lives in utils.js — re-implement minimally for the probe.
-    const escapeHTML = (s) => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-    const target = document.getElementById('probe-target');
-    target.innerHTML = `<div class="ctx-suggestion-item" id="probe-suggest" onmousedown="document.getElementById('probe-cond-input').value = ${escapeHTML(JSON.stringify(m))}">${escapeHTML(m)}</div>`;
-    // Simulate the click.
-    const evt = new MouseEvent('mousedown', { bubbles: true });
-    document.getElementById('probe-suggest').dispatchEvent(evt);
-    const result = document.getElementById('probe-cond-input').value;
-    assert("Apostrophe condition (Alzheimer's Disease) round-trips through inline onmousedown",
-      result === "Alzheimer's Disease", `got: "${result}"`);
-  } finally {
-    probe.remove();
-  }
+// ═══════════════════════════════════════
+// 2. Apostrophe-condition click fix (source guard)
+// ═══════════════════════════════════════
+console.log('2. Apostrophe click fix');
 
-  // ═══════════════════════════════════════
-  // 3. FAMILY_RELATIVES allowlist + addFamilyHistoryEntry
-  // ═══════════════════════════════════════
-  console.log('%c 3. FAMILY_RELATIVES + addEntry ', 'font-weight:bold;color:#f59e0b');
+const ctxSrc = await fetch('js/context-cards.js').then(r => r.text());
+// filterConditionSuggestions must wrap the inline call arg in JSON.stringify
+// so apostrophes survive the HTML-attribute → JS-string round-trip. The
+// live DOM round-trip probe lives in test-family-history-dom.js.
+assert("filterConditionSuggestions uses JSON.stringify(m) for inline onclick arg",
+  /selectConditionSuggestion\(\$\{escapeHTML\(JSON\.stringify\(m\)\)\}\)/.test(ctxSrc));
+assert("filterFamilyConditionSuggestions uses JSON.stringify(m) for inline onclick arg",
+  /selectFamilyConditionSuggestion\(\$\{escapeHTML\(JSON\.stringify\(m\)\)\}\)/.test(ctxSrc));
 
-  // FAMILY_RELATIVES isn't exported (private to context-cards.js), so we
-  // assert its allowlist via the source.
-  assert('FAMILY_RELATIVES declared with 8 first-degree+grandparent keys',
-    /FAMILY_RELATIVES\s*=\s*\[[^\]]*'mother'[^\]]*'father'[^\]]*'sibling'[^\]]*'child'[^\]]*'maternal_grandmother'[^\]]*'maternal_grandfather'[^\]]*'paternal_grandmother'[^\]]*'paternal_grandfather'/s.test(ctxSrc));
-  assert('addFamilyHistoryEntry validates relative against FAMILY_RELATIVES',
-    /addFamilyHistoryEntry[\s\S]{0,1000}if \(!FAMILY_RELATIVES\.some\(r => r\.key === relative\)\) return/.test(ctxSrc));
-  assert('addFamilyHistoryEntry clamps onsetAge to 0–120',
-    /Math\.max\(0,\s*Math\.min\(120,\s*parseInt\(ageRaw, 10\)\)\)/.test(ctxSrc));
-  assert('addFamilyHistoryEntry early-returns when relative or condition empty',
-    /if \(!relative \|\| !condition\) return/.test(ctxSrc));
+// ═══════════════════════════════════════
+// 3. FAMILY_RELATIVES allowlist + addFamilyHistoryEntry guards (source)
+// ═══════════════════════════════════════
+console.log('3. FAMILY_RELATIVES + addEntry guards');
 
-  // State-manipulation: live-call the handler against fake DOM inputs, verify
-  // mutation. Wrap in try/catch because addFamilyHistoryEntry re-renders the
-  // modal via renderDiagnosesModal(document.getElementById("detail-modal"))
-  // and that node might not be visible in every test-runner state. We care
-  // about the data mutation; the render is exercised separately.
-  const savedDiag = state.importedData?.diagnoses;
-  state.importedData = state.importedData || {};
-  state.importedData.diagnoses = { conditions: [], note: '', familyHistory: [] };
-  // Ensure the modal exists so renderDiagnosesModal's `modal.innerHTML = …`
-  // doesn't throw. Detach + re-attach if necessary.
-  let detachedModal = null;
-  if (!document.getElementById('detail-modal')) {
-    detachedModal = document.createElement('div');
-    detachedModal.id = 'detail-modal';
-    document.body.appendChild(detachedModal);
-  }
+// FAMILY_RELATIVES isn't exported (private to context-cards.js), so we
+// assert its allowlist + the handler's guards via the source. The live
+// handler-mutation test lives in test-family-history-dom.js.
+assert('FAMILY_RELATIVES declared with 8 first-degree+grandparent keys',
+  /FAMILY_RELATIVES\s*=\s*\[[^\]]*'mother'[^\]]*'father'[^\]]*'sibling'[^\]]*'child'[^\]]*'maternal_grandmother'[^\]]*'maternal_grandfather'[^\]]*'paternal_grandmother'[^\]]*'paternal_grandfather'/s.test(ctxSrc));
+assert('addFamilyHistoryEntry validates relative against FAMILY_RELATIVES',
+  /addFamilyHistoryEntry[\s\S]{0,1000}if \(!FAMILY_RELATIVES\.some\(r => r\.key === relative\)\) return/.test(ctxSrc));
+assert('addFamilyHistoryEntry clamps onsetAge to 0–120',
+  /Math\.max\(0,\s*Math\.min\(120,\s*parseInt\(ageRaw, 10\)\)\)/.test(ctxSrc));
+assert('addFamilyHistoryEntry early-returns when relative or condition empty',
+  /if \(!relative \|\| !condition\) return/.test(ctxSrc));
 
-  const probe2 = document.createElement('div');
-  probe2.innerHTML = `
-    <select id="fh-relative"><option value="mother" selected>Mother</option></select>
-    <input id="fh-condition" value="Type 2 Diabetes">
-    <input id="fh-age" value="45">
-    <input id="fh-note" value="on metformin">
-    <textarea id="ctx-note-input"></textarea>`;
-  document.body.appendChild(probe2);
-  try {
-    cards.addFamilyHistoryEntry();
-    const fh = state.importedData.diagnoses.familyHistory;
-    assert('addFamilyHistoryEntry pushed one entry', fh && fh.length === 1);
-    const entry = fh && fh[0];
-    assert('Entry has relative=mother', entry && entry.relative === 'mother');
-    assert('Entry has condition=Type 2 Diabetes', entry && entry.condition === 'Type 2 Diabetes');
-    assert('Entry has onsetAge=45', entry && entry.onsetAge === 45);
-    assert('Entry preserves note', entry && entry.note === 'on metformin');
+// ═══════════════════════════════════════
+// 4. saveDiagnoses null-guard with familyHistory-only
+// ═══════════════════════════════════════
+console.log('4. saveDiagnoses null-guard');
 
-    // Reset state for the reject-path test — renderDiagnosesModal replaced
-    // probe2's #fh-relative with the modal's, but probe2 still exists and
-    // duplicate IDs are tree-order-resolved. Re-inject a fresh probe with a
-    // unique-id workaround: nuke the modal contents first so probe2's
-    // elements win the getElementById lookup.
-    const modalEl = document.getElementById('detail-modal');
-    if (modalEl) modalEl.innerHTML = '';
-    // Re-render probe2 inputs (in case rendering mutated the DOM elsewhere).
-    probe2.innerHTML = `
-      <select id="fh-relative"><option value="__evil_relative" selected>x</option></select>
-      <input id="fh-condition" value="something">
-      <input id="fh-age" value="50">
-      <input id="fh-note" value="">
-      <textarea id="ctx-note-input"></textarea>`;
-    const before = state.importedData.diagnoses.familyHistory.length;
-    cards.addFamilyHistoryEntry();
-    assert('Tampered relative is rejected silently (no push)',
-      state.importedData.diagnoses.familyHistory.length === before);
+assert('saveDiagnoses considers familyHistory.length before nulling diagnoses',
+  /const fhLen = Array\.isArray\(state\.importedData\.diagnoses\.familyHistory\)[\s\S]{0,300}fhLen === 0/.test(ctxSrc));
 
-    // deleteFamilyHistoryEntry removes by index
-    const lenBeforeDelete = state.importedData.diagnoses.familyHistory.length;
-    cards.deleteFamilyHistoryEntry(0);
-    assert('deleteFamilyHistoryEntry removes by index',
-      state.importedData.diagnoses.familyHistory.length === lenBeforeDelete - 1);
-  } catch (e) {
-    console.warn('Live handler test threw:', e?.message || e);
-    assert('Live addFamilyHistoryEntry test ran without throwing', false, e?.message);
-  } finally {
-    probe2.remove();
-    if (detachedModal) detachedModal.remove();
-    state.importedData.diagnoses = savedDiag;
-  }
+// Profile migration backfills familyHistory on legacy diagnoses objects.
+const profSrc = await fetch('js/profile.js').then(r => r.text());
+assert('profile.js migrates string-diagnoses into structured object with familyHistory: []',
+  /data\.diagnoses\.trim\(\)\s*\?\s*\{ conditions: \[\], note: data\.diagnoses\.trim\(\), familyHistory: \[\] \}/.test(profSrc));
+assert('profile.js backfills familyHistory=[] on existing diagnoses objects without it',
+  /data\.diagnoses && typeof data\.diagnoses === 'object' && !Array\.isArray\(data\.diagnoses\.familyHistory\)[\s\S]{0,200}data\.diagnoses\.familyHistory = \[\]/.test(profSrc));
 
-  // ═══════════════════════════════════════
-  // 4. saveDiagnoses null-guard with familyHistory-only
-  // ═══════════════════════════════════════
-  console.log('%c 4. saveDiagnoses null-guard ', 'font-weight:bold;color:#f59e0b');
+// ═══════════════════════════════════════
+// 5. getConditionsSummary includes family history
+// ═══════════════════════════════════════
+console.log('5. Summary inclusion');
 
-  assert('saveDiagnoses considers familyHistory.length before nulling diagnoses',
-    /const fhLen = Array\.isArray\(state\.importedData\.diagnoses\.familyHistory\)[\s\S]{0,300}fhLen === 0/.test(ctxSrc));
+const sum1 = cards.getConditionsSummary({
+  conditions: [],
+  familyHistory: [{ relative: 'father', condition: 'Heart Attack (MI)', onsetAge: 52 }]
+});
+assert('Summary includes "Family:" prefix when conditions empty', sum1.includes('Family:'));
+assert('Summary compacts relative + condition + @age',
+  /father Heart Attack \(MI\)@52/.test(sum1), `got: "${sum1}"`);
 
-  // Profile migration backfills familyHistory on legacy diagnoses objects.
-  const profSrc = await fetch('js/profile.js').then(r => r.text());
-  assert('profile.js migrates string-diagnoses into structured object with familyHistory: []',
-    /data\.diagnoses\.trim\(\)\s*\?\s*\{ conditions: \[\], note: data\.diagnoses\.trim\(\), familyHistory: \[\] \}/.test(profSrc));
-  assert('profile.js backfills familyHistory=[] on existing diagnoses objects without it',
-    /data\.diagnoses && typeof data\.diagnoses === 'object' && !Array\.isArray\(data\.diagnoses\.familyHistory\)[\s\S]{0,200}data\.diagnoses\.familyHistory = \[\]/.test(profSrc));
+const sum2 = cards.getConditionsSummary({
+  conditions: [],
+  familyHistory: [{ relative: 'maternal_grandmother', condition: 'Breast Cancer' }]
+});
+assert('Summary normalizes "maternal_" → "mat." prefix',
+  sum2.includes('mat. grandmother'), `got: "${sum2}"`);
 
-  // ═══════════════════════════════════════
-  // 5. getConditionsSummary includes family history
-  // ═══════════════════════════════════════
-  console.log('%c 5. Summary inclusion ', 'font-weight:bold;color:#f59e0b');
+const sum3 = cards.getConditionsSummary({
+  conditions: [{ name: 'Hypertension', severity: 'mild' }],
+  familyHistory: [{ relative: 'mother', condition: 'Type 2 Diabetes', onsetAge: 45 }]
+});
+assert('Summary joins your-conditions + family with " — "',
+  sum3.includes('Hypertension') && sum3.includes('Family:') && sum3.includes(' — '));
 
-  const sum1 = cards.getConditionsSummary({
-    conditions: [],
-    familyHistory: [{ relative: 'father', condition: 'Heart Attack (MI)', onsetAge: 52 }]
-  });
-  assert('Summary includes "Family:" prefix when conditions empty', sum1.includes('Family:'));
-  assert('Summary compacts relative + condition + @age',
-    /father Heart Attack \(MI\)@52/.test(sum1), `got: "${sum1}"`);
+// ═══════════════════════════════════════
+// 6. AI context emission — family history block
+// ═══════════════════════════════════════
+console.log('6. AI context family history');
 
-  const sum2 = cards.getConditionsSummary({
-    conditions: [],
-    familyHistory: [{ relative: 'maternal_grandmother', condition: 'Breast Cancer' }]
-  });
-  assert('Summary normalizes "maternal_" → "mat." prefix',
-    sum2.includes('mat. grandmother'), `got: "${sum2}"`);
+const labCtxSrc = await fetch('js/lab-context.js').then(r => r.text());
+assert('Family history block emitted within [section:diagnoses]',
+  /\[section:diagnoses\][\s\S]{0,1500}### Family history \(heritable\/environmental risk signal\)/.test(labCtxSrc));
+assert('Family history block iterates diag.familyHistory',
+  /Array\.isArray\(diag\.familyHistory\) && diag\.familyHistory\.length[\s\S]{0,800}for \(const e of diag\.familyHistory\)/.test(labCtxSrc));
+assert('Family history line format includes relative, condition, optional onset age, optional note',
+  /\$\{rel\}: \$\{e\.condition \|\| ''\}\$\{age\}\$\{note\}/.test(labCtxSrc));
 
-  const sum3 = cards.getConditionsSummary({
-    conditions: [{ name: 'Hypertension', severity: 'mild' }],
-    familyHistory: [{ relative: 'mother', condition: 'Type 2 Diabetes', onsetAge: 45 }]
-  });
-  assert('Summary joins your-conditions + family with " — "',
-    sum3.includes('Hypertension') && sum3.includes('Family:') && sum3.includes(' — '));
+// ═══════════════════════════════════════
+// 7. Areas list counts family entries
+// ═══════════════════════════════════════
+console.log('7. Active areas list');
 
-  // ═══════════════════════════════════════
-  // 6. AI context emission — family history block
-  // ═══════════════════════════════════════
-  console.log('%c 6. AI context family history ', 'font-weight:bold;color:#f59e0b');
+assert('Active-areas list counts both conditions and family entries',
+  /label: 'Medical History', detail \}\)/.test(labCtxSrc) &&
+  /family entr/.test(labCtxSrc));
 
-  const labCtxSrc = await fetch('js/lab-context.js').then(r => r.text());
-  assert('Family history block emitted within [section:diagnoses]',
-    /\[section:diagnoses\][\s\S]{0,1500}### Family history \(heritable\/environmental risk signal\)/.test(labCtxSrc));
-  assert('Family history block iterates diag.familyHistory',
-    /Array\.isArray\(diag\.familyHistory\) && diag\.familyHistory\.length[\s\S]{0,800}for \(const e of diag\.familyHistory\)/.test(labCtxSrc));
-  assert('Family history line format includes relative, condition, optional onset age, optional note',
-    /\$\{rel\}: \$\{e\.condition \|\| ''\}\$\{age\}\$\{note\}/.test(labCtxSrc));
+// ═══════════════════════════════════════
+// 8. "Medical History" rename — verifying user-facing strings
+// ═══════════════════════════════════════
+console.log('8. Medical History rename');
 
-  // ═══════════════════════════════════════
-  // 7. Areas list counts family entries
-  // ═══════════════════════════════════════
-  console.log('%c 7. Active areas list ', 'font-weight:bold;color:#f59e0b');
+assert("Card label is 'Medical History'",
+  /label:\s*'Medical History'/.test(ctxSrc));
+assert("Modal headline reads 'Medical History'",
+  /<h3>Medical History<\/h3>/.test(ctxSrc));
+assert('Modal description mentions both diagnoses and family history',
+  /diagnoses and family history/.test(ctxSrc));
+assert('Card placeholder mentions family history',
+  /'Add diagnoses or family history'/.test(ctxSrc));
+assert("saveAndRefresh toast says 'Medical history saved'",
+  ctxSrc.includes("saveAndRefresh('Medical history saved', 'diagnoses')"));
+assert("clearDiagnoses toast says 'Medical history cleared'",
+  ctxSrc.includes("'Medical history cleared'"));
+assert('Tooltip mentions family history reframing risk',
+  /heart attack at 52 reframes a borderline LDL/.test(ctxSrc));
+assert('AI context section header renamed to Medical History / Diagnoses',
+  labCtxSrc.includes('## Medical History / Diagnoses'));
+assert("Field-label map uses 'Medical History'",
+  /diagnoses:\s*'Medical History'/.test(labCtxSrc));
 
-  assert('Active-areas list counts both conditions and family entries',
-    /label: 'Medical History', detail \}\)/.test(labCtxSrc) &&
-    /family entr/.test(labCtxSrc));
+// ═══════════════════════════════════════
+// 9. UI subsection markers (CSS hooks the renderer relies on)
+// ═══════════════════════════════════════
+console.log('9. UI subsection');
 
-  // ═══════════════════════════════════════
-  // 8. "Medical History" rename — verifying user-facing strings
-  // ═══════════════════════════════════════
-  console.log('%c 8. Medical History rename ', 'font-weight:bold;color:#f59e0b');
+assert("Modal renders <div class='ctx-family-history'> wrapper",
+  /class="ctx-family-history"/.test(ctxSrc));
+assert('Relative dropdown uses <optgroup> grouping',
+  /<optgroup label="Parents"/.test(ctxSrc) &&
+  /<optgroup label="Siblings & Children"/.test(ctxSrc) &&
+  /<optgroup label="Maternal grandparents"/.test(ctxSrc) &&
+  /<optgroup label="Paternal grandparents"/.test(ctxSrc));
+assert('Add form is split into two rows for legibility',
+  (ctxSrc.match(/ctx-family-add-row/g) || []).length >= 2);
+assert('Relative chip emoji mapping defined',
+  /RELATIVE_EMOJI\s*=\s*\{/.test(ctxSrc));
+assert("Closing-suggestions handler also clears fh-condition-suggestions",
+  /fh-condition-suggestions[\s\S]{0,200}fhContainer\.innerHTML\s*=\s*''/.test(ctxSrc));
 
-  assert("Card label is 'Medical History'",
-    /label:\s*'Medical History'/.test(ctxSrc));
-  assert("Modal headline reads 'Medical History'",
-    /<h3>Medical History<\/h3>/.test(ctxSrc));
-  assert('Modal description mentions both diagnoses and family history',
-    /diagnoses and family history/.test(ctxSrc));
-  assert('Card placeholder mentions family history',
-    /'Add diagnoses or family history'/.test(ctxSrc));
-  assert("saveAndRefresh toast says 'Medical history saved'",
-    ctxSrc.includes("saveAndRefresh('Medical history saved', 'diagnoses')"));
-  assert("clearDiagnoses toast says 'Medical history cleared'",
-    ctxSrc.includes("'Medical history cleared'"));
-  assert('Tooltip mentions family history reframing risk',
-    /heart attack at 52 reframes a borderline LDL/.test(ctxSrc));
-  assert('AI context section header renamed to Medical History / Diagnoses',
-    labCtxSrc.includes('## Medical History / Diagnoses'));
-  assert("Field-label map uses 'Medical History'",
-    /diagnoses:\s*'Medical History'/.test(labCtxSrc));
+// ═══════════════════════════════════════
+// 10. CSS hooks
+// ═══════════════════════════════════════
+console.log('10. CSS hooks');
+const stylesSrc = await fetch('styles.css').then(r => r.text());
+for (const cls of [
+  '.ctx-family-history', '.ctx-family-head', '.ctx-family-count',
+  '.ctx-family-list', '.ctx-family-item', '.ctx-family-relative',
+  '.ctx-family-condition', '.ctx-family-age', '.ctx-family-note',
+  '.ctx-family-add', '.ctx-family-add-row',
+]) {
+  assert(`CSS defines ${cls}`, new RegExp(cls.replace('.', '\\.') + '\\s*\\{').test(stylesSrc));
+}
 
-  // ═══════════════════════════════════════
-  // 9. UI subsection markers (CSS hooks the renderer relies on)
-  // ═══════════════════════════════════════
-  console.log('%c 9. UI subsection ', 'font-weight:bold;color:#f59e0b');
-
-  assert("Modal renders <div class='ctx-family-history'> wrapper",
-    /class="ctx-family-history"/.test(ctxSrc));
-  assert('Relative dropdown uses <optgroup> grouping',
-    /<optgroup label="Parents"/.test(ctxSrc) &&
-    /<optgroup label="Siblings & Children"/.test(ctxSrc) &&
-    /<optgroup label="Maternal grandparents"/.test(ctxSrc) &&
-    /<optgroup label="Paternal grandparents"/.test(ctxSrc));
-  assert('Add form is split into two rows for legibility',
-    (ctxSrc.match(/ctx-family-add-row/g) || []).length >= 2);
-  assert('Relative chip emoji mapping defined',
-    /RELATIVE_EMOJI\s*=\s*\{/.test(ctxSrc));
-  assert("Closing-suggestions handler also clears fh-condition-suggestions",
-    /fh-condition-suggestions[\s\S]{0,200}fhContainer\.innerHTML\s*=\s*''/.test(ctxSrc));
-
-  // ═══════════════════════════════════════
-  // 10. CSS hooks
-  // ═══════════════════════════════════════
-  console.log('%c 10. CSS hooks ', 'font-weight:bold;color:#f59e0b');
-  const stylesSrc = await fetch('styles.css').then(r => r.text());
-  for (const cls of [
-    '.ctx-family-history', '.ctx-family-head', '.ctx-family-count',
-    '.ctx-family-list', '.ctx-family-item', '.ctx-family-relative',
-    '.ctx-family-condition', '.ctx-family-age', '.ctx-family-note',
-    '.ctx-family-add', '.ctx-family-add-row',
-  ]) {
-    assert(`CSS defines ${cls}`, new RegExp(cls.replace('.', '\\.') + '\\s*\\{').test(stylesSrc));
-  }
-
-  console.log(`\n%c ${pass} passed, ${fail} failed `, fail === 0 ? 'background:#22c55e;color:#fff;padding:4px 12px' : 'background:#ef4444;color:#fff;padding:4px 12px');
-  console.log(`Result: ${pass} passed, ${fail} failed`);
-})();
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **test-family-history.js** → Vitest (56 asserts): COMMON_CONDITIONS coverage, `getConditionsSummary` family inclusion, the apostrophe-fix source guard, FAMILY_RELATIVES/addEntry regex guards, the "Medical History" rename strings, UI markers, CSS hooks. The two genuinely DOM-runtime sections — the apostrophe-condition round-trip probe (real `innerHTML` parsing + `dispatchEvent` of an inline `onmousedown`) and the live `addFamilyHistoryEntry`/`deleteFamilyHistoryEntry` handler test (reads `#fh-*` inputs, re-renders `renderDiagnosesModal` against a live `#detail-modal`) — split into **test-family-history-dom.js** on the puppeteer runner.
- **test-emf-flow.js** → Vitest (30 asserts, full port): CRUD/state assertions are pure object mutations; the render/modal/photo/interpretation paths are coverage-only (`try/catch` + `withTimeout`, asserting "X ran") and degrade gracefully against the Node DOM stub. A local `getElementById` patch hands back a stub element for `#detail-modal` / `#modal-overlay` so `renderEMFEditor`'s `modal.innerHTML` doesn't throw on null.
- Vitest: 83 → 85 tests. Puppeteer originals: 30 → 29.

## Test plan
- [x] `node tests/test-family-history.js` → 56/56
- [x] `node tests/test-emf-flow.js` → 30/30
- [x] `npx vitest run` → 85 tests pass
- [x] `./run-tests.sh` → all green (node-side + Puppeteer, incl. new test-family-history-dom.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)