### PR TITLE
[codex] Extract sync lifecycle actions

### DIFF
--- a/js/sync-lifecycle.js
+++ b/js/sync-lifecycle.js
@@ -1,0 +1,106 @@
+// sync-lifecycle.js - Sync enable / disable lifecycle actions.
+
+import { showNotification } from './utils.js';
+import { getSyncBlocker } from './sync-environment.js';
+import { setSyncEnabled } from './sync-settings-state.js';
+import { clearSyncDisableStorage } from './sync-disable-cleanup.js';
+import { resetSyncStatus } from './sync-state.js';
+import { clearSyncActionTimers, pushAllProfiles } from './sync-actions.js';
+import { clearSyncPullTimers } from './sync-pull.js';
+import { clearSyncSubscriptionTimers } from './sync-subscriptions.js';
+import { renderSyncIndicator } from './sync-ui.js';
+import { initSync } from './sync-init.js';
+import {
+  clearSyncRuntimeState, getSyncAppOwner, getSyncAppOwnerError, getSyncEvolu,
+  getSyncQueryLoadedPromise, getSyncReadyPromise, setSyncAppOwnerError,
+} from './sync-runtime.js';
+
+export async function enableSync({ skipPush = false } = {}) {
+  // Reject early if the webview can't actually run Evolu - no point flipping
+  // the persisted flag and starting init only to time out at 30s.
+  const blocker = getSyncBlocker();
+  if (blocker) {
+    showNotification(`Sync unavailable in this browser: ${blocker}`, 'error');
+    return;
+  }
+  setSyncEnabled(true);
+  setSyncAppOwnerError(null);
+  await initSync();
+  const readyPromise = getSyncReadyPromise();
+  if (!getSyncEvolu() || !readyPromise) {
+    // initSync bailed before evolu was created - likely an import / module
+    // load failure. Already logged by initSync; surface a toast so the user
+    // doesn't sit staring at a Resolving... spinner.
+    showNotification(`Sync failed to initialize. ${getSyncAppOwnerError() || 'Check console for [sync] errors.'}`, 'error');
+    return;
+  }
+  // Race the owner-resolution promise against a 30s ceiling. A stuck
+  // OPFS handle or a Web Lock that never resolves can leave Evolu's
+  // appOwner promise pending forever - without this race the await
+  // blocks toggleSync's finally, leaving the UI stuck.
+  const timeout = new Promise(resolve => setTimeout(() => resolve('__timeout__'), 30000));
+  const result = await Promise.race([readyPromise.then(() => 'ok'), timeout]);
+  if (result === '__timeout__' || !getSyncAppOwner()) {
+    const reason = getSyncAppOwnerError() || 'Evolu owner did not resolve within 30s';
+    showNotification(`Sync init failed: ${reason}`, 'error');
+    return;
+  }
+  const queryLoaded = getSyncQueryLoadedPromise();
+  if (queryLoaded) {
+    // Cap query load too - same hang risk.
+    await Promise.race([queryLoaded, new Promise(r => setTimeout(r, 30000))]);
+  }
+  if (!skipPush) {
+    try { await pushAllProfiles(); } catch (e) { console.warn('[sync] initial push failed:', e); }
+  }
+  showNotification('Sync enabled', 'success');
+  renderSyncIndicator();
+}
+
+export async function disableSync() {
+  // Flip the persisted flag FIRST, before any awaits. If anything below
+  // hangs (Evolu worker stuck on OPFS or a Web Lock), a manual page
+  // reload will still see sync as off.
+  setSyncEnabled(false);
+  setSyncAppOwnerError(null);
+
+  // Stop background timers + reset status (UI feedback before the reload).
+  clearSyncActionTimers();
+  clearSyncPullTimers();
+  clearSyncSubscriptionTimers();
+  resetSyncStatus();
+  renderSyncIndicator();
+
+  // v1.7.11 audit fix: clear per-array delta snapshots too. After a
+  // re-enable (which may bring a different Evolu owner via mnemonic
+  // change), the OLD snapshot would tell the planner "I already pushed
+  // these items" -> next push silently skips them, so the new owner's
+  // relay never receives the user's existing data. Drop the snapshots
+  // so the next push re-emits everything as inserts (relay starts
+  // empty under the new owner anyway). Same for telemetry + cutover
+  // flag (cutover was profile-scoped to the previous owner).
+  clearSyncDisableStorage();
+
+  // Fire-and-forget the Evolu reset. We can't trust this await: if the
+  // worker is hung (OPFS / lock contention), `resetAppOwner` never
+  // resolves and the user sees the toggle silently do nothing.
+  // The page reload below kills the worker process anyway, so a
+  // half-completed reset is harmless - the new tab boots clean.
+  const evolu = getSyncEvolu();
+  if (evolu) {
+    try {
+      Promise.resolve(evolu.resetAppOwner({ reload: false }))
+        .catch(e => console.warn('[sync] Evolu reset failed (proceeding anyway):', e));
+    } catch (e) {
+      console.warn('[sync] Evolu reset threw synchronously:', e);
+    }
+  }
+
+  // Drop in-memory references so any stray callers see fresh-state behavior.
+  clearSyncRuntimeState();
+
+  showNotification('Sync disabled — reloading…', 'success');
+  // Reload regardless of whether Evolu cooperated. ~250ms gives the toast
+  // time to render before the page swaps.
+  setTimeout(() => window.location.reload(), 250);
+}

--- a/js/sync.js
+++ b/js/sync.js
@@ -9,15 +9,11 @@ import {
   resetRelayQuotaEstimate, verifyPushLanded,
 } from './sync-relay-health.js';
 import {
-  getRecentSyncEvents, logSyncEvent, resetSyncStatus,
-  subscribeSyncStatus, updateSyncStatus,
+  getRecentSyncEvents, logSyncEvent, subscribeSyncStatus, updateSyncStatus,
 } from './sync-state.js';
 import {
-  isSyncEnabled, primeSyncState, setSyncEnabled,
+  isSyncEnabled, primeSyncState,
 } from './sync-settings-state.js';
-import {
-  clearSyncDisableStorage,
-} from './sync-disable-cleanup.js';
 import {
   configureSyncDelta, getDeltaCutoverReadiness, getDeltaTelemetry,
   resetDeltaTelemetry,
@@ -51,9 +47,9 @@ import {
   showSyncDiagnose,
 } from './sync-diagnose-ui.js';
 import {
-  bindSyncActionEvents, cleanStorage, clearSyncActionTimers,
-  configureSyncActions, forceResendCurrentProfile, onChatSaved,
-  onDataSaved, onProfileSaved, pushAllProfiles, pushCurrentProfile, syncNow,
+  bindSyncActionEvents, cleanStorage, configureSyncActions,
+  forceResendCurrentProfile, onChatSaved,
+  onDataSaved, onProfileSaved, pushCurrentProfile, syncNow,
 } from './sync-actions.js';
 import {
   configureSyncPush, isSyncPushInFlight, pushProfile,
@@ -66,29 +62,26 @@ import {
   disablePhase2Cutover, enablePhase2Cutover, isPhase2CutoverEnabled,
 } from './sync-cutover.js';
 import {
-  clearSyncPullTimers, configureSyncPull, forcePull as _forcePull,
-  isSyncPulling, onSyncReceived,
+  configureSyncPull, forcePull as _forcePull, isSyncPulling, onSyncReceived,
 } from './sync-pull.js';
 import {
-  clearSyncSubscriptionTimers, configureSyncSubscriptions,
-  getSyncSubscriptionFireCount,
+  configureSyncSubscriptions, getSyncSubscriptionFireCount,
 } from './sync-subscriptions.js';
 import {
   bindSyncWindowActions,
 } from './sync-window-bindings.js';
 import { initSync } from './sync-init.js';
+import { disableSync, enableSync } from './sync-lifecycle.js';
 import {
-  clearSyncRuntimeState, getSyncAppOwner, getSyncAppOwnerError, getSyncEvolu,
-  getSyncItemRowQuery, getSyncProfileQuery, getSyncQueryLoadedPromise,
-  getSyncReadyPromise, getSyncTombstoneQuery, isSyncEvoluReady,
-  setSyncAppOwnerError,
+  getSyncAppOwner, getSyncAppOwnerError, getSyncEvolu, getSyncItemRowQuery,
+  getSyncProfileQuery, getSyncTombstoneQuery, isSyncEvoluReady,
 } from './sync-runtime.js';
 
 export {
   compactOwnerSelfServe, fetchOwnerStorageFromRelay, getRelayHealthVerdict,
   getRelayQuotaEstimate, resetRelayQuotaEstimate, verifyPushLanded,
   getRecentSyncEvents, subscribeSyncStatus,
-  isSyncEnabled, initSync, primeSyncState,
+  isSyncEnabled, initSync, primeSyncState, enableSync, disableSync,
   applyPendingTombstone, deleteProfileFromRelay, listPendingTombstones,
   rejectPendingTombstone,
   generateMessengerToken, getMessengerToken, isMessengerEnabled,
@@ -223,99 +216,5 @@ configureSyncReconcile({
   pushProfile,
   debug: dbg,
 });
-
-// ═══════════════════════════════════════════════
-// ENABLE / DISABLE
-// ═══════════════════════════════════════════════
-
-export async function enableSync({ skipPush = false } = {}) {
-  // Reject early if the webview can't actually run Evolu — no point flipping
-  // the persisted flag and starting init only to time out at 30s.
-  const blocker = getSyncBlocker();
-  if (blocker) {
-    showNotification(`Sync unavailable in this browser: ${blocker}`, 'error');
-    return;
-  }
-  setSyncEnabled(true);
-  setSyncAppOwnerError(null);
-  await initSync();
-  const readyPromise = getSyncReadyPromise();
-  if (!getSyncEvolu() || !readyPromise) {
-    // initSync bailed before evolu was created — likely an import / module
-    // load failure. Already logged by initSync; surface a toast so the user
-    // doesn't sit staring at a Resolving… spinner.
-    showNotification(`Sync failed to initialize. ${getSyncAppOwnerError() || 'Check console for [sync] errors.'}`, 'error');
-    return;
-  }
-  // Race the owner-resolution promise against a 30s ceiling. A stuck
-  // OPFS handle or a Web Lock that never resolves can leave Evolu's
-  // appOwner promise pending forever — without this race the await
-  // blocks toggleSync's finally, leaving the UI stuck.
-  const timeout = new Promise(resolve => setTimeout(() => resolve('__timeout__'), 30000));
-  const result = await Promise.race([readyPromise.then(() => 'ok'), timeout]);
-  if (result === '__timeout__' || !getSyncAppOwner()) {
-    const reason = getSyncAppOwnerError() || 'Evolu owner did not resolve within 30s';
-    showNotification(`Sync init failed: ${reason}`, 'error');
-    return;
-  }
-  const queryLoaded = getSyncQueryLoadedPromise();
-  if (queryLoaded) {
-    // Cap query load too — same hang risk
-    await Promise.race([queryLoaded, new Promise(r => setTimeout(r, 30000))]);
-  }
-  if (!skipPush) {
-    try { await pushAllProfiles(); } catch (e) { console.warn('[sync] initial push failed:', e); }
-  }
-  showNotification('Sync enabled', 'success');
-  renderSyncIndicator();
-}
-
-export async function disableSync() {
-  // Flip the persisted flag FIRST, before any awaits. If anything below
-  // hangs (Evolu worker stuck on OPFS or a Web Lock), a manual page
-  // reload will still see sync as off.
-  setSyncEnabled(false);
-  setSyncAppOwnerError(null);
-
-  // Stop background timers + reset status (UI feedback before the reload)
-  clearSyncActionTimers();
-  clearSyncPullTimers();
-  clearSyncSubscriptionTimers();
-  resetSyncStatus();
-  renderSyncIndicator();
-
-  // v1.7.11 audit fix: clear per-array delta snapshots too. After a
-  // re-enable (which may bring a different Evolu owner via mnemonic
-  // change), the OLD snapshot would tell the planner "I already pushed
-  // these items" → next push silently skips them, so the new owner's
-  // relay never receives the user's existing data. Drop the snapshots
-  // so the next push re-emits everything as inserts (relay starts
-  // empty under the new owner anyway). Same for telemetry + cutover
-  // flag (cutover was profile-scoped to the previous owner).
-  clearSyncDisableStorage();
-
-  // Fire-and-forget the Evolu reset. We can't trust this await: if the
-  // worker is hung (OPFS / lock contention), `resetAppOwner` never
-  // resolves and the user sees the toggle silently do nothing.
-  // The page reload below kills the worker process anyway, so a
-  // half-completed reset is harmless — the new tab boots clean.
-  const evolu = getSyncEvolu();
-  if (evolu) {
-    try {
-      Promise.resolve(evolu.resetAppOwner({ reload: false }))
-        .catch(e => console.warn('[sync] Evolu reset failed (proceeding anyway):', e));
-    } catch (e) {
-      console.warn('[sync] Evolu reset threw synchronously:', e);
-    }
-  }
-
-  // Drop in-memory references so any stray callers see fresh-state behavior
-  clearSyncRuntimeState();
-
-  showNotification('Sync disabled — reloading…', 'success');
-  // Reload regardless of whether Evolu cooperated. ~250ms gives the toast
-  // time to render before the page swaps.
-  setTimeout(() => window.location.reload(), 250);
-}
 
 bindSyncWindowActions({ enableSync, disableSync });

--- a/service-worker.js
+++ b/service-worker.js
@@ -141,6 +141,7 @@ const APP_SHELL = [
   '/js/sync-settings-state.js',
   '/js/sync-runtime.js',
   '/js/sync-init.js',
+  '/js/sync-lifecycle.js',
   '/js/sync-disable-cleanup.js',
   '/js/sync-apply.js',
   '/js/sync-schema.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -29,6 +29,7 @@ console.log('=== Phase 2 Correctness Tests ===\n');
 console.log('1. Per-profile sync debouncer');
 const syncSrc = read('js/sync.js');
 const syncActionsSrc = read('js/sync-actions.js');
+const syncLifecycleSrc = read('js/sync-lifecycle.js');
 assert('sync-actions.js declares per-profile timer Map',
   syncActionsSrc.includes('const _debounceTimers = new Map()'),
   'shared single timer dropped pending push when user swapped profile mid-debounce');
@@ -36,9 +37,9 @@ assert('sync-actions.js no longer has single _debounceTimer',
   !/\blet _debounceTimer\b/.test(syncActionsSrc));
 assert('sync-actions.js looks up timer by profileId',
   syncActionsSrc.includes('_debounceTimers.get(profileId)') && syncActionsSrc.includes('_debounceTimers.set(profileId'));
-assert('sync.js clears action and pull timers on disable',
-  syncSrc.includes('clearSyncActionTimers()')
-    && syncSrc.includes('clearSyncPullTimers()')
+assert('sync-lifecycle.js clears action and pull timers on disable',
+  syncLifecycleSrc.includes('clearSyncActionTimers()')
+    && syncLifecycleSrc.includes('clearSyncPullTimers()')
     && syncActionsSrc.includes('for (const t of _debounceTimers.values()) clearTimeout(t)'));
 
 // ─── 2. Lab-context fingerprint includes wearableSummary ───

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -781,8 +781,11 @@ await import('../js/settings.js');
   // or a Web Lock). The page reload below kills the worker process
   // anyway. The persisted SYNC_STORAGE_KEY flips before any await so a
   // hard refresh always sees sync as off.
+  const disableSyncStart = syncLifecycleSrc.indexOf('export async function disableSync');
+  const disableSyncEnd = syncLifecycleSrc.indexOf('\nexport ', disableSyncStart + 1);
   const disableSyncSrc = syncLifecycleSrc.slice(
-    syncLifecycleSrc.indexOf('export async function disableSync')
+    disableSyncStart,
+    disableSyncEnd === -1 ? undefined : disableSyncEnd
   );
   assert('disableSync flips SYNC_STORAGE_KEY before any await',
     disableSyncSrc.includes('setSyncEnabled(false);')

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -38,6 +38,7 @@ await import('../js/settings.js');
   const syncSettingsStateSrc = await fetchWithRetry('js/sync-settings-state.js');
   const syncRuntimeSrc = await fetchWithRetry('js/sync-runtime.js');
   const syncInitSrc = await fetchWithRetry('js/sync-init.js');
+  const syncLifecycleSrc = await fetchWithRetry('js/sync-lifecycle.js');
   const syncDisableCleanupSrc = await fetchWithRetry('js/sync-disable-cleanup.js');
   const syncSchemaSrc = await fetchWithRetry('js/sync-schema.js');
   const syncDeltaSrc = await fetchWithRetry('js/sync-delta.js');
@@ -115,7 +116,7 @@ await import('../js/settings.js');
       && syncRuntimeSrc.includes('export function getSyncAppOwner')
       && syncRuntimeSrc.includes('export function clearSyncRuntimeState')
       && syncSrc.includes('getEvolu: getSyncEvolu')
-      && syncSrc.includes('clearSyncRuntimeState();'));
+      && syncLifecycleSrc.includes('clearSyncRuntimeState();'));
   assert('service worker precaches sync-runtime.js',
     serviceWorkerSrc.includes("'/js/sync-runtime.js'"));
   assert('sync-init.js owns Evolu startup orchestration',
@@ -130,10 +131,20 @@ await import('../js/settings.js');
       && syncInitSrc.includes('setSyncQueries({ profileQuery, tombstoneQuery, itemRowQuery })'));
   assert('service worker precaches sync-init.js',
     serviceWorkerSrc.includes("'/js/sync-init.js'"));
+  assert('sync-lifecycle.js owns enable/disable lifecycle actions',
+    syncSrc.includes("from './sync-lifecycle.js'")
+      && syncLifecycleSrc.includes('export async function enableSync')
+      && syncLifecycleSrc.includes('export async function disableSync')
+      && syncLifecycleSrc.includes('await initSync()')
+      && syncLifecycleSrc.includes('await pushAllProfiles()')
+      && syncLifecycleSrc.includes('clearSyncRuntimeState();')
+      && exportBlockIncludes(syncSrc, ['enableSync', 'disableSync']));
+  assert('service worker precaches sync-lifecycle.js',
+    serviceWorkerSrc.includes("'/js/sync-lifecycle.js'"));
   assert('sync-disable-cleanup.js owns disable localStorage cleanup',
-    syncSrc.includes("from './sync-disable-cleanup.js'")
+    syncLifecycleSrc.includes("from './sync-disable-cleanup.js'")
       && syncIdentitySrc.includes("from './sync-disable-cleanup.js'")
-      && syncSrc.includes('clearSyncDisableStorage();')
+      && syncLifecycleSrc.includes('clearSyncDisableStorage();')
       && syncIdentitySrc.includes('clearSyncDisableStorage();')
       && syncDisableCleanupSrc.includes('export function clearSyncDisableStorage')
       && syncDisableCleanupSrc.includes('export function isSyncDisableCleanupKey')
@@ -314,7 +325,7 @@ await import('../js/settings.js');
       && syncSubscriptionsSrc.includes('.catch(onRelayProbeError)')
       && syncInitSrc.includes('bindSyncSubscriptions({ evolu, profileQuery, tombstoneQuery, itemRowQuery })')
       && syncInitSrc.includes('startRelayProbe();')
-      && syncSrc.includes('clearSyncSubscriptionTimers();')
+      && syncLifecycleSrc.includes('clearSyncSubscriptionTimers();')
       && syncSrc.includes('getSubscriptionFireCount: getSyncSubscriptionFireCount'));
   assert('service worker precaches sync-subscriptions.js',
     serviceWorkerSrc.includes("'/js/sync-subscriptions.js'"));
@@ -757,22 +768,21 @@ await import('../js/settings.js');
   assert('Pull re-renders the active view', syncPullSrc.includes('window.navigate?.(cat)'));
   assert('Pull calls migrateProfileData', syncPullSrc.includes('migrateProfileData(state.importedData)'));
   assert('pushAllProfiles pushes all profiles on first enable',
-    syncSrc.includes('await pushAllProfiles()') && syncActionsSrc.includes('export async function pushAllProfiles'));
+    syncLifecycleSrc.includes('await pushAllProfiles()') && syncActionsSrc.includes('export async function pushAllProfiles'));
   assert('pushAllProfiles pushes metadata-only profiles with default data',
     syncActionsSrc.includes('createDefaultProfileData()')
       && /pushAllProfiles[\s\S]{0,800}readProfileImportedData\(p\.id\)/.test(syncActionsSrc)
       && !/pushAllProfiles[\s\S]{0,800}if \(!raw\) continue/.test(syncActionsSrc));
   assert('disableSync clears appOwner via runtime cleanup',
-    syncSrc.includes('clearSyncRuntimeState();')
+    syncLifecycleSrc.includes('clearSyncRuntimeState();')
       && /clearSyncRuntimeState[\s\S]{0,500}_appOwner\s*=\s*null/.test(syncRuntimeSrc));
   // disableSync intentionally NO LONGER waits for in-flight ops or awaits
   // Evolu reset — both introduced hang risks (Evolu worker stuck on OPFS
   // or a Web Lock). The page reload below kills the worker process
   // anyway. The persisted SYNC_STORAGE_KEY flips before any await so a
   // hard refresh always sees sync as off.
-  const disableSyncSrc = syncSrc.slice(
-    syncSrc.indexOf('export async function disableSync'),
-    syncSrc.indexOf('// ═══════════════════════════════════════════════\n// DIAGNOSTICS')
+  const disableSyncSrc = syncLifecycleSrc.slice(
+    syncLifecycleSrc.indexOf('export async function disableSync')
   );
   assert('disableSync flips SYNC_STORAGE_KEY before any await',
     disableSyncSrc.includes('setSyncEnabled(false);')
@@ -780,10 +790,10 @@ await import('../js/settings.js');
       && (!disableSyncSrc.includes('await ') || disableSyncSrc.indexOf('setSyncEnabled(false);') < disableSyncSrc.indexOf('await '))
       && syncSettingsStateSrc.includes("localStorage.setItem(SYNC_STORAGE_KEY, enabled ? 'true' : 'false')"));
   assert('disableSync does not block on Evolu reset (fire-and-forget)',
-    /Promise\.resolve\(evolu\.resetAppOwner/.test(syncSrc),
+    /Promise\.resolve\(evolu\.resetAppOwner/.test(syncLifecycleSrc),
     'awaiting resetAppOwner blocks the toggle when Evolu worker is hung');
-  assert('disableSync resets Evolu identity for mnemonic regeneration', syncSrc.includes('evolu.resetAppOwner('));
-  assert('disableSync reloads page after reset to kill Worker', syncSrc.includes('window.location.reload()'));
+  assert('disableSync resets Evolu identity for mnemonic regeneration', syncLifecycleSrc.includes('evolu.resetAppOwner('));
+  assert('disableSync reloads page after reset to kill Worker', syncLifecycleSrc.includes('window.location.reload()'));
   assert('disableSync clears sync timestamps',
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /key\.endsWith\('-sync-ts'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(syncDisableCleanupSrc));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.145';
+self.APP_VERSION = '1.8.146';


### PR DESCRIPTION
## Summary
- Move sync enable/disable lifecycle behavior into `js/sync-lifecycle.js`
- Keep `js/sync.js` as the public facade/composition layer and re-export lifecycle actions
- Precache the new lifecycle module and bump `APP_VERSION` for cache invalidation
- Update sync and correctness regression tests to assert the new module boundary

## Validation
- `node tests/test-sync.js`
- `./run-tests.sh`