### PR TITLE
Centralize lab entry marker mutations

### DIFF
--- a/js/context-card-health-dots.js
+++ b/js/context-card-health-dots.js
@@ -97,7 +97,7 @@ function staleCardsHaveAssessableData(staleKeys) {
     return hasCardContent(state.importedData[k]);
   });
   if (staleHaveContent) return true;
-  return (state.importedData.entries || []).length > 0;
+  return (state.importedData.entries || []).some(entry => Object.keys(entry?.markers || {}).length > 0);
 }
 
 function applyGrayDots(keys) {

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -2,6 +2,14 @@
 
 import { DELTA_ARRAY_CONFIG } from './sync-delta-surface-config.js';
 import { _isAllowlistSafeId } from './sync-delta-id.js';
+import {
+  LAB_ENTRY_MARKER_TOMBSTONES,
+  getLabEntryMarkerTombstoneAt,
+  getLabEntryMarkerTombstones,
+  getLabEntryMarkerValueTimestamp,
+  labEntryMarkerAffectsHOMAIR,
+  recalculateLabEntryHOMAIR,
+} from './lab-entry.js';
 //
 // Background: sync pushes the whole `importedData` blob and pull used to do
 // `localStorage.setItem(JSON.stringify(remote))`. With concurrent edits on
@@ -186,29 +194,69 @@ export function mergeLabEntry(existing, incoming) {
   const base = incomingWins ? { ...existing, ...incoming } : { ...incoming, ...existing };
   const markers = {};
   const markerSources = {};
+  const markerTombstones = {};
   const existingMarkers = existing.markers && typeof existing.markers === 'object' ? existing.markers : {};
   const incomingMarkers = incoming.markers && typeof incoming.markers === 'object' ? incoming.markers : {};
   const existingSources = existing.markerSources && typeof existing.markerSources === 'object' ? existing.markerSources : {};
   const incomingSources = incoming.markerSources && typeof incoming.markerSources === 'object' ? incoming.markerSources : {};
-  const markerKeys = new Set([...Object.keys(existingMarkers), ...Object.keys(incomingMarkers)]);
+  const existingTombstones = getLabEntryMarkerTombstones(existing);
+  const incomingTombstones = getLabEntryMarkerTombstones(incoming);
+  const markerKeys = new Set([
+    ...Object.keys(existingMarkers),
+    ...Object.keys(incomingMarkers),
+    ...Object.keys(existingTombstones),
+    ...Object.keys(incomingTombstones),
+  ]);
+  let homaIRInputChanged = false;
+  let homaIRInputDeleted = false;
   for (const key of markerKeys) {
-    if (Object.prototype.hasOwnProperty.call(existingMarkers, key)
-      && Object.prototype.hasOwnProperty.call(incomingMarkers, key)) {
-      markers[key] = incomingWins ? incomingMarkers[key] : existingMarkers[key];
-      markerSources[key] = incomingWins
-        ? (incomingSources[key] || existingSources[key])
-        : (existingSources[key] || incomingSources[key]);
-    } else if (Object.prototype.hasOwnProperty.call(incomingMarkers, key)) {
+    const hasExisting = Object.prototype.hasOwnProperty.call(existingMarkers, key);
+    const hasIncoming = Object.prototype.hasOwnProperty.call(incomingMarkers, key);
+    const existingValueTs = hasExisting ? getLabEntryMarkerValueTimestamp(existing, key) : 0;
+    const incomingValueTs = hasIncoming ? getLabEntryMarkerValueTimestamp(incoming, key) : 0;
+    const deleteTs = Math.max(
+      getLabEntryMarkerTombstoneAt(existing, key),
+      getLabEntryMarkerTombstoneAt(incoming, key)
+    );
+    const valueTs = Math.max(existingValueTs, incomingValueTs);
+    if (deleteTs && deleteTs >= valueTs) {
+      markerTombstones[key] = deleteTs;
+      if (labEntryMarkerAffectsHOMAIR(key)) {
+        homaIRInputChanged = true;
+        homaIRInputDeleted = true;
+      }
+      continue;
+    }
+    if (hasExisting && hasIncoming) {
+      const markerIncomingWins = incomingValueTs > existingValueTs
+        || (incomingValueTs === existingValueTs && incomingWins);
+      markers[key] = markerIncomingWins ? incomingMarkers[key] : existingMarkers[key];
+      const sources = markerIncomingWins ? incomingSources : existingSources;
+      if (Object.prototype.hasOwnProperty.call(sources, key)) markerSources[key] = sources[key];
+      if (labEntryMarkerAffectsHOMAIR(key) && !Object.is(existingMarkers[key], incomingMarkers[key])) {
+        homaIRInputChanged = true;
+      }
+    } else if (hasIncoming) {
       markers[key] = incomingMarkers[key];
       if (incomingSources[key]) markerSources[key] = incomingSources[key];
-    } else {
+      if (labEntryMarkerAffectsHOMAIR(key)) homaIRInputChanged = true;
+    } else if (hasExisting) {
       markers[key] = existingMarkers[key];
       if (existingSources[key]) markerSources[key] = existingSources[key];
+      if (labEntryMarkerAffectsHOMAIR(key)) homaIRInputChanged = true;
     }
   }
   base.markers = markers;
   if (Object.keys(markerSources).length) base.markerSources = markerSources;
   else delete base.markerSources;
+  if (Object.keys(markerTombstones).length) base[LAB_ENTRY_MARKER_TOMBSTONES] = markerTombstones;
+  else delete base[LAB_ENTRY_MARKER_TOMBSTONES];
+  const hasMergedHOMAIR = Object.prototype.hasOwnProperty.call(markers, 'diabetes.homaIR');
+  const hasMergedGlucose = Object.prototype.hasOwnProperty.call(markers, 'biochemistry.glucose');
+  const hasMergedInsulin = Object.prototype.hasOwnProperty.call(markers, 'hormones.insulin')
+    || Object.prototype.hasOwnProperty.call(markers, 'diabetes.insulin_d');
+  const wouldDeleteExistingHOMAIR = hasMergedHOMAIR && (!hasMergedGlucose || !hasMergedInsulin);
+  if (homaIRInputChanged && (!wouldDeleteExistingHOMAIR || homaIRInputDeleted)) recalculateLabEntryHOMAIR(base);
   const sourceFiles = mergeSourceFiles(existing, incoming);
   if (sourceFiles.length) {
     base.sourceFiles = sourceFiles;
@@ -734,6 +782,12 @@ export function localHasRowsRemoteLacks(local, remote) {
         if (!Object.prototype.hasOwnProperty.call(remoteMarkers, key)) return true;
         if (JSON.stringify(value) !== JSON.stringify(remoteMarkers[key])) return true;
       }
+      const localMarkerTombs = getLabEntryMarkerTombstones(entry);
+      const remoteMarkerTombs = getLabEntryMarkerTombstones(remoteEntry);
+      for (const [key, ts] of Object.entries(localMarkerTombs)) {
+        if (Number.isFinite(ts) && ts > (normalizeTimestamp(remoteMarkerTombs[key]) || 0)) return true;
+      }
+      if (compareRecordFreshness(entry, remoteEntry) > 0) return true;
     }
   }
   for (const field of LOCAL_WINS_MAP_FIELDS) {

--- a/js/data.js
+++ b/js/data.js
@@ -6,6 +6,7 @@ import { hashString, getStatus, formatValue, linearRegression, showNotification 
 import { profileStorageKey, touchProfileTimestamp } from './profile.js';
 import { encryptedSetItem, broadcastDataChanged, scheduleAutoBackup } from './crypto.js';
 import { onDataSaved } from './sync.js';
+import { recalculateLabEntryHOMAIR } from './lab-entry.js';
 
 // ═══════════════════════════════════════════════
 // PRIVATE CYCLE PHASE HELPER (avoids circular dep with cycle.js)
@@ -743,11 +744,7 @@ export function setPhaseOverlay(mode) {
 }
 
 export function recalculateHOMAIR(entry) {
-  const glucose = entry.markers["biochemistry.glucose"];
-  const insulin = entry.markers["hormones.insulin"] || entry.markers["diabetes.insulin_d"];
-  if (glucose !== undefined && insulin !== undefined) {
-    entry.markers["diabetes.homaIR"] = Math.round((glucose * insulin) / 22.5 * 100) / 100;
-  }
+  recalculateLabEntryHOMAIR(entry);
 }
 
 // ═══════════════════════════════════════════════

--- a/js/export.js
+++ b/js/export.js
@@ -13,6 +13,8 @@ import {
   sortImportedArray,
   trimImportedArray,
 } from './data-merge.js';
+import { findOrCreateLabEntry } from './lab-entry-mutations.js';
+import { setLabEntryMarker } from './lab-entry.js';
 
 // ═══════════════════════════════════════════════
 // PDF REPORT EXPORT
@@ -557,9 +559,9 @@ export function importDataJSON(file) {
         await loadProfile(profileId);
       }
       let count = 0;
+      const importTs = Date.now();
       for (const entry of json.entries) {
         if (!entry.date || !entry.markers) continue;
-        const entries = ensureImportedArray(state.importedData, 'entries');
         // Earlier draft did `filter(ex => ex.date !== entry.date)` — same-
         // date entries clobbered each other. The demos legitimately ship
         // two entries per date (comprehensive panel + specialty add-on
@@ -567,16 +569,24 @@ export function importDataJSON(file) {
         // second entry was silently dropped, losing every fatty-acid /
         // specialty marker on import. Merge markers + markerSources
         // instead so all data lands; later entries win on key conflicts.
-        const existing = entries.find(ex => ex.date === entry.date);
-        if (existing) {
-          Object.assign(existing.markers || (existing.markers = {}), entry.markers);
-          if (entry.markerSources) {
-            Object.assign(existing.markerSources || (existing.markerSources = {}), entry.markerSources);
-          }
-          if (entry.file && !existing.file) existing.file = entry.file;
-        } else {
-          appendImportedArrayItem(state.importedData, 'entries', entry);
+        const existing = findOrCreateLabEntry(state.importedData, entry.date, { now: importTs });
+        for (const [key, value] of Object.entries(entry.markers)) {
+          const source = entry.markerSources?.[key]
+            ? { ...entry.markerSources[key] }
+            : null;
+          setLabEntryMarker(existing, key, value, {
+            now: importTs,
+            mirrorInsulin: true,
+            ...(source ? { source } : {}),
+          });
         }
+        if (entry.file && !existing.file) existing.file = entry.file;
+        if (entry.sourceFile && !existing.sourceFile) existing.sourceFile = entry.sourceFile;
+        if (Array.isArray(entry.sourceFiles)) {
+          existing.sourceFiles = Array.from(new Set([...(existing.sourceFiles || []), ...entry.sourceFiles]));
+        }
+        if (entry.importedWith && !existing.importedWith) existing.importedWith = entry.importedWith;
+        if (entry.importHash && !existing.importHash) existing.importHash = entry.importHash;
         count++;
       }
       if (count === 0 && (!json.notes || json.notes.length === 0)) { showNotification('No valid entries found in JSON', 'error'); return; }
@@ -1230,16 +1240,16 @@ export async function loadDemoData(sex = 'male') {
         // structuredClone keeps the original demoJson reference clean
         // for any downstream usage (currently none, but defensive).
         const _ctxData = structuredClone(demoJson);
-        const _entryByDate = new Map();
-        for (const e of (_ctxData.entries || [])) {
-          const existing = _entryByDate.get(e.date);
-          if (existing) {
-            Object.assign(existing.markers || (existing.markers = {}), e.markers || {});
-          } else {
-            _entryByDate.set(e.date, e);
+        const _ctxSourceEntries = Array.isArray(_ctxData.entries) ? _ctxData.entries : [];
+        const _ctxImportTs = Date.now();
+        _ctxData.entries = [];
+        for (const entry of _ctxSourceEntries) {
+          if (!entry.date || !entry.markers) continue;
+          const existing = findOrCreateLabEntry(_ctxData, entry.date, { now: _ctxImportTs });
+          for (const [key, value] of Object.entries(entry.markers)) {
+            setLabEntryMarker(existing, key, value, { now: _ctxImportTs, mirrorInsulin: true });
           }
         }
-        _ctxData.entries = Array.from(_entryByDate.values());
         try { migrateProfileData(_ctxData); } catch (_) {}
         const ctx = {
           importedData: _ctxData,

--- a/js/lab-entry-mutations.js
+++ b/js/lab-entry-mutations.js
@@ -1,0 +1,89 @@
+// lab-entry-mutations.js - importedData-level lab entry mutation helpers.
+
+import {
+  appendImportedArrayItem,
+  clearTombstone,
+  deleteImportedArrayItems,
+  ensureImportedArray,
+} from './data-merge.js';
+import {
+  createLabEntry,
+  deleteLabEntryMarker,
+  isLabEntryRemovable,
+} from './lab-entry.js';
+
+export function findOrCreateLabEntry(importedData, date, opts = {}) {
+  if (!importedData || typeof importedData !== 'object' || !date) return null;
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const entries = ensureImportedArray(importedData, 'entries');
+  if (opts.clearTombstone !== false) clearTombstone(importedData, 'entries', date);
+  let entry = entries.find(e => e?.date === date);
+  if (!entry) {
+    entry = createLabEntry(date, { now });
+    appendImportedArrayItem(importedData, 'entries', entry);
+  }
+  return entry;
+}
+
+export function deleteEmptyLabEntries(importedData) {
+  return deleteImportedArrayItems(importedData, 'entries', entry => isLabEntryRemovable(entry));
+}
+
+export function deleteLabEntryMarkerFromImportedData(importedData, entry, dotKey, opts = {}) {
+  const result = deleteLabEntryMarker(entry, dotKey, opts);
+  if (!result.changed) return result;
+  if (opts.deleteMetadata !== false) {
+    for (const key of result.deletedKeys) deleteLabEntryMarkerMetadata(importedData, key, entry.date);
+  }
+  if (opts.deleteEntryIfEmpty === false) return result;
+  if (isLabEntryRemovable(entry)) {
+    const removed = deleteImportedArrayItems(importedData, 'entries', item => item === entry);
+    result.removedEntry = removed.length > 0;
+  }
+  return result;
+}
+
+export function deleteLabEntryMarkerMetadata(importedData, dotKey, date) {
+  if (!importedData || !dotKey || !date) return;
+  const key = `${dotKey}:${date}`;
+  if (importedData.manualValues && Object.prototype.hasOwnProperty.call(importedData.manualValues, key)) {
+    importedData.manualValues[key] = null;
+  }
+  if (importedData.markerValueNotes && Object.prototype.hasOwnProperty.call(importedData.markerValueNotes, key)) {
+    importedData.markerValueNotes[key] = null;
+  }
+}
+
+export function deleteLabEntryMarkerMetadataForAllDates(importedData, dotKey) {
+  if (!importedData || !dotKey) return;
+  const prefix = `${dotKey}:`;
+  for (const mapName of ['manualValues', 'markerValueNotes']) {
+    const map = importedData[mapName];
+    if (!map || typeof map !== 'object') continue;
+    for (const key of Object.keys(map)) {
+      if (key.startsWith(prefix)) map[key] = null;
+    }
+  }
+}
+
+export function deleteLabEntryMarkerValues(importedData, dotKey, opts = {}) {
+  if (!importedData || typeof importedData !== 'object' || !Array.isArray(importedData.entries)) return [];
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const changed = [];
+  for (const entry of importedData.entries) {
+    const result = deleteLabEntryMarker(entry, dotKey, {
+      now,
+      mirrorInsulin: opts.mirrorInsulin,
+      recordTombstone: opts.recordTombstone,
+      stamp: opts.stamp,
+    });
+    if (!result.changed) continue;
+    changed.push({ entry, result });
+    if (opts.deleteMetadata !== false) {
+      for (const key of result.deletedKeys) deleteLabEntryMarkerMetadata(importedData, key, entry.date);
+    }
+  }
+  if (opts.deleteMetadata !== false) deleteLabEntryMarkerMetadataForAllDates(importedData, dotKey);
+  if (opts.deleteEmptyEntries !== false) deleteEmptyLabEntries(importedData);
+  return changed;
+}

--- a/js/lab-entry.js
+++ b/js/lab-entry.js
@@ -1,0 +1,212 @@
+// lab-entry.js - shared helpers for mutating one lab entry row.
+
+export const LAB_ENTRY_MARKER_TOMBSTONES = 'deletedMarkers';
+
+function normalizeTimestamp(value) {
+  if (Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function ensureMarkerMap(entry) {
+  if (!entry.markers || typeof entry.markers !== 'object') entry.markers = {};
+  return entry.markers;
+}
+
+function ensureMarkerSources(entry) {
+  if (!entry.markerSources || typeof entry.markerSources !== 'object') entry.markerSources = {};
+  return entry.markerSources;
+}
+
+function ensureMarkerTombstones(entry) {
+  if (!entry[LAB_ENTRY_MARKER_TOMBSTONES] || typeof entry[LAB_ENTRY_MARKER_TOMBSTONES] !== 'object') {
+    entry[LAB_ENTRY_MARKER_TOMBSTONES] = {};
+  }
+  return entry[LAB_ENTRY_MARKER_TOMBSTONES];
+}
+
+export function getInsulinMirrorMarkerKey(dotKey) {
+  if (dotKey === 'hormones.insulin') return 'diabetes.insulin_d';
+  if (dotKey === 'diabetes.insulin_d') return 'hormones.insulin';
+  return null;
+}
+
+export function stampLabEntryUpdated(entry, now = Date.now()) {
+  if (!entry || typeof entry !== 'object') return now;
+  entry.updatedAt = now;
+  return now;
+}
+
+export function createLabEntry(date, opts = {}) {
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  return { date, markers: {}, updatedAt: now };
+}
+
+export function recalculateLabEntryHOMAIR(entry) {
+  if (!entry?.markers) return;
+  const glucose = entry.markers['biochemistry.glucose'];
+  const insulin = entry.markers['hormones.insulin'] ?? entry.markers['diabetes.insulin_d'];
+  if (glucose !== undefined && insulin !== undefined) {
+    entry.markers['diabetes.homaIR'] = Math.round((glucose * insulin) / 22.5 * 100) / 100;
+  } else {
+    delete entry.markers['diabetes.homaIR'];
+    if (entry.markerSources) delete entry.markerSources['diabetes.homaIR'];
+  }
+}
+
+export function labEntryMarkerAffectsHOMAIR(dotKey) {
+  return dotKey === 'biochemistry.glucose'
+    || dotKey === 'hormones.insulin'
+    || dotKey === 'diabetes.insulin_d';
+}
+
+function affectsHOMAIR(dotKey, keys = []) {
+  return labEntryMarkerAffectsHOMAIR(dotKey) || keys.some(labEntryMarkerAffectsHOMAIR);
+}
+
+export function getLabEntryMarkerTombstones(entry) {
+  const tombstones = entry?.[LAB_ENTRY_MARKER_TOMBSTONES];
+  return tombstones && typeof tombstones === 'object' && !Array.isArray(tombstones)
+    ? tombstones
+    : {};
+}
+
+export function hasLabEntryMarkerTombstones(entry) {
+  return Object.keys(getLabEntryMarkerTombstones(entry)).length > 0;
+}
+
+export function getLabEntryMarkerTombstoneAt(entry, dotKey) {
+  const ts = normalizeTimestamp(getLabEntryMarkerTombstones(entry)[dotKey]);
+  return ts === null ? 0 : ts;
+}
+
+export function getLabEntryMarkerValueTimestamp(entry, dotKey) {
+  const sourceTs = normalizeTimestamp(entry?.markerSources?.[dotKey]?.at);
+  if (sourceTs !== null) return sourceTs;
+  const updatedTs = normalizeTimestamp(entry?.updatedAt);
+  if (updatedTs !== null) return updatedTs;
+  if (typeof entry?.date === 'string') {
+    const parsed = Date.parse(entry.date);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+export function clearLabEntryMarkerTombstone(entry, dotKey) {
+  const tombstones = entry?.[LAB_ENTRY_MARKER_TOMBSTONES];
+  if (!tombstones || typeof tombstones !== 'object') return;
+  delete tombstones[dotKey];
+  if (Object.keys(tombstones).length === 0) delete entry[LAB_ENTRY_MARKER_TOMBSTONES];
+}
+
+export function markLabEntryMarkerDeleted(entry, dotKey, now = Date.now()) {
+  if (!entry || typeof entry !== 'object' || !dotKey) return;
+  ensureMarkerTombstones(entry)[dotKey] = now;
+}
+
+export function setLabEntryMarker(entry, dotKey, value, opts = {}) {
+  if (!entry || typeof entry !== 'object' || !dotKey) return null;
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const keys = [dotKey];
+  const mirrorKey = opts.mirrorInsulin ? getInsulinMirrorMarkerKey(dotKey) : null;
+  if (mirrorKey) keys.push(mirrorKey);
+
+  for (const key of keys) {
+    ensureMarkerMap(entry)[key] = value;
+    clearLabEntryMarkerTombstone(entry, key);
+    if (Object.prototype.hasOwnProperty.call(opts, 'source')) {
+      if (opts.source == null) {
+        if (entry.markerSources) delete entry.markerSources[key];
+      } else {
+        ensureMarkerSources(entry)[key] = opts.source;
+      }
+    } else if (opts.clearSource && entry.markerSources) {
+      delete entry.markerSources[key];
+    }
+  }
+  if (affectsHOMAIR(dotKey, keys)) recalculateLabEntryHOMAIR(entry);
+  if (opts.stamp !== false) stampLabEntryUpdated(entry, now);
+  return entry;
+}
+
+export function syncLabEntryInsulinMirror(entry, opts = {}) {
+  if (!entry?.markers) return false;
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const hormonesKey = 'hormones.insulin';
+  const diabetesKey = 'diabetes.insulin_d';
+  let sourceKey = null;
+  if (entry.markers[hormonesKey] !== undefined) {
+    entry.markers[diabetesKey] = entry.markers[hormonesKey];
+    sourceKey = hormonesKey;
+  } else if (entry.markers[diabetesKey] !== undefined) {
+    entry.markers[hormonesKey] = entry.markers[diabetesKey];
+    sourceKey = diabetesKey;
+  } else {
+    return false;
+  }
+  clearLabEntryMarkerTombstone(entry, getInsulinMirrorMarkerKey(sourceKey));
+  if (entry.markerSources?.[sourceKey]) {
+    ensureMarkerSources(entry)[getInsulinMirrorMarkerKey(sourceKey)] = entry.markerSources[sourceKey];
+  }
+  recalculateLabEntryHOMAIR(entry);
+  if (opts.stamp !== false) stampLabEntryUpdated(entry, now);
+  return true;
+}
+
+export function deleteLabEntryMarker(entry, dotKey, opts = {}) {
+  if (!entry || typeof entry !== 'object' || !dotKey) return { changed: false, deletedKeys: [] };
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const keys = [dotKey];
+  const mirrorKey = opts.mirrorInsulin ? getInsulinMirrorMarkerKey(dotKey) : null;
+  if (mirrorKey) keys.push(mirrorKey);
+  const deletedKeys = [];
+
+  for (const key of keys) {
+    const hadValue = !!(entry.markers && Object.prototype.hasOwnProperty.call(entry.markers, key));
+    const hadSource = !!(entry.markerSources && Object.prototype.hasOwnProperty.call(entry.markerSources, key));
+    if (!hadValue && !hadSource) continue;
+    if (entry.markers) delete entry.markers[key];
+    if (entry.markerSources) delete entry.markerSources[key];
+    if (opts.recordTombstone !== false) markLabEntryMarkerDeleted(entry, key, now);
+    deletedKeys.push(key);
+  }
+  if (deletedKeys.length && affectsHOMAIR(dotKey, deletedKeys)) recalculateLabEntryHOMAIR(entry);
+  if (deletedKeys.length && opts.stamp !== false) stampLabEntryUpdated(entry, now);
+  return { changed: deletedKeys.length > 0, deletedKeys };
+}
+
+export function renameLabEntryMarker(entry, fromKey, toKey, opts = {}) {
+  if (!entry || typeof entry !== 'object' || !fromKey || !toKey || fromKey === toKey) return false;
+  let changed = false;
+  const markers = entry.markers && typeof entry.markers === 'object' ? entry.markers : null;
+  if (markers && Object.prototype.hasOwnProperty.call(markers, fromKey)) {
+    if (opts.overwrite || !Object.prototype.hasOwnProperty.call(markers, toKey)) {
+      markers[toKey] = markers[fromKey];
+    }
+    delete markers[fromKey];
+    changed = true;
+  }
+  const sources = entry.markerSources && typeof entry.markerSources === 'object' ? entry.markerSources : null;
+  if (sources && Object.prototype.hasOwnProperty.call(sources, fromKey)) {
+    if (opts.overwrite || !Object.prototype.hasOwnProperty.call(sources, toKey)) {
+      sources[toKey] = sources[fromKey];
+    }
+    delete sources[fromKey];
+    changed = true;
+  }
+  clearLabEntryMarkerTombstone(entry, fromKey);
+  if (changed && (affectsHOMAIR(fromKey) || affectsHOMAIR(toKey))) recalculateLabEntryHOMAIR(entry);
+  if (changed && opts.stamp !== false) stampLabEntryUpdated(entry, opts.now);
+  return changed;
+}
+
+export function isLabEntryEmpty(entry) {
+  return !entry?.markers || Object.keys(entry.markers).length === 0;
+}
+
+export function isLabEntryRemovable(entry) {
+  return isLabEntryEmpty(entry) && !hasLabEntryMarkerTombstones(entry);
+}

--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -3,13 +3,16 @@
 import { state } from './state.js';
 import { getAlternateUnit, convertUserInputToSI } from './schema.js';
 import { escapeHTML, escapeAttr, formatValue, showNotification, showConfirmDialog, showPromptDialog } from './utils.js';
-import { getActiveData, saveImportedData, recalculateHOMAIR, updateHeaderDates, convertDisplayToSI } from './data.js';
+import { getActiveData, saveImportedData, updateHeaderDates, convertDisplayToSI } from './data.js';
 import {
-  appendImportedArrayItem,
-  clearTombstone,
-  deleteImportedArrayItems,
-  ensureImportedArray,
-} from './data-merge.js';
+  deleteLabEntryMarkerFromImportedData,
+  findOrCreateLabEntry,
+} from './lab-entry-mutations.js';
+import {
+  getInsulinMirrorMarkerKey,
+  setLabEntryMarker,
+  stampLabEntryUpdated,
+} from './lab-entry.js';
 
 const markerDetailDeps = {
   navigate: (category, data) => window.navigate?.(category, data),
@@ -40,34 +43,63 @@ function closeModal() {
 // category the user is editing from. Returns the OTHER key (if any) so the
 // caller can write the same note value to both sides.
 function _insulinMirrorNoteKey(dotKey, date) {
-  if (dotKey === 'hormones.insulin') return 'diabetes.insulin_d:' + date;
-  if (dotKey === 'diabetes.insulin_d') return 'hormones.insulin:' + date;
-  return null;
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  return mirror ? mirror + ':' + date : null;
+}
+
+function _entryMarkerValue(entry, dotKey) {
+  const markers = entry?.markers && typeof entry.markers === 'object' ? entry.markers : null;
+  if (!markers || !dotKey) return undefined;
+  if (Object.prototype.hasOwnProperty.call(markers, dotKey)) return markers[dotKey];
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  if (mirror && Object.prototype.hasOwnProperty.call(markers, mirror)) return markers[mirror];
+  return undefined;
 }
 
 function _entryHasImportedSource(entry, dotKey) {
   if (!entry) return false;
   const markerSource = entry.markerSources?.[dotKey];
-  return !!(markerSource?.file || entry.sourceFile);
+  if (markerSource?.file) return true;
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  if (mirror && entry.markerSources?.[mirror]?.file) return true;
+  if (entry.sourceFile) return true;
+  return Array.isArray(entry.sourceFiles) && entry.sourceFiles.some(Boolean);
 }
 
 function _rememberManualOriginal(dotKey, date, entry) {
   if (!entry || !dotKey || !date) return;
   if (!state.importedData.manualValues) state.importedData.manualValues = {};
   const mvKey = dotKey + ':' + date;
-  const current = entry.markers?.[dotKey];
+  const current = _entryMarkerValue(entry, dotKey);
   const hasImportedOriginal = current != null && _entryHasImportedSource(entry, dotKey);
-  if (!(mvKey in state.importedData.manualValues)) {
+  if (!(mvKey in state.importedData.manualValues) || state.importedData.manualValues[mvKey] == null) {
     state.importedData.manualValues[mvKey] = hasImportedOriginal ? current : true;
   } else if (state.importedData.manualValues[mvKey] === true && hasImportedOriginal) {
     state.importedData.manualValues[mvKey] = current;
   }
 }
 
-function stampLabEntryUpdated(entry, now = Date.now()) {
-  if (!entry || typeof entry !== 'object') return now;
-  entry.updatedAt = now;
-  return now;
+function _clearSyncedMapValue(map, key) {
+  if (!map || typeof map !== 'object' || !key) return;
+  if (!Object.prototype.hasOwnProperty.call(map, key)) return;
+  map[key] = null;
+}
+
+function _manualOriginalFor(dotKey, date) {
+  const map = state.importedData.manualValues;
+  if (!map || typeof map !== 'object' || !dotKey || !date) return undefined;
+  const key = dotKey + ':' + date;
+  if (Object.prototype.hasOwnProperty.call(map, key) && map[key] != null && map[key] !== true) {
+    return map[key];
+  }
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  const mirrorKey = mirror ? mirror + ':' + date : null;
+  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey) && map[mirrorKey] != null && map[mirrorKey] !== true) {
+    return map[mirrorKey];
+  }
+  if (Object.prototype.hasOwnProperty.call(map, key)) return map[key];
+  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey)) return map[mirrorKey];
+  return undefined;
 }
 
 export async function saveManualEntry(id, opts = {}) {
@@ -126,14 +158,8 @@ export async function saveManualEntry(id, opts = {}) {
     const unit = marker?.unit || '';
     if (!await showConfirmDialog(`A value of ${displayVal} ${unit} already exists for ${date}. Overwrite?`)) return;
   }
-  const entries = ensureImportedArray(state.importedData, 'entries');
-  clearTombstone(state.importedData, 'entries', date);
-  let entry = entries.find(e => e.date === date);
   const now = Date.now();
-  if (!entry) {
-    entry = { date: date, markers: {}, updatedAt: now };
-    appendImportedArrayItem(state.importedData, 'entries', entry);
-  }
+  const entry = findOrCreateLabEntry(state.importedData, date, { now });
   // If the user picked the alternate unit, convert from there directly to SI
   // (convertUserInputToSI is a no-op when inputUnit is already the SI unit, so
   // the EU-mode default keeps working unchanged). Otherwise fall through to the
@@ -142,19 +168,18 @@ export async function saveManualEntry(id, opts = {}) {
     ? convertUserInputToSI(dotKey, value, inputUnit)
     : convertDisplayToSI(dotKey, value);
   _rememberManualOriginal(dotKey, date, entry);
-  entry.markers[dotKey] = storedValue;
-  if (!entry.markerSources) entry.markerSources = {};
-  entry.markerSources[dotKey] = { file: null, at: now };
+  const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
+  if (insulinMirror) _rememberManualOriginal(insulinMirror, date, entry);
+  setLabEntryMarker(entry, dotKey, storedValue, {
+    now,
+    source: { file: null, at: now },
+    mirrorInsulin: true,
+  });
   // Per-value note: store on save when non-empty; clear when emptied.
   if (!state.importedData.markerValueNotes) state.importedData.markerValueNotes = {};
   const noteKey = dotKey + ':' + date;
   if (noteText) state.importedData.markerValueNotes[noteKey] = noteText;
-  else delete state.importedData.markerValueNotes[noteKey];
-  if (dotKey === 'hormones.insulin') {
-    _rememberManualOriginal('diabetes.insulin_d', date, entry);
-    entry.markers['diabetes.insulin_d'] = storedValue;
-    entry.markerSources['diabetes.insulin_d'] = entry.markerSources[dotKey];
-  }
+  else _clearSyncedMapValue(state.importedData.markerValueNotes, noteKey);
   // Mirror the per-value note across the insulin dual-mapping — same reading,
   // two views. Bidirectional: user may save via either category page. Without
   // this, a note added on one side wouldn't show on the other, and orphans
@@ -162,10 +187,8 @@ export async function saveManualEntry(id, opts = {}) {
   const insulinNoteMirror = _insulinMirrorNoteKey(dotKey, date);
   if (insulinNoteMirror) {
     if (noteText) state.importedData.markerValueNotes[insulinNoteMirror] = noteText;
-    else delete state.importedData.markerValueNotes[insulinNoteMirror];
+    else _clearSyncedMapValue(state.importedData.markerValueNotes, insulinNoteMirror);
   }
-  recalculateHOMAIR(entry);
-  stampLabEntryUpdated(entry, now);
   await saveImportedData();
   // Remember the date session-wide so the next manual entry defaults to it.
   try { sessionStorage.setItem('labcharts-last-manual-date', date); } catch (_) {}
@@ -199,32 +222,10 @@ export async function deleteMarkerValue(id, date) {
   if (!entry || entry.markers[dotKey] === undefined) return;
   if (await showConfirmDialog(`Delete this value (${date})? This can't be undone.`)) {
     const now = Date.now();
-    delete entry.markers[dotKey];
-    // Clean up provenance and manual tracking
-    if (entry.markerSources) delete entry.markerSources[dotKey];
-    if (state.importedData.manualValues) delete state.importedData.manualValues[dotKey + ':' + date];
-    // Drop the per-value note (if any) — value is gone, note is orphaned.
-    if (state.importedData.markerValueNotes) delete state.importedData.markerValueNotes[dotKey + ':' + date];
-    // Clean up insulin dual-mapping (value, provenance, AND the per-value
-    // note for the mirror key — same reading, both views must go together).
-    if (dotKey === 'hormones.insulin') {
-      delete entry.markers['diabetes.insulin_d'];
-      if (entry.markerSources) delete entry.markerSources['diabetes.insulin_d'];
-      if (state.importedData.manualValues) delete state.importedData.manualValues['diabetes.insulin_d:' + date];
-      recalculateHOMAIR(entry);
-    }
-    // Mirror the note delete in both directions — user may delete via either
-    // category. Forward-only would leave orphans on the other side.
-    const mirrorKey = _insulinMirrorNoteKey(dotKey, date);
-    if (mirrorKey && state.importedData.markerValueNotes) {
-      delete state.importedData.markerValueNotes[mirrorKey];
-    }
-    // Remove entry entirely if no markers left
-    if (Object.keys(entry.markers).length === 0) {
-      deleteImportedArrayItems(state.importedData, 'entries', e => e.date === date);
-    } else {
-      stampLabEntryUpdated(entry, now);
-    }
+    deleteLabEntryMarkerFromImportedData(state.importedData, entry, dotKey, {
+      now,
+      mirrorInsulin: true,
+    });
     saveImportedData();
     window.buildSidebar();
     updateHeaderDates();
@@ -267,12 +268,13 @@ export function editMarkerValue(id, date, currentValue, event) {
     _rememberManualOriginal(dotKey, date, entry);
     const storedValue = convertDisplayToSI(dotKey, newValue);
     const now = Date.now();
-    entry.markers[dotKey] = storedValue;
-    // Update provenance to reflect manual edit
-    if (!entry.markerSources) entry.markerSources = {};
-    entry.markerSources[dotKey] = { file: null, at: now };
-    if (dotKey === 'hormones.insulin') { entry.markers['diabetes.insulin_d'] = storedValue; if (entry.markerSources) entry.markerSources['diabetes.insulin_d'] = entry.markerSources[dotKey]; recalculateHOMAIR(entry); }
-    stampLabEntryUpdated(entry, now);
+    const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
+    if (insulinMirror) _rememberManualOriginal(insulinMirror, date, entry);
+    setLabEntryMarker(entry, dotKey, storedValue, {
+      now,
+      source: { file: null, at: now },
+      mirrorInsulin: true,
+    });
     await saveImportedData();
     // Rebuild the underlying view so Table/Heatmap/Chart reflect the edit.
     markerDetailDeps.navigate(state.currentView || 'dashboard');
@@ -288,19 +290,17 @@ export function editMarkerValue(id, date, currentValue, event) {
 export async function revertMarkerValue(id, date) {
   const dotKey = id.replace('_', '.');
   const mvKey = dotKey + ':' + date;
-  const original = state.importedData.manualValues?.[mvKey];
+  const original = _manualOriginalFor(dotKey, date);
   if (original == null || original === true) return;
   const entry = state.importedData.entries?.find(e => e.date === date);
   if (!entry) return;
-  entry.markers[dotKey] = original;
-  if (entry.markerSources) delete entry.markerSources[dotKey];
-  if (dotKey === 'hormones.insulin') {
-    entry.markers['diabetes.insulin_d'] = original;
-    if (entry.markerSources) delete entry.markerSources['diabetes.insulin_d'];
-    delete state.importedData.manualValues['diabetes.insulin_d:' + date];
-    recalculateHOMAIR(entry);
-  }
-  delete state.importedData.manualValues[mvKey];
+  const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
+  setLabEntryMarker(entry, dotKey, original, {
+    clearSource: true,
+    mirrorInsulin: true,
+  });
+  if (insulinMirror) _clearSyncedMapValue(state.importedData.manualValues, insulinMirror + ':' + date);
+  _clearSyncedMapValue(state.importedData.manualValues, mvKey);
   stampLabEntryUpdated(entry);
   await saveImportedData();
   // Rebuild the underlying view so Table/Heatmap/Chart reflect the revert.
@@ -340,10 +340,10 @@ export async function deleteValueNote(id, date) {
   const dotKey = id.replace('_', '.');
   const noteKey = dotKey + ':' + date;
   if (state.importedData.markerValueNotes && state.importedData.markerValueNotes[noteKey]) {
-    delete state.importedData.markerValueNotes[noteKey];
+    _clearSyncedMapValue(state.importedData.markerValueNotes, noteKey);
     // Mirror cleanup in BOTH directions across the insulin dual-mapping.
     const mirror = _insulinMirrorNoteKey(dotKey, date);
-    if (mirror) delete state.importedData.markerValueNotes[mirror];
+    if (mirror) _clearSyncedMapValue(state.importedData.markerValueNotes, mirror);
     saveImportedData();
     showDetailModal(id);
   }

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -7,7 +7,8 @@ import { getActiveData, getEffectiveRange, getEffectiveRangeForDate, saveImporte
 import { createLineChart, getMarkerDescription } from './charts.js';
 import { closeSuggestionsOnClickOutside } from './context-cards.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from './api.js';
-import { deleteImportedArrayItems } from './data-merge.js';
+import { deleteEmptyLabEntries, deleteLabEntryMarkerValues } from './lab-entry-mutations.js';
+import { getInsulinMirrorMarkerKey } from './lab-entry.js';
 import {
   configureMarkerDetailEditing,
   editRefRange,
@@ -141,6 +142,21 @@ function restoreModalTrigger() {
 // default and expand in place instead of opening a nested history modal.
 const MARKER_HISTORY_DEFAULT_CAP = 3;
 const MARKER_HISTORY_EXPANDED_CAP = 40;
+
+function getManualValueForMarker(dotKey, date) {
+  const map = state.importedData.manualValues;
+  if (!map || typeof map !== 'object' || !dotKey || !date) return undefined;
+  const key = dotKey + ':' + date;
+  if (Object.prototype.hasOwnProperty.call(map, key) && map[key] != null && map[key] !== true) return map[key];
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  const mirrorKey = mirror ? mirror + ':' + date : null;
+  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey) && map[mirrorKey] != null && map[mirrorKey] !== true) {
+    return map[mirrorKey];
+  }
+  if (Object.prototype.hasOwnProperty.call(map, key)) return map[key];
+  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey)) return map[mirrorKey];
+  return undefined;
+}
 
 // ═══════════════════════════════════════════════
 // DETAIL MODAL & MANUAL ENTRY
@@ -395,9 +411,12 @@ export function showDetailModal(id, opts = {}) {
     const matchingNote = rawDate && state.importedData.notes ? state.importedData.notes.find(n => n.date === rawDate) : null;
     const noteIcon = matchingNote ? `<button type="button" class="mv-note" onclick="event.stopPropagation();this.parentElement.parentElement.querySelector('.mv-note-text').classList.toggle('show')">Note</button><div class="mv-note-text">${escapeHTML(matchingNote.text)}</div>` : '';
     const mvKey = dotKey + ':' + rawDate;
-    const manualVal = rawDate && state.importedData.manualValues && state.importedData.manualValues[mvKey];
-    const isManual = manualVal !== undefined && manualVal !== null;
-    const canRevert = isManual && manualVal !== true;
+    const srcEntry = rawDate ? state.importedData.entries?.find(e => e.date === rawDate) : null;
+    const src = srcEntry?.markerSources?.[dotKey];
+    const manualVal = rawDate ? getManualValueForMarker(dotKey, rawDate) : undefined;
+    const isManualSource = !!(src && src.file == null);
+    const isManual = isManualSource || (manualVal !== undefined && manualVal !== null);
+    const canRevert = manualVal !== undefined && manualVal !== null && manualVal !== true;
     const manualBadge = canRevert
       ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Revert manual value to imported value" title="Manual — click to revert to imported value" onclick="event.stopPropagation();revertMarkerValue('${id}','${rawDate}')">manual \u00d7</span>`
       : isManual ? ' <span class="ref-edited-badge" title="Manually entered">manual</span>' : '';
@@ -406,8 +425,6 @@ export function showDetailModal(id, opts = {}) {
     // Provenance: which file imported this value
     let sourceHtml = '';
     if (rawDate) {
-      const srcEntry = state.importedData.entries?.find(e => e.date === rawDate);
-      const src = srcEntry?.markerSources?.[dotKey];
       if (src) {
         const fname = src.file;
         if (fname) {
@@ -962,28 +979,18 @@ export async function deleteCustomMarker(id) {
   if (await showConfirmDialog(msg)) {
     // Determine which keys to delete — just this marker, or all in category
     const keysToDelete = isLastInCat ? siblingsInCat : [dotKey];
+    const now = Date.now();
     for (const key of keysToDelete) {
-      // Remove from all entries
-      if (state.importedData.entries) {
-        for (const entry of state.importedData.entries) {
-          if (entry.markers) delete entry.markers[key];
-        }
-      }
-      // Remove manual value tracking
-      if (state.importedData.manualValues) {
-        for (const k of Object.keys(state.importedData.manualValues)) {
-          if (k.startsWith(key + ':')) delete state.importedData.manualValues[k];
-        }
-      }
+      deleteLabEntryMarkerValues(state.importedData, key, { now, deleteEmptyEntries: false });
       // Remove ref overrides
       if (state.importedData.refOverrides) delete state.importedData.refOverrides[key];
+      if (state.importedData.markerNotes) delete state.importedData.markerNotes[key];
+      if (state.importedData.markerLabels) delete state.importedData.markerLabels[key];
       // Remove custom marker definition
       delete state.importedData.customMarkers[key];
     }
     // Clean up empty entries
-    if (state.importedData.entries) {
-      deleteImportedArrayItems(state.importedData, 'entries', e => Object.keys(e.markers || {}).length === 0);
-    }
+    deleteEmptyLabEntries(state.importedData);
     saveImportedData();
     closeModal();
     window.buildSidebar();

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -3,12 +3,13 @@
 import { state } from './state.js';
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS, calculateCost, trackUsage } from './schema.js';
 import { showNotification, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
-import { saveImportedData, recalculateHOMAIR } from './data.js';
+import { saveImportedData } from './data.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
-import { appendImportedArrayItem, clearTombstone, ensureImportedArray } from './data-merge.js';
+import { findOrCreateLabEntry } from './lab-entry-mutations.js';
+import { setLabEntryMarker, syncLabEntryInsulinMirror } from './lab-entry.js';
 import { runPreflightChecks } from './pdf-import-preflight.js';
 import { normalizeParsedImportMarkers } from './pdf-import-marker-normalization.js';
 import {
@@ -405,13 +406,8 @@ export async function confirmImport() {
     closeImportModal();
     return;
   }
-  const entries = ensureImportedArray(state.importedData, 'entries');
-  clearTombstone(state.importedData, 'entries', result.date);
-  let entry = entries.find(e => e.date === result.date);
-  if (!entry) {
-    entry = { date: result.date, markers: {} };
-    appendImportedArrayItem(state.importedData, 'entries', entry);
-  }
+  const importTs = Date.now();
+  const entry = findOrCreateLabEntry(state.importedData, result.date, { now: importTs });
   entry.importedWith = {
     provider: result.costInfo?.provider || null,
     modelId: result.costInfo?.modelId || null
@@ -422,12 +418,12 @@ export async function confirmImport() {
     if (!entry.sourceFiles.includes(result.fileName)) entry.sourceFiles.push(result.fileName);
     entry.sourceFile = result.fileName; // backwards compat
   }
-  if (!entry.markerSources) entry.markerSources = {};
-  const importTs = Date.now();
   entry.updatedAt = importTs;
   for (const m of matched) {
-    entry.markers[m.mappedKey] = normalizeToSI(m.mappedKey, m.value, m.unit);
-    entry.markerSources[m.mappedKey] = { file: result.fileName || null, at: importTs };
+    setLabEntryMarker(entry, m.mappedKey, normalizeToSI(m.mappedKey, m.value, m.unit), {
+      now: importTs,
+      source: { file: result.fileName || null, at: importTs },
+    });
   }
   // For non-blood imports, testType is the authoritative sidebar group for all markers
   const importGroup = (result.testType && result.testType !== 'blood')
@@ -454,8 +450,10 @@ export async function confirmImport() {
   }
   // Save new (custom) marker values and definitions
   for (const m of newMarkers) {
-    entry.markers[m.suggestedKey] = normalizeToSI(m.suggestedKey, m.value, m.unit);
-    entry.markerSources[m.suggestedKey] = { file: result.fileName || null, at: importTs };
+    setLabEntryMarker(entry, m.suggestedKey, normalizeToSI(m.suggestedKey, m.value, m.unit), {
+      now: importTs,
+      source: { file: result.fileName || null, at: importTs },
+    });
     const [catKey] = m.suggestedKey.split('.');
     const schemaCategory = MARKER_SCHEMA[catKey];
     const categoryLabel = schemaCategory ? schemaCategory.label : m.suggestedCategoryLabel || catKey.charAt(0).toUpperCase() + catKey.slice(1);
@@ -472,15 +470,7 @@ export async function confirmImport() {
     state.importedData.customMarkers[m.suggestedKey] = cmDef;
   }
   // Mirror insulin between hormones and diabetes categories (AI may map to either)
-  if (entry.markers["hormones.insulin"] !== undefined) {
-    entry.markers["diabetes.insulin_d"] = entry.markers["hormones.insulin"];
-    if (entry.markerSources?.["hormones.insulin"]) entry.markerSources["diabetes.insulin_d"] = entry.markerSources["hormones.insulin"];
-  }
-  if (entry.markers["diabetes.insulin_d"] !== undefined && entry.markers["hormones.insulin"] === undefined) {
-    entry.markers["hormones.insulin"] = entry.markers["diabetes.insulin_d"];
-    if (entry.markerSources?.["diabetes.insulin_d"]) entry.markerSources["hormones.insulin"] = entry.markerSources["diabetes.insulin_d"];
-  }
-  recalculateHOMAIR(entry);
+  syncLabEntryInsulinMirror(entry, { now: importTs });
   // Adopt PDF reference ranges if user opted in (skip if range matches schema default)
   const adoptRanges = document.getElementById('import-adopt-ranges');
   if (adoptRanges && adoptRanges.checked) {

--- a/js/profile.js
+++ b/js/profile.js
@@ -6,6 +6,12 @@ import { COUNTRY_LATITUDES, LATITUDE_BANDS } from './constants.js';
 import { showNotification } from './utils.js';
 import { encryptedSetItem, encryptedGetItem, getEncryptionEnabled, encryptedRemoveItem } from './crypto.js';
 import { normalizeLightEnvironmentEveningFields } from './light-env-evening.js';
+import {
+  deleteLabEntryMarker,
+  renameLabEntryMarker,
+  setLabEntryMarker,
+  syncLabEntryInsulinMirror,
+} from './lab-entry.js';
 
 // ═══════════════════════════════════════════════
 // PROFILE MANAGEMENT
@@ -164,14 +170,7 @@ function _repairUnitSuffixedStandardMarkers(data) {
     const targetCatKey = target.split('.')[0];
     if (catKey === 'urinalysis' && targetCatKey !== 'urinalysis') continue;
     for (const entry of data.entries) {
-      if (entry.markers?.[fullKey] !== undefined) {
-        if (entry.markers[target] === undefined) entry.markers[target] = entry.markers[fullKey];
-        delete entry.markers[fullKey];
-      }
-      if (entry.markerSources?.[fullKey]) {
-        if (!entry.markerSources[target]) entry.markerSources[target] = entry.markerSources[fullKey];
-        delete entry.markerSources[fullKey];
-      }
+      renameLabEntryMarker(entry, fullKey, target, { stamp: false });
     }
     const remapByPrefix = (obj) => {
       if (!obj) return;
@@ -329,10 +328,7 @@ export function migrateProfileData(data) {
       const stdKey = _stdLookup[markerKey];
       if (!stdKey) continue;
       for (const entry of data.entries) {
-        if (entry.markers?.[fullKey] !== undefined) {
-          if (entry.markers[stdKey] === undefined) entry.markers[stdKey] = entry.markers[fullKey];
-          delete entry.markers[fullKey];
-        }
+        renameLabEntryMarker(entry, fullKey, stdKey, { stamp: false });
       }
       toDelete.push(fullKey);
     }
@@ -351,7 +347,7 @@ export function migrateProfileData(data) {
         if (!_stdCats.has(catKey) && !SPECIALTY_MARKER_DEFS[key] && (catKey.endsWith('FA') || catKey === 'fattyAcidsTest')) {
           // Keep markers that have a valid custom marker definition (legitimate FA import)
           if (data.customMarkers?.[key]) continue;
-          delete entry.markers[key];
+          deleteLabEntryMarker(entry, key, { recordTombstone: false, stamp: false });
         }
       }
     }
@@ -367,13 +363,7 @@ export function migrateProfileData(data) {
   // Backfill insulin mirror: sync hormones.insulin ↔ diabetes.insulin_d — v1.6.1
   if (data.entries) {
     for (const entry of data.entries) {
-      if (!entry.markers) continue;
-      if (entry.markers['hormones.insulin'] !== undefined && entry.markers['diabetes.insulin_d'] === undefined) {
-        entry.markers['diabetes.insulin_d'] = entry.markers['hormones.insulin'];
-      }
-      if (entry.markers['diabetes.insulin_d'] !== undefined && entry.markers['hormones.insulin'] === undefined) {
-        entry.markers['hormones.insulin'] = entry.markers['diabetes.insulin_d'];
-      }
+      syncLabEntryInsulinMirror(entry, { stamp: false });
     }
   }
   // Migrate trombocrit/plateletcrit custom markers → hematology.pct — v1.6.1
@@ -383,10 +373,7 @@ export function migrateProfileData(data) {
     );
     for (const oldKey of pctAliases) {
       for (const entry of data.entries) {
-        if (entry.markers?.[oldKey] != null && entry.markers['hematology.pct'] == null) {
-          entry.markers['hematology.pct'] = entry.markers[oldKey];
-        }
-        delete entry.markers?.[oldKey];
+        renameLabEntryMarker(entry, oldKey, 'hematology.pct', { stamp: false });
       }
       delete data.customMarkers[oldKey];
     }
@@ -396,7 +383,7 @@ export function migrateProfileData(data) {
     for (const entry of data.entries) {
       const hct = entry.markers?.['hematology.hematocrit'];
       if (hct != null && hct < 1) {
-        entry.markers['hematology.hematocrit'] = parseFloat((hct * 100).toFixed(1));
+        setLabEntryMarker(entry, 'hematology.hematocrit', parseFloat((hct * 100).toFixed(1)), { stamp: false });
       }
     }
   }

--- a/js/settings.js
+++ b/js/settings.js
@@ -969,7 +969,11 @@ export function closeSettingsModal() {
 }
 
 export function renderDataEntriesSection() {
-  const entries = (state.importedData && state.importedData.entries) ? state.importedData.entries : [];
+  const rawEntries = state.importedData?.entries || [];
+  const entries = [];
+  for (const entry of rawEntries) {
+    if (Object.keys(entry?.markers || {}).length > 0) entries.push(entry);
+  }
   if (entries.length === 0) {
     return '<div style="color:var(--text-muted);font-size:13px;padding:8px 0">No data yet. Drop a PDF or JSON file on the dashboard, or add values manually.</div>';
   }

--- a/js/sync-delta-map-planner.js
+++ b/js/sync-delta-map-planner.js
@@ -10,6 +10,8 @@ import {
 import { _readDeltaSnapshot } from './sync-delta-snapshot.js';
 import { getPlannerItemRows } from './sync-delta-planner-context.js';
 
+const CLEARED_VALUE_MAPS = new Set(['manualValues', 'markerValueNotes']);
+
 // Keyed-map planner. Same shape as _planArrayDelta but iterates
 // Object.entries() and uses the map key (sanitized) as itemId. Payload
 // is `{k, v}` so the pull side can verify the key column matches the
@@ -69,7 +71,7 @@ export async function _planKeyedMapDelta(profileId, mapName, mapObj) {
     // its own check, re-validate via _isAllowlistSafeId so a buggy custom
     // fn can't smuggle __proto__/constructor through.
     if (!_isAllowlistSafeId(itemId)) continue;
-    if (value === null || value === undefined) continue;
+    if (value === undefined || (value === null && !CLEARED_VALUE_MAPS.has(mapName))) continue;
     // payload.k carries the ORIGINAL key - pull side rebuilds the map
     // under that key, not the synth itemId, so consumers reading the
     // raw `category.markerKey:date` form keep working.

--- a/js/sync-pull-active-refresh.js
+++ b/js/sync-pull-active-refresh.js
@@ -8,6 +8,23 @@ function dbg(debug, ...args) {
   try { debug?.(...args); } catch {}
 }
 
+function refreshOpenMarkerDetailModal(debug) {
+  const openId = state._activeDetailMarkerId;
+  if (!openId || typeof window === 'undefined' || typeof document === 'undefined') return false;
+  const overlay = document.getElementById('modal-overlay');
+  const modal = document.getElementById('detail-modal');
+  const isOpen = !!overlay?.classList?.contains('show');
+  const isMarkerDetail = !!modal?.classList?.contains('marker-detail-modal');
+  if (!isOpen || !isMarkerDetail || typeof window.showDetailModal !== 'function') return false;
+  try {
+    window.showDetailModal(openId);
+    return true;
+  } catch (e) {
+    dbg(debug, `Pulled active profile — marker detail refresh failed: ${e?.message || e}`);
+    return false;
+  }
+}
+
 export function refreshActiveProfileAfterPull({
   profileId,
   merged,
@@ -63,6 +80,8 @@ export function refreshActiveProfileAfterPull({
     }
     dbg(debug, `Pulled active profile ${profileId.slice(0,8)} → re-rendered '${cat}'`);
   }
+
+  refreshOpenMarkerDetailModal(debug);
 
   // Broadcast for any detached UI listening for cross-device
   // updates (e.g., the All-Sessions modal in views.js). The

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -54,6 +54,7 @@ const LEGACY_TESTS = [
   './test-markdown.js',
   // Batch 2 — incremental ports.
   './test-data-merge.js',
+  './test-lab-entry.js',
   './test-security-phase1.js',
   './test-correctness-phase2.js',
   // Batch 3 — more pure-logic ports.

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -244,6 +244,184 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
   assert('stale per-row entries overlay does not revert same-marker manual edit',
     sameMarkerManualEdit.entries[0].markers?.['biochemistry.glucose'] === 5.1
       && sameMarkerManualEdit.entries[0].markerSources?.['biochemistry.glucose']?.file === null);
+  const revertedManualEdit = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: 200,
+      markers: { 'biochemistry.glucose': 5.1 },
+      markerSources: { 'biochemistry.glucose': { file: null, at: 200 } },
+    }],
+  };
+  await mergeArrayRowsIntoImported(revertedManualEdit, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: new Date(300).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      date: '2026-05-01',
+      updatedAt: 300,
+      markers: { 'biochemistry.glucose': 4.7 },
+    }),
+  }]);
+  assert('newer per-row entries revert clears stale manual marker source',
+    revertedManualEdit.entries[0].markers?.['biochemistry.glucose'] === 4.7
+      && !Object.prototype.hasOwnProperty.call(revertedManualEdit.entries[0].markerSources || {}, 'biochemistry.glucose'));
+  const sameDateMarkerDelete = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: 100,
+      markers: {
+        'biochemistry.glucose': 4.7,
+        'biochemistry.alp': 1.2,
+      },
+      markerSources: {
+        'biochemistry.glucose': { file: 'old-sync.pdf', at: 100 },
+        'biochemistry.alp': { file: 'old-sync.pdf', at: 100 },
+      },
+    }],
+  };
+  await mergeArrayRowsIntoImported(sameDateMarkerDelete, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: new Date(200).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      date: '2026-05-01',
+      updatedAt: 200,
+      markers: { 'biochemistry.alp': 1.2 },
+      markerSources: { 'biochemistry.alp': { file: 'old-sync.pdf', at: 100 } },
+      deletedMarkers: { 'biochemistry.glucose': 200 },
+    }),
+  }]);
+  assert('newer per-row entries marker tombstone deletes one same-date marker',
+    !Object.prototype.hasOwnProperty.call(sameDateMarkerDelete.entries[0].markers || {}, 'biochemistry.glucose')
+      && sameDateMarkerDelete.entries[0].markers?.['biochemistry.alp'] === 1.2);
+  const staleMarkerDelete = {
+    entries: [{
+      date: '2026-05-01',
+      updatedAt: 300,
+      markers: { 'biochemistry.glucose': 5.1 },
+      markerSources: { 'biochemistry.glucose': { file: null, at: 300 } },
+    }],
+  };
+  await mergeArrayRowsIntoImported(staleMarkerDelete, 'entries', [{
+    itemId: '2026-05-01',
+    syncedAt: new Date(200).toISOString(),
+    isDeleted: 0,
+    payload: JSON.stringify({
+      date: '2026-05-01',
+      updatedAt: 200,
+      markers: {},
+      deletedMarkers: { 'biochemistry.glucose': 200 },
+    }),
+  }]);
+  assert('stale per-row entries marker tombstone does not delete newer same-marker edit',
+    staleMarkerDelete.entries[0].markers?.['biochemistry.glucose'] === 5.1);
+  const reimportAfterLastMarkerDelete = mergeImportedData(
+    {
+      entries: [{
+        date: '2026-05-01',
+        updatedAt: 700,
+        markers: { 'biochemistry.alp': 1.4 },
+        markerSources: { 'biochemistry.alp': { file: 'new.pdf', at: 700 } },
+        deletedMarkers: { 'biochemistry.glucose': 400 },
+      }],
+    },
+    {
+      entries: [{
+        date: '2026-05-01',
+        updatedAt: 100,
+        markers: { 'biochemistry.glucose': 4.7, 'biochemistry.alp': 1.2 },
+        markerSources: {
+          'biochemistry.glucose': { file: 'old.pdf', at: 100 },
+          'biochemistry.alp': { file: 'old.pdf', at: 100 },
+        },
+      }],
+    }
+  );
+  const reimportedLab = reimportAfterLastMarkerDelete.entries.find(e => e.date === '2026-05-01');
+  assert('same-date reimport keeps marker tombstones so stale peers cannot resurrect deleted markers',
+    reimportedLab?.markers?.['biochemistry.alp'] === 1.4
+      && !Object.prototype.hasOwnProperty.call(reimportedLab.markers || {}, 'biochemistry.glucose')
+      && reimportedLab.deletedMarkers?.['biochemistry.glucose'] === 400);
+  const directHomaMerge = mergeImportedData(
+    {
+      entries: [{
+        date: '2026-06-01',
+        updatedAt: 200,
+        markers: { 'diabetes.homaIR': 1.1 },
+        markerSources: { 'diabetes.homaIR': { file: 'calc.pdf', at: 200 } },
+      }],
+    },
+    {
+      entries: [{
+        date: '2026-06-01',
+        updatedAt: 100,
+        markers: { 'diabetes.hba1c': 31 },
+        markerSources: { 'diabetes.hba1c': { file: 'old.pdf', at: 100 } },
+      }],
+    }
+  );
+  const directHomaEntry = directHomaMerge.entries.find(e => e.date === '2026-06-01');
+  assert('same-date merge preserves direct HOMA-IR when glucose/insulin were not part of the conflict',
+    directHomaEntry?.markers?.['diabetes.homaIR'] === 1.1
+      && directHomaEntry.markers?.['diabetes.hba1c'] === 31);
+  const directHomaWithGlucoseMerge = mergeImportedData(
+    {
+      entries: [{
+        date: '2026-06-02',
+        updatedAt: 200,
+        markers: { 'biochemistry.glucose': 5.1, 'diabetes.homaIR': 1.5 },
+        markerSources: {
+          'biochemistry.glucose': { file: 'calc.pdf', at: 200 },
+          'diabetes.homaIR': { file: 'calc.pdf', at: 200 },
+        },
+      }],
+    },
+    {
+      entries: [{
+        date: '2026-06-02',
+        updatedAt: 100,
+        markers: { 'biochemistry.glucose': 5.1 },
+        markerSources: { 'biochemistry.glucose': { file: 'old.pdf', at: 100 } },
+      }],
+    }
+  );
+  const directHomaWithGlucoseEntry = directHomaWithGlucoseMerge.entries.find(e => e.date === '2026-06-02');
+  assert('same-date merge preserves direct HOMA-IR when glucose is present but insulin is absent',
+    directHomaWithGlucoseEntry?.markers?.['diabetes.homaIR'] === 1.5
+      && directHomaWithGlucoseEntry.markers?.['biochemistry.glucose'] === 5.1);
+  const insulinDeleteHomaMerge = mergeImportedData(
+    {
+      entries: [{
+        date: '2026-06-03',
+        updatedAt: 300,
+        markers: { 'biochemistry.glucose': 5, 'diabetes.homaIR': 2 },
+        markerSources: { 'diabetes.homaIR': { file: 'calc.pdf', at: 100 } },
+        deletedMarkers: { 'hormones.insulin': 300, 'diabetes.insulin_d': 300 },
+      }],
+    },
+    {
+      entries: [{
+        date: '2026-06-03',
+        updatedAt: 100,
+        markers: {
+          'biochemistry.glucose': 5,
+          'hormones.insulin': 9,
+          'diabetes.insulin_d': 9,
+          'diabetes.homaIR': 2,
+        },
+        markerSources: {
+          'hormones.insulin': { file: 'old.pdf', at: 100 },
+          'diabetes.insulin_d': { file: 'old.pdf', at: 100 },
+          'diabetes.homaIR': { file: 'old.pdf', at: 100 },
+        },
+      }],
+    }
+  );
+  const insulinDeleteHomaEntry = insulinDeleteHomaMerge.entries.find(e => e.date === '2026-06-03');
+  assert('same-date merge clears stale computed HOMA-IR when insulin tombstone wins',
+    !Object.prototype.hasOwnProperty.call(insulinDeleteHomaEntry?.markers || {}, 'diabetes.homaIR')
+      && !Object.prototype.hasOwnProperty.call(insulinDeleteHomaEntry?.markers || {}, 'hormones.insulin')
+      && !Object.prototype.hasOwnProperty.call(insulinDeleteHomaEntry?.markers || {}, 'diabetes.insulin_d'));
   const editedDeviceSession = {
     deviceSessions: [{
       id: 'devsess_duration_edit',
@@ -788,6 +966,11 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
       { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.2 } }] },
       { entries: [{ date: '2026-05-01', markers: { 'biochemistry.alp': 1.2, 'biochemistry.alt': 0.5 } }] }
     ) === false);
+  assert('local lab marker tombstone missing remotely → true',
+    localHasRowsRemoteLacks(
+      { entries: [{ date: '2026-05-01', updatedAt: 200, markers: { 'biochemistry.alp': 1.2 }, deletedMarkers: { 'biochemistry.glucose': 200 } }] },
+      { entries: [{ date: '2026-05-01', updatedAt: 100, markers: { 'biochemistry.alp': 1.2, 'biochemistry.glucose': 4.7 } }] }
+    ) === true);
 
   // Within-id conflict: same id, local's record has a strictly higher
   // pickTimestamp than remote's. After mergeImportedData this means

--- a/tests/test-lab-entry.js
+++ b/tests/test-lab-entry.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// test-lab-entry.js - shared lab entry mutation helper coverage.
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+console.log('=== Lab Entry Mutation Tests ===\n');
+
+const {
+  createLabEntry,
+  deleteLabEntryMarker,
+  getInsulinMirrorMarkerKey,
+  setLabEntryMarker,
+  syncLabEntryInsulinMirror,
+} = await import('../js/lab-entry.js');
+const {
+  deleteLabEntryMarkerFromImportedData,
+  deleteLabEntryMarkerValues,
+  findOrCreateLabEntry,
+} = await import('../js/lab-entry-mutations.js');
+
+console.log('%c 1. Set marker ', 'font-weight:bold;color:#f59e0b');
+const entry = createLabEntry('2026-05-01', { now: 100 });
+entry.deletedMarkers = { 'biochemistry.glucose': 90 };
+setLabEntryMarker(entry, 'biochemistry.glucose', 5.1, {
+  now: 200,
+  source: { file: null, at: 200 },
+});
+assert('setLabEntryMarker writes marker value and source',
+  entry.markers['biochemistry.glucose'] === 5.1
+    && entry.markerSources['biochemistry.glucose'].file === null);
+assert('setLabEntryMarker stamps updatedAt and clears marker tombstone',
+  entry.updatedAt === 200
+    && !Object.prototype.hasOwnProperty.call(entry.deletedMarkers || {}, 'biochemistry.glucose'));
+
+console.log('%c 2. Insulin mirror ', 'font-weight:bold;color:#f59e0b');
+setLabEntryMarker(entry, 'diabetes.insulin_d', 8, {
+  now: 300,
+  source: { file: null, at: 300 },
+  mirrorInsulin: true,
+});
+entry.markers['biochemistry.glucose'] = 5;
+syncLabEntryInsulinMirror(entry, { now: 300 });
+assert('insulin mirror works from diabetes to hormones',
+  getInsulinMirrorMarkerKey('diabetes.insulin_d') === 'hormones.insulin'
+    && entry.markers['hormones.insulin'] === 8
+    && entry.markerSources['hormones.insulin'].at === 300);
+assert('insulin mirror recalculates HOMA-IR',
+  entry.markers['diabetes.homaIR'] === Math.round((5 * 8) / 22.5 * 100) / 100);
+setLabEntryMarker(entry, 'biochemistry.glucose', 6, { now: 325 });
+assert('glucose edits recalculate HOMA-IR when insulin is present',
+  entry.markers['diabetes.homaIR'] === Math.round((6 * 8) / 22.5 * 100) / 100);
+deleteLabEntryMarker(entry, 'diabetes.insulin_d', { now: 350, mirrorInsulin: true });
+assert('insulin delete clears stale HOMA-IR',
+  !Object.prototype.hasOwnProperty.call(entry.markers, 'diabetes.homaIR'));
+
+console.log('%c 3. Delete marker ', 'font-weight:bold;color:#f59e0b');
+const imported = {
+  entries: [{
+    date: '2026-06-01',
+    updatedAt: 100,
+    markers: {
+      'biochemistry.glucose': 4.7,
+      'biochemistry.alp': 1.2,
+    },
+    markerSources: {
+      'biochemistry.glucose': { file: 'old.pdf', at: 100 },
+      'biochemistry.alp': { file: 'old.pdf', at: 100 },
+    },
+  }],
+  manualValues: { 'biochemistry.glucose:2026-06-01': 4.6 },
+  markerValueNotes: { 'biochemistry.glucose:2026-06-01': 'fasted' },
+};
+const deleteResult = deleteLabEntryMarkerFromImportedData(
+  imported,
+  imported.entries[0],
+  'biochemistry.glucose',
+  { now: 400 }
+);
+assert('deleteLabEntryMarkerFromImportedData removes only target marker from multi-marker row',
+  deleteResult.changed
+    && imported.entries.length === 1
+    && imported.entries[0].markers['biochemistry.alp'] === 1.2
+    && !Object.prototype.hasOwnProperty.call(imported.entries[0].markers, 'biochemistry.glucose'));
+assert('deleteLabEntryMarkerFromImportedData records marker tombstone and metadata cleanup',
+  imported.entries[0].deletedMarkers['biochemistry.glucose'] === 400
+    && imported.entries[0].updatedAt === 400
+    && !imported.manualValues['biochemistry.glucose:2026-06-01']
+    && !imported.markerValueNotes['biochemistry.glucose:2026-06-01']);
+
+console.log('%c 4. Imported data helpers ', 'font-weight:bold;color:#f59e0b');
+const created = findOrCreateLabEntry(imported, '2026-07-01', { now: 500 });
+assert('findOrCreateLabEntry creates a date-keyed row with updatedAt',
+  created.date === '2026-07-01' && created.updatedAt === 500 && imported.entries.includes(created));
+const removed = deleteLabEntryMarkerValues(imported, 'biochemistry.alp', { now: 600 });
+const tombstoneOnlyEntry = imported.entries.find(e => e.date === '2026-06-01');
+assert('deleteLabEntryMarkerValues preserves marker tombstones when last marker is removed',
+  removed.length === 1
+    && tombstoneOnlyEntry
+    && Object.keys(tombstoneOnlyEntry.markers || {}).length === 0
+    && tombstoneOnlyEntry.deletedMarkers['biochemistry.glucose'] === 400
+    && tombstoneOnlyEntry.deletedMarkers['biochemistry.alp'] === 600
+    && !imported._deleted?.entries?.includes('2026-06-01'));
+assert('deleteLabEntryMarkerValues cleans empty rows that have no marker tombstones',
+  !imported.entries.some(e => e.date === '2026-07-01')
+    && imported._deleted?.entries?.includes('2026-07-01'));
+const reimported = findOrCreateLabEntry(imported, '2026-06-01', { now: 700 });
+setLabEntryMarker(reimported, 'biochemistry.alp', 1.4, {
+  now: 700,
+  source: { file: 'new.pdf', at: 700 },
+});
+assert('reimport into tombstone-only row clears only the restored marker tombstone',
+  reimported.markers['biochemistry.alp'] === 1.4
+    && reimported.deletedMarkers['biochemistry.glucose'] === 400
+    && !Object.prototype.hasOwnProperty.call(reimported.deletedMarkers || {}, 'biochemistry.alp'));
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-manual-entry-flow.js
+++ b/tests/test-manual-entry-flow.js
@@ -22,6 +22,7 @@ console.log('=== Manual Entry Flow Tests ===\n');
   const viewsSrc = read('js/views.js');
   const markerDetailSrc = read('js/marker-detail-modal.js');
   const markerDetailEditingSrc = read('js/marker-detail-editing.js');
+  const labEntrySrc = read('js/lab-entry.js');
 
   // ═══════════════════════════════════════
   // 1. saveManualEntry is async (we await dialogs)
@@ -75,17 +76,30 @@ console.log('=== Manual Entry Flow Tests ===\n');
     /function _rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailEditingSrc) &&
     /state\.importedData\.manualValues\[mvKey\] = hasImportedOriginal \? current : true/.test(markerDetailEditingSrc) &&
     /saveManualEntry[\s\S]{0,5000}_rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailEditingSrc));
+  assert('Manual original detection accepts sourceFiles and mirrored insulin entries',
+    /function _entryMarkerValue\(entry, dotKey\)[\s\S]{0,500}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailEditingSrc) &&
+    /function _entryHasImportedSource\(entry, dotKey\)[\s\S]{0,700}entry\.sourceFiles\.some\(Boolean\)/.test(markerDetailEditingSrc));
+  assert('Manual revert can use the mirrored insulin manual original',
+    /function _manualOriginalFor\(dotKey, date\)[\s\S]{0,900}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailEditingSrc) &&
+    /revertMarkerValue[\s\S]{0,350}const original = _manualOriginalFor\(dotKey, date\)/.test(markerDetailEditingSrc));
   assert('Manual value saves stamp lab entry updatedAt for sync freshness',
-    /function stampLabEntryUpdated\(entry, now = Date\.now\(\)\)/.test(markerDetailEditingSrc)
-      && /saveManualEntry[\s\S]{0,4500}stampLabEntryUpdated\(entry, now\)/.test(markerDetailEditingSrc)
-      && /editMarkerValue[\s\S]{0,2200}stampLabEntryUpdated\(entry, now\)/.test(markerDetailEditingSrc)
-      && /revertMarkerValue[\s\S]{0,1000}stampLabEntryUpdated\(entry\)/.test(markerDetailEditingSrc));
+    /function stampLabEntryUpdated\(entry, now = Date\.now\(\)\)/.test(labEntrySrc)
+      && /saveManualEntry[\s\S]{0,4500}setLabEntryMarker\(entry, dotKey, storedValue/.test(markerDetailEditingSrc)
+      && /editMarkerValue[\s\S]{0,2400}setLabEntryMarker\(entry, dotKey, storedValue/.test(markerDetailEditingSrc)
+      && /revertMarkerValue[\s\S]{0,1200}stampLabEntryUpdated\(entry\)/.test(markerDetailEditingSrc));
   assert('Manual marker delete stamps remaining lab entry for sync freshness',
-    /deleteMarkerValue[\s\S]{0,1800}else \{\s*stampLabEntryUpdated\(entry, now\);?\s*\}/.test(markerDetailEditingSrc));
+    /deleteMarkerValue[\s\S]{0,1200}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey/.test(markerDetailEditingSrc)
+      && /deleteLabEntryMarker[\s\S]{0,1800}stampLabEntryUpdated\(entry, now\)/.test(labEntrySrc));
   assert('Clickable manual badge reverts to imported value when original exists',
     /manual \\u00d7/.test(markerDetailSrc) &&
     /Revert manual value to imported value/.test(markerDetailSrc) &&
     /revertMarkerValue\('\$\{id\}','\$\{rawDate\}'\)/.test(markerDetailSrc));
+  assert('Manual badge reads mirrored insulin original before falling back to plain manual state',
+    /function getManualValueForMarker\(dotKey, date\)[\s\S]{0,800}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailSrc) &&
+    /map\[key\] != null && map\[key\] !== true/.test(markerDetailSrc) &&
+    /map\[mirrorKey\] != null && map\[mirrorKey\] !== true/.test(markerDetailSrc) &&
+    /const manualVal = rawDate \? getManualValueForMarker\(dotKey, rawDate\) : undefined/.test(markerDetailSrc) &&
+    /const isManualSource = !!\(src && src\.file == null\)/.test(markerDetailSrc));
 
   // ═══════════════════════════════════════
   // 4. Save & Add Another flow

--- a/tests/test-marker-value-notes.js
+++ b/tests/test-marker-value-notes.js
@@ -92,12 +92,14 @@ const state = (await import('../js/state.js')).state;
   const categoryViewRenderersSrc = read('js/category-view-renderers.js');
   const markerDetailSrc = read('js/marker-detail-modal.js');
   const markerDetailEditingSrc = read('js/marker-detail-editing.js');
+  const labEntrySrc = read('js/lab-entry.js');
+  const labEntryMutationsSrc = read('js/lab-entry-mutations.js');
   assert('saveManualEntry reads me-note from the form',
     /const\s+noteInput\s*=\s*document\.getElementById\('me-note'\)/.test(markerDetailEditingSrc));
   assert('saveManualEntry stores noteText in markerValueNotes when non-empty',
     /if \(noteText\) state\.importedData\.markerValueNotes\[noteKey\] = noteText/.test(markerDetailEditingSrc));
   assert('saveManualEntry clears the entry when noteText is empty (idempotent edit-to-blank)',
-    /else delete state\.importedData\.markerValueNotes\[noteKey\]/.test(markerDetailEditingSrc));
+    /else _clearSyncedMapValue\(state\.importedData\.markerValueNotes, noteKey\)/.test(markerDetailEditingSrc));
   assert('manual-entry form HTML includes the me-note textarea',
     markerDetailSrc.includes('id="me-note"') && /placeholder=".*fasted/i.test(markerDetailSrc));
 
@@ -134,9 +136,12 @@ const state = (await import('../js/state.js')).state;
   console.log('%c 6. Orphan cleanup ', 'font-weight:bold;color:#f59e0b');
 
   assert('deleteMarkerValue drops the per-value note for the same (date, marker)',
-    /deleteMarkerValue[\s\S]{0,2000}delete state\.importedData\.markerValueNotes\[dotKey \+ ':' \+ date\]/.test(markerDetailEditingSrc));
+    /deleteMarkerValue[\s\S]{0,1200}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey/.test(markerDetailEditingSrc)
+      && /function deleteLabEntryMarkerMetadata\(importedData, dotKey, date\)[\s\S]{0,500}importedData\.markerValueNotes\[key\] = null/.test(labEntryMutationsSrc));
   assert('deleteMarkerValue drops mirrored insulin manualValues state',
-    /deleteMarkerValue[\s\S]{0,1200}delete state\.importedData\.manualValues\['diabetes\.insulin_d:' \+ date\]/.test(markerDetailEditingSrc));
+    /deleteMarkerValue[\s\S]{0,1200}mirrorInsulin: true/.test(markerDetailEditingSrc)
+      && /deleteLabEntryMarker[\s\S]{0,700}const mirrorKey = opts\.mirrorInsulin \? getInsulinMirrorMarkerKey\(dotKey\)/.test(labEntrySrc)
+      && /function deleteLabEntryMarkerMetadata\(importedData, dotKey, date\)[\s\S]{0,250}importedData\.manualValues\[key\] = null/.test(labEntryMutationsSrc));
 
   // Insulin dual-mapping parity: the value mirrors hormones.insulin ↔
   // diabetes.insulin_d, so the per-value note must mirror too. Bidirectional
@@ -158,12 +163,13 @@ const state = (await import('../js/state.js')).state;
   // edit/delete via the hormones panel OR the diabetes panel.
   assert('_insulinMirrorNoteKey helper defined and bidirectional',
     /_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc) &&
-    /if \(dotKey === 'hormones\.insulin'\) return 'diabetes\.insulin_d:' \+ date/.test(markerDetailEditingSrc) &&
-    /if \(dotKey === 'diabetes\.insulin_d'\) return 'hormones\.insulin:' \+ date/.test(markerDetailEditingSrc));
+    /getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailEditingSrc) &&
+    /if \(dotKey === 'hormones\.insulin'\) return 'diabetes\.insulin_d'/.test(labEntrySrc) &&
+    /if \(dotKey === 'diabetes\.insulin_d'\) return 'hormones\.insulin'/.test(labEntrySrc));
   assert('saveManualEntry uses bidirectional mirror helper',
     /saveManualEntry[\s\S]{0,2500}_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc));
   assert('deleteMarkerValue uses bidirectional mirror helper',
-    /deleteMarkerValue[\s\S]{0,2500}_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc));
+    /deleteMarkerValue[\s\S]{0,1200}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey[\s\S]{0,200}mirrorInsulin: true/.test(markerDetailEditingSrc));
   assert('editValueNote uses bidirectional mirror helper',
     /editValueNote[\s\S]{0,1500}_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc));
 

--- a/tests/test-provenance.js
+++ b/tests/test-provenance.js
@@ -23,19 +23,20 @@ console.log('=== Import Provenance Tests ===\n');
 // ─── 1. PDF Import Provenance ───
 console.log('1. PDF Import Provenance');
 const pdfSrc = read('js/pdf-import.js');
-assert('Init markerSources on entry', pdfSrc.includes('if (!entry.markerSources) entry.markerSources = {};'));
+const labEntrySrc = read('js/lab-entry.js');
+assert('Init markerSources on entry', labEntrySrc.includes('function ensureMarkerSources(entry)'));
 assert('Uses importTs timestamp', pdfSrc.includes('const importTs = Date.now()'));
-assert('Matched markers get markerSources', pdfSrc.includes('entry.markerSources[m.mappedKey] = { file: result.fileName'));
-assert('New markers get markerSources', pdfSrc.includes('entry.markerSources[m.suggestedKey] = { file: result.fileName'));
+assert('Matched markers get markerSources', /setLabEntryMarker\(entry, m\.mappedKey[\s\S]{0,180}source: \{ file: result\.fileName/.test(pdfSrc));
+assert('New markers get markerSources', /setLabEntryMarker\(entry, m\.suggestedKey[\s\S]{0,180}source: \{ file: result\.fileName/.test(pdfSrc));
 
 // ─── 2. Manual Entry Provenance ───
 console.log('\n2. Manual Entry Provenance');
 const markerDetailSrc = read('js/marker-detail-modal.js');
 const markerDetailEditingSrc = read('js/marker-detail-editing.js');
-assert('saveManualEntry inits markerSources', markerDetailEditingSrc.includes('if (!entry.markerSources) entry.markerSources = {};'));
-assert('saveManualEntry sets file:null', /entry\.markerSources\[dotKey\] = \{ file: null, at: (?:Date\.now\(\)|now) \}/.test(markerDetailEditingSrc));
+assert('saveManualEntry inits markerSources', labEntrySrc.includes('function ensureMarkerSources(entry)'));
+assert('saveManualEntry sets file:null', /saveManualEntry[\s\S]{0,4500}source: \{ file: null, at: now \}/.test(markerDetailEditingSrc));
 const editSection = markerDetailEditingSrc.split('function editMarkerValue')[1] || '';
-assert('editMarkerValue sets provenance', /entry\.markerSources\[dotKey\] = \{ file: null, at: (?:Date\.now\(\)|now) \}/.test(editSection));
+assert('editMarkerValue sets provenance', /source: \{ file: null, at: now \}/.test(editSection));
 
 // ─── 3. Detail Modal Display ───
 console.log('\n3. Detail Modal Display');

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -671,6 +671,11 @@ await import('../js/settings.js');
     markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshKind')
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshDate')
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshEditIdx'));
+  assert('active-profile sync refreshes an open marker detail modal',
+    syncPullActiveRefreshSrc.includes('function refreshOpenMarkerDetailModal')
+      && syncPullActiveRefreshSrc.includes("modal?.classList?.contains('marker-detail-modal')")
+      && syncPullActiveRefreshSrc.includes('window.showDetailModal(openId)')
+      && syncPullActiveRefreshSrc.includes('refreshOpenMarkerDetailModal(debug)'));
   assert('sync-pull-rebroadcast.js owns pull-side rebroadcast scheduling',
     syncPullRebroadcastSrc.includes('export function maybeScheduleRebroadcast')
       && syncPullRebroadcastSrc.includes('consumeRebroadcastBudget(profileId)')
@@ -1725,6 +1730,9 @@ await import('../js/settings.js');
     /_planKeyedMapDelta[\s\S]{0,3500}DELTA_MAP_CONFIG\[mapName\][\s\S]{0,3500}keyIdFn\(rawKey\)/.test(deltaSearchSrc));
   assert('_planKeyedMapDelta payload preserves the ORIGINAL raw key (not the synth)',
     /payloadObj\s*=\s*\{\s*k:\s*rawKey,\s*v:\s*value\s*\}/.test(deltaSearchSrc));
+  assert('_planKeyedMapDelta keeps manual value clears as live null rows',
+    /CLEARED_VALUE_MAPS\s*=\s*new Set\(\['manualValues', 'markerValueNotes'\]\)/.test(syncDeltaMapPlannerSrc)
+      && /value === null && !CLEARED_VALUE_MAPS\.has\(mapName\)/.test(syncDeltaMapPlannerSrc));
   assert('Map-shape pull verifies via keyIdFn(parsed.k) === row.itemId',
     /keyIdFn\(parsed\.k\)\s*!==\s*row\.itemId/.test(deltaSearchSrc));
   assert('Map-shape pull rebuilds map under ORIGINAL rawKey, not synth itemId',
@@ -1753,6 +1761,48 @@ await import('../js/settings.js');
     // real-world manualValues shapes)
     assert('distinct keys → distinct synths',
       synthFn('biochemistry.glucose:2026-05-03') !== synthFn('biochemistry.sodium:2026-05-03'));
+    {
+      const profileId = 'sync-test-manual-values-null-clear';
+      const rawKey = 'diabetes.insulin_d:2026-05-03';
+      const itemId = rawKey.replace(/_/g, '__').replace(/:/g, '_');
+      const snapshotKey = `labcharts-${profileId}-delta-manualValues`;
+      const metaKey = `${snapshotKey}-meta`;
+      const oldSnapshot = localStorage.getItem(snapshotKey);
+      const oldMeta = localStorage.getItem(metaKey);
+      try {
+        localStorage.removeItem(snapshotKey);
+        localStorage.removeItem(metaKey);
+        syncDelta.configureSyncDelta({
+          getEvolu: () => ({
+            getQueryRows: () => [{
+              id: 'row_manual_insulin',
+              profileId,
+              arrayName: 'manualValues',
+              itemId,
+              payload: JSON.stringify({ k: rawKey, v: 8 }),
+              syncedAt: '2026-05-03T10:00:00.000Z',
+              isDeleted: null,
+            }],
+          }),
+          getItemRowQuery: () => ({}),
+        });
+        const plan = await syncDelta._planKeyedMapDelta(profileId, 'manualValues', { [rawKey]: null });
+        const payload = JSON.parse(plan.ops[0]?.args?.payload || '{}');
+        assert('manualValues null clear updates a pulled row instead of being skipped',
+          plan.ops.length === 1
+            && plan.ops[0].kind === 'update'
+            && plan.ops[0].args.id === 'row_manual_insulin'
+            && payload.k === rawKey
+            && payload.v === null
+            && Object.prototype.hasOwnProperty.call(plan.next || {}, itemId));
+      } finally {
+        syncDelta.configureSyncDelta({ getEvolu: () => null, getItemRowQuery: () => null });
+        if (oldSnapshot === null) localStorage.removeItem(snapshotKey);
+        else localStorage.setItem(snapshotKey, oldSnapshot);
+        if (oldMeta === null) localStorage.removeItem(metaKey);
+        else localStorage.setItem(metaKey, oldMeta);
+      }
+    }
   }
   assert('_planKeyedMapDelta defined',
     /async function _planKeyedMapDelta\(profileId,\s*mapName,\s*mapObj\)/.test(deltaSearchSrc));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -61,6 +61,10 @@ return (async function() {
         date: '2099-12-31',
         markers: { 'biochemistry.alp': 1 },
         importedWith: { modelId: 'ui-flow-smoke' }
+      }, {
+        date: '2099-12-30',
+        markers: {},
+        deletedMarkers: { 'biochemistry.glucose': Date.now() }
       }],
       manualValues: {}
     });
@@ -69,6 +73,7 @@ return (async function() {
     assert('Settings Data legacy remove bridge is callable', typeof window.removeImportedEntry === 'function');
     assert('Settings Data remove button uses lazy wrapper', entriesHtml.includes('removeImportedEntryFromSettings(&quot;2099-12-31&quot;)'));
     assert('Settings Data edit button uses lazy wrapper', entriesHtml.includes('renameImportedEntryDateFromSettings(&quot;2099-12-31&quot;)'));
+    assert('Settings Data hides marker-tombstone-only sync rows', !entriesHtml.includes('0 markers'));
     await window.removeImportedEntryFromSettings('2099-12-31');
     await wait(50);
     assert('Settings Data remove wrapper deletes entry',

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -21,6 +21,7 @@ function assert(name, condition, detail) {
 console.log('=== Unit Normalization on Import Tests ===\n');
 
 const src = read('js/pdf-import.js');
+const exportSrc = read('js/export.js');
 const mappingSrc = read('js/pdf-import-marker-mapping.js');
 const normalizationSrc = read('js/pdf-import-marker-normalization.js');
 const persistenceSrc = read('js/pdf-import-persistence.js');
@@ -57,10 +58,16 @@ const settingsSrc = read('js/settings.js');
   assert('PDF import requests immediate sync push after durable save',
     /await\s+saveImportedData\(\{\s*immediate:\s*true\s*\}\)/.test(confirmBlock));
   assert('PDF import clears same-date entry tombstone when intentionally re-importing',
-    /clearTombstone\(state\.importedData,\s*['"]entries['"],\s*result\.date\)/.test(confirmBlock));
+    /findOrCreateLabEntry\(state\.importedData,\s*result\.date,\s*\{ now: importTs \}\)/.test(confirmBlock));
   assert('PDF import rolls back in-memory state when durable save fails',
     /const rollback = snapshotImportedData\(\)/.test(confirmBlock)
       && /if \(!saved\) \{[\s\S]{0,200}restoreImportedDataSnapshot\(rollback\)/.test(confirmBlock));
+  const jsonImportBlock = exportSrc.substring(exportSrc.indexOf('export function importDataJSON'), exportSrc.indexOf('function importContextField'));
+  assert('JSON import preserves markerSources.at instead of stamping wall-clock time',
+    /\? \{ \.\.\.entry\.markerSources\[key\] \}/.test(jsonImportBlock)
+      && !/\? \{ \.\.\.entry\.markerSources\[key\], at: importTs \}/.test(jsonImportBlock));
+  assert('JSON import mirrors insulin through shared lab entry helper',
+    /setLabEntryMarker\(existing, key, value,[\s\S]{0,180}mirrorInsulin: true/.test(jsonImportBlock));
   const removeBlock = persistenceSrc.substring(persistenceSrc.indexOf('export async function removeImportedEntry'), persistenceSrc.indexOf('export async function renameImportedEntryDate'));
   assert('import delete records entries tombstone before removing row',
     /recordTombstone\(state\.importedData,\s*['"]entries['"],\s*date\)[\s\S]{0,180}deleteImportedArrayItems\(state\.importedData,\s*['"]entries['"],\s*e => e\.date === date\)/.test(removeBlock));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.297';
+self.APP_VERSION = '1.8.302';


### PR DESCRIPTION
## Summary
- add shared lab-entry mutation helpers for marker set/delete/rename, insulin mirroring, HOMA-IR recalculation, freshness stamping, and marker-level tombstones
- route manual marker edits, custom marker deletion, PDF import, JSON import, and profile repairs through the shared helpers
- teach lab-entry sync merge to honor marker-level tombstones so deleting one marker from a multi-marker date does not resurrect it remotely

## Tests
- `npm test`
- `./run-tests.sh`
- `node tests/test-lab-entry.js`
- `node tests/test-data-merge.js`
- `node tests/test-marker-value-notes.js`
- `node tests/test-unit-import.js`