### PR TITLE
Fix flaky trapModalFocus test (shared-page teardown race)

### DIFF
--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -117,15 +117,25 @@ return (async function () {
 
     // Poll until `cond()` holds (or timeout). The whole suite runs in one
     // shared page, so an earlier test file's async modal-teardown observer
-    // can still be in flight here — a fixed delay races it.
+    // can still be in flight here — a fixed delay races it. Warns on
+    // timeout so a future failure reads as "race" not "regression".
     const waitFor = async (cond, ms = 500) => {
       const start = Date.now();
       while (!cond() && Date.now() - start < ms) await delay(10);
+      const ok = cond();
+      if (!ok) console.warn(`[test-audit-fixes] waitFor timed out after ${ms}ms`);
+      return ok;
     };
 
-    // Drain any leaked teardown observers from earlier files, *then* set the
-    // baseline last so a stale restore() can't clobber it mid-section.
-    await delay(50);
+    // An earlier test file's async modal-teardown can still be writing
+    // document.body.style.overflow. Wait for it to settle (value unchanged
+    // across a 10ms tick) before capturing our baseline — self-calibrating,
+    // not a fixed drain — then set the baseline value last.
+    let prevOverflow = null;
+    for (let i = 0; i < 50 && document.body.style.overflow !== prevOverflow; i++) {
+      prevOverflow = document.body.style.overflow;
+      await delay(10);
+    }
     document.body.style.overflow = 'auto';
     const baseline = document.body.style.overflow;
 

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -115,7 +115,17 @@ return (async function () {
     const sun = await import('/js/sun.js?bust=' + Date.now());
     assert('sun.js exports trapModalFocus', typeof sun.trapModalFocus === 'function');
 
-    // Set a baseline overflow we can verify gets restored.
+    // Poll until `cond()` holds (or timeout). The whole suite runs in one
+    // shared page, so an earlier test file's async modal-teardown observer
+    // can still be in flight here — a fixed delay races it.
+    const waitFor = async (cond, ms = 500) => {
+      const start = Date.now();
+      while (!cond() && Date.now() - start < ms) await delay(10);
+    };
+
+    // Drain any leaked teardown observers from earlier files, *then* set the
+    // baseline last so a stale restore() can't clobber it mid-section.
+    await delay(50);
     document.body.style.overflow = 'auto';
     const baseline = document.body.style.overflow;
 
@@ -147,7 +157,7 @@ return (async function () {
     // Escape key on outer — overlay should be removed.
     const escEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
     document.dispatchEvent(escEvent);
-    await delay(20);
+    await waitFor(() => !document.body.contains(overlay) && document.body.style.overflow === baseline);
     assert('Escape key removes overlay',
       !document.body.contains(overlay));
     assert('body overflow restored to baseline after all modals closed',
@@ -165,7 +175,7 @@ return (async function () {
     sun.trapModalFocus(overlay3);
     stash.remove(); // detach previouslyFocused
     let threw = false;
-    try { overlay3.remove(); await delay(20); } catch (e) { threw = true; }
+    try { overlay3.remove(); await waitFor(() => document.body.style.overflow === baseline); } catch (e) { threw = true; }
     assert('detached-previouslyFocused does not throw on restore', !threw);
     assert('body overflow restored even after detached restore',
       document.body.style.overflow === baseline);


### PR DESCRIPTION
## Summary
`test-audit-fixes.js` section 3 ("trapModalFocus") failed **deterministically on CI** but passed locally (verified 13/13 green runs) — `main`'s longstanding flake.

**Root cause:** the suite runs all ~50 test files in one shared browser page, and `trapModalFocus` tears down via an async `MutationObserver` → `restore()` that writes `document.body.style.overflow`. An earlier modal-touching test file's pending `restore()` could still be in flight when this section captured its `baseline`, then fire and clobber it mid-section — passing the first overflow assertion and failing the later one (exactly the observed split). Locally the microtasks settled before section 3 ran; the slower CI runner interleaved differently.

**Fix (test-only):**
- Drain pending teardown observers (`await delay`) before capturing `baseline`, and set the baseline value *last* so a stale `restore()` can't clobber it.
- Replace the fixed `await delay(20)` waits after modal removal with a `waitFor()` poll on the actual condition — the assertions no longer race the async teardown.

No production code touched — the fragility was purely a test-harness artifact (`trapModalFocus` itself works correctly; I traced its logic exhaustively).

## Test plan
- [x] `node run-tests.js` → `test-audit-fixes.js` 62/62, 8 consecutive runs
- [ ] CI `Tests` job goes green (the real proof — flake was CI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)