### PR TITLE
[codex] Fix older manual wearable entries

### DIFF
--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -1347,7 +1347,7 @@ Each connected source ships as a pair: `wearables-<vendor>.js` (read API) + `wea
 
 **No OAuth:** `wearables-apple-health.js` (file-import — `parseAppleHealthXml` reads the `export.xml` from a Health zip), `wearables-manual.js` (`logManualMetric` / `logManualBP` + `MANUAL_TAGS` whitelist for what users can log by hand).
 
-**L1 storage + summary derivation:** `wearables-store.js` (per-profile IndexedDB at `labcharts-wearables-{profileId}`; two-phase upsertDailyBatch), `wearables-summary.js` (L2 derivation, write gate — 5% d7 shift / trend flip / 14d force-refresh / source flip / metric removal triggers).
+**L1 storage + summary derivation:** `wearables-store.js` (per-profile IndexedDB at `labcharts-wearables-{profileId}`; two-phase upsertDailyBatch), `wearables-summary.js` (L2 derivation; vendor sources read a 90-day window, while sparse manual rows read all history so older hand-entered BP/pulse/weight entries stay visible; write gate — 5% d7 shift / trend flip / 14d force-refresh / source flip / metric removal triggers).
 
 **UI surface:** `wearables.js` (dashboard strip + detail modal + reorder mode + Settings → Wearables list + manual-log forms), `brand-assets.js` (per-vendor logo registry — `iconLight/Dark` for in-app rows, `signInLight/Dark` for landing-site Connect buttons, `mono` SVG fallback while a vendor logo is gated).
 

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -26,6 +26,8 @@ const GATE_WEEKLY_DELTA_PCT = 5;       // any weekly-series metric delta ≥ 5% 
 const MIN_L2_REFRESH_MS     = 14 * 24 * 60 * 60 * 1000; // force-write after 14d silence
 const ANOMALY_STREAK_DAYS   = 3;       // sustained breach length to fire an anomaly event
 const CHANGE_HISTORY_CAP    = 200;     // existing global cap; honour it when appending
+const SUMMARY_WINDOW_DAYS   = 90;
+const MANUAL_SUMMARY_START_DATE = '1970-01-01';
 
 const METRICS_FOR_SUMMARY = DEFAULT_METRIC_ORDER;
 
@@ -376,16 +378,17 @@ export async function syncWearableSummary(profileId, connectedSources, { force =
   const sourceIds = Object.keys(connectedSources);
   if (sourceIds.length === 0) return { wrote: false, reason: 'no-sources' };
 
-  // Pull last 90 days of rows for every connected source. Local-tz dates
-  // so the window aligns with vendor `day`/date fields (Oura, Withings,
-  // etc. use the user's local day boundary, not UTC).
+  // Pull last 90 days for vendor sources. Manual entries are sparse, user-
+  // authored rows, so read all history; otherwise a single older pulse/BP
+  // reading saves successfully but never creates a visible summary card.
   const endDate = isoDay();
-  const start = new Date(); start.setDate(start.getDate() - 90);
+  const start = new Date(); start.setDate(start.getDate() - SUMMARY_WINDOW_DAYS);
   const startDate = isoDay(start);
 
   const rowsBySource = {};
   for (const sid of sourceIds) {
-    try { rowsBySource[sid] = await getDailyRange(profileId, sid, startDate, endDate); }
+    const readStartDate = sid === 'manual' ? MANUAL_SUMMARY_START_DATE : startDate;
+    try { rowsBySource[sid] = await getDailyRange(profileId, sid, readStartDate, endDate); }
     catch (e) { if (isDebugMode?.()) console.warn(`[wearable-summary] L1 read failed for ${sid}:`, e.message); rowsBySource[sid] = []; }
   }
 

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -682,6 +682,7 @@ const WEARABLE_DETAIL_RANGES = [
   { key: '1y', days: 365, label: '1y', coverageSuffix: 'of last 12 months', emptyWindow: 'the last 12 months' },
   { key: 'all', days: null, label: 'All', coverageSuffix: 'all-time', emptyWindow: 'all recorded data' },
 ];
+const WEARABLE_ALL_HISTORY_START_DATE = '1970-01-01';
 const WEARABLE_DETAIL_RANGE_KEY = 'wearable-detail-range';
 function getWearableDetailRange() {
   const stored = localStorage.getItem(WEARABLE_DETAIL_RANGE_KEY);
@@ -746,15 +747,12 @@ async function openWearableDetail(metricId, opts = {}) {
     && series.length > 0
     && series.every(p => p.v === 0);
 
-  // Separately pull ALL manual rows (not just primary-source rows) so the
-  // detail modal's "Manual entries" list shows manual readings even when
-  // another source is currently primary for this metric. A user with both
-  // Withings and manual weight entries wants to see + delete both.
+  // Separately pull ALL manual rows (not just primary-source rows, and not
+  // just the selected chart range) so the detail modal's "Manual entries"
+  // list shows old hand-entered readings even when the 90d chart is empty.
   let manualRows = [];
-  if (m.primarySource === 'manual') {
-    manualRows = rows;
-  } else {
-    try { manualRows = await getDailyRange(profileId, 'manual', startDate, endDate); }
+  if (MANUAL_METRICS.includes(metricId)) {
+    try { manualRows = await getDailyRange(profileId, 'manual', WEARABLE_ALL_HISTORY_START_DATE, endDate); }
     catch { /* no manual data yet — empty list, that's fine */ }
     if (op !== _detailOp) return;
   }
@@ -762,6 +760,11 @@ async function openWearableDetail(metricId, opts = {}) {
     .map(r => ({ date: r.date, v: r[metricId], tags: r.tags, note: r.note }))
     .filter(p => isMetricValueMeaningful(metricId, p.v))
     .sort((a, b) => b.date.localeCompare(a.date)); // reverse-chron for display
+  const manualChartEntries = m.primarySource === 'manual'
+    ? []
+    : manualEntries
+        .filter(p => rangeDef.days == null || p.date >= startDate)
+        .sort((a, b) => a.date.localeCompare(b.date));
 
   const modal = document.getElementById('detail-modal');
   const overlay = document.getElementById('modal-overlay');
@@ -787,8 +790,8 @@ async function openWearableDetail(metricId, opts = {}) {
   _installWearableModalFocusTrap(modal);
 
   const canvas = document.getElementById('chart-modal');
-  if (canvas && series.length > 0) {
-    renderWearableChart(canvas, canon, m, series);
+  if (canvas && (series.length > 0 || manualChartEntries.length > 0)) {
+    renderWearableChart(canvas, canon, m, series, manualChartEntries);
   }
 }
 
@@ -1008,7 +1011,9 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
   const emptyHint = opts.allZeroActivity
     ? `<div class="wearable-detail-empty">Every day shows 0 — Oura suppresses the Activity composite score while Rest Mode is on. Check the <b>Steps</b> card for raw movement data, or disable Rest Mode in the Oura app.</div>`
     : series.length === 0
-      ? `<div class="wearable-detail-empty">No daily samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`
+      ? manualEntries.length > 0
+        ? `<div class="wearable-detail-empty">No chart samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Manual readings are listed below${m.primarySource === 'manual' && rangeDef.days != null ? '; switch to All to chart older manual readings' : ''}.</div>`
+        : `<div class="wearable-detail-empty">No daily samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`
       : '';
 
   // Show the source-swap button whenever ≥2 wearables are connected — the
@@ -1071,65 +1076,92 @@ function _buildEMFSleepHint(metricId, m) {
   return `<div class="wearable-detail-emf-hint"><span aria-hidden="true">💡</span> Sleep regressing? Sometimes it's the room. <a href="#" onclick="${openHandler}" data-umami-event="emf-nudge-wearable-sleep">Check your EMF environment →</a></div>`;
 }
 
-function renderWearableChart(canvas, canon, m, series) {
+function renderWearableChart(canvas, canon, m, series, manualSeries = []) {
   if (!window.Chart || !isChartDateAdapterReady()) {
     ensureChartJs().then(() => {
       const currentCanvas = document.getElementById(canvas.id);
-      if (currentCanvas) renderWearableChart(currentCanvas, canon, m, series);
+      if (currentCanvas) renderWearableChart(currentCanvas, canon, m, series, manualSeries);
     }).catch(() => {});
     return;
   }
   const tc = getChartColors();
-  const labels = series.map(p => p.date);
-  const values = series.map(p => p.v);
-  const baselineValues = values.map(() => m.baseline);
+  const primaryData = series.map(p => ({ x: p.date, y: p.v }));
+  const manualData = manualSeries.map(p => ({ x: p.date, y: p.v }));
+  const xDates = [...series.map(p => p.date), ...manualSeries.map(p => p.date)].sort();
+  const values = [...series.map(p => p.v), ...manualSeries.map(p => p.v)];
+  if (values.length === 0) return;
+  const baselineIsFinite = typeof m.baseline === 'number' && isFinite(m.baseline);
+  const baselineValues = baselineIsFinite && xDates.length
+    ? [{ x: xDates[0], y: m.baseline }, { x: xDates[xDates.length - 1], y: m.baseline }]
+    : [];
   const isCumulative = CUMULATIVE_METRICS.has(canon.id);
   const todayISO = isoDay();
   const isPartialIdx = (idx) => isCumulative && series[idx]?.date === todayISO;
   const partialColor = '#f59e0b';
+  const primaryAdapter = adapterById(m.primarySource);
+  const primaryLabel = primaryAdapter?.displayName || canon.label;
 
   // Y-axis padding so baseline line and sparkline aren't clipped to the edge.
-  const ymin = Math.min(...values, m.baseline);
-  const ymax = Math.max(...values, m.baseline);
+  const yValues = baselineIsFinite ? [...values, m.baseline] : values;
+  const ymin = Math.min(...yValues);
+  const ymax = Math.max(...yValues);
   const pad = Math.max((ymax - ymin) * 0.08, 0.5);
 
   const unit = canon.unit || '';
   const formatV = v => formatValue(v, unit);
+  const datasets = [];
+  if (primaryData.length > 0) {
+    datasets.push({
+      label: primaryLabel,
+      data: primaryData,
+      _kind: 'primary',
+      borderColor: tc.lineColor || '#60a5fa',
+      backgroundColor: 'transparent',
+      borderWidth: 2,
+      pointRadius: primaryData.map((_, i) => isPartialIdx(i) ? 5 : 0),
+      pointBackgroundColor: primaryData.map((_, i) => isPartialIdx(i) ? partialColor : 'transparent'),
+      pointBorderColor: primaryData.map((_, i) => isPartialIdx(i) ? partialColor : 'transparent'),
+      pointHoverRadius: primaryData.map((_, i) => isPartialIdx(i) ? 7 : 4),
+      tension: 0.3,
+      spanGaps: true,
+      segment: {
+        borderDash: (ctx) => isPartialIdx(ctx.p1DataIndex) ? [5, 4] : undefined,
+        borderColor: (ctx) => isPartialIdx(ctx.p1DataIndex) ? partialColor : undefined,
+      },
+    });
+  }
+  if (baselineValues.length > 0) {
+    datasets.push({
+      label: 'Baseline',
+      data: baselineValues,
+      _kind: 'baseline',
+      borderColor: tc.gridColor || '#9ca3af',
+      backgroundColor: 'transparent',
+      borderWidth: 1,
+      borderDash: [4, 4],
+      pointRadius: 0,
+      pointHoverRadius: 0,
+      tension: 0,
+    });
+  }
+  if (manualData.length > 0) {
+    datasets.push({
+      type: 'scatter',
+      label: 'Manual',
+      data: manualData,
+      _kind: 'manual',
+      borderColor: partialColor,
+      backgroundColor: partialColor,
+      pointRadius: 5,
+      pointHoverRadius: 7,
+      showLine: false,
+    });
+  }
 
   state.chartInstances['modal'] = new window.Chart(canvas, {
     type: 'line',
     data: {
-      labels,
-      datasets: [
-        {
-          label: canon.label,
-          data: values,
-          borderColor: tc.lineColor || '#60a5fa',
-          backgroundColor: 'transparent',
-          borderWidth: 2,
-          pointRadius: values.map((_, i) => isPartialIdx(i) ? 5 : 0),
-          pointBackgroundColor: values.map((_, i) => isPartialIdx(i) ? partialColor : 'transparent'),
-          pointBorderColor: values.map((_, i) => isPartialIdx(i) ? partialColor : 'transparent'),
-          pointHoverRadius: values.map((_, i) => isPartialIdx(i) ? 7 : 4),
-          tension: 0.3,
-          spanGaps: true,
-          segment: {
-            borderDash: (ctx) => isPartialIdx(ctx.p1DataIndex) ? [5, 4] : undefined,
-            borderColor: (ctx) => isPartialIdx(ctx.p1DataIndex) ? partialColor : undefined,
-          },
-        },
-        {
-          label: 'Baseline',
-          data: baselineValues,
-          borderColor: tc.gridColor || '#9ca3af',
-          backgroundColor: 'transparent',
-          borderWidth: 1,
-          borderDash: [4, 4],
-          pointRadius: 0,
-          pointHoverRadius: 0,
-          tension: 0,
-        },
-      ],
+      datasets,
     },
     options: {
       responsive: true,
@@ -1143,7 +1175,8 @@ function renderWearableChart(canvas, canon, m, series) {
           callbacks: {
             label: (c) => {
               const base = `${c.dataset.label}: ${formatV(c.parsed.y)}${unit ? ' ' + unit : ''}`;
-              return (c.datasetIndex === 0 && isPartialIdx(c.dataIndex))
+              if (c.dataset._kind === 'manual') return `${base}  (manual entry)`;
+              return (c.dataset._kind === 'primary' && isPartialIdx(c.dataIndex))
                 ? `${base}  (partial day · in progress)`
                 : base;
             },

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -71,7 +71,8 @@ return (async function() {
   assert('Chart instance stored under state.chartInstances.modal', !!window._labState.chartInstances?.modal);
   const modalChart = window._labState.chartInstances?.modal;
   assert('Chart has 3 data points matching L1 row count', modalChart?.data?.datasets?.[0]?.data?.length === 3);
-  assert('Chart labels array has 3 entries', modalChart?.data?.labels?.length === 3);
+  assert('Chart primary dataset carries 3 dated points',
+    modalChart?.data?.datasets?.[0]?.data?.filter(p => p?.x && typeof p?.y === 'number')?.length === 3);
   assert('Chart x-axis is time type', modalChart?.options?.scales?.x?.type === 'time');
   const rangeButtons = Array.from(document.querySelectorAll('#detail-modal .wearable-detail-range .ctx-btn-option'));
   assert('Detail modal renders 90d / 6m / 1y / All range buttons',
@@ -168,11 +169,11 @@ return (async function() {
     { source: 'oura', date: todayISO, steps: 1200 },
   ]);
   await window.openWearableDetail('steps');
-  await waitFor(() => window._labState?.chartInstances?.modal?.data?.labels?.includes(todayISO));
+  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.[0]?.data?.some(p => p?.x === todayISO));
   const stepsChart = window._labState.chartInstances?.modal;
-  const todayIdx = stepsChart?.data?.labels?.indexOf(todayISO);
+  const todayIdx = stepsChart?.data?.datasets?.[0]?.data?.findIndex(p => p?.x === todayISO);
   assert('Cumulative detail chart keeps today in the plotted series',
-    todayIdx >= 0 && stepsChart.data.datasets[0].data[todayIdx] === 1200);
+    todayIdx >= 0 && stepsChart.data.datasets[0].data[todayIdx]?.y === 1200);
   assert('Today partial cumulative point renders as visible amber dot',
     stepsChart?.data?.datasets?.[0]?.pointRadius?.[todayIdx] === 5 &&
     stepsChart?.data?.datasets?.[0]?.pointBackgroundColor?.[todayIdx] === '#f59e0b');
@@ -181,7 +182,7 @@ return (async function() {
   const tooltipLabel = stepsChart?.options?.plugins?.tooltip?.callbacks?.label?.({
     datasetIndex: 0,
     dataIndex: todayIdx,
-    dataset: { label: 'Steps' },
+    dataset: stepsChart.data.datasets[0],
     parsed: { y: 1200 },
   });
   assert('Today partial tooltip labels the point as in progress',

--- a/tests/test-wearables-sync-flow.js
+++ b/tests/test-wearables-sync-flow.js
@@ -45,6 +45,7 @@ await import('../js/state.js');
 const connect = await import('../js/wearables-connect.js');
 const store = await import('../js/wearables-store.js');
 const summary = await import('../js/wearables-summary.js');
+const manual = await import('../js/wearables-manual.js');
 await import('../js/sync.js'); // registers window.pushContextToGateway
 
 // ─────────────────────────────────────────────────────────
@@ -102,10 +103,34 @@ function fakeConnect(adapterId) {
 }
 
 async function wipeWearableIDB() {
+  try { await store.clearSource(TEST_PROFILE_ID, 'manual'); } catch {}
   try { await store.clearSource(TEST_PROFILE_ID, 'oura'); } catch {}
   try { await store.clearSource(TEST_PROFILE_ID, 'fitbit'); } catch {}
 }
 await wipeWearableIDB();
+
+// ═══════════════════════════════════════
+// 0. Manual entries outside vendor window
+// ═══════════════════════════════════════
+console.log('0. Manual All-History Summary');
+const oldManualDate = '2025-05-01';
+await manual.logManualMetric(TEST_PROFILE_ID, 'rhr', { date: oldManualDate, value: 57 });
+const oldManualRows = await store.getDailyRange(TEST_PROFILE_ID, 'manual', '2025-01-01', '2025-12-31');
+assert('Older manual RHR row is persisted in L1',
+  oldManualRows.some(r => r.date === oldManualDate && r.rhr === 57));
+const oldManualSync = await summary.syncWearableSummary(TEST_PROFILE_ID, connect.listConnectedSources());
+const oldManualSummary = window._labState.importedData?.wearableSummary;
+assert('Older manual RHR writes an L2 summary metric outside the 90d vendor window',
+  oldManualSync.wrote === true &&
+  oldManualSummary?.metrics?.rhr?.latest === 57 &&
+  oldManualSummary.metrics.rhr.latestDate === oldManualDate,
+  JSON.stringify(oldManualSummary?.metrics?.rhr));
+assert('Manual source coverage counts the old row',
+  oldManualSummary?.sources?.manual?.coverageDays === 1,
+  JSON.stringify(oldManualSummary?.sources?.manual));
+await store.clearSource(TEST_PROFILE_ID, 'manual');
+delete window._labState.importedData.wearableConnections.manual;
+window._labState.importedData.wearableSummary = null;
 
 // ═══════════════════════════════════════
 // 1. backfillWearable — full pull populates IDB + meta

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -25,6 +25,7 @@ return (async function() {
   const BIOMETRIC_SELECTION_KEY = `labcharts-${TEST_PROFILE_ID}-dashboardBiometricMetricsV1`;
   const DASHBOARD_WIDGET_PREFS_KEY = `labcharts-${TEST_PROFILE_ID}-dashboardWidgetsV9`;
   const origActive = localStorage.getItem('labcharts-active-profile');
+  const origWearableDetailRange = localStorage.getItem('wearable-detail-range');
   // CRITICAL: saveImportedData() keys off state.currentProfile, NOT the
   // localStorage active-profile entry. Swap both — otherwise any save
   // inside the test writes the fake state to the USER'S real profile.
@@ -121,18 +122,53 @@ return (async function() {
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
-  // 4. Source-swap button on detail modal opens picker
+  // 4. Old manual readings stay manageable
   // ═══════════════════════════════════════
-  console.log('%c 4. Source Picker ', 'font-weight:bold;color:#f59e0b');
-  // Add a second source so the swap button renders (gated on ≥2 connected)
+  console.log('%c 4. Old Manual Reading ', 'font-weight:bold;color:#f59e0b');
+  const oldManualDate = '2025-05-01';
+  await manual.logManualMetric(TEST_PROFILE_ID, 'rhr', { date: oldManualDate, value: 57, tags: ['resting'] });
   window._labState.importedData.wearableConnections.oura = {
     source: 'oura', connectedAt: new Date().toISOString(),
-    lastSyncAt: Date.now(), coverageDays: 0,
+    lastSyncAt: Date.now(), coverageDays: 1,
     accessToken: 'fake-oura', refreshToken: 'fake-rfr',
     expiresAt: Date.now() + 86400000,
   };
-  // Stub the summary with BOTH sources directly — a real syncWearableSummary
-  // would also work but skips since oura has zero IDB rows in this test.
+  await store.upsertDaily(TEST_PROFILE_ID, {
+    source: 'oura',
+    date: '2026-05-20',
+    rhr: 61,
+  });
+  await manual.refreshManualSummary(TEST_PROFILE_ID);
+  const oldRhrSummary = window._labState.importedData?.wearableSummary?.metrics?.rhr;
+  assert('Newer Oura RHR can remain primary while old manual RHR is stored',
+    oldRhrSummary?.primarySource === 'oura' && oldRhrSummary?.latest === 61,
+    JSON.stringify(oldRhrSummary));
+  localStorage.setItem('wearable-detail-range', '90d');
+  await window.openWearableDetail('rhr');
+  await new Promise(r => setTimeout(r, 300));
+  assert('Older manual RHR appears in the default detail manual-entry list',
+    !!document.querySelector(`#detail-modal .wearable-manual-entry[data-entry-date="${oldManualDate}"]`));
+  localStorage.setItem('wearable-detail-range', 'all');
+  await window.openWearableDetail('rhr');
+  await new Promise(r => setTimeout(r, 500));
+  const chartDatasets = window._labState.chartInstances?.modal?.data?.datasets || [];
+  const manualOverlay = chartDatasets.find(ds => ds.label === 'Manual');
+  const ouraLine = chartDatasets.find(ds => ds.label === 'Oura');
+  assert('All-range chart keeps the Oura line and overlays old manual RHR readings',
+    !!ouraLine?.data?.some(p => p.x === '2026-05-20' && p.y === 61) &&
+    !!manualOverlay?.data?.some(p => p.x === oldManualDate && p.y === 57),
+    JSON.stringify(window._labState.chartInstances?.modal?.data?.datasets?.map(ds => ({ label: ds.label, n: ds.data?.length }))));
+  if (window.closeModal) window.closeModal();
+  await new Promise(r => setTimeout(r, 200));
+
+  // ═══════════════════════════════════════
+  // 5. Source-swap button on detail modal opens picker
+  // ═══════════════════════════════════════
+  console.log('%c 5. Source Picker ', 'font-weight:bold;color:#f59e0b');
+  // Add a second source so the swap button renders (gated on ≥2 connected)
+  window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now();
+  // Stub the summary with BOTH sources directly so this section only tests
+  // the source-picker UI, not the summary auto-picker.
   window._labState.importedData.wearableSummary = {
     summaryUpdatedAt: new Date().toISOString(),
     sources: {
@@ -169,9 +205,9 @@ return (async function() {
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
-  // 5. Biometrics Overview tile click opens detail modal
+  // 6. Biometrics Overview tile click opens detail modal
   // ═══════════════════════════════════════
-  console.log('%c 5. Overview Tile → Modal ', 'font-weight:bold;color:#f59e0b');
+  console.log('%c 6. Overview Tile → Modal ', 'font-weight:bold;color:#f59e0b');
   if (window.navigate) window.navigate('dashboard');
   await new Promise(r => setTimeout(r, 200));
   const overview = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
@@ -192,9 +228,9 @@ return (async function() {
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
-  // 6. Modular metric selection — add/remove inside the overview
+  // 7. Modular metric selection — add/remove inside the overview
   // ═══════════════════════════════════════
-  console.log('%c 6. Modular Metric Selection ', 'font-weight:bold;color:#f59e0b');
+  console.log('%c 7. Modular Metric Selection ', 'font-weight:bold;color:#f59e0b');
   await window.addDashboardBiometricMetric?.('weight');
   await new Promise(r => setTimeout(r, 300));
   const overviewAfterAdd = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
@@ -218,9 +254,9 @@ return (async function() {
   }
 
   // ═══════════════════════════════════════
-  // 7. Picker + stale sync state
+  // 8. Picker + stale sync state
   // ═══════════════════════════════════════
-  console.log('%c 7. Picker + Stale Sync ', 'font-weight:bold;color:#f59e0b');
+  console.log('%c 8. Picker + Stale Sync ', 'font-weight:bold;color:#f59e0b');
   localStorage.setItem(BIOMETRIC_SELECTION_KEY, JSON.stringify(['rhr']));
   if (window._labState.importedData.wearableSummary?.sources?.oura) {
     window._labState.importedData.wearableSummary.sources.oura.coverageDays = 1;
@@ -285,6 +321,8 @@ return (async function() {
   localStorage.removeItem(`labcharts-${TEST_PROFILE_ID}-imported`);
   localStorage.removeItem(BIOMETRIC_SELECTION_KEY);
   localStorage.removeItem(DASHBOARD_WIDGET_PREFS_KEY);
+  if (origWearableDetailRange) localStorage.setItem('wearable-detail-range', origWearableDetailRange);
+  else localStorage.removeItem('wearable-detail-range');
   if (origActive) localStorage.setItem('labcharts-active-profile', origActive);
   else localStorage.removeItem('labcharts-active-profile');
   window._labState.currentProfile = origCurrentProfile;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.197';
+self.APP_VERSION = '1.8.198';


### PR DESCRIPTION
## Summary

Fixes #240.

Manual wearable rows are sparse user-authored data, unlike vendor wearable rows. A single older manual resting-heart-rate entry was saved to IndexedDB, but the L2 summary only read the last 90 days, so no dashboard card/detail path was created and the entry looked lost after the success toast.

This changes the manual source to read all history during summary derivation while keeping vendor sources on the existing 90-day window. The detail modal also reads all manual rows for the Manual entries list, independent of the selected chart range, so older hand-entered BP/pulse/weight readings stay visible and deletable even when the 90d chart is empty.

When a wearable such as Oura remains the primary source for a metric, manual readings now overlay on the detail chart as separate `Manual` scatter points for the selected range. That keeps the Oura line intact while still making same-range manual entries visible on the chart; older entries appear when switching the detail range to `All`.

## Validation

- `node --check js/wearables-summary.js`
- `node --check js/wearables.js`
- `node tests/test-wearables-sync-flow.js` (40 passed, 0 failed)
- `node tests/test-wearables.js` (574 passed, 0 failed)
- targeted browser run of `tests/test-wearables-ui-flows.js` (30 passed, 0 failed)
- `git diff --check`
- `./run-tests.sh` (all tests passed; `test-wearables-dom` 24 passed, 0 failed; `test-wearables-ui-flows` 30 passed, 0 failed; Theme Responsive E2E 244 passed, 0 failed)