### PR TITLE
[codex] Extract mobile dashboard view

### DIFF
--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -194,54 +194,6 @@ export function getMobileDashboardMarkers(ctx) {
   return summaries.slice(0, 10);
 }
 
-function renderMobileSparkline(values, status) {
-  const points = (values || []).filter(v => v !== null && Number.isFinite(Number(v))).slice(-7).map(Number);
-  if (points.length < 2) return `<span class="m-spark m-spark-empty" aria-hidden="true"></span>`;
-  const min = Math.min(...points);
-  const max = Math.max(...points);
-  const span = max - min || 1;
-  const coords = points.map((value, index) => {
-    const x = points.length === 1 ? 50 : (index / (points.length - 1)) * 100;
-    const y = 28 - ((value - min) / span) * 24;
-    return `${x.toFixed(1)},${y.toFixed(1)}`;
-  }).join(' ');
-  return `<svg class="m-spark m-spark-${escapeAttr(status)}" viewBox="0 0 100 32" preserveAspectRatio="none" aria-hidden="true">
-    <polyline points="${escapeAttr(coords)}"></polyline>
-  </svg>`;
-}
-
-function renderMobileStatCard(item) {
-  if (item.type === 'summary') {
-    const summaryLabel = `${item.label}: ${item.value}, ${item.meta}`;
-    return `<div class="m-stat-card m-stat-summary" role="group" aria-label="${escapeAttr(summaryLabel)}">
-      <div class="m-stat-head"><span class="m-marker-dot" aria-hidden="true"></span><span class="m-stat-label">${escapeHTML(item.label)}</span></div>
-      <strong>${escapeHTML(item.value)}</strong>
-      <span class="m-stat-meta">${escapeHTML(item.meta)}</span>
-    </div>`;
-  }
-  return `<button type="button" class="m-stat-card m-stat-${escapeAttr(item.status)}" onclick="window.showDetailModal('${item.id}')" aria-label="${escapeAttr(item.name + ': ' + item.value + ' ' + item.unit + ', ' + item.statusLabel)}">
-    <div class="m-stat-head"><span class="m-marker-dot m-marker-${escapeAttr(item.status)}" aria-hidden="true"></span><span class="m-stat-label">${escapeHTML(item.name)}</span></div>
-    <strong>${escapeHTML(item.value)}${item.unit ? `<small>${escapeHTML(item.unit)}</small>` : ''}</strong>
-    <span class="m-stat-meta">${escapeHTML(item.statusLabel)}${item.trend?.arrow ? ` · ${escapeHTML(item.trend.arrow)}` : ''}</span>
-  </button>`;
-}
-
-function getMobileDashboardStats(data, ctx, markers) {
-  const counts = getMobileDashboardCounts(data);
-  const cards = markers.slice(0, 4).map(marker => ({ ...marker, type: 'marker' }));
-  const summaryCards = [
-    { type: 'summary', label: 'Attention', value: String((ctx.trendAlerts?.length || 0) + counts.flagged), meta: 'active flags' },
-    { type: 'summary', label: 'In range', value: `${counts.inRange}/${counts.markerCount || 0}`, meta: 'latest values' },
-    { type: 'summary', label: 'Last labs', value: counts.latestDate ? formatDate(counts.latestDate, 'short') : 'N/A', meta: `${data.dates?.length || 0} dates` },
-    { type: 'summary', label: 'Markers', value: String(counts.markerCount), meta: 'tracked' },
-  ];
-  for (const card of summaryCards) {
-    if (cards.length >= 4) break;
-    cards.push(card);
-  }
-  return cards.slice(0, 4);
-}
-
 export function getMobileDashboardInsights(ctx, markers) {
   const insights = [];
   for (const flag of ctx.criticalFlags.slice(0, 2)) {
@@ -276,32 +228,6 @@ export function getMobileDashboardInsights(ctx, markers) {
     });
   }
   return insights.slice(0, 3);
-}
-
-function renderMobileInsightCard(insight) {
-  const body = `<span class="m-insight-eyebrow">${escapeHTML(insight.eyebrow)}</span>
-    <strong>${escapeHTML(insight.title)}</strong>
-    <span>${escapeHTML(insight.body)}</span>
-    ${insight.meta ? `<small>${escapeHTML(insight.meta)}</small>` : ''}`;
-  if (insight.id && safeMarkerId(insight.id)) {
-    return `<button type="button" class="m-insight m-insight-${escapeAttr(insight.tone)}" onclick="window.showDetailModal('${insight.id}')">${body}</button>`;
-  }
-  return `<div class="m-insight m-insight-${escapeAttr(insight.tone)}">${body}</div>`;
-}
-
-function renderMobileMarkerRow(marker) {
-  return `<button type="button" class="m-marker-row" onclick="window.showDetailModal('${marker.id}')" aria-label="${escapeAttr(marker.name + ': ' + marker.value + ' ' + marker.unit)}">
-    <span class="m-marker-dot m-marker-${escapeAttr(marker.status)}" aria-hidden="true"></span>
-    <span class="m-marker-main">
-      <strong>${escapeHTML(marker.name)}</strong>
-      <small>${escapeHTML(marker.category)} · ${escapeHTML(marker.date)}</small>
-    </span>
-    ${renderMobileSparkline(marker.values, marker.status)}
-    <span class="m-marker-value">
-      <strong>${escapeHTML(marker.value)}</strong>
-      ${marker.unit ? `<small>${escapeHTML(marker.unit)}</small>` : ''}
-    </span>
-  </button>`;
 }
 
 export function getMobileWearablePriority() {
@@ -365,23 +291,6 @@ export function getMobileWearableTiles() {
     if (tiles.length >= 4) break;
   }
   return tiles;
-}
-
-function renderMobileWearableTiles(tiles) {
-  if (!tiles.length) {
-    return `<div class="m-wear-empty">
-      <strong>Connect body data</strong>
-      <span>HRV, sleep, steps, recovery and body composition can sit next to your labs.</span>
-      <button type="button" onclick="window.openSettingsModal && window.openSettingsModal('wearables')">Connect</button>
-    </div>`;
-  }
-  return `<div class="m-wear-strip">
-    ${tiles.map(tile => `<button type="button" class="m-wear-tile" onclick="window.openWearableDetail ? window.openWearableDetail('${escapeAttr(tile.id)}') : window.openSettingsModal?.('wearables')" aria-label="${escapeAttr(tile.label + ': ' + tile.value + ' ' + tile.unit)}">
-      <span class="m-wear-label">${escapeHTML(tile.label)}</span>
-      <strong>${escapeHTML(tile.value)}${tile.unit ? `<small>${escapeHTML(tile.unit)}</small>` : ''}</strong>
-      <span class="m-wear-change">${escapeHTML(tile.change || 'latest')}</span>
-    </button>`).join('')}
-  </div>`;
 }
 
 function renderMobileSectionHead(title, count, actionLabel = '', action = '') {

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -1,0 +1,505 @@
+// mobile-dashboard.js - Mobile dashboard shell and bottom navigation
+
+import { state } from './state.js';
+import { escapeHTML, escapeAttr, getStatus, formatValue, getTrend, formatDate, safeMarkerId } from './utils.js';
+import { getActiveData, getEffectiveRangeForDate, getLatestValueIndex, getAllFlaggedMarkers } from './data.js';
+import { getProfiles } from './profile.js';
+import { canonicalMetric, metricsForSources } from './wearable-adapters.js';
+import { loadContextHealthDots } from './context-cards.js';
+
+const MOBILE_DASHBOARD_QUERY = '(max-width: 799px)';
+const MOBILE_WEARABLE_PRIORITY = [
+  'hrv_rmssd',
+  'sleep_score',
+  'readiness_score',
+  'steps',
+  'rhr',
+  'weight',
+  'body_fat_pct',
+  'bp_systolic',
+];
+
+let _mobileDashboardManualTabLockUntil = 0;
+
+const mobileDashboardDeps = {
+  buildDashboardWidgetContext: () => ({ data: getActiveData(), filteredData: getActiveData() }),
+  getDashboardWidgetPrefs: () => ({}),
+  getVisibleDashboardWidgetEntries: () => [],
+  renderDashboardControlButtons: () => '',
+  isDashboardOrganizeMode: () => false,
+  renderDashboardWidget: () => '',
+  setupDropZone: () => {},
+  loadCommitHash: () => {},
+};
+
+export function configureMobileDashboardView(deps = {}) {
+  Object.assign(mobileDashboardDeps, deps);
+}
+
+function markerHasData(m) {
+  return m.values?.some(v => v !== null) ?? false;
+}
+
+export function isMobileDashboardViewport() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia(MOBILE_DASHBOARD_QUERY).matches;
+}
+
+function getMobileBottomTabForRoute(route) {
+  if (['dashboard', 'labs', 'body', 'light', 'insight'].includes(route)) return route;
+  if (route === 'recommendations') return 'insight';
+  if (route === 'compare' || route === 'correlations') return 'labs';
+  if (route && getActiveData().categories?.[route]) return 'labs';
+  return 'dashboard';
+}
+
+export function syncMobileBottomNav(route = state.currentView || 'dashboard') {
+  if (typeof document === 'undefined') return;
+  const existing = document.getElementById('mobile-bottom-tabs');
+  const hasDashboardShell = document.body.classList.contains('mobile-dashboard-active');
+  const shouldRender = isMobileDashboardViewport() && !hasDashboardShell;
+  document.body.classList.toggle('mobile-tabs-active', shouldRender);
+  if (!shouldRender) {
+    existing?.remove();
+    return;
+  }
+  const activeTab = getMobileBottomTabForRoute(route);
+  const html = renderMobileBottomTabs(activeTab, { id: 'mobile-bottom-tabs' });
+  if (existing) {
+    existing.outerHTML = html;
+  } else {
+    document.body.insertAdjacentHTML('beforeend', html);
+  }
+}
+
+export function refreshMobileDashboardActiveTab() {
+  if (!document.body.classList.contains('mobile-dashboard-active')) return;
+  _mobileDashboardManualTabLockUntil = 0;
+  mobileDashboardSetTab('dashboard', { fromScroll: true });
+}
+
+if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+  const mobileDashboardMedia = window.matchMedia(MOBILE_DASHBOARD_QUERY);
+  const refreshDashboardForBreakpoint = () => {
+    if (state.currentView === 'dashboard') window.navigate?.('dashboard');
+    else syncMobileBottomNav(state.currentView || 'dashboard');
+  };
+  if (typeof mobileDashboardMedia.addEventListener === 'function') {
+    mobileDashboardMedia.addEventListener('change', refreshDashboardForBreakpoint);
+  } else if (typeof mobileDashboardMedia.addListener === 'function') {
+    mobileDashboardMedia.addListener(refreshDashboardForBreakpoint);
+  }
+}
+
+export function getMobileDashboardProfile() {
+  const profiles = getProfiles() || [];
+  return profiles.find(p => p.id === state.currentProfile) || profiles[0] || { id: 'default', name: 'Default' };
+}
+
+export function getMobileGreetingName(profile) {
+  const name = (profile?.name || 'there').trim();
+  if (!name || name === 'Default') return 'there';
+  return name.split(/\s+/)[0];
+}
+
+export function getMobileDashboardCounts(data) {
+  let markerCount = 0;
+  let inRange = 0;
+  let flagged = 0;
+  for (const cat of Object.values(data.categories || {})) {
+    for (const marker of Object.values(cat.markers || {})) {
+      if (!markerHasData(marker)) continue;
+      markerCount++;
+      const idx = getLatestValueIndex(marker.values || []);
+      if (idx < 0) continue;
+      const value = marker.values[idx];
+      const range = getEffectiveRangeForDate(marker, idx);
+      const status = getStatus(value, range.min, range.max);
+      if (status === 'normal') inRange++;
+      else if (status === 'high' || status === 'low') flagged++;
+    }
+  }
+  const latestDate = data.dates?.[data.dates.length - 1] || '';
+  return { markerCount, inRange, flagged, latestDate };
+}
+
+function mobileStatusLabel(status) {
+  if (status === 'normal') return 'In range';
+  if (status === 'high') return 'High';
+  if (status === 'low') return 'Low';
+  return 'No value';
+}
+
+function mobileStatusTone(status) {
+  if (status === 'normal') return 'good';
+  if (status === 'high' || status === 'low') return 'alert';
+  return 'muted';
+}
+
+function getMobileMarkerSummary(data, catKey, markerKey) {
+  const id = `${catKey}_${markerKey}`;
+  if (!safeMarkerId(id)) return null;
+  const category = data.categories?.[catKey];
+  const marker = category?.markers?.[markerKey];
+  if (!marker || !markerHasData(marker)) return null;
+  const latestIdx = getLatestValueIndex(marker.values || []);
+  if (latestIdx < 0) return null;
+  const value = marker.values[latestIdx];
+  const range = getEffectiveRangeForDate(marker, latestIdx);
+  const status = getStatus(value, range.min, range.max);
+  const trend = getTrend(marker.values || [], range.min, range.max);
+  const labelSource = marker.singlePoint ? [marker.singleDateLabel || 'Latest'] : (data.dateLabels || data.dates || []);
+  state.markerRegistry[id] = marker;
+  return {
+    id,
+    name: marker.name || markerKey,
+    category: category.label || catKey,
+    value: formatValue(value),
+    unit: marker.unit || '',
+    date: labelSource[latestIdx] || 'Latest',
+    status,
+    statusLabel: mobileStatusLabel(status),
+    tone: mobileStatusTone(status),
+    trend,
+    values: marker.values || [],
+  };
+}
+
+export function getMobileDashboardMarkers(ctx) {
+  const seen = new Set();
+  const summaries = [];
+  const add = (catKey, markerKey, sourceData = ctx.filteredData) => {
+    const id = `${catKey}_${markerKey}`;
+    if (seen.has(id)) return;
+    const summary = getMobileMarkerSummary(sourceData, catKey, markerKey)
+      || getMobileMarkerSummary(ctx.data, catKey, markerKey);
+    if (!summary) return;
+    seen.add(id);
+    summaries.push(summary);
+  };
+
+  for (const km of ctx.keyMarkers || []) add(km.cat, km.key);
+  for (const alert of ctx.trendAlerts || []) {
+    const idx = alert.id.indexOf('_');
+    if (idx > 0) add(alert.id.slice(0, idx), alert.id.slice(idx + 1));
+  }
+  for (const flag of getAllFlaggedMarkers(ctx.data).slice(0, 12)) {
+    add(flag.categoryKey, flag.markerKey, ctx.data);
+  }
+  for (const [catKey, category] of Object.entries(ctx.filteredData.categories || {})) {
+    for (const markerKey of Object.keys(category.markers || {})) add(catKey, markerKey);
+    if (summaries.length >= 10) break;
+  }
+  return summaries.slice(0, 10);
+}
+
+function renderMobileSparkline(values, status) {
+  const points = (values || []).filter(v => v !== null && Number.isFinite(Number(v))).slice(-7).map(Number);
+  if (points.length < 2) return `<span class="m-spark m-spark-empty" aria-hidden="true"></span>`;
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const span = max - min || 1;
+  const coords = points.map((value, index) => {
+    const x = points.length === 1 ? 50 : (index / (points.length - 1)) * 100;
+    const y = 28 - ((value - min) / span) * 24;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).join(' ');
+  return `<svg class="m-spark m-spark-${escapeAttr(status)}" viewBox="0 0 100 32" preserveAspectRatio="none" aria-hidden="true">
+    <polyline points="${escapeAttr(coords)}"></polyline>
+  </svg>`;
+}
+
+function renderMobileStatCard(item) {
+  if (item.type === 'summary') {
+    const summaryLabel = `${item.label}: ${item.value}, ${item.meta}`;
+    return `<div class="m-stat-card m-stat-summary" role="group" aria-label="${escapeAttr(summaryLabel)}">
+      <div class="m-stat-head"><span class="m-marker-dot" aria-hidden="true"></span><span class="m-stat-label">${escapeHTML(item.label)}</span></div>
+      <strong>${escapeHTML(item.value)}</strong>
+      <span class="m-stat-meta">${escapeHTML(item.meta)}</span>
+    </div>`;
+  }
+  return `<button type="button" class="m-stat-card m-stat-${escapeAttr(item.status)}" onclick="window.showDetailModal('${item.id}')" aria-label="${escapeAttr(item.name + ': ' + item.value + ' ' + item.unit + ', ' + item.statusLabel)}">
+    <div class="m-stat-head"><span class="m-marker-dot m-marker-${escapeAttr(item.status)}" aria-hidden="true"></span><span class="m-stat-label">${escapeHTML(item.name)}</span></div>
+    <strong>${escapeHTML(item.value)}${item.unit ? `<small>${escapeHTML(item.unit)}</small>` : ''}</strong>
+    <span class="m-stat-meta">${escapeHTML(item.statusLabel)}${item.trend?.arrow ? ` · ${escapeHTML(item.trend.arrow)}` : ''}</span>
+  </button>`;
+}
+
+function getMobileDashboardStats(data, ctx, markers) {
+  const counts = getMobileDashboardCounts(data);
+  const cards = markers.slice(0, 4).map(marker => ({ ...marker, type: 'marker' }));
+  const summaryCards = [
+    { type: 'summary', label: 'Attention', value: String((ctx.trendAlerts?.length || 0) + counts.flagged), meta: 'active flags' },
+    { type: 'summary', label: 'In range', value: `${counts.inRange}/${counts.markerCount || 0}`, meta: 'latest values' },
+    { type: 'summary', label: 'Last labs', value: counts.latestDate ? formatDate(counts.latestDate, 'short') : 'N/A', meta: `${data.dates?.length || 0} dates` },
+    { type: 'summary', label: 'Markers', value: String(counts.markerCount), meta: 'tracked' },
+  ];
+  for (const card of summaryCards) {
+    if (cards.length >= 4) break;
+    cards.push(card);
+  }
+  return cards.slice(0, 4);
+}
+
+export function getMobileDashboardInsights(ctx, markers) {
+  const insights = [];
+  for (const flag of ctx.criticalFlags.slice(0, 2)) {
+    const summary = markers.find(m => m.id === flag.id);
+    insights.push({
+      id: flag.id,
+      tone: 'danger',
+      eyebrow: flag.status === 'high' ? 'Critical high' : 'Critical low',
+      title: flag.name,
+      body: `${formatValue(flag.rawValue)} ${flag.unit || ''} is outside the active range.`,
+      meta: summary?.trend?.arrow || summary?.date || '',
+    });
+  }
+  for (const alert of ctx.trendAlerts.slice(0, 3)) {
+    if (insights.length >= 3) break;
+    insights.push({
+      id: alert.id,
+      tone: alert.concern.startsWith('past_') || alert.concern.startsWith('sudden_') ? 'warn' : 'info',
+      eyebrow: 'Trend',
+      title: alert.name,
+      body: alert.concern.replace(/_/g, ' '),
+      meta: (alert.spark || []).join(' -> '),
+    });
+  }
+  if (insights.length === 0) {
+    insights.push({
+      tone: 'good',
+      eyebrow: 'Snapshot',
+      title: 'No urgent trend alerts',
+      body: 'Latest high-priority markers are not showing sudden range breaks.',
+      meta: `${markers.length} markers in the mobile watch list`,
+    });
+  }
+  return insights.slice(0, 3);
+}
+
+function renderMobileInsightCard(insight) {
+  const body = `<span class="m-insight-eyebrow">${escapeHTML(insight.eyebrow)}</span>
+    <strong>${escapeHTML(insight.title)}</strong>
+    <span>${escapeHTML(insight.body)}</span>
+    ${insight.meta ? `<small>${escapeHTML(insight.meta)}</small>` : ''}`;
+  if (insight.id && safeMarkerId(insight.id)) {
+    return `<button type="button" class="m-insight m-insight-${escapeAttr(insight.tone)}" onclick="window.showDetailModal('${insight.id}')">${body}</button>`;
+  }
+  return `<div class="m-insight m-insight-${escapeAttr(insight.tone)}">${body}</div>`;
+}
+
+function renderMobileMarkerRow(marker) {
+  return `<button type="button" class="m-marker-row" onclick="window.showDetailModal('${marker.id}')" aria-label="${escapeAttr(marker.name + ': ' + marker.value + ' ' + marker.unit)}">
+    <span class="m-marker-dot m-marker-${escapeAttr(marker.status)}" aria-hidden="true"></span>
+    <span class="m-marker-main">
+      <strong>${escapeHTML(marker.name)}</strong>
+      <small>${escapeHTML(marker.category)} · ${escapeHTML(marker.date)}</small>
+    </span>
+    ${renderMobileSparkline(marker.values, marker.status)}
+    <span class="m-marker-value">
+      <strong>${escapeHTML(marker.value)}</strong>
+      ${marker.unit ? `<small>${escapeHTML(marker.unit)}</small>` : ''}
+    </span>
+  </button>`;
+}
+
+export function getMobileWearablePriority() {
+  return MOBILE_WEARABLE_PRIORITY;
+}
+
+export function formatMobileWearableValue(metricId, metric, summary) {
+  if (metricId === 'bp_systolic' && summary?.metrics?.bp_diastolic?.latest != null) {
+    return `${formatValue(metric.latest)}/${formatValue(summary.metrics.bp_diastolic.latest)}`;
+  }
+  const value = Number(metric?.latest);
+  if (!Number.isFinite(value)) return '—';
+  if (metricId === 'steps' && Math.abs(value) >= 1000) {
+    return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1).replace(/\.0$/, '')}k`;
+  }
+  return formatValue(value);
+}
+
+export function formatMobileWearableDelta(metricId, metric, canon) {
+  const latest = Number(metric?.latest);
+  const baseline = Number(metric?.baseline);
+  if (!Number.isFinite(latest) || !Number.isFinite(baseline) || baseline === 0) return '';
+  if (metricId === 'steps') return '';
+  if (canon?.sub === 'Δ') {
+    const diff = latest - baseline;
+    const arrow = diff > 0.005 ? '↑' : diff < -0.005 ? '↓' : '→';
+    return `${arrow} ${Math.abs(diff).toFixed(2)}${canon.unit || ''}`;
+  }
+  const pct = ((latest - baseline) / baseline) * 100;
+  if (Math.abs(pct) < 0.5) return '→ baseline';
+  const arrow = pct > 0 ? '↑' : '↓';
+  return `${arrow} ${Math.abs(pct).toFixed(0)}%`;
+}
+
+export function getMobileWearableTiles() {
+  const summary = state.importedData?.wearableSummary;
+  if (!summary?.metrics || Object.keys(summary.metrics).length === 0) return [];
+  const sourceIds = Object.keys(summary.sources || {});
+  const registryOrder = metricsForSources(sourceIds.length ? sourceIds : Object.keys(summary.metrics || {}));
+  const ordered = [
+    ...MOBILE_WEARABLE_PRIORITY,
+    ...registryOrder,
+    ...Object.keys(summary.metrics || {}),
+  ];
+  const seen = new Set();
+  const tiles = [];
+  for (const metricId of ordered) {
+    if (seen.has(metricId)) continue;
+    seen.add(metricId);
+    if (metricId === 'bp_diastolic' && summary.metrics.bp_systolic) continue;
+    const metric = summary.metrics[metricId];
+    const canon = canonicalMetric(metricId);
+    if (!metric || !canon || metric.latest == null) continue;
+    tiles.push({
+      id: metricId,
+      label: canon.label,
+      value: formatMobileWearableValue(metricId, metric, summary),
+      unit: metricId === 'bp_systolic' ? 'mmHg' : (canon.unit || canon.sub || ''),
+      change: formatMobileWearableDelta(metricId, metric, canon),
+    });
+    if (tiles.length >= 4) break;
+  }
+  return tiles;
+}
+
+function renderMobileWearableTiles(tiles) {
+  if (!tiles.length) {
+    return `<div class="m-wear-empty">
+      <strong>Connect body data</strong>
+      <span>HRV, sleep, steps, recovery and body composition can sit next to your labs.</span>
+      <button type="button" onclick="window.openSettingsModal && window.openSettingsModal('wearables')">Connect</button>
+    </div>`;
+  }
+  return `<div class="m-wear-strip">
+    ${tiles.map(tile => `<button type="button" class="m-wear-tile" onclick="window.openWearableDetail ? window.openWearableDetail('${escapeAttr(tile.id)}') : window.openSettingsModal?.('wearables')" aria-label="${escapeAttr(tile.label + ': ' + tile.value + ' ' + tile.unit)}">
+      <span class="m-wear-label">${escapeHTML(tile.label)}</span>
+      <strong>${escapeHTML(tile.value)}${tile.unit ? `<small>${escapeHTML(tile.unit)}</small>` : ''}</strong>
+      <span class="m-wear-change">${escapeHTML(tile.change || 'latest')}</span>
+    </button>`).join('')}
+  </div>`;
+}
+
+function renderMobileSectionHead(title, count, actionLabel = '', action = '') {
+  return `<div class="m-section-head">
+    <div class="m-section-labels">
+      <span class="m-section-title">${escapeHTML(title)}</span>
+      ${count ? `<span class="m-section-count">${escapeHTML(count)}</span>` : ''}
+    </div>
+    ${actionLabel && action ? `<button type="button" onclick="${escapeAttr(action)}">${escapeHTML(actionLabel)}</button>` : ''}
+  </div>`;
+}
+
+function renderMobileIcon(name) {
+  const icons = {
+    labs: '<rect x="4" y="4" width="6" height="6" rx="1.2"></rect><rect x="14" y="4" width="6" height="6" rx="1.2"></rect><rect x="4" y="14" width="6" height="6" rx="1.2"></rect><rect x="14" y="14" width="6" height="6" rx="1.2"></rect>',
+    genome: '<path d="M8 4c4 4 4 12 8 16"></path><path d="M16 4c-4 4-4 12-8 16"></path><path d="M9.5 8h5"></path><path d="M9.5 12h5"></path><path d="M9.5 16h5"></path>',
+    body: '<path d="M4 12h4l2-6 4 12 2-6h4"></path>',
+    light: '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v3"></path><path d="M12 19v3"></path><path d="M4.93 4.93l2.12 2.12"></path><path d="M16.95 16.95l2.12 2.12"></path><path d="M2 12h3"></path><path d="M19 12h3"></path><path d="M4.93 19.07l2.12-2.12"></path><path d="M16.95 7.05l2.12-2.12"></path>',
+    insight: '<path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path><path d="M8 9h8"></path><path d="M8 13h5"></path>',
+    more: '<path d="M4 7h16"></path><path d="M4 12h16"></path><path d="M4 17h16"></path>',
+    tweaks: '<line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line>',
+    settings: '<circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>',
+    search: '<circle cx="11" cy="11" r="6"></circle><path d="m16 16 4 4"></path>',
+    chat: '<path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path>',
+  };
+  return `<svg class="m-svg-icon" viewBox="0 0 24 24" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${icons[name] || icons.labs}</svg>`;
+}
+
+export function mobileDashboardSetTab(tab, { fromScroll = false } = {}) {
+  if (!fromScroll) _mobileDashboardManualTabLockUntil = Date.now() + 600;
+  document.querySelectorAll('.m-tab').forEach(btn => {
+    const isActive = btn.dataset.tab === tab;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-current', isActive ? 'page' : 'false');
+  });
+}
+
+function renderMobileBottomTabs(activeTab = 'dashboard', { id = '' } = {}) {
+  const navId = id ? ` id="${id}"` : '';
+  const tabAttrs = tab => `class="m-tab${activeTab === tab ? ' active' : ''}" data-tab="${tab}" aria-current="${activeTab === tab ? 'page' : 'false'}"`;
+  return `<nav${navId} class="m-tabbar" aria-label="Mobile primary navigation">
+    <button type="button" ${tabAttrs('dashboard')} onclick="window.mobileDashboardSetTab('dashboard');window.navigate('dashboard')" aria-label="Dashboard"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Home</small></button>
+    <button type="button" ${tabAttrs('labs')} onclick="window.mobileDashboardSetTab('labs');window.navigate('labs')" aria-label="Labs"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Labs</small></button>
+    <button type="button" ${tabAttrs('body')} onclick="window.mobileDashboardSetTab('body');window.navigate('body')" aria-label="Body"><span class="m-tab-icon">${renderMobileIcon('body')}</span><small>Body</small></button>
+    <button type="button" ${tabAttrs('light')} onclick="window.mobileDashboardSetTab('light');window.navigate('light')" aria-label="Light"><span class="m-tab-icon">${renderMobileIcon('light')}</span><small>Light</small></button>
+    <button type="button" ${tabAttrs('insight')} onclick="window.mobileDashboardSetTab('insight');window.navigate('insight')" aria-label="Insight"><span class="m-tab-icon">${renderMobileIcon('insight')}</span><small>Insight</small></button>
+  </nav>`;
+}
+
+function renderMobileDashboardWidgetStack(ctx) {
+  const prefs = mobileDashboardDeps.getDashboardWidgetPrefs();
+  const visibleEntries = mobileDashboardDeps.getVisibleDashboardWidgetEntries(ctx, prefs);
+  return `<section class="m-section m-dashboard-widget-section">
+    ${renderMobileSectionHead('Dashboard widgets', String(visibleEntries.length))}
+    <div class="m-dashboard-widget-actions">${mobileDashboardDeps.renderDashboardControlButtons({ includeReset: mobileDashboardDeps.isDashboardOrganizeMode() })}</div>
+    <div class="dashboard-widgets m-dashboard-widgets">
+      ${visibleEntries.length
+        ? visibleEntries.map((entry, index) => mobileDashboardDeps.renderDashboardWidget(entry, prefs, index, visibleEntries)).join('')
+        : '<div class="dashboard-widget dashboard-widget-full is-empty"><div class="dashboard-widget-empty">No widgets are visible.</div></div>'}
+    </div>
+  </section>`;
+}
+
+export function openMobileDashboardSearch() {
+  if (window.toggleMobileSidebar) window.toggleMobileSidebar();
+  setTimeout(() => document.getElementById('sidebar-search')?.focus(), 80);
+}
+
+export function mobileDashboardJump(section) {
+  const route = ['dashboard', 'labs', 'genome', 'body', 'light', 'insight', 'recommendations'].includes(section) ? section : 'dashboard';
+  mobileDashboardSetTab(route === 'genome' || route === 'recommendations' ? 'dashboard' : route);
+  window.navigate?.(route);
+}
+
+export function renderMobileDashboard(data, { resetScroll = false } = {}) {
+  const main = document.getElementById("main-content");
+  if (!main) return;
+  const ctx = mobileDashboardDeps.buildDashboardWidgetContext(data);
+  const profile = getMobileDashboardProfile();
+  const mobileWidgetStack = renderMobileDashboardWidgetStack(ctx);
+  const firstName = getMobileGreetingName(profile);
+  const counts = getMobileDashboardCounts(data);
+  const greetingSub = [
+    `${counts.markerCount || 0} markers`,
+    counts.latestDate ? `last draw ${formatDate(counts.latestDate, 'short')}` : '',
+    `${data.dates?.length || 0} draw${data.dates?.length === 1 ? '' : 's'}`,
+  ].filter(Boolean).join(' · ');
+
+  document.body.classList.add('mobile-dashboard-active');
+  main.innerHTML = `<div class="drop-zone drop-zone-hidden" id="drop-zone"></div>
+    <div class="m-shell">
+      <div class="m-bg" aria-hidden="true"></div>
+      <div class="m-content">
+        <section class="m-greeting">
+          <h1>Hey ${escapeHTML(firstName)}.</h1>
+          <div class="m-greeting-sub">${escapeHTML(greetingSub)}</div>
+        </section>
+
+        ${mobileWidgetStack}
+      </div>
+      <button type="button" class="m-chat-fab" onclick="window.openChatPanel && window.openChatPanel()" aria-label="Ask AI">${renderMobileIcon('chat')}</button>
+      ${renderMobileBottomTabs('dashboard')}
+    </div>`;
+
+  if (resetScroll && typeof window.scrollTo === 'function') {
+    window.scrollTo(0, 0);
+  }
+  mobileDashboardDeps.setupDropZone();
+  refreshMobileDashboardActiveTab();
+  loadContextHealthDots();
+  if (window.loadContextCardTips) window.loadContextCardTips();
+  mobileDashboardDeps.loadCommitHash();
+  if (window.loadCatalog) window.loadCatalog().then(c => { window._cachedCatalog = c; });
+}
+
+Object.assign(window, {
+  openMobileDashboardSearch,
+  mobileDashboardJump,
+  mobileDashboardSetTab,
+  refreshMobileDashboardActiveTab,
+});

--- a/js/views.js
+++ b/js/views.js
@@ -5,9 +5,9 @@ import { trackUsage } from './schema.js';
 import { escapeHTML, escapeAttr, getStatus, getRangePosition, formatValue, getTrend, showNotification, hasCardContent, formatDate, safeMarkerId } from './utils.js';
 import { getChartColors } from './theme.js';
 import { getActiveData, filterDatesByRange, destroyAllCharts, getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, getAllFlaggedMarkers, countFlagged, statusIcon, getFocusCardFingerprint, saveImportedData, updateHeaderDates, renderDateRangeFilter, renderChartLayersDropdown } from './data.js';
-import { profileStorageKey, getProfiles } from './profile.js';
+import { profileStorageKey } from './profile.js';
 import { createLineChart, ensureChartJs } from './charts.js';
-import { canonicalMetric, metricsForSources } from './wearable-adapters.js';
+import { canonicalMetric } from './wearable-adapters.js';
 import { loadContextHealthDots } from './context-cards.js';
 import { callClaudeAPI, hasAIProvider, isAIPaused, getAIProvider, getActiveModelId } from './api.js';
 import { injectLensChunks } from './lab-context.js';
@@ -20,6 +20,25 @@ import { createDashboardWidgetRegistry } from './dashboard-widgets.js';
 import { createDashboardWidgetControls } from './dashboard-widget-controls.js';
 import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js';
 import { renderLightConditionsWidgetBody, renderConditionsNow, _refreshConditionsNow, _inspectConditionsNow, _setManualUvi, _clearManualUvi, _formatElapsedShort } from './light-conditions-now.js';
+import {
+  configureMobileDashboardView,
+  isMobileDashboardViewport,
+  syncMobileBottomNav,
+  refreshMobileDashboardActiveTab,
+  getMobileDashboardProfile,
+  getMobileGreetingName,
+  getMobileDashboardCounts,
+  getMobileDashboardMarkers,
+  getMobileDashboardInsights,
+  getMobileWearableTiles,
+  formatMobileWearableValue,
+  formatMobileWearableDelta,
+  getMobileWearablePriority,
+  mobileDashboardSetTab,
+  openMobileDashboardSearch,
+  mobileDashboardJump,
+  renderMobileDashboard,
+} from './mobile-dashboard.js';
 import {
   configureCompareCorrelationViews,
   showCompare,
@@ -63,6 +82,10 @@ import {
   rememberModalTrigger,
 } from './marker-detail-modal.js';
 export {
+  refreshMobileDashboardActiveTab,
+  mobileDashboardSetTab,
+  openMobileDashboardSearch,
+  mobileDashboardJump,
   showCompare,
   setCompareDate1,
   setCompareDate2,
@@ -1882,7 +1905,7 @@ const dashboardWidgetRenderers = createDashboardWidgetRenderers({
   getMobileWearableTiles,
   formatMobileWearableValue,
   formatMobileWearableDelta,
-  getMobileWearablePriority: () => MOBILE_WEARABLE_PRIORITY,
+  getMobileWearablePriority,
   rerenderDashboardFromWidgetChange,
   showRecommendations,
 });
@@ -1984,6 +2007,17 @@ const {
   renderDashboardStickyControls,
   renderDashboardWidget,
 } = dashboardWidgetControls;
+
+configureMobileDashboardView({
+  buildDashboardWidgetContext,
+  getDashboardWidgetPrefs,
+  getVisibleDashboardWidgetEntries,
+  renderDashboardControlButtons,
+  isDashboardOrganizeMode: () => dashboardWidgetControls.isOrganizeMode(),
+  renderDashboardWidget,
+  setupDropZone,
+  loadCommitHash,
+});
 
 export const toggleDashboardOrganizeMode = (...args) => dashboardWidgetControls.toggleDashboardOrganizeMode(...args);
 export const moveDashboardWidget = (...args) => dashboardWidgetControls.moveDashboardWidget(...args);
@@ -2285,484 +2319,6 @@ Object.assign(window, {
   startDashboardWidgetDrag,
   allowDashboardWidgetDrop,
   dropDashboardWidget,
-});
-
-// ═══════════════════════════════════════════════
-// MOBILE DASHBOARD
-// ═══════════════════════════════════════════════
-
-const MOBILE_DASHBOARD_QUERY = '(max-width: 799px)';
-let _mobileDashboardManualTabLockUntil = 0;
-
-function isMobileDashboardViewport() {
-  return typeof window !== 'undefined'
-    && typeof window.matchMedia === 'function'
-    && window.matchMedia(MOBILE_DASHBOARD_QUERY).matches;
-}
-
-function getMobileBottomTabForRoute(route) {
-  if (['dashboard', 'labs', 'body', 'light', 'insight'].includes(route)) return route;
-  if (route === 'recommendations') return 'insight';
-  if (route === 'compare' || route === 'correlations') return 'labs';
-  if (route && getActiveData().categories?.[route]) return 'labs';
-  return 'dashboard';
-}
-
-function syncMobileBottomNav(route = state.currentView || 'dashboard') {
-  if (typeof document === 'undefined') return;
-  const existing = document.getElementById('mobile-bottom-tabs');
-  const hasDashboardShell = document.body.classList.contains('mobile-dashboard-active');
-  const shouldRender = isMobileDashboardViewport() && !hasDashboardShell;
-  document.body.classList.toggle('mobile-tabs-active', shouldRender);
-  if (!shouldRender) {
-    existing?.remove();
-    return;
-  }
-  const activeTab = getMobileBottomTabForRoute(route);
-  const html = renderMobileBottomTabs(activeTab, { id: 'mobile-bottom-tabs' });
-  if (existing) {
-    existing.outerHTML = html;
-  } else {
-    document.body.insertAdjacentHTML('beforeend', html);
-  }
-}
-
-export function refreshMobileDashboardActiveTab() {
-  if (!document.body.classList.contains('mobile-dashboard-active')) return;
-  _mobileDashboardManualTabLockUntil = 0;
-  mobileDashboardSetTab('dashboard', { fromScroll: true });
-}
-
-if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-  const mobileDashboardMedia = window.matchMedia(MOBILE_DASHBOARD_QUERY);
-  const refreshDashboardForBreakpoint = () => {
-    if (state.currentView === 'dashboard') window.navigate?.('dashboard');
-    else syncMobileBottomNav(state.currentView || 'dashboard');
-  };
-  if (typeof mobileDashboardMedia.addEventListener === 'function') {
-    mobileDashboardMedia.addEventListener('change', refreshDashboardForBreakpoint);
-  } else if (typeof mobileDashboardMedia.addListener === 'function') {
-    mobileDashboardMedia.addListener(refreshDashboardForBreakpoint);
-  }
-}
-
-function getMobileDashboardProfile() {
-  const profiles = getProfiles() || [];
-  return profiles.find(p => p.id === state.currentProfile) || profiles[0] || { id: 'default', name: 'Default' };
-}
-
-function getMobileGreetingName(profile) {
-  const name = (profile?.name || 'there').trim();
-  if (!name || name === 'Default') return 'there';
-  return name.split(/\s+/)[0];
-}
-
-function getMobileDashboardCounts(data) {
-  let markerCount = 0;
-  let inRange = 0;
-  let flagged = 0;
-  for (const cat of Object.values(data.categories || {})) {
-    for (const marker of Object.values(cat.markers || {})) {
-      if (!markerHasData(marker)) continue;
-      markerCount++;
-      const idx = getLatestValueIndex(marker.values || []);
-      if (idx < 0) continue;
-      const value = marker.values[idx];
-      const range = getEffectiveRangeForDate(marker, idx);
-      const status = getStatus(value, range.min, range.max);
-      if (status === 'normal') inRange++;
-      else if (status === 'high' || status === 'low') flagged++;
-    }
-  }
-  const latestDate = data.dates?.[data.dates.length - 1] || '';
-  return { markerCount, inRange, flagged, latestDate };
-}
-
-function mobileStatusLabel(status) {
-  if (status === 'normal') return 'In range';
-  if (status === 'high') return 'High';
-  if (status === 'low') return 'Low';
-  return 'No value';
-}
-
-function mobileStatusTone(status) {
-  if (status === 'normal') return 'good';
-  if (status === 'high' || status === 'low') return 'alert';
-  return 'muted';
-}
-
-function getMobileMarkerSummary(data, catKey, markerKey) {
-  const id = `${catKey}_${markerKey}`;
-  if (!safeMarkerId(id)) return null;
-  const category = data.categories?.[catKey];
-  const marker = category?.markers?.[markerKey];
-  if (!marker || !markerHasData(marker)) return null;
-  const latestIdx = getLatestValueIndex(marker.values || []);
-  if (latestIdx < 0) return null;
-  const value = marker.values[latestIdx];
-  const range = getEffectiveRangeForDate(marker, latestIdx);
-  const status = getStatus(value, range.min, range.max);
-  const trend = getTrend(marker.values || [], range.min, range.max);
-  const labelSource = marker.singlePoint ? [marker.singleDateLabel || 'Latest'] : (data.dateLabels || data.dates || []);
-  state.markerRegistry[id] = marker;
-  return {
-    id,
-    name: marker.name || markerKey,
-    category: category.label || catKey,
-    value: formatValue(value),
-    unit: marker.unit || '',
-    date: labelSource[latestIdx] || 'Latest',
-    status,
-    statusLabel: mobileStatusLabel(status),
-    tone: mobileStatusTone(status),
-    trend,
-    values: marker.values || [],
-  };
-}
-
-function getMobileDashboardMarkers(ctx) {
-  const seen = new Set();
-  const summaries = [];
-  const add = (catKey, markerKey, sourceData = ctx.filteredData) => {
-    const id = `${catKey}_${markerKey}`;
-    if (seen.has(id)) return;
-    const summary = getMobileMarkerSummary(sourceData, catKey, markerKey)
-      || getMobileMarkerSummary(ctx.data, catKey, markerKey);
-    if (!summary) return;
-    seen.add(id);
-    summaries.push(summary);
-  };
-
-  for (const km of ctx.keyMarkers || []) add(km.cat, km.key);
-  for (const alert of ctx.trendAlerts || []) {
-    const idx = alert.id.indexOf('_');
-    if (idx > 0) add(alert.id.slice(0, idx), alert.id.slice(idx + 1));
-  }
-  for (const flag of getAllFlaggedMarkers(ctx.data).slice(0, 12)) {
-    add(flag.categoryKey, flag.markerKey, ctx.data);
-  }
-  for (const [catKey, category] of Object.entries(ctx.filteredData.categories || {})) {
-    for (const markerKey of Object.keys(category.markers || {})) add(catKey, markerKey);
-    if (summaries.length >= 10) break;
-  }
-  return summaries.slice(0, 10);
-}
-
-function renderMobileSparkline(values, status) {
-  const points = (values || []).filter(v => v !== null && Number.isFinite(Number(v))).slice(-7).map(Number);
-  if (points.length < 2) return `<span class="m-spark m-spark-empty" aria-hidden="true"></span>`;
-  const min = Math.min(...points);
-  const max = Math.max(...points);
-  const span = max - min || 1;
-  const coords = points.map((value, index) => {
-    const x = points.length === 1 ? 50 : (index / (points.length - 1)) * 100;
-    const y = 28 - ((value - min) / span) * 24;
-    return `${x.toFixed(1)},${y.toFixed(1)}`;
-  }).join(' ');
-  return `<svg class="m-spark m-spark-${escapeAttr(status)}" viewBox="0 0 100 32" preserveAspectRatio="none" aria-hidden="true">
-    <polyline points="${escapeAttr(coords)}"></polyline>
-  </svg>`;
-}
-
-function renderMobileStatCard(item) {
-  if (item.type === 'summary') {
-    const summaryLabel = `${item.label}: ${item.value}, ${item.meta}`;
-    return `<div class="m-stat-card m-stat-summary" role="group" aria-label="${escapeAttr(summaryLabel)}">
-      <div class="m-stat-head"><span class="m-marker-dot" aria-hidden="true"></span><span class="m-stat-label">${escapeHTML(item.label)}</span></div>
-      <strong>${escapeHTML(item.value)}</strong>
-      <span class="m-stat-meta">${escapeHTML(item.meta)}</span>
-    </div>`;
-  }
-  return `<button type="button" class="m-stat-card m-stat-${escapeAttr(item.status)}" onclick="window.showDetailModal('${item.id}')" aria-label="${escapeAttr(item.name + ': ' + item.value + ' ' + item.unit + ', ' + item.statusLabel)}">
-    <div class="m-stat-head"><span class="m-marker-dot m-marker-${escapeAttr(item.status)}" aria-hidden="true"></span><span class="m-stat-label">${escapeHTML(item.name)}</span></div>
-    <strong>${escapeHTML(item.value)}${item.unit ? `<small>${escapeHTML(item.unit)}</small>` : ''}</strong>
-    <span class="m-stat-meta">${escapeHTML(item.statusLabel)}${item.trend?.arrow ? ` · ${escapeHTML(item.trend.arrow)}` : ''}</span>
-  </button>`;
-}
-
-function getMobileDashboardStats(data, ctx, markers) {
-  const counts = getMobileDashboardCounts(data);
-  const cards = markers.slice(0, 4).map(marker => ({ ...marker, type: 'marker' }));
-  const summaryCards = [
-    { type: 'summary', label: 'Attention', value: String((ctx.trendAlerts?.length || 0) + counts.flagged), meta: 'active flags' },
-    { type: 'summary', label: 'In range', value: `${counts.inRange}/${counts.markerCount || 0}`, meta: 'latest values' },
-    { type: 'summary', label: 'Last labs', value: counts.latestDate ? formatDate(counts.latestDate, 'short') : 'N/A', meta: `${data.dates?.length || 0} dates` },
-    { type: 'summary', label: 'Markers', value: String(counts.markerCount), meta: 'tracked' },
-  ];
-  for (const card of summaryCards) {
-    if (cards.length >= 4) break;
-    cards.push(card);
-  }
-  return cards.slice(0, 4);
-}
-
-function getMobileDashboardInsights(ctx, markers) {
-  const insights = [];
-  for (const flag of ctx.criticalFlags.slice(0, 2)) {
-    const summary = markers.find(m => m.id === flag.id);
-    insights.push({
-      id: flag.id,
-      tone: 'danger',
-      eyebrow: flag.status === 'high' ? 'Critical high' : 'Critical low',
-      title: flag.name,
-      body: `${formatValue(flag.rawValue)} ${flag.unit || ''} is outside the active range.`,
-      meta: summary?.trend?.arrow || summary?.date || '',
-    });
-  }
-  for (const alert of ctx.trendAlerts.slice(0, 3)) {
-    if (insights.length >= 3) break;
-    insights.push({
-      id: alert.id,
-      tone: alert.concern.startsWith('past_') || alert.concern.startsWith('sudden_') ? 'warn' : 'info',
-      eyebrow: 'Trend',
-      title: alert.name,
-      body: alert.concern.replace(/_/g, ' '),
-      meta: (alert.spark || []).join(' -> '),
-    });
-  }
-  if (insights.length === 0) {
-    insights.push({
-      tone: 'good',
-      eyebrow: 'Snapshot',
-      title: 'No urgent trend alerts',
-      body: 'Latest high-priority markers are not showing sudden range breaks.',
-      meta: `${markers.length} markers in the mobile watch list`,
-    });
-  }
-  return insights.slice(0, 3);
-}
-
-function renderMobileInsightCard(insight) {
-  const body = `<span class="m-insight-eyebrow">${escapeHTML(insight.eyebrow)}</span>
-    <strong>${escapeHTML(insight.title)}</strong>
-    <span>${escapeHTML(insight.body)}</span>
-    ${insight.meta ? `<small>${escapeHTML(insight.meta)}</small>` : ''}`;
-  if (insight.id && safeMarkerId(insight.id)) {
-    return `<button type="button" class="m-insight m-insight-${escapeAttr(insight.tone)}" onclick="window.showDetailModal('${insight.id}')">${body}</button>`;
-  }
-  return `<div class="m-insight m-insight-${escapeAttr(insight.tone)}">${body}</div>`;
-}
-
-function renderMobileMarkerRow(marker) {
-  return `<button type="button" class="m-marker-row" onclick="window.showDetailModal('${marker.id}')" aria-label="${escapeAttr(marker.name + ': ' + marker.value + ' ' + marker.unit)}">
-    <span class="m-marker-dot m-marker-${escapeAttr(marker.status)}" aria-hidden="true"></span>
-    <span class="m-marker-main">
-      <strong>${escapeHTML(marker.name)}</strong>
-      <small>${escapeHTML(marker.category)} · ${escapeHTML(marker.date)}</small>
-    </span>
-    ${renderMobileSparkline(marker.values, marker.status)}
-    <span class="m-marker-value">
-      <strong>${escapeHTML(marker.value)}</strong>
-      ${marker.unit ? `<small>${escapeHTML(marker.unit)}</small>` : ''}
-    </span>
-  </button>`;
-}
-
-const MOBILE_WEARABLE_PRIORITY = [
-  'hrv_rmssd',
-  'sleep_score',
-  'readiness_score',
-  'steps',
-  'rhr',
-  'weight',
-  'body_fat_pct',
-  'bp_systolic',
-];
-
-function formatMobileWearableValue(metricId, metric, summary) {
-  if (metricId === 'bp_systolic' && summary?.metrics?.bp_diastolic?.latest != null) {
-    return `${formatValue(metric.latest)}/${formatValue(summary.metrics.bp_diastolic.latest)}`;
-  }
-  const value = Number(metric?.latest);
-  if (!Number.isFinite(value)) return '—';
-  if (metricId === 'steps' && Math.abs(value) >= 1000) {
-    return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1).replace(/\.0$/, '')}k`;
-  }
-  return formatValue(value);
-}
-
-function formatMobileWearableDelta(metricId, metric, canon) {
-  const latest = Number(metric?.latest);
-  const baseline = Number(metric?.baseline);
-  if (!Number.isFinite(latest) || !Number.isFinite(baseline) || baseline === 0) return '';
-  if (metricId === 'steps') return '';
-  if (canon?.sub === 'Δ') {
-    const diff = latest - baseline;
-    const arrow = diff > 0.005 ? '↑' : diff < -0.005 ? '↓' : '→';
-    return `${arrow} ${Math.abs(diff).toFixed(2)}${canon.unit || ''}`;
-  }
-  const pct = ((latest - baseline) / baseline) * 100;
-  if (Math.abs(pct) < 0.5) return '→ baseline';
-  const arrow = pct > 0 ? '↑' : '↓';
-  return `${arrow} ${Math.abs(pct).toFixed(0)}%`;
-}
-
-function getMobileWearableTiles() {
-  const summary = state.importedData?.wearableSummary;
-  if (!summary?.metrics || Object.keys(summary.metrics).length === 0) return [];
-  const sourceIds = Object.keys(summary.sources || {});
-  const registryOrder = metricsForSources(sourceIds.length ? sourceIds : Object.keys(summary.metrics || {}));
-  const ordered = [
-    ...MOBILE_WEARABLE_PRIORITY,
-    ...registryOrder,
-    ...Object.keys(summary.metrics || {}),
-  ];
-  const seen = new Set();
-  const tiles = [];
-  for (const metricId of ordered) {
-    if (seen.has(metricId)) continue;
-    seen.add(metricId);
-    if (metricId === 'bp_diastolic' && summary.metrics.bp_systolic) continue;
-    const metric = summary.metrics[metricId];
-    const canon = canonicalMetric(metricId);
-    if (!metric || !canon || metric.latest == null) continue;
-    tiles.push({
-      id: metricId,
-      label: canon.label,
-      value: formatMobileWearableValue(metricId, metric, summary),
-      unit: metricId === 'bp_systolic' ? 'mmHg' : (canon.unit || canon.sub || ''),
-      change: formatMobileWearableDelta(metricId, metric, canon),
-    });
-    if (tiles.length >= 4) break;
-  }
-  return tiles;
-}
-
-function renderMobileWearableTiles(tiles) {
-  if (!tiles.length) {
-    return `<div class="m-wear-empty">
-      <strong>Connect body data</strong>
-      <span>HRV, sleep, steps, recovery and body composition can sit next to your labs.</span>
-      <button type="button" onclick="window.openSettingsModal && window.openSettingsModal('wearables')">Connect</button>
-    </div>`;
-  }
-  return `<div class="m-wear-strip">
-    ${tiles.map(tile => `<button type="button" class="m-wear-tile" onclick="window.openWearableDetail ? window.openWearableDetail('${escapeAttr(tile.id)}') : window.openSettingsModal?.('wearables')" aria-label="${escapeAttr(tile.label + ': ' + tile.value + ' ' + tile.unit)}">
-      <span class="m-wear-label">${escapeHTML(tile.label)}</span>
-      <strong>${escapeHTML(tile.value)}${tile.unit ? `<small>${escapeHTML(tile.unit)}</small>` : ''}</strong>
-      <span class="m-wear-change">${escapeHTML(tile.change || 'latest')}</span>
-    </button>`).join('')}
-  </div>`;
-}
-
-function renderMobileSectionHead(title, count, actionLabel = '', action = '') {
-  return `<div class="m-section-head">
-    <div class="m-section-labels">
-      <span class="m-section-title">${escapeHTML(title)}</span>
-      ${count ? `<span class="m-section-count">${escapeHTML(count)}</span>` : ''}
-    </div>
-    ${actionLabel && action ? `<button type="button" onclick="${escapeAttr(action)}">${escapeHTML(actionLabel)}</button>` : ''}
-  </div>`;
-}
-
-function renderMobileIcon(name) {
-  const icons = {
-    labs: '<rect x="4" y="4" width="6" height="6" rx="1.2"></rect><rect x="14" y="4" width="6" height="6" rx="1.2"></rect><rect x="4" y="14" width="6" height="6" rx="1.2"></rect><rect x="14" y="14" width="6" height="6" rx="1.2"></rect>',
-    genome: '<path d="M8 4c4 4 4 12 8 16"></path><path d="M16 4c-4 4-4 12-8 16"></path><path d="M9.5 8h5"></path><path d="M9.5 12h5"></path><path d="M9.5 16h5"></path>',
-    body: '<path d="M4 12h4l2-6 4 12 2-6h4"></path>',
-    light: '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v3"></path><path d="M12 19v3"></path><path d="M4.93 4.93l2.12 2.12"></path><path d="M16.95 16.95l2.12 2.12"></path><path d="M2 12h3"></path><path d="M19 12h3"></path><path d="M4.93 19.07l2.12-2.12"></path><path d="M16.95 7.05l2.12-2.12"></path>',
-    insight: '<path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path><path d="M8 9h8"></path><path d="M8 13h5"></path>',
-    more: '<path d="M4 7h16"></path><path d="M4 12h16"></path><path d="M4 17h16"></path>',
-    tweaks: '<line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line>',
-    settings: '<circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>',
-    search: '<circle cx="11" cy="11" r="6"></circle><path d="m16 16 4 4"></path>',
-    chat: '<path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path>',
-  };
-  return `<svg class="m-svg-icon" viewBox="0 0 24 24" fill="none" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${icons[name] || icons.labs}</svg>`;
-}
-
-export function mobileDashboardSetTab(tab, { fromScroll = false } = {}) {
-  if (!fromScroll) _mobileDashboardManualTabLockUntil = Date.now() + 600;
-  document.querySelectorAll('.m-tab').forEach(btn => {
-    const isActive = btn.dataset.tab === tab;
-    btn.classList.toggle('active', isActive);
-    btn.setAttribute('aria-current', isActive ? 'page' : 'false');
-  });
-}
-
-function renderMobileBottomTabs(activeTab = 'dashboard', { id = '' } = {}) {
-  const navId = id ? ` id="${id}"` : '';
-  const tabAttrs = tab => `class="m-tab${activeTab === tab ? ' active' : ''}" data-tab="${tab}" aria-current="${activeTab === tab ? 'page' : 'false'}"`;
-  return `<nav${navId} class="m-tabbar" aria-label="Mobile primary navigation">
-    <button type="button" ${tabAttrs('dashboard')} onclick="window.mobileDashboardSetTab('dashboard');window.navigate('dashboard')" aria-label="Dashboard"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Home</small></button>
-    <button type="button" ${tabAttrs('labs')} onclick="window.mobileDashboardSetTab('labs');window.navigate('labs')" aria-label="Labs"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Labs</small></button>
-    <button type="button" ${tabAttrs('body')} onclick="window.mobileDashboardSetTab('body');window.navigate('body')" aria-label="Body"><span class="m-tab-icon">${renderMobileIcon('body')}</span><small>Body</small></button>
-    <button type="button" ${tabAttrs('light')} onclick="window.mobileDashboardSetTab('light');window.navigate('light')" aria-label="Light"><span class="m-tab-icon">${renderMobileIcon('light')}</span><small>Light</small></button>
-    <button type="button" ${tabAttrs('insight')} onclick="window.mobileDashboardSetTab('insight');window.navigate('insight')" aria-label="Insight"><span class="m-tab-icon">${renderMobileIcon('insight')}</span><small>Insight</small></button>
-  </nav>`;
-}
-
-function renderMobileDashboardWidgetStack(ctx) {
-  const prefs = getDashboardWidgetPrefs();
-  const visibleEntries = getVisibleDashboardWidgetEntries(ctx, prefs);
-  return `<section class="m-section m-dashboard-widget-section">
-    ${renderMobileSectionHead('Dashboard widgets', String(visibleEntries.length))}
-    <div class="m-dashboard-widget-actions">${renderDashboardControlButtons({ includeReset: dashboardWidgetControls.isOrganizeMode() })}</div>
-    <div class="dashboard-widgets m-dashboard-widgets">
-      ${visibleEntries.length
-        ? visibleEntries.map((entry, index) => renderDashboardWidget(entry, prefs, index, visibleEntries)).join('')
-        : '<div class="dashboard-widget dashboard-widget-full is-empty"><div class="dashboard-widget-empty">No widgets are visible.</div></div>'}
-    </div>
-  </section>`;
-}
-
-export function openMobileDashboardSearch() {
-  if (window.toggleMobileSidebar) window.toggleMobileSidebar();
-  setTimeout(() => document.getElementById('sidebar-search')?.focus(), 80);
-}
-
-export function mobileDashboardJump(section) {
-  const route = ['dashboard', 'labs', 'genome', 'body', 'light', 'insight', 'recommendations'].includes(section) ? section : 'dashboard';
-  mobileDashboardSetTab(route === 'genome' || route === 'recommendations' ? 'dashboard' : route);
-  window.navigate?.(route);
-}
-
-function renderMobileDashboard(data, { resetScroll = false } = {}) {
-  const main = document.getElementById("main-content");
-  if (!main) return;
-  const ctx = buildDashboardWidgetContext(data);
-  const profile = getMobileDashboardProfile();
-  const mobileWidgetStack = renderMobileDashboardWidgetStack(ctx);
-  const firstName = getMobileGreetingName(profile);
-  const counts = getMobileDashboardCounts(data);
-  const greetingSub = [
-    `${counts.markerCount || 0} markers`,
-    counts.latestDate ? `last draw ${formatDate(counts.latestDate, 'short')}` : '',
-    `${data.dates?.length || 0} draw${data.dates?.length === 1 ? '' : 's'}`,
-  ].filter(Boolean).join(' · ');
-
-  document.body.classList.add('mobile-dashboard-active');
-  main.innerHTML = `<div class="drop-zone drop-zone-hidden" id="drop-zone"></div>
-    <div class="m-shell">
-      <div class="m-bg" aria-hidden="true"></div>
-      <div class="m-content">
-        <section class="m-greeting">
-          <h1>Hey ${escapeHTML(firstName)}.</h1>
-          <div class="m-greeting-sub">${escapeHTML(greetingSub)}</div>
-        </section>
-
-        ${mobileWidgetStack}
-      </div>
-      <button type="button" class="m-chat-fab" onclick="window.openChatPanel && window.openChatPanel()" aria-label="Ask AI">${renderMobileIcon('chat')}</button>
-      ${renderMobileBottomTabs('dashboard')}
-    </div>`;
-
-  if (resetScroll && typeof window.scrollTo === 'function') {
-    window.scrollTo(0, 0);
-  }
-  setupDropZone();
-  refreshMobileDashboardActiveTab();
-  loadContextHealthDots();
-  if (window.loadContextCardTips) window.loadContextCardTips();
-  loadCommitHash();
-  if (window.loadCatalog) window.loadCatalog().then(c => { window._cachedCatalog = c; });
-}
-
-Object.assign(window, {
-  openMobileDashboardSearch,
-  mobileDashboardJump,
-  mobileDashboardSetTab,
-  refreshMobileDashboardActiveTab,
 });
 
 // ═══════════════════════════════════════════════

--- a/service-worker.js
+++ b/service-worker.js
@@ -66,6 +66,7 @@ const APP_SHELL = [
   '/js/marker-detail-modal.js',
   '/js/light-conditions-now.js',
   '/js/compare-correlations.js',
+  '/js/mobile-dashboard.js',
   '/js/views.js',
   '/js/recommendations.js',
   '/js/crypto.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -129,7 +129,7 @@ const _SAFE_HELPERS = new Set([
   // is the markdown.js sanitized full renderer)
   'escapeHTML', 'renderMarkdown',
 ]);
-const _SWEEP_FILES = ['views.js', 'marker-detail-modal.js', 'dashboard-widget-renderers.js', 'light-conditions-now.js', 'compare-correlations.js', 'chat.js', 'charts.js'];
+const _SWEEP_FILES = ['views.js', 'marker-detail-modal.js', 'dashboard-widget-renderers.js', 'light-conditions-now.js', 'compare-correlations.js', 'mobile-dashboard.js', 'chat.js', 'charts.js'];
 
 function _sweepInnerHTML(filename, src) {
   const lines = src.split('\n');

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -82,6 +82,7 @@ const pwaAppShellAssets = [
   '/js/dashboard-widget-renderers.js',
   '/js/light-conditions-now.js',
   '/js/compare-correlations.js',
+  '/js/mobile-dashboard.js',
   '/js/light-devices.js',
   '/js/light-env.js',
   '/js/light-tools.js',

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -73,6 +73,11 @@ return (async function() {
     !mobileDashboardSrc.includes('id="mobile-body-section"') &&
     !mobileDashboardSrc.includes('id="mobile-genome-section"') &&
     !mobileDashboardSrc.includes('const lightHtml = renderLightTodayStrip();') &&
+    !mobileDashboardSrc.includes('function renderMobileStatCard') &&
+    !mobileDashboardSrc.includes('function getMobileDashboardStats') &&
+    !mobileDashboardSrc.includes('function renderMobileInsightCard') &&
+    !mobileDashboardSrc.includes('function renderMobileMarkerRow') &&
+    !mobileDashboardSrc.includes('function renderMobileWearableTiles') &&
     !mobileDashboardSrc.includes('stats.map(renderMobileStatCard)') &&
     !mobileDashboardSrc.includes('insights.map(renderMobileInsightCard)') &&
     !mobileDashboardSrc.includes('markers.slice(0, 7).map(renderMobileMarkerRow)'));

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -39,6 +39,7 @@ return (async function() {
     css.includes('position: fixed') &&
     css.includes('z-index: 360'));
   const viewsSrc = await fetchWithRetry('js/views.js');
+  const mobileDashboardSrc = await fetchWithRetry('js/mobile-dashboard.js');
   const dashboardControlsSrc = await fetchWithRetry('js/dashboard-widget-controls.js');
   const routerSrc = await fetchWithRetry('js/views-router.js');
   assert('mobile landing does not auto-open fullscreen chat',
@@ -46,35 +47,35 @@ return (async function() {
     viewsSrc.includes('if (!isDesktopChatOnboardingViewport || window.innerWidth <= 768) return'));
   assert('mobile bottom tabs persist outside dashboard shell',
     routerSrc.includes('syncMobileBottomNav?.(routeCategory)') &&
-    viewsSrc.includes("id: 'mobile-bottom-tabs'") &&
-    viewsSrc.includes('renderMobileBottomTabs(activeTab'));
+    mobileDashboardSrc.includes("id: 'mobile-bottom-tabs'") &&
+    mobileDashboardSrc.includes('renderMobileBottomTabs(activeTab'));
   assert('mobile dashboard home uses the shared header chrome',
     css.includes('body.mobile-dashboard-active .header') &&
     css.includes('display: flex') &&
-    !viewsSrc.includes('class="m-topbar"'));
+    !mobileDashboardSrc.includes('class="m-topbar"'));
   assert('mobile dashboard no longer ships dead private topbar styles',
     !css.includes('.m-topbar-actions') &&
     !css.includes('.m-avatar-btn') &&
     !css.includes('.m-icon-btn') &&
-    !viewsSrc.includes('getMobileAvatar'));
+    !mobileDashboardSrc.includes('getMobileAvatar'));
   assert('mobile dashboard renders the same registered widget stack as desktop',
-    viewsSrc.includes('function renderMobileDashboardWidgetStack(ctx)') &&
-    viewsSrc.includes('getVisibleDashboardWidgetEntries(ctx, prefs') &&
-    viewsSrc.includes('m-dashboard-widget-actions') &&
-    viewsSrc.includes('renderDashboardControlButtons({ includeReset: dashboardWidgetControls.isOrganizeMode() })') &&
+    mobileDashboardSrc.includes('function renderMobileDashboardWidgetStack(ctx)') &&
+    mobileDashboardSrc.includes('getVisibleDashboardWidgetEntries(ctx, prefs') &&
+    mobileDashboardSrc.includes('m-dashboard-widget-actions') &&
+    mobileDashboardSrc.includes('renderDashboardControlButtons({ includeReset: mobileDashboardDeps.isDashboardOrganizeMode() })') &&
     dashboardControlsSrc.includes('function renderDashboardControlButtons') &&
-    viewsSrc.includes('renderDashboardWidget(entry, prefs, index, visibleEntries)') &&
+    mobileDashboardSrc.includes('renderDashboardWidget(entry, prefs, index, visibleEntries)') &&
     dashboardControlsSrc.includes('function renderDashboardWidget(entry, prefs, index, visibleEntries)') &&
-    viewsSrc.includes('${mobileWidgetStack}') &&
+    mobileDashboardSrc.includes('${mobileWidgetStack}') &&
     css.includes('.m-dashboard-widgets'));
   assert('mobile dashboard no longer has static duplicate dashboard sections',
-    !viewsSrc.includes('id="mobile-light-section"') &&
-    !viewsSrc.includes('id="mobile-body-section"') &&
-    !viewsSrc.includes('id="mobile-genome-section"') &&
-    !viewsSrc.includes('const lightHtml = renderLightTodayStrip();') &&
-    !viewsSrc.includes('stats.map(renderMobileStatCard)') &&
-    !viewsSrc.includes('insights.map(renderMobileInsightCard)') &&
-    !viewsSrc.includes('markers.slice(0, 7).map(renderMobileMarkerRow)'));
+    !mobileDashboardSrc.includes('id="mobile-light-section"') &&
+    !mobileDashboardSrc.includes('id="mobile-body-section"') &&
+    !mobileDashboardSrc.includes('id="mobile-genome-section"') &&
+    !mobileDashboardSrc.includes('const lightHtml = renderLightTodayStrip();') &&
+    !mobileDashboardSrc.includes('stats.map(renderMobileStatCard)') &&
+    !mobileDashboardSrc.includes('insights.map(renderMobileInsightCard)') &&
+    !mobileDashboardSrc.includes('markers.slice(0, 7).map(renderMobileMarkerRow)'));
   const themesSrc = await fetchWithRetry('themes-extra.css');
   assert('glass tweaks panel is opaque enough to read',
     themesSrc.includes('[data-theme="glass"] .tweaks-panel') &&

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -568,6 +568,9 @@
     const hasCompareCorrelationsJs = sw.includes('/js/compare-correlations.js');
     assert('Service worker caches js/compare-correlations.js', hasCompareCorrelationsJs);
 
+    const hasMobileDashboardJs = sw.includes('/js/mobile-dashboard.js');
+    assert('Service worker caches js/mobile-dashboard.js', hasMobileDashboardJs);
+
     const hasSchemaJs = sw.includes('/js/schema.js');
     assert('Service worker caches js/schema.js', hasSchemaJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.23';
+self.APP_VERSION = '1.8.24';


### PR DESCRIPTION
## Summary
- Extract the mobile dashboard shell, bottom tabs, mobile marker summaries, and mobile wearable helpers into `js/mobile-dashboard.js`.
- Keep `views.js` as the integration point by injecting dashboard widget rendering hooks into the new module.
- Add the new module to the service-worker app shell and update source-inspection coverage.
- Bump app version to `1.8.24` for cache invalidation.

## Validation
- `node --check js/views.js js/mobile-dashboard.js`
- `node tests/test-audit.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-v1-6-shipped.js`
- `./run-tests.sh`