### PR TITLE
Import VO2max + Breathing Disturbance Index from Oura

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -89,7 +89,7 @@ export const CANONICAL_METRICS = {
   sleep_hr_avg:         { id: 'sleep_hr_avg',         label: 'Sleep HR',    sub: 'avg',   unit: 'bpm', worseWhen: 'up'     }, // distinct from rhr (= hr_min) — average overnight
   sleep_breathing_rate: { id: 'sleep_breathing_rate', label: 'Breathing',   sub: 'sleep', unit: 'rpm', worseWhen: 'up'     },
   sleep_snoring_min:    { id: 'sleep_snoring_min',    label: 'Snoring',     sub: '',      unit: 'min', worseWhen: 'up'     },
-  sleep_breath_disturb: { id: 'sleep_breath_disturb', label: 'Apnea',       sub: 'level', unit: '',    worseWhen: 'up'     }, // breathing-disturbances intensity 0-100 (Withings' apnea-class signal)
+  sleep_breath_disturb: { id: 'sleep_breath_disturb', label: 'Apnea',       sub: 'level', unit: '',    worseWhen: 'up'     }, // breathing-disturbances intensity 0-100 — populated by Withings (apnea-class signal) and Oura (daily_spo2.breathing_disturbance_index). Both vendors use the same nominal 0-100 scale; sanity-check alignment if cross-source swap shows a step change.
 };
 
 // For most wearable metrics, 0 is a sentinel for "no measurement" — the
@@ -182,6 +182,13 @@ export const ADAPTERS = [
       cardio_age:       { endpoint: 'v2/usercollection/daily_cardiovascular_age', field: 'vascular_age' },
       spo2_avg:         { endpoint: 'v2/usercollection/daily_spo2',              field: 'spo2_percentage' },
       body_temp_delta:  { endpoint: 'v2/usercollection/daily_readiness',         field: 'temperature_deviation' },
+      // BDI lives on the SAME daily_spo2 response as spo2_avg, so no extra
+      // round-trip. Higher = more breathing irregularities (apnea events,
+      // hypopnea, irregular breathing patterns).
+      sleep_breath_disturb: { endpoint: 'v2/usercollection/daily_spo2',          field: 'breathing_disturbance_index' },
+      // Oura Gen3+ surfaces VO₂max from walking sessions in its own endpoint.
+      // Sparse — typically populated a few times a month, not daily.
+      vo2max:           { endpoint: 'v2/usercollection/vO2_max',                 field: 'vo2_max' },
     },
     accountInfo: { endpoint: 'v2/usercollection/personal_info', identityField: 'email' },
   },

--- a/js/wearables-oura.js
+++ b/js/wearables-oura.js
@@ -184,6 +184,7 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
   const [
     sleepSessions, dailySleep, dailyReadiness, dailySpo2,
     dailyActivity, dailyStress, dailyResilience, dailyCardioAge,
+    vo2maxSamples,
     heartrateSamples,
   ] = await Promise.all([
     ouraCollect('v2/usercollection/sleep',                    accessToken, params).catch(e => { logDebug('sleep', e); return []; }),
@@ -194,6 +195,10 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
     ouraCollect('v2/usercollection/daily_stress',             accessToken, params).catch(e => { logDebug('daily_stress', e); return []; }),
     ouraCollect('v2/usercollection/daily_resilience',         accessToken, params).catch(e => { logDebug('daily_resilience', e); return []; }),
     ouraCollect('v2/usercollection/daily_cardiovascular_age', accessToken, params).catch(e => { logDebug('daily_cardiovascular_age', e); return []; }),
+    // VO₂max is sparse (Oura emits a value only after a qualifying walk).
+    // Older rings / accounts that have never produced a value will 404; the
+    // .catch swallows it so the rest of the sync continues.
+    ouraCollect('v2/usercollection/vO2_max',                  accessToken, params).catch(e => { logDebug('vO2_max', e); return []; }),
     ouraCollectHeartrate(accessToken, startDt, endDt)
       .catch(e => { logDebug('heartrate', e); return []; }),
   ]);
@@ -211,6 +216,7 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
         activity_score: null, steps: null,
         stress_high_min: null, resilience_level: null, cardio_age: null,
         spo2_avg: null, body_temp_delta: null, glucose_avg: null,
+        sleep_breath_disturb: null, vo2max: null,
       });
     }
     return byDate.get(day);
@@ -255,6 +261,13 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
     if (!d?.day) continue;
     const v = typeof d.spo2_percentage === 'object' ? d.spo2_percentage?.average : d.spo2_percentage;
     if (typeof v === 'number') ensureRow(d.day).spo2_avg = v;
+    // BDI is on the same response — extract while we already have the row.
+    // Oura emits 0 on nights with no usable signal; gtZero() filters those
+    // out so the strip card doesn't read "Apnea: 0" for ring-was-off nights.
+    if (typeof d.breathing_disturbance_index === 'number') {
+      const bdi = gtZero(d.breathing_disturbance_index);
+      if (bdi != null) ensureRow(d.day).sleep_breath_disturb = bdi;
+    }
   }
   for (const d of dailyActivity) {
     if (!d?.day) continue;
@@ -275,6 +288,15 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
   for (const d of dailyCardioAge) {
     if (!d?.day) continue;
     if (typeof d.vascular_age === 'number') ensureRow(d.day).cardio_age = d.vascular_age;
+  }
+  // VO₂max — Oura's vO2_max endpoint emits sparse rows (a value only on days
+  // with a qualifying walking session). Each entry carries `day` + `vo2_max`.
+  // gtZero() guards the 0-sentinel; spanGaps in the chart handles the days
+  // without a value.
+  for (const d of vo2maxSamples) {
+    if (!d?.day) continue;
+    const v = gtZero(d.vo2_max);
+    if (v != null) ensureRow(d.day).vo2max = v;
   }
 
   // Daytime HR aggregate from the heartrate stream — Oura tags each sample as


### PR DESCRIPTION
## Summary

Two unused Oura signals wired into existing canonical metric slots.

**VO₂max** — new \`v2/usercollection/vO2_max\` endpoint added to the parallel fetch block in \`fetchOuraDailyRange\`. Oura Gen3+ emits walking-derived VO₂max estimates sparsely (a few times a month). Lands in the canonical \`vo2max\` slot that the Apple Health adapter also populates, so source-swap between Oura and Apple Health works out of the box. \`gtZero()\` filters the 0-sentinel; chart \`spanGaps\` handles the days without a value.

**BDI** — Breathing Disturbance Index lives on the **same** \`daily_spo2\` response as \`spo2_avg\`, so no extra round-trip. Routed into the existing \`sleep_breath_disturb\` canonical slot already populated by Withings's apnea-class signal. Both vendors use a nominal 0-100 disturbance intensity scale; an inline note flags that scale alignment should be sanity-checked on first real data, since cross-source swap would be visibly off if the scales differ.

## Test plan
- [ ] Settings → Wearables → Oura → Sync now / Backfill 90 days
- [ ] BDI card appears on strip if user has any nightly breathing disturbances >0
- [ ] VO₂max card appears on strip if user has Oura Gen3+ and at least one qualifying walking session in the last 90 days
- [ ] User with both Oura and Withings — verify BDI source-swap doesn't show a wild step change (sanity check the 0–100 scale alignment between vendors)
- [ ] User with both Oura and Apple Health — verify VO₂max source-swap works (both feed the same canonical slot)
- [ ] \`./run-tests.sh\` — no new failures (only the pre-existing \`chat-shift\` flake)