### PR TITLE
[codex] Move light environment into assessment modal

### DIFF
--- a/css/light-sun.css
+++ b/css/light-sun.css
@@ -2303,25 +2303,11 @@
   text-transform: uppercase; letter-spacing: 0.04em;
   flex: 1;
 }
-/* "+ Add a screen here" — dashed-outline button at the bottom of
-   each room's Step 3 list. Distinguishes "add" from primary CTAs. */
-.light-env-add-screen-here {
-  background: transparent; border: 1px dashed var(--border);
-  border-radius: var(--radius-sm);
-  padding: 4px 10px; font-size: 12px;
-  color: var(--text-secondary); cursor: pointer;
-  font-family: inherit;
-  margin-top: 8px;
-}
-.light-env-add-screen-here:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
 /* Quick-pick chip row inside Step 3 — mirrors the room quick-picks at
-   the bottom of the Rooms section. Common device types are one-click;
-   "+ Other…" falls back to the device-by-room-name inference path. */
+   the bottom of the Rooms section. Shared row styles come from
+   .light-env-quickpicks-row; this selector only spaces the row from
+   the preceding screen list / empty copy. */
 .light-env-screen-quickpicks {
-  display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
   margin-top: 10px;
 }
 

--- a/css/light-sun.css
+++ b/css/light-sun.css
@@ -1853,7 +1853,7 @@
 }
 .light-env-assessment-metrics {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 8px;
 }
 .light-env-assessment-metric {

--- a/css/light-sun.css
+++ b/css/light-sun.css
@@ -1819,6 +1819,112 @@
 }
 
 /* Light Environment — rooms + screens survey */
+.light-env-assessment-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border-left: 4px solid var(--text-muted);
+  padding-left: 14px;
+}
+.light-env-assessment-summary-green { border-left-color: var(--green); }
+.light-env-assessment-summary-orange { border-left-color: var(--orange); }
+.light-env-assessment-summary-red { border-left-color: var(--red); }
+.light-env-assessment-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.light-env-assessment-tier {
+  color: var(--text-primary);
+  font-weight: 700;
+  font-size: 16px;
+}
+.light-env-assessment-parts {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.light-env-assessment-lead {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.light-env-assessment-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+.light-env-assessment-metric {
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.light-env-assessment-metric-label,
+.light-env-assessment-metric span:last-child {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+}
+.light-env-assessment-metric strong {
+  color: var(--text-primary);
+  font-size: 22px;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+.light-env-assessment-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.light-env-assessment-overlay.modal-overlay.show {
+  align-items: flex-start;
+  overflow-y: auto;
+}
+.light-env-assessment-modal {
+  width: min(96vw, 980px);
+  max-width: 980px;
+  max-height: none;
+  margin: 24px 0;
+}
+.light-env-assessment-modal .modal-header {
+  margin-bottom: 6px;
+  padding-right: 38px;
+}
+.light-env-assessment-modal-copy {
+  margin: 0 0 18px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.light-env-section-embedded {
+  margin-top: 0;
+}
+.light-env-section-embedded .light-env-summary-top {
+  margin-top: 0;
+}
+@media (max-width: 700px) {
+  .light-env-assessment-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .light-env-assessment-modal {
+    width: 100%;
+    margin: 0;
+    border-radius: 0;
+    min-height: 100vh;
+  }
+}
+@media (max-width: 420px) {
+  .light-env-assessment-metrics {
+    grid-template-columns: 1fr;
+  }
+}
 .light-env-section { margin-top: 24px; }
 .light-env-block { margin-top: 16px; }
 .light-env-portable-readings > summary {

--- a/css/light-sun.css
+++ b/css/light-sun.css
@@ -1885,13 +1885,16 @@
 }
 .light-env-assessment-overlay.modal-overlay.show {
   align-items: flex-start;
-  overflow-y: auto;
+  overflow: hidden;
+  padding: 24px;
 }
 .light-env-assessment-modal {
   width: min(96vw, 980px);
   max-width: 980px;
-  max-height: none;
-  margin: 24px 0;
+  max-height: calc(100dvh - 48px);
+  margin: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .light-env-assessment-modal .modal-header {
   margin-bottom: 6px;
@@ -1915,10 +1918,12 @@
   }
   .light-env-assessment-modal {
     width: 100%;
+    height: 100dvh;
+    max-height: 100dvh;
     margin: 0;
     border-radius: 0;
-    min-height: 100vh;
   }
+  .light-env-assessment-overlay.modal-overlay.show { padding: 0; }
 }
 @media (max-width: 420px) {
   .light-env-assessment-metrics {

--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -39,6 +39,7 @@ function handleDocumentClick(e) {
   }
   // Read-only modals close on backdrop click.
   if (e.target.id === "modal-overlay") { window.closeModal(); return; }
+  if (e.target.id === "light-env-assessment-overlay") { window.closeLightEnvironmentAssessment?.(); return; }
   if (e.target.id === "changelog-modal-overlay") { window.closeChangelog(); return; }
   // Auto-save modals close on backdrop click.
   if (e.target.id === "settings-modal-overlay") { window.closeSettingsModal(); return; }
@@ -116,6 +117,13 @@ function handleAppKeydown(e) {
     if (settingsOverlay && settingsOverlay.classList.contains("show")) { window.closeSettingsModal(); return; }
     const tweaksOverlay = document.getElementById("tweaks-panel-overlay");
     if (tweaksOverlay && tweaksOverlay.classList.contains("show")) { window.closeTweaksPanel(); return; }
+    const anonymousOverlays = document.querySelectorAll('.modal-overlay.show:not([id])');
+    if (anonymousOverlays.length > 0) {
+      anonymousOverlays[anonymousOverlays.length - 1].remove();
+      return;
+    }
+    const lightEnvOverlay = document.getElementById("light-env-assessment-overlay");
+    if (lightEnvOverlay && lightEnvOverlay.classList.contains("show")) { window.closeLightEnvironmentAssessment?.(); return; }
     const modalOverlay = document.getElementById("modal-overlay");
     if (modalOverlay && modalOverlay.classList.contains("show")) { window.closeModal(); return; }
     // Generic fallback: anonymous dynamically-injected overlays.
@@ -129,10 +137,12 @@ function handleAppKeydown(e) {
 
   // Focus trap for open modals. Sync overlays use `.confirm-overlay` too.
   if (e.key === "Tab") {
-    const overlayIds = ["client-list-overlay", "changelog-modal-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "data-protection-picker-overlay"];
+    const overlayIds = ["client-list-overlay", "changelog-modal-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "light-env-assessment-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "data-protection-picker-overlay"];
     for (const oid of overlayIds) {
       const ov = document.getElementById(oid);
       if (ov && ov.classList.contains("show")) {
+        const openOverlays = Array.from(document.querySelectorAll('.modal-overlay.show'));
+        if (openOverlays.length && openOverlays[openOverlays.length - 1] !== ov) continue;
         const modal = ov.querySelector('[role="dialog"]') || ov.querySelector('.modal') || ov.querySelector('.confirm-dialog') || ov;
         const focusable = modal.querySelectorAll('button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),a[href],[tabindex]:not([tabindex="-1"])');
         if (focusable.length === 0) return;

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -844,7 +844,7 @@ function renderEnvironmentLoadSummary() {
 }
 
 function formatLatestLightAudit(audits) {
-  if (!audits.length) return 'No saved audits';
+  if (!audits.length) return 'No saved snapshots';
   const latest = audits
     .slice()
     .sort((a, b) => (b.createdAt || Date.parse(b.date || '') || 0) - (a.createdAt || Date.parse(a.date || '') || 0))[0];
@@ -864,10 +864,10 @@ export function renderEnvironmentAssessmentSummary() {
   const activeScreens = screens.filter(isActiveToday).length;
   const measuredRooms = new Set(measurements.filter(m => m.roomId).map(m => m.roomId)).size;
   const hasMapped = rooms.length > 0 || screens.length > 0;
-  const actionLabel = hasMapped ? 'Open assessment' : 'Map rooms';
+  const actionLabel = hasMapped ? 'Open assessment' : 'Start assessment';
   const lead = hasMapped
     ? burden.interp
-    : 'Map rooms and screens once, then use this assessment for indoor-light audits instead of keeping the whole workflow on the Light page.';
+    : 'Map your bedroom, work areas, and screens once; update the assessment when bulbs, monitors, or evening routines change.';
   const metrics = [
     {
       label: 'Rooms',
@@ -936,9 +936,9 @@ function renderLightEnvironmentAssessmentModal() {
   overlay.innerHTML = `<div class="modal light-env-assessment-modal" role="dialog" aria-modal="true" aria-labelledby="light-env-assessment-title">
     <button class="modal-close" onclick="window.closeLightEnvironmentAssessment && window.closeLightEnvironmentAssessment()" aria-label="Close">×</button>
     <div class="modal-header">
-      <h3 id="light-env-assessment-title">Light Environment Assessment</h3>
+      <h3 id="light-env-assessment-title">Indoor Light Assessment</h3>
     </div>
-    <p class="light-env-assessment-modal-copy">Rooms, screens, readings, and audit snapshots live here. The Light page keeps the summary; this is the workspace.</p>
+    <p class="light-env-assessment-modal-copy">Map the rooms, screens, and readings that shape your indoor day. Save audit snapshots before and after changes to compare what moved.</p>
     ${renderEnvironmentSection({ embedded: true })}
   </div>`;
 }

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -843,6 +843,123 @@ function renderEnvironmentLoadSummary() {
   </div>`;
 }
 
+function formatLatestLightAudit(audits) {
+  if (!audits.length) return 'No saved audits';
+  const latest = audits
+    .slice()
+    .sort((a, b) => (b.createdAt || Date.parse(b.date || '') || 0) - (a.createdAt || Date.parse(a.date || '') || 0))[0];
+  const label = latest?.label ? ` · ${latest.label}` : '';
+  const date = latest?.date ? fmtMeasureTime(new Date(latest.date + 'T00:00:00').getTime()) : 'latest';
+  return `${audits.length} audit${audits.length === 1 ? '' : 's'} · ${date}${label}`;
+}
+
+export function renderEnvironmentAssessmentSummary() {
+  const env = getEnvironment();
+  const rooms = env?.rooms || [];
+  const screens = env?.screens || [];
+  const audits = getLightAudits();
+  const measurements = state.importedData?.lightMeasurements || [];
+  const burden = computeIndoorBurden();
+  const activeRooms = rooms.filter(isActiveToday).length;
+  const activeScreens = screens.filter(isActiveToday).length;
+  const measuredRooms = new Set(measurements.filter(m => m.roomId).map(m => m.roomId)).size;
+  const hasMapped = rooms.length > 0 || screens.length > 0;
+  const actionLabel = hasMapped ? 'Open assessment' : 'Map rooms';
+  const lead = hasMapped
+    ? burden.interp
+    : 'Map rooms and screens once, then use this assessment for indoor-light audits instead of keeping the whole workflow on the Light page.';
+  const metrics = [
+    {
+      label: 'Rooms',
+      value: String(rooms.length),
+      sub: rooms.length ? `${activeRooms} active today` : 'Start with bedroom',
+    },
+    {
+      label: 'Screens',
+      value: String(screens.length),
+      sub: screens.length ? `${activeScreens} active today` : 'Portable or room-bound',
+    },
+    {
+      label: 'Readings',
+      value: String(measurements.length),
+      sub: measuredRooms ? `${measuredRooms} room${measuredRooms === 1 ? '' : 's'} measured` : 'Run lux/flicker/CCT',
+    },
+    {
+      label: 'Audits',
+      value: String(audits.length),
+      sub: formatLatestLightAudit(audits),
+    },
+  ];
+  return `<div class="light-env-assessment-summary light-env-assessment-summary-${escapeAttr(burden.color)}">
+    <div class="light-env-assessment-status">
+      <span class="light-env-summary-kicker">Indoor light load</span>
+      <span class="light-env-assessment-tier">${escapeHTML(burden.label)}</span>
+      ${burden.parts.length ? `<span class="light-env-assessment-parts">${escapeHTML(burden.parts.join(' · '))}</span>` : ''}
+    </div>
+    <p class="light-env-assessment-lead">${escapeHTML(lead)}</p>
+    <div class="light-env-assessment-metrics">
+      ${metrics.map(m => `<div class="light-env-assessment-metric">
+        <span class="light-env-assessment-metric-label">${escapeHTML(m.label)}</span>
+        <strong>${escapeHTML(m.value)}</strong>
+        <span>${escapeHTML(m.sub)}</span>
+      </div>`).join('')}
+    </div>
+    <div class="light-env-assessment-actions">
+      <button class="dashboard-action-btn dashboard-action-btn-primary" onclick="window.openLightEnvironmentAssessment && window.openLightEnvironmentAssessment()">${escapeHTML(actionLabel)}</button>
+      ${rooms.length ? `<button class="dashboard-action-btn" onclick="window.openLightEnvironmentAssessment && window.openLightEnvironmentAssessment();setTimeout(() => window.saveLightAuditFromUI && window.saveLightAuditFromUI(), 0)">Save audit</button>` : ''}
+    </div>
+  </div>`;
+}
+
+const LIGHT_ENV_ASSESSMENT_OVERLAY_ID = 'light-env-assessment-overlay';
+
+function getLightEnvironmentAssessmentOverlay() {
+  return document.getElementById(LIGHT_ENV_ASSESSMENT_OVERLAY_ID);
+}
+
+function isLightEnvironmentAssessmentOpen() {
+  return !!getLightEnvironmentAssessmentOverlay();
+}
+
+function renderLightEnvironmentAssessmentModal() {
+  let overlay = getLightEnvironmentAssessmentOverlay();
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = LIGHT_ENV_ASSESSMENT_OVERLAY_ID;
+    overlay.className = 'modal-overlay show light-env-assessment-overlay';
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) window.closeLightEnvironmentAssessment?.();
+    });
+    document.body.appendChild(overlay);
+  }
+  overlay.classList.add('show');
+  overlay.innerHTML = `<div class="modal light-env-assessment-modal" role="dialog" aria-modal="true" aria-labelledby="light-env-assessment-title">
+    <button class="modal-close" onclick="window.closeLightEnvironmentAssessment && window.closeLightEnvironmentAssessment()" aria-label="Close">×</button>
+    <div class="modal-header">
+      <h3 id="light-env-assessment-title">Light Environment Assessment</h3>
+    </div>
+    <p class="light-env-assessment-modal-copy">Rooms, screens, readings, and audit snapshots live here. The Light page keeps the summary; this is the workspace.</p>
+    ${renderEnvironmentSection({ embedded: true })}
+  </div>`;
+}
+
+export function openLightEnvironmentAssessment() {
+  renderLightEnvironmentAssessmentModal();
+}
+
+export function closeLightEnvironmentAssessment() {
+  getLightEnvironmentAssessmentOverlay()?.remove();
+}
+
+export function refreshLightEnvironmentAssessment() {
+  if (isLightEnvironmentAssessmentOpen()) renderLightEnvironmentAssessmentModal();
+}
+
+function refreshLightEnvironmentUI() {
+  refreshLightEnvironmentAssessment();
+  if (window.navigate && state.currentView === 'light') window.navigate('light');
+}
+
 // Disclosure-pattern room card. Header shows: name · severity dot ·
 // hours · source · today-toggle · expand affordance. Click anywhere on
 // the header (except interactive children) to toggle expand. Expanded
@@ -1014,17 +1131,20 @@ function renderRoomExpandedBody(r, measurements, sev) {
   return html;
 }
 
-export function renderEnvironmentSection() {
+export function renderEnvironmentSection(options = {}) {
   const env = getEnvironment();
   const rooms = env?.rooms || [];
   const screens = env?.screens || [];
+  const embedded = !!options.embedded;
 
-  let html = `<div class="light-env-section">
-    <div class="light-env-head">
+  let html = `<div class="light-env-section${embedded ? ' light-env-section-embedded' : ''}">`;
+  if (!embedded) {
+    html += `<div class="light-env-head">
       <h3 class="light-section-title">Light environment</h3>
       <p class="light-section-hint">Indoor light is the dominant exposure most days. Map your spaces and screens — the rest of the app uses this to weight your channel pills + interpret your sleep data.</p>
-    </div>
-    ${renderEnvironmentLoadSummary()}`;
+    </div>`;
+  }
+  html += renderEnvironmentLoadSummary();
 
   // Rooms — disclosure list (mirrors EMF Assessment + Light Audits).
   // Each row is collapsed-by-default with name + severity + key
@@ -1576,7 +1696,7 @@ if (typeof window !== 'undefined') {
       // Auto-expand the new room so the user can fill it out immediately
       const after = env?.rooms || [];
       if (after.length > before) writeActiveRoomId(after[after.length - 1].id);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     // Quick-pick chip handler — adds a room with the exact chosen name
     // (no "Room N" fallback). Auto-expands the new room.
@@ -1586,7 +1706,7 @@ if (typeof window !== 'undefined') {
       await addRoom(name);
       const after = env?.rooms || [];
       if (after.length > before) writeActiveRoomId(after[after.length - 1].id);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     // "Other…" quick-pick — opens the prompt dialog for a custom name.
     addLightEnvRoomCustom: async () => {
@@ -1603,7 +1723,7 @@ if (typeof window !== 'undefined') {
       await addRoom(trimmed);
       const after = env?.rooms || [];
       if (after.length > before) writeActiveRoomId(after[after.length - 1].id);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     // Disclosure toggle — clicking the header expands/collapses. The
     // event check ignores clicks on interactive children (the today-
@@ -1632,7 +1752,7 @@ if (typeof window !== 'undefined') {
       }
       const current = readActiveRoomId();
       writeActiveRoomId(current === id ? null : id);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     updateLightEnvRoom: async (id, patch) => { await updateRoom(id, patch); },
     // Chip-picker setters — translate archetype/bucket choices into
@@ -1642,13 +1762,13 @@ if (typeof window !== 'undefined') {
       const a = SOURCE_ARCHETYPES.find(x => x.key === archetypeKey);
       if (!a) return;
       await updateRoom(id, { primarySource: a.storeAs });
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     setLightEnvRoomHoursBucket: async (id, bucketKey) => {
       const b = HOURS_BUCKETS.find(x => x.key === bucketKey);
       if (!b) return;
       await updateRoom(id, { hoursOccupiedPerDay: b.midpoint });
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     // Auto-fill a room's primarySource from the Spectrum tool's
     // classification — only when the user hasn't picked one yet, so
@@ -1685,21 +1805,21 @@ if (typeof window !== 'undefined') {
         eveningHoursAfterSunset: b.midpoint,
         eveningUseAfterSunset: b.midpoint > 0,
       });
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     // Discrete-toggle variant — same persistence as updateLightEnvRoom
-    // but follows up with a navigate('light') so the severity chip
-    // and accent strip refresh. Use for select/checkbox handlers
+    // but refreshes the Light page / assessment modal so the severity
+    // chip and accent strip update. Use for select/checkbox handlers
     // where focus-loss isn't a concern; keep plain updateLightEnvRoom
     // for text + number inputs to preserve cursor mid-typing.
     updateLightEnvRoomAndRender: async (id, patch) => {
       await updateRoom(id, patch);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     deleteLightEnvRoom: async (id) => {
       await deleteRoom(id);
       if (readActiveRoomId() === id) writeActiveRoomId(null);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     // Confirm-dialog wrapped delete — reachable from the expanded
     // room's footer. The bare delete handler stays in case anything
@@ -1708,12 +1828,12 @@ if (typeof window !== 'undefined') {
       if (await showConfirmDialog('Delete this room? Measurements stay but lose their room link.')) {
         await deleteRoom(id);
         if (readActiveRoomId() === id) writeActiveRoomId(null);
-        if (window.navigate && state.currentView === 'light') window.navigate('light');
+        refreshLightEnvironmentUI();
       }
     },
     setActiveLightEnvRoom: (id) => {
       writeActiveRoomId(id);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     // Quick-pick variant — adds a screen with an explicit device type
     // (phone / laptop / monitor / tablet / tv). Auto-expands the new
@@ -1725,7 +1845,7 @@ if (typeof window !== 'undefined') {
       const env = getEnvironment();
       const after = env?.screens || [];
       if (after.length > 0) _expandedScreenId = after[after.length - 1].id;
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     addLightEnvScreen: async (roomId = null) => {
       // Sensible default device by room name — laptop for office, TV
@@ -1741,22 +1861,22 @@ if (typeof window !== 'undefined') {
         else if (/bedroom|sleep/.test(name)) device = 'phone';
       }
       await addScreen(device, roomId);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     updateLightEnvScreen: async (id, patch) => { await updateScreen(id, patch); },
     updateLightEnvScreenAndRender: async (id, patch) => {
       await updateScreen(id, patch);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     deleteLightEnvScreen: async (id) => {
       await deleteScreen(id);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     deleteLightEnvScreenConfirm: async (id) => {
       if (await showConfirmDialog('Delete this screen?')) {
         await deleteScreen(id);
         if (_expandedScreenId === id) _expandedScreenId = null;
-        if (window.navigate && state.currentView === 'light') window.navigate('light');
+        refreshLightEnvironmentUI();
       }
     },
     // Disclosure toggle for screen cards — same event-target gating as
@@ -1776,19 +1896,19 @@ if (typeof window !== 'undefined') {
         }
       }
       _expandedScreenId = (_expandedScreenId === id) ? null : id;
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     setLightEnvScreenHoursBucket: async (id, bucketKey) => {
       const b = SCREEN_HOURS_BUCKETS.find(x => x.key === bucketKey);
       if (!b) return;
       await updateScreen(id, { hoursPerDay: b.midpoint });
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     setLightEnvScreenEveningBucket: async (id, bucketKey) => {
       const map = { none: 0, lt1: 0.5, mid: 2, gt3: 4 };
       if (!(bucketKey in map)) return;
       await updateScreen(id, { eveningUseAfterSunset: map[bucketKey] });
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     computeLightDeficitAxes: computeDeficitAxes,
     computeDeficitAxes,
@@ -1804,9 +1924,13 @@ if (typeof window !== 'undefined') {
     isLightEnvActiveToday: isActiveToday,
     setLightEnvTodayActive: async (kind, id, active) => {
       await setTodayActive(kind, id, active);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     renderEnvironmentSection,
+    renderEnvironmentAssessmentSummary,
+    openLightEnvironmentAssessment,
+    closeLightEnvironmentAssessment,
+    refreshLightEnvironmentAssessment,
     // ─── Light Audits ───
     getLightAudits,
     saveLightAuditFromUI: async () => {
@@ -1823,17 +1947,17 @@ if (typeof window !== 'undefined') {
       if (audit) {
         showNotification(`Saved audit: ${audit.label}`);
         _expandedAuditId = audit.id;
-        if (window.navigate && state.currentView === 'light') window.navigate('light');
+        refreshLightEnvironmentUI();
       }
     },
     toggleLightAudit: (id) => {
       _expandedAuditId = (_expandedAuditId === id) ? null : id;
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     toggleLightAuditCompare: () => {
       _auditCompareMode = !_auditCompareMode;
       _expandedAuditId = null;
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
+      refreshLightEnvironmentUI();
     },
     updateLightAuditField: async (id, field, value) => {
       await updateLightAudit(id, { [field]: value });
@@ -1842,7 +1966,7 @@ if (typeof window !== 'undefined') {
       if (await showConfirmDialog('Delete this audit? This cannot be undone.')) {
         await deleteLightAudit(id);
         if (_expandedAuditId === id) _expandedAuditId = null;
-        if (window.navigate && state.currentView === 'light') window.navigate('light');
+        refreshLightEnvironmentUI();
       }
     },
     // "Interpret changes" — pre-fills the chat panel with a comparison

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -784,17 +784,38 @@ function renderScreenExpandedBody(s, rooms) {
 // "Room 1" footgun and accelerates the common path. Hides chips for
 // names already in use; "Other…" opens a prompt for custom names.
 const ROOM_QUICK_PICKS = ['Bedroom', 'Living room', 'Kitchen', 'Office', 'Bathroom'];
+const SCREEN_QUICK_PICK_LABELS = {
+  phone: '📱 Phone',
+  laptop: '💻 Laptop',
+  monitor: '🖥 Monitor',
+  tablet: '📲 Tablet',
+  tv: '📺 TV',
+};
 
 function renderRoomQuickPicks(rooms) {
   const usedLC = new Set((rooms || []).map(r => (r.name || '').trim().toLowerCase()));
   const chips = ROOM_QUICK_PICKS
     .filter(name => !usedLC.has(name.toLowerCase()))
-    .map(name => `<button class="light-env-quickpick" onclick="window.addLightEnvRoomNamed('${escapeAttr(name)}')">+ ${escapeHTML(name)}</button>`)
+    .map(name => `<button class="light-env-quickpick" onclick="window.addLightEnvRoomNamed('${escapeAttr(name)}')">${escapeHTML(name)}</button>`)
     .join('');
   return `<div class="light-env-quickpicks-row">
-    <span class="light-env-quickpicks-label">${rooms.length === 0 ? 'Add your first room' : 'Add a room'}:</span>
+    <span class="light-env-quickpicks-label">${rooms.length === 0 ? 'Start with' : 'Add'}:</span>
     ${chips}
-    <button class="light-env-quickpick light-env-quickpick-other" onclick="window.addLightEnvRoomCustom()">+ Other…</button>
+    <button class="light-env-quickpick light-env-quickpick-other" onclick="window.addLightEnvRoomCustom()">Other…</button>
+  </div>`;
+}
+
+function renderScreenQuickPicks(screens, roomId = null, preferred = ['phone', 'laptop', 'monitor', 'tablet', 'tv']) {
+  const existing = new Set((screens || []).filter(s => (s.roomId || null) === (roomId || null)).map(s => s.device));
+  const roomArg = roomId ? `'${escapeAttr(roomId)}'` : 'null';
+  const chips = preferred
+    .filter(device => !existing.has(device))
+    .map(device => `<button class="light-env-quickpick" onclick="window.addLightEnvScreenWithDevice(${roomArg},'${escapeAttr(device)}')">${escapeHTML(SCREEN_QUICK_PICK_LABELS[device] || device)}</button>`)
+    .join('');
+  return `<div class="light-env-quickpicks-row light-env-screen-quickpicks">
+    <span class="light-env-quickpicks-label">${existing.size === 0 ? 'Start with' : 'Add'}:</span>
+    ${chips}
+    <button class="light-env-quickpick light-env-quickpick-other" onclick="window.addLightEnvScreen(${roomArg})">Other…</button>
   </div>`;
 }
 
@@ -864,6 +885,7 @@ export function renderEnvironmentAssessmentSummary() {
   const activeScreens = screens.filter(isActiveToday).length;
   const measuredRooms = new Set(measurements.filter(m => m.roomId).map(m => m.roomId)).size;
   const hasMapped = rooms.length > 0 || screens.length > 0;
+  const hasRooms = rooms.length > 0;
   const actionLabel = hasMapped ? 'Open assessment' : 'Start assessment';
   const lead = hasMapped
     ? burden.interp
@@ -879,17 +901,18 @@ export function renderEnvironmentAssessmentSummary() {
       value: String(screens.length),
       sub: screens.length ? `${activeScreens} active today` : 'Portable or room-bound',
     },
-    {
+  ];
+  if (hasRooms) {
+    metrics.push({
       label: 'Readings',
       value: String(measurements.length),
       sub: measuredRooms ? `${measuredRooms} room${measuredRooms === 1 ? '' : 's'} measured` : 'Run lux/flicker/CCT',
-    },
-    {
+    }, {
       label: 'Audits',
       value: String(audits.length),
       sub: formatLatestLightAudit(audits),
-    },
-  ];
+    });
+  }
   return `<div class="light-env-assessment-summary light-env-assessment-summary-${escapeAttr(burden.color)}">
     <div class="light-env-assessment-status">
       <span class="light-env-summary-kicker">Indoor light load</span>
@@ -1093,11 +1116,6 @@ function renderRoomExpandedBody(r, measurements, sev) {
     emptyCopy = 'Map any phone, tablet, laptop, monitor, or TV used in this room.';
     quickPicks = ['phone', 'laptop', 'tv'];
   }
-  // Hide quick-picks for devices already mapped to this room — no need
-  // to suggest "+ phone" if there's already a phone here.
-  const existingDevices = new Set(screensHere.map(s => s.device));
-  const availablePicks = quickPicks.filter(d => !existingDevices.has(d));
-  const pickLabels = { phone: '📱 Phone', laptop: '💻 Laptop', monitor: '🖥 Monitor', tablet: '📲 Tablet', tv: '📺 TV' };
 
   html += `<div class="light-env-room-step">
     <div class="light-env-room-step-head">${escapeHTML(stepHead)}</div>
@@ -1112,16 +1130,7 @@ function renderRoomExpandedBody(r, measurements, sev) {
   // Quick-pick chip row — one-click adds a screen with the right device
   // type. "Other…" falls back to the original generic "+ Add screen"
   // path which infers device by room name.
-  if (availablePicks.length > 0) {
-    html += `<div class="light-env-screen-quickpicks">`;
-    for (const device of availablePicks) {
-      html += `<button class="light-env-quickpick" onclick="window.addLightEnvScreenWithDevice('${escapeAttr(r.id)}','${device}')">+ ${escapeHTML(pickLabels[device] || device)}</button>`;
-    }
-    html += `<button class="light-env-quickpick light-env-quickpick-other" onclick="window.addLightEnvScreen('${escapeAttr(r.id)}')">+ Other…</button>`;
-    html += `</div>`;
-  } else {
-    html += `<button class="light-env-add-screen-here" onclick="window.addLightEnvScreen('${escapeAttr(r.id)}')">+ Add another screen</button>`;
-  }
+  html += renderScreenQuickPicks(screensHere, r.id, quickPicks);
   html += `    </div>
   </div>`;
 
@@ -1154,6 +1163,7 @@ export function renderEnvironmentSection(options = {}) {
   html += `<div class="light-env-block">
     <div class="light-env-block-head">
       <strong>Rooms you spend time in</strong>
+      <button class="import-btn import-btn-secondary" onclick="window.addLightEnvRoom()">+ Room</button>
     </div>`;
   if (rooms.length === 0) {
     html += `<div class="light-env-empty light-env-empty-cta">
@@ -1185,16 +1195,19 @@ export function renderEnvironmentSection(options = {}) {
   html += `<div class="light-env-block">
     <div class="light-env-block-head">
       <strong>Portable screens</strong>
-      <button class="import-btn import-btn-secondary" onclick="window.addLightEnvScreen()">+ Portable screen</button>
+      <button class="import-btn import-btn-secondary" onclick="window.addLightEnvScreen()">+ Screen</button>
     </div>`;
   if (portableScreens.length === 0 && screens.length === 0 && rooms.length === 0) {
     // First-time: show the value-prop CTA only when the whole section is empty
     html += `<div class="light-env-empty light-env-empty-cta">
       <p><strong>Track your phone, TV, or any screen that moves between rooms.</strong> Screens you use in a specific room (laptop in the Office, TV in the Living Room) live inside that room's card — add them from there.</p>
-      <button class="import-btn import-btn-primary" onclick="window.addLightEnvScreen()">+ Add a portable screen</button>
+      ${renderScreenQuickPicks(portableScreens)}
     </div>`;
   } else if (portableScreens.length === 0) {
-    html += `<p class="light-env-empty">No portable screens yet. Devices that stay in one place are listed inside their room card above.</p>`;
+    html += `<div class="light-env-empty light-env-empty-cta">
+      <p>No portable screens yet. Devices that stay in one place are listed inside their room card above.</p>
+      ${renderScreenQuickPicks(portableScreens)}
+    </div>`;
   } else {
     html += `<div class="light-env-screen-cards">`;
     for (const s of portableScreens) html += renderScreenCard(s);
@@ -1214,7 +1227,7 @@ export function renderEnvironmentSection(options = {}) {
   const portable = allMeasurements
     .filter(m => !m.roomId)
     .sort((a, b) => (b.takenAt || b.capturedAt || 0) - (a.takenAt || a.capturedAt || 0));
-  if (portable.length > 0) {
+  if (rooms.length > 0 && portable.length > 0) {
     html += `<details class="light-env-block light-env-portable-readings">
       <summary><strong>Portable readings</strong> <span class="light-env-portable-count">${portable.length} not matched to a room</span></summary>
       <div class="light-env-portable-readings-list">`;

--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -573,8 +573,8 @@ export function showLight(_data) {
   });
   widgets.push({
     id: 'light-environment',
-    title: 'Light Environment',
-    description: 'Indoor rooms, screens, and evening light context',
+    title: 'Indoor Light Assessment',
+    description: 'Rooms, screens, measurements, and saved audit snapshots',
     body: `<div id="${escapeAttr(environmentSlotId)}" class="light-widget-loading">Loading environment...</div>`,
     size: 'full',
     opts: { source: 'Light', dashboardId: '' },
@@ -647,11 +647,9 @@ export function showLight(_data) {
   }
   const envSlot = document.getElementById(environmentSlotId);
   if (envSlot) {
-    const env = (window.getLightEnvironment && window.getLightEnvironment()) || null;
-    const hasLightEnvironment = !!(env?.rooms?.length || env?.screens?.length);
-    envSlot.outerHTML = hasLightEnvironment && window.renderEnvironmentSection
-      ? (window.renderEnvironmentSection() || '')
-      : renderLightWidgetPrompt('No rooms mapped', 'Map a room', "window.addLightEnvRoom && window.addLightEnvRoom()", 'Map bedroom, office, screens, and evening light so Light can interpret your indoor day.', 'light-environment-prompt');
+    envSlot.outerHTML = window.renderEnvironmentAssessmentSummary
+      ? (window.renderEnvironmentAssessmentSummary() || '')
+      : renderLightWidgetPrompt('No rooms mapped', 'Open assessment', "window.openLightEnvironmentAssessment && window.openLightEnvironmentAssessment()", 'Map bedroom, office, screens, and evening light so Light can interpret your indoor day.', 'light-environment-prompt');
   }
   const toolsSlot = document.getElementById(toolsSlotId);
   if (toolsSlot) {

--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -574,7 +574,7 @@ export function showLight(_data) {
   widgets.push({
     id: 'light-environment',
     title: 'Indoor Light Assessment',
-    description: 'Rooms, screens, measurements, and saved audit snapshots',
+    description: 'Rooms, screens, readings, and saved audit snapshots',
     body: `<div id="${escapeAttr(environmentSlotId)}" class="light-widget-loading">Loading environment...</div>`,
     size: 'full',
     opts: { source: 'Light', dashboardId: '' },

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -228,6 +228,9 @@ export async function saveMeasurement(tool, value, opts = {}) {
   if (tool === 'spectrum' && opts.roomId && typeof window !== 'undefined' && typeof window.suggestRoomSourceFromSpectrum === 'function') {
     try { await window.suggestRoomSourceFromSpectrum(opts.roomId, value); } catch (e) {}
   }
+  if (typeof window !== 'undefined' && typeof window.refreshLightEnvironmentAssessment === 'function') {
+    try { window.refreshLightEnvironmentAssessment(); } catch (e) {}
+  }
   // Re-render the Light & Sun page if the user is on it so per-room
   // detail panels pick up the new reading + recompute severity dots.
   // Skip when any modal is still open — the tool may not have torn down

--- a/js/nav.js
+++ b/js/nav.js
@@ -160,15 +160,13 @@ export function buildSidebar(data) {
     navigate: 'fn:window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()',
     badge: emfAssessmentCount > 0 ? emfAssessmentCount : null,
   });
-  const lightEnv = state.importedData?.lightEnvironment || {};
-  const lightEnvItems = (Array.isArray(lightEnv.rooms) ? lightEnv.rooms.length : 0) +
-    (Array.isArray(lightEnv.screens) ? lightEnv.screens.length : 0);
+  const lightAuditCount = Array.isArray(state.importedData?.lightAudits) ? state.importedData.lightAudits.length : 0;
   html += _renderConditionalNavItem({
     key: 'light-env-assessment',
     icon: 'light',
     label: 'Light assessment',
     navigate: 'fn:window.openLightEnvironmentAssessment&&window.openLightEnvironmentAssessment()',
-    badge: lightEnvItems > 0 ? lightEnvItems : null,
+    badge: lightAuditCount > 0 ? lightAuditCount : null,
   });
 
   html += `<div class="nav-section">Manage</div>`;

--- a/js/nav.js
+++ b/js/nav.js
@@ -160,13 +160,14 @@ export function buildSidebar(data) {
     navigate: 'fn:window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()',
     badge: emfAssessmentCount > 0 ? emfAssessmentCount : null,
   });
+  const lightRoomCount = Array.isArray(state.importedData?.lightEnvironment?.rooms) ? state.importedData.lightEnvironment.rooms.length : 0;
   const lightAuditCount = Array.isArray(state.importedData?.lightAudits) ? state.importedData.lightAudits.length : 0;
   html += _renderConditionalNavItem({
     key: 'light-env-assessment',
     icon: 'light',
     label: 'Light assessment',
     navigate: 'fn:window.openLightEnvironmentAssessment&&window.openLightEnvironmentAssessment()',
-    badge: lightAuditCount > 0 ? lightAuditCount : null,
+    badge: lightRoomCount > 0 && lightAuditCount > 0 ? lightAuditCount : null,
   });
 
   html += `<div class="nav-section">Manage</div>`;

--- a/js/nav.js
+++ b/js/nav.js
@@ -160,6 +160,16 @@ export function buildSidebar(data) {
     navigate: 'fn:window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()',
     badge: emfAssessmentCount > 0 ? emfAssessmentCount : null,
   });
+  const lightEnv = state.importedData?.lightEnvironment || {};
+  const lightEnvItems = (Array.isArray(lightEnv.rooms) ? lightEnv.rooms.length : 0) +
+    (Array.isArray(lightEnv.screens) ? lightEnv.screens.length : 0);
+  html += _renderConditionalNavItem({
+    key: 'light-env-assessment',
+    icon: 'light',
+    label: 'Light assessment',
+    navigate: 'fn:window.openLightEnvironmentAssessment&&window.openLightEnvironmentAssessment()',
+    badge: lightEnvItems > 0 ? lightEnvItems : null,
+  });
 
   html += `<div class="nav-section">Manage</div>`;
   html += `<div class="nav-item" data-category="knowledge" tabindex="0" role="button" onclick="window.openKnowledgeBaseModal&&window.openKnowledgeBaseModal()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
@@ -271,7 +281,7 @@ export function filterSidebar() {
   // When searching: show matching items, expand groups with matches, hide empty groups
   items.forEach(el => {
     const cat = el.dataset.category;
-    if (cat === 'dashboard' || cat === 'labs' || cat === 'correlations' || cat === 'compare' || cat === 'recommendations' || cat === 'knowledge' || cat === 'custom-markers' || cat === 'light' || cat === 'body' || cat === 'wearables' || cat === 'emf' || cat === 'genome' || cat === 'genetics' || cat === 'insight') { el.style.display = ''; return; }
+    if (cat === 'dashboard' || cat === 'labs' || cat === 'correlations' || cat === 'compare' || cat === 'recommendations' || cat === 'knowledge' || cat === 'custom-markers' || cat === 'light' || cat === 'body' || cat === 'wearables' || cat === 'emf' || cat === 'light-env-assessment' || cat === 'genome' || cat === 'genetics' || cat === 'insight') { el.style.display = ''; return; }
     const label = el.textContent.toLowerCase();
     const markers = (el.dataset.markers || '').toLowerCase();
     el.style.display = (label.includes(query) || markers.includes(query)) ? '' : 'none';

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -335,6 +335,16 @@ const {
   assert('Assessment modal functions are exported on window',
     typeof window.openLightEnvironmentAssessment === 'function' &&
     typeof window.closeLightEnvironmentAssessment === 'function');
+  const navSrc = await (await import('node:fs/promises')).readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
+  const cssSrc = await (await import('node:fs/promises')).readFile(new URL('../css/light-sun.css', import.meta.url), 'utf8');
+  assert('Light assessment is linked from sidebar Analysis tools',
+    navSrc.includes("label: 'Light assessment'") &&
+    navSrc.includes("key: 'light-env-assessment'") &&
+    navSrc.indexOf('Analysis tools') < navSrc.indexOf("label: 'Light assessment'"));
+  const modalCss = cssSrc.match(/\.light-env-assessment-modal\s*\{[^}]+\}/)?.[0] || '';
+  assert('Assessment modal owns vertical scrolling',
+    /max-height:\s*calc\(100dvh - 48px\)/.test(modalCss) &&
+    /overflow-y:\s*auto/.test(modalCss));
 
   // ─── deleteRoom orphan cleanup ─────────────────────────────────────
   // Earlier deleteRoom dropped the room but left measurements + screens

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -30,6 +30,7 @@ const {
   computeRoomSeverity, computeScreenStatus,
   computeIndoorBurden, computeDeficitAxes,
   getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit,
+  renderEnvironmentAssessmentSummary, renderEnvironmentSection,
 } = env;
 
   const orig = window._labState.importedData;
@@ -314,6 +315,26 @@ const {
   await deleteLightAudit(audit.id);
   assert('deleteLightAudit removes from list',
     !getLightAudits().some(a => a.id === audit.id));
+
+  // ─── 11. Assessment surface renderers ───────────────────────────────
+  console.log('%c 11. Assessment surface renderers ', 'font-weight:bold;color:#f59e0b');
+
+  const summaryHtml = renderEnvironmentAssessmentSummary();
+  assert('Light page uses compact assessment summary shell',
+    summaryHtml.includes('light-env-assessment-summary') &&
+    summaryHtml.includes('Open assessment') &&
+    !summaryHtml.includes('light-env-room-disclosure'));
+  const fullHtml = renderEnvironmentSection();
+  assert('Full environment section remains available for the assessment workspace',
+    fullHtml.includes('class="light-env-head"') &&
+    fullHtml.includes('light-env-room-disclosure'));
+  const embeddedHtml = renderEnvironmentSection({ embedded: true });
+  assert('Embedded assessment section suppresses duplicate page header',
+    embeddedHtml.includes('light-env-section-embedded') &&
+    !embeddedHtml.includes('class="light-env-head"'));
+  assert('Assessment modal functions are exported on window',
+    typeof window.openLightEnvironmentAssessment === 'function' &&
+    typeof window.closeLightEnvironmentAssessment === 'function');
 
   // ─── deleteRoom orphan cleanup ─────────────────────────────────────
   // Earlier deleteRoom dropped the room but left measurements + screens

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -335,12 +335,20 @@ const {
   assert('Assessment modal functions are exported on window',
     typeof window.openLightEnvironmentAssessment === 'function' &&
     typeof window.closeLightEnvironmentAssessment === 'function');
+  const envSrc = await (await import('node:fs/promises')).readFile(new URL('../js/light-env.js', import.meta.url), 'utf8');
+  assert('Assessment modal uses user-facing indoor assessment copy',
+    envSrc.includes('Indoor Light Assessment') &&
+    envSrc.includes('Save audit snapshots before and after changes') &&
+    !envSrc.includes('The Light page keeps the summary'));
   const navSrc = await (await import('node:fs/promises')).readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const cssSrc = await (await import('node:fs/promises')).readFile(new URL('../css/light-sun.css', import.meta.url), 'utf8');
   assert('Light assessment is linked from sidebar Analysis tools',
     navSrc.includes("label: 'Light assessment'") &&
     navSrc.includes("key: 'light-env-assessment'") &&
     navSrc.indexOf('Analysis tools') < navSrc.indexOf("label: 'Light assessment'"));
+  assert('Light assessment sidebar badge reflects saved audit snapshots',
+    navSrc.includes('lightAuditCount') &&
+    !navSrc.includes('lightEnvItems'));
   const modalCss = cssSrc.match(/\.light-env-assessment-modal\s*\{[^}]+\}/)?.[0] || '';
   assert('Assessment modal owns vertical scrolling',
     /max-height:\s*calc\(100dvh - 48px\)/.test(modalCss) &&

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -348,11 +348,36 @@ const {
     navSrc.indexOf('Analysis tools') < navSrc.indexOf("label: 'Light assessment'"));
   assert('Light assessment sidebar badge reflects saved audit snapshots',
     navSrc.includes('lightAuditCount') &&
+    navSrc.includes('lightRoomCount') &&
     !navSrc.includes('lightEnvItems'));
   const modalCss = cssSrc.match(/\.light-env-assessment-modal\s*\{[^}]+\}/)?.[0] || '';
   assert('Assessment modal owns vertical scrolling',
     /max-height:\s*calc\(100dvh - 48px\)/.test(modalCss) &&
     /overflow-y:\s*auto/.test(modalCss));
+  const beforeEmptyAssessment = window._labState.importedData;
+  window._labState.importedData = {
+    lightEnvironment: { rooms: [], screens: [] },
+    lightMeasurements: [{ id: 'orphan-reading', tool: 'lux', roomId: null, value: 50, takenAt: Date.now() }],
+    lightAudits: [{ id: 'old-audit', date: '2026-05-01', label: 'Old room' }],
+  };
+  const emptySummaryHtml = renderEnvironmentAssessmentSummary();
+  const emptyAssessmentHtml = renderEnvironmentSection({ embedded: true });
+  assert('Assessment summary hides orphan readings and audits when no rooms are mapped',
+    !emptySummaryHtml.includes('Readings') &&
+    !emptySummaryHtml.includes('Audits') &&
+    emptySummaryHtml.includes('Start assessment'));
+  assert('Assessment workspace hides orphan readings and audits until a room is mapped',
+    !emptyAssessmentHtml.includes('Portable readings') &&
+    !emptyAssessmentHtml.includes('Light audits'));
+  assert('Room and portable-screen empty states share header actions plus quick-picks',
+    emptyAssessmentHtml.includes('+ Room') &&
+    emptyAssessmentHtml.includes('+ Screen') &&
+    emptyAssessmentHtml.includes('Start with') &&
+    emptyAssessmentHtml.includes('Bedroom') &&
+    emptyAssessmentHtml.includes('📱 Phone') &&
+    !emptyAssessmentHtml.includes('+ Bedroom') &&
+    !emptyAssessmentHtml.includes('+ 📱 Phone'));
+  window._labState.importedData = beforeEmptyAssessment;
 
   // ─── deleteRoom orphan cleanup ─────────────────────────────────────
   // Earlier deleteRoom dropped the room but left measurements + screens

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -144,6 +144,11 @@ return (async function() {
     !!sidebar.querySelector('.nav-item[data-category="emf"]') &&
       analysisIndex > -1 && emfIndex > -1 && manageIndex > -1 &&
       analysisIndex < emfIndex && emfIndex < manageIndex);
+  const lightAssessmentIndex = sidebarText.indexOf('Light assessment');
+  assert('Sidebar exposes Light assessment as an analysis tool',
+    !!sidebar.querySelector('.nav-item[data-category="light-env-assessment"]') &&
+      analysisIndex > -1 && lightAssessmentIndex > -1 && manageIndex > -1 &&
+      analysisIndex < lightAssessmentIndex && lightAssessmentIndex < manageIndex);
 
   // Header elements
   assert('Header dates populated', document.getElementById('header-dates')?.innerHTML.length > 10);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.219';
+self.APP_VERSION = '1.8.220';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.220';
+self.APP_VERSION = '1.8.221';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.218';
+self.APP_VERSION = '1.8.219';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.217';
+self.APP_VERSION = '1.8.218';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.216';
+self.APP_VERSION = '1.8.217';


### PR DESCRIPTION
## Summary
- Replace the full Light Environment page widget with a compact Indoor Light Assessment summary.
- Move the rooms, screens, readings, and light audit workflow into a dedicated assessment modal.
- Add a Light assessment shortcut under sidebar Analysis tools, matching the EMF assessment pattern.
- Keep the assessment modal and Light page summary refreshed after environment edits and light tool measurements.
- Fix the assessment modal so the modal body owns vertical scrolling and works with the shared modal wheel guard.
- Polish the Light page vs assessment copy so the page reads as a summary surface and the modal reads as the indoor assessment workspace.
- Hide orphan readings/audit history from the active assessment when no rooms are mapped, and align room/screen empty-state CTAs.
- Remove dead Light assessment quick-pick CSS and let screen quick-picks reuse the shared quick-pick row styling.

## Validation
- `node tests/test-light-env.js`
- `node tests/test-light-tools.js`
- `node tests/test-audit.js`
- `./run-tests.sh`
- Focused Chromium smoke: Analysis tools shortcut opens the Light assessment modal and wheel scrolling advances the modal body.
- Focused Chromium smoke: revised Light assessment copy renders, old implementation-language copy is absent, and the sidebar badge reflects saved audit snapshots.
- Focused Chromium smoke: no-room assessment hides orphan readings/audits, uses matching room/screen add controls, and suppresses the sidebar audit badge.
- Focused Chromium smoke: cleaned screen quick-pick CSS still inherits the shared flex row layout.