### PR TITLE
Improve EMF assessment discoverability

### DIFF
--- a/css/context-profile.css
+++ b/css/context-profile.css
@@ -177,6 +177,13 @@
   font-weight: 800;
   white-space: nowrap;
 }
+.ctx-emf-launcher.has-data {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-card));
+}
+.ctx-emf-launcher.has-data .ctx-emf-launcher-mark {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
 /* Button-group selector (replaces native <select>) */
 .ctx-btn-group { display: flex; flex-wrap: wrap; gap: 6px; }
 .ctx-btn-option {

--- a/css/context-profile.css
+++ b/css/context-profile.css
@@ -113,6 +113,70 @@
   font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
   color: var(--text-muted); margin-bottom: 8px; display: block;
 }
+.ctx-emf-launcher {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.ctx-emf-launcher:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+.ctx-emf-launcher:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.ctx-emf-launcher-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+.ctx-emf-launcher-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.ctx-emf-launcher-kicker {
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.ctx-emf-launcher-copy strong {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.ctx-emf-launcher-copy span:last-child {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.ctx-emf-launcher-action {
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
 /* Button-group selector (replaces native <select>) */
 .ctx-btn-group { display: flex; flex-wrap: wrap; gap: 6px; }
 .ctx-btn-option {

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -2,7 +2,7 @@
 
 import { state } from './state.js';
 import { COMMON_CONDITIONS, DIET_TYPES, DIET_RESTRICTIONS, DIET_PATTERNS, BOWEL_FREQUENCY, STOOL_CONSISTENCY, BLOATING_SEVERITY, GAS_SEVERITY, ACID_REFLUX, BURPING, NAUSEA, APPETITE, ABDOMINAL_PAIN, FOOD_SENSITIVITIES, EXERCISE_FREQ, EXERCISE_TYPES, EXERCISE_INTENSITY, DAILY_MOVEMENT, SLEEP_DURATIONS, SLEEP_QUALITY, SLEEP_SCHEDULE, SLEEP_ROOM_TEMP, SLEEP_ISSUES, SLEEP_ENVIRONMENT, SLEEP_PRACTICES, LIGHT_AM, LIGHT_DAYTIME, LIGHT_UV, LIGHT_EVENING, LIGHT_COLD, LIGHT_GROUNDING, LIGHT_SCREEN_TIME, LIGHT_TECH_ENV, LIGHT_MEAL_TIMING, STRESS_LEVELS, STRESS_SOURCES, STRESS_MGMT, LOVE_STATUS, LOVE_SATISFACTION, LOVE_LIBIDO, LOVE_FREQUENCY, LOVE_ORGASM, LOVE_RELATIONSHIP, LOVE_CONCERNS, ENV_SETTING, ENV_CLIMATE, ENV_WATER, ENV_WATER_CONCERNS, ENV_EMF, ENV_EMF_MITIGATION, ENV_HOME_LIGHT, ENV_AIR, ENV_TOXINS, ENV_BUILDING } from './constants.js';
-import { escapeHTML, hashString, showNotification, hasCardContent } from './utils.js';
+import { escapeHTML, escapeAttr, hashString, showNotification, hasCardContent } from './utils.js';
 import { formatTime, getTimeFormat, parseTimeInput } from './theme.js';
 import { saveImportedData, getActiveData } from './data.js';
 import { getLatitudeFromLocation, profileStorageKey } from './profile.js';
@@ -18,14 +18,19 @@ import { getFolderBackupState } from './backup.js';
 import { getEMFSeverity, trackUsage } from './schema.js';
 import { scanDietForContaminants } from './food-contaminants.js';
 
+function getEMFAssessments() {
+  const assessments = state.importedData.emfAssessment?.assessments;
+  return Array.isArray(assessments) ? assessments : [];
+}
+
 function getEMFSummary() {
-  const emf = state.importedData.emfAssessment;
-  if (!emf || !emf.assessments || emf.assessments.length === 0) return '';
-  const sorted = [...emf.assessments].sort((a, b) => b.date.localeCompare(a.date));
+  const assessments = getEMFAssessments();
+  if (!assessments.length) return '';
+  const sorted = [...assessments].sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')));
   const latest = sorted[0];
   let worst = null, worstIdx = -1;
   const tierOrder = ['green', 'yellow', 'orange', 'red'];
-  for (const room of latest.rooms) {
+  for (const room of latest.rooms || []) {
     const sleeping = room.sleeping !== false;
     for (const [type, m] of Object.entries(room.measurements || {})) {
       if (m && m.value != null) {
@@ -34,8 +39,38 @@ function getEMFSummary() {
       }
     }
   }
-  const fmtDate = d => new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
-  return `EMF: ${sorted.length} assessment${sorted.length > 1 ? 's' : ''} (latest: ${fmtDate(latest.date)}${worst ? ', ' + worst.label : ''})`;
+  const fmtDate = d => {
+    const parsed = new Date(d + 'T00:00:00');
+    if (Number.isNaN(parsed.getTime())) return String(d || 'saved');
+    return parsed.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+  };
+  const latestText = latest.date ? fmtDate(latest.date) : 'saved';
+  return `EMF: ${sorted.length} assessment${sorted.length > 1 ? 's' : ''} (latest: ${latestText}${worst ? ', ' + worst.label : ''})`;
+}
+
+export function renderEMFAssessmentLauncher({ inModal = false, surface = 'environment-editor' } = {}) {
+  const assessments = getEMFAssessments();
+  const hasAssessments = assessments.length > 0;
+  const action = inModal
+    ? 'window.closeModal&&window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor(),100)'
+    : 'window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()';
+  const summary = hasAssessments
+    ? getEMFSummary()
+    : 'Room-by-room Baubiologie workflow with readings, photos, comparison, and AI interpretation.';
+  const kicker = hasAssessments
+    ? `${assessments.length} saved`
+    : 'Environment tool';
+  const title = hasAssessments ? 'Open EMF assessment' : 'Start EMF assessment';
+  const cta = hasAssessments ? 'Open' : 'Start';
+  return `<button type="button" class="ctx-emf-launcher${hasAssessments ? ' has-data' : ''}" onclick="${escapeAttr(action)}" data-umami-event="${escapeAttr('emf-launcher-' + surface)}">
+    <span class="ctx-emf-launcher-mark" aria-hidden="true">EMF</span>
+    <span class="ctx-emf-launcher-copy">
+      <span class="ctx-emf-launcher-kicker">${escapeHTML(kicker)}</span>
+      <strong>${escapeHTML(title)}</strong>
+      <span>${escapeHTML(summary)}</span>
+    </span>
+    <span class="ctx-emf-launcher-action">${escapeHTML(cta)}</span>
+  </button>`;
 }
 
 // ── Context card summary generators ──
@@ -161,19 +196,20 @@ export function getLoveLifeSummary(d) {
 }
 
 export function getEnvironmentSummary(d) {
-  if (!d) return '';
   const parts = [];
-  if (d.setting) parts.push(d.setting);
-  if (d.climate) parts.push(d.climate);
-  if (d.water) parts.push(d.water);
-  if (d.waterConcerns && d.waterConcerns.length) parts.push(d.waterConcerns.join(', '));
-  if (d.emf && d.emf.length) parts.push(d.emf.length + ' EMF source' + (d.emf.length > 1 ? 's' : ''));
-  if (d.emfMitigation && d.emfMitigation.length) parts.push(d.emfMitigation.length + ' EMF mitigation');
-  if (d.homeLight) parts.push(d.homeLight);
-  if (d.air && d.air.length) parts.push(d.air.join(', '));
-  if (d.toxins && d.toxins.length) parts.push(d.toxins.length + ' toxin exposure' + (d.toxins.length > 1 ? 's' : ''));
-  if (d.building) parts.push(d.building);
-  if (d.note) parts.push(d.note);
+  if (d) {
+    if (d.setting) parts.push(d.setting);
+    if (d.climate) parts.push(d.climate);
+    if (d.water) parts.push(d.water);
+    if (d.waterConcerns && d.waterConcerns.length) parts.push(d.waterConcerns.join(', '));
+    if (d.emf && d.emf.length) parts.push(d.emf.length + ' EMF source' + (d.emf.length > 1 ? 's' : ''));
+    if (d.emfMitigation && d.emfMitigation.length) parts.push(d.emfMitigation.length + ' EMF mitigation');
+    if (d.homeLight) parts.push(d.homeLight);
+    if (d.air && d.air.length) parts.push(d.air.join(', '));
+    if (d.toxins && d.toxins.length) parts.push(d.toxins.length + ' toxin exposure' + (d.toxins.length > 1 ? 's' : ''));
+    if (d.building) parts.push(d.building);
+    if (d.note) parts.push(d.note);
+  }
   const emfSummary = getEMFSummary();
   if (emfSummary) parts.push(emfSummary);
   return parts.join(', ');
@@ -190,6 +226,7 @@ export function getGoalsSummary() {
 
 export function isContextFilled(key) {
   if (key === 'healthGoals') return (state.importedData.healthGoals || []).length > 0;
+  if (key === 'environment') return state.importedData.environment != null || getEMFAssessments().length > 0;
   return state.importedData[key] != null;
 }
 
@@ -1228,6 +1265,7 @@ export function openEnvironmentEditor() {
   const modal = document.getElementById("detail-modal");
   const overlay = document.getElementById("modal-overlay");
   const current = state.importedData.environment || { setting: null, climate: null, water: null, waterConcerns: [], emf: [], emfMitigation: [], homeLight: null, air: [], toxins: [], building: null, note: '' };
+  const hasEMFAssessment = getEMFAssessments().length > 0;
   renderContextEditorModal(modal, 'Environment', 'Your environment shapes your biology — water quality, EMF, light, air, and toxin exposure directly impact mitochondria, inflammation, and hormone function.', `
     ${renderSelectField('Living setting', 'env-setting', ENV_SETTING, current.setting)}
     ${renderSelectField('Climate', 'env-climate', ENV_CLIMATE, current.climate)}
@@ -1235,17 +1273,12 @@ export function openEnvironmentEditor() {
     ${renderSelectField('Primary water source', 'env-water', ENV_WATER, current.water)}
     ${renderTagsField('Water concerns', 'env-water-concerns', ENV_WATER_CONCERNS, current.waterConcerns)}
     <div class="ctx-editor-divider"></div>
-    ${state.importedData.emfAssessment?.assessments?.length
-      ? `<div class="ctx-field-group">
-          <label class="ctx-field-label">EMF</label>
-          <div style="font-size:12px;color:var(--text-muted);margin-bottom:8px">${escapeHTML(getEMFSummary())}</div>
-          <button class="import-btn import-btn-secondary" onclick="closeModal();setTimeout(()=>openEMFAssessmentEditor(),100)">View EMF Assessment →</button>
-        </div>`
-      : `${renderTagsField('EMF exposure', 'env-emf', ENV_EMF, current.emf)}
-    ${renderTagsField('EMF mitigation', 'env-emf-mit', ENV_EMF_MITIGATION, current.emfMitigation)}
-    <div class="ctx-field-group" style="margin-top:8px">
-      <button class="import-btn import-btn-secondary" onclick="closeModal();setTimeout(()=>openEMFAssessmentEditor(),100)">Baubiologie EMF Assessment →</button>
-    </div>`}
+    <div class="ctx-field-group">
+      <label class="ctx-field-label">EMF</label>
+      ${renderEMFAssessmentLauncher({ inModal: true, surface: 'environment-editor' })}
+    </div>
+    ${hasEMFAssessment ? '' : `${renderTagsField('EMF exposure', 'env-emf', ENV_EMF, current.emf)}
+    ${renderTagsField('EMF mitigation', 'env-emf-mit', ENV_EMF_MITIGATION, current.emfMitigation)}`}
     <div class="ctx-editor-divider"></div>
     ${renderSelectField('Home/work lighting', 'env-light', ENV_HOME_LIGHT, current.homeLight)}
     ${renderTagsField('Air quality', 'env-air', ENV_AIR, current.air)}

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -190,6 +190,7 @@ export function createLensPageHandlers(deps) {
     const ctx = buildDashboardWidgetContext(rawData);
     let html = renderLensHeader('Insight', 'Dedicated synthesis workspace: AI focus, trend interpretation, context, and next-step surfaces.',
       `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="window.openChatPanel && window.openChatPanel()">Open AI chat</button>
+       <button type="button" class="dashboard-action-btn" onclick="window.openEMFAssessmentEditor && window.openEMFAssessmentEditor()">EMF assessment</button>
        <button type="button" class="dashboard-action-btn" onclick="window.navigate && window.navigate('recommendations')">Recommendations</button>`);
     html += renderLensPageWidgets('insight', [
       { id: 'focus', title: 'Current Focus', description: 'One synthesized read on the latest data', body: renderFocusCard(), size: 'full', opts: { source: 'Insight' } },

--- a/js/nav.js
+++ b/js/nav.js
@@ -151,24 +151,21 @@ export function buildSidebar(data) {
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('compare')}</span><span class="nav-item-label">Compare dates</span><span class="nav-item-dot"></span></div>`;
   html += `<div class="nav-item" data-category="correlations" tabindex="0" role="button" onclick="window.navigate('correlations')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('correlations')}">
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('correlations')}</span><span class="nav-item-label">Correlations</span><span class="nav-item-dot"></span></div>`;
+  const emfAssessments = state.importedData?.emfAssessment?.assessments;
+  const emfAssessmentCount = Array.isArray(emfAssessments) ? emfAssessments.length : 0;
+  html += _renderConditionalNavItem({
+    key: 'emf',
+    icon: 'emf',
+    label: 'EMF assessment',
+    navigate: 'fn:window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()',
+    badge: emfAssessmentCount > 0 ? emfAssessmentCount : null,
+  });
 
   html += `<div class="nav-section">Manage</div>`;
   html += `<div class="nav-item" data-category="knowledge" tabindex="0" role="button" onclick="window.openKnowledgeBaseModal&&window.openKnowledgeBaseModal()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('knowledge')}</span><span class="nav-item-label">Knowledge Base</span><span class="nav-item-dot"></span></div>`;
   html += `<div class="nav-item" data-category="custom-markers" tabindex="0" role="button" onclick="window.openCreateMarkerModal&&window.openCreateMarkerModal()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('plus')}</span><span class="nav-item-label">Custom markers</span><span class="nav-item-dot"></span></div>`;
-
-  // \uD83D\uDCE1 EMF \u2014 opens editor directly (no dedicated dashboard section)
-  const emfAssessments = state.importedData?.emfAssessment?.assessments;
-  if (Array.isArray(emfAssessments) && emfAssessments.length > 0) {
-    html += _renderConditionalNavItem({
-      key: 'emf',
-      icon: 'emf',
-      label: 'EMF',
-      navigate: 'fn:window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()',
-      badge: emfAssessments.length,
-    });
-  }
 
   // Separate categories into blood work (no group) and specialty groups
   const bloodWork = [];

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -159,7 +159,9 @@ assert('45h. Environment context card counts saved EMF assessments',
 assert('45i. Environment editor uses the EMF assessment launcher',
   contextCardsSrc.includes('renderEMFAssessmentLauncher({ inModal: true') && contextCardsSrc.includes('ctx-emf-launcher'));
 assert('45j. EMF launcher has dedicated context CSS',
-  contextProfileCss.includes('.ctx-emf-launcher') && contextProfileCss.includes('.ctx-emf-launcher-action'));
+  contextProfileCss.includes('.ctx-emf-launcher') &&
+  contextProfileCss.includes('.ctx-emf-launcher-action') &&
+  contextProfileCss.includes('.ctx-emf-launcher.has-data'));
 assert('45k. Insight lens exposes EMF assessment action',
   lensPagesSrc.includes('EMF assessment') && lensPagesSrc.includes('window.openEMFAssessmentEditor'));
 

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -141,6 +141,27 @@ assert('45c. startup-orchestrator.js imports the EMF lazy facade', orchestratorS
 assert('45d. startup-orchestrator.js installs the EMF lazy facade', orchestratorSrc.includes('installEMFLazyFacade()'));
 assert('45d2. main.js starts the startup orchestrator', mainSrc.includes('startApp()'));
 assert('45e. main.js no longer owns the EMF function list', !mainSrc.includes('const _emfFns'));
+const navSrc = read('js/nav.js');
+const contextCardsSrc = read('js/context-cards.js');
+const contextProfileCss = read('css/context-profile.css');
+const lensPagesSrc = read('js/lens-pages.js');
+assert('45f. Sidebar exposes EMF assessment under Analysis tools', (() => {
+  const analysisIndex = navSrc.indexOf('Analysis tools');
+  const emfIndex = navSrc.indexOf("label: 'EMF assessment'");
+  const manageIndex = navSrc.indexOf('Manage');
+  return analysisIndex > -1 && emfIndex > -1 && manageIndex > -1 && analysisIndex < emfIndex && emfIndex < manageIndex;
+})());
+assert('45g. EMF sidebar entry is available before assessment data exists',
+  navSrc.includes('emfAssessmentCount > 0 ? emfAssessmentCount : null') &&
+  !navSrc.includes("label: 'EMF',"));
+assert('45h. Environment context card counts saved EMF assessments',
+  contextCardsSrc.includes("key === 'environment'") && contextCardsSrc.includes('getEMFAssessments().length > 0'));
+assert('45i. Environment editor uses the EMF assessment launcher',
+  contextCardsSrc.includes('renderEMFAssessmentLauncher({ inModal: true') && contextCardsSrc.includes('ctx-emf-launcher'));
+assert('45j. EMF launcher has dedicated context CSS',
+  contextProfileCss.includes('.ctx-emf-launcher') && contextProfileCss.includes('.ctx-emf-launcher-action'));
+assert('45k. Insight lens exposes EMF assessment action',
+  lensPagesSrc.includes('EMF assessment') && lensPagesSrc.includes('window.openEMFAssessmentEditor'));
 
 // ── EMF affiliate catalog (Safe Living Technologies) ──
 const recsMod = await import('../js/recommendations.js');

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -129,7 +129,7 @@ const labCtxSrc = read('js/lab-context.js');
 
   assert('context-cards imports getActiveData', ccSrc.includes("import { saveImportedData, getActiveData } from './data.js'"),
     'Should import getActiveData for lab data check');
-  assert('context-cards imports hasCardContent', ccSrc.includes("import { escapeHTML, hashString, showNotification, hasCardContent } from './utils.js'"),
+  assert('context-cards imports hasCardContent', /import\s+{[^}]*hasCardContent[^}]*}\s+from '\.\/utils\.js'/.test(ccSrc),
     'Should import hasCardContent for health dots fix');
   assert('Checks hasLabs for subtitle', ccSrc.includes('_ccHasLabs'),
     'Should compute hasLabs in renderProfileContextCards');

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -139,6 +139,11 @@ return (async function() {
   assert('Sidebar places tools and management above Lab categories',
     analysisIndex > -1 && manageIndex > -1 && labCategoriesIndex > -1 &&
       analysisIndex < labCategoriesIndex && manageIndex < labCategoriesIndex);
+  const emfIndex = sidebarText.indexOf('EMF assessment');
+  assert('Sidebar exposes EMF assessment as an analysis tool',
+    !!sidebar.querySelector('.nav-item[data-category="emf"]') &&
+      analysisIndex > -1 && emfIndex > -1 && manageIndex > -1 &&
+      analysisIndex < emfIndex && emfIndex < manageIndex);
 
   // Header elements
   assert('Header dates populated', document.getElementById('header-dates')?.innerHTML.length > 10);


### PR DESCRIPTION
## Summary
- expose EMF assessment as an always-available Analysis tools sidebar item
- add an Insight lens action for opening the EMF assessment
- make saved EMF assessments count as Environment context and replace the buried Environment editor link with a clearer launcher

## Tests
- `node tests/test-emf.js`
- `node tests/test-prelab.js`
- `git diff --check`
- `./run-tests.sh`