### PR TITLE
Extract sync recovery hooks

### DIFF
--- a/js/sync-recovery.js
+++ b/js/sync-recovery.js
@@ -63,13 +63,13 @@ export function bindSyncRecoveryEvents() {
       _kickSync('online');
       if (!_lastNetState) {
         _lastNetState = true;
-        _notify('Back online - syncing your changes.', 'success', 3000);
+        _notify('Back online — syncing your changes.', 'success', 3000);
       }
     });
 
     window.addEventListener('offline', () => {
       _lastNetState = false;
-      _notify('Offline - changes are saved locally and will sync when you reconnect.', 'info', 5000);
+      _notify('Offline — changes are saved locally and will sync when you reconnect.', 'info', 5000);
     });
   }
 }

--- a/js/sync-recovery.js
+++ b/js/sync-recovery.js
@@ -1,0 +1,75 @@
+// sync-recovery.js - resume and network recovery hooks for sync.
+
+let _isSyncEnabled = () => false;
+let _isEvoluReady = () => false;
+let _pushCurrentProfile = async () => {};
+let _forcePull = () => {};
+let _debug = () => {};
+let _notify = () => {};
+let _eventsBound = false;
+let _lastVisibleSyncAt = 0;
+let _lastNetState = true;
+
+export function configureSyncRecovery({
+  isSyncEnabled,
+  isEvoluReady,
+  pushCurrentProfile,
+  forcePull,
+  debug,
+  notify,
+} = {}) {
+  if (typeof isSyncEnabled === 'function') _isSyncEnabled = isSyncEnabled;
+  if (typeof isEvoluReady === 'function') _isEvoluReady = isEvoluReady;
+  if (typeof pushCurrentProfile === 'function') _pushCurrentProfile = pushCurrentProfile;
+  if (typeof forcePull === 'function') _forcePull = forcePull;
+  if (typeof debug === 'function') _debug = debug;
+  if (typeof notify === 'function') _notify = notify;
+}
+
+function _kickSync(reason) {
+  if (!_isSyncEnabled() || !_isEvoluReady()) return;
+  const now = Date.now();
+  if (now - _lastVisibleSyncAt < 30_000) return;
+  _lastVisibleSyncAt = now;
+  _debug(`Tab resume (${reason}) - kicking syncNow`);
+  // Let the visibility/network event return before heavier push/pull work.
+  setTimeout(() => {
+    _pushCurrentProfile().catch(() => {});
+    _forcePull();
+  }, 100);
+}
+
+export function bindSyncRecoveryEvents() {
+  if (_eventsBound) return;
+  _eventsBound = true;
+
+  if (typeof navigator !== 'undefined') {
+    _lastNetState = navigator.onLine ?? true;
+  }
+
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') _kickSync('visibilitychange');
+    });
+  }
+
+  if (typeof window !== 'undefined') {
+    // pageshow fires when the tab is restored from bfcache or rehydrated.
+    window.addEventListener('pageshow', (e) => {
+      if (e.persisted) _kickSync('pageshow-persisted');
+    });
+
+    window.addEventListener('online', () => {
+      _kickSync('online');
+      if (!_lastNetState) {
+        _lastNetState = true;
+        _notify('Back online - syncing your changes.', 'success', 3000);
+      }
+    });
+
+    window.addEventListener('offline', () => {
+      _lastNetState = false;
+      _notify('Offline - changes are saved locally and will sync when you reconnect.', 'info', 5000);
+    });
+  }
+}

--- a/js/sync.js
+++ b/js/sync.js
@@ -57,6 +57,9 @@ import {
   configureSyncPush, isSyncPushInFlight, pushProfile,
 } from './sync-push.js';
 import {
+  bindSyncRecoveryEvents, configureSyncRecovery,
+} from './sync-recovery.js';
+import {
   configureSyncReconcile, reconcileLocalStorageWithEvolu,
 } from './sync-reconcile.js';
 import {
@@ -190,6 +193,17 @@ configureSyncActions({
   isSyncing: isSyncPushInFlight,
 });
 bindSyncActionEvents();
+
+configureSyncRecovery({
+  isSyncEnabled: () => _syncEnabled,
+  isEvoluReady: () => !!evolu,
+  pushCurrentProfile,
+  forcePull: _forcePull,
+  debug: dbg,
+  notify: (...args) => {
+    try { showNotification(...args); } catch {}
+  },
+});
 
 configureSyncReconcile({
   getEvolu: () => evolu,
@@ -352,63 +366,7 @@ export async function initSync() {
       updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
     }, 60000);
 
-    // Resume-from-suspended-tab recovery — Android browsers (Brave/Chrome on
-    // mobile) aggressively kill background tab processes to save battery.
-    // The renderer + Evolu's WebSocket worker get evicted; on resume we
-    // come back with a stale (or no) WS, and Evolu's reconnect loop doesn't
-    // automatically drain the push queue or trigger a fresh pull. Without
-    // this hook the user has to swipe-to-refresh after every screen-off
-    // cycle to converge — observed in production on Brave Android where
-    // the device shows up in chrome://inspect/#devices, sync indicator
-    // stays yellow, then disappears entirely once the renderer is reaped.
-    //
-    // Throttled to once per 30s — multiple visibility flips in quick
-    // succession (notifications, recents-pane peeks) shouldn't pile up
-    // pushes, and the existing 30s poll covers the steady-state case.
-    let _lastVisibleSyncAt = 0;
-    const _kickSync = (reason) => {
-      if (!_syncEnabled || !evolu) return;
-      const now = Date.now();
-      if (now - _lastVisibleSyncAt < 30_000) return;
-      _lastVisibleSyncAt = now;
-      dbg(`Tab resume (${reason}) — kicking syncNow`);
-      // Schedule via setTimeout so the visibilitychange handler returns
-      // before any heavy push/pull work starts (browsers occasionally
-      // throttle long-running sync work in the visibility transition).
-      setTimeout(() => {
-        pushCurrentProfile().catch(() => {});
-        _forcePull();
-      }, 100);
-    };
-    if (typeof document !== 'undefined') {
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible') _kickSync('visibilitychange');
-      });
-    }
-    if (typeof window !== 'undefined') {
-      // pageshow fires when the tab is restored from the back/forward cache
-      // or after the renderer was killed and the page is rehydrating.
-      window.addEventListener('pageshow', (e) => {
-        if (e.persisted) _kickSync('pageshow-persisted');
-      });
-      // Network came back — drain any pending pushes + toast the user.
-      // Evolu queues writes locally while offline; the user has no other
-      // signal that their edits are safely persisted (vs. lost). The
-      // toasts are throttled — only one fires per offline → online
-      // transition, not per visibilitychange.
-      let _lastNetState = navigator.onLine ?? true;
-      window.addEventListener('online', () => {
-        _kickSync('online');
-        if (!_lastNetState) {
-          _lastNetState = true;
-          if (window.showNotification) window.showNotification('Back online — syncing your changes.', 'success', 3000);
-        }
-      });
-      window.addEventListener('offline', () => {
-        _lastNetState = false;
-        if (window.showNotification) window.showNotification('Offline — changes are saved locally and will sync when you reconnect.', 'info', 5000);
-      });
-    }
+    bindSyncRecoveryEvents();
 
     dbg('Initialized, relay:', relay);
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -149,6 +149,7 @@ const APP_SHELL = [
   '/js/sync-diagnose-ui.js',
   '/js/sync-actions.js',
   '/js/sync-push.js',
+  '/js/sync-recovery.js',
   '/js/sync-reconcile.js',
   '/js/sync-pull.js',
   '/js/sync-cutover.js',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -45,6 +45,7 @@ await import('../js/settings.js');
   const syncDiagnoseUiSrc = await fetchWithRetry('js/sync-diagnose-ui.js');
   const syncActionsSrc = await fetchWithRetry('js/sync-actions.js');
   const syncPushSrc = await fetchWithRetry('js/sync-push.js');
+  const syncRecoverySrc = await fetchWithRetry('js/sync-recovery.js');
   const syncReconcileSrc = await fetchWithRetry('js/sync-reconcile.js');
   const syncPullSrc = await fetchWithRetry('js/sync-pull.js');
   const syncCutoverSrc = await fetchWithRetry('js/sync-cutover.js');
@@ -209,6 +210,18 @@ await import('../js/settings.js');
       && syncSrc.includes('configureSyncPush({'));
   assert('service worker precaches sync-push.js',
     serviceWorkerSrc.includes("'/js/sync-push.js'"));
+  assert('sync-recovery.js owns tab resume and network recovery hooks',
+    syncSrc.includes("from './sync-recovery.js'")
+      && syncRecoverySrc.includes('export function configureSyncRecovery')
+      && syncRecoverySrc.includes('export function bindSyncRecoveryEvents')
+      && syncRecoverySrc.includes("document.addEventListener('visibilitychange'")
+      && syncRecoverySrc.includes("window.addEventListener('pageshow'")
+      && syncRecoverySrc.includes("window.addEventListener('online'")
+      && syncRecoverySrc.includes("window.addEventListener('offline'")
+      && syncSrc.includes('configureSyncRecovery({')
+      && syncSrc.includes('bindSyncRecoveryEvents();'));
+  assert('service worker precaches sync-recovery.js',
+    serviceWorkerSrc.includes("'/js/sync-recovery.js'"));
   assert('sync-reconcile.js owns startup reconciliation helper',
     syncSrc.includes("from './sync-reconcile.js'")
       && syncReconcileSrc.includes('export function configureSyncReconcile')

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -295,10 +295,10 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /addEventListener\('offline'/.test(syncRecoverySrc));
     assert('sync-recovery.js: listens for online event + kicks sync',
       /addEventListener\('online'[\s\S]{0,200}_kickSync\('online'\)/.test(syncRecoverySrc));
-    assert('sync-recovery.js: offline toast mentions "saved locally"',
-      /saved locally and will sync when you reconnect/.test(syncRecoverySrc));
-    assert('sync-recovery.js: online toast mentions "syncing"',
-      /Back online[\s\S]{0,80}syncing your changes/i.test(syncRecoverySrc));
+    assert('sync-recovery.js: offline toast copy matches shipped em-dash wording',
+      syncRecoverySrc.includes('Offline — changes are saved locally and will sync when you reconnect.'));
+    assert('sync-recovery.js: online toast copy matches shipped em-dash wording',
+      syncRecoverySrc.includes('Back online — syncing your changes.'));
     assert('sync-recovery.js: toast guarded against double-firing',
       /_lastNetState/.test(syncRecoverySrc));
   }

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -290,17 +290,17 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   // ─── 8. v1.6.7 Sync offline/online toast affordance ─────────────────
   console.log('%c 8. Sync offline/online toast affordance ', 'font-weight:bold;color:#0891b2');
   {
-    const syncSrc = fetchSrc('js/sync.js');
-    assert('sync.js: listens for offline event',
-      /addEventListener\('offline'/.test(syncSrc));
-    assert('sync.js: listens for online event + kicks sync',
-      /addEventListener\('online'[\s\S]{0,200}_kickSync\('online'\)/.test(syncSrc));
-    assert('sync.js: offline toast mentions "saved locally"',
-      /saved locally and will sync when you reconnect/.test(syncSrc));
-    assert('sync.js: online toast mentions "syncing"',
-      /Back online[\s\S]{0,80}syncing your changes/i.test(syncSrc));
-    assert('sync.js: toast guarded against double-firing',
-      /_lastNetState/.test(syncSrc));
+    const syncRecoverySrc = fetchSrc('js/sync-recovery.js');
+    assert('sync-recovery.js: listens for offline event',
+      /addEventListener\('offline'/.test(syncRecoverySrc));
+    assert('sync-recovery.js: listens for online event + kicks sync',
+      /addEventListener\('online'[\s\S]{0,200}_kickSync\('online'\)/.test(syncRecoverySrc));
+    assert('sync-recovery.js: offline toast mentions "saved locally"',
+      /saved locally and will sync when you reconnect/.test(syncRecoverySrc));
+    assert('sync-recovery.js: online toast mentions "syncing"',
+      /Back online[\s\S]{0,80}syncing your changes/i.test(syncRecoverySrc));
+    assert('sync-recovery.js: toast guarded against double-firing',
+      /_lastNetState/.test(syncRecoverySrc));
   }
 
   // ─── 9. v1.6.14 Sync pull reads view from state, not DOM ────────────

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.135';
+self.APP_VERSION = '1.8.136';


### PR DESCRIPTION
## Summary
- Move tab resume and online/offline sync recovery listeners into `js/sync-recovery.js`
- Configure and bind recovery hooks from `sync.js` after sync initialization succeeds
- Add the new module to the service worker app shell and bump `APP_VERSION`
- Update sync source-shape regressions to track the new module owner

## Validation
- `node --check js/sync.js`
- `node --check js/sync-recovery.js`
- `node --check tests/test-sync.js`
- `node --check tests/test-v1-6-shipped.js`
- `node --check service-worker.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`