### PR TITLE
Make import collection-date editable in Review & Edit Import

### DIFF
--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -708,7 +708,7 @@ export function showImportPreview(parseResult) {
       </div>
       <div class="import-review-file">
         <span class="import-review-label">Collection date</span>
-        <strong>${escapeHTML(dateFormatted)}</strong>
+        <input type="date" id="import-manual-date" value="${escapeHTML(date || '')}" onchange="applyManualImportDate(this.value)" aria-label="Collection date">
       </div>
       <div class="import-review-stats" aria-label="Import mapping summary">
         <span class="import-review-stat import-review-stat-matched"><strong>${matched.length}</strong> matched</span>
@@ -725,8 +725,7 @@ export function showImportPreview(parseResult) {
   }
   if (!date) {
     html += `<div class="import-review-warning import-review-date-warning">
-      Could not extract collection date from PDF. Please enter it manually:
-      <input type="date" id="import-manual-date" onchange="applyManualImportDate(this.value)" aria-label="Manual collection date"></div>`;
+      Could not extract collection date from PDF. Please set it above before importing.</div>`;
   }
   // Build reference lookup (used for unmatched dropdown + range comparison)
   const refLookup = buildMarkerReference();


### PR DESCRIPTION
## Summary
- The Review & Edit Import modal renders the AI-extracted collection date as a static `<strong>`, only exposing an editable `<input type="date">` when no date was detected.
- If the AI extracts the *wrong* date — common for image (JPEG/PNG) imports where dates can be ambiguous or appear in multiple places — there is currently no way to correct it before clicking Import.
- This promotes the date row to an always-editable `<input type="date">`, pre-filled with the extracted value. The "could not extract" warning still renders when the AI returned nothing, but no longer carries a duplicate `<input id="import-manual-date">` (which would have collided in the DOM had both rendered together).

## Test plan
- [ ] Import a PDF where AI extracts the collection date correctly → date prefilled, editable, confirming uses the prefilled value.
- [ ] Import a PDF/JPEG where AI extracts the wrong collection date → edit the input → Import → entry lands under the corrected date.
- [ ] Import a PDF where AI returns no date → input renders empty, warning banner asks user to set it, Import button stays disabled until a date is set.
- [ ] No DOM id collision on `#import-manual-date`.