### PR TITLE
Advertise discovery files via Link header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,8 @@
         "Referrer-Policy": "strict-origin-when-cross-origin",
         "Cross-Origin-Opener-Policy": "same-origin",
         "Cross-Origin-Embedder-Policy": "credentialless",
-        "Onion-Location": "http://iobqafpywmncin7m2wpvbemouvulaeb7jnvtvugxnru4gpneushb5jyd.onion/$1"
+        "Onion-Location": "http://iobqafpywmncin7m2wpvbemouvulaeb7jnvtvugxnru4gpneushb5jyd.onion/$1",
+        "Link": "</.well-known/mcp.json>; rel=\"service-desc\"; type=\"application/json\"; title=\"MCP server card\", </.well-known/agent-skills/index.json>; rel=\"service-desc\"; type=\"application/json\"; title=\"Agent Skills index\""
       },
       "continue": true
     },


### PR DESCRIPTION
## Summary
Adds a `Link` response header on the catch-all route, pointing agents to the MCP server card and Agent Skills index. This is the last remaining Discoverability check on [isitagentready.com](https://isitagentready.com/app.getbased.health) — the app is currently 2/3 there (robots.txt ✓, sitemap ✓, Link headers ✗).

- Header lives in the existing `routes` catch-all `headers` block (legacy Vercel config — `headers`/`rewrites` keys aren't available, but `routes` handles this fine).
- Relative URLs (`</.well-known/...>`) so preview deployments resolve to the preview copy, not production.
- No `llms.txt` entry — the app domain doesn't have one (that's the marketing site).

Expected effect: Discoverability 2/3 → 3/3, overall score ~50 → ~58.

## Test plan
- [ ] After deploy, `curl -I https://app.getbased.health/` shows the `Link` header
- [ ] Both linked paths (`/.well-known/mcp.json`, `/.well-known/agent-skills/index.json`) return 200
- [ ] Re-scan on isitagentready.com — Link headers check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)