### PR TITLE
[codex] Centralize sync-aware array mutations

### DIFF
--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -1552,6 +1552,7 @@ Not separately documented because their exports are best read from source — ke
 - `sync-pull-maintenance.js` — pull-path one-time migrations such as stale `-sync-hash` localStorage cleanup.
 - `sync-pull-active-refresh.js` — active-profile in-memory update, migration, chat reload, sidebar rebuild, current-view refresh, toast, and sync-applied event after a pull.
 - `sync-pull-rebroadcast.js` — pull-side rebroadcast gating, budget checks, push-pending guard, and delayed active-profile push scheduling.
+- `data-merge.js` — importedData blob merge helpers, shared record freshness comparison, tombstone state merge, and sync-aware array mutation helpers (`appendImportedArrayItem`, `replaceImportedArrayItem`, `deleteImportedArrayItem`, `deleteImportedArrayItems`, `clearImportedArray`) used by feature modules so identity edits/deletes record the right tombstones before the next sync push.
 - `sync-cutover.js` — readiness-gated Phase 2 lean-sync cutover enable/disable bridge over payload flags and delta readiness.
 - `sync-delta.js` — per-row CRDT delta facade; config fan-out, apply helpers, and compatibility re-exports for planners, snapshots, merge, telemetry, and readiness.
 - `sync-delta-planners.js` — push-side planner facade; configures shared planner dependency context and compatibility re-exports for array/map/scalar planners.

--- a/js/chat-history.js
+++ b/js/chat-history.js
@@ -3,7 +3,7 @@
 import { state } from './state.js';
 import { encryptedSetItem, encryptedGetItem, getEncryptionEnabled } from './crypto.js';
 import { saveImportedData } from './data.js';
-import { recordArrayItemTombstone } from './data-merge.js';
+import { deleteImportedArrayItems } from './data-merge.js';
 import { showConfirmDialog, showNotification } from './utils.js';
 import {
   getChatThreadKey, invalidateThreadContentCache,
@@ -69,10 +69,7 @@ export async function clearChatHistory() {
         saveChatThreadIndex();
         renderThreadList();
         if (state.importedData.chatSummaries) {
-          for (const summary of state.importedData.chatSummaries.filter(s => s.threadId === state.currentThreadId)) {
-            recordArrayItemTombstone(state.importedData, 'chatSummaries', summary);
-          }
-          state.importedData.chatSummaries = state.importedData.chatSummaries.filter(s => s.threadId !== state.currentThreadId);
+          deleteImportedArrayItems(state.importedData, 'chatSummaries', s => s.threadId === state.currentThreadId);
           saveImportedData();
         }
         renderSavedSummaries();

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -7,7 +7,12 @@ import { saveImportedData } from './data.js';
 import { callClaudeAPI, getActiveModelDisplay, getActiveModelId, getAIProvider, hasAIProvider, isAIPaused } from './api.js';
 import { renderThreadList, saveChatThreadIndex } from './chat-threads.js';
 import { renderMarkdown } from './markdown.js';
-import { recordArrayItemTombstone } from './data-merge.js';
+import {
+  appendImportedArrayItem,
+  deleteImportedArrayItems,
+  ensureImportedArray,
+  replaceImportedArrayItem,
+} from './data-merge.js';
 
 const SUMMARY_PROMPT = `You are a concise medical note-taker. Summarize this health consultation into a structured note.
 
@@ -159,13 +164,13 @@ function _getSavedSummaries() {
 }
 
 async function _saveSummaryToProfile(summary) {
-  if (!state.importedData.chatSummaries) state.importedData.chatSummaries = [];
-  const idx = state.importedData.chatSummaries.findIndex(s => s.threadId === summary.threadId);
+  const summaries = ensureImportedArray(state.importedData, 'chatSummaries');
+  const idx = summaries.findIndex(s => s.threadId === summary.threadId);
   if (idx >= 0) {
-    summary.id = state.importedData.chatSummaries[idx].id;
-    state.importedData.chatSummaries[idx] = summary;
+    summary.id = summaries[idx].id;
+    replaceImportedArrayItem(state.importedData, 'chatSummaries', idx, summary);
   } else {
-    state.importedData.chatSummaries.push(summary);
+    appendImportedArrayItem(state.importedData, 'chatSummaries', summary);
   }
   await saveImportedData();
 }
@@ -176,9 +181,7 @@ function _getLatestSavedSummary(threadId) {
 
 export async function deleteSavedSummary(id) {
   if (!state.importedData.chatSummaries) return;
-  const summary = state.importedData.chatSummaries.find(s => s.id === id);
-  recordArrayItemTombstone(state.importedData, 'chatSummaries', summary);
-  state.importedData.chatSummaries = state.importedData.chatSummaries.filter(s => s.id !== id);
+  deleteImportedArrayItems(state.importedData, 'chatSummaries', s => s.id === id);
   await saveImportedData();
   renderSavedSummaries();
   _closeSummaryModal();

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -179,6 +179,24 @@ function _getLatestSavedSummary(threadId) {
   return _getSavedSummaries().find(s => s.threadId === threadId);
 }
 
+function refreshOpenSummaryModalOnSync() {
+  const overlay = document.getElementById('summary-modal-overlay');
+  if (!overlay?.classList?.contains('show') || overlay.dataset.syncRefreshKind !== 'chat-summary') return;
+  const id = overlay.dataset.syncRefreshSummaryId || '';
+  renderSavedSummaries();
+  if (!id) return;
+  const summary = _getSavedSummaries().find(s => s.id === id);
+  if (summary) {
+    viewSavedSummary(id);
+  } else {
+    _closeSummaryModal();
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('labcharts-sync-applied', refreshOpenSummaryModalOnSync);
+}
+
 export async function deleteSavedSummary(id) {
   if (!state.importedData.chatSummaries) return;
   deleteImportedArrayItems(state.importedData, 'chatSummaries', s => s.id === id);
@@ -234,6 +252,8 @@ function _showSummaryModal(summaryText, thread, loading = false, usageInfo = nul
   } else {
     overlay.className = 'modal-overlay show';
   }
+  overlay.dataset.syncRefreshKind = 'chat-summary';
+  overlay.dataset.syncRefreshSummaryId = thread?._savedId || '';
 
   const threadName = thread ? escapeHTML(thread.name) : 'Conversation';
   const dateStr = thread?.summaryDate ? new Date(thread.summaryDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '';

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -23,7 +23,7 @@
 import { state } from './state.js';
 import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
-import { recordArrayItemTombstone } from './data-merge.js';
+import { deleteImportedArrayItems } from './data-merge.js';
 import { onChatSaved } from './sync.js';
 import { chatDeletedThreadsKey } from './sync-payload-collectors.js';
 import { CHAT_PERSONALITIES } from './constants.js';
@@ -190,10 +190,7 @@ export async function deleteThread(threadId) {
     localStorage.removeItem(getChatThreadKey(threadId));
     // Remove saved summary
     if (state.importedData.chatSummaries) {
-      for (const summary of state.importedData.chatSummaries.filter(s => s.threadId === threadId)) {
-        recordArrayItemTombstone(state.importedData, 'chatSummaries', summary);
-      }
-      state.importedData.chatSummaries = state.importedData.chatSummaries.filter(s => s.threadId !== threadId);
+      deleteImportedArrayItems(state.importedData, 'chatSummaries', s => s.threadId === threadId);
       saveImportedData();
     }
     window.renderSavedSummaries?.();

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -59,7 +59,10 @@ import {
 import { escapeHTML, showNotification } from './utils.js';
 import { formatTime, getTimeFormat, parseTimeInput } from './theme.js';
 import { saveImportedData } from './data.js';
-import { recordArrayItemTombstone } from './data-merge.js';
+import {
+  clearImportedArray,
+  deleteImportedArrayItem,
+} from './data-merge.js';
 import { getLatitudeFromLocation } from './profile.js';
 import { scanDietForContaminants } from './food-contaminants.js';
 import {
@@ -570,8 +573,7 @@ export function addHealthGoal() {
 
 export function deleteHealthGoal(idx) {
   if (!state.importedData.healthGoals) return;
-  recordArrayItemTombstone(state.importedData, 'healthGoals', state.importedData.healthGoals[idx]);
-  state.importedData.healthGoals.splice(idx, 1);
+  deleteImportedArrayItem(state.importedData, 'healthGoals', idx);
   recordContextChange('healthGoals');
   saveImportedData();
   renderHealthGoalsModal(document.getElementById("detail-modal"));
@@ -585,10 +587,7 @@ export function closeHealthGoals() {
 }
 
 export function clearHealthGoals() {
-  for (const goal of state.importedData.healthGoals || []) {
-    recordArrayItemTombstone(state.importedData, 'healthGoals', goal);
-  }
-  state.importedData.healthGoals = [];
+  clearImportedArray(state.importedData, 'healthGoals');
   recordContextChange('healthGoals');
   saveImportedData();
   window.closeModal();

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -56,7 +56,7 @@ import {
   ENV_TOXINS,
   ENV_BUILDING,
 } from './constants.js';
-import { escapeHTML, showNotification } from './utils.js';
+import { escapeHTML, hasDirtyFormFields, showNotification } from './utils.js';
 import { formatTime, getTimeFormat, parseTimeInput } from './theme.js';
 import { saveImportedData } from './data.js';
 import {
@@ -86,6 +86,18 @@ let saveContextAndRefresh = (msg, field) => {
   saveImportedData();
   showNotification(msg, 'success');
 };
+
+function refreshOpenHealthGoalsModalOnSync() {
+  const overlay = document.getElementById('modal-overlay');
+  const modal = document.getElementById('detail-modal');
+  if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== 'healthGoals') return;
+  if (hasDirtyFormFields(modal)) return;
+  renderHealthGoalsModal(modal);
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('labcharts-sync-applied', refreshOpenHealthGoalsModalOnSync);
+}
 
 export function configureLifestyleContextEditors({ recordChange, saveAndRefresh } = {}) {
   if (typeof recordChange === 'function') recordContextChange = recordChange;
@@ -520,6 +532,7 @@ export function openHealthGoalsEditor() {
 }
 
 export function renderHealthGoalsModal(modal) {
+  if (modal?.dataset) modal.dataset.syncRefreshKind = 'healthGoals';
   const goals = state.importedData.healthGoals || [];
   let html = '';
   if (goals.length > 0) {

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -367,7 +367,7 @@ export function appendImportedArrayItem(importedData, arrayPath, item) {
 
 export function replaceImportedArrayItem(importedData, arrayPath, index, nextItem) {
   const arr = ensureImportedArray(importedData, arrayPath);
-  if (!Number.isInteger(index) || index < 0) return null;
+  if (!Number.isInteger(index) || index < 0 || index >= arr.length) return null;
   const previousItem = arr[index];
   const tombstonedId = tombstoneChangedArrayIdentity(importedData, arrayPath, previousItem, nextItem);
   arr[index] = nextItem;

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -342,6 +342,73 @@ export function recordArrayItemTombstone(importedData, arrayPath, item) {
   return id;
 }
 
+export function ensureImportedArray(importedData, arrayPath) {
+  if (!importedData || typeof importedData !== 'object') return [];
+  const existing = getAt(importedData, arrayPath);
+  if (Array.isArray(existing)) return existing;
+  const next = [];
+  setAt(importedData, arrayPath, next);
+  return next;
+}
+
+function tombstoneChangedArrayIdentity(importedData, arrayPath, previousItem, nextItem) {
+  const previousId = getConfiguredArrayItemId(arrayPath, previousItem);
+  if (!previousId) return null;
+  const nextId = getConfiguredArrayItemId(arrayPath, nextItem);
+  if (previousId === nextId) return null;
+  return recordArrayItemTombstone(importedData, arrayPath, previousItem);
+}
+
+export function appendImportedArrayItem(importedData, arrayPath, item) {
+  const arr = ensureImportedArray(importedData, arrayPath);
+  arr.push(item);
+  return item;
+}
+
+export function replaceImportedArrayItem(importedData, arrayPath, index, nextItem) {
+  const arr = ensureImportedArray(importedData, arrayPath);
+  if (!Number.isInteger(index) || index < 0) return null;
+  const previousItem = arr[index];
+  const tombstonedId = tombstoneChangedArrayIdentity(importedData, arrayPath, previousItem, nextItem);
+  arr[index] = nextItem;
+  return { previousItem, nextItem, tombstonedId };
+}
+
+export function deleteImportedArrayItem(importedData, arrayPath, index) {
+  const arr = getAt(importedData, arrayPath);
+  if (!Array.isArray(arr)) return null;
+  if (!Number.isInteger(index) || index < 0 || index >= arr.length) return null;
+  const [removedItem] = arr.splice(index, 1);
+  const tombstonedId = recordArrayItemTombstone(importedData, arrayPath, removedItem);
+  return { removedItem, tombstonedId };
+}
+
+export function deleteImportedArrayItems(importedData, arrayPath, predicate) {
+  const arr = getAt(importedData, arrayPath);
+  if (!Array.isArray(arr) || typeof predicate !== 'function') return [];
+  const kept = [];
+  const removed = [];
+  arr.forEach((item, index) => {
+    if (predicate(item, index, arr)) {
+      recordArrayItemTombstone(importedData, arrayPath, item);
+      removed.push(item);
+    } else {
+      kept.push(item);
+    }
+  });
+  if (removed.length) setAt(importedData, arrayPath, kept);
+  return removed;
+}
+
+export function clearImportedArray(importedData, arrayPath) {
+  const arr = getAt(importedData, arrayPath);
+  if (!Array.isArray(arr)) return [];
+  const removed = arr.slice();
+  for (const item of removed) recordArrayItemTombstone(importedData, arrayPath, item);
+  setAt(importedData, arrayPath, []);
+  return removed;
+}
+
 function unionByItemId(localArr, remoteArr, tombstones, itemIdFn) {
   const tomb = tombstones instanceof Set ? tombstones : new Set(tombstones || []);
   const byId = new Map();

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -20,7 +20,7 @@
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, formatDate } from './utils.js';
 import { saveImportedData } from './data.js';
-import { recordTombstone } from './data-merge.js';
+import { deleteImportedArrayItem } from './data-merge.js';
 import { CHANNEL_DISPLAY } from './sun.js';
 import { BODY_REGIONS } from './sun-body-silhouette.js';
 import {
@@ -148,8 +148,7 @@ export async function deleteDevice(id) {
   const devs = getDevices();
   const idx = devs.findIndex(d => d.id === id);
   if (idx < 0) return false;
-  recordTombstone(state.importedData, 'lightDevices', id);
-  devs.splice(idx, 1);
+  deleteImportedArrayItem(state.importedData, 'lightDevices', idx);
   await saveImportedData();
   return true;
 }
@@ -458,8 +457,7 @@ export async function deleteDeviceSession(id) {
   const sessions = getDeviceSessions();
   const idx = sessions.findIndex(s => s.id === id);
   if (idx < 0) return false;
-  recordTombstone(state.importedData, 'deviceSessions', id);
-  sessions.splice(idx, 1);
+  deleteImportedArrayItem(state.importedData, 'deviceSessions', idx);
   await saveImportedData();
   return true;
 }

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -18,7 +18,7 @@
 //   importedData.deviceSessions[] — session log
 
 import { state } from './state.js';
-import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, formatDate } from './utils.js';
+import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItem } from './data-merge.js';
 import { CHANNEL_DISPLAY } from './sun.js';
@@ -616,6 +616,12 @@ export function openDeviceSessionDetail(id) {
     </div>
   </div>`;
   _wireModal(overlay);
+  bindDetachedModalSyncRefresh({
+    overlay,
+    id,
+    opener: openDeviceSessionDetail,
+    exists: sessionId => getDeviceSessions().some(s => s.id === sessionId),
+  });
 }
 
 // Rolling totals — same shape as sun.rollingChannelTotals so the AI context

--- a/js/light-env-audits.js
+++ b/js/light-env-audits.js
@@ -129,7 +129,6 @@ export async function updateLightAudit(id, patch) {
 }
 
 export async function deleteLightAudit(id) {
-  getLightAudits();
   deleteImportedArrayItems(state.importedData, 'lightAudits', a => a.id === id);
   await saveImportedData();
 }

--- a/js/light-env-audits.js
+++ b/js/light-env-audits.js
@@ -8,7 +8,7 @@
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
-import { recordTombstone } from './data-merge.js';
+import { deleteImportedArrayItems } from './data-merge.js';
 
 // Mirrors the EMF Assessment pattern: each audit is a dated, labeled,
 // immutable snapshot of the rooms + screens + recent measurements at
@@ -129,9 +129,8 @@ export async function updateLightAudit(id, patch) {
 }
 
 export async function deleteLightAudit(id) {
-  const audits = getLightAudits();
-  recordTombstone(state.importedData, 'lightAudits', id);
-  state.importedData.lightAudits = audits.filter(a => a.id !== id);
+  getLightAudits();
+  deleteImportedArrayItems(state.importedData, 'lightAudits', a => a.id === id);
   await saveImportedData();
 }
 

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -15,7 +15,7 @@
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
-import { recordTombstone } from './data-merge.js';
+import { deleteImportedArrayItems } from './data-merge.js';
 import {
   normalizeLightEnvironmentEveningFields,
   normalizeRoomEveningFields,
@@ -135,15 +135,11 @@ export async function updateRoom(id, patch) {
 
 export async function deleteRoom(id) {
   const env = getEnvironment();
-  recordTombstone(state.importedData, 'lightEnvironment.rooms', id);
-  env.rooms = (env.rooms || []).filter(r => r.id !== id);
+  deleteImportedArrayItems(state.importedData, 'lightEnvironment.rooms', r => r.id === id);
   // Measurements are meaningful only in the room context where they
   // were taken. Deleting the room removes those readings instead of
   // moving them into an unmapped "portable" bucket.
-  const measurements = state.importedData?.lightMeasurements;
-  if (Array.isArray(measurements)) {
-    state.importedData.lightMeasurements = measurements.filter(m => !m || m.roomId !== id);
-  }
+  deleteImportedArrayItems(state.importedData, 'lightMeasurements', m => m && m.roomId === id);
   if (Array.isArray(env.screens)) {
     for (const sc of env.screens) {
       if (sc && sc.roomId === id) sc.roomId = null;
@@ -221,8 +217,7 @@ export async function updateScreen(id, patch) {
 
 export async function deleteScreen(id) {
   const env = getEnvironment();
-  recordTombstone(state.importedData, 'lightEnvironment.screens', id);
-  env.screens = (env.screens || []).filter(s => s.id !== id);
+  deleteImportedArrayItems(state.importedData, 'lightEnvironment.screens', s => s.id === id);
   await saveImportedData();
 }
 

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -21,7 +21,7 @@
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
-import { recordTombstone } from './data-merge.js';
+import { deleteImportedArrayItem } from './data-merge.js';
 import {
   aimingGuideHTML,
   lockCameraForMeasurement,
@@ -109,8 +109,7 @@ function _collapseToLatestPerRoomTool(list) {
   for (let i = list.length - 1; i >= 0; i--) {
     const m = list[i];
     if (keep.has(m)) continue;
-    if (m && m.id) recordTombstone(state.importedData, 'lightMeasurements', m.id);
-    list.splice(i, 1);
+    deleteImportedArrayItem(state.importedData, 'lightMeasurements', i);
     dropped++;
   }
   return dropped;
@@ -128,8 +127,7 @@ function _supersedePriorMeasurement(list, roomId, tool) {
     if (!m || m.tool !== tool) continue;
     const sameRoom = (m.roomId || null) === (roomId || null);
     if (!sameRoom) continue;
-    if (m.id) recordTombstone(state.importedData, 'lightMeasurements', m.id);
-    list.splice(i, 1);
+    deleteImportedArrayItem(state.importedData, 'lightMeasurements', i);
     removed++;
   }
   return removed;
@@ -209,8 +207,7 @@ export async function deleteMeasurement(id) {
   const list = getMeasurements();
   const idx = list.findIndex(m => m.id === id);
   if (idx < 0) return false;
-  recordTombstone(state.importedData, 'lightMeasurements', id);
-  list.splice(idx, 1);
+  deleteImportedArrayItem(state.importedData, 'lightMeasurements', idx);
   await saveImportedData();
   return true;
 }

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -1002,6 +1002,7 @@ export function closeModal() {
     delete detailModal.dataset.syncRefreshIndex;
     delete detailModal.dataset.syncRefreshDate;
     delete detailModal.dataset.syncRefreshEditIdx;
+    delete detailModal.dataset.syncRefreshItemId;
   }
   if (state.chartInstances["modal"]) { state.chartInstances["modal"].destroy(); delete state.chartInstances["modal"]; }
   document.removeEventListener('click', closeSuggestionsOnClickOutside);

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -995,7 +995,14 @@ export async function deleteCustomMarker(id) {
 export function closeModal() {
   document.getElementById("modal-overlay").classList.remove("show");
   const detailModal = document.getElementById("detail-modal");
-  if (detailModal) detailModal.className = 'modal';
+  if (detailModal) {
+    detailModal.className = 'modal';
+    delete detailModal.dataset.syncRefreshKind;
+    delete detailModal.dataset.syncRefreshMode;
+    delete detailModal.dataset.syncRefreshIndex;
+    delete detailModal.dataset.syncRefreshDate;
+    delete detailModal.dataset.syncRefreshEditIdx;
+  }
   if (state.chartInstances["modal"]) { state.chartInstances["modal"].destroy(); delete state.chartInstances["modal"]; }
   document.removeEventListener('click', closeSuggestionsOnClickOutside);
   if (window.closeEMFInterpretation) window.closeEMFInterpretation();

--- a/js/notes.js
+++ b/js/notes.js
@@ -3,8 +3,10 @@ import { state } from './state.js';
 import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
-  getConfiguredArrayItemId,
-  recordArrayItemTombstone,
+  appendImportedArrayItem,
+  deleteImportedArrayItem,
+  ensureImportedArray,
+  replaceImportedArrayItem,
 } from './data-merge.js';
 
 export function openNoteEditor(date, existingIdx) {
@@ -42,18 +44,12 @@ export function saveNote(idx) {
   const text = ta ? ta.value.trim() : '';
   if (!date) { showNotification('Please select a date', 'error'); return; }
   if (!text) { showNotification('Please enter note text', 'error'); return; }
-  if (!state.importedData.notes) state.importedData.notes = [];
+  ensureImportedArray(state.importedData, 'notes');
   const nextNote = { date, text };
   if (idx !== null && idx !== undefined) {
-    const existing = state.importedData.notes[idx];
-    const existingId = getConfiguredArrayItemId('notes', existing);
-    const nextId = getConfiguredArrayItemId('notes', nextNote);
-    if (existingId && existingId !== nextId) {
-      recordArrayItemTombstone(state.importedData, 'notes', existing);
-    }
-    state.importedData.notes[idx] = nextNote;
+    replaceImportedArrayItem(state.importedData, 'notes', idx, nextNote);
   } else {
-    state.importedData.notes.push(nextNote);
+    appendImportedArrayItem(state.importedData, 'notes', nextNote);
   }
   saveImportedData();
   window.closeModal();
@@ -65,8 +61,7 @@ export function saveNote(idx) {
 export async function deleteNote(idx) {
   if (!state.importedData.notes) return;
   if (await showConfirmDialog("Delete this note? This can't be undone.")) {
-    recordArrayItemTombstone(state.importedData, 'notes', state.importedData.notes[idx]);
-    state.importedData.notes.splice(idx, 1);
+    deleteImportedArrayItem(state.importedData, 'notes', idx);
     saveImportedData();
     window.closeModal();
     const activeNav = document.querySelector(".nav-item.active");

--- a/js/notes.js
+++ b/js/notes.js
@@ -20,7 +20,8 @@ function refreshOpenNoteEditorOnSync() {
   }
   const idx = Number.parseInt(modal.dataset.syncRefreshIndex || '', 10);
   const date = modal.dataset.syncRefreshDate || '';
-  if (Number.isInteger(idx) && state.importedData.notes?.[idx]) {
+  const noteAtIdx = state.importedData.notes?.[idx];
+  if (Number.isInteger(idx) && noteAtIdx && (!date || noteAtIdx.date === date)) {
     openNoteEditor(null, idx);
     return;
   }

--- a/js/notes.js
+++ b/js/notes.js
@@ -1,6 +1,6 @@
 // notes.js — Standalone note editor
 import { state } from './state.js';
-import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
+import { escapeHTML, hasDirtyFormFields, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
   appendImportedArrayItem,
@@ -8,6 +8,33 @@ import {
   ensureImportedArray,
   replaceImportedArrayItem,
 } from './data-merge.js';
+
+function refreshOpenNoteEditorOnSync() {
+  const overlay = document.getElementById('modal-overlay');
+  const modal = document.getElementById('detail-modal');
+  if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== 'note') return;
+  if (hasDirtyFormFields(modal)) return;
+  if (modal.dataset.syncRefreshMode !== 'edit') {
+    openNoteEditor(modal.dataset.syncRefreshDate || undefined);
+    return;
+  }
+  const idx = Number.parseInt(modal.dataset.syncRefreshIndex || '', 10);
+  const date = modal.dataset.syncRefreshDate || '';
+  if (Number.isInteger(idx) && state.importedData.notes?.[idx]) {
+    openNoteEditor(null, idx);
+    return;
+  }
+  const nextIdx = (state.importedData.notes || []).findIndex(n => n?.date === date);
+  if (nextIdx >= 0) {
+    openNoteEditor(null, nextIdx);
+  } else {
+    window.closeModal?.();
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('labcharts-sync-applied', refreshOpenNoteEditorOnSync);
+}
 
 export function openNoteEditor(date, existingIdx) {
   const modal = document.getElementById("detail-modal");
@@ -30,6 +57,10 @@ export function openNoteEditor(date, existingIdx) {
       <button class="import-btn import-btn-secondary" onclick="closeModal()">Cancel</button>
       ${isEditing ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" onclick="deleteNote(${existingIdx})">Delete</button>` : ''}
     </div>`;
+  modal.dataset.syncRefreshKind = 'note';
+  modal.dataset.syncRefreshMode = isEditing ? 'edit' : 'add';
+  modal.dataset.syncRefreshIndex = isEditing ? String(existingIdx) : '';
+  modal.dataset.syncRefreshDate = defaultDate || '';
   overlay.classList.add("show");
   setTimeout(() => {
     const ta = document.getElementById('note-textarea');

--- a/js/sun-session-ui.js
+++ b/js/sun-session-ui.js
@@ -4,7 +4,7 @@
 // the UI layer can stay separate without importing sun.js and creating a cycle.
 
 import { state } from './state.js';
-import { escapeHTML, escapeAttr, formatDate, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
+import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
 import { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette } from './sun-body-silhouette.js';
 
 const uiDeps = {
@@ -379,6 +379,12 @@ export function openSunSessionDetail(id) {
   uiDeps.wireBackdropClose(overlay);
   document.body.appendChild(overlay);
   uiDeps.trapModalFocus(overlay);
+  bindDetachedModalSyncRefresh({
+    overlay,
+    id,
+    opener: openSunSessionDetail,
+    exists: sessionId => uiDeps.getSessions().some(s => s.id === sessionId),
+  });
 }
 
 // Per-channel chip value — small inline real-unit number rendered on

--- a/js/sun-sessions-store.js
+++ b/js/sun-sessions-store.js
@@ -5,7 +5,7 @@
 
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
-import { recordTombstone } from './data-merge.js';
+import { deleteImportedArrayItem } from './data-merge.js';
 import { BODY_REGIONS } from './sun-body-silhouette.js';
 import {
   EXPOSURE_PRESETS,
@@ -151,8 +151,7 @@ export async function deleteSession(id) {
   const sessions = getSessions();
   const idx = sessions.findIndex(s => s.id === id);
   if (idx < 0) return false;
-  recordTombstone(state.importedData, 'sunSessions', id);
-  sessions.splice(idx, 1);
+  deleteImportedArrayItem(state.importedData, 'sunSessions', idx);
   storeDeps.clearLiveState(id);
   await saveImportedData();
   return true;

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -1,7 +1,7 @@
 // supplements.js — Supplement/medication editor and dashboard section
 
 import { state } from './state.js';
-import { escapeHTML, showNotification, isDebugMode } from './utils.js';
+import { escapeHTML, hasDirtyFormFields, showNotification, isDebugMode } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
   appendImportedArrayItem,
@@ -52,6 +52,20 @@ function _sourceUrlParts(raw) {
     url: parsed.toString(),
     host: parsed.hostname.replace(/^www\./, '')
   };
+}
+
+function refreshOpenSupplementsEditorOnSync() {
+  const overlay = document.getElementById('modal-overlay');
+  const modal = document.getElementById('detail-modal');
+  if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== 'supplements') return;
+  if (hasDirtyFormFields(modal)) return;
+  const idx = Number.parseInt(modal.dataset.syncRefreshEditIdx || '', 10);
+  const supps = state.importedData.supplements || [];
+  openSupplementsEditor(Number.isInteger(idx) && supps[idx] ? idx : undefined);
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('labcharts-sync-applied', refreshOpenSupplementsEditorOnSync);
 }
 
 export function renderSupplementsSection() {
@@ -501,6 +515,8 @@ export function openSupplementsEditor(editIdx) {
     <div id="supp-add-form-area"></div>
   </div>`;
   modal.innerHTML = html;
+  modal.dataset.syncRefreshKind = 'supplements';
+  modal.dataset.syncRefreshEditIdx = isEdit ? String(editIdx) : '';
   overlay.classList.add("show");
   if (isEdit) {
     const expanded = document.querySelector('.supp-list-expanded');

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -4,8 +4,9 @@ import { state } from './state.js';
 import { escapeHTML, showNotification, isDebugMode } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
-  getConfiguredArrayItemId,
-  recordArrayItemTombstone,
+  appendImportedArrayItem,
+  deleteImportedArrayItem,
+  replaceImportedArrayItem,
 } from './data-merge.js';
 import { callClaudeAPI, hasAIProvider, supportsVision } from './api.js';
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
@@ -569,15 +570,9 @@ export function saveSupplement(idx) {
   if (isFinite(timesNum) && timesNum > 0) entry.timesPerDay = timesNum;
   if (parsedSourceUrl) entry.sourceUrl = parsedSourceUrl.toString();
   if (idx >= 0) {
-    const existing = state.importedData.supplements[idx];
-    const existingId = getConfiguredArrayItemId('supplements', existing);
-    const nextId = getConfiguredArrayItemId('supplements', entry);
-    if (existingId && existingId !== nextId) {
-      recordArrayItemTombstone(state.importedData, 'supplements', existing);
-    }
-    state.importedData.supplements[idx] = entry;
+    replaceImportedArrayItem(state.importedData, 'supplements', idx, entry);
   } else {
-    state.importedData.supplements.push(entry);
+    appendImportedArrayItem(state.importedData, 'supplements', entry);
   }
   saveImportedData();
   showNotification(idx >= 0 ? 'Supplement updated' : 'Supplement added', 'success');
@@ -592,8 +587,7 @@ export function saveSupplement(idx) {
 export function deleteSupplement(idx) {
   if (!state.importedData.supplements || !state.importedData.supplements[idx]) return;
   const name = state.importedData.supplements[idx].name;
-  recordArrayItemTombstone(state.importedData, 'supplements', state.importedData.supplements[idx]);
-  state.importedData.supplements.splice(idx, 1);
+  deleteImportedArrayItem(state.importedData, 'supplements', idx);
   saveImportedData();
   showNotification(`"${name}" removed`, 'info');
   // Re-render dashboard supplements section

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -6,6 +6,7 @@ import { saveImportedData } from './data.js';
 import {
   appendImportedArrayItem,
   deleteImportedArrayItem,
+  getConfiguredArrayItemId,
   replaceImportedArrayItem,
 } from './data-merge.js';
 import { callClaudeAPI, hasAIProvider, supportsVision } from './api.js';
@@ -60,8 +61,17 @@ function refreshOpenSupplementsEditorOnSync() {
   if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== 'supplements') return;
   if (hasDirtyFormFields(modal)) return;
   const idx = Number.parseInt(modal.dataset.syncRefreshEditIdx || '', 10);
+  const itemId = modal.dataset.syncRefreshItemId || '';
   const supps = state.importedData.supplements || [];
-  openSupplementsEditor(Number.isInteger(idx) && supps[idx] ? idx : undefined);
+  let nextIdx = -1;
+  if (Number.isInteger(idx) && supps[idx]) {
+    const idxItemId = getConfiguredArrayItemId('supplements', supps[idx]);
+    if (!itemId || idxItemId === itemId) nextIdx = idx;
+  }
+  if (nextIdx < 0 && itemId) {
+    nextIdx = supps.findIndex(s => getConfiguredArrayItemId('supplements', s) === itemId);
+  }
+  openSupplementsEditor(nextIdx >= 0 ? nextIdx : undefined);
 }
 
 if (typeof window !== 'undefined') {
@@ -517,6 +527,7 @@ export function openSupplementsEditor(editIdx) {
   modal.innerHTML = html;
   modal.dataset.syncRefreshKind = 'supplements';
   modal.dataset.syncRefreshEditIdx = isEdit ? String(editIdx) : '';
+  modal.dataset.syncRefreshItemId = isEdit ? (getConfiguredArrayItemId('supplements', supps[editIdx]) || '') : '';
   overlay.classList.add("show");
   if (isEdit) {
     const expanded = document.querySelector('.supp-list-expanded');

--- a/js/utils.js
+++ b/js/utils.js
@@ -56,6 +56,67 @@ export function sanitizeMarkerKey(fullKey) {
   return `${cat}.${mk}`;
 }
 
+export function hasDirtyFormFields(root) {
+  if (!root || !root.querySelectorAll) return false;
+  const fields = root.querySelectorAll('input, textarea, select');
+  for (const field of fields) {
+    if (!field || field.disabled) continue;
+    if (field.tagName === 'SELECT') {
+      const options = Array.from(field.options || []);
+      if (options.some(opt => opt.selected !== opt.defaultSelected)) return true;
+      continue;
+    }
+    if (field.type === 'checkbox' || field.type === 'radio') {
+      if (field.checked !== field.defaultChecked) return true;
+      continue;
+    }
+    if (field.value !== field.defaultValue) return true;
+  }
+  return false;
+}
+
+export function bindDetachedModalSyncRefresh({
+  overlay,
+  id,
+  opener,
+  exists,
+  bodySelector = '.modal-body',
+  restoreSelector = '.modal-overlay.show .sun-detail-modal .modal-body',
+} = {}) {
+  if (typeof window === 'undefined' || typeof document === 'undefined' || !overlay || typeof opener !== 'function') return;
+  let detached = false;
+  const nativeRemove = overlay.remove.bind(overlay);
+  const detach = () => {
+    if (detached) return;
+    detached = true;
+    window.removeEventListener('labcharts-sync-applied', onSync);
+  };
+  const restoreScroll = scrollTop => {
+    const nextBodies = document.querySelectorAll(restoreSelector);
+    const nextBody = nextBodies[nextBodies.length - 1];
+    if (nextBody) nextBody.scrollTop = scrollTop;
+  };
+  const onSync = () => {
+    if (!document.body.contains(overlay)) { detach(); return; }
+    if (hasDirtyFormFields(overlay)) return;
+    const body = overlay.querySelector(bodySelector);
+    const scrollTop = body ? body.scrollTop : 0;
+    overlay.remove();
+    if (typeof exists === 'function' && !exists(id)) return;
+    opener(id);
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => restoreScroll(scrollTop));
+    } else {
+      setTimeout(() => restoreScroll(scrollTop), 0);
+    }
+  };
+  overlay.remove = () => {
+    detach();
+    nativeRemove();
+  };
+  window.addEventListener('labcharts-sync-applied', onSync);
+}
+
 export function getStatus(value, refMin, refMax) {
   if (value === null || value === undefined) return "missing";
   if (refMin == null && refMax == null) return "normal";

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -598,6 +598,11 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
     helperBlob.notes.length === 1
       && helperBlob.notes[0].text === 'Edited note'
       && helperBlob._deleted?.notes?.includes(originalNoteId));
+  const outOfBoundsReplace = replaceImportedArrayItem(helperBlob, 'notes', 4, { date: '2026-05-02', text: 'Sparse note' });
+  assert('replaceImportedArrayItem rejects out-of-bounds indexes without sparse holes',
+    outOfBoundsReplace === null
+      && helperBlob.notes.length === 1
+      && !Object.prototype.hasOwnProperty.call(helperBlob.notes, 4));
   const editedNoteId = DELTA_ARRAY_CONFIG.notes.itemIdFn(helperBlob.notes[0]);
   deleteImportedArrayItem(helperBlob, 'notes', 0);
   assert('deleteImportedArrayItem tombstones removed natural-key rows',

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -17,8 +17,14 @@ globalThis.window = globalThis.window || {};
 
 const {
   compareRecordFreshness,
+  appendImportedArrayItem,
+  clearImportedArray,
+  deleteImportedArrayItem,
+  deleteImportedArrayItems,
+  ensureImportedArray,
   mergeImportedData,
   preserveFreshLocalLabEntries,
+  replaceImportedArrayItem,
   recordTombstone,
   recordArrayItemTombstone,
   clearTombstone,
@@ -578,6 +584,53 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
     !blob._deleted.entries);
   assert('clearTombstone stores tombstone-clear timestamp metadata',
     Number.isFinite(blob._deletedClearedAt?.entries?.['2026-05-01']));
+
+  // ─── 9b. Sync-aware imported array mutations ─────────────────────────
+  console.log('%c 9b. imported array mutation helpers ', 'font-weight:bold;color:#f59e0b');
+  const helperBlob = {};
+  const ensuredNotes = ensureImportedArray(helperBlob, 'notes');
+  appendImportedArrayItem(helperBlob, 'notes', { date: '2026-05-01', text: 'Original note' });
+  assert('ensureImportedArray creates missing top-level arrays',
+    Array.isArray(ensuredNotes) && helperBlob.notes.length === 1);
+  const originalNoteId = DELTA_ARRAY_CONFIG.notes.itemIdFn(helperBlob.notes[0]);
+  replaceImportedArrayItem(helperBlob, 'notes', 0, { date: '2026-05-01', text: 'Edited note' });
+  assert('replaceImportedArrayItem tombstones old natural-key identity on edit',
+    helperBlob.notes.length === 1
+      && helperBlob.notes[0].text === 'Edited note'
+      && helperBlob._deleted?.notes?.includes(originalNoteId));
+  const editedNoteId = DELTA_ARRAY_CONFIG.notes.itemIdFn(helperBlob.notes[0]);
+  deleteImportedArrayItem(helperBlob, 'notes', 0);
+  assert('deleteImportedArrayItem tombstones removed natural-key rows',
+    helperBlob.notes.length === 0
+      && helperBlob._deleted?.notes?.includes(editedNoteId));
+
+  const nestedBlob = {
+    lightEnvironment: { rooms: [{ id: 'r1', name: 'Desk' }, { id: 'r2', name: 'Bed' }] },
+    lightMeasurements: [
+      { id: 'm1', roomId: 'r1', tool: 'lux' },
+      { id: 'm2', roomId: 'r2', tool: 'lux' },
+    ],
+  };
+  deleteImportedArrayItems(nestedBlob, 'lightEnvironment.rooms', r => r.id === 'r1');
+  deleteImportedArrayItems(nestedBlob, 'lightMeasurements', m => m.roomId === 'r1');
+  assert('deleteImportedArrayItems handles dotted paths and cascaded id tombstones',
+    nestedBlob.lightEnvironment.rooms.length === 1
+      && nestedBlob.lightEnvironment.rooms[0].id === 'r2'
+      && nestedBlob.lightMeasurements.length === 1
+      && nestedBlob._deleted?.['lightEnvironment.rooms']?.includes('r1')
+      && nestedBlob._deleted?.lightMeasurements?.includes('m1'));
+
+  const clearedBlob = {
+    healthGoals: [
+      { text: 'Lower CRP', severity: 'major' },
+      { text: 'Raise ferritin', severity: 'minor' },
+    ],
+  };
+  const clearedGoalIds = clearedBlob.healthGoals.map(g => DELTA_ARRAY_CONFIG.healthGoals.itemIdFn(g));
+  clearImportedArray(clearedBlob, 'healthGoals');
+  assert('clearImportedArray tombstones every configured row',
+    clearedBlob.healthGoals.length === 0
+      && clearedGoalIds.every(id => clearedBlob._deleted?.healthGoals?.includes(id)));
 
   // ─── 10. Tombstone union from both sides ──────────────────────────────
   console.log('%c 10. Tombstone union ', 'font-weight:bold;color:#f59e0b');

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -620,6 +620,8 @@ const {
   const screensAfter = window._labState.importedData.lightEnvironment.screens;
   assert('deleteRoom removes linked measurements',
     !measurementsAfter.find(m => m.id === 'm-orphan-1'));
+  assert('deleteRoom tombstones linked measurements for sync',
+    window._labState.importedData._deleted?.lightMeasurements?.includes('m-orphan-1'));
   assert('deleteRoom leaves measurements pointing at OTHER rooms untouched',
     measurementsAfter.find(m => m.id === 'm-orphan-2').roomId === 'other-room');
   assert('deleteRoom nulls roomId on linked screens',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -624,6 +624,8 @@ await import('../js/settings.js');
     supplementsSrc.includes('refreshOpenSupplementsEditorOnSync')
       && supplementsSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenSupplementsEditorOnSync)")
       && supplementsSrc.includes("modal.dataset.syncRefreshKind = 'supplements'")
+      && supplementsSrc.includes("modal.dataset.syncRefreshItemId")
+      && supplementsSrc.includes("getConfiguredArrayItemId('supplements'")
       && notesSrc.includes('refreshOpenNoteEditorOnSync')
       && notesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenNoteEditorOnSync)")
       && notesSrc.includes("modal.dataset.syncRefreshKind = 'note'")

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -629,6 +629,8 @@ await import('../js/settings.js');
       && notesSrc.includes('refreshOpenNoteEditorOnSync')
       && notesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenNoteEditorOnSync)")
       && notesSrc.includes("modal.dataset.syncRefreshKind = 'note'")
+      && notesSrc.includes('const noteAtIdx = state.importedData.notes?.[idx]')
+      && notesSrc.includes('noteAtIdx.date === date')
       && contextCardLifestyleEditorsSrc.includes('refreshOpenHealthGoalsModalOnSync')
       && contextCardLifestyleEditorsSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenHealthGoalsModalOnSync)")
       && contextCardLifestyleEditorsSrc.includes("modal.dataset.syncRefreshKind = 'healthGoals'"));

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -115,6 +115,14 @@ await import('../js/settings.js');
   const appShellCssSrc = await fetchWithRetry('css/app-shell.css');
   const themeExtraSrc = await fetchWithRetry('themes-extra.css');
   const serviceWorkerSrc = await fetchWithRetry('service-worker.js');
+  const utilsSrc = await fetchWithRetry('js/utils.js');
+  const sunSessionUISrc = await fetchWithRetry('js/sun-session-ui.js');
+  const lightDevicesSrc = await fetchWithRetry('js/light-devices.js');
+  const supplementsSrc = await fetchWithRetry('js/supplements.js');
+  const notesSrc = await fetchWithRetry('js/notes.js');
+  const contextCardLifestyleEditorsSrc = await fetchWithRetry('js/context-card-lifestyle-editors.js');
+  const chatSummariesSrc = await fetchWithRetry('js/chat-summaries.js');
+  const markerDetailModalSrc = await fetchWithRetry('js/marker-detail-modal.js');
   const syncDeltaPlannerSearchSrc = `${syncDeltaPlannersSrc}\n${syncDeltaPlannerContextSrc}\n${syncDeltaArrayPlannerSrc}\n${syncDeltaMapPlannerSrc}\n${syncDeltaScalarPlannerSrc}`;
   const syncDeltaMergeSearchSrc = `${syncDeltaMergeShapesSrc}\n${syncDeltaRowCodecSrc}\n${syncDeltaArrayMergeSrc}\n${syncDeltaMapMergeSrc}\n${syncDeltaScalarMergeSrc}`;
   const syncDeltaRegistrySearchSrc = `${syncDeltaRegistrySrc}\n${syncDeltaSurfacesSrc}\n${syncDeltaSurfaceConfigSrc}\n${syncDeltaIdSrc}`;
@@ -601,6 +609,36 @@ await import('../js/settings.js');
       && syncPullActiveRefreshSrc.includes("new CustomEvent('labcharts-sync-applied')"));
   assert('service worker precaches sync-pull-active-refresh.js',
     serviceWorkerSrc.includes("'/js/sync-pull-active-refresh.js'"));
+  assert('modal refresh dirty-form guard is shared',
+    utilsSrc.includes('export function hasDirtyFormFields')
+      && utilsSrc.includes("querySelectorAll('input, textarea, select')")
+      && utilsSrc.includes('export function bindDetachedModalSyncRefresh')
+      && utilsSrc.includes("window.addEventListener('labcharts-sync-applied', onSync)")
+      && utilsSrc.includes('hasDirtyFormFields(overlay)'));
+  assert('sun and device session detail modals refresh on sync-applied',
+    sunSessionUISrc.includes('bindDetachedModalSyncRefresh({')
+      && sunSessionUISrc.includes('opener: openSunSessionDetail')
+      && lightDevicesSrc.includes('bindDetachedModalSyncRefresh({')
+      && lightDevicesSrc.includes('opener: openDeviceSessionDetail'));
+  assert('shared data modals refresh clean editors on sync-applied',
+    supplementsSrc.includes('refreshOpenSupplementsEditorOnSync')
+      && supplementsSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenSupplementsEditorOnSync)")
+      && supplementsSrc.includes("modal.dataset.syncRefreshKind = 'supplements'")
+      && notesSrc.includes('refreshOpenNoteEditorOnSync')
+      && notesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenNoteEditorOnSync)")
+      && notesSrc.includes("modal.dataset.syncRefreshKind = 'note'")
+      && contextCardLifestyleEditorsSrc.includes('refreshOpenHealthGoalsModalOnSync')
+      && contextCardLifestyleEditorsSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenHealthGoalsModalOnSync)")
+      && contextCardLifestyleEditorsSrc.includes("modal.dataset.syncRefreshKind = 'healthGoals'"));
+  assert('saved chat summary modal refreshes on sync-applied',
+    chatSummariesSrc.includes('refreshOpenSummaryModalOnSync')
+      && chatSummariesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenSummaryModalOnSync)")
+      && chatSummariesSrc.includes("overlay.dataset.syncRefreshKind = 'chat-summary'")
+      && chatSummariesSrc.includes('viewSavedSummary(id)'));
+  assert('closeModal clears sync refresh modal metadata',
+    markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshKind')
+      && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshDate')
+      && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshEditIdx'));
   assert('sync-pull-rebroadcast.js owns pull-side rebroadcast scheduling',
     syncPullRebroadcastSrc.includes('export function maybeScheduleRebroadcast')
       && syncPullRebroadcastSrc.includes('consumeRebroadcastBudget(profileId)')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.292';
+self.APP_VERSION = '1.8.293';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.291';
+self.APP_VERSION = '1.8.292';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.293';
+self.APP_VERSION = '1.8.294';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.294';
+self.APP_VERSION = '1.8.295';


### PR DESCRIPTION
## Summary
- Add shared importedData array mutation helpers that automatically tombstone configured item identities on replace, delete, bulk delete, and clear.
- Move notes, supplements, health goals, chat summaries, sun/light sessions, light devices, light audits, light measurements, rooms, and screens onto the shared helpers.
- Fix room deletion so linked light measurements are tombstoned before removal, preventing stale peers from resurrecting them.
- Refresh clean open data/session modals after `labcharts-sync-applied`, while preserving dirty local form edits.
- Address Greptile review feedback: reject out-of-bounds array replacements, keep supplements and notes modal refreshes anchored to item identity after sync, and remove a dead light-audit read.

## Validation
- `git diff --check`
- `node --check js/utils.js js/sun-session-ui.js js/light-devices.js js/supplements.js js/context-card-lifestyle-editors.js js/notes.js js/chat-summaries.js js/marker-detail-modal.js`
- `node tests/test-data-merge.js`
- `node tests/test-light-env.js`
- `node tests/test-light-tools.js`
- `node tests/test-light-devices.js`
- `node tests/test-sun.js`
- `node tests/test-sync.js`
- `node tests/test-chat-threads.js`
- `node tests/test-unit-import.js`
- `./run-tests.sh`