### PR TITLE
[codex] Extract discussion thread lifecycle helpers

### DIFF
--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -629,9 +629,9 @@ Multi-persona discussion DOM controls. Owns the Discuss button visibility/add-pe
 
 ### `chat-discussion-state.js`
 
-Multi-persona discussion state helpers. Owns per-thread active discussion detection, history fallback persona collection, current-thread lookup, and unique assistant-persona counts.
+Multi-persona discussion state helpers. Owns per-thread active discussion detection, history fallback persona collection, current-thread lookup, unique assistant-persona counts, and current-thread discussion lifecycle metadata.
 
-**Key exports:** `getThreadPersonaCount`, `collectDiscussionPersonas`, `getCurrentThread`, `getCurrentDiscussionState`
+**Key exports:** `getThreadPersonaCount`, `collectDiscussionPersonas`, `getCurrentThread`, `clearCurrentDiscussionThreadState`, `reopenCurrentDiscussionThread`, `getCurrentDiscussionState`
 
 **Window exports:** none directly; `chat-discussion.js` re-exports the public count/state helpers and `chat-window-bindings.js` assigns them.
 

--- a/js/chat-discussion-state.js
+++ b/js/chat-discussion-state.js
@@ -3,6 +3,7 @@
 import { state } from './state.js';
 import { CHAT_PERSONALITIES } from './constants.js';
 import { getCustomPersonalities } from './chat-personalities.js';
+import { saveChatThreadIndex } from './chat-threads.js';
 
 export function getThreadPersonaCount() {
   const names = new Set();
@@ -40,6 +41,25 @@ export function collectDiscussionPersonas() {
 
 export function getCurrentThread() {
   return state.chatThreads.find(t => t.id === state.currentThreadId) || null;
+}
+
+export function clearCurrentDiscussionThreadState({ clearThread = false, markEnded = false } = {}) {
+  const thread = getCurrentThread();
+  if (!thread || (!clearThread && !markEnded)) return;
+
+  delete thread.discussionPersonas;
+  delete thread.discussionOriginalPersonality;
+  if (markEnded) thread.discussionEnded = true;
+  else delete thread.discussionEnded;
+  saveChatThreadIndex();
+}
+
+export function reopenCurrentDiscussionThread() {
+  const thread = getCurrentThread();
+  if (!thread?.discussionEnded) return thread;
+  delete thread.discussionEnded;
+  saveChatThreadIndex();
+  return thread;
 }
 
 export function getCurrentDiscussionState({ allowHistoryFallback = true } = {}) {

--- a/js/chat-discussion.js
+++ b/js/chat-discussion.js
@@ -1,7 +1,6 @@
 // chat-discussion.js — Multi-persona discussion/debate orchestration
 
 import { state } from './state.js';
-import { saveChatThreadIndex } from './chat-threads.js';
 import {
   updateChatHeaderTitle,
 } from './chat-personalities.js';
@@ -10,7 +9,8 @@ import {
   isAIResponseTruncated,
 } from './chat-continuation.js';
 import {
-  getCurrentDiscussionState, getCurrentThread,
+  clearCurrentDiscussionThreadState, getCurrentDiscussionState, getCurrentThread,
+  reopenCurrentDiscussionThread,
 } from './chat-discussion-state.js';
 import {
   createDiscussionTypewriter, getChatAbortController, renderChatMessages,
@@ -195,14 +195,7 @@ export function cleanupDiscussionState({ clearThread = false, markEnded = false 
   // Only clear persisted discussion state when the user explicitly ends it.
   // Thread switches and new-thread creation should remove transient UI state
   // without erasing the old thread's Continue prompt metadata.
-  const thread = getCurrentThread();
-  if (thread && (clearThread || markEnded)) {
-    delete thread.discussionPersonas;
-    delete thread.discussionOriginalPersonality;
-    if (markEnded) thread.discussionEnded = true;
-    else delete thread.discussionEnded;
-    saveChatThreadIndex();
-  }
+  clearCurrentDiscussionThreadState({ clearThread, markEnded });
 }
 
 export async function continueDiscussion() {
@@ -234,11 +227,7 @@ export function endDiscussion() {
 export async function startDiscussion() {
   if (getChatAbortController()) return; // already streaming
 
-  const thread = getCurrentThread();
-  if (thread?.discussionEnded) {
-    delete thread.discussionEnded;
-    saveChatThreadIndex();
-  }
+  reopenCurrentDiscussionThread();
 
   showDiscussPersonaPicker();
 }

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -39,6 +39,9 @@ const {
   attachLensSources, buildMultiPersonaInstruction, buildTaggedChatMessages, buildWebSearchHint,
 } = await import('../js/chat-prompt-context.js');
 const {
+  clearCurrentDiscussionThreadState, reopenCurrentDiscussionThread,
+} = await import('../js/chat-discussion-state.js');
+const {
   DEFAULT_DISCUSS_PROMPT, DISCUSSION_JOIN_PROMPT, INITIAL_DISCUSS_PROMPT,
   buildDiscussionAutoMessage, buildDiscussionJoinMessage, getDiscussionPromptText,
   hasExistingDiscussionResponses,
@@ -137,6 +140,57 @@ console.log('Section 1b: Discuss picker selection');
     'one added persona');
 
   document.querySelector = origQuerySelector;
+}
+
+// ─── Section 1c: Discussion Thread Lifecycle State ───
+console.log('Section 1c: Discussion thread lifecycle state');
+if (hasState) {
+  const origThreads = S.chatThreads;
+  const origThreadId = S.currentThreadId;
+  const threadIndexKey = `labcharts-${S.currentProfile}-chat-threads`;
+  const origThreadIndex = localStorage.getItem(threadIndexKey);
+
+  const thread = {
+    id: 'test-discussion-thread',
+    discussionPersonas: [{ id: 'a' }, { id: 'b' }],
+    discussionOriginalPersonality: 'default',
+  };
+  S.chatThreads = [thread];
+  S.currentThreadId = thread.id;
+
+  clearCurrentDiscussionThreadState();
+  assert('Discussion thread lifecycle no-ops without explicit clear/end',
+    Array.isArray(thread.discussionPersonas) && thread.discussionOriginalPersonality === 'default',
+    'keeps metadata');
+
+  clearCurrentDiscussionThreadState({ markEnded: true });
+  assert('Discussion thread lifecycle marks ended and clears metadata',
+    thread.discussionEnded === true &&
+      !('discussionPersonas' in thread) &&
+      !('discussionOriginalPersonality' in thread),
+    'ended');
+
+  reopenCurrentDiscussionThread();
+  assert('Discussion thread lifecycle reopens ended thread',
+    !('discussionEnded' in thread),
+    'reopened');
+
+  thread.discussionPersonas = [{ id: 'a' }, { id: 'b' }];
+  thread.discussionOriginalPersonality = 'default';
+  thread.discussionEnded = true;
+  clearCurrentDiscussionThreadState({ clearThread: true });
+  assert('Discussion thread lifecycle clears without marking ended',
+    !('discussionEnded' in thread) &&
+      !('discussionPersonas' in thread) &&
+      !('discussionOriginalPersonality' in thread),
+    'cleared');
+
+  S.chatThreads = origThreads;
+  S.currentThreadId = origThreadId;
+  if (origThreadIndex === null) localStorage.removeItem(threadIndexKey);
+  else localStorage.setItem(threadIndexKey, origThreadIndex);
+} else {
+  console.warn('Skipping discussion lifecycle state tests — _labState not available');
 }
 
 // ─── Section 2: getContextSummary() ───
@@ -398,7 +452,12 @@ assert('chat-discussion-round-prompts.js owns round prompt helpers',
 assert('chat-discussion-state.js owns persona state helpers',
   chatDiscussionSrc.includes("from './chat-discussion-state.js'") &&
     chatDiscussionStateSrc.includes('export function getCurrentDiscussionState') &&
-    chatDiscussionStateSrc.includes('export function collectDiscussionPersonas'),
+    chatDiscussionStateSrc.includes('export function collectDiscussionPersonas') &&
+    chatDiscussionStateSrc.includes('export function clearCurrentDiscussionThreadState') &&
+    chatDiscussionStateSrc.includes('export function reopenCurrentDiscussionThread') &&
+    chatDiscussionSrc.includes('clearCurrentDiscussionThreadState({ clearThread, markEnded })') &&
+    chatDiscussionSrc.includes('reopenCurrentDiscussionThread()') &&
+    !chatDiscussionSrc.includes('saveChatThreadIndex'),
   'found');
 assert('chat-discussion-ui.js owns discussion DOM controls',
   chatDiscussionSrc.includes("from './chat-discussion-ui.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.106';
+self.APP_VERSION = '1.8.107';


### PR DESCRIPTION
## Summary
- Move discussion thread lifecycle metadata updates into `chat-discussion-state.js`
- Keep `chat-discussion.js` focused on orchestration by calling the state helpers
- Add focused lifecycle coverage and update module docs
- Bump `version.js` for app cache invalidation

## Validation
- `node --check js/chat-discussion.js`
- `node --check js/chat-discussion-state.js`
- `git diff --check`
- `node tests/test-chat-actions.js`
- `node tests/test-custom-personality.js`
- `node tests/test-correctness-phase2.js`
- `./run-tests.sh`