### PR TITLE
Extract discussion picker selection helper

### DIFF
--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -621,9 +621,9 @@ Live discussion round DOM helpers. Owns typing indicators, persona labels, strea
 
 ### `chat-discussion-ui.js`
 
-Multi-persona discussion DOM controls. Owns the Discuss button visibility/add-persona state, continuation prompt, persona picker markup, picker checkbox limiting, and transient state handoff used by `continueDiscussion()` and `endDiscussion()`.
+Multi-persona discussion DOM controls. Owns the Discuss button visibility/add-persona state, continuation prompt, persona picker markup, picker checkbox limiting, picker selection reads, and transient state handoff used by `continueDiscussion()` and `endDiscussion()`.
 
-**Key exports:** `updateDiscussButton`, `showDiscussContinuePrompt`, `removeDiscussContinuePrompt`, `removeDiscussPersonaPicker`, `showDiscussPersonaPicker`
+**Key exports:** `updateDiscussButton`, `showDiscussContinuePrompt`, `removeDiscussContinuePrompt`, `removeDiscussPersonaPicker`, `readDiscussPersonaPickerSelection`, `showDiscussPersonaPicker`
 
 **Window exports:** none directly; `chat-discussion.js` wraps/re-exports public controls and `chat-window-bindings.js` assigns the compatibility handlers.
 

--- a/js/chat-discussion-ui.js
+++ b/js/chat-discussion-ui.js
@@ -55,6 +55,29 @@ export function removeDiscussPersonaPicker() {
   if (picker) picker.remove();
 }
 
+export function readDiscussPersonaPickerSelection() {
+  const picker = document.querySelector('.discuss-persona-picker');
+  if (!picker) return null;
+
+  const lockedInputs = picker.querySelectorAll('input[data-locked="1"]');
+  const checkedInputs = picker.querySelectorAll('input:checked:not([data-locked="1"])');
+  const allSelected = [...lockedInputs, ...checkedInputs];
+  if (lockedInputs.length > 0) {
+    if (checkedInputs.length !== 1) return null;
+  } else if (allSelected.length !== 2) {
+    return null;
+  }
+
+  const lockedIds = new Set(Array.from(lockedInputs).map(cb => cb.value));
+  const allPersonas = allSelected.map(cb => ({
+    id: cb.value,
+    name: cb.dataset.name,
+    icon: cb.dataset.icon
+  }));
+  const newPersonas = allPersonas.filter(p => !lockedIds.has(p.id));
+  return { allPersonas, newPersonas };
+}
+
 export function showDiscussPersonaPicker() {
   const allPersonas = [
     ...CHAT_PERSONALITIES.map(p => ({ id: p.id, name: p.name, icon: p.icon })),

--- a/js/chat-discussion.js
+++ b/js/chat-discussion.js
@@ -17,7 +17,7 @@ import {
   setChatAbortController, setSendButtonMode,
 } from './chat-discussion-callbacks.js';
 import {
-  removeDiscussContinuePrompt, removeDiscussPersonaPicker,
+  readDiscussPersonaPickerSelection, removeDiscussContinuePrompt, removeDiscussPersonaPicker,
   showDiscussContinuePrompt as showDiscussContinuePromptUI,
   showDiscussPersonaPicker, updateDiscussButton,
 } from './chat-discussion-ui.js';
@@ -244,30 +244,13 @@ export async function startDiscussion() {
 }
 
 export async function startDiscussionFromPicker() {
-  const picker = document.querySelector('.discuss-persona-picker');
-  if (!picker) return;
-  // Collect locked (already in thread) and newly checked personas
-  const lockedInputs = picker.querySelectorAll('input[data-locked="1"]');
-  const checkedInputs = picker.querySelectorAll('input:checked:not([data-locked="1"])');
-  const allSelected = [...lockedInputs, ...checkedInputs];
-  if (lockedInputs.length > 0) {
-    if (checkedInputs.length !== 1) return;
-  } else if (allSelected.length !== 2) {
-    return;
-  }
-
-  const lockedIds = new Set(Array.from(lockedInputs).map(cb => cb.value));
-  const allPersonas = allSelected.map(cb => ({
-    id: cb.value,
-    name: cb.dataset.name,
-    icon: cb.dataset.icon
-  }));
-  // Only the NEW persona (not locked) responds — they're joining the conversation
-  const newPersonas = allPersonas.filter(p => !lockedIds.has(p.id));
-  picker.remove();
+  const selection = readDiscussPersonaPickerSelection();
+  if (!selection) return;
+  const { allPersonas, newPersonas } = selection;
+  removeDiscussPersonaPicker();
 
   if (newPersonas.length > 0) {
-    // Adding a second persona — only they respond (one turn)
+    // Adding a new persona — only they respond (one turn)
     return _runSingleTurn(newPersonas[0], allPersonas);
   }
   // Shouldn't happen, but fallback

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -43,6 +43,7 @@ const {
   buildDiscussionAutoMessage, buildDiscussionJoinMessage, getDiscussionPromptText,
   hasExistingDiscussionResponses,
 } = await import('../js/chat-discussion-round-prompts.js');
+const { readDiscussPersonaPickerSelection } = await import('../js/chat-discussion-ui.js');
 
 const S = window._labState;
 const hasState = S && typeof S === 'object';
@@ -87,6 +88,55 @@ if (hasState) {
   document.getElementById = origGetElementById;
 } else {
   console.warn('Skipping Discuss button UI tests — _labState not available');
+}
+
+// ─── Section 1b: Discuss Picker Selection ───
+console.log('Section 1b: Discuss picker selection');
+{
+  const origQuerySelector = document.querySelector;
+  const makeInput = (id, name = id, icon = id[0].toUpperCase()) => ({
+    value: id,
+    dataset: { name, icon },
+  });
+  const withPicker = (locked, checked, fn) => {
+    const picker = {
+      querySelectorAll(selector) {
+        if (selector === 'input[data-locked="1"]') return locked;
+        if (selector === 'input:checked:not([data-locked="1"])') return checked;
+        return [];
+      },
+    };
+    document.querySelector = (selector) => (selector === '.discuss-persona-picker' ? picker : origQuerySelector.call(document, selector));
+    return fn();
+  };
+
+  assert('Picker selection returns null when no picker exists',
+    readDiscussPersonaPickerSelection() === null,
+    'no picker');
+  assert('Picker selection requires two new personas for a fresh debate',
+    withPicker([], [makeInput('a', 'Analyst A')], () => readDiscussPersonaPickerSelection() === null),
+    'one fresh selection');
+  assert('Picker selection reads two fresh debate personas',
+    withPicker([], [makeInput('a', 'Analyst A'), makeInput('b', 'Analyst B')], () => {
+      const selection = readDiscussPersonaPickerSelection();
+      return selection?.allPersonas.length === 2 &&
+        selection?.newPersonas.length === 2 &&
+        selection.allPersonas[0].name === 'Analyst A';
+    }),
+    'two fresh selections');
+  assert('Picker selection requires one new persona for an active debate',
+    withPicker([makeInput('a'), makeInput('b')], [], () => readDiscussPersonaPickerSelection() === null),
+    'locked without new selection');
+  assert('Picker selection reads one added persona for an active debate',
+    withPicker([makeInput('a'), makeInput('b')], [makeInput('c', 'Analyst C')], () => {
+      const selection = readDiscussPersonaPickerSelection();
+      return selection?.allPersonas.length === 3 &&
+        selection?.newPersonas.length === 1 &&
+        selection.newPersonas[0].id === 'c';
+    }),
+    'one added persona');
+
+  document.querySelector = origQuerySelector;
 }
 
 // ─── Section 2: getContextSummary() ───
@@ -353,10 +403,13 @@ assert('chat-discussion-state.js owns persona state helpers',
 assert('chat-discussion-ui.js owns discussion DOM controls',
   chatDiscussionSrc.includes("from './chat-discussion-ui.js'") &&
     chatDiscussionUiSrc.includes('export function updateDiscussButton') &&
+    chatDiscussionUiSrc.includes('export function readDiscussPersonaPickerSelection') &&
     chatDiscussionUiSrc.includes('export function showDiscussContinuePrompt') &&
     chatDiscussionUiSrc.includes('export function showDiscussPersonaPicker') &&
     chatDiscussionUiSrc.includes('const addingToExisting = activePersonaIds.size > 0') &&
     chatDiscussionUiSrc.includes('checkedCount !== maxNewSelections') &&
+    chatDiscussionSrc.includes('readDiscussPersonaPickerSelection()') &&
+    !chatDiscussionSrc.includes("querySelector('.discuss-persona-picker')") &&
     !chatDiscussionSrc.includes('export function updateDiscussButton'),
   'found');
 assert('Discuss button does not duplicate inline Continue',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.105';
+self.APP_VERSION = '1.8.106';


### PR DESCRIPTION
## Summary
- Move discussion persona picker DOM parsing and validation into `chat-discussion-ui.js`
- Keep `chat-discussion.js` focused on orchestrating the selected personas
- Add focused coverage for fresh debate selection and active-debate add-persona selection
- Update module docs and bump `version.js` for cache invalidation

## Tests
- `git diff --check`
- `node --check js/chat-discussion.js`
- `node --check js/chat-discussion-ui.js`
- `node tests/test-chat-actions.js`
- `node tests/test-custom-personality.js`
- `node tests/test-correctness-phase2.js`
- `./run-tests.sh`