### PR TITLE
Exclude today from L2 summary for cumulative-from-midnight metrics

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -117,6 +117,26 @@ export function isMetricValueMeaningful(metricId, v) {
   return v > 0;
 }
 
+// Cumulative-from-midnight metrics: the daily value is a running total that
+// accumulates over the course of the day, so today's row is mathematically
+// incomplete until midnight local time. Including it in baselines / d7 / d30
+// drags those averages down on every read between 00:00 and 23:59. L2 summary
+// derivation filters today's row for any metric in this set; the row stays in
+// L1 IDB so the detail-modal chart can still plot the running total if
+// useful, but the user-facing latest / baseline / rolling read from the last
+// finalized day.
+//
+// Co-measure metrics (HRV, RHR, weight, BP, body fat) and sleep-derived
+// metrics (sleep_score, readiness_score) are NOT in this set — they're
+// either event-based (one measurement per session) or finalized by the
+// vendor once sleep ends. Day-mean metrics (hr_day, hrv_day, glucose_avg)
+// are a grey zone: their partial value is biased but not artificially low,
+// and excluding them costs more information than it saves. Out of scope.
+export const CUMULATIVE_METRICS = new Set([
+  'steps',
+  'stress_high_min', // Oura emits seconds in high-stress state, accumulates through the day
+]);
+
 // Default display order for the dashboard strip. A canonical metric not listed
 // here still renders (appended in registry order) — the list just pins priority.
 // Also used as METRICS_FOR_SUMMARY in wearables-summary.js, so any metric that

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -9,7 +9,7 @@
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
 import { getDailyRange } from './wearables-store.js';
-import { DEFAULT_METRIC_ORDER, isMetricValueMeaningful } from './wearable-adapters.js';
+import { DEFAULT_METRIC_ORDER, isMetricValueMeaningful, CUMULATIVE_METRICS } from './wearable-adapters.js';
 import { isDebugMode } from './utils.js';
 import { isoDay } from './wearables-oura.js';
 
@@ -57,9 +57,28 @@ function linearRegressionSlope(values) {
 // Per-metric derivation
 // ─────────────────────────────────────────────────────────
 
+// Today's local date in YYYY-MM-DD. Matches the format vendor adapters use
+// when stamping daily rows (CLAUDE.md: "Local-tz: vendor adapters tag rows
+// with the user's local day, not UTC"). Recomputed per call so a tab left
+// open across midnight gets the right "today" on the next sync.
+function _todayLocalISO() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 function seriesFor(rowsByDate, metricId) {
   const out = [];
+  // For cumulative-from-midnight metrics (steps, stress_high_min), today's
+  // row is a running total that's mathematically incomplete until midnight.
+  // Exclude it so latest / baseline / d7 / d30 / trend all read from the
+  // last finalized day instead of being dragged down by the partial value.
+  const skipTodayForCumulative = CUMULATIVE_METRICS.has(metricId);
+  const todayISO = skipTodayForCumulative ? _todayLocalISO() : null;
   for (const row of rowsByDate) {
+    if (skipTodayForCumulative && row.date === todayISO) continue;
     const v = row[metricId];
     if (isMetricValueMeaningful(metricId, v)) out.push({ date: row.date, v });
   }

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -246,6 +246,41 @@ const sameDateRes = summary.shouldWriteL2(sameDate, oldLagging);
 assert('Gate: identical snapshot (same latestDate) does NOT write',
   sameDateRes.write === false, `reason=${sameDateRes.reason}`);
 
+// Cumulative-from-midnight metrics: today's row is incomplete (still
+// accumulating until 23:59), so L2 must filter it out from latest /
+// baseline / rolling. Otherwise the strip card drags downward all day
+// long as the partial value gets averaged in.
+{
+  const today = new Date();
+  const todayISO = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+  const yesterday = new Date(today); yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayISO = `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, '0')}-${String(yesterday.getDate()).padStart(2, '0')}`;
+  const twoDaysAgo = new Date(today); twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+  const twoDaysAgoISO = `${twoDaysAgo.getFullYear()}-${String(twoDaysAgo.getMonth() + 1).padStart(2, '0')}-${String(twoDaysAgo.getDate()).padStart(2, '0')}`;
+  const cumulRows = [
+    { source: 'oura', date: twoDaysAgoISO, steps: 9000, stress_high_min: 30, hrv_rmssd: 50, rhr: 60 },
+    { source: 'oura', date: yesterdayISO,  steps: 8500, stress_high_min: 25, hrv_rmssd: 50, rhr: 60 },
+    { source: 'oura', date: todayISO,      steps: 1200, stress_high_min: 4,  hrv_rmssd: 50, rhr: 60 }, // partial day
+  ];
+  const cumulSum = summary.computeWearableSummary(
+    { oura: cumulRows },
+    { oura: { connectedSince: twoDaysAgoISO, lastSyncAt: Date.now() } }
+  );
+  assert('Cumulative metric (steps): latest = yesterday, not today',
+    cumulSum.metrics.steps?.latest === 8500,
+    `latest=${cumulSum.metrics.steps?.latest}`);
+  assert('Cumulative metric (steps): latestDate skips today',
+    cumulSum.metrics.steps?.latestDate === yesterdayISO,
+    `latestDate=${cumulSum.metrics.steps?.latestDate}`);
+  assert('Cumulative metric (stress_high_min): today excluded from latest',
+    cumulSum.metrics.stress_high_min?.latest === 25,
+    `latest=${cumulSum.metrics.stress_high_min?.latest}`);
+  // Non-cumulative co-measure: today's value (still 50) should pass through
+  assert('Non-cumulative metric (hrv_rmssd): today included normally',
+    cumulSum.metrics.hrv_rmssd?.latestDate === todayISO,
+    `latestDate=${cumulSum.metrics.hrv_rmssd?.latestDate}`);
+}
+
 // ═══════════════════════════════════════
 // 5. buildWearableContext
 // ═══════════════════════════════════════


### PR DESCRIPTION
## Summary

\`steps\`, \`stress_high_min\`, and other cumulative-from-midnight metrics report a running total that accumulates over the day. Including today's partial value in \`latest\` / \`baseline\` / \`d7\` / \`d30\` / \`trend\` drags every average downward all day long — open the app at 14:00, see "steps: 4,200" as today's reading, and the d7 mean visibly drops because today isn't done yet.

Fix at L2 summary derivation (\`wearables-summary.js\` \`seriesFor\`): for metrics in the new \`CUMULATIVE_METRICS\` set, today's row is filtered out of the computed series. The row stays in L1 IDB so the detail-modal chart can still plot the running total if useful, but the strip card's latest / baseline / rolling all read from the last finalized day.

## Metric scope

**In scope (cumulative across the day):**
- \`steps\` (Oura \`daily_activity.steps\`, Apple Health \`HKQuantityTypeIdentifierStepCount\`, Fitbit, Withings)
- \`stress_high_min\` (Oura emits accumulated seconds in high-stress state)

**Out of scope:**
- Co-measure metrics (HRV, RHR, weight, BP, body fat) and sleep-derived metrics (sleep_score, readiness_score, body_temp_delta) — event-based or finalized once sleep ends, no partial-day issue.
- Day-mean metrics (\`hr_day\`, \`hrv_day\`, \`glucose_avg\`) — biased but not artificially low; excluding them would cost more information than it saves. Out of scope for now.

The \`CUMULATIVE_METRICS\` set lives alongside \`ZERO_IS_LEGITIMATE_METRICS\` in \`wearable-adapters.js\` and is the place to add future additive metrics (\`active_calories\`, \`exercise_time\`, \`distance\`, \`flights_climbed\`, \`time_in_daylight\`, activity time-in-zone) when their adapters land.

## Test plan
- [ ] Sync any wearable mid-day (Oura / Apple Health / Fitbit) — steps card reads yesterday's count as Latest, baseline shouldn't visibly shift compared to before the sync
- [ ] Same for the Stress card (Oura connections only)
- [ ] HRV / RHR / Sleep / Weight cards still show today's value when present (not affected by the filter)
- [ ] After midnight local time, yesterday's now-finalized value enters the average naturally on the next sync
- [ ] \`./run-tests.sh\` — new cumulative-metrics assertions pass; everything else green except the known pre-existing \`chat-shift\` and \`audit-fixes overflow\` flakes