### PR TITLE
[codex] Salvage import and supplement fixes

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -640,7 +640,8 @@ function _proxyFetch(url, options) {
 // gives up. 60s is generous for slow models (long prompts still respond
 // within ~10s) but short enough to surface offline state quickly.
 export const FETCH_REQUEST_TIMEOUT_MS = 60000;
-async function _fetchWithRetry(url, options, retries = 2, useProxy = true) {
+export const AI_IMPORT_REQUEST_TIMEOUT_MS = 180000;
+async function _fetchWithRetry(url, options, retries = 2, useProxy = true, requestTimeoutMs = FETCH_REQUEST_TIMEOUT_MS) {
   const fetchFn = useProxy ? _proxyFetch : fetch;
   // Combine the caller's abort signal (if any) with a per-attempt timeout
   // signal so a stalled fetch fails loud instead of hanging forever.
@@ -648,7 +649,8 @@ async function _fetchWithRetry(url, options, retries = 2, useProxy = true) {
   // (readWithStallTimeout) — this one covers the request-establishment
   // phase before chunks start flowing.
   const buildOpts = () => {
-    const timeoutSig = AbortSignal.timeout(FETCH_REQUEST_TIMEOUT_MS);
+    const timeoutMs = Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0 ? requestTimeoutMs : FETCH_REQUEST_TIMEOUT_MS;
+    const timeoutSig = AbortSignal.timeout(timeoutMs);
     let signal;
     if (!options.signal) {
       signal = timeoutSig;
@@ -690,7 +692,8 @@ async function _fetchWithRetry(url, options, retries = 2, useProxy = true) {
         continue;
       }
       if (isTimeout) {
-        throw new Error(`request timed out after ${Math.round(FETCH_REQUEST_TIMEOUT_MS / 1000)}s — check your network`);
+        const timeoutMs = Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0 ? requestTimeoutMs : FETCH_REQUEST_TIMEOUT_MS;
+        throw new Error(`request timed out after ${Math.round(timeoutMs / 1000)}s — check your network`);
       }
       throw e;
     }
@@ -873,7 +876,7 @@ export function needsMaxCompletionTokens(modelId) {
   return /^(gpt-5|o[1-9])([-.]|$)/.test(bare);
 }
 
-async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal }, extraHeaders = {}, { useProxy = true, extraBody = {} } = {}) {
+async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs }, extraHeaders = {}, { useProxy = true, extraBody = {} } = {}) {
   const apiMessages = [];
   if (system) apiMessages.push({ role: 'system', content: system });
   for (const msg of messages) apiMessages.push({ role: msg.role, content: msg.content });
@@ -899,7 +902,7 @@ async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { sys
       },
       body: JSON.stringify(body),
       signal
-    }, 2, useProxy);
+    }, 2, useProxy, requestTimeoutMs);
   } catch (e) {
     throw new Error(`Cannot reach ${providerName} API: ${e.message}`);
   }
@@ -1065,14 +1068,16 @@ export async function callVeniceAPI(opts) {
   document.querySelector('.chat-header-model')?.dispatchEvent(new CustomEvent('e2ee-attestation'));
 
   const _contentStr = (c) => typeof c === 'string' ? c : Array.isArray(c) ? c.filter(b => b.type === 'text').map(b => b.text).join('') : String(c);
-  const { system, messages, maxTokens, onStream, signal } = opts;
+  const { system, messages, maxTokens, onStream, signal, forceNonStream, requestTimeoutMs } = opts;
   const apiMessages = [];
   if (system) apiMessages.push({ role: 'system', content: await encryptMessage(session.aesKey, session.publicKey, system) });
   for (const msg of messages) {
     apiMessages.push({ role: msg.role, content: await encryptMessage(session.aesKey, session.publicKey, _contentStr(msg.content)) });
   }
 
-  const body = { model: modelId, messages: apiMessages, max_tokens: maxTokens || 4096, stream: true, stream_options: { include_usage: true } };
+  const useStream = !forceNonStream;
+  const body = { model: modelId, messages: apiMessages, max_tokens: maxTokens || 4096, stream: useStream };
+  if (useStream) body.stream_options = { include_usage: true };
   let res;
   try {
     res = await _fetchWithRetry('https://api.venice.ai/api/v1/chat/completions', {
@@ -1082,7 +1087,7 @@ export async function callVeniceAPI(opts) {
         'X-Venice-TEE-Model-Pub-Key': session.modelPubKeyHex,
         'X-Venice-TEE-Signing-Algo': 'ecdsa' },
       body: JSON.stringify(body), signal
-    }, 2, true);
+    }, 2, true, requestTimeoutMs);
   } catch (e) { throw new Error(`Cannot reach Venice API: ${e.message}`); }
 
   if (!res.ok) {
@@ -1091,6 +1096,21 @@ export async function callVeniceAPI(opts) {
     let errMsg = `Venice API error (${res.status})`;
     try { const b = await res.json(); errMsg += `: ${b.error?.message || JSON.stringify(b.error)}`; } catch {}
     throw new Error(errMsg);
+  }
+
+  if (!useStream) {
+    const data = await res.json();
+    const usage = data.usage || {};
+    const choice = data.choices?.[0];
+    const encryptedContent = choice?.message?.content || '';
+    const text = await decryptChunk(session.privateKey, encryptedContent);
+    const finishReason = choice?.finish_reason || choice?.native_finish_reason || null;
+    return {
+      text,
+      usage: { inputTokens: usage.prompt_tokens || 0, outputTokens: usage.completion_tokens || 0 },
+      finishReason,
+      truncated: isTokenLimitFinish(finishReason)
+    };
   }
 
   // Streaming with per-chunk decryption

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -39,6 +39,15 @@ export const ID_KEYED_ARRAYS = [
   'lightEnvironment.screens',
 ];
 
+// `_deleted[path]` tombstones can apply to id-keyed arrays and to select
+// natural-key arrays that have a stable sync item id. Lab entries are keyed by
+// collection date in the per-row sync layer, so a deleted import date needs a
+// tombstone or a peer's still-live row can resurrect it before our next push.
+export const TOMBSTONE_ARRAY_PATHS = [
+  ...ID_KEYED_ARRAYS,
+  'entries',
+];
+
 // Arrays whose entries don't carry an `id` but have a stable composite
 // key. Each entry: { path, key: (entry) => string, cap?: number }.
 // During merge we union local + remote, dedup by composite key (later
@@ -54,6 +63,21 @@ export const ID_KEYED_ARRAYS = [
 export const COMPOSITE_KEYED_ARRAYS = [
   { path: 'changeHistory', key: (e) => e?.field && e?.date ? `${e.field}|${e.date}` : null, cap: 200 },
 ];
+
+const LOCAL_WINS_MAP_FIELDS = [
+  'customMarkers',
+  'refOverrides',
+  'categoryLabels',
+  'categoryIcons',
+  'markerLabels',
+  'markerNotes',
+  'markerValueNotes',
+  'manualValues',
+];
+
+export const FRESH_LOCAL_LAB_ENTRY_TTL_MS = 2 * 60 * 1000;
+const TOMBSTONE_META_KEY = '_deletedAt';
+const TOMBSTONE_CLEAR_META_KEY = '_deletedClearedAt';
 
 // Pick a comparable timestamp for conflict resolution. Higher wins.
 // Tries the most recently-edited signal first, falls back through the
@@ -88,6 +112,136 @@ function hasExplicitTimestamp(rec) {
   if (!rec || typeof rec !== 'object') return false;
   return Number.isFinite(rec.updatedAt ?? rec.endedAt ?? rec.startedAt
     ?? rec.capturedAt ?? rec.loggedAt ?? rec.createdAt ?? rec.at);
+}
+
+function mergePlainMap(localMap, remoteMap) {
+  const hasLocal = localMap && typeof localMap === 'object' && !Array.isArray(localMap);
+  const hasRemote = remoteMap && typeof remoteMap === 'object' && !Array.isArray(remoteMap);
+  if (!hasLocal && !hasRemote) return undefined;
+  return { ...(hasRemote ? remoteMap : {}), ...(hasLocal ? localMap : {}) };
+}
+
+function mergeSourceFiles(a, b) {
+  const files = [];
+  for (const item of [a?.sourceFiles, a?.sourceFile, b?.sourceFiles, b?.sourceFile]) {
+    if (Array.isArray(item)) {
+      for (const file of item) if (file && !files.includes(file)) files.push(file);
+    } else if (item && !files.includes(item)) {
+      files.push(item);
+    }
+  }
+  return files;
+}
+
+export function mergeLabEntry(existing, incoming) {
+  if (!existing || typeof existing !== 'object') return incoming;
+  if (!incoming || typeof incoming !== 'object') return existing;
+  const existingTs = pickTimestamp(existing);
+  const incomingTs = pickTimestamp(incoming);
+  const incomingWins = incomingTs > existingTs || incomingTs === existingTs;
+  const base = incomingWins ? { ...existing, ...incoming } : { ...incoming, ...existing };
+  const markers = {};
+  const markerSources = {};
+  const existingMarkers = existing.markers && typeof existing.markers === 'object' ? existing.markers : {};
+  const incomingMarkers = incoming.markers && typeof incoming.markers === 'object' ? incoming.markers : {};
+  const existingSources = existing.markerSources && typeof existing.markerSources === 'object' ? existing.markerSources : {};
+  const incomingSources = incoming.markerSources && typeof incoming.markerSources === 'object' ? incoming.markerSources : {};
+  const markerKeys = new Set([...Object.keys(existingMarkers), ...Object.keys(incomingMarkers)]);
+  for (const key of markerKeys) {
+    if (Object.prototype.hasOwnProperty.call(existingMarkers, key)
+      && Object.prototype.hasOwnProperty.call(incomingMarkers, key)) {
+      markers[key] = incomingWins ? incomingMarkers[key] : existingMarkers[key];
+      markerSources[key] = incomingWins
+        ? (incomingSources[key] || existingSources[key])
+        : (existingSources[key] || incomingSources[key]);
+    } else if (Object.prototype.hasOwnProperty.call(incomingMarkers, key)) {
+      markers[key] = incomingMarkers[key];
+      if (incomingSources[key]) markerSources[key] = incomingSources[key];
+    } else {
+      markers[key] = existingMarkers[key];
+      if (existingSources[key]) markerSources[key] = existingSources[key];
+    }
+  }
+  base.markers = markers;
+  if (Object.keys(markerSources).length) base.markerSources = markerSources;
+  else delete base.markerSources;
+  const sourceFiles = mergeSourceFiles(existing, incoming);
+  if (sourceFiles.length) {
+    base.sourceFiles = sourceFiles;
+    base.sourceFile = incomingWins
+      ? (incoming.sourceFile || existing.sourceFile || sourceFiles[sourceFiles.length - 1])
+      : (existing.sourceFile || incoming.sourceFile || sourceFiles[sourceFiles.length - 1]);
+  }
+  return base;
+}
+
+function mergeLabEntriesByDate(localEntries, remoteEntries) {
+  const hasLocal = Array.isArray(localEntries);
+  const hasRemote = Array.isArray(remoteEntries);
+  if (!hasLocal && !hasRemote) return undefined;
+  const byDate = new Map();
+  const noDate = [];
+  function consume(entries) {
+    if (!Array.isArray(entries)) return;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (typeof entry.date !== 'string' || !entry.date) {
+        noDate.push(entry);
+        continue;
+      }
+      const existing = byDate.get(entry.date);
+      byDate.set(entry.date, existing ? mergeLabEntry(existing, entry) : entry);
+    }
+  }
+  // Remote first, local second. Local wins timestamp ties so a just-imported
+  // unsynced lab entry cannot be wiped by a stale pull.
+  consume(remoteEntries);
+  consume(localEntries);
+  return [...byDate.values(), ...noDate].sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
+}
+
+function isFreshLocalLabEntry(entry, now) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (typeof entry.date !== 'string' || !entry.date) return false;
+  if (!Number.isFinite(entry.updatedAt)) return false;
+  return entry.updatedAt <= now + 1000 && now - entry.updatedAt <= FRESH_LOCAL_LAB_ENTRY_TTL_MS;
+}
+
+export function preserveFreshLocalLabEntries(merged, local, now = Date.now()) {
+  if (!merged || typeof merged !== 'object') return false;
+  if (!local || typeof local !== 'object' || !Array.isArray(local.entries)) return false;
+  const freshLocalEntries = local.entries.filter(entry => isFreshLocalLabEntry(entry, now));
+  if (!freshLocalEntries.length) return false;
+
+  if (!Array.isArray(merged.entries)) merged.entries = [];
+  const deletedEntryDates = new Set(Array.isArray(merged._deleted?.entries) ? merged._deleted.entries : []);
+  const byDate = new Map();
+  for (let i = 0; i < merged.entries.length; i++) {
+    const date = merged.entries[i]?.date;
+    if (typeof date === 'string' && date) byDate.set(date, i);
+  }
+
+  let changed = false;
+  for (const localEntry of freshLocalEntries) {
+    if (deletedEntryDates.has(localEntry.date)) continue;
+    const idx = byDate.get(localEntry.date);
+    if (idx === undefined) {
+      merged.entries.push(localEntry);
+      byDate.set(localEntry.date, merged.entries.length - 1);
+      changed = true;
+      continue;
+    }
+    const before = JSON.stringify(merged.entries[idx]);
+    const next = mergeLabEntry(merged.entries[idx], localEntry);
+    if (JSON.stringify(next) !== before) {
+      merged.entries[idx] = next;
+      changed = true;
+    }
+  }
+  if (changed) {
+    merged.entries.sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
+  }
+  return changed;
 }
 
 // Get/set helpers for the dotted path.
@@ -151,17 +305,98 @@ export function unionById(localArr, remoteArr, tombstones) {
   return [...byId.values(), ...noId];
 }
 
-// Union two tombstone arrays — order-insensitive set union. Capped so a
-// tampered remote payload can't ship 10⁶ fabricated ids and bloat every
-// device's localStorage / pull cost. Real workloads should stay well below
-// this — a user deleting 50 rows/month for a year is 600 entries.
+// Merge tombstones plus explicit "clear" markers. The clear metadata is what
+// lets a later re-import of an already-deleted lab date beat an older tombstone
+// from another device instead of being silently erased on the next pull.
+// Capped so a tampered remote payload can't ship 10⁶ fabricated ids and bloat
+// every device's localStorage / pull cost.
 const TOMBSTONE_CAP_PER_PATH = 5000;
-function mergeTombstones(localT, remoteT) {
-  const out = new Set();
-  if (Array.isArray(localT))  for (const id of localT)  if (typeof id === 'string') out.add(id);
-  if (Array.isArray(remoteT)) for (const id of remoteT) if (typeof id === 'string') out.add(id);
-  if (out.size <= TOMBSTONE_CAP_PER_PATH) return [...out];
-  return [...out].slice(0, TOMBSTONE_CAP_PER_PATH);
+function readMetaAt(importedData, metaKey, path, id) {
+  const n = importedData?.[metaKey]?.[path]?.[id];
+  return Number.isFinite(n) ? n : 0;
+}
+
+function readPathMeta(importedData, metaKey, path) {
+  const meta = importedData?.[metaKey]?.[path];
+  return meta && typeof meta === 'object' && !Array.isArray(meta) ? meta : {};
+}
+
+function ensurePathMeta(importedData, metaKey, path) {
+  if (!importedData[metaKey] || typeof importedData[metaKey] !== 'object' || Array.isArray(importedData[metaKey])) {
+    importedData[metaKey] = {};
+  }
+  if (!importedData[metaKey][path] || typeof importedData[metaKey][path] !== 'object' || Array.isArray(importedData[metaKey][path])) {
+    importedData[metaKey][path] = {};
+  }
+  return importedData[metaKey][path];
+}
+
+function deletePathMeta(importedData, metaKey, path, id) {
+  const root = importedData?.[metaKey];
+  const meta = root?.[path];
+  if (!meta || typeof meta !== 'object') return;
+  delete meta[id];
+  if (Object.keys(meta).length === 0) delete root[path];
+  if (Object.keys(root).length === 0) delete importedData[metaKey];
+}
+
+function mergeTombstoneState(path, local, remote) {
+  const localT = local?._deleted?.[path];
+  const remoteT = remote?._deleted?.[path];
+  const ids = new Set();
+  if (Array.isArray(localT))  for (const id of localT)  if (typeof id === 'string') ids.add(id);
+  if (Array.isArray(remoteT)) for (const id of remoteT) if (typeof id === 'string') ids.add(id);
+
+  const clearIds = new Set([
+    ...Object.keys(readPathMeta(local, TOMBSTONE_CLEAR_META_KEY, path)),
+    ...Object.keys(readPathMeta(remote, TOMBSTONE_CLEAR_META_KEY, path)),
+  ].filter(id => typeof id === 'string' && id));
+
+  const tombstones = [];
+  const tombstoneMeta = Object.create(null);
+  const clearMeta = Object.create(null);
+
+  for (const id of ids) {
+    const tombAt = Math.max(
+      readMetaAt(local, TOMBSTONE_META_KEY, path, id),
+      readMetaAt(remote, TOMBSTONE_META_KEY, path, id)
+    );
+    const clearAt = Math.max(
+      readMetaAt(local, TOMBSTONE_CLEAR_META_KEY, path, id),
+      readMetaAt(remote, TOMBSTONE_CLEAR_META_KEY, path, id)
+    );
+    if (clearAt > tombAt) {
+      clearMeta[id] = clearAt;
+      continue;
+    }
+    tombstones.push(id);
+    if (tombAt) tombstoneMeta[id] = tombAt;
+  }
+
+  for (const id of clearIds) {
+    if (Object.prototype.hasOwnProperty.call(clearMeta, id)) continue;
+    if (ids.has(id)) continue;
+    const clearAt = Math.max(
+      readMetaAt(local, TOMBSTONE_CLEAR_META_KEY, path, id),
+      readMetaAt(remote, TOMBSTONE_CLEAR_META_KEY, path, id)
+    );
+    if (clearAt) clearMeta[id] = clearAt;
+  }
+
+  const cappedTombstones = tombstones.slice(0, TOMBSTONE_CAP_PER_PATH);
+  const cappedSet = new Set(cappedTombstones);
+  for (const id of Object.keys(tombstoneMeta)) {
+    if (!cappedSet.has(id)) delete tombstoneMeta[id];
+  }
+
+  const clearEntries = Object.entries(clearMeta)
+    .filter(([, ts]) => Number.isFinite(ts) && ts > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, TOMBSTONE_CAP_PER_PATH);
+  const cappedClearMeta = Object.create(null);
+  for (const [id, ts] of clearEntries) cappedClearMeta[id] = ts;
+
+  return { tombstones: cappedTombstones, tombstoneMeta, clearMeta: cappedClearMeta };
 }
 
 // Dangerous keys that, if reached via bracket-assignment, mutate the
@@ -187,21 +422,40 @@ export function mergeImportedData(local, remote) {
   // non-id-keyed scalars and arrays.
   const out = { ...remote };
 
+  const mergedEntries = mergeLabEntriesByDate(local.entries, remote.entries);
+  if (mergedEntries) out.entries = mergedEntries;
+
+  for (const field of LOCAL_WINS_MAP_FIELDS) {
+    const mergedMap = mergePlainMap(local[field], remote[field]);
+    if (mergedMap) out[field] = mergedMap;
+  }
+
   // Tombstones — union both sides' deletes. Restricted to paths in
-  // ID_KEYED_ARRAYS to prevent (a) prototype-pollution via `__proto__`
+  // TOMBSTONE_ARRAY_PATHS to prevent (a) prototype-pollution via `__proto__`
   // / `constructor` keys from a tampered remote payload, and (b) unbounded
-  // accumulation of unrelated keys. mergeTombstones itself caps each
+  // accumulation of unrelated keys. mergeTombstoneState itself caps each
   // path's tombstone list at TOMBSTONE_CAP_PER_PATH to limit DoS bloat.
-  const localDel  = (local._deleted  && typeof local._deleted  === 'object') ? local._deleted  : {};
-  const remoteDel = (remote._deleted && typeof remote._deleted === 'object') ? remote._deleted : {};
   const mergedDel = Object.create(null); // null-prototype so __proto__ key cannot mutate the chain
-  for (const path of ID_KEYED_ARRAYS) {
-    if (!isSafeArrayPath(path)) continue; // guard against future ID_KEYED_ARRAYS entries
-    const merged = mergeTombstones(localDel[path], remoteDel[path]);
-    if (merged.length) mergedDel[path] = merged;
+  const mergedDeletedAt = Object.create(null);
+  const mergedDeletedClearedAt = Object.create(null);
+  for (const path of TOMBSTONE_ARRAY_PATHS) {
+    if (!isSafeArrayPath(path)) continue; // guard against future tombstone path additions
+    const merged = mergeTombstoneState(path, local, remote);
+    if (merged.tombstones.length) mergedDel[path] = merged.tombstones;
+    if (Object.keys(merged.tombstoneMeta).length) mergedDeletedAt[path] = merged.tombstoneMeta;
+    if (Object.keys(merged.clearMeta).length) mergedDeletedClearedAt[path] = merged.clearMeta;
   }
   if (Object.keys(mergedDel).length) out._deleted = mergedDel;
   else delete out._deleted;
+  if (Object.keys(mergedDeletedAt).length) out[TOMBSTONE_META_KEY] = mergedDeletedAt;
+  else delete out[TOMBSTONE_META_KEY];
+  if (Object.keys(mergedDeletedClearedAt).length) out[TOMBSTONE_CLEAR_META_KEY] = mergedDeletedClearedAt;
+  else delete out[TOMBSTONE_CLEAR_META_KEY];
+
+  if (Array.isArray(out.entries) && Array.isArray(mergedDel.entries) && mergedDel.entries.length) {
+    const deletedDates = new Set(mergedDel.entries);
+    out.entries = out.entries.filter(entry => !deletedDates.has(entry?.date));
+  }
 
   // For each id-keyed array path, do union-by-id with tombstones applied.
   for (const path of ID_KEYED_ARRAYS) {
@@ -290,6 +544,36 @@ export function mergeImportedData(local, remote) {
 export function localHasRowsRemoteLacks(local, remote) {
   if (!local || typeof local !== 'object') return false;
   if (!remote || typeof remote !== 'object') return true; // no remote, all local is news
+  if (Array.isArray(local.entries)) {
+    const remoteEntries = new Map();
+    if (Array.isArray(remote.entries)) {
+      for (const entry of remote.entries) {
+        if (entry?.date) remoteEntries.set(entry.date, entry);
+      }
+    }
+    for (const entry of local.entries) {
+      if (!entry?.date) continue;
+      const remoteEntry = remoteEntries.get(entry.date);
+      if (!remoteEntry) return true;
+      const localMarkers = entry.markers && typeof entry.markers === 'object' ? entry.markers : {};
+      const remoteMarkers = remoteEntry.markers && typeof remoteEntry.markers === 'object' ? remoteEntry.markers : {};
+      for (const [key, value] of Object.entries(localMarkers)) {
+        if (!Object.prototype.hasOwnProperty.call(remoteMarkers, key)) return true;
+        if (JSON.stringify(value) !== JSON.stringify(remoteMarkers[key])) return true;
+      }
+    }
+  }
+  for (const field of LOCAL_WINS_MAP_FIELDS) {
+    const localMap = local[field];
+    if (!localMap || typeof localMap !== 'object' || Array.isArray(localMap)) continue;
+    const remoteMap = remote[field] && typeof remote[field] === 'object' && !Array.isArray(remote[field])
+      ? remote[field]
+      : {};
+    for (const [key, value] of Object.entries(localMap)) {
+      if (!Object.prototype.hasOwnProperty.call(remoteMap, key)) return true;
+      if (JSON.stringify(value) !== JSON.stringify(remoteMap[key])) return true;
+    }
+  }
   for (const path of ID_KEYED_ARRAYS) {
     const lArr = getAt(local, path);
     const rArr = getAt(remote, path);
@@ -315,25 +599,38 @@ export function localHasRowsRemoteLacks(local, remote) {
     }
   }
   // (3) Tombstones on local but not on remote also need rebroadcast so
-  // the delete propagates. Restricted to ID_KEYED_ARRAYS paths — same
+  // the delete propagates. Restricted to TOMBSTONE_ARRAY_PATHS paths — same
   // guard as mergeImportedData's tombstone block; prevents an attacker-
   // injected path from forcing an infinite rebroadcast.
   const lDel = (local._deleted && typeof local._deleted === 'object') ? local._deleted : {};
   const rDel = (remote._deleted && typeof remote._deleted === 'object') ? remote._deleted : {};
-  for (const path of ID_KEYED_ARRAYS) {
+  for (const path of TOMBSTONE_ARRAY_PATHS) {
     if (!Object.prototype.hasOwnProperty.call(lDel, path)) continue;
     const remoteSet = new Set(Array.isArray(rDel[path]) ? rDel[path] : []);
     for (const id of (lDel[path] || [])) {
       if (typeof id === 'string' && !remoteSet.has(id)) return true;
+      if (typeof id === 'string'
+        && readMetaAt(local, TOMBSTONE_META_KEY, path, id) > readMetaAt(remote, TOMBSTONE_META_KEY, path, id)) {
+        return true;
+      }
+    }
+  }
+  for (const path of TOMBSTONE_ARRAY_PATHS) {
+    const localClears = readPathMeta(local, TOMBSTONE_CLEAR_META_KEY, path);
+    for (const [id, ts] of Object.entries(localClears)) {
+      if (typeof id === 'string' && Number.isFinite(ts)
+        && ts > readMetaAt(remote, TOMBSTONE_CLEAR_META_KEY, path, id)) {
+        return true;
+      }
     }
   }
   return false;
 }
 
-// Record a delete for a known id-keyed array. Mutates the importedData blob
-// in place. Callers (delete sites in sun.js, light-devices.js, etc.) should
-// run this BEFORE the array.filter() that removes the row, so the tombstone
-// survives even if the row is gone before the next sync push.
+// Record a delete for a known sync row. Mutates the importedData blob in place.
+// Callers (delete sites in sun.js, light-devices.js, pdf-import.js, etc.)
+// should run this BEFORE the array.filter() that removes the row, so the
+// tombstone survives even if the row is gone before the next sync push.
 export function recordTombstone(importedData, arrayPath, id) {
   if (!importedData || typeof importedData !== 'object') return;
   if (typeof id !== 'string' || !id) return;
@@ -346,4 +643,21 @@ export function recordTombstone(importedData, arrayPath, id) {
   } else {
     importedData._deleted[arrayPath] = [id];
   }
+  ensurePathMeta(importedData, TOMBSTONE_META_KEY, arrayPath)[id] = Date.now();
+  deletePathMeta(importedData, TOMBSTONE_CLEAR_META_KEY, arrayPath, id);
+}
+
+export function clearTombstone(importedData, arrayPath, id) {
+  if (!importedData || typeof importedData !== 'object') return;
+  if (typeof id !== 'string' || !id) return;
+  ensurePathMeta(importedData, TOMBSTONE_CLEAR_META_KEY, arrayPath)[id] = Date.now();
+  deletePathMeta(importedData, TOMBSTONE_META_KEY, arrayPath, id);
+  const deleted = importedData._deleted;
+  if (!deleted || typeof deleted !== 'object') return;
+  const list = deleted[arrayPath];
+  if (!Array.isArray(list)) return;
+  const next = list.filter(x => x !== id);
+  if (next.length) deleted[arrayPath] = next;
+  else delete deleted[arrayPath];
+  if (Object.keys(deleted).length === 0) delete importedData._deleted;
 }

--- a/js/data.js
+++ b/js/data.js
@@ -102,7 +102,7 @@ function _makeActiveDataCacheMeta() {
 // ═══════════════════════════════════════════════
 // STORAGE
 // ═══════════════════════════════════════════════
-export async function saveImportedData() {
+export async function saveImportedData(options = {}) {
   invalidateActiveDataCache();
   try {
     const key = profileStorageKey(state.currentProfile, 'imported');
@@ -116,9 +116,11 @@ export async function saveImportedData() {
     scheduleAutoBackup();
     touchProfileTimestamp(state.currentProfile);
     if (window.invalidateLabContextCache) window.invalidateLabContextCache();
-    onDataSaved();
+    onDataSaved(options);
+    return true;
   } catch (e) {
     showNotification('Storage limit reached — clear old data or profiles to free space.', 'error');
+    return false;
   }
 }
 

--- a/js/export.js
+++ b/js/export.js
@@ -866,7 +866,18 @@ export function importDataJSON(file) {
         for (const s of json.supplements) {
           if (!s.name || !s.startDate) continue;
           const exists = state.importedData.supplements.some(x => x.name === s.name && x.startDate === s.startDate);
-          if (!exists) { const entry = { name: s.name, dosage: s.dosage || '', startDate: s.startDate, endDate: s.endDate || null, type: s.type || 'supplement', note: s.note || '' }; if (s.ingredients) entry.ingredients = s.ingredients; if (s.periods && s.periods.length > 1) entry.periods = s.periods; state.importedData.supplements.push(entry); }
+          if (!exists) {
+            const entry = { name: s.name, dosage: s.dosage || '', startDate: s.startDate, endDate: s.endDate || null, type: s.type || 'supplement', note: s.note || '' };
+            if (s.ingredients) entry.ingredients = s.ingredients;
+            if (s.periods && s.periods.length > 1) entry.periods = s.periods;
+            if (s.sourceUrl) {
+              try {
+                const sourceUrl = new URL(s.sourceUrl);
+                if (sourceUrl.protocol === 'http:' || sourceUrl.protocol === 'https:') entry.sourceUrl = sourceUrl.toString();
+              } catch {}
+            }
+            state.importedData.supplements.push(entry);
+          }
         }
       }
       // Import notes

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -4,6 +4,7 @@ import { state } from './state.js';
 import { trackUsage, UNIT_CONVERSIONS, getAlternateUnit, convertUserInputToSI } from './schema.js';
 import { escapeHTML, escapeAttr, getStatus, formatValue, showNotification, showConfirmDialog, showPromptDialog, safeMarkerId } from './utils.js';
 import { getActiveData, getEffectiveRange, getEffectiveRangeForDate, saveImportedData, recalculateHOMAIR, updateHeaderDates, convertDisplayToSI } from './data.js';
+import { clearTombstone } from './data-merge.js';
 import { createLineChart, getMarkerDescription } from './charts.js';
 import { closeSuggestionsOnClickOutside } from './context-cards.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from './api.js';
@@ -760,6 +761,7 @@ export async function saveManualEntry(id, opts = {}) {
     if (!await showConfirmDialog(`A value of ${displayVal} ${unit} already exists for ${date}. Overwrite?`)) return;
   }
   if (!state.importedData.entries) state.importedData.entries = [];
+  clearTombstone(state.importedData, 'entries', date);
   let entry = state.importedData.entries.find(e => e.date === date);
   if (!entry) {
     entry = { date: date, markers: {} };

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -5,11 +5,12 @@ import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS, UNIT_CONVERSIONS, calculateCost, 
 import { IMPORT_STEPS } from './constants.js';
 import { escapeHTML, showNotification, isDebugMode, isPIIReviewEnabled, hashString, showPromptDialog } from './utils.js';
 import { saveImportedData, recalculateHOMAIR } from './data.js';
-import { callClaudeAPI, hasAIProvider, getAIProvider, setAIProvider, setVeniceModel, setOpenRouterModel, getOllamaMainModel, setOllamaMainModel, getVeniceModelDisplay, getOpenRouterModelDisplay, getActiveModelId, getActiveModelDisplay, getOllamaPIIModel, setCustomApiModel, setPpqModel, setRoutstrModel } from './api.js';
+import { callClaudeAPI, hasAIProvider, getAIProvider, setAIProvider, setVeniceModel, setOpenRouterModel, getOllamaMainModel, setOllamaMainModel, getVeniceModelDisplay, getOpenRouterModelDisplay, getActiveModelId, getActiveModelDisplay, getOllamaPIIModel, setCustomApiModel, setPpqModel, setRoutstrModel, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { detectProduct, normalizeWithAdapter, getAdapterByTestType } from './adapters.js';
 import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
+import { clearTombstone, recordTombstone } from './data-merge.js';
 
 
 // ═══════════════════════════════════════════════
@@ -93,6 +94,328 @@ function _sanitizeAIMarker(m) {
   if (typeof m.mappedKey === 'string' && !_SAFE_MARKER_KEY.test(m.mappedKey)) m.mappedKey = null;
   if (typeof m.suggestedKey === 'string' && !_SAFE_MARKER_KEY.test(m.suggestedKey)) m.suggestedKey = null;
   return m;
+}
+
+function _stripImportAccents(value) {
+  return String(value || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+const IMPORT_SPECIMEN_PREFIX_RE = /^\s*(used|xxx|fs|fw|s|p|b|u|f)(?=$|[\s._:-])/i;
+
+function _stripImportSpecimenPrefix(value) {
+  return String(value || '').replace(/^\s*(?:used|xxx|fs|fw|s|p|b|u|f)(?=$|[\s._:-])[\s._:-]*/i, '');
+}
+
+function _stripImportLabelUnits(value) {
+  return _stripImportAccents(value)
+    .replace(/[\u00b5\u03bc]/g, 'u')
+    .replace(/\s*[\(\[]\s*[^)\]]*(?:u?kat|mmol|umol|nmol|pmol|mol|mg|ug|ng|pg|g\s*\/\s*l|m\s*u|iu\s*\/\s*l|u\s*\/\s*l|10\s*\^?\s*\d+|arb\.?\s*j\.?|fl|%)[^)\]]*[\)\]]\s*/gi, ' ')
+    .replace(/\s+(?:u?kat|mmol|umol|nmol|pmol|mol|mg|ug|ng|pg|g|m\s*u|iu|u|10\s*\^?\s*\d+|arb\.?\s*j\.?|fl|%)\s*(?:\/\s*[a-z0-9^]+)?\s*$/i, ' ');
+}
+
+function _normalizeImportLabel(value) {
+  return _stripImportLabelUnits(_stripImportSpecimenPrefix(value))
+    .toLowerCase()
+    .replace(/\bvypocet\b/g, '')
+    .replace(/[^a-z0-9#]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function _compactImportLabel(value) {
+  return _normalizeImportLabel(value).replace(/[^a-z0-9#]/g, '');
+}
+
+function _compactImportLabelVariants(value) {
+  const variants = [
+    _compactImportLabel(value),
+    _compactImportLabel(String(value || '').replace(/\s*[\(\[].*?[\)\]]\s*/g, ' ')),
+  ].filter(Boolean);
+  return [...new Set(variants)];
+}
+
+function _cleanImportedMarkerDisplayName(value) {
+  const cleaned = _stripImportLabelUnits(_stripImportSpecimenPrefix(value))
+    .trim()
+    .replace(/\s+/g, ' ');
+  return cleaned || String(value || '').trim();
+}
+
+function _getImportSpecimen(rawName) {
+  const match = String(rawName || '').match(IMPORT_SPECIMEN_PREFIX_RE);
+  return match ? match[1].toLowerCase() : '';
+}
+
+function _isUrineImportSpecimen(specimen) {
+  return specimen === 'u' || specimen === 'used';
+}
+
+function _camelImportKeyPart(value, fallback = 'marker') {
+  const words = _normalizeImportLabel(value).split(/\s+/).filter(Boolean);
+  if (words.length === 0) return fallback;
+  const key = words.map((word, idx) => idx === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)).join('');
+  return key.replace(/^[0-9]+/, '') || fallback;
+}
+
+const URINE_CUSTOM_IMPORT_KEYS = new Map([
+  ['bilkovina', 'urinalysis.proteinQualitative'],
+  ['glukosa', 'urinalysis.glucoseQualitative'],
+  ['glukoza', 'urinalysis.glucoseQualitative'],
+  ['krev', 'urinalysis.bloodQualitative'],
+  ['leukocyty', 'urinalysis.leukocytesQualitative'],
+  ['ketolatky', 'urinalysis.ketonesQualitative'],
+  ['bilirubin', 'urinalysis.bilirubinQualitative'],
+  ['urobilinogen', 'urinalysis.urobilinogenQualitative'],
+  ['nitrity', 'urinalysis.nitritesQualitative'],
+  ['erytrocyty', 'urinalysis.erythrocytes'],
+  ['hlen', 'urinalysis.mucus'],
+  ['kreatinin', 'urinalysis.creatinine'],
+  ['celkbilkovina', 'urinalysis.totalProtein'],
+  ['celkovabilkovina', 'urinalysis.totalProtein'],
+  ['pomerproteinkreatinin', 'urinalysis.proteinCreatinineRatio'],
+]);
+
+function _isSpecimenIncompatibleImportKey(marker, key, standardCats) {
+  if (typeof key !== 'string' || !_SAFE_MARKER_KEY.test(key)) return false;
+  const specimen = _getImportSpecimen(marker?.rawName || marker?.suggestedName || '');
+  if (!_isUrineImportSpecimen(specimen)) return false;
+  const catKey = key.split('.')[0];
+  return standardCats.has(catKey) && catKey !== 'urinalysis';
+}
+
+function _urineSuggestedImportKey(marker) {
+  const label = marker?.rawName || marker?.suggestedName || '';
+  const compact = _compactImportLabel(label).replace(/#/g, '');
+  const known = URINE_CUSTOM_IMPORT_KEYS.get(compact);
+  if (known) return known;
+  return `urinalysis.${_camelImportKeyPart(label, 'urineMarker')}`;
+}
+
+function _demoteSpecimenIncompatibleImportKey(marker, rejectedKey, standardCats) {
+  const suggestedBad = _isSpecimenIncompatibleImportKey(marker, marker.suggestedKey, standardCats);
+  if (!marker.suggestedKey || suggestedBad || marker.suggestedKey === rejectedKey) {
+    marker.suggestedKey = _urineSuggestedImportKey(marker);
+  }
+  marker.suggestedName = marker.suggestedName || _cleanImportedMarkerDisplayName(marker.rawName);
+  marker.suggestedCategoryLabel = marker.suggestedCategoryLabel || 'Urinalysis';
+  marker.mappedKey = null;
+  marker.matched = false;
+}
+
+const BLOOD_IMPORT_ALIASES = new Map([
+  ['glukoza', 'biochemistry.glucose'],
+  ['glukosa', 'biochemistry.glucose'],
+  ['urea', 'biochemistry.urea'],
+  ['kreatinin', 'biochemistry.creatinine'],
+  ['egfckdepi', 'biochemistry.egfr'],
+  ['egfrckdepi', 'biochemistry.egfr'],
+  ['egfr', 'biochemistry.egfr'],
+  ['kyselinamocova', 'biochemistry.uricAcid'],
+  ['bilirubincelkovy', 'biochemistry.bilirubinTotal'],
+  ['ast', 'biochemistry.ast'],
+  ['alt', 'biochemistry.alt'],
+  ['alp', 'biochemistry.alp'],
+  ['ggt', 'biochemistry.ggt'],
+  ['kreatinkinaza', 'biochemistry.creatineKinase'],
+  ['cystatinc', 'biochemistry.cystatinC'],
+  ['gfcystatin', 'biochemistry.gfrCystatin'],
+  ['sodik', 'electrolytes.sodium'],
+  ['draslik', 'electrolytes.potassium'],
+  ['chloridy', 'electrolytes.chloride'],
+  ['cacelkovy', 'electrolytes.calciumTotal'],
+  ['panorganicky', 'electrolytes.phosphorus'],
+  ['horcik', 'electrolytes.magnesium'],
+  ['horcikvery', 'electrolytes.magnesiumRBC'],
+  ['cholesterol', 'lipids.cholesterol'],
+  ['triacylglyceroly', 'lipids.triglycerides'],
+  ['hdlcholesterol', 'lipids.hdl'],
+  ['ldlcholesterol', 'lipids.ldl'],
+  ['apoai', 'lipids.apoAI'],
+  ['apob', 'lipids.apoB'],
+  ['nonhdl', 'lipids.nonHdl'],
+  ['cholhdl', 'lipids.cholHdlRatio'],
+  ['zelezo', 'iron.iron'],
+  ['ferritin', 'iron.ferritin'],
+  ['transferin', 'iron.transferrin'],
+  ['crp', 'proteins.crp'],
+  ['hscrp', 'proteins.hsCRP'],
+  ['celkbilkovina', 'proteins.totalProtein'],
+  ['celkovabilkovina', 'proteins.totalProtein'],
+  ['albumin', 'proteins.albumin'],
+  ['vitamindcelkovy', 'vitamins.vitaminD'],
+  ['kyselinalistova', 'vitamins.folate'],
+  ['hba1c', 'diabetes.hba1c'],
+  ['inzulin', 'hormones.insulin'],
+  ['fsh', 'hormones.fsh'],
+  ['lh', 'hormones.lh'],
+  ['prolaktin', 'hormones.prolactin'],
+  ['shbg', 'hormones.shbg'],
+  ['testosteron', 'hormones.testosterone'],
+  ['fai', 'hormones.fai'],
+  ['igf1', 'hormones.igf1'],
+  ['leukocyty', 'hematology.wbc'],
+  ['erytrocyty', 'hematology.rbc'],
+  ['hemoglobin', 'hematology.hemoglobin'],
+  ['hematokrit', 'hematology.hematocrit'],
+  ['mcv', 'hematology.mcv'],
+  ['mch', 'hematology.mch'],
+  ['mchc', 'hematology.mchc'],
+  ['rdwcv', 'hematology.rdwcv'],
+  ['trombocyty', 'hematology.platelets'],
+  ['trombokrit', 'hematology.pct'],
+  ['pdw', 'hematology.pdw'],
+  ['mpv', 'hematology.mpv'],
+  ['homocystein', 'coagulation.homocysteine'],
+]);
+
+function _standardMarkerShortNames() {
+  const names = new Set();
+  for (const cat of Object.values(MARKER_SCHEMA)) {
+    if (cat.calculated) continue;
+    for (const markerKey of Object.keys(cat.markers || {})) names.add(markerKey);
+  }
+  return names;
+}
+
+function _getExistingImportMarkerKeys() {
+  const keys = new Set();
+  for (const key of Object.keys(state.importedData?.customMarkers || {})) keys.add(key);
+  return keys;
+}
+
+function _knownImportKey(key, testType, refLookup, existingKeys, standardCats) {
+  if (typeof key !== 'string' || !_SAFE_MARKER_KEY.test(key)) return null;
+  const catKey = key.split('.')[0];
+  const standard = standardCats.has(catKey);
+  if (testType !== 'blood' && testType !== 'biostarks' && standard) return null;
+  return (refLookup[key] || existingKeys.has(key)) ? key : null;
+}
+
+function _buildExistingCustomMarkerNameLookup(existingKeys) {
+  const lookup = new Map();
+  const standardCats = new Set(Object.keys(MARKER_SCHEMA));
+  const standardMarkerNames = _standardMarkerShortNames();
+  const add = (label, key) => {
+    const compact = _compactImportLabel(label);
+    if (compact && !lookup.has(compact)) lookup.set(compact, key);
+  };
+  const custom = state.importedData?.customMarkers || {};
+  for (const [key, def] of Object.entries(custom)) {
+    if (!_SAFE_MARKER_KEY.test(key)) continue;
+    const [catKey, markerKey] = key.split('.');
+    if (!standardCats.has(catKey) && standardMarkerNames.has(markerKey)) continue;
+    add(def?.name, key);
+    add(markerKey, key);
+  }
+  for (const key of existingKeys || []) {
+    if (!_SAFE_MARKER_KEY.test(key)) continue;
+    const [catKey, markerKey] = key.split('.');
+    if (!standardCats.has(catKey) && markerKey && !standardMarkerNames.has(markerKey)) add(markerKey, key);
+  }
+  return lookup;
+}
+
+function _resolveExistingCustomImportKey(marker, nameLookup, testType, refLookup, existingKeys, standardCats) {
+  const labels = [marker.rawName, marker.suggestedName];
+  if (marker.suggestedKey) labels.push(marker.suggestedKey.split('.').pop());
+  if (marker.mappedKey) labels.push(marker.mappedKey.split('.').pop());
+  for (const label of labels) {
+    for (const variant of _compactImportLabelVariants(label)) {
+      const key = nameLookup.get(variant);
+      const known = _knownImportKey(key, testType, refLookup, existingKeys, standardCats);
+      if (known) return known;
+    }
+  }
+  return null;
+}
+
+function _buildStandardBloodNameLookup() {
+  const lookup = new Map(BLOOD_IMPORT_ALIASES);
+  const add = (label, key) => {
+    for (const variant of _compactImportLabelVariants(label)) {
+      if (variant && !lookup.has(variant)) lookup.set(variant, key);
+    }
+  };
+  for (const [catKey, cat] of Object.entries(MARKER_SCHEMA)) {
+    if (cat.calculated) continue;
+    for (const [markerKey, marker] of Object.entries(cat.markers || {})) {
+      const fullKey = `${catKey}.${markerKey}`;
+      add(markerKey, fullKey);
+      add(marker.name, fullKey);
+    }
+  }
+  return lookup;
+}
+
+function _resolveStandardBloodImportKey(marker, refLookup) {
+  const rawName = marker.rawName || marker.suggestedName || '';
+  const specimen = _getImportSpecimen(rawName);
+  const unit = normalizeUnitStr(marker.unit || '');
+  const compact = _compactImportLabel(rawName);
+  const compactBase = compact.replace(/#/g, '');
+
+  if (_isUrineImportSpecimen(specimen)) {
+    if (compactBase === 'ph') return 'urinalysis.ph';
+    if (compactBase === 'hustotamoci' || compactBase === 'specifickahustota' || compactBase === 'specificgravity') return 'urinalysis.specificGravity';
+    return null;
+  }
+
+  if (unit === 'arb.j.' || unit.includes('/ul')) return null;
+
+  const hasAbsoluteHint = /#|\babs\b|absolute/i.test(String(rawName)) || unit.includes('10^9');
+  if (compactBase === 'neutrofily') return hasAbsoluteHint ? 'differential.neutrophils' : 'differential.neutrophilsPct';
+  if (compactBase === 'lymfocyty') return hasAbsoluteHint ? 'differential.lymphocytes' : 'differential.lymphocytesPct';
+  if (compactBase === 'monocyty') return hasAbsoluteHint ? 'differential.monocytes' : 'differential.monocytesPct';
+  if (compactBase === 'eosinofily') return hasAbsoluteHint ? 'differential.eosinophils' : null;
+  if (compactBase === 'basofily') return hasAbsoluteHint ? 'differential.basophils' : null;
+
+  const lookup = _buildStandardBloodNameLookup();
+  const labels = [marker.rawName, marker.suggestedName];
+  if (marker.mappedKey) labels.push(marker.mappedKey.split('.').pop());
+  if (marker.suggestedKey) labels.push(marker.suggestedKey.split('.').pop());
+  let key = null;
+  for (const label of labels) {
+    for (const variant of _compactImportLabelVariants(label)) {
+      key = lookup.get(variant);
+      if (key) break;
+    }
+    if (key) break;
+  }
+  if (!key) return null;
+  if (key === 'biochemistry.creatinine' && unit && unit !== normalizeUnitStr('µmol/l')) return null;
+  return refLookup[key] ? key : null;
+}
+
+export function reconcileImportMarkerMappings(markers, options = {}) {
+  if (!Array.isArray(markers)) return markers;
+  const testType = options.testType || 'blood';
+  const refLookup = options.refLookup || buildMarkerReference();
+  const existingKeys = options.existingKeys || _getExistingImportMarkerKeys();
+  const standardCats = new Set(Object.keys(MARKER_SCHEMA));
+  const existingNameLookup = options.existingNameLookup || _buildExistingCustomMarkerNameLookup(existingKeys);
+  for (const marker of markers) {
+    if (!marker) continue;
+    const mappedSpecimenBad = _isSpecimenIncompatibleImportKey(marker, marker.mappedKey, standardCats);
+    const suggestedSpecimenBad = _isSpecimenIncompatibleImportKey(marker, marker.suggestedKey, standardCats);
+    const exactMappedKey = mappedSpecimenBad ? null : _knownImportKey(marker.mappedKey, testType, refLookup, existingKeys, standardCats);
+    const exactSuggestedKey = suggestedSpecimenBad ? null : _knownImportKey(marker.suggestedKey, testType, refLookup, existingKeys, standardCats);
+    const exactKey = exactMappedKey || exactSuggestedKey;
+    const existingCustomKey = exactKey || _resolveExistingCustomImportKey(marker, existingNameLookup, testType, refLookup, existingKeys, standardCats);
+    const aliasKey = testType === 'blood' ? _resolveStandardBloodImportKey(marker, refLookup) : null;
+    const resolvedKey = aliasKey || existingCustomKey;
+    if (resolvedKey) {
+      marker.mappedKey = resolvedKey;
+      marker.matched = true;
+      marker.suggestedKey = null;
+    } else if (mappedSpecimenBad || suggestedSpecimenBad) {
+      _demoteSpecimenIncompatibleImportKey(marker, marker.mappedKey || marker.suggestedKey, standardCats);
+    } else if (marker.mappedKey && !_knownImportKey(marker.mappedKey, testType, refLookup, existingKeys, standardCats)) {
+      if (!marker.suggestedKey && _SAFE_MARKER_KEY.test(marker.mappedKey)) marker.suggestedKey = marker.mappedKey;
+      marker.mappedKey = null;
+      marker.matched = false;
+    }
+  }
+  return markers;
 }
 
 function normalizeToSI(key, value, unit) {
@@ -382,7 +705,7 @@ export function buildMarkerReference() {
 }
 
 export async function extractPDFText(file) {
-  const arrayBuffer = await file.arrayBuffer();
+  const arrayBuffer = await readFileArrayBuffer(file);
   const pdf = await getPdfDocument({ data: arrayBuffer });
   let allItems = [];
   for (let i = 1; i <= pdf.numPages; i++) {
@@ -422,6 +745,54 @@ export async function extractPDFText(file) {
     text += currentRow.sort((a, b) => a.x - b.x).map(r => r.text).join('  ') + '\n';
   }
   return text;
+}
+
+async function readFileArrayBuffer(file) {
+  try {
+    return await file.arrayBuffer();
+  } catch (firstError) {
+    if (typeof FileReader === 'undefined') throw firstError;
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || firstError);
+      reader.onabort = () => reject(firstError);
+      reader.readAsArrayBuffer(file);
+    });
+  }
+}
+
+function isAIStreamAbortError(err) {
+  const message = String(err?.message || err || '').toLowerCase();
+  const name = String(err?.name || '').toLowerCase();
+  return message.includes('bodystreambuffer was aborted')
+    || message.includes('aborted by user')
+    || (message.includes('body') && message.includes('stream') && message.includes('abort'))
+    || name === 'aborterror';
+}
+
+async function callImportAIWithStreamFallback(request, label) {
+  try {
+    return await callClaudeAPI(request);
+  } catch (err) {
+    if (!request.onStream || request.signal?.aborted || !isAIStreamAbortError(err)) throw err;
+    if (isDebugMode()) console.warn(`[Import] ${label} stream aborted; retrying without streaming`, err);
+    try {
+      return await callClaudeAPI({ ...request, onStream: undefined, forceNonStream: true, requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS });
+    } catch (retryErr) {
+      if (isAIStreamAbortError(retryErr)) {
+        throw new Error('AI analysis request was aborted after retrying without streaming. The PDF text extracted correctly; try another model/provider if this persists.');
+      }
+      throw retryErr;
+    }
+  }
+}
+
+function formatImportError(err) {
+  if (isAIStreamAbortError(err)) {
+    return 'AI analysis request was interrupted after privacy review. Try again, or switch provider/model if it repeats.';
+  }
+  return err?.message || String(err);
 }
 
 export function tryParseJSON(str) {
@@ -490,6 +861,7 @@ ${dateHint}
    - CRP: "hs-CRP" / "hsCRP" / "high-sensitivity CRP" / "vysoce senzitivní CRP" → "proteins.hsCRP". Plain "CRP" / "S-CRP" / "C-reaktívny proteín" → "proteins.crp". These are different assays — do not merge them
    - Use the units and reference ranges to help disambiguate
    - IMPORTANT: Many labs prefix marker names with specimen type codes: S- (serum), P- (plasma), B- (blood), U- (urine), fS- (fasting serum), USED- (urine sediment), F- (fecal), FW (sedimentation). Strip these prefixes when matching to known markers. Keep them in rawName for reference
+   - Do NOT map urine-prefixed rows to serum/plasma/blood markers. Example: "S Celk.bílkovina" is serum Total Protein → "proteins.totalProtein", but "U Celková bílkovina" is urine total protein and must be a separate urine marker, not "proteins.totalProtein"
 4. Only map to a marker if you're confident it's the correct match
 5. For differential WBC: only map absolute count values (marked with # or abs.) to the # markers; percentage values go to the Pct markers
 6. Skip non-numeric results (text-only findings, interpretive notes). But EVERY numeric result MUST be included — if it doesn't match a known key, set mappedKey to null and provide suggestedKey/suggestedName/suggestedCategoryLabel. Never silently drop a numeric marker
@@ -540,20 +912,18 @@ Return ONLY valid JSON in this exact format, no other text:
     };
   }
   // Include previously imported marker keys so the AI reuses consistent mappings
-  const existingKeys = new Set();
-  for (const entry of (state.importedData?.entries || [])) {
-    for (const key of Object.keys(entry.markers || {})) existingKeys.add(key);
-  }
+  const existingKeys = _getExistingImportMarkerKeys();
   const existingKeysNote = existingKeys.size > 0
     ? `\n\nIMPORTANT — These marker keys were used in previous imports for this profile. Reuse them for the same biomarkers to ensure consistency:\n${[...existingKeys].join(', ')}`
     : '';
 
-  const { text: response, usage } = await callClaudeAPI({
+  const { text: response, usage } = await callImportAIWithStreamFallback({
     system: system + existingKeysNote,
     messages: [{ role: 'user', content: `Extract all biomarker results from this lab report${fileName ? ' (file: ' + fileName + ')' : ''}:\n\n${pdfText}` }],
     maxTokens,
-    onStream
-  });
+    onStream,
+    requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS
+  }, 'PDF text analysis');
 
   // Parse JSON from response (handle markdown code blocks, thinking tags, truncated output)
   let jsonStr = (response || '').trim();
@@ -583,10 +953,7 @@ Return ONLY valid JSON in this exact format, no other text:
   }
   const standardCats = new Set(Object.keys(MARKER_SCHEMA));
   const _specialtyTypes = ['OAT', 'fattyAcids', 'Metabolomix+', 'DUTCH', 'HTMA', 'GI'];
-  return {
-    date: parsed.date || null,
-    testType,
-    markers: (parsed.markers || []).map(m => {
+  const markers = (parsed.markers || []).map(m => {
       let mappedKey = m.mappedKey || null;
       let matched = !!mappedKey;
       // Guard: never allow standard blood work mappings for known specialty tests
@@ -671,7 +1038,12 @@ Return ONLY valid JSON in this exact format, no other text:
         refMax: m.refMax != null ? m.refMax : null,
         group: m.suggestedGroup || m.group || (testType !== 'blood' ? testType : null) || null
       };
-    }).filter(m => !isNaN(m.value)),
+    }).filter(m => !isNaN(m.value));
+  reconcileImportMarkerMappings(markers, { testType, refLookup: markerRef, existingKeys });
+  return {
+    date: parsed.date || null,
+    testType,
+    markers,
     fileName,
     usage,
     provider
@@ -685,7 +1057,6 @@ export function showImportPreview(parseResult) {
   const { date, markers, fileName } = parseResult;
   const modal = document.getElementById("import-modal");
   const overlay = document.getElementById("import-modal-overlay");
-  const dateFormatted = date ? new Date(date + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) : 'Unknown';
   const matched = markers.filter(m => m.matched);
   const newMarkers = markers.filter(m => !m.matched && m.suggestedKey);
   const unmatched = markers.filter(m => !m.matched && !m.suggestedKey);
@@ -708,7 +1079,7 @@ export function showImportPreview(parseResult) {
       </div>
       <div class="import-review-file">
         <span class="import-review-label">Collection date</span>
-        <strong>${escapeHTML(dateFormatted)}</strong>
+        <input type="date" id="import-manual-date" value="${escapeHTML(date || '')}" onchange="applyManualImportDate(this.value)" aria-label="Collection date">
       </div>
       <div class="import-review-stats" aria-label="Import mapping summary">
         <span class="import-review-stat import-review-stat-matched"><strong>${matched.length}</strong> matched</span>
@@ -725,8 +1096,7 @@ export function showImportPreview(parseResult) {
   }
   if (!date) {
     html += `<div class="import-review-warning import-review-date-warning">
-      Could not extract collection date from PDF. Please enter it manually:
-      <input type="date" id="import-manual-date" onchange="applyManualImportDate(this.value)" aria-label="Manual collection date"></div>`;
+      Could not extract collection date from PDF. Please set it above before importing.</div>`;
   }
   // Build reference lookup (used for unmatched dropdown + range comparison)
   const refLookup = buildMarkerReference();
@@ -964,10 +1334,15 @@ export function applyImportReviewFilters() {
 }
 
 export function applyManualImportDate(dateStr) {
-  if (!window._pendingImport || !dateStr) return;
-  window._pendingImport.date = dateStr;
   const btn = document.getElementById('import-confirm-btn');
-  if (btn) { btn.disabled = false; btn.style.opacity = ''; btn.style.cursor = ''; }
+  if (!window._pendingImport) return;
+  const nextDate = (dateStr || '').trim();
+  window._pendingImport.date = nextDate;
+  if (btn) {
+    btn.disabled = !nextDate;
+    btn.style.opacity = '';
+    btn.style.cursor = '';
+  }
 }
 
 export function toggleImportRow(btn) {
@@ -1004,21 +1379,48 @@ export function closeImportModal() {
   }
 }
 
-export function confirmImport() {
+function snapshotImportedData() {
+  try { return JSON.stringify(state.importedData || {}); } catch { return null; }
+}
+
+function restoreImportedDataSnapshot(snapshot) {
+  if (!snapshot) return;
+  try { state.importedData = JSON.parse(snapshot); } catch {}
+}
+
+function isValidISOCalendarDate(date) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  const [year, month, day] = date.split('-').map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day;
+}
+
+export async function confirmImport() {
   const result = window._pendingImport;
   if (!result || !result.date) return;
+  const confirmBtn = document.getElementById('import-confirm-btn');
+  if (confirmBtn) confirmBtn.disabled = true;
   // Guard: if profile changed during async import, abort to prevent saving to wrong profile
   if (result._importProfileId && result._importProfileId !== state.currentProfile) {
     showNotification('Profile changed during import — import cancelled for safety.', 'error');
     window.closeImportModal();
     return;
   }
+  const rollback = snapshotImportedData();
   const excludedIdxs = _getExcludedIndices();
   const matched = result.markers.filter((m, i) => m.matched && !excludedIdxs.has(i));
   const newMarkers = result.markers.filter((m, i) => !m.matched && m.suggestedKey && !excludedIdxs.has(i));
   const importCount = matched.length + newMarkers.length;
-  if (importCount === 0) { showNotification("No markers to import", "error"); window.closeImportModal(); return; }
+  if (importCount === 0) {
+    showNotification("No markers to import", "error");
+    if (confirmBtn) confirmBtn.disabled = false;
+    window.closeImportModal();
+    return;
+  }
   if (!state.importedData.entries) state.importedData.entries = [];
+  clearTombstone(state.importedData, 'entries', result.date);
   let entry = state.importedData.entries.find(e => e.date === result.date);
   if (!entry) {
     entry = { date: result.date, markers: {} };
@@ -1036,6 +1438,7 @@ export function confirmImport() {
   }
   if (!entry.markerSources) entry.markerSources = {};
   const importTs = Date.now();
+  entry.updatedAt = importTs;
   for (const m of matched) {
     entry.markers[m.mappedKey] = normalizeToSI(m.mappedKey, m.value, m.unit);
     entry.markerSources[m.mappedKey] = { file: result.fileName || null, at: importTs };
@@ -1072,7 +1475,7 @@ export function confirmImport() {
     const categoryLabel = schemaCategory ? schemaCategory.label : m.suggestedCategoryLabel || catKey.charAt(0).toUpperCase() + catKey.slice(1);
     const existing = state.importedData.customMarkers[m.suggestedKey];
     const cmDef = existing || {};
-    cmDef.name = cmDef.name || m.suggestedName || m.rawName;
+    cmDef.name = cmDef.name || _cleanImportedMarkerDisplayName(m.suggestedName || m.rawName);
     cmDef.unit = m.unit || cmDef.unit || '';
     cmDef.refMin = m.refMin != null ? m.refMin : cmDef.refMin;
     cmDef.refMax = m.refMax != null ? m.refMax : cmDef.refMax;
@@ -1118,7 +1521,12 @@ export function confirmImport() {
       state.importedData.refOverrides[m.mappedKey] = ovr;
     }
   }
-  saveImportedData();
+  const saved = await saveImportedData({ immediate: true });
+  if (!saved) {
+    restoreImportedDataSnapshot(rollback);
+    if (confirmBtn) confirmBtn.disabled = false;
+    return;
+  }
   // Resolve batch promise before closeImportModal (which would resolve with 'skip')
   if (window._batchImportResolve) {
     const resolve = window._batchImportResolve;
@@ -1145,44 +1553,55 @@ export function confirmImport() {
   if (!_batchMode && typeof window.maybeShowEncryptionNudge === 'function') window.maybeShowEncryptionNudge();
 }
 
-export function removeImportedEntry(date) {
-  if (!state.importedData.entries) return;
+export async function removeImportedEntry(date) {
+  if (!date) return false;
+  const rollback = snapshotImportedData();
+  if (!state.importedData.entries) state.importedData.entries = [];
+  recordTombstone(state.importedData, 'entries', date);
   state.importedData.entries = state.importedData.entries.filter(e => e.date !== date);
-  saveImportedData();
+  const saved = await saveImportedData({ immediate: true });
+  if (!saved) {
+    restoreImportedDataSnapshot(rollback);
+    return false;
+  }
   window.buildSidebar();
   window.updateHeaderDates();
   // buildSidebar resets .active to Dashboard — use state.currentView.
   window.navigate(state.currentView || "dashboard");
   showNotification(`Removed imported data from ${date}`, "info");
+  return true;
 }
 
 export async function renameImportedEntryDate(oldDate) {
   const entries = state.importedData?.entries;
   const entry = entries?.find(e => e.date === oldDate);
-  if (!entry) return;
+  if (!entry) return false;
   const newDate = await showPromptDialog(
     `Edit collection date (was ${oldDate})`,
     { defaultValue: oldDate, inputType: 'date', okLabel: 'Save' }
   );
-  if (!newDate || newDate === oldDate) return;
+  if (!newDate || newDate === oldDate) return false;
   if (!/^\d{4}-\d{2}-\d{2}$/.test(newDate)) {
     showNotification('Date must be YYYY-MM-DD', 'error');
-    return;
+    return false;
   }
   // Format-only regex accepts logically invalid dates (Feb 30, month 13).
   // Round-trip through Date to reject those — `<input type="date">` already
   // guards in modern browsers, but free-text fallbacks and programmatic
   // values can still slip through.
-  const parsed = new Date(newDate + 'T00:00:00');
-  if (isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== newDate) {
+  if (!isValidISOCalendarDate(newDate)) {
     showNotification('That date doesn\'t exist on the calendar.', 'error');
-    return;
+    return false;
   }
   if (entries.some(e => e.date === newDate)) {
     showNotification(`Another entry already exists on ${newDate} — remove it first, then try again.`, 'error', 5000);
-    return;
+    return false;
   }
+  const rollback = snapshotImportedData();
+  recordTombstone(state.importedData, 'entries', oldDate);
+  clearTombstone(state.importedData, 'entries', newDate);
   entry.date = newDate;
+  entry.updatedAt = Date.now();
   // manualValues are keyed `markerKey:date` — remap to keep manual-vs-imported provenance correct
   const manualValues = state.importedData.manualValues;
   if (manualValues) {
@@ -1195,12 +1614,17 @@ export async function renameImportedEntryDate(oldDate) {
       }
     }
   }
-  saveImportedData();
+  const saved = await saveImportedData({ immediate: true });
+  if (!saved) {
+    restoreImportedDataSnapshot(rollback);
+    return false;
+  }
   window.buildSidebar();
   window.updateHeaderDates();
   // buildSidebar resets .active to Dashboard — use state.currentView.
   window.navigate(state.currentView || "dashboard");
   showNotification(`Date changed from ${oldDate} to ${newDate}`, 'success');
+  return true;
 }
 
 // ═══════════════════════════════════════════════
@@ -1387,7 +1811,7 @@ export function assessTextQuality(text) {
 }
 
 export async function extractPDFImages(file, maxPages = 8) {
-  const arrayBuffer = await file.arrayBuffer();
+  const arrayBuffer = await readFileArrayBuffer(file);
   const pdf = await getPdfDocument({ data: arrayBuffer });
   const pages = Math.min(pdf.numPages, maxPages);
   const images = [];
@@ -1429,7 +1853,7 @@ ${dateHint}
    - unit: the unit as shown
    - refMin: the lower reference range bound EXACTLY as printed on the report (number or null). Do NOT copy from the known markers list above
    - refMax: the upper reference range bound EXACTLY as printed on the report (number or null). Do NOT copy from the known markers list above
-3. Match based on medical/biochemical equivalence, not just string similarity. "hs-CRP"/"hsCRP" → "proteins.hsCRP", plain "CRP" → "proteins.crp" (different assays). Strip specimen-type prefixes (S-, P-, B-, U-, fS-, USED-, F-, FW) when matching — keep in rawName
+3. Match based on medical/biochemical equivalence, not just string similarity. "hs-CRP"/"hsCRP" → "proteins.hsCRP", plain "CRP" → "proteins.crp" (different assays). Strip specimen-type prefixes (S-, P-, B-, U-, fS-, USED-, F-, FW) when matching — keep in rawName. Do NOT map urine-prefixed rows to serum/plasma/blood markers; "U Celková bílkovina" is urine total protein, not serum Total Protein.
 4. Only map to a marker if you're confident it's the correct match
 5. Identify the type of lab test. Return as "testType" field: "blood", "OAT", "fattyAcids", "biostarks", "DUTCH", "HTMA", "GI", or a descriptive name. For fatty acid tests: put ALL markers into ONE product-specific category — spadiaFA (Spadia), zinzinoFA (ZinZino), omegaquantFA (OmegaQuant), or labNameFA. Use suggestedCategoryLabel = product name, suggestedGroup = "Fatty Acids". Do NOT split by fatty acid type (omega-3/omega-6/saturated/trans). For BioStarks: map standard blood markers to standard keys, amino acids to biostarksAmino.*, fatty acids to biostarksFA.*, intracellular minerals (µg/gHb) to biostarksMineral.*, cortisol/T:C ratio to biostarksHormone.*, vitamin E to biostarksVitamin.*
 6. CRITICAL for specialty tests (testType ≠ "blood"): Do NOT use standard blood work category keys. Use test-type-prefixed keys or set mappedKey to null. EXCEPTION: BioStarks (testType "biostarks") is hybrid — DO map its standard blood markers to standard keys
@@ -1465,12 +1889,13 @@ Return ONLY valid JSON in this exact format:
     { type: 'text', text: `Extract all biomarker results from this lab report${fileName ? ' (file: ' + fileName + ')' : ''}. Read every page carefully.` }
   ];
 
-  const { text: response, usage } = await callClaudeAPI({
+  const { text: response, usage } = await callImportAIWithStreamFallback({
     system,
     messages: [{ role: 'user', content }],
     maxTokens,
-    onStream
-  });
+    onStream,
+    requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS
+  }, 'PDF image analysis');
 
   let jsonStr = (response || '').trim();
   jsonStr = jsonStr.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
@@ -1495,10 +1920,7 @@ Return ONLY valid JSON in this exact format:
   }
   const standardCats = new Set(Object.keys(MARKER_SCHEMA));
   const _specialtyTypes = ['OAT', 'fattyAcids', 'Metabolomix+', 'DUTCH', 'HTMA', 'GI'];
-  return {
-    date: parsed.date || null,
-    testType,
-    markers: (parsed.markers || []).map(m => {
+  const markers = (parsed.markers || []).map(m => {
       let mappedKey = m.mappedKey || null;
       let matched = !!mappedKey;
       // Guard: never allow standard blood work mappings for known specialty tests
@@ -1574,7 +1996,12 @@ Return ONLY valid JSON in this exact format:
         suggestedCategoryLabel: m.suggestedCategoryLabel || null,
         suggestedGroup: m.suggestedGroup || null,
       };
-    }),
+    }).filter(m => !isNaN(m.value));
+  reconcileImportMarkerMappings(markers, { testType, refLookup: markerRef });
+  return {
+    date: parsed.date || null,
+    testType,
+    markers,
     usage: usage || {},
     provider,
     imageMode: true,
@@ -1771,7 +2198,7 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
   } catch (err) {
     hideImportProgress('error');
     if (isDebugMode()) console.error("PDF parse error:", err);
-    showNotification("Error parsing PDF: " + err.message, "error", 10000);
+    showNotification("Error parsing PDF: " + formatImportError(err), "error", 10000);
   }
 }
 
@@ -2077,6 +2504,7 @@ export async function handleTextFile(file) {
 // ═══════════════════════════════════════════════
 Object.assign(window, {
   buildMarkerReference,
+  reconcileImportMarkerMappings,
   extractPDFText,
   tryParseJSON,
   parseLabPDFWithAI,

--- a/js/profile.js
+++ b/js/profile.js
@@ -101,6 +101,102 @@ export function createDefaultProfileData() {
   };
 }
 
+function _normalizeProfileMarkerLabel(value) {
+  return String(value || '')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\u00b5\u03bc]/g, 'u')
+    .replace(/\s*[\(\[]\s*[^)\]]*(?:u?kat|mmol|umol|nmol|pmol|mol|mg|ug|ng|pg|g\s*\/\s*l|m\s*u|iu\s*\/\s*l|u\s*\/\s*l|10\s*\^?\s*\d+|arb\.?\s*j\.?|fl|%)[^)\]]*[\)\]]\s*/gi, ' ')
+    .replace(/\s+(?:u?kat|mmol|umol|nmol|pmol|mol|mg|ug|ng|pg|g|m\s*u|iu|u|10\s*\^?\s*\d+|arb\.?\s*j\.?|fl|%)\s*(?:\/\s*[a-z0-9^]+)?\s*$/i, ' ')
+    .replace(/[^a-zA-Z0-9#]+/g, '')
+    .toLowerCase();
+}
+
+function _stripProfileMarkerUnitSuffix(value) {
+  return String(value || '').replace(/(?:u?katl|mmoll|umoll|nmoll|pmoll|mgl|ugl|ngl|gl|iul|ul|percent)$/i, '');
+}
+
+function _hasProfileMarkerUnitDecoration(value) {
+  const raw = String(value || '');
+  if (!raw) return false;
+  if (_stripProfileMarkerUnitSuffix(raw) !== raw) return true;
+  return /\s*[\(\[]\s*[^)\]]*(?:u?kat|mmol|umol|nmol|pmol|mol|mg|ug|ng|pg|g\s*\/\s*l|m\s*u|iu\s*\/\s*l|u\s*\/\s*l|10\s*\^?\s*\d+|arb\.?\s*j\.?|fl|%)[^)\]]*[\)\]]\s*/i.test(raw.replace(/[\u00b5\u03bc]/g, 'u'));
+}
+
+function _buildProfileStandardMarkerLookup() {
+  const lookup = new Map();
+  const add = (label, key) => {
+    const normalized = _normalizeProfileMarkerLabel(label);
+    if (normalized && !lookup.has(normalized)) lookup.set(normalized, key);
+    const suffixStripped = _normalizeProfileMarkerLabel(_stripProfileMarkerUnitSuffix(label));
+    if (suffixStripped && !lookup.has(suffixStripped)) lookup.set(suffixStripped, key);
+  };
+  for (const [catKey, cat] of Object.entries(MARKER_SCHEMA)) {
+    if (cat.calculated) continue;
+    for (const [markerKey, marker] of Object.entries(cat.markers || {})) {
+      const fullKey = `${catKey}.${markerKey}`;
+      add(markerKey, fullKey);
+      add(marker.name, fullKey);
+    }
+  }
+  return lookup;
+}
+
+function _repairUnitSuffixedStandardMarkers(data) {
+  if (!data.entries?.length) return;
+  const lookup = _buildProfileStandardMarkerLookup();
+  const candidates = new Set(Object.keys(data.customMarkers || {}));
+  for (const entry of data.entries) {
+    for (const key of Object.keys(entry.markers || {})) candidates.add(key);
+  }
+  const toDelete = [];
+  for (const fullKey of candidates) {
+    const def = data.customMarkers?.[fullKey] || {};
+    const [catKey, markerKey] = fullKey.split('.');
+    if (!markerKey || SPECIALTY_MARKER_DEFS[fullKey]) continue;
+    if (MARKER_SCHEMA[catKey]?.markers?.[markerKey]) continue;
+    const looksUnitSuffixed = _hasProfileMarkerUnitDecoration(def?.name) || _hasProfileMarkerUnitDecoration(markerKey);
+    if (!looksUnitSuffixed) continue;
+    const target = lookup.get(_normalizeProfileMarkerLabel(def?.name))
+      || lookup.get(_normalizeProfileMarkerLabel(markerKey))
+      || lookup.get(_normalizeProfileMarkerLabel(_stripProfileMarkerUnitSuffix(markerKey)));
+    if (!target || target === fullKey) continue;
+    const targetCatKey = target.split('.')[0];
+    if (catKey === 'urinalysis' && targetCatKey !== 'urinalysis') continue;
+    for (const entry of data.entries) {
+      if (entry.markers?.[fullKey] !== undefined) {
+        if (entry.markers[target] === undefined) entry.markers[target] = entry.markers[fullKey];
+        delete entry.markers[fullKey];
+      }
+      if (entry.markerSources?.[fullKey]) {
+        if (!entry.markerSources[target]) entry.markerSources[target] = entry.markerSources[fullKey];
+        delete entry.markerSources[fullKey];
+      }
+    }
+    const remapByPrefix = (obj) => {
+      if (!obj) return;
+      const prefix = fullKey + ':';
+      for (const key of Object.keys(obj)) {
+        if (!key.startsWith(prefix)) continue;
+        const nextKey = target + key.slice(fullKey.length);
+        if (obj[nextKey] === undefined) obj[nextKey] = obj[key];
+        delete obj[key];
+      }
+    };
+    remapByPrefix(data.manualValues);
+    remapByPrefix(data.markerValueNotes);
+    if (data.refOverrides?.[fullKey]) {
+      if (!data.refOverrides[target]) data.refOverrides[target] = data.refOverrides[fullKey];
+      delete data.refOverrides[fullKey];
+    }
+    if (data.markerNotes?.[fullKey] && !data.markerNotes[target]) data.markerNotes[target] = data.markerNotes[fullKey];
+    if (data.markerNotes) delete data.markerNotes[fullKey];
+    if (data.markerLabels?.[fullKey] && !data.markerLabels[target]) data.markerLabels[target] = data.markerLabels[fullKey];
+    if (data.markerLabels) delete data.markerLabels[fullKey];
+    if (data.customMarkers?.[fullKey]) toDelete.push(fullKey);
+  }
+  for (const key of toDelete) delete data.customMarkers[key];
+}
+
 function queueProfileSync(profileId, importedData = null) {
   if (!profileId) return;
   try {
@@ -213,6 +309,9 @@ export function migrateProfileData(data) {
       }
     }
   }
+  // Repair AI-imported duplicate markers such as `ALP (ukat/l)` that were
+  // stored as custom keys instead of the existing standard schema marker.
+  _repairUnitSuffixedStandardMarkers(data);
   // Fix corrupted FA-prefixed standard markers (bug: _normalizeFattyAcidMarkers rewrote blood work to FA categories)
   if (data.customMarkers && data.entries?.length) {
     // Phase 1: relocate markers whose key matches a standard schema marker

--- a/js/settings.js
+++ b/js/settings.js
@@ -9,6 +9,7 @@ import { isOllamaPIIEnabled, setOllamaPIIEnabled, getOllamaConfig, checkOpenAICo
 import { renderEncryptionSection, renderBackupSection, loadBackupSnapshots } from './crypto.js';
 import { isSyncEnabled, enableSync, disableSync, getMnemonic, getMnemonicResolutionError, getSyncBlocker, restoreFromMnemonic, getSyncRelay, setSyncRelay, checkRelayConnection, isMessengerEnabled, getMessengerToken, generateMessengerToken, revokeMessengerToken, pushContextToGateway } from './sync.js';
 import { renderWearablesSettingsSection } from './wearables.js';
+import { loadPdfImport } from './import-loader.js';
 
 let _providerPanelsLoad = null;
 
@@ -1584,11 +1585,12 @@ export function renderDataEntriesSection() {
         : manualCount > 0
           ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${manualCount} manual</span>`
           : '';
+    const dateArg = escapeAttr(JSON.stringify(entry.date));
     html += `<div class="imported-entry">
       <span class="ie-info"><span class="ie-date">${d}</span><span class="ie-count">${cnt} markers</span>${fileLabel}${sourceLabel}</span>
       <div class="ie-actions">
-        <button class="ie-edit" onclick="renameImportedEntryDate('${entry.date}').then(refreshDataEntriesSection)" title="Edit collection date">Edit date</button>
-        <button class="ie-remove" onclick="removeImportedEntry('${entry.date}');refreshDataEntriesSection()">Remove</button>
+        <button class="ie-edit" onclick="renameImportedEntryDateFromSettings(${dateArg})" title="Edit collection date">Edit date</button>
+        <button class="ie-remove" onclick="removeImportedEntryFromSettings(${dateArg})">Remove</button>
       </div>
     </div>`;
   }
@@ -1603,6 +1605,28 @@ export function renderDataEntriesSection() {
 export function refreshDataEntriesSection() {
   const el = document.getElementById('data-entries-section');
   if (el) el.innerHTML = renderDataEntriesSection();
+}
+
+export async function removeImportedEntryFromSettings(date) {
+  try {
+    const { removeImportedEntry } = await loadPdfImport();
+    const ok = await removeImportedEntry(date);
+    if (ok) refreshDataEntriesSection();
+  } catch (err) {
+    if (isDebugMode()) console.error('Remove imported entry failed:', err);
+    showNotification('Could not remove imported data. Reload and try again.', 'error');
+  }
+}
+
+export async function renameImportedEntryDateFromSettings(date) {
+  try {
+    const { renameImportedEntryDate } = await loadPdfImport();
+    const ok = await renameImportedEntryDate(date);
+    if (ok) refreshDataEntriesSection();
+  } catch (err) {
+    if (isDebugMode()) console.error('Rename imported entry failed:', err);
+    showNotification('Could not edit the import date. Reload and try again.', 'error');
+  }
 }
 
 function formatTokens(n) {
@@ -1668,6 +1692,10 @@ Object.assign(window, {
   updateSettingsUI,
   renderDataEntriesSection,
   refreshDataEntriesSection,
+  removeImportedEntry: removeImportedEntryFromSettings,
+  renameImportedEntryDate: renameImportedEntryDateFromSettings,
+  removeImportedEntryFromSettings,
+  renameImportedEntryDateFromSettings,
   resetCurrentProfileUsage,
   openTweaksPanel,
   closeTweaksPanel,

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -13,6 +13,26 @@ export function getSupplementPeriods(s) {
   return [{ start: s.startDate, end: s.endDate }];
 }
 
+function _parseHttpUrl(raw) {
+  const value = (raw || '').trim();
+  if (!value) return null;
+  try {
+    const parsed = new URL(value);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function _sourceUrlParts(raw) {
+  const parsed = _parseHttpUrl(raw);
+  if (!parsed) return null;
+  return {
+    url: parsed.toString(),
+    host: parsed.hostname.replace(/^www\./, '')
+  };
+}
+
 export function renderSupplementsSection() {
   const supps = state.importedData.supplements || [];
   let html = `<div class="supp-timeline-section">
@@ -293,9 +313,11 @@ function _applyParsedSupplement(parsed) {
 
 async function fetchSupplementFromURL() {
   const urlInput = document.getElementById('supp-url');
-  const url = urlInput?.value.trim();
-  if (!url) { showNotification('Paste a product URL first', 'error'); return; }
-  try { new URL(url); } catch { showNotification('Invalid URL', 'error'); return; }
+  const rawUrl = urlInput?.value.trim();
+  if (!rawUrl) { showNotification('Paste a product URL first', 'error'); return; }
+  const parsedUrl = _parseHttpUrl(rawUrl);
+  if (!parsedUrl) { showNotification('Product URL must be http or https', 'error'); return; }
+  const url = parsedUrl.toString();
   const btn = document.querySelector('.supp-url-fetch');
   if (btn) { btn.textContent = 'Fetching...'; btn.disabled = true; }
   try {
@@ -358,15 +380,16 @@ function _suppFormHtml(editIdx, s) {
   const editing = !!s;
   const ingredients = editing && s.ingredients ? s.ingredients : [];
   const periods = editing ? getSupplementPeriods(s) : [{ start: new Date().toISOString().slice(0, 10), end: null }];
+  const sourceUrl = editing && s.sourceUrl ? s.sourceUrl : '';
   return `<div class="supp-form" id="supp-form-panel">
-    ${hasAIProvider() ? `<div class="supp-form-row supp-url-row">
-      <div class="supp-form-field" style="flex:1"><label>Import from URL</label>
+    <div class="supp-form-row supp-url-row">
+      <div class="supp-form-field" style="flex:1"><label>Product URL <span style="font-weight:normal;color:var(--text-muted)">(saved for reference${hasAIProvider() ? '; Fetch auto-fills' : ''})</span></label>
         <div class="supp-url-input-row">
-          <input type="url" id="supp-url" placeholder="Paste product page link to auto-fill" autocomplete="off">
-          <button class="supp-url-fetch" onclick="fetchSupplementFromURL()">Fetch</button>
+          <input type="url" id="supp-url" placeholder="https://..." autocomplete="off" value="${escapeHTML(sourceUrl)}">
+          ${hasAIProvider() ? `<button class="supp-url-fetch" onclick="fetchSupplementFromURL()">Fetch</button>` : ''}
         </div>
       </div>
-    </div>` : ''}
+    </div>
     <div class="supp-form-row">
       <div class="supp-form-field"><label>Name</label>
         <input type="text" id="supp-name" placeholder="e.g. Creatine, Metformin" value="${editing ? escapeHTML(s.name) : ''}">
@@ -461,11 +484,12 @@ export function openSupplementsEditor(editIdx) {
       const dateRange = pds.length === 1
         ? `${fmtDate(pds[0].start)} \u2192 ${pds[0].end ? fmtDate(pds[0].end) : 'ongoing'}`
         : pds.map(p => `${fmtDate(p.start)}\u2192${p.end ? fmtDate(p.end) : 'now'}`).join(' \u00b7 ');
+      const source = _sourceUrlParts(s.sourceUrl);
       html += `<div class="supp-list-item${isEdit && editIdx === i ? ' supp-list-item-active' : ''}" data-idx="${i}" onclick="toggleSuppAccordion(${i})">
         <span class="supp-list-icon">${icon}</span>
         <div class="supp-list-info">
           <div class="supp-list-name">${escapeHTML(s.name)}${s.dosage ? ` <span class="supp-list-meta">${escapeHTML(s.dosage)}</span>` : ''}</div>
-          <div class="supp-list-meta">${dateRange}</div>
+          <div class="supp-list-meta">${dateRange}${source ? ` &middot; <a href="${escapeHTML(source.url)}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" class="supp-list-source">${escapeHTML(source.host)} ↗</a>` : ''}</div>
           ${s.ingredients?.length ? `<div class="supp-list-ingredients">${s.ingredients.map(ing => {
             const total = ingredientDailyTotal(ing, s);
             const times = effectiveTimesPerDay(ing, s);
@@ -540,11 +564,26 @@ export function saveSupplement(idx) {
   const ingredients = _collectIngredients();
   const timesRaw = document.getElementById('supp-times')?.value.trim();
   const timesNum = timesRaw ? parseFloat(timesRaw) : NaN;
+  const sourceUrlRaw = document.getElementById('supp-url')?.value.trim() || '';
+  let parsedSourceUrl = null;
+  if (sourceUrlRaw) {
+    try {
+      parsedSourceUrl = new URL(sourceUrlRaw);
+      if (parsedSourceUrl.protocol !== 'http:' && parsedSourceUrl.protocol !== 'https:') {
+        showNotification('Product URL must be http or https', 'error');
+        return;
+      }
+    } catch {
+      showNotification('Invalid product URL', 'error');
+      return;
+    }
+  }
   if (!state.importedData.supplements) state.importedData.supplements = [];
   const entry = { name, dosage, startDate, endDate, type, note };
   if (sorted.length > 1) entry.periods = sorted;
   if (ingredients) entry.ingredients = ingredients;
   if (isFinite(timesNum) && timesNum > 0) entry.timesPerDay = timesNum;
+  if (parsedSourceUrl) entry.sourceUrl = parsedSourceUrl.toString();
   if (idx >= 0) {
     state.importedData.supplements[idx] = entry;
   } else {

--- a/js/sync-actions.js
+++ b/js/sync-actions.js
@@ -63,7 +63,7 @@ export async function syncNow() {
 }
 
 // Push all profiles on first enable.
-export async function pushAllProfiles() {
+export async function pushAllProfiles(options = {}) {
   const profiles = getProfiles();
   for (const p of profiles) {
     try {
@@ -73,7 +73,7 @@ export async function pushAllProfiles() {
       } else {
         dataJson = await readProfileImportedData(p.id);
       }
-      if (dataJson) await _pushProfile(p.id, dataJson);
+      if (dataJson) await _pushProfile(p.id, dataJson, options);
     } catch (e) {
       console.error('[sync] Push failed for profile:', p.id, e);
     }

--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -12,7 +12,7 @@ import { configureSyncIdentity, restoreFromMnemonic } from './sync-identity.js';
 import { configureSyncDiagnostics } from './sync-diagnostics.js';
 import { bindSyncUIStatusUpdates, configureSyncUI } from './sync-ui.js';
 import { configureSyncDiagnoseUI } from './sync-diagnose-ui.js';
-import { configureSyncActions, pushCurrentProfile } from './sync-actions.js';
+import { configureSyncActions, pushAllProfiles, pushCurrentProfile } from './sync-actions.js';
 import { bindSyncSaveHookEvents, configureSyncSaveHooks } from './sync-save-hooks.js';
 import { configureSyncPush, isSyncPushInFlight, pushProfile } from './sync-push.js';
 import { configureSyncRecovery } from './sync-recovery.js';
@@ -97,6 +97,7 @@ export function configureSyncModules({ enableSync, disableSync } = {}) {
     getAppOwner: getSyncAppOwner,
     getAppOwnerError: getSyncAppOwnerError,
     getEvolu: getSyncEvolu,
+    seedLocalProfiles: () => pushAllProfiles({ force: true }),
   });
 
   configureSyncDiagnostics({

--- a/js/sync-delta-array-merge.js
+++ b/js/sync-delta-array-merge.js
@@ -1,12 +1,17 @@
 // sync-delta-array-merge.js - Pull-side array row overlay helper.
 
-import { COMPOSITE_KEYED_ARRAYS, pickTimestamp, getAt, setAt } from './data-merge.js';
+import { COMPOSITE_KEYED_ARRAYS, pickTimestamp, getAt, setAt, mergeLabEntry } from './data-merge.js';
 import { recordPullDeltaSurface } from './sync-delta-observability.js';
 import {
   DELTA_ARRAY_CONFIG,
   _isAllowlistSafeId,
 } from './sync-delta-registry.js';
 import { decodeRowPayload } from './sync-delta-row-codec.js';
+
+function parseRowSyncedAt(row) {
+  const ts = Date.parse(row?.syncedAt || '');
+  return Number.isFinite(ts) ? ts : 0;
+}
 
 export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
   // Read/write the target array: flat top-level for most surfaces, dotted-path
@@ -24,15 +29,20 @@ export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
   // Seed the tombstone set with the local blob's `_deleted[path]` list before
   // walking relay rows. Trust local user intent while Phase 1 dual-write can
   // still race peer pushes.
-  const tombs = new Set();
+  const localTombs = new Set();
+  const remoteTombs = new Map();
   try {
     const localDel = imported && imported._deleted;
     const localList = localDel && Array.isArray(localDel[arrayName]) ? localDel[arrayName] : null;
-    if (localList) for (const id of localList) if (typeof id === 'string') tombs.add(id);
+    if (localList) for (const id of localList) if (typeof id === 'string') localTombs.add(id);
   } catch {}
   const liveById = new Map(); // itemId -> { item, ts, syncedAt }
   for (const row of arrRows) {
-    if (row.isDeleted) { tombs.add(row.itemId); continue; }
+    if (row.isDeleted) {
+      const prev = remoteTombs.get(row.itemId) || 0;
+      remoteTombs.set(row.itemId, Math.max(prev, parseRowSyncedAt(row)));
+      continue;
+    }
     try {
       const item = await decodeRowPayload(row);
       // Verify the payload's derived itemId matches the row column.
@@ -49,9 +59,24 @@ export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
       }
     } catch {}
   }
+  const tombstoneWinsOverItem = (itemId, item) => {
+    if (!itemId) return false;
+    if (localTombs.has(itemId)) return true;
+    const tombAt = remoteTombs.get(itemId);
+    if (tombAt == null) return false;
+    return tombAt >= pickTimestamp(item);
+  };
+  const tombstoneWinsOverLiveRow = (itemId, entry) => {
+    if (!itemId) return false;
+    if (localTombs.has(itemId)) return true;
+    const tombAt = remoteTombs.get(itemId);
+    if (tombAt == null) return false;
+    const liveAt = Math.max(entry?.ts || 0, Date.parse(entry?.syncedAt || '') || 0);
+    return tombAt >= liveAt;
+  };
   // Apply tombstones (drop) + live (replace or insert). Both sides key on
   // itemIdFn so changeHistory finds existing entries by synthesized id.
-  let nextArr = curArr.filter(it => !tombs.has(itemIdFn(it)));
+  let nextArr = curArr.filter(it => !tombstoneWinsOverItem(itemIdFn(it), it));
   // Dedup `nextArr` by itemIdFn before the liveById overlay. Keep the first
   // occurrence; the live overlay below will replace it with relay-authority.
   const seen = new Map();
@@ -71,10 +96,12 @@ export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
   }
   for (const [itemId, entry] of liveById) {
     // Honour blob tombstones seeded above.
-    if (tombs.has(itemId)) continue;
+    if (tombstoneWinsOverLiveRow(itemId, entry)) continue;
     const item = entry.item;
     const idx = seen.get(itemId);
-    if (idx !== undefined) nextArr[idx] = item;
+    if (idx !== undefined) {
+      nextArr[idx] = arrayName === 'entries' ? mergeLabEntry(nextArr[idx], item) : item;
+    }
     else nextArr.push(item);
   }
   writeArr(nextArr);
@@ -90,5 +117,5 @@ export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
     });
     writeArr(trimmed.slice(0, cap));
   }
-  recordPullDeltaSurface(arrayName, { live: liveById.size, tombstones: tombs.size });
+  recordPullDeltaSurface(arrayName, { live: liveById.size, tombstones: localTombs.size + remoteTombs.size });
 }

--- a/js/sync-diagnose-identity-actions.js
+++ b/js/sync-diagnose-identity-actions.js
@@ -151,7 +151,7 @@ export async function confirmRotateIdentity(btn) {
       if (!currentSyncEnabled()) {
         await enableSyncForDiagnose({ skipPush: true });
       }
-      const ok = await restoreMnemonicForDiagnose(words.join(' '));
+      const ok = await restoreMnemonicForDiagnose(words.join(' '), { seedLocal: true });
       if (!ok) {
         showNotification('Restore returned false — generated mnemonic was rejected', 'error');
         applyBtn.disabled = false;

--- a/js/sync-disable-cleanup.js
+++ b/js/sync-disable-cleanup.js
@@ -5,6 +5,7 @@ export function isSyncDisableCleanupKey(key) {
     && (key.includes('-delta-')
       || key.includes('-sync-cutover-v2')
       || key.includes('-relay-bytes-')
+      || key === 'labcharts-sync-restore-join-pending'
       || key === 'labcharts-relay-quota-warned');
 }
 

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -10,11 +10,20 @@ let _qrCodeLoad = null;
 let _getAppOwner = () => null;
 let _getAppOwnerError = () => null;
 let _getEvolu = () => null;
+let _seedLocalProfiles = async () => {};
 
-export function configureSyncIdentity({ getAppOwner, getAppOwnerError, getEvolu } = {}) {
+export const RESTORE_JOIN_PENDING_KEY = 'labcharts-sync-restore-join-pending';
+
+export function configureSyncIdentity({
+  getAppOwner,
+  getAppOwnerError,
+  getEvolu,
+  seedLocalProfiles,
+} = {}) {
   if (typeof getAppOwner === 'function') _getAppOwner = getAppOwner;
   if (typeof getAppOwnerError === 'function') _getAppOwnerError = getAppOwnerError;
   if (typeof getEvolu === 'function') _getEvolu = getEvolu;
+  if (typeof seedLocalProfiles === 'function') _seedLocalProfiles = seedLocalProfiles;
 }
 
 function currentAppOwner() {
@@ -69,7 +78,22 @@ export function getMnemonicResolutionError() {
   try { return _getAppOwnerError?.() || null; } catch { return null; }
 }
 
-export async function restoreFromMnemonic(mnemonic) {
+function setRestoreJoinPending(enabled) {
+  try {
+    if (enabled) localStorage.setItem(RESTORE_JOIN_PENDING_KEY, String(Date.now()));
+    else localStorage.removeItem(RESTORE_JOIN_PENDING_KEY);
+  } catch {}
+}
+
+export function isRestoreJoinPending() {
+  try { return !!localStorage.getItem(RESTORE_JOIN_PENDING_KEY); } catch { return false; }
+}
+
+export function clearRestoreJoinPending() {
+  setRestoreJoinPending(false);
+}
+
+export async function restoreFromMnemonic(mnemonic, options = {}) {
   const evolu = currentEvolu();
   if (!evolu) return false;
   try {
@@ -79,7 +103,17 @@ export async function restoreFromMnemonic(mnemonic) {
     // leaving the new owner's relay empty. Drop snapshots so the first push
     // under the new identity re-emits everything as inserts.
     clearSyncDisableStorage();
-    showNotification('Restored from mnemonic — reloading…', 'success');
+    if (options?.seedLocal) {
+      setRestoreJoinPending(false);
+      await _seedLocalProfiles();
+      showNotification('Restored mnemonic and seeded this device — reloading…', 'success');
+    } else {
+      // This device is joining an existing owner. On first pull, old local
+      // tombstones from the previous owner must not veto the source device's
+      // rows, or a stale "deleted May" marker can re-delete valid data.
+      setRestoreJoinPending(true);
+      showNotification('Restored from mnemonic — reloading…', 'success');
+    }
     // Reload so the app re-initializes from the restored CRDT identity.
     setTimeout(() => window.location.reload(), 500);
     return true;

--- a/js/sync-lifecycle.js
+++ b/js/sync-lifecycle.js
@@ -7,7 +7,7 @@ import { clearSyncDisableStorage } from './sync-disable-cleanup.js';
 import { resetSyncStatus } from './sync-state.js';
 import { pushAllProfiles } from './sync-actions.js';
 import { clearSyncSaveTimers } from './sync-save-hooks.js';
-import { clearSyncPullTimers } from './sync-pull.js';
+import { clearSyncPullTimers, forcePull } from './sync-pull.js';
 import { clearSyncSubscriptionTimers } from './sync-subscriptions.js';
 import { renderSyncIndicator } from './sync-ui.js';
 import { initSync } from './sync-init.js';
@@ -52,6 +52,7 @@ export async function enableSync({ skipPush = false } = {}) {
     await Promise.race([queryLoaded, new Promise(r => setTimeout(r, 30000))]);
   }
   if (!skipPush) {
+    try { await forcePull(); } catch (e) { console.warn('[sync] initial pull failed:', e); }
     try { await pushAllProfiles(); } catch (e) { console.warn('[sync] initial push failed:', e); }
   }
   showNotification('Sync enabled', 'success');

--- a/js/sync-pull-merge.js
+++ b/js/sync-pull-merge.js
@@ -3,9 +3,10 @@
 import { state } from './state.js';
 import { profileStorageKey, getProfiles, saveProfiles } from './profile.js';
 import { getEncryptionEnabled, encryptedSetItem, encryptedGetItem } from './crypto.js';
-import { mergeImportedData, localHasRowsRemoteLacks } from './data-merge.js';
+import { mergeImportedData, localHasRowsRemoteLacks, preserveFreshLocalLabEntries } from './data-merge.js';
 import { parseSyncPayload } from './sync-payload.js';
 import { _mergeItemRowsIntoImported } from './sync-delta.js';
+import { isRestoreJoinPending } from './sync-identity.js';
 
 export const PROFILE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 
@@ -84,11 +85,22 @@ function countArray(b, k) {
   return Array.isArray(b?.[k]) ? b[k].length : 0;
 }
 
+function withoutLocalTombstones(importedData) {
+  if (!importedData || typeof importedData !== 'object') return importedData;
+  if (!importedData._deleted && !importedData._deletedAt && !importedData._deletedClearedAt) return importedData;
+  const { _deleted, _deletedAt, _deletedClearedAt, ...rest } = importedData;
+  return rest;
+}
+
 export async function mergePulledImportedData(profileId, importedData, { debug } = {}) {
   const localKey = profileStorageKey(profileId, 'imported');
   const localImportedForMerge = profileId === state.currentProfile
     ? (state.importedData || null)
     : await readStoredImportedData(localKey, debug, 'merge');
+  const restoreJoinApplied = profileId === state.currentProfile && isRestoreJoinPending();
+  const localBaselineForMerge = restoreJoinApplied
+    ? withoutLocalTombstones(localImportedForMerge)
+    : localImportedForMerge;
 
   // Preserve local wearableConnections - they're stripped from the push
   // payload (tokens stay per-device), so the remote blob never carries
@@ -104,8 +116,8 @@ export async function mergePulledImportedData(profileId, importedData, { debug }
   // v4 cutover: importedData is null by design. Use local as the baseline;
   // per-row overlay below fills in every field. v3 and older still merge
   // blob-into-local as before.
-  let merged = localImportedForMerge
-    ? (importedData ? mergeImportedData(localImportedForMerge, importedData) : localImportedForMerge)
+  let merged = localBaselineForMerge
+    ? (importedData ? mergeImportedData(localBaselineForMerge, importedData) : localBaselineForMerge)
     : (importedData || {});
 
   // Phase 1 of CRDT-delta refactor: overlay per-row tables AFTER the blob
@@ -116,11 +128,13 @@ export async function mergePulledImportedData(profileId, importedData, { debug }
   } catch (e) {
     console.warn('[sync] per-row overlay merge failed (blob still applied):', e?.message || e);
   }
+  const preservedFreshLocalEntries = preserveFreshLocalLabEntries(merged, localImportedForMerge);
 
   const mergeMsg = `Pull ${profileId.slice(0,8)} — local sun=${countArray(localImportedForMerge,'sunSessions')}/dev=${countArray(localImportedForMerge,'lightDevices')} · remote sun=${countArray(importedData,'sunSessions')}/dev=${countArray(importedData,'lightDevices')} · merged sun=${countArray(merged,'sunSessions')}/dev=${countArray(merged,'lightDevices')}`;
-  const needsRebroadcast = !!localImportedForMerge && !!importedData
-    && localHasRowsRemoteLacks(localImportedForMerge, importedData);
-  const remoteBroughtNewRows = !!localImportedForMerge && !!importedData
+  const needsRebroadcast = preservedFreshLocalEntries
+    || (!!localImportedForMerge && !!importedData
+      && localHasRowsRemoteLacks(localImportedForMerge, importedData));
+  const remoteBroughtNewRows = !preservedFreshLocalEntries && !!localImportedForMerge && !!importedData
     && localHasRowsRemoteLacks(importedData, localImportedForMerge);
 
   return {
@@ -130,6 +144,7 @@ export async function mergePulledImportedData(profileId, importedData, { debug }
     mergeMsg,
     needsRebroadcast,
     remoteBroughtNewRows,
+    restoreJoinApplied,
   };
 }
 

--- a/js/sync-pull.js
+++ b/js/sync-pull.js
@@ -13,6 +13,7 @@ import {
 } from './sync-pull-merge.js';
 import { maybeScheduleRebroadcast } from './sync-pull-rebroadcast.js';
 import { applyRemoteTombstones } from './sync-tombstones.js';
+import { clearRestoreJoinPending } from './sync-identity.js';
 import {
   logSyncEvent, updateSyncStatus,
 } from './sync-state.js';
@@ -71,8 +72,7 @@ export function forcePull() {
   }
   _pulling = false;
   dbg('Force pull triggered');
-  onSyncReceived();
-  return 'triggered';
+  return onSyncReceived();
 }
 
 function scheduleChatPullRetry(profileId, delayMs) {
@@ -172,12 +172,13 @@ export async function onSyncReceived() {
 
         const {
           localKey, merged, mergeMsg,
-          needsRebroadcast, remoteBroughtNewRows,
+          needsRebroadcast, remoteBroughtNewRows, restoreJoinApplied,
         } = await mergePulledImportedData(profileId, importedData, { debug: dbg });
         dbg(mergeMsg);
         logSyncEvent('pull', mergeMsg);
 
         await persistPulledImportedData(localKey, profileId, merged, remoteUpdated);
+        if (restoreJoinApplied) clearRestoreJoinPending();
 
         if (await mergePulledProfile(profileId, profile)) {
           profilesChanged = true;

--- a/js/sync-push.js
+++ b/js/sync-push.js
@@ -58,7 +58,7 @@ export async function pushProfile(profileId, importedData, opts = {}) {
   // run regardless of a stuck flag from a prior wedged push.
   if (!opts.force && _syncing && Date.now() - _syncingSince < 60_000) {
     console.warn('[sync] pushProfile bailed — another push is in-flight (set <60s ago)');
-    return;
+    return { ok: false, skipped: true, reason: 'in-flight' };
   }
   if (_syncing && !opts.force) console.warn('[sync] pushProfile clearing stale _syncing flag (>60s old)');
   if (opts.force && _syncing) console.warn('[sync] pushProfile force-overriding in-flight flag');
@@ -104,85 +104,95 @@ export async function pushProfile(profileId, importedData, opts = {}) {
 
     const { deltaPlans, deltaOpCount } = await planProfileDeltas(profileId, importedData);
 
-    let completed = false;
-    let watchdogId = null;
-    const finish = () => {
-      _syncing = false;
-      if (watchdogId !== null) { clearTimeout(watchdogId); watchdogId = null; }
-    };
-    const onComplete = () => {
-      completed = true;
-      const elapsed = Date.now() - queuedAt;
-      updateSyncStatus({ push: 'confirmed', pushConfirmedAt: Date.now() });
-      const okMsg = `Push committed ${profileId.slice(0,8)} (${elapsed}ms) — sun=${sunCount} dev=${devCount}`;
-      _debug(okMsg);
-      logSyncEvent('push', okMsg);
-      // Mark the moment a push committed locally so the relay-health
-      // verifier (verifyPushLanded) can distinguish "no push happened
-      // yet" from "push happened but relay didn't advance" (silent
-      // reject).
-      notePushCommitted();
-      // Only advance the local-sync-ts watermark when the push actually
-      // landed. The previous (synchronous) bump after evolu.update meant
-      // a wedged push set the watermark anyway → subsequent pulls saw
-      // `remote.syncedAt < local-sync-ts` and skipped, leaving the local
-      // Evolu row stuck at older state with no auto-recovery. Now the
-      // watermark only moves on real success.
-      // Use syncedAt (same value stored in Evolu) so pulls see exact
-      // equality and don't skip the row from 1ms clock drift.
-      localStorage.setItem(`labcharts-${profileId}-sync-ts`, String(new Date(syncedAt).getTime()));
-      // Track bytes for the local relay-storage estimate (see
-      // getRelayQuotaEstimate). Each successful push adds dataJson.length
-      // to the cumulative — close enough to relay's storedBytes to warn
-      // the user before the 50 MB wall.
-      trackPushBytes((dataJson || '').length);
-      applyCommittedDeltas(profileId, dataJson, deltaPlans, deltaOpCount, _debug);
-      finish();
-    };
-    // Watchdog: if Evolu never calls onComplete within 30s, the worker is
-    // wedged (broken WS, OPFS lock, dead replication). Log explicitly so
-    // the user / popover can show "Stuck — try reloading the page" instead
-    // of silent forever-pending. Cleared on success so a slow-but-eventually-
-    // successful push doesn't get a spurious "stuck" event in the activity log.
-    watchdogId = setTimeout(() => {
-      if (!completed) {
-        const stuckMsg = `Push NOT committed after 30s ${profileId.slice(0,8)} — Evolu worker likely wedged`;
-        console.warn(`[sync] ${stuckMsg}`);
-        logSyncEvent('skip', `Push stuck >30s — try reloading`);
-        updateSyncStatus({ push: 'error', lastError: { type: 'PushStuck', message: 'Evolu replication did not complete in 30s', at: Date.now() } });
-        finish();
+    return await new Promise((resolve) => {
+      let completed = false;
+      let watchdogId = null;
+      const finish = (result) => {
+        _syncing = false;
+        if (watchdogId !== null) { clearTimeout(watchdogId); watchdogId = null; }
+        resolve(result);
+      };
+      const onComplete = () => {
+        completed = true;
+        const elapsed = Date.now() - queuedAt;
+        updateSyncStatus({ push: 'confirmed', pushConfirmedAt: Date.now() });
+        const okMsg = `Push committed ${profileId.slice(0,8)} (${elapsed}ms) — sun=${sunCount} dev=${devCount}`;
+        _debug(okMsg);
+        logSyncEvent('push', okMsg);
+        // Mark the moment a push committed locally so the relay-health
+        // verifier (verifyPushLanded) can distinguish "no push happened
+        // yet" from "push happened but relay didn't advance" (silent
+        // reject).
+        notePushCommitted();
+        // Only advance the local-sync-ts watermark when the push actually
+        // landed. The previous (synchronous) bump after evolu.update meant
+        // a wedged push set the watermark anyway → subsequent pulls saw
+        // `remote.syncedAt < local-sync-ts` and skipped, leaving the local
+        // Evolu row stuck at older state with no auto-recovery. Now the
+        // watermark only moves on real success.
+        // Use syncedAt (same value stored in Evolu) so pulls see exact
+        // equality and don't skip the row from 1ms clock drift.
+        localStorage.setItem(`labcharts-${profileId}-sync-ts`, String(new Date(syncedAt).getTime()));
+        // Track bytes for the local relay-storage estimate (see
+        // getRelayQuotaEstimate). Each successful push adds dataJson.length
+        // to the cumulative — close enough to relay's storedBytes to warn
+        // the user before the 50 MB wall.
+        trackPushBytes((dataJson || '').length);
+        applyCommittedDeltas(profileId, dataJson, deltaPlans, deltaOpCount, _debug);
+        finish({ ok: true });
+      };
+      // Watchdog: if Evolu never calls onComplete within 30s, the worker is
+      // wedged (broken WS, OPFS lock, dead replication). Log explicitly so
+      // the user / popover can show "Stuck — try reloading the page" instead
+      // of silent forever-pending. Cleared on success so a slow-but-eventually-
+      // successful push doesn't get a spurious "stuck" event in the activity log.
+      watchdogId = setTimeout(() => {
+        if (!completed) {
+          const stuckMsg = `Push NOT committed after 30s ${profileId.slice(0,8)} — Evolu worker likely wedged`;
+          console.warn(`[sync] ${stuckMsg}`);
+          logSyncEvent('skip', `Push stuck >30s — try reloading`);
+          updateSyncStatus({ push: 'error', lastError: { type: 'PushStuck', message: 'Evolu replication did not complete in 30s', at: Date.now() } });
+          finish({ ok: false, reason: 'timeout' });
+        }
+      }, 30_000);
+
+      try {
+        // Check if row exists for this profile
+        const rows = evolu.getQueryRows(profileQuery);
+        const existing = rows?.find(r => r.profileId === profileId);
+
+        if (existing) {
+          // profileId is repeated on every update so post-compaction replicas
+          // see it on every CRDT message — without this, a relay that drops
+          // the original insert from `evolu_message` (e.g. /compact-owner)
+          // strands every receiving device with an empty profileId column,
+          // which onSyncReceived's allowlist regex rejects → row never merges.
+          evolu.update("profileData", {
+            id: existing.id,
+            profileId,
+            dataJson,
+            syncedAt,
+          }, { onComplete });
+        } else {
+          evolu.insert("profileData", {
+            profileId,
+            dataJson,
+            syncedAt,
+          }, { onComplete });
+        }
+        // local-sync-ts is now bumped inside onComplete only — see comment there.
+      } catch (e) {
+        console.error('[sync] Push failed:', e);
+        updateSyncStatus({ push: 'error', lastError: { type: 'PushError', message: e.message, at: Date.now() } });
+        finish({ ok: false, error: e });
       }
-    }, 30_000);
-
-    // Check if row exists for this profile
-    const rows = evolu.getQueryRows(profileQuery);
-    const existing = rows?.find(r => r.profileId === profileId);
-
-    if (existing) {
-      // profileId is repeated on every update so post-compaction replicas
-      // see it on every CRDT message — without this, a relay that drops
-      // the original insert from `evolu_message` (e.g. /compact-owner)
-      // strands every receiving device with an empty profileId column,
-      // which onSyncReceived's allowlist regex rejects → row never merges.
-      evolu.update("profileData", {
-        id: existing.id,
-        profileId,
-        dataJson,
-        syncedAt,
-      }, { onComplete });
-    } else {
-      evolu.insert("profileData", {
-        profileId,
-        dataJson,
-        syncedAt,
-      }, { onComplete });
-    }
-    // local-sync-ts is now bumped inside onComplete only — see comment there.
+    });
   } catch (e) {
     console.error('[sync] Push failed:', e);
     updateSyncStatus({ push: 'error', lastError: { type: 'PushError', message: e.message, at: Date.now() } });
     // Synchronous error path — onComplete will never fire, release the lock.
     _syncing = false;
+    return { ok: false, error: e };
   }
   // _syncing now released by onComplete / watchdog / catch — NOT here. The
   // earlier synchronous `finally { _syncing = false }` released it before

--- a/js/sync-reconcile.js
+++ b/js/sync-reconcile.js
@@ -5,6 +5,7 @@ import { localHasRowsRemoteLacks } from './data-merge.js';
 import { collectAISettings } from './sync-payload-collectors.js';
 import { parseSyncPayload } from './sync-payload.js';
 import { logSyncEvent } from './sync-state.js';
+import { isRestoreJoinPending } from './sync-identity.js';
 
 let _getEvolu = () => null;
 let _getProfileQuery = () => null;
@@ -43,6 +44,11 @@ export async function reconcileLocalStorageWithEvolu() {
   const evolu = _getEvolu();
   const profileQuery = _getProfileQuery();
   if (!evolu || !_isSyncEnabled() || !state.currentProfile || !state.importedData) return;
+  if (isRestoreJoinPending()) {
+    _debug('Startup reconciliation skipped until restored mnemonic pulls remote owner data');
+    logSyncEvent('reconcile', `Reconcile ${state.currentProfile.slice(0, 8)} skipped - restore join pending`);
+    return;
+  }
   const rows = evolu.getQueryRows(profileQuery);
   const existing = rows?.find(r => r.profileId === state.currentProfile);
   // No existing row -> first sync ever for this profile, normal push path

--- a/js/sync-save-hooks.js
+++ b/js/sync-save-hooks.js
@@ -113,18 +113,23 @@ export function onProfileSaved(profileId, importedData = null) {
   _profileSyncTimers.set(profileId, timer);
 }
 
-export function onDataSaved() {
+export function onDataSaved(options = {}) {
   if (_isSyncEnabled() && _isEvoluReady()) {
     const profileId = state.currentProfile;
     const data = state.importedData;
     if (profileId) {
       const prev = _debounceTimers.get(profileId);
       if (prev) clearTimeout(prev);
-      const timer = setTimeout(() => {
+      if (options?.immediate) {
         _debounceTimers.delete(profileId);
         scheduleProfilePush(profileId, data);
-      }, 10_000);
-      _debounceTimers.set(profileId, timer);
+      } else {
+        const timer = setTimeout(() => {
+          _debounceTimers.delete(profileId);
+          scheduleProfilePush(profileId, data);
+        }, 10_000);
+        _debounceTimers.set(profileId, timer);
+      }
     }
   }
   pushContextToGateway();

--- a/styles.css
+++ b/styles.css
@@ -5211,6 +5211,8 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .supp-list-info { flex: 1; min-width: 0; }
 .supp-list-name { font-weight: 500; color: var(--text-primary); }
 .supp-list-meta { font-size: 11px; color: var(--text-muted); }
+.supp-list-source { color: var(--accent); text-decoration: none; }
+.supp-list-source:hover { text-decoration: underline; }
 .supp-list-note { font-size: 11px; color: var(--text-secondary); font-style: italic; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Supplement impact analysis (AI-driven) */
 .supp-impact-section { border-top: 1px solid var(--border); padding: 12px 0; }

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -13,7 +13,20 @@ function assert(name, condition, detail) {
 
 console.log('=== Data Merge Tests ===\n');
 
-const { mergeImportedData, recordTombstone, unionById, ID_KEYED_ARRAYS, localHasRowsRemoteLacks, pickTimestamp } = await import('../js/data-merge.js');
+globalThis.window = globalThis.window || {};
+
+const {
+  mergeImportedData,
+  preserveFreshLocalLabEntries,
+  recordTombstone,
+  clearTombstone,
+  unionById,
+  ID_KEYED_ARRAYS,
+  TOMBSTONE_ARRAY_PATHS,
+  localHasRowsRemoteLacks,
+  pickTimestamp,
+} = await import('../js/data-merge.js');
+const { mergeArrayRowsIntoImported } = await import('../js/sync-delta-array-merge.js');
 
   // ─── pickTimestamp precedence (v1.7.20) ───────────────────────────────
   // Direct test for the field-precedence walk used by every cross-device
@@ -47,6 +60,7 @@ const { mergeImportedData, recordTombstone, unionById, ID_KEYED_ARRAYS, localHas
   for (const path of ['sunSessions','deviceSessions','lightDevices','lightMeasurements','lightEnvironment.rooms','lightEnvironment.screens']) {
     assert(`covers ${path}`, ID_KEYED_ARRAYS.includes(path));
   }
+  assert('entries is an explicit tombstone path', TOMBSTONE_ARRAY_PATHS.includes('entries'));
 
   // ─── 2. unionById additivity ──────────────────────────────────────────
   console.log('%c 2. unionById additive merge ', 'font-weight:bold;color:#f59e0b');
@@ -108,6 +122,129 @@ const { mergeImportedData, recordTombstone, unionById, ID_KEYED_ARRAYS, localHas
   assert('desktop keeps own device Y after pull', onDesktop.lightDevices.find(d=>d.id==='Y'));
   assert('desktop gains phone session C', onDesktop.sunSessions.find(s=>s.id==='c'));
 
+  // Lab entries have no `id`; they are keyed by collection date and must
+  // still merge additively. Otherwise a stale sync pull can wipe a just-
+  // imported PDF entry from Settings → Data.
+  const localLabs = {
+    entries: [
+      { date: '2026-03-01', markers: { 'biochemistry.glucose': 4.8 } },
+      { date: '2026-05-01', updatedAt: 200, markers: { 'biochemistry.alp': 1.2 }, markerSources: { 'biochemistry.alp': { file: 'may.pdf' } }, sourceFiles: ['may.pdf'] }
+    ],
+    customMarkers: { 'custom.activeB12': { name: 'Active B12' } }
+  };
+  const remoteLabs = {
+    entries: [
+      { date: '2026-03-01', updatedAt: 100, markers: { 'biochemistry.glucose': 4.7, 'biochemistry.alt': 0.5 }, sourceFiles: ['march.pdf'] }
+    ],
+    customMarkers: { 'custom.oldMarker': { name: 'Old Marker' } }
+  };
+  const mergedLabs = mergeImportedData(localLabs, remoteLabs);
+  const march = mergedLabs.entries.find(e => e.date === '2026-03-01');
+  const may = mergedLabs.entries.find(e => e.date === '2026-05-01');
+  assert('lab entries merge by date instead of stale remote replacing local',
+    mergedLabs.entries.length === 2 && may?.markers?.['biochemistry.alp'] === 1.2);
+  assert('same-date lab entries merge marker keys',
+    march?.markers?.['biochemistry.glucose'] === 4.8 && march?.markers?.['biochemistry.alt'] === 0.5);
+  assert('custom marker maps merge local and remote definitions',
+    mergedLabs.customMarkers['custom.activeB12'] && mergedLabs.customMarkers['custom.oldMarker']);
+
+  const deltaImported = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: 200,
+      markers: { 'biochemistry.alp': 1.2 },
+      markerSources: { 'biochemistry.alp': { file: 'may.pdf' } },
+      sourceFiles: ['may.pdf'],
+    }],
+  };
+  await mergeArrayRowsIntoImported(deltaImported, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: '2026-05-26T08:00:00.000Z',
+    isDeleted: 0,
+    payload: JSON.stringify({
+      date: '2026-05-01',
+      updatedAt: 100,
+      markers: { 'biochemistry.glucose': 4.7 },
+      markerSources: { 'biochemistry.glucose': { file: 'old-sync.pdf' } },
+      sourceFiles: ['old-sync.pdf'],
+    }),
+  }]);
+  const deltaMay = deltaImported.entries.find(e => e.date === '2026-05-01');
+  assert('per-row entries overlay merges same-date markers instead of replacing fresh import',
+    deltaMay?.markers?.['biochemistry.alp'] === 1.2
+      && deltaMay?.markers?.['biochemistry.glucose'] === 4.7);
+  const freshNow = 2_000_000;
+  const stalePulledImport = {
+    entries: [{
+      date: '2026-03-01',
+      updatedAt: freshNow - 60_000,
+      markers: { 'biochemistry.glucose': 4.7 },
+    }],
+  };
+  const localAfterMayImport = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: freshNow - 1000,
+      markers: { 'biochemistry.alp': 1.2 },
+      markerSources: { 'biochemistry.alp': { file: 'may.pdf', at: freshNow - 1000 } },
+      sourceFiles: ['may.pdf'],
+    }],
+  };
+  assert('fresh local lab import is restored after stale pull overlay drops it',
+    preserveFreshLocalLabEntries(stalePulledImport, localAfterMayImport, freshNow) === true
+      && stalePulledImport.entries.some(e => e.date === '2026-05-01' && e.markers?.['biochemistry.alp'] === 1.2));
+  const tombstonedFreshPulledImport = {
+    entries: [],
+    _deleted: { entries: ['2026-05-01'] },
+    _deletedAt: { entries: { '2026-05-01': freshNow } },
+  };
+  assert('fresh local lab import is not restored over a merged entry tombstone',
+    preserveFreshLocalLabEntries(tombstonedFreshPulledImport, localAfterMayImport, freshNow) === false
+      && !tombstonedFreshPulledImport.entries.some(e => e.date === '2026-05-01'));
+  const sameDatePulledImport = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: freshNow - 60_000,
+      markers: { 'biochemistry.glucose': 4.7 },
+    }],
+  };
+  assert('fresh same-date lab import markers survive stale pull overlay',
+    preserveFreshLocalLabEntries(sameDatePulledImport, localAfterMayImport, freshNow) === true
+      && sameDatePulledImport.entries[0].markers?.['biochemistry.alp'] === 1.2
+      && sameDatePulledImport.entries[0].markers?.['biochemistry.glucose'] === 4.7);
+  const oldLocalImport = {
+    entries: [{
+      date: '2026-04-01',
+      updatedAt: freshNow - 3 * 60 * 1000,
+      markers: { 'biochemistry.alt': 0.5 },
+    }],
+  };
+  assert('old local lab entry is not resurrected by freshness guard',
+    preserveFreshLocalLabEntries({ entries: [] }, oldLocalImport, freshNow) === false);
+  const tombstoneImported = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: 200,
+      markers: { 'biochemistry.alp': 1.2 },
+    }],
+  };
+  await mergeArrayRowsIntoImported(tombstoneImported, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: new Date(100).toISOString(),
+    isDeleted: 1,
+    payload: '{}',
+  }]);
+  assert('stale per-row entries tombstone does not delete fresher local import',
+    tombstoneImported.entries.some(e => e.date === '2026-05-01' && e.markers?.['biochemistry.alp'] === 1.2));
+  await mergeArrayRowsIntoImported(tombstoneImported, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: new Date(300).toISOString(),
+    isDeleted: 1,
+    payload: '{}',
+  }]);
+  assert('newer per-row entries tombstone still deletes older local import',
+    !tombstoneImported.entries.some(e => e.date === '2026-05-01'));
+
   // ─── 5. mergeImportedData with tombstones ─────────────────────────────
   console.log('%c 5. mergeImportedData tombstones ', 'font-weight:bold;color:#f59e0b');
 
@@ -124,6 +261,39 @@ const { mergeImportedData, recordTombstone, unionById, ID_KEYED_ARRAYS, localHas
   assert('deleted session B does NOT resurrect on merge', !merged.sunSessions.find(s=>s.id==='b'));
   assert('non-deleted sessions A and C remain', merged.sunSessions.find(s=>s.id==='a') && merged.sunSessions.find(s=>s.id==='c'));
   assert('tombstone preserved through merge', merged._deleted && merged._deleted.sunSessions && merged._deleted.sunSessions.includes('b'));
+  const localAfterLabDelete = {
+    entries: [{ date: '2026-03-01', markers: { 'biochemistry.glucose': 4.8 } }],
+    _deleted: { entries: ['2026-05-01'] },
+    _deletedAt: { entries: { '2026-05-01': Date.now() } },
+  };
+  const remoteWithDeletedLab = {
+    entries: [
+      { date: '2026-03-01', markers: { 'biochemistry.glucose': 4.8 } },
+      { date: '2026-05-01', markers: { 'biochemistry.alp': 1.2 } },
+    ],
+  };
+  const mergedLabDelete = mergeImportedData(localAfterLabDelete, remoteWithDeletedLab);
+  assert('deleted lab import date does NOT resurrect on blob merge',
+    !mergedLabDelete.entries.some(e => e.date === '2026-05-01'));
+  assert('lab entry tombstone preserved through blob merge',
+    mergedLabDelete._deleted?.entries?.includes('2026-05-01'));
+  assert('lab entry tombstone timestamp preserved through blob merge',
+    Number.isFinite(mergedLabDelete._deletedAt?.entries?.['2026-05-01']));
+  const reimportedAfterDelete = {
+    entries: [{ date: '2026-05-01', updatedAt: Date.now(), markers: { 'biochemistry.alp': 1.3 } }],
+  };
+  clearTombstone(reimportedAfterDelete, 'entries', '2026-05-01');
+  const stalePeerDelete = {
+    entries: [],
+    _deleted: { entries: ['2026-05-01'] },
+    _deletedAt: { entries: { '2026-05-01': Date.now() - 10_000 } },
+  };
+  const mergedReimport = mergeImportedData(reimportedAfterDelete, stalePeerDelete);
+  assert('re-imported lab date clears older synced tombstone',
+    mergedReimport.entries.some(e => e.date === '2026-05-01' && e.markers?.['biochemistry.alp'] === 1.3)
+      && !mergedReimport._deleted?.entries?.includes('2026-05-01'));
+  assert('entry tombstone clear marker is preserved for rebroadcast',
+    Number.isFinite(mergedReimport._deletedClearedAt?.entries?.['2026-05-01']));
 
   // ─── 6. Nested paths (lightEnvironment.rooms / .screens) ──────────────
   console.log('%c 6. Nested path merge (lightEnvironment) ', 'font-weight:bold;color:#f59e0b');
@@ -183,12 +353,22 @@ const { mergeImportedData, recordTombstone, unionById, ID_KEYED_ARRAYS, localHas
   recordTombstone(blob, 'sunSessions', 'b');
   assert('first tombstone creates _deleted entry',
     blob._deleted && Array.isArray(blob._deleted.sunSessions) && blob._deleted.sunSessions.includes('b'));
+  assert('recordTombstone stores tombstone timestamp metadata',
+    Number.isFinite(blob._deletedAt?.sunSessions?.b));
   recordTombstone(blob, 'sunSessions', 'b');
   assert('duplicate tombstone is deduped',
     blob._deleted.sunSessions.filter(x=>x==='b').length === 1);
   recordTombstone(blob, 'lightDevices', 'X');
   assert('multiple paths tracked separately',
     blob._deleted.lightDevices.includes('X') && blob._deleted.sunSessions.includes('b'));
+  recordTombstone(blob, 'entries', '2026-05-01');
+  assert('entries tombstone can be recorded',
+    blob._deleted.entries.includes('2026-05-01'));
+  clearTombstone(blob, 'entries', '2026-05-01');
+  assert('clearTombstone removes entry tombstone',
+    !blob._deleted.entries);
+  assert('clearTombstone stores tombstone-clear timestamp metadata',
+    Number.isFinite(blob._deletedClearedAt?.entries?.['2026-05-01']));
 
   // ─── 10. Tombstone union from both sides ──────────────────────────────
   console.log('%c 10. Tombstone union ', 'font-weight:bold;color:#f59e0b');
@@ -237,6 +417,11 @@ const { mergeImportedData, recordTombstone, unionById, ID_KEYED_ARRAYS, localHas
       {sunSessions:[{id:'a'}], _deleted:{sunSessions:['b']}},
       {sunSessions:[{id:'a'},{id:'b'}]}
     ) === true);
+  assert('local lab-entry tombstone not on remote → true',
+    localHasRowsRemoteLacks(
+      {entries: [], _deleted:{entries:['2026-05-01']}},
+      {entries:[{date:'2026-05-01', markers:{'biochemistry.alp':1.2}}]}
+    ) === true);
 
   // Both sides have the same tombstone → no rebroadcast
   assert('matching tombstones → false',
@@ -244,11 +429,36 @@ const { mergeImportedData, recordTombstone, unionById, ID_KEYED_ARRAYS, localHas
       {sunSessions:[{id:'a'}], _deleted:{sunSessions:['b']}},
       {sunSessions:[{id:'a'}], _deleted:{sunSessions:['b']}}
     ) === false);
+  assert('matching lab-entry tombstones → false',
+    localHasRowsRemoteLacks(
+      {entries: [], _deleted:{entries:['2026-05-01']}},
+      {entries: [], _deleted:{entries:['2026-05-01']}}
+    ) === false);
+  assert('local tombstone-clear marker not on remote → true',
+    localHasRowsRemoteLacks(
+      { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.3 } }], _deletedClearedAt: { entries: { '2026-05-01': Date.now() } } },
+      { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.3 } }], _deleted: { entries: ['2026-05-01'] } }
+    ) === true);
 
   // Null guards
   assert('null local → false', localHasRowsRemoteLacks(null, {sunSessions:[{id:'a'}]}) === false);
   assert('null remote → true (everything local is news)',
     localHasRowsRemoteLacks({sunSessions:[{id:'a'}]}, null) === true);
+  assert('local lab entry date missing remotely → true',
+    localHasRowsRemoteLacks(
+      { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.2 } }] },
+      { entries: [] }
+    ) === true);
+  assert('local lab marker missing remotely → true',
+    localHasRowsRemoteLacks(
+      { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.2, 'biochemistry.alt': 0.5 } }] },
+      { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.2 } }] }
+    ) === true);
+  assert('remote superset of lab markers → false',
+    localHasRowsRemoteLacks(
+      { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.2 } }] },
+      { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.2, 'biochemistry.alt': 0.5 } }] }
+    ) === false);
 
   // Within-id conflict: same id, local's record has a strictly higher
   // pickTimestamp than remote's. After mergeImportedData this means

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -74,6 +74,7 @@ return (async function() {
   assert('Client export includes markerNotes', exportSrc.includes('markerNotes: data.markerNotes'));
   assert('Client export includes changeHistory', exportSrc.includes('changeHistory: data.changeHistory'));
   assert('Client export includes chatSummaries', exportSrc.includes('chatSummaries: data.chatSummaries'));
+  assert('Supplement import preserves safe sourceUrl', exportSrc.includes('entry.sourceUrl = sourceUrl.toString()'));
   // Light & Sun stack — earlier export schema dropped these silently;
   // import learned them in v1.6.x but export hadn't followed suit.
   assert('Client export includes sunSessions', exportSrc.includes('sunSessions: data.sunSessions'));

--- a/tests/test-image-utils.js
+++ b/tests/test-image-utils.js
@@ -150,6 +150,8 @@ assert('extractPDFImages in pdf-import', pdfSrc.includes('export async function 
 assert('parseLabPDFWithAIImages in pdf-import', pdfSrc.includes('export async function parseLabPDFWithAIImages'));
 assert('handleImageFile in pdf-import', pdfSrc.includes('export async function handleImageFile'));
 assert('Image mode dialog for poor text quality', pdfSrc.includes("_showImageModeDialog"));
+assert('PDF reads use FileReader fallback after Blob.arrayBuffer aborts', pdfSrc.includes('function readFileArrayBuffer') && pdfSrc.includes('new FileReader()'));
+assert('PDF text extraction uses resilient file read helper', pdfSrc.includes('const arrayBuffer = await readFileArrayBuffer(file);'));
 
 // CSS source-string checks — runtime "rule is loaded in stylesheet"
 // version lives in test-image-utils-dom.js (puppeteer).

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -200,6 +200,7 @@ await import('../js/settings.js');
       && syncLifecycleSrc.includes('export async function enableSync')
       && syncLifecycleSrc.includes('export async function disableSync')
       && syncLifecycleSrc.includes('await initSync()')
+      && syncLifecycleSrc.includes('await forcePull()')
       && syncLifecycleSrc.includes('await pushAllProfiles()')
       && syncLifecycleSrc.includes('clearSyncRuntimeState();')
       && exportBlockIncludes(syncSrc, ['enableSync', 'disableSync']));
@@ -381,6 +382,8 @@ await import('../js/settings.js');
       && syncIdentitySrc.includes('export function getMnemonic')
       && syncIdentitySrc.includes('export function getMnemonicResolutionError')
       && syncIdentitySrc.includes('export async function restoreFromMnemonic')
+      && syncIdentitySrc.includes('RESTORE_JOIN_PENDING_KEY')
+      && syncConfigureSrc.includes('seedLocalProfiles: () => pushAllProfiles({ force: true })')
       && exportBlockIncludes(syncSrc, ['getMnemonic', 'getMnemonicResolutionError', 'restoreFromMnemonic']));
   assert('service worker precaches sync-identity.js',
     serviceWorkerSrc.includes("'/js/sync-identity.js'"));
@@ -933,18 +936,23 @@ await import('../js/settings.js');
 
   // Pull-side merge contract — per-row authoritative, blob fallback
   assert('onSyncReceived overlays per-row state AFTER blob merge',
-    /merged\s*=\s*localImportedForMerge[\s\S]{0,400}mergeImportedData[\s\S]{0,800}_mergeItemRowsIntoImported/.test(syncPullMergeSrc));
+    /merged\s*=\s*localBaselineForMerge[\s\S]{0,400}mergeImportedData[\s\S]{0,800}_mergeItemRowsIntoImported/.test(syncPullMergeSrc));
   assert('_mergeItemRowsIntoImported drops tombstoned items from imported arrays',
-    /mergeArrayRowsIntoImported[\s\S]{0,12000}let nextArr\s*=\s*curArr\.filter\(it\s*=>\s*!tombs\.has\(itemIdFn\(it\)\)\)/.test(syncDeltaMergeSearchSrc));
+    /mergeArrayRowsIntoImported[\s\S]{0,12000}let nextArr\s*=\s*curArr\.filter\(it\s*=>\s*!tombstoneWinsOverItem\(itemIdFn\(it\),\s*it\)\)/.test(syncDeltaMergeSearchSrc));
   // Resurrection-prevention seed: blob-side `_deleted[arrayName]` must
   // pre-populate the row-side tombs Set, otherwise a peer pushing the
   // row back as live (before pulling our delete) re-inserts it locally.
   assert('_mergeItemRowsIntoImported seeds tombs from local blob _deleted before walking rows',
-    /imported\.\s*_deleted[\s\S]{0,200}\[arrayName\][\s\S]{0,200}tombs\.add/.test(syncDeltaMergeSearchSrc));
+    /imported\.\s*_deleted[\s\S]{0,200}\[arrayName\][\s\S]{0,240}localTombs\.add/.test(syncDeltaMergeSearchSrc));
   assert('_mergeItemRowsIntoImported skips inserting items that match a blob-tombstoned itemId',
-    /tombs\.has\(itemId\)\)\s*continue/.test(syncDeltaMergeSearchSrc));
-  assert('_mergeItemRowsIntoImported prefers per-row payload when itemId already present in array (replace)',
-    /idx\s*!==\s*undefined[\s\S]{0,200}nextArr\[idx\]\s*=\s*item/.test(syncDeltaMergeSearchSrc));
+    /tombstoneWinsOverLiveRow\(itemId,\s*entry\)\)\s*continue/.test(syncDeltaMergeSearchSrc));
+  assert('_mergeItemRowsIntoImported ignores stale remote tombstones when local item is newer',
+    /remoteTombs\.set\(row\.itemId[\s\S]{0,1200}tombAt\s*>=\s*pickTimestamp\(item\)/.test(syncDeltaArrayMergeSrc));
+  assert('_mergeItemRowsIntoImported prefers per-row payload when itemId already present in non-lab arrays',
+    /idx\s*!==\s*undefined[\s\S]{0,260}arrayName\s*===\s*'entries'\s*\?[\s\S]{0,120}:\s*item/.test(syncDeltaMergeSearchSrc));
+  assert('_mergeItemRowsIntoImported merges same-date lab entries instead of replacing marker maps',
+    /import\s*\{[^}]*mergeLabEntry[^}]*\}\s*from\s*['"]\.\/data-merge\.js['"]/.test(syncDeltaArrayMergeSrc)
+      && /arrayName\s*===\s*'entries'\s*\?\s*mergeLabEntry\(nextArr\[idx\],\s*item\)\s*:\s*item/.test(syncDeltaArrayMergeSrc));
   assert('_mergeItemRowsIntoImported gunzips GZ|v1| payloads via capped variant',
     /json\.startsWith\('GZ\|v1\|'\)[\s\S]{0,300}_gunzipToStringCapped\(_base64ToBytes\(json\.slice\(6\)\)\)/.test(syncDeltaMergeSearchSrc));
   assert('_mergeItemRowsIntoImported guards against itemId/payload mismatch (defence-in-depth)',
@@ -1053,7 +1061,7 @@ await import('../js/settings.js');
   console.log('6. Data Integration');
 
   assert('data.js imports onDataSaved from sync.js', dataSrc.includes("import { onDataSaved } from './sync.js'"));
-  assert('saveImportedData calls onDataSaved()', dataSrc.includes('onDataSaved()'));
+  assert('saveImportedData calls onDataSaved()', /onDataSaved\([^)]*\)/.test(dataSrc));
 
   // ═══════════════════════════════════════
   // 7. STARTUP UI INTEGRATION
@@ -1091,6 +1099,9 @@ await import('../js/settings.js');
     syncPushSrc.includes('_syncing && Date.now() - _syncingSince < 60_000')
       && syncPushSrc.includes('_syncing = true')
       && syncPushSrc.includes('export function isSyncPushInFlight'));
+  assert('pushProfile await resolves only from onComplete/watchdog paths',
+    /return await new Promise\(\(resolve\)[\s\S]{0,1200}const onComplete[\s\S]{0,1800}finish\(\{ ok: true \}\)/.test(syncPushSrc)
+      && /Push NOT committed after 30s[\s\S]{0,800}finish\(\{ ok: false, reason: 'timeout' \}\)/.test(syncPushSrc));
   assert('pushProfile uses insert/update pattern', syncPushSrc.includes('evolu.insert(') && syncPushSrc.includes('evolu.update('));
   // v1.6.3: debounce bumped 2s → 10s. Each push is the full importedData
   // blob (~500 KB pre-gzip), so coalescing editing bursts directly reduces
@@ -1118,12 +1129,30 @@ await import('../js/settings.js');
   // instead of just showing a "Data updated" toast).
   assert('Pull re-renders the active view', syncPullActiveRefreshSrc.includes('window.navigate?.(cat)'));
   assert('Pull calls migrateProfileData', syncPullActiveRefreshSrc.includes('migrateProfileData(state.importedData)'));
-  assert('pushAllProfiles pushes all profiles on first enable',
+  assert('enableSync pulls before first enable push to avoid publishing stale local state',
+    /await forcePull\(\)[\s\S]{0,300}await pushAllProfiles\(\)/.test(syncLifecycleSrc));
+  assert('pushAllProfiles pushes all profiles after first enable pull',
     syncLifecycleSrc.includes('await pushAllProfiles()') && syncActionsSrc.includes('export async function pushAllProfiles'));
+  assert('pushAllProfiles forwards force/seed options to profile pushes',
+    /export async function pushAllProfiles\(options = \{\}\)/.test(syncActionsSrc)
+      && /_pushProfile\(p\.id,\s*dataJson,\s*options\)/.test(syncActionsSrc));
   assert('pushAllProfiles pushes metadata-only profiles with default data',
     syncActionsSrc.includes('createDefaultProfileData()')
       && /pushAllProfiles[\s\S]{0,800}readProfileImportedData\(p\.id\)/.test(syncActionsSrc)
       && !/pushAllProfiles[\s\S]{0,800}if \(!raw\) continue/.test(syncActionsSrc));
+  assert('restore-as-source seeds the new owner before reload',
+    /restoreFromMnemonic\(mnemonic,\s*options = \{\}\)/.test(syncIdentitySrc)
+      && /options\?\.seedLocal[\s\S]{0,400}await _seedLocalProfiles\(\)/.test(syncIdentitySrc)
+      && /restoreMnemonicForDiagnose\(words\.join\(' '\),\s*\{ seedLocal: true \}\)/.test(syncDiagnoseIdentityActionsSrc));
+  assert('restore-as-joiner marks first pull to ignore old local tombstones',
+    /setRestoreJoinPending\(true\)/.test(syncIdentitySrc)
+      && /isRestoreJoinPending/.test(syncPullMergeSrc)
+      && /withoutLocalTombstones\(localImportedForMerge\)/.test(syncPullMergeSrc)
+      && /const \{\s*_deleted,\s*_deletedAt,\s*_deletedClearedAt,\s*\.\.\.rest\s*\}/.test(syncPullMergeSrc)
+      && /if \(restoreJoinApplied\) clearRestoreJoinPending\(\)/.test(syncPullSrc));
+  assert('restore-as-joiner blocks startup reconciliation push before first pull',
+    /isRestoreJoinPending/.test(syncReconcileSrc)
+      && /reconcileLocalStorageWithEvolu[\s\S]{0,500}isRestoreJoinPending\(\)[\s\S]{0,500}return/.test(syncReconcileSrc));
   assert('disableSync clears appOwner via runtime cleanup',
     syncLifecycleSrc.includes('clearSyncRuntimeState();')
       && /clearSyncRuntimeState[\s\S]{0,500}_appOwner\s*=\s*null/.test(syncRuntimeSrc));
@@ -1151,6 +1180,8 @@ await import('../js/settings.js');
   assert('disableSync clears sync timestamps',
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /key\.endsWith\('-sync-ts'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(syncDisableCleanupSrc));
+  assert('disableSync clears restore-join pending marker',
+    syncDisableCleanupSrc.includes("key === 'labcharts-sync-restore-join-pending'"));
   assert('applyChatData uses plain localStorage for thread index (matches saveChatThreadIndex)',
     syncChatApplySrc.includes("localStorage.setItem(threadsKey, JSON.stringify(mergedThreads))"));
 
@@ -1768,7 +1799,7 @@ await import('../js/settings.js');
     /Push committed[\s\S]{0,3500}applyCommittedDeltas\(profileId,\s*dataJson,\s*deltaPlans,\s*deltaOpCount,\s*_debug\)/.test(syncPushSrc)
       && /applyCommittedDeltas[\s\S]{0,2000}_recordPushTelemetry\(profileId,\s*\(dataJson\s*\|\|\s*''\)\.length,\s*deltaPlans\)/.test(syncPushDeltasSrc));
   assert('Pull-side merge records pull telemetry per array',
-    /recordPullDeltaSurface\(arrayName,\s*\{\s*live:\s*liveById\.size,\s*tombstones:\s*tombs\.size\s*\}\)/.test(deltaSearchSrc));
+    /recordPullDeltaSurface\(arrayName,\s*\{\s*live:\s*liveById\.size,\s*tombstones:\s*localTombs\.size\s*\+\s*remoteTombs\.size\s*\}\)/.test(deltaSearchSrc));
   assert('Pull snapshot resets profileId on each merge (no stale carry-over)',
     /resetPullDeltaSnapshot\(profileId\)[\s\S]{0,1000}_pullDeltaSnapshot\.profileId\s*=\s*profileId[\s\S]{0,200}_pullDeltaSnapshot\.perArray\s*=\s*\{\}/.test(deltaSearchSrc));
   assert('Diagnose surface renders Phase 1 dual-write health section',
@@ -1917,7 +1948,7 @@ await import('../js/settings.js');
   assert('Receive path treats v4 (importedData null) as legitimate, not malformed',
     /function isMalformedPulledImportedData[\s\S]{0,160}importedData\s*!==\s*null[\s\S]{0,160}!importedData/.test(syncPullMergeSrc));
   assert('Receive path uses local as baseline when v4 (no blob to merge)',
-    /v4 cutover[\s\S]{0,800}importedData\s*\?\s*mergeImportedData\(localImportedForMerge,\s*importedData\)\s*:\s*localImportedForMerge/.test(deltaSearchSrc));
+    /v4 cutover[\s\S]{0,800}importedData\s*\?\s*mergeImportedData\(localBaselineForMerge,\s*importedData\)\s*:\s*localBaselineForMerge/.test(deltaSearchSrc));
   assert('confirmEnablePhase2 re-checks readiness as defence-in-depth',
     /confirmEnablePhase2[\s\S]{0,400}getDeltaCutoverReadiness\(state\.currentProfile\)[\s\S]{0,200}!r\?\.ready/.test(deltaSearchSrc));
   assert('Cutover modal button gated when not ready (disabled attribute)',

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -51,6 +51,39 @@ return (async function() {
   assert('Setup: demo data loaded', data.dates.length > 0, `${data.dates.length} dates`);
 
   // ═══════════════════════════════════════════════
+  // 0. SETTINGS DATA IMPORT ACTIONS
+  // ═══════════════════════════════════════════════
+  console.log('%c 0. Settings Data import actions', 'font-weight:bold;color:#6366f1');
+  const originalImportedData = JSON.parse(JSON.stringify(S.importedData || {}));
+  try {
+    S.importedData = Object.assign({}, originalImportedData, {
+      entries: [{
+        date: '2099-12-31',
+        markers: { 'biochemistry.alp': 1 },
+        importedWith: { modelId: 'ui-flow-smoke' }
+      }],
+      manualValues: {}
+    });
+    const entriesHtml = window.renderDataEntriesSection();
+    assert('Settings Data remove wrapper is callable', typeof window.removeImportedEntryFromSettings === 'function');
+    assert('Settings Data legacy remove bridge is callable', typeof window.removeImportedEntry === 'function');
+    assert('Settings Data remove button uses lazy wrapper', entriesHtml.includes('removeImportedEntryFromSettings(&quot;2099-12-31&quot;)'));
+    assert('Settings Data edit button uses lazy wrapper', entriesHtml.includes('renameImportedEntryDateFromSettings(&quot;2099-12-31&quot;)'));
+    await window.removeImportedEntryFromSettings('2099-12-31');
+    await wait(50);
+    assert('Settings Data remove wrapper deletes entry',
+      !(S.importedData.entries || []).some(e => e.date === '2099-12-31'));
+    assert('Settings Data remove wrapper records sync tombstone',
+      S.importedData._deleted?.entries?.includes('2099-12-31'));
+  } finally {
+    S.importedData = originalImportedData;
+    window.saveImportedData();
+    window.buildSidebar();
+    window.navigate('dashboard');
+    await wait(50);
+  }
+
+  // ═══════════════════════════════════════════════
   // 0. MODAL FOCUS-RETURN WIRING (source-check)
   // ═══════════════════════════════════════════════
   // Detail modal closing must return focus to the triggering element so
@@ -255,9 +288,45 @@ return (async function() {
   assert('Settings modal closes', !settingsOverlay.classList.contains('show'));
 
   // ═══════════════════════════════════════════════
-  // 4. SUPPLEMENT FLOW — add, save, verify dashboard, delete
+  // 4. IMPORT REVIEW — editable collection date
   // ═══════════════════════════════════════════════
-  console.log('%c 4. Supplement flow', 'font-weight:bold;color:#6366f1');
+  console.log('%c 4. Import review date editing', 'font-weight:bold;color:#6366f1');
+  window.showImportPreview({
+    date: '2026-01-10',
+    fileName: 'ui-flow-import.pdf',
+    markers: [{ rawName: 'Glucose', value: 5.1, unit: 'mmol/L', matched: true, mappedKey: 'biochemistry.glucose' }]
+  });
+  await wait(20);
+  const importDateInput = document.getElementById('import-manual-date');
+  assert('Import preview has editable date input', !!importDateInput);
+  assert('Import date input prefilled from extracted date', importDateInput?.value === '2026-01-10');
+  assert('Import preview has one date input', document.querySelectorAll('#import-manual-date').length === 1);
+  importDateInput.value = '2026-02-03';
+  window.applyManualImportDate(importDateInput.value);
+  assert('Edited import date updates pending import', window._pendingImport?.date === '2026-02-03');
+  const importBtn = document.getElementById('import-confirm-btn');
+  assert('Import stays enabled after valid edited date', importBtn && !importBtn.disabled);
+  importDateInput.value = '';
+  window.applyManualImportDate(importDateInput.value);
+  assert('Clearing import date clears pending import date', window._pendingImport?.date === '');
+  assert('Clearing import date disables import button', importBtn?.disabled === true);
+  window.closeImportModal();
+  await wait(20);
+
+  window.showImportPreview({ date: '', fileName: 'ui-flow-no-date.pdf', markers: [] });
+  await wait(20);
+  const missingDateInput = document.getElementById('import-manual-date');
+  assert('Missing-date import still has one date input', document.querySelectorAll('#import-manual-date').length === 1);
+  assert('Missing-date input starts empty', missingDateInput?.value === '');
+  assert('Missing-date warning points to existing date input', document.querySelector('.import-review-date-warning')?.textContent.includes('set it above'));
+  assert('Missing-date import starts disabled', document.getElementById('import-confirm-btn')?.disabled === true);
+  window.closeImportModal();
+  await wait(20);
+
+  // ═══════════════════════════════════════════════
+  // 5. SUPPLEMENT FLOW — add, save, verify dashboard, delete
+  // ═══════════════════════════════════════════════
+  console.log('%c 5. Supplement flow', 'font-weight:bold;color:#6366f1');
   const modalOverlay = document.getElementById('modal-overlay');
 
   // Count existing supplements
@@ -280,6 +349,9 @@ return (async function() {
   if (dosageInput) dosageInput.value = '500mg';
   const startInput = document.querySelector('.supp-period-start');
   if (startInput) startInput.value = '2026-01-01';
+  const sourceInput = document.getElementById('supp-url');
+  assert('Supplement URL input visible without fetch requirement', !!sourceInput);
+  if (sourceInput) sourceInput.value = 'https://www.example.com/products/a?x=1';
 
   // Save
   window.saveSupplement(-1);
@@ -291,6 +363,11 @@ return (async function() {
   const savedSupp = S.importedData.supplements.find(s => s.name === '__UI_TEST_SUPP__');
   assert('Supplement has correct name', !!savedSupp);
   assert('Supplement has correct dosage', savedSupp?.dosage === '500mg');
+  assert('Supplement saves product URL', savedSupp?.sourceUrl === 'https://www.example.com/products/a?x=1');
+  const savedSuppRow = Array.from(document.querySelectorAll('.supp-list-item')).find(row => row.textContent.includes('__UI_TEST_SUPP__'));
+  const savedSuppLink = savedSuppRow?.querySelector('.supp-list-source');
+  assert('Supplement row shows source hostname link', savedSuppLink?.textContent.trim() === 'example.com ↗');
+  assert('Supplement source link href is saved URL', savedSuppLink?.getAttribute('href') === 'https://www.example.com/products/a?x=1');
 
   // Verify the optional dashboard widget can be shown after save
   window.closeModal();
@@ -318,10 +395,46 @@ return (async function() {
   const stillShows = suppSectionAfter?.innerHTML.includes('__UI_TEST_SUPP__');
   assert('Dashboard no longer shows deleted supplement', !stillShows);
 
+  window.openSupplementsEditor();
+  await wait(50);
+  window.showAddSuppForm();
+  await wait(20);
+  const invalidNameInput = document.getElementById('supp-name');
+  if (invalidNameInput) invalidNameInput.value = '__UI_TEST_BAD_URL__';
+  const invalidStartInput = document.querySelector('.supp-period-start');
+  if (invalidStartInput) invalidStartInput.value = '2026-01-02';
+  const invalidSourceInput = document.getElementById('supp-url');
+  if (invalidSourceInput) invalidSourceInput.value = 'javascript:alert(1)';
+  const beforeInvalidSuppCount = (S.importedData.supplements || []).length;
+  window.saveSupplement(-1);
+  await wait(50);
+  assert('Invalid supplement URL is rejected', (S.importedData.supplements || []).length === beforeInvalidSuppCount);
+  assert('Invalid URL supplement not saved', !S.importedData.supplements?.some(s => s.name === '__UI_TEST_BAD_URL__'));
+  window.closeModal();
+  await wait(20);
+
+  const beforeUnsafeSupps = (S.importedData.supplements || []).slice();
+  S.importedData.supplements = [...beforeUnsafeSupps, {
+    name: '__UI_TEST_UNSAFE_SOURCE__',
+    dosage: '',
+    startDate: '2026-01-03',
+    endDate: null,
+    type: 'supplement',
+    note: '',
+    sourceUrl: 'javascript://example.com/%0Aalert(1)'
+  }];
+  window.openSupplementsEditor();
+  await wait(50);
+  const unsafeSuppRow = Array.from(document.querySelectorAll('.supp-list-item')).find(row => row.textContent.includes('__UI_TEST_UNSAFE_SOURCE__'));
+  assert('Unsafe imported source URL does not render as link', unsafeSuppRow && !unsafeSuppRow.querySelector('.supp-list-source'));
+  S.importedData.supplements = beforeUnsafeSupps;
+  window.closeModal();
+  await wait(20);
+
   // ═══════════════════════════════════════════════
-  // 5. SUPPLEMENT PERIODS — multiple date ranges
+  // 6. SUPPLEMENT PERIODS — multiple date ranges
   // ═══════════════════════════════════════════════
-  console.log('%c 5. Supplement periods', 'font-weight:bold;color:#6366f1');
+  console.log('%c 6. Supplement periods', 'font-weight:bold;color:#6366f1');
 
   window.openSupplementsEditor();
   await wait(50);
@@ -352,9 +465,9 @@ return (async function() {
   await wait(20);
 
   // ═══════════════════════════════════════════════
-  // 6. DETAIL MODAL — open marker, verify content, close
+  // 7. DETAIL MODAL — open marker, verify content, close
   // ═══════════════════════════════════════════════
-  console.log('%c 6. Detail modal', 'font-weight:bold;color:#6366f1');
+  console.log('%c 7. Detail modal', 'font-weight:bold;color:#6366f1');
 
   // Find a marker with data
   let testMarkerId = null;

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -21,6 +21,7 @@ function assert(name, condition, detail) {
 console.log('=== Unit Normalization on Import Tests ===\n');
 
 const src = read('js/pdf-import.js');
+const settingsSrc = read('js/settings.js');
   // ═══════════════════════════════════════
   // 1. normalizeToSI function exists
   // ═══════════════════════════════════════
@@ -48,6 +49,38 @@ const src = read('js/pdf-import.js');
     confirmBlock.includes('normalizeToSI(m.mappedKey, m.value, m.unit)'));
   assert('new (custom) markers normalized',
     confirmBlock.includes('normalizeToSI(m.suggestedKey, m.value, m.unit)'));
+  assert('confirmImport waits for async save before closing UI',
+    src.includes('export async function confirmImport') && /await\s+saveImportedData\([^)]*\)/.test(confirmBlock));
+  assert('PDF import requests immediate sync push after durable save',
+    /await\s+saveImportedData\(\{\s*immediate:\s*true\s*\}\)/.test(confirmBlock));
+  assert('PDF import clears same-date entry tombstone when intentionally re-importing',
+    /clearTombstone\(state\.importedData,\s*['"]entries['"],\s*result\.date\)/.test(confirmBlock));
+  assert('PDF import rolls back in-memory state when durable save fails',
+    /const rollback = snapshotImportedData\(\)[\s\S]{0,4000}if \(!saved\) \{[\s\S]{0,200}restoreImportedDataSnapshot\(rollback\)/.test(confirmBlock));
+  const removeBlock = src.substring(src.indexOf('export async function removeImportedEntry'), src.indexOf('export async function renameImportedEntryDate'));
+  assert('import delete records entries tombstone before removing row',
+    /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*date\)[\s\S]{0,180}entries\.filter/.test(removeBlock));
+  assert('import delete uses immediate sync push',
+    /await\s+saveImportedData\(\{\s*immediate:\s*true\s*\}\)/.test(removeBlock));
+  assert('import delete restores state and returns false when save fails',
+    /const rollback = snapshotImportedData\(\)[\s\S]{0,400}if \(!saved\) \{[\s\S]{0,160}restoreImportedDataSnapshot\(rollback\)[\s\S]{0,120}return false/.test(removeBlock));
+  const renameStart = src.indexOf('export async function renameImportedEntryDate');
+  const renameEnd = src.indexOf('export function classifyImportFiles');
+  const renameBlock = src.substring(renameStart, renameEnd > renameStart ? renameEnd : src.length);
+  assert('import date rename tombstones old date',
+    /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*oldDate\)/.test(renameBlock));
+  assert('import date rename clears tombstone for new date',
+    /clearTombstone\(state\.importedData,\s*['"]entries['"],\s*newDate\)/.test(renameBlock));
+  assert('import date rename restores state and returns false when save fails',
+    /const saved = await saveImportedData\(\{\s*immediate:\s*true\s*\}\)[\s\S]{0,160}if \(!saved\) \{[\s\S]{0,160}restoreImportedDataSnapshot\(rollback\)[\s\S]{0,120}return false/.test(renameBlock));
+  assert('import date rename validates calendar dates without local-timezone shift',
+    /function isValidISOCalendarDate\(date\)/.test(src)
+      && /Date\.UTC\(year,\s*month - 1,\s*day\)/.test(src)
+      && /getUTCFullYear\(\)\s*===\s*year[\s\S]{0,120}getUTCMonth\(\)\s*===\s*month - 1[\s\S]{0,120}getUTCDate\(\)\s*===\s*day/.test(src));
+  assert('Settings Data remove refreshes only after successful delete',
+    /removeImportedEntryFromSettings[\s\S]{0,240}const ok = await removeImportedEntry\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsSrc));
+  assert('Settings Data rename refreshes only after successful save',
+    /renameImportedEntryDateFromSettings[\s\S]{0,260}const ok = await renameImportedEntryDate\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsSrc));
 
   // ═══════════════════════════════════════
   // 4. normalizeToSI handles multiply type (inverse)
@@ -226,6 +259,150 @@ const src = read('js/pdf-import.js');
   // Verify guard at line 367 only fires for non-blood tests
   assert('Guard checks testType !== blood',
     src.includes("testType !== 'blood'") && src.includes('Import Guard'));
+
+  // ═══════════════════════════════════════
+  // 7. Import mapping reconciliation
+  // ═══════════════════════════════════════
+  console.log('%c 7. Import mapping reconciliation ', 'font-weight:bold;color:#f59e0b');
+
+  assert('pdf-import exports reconcileImportMarkerMappings',
+    /export function reconcileImportMarkerMappings/.test(src));
+  assert('Czech/Spadia alias table includes key labels',
+    src.includes("'glukoza', 'biochemistry.glucose'")
+    && src.includes("'horcikvery', 'electrolytes.magnesiumRBC'")
+    && src.includes("'homocystein', 'coagulation.homocysteine'"));
+
+  const { reconcileImportMarkerMappings } = await import('../js/pdf-import.js');
+  const { state } = await import('../js/state.js');
+  const originalImportedData = state.importedData;
+  state.importedData = {
+    entries: [{
+      date: '2026-03-13',
+      markers: {
+        'custom.activeB12': 145,
+        'spadiaFA.epaC20_5': 0.46
+      }
+    }],
+    customMarkers: {
+      'custom.activeB12': { name: 'Active B12', unit: 'pmol/l' },
+      'spadiaFA.epaC20_5': { name: 'EPA C20:5', unit: '%' },
+      'biochemistry.alpUkatL': { name: 'ALP (ukat/l)', unit: 'µkat/l' }
+    }
+  };
+  try {
+    const importMarkers = [
+      { rawName: 'S Glukóza', value: 4.56, unit: 'mmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.glukoza' },
+      { rawName: 'P Hořčík v ery', value: 2.56, unit: 'mmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.magnesiumEry' },
+      { rawName: 'S Aktivní B12', value: 300, unit: 'pmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.activeVitaminB12', suggestedName: 'Active B12' },
+      { rawName: 'B Neutrofily #', value: 3.22, unit: '10^9/l', matched: false, mappedKey: null, suggestedKey: 'custom.neutrophilsAbs' },
+      { rawName: 'U Glukosa', value: 0, unit: 'arb.j.', matched: false, mappedKey: null, suggestedKey: 'custom.urineGlucose' },
+      { rawName: 'U pH', value: 5, unit: '-', matched: false, mappedKey: null, suggestedKey: 'custom.urinePh' },
+      { rawName: 'S Celk.bílkovina', value: 69.6, unit: 'g/l', matched: false, mappedKey: null, suggestedKey: 'custom.totalProtein' },
+      { rawName: 'U Celková bílkovina', value: 0.142, unit: 'g/l', matched: true, mappedKey: 'proteins.totalProtein', suggestedKey: null },
+      { rawName: 'EPA C20:5', value: 0.46, unit: '%', matched: false, mappedKey: null, suggestedKey: 'spadiaFA.epaC20_5' },
+      { rawName: 'ALP (ukat/l)', value: 1.2, unit: 'µkat/l', matched: false, mappedKey: null, suggestedKey: 'biochemistry.alpUkatL' },
+      { rawName: 'ALT [µkat/l]', value: 0.5, unit: 'µkat/l', matched: true, mappedKey: 'biochemistry.altUkatL', suggestedKey: null },
+      { rawName: 'USED Leukocyty', value: 4, unit: '/µl', matched: true, mappedKey: 'hematology.wbc', suggestedKey: null },
+      { rawName: 'Unknown Marker', value: 42, unit: 'x', matched: true, mappedKey: 'custom.unknownMarker', suggestedKey: null }
+    ];
+    reconcileImportMarkerMappings(importMarkers, { testType: 'blood' });
+    assert('Czech glucose reconciles to existing schema marker',
+      importMarkers[0].matched && importMarkers[0].mappedKey === 'biochemistry.glucose');
+    assert('Erythrocyte magnesium reconciles to magnesium RBC',
+      importMarkers[1].matched && importMarkers[1].mappedKey === 'electrolytes.magnesiumRBC');
+    assert('Same-name custom marker reconciles to previous custom key',
+      importMarkers[2].matched && importMarkers[2].mappedKey === 'custom.activeB12');
+    assert('Differential # value reconciles to absolute-count marker',
+      importMarkers[3].matched && importMarkers[3].mappedKey === 'differential.neutrophils');
+    assert('Urine glucose is not incorrectly merged into blood glucose',
+      !importMarkers[4].matched && importMarkers[4].suggestedKey === 'custom.urineGlucose');
+    assert('Urine pH reconciles to urinalysis pH',
+      importMarkers[5].matched && importMarkers[5].mappedKey === 'urinalysis.ph');
+    assert('Serum total protein reconciles to proteins.totalProtein',
+      importMarkers[6].matched && importMarkers[6].mappedKey === 'proteins.totalProtein');
+    assert('Urine total protein is demoted instead of overwriting serum total protein',
+      !importMarkers[7].matched
+      && importMarkers[7].mappedKey === null
+      && importMarkers[7].suggestedKey === 'urinalysis.totalProtein');
+    assert('Existing product-specific custom key is matched, not new',
+      importMarkers[8].matched && importMarkers[8].mappedKey === 'spadiaFA.epaC20_5');
+    assert('Unit suffix in marker label does not create duplicate ALP marker',
+      importMarkers[9].matched && importMarkers[9].mappedKey === 'biochemistry.alp');
+    assert('Invalid matched key with unit suffix is remapped to existing ALT',
+      importMarkers[10].matched && importMarkers[10].mappedKey === 'biochemistry.alt');
+    assert('Urine sediment prefix is not merged into blood WBC',
+      !importMarkers[11].matched
+      && importMarkers[11].mappedKey === null
+      && importMarkers[11].suggestedKey === 'urinalysis.leukocytesQualitative');
+    assert('Unknown invalid mappedKey is demoted so it becomes a real custom marker',
+      !importMarkers[12].matched && importMarkers[12].mappedKey === null && importMarkers[12].suggestedKey === 'custom.unknownMarker');
+  } finally {
+    state.importedData = originalImportedData;
+  }
+
+  // ═══════════════════════════════════════
+  // 8. Profile repair for already-imported unit-suffixed duplicates
+  // ═══════════════════════════════════════
+  console.log('%c 8. Profile import repair ', 'font-weight:bold;color:#f59e0b');
+
+  const { migrateProfileData } = await import('../js/profile.js');
+  const migrated = {
+    entries: [{
+      date: '2026-05-01',
+      markers: { 'biochemistry.alpUkatL': 1.2 },
+      markerSources: { 'biochemistry.alpUkatL': { file: 'spadia.pdf' } }
+    }],
+    customMarkers: {
+      'biochemistry.alpUkatL': { name: 'ALP (ukat/l)', unit: 'µkat/l' }
+    },
+    markerLabels: {
+      'biochemistry.alpUkatL': 'My ALP label'
+    },
+    markerValueNotes: {
+      'biochemistry.alpUkatL:2026-05-01': 'lab note'
+    }
+  };
+  migrateProfileData(migrated);
+  assert('Profile migration moves ALP unit-suffixed duplicate onto schema key',
+    migrated.entries[0].markers['biochemistry.alp'] === 1.2
+    && migrated.entries[0].markers['biochemistry.alpUkatL'] === undefined);
+  assert('Profile migration removes duplicate custom marker definition',
+    migrated.customMarkers['biochemistry.alpUkatL'] === undefined);
+  assert('Profile migration remaps marker value notes',
+    migrated.markerValueNotes['biochemistry.alp:2026-05-01'] === 'lab note');
+  assert('Profile migration remaps custom marker labels',
+    migrated.markerLabels['biochemistry.alp'] === 'My ALP label'
+    && migrated.markerLabels['biochemistry.alpUkatL'] === undefined);
+  const invisible = {
+    entries: [{ date: '2026-05-01', markers: { 'biochemistry.altUkatL': 0.5 } }],
+    customMarkers: {}
+  };
+  migrateProfileData(invisible);
+  assert('Profile migration repairs unit-suffixed entry keys even without custom marker definition',
+    invisible.entries[0].markers['biochemistry.alt'] === 0.5
+    && invisible.entries[0].markers['biochemistry.altUkatL'] === undefined);
+  const urineProtein = {
+    entries: [{ date: '2026-05-01', markers: { 'urinalysis.totalProtein': 0.142 } }],
+    customMarkers: {
+      'urinalysis.totalProtein': { name: 'Celková bílkovina', unit: 'g/l' }
+    }
+  };
+  migrateProfileData(urineProtein);
+  assert('Profile migration does not remap deliberate urine total protein to serum total protein',
+    urineProtein.entries[0].markers['urinalysis.totalProtein'] === 0.142
+    && urineProtein.entries[0].markers['proteins.totalProtein'] === undefined
+    && urineProtein.customMarkers['urinalysis.totalProtein']);
+  const urineProteinUnitDecorated = {
+    entries: [{ date: '2026-05-01', markers: { 'urinalysis.totalProteinGl': 0.142 } }],
+    customMarkers: {
+      'urinalysis.totalProteinGl': { name: 'Total Protein (g/l)', unit: 'g/l' }
+    }
+  };
+  migrateProfileData(urineProteinUnitDecorated);
+  assert('Profile migration does not cross-map unit-decorated urine markers into blood categories',
+    urineProteinUnitDecorated.entries[0].markers['urinalysis.totalProteinGl'] === 0.142
+    && urineProteinUnitDecorated.entries[0].markers['proteins.totalProtein'] === undefined
+    && urineProteinUnitDecorated.customMarkers['urinalysis.totalProteinGl']);
 
   // ═══════════════════════════════════════
   // Results

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -271,11 +271,13 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       api.STREAM_STALL_TIMEOUT_MS === 30000, `got ${api.STREAM_STALL_TIMEOUT_MS}`);
     assert('api.js: FETCH_REQUEST_TIMEOUT_MS exported = 60000',
       api.FETCH_REQUEST_TIMEOUT_MS === 60000, `got ${api.FETCH_REQUEST_TIMEOUT_MS}`);
+    assert('api.js: AI_IMPORT_REQUEST_TIMEOUT_MS exported = 180000',
+      api.AI_IMPORT_REQUEST_TIMEOUT_MS === 180000, `got ${api.AI_IMPORT_REQUEST_TIMEOUT_MS}`);
     const apiSrc = fetchSrc('js/api.js');
     assert('api.js: readWithStallTimeout exists',
       /function readWithStallTimeout/.test(apiSrc));
     assert('api.js: _fetchWithRetry composes AbortSignal.timeout + caller signal',
-      /AbortSignal\.timeout\(FETCH_REQUEST_TIMEOUT_MS\)/.test(apiSrc)
+      /AbortSignal\.timeout\(timeoutMs\)/.test(apiSrc)
       && /AbortSignal\.any/.test(apiSrc));
     // Polyfill path: when AbortSignal.any is unavailable, manual
     // AbortController forwards both signals. Without this older
@@ -419,8 +421,19 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
     // sites exist so a future refactor doesn't accidentally bypass them.
     assert('pdf-import.js: imports callClaudeAPI from api.js',
       /import\s*\{[^}]*callClaudeAPI[^}]*\}\s*from\s*['"]\.\/api\.js['"]/.test(pdfSrc));
-    assert('pdf-import.js: parseLabPDFWithAI calls callClaudeAPI',
-      /export\s+async\s+function\s+parseLabPDFWithAI[\s\S]+?callClaudeAPI\(/.test(pdfSrc));
+    assert('pdf-import.js: imports import-specific AI timeout from api.js',
+      /import\s*\{[^}]*AI_IMPORT_REQUEST_TIMEOUT_MS[^}]*\}\s*from\s*['"]\.\/api\.js['"]/.test(pdfSrc));
+    assert('pdf-import.js: import AI fallback calls callClaudeAPI',
+      /function\s+callImportAIWithStreamFallback[\s\S]+?callClaudeAPI\(/.test(pdfSrc));
+    assert('pdf-import.js: retries aborted AI import streams without streaming',
+      /function\s+isAIStreamAbortError/.test(pdfSrc)
+      && /aborted by user/.test(pdfSrc)
+      && /name\s*===\s*['"]aborterror['"]/.test(pdfSrc)
+      && /function\s+callImportAIWithStreamFallback/.test(pdfSrc)
+      && /onStream:\s*undefined/.test(pdfSrc)
+      && /forceNonStream:\s*true/.test(pdfSrc)
+      && /requestTimeoutMs:\s*AI_IMPORT_REQUEST_TIMEOUT_MS/.test(pdfSrc)
+      && /parseLabPDFWithAI[\s\S]+?callImportAIWithStreamFallback/.test(pdfSrc));
     assert('pdf-import.js: catch path closes the import modal on error',
       /catch\s*\([^)]+\)\s*\{[\s\S]{0,500}hideImportProgress\('error'\)/.test(pdfSrc));
   }
@@ -570,7 +583,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       && /profileDob:\s*state\.profileDob/.test(dataSrc)
       && /wearableWeightLatest/.test(dataSrc)
       && /legacyWeightStamp/.test(dataSrc)
-      && /saveImportedData\(\)[\s\S]{0,120}invalidateActiveDataCache\(\)/.test(dataSrc)
+      && /saveImportedData\([^)]*\)[\s\S]{0,120}invalidateActiveDataCache\(\)/.test(dataSrc)
       && !/_makeActiveDataCacheMeta\(\)[\s\S]{0,900}rangeMode:\s*state\.rangeMode/.test(dataSrc)
       && !/switchRangeMode\(mode\)[\s\S]{0,220}invalidateActiveDataCache\(\)/.test(dataSrc));
     assert('category-glyphs.js: marker category surfaces use coded glyphs instead of emoji icons',

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -34,6 +34,12 @@ assert('callVeniceAPI has E2EE import', apiSrc.includes("import('../vendor/venic
 assert('supportsWebSearch excludes E2EE', apiSrc.includes('isE2EEModel(getVeniceModel())'));
 assert('supportsVision excludes E2EE', apiSrc.includes('isE2EEModel(getVeniceModel())') && apiSrc.includes('return false'));
 assert('fetchVeniceModels preserves e2ee- prefix', apiSrc.includes("id.startsWith('e2ee-')"));
+assert('Venice E2EE supports forced non-stream retry path',
+  /forceNonStream/.test(apiSrc)
+  && /requestTimeoutMs/.test(apiSrc)
+  && /stream:\s*useStream/.test(apiSrc)
+  && /if\s*\(!useStream\)/.test(apiSrc)
+  && /decryptChunk\(session\.privateKey,\s*encryptedContent\)/.test(apiSrc));
 
 // 2. window.isE2EEModel function
 assert('window.isE2EEModel is function', typeof window.isE2EEModel === 'function');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.173';
+self.APP_VERSION = '1.8.193';


### PR DESCRIPTION
## Summary

This consolidates the relevant Savi import/supplement work into one current branch on top of `main`.

Credit to @Savi-1 for the original PRs this salvages:

- #236 — supplement product/source URL persistence
- #338 — editable collection date in the import review modal

Additional fixes from testing and audit are included so the feature set lands safely on current `main`:

- preserve supplement `sourceUrl` with `http`/`https` validation and safe rendering
- make import collection dates editable and prevent duplicate date inputs
- harden PDF import against stream/arrayBuffer aborts and retry AI stream interruptions non-streaming
- reconcile imported marker labels/units so standard markers are reused instead of creating `ALP (ukat/l)`-style duplicates
- keep urine markers separate from blood markers, including total protein and sediment leukocytes
- prevent imported entries from disappearing after sync by merging same-date lab rows and pushing imports immediately
- make Settings → Data delete lazy-load the import module and sync an explicit lab-entry tombstone so deleted imports propagate to other devices
- migrate existing unit-suffixed duplicate custom markers back onto standard schema keys without cross-mapping urinalysis markers

## Validation

- `node --check js/data-merge.js`
- `node --check js/pdf-import.js`
- `node --check js/settings.js`
- `node tests/test-data-merge.js`
- `node tests/test-unit-import.js`
- browser smoke: Settings → Data → Remove deletes the row and writes `_deleted.entries`
- `npm test`
- `./run-tests.sh`
- `git diff --check`