### PR TITLE
[codex] Extract chart card recommendations

### DIFF
--- a/js/chart-card-recs.js
+++ b/js/chart-card-recs.js
@@ -1,0 +1,43 @@
+// chart-card-recs.js - Recommendation badges for marker chart cards
+
+import { showNotification } from './utils.js';
+import { showDetailModal } from './marker-detail-modal.js';
+
+export async function loadChartCardRecs() {
+  if (!window.isProductRecsEnabled || !window.isProductRecsEnabled()) return;
+  if (!window.loadCatalog) return;
+  const catalog = await window.loadCatalog();
+  if (!catalog || !catalog.slots) return;
+
+  const els = document.querySelectorAll('[id^="chart-rec-"]');
+  for (const el of els) {
+    if (el.children.length > 0) continue;
+    const id = el.id.replace('chart-rec-', '');
+    const slotKey = id.replace('_', '.');
+    const slot = catalog.slots[slotKey];
+    if (!slot) continue;
+    const badge = document.createElement('span');
+    badge.className = 'ctx-tips-badge';
+    badge.textContent = 'Tips';
+    badge.title = 'What can help';
+    badge.onclick = e => {
+      e.stopPropagation();
+      showDetailModal(id, { scrollToRec: true });
+    };
+    el.appendChild(badge);
+  }
+
+  for (const grid of document.querySelectorAll('.charts-grid')) {
+    const cards = Array.from(grid.querySelectorAll('.chart-card'));
+    const withRec = cards.filter(c => c.querySelector('.ctx-tips-badge'));
+    const without = cards.filter(c => !c.querySelector('.ctx-tips-badge'));
+    for (const c of [...withRec, ...without]) grid.appendChild(c);
+  }
+
+  const recLinks = document.querySelectorAll('[id^="chart-rec-"] .ctx-tips-badge');
+  const modalOpen = !!document.querySelector('.modal-overlay.show');
+  if (recLinks.length > 0 && !modalOpen && !localStorage.getItem('labcharts-rec-nudge-seen')) {
+    localStorage.setItem('labcharts-rec-nudge-seen', '1');
+    showNotification(`${recLinks.length} marker${recLinks.length > 1 ? 's have' : ' has'} actionable tips \u2014 look for the Tips badge on your chart cards`, 'info');
+  }
+}

--- a/js/chart-card-recs.js
+++ b/js/chart-card-recs.js
@@ -27,6 +27,7 @@ export async function loadChartCardRecs() {
     el.appendChild(badge);
   }
 
+  // Reorder chart cards: those with tips badges first (within each grid)
   for (const grid of document.querySelectorAll('.charts-grid')) {
     const cards = Array.from(grid.querySelectorAll('.chart-card'));
     const withRec = cards.filter(c => c.querySelector('.ctx-tips-badge'));
@@ -34,6 +35,7 @@ export async function loadChartCardRecs() {
     for (const c of [...withRec, ...without]) grid.appendChild(c);
   }
 
+  // One-time nudge (must query after badges are added)
   const recLinks = document.querySelectorAll('[id^="chart-rec-"] .ctx-tips-badge');
   const modalOpen = !!document.querySelector('.modal-overlay.show');
   if (recLinks.length > 0 && !modalOpen && !localStorage.getItem('labcharts-rec-nudge-seen')) {

--- a/js/views.js
+++ b/js/views.js
@@ -17,6 +17,7 @@ import { createDashboardWidgetControls } from './dashboard-widget-controls.js';
 import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js';
 import { renderFocusCard, buildFocusContext, loadFocusCard, refreshFocusCard } from './focus-card.js';
 import { configureOnboardingView, renderOnboardingBanner, renderAIConnectionReminder, dismissAIReminder, openChatProviderQuiz, setOnboardingFocus, completeOnboardingSex, completeOnboardingProfile, dismissOnboarding } from './onboarding-view.js';
+import { loadChartCardRecs } from './chart-card-recs.js';
 import { renderLightConditionsWidgetBody, renderConditionsNow, _refreshConditionsNow, _inspectConditionsNow, _setManualUvi, _clearManualUvi, _formatElapsedShort } from './light-conditions-now.js';
 import { renderUnifiedSessionsList, _openAllSessionsModal } from './light-sessions-view.js';
 import {
@@ -2276,46 +2277,6 @@ function loadCommitHash() {
     .then(r => r.ok ? r.text() : Promise.reject())
     .then(sha => { _cachedCommitHash = sha.slice(0, 7); const e = document.getElementById('app-commit-hash'); if (e) e.innerHTML = `<a href="https://github.com/elkimek/get-based/commit/${_cachedCommitHash}" target="_blank" rel="noopener">${_cachedCommitHash}</a>`; })
     .catch(() => {});
-}
-
-// ── Chart Card Recommendation Links ──
-async function loadChartCardRecs() {
-  if (!window.isProductRecsEnabled || !window.isProductRecsEnabled()) return;
-  if (!window.loadCatalog) return;
-  const catalog = await window.loadCatalog();
-  if (!catalog || !catalog.slots) return;
-
-  const els = document.querySelectorAll('[id^="chart-rec-"]');
-  for (const el of els) {
-    if (el.children.length > 0) continue;
-    const id = el.id.replace('chart-rec-', '');
-    const slotKey = id.replace('_', '.');
-    const slot = catalog.slots[slotKey];
-    if (!slot) continue;
-    const badge = document.createElement('span');
-    badge.className = 'ctx-tips-badge';
-    badge.textContent = 'Tips';
-    badge.title = 'What can help';
-    badge.onclick = e => {
-      e.stopPropagation();
-      showDetailModal(id, { scrollToRec: true });
-    };
-    el.appendChild(badge);
-  }
-  // Reorder chart cards: those with tips badges first (within each grid)
-  for (const grid of document.querySelectorAll('.charts-grid')) {
-    const cards = Array.from(grid.querySelectorAll('.chart-card'));
-    const withRec = cards.filter(c => c.querySelector('.ctx-tips-badge'));
-    const without = cards.filter(c => !c.querySelector('.ctx-tips-badge'));
-    for (const c of [...withRec, ...without]) grid.appendChild(c);
-  }
-  // One-time nudge (must query after badges are added)
-  const recLinks = document.querySelectorAll('[id^="chart-rec-"] .ctx-tips-badge');
-  const modalOpen = !!document.querySelector('.modal-overlay.show');
-  if (recLinks.length > 0 && !modalOpen && !localStorage.getItem('labcharts-rec-nudge-seen')) {
-    localStorage.setItem('labcharts-rec-nudge-seen', '1');
-    showNotification(`${recLinks.length} marker${recLinks.length > 1 ? 's have' : ' has'} actionable tips \u2014 look for the Tips badge on your chart cards`, 'info');
-  }
 }
 
 // ═══════════════════════════════════════════════

--- a/service-worker.js
+++ b/service-worker.js
@@ -65,6 +65,7 @@ const APP_SHELL = [
   '/js/dashboard-widgets.js',
   '/js/dashboard-widget-controls.js',
   '/js/dashboard-widget-renderers.js',
+  '/js/chart-card-recs.js',
   '/js/marker-detail-modal.js',
   '/js/light-conditions-now.js',
   '/js/light-sessions-view.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -80,6 +80,7 @@ const pwaAppShellAssets = [
   '/js/dashboard-widgets.js',
   '/js/dashboard-widget-controls.js',
   '/js/dashboard-widget-renderers.js',
+  '/js/chart-card-recs.js',
   '/js/focus-card.js',
   '/js/onboarding-view.js',
   '/js/light-conditions-now.js',

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -40,6 +40,7 @@ globalThis.fetch = async (url, opts) => {
   const mainSrc = await fetchWithRetry('js/main.js');
   const chatSrc = await fetchWithRetry('js/chat.js');
   const viewsSrc = await fetchWithRetry('js/views.js');
+  const chartCardRecsSrc = await fetchWithRetry('js/chart-card-recs.js');
   const markerDetailSrc = await fetchWithRetry('js/marker-detail-modal.js');
   const dashboardWidgetsSrc = await fetchWithRetry('js/dashboard-widgets.js');
   const contextSrc = await fetchWithRetry('js/context-cards.js');
@@ -199,7 +200,8 @@ globalThis.fetch = async (url, opts) => {
   assert('chat.js has rec-chat-wrapper class', chatSrc.includes('rec-chat-wrapper'));
   assert('views.js has chart-rec placeholder in header', viewsSrc.includes('chart-rec-'));
   assert('views.js keeps chart title text separate from tips host', viewsSrc.includes('chart-card-title-text') && viewsSrc.includes('chart-card-tips-host'));
-  assert('views.js has loadChartCardRecs function', viewsSrc.includes('function loadChartCardRecs'));
+  assert('views.js imports chart card recommendation module', viewsSrc.includes("from './chart-card-recs.js'"));
+  assert('chart-card-recs.js has loadChartCardRecs function', chartCardRecsSrc.includes('function loadChartCardRecs'));
   assert('marker-detail-modal.js scrollToRec auto-opens details', markerDetailSrc.includes('scrollToRec'));
   assert('loadCatalog on window', typeof window.loadCatalog === 'function');
   assert('nav.js exposes recommendations sidebar helper', navSrc.includes('openRecommendationsFromSidebar'));

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -519,6 +519,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   console.log('%c 19. category marker card redesign ', 'font-weight:bold;color:#0891b2');
   {
     const viewsSrc = fetchSrc('js/views.js');
+    const chartCardRecsSrc = fetchSrc('js/chart-card-recs.js');
     const compareCorrelationsSrc = fetchSrc('js/compare-correlations.js');
     const markerDetailSrc = fetchSrc('js/marker-detail-modal.js');
     const dataSrc = fetchSrc('js/data.js');
@@ -538,9 +539,9 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /\.chart-card-snapshot\s*\{/.test(cssSrc)
       && /\.chart-container\s*\{[^\}]*height:\s*150px/.test(cssSrc)
       && /\.chart-values\s*\{[\s\S]{0,140}grid-template-columns:\s*repeat\(4/.test(cssSrc));
-    assert('views.js: tips nudge does not cover open marker modal',
-      /const modalOpen\s*=\s*!!document\.querySelector\('\.modal-overlay\.show'\)/.test(viewsSrc)
-      && /recLinks\.length > 0 && !modalOpen/.test(viewsSrc));
+    assert('chart-card-recs.js: tips nudge does not cover open marker modal',
+      /const modalOpen\s*=\s*!!document\.querySelector\('\.modal-overlay\.show'\)/.test(chartCardRecsSrc)
+      && /recLinks\.length > 0 && !modalOpen/.test(chartCardRecsSrc));
     assert('data.js: range mode switch paints the active pill before heavy rebuild',
       /function _afterNextPaint\(fn\)/.test(dataSrc)
       && /window\.requestAnimationFrame\(\(\) => setTimeout\(fn,\s*0\)\)/.test(dataSrc)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -559,6 +559,9 @@
     const hasViewsJs = sw.includes('/js/views.js');
     assert('Service worker caches js/views.js', hasViewsJs);
 
+    const hasChartCardRecsJs = sw.includes('/js/chart-card-recs.js');
+    assert('Service worker caches js/chart-card-recs.js', hasChartCardRecsJs);
+
     const hasFocusCardJs = sw.includes('/js/focus-card.js');
     assert('Service worker caches js/focus-card.js', hasFocusCardJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.27';
+self.APP_VERSION = '1.8.28';


### PR DESCRIPTION
## Summary
- Extract chart-card recommendation badge hydration into `js/chart-card-recs.js`
- Keep `views.js` as the category-page caller
- Add the new module to the service worker app shell and update source-inspection tests
- Bump `APP_VERSION` to `1.8.28` for cache invalidation

## Validation
- `node --check js/chart-card-recs.js`
- `node --check js/views.js`
- `node tests/test-recommendations.js`
- `node tests/test-v1-6-shipped.js`
- `node tests/test-correctness-phase2.js`
- `./run-tests.sh`