### PR TITLE
[codex] Centralize sync record freshness

### DIFF
--- a/js/chat-history.js
+++ b/js/chat-history.js
@@ -3,6 +3,7 @@
 import { state } from './state.js';
 import { encryptedSetItem, encryptedGetItem, getEncryptionEnabled } from './crypto.js';
 import { saveImportedData } from './data.js';
+import { recordArrayItemTombstone } from './data-merge.js';
 import { showConfirmDialog, showNotification } from './utils.js';
 import {
   getChatThreadKey, invalidateThreadContentCache,
@@ -68,6 +69,9 @@ export async function clearChatHistory() {
         saveChatThreadIndex();
         renderThreadList();
         if (state.importedData.chatSummaries) {
+          for (const summary of state.importedData.chatSummaries.filter(s => s.threadId === state.currentThreadId)) {
+            recordArrayItemTombstone(state.importedData, 'chatSummaries', summary);
+          }
           state.importedData.chatSummaries = state.importedData.chatSummaries.filter(s => s.threadId !== state.currentThreadId);
           saveImportedData();
         }

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -7,6 +7,7 @@ import { saveImportedData } from './data.js';
 import { callClaudeAPI, getActiveModelDisplay, getActiveModelId, getAIProvider, hasAIProvider, isAIPaused } from './api.js';
 import { renderThreadList, saveChatThreadIndex } from './chat-threads.js';
 import { renderMarkdown } from './markdown.js';
+import { recordArrayItemTombstone } from './data-merge.js';
 
 const SUMMARY_PROMPT = `You are a concise medical note-taker. Summarize this health consultation into a structured note.
 
@@ -175,6 +176,8 @@ function _getLatestSavedSummary(threadId) {
 
 export async function deleteSavedSummary(id) {
   if (!state.importedData.chatSummaries) return;
+  const summary = state.importedData.chatSummaries.find(s => s.id === id);
+  recordArrayItemTombstone(state.importedData, 'chatSummaries', summary);
   state.importedData.chatSummaries = state.importedData.chatSummaries.filter(s => s.id !== id);
   await saveImportedData();
   renderSavedSummaries();

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -23,6 +23,7 @@
 import { state } from './state.js';
 import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
+import { recordArrayItemTombstone } from './data-merge.js';
 import { onChatSaved } from './sync.js';
 import { chatDeletedThreadsKey } from './sync-payload-collectors.js';
 import { CHAT_PERSONALITIES } from './constants.js';
@@ -189,6 +190,9 @@ export async function deleteThread(threadId) {
     localStorage.removeItem(getChatThreadKey(threadId));
     // Remove saved summary
     if (state.importedData.chatSummaries) {
+      for (const summary of state.importedData.chatSummaries.filter(s => s.threadId === threadId)) {
+        recordArrayItemTombstone(state.importedData, 'chatSummaries', summary);
+      }
       state.importedData.chatSummaries = state.importedData.chatSummaries.filter(s => s.threadId !== threadId);
       saveImportedData();
     }

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -59,6 +59,7 @@ import {
 import { escapeHTML, showNotification } from './utils.js';
 import { formatTime, getTimeFormat, parseTimeInput } from './theme.js';
 import { saveImportedData } from './data.js';
+import { recordArrayItemTombstone } from './data-merge.js';
 import { getLatitudeFromLocation } from './profile.js';
 import { scanDietForContaminants } from './food-contaminants.js';
 import {
@@ -569,6 +570,7 @@ export function addHealthGoal() {
 
 export function deleteHealthGoal(idx) {
   if (!state.importedData.healthGoals) return;
+  recordArrayItemTombstone(state.importedData, 'healthGoals', state.importedData.healthGoals[idx]);
   state.importedData.healthGoals.splice(idx, 1);
   recordContextChange('healthGoals');
   saveImportedData();
@@ -583,6 +585,9 @@ export function closeHealthGoals() {
 }
 
 export function clearHealthGoals() {
+  for (const goal of state.importedData.healthGoals || []) {
+    recordArrayItemTombstone(state.importedData, 'healthGoals', goal);
+  }
   state.importedData.healthGoals = [];
   recordContextChange('healthGoals');
   saveImportedData();

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -561,7 +561,7 @@ export function addHealthGoal() {
   const text = input ? input.value.trim() : '';
   if (!text) return;
   if (!state.importedData.healthGoals) state.importedData.healthGoals = [];
-  state.importedData.healthGoals.push({ text, severity });
+  state.importedData.healthGoals.push({ text, severity, updatedAt: Date.now() });
   recordContextChange('healthGoals');
   saveImportedData();
   renderHealthGoalsModal(document.getElementById("detail-modal"));

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -328,6 +328,20 @@ function naturalItemId(path, item) {
   return _isAllowlistSafeId(id) ? id : null;
 }
 
+export function getConfiguredArrayItemId(path, item) {
+  const naturalId = naturalItemId(path, item);
+  if (naturalId) return naturalId;
+  return item && typeof item.id === 'string' && _isAllowlistSafeId(item.id)
+    ? item.id
+    : null;
+}
+
+export function recordArrayItemTombstone(importedData, arrayPath, item) {
+  const id = getConfiguredArrayItemId(arrayPath, item);
+  if (id) recordTombstone(importedData, arrayPath, id);
+  return id;
+}
+
 function unionByItemId(localArr, remoteArr, tombstones, itemIdFn) {
   const tomb = tombstones instanceof Set ? tombstones : new Set(tombstones || []);
   const byId = new Map();

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -1,4 +1,7 @@
-// data-merge.js — per-array union-by-id merge for cross-device sync.
+// data-merge.js — per-array record merge for cross-device sync.
+
+import { DELTA_ARRAY_CONFIG } from './sync-delta-surface-config.js';
+import { _isAllowlistSafeId } from './sync-delta-id.js';
 //
 // Background: sync pushes the whole `importedData` blob and pull used to do
 // `localStorage.setItem(JSON.stringify(remote))`. With concurrent edits on
@@ -9,16 +12,17 @@
 //
 // Strategy: for known append-only id-keyed arrays (sun feature + a couple
 // related), union local ∪ remote by `id`. Conflict on the same id picks the
-// record with the higher `updatedAt` / `endedAt` / `startedAt` / `capturedAt`
-// (whichever exists). Tombstones in `_deleted[arrayPath]` filter resurrected
-// rows so deletes don't undo themselves on the device that didn't issue them.
+// record with the higher shared freshness timestamp (`updatedAt`, `endedAt`,
+// `capturedAt`, `createdAt`, etc.; whichever exists). Tombstones in
+// `_deleted[arrayPath]` filter resurrected rows so deletes don't undo
+// themselves on the device that didn't issue them.
 //
 // Single-object subtrees (lifelightProfile, sunDefaults, sunCorrelations,
 // lightEnvironment top-level scalars) stay LWW — they're not multi-record.
 //
-// Other id-less arrays (entries by date, notes by date, supplements by name)
-// fall through to LWW for now — separate refactor; the sun feature is the
-// scope of this fix.
+// Other id-less arrays that have stable per-row sync ids merge through their
+// configured itemIdFn below, so the blob baseline and itemRow overlay use the
+// same freshness policy.
 
 // id-keyed arrays inside importedData. Each key is a dotted path; nested
 // arrays inside lightEnvironment go through a tiny accessor helper.
@@ -39,12 +43,16 @@ export const ID_KEYED_ARRAYS = [
   'lightEnvironment.screens',
 ];
 
+export const NATURAL_KEYED_ARRAYS = Object.keys(DELTA_ARRAY_CONFIG)
+  .filter(path => path !== 'entries' && path !== 'changeHistory');
+
 // `_deleted[path]` tombstones can apply to id-keyed arrays and to select
 // natural-key arrays that have a stable sync item id. Lab entries are keyed by
 // collection date in the per-row sync layer, so a deleted import date needs a
 // tombstone or a peer's still-live row can resurrect it before our next push.
 export const TOMBSTONE_ARRAY_PATHS = [
   ...ID_KEYED_ARRAYS,
+  ...NATURAL_KEYED_ARRAYS,
   'entries',
 ];
 
@@ -79,39 +87,64 @@ export const FRESH_LOCAL_LAB_ENTRY_TTL_MS = 2 * 60 * 1000;
 const TOMBSTONE_META_KEY = '_deletedAt';
 const TOMBSTONE_CLEAR_META_KEY = '_deletedClearedAt';
 
-// Pick a comparable timestamp for conflict resolution. Higher wins.
-// Tries the most recently-edited signal first, falls back through the
-// usual creation timestamps. Returns 0 if nothing recognizable found —
-// the function is permissive so foreign records (older schemas) merge
-// instead of throwing.
-//
-// Returns { ts, explicit }: explicit=true when the value came from an
-// edit-time field (updatedAt/endedAt/startedAt/etc); false when it's
-// just a Date.parse(rec.date) fallback. Callers comparing two records
-// from the same composite key should prefer explicit over implicit on
-// tie-break — a record with no explicit stamp must lose to one with
-// any explicit stamp (otherwise old un-stamped entries permanently
-// shadow newer cross-device edits).
+const TIMESTAMP_FIELDS = [
+  'updatedAt',
+  'endedAt',
+  'startedAt',
+  'capturedAt',
+  'takenAt',
+  'savedAt',
+  'loggedAt',
+  'createdAt',
+  'addedAt',
+  'at',
+];
+
+function normalizeTimestamp(value) {
+  if (Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+// Pick a comparable timestamp for conflict resolution. Higher wins. Tries
+// the most recently-edited signal first, then creation/capture fields that
+// several synced array surfaces use. Returns 0 if nothing recognizable is
+// present so older/foreign records can still merge without throwing.
 export function pickTimestamp(rec) {
   if (!rec || typeof rec !== 'object') return 0;
-  const t = rec.updatedAt
-    ?? rec.endedAt
-    ?? rec.startedAt
-    ?? rec.capturedAt
-    ?? rec.loggedAt
-    ?? rec.createdAt
-    ?? rec.at;
-  if (Number.isFinite(t)) return t;
+  for (const field of TIMESTAMP_FIELDS) {
+    const ts = normalizeTimestamp(rec[field]);
+    if (ts !== null) return ts;
+  }
   if (typeof rec.date === 'string') {
     const parsed = Date.parse(rec.date);
     return Number.isFinite(parsed) ? parsed : 0;
   }
   return 0;
 }
+
+// Shared freshness ordering for id-keyed array records. Positive means `a`
+// is newer than `b`, negative means older, zero means no winner. Callers
+// intentionally treat zero as "keep the local/current record" so a stale
+// pull cannot undo a just-saved local edit when timestamps tie or are absent.
+export function compareRecordFreshness(a, b) {
+  const aTs = pickTimestamp(a);
+  const bTs = pickTimestamp(b);
+  if (aTs > bTs) return 1;
+  if (aTs < bTs) return -1;
+  return 0;
+}
+
+export function pickFresherRecord(current, candidate) {
+  return compareRecordFreshness(candidate, current) > 0 ? candidate : current;
+}
+
 function hasExplicitTimestamp(rec) {
   if (!rec || typeof rec !== 'object') return false;
-  return Number.isFinite(rec.updatedAt ?? rec.endedAt ?? rec.startedAt
-    ?? rec.capturedAt ?? rec.loggedAt ?? rec.createdAt ?? rec.at);
+  return TIMESTAMP_FIELDS.some(field => normalizeTimestamp(rec[field]) !== null);
 }
 
 function mergePlainMap(localMap, remoteMap) {
@@ -288,32 +321,45 @@ export function setAt(obj, path, value) {
   cur[parts[parts.length - 1]] = value;
 }
 
-// Union two arrays by record `id`. Records lacking an `id` are kept from
-// both sides (no dedup possible). Tombstones is a Set of ids to drop.
-export function unionById(localArr, remoteArr, tombstones) {
+function naturalItemId(path, item) {
+  const itemIdFn = DELTA_ARRAY_CONFIG[path]?.itemIdFn;
+  if (typeof itemIdFn !== 'function') return null;
+  const id = itemIdFn(item);
+  return _isAllowlistSafeId(id) ? id : null;
+}
+
+function unionByItemId(localArr, remoteArr, tombstones, itemIdFn) {
   const tomb = tombstones instanceof Set ? tombstones : new Set(tombstones || []);
   const byId = new Map();
   const noId = [];
 
   function consider(item) {
     if (!item || typeof item !== 'object') return;
-    if (typeof item.id === 'string') {
-      if (tomb.has(item.id)) return; // tombstoned — drop
-      const existing = byId.get(item.id);
-      if (!existing) { byId.set(item.id, item); return; }
-      // Conflict — pick the record with the higher timestamp.
-      const lTs = pickTimestamp(existing);
-      const rTs = pickTimestamp(item);
-      byId.set(item.id, rTs > lTs ? item : existing);
-    } else {
+    const id = itemIdFn(item);
+    if (typeof id !== 'string') {
       noId.push(item);
+      return;
     }
+    if (tomb.has(id)) return; // tombstoned — drop
+    const existing = byId.get(id);
+    if (!existing) { byId.set(id, item); return; }
+    // Conflict — pick the fresher record. Existing/current wins ties so a
+    // stale pull cannot revert local data when timestamps are equal/missing.
+    byId.set(id, pickFresherRecord(existing, item));
   }
 
   if (Array.isArray(localArr))  for (const it of localArr)  consider(it);
   if (Array.isArray(remoteArr)) for (const it of remoteArr) consider(it);
 
   return [...byId.values(), ...noId];
+}
+
+// Union two arrays by record `id`. Records lacking an `id` are kept from
+// both sides (no dedup possible). Tombstones is a Set of ids to drop.
+export function unionById(localArr, remoteArr, tombstones) {
+  return unionByItemId(localArr, remoteArr, tombstones, item => (
+    item && typeof item.id === 'string' ? item.id : null
+  ));
 }
 
 // Merge tombstones plus explicit "clear" markers. The clear metadata is what
@@ -488,6 +534,20 @@ export function mergeImportedData(local, remote) {
     }
   }
 
+  // Natural-keyed per-row arrays (supplements, goals, notes, chat summaries)
+  // lack `.id` but do have stable itemIdFn definitions in the delta registry.
+  // Merge them before the itemRow overlay so a stale remote blob cannot wipe a
+  // fresher local edit before the row-level freshness guard sees it.
+  for (const path of NATURAL_KEYED_ARRAYS) {
+    const localArr  = getAt(local,  path);
+    const remoteArr = getAt(remote, path);
+    if (!Array.isArray(localArr) && !Array.isArray(remoteArr)) continue;
+
+    const tomb = new Set(mergedDel[path] || []);
+    const merged = unionByItemId(localArr, remoteArr, tomb, item => naturalItemId(path, item));
+    setAt(out, path, merged);
+  }
+
   // Composite-keyed arrays (changeHistory etc.) — dedup by composite key,
   // cap to the configured per-array max. Without this, the merge would
   // double the array on every cross-device pull (no `id` for unionById to
@@ -605,9 +665,26 @@ export function localHasRowsRemoteLacks(local, remote) {
       //     strictly higher canonical timestamp. Same logic mergeImportedData
       //     uses to pick a winner; mirroring it here keeps the rebroadcast
       //     decision aligned with what the merge actually did.
-      const lTs = pickTimestamp(item);
-      const rTs = pickTimestamp(remoteItem);
-      if (lTs > rTs) return true;
+      if (compareRecordFreshness(item, remoteItem) > 0) return true;
+    }
+  }
+  for (const path of NATURAL_KEYED_ARRAYS) {
+    const lArr = getAt(local, path);
+    const rArr = getAt(remote, path);
+    if (!Array.isArray(lArr)) continue;
+    const remoteById = new Map();
+    if (Array.isArray(rArr)) {
+      for (const item of rArr) {
+        const id = naturalItemId(path, item);
+        if (id) remoteById.set(id, item);
+      }
+    }
+    for (const item of lArr) {
+      const id = naturalItemId(path, item);
+      if (!id) continue;
+      const remoteItem = remoteById.get(id);
+      if (!remoteItem) return true;
+      if (compareRecordFreshness(item, remoteItem) > 0) return true;
     }
   }
   // (3) Tombstones on local but not on remote also need rebroadcast so

--- a/js/notes.js
+++ b/js/notes.js
@@ -2,6 +2,10 @@
 import { state } from './state.js';
 import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
+import {
+  getConfiguredArrayItemId,
+  recordArrayItemTombstone,
+} from './data-merge.js';
 
 export function openNoteEditor(date, existingIdx) {
   const modal = document.getElementById("detail-modal");
@@ -39,10 +43,17 @@ export function saveNote(idx) {
   if (!date) { showNotification('Please select a date', 'error'); return; }
   if (!text) { showNotification('Please enter note text', 'error'); return; }
   if (!state.importedData.notes) state.importedData.notes = [];
+  const nextNote = { date, text };
   if (idx !== null && idx !== undefined) {
-    state.importedData.notes[idx] = { date, text };
+    const existing = state.importedData.notes[idx];
+    const existingId = getConfiguredArrayItemId('notes', existing);
+    const nextId = getConfiguredArrayItemId('notes', nextNote);
+    if (existingId && existingId !== nextId) {
+      recordArrayItemTombstone(state.importedData, 'notes', existing);
+    }
+    state.importedData.notes[idx] = nextNote;
   } else {
-    state.importedData.notes.push({ date, text });
+    state.importedData.notes.push(nextNote);
   }
   saveImportedData();
   window.closeModal();
@@ -54,6 +65,7 @@ export function saveNote(idx) {
 export async function deleteNote(idx) {
   if (!state.importedData.notes) return;
   if (await showConfirmDialog("Delete this note? This can't be undone.")) {
+    recordArrayItemTombstone(state.importedData, 'notes', state.importedData.notes[idx]);
     state.importedData.notes.splice(idx, 1);
     saveImportedData();
     window.closeModal();

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -559,7 +559,7 @@ export function saveSupplement(idx) {
     }
   }
   if (!state.importedData.supplements) state.importedData.supplements = [];
-  const entry = { name, dosage, startDate, endDate, type, note };
+  const entry = { name, dosage, startDate, endDate, type, note, updatedAt: Date.now() };
   if (sorted.length > 1) entry.periods = sorted;
   if (ingredients) entry.ingredients = ingredients;
   if (isFinite(timesNum) && timesNum > 0) entry.timesPerDay = timesNum;

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -3,6 +3,10 @@
 import { state } from './state.js';
 import { escapeHTML, showNotification, isDebugMode } from './utils.js';
 import { saveImportedData } from './data.js';
+import {
+  getConfiguredArrayItemId,
+  recordArrayItemTombstone,
+} from './data-merge.js';
 import { callClaudeAPI, hasAIProvider, supportsVision } from './api.js';
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
@@ -565,6 +569,12 @@ export function saveSupplement(idx) {
   if (isFinite(timesNum) && timesNum > 0) entry.timesPerDay = timesNum;
   if (parsedSourceUrl) entry.sourceUrl = parsedSourceUrl.toString();
   if (idx >= 0) {
+    const existing = state.importedData.supplements[idx];
+    const existingId = getConfiguredArrayItemId('supplements', existing);
+    const nextId = getConfiguredArrayItemId('supplements', entry);
+    if (existingId && existingId !== nextId) {
+      recordArrayItemTombstone(state.importedData, 'supplements', existing);
+    }
     state.importedData.supplements[idx] = entry;
   } else {
     state.importedData.supplements.push(entry);
@@ -582,6 +592,7 @@ export function saveSupplement(idx) {
 export function deleteSupplement(idx) {
   if (!state.importedData.supplements || !state.importedData.supplements[idx]) return;
   const name = state.importedData.supplements[idx].name;
+  recordArrayItemTombstone(state.importedData, 'supplements', state.importedData.supplements[idx]);
   state.importedData.supplements.splice(idx, 1);
   saveImportedData();
   showNotification(`"${name}" removed`, 'info');

--- a/js/sync-delta-array-merge.js
+++ b/js/sync-delta-array-merge.js
@@ -1,6 +1,13 @@
 // sync-delta-array-merge.js - Pull-side array row overlay helper.
 
-import { COMPOSITE_KEYED_ARRAYS, pickTimestamp, getAt, setAt, mergeLabEntry } from './data-merge.js';
+import {
+  COMPOSITE_KEYED_ARRAYS,
+  compareRecordFreshness,
+  pickTimestamp,
+  getAt,
+  setAt,
+  mergeLabEntry,
+} from './data-merge.js';
 import { recordPullDeltaSurface } from './sync-delta-observability.js';
 import {
   DELTA_ARRAY_CONFIG,
@@ -105,9 +112,9 @@ export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
         continue;
       }
       // The blob merge may already contain a fresh local edit that has not
-      // reached the per-row relay yet. Keep that winner instead of letting a
-      // stale itemRow undo the edit on the immediate pull-after-save tick.
-      if (pickTimestamp(nextArr[idx]) > entry.ts) continue;
+      // reached the per-row relay yet. Keep current on ties too; this must
+      // match unionById/localHasRowsRemoteLacks in data-merge.js.
+      if (compareRecordFreshness(item, nextArr[idx]) <= 0) continue;
       nextArr[idx] = item;
     }
     else nextArr.push(item);
@@ -118,11 +125,7 @@ export async function mergeArrayRowsIntoImported(imported, arrayName, arrRows) {
   const cap = COMPOSITE_KEYED_ARRAYS.find(c => c.path === arrayName)?.cap;
   const cappedArr = readArr();
   if (cap && cappedArr.length > cap) {
-    const trimmed = cappedArr.slice().sort((a, b) => {
-      const ta = a?.updatedAt ?? a?.createdAt ?? a?.at ?? (typeof a?.date === 'string' ? Date.parse(a.date) : 0) ?? 0;
-      const tb = b?.updatedAt ?? b?.createdAt ?? b?.at ?? (typeof b?.date === 'string' ? Date.parse(b.date) : 0) ?? 0;
-      return tb - ta;
-    });
+    const trimmed = cappedArr.slice().sort((a, b) => pickTimestamp(b) - pickTimestamp(a));
     writeArr(trimmed.slice(0, cap));
   }
   recordPullDeltaSurface(arrayName, { live: liveById.size, tombstones: localTombs.size + remoteTombs.size });

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -20,6 +20,7 @@ const {
   mergeImportedData,
   preserveFreshLocalLabEntries,
   recordTombstone,
+  recordArrayItemTombstone,
   clearTombstone,
   unionById,
   ID_KEYED_ARRAYS,
@@ -313,6 +314,42 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
     notesUnion.notes.length === 2
       && notesUnion.notes.some(n => n.text === 'Local note')
       && notesUnion.notes.some(n => n.text === 'Remote note'));
+  const oldNote = { date: '2026-05-01', text: 'Original note' };
+  const editedNote = { date: '2026-05-01', text: 'Edited note' };
+  const editedNoteLocal = { notes: [editedNote] };
+  recordArrayItemTombstone(editedNoteLocal, 'notes', oldNote);
+  const mergedEditedNote = mergeImportedData(editedNoteLocal, { notes: [oldNote] });
+  assert('notes identity edit tombstone prevents old text ghost duplicate',
+    mergedEditedNote.notes.length === 1
+      && mergedEditedNote.notes[0].text === 'Edited note');
+  const renamedSupplementLocal = {
+    supplements: [{
+      name: 'Magnesium glycinate',
+      startDate: '2026-05-01',
+      type: 'supplement',
+      dosage: '200 mg',
+      updatedAt: 6_000_000,
+    }],
+  };
+  recordArrayItemTombstone(renamedSupplementLocal, 'supplements', {
+    name: 'Magnesium',
+    startDate: '2026-05-01',
+    type: 'supplement',
+    dosage: '200 mg',
+    updatedAt: 5_000_000,
+  });
+  const mergedRenamedSupplement = mergeImportedData(renamedSupplementLocal, {
+    supplements: [{
+      name: 'Magnesium',
+      startDate: '2026-05-01',
+      type: 'supplement',
+      dosage: '200 mg',
+      updatedAt: 5_000_000,
+    }],
+  });
+  assert('supplement identity edit tombstone prevents old-name ghost duplicate',
+    mergedRenamedSupplement.supplements.length === 1
+      && mergedRenamedSupplement.supplements[0].name === 'Magnesium glycinate');
   const healthGoalLocal = { healthGoals: [{ text: 'Lower CRP', severity: 'major', updatedAt: 5_000_000 }] };
   await mergeArrayRowsIntoImported(healthGoalLocal, 'healthGoals', [{
     itemId: DELTA_ARRAY_CONFIG.healthGoals.itemIdFn({ text: 'Lower CRP', severity: 'minor' }),

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -16,17 +16,21 @@ console.log('=== Data Merge Tests ===\n');
 globalThis.window = globalThis.window || {};
 
 const {
+  compareRecordFreshness,
   mergeImportedData,
   preserveFreshLocalLabEntries,
   recordTombstone,
   clearTombstone,
   unionById,
   ID_KEYED_ARRAYS,
+  NATURAL_KEYED_ARRAYS,
   TOMBSTONE_ARRAY_PATHS,
   localHasRowsRemoteLacks,
   pickTimestamp,
+  pickFresherRecord,
 } = await import('../js/data-merge.js');
 const { mergeArrayRowsIntoImported } = await import('../js/sync-delta-array-merge.js');
+const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js');
 
   // ─── pickTimestamp precedence (v1.7.20) ───────────────────────────────
   // Direct test for the field-precedence walk used by every cross-device
@@ -47,6 +51,10 @@ const { mergeArrayRowsIntoImported } = await import('../js/sync-delta-array-merg
     pickTimestamp({ loggedAt: 30 }) === 30 &&
     pickTimestamp({ createdAt: 20 }) === 20 &&
     pickTimestamp({ at: 10 }) === 10);
+  assert('createdAt ISO strings are parsed for chat-summary freshness',
+    pickTimestamp({ createdAt: '2026-05-31T04:00:00.000Z' }) === Date.parse('2026-05-31T04:00:00.000Z'));
+  assert('takenAt and addedAt are recognized for light tools/devices',
+    pickTimestamp({ takenAt: 70 }) === 70 && pickTimestamp({ addedAt: 80 }) === 80);
   assert('falls back to Date.parse(date) when no numeric field',
     pickTimestamp({ date: '2026-04-15' }) === Date.parse('2026-04-15'));
   assert('returns 0 on totally bare record', pickTimestamp({}) === 0);
@@ -54,11 +62,21 @@ const { mergeArrayRowsIntoImported } = await import('../js/sync-delta-array-merg
     pickTimestamp({ updatedAt: NaN, date: '2026-04-15' }) === Date.parse('2026-04-15'));
   assert('zero updatedAt is honored (epoch — not falsy fallthrough)',
     pickTimestamp({ updatedAt: 0, endedAt: 200 }) === 0);
+  assert('compareRecordFreshness reports newer/older/equal',
+    compareRecordFreshness({ updatedAt: 20 }, { updatedAt: 10 }) === 1
+      && compareRecordFreshness({ updatedAt: 10 }, { updatedAt: 20 }) === -1
+      && compareRecordFreshness({ updatedAt: 10 }, { updatedAt: 10 }) === 0);
+  assert('pickFresherRecord keeps current record on timestamp tie',
+    pickFresherRecord({ id: 'tie', value: 'current', updatedAt: 10 }, { id: 'tie', value: 'candidate', updatedAt: 10 }).value === 'current');
 
   // ─── 1. Coverage of known arrays ──────────────────────────────────────
   console.log('%c 1. ID_KEYED_ARRAYS coverage ', 'font-weight:bold;color:#f59e0b');
   for (const path of ['sunSessions','deviceSessions','lightDevices','lightMeasurements','lightEnvironment.rooms','lightEnvironment.screens']) {
     assert(`covers ${path}`, ID_KEYED_ARRAYS.includes(path));
+  }
+  for (const path of ['supplements','healthGoals','notes','chatSummaries']) {
+    assert(`natural-key merge covers ${path}`, NATURAL_KEYED_ARRAYS.includes(path));
+    assert(`tombstone path covers ${path}`, TOMBSTONE_ARRAY_PATHS.includes(path));
   }
   assert('entries is an explicit tombstone path', TOMBSTONE_ARRAY_PATHS.includes('entries'));
 
@@ -212,6 +230,121 @@ const { mergeArrayRowsIntoImported } = await import('../js/sync-delta-array-merg
   assert('newer per-row deviceSession still updates local copy',
     editedDeviceSession.deviceSessions[0].durationMin === 25
       && editedDeviceSession.deviceSessions[0].doses?.circadian === 250);
+  const magnesiumV1 = {
+    name: 'Magnesium',
+    startDate: '2026-05-01',
+    type: 'supplement',
+    dosage: '100 mg',
+    updatedAt: 1_000_000,
+  };
+  const magnesiumId = DELTA_ARRAY_CONFIG.supplements.itemIdFn(magnesiumV1);
+  const editedSupplement = {
+    supplements: [{
+      name: 'Magnesium',
+      startDate: '2026-05-01',
+      type: 'supplement',
+      dosage: '200 mg',
+      updatedAt: 2_000_000,
+    }],
+  };
+  await mergeArrayRowsIntoImported(editedSupplement, 'supplements', [{
+    itemId: magnesiumId,
+    syncedAt: new Date(1_500_000).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify(magnesiumV1),
+  }]);
+  assert('stale per-row supplement does not revert fresh local stable-id edit',
+    editedSupplement.supplements[0].dosage === '200 mg');
+  await mergeArrayRowsIntoImported(editedSupplement, 'supplements', [{
+    itemId: magnesiumId,
+    syncedAt: new Date(2_500_000).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      name: 'Magnesium',
+      startDate: '2026-05-01',
+      type: 'supplement',
+      dosage: '300 mg',
+      updatedAt: 3_000_000,
+    }),
+  }]);
+  assert('newer per-row supplement still updates stable-id local copy',
+    editedSupplement.supplements[0].dosage === '300 mg');
+  const zincRemote = { name: 'Zinc', startDate: '2026-05-02', type: 'supplement', dosage: '10 mg' };
+  const tieSupplement = {
+    supplements: [{ name: 'Zinc', startDate: '2026-05-02', type: 'supplement', dosage: '15 mg' }],
+  };
+  await mergeArrayRowsIntoImported(tieSupplement, 'supplements', [{
+    itemId: DELTA_ARRAY_CONFIG.supplements.itemIdFn(zincRemote),
+    syncedAt: new Date(4_000_000).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify(zincRemote),
+  }]);
+  assert('timestamp tie keeps current stable-id array item instead of reverting',
+    tieSupplement.supplements[0].dosage === '15 mg');
+  const blobSupplementLocal = {
+    supplements: [{
+      name: 'Magnesium',
+      startDate: '2026-05-01',
+      type: 'supplement',
+      dosage: '400 mg',
+      updatedAt: 5_000_000,
+    }],
+  };
+  const blobSupplementRemote = {
+    supplements: [{
+      name: 'Magnesium',
+      startDate: '2026-05-01',
+      type: 'supplement',
+      dosage: '100 mg',
+      updatedAt: 1_000_000,
+    }],
+  };
+  const mergedSupplementBlob = mergeImportedData(blobSupplementLocal, blobSupplementRemote);
+  assert('blob merge preserves fresher local natural-key supplement before row overlay',
+    mergedSupplementBlob.supplements.length === 1
+      && mergedSupplementBlob.supplements[0].dosage === '400 mg');
+  assert('localHasRowsRemoteLacks detects natural-key supplement timestamp drift',
+    localHasRowsRemoteLacks(blobSupplementLocal, blobSupplementRemote) === true);
+  const notesUnion = mergeImportedData(
+    { notes: [{ date: '2026-05-01', text: 'Local note' }] },
+    { notes: [{ date: '2026-05-02', text: 'Remote note' }] },
+  );
+  assert('natural-key notes merge additively instead of whole-array LWW',
+    notesUnion.notes.length === 2
+      && notesUnion.notes.some(n => n.text === 'Local note')
+      && notesUnion.notes.some(n => n.text === 'Remote note'));
+  const healthGoalLocal = { healthGoals: [{ text: 'Lower CRP', severity: 'major', updatedAt: 5_000_000 }] };
+  await mergeArrayRowsIntoImported(healthGoalLocal, 'healthGoals', [{
+    itemId: DELTA_ARRAY_CONFIG.healthGoals.itemIdFn({ text: 'Lower CRP', severity: 'minor' }),
+    syncedAt: new Date(4_000_000).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({ text: 'Lower CRP', severity: 'minor', updatedAt: 1_000_000 }),
+  }]);
+  assert('stale per-row health goal does not revert fresh local severity',
+    healthGoalLocal.healthGoals[0].severity === 'major');
+  const chatSummaryLocal = {
+    chatSummaries: [{
+      id: 's_local',
+      threadId: 't_lab',
+      threadName: 'Lab',
+      content: 'Fresh',
+      createdAt: '2026-05-31T04:00:00.000Z',
+    }],
+  };
+  await mergeArrayRowsIntoImported(chatSummaryLocal, 'chatSummaries', [{
+    itemId: DELTA_ARRAY_CONFIG.chatSummaries.itemIdFn({ threadId: 't_lab' }),
+    syncedAt: '2026-05-31T04:01:00.000Z',
+    isDeleted: 0,
+    payload: JSON.stringify({
+      id: 's_remote',
+      threadId: 't_lab',
+      threadName: 'Lab',
+      content: 'Stale',
+      createdAt: '2026-05-31T03:00:00.000Z',
+    }),
+  }]);
+  assert('stale per-row chat summary respects ISO createdAt freshness',
+    chatSummaryLocal.chatSummaries[0].content === 'Fresh');
   const freshNow = 2_000_000;
   const stalePulledImport = {
     entries: [{

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -954,7 +954,7 @@ await import('../js/settings.js');
   assert('_mergeItemRowsIntoImported ignores stale remote tombstones when local item is newer',
     /remoteTombs\.set\(row\.itemId[\s\S]{0,1200}tombAt\s*>=\s*pickTimestamp\(item\)/.test(syncDeltaArrayMergeSrc));
   assert('_mergeItemRowsIntoImported preserves fresher local non-lab items over stale per-row payloads',
-    /pickTimestamp\(nextArr\[idx\]\)\s*>\s*entry\.ts[\s\S]{0,120}continue/.test(syncDeltaArrayMergeSrc)
+    /compareRecordFreshness\(item,\s*nextArr\[idx\]\)\s*<=\s*0[\s\S]{0,120}continue/.test(syncDeltaArrayMergeSrc)
       && /nextArr\[idx\]\s*=\s*item/.test(syncDeltaArrayMergeSrc));
   assert('_mergeItemRowsIntoImported merges same-date lab entries instead of replacing marker maps',
     /import\s*\{[^}]*mergeLabEntry[^}]*\}\s*from\s*['"]\.\/data-merge\.js['"]/.test(syncDeltaArrayMergeSrc)
@@ -2171,8 +2171,8 @@ await import('../js/settings.js');
     await fetchWithRetry('js/data-merge.js').then(s => /export const COMPOSITE_KEYED_ARRAYS/.test(s)));
   assert('Per-row array overlay re-applies cap after merge',
     /COMPOSITE_KEYED_ARRAYS\.find\(c\s*=>\s*c\.path\s*===\s*arrayName\)\?\.cap[\s\S]{0,500}writeArr\(trimmed\.slice\(0,\s*cap\)\)/.test(deltaSearchSrc));
-  assert('Cap trim sorts newest-first by updatedAt/createdAt/date',
-    /cappedArr\.slice\(\)\.sort[\s\S]{0,400}updatedAt[\s\S]{0,100}createdAt[\s\S]{0,100}Date\.parse\(a\.date\)/.test(deltaSearchSrc));
+  assert('Cap trim sorts newest-first through shared pickTimestamp',
+    /cappedArr\.slice\(\)\.sort\(\(a,\s*b\)\s*=>\s*pickTimestamp\(b\)\s*-\s*pickTimestamp\(a\)\)/.test(deltaSearchSrc));
   assert('Cap trim uses nested-path array helpers instead of imported[arrayName]',
     /const cappedArr\s*=\s*readArr\(\)[\s\S]{0,500}writeArr\(trimmed\.slice\(0,\s*cap\)\)/.test(deltaSearchSrc)
       && !/const cap = COMPOSITE_KEYED_ARRAYS\.find[\s\S]{0,500}imported\[arrayName\]/.test(syncDeltaMergeSrc));
@@ -2941,9 +2941,16 @@ await import('../js/settings.js');
     // Inline the helper logic — we can't import data-merge.js from a
     // Puppeteer-driven test page, but the logic is small enough to re-check.
     const pickTs = (rec) => {
-      const t = rec?.updatedAt ?? rec?.endedAt ?? rec?.startedAt
-        ?? rec?.capturedAt ?? rec?.loggedAt ?? rec?.createdAt ?? rec?.at;
-      return Number.isFinite(t) ? t : 0;
+      for (const field of ['updatedAt', 'endedAt', 'startedAt', 'capturedAt', 'takenAt', 'savedAt', 'loggedAt', 'createdAt', 'addedAt', 'at']) {
+        const value = rec?.[field];
+        if (Number.isFinite(value)) return value;
+        if (typeof value === 'string' && value.trim()) {
+          const parsed = Date.parse(value);
+          if (Number.isFinite(parsed)) return parsed;
+        }
+      }
+      const parsedDate = typeof rec?.date === 'string' ? Date.parse(rec.date) : NaN;
+      return Number.isFinite(parsedDate) ? parsedDate : 0;
     };
     const detect = (local, remote) => {
       // Mirror localHasRowsRemoteLacks for sunSessions only — that's the

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.290';
+self.APP_VERSION = '1.8.291';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.289';
+self.APP_VERSION = '1.8.290';


### PR DESCRIPTION
## Summary
- Centralize record freshness comparison for sync merges, including ISO timestamps and additional timestamp fields.
- Apply the same freshness policy to blob merges, per-row array overlays, and natural-keyed arrays such as supplements, health goals, notes, and chat summaries.
- Stamp supplement and health-goal writes with `updatedAt` so stable-id edits are not tied forever.

## Root cause
A stale per-row or blob sync payload could still win in some paths because freshness handling was split across callers and some stable-id array records had no usable edit timestamp. That let a remote pull revert a fresh local edit and show the "Data updated from another device" notification.

## Validation
- `node tests/test-data-merge.js` - 114 passed
- `node tests/test-sync.js` - 732 passed
- `git diff --check`
- `./run-tests.sh` - all passed, including Theme Responsive E2E 472/472