### PR TITLE
Fix agent-access docs: name, tool list, dedup

### DIFF
--- a/.well-known/agent-skills/getbased-health-data/SKILL.md
+++ b/.well-known/agent-skills/getbased-health-data/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when the user wants you to reason about *their own* health data: 
 The MCP server is installed and run locally by the user — there is no hosted endpoint.
 
 1. Install: `pip install getbased-mcp` (or the `getbased-agent-stack` bundle).
-2. The user enables **Settings > Data > Messenger Access** in the getbased app and copies the read-only token.
+2. The user enables **Settings > Data > Agent Access** in the getbased app and copies the read-only token.
 3. The token is provided to the MCP server via the `GETBASED_TOKEN` environment variable. It grants access to lab-context text only, no raw data, and is revocable.
 4. Add `getbased` to the MCP client config pointing at the `getbased-mcp` command.
 

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Connect to a user's getbased health data and query their blood work, biomarkers, genome, wearables, and personal research library via the getbased MCP server. Use when a user asks about their lab results, health trends, or wants AI reasoning grounded in their own health data.",
       "url": "/.well-known/agent-skills/getbased-health-data/SKILL.md",
-      "digest": "sha256:21e2c05fab6d810842d48562af259d5dde9cd005152ae4463aa4cbb0c189fc3d"
+      "digest": "sha256:f7b9f3f69cf7831f8b9155eb756a198f3d9dd0850586f1938736cadcb32e74f8"
     }
   ]
 }

--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -20,7 +20,7 @@
   "authentication": {
     "type": "token",
     "env": "GETBASED_TOKEN",
-    "description": "Read-only token generated in the getbased app under Settings > Data > Messenger Access. Grants access to lab-context text only — no raw data, no write access. Revocable at any time by regenerating the token."
+    "description": "Read-only token generated in the getbased app under Settings > Data > Agent Access. Grants access to lab-context text only — no raw data, no write access. Revocable at any time by regenerating the token."
   },
   "syncBackend": "https://sync.getbased.health",
   "tools": [

--- a/docs/guide/agent-access.md
+++ b/docs/guide/agent-access.md
@@ -97,6 +97,7 @@ getbased-mcp provides these tools:
 |---|---|
 | `getbased_lab_context` | Full lab summary — values, ranges, trends, context cards, supplements, goals |
 | `getbased_section` | Query a specific section (hormones, biometrics, etc.) or list available sections |
+| `getbased_wearables_series` | Daily wearable time-series (HRV, resting HR, sleep score, readiness, steps, weight…) over the 7/30/90-day window you opted into — see [Wearable data](#wearable-data-hrv-rhr-sleep-recovery) below |
 | `getbased_list_profiles` | List all profiles by name and ID |
 | `knowledge_search` | Semantic search over your knowledge base. Requires a lens RAG server (default: `http://127.0.0.1:8322`, configurable via `LENS_URL`). Degrades gracefully — the lab-context tools keep working even if no RAG server is reachable. |
 | `knowledge_list_libraries` | List all libraries on the RAG server with their ids + which is active |
@@ -116,7 +117,7 @@ getbased_section('wearables', profile='Main')
 
 #### 30-day daily series (opt-in, ~400 tokens)
 
-For time-series reasoning ("did HRV drop the week before I got sick?"), the always-on summary isn't enough. Open **Settings → Agent Access** and turn on **"Push 30-day wearable series"**. The browser then writes a pivoted matrix into a separate section:
+For time-series reasoning ("did HRV drop the week before I got sick?"), the always-on summary isn't enough. Open **Settings → Data → Agent Access** and turn on **"Push 30-day wearable series"**. The browser then writes a pivoted matrix into a separate section:
 
 ```
 getbased_section('wearables-series-30d', profile='Main')

--- a/docs/guide/personal-agents.md
+++ b/docs/guide/personal-agents.md
@@ -16,75 +16,18 @@ Any client that speaks the [Model Context Protocol](https://modelcontextprotocol
 
 Any other MCP client works too — the adapter is client-agnostic.
 
-## How It Works
+## How it works
 
 ```
 getbased (browser) ──► Context Gateway ──► your agent (via MCP)
                        (text summary)       (read-only)
 ```
 
-1. You toggle **Agent Access** in getbased Settings → Data. A read-only token is minted.
-2. getbased pushes a text summary of your labs, context cards, supplements, and goals to the context gateway on every save.
-3. Your agent (Hermes, OpenClaw, Claude Code, …) uses the `getbased-agent-stack` adapter with your token to read that summary and answer questions.
+getbased pushes a text summary of your labs, context cards, supplements, and goals to the context gateway on every save. Your agent uses the `getbased-agent-stack` adapter with your token to read that summary and answer questions — read-only, no raw data, no mnemonic.
 
 ## Setup
 
-### 1. Enable in getbased
-
-Go to **Settings → Data → Agent Access** and toggle it on. A read-only token is generated — copy it.
-
-### 2. Install the agent stack
-
-Linux, one command:
-
-```bash
-curl -sSL https://getbased.health/install.sh | bash
-```
-
-Installs the MCP adapter, the local RAG knowledge server, and the browser setup dashboard; starts the latter two as systemd user services. [Read the script first](https://github.com/elkimek/get-based-site/blob/main/install.sh) if you prefer to audit before running — the [Interpretive Lens guide](./interpretive-lens.md#external-server) lists the `sha256sum -c` verification command.
-
-macOS / Windows / WSL1, or prefer a manual path:
-
-```bash
-pipx install --include-deps "getbased-agent-stack[full]"
-# or with uv:
-# uv tool install --with-executables-from getbased-rag \
-#                 --with-executables-from getbased-dashboard \
-#                 --with-executables-from getbased-mcp \
-#                 "getbased-agent-stack[full]"
-getbased-stack init --yes      # writes config, generates API key
-```
-
-If you only want the MCP adapter and nothing else (no RAG), `pipx install getbased-mcp` is a smaller ~10 MB alternative.
-
-### 3. Generate client config
-
-Launch the dashboard (or open it via the one-click login URL the installer prints at the end) and copy a paste-ready config block for your client:
-
-```bash
-# Already running via systemd after install.sh — visit http://127.0.0.1:8323
-# Manual install? run:
-getbased-dashboard serve       # http://127.0.0.1:8323
-```
-
-Open it in a browser, paste your bearer key at the auth gate, switch to the **MCP** tab, pick your client from the dropdown (Claude Desktop / Claude Code / Cursor / Cline / Hermes / OpenClaw), click **copy**. Paste into the client's config file (path shown in the dashboard).
-
-Click **Run test** to verify the adapter spawns correctly before switching to your agent.
-
-### 4. Chat
-
-In your agent, ask anything about your labs. The adapter exposes these tools:
-
-| Tool | Purpose |
-|---|---|
-| `getbased_lab_context` | Full lab summary — values, ranges, trends, context cards, supplements, goals |
-| `getbased_section` | One specific section (hormones, biometrics, etc.) or the section index |
-| `getbased_list_profiles` | List all profiles you track |
-| `knowledge_search` | Semantic search over your Knowledge Base — requires the local RAG server running (systemd user service on Linux after `install.sh`, or `lens serve` manually on other platforms). Degrades gracefully when unavailable. |
-| `knowledge_list_libraries` | List RAG libraries + which is active |
-| `knowledge_activate_library` | Switch the active library for subsequent searches |
-| `knowledge_stats` | Per-source chunk counts for diagnosing missing results |
-| `getbased_lens_config` | Show the Custom Knowledge Source endpoint + key so the agent stays in sync with what the PWA is configured to query |
+Setup is covered end-to-end on the [**Agent Access**](./agent-access.md#setup) page: enable the token in **Settings → Data → Agent Access**, install `getbased-agent-stack`, and copy a paste-ready config for your client from the dashboard. That page also has the full [tool reference](./agent-access.md#compatible-tools), the [Hermes Agent example](./agent-access.md#hermes-agent-example), wearable time-series setup, and troubleshooting.
 
 ## Running a local knowledge base
 
@@ -96,32 +39,6 @@ lens serve                   # starts on 127.0.0.1:8322
 lens ingest ~/Documents/research
 ```
 
-With `lens serve` running, `knowledge_search` is grounded in your own document corpus (research papers, clinical guides, personal notes).
+With `lens serve` running, the `knowledge_search` tool is grounded in your own document corpus (research papers, clinical guides, personal notes).
 
 See [Interpretive Lens](./interpretive-lens.md#external-server) for the full RAG setup — including per-library embedding models (MiniLM for speed, BGE-M3 for quality) and connecting the same server to the in-app AI chat via the External server backend.
-
-## Hermes Agent quick-config
-
-```yaml
-# ~/.hermes/config.yaml
-mcp_servers:
-  getbased:
-    command: getbased-mcp
-    args: []
-    env:
-      GETBASED_GATEWAY: https://sync.getbased.health
-      GETBASED_TOKEN: your-token-here
-```
-
-Restart: `hermes gateway restart`. The dashboard's MCP tab generates this exact YAML (with the fields pre-filled) — copy from there to avoid typos.
-
-## Security
-
-- The token grants **read-only** access to a pre-built text summary — no writes, no mutations, no raw data
-- Your sync mnemonic is never shared — Agent Access is a separate system
-- Revoking (toggle off or regenerate) immediately invalidates the token
-- Treat the token like a password — don't commit it to a public repo
-
-## Self-hosting the gateway
-
-The context gateway is a lightweight Node.js server. If you [self-host your sync relay](./cross-device-sync.md#running-your-own-relay), the gateway runs alongside it on the same VPS. All data stays on your own infrastructure.

--- a/docs/guide/wearables.md
+++ b/docs/guide/wearables.md
@@ -58,7 +58,7 @@ Manual entries sync to your other devices via the same Evolu CRDT summary layer 
 - **Compact summary** (the L2 dashboard data) syncs to your other devices via Evolu CRDT (E2E encrypted, mnemonic-based identity).
 - **OAuth refresh tokens stay local.** They are *not* synced — you re-connect on each device.
 - **AI chat context** includes a ~200-token wearable summary by default. Toggle it off in Settings → AI → AI Context.
-- **Personal Agent (MCP)** receives the same compact summary by default. Optionally enable a 30-day pivoted daily series in Settings → Agent Access → "Push 30-day wearable series" for time-series reasoning ("did HRV drop the week before I got sick?"). See [Agent Access](agent-access.md).
+- **Personal Agent (MCP)** receives the same compact summary by default. Optionally enable a 30-day pivoted daily series in Settings → Data → Agent Access → "Push 30-day wearable series" for time-series reasoning ("did HRV drop the week before I got sick?"). See [Agent Access](agent-access.md).
 
 ## Multi-vendor metric ownership
 


### PR DESCRIPTION
## Summary
Cleanup of the MCP/agent setup docs after an end-to-end review found real consistency bugs.

### Stale "Messenger Access" name
The app UI calls this **"Agent Access"** — "Messenger Access" is the old name (survives only in code comments). The `.well-known` discovery files inherited it from the `getbased-mcp` README and pointed users at a toggle that doesn't exist by that name.
- `.well-known/mcp.json`, `SKILL.md` — fixed; `index.json` digest regenerated
- Companion fixes: getbased-agents#15 (README + dashboard), get-based-site#8

### Stale tool table
`agent-access.md` listed **8** tools — the server exposes **9**. `getbased_wearables_series` was missing, even though the 30-day wearables series it powers is described in prose right below the table. Added.

### Settings path
Fixed `Settings → Agent Access` → `Settings → Data → Agent Access` in `agent-access.md` and `wearables.md` (everywhere else already had the full path).

### Dedup
`personal-agents.md` duplicated `agent-access.md`'s Setup, tool table, Hermes config, and Security sections wholesale — which is exactly why they'd drifted. Trimmed it to what's unique: the concept, the supported-agents catalog, and the local-knowledge-base section. Setup now defers to `agent-access.md`, the canonical reference. (−81 lines.)

## Test plan
- [ ] `docs:build` succeeds; `personal-agents.md` cross-links to `agent-access.md` resolve
- [ ] `grep -ri "messenger access" docs/ .well-known/` returns nothing
- [ ] `agent-access.md` tool table shows 9 tools
- [ ] `sha256sum` of `SKILL.md` matches the `digest` in `index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)