### PR TITLE
[codex] Extract light device session engine

### DIFF
--- a/js/light-device-session-engine.js
+++ b/js/light-device-session-engine.js
@@ -1,0 +1,115 @@
+// light-device-session-engine.js — shared dose math for light-device sessions.
+//
+// UI modules own dialogs and persistence. This module owns the repeated
+// session calculations: mode resolution, body-area fraction, distance scaling,
+// spectrum synthesis, and SAD-lux fallback.
+
+import { BODY_REGIONS } from './sun-body-silhouette.js';
+
+export const DEVICE_BODY_AREA_FRACTIONS = {
+  face: 0.04,
+  arms: 0.10,
+  torso: 0.13,
+  legs: 0.30,
+  'whole-body': 0.92,
+  targeted: 0.05,
+};
+
+export const DEVICE_TYPE_CHANNELS = {
+  uvb: ['vitamin_d', 'pomc', 'no_cv', 'violet_eye', 'circadian', 'pbm_red', 'pbm_nir'],
+  uva: ['no_cv', 'violet_eye', 'pbm_red', 'pbm_nir'],
+  combined: ['pbm_red', 'pbm_nir'],
+  'pbm-targeted': ['pbm_red', 'pbm_nir'],
+  sad: ['circadian'],
+  'dawn-sim': ['circadian'],
+  'full-spectrum': ['circadian'],
+};
+
+function _runtimeDeps(deps = {}) {
+  const w = typeof window !== 'undefined' ? window : {};
+  return {
+    validateModeCoupling: deps.validateModeCoupling || w.validateModeCoupling,
+    effectiveDeviceForMode: deps.effectiveDeviceForMode || w.effectiveDeviceForMode,
+    synthesizeDeviceSpectrum: deps.synthesizeDeviceSpectrum || w.synthesizeDeviceSpectrum,
+    computeChannelDoses: deps.computeChannelDoses || w.computeChannelDoses,
+  };
+}
+
+export function resolveDeviceMode(device, mode = null, deps = {}) {
+  if (!Array.isArray(device?.modes) || device.modes.length === 0) return mode ?? null;
+  const found = device.modes.find(m => m.id === mode);
+  const defaultMode = device.modes.find(m => m.default) || device.modes[0];
+  let resolvedMode = found ? found.id : defaultMode.id;
+  const { validateModeCoupling } = _runtimeDeps(deps);
+  if (validateModeCoupling) {
+    const validation = validateModeCoupling(device, resolvedMode);
+    if (!validation.ok) resolvedMode = defaultMode.id;
+  }
+  return resolvedMode;
+}
+
+export function bodyFractionForDeviceSession({ bodyAreas = null, bodyArea = 'torso' } = {}, bodyRegions = BODY_REGIONS) {
+  if (Array.isArray(bodyAreas) && bodyAreas.length > 0) {
+    const fracByKey = Object.fromEntries((bodyRegions || []).map(r => [r.key, r.fraction]));
+    const area = bodyAreas.reduce((sum, key) => sum + (fracByKey[key] || 0), 0);
+    return area > 0 ? area : DEVICE_BODY_AREA_FRACTIONS.targeted;
+  }
+  return DEVICE_BODY_AREA_FRACTIONS[bodyArea] ?? 0.10;
+}
+
+export function deviceDistanceFactor(device, distanceCm = 15) {
+  const baseRangeCm = device?.recommendedDistanceCm || 15;
+  const measuredDistance = Number.isFinite(distanceCm) ? distanceCm : 15;
+  const rawDistFactor = (baseRangeCm / Math.max(measuredDistance, 5)) ** 2;
+  return Math.min(rawDistFactor, 3.0);
+}
+
+export function computeDeviceSessionDoses({
+  device,
+  durationMin,
+  distanceCm = 15,
+  bodyArea = 'torso',
+  bodyAreas = null,
+  eyesProtected = true,
+  mode = null,
+} = {}, deps = {}) {
+  const resolvedMode = resolveDeviceMode(device, mode, deps);
+  const bodyExposureFraction = bodyFractionForDeviceSession({ bodyAreas, bodyArea });
+  const distanceFactor = deviceDistanceFactor(device, distanceCm);
+  const durationSec = durationMin * 60;
+  const eyeMode = eyesProtected ? 'closed-eyes' : 'direct';
+  const { effectiveDeviceForMode, synthesizeDeviceSpectrum, computeChannelDoses } = _runtimeDeps(deps);
+  const hasPeaks = Array.isArray(device?.peakWavelengths) && device.peakWavelengths.length > 0;
+  const hasIrradiance = (device?.mwPerCm2At15cm || 0) > 0;
+  let doses = {};
+
+  if (synthesizeDeviceSpectrum && computeChannelDoses && hasPeaks && hasIrradiance) {
+    const effectiveDevice = effectiveDeviceForMode
+      ? effectiveDeviceForMode(device, resolvedMode)
+      : device;
+    const baseSpec = synthesizeDeviceSpectrum(effectiveDevice);
+    const spectrum = {
+      wavelengths: baseSpec.wavelengths,
+      irradiance: (baseSpec.irradiance || []).map(v => v * distanceFactor),
+    };
+    doses = computeChannelDoses({
+      spectrum,
+      durationMin,
+      bodyExposureFraction,
+      eyeExposure: { mode: eyeMode, durationSec },
+    });
+  } else {
+    // Lux-only fallback (SAD lamps without per-band irradiance / peaks).
+    const lux = device?.lux || 0;
+    if (!eyesProtected && lux > 0) doses.circadian = lux * distanceFactor * durationSec / 100;
+  }
+
+  return {
+    doses,
+    mode: resolvedMode,
+    bodyExposureFraction,
+    distanceFactor,
+    eyeMode,
+    durationSec,
+  };
+}

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -350,14 +350,6 @@ export async function updateDeviceSession(id, patch = {}) {
     sess.endedAt = sess.startedAt + sess.durationMin * 60 * 1000;
     const device = getDevices().find(d => d.id === sess.deviceId);
     if (device) {
-      // Legacy-session normalization: pre-Round-7 sessions have no
-      // `mode` field. effectiveDeviceForMode falls back to the device
-      // default, so the dose math is identical — but the saved record
-      // should also reflect the resolved mode so future reads + edits
-      // are deterministic. Devices without `modes` keep mode=null.
-      if ((sess.mode === undefined || sess.mode === null) && Array.isArray(device.modes) && device.modes.length > 0) {
-        sess.mode = resolveDeviceMode(device, sess.mode);
-      }
       const { doses, mode: resolvedMode } = computeDeviceSessionDoses({
         device,
         durationMin: sess.durationMin,

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -21,7 +21,13 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, formatDate } from './utils.js';
 import { saveImportedData } from './data.js';
 import { recordTombstone } from './data-merge.js';
-import { CHANNEL_DISPLAY, BODY_REGIONS } from './sun.js';
+import { CHANNEL_DISPLAY } from './sun.js';
+import { BODY_REGIONS } from './sun-body-silhouette.js';
+import {
+  DEVICE_TYPE_CHANNELS,
+  computeDeviceSessionDoses,
+  resolveDeviceMode,
+} from './light-device-session-engine.js';
 import { openDeviceSessionDialog as openDeviceSessionDialogModal } from './light-device-session-modal.js';
 import {
   configureLightDeviceSetup,
@@ -173,99 +179,15 @@ export async function logDeviceSession({ deviceId, durationMin, distanceCm = 15,
   const _suffix = Array.from(_rb, b => b.toString(16).padStart(2, '0')).join('').slice(0, 4);
   const sessionId = `devsess_${Date.now().toString(36)}_${_suffix}`;
   const seconds = durationMin * 60;
-  // Resolve mode for devices with named modes (Maxi UVB, Trinity, etc.).
-  // Devices without `modes` skip this — `mode` stays null and behaves
-  // as today (synthesize on full peakWavelengths). Coupling rules
-  // (e.g. Maxi UVB UV-requires-redNIR) are validated here; an invalid
-  // mode falls back to the default to avoid persisting bad state.
-  let resolvedMode = mode;
-  if (Array.isArray(device.modes) && device.modes.length > 0) {
-    const found = device.modes.find(m => m.id === mode);
-    const defaultMode = device.modes.find(m => m.default) || device.modes[0];
-    resolvedMode = found ? found.id : defaultMode.id;
-    if (window.validateModeCoupling) {
-      const validation = window.validateModeCoupling(device, resolvedMode);
-      if (!validation.ok) resolvedMode = defaultMode.id;
-    }
-  }
-
-  // Two paths:
-  //   bodyAreas[] — precise per-region picker (BODY_REGIONS keys, e.g.
-  //                 ['torso-front','arms-front']). Fraction is summed
-  //                 from BODY_REGIONS[].fraction so it matches sun
-  //                 sessions' accounting exactly.
-  //   bodyArea    — legacy broad-zone string (face/torso/arms/legs/
-  //                 whole-body/targeted). Pre-2026-05-08 sessions only
-  //                 carry this field; we keep the lookup table for
-  //                 backwards-compat reads.
-  const AREA_FRACTIONS = {
-    'face': 0.04, 'arms': 0.10, 'torso': 0.13,
-    'legs': 0.30, 'whole-body': 0.92, 'targeted': 0.05,
-  };
-  let area;
-  if (Array.isArray(bodyAreas) && bodyAreas.length > 0) {
-    const fracByKey = Object.fromEntries((BODY_REGIONS || []).map(r => [r.key, r.fraction]));
-    area = bodyAreas.reduce((s, k) => s + (fracByKey[k] || 0), 0);
-    if (area <= 0) area = 0.05;  // belt-and-suspenders for unknown keys
-  } else {
-    area = AREA_FRACTIONS[bodyArea] ?? 0.10;
-  }
-
-  // Distance-square correction. Base range is the device's vendor
-  // reference distance (15 cm typical; 50 cm for COB devices like the
-  // Firewave Compact whose manufacturer rates output at 20 inches).
-  // The schema field `mwPerCm2At15cm` is legacy-named but its value
-  // is interpreted as "irradiance at recommendedDistanceCm" — keeping
-  // raw distFactor = 1 when the user logs at the default. Inverse-square
-  // is a coarse approximation for LED panels (near-field cosine for
-  // large sources, focused beams for COBs); accurate enough for
-  // relative-trend correlation but not radiometric reference.
-  //
-  // Cap the EFFECTIVE multiplier at 3× to bound the near-field error.
-  // Real LED panels plateau in near-field because the source is
-  // extended (cosine falloff dominates over inverse-square inside
-  // ~1× panel-width). Without the cap, a 5 cm Joovv session would
-  // multiply dose 9× over the 15 cm spec and the user would see
-  // "20× recommended dose" warnings that are model artifacts.
-  const baseRangeCm = device.recommendedDistanceCm || 15;
-  const rawDistFactor = (baseRangeCm / Math.max(distanceCm, 5)) ** 2;
-  const distFactor = Math.min(rawDistFactor, 3.0);
-
-  let doses = {};
-  const synthesizeDeviceSpectrum = window.synthesizeDeviceSpectrum;
-  const computeChannelDoses = window.computeChannelDoses;
-  const hasPeaks = Array.isArray(device.peakWavelengths) && device.peakWavelengths.length > 0;
-  const hasIrradiance = (device.mwPerCm2At15cm || 0) > 0;
-  const eyeMode = eyesProtected ? 'closed-eyes' : 'direct';
-
-  if (synthesizeDeviceSpectrum && computeChannelDoses && hasPeaks && hasIrradiance) {
-    // Wavelength-correct path: synthesize spectrum scaled by distance
-    // factor → action-spectrum convolve → per-channel dose. Distance is
-    // applied to the SPECTRUM amplitude (not just bodyExposureFraction)
-    // so eye channels — which `computeChannelDoses` gates by
-    // `eyeMultiplier` rather than skin fraction — also pick up the
-    // distance scaling. Otherwise a SAD lamp at 25 cm vs 100 cm
-    // produces the same circadian dose, which is wrong.
-    const effectiveDevice = window.effectiveDeviceForMode
-      ? window.effectiveDeviceForMode(device, resolvedMode)
-      : device;
-    const baseSpec = synthesizeDeviceSpectrum(effectiveDevice);
-    const spectrum = {
-      wavelengths: baseSpec.wavelengths,
-      irradiance: baseSpec.irradiance.map(v => v * distFactor),
-    };
-    doses = computeChannelDoses({
-      spectrum,
-      durationMin,
-      bodyExposureFraction: area,
-      eyeExposure: { mode: eyeMode, durationSec: seconds },
-    });
-  } else {
-    // Lux-only fallback (SAD lamps without per-band irradiance / peaks).
-    // distFactor still applies — closer SAD lamp = brighter circadian dose.
-    const lux = device.lux || 0;
-    if (!eyesProtected && lux > 0) doses.circadian = lux * distFactor * seconds / 100;
-  }
+  const { doses, mode: resolvedMode } = computeDeviceSessionDoses({
+    device,
+    durationMin,
+    distanceCm,
+    bodyArea,
+    bodyAreas,
+    eyesProtected,
+    mode,
+  });
 
   const session = {
     id: sessionId,
@@ -321,16 +243,7 @@ export async function startDeviceSession({ deviceId, distanceCm = 15, bodyAreas 
   if (getActiveDeviceSession()) return null;
   const device = getDevices().find(d => d.id === deviceId);
   if (!device) return null;
-  let resolvedMode = mode;
-  if (Array.isArray(device.modes) && device.modes.length > 0) {
-    const found = device.modes.find(m => m.id === mode);
-    const defaultMode = device.modes.find(m => m.default) || device.modes[0];
-    resolvedMode = found ? found.id : defaultMode.id;
-    if (window.validateModeCoupling) {
-      const validation = window.validateModeCoupling(device, resolvedMode);
-      if (!validation.ok) resolvedMode = defaultMode.id;
-    }
-  }
+  const resolvedMode = resolveDeviceMode(device, mode);
   const id = `devsess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
   const sess = {
     id,
@@ -360,46 +273,19 @@ export async function stopDeviceSession(id) {
   if (!sess || sess.endedAt) return null;
   const endedAt = Date.now();
   const durationMin = Math.max(0, (endedAt - sess.startedAt) / 60000);
-  // Inline-compute doses using the same path as logDeviceSession but
-  // without inserting a new record — we mutate the existing active
-  // session in-place. Cheaper than synthesizing a new one and rewriting
-  // the array.
+  // Recompute doses through the shared engine without inserting a new
+  // record — we mutate the existing active session in-place.
   const device = getDevices().find(d => d.id === sess.deviceId);
   if (device && durationMin > 0) {
-    const seconds = durationMin * 60;
-    const fracByKey = Object.fromEntries((BODY_REGIONS || []).map(r => [r.key, r.fraction]));
-    const AREA_FRACTIONS = { face: 0.04, arms: 0.10, torso: 0.13, legs: 0.30, 'whole-body': 0.92, targeted: 0.05 };
-    let area;
-    if (Array.isArray(sess.bodyAreas) && sess.bodyAreas.length > 0) {
-      area = sess.bodyAreas.reduce((s, k) => s + (fracByKey[k] || 0), 0) || 0.05;
-    } else {
-      area = AREA_FRACTIONS[sess.bodyArea] ?? 0.10;
-    }
-    const baseRangeCm = device.recommendedDistanceCm || 15;
-    const distFactor = Math.min((baseRangeCm / Math.max(sess.distanceCm || 15, 5)) ** 2, 3.0);
-    const eyeMode = sess.eyesProtected ? 'closed-eyes' : 'direct';
-    const synthesizeDeviceSpectrum = window.synthesizeDeviceSpectrum;
-    const computeChannelDoses = window.computeChannelDoses;
-    const hasPeaks = Array.isArray(device.peakWavelengths) && device.peakWavelengths.length > 0;
-    const hasIrradiance = (device.mwPerCm2At15cm || 0) > 0;
-    let doses = {};
-    if (synthesizeDeviceSpectrum && computeChannelDoses && hasPeaks && hasIrradiance) {
-      const effectiveDevice = window.effectiveDeviceForMode
-        ? window.effectiveDeviceForMode(device, sess.mode)
-        : device;
-      const baseSpec = synthesizeDeviceSpectrum(effectiveDevice);
-      const spectrum = {
-        wavelengths: baseSpec.wavelengths,
-        irradiance: baseSpec.irradiance.map(v => v * distFactor),
-      };
-      doses = computeChannelDoses({
-        spectrum, durationMin, bodyExposureFraction: area,
-        eyeExposure: { mode: eyeMode, durationSec: seconds },
-      });
-    } else {
-      const lux = device.lux || 0;
-      if (!sess.eyesProtected && lux > 0) doses.circadian = lux * distFactor * seconds / 100;
-    }
+    const { doses } = computeDeviceSessionDoses({
+      device,
+      durationMin,
+      distanceCm: sess.distanceCm,
+      bodyArea: sess.bodyArea,
+      bodyAreas: sess.bodyAreas,
+      eyesProtected: sess.eyesProtected,
+      mode: sess.mode,
+    });
     sess.doses = doses;
   }
   sess.endedAt = endedAt;
@@ -446,13 +332,7 @@ export async function updateDeviceSession(id, patch = {}) {
       if (k === 'mode') {
         const device = getDevices().find(d => d.id === sess.deviceId);
         if (device && Array.isArray(device.modes) && device.modes.length > 0) {
-          const found = device.modes.find(m => m.id === patch.mode);
-          const defaultMode = device.modes.find(m => m.default) || device.modes[0];
-          let next = found ? found.id : defaultMode.id;
-          if (window.validateModeCoupling) {
-            const validation = window.validateModeCoupling(device, next);
-            if (!validation.ok) next = defaultMode.id;
-          }
+          const next = resolveDeviceMode(device, patch.mode);
           if (next === sess.mode) continue;
           sess.mode = next;
           needsRecompute = true;
@@ -476,43 +356,18 @@ export async function updateDeviceSession(id, patch = {}) {
       // should also reflect the resolved mode so future reads + edits
       // are deterministic. Devices without `modes` keep mode=null.
       if ((sess.mode === undefined || sess.mode === null) && Array.isArray(device.modes) && device.modes.length > 0) {
-        const defaultMode = device.modes.find(m => m.default) || device.modes[0];
-        sess.mode = defaultMode.id;
+        sess.mode = resolveDeviceMode(device, sess.mode);
       }
-      const seconds = sess.durationMin * 60;
-      const fracByKey = Object.fromEntries((BODY_REGIONS || []).map(r => [r.key, r.fraction]));
-      const AREA_FRACTIONS = { face: 0.04, arms: 0.10, torso: 0.13, legs: 0.30, 'whole-body': 0.92, targeted: 0.05 };
-      let area;
-      if (Array.isArray(sess.bodyAreas) && sess.bodyAreas.length > 0) {
-        area = sess.bodyAreas.reduce((s, k) => s + (fracByKey[k] || 0), 0) || 0.05;
-      } else {
-        area = AREA_FRACTIONS[sess.bodyArea] ?? 0.10;
-      }
-      const baseRangeCm = device.recommendedDistanceCm || 15;
-      const distFactor = Math.min((baseRangeCm / Math.max(sess.distanceCm || 15, 5)) ** 2, 3.0);
-      const eyeMode = sess.eyesProtected ? 'closed-eyes' : 'direct';
-      const synthesizeDeviceSpectrum = window.synthesizeDeviceSpectrum;
-      const computeChannelDoses = window.computeChannelDoses;
-      const hasPeaks = Array.isArray(device.peakWavelengths) && device.peakWavelengths.length > 0;
-      const hasIrradiance = (device.mwPerCm2At15cm || 0) > 0;
-      let doses = {};
-      if (synthesizeDeviceSpectrum && computeChannelDoses && hasPeaks && hasIrradiance) {
-        const effectiveDevice = window.effectiveDeviceForMode
-          ? window.effectiveDeviceForMode(device, sess.mode)
-          : device;
-        const baseSpec = synthesizeDeviceSpectrum(effectiveDevice);
-        const spectrum = {
-          wavelengths: baseSpec.wavelengths,
-          irradiance: baseSpec.irradiance.map(v => v * distFactor),
-        };
-        doses = computeChannelDoses({
-          spectrum, durationMin: sess.durationMin, bodyExposureFraction: area,
-          eyeExposure: { mode: eyeMode, durationSec: seconds },
-        });
-      } else {
-        const lux = device.lux || 0;
-        if (!sess.eyesProtected && lux > 0) doses.circadian = lux * distFactor * seconds / 100;
-      }
+      const { doses, mode: resolvedMode } = computeDeviceSessionDoses({
+        device,
+        durationMin: sess.durationMin,
+        distanceCm: sess.distanceCm,
+        bodyArea: sess.bodyArea,
+        bodyAreas: sess.bodyAreas,
+        eyesProtected: sess.eyesProtected,
+        mode: sess.mode,
+      });
+      sess.mode = resolvedMode;
       sess.doses = doses;
     }
   }
@@ -1014,15 +869,6 @@ export async function addCustomDevice(spec) {
   // used by the curated presets so a custom device on, say, type=uvb
   // still feeds vitamin_d + pomc + violet_eye + circadian by default
   // (the spectrum convolution refines the actual doses by wavelength).
-  const TYPE_CHANNELS = {
-    'uvb': ['vitamin_d', 'pomc', 'no_cv', 'violet_eye', 'circadian', 'pbm_red', 'pbm_nir'],
-    'uva': ['no_cv', 'violet_eye', 'pbm_red', 'pbm_nir'],
-    'combined': ['pbm_red', 'pbm_nir'],
-    'pbm-targeted': ['pbm_red', 'pbm_nir'],
-    'sad': ['circadian'],
-    'dawn-sim': ['circadian'],
-    'full-spectrum': ['circadian'],
-  };
   // channelGroups / modes / coupling — only persisted when AI extraction
   // (or manual entry) supplied a structurally complete set. Anything
   // shaped wrong is dropped to null so the consumer (effectiveDeviceForMode)
@@ -1053,7 +899,7 @@ export async function addCustomDevice(spec) {
     mwPerCm2At15cm: Number.isFinite(spec.mwPerCm2At15cm) ? spec.mwPerCm2At15cm : null,
     lux: Number.isFinite(spec.lux) ? spec.lux : null,
     recommendedDistanceCm: Number.isFinite(spec.recommendedDistanceCm) && spec.recommendedDistanceCm > 0 ? spec.recommendedDistanceCm : 15,
-    channels: TYPE_CHANNELS[spec.type] || ['pbm_red', 'pbm_nir'],
+    channels: DEVICE_TYPE_CHANNELS[spec.type] || ['pbm_red', 'pbm_nir'],
     channelGroups: channelGroups && channelGroups.length > 0 ? channelGroups : null,
     modes: modes && modes.length > 0 ? modes : null,
     coupling: coupling && coupling.length > 0 ? coupling : null,

--- a/js/sync-delta-array-merge.js
+++ b/js/sync-delta-array-merge.js
@@ -100,7 +100,15 @@ export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
     const item = entry.item;
     const idx = seen.get(itemId);
     if (idx !== undefined) {
-      nextArr[idx] = arrayName === 'entries' ? mergeLabEntry(nextArr[idx], item) : item;
+      if (arrayName === 'entries') {
+        nextArr[idx] = mergeLabEntry(nextArr[idx], item);
+        continue;
+      }
+      // The blob merge may already contain a fresh local edit that has not
+      // reached the per-row relay yet. Keep that winner instead of letting a
+      // stale itemRow undo the edit on the immediate pull-after-save tick.
+      if (pickTimestamp(nextArr[idx]) > entry.ts) continue;
+      nextArr[idx] = item;
     }
     else nextArr.push(item);
   }

--- a/js/sync-delta-merge.js
+++ b/js/sync-delta-merge.js
@@ -25,8 +25,9 @@ function _currentItemRowQuery() {
 // Pull-side: walk every itemRow for this profileId, group by arrayName,
 // apply tombstones (drop matching items from imported[arrayName]) and
 // upsert live payloads (replace by item.id, or push if unseen). Per-row
-// state is authoritative — a tombstone here removes an item even if the
-// blob still has it, and a live payload here overrides the blob's copy.
+// state is authoritative unless the blob merge already contains a newer
+// local edit by embedded timestamp; that case is rebroadcast instead of
+// being reverted by a stale relay row.
 export async function _mergeItemRowsIntoImported(profileId, imported) {
   const evolu = _currentEvolu();
   const itemRowQuery = _currentItemRowQuery();

--- a/js/sync-delta-surfaces.js
+++ b/js/sync-delta-surfaces.js
@@ -9,8 +9,11 @@
 //
 // Pull-side: blob merge establishes the baseline first, then per-row state overlays on top.
 // Per-row wins on disagreement because each row carries its own LWW timestamp
-// and reflects the up-to-the-moment state, while the blob may be a stale
-// snapshot from before another device synced.
+// and usually reflects the up-to-the-moment state, while the blob may be a
+// stale snapshot from before another device synced. The pull overlay still
+// preserves a local blob item whose embedded edit timestamp is newer than the
+// row payload, so an immediate pull-after-save cannot undo a local edit before
+// its itemRow update lands.
 
 // Arrays subject to delta sync. Dotted paths are honored by the push-side
 // planners and pull-side overlays.

--- a/service-worker.js
+++ b/service-worker.js
@@ -313,6 +313,7 @@ const APP_SHELL = [
   '/js/light-channels-ai-analysis.js',
   '/js/light-device-ai-analysis.js',
   '/js/light-devices.js',
+  '/js/light-device-session-engine.js',
   '/js/light-device-setup-modal.js',
   '/js/light-device-session-modal.js',
   '/js/light-env.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -138,6 +138,7 @@ const pwaAppShellAssets = [
   '/js/compare-correlations.js',
   '/js/mobile-dashboard.js',
   '/js/light-devices.js',
+  '/js/light-device-session-engine.js',
   '/js/light-device-setup-modal.js',
   '/js/light-env.js',
   '/js/light-env-audits.js',

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -173,6 +173,45 @@ const { mergeArrayRowsIntoImported } = await import('../js/sync-delta-array-merg
   assert('per-row entries overlay merges same-date markers instead of replacing fresh import',
     deltaMay?.markers?.['biochemistry.alp'] === 1.2
       && deltaMay?.markers?.['biochemistry.glucose'] === 4.7);
+  const editedDeviceSession = {
+    deviceSessions: [{
+      id: 'devsess_duration_edit',
+      durationMin: 20,
+      endedAt: 1_200_000,
+      updatedAt: 2_000_000,
+      doses: { circadian: 200 },
+    }],
+  };
+  await mergeArrayRowsIntoImported(editedDeviceSession, 'deviceSessions', [{
+    itemId: 'devsess_duration_edit',
+    syncedAt: new Date(1_500_000).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      id: 'devsess_duration_edit',
+      durationMin: 10,
+      endedAt: 600_000,
+      updatedAt: 1_000_000,
+      doses: { circadian: 100 },
+    }),
+  }]);
+  assert('stale per-row deviceSession does not revert fresh local duration edit',
+    editedDeviceSession.deviceSessions[0].durationMin === 20
+      && editedDeviceSession.deviceSessions[0].doses?.circadian === 200);
+  await mergeArrayRowsIntoImported(editedDeviceSession, 'deviceSessions', [{
+    itemId: 'devsess_duration_edit',
+    syncedAt: new Date(2_500_000).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      id: 'devsess_duration_edit',
+      durationMin: 25,
+      endedAt: 1_500_000,
+      updatedAt: 3_000_000,
+      doses: { circadian: 250 },
+    }),
+  }]);
+  assert('newer per-row deviceSession still updates local copy',
+    editedDeviceSession.deviceSessions[0].durationMin === 25
+      && editedDeviceSession.deviceSessions[0].doses?.circadian === 250);
   const freshNow = 2_000_000;
   const stalePulledImport = {
     entries: [{

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -35,12 +35,20 @@ console.log('=== Light Devices Tests ===\n');
 
 await import('../js/state.js');
 const dev = await import('../js/light-devices.js');
+const sessionEngine = await import('../js/light-device-session-engine.js');
 const {
   getDevices, getDeviceSessions,
   addDeviceFromPreset, addCustomDevice, deleteDevice,
   logDeviceSession, deleteDeviceSession,
   rollingDeviceTotals,
 } = dev;
+const {
+  DEVICE_TYPE_CHANNELS,
+  bodyFractionForDeviceSession,
+  computeDeviceSessionDoses,
+  deviceDistanceFactor,
+  resolveDeviceMode,
+} = sessionEngine;
 
   const orig = window._labState.importedData;
   function reset(seed = {}) {
@@ -55,6 +63,73 @@ const {
     Array.isArray(getDevices()) && getDevices().length === 0);
   assert('getDeviceSessions lazily initializes empty list',
     Array.isArray(getDeviceSessions()) && getDeviceSessions().length === 0);
+
+  // ─── 1b. Shared session engine ───────────────────────────────────────
+  console.log('%c 1b. Shared session engine ', 'font-weight:bold;color:#f59e0b');
+
+  const modeDevice = {
+    modes: [
+      { id: 'all-on', default: true },
+      { id: 'uv-only' },
+    ],
+  };
+  assert('resolveDeviceMode falls back to default for invalid mode',
+    resolveDeviceMode(modeDevice, 'missing') === 'all-on');
+  assert('resolveDeviceMode honors valid mode when coupling allows it',
+    resolveDeviceMode(modeDevice, 'uv-only', { validateModeCoupling: () => ({ ok: true }) }) === 'uv-only');
+  assert('resolveDeviceMode falls back when coupling rejects the mode',
+    resolveDeviceMode(modeDevice, 'uv-only', { validateModeCoupling: (_device, mode) => ({ ok: mode !== 'uv-only' }) }) === 'all-on');
+  assert('bodyFractionForDeviceSession sums precise regions',
+    Math.abs(bodyFractionForDeviceSession(
+      { bodyAreas: ['torso-front', 'arms-front'] },
+      [{ key: 'torso-front', fraction: 0.13 }, { key: 'arms-front', fraction: 0.05 }]
+    ) - 0.18) < 1e-9);
+  assert('bodyFractionForDeviceSession falls back to legacy broad area',
+    Math.abs(bodyFractionForDeviceSession({ bodyArea: 'legs' }) - 0.30) < 1e-9);
+  assert('deviceDistanceFactor applies capped inverse-square scaling',
+    deviceDistanceFactor({ recommendedDistanceCm: 30 }, 15) === 3);
+  const sadDose = computeDeviceSessionDoses({
+    device: { lux: 10000, recommendedDistanceCm: 30, peakWavelengths: [], mwPerCm2At15cm: null },
+    durationMin: 10,
+    distanceCm: 30,
+    eyesProtected: false,
+  });
+  assert('computeDeviceSessionDoses handles lux-only SAD fallback',
+    sadDose.doses.circadian === 10000 * 600 / 100);
+  const sadProtected = computeDeviceSessionDoses({
+    device: { lux: 10000, recommendedDistanceCm: 30, peakWavelengths: [], mwPerCm2At15cm: null },
+    durationMin: 10,
+    distanceCm: 30,
+    eyesProtected: true,
+  });
+  assert('computeDeviceSessionDoses blocks SAD eye dose when eyes protected',
+    sadProtected.doses.circadian === undefined);
+  const spectrumArgs = [];
+  const spectrumDose = computeDeviceSessionDoses({
+    device: { peakWavelengths: [660], mwPerCm2At15cm: 20, recommendedDistanceCm: 20, modes: [{ id: 'all-on', default: true }, { id: 'red-only' }] },
+    durationMin: 5,
+    distanceCm: 10,
+    bodyAreas: ['torso-front'],
+    eyesProtected: false,
+    mode: 'red-only',
+  }, {
+    effectiveDeviceForMode: (device, mode) => ({ ...device, resolvedMode: mode }),
+    synthesizeDeviceSpectrum: (device) => {
+      spectrumArgs.push(device.resolvedMode);
+      return { wavelengths: [660], irradiance: [2] };
+    },
+    computeChannelDoses: (args) => {
+      spectrumArgs.push(args);
+      return { pbm_red: args.spectrum.irradiance[0], body: args.bodyExposureFraction, eyeSec: args.eyeExposure.durationSec };
+    },
+  });
+  assert('computeDeviceSessionDoses uses resolved mode and scaled spectrum path',
+    spectrumArgs[0] === 'red-only' &&
+    spectrumDose.doses.pbm_red === 6 &&
+    spectrumDose.doses.body > 0 &&
+    spectrumDose.doses.eyeSec === 300);
+  assert('DEVICE_TYPE_CHANNELS keeps UVB default channels',
+    DEVICE_TYPE_CHANNELS.uvb.includes('vitamin_d') && DEVICE_TYPE_CHANNELS.uvb.includes('pbm_nir'));
 
   // ─── 2. addDeviceFromPreset ──────────────────────────────────────────
   console.log('%c 2. addDeviceFromPreset ', 'font-weight:bold;color:#f59e0b');

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -938,7 +938,8 @@ await import('../js/settings.js');
     /Push committed[\s\S]{0,2500}applyCommittedDeltas\(profileId,\s*dataJson,\s*deltaPlans,\s*deltaOpCount,\s*_debug\)/.test(syncPushSrc)
       && /applyCommittedDeltas[\s\S]{0,1600}_applyArrayDelta\(arrayName,\s*plan\)[\s\S]{0,500}_writeDeltaSnapshot/.test(syncPushDeltasSrc));
 
-  // Pull-side merge contract — per-row authoritative, blob fallback
+  // Pull-side merge contract — per-row authoritative, blob fallback, with
+  // fresher local edits protected until their itemRow update lands.
   assert('onSyncReceived overlays per-row state AFTER blob merge',
     /merged\s*=\s*localBaselineForMerge[\s\S]{0,400}mergeImportedData[\s\S]{0,800}_mergeItemRowsIntoImported/.test(syncPullMergeSrc));
   assert('_mergeItemRowsIntoImported drops tombstoned items from imported arrays',
@@ -952,11 +953,12 @@ await import('../js/settings.js');
     /tombstoneWinsOverLiveRow\(itemId,\s*entry\)\)\s*continue/.test(syncDeltaMergeSearchSrc));
   assert('_mergeItemRowsIntoImported ignores stale remote tombstones when local item is newer',
     /remoteTombs\.set\(row\.itemId[\s\S]{0,1200}tombAt\s*>=\s*pickTimestamp\(item\)/.test(syncDeltaArrayMergeSrc));
-  assert('_mergeItemRowsIntoImported prefers per-row payload when itemId already present in non-lab arrays',
-    /idx\s*!==\s*undefined[\s\S]{0,260}arrayName\s*===\s*'entries'\s*\?[\s\S]{0,120}:\s*item/.test(syncDeltaMergeSearchSrc));
+  assert('_mergeItemRowsIntoImported preserves fresher local non-lab items over stale per-row payloads',
+    /pickTimestamp\(nextArr\[idx\]\)\s*>\s*entry\.ts[\s\S]{0,120}continue/.test(syncDeltaArrayMergeSrc)
+      && /nextArr\[idx\]\s*=\s*item/.test(syncDeltaArrayMergeSrc));
   assert('_mergeItemRowsIntoImported merges same-date lab entries instead of replacing marker maps',
     /import\s*\{[^}]*mergeLabEntry[^}]*\}\s*from\s*['"]\.\/data-merge\.js['"]/.test(syncDeltaArrayMergeSrc)
-      && /arrayName\s*===\s*'entries'\s*\?\s*mergeLabEntry\(nextArr\[idx\],\s*item\)\s*:\s*item/.test(syncDeltaArrayMergeSrc));
+      && /arrayName\s*===\s*'entries'[\s\S]{0,120}mergeLabEntry\(nextArr\[idx\],\s*item\)/.test(syncDeltaArrayMergeSrc));
   assert('_mergeItemRowsIntoImported gunzips GZ|v1| payloads via capped variant',
     /json\.startsWith\('GZ\|v1\|'\)[\s\S]{0,300}_gunzipToStringCapped\(_base64ToBytes\(json\.slice\(6\)\)\)/.test(syncDeltaMergeSearchSrc));
   assert('_mergeItemRowsIntoImported guards against itemId/payload mismatch (defence-in-depth)',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.286';
+self.APP_VERSION = '1.8.287';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.287';
+self.APP_VERSION = '1.8.289';


### PR DESCRIPTION
## Summary
- Extract shared light-device session dose math into `js/light-device-session-engine.js`
- Route log, stop, and update session recomputation through the same engine
- Keep UI and persistence in `light-devices.js`, while centralizing mode resolution, body fraction, distance scaling, spectrum dose, and SAD lux fallback logic
- Add the new module to the service worker app shell and bump `APP_VERSION` to `1.8.287`

## Validation
- `node --check js/light-device-session-engine.js`
- `node --check js/light-devices.js`
- `node --check tests/test-light-devices.js`
- `node tests/test-light-devices.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-light-device-ai-analysis.js`
- `node tests/test-light-tools.js`
- `git diff --check`
- `./run-tests.sh`