### PR TITLE
[codex] Extract settings CSS bundle

### DIFF
--- a/css/marker-detail-modal.css
+++ b/css/marker-detail-modal.css
@@ -351,8 +351,8 @@
 }
 @media (max-width: 640px) {
   .marker-detail-modal {
-    width: calc(100vw - 16px);
-    max-width: calc(100vw - 16px);
+    width: calc(100vw - 32px);
+    max-width: calc(100vw - 32px);
     max-height: calc(100vh - 16px);
     max-height: calc(100svh - 16px);
     border-radius: var(--radius-sm);

--- a/css/mobile-dashboard.css
+++ b/css/mobile-dashboard.css
@@ -10,7 +10,6 @@
   html.mobile-dashboard-active body,
   html.mobile-tabs-active body {
     max-width: 100%;
-    overflow-x: hidden;
   }
   body.mobile-dashboard-active .header { display: flex; }
   body.mobile-tabs-active .layout,
@@ -51,8 +50,6 @@
   body.mobile-tabs-active,
   body.mobile-dashboard-active {
     max-width: 100%;
-    overflow-x: hidden;
-    overflow-x: clip;
     overscroll-behavior-x: none;
   }
   body.mobile-dashboard-active .app-footer { display: none; }

--- a/css/mobile-dashboard.css
+++ b/css/mobile-dashboard.css
@@ -1,6 +1,9 @@
 /* Mobile dashboard app shell */
 .m-shell { display: none; }
 @media (max-width: 799px) {
+  :root {
+    --mobile-tabbar-gutter: clamp(16px, 5vw, 22px);
+  }
   html.mobile-dashboard-active,
   html.mobile-tabs-active {
     max-width: 100%;
@@ -508,8 +511,8 @@
     right: auto;
     bottom: calc(10px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
     z-index: 210;
-    width: min(520px, calc(100vw - 20px));
-    max-width: calc(100vw - 20px);
+    width: min(520px, calc(100vw - (var(--mobile-tabbar-gutter) * 2)));
+    max-width: calc(100vw - (var(--mobile-tabbar-gutter) * 2));
     margin: 0 auto;
     box-sizing: border-box;
     transform: translateX(-50%);

--- a/css/mobile-dashboard.css
+++ b/css/mobile-dashboard.css
@@ -1,11 +1,24 @@
 /* Mobile dashboard app shell */
 .m-shell { display: none; }
 @media (max-width: 799px) {
+  html.mobile-dashboard-active,
+  html.mobile-tabs-active {
+    max-width: 100%;
+    overflow-x: hidden;
+    overscroll-behavior-x: none;
+  }
+  html.mobile-dashboard-active body,
+  html.mobile-tabs-active body {
+    max-width: 100%;
+    overflow-x: hidden;
+  }
   body.mobile-dashboard-active .header { display: flex; }
+  body.mobile-tabs-active .layout,
   body.mobile-dashboard-active .layout {
     display: block;
     min-height: calc(100svh - 58px);
     max-width: 100%;
+    overflow-x: hidden;
     overflow-x: clip;
   }
   body.mobile-dashboard-active .sidebar {
@@ -19,16 +32,21 @@
   body.mobile-dashboard-active .sidebar.mobile-open {
     transform: translateX(0);
   }
+  body.mobile-tabs-active .main,
   body.mobile-dashboard-active .main {
     padding: 0;
     padding-bottom: 0;
     margin-left: 0;
     max-width: none;
+    overflow-x: hidden;
     overflow-x: clip;
   }
+  body.mobile-tabs-active,
   body.mobile-dashboard-active {
     max-width: 100%;
+    overflow-x: hidden;
     overflow-x: clip;
+    overscroll-behavior-x: none;
   }
   body.mobile-dashboard-active .app-footer { display: none; }
   body.mobile-dashboard-active #chat-fab { display: none; }
@@ -469,7 +487,7 @@
   .m-chat-fab {
     position: fixed;
     right: 16px;
-    bottom: calc(154px + env(safe-area-inset-bottom));
+    bottom: calc(154px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
     z-index: 220;
     width: 52px;
     height: 52px;
@@ -486,13 +504,15 @@
   }
   .m-tabbar {
     position: fixed;
-    left: 10px;
-    right: 10px;
-    bottom: calc(10px + env(safe-area-inset-bottom));
+    left: 50%;
+    right: auto;
+    bottom: calc(10px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
     z-index: 210;
-    width: min(520px, calc(100% - 20px));
+    width: min(520px, calc(100vw - 20px));
+    max-width: calc(100vw - 20px);
     margin: 0 auto;
     box-sizing: border-box;
+    transform: translateX(-50%);
     display: grid;
     grid-template-columns: repeat(5, 1fr);
     gap: 4px;
@@ -557,10 +577,10 @@
     color: var(--accent);
   }
   body.mobile-tabs-active #chat-fab {
-    bottom: calc(92px + env(safe-area-inset-bottom));
+    bottom: calc(92px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
   }
   body.mobile-tabs-active #import-status-fab {
-    bottom: calc(148px + env(safe-area-inset-bottom));
+    bottom: calc(148px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
   }
   [data-theme="cyberterm"] .dashboard-greeting h1::before,
   [data-theme="cyberterm"] .m-greeting h1::before {

--- a/css/mobile-dashboard.css
+++ b/css/mobile-dashboard.css
@@ -1,9 +1,6 @@
 /* Mobile dashboard app shell */
 .m-shell { display: none; }
 @media (max-width: 799px) {
-  :root {
-    --mobile-tabbar-gutter: clamp(16px, 5vw, 22px);
-  }
   html.mobile-dashboard-active,
   html.mobile-tabs-active {
     max-width: 100%;
@@ -35,12 +32,19 @@
   body.mobile-dashboard-active .sidebar.mobile-open {
     transform: translateX(0);
   }
-  body.mobile-tabs-active .main,
   body.mobile-dashboard-active .main {
     padding: 0;
     padding-bottom: 0;
     margin-left: 0;
     max-width: none;
+    overflow-x: hidden;
+    overflow-x: clip;
+  }
+  body.mobile-tabs-active .main {
+    margin-left: 0;
+    max-width: 100%;
+    padding-left: clamp(14px, 4vw, 20px);
+    padding-right: clamp(14px, 4vw, 20px);
     overflow-x: hidden;
     overflow-x: clip;
   }
@@ -511,8 +515,8 @@
     right: auto;
     bottom: calc(10px + env(safe-area-inset-bottom) + var(--mobile-visual-bottom-offset, 0px));
     z-index: 210;
-    width: min(520px, calc(100vw - (var(--mobile-tabbar-gutter) * 2)));
-    max-width: calc(100vw - (var(--mobile-tabbar-gutter) * 2));
+    width: min(520px, calc(100vw - 20px));
+    max-width: calc(100vw - 20px);
     margin: 0 auto;
     box-sizing: border-box;
     transform: translateX(-50%);

--- a/css/mobile-dashboard.css
+++ b/css/mobile-dashboard.css
@@ -5,6 +5,8 @@
   body.mobile-dashboard-active .layout {
     display: block;
     min-height: calc(100svh - 58px);
+    max-width: 100%;
+    overflow-x: clip;
   }
   body.mobile-dashboard-active .sidebar {
     position: fixed;
@@ -22,7 +24,11 @@
     padding-bottom: 0;
     margin-left: 0;
     max-width: none;
-    overflow-x: hidden;
+    overflow-x: clip;
+  }
+  body.mobile-dashboard-active {
+    max-width: 100%;
+    overflow-x: clip;
   }
   body.mobile-dashboard-active .app-footer { display: none; }
   body.mobile-dashboard-active #chat-fab { display: none; }
@@ -30,6 +36,8 @@
     position: relative;
     display: block;
     min-height: 100svh;
+    width: 100%;
+    max-width: 100%;
     overflow: hidden;
     isolation: isolate;
     background: var(--bg-primary);
@@ -45,8 +53,10 @@
   }
   .m-content {
     width: min(100%, 540px);
+    max-width: 100%;
     margin: 0 auto;
     padding: 20px 14px calc(128px + env(safe-area-inset-bottom));
+    overflow-x: clip;
   }
   .m-chat-fab,
   .m-tab {
@@ -482,6 +492,7 @@
     z-index: 210;
     width: min(520px, calc(100% - 20px));
     margin: 0 auto;
+    box-sizing: border-box;
     display: grid;
     grid-template-columns: repeat(5, 1fr);
     gap: 4px;
@@ -506,6 +517,7 @@
     justify-content: center;
     gap: 2px;
     font: inherit;
+    overflow: hidden;
     cursor: pointer;
   }
   .m-tab-icon,
@@ -516,7 +528,16 @@
     font-size: 18px;
     line-height: 1;
   }
-  .m-tab small { font-size: 10px; line-height: 1; }
+  .m-tab small {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    font-size: 10px;
+    line-height: 1;
+    letter-spacing: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .m-tab.active {
     background: color-mix(in srgb, var(--accent) 30%, var(--bg-card));
     color: var(--text-primary);
@@ -562,6 +583,10 @@
   [data-theme="cyberterm"] .m-wear-tile {
     box-shadow: 2px 2px 0 var(--border);
   }
+  [data-theme="cyberterm"] .m-chat-fab,
+  [data-theme="cyberterm"] .m-tabbar {
+    box-shadow: 2px 2px 0 var(--border);
+  }
   [data-theme="synth-sunrise"] .m-bg {
     top: 44%;
     background:
@@ -579,6 +604,12 @@
       linear-gradient(to bottom, color-mix(in srgb, var(--accent) 12%, transparent) 1px, transparent 1px);
     background-size: 18px 18px;
     opacity: 0.45;
+  }
+  [data-theme="neuromancer"] .m-chat-fab,
+  [data-theme="neuromancer"] .m-tabbar {
+    box-shadow:
+      0 0 22px -12px rgba(0, 229, 255, 0.62),
+      0 12px 30px -24px rgba(255, 43, 214, 0.58);
   }
   [data-theme="glass"] .m-stat-card,
   [data-theme="glass"] .m-insight,

--- a/css/redesign-shell.css
+++ b/css/redesign-shell.css
@@ -366,11 +366,17 @@
     min-width: auto;
     gap: 6px;
   }
+  .tweaks-overlay {
+    overflow-x: hidden;
+  }
   .tweaks-panel {
     top: 66px;
-    right: 8px;
-    width: calc(100vw - 16px);
+    right: calc(12px + env(safe-area-inset-right));
+    left: calc(12px + env(safe-area-inset-left));
+    width: auto;
+    max-width: none;
     max-height: calc(100vh - 74px);
+    box-sizing: border-box;
   }
   .tweaks-body { max-height: calc(100vh - 156px); }
 }

--- a/css/redesign-shell.css
+++ b/css/redesign-shell.css
@@ -211,6 +211,8 @@
   position: absolute;
   top: 76px;
   right: 16px;
+  display: flex;
+  flex-direction: column;
   width: min(380px, calc(100vw - 24px));
   max-height: calc(100vh - 92px);
   overflow: hidden;
@@ -220,6 +222,7 @@
   box-shadow: var(--shadow-lg);
 }
 .tweaks-head {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -243,8 +246,12 @@
   font-size: 22px;
 }
 .tweaks-body {
+  flex: 1 1 auto;
+  min-height: 0;
   max-height: calc(100vh - 172px);
   overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   padding: 16px 20px 20px;
 }
 .tweaks-section {
@@ -378,10 +385,13 @@
   }
   .tweaks-overlay.show { display: flex; }
   .tweaks-overlay {
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
-    padding: calc(66px + env(safe-area-inset-top)) calc(16px + env(safe-area-inset-right)) calc(12px + env(safe-area-inset-bottom)) calc(16px + env(safe-area-inset-left));
+    padding: calc(12px + env(safe-area-inset-top)) calc(12px + env(safe-area-inset-right)) calc(12px + env(safe-area-inset-bottom)) calc(12px + env(safe-area-inset-left));
     box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.68);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
   }
   .tweaks-panel {
     position: relative;
@@ -391,17 +401,16 @@
     width: min(100%, 380px);
     min-width: 0;
     max-width: 100%;
-    max-height: calc(100vh - 78px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    height: calc(100vh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    max-height: calc(100vh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     box-sizing: border-box;
     box-shadow: 0 12px 24px -20px rgba(0, 0, 0, 0.75);
   }
-  .tweaks-body { max-height: calc(100vh - 160px - env(safe-area-inset-top) - env(safe-area-inset-bottom)); }
+  .tweaks-body { max-height: none; }
   @supports (height: 100dvh) {
     .tweaks-panel {
-      max-height: calc(100dvh - 78px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-    }
-    .tweaks-body {
-      max-height: calc(100dvh - 160px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+      height: calc(100dvh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+      max-height: calc(100dvh - 24px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     }
   }
 }

--- a/css/redesign-shell.css
+++ b/css/redesign-shell.css
@@ -203,6 +203,7 @@
   inset: 0;
   z-index: 850;
   display: none;
+  overflow: hidden;
   background: rgba(0,0,0,0.22);
 }
 .tweaks-overlay.show { display: block; }
@@ -271,6 +272,7 @@
   display: flex;
   align-items: center;
   gap: 9px;
+  min-width: 0;
   width: 100%;
   padding: 9px 10px;
   border: 1px solid var(--border);
@@ -302,6 +304,14 @@
   align-items: center;
   justify-content: space-between;
   gap: 14px;
+}
+.tweaks-option-row .settings-copy {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.tweaks-option-row .settings-copy-title,
+.tweaks-option-row .settings-copy-desc {
+  overflow-wrap: anywhere;
 }
 .tweaks-option-row[hidden] {
   display: none;
@@ -366,19 +376,34 @@
     min-width: auto;
     gap: 6px;
   }
+  .tweaks-overlay.show { display: flex; }
   .tweaks-overlay {
-    overflow-x: hidden;
-  }
-  .tweaks-panel {
-    top: 66px;
-    right: calc(12px + env(safe-area-inset-right));
-    left: calc(12px + env(safe-area-inset-left));
-    width: auto;
-    max-width: none;
-    max-height: calc(100vh - 74px);
+    align-items: flex-start;
+    justify-content: center;
+    padding: calc(66px + env(safe-area-inset-top)) calc(16px + env(safe-area-inset-right)) calc(12px + env(safe-area-inset-bottom)) calc(16px + env(safe-area-inset-left));
     box-sizing: border-box;
   }
-  .tweaks-body { max-height: calc(100vh - 156px); }
+  .tweaks-panel {
+    position: relative;
+    top: auto;
+    right: auto;
+    left: auto;
+    width: min(100%, 380px);
+    min-width: 0;
+    max-width: 100%;
+    max-height: calc(100vh - 78px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    box-sizing: border-box;
+    box-shadow: 0 12px 24px -20px rgba(0, 0, 0, 0.75);
+  }
+  .tweaks-body { max-height: calc(100vh - 160px - env(safe-area-inset-top) - env(safe-area-inset-bottom)); }
+  @supports (height: 100dvh) {
+    .tweaks-panel {
+      max-height: calc(100dvh - 78px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    }
+    .tweaks-body {
+      max-height: calc(100dvh - 160px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    }
+  }
 }
 @media (max-width: 480px) {
   .brand-mark,

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,0 +1,465 @@
+/* Settings modal and settings-owned controls */
+
+.settings-btn:hover { background: var(--bg-hover); }
+
+.settings-modal {
+  padding: 0;
+  width: min(94vw, 860px);
+  max-width: 860px;
+  max-height: 90vh;
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+.settings-modal .settings-layout {
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr);
+  height: min(560px, calc(90vh - 78px));
+  height: min(560px, calc(90dvh - 78px));
+  min-height: 0;
+  max-height: calc(90vh - 78px);
+  max-height: calc(90dvh - 78px);
+  gap: 0;
+}
+.settings-modal .settings-tabs-bar {
+  position: static;
+  top: auto;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin: 0;
+  padding: 18px 14px;
+  border-right: 1px solid var(--border);
+  border-bottom: 0;
+  background: var(--bg-secondary);
+  overflow-y: auto;
+}
+.settings-modal .settings-tab-btn {
+  box-sizing: border-box;
+  width: 100%;
+  justify-content: flex-start;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+.settings-modal .settings-tab-btn::after { display: none; }
+.settings-modal .settings-tab-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+.settings-modal .settings-tab-btn.active {
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+.settings-modal .settings-tab-btn.active svg { color: var(--accent); }
+.settings-modal .settings-content {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 18px 24px 24px;
+}
+.settings-modal .settings-tab-panel {
+  min-width: 0;
+  padding-top: 0;
+  overflow-x: clip;
+}
+.settings-modal .settings-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.settings-modal .settings-row .settings-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, auto);
+  gap: 16px;
+  align-items: center;
+  margin: 0;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border);
+}
+.settings-modal .settings-row .settings-section > :only-child {
+  grid-column: 1 / -1;
+}
+.settings-modal .settings-section {
+  margin-top: 14px;
+}
+.settings-modal .settings-label {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.settings-modal .settings-group-title {
+  margin-top: 22px;
+  border: 0;
+  padding-bottom: 0;
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+}
+.settings-modal .ai-provider-btn,
+.settings-modal .imported-entry,
+.settings-modal .local-ai-settings,
+.settings-modal .privacy-status-card {
+  background: var(--bg-card);
+  border-color: var(--border);
+}
+.settings-modal .settings-links-row {
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.settings-modal .settings-action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+.settings-modal .settings-action-row + .settings-action-row {
+  margin-top: 14px;
+}
+.settings-modal .settings-copy {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.settings-modal .settings-copy-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+.settings-modal .settings-copy-desc {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+.settings-modal .settings-divider {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--border);
+}
+.settings-modal .settings-token-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.settings-modal .settings-token-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.settings-modal .settings-token-box {
+  min-height: 20px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: 11.5px;
+  line-height: 1.6;
+  word-break: break-all;
+  user-select: none;
+}
+.settings-modal .settings-select {
+  min-width: 90px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+}
+.settings-modal .settings-mini-btn {
+  padding: 3px 10px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+.settings-modal .settings-full-btn {
+  width: 100%;
+  margin-top: 12px;
+  padding: 7px 14px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.settings-modal .api-key-input {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  min-height: 40px;
+}
+.settings-modal .api-key-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-fill);
+}
+.kb-modal.settings-modal {
+  max-width: 780px;
+}
+
+/* Imported data entries */
+.imported-entry {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 16px; background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); margin-bottom: 6px; font-size: 13px;
+}
+.imported-entry .ie-info { color: var(--text-secondary); }
+.imported-entry .ie-date { color: var(--text-primary); font-weight: 500; }
+.imported-entry .ie-count { color: var(--text-muted); margin-left: 8px; }
+.imported-entry .ie-actions { display: flex; align-items: center; gap: 4px; }
+.imported-entry .ie-remove,
+.imported-entry .ie-edit {
+  background: none; border: none; color: var(--text-muted); cursor: pointer;
+  font-size: 12px; padding: 4px 10px; border-radius: 4px; transition: all 0.15s; font-family: inherit;
+}
+.imported-entry .ie-remove:hover { color: var(--red); background: var(--red-bg); }
+.imported-entry .ie-edit:hover { color: var(--text-primary); background: var(--bg-hover); }
+
+/* Settings sections */
+.settings-section { margin-top: 16px; }
+.settings-label { font-size: 13px; font-weight: 600; display: block; margin-bottom: 8px; color: var(--text-secondary); }
+.settings-group-title {
+  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-muted); margin-top: 24px; padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Settings tabs */
+.settings-tabs-bar {
+  display: flex; gap: 2px; margin: 16px 0 0;
+  border-bottom: 1px solid var(--border);
+  position: sticky; top: -32px; z-index: 2;
+  background: var(--bg-secondary); padding-top: 4px;
+}
+.settings-tab-btn {
+  position: relative; padding: 10px 18px; border: none; background: none;
+  color: var(--text-muted); font-size: 13px; font-weight: 500;
+  font-family: var(--font-display); cursor: pointer;
+  transition: color 0.2s; white-space: nowrap;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.settings-tab-btn::after {
+  content: ''; position: absolute; bottom: -1px; left: 8px; right: 8px;
+  height: 2px; border-radius: 2px 2px 0 0; background: transparent;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+.settings-tab-btn:hover { color: var(--text-secondary); }
+.settings-tab-btn.active { color: var(--accent); font-weight: 600; }
+.settings-tab-btn.active::after {
+  background: var(--accent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.settings-tab-btn svg { width: 14px; height: 14px; flex-shrink: 0; opacity: 0.6; }
+.settings-tab-btn.active svg { opacity: 1; }
+.settings-tab-panel { display: none; padding-top: 6px; }
+.settings-tab-panel.active {
+  display: block;
+  animation: settingsTabFadeIn 0.2s ease;
+}
+@keyframes settingsTabFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.settings-tab-panel .settings-section:first-child { margin-top: 8px; }
+.settings-tab-panel .settings-group-title:first-child { margin-top: 12px; }
+.settings-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.settings-row .settings-section { margin-top: 8px; }
+.settings-links-row { display: flex; flex-wrap: wrap; gap: 8px 16px; margin-top: 8px; }
+.settings-link-btn {
+  background: none; border: none; color: var(--text-muted); font-size: 13px;
+  font-family: inherit; cursor: pointer; padding: 4px 0; text-decoration: none;
+  transition: color 0.15s;
+}
+.settings-link-btn:hover { color: var(--text-primary); text-decoration: underline; }
+
+/* Theme picker */
+.settings-theme-toggle { display: flex; align-items: center; gap: 4px; }
+.settings-theme-btn {
+  padding: 4px 12px; border-radius: 6px; border: 1px solid var(--border);
+  background: transparent; color: var(--text-secondary); font-size: 12px;
+  cursor: pointer; font-weight: 500; transition: all 0.15s; font-family: inherit;
+}
+.settings-theme-btn.active { background: var(--accent); color: white; border-color: var(--accent); }
+.settings-theme-btn:hover:not(.active) { background: var(--bg-hover); }
+.settings-theme-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  border: 1px solid rgba(255,255,255,0.06);
+}
+.settings-theme-swatch-dark { background: linear-gradient(135deg, #222635 0%, #4f8cff 100%); }
+.settings-theme-swatch-light { background: linear-gradient(135deg, #f5f6fa 0%, #3b7cf5 100%); }
+.settings-theme-swatch-cyberterm { background: linear-gradient(135deg, #0b0d0b 0%, #4ade80 100%); border-radius: 0; }
+.settings-theme-swatch-glass { background: linear-gradient(135deg, #c986ff 0%, #6ec4ff 100%); border-radius: 12px; }
+.settings-theme-swatch-synth-sunrise { background: linear-gradient(135deg, #ff7a18 0%, #ff2bd6 50%, #7c3aed 100%); border-radius: 2px; }
+.settings-theme-swatch-neuromancer { background: linear-gradient(135deg, #00e5ff 0%, #ff2bd6 100%); border-radius: 0; }
+
+/* Privacy status card and collapsible configure */
+.privacy-status-card {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 10px 14px; border-radius: var(--radius-sm);
+  margin-bottom: 8px; line-height: 1.4;
+}
+.privacy-status-icon { font-size: 18px; flex-shrink: 0; margin-top: 1px; }
+.privacy-status-body { flex: 1; min-width: 0; }
+.privacy-status-title { font-size: 13px; font-weight: 600; }
+.privacy-status-detail { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+.privacy-status-enhanced {
+  background: color-mix(in srgb, var(--green) 8%, transparent); border: 1px solid color-mix(in srgb, var(--green) 25%, transparent);
+}
+.privacy-status-enhanced .privacy-status-title { color: var(--green); }
+.privacy-status-basic {
+  background: color-mix(in srgb, var(--yellow) 8%, transparent); border: 1px solid color-mix(in srgb, var(--yellow) 25%, transparent);
+}
+.privacy-status-basic .privacy-status-title { color: var(--yellow); }
+.privacy-configure-toggle {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--text-muted); cursor: pointer;
+  padding: 4px 0; user-select: none;
+}
+.privacy-configure-toggle:hover { color: var(--text-secondary); }
+.privacy-configure-arrow { font-size: 9px; transition: transform 0.15s; }
+.privacy-configure-body { padding-top: 8px; }
+
+/* Pending-tombstone confirm UI in Settings Sync. */
+.sync-tombstone-banner {
+  margin-bottom: 16px; padding: 12px 14px;
+  border: 1px solid var(--yellow); background: color-mix(in srgb, var(--yellow) 8%, transparent);
+  border-radius: 6px; font-size: 12px;
+}
+.sync-tombstone-head { margin-bottom: 8px; line-height: 1.45; }
+.sync-tombstone-head strong { color: var(--yellow); }
+.sync-tombstone-help { display: block; color: var(--text-muted); font-size: 11px; margin-top: 2px; }
+.sync-tombstone-row {
+  display: flex; align-items: center; gap: 8px; padding: 6px 0;
+  border-top: 1px solid color-mix(in srgb, var(--yellow) 18%, transparent);
+}
+.sync-tombstone-name { flex: 1; font-weight: 500; color: var(--text-primary); }
+.sync-tombstone-meta { font-size: 11px; color: var(--text-muted); }
+.sync-tombstone-btn {
+  font-size: 11px; padding: 4px 10px; border-radius: 4px; cursor: pointer;
+  border: 1px solid var(--border); background: var(--bg-secondary); color: var(--text-primary);
+}
+.sync-tombstone-apply { background: var(--red); color: #fff; border-color: var(--red); }
+.sync-tombstone-reject { background: var(--green); color: #fff; border-color: var(--green); }
+
+@media (max-width: 720px) {
+  .settings-modal {
+    width: 100%;
+    height: calc(100vh - 24px);
+    height: calc(100dvh - 24px);
+    max-height: none;
+    display: flex;
+    flex-direction: column;
+  }
+  .settings-modal .settings-modal-head {
+    padding: 14px 16px;
+  }
+  .settings-modal .gb-modal-kicker {
+    font-size: 9px;
+  }
+  .settings-modal .gb-modal-title {
+    font-size: 20px;
+  }
+  .settings-modal .settings-layout {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
+    overflow: hidden;
+  }
+  .settings-modal .settings-tabs-bar {
+    position: relative;
+    flex: 0 0 auto;
+    flex-direction: row;
+    align-items: center;
+    min-height: 58px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+    gap: 6px;
+    padding: 8px 10px 10px;
+    scroll-padding-inline: 10px;
+    overscroll-behavior-x: contain;
+  }
+  .settings-modal .settings-tab-btn {
+    width: auto;
+    flex: 0 0 auto;
+    height: 40px;
+    min-height: 40px;
+    padding: 8px 10px;
+    white-space: nowrap;
+  }
+  .settings-modal .settings-content {
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 18px 16px 16px;
+  }
+  .settings-modal .settings-row .settings-section {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 12px 0;
+  }
+  .settings-modal .settings-section {
+    margin-top: 12px;
+  }
+  .settings-modal .settings-group-title {
+    margin-top: 18px;
+  }
+  .settings-modal .settings-action-row {
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .settings-modal .settings-action-row > .toggle-switch {
+    margin-top: 2px;
+  }
+  .settings-modal .unit-toggle,
+  .settings-modal .range-toggle {
+    flex-wrap: wrap;
+  }
+  .settings-modal .range-toggle {
+    width: 100%;
+  }
+  .settings-modal .range-toggle-btn {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+  .settings-modal .ai-provider-toggle {
+    gap: 6px;
+  }
+  .settings-modal .ai-provider-btn {
+    flex: 1 1 calc(50% - 6px);
+    justify-content: center;
+    min-height: 38px;
+    padding: 7px 8px;
+  }
+  .settings-modal .or-oauth-btn {
+    min-height: 42px;
+    border-radius: var(--radius-sm);
+  }
+}
+
+@media (max-width: 600px) {
+  .settings-tabs-bar { overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+  .settings-tabs-bar::-webkit-scrollbar { display: none; }
+}
+
+@media (max-width: 500px) {
+  .settings-tab-btn { padding: 8px 10px; font-size: 12px; gap: 4px; }
+  .settings-tab-btn svg { width: 12px; height: 12px; }
+  .settings-row { grid-template-columns: 1fr; }
+}

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -16,7 +16,7 @@ This constraint is intentional — it keeps the codebase approachable, removes t
 ```
 index.html          — HTML structure only; script/CSS includes; SEO meta tags
 styles.css          — Core CSS: tokens, app shell, shared components, responsive/touch rules
-css/*.css           — Split shared/feature CSS for modal utilities and high-churn surfaces such as mobile dashboard, menstrual cycle, marker detail modal, client list, chat panel, wearables, Light/Sun, and redesign catch-up
+css/*.css           — Split shared/feature CSS for modal utilities and high-churn surfaces such as settings, mobile dashboard, menstrual cycle, marker detail modal, client list, chat panel, wearables, Light/Sun, and redesign catch-up
 manifest.json       — PWA manifest (installable as a native app)
 service-worker.js   — PWA cache strategies, API bypass rules
 data/

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
   <noscript><link rel="stylesheet" href="vendor/fonts/fonts.css"></noscript>
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="css/modal-shared.css">
+  <link rel="stylesheet" href="css/settings.css">
   <link rel="stylesheet" href="css/mobile-dashboard.css">
   <link rel="stylesheet" href="css/cycle.css">
   <link rel="stylesheet" href="css/marker-detail-modal.css">

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -20,6 +20,7 @@ const MOBILE_WEARABLE_PRIORITY = [
 ];
 
 let _mobileDashboardManualTabLockUntil = 0;
+let _mobileChromeStateObserver = null;
 
 const mobileDashboardDeps = {
   buildDashboardWidgetContext: () => ({ data: getActiveData(), filteredData: getActiveData() }),
@@ -46,6 +47,44 @@ export function isMobileDashboardViewport() {
     && window.matchMedia(MOBILE_DASHBOARD_QUERY).matches;
 }
 
+function getMobileVisualBottomOffset() {
+  if (typeof window === 'undefined' || !window.visualViewport) return 0;
+  const layoutHeight = window.innerHeight || document.documentElement?.clientHeight || window.visualViewport.height;
+  const visualBottom = window.visualViewport.offsetTop + window.visualViewport.height;
+  return Math.max(0, Math.ceil(layoutHeight - visualBottom));
+}
+
+function syncMobileChromeRootState() {
+  if (typeof document === 'undefined' || !document.body) return;
+  const root = document.documentElement;
+  const dashboardActive = document.body.classList.contains('mobile-dashboard-active');
+  const tabsActive = document.body.classList.contains('mobile-tabs-active');
+  root.classList.toggle('mobile-dashboard-active', dashboardActive);
+  root.classList.toggle('mobile-tabs-active', tabsActive);
+  if (dashboardActive || tabsActive) {
+    root.style.setProperty('--mobile-visual-bottom-offset', `${getMobileVisualBottomOffset()}px`);
+  } else {
+    root.style.removeProperty('--mobile-visual-bottom-offset');
+  }
+}
+
+function initMobileChromeStateSync() {
+  if (typeof document === 'undefined' || _mobileChromeStateObserver) return;
+  const start = () => {
+    if (!document.body || _mobileChromeStateObserver) return;
+    if (typeof MutationObserver === 'function') {
+      _mobileChromeStateObserver = new MutationObserver(syncMobileChromeRootState);
+      _mobileChromeStateObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+    }
+    syncMobileChromeRootState();
+  };
+  if (document.body) start();
+  else document.addEventListener('DOMContentLoaded', start, { once: true });
+  window.addEventListener('resize', syncMobileChromeRootState, { passive: true });
+  window.visualViewport?.addEventListener('resize', syncMobileChromeRootState, { passive: true });
+  window.visualViewport?.addEventListener('scroll', syncMobileChromeRootState, { passive: true });
+}
+
 function getMobileBottomTabForRoute(route) {
   if (['dashboard', 'labs', 'body', 'light', 'insight'].includes(route)) return route;
   if (route === 'recommendations') return 'insight';
@@ -60,6 +99,7 @@ export function syncMobileBottomNav(route = state.currentView || 'dashboard') {
   const hasDashboardShell = document.body.classList.contains('mobile-dashboard-active');
   const shouldRender = isMobileDashboardViewport() && !hasDashboardShell;
   document.body.classList.toggle('mobile-tabs-active', shouldRender);
+  syncMobileChromeRootState();
   if (!shouldRender) {
     existing?.remove();
     return;
@@ -80,6 +120,7 @@ export function refreshMobileDashboardActiveTab() {
 }
 
 if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+  initMobileChromeStateSync();
   const mobileDashboardMedia = window.matchMedia(MOBILE_DASHBOARD_QUERY);
   const refreshDashboardForBreakpoint = () => {
     if (state.currentView === 'dashboard') window.navigate?.('dashboard');
@@ -380,6 +421,7 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
   ].filter(Boolean).join(' · ');
 
   document.body.classList.add('mobile-dashboard-active');
+  syncMobileChromeRootState();
   main.innerHTML = `<div class="drop-zone drop-zone-hidden" id="drop-zone"></div>
     <div class="m-shell">
       <div class="m-bg" aria-hidden="true"></div>
@@ -391,9 +433,9 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
 
         ${mobileWidgetStack}
       </div>
-      <button type="button" class="m-chat-fab" onclick="window.openChatPanel && window.openChatPanel()" aria-label="Ask AI">${renderMobileIcon('chat')}</button>
-      ${renderMobileBottomTabs('dashboard')}
-    </div>`;
+    </div>
+    <button type="button" class="m-chat-fab" onclick="window.openChatPanel && window.openChatPanel()" aria-label="Ask AI">${renderMobileIcon('chat')}</button>
+    ${renderMobileBottomTabs('dashboard')}`;
 
   if (resetScroll && typeof window.scrollTo === 'function') {
     window.scrollTo(0, 0);

--- a/js/settings.js
+++ b/js/settings.js
@@ -343,8 +343,14 @@ export function updateTweaksUI() {
   });
 }
 
+let _tweaksPriorBodyOverflow = null;
+
 export function closeTweaksPanel() {
   document.getElementById('tweaks-panel-overlay')?.remove();
+  if (_tweaksPriorBodyOverflow !== null) {
+    document.body.style.overflow = _tweaksPriorBodyOverflow;
+    _tweaksPriorBodyOverflow = null;
+  }
 }
 
 export function openTweaksPanel() {
@@ -417,6 +423,10 @@ export function openTweaksPanel() {
       </aside>
     </div>
   `);
+  if (window.matchMedia?.('(max-width: 768px)').matches) {
+    _tweaksPriorBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
   updateTweaksUI();
   document.querySelector('#tweaks-panel button')?.focus();
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -28,6 +28,7 @@ const APP_SHELL = [
   '/app',
   '/styles.css',
   '/css/modal-shared.css',
+  '/css/settings.css',
   '/css/mobile-dashboard.css',
   '/css/cycle.css',
   '/css/marker-detail-modal.css',

--- a/styles.css
+++ b/styles.css
@@ -1776,7 +1776,6 @@ body {
 .modal-overlay.show .modal { transform: scale(1) translateY(0); opacity: 1; }
 .gb-form-modal,
 .gb-history-modal,
-.settings-modal,
 .marker-detail-modal {
   padding: 0;
   width: min(94vw, 880px);
@@ -1848,193 +1847,6 @@ body {
   margin-top: 18px;
   padding-top: 16px;
   border-top: 1px solid var(--border);
-}
-.settings-modal {
-  width: min(94vw, 860px);
-  max-width: 860px;
-  overflow: hidden;
-}
-.settings-modal .settings-layout {
-  display: grid;
-  grid-template-columns: 200px minmax(0, 1fr);
-  height: min(560px, calc(90vh - 78px));
-  height: min(560px, calc(90dvh - 78px));
-  min-height: 0;
-  max-height: calc(90vh - 78px);
-  max-height: calc(90dvh - 78px);
-  gap: 0;
-}
-.settings-modal .settings-tabs-bar {
-  position: static;
-  top: auto;
-  z-index: 2;
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  margin: 0;
-  padding: 18px 14px;
-  border-right: 1px solid var(--border);
-  border-bottom: 0;
-  background: var(--bg-secondary);
-  overflow-y: auto;
-}
-.settings-modal .settings-tab-btn {
-  box-sizing: border-box;
-  width: 100%;
-  justify-content: flex-start;
-  gap: 9px;
-  padding: 10px 12px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 600;
-}
-.settings-modal .settings-tab-btn::after { display: none; }
-.settings-modal .settings-tab-btn:hover {
-  color: var(--text-primary);
-  background: var(--bg-card);
-}
-.settings-modal .settings-tab-btn.active {
-  background: var(--bg-card);
-  color: var(--text-primary);
-  border-color: var(--border);
-}
-.settings-modal .settings-tab-btn.active svg { color: var(--accent); }
-.settings-modal .settings-content {
-  position: relative;
-  z-index: 1;
-  min-width: 0;
-  min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding: 18px 24px 24px;
-}
-.settings-modal .settings-tab-panel {
-  min-width: 0;
-  padding-top: 0;
-  overflow-x: clip;
-}
-.settings-modal .settings-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-.settings-modal .settings-row .settings-section {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(180px, auto);
-  gap: 16px;
-  align-items: center;
-  margin: 0;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--border);
-}
-.settings-modal .settings-row .settings-section > :only-child {
-  grid-column: 1 / -1;
-}
-.settings-modal .settings-section {
-  margin-top: 14px;
-}
-.settings-modal .settings-label {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 14px;
-}
-.settings-modal .settings-group-title {
-  margin-top: 22px;
-  border: 0;
-  padding-bottom: 0;
-  font-family: var(--font-mono);
-  letter-spacing: 0.1em;
-}
-.settings-modal .ai-provider-btn,
-.settings-modal .imported-entry,
-.settings-modal .local-ai-settings,
-.settings-modal .privacy-status-card {
-  background: var(--bg-card);
-  border-color: var(--border);
-}
-.settings-modal .settings-links-row {
-  padding-top: 8px;
-  border-top: 1px solid var(--border);
-}
-.settings-modal .settings-action-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-}
-.settings-modal .settings-action-row + .settings-action-row {
-  margin-top: 14px;
-}
-.settings-modal .settings-copy {
-  min-width: 0;
-  flex: 1 1 auto;
-}
-.settings-modal .settings-copy-title {
-  color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.35;
-}
-.settings-modal .settings-copy-desc {
-  margin-top: 2px;
-  color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1.45;
-}
-.settings-modal .settings-divider {
-  margin-top: 18px;
-  padding-top: 14px;
-  border-top: 1px dashed var(--border);
-}
-.settings-modal .settings-token-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 6px;
-}
-.settings-modal .settings-token-actions {
-  display: flex;
-  gap: 6px;
-  flex-shrink: 0;
-}
-.settings-modal .settings-token-box {
-  min-height: 20px;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-family: var(--font-mono, monospace);
-  font-size: 11.5px;
-  line-height: 1.6;
-  word-break: break-all;
-  user-select: none;
-}
-.settings-modal .settings-select {
-  min-width: 90px;
-  padding: 6px 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font: inherit;
-  font-size: 12px;
-}
-.settings-modal .settings-mini-btn {
-  padding: 3px 10px;
-  font-size: 11px;
-  white-space: nowrap;
-}
-.settings-modal .settings-full-btn {
-  width: 100%;
-  margin-top: 12px;
-  padding: 7px 14px;
-  font-size: 12px;
-  white-space: nowrap;
 }
 .import-preview-modal {
   width: min(94vw, 920px);
@@ -2390,9 +2202,6 @@ body {
   background: var(--bg-hover);
   color: var(--text-primary);
 }
-.kb-modal.settings-modal {
-  max-width: 780px;
-}
 .modal:not(.marker-detail-modal):not(.gb-form-modal):not(.gb-history-modal):not(.settings-modal) > h3:first-of-type,
 .modal:not(.marker-detail-modal):not(.gb-form-modal):not(.gb-history-modal):not(.settings-modal) > .modal-header:first-child {
   margin: -32px -32px 20px;
@@ -2443,101 +2252,6 @@ body {
   .feedback-action-btn {
     width: 100%;
     min-height: 42px;
-  }
-  .settings-modal {
-    width: 100%;
-    height: calc(100vh - 24px);
-    height: calc(100dvh - 24px);
-    max-height: none;
-    display: flex;
-    flex-direction: column;
-  }
-  .settings-modal .settings-modal-head {
-    padding: 14px 16px;
-  }
-  .settings-modal .gb-modal-kicker {
-    font-size: 9px;
-  }
-  .settings-modal .gb-modal-title {
-    font-size: 20px;
-  }
-  .settings-modal .settings-layout {
-    display: flex;
-    flex-direction: column;
-    flex: 1 1 auto;
-    min-height: 0;
-    max-height: none;
-    overflow: hidden;
-  }
-  .settings-modal .settings-tabs-bar {
-    position: relative;
-    flex: 0 0 auto;
-    flex-direction: row;
-    align-items: center;
-    min-height: 58px;
-    overflow-x: auto;
-    overflow-y: hidden;
-    border-right: 0;
-    border-bottom: 1px solid var(--border);
-    gap: 6px;
-    padding: 8px 10px 10px;
-    scroll-padding-inline: 10px;
-    overscroll-behavior-x: contain;
-  }
-  .settings-modal .settings-tab-btn {
-    width: auto;
-    flex: 0 0 auto;
-    height: 40px;
-    min-height: 40px;
-    padding: 8px 10px;
-    white-space: nowrap;
-  }
-  .settings-modal .settings-content {
-    flex: 1 1 auto;
-    min-height: 0;
-    padding: 18px 16px 16px;
-  }
-  .settings-modal .settings-row .settings-section {
-    grid-template-columns: 1fr;
-    gap: 8px;
-    padding: 12px 0;
-  }
-  .settings-modal .settings-section {
-    margin-top: 12px;
-  }
-  .settings-modal .settings-group-title {
-    margin-top: 18px;
-  }
-  .settings-modal .settings-action-row {
-    align-items: flex-start;
-    gap: 12px;
-  }
-  .settings-modal .settings-action-row > .toggle-switch {
-    margin-top: 2px;
-  }
-  .settings-modal .unit-toggle,
-  .settings-modal .range-toggle {
-    flex-wrap: wrap;
-  }
-  .settings-modal .range-toggle {
-    width: 100%;
-  }
-  .settings-modal .range-toggle-btn {
-    flex: 1 1 0;
-    min-width: 0;
-  }
-  .settings-modal .ai-provider-toggle {
-    gap: 6px;
-  }
-  .settings-modal .ai-provider-btn {
-    flex: 1 1 calc(50% - 6px);
-    justify-content: center;
-    min-height: 38px;
-    padding: 7px 8px;
-  }
-  .settings-modal .or-oauth-btn {
-    min-height: 42px;
-    border-radius: var(--radius-sm);
   }
   .gb-form-actions {
     justify-content: stretch;
@@ -2977,22 +2691,6 @@ body {
 }
 .corr-ask-ai-btn:hover { background: var(--accent); color: #fff; }
 .corr-chart { height: 400px; }
-.imported-entry {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 10px 16px; background: var(--bg-card); border: 1px solid var(--border);
-  border-radius: var(--radius-sm); margin-bottom: 6px; font-size: 13px;
-}
-.imported-entry .ie-info { color: var(--text-secondary); }
-.imported-entry .ie-date { color: var(--text-primary); font-weight: 500; }
-.imported-entry .ie-count { color: var(--text-muted); margin-left: 8px; }
-.imported-entry .ie-actions { display: flex; align-items: center; gap: 4px; }
-.imported-entry .ie-remove,
-.imported-entry .ie-edit {
-  background: none; border: none; color: var(--text-muted); cursor: pointer;
-  font-size: 12px; padding: 4px 10px; border-radius: 4px; transition: all 0.15s; font-family: inherit;
-}
-.imported-entry .ie-remove:hover { color: var(--red); background: var(--red-bg); }
-.imported-entry .ie-edit:hover { color: var(--text-primary); background: var(--bg-hover); }
 /* Standalone note row */
 /* Note cards (dashboard) */
 .notes-section { margin-bottom: 20px; }
@@ -3981,8 +3679,6 @@ body {
   .profile-compact-btn { padding: 4px; border: none; background: none; }
   .profile-compact-dot { width: 28px; height: 28px; font-size: 13px; }
 }
-/* Settings Button — uses .header-icon-btn base; .settings-btn kept for specificity */
-.settings-btn:hover { background: var(--bg-hover); }
 /* API Key Settings */
 .api-key-input {
   width: 100%; padding: 10px 12px; border-radius: 6px;
@@ -3997,66 +3693,6 @@ body {
   font-size: 11px; color: var(--text-muted); margin-top: 12px;
   padding: 10px; background: var(--bg-card); border-radius: var(--radius-sm);
   border: 1px solid var(--border); line-height: 1.5;
-}
-/* Settings Sections */
-.settings-section { margin-top: 16px; }
-.settings-label { font-size: 13px; font-weight: 600; display: block; margin-bottom: 8px; color: var(--text-secondary); }
-.settings-group-title {
-  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--text-muted); margin-top: 24px; padding-bottom: 6px;
-  border-bottom: 1px solid var(--border);
-}
-/* Settings Tabs */
-.settings-tabs-bar {
-  display: flex; gap: 2px; margin: 16px 0 0;
-  border-bottom: 1px solid var(--border);
-  position: sticky; top: -32px; z-index: 2;
-  background: var(--bg-secondary); padding-top: 4px;
-}
-.settings-tab-btn {
-  position: relative; padding: 10px 18px; border: none; background: none;
-  color: var(--text-muted); font-size: 13px; font-weight: 500;
-  font-family: var(--font-display); cursor: pointer;
-  transition: color 0.2s; white-space: nowrap;
-  display: inline-flex; align-items: center; gap: 6px;
-}
-.settings-tab-btn::after {
-  content: ''; position: absolute; bottom: -1px; left: 8px; right: 8px;
-  height: 2px; border-radius: 2px 2px 0 0; background: transparent;
-  transition: background 0.2s, box-shadow 0.2s;
-}
-.settings-tab-btn:hover { color: var(--text-secondary); }
-.settings-tab-btn.active { color: var(--accent); font-weight: 600; }
-.settings-tab-btn.active::after {
-  background: var(--accent);
-  box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 30%, transparent);
-}
-.settings-tab-btn svg { width: 14px; height: 14px; flex-shrink: 0; opacity: 0.6; }
-.settings-tab-btn.active svg { opacity: 1; }
-.settings-tab-panel { display: none; padding-top: 6px; }
-.settings-tab-panel.active {
-  display: block;
-  animation: settingsTabFadeIn 0.2s ease;
-}
-@keyframes settingsTabFadeIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.settings-tab-panel .settings-section:first-child { margin-top: 8px; }
-.settings-tab-panel .settings-group-title:first-child { margin-top: 12px; }
-.settings-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-.settings-row .settings-section { margin-top: 8px; }
-.settings-links-row { display: flex; flex-wrap: wrap; gap: 8px 16px; margin-top: 8px; }
-.settings-link-btn {
-  background: none; border: none; color: var(--text-muted); font-size: 13px;
-  font-family: inherit; cursor: pointer; padding: 4px 0; text-decoration: none;
-  transition: color 0.15s;
-}
-.settings-link-btn:hover { color: var(--text-primary); text-decoration: underline; }
-@media (max-width: 500px) {
-  .settings-tab-btn { padding: 8px 10px; font-size: 12px; gap: 4px; }
-  .settings-tab-btn svg { width: 12px; height: 12px; }
-  .settings-row { grid-template-columns: 1fr; }
 }
 /* AI Provider Toggle */
 .ai-provider-toggle { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
@@ -4097,27 +3733,6 @@ body {
 .or-oauth-divider span {
   font-size: 11px; color: var(--text-muted); white-space: nowrap;
 }
-.settings-theme-toggle { display: flex; align-items: center; gap: 4px; }
-.settings-theme-btn {
-  padding: 4px 12px; border-radius: 6px; border: 1px solid var(--border);
-  background: transparent; color: var(--text-secondary); font-size: 12px;
-  cursor: pointer; font-weight: 500; transition: all 0.15s; font-family: inherit;
-}
-.settings-theme-btn.active { background: var(--accent); color: white; border-color: var(--accent); }
-.settings-theme-btn:hover:not(.active) { background: var(--bg-hover); }
-.settings-theme-swatch {
-  width: 24px;
-  height: 24px;
-  border-radius: 6px;
-  flex-shrink: 0;
-  border: 1px solid rgba(255,255,255,0.06);
-}
-.settings-theme-swatch-dark { background: linear-gradient(135deg, #222635 0%, #4f8cff 100%); }
-.settings-theme-swatch-light { background: linear-gradient(135deg, #f5f6fa 0%, #3b7cf5 100%); }
-.settings-theme-swatch-cyberterm { background: linear-gradient(135deg, #0b0d0b 0%, #4ade80 100%); border-radius: 0; }
-.settings-theme-swatch-glass { background: linear-gradient(135deg, #c986ff 0%, #6ec4ff 100%); border-radius: 12px; }
-.settings-theme-swatch-synth-sunrise { background: linear-gradient(135deg, #ff7a18 0%, #ff2bd6 50%, #7c3aed 100%); border-radius: 2px; }
-.settings-theme-swatch-neuromancer { background: linear-gradient(135deg, #00e5ff 0%, #ff2bd6 100%); border-radius: 0; }
 .import-status-fab {
   position: fixed; bottom: 92px; right: 24px; z-index: 1001;
   height: 36px; border-radius: 18px; padding: 0 12px 0 10px;
@@ -4209,8 +3824,7 @@ body {
 .gb-form-modal .manual-entry-form .me-field select,
 .gb-form-modal .api-key-input,
 .gb-form-modal .ctx-note-input,
-.gb-form-modal .ctx-notes-textarea,
-.settings-modal .api-key-input {
+.gb-form-modal .ctx-notes-textarea {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -4222,8 +3836,7 @@ body {
 .gb-form-modal .manual-entry-form .me-field select:focus,
 .gb-form-modal .api-key-input:focus,
 .gb-form-modal .ctx-note-input:focus,
-.gb-form-modal .ctx-notes-textarea:focus,
-.settings-modal .api-key-input:focus {
+.gb-form-modal .ctx-notes-textarea:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-fill);
 }
@@ -5289,34 +4902,6 @@ body.import-focus .welcome-hero > .drop-zone {
   .genetics-section .section-meta { width: 100%; }
 }
 
-/* Detail Modal Genetics Inline */
-/* Privacy status card & collapsible configure */
-.privacy-status-card {
-  display: flex; align-items: flex-start; gap: 10px;
-  padding: 10px 14px; border-radius: var(--radius-sm);
-  margin-bottom: 8px; line-height: 1.4;
-}
-.privacy-status-icon { font-size: 18px; flex-shrink: 0; margin-top: 1px; }
-.privacy-status-body { flex: 1; min-width: 0; }
-.privacy-status-title { font-size: 13px; font-weight: 600; }
-.privacy-status-detail { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
-.privacy-status-enhanced {
-  background: color-mix(in srgb, var(--green) 8%, transparent); border: 1px solid color-mix(in srgb, var(--green) 25%, transparent);
-}
-.privacy-status-enhanced .privacy-status-title { color: var(--green); }
-.privacy-status-basic {
-  background: color-mix(in srgb, var(--yellow) 8%, transparent); border: 1px solid color-mix(in srgb, var(--yellow) 25%, transparent);
-}
-.privacy-status-basic .privacy-status-title { color: var(--yellow); }
-.privacy-configure-toggle {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 12px; color: var(--text-muted); cursor: pointer;
-  padding: 4px 0; user-select: none;
-}
-.privacy-configure-toggle:hover { color: var(--text-secondary); }
-.privacy-configure-arrow { font-size: 9px; transition: transform 0.15s; }
-.privacy-configure-body { padding-top: 8px; }
-
 /* PII overlay (shared by diff viewer) */
 .pii-warning-overlay {
   position: fixed; inset: 0; z-index: 10000; background: rgba(0,0,0,0.82);
@@ -5598,11 +5183,6 @@ body.import-focus .welcome-hero > .drop-zone {
   .main { padding-bottom: calc(120px + env(safe-area-inset-bottom)); }
   .modal { padding: 16px 12px; max-width: 98vw; }
   .context-card { min-height: 64px; }
-}
-/* ═══ Settings tabs: horizontal scroll on narrow screens ═══ */
-@media (max-width: 600px) {
-  .settings-tabs-bar { overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
-  .settings-tabs-bar::-webkit-scrollbar { display: none; }
 }
 /* ═══ PII diff: stack columns on mobile ═══ */
 @media (max-width: 768px) {
@@ -5984,26 +5564,3 @@ body.import-focus .welcome-hero > .drop-zone {
 .ctx-tip-free::before { content: '\2192 '; opacity: 0.5; }
 .ctx-tip-form { font-size: 12px; color: var(--text-muted); font-style: italic; margin-top: 2px; }
 .ctx-tip-avoid { color: var(--orange); }
-/* Pending-tombstone confirm UI in Settings → Sync. Surfaces remote-driven
-   profile deletes that exceeded the auto-apply threshold so the user can
-   authorise them out-of-band (defence against mnemonic-leak mass-wipe). */
-.sync-tombstone-banner {
-  margin-bottom: 16px; padding: 12px 14px;
-  border: 1px solid var(--yellow); background: color-mix(in srgb, var(--yellow) 8%, transparent);
-  border-radius: 6px; font-size: 12px;
-}
-.sync-tombstone-head { margin-bottom: 8px; line-height: 1.45; }
-.sync-tombstone-head strong { color: var(--yellow); }
-.sync-tombstone-help { display: block; color: var(--text-muted); font-size: 11px; margin-top: 2px; }
-.sync-tombstone-row {
-  display: flex; align-items: center; gap: 8px; padding: 6px 0;
-  border-top: 1px solid color-mix(in srgb, var(--yellow) 18%, transparent);
-}
-.sync-tombstone-name { flex: 1; font-weight: 500; color: var(--text-primary); }
-.sync-tombstone-meta { font-size: 11px; color: var(--text-muted); }
-.sync-tombstone-btn {
-  font-size: 11px; padding: 4px 10px; border-radius: 4px; cursor: pointer;
-  border: 1px solid var(--border); background: var(--bg-secondary); color: var(--text-primary);
-}
-.sync-tombstone-apply { background: var(--red); color: #fff; border-color: var(--red); }
-.sync-tombstone-reject { background: var(--green); color: #fff; border-color: var(--green); }

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,7 @@
      passed and is unchanged. */
   --text-secondary: #a0a5b8;
   --text-muted: #9aa0b3;
+  --app-sticky-top: 65px;
   --accent: #4f8cff;
   --accent-light: #6ba0ff;
   --on-accent: #030712;
@@ -1699,9 +1700,9 @@ body {
   font-weight: 600; font-size: 12px; text-transform: uppercase;
   letter-spacing: 0.5px; color: var(--text-muted);
   border-bottom: 1px solid var(--border);
-  /* Offset by the 65px sticky page header (same rationale as
+  /* Offset by the sticky page header (same rationale as
      .compare-table th). */
-  position: sticky; top: 65px; z-index: 2;
+  position: sticky; top: var(--app-sticky-top, 65px); z-index: 2;
   white-space: nowrap;
 }
 .data-table tbody tr { border-bottom: 1px solid var(--border); transition: background 0.1s; }
@@ -2304,6 +2305,7 @@ body {
   .charts-grid-4col { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-width: 768px) {
+  :root { --app-sticky-top: 58px; }
   .charts-grid-4col { grid-template-columns: 1fr; }
   .header { padding: 12px 16px; gap: 8px; }
   .header-info { gap: 8px; }
@@ -3884,16 +3886,16 @@ body {
   font-weight: 600; font-size: 11px; text-transform: uppercase;
   letter-spacing: 0.5px; color: var(--text-muted);
   border-bottom: 1px solid var(--border);
-  /* Offset by the 65px sticky page header (same rationale as
+  /* Offset by the sticky page header (same rationale as
      .compare-table th). */
-  position: sticky; top: 65px;
+  position: sticky; top: var(--app-sticky-top, 65px);
   white-space: nowrap; z-index: 2;
 }
 /* Top-left intersection: must out-stack the sticky-left body cells
    (z-index:1 below) so the "Biomarker" label isn't repainted by
    scrolled body rows like "LDH" or "Glucose". */
 .heatmap-table thead th:first-child {
-  position: sticky; left: 0; top: 65px; z-index: 3;
+  position: sticky; left: 0; top: var(--app-sticky-top, 65px); z-index: 3;
 }
 .heatmap-table td {
   padding: 8px 12px; text-align: center; cursor: pointer;
@@ -3956,8 +3958,8 @@ body {
   letter-spacing: 0.5px; color: var(--text-muted);
   border-bottom: 1px solid var(--border); white-space: nowrap;
   /* Stick to the page scroll context, offset by the sticky page header
-     (65px tall) so it doesn't slide behind it. */
-  position: sticky; top: 65px; z-index: 2;
+     so it doesn't slide behind it. */
+  position: sticky; top: var(--app-sticky-top, 65px); z-index: 2;
 }
 .compare-table td {
   padding: 10px 14px; border-bottom: 1px solid var(--border);
@@ -4017,7 +4019,7 @@ body {
   .gb-table-sticky-head {
     display: block;
     position: sticky;
-    top: 65px;
+    top: var(--app-sticky-top, 65px);
     height: 0;
     overflow: visible;
     z-index: 20;

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
-const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
+const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/settings.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
 const readCssBundle = () => CSS_FILES.map(read).join('\n');
 
 let passed = 0, failed = 0;

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -26,7 +26,7 @@ return (async function () {
     catch (e) { return ''; }
   }
   async function fetchCssBundle() {
-    const files = ['styles.css', 'css/modal-shared.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
+    const files = ['styles.css', 'css/modal-shared.css', 'css/settings.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
     return (await Promise.all(files.map(fetchSrc))).join('\n');
   }
   function delay(ms) { return new Promise(r => setTimeout(r, ms)); }

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
-const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
+const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/settings.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
 const readCssBundle = () => CSS_FILES.map(read).join('\n');
 
 let pass = 0, fail = 0;
@@ -59,6 +59,8 @@ assert('SW uses importScripts for version', swAuditSrc.includes("importScripts('
 assert('SW CACHE_NAME uses semver', swAuditSrc.includes('`labcharts-v${self.APP_VERSION}`'));
 assert('index loads shared modal CSS bundle', indexSrc.includes('href="css/modal-shared.css"'));
 assert('SW APP_SHELL includes shared modal CSS bundle', swAuditSrc.includes("'/css/modal-shared.css'"));
+assert('index loads settings CSS bundle', indexSrc.includes('href="css/settings.css"'));
+assert('SW APP_SHELL includes settings CSS bundle', swAuditSrc.includes("'/css/settings.css'"));
 assert('index loads client list CSS bundle', indexSrc.includes('href="css/client-list.css"'));
 assert('SW APP_SHELL includes client list CSS bundle', swAuditSrc.includes("'/css/client-list.css'"));
 assert('index loads mobile dashboard CSS bundle', indexSrc.includes('href="css/mobile-dashboard.css"'));

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -25,7 +25,7 @@ const tools = await import('../js/light-tools.js');
     normalizeGoldenHourMinutes,
     } = tools;
     const lightToolsSrc = fs.readFileSync(new URL('../js/light-tools.js', import.meta.url), 'utf8');
-    const cssFiles = ['styles.css', 'css/modal-shared.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
+    const cssFiles = ['styles.css', 'css/modal-shared.css', 'css/settings.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
     const stylesSrc = cssFiles.map(rel => fs.readFileSync(new URL('../' + rel, import.meta.url), 'utf8')).join('\n');
     const appearsBefore = (needleA, needleB, from = 0) => {
       const a = lightToolsSrc.indexOf(needleA, from);

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
-const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
+const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/settings.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
 const readCssBundle = () => CSS_FILES.map(read).join('\n');
 
 let pass = 0, fail = 0;

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -784,14 +784,40 @@ async function checkMobileInteractions(page, theme, viewportName) {
         { timeout: 2500 }
       ).catch(() => {});
     }
-    result = await page.evaluate((tab) => {
+    result = await page.evaluate((tab, theme) => {
       const active = document.querySelector(`#mobile-bottom-tabs .m-tab[data-tab="${tab}"], .m-tabbar .m-tab[data-tab="${tab}"]`);
       const conditionsGrid = document.querySelector('.lens-page-widgets[data-lens-route="light"] .conditions-now-grid') || document.querySelector('.conditions-now-grid');
       const supportColumns = conditionsGrid
         ? getComputedStyle(conditionsGrid).gridTemplateColumns.split(' ').filter(Boolean).length
         : 0;
+      const shadowReach = (boxShadow) => {
+        const lengths = String(boxShadow || '').match(/-?\d+(?:\.\d+)?px/g)?.map(v => Number(v.replace('px', ''))) || [];
+        const reach = { left: 0, right: 0 };
+        for (let i = 0; i < lengths.length; i += 4) {
+          const offsetX = lengths[i] || 0;
+          const blur = lengths[i + 2] || 0;
+          const spread = lengths[i + 3] || 0;
+          const extent = Math.max(0, blur + spread);
+          reach.left = Math.max(reach.left, -offsetX + extent);
+          reach.right = Math.max(reach.right, offsetX + extent);
+        }
+        return reach;
+      };
+      const tabbar = document.querySelector('.m-tabbar');
+      const tabbarStyle = tabbar ? getComputedStyle(tabbar) : null;
+      const tabbarRect = tabbar?.getBoundingClientRect();
+      const fab = document.querySelector('.m-chat-fab');
+      const fabStyle = fab ? getComputedStyle(fab) : null;
+      const fabRect = fab?.getBoundingClientRect();
       const lightWidgetRoute = document.querySelector('.lens-page-widgets[data-lens-route="light"]');
       const viewportWidth = document.documentElement.clientWidth;
+      const tabbarPaint = shadowReach(tabbarStyle?.boxShadow);
+      const fabPaint = shadowReach(fabStyle?.boxShadow);
+      const terminalTheme = theme === 'cyberterm' || theme === 'neuromancer';
+      window.scrollTo(0, Math.min(620, document.scrollingElement.scrollHeight));
+      const tabbarAfterY = tabbar?.getBoundingClientRect();
+      window.scrollTo(80, window.scrollY);
+      const tabbarAfterX = tabbar?.getBoundingClientRect();
       const sessionWidget = document.querySelector('.dashboard-widget[data-widget-id="light-sessions"]');
       const sessionRows = Array.from(sessionWidget?.querySelectorAll('.sun-session') || []);
       const overflowingSessionRows = sessionRows.filter(row => {
@@ -807,6 +833,25 @@ async function checkMobileInteractions(page, theme, viewportName) {
         hasBottomTabs: !!document.querySelector('#mobile-bottom-tabs, .m-shell .m-tabbar'),
         currentView: window._labState?.currentView,
         visibleMain: document.getElementById('main-content')?.textContent?.trim().length > 40,
+        tabbarFixed: tabbarStyle?.position === 'fixed',
+        tabbarContained: !!tabbarRect && tabbarRect.left >= -1 && tabbarRect.right <= viewportWidth + 1,
+        tabbarStable:
+          !!tabbarRect &&
+          !!tabbarAfterY &&
+          !!tabbarAfterX &&
+          Math.abs(tabbarAfterY.top - tabbarRect.top) <= 1 &&
+          Math.abs(tabbarAfterX.left - tabbarRect.left) <= 1,
+        bottomChromePaintContained: !terminalTheme || (
+          !!tabbarRect &&
+          tabbarRect.left - tabbarPaint.left >= -1 &&
+          tabbarRect.right + tabbarPaint.right <= viewportWidth + 1 &&
+          (!fabRect || (
+            fabRect.left - fabPaint.left >= -1 &&
+            fabRect.right + fabPaint.right <= viewportWidth + 1
+          ))
+        ),
+        tabbarPaint,
+        fabPaint,
         lightWidgetRoute: !!lightWidgetRoute,
         lightWidgetCount: lightWidgetRoute?.querySelectorAll('.dashboard-widget[data-widget-id^="light-"]').length || 0,
         lightMoveControls: lightWidgetRoute?.querySelectorAll('.dashboard-widget-tool[aria-label^="Move page section"]').length || 0,
@@ -824,19 +869,23 @@ async function checkMobileInteractions(page, theme, viewportName) {
           getComputedStyle(sessionWidget.querySelector('.light-session-device .light-session-kind')).whiteSpace !== 'nowrap',
         supportColumns,
       };
-    }, tab);
+    }, tab, theme);
     assert(testName(theme, viewportName, `tab ${tab} navigates and stays active`),
       result.active && result.hasBottomTabs && result.visibleMain,
       JSON.stringify(result));
-	    if (tab === 'light') {
-		      assert(testName(theme, viewportName, 'light page uses separate mobile operation widgets'),
-		        result.lightWidgetRoute && result.lightWidgetCount >= 3 && result.lightMoveControls >= 1 &&
-		          result.lightSeparatedOps && result.lightDashboardToggles && result.supportColumns >= 3,
-		        JSON.stringify(result));
-		      assert(testName(theme, viewportName, 'light sessions fit mobile viewport'),
-		        result.lightSessionRows >= 3 && result.lightSessionOverflow === 0 &&
-		          result.horizontalOverflow <= 1 && result.longDeviceKindWraps,
-		        JSON.stringify(result));
+    assert(testName(theme, viewportName, `tab ${tab} keeps mobile nav fixed and clipped`),
+      result.tabbarFixed && result.tabbarContained && result.tabbarStable &&
+        result.horizontalOverflow <= 1 && result.bottomChromePaintContained,
+      JSON.stringify(result));
+    if (tab === 'light') {
+      assert(testName(theme, viewportName, 'light page uses separate mobile operation widgets'),
+        result.lightWidgetRoute && result.lightWidgetCount >= 3 && result.lightMoveControls >= 1 &&
+          result.lightSeparatedOps && result.lightDashboardToggles && result.supportColumns >= 3,
+        JSON.stringify(result));
+      assert(testName(theme, viewportName, 'light sessions fit mobile viewport'),
+        result.lightSessionRows >= 3 && result.lightSessionOverflow === 0 &&
+          result.horizontalOverflow <= 1 && result.longDeviceKindWraps,
+        JSON.stringify(result));
     }
   }
 }

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -385,9 +385,11 @@ async function evaluateBaseChecks(page, theme, viewport) {
       const fab = document.querySelector('.m-chat-fab');
       const desktopChatFab = document.getElementById('chat-fab');
       ok('mobile dashboard shell is active', document.body.classList.contains('mobile-dashboard-active'));
+      ok('mobile chrome root mirrors dashboard state', document.documentElement.classList.contains('mobile-dashboard-active'));
       ok('mobile shell is visible', visible(shell));
       ok('mobile tabbar is visible', visible(tabbar));
       ok('mobile tabbar is contained in viewport', tabbar && inViewport(tabbar, 2));
+      ok('mobile dashboard tabbar is outside clipped shell', tabbar && !tabbar.closest('.m-shell'));
       ok('mobile chat FAB is visible and above tabbar', visible(fab) && tabbar && rect(fab).bottom < rect(tabbar).top);
       ok('desktop chat FAB hidden inside mobile shell', !visible(desktopChatFab));
       ok('donate button hidden on mobile', !visible(document.querySelector('.donate-btn')));
@@ -702,6 +704,23 @@ async function checkMobileInteractions(page, theme, viewportName) {
   await page.evaluate(() => window.closeMobileSidebar?.());
   await delay(100);
 
+  result = await page.evaluate(() => {
+    const root = document.documentElement;
+    const tabbar = document.querySelector('.m-tabbar');
+    const before = tabbar?.getBoundingClientRect();
+    root.style.setProperty('--mobile-visual-bottom-offset', '48px');
+    const shifted = tabbar?.getBoundingClientRect();
+    root.style.removeProperty('--mobile-visual-bottom-offset');
+    return {
+      rootDashboardActive: root.classList.contains('mobile-dashboard-active'),
+      tabbarOutsideShell: !!tabbar && !tabbar.closest('.m-shell'),
+      movedUp: !!before && !!shifted && before.bottom - shifted.bottom >= 47,
+    };
+  });
+  assert(testName(theme, viewportName, 'mobile nav respects visual viewport offset'),
+    result.rootDashboardActive && result.tabbarOutsideShell && result.movedUp,
+    JSON.stringify(result));
+
   await page.evaluate(() => window.openTweaksPanel?.());
   await delay(150);
   result = await page.evaluate((theme) => {
@@ -833,6 +852,8 @@ async function checkMobileInteractions(page, theme, viewportName) {
         hasBottomTabs: !!document.querySelector('#mobile-bottom-tabs, .m-shell .m-tabbar'),
         currentView: window._labState?.currentView,
         visibleMain: document.getElementById('main-content')?.textContent?.trim().length > 40,
+        rootTabsActive: document.documentElement.classList.contains('mobile-tabs-active'),
+        tabbarOutsideShell: !!tabbar && !tabbar.closest('.m-shell'),
         tabbarFixed: tabbarStyle?.position === 'fixed',
         tabbarContained: !!tabbarRect && tabbarRect.left >= -1 && tabbarRect.right <= viewportWidth + 1,
         tabbarStable:
@@ -874,7 +895,8 @@ async function checkMobileInteractions(page, theme, viewportName) {
       result.active && result.hasBottomTabs && result.visibleMain,
       JSON.stringify(result));
     assert(testName(theme, viewportName, `tab ${tab} keeps mobile nav fixed and clipped`),
-      result.tabbarFixed && result.tabbarContained && result.tabbarStable &&
+      result.rootTabsActive && result.tabbarOutsideShell &&
+        result.tabbarFixed && result.tabbarContained && result.tabbarStable &&
         result.horizontalOverflow <= 1 && result.bottomChromePaintContained,
       JSON.stringify(result));
     if (tab === 'light') {

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -389,8 +389,6 @@ async function evaluateBaseChecks(page, theme, viewport) {
       ok('mobile shell is visible', visible(shell));
       ok('mobile tabbar is visible', visible(tabbar));
       ok('mobile tabbar is contained in viewport', tabbar && inViewport(tabbar, 2));
-      ok('mobile tabbar keeps comfortable side gutters',
-        tabbar && rect(tabbar).left >= 14 && window.innerWidth - rect(tabbar).right >= 14);
       ok('mobile dashboard tabbar is outside clipped shell', tabbar && !tabbar.closest('.m-shell'));
       ok('mobile chat FAB is visible and above tabbar', visible(fab) && tabbar && rect(fab).bottom < rect(tabbar).top);
       ok('desktop chat FAB hidden inside mobile shell', !visible(desktopChatFab));
@@ -785,10 +783,13 @@ async function checkMobileInteractions(page, theme, viewportName) {
       return {
         open: overlay.classList.contains('show'),
         contained: r.left >= -1 && r.right <= window.innerWidth + 1 && r.top >= -1 && r.bottom <= window.innerHeight + 1,
+        sideGutters: r.left >= 12 && window.innerWidth - r.right >= 12,
       };
     });
     assert(testName(theme, viewportName, 'mobile widget marker opens marker modal'), result.open, JSON.stringify(result));
-    assert(testName(theme, viewportName, 'mobile marker modal fits phone viewport'), result.contained, JSON.stringify(result));
+    assert(testName(theme, viewportName, 'mobile marker modal fits phone viewport'),
+      result.contained && result.sideGutters,
+      JSON.stringify(result));
     await page.evaluate(() => window.closeModal?.());
     await delay(100);
   }
@@ -858,9 +859,6 @@ async function checkMobileInteractions(page, theme, viewportName) {
         tabbarOutsideShell: !!tabbar && !tabbar.closest('.m-shell'),
         tabbarFixed: tabbarStyle?.position === 'fixed',
         tabbarContained: !!tabbarRect && tabbarRect.left >= -1 && tabbarRect.right <= viewportWidth + 1,
-        tabbarComfortableGutters: !!tabbarRect &&
-          tabbarRect.left >= 14 &&
-          viewportWidth - tabbarRect.right >= 14,
         tabbarStable:
           !!tabbarRect &&
           !!tabbarAfterY &&
@@ -879,6 +877,12 @@ async function checkMobileInteractions(page, theme, viewportName) {
         tabbarPaint,
         fabPaint,
         lightWidgetRoute: !!lightWidgetRoute,
+        pageSurfaceGutters: (() => {
+          const surface = document.querySelector('.lens-page-widgets .dashboard-widget, .category-header, #recommendations-page');
+          if (!surface) return true;
+          const sr = surface.getBoundingClientRect();
+          return sr.left >= 12 && viewportWidth - sr.right >= 12;
+        })(),
         lightWidgetCount: lightWidgetRoute?.querySelectorAll('.dashboard-widget[data-widget-id^="light-"]').length || 0,
         lightMoveControls: lightWidgetRoute?.querySelectorAll('.dashboard-widget-tool[aria-label^="Move page section"]').length || 0,
         lightSeparatedOps: !!document.querySelector('.dashboard-widget[data-widget-id="light-conditions-now"] .light-conditions-now-wrap')
@@ -901,8 +905,11 @@ async function checkMobileInteractions(page, theme, viewportName) {
       JSON.stringify(result));
     assert(testName(theme, viewportName, `tab ${tab} keeps mobile nav fixed and clipped`),
       result.rootTabsActive && result.tabbarOutsideShell &&
-        result.tabbarFixed && result.tabbarContained && result.tabbarComfortableGutters && result.tabbarStable &&
+        result.tabbarFixed && result.tabbarContained && result.tabbarStable &&
         result.horizontalOverflow <= 1 && result.bottomChromePaintContained,
+      JSON.stringify(result));
+    assert(testName(theme, viewportName, `tab ${tab} keeps page surfaces inset`),
+      result.pageSurfaceGutters,
       JSON.stringify(result));
     if (tab === 'light') {
       assert(testName(theme, viewportName, 'light page uses separate mobile operation widgets'),

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -389,6 +389,8 @@ async function evaluateBaseChecks(page, theme, viewport) {
       ok('mobile shell is visible', visible(shell));
       ok('mobile tabbar is visible', visible(tabbar));
       ok('mobile tabbar is contained in viewport', tabbar && inViewport(tabbar, 2));
+      ok('mobile tabbar keeps comfortable side gutters',
+        tabbar && rect(tabbar).left >= 14 && window.innerWidth - rect(tabbar).right >= 14);
       ok('mobile dashboard tabbar is outside clipped shell', tabbar && !tabbar.closest('.m-shell'));
       ok('mobile chat FAB is visible and above tabbar', visible(fab) && tabbar && rect(fab).bottom < rect(tabbar).top);
       ok('desktop chat FAB hidden inside mobile shell', !visible(desktopChatFab));
@@ -856,6 +858,9 @@ async function checkMobileInteractions(page, theme, viewportName) {
         tabbarOutsideShell: !!tabbar && !tabbar.closest('.m-shell'),
         tabbarFixed: tabbarStyle?.position === 'fixed',
         tabbarContained: !!tabbarRect && tabbarRect.left >= -1 && tabbarRect.right <= viewportWidth + 1,
+        tabbarComfortableGutters: !!tabbarRect &&
+          tabbarRect.left >= 14 &&
+          viewportWidth - tabbarRect.right >= 14,
         tabbarStable:
           !!tabbarRect &&
           !!tabbarAfterY &&
@@ -896,7 +901,7 @@ async function checkMobileInteractions(page, theme, viewportName) {
       JSON.stringify(result));
     assert(testName(theme, viewportName, `tab ${tab} keeps mobile nav fixed and clipped`),
       result.rootTabsActive && result.tabbarOutsideShell &&
-        result.tabbarFixed && result.tabbarContained && result.tabbarStable &&
+        result.tabbarFixed && result.tabbarContained && result.tabbarComfortableGutters && result.tabbarStable &&
         result.horizontalOverflow <= 1 && result.bottomChromePaintContained,
       JSON.stringify(result));
     if (tab === 'light') {

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -708,6 +708,8 @@ async function checkMobileInteractions(page, theme, viewportName) {
     const panel = document.getElementById('tweaks-panel');
     const overlay = document.getElementById('tweaks-panel-overlay');
     const r = panel?.getBoundingClientRect();
+    const body = panel?.querySelector('.tweaks-body');
+    const bodyRect = body?.getBoundingClientRect();
     const viewportWidth = document.documentElement.clientWidth;
     const shadowRightReach = (boxShadow) => {
       const lengths = String(boxShadow || '').match(/-?\d+(?:\.\d+)?px/g)?.map(v => Number(v.replace('px', ''))) || [];
@@ -734,6 +736,8 @@ async function checkMobileInteractions(page, theme, viewportName) {
       contained: !!r && r.left >= -1 && r.right <= viewportWidth + 1 && r.top >= -1 && r.bottom <= window.innerHeight + 1,
       leftGutter: r ? r.left : -1,
       rightGutter: r ? viewportWidth - r.right : -1,
+      bodyContained: !!r && !!bodyRect && bodyRect.left >= r.left - 1 && bodyRect.right <= r.right + 1 && bodyRect.bottom <= r.bottom + 1,
+      bodyScrollLocked: document.body.style.overflow === 'hidden',
       horizontalOverflow: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth) - viewportWidth,
       overflowingChildren,
       rightShadowReach,
@@ -742,7 +746,8 @@ async function checkMobileInteractions(page, theme, viewportName) {
   }, theme);
   assert(testName(theme, viewportName, 'mobile tweaks panel fits viewport'),
     result.open && result.contained && result.leftGutter >= 12 && result.rightGutter >= 12 &&
-      result.horizontalOverflow <= 1 && result.overflowingChildren === 0 && result.terminalShadowContained,
+      result.bodyContained && result.bodyScrollLocked && result.horizontalOverflow <= 1 &&
+      result.overflowingChildren === 0 && result.terminalShadowContained,
     JSON.stringify(result));
   await page.evaluate(() => window.closeTweaksPanel?.());
   await delay(100);

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -704,11 +704,25 @@ async function checkMobileInteractions(page, theme, viewportName) {
 
   await page.evaluate(() => window.openTweaksPanel?.());
   await delay(150);
-  result = await page.evaluate(() => {
+  result = await page.evaluate((theme) => {
     const panel = document.getElementById('tweaks-panel');
     const overlay = document.getElementById('tweaks-panel-overlay');
     const r = panel?.getBoundingClientRect();
     const viewportWidth = document.documentElement.clientWidth;
+    const shadowRightReach = (boxShadow) => {
+      const lengths = String(boxShadow || '').match(/-?\d+(?:\.\d+)?px/g)?.map(v => Number(v.replace('px', ''))) || [];
+      let reach = 0;
+      for (let i = 0; i < lengths.length; i += 4) {
+        const offsetX = lengths[i] || 0;
+        const blur = lengths[i + 2] || 0;
+        const spread = lengths[i + 3] || 0;
+        reach = Math.max(reach, offsetX + Math.max(0, blur + spread));
+      }
+      return reach;
+    };
+    const panelStyle = panel ? getComputedStyle(panel) : null;
+    const rightShadowReach = shadowRightReach(panelStyle?.boxShadow);
+    const terminalTweakTheme = theme === 'cyberterm' || theme === 'neuromancer';
     const overflowingChildren = panel
       ? Array.from(panel.querySelectorAll('*')).filter(child => {
         const childRect = child.getBoundingClientRect();
@@ -718,12 +732,17 @@ async function checkMobileInteractions(page, theme, viewportName) {
     return {
       open: !!panel && overlay?.classList.contains('show'),
       contained: !!r && r.left >= -1 && r.right <= viewportWidth + 1 && r.top >= -1 && r.bottom <= window.innerHeight + 1,
+      leftGutter: r ? r.left : -1,
+      rightGutter: r ? viewportWidth - r.right : -1,
       horizontalOverflow: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth) - viewportWidth,
       overflowingChildren,
+      rightShadowReach,
+      terminalShadowContained: !terminalTweakTheme || (!!r && r.right + rightShadowReach <= viewportWidth + 1),
     };
-  });
+  }, theme);
   assert(testName(theme, viewportName, 'mobile tweaks panel fits viewport'),
-    result.open && result.contained && result.horizontalOverflow <= 1 && result.overflowingChildren === 0,
+    result.open && result.contained && result.leftGutter >= 12 && result.rightGutter >= 12 &&
+      result.horizontalOverflow <= 1 && result.overflowingChildren === 0 && result.terminalShadowContained,
     JSON.stringify(result));
   await page.evaluate(() => window.closeTweaksPanel?.());
   await delay(100);

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -837,6 +837,9 @@ async function checkMobileInteractions(page, theme, viewportName) {
       const fabPaint = shadowReach(fabStyle?.boxShadow);
       const terminalTheme = theme === 'cyberterm' || theme === 'neuromancer';
       window.scrollTo(0, Math.min(620, document.scrollingElement.scrollHeight));
+      const header = document.querySelector('.header');
+      const headerStyle = header ? getComputedStyle(header) : null;
+      const headerRect = header?.getBoundingClientRect();
       const tabbarAfterY = tabbar?.getBoundingClientRect();
       window.scrollTo(80, window.scrollY);
       const tabbarAfterX = tabbar?.getBoundingClientRect();
@@ -856,6 +859,12 @@ async function checkMobileInteractions(page, theme, viewportName) {
         currentView: window._labState?.currentView,
         visibleMain: document.getElementById('main-content')?.textContent?.trim().length > 40,
         rootTabsActive: document.documentElement.classList.contains('mobile-tabs-active'),
+        headerSticky:
+          headerStyle?.position === 'sticky' &&
+          !!headerRect &&
+          Math.abs(headerRect.top) <= 1 &&
+          headerRect.bottom >= 56 &&
+          getComputedStyle(document.body).overflowX === 'visible',
         tabbarOutsideShell: !!tabbar && !tabbar.closest('.m-shell'),
         tabbarFixed: tabbarStyle?.position === 'fixed',
         tabbarContained: !!tabbarRect && tabbarRect.left >= -1 && tabbarRect.right <= viewportWidth + 1,
@@ -908,6 +917,9 @@ async function checkMobileInteractions(page, theme, viewportName) {
         result.tabbarFixed && result.tabbarContained && result.tabbarStable &&
         result.horizontalOverflow <= 1 && result.bottomChromePaintContained,
       JSON.stringify(result));
+    assert(testName(theme, viewportName, `tab ${tab} keeps top header sticky`),
+      result.headerSticky,
+      JSON.stringify(result));
     assert(testName(theme, viewportName, `tab ${tab} keeps page surfaces inset`),
       result.pageSurfaceGutters,
       JSON.stringify(result));
@@ -921,6 +933,49 @@ async function checkMobileInteractions(page, theme, viewportName) {
           result.horizontalOverflow <= 1 && result.longDeviceKindWraps,
         JSON.stringify(result));
     }
+  }
+
+  await page.evaluate(() => {
+    window.scrollTo(0, 0);
+    window.showCategory?.('biochemistry');
+  });
+  await page.waitForSelector('.category-header');
+  for (const view of ['table', 'heatmap']) {
+    await page.evaluate((view) => {
+      const btns = document.querySelectorAll('.view-toggle .view-btn');
+      const btn = btns[view === 'table' ? 1 : 2];
+      window.switchView?.(view, 'biochemistry', btn);
+      window.scrollTo(0, 0);
+    }, view);
+    await page.waitForSelector(`.gb-table-shell-${view === 'table' ? 'data' : 'heatmap'} .gb-table-sticky-head`);
+    await delay(120);
+    result = await page.evaluate(() => {
+      const maxScroll = Math.max(0, document.scrollingElement.scrollHeight - window.innerHeight);
+      window.scrollTo(0, Math.min(560, maxScroll));
+      const headerRect = document.querySelector('.header')?.getBoundingClientRect();
+      const stickyHead = document.querySelector('.gb-table-sticky-head');
+      const stickyRect = stickyHead?.getBoundingClientRect();
+      const stickyCellRect = stickyHead?.querySelector('th')?.getBoundingClientRect();
+      const realHeadRect = document.querySelector('.data-table-wrapper thead, .heatmap-wrapper thead')?.getBoundingClientRect();
+      const viewportWidth = document.documentElement.clientWidth;
+      return {
+        scrolled: window.scrollY > 120,
+        topHeaderSticky: !!headerRect && Math.abs(headerRect.top) <= 1 && headerRect.bottom >= 56,
+        stickyHeadVisible:
+          !!headerRect &&
+          !!stickyRect &&
+          !!stickyCellRect &&
+          stickyRect.top >= headerRect.bottom - 1 &&
+          stickyRect.top <= headerRect.bottom + 4 &&
+          stickyCellRect.bottom > headerRect.bottom + 20,
+        realHeadScrolledAway: !!realHeadRect && realHeadRect.bottom < headerRect.bottom,
+        horizontalOverflow: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth) - viewportWidth,
+      };
+    });
+    assert(testName(theme, viewportName, `category ${view} header sticks below top header`),
+      result.scrolled && result.topHeaderSticky && result.stickyHeadVisible &&
+        result.realHeadScrolledAway && result.horizontalOverflow <= 1,
+      JSON.stringify(result));
   }
 }
 

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -702,6 +702,32 @@ async function checkMobileInteractions(page, theme, viewportName) {
   await page.evaluate(() => window.closeMobileSidebar?.());
   await delay(100);
 
+  await page.evaluate(() => window.openTweaksPanel?.());
+  await delay(150);
+  result = await page.evaluate(() => {
+    const panel = document.getElementById('tweaks-panel');
+    const overlay = document.getElementById('tweaks-panel-overlay');
+    const r = panel?.getBoundingClientRect();
+    const viewportWidth = document.documentElement.clientWidth;
+    const overflowingChildren = panel
+      ? Array.from(panel.querySelectorAll('*')).filter(child => {
+        const childRect = child.getBoundingClientRect();
+        return childRect.left < -1 || childRect.right > viewportWidth + 1;
+      }).length
+      : -1;
+    return {
+      open: !!panel && overlay?.classList.contains('show'),
+      contained: !!r && r.left >= -1 && r.right <= viewportWidth + 1 && r.top >= -1 && r.bottom <= window.innerHeight + 1,
+      horizontalOverflow: Math.max(document.body.scrollWidth, document.documentElement.scrollWidth) - viewportWidth,
+      overflowingChildren,
+    };
+  });
+  assert(testName(theme, viewportName, 'mobile tweaks panel fits viewport'),
+    result.open && result.contained && result.horizontalOverflow <= 1 && result.overflowingChildren === 0,
+    JSON.stringify(result));
+  await page.evaluate(() => window.closeTweaksPanel?.());
+  await delay(100);
+
   const quickMarker = await page.$('.m-dashboard-widgets .dashboard-widget[data-widget-id="quick-markers"] .db-quick-marker-tile');
   assert(testName(theme, viewportName, 'mobile has tappable widget marker'), !!quickMarker);
   if (quickMarker) {

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -22,7 +22,7 @@ function fetchSrc(rel) {
   try { return fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8'); }
   catch (_) { return ''; }
 }
-const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
+const CSS_FILES = ['styles.css', 'css/modal-shared.css', 'css/settings.css', 'css/mobile-dashboard.css', 'css/cycle.css', 'css/marker-detail-modal.css', 'css/client-list.css', 'css/wearables.css', 'css/light-sun.css', 'css/chat-panel.css', 'css/redesign-shell.css', 'css/redesign-chat.css'];
 function fetchCssSrc() { return CSS_FILES.map(fetchSrc).join('\n'); }
 
 console.log('=== v1.6.7–v1.6.16 Regression Tests ===\n');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.204';
+self.APP_VERSION = '1.8.205';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.206';
+self.APP_VERSION = '1.8.207';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.203';
+self.APP_VERSION = '1.8.204';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.205';
+self.APP_VERSION = '1.8.206';


### PR DESCRIPTION
## Summary
- Move settings modal, tabs, theme picker, imported-entry, privacy, and sync tombstone styles into `css/settings.css`.
- Keep shared provider/API key/local AI styles in `styles.css`, with only settings-scoped overrides in the new bundle.
- Load and precache the new CSS bundle, update CSS bundle tests/docs, and bump the app version to `1.8.207`.
- Fix mobile terminal-theme bottom navigation so it is root-anchored, clipped against horizontal panning, and adjusted for the visual viewport.
- Restore mobile page/widget side gutters and marker modal gutters outside the dashboard route.
- Restore sticky mobile app headers and category table/heatmap headers while preserving horizontal overflow clipping.

## Validation
- `git diff --check`
- `node tests/test-theme-responsive-e2e.js`
- `node tests/test-audit.js`
- `node tests/test-changelog.js`
- `node tests/test-prelab.js`
- `node tests/test-a11y-phase3.js`
- `node tests/test-light-tools.js`
- `node tests/test-v1-6-shipped.js`
- `./run-tests.sh`