### PR TITLE
Extract sync startup reconciliation

### DIFF
--- a/js/sync-reconcile.js
+++ b/js/sync-reconcile.js
@@ -1,0 +1,84 @@
+// sync-reconcile.js - startup reconciliation for localStorage vs Evolu rows.
+
+import { state } from './state.js';
+import { localHasRowsRemoteLacks } from './data-merge.js';
+import { collectAISettings, parseSyncPayload } from './sync-payload.js';
+import { logSyncEvent } from './sync-state.js';
+
+let _getEvolu = () => null;
+let _getProfileQuery = () => null;
+let _isSyncEnabled = () => false;
+let _pushProfile = async () => {};
+let _debug = () => {};
+
+export function configureSyncReconcile({
+  getEvolu,
+  getProfileQuery,
+  isSyncEnabled,
+  pushProfile,
+  debug,
+} = {}) {
+  if (typeof getEvolu === 'function') _getEvolu = getEvolu;
+  if (typeof getProfileQuery === 'function') _getProfileQuery = getProfileQuery;
+  if (typeof isSyncEnabled === 'function') _isSyncEnabled = isSyncEnabled;
+  if (typeof pushProfile === 'function') _pushProfile = pushProfile;
+  if (typeof debug === 'function') _debug = debug;
+}
+
+// Compare state.importedData (loaded from localStorage on page-load) with
+// the Evolu DB row's dataJson for the active profile. If local has unsynced
+// changes - either new ids the remote lacks OR same-id rows where the local
+// copy has a strictly higher pickTimestamp (the canonical signal data-merge.js
+// uses to pick a winner) - trigger a forced push so the divergence catches up
+// without the user needing to tap Force Resend.
+//
+// The within-id timestamp branch is what catches the "phone stopped a session
+// then closed before the 10s debounce push fired" failure mode: ids match on
+// both sides but local has the stopped session (endedAt set, ts=endedAt) while
+// remote still has the active session (endedAt=null, ts=startedAt). Without it
+// the stop sits in localStorage indefinitely until some other edit triggers
+// onDataSaved.
+export async function reconcileLocalStorageWithEvolu() {
+  const evolu = _getEvolu();
+  const profileQuery = _getProfileQuery();
+  if (!evolu || !_isSyncEnabled() || !state.currentProfile || !state.importedData) return;
+  const rows = evolu.getQueryRows(profileQuery);
+  const existing = rows?.find(r => r.profileId === state.currentProfile);
+  // No existing row -> first sync ever for this profile, normal push path
+  // (onDataSaved or enableSync) will handle it. Skip.
+  if (!existing) return;
+  let remoteImported;
+  let localAiSettingsDiffer = false;
+  try {
+    const parsed = await parseSyncPayload(existing.dataJson);
+    remoteImported = parsed?.importedData || null;
+    const remoteAiSettings = parsed?.aiSettings || {};
+    const localAiSettings = await collectAISettings();
+    localAiSettingsDiffer = Object.entries(localAiSettings)
+      .some(([key, val]) => remoteAiSettings?.[key] !== val);
+  } catch {
+    // Malformed row -> reconciliation can't reason about it. The user can
+    // still recover via the Force Resend button.
+    return;
+  }
+  if (!remoteImported && !localAiSettingsDiffer) return;
+
+  // Reuse the rebroadcast helper - same semantic ("local has anything remote
+  // doesn't reflect"), same id-keyed array list, same pickTimestamp tiebreak.
+  // Returns true on (a) new local ids, (b) same-id with lTs>rTs, (c) tombstones
+  // local has remote lacks. Without (b) the start-then-stop-then-close sequence
+  // strands the stop on the phone forever - relay row keeps endedAt=null and
+  // every other device shows the session as still running.
+  const localHasUnsynced = remoteImported ? localHasRowsRemoteLacks(state.importedData, remoteImported) : false;
+  if (!localHasUnsynced && !localAiSettingsDiffer) {
+    _debug('Startup reconciliation: localStorage, AI settings, and Evolu row match - nothing to do');
+    return;
+  }
+  const reason = localHasUnsynced ? 'unsynced rows' : 'newer local AI settings';
+  _debug(`Startup reconciliation: localStorage has ${reason} vs Evolu row`);
+  logSyncEvent('reconcile', `Reconcile ${state.currentProfile.slice(0, 8)} - local has ${reason}`);
+  // Force-push so the next watchdog cycle can't lose us a clearly-needed
+  // catch-up. Bypasses the _syncing guard if it was wedged from a prior
+  // session - the same wedge that caused the divergence in the first place.
+  await _pushProfile(state.currentProfile, state.importedData, { force: true });
+}

--- a/js/sync.js
+++ b/js/sync.js
@@ -4,11 +4,6 @@
 
 import { state } from './state.js';
 import { showNotification, isDebugMode } from './utils.js';
-import { localHasRowsRemoteLacks } from './data-merge.js';
-import {
-  collectAISettings,
-  parseSyncPayload,
-} from './sync-payload.js';
 import {
   compactOwnerSelfServe, configureRelayHealth, fetchOwnerStorageFromRelay,
   getRelayHealthVerdict, getRelayQuotaEstimate,
@@ -58,6 +53,9 @@ import {
 import {
   configureSyncPush, isSyncPushInFlight, pushProfile,
 } from './sync-push.js';
+import {
+  configureSyncReconcile, reconcileLocalStorageWithEvolu,
+} from './sync-reconcile.js';
 import {
   disablePhase2Cutover, enablePhase2Cutover, isPhase2CutoverEnabled,
 } from './sync-cutover.js';
@@ -189,6 +187,14 @@ configureSyncActions({
   isSyncing: isSyncPushInFlight,
 });
 bindSyncActionEvents();
+
+configureSyncReconcile({
+  getEvolu: () => evolu,
+  getProfileQuery: () => profileQuery,
+  isSyncEnabled: () => _syncEnabled,
+  pushProfile,
+  debug: dbg,
+});
 
 // ═══════════════════════════════════════════════
 // SETTINGS
@@ -467,7 +473,7 @@ export async function initSync() {
     // up. Defer until after appOwner + initial query both load — those
     // are async and the CRDT row doesn't exist until then.
     Promise.all([_readyPromise, _queryLoaded]).then(() => {
-      _reconcileLocalStorageWithEvolu().catch(e => {
+      reconcileLocalStorageWithEvolu().catch(e => {
         console.warn('[sync] Startup reconciliation failed:', e);
       });
     });
@@ -475,62 +481,6 @@ export async function initSync() {
     console.error('[sync] Failed to initialize Evolu:', e);
     _syncEnabled = false;
   }
-}
-
-// Compare state.importedData (loaded from localStorage on page-load) with
-// the Evolu DB row's dataJson for the active profile. If local has unsynced
-// changes — either new ids the remote lacks OR same-id rows where the local
-// copy has a strictly higher pickTimestamp (the canonical signal data-merge.js
-// uses to pick a winner) — trigger a forced push so the divergence catches up
-// without the user needing to tap Force Resend.
-//
-// The within-id timestamp branch is what catches the "phone stopped a session
-// then closed before the 10s debounce push fired" failure mode: ids match on
-// both sides but local has the stopped session (endedAt set, ts=endedAt) while
-// remote still has the active session (endedAt=null, ts=startedAt). Without it
-// the stop sits in localStorage indefinitely until some other edit triggers
-// onDataSaved.
-async function _reconcileLocalStorageWithEvolu() {
-  if (!evolu || !_syncEnabled || !state.currentProfile || !state.importedData) return;
-  const rows = evolu.getQueryRows(profileQuery);
-  const existing = rows?.find(r => r.profileId === state.currentProfile);
-  // No existing row → first sync ever for this profile, normal push path
-  // (onDataSaved or enableSync) will handle it. Skip.
-  if (!existing) return;
-  let remoteImported;
-  let localAiSettingsDiffer = false;
-  try {
-    const parsed = await parseSyncPayload(existing.dataJson);
-    remoteImported = parsed?.importedData || null;
-    const remoteAiSettings = parsed?.aiSettings || {};
-    const localAiSettings = await collectAISettings();
-    localAiSettingsDiffer = Object.entries(localAiSettings)
-      .some(([key, val]) => remoteAiSettings?.[key] !== val);
-  } catch {
-    // Malformed row → reconciliation can't reason about it. The user can
-    // still recover via the Force Resend button.
-    return;
-  }
-  if (!remoteImported && !localAiSettingsDiffer) return;
-
-  // Reuse the rebroadcast helper — same semantic ("local has anything remote
-  // doesn't reflect"), same id-keyed array list, same pickTimestamp tiebreak.
-  // Returns true on (a) new local ids, (b) same-id with lTs>rTs, (c) tombstones
-  // local has remote lacks. Without (b) the start-then-stop-then-close sequence
-  // strands the stop on the phone forever — relay row keeps endedAt=null and
-  // every other device shows the session as still running.
-  const localHasUnsynced = remoteImported ? localHasRowsRemoteLacks(state.importedData, remoteImported) : false;
-  if (!localHasUnsynced && !localAiSettingsDiffer) {
-    dbg('Startup reconciliation: localStorage, AI settings, and Evolu row match — nothing to do');
-    return;
-  }
-  const reason = localHasUnsynced ? 'unsynced rows' : 'newer local AI settings';
-  dbg(`Startup reconciliation: localStorage has ${reason} vs Evolu row`);
-  logSyncEvent('reconcile', `Reconcile ${state.currentProfile.slice(0, 8)} — local has ${reason}`);
-  // Force-push so the next watchdog cycle can't lose us a clearly-needed
-  // catch-up. Bypasses the _syncing guard if it was wedged from a prior
-  // session — the same wedge that caused the divergence in the first place.
-  await pushProfile(state.currentProfile, state.importedData, { force: true });
 }
 
 // ═══════════════════════════════════════════════

--- a/service-worker.js
+++ b/service-worker.js
@@ -148,6 +148,7 @@ const APP_SHELL = [
   '/js/sync-diagnose-ui.js',
   '/js/sync-actions.js',
   '/js/sync-push.js',
+  '/js/sync-reconcile.js',
   '/js/sync-pull.js',
   '/js/sync-cutover.js',
   '/js/sync-ui.js',

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -286,6 +286,7 @@ assert('startup-oauth-callbacks.js clears pending OAuth state after callback',
 assert('startup-oauth-callbacks.js marks fresh OpenRouter settings local for sync',
   startupOAuthSrc.includes('markOpenRouterOAuthSettingsLocal()'));
 const syncSrc = read('js/sync.js');
+const syncReconcileSrc = read('js/sync-reconcile.js');
 const syncApplySrc = read('js/sync-apply.js');
 assert('sync preserves fresh OpenRouter OAuth provider/key against stale pull',
   syncApplySrc.includes('shouldKeepLocalOpenRouterOAuthSetting') && syncApplySrc.includes("'labcharts-openrouter-key'"));
@@ -294,7 +295,9 @@ assert('sync preserves fresh local AI settings against stale pull',
 assert('sync refreshes AI header after remote AI settings apply',
   syncApplySrc.includes('window.updateChatHeaderModel?.()') && syncApplySrc.includes('window.refreshWebSearchToggle?.()'));
 assert('startup sync reconciliation pushes local AI setting drift',
-  syncSrc.includes('newer local AI settings') && syncSrc.includes('collectAISettings()'));
+  syncSrc.includes("from './sync-reconcile.js'")
+    && syncReconcileSrc.includes('newer local AI settings')
+    && syncReconcileSrc.includes('collectAISettings()'));
 const cssSrc = read('styles.css');
 assert('CSS: .or-oauth-btn defined', cssSrc.includes('.or-oauth-btn'));
 assert('CSS: .or-oauth-divider defined', cssSrc.includes('.or-oauth-divider'));

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -44,6 +44,7 @@ await import('../js/settings.js');
   const syncDiagnoseUiSrc = await fetchWithRetry('js/sync-diagnose-ui.js');
   const syncActionsSrc = await fetchWithRetry('js/sync-actions.js');
   const syncPushSrc = await fetchWithRetry('js/sync-push.js');
+  const syncReconcileSrc = await fetchWithRetry('js/sync-reconcile.js');
   const syncPullSrc = await fetchWithRetry('js/sync-pull.js');
   const syncCutoverSrc = await fetchWithRetry('js/sync-cutover.js');
   const profileSrc = await fetchWithRetry('js/profile.js');
@@ -57,7 +58,7 @@ await import('../js/settings.js');
   const stylesSrc = await fetchWithRetry('styles.css');
   const themeExtraSrc = await fetchWithRetry('themes-extra.css');
   const serviceWorkerSrc = await fetchWithRetry('service-worker.js');
-  const deltaSearchSrc = `${syncSrc}\n${syncPushSrc}\n${syncPullSrc}\n${syncCutoverSrc}\n${syncDeltaSrc}\n${syncDiagnosticsSrc}\n${syncDiagnoseUiSrc}`;
+  const deltaSearchSrc = `${syncSrc}\n${syncPushSrc}\n${syncReconcileSrc}\n${syncPullSrc}\n${syncCutoverSrc}\n${syncDeltaSrc}\n${syncDiagnosticsSrc}\n${syncDiagnoseUiSrc}`;
   const exportBlockIncludes = (src, names) => [...src.matchAll(/export\s+\{([^}]*)\};/g)]
     .some(([, block]) => names.every(name => new RegExp(`\\b${name}\\b`).test(block)));
 
@@ -199,6 +200,13 @@ await import('../js/settings.js');
       && syncSrc.includes('configureSyncPush({'));
   assert('service worker precaches sync-push.js',
     serviceWorkerSrc.includes("'/js/sync-push.js'"));
+  assert('sync-reconcile.js owns startup reconciliation helper',
+    syncSrc.includes("from './sync-reconcile.js'")
+      && syncReconcileSrc.includes('export function configureSyncReconcile')
+      && syncReconcileSrc.includes('export async function reconcileLocalStorageWithEvolu')
+      && syncSrc.includes('configureSyncReconcile({'));
+  assert('service worker precaches sync-reconcile.js',
+    serviceWorkerSrc.includes("'/js/sync-reconcile.js'"));
   assert('sync-pull.js owns inbound pull merge helpers',
     syncSrc.includes("from './sync-pull.js'")
       && syncPullSrc.includes('export function configureSyncPull')
@@ -296,7 +304,9 @@ await import('../js/settings.js');
   // ═══════════════════════════════════════
   console.log('2. Sync Payload Format');
 
-  assert('sync-payload.js owns buildSyncPayload', syncSrc.includes("from './sync-payload.js'") && syncPayloadSrc.includes('export async function buildSyncPayload'));
+  assert('sync-payload.js owns buildSyncPayload',
+    syncPushSrc.includes("from './sync-payload.js'")
+      && syncPayloadSrc.includes('export async function buildSyncPayload'));
   assert('buildSyncPayload still emits _v: 3 (default dual-write)', syncPayloadSrc.includes('cutover ? 4 : 3'));
   assert('buildSyncPayload includes importedData', syncPayloadSrc.includes('importedData,') || syncPayloadSrc.includes('importedData:'));
   assert('buildSyncPayload includes profile metadata', syncPayloadSrc.includes('profile: profile'));
@@ -2266,22 +2276,22 @@ await import('../js/settings.js');
 
   // Source-shape: the reconciliation function exists and routes through
   // the pickTimestamp-aware helper instead of bare id-set comparison.
-  assert('_reconcileLocalStorageWithEvolu defined',
-    /async function _reconcileLocalStorageWithEvolu\(\)/.test(syncSrc));
+  assert('reconcileLocalStorageWithEvolu defined',
+    /export async function reconcileLocalStorageWithEvolu\(\)/.test(syncReconcileSrc));
   assert('Reconciliation runs on initSync after appOwner + queries are ready',
-    /Promise\.all\(\[_readyPromise,\s*_queryLoaded\]\)[\s\S]{0,300}_reconcileLocalStorageWithEvolu/.test(syncSrc));
+    /Promise\.all\(\[_readyPromise,\s*_queryLoaded\]\)[\s\S]{0,300}reconcileLocalStorageWithEvolu/.test(syncSrc));
   assert('Reconciliation reads remote dataJson via parseSyncPayload',
-    /_reconcileLocalStorageWithEvolu[\s\S]{0,800}parseSyncPayload\(existing\.dataJson\)/.test(syncSrc));
+    /reconcileLocalStorageWithEvolu[\s\S]{0,800}parseSyncPayload\(existing\.dataJson\)/.test(syncReconcileSrc));
   assert('Reconciliation routes through localHasRowsRemoteLacks (catches same-id timestamp drift)',
-    /_reconcileLocalStorageWithEvolu[\s\S]{0,1500}localHasRowsRemoteLacks\(state\.importedData,\s*remoteImported\)/.test(syncSrc));
+    /reconcileLocalStorageWithEvolu[\s\S]{0,2500}localHasRowsRemoteLacks\(state\.importedData,\s*remoteImported\)/.test(syncReconcileSrc));
   assert('Reconciliation force-pushes when local has unsynced rows',
-    /_reconcileLocalStorageWithEvolu[\s\S]{0,4000}pushProfile\(state\.currentProfile,\s*state\.importedData,\s*\{\s*force:\s*true\s*\}\)/.test(syncSrc));
+    /reconcileLocalStorageWithEvolu[\s\S]{0,4000}_pushProfile\(state\.currentProfile,\s*state\.importedData,\s*\{\s*force:\s*true\s*\}\)/.test(syncReconcileSrc));
   // Defence-in-depth: the regression we're guarding against was id-only
   // comparison, so explicitly assert the OLD shape is gone. Hard to write
   // without false-positives — this regex matches the v1.7.x id-set diff
   // pattern that was specifically replaced.
   assert('Reconciliation no longer relies on bare id-set diff (would miss within-id ts drift)',
-    !/_reconcileLocalStorageWithEvolu[\s\S]{0,1500}new Set\(local\.map\(r\s*=>\s*r\?\.id\)/.test(syncSrc));
+    !/reconcileLocalStorageWithEvolu[\s\S]{0,1500}new Set\(local\.map\(r\s*=>\s*r\?\.id\)/.test(syncReconcileSrc));
 
   // Live: simulate localHasRowsRemoteLacks's three-case decision with the
   // exact shape our reconciliation feeds it. Confirms the function still

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.133';
+self.APP_VERSION = '1.8.134';


### PR DESCRIPTION
## Summary
- Move startup localStorage-vs-Evolu reconciliation into `js/sync-reconcile.js`
- Configure the extracted reconciler from `sync.js` without changing reconciliation behavior
- Add the new module to the service worker app shell and bump `APP_VERSION`
- Update sync/OpenRouter source-shape tests for the new module boundary

## Validation
- `git diff --check`
- `node --check js/sync.js`
- `node --check js/sync-reconcile.js`
- `node --check tests/test-sync.js`
- `node --check tests/test-openrouter.js`
- `node --check service-worker.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `node tests/test-openrouter.js`
- `./run-tests.sh`