### PR TITLE
[codex] Preserve synced DNA SNPs

### DIFF
--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -1498,7 +1498,7 @@ Not separately documented because their exports are best read from source — ke
 - `sync-push.js` — outbound profile push path, in-flight push watchdog, Phase 2 drift auto-revert, and Evolu profileData insert/update.
 - `sync-push-deltas.js` — push-side per-row delta planning/application; walks DELTA_ARRAYS/MAPS/SCALARS before blob writes, advances snapshots after onComplete, and records delta telemetry.
 - `sync-pull.js` — inbound pull orchestration and row loop; delegates one-time cleanup, active-profile UI refresh, and rebroadcast scheduling to helper modules.
-- `sync-pull-merge.js` — pull row recovery/dedupe, importedData blob/per-row merge, wearable-token preservation, and profile metadata merge helpers.
+- `sync-pull-merge.js` — pull row recovery/dedupe, importedData blob/per-row merge, wearable-token preservation, metadata-only genetics blob protection, and profile metadata merge helpers.
 - `sync-pull-maintenance.js` — pull-path one-time migrations such as stale `-sync-hash` localStorage cleanup.
 - `sync-pull-active-refresh.js` — active-profile in-memory update, migration, chat reload, sidebar rebuild, current-view refresh, toast, and sync-applied event after a pull.
 - `sync-pull-rebroadcast.js` — pull-side rebroadcast gating, budget checks, push-pending guard, and delayed active-profile push scheduling.

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -121,6 +121,17 @@ function mergePlainMap(localMap, remoteMap) {
   return { ...(hasRemote ? remoteMap : {}), ...(hasLocal ? localMap : {}) };
 }
 
+function preserveLocalGeneticsSnps(local, remote, out) {
+  const localSnps = local?.genetics?.snps;
+  const remoteGenetics = remote?.genetics;
+  if (!localSnps || typeof localSnps !== 'object' || Array.isArray(localSnps)) return;
+  if (Object.keys(localSnps).length === 0) return;
+  if (!remoteGenetics || typeof remoteGenetics !== 'object' || Array.isArray(remoteGenetics)) return;
+  if (Object.prototype.hasOwnProperty.call(remoteGenetics, 'snps')) return;
+  if (!out.genetics || typeof out.genetics !== 'object' || Array.isArray(out.genetics)) return;
+  out.genetics = { ...out.genetics, snps: { ...localSnps } };
+}
+
 function mergeSourceFiles(a, b) {
   const files = [];
   for (const item of [a?.sourceFiles, a?.sourceFile, b?.sourceFiles, b?.sourceFile]) {
@@ -421,6 +432,7 @@ export function mergeImportedData(local, remote) {
   // Start from a shallow clone of remote — picks up new keys + LWW for
   // non-id-keyed scalars and arrays.
   const out = { ...remote };
+  preserveLocalGeneticsSnps(local, remote, out);
 
   const mergedEntries = mergeLabEntriesByDate(local.entries, remote.entries);
   if (mergedEntries) out.entries = mergedEntries;

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -164,7 +164,11 @@ return (async function () {
 
     // Close inner — outer still mounted.
     overlay2.remove();
-    await delay(20); // MutationObserver fires async
+    await waitFor(() =>
+      !document.body.contains(overlay2)
+      && document.body.contains(overlay)
+      && document.body.style.overflow === 'hidden'
+    );
     assert('body still locked after inner modal closed (outer still up)',
       document.body.style.overflow === 'hidden');
 
@@ -193,7 +197,11 @@ return (async function () {
     document.body.appendChild(overlayCrossB);
     sunReloaded.trapModalFocus(overlayCrossB);
     overlayCrossA.remove();
-    await delay(20);
+    await waitFor(() =>
+      !document.body.contains(overlayCrossA)
+      && document.body.contains(overlayCrossB)
+      && document.body.style.overflow === 'hidden'
+    );
     assert('body still locked across separate sun.js module instances',
       document.body.style.overflow === 'hidden');
     overlayCrossB.remove();

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -33,6 +33,7 @@ const syncSaveHooks = await import('../js/sync-save-hooks.js');
 const syncApply = await import('../js/sync-apply.js');
 const syncChatApply = await import('../js/sync-chat-apply.js');
 const syncDelta = await import('../js/sync-delta.js');
+const dataMerge = await import('../js/data-merge.js');
 const syncSubscriptions = await import('../js/sync-subscriptions.js');
 const syncPayloadCollectors = await import('../js/sync-payload-collectors.js');
 const syncStorageCleanup = await import('../js/sync-storage-cleanup.js');
@@ -2592,6 +2593,37 @@ await import('../js/settings.js');
   // import. Lives in sync-pull-active-refresh.js's active-profile post-merge block.
   assert('onSyncReceived rebuilds sidebar after every pull (catches nav items gated on per-row data)',
     /profileId\s*!==\s*state\.currentProfile[\s\S]{0,2000}window\.buildSidebar[\s\S]{0,400}remoteBroughtNewRows/.test(deltaSearchSrc));
+
+  const localWithSnps = {
+    genetics: {
+      source: '23andMe',
+      importDate: '2026-05-29',
+      coverage: { found: 2, total: 10 },
+      snps: {
+        rs1801133: { genotype: 'GA', gene: 'MTHFR' },
+        rs4680: { genotype: 'AG', gene: 'COMT' },
+      },
+    },
+    entries: [],
+  };
+  const remoteMetadataOnly = {
+    genetics: {
+      source: '23andMe',
+      importDate: '2026-05-30',
+      coverage: { found: 2, total: 10 },
+    },
+    entries: [],
+  };
+  const mergedMetadataOnly = dataMerge.mergeImportedData(localWithSnps, remoteMetadataOnly);
+  assert('metadata-only genetics blob preserves local SNP map during pull merge',
+    Object.keys(mergedMetadataOnly.genetics?.snps || {}).length === 2
+    && mergedMetadataOnly.genetics.snps.rs1801133?.genotype === 'GA'
+    && mergedMetadataOnly.genetics.importDate === '2026-05-30');
+
+  const remoteExplicitDelete = { genetics: null, entries: [] };
+  const mergedDelete = dataMerge.mergeImportedData(localWithSnps, remoteExplicitDelete);
+  assert('explicit remote genetics delete still clears SNP map',
+    mergedDelete.genetics === null);
 
   // Live: simulate the strip helper inline and prove shape preservation
   if (typeof window !== 'undefined') {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.272';
+self.APP_VERSION = '1.8.274';


### PR DESCRIPTION
## What changed
- Preserve local `genetics.snps` when a sync pull merges a metadata-only `genetics` blob.
- Keep explicit remote genetics deletes authoritative.
- Add sync regression coverage for the metadata-only genetics merge case, including Node-side coverage outside the browser-only guard.
- Tighten a CI-only audit regression wait so the unrelated nested-modal scroll-lock check waits on the actual condition instead of a fixed 20ms sleep.
- Bump `APP_VERSION` to `1.8.274`.

## Root cause
Sync strips `genetics.snps` from the full profile blob because SNP rows are carried through the per-key `genetics.snps` delta surface. During reloads or version bumps, the blob merge could run before the per-row overlay was available, replacing local genetics with metadata-only genetics and making DNA appear to disappear.

## Validation
- `node --check js/data-merge.js`
- `node --check tests/test-sync.js`
- `node tests/test-sync.js`
- `node tests/test-dna.js`
- browser smoke for `tests/test-audit-fixes.js`
- `git diff --check`