### PR TITLE
Extract sync runtime init

### DIFF
--- a/js/sync-init.js
+++ b/js/sync-init.js
@@ -1,0 +1,123 @@
+// sync-init.js - Evolu initialization and startup reconciliation.
+
+import { isDebugMode } from './utils.js';
+import { createSyncQueries, createSyncSchema } from './sync-schema.js';
+import { getSyncBlocker, getSyncRelay } from './sync-environment.js';
+import { primeSyncState, setSyncEnabled } from './sync-settings-state.js';
+import { bindSyncRecoveryEvents } from './sync-recovery.js';
+import { reconcileLocalStorageWithEvolu } from './sync-reconcile.js';
+import { bindSyncSubscriptions, startRelayProbe } from './sync-subscriptions.js';
+import {
+  getSyncAppOwner, getSyncEvolu, setSyncAppOwner, setSyncAppOwnerError,
+  setSyncEvolu, setSyncQueries, setSyncQueryLoadedPromise,
+  setSyncReadyPromise,
+} from './sync-runtime.js';
+
+function dbg(...args) { if (isDebugMode()) console.log('[sync]', ...args); }
+
+export async function initSync() {
+  if (!primeSyncState()) return;
+
+  // Fail fast if the webview doesn't have what Evolu needs. Otherwise the
+  // worker hangs forever on appOwner and the toggle/restore flow looks
+  // mysteriously broken - exactly the rabbit hole we just spent an hour in.
+  const blocker = getSyncBlocker();
+  if (blocker) {
+    setSyncAppOwnerError(blocker);
+    console.warn('[sync] Cannot init:', blocker);
+    return;
+  }
+
+  // Re-entrancy guard - don't create duplicate Evolu instances.
+  if (getSyncEvolu()) return;
+
+  // Defer to next microtask - Worker + navigator.locks can race during DOMContentLoaded.
+  await new Promise(r => setTimeout(r, 0));
+
+  try {
+    const { createEvolu, id, nullOr, SimpleName, NonEmptyString, evoluWebDeps } =
+      await import('../vendor/evolu/evolu-bundle.js');
+
+    const Schema = createSyncSchema({ id, nullOr, NonEmptyString });
+
+    const relay = getSyncRelay();
+    const evolu = createEvolu(evoluWebDeps)(Schema, {
+      name: SimpleName.orThrow("getbased4"),
+      reloadUrl: window.location.pathname,
+      enableLogging: isDebugMode(),
+      transports: [{ type: "WebSocket", url: relay }],
+    });
+    setSyncEvolu(evolu);
+
+    const { profileQuery, tombstoneQuery, itemRowQuery } = createSyncQueries(evolu);
+    setSyncQueries({ profileQuery, tombstoneQuery, itemRowQuery });
+
+    bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery });
+
+    // Load initial data - store promise for enableSync to await.
+    const queryLoaded = Promise.all([
+      evolu.loadQuery(profileQuery),
+      evolu.loadQuery(tombstoneQuery),
+      evolu.loadQuery(itemRowQuery),
+    ]).then(() => {
+      dbg('Initial queries loaded');
+    }).catch(e => {
+      console.warn('[sync] Query load failed:', e);
+    });
+    setSyncQueryLoadedPromise(queryLoaded);
+
+    // Wait for owner (mnemonic) - signals DB is ready.
+    const readyPromise = evolu.appOwner.then(owner => {
+      setSyncAppOwner(owner);
+      setSyncAppOwnerError(null);
+      dbg('Owner resolved');
+    }).catch(e => {
+      // Don't silently swallow - Settings > Data shows "Resolving..." while
+      // appOwner is null and there's no other signal the user gets. We
+      // stash the message so the UI can surface it instead of timing out
+      // after 30s with the unhelpful "Could not resolve mnemonic".
+      setSyncAppOwnerError(e?.message || String(e));
+      console.warn('[sync] Owner resolution failed:', e);
+    });
+    setSyncReadyPromise(readyPromise);
+
+    // Debug helper. Gated on isDebugMode() - earlier versions exposed this
+    // unconditionally, which leaked the BIP-39 mnemonic to anyone with
+    // console access (screen-share, malicious extension, MCP evaluate_script
+    // capability). The mnemonic decrypts every Evolu blob ever pushed to
+    // the relay, so this had to be opt-in. Toggle Settings > Privacy >
+    // Debug mode to expose.
+    if (isDebugMode?.()) {
+      window._syncDebug = {
+        getRows: () => evolu.getQueryRows(profileQuery),
+        getOwner: () => getSyncAppOwner(),
+        evolu,
+      };
+    }
+
+    // Initial relay probe + periodic 60s health check.
+    startRelayProbe();
+
+    bindSyncRecoveryEvents();
+
+    dbg('Initialized, relay:', relay);
+
+    // Startup reconciliation - handles the case where state.importedData
+    // (loaded fresh from localStorage on this page-load) has rows that
+    // the local Evolu DB row's dataJson doesn't have. This happens when
+    // a previous session's pushProfile got wedged (Evolu's onComplete
+    // never fired, _syncing stayed true until the watchdog), so saves
+    // landed in localStorage but never reached Evolu's CRDT log. Fix:
+    // detect the divergence after init + force-push so the row catches
+    // up. Defer until after appOwner + initial query both load - those
+    // are async and the CRDT row doesn't exist until then.
+    Promise.all([readyPromise, queryLoaded]).then(() => {
+      reconcileLocalStorageWithEvolu().catch(e => {
+        console.warn('[sync] Startup reconciliation failed:', e);
+      });
+    });
+  } catch (e) {
+    console.error('[sync] Failed to initialize Evolu:', e);
+    setSyncEnabled(false, { persist: false });
+  }
+}

--- a/js/sync-runtime.js
+++ b/js/sync-runtime.js
@@ -1,0 +1,57 @@
+// sync-runtime.js - Mutable Evolu runtime handles shared by sync modules.
+
+let _evolu = null;
+let _profileQuery = null;
+let _tombstoneQuery = null;
+let _itemRowQuery = null;
+let _appOwner = null;
+let _appOwnerError = null;
+let _readyPromise = null;
+let _queryLoadedPromise = null;
+
+export function getSyncEvolu() { return _evolu; }
+export function getSyncProfileQuery() { return _profileQuery; }
+export function getSyncTombstoneQuery() { return _tombstoneQuery; }
+export function getSyncItemRowQuery() { return _itemRowQuery; }
+export function getSyncAppOwner() { return _appOwner; }
+export function getSyncAppOwnerError() { return _appOwnerError; }
+export function getSyncReadyPromise() { return _readyPromise; }
+export function getSyncQueryLoadedPromise() { return _queryLoadedPromise; }
+export function isSyncEvoluReady() { return !!_evolu; }
+
+export function setSyncEvolu(evolu) {
+  _evolu = evolu;
+}
+
+export function setSyncQueries({ profileQuery, tombstoneQuery, itemRowQuery } = {}) {
+  _profileQuery = profileQuery || null;
+  _tombstoneQuery = tombstoneQuery || null;
+  _itemRowQuery = itemRowQuery || null;
+}
+
+export function setSyncAppOwner(owner) {
+  _appOwner = owner || null;
+}
+
+export function setSyncAppOwnerError(error) {
+  _appOwnerError = error || null;
+}
+
+export function setSyncReadyPromise(promise) {
+  _readyPromise = promise || null;
+}
+
+export function setSyncQueryLoadedPromise(promise) {
+  _queryLoadedPromise = promise || null;
+}
+
+export function clearSyncRuntimeState() {
+  _evolu = null;
+  _profileQuery = null;
+  _tombstoneQuery = null;
+  _itemRowQuery = null;
+  _appOwner = null;
+  _appOwnerError = null;
+  _readyPromise = null;
+  _queryLoadedPromise = null;
+}

--- a/js/sync-runtime.js
+++ b/js/sync-runtime.js
@@ -24,25 +24,25 @@ export function setSyncEvolu(evolu) {
 }
 
 export function setSyncQueries({ profileQuery, tombstoneQuery, itemRowQuery } = {}) {
-  _profileQuery = profileQuery || null;
-  _tombstoneQuery = tombstoneQuery || null;
-  _itemRowQuery = itemRowQuery || null;
+  _profileQuery = profileQuery ?? null;
+  _tombstoneQuery = tombstoneQuery ?? null;
+  _itemRowQuery = itemRowQuery ?? null;
 }
 
 export function setSyncAppOwner(owner) {
-  _appOwner = owner || null;
+  _appOwner = owner ?? null;
 }
 
 export function setSyncAppOwnerError(error) {
-  _appOwnerError = error || null;
+  _appOwnerError = error ?? null;
 }
 
 export function setSyncReadyPromise(promise) {
-  _readyPromise = promise || null;
+  _readyPromise = promise ?? null;
 }
 
 export function setSyncQueryLoadedPromise(promise) {
-  _queryLoadedPromise = promise || null;
+  _queryLoadedPromise = promise ?? null;
 }
 
 export function clearSyncRuntimeState() {

--- a/js/sync.js
+++ b/js/sync.js
@@ -2,16 +2,12 @@
 // Stores importedData + profile metadata per profile as a JSON blob.
 // Last-write-wins at the profile level — fine for single-user cross-device sync.
 
-import { state } from './state.js';
 import { showNotification, isDebugMode } from './utils.js';
 import {
   compactOwnerSelfServe, configureRelayHealth, fetchOwnerStorageFromRelay,
   getRelayHealthVerdict, getRelayQuotaEstimate,
   resetRelayQuotaEstimate, verifyPushLanded,
 } from './sync-relay-health.js';
-import {
-  createSyncQueries, createSyncSchema,
-} from './sync-schema.js';
 import {
   getRecentSyncEvents, logSyncEvent, resetSyncStatus,
   subscribeSyncStatus, updateSyncStatus,
@@ -62,11 +58,9 @@ import {
 import {
   configureSyncPush, isSyncPushInFlight, pushProfile,
 } from './sync-push.js';
+import { configureSyncRecovery } from './sync-recovery.js';
 import {
-  bindSyncRecoveryEvents, configureSyncRecovery,
-} from './sync-recovery.js';
-import {
-  configureSyncReconcile, reconcileLocalStorageWithEvolu,
+  configureSyncReconcile,
 } from './sync-reconcile.js';
 import {
   disablePhase2Cutover, enablePhase2Cutover, isPhase2CutoverEnabled,
@@ -76,18 +70,25 @@ import {
   isSyncPulling, onSyncReceived,
 } from './sync-pull.js';
 import {
-  bindSyncSubscriptions, clearSyncSubscriptionTimers, configureSyncSubscriptions,
-  getSyncSubscriptionFireCount, startRelayProbe,
+  clearSyncSubscriptionTimers, configureSyncSubscriptions,
+  getSyncSubscriptionFireCount,
 } from './sync-subscriptions.js';
 import {
   bindSyncWindowActions,
 } from './sync-window-bindings.js';
+import { initSync } from './sync-init.js';
+import {
+  clearSyncRuntimeState, getSyncAppOwner, getSyncAppOwnerError, getSyncEvolu,
+  getSyncItemRowQuery, getSyncProfileQuery, getSyncQueryLoadedPromise,
+  getSyncReadyPromise, getSyncTombstoneQuery, isSyncEvoluReady,
+  setSyncAppOwnerError,
+} from './sync-runtime.js';
 
 export {
   compactOwnerSelfServe, fetchOwnerStorageFromRelay, getRelayHealthVerdict,
   getRelayQuotaEstimate, resetRelayQuotaEstimate, verifyPushLanded,
   getRecentSyncEvents, subscribeSyncStatus,
-  isSyncEnabled, primeSyncState,
+  isSyncEnabled, initSync, primeSyncState,
   applyPendingTombstone, deleteProfileFromRelay, listPendingTombstones,
   rejectPendingTombstone,
   generateMessengerToken, getMessengerToken, isMessengerEnabled,
@@ -106,7 +107,7 @@ export {
 function dbg(...args) { if (isDebugMode()) console.log('[sync]', ...args); }
 
 configureRelayHealth({
-  getAppOwner: () => _appOwner,
+  getAppOwner: getSyncAppOwner,
   getSyncRelay,
   onQuotaThreshold(q) {
     if (q.level === 'red') {
@@ -118,23 +119,14 @@ configureRelayHealth({
   },
 });
 
-let evolu = null;
-let profileQuery = null;
-let tombstoneQuery = null;
-let itemRowQuery = null;
-let _appOwner = null;
-let _appOwnerError = null;
-let _readyPromise = null;
-let _queryLoaded = null;
-
 configureSyncDelta({
-  getEvolu: () => evolu,
-  getItemRowQuery: () => itemRowQuery,
+  getEvolu: getSyncEvolu,
+  getItemRowQuery: getSyncItemRowQuery,
 });
 
 configureSyncPush({
-  getEvolu: () => evolu,
-  getProfileQuery: () => profileQuery,
+  getEvolu: getSyncEvolu,
+  getProfileQuery: getSyncProfileQuery,
   isSyncEnabled,
   isPhase2CutoverEnabled,
   disablePhase2Cutover,
@@ -142,8 +134,8 @@ configureSyncPush({
 });
 
 configureSyncPull({
-  getEvolu: () => evolu,
-  getProfileQuery: () => profileQuery,
+  getEvolu: getSyncEvolu,
+  getProfileQuery: getSyncProfileQuery,
   isSyncPushInFlight,
   pushProfile,
   debug: dbg,
@@ -159,9 +151,9 @@ configureSyncSubscriptions({
 });
 
 configureSyncTombstones({
-  getEvolu: () => evolu,
-  getProfileQuery: () => profileQuery,
-  getTombstoneQuery: () => tombstoneQuery,
+  getEvolu: getSyncEvolu,
+  getProfileQuery: getSyncProfileQuery,
+  getTombstoneQuery: getSyncTombstoneQuery,
   isSyncEnabled,
   pushProfile,
   debug: dbg,
@@ -173,16 +165,16 @@ configureSyncMessenger({
 });
 
 configureSyncIdentity({
-  getAppOwner: () => _appOwner,
-  getAppOwnerError: () => _appOwnerError,
-  getEvolu: () => evolu,
+  getAppOwner: getSyncAppOwner,
+  getAppOwnerError: getSyncAppOwnerError,
+  getEvolu: getSyncEvolu,
 });
 
 configureSyncDiagnostics({
-  getEvolu: () => evolu,
-  getProfileQuery: () => profileQuery,
-  getTombstoneQuery: () => tombstoneQuery,
-  getAppOwner: () => _appOwner,
+  getEvolu: getSyncEvolu,
+  getProfileQuery: getSyncProfileQuery,
+  getTombstoneQuery: getSyncTombstoneQuery,
+  getAppOwner: getSyncAppOwner,
   isSyncEnabled,
   getSubscriptionFireCount: getSyncSubscriptionFireCount,
   isSyncing: isSyncPushInFlight,
@@ -208,14 +200,14 @@ configureSyncActions({
   pushProfile,
   forcePull: _forcePull,
   isSyncEnabled,
-  isEvoluReady: () => !!evolu,
+  isEvoluReady: isSyncEvoluReady,
   isSyncing: isSyncPushInFlight,
 });
 bindSyncActionEvents();
 
 configureSyncRecovery({
   isSyncEnabled,
-  isEvoluReady: () => !!evolu,
+  isEvoluReady: isSyncEvoluReady,
   pushCurrentProfile,
   forcePull: _forcePull,
   debug: dbg,
@@ -225,119 +217,12 @@ configureSyncRecovery({
 });
 
 configureSyncReconcile({
-  getEvolu: () => evolu,
-  getProfileQuery: () => profileQuery,
+  getEvolu: getSyncEvolu,
+  getProfileQuery: getSyncProfileQuery,
   isSyncEnabled,
   pushProfile,
   debug: dbg,
 });
-
-// ═══════════════════════════════════════════════
-// INIT
-// ═══════════════════════════════════════════════
-
-export async function initSync() {
-  if (!primeSyncState()) return;
-
-  // Fail fast if the webview doesn't have what Evolu needs. Otherwise the
-  // worker hangs forever on appOwner and the toggle/restore flow looks
-  // mysteriously broken — exactly the rabbit hole we just spent an hour in.
-  const blocker = getSyncBlocker();
-  if (blocker) {
-    _appOwnerError = blocker;
-    console.warn('[sync] Cannot init:', blocker);
-    return;
-  }
-
-  // Re-entrancy guard — don't create duplicate Evolu instances
-  if (evolu) return;
-
-  // Defer to next microtask — Worker + navigator.locks can race during DOMContentLoaded
-  await new Promise(r => setTimeout(r, 0));
-
-  try {
-    const { createEvolu, id, nullOr, SimpleName, NonEmptyString, evoluWebDeps } =
-      await import('../vendor/evolu/evolu-bundle.js');
-
-    const Schema = createSyncSchema({ id, nullOr, NonEmptyString });
-
-    const relay = getSyncRelay();
-    evolu = createEvolu(evoluWebDeps)(Schema, {
-      name: SimpleName.orThrow("getbased4"),
-      reloadUrl: window.location.pathname,
-      enableLogging: isDebugMode(),
-      transports: [{ type: "WebSocket", url: relay }],
-    });
-
-    ({ profileQuery, tombstoneQuery, itemRowQuery } = createSyncQueries(evolu));
-
-    bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery });
-
-    // Load initial data — store promise for enableSync to await
-    _queryLoaded = Promise.all([
-      evolu.loadQuery(profileQuery),
-      evolu.loadQuery(tombstoneQuery),
-      evolu.loadQuery(itemRowQuery),
-    ]).then(() => {
-      dbg('Initial queries loaded');
-    }).catch(e => {
-      console.warn('[sync] Query load failed:', e);
-    });
-
-    // Wait for owner (mnemonic) — signals DB is ready
-    _readyPromise = evolu.appOwner.then(owner => {
-      _appOwner = owner;
-      _appOwnerError = null;
-      dbg('Owner resolved');
-    }).catch(e => {
-      // Don't silently swallow — Settings → Data shows "Resolving…" while
-      // _appOwner is null and there's no other signal the user gets. We
-      // stash the message so the UI can surface it instead of timing out
-      // after 30s with the unhelpful "Could not resolve mnemonic".
-      _appOwnerError = e?.message || String(e);
-      console.warn('[sync] Owner resolution failed:', e);
-    });
-
-    // Debug helper. Gated on isDebugMode() — earlier versions exposed this
-    // unconditionally, which leaked the BIP-39 mnemonic to anyone with
-    // console access (screen-share, malicious extension, MCP evaluate_script
-    // capability). The mnemonic decrypts every Evolu blob ever pushed to
-    // the relay, so this had to be opt-in. Toggle Settings → Privacy →
-    // Debug mode to expose.
-    if (isDebugMode?.()) {
-      window._syncDebug = {
-        getRows: () => evolu.getQueryRows(profileQuery),
-        getOwner: () => _appOwner,
-        evolu,
-      };
-    }
-
-    // Initial relay probe + periodic 60s health check
-    startRelayProbe();
-
-    bindSyncRecoveryEvents();
-
-    dbg('Initialized, relay:', relay);
-
-    // Startup reconciliation — handles the case where state.importedData
-    // (loaded fresh from localStorage on this page-load) has rows that
-    // the local Evolu DB row's dataJson doesn't have. This happens when
-    // a previous session's pushProfile got wedged (Evolu's onComplete
-    // never fired, _syncing stayed true until the watchdog), so saves
-    // landed in localStorage but never reached Evolu's CRDT log. Fix:
-    // detect the divergence after init + force-push so the row catches
-    // up. Defer until after appOwner + initial query both load — those
-    // are async and the CRDT row doesn't exist until then.
-    Promise.all([_readyPromise, _queryLoaded]).then(() => {
-      reconcileLocalStorageWithEvolu().catch(e => {
-        console.warn('[sync] Startup reconciliation failed:', e);
-      });
-    });
-  } catch (e) {
-    console.error('[sync] Failed to initialize Evolu:', e);
-    setSyncEnabled(false, { persist: false });
-  }
-}
 
 // ═══════════════════════════════════════════════
 // ENABLE / DISABLE
@@ -352,13 +237,14 @@ export async function enableSync({ skipPush = false } = {}) {
     return;
   }
   setSyncEnabled(true);
-  _appOwnerError = null;
+  setSyncAppOwnerError(null);
   await initSync();
-  if (!evolu || !_readyPromise) {
+  const readyPromise = getSyncReadyPromise();
+  if (!getSyncEvolu() || !readyPromise) {
     // initSync bailed before evolu was created — likely an import / module
     // load failure. Already logged by initSync; surface a toast so the user
     // doesn't sit staring at a Resolving… spinner.
-    showNotification(`Sync failed to initialize. ${_appOwnerError || 'Check console for [sync] errors.'}`, 'error');
+    showNotification(`Sync failed to initialize. ${getSyncAppOwnerError() || 'Check console for [sync] errors.'}`, 'error');
     return;
   }
   // Race the owner-resolution promise against a 30s ceiling. A stuck
@@ -366,15 +252,16 @@ export async function enableSync({ skipPush = false } = {}) {
   // appOwner promise pending forever — without this race the await
   // blocks toggleSync's finally, leaving the UI stuck.
   const timeout = new Promise(resolve => setTimeout(() => resolve('__timeout__'), 30000));
-  const result = await Promise.race([_readyPromise.then(() => 'ok'), timeout]);
-  if (result === '__timeout__' || !_appOwner) {
-    const reason = _appOwnerError || 'Evolu owner did not resolve within 30s';
+  const result = await Promise.race([readyPromise.then(() => 'ok'), timeout]);
+  if (result === '__timeout__' || !getSyncAppOwner()) {
+    const reason = getSyncAppOwnerError() || 'Evolu owner did not resolve within 30s';
     showNotification(`Sync init failed: ${reason}`, 'error');
     return;
   }
-  if (_queryLoaded) {
+  const queryLoaded = getSyncQueryLoadedPromise();
+  if (queryLoaded) {
     // Cap query load too — same hang risk
-    await Promise.race([_queryLoaded, new Promise(r => setTimeout(r, 30000))]);
+    await Promise.race([queryLoaded, new Promise(r => setTimeout(r, 30000))]);
   }
   if (!skipPush) {
     try { await pushAllProfiles(); } catch (e) { console.warn('[sync] initial push failed:', e); }
@@ -388,7 +275,7 @@ export async function disableSync() {
   // hangs (Evolu worker stuck on OPFS or a Web Lock), a manual page
   // reload will still see sync as off.
   setSyncEnabled(false);
-  _appOwnerError = null;
+  setSyncAppOwnerError(null);
 
   // Stop background timers + reset status (UI feedback before the reload)
   clearSyncActionTimers();
@@ -412,6 +299,7 @@ export async function disableSync() {
   // resolves and the user sees the toggle silently do nothing.
   // The page reload below kills the worker process anyway, so a
   // half-completed reset is harmless — the new tab boots clean.
+  const evolu = getSyncEvolu();
   if (evolu) {
     try {
       Promise.resolve(evolu.resetAppOwner({ reload: false }))
@@ -422,11 +310,7 @@ export async function disableSync() {
   }
 
   // Drop in-memory references so any stray callers see fresh-state behavior
-  evolu = null;
-  profileQuery = null;
-  _appOwner = null;
-  _readyPromise = null;
-  _queryLoaded = null;
+  clearSyncRuntimeState();
 
   showNotification('Sync disabled — reloading…', 'success');
   // Reload regardless of whether Evolu cooperated. ~250ms gives the toast

--- a/service-worker.js
+++ b/service-worker.js
@@ -139,6 +139,8 @@ const APP_SHELL = [
   '/js/hardware.js',
   '/js/sync.js',
   '/js/sync-settings-state.js',
+  '/js/sync-runtime.js',
+  '/js/sync-init.js',
   '/js/sync-disable-cleanup.js',
   '/js/sync-apply.js',
   '/js/sync-schema.js',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -36,6 +36,8 @@ await import('../js/settings.js');
   const syncSrc = await fetchWithRetry('js/sync.js');
   const syncApplySrc = await fetchWithRetry('js/sync-apply.js');
   const syncSettingsStateSrc = await fetchWithRetry('js/sync-settings-state.js');
+  const syncRuntimeSrc = await fetchWithRetry('js/sync-runtime.js');
+  const syncInitSrc = await fetchWithRetry('js/sync-init.js');
   const syncDisableCleanupSrc = await fetchWithRetry('js/sync-disable-cleanup.js');
   const syncSchemaSrc = await fetchWithRetry('js/sync-schema.js');
   const syncDeltaSrc = await fetchWithRetry('js/sync-delta.js');
@@ -105,6 +107,29 @@ await import('../js/settings.js');
       && exportBlockIncludes(syncSrc, ['isSyncEnabled', 'primeSyncState']));
   assert('service worker precaches sync-settings-state.js',
     serviceWorkerSrc.includes("'/js/sync-settings-state.js'"));
+  assert('sync-runtime.js owns mutable Evolu runtime handles',
+    syncSrc.includes("from './sync-runtime.js'")
+      && syncRuntimeSrc.includes('let _evolu = null')
+      && syncRuntimeSrc.includes('export function getSyncEvolu')
+      && syncRuntimeSrc.includes('export function getSyncProfileQuery')
+      && syncRuntimeSrc.includes('export function getSyncAppOwner')
+      && syncRuntimeSrc.includes('export function clearSyncRuntimeState')
+      && syncSrc.includes('getEvolu: getSyncEvolu')
+      && syncSrc.includes('clearSyncRuntimeState();'));
+  assert('service worker precaches sync-runtime.js',
+    serviceWorkerSrc.includes("'/js/sync-runtime.js'"));
+  assert('sync-init.js owns Evolu startup orchestration',
+    syncSrc.includes("from './sync-init.js'")
+      && syncInitSrc.includes('export async function initSync')
+      && syncInitSrc.includes('createSyncSchema({')
+      && syncInitSrc.includes('createSyncQueries(evolu)')
+      && syncInitSrc.includes('bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery })')
+      && syncInitSrc.includes('startRelayProbe();')
+      && syncInitSrc.includes('bindSyncRecoveryEvents();')
+      && syncInitSrc.includes('setSyncEvolu(evolu)')
+      && syncInitSrc.includes('setSyncQueries({ profileQuery, tombstoneQuery, itemRowQuery })'));
+  assert('service worker precaches sync-init.js',
+    serviceWorkerSrc.includes("'/js/sync-init.js'"));
   assert('sync-disable-cleanup.js owns disable localStorage cleanup',
     syncSrc.includes("from './sync-disable-cleanup.js'")
       && syncIdentitySrc.includes("from './sync-disable-cleanup.js'")
@@ -120,11 +145,11 @@ await import('../js/settings.js');
   assert('service worker precaches sync-disable-cleanup.js',
     serviceWorkerSrc.includes("'/js/sync-disable-cleanup.js'"));
   assert('sync-schema.js owns Evolu schema/query helpers',
-    syncSrc.includes("from './sync-schema.js'")
+    syncInitSrc.includes("from './sync-schema.js'")
       && syncSchemaSrc.includes('export function createSyncSchema')
       && syncSchemaSrc.includes('export function createSyncQueries')
-      && syncSrc.includes('createSyncSchema({')
-      && syncSrc.includes('createSyncQueries(evolu)'));
+      && syncInitSrc.includes('createSyncSchema({')
+      && syncInitSrc.includes('createSyncQueries(evolu)'));
   assert('service worker precaches sync-schema.js',
     serviceWorkerSrc.includes("'/js/sync-schema.js'"));
   assert('sync-apply.js owns inbound AI/chat/display apply helpers',
@@ -252,7 +277,7 @@ await import('../js/settings.js');
       && syncRecoverySrc.includes("window.addEventListener('online'")
       && syncRecoverySrc.includes("window.addEventListener('offline'")
       && syncSrc.includes('configureSyncRecovery({')
-      && syncSrc.includes('bindSyncRecoveryEvents();'));
+      && syncInitSrc.includes('bindSyncRecoveryEvents();'));
   assert('service worker precaches sync-recovery.js',
     serviceWorkerSrc.includes("'/js/sync-recovery.js'"));
   assert('sync-reconcile.js owns startup reconciliation helper',
@@ -287,8 +312,8 @@ await import('../js/settings.js');
       && syncSubscriptionsSrc.includes('_checkRelayConnection()')
       && syncSubscriptionsSrc.includes('_subscriptionFireCount = 0')
       && syncSubscriptionsSrc.includes('.catch(onRelayProbeError)')
-      && syncSrc.includes('bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery })')
-      && syncSrc.includes('startRelayProbe();')
+      && syncInitSrc.includes('bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery })')
+      && syncInitSrc.includes('startRelayProbe();')
       && syncSrc.includes('clearSyncSubscriptionTimers();')
       && syncSrc.includes('getSubscriptionFireCount: getSyncSubscriptionFireCount'));
   assert('service worker precaches sync-subscriptions.js',
@@ -513,7 +538,7 @@ await import('../js/settings.js');
   assert('itemRowQuery created by sync-schema.js',
     /itemRowQuery\s*=\s*evolu\.createQuery\([\s\S]{0,200}selectFrom\("itemRow"\)/.test(syncSchemaSrc));
   assert('itemRowQuery loaded with profileQuery + tombstoneQuery',
-    /Promise\.all\(\[[\s\S]{0,400}evolu\.loadQuery\(itemRowQuery\)/.test(syncSrc));
+    /Promise\.all\(\[[\s\S]{0,400}evolu\.loadQuery\(itemRowQuery\)/.test(syncInitSrc));
   assert('itemRow subscription retriggers onSyncReceived',
     /evolu\.subscribeQuery\(itemRowQuery\)\([\s\S]{0,200}_onSyncReceived\(\)/.test(syncSubscriptionsSrc));
 
@@ -652,12 +677,12 @@ await import('../js/settings.js');
   // ═══════════════════════════════════════
   console.log('5. Evolu Configuration');
 
-  assert('reloadUrl uses window.location.pathname', syncSrc.includes('reloadUrl: window.location.pathname'));
-  assert('enableLogging gated on debug mode', syncSrc.includes('enableLogging: isDebugMode()'));
+  assert('reloadUrl uses window.location.pathname', syncInitSrc.includes('reloadUrl: window.location.pathname'));
+  assert('enableLogging gated on debug mode', syncInitSrc.includes('enableLogging: isDebugMode()'));
   assert('Default relay is wss://sync.getbased.health', syncEnvironmentSrc.includes("wss://sync.getbased.health"));
-  assert('Transport uses plural "transports" array (not singular)', syncSrc.includes('transports: [{ type:') && !syncSrc.includes('transport: { type:'));
+  assert('Transport uses plural "transports" array (not singular)', syncInitSrc.includes('transports: [{ type:') && !syncInitSrc.includes('transport: { type:'));
   assert('COOP header in dev-server', await fetchWithRetry('dev-server.js').then(s => s.includes('Cross-Origin-Opener-Policy')));
-  assert('initSync has re-entrancy guard', syncSrc.includes('if (evolu) return'));
+  assert('initSync has re-entrancy guard', syncInitSrc.includes('if (getSyncEvolu()) return'));
   assert('checkRelayConnection exported', exportBlockIncludes(syncSrc, ['checkRelayConnection']));
 
   // ═══════════════════════════════════════
@@ -737,7 +762,9 @@ await import('../js/settings.js');
     syncActionsSrc.includes('createDefaultProfileData()')
       && /pushAllProfiles[\s\S]{0,800}readProfileImportedData\(p\.id\)/.test(syncActionsSrc)
       && !/pushAllProfiles[\s\S]{0,800}if \(!raw\) continue/.test(syncActionsSrc));
-  assert('disableSync clears _appOwner', syncSrc.includes('_appOwner = null'));
+  assert('disableSync clears appOwner via runtime cleanup',
+    syncSrc.includes('clearSyncRuntimeState();')
+      && /clearSyncRuntimeState[\s\S]{0,500}_appOwner\s*=\s*null/.test(syncRuntimeSrc));
   // disableSync intentionally NO LONGER waits for in-flight ops or awaits
   // Evolu reset — both introduced hang risks (Evolu worker stuck on OPFS
   // or a Web Lock). The page reload below kills the worker process
@@ -749,7 +776,7 @@ await import('../js/settings.js');
   );
   assert('disableSync flips SYNC_STORAGE_KEY before any await',
     disableSyncSrc.includes('setSyncEnabled(false);')
-      && disableSyncSrc.indexOf('setSyncEnabled(false);') < disableSyncSrc.indexOf('_appOwnerError = null')
+      && disableSyncSrc.indexOf('setSyncEnabled(false);') < disableSyncSrc.indexOf('setSyncAppOwnerError(null)')
       && (!disableSyncSrc.includes('await ') || disableSyncSrc.indexOf('setSyncEnabled(false);') < disableSyncSrc.indexOf('await '))
       && syncSettingsStateSrc.includes("localStorage.setItem(SYNC_STORAGE_KEY, enabled ? 'true' : 'false')"));
   assert('disableSync does not block on Evolu reset (fire-and-forget)',
@@ -2384,7 +2411,7 @@ await import('../js/settings.js');
   assert('reconcileLocalStorageWithEvolu defined',
     /export async function reconcileLocalStorageWithEvolu\(\)/.test(syncReconcileSrc));
   assert('Reconciliation runs on initSync after appOwner + queries are ready',
-    /Promise\.all\(\[_readyPromise,\s*_queryLoaded\]\)[\s\S]{0,300}reconcileLocalStorageWithEvolu/.test(syncSrc));
+    /Promise\.all\(\[readyPromise,\s*queryLoaded\]\)[\s\S]{0,300}reconcileLocalStorageWithEvolu/.test(syncInitSrc));
   assert('Reconciliation reads remote dataJson via parseSyncPayload',
     /reconcileLocalStorageWithEvolu[\s\S]{0,800}parseSyncPayload\(existing\.dataJson\)/.test(syncReconcileSrc));
   assert('Reconciliation routes through localHasRowsRemoteLacks (catches same-id timestamp drift)',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.144';
+self.APP_VERSION = '1.8.145';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.143';
+self.APP_VERSION = '1.8.144';


### PR DESCRIPTION
## Summary
- Move mutable Evolu runtime handles into `js/sync-runtime.js`
- Move Evolu startup/query subscription/reconciliation orchestration into `js/sync-init.js`
- Keep `sync.js` as the facade for lifecycle/configuration, wired through runtime getters
- Use nullish coalescing in runtime setters so falsy-but-valid values are not coerced to `null`
- Precache the new modules and bump `APP_VERSION` to `1.8.145`
- Update sync source-shape tests for the split modules

## Validation
- `node --check js/sync.js`
- `node --check js/sync-init.js`
- `node --check js/sync-runtime.js`
- `node --check tests/test-sync.js`
- `node --check service-worker.js`
- `node --check version.js`
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`