### PR TITLE
Extract sync subscriptions

### DIFF
--- a/js/sync-subscriptions.js
+++ b/js/sync-subscriptions.js
@@ -1,0 +1,117 @@
+// sync-subscriptions.js - Evolu subscriptions and poll safety net.
+
+let _isSyncing = () => false;
+let _isPulling = () => false;
+let _onSyncReceived = () => {};
+let _checkRelayConnection = async () => false;
+let _updateSyncStatus = () => {};
+let _debug = () => {};
+
+let _pollInterval = null;
+let _relayProbeInterval = null;
+let _lastPollRowCount = -1;
+let _lastPollTombstoneCount = -1;
+let _subscriptionFireCount = 0;
+
+export function configureSyncSubscriptions({
+  isSyncing,
+  isPulling,
+  onSyncReceived,
+  checkRelayConnection,
+  updateSyncStatus,
+  debug,
+} = {}) {
+  if (typeof isSyncing === 'function') _isSyncing = isSyncing;
+  if (typeof isPulling === 'function') _isPulling = isPulling;
+  if (typeof onSyncReceived === 'function') _onSyncReceived = onSyncReceived;
+  if (typeof checkRelayConnection === 'function') _checkRelayConnection = checkRelayConnection;
+  if (typeof updateSyncStatus === 'function') _updateSyncStatus = updateSyncStatus;
+  if (typeof debug === 'function') _debug = debug;
+}
+
+export function getSyncSubscriptionFireCount() {
+  return _subscriptionFireCount;
+}
+
+export function clearSyncSubscriptionTimers() {
+  if (_pollInterval) {
+    clearInterval(_pollInterval);
+    _pollInterval = null;
+  }
+  if (_relayProbeInterval) {
+    clearInterval(_relayProbeInterval);
+    _relayProbeInterval = null;
+  }
+  _lastPollRowCount = -1;
+  _lastPollTombstoneCount = -1;
+}
+
+function canReceiveSync() {
+  return !_isSyncing() && !_isPulling();
+}
+
+export function bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery } = {}) {
+  if (!evolu || !profileQuery || !tombstoneQuery || !itemRowQuery) return;
+
+  evolu.subscribeQuery(profileQuery)(() => {
+    _subscriptionFireCount++;
+    const syncing = _isSyncing();
+    const pulling = _isPulling();
+    _debug(`subscription fired (#${_subscriptionFireCount}), syncing: ${syncing}, pulling: ${pulling}`);
+    if (!syncing && !pulling) _onSyncReceived();
+  });
+
+  // Tombstone rows live outside profileQuery's "isDeleted is not 1"
+  // filter. Evolu refreshes subscribed queries after remote mutations,
+  // so this subscription is required for device B to see device A's
+  // profile-delete tombstone without waiting for a full reload.
+  evolu.subscribeQuery(tombstoneQuery)(() => {
+    if (canReceiveSync()) _onSyncReceived();
+  });
+
+  // itemRow rows arriving asynchronously must also retrigger the merge
+  // - without this, a per-row push from device A would only land on
+  // device B after the next blob-driven pull tick (which v1.6.4's 10s
+  // debounce stretches out). Subscribing here gives near-real-time
+  // delta propagation, which is half the point of Phase 1.
+  evolu.subscribeQuery(itemRowQuery)(() => {
+    if (canReceiveSync()) _onSyncReceived();
+  });
+
+  clearSyncSubscriptionTimers();
+  // Poll every 30s as safety net - subscribeQuery may miss remote changes.
+  _pollInterval = setInterval(() => {
+    if (!evolu || !profileQuery || !tombstoneQuery || !canReceiveSync()) return;
+    const rows = evolu.getQueryRows(profileQuery);
+    const tombstones = evolu.getQueryRows(tombstoneQuery);
+    const count = rows?.length ?? 0;
+    const tombstoneCount = tombstones?.length ?? 0;
+    if (count !== _lastPollRowCount || tombstoneCount !== _lastPollTombstoneCount) {
+      _debug(`poll: row/tombstone count changed ${_lastPollRowCount}/${_lastPollTombstoneCount} -> ${count}/${tombstoneCount}, triggering onSyncReceived`);
+      _lastPollRowCount = count;
+      _lastPollTombstoneCount = tombstoneCount;
+      _onSyncReceived();
+    }
+  }, 30000);
+
+  // Subscribe to Evolu errors - catches relay connection failures.
+  evolu.subscribeError((error) => {
+    if (!error) return;
+    const type = error?.type || 'unknown';
+    _debug('Evolu error:', type);
+    if (type.startsWith('WebSocket')) {
+      _updateSyncStatus({ relay: 'unreachable', lastError: { type, message: type, at: Date.now() } });
+    }
+  });
+}
+
+export function startRelayProbe() {
+  _checkRelayConnection().then(ok => {
+    _updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
+  });
+  if (_relayProbeInterval) clearInterval(_relayProbeInterval);
+  _relayProbeInterval = setInterval(async () => {
+    const ok = await _checkRelayConnection();
+    _updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
+  }, 60000);
+}

--- a/js/sync-subscriptions.js
+++ b/js/sync-subscriptions.js
@@ -44,6 +44,7 @@ export function clearSyncSubscriptionTimers() {
   }
   _lastPollRowCount = -1;
   _lastPollTombstoneCount = -1;
+  _subscriptionFireCount = 0;
 }
 
 function canReceiveSync() {
@@ -52,6 +53,8 @@ function canReceiveSync() {
 
 export function bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery } = {}) {
   if (!evolu || !profileQuery || !tombstoneQuery || !itemRowQuery) return;
+
+  clearSyncSubscriptionTimers();
 
   evolu.subscribeQuery(profileQuery)(() => {
     _subscriptionFireCount++;
@@ -78,7 +81,6 @@ export function bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, ite
     if (canReceiveSync()) _onSyncReceived();
   });
 
-  clearSyncSubscriptionTimers();
   // Poll every 30s as safety net - subscribeQuery may miss remote changes.
   _pollInterval = setInterval(() => {
     if (!evolu || !profileQuery || !tombstoneQuery || !canReceiveSync()) return;
@@ -105,13 +107,26 @@ export function bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, ite
   });
 }
 
-export function startRelayProbe() {
-  _checkRelayConnection().then(ok => {
-    _updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
+async function runRelayProbe() {
+  const ok = await _checkRelayConnection();
+  _updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
+}
+
+function onRelayProbeError(error) {
+  const message = error?.message || String(error);
+  const at = Date.now();
+  _debug('relay probe error:', error);
+  _updateSyncStatus({
+    relay: 'unreachable',
+    relayCheckedAt: at,
+    lastError: { type: 'RelayProbeError', message, at },
   });
+}
+
+export function startRelayProbe() {
+  runRelayProbe().catch(onRelayProbeError);
   if (_relayProbeInterval) clearInterval(_relayProbeInterval);
-  _relayProbeInterval = setInterval(async () => {
-    const ok = await _checkRelayConnection();
-    _updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
+  _relayProbeInterval = setInterval(() => {
+    runRelayProbe().catch(onRelayProbeError);
   }, 60000);
 }

--- a/js/sync.js
+++ b/js/sync.js
@@ -75,6 +75,10 @@ import {
   clearSyncPullTimers, configureSyncPull, forcePull as _forcePull,
   isSyncPulling, onSyncReceived,
 } from './sync-pull.js';
+import {
+  bindSyncSubscriptions, clearSyncSubscriptionTimers, configureSyncSubscriptions,
+  getSyncSubscriptionFireCount, startRelayProbe,
+} from './sync-subscriptions.js';
 
 export {
   compactOwnerSelfServe, fetchOwnerStorageFromRelay, getRelayHealthVerdict,
@@ -119,11 +123,6 @@ let _appOwner = null;
 let _appOwnerError = null;
 let _readyPromise = null;
 let _queryLoaded = null;
-let _pollInterval = null;
-let _lastPollRowCount = -1;
-let _lastPollTombstoneCount = -1;
-let _subscriptionFireCount = 0;
-let _relayProbeInterval = null;
 
 configureSyncDelta({
   getEvolu: () => evolu,
@@ -144,6 +143,15 @@ configureSyncPull({
   getProfileQuery: () => profileQuery,
   isSyncPushInFlight,
   pushProfile,
+  debug: dbg,
+});
+
+configureSyncSubscriptions({
+  isSyncing: isSyncPushInFlight,
+  isPulling: isSyncPulling,
+  onSyncReceived,
+  checkRelayConnection,
+  updateSyncStatus,
   debug: dbg,
 });
 
@@ -173,7 +181,7 @@ configureSyncDiagnostics({
   getTombstoneQuery: () => tombstoneQuery,
   getAppOwner: () => _appOwner,
   isSyncEnabled,
-  getSubscriptionFireCount: () => _subscriptionFireCount,
+  getSubscriptionFireCount: getSyncSubscriptionFireCount,
   isSyncing: isSyncPushInFlight,
   isPulling: isSyncPulling,
 });
@@ -260,29 +268,7 @@ export async function initSync() {
 
     ({ profileQuery, tombstoneQuery, itemRowQuery } = createSyncQueries(evolu));
 
-    // Subscribe to sync updates
-    evolu.subscribeQuery(profileQuery)(() => {
-      _subscriptionFireCount++;
-      const syncing = isSyncPushInFlight();
-      const pulling = isSyncPulling();
-      dbg(`subscription fired (#${_subscriptionFireCount}), syncing: ${syncing}, pulling: ${pulling}`);
-      if (!syncing && !pulling) onSyncReceived();
-    });
-    // Tombstone rows live outside profileQuery's "isDeleted is not 1"
-    // filter. Evolu refreshes subscribed queries after remote mutations,
-    // so this subscription is required for device B to see device A's
-    // profile-delete tombstone without waiting for a full reload.
-    evolu.subscribeQuery(tombstoneQuery)(() => {
-      if (!isSyncPushInFlight() && !isSyncPulling()) onSyncReceived();
-    });
-    // itemRow rows arriving asynchronously must also retrigger the merge
-    // — without this, a per-row push from device A would only land on
-    // device B after the next blob-driven pull tick (which v1.6.4's 10s
-    // debounce stretches out). Subscribing here gives near-real-time
-    // delta propagation, which is half the point of Phase 1.
-    evolu.subscribeQuery(itemRowQuery)(() => {
-      if (!isSyncPushInFlight() && !isSyncPulling()) onSyncReceived();
-    });
+    bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery });
 
     // Load initial data — store promise for enableSync to await
     _queryLoaded = Promise.all([
@@ -323,39 +309,8 @@ export async function initSync() {
       };
     }
 
-    // Poll every 30s as safety net — subscribeQuery may miss remote changes
-    _pollInterval = setInterval(() => {
-      if (!evolu || !profileQuery || !tombstoneQuery || isSyncPushInFlight() || isSyncPulling()) return;
-      const rows = evolu.getQueryRows(profileQuery);
-      const tombstones = evolu.getQueryRows(tombstoneQuery);
-      const count = rows?.length ?? 0;
-      const tombstoneCount = tombstones?.length ?? 0;
-      if (count !== _lastPollRowCount || tombstoneCount !== _lastPollTombstoneCount) {
-        dbg(`poll: row/tombstone count changed ${_lastPollRowCount}/${_lastPollTombstoneCount} -> ${count}/${tombstoneCount}, triggering onSyncReceived`);
-        _lastPollRowCount = count;
-        _lastPollTombstoneCount = tombstoneCount;
-        onSyncReceived();
-      }
-    }, 30000);
-
-    // Subscribe to Evolu errors — catches relay connection failures
-    evolu.subscribeError((error) => {
-      if (!error) return;
-      const type = error?.type || 'unknown';
-      dbg('Evolu error:', type);
-      if (type.startsWith('WebSocket')) {
-        updateSyncStatus({ relay: 'unreachable', lastError: { type, message: type, at: Date.now() } });
-      }
-    });
-
     // Initial relay probe + periodic 60s health check
-    checkRelayConnection().then(ok => {
-      updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
-    });
-    _relayProbeInterval = setInterval(async () => {
-      const ok = await checkRelayConnection();
-      updateSyncStatus({ relay: ok ? 'connected' : 'unreachable', relayCheckedAt: Date.now() });
-    }, 60000);
+    startRelayProbe();
 
     bindSyncRecoveryEvents();
 
@@ -433,10 +388,9 @@ export async function disableSync() {
   _appOwnerError = null;
 
   // Stop background timers + reset status (UI feedback before the reload)
-  if (_relayProbeInterval) { clearInterval(_relayProbeInterval); _relayProbeInterval = null; }
   clearSyncActionTimers();
   clearSyncPullTimers();
-  if (_pollInterval) { clearInterval(_pollInterval); _pollInterval = null; }
+  clearSyncSubscriptionTimers();
   resetSyncStatus();
   renderSyncIndicator();
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -154,6 +154,7 @@ const APP_SHELL = [
   '/js/sync-recovery.js',
   '/js/sync-reconcile.js',
   '/js/sync-pull.js',
+  '/js/sync-subscriptions.js',
   '/js/sync-cutover.js',
   '/js/sync-ui.js',
   '/js/sync-payload.js',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -50,6 +50,7 @@ await import('../js/settings.js');
   const syncRecoverySrc = await fetchWithRetry('js/sync-recovery.js');
   const syncReconcileSrc = await fetchWithRetry('js/sync-reconcile.js');
   const syncPullSrc = await fetchWithRetry('js/sync-pull.js');
+  const syncSubscriptionsSrc = await fetchWithRetry('js/sync-subscriptions.js');
   const syncCutoverSrc = await fetchWithRetry('js/sync-cutover.js');
   const profileSrc = await fetchWithRetry('js/profile.js');
   const syncUiSrc = await fetchWithRetry('js/sync-ui.js');
@@ -237,7 +238,7 @@ await import('../js/settings.js');
       && syncPushSrc.includes('export function configureSyncPush')
       && syncPushSrc.includes('export function isSyncPushInFlight')
       && syncPushSrc.includes('export async function pushProfile')
-      && syncSrc.includes('isSyncPushInFlight()')
+      && syncSrc.includes('isSyncing: isSyncPushInFlight')
       && syncSrc.includes('configureSyncPush({'));
   assert('service worker precaches sync-push.js',
     serviceWorkerSrc.includes("'/js/sync-push.js'"));
@@ -270,6 +271,25 @@ await import('../js/settings.js');
       && syncSrc.includes('configureSyncPull({'));
   assert('service worker precaches sync-pull.js',
     serviceWorkerSrc.includes("'/js/sync-pull.js'"));
+  assert('sync-subscriptions.js owns Evolu subscription and polling helpers',
+    syncSrc.includes("from './sync-subscriptions.js'")
+      && syncSubscriptionsSrc.includes('export function configureSyncSubscriptions')
+      && syncSubscriptionsSrc.includes('export function bindSyncSubscriptions')
+      && syncSubscriptionsSrc.includes('export function clearSyncSubscriptionTimers')
+      && syncSubscriptionsSrc.includes('export function getSyncSubscriptionFireCount')
+      && syncSubscriptionsSrc.includes('export function startRelayProbe')
+      && syncSubscriptionsSrc.includes('evolu.subscribeQuery(profileQuery)')
+      && syncSubscriptionsSrc.includes('evolu.subscribeQuery(tombstoneQuery)')
+      && syncSubscriptionsSrc.includes('evolu.subscribeQuery(itemRowQuery)')
+      && syncSubscriptionsSrc.includes('evolu.subscribeError')
+      && syncSubscriptionsSrc.includes('setInterval')
+      && syncSubscriptionsSrc.includes('_checkRelayConnection()')
+      && syncSrc.includes('bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery })')
+      && syncSrc.includes('startRelayProbe();')
+      && syncSrc.includes('clearSyncSubscriptionTimers();')
+      && syncSrc.includes('getSubscriptionFireCount: getSyncSubscriptionFireCount'));
+  assert('service worker precaches sync-subscriptions.js',
+    serviceWorkerSrc.includes("'/js/sync-subscriptions.js'"));
   assert('sync-cutover.js owns Phase 2 cutover flag actions',
     syncSrc.includes("from './sync-cutover.js'")
       && syncCutoverSrc.includes('export { isPhase2CutoverEnabled }')
@@ -325,10 +345,10 @@ await import('../js/settings.js');
   assert('sync-schema.js declares a tombstoneQuery selecting isDeleted = 1 rows',
     /tombstoneQuery\s*=\s*evolu\.createQuery[\s\S]{0,300}isDeleted[",\s]+=[",\s]+1/.test(syncSchemaSrc));
   assert('tombstoneQuery subscription retriggers onSyncReceived',
-    /evolu\.subscribeQuery\(tombstoneQuery\)\([\s\S]{0,250}onSyncReceived\(\)/.test(syncSrc));
+    /evolu\.subscribeQuery\(tombstoneQuery\)\([\s\S]{0,250}_onSyncReceived\(\)/.test(syncSubscriptionsSrc));
   assert('poll safety tracks tombstone count as well as live rows',
-    syncSrc.includes('_lastPollTombstoneCount')
-      && /getQueryRows\(tombstoneQuery\)[\s\S]{0,300}tombstoneCount/.test(syncSrc));
+    syncSubscriptionsSrc.includes('_lastPollTombstoneCount')
+      && /getQueryRows\(tombstoneQuery\)[\s\S]{0,300}tombstoneCount/.test(syncSubscriptionsSrc));
   assert('Sync diagnose includes tombstone rows and deleted-state column',
     /tombstoneRows[\s\S]{0,300}isDeleted:\s*true/.test(syncDiagnosticsSrc)
       && syncDiagnoseUiSrc.includes('<th style="padding:4px 8px;text-align:right">deleted</th>'));
@@ -483,7 +503,7 @@ await import('../js/settings.js');
   assert('itemRowQuery loaded with profileQuery + tombstoneQuery',
     /Promise\.all\(\[[\s\S]{0,400}evolu\.loadQuery\(itemRowQuery\)/.test(syncSrc));
   assert('itemRow subscription retriggers onSyncReceived',
-    /evolu\.subscribeQuery\(itemRowQuery\)\([\s\S]{0,200}onSyncReceived\(\)/.test(syncSrc));
+    /evolu\.subscribeQuery\(itemRowQuery\)\([\s\S]{0,200}_onSyncReceived\(\)/.test(syncSubscriptionsSrc));
 
   // DELTA_ARRAYS list (high-velocity arrays)
   assert('DELTA_ARRAYS includes sunSessions + lightDevices',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -284,6 +284,8 @@ await import('../js/settings.js');
       && syncSubscriptionsSrc.includes('evolu.subscribeError')
       && syncSubscriptionsSrc.includes('setInterval')
       && syncSubscriptionsSrc.includes('_checkRelayConnection()')
+      && syncSubscriptionsSrc.includes('_subscriptionFireCount = 0')
+      && syncSubscriptionsSrc.includes('.catch(onRelayProbeError)')
       && syncSrc.includes('bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery })')
       && syncSrc.includes('startRelayProbe();')
       && syncSrc.includes('clearSyncSubscriptionTimers();')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.141';
+self.APP_VERSION = '1.8.142';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.140';
+self.APP_VERSION = '1.8.141';


### PR DESCRIPTION
## Summary
- Move Evolu query subscriptions, tombstone/item-row retriggers, poll safety, relay error handling, and relay probing into `js/sync-subscriptions.js`
- Keep `sync.js` focused on orchestration/configuration for the next refactor step
- Precache the new sync module, bump `APP_VERSION`, and update sync source-shape coverage

## Validation
- `node --check js/sync.js`
- `node --check js/sync-subscriptions.js`
- `node --check tests/test-sync.js`
- `node --check service-worker.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`