### PR TITLE
[codex] Extract focus card module

### DIFF
--- a/js/focus-card.js
+++ b/js/focus-card.js
@@ -1,0 +1,223 @@
+// focus-card.js - Current Focus dashboard and Insight lens card
+
+import { state } from './state.js';
+import { trackUsage } from './schema.js';
+import { hasCardContent, getStatus } from './utils.js';
+import { getActiveData, getAllFlaggedMarkers, getFocusCardFingerprint } from './data.js';
+import { profileStorageKey } from './profile.js';
+import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from './api.js';
+import { injectLensChunks } from './lab-context.js';
+import { hasLens, queryLens } from './lens.js';
+import { applyInlineMarkdown } from './markdown.js';
+
+export function renderFocusCard() {
+  const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
+  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey)); } catch(e) { return null; } })();
+  const fp = getFocusCardFingerprint();
+  const text = (cached && cached.fingerprint === fp) ? cached.text : null;
+  return `<div class="focus-card" id="focus-card">
+    <div class="focus-card-icon">\uD83D\uDD2C</div>
+    <div class="focus-card-body" id="focus-card-body">${text
+      ? `<span class="focus-card-text">${applyInlineMarkdown(text)}</span>`
+      : `<span class="focus-card-shimmer"></span>`}</div>
+    <button class="focus-card-refresh" onclick="refreshFocusCard()" aria-label="Regenerate insight" title="Regenerate insight">\u21BB</button>
+  </div>`;
+}
+
+export function buildFocusContext() {
+  const data = getActiveData();
+  if (!data.dates.length && !Object.values(data.categories).some(c => c.singleDate)) {
+    return null;
+  }
+  const sexLabel = state.profileSex === 'female' ? 'female' : state.profileSex === 'male' ? 'male' : 'not specified';
+  const age = state.profileDob ? Math.floor((new Date() - new Date(state.profileDob)) / (365.25 * 24 * 60 * 60 * 1000)) : null;
+  const today = new Date().toISOString().slice(0, 10);
+  const lastDate = data.dates[data.dates.length - 1];
+  let ctx = `Profile: ${sexLabel}${age !== null ? ', age ' + age : ''}, today ${today}, last labs ${lastDate}\n`;
+
+  const healthGoals = state.importedData.healthGoals || [];
+  if (healthGoals.length > 0) {
+    const byPriority = { major: [], mild: [], minor: [] };
+    for (const g of healthGoals) (byPriority[g.severity] || byPriority.minor).push(g.text);
+    const parts = [];
+    for (const [sev, items] of Object.entries(byPriority)) {
+      if (items.length > 0) parts.push(`${sev}: ${items.join('; ')}`);
+    }
+    ctx += `Goals: ${parts.join(' | ')}\n`;
+  }
+
+  const interpretiveLens = state.importedData.interpretiveLens || '';
+  if (interpretiveLens.trim()) {
+    ctx += `Lens: ${interpretiveLens.trim()}\n`;
+  }
+
+  const diag = state.importedData.diagnoses;
+  if (hasCardContent(diag)) {
+    const conditions = (diag.conditions || []).map(c => `${c.name} (${c.severity})`);
+    if (conditions.length > 0) ctx += `Conditions: ${conditions.join(', ')}\n`;
+    if (diag.note) ctx += `Medical notes: ${diag.note}\n`;
+  }
+
+  const contextNotes = state.importedData.contextNotes || '';
+  if (contextNotes.trim()) {
+    ctx += `Notes for AI: ${contextNotes.trim()}\n`;
+  }
+
+  const _isAICtx = (catKey) => { const g = data.categories[catKey]?.group; return !g || (window.isGroupInAIContext ? window.isGroupInAIContext(g) : true); };
+  const flags = getAllFlaggedMarkers(data).filter(f => _isAICtx(f.categoryKey));
+  if (flags.length > 0) {
+    ctx += `Flagged (${flags.length} total${flags.length > 15 ? ', showing top 15' : ''}):\n`;
+    for (const f of flags.slice(0, 15)) {
+      ctx += `- ${f.name}: ${f.value} ${f.unit} (${f.status}, ref ${f.effectiveMin}\u2013${f.effectiveMax})\n`;
+    }
+  }
+
+  const supps = (state.importedData.supplements || []).slice(0, 8);
+  if (supps.length > 0) {
+    ctx += `Supplements:\n`;
+    for (const s of supps) {
+      const pds = (s.periods && s.periods.length > 0) ? [...s.periods].sort((a, b) => a.start.localeCompare(b.start)) : [{ start: s.startDate, end: s.endDate }];
+      const dateRange = pds.length === 1
+        ? `${pds[0].start} \u2192 ${pds[0].end || 'ongoing'}`
+        : pds.map(p => `${p.start}\u2192${p.end || 'now'}`).join(', ');
+      let timing = '';
+      const firstStart = pds[0].start;
+      if (lastDate && firstStart > lastDate) timing = ' (started AFTER last labs \u2014 cannot have affected these results)';
+      else if (lastDate && data.dates.length >= 2 && firstStart > data.dates[data.dates.length - 2]) timing = ' (started between last two labs)';
+      let impactNote = '';
+      if (!timing && data.dates.length >= 2) {
+        const impacts = window.computeAllImpacts?.(s, data);
+        if (impacts && impacts.length > 0) {
+          const top = impacts.slice(0, 2).filter(im => im.confidence !== 'low');
+          if (top.length > 0) {
+            impactNote = ' \u2014 impacts: ' + top.map(im => `${im.markerName} ${im.pctChange > 0 ? '+' : ''}${im.pctChange.toFixed(1)}%`).join(', ');
+          }
+        }
+      }
+      ctx += `- ${s.name}${s.dosage ? ' (' + s.dosage + ')' : ''} [${s.type}]: ${dateRange}${timing}${impactNote}\n`;
+    }
+  }
+
+  const changes = [];
+  for (const [catKey, cat] of Object.entries(data.categories)) {
+    if (!_isAICtx(catKey)) continue;
+    for (const [, m] of Object.entries(cat.markers)) {
+      const nonNull = m.values.filter(v => v !== null);
+      if (nonNull.length < 2) continue;
+      const prev = nonNull[nonNull.length - 2];
+      const last = nonNull[nonNull.length - 1];
+      if (prev === 0) continue;
+      const pct = Math.abs((last - prev) / prev * 100);
+      if (pct > 20) {
+        const dir = last > prev ? 'up' : 'down';
+        const ref = m.refMin != null && m.refMax != null ? `, ref ${m.refMin}\u2013${m.refMax}` : '';
+        const status = getStatus(last, m.refMin, m.refMax);
+        changes.push(`${m.name}: ${prev} \u2192 ${last} ${m.unit || ''} (${dir} ${pct.toFixed(0)}%${ref}, ${status})`);
+      }
+    }
+  }
+  if (changes.length > 0) {
+    ctx += `Notable changes:\n${changes.slice(0, 5).map(c => '- ' + c).join('\n')}\n`;
+  }
+
+  return ctx;
+}
+
+export async function loadFocusCard(opts = {}) {
+  const el = document.getElementById('focus-card-body');
+  if (!el) return;
+  const refreshStale = opts.refreshStale !== false;
+  const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
+  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey)); } catch(e) { return null; } })();
+  const fp = getFocusCardFingerprint();
+  if (cached && cached.text) {
+    el.innerHTML = `<span class="focus-card-text">${applyInlineMarkdown(cached.text)}</span>`;
+    // Hand-authored prefill (demo profiles only) ships without a
+    // fingerprint; never auto-refresh. The manual refresh button still
+    // works because refreshFocusCard clears the cache entirely.
+    if (!cached.fingerprint) return;
+    if (cached.fingerprint === fp || !hasAIProvider()) return;
+    if (!refreshStale) return;
+  }
+  if (!hasAIProvider()) {
+    if (!cached?.text) el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">Enable AI to generate insights</span>`;
+    return;
+  }
+  el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">\uD83D\uDD0D Looking into your results\u2026</span>`;
+  try {
+    let ctx = buildFocusContext();
+    if (!ctx) {
+      el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">No insight available</span>`;
+      return;
+    }
+    if (hasLens()) {
+      const data = getActiveData();
+      const goals = (state.importedData.healthGoals || []).map(g => g.text).slice(0, 3).join('; ');
+      const flags = getAllFlaggedMarkers(data).slice(0, 5).map(f => f.name).join(', ');
+      const hint = [goals && 'Goals: ' + goals, flags && 'Flagged: ' + flags].filter(Boolean).join(' | ') || 'prioritize and summarize lab findings';
+      const lensResult = await queryLens(hint);
+      if (lensResult) ctx = injectLensChunks(ctx, lensResult);
+    }
+    const focusSystem = `You summarize blood work for a health dashboard card. Write 3-5 sentences, no more. Rules:
+- Start with the single most critical finding and why it matters for this person's goals/conditions
+- Then mention 1-2 secondary findings worth watching
+- End with one concrete next step (retest, lifestyle change, discuss with provider)
+- Connect findings to each other when relevant (e.g. liver markers + hormones)
+- Only flag values genuinely outside reference range
+- Never recommend specific supplements or products
+- Only reference data provided below \u2014 never infer or assume
+- Never attribute changes to supplements started after the last lab date
+- CRITICAL: Output ONLY the insight text. No thinking, no reasoning, no "Let me analyze", no numbered analysis steps, no preamble. Start directly with your finding.`;
+
+    const textEl = document.createElement('span');
+    textEl.className = 'focus-card-text';
+    let target = '', displayed = 0, timer = null;
+    function tick() {
+      if (displayed >= target.length) { timer = null; return; }
+      const batch = Math.max(1, Math.ceil((target.length - displayed) * 0.3));
+      displayed = Math.min(displayed + batch, target.length);
+      textEl.textContent = target.slice(0, displayed);
+      timer = setTimeout(tick, 16);
+    }
+
+    const { text: fullText, usage } = await callClaudeAPI({
+      system: focusSystem,
+      messages: [{ role: 'user', content: ctx }],
+      maxTokens: 500,
+      onStream(text) {
+        if (text.length < target.length) displayed = 0;
+        target = text;
+        if (!textEl.parentNode) { el.innerHTML = ''; el.appendChild(textEl); }
+        if (!timer) tick();
+      }
+    });
+    if (timer) { clearTimeout(timer); timer = null; }
+
+    if (usage) {
+      trackUsage(getAIProvider(), getActiveModelId(), usage.inputTokens || 0, usage.outputTokens || 0);
+    }
+    let trimmed = (fullText || '')
+      .replace(/<think>[\s\S]*?<\/think>/g, '')
+      .trim();
+    const lines = trimmed.split('\n');
+    const thinkingPattern = /^(Let me |I need to |I should |I'll |Key findings|The user |Looking at the|Now |First,|So |OK |Alright|\d+\.\s+\w+:)/i;
+    let startIdx = 0;
+    while (startIdx < lines.length && (thinkingPattern.test(lines[startIdx].trim()) || lines[startIdx].trim() === '')) startIdx++;
+    if (startIdx > 0 && startIdx < lines.length) trimmed = lines.slice(startIdx).join('\n').trim();
+    if (trimmed.length > 1500) { const cut = trimmed.slice(0, 1500).lastIndexOf('.'); if (cut > 100) trimmed = trimmed.slice(0, cut + 1); }
+    if (trimmed) {
+      localStorage.setItem(cacheKey, JSON.stringify({ fingerprint: fp, text: trimmed }));
+      el.innerHTML = `<span class="focus-card-text">${applyInlineMarkdown(trimmed)}</span>`;
+    } else {
+      el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">No insight available</span>`;
+    }
+  } catch(e) {
+    el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">Could not load insight</span>`;
+  }
+}
+
+export function refreshFocusCard() {
+  const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
+  localStorage.removeItem(cacheKey);
+  loadFocusCard();
+}

--- a/js/views.js
+++ b/js/views.js
@@ -1,24 +1,21 @@
 // views.js — Navigate, dashboard, category views, and shared view composition
 
 import { state } from './state.js';
-import { trackUsage } from './schema.js';
-import { escapeHTML, escapeAttr, getStatus, getRangePosition, formatValue, getTrend, showNotification, hasCardContent, formatDate, safeMarkerId } from './utils.js';
+import { escapeHTML, escapeAttr, getStatus, getRangePosition, formatValue, getTrend, showNotification, formatDate, safeMarkerId } from './utils.js';
 import { getChartColors } from './theme.js';
-import { getActiveData, filterDatesByRange, destroyAllCharts, getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, getAllFlaggedMarkers, countFlagged, statusIcon, getFocusCardFingerprint, saveImportedData, updateHeaderDates, renderDateRangeFilter, renderChartLayersDropdown } from './data.js';
+import { getActiveData, filterDatesByRange, destroyAllCharts, getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, countFlagged, statusIcon, saveImportedData, updateHeaderDates, renderDateRangeFilter, renderChartLayersDropdown } from './data.js';
 import { profileStorageKey } from './profile.js';
 import { createLineChart, ensureChartJs } from './charts.js';
 import { canonicalMetric } from './wearable-adapters.js';
 import { loadContextHealthDots } from './context-cards.js';
-import { callClaudeAPI, hasAIProvider, isAIPaused, getAIProvider, getActiveModelId } from './api.js';
-import { injectLensChunks } from './lab-context.js';
-import { hasLens, queryLens } from './lens.js';
-import { applyInlineMarkdown } from './markdown.js';
+import { hasAIProvider, isAIPaused } from './api.js';
 import { loadPdfImport } from './import-loader.js';
 import { createNavigate, getInitialView as getRouterInitialView } from './views-router.js';
 import { createLensPageHandlers } from './lens-pages.js';
 import { createDashboardWidgetRegistry } from './dashboard-widgets.js';
 import { createDashboardWidgetControls } from './dashboard-widget-controls.js';
 import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js';
+import { renderFocusCard, buildFocusContext, loadFocusCard, refreshFocusCard } from './focus-card.js';
 import { renderLightConditionsWidgetBody, renderConditionsNow, _refreshConditionsNow, _inspectConditionsNow, _setManualUvi, _clearManualUvi, _formatElapsedShort } from './light-conditions-now.js';
 import { renderUnifiedSessionsList, _openAllSessionsModal } from './light-sessions-view.js';
 import {
@@ -87,6 +84,10 @@ export {
   mobileDashboardSetTab,
   openMobileDashboardSearch,
   mobileDashboardJump,
+  renderFocusCard,
+  buildFocusContext,
+  loadFocusCard,
+  refreshFocusCard,
   showCompare,
   setCompareDate1,
   setCompareDate2,
@@ -2264,233 +2265,6 @@ function loadCommitHash() {
     .then(r => r.ok ? r.text() : Promise.reject())
     .then(sha => { _cachedCommitHash = sha.slice(0, 7); const e = document.getElementById('app-commit-hash'); if (e) e.innerHTML = `<a href="https://github.com/elkimek/get-based/commit/${_cachedCommitHash}" target="_blank" rel="noopener">${_cachedCommitHash}</a>`; })
     .catch(() => {});
-}
-
-// ── Focus Card ──
-
-export function renderFocusCard() {
-  const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
-  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey)); } catch(e) { return null; } })();
-  const fp = getFocusCardFingerprint();
-  const text = (cached && cached.fingerprint === fp) ? cached.text : null;
-  return `<div class="focus-card" id="focus-card">
-    <div class="focus-card-icon">\uD83D\uDD2C</div>
-    <div class="focus-card-body" id="focus-card-body">${text
-      ? `<span class="focus-card-text">${applyInlineMarkdown(text)}</span>`
-      : `<span class="focus-card-shimmer"></span>`}</div>
-    <button class="focus-card-refresh" onclick="refreshFocusCard()" aria-label="Regenerate insight" title="Regenerate insight">\u21BB</button>
-  </div>`;
-}
-
-export function buildFocusContext() {
-  const data = getActiveData();
-  if (!data.dates.length && !Object.values(data.categories).some(c => c.singleDate)) {
-    return null;
-  }
-  const sexLabel = state.profileSex === 'female' ? 'female' : state.profileSex === 'male' ? 'male' : 'not specified';
-  const age = state.profileDob ? Math.floor((new Date() - new Date(state.profileDob)) / (365.25 * 24 * 60 * 60 * 1000)) : null;
-  const today = new Date().toISOString().slice(0, 10);
-  const lastDate = data.dates[data.dates.length - 1];
-  let ctx = `Profile: ${sexLabel}${age !== null ? ', age ' + age : ''}, today ${today}, last labs ${lastDate}\n`;
-
-  // Health goals (all priorities)
-  const healthGoals = state.importedData.healthGoals || [];
-  if (healthGoals.length > 0) {
-    const byPriority = { major: [], mild: [], minor: [] };
-    for (const g of healthGoals) (byPriority[g.severity] || byPriority.minor).push(g.text);
-    const parts = [];
-    for (const [sev, items] of Object.entries(byPriority)) {
-      if (items.length > 0) parts.push(`${sev}: ${items.join('; ')}`);
-    }
-    ctx += `Goals: ${parts.join(' | ')}\n`;
-  }
-
-  // Interpretive lens
-  const interpretiveLens = state.importedData.interpretiveLens || '';
-  if (interpretiveLens.trim()) {
-    ctx += `Lens: ${interpretiveLens.trim()}\n`;
-  }
-
-  // Medical history (own diagnoses + family history)
-  const diag = state.importedData.diagnoses;
-  if (hasCardContent(diag)) {
-    const conditions = (diag.conditions || []).map(c => `${c.name} (${c.severity})`);
-    if (conditions.length > 0) ctx += `Conditions: ${conditions.join(', ')}\n`;
-    if (diag.note) ctx += `Medical notes: ${diag.note}\n`;
-  }
-
-  // Additional context notes
-  const contextNotes = state.importedData.contextNotes || '';
-  if (contextNotes.trim()) {
-    ctx += `Notes for AI: ${contextNotes.trim()}\n`;
-  }
-
-  // Flagged/non-normal markers (latest values only), respecting AI context toggles
-  const _isAICtx = (catKey) => { const g = data.categories[catKey]?.group; return !g || (window.isGroupInAIContext ? window.isGroupInAIContext(g) : true); };
-  const flags = getAllFlaggedMarkers(data).filter(f => _isAICtx(f.categoryKey));
-  if (flags.length > 0) {
-    ctx += `Flagged (${flags.length} total${flags.length > 15 ? ', showing top 15' : ''}):\n`;
-    for (const f of flags.slice(0, 15)) {
-      ctx += `- ${f.name}: ${f.value} ${f.unit} (${f.status}, ref ${f.effectiveMin}\u2013${f.effectiveMax})\n`;
-    }
-  }
-
-  // Supplements with temporal context (cap at 8 for focus card)
-  const supps = (state.importedData.supplements || []).slice(0, 8);
-  if (supps.length > 0) {
-    ctx += `Supplements:\n`;
-    for (const s of supps) {
-      const pds = (s.periods && s.periods.length > 0) ? [...s.periods].sort((a, b) => a.start.localeCompare(b.start)) : [{ start: s.startDate, end: s.endDate }];
-      const dateRange = pds.length === 1
-        ? `${pds[0].start} \u2192 ${pds[0].end || 'ongoing'}`
-        : pds.map(p => `${p.start}\u2192${p.end || 'now'}`).join(', ');
-      let timing = '';
-      const firstStart = pds[0].start;
-      if (lastDate && firstStart > lastDate) timing = ' (started AFTER last labs — cannot have affected these results)';
-      else if (lastDate && data.dates.length >= 2 && firstStart > data.dates[data.dates.length - 2]) timing = ' (started between last two labs)';
-      // Top impact summary for AI context
-      let impactNote = '';
-      if (!timing && data.dates.length >= 2) {
-        const impacts = window.computeAllImpacts?.(s, data);
-        if (impacts && impacts.length > 0) {
-          const top = impacts.slice(0, 2).filter(im => im.confidence !== 'low');
-          if (top.length > 0) {
-            impactNote = ' — impacts: ' + top.map(im => `${im.markerName} ${im.pctChange > 0 ? '+' : ''}${im.pctChange.toFixed(1)}%`).join(', ');
-          }
-        }
-      }
-      ctx += `- ${s.name}${s.dosage ? ' (' + s.dosage + ')' : ''} [${s.type}]: ${dateRange}${timing}${impactNote}\n`;
-    }
-  }
-
-  // Also include any markers that changed significantly (latest vs previous)
-  const changes = [];
-  for (const [catKey, cat] of Object.entries(data.categories)) {
-    if (!_isAICtx(catKey)) continue;
-    for (const [key, m] of Object.entries(cat.markers)) {
-      const nonNull = m.values.filter(v => v !== null);
-      if (nonNull.length < 2) continue;
-      const prev = nonNull[nonNull.length - 2];
-      const last = nonNull[nonNull.length - 1];
-      if (prev === 0) continue;
-      const pct = Math.abs((last - prev) / prev * 100);
-      if (pct > 20) {
-        const dir = last > prev ? 'up' : 'down';
-        const ref = m.refMin != null && m.refMax != null ? `, ref ${m.refMin}–${m.refMax}` : '';
-        const status = getStatus(last, m.refMin, m.refMax);
-        changes.push(`${m.name}: ${prev} → ${last} ${m.unit || ''} (${dir} ${pct.toFixed(0)}%${ref}, ${status})`);
-      }
-    }
-  }
-  if (changes.length > 0) {
-    ctx += `Notable changes:\n${changes.slice(0, 5).map(c => '- ' + c).join('\n')}\n`;
-  }
-
-  return ctx;
-}
-
-export async function loadFocusCard(opts = {}) {
-  const el = document.getElementById('focus-card-body');
-  if (!el) return;
-  const refreshStale = opts.refreshStale !== false;
-  const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
-  const cached = (() => { try { return JSON.parse(localStorage.getItem(cacheKey)); } catch(e) { return null; } })();
-  const fp = getFocusCardFingerprint();
-  if (cached && cached.text) {
-    el.innerHTML = `<span class="focus-card-text">${applyInlineMarkdown(cached.text)}</span>`;
-    // Hand-authored prefill (demo profiles only) ships without a
-    // fingerprint — never auto-refresh. The manual ↻ button still
-    // works because refreshFocusCard clears the cache entirely.
-    // Real users always have a fingerprint set by loadFocusCard's
-    // own write path below, so this branch never matches them.
-    if (!cached.fingerprint) return;
-    if (cached.fingerprint === fp || !hasAIProvider()) return;
-    if (!refreshStale) return;
-  }
-  if (!hasAIProvider()) {
-    if (!cached?.text) el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">Enable AI to generate insights</span>`;
-    return;
-  }
-  el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">🔍 Looking into your results\u2026</span>`;
-  try {
-    let ctx = buildFocusContext();
-    if (!ctx) {
-      el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">No insight available</span>`;
-      return;
-    }
-    if (hasLens()) {
-      const data = getActiveData();
-      const goals = (state.importedData.healthGoals || []).map(g => g.text).slice(0, 3).join('; ');
-      const flags = getAllFlaggedMarkers(data).slice(0, 5).map(f => f.name).join(', ');
-      const hint = [goals && 'Goals: ' + goals, flags && 'Flagged: ' + flags].filter(Boolean).join(' | ') || 'prioritize and summarize lab findings';
-      const lensResult = await queryLens(hint);
-      if (lensResult) ctx = injectLensChunks(ctx, lensResult);
-    }
-    const focusSystem = `You summarize blood work for a health dashboard card. Write 3-5 sentences, no more. Rules:
-- Start with the single most critical finding and why it matters for this person's goals/conditions
-- Then mention 1-2 secondary findings worth watching
-- End with one concrete next step (retest, lifestyle change, discuss with provider)
-- Connect findings to each other when relevant (e.g. liver markers + hormones)
-- Only flag values genuinely outside reference range
-- Never recommend specific supplements or products
-- Only reference data provided below — never infer or assume
-- Never attribute changes to supplements started after the last lab date
-- CRITICAL: Output ONLY the insight text. No thinking, no reasoning, no "Let me analyze", no numbered analysis steps, no preamble. Start directly with your finding.`;
-
-    // Typewriter: trickle streamed text for smooth appearance
-    const textEl = document.createElement('span');
-    textEl.className = 'focus-card-text';
-    let target = '', displayed = 0, timer = null;
-    function tick() {
-      if (displayed >= target.length) { timer = null; return; }
-      const batch = Math.max(1, Math.ceil((target.length - displayed) * 0.3));
-      displayed = Math.min(displayed + batch, target.length);
-      textEl.textContent = target.slice(0, displayed);
-      timer = setTimeout(tick, 16);
-    }
-
-    const { text: fullText, usage } = await callClaudeAPI({
-      system: focusSystem,
-      messages: [{ role: 'user', content: ctx }],
-      maxTokens: 500,
-      onStream(text) {
-        if (text.length < target.length) displayed = 0; // reset typewriter if stream cleared reasoning
-        target = text;
-        if (!textEl.parentNode) { el.innerHTML = ''; el.appendChild(textEl); }
-        if (!timer) tick();
-      }
-    });
-    if (timer) { clearTimeout(timer); timer = null; }
-
-    if (usage) {
-      trackUsage(getAIProvider(), getActiveModelId(), usage.inputTokens || 0, usage.outputTokens || 0);
-    }
-    let trimmed = (fullText || '')
-      .replace(/<think>[\s\S]*?<\/think>/g, '')
-      .trim();
-    // Strip thinking-out-loud preamble — remove lines starting with reasoning patterns
-    const lines = trimmed.split('\n');
-    const thinkingPattern = /^(Let me |I need to |I should |I'll |Key findings|The user |Looking at the|Now |First,|So |OK |Alright|\d+\.\s+\w+:)/i;
-    let startIdx = 0;
-    while (startIdx < lines.length && (thinkingPattern.test(lines[startIdx].trim()) || lines[startIdx].trim() === '')) startIdx++;
-    if (startIdx > 0 && startIdx < lines.length) trimmed = lines.slice(startIdx).join('\n').trim();
-    // Safety cap — truncate at last sentence boundary within 1500 chars
-    if (trimmed.length > 1500) { const cut = trimmed.slice(0, 1500).lastIndexOf('.'); if (cut > 100) trimmed = trimmed.slice(0, cut + 1); }
-    if (trimmed) {
-      localStorage.setItem(cacheKey, JSON.stringify({ fingerprint: fp, text: trimmed }));
-      el.innerHTML = `<span class="focus-card-text">${applyInlineMarkdown(trimmed)}</span>`;
-    } else {
-      el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">No insight available</span>`;
-    }
-  } catch(e) {
-    el.innerHTML = `<span class="focus-card-text" style="color:var(--text-muted)">Could not load insight</span>`;
-  }
-}
-
-export function refreshFocusCard() {
-  const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
-  localStorage.removeItem(cacheKey);
-  loadFocusCard();
 }
 
 // ── Chart Card Recommendation Links ──

--- a/service-worker.js
+++ b/service-worker.js
@@ -47,6 +47,7 @@ const APP_SHELL = [
   '/js/supplements.js',
   '/js/cycle.js',
   '/js/context-cards.js',
+  '/js/focus-card.js',
   '/js/emf.js',
   '/js/image-utils.js',
   '/js/pdf-import.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -32,6 +32,7 @@ console.log('=== Phase 3 A11y Tests ===\n');
 
   // ─── 2. Clickable divs gain role+tabindex ───
   const viewsSrc = read('/js/views.js');
+  const focusCardSrc = read('/js/focus-card.js');
   const markerDetailSrc = read('/js/marker-detail-modal.js');
   const dashboardRenderersSrc = read('/js/dashboard-widget-renderers.js');
   assert('chart-card has role and tabindex',
@@ -51,7 +52,7 @@ console.log('=== Phase 3 A11y Tests ===\n');
   assert('ref-editable span has role+tabindex',
     markerDetailSrc.includes('class="ref-editable" role="button" tabindex="0"'));
   assert('focus-card refresh has aria-label',
-    viewsSrc.includes('class="focus-card-refresh" onclick="refreshFocusCard()" aria-label="Regenerate insight"'));
+    focusCardSrc.includes('class="focus-card-refresh" onclick="refreshFocusCard()" aria-label="Regenerate insight"'));
 
   const cycleSrc = read('/js/cycle.js');
   assert('cycle-prompt is a semantic button',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -62,6 +62,7 @@ assert('Umami blocked on file:// protocol', /location\.protocol\s*!==\s*['"]file
 console.log('3. XSS Prevention');
 
 const viewsSrc = read('js/views.js');
+const focusCardSrc = read('js/focus-card.js');
 const compareCorrelationsSrc = read('js/compare-correlations.js');
 const markerDetailSrc = read('js/marker-detail-modal.js');
 const lightSessionsViewSrc = read('js/light-sessions-view.js');
@@ -130,7 +131,7 @@ const _SAFE_HELPERS = new Set([
   // is the markdown.js sanitized full renderer)
   'escapeHTML', 'renderMarkdown',
 ]);
-const _SWEEP_FILES = ['views.js', 'marker-detail-modal.js', 'dashboard-widget-renderers.js', 'light-conditions-now.js', 'light-sessions-view.js', 'compare-correlations.js', 'mobile-dashboard.js', 'chat.js', 'charts.js'];
+const _SWEEP_FILES = ['views.js', 'focus-card.js', 'marker-detail-modal.js', 'dashboard-widget-renderers.js', 'light-conditions-now.js', 'light-sessions-view.js', 'compare-correlations.js', 'mobile-dashboard.js', 'chat.js', 'charts.js'];
 
 function _sweepInnerHTML(filename, src) {
   const lines = src.split('\n');
@@ -528,7 +529,7 @@ assert('buildLabContext has global staleness daysSince', labCtxSrc.includes('day
 assert('buildLabContext has global staleness months ago', labCtxSrc.includes('months ago'));
 assert('buildLabContext has per-category staleness', labCtxSrc.includes('catDaysSince') && labCtxSrc.includes('catMonthsAgo'));
 assert('Per-category staleness uses warning marker', labCtxSrc.includes('⚠ Last tested'));
-assert('buildFocusContext has last labs date', viewsSrc.includes('last labs'));
+assert('buildFocusContext has last labs date', focusCardSrc.includes('last labs'));
 
 const hccCount = (labCtxSrc.match(/hasCardContent\(/g) || []).length;
 assert('lab-context.js uses hasCardContent for 7 card gates', hccCount >= 7, `found ${hccCount}`);
@@ -557,9 +558,10 @@ assert('Health goals at top of Priority Context', constSrc.indexOf('Health goals
 
 assert('Persona placed after lab data', chatSrc.includes("'\\n\\nCurrent lab data:\\n' + labContext + personalityPrompt"));
 
-assert('buildFocusContext exists in views.js', viewsSrc.includes('function buildFocusContext()'));
-assert('Focus card uses buildFocusContext', viewsSrc.includes('buildFocusContext()'));
-assert('Focus card context-aware system prompt', viewsSrc.includes("this person's goals/conditions"));
+assert('buildFocusContext exists in focus-card.js', focusCardSrc.includes('function buildFocusContext()'));
+assert('views.js imports focus card module', viewsSrc.includes("from './focus-card.js'"));
+assert('Focus card uses buildFocusContext', focusCardSrc.includes('buildFocusContext()'));
+assert('Focus card context-aware system prompt', focusCardSrc.includes("this person's goals/conditions"));
 
 assert('askAIAboutMarker uses marker.refMin/refMax', chatSrc.includes('${marker.refMin}') && chatSrc.includes('${marker.refMax}'));
 assert('askAIAboutMarker has trend direction', chatSrc.includes("Trend: ${dir}"));

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -80,6 +80,7 @@ const pwaAppShellAssets = [
   '/js/dashboard-widgets.js',
   '/js/dashboard-widget-controls.js',
   '/js/dashboard-widget-renderers.js',
+  '/js/focus-card.js',
   '/js/light-conditions-now.js',
   '/js/light-sessions-view.js',
   '/js/compare-correlations.js',

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -281,12 +281,14 @@ assert('main send calls queryLensMulti with user text', /await queryLensMulti\(t
 assert('multi-persona calls queryLensMulti with msgText', /await queryLensMulti\(msgText,/.test(chatSrc));
 assert('openChatPanel calls updateLensIndicator', chatSrc.includes('updateLensIndicator()'));
 
-// ─── 10. Wiring: views.js focus card ───
-console.log('\n10. views.js wiring');
+// ─── 10. Wiring: focus-card.js lens integration ───
+console.log('\n10. focus-card.js wiring');
 const viewsSrc = read('js/views.js');
-assert('views imports hasLens + queryLens', viewsSrc.includes('hasLens') && viewsSrc.includes('queryLens'));
-assert('views imports injectLensChunks', viewsSrc.includes('injectLensChunks'));
-assert('focus card calls hasLens', /if \(hasLens\(\)\) \{[\s\S]{0,800}await queryLens/.test(viewsSrc));
+const focusCardSrc = read('js/focus-card.js');
+assert('views imports focus card module', viewsSrc.includes("from './focus-card.js'"));
+assert('focus-card imports hasLens + queryLens', focusCardSrc.includes('hasLens') && focusCardSrc.includes('queryLens'));
+assert('focus-card imports injectLensChunks', focusCardSrc.includes('injectLensChunks'));
+assert('focus card calls hasLens', /if \(hasLens\(\)\) \{[\s\S]{0,800}await queryLens/.test(focusCardSrc));
 
 // ─── 11. Wiring: lab-context.js helper ───
 console.log('\n11. lab-context.js helper');

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -589,9 +589,9 @@ return (async function() {
       assert('demo JSON ships focusCard.text',
         typeof demo.focusCard?.text === 'string' && demo.focusCard.text.length > 50,
         `got ${typeof demo.focusCard?.text} (${demo.focusCard?.text?.length || 0} chars)`);
-      const viewsSrc = await fetch('/js/views.js').then(r => r.text());
+      const focusCardSrc = await fetch('/js/focus-card.js').then(r => r.text());
       assert('loadFocusCard early-returns when cache has no fingerprint (demo prefill marker)',
-        viewsSrc.includes('if (!cached.fingerprint) return;'),
+        focusCardSrc.includes('if (!cached.fingerprint) return;'),
         'loadFocusCard must skip AI refresh when cached.fingerprint is missing');
       const exportSrcLive = await fetch('/js/export.js').then(r => r.text());
       assert('loadDemoData writes focusCard to localStorage (demo-only by code path)',

--- a/tests/test-supplement-impact.js
+++ b/tests/test-supplement-impact.js
@@ -215,8 +215,8 @@ const { computeSupplementImpact, computeAllImpacts, parseAmount, ingredientDaily
   assert('Falls back without AI', suppSrc.includes('Set up an AI provider'));
 
   // Focus card integration
-  const viewsSrc = read('js/views.js');
-  assert('Focus card uses computeAllImpacts', viewsSrc.includes('computeAllImpacts'));
+  const focusCardSrc = read('js/focus-card.js');
+  assert('Focus card uses computeAllImpacts', focusCardSrc.includes('computeAllImpacts'));
 
   // CSS
   const cssSrc = read('styles.css');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -559,6 +559,9 @@
     const hasViewsJs = sw.includes('/js/views.js');
     assert('Service worker caches js/views.js', hasViewsJs);
 
+    const hasFocusCardJs = sw.includes('/js/focus-card.js');
+    assert('Service worker caches js/focus-card.js', hasFocusCardJs);
+
     const hasMarkerDetailModalJs = sw.includes('/js/marker-detail-modal.js');
     assert('Service worker caches js/marker-detail-modal.js', hasMarkerDetailModalJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.25';
+self.APP_VERSION = '1.8.26';


### PR DESCRIPTION
## Summary
- Extract the Current Focus dashboard/lens card into `js/focus-card.js`
- Keep `views.js` as the composition layer by importing and re-exporting the Focus card helpers
- Add the new module to the service worker app shell and update source-inspection tests
- Bump `APP_VERSION` to `1.8.26` for cache invalidation

## Validation
- `node --check js/focus-card.js`
- `node --check js/views.js`
- `node tests/test-audit.js`
- `node tests/test-a11y-phase3.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-supplement-impact.js`
- `node tests/test-custom-lens.js`
- `./run-tests.sh`