### PR TITLE
[codex] Salvage Savi wearable import fixes

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -89,7 +89,7 @@ export const CANONICAL_METRICS = {
   sleep_hr_avg:         { id: 'sleep_hr_avg',         label: 'Sleep HR',    sub: 'avg',   unit: 'bpm', worseWhen: 'up'     }, // distinct from rhr (= hr_min) — average overnight
   sleep_breathing_rate: { id: 'sleep_breathing_rate', label: 'Breathing',   sub: 'sleep', unit: 'rpm', worseWhen: 'up'     },
   sleep_snoring_min:    { id: 'sleep_snoring_min',    label: 'Snoring',     sub: '',      unit: 'min', worseWhen: 'up'     },
-  sleep_breath_disturb: { id: 'sleep_breath_disturb', label: 'Apnea',       sub: 'level', unit: '',    worseWhen: 'up'     }, // breathing-disturbances intensity 0-100 (Withings' apnea-class signal)
+  sleep_breath_disturb: { id: 'sleep_breath_disturb', label: 'Apnea',       sub: 'level', unit: '',    worseWhen: 'up'     }, // breathing-disturbances intensity 0-100 (Withings + Oura BDI)
 };
 
 // For most wearable metrics, 0 is a sentinel for "no measurement" — the
@@ -181,7 +181,9 @@ export const ADAPTERS = [
       resilience_level: { endpoint: 'v2/usercollection/daily_resilience',        field: 'level' },           // enum → 1-5 in fetcher
       cardio_age:       { endpoint: 'v2/usercollection/daily_cardiovascular_age', field: 'vascular_age' },
       spo2_avg:         { endpoint: 'v2/usercollection/daily_spo2',              field: 'spo2_percentage' },
+      sleep_breath_disturb: { endpoint: 'v2/usercollection/daily_spo2',           field: 'breathing_disturbance_index' },
       body_temp_delta:  { endpoint: 'v2/usercollection/daily_readiness',         field: 'temperature_deviation' },
+      vo2max:           { endpoint: 'v2/usercollection/vO2_max',                 field: 'vo2_max' },
     },
     accountInfo: { endpoint: 'v2/usercollection/personal_info', identityField: 'email' },
   },
@@ -450,6 +452,14 @@ export const ADAPTERS = [
       spo2_avg:        { hkType: 'HKQuantityTypeIdentifierOxygenSaturation' },
       body_temp_delta: { hkType: 'HKQuantityTypeIdentifierBodyTemperature' },
       vo2max:          { hkType: 'HKQuantityTypeIdentifierVO2Max' },
+      // Body composition + cardio — Apple Health receives these from 3rd-party
+      // scales and BP cuffs writing into HealthKit. fat_mass_kg has no HK
+      // identifier; the parser derives it from weight × body_fat_pct.
+      weight:          { hkType: 'HKQuantityTypeIdentifierBodyMass' },
+      body_fat_pct:    { hkType: 'HKQuantityTypeIdentifierBodyFatPercentage' },
+      lean_mass_kg:    { hkType: 'HKQuantityTypeIdentifierLeanBodyMass' },
+      bp_systolic:     { hkType: 'HKQuantityTypeIdentifierBloodPressureSystolic' },
+      bp_diastolic:    { hkType: 'HKQuantityTypeIdentifierBloodPressureDiastolic' },
     },
   },
 ];

--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -182,7 +182,7 @@ function _processRecordAttrs(attrsRaw, typeToCanonical, byDayByMetric) {
   if (!byDayByMetric.has(day)) byDayByMetric.set(day, {});
   const bucket = byDayByMetric.get(day);
   if (!bucket[metricId]) bucket[metricId] = [];
-  bucket[metricId].push({ v: normalised, h: hour });
+  bucket[metricId].push({ v: normalised, h: hour, src: attrs.sourceName || '' });
 }
 
 // Streaming parser — reads `blob` via TextDecoderStream, splits on '\n', and
@@ -253,13 +253,25 @@ function _aggregateByDayByMetric(byDayByMetric) {
   //              app spikes).
   //   hr_day     null — would require parsing HKQuantityTypeIdentifierHeartRate
   //              (the raw intraday stream), which we don't ingest yet.
-  //   steps      sum
+  //   steps      sum by sourceName, then pick the max source total
   //   spo2_avg   mean
   //   body_temp  mean
   const isNight = (h) => (typeof h === 'number') && (h < 6 || h >= 22);
   const isDay   = (h) => (typeof h === 'number') && (h >= 6 && h < 22);
   const mean = (arr) => arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : null;
-  const sum  = (arr) => arr.reduce((a, b) => a + b, 0);
+  const sumByMaxSource = (samples) => {
+    if (!Array.isArray(samples) || samples.length === 0) return null;
+    const totals = new Map();
+    for (const sample of samples) {
+      const source = sample.src || '';
+      totals.set(source, (totals.get(source) || 0) + sample.v);
+    }
+    let best = null;
+    for (const total of totals.values()) {
+      if (best == null || total > best) best = total;
+    }
+    return best;
+  };
 
   const rows = [];
   for (const [day, bucket] of byDayByMetric) {
@@ -272,6 +284,7 @@ function _aggregateByDayByMetric(byDayByMetric) {
       strain: null,
       stress_high_min: null, resilience_level: null, cardio_age: null,
       weight: null, bp_systolic: null, bp_diastolic: null,
+      body_fat_pct: null, lean_mass_kg: null, fat_mass_kg: null,
       spo2_avg: null, body_temp_delta: null, glucose_avg: null,
       vo2max: null,
     };
@@ -314,8 +327,9 @@ function _aggregateByDayByMetric(byDayByMetric) {
       }
     }
 
-    if (Array.isArray(bucket.steps) && bucket.steps.length) {
-      row.steps = Math.round(sum(bucket.steps.map(s => s.v)) * 100) / 100;
+    const stepsBest = sumByMaxSource(bucket.steps);
+    if (stepsBest != null) {
+      row.steps = Math.round(stepsBest * 100) / 100;
     }
     if (Array.isArray(bucket.spo2_avg) && bucket.spo2_avg.length) {
       row.spo2_avg = Math.round(mean(bucket.spo2_avg.map(s => s.v)) * 100) / 100;
@@ -329,6 +343,24 @@ function _aggregateByDayByMetric(byDayByMetric) {
     // expected and handled by the chart's span-gaps.
     if (Array.isArray(bucket.vo2max) && bucket.vo2max.length) {
       row.vo2max = Math.round(mean(bucket.vo2max.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.weight) && bucket.weight.length) {
+      row.weight = Math.round(mean(bucket.weight.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.body_fat_pct) && bucket.body_fat_pct.length) {
+      row.body_fat_pct = Math.round(mean(bucket.body_fat_pct.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.lean_mass_kg) && bucket.lean_mass_kg.length) {
+      row.lean_mass_kg = Math.round(mean(bucket.lean_mass_kg.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.bp_systolic) && bucket.bp_systolic.length) {
+      row.bp_systolic = Math.round(mean(bucket.bp_systolic.map(s => s.v)) * 100) / 100;
+    }
+    if (Array.isArray(bucket.bp_diastolic) && bucket.bp_diastolic.length) {
+      row.bp_diastolic = Math.round(mean(bucket.bp_diastolic.map(s => s.v)) * 100) / 100;
+    }
+    if (row.weight != null && row.body_fat_pct != null) {
+      row.fat_mass_kg = Math.round(row.weight * row.body_fat_pct) / 100;
     }
 
     rows.push(row);
@@ -367,6 +399,18 @@ function normaliseUnit(metricId, value, unit) {
       // Apple ships VO₂max in "mL/min·kg" (their formatting). Canonical is
       // mL/kg/min — same physiological quantity, just transposed factors.
       return (!unit || unit === 'mL/min·kg' || unit === 'mL/kg/min') ? value : null;
+    case 'weight':
+    case 'lean_mass_kg':
+      if (!unit || unit === 'kg') return value;
+      if (unit === 'lb') return value / 2.20462;
+      if (unit === 'st') return value * 6.35029;
+      return null;
+    case 'body_fat_pct':
+      if (!unit || unit === '%' || unit === '1') return value <= 1 ? value * 100 : value;
+      return null;
+    case 'bp_systolic':
+    case 'bp_diastolic':
+      return (!unit || unit === 'mmHg') ? value : null;
     default:
       // If canonical declares a unit string and Apple disagrees, refuse.
       return (!unit || unit === canonUnit) ? value : null;

--- a/js/wearables-oura.js
+++ b/js/wearables-oura.js
@@ -184,6 +184,7 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
   const [
     sleepSessions, dailySleep, dailyReadiness, dailySpo2,
     dailyActivity, dailyStress, dailyResilience, dailyCardioAge,
+    vo2maxSamples,
     heartrateSamples,
   ] = await Promise.all([
     ouraCollect('v2/usercollection/sleep',                    accessToken, params).catch(e => { logDebug('sleep', e); return []; }),
@@ -194,6 +195,7 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
     ouraCollect('v2/usercollection/daily_stress',             accessToken, params).catch(e => { logDebug('daily_stress', e); return []; }),
     ouraCollect('v2/usercollection/daily_resilience',         accessToken, params).catch(e => { logDebug('daily_resilience', e); return []; }),
     ouraCollect('v2/usercollection/daily_cardiovascular_age', accessToken, params).catch(e => { logDebug('daily_cardiovascular_age', e); return []; }),
+    ouraCollect('v2/usercollection/vO2_max',                  accessToken, params).catch(e => { logDebug('vO2_max', e); return []; }),
     ouraCollectHeartrate(accessToken, startDt, endDt)
       .catch(e => { logDebug('heartrate', e); return []; }),
   ]);
@@ -211,6 +213,7 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
         activity_score: null, steps: null,
         stress_high_min: null, resilience_level: null, cardio_age: null,
         spo2_avg: null, body_temp_delta: null, glucose_avg: null,
+        sleep_breath_disturb: null, vo2max: null,
       });
     }
     return byDate.get(day);
@@ -253,8 +256,11 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
   }
   for (const d of dailySpo2) {
     if (!d?.day) continue;
+    const row = ensureRow(d.day);
     const v = typeof d.spo2_percentage === 'object' ? d.spo2_percentage?.average : d.spo2_percentage;
-    if (typeof v === 'number') ensureRow(d.day).spo2_avg = v;
+    if (typeof v === 'number') row.spo2_avg = v;
+    const bdi = gtZero(d.breathing_disturbance_index);
+    if (bdi != null) row.sleep_breath_disturb = bdi;
   }
   for (const d of dailyActivity) {
     if (!d?.day) continue;
@@ -275,6 +281,14 @@ export async function fetchOuraDailyRange(accessToken, startDate, endDate) {
   for (const d of dailyCardioAge) {
     if (!d?.day) continue;
     if (typeof d.vascular_age === 'number') ensureRow(d.day).cardio_age = d.vascular_age;
+  }
+  for (const d of vo2maxSamples) {
+    if (!d?.day) continue;
+    const raw = (d.vo2_max && typeof d.vo2_max === 'object')
+      ? (d.vo2_max.value ?? d.vo2_max.vo2_max)
+      : d.vo2_max;
+    const v = gtZero(raw);
+    if (v != null) ensureRow(d.day).vo2max = v;
   }
 
   // Daytime HR aggregate from the heartrate stream — Oura tags each sample as

--- a/tests/spike-fixtures/apple-health-sample.xml
+++ b/tests/spike-fixtures/apple-health-sample.xml
@@ -20,4 +20,8 @@
  <Record type="HKQuantityTypeIdentifierHeartRate" sourceName="Apple Watch" unit="count/min" creationDate="2026-04-20 10:00:00 +0200" startDate="2026-04-20 10:00:00 +0200" endDate="2026-04-20 10:00:00 +0200" value="72"/>
  <Record type="HKQuantityTypeIdentifierActiveEnergyBurned" sourceName="Apple Watch" unit="kcal" creationDate="2026-04-20 11:00:00 +0200" startDate="2026-04-20 10:55:00 +0200" endDate="2026-04-20 11:00:00 +0200" value="45"/>
  <Record type="HKQuantityTypeIdentifierBodyMass" sourceName="Withings Scale" unit="kg" creationDate="2026-04-21 07:00:00 +0200" startDate="2026-04-21 07:00:00 +0200" endDate="2026-04-21 07:00:00 +0200" value="72.5"/>
+ <Record type="HKQuantityTypeIdentifierBodyFatPercentage" sourceName="Withings Scale" unit="%" creationDate="2026-04-21 07:00:00 +0200" startDate="2026-04-21 07:00:00 +0200" endDate="2026-04-21 07:00:00 +0200" value="0.185"/>
+ <Record type="HKQuantityTypeIdentifierLeanBodyMass" sourceName="Withings Scale" unit="lb" creationDate="2026-04-21 07:00:00 +0200" startDate="2026-04-21 07:00:00 +0200" endDate="2026-04-21 07:00:00 +0200" value="128.1"/>
+ <Record type="HKQuantityTypeIdentifierBloodPressureSystolic" sourceName="Blood Pressure Cuff" unit="mmHg" creationDate="2026-04-21 07:10:00 +0200" startDate="2026-04-21 07:10:00 +0200" endDate="2026-04-21 07:10:00 +0200" value="121"/>
+ <Record type="HKQuantityTypeIdentifierBloodPressureDiastolic" sourceName="Blood Pressure Cuff" unit="mmHg" creationDate="2026-04-21 07:10:00 +0200" startDate="2026-04-21 07:10:00 +0200" endDate="2026-04-21 07:10:00 +0200" value="78"/>
 </HealthData>

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -342,6 +342,10 @@ for (const mid of ['activity_score','steps','stress_high_min','resilience_level'
   assert(`CANONICAL_METRICS has ${mid}`, !!reg.CANONICAL_METRICS[mid]);
   assert(`Oura adapter maps ${mid}`, reg.adapterSupportsMetric('oura', mid));
 }
+assert('Oura adapter maps VO2max',
+  reg.adapterSupportsMetric('oura', 'vo2max'));
+assert('Oura adapter maps breathing disturbance index',
+  reg.adapterSupportsMetric('oura', 'sleep_breath_disturb'));
 // Total canonicals: 14 (pre-#143) + 8 Body Scan body-comp + 6
 // additional /measure (fat_mass, spo2, body_temp, skin_temp,
 // vascular_age, cardio_fitness) + 9 sleep-arch + 1 (vo2max from
@@ -368,6 +372,10 @@ assert('CANONICAL_METRICS bp_systolic carries spoken-aria override', reg.CANONIC
 assert('CANONICAL_METRICS bp_diastolic carries spoken-aria override', reg.CANONICAL_METRICS.bp_diastolic?.ariaLabel === 'Blood pressure diastolic');
 assert('Steps is mapped to the same endpoint as activity_score (both from daily_activity)',
   reg.adapterById('oura').metrics.steps.endpoint === reg.adapterById('oura').metrics.activity_score.endpoint);
+const appleHealth = reg.adapterById('apple_health');
+for (const mid of ['weight', 'body_fat_pct', 'lean_mass_kg', 'bp_systolic', 'bp_diastolic']) {
+  assert(`Apple Health adapter maps ${mid}`, reg.adapterSupportsMetric('apple_health', mid));
+}
 
 // AI context labels derive from canonical registry — must handle every ordered
 // metric without falling back to raw ids.
@@ -399,6 +407,43 @@ assert('resilience_level metric unit is /5 (registry contract)',
   reg.CANONICAL_METRICS.resilience_level.unit === '/5');
 assert('stress_high_min metric unit is min (registry contract)',
   reg.CANONICAL_METRICS.stress_high_min.unit === 'min');
+const fetchBeforeOuraStub = globalThis.fetch;
+try {
+  globalThis.fetch = async (url, opts = {}) => {
+    const payload = JSON.parse(opts.body || '{}');
+    const path = new URL(payload.url).pathname;
+    const dataByPath = {
+      '/v2/usercollection/daily_spo2': [
+        {
+          day: '2026-04-20',
+          spo2_percentage: { average: 97 },
+          breathing_disturbance_index: 14,
+        },
+      ],
+      '/v2/usercollection/vO2_max': [
+        { day: '2026-04-20', vo2_max: { value: 42.1 } },
+        { day: '2026-04-21', vo2_max: 0 },
+      ],
+    };
+    return new Response(JSON.stringify({
+      data: dataByPath[path] || [],
+      next_token: null,
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  const ouraRows = await fetchOuraDailyRange('test-token', '2026-04-20', '2026-04-21');
+  const ouraDay1 = ouraRows.find(r => r.date === '2026-04-20');
+  assert('Oura daily_spo2 maps average SpO2 plus breathing disturbance index',
+    ouraDay1?.spo2_avg === 97 && ouraDay1.sleep_breath_disturb === 14,
+    `row=${JSON.stringify(ouraDay1)}`);
+  assert('Oura VO2max accepts object payloads and rejects zero sentinels',
+    ouraDay1?.vo2max === 42.1 && !ouraRows.some(r => r.date === '2026-04-21' && r.vo2max === 0),
+    `rows=${JSON.stringify(ouraRows)}`);
+} finally {
+  globalThis.fetch = fetchBeforeOuraStub;
+}
 
 // ═══════════════════════════════════════
 // 9. Render-helper divide-by-zero guards
@@ -594,9 +639,11 @@ assert('HRV SDNN aggregates night-window samples (42.5 & 48.5 → 45.5)',
 // No day-window HRV samples in fixture → hrv_day should be null on day 1.
 assert('hrv_day is null when no day-window samples exist',
   day1.hrv_day === null);
-// Steps is sum-per-day (320 + 2100 + 5430 = 7850)
-assert('Steps sum multiple sources per day (320+2100+5430=7850)',
-  day1.steps === 7850);
+// Steps are additive per source but Apple Health may contain overlapping
+// iPhone/Watch/Oura rows. Sum within source, then take the max source total:
+// iPhone=2420, Apple Watch=5430 → 5430.
+assert('Steps de-duplicate multi-source Apple Health days by max source total',
+  day1.steps === 5430, `got ${day1.steps}`);
 // SpO2 mean of 97 + 95 = 96
 assert('SpO2 mean-per-day aggregator (97+95 → 96)',
   day1.spo2_avg === 96);
@@ -604,9 +651,10 @@ assert('SpO2 mean-per-day aggregator (97+95 → 96)',
 assert('Day 2 RHR populated (single reading → 56)', day2.rhr === 56);
 assert('Day 2 HRV SDNN populated (single night-window sample → 51)', day2.hrv_sdnn === 51);
 assert('Day 2 hrv_day null (no day-window samples)', day2.hrv_day === null);
+assert('Day 2 steps single-source value passes through unchanged',
+  day2.steps === 8200, `got ${day2.steps}`);
 
-// Records we explicitly don't map must NOT end up in canonical rows —
-// HeartRate (real-time) and BodyMass aren't in our Apple Health mapping yet.
+// Records we explicitly don't map must NOT end up in canonical rows.
 assert('rMSSD is not derivable from Apple Health (we use SDNN type only) — hrv_rmssd stays null',
   day1.hrv_rmssd === null && day2.hrv_rmssd === null);
 // Day 1 has one HKQuantityTypeIdentifierHeartRate sample at 10:00 (day window) value=72.
@@ -617,6 +665,17 @@ assert('hr_day null when no day-window HR samples exist on that day',
   day2.hr_day === null);
 assert('Body temp delta correctly dropped (no baseline yet, absolute temp unusable)',
   day1.body_temp_delta === null);
+assert('Apple Health BodyMass maps to weight',
+  day2.weight === 72.5, `weight=${day2.weight}`);
+assert('Apple Health BodyFatPercentage fraction maps to percent',
+  day2.body_fat_pct === 18.5, `body_fat_pct=${day2.body_fat_pct}`);
+assert('Apple Health derives fat_mass_kg from weight and body fat percent',
+  day2.fat_mass_kg === 13.41, `fat_mass_kg=${day2.fat_mass_kg}`);
+assert('Apple Health LeanBodyMass lb converts to kg',
+  day2.lean_mass_kg === 58.11, `lean_mass_kg=${day2.lean_mass_kg}`);
+assert('Apple Health BP parses systolic and diastolic',
+  day2.bp_systolic === 121 && day2.bp_diastolic === 78,
+  `bp=${day2.bp_systolic}/${day2.bp_diastolic}`);
 
 // Source tag is apple_health so the L1 IDB + multi-source badge paths pick
 // it up as a distinct vendor alongside Oura/WHOOP.
@@ -628,6 +687,15 @@ const hostileXml = '<?xml version="1.0"?><HealthData><Record type="HKQuantityTyp
 const hostileRows = ah.parseAppleHealthXml(hostileXml);
 assert('Hostile unit ("furlongs" for steps) is refused, not ingested',
   hostileRows.length === 0 || hostileRows[0].steps === null);
+const bodyUnitXml = '<?xml version="1.0"?><HealthData>'
+  + '<Record type="HKQuantityTypeIdentifierBodyMass" unit="st" startDate="2026-04-20 00:00:00 +0000" value="11"/>'
+  + '<Record type="HKQuantityTypeIdentifierLeanBodyMass" unit="lb" startDate="2026-04-20 00:00:00 +0000" value="100"/>'
+  + '</HealthData>';
+const bodyUnitRows = ah.parseAppleHealthXml(bodyUnitXml);
+assert('Apple Health BodyMass stone unit converts to kg',
+  bodyUnitRows[0]?.weight === 69.85, `weight=${bodyUnitRows[0]?.weight}`);
+assert('Apple Health LeanBodyMass lb unit converts to kg',
+  bodyUnitRows[0]?.lean_mass_kg === 45.36, `lean=${bodyUnitRows[0]?.lean_mass_kg}`);
 
 // ── #180 regression: lazy-load JSZip on first ZIP import ──
 // index.html intentionally does NOT pre-load /vendor/jszip.min.js. A prior

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.193';
+self.APP_VERSION = '1.8.194';


### PR DESCRIPTION
## Summary

Salvages the focused wearable-import pieces from @Savi-1's open PRs:

- #355: Apple Health body composition and blood pressure import support
- #356: Apple Health step de-duplication across overlapping sources
- #357: Oura VO2max and breathing disturbance index ingestion

I also folded in the review cleanup we identified while auditing those PRs: added missing parser/fetcher coverage, removed the dead Apple Health steps helper path, avoided repeated Oura row creation in the SpO2/BDI loop, and made Oura VO2max handle object payloads defensively.

## Validation

- `node --check js/wearable-adapters.js`
- `node --check js/wearables-apple-health.js`
- `node --check js/wearables-oura.js`
- `node --check tests/test-wearables.js`
- `node tests/test-wearables.js` — 565 passed, 0 failed
- `./run-tests.sh` — full regression passed, including Theme Responsive E2E 244 passed, 0 failed

Co-authored-by: Savi-1 <65488451+Savi-1@users.noreply.github.com>