### PR TITLE
Mark today's partial value visibly on wearable detail chart

### DIFF
--- a/js/wearables.js
+++ b/js/wearables.js
@@ -1046,6 +1046,24 @@ function renderWearableChart(canvas, canon, m, series) {
   const values = series.map(p => p.v);
   const baselineValues = values.map(() => m.baseline);
 
+  // For cumulative-from-midnight metrics (steps, stress_high_min), today's
+  // row is a running total — incomplete until midnight. The chart plots it
+  // anyway (data isn't lost), but flag today's point so we can render it
+  // differently (visible dot, amber tint, "partial day" tooltip) and dash
+  // the connecting segment, making the in-progress state obvious.
+  //
+  // Kept inline (not imported from wearable-adapters.js) so this UX change
+  // is independent of any L2-summary changes. If a CUMULATIVE_METRICS set
+  // lands centrally later, this can re-import.
+  const CUMULATIVE_CHART_METRICS = new Set(['steps', 'stress_high_min']);
+  const todayISO = (() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  })();
+  const isCumulative = CUMULATIVE_CHART_METRICS.has(canon.id);
+  const isPartialIdx = (idx) => isCumulative && series[idx]?.date === todayISO;
+  const PARTIAL_COLOR = '#f59e0b'; // amber, matches the wear-min ⚠ glyph
+
   // Y-axis padding so baseline line and sparkline aren't clipped to the edge.
   const ymin = Math.min(...values, m.baseline);
   const ymax = Math.max(...values, m.baseline);
@@ -1065,10 +1083,22 @@ function renderWearableChart(canvas, canon, m, series) {
           borderColor: tc.lineColor || '#60a5fa',
           backgroundColor: 'transparent',
           borderWidth: 2,
-          pointRadius: 0,
+          // Hide all points except today's partial — that one renders as a
+          // visible amber dot so users see "this last point is in progress."
+          pointRadius: values.map((_, i) => isPartialIdx(i) ? 5 : 0),
+          pointBackgroundColor: values.map((_, i) => isPartialIdx(i) ? PARTIAL_COLOR : 'transparent'),
+          pointBorderColor: values.map((_, i) => isPartialIdx(i) ? PARTIAL_COLOR : 'transparent'),
           pointHoverRadius: 4,
           tension: 0.3,
           spanGaps: true,
+          // Segment styling: the line segment leading INTO today's partial
+          // point renders dashed, signalling "the trend hasn't completed
+          // here yet." Chart.js v3+ segment API; falls back gracefully on
+          // older versions by ignoring the callback.
+          segment: {
+            borderDash: (ctx) => isPartialIdx(ctx.p1?.parsed?.x != null ? ctx.p1DataIndex : -1) ? [5, 4] : undefined,
+            borderColor: (ctx) => isPartialIdx(ctx.p1DataIndex) ? PARTIAL_COLOR : undefined,
+          },
         },
         {
           label: 'Baseline',
@@ -1091,7 +1121,14 @@ function renderWearableChart(canvas, canon, m, series) {
         tooltip: {
           backgroundColor: tc.tooltipBg, titleColor: tc.tooltipTitle,
           bodyColor: tc.tooltipBody, borderColor: tc.tooltipBorder, borderWidth: 1,
-          callbacks: { label: (c) => `${c.dataset.label}: ${formatV(c.parsed.y)}${unit ? ' ' + unit : ''}` },
+          callbacks: {
+            label: (c) => {
+              const base = `${c.dataset.label}: ${formatV(c.parsed.y)}${unit ? ' ' + unit : ''}`;
+              return (c.datasetIndex === 0 && isPartialIdx(c.dataIndex))
+                ? `${base}  (partial day · in progress)`
+                : base;
+            },
+          },
         },
       },
       scales: {


### PR DESCRIPTION
## Summary

For cumulative-from-midnight metrics (\`steps\`, \`stress_high_min\`), today's row is a running total that keeps accumulating until 23:59. With #364, the L2 summary excludes today from \`latest\` / \`baseline\` / \`d7\` / \`d30\` — but the detail-modal chart still plots it, which previously showed today as a naked dip at the right edge with no indication it was incomplete.

This PR makes the in-progress state obvious without removing data:

- **Today's point** renders as a 5px amber dot (\`#f59e0b\`), matching the warning glyph used elsewhere. All other points stay invisible (\`pointRadius: 0\`) so the line stays clean.
- **The connecting segment** (yesterday → today) renders **dashed in amber** via Chart.js v3+ segment styling. Older Chart.js versions ignore the segment callback gracefully — the dot still shows.
- **Tooltip** on today's point appends "(partial day · in progress)" so hovering confirms what the visual signals.

\`CUMULATIVE_CHART_METRICS\` is kept inline (not imported from \`wearable-adapters.js\`) so this UX change ships standalone, independent of any L2 summary work. If a central \`CUMULATIVE_METRICS\` set lands later this can re-import.

## Test plan
- [ ] Open the Steps detail modal mid-day — last point shows as an amber dot, segment from yesterday to today is dashed
- [ ] Hover the amber dot — tooltip ends with "(partial day · in progress)"
- [ ] Non-cumulative metrics (HRV, RHR, weight, BP) — chart looks unchanged, no amber dots
- [ ] After midnight, yesterday's now-finalized value renders normally on the next sync; the amber marker moves to the new "today"
- [ ] \`./run-tests.sh\` — passes (only known pre-existing chat-shift flake)