### PR TITLE
Guard synced array mutations

### DIFF
--- a/js/chat-onboarding.js
+++ b/js/chat-onboarding.js
@@ -5,6 +5,10 @@ import { LATITUDE_BANDS } from './constants.js';
 import { escapeHTML, showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
+  appendImportedArrayItem,
+  deleteImportedArrayItem,
+} from './data-merge.js';
+import {
   detectLatitudeWithAI, getLatitudeFromLocation, getLocationCache,
   latitudeToBand, renameProfile, setProfileDob, setProfileLocation,
   setProfileSex,
@@ -290,13 +294,13 @@ export function addChatSupplement() {
   const typeEl = document.getElementById('chat-onboard-supp-type');
   const name = nameEl?.value?.trim();
   if (!name) { nameEl?.focus(); return; }
-  if (!state.importedData.supplements) state.importedData.supplements = [];
-  state.importedData.supplements.push({
+  appendImportedArrayItem(state.importedData, 'supplements', {
     name,
     dosage: doseEl?.value?.trim() || '',
     type: typeEl?.value || 'supplement',
     startDate: new Date().toISOString().slice(0, 10),
-    endDate: null
+    endDate: null,
+    updatedAt: Date.now(),
   });
   saveImportedData();
   _refreshDashboardSupps();
@@ -305,7 +309,7 @@ export function addChatSupplement() {
 
 export function removeChatSupplement(idx) {
   if (!state.importedData.supplements?.[idx]) return;
-  state.importedData.supplements.splice(idx, 1);
+  deleteImportedArrayItem(state.importedData, 'supplements', idx);
   saveImportedData();
   _refreshDashboardSupps();
   renderChatMessages();

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -60,6 +60,7 @@ import { escapeHTML, hasDirtyFormFields, showNotification } from './utils.js';
 import { formatTime, getTimeFormat, parseTimeInput } from './theme.js';
 import { saveImportedData } from './data.js';
 import {
+  appendImportedArrayItem,
   clearImportedArray,
   deleteImportedArrayItem,
 } from './data-merge.js';
@@ -577,8 +578,7 @@ export function addHealthGoal() {
   const severity = getSelectedOption('goal-severity-select') || 'major';
   const text = input ? input.value.trim() : '';
   if (!text) return;
-  if (!state.importedData.healthGoals) state.importedData.healthGoals = [];
-  state.importedData.healthGoals.push({ text, severity, updatedAt: Date.now() });
+  appendImportedArrayItem(state.importedData, 'healthGoals', { text, severity, updatedAt: Date.now() });
   recordContextChange('healthGoals');
   saveImportedData();
   renderHealthGoalsModal(document.getElementById("detail-modal"));

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -5,6 +5,12 @@ import { escapeHTML, showNotification } from './utils.js';
 import { saveImportedData, getActiveData } from './data.js';
 import { hasAIProvider } from './api.js';
 import {
+  appendImportedArrayItem,
+  ensureImportedArray,
+  replaceImportedArrayItem,
+  trimImportedArray,
+} from './data-merge.js';
+import {
   getConditionsSummary,
   getDietSummary,
   getExerciseSummary,
@@ -277,8 +283,7 @@ export function recordChange(field) {
   const current = state.importedData[field];
   const snapshot = current != null ? JSON.parse(JSON.stringify(current)) : null;
   const snapshotStr = JSON.stringify(snapshot);
-  if (!state.importedData.changeHistory) state.importedData.changeHistory = [];
-  const history = state.importedData.changeHistory;
+  const history = ensureImportedArray(state.importedData, 'changeHistory');
   // Skip if identical to last snapshot for this field
   const lastIdx = history.findLastIndex(e => e.field === field);
   if (lastIdx >= 0 && JSON.stringify(history[lastIdx].snapshot) === snapshotStr) return;
@@ -289,13 +294,16 @@ export function recordChange(field) {
   const now = Date.now();
   const todayIdx = history.findIndex(e => e.field === field && e.date === today);
   if (todayIdx >= 0) {
-    history[todayIdx].snapshot = snapshot;
-    history[todayIdx].updatedAt = now;
+    replaceImportedArrayItem(state.importedData, 'changeHistory', todayIdx, {
+      ...history[todayIdx],
+      snapshot,
+      updatedAt: now,
+    });
   } else {
-    history.push({ field, date: today, snapshot, updatedAt: now });
+    appendImportedArrayItem(state.importedData, 'changeHistory', { field, date: today, snapshot, updatedAt: now });
   }
   // Cap at 200
-  while (history.length > 200) history.shift();
+  trimImportedArray(state.importedData, 'changeHistory', 200);
 }
 
 export function saveAndRefresh(msg, field) {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -4,6 +4,7 @@ import { state } from './state.js';
 import { showNotification, showConfirmDialog, escapeHTML } from './utils.js';
 import { profileStorageKey } from './profile.js';
 import { getBlob, setBlob, deleteBlob, shouldUseBlob } from './blob-storage.js';
+import { ensureImportedArray } from './data-merge.js';
 
 // ═══════════════════════════════════════════════
 // SENSITIVE KEY PATTERNS
@@ -840,8 +841,8 @@ export function initBroadcastChannel() {
       if (raw) {
         try {
           state.importedData = JSON.parse(raw);
-          if (!state.importedData.notes) state.importedData.notes = [];
-          if (!state.importedData.supplements) state.importedData.supplements = [];
+          ensureImportedArray(state.importedData, 'notes');
+          ensureImportedArray(state.importedData, 'supplements');
           window.migrateProfileData(state.importedData);
           window.buildSidebar();
           // buildSidebar resets the .active class to Dashboard, so source

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -337,6 +337,7 @@ export function getConfiguredArrayItemId(path, item) {
 }
 
 export function recordArrayItemTombstone(importedData, arrayPath, item) {
+  if (DELTA_ARRAY_CONFIG[arrayPath]?.noTombstones) return null;
   const id = getConfiguredArrayItemId(arrayPath, item);
   if (id) recordTombstone(importedData, arrayPath, id);
   return id;
@@ -406,6 +407,25 @@ export function clearImportedArray(importedData, arrayPath) {
   const removed = arr.slice();
   for (const item of removed) recordArrayItemTombstone(importedData, arrayPath, item);
   setAt(importedData, arrayPath, []);
+  return removed;
+}
+
+export function sortImportedArray(importedData, arrayPath, compareFn) {
+  const arr = getAt(importedData, arrayPath);
+  if (!Array.isArray(arr) || typeof compareFn !== 'function') return [];
+  arr.sort(compareFn);
+  return arr;
+}
+
+export function trimImportedArray(importedData, arrayPath, maxLength, opts = {}) {
+  const arr = getAt(importedData, arrayPath);
+  if (!Array.isArray(arr) || !Number.isInteger(maxLength) || maxLength < 0 || arr.length <= maxLength) return [];
+  const keep = opts.keep === 'first' ? 'first' : 'last';
+  const cut = arr.length - maxLength;
+  const removed = keep === 'first' ? arr.slice(maxLength) : arr.slice(0, cut);
+  const kept = keep === 'first' ? arr.slice(0, maxLength) : arr.slice(cut);
+  for (const item of removed) recordArrayItemTombstone(importedData, arrayPath, item);
+  setAt(importedData, arrayPath, kept);
   return removed;
 }
 

--- a/js/export.js
+++ b/js/export.js
@@ -6,6 +6,13 @@ import { getActiveData, filterDatesByRange, getEffectiveRange, getAllFlaggedMark
 import { getProfiles, profileStorageKey, createProfile, updateProfileMeta, loadProfile, saveProfiles, migrateProfileData } from './profile.js';
 import { getBloodDrawPhases } from './cycle.js';
 import { encryptedGetItem, encryptedSetItem, getEncryptionEnabled, encryptedRemoveItem } from './crypto.js';
+import {
+  appendImportedArrayItem,
+  ensureImportedArray,
+  replaceImportedArrayItem,
+  sortImportedArray,
+  trimImportedArray,
+} from './data-merge.js';
 
 // ═══════════════════════════════════════════════
 // PDF REPORT EXPORT
@@ -552,7 +559,7 @@ export function importDataJSON(file) {
       let count = 0;
       for (const entry of json.entries) {
         if (!entry.date || !entry.markers) continue;
-        if (!state.importedData.entries) state.importedData.entries = [];
+        const entries = ensureImportedArray(state.importedData, 'entries');
         // Earlier draft did `filter(ex => ex.date !== entry.date)` — same-
         // date entries clobbered each other. The demos legitimately ship
         // two entries per date (comprehensive panel + specialty add-on
@@ -560,7 +567,7 @@ export function importDataJSON(file) {
         // second entry was silently dropped, losing every fatty-acid /
         // specialty marker on import. Merge markers + markerSources
         // instead so all data lands; later entries win on key conflicts.
-        const existing = state.importedData.entries.find(ex => ex.date === entry.date);
+        const existing = entries.find(ex => ex.date === entry.date);
         if (existing) {
           Object.assign(existing.markers || (existing.markers = {}), entry.markers);
           if (entry.markerSources) {
@@ -568,7 +575,7 @@ export function importDataJSON(file) {
           }
           if (entry.file && !existing.file) existing.file = entry.file;
         } else {
-          state.importedData.entries.push(entry);
+          appendImportedArrayItem(state.importedData, 'entries', entry);
         }
         count++;
       }
@@ -629,11 +636,11 @@ export function importDataJSON(file) {
       }
       // Import health goals (merge, deduplicate by text)
       if (json.healthGoals && Array.isArray(json.healthGoals)) {
-        if (!state.importedData.healthGoals) state.importedData.healthGoals = [];
+        const healthGoals = ensureImportedArray(state.importedData, 'healthGoals');
         for (const g of json.healthGoals) {
           if (!g.text || !g.severity) continue;
-          const exists = state.importedData.healthGoals.some(x => x.text === g.text);
-          if (!exists) state.importedData.healthGoals.push({ text: g.text, severity: g.severity });
+          const exists = healthGoals.some(x => x.text === g.text);
+          if (!exists) appendImportedArrayItem(state.importedData, 'healthGoals', { text: g.text, severity: g.severity });
         }
       }
       // Import custom markers (merge, don't overwrite existing definitions)
@@ -814,15 +821,15 @@ export function importDataJSON(file) {
       }
       // Import change history (merge by field+date, imported snapshot wins on conflict)
       if (Array.isArray(json.changeHistory)) {
-        if (!state.importedData.changeHistory) state.importedData.changeHistory = [];
+        const changeHistory = ensureImportedArray(state.importedData, 'changeHistory');
         for (const entry of json.changeHistory) {
           if (!entry.field || !entry.date) continue;
-          const idx = state.importedData.changeHistory.findIndex(e => e.field === entry.field && e.date === entry.date);
-          if (idx >= 0) { state.importedData.changeHistory[idx] = entry; }
-          else { state.importedData.changeHistory.push(entry); }
+          const idx = changeHistory.findIndex(e => e.field === entry.field && e.date === entry.date);
+          if (idx >= 0) { replaceImportedArrayItem(state.importedData, 'changeHistory', idx, entry); }
+          else { appendImportedArrayItem(state.importedData, 'changeHistory', entry); }
         }
-        state.importedData.changeHistory.sort((a, b) => a.date.localeCompare(b.date));
-        while (state.importedData.changeHistory.length > 200) state.importedData.changeHistory.shift();
+        sortImportedArray(state.importedData, 'changeHistory', (a, b) => a.date.localeCompare(b.date));
+        trimImportedArray(state.importedData, 'changeHistory', 200);
       }
       // Import wearable layer (added v1.27.1). The summary, card order, and
       // per-metric override flow in; raw L1 IDB rows do not (they're never
@@ -852,20 +859,20 @@ export function importDataJSON(file) {
       }
       // Import chat summaries (merge by threadId)
       if (Array.isArray(json.chatSummaries)) {
-        if (!state.importedData.chatSummaries) state.importedData.chatSummaries = [];
+        const chatSummaries = ensureImportedArray(state.importedData, 'chatSummaries');
         for (const s of json.chatSummaries) {
           if (!s.threadId) continue;
-          const idx = state.importedData.chatSummaries.findIndex(e => e.threadId === s.threadId);
-          if (idx >= 0) { state.importedData.chatSummaries[idx] = s; }
-          else { state.importedData.chatSummaries.push(s); }
+          const idx = chatSummaries.findIndex(e => e.threadId === s.threadId);
+          if (idx >= 0) { replaceImportedArrayItem(state.importedData, 'chatSummaries', idx, s); }
+          else { appendImportedArrayItem(state.importedData, 'chatSummaries', s); }
         }
       }
       // Import supplements
       if (json.supplements && Array.isArray(json.supplements)) {
-        if (!state.importedData.supplements) state.importedData.supplements = [];
+        const supplements = ensureImportedArray(state.importedData, 'supplements');
         for (const s of json.supplements) {
           if (!s.name || !s.startDate) continue;
-          const exists = state.importedData.supplements.some(x => x.name === s.name && x.startDate === s.startDate);
+          const exists = supplements.some(x => x.name === s.name && x.startDate === s.startDate);
           if (!exists) {
             const entry = { name: s.name, dosage: s.dosage || '', startDate: s.startDate, endDate: s.endDate || null, type: s.type || 'supplement', note: s.note || '' };
             if (s.ingredients) entry.ingredients = s.ingredients;
@@ -876,18 +883,18 @@ export function importDataJSON(file) {
                 if (sourceUrl.protocol === 'http:' || sourceUrl.protocol === 'https:') entry.sourceUrl = sourceUrl.toString();
               } catch {}
             }
-            state.importedData.supplements.push(entry);
+            appendImportedArrayItem(state.importedData, 'supplements', entry);
           }
         }
       }
       // Import notes
       if (json.notes && Array.isArray(json.notes)) {
-        if (!state.importedData.notes) state.importedData.notes = [];
+        const notes = ensureImportedArray(state.importedData, 'notes');
         for (const note of json.notes) {
           if (!note.date || !note.text) continue;
           // Avoid duplicates (same date + same text)
-          const exists = state.importedData.notes.some(n => n.date === note.date && n.text === note.text);
-          if (!exists) state.importedData.notes.push({ date: note.date, text: note.text });
+          const exists = notes.some(n => n.date === note.date && n.text === note.text);
+          if (!exists) appendImportedArrayItem(state.importedData, 'notes', { date: note.date, text: note.text });
         }
       }
       migrateProfileData(state.importedData);
@@ -945,37 +952,38 @@ async function _importDatabaseBundle(json) {
       const raw = await encryptedGetItem(storageKey);
       let current;
       try { current = raw ? JSON.parse(raw) : {}; } catch { current = {}; }
-      if (!current.entries) current.entries = [];
       // Entries: date-keyed upsert
       if (Array.isArray(importData.entries)) {
+        const entries = ensureImportedArray(current, 'entries');
         for (const entry of importData.entries) {
           if (!entry.date || !entry.markers) continue;
-          current.entries = current.entries.filter(ex => ex.date !== entry.date);
-          current.entries.push(entry);
+          const idx = entries.findIndex(ex => ex.date === entry.date);
+          if (idx >= 0) { replaceImportedArrayItem(current, 'entries', idx, entry); }
+          else { appendImportedArrayItem(current, 'entries', entry); }
         }
       }
       // Notes: deduplicate by date+text
       if (Array.isArray(importData.notes)) {
-        if (!current.notes) current.notes = [];
+        const notes = ensureImportedArray(current, 'notes');
         for (const n of importData.notes) {
           if (!n.date || !n.text) continue;
-          if (!current.notes.some(x => x.date === n.date && x.text === n.text)) current.notes.push(n);
+          if (!notes.some(x => x.date === n.date && x.text === n.text)) appendImportedArrayItem(current, 'notes', n);
         }
       }
       // Supplements: deduplicate by name+startDate
       if (Array.isArray(importData.supplements)) {
-        if (!current.supplements) current.supplements = [];
+        const supplements = ensureImportedArray(current, 'supplements');
         for (const s of importData.supplements) {
           if (!s.name || !s.startDate) continue;
-          if (!current.supplements.some(x => x.name === s.name && x.startDate === s.startDate)) current.supplements.push(s);
+          if (!supplements.some(x => x.name === s.name && x.startDate === s.startDate)) appendImportedArrayItem(current, 'supplements', s);
         }
       }
       // Health goals: deduplicate by text
       if (Array.isArray(importData.healthGoals)) {
-        if (!current.healthGoals) current.healthGoals = [];
+        const healthGoals = ensureImportedArray(current, 'healthGoals');
         for (const g of importData.healthGoals) {
           if (!g.text) continue;
-          if (!current.healthGoals.some(x => x.text === g.text)) current.healthGoals.push(g);
+          if (!healthGoals.some(x => x.text === g.text)) appendImportedArrayItem(current, 'healthGoals', g);
         }
       }
       // Custom markers: merge (don't overwrite existing)
@@ -1000,24 +1008,24 @@ async function _importDatabaseBundle(json) {
       if (importData.contextNotes) current.contextNotes = importData.contextNotes;
       // Change history: merge by field+date, imported snapshot wins on conflict
       if (Array.isArray(importData.changeHistory)) {
-        if (!current.changeHistory) current.changeHistory = [];
+        const changeHistory = ensureImportedArray(current, 'changeHistory');
         for (const entry of importData.changeHistory) {
           if (!entry.field || !entry.date) continue;
-          const idx = current.changeHistory.findIndex(e => e.field === entry.field && e.date === entry.date);
-          if (idx >= 0) { current.changeHistory[idx] = entry; }
-          else { current.changeHistory.push(entry); }
+          const idx = changeHistory.findIndex(e => e.field === entry.field && e.date === entry.date);
+          if (idx >= 0) { replaceImportedArrayItem(current, 'changeHistory', idx, entry); }
+          else { appendImportedArrayItem(current, 'changeHistory', entry); }
         }
-        current.changeHistory.sort((a, b) => a.date.localeCompare(b.date));
-        while (current.changeHistory.length > 200) current.changeHistory.shift();
+        sortImportedArray(current, 'changeHistory', (a, b) => a.date.localeCompare(b.date));
+        trimImportedArray(current, 'changeHistory', 200);
       }
       // Chat summaries: merge by threadId
       if (Array.isArray(importData.chatSummaries)) {
-        if (!current.chatSummaries) current.chatSummaries = [];
+        const chatSummaries = ensureImportedArray(current, 'chatSummaries');
         for (const s of importData.chatSummaries) {
           if (!s.threadId) continue;
-          const idx = current.chatSummaries.findIndex(e => e.threadId === s.threadId);
-          if (idx >= 0) { current.chatSummaries[idx] = s; }
-          else { current.chatSummaries.push(s); }
+          const idx = chatSummaries.findIndex(e => e.threadId === s.threadId);
+          if (idx >= 0) { replaceImportedArrayItem(current, 'chatSummaries', idx, s); }
+          else { appendImportedArrayItem(current, 'chatSummaries', s); }
         }
       }
       // Display overrides: merge labels/icons/manualValues (don't overwrite existing)

--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -4,7 +4,12 @@ import { state } from './state.js';
 import { getAlternateUnit, convertUserInputToSI } from './schema.js';
 import { escapeHTML, escapeAttr, formatValue, showNotification, showConfirmDialog, showPromptDialog } from './utils.js';
 import { getActiveData, saveImportedData, recalculateHOMAIR, updateHeaderDates, convertDisplayToSI } from './data.js';
-import { clearTombstone } from './data-merge.js';
+import {
+  appendImportedArrayItem,
+  clearTombstone,
+  deleteImportedArrayItems,
+  ensureImportedArray,
+} from './data-merge.js';
 
 const markerDetailDeps = {
   navigate: (category, data) => window.navigate?.(category, data),
@@ -57,6 +62,12 @@ function _rememberManualOriginal(dotKey, date, entry) {
   } else if (state.importedData.manualValues[mvKey] === true && hasImportedOriginal) {
     state.importedData.manualValues[mvKey] = current;
   }
+}
+
+function stampLabEntryUpdated(entry, now = Date.now()) {
+  if (!entry || typeof entry !== 'object') return now;
+  entry.updatedAt = now;
+  return now;
 }
 
 export async function saveManualEntry(id, opts = {}) {
@@ -115,12 +126,13 @@ export async function saveManualEntry(id, opts = {}) {
     const unit = marker?.unit || '';
     if (!await showConfirmDialog(`A value of ${displayVal} ${unit} already exists for ${date}. Overwrite?`)) return;
   }
-  if (!state.importedData.entries) state.importedData.entries = [];
+  const entries = ensureImportedArray(state.importedData, 'entries');
   clearTombstone(state.importedData, 'entries', date);
-  let entry = state.importedData.entries.find(e => e.date === date);
+  let entry = entries.find(e => e.date === date);
+  const now = Date.now();
   if (!entry) {
-    entry = { date: date, markers: {} };
-    state.importedData.entries.push(entry);
+    entry = { date: date, markers: {}, updatedAt: now };
+    appendImportedArrayItem(state.importedData, 'entries', entry);
   }
   // If the user picked the alternate unit, convert from there directly to SI
   // (convertUserInputToSI is a no-op when inputUnit is already the SI unit, so
@@ -132,7 +144,7 @@ export async function saveManualEntry(id, opts = {}) {
   _rememberManualOriginal(dotKey, date, entry);
   entry.markers[dotKey] = storedValue;
   if (!entry.markerSources) entry.markerSources = {};
-  entry.markerSources[dotKey] = { file: null, at: Date.now() };
+  entry.markerSources[dotKey] = { file: null, at: now };
   // Per-value note: store on save when non-empty; clear when emptied.
   if (!state.importedData.markerValueNotes) state.importedData.markerValueNotes = {};
   const noteKey = dotKey + ':' + date;
@@ -153,6 +165,7 @@ export async function saveManualEntry(id, opts = {}) {
     else delete state.importedData.markerValueNotes[insulinNoteMirror];
   }
   recalculateHOMAIR(entry);
+  stampLabEntryUpdated(entry, now);
   await saveImportedData();
   // Remember the date session-wide so the next manual entry defaults to it.
   try { sessionStorage.setItem('labcharts-last-manual-date', date); } catch (_) {}
@@ -185,6 +198,7 @@ export async function deleteMarkerValue(id, date) {
   const entry = state.importedData.entries.find(e => e.date === date);
   if (!entry || entry.markers[dotKey] === undefined) return;
   if (await showConfirmDialog(`Delete this value (${date})? This can't be undone.`)) {
+    const now = Date.now();
     delete entry.markers[dotKey];
     // Clean up provenance and manual tracking
     if (entry.markerSources) delete entry.markerSources[dotKey];
@@ -207,7 +221,9 @@ export async function deleteMarkerValue(id, date) {
     }
     // Remove entry entirely if no markers left
     if (Object.keys(entry.markers).length === 0) {
-      state.importedData.entries = state.importedData.entries.filter(e => e.date !== date);
+      deleteImportedArrayItems(state.importedData, 'entries', e => e.date === date);
+    } else {
+      stampLabEntryUpdated(entry, now);
     }
     saveImportedData();
     window.buildSidebar();
@@ -250,11 +266,13 @@ export function editMarkerValue(id, date, currentValue, event) {
     // Track as manually edited — store original value for revert (true = manual entry with no original)
     _rememberManualOriginal(dotKey, date, entry);
     const storedValue = convertDisplayToSI(dotKey, newValue);
+    const now = Date.now();
     entry.markers[dotKey] = storedValue;
     // Update provenance to reflect manual edit
     if (!entry.markerSources) entry.markerSources = {};
-    entry.markerSources[dotKey] = { file: null, at: Date.now() };
+    entry.markerSources[dotKey] = { file: null, at: now };
     if (dotKey === 'hormones.insulin') { entry.markers['diabetes.insulin_d'] = storedValue; if (entry.markerSources) entry.markerSources['diabetes.insulin_d'] = entry.markerSources[dotKey]; recalculateHOMAIR(entry); }
+    stampLabEntryUpdated(entry, now);
     await saveImportedData();
     // Rebuild the underlying view so Table/Heatmap/Chart reflect the edit.
     markerDetailDeps.navigate(state.currentView || 'dashboard');
@@ -283,6 +301,7 @@ export async function revertMarkerValue(id, date) {
     recalculateHOMAIR(entry);
   }
   delete state.importedData.manualValues[mvKey];
+  stampLabEntryUpdated(entry);
   await saveImportedData();
   // Rebuild the underlying view so Table/Heatmap/Chart reflect the revert.
   markerDetailDeps.navigate(state.currentView || 'dashboard');

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -7,6 +7,7 @@ import { getActiveData, getEffectiveRange, getEffectiveRangeForDate, saveImporte
 import { createLineChart, getMarkerDescription } from './charts.js';
 import { closeSuggestionsOnClickOutside } from './context-cards.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from './api.js';
+import { deleteImportedArrayItems } from './data-merge.js';
 import {
   configureMarkerDetailEditing,
   editRefRange,
@@ -981,7 +982,7 @@ export async function deleteCustomMarker(id) {
     }
     // Clean up empty entries
     if (state.importedData.entries) {
-      state.importedData.entries = state.importedData.entries.filter(e => Object.keys(e.markers || {}).length > 0);
+      deleteImportedArrayItems(state.importedData, 'entries', e => Object.keys(e.markers || {}).length === 0);
     }
     saveImportedData();
     closeModal();

--- a/js/pdf-import-persistence.js
+++ b/js/pdf-import-persistence.js
@@ -3,7 +3,7 @@
 import { state } from './state.js';
 import { showNotification, showPromptDialog } from './utils.js';
 import { saveImportedData } from './data.js';
-import { clearTombstone, recordTombstone } from './data-merge.js';
+import { clearTombstone, deleteImportedArrayItems, recordTombstone } from './data-merge.js';
 
 export function snapshotImportedData() {
   try { return JSON.stringify(state.importedData || {}); } catch { return null; }
@@ -33,9 +33,8 @@ function isValidISOCalendarDate(date) {
 export async function removeImportedEntry(date) {
   if (!date) return false;
   const rollback = snapshotImportedData();
-  if (!state.importedData.entries) state.importedData.entries = [];
   recordTombstone(state.importedData, 'entries', date);
-  state.importedData.entries = state.importedData.entries.filter(e => e.date !== date);
+  deleteImportedArrayItems(state.importedData, 'entries', e => e.date === date);
   const saved = await saveImportedData({ immediate: true });
   if (!saved) {
     restoreImportedDataSnapshot(rollback);

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -8,7 +8,7 @@ import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId, AI_IMPOR
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
-import { clearTombstone } from './data-merge.js';
+import { appendImportedArrayItem, clearTombstone, ensureImportedArray } from './data-merge.js';
 import { runPreflightChecks } from './pdf-import-preflight.js';
 import { normalizeParsedImportMarkers } from './pdf-import-marker-normalization.js';
 import {
@@ -405,12 +405,12 @@ export async function confirmImport() {
     closeImportModal();
     return;
   }
-  if (!state.importedData.entries) state.importedData.entries = [];
+  const entries = ensureImportedArray(state.importedData, 'entries');
   clearTombstone(state.importedData, 'entries', result.date);
-  let entry = state.importedData.entries.find(e => e.date === result.date);
+  let entry = entries.find(e => e.date === result.date);
   if (!entry) {
     entry = { date: result.date, markers: {} };
-    state.importedData.entries.push(entry);
+    appendImportedArrayItem(state.importedData, 'entries', entry);
   }
   entry.importedWith = {
     provider: result.costInfo?.provider || null,

--- a/js/startup-profile.js
+++ b/js/startup-profile.js
@@ -12,6 +12,7 @@ import {
   initProfilesCache,
 } from './profile.js';
 import { encryptedGetItem, encryptedSetItem } from './crypto.js';
+import { ensureImportedArray } from './data-merge.js';
 
 async function migrateLegacyProfileStorage() {
   if (localStorage.getItem('labcharts-profiles')) return;
@@ -52,7 +53,7 @@ export async function initializeProfileData() {
 
   try {
     state.importedData = JSON.parse(savedImported);
-    if (!state.importedData.notes) state.importedData.notes = [];
+    ensureImportedArray(state.importedData, 'notes');
     migrateProfileData(state.importedData);
   } catch (e) {}
 }

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -590,7 +590,6 @@ export function saveSupplement(idx) {
       return;
     }
   }
-  if (!state.importedData.supplements) state.importedData.supplements = [];
   const entry = { name, dosage, startDate, endDate, type, note, updatedAt: Date.now() };
   if (sorted.length > 1) entry.periods = sorted;
   if (ingredients) entry.ingredients = ingredients;

--- a/js/sync-storage-cleanup.js
+++ b/js/sync-storage-cleanup.js
@@ -3,6 +3,7 @@
 import { state } from './state.js';
 import { showNotification } from './utils.js';
 import { logSyncEvent } from './sync-state.js';
+import { trimImportedArray } from './data-merge.js';
 
 // "Clean storage" - emergency localStorage compaction. The 'imported'
 // blob can grow past the browser's 5 MB localStorage cap (caps were
@@ -33,7 +34,7 @@ export async function cleanStorage() {
   let historyTrimmed = 0;
   if (Array.isArray(state.importedData?.changeHistory) && state.importedData.changeHistory.length > 200) {
     historyTrimmed = state.importedData.changeHistory.length - 200;
-    state.importedData.changeHistory = state.importedData.changeHistory.slice(-200);
+    trimImportedArray(state.importedData, 'changeHistory', 200);
     try {
       const { saveImportedData } = await import('./data.js');
       await saveImportedData();

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -8,6 +8,11 @@
 
 import { state } from './state.js';
 import { saveImportedData } from './data.js';
+import {
+  appendImportedArrayItem,
+  ensureImportedArray,
+  trimImportedArray,
+} from './data-merge.js';
 import { getDailyRange } from './wearables-store.js';
 import {
   DEFAULT_METRIC_ORDER,
@@ -345,9 +350,9 @@ function appendAnomalyToChangeHistory(events) {
   if (!events || events.length === 0) return;
   const imp = state.importedData;
   if (!imp) return;
-  if (!Array.isArray(imp.changeHistory)) imp.changeHistory = [];
+  ensureImportedArray(imp, 'changeHistory');
   for (const e of events) {
-    imp.changeHistory.push({
+    appendImportedArrayItem(imp, 'changeHistory', {
       ts: e.ts || Date.now(),
       type: 'wearable',
       kind: e.kind,
@@ -356,9 +361,7 @@ function appendAnomalyToChangeHistory(events) {
       message: e.message,
     });
   }
-  if (imp.changeHistory.length > CHANGE_HISTORY_CAP) {
-    imp.changeHistory = imp.changeHistory.slice(-CHANGE_HISTORY_CAP);
-  }
+  trimImportedArray(imp, 'changeHistory', CHANGE_HISTORY_CAP);
 }
 
 export function persistWearableSummary(newSummary, anomalyEvents) {

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -28,6 +28,8 @@ const {
   recordTombstone,
   recordArrayItemTombstone,
   clearTombstone,
+  sortImportedArray,
+  trimImportedArray,
   unionById,
   ID_KEYED_ARRAYS,
   NATURAL_KEYED_ARRAYS,
@@ -198,6 +200,50 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
   assert('per-row entries overlay merges same-date markers instead of replacing fresh import',
     deltaMay?.markers?.['biochemistry.alp'] === 1.2
       && deltaMay?.markers?.['biochemistry.glucose'] === 4.7);
+  const sameMarkerRemoteManualEdit = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: 100,
+      markers: { 'biochemistry.glucose': 4.7 },
+      markerSources: { 'biochemistry.glucose': { file: 'old-sync.pdf', at: 100 } },
+    }],
+  };
+  await mergeArrayRowsIntoImported(sameMarkerRemoteManualEdit, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: new Date(200).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      date: '2026-05-01',
+      updatedAt: 200,
+      markers: { 'biochemistry.glucose': 5.1 },
+      markerSources: { 'biochemistry.glucose': { file: null, at: 200 } },
+    }),
+  }]);
+  assert('newer per-row entries overlay applies same-marker manual edit',
+    sameMarkerRemoteManualEdit.entries[0].markers?.['biochemistry.glucose'] === 5.1
+      && sameMarkerRemoteManualEdit.entries[0].markerSources?.['biochemistry.glucose']?.file === null);
+  const sameMarkerManualEdit = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: 200,
+      markers: { 'biochemistry.glucose': 5.1 },
+      markerSources: { 'biochemistry.glucose': { file: null, at: 200 } },
+    }],
+  };
+  await mergeArrayRowsIntoImported(sameMarkerManualEdit, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: new Date(100).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      date: '2026-05-01',
+      updatedAt: 100,
+      markers: { 'biochemistry.glucose': 4.7 },
+      markerSources: { 'biochemistry.glucose': { file: 'old-sync.pdf', at: 100 } },
+    }),
+  }]);
+  assert('stale per-row entries overlay does not revert same-marker manual edit',
+    sameMarkerManualEdit.entries[0].markers?.['biochemistry.glucose'] === 5.1
+      && sameMarkerManualEdit.entries[0].markerSources?.['biochemistry.glucose']?.file === null);
   const editedDeviceSession = {
     deviceSessions: [{
       id: 'devsess_duration_edit',
@@ -636,6 +682,22 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
   assert('clearImportedArray tombstones every configured row',
     clearedBlob.healthGoals.length === 0
       && clearedGoalIds.every(id => clearedBlob._deleted?.healthGoals?.includes(id)));
+
+  const historyBlob = {
+    changeHistory: [
+      { field: 'b', date: '2026-05-03', snapshot: 3 },
+      { field: 'a', date: '2026-05-01', snapshot: 1 },
+      { field: 'a', date: '2026-05-02', snapshot: 2 },
+    ],
+  };
+  sortImportedArray(historyBlob, 'changeHistory', (a, b) => a.date.localeCompare(b.date));
+  const trimmedHistory = trimImportedArray(historyBlob, 'changeHistory', 2);
+  assert('sortImportedArray + trimImportedArray keep newest composite rows without tombstones',
+    trimmedHistory.length === 1
+      && trimmedHistory[0].date === '2026-05-01'
+      && historyBlob.changeHistory.length === 2
+      && historyBlob.changeHistory[0].date === '2026-05-02'
+      && !historyBlob._deleted?.changeHistory);
 
   // ─── 10. Tombstone union from both sides ──────────────────────────────
   console.log('%c 10. Tombstone union ', 'font-weight:bold;color:#f59e0b');

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -340,15 +340,16 @@ return (async function() {
   // _importDatabaseBundle merge logic
   assert('Bundle import matches by id first', exportSrc.includes('profiles.find(p => p.id === bp.id)'));
   assert('Bundle import falls back to name match', exportSrc.includes('profiles.find(p => p.name === bp.name)'));
-  assert('Bundle import does date-keyed entry upsert', exportSrc.includes('current.entries.filter(ex => ex.date !== entry.date)'));
-  assert('Bundle import deduplicates notes', exportSrc.includes('current.notes.some(x => x.date === n.date && x.text === n.text)'));
-  assert('Bundle import deduplicates supplements', exportSrc.includes('current.supplements.some(x => x.name === s.name && x.startDate === s.startDate)'));
-  assert('Bundle import merges health goals', exportSrc.includes('current.healthGoals.some(x => x.text === g.text)'));
+  assert('Bundle import does date-keyed entry upsert',
+    /const entries = ensureImportedArray\(current,\s*['"]entries['"]\)[\s\S]{0,260}entries\.findIndex\(ex => ex\.date === entry\.date\)[\s\S]{0,180}replaceImportedArrayItem\(current,\s*['"]entries['"],\s*idx,\s*entry\)/.test(exportSrc));
+  assert('Bundle import deduplicates notes', exportSrc.includes('notes.some(x => x.date === n.date && x.text === n.text)'));
+  assert('Bundle import deduplicates supplements', exportSrc.includes('supplements.some(x => x.name === s.name && x.startDate === s.startDate)'));
+  assert('Bundle import merges health goals', exportSrc.includes('healthGoals.some(x => x.text === g.text)'));
   assert('Bundle import merges custom markers', exportSrc.includes("!current.customMarkers[key]"));
   assert('Bundle import merges ref overrides', exportSrc.includes("!current.refOverrides[key]"));
   assert('Bundle import replaces context fields', exportSrc.includes("for (const field of ['diagnoses', 'diet', 'exercise'"));
-  assert('Bundle import caps changeHistory at 200', exportSrc.includes('current.changeHistory.length > 200'));
-  assert('Bundle import merges chat summaries', exportSrc.includes('current.chatSummaries.findIndex'));
+  assert('Bundle import caps changeHistory at 200', exportSrc.includes("trimImportedArray(current, 'changeHistory', 200)"));
+  assert('Bundle import merges chat summaries', exportSrc.includes('chatSummaries.findIndex'));
   assert('Bundle import creates new profiles', exportSrc.includes("createProfile(bp.name || 'Imported'"));
   assert('Bundle import loads first imported profile', exportSrc.includes('loadProfile(targetId)'));
   assert('Bundle import handles wallet restore', exportSrc.includes('json.wallet'));

--- a/tests/test-manual-entry-flow.js
+++ b/tests/test-manual-entry-flow.js
@@ -74,7 +74,14 @@ console.log('=== Manual Entry Flow Tests ===\n');
   assert('Manual overwrite remembers imported original for revert',
     /function _rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailEditingSrc) &&
     /state\.importedData\.manualValues\[mvKey\] = hasImportedOriginal \? current : true/.test(markerDetailEditingSrc) &&
-    /saveManualEntry[\s\S]{0,3500}_rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailEditingSrc));
+    /saveManualEntry[\s\S]{0,5000}_rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailEditingSrc));
+  assert('Manual value saves stamp lab entry updatedAt for sync freshness',
+    /function stampLabEntryUpdated\(entry, now = Date\.now\(\)\)/.test(markerDetailEditingSrc)
+      && /saveManualEntry[\s\S]{0,4500}stampLabEntryUpdated\(entry, now\)/.test(markerDetailEditingSrc)
+      && /editMarkerValue[\s\S]{0,2200}stampLabEntryUpdated\(entry, now\)/.test(markerDetailEditingSrc)
+      && /revertMarkerValue[\s\S]{0,1000}stampLabEntryUpdated\(entry\)/.test(markerDetailEditingSrc));
+  assert('Manual marker delete stamps remaining lab entry for sync freshness',
+    /deleteMarkerValue[\s\S]{0,1800}else \{\s*stampLabEntryUpdated\(entry, now\);?\s*\}/.test(markerDetailEditingSrc));
   assert('Clickable manual badge reverts to imported value when original exists',
     /manual \\u00d7/.test(markerDetailSrc) &&
     /Revert manual value to imported value/.test(markerDetailSrc) &&

--- a/tests/test-provenance.js
+++ b/tests/test-provenance.js
@@ -33,9 +33,9 @@ console.log('\n2. Manual Entry Provenance');
 const markerDetailSrc = read('js/marker-detail-modal.js');
 const markerDetailEditingSrc = read('js/marker-detail-editing.js');
 assert('saveManualEntry inits markerSources', markerDetailEditingSrc.includes('if (!entry.markerSources) entry.markerSources = {};'));
-assert('saveManualEntry sets file:null', markerDetailEditingSrc.includes("entry.markerSources[dotKey] = { file: null, at: Date.now() }"));
+assert('saveManualEntry sets file:null', /entry\.markerSources\[dotKey\] = \{ file: null, at: (?:Date\.now\(\)|now) \}/.test(markerDetailEditingSrc));
 const editSection = markerDetailEditingSrc.split('function editMarkerValue')[1] || '';
-assert('editMarkerValue sets provenance', editSection.includes("entry.markerSources[dotKey] = { file: null, at: Date.now() }"));
+assert('editMarkerValue sets provenance', /entry\.markerSources\[dotKey\] = \{ file: null, at: (?:Date\.now\(\)|now) \}/.test(editSection));
 
 // ─── 3. Detail Modal Display ───
 console.log('\n3. Detail Modal Display');

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -17,6 +17,16 @@ function fetchWithRetry(rel) {
   return Promise.resolve(read(rel));
 }
 
+function listJsFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listJsFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
   if (condition) { pass++; console.log(`  PASS: ${name}`); }
@@ -634,6 +644,24 @@ await import('../js/settings.js');
       && contextCardLifestyleEditorsSrc.includes('refreshOpenHealthGoalsModalOnSync')
       && contextCardLifestyleEditorsSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenHealthGoalsModalOnSync)")
       && contextCardLifestyleEditorsSrc.includes("modal.dataset.syncRefreshKind = 'healthGoals'"));
+  {
+    const syncedArraySurfaces = ['entries', 'notes', 'supplements', 'healthGoals', 'chatSummaries', 'changeHistory'];
+    const helperOwnedFiles = new Set(['js/data-merge.js']);
+    const ownerExpr = '(?:state\\.importedData|current|imp)';
+    const mutationExpr = new RegExp(`${ownerExpr}\\.(${syncedArraySurfaces.join('|')})(?:\\s*=|\\.(?:push|splice|filter|sort|unshift|shift|pop|reverse)\\b)`);
+    const violations = [];
+    for (const abs of listJsFiles(path.join(ROOT, 'js'))) {
+      const rel = path.relative(ROOT, abs).replace(/\\/g, '/');
+      if (helperOwnedFiles.has(rel)) continue;
+      const lines = fs.readFileSync(abs, 'utf-8').split('\n');
+      lines.forEach((line, i) => {
+        if (mutationExpr.test(line)) violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+      });
+    }
+    assert('delta-synced arrays mutate through shared imported-array helpers',
+      violations.length === 0,
+      violations.slice(0, 8).join(' | '));
+  }
   assert('saved chat summary modal refreshes on sync-applied',
     chatSummariesSrc.includes('refreshOpenSummaryModalOnSync')
       && chatSummariesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenSummaryModalOnSync)")

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -63,7 +63,7 @@ const settingsSrc = read('js/settings.js');
       && /if \(!saved\) \{[\s\S]{0,200}restoreImportedDataSnapshot\(rollback\)/.test(confirmBlock));
   const removeBlock = persistenceSrc.substring(persistenceSrc.indexOf('export async function removeImportedEntry'), persistenceSrc.indexOf('export async function renameImportedEntryDate'));
   assert('import delete records entries tombstone before removing row',
-    /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*date\)[\s\S]{0,180}entries\.filter/.test(removeBlock));
+    /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*date\)[\s\S]{0,180}deleteImportedArrayItems\(state\.importedData,\s*['"]entries['"],\s*e => e\.date === date\)/.test(removeBlock));
   assert('import delete uses immediate sync push',
     /await\s+saveImportedData\(\{\s*immediate:\s*true\s*\}\)/.test(removeBlock));
   assert('import delete restores state and returns false when save fails',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.295';
+self.APP_VERSION = '1.8.297';


### PR DESCRIPTION
## Summary
- routes remaining synced `importedData` array mutations through shared helpers for entries, notes, supplements, health goals, chat summaries, and change history
- adds sort/trim helpers for imported arrays, with no-tombstone handling for capped change history
- adds a source guard so future direct mutations in `js/` fail tests

## Validation
- `node tests/test-unit-import.js`
- `node tests/test-sync.js`
- `node tests/test-data-merge.js`
- focused `tests/test-export-import.js` browser run: 211 passed, 0 failed
- `./run-tests.sh`