### PR TITLE
Extract sync schema setup

### DIFF
--- a/js/sync-schema.js
+++ b/js/sync-schema.js
@@ -1,0 +1,55 @@
+// sync-schema.js - Evolu schema and query setup for sync.
+
+export function createSyncSchema({
+  id,
+  nullOr,
+  NonEmptyString,
+}) {
+  const ProfileDataId = id("ProfileData");
+  const ItemRowId = id("ItemRow");
+
+  // Per-array delta table (Phase 1 of the CRDT-delta refactor). Each row
+  // holds one item from one importedData surface. Push side dual-writes
+  // changed items; pull side overlays rows before the fat-blob merge.
+  return {
+    profileData: {
+      id: ProfileDataId,
+      profileId: NonEmptyString,
+      dataJson: NonEmptyString,
+      syncedAt: nullOr(NonEmptyString),
+    },
+    itemRow: {
+      id: ItemRowId,
+      profileId: NonEmptyString,
+      arrayName: NonEmptyString,
+      itemId: NonEmptyString,
+      payload: NonEmptyString,
+      syncedAt: nullOr(NonEmptyString),
+    },
+  };
+}
+
+export function createSyncQueries(evolu) {
+  // Query all live profile data rows.
+  const profileQuery = evolu.createQuery((db) =>
+    db.selectFrom("profileData")
+      .selectAll()
+      .where("isDeleted", "is not", 1)
+  );
+
+  // Companion query that returns only tombstoned rows. Used during pull to
+  // apply remote profile deletes locally.
+  const tombstoneQuery = evolu.createQuery((db) =>
+    db.selectFrom("profileData")
+      .selectAll()
+      .where("isDeleted", "=", 1)
+  );
+
+  // Per-array delta rows, live and tombstoned. profileId is filtered later
+  // at merge time so one subscribed query can cover current-profile changes.
+  const itemRowQuery = evolu.createQuery((db) =>
+    db.selectFrom("itemRow").selectAll()
+  );
+
+  return { profileQuery, tombstoneQuery, itemRowQuery };
+}

--- a/js/sync.js
+++ b/js/sync.js
@@ -10,6 +10,9 @@ import {
   resetRelayQuotaEstimate, verifyPushLanded,
 } from './sync-relay-health.js';
 import {
+  createSyncQueries, createSyncSchema,
+} from './sync-schema.js';
+import {
   getRecentSyncEvents, logSyncEvent, resetSyncStatus,
   subscribeSyncStatus, updateSyncStatus,
 } from './sync-state.js';
@@ -237,40 +240,10 @@ export async function initSync() {
   await new Promise(r => setTimeout(r, 0));
 
   try {
-    const { createEvolu, id, nullOr, SimpleName, NonEmptyString1000, NonEmptyString, evoluWebDeps } =
+    const { createEvolu, id, nullOr, SimpleName, NonEmptyString, evoluWebDeps } =
       await import('../vendor/evolu/evolu-bundle.js');
 
-    const ProfileDataId = id("ProfileData");
-    const ItemRowId = id("ItemRow");
-    // Per-array delta table (Phase 1 of the CRDT-delta refactor — see
-    // memory/project_evolu_delta_refactor_plan.md). Each row holds ONE
-    // item from one of the importedData arrays (sunSessions, lightDevices,
-    // entries, …). Push side dual-writes: every successful pushProfile()
-    // also emits inserts/updates/tombstones for items that changed since
-    // the last successful push (snapshot diff). Pull side merges itemRow
-    // payloads into state.importedData BEFORE the fat-blob merge runs, so
-    // per-row data is authoritative when present and the blob acts as
-    // fallback for pre-Phase-1 device pushes.
-    //
-    // ONE table with arrayName discriminator instead of N tables: adding a
-    // new array doesn't require schema migration, single subscribeQuery
-    // covers everything, identical merge logic per array.
-    const Schema = {
-      profileData: {
-        id: ProfileDataId,
-        profileId: NonEmptyString,
-        dataJson: NonEmptyString,
-        syncedAt: nullOr(NonEmptyString),
-      },
-      itemRow: {
-        id: ItemRowId,
-        profileId: NonEmptyString,
-        arrayName: NonEmptyString,  // 'sunSessions' | 'lightDevices' | …
-        itemId: NonEmptyString,     // the item.id field, e.g. 'sun_1714780123456'
-        payload: NonEmptyString,    // gzip-base64-encoded JSON of one item
-        syncedAt: nullOr(NonEmptyString),
-      },
-    };
+    const Schema = createSyncSchema({ id, nullOr, NonEmptyString });
 
     const relay = getSyncRelay();
     evolu = createEvolu(evoluWebDeps)(Schema, {
@@ -280,31 +253,7 @@ export async function initSync() {
       transports: [{ type: "WebSocket", url: relay }],
     });
 
-    // Query all profile data rows
-    profileQuery = evolu.createQuery((db) =>
-      db.selectFrom("profileData")
-        .selectAll()
-        .where("isDeleted", "is not", 1)
-    );
-
-    // Companion query that returns ONLY tombstoned rows. Used during pull
-    // to apply remote deletes locally — when device A tombstones profile X,
-    // device B sees X here and wipes its local copy. Without this, B's
-    // local profiles list keeps showing X even though A "deleted" it.
-    tombstoneQuery = evolu.createQuery((db) =>
-      db.selectFrom("profileData")
-        .selectAll()
-        .where("isDeleted", "=", 1)
-    );
-
-    // Per-array delta rows (live + tombstoned). The merge logic in
-    // _mergeItemRowsIntoImported sorts on isDeleted, so a single query
-    // returning every itemRow is sufficient. profileId filter applied
-    // at merge time so subscribeQuery doesn't have to refire on each
-    // currentProfile change.
-    itemRowQuery = evolu.createQuery((db) =>
-      db.selectFrom("itemRow").selectAll()
-    );
+    ({ profileQuery, tombstoneQuery, itemRowQuery } = createSyncQueries(evolu));
 
     // Subscribe to sync updates
     evolu.subscribeQuery(profileQuery)(() => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -139,6 +139,7 @@ const APP_SHELL = [
   '/js/hardware.js',
   '/js/sync.js',
   '/js/sync-apply.js',
+  '/js/sync-schema.js',
   '/js/sync-delta.js',
   '/js/sync-tombstones.js',
   '/js/sync-messenger.js',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -35,6 +35,7 @@ await import('../js/settings.js');
 
   const syncSrc = await fetchWithRetry('js/sync.js');
   const syncApplySrc = await fetchWithRetry('js/sync-apply.js');
+  const syncSchemaSrc = await fetchWithRetry('js/sync-schema.js');
   const syncDeltaSrc = await fetchWithRetry('js/sync-delta.js');
   const syncTombstonesSrc = await fetchWithRetry('js/sync-tombstones.js');
   const syncMessengerSrc = await fetchWithRetry('js/sync-messenger.js');
@@ -88,6 +89,14 @@ await import('../js/settings.js');
       && syncStateSrc.includes('export function consumeRebroadcastBudget'));
   assert('service worker precaches sync-state.js',
     serviceWorkerSrc.includes("'/js/sync-state.js'"));
+  assert('sync-schema.js owns Evolu schema/query helpers',
+    syncSrc.includes("from './sync-schema.js'")
+      && syncSchemaSrc.includes('export function createSyncSchema')
+      && syncSchemaSrc.includes('export function createSyncQueries')
+      && syncSrc.includes('createSyncSchema({')
+      && syncSrc.includes('createSyncQueries(evolu)'));
+  assert('service worker precaches sync-schema.js',
+    serviceWorkerSrc.includes("'/js/sync-schema.js'"));
   assert('sync-apply.js owns inbound AI/chat/display apply helpers',
     syncPullSrc.includes("from './sync-apply.js'")
       && syncApplySrc.includes('export async function applyAISettings')
@@ -269,8 +278,8 @@ await import('../js/settings.js');
 
   // Tombstone-aware pull: a remote delete from another device wipes the
   // local copy on next sync, so multi-device cleanup completes itself.
-  assert('sync.js declares a tombstoneQuery selecting isDeleted = 1 rows',
-    /tombstoneQuery\s*=\s*evolu\.createQuery[\s\S]{0,300}isDeleted[",\s]+=[",\s]+1/.test(syncSrc));
+  assert('sync-schema.js declares a tombstoneQuery selecting isDeleted = 1 rows',
+    /tombstoneQuery\s*=\s*evolu\.createQuery[\s\S]{0,300}isDeleted[",\s]+=[",\s]+1/.test(syncSchemaSrc));
   assert('tombstoneQuery subscription retriggers onSyncReceived',
     /evolu\.subscribeQuery\(tombstoneQuery\)\([\s\S]{0,250}onSyncReceived\(\)/.test(syncSrc));
   assert('poll safety tracks tombstone count as well as live rows',
@@ -424,9 +433,9 @@ await import('../js/settings.js');
 
   // Schema additions
   assert('Schema declares itemRow table',
-    /itemRow:\s*\{[\s\S]{0,300}arrayName:\s*NonEmptyString[\s\S]{0,300}itemId:\s*NonEmptyString[\s\S]{0,200}payload:\s*NonEmptyString/.test(syncSrc));
-  assert('itemRowQuery created on init',
-    /itemRowQuery\s*=\s*evolu\.createQuery\([\s\S]{0,200}selectFrom\("itemRow"\)/.test(syncSrc));
+    /itemRow:\s*\{[\s\S]{0,300}arrayName:\s*NonEmptyString[\s\S]{0,300}itemId:\s*NonEmptyString[\s\S]{0,200}payload:\s*NonEmptyString/.test(syncSchemaSrc));
+  assert('itemRowQuery created by sync-schema.js',
+    /itemRowQuery\s*=\s*evolu\.createQuery\([\s\S]{0,200}selectFrom\("itemRow"\)/.test(syncSchemaSrc));
   assert('itemRowQuery loaded with profileQuery + tombstoneQuery',
     /Promise\.all\(\[[\s\S]{0,400}evolu\.loadQuery\(itemRowQuery\)/.test(syncSrc));
   assert('itemRow subscription retriggers onSyncReceived',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.134';
+self.APP_VERSION = '1.8.135';


### PR DESCRIPTION
## Summary
- Move Evolu sync schema and query construction into `js/sync-schema.js`
- Keep `sync.js` focused on initialization and lifecycle wiring
- Add the new module to the service worker app shell and bump `APP_VERSION`
- Update sync source-shape tests for the new module boundary

## Validation
- `git diff --check`
- `node --check js/sync.js`
- `node --check js/sync-schema.js`
- `node --check tests/test-sync.js`
- `node --check service-worker.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `./run-tests.sh`