### PR TITLE
[codex] Move context input CSS into profile bundle

### DIFF
--- a/css/context-profile.css
+++ b/css/context-profile.css
@@ -57,6 +57,259 @@
   border-style: dashed; opacity: 0.75;
 }
 .context-card:has(.context-card-placeholder):hover { opacity: 1; }
+/* Dashboard notes, health goals, supplements, and medications */
+.notes-section { margin-bottom: 20px; }
+.note-card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-left: 3px solid var(--yellow); border-radius: var(--radius-sm);
+  padding: 16px; margin-bottom: 8px; cursor: pointer; transition: all 0.15s;
+}
+.note-card:hover { border-color: var(--accent); border-left-color: var(--yellow); background: var(--bg-hover); }
+.note-card-date { font-size: 12px; font-weight: 600; color: var(--text-secondary); margin-bottom: 6px; }
+.note-card-text { font-size: 13px; color: var(--text-primary); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+.note-card-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+.note-card-action {
+  background: none; border: none; color: var(--text-muted); cursor: pointer;
+  font-size: 12px; padding: 2px 8px; border-radius: 4px; transition: all 0.15s; font-family: inherit;
+}
+.note-card-action:hover { color: var(--accent); background: rgba(79,140,255,0.08); }
+.note-card-action-delete:hover { color: var(--red); background: var(--red-bg); }
+.add-note-btn {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 6px 14px; border-radius: 6px; border: 1px dashed var(--border);
+  background: transparent; color: var(--text-secondary); font-size: 13px;
+  cursor: pointer; font-family: inherit; transition: all 0.15s; margin-bottom: 10px;
+}
+.add-note-btn:hover { border-color: var(--accent); color: var(--accent); background: rgba(79,140,255,0.05); }
+.note-editor {
+  width: 100%; min-height: 120px; padding: 12px; border-radius: 6px;
+  border: 1px solid var(--border); background: var(--bg-primary);
+  color: var(--text-primary); font-size: 13px; font-family: inherit;
+  resize: vertical; line-height: 1.5; margin: 16px 0;
+}
+.note-editor:focus { border-color: var(--accent); }
+.note-editor-actions { display: flex; gap: 8px; align-items: center; }
+.goals-list { margin-bottom: 16px; }
+.goals-list-item {
+  display: flex; align-items: center; gap: 10px; padding: 10px 12px;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  margin-bottom: 6px; font-size: 13px;
+}
+.goals-severity-badge {
+  font-size: 11px; font-weight: 700; padding: 2px 10px; border-radius: 4px;
+  white-space: nowrap; flex-shrink: 0; text-transform: uppercase; letter-spacing: 0.3px;
+}
+.severity-major { background: var(--red-bg); color: var(--red); }
+.severity-mild { background: var(--yellow-bg); color: var(--yellow); }
+.severity-minor { background: var(--green-bg); color: var(--green); }
+.goals-list-item .goals-text { flex: 1; color: var(--text-primary); min-width: 0; }
+.goals-delete-btn {
+  background: none; border: none; color: var(--text-muted); font-size: 16px;
+  cursor: pointer; padding: 0 4px; line-height: 1; flex-shrink: 0; transition: color 0.15s;
+}
+.goals-delete-btn:hover { color: var(--red); }
+.goals-add-row {
+  display: flex; gap: 8px; align-items: flex-end; margin-top: 16px;
+}
+.supp-timeline-section { margin-bottom: 16px; }
+.supp-timeline-header {
+  display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px;
+}
+.supp-timeline-header .context-section-title { margin-bottom: 0; }
+.supp-add-btn {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 12px; border-radius: 6px; border: 1px dashed var(--border);
+  background: transparent; color: var(--text-secondary); font-size: 12px;
+  cursor: pointer; font-family: inherit; transition: all 0.15s;
+}
+.supp-add-btn:hover { border-color: var(--accent); color: var(--accent); background: rgba(79,140,255,0.05); }
+.supp-timeline {
+  background: var(--bg-card); border-radius: var(--radius-sm);
+  border: 1px solid var(--border); padding: 14px 18px;
+}
+.supp-timeline-axis {
+  display: flex; justify-content: space-between; font-size: 11px;
+  color: var(--text-muted); margin-bottom: 10px; padding: 0 2px;
+}
+.supp-bar-row {
+  display: flex; align-items: center; gap: 10px; padding: 5px 0;
+  cursor: pointer; transition: background 0.1s; border-radius: 4px;
+}
+.supp-bar-row:hover { background: var(--bg-hover); }
+.supp-bar-label {
+  flex-shrink: 0; font-size: 13px; font-weight: 500; max-width: 40%;
+  color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.supp-bar-dosage {
+  font-size: 11px; color: var(--text-muted); font-weight: 400; margin-left: 2px;
+}
+.supp-bar-track {
+  flex: 1; height: 14px;
+  background: color-mix(in srgb, var(--bg-primary) 84%, var(--text-muted) 16%);
+  border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
+  border-radius: 7px; position: relative; overflow: hidden;
+}
+.supp-bar {
+  position: absolute; top: 1px; height: calc(100% - 2px); border-radius: 7px; min-width: 4px;
+}
+.supp-bar-supplement { background: var(--cyan); }
+.supp-bar-medication { background: var(--purple-light); }
+.supp-bar-gap {
+  position: absolute; top: 1px; height: calc(100% - 2px);
+  border: 1px solid color-mix(in srgb, var(--text-muted) 24%, transparent);
+  border-radius: 6px;
+  background:
+    repeating-linear-gradient(90deg, color-mix(in srgb, var(--text-muted) 48%, transparent) 0 2px, transparent 2px 5px),
+    color-mix(in srgb, var(--text-muted) 14%, transparent);
+  opacity: 1;
+}
+.supp-bar-ongoing {
+  border-top-right-radius: 0; border-bottom-right-radius: 0;
+  -webkit-mask-image: linear-gradient(to right, black 80%, rgba(0,0,0,0.4) 95%, rgba(0,0,0,0.15));
+  mask-image: linear-gradient(to right, black 80%, rgba(0,0,0,0.4) 95%, rgba(0,0,0,0.15));
+}
+.supp-bar-ongoing::after {
+  content: ''; position: absolute; right: 0; top: 0; bottom: 0; width: 3px;
+  background: repeating-linear-gradient(to bottom, transparent 0px, transparent 2px, currentColor 2px, currentColor 4px);
+  opacity: 0.35;
+}
+.supp-empty {
+  font-size: 12px; color: var(--text-muted); font-style: italic; text-align: center;
+  padding: 8px 0;
+}
+.supp-list { margin-bottom: 16px; }
+.supp-list-item {
+  display: flex; align-items: center; gap: 10px; padding: 10px 12px;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  margin-bottom: 0; font-size: 13px; cursor: pointer; transition: border-color 0.15s, background 0.15s;
+}
+.supp-list-item:not(:last-child):not(.supp-list-item-active) { margin-bottom: 6px; }
+.supp-list-item:hover { border-color: var(--accent); }
+.supp-list-item-active { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 6%, transparent); border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
+.supp-list-expanded {
+  border: 1px solid var(--accent); border-top: none; border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+  padding: 12px; margin-bottom: 6px; background: color-mix(in srgb, var(--accent) 3%, transparent);
+}
+.supp-list-expanded .supp-form { border-top: none; padding-top: 0; margin-top: 0; }
+.supp-add-section { margin-top: 8px; }
+.supp-add-section .supp-add-btn { width: 100%; padding: 8px; border: 1px dashed var(--border); border-radius: var(--radius-sm); background: none; color: var(--text-muted); font-size: 13px; cursor: pointer; font-family: inherit; }
+.supp-add-section .supp-add-btn:hover { border-color: var(--accent); color: var(--accent); }
+.supp-add-section .supp-form { margin-top: 8px; }
+.supp-list-icon { font-size: 14px; flex-shrink: 0; }
+.supp-list-info { flex: 1; min-width: 0; max-width: 100%; }
+.supp-list-name { font-weight: 500; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.supp-list-meta { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.supp-list-source { color: var(--accent); text-decoration: none; }
+.supp-list-source:hover { text-decoration: underline; }
+.supp-list-note { font-size: 11px; color: var(--text-secondary); font-style: italic; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.supp-impact-section { border-top: 1px solid var(--border); padding: 12px 0; }
+.supp-impact-header { display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.supp-impact-refresh { background: none; border: none; color: var(--text-muted); font-size: 11px; cursor: pointer; padding: 0 4px; margin-left: auto; }
+.supp-impact-refresh:hover { color: var(--accent); }
+.supp-impact-hint { font-size: 11px; color: var(--text-muted); margin-top: 4px; }
+.supp-impact-summary {
+  font-size: 12px; line-height: 1.4; color: var(--text-muted); font-style: italic;
+  max-height: 0; opacity: 0; overflow: hidden; transition: max-height 0.3s, opacity 0.3s, margin 0.3s;
+  margin-top: 0;
+}
+.supp-impact-summary-visible { max-height: 80px; opacity: 1; margin-top: 8px; }
+.supp-impact-summary-green { color: var(--green); }
+.supp-impact-summary-yellow { color: var(--yellow); }
+.supp-impact-summary-red { color: var(--red); }
+.supp-form { border-top: 1px solid var(--border); padding-top: 16px; min-width: 0; max-width: 100%; }
+.supp-form-title { font-size: 14px; font-weight: 600; margin-bottom: 12px; }
+.supp-form-row { display: flex; gap: 12px; margin-bottom: 10px; flex-wrap: wrap; min-width: 0; max-width: 100%; }
+.supp-form-field { flex: 1 1 150px; min-width: 0; max-width: 100%; }
+.supp-form-field-compact { flex: 0 0 100px; }
+.supp-form-field-wide { flex: 2 1 220px; }
+.supp-form-field label {
+  display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 4px; font-weight: 500;
+}
+.supp-form-field input,
+.supp-form-field select {
+  width: 100%; min-width: 0; max-width: 100%; padding: 8px 10px; border-radius: 6px;
+  border: 1px solid var(--border); background: var(--bg-primary);
+  color: var(--text-primary); font-size: 13px; font-family: inherit;
+}
+.supp-form-field input:focus,
+.supp-form-field select:focus { border-color: var(--accent); }
+.supp-form-field select { cursor: pointer; }
+.supp-form-field select option { background: var(--bg-secondary); }
+.supp-ingredient-row { display: flex; gap: 6px; margin-bottom: 6px; align-items: center; flex-wrap: wrap; min-width: 0; max-width: 100%; }
+.supp-ingredient-row .supp-ing-name { flex: 3 1 140px; min-width: 110px; }
+.supp-ingredient-row .supp-ing-amount { flex: 1 1 80px; min-width: 70px; }
+.supp-ingredient-row .supp-ing-times { width: 64px; flex: 0 0 64px; text-align: center; }
+.supp-ing-total { font-size: 11px; color: var(--text-muted); white-space: nowrap; font-variant-numeric: tabular-nums; min-width: 60px; text-align: right; }
+.supp-ingredient-row input { min-width: 0; max-width: 100%; font-size: 12px; padding: 5px 8px; background: var(--bg-primary); border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-primary); }
+.supp-ingredient-row input:focus { border-color: var(--accent); outline: none; }
+.supp-ing-remove { background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 16px; padding: 2px 6px; border-radius: 4px; }
+.supp-ing-remove:hover { color: var(--danger, #ef4444); background: rgba(239, 68, 68, 0.1); }
+.supp-url-input-row { display: flex; gap: 6px; min-width: 0; max-width: 100%; }
+.supp-url-input-row input { flex: 1; min-width: 0; font-size: 12px; padding: 6px 10px; background: var(--bg-primary); border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-primary); }
+.supp-url-input-row input:focus { border-color: var(--accent); outline: none; }
+.supp-url-fetch { background: var(--bg-secondary); border: 1px solid var(--border-color); color: var(--text-secondary); font-size: 12px; padding: 6px 12px; border-radius: 6px; cursor: pointer; white-space: nowrap; }
+.supp-url-fetch:hover { border-color: var(--accent); color: var(--accent); }
+.supp-url-fetch:disabled { opacity: 0.5; cursor: wait; }
+.supp-ingredient-actions { display: flex; gap: 6px; margin-top: 4px; }
+.supp-ingredient-add { background: none; border: 1px dashed var(--border-color); color: var(--text-muted); font-size: 12px; padding: 4px 10px; border-radius: 6px; cursor: pointer; }
+.supp-ingredient-add:hover { border-color: var(--accent); color: var(--accent); }
+.supp-ingredient-add:disabled { opacity: 0.5; cursor: wait; }
+.supp-period-row { display: flex; gap: 6px; margin-bottom: 4px; align-items: center; min-width: 0; max-width: 100%; }
+.supp-period-row input[type="date"] { flex: 1 1 0; min-width: 0; max-width: 100%; font-size: 12px; padding: 5px 8px; background: var(--bg-primary); border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-primary); }
+.supp-period-row input[type="date"]:focus { border-color: var(--accent); outline: none; }
+.supp-period-arrow { color: var(--text-muted); font-size: 12px; flex-shrink: 0; }
+.supp-period-remove { background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 16px; padding: 2px 6px; border-radius: 4px; flex-shrink: 0; }
+.supp-period-remove:hover { color: var(--danger, #ef4444); background: rgba(239, 68, 68, 0.1); }
+.supp-period-actions { display: flex; gap: 6px; margin-top: 4px; }
+.supp-period-add { background: none; border: 1px dashed var(--border-color); color: var(--text-muted); font-size: 12px; padding: 4px 10px; border-radius: 6px; cursor: pointer; }
+.supp-period-add:hover { border-color: var(--accent); color: var(--accent); }
+.supp-list-ingredients { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; min-width: 0; max-width: 100%; overflow: hidden; }
+.supp-ing-pill { max-width: 100%; min-width: 0; overflow: hidden; text-overflow: ellipsis; font-size: 10px; padding: 1px 6px; border-radius: 10px; background: var(--bg-primary); border: 1px solid var(--border-color); color: var(--text-secondary); white-space: nowrap; }
+.supp-mitotox {
+  margin-top: 8px; padding: 8px 12px; border-radius: 8px;
+  background: color-mix(in srgb, var(--yellow) 6%, transparent); border: 1px solid color-mix(in srgb, var(--yellow) 15%, transparent);
+  font-size: 12px; color: var(--text-secondary);
+}
+.supp-mitotox-header { font-size: 11px; color: var(--text-muted); margin-bottom: 6px; }
+.supp-mitotox-ask { color: var(--text-primary); cursor: pointer; font-weight: 700; }
+.supp-mitotox-ask:hover { text-decoration: underline; }
+.supp-mitotox-item { margin-bottom: 4px; line-height: 1.5; }
+.supp-mitotox-link { color: var(--text-primary); text-decoration: underline; margin-left: 4px; white-space: nowrap; font-weight: 700; }
+.supp-mitotox-link:hover { text-decoration: underline; text-decoration-thickness: 2px; }
+@media (max-width: 768px) {
+  .supp-bar-label { max-width: 35%; font-size: 12px; }
+  .supp-form-row { flex-direction: column; align-items: stretch; gap: 8px; margin-bottom: 8px; }
+  .supp-form-field,
+  .supp-form-field-compact,
+  .supp-form-field-wide {
+    flex: 0 1 auto;
+    width: 100%;
+  }
+}
+@media (max-width: 600px) {
+  .goals-add-row { flex-wrap: wrap; }
+  .supp-ingredient-row { row-gap: 2px; }
+  .supp-ing-total { flex-basis: 100%; text-align: left; padding-left: 2px; margin-top: -2px; }
+}
+@media (max-width: 480px) {
+  .supp-bar-label { max-width: 30%; font-size: 11px; }
+}
+@media (pointer: coarse) {
+  .supp-mitotox-ask,
+  .supp-mitotox-link {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+  .supp-list-actions button { min-height: 44px; padding: 6px 12px; }
+  .goals-delete-btn {
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
 /* Food contaminant warnings on diet card */
 .diet-contaminants {
   margin-top: 4px; font-size: 11px; color: var(--yellow); line-height: 1.4;

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -383,7 +383,7 @@ function _suppFormHtml(editIdx, s) {
   const sourceUrl = editing && s.sourceUrl ? s.sourceUrl : '';
   return `<div class="supp-form" id="supp-form-panel">
     <div class="supp-form-row supp-url-row">
-      <div class="supp-form-field" style="flex:1"><label>Product URL <span style="font-weight:normal;color:var(--text-muted)">(saved for reference${hasAIProvider() ? '; Fetch auto-fills' : ''})</span></label>
+      <div class="supp-form-field"><label>Product URL <span style="font-weight:normal;color:var(--text-muted)">(saved for reference${hasAIProvider() ? '; Fetch auto-fills' : ''})</span></label>
         <div class="supp-url-input-row">
           <input type="url" id="supp-url" placeholder="https://..." autocomplete="off" value="${escapeHTML(sourceUrl)}">
           ${hasAIProvider() ? `<button class="supp-url-fetch" onclick="fetchSupplementFromURL()">Fetch</button>` : ''}
@@ -397,7 +397,7 @@ function _suppFormHtml(editIdx, s) {
       <div class="supp-form-field"><label>Dosage <span style="font-weight:normal;color:var(--text-muted)">(free text)</span></label>
         <input type="text" id="supp-dosage" placeholder="e.g. with food, before bed" value="${editing ? escapeHTML(s.dosage || '') : ''}">
       </div>
-      <div class="supp-form-field" style="flex:0 0 100px"><label>Doses/day</label>
+      <div class="supp-form-field supp-form-field-compact"><label>Doses/day</label>
         <input type="number" id="supp-times" placeholder="e.g. 2" min="0" max="99" step="0.5" value="${editing && s.timesPerDay != null ? escapeHTML(String(s.timesPerDay)) : ''}" oninput="updateAllIngTotals()">
       </div>
     </div>
@@ -408,13 +408,13 @@ function _suppFormHtml(editIdx, s) {
           <option value="medication"${editing && s.type === 'medication' ? ' selected' : ''}>Medication</option>
         </select>
       </div>
-      <div class="supp-form-field" style="flex:2"><label>Periods <span style="font-weight:normal;color:var(--text-muted)">(blank end = ongoing)</span></label>
+      <div class="supp-form-field supp-form-field-wide"><label>Periods <span style="font-weight:normal;color:var(--text-muted)">(blank end = ongoing)</span></label>
         <div id="supp-periods">${periods.map((p, i) => _periodRowHtml(i, p.start, p.end || '', periods.length > 1)).join('')}</div>
         <div class="supp-period-actions"><button class="supp-period-add" onclick="addPeriodRow()">+ Add period</button></div>
       </div>
     </div>
     <div class="supp-form-row">
-      <div class="supp-form-field" style="flex:1"><label>Ingredients</label>
+      <div class="supp-form-field"><label>Ingredients</label>
         <div id="supp-ingredients">${ingredients.map((ing, i) => _ingredientRowHtml(i, ing.name, ing.amount, ing.timesPerDay, editing && s.timesPerDay ? s.timesPerDay : '')).join('')}</div>
         <div class="supp-ingredient-actions">
           <button class="supp-ingredient-add" onclick="addIngredientRow()">+ Add</button>
@@ -424,7 +424,7 @@ function _suppFormHtml(editIdx, s) {
       </div>
     </div>
     <div class="supp-form-row">
-      <div class="supp-form-field" style="flex:1"><label>Note / Reason</label>
+      <div class="supp-form-field"><label>Note / Reason</label>
         <input type="text" id="supp-note" placeholder="e.g. For low vitamin D, recommended by Dr. Smith" value="${editing ? escapeHTML(s.note || '') : ''}">
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -653,41 +653,6 @@ body {
 }
 .corr-ask-ai-btn:hover { background: var(--accent); color: #fff; }
 .corr-chart { height: 400px; }
-/* Standalone note row */
-/* Note cards (dashboard) */
-.notes-section { margin-bottom: 20px; }
-.note-card {
-  background: var(--bg-card); border: 1px solid var(--border);
-  border-left: 3px solid var(--yellow); border-radius: var(--radius-sm);
-  padding: 16px; margin-bottom: 8px; cursor: pointer; transition: all 0.15s;
-}
-.note-card:hover { border-color: var(--accent); border-left-color: var(--yellow); background: var(--bg-hover); }
-.note-card-date { font-size: 12px; font-weight: 600; color: var(--text-secondary); margin-bottom: 6px; }
-.note-card-text { font-size: 13px; color: var(--text-primary); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
-.note-card-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
-.note-card-action {
-  background: none; border: none; color: var(--text-muted); cursor: pointer;
-  font-size: 12px; padding: 2px 8px; border-radius: 4px; transition: all 0.15s; font-family: inherit;
-}
-.note-card-action:hover { color: var(--accent); background: rgba(79,140,255,0.08); }
-.note-card-action-delete:hover { color: var(--red); background: var(--red-bg); }
-/* Add Note button */
-.add-note-btn {
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 6px 14px; border-radius: 6px; border: 1px dashed var(--border);
-  background: transparent; color: var(--text-secondary); font-size: 13px;
-  cursor: pointer; font-family: inherit; transition: all 0.15s; margin-bottom: 10px;
-}
-.add-note-btn:hover { border-color: var(--accent); color: var(--accent); background: rgba(79,140,255,0.05); }
-/* Note Editor */
-.note-editor {
-  width: 100%; min-height: 120px; padding: 12px; border-radius: 6px;
-  border: 1px solid var(--border); background: var(--bg-primary);
-  color: var(--text-primary); font-size: 13px; font-family: inherit;
-  resize: vertical; line-height: 1.5; margin: 16px 0;
-}
-.note-editor:focus { border-color: var(--accent); }
-.note-editor-actions { display: flex; gap: 8px; align-items: center; }
 /* Note icon in detail modal */
 .mv-note {
   display: inline-flex; align-items: center; justify-content: center;
@@ -707,213 +672,6 @@ body {
 .mv-note-text.show { display: block; }
 /* Shared shimmer animation used by loading indicators across CSS bundles. */
 @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
-/* Health Goals List */
-.goals-list { margin-bottom: 16px; }
-.goals-list-item {
-  display: flex; align-items: center; gap: 10px; padding: 10px 12px;
-  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm);
-  margin-bottom: 6px; font-size: 13px;
-}
-.goals-severity-badge {
-  font-size: 11px; font-weight: 700; padding: 2px 10px; border-radius: 4px;
-  white-space: nowrap; flex-shrink: 0; text-transform: uppercase; letter-spacing: 0.3px;
-}
-.severity-major { background: var(--red-bg); color: var(--red); }
-.severity-mild { background: var(--yellow-bg); color: var(--yellow); }
-.severity-minor { background: var(--green-bg); color: var(--green); }
-.goals-list-item .goals-text { flex: 1; color: var(--text-primary); min-width: 0; }
-.goals-delete-btn {
-  background: none; border: none; color: var(--text-muted); font-size: 16px;
-  cursor: pointer; padding: 0 4px; line-height: 1; flex-shrink: 0; transition: color 0.15s;
-}
-.goals-delete-btn:hover { color: var(--red); }
-.goals-add-row {
-  display: flex; gap: 8px; align-items: flex-end; margin-top: 16px;
-}
-@media (max-width: 600px) {
-  .goals-add-row { flex-wrap: wrap; }
-}
-/* Supplements & Medications Timeline */
-.supp-timeline-section { margin-bottom: 16px; }
-.supp-timeline-header {
-  display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px;
-}
-.supp-timeline-header .context-section-title { margin-bottom: 0; }
-.supp-add-btn {
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 4px 12px; border-radius: 6px; border: 1px dashed var(--border);
-  background: transparent; color: var(--text-secondary); font-size: 12px;
-  cursor: pointer; font-family: inherit; transition: all 0.15s;
-}
-.supp-add-btn:hover { border-color: var(--accent); color: var(--accent); background: rgba(79,140,255,0.05); }
-.supp-timeline {
-  background: var(--bg-card); border-radius: var(--radius-sm);
-  border: 1px solid var(--border); padding: 14px 18px;
-}
-.supp-timeline-axis {
-  display: flex; justify-content: space-between; font-size: 11px;
-  color: var(--text-muted); margin-bottom: 10px; padding: 0 2px;
-}
-.supp-bar-row {
-  display: flex; align-items: center; gap: 10px; padding: 5px 0;
-  cursor: pointer; transition: background 0.1s; border-radius: 4px;
-}
-.supp-bar-row:hover { background: var(--bg-hover); }
-.supp-bar-label {
-  flex-shrink: 0; font-size: 13px; font-weight: 500; max-width: 40%;
-  color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.supp-bar-dosage {
-  font-size: 11px; color: var(--text-muted); font-weight: 400; margin-left: 2px;
-}
-.supp-bar-track {
-  flex: 1; height: 14px;
-  background: color-mix(in srgb, var(--bg-primary) 84%, var(--text-muted) 16%);
-  border: 1px solid color-mix(in srgb, var(--text-muted) 18%, transparent);
-  border-radius: 7px; position: relative; overflow: hidden;
-}
-.supp-bar {
-  position: absolute; top: 1px; height: calc(100% - 2px); border-radius: 7px; min-width: 4px;
-}
-.supp-bar-supplement { background: var(--cyan); }
-.supp-bar-medication { background: var(--purple-light); }
-.supp-bar-gap {
-  position: absolute; top: 1px; height: calc(100% - 2px);
-  border: 1px solid color-mix(in srgb, var(--text-muted) 24%, transparent);
-  border-radius: 6px;
-  background:
-    repeating-linear-gradient(90deg, color-mix(in srgb, var(--text-muted) 48%, transparent) 0 2px, transparent 2px 5px),
-    color-mix(in srgb, var(--text-muted) 14%, transparent);
-  opacity: 1;
-}
-.supp-bar-ongoing {
-  border-top-right-radius: 0; border-bottom-right-radius: 0;
-  -webkit-mask-image: linear-gradient(to right, black 80%, rgba(0,0,0,0.4) 95%, rgba(0,0,0,0.15));
-  mask-image: linear-gradient(to right, black 80%, rgba(0,0,0,0.4) 95%, rgba(0,0,0,0.15));
-}
-.supp-bar-ongoing::after {
-  content: ''; position: absolute; right: 0; top: 0; bottom: 0; width: 3px;
-  background: repeating-linear-gradient(to bottom, transparent 0px, transparent 2px, currentColor 2px, currentColor 4px);
-  opacity: 0.35;
-}
-.supp-empty {
-  font-size: 12px; color: var(--text-muted); font-style: italic; text-align: center;
-  padding: 8px 0;
-}
-/* Supplement Editor */
-.supp-list { margin-bottom: 16px; }
-.supp-list-item {
-  display: flex; align-items: center; gap: 10px; padding: 10px 12px;
-  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-sm);
-  margin-bottom: 0; font-size: 13px; cursor: pointer; transition: border-color 0.15s, background 0.15s;
-}
-.supp-list-item:not(:last-child):not(.supp-list-item-active) { margin-bottom: 6px; }
-.supp-list-item:hover { border-color: var(--accent); }
-.supp-list-item-active { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 6%, transparent); border-radius: var(--radius-sm) var(--radius-sm) 0 0; }
-.supp-list-expanded {
-  border: 1px solid var(--accent); border-top: none; border-radius: 0 0 var(--radius-sm) var(--radius-sm);
-  padding: 12px; margin-bottom: 6px; background: color-mix(in srgb, var(--accent) 3%, transparent);
-}
-.supp-list-expanded .supp-form { border-top: none; padding-top: 0; margin-top: 0; }
-.supp-add-section { margin-top: 8px; }
-.supp-add-section .supp-add-btn { width: 100%; padding: 8px; border: 1px dashed var(--border); border-radius: var(--radius-sm); background: none; color: var(--text-muted); font-size: 13px; cursor: pointer; font-family: inherit; }
-.supp-add-section .supp-add-btn:hover { border-color: var(--accent); color: var(--accent); }
-.supp-add-section .supp-form { margin-top: 8px; }
-.supp-list-icon { font-size: 14px; flex-shrink: 0; }
-.supp-list-info { flex: 1; min-width: 0; }
-.supp-list-name { font-weight: 500; color: var(--text-primary); }
-.supp-list-meta { font-size: 11px; color: var(--text-muted); }
-.supp-list-source { color: var(--accent); text-decoration: none; }
-.supp-list-source:hover { text-decoration: underline; }
-.supp-list-note { font-size: 11px; color: var(--text-secondary); font-style: italic; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-/* Supplement impact analysis (AI-driven) */
-.supp-impact-section { border-top: 1px solid var(--border); padding: 12px 0; }
-.supp-impact-header { display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; color: var(--text-primary); }
-.supp-impact-refresh { background: none; border: none; color: var(--text-muted); font-size: 11px; cursor: pointer; padding: 0 4px; margin-left: auto; }
-.supp-impact-refresh:hover { color: var(--accent); }
-.supp-impact-hint { font-size: 11px; color: var(--text-muted); margin-top: 4px; }
-.supp-impact-summary {
-  font-size: 12px; line-height: 1.4; color: var(--text-muted); font-style: italic;
-  max-height: 0; opacity: 0; overflow: hidden; transition: max-height 0.3s, opacity 0.3s, margin 0.3s;
-  margin-top: 0;
-}
-.supp-impact-summary-visible { max-height: 80px; opacity: 1; margin-top: 8px; }
-.supp-impact-summary-green { color: var(--green); }
-.supp-impact-summary-yellow { color: var(--yellow); }
-.supp-impact-summary-red { color: var(--red); }
-.supp-form { border-top: 1px solid var(--border); padding-top: 16px; }
-.supp-form-title { font-size: 14px; font-weight: 600; margin-bottom: 12px; }
-.supp-form-row { display: flex; gap: 12px; margin-bottom: 10px; flex-wrap: wrap; }
-.supp-form-field { flex: 1 1 150px; min-width: 0; }
-.supp-form-field label {
-  display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 4px; font-weight: 500;
-}
-.supp-form-field input,
-.supp-form-field select {
-  width: 100%; padding: 8px 10px; border-radius: 6px;
-  border: 1px solid var(--border); background: var(--bg-primary);
-  color: var(--text-primary); font-size: 13px; font-family: inherit;
-}
-.supp-form-field input:focus,
-.supp-form-field select:focus { border-color: var(--accent); }
-.supp-form-field select { cursor: pointer; }
-.supp-form-field select option { background: var(--bg-secondary); }
-.supp-ingredient-row { display: flex; gap: 6px; margin-bottom: 6px; align-items: center; flex-wrap: wrap; }
-.supp-ingredient-row .supp-ing-name { flex: 3 1 140px; min-width: 110px; }
-.supp-ingredient-row .supp-ing-amount { flex: 1 1 80px; min-width: 70px; }
-.supp-ingredient-row .supp-ing-times { width: 64px; flex: 0 0 64px; text-align: center; }
-.supp-ing-total { font-size: 11px; color: var(--text-muted); white-space: nowrap; font-variant-numeric: tabular-nums; min-width: 60px; text-align: right; }
-.supp-ingredient-row input { font-size: 12px; padding: 5px 8px; background: var(--bg-primary); border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-primary); }
-.supp-ingredient-row input:focus { border-color: var(--accent); outline: none; }
-/* Narrow viewports: total drops below inputs to avoid crammed wrap */
-@media (max-width: 600px) {
-  .supp-ingredient-row { row-gap: 2px; }
-  .supp-ing-total { flex-basis: 100%; text-align: left; padding-left: 2px; margin-top: -2px; }
-}
-.supp-ing-remove { background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 16px; padding: 2px 6px; border-radius: 4px; }
-.supp-ing-remove:hover { color: var(--danger, #ef4444); background: rgba(239, 68, 68, 0.1); }
-.supp-url-input-row { display: flex; gap: 6px; }
-.supp-url-input-row input { flex: 1; font-size: 12px; padding: 6px 10px; background: var(--bg-primary); border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-primary); }
-.supp-url-input-row input:focus { border-color: var(--accent); outline: none; }
-.supp-url-fetch { background: var(--bg-secondary); border: 1px solid var(--border-color); color: var(--text-secondary); font-size: 12px; padding: 6px 12px; border-radius: 6px; cursor: pointer; white-space: nowrap; }
-.supp-url-fetch:hover { border-color: var(--accent); color: var(--accent); }
-.supp-url-fetch:disabled { opacity: 0.5; cursor: wait; }
-.supp-ingredient-actions { display: flex; gap: 6px; margin-top: 4px; }
-.supp-ingredient-add { background: none; border: 1px dashed var(--border-color); color: var(--text-muted); font-size: 12px; padding: 4px 10px; border-radius: 6px; cursor: pointer; }
-.supp-ingredient-add:hover { border-color: var(--accent); color: var(--accent); }
-.supp-ingredient-add:disabled { opacity: 0.5; cursor: wait; }
-/* Period rows */
-.supp-period-row { display: flex; gap: 6px; margin-bottom: 4px; align-items: center; }
-.supp-period-row input[type="date"] { flex: 1; font-size: 12px; padding: 5px 8px; background: var(--bg-primary); border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-primary); }
-.supp-period-row input[type="date"]:focus { border-color: var(--accent); outline: none; }
-.supp-period-arrow { color: var(--text-muted); font-size: 12px; flex-shrink: 0; }
-.supp-period-remove { background: none; border: none; color: var(--text-muted); cursor: pointer; font-size: 16px; padding: 2px 6px; border-radius: 4px; flex-shrink: 0; }
-.supp-period-remove:hover { color: var(--danger, #ef4444); background: rgba(239, 68, 68, 0.1); }
-.supp-period-actions { display: flex; gap: 6px; margin-top: 4px; }
-.supp-period-add { background: none; border: 1px dashed var(--border-color); color: var(--text-muted); font-size: 12px; padding: 4px 10px; border-radius: 6px; cursor: pointer; }
-.supp-period-add:hover { border-color: var(--accent); color: var(--accent); }
-.supp-list-ingredients { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
-.supp-ing-pill { font-size: 10px; padding: 1px 6px; border-radius: 10px; background: var(--bg-primary); border: 1px solid var(--border-color); color: var(--text-secondary); white-space: nowrap; }
-.supp-mitotox {
-  margin-top: 8px; padding: 8px 12px; border-radius: 8px;
-  background: color-mix(in srgb, var(--yellow) 6%, transparent); border: 1px solid color-mix(in srgb, var(--yellow) 15%, transparent);
-  font-size: 12px; color: var(--text-secondary);
-}
-.supp-mitotox-header { font-size: 11px; color: var(--text-muted); margin-bottom: 6px; }
-.supp-mitotox-ask { color: var(--text-primary); cursor: pointer; font-weight: 700; }
-.supp-mitotox-ask:hover { text-decoration: underline; }
-.supp-mitotox-item { margin-bottom: 4px; line-height: 1.5; }
-/* underline persistent (axe link-in-text-block — links must be
-   distinguishable without color alone when sitting inside a paragraph). */
-.supp-mitotox-link { color: var(--text-primary); text-decoration: underline; margin-left: 4px; white-space: nowrap; font-weight: 700; }
-.supp-mitotox-link:hover { text-decoration: underline; text-decoration-thickness: 2px; }
-@media (pointer: coarse) {
-  .supp-mitotox-ask, .supp-mitotox-link { min-height: 44px; display: inline-flex; align-items: center; }
-}
-@media (max-width: 768px) {
-  .supp-bar-label { max-width: 35%; font-size: 12px; }
-  .supp-form-row { flex-direction: column; gap: 8px; }
-}
 /* Empty State */
 .empty-state {
   background: var(--bg-card); border-radius: var(--radius);
@@ -1402,7 +1160,6 @@ body {
   .modal { padding: 20px 16px; }
   .modal h3 { font-size: 18px; }
   .corr-dropdown { min-width: 100%; }
-  .supp-bar-label { max-width: 30%; font-size: 11px; }
   .empty-state { padding: 32px 16px; }
   .notification-container { right: 8px; left: 8px; }
   .notification-toast { min-width: 0; width: 100%; }
@@ -1425,9 +1182,7 @@ body {
 @media (pointer: coarse) {
   .header-icon-btn { min-width: 44px; min-height: 44px; display: inline-flex; align-items: center; justify-content: center; }
   .range-toggle-btn { min-height: 44px; padding: 8px 12px; }
-  .supp-list-actions button { min-height: 44px; padding: 6px 12px; }
   .nav-item { min-height: 44px; }
-  .goals-delete-btn { min-width: 44px; min-height: 44px; display: inline-flex; align-items: center; justify-content: center; }
   .ie-remove { min-height: 44px; }
   .modal-close { min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; }
   .sidebar-toggle { min-width: 44px; min-height: 44px; }

--- a/tests/test-supplement-impact.js
+++ b/tests/test-supplement-impact.js
@@ -219,7 +219,7 @@ const { computeSupplementImpact, computeAllImpacts, parseAmount, ingredientDaily
   assert('Focus card uses computeAllImpacts', focusCardSrc.includes('computeAllImpacts'));
 
   // CSS
-  const cssSrc = read('styles.css');
+  const cssSrc = read('styles.css') + '\n' + read('css/context-profile.css');
   assert('Impact CSS exists', cssSrc.includes('.supp-impact-section'));
   assert('Impact summary CSS exists', cssSrc.includes('.supp-impact-summary'));
   assert('Summary color variants', cssSrc.includes('.supp-impact-summary-green'));

--- a/tests/test-theme-responsive-e2e.js
+++ b/tests/test-theme-responsive-e2e.js
@@ -794,6 +794,97 @@ async function checkMobileInteractions(page, theme, viewportName) {
     await delay(100);
   }
 
+  await page.evaluate(() => {
+    const state = window._labState;
+    window.__suppModalSnapshot = JSON.stringify(state?.importedData?.supplements || []);
+    if (state?.importedData) {
+      state.importedData.supplements = [{
+        name: 'Supplement With Ingredient Header',
+        dosage: '500mg',
+        type: 'supplement',
+        periods: [{ start: '2026-01-01', end: null }],
+        ingredients: [{
+          name: 'ExtremelyLongIngredientNameWithoutBreaksThatShouldNotOverflowTheHeaderPill',
+          amount: '100000 milligrams',
+          timesPerDay: 12,
+        }],
+        note: '',
+      }];
+    }
+    window.openSupplementsEditor?.();
+    window.showAddSuppForm?.();
+    window.addIngredientRow?.();
+    window.addPeriodRow?.();
+  });
+  await delay(150);
+  result = await page.evaluate(() => {
+    const form = document.getElementById('supp-form-panel');
+    const item = document.querySelector('.supp-list-item');
+    const overlay = document.getElementById('modal-overlay');
+    const formRect = form?.getBoundingClientRect();
+    const itemRect = item?.getBoundingClientRect();
+    const selectors = [
+      '.supp-form-field',
+      '.supp-ingredient-row',
+      '.supp-ingredient-row input',
+      '.supp-period-row',
+      '.supp-period-row input',
+      '#supp-type',
+      '#supp-ingredients',
+      '#supp-periods',
+    ];
+    const headerSelectors = [
+      '.supp-list-info',
+      '.supp-list-name',
+      '.supp-list-info > .supp-list-meta',
+      '.supp-list-ingredients',
+      '.supp-ing-pill',
+    ];
+    const bad = form && formRect
+      ? selectors.flatMap(sel => Array.from(document.querySelectorAll(sel)).map((el, i) => {
+        const r = el.getBoundingClientRect();
+        const over = r.left < formRect.left - 1 || r.right > formRect.right + 1 || r.left < -1 || r.right > document.documentElement.clientWidth + 1;
+        return over ? `${sel}[${i}] ${Math.round(r.left)}-${Math.round(r.right)} / ${Math.round(formRect.left)}-${Math.round(formRect.right)}` : null;
+      })).filter(Boolean)
+      : ['missing-form'];
+    const badHeader = item && itemRect
+      ? headerSelectors.flatMap(sel => Array.from(item.querySelectorAll(sel)).map((el, i) => {
+        const r = el.getBoundingClientRect();
+        const over = r.left < itemRect.left - 1 || r.right > itemRect.right + 1 || r.left < -1 || r.right > document.documentElement.clientWidth + 1;
+        return over ? `${sel}[${i}] ${Math.round(r.left)}-${Math.round(r.right)} / ${Math.round(itemRect.left)}-${Math.round(itemRect.right)}` : null;
+      })).filter(Boolean)
+      : ['missing-list-item'];
+    const compactFields = ['#supp-name', '#supp-dosage', '#supp-times', '#supp-type'];
+    const oversizedFields = form
+      ? compactFields.map(sel => {
+        const field = document.querySelector(sel)?.closest('.supp-form-field');
+        const height = field?.getBoundingClientRect().height || 0;
+        return height > 86 ? `${sel} field height ${Math.round(height)}` : null;
+      }).filter(Boolean)
+      : ['missing-form'];
+    const horizontalOverflow = Math.max(document.body.scrollWidth, document.documentElement.scrollWidth) - document.documentElement.clientWidth;
+    const open = overlay?.classList.contains('show');
+    window.closeModal?.();
+    const state = window._labState;
+    if (state?.importedData && window.__suppModalSnapshot) {
+      state.importedData.supplements = JSON.parse(window.__suppModalSnapshot);
+    }
+    delete window.__suppModalSnapshot;
+    return {
+      open,
+      form: !!form,
+      bad,
+      item: !!item,
+      badHeader,
+      oversizedFields,
+      horizontalOverflow,
+    };
+  });
+  assert(testName(theme, viewportName, 'mobile supplement modal fields stay inside form frame'),
+    result.open && result.form && result.item && result.bad.length === 0 && result.badHeader.length === 0 && result.oversizedFields.length === 0 && result.horizontalOverflow <= 1,
+    JSON.stringify(result));
+  await delay(100);
+
   for (const tab of ['labs', 'body', 'light', 'insight']) {
     await page.evaluate(() => window.navigate?.('dashboard'));
     await delay(180);


### PR DESCRIPTION
## Summary
- Move dashboard note, health goal, supplement, and medication CSS from `styles.css` into `css/context-profile.css`.
- Keep marker-detail note pill styling in `styles.css` because it belongs to the marker detail modal, not the profile/context bundle.
- Clamp supplement editor form controls so the Type dropdown, ingredient rows, and period date fields stay inside the modal frame on mobile.
- Update the supplement impact CSS source inspection and add a mobile responsive E2E regression for the supplement modal.

## Validation
- `node tests/test-supplement-impact.js`
- `node tests/test-a11y-phase3.js`
- `node tests/test-family-history.js`
- `node tests/test-audit.js`
- `PORT=8000 NODE_PATH=./node_modules node tests/test-theme-responsive-e2e.js`
- `./run-tests.sh`