### PR TITLE
Fix changelog test regex for docs.getbased.health

### DIFF
--- a/tests/test-changelog-dom.js
+++ b/tests/test-changelog-dom.js
@@ -88,7 +88,7 @@ return (async function() {
   assert('changelog renders <code> as code (not literal text)',
     !itemsHTML.includes('&lt;code&gt;'));
   assert('changelog renders safe https <a> as a real link',
-    /<a href="https:\/\/getbased\.health[^"]*" target="_blank" rel="noopener noreferrer">[^<]+<\/a>/.test(itemsHTML));
+    /<a href="https:\/\/(?:[a-z-]+\.)?getbased\.health[^"]*" target="_blank" rel="noopener noreferrer">[^<]+<\/a>/.test(itemsHTML));
   window.closeChangelog();
 
   // Clean up


### PR DESCRIPTION
## Summary
The `test-changelog-dom.js` assertion "renders safe https `<a>` as a real link" hardcoded `https://getbased.health` in its regex. PR #231 repointed the changelog's docs link to `https://docs.getbased.health/...`, which the regex doesn't match — so the test has been failing on `main` ever since #231 merged.

Broadened the host pattern to `https://(?:[a-z-]+\.)?getbased\.health` — matches `getbased.health` and its subdomains (`docs.`, `app.`).

This is a self-inflicted regression from #231; it's also why **#232's CI shows red** (it inherits the broken `main` test). Merging this unblocks #232.

## Test plan
- [x] `node run-tests.js` → `test-changelog-dom.js`: 14 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)