### PR TITLE
Centralize light device session mutations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Functions called from inline HTML `onclick` handlers are exposed via `Object.ass
 4. Marker values are arrays aligned with `dates`; `null` = no result. `singlePoint` categories use grid cards. Charts use `spanGaps: true`
 5. Each entry has `markerSources` (per-marker provenance): `{ "category.markerKey": { file: "filename.pdf", at: unixMs } }`. `file: null` = manual entry. Detail modal shows source filename per value
 6. Marker detail UI keeps prompts/rendering in `marker-detail-editing.js`; synced writes for manual values, value notes, marker notes, and reference overrides are centralized in `marker-detail-store.js` so `entries`, `manualValues`, `markerValueNotes`, `markerNotes`, and `refOverrides` update atomically before `saveImportedData()`
+7. Light device UI keeps preset loading, dialogs, rendering, and notifications in `light-devices.js`; synced writes for owned devices and device sessions are centralized in `light-devices-store.js` so `lightDevices`, `deviceSessions`, dose recomputes, sync freshness stamps, and tombstones update before `saveImportedData()`
 
 ### PDF Import Pipeline
 

--- a/dev-docs/testing.md
+++ b/dev-docs/testing.md
@@ -97,6 +97,7 @@ A few tests run node-side (no browser, no Puppeteer) — pure-helper unit tests 
 | `tests/test-light-ai-renders.js` | Smoke coverage for the 10 feature-specific Light & Sun AI modules |
 | `tests/test-light-device-ai-analysis.js` | Per-device-session AI verdict: fingerprint determinism, prompt-context shape (incl. mode resolution + injection guards), render state machine, engine adapter coverage |
 | `tests/test-light-devices.js` | Light therapy device library + sessions: addDeviceFromPreset, deleteDevice, logDeviceSession |
+| `tests/test-light-devices-store.js` | Light-device mutation boundary: device CRUD, session lifecycle, dose recompute, sync tombstones |
 | `tests/test-light-env.js` | Light Environment math + CRUD: rooms, screens, audits, computeRoomSeverity, computeScreenStatus, computeIndoorBurden |
 | `tests/test-light-tools.js` | Pure helpers re-exported from `light-tools.js`: computeRowBanding (flicker FFT), saveMeasurement, lockStatusLine |
 | `tests/test-light-tools-flow.js` | Drives `saveMeasurement` across all 8 tool types + every camera-bound opener (handles missing getUserMedia cleanly) |

--- a/js/light-device-session-engine.js
+++ b/js/light-device-session-engine.js
@@ -1,6 +1,6 @@
 // light-device-session-engine.js — shared dose math for light-device sessions.
 //
-// UI modules own dialogs and persistence. This module owns the repeated
+// UI/store modules own dialogs and persistence. This module owns the repeated
 // session calculations: mode resolution, body-area fraction, distance scaling,
 // spectrum synthesis, and SAD-lux fallback.
 

--- a/js/light-device-setup-modal.js
+++ b/js/light-device-setup-modal.js
@@ -1,8 +1,8 @@
 // light-device-setup-modal.js — add/custom light-device setup UI.
 //
-// Device persistence stays in light-devices.js. This module owns the
-// preset-picker modal, custom-device form, and AI-assisted URL/photo spec
-// extraction, then calls injected persistence callbacks.
+// Device persistence stays behind light-devices-store.js via injected
+// callbacks. This module owns the preset-picker modal, custom-device form,
+// and AI-assisted URL/photo spec extraction.
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, isDebugMode } from './utils.js';

--- a/js/light-devices-store.js
+++ b/js/light-devices-store.js
@@ -1,0 +1,337 @@
+// light-devices-store.js - persisted light-device and device-session mutations.
+//
+// UI modules own preset loading, dialogs, rendering, and notifications. This
+// module owns importedData.lightDevices[] / deviceSessions[] writes, dose
+// recompute, sync freshness stamps, and saveImportedData().
+
+import { state } from './state.js';
+import { saveImportedData } from './data.js';
+import { deleteImportedArrayItem } from './data-merge.js';
+import {
+  DEVICE_TYPE_CHANNELS,
+  computeDeviceSessionDoses,
+  resolveDeviceMode,
+} from './light-device-session-engine.js';
+
+function randomSuffix(chars = 4) {
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(Math.ceil(chars * 0.75) + 1);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('').slice(0, chars);
+  }
+  return Math.random().toString(36).slice(2, 2 + chars).padEnd(chars, '0');
+}
+
+function makeId(prefix, now = Date.now()) {
+  return `${prefix}_${now.toString(36)}_${randomSuffix()}`;
+}
+
+function runDeviceSessionAnalysis(session) {
+  if (typeof window !== 'undefined' && window.maybeAnalyzeDeviceSessionAfterFinish) {
+    try { window.maybeAnalyzeDeviceSessionAfterFinish(session); } catch (_) {}
+  }
+}
+
+export function getDevices() {
+  if (!state.importedData) return [];
+  if (!Array.isArray(state.importedData.lightDevices)) state.importedData.lightDevices = [];
+  return state.importedData.lightDevices;
+}
+
+export function getDeviceSessions() {
+  if (!state.importedData) return [];
+  if (!Array.isArray(state.importedData.deviceSessions)) state.importedData.deviceSessions = [];
+  return state.importedData.deviceSessions;
+}
+
+export async function addDeviceFromPresetRecord(preset, overrides = {}, { now = Date.now() } = {}) {
+  if (!preset) return null;
+  const device = {
+    id: makeId('dev', now),
+    presetId: preset.id,
+    brand: overrides.brand || preset.brand,
+    model: overrides.model || preset.model,
+    type: overrides.type || preset.type,
+    peakWavelengths: overrides.peakWavelengths || preset.peakWavelengths || [],
+    mwPerCm2At15cm: overrides.mwPerCm2At15cm ?? preset.mwPerCm2At15cm ?? null,
+    lux: overrides.lux ?? preset.lux ?? null,
+    recommendedDistanceCm: overrides.recommendedDistanceCm ?? preset.recommendedDistanceCm ?? 15,
+    channels: overrides.channels || preset.channels || [],
+    // Round 7: copy the LED-group schema through so the session-log
+    // dialog can render the mode picker. Devices added pre-Round-7 are
+    // healed by hydrateDevicesFromPresetRecords at boot.
+    channelGroups: Array.isArray(preset.channelGroups) ? preset.channelGroups : null,
+    modes: Array.isArray(preset.modes) ? preset.modes : null,
+    coupling: Array.isArray(preset.coupling) ? preset.coupling : null,
+    catalogSlug: preset.catalogSlug || null,
+    notes: overrides.notes || '',
+    addedAt: now,
+  };
+  getDevices().push(device);
+  await saveImportedData();
+  return device;
+}
+
+export async function hydrateDevicesFromPresetRecords(presets) {
+  if (!Array.isArray(presets) || presets.length === 0) return false;
+  if (!state.importedData) return false;
+  const devices = Array.isArray(state.importedData.lightDevices) ? state.importedData.lightDevices : [];
+  let dirty = false;
+  for (const dev of devices) {
+    if (!dev || !dev.presetId) continue;
+    const preset = presets.find(p => p.id === dev.presetId);
+    if (!preset) continue;
+    if (!Array.isArray(dev.channelGroups) && Array.isArray(preset.channelGroups)) {
+      dev.channelGroups = preset.channelGroups;
+      dirty = true;
+    }
+    if (!Array.isArray(dev.modes) && Array.isArray(preset.modes)) {
+      dev.modes = preset.modes;
+      dirty = true;
+    }
+    if (!Array.isArray(dev.coupling) && Array.isArray(preset.coupling)) {
+      dev.coupling = preset.coupling;
+      dirty = true;
+    }
+  }
+  if (dirty) await saveImportedData();
+  return dirty;
+}
+
+export async function deleteDevice(id) {
+  const devs = getDevices();
+  const idx = devs.findIndex(d => d.id === id);
+  if (idx < 0) return false;
+  deleteImportedArrayItem(state.importedData, 'lightDevices', idx);
+  await saveImportedData();
+  return true;
+}
+
+export async function logDeviceSession({ deviceId, durationMin, distanceCm = 15, bodyArea = 'torso', bodyAreas = null, eyesProtected = true, notes = '', mode = null } = {}) {
+  const device = getDevices().find(d => d.id === deviceId);
+  if (!device) return null;
+  const now = Date.now();
+  const seconds = durationMin * 60;
+  const { doses, mode: resolvedMode } = computeDeviceSessionDoses({
+    device,
+    durationMin,
+    distanceCm,
+    bodyArea,
+    bodyAreas,
+    eyesProtected,
+    mode,
+  });
+
+  const session = {
+    id: makeId('devsess', now),
+    deviceId,
+    startedAt: now - seconds * 1000,
+    endedAt: now,
+    durationMin,
+    distanceCm,
+    bodyArea,
+    // bodyAreas[] is the precise-region field; bodyArea remains as a
+    // denormalized broad-zone hint for legacy readers + listing rows.
+    bodyAreas: Array.isArray(bodyAreas) ? bodyAreas.slice() : null,
+    eyesProtected,
+    mode: resolvedMode,
+    doses,
+    notes,
+  };
+  getDeviceSessions().push(session);
+  // Remember user params for the next log dialog. Notes intentionally stay
+  // per-session and are not carried forward.
+  device.lastSession = { durationMin, distanceCm, bodyArea, bodyAreas: session.bodyAreas, eyesProtected, mode: resolvedMode };
+  device.updatedAt = now;
+  await saveImportedData();
+  runDeviceSessionAnalysis(session);
+  return session;
+}
+
+export function getActiveDeviceSession() {
+  return getDeviceSessions().find(s => !s.endedAt) || null;
+}
+
+export async function startDeviceSession({ deviceId, distanceCm = 15, bodyAreas = null, bodyArea = 'torso', eyesProtected = true, mode = null } = {}) {
+  // Reject a second active timer - one session at a time keeps the
+  // active-card UI unambiguous and matches sun-session semantics.
+  if (getActiveDeviceSession()) return null;
+  const device = getDevices().find(d => d.id === deviceId);
+  if (!device) return null;
+  const now = Date.now();
+  const resolvedMode = resolveDeviceMode(device, mode);
+  const id = makeId('devsess', now);
+  const sess = {
+    id,
+    deviceId,
+    startedAt: now,
+    endedAt: null,
+    durationMin: 0,
+    distanceCm,
+    bodyArea,
+    bodyAreas: Array.isArray(bodyAreas) ? bodyAreas.slice() : null,
+    eyesProtected,
+    mode: resolvedMode,
+    doses: {},
+    notes: '',
+  };
+  getDeviceSessions().push(sess);
+  await saveImportedData();
+  return id;
+}
+
+export async function stopDeviceSession(id) {
+  const sessions = getDeviceSessions();
+  const sess = id ? sessions.find(s => s.id === id) : getActiveDeviceSession();
+  if (!sess || sess.endedAt) return null;
+  const endedAt = Date.now();
+  const durationMin = Math.max(0, (endedAt - sess.startedAt) / 60000);
+  const device = getDevices().find(d => d.id === sess.deviceId);
+  if (device && durationMin > 0) {
+    const { doses } = computeDeviceSessionDoses({
+      device,
+      durationMin,
+      distanceCm: sess.distanceCm,
+      bodyArea: sess.bodyArea,
+      bodyAreas: sess.bodyAreas,
+      eyesProtected: sess.eyesProtected,
+      mode: sess.mode,
+    });
+    sess.doses = doses;
+  }
+  sess.endedAt = endedAt;
+  sess.durationMin = durationMin;
+  if (device) {
+    device.lastSession = {
+      durationMin,
+      distanceCm: sess.distanceCm,
+      bodyArea: sess.bodyArea,
+      bodyAreas: sess.bodyAreas,
+      eyesProtected: sess.eyesProtected,
+      mode: sess.mode,
+    };
+    device.updatedAt = Date.now();
+  }
+  await saveImportedData();
+  runDeviceSessionAnalysis(sess);
+  return sess;
+}
+
+export async function updateDeviceSession(id, patch = {}) {
+  const sessions = getDeviceSessions();
+  const sess = sessions.find(s => s.id === id);
+  if (!sess) return null;
+  const editable = ['durationMin', 'distanceCm', 'bodyArea', 'bodyAreas', 'eyesProtected', 'notes', 'mode'];
+  let needsRecompute = false;
+  for (const k of editable) {
+    if (k in patch && patch[k] !== sess[k]) {
+      // Array deep-compare for bodyAreas - patch comes in as a fresh array;
+      // detect content change, not just identity.
+      if (k === 'bodyAreas') {
+        const before = JSON.stringify((sess.bodyAreas || []).slice().sort());
+        const after = JSON.stringify((patch.bodyAreas || []).slice().sort());
+        if (before === after) continue;
+      }
+      // mode patches go through coupling validation; bad input falls back to
+      // the device default instead of persisting.
+      if (k === 'mode') {
+        const device = getDevices().find(d => d.id === sess.deviceId);
+        if (device && Array.isArray(device.modes) && device.modes.length > 0) {
+          const next = resolveDeviceMode(device, patch.mode);
+          if (next === sess.mode) continue;
+          sess.mode = next;
+          needsRecompute = true;
+          continue;
+        }
+      }
+      sess[k] = patch[k];
+      if (['durationMin', 'distanceCm', 'bodyArea', 'bodyAreas', 'eyesProtected'].includes(k)) needsRecompute = true;
+    }
+  }
+  // Re-derive endedAt + dose if duration changed so stored duration and
+  // channel doses cannot drift.
+  if (needsRecompute && sess.endedAt && Number.isFinite(sess.durationMin)) {
+    sess.endedAt = sess.startedAt + sess.durationMin * 60 * 1000;
+    const device = getDevices().find(d => d.id === sess.deviceId);
+    if (device) {
+      const { doses, mode: resolvedMode } = computeDeviceSessionDoses({
+        device,
+        durationMin: sess.durationMin,
+        distanceCm: sess.distanceCm,
+        bodyArea: sess.bodyArea,
+        bodyAreas: sess.bodyAreas,
+        eyesProtected: sess.eyesProtected,
+        mode: sess.mode,
+      });
+      sess.mode = resolvedMode;
+      sess.doses = doses;
+    }
+  }
+  sess.updatedAt = Date.now();
+  await saveImportedData();
+  runDeviceSessionAnalysis(sess);
+  return sess;
+}
+
+export async function deleteDeviceSession(id) {
+  const sessions = getDeviceSessions();
+  const idx = sessions.findIndex(s => s.id === id);
+  if (idx < 0) return false;
+  deleteImportedArrayItem(state.importedData, 'deviceSessions', idx);
+  await saveImportedData();
+  return true;
+}
+
+export function rollingDeviceTotals(days = 7) {
+  const cutoff = Date.now() - days * 86400 * 1000;
+  const totals = {};
+  for (const sess of getDeviceSessions()) {
+    if (!sess.doses || (sess.endedAt && sess.endedAt < cutoff)) continue;
+    for (const [k, v] of Object.entries(sess.doses)) {
+      totals[k] = (totals[k] || 0) + (Number.isFinite(v) ? v : 0);
+    }
+  }
+  return totals;
+}
+
+export async function addCustomDevice(spec) {
+  if (!spec || !spec.brand || !spec.model) return null;
+  const now = Date.now();
+  const channelGroups = Array.isArray(spec.channelGroups)
+    ? spec.channelGroups.filter(g => g && typeof g.id === 'string' && Array.isArray(g.peaks) && g.peaks.length > 0)
+    : null;
+  const validGroupIds = channelGroups ? new Set(channelGroups.map(g => g.id)) : null;
+  const modes = Array.isArray(spec.modes) && validGroupIds && validGroupIds.size > 0
+    ? spec.modes
+        .filter(m => m && typeof m.id === 'string' && Array.isArray(m.groups) && m.groups.length > 0)
+        .map(m => ({ ...m, groups: m.groups.filter(gid => validGroupIds.has(gid)) }))
+        .filter(m => m.groups.length > 0)
+    : null;
+  const coupling = Array.isArray(spec.coupling) && validGroupIds && validGroupIds.size > 0
+    ? spec.coupling.filter(r =>
+        r && typeof r.if === 'string' && validGroupIds.has(r.if)
+        && Array.isArray(r.requires) && r.requires.every(req => validGroupIds.has(req))
+      )
+    : null;
+  const device = {
+    id: makeId('dev', now),
+    presetId: null,
+    brand: spec.brand,
+    model: spec.model,
+    type: spec.type || 'combined',
+    peakWavelengths: Array.isArray(spec.peakWavelengths) ? spec.peakWavelengths : [],
+    mwPerCm2At15cm: Number.isFinite(spec.mwPerCm2At15cm) ? spec.mwPerCm2At15cm : null,
+    lux: Number.isFinite(spec.lux) ? spec.lux : null,
+    recommendedDistanceCm: Number.isFinite(spec.recommendedDistanceCm) && spec.recommendedDistanceCm > 0 ? spec.recommendedDistanceCm : 15,
+    channels: DEVICE_TYPE_CHANNELS[spec.type] || ['pbm_red', 'pbm_nir'],
+    channelGroups: channelGroups && channelGroups.length > 0 ? channelGroups : null,
+    modes: modes && modes.length > 0 ? modes : null,
+    coupling: coupling && coupling.length > 0 ? coupling : null,
+    catalogSlug: null,
+    notes: spec.notes || '',
+    addedAt: now,
+  };
+  getDevices().push(device);
+  await saveImportedData();
+  return device;
+}

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -19,15 +19,23 @@
 
 import { state } from './state.js';
 import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showConfirmDialog } from './utils.js';
-import { saveImportedData } from './data.js';
-import { deleteImportedArrayItem } from './data-merge.js';
 import { CHANNEL_DISPLAY } from './sun.js';
 import { BODY_REGIONS } from './sun-body-silhouette.js';
 import {
-  DEVICE_TYPE_CHANNELS,
-  computeDeviceSessionDoses,
-  resolveDeviceMode,
-} from './light-device-session-engine.js';
+  addCustomDevice,
+  addDeviceFromPresetRecord,
+  deleteDevice,
+  deleteDeviceSession,
+  getActiveDeviceSession,
+  getDeviceSessions,
+  getDevices,
+  hydrateDevicesFromPresetRecords,
+  logDeviceSession,
+  rollingDeviceTotals,
+  startDeviceSession,
+  stopDeviceSession,
+  updateDeviceSession,
+} from './light-devices-store.js';
 import { openDeviceSessionDialog as openDeviceSessionDialogModal } from './light-device-session-modal.js';
 import {
   configureLightDeviceSetup,
@@ -36,6 +44,19 @@ import {
 } from './light-device-setup-modal.js';
 
 export { openAddDeviceDialog, openCustomDeviceDialog };
+export {
+  addCustomDevice,
+  deleteDevice,
+  deleteDeviceSession,
+  getActiveDeviceSession,
+  getDeviceSessions,
+  getDevices,
+  logDeviceSession,
+  rollingDeviceTotals,
+  startDeviceSession,
+  stopDeviceSession,
+  updateDeviceSession,
+};
 
 // Preset library is loaded lazily — keeps the JSON out of the boot path.
 let _PRESETS = null;
@@ -69,47 +90,10 @@ async function loadPresets() {
 
 // ─── Public API ────────────────────────────────────────────────────────
 
-export function getDevices() {
-  if (!state.importedData) return [];
-  if (!Array.isArray(state.importedData.lightDevices)) state.importedData.lightDevices = [];
-  return state.importedData.lightDevices;
-}
-
-export function getDeviceSessions() {
-  if (!state.importedData) return [];
-  if (!Array.isArray(state.importedData.deviceSessions)) state.importedData.deviceSessions = [];
-  return state.importedData.deviceSessions;
-}
-
 export async function addDeviceFromPreset(presetId, overrides = {}) {
   const { presets } = await loadPresets();
   const preset = presets.find(p => p.id === presetId);
-  if (!preset) return null;
-  const id = `dev_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
-  const device = {
-    id,
-    presetId: preset.id,
-    brand: overrides.brand || preset.brand,
-    model: overrides.model || preset.model,
-    type: overrides.type || preset.type,
-    peakWavelengths: overrides.peakWavelengths || preset.peakWavelengths || [],
-    mwPerCm2At15cm: overrides.mwPerCm2At15cm ?? preset.mwPerCm2At15cm ?? null,
-    lux: overrides.lux ?? preset.lux ?? null,
-    recommendedDistanceCm: overrides.recommendedDistanceCm ?? preset.recommendedDistanceCm ?? 15,
-    channels: overrides.channels || preset.channels || [],
-    // Round 7: copy the LED-group schema through so the session-log
-    // dialog can render the mode picker. Devices added pre-Round-7 are
-    // healed by hydrateDevicesFromPresets at boot.
-    channelGroups: Array.isArray(preset.channelGroups) ? preset.channelGroups : null,
-    modes: Array.isArray(preset.modes) ? preset.modes : null,
-    coupling: Array.isArray(preset.coupling) ? preset.coupling : null,
-    catalogSlug: preset.catalogSlug || null,
-    notes: overrides.notes || '',
-    addedAt: Date.now(),
-  };
-  getDevices().push(device);
-  await saveImportedData();
-  return device;
+  return addDeviceFromPresetRecord(preset, overrides);
 }
 
 // Backfill channelGroups / modes / coupling from the preset library onto
@@ -119,109 +103,7 @@ export async function addDeviceFromPreset(presetId, overrides = {}) {
 // without requiring re-add.
 export async function hydrateDevicesFromPresets() {
   const { presets } = await loadPresets();
-  if (!Array.isArray(presets) || presets.length === 0) return false;
-  if (!state.importedData) return false;
-  const devices = Array.isArray(state.importedData.lightDevices) ? state.importedData.lightDevices : [];
-  let dirty = false;
-  for (const dev of devices) {
-    if (!dev || !dev.presetId) continue;
-    const preset = presets.find(p => p.id === dev.presetId);
-    if (!preset) continue;
-    if (!Array.isArray(dev.channelGroups) && Array.isArray(preset.channelGroups)) {
-      dev.channelGroups = preset.channelGroups;
-      dirty = true;
-    }
-    if (!Array.isArray(dev.modes) && Array.isArray(preset.modes)) {
-      dev.modes = preset.modes;
-      dirty = true;
-    }
-    if (!Array.isArray(dev.coupling) && Array.isArray(preset.coupling)) {
-      dev.coupling = preset.coupling;
-      dirty = true;
-    }
-  }
-  if (dirty) await saveImportedData();
-  return dirty;
-}
-
-export async function deleteDevice(id) {
-  const devs = getDevices();
-  const idx = devs.findIndex(d => d.id === id);
-  if (idx < 0) return false;
-  deleteImportedArrayItem(state.importedData, 'lightDevices', idx);
-  await saveImportedData();
-  return true;
-}
-
-// Log a completed device session (e.g. "10 min on the Joovv Mini at 15cm").
-//
-// Per-channel doses are computed by synthesizing a sparse spectrum from
-// the device's declared `peakWavelengths` + `mwPerCm2At15cm`, then routing
-// it through the SAME `computeChannelDoses` used by sun sessions. That
-// produces wavelength-correct doses (UVB → vitamin_d only, NIR → pbm_nir
-// only, etc.) without double-counting photons across multiple channels —
-// which the previous heuristic did, giving every declared channel the
-// full device irradiance.
-//
-// Falls back to a legacy lux-only path for SAD lamps that declare `lux`
-// instead of `mwPerCm2At15cm` (Verilux, Carex, Lumie, etc.) — those don't
-// have a meaningful peak-wavelengths spectrum and only feed the circadian
-// channel via lux-seconds.
-export async function logDeviceSession({ deviceId, durationMin, distanceCm = 15, bodyArea = 'torso', bodyAreas = null, eyesProtected = true, notes = '', mode = null }) {
-  const device = getDevices().find(d => d.id === deviceId);
-  if (!device) return null;
-  // Cryptographic randomness for session ids — Math.random() is enough
-  // for collision avoidance but CodeQL flags it as a security smell on
-  // any id-shaped string, and crypto.getRandomValues is available
-  // everywhere this code runs.
-  const _rb = new Uint8Array(3); crypto.getRandomValues(_rb);
-  const _suffix = Array.from(_rb, b => b.toString(16).padStart(2, '0')).join('').slice(0, 4);
-  const sessionId = `devsess_${Date.now().toString(36)}_${_suffix}`;
-  const seconds = durationMin * 60;
-  const { doses, mode: resolvedMode } = computeDeviceSessionDoses({
-    device,
-    durationMin,
-    distanceCm,
-    bodyArea,
-    bodyAreas,
-    eyesProtected,
-    mode,
-  });
-
-  const session = {
-    id: sessionId,
-    deviceId,
-    startedAt: Date.now() - seconds * 1000,
-    endedAt: Date.now(),
-    durationMin,
-    distanceCm,
-    bodyArea,
-    // bodyAreas[] is the new precise-region field; bodyArea remains as
-    // a denormalized "broad zone" hint for legacy readers + listing rows.
-    bodyAreas: Array.isArray(bodyAreas) ? bodyAreas.slice() : null,
-    eyesProtected,
-    // mode is the named touchscreen-preset id for devices with `modes`
-    // (Maxi UVB, Trinity, etc.); null for single-mode devices. Persisted
-    // so dose recomputation on edit reuses the same mode. Legacy
-    // sessions logged before Round 7 read back as null and route through
-    // the device's default mode in effectiveDeviceForMode.
-    mode: resolvedMode,
-    doses,
-    notes,
-  };
-  getDeviceSessions().push(session);
-  // Remember the user's chosen params on the device record so the
-  // next session log dialog opens with their actual ritual prefilled
-  // (most users do the same duration / distance / body area each
-  // session — re-typing every time is friction). Notes intentionally
-  // excluded — they're session-specific, shouldn't leak forward.
-  device.lastSession = { durationMin, distanceCm, bodyArea, bodyAreas: session.bodyAreas, eyesProtected, mode: resolvedMode };
-  device.updatedAt = Date.now();
-  await saveImportedData();
-  if (window.maybeAnalyzeDeviceSessionAfterFinish) {
-    try { window.maybeAnalyzeDeviceSessionAfterFinish(session); } catch (_) {}
-  }
-  return session;
+  return hydrateDevicesFromPresetRecords(presets);
 }
 
 // ─── Live device-session timer ─────────────────────────────────────────
@@ -231,144 +113,6 @@ export async function logDeviceSession({ deviceId, durationMin, distanceCm = 15,
 // + /light surfaces show a live elapsed counter; stopDeviceSession()
 // finalizes it through logDeviceSession's dose math so the saved record
 // is identical in shape to an after-the-fact log.
-
-export function getActiveDeviceSession() {
-  return getDeviceSessions().find(s => !s.endedAt) || null;
-}
-
-export async function startDeviceSession({ deviceId, distanceCm = 15, bodyAreas = null, bodyArea = 'torso', eyesProtected = true, mode = null } = {}) {
-  // Reject a second active timer — one session at a time keeps the
-  // active-card UI unambiguous and matches sun-session semantics.
-  if (getActiveDeviceSession()) return null;
-  const device = getDevices().find(d => d.id === deviceId);
-  if (!device) return null;
-  const resolvedMode = resolveDeviceMode(device, mode);
-  const id = `devsess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
-  const sess = {
-    id,
-    deviceId,
-    startedAt: Date.now(),
-    endedAt: null,
-    durationMin: 0,
-    distanceCm,
-    bodyArea,
-    bodyAreas: Array.isArray(bodyAreas) ? bodyAreas.slice() : null,
-    eyesProtected,
-    mode: resolvedMode,
-    doses: {},
-    notes: '',
-  };
-  getDeviceSessions().push(sess);
-  await saveImportedData();
-  return id;
-}
-
-// Stop the active device session. Computes doses through the same
-// `logDeviceSession` math by replaying the recorded params, then
-// finalizes endedAt + durationMin on the existing record.
-export async function stopDeviceSession(id) {
-  const sessions = getDeviceSessions();
-  const sess = id ? sessions.find(s => s.id === id) : getActiveDeviceSession();
-  if (!sess || sess.endedAt) return null;
-  const endedAt = Date.now();
-  const durationMin = Math.max(0, (endedAt - sess.startedAt) / 60000);
-  // Recompute doses through the shared engine without inserting a new
-  // record — we mutate the existing active session in-place.
-  const device = getDevices().find(d => d.id === sess.deviceId);
-  if (device && durationMin > 0) {
-    const { doses } = computeDeviceSessionDoses({
-      device,
-      durationMin,
-      distanceCm: sess.distanceCm,
-      bodyArea: sess.bodyArea,
-      bodyAreas: sess.bodyAreas,
-      eyesProtected: sess.eyesProtected,
-      mode: sess.mode,
-    });
-    sess.doses = doses;
-  }
-  sess.endedAt = endedAt;
-  sess.durationMin = durationMin;
-  if (device) {
-    device.lastSession = {
-      durationMin, distanceCm: sess.distanceCm,
-      bodyArea: sess.bodyArea, bodyAreas: sess.bodyAreas,
-      eyesProtected: sess.eyesProtected,
-      mode: sess.mode,
-    };
-    device.updatedAt = Date.now();
-  }
-  await saveImportedData();
-  if (window.maybeAnalyzeDeviceSessionAfterFinish) {
-    try { window.maybeAnalyzeDeviceSessionAfterFinish(sess); } catch (_) {}
-  }
-  return sess;
-}
-
-// Patch a finished session in place — accepts any subset of editable
-// fields. Recomputes doses if duration / distance / regions / eyes
-// changed, since those all feed the dose math. Mirrors sun.js
-// updateSession but without the active-session branch (device sessions
-// don't have the sun-style mid-session controls — once stopped, they
-// stay stopped). Bumps updatedAt so sync sees the change.
-export async function updateDeviceSession(id, patch = {}) {
-  const sessions = getDeviceSessions();
-  const sess = sessions.find(s => s.id === id);
-  if (!sess) return null;
-  const editable = ['durationMin', 'distanceCm', 'bodyArea', 'bodyAreas', 'eyesProtected', 'notes', 'mode'];
-  let needsRecompute = false;
-  for (const k of editable) {
-    if (k in patch && patch[k] !== sess[k]) {
-      // Array deep-compare for bodyAreas — patch comes in as a fresh
-      // array; we want to detect content change, not just identity.
-      if (k === 'bodyAreas') {
-        const before = JSON.stringify((sess.bodyAreas || []).slice().sort());
-        const after = JSON.stringify((patch.bodyAreas || []).slice().sort());
-        if (before === after) continue;
-      }
-      // mode patches go through coupling validation; bad input falls
-      // back to the device's default mode rather than persisting.
-      if (k === 'mode') {
-        const device = getDevices().find(d => d.id === sess.deviceId);
-        if (device && Array.isArray(device.modes) && device.modes.length > 0) {
-          const next = resolveDeviceMode(device, patch.mode);
-          if (next === sess.mode) continue;
-          sess.mode = next;
-          needsRecompute = true;
-          continue;
-        }
-      }
-      sess[k] = patch[k];
-      if (['durationMin', 'distanceCm', 'bodyArea', 'bodyAreas', 'eyesProtected'].includes(k)) needsRecompute = true;
-    }
-  }
-  // Re-derive endedAt + dose if duration changed (otherwise the saved
-  // record keeps its original end-stamp + doses, which would drift from
-  // the new duration).
-  if (needsRecompute && sess.endedAt && Number.isFinite(sess.durationMin)) {
-    sess.endedAt = sess.startedAt + sess.durationMin * 60 * 1000;
-    const device = getDevices().find(d => d.id === sess.deviceId);
-    if (device) {
-      const { doses, mode: resolvedMode } = computeDeviceSessionDoses({
-        device,
-        durationMin: sess.durationMin,
-        distanceCm: sess.distanceCm,
-        bodyArea: sess.bodyArea,
-        bodyAreas: sess.bodyAreas,
-        eyesProtected: sess.eyesProtected,
-        mode: sess.mode,
-      });
-      sess.mode = resolvedMode;
-      sess.doses = doses;
-    }
-  }
-  sess.updatedAt = Date.now();
-  await saveImportedData();
-  if (window.maybeAnalyzeDeviceSessionAfterFinish) {
-    try { window.maybeAnalyzeDeviceSessionAfterFinish(sess); } catch (_) {}
-  }
-  return sess;
-}
 
 // User-facing edit-mode entry point. Mirrors editDeviceSessionDuration
 // but for the mode field — opens a small picker dialog filtered to
@@ -451,15 +195,6 @@ export async function editDeviceSessionDuration(id) {
   await updateDeviceSession(id, { durationMin: next });
   showNotification(`Session duration set to ${next} min. Doses recomputed.`, 'success');
   if (window.navigate && state.currentView === 'light') window.navigate('light');
-}
-
-export async function deleteDeviceSession(id) {
-  const sessions = getDeviceSessions();
-  const idx = sessions.findIndex(s => s.id === id);
-  if (idx < 0) return false;
-  deleteImportedArrayItem(state.importedData, 'deviceSessions', idx);
-  await saveImportedData();
-  return true;
 }
 
 // ─── UI: per-device-session detail modal ──────────────────────────────
@@ -622,20 +357,6 @@ export function openDeviceSessionDetail(id) {
     opener: openDeviceSessionDetail,
     exists: sessionId => getDeviceSessions().some(s => s.id === sessionId),
   });
-}
-
-// Rolling totals — same shape as sun.rollingChannelTotals so the AI context
-// and dashboard pills can sum across both sources transparently.
-export function rollingDeviceTotals(days = 7) {
-  const cutoff = Date.now() - days * 86400 * 1000;
-  const totals = {};
-  for (const sess of getDeviceSessions()) {
-    if (!sess.doses || (sess.endedAt && sess.endedAt < cutoff)) continue;
-    for (const [k, v] of Object.entries(sess.doses)) {
-      totals[k] = (totals[k] || 0) + (Number.isFinite(v) ? v : 0);
-    }
-  }
-  return totals;
 }
 
 // ─── Active device-session card + 1Hz ticker ─────────────────────────
@@ -853,59 +574,6 @@ function _relativeTimeShort(ts) {
   }
   const y = Math.floor(days / 365);
   return `${y} year${y !== 1 ? 's' : ''} ago`;
-}
-
-// Save a user-defined device (no preset lookup). Same shape as
-// addDeviceFromPreset's output minus presetId/catalogSlug — custom devices
-// don't get an affiliate link surface (no canonical product to link to).
-export async function addCustomDevice(spec) {
-  if (!spec || !spec.brand || !spec.model) return null;
-  const id = `dev_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
-  // Map type → channels for dose math. Mirrors the per-channel logic
-  // used by the curated presets so a custom device on, say, type=uvb
-  // still feeds vitamin_d + pomc + violet_eye + circadian by default
-  // (the spectrum convolution refines the actual doses by wavelength).
-  // channelGroups / modes / coupling — only persisted when AI extraction
-  // (or manual entry) supplied a structurally complete set. Anything
-  // shaped wrong is dropped to null so the consumer (effectiveDeviceForMode)
-  // sees a clean schema and falls back to the all-peaks-fire identity path.
-  const channelGroups = Array.isArray(spec.channelGroups)
-    ? spec.channelGroups.filter(g => g && typeof g.id === 'string' && Array.isArray(g.peaks) && g.peaks.length > 0)
-    : null;
-  const validGroupIds = channelGroups ? new Set(channelGroups.map(g => g.id)) : null;
-  const modes = Array.isArray(spec.modes) && validGroupIds && validGroupIds.size > 0
-    ? spec.modes
-        .filter(m => m && typeof m.id === 'string' && Array.isArray(m.groups) && m.groups.length > 0)
-        .map(m => ({ ...m, groups: m.groups.filter(gid => validGroupIds.has(gid)) }))
-        .filter(m => m.groups.length > 0)
-    : null;
-  const coupling = Array.isArray(spec.coupling) && validGroupIds && validGroupIds.size > 0
-    ? spec.coupling.filter(r =>
-        r && typeof r.if === 'string' && validGroupIds.has(r.if)
-        && Array.isArray(r.requires) && r.requires.every(req => validGroupIds.has(req))
-      )
-    : null;
-  const device = {
-    id,
-    presetId: null,
-    brand: spec.brand,
-    model: spec.model,
-    type: spec.type || 'combined',
-    peakWavelengths: Array.isArray(spec.peakWavelengths) ? spec.peakWavelengths : [],
-    mwPerCm2At15cm: Number.isFinite(spec.mwPerCm2At15cm) ? spec.mwPerCm2At15cm : null,
-    lux: Number.isFinite(spec.lux) ? spec.lux : null,
-    recommendedDistanceCm: Number.isFinite(spec.recommendedDistanceCm) && spec.recommendedDistanceCm > 0 ? spec.recommendedDistanceCm : 15,
-    channels: DEVICE_TYPE_CHANNELS[spec.type] || ['pbm_red', 'pbm_nir'],
-    channelGroups: channelGroups && channelGroups.length > 0 ? channelGroups : null,
-    modes: modes && modes.length > 0 ? modes : null,
-    coupling: coupling && coupling.length > 0 ? coupling : null,
-    catalogSlug: null,
-    notes: spec.notes || '',
-    addedAt: Date.now(),
-  };
-  getDevices().push(device);
-  await saveImportedData();
-  return device;
 }
 
 configureLightDeviceSetup({

--- a/service-worker.js
+++ b/service-worker.js
@@ -314,6 +314,7 @@ const APP_SHELL = [
   '/js/light-channels-ai-analysis.js',
   '/js/light-device-ai-analysis.js',
   '/js/light-devices.js',
+  '/js/light-devices-store.js',
   '/js/light-device-session-engine.js',
   '/js/light-device-setup-modal.js',
   '/js/light-device-session-modal.js',

--- a/tests/test-light-devices-store.js
+++ b/tests/test-light-devices-store.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// test-light-devices-store.js - light-device mutation boundary coverage.
+
+import './_node-shim.js';
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => readFileSync(path.join(ROOT, rel), 'utf-8');
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Light Devices Store Tests ===\n');
+
+const { state } = await import('../js/state.js');
+const {
+  addCustomDevice,
+  addDeviceFromPresetRecord,
+  deleteDevice,
+  deleteDeviceSession,
+  getActiveDeviceSession,
+  getDeviceSessions,
+  getDevices,
+  hydrateDevicesFromPresetRecords,
+  logDeviceSession,
+  rollingDeviceTotals,
+  startDeviceSession,
+  stopDeviceSession,
+  updateDeviceSession,
+} = await import('../js/light-devices-store.js');
+
+state.currentProfile = 'light-devices-store-test';
+let analysisCalls = 0;
+const originalAnalyzer = window.maybeAnalyzeDeviceSessionAfterFinish;
+window.maybeAnalyzeDeviceSessionAfterFinish = () => { analysisCalls++; };
+
+function reset(seed = {}) {
+  analysisCalls = 0;
+  state.importedData = Object.assign({ entries: [], lightDevices: [], deviceSessions: [] }, seed);
+}
+
+console.log('%c 1. Device library mutations ', 'font-weight:bold;color:#f59e0b');
+reset();
+assert('getDevices lazily initializes lightDevices',
+  Array.isArray(getDevices()) && getDevices().length === 0);
+assert('getDeviceSessions lazily initializes deviceSessions',
+  Array.isArray(getDeviceSessions()) && getDeviceSessions().length === 0);
+
+const preset = {
+  id: 'preset-test',
+  brand: 'PresetCo',
+  model: 'Panel',
+  type: 'sad',
+  peakWavelengths: [],
+  lux: 10000,
+  recommendedDistanceCm: 30,
+  channels: ['circadian'],
+  channelGroups: [{ id: 'white', peaks: [480] }],
+  modes: [{ id: 'all-on', groups: ['white'], default: true }],
+  coupling: [{ if: 'white', requires: [], reason: 'test' }],
+  catalogSlug: 'preset-panel',
+};
+const presetDevice = await addDeviceFromPresetRecord(preset, { notes: 'desk' }, { now: 1_000 });
+assert('addDeviceFromPresetRecord persists preset metadata',
+  presetDevice?.id?.startsWith('dev_')
+    && presetDevice.addedAt === 1_000
+    && presetDevice.notes === 'desk'
+    && presetDevice.catalogSlug === 'preset-panel'
+    && getDevices()[0] === presetDevice);
+assert('addDeviceFromPresetRecord copies mode schema',
+  Array.isArray(presetDevice.modes)
+    && Array.isArray(presetDevice.channelGroups)
+    && Array.isArray(presetDevice.coupling));
+
+presetDevice.channelGroups = undefined;
+presetDevice.modes = undefined;
+presetDevice.coupling = undefined;
+const hydrated = await hydrateDevicesFromPresetRecords([preset]);
+assert('hydrateDevicesFromPresetRecords backfills missing preset mode schema',
+  hydrated === true
+    && Array.isArray(presetDevice.modes)
+    && Array.isArray(presetDevice.channelGroups)
+    && Array.isArray(presetDevice.coupling));
+assert('hydrateDevicesFromPresetRecords is idempotent',
+  await hydrateDevicesFromPresetRecords([preset]) === false);
+
+const custom = await addCustomDevice({
+  brand: 'Bench',
+  model: 'Hybrid',
+  type: 'uvb',
+  peakWavelengths: [295, 660, 850],
+  mwPerCm2At15cm: 42,
+  recommendedDistanceCm: 30,
+  channelGroups: [{ id: 'uv', peaks: [295] }, { id: 'red', peaks: [660, 850] }],
+  modes: [{ id: 'all-on', groups: ['uv', 'red'] }, { id: 'bad', groups: ['missing'] }],
+  coupling: [{ if: 'uv', requires: ['red'], reason: 'test' }, { if: 'missing', requires: ['red'] }],
+});
+assert('addCustomDevice persists a sanitized custom device',
+  custom?.presetId === null
+    && custom.channels.includes('vitamin_d')
+    && custom.modes.length === 1
+    && custom.coupling.length === 1);
+
+console.log('%c 2. Session lifecycle ', 'font-weight:bold;color:#f59e0b');
+reset({ lightDevices: [{
+  id: 'sad-1',
+  brand: 'Bright',
+  model: 'Desk',
+  type: 'sad',
+  peakWavelengths: [],
+  mwPerCm2At15cm: null,
+  lux: 10000,
+  recommendedDistanceCm: 30,
+  channels: ['circadian'],
+}] });
+
+const logged = await logDeviceSession({
+  deviceId: 'sad-1',
+  durationMin: 10,
+  distanceCm: 30,
+  bodyArea: 'face',
+  eyesProtected: false,
+  notes: 'morning',
+});
+const loggedDevice = getDevices()[0];
+assert('logDeviceSession persists dose, lastSession, updatedAt, and analyzer hook',
+  logged?.id?.startsWith('devsess_')
+    && logged.doses.circadian === 10000 * 10 * 60 / 100
+    && logged.notes === 'morning'
+    && loggedDevice.lastSession.durationMin === 10
+    && Number.isFinite(loggedDevice.updatedAt)
+    && analysisCalls === 1);
+
+const startedId = await startDeviceSession({ deviceId: 'sad-1', distanceCm: 30, eyesProtected: false });
+const active = getActiveDeviceSession();
+assert('startDeviceSession creates one active session',
+  startedId && active?.id === startedId && active.endedAt === null);
+assert('startDeviceSession rejects a second active timer',
+  await startDeviceSession({ deviceId: 'sad-1' }) === null);
+active.startedAt = Date.now() - 5 * 60_000;
+const stopped = await stopDeviceSession(startedId);
+assert('stopDeviceSession finalizes active session and recomputes dose',
+  stopped?.endedAt
+    && stopped.durationMin >= 4.9
+    && stopped.doses.circadian > 0
+    && getDevices()[0].lastSession.durationMin >= 4.9
+    && analysisCalls === 2);
+
+const edited = await updateDeviceSession(logged.id, { durationMin: 20, notes: 'edited' });
+assert('updateDeviceSession recomputes duration-derived fields and stamps sync freshness',
+  edited?.durationMin === 20
+    && edited.notes === 'edited'
+    && edited.endedAt === edited.startedAt + 20 * 60 * 1000
+    && edited.doses.circadian === 10000 * 20 * 60 / 100
+    && Number.isFinite(edited.updatedAt)
+    && analysisCalls === 3);
+assert('updateDeviceSession returns null for missing session',
+  await updateDeviceSession('missing', { durationMin: 1 }) === null);
+
+const beforeDelete = getDeviceSessions().length;
+assert('deleteDeviceSession removes session and records tombstone',
+  await deleteDeviceSession(logged.id) === true
+    && getDeviceSessions().length === beforeDelete - 1
+    && state.importedData._deleted.deviceSessions.includes(logged.id));
+assert('deleteDevice removes device and records tombstone',
+  await deleteDevice('sad-1') === true
+    && !getDevices().some(d => d.id === 'sad-1')
+    && state.importedData._deleted.lightDevices.includes('sad-1'));
+assert('delete miss paths return false',
+  await deleteDevice('missing') === false
+    && await deleteDeviceSession('missing') === false);
+
+reset({ deviceSessions: [
+  { id: 'recent', endedAt: Date.now(), doses: { circadian: 100, pbm_red: 5 } },
+  { id: 'old', endedAt: Date.now() - 30 * 86400 * 1000, doses: { circadian: 999 } },
+] });
+const totals = rollingDeviceTotals(7);
+assert('rollingDeviceTotals sums only in-window finite doses',
+  totals.circadian === 100 && totals.pbm_red === 5);
+
+console.log('%c 3. Boundary ownership ', 'font-weight:bold;color:#f59e0b');
+const uiSrc = read('js/light-devices.js');
+const storeSrc = read('js/light-devices-store.js');
+assert('light-devices imports the store boundary',
+  uiSrc.includes("from './light-devices-store.js'"));
+assert('light-devices no longer persists device/session mutations directly',
+  !/saveImportedData\(/.test(uiSrc)
+    && !/deleteImportedArrayItem\(/.test(uiSrc)
+    && !/state\.importedData\.(?:lightDevices|deviceSessions)\s*(?:\[|=|\.)/.test(uiSrc));
+assert('light-devices-store owns synced persistence for devices and sessions',
+  /saveImportedData\(/.test(storeSrc)
+    && /deleteImportedArrayItem\(state\.importedData, 'lightDevices'/.test(storeSrc)
+    && /deleteImportedArrayItem\(state\.importedData, 'deviceSessions'/.test(storeSrc)
+    && /computeDeviceSessionDoses/.test(storeSrc));
+
+if (originalAnalyzer) window.maybeAnalyzeDeviceSessionAfterFinish = originalAnalyzer;
+else delete window.maybeAnalyzeDeviceSessionAfterFinish;
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.306';
+self.APP_VERSION = '1.8.307';


### PR DESCRIPTION
## Summary
- add a `light-devices-store.js` boundary for owned light devices and device sessions
- keep preset loading, dialogs, rendering, and notifications in `light-devices.js` while moving synced writes, dose recompute, freshness stamps, and tombstones into the store
- add targeted store coverage plus service-worker precache, docs, and version updates

## Tests
- `node --check js/light-devices.js`
- `node --check js/light-devices-store.js`
- `node --check tests/test-light-devices-store.js`
- `node --check js/light-device-setup-modal.js`
- `node --check js/light-device-session-engine.js`
- `node tests/test-light-devices-store.js`
- `node tests/test-light-devices.js`
- `node tests/test-light-device-ai-analysis.js`
- `node tests/test-sync-modal-refresh.js`
- `node tests/test-sync.js`
- `npm test`
- `./run-tests.sh`