### PR TITLE
Extract sync settings state

### DIFF
--- a/js/sync-settings-state.js
+++ b/js/sync-settings-state.js
@@ -1,0 +1,25 @@
+// sync-settings-state.js - persisted sync enabled flag.
+
+export const SYNC_STORAGE_KEY = 'labcharts-sync-enabled';
+
+let _syncEnabled = false;
+let _syncStatePrimed = false;
+
+export function primeSyncState() {
+  if (!_syncStatePrimed) {
+    _syncEnabled = localStorage.getItem(SYNC_STORAGE_KEY) === 'true';
+    _syncStatePrimed = true;
+  }
+  return _syncEnabled;
+}
+
+export function isSyncEnabled() {
+  return _syncStatePrimed ? _syncEnabled : primeSyncState();
+}
+
+export function setSyncEnabled(enabled, { persist = true } = {}) {
+  if (persist) localStorage.setItem(SYNC_STORAGE_KEY, enabled ? 'true' : 'false');
+  _syncEnabled = !!enabled;
+  _syncStatePrimed = true;
+  return _syncEnabled;
+}

--- a/js/sync.js
+++ b/js/sync.js
@@ -17,6 +17,9 @@ import {
   subscribeSyncStatus, updateSyncStatus,
 } from './sync-state.js';
 import {
+  isSyncEnabled, primeSyncState, setSyncEnabled,
+} from './sync-settings-state.js';
+import {
   configureSyncDelta, getDeltaCutoverReadiness, getDeltaTelemetry,
   resetDeltaTelemetry,
 } from './sync-delta.js';
@@ -74,6 +77,7 @@ export {
   compactOwnerSelfServe, fetchOwnerStorageFromRelay, getRelayHealthVerdict,
   getRelayQuotaEstimate, resetRelayQuotaEstimate, verifyPushLanded,
   getRecentSyncEvents, subscribeSyncStatus,
+  isSyncEnabled, primeSyncState,
   applyPendingTombstone, deleteProfileFromRelay, listPendingTombstones,
   rejectPendingTombstone,
   generateMessengerToken, getMessengerToken, isMessengerEnabled,
@@ -108,8 +112,6 @@ let evolu = null;
 let profileQuery = null;
 let tombstoneQuery = null;
 let itemRowQuery = null;
-let _syncEnabled = false;
-let _syncStatePrimed = false;
 let _appOwner = null;
 let _appOwnerError = null;
 let _readyPromise = null;
@@ -128,7 +130,7 @@ configureSyncDelta({
 configureSyncPush({
   getEvolu: () => evolu,
   getProfileQuery: () => profileQuery,
-  isSyncEnabled: () => _syncEnabled,
+  isSyncEnabled,
   isPhase2CutoverEnabled,
   disablePhase2Cutover,
   debug: dbg,
@@ -146,7 +148,7 @@ configureSyncTombstones({
   getEvolu: () => evolu,
   getProfileQuery: () => profileQuery,
   getTombstoneQuery: () => tombstoneQuery,
-  isSyncEnabled: () => _syncEnabled,
+  isSyncEnabled,
   pushProfile,
   debug: dbg,
 });
@@ -167,11 +169,11 @@ configureSyncDiagnostics({
   getProfileQuery: () => profileQuery,
   getTombstoneQuery: () => tombstoneQuery,
   getAppOwner: () => _appOwner,
-  isSyncEnabled: () => _syncEnabled,
+  isSyncEnabled,
 });
 
 configureSyncUI({
-  isSyncEnabled: () => _syncEnabled,
+  isSyncEnabled,
 });
 bindSyncUIStatusUpdates();
 
@@ -188,14 +190,14 @@ configureSyncDiagnoseUI({
 configureSyncActions({
   pushProfile,
   forcePull: _forcePull,
-  isSyncEnabled: () => _syncEnabled,
+  isSyncEnabled,
   isEvoluReady: () => !!evolu,
   isSyncing: isSyncPushInFlight,
 });
 bindSyncActionEvents();
 
 configureSyncRecovery({
-  isSyncEnabled: () => _syncEnabled,
+  isSyncEnabled,
   isEvoluReady: () => !!evolu,
   pushCurrentProfile,
   forcePull: _forcePull,
@@ -208,34 +210,17 @@ configureSyncRecovery({
 configureSyncReconcile({
   getEvolu: () => evolu,
   getProfileQuery: () => profileQuery,
-  isSyncEnabled: () => _syncEnabled,
+  isSyncEnabled,
   pushProfile,
   debug: dbg,
 });
-
-// ═══════════════════════════════════════════════
-// SETTINGS
-// ═══════════════════════════════════════════════
-
-const SYNC_STORAGE_KEY = 'labcharts-sync-enabled';
-
-export function primeSyncState() {
-  if (!_syncStatePrimed) {
-    _syncEnabled = localStorage.getItem(SYNC_STORAGE_KEY) === 'true';
-    _syncStatePrimed = true;
-  }
-  return _syncEnabled;
-}
-
-export function isSyncEnabled() { return _syncStatePrimed ? _syncEnabled : primeSyncState(); }
 
 // ═══════════════════════════════════════════════
 // INIT
 // ═══════════════════════════════════════════════
 
 export async function initSync() {
-  primeSyncState();
-  if (!_syncEnabled) return;
+  if (!primeSyncState()) return;
 
   // Fail fast if the webview doesn't have what Evolu needs. Otherwise the
   // worker hangs forever on appOwner and the toggle/restore flow looks
@@ -386,7 +371,7 @@ export async function initSync() {
     });
   } catch (e) {
     console.error('[sync] Failed to initialize Evolu:', e);
-    _syncEnabled = false;
+    setSyncEnabled(false, { persist: false });
   }
 }
 
@@ -402,8 +387,7 @@ export async function enableSync({ skipPush = false } = {}) {
     showNotification(`Sync unavailable in this browser: ${blocker}`, 'error');
     return;
   }
-  localStorage.setItem(SYNC_STORAGE_KEY, 'true');
-  _syncEnabled = true;
+  setSyncEnabled(true);
   _appOwnerError = null;
   await initSync();
   if (!evolu || !_readyPromise) {
@@ -439,8 +423,7 @@ export async function disableSync() {
   // Flip the persisted flag FIRST, before any awaits. If anything below
   // hangs (Evolu worker stuck on OPFS or a Web Lock), a manual page
   // reload will still see sync as off.
-  localStorage.setItem(SYNC_STORAGE_KEY, 'false');
-  _syncEnabled = false;
+  setSyncEnabled(false);
   _appOwnerError = null;
 
   // Stop background timers + reset status (UI feedback before the reload)
@@ -506,7 +489,7 @@ export async function disableSync() {
 
 function _syncDiag() {
   const info = {
-    enabled: _syncEnabled,
+    enabled: isSyncEnabled(),
     evoluReady: !!evolu,
     relay: getSyncRelay(),
     mnemonic: _appOwner?.mnemonic ? '<set>' : null,

--- a/service-worker.js
+++ b/service-worker.js
@@ -138,6 +138,7 @@ const APP_SHELL = [
   '/js/dna.js',
   '/js/hardware.js',
   '/js/sync.js',
+  '/js/sync-settings-state.js',
   '/js/sync-apply.js',
   '/js/sync-schema.js',
   '/js/sync-delta.js',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -35,6 +35,7 @@ await import('../js/settings.js');
 
   const syncSrc = await fetchWithRetry('js/sync.js');
   const syncApplySrc = await fetchWithRetry('js/sync-apply.js');
+  const syncSettingsStateSrc = await fetchWithRetry('js/sync-settings-state.js');
   const syncSchemaSrc = await fetchWithRetry('js/sync-schema.js');
   const syncDeltaSrc = await fetchWithRetry('js/sync-delta.js');
   const syncTombstonesSrc = await fetchWithRetry('js/sync-tombstones.js');
@@ -90,6 +91,17 @@ await import('../js/settings.js');
       && syncStateSrc.includes('export function consumeRebroadcastBudget'));
   assert('service worker precaches sync-state.js',
     serviceWorkerSrc.includes("'/js/sync-state.js'"));
+  assert('sync-settings-state.js owns persisted sync enabled flag',
+    syncSrc.includes("from './sync-settings-state.js'")
+      && syncSettingsStateSrc.includes("export const SYNC_STORAGE_KEY = 'labcharts-sync-enabled'")
+      && syncSettingsStateSrc.includes('export function primeSyncState')
+      && syncSettingsStateSrc.includes('export function isSyncEnabled')
+      && syncSettingsStateSrc.includes('export function setSyncEnabled')
+      && syncSettingsStateSrc.includes("localStorage.getItem(SYNC_STORAGE_KEY) === 'true'")
+      && syncSettingsStateSrc.includes("localStorage.setItem(SYNC_STORAGE_KEY, enabled ? 'true' : 'false')")
+      && exportBlockIncludes(syncSrc, ['isSyncEnabled', 'primeSyncState']));
+  assert('service worker precaches sync-settings-state.js',
+    serviceWorkerSrc.includes("'/js/sync-settings-state.js'"));
   assert('sync-schema.js owns Evolu schema/query helpers',
     syncSrc.includes("from './sync-schema.js'")
       && syncSchemaSrc.includes('export function createSyncSchema')
@@ -677,8 +689,15 @@ await import('../js/settings.js');
   // or a Web Lock). The page reload below kills the worker process
   // anyway. The persisted SYNC_STORAGE_KEY flips before any await so a
   // hard refresh always sees sync as off.
+  const disableSyncSrc = syncSrc.slice(
+    syncSrc.indexOf('export async function disableSync'),
+    syncSrc.indexOf('// ═══════════════════════════════════════════════\n// DIAGNOSTICS')
+  );
   assert('disableSync flips SYNC_STORAGE_KEY before any await',
-    /localStorage\.setItem\(SYNC_STORAGE_KEY,\s*['"]false['"]\)[\s\S]{0,200}_syncEnabled = false/.test(syncSrc));
+    disableSyncSrc.includes('setSyncEnabled(false);')
+      && disableSyncSrc.indexOf('setSyncEnabled(false);') < disableSyncSrc.indexOf('_appOwnerError = null')
+      && (!disableSyncSrc.includes('await ') || disableSyncSrc.indexOf('setSyncEnabled(false);') < disableSyncSrc.indexOf('await '))
+      && syncSettingsStateSrc.includes("localStorage.setItem(SYNC_STORAGE_KEY, enabled ? 'true' : 'false')"));
   assert('disableSync does not block on Evolu reset (fire-and-forget)',
     /Promise\.resolve\(evolu\.resetAppOwner/.test(syncSrc),
     'awaiting resetAppOwner blocks the toggle when Evolu worker is hung');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.136';
+self.APP_VERSION = '1.8.137';


### PR DESCRIPTION
## Summary
- Move the persisted sync enabled flag and priming logic into `js/sync-settings-state.js`
- Keep `sync.js` as the public facade by re-exporting `isSyncEnabled` and `primeSyncState`
- Wire sync submodules to the shared state helper instead of local `_syncEnabled` closures
- Add the new module to the service worker app shell and bump `APP_VERSION`
- Update sync source-shape tests for the new owner and disable path guard

## Validation
- `node --check js/sync.js`
- `node --check js/sync-settings-state.js`
- `node --check tests/test-sync.js`
- `node --check service-worker.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`