### PR TITLE
[codex] Preserve local chat during sync pulls

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -1808,7 +1808,7 @@ export async function sendChatMessage() {
   input.style.height = '';
   clearAttachments();
   renderChatMessages();
-  saveChatHistory(); // persist immediately so messages survive API failures
+  await saveChatHistory(); // persist immediately so messages survive API failures
 
   if (isFirstMessage) {
     autoNameThread(state.currentThreadId, text);
@@ -1978,6 +1978,8 @@ export async function sendChatMessage() {
       } catch {}
     })();
 
+    await saveChatHistory(); // persist before any sync-triggered chat reload can repaint older storage
+
     // Append action bar
     const msgIndex = state.chatHistory.length - 1;
     const actionBarHtml = buildActionBar(msgIndex);
@@ -2017,7 +2019,6 @@ export async function sendChatMessage() {
     }
 
     container.scrollTop = container.scrollHeight;
-    saveChatHistory();
   } catch (err) {
     if (typingEl.parentNode) typingEl.remove();
 
@@ -2031,7 +2032,7 @@ export async function sendChatMessage() {
         aiMsgEl.innerHTML = renderMarkdown(partialText) + '<div class="chat-stopped-note">[stopped]</div>';
         const personality = getActivePersonality();
         state.chatHistory.push({ role: 'assistant', content: partialText, personalityName: personality.name, personalityIcon: personality.icon, stopped: true });
-        saveChatHistory();
+        await saveChatHistory();
       }
     } else if (!err?._modalShown) {
       // Skip inline error rendering when a modal already surfaced the
@@ -2196,7 +2197,7 @@ async function runDiscussionRound(personas, steerPrompt, opts = {}) {
       const autoMsg = { role: 'user', content: msgText, auto: true, hidden: !!opts.hideAutoMsg };
       state.chatHistory.push(autoMsg);
       renderChatMessages();
-      saveChatHistory();
+      await saveChatHistory();
 
       const typingEl = document.createElement('div');
       typingEl.className = 'typing-indicator';
@@ -2296,7 +2297,7 @@ async function runDiscussionRound(personas, steerPrompt, opts = {}) {
         trackUsage(_dMsgProvider, _dMsgModelId, usage.inputTokens, usage.outputTokens);
       }
       state.chatHistory.push(assistantMsg);
-      saveChatHistory();
+      await saveChatHistory();
       container.scrollTop = container.scrollHeight;
     }
   } catch (err) {

--- a/js/sync.js
+++ b/js/sync.js
@@ -902,6 +902,8 @@ const AI_SETTINGS_KEYS = [
 const OPENROUTER_OAUTH_LOCAL_SETTINGS_LOCK_UNTIL_KEY = 'or_oauth_local_settings_lock_until';
 const OPENROUTER_OAUTH_LOCAL_SETTING_KEYS = new Set(['labcharts-ai-provider', 'labcharts-openrouter-key']);
 const AI_SETTINGS_LOCAL_LOCK_UNTIL_KEY = 'labcharts-ai-settings-local-lock-until';
+const CHAT_LOCAL_LOCK_UNTIL_KEY = 'labcharts-chat-local-lock-until';
+const CHAT_LOCAL_LOCK_MS = 5 * 60 * 1000;
 
 function hasLocalAISettingsLock() {
   try {
@@ -925,6 +927,22 @@ function shouldKeepLocalOpenRouterOAuthSetting(key) {
 function shouldKeepLocalAISetting(key) {
   return shouldKeepLocalOpenRouterOAuthSetting(key)
     || (AI_SETTINGS_KEYS.includes(key) && hasLocalAISettingsLock());
+}
+
+function markChatDataLocal() {
+  try {
+    sessionStorage.setItem(CHAT_LOCAL_LOCK_UNTIL_KEY, String(Date.now() + CHAT_LOCAL_LOCK_MS));
+  } catch {}
+}
+
+function shouldKeepLocalChatData(profileId) {
+  if (profileId !== state.currentProfile) return false;
+  try {
+    const until = Number(sessionStorage.getItem(CHAT_LOCAL_LOCK_UNTIL_KEY) || '0');
+    return Number.isFinite(until) && Date.now() < until;
+  } catch {
+    return false;
+  }
 }
 
 async function collectAISettings() {
@@ -991,7 +1009,12 @@ async function collectChatData(profileId) {
 }
 
 async function applyChatData(profileId, chatData) {
-  if (!chatData || !chatData.threads) return;
+  if (!chatData || !chatData.threads) return false;
+  if (shouldKeepLocalChatData(profileId)) {
+    dbg(`Skipped chatData for ${profileId.slice(0,8)} — local chat has newer unsynced changes`);
+    _logSyncEvent('skip', `Chat pull skipped ${profileId.slice(0,8)} — local changes pending`);
+    return false;
+  }
   // Thread index: always plain localStorage (matches saveChatThreadIndex in chat.js).
   // encryptAllSensitiveKeys handles at-rest encryption when session ends.
   const threadsKey = `labcharts-${profileId}-chat-threads`;
@@ -1013,6 +1036,7 @@ async function applyChatData(profileId, chatData) {
   if (chatData.activePersonality) {
     localStorage.setItem(`labcharts-${profileId}-chatPersonality`, chatData.activePersonality);
   }
+  return true;
 }
 
 // Per-profile display preferences to sync
@@ -3556,7 +3580,7 @@ async function onSyncReceived() {
         }
 
         // Apply chat data and display preferences
-        if (chatData) await applyChatData(profileId, chatData);
+        const chatApplied = chatData ? await applyChatData(profileId, chatData) : false;
         if (displayPrefs) applyDisplayPrefs(profileId, displayPrefs);
 
         // If this is the active profile, update in-memory state
@@ -3564,7 +3588,7 @@ async function onSyncReceived() {
           state.importedData = merged;
           migrateProfileData(state.importedData);
           // Reload chat threads + active thread messages into memory and re-render
-          if (chatData) {
+          if (chatApplied) {
             window.loadChatThreads?.();
             window.renderThreadList?.();
             window.loadChatHistory?.(); // reloads state.chatHistory from localStorage + renders
@@ -3710,6 +3734,7 @@ export function onDataSaved() {
 // changes. Mirrors the same pattern as onDataSaved's _debounceTimers.
 const _chatSyncTimers = new Map();
 export function onChatSaved() {
+  markChatDataLocal();
   if (!_syncEnabled || !evolu) return;
   // Capture the active profile + data at QUEUE time so a mid-window
   // profile switch doesn't repoint the push.

--- a/js/sync.js
+++ b/js/sync.js
@@ -903,7 +903,7 @@ const OPENROUTER_OAUTH_LOCAL_SETTINGS_LOCK_UNTIL_KEY = 'or_oauth_local_settings_
 const OPENROUTER_OAUTH_LOCAL_SETTING_KEYS = new Set(['labcharts-ai-provider', 'labcharts-openrouter-key']);
 const AI_SETTINGS_LOCAL_LOCK_UNTIL_KEY = 'labcharts-ai-settings-local-lock-until';
 const CHAT_LOCAL_LOCK_UNTIL_KEY = 'labcharts-chat-local-lock-until';
-const CHAT_LOCAL_LOCK_MS = 5 * 60 * 1000;
+const CHAT_LOCAL_LOCK_MS = 90 * 1000;
 
 function hasLocalAISettingsLock() {
   try {

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -172,6 +172,9 @@ assert('chat.js does NOT have readAloud', !chatSrc.includes('function readAloud'
 assert('chat.js has copyMessage', chatSrc.includes('function copyMessage'), 'found');
 assert('sendChatMessage snapshots context', chatSrc.includes('contextSnapshot'), 'found');
 assert('sendChatMessage snapshots provider for API call', chatSrc.includes('const _msgProvider = getAIProvider()') && chatSrc.includes('provider: _msgProvider'), 'found');
+assert('sendChatMessage awaits chat saves before repaint-sensitive work',
+  chatSrc.includes('await saveChatHistory(); // persist immediately so messages survive API failures')
+    && chatSrc.includes('await saveChatHistory(); // persist before any sync-triggered chat reload can repaint older storage'), 'found');
 assert('chat raises response token headroom', chatContinuationSrc.includes('CHAT_RESPONSE_MAX_TOKENS = 16384'), 'found');
 assert('chat auto-continues token-limit stops', chatContinuationSrc.includes('CHAT_AUTO_CONTINUE_LIMIT') && chatContinuationSrc.includes('callChatAPIWithContinuation'), 'found');
 assert('chat continuation uses provider snapshot', chatContinuationSrc.includes('provider })') && chatContinuationSrc.includes('}, provider)'), 'found');

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -173,8 +173,7 @@ assert('chat.js has copyMessage', chatSrc.includes('function copyMessage'), 'fou
 assert('sendChatMessage snapshots context', chatSrc.includes('contextSnapshot'), 'found');
 assert('sendChatMessage snapshots provider for API call', chatSrc.includes('const _msgProvider = getAIProvider()') && chatSrc.includes('provider: _msgProvider'), 'found');
 assert('sendChatMessage awaits chat saves before repaint-sensitive work',
-  chatSrc.includes('await saveChatHistory(); // persist immediately so messages survive API failures')
-    && chatSrc.includes('await saveChatHistory(); // persist before any sync-triggered chat reload can repaint older storage'), 'found');
+  (chatSrc.match(/await saveChatHistory\(\)/g) || []).length >= 2, 'found');
 assert('chat raises response token headroom', chatContinuationSrc.includes('CHAT_RESPONSE_MAX_TOKENS = 16384'), 'found');
 assert('chat auto-continues token-limit stops', chatContinuationSrc.includes('CHAT_AUTO_CONTINUE_LIMIT') && chatContinuationSrc.includes('callChatAPIWithContinuation'), 'found');
 assert('chat continuation uses provider snapshot', chatContinuationSrc.includes('provider })') && chatContinuationSrc.includes('}, provider)'), 'found');

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -472,6 +472,8 @@ await import('../js/settings.js');
   assert('applyChatData writes threads', syncSrc.includes('applyChatData'));
   assert('applyChatData skips stale remote chat while local save is fresh',
     syncSrc.includes('CHAT_LOCAL_LOCK_UNTIL_KEY') && syncSrc.includes('shouldKeepLocalChatData(profileId)'));
+  assert('chat freshness lock is shorter than two minutes',
+    syncSrc.includes('const CHAT_LOCAL_LOCK_MS = 90 * 1000'));
   assert('active chat reload only runs after chatData is applied',
     syncSrc.includes('const chatApplied = chatData ? await applyChatData(profileId, chatData) : false')
       && syncSrc.includes('if (chatApplied)'));

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -470,6 +470,15 @@ await import('../js/settings.js');
   assert('collectChatData reads per-thread messages', syncSrc.includes('chat-t_${t.id}'));
   assert('collectChatData includes custom personalities', syncSrc.includes('chatPersonalityCustom'));
   assert('applyChatData writes threads', syncSrc.includes('applyChatData'));
+  assert('applyChatData skips stale remote chat while local save is fresh',
+    syncSrc.includes('CHAT_LOCAL_LOCK_UNTIL_KEY') && syncSrc.includes('shouldKeepLocalChatData(profileId)'));
+  assert('active chat reload only runs after chatData is applied',
+    syncSrc.includes('const chatApplied = chatData ? await applyChatData(profileId, chatData) : false')
+      && syncSrc.includes('if (chatApplied)'));
+  const onChatSavedSrc = syncSrc.slice(syncSrc.indexOf('export function onChatSaved'), syncSrc.indexOf('export function onChatSaved') + 600);
+  assert('onChatSaved marks local chat before debounce',
+    onChatSavedSrc.includes('markChatDataLocal();')
+      && onChatSavedSrc.indexOf('markChatDataLocal();') < onChatSavedSrc.indexOf('if (!_syncEnabled || !evolu) return;'));
   assert('Display prefs synced', syncSrc.includes('DISPLAY_PREF_SUFFIXES') && syncSrc.includes('collectDisplayPrefs'));
   assert('onChatSaved exported', syncSrc.includes('export function onChatSaved'));
   assert('onChatSaved has debounce', syncSrc.includes('_chatSyncTimer') && syncSrc.includes('10000'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.77';
+self.APP_VERSION = '1.8.78';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.76';
+self.APP_VERSION = '1.8.77';


### PR DESCRIPTION
## Summary
- Await critical chat history saves before repaint-sensitive work.
- Add a short local chat freshness lock so stale active-profile sync pulls do not overwrite a just-saved local assistant response.
- Bump the app version for cache invalidation.

## Root Cause
Moving a browser tab/window between displays can trigger a visibility-driven sync pull. If that pull received stale remote `chatData` before the debounced local chat push landed, the active thread reloaded from older storage and the latest assistant response disappeared.

## Validation
- `node --check js/chat.js`
- `node --check js/sync.js`
- `node tests/test-chat-actions.js`
- `node tests/test-sync.js`
- `node tests/test-chat-threads.js`
- `git diff --check origin/main...HEAD`

Note: `./run-tests.sh` also passed earlier on the same patch before splitting this clean follow-up branch from `main`.