### PR TITLE
Centralize modal sync refresh handling

### DIFF
--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -125,6 +125,7 @@ Shared pure utility functions.
 - `showConfirmDialog(message)` — returns `Promise<boolean>`, styled confirm dialog
 - `linearRegression(points)` — `{ slope, intercept, r2 }` from `[{ x, y }]` array
 - `hasCardContent(obj)` — generic empty-card gate: returns `true` if any field has content (strings non-empty, arrays non-empty, `note` trimmed). Used by `buildLabContext()` for 7 context card gates
+- `bindModalSyncRefresh(opts)` / `bindDetailModalSyncRefresh(kind, refresh)` / `bindDetachedModalSyncRefresh(opts)` — shared `labcharts-sync-applied` modal refresh bindings with dirty-form guards and scroll restoration
 
 **Window exports:** `showNotification`, `showConfirmDialog`, `setDebugMode`, `setPIIReviewEnabled`, `hasCardContent`
 

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -2,7 +2,7 @@
 
 import { state } from './state.js';
 import { calculateCost, formatCost } from './schema.js';
-import { escapeHTML, showNotification } from './utils.js';
+import { bindModalSyncRefresh, escapeHTML, showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
 import { callClaudeAPI, getActiveModelDisplay, getActiveModelId, getAIProvider, hasAIProvider, isAIPaused } from './api.js';
 import { renderThreadList, saveChatThreadIndex } from './chat-threads.js';
@@ -179,10 +179,7 @@ function _getLatestSavedSummary(threadId) {
   return _getSavedSummaries().find(s => s.threadId === threadId);
 }
 
-function refreshOpenSummaryModalOnSync() {
-  const overlay = document.getElementById('summary-modal-overlay');
-  if (!overlay?.classList?.contains('show') || overlay.dataset.syncRefreshKind !== 'chat-summary') return;
-  const id = overlay.dataset.syncRefreshSummaryId || '';
+function refreshOpenSummaryModalOnSync({ itemId: id = '' } = {}) {
   renderSavedSummaries();
   if (!id) return;
   const summary = _getSavedSummaries().find(s => s.id === id);
@@ -194,7 +191,14 @@ function refreshOpenSummaryModalOnSync() {
 }
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('labcharts-sync-applied', refreshOpenSummaryModalOnSync);
+  bindModalSyncRefresh({
+    overlayId: 'summary-modal-overlay',
+    modalSelector: '.modal',
+    kind: 'chat-summary',
+    scrollSelector: '#summary-modal-body',
+    getItemId: ({ overlay }) => overlay?.dataset?.syncRefreshSummaryId || '',
+    refresh: refreshOpenSummaryModalOnSync,
+  });
 }
 
 export async function deleteSavedSummary(id) {

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -13,7 +13,7 @@
 //   }
 
 import { state } from './state.js';
-import { escapeHTML, escapeAttr, hasDirtyFormFields, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
+import { bindModalSyncRefresh, escapeHTML, escapeAttr, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
 import { roomUsesEveningAfterSunset } from './light-env-evening.js';
 import {
   addRoom,
@@ -600,13 +600,7 @@ export function refreshLightEnvironmentAssessment() {
 }
 
 function refreshOpenLightEnvironmentAssessmentOnSync() {
-  const overlay = getLightEnvironmentAssessmentOverlay();
-  const modal = overlay?.querySelector('.light-env-assessment-modal');
-  if (!overlay || !modal) return;
-  if (hasDirtyFormFields(modal)) return;
-  const scrollTop = modal.scrollTop || 0;
   renderLightEnvironmentAssessmentModal();
-  if (scrollTop) setLightEnvironmentAssessmentScrollTop(scrollTop);
 }
 
 function setLightEnvironmentAssessmentScrollTop(scrollTop) {
@@ -887,7 +881,11 @@ configureLightEnvAudits({
 });
 
 if (typeof window !== 'undefined') {
-  window.addEventListener('labcharts-sync-applied', refreshOpenLightEnvironmentAssessmentOnSync);
+  bindModalSyncRefresh({
+    overlayId: LIGHT_ENV_ASSESSMENT_OVERLAY_ID,
+    modalSelector: '.light-env-assessment-modal',
+    refresh: refreshOpenLightEnvironmentAssessmentOnSync,
+  });
 
   Object.assign(window, {
     getLightEnvironment: getEnvironment,

--- a/js/light-sessions-view.js
+++ b/js/light-sessions-view.js
@@ -1,6 +1,6 @@
 // light-sessions-view.js — Unified Light & Sun session list and modal
 
-import { escapeHTML, escapeAttr, formatDate } from './utils.js';
+import { bindModalSyncRefresh, escapeHTML, escapeAttr, formatDate } from './utils.js';
 
 // Inline cap on the historical sessions list. 3 is enough for
 // at-a-glance context ("what did I do recently"); the full history
@@ -166,16 +166,21 @@ export function _openAllSessionsModal() {
   renderInto();
   // Re-render on sync pull / AI verdict completion so the modal stays
   // fresh when a paired device adds/edits/deletes sessions while it's open.
-  const onSync = () => {
+  const detachSyncRefresh = bindModalSyncRefresh({
+    overlay,
+    modalSelector: '.light-sessions-modal',
+    scrollSelector: '.light-sessions-modal-body',
+    refresh: renderInto,
+  });
+  const onVerdictRefresh = () => {
     if (!document.body.contains(overlay)) { _detach(); return; }
     renderInto();
   };
   _detach = () => {
-    window.removeEventListener('labcharts-ai-verdict-updated', onSync);
-    window.removeEventListener('labcharts-sync-applied', onSync);
+    detachSyncRefresh();
+    window.removeEventListener('labcharts-ai-verdict-updated', onVerdictRefresh);
   };
-  window.addEventListener('labcharts-ai-verdict-updated', onSync);
-  window.addEventListener('labcharts-sync-applied', onSync);
+  window.addEventListener('labcharts-ai-verdict-updated', onVerdictRefresh);
   const eventElement = (target) => {
     if (!target) return null;
     if (target.closest) return target;

--- a/js/utils.js
+++ b/js/utils.js
@@ -118,7 +118,7 @@ export function bindDetachedModalSyncRefresh({
 }
 
 export function bindModalSyncRefresh({
-  overlay,
+  overlay: directOverlay,
   overlayId,
   overlaySelector,
   modalId,
@@ -134,7 +134,7 @@ export function bindModalSyncRefresh({
     return () => {};
   }
   const findOverlay = () => {
-    if (overlay) return overlay;
+    if (directOverlay) return directOverlay;
     if (overlayId) return document.getElementById(overlayId);
     if (overlaySelector && typeof document.querySelector === 'function') return document.querySelector(overlaySelector);
     return null;
@@ -154,6 +154,14 @@ export function bindModalSyncRefresh({
     }
     return modal || overlay || null;
   };
+  const isDetachedDirectOverlay = (overlay) => {
+    if (!directOverlay || !overlay || typeof document.body?.contains !== 'function') return false;
+    try {
+      return !document.body.contains(overlay);
+    } catch (_) {
+      return false;
+    }
+  };
   const restoreScroll = (scrollTop) => {
     if (!Number.isFinite(scrollTop)) return;
     const overlay = findOverlay();
@@ -162,8 +170,15 @@ export function bindModalSyncRefresh({
     if (!el || typeof el.scrollTop !== 'number') return;
     el.scrollTop = Math.max(0, scrollTop);
   };
+  let detached = false;
+  const detach = () => {
+    if (detached) return;
+    detached = true;
+    window.removeEventListener('labcharts-sync-applied', onSync);
+  };
   const onSync = () => {
     const overlay = findOverlay();
+    if (isDetachedDirectOverlay(overlay)) { detach(); return; }
     const modal = findModal(overlay);
     if (!overlay?.classList?.contains('show') || !modal) return;
     if (kind && overlay?.dataset?.syncRefreshKind !== kind && modal?.dataset?.syncRefreshKind !== kind) return;
@@ -184,7 +199,7 @@ export function bindModalSyncRefresh({
     }
   };
   window.addEventListener('labcharts-sync-applied', onSync);
-  return () => window.removeEventListener('labcharts-sync-applied', onSync);
+  return detach;
 }
 
 export function bindDetailModalSyncRefresh(kind, refresh) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -117,19 +117,83 @@ export function bindDetachedModalSyncRefresh({
   window.addEventListener('labcharts-sync-applied', onSync);
 }
 
-export function bindDetailModalSyncRefresh(kind, refresh) {
-  if (typeof window === 'undefined' || typeof document === 'undefined' || !kind || typeof refresh !== 'function') {
+export function bindModalSyncRefresh({
+  overlay,
+  overlayId,
+  overlaySelector,
+  modalId,
+  modalSelector,
+  kind,
+  refresh,
+  getItemId,
+  scrollSelector,
+  getScrollElement,
+  preserveScroll = true,
+} = {}) {
+  if (typeof window === 'undefined' || typeof document === 'undefined' || typeof refresh !== 'function') {
     return () => {};
   }
+  const findOverlay = () => {
+    if (overlay) return overlay;
+    if (overlayId) return document.getElementById(overlayId);
+    if (overlaySelector && typeof document.querySelector === 'function') return document.querySelector(overlaySelector);
+    return null;
+  };
+  const findModal = (overlay) => {
+    if (modalId) return document.getElementById(modalId);
+    if (modalSelector && overlay?.querySelector) return overlay.querySelector(modalSelector);
+    return overlay || null;
+  };
+  const resolveScrollElement = ({ overlay, modal }) => {
+    if (!preserveScroll) return null;
+    if (typeof getScrollElement === 'function') return getScrollElement({ overlay, modal }) || null;
+    if (scrollSelector) {
+      return overlay?.querySelector?.(scrollSelector)
+        || modal?.querySelector?.(scrollSelector)
+        || null;
+    }
+    return modal || overlay || null;
+  };
+  const restoreScroll = (scrollTop) => {
+    if (!Number.isFinite(scrollTop)) return;
+    const overlay = findOverlay();
+    const modal = findModal(overlay);
+    const el = resolveScrollElement({ overlay, modal });
+    if (!el || typeof el.scrollTop !== 'number') return;
+    el.scrollTop = Math.max(0, scrollTop);
+  };
   const onSync = () => {
-    const overlay = document.getElementById('modal-overlay');
-    const modal = document.getElementById('detail-modal');
-    if (!overlay?.classList?.contains('show') || modal?.dataset?.syncRefreshKind !== kind) return;
+    const overlay = findOverlay();
+    const modal = findModal(overlay);
+    if (!overlay?.classList?.contains('show') || !modal) return;
+    if (kind && overlay?.dataset?.syncRefreshKind !== kind && modal?.dataset?.syncRefreshKind !== kind) return;
     if (hasDirtyFormFields(modal)) return;
-    refresh({ overlay, modal });
+    const scrollEl = resolveScrollElement({ overlay, modal });
+    const scrollTop = scrollEl && typeof scrollEl.scrollTop === 'number' ? scrollEl.scrollTop : NaN;
+    const itemId = typeof getItemId === 'function'
+      ? getItemId({ overlay, modal })
+      : (modal?.dataset?.syncRefreshItemId || overlay?.dataset?.syncRefreshItemId || '');
+    refresh({ overlay, modal, itemId, scrollTop });
+    if (Number.isFinite(scrollTop)) {
+      restoreScroll(scrollTop);
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => restoreScroll(scrollTop));
+      } else {
+        setTimeout(() => restoreScroll(scrollTop), 0);
+      }
+    }
   };
   window.addEventListener('labcharts-sync-applied', onSync);
   return () => window.removeEventListener('labcharts-sync-applied', onSync);
+}
+
+export function bindDetailModalSyncRefresh(kind, refresh) {
+  return bindModalSyncRefresh({
+    overlayId: 'modal-overlay',
+    modalId: 'detail-modal',
+    kind,
+    refresh,
+  });
 }
 
 export function getStatus(value, refMin, refMax) {

--- a/tests/test-sync-modal-refresh.js
+++ b/tests/test-sync-modal-refresh.js
@@ -21,6 +21,7 @@ function assert(name, condition, detail) {
 console.log('=== Sync Modal Refresh Tests ===\n');
 
 const originalGetElementById = document.getElementById;
+const originalBodyContains = document.body?.contains;
 
 function makeOverlay({ open = true, dataset = {}, querySelector = () => null } = {}) {
   return {
@@ -100,6 +101,7 @@ try {
     querySelector: selector => selector === '.direct-modal' ? directModal : selector === '.direct-body' ? directBody : null,
   });
   let directCalls = 0;
+  document.body.contains = node => node === directOverlay;
   const detachDirectOverlay = bindModalSyncRefresh({
     overlay: directOverlay,
     modalSelector: '.direct-modal',
@@ -118,8 +120,31 @@ try {
     directCalls === 1 && directBody.scrollTop === 12,
     JSON.stringify({ directCalls, scrollTop: directBody.scrollTop }));
   detachDirectOverlay();
+
+  const ghostModal = {
+    querySelectorAll: () => [],
+    querySelector: () => null,
+  };
+  const ghostOverlay = makeOverlay({
+    querySelector: selector => selector === '.ghost-modal' ? ghostModal : null,
+  });
+  document.body.contains = node => node !== ghostOverlay;
+  let ghostCalls = 0;
+  const detachGhostOverlay = bindModalSyncRefresh({
+    overlay: ghostOverlay,
+    modalSelector: '.ghost-modal',
+    refresh: () => { ghostCalls++; },
+  });
+  emitSyncApplied();
+  emitSyncApplied();
+  assert('generic modal sync helper detaches removed direct overlay instances',
+    ghostCalls === 0,
+    JSON.stringify({ ghostCalls }));
+  detachGhostOverlay();
 } finally {
   document.getElementById = originalGetElementById;
+  if (originalBodyContains === undefined) delete document.body.contains;
+  else document.body.contains = originalBodyContains;
 }
 
 try {

--- a/tests/test-sync-modal-refresh.js
+++ b/tests/test-sync-modal-refresh.js
@@ -5,7 +5,7 @@
 
 import './_node-shim.js';
 
-const { bindDetailModalSyncRefresh } = await import('../js/utils.js');
+const { bindDetailModalSyncRefresh, bindModalSyncRefresh } = await import('../js/utils.js');
 const { state } = await import('../js/state.js');
 const { configureSyncDelta } = await import('../js/sync-delta.js');
 const { mergePulledImportedData } = await import('../js/sync-pull-merge.js');
@@ -22,9 +22,11 @@ console.log('=== Sync Modal Refresh Tests ===\n');
 
 const originalGetElementById = document.getElementById;
 
-function makeOverlay({ open = true } = {}) {
+function makeOverlay({ open = true, dataset = {}, querySelector = () => null } = {}) {
   return {
+    dataset,
     classList: { contains: cls => cls === 'show' && open },
+    querySelector,
   };
 }
 
@@ -41,6 +43,83 @@ function makeModal({ kind = 'note', dirty = false, itemId = null } = {}) {
 
 function emitSyncApplied() {
   window.dispatchEvent({ type: 'labcharts-sync-applied' });
+}
+
+try {
+  let body = { scrollTop: 37 };
+  let modal = {
+    querySelectorAll: () => [],
+    querySelector: selector => selector === '#summary-modal-body' ? body : null,
+  };
+  let overlay = makeOverlay({
+    dataset: { syncRefreshKind: 'chat-summary', syncRefreshSummaryId: 'summary-1' },
+    querySelector: selector => selector === '.modal' ? modal : selector === '#summary-modal-body' ? body : null,
+  });
+  document.getElementById = id => id === 'summary-modal-overlay' ? overlay : null;
+  let overlayRefreshCalls = 0;
+  let overlayRefreshItemId = '';
+  const detachOverlayRefresh = bindModalSyncRefresh({
+    overlayId: 'summary-modal-overlay',
+    modalSelector: '.modal',
+    kind: 'chat-summary',
+    scrollSelector: '#summary-modal-body',
+    getItemId: ({ overlay: activeOverlay }) => activeOverlay.dataset.syncRefreshSummaryId,
+    refresh: ({ itemId }) => {
+      overlayRefreshCalls++;
+      overlayRefreshItemId = itemId;
+      body = { scrollTop: 0 };
+      modal = {
+        querySelectorAll: () => [],
+        querySelector: selector => selector === '#summary-modal-body' ? body : null,
+      };
+    },
+  });
+
+  emitSyncApplied();
+  assert('generic modal sync helper refreshes matching open clean modal and restores scroll',
+    overlayRefreshCalls === 1 && overlayRefreshItemId === 'summary-1' && body.scrollTop === 37,
+    JSON.stringify({ overlayRefreshCalls, overlayRefreshItemId, scrollTop: body.scrollTop }));
+
+  body.scrollTop = 50;
+  modal = {
+    querySelectorAll: () => [{ disabled: false, tagName: 'INPUT', type: 'text', value: 'draft', defaultValue: '' }],
+    querySelector: selector => selector === '#summary-modal-body' ? body : null,
+  };
+  emitSyncApplied();
+  assert('generic modal sync helper skips dirty modal forms',
+    overlayRefreshCalls === 1 && body.scrollTop === 50,
+    JSON.stringify({ overlayRefreshCalls, scrollTop: body.scrollTop }));
+  detachOverlayRefresh();
+
+  let directBody = { scrollTop: 12 };
+  let directModal = {
+    querySelectorAll: () => [],
+    querySelector: selector => selector === '.direct-body' ? directBody : null,
+  };
+  const directOverlay = makeOverlay({
+    querySelector: selector => selector === '.direct-modal' ? directModal : selector === '.direct-body' ? directBody : null,
+  });
+  let directCalls = 0;
+  const detachDirectOverlay = bindModalSyncRefresh({
+    overlay: directOverlay,
+    modalSelector: '.direct-modal',
+    scrollSelector: '.direct-body',
+    refresh: () => {
+      directCalls++;
+      directBody = { scrollTop: 0 };
+      directModal = {
+        querySelectorAll: () => [],
+        querySelector: selector => selector === '.direct-body' ? directBody : null,
+      };
+    },
+  });
+  emitSyncApplied();
+  assert('generic modal sync helper supports detached overlay instances',
+    directCalls === 1 && directBody.scrollTop === 12,
+    JSON.stringify({ directCalls, scrollTop: directBody.scrollTop }));
+  detachDirectOverlay();
+} finally {
+  document.getElementById = originalGetElementById;
 }
 
 try {

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -128,6 +128,7 @@ await import('../js/settings.js');
   const utilsSrc = await fetchWithRetry('js/utils.js');
   const sunSessionUISrc = await fetchWithRetry('js/sun-session-ui.js');
   const lightDevicesSrc = await fetchWithRetry('js/light-devices.js');
+  const lightSessionsSrc = await fetchWithRetry('js/light-sessions-view.js');
   const lightEnvSrc = await fetchWithRetry('js/light-env.js');
   const supplementsSrc = await fetchWithRetry('js/supplements.js');
   const notesSrc = await fetchWithRetry('js/notes.js');
@@ -627,9 +628,11 @@ await import('../js/settings.js');
   assert('modal refresh dirty-form guard is shared',
     utilsSrc.includes('export function hasDirtyFormFields')
       && utilsSrc.includes("querySelectorAll('input, textarea, select')")
+      && utilsSrc.includes('export function bindModalSyncRefresh')
       && utilsSrc.includes('export function bindDetachedModalSyncRefresh')
       && utilsSrc.includes('export function bindDetailModalSyncRefresh')
       && utilsSrc.includes("window.addEventListener('labcharts-sync-applied', onSync)")
+      && utilsSrc.includes('restoreScroll(scrollTop)')
       && utilsSrc.includes('hasDirtyFormFields(overlay)')
       && utilsSrc.includes('hasDirtyFormFields(modal)'));
   assert('marker detail modal refreshes through shared sync-applied detail helper',
@@ -643,11 +646,17 @@ await import('../js/settings.js');
       && sunSessionUISrc.includes('opener: openSunSessionDetail')
       && lightDevicesSrc.includes('bindDetachedModalSyncRefresh({')
       && lightDevicesSrc.includes('opener: openDeviceSessionDetail'));
+  assert('all-sessions modal refreshes through shared sync-applied modal helper',
+    lightSessionsSrc.includes('bindModalSyncRefresh({')
+      && lightSessionsSrc.includes("modalSelector: '.light-sessions-modal'")
+      && lightSessionsSrc.includes("scrollSelector: '.light-sessions-modal-body'")
+      && !lightSessionsSrc.includes("window.addEventListener('labcharts-sync-applied'"));
   assert('Light Environment assessment modal refreshes clean open content on sync-applied',
     lightEnvSrc.includes('refreshOpenLightEnvironmentAssessmentOnSync')
-      && lightEnvSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenLightEnvironmentAssessmentOnSync)")
-      && lightEnvSrc.includes('hasDirtyFormFields(modal)')
-      && lightEnvSrc.includes('setLightEnvironmentAssessmentScrollTop(scrollTop)'));
+      && lightEnvSrc.includes('bindModalSyncRefresh({')
+      && lightEnvSrc.includes('overlayId: LIGHT_ENV_ASSESSMENT_OVERLAY_ID')
+      && lightEnvSrc.includes("modalSelector: '.light-env-assessment-modal'")
+      && !lightEnvSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenLightEnvironmentAssessmentOnSync)"));
   assert('shared data modals refresh clean editors on sync-applied',
     supplementsSrc.includes('refreshOpenSupplementsEditorOnSync')
       && supplementsSrc.includes("bindDetailModalSyncRefresh('supplements', refreshOpenSupplementsEditorOnSync)")
@@ -682,9 +691,25 @@ await import('../js/settings.js');
   }
   assert('saved chat summary modal refreshes on sync-applied',
     chatSummariesSrc.includes('refreshOpenSummaryModalOnSync')
-      && chatSummariesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenSummaryModalOnSync)")
+      && chatSummariesSrc.includes('bindModalSyncRefresh({')
+      && chatSummariesSrc.includes("overlayId: 'summary-modal-overlay'")
+      && chatSummariesSrc.includes("kind: 'chat-summary'")
+      && chatSummariesSrc.includes("scrollSelector: '#summary-modal-body'")
       && chatSummariesSrc.includes("overlay.dataset.syncRefreshKind = 'chat-summary'")
-      && chatSummariesSrc.includes('viewSavedSummary(id)'));
+      && chatSummariesSrc.includes('viewSavedSummary(id)')
+      && !chatSummariesSrc.includes("window.addEventListener('labcharts-sync-applied', refreshOpenSummaryModalOnSync)"));
+  {
+    const violations = [];
+    for (const abs of listJsFiles(path.join(ROOT, 'js'))) {
+      const rel = path.relative(ROOT, abs).replace(/\\/g, '/');
+      if (rel === 'js/utils.js') continue;
+      const src = fs.readFileSync(abs, 'utf-8');
+      if (src.includes("window.addEventListener('labcharts-sync-applied'")) violations.push(rel);
+    }
+    assert('sync-applied modal listeners are centralized in utils helpers',
+      violations.length === 0,
+      violations.join(', '));
+  }
   assert('closeModal clears sync refresh modal metadata',
     markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshKind')
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshDate')

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -633,6 +633,8 @@ await import('../js/settings.js');
       && utilsSrc.includes('export function bindDetailModalSyncRefresh')
       && utilsSrc.includes("window.addEventListener('labcharts-sync-applied', onSync)")
       && utilsSrc.includes('restoreScroll(scrollTop)')
+      && utilsSrc.includes('isDetachedDirectOverlay(overlay)')
+      && utilsSrc.includes('document.body.contains(overlay)')
       && utilsSrc.includes('hasDirtyFormFields(overlay)')
       && utilsSrc.includes('hasDirtyFormFields(modal)'));
   assert('marker detail modal refreshes through shared sync-applied detail helper',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.310';
+self.APP_VERSION = '1.8.311';


### PR DESCRIPTION
## Summary
- Add a shared `bindModalSyncRefresh` helper for open modal refreshes on `labcharts-sync-applied`, including dirty-form guards and scroll restoration.
- Move Light Environment assessment, saved chat summaries, and the All Sessions modal onto the shared helper.
- Add regression/source guards, document the helper, and bump `APP_VERSION` to `1.8.311`.

## Validation
- `node --check js/utils.js js/light-env.js js/chat-summaries.js js/light-sessions-view.js tests/test-sync-modal-refresh.js`
- `git diff --check`
- `node tests/test-sync-modal-refresh.js`
- `node tests/test-light-env.js`
- `node tests/test-sync.js`
- `./run-tests.sh`