### PR TITLE
[codex] Salvage Savi wearable detail and summary fixes

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -117,6 +117,26 @@ export function isMetricValueMeaningful(metricId, v) {
   return v > 0;
 }
 
+// Cumulative-from-midnight metrics: values are running totals until the local
+// day ends. L2 summary derivation excludes today's row for these metrics so
+// latest/baseline/rolling averages use finalized days, while L1 and charts
+// still keep the in-progress value visible.
+//
+// `stress_high_min` is stored in minutes in L1; Oura emits seconds, but the
+// fetcher converts to minutes before writing the canonical row.
+export const CUMULATIVE_METRICS = new Set([
+  'steps',
+  'stress_high_min',
+]);
+
+// Per-metric minimum daily value below which the row is treated as non-wear
+// for L2 summary math. The row stays in IDB and remains chartable; it is only
+// skipped for latest/baseline/rolling/trend so off-wrist days do not drag
+// activity averages down.
+export const WEAR_REQUIRED_MINIMUMS = {
+  steps: 300,
+};
+
 // Default display order for the dashboard strip. A canonical metric not listed
 // here still renders (appended in registry order) — the list just pins priority.
 // Also used as METRICS_FOR_SUMMARY in wearables-summary.js, so any metric that

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -9,9 +9,14 @@
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
 import { getDailyRange } from './wearables-store.js';
-import { DEFAULT_METRIC_ORDER, isMetricValueMeaningful } from './wearable-adapters.js';
+import {
+  DEFAULT_METRIC_ORDER,
+  isMetricValueMeaningful,
+  CUMULATIVE_METRICS,
+  WEAR_REQUIRED_MINIMUMS,
+  isoDay,
+} from './wearable-adapters.js';
 import { isDebugMode } from './utils.js';
-import { isoDay } from './wearables-oura.js';
 
 // ─────────────────────────────────────────────────────────
 // Tunables — see dev-docs/module-reference.md (wearables-summary.js section)
@@ -57,11 +62,19 @@ function linearRegressionSlope(values) {
 // Per-metric derivation
 // ─────────────────────────────────────────────────────────
 
-function seriesFor(rowsByDate, metricId) {
+function isSummaryEligibleRow(row, metricId, todayISO = isoDay()) {
+  if (!row) return false;
+  const v = row[metricId];
+  if (CUMULATIVE_METRICS.has(metricId) && row.date === todayISO) return false;
+  const wearMin = WEAR_REQUIRED_MINIMUMS[metricId];
+  if (wearMin != null && typeof v === 'number' && isFinite(v) && v < wearMin) return false;
+  return isMetricValueMeaningful(metricId, v);
+}
+
+function seriesFor(rowsByDate, metricId, todayISO = isoDay()) {
   const out = [];
   for (const row of rowsByDate) {
-    const v = row[metricId];
-    if (isMetricValueMeaningful(metricId, v)) out.push({ date: row.date, v });
+    if (isSummaryEligibleRow(row, metricId, todayISO)) out.push({ date: row.date, v: row[metricId] });
   }
   return out;
 }
@@ -89,8 +102,8 @@ function weeklyMeans(series, weeksBack = 12) {
   return weeks.slice(-weeksBack);
 }
 
-function deriveMetric(rowsByDate, metricId, primarySource) {
-  const series = seriesFor(rowsByDate, metricId);
+function deriveMetric(rowsByDate, metricId, primarySource, todayISO = isoDay()) {
+  const series = seriesFor(rowsByDate, metricId, todayISO);
   if (series.length === 0) return null;
 
   const latest = series[series.length - 1];
@@ -152,6 +165,7 @@ function deriveMetric(rowsByDate, metricId, primarySource) {
 export function computeWearableSummary(rowsBySource, connectedSources, primaryOverride = {}) {
   const sources = {};
   const pickedPrimary = {}; // metricId → sourceId
+  const todayISO = isoDay();
 
   for (const [sid, rows] of Object.entries(rowsBySource)) {
     // coverageDays counts rows that carry at least ONE non-null canonical
@@ -188,16 +202,15 @@ export function computeWearableSummary(rowsBySource, connectedSources, primaryOv
     if (overrideSrc && rowsBySource[overrideSrc]) {
       const overRows = rowsBySource[overrideSrc];
       for (let i = overRows.length - 1; i >= 0; i--) {
-        const v = overRows[i]?.[metricId];
-        if (isMetricValueMeaningful(metricId, v)) { bestSrc = overrideSrc; break; }
+        if (isSummaryEligibleRow(overRows[i], metricId, todayISO)) { bestSrc = overrideSrc; break; }
       }
     }
     if (!bestSrc) {
       for (const [sid, rows] of Object.entries(rowsBySource)) {
         for (let i = rows.length - 1; i >= 0; i--) {
-          const v = rows[i]?.[metricId];
-          if (isMetricValueMeaningful(metricId, v)) {
-            if (rows[i].date > bestDate) { bestDate = rows[i].date; bestSrc = sid; }
+          if (isSummaryEligibleRow(rows[i], metricId, todayISO)) {
+            const rowDate = rows[i]?.date || '';
+            if (rowDate > bestDate) { bestDate = rowDate; bestSrc = sid; }
             break;
           }
         }
@@ -205,7 +218,7 @@ export function computeWearableSummary(rowsBySource, connectedSources, primaryOv
     }
     if (!bestSrc) continue;
     pickedPrimary[metricId] = bestSrc;
-    const derived = deriveMetric(rowsBySource[bestSrc], metricId, bestSrc);
+    const derived = deriveMetric(rowsBySource[bestSrc], metricId, bestSrc, todayISO);
     if (derived) metrics[metricId] = derived;
   }
 

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -17,7 +17,7 @@
 
 import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { state } from './state.js';
-import { ADAPTERS, adapterById, canonicalMetric, metricsForSources, visibleAdapters, getOAuthClientId, isMetricValueMeaningful } from './wearable-adapters.js';
+import { ADAPTERS, adapterById, canonicalMetric, metricsForSources, visibleAdapters, getOAuthClientId, isMetricValueMeaningful, CUMULATIVE_METRICS, isoDay } from './wearable-adapters.js';
 import { brandMarkMono } from './brand-assets.js';
 
 // Vendor logo / mark beside the adapter name. Backed by brands/<vendor>/
@@ -37,7 +37,6 @@ import { getDailyRange } from './wearables-store.js';
 import { MANUAL_METRICS } from './wearables-manual.js';
 import { getChartColors } from './theme.js';
 import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
-import { isoDay } from './wearables-oura.js';
 
 // ─────────────────────────────────────────────────────────
 // MOCK SUMMARY — remove once the real L2 pipeline ships
@@ -276,12 +275,17 @@ function renderEmptyManualCard(metricId, canon) {
 }
 
 // Format an ISO date (YYYY-MM-DD) as "Apr 24" for compact display next to a
-// metric value. Returns the raw input on parse failure.
+// metric value. Include the year for dates outside the current local year.
+// Returns the raw input on parse failure.
 function shortDate(iso) {
   if (!iso || typeof iso !== 'string') return iso || '';
   const d = new Date(iso + 'T00:00:00Z');
   if (isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  const sameYear = d.getUTCFullYear() === Number(isoDay().slice(0, 4));
+  const fmt = sameYear
+    ? { month: 'short', day: 'numeric', timeZone: 'UTC' }
+    : { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' };
+  return d.toLocaleDateString(undefined, fmt);
 }
 
 function renderCard(metricId, canon, metric, showSourceBadge, sourceMaxDate, opts = {}) {
@@ -669,15 +673,33 @@ function toggleWearableStrip() {
 }
 
 // ─────────────────────────────────────────────────────────
-// DETAIL MODAL — 90d daily chart + stats for a single metric
+// DETAIL MODAL — daily chart + stats for a single metric
 // ─────────────────────────────────────────────────────────
+
+const WEARABLE_DETAIL_RANGES = [
+  { key: '90d', days: 90, label: '90d', coverageSuffix: 'of last 90 days', emptyWindow: 'the last 90 days' },
+  { key: '6m', days: 180, label: '6m', coverageSuffix: 'of last 6 months', emptyWindow: 'the last 6 months' },
+  { key: '1y', days: 365, label: '1y', coverageSuffix: 'of last 12 months', emptyWindow: 'the last 12 months' },
+  { key: 'all', days: null, label: 'All', coverageSuffix: 'all-time', emptyWindow: 'all recorded data' },
+];
+const WEARABLE_DETAIL_RANGE_KEY = 'wearable-detail-range';
+function getWearableDetailRange() {
+  const stored = localStorage.getItem(WEARABLE_DETAIL_RANGE_KEY);
+  if (stored && WEARABLE_DETAIL_RANGES.some(r => r.key === stored)) return stored;
+  return '90d';
+}
+function setWearableDetailRange(metricId, rangeKey) {
+  if (!WEARABLE_DETAIL_RANGES.some(r => r.key === rangeKey)) return;
+  localStorage.setItem(WEARABLE_DETAIL_RANGE_KEY, rangeKey);
+  openWearableDetail(metricId, { fromRangeToggle: true });
+}
 
 // Monotonic op token — fast successive clicks on different cards shouldn't
 // land mismatched data in the modal. Each call grabs a new token; any work
 // that resolves with a stale token aborts before touching the DOM.
 let _detailOp = 0;
 
-async function openWearableDetail(metricId) {
+async function openWearableDetail(metricId, opts = {}) {
   const op = ++_detailOp;
   const canon = canonicalMetric(metricId);
   const summary = state.importedData?.wearableSummary;
@@ -689,16 +711,23 @@ async function openWearableDetail(metricId) {
 
   // Snapshot the focused element (clicked card) so closeModal can return
   // focus to it — keyboard users otherwise land on <body> after close.
-  window.rememberModalTrigger?.();
+  if (!opts.fromRangeToggle) window.rememberModalTrigger?.();
 
-  // Pull last 90 days from L1 for whichever source is primary for this metric.
-  // Series may have gaps (ring not worn, feature off) — we plot what's there
-  // and label missing days via Chart.js spanGaps rather than forward-filling.
+  // Pull rows from L1 for whichever source is primary for this metric. Series
+  // may have gaps (ring not worn, feature off) — we plot what's there and
+  // label missing days via Chart.js spanGaps rather than forward-filling.
+  const rangeKey = getWearableDetailRange();
+  const rangeDef = WEARABLE_DETAIL_RANGES.find(r => r.key === rangeKey) || WEARABLE_DETAIL_RANGES[0];
   const profileId = getActiveProfileId();
   // Local-tz: vendor adapters tag rows with the user's local day, not UTC.
   const endDate = isoDay();
-  const start = new Date(); start.setDate(start.getDate() - 90);
-  const startDate = isoDay(start);
+  let startDate;
+  if (rangeDef.days == null) {
+    startDate = '1970-01-01';
+  } else {
+    const start = new Date(); start.setDate(start.getDate() - rangeDef.days);
+    startDate = isoDay(start);
+  }
   let rows = [];
   try { rows = await getDailyRange(profileId, m.primarySource, startDate, endDate); }
   catch (e) { showNotification?.(`Couldn't read local history: ${e.message}`, 'error', 4000); return; }
@@ -744,10 +773,13 @@ async function openWearableDetail(metricId) {
     delete state.chartInstances['modal'];
   }
 
-  modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries, { allZeroActivity });
+  modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries, { allZeroActivity, rangeKey });
   overlay.classList.add('show');
-  // Move focus to the close button so keyboard users land inside the modal.
-  modal.querySelector('.modal-close')?.focus?.();
+  // Fresh opens land on close; range re-renders keep focus on the active pill.
+  const focusTarget = opts.fromRangeToggle
+    ? modal.querySelector('.wearable-detail-range .ctx-btn-option.active')
+    : modal.querySelector('.modal-close');
+  focusTarget?.focus?.();
   // Trap Tab / Shift-Tab inside the modal so keyboard navigation can't
   // accidentally land on background controls (the strip, supplements,
   // chat FAB, etc.). One listener per modal-open; cleared on close via
@@ -908,13 +940,15 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
                        : null;
   const companionUnitSpaced = companion ? unitSpaced : '';
 
+  const rangeKey = opts.rangeKey || '90d';
+  const rangeDef = WEARABLE_DETAIL_RANGES.find(r => r.key === rangeKey) || WEARABLE_DETAIL_RANGES[0];
   const baseStats = [
     ['Latest',   `${formatV(m.latest)}${unitSpaced}`, m.latestDate ? shortDate(m.latestDate) : ''],
     ['Baseline (90d)', `${formatV(m.baseline)}${unitSpaced}`, 'median'],
     ['7-day avg', `${formatV(m.rolling?.d7)}${unitSpaced}`, ''],
     ['30-day avg', `${formatV(m.rolling?.d30)}${unitSpaced}`, ''],
     ['Typical range', `${formatV(m.baselineP25)} – ${formatV(m.baselineP75)}${unitSpaced}`, '25th–75th percentile'],
-    ['Coverage', `${series.length}d`, `of last 90 days`],
+    ['Chart samples', `${series.length}d`, rangeDef.coverageSuffix],
   ];
   // Daytime companion: emit up to three sub-stats — latest, 7-day average,
   // 30-day average — so the user gets the trend, not just today (a single
@@ -974,7 +1008,7 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
   const emptyHint = opts.allZeroActivity
     ? `<div class="wearable-detail-empty">Every day shows 0 — Oura suppresses the Activity composite score while Rest Mode is on. Check the <b>Steps</b> card for raw movement data, or disable Rest Mode in the Oura app.</div>`
     : series.length === 0
-      ? `<div class="wearable-detail-empty">No daily samples for this metric in the last 90 days. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`
+      ? `<div class="wearable-detail-empty">No daily samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`
       : '';
 
   // Show the source-swap button whenever ≥2 wearables are connected — the
@@ -988,6 +1022,9 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
     : '';
 
   const emfSleepHint = _buildEMFSleepHint(metricId, m);
+  const rangePills = WEARABLE_DETAIL_RANGES.map(r =>
+    `<button type="button" class="ctx-btn-option${r.key === rangeKey ? ' active' : ''}" aria-pressed="${r.key === rangeKey}" onclick="setWearableDetailRange('${escapeHTML(metricId)}','${r.key}')">${escapeHTML(r.label)}</button>`
+  ).join('');
 
   return `<button class="modal-close" onclick="closeModal()">&times;</button>
     <h3>${escapeHTML(canon.label)}${subLabel}</h3>
@@ -995,6 +1032,7 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
       ${escapeHTML(sourceName)}${deltaStr ? ` · ${deltaStr} vs baseline` : ''} · ${escapeHTML(trendWord)} 30d
       ${swapButton}
     </div>
+    <div class="ctx-btn-group wearable-detail-range" role="group" aria-label="Chart range">${rangePills}</div>
     <div class="modal-chart" style="height:260px"><canvas id="chart-modal"></canvas></div>
     ${emptyHint}
     <div class="wearable-detail-stats">${statsCells}</div>
@@ -1045,6 +1083,10 @@ function renderWearableChart(canvas, canon, m, series) {
   const labels = series.map(p => p.date);
   const values = series.map(p => p.v);
   const baselineValues = values.map(() => m.baseline);
+  const isCumulative = CUMULATIVE_METRICS.has(canon.id);
+  const todayISO = isoDay();
+  const isPartialIdx = (idx) => isCumulative && series[idx]?.date === todayISO;
+  const partialColor = '#f59e0b';
 
   // Y-axis padding so baseline line and sparkline aren't clipped to the edge.
   const ymin = Math.min(...values, m.baseline);
@@ -1065,10 +1107,16 @@ function renderWearableChart(canvas, canon, m, series) {
           borderColor: tc.lineColor || '#60a5fa',
           backgroundColor: 'transparent',
           borderWidth: 2,
-          pointRadius: 0,
-          pointHoverRadius: 4,
+          pointRadius: values.map((_, i) => isPartialIdx(i) ? 5 : 0),
+          pointBackgroundColor: values.map((_, i) => isPartialIdx(i) ? partialColor : 'transparent'),
+          pointBorderColor: values.map((_, i) => isPartialIdx(i) ? partialColor : 'transparent'),
+          pointHoverRadius: values.map((_, i) => isPartialIdx(i) ? 7 : 4),
           tension: 0.3,
           spanGaps: true,
+          segment: {
+            borderDash: (ctx) => isPartialIdx(ctx.p1DataIndex) ? [5, 4] : undefined,
+            borderColor: (ctx) => isPartialIdx(ctx.p1DataIndex) ? partialColor : undefined,
+          },
         },
         {
           label: 'Baseline',
@@ -1086,12 +1134,20 @@ function renderWearableChart(canvas, canon, m, series) {
     options: {
       responsive: true,
       maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false, axis: 'x' },
       plugins: {
         legend: { display: false },
         tooltip: {
           backgroundColor: tc.tooltipBg, titleColor: tc.tooltipTitle,
           bodyColor: tc.tooltipBody, borderColor: tc.tooltipBorder, borderWidth: 1,
-          callbacks: { label: (c) => `${c.dataset.label}: ${formatV(c.parsed.y)}${unit ? ' ' + unit : ''}` },
+          callbacks: {
+            label: (c) => {
+              const base = `${c.dataset.label}: ${formatV(c.parsed.y)}${unit ? ' ' + unit : ''}`;
+              return (c.datasetIndex === 0 && isPartialIdx(c.dataIndex))
+                ? `${base}  (partial day · in progress)`
+                : base;
+            },
+          },
         },
       },
       scales: {
@@ -2019,6 +2075,7 @@ Object.assign(window, {
   dismissWearableStub,
   toggleWearableStrip,
   openWearableDetail,
+  setWearableDetailRange,
   _uninstallWearableModalFocusTrap,
   syncWearableNow,
   chooseWearableSource,

--- a/styles.css
+++ b/styles.css
@@ -10327,6 +10327,7 @@ body.import-focus .welcome-hero > .drop-zone {
 }
 
 /* ── Wearable detail modal ── */
+.wearable-detail-range { margin: 10px 0 4px; justify-content: flex-start; }
 .wearable-detail-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -10,7 +10,8 @@
 //   B. JSZip lazy-loader functional smoke — clear window.JSZip, route a
 //      .zip File through importAppleHealthFile, confirm loadJSZip set it.
 //   C. SpO2 modal-renderer parity — modal renders "97 %" not "97.0 %".
-//   D. Daytime-empty-state HRV modal — "Not from Oura · why?" row + tooltip.
+//   D. Partial-day cumulative chart marker.
+//   E. Daytime-empty-state HRV modal — "Not from Oura · why?" row + tooltip.
 //
 // Run: fetch('tests/test-wearables-dom.js').then(r=>r.text()).then(s=>Function(s)())
 
@@ -33,10 +34,12 @@ return (async function() {
 
   const store = await import('../js/wearables-store.js');
   const ah = await import('../js/wearables-apple-health.js');
+  const reg = await import('../js/wearable-adapters.js');
   await import('../js/wearables.js'); // registers window.openWearableDetail / closeModal / renderWearableStrip
 
   window._labState.importedData = window._labState.importedData || {};
   const TEST_PROFILE = window._labState.currentProfile || ('__test-wearables-dom-' + Math.random().toString(36).slice(2, 8));
+  localStorage.removeItem('wearable-detail-range');
 
   // ═══════════════════════════════════════
   // A. Detail modal — HRV + activity_score
@@ -63,13 +66,23 @@ return (async function() {
   assert('Detail modal includes metric label HRV', modalHtml.includes('HRV'));
   assert('Detail modal shows latest value', /42/.test(modalHtml));
   assert('Detail modal shows Baseline (90d) stat', /Baseline/.test(modalHtml));
-  assert('Detail modal shows Coverage stat', /Coverage/.test(modalHtml));
+  assert('Detail modal shows Chart samples stat', /Chart samples/.test(modalHtml));
   assert('Chart canvas mounted on modal', !!document.getElementById('chart-modal'));
   assert('Chart instance stored under state.chartInstances.modal', !!window._labState.chartInstances?.modal);
   const modalChart = window._labState.chartInstances?.modal;
   assert('Chart has 3 data points matching L1 row count', modalChart?.data?.datasets?.[0]?.data?.length === 3);
   assert('Chart labels array has 3 entries', modalChart?.data?.labels?.length === 3);
   assert('Chart x-axis is time type', modalChart?.options?.scales?.x?.type === 'time');
+  const rangeButtons = Array.from(document.querySelectorAll('#detail-modal .wearable-detail-range .ctx-btn-option'));
+  assert('Detail modal renders 90d / 6m / 1y / All range buttons',
+    rangeButtons.map(b => b.textContent.trim()).join('|') === '90d|6m|1y|All');
+  assert('Detail modal defaults to 90d range',
+    document.querySelector('#detail-modal .wearable-detail-range .ctx-btn-option.active')?.textContent?.trim() === '90d');
+  window.setWearableDetailRange('hrv_rmssd', '6m');
+  await waitFor(() => document.querySelector('#detail-modal .wearable-detail-range .ctx-btn-option.active')?.textContent?.trim() === '6m');
+  assert('Range toggle persists and re-renders active 6m pill',
+    localStorage.getItem('wearable-detail-range') === '6m' &&
+    /of last 6 months/.test(document.getElementById('detail-modal')?.textContent || ''));
   window.closeModal();
   assert('closeModal clears modal chart instance', !window._labState.chartInstances?.modal);
 
@@ -127,12 +140,64 @@ return (async function() {
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
-  // D. Daytime-empty-state HRV modal
+  // D. Partial-day cumulative chart marker
+  // ═══════════════════════════════════════
+  console.log('%c D. Partial-Day Chart Marker ', 'font-weight:bold;color:#f59e0b');
+  localStorage.setItem('wearable-detail-range', '90d');
+  const todayISO = reg.isoDay();
+  const yesterday = new Date(); yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayISO = reg.isoDay(yesterday);
+  window._labState.importedData.wearableSummary = {
+    sources: { oura: { connectedSince: yesterdayISO, lastSyncAt: Date.now(), coverageDays: 2 } },
+    metrics: {
+      steps: {
+        primarySource: 'oura',
+        latest: 9000,
+        latestDate: yesterdayISO,
+        baseline: 9000,
+        baselineP25: 9000,
+        baselineP75: 9000,
+        rolling: { d7: 9000, d30: 9000, d90: 9000 },
+        trend30d: 'flat',
+        weekly: [9000],
+      },
+    },
+  };
+  await store.upsertDailyBatch(TEST_PROFILE, [
+    { source: 'oura', date: yesterdayISO, steps: 9000 },
+    { source: 'oura', date: todayISO, steps: 1200 },
+  ]);
+  await window.openWearableDetail('steps');
+  await waitFor(() => window._labState?.chartInstances?.modal?.data?.labels?.includes(todayISO));
+  const stepsChart = window._labState.chartInstances?.modal;
+  const todayIdx = stepsChart?.data?.labels?.indexOf(todayISO);
+  assert('Cumulative detail chart keeps today in the plotted series',
+    todayIdx >= 0 && stepsChart.data.datasets[0].data[todayIdx] === 1200);
+  assert('Today partial cumulative point renders as visible amber dot',
+    stepsChart?.data?.datasets?.[0]?.pointRadius?.[todayIdx] === 5 &&
+    stepsChart?.data?.datasets?.[0]?.pointBackgroundColor?.[todayIdx] === '#f59e0b');
+  assert('Today partial cumulative point grows on hover',
+    stepsChart?.data?.datasets?.[0]?.pointHoverRadius?.[todayIdx] === 7);
+  const tooltipLabel = stepsChart?.options?.plugins?.tooltip?.callbacks?.label?.({
+    datasetIndex: 0,
+    dataIndex: todayIdx,
+    dataset: { label: 'Steps' },
+    parsed: { y: 1200 },
+  });
+  assert('Today partial tooltip labels the point as in progress',
+    /partial day · in progress/.test(String(tooltipLabel || '')));
+  assert('Detail chart tooltip snaps by x-index, not invisible point intersection',
+    stepsChart?.options?.interaction?.mode === 'index' && stepsChart.options.interaction.intersect === false);
+  window.closeModal();
+  delete window._labState.importedData.wearableSummary;
+
+  // ═══════════════════════════════════════
+  // E. Daytime-empty-state HRV modal
   // ═══════════════════════════════════════
   // Primary is Oura, which has no daytime HRV → the modal's stats grid should
   // surface a "Not from {Source} · why?" empty-state row carrying the long
   // explanation in a title attr.
-  console.log('%c D. Daytime-Empty-State Modal ', 'font-weight:bold;color:#f59e0b');
+  console.log('%c E. Daytime-Empty-State Modal ', 'font-weight:bold;color:#f59e0b');
   const _origImported = window._labState.importedData;
   window._labState.importedData = {
     entries: [],

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -246,6 +246,106 @@ const sameDateRes = summary.shouldWriteL2(sameDate, oldLagging);
 assert('Gate: identical snapshot (same latestDate) does NOT write',
   sameDateRes.write === false, `reason=${sameDateRes.reason}`);
 
+// Cumulative-from-midnight metrics: today's row is incomplete until the local
+// day ends, so L2 summary math should read from finalized days. The raw row
+// remains in L1 for charts; only summary latest/baseline/rolling are filtered.
+{
+  const today = new Date();
+  const yesterday = new Date(today); yesterday.setDate(yesterday.getDate() - 1);
+  const twoDaysAgo = new Date(today); twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+  const todayISO = reg.isoDay(today);
+  const yesterdayISO = reg.isoDay(yesterday);
+  const twoDaysAgoISO = reg.isoDay(twoDaysAgo);
+  const cumulRows = [
+    { source: 'oura', date: twoDaysAgoISO, steps: 9000, stress_high_min: 30, hrv_rmssd: 48, rhr: 60 },
+    { source: 'oura', date: yesterdayISO,  steps: 8500, stress_high_min: 25, hrv_rmssd: 49, rhr: 60 },
+    { source: 'oura', date: todayISO,      steps: 1200, stress_high_min: 4,  hrv_rmssd: 50, rhr: 60 },
+  ];
+  const cumulSum = summary.computeWearableSummary(
+    { oura: cumulRows },
+    { oura: { connectedSince: twoDaysAgoISO, lastSyncAt: Date.now() } }
+  );
+  assert('Cumulative metric (steps): latest skips today',
+    cumulSum.metrics.steps?.latest === 8500 && cumulSum.metrics.steps.latestDate === yesterdayISO,
+    `steps=${JSON.stringify(cumulSum.metrics.steps)}`);
+  assert('Cumulative metric (stress_high_min): latest skips today',
+    cumulSum.metrics.stress_high_min?.latest === 25 && cumulSum.metrics.stress_high_min.latestDate === yesterdayISO,
+    `stress=${JSON.stringify(cumulSum.metrics.stress_high_min)}`);
+  assert('Non-cumulative metric (hrv_rmssd): today remains eligible',
+    cumulSum.metrics.hrv_rmssd?.latest === 50 && cumulSum.metrics.hrv_rmssd.latestDate === todayISO,
+    `hrv=${JSON.stringify(cumulSum.metrics.hrv_rmssd)}`);
+
+  const multiSource = summary.computeWearableSummary(
+    {
+      oura: [{ source: 'oura', date: yesterdayISO, steps: 8500 }],
+      apple_health: [{ source: 'apple_health', date: todayISO, steps: 1200 }],
+    },
+    {
+      oura: { connectedSince: twoDaysAgoISO, lastSyncAt: Date.now() - 86400000 },
+      apple_health: { connectedSince: todayISO, lastSyncAt: Date.now() },
+    }
+  );
+  assert('Cumulative source picker ignores sources with only today partial rows',
+    multiSource.metrics.steps?.primarySource === 'oura' && multiSource.metrics.steps.latest === 8500,
+    `steps=${JSON.stringify(multiSource.metrics.steps)}`);
+
+  const overrideFallback = summary.computeWearableSummary(
+    {
+      oura: [{ source: 'oura', date: yesterdayISO, steps: 8500 }],
+      apple_health: [{ source: 'apple_health', date: todayISO, steps: 1200 }],
+    },
+    {
+      oura: { connectedSince: twoDaysAgoISO, lastSyncAt: Date.now() - 86400000 },
+      apple_health: { connectedSince: todayISO, lastSyncAt: Date.now() },
+    },
+    { steps: 'apple_health' }
+  );
+  assert('Cumulative override falls back when override has no finalized eligible row',
+    overrideFallback.metrics.steps?.primarySource === 'oura',
+    `steps=${JSON.stringify(overrideFallback.metrics.steps)}`);
+}
+
+// Wear-required minimum: low-step days are valid raw rows, but non-wear for
+// summary math. This protects Oura/Apple Health step averages from off-wrist
+// charging days and phone-left-at-home trickles.
+{
+  const wearTestRows = [];
+  for (let i = 0; i < 14; i++) {
+    const d = new Date('2026-04-01'); d.setUTCDate(d.getUTCDate() + i);
+    const steps = i < 4 ? (i % 2 ? 150 : 0) : 8000;
+    wearTestRows.push({
+      source: 'oura',
+      date: d.toISOString().slice(0, 10),
+      steps,
+      hrv_rmssd: 50,
+      rhr: 60,
+      sleep_score: 80,
+      readiness_score: 80,
+    });
+  }
+  const wearSum = summary.computeWearableSummary(
+    { oura: wearTestRows },
+    { oura: { connectedSince: '2026-04-01', lastSyncAt: Date.now() } }
+  );
+  assert('Wear-min (steps): d7 mean excludes 0 and non-zero sub-threshold days',
+    wearSum.metrics.steps?.rolling?.d7 === 8000,
+    `d7=${wearSum.metrics.steps?.rolling?.d7}`);
+  assert('Wear-min (steps): baseline excludes 0 and non-zero sub-threshold days',
+    wearSum.metrics.steps?.baseline === 8000,
+    `baseline=${wearSum.metrics.steps?.baseline}`);
+
+  const thresholdSum = summary.computeWearableSummary(
+    { oura: [
+      { source: 'oura', date: '2026-04-01', steps: 299 },
+      { source: 'oura', date: '2026-04-02', steps: 300 },
+    ] },
+    { oura: { connectedSince: '2026-04-01', lastSyncAt: Date.now() } }
+  );
+  assert('Wear-min (steps): 299 excluded but 300 included',
+    thresholdSum.metrics.steps?.latest === 300 && thresholdSum.metrics.steps.baseline === 300,
+    `steps=${JSON.stringify(thresholdSum.metrics.steps)}`);
+}
+
 // ═══════════════════════════════════════
 // 5. buildWearableContext
 // ═══════════════════════════════════════
@@ -530,6 +630,7 @@ assert('window.handleWearableConnect exists', typeof window.handleWearableConnec
 assert('window.handleWearableDisconnect exists', typeof window.handleWearableDisconnect === 'function');
 assert('window.syncWearableNow exists', typeof window.syncWearableNow === 'function');
 assert('window.openWearableDetail exists', typeof window.openWearableDetail === 'function');
+assert('window.setWearableDetailRange exists', typeof window.setWearableDetailRange === 'function');
 assert('handleWearablePATConnect removed (Ultrahuman moved to OAuth2)',
   typeof window.handleWearablePATConnect === 'undefined');
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.194';
+self.APP_VERSION = '1.8.196';


### PR DESCRIPTION
## Summary

Salvages Savi's wearable follow-up PRs into one corrected branch:

- adds range controls to the wearable detail modal (90d / 6m / 1y / all), year-aware compact dates, and range-aware empty/coverage text from #354
- excludes in-progress cumulative metrics from L2 summary math so steps/stress do not treat today's partial values as finalized, from #364
- filters sub-threshold step days from summary latest/baseline/rolling calculations while keeping raw L1 rows chartable, from #365
- marks today's cumulative detail-chart point as an amber partial-day value with tooltip copy, from #368

I also corrected the risky parts I found while auditing the original implementations: source picking now uses the same eligibility rules as metric derivation, override sources fall back when they only have today's partial cumulative row, the partial-day marker uses the shared cumulative metric registry, and the partial marker grows on hover instead of shrinking.

Co-authored-by: Savi-1 <65488451+Savi-1@users.noreply.github.com>

## Validation

- `git diff --check`
- `node --check js/wearable-adapters.js`
- `node --check js/wearables-summary.js`
- `node --check js/wearables.js`
- `node --check tests/test-wearables.js`
- `node tests/test-wearables.js` (574 passed, 0 failed)
- `./run-tests.sh` (all tests passed, including Wearables DOM 24/0 and Theme Responsive E2E 244/0)