### PR TITLE
Centralize sun session mid-session writes

### DIFF
--- a/js/sun-sessions-store.js
+++ b/js/sun-sessions-store.js
@@ -188,6 +188,69 @@ export async function resumeSession(id) {
   return sess;
 }
 
+function markSessionEdited(sess) {
+  sess.updatedAt = Date.now();
+}
+
+function normalizedRegionList(regions) {
+  if (!Array.isArray(regions)) return [];
+  const allowed = new Set(BODY_REGIONS.map(r => r.key));
+  const out = [];
+  for (const key of regions) {
+    if (typeof key !== 'string' || !allowed.has(key) || out.includes(key)) continue;
+    out.push(key);
+  }
+  return out;
+}
+
+function bodyFractionForRegions(regions) {
+  return regions.reduce((sum, key) => {
+    const r = BODY_REGIONS.find(b => b.key === key);
+    return sum + (r?.fraction || 0);
+  }, 0);
+}
+
+export async function markSessionRotated(id) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess || sess.endedAt) return null;
+  if (!sess.bodyExposure) sess.bodyExposure = {};
+  if (sess.bodyExposure.rotatedSides) return sess;
+  sess.bodyExposure.rotatedSides = true;
+  markSessionEdited(sess);
+  await saveImportedData();
+  return sess;
+}
+
+export async function setSessionSunscreen(id, spf) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess || sess.endedAt) return null;
+  const nextSpf = Number(spf);
+  if (!Number.isFinite(nextSpf) || nextSpf < 0 || nextSpf > 100) return null;
+  storeDeps.commitCurrentSlice(sess);
+  if (!sess.bodyExposure) sess.bodyExposure = {};
+  sess.bodyExposure.sunscreenSPF = nextSpf || null;
+  markSessionEdited(sess);
+  storeDeps.setLiveState(id, { ratePerMin: null });
+  await saveImportedData();
+  return sess;
+}
+
+export async function setSessionCoverage(id, regions) {
+  const sess = getSessions().find(s => s.id === id);
+  if (!sess || sess.endedAt) return null;
+  const nextRegions = normalizedRegionList(regions);
+  const fraction = bodyFractionForRegions(nextRegions);
+  storeDeps.commitCurrentSlice(sess);
+  if (!sess.bodyExposure) sess.bodyExposure = {};
+  sess.bodyExposure.regions = nextRegions;
+  sess.bodyExposure.fraction = fraction;
+  sess.bodyExposure.preset = nextRegions.length === 0 ? 'face_hands' : 'detailed';
+  markSessionEdited(sess);
+  storeDeps.setLiveState(id, { ratePerMin: null });
+  await saveImportedData();
+  return sess;
+}
+
 // Edit fields on a saved session. Bumps `updatedAt` so the cross-device
 // merge (data-merge.js pickTimestamp) picks this version on conflict —
 // without that, a careless re-end on a second device would silently
@@ -224,7 +287,7 @@ export async function updateSession(id, patch) {
   if (durationChanged && sess.eyeExposure && sess.eyeExposure.durationSec != null) {
     sess.eyeExposure.durationSec = Math.round(sess.durationMin * 60);
   }
-  sess.updatedAt = Date.now();
+  markSessionEdited(sess);
   await saveImportedData();
   // Re-hydrate doses asynchronously. Per-session in-flight promise serializes
   // concurrent edits — without it, two quick updateSession calls can race two

--- a/js/sun.js
+++ b/js/sun.js
@@ -59,6 +59,9 @@ import {
   deleteSession,
   pauseSession,
   resumeSession,
+  markSessionRotated,
+  setSessionSunscreen,
+  setSessionCoverage,
   updateSession,
   hydrateSession,
   rehydrateStaleSessions,
@@ -95,6 +98,9 @@ export {
   deleteSession,
   pauseSession,
   resumeSession,
+  markSessionRotated,
+  setSessionSunscreen,
+  setSessionCoverage,
   updateSession,
   hydrateSession,
   rehydrateStaleSessions,
@@ -320,13 +326,12 @@ export async function resumeSunSession(id) {
 export async function flipSidesMidSession(id) {
   const sess = getSessions().find(s => s.id === id);
   if (!sess || sess.endedAt) return;
-  if (!sess.bodyExposure) sess.bodyExposure = {};
-  if (sess.bodyExposure.rotatedSides) {
+  if (sess.bodyExposure?.rotatedSides) {
     showNotification('Already logged as rotated — IU readout already accounts for both sides.', 'success', 3500);
     return;
   }
-  sess.bodyExposure.rotatedSides = true;
-  await saveImportedData();
+  const updated = await markSessionRotated(id);
+  if (!updated) return;
   showNotification('Logged as rotated — vit-D IU now reflects both sides exposed over the session.', 'success', 3500);
   _refreshSurfaces();
 }
@@ -349,13 +354,8 @@ export async function applySunscreenMidSession(id) {
     showNotification('SPF must be 0-100.', 'error', 3000);
     return;
   }
-  // Commit current slice with OLD SPF before the change, then update +
-  // clear rate so the next tick snapshots fresh under the NEW SPF.
-  _commitCurrentSlice(sess);
-  if (!sess.bodyExposure) sess.bodyExposure = {};
-  sess.bodyExposure.sunscreenSPF = spf || null;
-  _setLiveState(id, { ratePerMin: null });
-  await saveImportedData();
+  const updated = await setSessionSunscreen(id, spf);
+  if (!updated) return;
   showNotification(`SPF updated to ${spf || 'none'} — next dose-rate sample uses the new value.`, 'success', 3500);
   _refreshSurfaces();
 }
@@ -422,29 +422,12 @@ export async function changeCoverageMidSession(id) {
 
   overlay.querySelector('#coverage-confirm').addEventListener('click', async () => {
     const regions = Array.from(selected);
-    // Recompute fraction sum for the new selection. Floor at 0 — fully
-    // clothed is a valid intermediate state (e.g. user puts on a coat
-    // and walks to the next outdoor patch). Future ticks accrue zero
-    // until the next coverage change re-exposes skin.
-    const fraction = regions.reduce((sum, key) => {
-      const r = BODY_REGIONS.find(b => b.key === key);
-      return sum + (r?.fraction || 0);
-    }, 0);
-
-    // Commit the slice computed under the OLD regions so the historical
-    // dose stays accurate. Same plumbing applySunscreenMidSession uses.
-    _commitCurrentSlice(sess);
-    if (!sess.bodyExposure) sess.bodyExposure = {};
-    sess.bodyExposure.regions = regions;
-    sess.bodyExposure.fraction = fraction;
-    sess.bodyExposure.preset = regions.length === 0 ? 'face_hands' : 'detailed';
-    // Force a fresh rate snapshot on the next tick so the new fraction
-    // takes effect immediately rather than carrying stale rate forward.
-    _setLiveState(id, { ratePerMin: null });
-    await saveImportedData();
+    const updated = await setSessionCoverage(id, regions);
+    const fraction = updated?.bodyExposure?.fraction || 0;
     overlay.remove();
+    if (!updated) return;
     showNotification(
-      regions.length === 0
+      updated.bodyExposure?.regions?.length === 0
         ? 'Coverage updated: fully clothed — dose accrual paused until you uncover skin again.'
         : `Coverage updated: ${(fraction * 100).toFixed(0)}% body — next tick re-samples at the new fraction.`,
       'success', 3500

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -6,6 +6,13 @@
 
 import './_node-shim.js';
 
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => readFileSync(path.join(ROOT, rel), 'utf-8');
+
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
   if (condition) { pass++; console.log(`  PASS: ${name}`); }
@@ -24,7 +31,8 @@ const {
   channelTier, tierLabel, tierDots, formatChannelUnit,
   SUN_ENGINE_VERSION,
   getSessions, getActiveSession,
-  startSession, stopSession, logCompletedSession, deleteSession, pauseSession, resumeSession, updateSession,
+  startSession, stopSession, logCompletedSession, deleteSession, pauseSession, resumeSession,
+  markSessionRotated, setSessionSunscreen, setSessionCoverage, updateSession,
   rehydrateStaleSessions,
   rollingChannelTotals, dailyChannelBreakdown, rollingVitaminDIU,
   cumulativeMEDToday, cumulativeMEDYesterday,
@@ -79,7 +87,19 @@ const {
     startSession === sunSessionsStore.startSession &&
     pauseSession === sunSessionsStore.pauseSession &&
     resumeSession === sunSessionsStore.resumeSession &&
+    markSessionRotated === sunSessionsStore.markSessionRotated &&
+    setSessionSunscreen === sunSessionsStore.setSessionSunscreen &&
+    setSessionCoverage === sunSessionsStore.setSessionCoverage &&
     SUN_ENGINE_VERSION === sunSessionsStore.SUN_ENGINE_VERSION);
+  {
+    const sunSrc = read('js/sun.js');
+    const storeSrc = read('js/sun-sessions-store.js');
+    assert('mid-session sunSession writes are owned by sun-sessions-store.js',
+      !/sess\.bodyExposure\.(?:rotatedSides|sunscreenSPF|regions|fraction|preset)\s*=/.test(sunSrc)
+        && storeSrc.includes('export async function markSessionRotated')
+        && storeSrc.includes('export async function setSessionSunscreen')
+        && storeSrc.includes('export async function setSessionCoverage'));
+  }
 
   assert('EYE_MODES includes "direct" + "sunglasses" + "indoor"',
     EYE_MODES.some(e => e.key === 'direct') &&
@@ -177,6 +197,37 @@ const {
   await resumeSession(id2);
   assert('resumeSession clears paused state',
     sess2.paused === false && sess2.pausedAt === undefined);
+  const beforeRotate = Date.now() - 1;
+  await markSessionRotated(id2);
+  assert('markSessionRotated sets rotatedSides and stamps updatedAt',
+    sess2.bodyExposure.rotatedSides === true && sess2.updatedAt >= beforeRotate);
+  const rotatedAt = sess2.updatedAt;
+  await markSessionRotated(id2);
+  assert('markSessionRotated is idempotent once already rotated',
+    sess2.updatedAt === rotatedAt);
+  await setSessionSunscreen(id2, 30);
+  assert('setSessionSunscreen writes SPF and stamps updatedAt',
+    sess2.bodyExposure.sunscreenSPF === 30 && sess2.updatedAt >= rotatedAt);
+  await setSessionSunscreen(id2, 0);
+  assert('setSessionSunscreen stores zero SPF as null',
+    sess2.bodyExposure.sunscreenSPF === null);
+  const beforeInvalidSpfAt = sess2.updatedAt;
+  const invalidSpf = await setSessionSunscreen(id2, 101);
+  assert('setSessionSunscreen rejects out-of-range SPF at the store boundary',
+    invalidSpf === null && sess2.updatedAt === beforeInvalidSpfAt);
+  await setSessionCoverage(id2, ['face', 'arms-front', 'face', 'unknown-region']);
+  assert('setSessionCoverage stores deduped allowlisted regions',
+    JSON.stringify(sess2.bodyExposure.regions) === JSON.stringify(['face', 'arms-front']));
+  assert('setSessionCoverage recalculates body fraction',
+    Math.abs(sess2.bodyExposure.fraction - 0.09) < 1e-9);
+  assert('setSessionCoverage uses detailed preset for selected regions',
+    sess2.bodyExposure.preset === 'detailed');
+  await setSessionCoverage(id2, []);
+  assert('setSessionCoverage accepts fully clothed zero-fraction state',
+    Array.isArray(sess2.bodyExposure.regions)
+      && sess2.bodyExposure.regions.length === 0
+      && sess2.bodyExposure.fraction === 0
+      && sess2.bodyExposure.preset === 'face_hands');
 
   // delete one
   await stopSession(id2);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.304';
+self.APP_VERSION = '1.8.305';


### PR DESCRIPTION
## Summary
- move rotate/sunscreen/coverage active-session writes behind `sun-sessions-store` helpers
- stamp mid-session edits with `updatedAt` and clear stale live dose rates where needed
- add boundary/regression coverage and bump the app version

## Tests
- `node --check js/sun.js`
- `node --check js/sun-sessions-store.js`
- `node --check tests/test-sun.js`
- `node tests/test-sun.js`
- `npm test`
- `./run-tests.sh`