### PR TITLE
Extract PDF import persistence

### DIFF
--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -70,6 +70,7 @@ js/
   pdf-import.js     — PDF/image/text import pipeline, AI analysis, confirm/save merge
   pdf-import-preflight.js / pdf-import-progress.js — import preflight prompts and progress/status UI
   pdf-import-marker-normalization.js — shared AI marker sanitization, adapter normalization, specialty guards
+  pdf-import-persistence.js — imported-data snapshot, rollback, refresh, remove, and rename save flows
   pdf-import-review.js — import review modal rendering, row filtering/mapping UI state
   import-file-input.js — lazy file-picker import binding and import routing
   import-drop-zone.js — lazy import drop-zone binding shared by page shells

--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -532,6 +532,19 @@ Shared AI marker normalization for PDF text import and image import.
 
 ---
 
+### `pdf-import-persistence.js`
+
+Durable imported-data persistence helpers for PDF import flows.
+
+**Key exports:**
+- `snapshotImportedData()` / `restoreImportedDataSnapshot(snapshot)` — rollback guard used when durable import saves fail
+- `refreshImportedDataViews()` — rebuilds sidebar/header and restores the current route after imported data changes
+- `removeImportedEntry(date)` / `renameImportedEntryDate(oldDate)` — entry delete and date-edit mutations with tombstones, immediate sync save, rollback, and success refresh
+
+**Window exports:** via `pdf-import.js`
+
+---
+
 ### `pdf-import-review.js`
 
 Import review modal rendering and interaction state.

--- a/js/pdf-import-persistence.js
+++ b/js/pdf-import-persistence.js
@@ -21,7 +21,7 @@ export function refreshImportedDataViews() {
   window.navigate(state.currentView || 'dashboard');
 }
 
-export function isValidISOCalendarDate(date) {
+function isValidISOCalendarDate(date) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
   const [year, month, day] = date.split('-').map(Number);
   const parsed = new Date(Date.UTC(year, month - 1, day));

--- a/js/pdf-import-persistence.js
+++ b/js/pdf-import-persistence.js
@@ -1,0 +1,97 @@
+// pdf-import-persistence.js - durable imported-data save helpers for PDF import flows
+
+import { state } from './state.js';
+import { showNotification, showPromptDialog } from './utils.js';
+import { saveImportedData } from './data.js';
+import { clearTombstone, recordTombstone } from './data-merge.js';
+
+export function snapshotImportedData() {
+  try { return JSON.stringify(state.importedData || {}); } catch { return null; }
+}
+
+export function restoreImportedDataSnapshot(snapshot) {
+  if (!snapshot) return;
+  try { state.importedData = JSON.parse(snapshot); } catch {}
+}
+
+export function refreshImportedDataViews() {
+  window.buildSidebar();
+  window.updateHeaderDates();
+  // buildSidebar resets .active to Dashboard; use state.currentView.
+  window.navigate(state.currentView || 'dashboard');
+}
+
+export function isValidISOCalendarDate(date) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  const [year, month, day] = date.split('-').map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day;
+}
+
+export async function removeImportedEntry(date) {
+  if (!date) return false;
+  const rollback = snapshotImportedData();
+  if (!state.importedData.entries) state.importedData.entries = [];
+  recordTombstone(state.importedData, 'entries', date);
+  state.importedData.entries = state.importedData.entries.filter(e => e.date !== date);
+  const saved = await saveImportedData({ immediate: true });
+  if (!saved) {
+    restoreImportedDataSnapshot(rollback);
+    return false;
+  }
+  refreshImportedDataViews();
+  showNotification(`Removed imported data from ${date}`, 'info');
+  return true;
+}
+
+export async function renameImportedEntryDate(oldDate) {
+  const entries = state.importedData?.entries;
+  const entry = entries?.find(e => e.date === oldDate);
+  if (!entry) return false;
+  const newDate = await showPromptDialog(
+    `Edit collection date (was ${oldDate})`,
+    { defaultValue: oldDate, inputType: 'date', okLabel: 'Save' }
+  );
+  if (!newDate || newDate === oldDate) return false;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(newDate)) {
+    showNotification('Date must be YYYY-MM-DD', 'error');
+    return false;
+  }
+  // Format-only regex accepts logically invalid dates. Round-trip through Date
+  // to reject those without applying the local timezone.
+  if (!isValidISOCalendarDate(newDate)) {
+    showNotification('That date doesn\'t exist on the calendar.', 'error');
+    return false;
+  }
+  if (entries.some(e => e.date === newDate)) {
+    showNotification(`Another entry already exists on ${newDate} \u2014 remove it first, then try again.`, 'error', 5000);
+    return false;
+  }
+  const rollback = snapshotImportedData();
+  recordTombstone(state.importedData, 'entries', oldDate);
+  clearTombstone(state.importedData, 'entries', newDate);
+  entry.date = newDate;
+  entry.updatedAt = Date.now();
+  // manualValues are keyed markerKey:date; remap to preserve provenance.
+  const manualValues = state.importedData.manualValues;
+  if (manualValues) {
+    const suffixOld = ':' + oldDate;
+    const suffixNew = ':' + newDate;
+    for (const k of Object.keys(manualValues)) {
+      if (k.endsWith(suffixOld)) {
+        manualValues[k.slice(0, -suffixOld.length) + suffixNew] = manualValues[k];
+        delete manualValues[k];
+      }
+    }
+  }
+  const saved = await saveImportedData({ immediate: true });
+  if (!saved) {
+    restoreImportedDataSnapshot(rollback);
+    return false;
+  }
+  refreshImportedDataViews();
+  showNotification(`Date changed from ${oldDate} to ${newDate}`, 'success');
+  return true;
+}

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -2,15 +2,22 @@
 
 import { state } from './state.js';
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS, calculateCost, trackUsage } from './schema.js';
-import { showNotification, isDebugMode, isPIIReviewEnabled, hashString, showPromptDialog } from './utils.js';
+import { showNotification, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
 import { saveImportedData, recalculateHOMAIR } from './data.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
-import { clearTombstone, recordTombstone } from './data-merge.js';
+import { clearTombstone } from './data-merge.js';
 import { runPreflightChecks } from './pdf-import-preflight.js';
 import { normalizeParsedImportMarkers } from './pdf-import-marker-normalization.js';
+import {
+  refreshImportedDataViews,
+  removeImportedEntry,
+  renameImportedEntryDate,
+  restoreImportedDataSnapshot,
+  snapshotImportedData,
+} from './pdf-import-persistence.js';
 import {
   handleImportStatusClick,
   hideImportProgress,
@@ -57,6 +64,7 @@ export {
   showBatchImportProgress,
   showImportProgress,
 } from './pdf-import-progress.js';
+export { removeImportedEntry, renameImportedEntryDate } from './pdf-import-persistence.js';
 
 // ═══════════════════════════════════════════════
 // AI-NEEDED DIALOG — contextual fallback when import is invoked without an AI provider.
@@ -375,24 +383,6 @@ Return ONLY valid JSON in this exact format, no other text:
   };
 }
 
-function snapshotImportedData() {
-  try { return JSON.stringify(state.importedData || {}); } catch { return null; }
-}
-
-function restoreImportedDataSnapshot(snapshot) {
-  if (!snapshot) return;
-  try { state.importedData = JSON.parse(snapshot); } catch {}
-}
-
-function isValidISOCalendarDate(date) {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
-  const [year, month, day] = date.split('-').map(Number);
-  const parsed = new Date(Date.UTC(year, month - 1, day));
-  return parsed.getUTCFullYear() === year
-    && parsed.getUTCMonth() === month - 1
-    && parsed.getUTCDate() === day;
-}
-
 export async function confirmImport() {
   const result = getPendingImport();
   if (!result || !result.date) return;
@@ -527,88 +517,10 @@ export async function confirmImport() {
   if (!resolveImportPreviewBatch('import')) closeImportModal();
   // During batch mode, defer expensive UI refreshes until the batch completes
   if (!_batchMode) {
-    window.buildSidebar();
-    window.updateHeaderDates();
-    // buildSidebar resets .active to Dashboard — use state.currentView
-    // (kept in sync by navigate) instead of re-reading the stale DOM.
-    window.navigate(state.currentView || "dashboard");
+    refreshImportedDataViews();
   }
   showNotification(`Imported ${importCount} markers from ${result.date}`, "success");
   if (!_batchMode && typeof window.maybeShowEncryptionNudge === 'function') window.maybeShowEncryptionNudge();
-}
-
-export async function removeImportedEntry(date) {
-  if (!date) return false;
-  const rollback = snapshotImportedData();
-  if (!state.importedData.entries) state.importedData.entries = [];
-  recordTombstone(state.importedData, 'entries', date);
-  state.importedData.entries = state.importedData.entries.filter(e => e.date !== date);
-  const saved = await saveImportedData({ immediate: true });
-  if (!saved) {
-    restoreImportedDataSnapshot(rollback);
-    return false;
-  }
-  window.buildSidebar();
-  window.updateHeaderDates();
-  // buildSidebar resets .active to Dashboard — use state.currentView.
-  window.navigate(state.currentView || "dashboard");
-  showNotification(`Removed imported data from ${date}`, "info");
-  return true;
-}
-
-export async function renameImportedEntryDate(oldDate) {
-  const entries = state.importedData?.entries;
-  const entry = entries?.find(e => e.date === oldDate);
-  if (!entry) return false;
-  const newDate = await showPromptDialog(
-    `Edit collection date (was ${oldDate})`,
-    { defaultValue: oldDate, inputType: 'date', okLabel: 'Save' }
-  );
-  if (!newDate || newDate === oldDate) return false;
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(newDate)) {
-    showNotification('Date must be YYYY-MM-DD', 'error');
-    return false;
-  }
-  // Format-only regex accepts logically invalid dates (Feb 30, month 13).
-  // Round-trip through Date to reject those — `<input type="date">` already
-  // guards in modern browsers, but free-text fallbacks and programmatic
-  // values can still slip through.
-  if (!isValidISOCalendarDate(newDate)) {
-    showNotification('That date doesn\'t exist on the calendar.', 'error');
-    return false;
-  }
-  if (entries.some(e => e.date === newDate)) {
-    showNotification(`Another entry already exists on ${newDate} — remove it first, then try again.`, 'error', 5000);
-    return false;
-  }
-  const rollback = snapshotImportedData();
-  recordTombstone(state.importedData, 'entries', oldDate);
-  clearTombstone(state.importedData, 'entries', newDate);
-  entry.date = newDate;
-  entry.updatedAt = Date.now();
-  // manualValues are keyed `markerKey:date` — remap to keep manual-vs-imported provenance correct
-  const manualValues = state.importedData.manualValues;
-  if (manualValues) {
-    const suffixOld = ':' + oldDate;
-    const suffixNew = ':' + newDate;
-    for (const k of Object.keys(manualValues)) {
-      if (k.endsWith(suffixOld)) {
-        manualValues[k.slice(0, -suffixOld.length) + suffixNew] = manualValues[k];
-        delete manualValues[k];
-      }
-    }
-  }
-  const saved = await saveImportedData({ immediate: true });
-  if (!saved) {
-    restoreImportedDataSnapshot(rollback);
-    return false;
-  }
-  window.buildSidebar();
-  window.updateHeaderDates();
-  // buildSidebar resets .active to Dashboard — use state.currentView.
-  window.navigate(state.currentView || "dashboard");
-  showNotification(`Date changed from ${oldDate} to ${newDate}`, 'success');
-  return true;
 }
 
 // ═══════════════════════════════════════════════
@@ -1141,10 +1053,7 @@ export async function handleBatchPDFs(pdfFiles) {
   }
   _batchMode = false;
   // Refresh UI once after all files processed
-  window.buildSidebar();
-  window.updateHeaderDates();
-  // buildSidebar resets .active to Dashboard — use state.currentView.
-  window.navigate(state.currentView || "dashboard");
+  refreshImportedDataViews();
   hideImportProgress();
   const parts = [];
   if (imported > 0) parts.push(`${imported} imported`);

--- a/service-worker.js
+++ b/service-worker.js
@@ -116,6 +116,7 @@ const APP_SHELL = [
   '/js/pdf-import-review.js',
   '/js/pdf-import-marker-mapping.js',
   '/js/pdf-import-marker-normalization.js',
+  '/js/pdf-import-persistence.js',
   '/js/export.js',
   '/js/chat.js',
   '/js/chat-window-bindings.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -62,7 +62,8 @@ assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/
 assert('SW APP_SHELL includes PDF import support modules',
   swAuditSrc.includes("'/js/pdf-import-preflight.js'")
   && swAuditSrc.includes("'/js/pdf-import-progress.js'")
-  && swAuditSrc.includes("'/js/pdf-import-marker-normalization.js'"));
+  && swAuditSrc.includes("'/js/pdf-import-marker-normalization.js'")
+  && swAuditSrc.includes("'/js/pdf-import-persistence.js'"));
 assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes("'/js/context-card-summaries.js'"));
 assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.includes("'/js/context-card-editor-ui.js'"));
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -103,6 +103,7 @@ const pwaAppShellAssets = [
   '/js/pdf-import-review.js',
   '/js/pdf-import-marker-mapping.js',
   '/js/pdf-import-marker-normalization.js',
+  '/js/pdf-import-persistence.js',
   '/js/blob-storage.js',
   '/js/data-merge.js',
   '/js/views-router.js',

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -23,6 +23,7 @@ console.log('=== Unit Normalization on Import Tests ===\n');
 const src = read('js/pdf-import.js');
 const mappingSrc = read('js/pdf-import-marker-mapping.js');
 const normalizationSrc = read('js/pdf-import-marker-normalization.js');
+const persistenceSrc = read('js/pdf-import-persistence.js');
 const settingsSrc = read('js/settings.js');
   // ═══════════════════════════════════════
   // 1. normalizeToSI function exists
@@ -58,17 +59,17 @@ const settingsSrc = read('js/settings.js');
   assert('PDF import clears same-date entry tombstone when intentionally re-importing',
     /clearTombstone\(state\.importedData,\s*['"]entries['"],\s*result\.date\)/.test(confirmBlock));
   assert('PDF import rolls back in-memory state when durable save fails',
-    /const rollback = snapshotImportedData\(\)[\s\S]{0,4000}if \(!saved\) \{[\s\S]{0,200}restoreImportedDataSnapshot\(rollback\)/.test(confirmBlock));
-  const removeBlock = src.substring(src.indexOf('export async function removeImportedEntry'), src.indexOf('export async function renameImportedEntryDate'));
+    /const rollback = snapshotImportedData\(\)/.test(confirmBlock)
+      && /if \(!saved\) \{[\s\S]{0,200}restoreImportedDataSnapshot\(rollback\)/.test(confirmBlock));
+  const removeBlock = persistenceSrc.substring(persistenceSrc.indexOf('export async function removeImportedEntry'), persistenceSrc.indexOf('export async function renameImportedEntryDate'));
   assert('import delete records entries tombstone before removing row',
     /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*date\)[\s\S]{0,180}entries\.filter/.test(removeBlock));
   assert('import delete uses immediate sync push',
     /await\s+saveImportedData\(\{\s*immediate:\s*true\s*\}\)/.test(removeBlock));
   assert('import delete restores state and returns false when save fails',
     /const rollback = snapshotImportedData\(\)[\s\S]{0,400}if \(!saved\) \{[\s\S]{0,160}restoreImportedDataSnapshot\(rollback\)[\s\S]{0,120}return false/.test(removeBlock));
-  const renameStart = src.indexOf('export async function renameImportedEntryDate');
-  const renameEnd = src.indexOf('export function classifyImportFiles');
-  const renameBlock = src.substring(renameStart, renameEnd > renameStart ? renameEnd : src.length);
+  const renameStart = persistenceSrc.indexOf('export async function renameImportedEntryDate');
+  const renameBlock = persistenceSrc.substring(renameStart);
   assert('import date rename tombstones old date',
     /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*oldDate\)/.test(renameBlock));
   assert('import date rename clears tombstone for new date',
@@ -76,9 +77,9 @@ const settingsSrc = read('js/settings.js');
   assert('import date rename restores state and returns false when save fails',
     /const saved = await saveImportedData\(\{\s*immediate:\s*true\s*\}\)[\s\S]{0,160}if \(!saved\) \{[\s\S]{0,160}restoreImportedDataSnapshot\(rollback\)[\s\S]{0,120}return false/.test(renameBlock));
   assert('import date rename validates calendar dates without local-timezone shift',
-    /function isValidISOCalendarDate\(date\)/.test(src)
-      && /Date\.UTC\(year,\s*month - 1,\s*day\)/.test(src)
-      && /getUTCFullYear\(\)\s*===\s*year[\s\S]{0,120}getUTCMonth\(\)\s*===\s*month - 1[\s\S]{0,120}getUTCDate\(\)\s*===\s*day/.test(src));
+    /function isValidISOCalendarDate\(date\)/.test(persistenceSrc)
+      && /Date\.UTC\(year,\s*month - 1,\s*day\)/.test(persistenceSrc)
+      && /getUTCFullYear\(\)\s*===\s*year[\s\S]{0,120}getUTCMonth\(\)\s*===\s*month - 1[\s\S]{0,120}getUTCDate\(\)\s*===\s*day/.test(persistenceSrc));
   assert('Settings Data remove refreshes only after successful delete',
     /removeImportedEntryFromSettings[\s\S]{0,240}const ok = await removeImportedEntry\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsSrc));
   assert('Settings Data rename refreshes only after successful save',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.276';
+self.APP_VERSION = '1.8.277';


### PR DESCRIPTION
## Summary
- Add `pdf-import-persistence.js` for imported-data snapshot/rollback, post-save refresh, and remove/rename entry save flows
- Keep marker-specific `confirmImport` logic in `pdf-import.js`, but route rollback and refresh through the shared helper
- Preserve legacy `pdf-import.js` exports/window bindings for settings and existing callers
- Precache/document the new module and bump app version to `1.8.277`

## Validation
- `node --check js/pdf-import.js`
- `node --check js/pdf-import-persistence.js`
- `node tests/test-unit-import.js`
- `node tests/test-audit.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-image-utils.js`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`