### PR TITLE
[codex] Extract supplement impact module

### DIFF
--- a/js/focus-card.js
+++ b/js/focus-card.js
@@ -9,6 +9,7 @@ import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from '.
 import { injectLensChunks } from './lab-context.js';
 import { hasLens, queryLens } from './lens.js';
 import { applyInlineMarkdown } from './markdown.js';
+import { computeAllImpacts } from './supplement-impact.js';
 
 export function renderFocusCard() {
   const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
@@ -86,7 +87,7 @@ export function buildFocusContext() {
       else if (lastDate && data.dates.length >= 2 && firstStart > data.dates[data.dates.length - 2]) timing = ' (started between last two labs)';
       let impactNote = '';
       if (!timing && data.dates.length >= 2) {
-        const impacts = window.computeAllImpacts?.(s, data);
+        const impacts = computeAllImpacts(s, data);
         if (impacts && impacts.length > 0) {
           const top = impacts.slice(0, 2).filter(im => im.confidence !== 'low');
           if (top.length > 0) {

--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -9,7 +9,7 @@ import { getProfileLocation, getLatitudeFromLocation } from './profile.js';
 import { getBloodDrawPhases, getNextBestDrawDate, detectPerimenopausePattern, detectCycleIronAlerts } from './cycle.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
 import { scanDietForContaminants } from './food-contaminants.js';
-import { ingredientDailyTotal, effectiveTimesPerDay } from './supplements.js';
+import { ingredientDailyTotal, effectiveTimesPerDay } from './supplement-impact.js';
 import { CANONICAL_METRICS, DEFAULT_METRIC_ORDER } from './wearable-adapters.js';
 
 // ═══════════════════════════════════════════════

--- a/js/supplement-impact.js
+++ b/js/supplement-impact.js
@@ -1,0 +1,303 @@
+// supplement-impact.js - supplement dose math and lab impact analysis
+
+import { state } from './state.js';
+import { callClaudeAPI, hasAIProvider } from './api.js';
+import { getActiveData } from './data.js';
+import { profileStorageKey } from './profile.js';
+import { escapeHTML, hashString, isDebugMode } from './utils.js';
+
+export function getSupplementPeriods(s) {
+  if (s?.periods && s.periods.length > 0) return s.periods;
+  return [{ start: s?.startDate, end: s?.endDate }];
+}
+
+// Extract numeric value + unit from amount strings like "890mg", "500 IU", "25 mcg", "5,4 mg".
+// Handles both dot and comma decimal separators. Returns null for pure text ("once daily").
+export function parseAmount(str) {
+  if (!str || typeof str !== 'string') return null;
+  const match = str.trim().match(/^(\d+(?:[.,]\d+)?)\s*([a-zA-Zµμ]+)?/);
+  if (!match) return null;
+  const value = parseFloat(match[1].replace(',', '.'));
+  if (!isFinite(value)) return null;
+  const unit = (match[2] || '').trim();
+  return { value, unit };
+}
+
+// Effective timesPerDay for an ingredient: row override wins, else the supp-level default.
+export function effectiveTimesPerDay(ing, supp) {
+  if (ing && (ing.timesPerDay === 0 || ing.timesPerDay)) return Number(ing.timesPerDay);
+  if (supp && (supp.timesPerDay === 0 || supp.timesPerDay)) return Number(supp.timesPerDay);
+  return null;
+}
+
+// Compute daily total when amount is parseable and there's an effective timesPerDay.
+export function ingredientDailyTotal(ing, supp) {
+  const times = effectiveTimesPerDay(ing, supp);
+  if (!ing || !times) return null;
+  const parsed = parseAmount(ing.amount);
+  if (!parsed) return null;
+  const total = parsed.value * times;
+  if (!isFinite(total)) return null;
+  return { value: total, unit: parsed.unit, times };
+}
+
+export function formatSupplementTotal(total) {
+  if (!total) return '';
+  const v = total.value % 1 === 0 ? total.value.toString() : total.value.toFixed(2).replace(/\.?0+$/, '');
+  return `${v}${total.unit ? ' ' + total.unit : ''}/day`;
+}
+
+export function computeSupplementImpact(supplement, markerKey, markerName, unit, values, dates, refMin, refMax) {
+  if (!values || !dates || values.length !== dates.length) return null;
+  const pds = getSupplementPeriods(supplement);
+  const sortedPds = [...pds].sort((a, b) => a.start.localeCompare(b.start));
+  const firstStart = sortedPds[0].start;
+  const isInPeriod = (date) => sortedPds.some(p => date >= p.start && (!p.end || date <= p.end));
+  const beforeValues = [], afterValues = [];
+  for (let i = 0; i < dates.length; i++) {
+    if (values[i] === null) continue;
+    if (dates[i] < firstStart) {
+      beforeValues.push(values[i]);
+    } else if (isInPeriod(dates[i])) {
+      afterValues.push(values[i]);
+    }
+  }
+  if (beforeValues.length === 0 && afterValues.length === 0) return null;
+  const mean = arr => arr.reduce((s, v) => s + v, 0) / arr.length;
+  const beforeMean = beforeValues.length > 0 ? mean(beforeValues) : null;
+  const afterMean = afterValues.length > 0 ? mean(afterValues) : null;
+  let pctChange = null, direction = 'stable';
+  if (beforeMean !== null && afterMean !== null && beforeMean !== 0) {
+    pctChange = ((afterMean - beforeMean) / Math.abs(beforeMean)) * 100;
+    direction = Math.abs(pctChange) < 1 ? 'stable' : pctChange > 0 ? 'up' : 'down';
+  }
+  let confidence = 'low';
+  if (beforeValues.length >= 3 && afterValues.length >= 3) confidence = 'high';
+  else if (beforeValues.length >= 2 && afterValues.length >= 2) confidence = 'moderate';
+  return {
+    marker: markerKey, markerName, unit,
+    beforeMean, afterMean, pctChange, direction, confidence,
+    nBefore: beforeValues.length, nAfter: afterValues.length,
+    refMin, refMax
+  };
+}
+
+export function computeAllImpacts(supplement, data) {
+  if (!data || !data.categories || !data.dates) return [];
+  const results = [];
+  for (const [catKey, cat] of Object.entries(data.categories)) {
+    for (const [mKey, marker] of Object.entries(cat.markers)) {
+      const dotKey = catKey + '.' + mKey;
+      const impact = computeSupplementImpact(
+        supplement, dotKey, marker.name, marker.unit,
+        marker.values, data.dates, marker.refMin, marker.refMax
+      );
+      if (impact && impact.pctChange !== null && Math.abs(impact.pctChange) >= 1) {
+        results.push(impact);
+      }
+    }
+  }
+  results.sort((a, b) => Math.abs(b.pctChange) - Math.abs(a.pctChange));
+  return results;
+}
+
+function getOverlappingSupplements(supplement, supps) {
+  const sPds = getSupplementPeriods(supplement);
+  return supps.filter(s => {
+    if (s === supplement) return false;
+    const oPds = getSupplementPeriods(s);
+    return sPds.some(sp => oPds.some(op => {
+      const sEnd = sp.end || '9999-12-31';
+      const oEnd = op.end || '9999-12-31';
+      return sp.start <= oEnd && op.start <= sEnd;
+    }));
+  });
+}
+
+// Per-supplement fingerprint: changes when that supp's edit-visible fields or lab dates change.
+// Editing dosage/ingredients/periods for one supp invalidates only that supp's cache entry.
+function getSuppFingerprint(supp, data) {
+  const labPart = (data.dates || []).join(',');
+  const pds = getSupplementPeriods(supp);
+  const ings = (supp.ingredients || []).map(i => `${i.name}:${i.amount || ''}:${i.timesPerDay || ''}`).join(',');
+  const suppPart = `${supp.name}|${supp.dosage || ''}|${supp.timesPerDay || ''}|${supp.type || ''}|${ings}|${pds.map(p => p.start + '~' + (p.end || '')).join(',')}`;
+  return hashString(labPart + '||' + suppPart);
+}
+
+function getImpactCache() {
+  try {
+    const key = profileStorageKey(state.currentProfile, 'suppImpact');
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : {};
+    // Migrate old batch-fingerprint schema (values without `fp` field) by discarding.
+    for (const k of Object.keys(parsed)) {
+      if (!parsed[k] || typeof parsed[k] !== 'object' || typeof parsed[k].fp !== 'string') delete parsed[k];
+    }
+    return parsed;
+  } catch { return {}; }
+}
+
+function setImpactCache(cache) {
+  try {
+    const key = profileStorageKey(state.currentProfile, 'suppImpact');
+    localStorage.setItem(key, JSON.stringify(cache));
+  } catch { /* quota exceeded */ }
+}
+
+// Debounced queue: coalesces multiple render calls into a single AI request for only the stale/missing supps.
+let _pendingAnalyses = new Map(); // suppName -> { supplement, editIdx }
+let _analyzeTimer = null;
+let _batchPromise = null;
+
+export function renderSupplementImpact(supplement, editIdx) {
+  const hasAI = hasAIProvider();
+  const data = getActiveData();
+  if (!data || !data.dates || data.dates.length < 2) {
+    return `<div class="supp-impact-section"><div class="supp-impact-header"><span class="ctx-health-dot ctx-health-dot-gray"></span><span>Impact Analysis</span></div><div class="supp-impact-hint">Needs at least 2 lab dates to compare</div></div>`;
+  }
+  const impacts = computeAllImpacts(supplement, data);
+  if (impacts.length === 0) {
+    const hasAfter = data.dates.some(d => d >= supplement.startDate);
+    const hasBefore = data.dates.some(d => d < supplement.startDate);
+    const hint = !hasBefore ? 'No lab results from before this supplement was started'
+      : !hasAfter ? 'No lab results since starting this supplement'
+      : 'No significant marker changes detected yet';
+    return `<div class="supp-impact-section"><div class="supp-impact-header"><span class="ctx-health-dot ctx-health-dot-gray"></span><span>Impact Analysis</span></div><div class="supp-impact-hint">${hint}</div></div>`;
+  }
+
+  const fp = getSuppFingerprint(supplement, data);
+  const cache = getImpactCache();
+  const entry = cache[supplement.name];
+  const cached = (entry && entry.fp === fp) ? entry : null;
+
+  const dotColor = cached ? `ctx-health-dot-${cached.dot}` : (hasAI ? 'ctx-health-dot-shimmer' : 'ctx-health-dot-gray');
+  const summaryClass = cached ? `supp-impact-summary-visible supp-impact-summary-${cached.dot}` : '';
+  const summaryText = cached ? escapeHTML(cached.summary) : (hasAI ? '' : 'Set up an AI provider for impact insights');
+
+  const html = `<div class="supp-impact-section">
+    <div class="supp-impact-header">
+      <span class="ctx-health-dot ${dotColor}" id="supp-impact-dot-${editIdx}"></span>
+      <span>Impact Analysis</span>
+      ${cached && hasAI ? `<button class="supp-impact-refresh" onclick="refreshSupplementImpact(${editIdx})" title="Re-analyze with current data">refresh</button>` : ''}
+    </div>
+    <div class="supp-impact-summary ${summaryClass}" id="supp-impact-summary-${editIdx}">${summaryText}</div>
+  </div>`;
+
+  // Auto-fire only if fingerprint mismatch (edit) or missing entirely - scoped to this supp only.
+  if (!cached && hasAI) scheduleAnalyze(supplement, editIdx, data);
+  return html;
+}
+
+function scheduleAnalyze(supplement, editIdx, data) {
+  _pendingAnalyses.set(supplement.name, { supplement, editIdx });
+  if (_analyzeTimer) return;
+  _analyzeTimer = setTimeout(() => { _analyzeTimer = null; flushAnalyses(data); }, 50);
+}
+
+async function flushAnalyses(data) {
+  const pending = [..._pendingAnalyses.values()];
+  _pendingAnalyses.clear();
+  if (pending.length === 0) return;
+  if (_batchPromise) await _batchPromise;
+  await loadImpactsForSupps(pending, data);
+}
+
+async function loadImpactsForSupps(pending, data) {
+  const allSupps = state.importedData.supplements || [];
+  const suppEntries = [];
+  for (const { supplement: s, editIdx } of pending) {
+    const impacts = computeAllImpacts(s, data);
+    if (impacts.length === 0) continue;
+    suppEntries.push({ supplement: s, impacts, editIdx });
+  }
+  if (suppEntries.length === 0) return;
+
+  const fmtVal = v => v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
+  let ctx = `Analyze ${suppEntries.length} supplement${suppEntries.length === 1 ? '' : 's'}:\n`;
+  for (const { supplement: s, impacts } of suppEntries) {
+    const top = impacts.slice(0, 5);
+    const overlapping = getOverlappingSupplements(s, allSupps);
+    const pds = getSupplementPeriods(s);
+    const pdStr = pds.length === 1
+      ? `since ${pds[0].start}${pds[0].end ? ' until ' + pds[0].end : ''}`
+      : `CYCLING: ${pds.map(p => p.start + ' to ' + (p.end || 'ongoing')).join('; ')}`;
+    ctx += `\n[${s.name}] ${s.dosage || ''} (${s.type}) ${pdStr}`;
+    if (s.ingredients?.length) ctx += ` ingredients: ${s.ingredients.map(ing => {
+      const total = ingredientDailyTotal(ing, s);
+      const times = effectiveTimesPerDay(ing, s);
+      if (total) return `${ing.name} ${ing.amount} x ${times}/day = ${formatSupplementTotal(total)}`;
+      if (times) return `${ing.name}${ing.amount ? ' ' + ing.amount : ''} x ${times}/day`;
+      return `${ing.name}${ing.amount ? ' ' + ing.amount : ''}`;
+    }).join(', ')}`;
+    if (overlapping.length > 0) ctx += ` (also taking: ${overlapping.map(o => o.name).join(', ')})`;
+    ctx += `\n`;
+    for (const imp of top) {
+      ctx += `  ${imp.markerName}: ${fmtVal(imp.beforeMean)}->${fmtVal(imp.afterMean)} ${imp.unit} (${imp.pctChange > 0 ? '+' : ''}${imp.pctChange.toFixed(0)}%)`;
+      if (imp.refMin != null || imp.refMax != null) ctx += ` ref ${imp.refMin ?? ''}-${imp.refMax ?? ''}`;
+      ctx += `\n`;
+    }
+  }
+
+  const names = suppEntries.map(e => `"${e.supplement.name}"`).join(', ');
+  const system = `ONLY JSON, no thinking, no explanation: {${names}: {"dot":"green|yellow|red|gray","summary":"max 20 words"}, ...}
+green=beneficial, yellow=mixed, red=concerning, gray=insufficient data. Mention key markers.`;
+
+  _batchPromise = (async () => {
+    try {
+      const result = await callClaudeAPI({ system, messages: [{ role: 'user', content: ctx }], maxTokens: 300 * suppEntries.length + 1000 });
+      const cleaned = result.text.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+      const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) return;
+      const parsed = JSON.parse(jsonMatch[0]);
+
+      const cache = getImpactCache();
+      for (const { supplement: s, editIdx } of suppEntries) {
+        const entry = parsed[s.name];
+        if (!entry || typeof entry !== 'object') continue;
+        const record = {
+          fp: getSuppFingerprint(s, data),
+          dot: ['green', 'yellow', 'red', 'gray'].includes(entry.dot) ? entry.dot : 'gray',
+          summary: typeof entry.summary === 'string' ? entry.summary.slice(0, 150) : ''
+        };
+        cache[s.name] = record;
+        applyImpactToDOM(editIdx, record);
+      }
+      // Cap cache at 50 entries (one per supp).
+      const keys = Object.keys(cache);
+      if (keys.length > 50) { for (const k of keys.slice(0, keys.length - 50)) delete cache[k]; }
+      setImpactCache(cache);
+    } catch (e) { if (isDebugMode()) console.warn('[suppImpact] AI failed:', e.message || e); }
+  })();
+
+  await _batchPromise;
+  _batchPromise = null;
+}
+
+export function refreshSupplementImpact(editIdx) {
+  const supps = state.importedData.supplements || [];
+  const s = supps[editIdx];
+  if (!s) return;
+  const data = getActiveData();
+  if (!data) return;
+  const cache = getImpactCache();
+  delete cache[s.name];
+  setImpactCache(cache);
+  const dotEl = document.getElementById(`supp-impact-dot-${editIdx}`);
+  if (dotEl) dotEl.className = 'ctx-health-dot ctx-health-dot-shimmer';
+  const sumEl = document.getElementById(`supp-impact-summary-${editIdx}`);
+  if (sumEl) { sumEl.textContent = ''; sumEl.className = 'supp-impact-summary'; }
+  const refreshBtn = dotEl?.closest('.supp-impact-header')?.querySelector('.supp-impact-refresh');
+  if (refreshBtn) refreshBtn.remove();
+  scheduleAnalyze(s, editIdx, data);
+}
+
+function applyImpactToDOM(editIdx, cached) {
+  if (!cached) return;
+  const dotEl = document.getElementById(`supp-impact-dot-${editIdx}`);
+  if (dotEl) dotEl.className = `ctx-health-dot ctx-health-dot-${cached.dot}`;
+  const sumEl = document.getElementById(`supp-impact-summary-${editIdx}`);
+  if (sumEl) {
+    sumEl.textContent = cached.summary;
+    sumEl.className = `supp-impact-summary supp-impact-summary-visible supp-impact-summary-${cached.dot}`;
+  }
+}

--- a/js/supplement-impact.js
+++ b/js/supplement-impact.js
@@ -225,15 +225,15 @@ async function loadImpactsForSupps(pending, data) {
     if (s.ingredients?.length) ctx += ` ingredients: ${s.ingredients.map(ing => {
       const total = ingredientDailyTotal(ing, s);
       const times = effectiveTimesPerDay(ing, s);
-      if (total) return `${ing.name} ${ing.amount} x ${times}/day = ${formatSupplementTotal(total)}`;
-      if (times) return `${ing.name}${ing.amount ? ' ' + ing.amount : ''} x ${times}/day`;
+      if (total) return `${ing.name} ${ing.amount} × ${times}/day = ${formatSupplementTotal(total)}`;
+      if (times) return `${ing.name}${ing.amount ? ' ' + ing.amount : ''} × ${times}/day`;
       return `${ing.name}${ing.amount ? ' ' + ing.amount : ''}`;
     }).join(', ')}`;
     if (overlapping.length > 0) ctx += ` (also taking: ${overlapping.map(o => o.name).join(', ')})`;
     ctx += `\n`;
     for (const imp of top) {
-      ctx += `  ${imp.markerName}: ${fmtVal(imp.beforeMean)}->${fmtVal(imp.afterMean)} ${imp.unit} (${imp.pctChange > 0 ? '+' : ''}${imp.pctChange.toFixed(0)}%)`;
-      if (imp.refMin != null || imp.refMax != null) ctx += ` ref ${imp.refMin ?? ''}-${imp.refMax ?? ''}`;
+      ctx += `  ${imp.markerName}: ${fmtVal(imp.beforeMean)}→${fmtVal(imp.afterMean)} ${imp.unit} (${imp.pctChange > 0 ? '+' : ''}${imp.pctChange.toFixed(0)}%)`;
+      if (imp.refMin != null || imp.refMax != null) ctx += ` ref ${imp.refMin ?? ''}–${imp.refMax ?? ''}`;
       ctx += `\n`;
     }
   }

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -1,17 +1,33 @@
 // supplements.js — Supplement/medication editor and dashboard section
 
 import { state } from './state.js';
-import { escapeHTML, showNotification, hashString, isDebugMode } from './utils.js';
-import { saveImportedData, getActiveData } from './data.js';
+import { escapeHTML, showNotification, isDebugMode } from './utils.js';
+import { saveImportedData } from './data.js';
 import { callClaudeAPI, hasAIProvider, supportsVision } from './api.js';
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
-import { profileStorageKey } from './profile.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
+import {
+  computeAllImpacts,
+  computeSupplementImpact,
+  effectiveTimesPerDay,
+  formatSupplementTotal,
+  getSupplementPeriods,
+  ingredientDailyTotal,
+  parseAmount,
+  refreshSupplementImpact,
+  renderSupplementImpact,
+} from './supplement-impact.js';
 
-export function getSupplementPeriods(s) {
-  if (s.periods && s.periods.length > 0) return s.periods;
-  return [{ start: s.startDate, end: s.endDate }];
-}
+export {
+  computeAllImpacts,
+  computeSupplementImpact,
+  effectiveTimesPerDay,
+  getSupplementPeriods,
+  ingredientDailyTotal,
+  parseAmount,
+  refreshSupplementImpact,
+  renderSupplementImpact,
+} from './supplement-impact.js';
 
 function _parseHttpUrl(raw) {
   const value = (raw || '').trim();
@@ -126,42 +142,6 @@ export function renderSupplementsSection() {
   return html;
 }
 
-// Extract numeric value + unit from amount strings like "890mg", "500 IU", "25 mcg", "5,4 mg".
-// Handles both dot and comma decimal separators. Returns null for pure text ("once daily").
-export function parseAmount(str) {
-  if (!str || typeof str !== 'string') return null;
-  const match = str.trim().match(/^(\d+(?:[.,]\d+)?)\s*([a-zA-Zµμ]+)?/);
-  if (!match) return null;
-  const value = parseFloat(match[1].replace(',', '.'));
-  if (!isFinite(value)) return null;
-  const unit = (match[2] || '').trim();
-  return { value, unit };
-}
-
-// Effective timesPerDay for an ingredient: row override wins, else the supp-level default.
-export function effectiveTimesPerDay(ing, supp) {
-  if (ing && (ing.timesPerDay === 0 || ing.timesPerDay)) return Number(ing.timesPerDay);
-  if (supp && (supp.timesPerDay === 0 || supp.timesPerDay)) return Number(supp.timesPerDay);
-  return null;
-}
-
-// Compute daily total when amount is parseable and there's an effective timesPerDay.
-export function ingredientDailyTotal(ing, supp) {
-  const times = effectiveTimesPerDay(ing, supp);
-  if (!ing || !times) return null;
-  const parsed = parseAmount(ing.amount);
-  if (!parsed) return null;
-  const total = parsed.value * times;
-  if (!isFinite(total)) return null;
-  return { value: total, unit: parsed.unit, times };
-}
-
-function _formatTotal(total) {
-  if (!total) return '';
-  const v = total.value % 1 === 0 ? total.value.toString() : total.value.toFixed(2).replace(/\.?0+$/, '');
-  return `${v}${total.unit ? ' ' + total.unit : ''}/day`;
-}
-
 function _ingredientRowHtml(idx, name = '', amount = '', timesPerDay = '', outerTimes = '') {
   const rowTimes = timesPerDay === 0 || timesPerDay ? String(timesPerDay) : '';
   const effective = rowTimes || outerTimes;
@@ -170,7 +150,7 @@ function _ingredientRowHtml(idx, name = '', amount = '', timesPerDay = '', outer
     <input type="text" class="supp-ing-name" placeholder="Ingredient" value="${escapeHTML(name)}">
     <input type="text" class="supp-ing-amount" placeholder="Per dose" value="${escapeHTML(amount)}" oninput="updateIngTotal(this)">
     <input type="number" class="supp-ing-times" placeholder="×/day" min="0" max="99" step="0.5" value="${escapeHTML(rowTimes)}" oninput="updateIngTotal(this)">
-    <span class="supp-ing-total">${total ? escapeHTML(_formatTotal(total)) : ''}</span>
+    <span class="supp-ing-total">${total ? escapeHTML(formatSupplementTotal(total)) : ''}</span>
     <button class="supp-ing-remove" onclick="removeIngredientRow(this)" title="Remove">&times;</button>
   </div>`;
 }
@@ -189,7 +169,7 @@ function updateIngTotal(inputEl) {
   if (!totalEl) return;
   const effective = rowTimes || _getOuterTimesFromForm();
   const total = effective ? ingredientDailyTotal({ amount, timesPerDay: effective }) : null;
-  totalEl.textContent = total ? _formatTotal(total) : '';
+  totalEl.textContent = total ? formatSupplementTotal(total) : '';
 }
 
 function updateAllIngTotals() {
@@ -494,7 +474,7 @@ export function openSupplementsEditor(editIdx) {
             const total = ingredientDailyTotal(ing, s);
             const times = effectiveTimesPerDay(ing, s);
             const timesStr = times && times > 1 ? ` × ${times}/day` : '';
-            const totalStr = total ? ` → ${_formatTotal(total)}` : '';
+            const totalStr = total ? ` → ${formatSupplementTotal(total)}` : '';
             return `<span class="supp-ing-pill">${escapeHTML(ing.name)}${ing.amount ? ` ${escapeHTML(ing.amount)}` : ''}${escapeHTML(timesStr)}${escapeHTML(totalStr)}</span>`;
           }).join('')}</div>` : ''}
           ${s.note ? `<div class="supp-list-note">${escapeHTML(s.note)}</div>` : ''}
@@ -628,265 +608,6 @@ function askAIMitoContext() {
       ta.focus();
     }
   }, 500);
-}
-
-// ═══════════════════════════════════════════════
-// Supplement-Biomarker Impact Analysis
-// ═══════════════════════════════════════════════
-
-export function computeSupplementImpact(supplement, markerKey, markerName, unit, values, dates, refMin, refMax) {
-  if (!values || !dates || values.length !== dates.length) return null;
-  const pds = getSupplementPeriods(supplement);
-  const sortedPds = [...pds].sort((a, b) => a.start.localeCompare(b.start));
-  const firstStart = sortedPds[0].start;
-  const isInPeriod = (date) => sortedPds.some(p => date >= p.start && (!p.end || date <= p.end));
-  const beforeValues = [], afterValues = [];
-  for (let i = 0; i < dates.length; i++) {
-    if (values[i] === null) continue;
-    if (dates[i] < firstStart) {
-      beforeValues.push(values[i]);
-    } else if (isInPeriod(dates[i])) {
-      afterValues.push(values[i]);
-    }
-  }
-  if (beforeValues.length === 0 && afterValues.length === 0) return null;
-  const mean = arr => arr.reduce((s, v) => s + v, 0) / arr.length;
-  const beforeMean = beforeValues.length > 0 ? mean(beforeValues) : null;
-  const afterMean = afterValues.length > 0 ? mean(afterValues) : null;
-  let pctChange = null, direction = 'stable';
-  if (beforeMean !== null && afterMean !== null && beforeMean !== 0) {
-    pctChange = ((afterMean - beforeMean) / Math.abs(beforeMean)) * 100;
-    direction = Math.abs(pctChange) < 1 ? 'stable' : pctChange > 0 ? 'up' : 'down';
-  }
-  let confidence = 'low';
-  if (beforeValues.length >= 3 && afterValues.length >= 3) confidence = 'high';
-  else if (beforeValues.length >= 2 && afterValues.length >= 2) confidence = 'moderate';
-  return {
-    marker: markerKey, markerName, unit,
-    beforeMean, afterMean, pctChange, direction, confidence,
-    nBefore: beforeValues.length, nAfter: afterValues.length,
-    refMin, refMax
-  };
-}
-
-export function computeAllImpacts(supplement, data) {
-  if (!data || !data.categories || !data.dates) return [];
-  const results = [];
-  for (const [catKey, cat] of Object.entries(data.categories)) {
-    for (const [mKey, marker] of Object.entries(cat.markers)) {
-      const dotKey = catKey + '.' + mKey;
-      const impact = computeSupplementImpact(
-        supplement, dotKey, marker.name, marker.unit,
-        marker.values, data.dates, marker.refMin, marker.refMax
-      );
-      if (impact && impact.pctChange !== null && Math.abs(impact.pctChange) >= 1) {
-        results.push(impact);
-      }
-    }
-  }
-  results.sort((a, b) => Math.abs(b.pctChange) - Math.abs(a.pctChange));
-  return results;
-}
-
-function getOverlappingSupplements(supplement, supps) {
-  const sPds = getSupplementPeriods(supplement);
-  return supps.filter(s => {
-    if (s === supplement) return false;
-    const oPds = getSupplementPeriods(s);
-    return sPds.some(sp => oPds.some(op => {
-      const sEnd = sp.end || '9999-12-31';
-      const oEnd = op.end || '9999-12-31';
-      return sp.start <= oEnd && op.start <= sEnd;
-    }));
-  });
-}
-
-// Per-supplement fingerprint: changes when that supp's edit-visible fields or lab dates change.
-// Editing dosage/ingredients/periods for one supp invalidates only that supp's cache entry.
-function getSuppFingerprint(supp, data) {
-  const labPart = (data.dates || []).join(',');
-  const pds = getSupplementPeriods(supp);
-  const ings = (supp.ingredients || []).map(i => `${i.name}:${i.amount || ''}:${i.timesPerDay || ''}`).join(',');
-  const suppPart = `${supp.name}|${supp.dosage || ''}|${supp.timesPerDay || ''}|${supp.type || ''}|${ings}|${pds.map(p => p.start + '~' + (p.end || '')).join(',')}`;
-  return hashString(labPart + '||' + suppPart);
-}
-
-function getImpactCache() {
-  try {
-    const key = profileStorageKey(state.currentProfile, 'suppImpact');
-    const raw = localStorage.getItem(key);
-    const parsed = raw ? JSON.parse(raw) : {};
-    // Migrate old batch-fingerprint schema (values without `fp` field) by discarding
-    for (const k of Object.keys(parsed)) {
-      if (!parsed[k] || typeof parsed[k] !== 'object' || typeof parsed[k].fp !== 'string') delete parsed[k];
-    }
-    return parsed;
-  } catch { return {}; }
-}
-
-function setImpactCache(cache) {
-  try {
-    const key = profileStorageKey(state.currentProfile, 'suppImpact');
-    localStorage.setItem(key, JSON.stringify(cache));
-  } catch { /* quota exceeded */ }
-}
-
-// Debounced queue: coalesces multiple render calls into a single AI request for only the stale/missing supps.
-let _pendingAnalyses = new Map(); // suppName → { supplement, editIdx }
-let _analyzeTimer = null;
-let _batchPromise = null;
-
-export function renderSupplementImpact(supplement, editIdx) {
-  const hasAI = hasAIProvider();
-  const data = getActiveData();
-  if (!data || !data.dates || data.dates.length < 2) {
-    return `<div class="supp-impact-section"><div class="supp-impact-header"><span class="ctx-health-dot ctx-health-dot-gray"></span><span>Impact Analysis</span></div><div class="supp-impact-hint">Needs at least 2 lab dates to compare</div></div>`;
-  }
-  const impacts = computeAllImpacts(supplement, data);
-  if (impacts.length === 0) {
-    const hasAfter = data.dates.some(d => d >= supplement.startDate);
-    const hasBefore = data.dates.some(d => d < supplement.startDate);
-    const hint = !hasBefore ? 'No lab results from before this supplement was started'
-      : !hasAfter ? 'No lab results since starting this supplement'
-      : 'No significant marker changes detected yet';
-    return `<div class="supp-impact-section"><div class="supp-impact-header"><span class="ctx-health-dot ctx-health-dot-gray"></span><span>Impact Analysis</span></div><div class="supp-impact-hint">${hint}</div></div>`;
-  }
-
-  const fp = getSuppFingerprint(supplement, data);
-  const cache = getImpactCache();
-  const entry = cache[supplement.name];
-  const cached = (entry && entry.fp === fp) ? entry : null;
-
-  const dotColor = cached ? `ctx-health-dot-${cached.dot}` : (hasAI ? 'ctx-health-dot-shimmer' : 'ctx-health-dot-gray');
-  const summaryClass = cached ? `supp-impact-summary-visible supp-impact-summary-${cached.dot}` : '';
-  const summaryText = cached ? escapeHTML(cached.summary) : (hasAI ? '' : 'Set up an AI provider for impact insights');
-
-  const html = `<div class="supp-impact-section">
-    <div class="supp-impact-header">
-      <span class="ctx-health-dot ${dotColor}" id="supp-impact-dot-${editIdx}"></span>
-      <span>Impact Analysis</span>
-      ${cached && hasAI ? `<button class="supp-impact-refresh" onclick="refreshSupplementImpact(${editIdx})" title="Re-analyze with current data">refresh</button>` : ''}
-    </div>
-    <div class="supp-impact-summary ${summaryClass}" id="supp-impact-summary-${editIdx}">${summaryText}</div>
-  </div>`;
-
-  // Auto-fire only if fingerprint mismatch (edit) or missing entirely — scoped to this supp only.
-  if (!cached && hasAI) scheduleAnalyze(supplement, editIdx, data);
-  return html;
-}
-
-function scheduleAnalyze(supplement, editIdx, data) {
-  _pendingAnalyses.set(supplement.name, { supplement, editIdx });
-  if (_analyzeTimer) return;
-  _analyzeTimer = setTimeout(() => { _analyzeTimer = null; flushAnalyses(data); }, 50);
-}
-
-async function flushAnalyses(data) {
-  const pending = [..._pendingAnalyses.values()];
-  _pendingAnalyses.clear();
-  if (pending.length === 0) return;
-  if (_batchPromise) await _batchPromise;
-  await loadImpactsForSupps(pending, data);
-}
-
-async function loadImpactsForSupps(pending, data) {
-  const allSupps = state.importedData.supplements || [];
-  const suppEntries = [];
-  for (const { supplement: s, editIdx } of pending) {
-    const impacts = computeAllImpacts(s, data);
-    if (impacts.length === 0) continue;
-    suppEntries.push({ supplement: s, impacts, editIdx });
-  }
-  if (suppEntries.length === 0) return;
-
-  const fmtVal = v => v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
-  let ctx = `Analyze ${suppEntries.length} supplement${suppEntries.length === 1 ? '' : 's'}:\n`;
-  for (const { supplement: s, impacts } of suppEntries) {
-    const top = impacts.slice(0, 5);
-    const overlapping = getOverlappingSupplements(s, allSupps);
-    const pds = getSupplementPeriods(s);
-    const pdStr = pds.length === 1
-      ? `since ${pds[0].start}${pds[0].end ? ' until ' + pds[0].end : ''}`
-      : `CYCLING: ${pds.map(p => p.start + ' to ' + (p.end || 'ongoing')).join('; ')}`;
-    ctx += `\n[${s.name}] ${s.dosage || ''} (${s.type}) ${pdStr}`;
-    if (s.ingredients?.length) ctx += ` ingredients: ${s.ingredients.map(ing => {
-      const total = ingredientDailyTotal(ing, s);
-      const times = effectiveTimesPerDay(ing, s);
-      if (total) return `${ing.name} ${ing.amount} × ${times}/day = ${_formatTotal(total)}`;
-      if (times) return `${ing.name}${ing.amount ? ' ' + ing.amount : ''} × ${times}/day`;
-      return `${ing.name}${ing.amount ? ' ' + ing.amount : ''}`;
-    }).join(', ')}`;
-    if (overlapping.length > 0) ctx += ` (also taking: ${overlapping.map(o => o.name).join(', ')})`;
-    ctx += `\n`;
-    for (const imp of top) {
-      ctx += `  ${imp.markerName}: ${fmtVal(imp.beforeMean)}→${fmtVal(imp.afterMean)} ${imp.unit} (${imp.pctChange > 0 ? '+' : ''}${imp.pctChange.toFixed(0)}%)`;
-      if (imp.refMin != null || imp.refMax != null) ctx += ` ref ${imp.refMin ?? ''}–${imp.refMax ?? ''}`;
-      ctx += `\n`;
-    }
-  }
-
-  const names = suppEntries.map(e => `"${e.supplement.name}"`).join(', ');
-  const system = `ONLY JSON, no thinking, no explanation: {${names}: {"dot":"green|yellow|red|gray","summary":"max 20 words"}, ...}
-green=beneficial, yellow=mixed, red=concerning, gray=insufficient data. Mention key markers.`;
-
-  _batchPromise = (async () => {
-    try {
-      const result = await callClaudeAPI({ system, messages: [{ role: 'user', content: ctx }], maxTokens: 300 * suppEntries.length + 1000 });
-      const cleaned = result.text.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
-      const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) return;
-      const parsed = JSON.parse(jsonMatch[0]);
-
-      const cache = getImpactCache();
-      for (const { supplement: s, editIdx } of suppEntries) {
-        const entry = parsed[s.name];
-        if (!entry || typeof entry !== 'object') continue;
-        const record = {
-          fp: getSuppFingerprint(s, data),
-          dot: ['green', 'yellow', 'red', 'gray'].includes(entry.dot) ? entry.dot : 'gray',
-          summary: typeof entry.summary === 'string' ? entry.summary.slice(0, 150) : ''
-        };
-        cache[s.name] = record;
-        applyImpactToDOM(editIdx, record);
-      }
-      // Cap cache at 50 entries (one per supp)
-      const keys = Object.keys(cache);
-      if (keys.length > 50) { for (const k of keys.slice(0, keys.length - 50)) delete cache[k]; }
-      setImpactCache(cache);
-    } catch (e) { if (isDebugMode()) console.warn('[suppImpact] AI failed:', e.message || e); }
-  })();
-
-  await _batchPromise;
-  _batchPromise = null;
-}
-
-function refreshSupplementImpact(editIdx) {
-  const supps = state.importedData.supplements || [];
-  const s = supps[editIdx];
-  if (!s) return;
-  const data = getActiveData();
-  if (!data) return;
-  const cache = getImpactCache();
-  delete cache[s.name];
-  setImpactCache(cache);
-  const dotEl = document.getElementById(`supp-impact-dot-${editIdx}`);
-  if (dotEl) dotEl.className = 'ctx-health-dot ctx-health-dot-shimmer';
-  const sumEl = document.getElementById(`supp-impact-summary-${editIdx}`);
-  if (sumEl) { sumEl.textContent = ''; sumEl.className = 'supp-impact-summary'; }
-  const refreshBtn = dotEl?.closest('.supp-impact-header')?.querySelector('.supp-impact-refresh');
-  if (refreshBtn) refreshBtn.remove();
-  scheduleAnalyze(s, editIdx, data);
-}
-
-function applyImpactToDOM(editIdx, cached) {
-  if (!cached) return;
-  const dotEl = document.getElementById(`supp-impact-dot-${editIdx}`);
-  if (dotEl) dotEl.className = `ctx-health-dot ctx-health-dot-${cached.dot}`;
-  const sumEl = document.getElementById(`supp-impact-summary-${editIdx}`);
-  if (sumEl) {
-    sumEl.textContent = cached.summary;
-    sumEl.className = `supp-impact-summary supp-impact-summary-visible supp-impact-summary-${cached.dot}`;
-  }
 }
 
 Object.assign(window, { renderSupplementsSection, openSupplementsEditor, toggleSuppAccordion, showAddSuppForm, saveSupplement, deleteSupplement, askAIMitoContext, computeAllImpacts, getSupplementPeriods, addIngredientRow, removeIngredientRow, addPeriodRow, removePeriodRow, scanSupplementLabel, fetchSupplementFromURL, refreshSupplementImpact, updateIngTotal, updateAllIngTotals, ingredientDailyTotal });

--- a/service-worker.js
+++ b/service-worker.js
@@ -98,6 +98,7 @@ const APP_SHELL = [
   '/js/charts.js',
   '/js/notes.js',
   '/js/supplements.js',
+  '/js/supplement-impact.js',
   '/js/cycle.js',
   '/js/context-cards.js',
   '/js/context-card-summaries.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -121,6 +121,7 @@ const pwaAppShellAssets = [
   '/js/context-card-summaries.js',
   '/js/context-card-editor-ui.js',
   '/js/context-card-medical-history-editor.js',
+  '/js/supplement-impact.js',
   '/js/commit-hash.js',
   '/js/focus-card.js',
   '/js/onboarding-view.js',

--- a/tests/test-supplement-impact.js
+++ b/tests/test-supplement-impact.js
@@ -142,22 +142,23 @@ const { computeSupplementImpact, computeAllImpacts, parseAmount, ingredientDaily
   console.log('%c 8. Source & UI Integration ', 'font-weight:bold;color:#f59e0b');
 
   const suppSrc = read('js/supplements.js');
-  assert('renderSupplementImpact exists', suppSrc.includes('function renderSupplementImpact'));
+  const impactSrc = read('js/supplement-impact.js');
+  assert('renderSupplementImpact exists', impactSrc.includes('function renderSupplementImpact'));
   assert('Wired into openSupplementsEditor', suppSrc.includes('renderSupplementImpact(s,'));
-  assert('Detects overlapping supplements', suppSrc.includes('getOverlappingSupplements'));
+  assert('Detects overlapping supplements', impactSrc.includes('getOverlappingSupplements'));
   assert('computeAllImpacts on window', suppSrc.includes('computeAllImpacts'));
 
   // AI-driven display (health dots pattern)
-  assert('Uses callClaudeAPI', suppSrc.includes('callClaudeAPI'));
-  assert('Uses hasAIProvider', suppSrc.includes('hasAIProvider'));
-  assert('Per-supp fingerprint includes dosage+ingredients', suppSrc.includes('getSuppFingerprint') && suppSrc.includes('supp.dosage') && suppSrc.includes('supp.ingredients'));
-  assert('Per-supp AI call (not whole batch)', suppSrc.includes('loadImpactsForSupps'));
-  assert('Coalesces concurrent renders via debounce', suppSrc.includes('_pendingAnalyses') && suppSrc.includes('scheduleAnalyze'));
-  assert('Deduplicates in-flight calls', suppSrc.includes('_batchPromise'));
-  assert('Cache keyed by supp name with fp field', suppSrc.includes('cache[s.name]') && suppSrc.includes('fp: getSuppFingerprint'));
-  assert('Fingerprint also includes timesPerDay', suppSrc.includes('i.timesPerDay'));
+  assert('Uses callClaudeAPI', impactSrc.includes('callClaudeAPI'));
+  assert('Uses hasAIProvider', impactSrc.includes('hasAIProvider'));
+  assert('Per-supp fingerprint includes dosage+ingredients', impactSrc.includes('getSuppFingerprint') && impactSrc.includes('supp.dosage') && impactSrc.includes('supp.ingredients'));
+  assert('Per-supp AI call (not whole batch)', impactSrc.includes('loadImpactsForSupps'));
+  assert('Coalesces concurrent renders via debounce', impactSrc.includes('_pendingAnalyses') && impactSrc.includes('scheduleAnalyze'));
+  assert('Deduplicates in-flight calls', impactSrc.includes('_batchPromise'));
+  assert('Cache keyed by supp name with fp field', impactSrc.includes('cache[s.name]') && impactSrc.includes('fp: getSuppFingerprint'));
+  assert('Fingerprint also includes timesPerDay', impactSrc.includes('i.timesPerDay'));
   assert('Ingredient row has ×/day input', suppSrc.includes('supp-ing-times'));
-  assert('AI prompt uses computed total with supp-level fallback', suppSrc.includes('ingredientDailyTotal(ing, s)') && suppSrc.includes('effectiveTimesPerDay'));
+  assert('AI prompt uses computed total with supp-level fallback', impactSrc.includes('ingredientDailyTotal(ing, s)') && impactSrc.includes('effectiveTimesPerDay'));
   assert('Outer ×/day form field exists', suppSrc.includes('id="supp-times"'));
   assert('Row placeholder is just ×/day (no "inherit N" jargon)', suppSrc.includes('placeholder="×/day"'));
   assert('Outer label reads "Doses/day" (non-tech)', suppSrc.includes('<label>Doses/day</label>'));
@@ -209,10 +210,10 @@ const { computeSupplementImpact, computeAllImpacts, parseAmount, ingredientDaily
   assert('No row + no supp → null', effectiveTimesPerDay({}, {}) === null);
   assert('Total inherits supp default for combo products', ingredientDailyTotal({ amount: '500mg' }, { timesPerDay: 2 })?.value === 1000);
   assert('Row override overrides supp default in total', ingredientDailyTotal({ amount: '500mg', timesPerDay: 3 }, { timesPerDay: 1 })?.value === 1500);
-  assert('Uses health dot CSS classes', suppSrc.includes('ctx-health-dot'));
-  assert('AI returns dot+summary JSON per supp', suppSrc.includes('"dot":"green|yellow|red|gray"'));
-  assert('Shimmer while loading', suppSrc.includes('ctx-health-dot-shimmer'));
-  assert('Falls back without AI', suppSrc.includes('Set up an AI provider'));
+  assert('Uses health dot CSS classes', impactSrc.includes('ctx-health-dot'));
+  assert('AI returns dot+summary JSON per supp', impactSrc.includes('"dot":"green|yellow|red|gray"'));
+  assert('Shimmer while loading', impactSrc.includes('ctx-health-dot-shimmer'));
+  assert('Falls back without AI', impactSrc.includes('Set up an AI provider'));
 
   // Focus card integration
   const focusCardSrc = read('js/focus-card.js');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -618,6 +618,9 @@
     const hasDashboardRecommendationWidgetJs = sw.includes('/js/dashboard-recommendation-widget.js');
     assert('Service worker caches js/dashboard-recommendation-widget.js', hasDashboardRecommendationWidgetJs);
 
+    const hasSupplementImpactJs = sw.includes('/js/supplement-impact.js');
+    assert('Service worker caches js/supplement-impact.js', hasSupplementImpactJs);
+
     const hasDashboardCompositionJs = sw.includes('/js/dashboard-view-composition.js');
     assert('Service worker caches js/dashboard-view-composition.js', hasDashboardCompositionJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.266';
+self.APP_VERSION = '1.8.267';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.267';
+self.APP_VERSION = '1.8.268';


### PR DESCRIPTION
## Summary
- Extract supplement dose math, lab impact analysis, cache handling, and AI analysis queue into `js/supplement-impact.js`
- Keep `js/supplements.js` focused on editor/dashboard UI while preserving the existing public exports and window API
- Point focus-card and lab-context consumers at the extracted helpers, and add the new module to app-shell cache checks

## Validation
- `node --check js/supplements.js`
- `node --check js/supplement-impact.js`
- `node --check js/focus-card.js`
- `node tests/test-supplement-impact.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-audit.js`
- `node tests/test-a11y-phase3.js`
- `node tests/test-prelab.js`
- `npm test -- --run tests/_vitest-legacy.test.js`
- `git diff --check`
- focused Puppeteer smoke against `http://127.0.0.1:8000/app` for module exports, impact math, and supplements editor rendering