### PR TITLE
Extract PDF import marker normalization

### DIFF
--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -69,6 +69,7 @@ js/
   context-card-lifestyle-editors.js — lifestyle context editors, goals, lens, and diet contaminant modal
   pdf-import.js     — PDF/image/text import pipeline, AI analysis, confirm/save merge
   pdf-import-preflight.js / pdf-import-progress.js — import preflight prompts and progress/status UI
+  pdf-import-marker-normalization.js — shared AI marker sanitization, adapter normalization, specialty guards
   pdf-import-review.js — import review modal rendering, row filtering/mapping UI state
   import-file-input.js — lazy file-picker import binding and import routing
   import-drop-zone.js — lazy import drop-zone binding shared by page shells

--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -521,6 +521,17 @@ Import progress bar, floating import status FAB, and batch progress rendering.
 
 ---
 
+### `pdf-import-marker-normalization.js`
+
+Shared AI marker normalization for PDF text import and image import.
+
+**Key exports:**
+- `normalizeParsedImportMarkers(parsed, options)` — sanitizes AI marker keys, runs product/test-type adapters, applies specialty guard rules, reconciles marker mappings, and returns `{ testType, markers }`
+
+**Window exports:** none directly; `pdf-import.js` calls this after AI JSON parsing.
+
+---
+
 ### `pdf-import-review.js`
 
 Import review modal rendering and interaction state.

--- a/js/pdf-import-marker-normalization.js
+++ b/js/pdf-import-marker-normalization.js
@@ -1,0 +1,163 @@
+// pdf-import-marker-normalization.js - AI marker normalization shared by text/image import
+
+import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS } from './schema.js';
+import { detectProduct, getAdapterByTestType, normalizeWithAdapter } from './adapters.js';
+import { isDebugMode } from './utils.js';
+import { _sanitizeAIMarker, reconcileImportMarkerMappings } from './pdf-import-marker-mapping.js';
+
+const _specialtyTypes = ['OAT', 'fattyAcids', 'Metabolomix+', 'DUTCH', 'HTMA', 'GI'];
+const standardCats = new Set(Object.keys(MARKER_SCHEMA));
+
+export function normalizeParsedImportMarkers(parsed, {
+  markerRef,
+  fileName = '',
+  sourceText = '',
+  existingKeys,
+  mode = 'text',
+  emitDebugLogs = false,
+} = {}) {
+  if (Array.isArray(parsed.markers)) parsed.markers.forEach(_sanitizeAIMarker);
+
+  const testType = parsed.testType || 'blood';
+  const detected = detectProduct(fileName, sourceText);
+  const adapterForTestType = !detected && testType !== 'blood' ? getAdapterByTestType(testType) : null;
+  const needsAdapterNormalize = testType === 'fattyAcids' || (!!detected && testType !== 'blood') || !!adapterForTestType;
+  if (needsAdapterNormalize && parsed.markers?.length) {
+    const adapter = detected?.adapter || adapterForTestType || getAdapterByTestType('fattyAcids');
+    normalizeWithAdapter(adapter, parsed.markers, fileName, sourceText, detected?.product);
+    if (emitDebugLogs && isDebugMode()) {
+      console.log(`[Import] Adapter ${adapter?.id || 'fattyAcids'} normalized ${parsed.markers.length} markers (testType=${testType})`);
+    }
+  }
+
+  const markers = (parsed.markers || [])
+    .map(marker => normalizeParsedImportMarker(marker, { testType, detected, mode, emitDebugLogs }))
+    .filter(marker => !isNaN(marker.value));
+
+  const reconcileOptions = { testType, refLookup: markerRef };
+  if (existingKeys) reconcileOptions.existingKeys = existingKeys;
+  reconcileImportMarkerMappings(markers, reconcileOptions);
+
+  return { testType, markers };
+}
+
+function normalizeParsedImportMarker(m, { testType, detected, mode, emitDebugLogs }) {
+  let mappedKey = m.mappedKey || null;
+  let matched = !!mappedKey;
+
+  // Guard: never allow standard blood work mappings for known specialty tests.
+  // Only fire for well-defined specialty types, not for mixed/comprehensive reports.
+  if (matched && _specialtyTypes.includes(testType)) {
+    const catKey = mappedKey.split('.')[0];
+    if (standardCats.has(catKey)) {
+      if (emitDebugLogs && isDebugMode()) {
+        console.log(`[Import Guard] Demoted ${mappedKey} - standard category in ${testType} test`);
+      }
+      const markerPart = mappedKey.split('.')[1];
+      const specialtyMatch = Object.keys(SPECIALTY_MARKER_DEFS).find(k => {
+        if (k.split('.')[1] !== markerPart || standardCats.has(k.split('.')[0])) return false;
+        const sDef = SPECIALTY_MARKER_DEFS[k];
+        return sDef.group === testType || sDef.group?.toLowerCase() === testType.toLowerCase();
+      });
+      if (specialtyMatch) {
+        const sDef = SPECIALTY_MARKER_DEFS[specialtyMatch];
+        m.suggestedKey = specialtyMatch;
+        m.suggestedName = sDef.name;
+        m.suggestedCategoryLabel = sDef.categoryLabel;
+        m.suggestedGroup = m.suggestedGroup || sDef.group || testType;
+      } else if (!m.suggestedKey) {
+        const prefix = testType.toLowerCase().replace(/[^a-z]/g, '');
+        const catSuffix = catKey.charAt(0).toUpperCase() + catKey.slice(1);
+        m.suggestedKey = `${prefix}${catSuffix}.${markerPart}`;
+        m.suggestedName = getDemotedSuggestedName(m, catKey, markerPart, mode);
+        m.suggestedCategoryLabel = m.suggestedCategoryLabel || MARKER_SCHEMA[catKey]?.label || catSuffix;
+        m.suggestedGroup = m.suggestedGroup || testType;
+      }
+      mappedKey = null;
+      matched = false;
+    }
+  }
+
+  // Guard: even for blood testType, remap to specialty key if adapter detected a product.
+  // This catches AI misidentifying specialty tests as blood.
+  if (matched && testType === 'blood' && detected) {
+    const catKey = mappedKey.split('.')[0];
+    if (standardCats.has(catKey)) {
+      const markerPart = mappedKey.split('.')[1];
+      const adapterGroup = detected.adapter?.id === 'oat' ? 'OAT' : detected.adapter?.id === 'fattyAcids' ? 'Fatty Acids' : null;
+      const specialtyMatch = adapterGroup && Object.keys(SPECIALTY_MARKER_DEFS).find(k => {
+        if (k.split('.')[1] !== markerPart || standardCats.has(k.split('.')[0])) return false;
+        return SPECIALTY_MARKER_DEFS[k].group === adapterGroup;
+      });
+      if (specialtyMatch) {
+        const sDef = SPECIALTY_MARKER_DEFS[specialtyMatch];
+        if (emitDebugLogs && isDebugMode()) {
+          console.log(`[Import Guard] Remapped ${mappedKey} -> ${specialtyMatch} (adapter detected)`);
+        }
+        m.suggestedKey = specialtyMatch;
+        m.suggestedName = sDef.name;
+        m.suggestedCategoryLabel = sDef.categoryLabel;
+        m.suggestedGroup = sDef.group || testType;
+        mappedKey = null;
+        matched = false;
+      }
+    }
+  }
+
+  // Guard: also rewrite suggestedKey if AI used a standard category for specialty test.
+  if (!matched && m.suggestedKey && testType !== 'blood') {
+    const sugCat = m.suggestedKey.split('.')[0];
+    if (standardCats.has(sugCat)) {
+      const markerPart = m.suggestedKey.split('.')[1] || m.rawName.replace(/[^a-zA-Z0-9]/g, '');
+      const prefix = testType.toLowerCase().replace(/[^a-z]/g, '');
+      const catSuffix = sugCat.charAt(0).toUpperCase() + sugCat.slice(1);
+      if (emitDebugLogs && isDebugMode()) {
+        console.log(`[Import Guard] Rewrote suggestedKey ${m.suggestedKey} -> ${prefix}${catSuffix}.${markerPart}`);
+      }
+      m.suggestedKey = `${prefix}${catSuffix}.${markerPart}`;
+      m.suggestedCategoryLabel = m.suggestedCategoryLabel || MARKER_SCHEMA[sugCat]?.label || catSuffix;
+      m.suggestedGroup = testType;
+    }
+  }
+
+  return mode === 'image'
+    ? normalizeImageImportMarker(m, mappedKey, matched)
+    : normalizeTextImportMarker(m, mappedKey, matched, testType);
+}
+
+function getDemotedSuggestedName(marker, catKey, markerPart, mode) {
+  if (mode === 'image') return marker.suggestedName || marker.rawName;
+  return marker.suggestedName || MARKER_SCHEMA[catKey]?.markers?.[markerPart]?.name || marker.rawName;
+}
+
+function normalizeTextImportMarker(m, mappedKey, matched, testType) {
+  return {
+    rawName: m.rawName,
+    value: typeof m.value === 'number' ? m.value : parseFloat(String(m.value).replace(',', '.')),
+    mappedKey,
+    matched,
+    suggestedKey: m.suggestedKey || null,
+    suggestedName: m.suggestedName || null,
+    suggestedCategoryLabel: m.suggestedCategoryLabel || null,
+    unit: m.unit || null,
+    refMin: m.refMin != null ? m.refMin : null,
+    refMax: m.refMax != null ? m.refMax : null,
+    group: m.suggestedGroup || m.group || (testType !== 'blood' ? testType : null) || null,
+  };
+}
+
+function normalizeImageImportMarker(m, mappedKey, matched) {
+  return {
+    rawName: m.rawName || '',
+    value: typeof m.value === 'number' ? m.value : parseFloat(m.value),
+    mappedKey,
+    matched,
+    unit: m.unit || '',
+    refMin: m.refMin != null ? m.refMin : null,
+    refMax: m.refMax != null ? m.refMax : null,
+    suggestedKey: m.suggestedKey || null,
+    suggestedName: m.suggestedName || null,
+    suggestedCategoryLabel: m.suggestedCategoryLabel || null,
+    suggestedGroup: m.suggestedGroup || null,
+  };
+}

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -6,11 +6,11 @@ import { showNotification, isDebugMode, isPIIReviewEnabled, hashString, showProm
 import { saveImportedData, recalculateHOMAIR } from './data.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
-import { detectProduct, normalizeWithAdapter, getAdapterByTestType } from './adapters.js';
 import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
 import { clearTombstone, recordTombstone } from './data-merge.js';
 import { runPreflightChecks } from './pdf-import-preflight.js';
+import { normalizeParsedImportMarkers } from './pdf-import-marker-normalization.js';
 import {
   handleImportStatusClick,
   hideImportProgress,
@@ -21,7 +21,7 @@ import {
   updateImportProgressPct,
 } from './pdf-import-progress.js';
 import {
-  _cleanImportedMarkerDisplayName, _sanitizeAIMarker,
+  _cleanImportedMarkerDisplayName,
   buildMarkerReference, getExistingImportMarkerKeys,
   normalizeToSI, reconcileImportMarkerMappings,
 } from './pdf-import-marker-mapping.js';
@@ -357,110 +357,14 @@ Return ONLY valid JSON in this exact format, no other text:
   if (jsonStart > 0) jsonStr = jsonStr.slice(jsonStart);
   const parsed = tryParseJSON(jsonStr);
 
-  // Sanitize AI-supplied keys at the boundary, before any adapter or guard
-  // logic runs. Downstream code constructs new keys from the cleaned halves.
-  if (Array.isArray(parsed.markers)) parsed.markers.forEach(_sanitizeAIMarker);
-
-  let testType = parsed.testType || 'blood';
-  // ── Adapter-based normalization (fatty acids, Metabolomix+, future specialty labs) ──
-  // Run adapter normalization when: product detected AND not plain blood, AI says fattyAcids, or testType has a registered adapter
-  const detected = detectProduct(fileName, pdfText);
-  const adapterForTestType = !detected && testType !== 'blood' ? getAdapterByTestType(testType) : null;
-  const needsAdapterNormalize = testType === 'fattyAcids' || (!!detected && testType !== 'blood') || !!adapterForTestType;
-  if (needsAdapterNormalize && parsed.markers?.length) {
-    const adapter = detected?.adapter || adapterForTestType || getAdapterByTestType('fattyAcids');
-    normalizeWithAdapter(adapter, parsed.markers, fileName, pdfText, detected?.product);
-    if (isDebugMode()) console.log(`[Import] Adapter ${adapter?.id || 'fattyAcids'} normalized ${parsed.markers.length} markers (testType=${testType})`);
-  }
-  const standardCats = new Set(Object.keys(MARKER_SCHEMA));
-  const _specialtyTypes = ['OAT', 'fattyAcids', 'Metabolomix+', 'DUTCH', 'HTMA', 'GI'];
-  const markers = (parsed.markers || []).map(m => {
-      let mappedKey = m.mappedKey || null;
-      let matched = !!mappedKey;
-      // Guard: never allow standard blood work mappings for known specialty tests
-      // Only fire for well-defined specialty types — not for mixed/comprehensive reports
-      if (matched && _specialtyTypes.includes(testType)) {
-        const catKey = mappedKey.split('.')[0];
-        if (standardCats.has(catKey)) {
-          if (isDebugMode()) console.log(`[Import Guard] Demoted ${mappedKey} — standard category in ${testType} test`);
-          // Check if a specialty equivalent exists by marker name AND matching test type group
-          const markerPart = mappedKey.split('.')[1];
-          const specialtyMatch = Object.keys(SPECIALTY_MARKER_DEFS).find(k => {
-            if (k.split('.')[1] !== markerPart || standardCats.has(k.split('.')[0])) return false;
-            const sDef = SPECIALTY_MARKER_DEFS[k];
-            return sDef.group === testType || sDef.group?.toLowerCase() === testType.toLowerCase();
-          });
-          if (specialtyMatch) {
-            const sDef = SPECIALTY_MARKER_DEFS[specialtyMatch];
-            m.suggestedKey = specialtyMatch;
-            m.suggestedName = sDef.name;
-            m.suggestedCategoryLabel = sDef.categoryLabel;
-            m.suggestedGroup = m.suggestedGroup || sDef.group || testType;
-          } else if (!m.suggestedKey) {
-            const prefix = testType.toLowerCase().replace(/[^a-z]/g, '');
-            const originalCat = MARKER_SCHEMA[catKey];
-            const catSuffix = catKey.charAt(0).toUpperCase() + catKey.slice(1);
-            m.suggestedKey = `${prefix}${catSuffix}.${markerPart}`;
-            m.suggestedName = m.suggestedName || (originalCat?.markers?.[markerPart]?.name) || m.rawName;
-            m.suggestedCategoryLabel = m.suggestedCategoryLabel || (originalCat?.label) || catSuffix;
-            m.suggestedGroup = m.suggestedGroup || testType;
-          }
-          mappedKey = null;
-          matched = false;
-        }
-      }
-      // Guard: even for blood testType, remap to specialty key if adapter detected a product
-      // This catches AI misidentifying specialty tests as blood
-      if (matched && testType === 'blood' && detected) {
-        const catKey = mappedKey.split('.')[0];
-        if (standardCats.has(catKey)) {
-          const markerPart = mappedKey.split('.')[1];
-          // Only match specialty markers whose group aligns with the detected adapter
-          const adapterGroup = detected.adapter?.id === 'oat' ? 'OAT' : detected.adapter?.id === 'fattyAcids' ? 'Fatty Acids' : null;
-          const specialtyMatch = adapterGroup && Object.keys(SPECIALTY_MARKER_DEFS).find(k => {
-            if (k.split('.')[1] !== markerPart || standardCats.has(k.split('.')[0])) return false;
-            return SPECIALTY_MARKER_DEFS[k].group === adapterGroup;
-          });
-          if (specialtyMatch) {
-            const sDef = SPECIALTY_MARKER_DEFS[specialtyMatch];
-            if (isDebugMode()) console.log(`[Import Guard] Remapped ${mappedKey} → ${specialtyMatch} (adapter detected)`);
-            m.suggestedKey = specialtyMatch;
-            m.suggestedName = sDef.name;
-            m.suggestedCategoryLabel = sDef.categoryLabel;
-            m.suggestedGroup = sDef.group || testType;
-            mappedKey = null;
-            matched = false;
-          }
-        }
-      }
-      // Guard: also rewrite suggestedKey if AI used a standard category for specialty test
-      if (!matched && m.suggestedKey && testType !== 'blood') {
-        const sugCat = m.suggestedKey.split('.')[0];
-        if (standardCats.has(sugCat)) {
-          const markerPart = m.suggestedKey.split('.')[1] || m.rawName.replace(/[^a-zA-Z0-9]/g, '');
-          const prefix = testType.toLowerCase().replace(/[^a-z]/g, '');
-          const catSuffix = sugCat.charAt(0).toUpperCase() + sugCat.slice(1);
-          if (isDebugMode()) console.log(`[Import Guard] Rewrote suggestedKey ${m.suggestedKey} → ${prefix}${catSuffix}.${markerPart}`);
-          m.suggestedKey = `${prefix}${catSuffix}.${markerPart}`;
-          m.suggestedCategoryLabel = m.suggestedCategoryLabel || MARKER_SCHEMA[sugCat]?.label || catSuffix;
-          m.suggestedGroup = testType;
-        }
-      }
-      return {
-        rawName: m.rawName,
-        value: typeof m.value === 'number' ? m.value : parseFloat(String(m.value).replace(',', '.')),
-        mappedKey,
-        matched,
-        suggestedKey: m.suggestedKey || null,
-        suggestedName: m.suggestedName || null,
-        suggestedCategoryLabel: m.suggestedCategoryLabel || null,
-        unit: m.unit || null,
-        refMin: m.refMin != null ? m.refMin : null,
-        refMax: m.refMax != null ? m.refMax : null,
-        group: m.suggestedGroup || m.group || (testType !== 'blood' ? testType : null) || null
-      };
-    }).filter(m => !isNaN(m.value));
-  reconcileImportMarkerMappings(markers, { testType, refLookup: markerRef, existingKeys });
+  const { testType, markers } = normalizeParsedImportMarkers(parsed, {
+    markerRef,
+    fileName,
+    sourceText: pdfText,
+    existingKeys,
+    mode: 'text',
+    emitDebugLogs: true,
+  });
   return {
     date: parsed.date || null,
     testType,
@@ -889,99 +793,12 @@ Return ONLY valid JSON in this exact format:
   if (jsonStart > 0) jsonStr = jsonStr.slice(jsonStart);
   const parsed = tryParseJSON(jsonStr);
 
-  // Sanitize AI-supplied keys at the boundary, before any adapter or guard
-  // logic runs.
-  if (Array.isArray(parsed.markers)) parsed.markers.forEach(_sanitizeAIMarker);
-
-  let testType = parsed.testType || 'blood';
-  // ── Adapter-based normalization (image pipeline) — same logic as text pipeline ──
-  const detected = detectProduct(fileName, '');
-  const adapterForTestType = !detected && testType !== 'blood' ? getAdapterByTestType(testType) : null;
-  const needsAdapterNormalize = testType === 'fattyAcids' || (!!detected && testType !== 'blood') || !!adapterForTestType;
-  if (needsAdapterNormalize && parsed.markers?.length) {
-    const adapter = detected?.adapter || adapterForTestType || getAdapterByTestType('fattyAcids');
-    normalizeWithAdapter(adapter, parsed.markers, fileName, '', detected?.product);
-  }
-  const standardCats = new Set(Object.keys(MARKER_SCHEMA));
-  const _specialtyTypes = ['OAT', 'fattyAcids', 'Metabolomix+', 'DUTCH', 'HTMA', 'GI'];
-  const markers = (parsed.markers || []).map(m => {
-      let mappedKey = m.mappedKey || null;
-      let matched = !!mappedKey;
-      // Guard: never allow standard blood work mappings for known specialty tests
-      if (matched && _specialtyTypes.includes(testType)) {
-        const catKey = mappedKey.split('.')[0];
-        if (standardCats.has(catKey)) {
-          const markerPart = mappedKey.split('.')[1];
-          const specialtyMatch = Object.keys(SPECIALTY_MARKER_DEFS).find(k => {
-            if (k.split('.')[1] !== markerPart || standardCats.has(k.split('.')[0])) return false;
-            const sDef = SPECIALTY_MARKER_DEFS[k];
-            return sDef.group === testType || sDef.group?.toLowerCase() === testType.toLowerCase();
-          });
-          if (specialtyMatch) {
-            const sDef = SPECIALTY_MARKER_DEFS[specialtyMatch];
-            m.suggestedKey = specialtyMatch;
-            m.suggestedName = sDef.name;
-            m.suggestedCategoryLabel = sDef.categoryLabel;
-            m.suggestedGroup = m.suggestedGroup || sDef.group || testType;
-          } else if (!m.suggestedKey) {
-            const prefix = testType.toLowerCase().replace(/[^a-z]/g, '');
-            const catSuffix = catKey.charAt(0).toUpperCase() + catKey.slice(1);
-            m.suggestedKey = `${prefix}${catSuffix}.${markerPart}`;
-            m.suggestedName = m.suggestedName || m.rawName;
-            m.suggestedCategoryLabel = m.suggestedCategoryLabel || MARKER_SCHEMA[catKey]?.label || catSuffix;
-            m.suggestedGroup = m.suggestedGroup || testType;
-          }
-          mappedKey = null;
-          matched = false;
-        }
-      }
-      // Guard: even for blood testType, remap to specialty key if adapter detected a product
-      if (matched && testType === 'blood' && detected) {
-        const catKey = mappedKey.split('.')[0];
-        if (standardCats.has(catKey)) {
-          const markerPart = mappedKey.split('.')[1];
-          const adapterGroup = detected.adapter?.id === 'oat' ? 'OAT' : detected.adapter?.id === 'fattyAcids' ? 'Fatty Acids' : null;
-          const specialtyMatch = adapterGroup && Object.keys(SPECIALTY_MARKER_DEFS).find(k => {
-            if (k.split('.')[1] !== markerPart || standardCats.has(k.split('.')[0])) return false;
-            return SPECIALTY_MARKER_DEFS[k].group === adapterGroup;
-          });
-          if (specialtyMatch) {
-            const sDef = SPECIALTY_MARKER_DEFS[specialtyMatch];
-            m.suggestedKey = specialtyMatch;
-            m.suggestedName = sDef.name;
-            m.suggestedCategoryLabel = sDef.categoryLabel;
-            m.suggestedGroup = sDef.group || testType;
-            mappedKey = null;
-            matched = false;
-          }
-        }
-      }
-      if (!matched && m.suggestedKey && testType !== 'blood') {
-        const sugCat = m.suggestedKey.split('.')[0];
-        if (standardCats.has(sugCat)) {
-          const markerPart = m.suggestedKey.split('.')[1] || m.rawName.replace(/[^a-zA-Z0-9]/g, '');
-          const prefix = testType.toLowerCase().replace(/[^a-z]/g, '');
-          const catSuffix = sugCat.charAt(0).toUpperCase() + sugCat.slice(1);
-          m.suggestedKey = `${prefix}${catSuffix}.${markerPart}`;
-          m.suggestedCategoryLabel = m.suggestedCategoryLabel || MARKER_SCHEMA[sugCat]?.label || catSuffix;
-          m.suggestedGroup = testType;
-        }
-      }
-      return {
-        rawName: m.rawName || '',
-        value: typeof m.value === 'number' ? m.value : parseFloat(m.value),
-        mappedKey,
-        matched,
-        unit: m.unit || '',
-        refMin: m.refMin != null ? m.refMin : null,
-        refMax: m.refMax != null ? m.refMax : null,
-        suggestedKey: m.suggestedKey || null,
-        suggestedName: m.suggestedName || null,
-        suggestedCategoryLabel: m.suggestedCategoryLabel || null,
-        suggestedGroup: m.suggestedGroup || null,
-      };
-    }).filter(m => !isNaN(m.value));
-  reconcileImportMarkerMappings(markers, { testType, refLookup: markerRef });
+  const { testType, markers } = normalizeParsedImportMarkers(parsed, {
+    markerRef,
+    fileName,
+    sourceText: '',
+    mode: 'image',
+  });
   return {
     date: parsed.date || null,
     testType,

--- a/service-worker.js
+++ b/service-worker.js
@@ -115,6 +115,7 @@ const APP_SHELL = [
   '/js/pdf-import-progress.js',
   '/js/pdf-import-review.js',
   '/js/pdf-import-marker-mapping.js',
+  '/js/pdf-import-marker-normalization.js',
   '/js/export.js',
   '/js/chat.js',
   '/js/chat-window-bindings.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -61,7 +61,8 @@ assert('SW APP_SHELL includes API transport module', swAuditSrc.includes("'/js/a
 assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/js/pdf-import-review.js'"));
 assert('SW APP_SHELL includes PDF import support modules',
   swAuditSrc.includes("'/js/pdf-import-preflight.js'")
-  && swAuditSrc.includes("'/js/pdf-import-progress.js'"));
+  && swAuditSrc.includes("'/js/pdf-import-progress.js'")
+  && swAuditSrc.includes("'/js/pdf-import-marker-normalization.js'"));
 assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes("'/js/context-card-summaries.js'"));
 assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.includes("'/js/context-card-editor-ui.js'"));
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));
@@ -596,7 +597,8 @@ assert('PDF report context serialization', exportSrc.includes('fmtCtx'));
 
 const pdfSrc = read('js/pdf-import.js');
 const pdfReviewSrc = read('js/pdf-import-review.js');
-assert('NaN markers filtered out', pdfSrc.includes('filter(m => !isNaN(m.value))'));
+const pdfNormalizationSrc = read('js/pdf-import-marker-normalization.js');
+assert('NaN markers filtered out', pdfNormalizationSrc.includes('filter(marker => !isNaN(marker.value))'));
 
 // ═══════════════════════════════════════
 // 8. Duplicate code cleanup

--- a/tests/test-biostarks-adapter.js
+++ b/tests/test-biostarks-adapter.js
@@ -22,6 +22,7 @@ console.log('=== BioStarks Adapter Tests ===\n');
 
 const adaptersSrc = read('js/adapters.js');
 const pdfImportSrc = read('js/pdf-import.js');
+const normalizationSrc = read('js/pdf-import-marker-normalization.js');
 
   // ═══════════════════════════════════════
   // 1. Adapter Registration
@@ -135,7 +136,7 @@ const pdfImportSrc = read('js/pdf-import.js');
   assert('Rule 8 has BioStarks exception', pdfImportSrc.includes('EXCEPTION') && pdfImportSrc.includes('BioStarks') && pdfImportSrc.includes('hybrid'));
 
   // BioStarks NOT in _specialtyTypes (standard markers should map normally)
-  const specialtyMatch = pdfImportSrc.match(/const _specialtyTypes\s*=\s*\[([^\]]+)\]/);
+  const specialtyMatch = normalizationSrc.match(/const _specialtyTypes\s*=\s*\[([^\]]+)\]/);
   if (specialtyMatch) {
     assert('biostarks NOT in _specialtyTypes', !specialtyMatch[1].includes('biostarks'), 'BioStarks is hybrid — standard markers must pass through');
   } else {

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -102,6 +102,7 @@ const pwaAppShellAssets = [
   '/js/pdf-import-progress.js',
   '/js/pdf-import-review.js',
   '/js/pdf-import-marker-mapping.js',
+  '/js/pdf-import-marker-normalization.js',
   '/js/blob-storage.js',
   '/js/data-merge.js',
   '/js/views-router.js',

--- a/tests/test-schema.js
+++ b/tests/test-schema.js
@@ -26,6 +26,7 @@ const profileSrc = read('js/profile.js');
 const dataSrc = read('js/data.js');
 const pdfImportSrc = read('js/pdf-import.js');
 const pdfImportMappingSrc = read('js/pdf-import-marker-mapping.js');
+const pdfImportNormalizationSrc = read('js/pdf-import-marker-normalization.js');
   // ═══════════════════════════════════════
   // 1. MARKER_SCHEMA no longer has specialty categories
   // ═══════════════════════════════════════
@@ -168,10 +169,12 @@ const pdfImportMappingSrc = read('js/pdf-import-marker-mapping.js');
   assert('confirmImport auto-creates custom markers for specialty keys', pdfImportSrc.includes('SPECIALTY_MARKER_DEFS[m.mappedKey]'));
   assert('Prompt asks for refMin/refMax on all markers', pdfImportSrc.includes('refMin: the lower reference range bound EXACTLY as printed on the PDF'));
   // Adapter integration
-  assert('pdf-import imports adapter functions', pdfImportSrc.includes("from './adapters.js'"));
-  assert('Inline FA functions removed', !pdfImportSrc.includes('FA_PRODUCT_PATTERNS') && !pdfImportSrc.includes('function _detectFAProduct'));
-  assert('Uses detectProduct from adapters', pdfImportSrc.includes('detectProduct('));
-  assert('Uses normalizeWithAdapter from adapters', pdfImportSrc.includes('normalizeWithAdapter('));
+  assert('pdf-import normalization imports adapter functions', pdfImportNormalizationSrc.includes("from './adapters.js'"));
+  assert('Inline FA functions removed',
+    !pdfImportSrc.includes('FA_PRODUCT_PATTERNS') && !pdfImportSrc.includes('function _detectFAProduct')
+    && !pdfImportNormalizationSrc.includes('FA_PRODUCT_PATTERNS') && !pdfImportNormalizationSrc.includes('function _detectFAProduct'));
+  assert('Uses detectProduct from adapters', pdfImportNormalizationSrc.includes('detectProduct('));
+  assert('Uses normalizeWithAdapter from adapters', pdfImportNormalizationSrc.includes('normalizeWithAdapter('));
 
   // ═══════════════════════════════════════
   // 7. getActiveData merges migrated specialty markers correctly

--- a/tests/test-security-phase1.js
+++ b/tests/test-security-phase1.js
@@ -40,6 +40,7 @@ assert('isEvalSupported wins over extraOpts (via spread order)',
 
 const importSrc = read('js/pdf-import.js');
 const importMappingSrc = read('js/pdf-import-marker-mapping.js');
+const importNormalizationSrc = read('js/pdf-import-marker-normalization.js');
 assert('pdf-import.js routes through getPdfDocument',
   importSrc.includes('getPdfDocument') && !importSrc.includes('pdfjsLib.getDocument'),
   'no direct pdfjsLib.getDocument calls — they bypass the eval guard');
@@ -52,7 +53,7 @@ console.log('\n2. AI key sanitization');
 assert('pdf-import-marker-mapping.js defines _SAFE_MARKER_KEY pattern',
   importMappingSrc.includes('_SAFE_MARKER_KEY') && importMappingSrc.includes('/^[a-zA-Z][a-zA-Z0-9]*\\.[a-zA-Z][a-zA-Z0-9_]*$/'));
 assert('_sanitizeAIMarker called before adapter runs',
-  importSrc.includes('parsed.markers.forEach(_sanitizeAIMarker)'),
+  importNormalizationSrc.includes('parsed.markers.forEach(_sanitizeAIMarker)'),
   'must run before normalizeWithAdapter to prevent adapter-derived keys from inheriting unsafe halves');
 const exposedSanitizer = importMappingSrc.match(/function _sanitizeAIMarker\(m\) \{([^}]+)\}/);
 assert('_sanitizeAIMarker drops both mappedKey and suggestedKey on bad input',

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -22,6 +22,7 @@ console.log('=== Unit Normalization on Import Tests ===\n');
 
 const src = read('js/pdf-import.js');
 const mappingSrc = read('js/pdf-import-marker-mapping.js');
+const normalizationSrc = read('js/pdf-import-marker-normalization.js');
 const settingsSrc = read('js/settings.js');
   // ═══════════════════════════════════════
   // 1. normalizeToSI function exists
@@ -243,10 +244,14 @@ const settingsSrc = read('js/settings.js');
   console.log('%c 6. FA normalization safety ', 'font-weight:bold;color:#f59e0b');
 
   // Verify FA normalization uses adapters.js (not inline functions)
-  assert('pdf-import imports adapter functions', src.includes("from './adapters.js'"));
-  assert('Inline FA functions removed', !src.includes('function _normalizeFattyAcidMarkers(') && !src.includes('FA_PRODUCT_PATTERNS'));
-  assert('Uses detectProduct from adapters', src.includes('detectProduct('));
-  assert('Uses normalizeWithAdapter from adapters', src.includes('normalizeWithAdapter('));
+  assert('pdf-import normalization imports adapter functions', normalizationSrc.includes("from './adapters.js'"));
+  assert('Inline FA functions removed',
+    !src.includes('function _normalizeFattyAcidMarkers(')
+    && !src.includes('FA_PRODUCT_PATTERNS')
+    && !normalizationSrc.includes('function _normalizeFattyAcidMarkers(')
+    && !normalizationSrc.includes('FA_PRODUCT_PATTERNS'));
+  assert('Uses detectProduct from adapters', normalizationSrc.includes('detectProduct('));
+  assert('Uses normalizeWithAdapter from adapters', normalizationSrc.includes('normalizeWithAdapter('));
 
   // FA normalize logic lives in adapters.js — check it there
   const adapterSrc = read('js/adapters.js');
@@ -255,11 +260,11 @@ const settingsSrc = read('js/settings.js');
 
   // Verify adapter normalization requires AI agreement — product detection alone + blood testType must NOT trigger
   assert('Adapter normalization requires non-blood testType',
-    src.includes("testType !== 'blood'") && src.includes('detected') && src.includes('needsAdapterNormalize'));
+    normalizationSrc.includes("testType !== 'blood'") && normalizationSrc.includes('detected') && normalizationSrc.includes('needsAdapterNormalize'));
 
   // Verify guard at line 367 only fires for non-blood tests
   assert('Guard checks testType !== blood',
-    src.includes("testType !== 'blood'") && src.includes('Import Guard'));
+    normalizationSrc.includes("testType !== 'blood'") && normalizationSrc.includes('Import Guard'));
 
   // ═══════════════════════════════════════
   // 7. Import mapping reconciliation

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.275';
+self.APP_VERSION = '1.8.276';


### PR DESCRIPTION
## Summary
- Extract shared AI marker sanitization, adapter normalization, specialty guard, and reconcile logic into `pdf-import-marker-normalization.js`
- Keep text and image import output shapes separate while removing the duplicated normalization blocks from `pdf-import.js`
- Precache/document the new module and update source-inspection tests for the new ownership
- Bump app version to `1.8.276`

## Validation
- `node --check js/pdf-import.js`
- `node --check js/pdf-import-marker-normalization.js`
- `node tests/test-unit-import.js`
- `node tests/test-schema.js`
- `node tests/test-biostarks-adapter.js`
- `node tests/test-security-phase1.js`
- `node tests/test-audit.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-image-utils.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- normalizer mode smoke for text `group` vs image `suggestedGroup`
- `./run-tests.sh`