### PR TITLE
[codex] Extract category glyph rendering

### DIFF
--- a/js/category-glyphs.js
+++ b/js/category-glyphs.js
@@ -1,0 +1,42 @@
+// category-glyphs.js - Coded glyph rendering for marker categories
+
+import { escapeHTML } from './utils.js';
+
+const CATEGORY_GLYPH_CODES = Object.freeze({
+  biochemistry: 'BC',
+  hormones: 'HR',
+  electrolytes: 'EM',
+  lipids: 'LP',
+  iron: 'FE',
+  proteins: 'IN',
+  thyroid: 'TH',
+  vitamins: 'VT',
+  diabetes: 'GL',
+  tumorMarkers: 'TM',
+  coagulation: 'CG',
+  hematology: 'CB',
+  wbcDifferential: 'WB',
+  bone: 'BN',
+  urinalysis: 'UR',
+  bodyComposition: 'BD',
+  boneDensity: 'DX',
+  calculatedRatios: 'RT',
+});
+
+export function getCategoryGlyphCode(categoryKey, label = '') {
+  if (CATEGORY_GLYPH_CODES[categoryKey]) return CATEGORY_GLYPH_CODES[categoryKey];
+  const words = String(label || categoryKey || '')
+    .replace(/&/g, ' ')
+    .replace(/[^A-Za-z0-9 ]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
+  const compact = String(label || categoryKey || 'M').replace(/[^A-Za-z0-9]+/g, '');
+  return (compact.slice(0, 2) || 'M').toUpperCase();
+}
+
+export function renderCategoryGlyph(categoryKey, label, { large = false } = {}) {
+  const code = getCategoryGlyphCode(categoryKey, label);
+  return `<span class="category-glyph${large ? ' category-glyph-large' : ''}" aria-hidden="true">${escapeHTML(code)}</span>`;
+}

--- a/js/views.js
+++ b/js/views.js
@@ -18,6 +18,7 @@ import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js'
 import { renderFocusCard, buildFocusContext, loadFocusCard, refreshFocusCard } from './focus-card.js';
 import { configureOnboardingView, renderOnboardingBanner, renderAIConnectionReminder, dismissAIReminder, openChatProviderQuiz, setOnboardingFocus, completeOnboardingSex, completeOnboardingProfile, dismissOnboarding } from './onboarding-view.js';
 import { loadChartCardRecs } from './chart-card-recs.js';
+import { renderCategoryGlyph } from './category-glyphs.js';
 import { renderLightConditionsWidgetBody, renderConditionsNow, _refreshConditionsNow, _inspectConditionsNow, _setManualUvi, _clearManualUvi, _formatElapsedShort } from './light-conditions-now.js';
 import { renderUnifiedSessionsList, _openAllSessionsModal } from './light-sessions-view.js';
 import {
@@ -2282,45 +2283,6 @@ function loadCommitHash() {
 // ═══════════════════════════════════════════════
 // CATEGORY VIEWS
 // ═══════════════════════════════════════════════
-
-const CATEGORY_GLYPH_CODES = Object.freeze({
-  biochemistry: 'BC',
-  hormones: 'HR',
-  electrolytes: 'EM',
-  lipids: 'LP',
-  iron: 'FE',
-  proteins: 'IN',
-  thyroid: 'TH',
-  vitamins: 'VT',
-  diabetes: 'GL',
-  tumorMarkers: 'TM',
-  coagulation: 'CG',
-  hematology: 'CB',
-  wbcDifferential: 'WB',
-  bone: 'BN',
-  urinalysis: 'UR',
-  bodyComposition: 'BD',
-  boneDensity: 'DX',
-  calculatedRatios: 'RT',
-});
-
-function _categoryGlyphCode(categoryKey, label = '') {
-  if (CATEGORY_GLYPH_CODES[categoryKey]) return CATEGORY_GLYPH_CODES[categoryKey];
-  const words = String(label || categoryKey || '')
-    .replace(/&/g, ' ')
-    .replace(/[^A-Za-z0-9 ]+/g, ' ')
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
-  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
-  const compact = String(label || categoryKey || 'M').replace(/[^A-Za-z0-9]+/g, '');
-  return (compact.slice(0, 2) || 'M').toUpperCase();
-}
-
-function renderCategoryGlyph(categoryKey, label, { large = false } = {}) {
-  const code = _categoryGlyphCode(categoryKey, label);
-  return `<span class="category-glyph${large ? ' category-glyph-large' : ''}" aria-hidden="true">${escapeHTML(code)}</span>`;
-}
 
 export function showCategory(categoryKey, preData) {
   // categoryKey is interpolated into inline-onclick handlers below (rename,

--- a/service-worker.js
+++ b/service-worker.js
@@ -66,6 +66,7 @@ const APP_SHELL = [
   '/js/dashboard-widget-controls.js',
   '/js/dashboard-widget-renderers.js',
   '/js/chart-card-recs.js',
+  '/js/category-glyphs.js',
   '/js/marker-detail-modal.js',
   '/js/light-conditions-now.js',
   '/js/light-sessions-view.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -81,6 +81,7 @@ const pwaAppShellAssets = [
   '/js/dashboard-widget-controls.js',
   '/js/dashboard-widget-renderers.js',
   '/js/chart-card-recs.js',
+  '/js/category-glyphs.js',
   '/js/focus-card.js',
   '/js/onboarding-view.js',
   '/js/light-conditions-now.js',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -520,6 +520,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   {
     const viewsSrc = fetchSrc('js/views.js');
     const chartCardRecsSrc = fetchSrc('js/chart-card-recs.js');
+    const categoryGlyphsSrc = fetchSrc('js/category-glyphs.js');
     const compareCorrelationsSrc = fetchSrc('js/compare-correlations.js');
     const markerDetailSrc = fetchSrc('js/marker-detail-modal.js');
     const dataSrc = fetchSrc('js/data.js');
@@ -560,8 +561,11 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       && /legacyWeightStamp/.test(dataSrc)
       && /saveImportedData\(\)[\s\S]{0,120}invalidateActiveDataCache\(\)/.test(dataSrc)
       && /switchRangeMode\(mode\)[\s\S]{0,220}invalidateActiveDataCache\(\)/.test(dataSrc));
-    assert('views.js: marker category surfaces use coded glyphs instead of emoji icons',
-      /function renderCategoryGlyph\(categoryKey,\s*label/.test(viewsSrc)
+    assert('category-glyphs.js: marker category surfaces use coded glyphs instead of emoji icons',
+      /export function renderCategoryGlyph\(categoryKey,\s*label/.test(categoryGlyphsSrc)
+      && /getCategoryGlyphCode\(categoryKey,\s*label\)/.test(categoryGlyphsSrc)
+      && /CATEGORY_GLYPH_CODES/.test(categoryGlyphsSrc)
+      && viewsSrc.includes("from './category-glyphs.js'")
       && /renderCategoryGlyph\(categoryKey,\s*cat\.label\)/.test(viewsSrc)
       && /empty-state-icon-category/.test(viewsSrc)
       && /compare-category-label/.test(compareCorrelationsSrc)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -562,6 +562,9 @@
     const hasChartCardRecsJs = sw.includes('/js/chart-card-recs.js');
     assert('Service worker caches js/chart-card-recs.js', hasChartCardRecsJs);
 
+    const hasCategoryGlyphsJs = sw.includes('/js/category-glyphs.js');
+    assert('Service worker caches js/category-glyphs.js', hasCategoryGlyphsJs);
+
     const hasFocusCardJs = sw.includes('/js/focus-card.js');
     assert('Service worker caches js/focus-card.js', hasFocusCardJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.28';
+self.APP_VERSION = '1.8.29';


### PR DESCRIPTION
## Summary
- Extract category glyph code and rendering from `views.js` into `js/category-glyphs.js`
- Keep category pages and compare/correlation rendering wired through the shared glyph renderer
- Add the new module to the service worker app shell and source-inspection tests
- Bump `APP_VERSION` to `1.8.29` for cache invalidation

## Validation
- `node --check js/category-glyphs.js`
- `node --check js/views.js`
- `node tests/test-v1-6-shipped.js`
- `node tests/test-correctness-phase2.js`
- `./run-tests.sh`