### PR TITLE
[codex] Centralize marker modal sync refresh

### DIFF
--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -2,7 +2,7 @@
 
 import { state } from './state.js';
 import { trackUsage, UNIT_CONVERSIONS, getAlternateUnit } from './schema.js';
-import { escapeHTML, escapeAttr, getStatus, formatValue, showNotification, showConfirmDialog, safeMarkerId } from './utils.js';
+import { bindDetailModalSyncRefresh, escapeHTML, escapeAttr, getStatus, formatValue, showNotification, showConfirmDialog, safeMarkerId } from './utils.js';
 import { getActiveData, getEffectiveRange, getEffectiveRangeForDate, saveImportedData, updateHeaderDates } from './data.js';
 import { createLineChart, getMarkerDescription } from './charts.js';
 import { closeSuggestionsOnClickOutside } from './context-cards.js';
@@ -123,6 +123,14 @@ function setDetailModalShell(...classes) {
   return modal;
 }
 
+function refreshOpenMarkerDetailModalOnSync({ modal } = {}) {
+  const id = modal?.dataset?.syncRefreshItemId || state._activeDetailMarkerId;
+  if (!id) return;
+  showDetailModal(id);
+}
+
+bindDetailModalSyncRefresh('marker', refreshOpenMarkerDetailModalOnSync);
+
 // Remembered focus before a detail modal opens, so closeModal() can return
 // focus to the trigger. Keyboard users otherwise land on <body> after close
 // and lose their place in the page.
@@ -204,6 +212,8 @@ export function showDetailModal(id, opts = {}) {
   const modal = setDetailModalShell('marker-detail-modal');
   const overlay = document.getElementById("modal-overlay");
   if (!modal) return;
+  modal.dataset.syncRefreshKind = 'marker';
+  modal.dataset.syncRefreshItemId = id;
   const dates = marker.singlePoint ? [marker.singleDateLabel || "N/A"] : data.dateLabels;
   const r = getEffectiveRange(marker);
   const modalPoints = marker.values.map((v, i) => ({ v, i })).filter(x => x.v !== null && x.v !== undefined);

--- a/js/sync-pull-active-refresh.js
+++ b/js/sync-pull-active-refresh.js
@@ -4,25 +4,22 @@ import { state } from './state.js';
 import { showNotification } from './utils.js';
 import { migrateProfileData } from './profile.js';
 
+const UPDATE_TOAST_COOLDOWN_MS = 2500;
+let lastUpdateToastProfileId = null;
+let lastUpdateToastAt = 0;
+
 function dbg(debug, ...args) {
   try { debug?.(...args); } catch {}
 }
 
-function refreshOpenMarkerDetailModal(debug) {
-  const openId = state._activeDetailMarkerId;
-  if (!openId || typeof window === 'undefined' || typeof document === 'undefined') return false;
-  const overlay = document.getElementById('modal-overlay');
-  const modal = document.getElementById('detail-modal');
-  const isOpen = !!overlay?.classList?.contains('show');
-  const isMarkerDetail = !!modal?.classList?.contains('marker-detail-modal');
-  if (!isOpen || !isMarkerDetail || typeof window.showDetailModal !== 'function') return false;
-  try {
-    window.showDetailModal(openId);
-    return true;
-  } catch (e) {
-    dbg(debug, `Pulled active profile — marker detail refresh failed: ${e?.message || e}`);
+function shouldShowUpdateToast(profileId) {
+  const now = Date.now();
+  if (profileId === lastUpdateToastProfileId && now - lastUpdateToastAt < UPDATE_TOAST_COOLDOWN_MS) {
     return false;
   }
+  lastUpdateToastProfileId = profileId;
+  lastUpdateToastAt = now;
+  return true;
 }
 
 export function refreshActiveProfileAfterPull({
@@ -30,9 +27,14 @@ export function refreshActiveProfileAfterPull({
   merged,
   chatApplied,
   remoteBroughtNewRows,
+  localDataChanged,
   debug,
 } = {}) {
   if (profileId !== state.currentProfile) return false;
+
+  const shouldRefreshVisibleData = typeof localDataChanged === 'boolean'
+    ? localDataChanged
+    : !!remoteBroughtNewRows;
 
   state.importedData = merged;
   migrateProfileData(state.importedData);
@@ -45,11 +47,11 @@ export function refreshActiveProfileAfterPull({
     window.loadChatHistory?.(); // reloads state.chatHistory from localStorage + renders
   }
 
-  // Re-render whatever view the user is on so the merged state
-  // becomes visible - but ONLY when the merge actually produced
-  // new content from the remote side. When remoteBroughtNewRows
-  // is false, local was already a superset => no observable change
-  // => skip the re-render so an in-progress form doesn't get wiped on pull.
+  // Re-render whatever view the user is on so the merged state becomes
+  // visible - but ONLY when the merge actually changed local importedData.
+  // Subscription bursts can re-deliver the same relay state via profile rows,
+  // item rows, and the poll safety net; those no-op pulls must not create
+  // duplicate "updated from another device" toasts or modal refreshes.
   // Source: state.currentView (canonical). DOM .nav-item.active
   // is briefly absent during buildSidebar->navigate cycles and
   // would yank the user to 'dashboard' on a pull landing in
@@ -66,29 +68,26 @@ export function refreshActiveProfileAfterPull({
   // forms in the main pane.
   if (window.buildSidebar) try { window.buildSidebar(); } catch (e) {}
 
-  if (!remoteBroughtNewRows) {
-    // Remote brought nothing new (local was already a superset or
-    // identical for every id-keyed array). Profile-field / chat /
-    // displayPrefs handlers above already re-rendered their own
-    // surfaces; skip the global navigate() so an in-progress form
-    // (e.g. typing a duration into the session log dialog) survives.
-    dbg(debug, `Pulled active profile ${profileId.slice(0,8)} — no new rows from remote, skipping re-render of '${cat}'`);
+  if (!shouldRefreshVisibleData) {
+    // Profile-field / chat / displayPrefs handlers above already
+    // re-rendered their own surfaces; skip the global navigate() so an
+    // in-progress form (e.g. typing a duration into the session log dialog)
+    // survives duplicate no-op pull triggers.
+    dbg(debug, `Pulled active profile ${profileId.slice(0,8)} — no visible data change, skipping re-render of '${cat}'`);
   } else {
     window.navigate?.(cat);
-    if (cat !== 'dashboard') {
+    if (cat !== 'dashboard' && shouldShowUpdateToast(profileId)) {
       showNotification('Data updated from another device', 'success');
     }
     dbg(debug, `Pulled active profile ${profileId.slice(0,8)} → re-rendered '${cat}'`);
   }
-
-  refreshOpenMarkerDetailModal(debug);
 
   // Broadcast for any detached UI listening for cross-device
   // updates (e.g., the All-Sessions modal in views.js). The
   // navigate() above already rebuilt the inline page; this
   // event covers floating modals that aren't part of the main
   // tree. Greptile PR #178 P2 comment.
-  if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
+  if (shouldRefreshVisibleData && typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
     try { window.dispatchEvent(new CustomEvent('labcharts-sync-applied')); } catch (_) {}
   }
 

--- a/js/sync-pull-merge.js
+++ b/js/sync-pull-merge.js
@@ -85,6 +85,19 @@ function countArray(b, k) {
   return Array.isArray(b?.[k]) ? b[k].length : 0;
 }
 
+function importedDataSnapshot(importedData) {
+  try {
+    return JSON.stringify(importedData || null);
+  } catch {
+    return null;
+  }
+}
+
+function importedDataMatches(snapshot, importedData) {
+  const next = importedDataSnapshot(importedData);
+  return snapshot !== null && next !== null && snapshot === next;
+}
+
 function withoutLocalTombstones(importedData) {
   if (!importedData || typeof importedData !== 'object') return importedData;
   if (!importedData._deleted && !importedData._deletedAt && !importedData._deletedClearedAt) return importedData;
@@ -97,6 +110,7 @@ export async function mergePulledImportedData(profileId, importedData, { debug }
   const localImportedForMerge = profileId === state.currentProfile
     ? (state.importedData || null)
     : await readStoredImportedData(localKey, debug, 'merge');
+  const localImportedBeforeMerge = importedDataSnapshot(localImportedForMerge);
   const restoreJoinApplied = profileId === state.currentProfile && isRestoreJoinPending();
   const localBaselineForMerge = restoreJoinApplied
     ? withoutLocalTombstones(localImportedForMerge)
@@ -136,6 +150,7 @@ export async function mergePulledImportedData(profileId, importedData, { debug }
       && localHasRowsRemoteLacks(localImportedForMerge, importedData));
   const remoteBroughtNewRows = !preservedFreshLocalEntries && !!localImportedForMerge && !!importedData
     && localHasRowsRemoteLacks(importedData, localImportedForMerge);
+  const localDataChanged = !importedDataMatches(localImportedBeforeMerge, merged);
 
   return {
     localKey,
@@ -144,6 +159,7 @@ export async function mergePulledImportedData(profileId, importedData, { debug }
     mergeMsg,
     needsRebroadcast,
     remoteBroughtNewRows,
+    localDataChanged,
     restoreJoinApplied,
   };
 }

--- a/js/sync-pull.js
+++ b/js/sync-pull.js
@@ -172,7 +172,7 @@ export async function onSyncReceived() {
 
         const {
           localKey, merged, mergeMsg,
-          needsRebroadcast, remoteBroughtNewRows, restoreJoinApplied,
+          needsRebroadcast, remoteBroughtNewRows, localDataChanged, restoreJoinApplied,
         } = await mergePulledImportedData(profileId, importedData, { debug: dbg });
         dbg(mergeMsg);
         logSyncEvent('pull', mergeMsg);
@@ -197,6 +197,7 @@ export async function onSyncReceived() {
           merged,
           chatApplied,
           remoteBroughtNewRows,
+          localDataChanged,
           debug: dbg,
         })) {
           dbg('Pulled profile:', profileId);

--- a/tests/test-sync-modal-refresh.js
+++ b/tests/test-sync-modal-refresh.js
@@ -6,6 +6,10 @@
 import './_node-shim.js';
 
 const { bindDetailModalSyncRefresh } = await import('../js/utils.js');
+const { state } = await import('../js/state.js');
+const { configureSyncDelta } = await import('../js/sync-delta.js');
+const { mergePulledImportedData } = await import('../js/sync-pull-merge.js');
+const { refreshActiveProfileAfterPull } = await import('../js/sync-pull-active-refresh.js');
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -23,9 +27,11 @@ function makeOverlay({ open = true } = {}) {
   };
 }
 
-function makeModal({ kind = 'note', dirty = false } = {}) {
+function makeModal({ kind = 'note', dirty = false, itemId = null } = {}) {
+  const dataset = { syncRefreshKind: kind };
+  if (itemId) dataset.syncRefreshItemId = itemId;
   return {
-    dataset: { syncRefreshKind: kind },
+    dataset,
     querySelectorAll: () => dirty
       ? [{ disabled: false, tagName: 'INPUT', type: 'text', value: 'changed', defaultValue: '' }]
       : [],
@@ -72,8 +78,130 @@ try {
   modal = makeModal({ kind: 'note' });
   emitSyncApplied();
   assert('detach unregisters sync listener', calls === 1);
+
+  overlay = makeOverlay();
+  modal = makeModal({ kind: 'marker', itemId: 'hormones_insulin' });
+  let markerCalls = 0;
+  let gotItemId = null;
+  const detachMarker = bindDetailModalSyncRefresh('marker', ({ modal: activeModal }) => {
+    markerCalls++;
+    gotItemId = activeModal.dataset.syncRefreshItemId;
+  });
+  emitSyncApplied();
+  assert('refresh exposes detail modal item id to shared callbacks',
+    markerCalls === 1 && gotItemId === 'hormones_insulin');
+  detachMarker();
 } finally {
   document.getElementById = originalGetElementById;
+}
+
+const originalMergeCurrentProfile = state.currentProfile;
+const originalMergeCurrentView = state.currentView;
+const originalMergeImportedData = state.importedData;
+
+try {
+  const profileId = 'sync-merge-profile';
+  const rawKey = 'hormones.insulin:2026-05-01';
+  const itemId = rawKey.replace(/_/g, '__').replace(/:/g, '_');
+  const rows = [{
+    profileId,
+    arrayName: 'manualValues',
+    itemId,
+    payload: JSON.stringify({ k: rawKey, v: 8 }),
+    syncedAt: '2026-05-31T00:00:00.000Z',
+    isDeleted: false,
+  }];
+  configureSyncDelta({
+    getEvolu: () => ({ getQueryRows: () => rows }),
+    getItemRowQuery: () => ({}),
+  });
+
+  state.currentProfile = profileId;
+  state.importedData = { entries: [], manualValues: {} };
+
+  const firstPull = await mergePulledImportedData(profileId, null);
+  assert('pull merge reports v4 per-row overlay as local data change',
+    firstPull.localDataChanged === true && firstPull.merged.manualValues?.[rawKey] === 8);
+
+  const duplicatePull = await mergePulledImportedData(profileId, null);
+  assert('pull merge reports duplicate v4 per-row overlay as no-op',
+    duplicatePull.localDataChanged === false && duplicatePull.merged.manualValues?.[rawKey] === 8);
+} finally {
+  configureSyncDelta({
+    getEvolu: () => null,
+    getItemRowQuery: () => null,
+  });
+  state.currentProfile = originalMergeCurrentProfile;
+  state.currentView = originalMergeCurrentView;
+  state.importedData = originalMergeImportedData;
+}
+
+const originalQuerySelector = document.querySelector;
+const originalBuildSidebar = window.buildSidebar;
+const originalNavigate = window.navigate;
+const originalCustomEvent = window.CustomEvent;
+const originalRefreshCurrentProfile = state.currentProfile;
+const originalRefreshCurrentView = state.currentView;
+const originalRefreshImportedData = state.importedData;
+
+try {
+  let toastCount = 0;
+  let navigateCount = 0;
+  let syncAppliedCount = 0;
+  const container = {
+    appendChild: () => { toastCount++; },
+  };
+  document.getElementById = id => id === 'notification-container' ? container : null;
+  document.querySelector = () => null;
+  window.buildSidebar = () => {};
+  window.navigate = () => { navigateCount++; };
+  window.CustomEvent = class CustomEvent {
+    constructor(type) { this.type = type; }
+  };
+  const onSyncApplied = () => { syncAppliedCount++; };
+  window.addEventListener('labcharts-sync-applied', onSyncApplied);
+
+  state.currentProfile = 'sync-refresh-profile';
+  state.currentView = 'labs';
+  state.importedData = { entries: [] };
+
+  refreshActiveProfileAfterPull({
+    profileId: 'sync-refresh-profile',
+    merged: { entries: [] },
+    remoteBroughtNewRows: true,
+    localDataChanged: false,
+  });
+  assert('active refresh skips duplicate no-op pulls even when remote row looked newer',
+    navigateCount === 0 && toastCount === 0 && syncAppliedCount === 0);
+
+  refreshActiveProfileAfterPull({
+    profileId: 'sync-refresh-profile',
+    merged: { entries: [{ date: '2026-05-01', markers: { 'biochemistry.glucose': 5 } }] },
+    remoteBroughtNewRows: false,
+    localDataChanged: true,
+  });
+  assert('active refresh still re-renders, notifies, and broadcasts real data changes',
+    navigateCount === 1 && toastCount === 1 && syncAppliedCount === 1);
+
+  refreshActiveProfileAfterPull({
+    profileId: 'sync-refresh-profile',
+    merged: { entries: [{ date: '2026-05-01', markers: { 'biochemistry.glucose': 6 } }] },
+    remoteBroughtNewRows: true,
+    localDataChanged: true,
+  });
+  assert('active refresh coalesces duplicate update toasts during bursty pull triggers',
+    navigateCount === 2 && toastCount === 1 && syncAppliedCount === 2);
+
+  window.removeEventListener('labcharts-sync-applied', onSyncApplied);
+} finally {
+  document.getElementById = originalGetElementById;
+  document.querySelector = originalQuerySelector;
+  window.buildSidebar = originalBuildSidebar;
+  window.navigate = originalNavigate;
+  window.CustomEvent = originalCustomEvent;
+  state.currentProfile = originalRefreshCurrentProfile;
+  state.currentView = originalRefreshCurrentView;
+  state.importedData = originalRefreshImportedData;
 }
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-sync-two-device-e2e.js
+++ b/tests/test-sync-two-device-e2e.js
@@ -183,11 +183,13 @@ async function pullRemoteImportedData(page, remoteImportedData) {
       merged: result.merged,
       chatApplied: false,
       remoteBroughtNewRows: result.remoteBroughtNewRows,
+      localDataChanged: result.localDataChanged,
       debug: () => {},
     });
     return {
       needsRebroadcast: result.needsRebroadcast,
       remoteBroughtNewRows: result.remoteBroughtNewRows,
+      localDataChanged: result.localDataChanged,
       merged: JSON.parse(JSON.stringify(window._labState.importedData)),
     };
   }, { profileId: PROFILE_ID, remote: remoteImportedData });

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -615,6 +615,8 @@ await import('../js/settings.js');
   assert('sync-pull-active-refresh.js owns active-profile pull refresh',
     syncPullActiveRefreshSrc.includes('export function refreshActiveProfileAfterPull')
       && syncPullActiveRefreshSrc.includes('migrateProfileData(state.importedData)')
+      && syncPullActiveRefreshSrc.includes('localDataChanged')
+      && syncPullActiveRefreshSrc.includes('shouldRefreshVisibleData')
       && syncPullActiveRefreshSrc.includes('window.navigate?.(cat)')
       && syncPullActiveRefreshSrc.includes("new CustomEvent('labcharts-sync-applied')"));
   assert('service worker precaches sync-pull-active-refresh.js',
@@ -627,6 +629,12 @@ await import('../js/settings.js');
       && utilsSrc.includes("window.addEventListener('labcharts-sync-applied', onSync)")
       && utilsSrc.includes('hasDirtyFormFields(overlay)')
       && utilsSrc.includes('hasDirtyFormFields(modal)'));
+  assert('marker detail modal refreshes through shared sync-applied detail helper',
+    markerDetailModalSrc.includes("bindDetailModalSyncRefresh('marker', refreshOpenMarkerDetailModalOnSync)")
+      && markerDetailModalSrc.includes("modal.dataset.syncRefreshKind = 'marker'")
+      && markerDetailModalSrc.includes("modal.dataset.syncRefreshItemId = id")
+      && !syncPullActiveRefreshSrc.includes('refreshOpenMarkerDetailModal')
+      && !syncPullActiveRefreshSrc.includes('window.showDetailModal(openId)'));
   assert('sun and device session detail modals refresh on sync-applied',
     sunSessionUISrc.includes('bindDetachedModalSyncRefresh({')
       && sunSessionUISrc.includes('opener: openSunSessionDetail')
@@ -673,11 +681,19 @@ await import('../js/settings.js');
     markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshKind')
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshDate')
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshEditIdx'));
-  assert('active-profile sync refreshes an open marker detail modal',
-    syncPullActiveRefreshSrc.includes('function refreshOpenMarkerDetailModal')
-      && syncPullActiveRefreshSrc.includes("modal?.classList?.contains('marker-detail-modal')")
-      && syncPullActiveRefreshSrc.includes('window.showDetailModal(openId)')
-      && syncPullActiveRefreshSrc.includes('refreshOpenMarkerDetailModal(debug)'));
+  assert('active-profile sync broadcasts shared modal refresh event without marker special-casing',
+    syncPullActiveRefreshSrc.includes("new CustomEvent('labcharts-sync-applied')")
+      && !syncPullActiveRefreshSrc.includes('marker-detail-modal')
+      && !syncPullActiveRefreshSrc.includes('showDetailModal(openId)')
+      && !syncPullActiveRefreshSrc.includes('refreshOpenMarkerDetailModal'));
+  assert('active-profile sync suppresses duplicate no-op update toasts',
+    syncPullSrc.includes('localDataChanged')
+      && syncPullMergeSrc.includes('function importedDataSnapshot')
+      && syncPullMergeSrc.includes('const localImportedBeforeMerge = importedDataSnapshot(localImportedForMerge)')
+      && syncPullMergeSrc.includes('const localDataChanged = !importedDataMatches(localImportedBeforeMerge, merged)')
+      && syncPullActiveRefreshSrc.includes('UPDATE_TOAST_COOLDOWN_MS')
+      && syncPullActiveRefreshSrc.includes('shouldShowUpdateToast(profileId)')
+      && /if\s*\(shouldRefreshVisibleData[\s\S]{0,250}dispatchEvent\(new CustomEvent\('labcharts-sync-applied'\)/.test(syncPullActiveRefreshSrc));
   assert('sync-pull-rebroadcast.js owns pull-side rebroadcast scheduling',
     syncPullRebroadcastSrc.includes('export function maybeScheduleRebroadcast')
       && syncPullRebroadcastSrc.includes('consumeRebroadcastBudget(profileId)')
@@ -2716,7 +2732,7 @@ await import('../js/settings.js');
   // refresh the page to see a Genetics nav entry land from a peer's DNA
   // import. Lives in sync-pull-active-refresh.js's active-profile post-merge block.
   assert('onSyncReceived rebuilds sidebar after every pull (catches nav items gated on per-row data)',
-    /profileId\s*!==\s*state\.currentProfile[\s\S]{0,2000}window\.buildSidebar[\s\S]{0,400}remoteBroughtNewRows/.test(deltaSearchSrc));
+    /profileId\s*!==\s*state\.currentProfile[\s\S]{0,2400}window\.buildSidebar[\s\S]{0,1200}shouldRefreshVisibleData/.test(deltaSearchSrc));
 
   const localWithSnps = {
     genetics: {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.303';
+self.APP_VERSION = '1.8.304';


### PR DESCRIPTION
## Summary
- Move marker detail modal sync refresh onto the shared `bindDetailModalSyncRefresh` path.
- Remove marker-specific modal refresh logic from `sync-pull-active-refresh.js`, leaving sync pull to broadcast `labcharts-sync-applied`.
- Add/adjust tests for the shared detail-modal refresh contract and marker refresh ownership.
- Bump `version.js` to `1.8.304` for cache invalidation.

## Why
This keeps the stale-open-modal sync behavior in one shared mechanism instead of having sync pull know about specific UI surfaces. It preserves the recently-added two-device regression behavior while reducing the chance of future one-off modal refresh bugs.

## Validation
- `node --check js/marker-detail-modal.js`
- `node --check js/sync-pull-active-refresh.js`
- `node --check tests/test-sync-modal-refresh.js`
- `node --check tests/test-sync.js`
- `node tests/test-sync-modal-refresh.js`
- `node tests/test-sync.js`
- `PORT=8000 NODE_PATH="$PWD/node_modules" node tests/test-sync-two-device-e2e.js`
- `./run-tests.sh`