### PR TITLE
[codex] Fix onboarding and focus card display

### DIFF
--- a/css/dashboard-widgets.css
+++ b/css/dashboard-widgets.css
@@ -69,17 +69,6 @@
 .dashboard-widget[data-widget-id="focus"] .focus-card {
   align-items: flex-start;
   margin: 0;
-  max-height: 222px;
-}
-.dashboard-widget[data-widget-id="focus"] .focus-card-body {
-  max-height: 176px;
-  overflow: hidden;
-}
-.dashboard-widget[data-widget-id="focus"] .focus-card-text {
-  display: -webkit-box;
-  -webkit-line-clamp: 8;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 .dashboard-widget-inline-controls {
   display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px;

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -46,8 +46,9 @@ export function renderEmptyChatState(container, panel) {
 
   const filled = _countFilledCards();
   const extrasDone = localStorage.getItem(`labcharts-onboard-extras-done-${state.currentProfile}`);
+  const forceContextCards = sessionStorage.getItem(`chat-onboard-force-context-cards-${state.currentProfile}`) === '1';
 
-  if (!context.hasData && !extrasDone) return renderOptionalContextState(container, panel, context);
+  if (!context.hasData && !extrasDone && !forceContextCards) return renderOptionalContextState(container, panel, context);
   if (filled >= 9 && !context.hasData) return renderFullContextNoDataState(container, panel, context);
   if (!context.hasData && filled > 0) return renderPartialContextNoDataState(container, panel, context, filled);
   if (!context.hasData) return renderInitialNoDataState(container, panel, context);
@@ -68,6 +69,10 @@ function getEmptyChatContext() {
 
 function setOnboardingActive(panel) {
   panel?.classList.add('chat-onboarding-active');
+}
+
+function renderChatContextCards() {
+  return `<div class="chat-context-cards">${renderProfileContextCards()}</div>`;
 }
 
 function shouldRenderProviderSetup() {
@@ -287,6 +292,7 @@ function renderPartialContextNoDataState(container, panel, { personality, name }
   setOnboardingActive(panel);
   const remaining = 9 - filled;
   const progressPct = Math.round((filled / 9) * 100);
+  const providerConnected = hasAIProvider();
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
       ${_renderOnboardCrumbs(4)}
@@ -294,35 +300,35 @@ function renderPartialContextNoDataState(container, panel, { personality, name }
       <div class="chat-onboard-progress"><div class="chat-onboard-progress-bar" style="width:${progressPct}%"></div></div>
       <p style="font-size:12px;color:var(--text-muted);margin:4px 0 0">The more context I have, the better I can interpret results and recommend what to test. Everything is optional.</p>
       <div class="chat-onboard-actions">
-        ${hasAIProvider()
-          ? `<button class="chat-onboard-cta" onclick="useChatPrompt('Help me finish the remaining health context. Ask me one question at a time.')">Continue in chat - ${remaining} area${remaining !== 1 ? 's' : ''} left</button>
-             <button class="chat-prompt-btn" onclick="useChatPrompt('Based on what you know about me so far, what blood tests should I get?')">Skip ahead - recommend tests</button>`
-          : `<button class="chat-onboard-cta" onclick="document.querySelector('.chat-context-cards')?.scrollIntoView({behavior:'smooth',block:'start'})">Continue context cards</button>
-             <button class="chat-prompt-btn" onclick="window.openChatProviderQuiz()">Connect AI for recommendations</button>`}
+        <button class="chat-onboard-cta" onclick="document.querySelector('.chat-context-cards')?.scrollIntoView({behavior:'smooth',block:'start'})">Continue context cards - ${remaining} area${remaining !== 1 ? 's' : ''} left</button>
+        ${providerConnected
+          ? `<button class="chat-prompt-btn" onclick="useChatPrompt('Based on what you know about me so far, what blood tests should I get?')">Skip ahead - recommend tests</button>`
+          : `<button class="chat-prompt-btn" onclick="window.openChatProviderQuiz()">Connect AI for recommendations</button>`}
       </div>
-      ${!hasAIProvider() ? `<div class="chat-context-cards">${renderProfileContextCards()}</div>` : ''}
+      ${renderChatContextCards()}
     </div>`;
   return true;
 }
 
 function renderInitialNoDataState(container, panel, { personality, name }) {
   setOnboardingActive(panel);
+  const providerConnected = hasAIProvider();
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
       ${_renderOnboardCrumbs(4)}
       <p>You're ready to go, ${escapeHTML(name)}. Tell me what you have or what you want to understand, and I'll guide the next step.</p>
-      <p style="font-size:13px;margin:4px 0"><strong>Have lab results?</strong> ${hasAIProvider() ? "Import them directly and I'll build the dashboard." : 'Connect AI first for lab PDFs or photos. JSON and DNA files can still be imported from the header.'}</p>
-      <p style="font-size:13px;margin:4px 0"><strong>No labs yet?</strong> ${hasAIProvider() ? 'I can ask for the useful context here and recommend what to test first.' : 'Add useful context below, then connect AI when you want recommendations.'}</p>
+      <p style="font-size:13px;margin:4px 0"><strong>Have lab results?</strong> ${providerConnected ? "Import them directly and I'll build the dashboard." : 'Connect AI first for lab PDFs or photos. JSON and DNA files can still be imported from the header.'}</p>
+      <p style="font-size:13px;margin:4px 0"><strong>No labs yet?</strong> Add useful context below${providerConnected ? ', then ask for recommended tests when you are ready.' : ', then connect AI when you want recommendations.'}</p>
       <div class="chat-onboard-actions">
-        ${hasAIProvider()
+        ${providerConnected
           ? `<button class="chat-onboard-cta" onclick="window.startOnboardingLabImport()">Import a lab file</button>
-             <button class="chat-onboard-cta" onclick="useChatPrompt('Help me build my health context before labs. Ask me one question at a time.')">Build my context in chat</button>
+             <button class="chat-onboard-cta" onclick="document.querySelector('.chat-context-cards')?.scrollIntoView({behavior:'smooth',block:'start'})">Add context below</button>
              <button class="chat-prompt-btn" onclick="useChatPrompt('I don\\'t have any labs yet. Based on my profile, what blood tests should I get and why?')">Just tell me what to test</button>`
           : `<button class="chat-onboard-cta" onclick="window.requestOnboardingLabImportProvider()">Connect AI to import labs</button>
              <button class="chat-onboard-cta" onclick="document.querySelector('.chat-context-cards')?.scrollIntoView({behavior:'smooth',block:'start'})">Add context below</button>
              <button class="chat-prompt-btn" onclick="window.openChatProviderQuiz()">Connect AI when ready</button>`}
       </div>
-      ${!hasAIProvider() ? `<div class="chat-context-cards">${renderProfileContextCards()}</div>` : ''}
+      ${renderChatContextCards()}
     </div>`;
   return true;
 }

--- a/js/onboarding-view.js
+++ b/js/onboarding-view.js
@@ -132,15 +132,22 @@ export function setOnboardingFocus(mode) {
     localStorage.setItem('labcharts-chat-fullscreen', 'false');
   }
   if (mode === 'cards') {
+    sessionStorage.setItem(`chat-onboard-force-context-cards-${state.currentProfile}`, '1');
     const cards = document.querySelector('.profile-context-cards');
     if (cards) {
       setTimeout(() => cards.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100);
     } else if (window.openChatPanel) {
       body.classList.remove('cards-focus');
-      const prefill = hasAIProvider()
-        ? 'Help me collect the health context you need before I import labs. Ask me one question at a time.'
-        : undefined;
-      window.openChatPanel(prefill);
+      Promise.resolve(window.openChatPanel()).then(() => {
+        if (!document.querySelector('#chat-panel .chat-context-cards') && state.chatHistory.length > 0 && window.createNewThread) {
+          window.createNewThread();
+        } else {
+          window.renderChatMessages?.();
+        }
+        setTimeout(() => {
+          document.querySelector('#chat-panel .chat-context-cards')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
+      });
     }
   } else if (mode === 'import') {
     setTimeout(() => document.querySelector('.welcome-direct-import-btn, .welcome-primary-panel')?.scrollIntoView({ behavior: 'smooth', block: 'center' }), 100);

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -369,6 +369,15 @@ const lightSessionLogEnd = lightPageViewSrc.indexOf('function renderLightWidgetP
 const lightSessionLogBlock = lightSessionLogStart >= 0 && lightSessionLogEnd > lightSessionLogStart
   ? lightPageViewSrc.slice(lightSessionLogStart, lightSessionLogEnd)
   : '';
+const dashboardFocusCardBlock = (cssSrc.match(/\.dashboard-widget\[data-widget-id="focus"\] \.focus-card\s*{([\s\S]*?)}/) || [null, ''])[1];
+const dashboardFocusCardBodyBlock = (cssSrc.match(/\.dashboard-widget\[data-widget-id="focus"\] \.focus-card-body\s*{([\s\S]*?)}/) || [null, ''])[1];
+const dashboardFocusCardTextBlock = (cssSrc.match(/\.dashboard-widget\[data-widget-id="focus"\] \.focus-card-text\s*{([\s\S]*?)}/) || [null, ''])[1];
+assert('Dashboard focus card does not truncate AI output',
+  dashboardFocusCardBlock &&
+  !/max-height\s*:/.test(dashboardFocusCardBlock) &&
+  !/overflow\s*:\s*hidden/.test(dashboardFocusCardBodyBlock || '') &&
+  !/-webkit-line-clamp|line-clamp|overflow\s*:\s*hidden/.test(dashboardFocusCardTextBlock || ''),
+  'Dashboard and Insight should show the same full focus-card text');
 assert('Light page renders as a reorderable page widget route',
   lightPageViewSrc.includes("renderLensPageWidgets('light', widgets)") &&
   lightPageViewSrc.includes("id: 'light-conditions-now'") &&

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -29,6 +29,7 @@ const chatEmptyStateSrc = read('js/chat-empty-state.js');
 const chatRenderSrc = read('js/chat-render.js');
 const chatSendSrc = read('js/chat-send.js');
 const labCtxSrc = read('js/lab-context.js');
+const onboardingViewSrc = read('js/onboarding-view.js');
 
   assert('No sentinel return string', !labCtxSrc.includes("return 'No lab data is currently loaded for this profile.'"),
     'The old sentinel early-return should be removed');
@@ -256,8 +257,19 @@ const labCtxSrc = read('js/lab-context.js');
     'Optional setup should use compact cards and preserve DNA import update hook');
   assert('Chat onboarding makes AI provider setup explicit', chatEmptyStateSrc.includes('chat-onboard-provider-requested') && !chatEmptyStateSrc.includes('!providerSkipped'),
     'No-provider users should continue into context first unless they ask to connect AI');
-  assert('Chat onboarding embeds context cards when AI is not connected', chatEmptyStateSrc.includes("import { renderProfileContextCards } from './context-cards.js'") && chatEmptyStateSrc.includes('chat-context-cards'),
-    'No-provider users should still be able to add context inside chat');
+  assert('Chat onboarding embeds context cards for provider and no-provider users',
+    chatEmptyStateSrc.includes("import { renderProfileContextCards } from './context-cards.js'") &&
+      chatEmptyStateSrc.includes('function renderChatContextCards()') &&
+      chatEmptyStateSrc.includes('${renderChatContextCards()}') &&
+      !chatEmptyStateSrc.includes('${!hasAIProvider() ? `<div class="chat-context-cards"'),
+    'Context cards should stay available inside chat even after AI is connected');
+  assert('Card onboarding focus opens card UI instead of AI prompt prefill',
+    onboardingViewSrc.includes('window.openChatPanel()') &&
+      onboardingViewSrc.includes('chat-onboard-force-context-cards') &&
+      chatEmptyStateSrc.includes('forceContextCards') &&
+      onboardingViewSrc.includes('#chat-panel .chat-context-cards') &&
+      !onboardingViewSrc.includes('Help me collect the health context'),
+    'setOnboardingFocus("cards") should scroll to card editors, not prefill a prompt');
   assert('Chat onboarding lab import CTA handles no-provider state', chatEmptyStateSrc.includes('startOnboardingLabImport') && chatEmptyStateSrc.includes('requestOnboardingLabImportProvider') && chatEmptyStateSrc.includes('Connect AI to import labs'),
     'No-provider lab-import CTA should explain AI setup instead of focusing hidden import controls');
   assert('Chat onboarding hides composer while active', cssSrc.includes('.chat-panel.chat-onboarding-active .chat-input-area') && cssSrc.includes('display: none'),

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.251';
+self.APP_VERSION = '1.8.252';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.250';
+self.APP_VERSION = '1.8.251';


### PR DESCRIPTION
## Summary
- Keep the 9 profile context card editors rendered in chat for both AI-connected and no-provider onboarding states.
- Make explicit context-card focus open the card UI instead of pre-filling an AI prompt, and bypass the optional extras interstitial only for that session.
- Remove the dashboard-only focus-card line clamp so Current Focus shows the full output like the Insight page.
- Add regression coverage and bump `version.js` for cache invalidation.

## Root Cause
The provider-connected onboarding path replaced the card editors with AI prompt CTAs. `setOnboardingFocus('cards')` also prefilled a chat prompt when the dashboard card widget was not present, so users were sent into chat instead of the actual card-editing flow.

The focus card used the same renderer on Dashboard and Insight, but the Dashboard widget CSS capped the card to 8 lines with hidden overflow, producing an ellipsis while Insight remained full length.

## Validation
- `node --check js/chat-empty-state.js`
- `node --check js/onboarding-view.js`
- `node tests/test-prelab.js`
- `node tests/test-audit.js`
- Provider-connected Puppeteer smoke: context cards render, no AI prompt prefilled
- No-provider mobile Puppeteer smoke: context cards render, chat input disabled, no horizontal overflow
- Dashboard focus-card Puppeteer smoke: long output has no max-height, no line clamp, no hidden overflow
- `./run-tests.sh` before the focus-card follow-up