### PR TITLE
Show component breakdown in Biological Age detail modal

### DIFF
--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -19,11 +19,12 @@ export function configureMarkerDetailModal(deps = {}) {
 }
 
 // PhenoAge and Bortz Age input lists — kept here (not in data.js) so the
-// detail modal can tell users exactly which markers are still missing for
-// the latest entry, without exposing data.js internals or risking drift.
-// Each tuple is [Human label, category, markerKey]; the category/markerKey
-// pair must match the calculation in data.js (phenoAge / bortzAge) — if you
-// add or remove an input there, mirror it here. Order is what users see.
+// detail modal can tell users exactly which markers are present or still
+// missing for the reference entry, without exposing data.js internals or
+// risking drift. Each tuple is [Human label, category, markerKey]; the
+// category/markerKey pair must match the calculation in data.js (phenoAge /
+// bortzAge) — if you add or remove an input there, mirror it here.
+// Order is what users see in the breakdown.
 const _PHENO_AGE_INPUTS = [
   ['Albumin',         'proteins',     'albumin'],
   ['Creatinine',      'biochemistry', 'creatinine'],
@@ -59,11 +60,28 @@ const _BORTZ_AGE_INPUTS = [
   ['ApoA-I',          'lipids',       'apoAI'],
 ];
 
-function _bioAgeMissingInputs(data, latestIdx) {
-  const getVal = (cat, key) => data.categories?.[cat]?.markers?.[key]?.values?.[latestIdx];
-  const phenoMissing = _PHENO_AGE_INPUTS.filter(([, c, k]) => getVal(c, k) == null).map(([label]) => label);
-  const bortzMissing = _BORTZ_AGE_INPUTS.filter(([, c, k]) => getVal(c, k) == null).map(([label]) => label);
-  return { phenoMissing, bortzMissing };
+// Per-input presence status at a given entry index — drives the ✓/⚠ glyphs
+// in the breakdown so users can see exactly which markers are in their panel.
+function _bioAgeStatusAtIndex(data, idx) {
+  const getVal = (cat, key) => data.categories?.[cat]?.markers?.[key]?.values?.[idx];
+  const phenoStatus = _PHENO_AGE_INPUTS.map(([label, c, k]) => ({ label, present: getVal(c, k) != null }));
+  const bortzStatus = _BORTZ_AGE_INPUTS.map(([label, c, k]) => ({ label, present: getVal(c, k) != null }));
+  return { phenoStatus, bortzStatus };
+}
+
+// biologicalAge falls back to whichever component is non-null per date, so
+// the value users see on the dashboard might be from an older comprehensive
+// panel — NOT the most recent entry. Inspecting markers at data.dates.length-1
+// produced false-positive "all missing" reports when the latest entry was a
+// minimal recent test. Walk backward to find the date the displayed bio age
+// was actually calculated for; that's where the present/missing inputs live.
+function _bioAgeReferenceIndex(data) {
+  const phenoValues = data.categories?.calculatedRatios?.markers?.phenoAge?.values || [];
+  const bortzValues = data.categories?.calculatedRatios?.markers?.bortzAge?.values || [];
+  for (let i = data.dates.length - 1; i >= 0; i--) {
+    if (phenoValues[i] != null || bortzValues[i] != null) return i;
+  }
+  return data.dates.length - 1;
 }
 
 function setDetailModalShell(...classes) {
@@ -521,36 +539,50 @@ export function showDetailModal(id, opts = {}) {
     }
     // Biological Age: show component breakdown. When at least one of
     // PhenoAge / Bortz is calculated, biologicalAge falls back to whichever
-    // is non-null, so the value IS shown on the dashboard. The previous
-    // implementation pushed a status string into `issues` and let the
-    // generic "Not calculated — " header prefix it, which incorrectly
-    // labelled a calculated value as missing. Render the breakdown as a
-    // separate info block instead, and for any missing component, list
-    // the specific markers still needed.
+    // is non-null, so the value IS shown on the dashboard — and the
+    // breakdown inspects the date that value was calculated FOR (not the
+    // latest entry, which might be a minimal recent test that has nothing
+    // in common with the older comprehensive panel the bio age came from).
     if (id === 'calculatedRatios_biologicalAge') {
-      const latestIdx = data.dates.length - 1;
-      const pheno = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[latestIdx];
-      const bortz = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[latestIdx];
-      const age = state.profileDob ? ((new Date(data.dates[latestIdx] + 'T00:00:00') - new Date(state.profileDob + 'T00:00:00')) / (365.25*24*60*60*1000)) : null;
-      const { phenoMissing, bortzMissing } = _bioAgeMissingInputs(data, latestIdx);
-      const componentRow = (name, value, missing) => {
+      const refIdx = _bioAgeReferenceIndex(data);
+      const refDate = data.dates?.[refIdx];
+      const refDateLabel = data.dateLabels?.[refIdx] || refDate || '';
+      const pheno = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[refIdx];
+      const bortz = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[refIdx];
+      const age = state.profileDob && refDate
+        ? ((new Date(refDate + 'T00:00:00') - new Date(state.profileDob + 'T00:00:00')) / (365.25*24*60*60*1000))
+        : null;
+      const { phenoStatus, bortzStatus } = _bioAgeStatusAtIndex(data, refIdx);
+      const renderInputGrid = (status) => status.map(s =>
+        `<span class="bio-age-input ${s.present ? 'is-present' : 'is-missing'}" title="${s.present ? 'In this panel' : 'Missing from this panel'}">${s.present ? '✓' : '⚠'} ${escapeHTML(s.label)}</span>`
+      ).join('');
+      const componentRow = (name, value, status) => {
+        const missing = status.filter(s => !s.present);
+        let header;
         if (value != null) {
           const delta = age != null ? ` <span class="bio-age-delta">(${value - age > 0 ? '+' : ''}${(value - age).toFixed(1)}y)</span>` : '';
-          return `<div class="bio-age-component bio-age-component-ok"><span class="bio-age-glyph">✓</span> <strong>${escapeHTML(name)}:</strong> ${escapeHTML(String(value))}${delta}</div>`;
+          header = `<span class="bio-age-glyph">✓</span> <strong>${escapeHTML(name)}:</strong> ${escapeHTML(String(value))}${delta}`;
+        } else {
+          const noun = missing.length === 1 ? 'input' : 'inputs';
+          header = `<span class="bio-age-glyph">⚠</span> <strong>${escapeHTML(name)}:</strong> missing ${missing.length} of ${status.length} ${noun}`;
         }
-        const labels = missing.map(escapeHTML).join(', ');
-        const noun = missing.length === 1 ? 'input' : 'inputs';
-        return `<div class="bio-age-component bio-age-component-missing"><span class="bio-age-glyph">⚠</span> <strong>${escapeHTML(name)}:</strong> needs ${missing.length} more ${noun}<div class="bio-age-component-list">${labels}</div></div>`;
+        const klass = value != null ? 'bio-age-component-ok' : 'bio-age-component-missing';
+        return `<div class="bio-age-component ${klass}">
+          <div class="bio-age-component-header">${header}</div>
+          <div class="bio-age-input-grid">${renderInputGrid(status)}</div>
+        </div>`;
       };
+      const dateNote = refDateLabel
+        ? `<div class="bio-age-breakdown-sub">Based on your panel from ${escapeHTML(refDateLabel)}</div>`
+        : '';
       html += `<div class="bio-age-breakdown">
         <div class="bio-age-breakdown-head">Component breakdown</div>
-        ${componentRow('PhenoAge', pheno, phenoMissing)}
-        ${componentRow('Bortz Age', bortz, bortzMissing)}
+        ${dateNote}
+        ${componentRow('PhenoAge', pheno, phenoStatus)}
+        ${componentRow('Bortz Age', bortz, bortzStatus)}
       </div>`;
       // Don't double-fire the generic "Not calculated" header for biological
-      // age. When BOTH components are missing, the breakdown block above
-      // already shows the specific markers each needs — that's clearer than
-      // the previous "check their detail views" pointer.
+      // age. The breakdown block above carries the present/missing detail.
     } else if (issues.length > 0) {
       html += `<div class="calc-missing-inputs">Not calculated — ${issues.join('. ')}</div>`;
     }

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -18,6 +18,54 @@ export function configureMarkerDetailModal(deps = {}) {
   Object.assign(markerDetailDeps, deps);
 }
 
+// PhenoAge and Bortz Age input lists — kept here (not in data.js) so the
+// detail modal can tell users exactly which markers are still missing for
+// the latest entry, without exposing data.js internals or risking drift.
+// Each tuple is [Human label, category, markerKey]; the category/markerKey
+// pair must match the calculation in data.js (phenoAge / bortzAge) — if you
+// add or remove an input there, mirror it here. Order is what users see.
+const _PHENO_AGE_INPUTS = [
+  ['Albumin',         'proteins',     'albumin'],
+  ['Creatinine',      'biochemistry', 'creatinine'],
+  ['Glucose',         'biochemistry', 'glucose'],
+  ['hs-CRP',          'proteins',     'hsCRP'],
+  ['Lymphocytes %',   'differential', 'lymphocytesPct'],
+  ['MCV',             'hematology',   'mcv'],
+  ['RDW-CV',          'hematology',   'rdwcv'],
+  ['ALP',             'biochemistry', 'alp'],
+  ['WBC',             'hematology',   'wbc'],
+];
+const _BORTZ_AGE_INPUTS = [
+  ['Albumin',         'proteins',     'albumin'],
+  ['ALP',             'biochemistry', 'alp'],
+  ['Urea',            'biochemistry', 'urea'],
+  ['Cholesterol',     'lipids',       'cholesterol'],
+  ['Creatinine',      'biochemistry', 'creatinine'],
+  ['Cystatin C',      'biochemistry', 'cystatinC'],
+  ['HbA1c',           'diabetes',     'hba1c'],
+  ['hs-CRP',          'proteins',     'hsCRP'],
+  ['GGT',             'biochemistry', 'ggt'],
+  ['RBC',             'hematology',   'rbc'],
+  ['MCV',             'hematology',   'mcv'],
+  ['RDW-CV',          'hematology',   'rdwcv'],
+  ['Monocytes',       'differential', 'monocytes'],
+  ['Neutrophils',     'differential', 'neutrophils'],
+  ['Lymphocytes %',   'differential', 'lymphocytesPct'],
+  ['ALT',             'biochemistry', 'alt'],
+  ['SHBG',            'hormones',     'shbg'],
+  ['Vitamin D',       'vitamins',     'vitaminD'],
+  ['Glucose',         'biochemistry', 'glucose'],
+  ['MCH',             'hematology',   'mch'],
+  ['ApoA-I',          'lipids',       'apoAI'],
+];
+
+function _bioAgeMissingInputs(data, latestIdx) {
+  const getVal = (cat, key) => data.categories?.[cat]?.markers?.[key]?.values?.[latestIdx];
+  const phenoMissing = _PHENO_AGE_INPUTS.filter(([, c, k]) => getVal(c, k) == null).map(([label]) => label);
+  const bortzMissing = _BORTZ_AGE_INPUTS.filter(([, c, k]) => getVal(c, k) == null).map(([label]) => label);
+  return { phenoMissing, bortzMissing };
+}
+
 function setDetailModalShell(...classes) {
   const modal = document.getElementById('detail-modal');
   if (!modal) return null;
@@ -471,24 +519,39 @@ export function showDetailModal(id, opts = {}) {
         }
       }
     }
-    // Biological Age: show component status
+    // Biological Age: show component breakdown. When at least one of
+    // PhenoAge / Bortz is calculated, biologicalAge falls back to whichever
+    // is non-null, so the value IS shown on the dashboard. The previous
+    // implementation pushed a status string into `issues` and let the
+    // generic "Not calculated — " header prefix it, which incorrectly
+    // labelled a calculated value as missing. Render the breakdown as a
+    // separate info block instead, and for any missing component, list
+    // the specific markers still needed.
     if (id === 'calculatedRatios_biologicalAge') {
       const latestIdx = data.dates.length - 1;
       const pheno = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[latestIdx];
       const bortz = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[latestIdx];
-      if (pheno == null && bortz == null) {
-        issues.push('Neither PhenoAge nor Bortz Age could be calculated — check their detail views for missing inputs');
-      } else {
-        const age = state.profileDob ? ((new Date(data.dates[latestIdx] + 'T00:00:00') - new Date(state.profileDob + 'T00:00:00')) / (365.25*24*60*60*1000)) : null;
-        const parts = [];
-        if (pheno != null) parts.push(`PhenoAge: ${pheno}${age ? ' (' + (pheno - age > 0 ? '+' : '') + (pheno - age).toFixed(1) + 'y)' : ''}`);
-        if (bortz != null) parts.push(`Bortz Age: ${bortz}${age ? ' (' + (bortz - age > 0 ? '+' : '') + (bortz - age).toFixed(1) + 'y)' : ''}`);
-        if (pheno == null) parts.push('PhenoAge: not calculated');
-        if (bortz == null) parts.push('Bortz Age: not calculated');
-        issues.push(parts.join(' · '));
-      }
-    }
-    if (issues.length > 0) {
+      const age = state.profileDob ? ((new Date(data.dates[latestIdx] + 'T00:00:00') - new Date(state.profileDob + 'T00:00:00')) / (365.25*24*60*60*1000)) : null;
+      const { phenoMissing, bortzMissing } = _bioAgeMissingInputs(data, latestIdx);
+      const componentRow = (name, value, missing) => {
+        if (value != null) {
+          const delta = age != null ? ` <span class="bio-age-delta">(${value - age > 0 ? '+' : ''}${(value - age).toFixed(1)}y)</span>` : '';
+          return `<div class="bio-age-component bio-age-component-ok"><span class="bio-age-glyph">✓</span> <strong>${escapeHTML(name)}:</strong> ${escapeHTML(String(value))}${delta}</div>`;
+        }
+        const labels = missing.map(escapeHTML).join(', ');
+        const noun = missing.length === 1 ? 'input' : 'inputs';
+        return `<div class="bio-age-component bio-age-component-missing"><span class="bio-age-glyph">⚠</span> <strong>${escapeHTML(name)}:</strong> needs ${missing.length} more ${noun}<div class="bio-age-component-list">${labels}</div></div>`;
+      };
+      html += `<div class="bio-age-breakdown">
+        <div class="bio-age-breakdown-head">Component breakdown</div>
+        ${componentRow('PhenoAge', pheno, phenoMissing)}
+        ${componentRow('Bortz Age', bortz, bortzMissing)}
+      </div>`;
+      // Don't double-fire the generic "Not calculated" header for biological
+      // age. When BOTH components are missing, the breakdown block above
+      // already shows the specific markers each needs — that's clearer than
+      // the previous "check their detail views" pointer.
+    } else if (issues.length > 0) {
       html += `<div class="calc-missing-inputs">Not calculated — ${issues.join('. ')}</div>`;
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -3323,21 +3323,32 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-muted);
-  margin-bottom: 8px;
+  margin-bottom: 4px;
+}
+.marker-detail-modal .bio-age-breakdown-sub {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 10px;
 }
 .marker-detail-modal .bio-age-component {
-  padding: 6px 0;
+  padding: 8px 0;
   font-size: 14px;
 }
 .marker-detail-modal .bio-age-component + .bio-age-component {
   border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  margin-top: 4px;
+  padding-top: 12px;
+}
+.marker-detail-modal .bio-age-component-header {
+  margin-bottom: 6px;
 }
 .marker-detail-modal .bio-age-glyph {
   display: inline-block;
   width: 18px;
   font-weight: 700;
 }
-.marker-detail-modal .bio-age-component-ok .bio-age-glyph {
+.marker-detail-modal .bio-age-component-ok .bio-age-glyph,
+.marker-detail-modal .bio-age-component-ok .bio-age-component-header strong {
   color: var(--success, #22c55e);
 }
 .marker-detail-modal .bio-age-component-missing .bio-age-glyph {
@@ -3348,12 +3359,24 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
   font-weight: 400;
   margin-left: 4px;
 }
-.marker-detail-modal .bio-age-component-list {
+.marker-detail-modal .bio-age-input-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
   margin-top: 4px;
   margin-left: 22px;
   font-size: 12px;
-  color: var(--text-muted);
-  line-height: 1.5;
+  line-height: 1.6;
+}
+.marker-detail-modal .bio-age-input {
+  white-space: nowrap;
+}
+.marker-detail-modal .bio-age-input.is-present {
+  color: var(--success, #22c55e);
+}
+.marker-detail-modal .bio-age-input.is-missing {
+  color: var(--warning, #f59e0b);
+  font-weight: 600;
 }
 .marker-detail-modal .manual-entry-btn,
 .marker-detail-modal .ask-ai-btn {

--- a/styles.css
+++ b/styles.css
@@ -3303,12 +3303,57 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .marker-detail-modal .marker-history-show-more,
 .marker-detail-modal .modal-ref-info,
 .marker-detail-modal .calc-missing-inputs,
+.marker-detail-modal .bio-age-breakdown,
 .marker-detail-modal .manual-entry-btn,
 .marker-detail-modal .marker-note-section,
 .marker-detail-modal [id^="rec-modal-"],
 .marker-detail-modal .ask-ai-btn {
   margin-left: 28px;
   margin-right: 28px;
+}
+.marker-detail-modal .bio-age-breakdown {
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+}
+.marker-detail-modal .bio-age-breakdown-head {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+.marker-detail-modal .bio-age-component {
+  padding: 6px 0;
+  font-size: 14px;
+}
+.marker-detail-modal .bio-age-component + .bio-age-component {
+  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+.marker-detail-modal .bio-age-glyph {
+  display: inline-block;
+  width: 18px;
+  font-weight: 700;
+}
+.marker-detail-modal .bio-age-component-ok .bio-age-glyph {
+  color: var(--success, #22c55e);
+}
+.marker-detail-modal .bio-age-component-missing .bio-age-glyph {
+  color: var(--warning, #f59e0b);
+}
+.marker-detail-modal .bio-age-delta {
+  color: var(--text-muted);
+  font-weight: 400;
+  margin-left: 4px;
+}
+.marker-detail-modal .bio-age-component-list {
+  margin-top: 4px;
+  margin-left: 22px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
 }
 .marker-detail-modal .manual-entry-btn,
 .marker-detail-modal .ask-ai-btn {


### PR DESCRIPTION
## Summary

The Biological Age detail modal previously read **"Not calculated — PhenoAge: 41 · Bortz Age: not calculated"** even when \`biologicalAge\` HAD a value on the dashboard (it falls back to whichever component is non-null). The component-status string was being pushed into the same \`issues\` array used for missing-inputs errors and unconditionally prefixed with "Not calculated —", contradicting the value the user could see on the dashboard widget.

## Fix

Render the component breakdown as a dedicated info block (\`.bio-age-breakdown\`) instead of misusing the issues array. Always shown for biological age, regardless of calculated state:

- **Calculated component**: ✓ glyph + value + delta vs chronological age
- **Missing component**: ⚠ glyph + count + the specific markers still needed ("needs 1 more input · Cystatin C")

The generic "Not calculated —" header path is skipped for biological age now; the breakdown block carries all the information users need without the contradictory framing.

## Why the marker list?

User feedback motivating this PR: *"wouldn't it be good to have a list of tests to do to have it calculated for both? some hint maybe"* — yes, this PR makes that explicit. Instead of telling users to "check their detail views" for each component, the modal directly lists the missing markers.

## Maintenance

Per-component input lists (\`_PHENO_AGE_INPUTS\` / \`_BORTZ_AGE_INPUTS\`) live in \`marker-detail-modal.js\` with a comment instructing maintainers to keep them in sync with \`data.js\`. Adding or removing an input in \`data.js\` requires mirroring it here so the missing-list stays accurate.

## Test plan
- [ ] Open Biological Age detail modal with PhenoAge calculated but Bortz missing — breakdown shows ✓ PhenoAge + ⚠ Bortz with the missing markers listed
- [ ] Open it with everything calculated — both rows show ✓ with values
- [ ] Open it with both missing — both rows show ⚠ with missing-marker lists, no contradictory "Not calculated" header
- [ ] Other calculated-marker detail modals (PhenoAge, Bortz, HOMA-IR, etc.) still show "Not calculated —" header when applicable (only the biological-age branch was changed)
- [ ] \`./run-tests.sh\` — no new failures (only the known pre-existing \`chat-shift\` flake)