### PR TITLE
[codex] Extract sun session store

### DIFF
--- a/js/sun-active-session.js
+++ b/js/sun-active-session.js
@@ -1,11 +1,12 @@
 // sun-active-session.js — active sun-session UI, live dose ticker, and
-// modal helpers. Core persisted session storage and hydration stay in
-// sun.js; this module receives those operations through configuration to
-// avoid importing sun.js back into the active UI layer.
+// modal helpers. Core persisted session storage and hydration live in
+// sun-sessions-store.js; this module receives those operations through
+// configuration to avoid importing sun.js back into the active UI layer.
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette } from './sun-body-silhouette.js';
+import { POSTURE_MULTIPLIERS, SURFACE_ALBEDO } from './sun-session-model.js';
 import { renderChannelChips } from './sun-session-ui.js';
 
 const activeDeps = {
@@ -30,24 +31,7 @@ export function configureSunActiveSession(deps = {}) {
   Object.assign(activeDeps, deps);
 }
 
-// Posture orientation multipliers on bodyExposureFraction. Lying-supine
-// makes the front of the body nearly horizontal at noon; lying-prone same
-// for back. These are rough but match the hydrated-session dose path.
-export const POSTURE_MULTIPLIERS = {
-  standing: 1.0,
-  sitting: 0.85,
-  'lying-supine': 1.4,
-  'lying-prone': 1.4,
-};
-
-// Surface albedo (UV reflectance). 0.25 = sand/water; 0.80 = fresh snow.
-export const SURFACE_ALBEDO = {
-  grass: 0.03,
-  concrete: 0.10,
-  sand: 0.25,
-  water: 0.25,
-  snow: 0.80,
-};
+export { POSTURE_MULTIPLIERS, SURFACE_ALBEDO } from './sun-session-model.js';
 
 // Single-tap "I'm outside now" — starts a session with last-used defaults.
 // On stop: skips confirm dialog because the user explicitly tapped stop.

--- a/js/sun-session-model.js
+++ b/js/sun-session-model.js
@@ -1,0 +1,93 @@
+// sun-session-model.js — shared Sun session option and safety model.
+//
+// Keep these constants out of UI/store modules so the active-session ticker,
+// persisted session store, and public sun.js facade all use one source.
+
+// Photosensitizing medication scale tiers — used by fractionOfMED() in
+// place of the legacy boolean flag. MED multipliers from AAD/Mayo Clinic
+// guidance: severe drugs (tetracyclines, retinoids systemic, amiodarone)
+// shift erythemal threshold ~4×; moderate (NSAIDs, thiazides, sulfa) ~2.5×;
+// mild (some antihistamines) ~1.5×.
+export const PHOTOSENSITIVE_MED_TIERS = [
+  { key: 'none',     label: 'None',      medScale: 1.0,  examples: '' },
+  { key: 'mild',     label: 'Mild',      medScale: 0.7,  examples: 'antihistamines (most), some NSAIDs' },
+  { key: 'moderate', label: 'Moderate',  medScale: 0.4,  examples: 'NSAIDs, thiazide diuretics, sulfa antibiotics, St. John\'s Wort, topical retinol' },
+  { key: 'severe',   label: 'Severe',    medScale: 0.25, examples: 'tetracyclines (doxycycline), oral retinoids (isotretinoin), amiodarone, citrus essential oils on skin' },
+];
+
+// Map tier key to multiplier; default to none (no scaling) on unknown.
+export function photosensitiveMedScale(tier) {
+  const t = PHOTOSENSITIVE_MED_TIERS.find(x => x.key === tier);
+  return t ? t.medScale : 1.0;
+}
+
+// Normalize legacy boolean photosensitiveMeds storage into a tier key.
+// boolean true → 'moderate' (the previous fixed-0.4 multiplier semantically
+// matches moderate); boolean false / null / undefined → 'none'.
+export function _normalizePSMTier(raw) {
+  if (raw === true) return 'moderate';
+  if (raw === false || raw == null) return 'none';
+  if (typeof raw === 'string' && PHOTOSENSITIVE_MED_TIERS.some(t => t.key === raw)) return raw;
+  return 'none';
+}
+
+// Standard quick-presets for the speed log. Fractions reflect a SINGLE
+// position (front-only OR back-only at any one moment) — capped at the
+// anatomical max of ~0.55. Use the in-session "🔄 Flip" button (or the
+// `rotatedSides` toggle in the start dialog) to log that you exposed
+// both sides over the session; that doubles the effective body dose
+// the same way dminder's "100% naked" assumes alternating sides.
+//
+// Cite: fractions derive from the Wallace rule of nines + Lund-Browder
+// (1944) chart, then halved (anterior face only). Face + hands ≈ 4.5%
+// face + 2.5% hands = 7% total body, ~5% projected to one side.
+// T-shirt + shorts exposes face/hands/forearms/lower legs ≈ 20%.
+// Swimwear exposes everything except briefs (~45% one side per Holick
+// 2007's "10% body surface = ~2 cm² per kg of pre-vit-D substrate").
+// Sunbathing tops out at ~50% one side per the dminder convention.
+// AI verdict math for synthesis ("you got 1500 IU because 20% of your
+// skin saw 15 min of UVI 7") is rooted in these fractions.
+export const EXPOSURE_PRESETS = [
+  { key: 'face_hands', label: 'Face + hands',         fraction: 0.05 },
+  { key: 'tshirt',     label: 'T-shirt + shorts',     fraction: 0.20 },
+  { key: 'swimwear',   label: 'Swimwear',             fraction: 0.45 },
+  { key: 'sunbathing', label: 'Sunbathing',           fraction: 0.50 },
+];
+
+// Posture options surfaced in pickers + applied as a multiplier on the
+// effective body fraction.
+export const POSTURE_OPTIONS = [
+  { key: 'standing',     label: 'Standing / walking' },
+  { key: 'sitting',      label: 'Sitting / reclined' },
+  { key: 'lying-supine', label: 'Lying face-up' },
+  { key: 'lying-prone',  label: 'Lying face-down' },
+];
+
+// Posture orientation multipliers on bodyExposureFraction. Lying-supine
+// makes the front of the body nearly horizontal at noon; lying-prone same
+// for back. These are rough but match the hydrated-session dose path.
+export const POSTURE_MULTIPLIERS = {
+  standing: 1.0,
+  sitting: 0.85,
+  'lying-supine': 1.4,
+  'lying-prone': 1.4,
+};
+
+// Surface albedo dropdown values — UV reflection from below augments
+// total received irradiance by ~(albedo × 0.5). See SURFACE_ALBEDO.
+export const SURFACE_OPTIONS = [
+  { key: 'grass',    label: 'Grass / dirt (~3% reflect)' },
+  { key: 'concrete', label: 'Concrete / pavement (~10%)' },
+  { key: 'sand',     label: 'Sand (~25%)' },
+  { key: 'water',    label: 'Water / pool (~25%)' },
+  { key: 'snow',     label: 'Snow / ice (~80%)' },
+];
+
+// Surface albedo (UV reflectance). 0.25 = sand/water; 0.80 = fresh snow.
+export const SURFACE_ALBEDO = {
+  grass: 0.03,
+  concrete: 0.10,
+  sand: 0.25,
+  water: 0.25,
+  snow: 0.80,
+};

--- a/js/sun-sessions-store.js
+++ b/js/sun-sessions-store.js
@@ -232,19 +232,31 @@ export async function updateSession(id, patch) {
   // fetchAtmosphere awaits and write doses for the older duration after the
   // newer one shipped (the relay briefly holds stale doses).
   if (durationChanged && sess.location) {
-    const prev = _hydrateInFlight.get(id) || Promise.resolve();
-    const next = prev
-      .catch(() => {})
-      .then(() => hydrateSession(id, { lat: sess.location.lat, lon: sess.location.lon }))
-      .catch(e => { if (typeof window !== 'undefined' && window.console) console.warn('hydrateSession after updateSession failed', e); });
-    _hydrateInFlight.set(id, next);
-    next.finally(() => { if (_hydrateInFlight.get(id) === next) _hydrateInFlight.delete(id); });
+    _runHydrateSession(id, { lat: sess.location.lat, lon: sess.location.lon }, {
+      queueAfterExisting: true,
+      warnContext: 'hydrateSession after updateSession failed',
+    });
   }
   return sess;
 }
 
 // Per-session hydrate serialization queue. Map<sessionId, Promise>.
 const _hydrateInFlight = new Map();
+
+function _runHydrateSession(id, coords, { queueAfterExisting = false, warnContext = 'hydrateSession failed' } = {}) {
+  const existing = _hydrateInFlight.get(id);
+  if (existing && !queueAfterExisting) return existing;
+  const base = queueAfterExisting && existing ? existing.catch(() => {}) : Promise.resolve();
+  const next = base
+    .then(() => hydrateSession(id, coords))
+    .catch(e => {
+      if (typeof window !== 'undefined' && window.console) console.warn(warnContext, e);
+      return null;
+    });
+  _hydrateInFlight.set(id, next);
+  next.finally(() => { if (_hydrateInFlight.get(id) === next) _hydrateInFlight.delete(id); });
+  return next;
+}
 
 // Hydrate a session record with computed atmosphere + channel doses.
 // Idempotent — reruns after edits.
@@ -424,12 +436,14 @@ export async function rehydrateStaleSessions() {
   );
   if (stale.length === 0) return { rehydrated: 0 };
   // Serialize so we don't fan out N concurrent atmosphere fetches.
-  // hydrateSession itself dedups by id, so two batches in parallel
-  // don't double-fetch the same session.
+  // _runHydrateSession dedups by id, so two batches in parallel don't
+  // double-fetch the same session.
   let ok = 0;
   for (const s of stale) {
     try {
-      const result = await hydrateSession(s.id, { lat: s.location.lat, lon: s.location.lon });
+      const result = await _runHydrateSession(s.id, { lat: s.location.lat, lon: s.location.lon }, {
+        warnContext: `rehydrateStaleSessions: ${s.id}`,
+      });
       if (result) ok++;
     } catch (e) {
       if (window.console && console.warn) console.warn('rehydrateStaleSessions:', s.id, e?.message || e);

--- a/js/sun-sessions-store.js
+++ b/js/sun-sessions-store.js
@@ -1,0 +1,443 @@
+// sun-sessions-store.js — persisted Sun session lifecycle, hydration, and safety.
+//
+// This module owns importedData.sunSessions[] CRUD and dose hydration. UI flows
+// stay in sun.js / sun-active-session.js and inject live-runtime hooks here.
+
+import { state } from './state.js';
+import { saveImportedData } from './data.js';
+import { recordTombstone } from './data-merge.js';
+import { BODY_REGIONS } from './sun-body-silhouette.js';
+import {
+  EXPOSURE_PRESETS,
+  POSTURE_MULTIPLIERS,
+  SURFACE_ALBEDO,
+  _normalizePSMTier,
+  photosensitiveMedScale,
+} from './sun-session-model.js';
+
+const storeDeps = {
+  commitCurrentSlice: () => {},
+  setLiveState: () => {},
+  clearLiveState: () => {},
+  formatElapsed: (ms) => `${Math.max(0, Math.floor((ms || 0) / 60000))}m`,
+};
+
+export function configureSunSessionsStore(deps = {}) {
+  Object.assign(storeDeps, deps);
+}
+
+export function getSessions() {
+  if (!state.importedData) return [];
+  if (!Array.isArray(state.importedData.sunSessions)) state.importedData.sunSessions = [];
+  // Strip runtime-only ticker fields that earlier dev builds may have
+  // accidentally persisted onto session objects. One-time cleanup on
+  // first read; no-op on records written after the fix.
+  for (const sess of state.importedData.sunSessions) {
+    if (sess && (sess._activeRate || sess._activeRatePending || sess._fractionOfMED)) {
+      delete sess._activeRate;
+      delete sess._activeRatePending;
+      delete sess._fractionOfMED;
+    }
+  }
+  return state.importedData.sunSessions;
+}
+
+export function getActiveSession() {
+  return getSessions().find(s => !s.endedAt) || null;
+}
+
+// Start a session — minimal entry with sensible defaults. Returns id.
+// Accepts either an `exposurePreset` (legacy 4-preset coarse buckets) or a
+// `regions` array (anatomical-region picker output). Regions take priority
+// when both are supplied — fraction is computed by summing region fractions.
+export async function startSession({ exposurePreset = 'face_hands', regions, eyeMode = 'direct', lensTint = 'clear', glassBetween = false, location, posture = 'standing', surfaceAlbedo = 'grass', rotatedSides = false } = {}) {
+  const id = `sun_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+
+  let preset, fraction, regionsArr;
+  // If the caller explicitly supplied a regions array, honor it strictly.
+  // An empty array means "the user picked nothing" — silently substituting
+  // a face_hands preset would record a phantom exposure.
+  if (Array.isArray(regions)) {
+    if (regions.length === 0) throw new Error('startSession: regions array was empty — pick at least one region or pass exposurePreset instead');
+    regionsArr = regions;
+    fraction = regions.reduce((sum, key) => {
+      const r = BODY_REGIONS.find(b => b.key === key);
+      return sum + (r?.fraction || 0);
+    }, 0);
+    fraction = Math.max(0.05, fraction);
+    preset = { key: 'detailed' };
+  } else {
+    preset = EXPOSURE_PRESETS.find(p => p.key === exposurePreset) || EXPOSURE_PRESETS[0];
+    fraction = preset.fraction;
+    regionsArr = [];
+  }
+
+  const session = {
+    id,
+    startedAt: Date.now(),
+    endedAt: null,
+    location: location || null,
+    // rotatedSides=true means the user flipped front↔back during the
+    // session (or alternated). Doubles the effective body fraction in the
+    // vit-D IU calc to match dminder's "100% naked = both sides over the
+    // session" convention. Set at session start, OR mid-session via the
+    // 🔄 Flip button (calls flipSidesMidSession).
+    bodyExposure: { preset: preset.key, fraction, regions: regionsArr, sunscreenSPF: null, glassBetween, rotatedSides: !!rotatedSides },
+    eyeExposure: { mode: eyeMode, lensTint, durationSec: null }, // durationSec assigned at stop
+    posture,                  // body orientation multiplier — see POSTURE_MULTIPLIERS
+    surfaceAlbedo,            // ground reflectance multiplier — see SURFACE_ALBEDO
+    atmosphere: null, // populated at stop or fetched async
+    doses: null,
+    safety: null,
+  };
+  getSessions().push(session);
+  await saveImportedData();
+  return id;
+}
+
+// Stop an in-progress session and (optionally) compute doses.
+export async function stopSession(id) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess) return null;
+  sess.endedAt = Date.now();
+  const durationMin = Math.max(0, (sess.endedAt - sess.startedAt) / 60000);
+  sess.durationMin = durationMin;
+  if (sess.eyeExposure && sess.eyeExposure.durationSec == null) {
+    sess.eyeExposure.durationSec = Math.round(durationMin * 60);
+  }
+  storeDeps.clearLiveState(id);
+  // Freeze every live-elapsed element for this session immediately so the
+  // dashboard CTA / cards visibly stop ticking even before surfaces re-render
+  // (network-stalled awaits, backgrounded tab, sync-driven stops from another
+  // device — all paths converge here).
+  if (typeof document !== 'undefined') {
+    document.querySelectorAll(`[data-live-elapsed-for="${CSS.escape(id)}"]`).forEach(el => {
+      el.removeAttribute('data-live-elapsed-for');
+      el.textContent = storeDeps.formatElapsed(sess.endedAt - sess.startedAt);
+    });
+  }
+  await saveImportedData();
+  if (typeof window !== 'undefined' && window.maybeAnalyzeSessionAfterFinish) {
+    try { window.maybeAnalyzeSessionAfterFinish(sess); } catch (_) {}
+  }
+  return sess;
+}
+
+// Log a completed session in one shot (after-the-fact entry).
+export async function logCompletedSession(payload) {
+  const id = `sun_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+  const session = Object.assign({
+    id,
+    startedAt: payload.startedAt || Date.now(),
+    endedAt: payload.endedAt || Date.now(),
+    location: payload.location || null,
+    bodyExposure: payload.bodyExposure || { preset: 'face_hands', fraction: 0.05, regions: [], sunscreenSPF: null, glassBetween: false, rotatedSides: false },
+    eyeExposure: payload.eyeExposure || { mode: 'indoor', lensTint: 'clear', durationSec: 0 },
+    atmosphere: payload.atmosphere || null,
+    doses: payload.doses || null,
+    safety: payload.safety || null,
+    notes: payload.notes || '',
+  }, payload);
+  if (!session.durationMin) session.durationMin = Math.max(0, (session.endedAt - session.startedAt) / 60000);
+  getSessions().push(session);
+  await saveImportedData();
+  if (typeof window !== 'undefined' && window.maybeAnalyzeSessionAfterFinish) {
+    try { window.maybeAnalyzeSessionAfterFinish(session); } catch (_) {}
+  }
+  return id;
+}
+
+export async function deleteSession(id) {
+  const sessions = getSessions();
+  const idx = sessions.findIndex(s => s.id === id);
+  if (idx < 0) return false;
+  recordTombstone(state.importedData, 'sunSessions', id);
+  sessions.splice(idx, 1);
+  storeDeps.clearLiveState(id);
+  await saveImportedData();
+  return true;
+}
+
+// Pause an active session. Commits the current rate slice to
+// committedDoses (so accumulated dose is preserved), then marks the
+// session paused so future ticks contribute zero. Active ticker
+// continues for elapsed display + UI state but stops accruing dose.
+// Idempotent — calling on an already-paused session is a no-op.
+export async function pauseSession(id) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess || sess.endedAt) return null;
+  if (sess.paused) return sess;
+  // Commit current slice with the currently-cached rate so the user-
+  // visible cumulative dose persists across the pause boundary.
+  storeDeps.commitCurrentSlice(sess);
+  sess.paused = true;
+  sess.pausedAt = Date.now();
+  // Clear rate so resume forces a fresh snapshot with current atm.
+  storeDeps.setLiveState(id, { ratePerMin: null });
+  await saveImportedData();
+  return sess;
+}
+
+// Resume a paused session — clears paused flag and the ticker re-snapshots
+// with current atmosphere on the next pass. New slice begins from now.
+export async function resumeSession(id) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess || sess.endedAt || !sess.paused) return null;
+  sess.paused = false;
+  delete sess.pausedAt;
+  await saveImportedData();
+  return sess;
+}
+
+// Edit fields on a saved session. Bumps `updatedAt` so the cross-device
+// merge (data-merge.js pickTimestamp) picks this version on conflict —
+// without that, a careless re-end on a second device would silently
+// stick because endedAt-based timestamps favored the later end. With
+// updatedAt set, an edit anywhere becomes the canonical version.
+//
+// When the patch changes session duration (durationMin or endedAt),
+// re-derive doses + safety via hydrateSession so the per-channel
+// breakdown reflects the new duration. Doses are downstream of duration,
+// so leaving them stale would silently misrepresent the session.
+export async function updateSession(id, patch) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess) return null;
+  // Apply allowed fields. Whitelist keeps a careless caller from blowing
+  // away the immutable id / startedAt or injecting fields the dose
+  // engine would choke on.
+  const ALLOWED = ['durationMin', 'endedAt', 'notes'];
+  let durationChanged = false;
+  for (const k of Object.keys(patch)) {
+    if (!ALLOWED.includes(k)) continue;
+    if (k === 'durationMin' || k === 'endedAt') durationChanged = true;
+    sess[k] = patch[k];
+  }
+  // Keep durationMin and endedAt consistent — the consumer of either
+  // shouldn't have to compute the other. If only one was patched, derive
+  // the other from startedAt.
+  if (patch.durationMin != null && patch.endedAt == null) {
+    sess.endedAt = sess.startedAt + patch.durationMin * 60000;
+  } else if (patch.endedAt != null && patch.durationMin == null) {
+    sess.durationMin = Math.max(0, (sess.endedAt - sess.startedAt) / 60000);
+  }
+  // Eye-exposure duration mirrors session duration when not explicitly
+  // shorter (eye open the whole time vs eyes closed for some interval).
+  if (durationChanged && sess.eyeExposure && sess.eyeExposure.durationSec != null) {
+    sess.eyeExposure.durationSec = Math.round(sess.durationMin * 60);
+  }
+  sess.updatedAt = Date.now();
+  await saveImportedData();
+  // Re-hydrate doses asynchronously. Per-session in-flight promise serializes
+  // concurrent edits — without it, two quick updateSession calls can race two
+  // fetchAtmosphere awaits and write doses for the older duration after the
+  // newer one shipped (the relay briefly holds stale doses).
+  if (durationChanged && sess.location) {
+    const prev = _hydrateInFlight.get(id) || Promise.resolve();
+    const next = prev
+      .catch(() => {})
+      .then(() => hydrateSession(id, { lat: sess.location.lat, lon: sess.location.lon }))
+      .catch(e => { if (typeof window !== 'undefined' && window.console) console.warn('hydrateSession after updateSession failed', e); });
+    _hydrateInFlight.set(id, next);
+    next.finally(() => { if (_hydrateInFlight.get(id) === next) _hydrateInFlight.delete(id); });
+  }
+  return sess;
+}
+
+// Per-session hydrate serialization queue. Map<sessionId, Promise>.
+const _hydrateInFlight = new Map();
+
+// Hydrate a session record with computed atmosphere + channel doses.
+// Idempotent — reruns after edits.
+// Bump this whenever the dose/safety math changes incompatibly so
+// `rehydrateStaleSessions` knows to re-run hydrate on existing sessions
+// computed under the old engine. Versions:
+//   1: original v1.7.0 ship
+//   2: 2026-05-02 fix — Bird-Riordan Rayleigh formula was inverted,
+//      collapsing UVB irradiance to ~1e-8 W/m²/nm.
+//   3: 2026-05-02 second fix — proper Bass-Paur ozone cross-sections
+//      (was ~3× too transmissive in UVB), added diffuse scatter term
+//      (was ~50% under in UVB / 30% under in UVA), corrected aerosol
+//      baseline to clean-sky default β=0.10 (was 0.27 / polluted),
+//      added cosZ to direct-beam horizontal flux. Implied UVI at
+//      zenith=30° now matches real-world (7.4 vs 7-8 reference);
+//      vit D synthesis at low sun naturally falls to ~zero per
+//      Bird-Riordan + JPL 19-5 cross-sections without the hand-tuned
+//      threshold gate carrying the load alone.
+//   4: 2026-05-03 — added posture multiplier (lying-supine ×1.4 etc),
+//      surface albedo reception multiplier (sand/water/snow), AOD-driven
+//      Bird-Riordan β when atm provides aerosol_optical_depth, and
+//      switched retinalUVdose from unweighted UV (280-400 sum) to
+//      actinic-weighted (CIE erythemal) — old sessions had retinalUV
+//      stored at 30-100× the correct ICNIRP-comparable value.
+//   5: 2026-05-03 — fix Open-Meteo past_days=0 bug. Forecast endpoint
+//      was queried with `forecast_days=1` and no `past_days`, so any
+//      session hydrated for a midpoint outside today (yesterday or
+//      earlier) snapped to today's 00:00 hour → atmosphere UVI 0 and
+//      the vit-D channel read "below UVI threshold" for sessions that
+//      were actually fine. URL now requests past_days=2; existing
+//      sessions stamped at v4 re-hydrate to pick up correct atm.
+//   6: 2026-05-05 — fix shapeOpenMeteoResponse anchoring `todayPrefix`
+//      on Date.now() instead of the session midpoint. Real-time logs
+//      worked, but retro-logged + pre-dawn sessions pinned daily.peakAt
+//      and the peak-finder scan to the wrong day in `past_days=2`. Some
+//      v5 sessions also persisted a single-day hourly array (24 entries
+//      instead of 72) when Open-Meteo returned just today's slice; bump
+//      forces rehydrate so those replay against the corrected anchor.
+//   7: 2026-05-05 — widen past_days from 2 to 7 in the Open-Meteo URL
+//      so retro-logged sessions up to a week old hydrate against the
+//      actual session day rather than snapping to today's 00:00 hour.
+//      Bump forces v6 sessions older than 2d to replay against the
+//      wider window.
+export const SUN_ENGINE_VERSION = 7;
+
+// Override the fetched atmosphere with user-set values (manual UVI, manual
+// cloud cover, manual ozone) when present in sunDefaults. Set null to clear.
+// Lets advanced users dial in a meter reading or stress-test scenarios.
+export function _applyAtmOverrides(atm) {
+  if (!atm) return atm;
+  const ov = state.importedData?.sunDefaults?.overrides;
+  if (!ov) return atm;
+  const out = { ...atm };
+  if (Number.isFinite(ov.uvIndex)) { out.uvIndex = ov.uvIndex; out._uvOverridden = true; }
+  if (Number.isFinite(ov.cloudCover)) { out.cloudCover = ov.cloudCover; out._cloudOverridden = true; }
+  if (Number.isFinite(ov.ozoneDU)) { out.ozoneDU = ov.ozoneDU; out._ozoneOverridden = true; }
+  return out;
+}
+
+export async function hydrateSession(id, { lat, lon } = {}) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess || !sess.endedAt) return null;
+  // Lazy-load engine modules — they are loaded by main.js at boot, so
+  // window.* references will resolve. Kept dynamic to avoid hard import
+  // in modules that may run before main.js wires window.
+  const fetchAtmosphere = window.fetchAtmosphere;
+  const reconstructSpectrum = window.reconstructSpectrum;
+  const computeChannelDoses = window.computeChannelDoses;
+  const erythemalSED = window.erythemalSED;
+  const fractionOfMED = window.fractionOfMED;
+  const retinalUVdose = window.retinalUVdose;
+  const solarZenithAngle = window.solarZenithAngle;
+  if (!fetchAtmosphere || !reconstructSpectrum) return null;
+  const useLat = lat ?? sess.location?.lat;
+  const useLon = lon ?? sess.location?.lon;
+  if (useLat == null || useLon == null) return null;
+  const midpoint = new Date((sess.startedAt + sess.endedAt) / 2).toISOString();
+  const altitudeM = sess.location?.altitudeM ?? 0;
+  try {
+    let atm = await fetchAtmosphere({ lat: useLat, lon: useLon, isoTime: midpoint });
+    if (!atm) {
+      if (window.console) console.warn('hydrateSession: atmosphere fetch returned null for', id);
+      return null;
+    }
+    atm = _applyAtmOverrides(atm);
+    // Strip private flags before persisting — _uvOverridden/_cloudOverridden/_ozoneOverridden
+    // are presentation-layer markers, not session data; persisting them
+    // wastes bytes in localStorage/CRDT and surfaces in exports.
+    const { _uvOverridden, _cloudOverridden, _ozoneOverridden, ...persistedAtm } = atm;
+    sess.atmosphere = persistedAtm;
+    const zenith = solarZenithAngle(new Date(midpoint), useLat, useLon);
+    const spectrum = reconstructSpectrum({
+      zenithDeg: zenith,
+      ozoneDU: atm.ozoneDU ?? 300,
+      altitudeM,
+      cloudCover: (atm.cloudCover ?? 0) / 100,
+      aod: atm?.airQuality?.aod ?? null,
+    });
+    const bodyModifiers = {
+      glassBetween: !!sess.bodyExposure?.glassBetween,
+      sunscreenSPF: sess.bodyExposure?.sunscreenSPF || 0,
+    };
+    // Apply posture + surface-albedo multipliers to body fraction so
+    // hydrated doses match the live engine's accounting.
+    const baseFraction = sess.bodyExposure?.fraction ?? 0;
+    const postureMult = POSTURE_MULTIPLIERS[sess.posture] ?? 1.0;
+    const albedoMult = 1 + (SURFACE_ALBEDO[sess.surfaceAlbedo] ?? 0) * 0.5;
+    const effFraction = baseFraction * postureMult * albedoMult;
+    sess.doses = computeChannelDoses({
+      spectrum,
+      durationMin: sess.durationMin,
+      bodyExposureFraction: effFraction,
+      eyeExposure: sess.eyeExposure,
+      bodyModifiers,
+    });
+    const sed = erythemalSED({
+      spectrum,
+      durationMin: sess.durationMin,
+      bodyExposureFraction: effFraction,
+      bodyModifiers,
+    });
+    // Read from one of two places, in priority order:
+    //   1. sunDefaults.fitzpatrick (Light setup card)
+    //   2. lightCircadian.skinType (Light & Circadian context card)
+    // Falls back to 'III' (median) if none.
+    const lcSkin = state.importedData?.lightCircadian?.skinType;
+    const lcRoman = lcSkin && (window._skinTypeToFitzpatrick ? window._skinTypeToFitzpatrick(lcSkin) : (lcSkin.match(/^(I{1,3}|IV|VI?)\b/) || [])[1]);
+    const fitzpatrick = state.importedData?.sunDefaults?.fitzpatrick || lcRoman || 'III';
+    const psmTier = _normalizePSMTier(state.importedData?.sunDefaults?.photosensitiveMeds);
+    const medScale = photosensitiveMedScale(psmTier);
+    sess.safety = {
+      sed,
+      medFraction: fractionOfMED({ sed, fitzpatrick, medScale }),
+      retinalUV: retinalUVdose({ spectrum, eyeExposure: sess.eyeExposure, zenithDeg: zenith }),
+      fitzpatrick,
+      photosensitiveMedTier: psmTier,
+      // Legacy boolean kept for backward compat with consumers that
+      // haven't migrated to the tier field yet.
+      photosensitive: medScale < 1.0,
+    };
+    // Stamp the engine version so rehydrateStaleSessions can detect
+    // sessions computed under older (buggy) versions and recompute.
+    sess.engineVersion = SUN_ENGINE_VERSION;
+    await saveImportedData();
+    return sess;
+  } catch (e) {
+    if (window.console && console.warn) console.warn('hydrateSession failed', e);
+    return null;
+  }
+}
+
+// Self-healing on load: walk the saved sessions, re-hydrate any whose
+// stamped engineVersion is older than the current SUN_ENGINE_VERSION.
+// Cheap (one network call per stale session, debounced; all-fresh
+// sessions just iterate the array). Lazy: caller invokes from main.js
+// after the engine module is loaded. Skips active sessions and ones
+// without a location (atmosphere fetch needs coords).
+//
+// Idempotent: subsequent calls find no stale sessions and bail in O(N).
+//
+// Memory note for future engine-version bumps — anything that changes
+// the computed values incompatibly (Rayleigh formula, channel action
+// spectra, MED thresholds, fitzpatrick mapping) should bump the
+// constant so users on the old data get a fresh recompute on reload.
+// Pre-2026-05-08: gated by a global `_rehydrateInFlight` boolean which
+// rejected the second caller outright. Now relies on per-session
+// `_hydrateInFlight` (declared above near hydrateSession) so two
+// batches arriving concurrently (e.g., dashboard + light page on cold
+// load) share work — each id rehydrates at most once but both callers
+// get the promise back.
+export async function rehydrateStaleSessions() {
+  const sessions = getSessions();
+  const stale = sessions.filter(s =>
+    s.endedAt &&
+    s.location?.lat != null &&
+    (s.engineVersion ?? 0) < SUN_ENGINE_VERSION
+  );
+  if (stale.length === 0) return { rehydrated: 0 };
+  // Serialize so we don't fan out N concurrent atmosphere fetches.
+  // hydrateSession itself dedups by id, so two batches in parallel
+  // don't double-fetch the same session.
+  let ok = 0;
+  for (const s of stale) {
+    try {
+      const result = await hydrateSession(s.id, { lat: s.location.lat, lon: s.location.lon });
+      if (result) ok++;
+    } catch (e) {
+      if (window.console && console.warn) console.warn('rehydrateStaleSessions:', s.id, e?.message || e);
+    }
+  }
+  return { rehydrated: ok, ofTotal: stale.length };
+}
+
+export function resetSunSessionsStoreState() {
+  _hydrateInFlight.clear();
+}

--- a/js/sun.js
+++ b/js/sun.js
@@ -14,7 +14,6 @@ import { escapeHTML, escapeAttr, showNotification, showPromptDialog, showConfirm
 import { saveImportedData } from './data.js';
 import { getProfileLocation } from './profile.js';
 import { COUNTRY_LATITUDES, COUNTRY_CENTROIDS } from './constants.js';
-import { recordTombstone } from './data-merge.js';
 import {
   BODY_REGIONS,
   renderBodySilhouette,
@@ -41,9 +40,31 @@ import {
   resumeActiveTickerIfNeeded as _resumeActiveTickerIfNeeded,
   hydrateSunSessionFromProfileCoords as _hydrateFromProfileCoords,
   resetSunActiveSessionState,
-  POSTURE_MULTIPLIERS,
-  SURFACE_ALBEDO,
 } from './sun-active-session.js';
+import {
+  photosensitiveMedScale,
+  _normalizePSMTier,
+  EXPOSURE_PRESETS,
+  POSTURE_OPTIONS,
+  SURFACE_OPTIONS,
+} from './sun-session-model.js';
+import {
+  configureSunSessionsStore,
+  SUN_ENGINE_VERSION,
+  getSessions,
+  getActiveSession,
+  startSession,
+  stopSession,
+  logCompletedSession,
+  deleteSession,
+  pauseSession,
+  resumeSession,
+  updateSession,
+  hydrateSession,
+  rehydrateStaleSessions,
+  _applyAtmOverrides,
+  resetSunSessionsStoreState,
+} from './sun-sessions-store.js';
 import {
   configureSunSessionUI,
   renderSessionsList,
@@ -56,6 +77,29 @@ import {
 export { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette };
 export { renderSessionsList, renderSunSessionRow, openDetailedSessionDialog, openSunSessionDetail };
 export { quickLogSunSession, openStartSunSessionDialog, _wireBackdropClose, trapModalFocus };
+export {
+  PHOTOSENSITIVE_MED_TIERS,
+  photosensitiveMedScale,
+  _normalizePSMTier,
+  EXPOSURE_PRESETS,
+  POSTURE_OPTIONS,
+  SURFACE_OPTIONS,
+} from './sun-session-model.js';
+export {
+  SUN_ENGINE_VERSION,
+  getSessions,
+  getActiveSession,
+  startSession,
+  stopSession,
+  logCompletedSession,
+  deleteSession,
+  pauseSession,
+  resumeSession,
+  updateSession,
+  hydrateSession,
+  rehydrateStaleSessions,
+  _applyAtmOverrides,
+} from './sun-sessions-store.js';
 // NOTE: sun-ai-analysis.js is intentionally NOT imported here — it
 // imports from this file (getSessions, formatChannelUnit, etc.), and a
 // reciprocal import would create a circular dependency that risks TDZ
@@ -64,58 +108,6 @@ export { quickLogSunSession, openStartSunSessionDialog, _wireBackdropClose, trap
 // follows the same pattern for consistency + cycle-safety. main.js
 // imports both modules in a deterministic order so the window functions
 // are available by the time sun.js's exports are first invoked.
-
-// ─── Photosensitive medication tiers ───────────────────────────────────
-// Photosensitizing medication scale tiers — used by fractionOfMED() in
-// place of the legacy boolean flag. MED multipliers from AAD/Mayo Clinic
-// guidance: severe drugs (tetracyclines, retinoids systemic, amiodarone)
-// shift erythemal threshold ~4×; moderate (NSAIDs, thiazides, sulfa) ~2.5×;
-// mild (some antihistamines) ~1.5×.
-export const PHOTOSENSITIVE_MED_TIERS = [
-  { key: 'none',     label: 'None',      medScale: 1.0,  examples: '' },
-  { key: 'mild',     label: 'Mild',      medScale: 0.7,  examples: 'antihistamines (most), some NSAIDs' },
-  { key: 'moderate', label: 'Moderate',  medScale: 0.4,  examples: 'NSAIDs, thiazide diuretics, sulfa antibiotics, St. John\'s Wort, topical retinol' },
-  { key: 'severe',   label: 'Severe',    medScale: 0.25, examples: 'tetracyclines (doxycycline), oral retinoids (isotretinoin), amiodarone, citrus essential oils on skin' },
-];
-
-// Map tier key to multiplier; default to none (no scaling) on unknown.
-export function photosensitiveMedScale(tier) {
-  const t = PHOTOSENSITIVE_MED_TIERS.find(x => x.key === tier);
-  return t ? t.medScale : 1.0;
-}
-
-// Normalize legacy boolean photosensitiveMeds storage into a tier key.
-// boolean true → 'moderate' (the previous fixed-0.4 multiplier semantically
-// matches moderate); boolean false / null / undefined → 'none'.
-export function _normalizePSMTier(raw) {
-  if (raw === true) return 'moderate';
-  if (raw === false || raw == null) return 'none';
-  if (typeof raw === 'string' && PHOTOSENSITIVE_MED_TIERS.some(t => t.key === raw)) return raw;
-  return 'none';
-}
-
-// Standard quick-presets for the speed log. Fractions reflect a SINGLE
-// position (front-only OR back-only at any one moment) — capped at the
-// anatomical max of ~0.55. Use the in-session "🔄 Flip" button (or the
-// `rotatedSides` toggle in the start dialog) to log that you exposed
-// both sides over the session; that doubles the effective body dose
-// the same way dminder's "100% naked" assumes alternating sides.
-//
-// Cite: fractions derive from the Wallace rule of nines + Lund-Browder
-// (1944) chart, then halved (anterior face only). Face + hands ≈ 4.5%
-// face + 2.5% hands = 7% total body, ~5% projected to one side.
-// T-shirt + shorts exposes face/hands/forearms/lower legs ≈ 20%.
-// Swimwear exposes everything except briefs (~45% one side per Holick
-// 2007's "10% body surface = ~2 cm² per kg of pre-vit-D substrate").
-// Sunbathing tops out at ~50% one side per the dminder convention.
-// AI verdict math for synthesis ("you got 1500 IU because 20% of your
-// skin saw 15 min of UVI 7") is rooted in these fractions.
-export const EXPOSURE_PRESETS = [
-  { key: 'face_hands', label: 'Face + hands',         fraction: 0.05 },
-  { key: 'tshirt',     label: 'T-shirt + shorts',     fraction: 0.20 },
-  { key: 'swimwear',   label: 'Swimwear',             fraction: 0.45 },
-  { key: 'sunbathing', label: 'Sunbathing',           fraction: 0.50 },
-];
 
 // `label` is the row-meta display; `pickerLabel` is what the dropdown
 // option shows (where the safety nudge belongs). Earlier the row-meta
@@ -304,189 +296,7 @@ export function formatChannelUnit(channelKey, channelAu, durationMin, fitzpatric
 }
 export function tierDots(tier) { return TIER_DOTS[tier] || TIER_DOTS[0]; }
 
-// ─── Public API ────────────────────────────────────────────────────────
-
-export function getSessions() {
-  if (!state.importedData) return [];
-  if (!Array.isArray(state.importedData.sunSessions)) state.importedData.sunSessions = [];
-  // Strip runtime-only ticker fields that earlier dev builds may have
-  // accidentally persisted onto session objects. One-time cleanup on
-  // first read; no-op on records written after the fix.
-  for (const sess of state.importedData.sunSessions) {
-    if (sess && (sess._activeRate || sess._activeRatePending || sess._fractionOfMED)) {
-      delete sess._activeRate;
-      delete sess._activeRatePending;
-      delete sess._fractionOfMED;
-    }
-  }
-  return state.importedData.sunSessions;
-}
-
-export function getActiveSession() {
-  return getSessions().find(s => !s.endedAt) || null;
-}
-
-// Posture options surfaced in pickers + applied as a multiplier on the
-// effective body fraction (see POSTURE_MULTIPLIERS in sun-active-session.js).
-export const POSTURE_OPTIONS = [
-  { key: 'standing',     label: 'Standing / walking' },
-  { key: 'sitting',      label: 'Sitting / reclined' },
-  { key: 'lying-supine', label: 'Lying face-up' },
-  { key: 'lying-prone',  label: 'Lying face-down' },
-];
-
-// Surface albedo dropdown values — UV reflection from below augments
-// total received irradiance by ~(albedo × 0.5). See SURFACE_ALBEDO.
-export const SURFACE_OPTIONS = [
-  { key: 'grass',    label: 'Grass / dirt (~3% reflect)' },
-  { key: 'concrete', label: 'Concrete / pavement (~10%)' },
-  { key: 'sand',     label: 'Sand (~25%)' },
-  { key: 'water',    label: 'Water / pool (~25%)' },
-  { key: 'snow',     label: 'Snow / ice (~80%)' },
-];
-
-// Start a session — minimal entry with sensible defaults. Returns id.
-// Accepts either an `exposurePreset` (legacy 4-preset coarse buckets) or a
-// `regions` array (anatomical-region picker output). Regions take priority
-// when both are supplied — fraction is computed by summing region fractions.
-export async function startSession({ exposurePreset = 'face_hands', regions, eyeMode = 'direct', lensTint = 'clear', glassBetween = false, location, posture = 'standing', surfaceAlbedo = 'grass', rotatedSides = false } = {}) {
-  const id = `sun_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
-
-  let preset, fraction, regionsArr;
-  // If the caller explicitly supplied a regions array, honor it strictly.
-  // An empty array means "the user picked nothing" — silently substituting
-  // a face_hands preset would record a phantom exposure.
-  if (Array.isArray(regions)) {
-    if (regions.length === 0) throw new Error('startSession: regions array was empty — pick at least one region or pass exposurePreset instead');
-    regionsArr = regions;
-    fraction = regions.reduce((sum, key) => {
-      const r = BODY_REGIONS.find(b => b.key === key);
-      return sum + (r?.fraction || 0);
-    }, 0);
-    fraction = Math.max(0.05, fraction);
-    preset = { key: 'detailed' };
-  } else {
-    preset = EXPOSURE_PRESETS.find(p => p.key === exposurePreset) || EXPOSURE_PRESETS[0];
-    fraction = preset.fraction;
-    regionsArr = [];
-  }
-
-  const session = {
-    id,
-    startedAt: Date.now(),
-    endedAt: null,
-    location: location || null,
-    // rotatedSides=true means the user flipped front↔back during the
-    // session (or alternated). Doubles the effective body fraction in the
-    // vit-D IU calc to match dminder's "100% naked = both sides over the
-    // session" convention. Set at session start, OR mid-session via the
-    // 🔄 Flip button (calls flipSidesMidSession).
-    bodyExposure: { preset: preset.key, fraction, regions: regionsArr, sunscreenSPF: null, glassBetween, rotatedSides: !!rotatedSides },
-    eyeExposure: { mode: eyeMode, lensTint, durationSec: null }, // durationSec assigned at stop
-    posture,                  // body orientation multiplier — see POSTURE_MULTIPLIERS
-    surfaceAlbedo,            // ground reflectance multiplier — see SURFACE_ALBEDO
-    atmosphere: null, // populated at stop or fetched async
-    doses: null,
-    safety: null,
-  };
-  getSessions().push(session);
-  await saveImportedData();
-  return id;
-}
-
-// Stop an in-progress session and (optionally) compute doses.
-export async function stopSession(id) {
-  const sess = getSessions().find(s => s.id === id);
-  if (!sess) return null;
-  sess.endedAt = Date.now();
-  const durationMin = Math.max(0, (sess.endedAt - sess.startedAt) / 60000);
-  sess.durationMin = durationMin;
-  if (sess.eyeExposure && sess.eyeExposure.durationSec == null) {
-    sess.eyeExposure.durationSec = Math.round(durationMin * 60);
-  }
-  _clearLiveState(id);
-  // Freeze every live-elapsed element for this session immediately so the
-  // dashboard CTA / cards visibly stop ticking even before _refreshSurfaces
-  // re-renders (network-stalled awaits, backgrounded tab, sync-driven stops
-  // from another device — all paths converge here).
-  if (typeof document !== 'undefined') {
-    document.querySelectorAll(`[data-live-elapsed-for="${CSS.escape(id)}"]`).forEach(el => {
-      el.removeAttribute('data-live-elapsed-for');
-      el.textContent = _formatElapsed(sess.endedAt - sess.startedAt);
-    });
-  }
-  await saveImportedData();
-  if (typeof window !== 'undefined' && window.maybeAnalyzeSessionAfterFinish) {
-    try { window.maybeAnalyzeSessionAfterFinish(sess); } catch (_) {}
-  }
-  return sess;
-}
-
-// Log a completed session in one shot (after-the-fact entry).
-export async function logCompletedSession(payload) {
-  const id = `sun_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
-  const session = Object.assign({
-    id,
-    startedAt: payload.startedAt || Date.now(),
-    endedAt: payload.endedAt || Date.now(),
-    location: payload.location || null,
-    bodyExposure: payload.bodyExposure || { preset: 'face_hands', fraction: 0.05, regions: [], sunscreenSPF: null, glassBetween: false, rotatedSides: false },
-    eyeExposure: payload.eyeExposure || { mode: 'indoor', lensTint: 'clear', durationSec: 0 },
-    atmosphere: payload.atmosphere || null,
-    doses: payload.doses || null,
-    safety: payload.safety || null,
-    notes: payload.notes || '',
-  }, payload);
-  if (!session.durationMin) session.durationMin = Math.max(0, (session.endedAt - session.startedAt) / 60000);
-  getSessions().push(session);
-  await saveImportedData();
-  if (typeof window !== 'undefined' && window.maybeAnalyzeSessionAfterFinish) {
-    try { window.maybeAnalyzeSessionAfterFinish(session); } catch (_) {}
-  }
-  return id;
-}
-
-export async function deleteSession(id) {
-  const sessions = getSessions();
-  const idx = sessions.findIndex(s => s.id === id);
-  if (idx < 0) return false;
-  recordTombstone(state.importedData, 'sunSessions', id);
-  sessions.splice(idx, 1);
-  _clearLiveState(id);
-  await saveImportedData();
-  return true;
-}
-
-// Pause an active session. Commits the current rate slice to
-// committedDoses (so accumulated dose is preserved), then marks the
-// session paused so future ticks contribute zero. Active ticker
-// continues for elapsed display + UI state but stops accruing dose.
-// Idempotent — calling on an already-paused session is a no-op.
-export async function pauseSession(id) {
-  const sess = getSessions().find(s => s.id === id);
-  if (!sess || sess.endedAt) return null;
-  if (sess.paused) return sess;
-  // Commit current slice with the currently-cached rate so the user-
-  // visible cumulative dose persists across the pause boundary.
-  _commitCurrentSlice(sess);
-  sess.paused = true;
-  sess.pausedAt = Date.now();
-  // Clear rate so resume forces a fresh snapshot with current atm.
-  _setLiveState(id, { ratePerMin: null });
-  await saveImportedData();
-  return sess;
-}
-
-// Resume a paused session — clears paused flag and the ticker re-snapshots
-// with current atmosphere on the next pass. New slice begins from now.
-export async function resumeSession(id) {
-  const sess = getSessions().find(s => s.id === id);
-  if (!sess || sess.endedAt || !sess.paused) return null;
-  sess.paused = false;
-  delete sess.pausedAt;
-  await saveImportedData();
-  return sess;
-}
+// ─── Session lifecycle facade helpers ─────────────────────────────────
 
 // User-facing wrappers — called from inline onclick handlers in
 // renderSunSessionRow's active controls. Both call the surface refresh
@@ -693,255 +503,6 @@ export async function _forgotStopPrompt(id) {
     _refreshSurfaces();
     showNotification('Session ended. Open the session detail to adjust the duration if needed.', 'success', 4500);
   }
-}
-
-// Edit fields on a saved session. Bumps `updatedAt` so the cross-device
-// merge (data-merge.js pickTimestamp) picks this version on conflict —
-// without that, a careless re-end on a second device would silently
-// stick because endedAt-based timestamps favored the later end. With
-// updatedAt set, an edit anywhere becomes the canonical version.
-//
-// When the patch changes session duration (durationMin or endedAt),
-// re-derive doses + safety via hydrateSession so the per-channel
-// breakdown reflects the new duration. Doses are downstream of duration,
-// so leaving them stale would silently misrepresent the session.
-export async function updateSession(id, patch) {
-  const sess = getSessions().find(s => s.id === id);
-  if (!sess) return null;
-  // Apply allowed fields. Whitelist keeps a careless caller from blowing
-  // away the immutable id / startedAt or injecting fields the dose
-  // engine would choke on.
-  const ALLOWED = ['durationMin', 'endedAt', 'notes'];
-  let durationChanged = false;
-  for (const k of Object.keys(patch)) {
-    if (!ALLOWED.includes(k)) continue;
-    if (k === 'durationMin' || k === 'endedAt') durationChanged = true;
-    sess[k] = patch[k];
-  }
-  // Keep durationMin and endedAt consistent — the consumer of either
-  // shouldn't have to compute the other. If only one was patched, derive
-  // the other from startedAt.
-  if (patch.durationMin != null && patch.endedAt == null) {
-    sess.endedAt = sess.startedAt + patch.durationMin * 60000;
-  } else if (patch.endedAt != null && patch.durationMin == null) {
-    sess.durationMin = Math.max(0, (sess.endedAt - sess.startedAt) / 60000);
-  }
-  // Eye-exposure duration mirrors session duration when not explicitly
-  // shorter (eye open the whole time vs eyes closed for some interval).
-  if (durationChanged && sess.eyeExposure && sess.eyeExposure.durationSec != null) {
-    sess.eyeExposure.durationSec = Math.round(sess.durationMin * 60);
-  }
-  sess.updatedAt = Date.now();
-  await saveImportedData();
-  // Re-hydrate doses asynchronously. Per-session in-flight promise serializes
-  // concurrent edits — without it, two quick updateSession calls can race two
-  // fetchAtmosphere awaits and write doses for the older duration after the
-  // newer one shipped (the relay briefly holds stale doses).
-  if (durationChanged && sess.location) {
-    const prev = _hydrateInFlight.get(id) || Promise.resolve();
-    const next = prev
-      .catch(() => {})
-      .then(() => hydrateSession(id, { lat: sess.location.lat, lon: sess.location.lon }))
-      .catch(e => { if (window.console) console.warn('hydrateSession after updateSession failed', e); });
-    _hydrateInFlight.set(id, next);
-    next.finally(() => { if (_hydrateInFlight.get(id) === next) _hydrateInFlight.delete(id); });
-  }
-  return sess;
-}
-
-// Per-session hydrate serialization queue. Map<sessionId, Promise>.
-const _hydrateInFlight = new Map();
-
-// Hydrate a session record with computed atmosphere + channel doses.
-// Idempotent — reruns after edits.
-// Bump this whenever the dose/safety math changes incompatibly so
-// `rehydrateStaleSessions` knows to re-run hydrate on existing sessions
-// computed under the old engine. Versions:
-//   1: original v1.7.0 ship
-//   2: 2026-05-02 fix — Bird-Riordan Rayleigh formula was inverted,
-//      collapsing UVB irradiance to ~1e-8 W/m²/nm.
-//   3: 2026-05-02 second fix — proper Bass-Paur ozone cross-sections
-//      (was ~3× too transmissive in UVB), added diffuse scatter term
-//      (was ~50% under in UVB / 30% under in UVA), corrected aerosol
-//      baseline to clean-sky default β=0.10 (was 0.27 / polluted),
-//      added cosZ to direct-beam horizontal flux. Implied UVI at
-//      zenith=30° now matches real-world (7.4 vs 7-8 reference);
-//      vit D synthesis at low sun naturally falls to ~zero per
-//      Bird-Riordan + JPL 19-5 cross-sections without the hand-tuned
-//      threshold gate carrying the load alone.
-//   4: 2026-05-03 — added posture multiplier (lying-supine ×1.4 etc),
-//      surface albedo reception multiplier (sand/water/snow), AOD-driven
-//      Bird-Riordan β when atm provides aerosol_optical_depth, and
-//      switched retinalUVdose from unweighted UV (280-400 sum) to
-//      actinic-weighted (CIE erythemal) — old sessions had retinalUV
-//      stored at 30-100× the correct ICNIRP-comparable value.
-//   5: 2026-05-03 — fix Open-Meteo past_days=0 bug. Forecast endpoint
-//      was queried with `forecast_days=1` and no `past_days`, so any
-//      session hydrated for a midpoint outside today (yesterday or
-//      earlier) snapped to today's 00:00 hour → atmosphere UVI 0 and
-//      the vit-D channel read "below UVI threshold" for sessions that
-//      were actually fine. URL now requests past_days=2; existing
-//      sessions stamped at v4 re-hydrate to pick up correct atm.
-//   6: 2026-05-05 — fix shapeOpenMeteoResponse anchoring `todayPrefix`
-//      on Date.now() instead of the session midpoint. Real-time logs
-//      worked, but retro-logged + pre-dawn sessions pinned daily.peakAt
-//      and the peak-finder scan to the wrong day in `past_days=2`. Some
-//      v5 sessions also persisted a single-day hourly array (24 entries
-//      instead of 72) when Open-Meteo returned just today's slice; bump
-//      forces rehydrate so those replay against the corrected anchor.
-//   7: 2026-05-05 — widen past_days from 2 to 7 in the Open-Meteo URL
-//      so retro-logged sessions up to a week old hydrate against the
-//      actual session day rather than snapping to today's 00:00 hour.
-//      Bump forces v6 sessions older than 2d to replay against the
-//      wider window.
-export const SUN_ENGINE_VERSION = 7;
-
-// Override the fetched atmosphere with user-set values (manual UVI, manual
-// cloud cover, manual ozone) when present in sunDefaults. Set null to clear.
-// Lets advanced users dial in a meter reading or stress-test scenarios.
-export function _applyAtmOverrides(atm) {
-  if (!atm) return atm;
-  const ov = state.importedData?.sunDefaults?.overrides;
-  if (!ov) return atm;
-  const out = { ...atm };
-  if (Number.isFinite(ov.uvIndex)) { out.uvIndex = ov.uvIndex; out._uvOverridden = true; }
-  if (Number.isFinite(ov.cloudCover)) { out.cloudCover = ov.cloudCover; out._cloudOverridden = true; }
-  if (Number.isFinite(ov.ozoneDU)) { out.ozoneDU = ov.ozoneDU; out._ozoneOverridden = true; }
-  return out;
-}
-
-export async function hydrateSession(id, { lat, lon } = {}) {
-  const sess = getSessions().find(s => s.id === id);
-  if (!sess || !sess.endedAt) return null;
-  // Lazy-load engine modules — they are loaded by main.js at boot, so
-  // window.* references will resolve. Kept dynamic to avoid hard import
-  // in modules that may run before main.js wires window.
-  const fetchAtmosphere = window.fetchAtmosphere;
-  const reconstructSpectrum = window.reconstructSpectrum;
-  const computeChannelDoses = window.computeChannelDoses;
-  const erythemalSED = window.erythemalSED;
-  const fractionOfMED = window.fractionOfMED;
-  const retinalUVdose = window.retinalUVdose;
-  const solarZenithAngle = window.solarZenithAngle;
-  if (!fetchAtmosphere || !reconstructSpectrum) return null;
-  const useLat = lat ?? sess.location?.lat;
-  const useLon = lon ?? sess.location?.lon;
-  if (useLat == null || useLon == null) return null;
-  const midpoint = new Date((sess.startedAt + sess.endedAt) / 2).toISOString();
-  const altitudeM = sess.location?.altitudeM ?? 0;
-  try {
-    let atm = await fetchAtmosphere({ lat: useLat, lon: useLon, isoTime: midpoint });
-    if (!atm) {
-      if (window.console) console.warn('hydrateSession: atmosphere fetch returned null for', id);
-      return null;
-    }
-    atm = _applyAtmOverrides(atm);
-    // Strip private flags before persisting — _uvOverridden/_cloudOverridden/_ozoneOverridden
-    // are presentation-layer markers, not session data; persisting them
-    // wastes bytes in localStorage/CRDT and surfaces in exports.
-    const { _uvOverridden, _cloudOverridden, _ozoneOverridden, ...persistedAtm } = atm;
-    sess.atmosphere = persistedAtm;
-    const zenith = solarZenithAngle(new Date(midpoint), useLat, useLon);
-    const spectrum = reconstructSpectrum({
-      zenithDeg: zenith,
-      ozoneDU: atm.ozoneDU ?? 300,
-      altitudeM,
-      cloudCover: (atm.cloudCover ?? 0) / 100,
-      aod: atm?.airQuality?.aod ?? null,
-    });
-    const bodyModifiers = {
-      glassBetween: !!sess.bodyExposure?.glassBetween,
-      sunscreenSPF: sess.bodyExposure?.sunscreenSPF || 0,
-    };
-    // Apply posture + surface-albedo multipliers to body fraction so
-    // hydrated doses match the live engine's accounting.
-    const baseFraction = sess.bodyExposure?.fraction ?? 0;
-    const postureMult = POSTURE_MULTIPLIERS[sess.posture] ?? 1.0;
-    const albedoMult = 1 + (SURFACE_ALBEDO[sess.surfaceAlbedo] ?? 0) * 0.5;
-    const effFraction = baseFraction * postureMult * albedoMult;
-    sess.doses = computeChannelDoses({
-      spectrum,
-      durationMin: sess.durationMin,
-      bodyExposureFraction: effFraction,
-      eyeExposure: sess.eyeExposure,
-      bodyModifiers,
-    });
-    const sed = erythemalSED({
-      spectrum,
-      durationMin: sess.durationMin,
-      bodyExposureFraction: effFraction,
-      bodyModifiers,
-    });
-    // Read from one of two places, in priority order:
-    //   1. sunDefaults.fitzpatrick (Light setup card)
-    //   2. lightCircadian.skinType (Light & Circadian context card)
-    // Falls back to 'III' (median) if none.
-    const lcSkin = state.importedData?.lightCircadian?.skinType;
-    const lcRoman = lcSkin && (window._skinTypeToFitzpatrick ? window._skinTypeToFitzpatrick(lcSkin) : (lcSkin.match(/^(I{1,3}|IV|VI?)\b/) || [])[1]);
-    const fitzpatrick = state.importedData?.sunDefaults?.fitzpatrick || lcRoman || 'III';
-    const psmTier = _normalizePSMTier(state.importedData?.sunDefaults?.photosensitiveMeds);
-    const medScale = photosensitiveMedScale(psmTier);
-    sess.safety = {
-      sed,
-      medFraction: fractionOfMED({ sed, fitzpatrick, medScale }),
-      retinalUV: retinalUVdose({ spectrum, eyeExposure: sess.eyeExposure, zenithDeg: zenith }),
-      fitzpatrick,
-      photosensitiveMedTier: psmTier,
-      // Legacy boolean kept for backward compat with consumers that
-      // haven't migrated to the tier field yet.
-      photosensitive: medScale < 1.0,
-    };
-    // Stamp the engine version so rehydrateStaleSessions can detect
-    // sessions computed under older (buggy) versions and recompute.
-    sess.engineVersion = SUN_ENGINE_VERSION;
-    await saveImportedData();
-    return sess;
-  } catch (e) {
-    if (window.console && console.warn) console.warn('hydrateSession failed', e);
-    return null;
-  }
-}
-
-// Self-healing on load: walk the saved sessions, re-hydrate any whose
-// stamped engineVersion is older than the current SUN_ENGINE_VERSION.
-// Cheap (one network call per stale session, debounced; all-fresh
-// sessions just iterate the array). Lazy: caller invokes from main.js
-// after the engine module is loaded. Skips active sessions and ones
-// without a location (atmosphere fetch needs coords).
-//
-// Idempotent: subsequent calls find no stale sessions and bail in O(N).
-//
-// Memory note for future engine-version bumps — anything that changes
-// the computed values incompatibly (Rayleigh formula, channel action
-// spectra, MED thresholds, fitzpatrick mapping) should bump the
-// constant so users on the old data get a fresh recompute on reload.
-// Pre-2026-05-08: gated by a global `_rehydrateInFlight` boolean which
-// rejected the second caller outright. Now relies on per-session
-// `_hydrateInFlight` (declared above near hydrateSession) so two
-// batches arriving concurrently (e.g., dashboard + light page on cold
-// load) share work — each id rehydrates at most once but both callers
-// get the promise back.
-export async function rehydrateStaleSessions() {
-  const sessions = getSessions();
-  const stale = sessions.filter(s =>
-    s.endedAt &&
-    s.location?.lat != null &&
-    (s.engineVersion ?? 0) < SUN_ENGINE_VERSION
-  );
-  if (stale.length === 0) return { rehydrated: 0 };
-  // Serialize so we don't fan out N concurrent atmosphere fetches.
-  // hydrateSession itself dedups by id, so two batches in parallel
-  // don't double-fetch the same session.
-  let ok = 0;
-  for (const s of stale) {
-    try {
-      const result = await hydrateSession(s.id, { lat: s.location.lat, lon: s.location.lon });
-      if (result) ok++;
-    } catch (e) {
-      if (window.console && console.warn) console.warn('rehydrateStaleSessions:', s.id, e?.message || e);
-    }
-  }
-  return { rehydrated: ok, ofTotal: stale.length };
 }
 
 // ─── Lifelight aggregates ──────────────────────────────────────────────
@@ -1474,6 +1035,13 @@ function _summarizeBodyExposure(sess) {
   return 'Body unset';
 }
 
+configureSunSessionsStore({
+  commitCurrentSlice: _commitCurrentSlice,
+  setLiveState: _setLiveState,
+  clearLiveState: _clearLiveState,
+  formatElapsed: _formatElapsed,
+});
+
 configureSunActiveSession({
   getSessions,
   getActiveSession,
@@ -1524,7 +1092,7 @@ configureSunSessionUI({
 function _resetSunModuleState() {
   resetSunActiveSessionState();
   resetBodySilhouetteState();
-  _hydrateInFlight.clear();
+  resetSunSessionsStoreState();
 }
 
 if (typeof window !== 'undefined') {

--- a/service-worker.js
+++ b/service-worker.js
@@ -297,6 +297,8 @@ const APP_SHELL = [
   // Sun + light modules are statically reachable from the app shell.
   '/js/sun.js',
   '/js/sun-active-session.js',
+  '/js/sun-session-model.js',
+  '/js/sun-sessions-store.js',
   '/js/sun-session-ui.js',
   '/js/sun-body-silhouette.js',
   '/js/sun-ai-analysis.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -148,6 +148,8 @@ const pwaAppShellAssets = [
   '/js/light-tools.js',
   '/js/sun.js',
   '/js/sun-active-session.js',
+  '/js/sun-session-model.js',
+  '/js/sun-sessions-store.js',
   '/js/sun-session-ui.js',
   '/js/sun-spectrum.js',
   '/js/sun-uvdata.js',

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -25,6 +25,7 @@ const {
   SUN_ENGINE_VERSION,
   getSessions, getActiveSession,
   startSession, stopSession, logCompletedSession, deleteSession, pauseSession, resumeSession, updateSession,
+  rehydrateStaleSessions,
   rollingChannelTotals, dailyChannelBreakdown, rollingVitaminDIU,
   cumulativeMEDToday, cumulativeMEDYesterday,
   _applyAtmOverrides,
@@ -388,8 +389,62 @@ const {
   assert('SUN_ENGINE_VERSION is a positive integer (current = 3)',
     Number.isInteger(SUN_ENGINE_VERSION) && SUN_ENGINE_VERSION >= 3);
 
-  // ─── 12. Source split guardrails ─────────────────────────────────────
-  console.log('%c 12. Sun session module boundaries ', 'font-weight:bold;color:#f59e0b');
+  // ─── 12. rehydrateStaleSessions dedupe ──────────────────────────────
+  console.log('%c 12. rehydrateStaleSessions dedupe ', 'font-weight:bold;color:#f59e0b');
+
+  reset();
+  const engineFns = [
+    'fetchAtmosphere',
+    'reconstructSpectrum',
+    'computeChannelDoses',
+    'erythemalSED',
+    'fractionOfMED',
+    'retinalUVdose',
+    'solarZenithAngle',
+  ];
+  const origEngineFns = Object.fromEntries(engineFns.map(k => [k, window[k]]));
+  let fetchCalls = 0;
+  let releaseFetch;
+  const fetchGate = new Promise(resolve => { releaseFetch = resolve; });
+  window.fetchAtmosphere = async () => {
+    fetchCalls++;
+    await fetchGate;
+    return { uvIndex: 6, ozoneDU: 300, cloudCover: 10, airQuality: { aod: 0.1 } };
+  };
+  window.reconstructSpectrum = () => ({ wavelengths: [300, 305], irradiance: [1, 1] });
+  window.computeChannelDoses = () => ({ vitamin_d: 42, circadian: 10 });
+  window.erythemalSED = () => 12;
+  window.fractionOfMED = () => 0.2;
+  window.retinalUVdose = () => 0.01;
+  window.solarZenithAngle = () => 30;
+  const staleId = await logCompletedSession({
+    startedAt: Date.now() - 45 * 60000,
+    endedAt: Date.now() - 15 * 60000,
+    location: { lat: 50.1, lon: 14.4 },
+    engineVersion: SUN_ENGINE_VERSION - 1,
+  });
+  const rehydrateA = rehydrateStaleSessions();
+  const rehydrateB = rehydrateStaleSessions();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert('Concurrent rehydrate batches share one atmosphere fetch per stale session',
+    fetchCalls === 1, `fetchCalls=${fetchCalls}`);
+  releaseFetch();
+  const [resultA, resultB] = await Promise.all([rehydrateA, rehydrateB]);
+  const staleSess = getSessions().find(s => s.id === staleId);
+  assert('Both concurrent rehydrate callers observe the shared completed work',
+    resultA.rehydrated === 1 && resultB.rehydrated === 1,
+    `A=${resultA.rehydrated}, B=${resultB.rehydrated}`);
+  assert('Shared rehydrate stamps the session with current engine output',
+    staleSess.engineVersion === SUN_ENGINE_VERSION &&
+    staleSess.doses?.vitamin_d === 42 &&
+    staleSess.safety?.medFraction === 0.2);
+  for (const [key, value] of Object.entries(origEngineFns)) {
+    if (value === undefined) delete window[key];
+    else window[key] = value;
+  }
+
+  // ─── 13. Source split guardrails ─────────────────────────────────────
+  console.log('%c 13. Sun session module boundaries ', 'font-weight:bold;color:#f59e0b');
 
   const fs = await import('node:fs/promises');
   const sunSrc = await fs.readFile(new URL('../js/sun.js', import.meta.url), 'utf8');

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -16,13 +16,15 @@ console.log('=== Sun Session Tests ===\n');
 
 await import('../js/state.js');
 const sun = await import('../js/sun.js');
+const sunSessionModel = await import('../js/sun-session-model.js');
+const sunSessionsStore = await import('../js/sun-sessions-store.js');
 const {
   BODY_REGIONS, EXPOSURE_PRESETS, EYE_MODES, LENS_TINTS,
   CHANNEL_DISPLAY,
   channelTier, tierLabel, tierDots, formatChannelUnit,
   SUN_ENGINE_VERSION,
   getSessions, getActiveSession,
-  startSession, stopSession, logCompletedSession, deleteSession, updateSession,
+  startSession, stopSession, logCompletedSession, deleteSession, pauseSession, resumeSession, updateSession,
   rollingChannelTotals, dailyChannelBreakdown, rollingVitaminDIU,
   cumulativeMEDToday, cumulativeMEDYesterday,
   _applyAtmOverrides,
@@ -66,6 +68,17 @@ const {
     missingPresets.length === 0 &&
     EXPOSURE_PRESETS.every(p => typeof p.fraction === 'number'),
     missingPresets.length ? `missing: ${missingPresets.join(',')}` : '');
+  assert('sun.js re-exports shared session model constants',
+    EXPOSURE_PRESETS === sunSessionModel.EXPOSURE_PRESETS &&
+    sun.POSTURE_OPTIONS === sunSessionModel.POSTURE_OPTIONS &&
+    sun.SURFACE_OPTIONS === sunSessionModel.SURFACE_OPTIONS &&
+    sun.PHOTOSENSITIVE_MED_TIERS === sunSessionModel.PHOTOSENSITIVE_MED_TIERS);
+  assert('sun.js re-exports persisted session store API',
+    getSessions === sunSessionsStore.getSessions &&
+    startSession === sunSessionsStore.startSession &&
+    pauseSession === sunSessionsStore.pauseSession &&
+    resumeSession === sunSessionsStore.resumeSession &&
+    SUN_ENGINE_VERSION === sunSessionsStore.SUN_ENGINE_VERSION);
 
   assert('EYE_MODES includes "direct" + "sunglasses" + "indoor"',
     EYE_MODES.some(e => e.key === 'direct') &&
@@ -154,6 +167,15 @@ const {
   let threw = false;
   try { await startSession({ regions: [] }); } catch (e) { threw = true; }
   assert('startSession({regions: []}) throws (refuses phantom exposure)', threw);
+
+  // pause/resume boundary lives in the extracted store and must remain
+  // callable through the public sun.js facade.
+  await pauseSession(id2);
+  assert('pauseSession marks active session paused',
+    sess2.paused === true && Number.isFinite(sess2.pausedAt));
+  await resumeSession(id2);
+  assert('resumeSession clears paused state',
+    sess2.paused === false && sess2.pausedAt === undefined);
 
   // delete one
   await stopSession(id2);
@@ -365,6 +387,30 @@ const {
 
   assert('SUN_ENGINE_VERSION is a positive integer (current = 3)',
     Number.isInteger(SUN_ENGINE_VERSION) && SUN_ENGINE_VERSION >= 3);
+
+  // ─── 12. Source split guardrails ─────────────────────────────────────
+  console.log('%c 12. Sun session module boundaries ', 'font-weight:bold;color:#f59e0b');
+
+  const fs = await import('node:fs/promises');
+  const sunSrc = await fs.readFile(new URL('../js/sun.js', import.meta.url), 'utf8');
+  const modelSrc = await fs.readFile(new URL('../js/sun-session-model.js', import.meta.url), 'utf8');
+  const storeSrc = await fs.readFile(new URL('../js/sun-sessions-store.js', import.meta.url), 'utf8');
+  const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
+  assert('Sun session model owns shared option/safety constants',
+    sunSrc.includes("from './sun-session-model.js'") &&
+    modelSrc.includes('export const EXPOSURE_PRESETS') &&
+    modelSrc.includes('export const POSTURE_MULTIPLIERS') &&
+    modelSrc.includes('export const PHOTOSENSITIVE_MED_TIERS'));
+  assert('Sun sessions store owns persisted lifecycle and hydration',
+    sunSrc.includes("from './sun-sessions-store.js'") &&
+    storeSrc.includes('export async function startSession') &&
+    storeSrc.includes('export async function hydrateSession') &&
+    storeSrc.includes('export function getSessions') &&
+    !storeSrc.includes('showPromptDialog') &&
+    !storeSrc.includes('renderBodySilhouette'));
+  assert('Service worker precaches extracted sun session modules',
+    swSrc.includes("'/js/sun-session-model.js'") &&
+    swSrc.includes("'/js/sun-sessions-store.js'"));
 
   // Restore
   window._labState.importedData = orig;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.285';
+self.APP_VERSION = '1.8.286';


### PR DESCRIPTION
## What changed

- Extracted shared Sun session options and safety constants into `sun-session-model.js`.
- Extracted persisted Sun session CRUD, pause/resume, hydration, stale rehydration, and atmosphere override logic into `sun-sessions-store.js`.
- Kept `sun.js` as the public facade for existing imports/window bindings, with injected hooks for live active-session state.
- Added the new modules to the service worker app shell and bumped `version.js` to `1.8.286`.

## Why

`sun.js` had accumulated storage, hydration, constants, UI facade, and aggregate logic in one large module. This separates the sensitive persisted session lifecycle from active UI/modal code while preserving the existing public API.

## Validation

- `node --check js/sun.js`
- `node --check js/sun-session-model.js`
- `node --check js/sun-sessions-store.js`
- `node --check js/sun-active-session.js`
- `node --check tests/test-sun.js`
- `node --check tests/test-correctness-phase2.js`
- `node tests/test-sun.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-sun-context.js`
- `node tests/test-sun-ai-analysis.js`
- `node tests/test-light-devices.js`
- `./run-tests.sh`