### PR TITLE
Centralize marker detail mutations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Functions called from inline HTML `onclick` handlers are exposed via `Object.ass
 3. `refOverrides`, `categoryLabels`/`categoryIcons`/`markerLabels` override display. `markerNotes` for freeform notes. `changeHistory` (capped 200) for AI temporal reasoning. `biometrics` stores time-series weight/BP/pulse (height on profile object)
 4. Marker values are arrays aligned with `dates`; `null` = no result. `singlePoint` categories use grid cards. Charts use `spanGaps: true`
 5. Each entry has `markerSources` (per-marker provenance): `{ "category.markerKey": { file: "filename.pdf", at: unixMs } }`. `file: null` = manual entry. Detail modal shows source filename per value
+6. Marker detail UI keeps prompts/rendering in `marker-detail-editing.js`; synced writes for manual values, value notes, marker notes, and reference overrides are centralized in `marker-detail-store.js` so `entries`, `manualValues`, `markerValueNotes`, `markerNotes`, and `refOverrides` update atomically before `saveImportedData()`
 
 ### PDF Import Pipeline
 

--- a/dev-docs/testing.md
+++ b/dev-docs/testing.md
@@ -104,6 +104,7 @@ A few tests run node-side (no browser, no Puppeteer) — pure-helper unit tests 
 | `tests/test-manual-entry-flow.js` | Manual-entry quality-of-life: range sanity check, duplicate-date confirm, Save & Add Another |
 | `tests/test-markdown.js` | Markdown rendering + XSS surface assertions for streamed AI responses |
 | `tests/test-marker-key-safety.js` | **node** — `safeMarkerId` + `sanitizeMarkerKey` allowlist + proto-pollution rejection (38 assertions) |
+| `tests/test-marker-detail-store.js` | Marker detail mutation boundary: manual values, mirrored insulin notes, ref overrides, marker notes |
 | `tests/test-marker-value-notes.js` | Per-value notes on lab markers: schema defaults, profile migration, sync DELTA_MAPS wiring |
 | `tests/test-mobile.js` | Responsive layout: breakpoints, grid overflow, touch tap targets, safe grid sizing |
 | `tests/test-no-native-dialogs.js` | **node** — guard against `window.prompt/confirm/alert` regressions across `js/` |

--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -8,6 +8,7 @@ import {
   deleteManualMarkerValue,
   editManualMarkerValue,
   getMarkerValueNote,
+  hasMarkerValueForDate,
   revertManualMarkerValue,
   revertRefRangeOverride,
   saveManualMarkerValue,
@@ -135,6 +136,7 @@ export async function deleteMarkerValue(id, date) {
   if (!state.importedData.entries) return;
   const entry = state.importedData.entries.find(e => e.date === date);
   if (!entry) return;
+  if (!hasMarkerValueForDate(dotKey, date)) return;
   if (await showConfirmDialog(`Delete this value (${date})? This can't be undone.`)) {
     const deleted = await deleteManualMarkerValue(dotKey, date);
     if (!deleted) return;
@@ -261,7 +263,8 @@ export async function saveRefRange(id, type) {
   if (newMin != null) newMin = convertDisplayToSI(dotKey, newMin);
   if (newMax != null) newMax = convertDisplayToSI(dotKey, newMax);
 
-  await saveRefRangeOverride(dotKey, type, { min: newMin, max: newMax });
+  const saved = await saveRefRangeOverride(dotKey, type, { min: newMin, max: newMax });
+  if (!saved) return;
   // Refresh background view, then re-render modal with new ranges
   const activeNav = document.querySelector('.nav-item.active');
   markerDetailDeps.navigate(activeNav ? activeNav.dataset.category : 'dashboard');

--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -2,17 +2,21 @@
 
 import { state } from './state.js';
 import { getAlternateUnit, convertUserInputToSI } from './schema.js';
-import { escapeHTML, escapeAttr, formatValue, showNotification, showConfirmDialog, showPromptDialog } from './utils.js';
-import { getActiveData, saveImportedData, updateHeaderDates, convertDisplayToSI } from './data.js';
+import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, showPromptDialog } from './utils.js';
+import { getActiveData, updateHeaderDates, convertDisplayToSI } from './data.js';
 import {
-  deleteLabEntryMarkerFromImportedData,
-  findOrCreateLabEntry,
-} from './lab-entry-mutations.js';
-import {
-  getInsulinMirrorMarkerKey,
-  setLabEntryMarker,
-  stampLabEntryUpdated,
-} from './lab-entry.js';
+  deleteManualMarkerValue,
+  editManualMarkerValue,
+  getMarkerValueNote,
+  revertManualMarkerValue,
+  revertRefRangeOverride,
+  saveManualMarkerValue,
+  saveMarkerNoteText,
+  saveMarkerValueNote,
+  saveRefRangeOverride,
+  deleteMarkerNoteText,
+  deleteMarkerValueNote,
+} from './marker-detail-store.js';
 
 const markerDetailDeps = {
   navigate: (category, data) => window.navigate?.(category, data),
@@ -35,71 +39,6 @@ function openManualEntryForm(id, prefillDate) {
 
 function closeModal() {
   return markerDetailDeps.closeModal();
-}
-
-// Insulin is stored under hormones.insulin but also surfaced on the diabetes
-// category as diabetes.insulin_d (so the marker shows up in both contexts).
-// Per-value notes need to mirror across both keys regardless of which
-// category the user is editing from. Returns the OTHER key (if any) so the
-// caller can write the same note value to both sides.
-function _insulinMirrorNoteKey(dotKey, date) {
-  const mirror = getInsulinMirrorMarkerKey(dotKey);
-  return mirror ? mirror + ':' + date : null;
-}
-
-function _entryMarkerValue(entry, dotKey) {
-  const markers = entry?.markers && typeof entry.markers === 'object' ? entry.markers : null;
-  if (!markers || !dotKey) return undefined;
-  if (Object.prototype.hasOwnProperty.call(markers, dotKey)) return markers[dotKey];
-  const mirror = getInsulinMirrorMarkerKey(dotKey);
-  if (mirror && Object.prototype.hasOwnProperty.call(markers, mirror)) return markers[mirror];
-  return undefined;
-}
-
-function _entryHasImportedSource(entry, dotKey) {
-  if (!entry) return false;
-  const markerSource = entry.markerSources?.[dotKey];
-  if (markerSource?.file) return true;
-  const mirror = getInsulinMirrorMarkerKey(dotKey);
-  if (mirror && entry.markerSources?.[mirror]?.file) return true;
-  if (entry.sourceFile) return true;
-  return Array.isArray(entry.sourceFiles) && entry.sourceFiles.some(Boolean);
-}
-
-function _rememberManualOriginal(dotKey, date, entry) {
-  if (!entry || !dotKey || !date) return;
-  if (!state.importedData.manualValues) state.importedData.manualValues = {};
-  const mvKey = dotKey + ':' + date;
-  const current = _entryMarkerValue(entry, dotKey);
-  const hasImportedOriginal = current != null && _entryHasImportedSource(entry, dotKey);
-  if (!(mvKey in state.importedData.manualValues) || state.importedData.manualValues[mvKey] == null) {
-    state.importedData.manualValues[mvKey] = hasImportedOriginal ? current : true;
-  } else if (state.importedData.manualValues[mvKey] === true && hasImportedOriginal) {
-    state.importedData.manualValues[mvKey] = current;
-  }
-}
-
-function _clearSyncedMapValue(map, key) {
-  if (!map || typeof map !== 'object' || !key) return;
-  if (!Object.prototype.hasOwnProperty.call(map, key)) return;
-  map[key] = null;
-}
-
-function _manualOriginalFor(dotKey, date) {
-  const map = state.importedData.manualValues;
-  if (!map || typeof map !== 'object' || !dotKey || !date) return undefined;
-  const key = dotKey + ':' + date;
-  if (Object.prototype.hasOwnProperty.call(map, key) && map[key] != null && map[key] !== true) {
-    return map[key];
-  }
-  const mirror = getInsulinMirrorMarkerKey(dotKey);
-  const mirrorKey = mirror ? mirror + ':' + date : null;
-  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey) && map[mirrorKey] != null && map[mirrorKey] !== true) {
-    return map[mirrorKey];
-  }
-  if (Object.prototype.hasOwnProperty.call(map, key)) return map[key];
-  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey)) return map[mirrorKey];
-  return undefined;
 }
 
 export async function saveManualEntry(id, opts = {}) {
@@ -158,8 +97,6 @@ export async function saveManualEntry(id, opts = {}) {
     const unit = marker?.unit || '';
     if (!await showConfirmDialog(`A value of ${displayVal} ${unit} already exists for ${date}. Overwrite?`)) return;
   }
-  const now = Date.now();
-  const entry = findOrCreateLabEntry(state.importedData, date, { now });
   // If the user picked the alternate unit, convert from there directly to SI
   // (convertUserInputToSI is a no-op when inputUnit is already the SI unit, so
   // the EU-mode default keeps working unchanged). Otherwise fall through to the
@@ -167,29 +104,7 @@ export async function saveManualEntry(id, opts = {}) {
   const storedValue = usingAltUnit
     ? convertUserInputToSI(dotKey, value, inputUnit)
     : convertDisplayToSI(dotKey, value);
-  _rememberManualOriginal(dotKey, date, entry);
-  const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
-  if (insulinMirror) _rememberManualOriginal(insulinMirror, date, entry);
-  setLabEntryMarker(entry, dotKey, storedValue, {
-    now,
-    source: { file: null, at: now },
-    mirrorInsulin: true,
-  });
-  // Per-value note: store on save when non-empty; clear when emptied.
-  if (!state.importedData.markerValueNotes) state.importedData.markerValueNotes = {};
-  const noteKey = dotKey + ':' + date;
-  if (noteText) state.importedData.markerValueNotes[noteKey] = noteText;
-  else _clearSyncedMapValue(state.importedData.markerValueNotes, noteKey);
-  // Mirror the per-value note across the insulin dual-mapping — same reading,
-  // two views. Bidirectional: user may save via either category page. Without
-  // this, a note added on one side wouldn't show on the other, and orphans
-  // would accumulate over delete cycles.
-  const insulinNoteMirror = _insulinMirrorNoteKey(dotKey, date);
-  if (insulinNoteMirror) {
-    if (noteText) state.importedData.markerValueNotes[insulinNoteMirror] = noteText;
-    else _clearSyncedMapValue(state.importedData.markerValueNotes, insulinNoteMirror);
-  }
-  await saveImportedData();
+  await saveManualMarkerValue({ dotKey, date, storedValue, noteText });
   // Remember the date session-wide so the next manual entry defaults to it.
   try { sessionStorage.setItem('labcharts-last-manual-date', date); } catch (_) {}
   window.buildSidebar();
@@ -219,14 +134,10 @@ export async function deleteMarkerValue(id, date) {
   const dotKey = id.replace('_', '.');
   if (!state.importedData.entries) return;
   const entry = state.importedData.entries.find(e => e.date === date);
-  if (!entry || entry.markers[dotKey] === undefined) return;
+  if (!entry) return;
   if (await showConfirmDialog(`Delete this value (${date})? This can't be undone.`)) {
-    const now = Date.now();
-    deleteLabEntryMarkerFromImportedData(state.importedData, entry, dotKey, {
-      now,
-      mirrorInsulin: true,
-    });
-    saveImportedData();
+    const deleted = await deleteManualMarkerValue(dotKey, date);
+    if (!deleted) return;
     window.buildSidebar();
     updateHeaderDates();
     // Re-open the detail modal to show updated values. buildSidebar
@@ -262,20 +173,9 @@ export function editMarkerValue(id, date, currentValue, event) {
     // No-op if the value didn't change — don't flip provenance to manual.
     if (newValue === parseFloat(currentValue)) { showDetailModal(id); return; }
     const dotKey = id.replace('_', '.');
-    const entry = state.importedData.entries?.find(e => e.date === date);
-    if (!entry) return;
-    // Track as manually edited — store original value for revert (true = manual entry with no original)
-    _rememberManualOriginal(dotKey, date, entry);
     const storedValue = convertDisplayToSI(dotKey, newValue);
-    const now = Date.now();
-    const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
-    if (insulinMirror) _rememberManualOriginal(insulinMirror, date, entry);
-    setLabEntryMarker(entry, dotKey, storedValue, {
-      now,
-      source: { file: null, at: now },
-      mirrorInsulin: true,
-    });
-    await saveImportedData();
+    const updated = await editManualMarkerValue({ dotKey, date, storedValue });
+    if (!updated) return;
     // Rebuild the underlying view so Table/Heatmap/Chart reflect the edit.
     markerDetailDeps.navigate(state.currentView || 'dashboard');
     showDetailModal(id);
@@ -289,20 +189,8 @@ export function editMarkerValue(id, date, currentValue, event) {
 
 export async function revertMarkerValue(id, date) {
   const dotKey = id.replace('_', '.');
-  const mvKey = dotKey + ':' + date;
-  const original = _manualOriginalFor(dotKey, date);
-  if (original == null || original === true) return;
-  const entry = state.importedData.entries?.find(e => e.date === date);
-  if (!entry) return;
-  const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
-  setLabEntryMarker(entry, dotKey, original, {
-    clearSource: true,
-    mirrorInsulin: true,
-  });
-  if (insulinMirror) _clearSyncedMapValue(state.importedData.manualValues, insulinMirror + ':' + date);
-  _clearSyncedMapValue(state.importedData.manualValues, mvKey);
-  stampLabEntryUpdated(entry);
-  await saveImportedData();
+  const updated = await revertManualMarkerValue(dotKey, date);
+  if (!updated) return;
   // Rebuild the underlying view so Table/Heatmap/Chart reflect the revert.
   markerDetailDeps.navigate(state.currentView || 'dashboard');
   showDetailModal(id);
@@ -311,9 +199,7 @@ export async function revertMarkerValue(id, date) {
 export async function editValueNote(id, date) {
   if (!id || !date) return;
   const dotKey = id.replace('_', '.');
-  const noteKey = dotKey + ':' + date;
-  if (!state.importedData.markerValueNotes) state.importedData.markerValueNotes = {};
-  const current = state.importedData.markerValueNotes[noteKey] || '';
+  const current = getMarkerValueNote(dotKey, date);
   const result = await showPromptDialog(
     current ? `Edit note for ${date}` : `Add note for ${date}`,
     { defaultValue: current, placeholder: 'e.g. fasted 14h, post-workout, different lab', okLabel: 'Save' }
@@ -324,13 +210,7 @@ export async function editValueNote(id, date) {
   // Cap to match saveManualEntry — defends against runaway paste flowing
   // into IDB, sync payloads, and AI context.
   const capped = result.length > 500 ? result.slice(0, 500) : result;
-  state.importedData.markerValueNotes[noteKey] = capped;
-  // Mirror across the insulin dual-mapping in BOTH directions so a note
-  // edited via diabetes.insulin_d also lands on hormones.insulin and vice
-  // versa.
-  const mirror = _insulinMirrorNoteKey(dotKey, date);
-  if (mirror) state.importedData.markerValueNotes[mirror] = capped;
-  saveImportedData();
+  await saveMarkerValueNote(dotKey, date, capped);
   showDetailModal(id);
 }
 
@@ -338,15 +218,8 @@ export async function deleteValueNote(id, date) {
   if (!id || !date) return;
   if (!await showConfirmDialog(`Remove the note for ${date}?`)) return;
   const dotKey = id.replace('_', '.');
-  const noteKey = dotKey + ':' + date;
-  if (state.importedData.markerValueNotes && state.importedData.markerValueNotes[noteKey]) {
-    _clearSyncedMapValue(state.importedData.markerValueNotes, noteKey);
-    // Mirror cleanup in BOTH directions across the insulin dual-mapping.
-    const mirror = _insulinMirrorNoteKey(dotKey, date);
-    if (mirror) _clearSyncedMapValue(state.importedData.markerValueNotes, mirror);
-    saveImportedData();
-    showDetailModal(id);
-  }
+  const changed = await deleteMarkerValueNote(dotKey, date);
+  if (changed) showDetailModal(id);
 }
 
 export function editRefRange(id, type, evt) {
@@ -373,7 +246,7 @@ export function editRefRange(id, type, evt) {
   form.addEventListener('keydown', e => { if (e.key === 'Escape') showDetailModal(id); });
 }
 
-export function saveRefRange(id, type) {
+export async function saveRefRange(id, type) {
   const dotKey = id.replace('_', '.');
   const minEl = document.getElementById('ref-edit-min');
   const maxEl = document.getElementById('ref-edit-max');
@@ -388,30 +261,7 @@ export function saveRefRange(id, type) {
   if (newMin != null) newMin = convertDisplayToSI(dotKey, newMin);
   if (newMax != null) newMax = convertDisplayToSI(dotKey, newMax);
 
-  if (!state.importedData.refOverrides) state.importedData.refOverrides = {};
-  if (!state.importedData.refOverrides[dotKey]) state.importedData.refOverrides[dotKey] = {};
-
-  const ovr = state.importedData.refOverrides[dotKey];
-  if (type === 'optimal') {
-    // Stash lab values before first manual edit
-    if (ovr.optimalSource !== 'manual' && ('optimalMin' in ovr) && !('labOptimalMin' in ovr)) {
-      ovr.labOptimalMin = ovr.optimalMin;
-      ovr.labOptimalMax = ovr.optimalMax;
-    }
-    ovr.optimalMin = newMin;
-    ovr.optimalMax = newMax;
-    ovr.optimalSource = 'manual';
-  } else {
-    if (ovr.refSource !== 'manual' && ('refMin' in ovr) && !('labRefMin' in ovr)) {
-      ovr.labRefMin = ovr.refMin;
-      ovr.labRefMax = ovr.refMax;
-    }
-    ovr.refMin = newMin;
-    ovr.refMax = newMax;
-    ovr.refSource = 'manual';
-  }
-
-  saveImportedData();
+  await saveRefRangeOverride(dotKey, type, { min: newMin, max: newMax });
   // Refresh background view, then re-render modal with new ranges
   const activeNav = document.querySelector('.nav-item.active');
   markerDetailDeps.navigate(activeNav ? activeNav.dataset.category : 'dashboard');
@@ -419,40 +269,14 @@ export function saveRefRange(id, type) {
   showNotification('Range updated', 'info');
 }
 
-export function revertRefRange(id, type) {
+export async function revertRefRange(id, type) {
   const dotKey = id.replace('_', '.');
-  const ovr = state.importedData?.refOverrides?.[dotKey];
-  if (!ovr) return;
-  let msg = 'Range reverted to default';
-  if (type === 'optimal') {
-    if ('labOptimalMin' in ovr) {
-      // Revert to imported lab range
-      ovr.optimalMin = ovr.labOptimalMin;
-      ovr.optimalMax = ovr.labOptimalMax;
-      ovr.optimalSource = 'import';
-      delete ovr.labOptimalMin; delete ovr.labOptimalMax;
-      msg = 'Range reverted to lab range';
-    } else {
-      delete ovr.optimalMin; delete ovr.optimalMax; delete ovr.optimalSource;
-    }
-  } else {
-    if ('labRefMin' in ovr) {
-      ovr.refMin = ovr.labRefMin;
-      ovr.refMax = ovr.labRefMax;
-      ovr.refSource = 'import';
-      delete ovr.labRefMin; delete ovr.labRefMax;
-      msg = 'Range reverted to lab range';
-    } else {
-      delete ovr.refMin; delete ovr.refMax; delete ovr.refSource;
-    }
-  }
-  // Clean up empty override objects
-  if (Object.keys(ovr).length === 0) delete state.importedData.refOverrides[dotKey];
-  saveImportedData();
+  const result = await revertRefRangeOverride(dotKey, type);
+  if (!result) return;
   const activeNav = document.querySelector('.nav-item.active');
   markerDetailDeps.navigate(activeNav ? activeNav.dataset.category : 'dashboard');
   showDetailModal(id);
-  showNotification(msg, 'info');
+  showNotification(result.message, 'info');
 }
 
 export function toggleMarkerNoteEditor(dotKey) {
@@ -466,30 +290,18 @@ export function toggleMarkerNoteEditor(dotKey) {
   }
 }
 
-export function saveMarkerNote(dotKey, id) {
+export async function saveMarkerNote(dotKey, id) {
   const input = document.getElementById('marker-note-input');
   const text = input?.value?.trim();
-  if (!text) {
-    // Empty text = delete the note
-    if (state.importedData.markerNotes?.[dotKey]) {
-      delete state.importedData.markerNotes[dotKey];
-      saveImportedData();
-      showNotification('Note removed', 'info');
-      showDetailModal(id);
-    }
-    return;
-  }
-  if (!state.importedData.markerNotes) state.importedData.markerNotes = {};
-  state.importedData.markerNotes[dotKey] = text;
-  saveImportedData();
-  showNotification('Note saved', 'success');
+  const result = await saveMarkerNoteText(dotKey, text);
+  if (result.action === 'noop') return;
+  showNotification(result.action === 'deleted' ? 'Note removed' : 'Note saved', result.action === 'deleted' ? 'info' : 'success');
   showDetailModal(id);
 }
 
-export function deleteMarkerNote(dotKey, id) {
-  if (!state.importedData.markerNotes) return;
-  delete state.importedData.markerNotes[dotKey];
-  saveImportedData();
+export async function deleteMarkerNote(dotKey, id) {
+  const changed = await deleteMarkerNoteText(dotKey);
+  if (!changed) return;
   showNotification('Note removed', 'info');
   showDetailModal(id);
 }

--- a/js/marker-detail-store.js
+++ b/js/marker-detail-store.js
@@ -88,6 +88,12 @@ export function getManualOriginalForMarker(dotKey, date) {
   return undefined;
 }
 
+export function hasMarkerValueForDate(dotKey, date) {
+  if (!dotKey || !date) return false;
+  const entry = state.importedData?.entries?.find(e => e.date === date);
+  return entryMarkerValue(entry, dotKey) !== undefined;
+}
+
 export function getMarkerValueNote(dotKey, date) {
   const key = mapKey(dotKey, date);
   if (!key) return '';
@@ -119,9 +125,10 @@ function writeMarkerValueNote(dotKey, date, noteText) {
 }
 
 export async function saveManualMarkerValue({ dotKey, date, storedValue, noteText = '', now = Date.now() } = {}) {
+  if (!dotKey || !date) return null;
   const data = ensureImportedData();
   const entry = findOrCreateLabEntry(data, date, { now });
-  if (!entry || !dotKey) return null;
+  if (!entry) return null;
   rememberManualOriginal(dotKey, date, entry);
   const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
   if (insulinMirror) rememberManualOriginal(insulinMirror, date, entry);

--- a/js/marker-detail-store.js
+++ b/js/marker-detail-store.js
@@ -1,0 +1,284 @@
+// marker-detail-store.js - synced marker-detail mutation boundary.
+
+import { state } from './state.js';
+import { saveImportedData } from './data.js';
+import {
+  deleteLabEntryMarkerFromImportedData,
+  findOrCreateLabEntry,
+} from './lab-entry-mutations.js';
+import {
+  getInsulinMirrorMarkerKey,
+  setLabEntryMarker,
+} from './lab-entry.js';
+
+const VALUE_NOTE_MAX_CHARS = 500;
+
+function ensureImportedData() {
+  if (!state.importedData || typeof state.importedData !== 'object') state.importedData = {};
+  return state.importedData;
+}
+
+function ensureMap(name) {
+  const data = ensureImportedData();
+  if (!data[name] || typeof data[name] !== 'object' || Array.isArray(data[name])) data[name] = {};
+  return data[name];
+}
+
+function mapKey(dotKey, date) {
+  return dotKey && date ? `${dotKey}:${date}` : null;
+}
+
+function insulinMirrorMapKey(dotKey, date) {
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  return mirror ? mapKey(mirror, date) : null;
+}
+
+function entryMarkerValue(entry, dotKey) {
+  const markers = entry?.markers && typeof entry.markers === 'object' ? entry.markers : null;
+  if (!markers || !dotKey) return undefined;
+  if (Object.prototype.hasOwnProperty.call(markers, dotKey)) return markers[dotKey];
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  if (mirror && Object.prototype.hasOwnProperty.call(markers, mirror)) return markers[mirror];
+  return undefined;
+}
+
+function entryHasImportedSource(entry, dotKey) {
+  if (!entry) return false;
+  const markerSource = entry.markerSources?.[dotKey];
+  if (markerSource?.file) return true;
+  const mirror = getInsulinMirrorMarkerKey(dotKey);
+  if (mirror && entry.markerSources?.[mirror]?.file) return true;
+  if (entry.sourceFile) return true;
+  return Array.isArray(entry.sourceFiles) && entry.sourceFiles.some(Boolean);
+}
+
+function rememberManualOriginal(dotKey, date, entry) {
+  const key = mapKey(dotKey, date);
+  if (!entry || !key) return;
+  const manualValues = ensureMap('manualValues');
+  const current = entryMarkerValue(entry, dotKey);
+  const hasImportedOriginal = current != null && entryHasImportedSource(entry, dotKey);
+  if (!(key in manualValues) || manualValues[key] == null) {
+    manualValues[key] = hasImportedOriginal ? current : true;
+  } else if (manualValues[key] === true && hasImportedOriginal) {
+    manualValues[key] = current;
+  }
+}
+
+function clearSyncedMapValue(map, key) {
+  if (!map || typeof map !== 'object' || !key) return false;
+  if (!Object.prototype.hasOwnProperty.call(map, key)) return false;
+  map[key] = null;
+  return true;
+}
+
+export function getManualOriginalForMarker(dotKey, date) {
+  const map = state.importedData?.manualValues;
+  const key = mapKey(dotKey, date);
+  if (!map || typeof map !== 'object' || !key) return undefined;
+  if (Object.prototype.hasOwnProperty.call(map, key) && map[key] != null && map[key] !== true) {
+    return map[key];
+  }
+  const mirrorKey = insulinMirrorMapKey(dotKey, date);
+  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey) && map[mirrorKey] != null && map[mirrorKey] !== true) {
+    return map[mirrorKey];
+  }
+  if (Object.prototype.hasOwnProperty.call(map, key)) return map[key];
+  if (mirrorKey && Object.prototype.hasOwnProperty.call(map, mirrorKey)) return map[mirrorKey];
+  return undefined;
+}
+
+export function getMarkerValueNote(dotKey, date) {
+  const key = mapKey(dotKey, date);
+  if (!key) return '';
+  return state.importedData?.markerValueNotes?.[key] || '';
+}
+
+function writeMarkerValueNote(dotKey, date, noteText) {
+  const key = mapKey(dotKey, date);
+  if (!key) return false;
+  const notes = ensureMap('markerValueNotes');
+  const capped = String(noteText || '').slice(0, VALUE_NOTE_MAX_CHARS);
+  let changed = false;
+  if (capped) {
+    changed = notes[key] !== capped;
+    notes[key] = capped;
+  } else {
+    changed = clearSyncedMapValue(notes, key);
+  }
+  const mirrorKey = insulinMirrorMapKey(dotKey, date);
+  if (mirrorKey) {
+    if (capped) {
+      changed = notes[mirrorKey] !== capped || changed;
+      notes[mirrorKey] = capped;
+    } else {
+      changed = clearSyncedMapValue(notes, mirrorKey) || changed;
+    }
+  }
+  return changed;
+}
+
+export async function saveManualMarkerValue({ dotKey, date, storedValue, noteText = '', now = Date.now() } = {}) {
+  const data = ensureImportedData();
+  const entry = findOrCreateLabEntry(data, date, { now });
+  if (!entry || !dotKey) return null;
+  rememberManualOriginal(dotKey, date, entry);
+  const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
+  if (insulinMirror) rememberManualOriginal(insulinMirror, date, entry);
+  setLabEntryMarker(entry, dotKey, storedValue, {
+    now,
+    source: { file: null, at: now },
+    mirrorInsulin: true,
+  });
+  writeMarkerValueNote(dotKey, date, noteText);
+  await saveImportedData();
+  return entry;
+}
+
+export async function editManualMarkerValue({ dotKey, date, storedValue, now = Date.now() } = {}) {
+  const entry = state.importedData?.entries?.find(e => e.date === date);
+  if (!entry || !dotKey) return null;
+  rememberManualOriginal(dotKey, date, entry);
+  const insulinMirror = getInsulinMirrorMarkerKey(dotKey);
+  if (insulinMirror) rememberManualOriginal(insulinMirror, date, entry);
+  setLabEntryMarker(entry, dotKey, storedValue, {
+    now,
+    source: { file: null, at: now },
+    mirrorInsulin: true,
+  });
+  await saveImportedData();
+  return entry;
+}
+
+export async function deleteManualMarkerValue(dotKey, date, { now = Date.now() } = {}) {
+  const entry = state.importedData?.entries?.find(e => e.date === date);
+  if (!entry || entryMarkerValue(entry, dotKey) === undefined) return null;
+  const result = deleteLabEntryMarkerFromImportedData(state.importedData, entry, dotKey, {
+    now,
+    mirrorInsulin: true,
+  });
+  if (!result.changed) return null;
+  await saveImportedData();
+  return result;
+}
+
+export async function revertManualMarkerValue(dotKey, date, { now = Date.now() } = {}) {
+  const original = getManualOriginalForMarker(dotKey, date);
+  if (original == null || original === true) return null;
+  const entry = state.importedData?.entries?.find(e => e.date === date);
+  if (!entry) return null;
+  setLabEntryMarker(entry, dotKey, original, {
+    now,
+    clearSource: true,
+    mirrorInsulin: true,
+  });
+  const manualValues = ensureMap('manualValues');
+  clearSyncedMapValue(manualValues, mapKey(dotKey, date));
+  clearSyncedMapValue(manualValues, insulinMirrorMapKey(dotKey, date));
+  await saveImportedData();
+  return entry;
+}
+
+export async function saveMarkerValueNote(dotKey, date, noteText) {
+  const changed = writeMarkerValueNote(dotKey, date, noteText);
+  if (changed) await saveImportedData();
+  return changed;
+}
+
+export async function deleteMarkerValueNote(dotKey, date) {
+  const notes = ensureMap('markerValueNotes');
+  const changedPrimary = clearSyncedMapValue(notes, mapKey(dotKey, date));
+  const changedMirror = clearSyncedMapValue(notes, insulinMirrorMapKey(dotKey, date));
+  const changed = changedPrimary || changedMirror;
+  if (changed) await saveImportedData();
+  return changed;
+}
+
+export async function saveRefRangeOverride(dotKey, type, { min, max } = {}) {
+  const isOptimal = type === 'optimal';
+  const isReference = type === 'ref' || type === 'reference';
+  if (!dotKey || (!isOptimal && !isReference)) return null;
+  const refOverrides = ensureMap('refOverrides');
+  if (!refOverrides[dotKey] || typeof refOverrides[dotKey] !== 'object') refOverrides[dotKey] = {};
+  const ovr = refOverrides[dotKey];
+  if (isOptimal) {
+    if (ovr.optimalSource !== 'manual' && ('optimalMin' in ovr) && !('labOptimalMin' in ovr)) {
+      ovr.labOptimalMin = ovr.optimalMin;
+      ovr.labOptimalMax = ovr.optimalMax;
+    }
+    ovr.optimalMin = min;
+    ovr.optimalMax = max;
+    ovr.optimalSource = 'manual';
+  } else {
+    if (ovr.refSource !== 'manual' && ('refMin' in ovr) && !('labRefMin' in ovr)) {
+      ovr.labRefMin = ovr.refMin;
+      ovr.labRefMax = ovr.refMax;
+    }
+    ovr.refMin = min;
+    ovr.refMax = max;
+    ovr.refSource = 'manual';
+  }
+  await saveImportedData();
+  return ovr;
+}
+
+export async function revertRefRangeOverride(dotKey, type) {
+  const ovr = state.importedData?.refOverrides?.[dotKey];
+  const isOptimal = type === 'optimal';
+  const isReference = type === 'ref' || type === 'reference';
+  if (!ovr || (!isOptimal && !isReference)) return null;
+  let message = 'Range reverted to default';
+  if (isOptimal) {
+    if ('labOptimalMin' in ovr) {
+      ovr.optimalMin = ovr.labOptimalMin;
+      ovr.optimalMax = ovr.labOptimalMax;
+      ovr.optimalSource = 'import';
+      delete ovr.labOptimalMin;
+      delete ovr.labOptimalMax;
+      message = 'Range reverted to lab range';
+    } else {
+      delete ovr.optimalMin;
+      delete ovr.optimalMax;
+      delete ovr.optimalSource;
+    }
+  } else {
+    if ('labRefMin' in ovr) {
+      ovr.refMin = ovr.labRefMin;
+      ovr.refMax = ovr.labRefMax;
+      ovr.refSource = 'import';
+      delete ovr.labRefMin;
+      delete ovr.labRefMax;
+      message = 'Range reverted to lab range';
+    } else {
+      delete ovr.refMin;
+      delete ovr.refMax;
+      delete ovr.refSource;
+    }
+  }
+  if (Object.keys(ovr).length === 0) delete state.importedData.refOverrides[dotKey];
+  await saveImportedData();
+  return { message };
+}
+
+export async function saveMarkerNoteText(dotKey, text) {
+  if (!dotKey) return { action: 'noop' };
+  const markerNotes = ensureMap('markerNotes');
+  const clean = String(text || '').trim();
+  if (!clean) {
+    if (!Object.prototype.hasOwnProperty.call(markerNotes, dotKey)) return { action: 'noop' };
+    delete markerNotes[dotKey];
+    await saveImportedData();
+    return { action: 'deleted' };
+  }
+  markerNotes[dotKey] = clean;
+  await saveImportedData();
+  return { action: 'saved' };
+}
+
+export async function deleteMarkerNoteText(dotKey) {
+  const markerNotes = state.importedData?.markerNotes;
+  if (!markerNotes || !Object.prototype.hasOwnProperty.call(markerNotes, dotKey)) return false;
+  delete markerNotes[dotKey];
+  await saveImportedData();
+  return true;
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -174,6 +174,7 @@ const APP_SHELL = [
   '/js/commit-hash.js',
   '/js/marker-detail-modal.js',
   '/js/marker-detail-editing.js',
+  '/js/marker-detail-store.js',
   '/js/light-conditions-now.js',
   '/js/light-page-view.js',
   '/js/light-channel-view.js',

--- a/tests/test-manual-entry-flow.js
+++ b/tests/test-manual-entry-flow.js
@@ -22,6 +22,7 @@ console.log('=== Manual Entry Flow Tests ===\n');
   const viewsSrc = read('js/views.js');
   const markerDetailSrc = read('js/marker-detail-modal.js');
   const markerDetailEditingSrc = read('js/marker-detail-editing.js');
+  const markerDetailStoreSrc = read('js/marker-detail-store.js');
   const labEntrySrc = read('js/lab-entry.js');
 
   // ═══════════════════════════════════════
@@ -73,22 +74,25 @@ console.log('=== Manual Entry Flow Tests ===\n');
   assert('Duplicate check uses display-unit value (marker.values[dateIdx]) not raw SI',
     /const dateIdx = data\.dates\.indexOf\(date\)[\s\S]{0,300}marker\.values\[dateIdx\]/.test(markerDetailEditingSrc));
   assert('Manual overwrite remembers imported original for revert',
-    /function _rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailEditingSrc) &&
-    /state\.importedData\.manualValues\[mvKey\] = hasImportedOriginal \? current : true/.test(markerDetailEditingSrc) &&
-    /saveManualEntry[\s\S]{0,5000}_rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailEditingSrc));
+    /function rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailStoreSrc) &&
+    /manualValues\[key\] = hasImportedOriginal \? current : true/.test(markerDetailStoreSrc) &&
+    /saveManualMarkerValue[\s\S]{0,1200}rememberManualOriginal\(dotKey, date, entry\)/.test(markerDetailStoreSrc) &&
+    /saveManualEntry[\s\S]{0,5000}saveManualMarkerValue\(\{ dotKey, date, storedValue, noteText \}\)/.test(markerDetailEditingSrc));
   assert('Manual original detection accepts sourceFiles and mirrored insulin entries',
-    /function _entryMarkerValue\(entry, dotKey\)[\s\S]{0,500}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailEditingSrc) &&
-    /function _entryHasImportedSource\(entry, dotKey\)[\s\S]{0,700}entry\.sourceFiles\.some\(Boolean\)/.test(markerDetailEditingSrc));
+    /function entryMarkerValue\(entry, dotKey\)[\s\S]{0,500}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailStoreSrc) &&
+    /function entryHasImportedSource\(entry, dotKey\)[\s\S]{0,700}entry\.sourceFiles\.some\(Boolean\)/.test(markerDetailStoreSrc));
   assert('Manual revert can use the mirrored insulin manual original',
-    /function _manualOriginalFor\(dotKey, date\)[\s\S]{0,900}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailEditingSrc) &&
-    /revertMarkerValue[\s\S]{0,350}const original = _manualOriginalFor\(dotKey, date\)/.test(markerDetailEditingSrc));
+    /function insulinMirrorMapKey\(dotKey, date\)[\s\S]{0,250}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailStoreSrc) &&
+    /export function getManualOriginalForMarker\(dotKey, date\)[\s\S]{0,900}insulinMirrorMapKey\(dotKey, date\)/.test(markerDetailStoreSrc) &&
+    /revertMarkerValue[\s\S]{0,350}revertManualMarkerValue\(dotKey, date\)/.test(markerDetailEditingSrc));
   assert('Manual value saves stamp lab entry updatedAt for sync freshness',
     /function stampLabEntryUpdated\(entry, now = Date\.now\(\)\)/.test(labEntrySrc)
-      && /saveManualEntry[\s\S]{0,4500}setLabEntryMarker\(entry, dotKey, storedValue/.test(markerDetailEditingSrc)
-      && /editMarkerValue[\s\S]{0,2400}setLabEntryMarker\(entry, dotKey, storedValue/.test(markerDetailEditingSrc)
-      && /revertMarkerValue[\s\S]{0,1200}stampLabEntryUpdated\(entry\)/.test(markerDetailEditingSrc));
+      && /saveManualMarkerValue[\s\S]{0,1200}setLabEntryMarker\(entry, dotKey, storedValue/.test(markerDetailStoreSrc)
+      && /editManualMarkerValue[\s\S]{0,900}setLabEntryMarker\(entry, dotKey, storedValue/.test(markerDetailStoreSrc)
+      && /revertManualMarkerValue[\s\S]{0,900}setLabEntryMarker\(entry, dotKey, original/.test(markerDetailStoreSrc));
   assert('Manual marker delete stamps remaining lab entry for sync freshness',
-    /deleteMarkerValue[\s\S]{0,1200}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey/.test(markerDetailEditingSrc)
+    /deleteMarkerValue[\s\S]{0,1200}deleteManualMarkerValue\(dotKey, date\)/.test(markerDetailEditingSrc)
+      && /deleteManualMarkerValue[\s\S]{0,900}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey/.test(markerDetailStoreSrc)
       && /deleteLabEntryMarker[\s\S]{0,1800}stampLabEntryUpdated\(entry, now\)/.test(labEntrySrc));
   assert('Clickable manual badge reverts to imported value when original exists',
     /manual \\u00d7/.test(markerDetailSrc) &&
@@ -160,9 +164,9 @@ console.log('=== Manual Entry Flow Tests ===\n');
     /let saveStarted = false/.test(markerDetailEditingSrc) &&
     /if \(saveStarted\) return;[\s\S]{0,80}saveStarted = true/.test(markerDetailEditingSrc));
   assert('Inline edit awaits persistence before refreshing the modal',
-    /await saveImportedData\(\);[\s\S]{0,160}markerDetailDeps\.navigate/.test(markerDetailEditingSrc));
+    /await editManualMarkerValue\(\{ dotKey, date, storedValue \}\);[\s\S]{0,180}markerDetailDeps\.navigate/.test(markerDetailEditingSrc));
   assert('revertMarkerValue awaits persistence before refreshing the modal',
-    /export async function revertMarkerValue\(id, date\)[\s\S]{0,900}await saveImportedData\(\);[\s\S]{0,160}markerDetailDeps\.navigate/.test(markerDetailEditingSrc));
+    /export async function revertMarkerValue\(id, date\)[\s\S]{0,300}await revertManualMarkerValue\(dotKey, date\)[\s\S]{0,160}markerDetailDeps\.navigate/.test(markerDetailEditingSrc));
   assert('editMarkerValue calls injected navigate() to rebuild Table/Heatmap after save',
     /editMarkerValue[\s\S]{0,2500}markerDetailDeps\.navigate\(state\.currentView \|\| 'dashboard'\)/.test(markerDetailEditingSrc));
   assert('revertMarkerValue also calls injected navigate() to rebuild the underlying view',

--- a/tests/test-marker-detail-store.js
+++ b/tests/test-marker-detail-store.js
@@ -25,6 +25,7 @@ const {
   deleteMarkerValueNote,
   editManualMarkerValue,
   getManualOriginalForMarker,
+  hasMarkerValueForDate,
   revertManualMarkerValue,
   revertRefRangeOverride,
   saveManualMarkerValue,
@@ -34,6 +35,24 @@ const {
 } = await import('../js/marker-detail-store.js');
 
 state.currentProfile = 'marker-detail-store-test';
+state.importedData = { entries: [] };
+
+console.log('%c 1. Defensive guards ', 'font-weight:bold;color:#f59e0b');
+const missingKeySave = await saveManualMarkerValue({
+  date: '2026-05-02',
+  storedValue: 1,
+  now: 900,
+});
+assert('saveManualMarkerValue rejects missing dotKey before creating an entry',
+  missingKeySave === null && state.importedData.entries.length === 0);
+const missingDateSave = await saveManualMarkerValue({
+  dotKey: 'biochemistry.glucose',
+  storedValue: 1,
+  now: 901,
+});
+assert('saveManualMarkerValue rejects missing date before creating an entry',
+  missingDateSave === null && state.importedData.entries.length === 0);
+
 state.importedData = {
   entries: [{
     date: '2026-05-01',
@@ -56,7 +75,7 @@ state.importedData = {
   refOverrides: {},
 };
 
-console.log('%c 1. Manual values ', 'font-weight:bold;color:#f59e0b');
+console.log('%c 2. Manual values ', 'font-weight:bold;color:#f59e0b');
 await saveManualMarkerValue({
   dotKey: 'hormones.insulin',
   date: '2026-05-01',
@@ -77,6 +96,10 @@ assert('saveManualMarkerValue records manual originals for both insulin keys',
 assert('saveManualMarkerValue writes mirrored value notes',
   state.importedData.markerValueNotes['hormones.insulin:2026-05-01'] === 'fasted'
     && state.importedData.markerValueNotes['diabetes.insulin_d:2026-05-01'] === 'fasted');
+assert('hasMarkerValueForDate detects primary and insulin mirror values',
+  hasMarkerValueForDate('hormones.insulin', '2026-05-01')
+    && hasMarkerValueForDate('diabetes.insulin_d', '2026-05-01')
+    && !hasMarkerValueForDate('hormones.cortisol', '2026-05-01'));
 
 await editManualMarkerValue({
   dotKey: 'biochemistry.glucose',
@@ -106,7 +129,7 @@ assert('deleteManualMarkerValue clears mirrored manual originals',
   state.importedData.manualValues['hormones.insulin:2026-05-01'] === null
     && state.importedData.manualValues['diabetes.insulin_d:2026-05-01'] === null);
 
-console.log('%c 2. Notes and ranges ', 'font-weight:bold;color:#f59e0b');
+console.log('%c 3. Notes and ranges ', 'font-weight:bold;color:#f59e0b');
 await saveMarkerValueNote('diabetes.insulin_d', '2026-05-01', 'x'.repeat(520));
 assert('saveMarkerValueNote caps and mirrors insulin notes',
   state.importedData.markerValueNotes['diabetes.insulin_d:2026-05-01'].length === 500
@@ -133,6 +156,9 @@ assert('revertRefRangeOverride restores stashed lab range',
     && state.importedData.refOverrides['biochemistry.alt'].refMin === 7
     && state.importedData.refOverrides['biochemistry.alt'].refSource === 'import'
     && !Object.prototype.hasOwnProperty.call(state.importedData.refOverrides['biochemistry.alt'], 'labRefMin'));
+const badRange = await saveRefRangeOverride('biochemistry.alt', 'bad-type', { min: 1, max: 2 });
+assert('saveRefRangeOverride rejects unknown range type',
+  badRange === null && state.importedData.refOverrides['biochemistry.alt'].refMin === 7);
 
 await saveMarkerNoteText('biochemistry.alt', '  liver context  ');
 assert('saveMarkerNoteText stores trimmed marker note',
@@ -141,15 +167,21 @@ await deleteMarkerNoteText('biochemistry.alt');
 assert('deleteMarkerNoteText deletes marker note key so map tombstone planner can run',
   !Object.prototype.hasOwnProperty.call(state.importedData.markerNotes, 'biochemistry.alt'));
 
-console.log('%c 3. Boundary guard ', 'font-weight:bold;color:#f59e0b');
+console.log('%c 4. Boundary guard ', 'font-weight:bold;color:#f59e0b');
 const editingSrc = read('js/marker-detail-editing.js');
 const storeSrc = read('js/marker-detail-store.js');
+const deleteMarkerValueBlock = editingSrc.match(/export async function deleteMarkerValue[\s\S]*?export function editMarkerValue/)?.[0] || '';
+const saveRefRangeBlock = editingSrc.match(/export async function saveRefRange[\s\S]*?export async function revertRefRange/)?.[0] || '';
 assert('marker-detail-editing imports the store boundary',
   editingSrc.includes("from './marker-detail-store.js'"));
 assert('marker-detail-editing no longer persists marker detail mutations directly',
   !/saveImportedData\(/.test(editingSrc)
     && !/setLabEntryMarker\(/.test(editingSrc)
     && !/deleteLabEntryMarkerFromImportedData\(/.test(editingSrc));
+assert('deleteMarkerValue checks store value presence before confirm dialog',
+  /if \(!hasMarkerValueForDate\(dotKey, date\)\) return;[\s\S]*showConfirmDialog/.test(deleteMarkerValueBlock));
+assert('saveRefRange skips UI success path when store rejects the range type',
+  /const saved = await saveRefRangeOverride\(dotKey, type, \{ min: newMin, max: newMax \}\);[\s\S]*if \(!saved\) return;[\s\S]*showNotification\('Range updated'/.test(saveRefRangeBlock));
 assert('synced marker maps are written only by marker-detail-store.js',
   !/state\.importedData\.(?:manualValues|markerValueNotes|refOverrides|markerNotes)\s*(?:\[|=|\.)/.test(editingSrc)
     && /manualValues[\s\S]{0,2000}markerValueNotes[\s\S]{0,3000}refOverrides[\s\S]{0,3000}markerNotes/.test(storeSrc));

--- a/tests/test-marker-detail-store.js
+++ b/tests/test-marker-detail-store.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// test-marker-detail-store.js - marker detail mutation boundary coverage.
+
+import './_node-shim.js';
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => readFileSync(path.join(ROOT, rel), 'utf-8');
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Marker Detail Store Tests ===\n');
+
+const { state } = await import('../js/state.js');
+const {
+  deleteManualMarkerValue,
+  deleteMarkerNoteText,
+  deleteMarkerValueNote,
+  editManualMarkerValue,
+  getManualOriginalForMarker,
+  revertManualMarkerValue,
+  revertRefRangeOverride,
+  saveManualMarkerValue,
+  saveMarkerNoteText,
+  saveMarkerValueNote,
+  saveRefRangeOverride,
+} = await import('../js/marker-detail-store.js');
+
+state.currentProfile = 'marker-detail-store-test';
+state.importedData = {
+  entries: [{
+    date: '2026-05-01',
+    updatedAt: 100,
+    markers: {
+      'hormones.insulin': 8,
+      'diabetes.insulin_d': 8,
+      'biochemistry.glucose': 4.7,
+    },
+    markerSources: {
+      'hormones.insulin': { file: 'lab.pdf', at: 100 },
+      'diabetes.insulin_d': { file: 'lab.pdf', at: 100 },
+      'biochemistry.glucose': { file: 'lab.pdf', at: 100 },
+    },
+    sourceFiles: ['lab.pdf'],
+  }],
+  manualValues: {},
+  markerValueNotes: {},
+  markerNotes: {},
+  refOverrides: {},
+};
+
+console.log('%c 1. Manual values ', 'font-weight:bold;color:#f59e0b');
+await saveManualMarkerValue({
+  dotKey: 'hormones.insulin',
+  date: '2026-05-01',
+  storedValue: 9,
+  noteText: 'fasted',
+  now: 1_000,
+});
+const entry = state.importedData.entries[0];
+assert('saveManualMarkerValue writes value and insulin mirror',
+  entry.markers['hormones.insulin'] === 9
+    && entry.markers['diabetes.insulin_d'] === 9
+    && entry.markerSources['hormones.insulin'].file === null
+    && entry.markerSources['diabetes.insulin_d'].file === null);
+assert('saveManualMarkerValue records manual originals for both insulin keys',
+  state.importedData.manualValues['hormones.insulin:2026-05-01'] === 8
+    && state.importedData.manualValues['diabetes.insulin_d:2026-05-01'] === 8
+    && getManualOriginalForMarker('diabetes.insulin_d', '2026-05-01') === 8);
+assert('saveManualMarkerValue writes mirrored value notes',
+  state.importedData.markerValueNotes['hormones.insulin:2026-05-01'] === 'fasted'
+    && state.importedData.markerValueNotes['diabetes.insulin_d:2026-05-01'] === 'fasted');
+
+await editManualMarkerValue({
+  dotKey: 'biochemistry.glucose',
+  date: '2026-05-01',
+  storedValue: 5.2,
+  now: 1_100,
+});
+assert('editManualMarkerValue records original imported value and stamps row',
+  entry.markers['biochemistry.glucose'] === 5.2
+    && entry.updatedAt === 1_100
+    && state.importedData.manualValues['biochemistry.glucose:2026-05-01'] === 4.7);
+
+await revertManualMarkerValue('biochemistry.glucose', '2026-05-01', { now: 1_200 });
+assert('revertManualMarkerValue restores original and clears manual map via null tombstone',
+  entry.markers['biochemistry.glucose'] === 4.7
+    && entry.updatedAt === 1_200
+    && state.importedData.manualValues['biochemistry.glucose:2026-05-01'] === null
+    && !Object.prototype.hasOwnProperty.call(entry.markerSources || {}, 'biochemistry.glucose'));
+
+await deleteManualMarkerValue('hormones.insulin', '2026-05-01', { now: 1_300 });
+assert('deleteManualMarkerValue removes mirrored insulin values and records marker tombstones',
+  !Object.prototype.hasOwnProperty.call(entry.markers, 'hormones.insulin')
+    && !Object.prototype.hasOwnProperty.call(entry.markers, 'diabetes.insulin_d')
+    && entry.deletedMarkers['hormones.insulin'] === 1_300
+    && entry.deletedMarkers['diabetes.insulin_d'] === 1_300);
+assert('deleteManualMarkerValue clears mirrored manual originals',
+  state.importedData.manualValues['hormones.insulin:2026-05-01'] === null
+    && state.importedData.manualValues['diabetes.insulin_d:2026-05-01'] === null);
+
+console.log('%c 2. Notes and ranges ', 'font-weight:bold;color:#f59e0b');
+await saveMarkerValueNote('diabetes.insulin_d', '2026-05-01', 'x'.repeat(520));
+assert('saveMarkerValueNote caps and mirrors insulin notes',
+  state.importedData.markerValueNotes['diabetes.insulin_d:2026-05-01'].length === 500
+    && state.importedData.markerValueNotes['hormones.insulin:2026-05-01'].length === 500);
+await deleteMarkerValueNote('hormones.insulin', '2026-05-01');
+assert('deleteMarkerValueNote nulls both insulin note keys',
+  state.importedData.markerValueNotes['hormones.insulin:2026-05-01'] === null
+    && state.importedData.markerValueNotes['diabetes.insulin_d:2026-05-01'] === null);
+
+state.importedData.refOverrides['biochemistry.alt'] = {
+  refMin: 7,
+  refMax: 40,
+  refSource: 'import',
+};
+await saveRefRangeOverride('biochemistry.alt', 'ref', { min: 8, max: 32 });
+assert('saveRefRangeOverride stashes lab range before manual override',
+  state.importedData.refOverrides['biochemistry.alt'].labRefMin === 7
+    && state.importedData.refOverrides['biochemistry.alt'].labRefMax === 40
+    && state.importedData.refOverrides['biochemistry.alt'].refMin === 8
+    && state.importedData.refOverrides['biochemistry.alt'].refSource === 'manual');
+const revertRange = await revertRefRangeOverride('biochemistry.alt', 'ref');
+assert('revertRefRangeOverride restores stashed lab range',
+  revertRange.message === 'Range reverted to lab range'
+    && state.importedData.refOverrides['biochemistry.alt'].refMin === 7
+    && state.importedData.refOverrides['biochemistry.alt'].refSource === 'import'
+    && !Object.prototype.hasOwnProperty.call(state.importedData.refOverrides['biochemistry.alt'], 'labRefMin'));
+
+await saveMarkerNoteText('biochemistry.alt', '  liver context  ');
+assert('saveMarkerNoteText stores trimmed marker note',
+  state.importedData.markerNotes['biochemistry.alt'] === 'liver context');
+await deleteMarkerNoteText('biochemistry.alt');
+assert('deleteMarkerNoteText deletes marker note key so map tombstone planner can run',
+  !Object.prototype.hasOwnProperty.call(state.importedData.markerNotes, 'biochemistry.alt'));
+
+console.log('%c 3. Boundary guard ', 'font-weight:bold;color:#f59e0b');
+const editingSrc = read('js/marker-detail-editing.js');
+const storeSrc = read('js/marker-detail-store.js');
+assert('marker-detail-editing imports the store boundary',
+  editingSrc.includes("from './marker-detail-store.js'"));
+assert('marker-detail-editing no longer persists marker detail mutations directly',
+  !/saveImportedData\(/.test(editingSrc)
+    && !/setLabEntryMarker\(/.test(editingSrc)
+    && !/deleteLabEntryMarkerFromImportedData\(/.test(editingSrc));
+assert('synced marker maps are written only by marker-detail-store.js',
+  !/state\.importedData\.(?:manualValues|markerValueNotes|refOverrides|markerNotes)\s*(?:\[|=|\.)/.test(editingSrc)
+    && /manualValues[\s\S]{0,2000}markerValueNotes[\s\S]{0,3000}refOverrides[\s\S]{0,3000}markerNotes/.test(storeSrc));
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-marker-value-notes.js
+++ b/tests/test-marker-value-notes.js
@@ -92,14 +92,16 @@ const state = (await import('../js/state.js')).state;
   const categoryViewRenderersSrc = read('js/category-view-renderers.js');
   const markerDetailSrc = read('js/marker-detail-modal.js');
   const markerDetailEditingSrc = read('js/marker-detail-editing.js');
+  const markerDetailStoreSrc = read('js/marker-detail-store.js');
   const labEntrySrc = read('js/lab-entry.js');
   const labEntryMutationsSrc = read('js/lab-entry-mutations.js');
   assert('saveManualEntry reads me-note from the form',
     /const\s+noteInput\s*=\s*document\.getElementById\('me-note'\)/.test(markerDetailEditingSrc));
   assert('saveManualEntry stores noteText in markerValueNotes when non-empty',
-    /if \(noteText\) state\.importedData\.markerValueNotes\[noteKey\] = noteText/.test(markerDetailEditingSrc));
+    /saveManualEntry[\s\S]{0,5200}saveManualMarkerValue\(\{ dotKey, date, storedValue, noteText \}\)/.test(markerDetailEditingSrc)
+      && /function writeMarkerValueNote\(dotKey, date, noteText\)[\s\S]{0,500}notes\[key\] = capped/.test(markerDetailStoreSrc));
   assert('saveManualEntry clears the entry when noteText is empty (idempotent edit-to-blank)',
-    /else _clearSyncedMapValue\(state\.importedData\.markerValueNotes, noteKey\)/.test(markerDetailEditingSrc));
+    /function writeMarkerValueNote\(dotKey, date, noteText\)[\s\S]{0,700}clearSyncedMapValue\(notes, key\)/.test(markerDetailStoreSrc));
   assert('manual-entry form HTML includes the me-note textarea',
     markerDetailSrc.includes('id="me-note"') && /placeholder=".*fasted/i.test(markerDetailSrc));
 
@@ -136,10 +138,11 @@ const state = (await import('../js/state.js')).state;
   console.log('%c 6. Orphan cleanup ', 'font-weight:bold;color:#f59e0b');
 
   assert('deleteMarkerValue drops the per-value note for the same (date, marker)',
-    /deleteMarkerValue[\s\S]{0,1200}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey/.test(markerDetailEditingSrc)
+    /deleteMarkerValue[\s\S]{0,1200}deleteManualMarkerValue\(dotKey, date\)/.test(markerDetailEditingSrc)
+      && /deleteManualMarkerValue[\s\S]{0,900}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey/.test(markerDetailStoreSrc)
       && /function deleteLabEntryMarkerMetadata\(importedData, dotKey, date\)[\s\S]{0,500}importedData\.markerValueNotes\[key\] = null/.test(labEntryMutationsSrc));
   assert('deleteMarkerValue drops mirrored insulin manualValues state',
-    /deleteMarkerValue[\s\S]{0,1200}mirrorInsulin: true/.test(markerDetailEditingSrc)
+    /deleteManualMarkerValue[\s\S]{0,1200}mirrorInsulin: true/.test(markerDetailStoreSrc)
       && /deleteLabEntryMarker[\s\S]{0,700}const mirrorKey = opts\.mirrorInsulin \? getInsulinMirrorMarkerKey\(dotKey\)/.test(labEntrySrc)
       && /function deleteLabEntryMarkerMetadata\(importedData, dotKey, date\)[\s\S]{0,250}importedData\.manualValues\[key\] = null/.test(labEntryMutationsSrc));
 
@@ -157,21 +160,26 @@ const state = (await import('../js/state.js')).state;
   // editValueNote + deleteValueNote also route through _insulinMirrorNoteKey
   // — see the bidirectional helper asserts below.
   assert('deleteValueNote cleans the mirror note for insulin',
-    /deleteValueNote[\s\S]{0,800}_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc));
+    /deleteValueNote[\s\S]{0,800}deleteMarkerValueNote\(dotKey, date\)/.test(markerDetailEditingSrc)
+      && /deleteMarkerValueNote[\s\S]{0,500}insulinMirrorMapKey\(dotKey, date\)/.test(markerDetailStoreSrc));
 
   // Greptile P1: insulin note mirror must be BIDIRECTIONAL — user may
   // edit/delete via the hormones panel OR the diabetes panel.
   assert('_insulinMirrorNoteKey helper defined and bidirectional',
-    /_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc) &&
-    /getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailEditingSrc) &&
+    /insulinMirrorMapKey\(dotKey, date\)/.test(markerDetailStoreSrc) &&
+    /getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailStoreSrc) &&
     /if \(dotKey === 'hormones\.insulin'\) return 'diabetes\.insulin_d'/.test(labEntrySrc) &&
     /if \(dotKey === 'diabetes\.insulin_d'\) return 'hormones\.insulin'/.test(labEntrySrc));
   assert('saveManualEntry uses bidirectional mirror helper',
-    /saveManualEntry[\s\S]{0,2500}_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc));
+    /saveManualEntry[\s\S]{0,5200}saveManualMarkerValue\(\{ dotKey, date, storedValue, noteText \}\)/.test(markerDetailEditingSrc)
+      && /writeMarkerValueNote[\s\S]{0,900}insulinMirrorMapKey\(dotKey, date\)/.test(markerDetailStoreSrc));
   assert('deleteMarkerValue uses bidirectional mirror helper',
-    /deleteMarkerValue[\s\S]{0,1200}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey[\s\S]{0,200}mirrorInsulin: true/.test(markerDetailEditingSrc));
+    /deleteMarkerValue[\s\S]{0,1200}deleteManualMarkerValue\(dotKey, date\)/.test(markerDetailEditingSrc)
+      && /deleteManualMarkerValue[\s\S]{0,900}deleteLabEntryMarkerFromImportedData\(state\.importedData, entry, dotKey[\s\S]{0,200}mirrorInsulin: true/.test(markerDetailStoreSrc));
   assert('editValueNote uses bidirectional mirror helper',
-    /editValueNote[\s\S]{0,1500}_insulinMirrorNoteKey\(dotKey, date\)/.test(markerDetailEditingSrc));
+    /editValueNote[\s\S]{0,1500}saveMarkerValueNote\(dotKey, date, capped\)/.test(markerDetailEditingSrc)
+      && /saveMarkerValueNote[\s\S]{0,500}writeMarkerValueNote\(dotKey, date, noteText\)/.test(markerDetailStoreSrc)
+      && /writeMarkerValueNote[\s\S]{0,900}insulinMirrorMapKey\(dotKey, date\)/.test(markerDetailStoreSrc));
 
   // CodeQL js/xss-through-dom: empty-cell onclick must use JSON.stringify
   // so interpolated id/date survive the HTML-attr → JS-string round-trip.

--- a/tests/test-provenance.js
+++ b/tests/test-provenance.js
@@ -33,10 +33,15 @@ assert('New markers get markerSources', /setLabEntryMarker\(entry, m\.suggestedK
 console.log('\n2. Manual Entry Provenance');
 const markerDetailSrc = read('js/marker-detail-modal.js');
 const markerDetailEditingSrc = read('js/marker-detail-editing.js');
+const markerDetailStoreSrc = read('js/marker-detail-store.js');
 assert('saveManualEntry inits markerSources', labEntrySrc.includes('function ensureMarkerSources(entry)'));
-assert('saveManualEntry sets file:null', /saveManualEntry[\s\S]{0,4500}source: \{ file: null, at: now \}/.test(markerDetailEditingSrc));
+assert('saveManualEntry sets file:null',
+  /saveManualEntry[\s\S]{0,5200}saveManualMarkerValue\(\{ dotKey, date, storedValue, noteText \}\)/.test(markerDetailEditingSrc)
+    && /saveManualMarkerValue[\s\S]{0,1200}source: \{ file: null, at: now \}/.test(markerDetailStoreSrc));
 const editSection = markerDetailEditingSrc.split('function editMarkerValue')[1] || '';
-assert('editMarkerValue sets provenance', /source: \{ file: null, at: now \}/.test(editSection));
+assert('editMarkerValue sets provenance',
+  /editManualMarkerValue\(\{ dotKey, date, storedValue \}\)/.test(editSection)
+    && /editManualMarkerValue[\s\S]{0,900}source: \{ file: null, at: now \}/.test(markerDetailStoreSrc));
 
 // ─── 3. Detail Modal Display ───
 console.log('\n3. Detail Modal Display');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.305';
+self.APP_VERSION = '1.8.306';


### PR DESCRIPTION
## Summary
- add a marker-detail store boundary for manual marker values, value notes, marker notes, and ref overrides
- route marker-detail UI mutation flows through the store while keeping prompts/rendering in the UI module
- add boundary/regression tests, service-worker precache entry, docs, and app version bump

## Tests
- `node --check js/marker-detail-editing.js`
- `node --check js/marker-detail-store.js`
- `node --check tests/test-marker-detail-store.js`
- `node tests/test-marker-detail-store.js`
- `node tests/test-manual-entry-flow.js`
- `node tests/test-marker-value-notes.js`
- `node tests/test-lab-entry.js`
- `node tests/test-provenance.js`
- `npm test`
- `./run-tests.sh`