### PR TITLE
[codex] Centralize sync modal refresh guard

### DIFF
--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -56,7 +56,7 @@ import {
   ENV_TOXINS,
   ENV_BUILDING,
 } from './constants.js';
-import { escapeHTML, hasDirtyFormFields, showNotification } from './utils.js';
+import { bindDetailModalSyncRefresh, escapeHTML, showNotification } from './utils.js';
 import { formatTime, getTimeFormat, parseTimeInput } from './theme.js';
 import { saveImportedData } from './data.js';
 import {
@@ -88,16 +88,12 @@ let saveContextAndRefresh = (msg, field) => {
   showNotification(msg, 'success');
 };
 
-function refreshOpenHealthGoalsModalOnSync() {
-  const overlay = document.getElementById('modal-overlay');
-  const modal = document.getElementById('detail-modal');
-  if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== 'healthGoals') return;
-  if (hasDirtyFormFields(modal)) return;
+function refreshOpenHealthGoalsModalOnSync({ modal }) {
   renderHealthGoalsModal(modal);
 }
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('labcharts-sync-applied', refreshOpenHealthGoalsModalOnSync);
+  bindDetailModalSyncRefresh('healthGoals', refreshOpenHealthGoalsModalOnSync);
 }
 
 export function configureLifestyleContextEditors({ recordChange, saveAndRefresh } = {}) {

--- a/js/notes.js
+++ b/js/notes.js
@@ -1,6 +1,6 @@
 // notes.js — Standalone note editor
 import { state } from './state.js';
-import { escapeHTML, hasDirtyFormFields, showNotification, showConfirmDialog } from './utils.js';
+import { bindDetailModalSyncRefresh, escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
   appendImportedArrayItem,
@@ -9,11 +9,7 @@ import {
   replaceImportedArrayItem,
 } from './data-merge.js';
 
-function refreshOpenNoteEditorOnSync() {
-  const overlay = document.getElementById('modal-overlay');
-  const modal = document.getElementById('detail-modal');
-  if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== 'note') return;
-  if (hasDirtyFormFields(modal)) return;
+function refreshOpenNoteEditorOnSync({ modal }) {
   if (modal.dataset.syncRefreshMode !== 'edit') {
     openNoteEditor(modal.dataset.syncRefreshDate || undefined);
     return;
@@ -34,7 +30,7 @@ function refreshOpenNoteEditorOnSync() {
 }
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('labcharts-sync-applied', refreshOpenNoteEditorOnSync);
+  bindDetailModalSyncRefresh('note', refreshOpenNoteEditorOnSync);
 }
 
 export function openNoteEditor(date, existingIdx) {

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -1,7 +1,7 @@
 // supplements.js — Supplement/medication editor and dashboard section
 
 import { state } from './state.js';
-import { escapeHTML, hasDirtyFormFields, showNotification, isDebugMode } from './utils.js';
+import { bindDetailModalSyncRefresh, escapeHTML, showNotification, isDebugMode } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
   appendImportedArrayItem,
@@ -55,11 +55,7 @@ function _sourceUrlParts(raw) {
   };
 }
 
-function refreshOpenSupplementsEditorOnSync() {
-  const overlay = document.getElementById('modal-overlay');
-  const modal = document.getElementById('detail-modal');
-  if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== 'supplements') return;
-  if (hasDirtyFormFields(modal)) return;
+function refreshOpenSupplementsEditorOnSync({ modal }) {
   const idx = Number.parseInt(modal.dataset.syncRefreshEditIdx || '', 10);
   const itemId = modal.dataset.syncRefreshItemId || '';
   const supps = state.importedData.supplements || [];
@@ -75,7 +71,7 @@ function refreshOpenSupplementsEditorOnSync() {
 }
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('labcharts-sync-applied', refreshOpenSupplementsEditorOnSync);
+  bindDetailModalSyncRefresh('supplements', refreshOpenSupplementsEditorOnSync);
 }
 
 export function renderSupplementsSection() {

--- a/js/utils.js
+++ b/js/utils.js
@@ -117,6 +117,21 @@ export function bindDetachedModalSyncRefresh({
   window.addEventListener('labcharts-sync-applied', onSync);
 }
 
+export function bindDetailModalSyncRefresh(kind, refresh) {
+  if (typeof window === 'undefined' || typeof document === 'undefined' || !kind || typeof refresh !== 'function') {
+    return () => {};
+  }
+  const onSync = () => {
+    const overlay = document.getElementById('modal-overlay');
+    const modal = document.getElementById('detail-modal');
+    if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== kind) return;
+    if (hasDirtyFormFields(modal)) return;
+    refresh({ overlay, modal });
+  };
+  window.addEventListener('labcharts-sync-applied', onSync);
+  return () => window.removeEventListener('labcharts-sync-applied', onSync);
+}
+
 export function getStatus(value, refMin, refMax) {
   if (value === null || value === undefined) return "missing";
   if (refMin == null && refMax == null) return "normal";

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -120,6 +120,7 @@ const LEGACY_TESTS = [
   // Batch 16 — sync + small dashboard tests.
   './test-dashboard-genetics-empty.js',
   './test-sync.js',
+  './test-sync-modal-refresh.js',
   // Batch 17 — recommendations module.
   './test-recommendations.js',
   // Batch 19 — DNA-aware recommendation integration + image utils

--- a/tests/test-sync-modal-refresh.js
+++ b/tests/test-sync-modal-refresh.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// test-sync-modal-refresh.js — shared sync-applied modal refresh guards.
+//
+// Run: node tests/test-sync-modal-refresh.js
+
+import './_node-shim.js';
+
+const { bindDetailModalSyncRefresh } = await import('../js/utils.js');
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+console.log('=== Sync Modal Refresh Tests ===\n');
+
+const originalGetElementById = document.getElementById;
+
+function makeOverlay({ open = true } = {}) {
+  return {
+    classList: { contains: cls => cls === 'show' && open },
+  };
+}
+
+function makeModal({ kind = 'note', dirty = false } = {}) {
+  return {
+    dataset: { syncRefreshKind: kind },
+    querySelectorAll: () => dirty
+      ? [{ disabled: false, tagName: 'INPUT', type: 'text', value: 'changed', defaultValue: '' }]
+      : [],
+  };
+}
+
+function emitSyncApplied() {
+  window.dispatchEvent({ type: 'labcharts-sync-applied' });
+}
+
+try {
+  let overlay = makeOverlay();
+  let modal = makeModal();
+  document.getElementById = id => id === 'modal-overlay' ? overlay : id === 'detail-modal' ? modal : null;
+
+  let calls = 0;
+  let gotModal = null;
+  let gotOverlay = null;
+  const detach = bindDetailModalSyncRefresh('note', ({ overlay: activeOverlay, modal: activeModal }) => {
+    calls++;
+    gotOverlay = activeOverlay;
+    gotModal = activeModal;
+  });
+
+  emitSyncApplied();
+  assert('refresh runs for matching open clean detail modal',
+    calls === 1 && gotOverlay === overlay && gotModal === modal);
+
+  modal = makeModal({ kind: 'supplements' });
+  emitSyncApplied();
+  assert('refresh ignores other modal kinds', calls === 1);
+
+  overlay = makeOverlay({ open: false });
+  modal = makeModal({ kind: 'note' });
+  emitSyncApplied();
+  assert('refresh ignores closed overlay', calls === 1);
+
+  overlay = makeOverlay();
+  modal = makeModal({ kind: 'note', dirty: true });
+  emitSyncApplied();
+  assert('refresh skips dirty forms', calls === 1);
+
+  detach();
+  modal = makeModal({ kind: 'note' });
+  emitSyncApplied();
+  assert('detach unregisters sync listener', calls === 1);
+} finally {
+  document.getElementById = originalGetElementById;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -623,8 +623,10 @@ await import('../js/settings.js');
     utilsSrc.includes('export function hasDirtyFormFields')
       && utilsSrc.includes("querySelectorAll('input, textarea, select')")
       && utilsSrc.includes('export function bindDetachedModalSyncRefresh')
+      && utilsSrc.includes('export function bindDetailModalSyncRefresh')
       && utilsSrc.includes("window.addEventListener('labcharts-sync-applied', onSync)")
-      && utilsSrc.includes('hasDirtyFormFields(overlay)'));
+      && utilsSrc.includes('hasDirtyFormFields(overlay)')
+      && utilsSrc.includes('hasDirtyFormFields(modal)'));
   assert('sun and device session detail modals refresh on sync-applied',
     sunSessionUISrc.includes('bindDetachedModalSyncRefresh({')
       && sunSessionUISrc.includes('opener: openSunSessionDetail')
@@ -632,17 +634,17 @@ await import('../js/settings.js');
       && lightDevicesSrc.includes('opener: openDeviceSessionDetail'));
   assert('shared data modals refresh clean editors on sync-applied',
     supplementsSrc.includes('refreshOpenSupplementsEditorOnSync')
-      && supplementsSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenSupplementsEditorOnSync)")
+      && supplementsSrc.includes("bindDetailModalSyncRefresh('supplements', refreshOpenSupplementsEditorOnSync)")
       && supplementsSrc.includes("modal.dataset.syncRefreshKind = 'supplements'")
       && supplementsSrc.includes("modal.dataset.syncRefreshItemId")
       && supplementsSrc.includes("getConfiguredArrayItemId('supplements'")
       && notesSrc.includes('refreshOpenNoteEditorOnSync')
-      && notesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenNoteEditorOnSync)")
+      && notesSrc.includes("bindDetailModalSyncRefresh('note', refreshOpenNoteEditorOnSync)")
       && notesSrc.includes("modal.dataset.syncRefreshKind = 'note'")
       && notesSrc.includes('const noteAtIdx = state.importedData.notes?.[idx]')
       && notesSrc.includes('noteAtIdx.date === date')
       && contextCardLifestyleEditorsSrc.includes('refreshOpenHealthGoalsModalOnSync')
-      && contextCardLifestyleEditorsSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenHealthGoalsModalOnSync)")
+      && contextCardLifestyleEditorsSrc.includes("bindDetailModalSyncRefresh('healthGoals', refreshOpenHealthGoalsModalOnSync)")
       && contextCardLifestyleEditorsSrc.includes("modal.dataset.syncRefreshKind = 'healthGoals'"));
   {
     const syncedArraySurfaces = ['entries', 'notes', 'supplements', 'healthGoals', 'chatSummaries', 'changeHistory'];

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.302';
+self.APP_VERSION = '1.8.303';


### PR DESCRIPTION
## Summary
- Add a shared `bindDetailModalSyncRefresh` helper for `#detail-modal` sync refresh listeners.
- Move notes, supplements, and health goals onto the shared open/kind/dirty-form guard while keeping their domain-specific refresh behavior local.
- Add focused coverage for the helper and update sync source checks.

## Why
These modals were each reimplementing the same `labcharts-sync-applied` policy: refresh only when the matching modal is open and the form is clean. Centralizing that guard reduces the chance that future synced modals refresh stale data or wipe an in-progress edit differently from the rest of the app.

## Validation
- `node tests/test-sync-modal-refresh.js`
- `node tests/test-sync.js`
- `npm test`
- `PORT=8001 ./run-tests.sh`