### PR TITLE
Extract sync disable cleanup

### DIFF
--- a/js/charts.js
+++ b/js/charts.js
@@ -5,13 +5,37 @@ import { getStatus, formatValue, loadScriptOnce } from './utils.js';
 import { getChartColors } from './theme.js';
 import { getEffectiveRange, getEffectiveRangeForDate, getPhaseRefEnvelope } from './data.js';
 
+const CHART_JS_SRC = '/vendor/chart.min.js';
+const CHART_DATE_ADAPTER_SRC = '/vendor/chartjs-adapter-native.js';
+
 let _chartJsLoad = null;
+let _chartDateAdapterLoad = null;
+
+export function isChartDateAdapterReady() {
+  return window.__labChartDateAdapterLoaded === true;
+}
+
+function ensureChartDateAdapter() {
+  if (isChartDateAdapterReady()) return Promise.resolve(window.Chart);
+  if (!_chartDateAdapterLoad) {
+    _chartDateAdapterLoad = loadScriptOnce(CHART_DATE_ADAPTER_SRC)
+      .then(() => {
+        window.__labChartDateAdapterLoaded = true;
+        return window.Chart;
+      })
+      .catch(err => {
+        _chartDateAdapterLoad = null;
+        throw err;
+      });
+  }
+  return _chartDateAdapterLoad;
+}
 
 export async function ensureChartJs() {
-  if (window.Chart) return window.Chart;
+  if (window.Chart) return ensureChartDateAdapter();
   if (!_chartJsLoad) {
-    _chartJsLoad = loadScriptOnce('/vendor/chart.min.js')
-      .then(() => loadScriptOnce('/vendor/chartjs-adapter-native.js'))
+    _chartJsLoad = loadScriptOnce(CHART_JS_SRC)
+      .then(() => ensureChartDateAdapter())
       .then(() => {
         if (!window.Chart) throw new Error('Chart.js did not initialize');
         return window.Chart;
@@ -627,4 +651,4 @@ export function getMarkerDescription(markerId) {
   return cache[markerId] || null;
 }
 
-Object.assign(window, { refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin, phaseBandPlugin, getNotesForChart, getSupplementsForChart, createLineChart, refreshChartThemeColors, getMarkerDescription, ensureChartJs });
+Object.assign(window, { refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin, phaseBandPlugin, getNotesForChart, getSupplementsForChart, createLineChart, refreshChartThemeColors, getMarkerDescription, ensureChartJs, isChartDateAdapterReady });

--- a/js/sync-disable-cleanup.js
+++ b/js/sync-disable-cleanup.js
@@ -1,0 +1,21 @@
+// sync-disable-cleanup.js - local cleanup helpers for disabling sync.
+
+export function isSyncDisableCleanupKey(key) {
+  return !!key
+    && (key.includes('-delta-')
+      || key.includes('-sync-cutover-v2')
+      || key.includes('-relay-bytes-')
+      || key === 'labcharts-relay-quota-warned');
+}
+
+export function clearSyncDisableStorage() {
+  for (let i = localStorage.length - 1; i >= 0; i--) {
+    const key = localStorage.key(i);
+    if (key && key.endsWith('-sync-ts')) localStorage.removeItem(key);
+  }
+
+  for (let i = localStorage.length - 1; i >= 0; i--) {
+    const key = localStorage.key(i);
+    if (isSyncDisableCleanupKey(key)) localStorage.removeItem(key);
+  }
+}

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -1,6 +1,9 @@
 // sync-identity.js - BIP-39/QR loading and mnemonic restore helpers.
 
 import { loadScriptOnce, showNotification } from './utils.js';
+import {
+  clearSyncDisableStorage,
+} from './sync-disable-cleanup.js';
 
 let _bip39Load = null;
 let _qrCodeLoad = null;
@@ -71,18 +74,11 @@ export async function restoreFromMnemonic(mnemonic) {
   if (!evolu) return false;
   try {
     await evolu.restoreAppOwner(mnemonic);
-    // Clear sync timestamps + per-array delta snapshots + cutover flag.
     // After mnemonic restore, the new Evolu owner has zero rows; the old
     // delta snapshot would tell the planner "I already pushed these items",
     // leaving the new owner's relay empty. Drop snapshots so the first push
     // under the new identity re-emits everything as inserts.
-    for (let i = localStorage.length - 1; i >= 0; i--) {
-      const key = localStorage.key(i);
-      if (!key) continue;
-      if (key.endsWith('-sync-ts') || key.includes('-delta-') || key.includes('-sync-cutover-v2') || key.includes('-relay-bytes-') || key === 'labcharts-relay-quota-warned') {
-        localStorage.removeItem(key);
-      }
-    }
+    clearSyncDisableStorage();
     showNotification('Restored from mnemonic — reloading…', 'success');
     // Reload so the app re-initializes from the restored CRDT identity.
     setTimeout(() => window.location.reload(), 500);

--- a/js/sync.js
+++ b/js/sync.js
@@ -20,6 +20,9 @@ import {
   isSyncEnabled, primeSyncState, setSyncEnabled,
 } from './sync-settings-state.js';
 import {
+  clearSyncDisableStorage,
+} from './sync-disable-cleanup.js';
+import {
   configureSyncDelta, getDeltaCutoverReadiness, getDeltaTelemetry,
   resetDeltaTelemetry,
 } from './sync-delta.js';
@@ -437,12 +440,6 @@ export async function disableSync() {
   resetSyncStatus();
   renderSyncIndicator();
 
-  // Clear sync timestamps so a fresh pull can happen after re-enable
-  for (let i = localStorage.length - 1; i >= 0; i--) {
-    const key = localStorage.key(i);
-    if (key && key.endsWith('-sync-ts')) localStorage.removeItem(key);
-  }
-
   // v1.7.11 audit fix: clear per-array delta snapshots too. After a
   // re-enable (which may bring a different Evolu owner via mnemonic
   // change), the OLD snapshot would tell the planner "I already pushed
@@ -451,13 +448,7 @@ export async function disableSync() {
   // so the next push re-emits everything as inserts (relay starts
   // empty under the new owner anyway). Same for telemetry + cutover
   // flag (cutover was profile-scoped to the previous owner).
-  for (let i = localStorage.length - 1; i >= 0; i--) {
-    const key = localStorage.key(i);
-    if (!key) continue;
-    if (key.includes('-delta-') || key.includes('-sync-cutover-v2') || key.includes('-relay-bytes-') || key === 'labcharts-relay-quota-warned') {
-      localStorage.removeItem(key);
-    }
-  }
+  clearSyncDisableStorage();
 
   // Fire-and-forget the Evolu reset. We can't trust this await: if the
   // worker is hung (OPFS / lock contention), `resetAppOwner` never

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -36,7 +36,7 @@ import { getActiveProfileId } from './profile.js';
 import { getDailyRange } from './wearables-store.js';
 import { MANUAL_METRICS } from './wearables-manual.js';
 import { getChartColors } from './theme.js';
-import { ensureChartJs } from './charts.js';
+import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
 import { isoDay } from './wearables-oura.js';
 
 // ─────────────────────────────────────────────────────────
@@ -1034,7 +1034,7 @@ function _buildEMFSleepHint(metricId, m) {
 }
 
 function renderWearableChart(canvas, canon, m, series) {
-  if (!window.Chart) {
+  if (!window.Chart || !isChartDateAdapterReady()) {
     ensureChartJs().then(() => {
       const currentCanvas = document.getElementById(canvas.id);
       if (currentCanvas) renderWearableChart(currentCanvas, canon, m, series);

--- a/service-worker.js
+++ b/service-worker.js
@@ -139,6 +139,7 @@ const APP_SHELL = [
   '/js/hardware.js',
   '/js/sync.js',
   '/js/sync-settings-state.js',
+  '/js/sync-disable-cleanup.js',
   '/js/sync-apply.js',
   '/js/sync-schema.js',
   '/js/sync-delta.js',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -105,7 +105,9 @@ await import('../js/settings.js');
     serviceWorkerSrc.includes("'/js/sync-settings-state.js'"));
   assert('sync-disable-cleanup.js owns disable localStorage cleanup',
     syncSrc.includes("from './sync-disable-cleanup.js'")
+      && syncIdentitySrc.includes("from './sync-disable-cleanup.js'")
       && syncSrc.includes('clearSyncDisableStorage();')
+      && syncIdentitySrc.includes('clearSyncDisableStorage();')
       && syncDisableCleanupSrc.includes('export function clearSyncDisableStorage')
       && syncDisableCleanupSrc.includes('export function isSyncDisableCleanupKey')
       && syncDisableCleanupSrc.includes("key.endsWith('-sync-ts')")
@@ -602,11 +604,14 @@ await import('../js/settings.js');
   // ═══════════════════════════════════════
   console.log('4. Mnemonic Restore');
 
-  assert('restoreFromMnemonic clears sync-ts after success', syncIdentitySrc.includes("'-sync-ts'") && syncIdentitySrc.includes('localStorage.removeItem(key)'));
+  assert('restoreFromMnemonic clears sync-ts after success',
+    syncIdentitySrc.includes('clearSyncDisableStorage();')
+      && syncDisableCleanupSrc.includes("key.endsWith('-sync-ts')")
+      && syncDisableCleanupSrc.includes('localStorage.removeItem(key)'));
   assert('restoreFromMnemonic calls evolu.restoreAppOwner', syncIdentitySrc.includes('evolu.restoreAppOwner(mnemonic)'));
   // Verify timestamps are cleared AFTER restoreAppOwner within restoreFromMnemonic (not before)
   const restoreIdx = syncIdentitySrc.indexOf('evolu.restoreAppOwner(mnemonic)');
-  const clearTsInRestore = syncIdentitySrc.indexOf("'-sync-ts'", restoreIdx);
+  const clearTsInRestore = syncIdentitySrc.indexOf('clearSyncDisableStorage();', restoreIdx);
   assert('Sync-ts cleared after restoreAppOwner (not before)', restoreIdx > 0 && clearTsInRestore > restoreIdx,
     `restoreAppOwner at ${restoreIdx}, sync-ts clear at ${clearTsInRestore}`);
 
@@ -1525,9 +1530,11 @@ await import('../js/settings.js');
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /isSyncDisableCleanupKey[\s\S]{0,300}-sync-cutover-v2/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears delta snapshots',
-    /restoreFromMnemonic[\s\S]{0,1000}key\.includes\('-delta-'\)/.test(syncIdentitySrc));
+    /restoreFromMnemonic[\s\S]{0,1000}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+      && /isSyncDisableCleanupKey[\s\S]{0,300}key\.includes\('-delta-'\)/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears cutover flag',
-    /restoreFromMnemonic[\s\S]{0,1000}-sync-cutover-v2/.test(syncIdentitySrc));
+    /restoreFromMnemonic[\s\S]{0,1000}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+      && /isSyncDisableCleanupKey[\s\S]{0,300}-sync-cutover-v2/.test(syncDisableCleanupSrc));
 
   // Live: proto-pollution defence — verify a malicious key is rejected
   if (typeof window !== 'undefined') {
@@ -1696,9 +1703,11 @@ await import('../js/settings.js');
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /isSyncDisableCleanupKey[\s\S]{0,300}key\s*===\s*'labcharts-relay-quota-warned'/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears -relay-bytes- keys',
-    /restoreFromMnemonic[\s\S]{0,1500}key\.includes\('-relay-bytes-'\)/.test(syncIdentitySrc));
+    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+      && /isSyncDisableCleanupKey[\s\S]{0,300}key\.includes\('-relay-bytes-'\)/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears legacy global quota-warned key',
-    /restoreFromMnemonic[\s\S]{0,1500}key\s*===\s*'labcharts-relay-quota-warned'/.test(syncIdentitySrc));
+    /restoreFromMnemonic[\s\S]{0,1500}clearSyncDisableStorage\(\)/.test(syncIdentitySrc)
+      && /isSyncDisableCleanupKey[\s\S]{0,300}key\s*===\s*'labcharts-relay-quota-warned'/.test(syncDisableCleanupSrc));
 
   // P2: warned-marker key now owner-scoped
   assert('_maybeWarnQuotaThreshold uses owner-scoped warned key',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -36,6 +36,7 @@ await import('../js/settings.js');
   const syncSrc = await fetchWithRetry('js/sync.js');
   const syncApplySrc = await fetchWithRetry('js/sync-apply.js');
   const syncSettingsStateSrc = await fetchWithRetry('js/sync-settings-state.js');
+  const syncDisableCleanupSrc = await fetchWithRetry('js/sync-disable-cleanup.js');
   const syncSchemaSrc = await fetchWithRetry('js/sync-schema.js');
   const syncDeltaSrc = await fetchWithRetry('js/sync-delta.js');
   const syncTombstonesSrc = await fetchWithRetry('js/sync-tombstones.js');
@@ -102,6 +103,18 @@ await import('../js/settings.js');
       && exportBlockIncludes(syncSrc, ['isSyncEnabled', 'primeSyncState']));
   assert('service worker precaches sync-settings-state.js',
     serviceWorkerSrc.includes("'/js/sync-settings-state.js'"));
+  assert('sync-disable-cleanup.js owns disable localStorage cleanup',
+    syncSrc.includes("from './sync-disable-cleanup.js'")
+      && syncSrc.includes('clearSyncDisableStorage();')
+      && syncDisableCleanupSrc.includes('export function clearSyncDisableStorage')
+      && syncDisableCleanupSrc.includes('export function isSyncDisableCleanupKey')
+      && syncDisableCleanupSrc.includes("key.endsWith('-sync-ts')")
+      && syncDisableCleanupSrc.includes("key.includes('-delta-')")
+      && syncDisableCleanupSrc.includes("key.includes('-sync-cutover-v2')")
+      && syncDisableCleanupSrc.includes("key.includes('-relay-bytes-')")
+      && syncDisableCleanupSrc.includes("key === 'labcharts-relay-quota-warned'"));
+  assert('service worker precaches sync-disable-cleanup.js',
+    serviceWorkerSrc.includes("'/js/sync-disable-cleanup.js'"));
   assert('sync-schema.js owns Evolu schema/query helpers',
     syncSrc.includes("from './sync-schema.js'")
       && syncSchemaSrc.includes('export function createSyncSchema')
@@ -708,7 +721,8 @@ await import('../js/settings.js');
   assert('disableSync resets Evolu identity for mnemonic regeneration', syncSrc.includes('evolu.resetAppOwner('));
   assert('disableSync reloads page after reset to kill Worker', syncSrc.includes('window.location.reload()'));
   assert('disableSync clears sync timestamps',
-    /disableSync[\s\S]{0,3000}key\.endsWith\('-sync-ts'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(syncSrc));
+    disableSyncSrc.includes('clearSyncDisableStorage();')
+      && /key\.endsWith\('-sync-ts'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(syncDisableCleanupSrc));
   assert('applyChatData uses plain localStorage for thread index (matches saveChatThreadIndex)',
     syncApplySrc.includes("localStorage.setItem(threadsKey, JSON.stringify(mergedThreads))"));
 
@@ -1504,9 +1518,12 @@ await import('../js/settings.js');
 
   // Snapshot rotation on owner change
   assert('disableSync clears delta snapshots',
-    /disableSync[\s\S]{0,3000}key\.includes\('-delta-'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(deltaSearchSrc));
+    disableSyncSrc.includes('clearSyncDisableStorage();')
+      && /isSyncDisableCleanupKey[\s\S]{0,300}key\.includes\('-delta-'\)/.test(syncDisableCleanupSrc)
+      && /clearSyncDisableStorage[\s\S]{0,800}localStorage\.removeItem\(key\)/.test(syncDisableCleanupSrc));
   assert('disableSync clears cutover flag',
-    /disableSync[\s\S]{0,3000}-sync-cutover-v2/.test(deltaSearchSrc));
+    disableSyncSrc.includes('clearSyncDisableStorage();')
+      && /isSyncDisableCleanupKey[\s\S]{0,300}-sync-cutover-v2/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears delta snapshots',
     /restoreFromMnemonic[\s\S]{0,1000}key\.includes\('-delta-'\)/.test(syncIdentitySrc));
   assert('restoreFromMnemonic clears cutover flag',
@@ -1673,9 +1690,11 @@ await import('../js/settings.js');
 
   // P1: -relay-bytes- and -relay-quota-warned cleared on owner change
   assert('disableSync clears -relay-bytes- keys on owner change',
-    /disableSync[\s\S]{0,3000}key\.includes\('-relay-bytes-'\)/.test(deltaSearchSrc));
+    disableSyncSrc.includes('clearSyncDisableStorage();')
+      && /isSyncDisableCleanupKey[\s\S]{0,300}key\.includes\('-relay-bytes-'\)/.test(syncDisableCleanupSrc));
   assert('disableSync clears legacy global quota-warned key',
-    /disableSync[\s\S]{0,3000}key\s*===\s*'labcharts-relay-quota-warned'/.test(deltaSearchSrc));
+    disableSyncSrc.includes('clearSyncDisableStorage();')
+      && /isSyncDisableCleanupKey[\s\S]{0,300}key\s*===\s*'labcharts-relay-quota-warned'/.test(syncDisableCleanupSrc));
   assert('restoreFromMnemonic clears -relay-bytes- keys',
     /restoreFromMnemonic[\s\S]{0,1500}key\.includes\('-relay-bytes-'\)/.test(syncIdentitySrc));
   assert('restoreFromMnemonic clears legacy global quota-warned key',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.139';
+self.APP_VERSION = '1.8.140';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.138';
+self.APP_VERSION = '1.8.139';


### PR DESCRIPTION
## Summary
- Move disable-time sync localStorage cleanup into `js/sync-disable-cleanup.js` and delegate `disableSync()` to it.
- Reuse the same cleanup helper from mnemonic restore so owner-change cleanup key patterns stay in one place.
- Precache the new sync helper and update source-shape coverage for the new owner.
- Ensure Chart.js readiness includes the native date adapter so the wearables modal time-scale chart does not fail when `window.Chart` already exists.
- Bump `APP_VERSION` for the app-file changes.

## Validation
- `node --check js/charts.js js/wearables.js js/sync.js js/sync-disable-cleanup.js js/sync-identity.js tests/test-sync.js version.js`
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`