### PR TITLE
Move sync diagnostic helper

### DIFF
--- a/js/sync-diagnostics.js
+++ b/js/sync-diagnostics.js
@@ -1,6 +1,7 @@
 // sync-diagnostics.js - Evolu row diagnostics snapshot and copy text helpers.
 
 import { state } from './state.js';
+import { isDebugMode } from './utils.js';
 import { getDeltaCutoverReadiness, getDeltaTelemetry } from './sync-delta.js';
 import { getSyncRelay } from './sync-environment.js';
 import { parseSyncPayload } from './sync-payload.js';
@@ -11,6 +12,9 @@ let _getProfileQuery = () => null;
 let _getTombstoneQuery = () => null;
 let _getAppOwner = () => null;
 let _isSyncEnabled = () => false;
+let _getSubscriptionFireCount = () => 0;
+let _isSyncing = () => false;
+let _isPulling = () => false;
 
 export function configureSyncDiagnostics({
   getEvolu,
@@ -18,12 +22,18 @@ export function configureSyncDiagnostics({
   getTombstoneQuery,
   getAppOwner,
   isSyncEnabled,
+  getSubscriptionFireCount,
+  isSyncing,
+  isPulling,
 } = {}) {
   if (typeof getEvolu === 'function') _getEvolu = getEvolu;
   if (typeof getProfileQuery === 'function') _getProfileQuery = getProfileQuery;
   if (typeof getTombstoneQuery === 'function') _getTombstoneQuery = getTombstoneQuery;
   if (typeof getAppOwner === 'function') _getAppOwner = getAppOwner;
   if (typeof isSyncEnabled === 'function') _isSyncEnabled = isSyncEnabled;
+  if (typeof getSubscriptionFireCount === 'function') _getSubscriptionFireCount = getSubscriptionFireCount;
+  if (typeof isSyncing === 'function') _isSyncing = isSyncing;
+  if (typeof isPulling === 'function') _isPulling = isPulling;
 }
 
 function currentEvolu() {
@@ -44,6 +54,54 @@ function currentAppOwner() {
 
 function currentSyncEnabled() {
   try { return !!_isSyncEnabled?.(); } catch { return false; }
+}
+
+function currentSubscriptionFireCount() {
+  try { return Number(_getSubscriptionFireCount?.() || 0); } catch { return 0; }
+}
+
+function currentSyncing() {
+  try { return !!_isSyncing?.(); } catch { return false; }
+}
+
+function currentPulling() {
+  try { return !!_isPulling?.(); } catch { return false; }
+}
+
+export function _syncDiag() {
+  const evolu = currentEvolu();
+  const profileQuery = currentProfileQuery();
+  const appOwner = currentAppOwner();
+  const info = {
+    enabled: currentSyncEnabled(),
+    evoluReady: !!evolu,
+    relay: getSyncRelay(),
+    mnemonic: appOwner?.mnemonic ? '<set>' : null,
+    subscriptionFires: currentSubscriptionFireCount(),
+    syncing: currentSyncing(),
+    pulling: currentPulling(),
+  };
+  if (evolu && profileQuery) {
+    const rows = evolu.getQueryRows(profileQuery);
+    info.evoluRows = (rows || []).map(r => ({
+      profileId: r.profileId,
+      syncedAt: r.syncedAt,
+      dataSize: r.dataJson?.length ?? 0,
+    }));
+  }
+  const tsList = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.endsWith('-sync-ts')) {
+      tsList.push({ key, ts: parseInt(localStorage.getItem(key), 10), date: new Date(parseInt(localStorage.getItem(key), 10)).toISOString() });
+    }
+  }
+  info.localTimestamps = tsList;
+  if (isDebugMode()) {
+    console.table?.(info.evoluRows);
+    console.log('[sync] Diagnostics:', JSON.stringify(info, null, 2));
+  }
+  return info;
 }
 
 // Snapshot Evolu's current state for the in-popover Diagnose button. Used

--- a/js/sync.js
+++ b/js/sync.js
@@ -39,7 +39,7 @@ import {
   restoreFromMnemonic,
 } from './sync-identity.js';
 import {
-  configureSyncDiagnostics, getEvoluDiagnostics,
+  _syncDiag, configureSyncDiagnostics, getEvoluDiagnostics,
 } from './sync-diagnostics.js';
 import {
   bindSyncUIStatusUpdates, configureSyncUI, copySyncEvents,
@@ -170,6 +170,9 @@ configureSyncDiagnostics({
   getTombstoneQuery: () => tombstoneQuery,
   getAppOwner: () => _appOwner,
   isSyncEnabled,
+  getSubscriptionFireCount: () => _subscriptionFireCount,
+  isSyncing: isSyncPushInFlight,
+  isPulling: isSyncPulling,
 });
 
 configureSyncUI({
@@ -481,44 +484,6 @@ export async function disableSync() {
   // Reload regardless of whether Evolu cooperated. ~250ms gives the toast
   // time to render before the page swaps.
   setTimeout(() => window.location.reload(), 250);
-}
-
-// ═══════════════════════════════════════════════
-// DIAGNOSTICS
-// ═══════════════════════════════════════════════
-
-function _syncDiag() {
-  const info = {
-    enabled: isSyncEnabled(),
-    evoluReady: !!evolu,
-    relay: getSyncRelay(),
-    mnemonic: _appOwner?.mnemonic ? '<set>' : null,
-    subscriptionFires: _subscriptionFireCount,
-    syncing: isSyncPushInFlight(),
-    pulling: isSyncPulling(),
-  };
-  if (evolu && profileQuery) {
-    const rows = evolu.getQueryRows(profileQuery);
-    info.evoluRows = (rows || []).map(r => ({
-      profileId: r.profileId,
-      syncedAt: r.syncedAt,
-      dataSize: r.dataJson?.length ?? 0,
-    }));
-  }
-  // Show local sync timestamps
-  const tsList = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key?.endsWith('-sync-ts')) {
-      tsList.push({ key, ts: parseInt(localStorage.getItem(key), 10), date: new Date(parseInt(localStorage.getItem(key), 10)).toISOString() });
-    }
-  }
-  info.localTimestamps = tsList;
-  if (isDebugMode()) {
-    console.table?.(info.evoluRows);
-    console.log('[sync] Diagnostics:', JSON.stringify(info, null, 2));
-  }
-  return info;
 }
 
 // ═══════════════════════════════════════════════

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -281,7 +281,7 @@ return (async function () {
   // ─── 7. _syncDiag — console output gated by isDebugMode() ──────────
   console.log('%c 7. _syncDiag debug-mode gate ', 'font-weight:bold;color:#0891b2');
   {
-    const src = await fetchSrc('js/sync.js');
+    const src = await fetchSrc('js/sync-diagnostics.js');
     const fn = src.slice(src.indexOf('function _syncDiag'),
                           src.indexOf('function _syncDiag') + 2000);
     assert('_syncDiag function found', fn.indexOf('function _syncDiag') === 0);

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -172,7 +172,11 @@ await import('../js/settings.js');
     syncSrc.includes("from './sync-diagnostics.js'")
       && syncDiagnosticsSrc.includes('export async function getEvoluDiagnostics')
       && syncDiagnosticsSrc.includes('export function _evoluDiagnosticsText')
+      && syncDiagnosticsSrc.includes('export function _syncDiag')
       && syncDiagnosticsSrc.includes('export function configureSyncDiagnostics')
+      && syncDiagnosticsSrc.includes('getSubscriptionFireCount')
+      && syncDiagnosticsSrc.includes('isSyncing')
+      && syncDiagnosticsSrc.includes('isPulling')
       && exportBlockIncludes(syncSrc, ['getEvoluDiagnostics']));
   assert('service worker precaches sync-diagnostics.js',
     serviceWorkerSrc.includes("'/js/sync-diagnostics.js'"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.137';
+self.APP_VERSION = '1.8.138';


### PR DESCRIPTION
## Summary
- Move the legacy `window._syncDiag` helper from `sync.js` into `js/sync-diagnostics.js`
- Extend `configureSyncDiagnostics` with the live subscription/push/pull state callbacks needed by `_syncDiag`
- Keep the public window binding unchanged from `sync.js`
- Update source-shape regressions for the new owner and bump `APP_VERSION`

## Validation
- `node --check js/sync.js`
- `node --check js/sync-diagnostics.js`
- `node --check tests/test-sync.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `git diff --check`
- `./run-tests.sh`

Note: `tests/test-audit-fixes.js` is a legacy browser-runner file with top-level `return`, so direct `node --check`/`node tests/test-audit-fixes.js` is not a valid invocation; it passed through `./run-tests.sh`.