### PR TITLE
Exclude low-step non-wear days from L2 averages

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -117,6 +117,29 @@ export function isMetricValueMeaningful(metricId, v) {
   return v > 0;
 }
 
+// Per-metric minimum daily value below which the day is treated as
+// non-wear / no-data for L2 averaging purposes. The row stays in IDB and
+// still plots on the chart, but baseline / d7 / d30 / trend skip it.
+//
+// Distinct from isMetricValueMeaningful: zero/low values are still valid
+// to STORE and PLOT (so the user can see "ring was off Tuesday"), but
+// they shouldn't drag the rolling-mean baseline downward. Oura users
+// report 5-15 ring-off-for-charging days per quarter; including those
+// 0-step rows in a 30-day mean pulls the average down 10-40%.
+//
+// Threshold rationale (steps): a genuine sedentary couch day still
+// produces 500-2000 steps from incidental movement (kitchen, bathroom,
+// shower). Ring-off-while-charging or phone-left-at-home days produce
+// 0-150. 300 catches non-wear without false-positives on real rest days.
+//
+// Future additive activity metrics should be added here with their own
+// per-metric thresholds when their adapters land:
+//   distance: 100m  · active_calories: 50kcal  · exercise_time: 1min
+//   flights_climbed: 1 (count) · stand_hours: 0 (already excluded by mean)
+export const WEAR_REQUIRED_MINIMUMS = {
+  steps: 300,
+};
+
 // Default display order for the dashboard strip. A canonical metric not listed
 // here still renders (appended in registry order) — the list just pins priority.
 // Also used as METRICS_FOR_SUMMARY in wearables-summary.js, so any metric that

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -9,7 +9,7 @@
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
 import { getDailyRange } from './wearables-store.js';
-import { DEFAULT_METRIC_ORDER, isMetricValueMeaningful } from './wearable-adapters.js';
+import { DEFAULT_METRIC_ORDER, isMetricValueMeaningful, WEAR_REQUIRED_MINIMUMS } from './wearable-adapters.js';
 import { isDebugMode } from './utils.js';
 import { isoDay } from './wearables-oura.js';
 
@@ -59,8 +59,16 @@ function linearRegressionSlope(values) {
 
 function seriesFor(rowsByDate, metricId) {
   const out = [];
+  // For wear-required metrics (steps, etc.), days below the per-metric
+  // minimum are treated as non-wear / no-data and excluded from averages.
+  // The row stays in L1 IDB so the chart still plots the zero (useful for
+  // "I see the ring was off Tuesday"), but baseline / d7 / d30 / trend
+  // ignore it. See WEAR_REQUIRED_MINIMUMS in wearable-adapters.js for the
+  // threshold rationale.
+  const wearMin = WEAR_REQUIRED_MINIMUMS[metricId];
   for (const row of rowsByDate) {
     const v = row[metricId];
+    if (wearMin != null && typeof v === 'number' && v < wearMin) continue;
     if (isMetricValueMeaningful(metricId, v)) out.push({ date: row.date, v });
   }
   return out;

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -246,6 +246,34 @@ const sameDateRes = summary.shouldWriteL2(sameDate, oldLagging);
 assert('Gate: identical snapshot (same latestDate) does NOT write',
   sameDateRes.write === false, `reason=${sameDateRes.reason}`);
 
+// Wear-required minimum (steps): days below 300 steps are non-wear /
+// no-data (ring-off-for-charging, phone-left-at-home, etc.) and must
+// be excluded from baseline / d7 / d30 / mean computations. Otherwise
+// 0-step rows drag the mean down by 10-40% on heavy-charging weeks.
+{
+  // Build 14 days: 4 days @ 0 (ring off charging), then 10 days @ 8000 steps.
+  // Mean including zeros: 80000/14 ≈ 5714
+  // Mean excluding zeros: 80000/10 = 8000 (matches Oura app convention)
+  const wearTestRows = [];
+  for (let i = 0; i < 14; i++) {
+    const d = new Date('2026-04-01'); d.setUTCDate(d.getUTCDate() + i);
+    const dateISO = d.toISOString().slice(0, 10);
+    const steps = i < 4 ? 0 : 8000;
+    wearTestRows.push({ source: 'oura', date: dateISO, steps, hrv_rmssd: 50, rhr: 60, sleep_score: 80, readiness_score: 80 });
+  }
+  const wearSum = summary.computeWearableSummary(
+    { oura: wearTestRows },
+    { oura: { connectedSince: '2026-04-01', lastSyncAt: Date.now() } }
+  );
+  const stepsMetric = wearSum.metrics.steps;
+  assert('Wear-min (steps): d7 mean excludes 0-step non-wear days',
+    stepsMetric?.rolling?.d7 === 8000,
+    `d7=${stepsMetric?.rolling?.d7} (expected 8000; with-zeros mean would be ~5714)`);
+  assert('Wear-min (steps): baseline excludes 0-step non-wear days',
+    stepsMetric?.baseline === 8000,
+    `baseline=${stepsMetric?.baseline}`);
+}
+
 // ═══════════════════════════════════════
 // 5. buildWearableContext
 // ═══════════════════════════════════════


### PR DESCRIPTION
## Summary

User-reported: \`steps\` d7/d30 averages in the strip are 10–40% lower than the Oura app's own numbers. Root cause: Oura emits \`steps=0\` on days the ring is off the wrist (charging, travel, swim laps over 4h, etc.), and our L2 summary includes those zeros in \`mean\` / \`baseline\` calculations. Oura's app filters non-wear days out of its averages.

**Fix at L2 summary level** (\`wearables-summary.js\` \`seriesFor\`): per-metric \`WEAR_REQUIRED_MINIMUMS\` threshold. Days below the threshold are treated as non-wear and excluded from the computed series (\`latest\`, \`baseline\`, \`d7\`, \`d30\`, \`trend30d\`, \`weekly\`). The row stays in L1 IDB and still plots on the detail-modal chart so the user can see "ring was off Tuesday"; only the rolling averages skip it.

## Per-metric threshold: steps = 300

- A genuine sedentary couch day produces 500–2000 steps from incidental movement (kitchen / bathroom / shower).
- Ring-off-charging or phone-at-home days produce 0–150 steps.
- 300 catches non-wear without false-positives on real rest days.

The constant is **per-metric** (not a global "exclude zeros" rule) because \`stress_high_min: 0\` is a legitimate "no high-stress events" day, not non-wear. Future additive activity metrics (\`distance\`, \`active_calories\`, \`exercise_time\`, \`flights_climbed\`) should be added to \`WEAR_REQUIRED_MINIMUMS\` with their own thresholds when their adapters land.

## Test plan
- [ ] Sync Oura mid-week after a few ring-off-charging days — steps d7/d30 mean now matches the Oura app within ~1% (was previously 10–40% lower)
- [ ] Detail-modal chart still shows the 0-step days as visible dots (data isn't removed, just excluded from averages)
- [ ] Apple Health users with iPhone-left-at-home days — same fix applies (source-agnostic L2 filter)
- [ ] Heavy walker who genuinely walked 500 steps on a sick day — value passes through unaffected (above 300 threshold)
- [ ] \`./run-tests.sh\` — new wear-min assertions pass (14-day fixture: 4 zero days + 10 days @ 8000, d7 / baseline both = 8000)

Two known pre-existing test failures unaffected: \`chat-shift\` and \`audit-fixes overflow\`.