### PR TITLE
Import body composition + BP from Apple Health

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -450,6 +450,17 @@ export const ADAPTERS = [
       spo2_avg:        { hkType: 'HKQuantityTypeIdentifierOxygenSaturation' },
       body_temp_delta: { hkType: 'HKQuantityTypeIdentifierBodyTemperature' },
       vo2max:          { hkType: 'HKQuantityTypeIdentifierVO2Max' },
+      // Body composition + cardio — Apple Health receives these from 3rd-party
+      // scales (Withings Health Mate, Renpho, Aria, etc.) and BP cuffs writing
+      // into HealthKit. Most users will have multiple readings per day; the
+      // aggregator averages to one daily value to match Withings's convention.
+      // fat_mass_kg has no HK identifier — derived from weight × body_fat_pct
+      // on days that have both.
+      weight:          { hkType: 'HKQuantityTypeIdentifierBodyMass' },
+      body_fat_pct:    { hkType: 'HKQuantityTypeIdentifierBodyFatPercentage' },
+      lean_mass_kg:    { hkType: 'HKQuantityTypeIdentifierLeanBodyMass' },
+      bp_systolic:     { hkType: 'HKQuantityTypeIdentifierBloodPressureSystolic' },
+      bp_diastolic:    { hkType: 'HKQuantityTypeIdentifierBloodPressureDiastolic' },
     },
   },
 ];

--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -272,6 +272,7 @@ function _aggregateByDayByMetric(byDayByMetric) {
       strain: null,
       stress_high_min: null, resilience_level: null, cardio_age: null,
       weight: null, bp_systolic: null, bp_diastolic: null,
+      body_fat_pct: null, lean_mass_kg: null, fat_mass_kg: null,
       spo2_avg: null, body_temp_delta: null, glucose_avg: null,
       vo2max: null,
     };
@@ -331,6 +332,32 @@ function _aggregateByDayByMetric(byDayByMetric) {
       row.vo2max = Math.round(mean(bucket.vo2max.map(s => s.v)) * 100) / 100;
     }
 
+    // Body composition + BP — mean across same-day samples. Matches Withings's
+    // daily convention (also a mean), and BP averaging is the AHA standard for
+    // multi-reading sessions. The 90d baseline (m.baseline) is a median, so
+    // the trend visualization stays robust against a single freak weigh-in.
+    if (Array.isArray(bucket.weight) && bucket.weight.length) {
+      row.weight = Math.round(mean(bucket.weight.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.body_fat_pct) && bucket.body_fat_pct.length) {
+      row.body_fat_pct = Math.round(mean(bucket.body_fat_pct.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.lean_mass_kg) && bucket.lean_mass_kg.length) {
+      row.lean_mass_kg = Math.round(mean(bucket.lean_mass_kg.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.bp_systolic) && bucket.bp_systolic.length) {
+      row.bp_systolic = Math.round(mean(bucket.bp_systolic.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.bp_diastolic) && bucket.bp_diastolic.length) {
+      row.bp_diastolic = Math.round(mean(bucket.bp_diastolic.map(s => s.v)) * 100) / 100;
+    }
+    // fat_mass_kg — HealthKit has no first-party identifier, derive on days
+    // that carry both weight and body_fat_pct so Apple-Health users see the
+    // same body-comp surface Withings reports directly.
+    if (row.weight != null && row.body_fat_pct != null) {
+      row.fat_mass_kg = Math.round(row.weight * row.body_fat_pct) / 100;
+    }
+
     rows.push(row);
   }
   rows.sort((a, b) => a.date.localeCompare(b.date));
@@ -367,6 +394,29 @@ function normaliseUnit(metricId, value, unit) {
       // Apple ships VO₂max in "mL/min·kg" (their formatting). Canonical is
       // mL/kg/min — same physiological quantity, just transposed factors.
       return (!unit || unit === 'mL/min·kg' || unit === 'mL/kg/min') ? value : null;
+    case 'weight':
+    case 'lean_mass_kg':
+      // Apple's body-mass unit follows the user's iOS region — `kg` in metric
+      // locales, `lb` in US/UK. Canonical is kg, so convert lb. `st` (stone)
+      // hasn't been observed in the wild but is on the HK supported-units
+      // list; convert it the same way (1 st = 6.35029 kg).
+      if (!unit || unit === 'kg') return value;
+      if (unit === 'lb') return value / 2.20462;
+      if (unit === 'st') return value * 6.35029;
+      return null;
+    case 'body_fat_pct':
+      // Apple BodyFatPercentage exports as a unitless 0–1 fraction in most
+      // cases; the unit attribute is typically '%' but the VALUE is fractional.
+      // Withings reports a 0–100 percentage. Normalise to percentage.
+      // Defensive: if a 3rd-party app wrote already-scaled values, leave them.
+      if (!unit || unit === '%' || unit === '1' || unit === '') {
+        return value <= 1 ? value * 100 : value;
+      }
+      return null;
+    case 'bp_systolic':
+    case 'bp_diastolic':
+      // Apple ships BP in mmHg, same as canonical.
+      return (!unit || unit === 'mmHg') ? value : null;
     default:
       // If canonical declares a unit string and Apple disagrees, refuse.
       return (!unit || unit === canonUnit) ? value : null;

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -605,10 +605,13 @@ assert('Day 2 RHR populated (single reading → 56)', day2.rhr === 56);
 assert('Day 2 HRV SDNN populated (single night-window sample → 51)', day2.hrv_sdnn === 51);
 assert('Day 2 hrv_day null (no day-window samples)', day2.hrv_day === null);
 
-// Records we explicitly don't map must NOT end up in canonical rows —
-// HeartRate (real-time) and BodyMass aren't in our Apple Health mapping yet.
+// rMSSD has no Apple HK identifier — we ingest SDNN only. Stays null.
 assert('rMSSD is not derivable from Apple Health (we use SDNN type only) — hrv_rmssd stays null',
   day1.hrv_rmssd === null && day2.hrv_rmssd === null);
+// BodyMass fixture lands on day 2 (2026-04-21, value=72.5 kg). With body-comp
+// wiring this should populate day2.weight directly (unit 'kg' → no conversion).
+assert('BodyMass record populates day2.weight (kg passthrough)',
+  day2.weight === 72.5);
 // Day 1 has one HKQuantityTypeIdentifierHeartRate sample at 10:00 (day window) value=72.
 // Day 2 has none. Verify hr_day surfaces 72 on day 1, null on day 2.
 assert('hr_day populated from raw HeartRate stream (day-window mean)',


### PR DESCRIPTION
## Summary

Adds five HealthKit identifiers to the Apple Health adapter so weight, body fat %, lean mass, and blood pressure flow into the canonical wearable slots Withings already populates. Apple-Health-only users now see the same body-comp surface as Withings users.

- **weight** (`HKQuantityTypeIdentifierBodyMass`) — kg/lb/st normalisation
- **body_fat_pct** (`HKQuantityTypeIdentifierBodyFatPercentage`) — handles Apple's 0–1 fraction export and rescales to the 0–100 % convention Withings uses
- **lean_mass_kg** (`HKQuantityTypeIdentifierLeanBodyMass`) — same kg/lb/st path
- **bp_systolic** / **bp_diastolic** — mmHg passthrough
- **fat_mass_kg** — derived as `weight × body_fat_pct / 100` on days that carry both, since HealthKit has no first-party identifier

Same-day samples are averaged per metric — matches Withings's daily convention and follows the AHA standard for averaging multi-reading BP sessions. The 90-day baseline already uses a median, so chart trends stay robust against a freak weigh-in.

Not in standard HealthKit, stays Withings-only: muscle_mass_kg, bone_mass_kg, water_mass_kg, visceral_fat (no first-party HK identifiers; 3rd-party scale apps use vendor-specific keys that don't survive the export).

## Test plan
- [ ] Re-import a fresh \`export.xml\` containing scale + BP data; weight / body fat % / lean mass / BP cards appear on the strip
- [ ] Verify fat_mass_kg populates on days where both weight + body_fat_pct exist
- [ ] iOS region with lb / st units — confirm values land in kg in IDB (correct numerical conversion)
- [ ] Multi-source weight (e.g. Withings + Apple Health both writing) — per-card source picker works
- [ ] Existing fields untouched: HRV, RHR, steps, SpO2, VO2max, body temp behaviour unchanged
- [ ] \`./run-tests.sh\` — new BodyMass assertion passes; everything else green except known pre-existing flakes (\`chat-shift\`, \`audit-fixes overflow\`)