### PR TITLE
Fix Apple Health steps multi-source double-count

### DIFF
--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -182,7 +182,11 @@ function _processRecordAttrs(attrsRaw, typeToCanonical, byDayByMetric) {
   if (!byDayByMetric.has(day)) byDayByMetric.set(day, {});
   const bucket = byDayByMetric.get(day);
   if (!bucket[metricId]) bucket[metricId] = [];
-  bucket[metricId].push({ v: normalised, h: hour });
+  // sourceName carries the writing device ("Apple Watch", "iPhone", "Oura",
+  // "Withings Scale", etc.). Captured for every metric so additive metrics
+  // (steps, distance, calories) can de-double-count multi-device days by
+  // grouping by source. Co-measure metrics (HR, HRV, weight, BP) ignore it.
+  bucket[metricId].push({ v: normalised, h: hour, src: attrs.sourceName || '' });
 }
 
 // Streaming parser — reads `blob` via TextDecoderStream, splits on '\n', and
@@ -261,6 +265,29 @@ function _aggregateByDayByMetric(byDayByMetric) {
   const mean = (arr) => arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
   const sum  = (arr) => arr.reduce((a, b) => a + b, 0);
 
+  // For ADDITIVE metrics (steps, distance, calories): Apple Health stores one
+  // record per writing device per time-window, and naively summing them
+  // double-counts overlap (e.g. Apple Watch + Oura + iPhone all recording the
+  // same walk). Group by sourceName, sum within each source, then take the
+  // MAX across sources — the device worn most that day wins. Better than a
+  // hardcoded priority list (works without Apple Watch) and lighter than the
+  // time-interval deduplication Apple does internally. Co-measure metrics
+  // (HR, HRV, weight) intentionally don't use this — averaging two devices'
+  // estimates of the same true value is appropriate.
+  const sumByMaxSource = (samples) => {
+    if (!Array.isArray(samples) || samples.length === 0) return null;
+    const totals = new Map();
+    for (const s of samples) {
+      const key = s.src || '';
+      totals.set(key, (totals.get(key) || 0) + s.v);
+    }
+    let best = null;
+    for (const v of totals.values()) {
+      if (best == null || v > best) best = v;
+    }
+    return best;
+  };
+
   const rows = [];
   for (const [day, bucket] of byDayByMetric) {
     const row = {
@@ -314,8 +341,11 @@ function _aggregateByDayByMetric(byDayByMetric) {
       }
     }
 
-    if (Array.isArray(bucket.steps) && bucket.steps.length) {
-      row.steps = Math.round(sum(bucket.steps.map(s => s.v)) * 100) / 100;
+    // Steps — additive across the day but multi-source-overlapping. See
+    // sumByMaxSource comment above.
+    const stepsBest = sumByMaxSource(bucket.steps);
+    if (stepsBest != null) {
+      row.steps = Math.round(stepsBest * 100) / 100;
     }
     if (Array.isArray(bucket.spo2_avg) && bucket.spo2_avg.length) {
       row.spo2_avg = Math.round(mean(bucket.spo2_avg.map(s => s.v)) * 100) / 100;

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -594,9 +594,16 @@ assert('HRV SDNN aggregates night-window samples (42.5 & 48.5 → 45.5)',
 // No day-window HRV samples in fixture → hrv_day should be null on day 1.
 assert('hrv_day is null when no day-window samples exist',
   day1.hrv_day === null);
-// Steps is sum-per-day (320 + 2100 + 5430 = 7850)
-assert('Steps sum multiple sources per day (320+2100+5430=7850)',
-  day1.steps === 7850);
+// Steps: multi-source de-duplication. iPhone (320+2100=2420) and Apple Watch
+// (5430) both wrote step records for day 1 — naively summing would yield
+// 7850 (the old bug). The fix groups by sourceName, sums within source, then
+// takes the MAX across sources, so Apple Watch's 5430 wins.
+assert('Steps max-per-source de-duplicates multi-device days (Apple Watch 5430 > iPhone 2420 → 5430)',
+  day1.steps === 5430);
+// Day 2 has a single iPhone source — max-per-source behaves identically to
+// sum when there's only one writing device.
+assert('Steps single-source day passes through unchanged (iPhone 8200 → 8200)',
+  day2.steps === 8200);
 // SpO2 mean of 97 + 95 = 96
 assert('SpO2 mean-per-day aggregator (97+95 → 96)',
   day1.spo2_avg === 96);


### PR DESCRIPTION
## Summary

Apple Health is an aggregator: every device that writes \`HKQuantityTypeIdentifierStepCount\` (Apple Watch, iPhone, Oura ring, Fitbit, AutoSleep, etc.) stores its own \`<Record>\` entries with a \`sourceName\` attribute. The previous parser blindly summed every step record for the day, producing inflated counts like 18 500 steps on days the user actually walked ~8 000 — with the difference scaling linearly with the number of devices syncing to HealthKit.

**Fix**: group step samples by \`sourceName\`, sum within each source, then take the **MAX** across sources. The device worn most that day wins; partial-day contributions from other devices are correctly ignored. Better than a hardcoded "Apple Watch first" priority list (works for Pixel/Fitbit/Garmin users without a Watch) and lighter than the time-interval deduplication Apple does internally.

Co-measure metrics (HRV, RHR, weight, BP, body fat) intentionally continue using \`mean\` — two devices measuring the same biological value are estimating the same thing, not adding contributions.

A new \`sumByMaxSource()\` helper is added for future use when other additive metrics land (distance, active calories, exercise time, flights climbed).

## Test plan
- [ ] Re-import \`export.xml\` on a profile that previously showed inflated steps — counts should drop to the most-worn device's daily total
- [ ] Single-source users (Apple Watch only) — counts unchanged
- [ ] \`./run-tests.sh\` — updated steps assertion (Apple Watch 5430 wins over iPhone 2420 → 5430) passes; new single-source day-2 assertion passes

Two known pre-existing test failures on \`main\` are unaffected: \`chat-shift\` and \`audit-fixes overflow flake\`.