### PR TITLE
Fix chat sync stale thread clobber

### DIFF
--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -24,6 +24,7 @@ import { state } from './state.js';
 import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import { onChatSaved } from './sync.js';
+import { chatDeletedThreadsKey } from './sync-payload.js';
 import { CHAT_PERSONALITIES } from './constants.js';
 import {
   configureChatThreadSearch, filterThreadList,
@@ -35,6 +36,7 @@ export { filterThreadList, invalidateThreadContentCache, jumpToSearchResult };
 const MAX_THREADS = 50;
 const THREAD_ICON_EDIT = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
 const THREAD_ICON_DELETE = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>';
+const CHAT_DELETED_PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 export function getChatThreadsKey() {
   return `labcharts-${state.currentProfile}-chat-threads`;
@@ -42,6 +44,25 @@ export function getChatThreadsKey() {
 
 export function getChatThreadKey(threadId) {
   return `labcharts-${state.currentProfile}-chat-t_${threadId}`;
+}
+
+function recordDeletedChatThread(threadId, deletedAt = Date.now()) {
+  if (!state.currentProfile || !threadId) return;
+  if (CHAT_DELETED_PROTO_KEYS.has(threadId)) return;
+  try {
+    const key = chatDeletedThreadsKey(state.currentProfile);
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : {};
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+    const deleted = Object.create(null);
+    for (const [id, ts] of Object.entries(parsed)) {
+      if (CHAT_DELETED_PROTO_KEYS.has(id)) continue;
+      const n = Number(ts);
+      if (typeof id === 'string' && id && Number.isFinite(n) && n > 0) deleted[id] = n;
+    }
+    deleted[threadId] = Math.max(Number(deleted[threadId]) || 0, deletedAt);
+    localStorage.setItem(key, JSON.stringify(deleted));
+  } catch {}
 }
 
 function generateThreadId() {
@@ -160,6 +181,7 @@ export async function switchToThread(threadId) {
 export async function deleteThread(threadId) {
   if (await showConfirmDialog('Delete this conversation? This cannot be undone.')) {
     invalidateThreadContentCache();
+    recordDeletedChatThread(threadId);
     // Remove from index
     state.chatThreads = state.chatThreads.filter(t => t.id !== threadId);
     saveChatThreadIndex();
@@ -226,6 +248,7 @@ export function pruneOldThreads() {
   const sorted = state.chatThreads.slice().sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   const toRemove = sorted.slice(MAX_THREADS);
   for (const t of toRemove) {
+    recordDeletedChatThread(t.id);
     localStorage.removeItem(getChatThreadKey(t.id));
   }
   state.chatThreads = sorted.slice(0, MAX_THREADS);

--- a/js/sync-actions.js
+++ b/js/sync-actions.js
@@ -219,11 +219,7 @@ export function onDataSaved() {
       if (prev) clearTimeout(prev);
       const timer = setTimeout(() => {
         _debounceTimers.delete(profileId);
-        if (_isSyncing()) {
-          setTimeout(() => { _pushProfile(profileId, data).catch(() => {}); }, 1000);
-        } else {
-          _pushProfile(profileId, data).catch(() => {});
-        }
+        scheduleProfilePush(profileId, data);
       }, 10_000);
       _debounceTimers.set(profileId, timer);
     }
@@ -241,11 +237,7 @@ export function onChatSaved() {
   if (prev) clearTimeout(prev);
   const timer = setTimeout(() => {
     _chatSyncTimers.delete(profileId);
-    if (_isSyncing()) {
-      setTimeout(() => { _pushProfile(profileId, data).catch(() => {}); }, 1000);
-    } else {
-      _pushProfile(profileId, data).catch(() => {});
-    }
+    scheduleProfilePush(profileId, data);
   }, 10000);
   _chatSyncTimers.set(profileId, timer);
 }

--- a/js/sync-apply.js
+++ b/js/sync-apply.js
@@ -3,7 +3,7 @@
 import { state } from './state.js';
 import { isDebugMode } from './utils.js';
 import { getEncryptionEnabled, encryptedSetItem, encryptedGetItem, encryptedRemoveItem } from './crypto.js';
-import { AI_SETTINGS_KEYS, DISPLAY_PREF_SUFFIXES } from './sync-payload.js';
+import { AI_SETTINGS_KEYS, DISPLAY_PREF_SUFFIXES, chatDeletedThreadsKey } from './sync-payload.js';
 import { logSyncEvent } from './sync-state.js';
 
 function dbg(...args) { if (isDebugMode()) console.log('[sync]', ...args); }
@@ -13,6 +13,8 @@ const OPENROUTER_OAUTH_LOCAL_SETTING_KEYS = new Set(['labcharts-ai-provider', 'l
 const AI_SETTINGS_LOCAL_LOCK_UNTIL_KEY = 'labcharts-ai-settings-local-lock-until';
 const CHAT_LOCAL_LOCK_UNTIL_KEY = 'labcharts-chat-local-lock-until';
 const CHAT_LOCAL_LOCK_MS = 90 * 1000;
+const CHAT_DELETED_THREADS_MAX = 200;
+const CHAT_DELETED_PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function hasLocalAISettingsLock() {
   try {
@@ -62,6 +64,55 @@ function shouldKeepLocalChatData(profileId) {
   return getChatDataLocalLockRemainingMs(profileId) > 0;
 }
 
+function threadUpdatedAtMs(thread) {
+  if (!thread || typeof thread !== 'object') return 0;
+  const value = thread.updatedAt || thread.createdAt || '';
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+function normalizeDeletedThreads(value) {
+  const out = Object.create(null);
+  if (!value) return out;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const id = typeof item === 'string' ? item : item?.id;
+      const deletedAt = typeof item === 'string' ? Date.now() : item?.deletedAt;
+      const ts = Number(deletedAt);
+      if (CHAT_DELETED_PROTO_KEYS.has(id)) continue;
+      if (typeof id === 'string' && id && Number.isFinite(ts) && ts > 0) out[id] = ts;
+    }
+    return out;
+  }
+  if (typeof value !== 'object') return out;
+  for (const [id, deletedAt] of Object.entries(value)) {
+    const ts = Number(deletedAt);
+    if (CHAT_DELETED_PROTO_KEYS.has(id)) continue;
+    if (typeof id === 'string' && id && Number.isFinite(ts) && ts > 0) out[id] = ts;
+  }
+  return out;
+}
+
+function readLocalDeletedThreads(profileId) {
+  try {
+    const raw = localStorage.getItem(chatDeletedThreadsKey(profileId));
+    return normalizeDeletedThreads(raw ? JSON.parse(raw) : null);
+  } catch {
+    return {};
+  }
+}
+
+function writeLocalDeletedThreads(profileId, deletedThreads) {
+  try {
+    const entries = Object.entries(normalizeDeletedThreads(deletedThreads))
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, CHAT_DELETED_THREADS_MAX);
+    const key = chatDeletedThreadsKey(profileId);
+    if (entries.length === 0) localStorage.removeItem(key);
+    else localStorage.setItem(key, JSON.stringify(Object.fromEntries(entries)));
+  } catch {}
+}
+
 const ENCRYPTED_AI_KEYS = ['labcharts-openrouter-key', 'labcharts-venice-key', 'labcharts-routstr-key', 'labcharts-ppq-key', 'labcharts-ollama', 'labcharts-cashu-wallet-mnemonic', 'labcharts-lens-key', 'labcharts-custom-key'];
 
 export async function applyAISettings(settings) {
@@ -97,22 +148,58 @@ export async function applyChatData(profileId, chatData) {
   // encryptAllSensitiveKeys handles at-rest encryption when session ends.
   const threadsKey = `labcharts-${profileId}-chat-threads`;
   const existingRaw = await encryptedGetItem(threadsKey) || localStorage.getItem(threadsKey);
-  const incomingThreadIds = new Set(chatData.threads.map(t => t?.id).filter(id => typeof id === 'string'));
+  let existingThreads = [];
   if (existingRaw) {
-    try {
-      const existingThreads = JSON.parse(existingRaw);
-      if (Array.isArray(existingThreads)) {
-        for (const t of existingThreads) {
-          if (typeof t?.id === 'string' && !incomingThreadIds.has(t.id)) {
-            await encryptedRemoveItem(`labcharts-${profileId}-chat-t_${t.id}`);
-          }
-        }
-      }
-    } catch {}
+    try { existingThreads = JSON.parse(existingRaw); }
+    catch { existingThreads = []; }
   }
-  localStorage.setItem(threadsKey, JSON.stringify(chatData.threads));
+  if (!Array.isArray(existingThreads)) existingThreads = [];
+
+  const deletedThreads = readLocalDeletedThreads(profileId);
+  for (const [id, deletedAt] of Object.entries(normalizeDeletedThreads(chatData.deletedThreads))) {
+    deletedThreads[id] = Math.max(Number(deletedThreads[id]) || 0, deletedAt);
+  }
+
+  const mergedById = new Map();
+  const existingById = new Map();
+  for (const thread of existingThreads) {
+    if (!thread || typeof thread.id !== 'string') continue;
+    existingById.set(thread.id, thread);
+    if ((Number(deletedThreads[thread.id]) || 0) >= threadUpdatedAtMs(thread)) continue;
+    mergedById.set(thread.id, thread);
+  }
+  for (const thread of chatData.threads) {
+    if (!thread || typeof thread.id !== 'string') continue;
+    if ((Number(deletedThreads[thread.id]) || 0) >= threadUpdatedAtMs(thread)) continue;
+    const prev = mergedById.get(thread.id);
+    const incomingTs = threadUpdatedAtMs(thread);
+    const prevTs = threadUpdatedAtMs(prev);
+    if (!prev || incomingTs > prevTs || (incomingTs === prevTs && (Number(thread.messageCount) || 0) > (Number(prev.messageCount) || 0))) {
+      mergedById.set(thread.id, thread);
+    }
+  }
+
+  const mergedThreads = Array.from(mergedById.values())
+    .sort((a, b) => (threadUpdatedAtMs(b) - threadUpdatedAtMs(a)) || String(a.id).localeCompare(String(b.id)));
+  localStorage.setItem(threadsKey, JSON.stringify(mergedThreads));
+
+  for (const thread of existingThreads) {
+    if (!thread || typeof thread.id !== 'string') continue;
+    if ((Number(deletedThreads[thread.id]) || 0) >= threadUpdatedAtMs(thread)) {
+      await encryptedRemoveItem(`labcharts-${profileId}-chat-t_${thread.id}`);
+    }
+  }
   if (chatData.messages) {
     for (const [threadId, msgs] of Object.entries(chatData.messages)) {
+      const incomingThread = chatData.threads.find(t => t?.id === threadId);
+      if (!incomingThread || !mergedById.has(threadId)) continue;
+      const existingThread = existingById.get(threadId);
+      const incomingTs = threadUpdatedAtMs(incomingThread);
+      const existingTs = threadUpdatedAtMs(existingThread);
+      const incomingCount = Number(incomingThread.messageCount) || 0;
+      const existingCount = Number(existingThread?.messageCount) || 0;
+      if (existingThread && incomingTs < existingTs) continue;
+      if (existingThread && incomingTs === existingTs && incomingCount < existingCount) continue;
       const msgKey = `labcharts-${profileId}-chat-t_${threadId}`;
       const msgJson = JSON.stringify(msgs);
       if (getEncryptionEnabled()) {
@@ -122,6 +209,7 @@ export async function applyChatData(profileId, chatData) {
       }
     }
   }
+  writeLocalDeletedThreads(profileId, deletedThreads);
   if (chatData.customPersonalities) {
     localStorage.setItem(`labcharts-${profileId}-chatPersonalityCustom`, JSON.stringify(chatData.customPersonalities));
   }

--- a/js/sync-delta.js
+++ b/js/sync-delta.js
@@ -483,7 +483,31 @@ export async function _planKeyedMapDelta(profileId, mapName, mapObj) {
   const matching = allItemRows.filter(r => r.profileId === profileId && r.arrayName === mapName);
   const rowByItemId = new Map(matching.map(r => [r.itemId, r]));
 
-  const obj = (mapObj && typeof mapObj === 'object' && !Array.isArray(mapObj)) ? mapObj : {};
+  let obj = (mapObj && typeof mapObj === 'object' && !Array.isArray(mapObj)) ? mapObj : {};
+  if (mapName === 'genetics.snps' && Object.keys(obj).length === 0 && mapObj == null) {
+    // The blob/scalar paths intentionally strip genetics.snps; per-row
+    // itemRows are the source of truth. If local importedData was hydrated
+    // from a metadata-only genetics blob before the per-row overlay ran,
+    // don't interpret the absent map as "delete every SNP" on the next
+    // unrelated save. Rebuild the planning input from live rows instead.
+    const fromRows = Object.create(null);
+    for (const row of matching) {
+      if (!row || row.isDeleted) continue;
+      try {
+        let json = row.payload;
+        if (typeof json === 'string' && json.startsWith('GZ|v1|')) {
+          if (typeof DecompressionStream === 'undefined') continue;
+          json = await _gunzipToStringCapped(_base64ToBytes(json.slice(6)));
+        }
+        const parsed = JSON.parse(json);
+        if (!parsed || typeof parsed !== 'object' || typeof parsed.k !== 'string') continue;
+        if (keyIdFn(parsed.k) !== row.itemId) continue;
+        if (_PROTO_POLLUTION_KEYS.has(parsed.k)) continue;
+        fromRows[parsed.k] = parsed.v;
+      } catch {}
+    }
+    if (Object.keys(fromRows).length > 0) obj = fromRows;
+  }
   for (const [rawKey, value] of Object.entries(obj)) {
     const itemId = keyIdFn(rawKey);
     // Defence-in-depth: even if cfg.keyIdFn returns a string that passes

--- a/js/sync-delta.js
+++ b/js/sync-delta.js
@@ -484,12 +484,13 @@ export async function _planKeyedMapDelta(profileId, mapName, mapObj) {
   const rowByItemId = new Map(matching.map(r => [r.itemId, r]));
 
   let obj = (mapObj && typeof mapObj === 'object' && !Array.isArray(mapObj)) ? mapObj : {};
-  if (mapName === 'genetics.snps' && Object.keys(obj).length === 0 && mapObj == null) {
+  if (mapName === 'genetics.snps' && Object.keys(obj).length === 0) {
     // The blob/scalar paths intentionally strip genetics.snps; per-row
     // itemRows are the source of truth. If local importedData was hydrated
-    // from a metadata-only genetics blob before the per-row overlay ran,
-    // don't interpret the absent map as "delete every SNP" on the next
-    // unrelated save. Rebuild the planning input from live rows instead.
+    // from a metadata-only genetics blob, or from an empty placeholder
+    // object, before the per-row overlay ran, don't interpret that as
+    // "delete every SNP" on the next unrelated save. Rebuild the
+    // planning input from live rows instead.
     const fromRows = Object.create(null);
     for (const row of matching) {
       if (!row || row.isDeleted) continue;
@@ -507,6 +508,9 @@ export async function _planKeyedMapDelta(profileId, mapName, mapObj) {
       } catch {}
     }
     if (Object.keys(fromRows).length > 0) obj = fromRows;
+    else if (Object.keys(prev).length > 0) {
+      return { ops, next: prev, plannedAt };
+    }
   }
   for (const [rawKey, value] of Object.entries(obj)) {
     const itemId = keyIdFn(rawKey);

--- a/js/sync-payload.js
+++ b/js/sync-payload.js
@@ -33,6 +33,31 @@ export const AI_SETTINGS_KEYS = [
 
 export const DISPLAY_PREF_SUFFIXES = ['units', 'rangeMode', 'suppOverlay', 'noteOverlay', 'phaseOverlay'];
 
+export function chatDeletedThreadsKey(profileId) {
+  return `labcharts-${profileId}-chat-deleted-threads`;
+}
+
+const CHAT_DELETED_PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function readChatDeletedThreads(profileId) {
+  try {
+    const raw = localStorage.getItem(chatDeletedThreadsKey(profileId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out = Object.create(null);
+    for (const [threadId, deletedAt] of Object.entries(parsed)) {
+      if (typeof threadId !== 'string' || !threadId) continue;
+      if (CHAT_DELETED_PROTO_KEYS.has(threadId)) continue;
+      const ts = Number(deletedAt);
+      if (Number.isFinite(ts) && ts > 0) out[threadId] = ts;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 export async function collectAISettings() {
   const settings = {};
   for (const key of AI_SETTINGS_KEYS) {
@@ -45,11 +70,21 @@ export async function collectAISettings() {
 // Per-profile chat keys to sync
 export async function collectChatData(profileId) {
   const threadsKey = `labcharts-${profileId}-chat-threads`;
+  const deletedThreads = readChatDeletedThreads(profileId);
   const threadsRaw = await encryptedGetItem(threadsKey) || localStorage.getItem(threadsKey);
-  if (!threadsRaw) return null;
+  if (!threadsRaw) {
+    return Object.keys(deletedThreads).length > 0
+      ? { threads: [], messages: {}, deletedThreads }
+      : null;
+  }
   try {
     const threads = JSON.parse(threadsRaw);
-    if (!Array.isArray(threads) || threads.length === 0) return null;
+    if (!Array.isArray(threads)) {
+      return Object.keys(deletedThreads).length > 0
+        ? { threads: [], messages: {}, deletedThreads }
+        : null;
+    }
+    if (threads.length === 0 && Object.keys(deletedThreads).length === 0) return null;
     const messages = {};
     for (const t of threads) {
       const msgKey = `labcharts-${profileId}-chat-t_${t.id}`;
@@ -67,6 +102,7 @@ export async function collectChatData(profileId) {
     return {
       threads,
       messages,
+      deletedThreads: Object.keys(deletedThreads).length > 0 ? deletedThreads : undefined,
       customPersonalities: customRaw ? JSON.parse(customRaw) : undefined,
       activePersonality: personality || undefined,
     };

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -243,7 +243,7 @@ return (async function () {
     assert('sync-payload.js loaded', src.length > 1000);
     // Find the inner loop that reads per-thread message JSON.
     const collectIdx = src.indexOf('async function collectChatData');
-    const block = src.slice(collectIdx, collectIdx + 1200);
+    const block = src.slice(collectIdx, collectIdx + 2200);
     assert('collectChatData function present', collectIdx !== -1);
     assert('per-thread parse wrapped in try/catch (skip-bad-msg pattern)',
       /try\s*\{\s*messages\[t\.id\]\s*=\s*JSON\.parse\(msgRaw\);?\s*\}\s*catch/.test(block));
@@ -257,16 +257,25 @@ return (async function () {
   console.log('%c 6. debounce pushProfile .catch() ', 'font-weight:bold;color:#0891b2');
   {
     const src = await fetchSrc('js/sync-actions.js');
-    // Both onDataSaved + onChatSaved have a (sync? defer : immediate) split.
-    // Each branch must terminate the chain with .catch.
+    // onDataSaved + onChatSaved route through scheduleProfilePush. The
+    // helper owns the retry loop and must still terminate the async push
+    // chain with .catch so rejected pushes do not leak as unhandled
+    // promise rejections.
+    const helper = src.slice(src.indexOf('function scheduleProfilePush'),
+                              src.indexOf('export function onProfileSaved'));
     const onSaved = src.slice(src.indexOf('export function onDataSaved'),
                               src.indexOf('export function onChatSaved'));
     const onChat = src.slice(src.indexOf('export function onChatSaved'),
                               src.indexOf('export function onChatSaved') + 1500);
-    assert('onDataSaved deferred push has .catch', /_pushProfile\(profileId, data\)\.catch/.test(onSaved));
-    assert('onDataSaved immediate push has .catch', (onSaved.match(/\.catch\(\(\)\s*=>\s*\{\}\)/g) || []).length >= 2);
-    assert('onChatSaved deferred push has .catch', /_pushProfile\(profileId, data\)\.catch/.test(onChat));
-    assert('onChatSaved immediate push has .catch', (onChat.match(/\.catch\(\(\)\s*=>\s*\{\}\)/g) || []).length >= 2);
+    assert('scheduleProfilePush retries while sync is busy',
+      /!_isEvoluReady\(\)\s*\|\|\s*_isSyncing\(\)/.test(helper)
+        && /attempt\s*<\s*60/.test(helper));
+    assert('scheduleProfilePush catches rejected push',
+      /_pushProfile\(profileId,\s*data\)\.catch\(\(\)\s*=>\s*\{\}\)/.test(helper));
+    assert('onDataSaved routes through scheduleProfilePush',
+      /scheduleProfilePush\(profileId,\s*data\)/.test(onSaved));
+    assert('onChatSaved routes through scheduleProfilePush',
+      /scheduleProfilePush\(profileId,\s*data\)/.test(onChat));
   }
 
   // ─── 7. _syncDiag — console output gated by isDebugMode() ──────────

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -29,6 +29,7 @@ console.log('=== Cross-Device Sync Tests ===\n');
 // populate window.enableSync, window.toggleSync, etc.
 const { state } = await import('../js/state.js');
 const syncApply = await import('../js/sync-apply.js');
+const syncDelta = await import('../js/sync-delta.js');
 await import('../js/sync.js');
 await import('../js/settings.js');
 
@@ -1047,7 +1048,7 @@ await import('../js/settings.js');
   assert('DELTA_MAP_CONFIG defines manualValues keyIdFn (doubling-escape)',
     /DELTA_MAP_CONFIG\s*=\s*\{[\s\S]{0,1500}manualValues:[\s\S]{0,500}rawKey\.replace\(\/_\/g,\s*'__'\)\.replace\(\/:\/g,\s*'_'\)/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta uses cfg.keyIdFn when present',
-    /_planKeyedMapDelta[\s\S]{0,2000}DELTA_MAP_CONFIG\[mapName\][\s\S]{0,1500}keyIdFn\(rawKey\)/.test(deltaSearchSrc));
+    /_planKeyedMapDelta[\s\S]{0,3500}DELTA_MAP_CONFIG\[mapName\][\s\S]{0,3500}keyIdFn\(rawKey\)/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta payload preserves the ORIGINAL raw key (not the synth)',
     /payloadObj\s*=\s*\{\s*k:\s*rawKey,\s*v:\s*value\s*\}/.test(deltaSearchSrc));
   assert('Map-shape pull verifies via keyIdFn(parsed.k) === row.itemId',
@@ -1082,9 +1083,9 @@ await import('../js/settings.js');
   assert('_planKeyedMapDelta defined',
     /async function _planKeyedMapDelta\(profileId,\s*mapName,\s*mapObj\)/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta validates key allowlist (no weird itemIds)',
-    /_planKeyedMapDelta[\s\S]{0,1500}!_isAllowlistSafeId\(itemId\)/.test(deltaSearchSrc));
+    /_planKeyedMapDelta[\s\S]{0,3500}!_isAllowlistSafeId\(itemId\)/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta wraps payload as {k, v} for itemId verification on pull',
-    /_planKeyedMapDelta[\s\S]{0,2200}payloadObj\s*=\s*\{\s*k:\s*rawKey,\s*v:\s*value\s*\}/.test(deltaSearchSrc));
+    /_planKeyedMapDelta[\s\S]{0,4200}payloadObj\s*=\s*\{\s*k:\s*rawKey,\s*v:\s*value\s*\}/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta emits tombstones when keys are removed',
     /_planKeyedMapDelta[\s\S]{0,3500}kind:\s*'tombstone'/.test(deltaSearchSrc));
   assert('pushProfile loops DELTA_MAPS after DELTA_ARRAYS',
@@ -1414,7 +1415,7 @@ await import('../js/settings.js');
   assert('_planArrayDelta uses _isAllowlistSafeId (not bare regex)',
     /_planArrayDelta[\s\S]{0,1500}_isAllowlistSafeId\(id\)/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta uses _isAllowlistSafeId on derived itemId',
-    /_planKeyedMapDelta[\s\S]{0,1500}!_isAllowlistSafeId\(itemId\)/.test(deltaSearchSrc));
+    /_planKeyedMapDelta[\s\S]{0,3500}!_isAllowlistSafeId\(itemId\)/.test(deltaSearchSrc));
   assert('Map-shape pull wraps keyIdFn with _isAllowlistSafeId guard',
     /rawKeyIdFn[\s\S]{0,200}keyIdFn\s*=\s*\(k\)\s*=>[\s\S]{0,200}_isAllowlistSafeId\(id\)/.test(deltaSearchSrc));
   assert('Array-shape pull wraps itemIdFn with _isAllowlistSafeId guard',
@@ -1426,7 +1427,7 @@ await import('../js/settings.js');
   assert('_planArrayDelta resurrects tombstoned row by clearing isDeleted',
     /_planArrayDelta[\s\S]{0,2500}existing\?\.isDeleted\s*\?\s*\{\s*isDeleted:\s*null\s*\}\s*:\s*\{\}/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta resurrects tombstoned row by clearing isDeleted',
-    /_planKeyedMapDelta[\s\S]{0,2700}existing\?\.isDeleted\s*\?\s*\{\s*isDeleted:\s*null\s*\}\s*:\s*\{\}/.test(deltaSearchSrc));
+    /_planKeyedMapDelta[\s\S]{0,4700}existing\?\.isDeleted\s*\?\s*\{\s*isDeleted:\s*null\s*\}\s*:\s*\{\}/.test(deltaSearchSrc));
   assert('_planScalarDelta resurrects tombstoned row by clearing isDeleted',
     /_planScalarDelta[\s\S]{0,2000}canonical\?\.isDeleted\s*\?\s*\{\s*isDeleted:\s*null\s*\}\s*:\s*\{\}/.test(deltaSearchSrc));
 
@@ -1477,8 +1478,8 @@ await import('../js/settings.js');
     /_PER_ROW_DECOMPRESSED_CAP_BYTES\s*=\s*1024\s*\*\s*1024[\s\S]{0,500}async function _gunzipToStringCapped/.test(syncPayloadSrc));
   assert('_gunzipToStringCapped throws on cap exceeded',
     /total\s*>\s*maxBytes[\s\S]{0,300}refusing to trust/.test(syncPayloadSrc));
-  assert('All 3 per-row gunzip sites use the capped variant',
-    (syncDeltaSrc.match(/_gunzipToStringCapped\(_base64ToBytes\(json\.slice\(6\)\)\)/g) || []).length === 3);
+  assert('All per-row gunzip sites use the capped variant',
+    (syncDeltaSrc.match(/_gunzipToStringCapped\(_base64ToBytes\(json\.slice\(6\)\)\)/g) || []).length >= 4);
   // Blob path also routes through _gunzipToStringCapped, with the
   // 5 MB MAX_SYNC_PAYLOAD_BYTES cap — a single capped helper is the
   // only gunzip entry point post-2026-05-10 audit (the bare
@@ -1963,6 +1964,8 @@ await import('../js/settings.js');
   // despite live rows in the per-row layer.
   assert('Pull-side genetics scalar TOMBSTONE branch preserves .snps when present',
     /tombstoned\s*&&\s*tombstonedAt\s*>=\s*chosenAt[\s\S]{0,1500}arrayName\s*===\s*'genetics'[\s\S]{0,500}imported\.genetics\s*=\s*\{\s*snps:\s*imported\.genetics\.snps\s*\}/.test(deltaSearchSrc));
+  assert('Genetics SNP planner rebuilds missing map input from itemRows',
+    /mapName\s*===\s*'genetics\.snps'[\s\S]{0,1600}fromRows\[parsed\.k\]\s*=\s*parsed\.v/.test(deltaSearchSrc));
 
   // Sidebar rebuild after every pull — conditional nav items (Genetics,
   // Wearables, etc.) gate on data presence, and per-row CRDT deltas can
@@ -2003,6 +2006,52 @@ await import('../js/settings.js');
     assert('strip simulator does not mutate input',
       'snps' in before.genetics
       && Object.keys(before.genetics.snps).length === 2);
+
+    {
+      const profileId = 'sync-test-genetics-row-fallback';
+      const snapshotKey = `labcharts-${profileId}-delta-genetics.snps`;
+      const metaKey = `${snapshotKey}-meta`;
+      const rows = Array.from({ length: 43 }, (_, i) => {
+        const rsid = `rs${100000 + i}`;
+        return {
+          profileId,
+          arrayName: 'genetics.snps',
+          itemId: rsid,
+          payload: JSON.stringify({ k: rsid, v: { genotype: 'AA', gene: `G${i}` } }),
+          syncedAt: '2026-05-24T12:00:00.000Z',
+          isDeleted: null,
+        };
+      });
+      const prevSnapshot = Object.fromEntries(rows.map(r => [r.itemId, 'old']));
+      const oldSnapshot = localStorage.getItem(snapshotKey);
+      const oldMeta = localStorage.getItem(metaKey);
+      const oldWarn = console.warn;
+      let tombstoneStormWarned = false;
+      try {
+        localStorage.setItem(snapshotKey, JSON.stringify(prevSnapshot));
+        localStorage.removeItem(metaKey);
+        syncDelta.configureSyncDelta({
+          getEvolu: () => ({ getQueryRows: () => rows }),
+          getItemRowQuery: () => ({}),
+        });
+        console.warn = (...args) => {
+          if (String(args[0] || '').includes('refused tombstone storm for genetics.snps')) tombstoneStormWarned = true;
+          oldWarn.apply(console, args);
+        };
+        const plan = await syncDelta._planKeyedMapDelta(profileId, 'genetics.snps', undefined);
+        assert('genetics.snps missing blob map falls back to live itemRows',
+          Object.keys(plan.next || {}).length === rows.length);
+        assert('genetics.snps row fallback avoids false tombstone-storm warning',
+          tombstoneStormWarned === false);
+      } finally {
+        console.warn = oldWarn;
+        syncDelta.configureSyncDelta({ getEvolu: () => null, getItemRowQuery: () => null });
+        if (oldSnapshot === null) localStorage.removeItem(snapshotKey);
+        else localStorage.setItem(snapshotKey, oldSnapshot);
+        if (oldMeta === null) localStorage.removeItem(metaKey);
+        else localStorage.setItem(metaKey, oldMeta);
+      }
+    }
   }
 
   // ═══════════════════════════════════════

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -2043,6 +2043,22 @@ await import('../js/settings.js');
           Object.keys(plan.next || {}).length === rows.length);
         assert('genetics.snps row fallback avoids false tombstone-storm warning',
           tombstoneStormWarned === false);
+        tombstoneStormWarned = false;
+        const emptyMapPlan = await syncDelta._planKeyedMapDelta(profileId, 'genetics.snps', {});
+        assert('genetics.snps empty blob map falls back to live itemRows',
+          Object.keys(emptyMapPlan.next || {}).length === rows.length);
+        assert('genetics.snps empty-map fallback avoids false tombstone-storm warning',
+          tombstoneStormWarned === false);
+        syncDelta.configureSyncDelta({
+          getEvolu: () => ({ getQueryRows: () => [] }),
+          getItemRowQuery: () => ({}),
+        });
+        tombstoneStormWarned = false;
+        const noRowsPlan = await syncDelta._planKeyedMapDelta(profileId, 'genetics.snps', {});
+        assert('genetics.snps empty map with unavailable itemRows preserves previous snapshot',
+          Object.keys(noRowsPlan.next || {}).length === rows.length && noRowsPlan.ops.length === 0);
+        assert('genetics.snps empty map with unavailable itemRows avoids false warning',
+          tombstoneStormWarned === false);
       } finally {
         console.warn = oldWarn;
         syncDelta.configureSyncDelta({ getEvolu: () => null, getItemRowQuery: () => null });

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -611,7 +611,10 @@ await import('../js/settings.js');
   // the rate at which the relay's per-owner quota fills.
   assert('onDataSaved has 10s debounce', syncActionsSrc.includes('}, 10_000)'));
   assert('onDataSaved captures profileId at schedule time', syncActionsSrc.includes('const profileId = state.currentProfile') && syncActionsSrc.includes('_pushProfile(profileId'));
-  assert('onDataSaved retries if syncing', syncActionsSrc.includes('if (_isSyncing())') && syncActionsSrc.includes('_pushProfile(profileId, data)'));
+  assert('onDataSaved retries while sync is not ready or a push is in-flight',
+    syncActionsSrc.includes('function scheduleProfilePush(profileId, data, attempt = 0)')
+      && syncActionsSrc.includes('!_isEvoluReady() || _isSyncing()')
+      && /export function onDataSaved[\s\S]{0,700}scheduleProfilePush\(profileId,\s*data\)/.test(syncActionsSrc));
   // v1.6.3: skip-decision REMOVED on the pull path. Both timestamp-skip
   // and hash-skip caused users to miss cross-device data (clock-skew
   // and stale hash keys from prior code versions). The mergeImportedData
@@ -651,7 +654,7 @@ await import('../js/settings.js');
   assert('disableSync clears sync timestamps',
     /disableSync[\s\S]{0,3000}key\.endsWith\('-sync-ts'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(syncSrc));
   assert('applyChatData uses plain localStorage for thread index (matches saveChatThreadIndex)',
-    syncApplySrc.includes("localStorage.setItem(threadsKey, JSON.stringify(chatData.threads)"));
+    syncApplySrc.includes("localStorage.setItem(threadsKey, JSON.stringify(mergedThreads))"));
 
   // ═══════════════════════════════════════
   // 9. SETTINGS UI
@@ -704,9 +707,18 @@ await import('../js/settings.js');
   assert('collectChatData includes custom personalities', syncPayloadSrc.includes('chatPersonalityCustom'));
   assert('collectChatData emits empty messages for cleared zero-message threads',
     syncPayloadSrc.includes('messageCount') && syncPayloadSrc.includes('messages[t.id] = []'));
+  assert('collectChatData includes explicit chat thread tombstones',
+    syncPayloadSrc.includes('chatDeletedThreadsKey')
+      && syncPayloadSrc.includes('deletedThreads'));
+  assert('chat thread tombstones reject proto-pollution keys',
+    syncApplySrc.includes('CHAT_DELETED_PROTO_KEYS')
+      && syncPayloadSrc.includes('CHAT_DELETED_PROTO_KEYS')
+      && await fetchWithRetry('js/chat-threads.js').then(s => s.includes('CHAT_DELETED_PROTO_KEYS.has(threadId)')));
   assert('applyChatData writes threads', syncApplySrc.includes('applyChatData'));
-  assert('applyChatData removes message keys for remotely deleted threads',
-    syncApplySrc.includes('incomingThreadIds') && syncApplySrc.includes('encryptedRemoveItem(`labcharts-${profileId}-chat-t_${t.id}`)'));
+  assert('applyChatData preserves local-only threads unless an explicit tombstone wins',
+    syncApplySrc.includes('mergedById.set(thread.id, thread)')
+      && syncApplySrc.includes('normalizeDeletedThreads(chatData.deletedThreads)')
+      && syncApplySrc.includes('encryptedRemoveItem(`labcharts-${profileId}-chat-t_${thread.id}`)'));
   assert('applyChatData skips stale remote chat while local save is fresh',
     syncApplySrc.includes('CHAT_LOCAL_LOCK_UNTIL_KEY') && syncApplySrc.includes('shouldKeepLocalChatData(profileId)'));
   assert('chat freshness lock is shorter than two minutes',
@@ -724,29 +736,43 @@ await import('../js/settings.js');
     const threadsKey = `labcharts-${profileId}-chat-threads`;
     const keepKey = `labcharts-${profileId}-chat-t_keep`;
     const goneKey = `labcharts-${profileId}-chat-t_gone`;
+    const deletedKey = `labcharts-${profileId}-chat-deleted-threads`;
     const oldLock = sessionStorage.getItem('labcharts-chat-local-lock-until');
+    const oldDeleted = localStorage.getItem(deletedKey);
     try {
       state.currentProfile = profileId;
       sessionStorage.removeItem('labcharts-chat-local-lock-until');
       localStorage.setItem(threadsKey, JSON.stringify([
-        { id: 'keep', messageCount: 1 },
-        { id: 'gone', messageCount: 1 },
+        { id: 'keep', messageCount: 1, updatedAt: '2026-05-24T10:00:00.000Z' },
+        { id: 'gone', messageCount: 1, updatedAt: '2026-05-24T10:00:00.000Z' },
       ]));
       localStorage.setItem(keepKey, JSON.stringify([{ role: 'user', content: 'old' }]));
       localStorage.setItem(goneKey, JSON.stringify([{ role: 'user', content: 'delete me' }]));
       const applied = await syncApply.applyChatData(profileId, {
-        threads: [{ id: 'keep', messageCount: 1 }],
+        threads: [{ id: 'keep', messageCount: 1, updatedAt: '2026-05-24T10:05:00.000Z' }],
         messages: { keep: [{ role: 'assistant', content: 'new' }] },
       });
       assert('applyChatData functional: remote thread index applied', applied === true);
-      assert('applyChatData functional: deleted thread message key removed', localStorage.getItem(goneKey) === null);
+      assert('applyChatData functional: stale remote absence does not delete local-only thread',
+        JSON.parse(localStorage.getItem(threadsKey) || '[]').some(t => t.id === 'gone')
+          && localStorage.getItem(goneKey) !== null);
       assert('applyChatData functional: kept thread messages overwritten',
         JSON.parse(localStorage.getItem(keepKey) || '[]')?.[0]?.content === 'new');
+      await syncApply.applyChatData(profileId, {
+        threads: [{ id: 'keep', messageCount: 1, updatedAt: '2026-05-24T10:05:00.000Z' }],
+        messages: { keep: [{ role: 'assistant', content: 'newer' }] },
+        deletedThreads: { gone: Date.parse('2026-05-24T10:06:00.000Z') },
+      });
+      assert('applyChatData functional: explicit remote tombstone removes deleted thread message key',
+        localStorage.getItem(goneKey) === null
+          && !JSON.parse(localStorage.getItem(threadsKey) || '[]').some(t => t.id === 'gone'));
     } finally {
       state.currentProfile = prevProfileId;
       localStorage.removeItem(threadsKey);
       localStorage.removeItem(keepKey);
       localStorage.removeItem(goneKey);
+      if (oldDeleted === null) localStorage.removeItem(deletedKey);
+      else localStorage.setItem(deletedKey, oldDeleted);
       if (oldLock === null) sessionStorage.removeItem('labcharts-chat-local-lock-until');
       else sessionStorage.setItem('labcharts-chat-local-lock-until', oldLock);
     }
@@ -758,6 +784,11 @@ await import('../js/settings.js');
   assert('Display prefs synced', syncPayloadSrc.includes('DISPLAY_PREF_SUFFIXES') && syncPayloadSrc.includes('collectDisplayPrefs'));
   assert('onChatSaved exported', exportBlockIncludes(syncSrc, ['onChatSaved']));
   assert('onChatSaved has debounce', syncActionsSrc.includes('_chatSyncTimers') && syncActionsSrc.includes('10000'));
+  assert('onChatSaved uses the profile push retry helper instead of one-shot push while syncing',
+    /export function onChatSaved[\s\S]{0,700}scheduleProfilePush\(profileId,\s*data\)/.test(syncActionsSrc));
+  assert('chat thread deletes record tombstones before syncing index',
+    await fetchWithRetry('js/chat-threads.js').then(s => s.includes('recordDeletedChatThread(threadId)')
+      && s.indexOf('recordDeletedChatThread(threadId)') < s.indexOf('state.chatThreads = state.chatThreads.filter')));
   assert('chat-threads.js imports onChatSaved', await fetchWithRetry('js/chat-threads.js').then(s => s.includes("import { onChatSaved } from './sync.js'")));
 
   // ═══════════════════════════════════════

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.131';
+self.APP_VERSION = '1.8.132';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.132';
+self.APP_VERSION = '1.8.133';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.130';
+self.APP_VERSION = '1.8.131';


### PR DESCRIPTION
## Summary
- Preserve local-only chat threads when an inbound sync payload is stale or missing them.
- Add explicit chat-thread delete tombstones so real deletes still propagate across devices.
- Route data/chat debounced pushes through the retry helper instead of one-shot delayed pushes during in-flight sync.
- Avoid false `genetics.snps` tombstone-storm warnings when the blob has metadata-only genetics, an empty SNP placeholder, or itemRows are briefly unavailable while live SNP rows already exist.
- Bump `version.js` for cache invalidation.

## Root Cause
The chat apply path treated absence from a remote thread index as deletion. When device B had a stale or empty chat payload, device A would pull it and remove its newer local thread/messages. During busy sync windows, the debounced save hook could also miss the push that should have published A's new chat state.

The console warning was a separate false positive from the genetics scalar/SNP-map split: the blob/scalar paths intentionally omit `genetics.snps`, but the planner could still see the missing or empty in-memory map as `43 -> 0` before the per-row overlay had restored it.

## Validation
- `node tests/test-sync.js`
- `git diff --check`
- `./run-tests.sh`