### PR TITLE
Extract sync window bindings

### DIFF
--- a/js/sync-window-bindings.js
+++ b/js/sync-window-bindings.js
@@ -1,0 +1,101 @@
+// sync-window-bindings.js - Browser global sync actions.
+
+import {
+  compactOwnerSelfServe, fetchOwnerStorageFromRelay, getRelayHealthVerdict,
+  getRelayQuotaEstimate, resetRelayQuotaEstimate, verifyPushLanded,
+} from './sync-relay-health.js';
+import {
+  getDeltaCutoverReadiness, getDeltaTelemetry, resetDeltaTelemetry,
+} from './sync-delta.js';
+import {
+  applyPendingTombstone, deleteProfileFromRelay, listPendingTombstones,
+  rejectPendingTombstone,
+} from './sync-tombstones.js';
+import {
+  generateMessengerToken, getMessengerToken, isMessengerEnabled,
+  pushContextToGateway, revokeMessengerToken,
+} from './sync-messenger.js';
+import {
+  checkRelayConnection, getSyncBlocker,
+} from './sync-environment.js';
+import {
+  getMnemonic, getMnemonicResolutionError, restoreFromMnemonic,
+} from './sync-identity.js';
+import {
+  isSyncEnabled,
+} from './sync-settings-state.js';
+import {
+  _syncDiag,
+} from './sync-diagnostics.js';
+import {
+  copySyncEvents, renderSyncIndicator, toggleSyncDetail, updateSyncIndicator,
+} from './sync-ui.js';
+import {
+  confirmBackfillBlockers, confirmCompactRelay, confirmDisablePhase2,
+  confirmEnablePhase2, confirmResetDeltaTelemetry, confirmRotateIdentity,
+  copySyncDiagnose, refreshRelayStorage, showSyncDiagnose,
+} from './sync-diagnose-ui.js';
+import {
+  cleanStorage, forceResendCurrentProfile, pushCurrentProfile, syncNow,
+} from './sync-actions.js';
+import {
+  forcePull,
+} from './sync-pull.js';
+import {
+  disablePhase2Cutover, enablePhase2Cutover, isPhase2CutoverEnabled,
+} from './sync-cutover.js';
+
+export function bindSyncWindowActions({ enableSync, disableSync } = {}) {
+  if (typeof window === 'undefined') return;
+
+  Object.assign(window, {
+    enableSync,
+    disableSync,
+    getMnemonic,
+    getMnemonicResolutionError,
+    getSyncBlocker,
+    restoreFromMnemonic,
+    isSyncEnabled,
+    pushCurrentProfile,
+    forceResendCurrentProfile,
+    cleanStorage,
+    syncNow,
+    showSyncDiagnose,
+    deleteProfileFromRelay,
+    listPendingTombstones,
+    applyPendingTombstone,
+    rejectPendingTombstone,
+    checkRelayConnection,
+    isMessengerEnabled,
+    getMessengerToken,
+    generateMessengerToken,
+    revokeMessengerToken,
+    pushContextToGateway,
+    _syncDiag,
+    _forcePull: forcePull,
+    renderSyncIndicator,
+    updateSyncIndicator,
+    toggleSyncDetail,
+    copySyncEvents,
+    copySyncDiagnose,
+    confirmCompactRelay,
+    confirmRotateIdentity,
+    refreshRelayStorage,
+    fetchOwnerStorageFromRelay,
+    verifyPushLanded,
+    getRelayHealthVerdict,
+    compactOwnerSelfServe,
+    getRelayQuotaEstimate,
+    resetRelayQuotaEstimate,
+    getDeltaTelemetry,
+    resetDeltaTelemetry,
+    confirmResetDeltaTelemetry,
+    getDeltaCutoverReadiness,
+    isPhase2CutoverEnabled,
+    enablePhase2Cutover,
+    disablePhase2Cutover,
+    confirmEnablePhase2,
+    confirmDisablePhase2,
+    confirmBackfillBlockers,
+  });
+}

--- a/js/sync.js
+++ b/js/sync.js
@@ -42,7 +42,7 @@ import {
   restoreFromMnemonic,
 } from './sync-identity.js';
 import {
-  _syncDiag, configureSyncDiagnostics, getEvoluDiagnostics,
+  configureSyncDiagnostics, getEvoluDiagnostics,
 } from './sync-diagnostics.js';
 import {
   bindSyncUIStatusUpdates, configureSyncUI, copySyncEvents,
@@ -79,6 +79,9 @@ import {
   bindSyncSubscriptions, clearSyncSubscriptionTimers, configureSyncSubscriptions,
   getSyncSubscriptionFireCount, startRelayProbe,
 } from './sync-subscriptions.js';
+import {
+  bindSyncWindowActions,
+} from './sync-window-bindings.js';
 
 export {
   compactOwnerSelfServe, fetchOwnerStorageFromRelay, getRelayHealthVerdict,
@@ -431,57 +434,4 @@ export async function disableSync() {
   setTimeout(() => window.location.reload(), 250);
 }
 
-// ═══════════════════════════════════════════════
-// EXPORTS for window binding
-// ═══════════════════════════════════════════════
-
-Object.assign(window, {
-  enableSync,
-  disableSync,
-  getMnemonic,
-  getMnemonicResolutionError,
-  getSyncBlocker,
-  restoreFromMnemonic,
-  isSyncEnabled,
-  pushCurrentProfile,
-  forceResendCurrentProfile,
-  cleanStorage,
-  syncNow,
-  showSyncDiagnose,
-  deleteProfileFromRelay,
-  listPendingTombstones,
-  applyPendingTombstone,
-  rejectPendingTombstone,
-  checkRelayConnection,
-  isMessengerEnabled,
-  getMessengerToken,
-  generateMessengerToken,
-  revokeMessengerToken,
-  pushContextToGateway,
-  _syncDiag,
-  _forcePull,
-  renderSyncIndicator,
-  updateSyncIndicator,
-  toggleSyncDetail,
-  copySyncEvents,
-  copySyncDiagnose,
-  confirmCompactRelay,
-  confirmRotateIdentity,
-  refreshRelayStorage,
-  fetchOwnerStorageFromRelay,
-  verifyPushLanded,
-  getRelayHealthVerdict,
-  compactOwnerSelfServe,
-  getRelayQuotaEstimate,
-  resetRelayQuotaEstimate,
-  getDeltaTelemetry,
-  resetDeltaTelemetry,
-  confirmResetDeltaTelemetry,
-  getDeltaCutoverReadiness,
-  isPhase2CutoverEnabled,
-  enablePhase2Cutover,
-  disablePhase2Cutover,
-  confirmEnablePhase2,
-  confirmDisablePhase2,
-  confirmBackfillBlockers,
-});
+bindSyncWindowActions({ enableSync, disableSync });

--- a/service-worker.js
+++ b/service-worker.js
@@ -155,6 +155,7 @@ const APP_SHELL = [
   '/js/sync-reconcile.js',
   '/js/sync-pull.js',
   '/js/sync-subscriptions.js',
+  '/js/sync-window-bindings.js',
   '/js/sync-cutover.js',
   '/js/sync-ui.js',
   '/js/sync-payload.js',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -25,8 +25,8 @@ function assert(name, condition, detail) {
 
 console.log('=== Cross-Device Sync Tests ===\n');
 
-// Load sync.js + settings.js so their Object.assign(window, ...) calls
-// populate window.enableSync, window.toggleSync, etc.
+// Load sync.js + settings.js so their window bindings populate
+// window.enableSync, window.toggleSync, etc.
 const { state } = await import('../js/state.js');
 const syncApply = await import('../js/sync-apply.js');
 const syncDelta = await import('../js/sync-delta.js');
@@ -51,6 +51,7 @@ await import('../js/settings.js');
   const syncReconcileSrc = await fetchWithRetry('js/sync-reconcile.js');
   const syncPullSrc = await fetchWithRetry('js/sync-pull.js');
   const syncSubscriptionsSrc = await fetchWithRetry('js/sync-subscriptions.js');
+  const syncWindowBindingsSrc = await fetchWithRetry('js/sync-window-bindings.js');
   const syncCutoverSrc = await fetchWithRetry('js/sync-cutover.js');
   const profileSrc = await fetchWithRetry('js/profile.js');
   const syncUiSrc = await fetchWithRetry('js/sync-ui.js');
@@ -63,7 +64,7 @@ await import('../js/settings.js');
   const stylesSrc = await fetchWithRetry('styles.css');
   const themeExtraSrc = await fetchWithRetry('themes-extra.css');
   const serviceWorkerSrc = await fetchWithRetry('service-worker.js');
-  const deltaSearchSrc = `${syncSrc}\n${syncPushSrc}\n${syncReconcileSrc}\n${syncPullSrc}\n${syncCutoverSrc}\n${syncDeltaSrc}\n${syncDiagnosticsSrc}\n${syncDiagnoseUiSrc}`;
+  const deltaSearchSrc = `${syncSrc}\n${syncPushSrc}\n${syncReconcileSrc}\n${syncPullSrc}\n${syncCutoverSrc}\n${syncDeltaSrc}\n${syncDiagnosticsSrc}\n${syncDiagnoseUiSrc}\n${syncWindowBindingsSrc}`;
   const exportBlockIncludes = (src, names) => [...src.matchAll(/export\s+\{([^}]*)\};/g)]
     .some(([, block]) => names.every(name => new RegExp(`\\b${name}\\b`).test(block)));
 
@@ -292,6 +293,15 @@ await import('../js/settings.js');
       && syncSrc.includes('getSubscriptionFireCount: getSyncSubscriptionFireCount'));
   assert('service worker precaches sync-subscriptions.js',
     serviceWorkerSrc.includes("'/js/sync-subscriptions.js'"));
+  assert('sync-window-bindings.js owns browser global sync actions',
+    syncSrc.includes("from './sync-window-bindings.js'")
+      && syncWindowBindingsSrc.includes('export function bindSyncWindowActions')
+      && syncWindowBindingsSrc.includes('Object.assign(window')
+      && syncWindowBindingsSrc.includes('_forcePull: forcePull')
+      && syncWindowBindingsSrc.includes('confirmBackfillBlockers')
+      && syncSrc.includes('bindSyncWindowActions({ enableSync, disableSync });'));
+  assert('service worker precaches sync-window-bindings.js',
+    serviceWorkerSrc.includes("'/js/sync-window-bindings.js'"));
   assert('sync-cutover.js owns Phase 2 cutover flag actions',
     syncSrc.includes("from './sync-cutover.js'")
       && syncCutoverSrc.includes('export { isPhase2CutoverEnabled }')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.142';
+self.APP_VERSION = '1.8.143';


### PR DESCRIPTION
## Summary
- Move the sync browser-global `window` binding surface into `js/sync-window-bindings.js`
- Leave `sync.js` responsible for lifecycle/orchestration and call the binding module with `enableSync` / `disableSync`
- Precache the new module, bump `APP_VERSION`, and update sync source-shape coverage

## Validation
- `node --check js/sync.js`
- `node --check js/sync-window-bindings.js`
- `node --check tests/test-sync.js`
- `node --check service-worker.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`