### PR TITLE
[codex] Extract compare correlations views

### DIFF
--- a/js/compare-correlations.js
+++ b/js/compare-correlations.js
@@ -1,0 +1,320 @@
+// compare-correlations.js - Compare Dates and Correlations views
+
+import { state } from './state.js';
+import { CORRELATION_PRESETS, CHIP_COLORS } from './schema.js';
+import { escapeHTML, getStatus, formatValue } from './utils.js';
+import { getChartColors } from './theme.js';
+import { getActiveData, getEffectiveRange, getEffectiveRangeForDate } from './data.js';
+import { ensureChartJs, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin } from './charts.js';
+
+const compareCorrelationDeps = {
+  renderTableColgroup: () => '',
+  renderScrollableTableShell: (_kind, _wrapperClass, _tableClass, _colgroup, headHtml, bodyHtml) => '<table>' + headHtml + bodyHtml + '</table>',
+  renderCategoryGlyph: (_categoryKey, label = '') => escapeHTML(label || ''),
+};
+
+export function configureCompareCorrelationViews(deps = {}) {
+  Object.assign(compareCorrelationDeps, deps);
+}
+
+function renderTableColgroup(cols) {
+  return compareCorrelationDeps.renderTableColgroup(cols);
+}
+
+function renderScrollableTableShell(...args) {
+  return compareCorrelationDeps.renderScrollableTableShell(...args);
+}
+
+function renderCategoryGlyph(...args) {
+  return compareCorrelationDeps.renderCategoryGlyph(...args);
+}
+// Compare Dates
+
+export function showCompare(data) {
+  if (!data) data = getActiveData();
+  const main = document.getElementById("main-content");
+  let html = `<div class="category-header"><h2>Compare Dates</h2>
+    <p>Side-by-side comparison of biomarker values between two collection dates</p></div>`;
+  if (data.dates.length < 2) {
+    html += `<div class="empty-state"><div class="empty-state-icon">\u2194</div>
+      <h3>Not Enough Data</h3><p>Import at least 2 lab result dates to compare values side by side.</p></div>`;
+    main.innerHTML = html;
+    return;
+  }
+  if (!state.compareDate1 || !data.dates.includes(state.compareDate1)) state.compareDate1 = data.dates[0];
+  if (!state.compareDate2 || !data.dates.includes(state.compareDate2)) state.compareDate2 = data.dates[data.dates.length - 1];
+  const fmtOpt = d => {
+    const label = new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    return `<option value="${d}">${label}</option>`;
+  };
+  html += `<div class="compare-controls">
+    <label class="compare-date-field" for="compare-select-1"><span>Date 1:</span>
+      <select id="compare-select-1" onchange="setCompareDate1(this.value)">${data.dates.map(d => fmtOpt(d)).join('')}</select>
+    </label>
+    <button class="compare-swap-btn" onclick="swapCompareDates()" title="Swap dates" aria-label="Swap dates">\u21C4</button>
+    <label class="compare-date-field" for="compare-select-2"><span>Date 2:</span>
+      <select id="compare-select-2" onchange="setCompareDate2(this.value)">${data.dates.map(d => fmtOpt(d)).join('')}</select>
+    </label>
+  </div>`;
+  html += `<div id="compare-results"></div>`;
+  main.innerHTML = html;
+  document.getElementById('compare-select-1').value = state.compareDate1;
+  document.getElementById('compare-select-2').value = state.compareDate2;
+  updateCompare();
+}
+
+export function setCompareDate1(value) { state.compareDate1 = value; updateCompare(); }
+export function setCompareDate2(value) { state.compareDate2 = value; updateCompare(); }
+
+export function updateCompare() {
+  const data = getActiveData();
+  const container = document.getElementById('compare-results');
+  if (!container) return;
+  const idx1 = data.dates.indexOf(state.compareDate1);
+  const idx2 = data.dates.indexOf(state.compareDate2);
+  if (idx1 === -1 || idx2 === -1) { container.innerHTML = ''; return; }
+  container.innerHTML = renderCompareTable(data, idx1, idx2);
+}
+
+export function swapCompareDates() {
+  const tmp = state.compareDate1;
+  state.compareDate1 = state.compareDate2;
+  state.compareDate2 = tmp;
+  const s1 = document.getElementById('compare-select-1');
+  const s2 = document.getElementById('compare-select-2');
+  if (s1) s1.value = state.compareDate1;
+  if (s2) s2.value = state.compareDate2;
+  updateCompare();
+}
+
+export function renderCompareTable(data, idx1, idx2) {
+  const d1Label = data.dateLabels[idx1];
+  const d2Label = data.dateLabels[idx2];
+  const colgroup = renderTableColgroup([
+    'gb-col-marker',
+    'gb-col-unit',
+    'gb-col-reference',
+    'gb-col-compare-date',
+    'gb-col-compare-date',
+    'gb-col-delta',
+    'gb-col-delta',
+  ]);
+  const headHtml = `<tr>
+    <th>Biomarker</th><th>Unit</th><th>Reference</th>
+    <th>${d1Label}</th><th>${d2Label}</th><th>Delta</th><th>% Change</th></tr>`;
+  let bodyHtml = '';
+  for (const [catKey, cat] of Object.entries(data.categories)) {
+    if (cat.singlePoint) continue;
+    const rows = [];
+    for (const [mKey, marker] of Object.entries(cat.markers)) {
+      const v1 = marker.values[idx1];
+      const v2 = marker.values[idx2];
+      if (v1 === null && v2 === null) continue;
+      const mr1 = getEffectiveRangeForDate(marker, idx1);
+      const mr2 = getEffectiveRangeForDate(marker, idx2);
+      const mr = getEffectiveRange(marker);
+      const s1 = v1 !== null ? getStatus(v1, mr1.min, mr1.max) : 'missing';
+      const s2 = v2 !== null ? getStatus(v2, mr2.min, mr2.max) : 'missing';
+      let delta = null, pctChange = null, directionClass = 'compare-neutral';
+      if (v1 !== null && v2 !== null) {
+        delta = v2 - v1;
+        pctChange = v1 !== 0 ? (delta / v1) * 100 : null;
+        if (mr.min != null && mr.max != null) {
+          const mid = (mr.min + mr.max) / 2;
+          const dist1 = Math.abs(v1 - mid);
+          const dist2 = Math.abs(v2 - mid);
+          if (dist2 < dist1 - 0.001) directionClass = 'compare-improved';
+          else if (dist2 > dist1 + 0.001) directionClass = 'compare-worsened';
+        }
+      }
+      const refStr = marker.refMin != null && marker.refMax != null ? `${formatValue(marker.refMin)} \u2013 ${formatValue(marker.refMax)}` : '\u2014';
+      rows.push(`<tr>
+        <td class="marker-name">${escapeHTML(marker.name)}</td>
+        <td style="color:var(--text-muted);font-size:12px">${escapeHTML(marker.unit)}</td>
+        <td style="color:var(--text-secondary);font-size:12px">${refStr}</td>
+        <td class="value-cell val-${s1}" style="font-weight:600">${v1 !== null ? formatValue(v1) : '\u2014'}</td>
+        <td class="value-cell val-${s2}" style="font-weight:600">${v2 !== null ? formatValue(v2) : '\u2014'}</td>
+        <td class="${directionClass}" style="font-weight:600">${delta !== null ? (delta > 0 ? '+' : '') + formatValue(delta) : '\u2014'}</td>
+        <td class="${directionClass}" style="font-weight:600">${pctChange !== null ? (pctChange > 0 ? '+' : '') + pctChange.toFixed(1) + '%' : '\u2014'}</td>
+      </tr>`);
+    }
+    if (rows.length > 0) {
+      bodyHtml += `<tr class="cat-row"><td colspan="7"><span class="compare-category-label">${renderCategoryGlyph(catKey, cat.label)}<span>${escapeHTML(cat.label)}</span></span></td></tr>`;
+      bodyHtml += rows.join('');
+    }
+  }
+  return renderScrollableTableShell('compare', 'compare-table-wrapper', 'compare-table', colgroup, headHtml, bodyHtml, 866);
+}
+
+// Correlations
+
+export function showCorrelations(data) {
+  if (!data) data = getActiveData();
+  const main = document.getElementById("main-content");
+  let html = `<div class="category-header"><h2>Correlations</h2>
+    <p>Compare biomarkers across categories on a normalized scale</p></div>`;
+  html += `<div class="correlation-controls">
+    <h3>Select Biomarkers (2\u20138)</h3>
+    <div class="corr-select-row">
+      <div class="corr-dropdown">
+        <input type="text" class="corr-search" id="corr-search" placeholder="Search biomarkers..."
+          oninput="filterCorrelationOptions()" onfocus="showCorrelationDropdown()">
+        <div class="corr-options" id="corr-options"></div>
+      </div>
+    </div>
+    <div class="corr-chips" id="corr-chips"></div>
+    <div class="corr-presets">
+      <div class="corr-presets-label">Quick Presets:</div>`;
+  for (let i = 0; i < CORRELATION_PRESETS.length; i++) {
+    html += `<button class="corr-preset-btn" onclick="applyCorrelationPreset(${i})">${CORRELATION_PRESETS[i].label}</button>`;
+  }
+  html += `</div></div>`;
+  html += `<div class="corr-chart-container" id="corr-chart-container" style="display:none">
+    <h3>Normalized Comparison (% of Reference Range)
+      <button class="corr-ask-ai-btn" onclick="askAIAboutCorrelations()" title="Ask AI about these correlations">Ask AI</button>
+    </h3>
+    <div class="corr-chart"><canvas id="chart-correlation"></canvas></div></div>`;
+  main.innerHTML = html;
+  populateCorrelationOptions(data);
+  renderCorrelationChips();
+  if (state.selectedCorrelationMarkers.length >= 2) renderCorrelationChart();
+}
+
+export function populateCorrelationOptions(data) {
+  if (!data) data = getActiveData();
+  const container = document.getElementById("corr-options");
+  if (!container) return;
+  let html = '';
+  for (const [catKey, cat] of Object.entries(data.categories)) {
+    for (const [markerKey, marker] of Object.entries(cat.markers)) {
+      if (marker.singlePoint) continue;
+      const fullKey = `${catKey}.${markerKey}`;
+      const selected = state.selectedCorrelationMarkers.includes(fullKey);
+      html += `<div class="corr-option ${selected ? 'selected' : ''}"
+        data-key="${fullKey}" data-name="${escapeHTML(marker.name)}" data-cat="${escapeHTML(cat.label)}"
+        onclick="toggleCorrelationMarker('${fullKey}')">
+        ${escapeHTML(marker.name)} <span class="opt-cat">${escapeHTML(cat.label)}</span></div>`;
+    }
+  }
+  container.innerHTML = html;
+}
+
+export function showCorrelationDropdown() {
+  document.getElementById("corr-options").classList.add("show");
+}
+
+export function filterCorrelationOptions() {
+  const search = document.getElementById("corr-search").value.toLowerCase();
+  document.querySelectorAll(".corr-option").forEach(opt => {
+    const name = opt.dataset.name.toLowerCase();
+    const cat = opt.dataset.cat.toLowerCase();
+    opt.style.display = (name.includes(search) || cat.includes(search)) ? '' : 'none';
+  });
+  document.getElementById("corr-options").classList.add("show");
+}
+
+export function toggleCorrelationMarker(key) {
+  const idx = state.selectedCorrelationMarkers.indexOf(key);
+  if (idx !== -1) state.selectedCorrelationMarkers.splice(idx, 1);
+  else if (state.selectedCorrelationMarkers.length < 8) state.selectedCorrelationMarkers.push(key);
+  renderCorrelationChips();
+  populateCorrelationOptions();
+  if (state.selectedCorrelationMarkers.length >= 2) renderCorrelationChart();
+  else {
+    document.getElementById("corr-chart-container").style.display = "none";
+    if (state.chartInstances["correlation"]) { state.chartInstances["correlation"].destroy(); delete state.chartInstances["correlation"]; }
+  }
+}
+
+export function applyCorrelationPreset(idx) {
+  state.selectedCorrelationMarkers = [...CORRELATION_PRESETS[idx].markers];
+  renderCorrelationChips();
+  populateCorrelationOptions();
+  if (state.selectedCorrelationMarkers.length >= 2) renderCorrelationChart();
+}
+
+export function renderCorrelationChips() {
+  const container = document.getElementById("corr-chips");
+  if (!container) return;
+  const data = getActiveData();
+  let html = '';
+  state.selectedCorrelationMarkers.forEach((key, i) => {
+    const [catKey, markerKey] = key.split('.');
+    const marker = data.categories[catKey]?.markers[markerKey];
+    if (!marker) return;
+    const color = CHIP_COLORS[i % CHIP_COLORS.length];
+    html += `<span class="corr-chip" style="background:${color}20;border-color:${color};color:${color}">
+      ${escapeHTML(marker.name)} <span class="chip-remove" onclick="toggleCorrelationMarker('${key}')">&times;</span></span>`;
+  });
+  container.innerHTML = html;
+}
+
+export function renderCorrelationChart() {
+  const data = getActiveData();
+  const container = document.getElementById("corr-chart-container");
+  container.style.display = "block";
+  if (state.chartInstances["correlation"]) { state.chartInstances["correlation"].destroy(); delete state.chartInstances["correlation"]; }
+  const canvas = document.getElementById("chart-correlation");
+  if (!canvas) return;
+  if (!window.Chart) {
+    ensureChartJs().then(() => {
+      if (document.getElementById("chart-correlation")) renderCorrelationChart();
+    }).catch(() => {});
+    return;
+  }
+  const datasets = [];
+  state.selectedCorrelationMarkers.forEach((key, i) => {
+    const [catKey, markerKey] = key.split('.');
+    const marker = data.categories[catKey]?.markers[markerKey];
+    if (!marker) return;
+    const normalizedValues = marker.values.map(v => {
+      if (v === null) return null;
+      if (marker.refMin == null || marker.refMax == null) return 50;
+      const range = marker.refMax - marker.refMin;
+      return range !== 0 ? ((v - marker.refMin) / range) * 100 : 50;
+    });
+    const color = CHIP_COLORS[i % CHIP_COLORS.length];
+    datasets.push({
+      label: marker.name, data: normalizedValues,
+      borderColor: color, backgroundColor: color + '20',
+      borderWidth: 2.5, pointRadius: 5, pointHoverRadius: 7,
+      pointBackgroundColor: color, tension: 0.3, fill: false, spanGaps: true,
+      _realValues: marker.values, _unit: marker.unit, _refMin: marker.refMin, _refMax: marker.refMax
+    });
+  });
+  const allVals = datasets.flatMap(ds => ds.data.filter(v => v !== null));
+  const minY = Math.min(0, ...allVals) - 10;
+  const maxY = Math.max(100, ...allVals) + 10;
+  const tc = getChartColors();
+  state.chartInstances["correlation"] = new window.Chart(canvas, {
+    type: "line",
+    data: { labels: data.dateLabels, datasets },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: {
+        legend: { display: true, labels: { color: tc.legendColor, font: { size: 12 }, usePointStyle: true, pointStyle: "circle" } },
+        tooltip: {
+          backgroundColor: tc.tooltipBg, titleColor: tc.tooltipTitle, bodyColor: tc.tooltipBody,
+          borderColor: tc.tooltipBorder, borderWidth: 1,
+          callbacks: {
+            label: (ctx) => {
+              const ds = ctx.dataset;
+              const realVal = ds._realValues[ctx.dataIndex];
+              const pct = ctx.parsed.y;
+              return `${ds.label}: ${formatValue(realVal)} ${ds._unit} (${pct !== null ? pct.toFixed(0) + '%' : 'N/A'})`;
+            }
+          }
+        },
+        refBand: { refMin: 0, refMax: 100 },
+        noteAnnotations: (function() { const n = getNotesForChart(data.dates); return n.length ? { notes: n, chartDates: data.dates } : false; })(),
+        supplementBars: (function() { const s = getSupplementsForChart(data.dates); return s.length ? { supplements: s, chartDates: data.dates } : false; })()
+      },
+      layout: { padding: { top: (function() { const s = getSupplementsForChart(data.dates); return s.length ? s.length * 14 + 6 : 0; })() } },
+      scales: {
+        x: { ticks: { color: tc.tickColor, font: { size: 11 } }, grid: { display: false } },
+        y: { min: minY, max: maxY, ticks: { color: tc.tickColor, font: { size: 10 }, callback: v => v + '%' }, grid: { color: tc.gridColor } }
+      }
+    },
+    plugins: [refBandPlugin, noteAnnotationPlugin, supplementBarPlugin]
+  });
+}

--- a/js/views.js
+++ b/js/views.js
@@ -1,12 +1,12 @@
-// views.js — Navigate, dashboard, category views, detail modal, compare, correlations
+// views.js — Navigate, dashboard, category views, and shared view composition
 
 import { state } from './state.js';
-import { CORRELATION_PRESETS, CHIP_COLORS, trackUsage } from './schema.js';
+import { trackUsage } from './schema.js';
 import { escapeHTML, escapeAttr, getStatus, getRangePosition, formatValue, getTrend, showNotification, hasCardContent, formatDate, safeMarkerId } from './utils.js';
 import { getChartColors } from './theme.js';
 import { getActiveData, filterDatesByRange, destroyAllCharts, getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, getAllFlaggedMarkers, countFlagged, statusIcon, getFocusCardFingerprint, saveImportedData, updateHeaderDates, renderDateRangeFilter, renderChartLayersDropdown } from './data.js';
 import { profileStorageKey, getProfiles } from './profile.js';
-import { createLineChart, ensureChartJs, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin } from './charts.js';
+import { createLineChart, ensureChartJs } from './charts.js';
 import { canonicalMetric, metricsForSources } from './wearable-adapters.js';
 import { loadContextHealthDots } from './context-cards.js';
 import { callClaudeAPI, hasAIProvider, isAIPaused, getAIProvider, getActiveModelId } from './api.js';
@@ -20,6 +20,23 @@ import { createDashboardWidgetRegistry } from './dashboard-widgets.js';
 import { createDashboardWidgetControls } from './dashboard-widget-controls.js';
 import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js';
 import { renderLightConditionsWidgetBody, renderConditionsNow, _refreshConditionsNow, _inspectConditionsNow, _setManualUvi, _clearManualUvi, _formatElapsedShort } from './light-conditions-now.js';
+import {
+  configureCompareCorrelationViews,
+  showCompare,
+  setCompareDate1,
+  setCompareDate2,
+  updateCompare,
+  swapCompareDates,
+  renderCompareTable,
+  showCorrelations,
+  populateCorrelationOptions,
+  showCorrelationDropdown,
+  filterCorrelationOptions,
+  toggleCorrelationMarker,
+  applyCorrelationPreset,
+  renderCorrelationChips,
+  renderCorrelationChart,
+} from './compare-correlations.js';
 import {
   configureMarkerDetailModal,
   fetchCustomMarkerDescription,
@@ -46,6 +63,20 @@ import {
   rememberModalTrigger,
 } from './marker-detail-modal.js';
 export {
+  showCompare,
+  setCompareDate1,
+  setCompareDate2,
+  updateCompare,
+  swapCompareDates,
+  renderCompareTable,
+  showCorrelations,
+  populateCorrelationOptions,
+  showCorrelationDropdown,
+  filterCorrelationOptions,
+  toggleCorrelationMarker,
+  applyCorrelationPreset,
+  renderCorrelationChips,
+  renderCorrelationChart,
   fetchCustomMarkerDescription,
   showDetailModal,
   editRefRange,
@@ -3781,6 +3812,12 @@ function renderScrollableTableShell(kind, wrapperClass, tableClass, colgroup, he
   </div>`;
 }
 
+configureCompareCorrelationViews({
+  renderTableColgroup,
+  renderScrollableTableShell,
+  renderCategoryGlyph,
+});
+
 export function renderTableView(cat, dateLabels, categoryKey, dates) {
   const labels = cat.singleDate ? [cat.singleDateLabel || "N/A"] : dateLabels;
   // Hide markers with no values at all — sidebar still lists them with 0 count.
@@ -3945,301 +3982,6 @@ export function renderFattyAcidsCharts(cat) {
       plugins: { legend:{display:false}, tooltip:{ backgroundColor:tc.tooltipBg, titleColor:tc.tooltipTitle, bodyColor:tc.tooltipBody, borderColor:tc.tooltipBorder, borderWidth:1 }},
       scales: { x:{ticks:{color:tc.tickColor,font:{size:10},maxRotation:45},grid:{display:false}}, y:{ticks:{color:tc.tickColor},grid:{color:tc.gridColor}} }
     }
-  });
-}
-
-// ═══════════════════════════════════════════════
-// COMPARE DATES
-// ═══════════════════════════════════════════════
-
-export function showCompare(data) {
-  if (!data) data = getActiveData();
-  const main = document.getElementById("main-content");
-  let html = `<div class="category-header"><h2>Compare Dates</h2>
-    <p>Side-by-side comparison of biomarker values between two collection dates</p></div>`;
-  if (data.dates.length < 2) {
-    html += `<div class="empty-state"><div class="empty-state-icon">\u2194</div>
-      <h3>Not Enough Data</h3><p>Import at least 2 lab result dates to compare values side by side.</p></div>`;
-    main.innerHTML = html;
-    return;
-  }
-  if (!state.compareDate1 || !data.dates.includes(state.compareDate1)) state.compareDate1 = data.dates[0];
-  if (!state.compareDate2 || !data.dates.includes(state.compareDate2)) state.compareDate2 = data.dates[data.dates.length - 1];
-  const fmtOpt = d => {
-    const label = new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    return `<option value="${d}">${label}</option>`;
-  };
-  html += `<div class="compare-controls">
-    <label class="compare-date-field" for="compare-select-1"><span>Date 1:</span>
-      <select id="compare-select-1" onchange="setCompareDate1(this.value)">${data.dates.map(d => fmtOpt(d)).join('')}</select>
-    </label>
-    <button class="compare-swap-btn" onclick="swapCompareDates()" title="Swap dates" aria-label="Swap dates">\u21C4</button>
-    <label class="compare-date-field" for="compare-select-2"><span>Date 2:</span>
-      <select id="compare-select-2" onchange="setCompareDate2(this.value)">${data.dates.map(d => fmtOpt(d)).join('')}</select>
-    </label>
-  </div>`;
-  html += `<div id="compare-results"></div>`;
-  main.innerHTML = html;
-  document.getElementById('compare-select-1').value = state.compareDate1;
-  document.getElementById('compare-select-2').value = state.compareDate2;
-  updateCompare();
-}
-
-export function setCompareDate1(value) { state.compareDate1 = value; updateCompare(); }
-export function setCompareDate2(value) { state.compareDate2 = value; updateCompare(); }
-
-export function updateCompare() {
-  const data = getActiveData();
-  const container = document.getElementById('compare-results');
-  if (!container) return;
-  const idx1 = data.dates.indexOf(state.compareDate1);
-  const idx2 = data.dates.indexOf(state.compareDate2);
-  if (idx1 === -1 || idx2 === -1) { container.innerHTML = ''; return; }
-  container.innerHTML = renderCompareTable(data, idx1, idx2);
-}
-
-export function swapCompareDates() {
-  const tmp = state.compareDate1;
-  state.compareDate1 = state.compareDate2;
-  state.compareDate2 = tmp;
-  const s1 = document.getElementById('compare-select-1');
-  const s2 = document.getElementById('compare-select-2');
-  if (s1) s1.value = state.compareDate1;
-  if (s2) s2.value = state.compareDate2;
-  updateCompare();
-}
-
-export function renderCompareTable(data, idx1, idx2) {
-  const d1Label = data.dateLabels[idx1];
-  const d2Label = data.dateLabels[idx2];
-  const colgroup = renderTableColgroup([
-    'gb-col-marker',
-    'gb-col-unit',
-    'gb-col-reference',
-    'gb-col-compare-date',
-    'gb-col-compare-date',
-    'gb-col-delta',
-    'gb-col-delta',
-  ]);
-  const headHtml = `<tr>
-    <th>Biomarker</th><th>Unit</th><th>Reference</th>
-    <th>${d1Label}</th><th>${d2Label}</th><th>Delta</th><th>% Change</th></tr>`;
-  let bodyHtml = '';
-  for (const [catKey, cat] of Object.entries(data.categories)) {
-    if (cat.singlePoint) continue;
-    const rows = [];
-    for (const [mKey, marker] of Object.entries(cat.markers)) {
-      const v1 = marker.values[idx1];
-      const v2 = marker.values[idx2];
-      if (v1 === null && v2 === null) continue;
-      const mr1 = getEffectiveRangeForDate(marker, idx1);
-      const mr2 = getEffectiveRangeForDate(marker, idx2);
-      const mr = getEffectiveRange(marker);
-      const s1 = v1 !== null ? getStatus(v1, mr1.min, mr1.max) : 'missing';
-      const s2 = v2 !== null ? getStatus(v2, mr2.min, mr2.max) : 'missing';
-      let delta = null, pctChange = null, directionClass = 'compare-neutral';
-      if (v1 !== null && v2 !== null) {
-        delta = v2 - v1;
-        pctChange = v1 !== 0 ? (delta / v1) * 100 : null;
-        if (mr.min != null && mr.max != null) {
-          const mid = (mr.min + mr.max) / 2;
-          const dist1 = Math.abs(v1 - mid);
-          const dist2 = Math.abs(v2 - mid);
-          if (dist2 < dist1 - 0.001) directionClass = 'compare-improved';
-          else if (dist2 > dist1 + 0.001) directionClass = 'compare-worsened';
-        }
-      }
-      const refStr = marker.refMin != null && marker.refMax != null ? `${formatValue(marker.refMin)} \u2013 ${formatValue(marker.refMax)}` : '\u2014';
-      rows.push(`<tr>
-        <td class="marker-name">${escapeHTML(marker.name)}</td>
-        <td style="color:var(--text-muted);font-size:12px">${escapeHTML(marker.unit)}</td>
-        <td style="color:var(--text-secondary);font-size:12px">${refStr}</td>
-        <td class="value-cell val-${s1}" style="font-weight:600">${v1 !== null ? formatValue(v1) : '\u2014'}</td>
-        <td class="value-cell val-${s2}" style="font-weight:600">${v2 !== null ? formatValue(v2) : '\u2014'}</td>
-        <td class="${directionClass}" style="font-weight:600">${delta !== null ? (delta > 0 ? '+' : '') + formatValue(delta) : '\u2014'}</td>
-        <td class="${directionClass}" style="font-weight:600">${pctChange !== null ? (pctChange > 0 ? '+' : '') + pctChange.toFixed(1) + '%' : '\u2014'}</td>
-      </tr>`);
-    }
-    if (rows.length > 0) {
-      bodyHtml += `<tr class="cat-row"><td colspan="7"><span class="compare-category-label">${renderCategoryGlyph(catKey, cat.label)}<span>${escapeHTML(cat.label)}</span></span></td></tr>`;
-      bodyHtml += rows.join('');
-    }
-  }
-  return renderScrollableTableShell('compare', 'compare-table-wrapper', 'compare-table', colgroup, headHtml, bodyHtml, 866);
-}
-
-// ═══════════════════════════════════════════════
-// CORRELATIONS
-// ═══════════════════════════════════════════════
-
-export function showCorrelations(data) {
-  if (!data) data = getActiveData();
-  const main = document.getElementById("main-content");
-  let html = `<div class="category-header"><h2>Correlations</h2>
-    <p>Compare biomarkers across categories on a normalized scale</p></div>`;
-  html += `<div class="correlation-controls">
-    <h3>Select Biomarkers (2\u20138)</h3>
-    <div class="corr-select-row">
-      <div class="corr-dropdown">
-        <input type="text" class="corr-search" id="corr-search" placeholder="Search biomarkers..."
-          oninput="filterCorrelationOptions()" onfocus="showCorrelationDropdown()">
-        <div class="corr-options" id="corr-options"></div>
-      </div>
-    </div>
-    <div class="corr-chips" id="corr-chips"></div>
-    <div class="corr-presets">
-      <div class="corr-presets-label">Quick Presets:</div>`;
-  for (let i = 0; i < CORRELATION_PRESETS.length; i++) {
-    html += `<button class="corr-preset-btn" onclick="applyCorrelationPreset(${i})">${CORRELATION_PRESETS[i].label}</button>`;
-  }
-  html += `</div></div>`;
-  html += `<div class="corr-chart-container" id="corr-chart-container" style="display:none">
-    <h3>Normalized Comparison (% of Reference Range)
-      <button class="corr-ask-ai-btn" onclick="askAIAboutCorrelations()" title="Ask AI about these correlations">Ask AI</button>
-    </h3>
-    <div class="corr-chart"><canvas id="chart-correlation"></canvas></div></div>`;
-  main.innerHTML = html;
-  populateCorrelationOptions(data);
-  renderCorrelationChips();
-  if (state.selectedCorrelationMarkers.length >= 2) renderCorrelationChart();
-}
-
-export function populateCorrelationOptions(data) {
-  if (!data) data = getActiveData();
-  const container = document.getElementById("corr-options");
-  if (!container) return;
-  let html = '';
-  for (const [catKey, cat] of Object.entries(data.categories)) {
-    for (const [markerKey, marker] of Object.entries(cat.markers)) {
-      if (marker.singlePoint) continue;
-      const fullKey = `${catKey}.${markerKey}`;
-      const selected = state.selectedCorrelationMarkers.includes(fullKey);
-      html += `<div class="corr-option ${selected ? 'selected' : ''}"
-        data-key="${fullKey}" data-name="${escapeHTML(marker.name)}" data-cat="${escapeHTML(cat.label)}"
-        onclick="toggleCorrelationMarker('${fullKey}')">
-        ${escapeHTML(marker.name)} <span class="opt-cat">${escapeHTML(cat.label)}</span></div>`;
-    }
-  }
-  container.innerHTML = html;
-}
-
-export function showCorrelationDropdown() {
-  document.getElementById("corr-options").classList.add("show");
-}
-
-export function filterCorrelationOptions() {
-  const search = document.getElementById("corr-search").value.toLowerCase();
-  document.querySelectorAll(".corr-option").forEach(opt => {
-    const name = opt.dataset.name.toLowerCase();
-    const cat = opt.dataset.cat.toLowerCase();
-    opt.style.display = (name.includes(search) || cat.includes(search)) ? '' : 'none';
-  });
-  document.getElementById("corr-options").classList.add("show");
-}
-
-export function toggleCorrelationMarker(key) {
-  const idx = state.selectedCorrelationMarkers.indexOf(key);
-  if (idx !== -1) state.selectedCorrelationMarkers.splice(idx, 1);
-  else if (state.selectedCorrelationMarkers.length < 8) state.selectedCorrelationMarkers.push(key);
-  renderCorrelationChips();
-  populateCorrelationOptions();
-  if (state.selectedCorrelationMarkers.length >= 2) renderCorrelationChart();
-  else {
-    document.getElementById("corr-chart-container").style.display = "none";
-    if (state.chartInstances["correlation"]) { state.chartInstances["correlation"].destroy(); delete state.chartInstances["correlation"]; }
-  }
-}
-
-export function applyCorrelationPreset(idx) {
-  state.selectedCorrelationMarkers = [...CORRELATION_PRESETS[idx].markers];
-  renderCorrelationChips();
-  populateCorrelationOptions();
-  if (state.selectedCorrelationMarkers.length >= 2) renderCorrelationChart();
-}
-
-export function renderCorrelationChips() {
-  const container = document.getElementById("corr-chips");
-  if (!container) return;
-  const data = getActiveData();
-  let html = '';
-  state.selectedCorrelationMarkers.forEach((key, i) => {
-    const [catKey, markerKey] = key.split('.');
-    const marker = data.categories[catKey]?.markers[markerKey];
-    if (!marker) return;
-    const color = CHIP_COLORS[i % CHIP_COLORS.length];
-    html += `<span class="corr-chip" style="background:${color}20;border-color:${color};color:${color}">
-      ${escapeHTML(marker.name)} <span class="chip-remove" onclick="toggleCorrelationMarker('${key}')">&times;</span></span>`;
-  });
-  container.innerHTML = html;
-}
-
-export function renderCorrelationChart() {
-  const data = getActiveData();
-  const container = document.getElementById("corr-chart-container");
-  container.style.display = "block";
-  if (state.chartInstances["correlation"]) { state.chartInstances["correlation"].destroy(); delete state.chartInstances["correlation"]; }
-  const canvas = document.getElementById("chart-correlation");
-  if (!canvas) return;
-  if (!window.Chart) {
-    ensureChartJs().then(() => {
-      if (document.getElementById("chart-correlation")) renderCorrelationChart();
-    }).catch(() => {});
-    return;
-  }
-  const datasets = [];
-  state.selectedCorrelationMarkers.forEach((key, i) => {
-    const [catKey, markerKey] = key.split('.');
-    const marker = data.categories[catKey]?.markers[markerKey];
-    if (!marker) return;
-    const normalizedValues = marker.values.map(v => {
-      if (v === null) return null;
-      if (marker.refMin == null || marker.refMax == null) return 50;
-      const range = marker.refMax - marker.refMin;
-      return range !== 0 ? ((v - marker.refMin) / range) * 100 : 50;
-    });
-    const color = CHIP_COLORS[i % CHIP_COLORS.length];
-    datasets.push({
-      label: marker.name, data: normalizedValues,
-      borderColor: color, backgroundColor: color + '20',
-      borderWidth: 2.5, pointRadius: 5, pointHoverRadius: 7,
-      pointBackgroundColor: color, tension: 0.3, fill: false, spanGaps: true,
-      _realValues: marker.values, _unit: marker.unit, _refMin: marker.refMin, _refMax: marker.refMax
-    });
-  });
-  const allVals = datasets.flatMap(ds => ds.data.filter(v => v !== null));
-  const minY = Math.min(0, ...allVals) - 10;
-  const maxY = Math.max(100, ...allVals) + 10;
-  const tc = getChartColors();
-  state.chartInstances["correlation"] = new window.Chart(canvas, {
-    type: "line",
-    data: { labels: data.dateLabels, datasets },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: {
-        legend: { display: true, labels: { color: tc.legendColor, font: { size: 12 }, usePointStyle: true, pointStyle: "circle" } },
-        tooltip: {
-          backgroundColor: tc.tooltipBg, titleColor: tc.tooltipTitle, bodyColor: tc.tooltipBody,
-          borderColor: tc.tooltipBorder, borderWidth: 1,
-          callbacks: {
-            label: (ctx) => {
-              const ds = ctx.dataset;
-              const realVal = ds._realValues[ctx.dataIndex];
-              const pct = ctx.parsed.y;
-              return `${ds.label}: ${formatValue(realVal)} ${ds._unit} (${pct !== null ? pct.toFixed(0) + '%' : 'N/A'})`;
-            }
-          }
-        },
-        refBand: { refMin: 0, refMax: 100 },
-        noteAnnotations: (function() { const n = getNotesForChart(data.dates); return n.length ? { notes: n, chartDates: data.dates } : false; })(),
-        supplementBars: (function() { const s = getSupplementsForChart(data.dates); return s.length ? { supplements: s, chartDates: data.dates } : false; })()
-      },
-      layout: { padding: { top: (function() { const s = getSupplementsForChart(data.dates); return s.length ? s.length * 14 + 6 : 0; })() } },
-      scales: {
-        x: { ticks: { color: tc.tickColor, font: { size: 11 } }, grid: { display: false } },
-        y: { min: minY, max: maxY, ticks: { color: tc.tickColor, font: { size: 10 }, callback: v => v + '%' }, grid: { color: tc.gridColor } }
-      }
-    },
-    plugins: [refBandPlugin, noteAnnotationPlugin, supplementBarPlugin]
   });
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -65,6 +65,7 @@ const APP_SHELL = [
   '/js/dashboard-widget-renderers.js',
   '/js/marker-detail-modal.js',
   '/js/light-conditions-now.js',
+  '/js/compare-correlations.js',
   '/js/views.js',
   '/js/recommendations.js',
   '/js/crypto.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -62,6 +62,7 @@ assert('Umami blocked on file:// protocol', /location\.protocol\s*!==\s*['"]file
 console.log('3. XSS Prevention');
 
 const viewsSrc = read('js/views.js');
+const compareCorrelationsSrc = read('js/compare-correlations.js');
 const markerDetailSrc = read('js/marker-detail-modal.js');
 const dashboardWidgetsSrc = read('js/dashboard-widgets.js');
 const dashboardRenderersSrc = read('js/dashboard-widget-renderers.js');
@@ -70,7 +71,7 @@ assert('Trend alert category escaped', dashboardRenderersSrc.includes('escapeHTM
 assert('Flagged marker name escaped', /escapeHTML\(f\.name\)/.test(dashboardRenderersSrc));
 assert('Category label escaped in header', viewsSrc.includes('escapeHTML(cat.label)'));
 assert('marker.unit escaped in detail modal', /escapeHTML\(marker\.unit\)/.test(markerDetailSrc));
-assert('Correlation option names escaped', /escapeHTML\(marker\.name\)/.test(viewsSrc));
+assert('Correlation option names escaped', /escapeHTML\(marker\.name\)/.test(compareCorrelationsSrc));
 
 const chatSrc = read('js/chat.js');
 const markdownSrc = read('js/markdown.js');
@@ -128,7 +129,7 @@ const _SAFE_HELPERS = new Set([
   // is the markdown.js sanitized full renderer)
   'escapeHTML', 'renderMarkdown',
 ]);
-const _SWEEP_FILES = ['views.js', 'marker-detail-modal.js', 'dashboard-widget-renderers.js', 'light-conditions-now.js', 'chat.js', 'charts.js'];
+const _SWEEP_FILES = ['views.js', 'marker-detail-modal.js', 'dashboard-widget-renderers.js', 'light-conditions-now.js', 'compare-correlations.js', 'chat.js', 'charts.js'];
 
 function _sweepInnerHTML(filename, src) {
   const lines = src.split('\n');
@@ -330,12 +331,12 @@ assert('Mobile quick marker grid override comes after base grid',
   /\.db-quick-marker-grid\s*\{[\s\S]*grid-template-columns:\s*1fr;/.test(cssSrc.slice(quickMarkerMobileIndex, quickMarkerMobileIndex + 1800)));
 assert('Mobile compare tables scroll instead of clipping columns',
   /@media \(max-width:\s*768px\)\s*\{[\s\S]*\.data-table-wrapper,\s*[\s\S]*\.compare-table-wrapper,\s*[\s\S]*\.heatmap-wrapper\s*\{[\s\S]*overflow-x:\s*auto;[\s\S]*overflow-y:\s*clip;/.test(cssSrc) &&
-  viewsSrc.includes('class="compare-date-field"'));
+  compareCorrelationsSrc.includes('class="compare-date-field"'));
 assert('Compare and correlations headings are text-only',
-  viewsSrc.includes('<h2>Compare Dates</h2>') &&
-  viewsSrc.includes('<h2>Correlations</h2>') &&
-  !viewsSrc.includes('<h2>\\u2194 Compare Dates</h2>') &&
-  !viewsSrc.includes('<h2>\\uD83D\\uDCC8 Correlations</h2>'));
+  compareCorrelationsSrc.includes('<h2>Compare Dates</h2>') &&
+  compareCorrelationsSrc.includes('<h2>Correlations</h2>') &&
+  !compareCorrelationsSrc.includes('<h2>\\u2194 Compare Dates</h2>') &&
+  !compareCorrelationsSrc.includes('<h2>\\uD83D\\uDCC8 Correlations</h2>'));
 const themesExtraSrc = read('themes-extra.css');
 assert('Glass theme includes Light page surfaces',
   themesExtraSrc.includes('[data-theme="glass"] .light-setup-card') &&

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -81,6 +81,7 @@ const pwaAppShellAssets = [
   '/js/dashboard-widget-controls.js',
   '/js/dashboard-widget-renderers.js',
   '/js/light-conditions-now.js',
+  '/js/compare-correlations.js',
   '/js/light-devices.js',
   '/js/light-env.js',
   '/js/light-tools.js',

--- a/tests/test-phase-ranges.js
+++ b/tests/test-phase-ranges.js
@@ -307,6 +307,7 @@ const cssSource = read('styles.css');
   // ═══════════════════════════════════════
   console.log('Section 14: views.js source inspection');
   const viewsSource = read('js/views.js');
+  const compareCorrelationsSource = read('js/compare-correlations.js');
   const markerDetailSource = read('js/marker-detail-modal.js');
   assert('views.js imports getEffectiveRangeForDate', viewsSource.includes('getEffectiveRangeForDate'));
   assert('renderChartCard uses getEffectiveRangeForDate', viewsSource.includes('getEffectiveRangeForDate(marker, latestIdx)'));
@@ -315,7 +316,7 @@ const cssSource = read('styles.css');
   assert('showDetailModal shows phase label', markerDetailSource.includes('mv-phase'));
   assert('renderTableView uses getEffectiveRangeForDate', viewsSource.includes('getEffectiveRangeForDate(marker, i)'));
   assert('renderHeatmapView uses getEffectiveRangeForDate', viewsSource.includes('getEffectiveRangeForDate(marker, i)'));
-  assert('renderCompareTable uses getEffectiveRangeForDate', viewsSource.includes('getEffectiveRangeForDate(marker, idx'));
+  assert('renderCompareTable uses getEffectiveRangeForDate', compareCorrelationsSource.includes('getEffectiveRangeForDate(marker, idx'));
 
   // ═══════════════════════════════════════
   // 15. chat.js source inspection

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -516,6 +516,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   console.log('%c 19. category marker card redesign ', 'font-weight:bold;color:#0891b2');
   {
     const viewsSrc = fetchSrc('js/views.js');
+    const compareCorrelationsSrc = fetchSrc('js/compare-correlations.js');
     const markerDetailSrc = fetchSrc('js/marker-detail-modal.js');
     const dataSrc = fetchSrc('js/data.js');
     const cssSrc = fetchSrc('styles.css');
@@ -559,7 +560,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /function renderCategoryGlyph\(categoryKey,\s*label/.test(viewsSrc)
       && /renderCategoryGlyph\(categoryKey,\s*cat\.label\)/.test(viewsSrc)
       && /empty-state-icon-category/.test(viewsSrc)
-      && /compare-category-label/.test(viewsSrc)
+      && /compare-category-label/.test(compareCorrelationsSrc)
       && !/Click to change icon/.test(viewsSrc));
     assert('styles.css: category glyph has redesigned non-emoji treatment',
       /\.category-glyph\s*\{[\s\S]{0,520}font-family:\s*var\(--font-mono\)/.test(cssSrc)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -565,6 +565,9 @@
     const hasLightConditionsNowJs = sw.includes('/js/light-conditions-now.js');
     assert('Service worker caches js/light-conditions-now.js', hasLightConditionsNowJs);
 
+    const hasCompareCorrelationsJs = sw.includes('/js/compare-correlations.js');
+    assert('Service worker caches js/compare-correlations.js', hasCompareCorrelationsJs);
+
     const hasSchemaJs = sw.includes('/js/schema.js');
     assert('Service worker caches js/schema.js', hasSchemaJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.22';
+self.APP_VERSION = '1.8.23';


### PR DESCRIPTION
## Summary
- Extract Compare Dates and Correlations view logic from `js/views.js` into `js/compare-correlations.js`.
- Keep existing window/export behavior by re-exporting through `views.js` and injecting shared table/glyph render helpers.
- Add the new module to the service-worker app shell and update source-inspection coverage.
- Bump app version to `1.8.23` for cache invalidation.

## Validation
- `node --check js/views.js js/compare-correlations.js tests/test-audit.js tests/test-phase-ranges.js tests/test-v1-6-shipped.js`
- `node tests/test-audit.js`
- `node tests/test-phase-ranges.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-v1-6-shipped.js`
- `./run-tests.sh`