### PR TITLE
[codex] Salvage biological age detail breakdown

### DIFF
--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -19,6 +19,63 @@ export function configureMarkerDetailModal(deps = {}) {
   Object.assign(markerDetailDeps, deps);
 }
 
+// Biological-age component inputs. Keep these in sync with the PhenoAge and
+// Bortz Age calculations in data.js so the detail modal can explain exactly
+// which panel inputs are present or still missing.
+const BIO_AGE_PHENO_INPUTS = [
+  ['proteins', 'albumin', 'Albumin'],
+  ['biochemistry', 'creatinine', 'Creatinine'],
+  ['biochemistry', 'glucose', 'Glucose'],
+  ['proteins', 'hsCRP', 'hs-CRP'],
+  ['differential', 'lymphocytesPct', 'Lymphocytes %'],
+  ['hematology', 'mcv', 'MCV'],
+  ['hematology', 'rdwcv', 'RDW-CV'],
+  ['biochemistry', 'alp', 'ALP'],
+  ['hematology', 'wbc', 'WBC'],
+];
+const BIO_AGE_BORTZ_INPUTS = [
+  ['proteins', 'albumin', 'Albumin'],
+  ['biochemistry', 'alp', 'ALP'],
+  ['biochemistry', 'urea', 'Urea'],
+  ['lipids', 'cholesterol', 'Cholesterol'],
+  ['biochemistry', 'creatinine', 'Creatinine'],
+  ['biochemistry', 'cystatinC', 'Cystatin C'],
+  ['diabetes', 'hba1c', 'HbA1c'],
+  ['proteins', 'hsCRP', 'hs-CRP'],
+  ['biochemistry', 'ggt', 'GGT'],
+  ['hematology', 'rbc', 'RBC'],
+  ['hematology', 'mcv', 'MCV'],
+  ['hematology', 'rdwcv', 'RDW-CV'],
+  ['differential', 'monocytes', 'Monocytes'],
+  ['differential', 'neutrophils', 'Neutrophils'],
+  ['differential', 'lymphocytesPct', 'Lymphocytes %'],
+  ['biochemistry', 'alt', 'ALT'],
+  ['hormones', 'shbg', 'SHBG'],
+  ['vitamins', 'vitaminD', 'Vitamin D'],
+  ['biochemistry', 'glucose', 'Glucose'],
+  ['hematology', 'mch', 'MCH'],
+  ['lipids', 'apoAI', 'ApoA-I'],
+];
+
+function bioAgeReferenceIndex(data, marker, latestPoint) {
+  if (latestPoint && Number.isInteger(latestPoint.i)) return latestPoint.i;
+  const values = marker?.values || [];
+  for (let i = values.length - 1; i >= 0; i--) {
+    if (values[i] != null) return i;
+  }
+  return data.dates?.length ? data.dates.length - 1 : -1;
+}
+
+function bioAgeInputStatusAtIndex(data, idx, inputs, profileRequirement = null) {
+  const status = inputs.map(([cat, key, label]) => ({
+    label,
+    present: idx >= 0 && data.categories?.[cat]?.markers?.[key]?.values?.[idx] != null,
+    kind: 'marker',
+  }));
+  if (profileRequirement) status.unshift(profileRequirement);
+  return status;
+}
+
 function setDetailModalShell(...classes) {
   const modal = document.getElementById('detail-modal');
   if (!modal) return null;
@@ -364,25 +421,8 @@ export function showDetailModal(id, opts = {}) {
   }
   // Calculated marker input diagnostic — show missing inputs
   const calcInputs = {
-    'calculatedRatios_phenoAge': [
-      ['proteins', 'albumin', 'Albumin'], ['biochemistry', 'creatinine', 'Creatinine'],
-      ['biochemistry', 'glucose', 'Glucose'], ['proteins', 'hsCRP', 'CRP'],
-      ['differential', 'lymphocytesPct', 'Lymphocytes %'], ['hematology', 'mcv', 'MCV'],
-      ['hematology', 'rdwcv', 'RDW-CV'], ['biochemistry', 'alp', 'ALP'], ['hematology', 'wbc', 'WBC']
-    ],
-    'calculatedRatios_bortzAge': [
-      ['proteins', 'albumin', 'Albumin'], ['biochemistry', 'alp', 'ALP'],
-      ['biochemistry', 'urea', 'Urea'], ['lipids', 'cholesterol', 'Cholesterol'],
-      ['biochemistry', 'creatinine', 'Creatinine'], ['biochemistry', 'cystatinC', 'Cystatin C'],
-      ['diabetes', 'hba1c', 'HbA1c'], ['proteins', 'hsCRP', 'CRP'],
-      ['biochemistry', 'ggt', 'GGT'], ['hematology', 'rbc', 'RBC'],
-      ['hematology', 'mcv', 'MCV'], ['hematology', 'rdwcv', 'RDW-CV'],
-      ['differential', 'monocytes', 'Monocytes'], ['differential', 'neutrophils', 'Neutrophils'],
-      ['differential', 'lymphocytesPct', 'Lymphocytes %'], ['biochemistry', 'alt', 'ALT'],
-      ['hormones', 'shbg', 'SHBG'], ['vitamins', 'vitaminD', 'Vitamin D'],
-      ['biochemistry', 'glucose', 'Glucose'], ['hematology', 'mch', 'MCH'],
-      ['lipids', 'apoAI', 'ApoA-I']
-    ],
+    'calculatedRatios_phenoAge': BIO_AGE_PHENO_INPUTS,
+    'calculatedRatios_bortzAge': BIO_AGE_BORTZ_INPUTS,
     'calculatedRatios_biologicalAge': [],
     'calculatedRatios_bunCreatRatio': [
       ['biochemistry', 'urea', 'Urea (BUN)'], ['biochemistry', 'creatinine', 'Creatinine']
@@ -472,24 +512,66 @@ export function showDetailModal(id, opts = {}) {
         }
       }
     }
-    // Biological Age: show component status
+    // Biological Age: show component breakdown. The dashboard can show a
+    // value from whichever component is non-null, so the modal should not
+    // describe that as a generic "Not calculated" error.
     if (id === 'calculatedRatios_biologicalAge') {
-      const latestIdx = data.dates.length - 1;
-      const pheno = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[latestIdx];
-      const bortz = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[latestIdx];
-      if (pheno == null && bortz == null) {
-        issues.push('Neither PhenoAge nor Bortz Age could be calculated — check their detail views for missing inputs');
-      } else {
-        const age = state.profileDob ? ((new Date(data.dates[latestIdx] + 'T00:00:00') - new Date(state.profileDob + 'T00:00:00')) / (365.25*24*60*60*1000)) : null;
-        const parts = [];
-        if (pheno != null) parts.push(`PhenoAge: ${pheno}${age ? ' (' + (pheno - age > 0 ? '+' : '') + (pheno - age).toFixed(1) + 'y)' : ''}`);
-        if (bortz != null) parts.push(`Bortz Age: ${bortz}${age ? ' (' + (bortz - age > 0 ? '+' : '') + (bortz - age).toFixed(1) + 'y)' : ''}`);
-        if (pheno == null) parts.push('PhenoAge: not calculated');
-        if (bortz == null) parts.push('Bortz Age: not calculated');
-        issues.push(parts.join(' · '));
-      }
-    }
-    if (issues.length > 0) {
+      const refIdx = bioAgeReferenceIndex(data, marker, latestPoint);
+      const refDate = refIdx >= 0 ? data.dates?.[refIdx] : null;
+      const refDateLabel = refIdx >= 0 ? (data.dateLabels?.[refIdx] || refDate || '') : '';
+      const pheno = refIdx >= 0 ? data.categories.calculatedRatios?.markers?.phenoAge?.values?.[refIdx] : null;
+      const bortz = refIdx >= 0 ? data.categories.calculatedRatios?.markers?.bortzAge?.values?.[refIdx] : null;
+      const age = state.profileDob && refDate
+        ? ((new Date(refDate + 'T00:00:00') - new Date(state.profileDob + 'T00:00:00')) / (365.25*24*60*60*1000))
+        : null;
+      const ageIsUsable = Number.isFinite(age) && age > 0;
+      const profileRequirement = !state.profileDob
+        ? { label: 'Date of birth', present: false, kind: 'profile' }
+        : (refDate && !ageIsUsable)
+          ? { label: 'Valid date of birth', present: false, kind: 'profile' }
+          : null;
+      const profileIssue = state.profileDob && refDate && !ageIsUsable
+        ? 'Date of birth must be before the panel date'
+        : null;
+      const phenoStatus = bioAgeInputStatusAtIndex(data, refIdx, BIO_AGE_PHENO_INPUTS, profileRequirement);
+      const bortzStatus = bioAgeInputStatusAtIndex(data, refIdx, BIO_AGE_BORTZ_INPUTS, profileRequirement);
+      const renderInputGrid = (status) => status.map(s => {
+        const title = s.kind === 'profile'
+          ? (s.present ? 'Set in profile' : 'Required in profile')
+          : (s.present ? 'In this panel' : 'Missing from this panel');
+        return `<span class="bio-age-input ${s.present ? 'is-present' : 'is-missing'}" title="${escapeAttr(title)}">${s.present ? '✓' : '⚠'} ${escapeHTML(s.label)}</span>`;
+      }).join('');
+      const componentRow = (name, value, status) => {
+        const missing = status.filter(s => !s.present);
+        let header;
+        if (value != null) {
+          const delta = ageIsUsable ? ` <span class="bio-age-delta">(${value - age > 0 ? '+' : ''}${(value - age).toFixed(1)}y)</span>` : '';
+          header = `<span class="bio-age-glyph">✓</span> <strong>${escapeHTML(name)}:</strong> ${formatValue(value)}${delta}`;
+        } else {
+          const noun = missing.length === 1 ? 'input' : 'inputs';
+          header = `<span class="bio-age-glyph">⚠</span> <strong>${escapeHTML(name)}:</strong> missing ${missing.length} of ${status.length} ${noun}`;
+        }
+        const klass = value != null ? 'bio-age-component-ok' : 'bio-age-component-missing';
+        return `<div class="bio-age-component ${klass}">
+          <div class="bio-age-component-header">${header}</div>
+          <div class="bio-age-input-grid">${renderInputGrid(status)}</div>
+        </div>`;
+      };
+      const dateNote = refDateLabel
+        ? `<div class="bio-age-breakdown-sub">Based on your panel from ${escapeHTML(refDateLabel)}</div>`
+        : '';
+      const breakdownIssues = profileIssue ? [...issues, profileIssue] : issues;
+      const issueNote = breakdownIssues.length > 0
+        ? `<div class="bio-age-breakdown-warning">${breakdownIssues.map(escapeHTML).join('. ')}</div>`
+        : '';
+      html += `<div class="bio-age-breakdown">
+        <div class="bio-age-breakdown-head">Component breakdown</div>
+        ${dateNote}
+        ${issueNote}
+        ${componentRow('PhenoAge', pheno, phenoStatus)}
+        ${componentRow('Bortz Age', bortz, bortzStatus)}
+      </div>`;
+    } else if (issues.length > 0) {
       html += `<div class="calc-missing-inputs">Not calculated — ${issues.join('. ')}</div>`;
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -3185,7 +3185,8 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .marker-detail-modal .modal-values-grid,
 .marker-detail-modal .modal-ref-info,
 .marker-detail-modal .marker-note-section,
-.marker-detail-modal .calc-missing-inputs {
+.marker-detail-modal .calc-missing-inputs,
+.marker-detail-modal .bio-age-breakdown {
   min-width: 0;
 }
 .marker-detail-modal h3,
@@ -3195,7 +3196,8 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .marker-detail-modal .mv-value,
 .marker-detail-modal .modal-ref-info,
 .marker-detail-modal .marker-note-text,
-.marker-detail-modal .calc-missing-inputs {
+.marker-detail-modal .calc-missing-inputs,
+.marker-detail-modal .bio-age-breakdown {
   overflow-wrap: anywhere;
 }
 .marker-detail-modal .modal-close {
@@ -3303,12 +3305,84 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .marker-detail-modal .marker-history-show-more,
 .marker-detail-modal .modal-ref-info,
 .marker-detail-modal .calc-missing-inputs,
+.marker-detail-modal .bio-age-breakdown,
 .marker-detail-modal .manual-entry-btn,
 .marker-detail-modal .marker-note-section,
 .marker-detail-modal [id^="rec-modal-"],
 .marker-detail-modal .ask-ai-btn {
   margin-left: 28px;
   margin-right: 28px;
+}
+.marker-detail-modal .bio-age-breakdown {
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-card) 74%, transparent);
+}
+.marker-detail-modal .bio-age-breakdown-head {
+  margin-bottom: 4px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.marker-detail-modal .bio-age-breakdown-sub,
+.marker-detail-modal .bio-age-breakdown-warning {
+  margin-bottom: 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.marker-detail-modal .bio-age-breakdown-warning {
+  color: var(--yellow);
+}
+.marker-detail-modal .bio-age-component {
+  padding: 8px 0;
+  font-size: 14px;
+}
+.marker-detail-modal .bio-age-component + .bio-age-component {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+}
+.marker-detail-modal .bio-age-component-header {
+  margin-bottom: 6px;
+}
+.marker-detail-modal .bio-age-glyph {
+  display: inline-block;
+  width: 18px;
+  font-weight: 700;
+}
+.marker-detail-modal .bio-age-component-ok .bio-age-glyph,
+.marker-detail-modal .bio-age-component-ok .bio-age-component-header strong,
+.marker-detail-modal .bio-age-input.is-present {
+  color: var(--green);
+}
+.marker-detail-modal .bio-age-component-missing .bio-age-glyph,
+.marker-detail-modal .bio-age-input.is-missing {
+  color: var(--yellow);
+}
+.marker-detail-modal .bio-age-delta {
+  margin-left: 4px;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+.marker-detail-modal .bio-age-input-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  margin-top: 4px;
+  margin-left: 22px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+.marker-detail-modal .bio-age-input {
+  white-space: nowrap;
+}
+.marker-detail-modal .bio-age-input.is-missing {
+  font-weight: 600;
 }
 .marker-detail-modal .manual-entry-btn,
 .marker-detail-modal .ask-ai-btn {
@@ -3491,6 +3565,7 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
   .marker-detail-modal .marker-history-show-more,
   .marker-detail-modal .modal-ref-info,
   .marker-detail-modal .calc-missing-inputs,
+  .marker-detail-modal .bio-age-breakdown,
   .marker-detail-modal .manual-entry-btn,
   .marker-detail-modal .marker-note-section,
   .marker-detail-modal [id^="rec-modal-"],
@@ -3597,6 +3672,7 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
   .marker-detail-modal .marker-history-show-more,
   .marker-detail-modal .modal-ref-info,
   .marker-detail-modal .calc-missing-inputs,
+  .marker-detail-modal .bio-age-breakdown,
   .marker-detail-modal .manual-entry-btn,
   .marker-detail-modal .marker-note-section,
   .marker-detail-modal [id^="rec-modal-"],

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -507,6 +507,53 @@ return (async function() {
   }
 
   // ═══════════════════════════════════════════════
+  // 7b. BIOLOGICAL AGE DETAIL MODAL — component breakdown
+  // ═══════════════════════════════════════════════
+  console.log('%c 7b. Biological Age detail modal', 'font-weight:bold;color:#6366f1');
+  const originalProfileDob = S.profileDob;
+  try {
+    S.profileDob = originalProfileDob || '1987-11-22';
+    window.invalidateActiveDataCache?.();
+    window.showDetailModal('calculatedRatios_biologicalAge');
+    await waitFor(() => document.querySelector('#detail-modal .bio-age-breakdown'));
+    const bioModal = document.getElementById('detail-modal');
+    let bioText = bioModal?.textContent || '';
+    assert('Biological Age detail renders component breakdown',
+      !!bioModal?.querySelector('.bio-age-breakdown'));
+    assert('Biological Age detail lists both component clocks',
+      bioText.includes('PhenoAge') && bioText.includes('Bortz Age'));
+    assert('Biological Age detail avoids contradictory generic not-calculated prefix',
+      !/Not calculated\s+—\s+.*PhenoAge/.test(bioText));
+
+    S.profileDob = '';
+    window.invalidateActiveDataCache?.();
+    window.showDetailModal('calculatedRatios_biologicalAge');
+    await waitFor(() => /Date of birth/.test(document.getElementById('detail-modal')?.textContent || ''));
+    const missingDobModal = document.getElementById('detail-modal');
+    bioText = missingDobModal?.textContent || '';
+    assert('Biological Age detail surfaces missing DOB as the blocker',
+      /Date of birth not set/.test(bioText) && /Date of birth/.test(bioText));
+    assert('Biological Age detail never says missing 0 inputs when DOB is absent',
+      !/missing 0 of/.test(bioText));
+    assert('Biological Age missing DOB is marked in the input grid',
+      Array.from(missingDobModal?.querySelectorAll('.bio-age-input.is-missing') || [])
+        .some(el => /Date of birth/.test(el.textContent || '')));
+
+    S.profileDob = '2999-01-01';
+    window.invalidateActiveDataCache?.();
+    window.showDetailModal('calculatedRatios_biologicalAge');
+    await waitFor(() => /Valid date of birth/.test(document.getElementById('detail-modal')?.textContent || ''));
+    bioText = document.getElementById('detail-modal')?.textContent || '';
+    assert('Biological Age detail surfaces invalid DOB instead of zero missing inputs',
+      /Valid date of birth/.test(bioText) && !/missing 0 of/.test(bioText));
+  } finally {
+    S.profileDob = originalProfileDob;
+    window.invalidateActiveDataCache?.();
+    window.closeModal();
+    await wait(20);
+  }
+
+  // ═══════════════════════════════════════════════
   // 7. CONTEXT CARDS — open editor, save, verify
   // ═══════════════════════════════════════════════
   console.log('%c 7. Context cards', 'font-weight:bold;color:#6366f1');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.196';
+self.APP_VERSION = '1.8.197';


### PR DESCRIPTION
## Summary

Salvages Savi-1's #366 by adding a dedicated Biological Age component breakdown to the marker detail modal. The modal now shows PhenoAge and Bortz Age side by side with their panel input status instead of folding the combined marker into a contradictory generic "Not calculated" message.

This version also fixes the review issues from Savi's implementation:

- missing DOB remains visible as a required profile input and warning
- invalid/future DOB is reported as an invalid date-of-birth requirement
- chronological-age deltas are only rendered for finite positive ages, so NaN cannot leak into the UI
- PhenoAge/Bortz input lists are shared constants and use the exact hs-CRP label/key expected by the calculation path

Co-authored-by: Savi-1 <65488451+Savi-1@users.noreply.github.com>

## Validation

- `node --check js/marker-detail-modal.js`
- `git diff --check`
- `node tests/test-calculated-markers.js`
- `node tests/test-audit.js`
- focused browser UI-flow run for the Biological Age modal
- desktop/mobile modal geometry smoke check
- `./run-tests.sh` (all tests passed; UI Flows 153 passed, 0 failed; Theme Responsive E2E 244 passed, 0 failed)

Salvages #366.