### PR TITLE
Add agent discovery metadata

### DIFF
--- a/.well-known/agent-skills/getbased-health-data/SKILL.md
+++ b/.well-known/agent-skills/getbased-health-data/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: getbased-health-data
+description: Connect to a user's getbased health data and query their blood work, biomarkers, genome, wearables, and personal research library via the getbased MCP server. Use when a user asks about their lab results, health trends, or wants AI reasoning grounded in their own health data.
+---
+
+# getbased Health Data
+
+[getbased](https://getbased.health) is a free, open-source Personal Health Intelligence app that runs in the user's browser. It connects five lenses on a person's biology — labs, genome, body, lifestyle, and environment — and exposes a read-only summary to AI agents through the [`getbased-mcp`](https://github.com/elkimek/getbased-agents/tree/main/packages/mcp) server.
+
+The user's raw data and encryption keys never leave their device. The MCP server reads the same pre-built context text the in-app AI chat uses — not the underlying database.
+
+## When to use this skill
+
+Use this skill when the user wants you to reason about *their own* health data: "how's my vitamin D", "what markers are out of range", "summarize my latest blood work", "what does my research library say about X". Do not use it for general medical questions unconnected to the user's data.
+
+## Setup
+
+The MCP server is installed and run locally by the user — there is no hosted endpoint.
+
+1. Install: `pip install getbased-mcp` (or the `getbased-agent-stack` bundle).
+2. The user enables **Settings > Data > Messenger Access** in the getbased app and copies the read-only token.
+3. The token is provided to the MCP server via the `GETBASED_TOKEN` environment variable. It grants access to lab-context text only, no raw data, and is revocable.
+4. Add `getbased` to the MCP client config pointing at the `getbased-mcp` command.
+
+Full configuration details: https://app.getbased.health/docs/guide/agent-access
+
+## Tools
+
+| Tool | Use it for |
+|---|---|
+| `getbased_lab_context` | Full lab summary — biomarkers, ranges, trends, context cards, supplements, goals |
+| `getbased_section` | One section (e.g. hormones, lipids) instead of the full dump — token-efficient |
+| `getbased_wearables_series` | Daily wearable time-series (HRV, resting HR, sleep score, readiness, steps, weight…) over the 7/30/90-day window the user opted into |
+| `getbased_list_profiles` | List profiles by name and ID; pass `profile` to any tool to target one |
+| `knowledge_search` | Semantic search over the user's own research library (requires the optional RAG server) |
+| `knowledge_list_libraries` / `knowledge_activate_library` / `knowledge_stats` | Manage which research library `knowledge_search` targets |
+| `getbased_lens_config` | Show the Custom Knowledge Source endpoint configuration |
+
+Start with `getbased_section()` (no args) to see the section index, then pull only what you need. Knowledge tools degrade gracefully — if the RAG server is down, the lab tools still work.
+
+## Responsible use
+
+- You are not a clinician. Interpret data, surface patterns and out-of-range markers, and cite reference/optimal ranges — but recommend the user confirm anything actionable with a healthcare provider.
+- Ground claims in the user's actual data and, where available, their research library via `knowledge_search`. Prefer cited passages over training-data recall for health claims.
+- The context is a summary, not raw records. Don't infer precision the data doesn't support.
+- Respect multi-profile boundaries — never mix data across profiles unless the user asks.

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "getbased-health-data",
+      "type": "skill-md",
+      "description": "Connect to a user's getbased health data and query their blood work, biomarkers, genome, wearables, and personal research library via the getbased MCP server. Use when a user asks about their lab results, health trends, or wants AI reasoning grounded in their own health data.",
+      "url": "/.well-known/agent-skills/getbased-health-data/SKILL.md",
+      "digest": "sha256:21e2c05fab6d810842d48562af259d5dde9cd005152ae4463aa4cbb0c189fc3d"
+    }
+  ]
+}

--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -22,7 +22,7 @@
     "env": "GETBASED_TOKEN",
     "description": "Read-only token generated in the getbased app under Settings > Data > Messenger Access. Grants access to lab-context text only — no raw data, no write access. Revocable at any time by regenerating the token."
   },
-  "gateway": "https://sync.getbased.health",
+  "syncBackend": "https://sync.getbased.health",
   "tools": [
     { "name": "getbased_lab_context", "description": "Full lab summary — biomarkers, ranges, trends, context cards, supplements, goals. Pass a profile to target a specific profile." },
     { "name": "getbased_section", "description": "Get a specific section (e.g. hormones, lipids) or list all available sections. Token-efficient alternative to the full dump." },

--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -1,0 +1,37 @@
+{
+  "name": "getbased",
+  "description": "MCP server that exposes your getbased health data — blood work context, biomarker sections, and an optional RAG knowledge base — as tools for any MCP-compatible agent. Your data stays on your device; the server reads a read-only context summary, not raw records.",
+  "version": "0.2.5",
+  "transport": "stdio",
+  "hosting": "local",
+  "homepage": "https://getbased.health",
+  "documentation": "https://app.getbased.health/docs/guide/agent-access",
+  "repository": "https://github.com/elkimek/getbased-agents/tree/main/packages/mcp",
+  "license": "AGPL-3.0-or-later",
+  "install": {
+    "pypi": "getbased-mcp",
+    "command": "getbased-mcp",
+    "bundle": {
+      "package": "getbased-agent-stack",
+      "repository": "https://github.com/elkimek/getbased-agents/tree/main/packages/stack",
+      "description": "Meta-package that bundles the MCP server with the RAG backend and example Claude Code / Hermes / OpenClaw configs."
+    }
+  },
+  "authentication": {
+    "type": "token",
+    "env": "GETBASED_TOKEN",
+    "description": "Read-only token generated in the getbased app under Settings > Data > Messenger Access. Grants access to lab-context text only — no raw data, no write access. Revocable at any time by regenerating the token."
+  },
+  "gateway": "https://sync.getbased.health",
+  "tools": [
+    { "name": "getbased_lab_context", "description": "Full lab summary — biomarkers, ranges, trends, context cards, supplements, goals. Pass a profile to target a specific profile." },
+    { "name": "getbased_section", "description": "Get a specific section (e.g. hormones, lipids) or list all available sections. Token-efficient alternative to the full dump." },
+    { "name": "getbased_wearables_series", "description": "Read the daily wearable time-series (HRV, resting HR, sleep score, readiness, steps, weight, etc.) over the 7/30/90-day window the user opted into pushing." },
+    { "name": "getbased_list_profiles", "description": "List available profiles by name and ID." },
+    { "name": "knowledge_search", "description": "Semantic search across the active library of your RAG knowledge base. Requires the getbased-rag server; degrades gracefully if unavailable." },
+    { "name": "knowledge_list_libraries", "description": "List all knowledge-base libraries and show which is active." },
+    { "name": "knowledge_activate_library", "description": "Switch the active knowledge-base library for subsequent searches." },
+    { "name": "knowledge_stats", "description": "Per-source chunk counts for the active library — useful for diagnosing missing results." },
+    { "name": "getbased_lens_config", "description": "Show the Custom Knowledge Source endpoint configuration used by the getbased app." }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,10 @@ VitePress at `/docs` (source in `docs/`). 33 user guide pages + 9 contributor pa
 
 `manifest.json` + `service-worker.js`. Cache: `labcharts-v${APP_VERSION}`. Bump `version.js` to bust cache. AI API calls bypass SW entirely (avoids IPC stream buffering).
 
+### Agent discovery metadata
+
+`.well-known/mcp.json` + `.well-known/agent-skills/` describe the `getbased-mcp` server for AI agents. These files are mirrored verbatim from the `get-based-site` repo — keep both copies in sync when the MCP version, tool list, or auth changes. If `SKILL.md` changes, regenerate its `sha256` digest in `index.json`.
+
 ### Responsive Layout
 
 Breakpoints: 3000/2000/1600/1400px (chat scaling), 1200px (cards 3→2 col), 1024px (sidebar → hamburger slide-out with backdrop), 768px (compact header — hides dates, range, feedback, donate; header groups with dividers), 600/480/375px (mobile). Grid items: `min-width: 0; overflow: hidden`. Touch: `@media (pointer: coarse)` 44px tap targets; `@media (hover: none)` reveals hover-only elements. Mobile sidebar: `toggleMobileSidebar()`/`closeMobileSidebar()` in nav.js, auto-closes on navigation.


### PR DESCRIPTION
## Summary
`app.getbased.health` is a separate Vercel deployment from the marketing site and hosts the docs (`/docs/guide/agent-access`). Agents landing on the app domain couldn't see the discovery metadata published on `getbased.health`. This mirrors it so the MCP server is discoverable from either domain.

- **`.well-known/mcp.json`** — MCP server card for `getbased-mcp` v0.2.5: stdio transport, local install, `GETBASED_TOKEN` auth, `sync.getbased.health` gateway, all 9 tools. Audited against `getbased-agents/packages/mcp` source.
- **`.well-known/agent-skills/index.json`** + **`getbased-health-data/SKILL.md`** — Agent Skills Discovery index (RFC v0.2.0) with one skill teaching agents how to connect to and responsibly query a user's health data.

Files are byte-identical to the copies on `get-based-site` (the skills `url`s are relative, so they resolve correctly on this host; the sha256 `digest` matches).

## Not included
- No `robots.txt` / `llms.txt` / `Link` header changes — the app's `vercel.json` uses the legacy `routes` config, and broader discoverability work is a separate decision.
- OAuth / API Catalog / WebMCP checks are intentionally skipped: the app is local-first with token (not OAuth) auth and no hosted API. WebMCP would be real feature work, not a metadata file.

## Test plan
- [ ] After deploy, `curl https://app.getbased.health/.well-known/mcp.json` returns valid JSON with 9 tools
- [ ] `curl https://app.getbased.health/.well-known/agent-skills/index.json` returns valid JSON
- [ ] `sha256sum` of the served `SKILL.md` matches the `digest` in `index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)