### PR TITLE
Move modal lifecycle helpers out of sun

### DIFF
--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -133,6 +133,16 @@ Shared pure utility functions.
 
 ## Layer 2 — Core Services
 
+### `modal-lifecycle.js`
+
+Shared modal backdrop, focus-trap, and body-scroll lock helpers. Owns the cross-module scroll-lock registry used by Light & Sun modals; `sun.js` re-exports the legacy names for compatibility.
+
+**Key exports:**
+- `wireBackdropClose(overlay, closeFn?)` / `_wireBackdropClose(overlay, closeFn?)` — backdrop click close wiring with inside-click guard
+- `trapModalFocus(overlay)` — locks background scroll, restores focus/overflow on removal, and handles Escape close
+
+**Window exports:** none directly; `sun.js` still exposes compatibility globals.
+
 ### `theme.js`
 
 Theme management and Chart.js color helpers.
@@ -1535,7 +1545,7 @@ Not separately documented because their exports are best read from source — ke
 - `provider-panel-renderers.js` — Settings → AI per-provider panel markup (Venice / OpenRouter / Routstr / PPQ / Local AI / Custom).
 - `pdfjs-loader.js` — cached dynamic import of vendored pdf.js ESM. Pins `isEvalSupported: false` defense-in-depth on every `getDocument` call.
 - `sun-body-silhouette.js` — anatomical sun-session body-region picker, stock-figure region-map hit testing, and async selection overlay. Re-exported by `sun.js` for compatibility.
-- `sun-active-session.js` — quick-log/start modal, live active-session ticker, Simpson live-dose integration, modal focus/backdrop helpers, and active-session compatibility handlers. Dependency-injected from `sun.js` so persistence and hydration stay in the owner module.
+- `sun-active-session.js` — quick-log/start modal, live active-session ticker, Simpson live-dose integration, and active-session compatibility handlers. Dependency-injected from `sun.js` so persistence and hydration stay in the owner module.
 - `sun-session-ui.js` — saved sun-session row/detail rendering, detailed past-session modal, channel chips, delete, and edit-duration UI. Dependency-injected from `sun.js` so storage, hydration, and dose math stay in the owning module.
 - `light-device-setup-modal.js` — add-device preset picker, custom-device form, and URL/photo AI spec extraction. Dependency-injected from `light-devices.js` so device persistence and channel defaults stay in the owning module.
 - `light-device-session-modal.js` — log/start light therapy device session modal; dependency-injected from `light-devices.js` so session persistence and active timer state stay in the owning module.

--- a/js/light-conditions-now.js
+++ b/js/light-conditions-now.js
@@ -2,6 +2,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 
 export function renderLightConditionsWidgetBody({ variant = 'full', slotId = '' } = {}) {
   const conditionsOpts = { variant };
@@ -365,9 +366,9 @@ export function _inspectConditionsNow() {
       </div>
     </div>
   </div>`;
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay); } catch (e) {}
+  try { wireBackdropClose(overlay); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
   // Manually drive scroll + halt propagation on the Raw payload <pre>.
   // CSS-only `overflow:auto`/`overscroll-behavior:contain` couldn't beat
   // the modal's own scroll container — wheel deltas were being claimed

--- a/js/light-device-session-modal.js
+++ b/js/light-device-session-modal.js
@@ -2,13 +2,14 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import { BODY_REGIONS } from './sun.js';
 
 function _wireDeviceSessionModal(overlay) {
   if (typeof window === 'undefined') { document.body.appendChild(overlay); return; }
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay); } catch (_) {}
+  try { wireBackdropClose(overlay); } catch (_) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (_) {}
+  try { trapModalFocus(overlay); } catch (_) {}
 }
 
 function _defaultRegionsForLastSession(last) {

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -19,6 +19,7 @@
 
 import { state } from './state.js';
 import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showConfirmDialog } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import { CHANNEL_DISPLAY } from './sun.js';
 import { BODY_REGIONS } from './sun-body-silhouette.js';
 import {
@@ -63,15 +64,12 @@ let _PRESETS = null;
 let _PRESET_TYPES = null;
 
 // Standard modal-mount pattern shared by every modal opener in this file:
-// wire backdrop-click close, append, then trap focus. The window.* refs
-// come from sun.js so we can't import them at top-level (back-edge);
-// guarding each call with typeof keeps this safe to invoke if the user
-// hits a device modal before sun.js finished its first load tick.
+// wire backdrop-click close, append, then trap focus.
 function _wireModal(overlay) {
   if (typeof window === 'undefined') { document.body.appendChild(overlay); return; }
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay); } catch (_) {}
+  try { wireBackdropClose(overlay); } catch (_) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (_) {}
+  try { trapModalFocus(overlay); } catch (_) {}
 }
 
 async function loadPresets() {

--- a/js/light-sessions-view.js
+++ b/js/light-sessions-view.js
@@ -1,6 +1,7 @@
 // light-sessions-view.js — Unified Light & Sun session list and modal
 
 import { bindModalSyncRefresh, escapeHTML, escapeAttr, formatDate } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 
 // Inline cap on the historical sessions list. 3 is enough for
 // at-a-glance context ("what did I do recently"); the full history
@@ -214,7 +215,7 @@ export function _openAllSessionsModal() {
     });
     event.preventDefault();
   }, { passive: false });
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay); } catch (e) {}
+  try { wireBackdropClose(overlay); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 }

--- a/js/light-tool-camera-modals.js
+++ b/js/light-tool-camera-modals.js
@@ -1,6 +1,7 @@
 // light-tool-camera-modals.js — Camera-backed Light tool modal flows.
 
 import { escapeHTML, showNotification } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import {
   aimingGuideHTML,
   lockCameraForMeasurement,
@@ -88,9 +89,9 @@ export async function openLuxMeter(opts = {}, deps = {}) {
     _luxState.video = null;
     overlay.remove();
   };
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay, () => window._closeLuxMeter()); } catch (e) {}
+  try { wireBackdropClose(overlay, () => window._closeLuxMeter()); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   let currentLux = null;
   // Snapshot of the LATEST raw camera luma (before calibration multiply).
@@ -330,9 +331,9 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
     if (_flickerState.stream) { try { _flickerState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _flickerState.stream = null; }
     overlay.remove();
   };
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay, () => window._closeFlicker()); } catch (e) {}
+  try { wireBackdropClose(overlay, () => window._closeFlicker()); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   let lastResult = null;
   const resultEl = overlay.querySelector('#flicker-result');
@@ -481,9 +482,9 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
       </div>
     </div>
   </div>`;
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay, () => window._closeDark()); } catch (e) {}
+  try { wireBackdropClose(overlay, () => window._closeDark()); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   let result = null;
   const statusEl = overlay.querySelector('#dark-status');
@@ -652,9 +653,9 @@ export async function openCCTMeter(opts = {}, deps = {}) {
     if (_cctState.stream) { try { _cctState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _cctState.stream = null; }
     overlay.remove();
   };
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay, () => window._closeCCT()); } catch (e) {}
+  try { wireBackdropClose(overlay, () => window._closeCCT()); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   let currentCCT = null;
   let currentMelanopic = null;
@@ -807,9 +808,9 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
     if (_specState.stream) { try { _specState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _specState.stream = null; }
     overlay.remove();
   };
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay, () => window._closeSpec()); } catch (e) {}
+  try { wireBackdropClose(overlay, () => window._closeSpec()); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   let result = null;
   const resultEl = overlay.querySelector('#spec-result');
@@ -1000,9 +1001,9 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
     activeGlassStreams.clear();
     overlay.remove();
   };
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay, () => window._closeGlass()); } catch (e) {}
+  try { wireBackdropClose(overlay, () => window._closeGlass()); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   _glassReadings = { inside: null, outside: null };
 
@@ -1083,4 +1084,3 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
   }
 
 }
-

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -20,6 +20,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItem } from './data-merge.js';
 import {
@@ -341,9 +342,9 @@ export function openSunriseLogger() {
       </div>
     </div>
   </div>`;
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay); } catch (e) {}
+  try { wireBackdropClose(overlay); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   overlay.querySelector('#sunrise-save').addEventListener('click', async () => {
     const minutes = normalizeGoldenHourMinutes(overlay.querySelector('#sunrise-duration').value);
@@ -388,9 +389,9 @@ export async function openEyeLevelAudit() {
       </div>
     </div>
   </div>`;
-  if (window._wireBackdropClose) try { window._wireBackdropClose(overlay, () => window._closeAudit()); } catch (e) {}
+  try { wireBackdropClose(overlay, () => window._closeAudit()); } catch (e) {}
   document.body.appendChild(overlay);
-  if (window.trapModalFocus) try { window.trapModalFocus(overlay); } catch (e) {}
+  try { trapModalFocus(overlay); } catch (e) {}
 
   const statusEl = overlay.querySelector('#audit-status');
   const listEl = overlay.querySelector('#audit-room-list');

--- a/js/modal-lifecycle.js
+++ b/js/modal-lifecycle.js
@@ -1,0 +1,87 @@
+// modal-lifecycle.js — shared modal backdrop, focus trap, and scroll lock.
+
+export function wireBackdropClose(overlay, closeFn) {
+  const close = typeof closeFn === 'function' ? closeFn : () => overlay.remove();
+  let mouseDownInside = false;
+  overlay.addEventListener('mousedown', (e) => {
+    mouseDownInside = !!e.target.closest('.modal');
+  });
+  overlay.addEventListener('click', (e) => {
+    if (mouseDownInside) { mouseDownInside = false; return; }
+    if (e.target === overlay) close();
+  });
+}
+
+export const _wireBackdropClose = wireBackdropClose;
+
+const _modalScrollState = (() => {
+  const fallback = { locks: new Set(), priorOverflow: '' };
+  if (typeof window === 'undefined') return fallback;
+  if (window.__labModalScrollState && window.__labModalScrollState.locks instanceof Set) {
+    return window.__labModalScrollState;
+  }
+  try {
+    Object.defineProperty(window, '__labModalScrollState', {
+      value: fallback,
+      configurable: true,
+    });
+  } catch (_) {
+    window.__labModalScrollState = fallback;
+  }
+  return fallback;
+})();
+
+const _modalScrollLocks = _modalScrollState.locks;
+
+function _pruneDetachedModalScrollLocks() {
+  for (const lock of Array.from(_modalScrollLocks)) {
+    if (!document.body.contains(lock)) _modalScrollLocks.delete(lock);
+  }
+}
+
+export function trapModalFocus(overlay) {
+  _pruneDetachedModalScrollLocks();
+  const previouslyFocused = document.activeElement;
+  if (_modalScrollLocks.size === 0) {
+    _modalScrollState.priorOverflow = document.body.style.overflow;
+  }
+  _modalScrollLocks.add(overlay);
+  document.body.style.overflow = 'hidden';
+  let teardown = false;
+  setTimeout(() => {
+    const focusables = overlay.querySelectorAll(
+      'button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),a[href],[tabindex]:not([tabindex="-1"])'
+    );
+    if (focusables.length > 0) try { focusables[0].focus(); } catch (e) {}
+  }, 30);
+  const onKeydown = (e) => {
+    if (e.key === 'Escape' && document.body.contains(overlay)) {
+      e.preventDefault();
+      try { overlay.remove(); } catch (_) {}
+    }
+  };
+  document.addEventListener('keydown', onKeydown);
+  const restore = () => {
+    if (teardown) return;
+    teardown = true;
+    document.removeEventListener('keydown', onKeydown);
+    _modalScrollLocks.delete(overlay);
+    _pruneDetachedModalScrollLocks();
+    if (_modalScrollLocks.size === 0) {
+      document.body.style.overflow = _modalScrollState.priorOverflow;
+    } else {
+      document.body.style.overflow = 'hidden';
+    }
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function'
+        && document.contains(previouslyFocused)) {
+      try { previouslyFocused.focus(); } catch (e) {}
+    }
+  };
+  const obs = new MutationObserver(() => {
+    if (!document.body.contains(overlay)) {
+      obs.disconnect();
+      restore();
+    }
+  });
+  obs.observe(document.body, { childList: true, subtree: true });
+}

--- a/js/sun-active-session.js
+++ b/js/sun-active-session.js
@@ -1,10 +1,11 @@
 // sun-active-session.js — active sun-session UI, live dose ticker, and
-// modal helpers. Core persisted session storage and hydration live in
+// active-session modal. Core persisted session storage and hydration live in
 // sun-sessions-store.js; this module receives those operations through
 // configuration to avoid importing sun.js back into the active UI layer.
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette } from './sun-body-silhouette.js';
 import { POSTURE_MULTIPLIERS, SURFACE_ALBEDO } from './sun-session-model.js';
 import { renderChannelChips } from './sun-session-ui.js';
@@ -182,7 +183,7 @@ export async function openStartSunSessionDialog() {
       </div>
     </div>
   </div>`;
-  _wireBackdropClose(overlay);
+  wireBackdropClose(overlay);
   document.body.appendChild(overlay);
   trapModalFocus(overlay);
 
@@ -249,87 +250,6 @@ export async function openStartSunSessionDialog() {
     ensureActiveTicker();
     return id;
   });
-}
-
-export function _wireBackdropClose(overlay, closeFn) {
-  const close = typeof closeFn === 'function' ? closeFn : () => overlay.remove();
-  let mouseDownInside = false;
-  overlay.addEventListener('mousedown', (e) => {
-    mouseDownInside = !!e.target.closest('.modal');
-  });
-  overlay.addEventListener('click', (e) => {
-    if (mouseDownInside) { mouseDownInside = false; return; }
-    if (e.target === overlay) close();
-  });
-}
-
-const _modalScrollState = (() => {
-  const fallback = { locks: new Set(), priorOverflow: '' };
-  if (typeof window === 'undefined') return fallback;
-  if (window.__labModalScrollState && window.__labModalScrollState.locks instanceof Set) {
-    return window.__labModalScrollState;
-  }
-  try {
-    Object.defineProperty(window, '__labModalScrollState', {
-      value: fallback,
-      configurable: true,
-    });
-  } catch (_) {
-    window.__labModalScrollState = fallback;
-  }
-  return fallback;
-})();
-const _modalScrollLocks = _modalScrollState.locks;
-function _pruneDetachedModalScrollLocks() {
-  for (const lock of Array.from(_modalScrollLocks)) {
-    if (!document.body.contains(lock)) _modalScrollLocks.delete(lock);
-  }
-}
-export function trapModalFocus(overlay) {
-  _pruneDetachedModalScrollLocks();
-  const previouslyFocused = document.activeElement;
-  if (_modalScrollLocks.size === 0) {
-    _modalScrollState.priorOverflow = document.body.style.overflow;
-  }
-  _modalScrollLocks.add(overlay);
-  document.body.style.overflow = 'hidden';
-  let teardown = false;
-  setTimeout(() => {
-    const focusables = overlay.querySelectorAll(
-      'button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),a[href],[tabindex]:not([tabindex="-1"])'
-    );
-    if (focusables.length > 0) try { focusables[0].focus(); } catch (e) {}
-  }, 30);
-  const onKeydown = (e) => {
-    if (e.key === 'Escape' && document.body.contains(overlay)) {
-      e.preventDefault();
-      try { overlay.remove(); } catch (_) {}
-    }
-  };
-  document.addEventListener('keydown', onKeydown);
-  const restore = () => {
-    if (teardown) return;
-    teardown = true;
-    document.removeEventListener('keydown', onKeydown);
-    _modalScrollLocks.delete(overlay);
-    _pruneDetachedModalScrollLocks();
-    if (_modalScrollLocks.size === 0) {
-      document.body.style.overflow = _modalScrollState.priorOverflow;
-    } else {
-      document.body.style.overflow = 'hidden';
-    }
-    if (previouslyFocused && typeof previouslyFocused.focus === 'function'
-        && document.contains(previouslyFocused)) {
-      try { previouslyFocused.focus(); } catch (e) {}
-    }
-  };
-  const obs = new MutationObserver(() => {
-    if (!document.body.contains(overlay)) {
-      obs.disconnect();
-      restore();
-    }
-  });
-  obs.observe(document.body, { childList: true, subtree: true });
 }
 
 function _plainStopSummary(sess, dur) {

--- a/js/sun-defaults.js
+++ b/js/sun-defaults.js
@@ -9,6 +9,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { SKIN_TYPE } from './constants.js';
 
@@ -514,13 +515,7 @@ function openSunSetupOverlay() {
     ${renderSetupActions()}
   </div>`;
 
-  if (window._wireBackdropClose) {
-    try { window._wireBackdropClose(overlay, closeSunSetupOverlay); } catch (_) {}
-  } else {
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) closeSunSetupOverlay();
-    });
-  }
+  try { wireBackdropClose(overlay, closeSunSetupOverlay); } catch (_) {}
 
   document.body.appendChild(overlay);
 
@@ -532,9 +527,7 @@ function openSunSetupOverlay() {
   });
   obs.observe(document.body, { childList: true, subtree: true });
 
-  if (window.trapModalFocus) {
-    try { window.trapModalFocus(overlay); } catch (_) {}
-  }
+  try { trapModalFocus(overlay); } catch (_) {}
   setLightSetupStep('core', { focus: false });
   const focusBody = () => overlay.querySelector('.light-setup-focus-body')?.focus?.({ preventScroll: true });
   setTimeout(() => {

--- a/js/sun.js
+++ b/js/sun.js
@@ -14,6 +14,7 @@ import { escapeHTML, escapeAttr, showNotification, showPromptDialog, showConfirm
 import { saveImportedData } from './data.js';
 import { getProfileLocation } from './profile.js';
 import { COUNTRY_LATITUDES, COUNTRY_CENTROIDS } from './constants.js';
+import { wireBackdropClose as _wireBackdropClose, trapModalFocus } from './modal-lifecycle.js';
 import {
   BODY_REGIONS,
   renderBodySilhouette,
@@ -29,8 +30,6 @@ import {
   configureSunActiveSession,
   quickLogSunSession,
   openStartSunSessionDialog,
-  _wireBackdropClose,
-  trapModalFocus,
   _formatElapsed,
   liveDosesFor as _liveDosesFor,
   commitSunLiveSlice as _commitCurrentSlice,

--- a/service-worker.js
+++ b/service-worker.js
@@ -295,6 +295,7 @@ const APP_SHELL = [
   '/js/wearables-apple-health.js',
   '/js/wearables-manual.js',
   '/js/brand-assets.js',
+  '/js/modal-lifecycle.js',
   // Sun + light modules are statically reachable from the app shell.
   '/js/sun.js',
   '/js/sun-active-session.js',

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -117,7 +117,9 @@ return (async function () {
   console.log('%c 3. trapModalFocus ', 'font-weight:bold;color:#0891b2');
   {
     const sun = await import('/js/sun.js?bust=' + Date.now());
-    assert('sun.js exports trapModalFocus', typeof sun.trapModalFocus === 'function');
+    const modalLifecycle = await import('/js/modal-lifecycle.js');
+    assert('modal-lifecycle.js exports trapModalFocus', typeof modalLifecycle.trapModalFocus === 'function');
+    assert('sun.js re-exports trapModalFocus for compatibility', typeof sun.trapModalFocus === 'function');
 
     // Poll until `cond()` holds (or timeout). The whole suite runs in one
     // shared page, so an earlier test file's async modal-teardown observer
@@ -148,7 +150,7 @@ return (async function () {
     overlay.className = 'modal-overlay';
     overlay.innerHTML = '<button id="audit-test-btn-1">A</button><button id="audit-test-btn-2">B</button>';
     document.body.appendChild(overlay);
-    sun.trapModalFocus(overlay);
+    modalLifecycle.trapModalFocus(overlay);
 
     assert('body.style.overflow becomes hidden on first modal',
       document.body.style.overflow === 'hidden');
@@ -158,7 +160,7 @@ return (async function () {
     overlay2.className = 'modal-overlay';
     overlay2.innerHTML = '<button id="audit-test-btn-3">C</button>';
     document.body.appendChild(overlay2);
-    sun.trapModalFocus(overlay2);
+    modalLifecycle.trapModalFocus(overlay2);
     assert('body still locked while second modal mounted',
       document.body.style.overflow === 'hidden');
 
@@ -184,18 +186,18 @@ return (async function () {
     // Cache-busted imports create separate module instances in tests. Their
     // scroll locks still need one shared registry or a stale teardown can
     // unlock the page while another instance's modal remains mounted.
-    const sunReloaded = await import('/js/sun.js?bust=' + Date.now() + '-modal-lock');
+    const modalLifecycleReloaded = await import('/js/modal-lifecycle.js?bust=' + Date.now() + '-modal-lock');
     document.body.style.overflow = baseline;
     const overlayCrossA = document.createElement('div');
     overlayCrossA.className = 'modal-overlay';
     overlayCrossA.innerHTML = '<button>Cross A</button>';
     document.body.appendChild(overlayCrossA);
-    sun.trapModalFocus(overlayCrossA);
+    modalLifecycle.trapModalFocus(overlayCrossA);
     const overlayCrossB = document.createElement('div');
     overlayCrossB.className = 'modal-overlay';
     overlayCrossB.innerHTML = '<button>Cross B</button>';
     document.body.appendChild(overlayCrossB);
-    sunReloaded.trapModalFocus(overlayCrossB);
+    modalLifecycleReloaded.trapModalFocus(overlayCrossB);
     overlayCrossA.remove();
     await waitFor(() =>
       !document.body.contains(overlayCrossA)
@@ -218,7 +220,7 @@ return (async function () {
     overlay3.className = 'modal-overlay';
     overlay3.innerHTML = '<button>X</button>';
     document.body.appendChild(overlay3);
-    sun.trapModalFocus(overlay3);
+    modalLifecycle.trapModalFocus(overlay3);
     stash.remove(); // detach previouslyFocused
     let threw = false;
     try { overlay3.remove(); await waitFor(() => document.body.style.overflow === baseline); } catch (e) { threw = true; }

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -63,6 +63,7 @@ assert('SW APP_SHELL includes provider local AI controls module', swAuditSrc.inc
 assert('SW APP_SHELL includes provider PPQ panels module', swAuditSrc.includes("'/js/provider-ppq-panels.js'"));
 assert('SW APP_SHELL includes API transport module', swAuditSrc.includes("'/js/api-transport.js'"));
 assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/js/pdf-import-review.js'"));
+assert('SW APP_SHELL includes modal lifecycle module', swAuditSrc.includes("'/js/modal-lifecycle.js'"));
 assert('SW APP_SHELL includes PDF import support modules',
   swAuditSrc.includes("'/js/pdf-import-preflight.js'")
   && swAuditSrc.includes("'/js/pdf-import-progress.js'")
@@ -376,6 +377,7 @@ const lightConditionsCss = read('css/light-conditions-now.css');
 const lightSetupCss = read('css/light-setup.css');
 const sunSrc = read('js/sun.js');
 const sunActiveSessionSrc = read('js/sun-active-session.js');
+const modalLifecycleSrc = read('js/modal-lifecycle.js');
 const sunSessionUiSrc = read('js/sun-session-ui.js');
 const lightDevicesSrc = read('js/light-devices.js');
 assert('No var(--card-bg) reference', !cssSrc.includes('var(--card-bg)'));
@@ -383,6 +385,10 @@ assert('No var(--text) without suffix', !/(var\(--text\))(?!-)/.test(cssSrc));
 assert('Dead overview-grid CSS removed', !cssSrc.includes('.overview-grid'));
 assert('Dead overview-card CSS removed', !cssSrc.includes('.overview-card'));
 assert('Light page uses scoped layout wrapper', lightPageViewSrc.includes('class="light-page"'));
+assert('Modal lifecycle helpers live outside sun-active-session.js',
+  /export function wireBackdropClose/.test(modalLifecycleSrc)
+    && /export function trapModalFocus/.test(modalLifecycleSrc)
+    && !/export function _wireBackdropClose|export function trapModalFocus/.test(sunActiveSessionSrc));
 const dashboardWidgetsBlock = (dashboardWidgetsSrc.match(/const dashboardWidgets = \[([\s\S]*?)\];/) || [null, ''])[1];
 const lightSessionLogStart = lightPageViewSrc.indexOf('function renderLightSessionLogActions');
 const lightSessionLogEnd = lightPageViewSrc.indexOf('function renderLightWidgetPrompt', lightSessionLogStart);

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -147,6 +147,7 @@ const pwaAppShellAssets = [
   '/js/light-tool-camera.js',
   '/js/light-tool-camera-modals.js',
   '/js/light-tools.js',
+  '/js/modal-lifecycle.js',
   '/js/sun.js',
   '/js/sun-active-session.js',
   '/js/sun-session-model.js',

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -185,17 +185,41 @@ return (async function() {
       'skipped — buildLabContext not on window');
   }
 
-  // ─── 7. Backdrop close wiring exists for Light & Sun modals ──────────
-  // Recent commit 8885589 wired backdrop-close on all 16 Light & Sun modals.
-  // Source-check the helper is exposed and used.
+  // ─── 7. Modal lifecycle wiring exists for Light & Sun modals ─────────
+  // Modal focus/backdrop/scroll-lock belongs to the shared lifecycle module;
+  // feature modules should import it directly rather than rely on sun.js
+  // installing window globals first.
   console.log('%c 7. Backdrop-close helper wired ', 'font-weight:bold;color:#6366f1');
 
-  assert('window._wireBackdropClose exists (the helper recent commits rely on)',
+  assert('sun.js keeps window._wireBackdropClose compatibility export',
     typeof window._wireBackdropClose === 'function');
 
+  const modalLifecycleSrc = await fetch('js/modal-lifecycle.js').then(r => r.text());
   const sunActiveSrc = await fetch('js/sun-active-session.js').then(r => r.text());
-  assert('sun-active-session.js calls _wireBackdropClose for its modals',
-    /_wireBackdropClose\s*\(/.test(sunActiveSrc));
+  assert('modal-lifecycle.js owns modal backdrop and focus helpers',
+    /export function wireBackdropClose/.test(modalLifecycleSrc)
+      && /export function trapModalFocus/.test(modalLifecycleSrc));
+  assert('sun-active-session.js imports shared modal lifecycle helpers',
+    /from '\.\/modal-lifecycle\.js'/.test(sunActiveSrc)
+      && /wireBackdropClose\s*\(/.test(sunActiveSrc));
+  {
+    const globalModalDeps = [];
+    for (const file of [
+      'js/light-tool-camera-modals.js',
+      'js/light-device-session-modal.js',
+      'js/light-tools.js',
+      'js/sun-defaults.js',
+      'js/light-devices.js',
+      'js/light-conditions-now.js',
+      'js/light-sessions-view.js',
+    ]) {
+      const src = await fetch(file).then(r => r.text());
+      if (/window\._wireBackdropClose|window\.trapModalFocus/.test(src)) globalModalDeps.push(file);
+    }
+    assert('Light modal modules import lifecycle helpers instead of window globals',
+      globalModalDeps.length === 0,
+      globalModalDeps.join(', '));
+  }
 
   // ─── 8. Region picker → bodyExposure.regions; prefill on reopen ──────
   // Drives the full flow: openStartSunSessionDialog → click 2 region

--- a/tests/test-sync-two-device-e2e.js
+++ b/tests/test-sync-two-device-e2e.js
@@ -146,6 +146,23 @@ async function makePage(browser, label, importedData) {
       && typeof window.openDeviceSessionDetail === 'function',
     { timeout: 15000 }
   );
+  const helperBust = `syncE2E=${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  await page.addScriptTag({
+    type: 'module',
+    content: `
+      import { mergePulledImportedData, persistPulledImportedData } from '/js/sync-pull-merge.js?${helperBust}';
+      import { refreshActiveProfileAfterPull } from '/js/sync-pull-active-refresh.js?${helperBust}';
+      window.__syncE2EMergePulledImportedData = mergePulledImportedData;
+      window.__syncE2EPersistPulledImportedData = persistPulledImportedData;
+      window.__syncE2ERefreshActiveProfileAfterPull = refreshActiveProfileAfterPull;
+    `,
+  });
+  await page.waitForFunction(
+    () => typeof window.__syncE2EMergePulledImportedData === 'function'
+      && typeof window.__syncE2EPersistPulledImportedData === 'function'
+      && typeof window.__syncE2ERefreshActiveProfileAfterPull === 'function',
+    { timeout: 15000 }
+  );
   await page.evaluate(async ({ profileId, imported }) => {
     localStorage.clear();
     sessionStorage.clear();
@@ -171,14 +188,11 @@ async function getImportedData(page) {
 
 async function pullRemoteImportedData(page, remoteImportedData) {
   return page.evaluate(async ({ profileId, remote }) => {
-    const bust = `?syncE2E=${Date.now()}_${Math.random().toString(36).slice(2)}`;
-    const mergeMod = await import(`/js/sync-pull-merge.js${bust}`);
-    const refreshMod = await import(`/js/sync-pull-active-refresh.js${bust}`);
-    const result = await mergeMod.mergePulledImportedData(profileId, JSON.parse(JSON.stringify(remote)), {
+    const result = await window.__syncE2EMergePulledImportedData(profileId, JSON.parse(JSON.stringify(remote)), {
       debug: () => {},
     });
-    await mergeMod.persistPulledImportedData(result.localKey, profileId, result.merged, Date.now());
-    refreshMod.refreshActiveProfileAfterPull({
+    await window.__syncE2EPersistPulledImportedData(result.localKey, profileId, result.merged, Date.now());
+    window.__syncE2ERefreshActiveProfileAfterPull({
       profileId,
       merged: result.merged,
       chatApplied: false,
@@ -197,9 +211,7 @@ async function pullRemoteImportedData(page, remoteImportedData) {
 
 async function applyMergedImportedData(page, mergedImportedData, remoteBroughtNewRows = true) {
   return page.evaluate(async ({ profileId, merged, remoteBroughtNewRows: broughtRows }) => {
-    const bust = `?syncE2E=${Date.now()}_${Math.random().toString(36).slice(2)}`;
-    const refreshMod = await import(`/js/sync-pull-active-refresh.js${bust}`);
-    refreshMod.refreshActiveProfileAfterPull({
+    window.__syncE2ERefreshActiveProfileAfterPull({
       profileId,
       merged: JSON.parse(JSON.stringify(merged)),
       chatApplied: false,

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -658,7 +658,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
     const sunActiveSrc = fetchSrc('js/sun-active-session.js');
     const startHandler = sunActiveSrc.slice(
       sunActiveSrc.indexOf("overlay.querySelector('#start-confirm').addEventListener"),
-      sunActiveSrc.indexOf('export function _wireBackdropClose')
+      sunActiveSrc.indexOf('function _plainStopSummary')
     );
     assert('sun-active-session.js: start flow uses one consolidated start-session toast helper',
       /function _buildStartSessionToast/.test(sunActiveSrc) &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.311';
+self.APP_VERSION = '1.8.312';


### PR DESCRIPTION
## Summary
- Add `js/modal-lifecycle.js` as the neutral owner for modal backdrop close wiring, focus trapping, and body scroll locking.
- Keep `sun.js` compatibility exports, but move Light/Sun modal call sites off `window._wireBackdropClose` and `window.trapModalFocus` onto direct imports.
- Precache the new module, document the boundary, bump `APP_VERSION` to `1.8.312`, and add source/browser guards against reintroducing the window-global dependency.

## Why
Modal lifecycle behavior is app infrastructure, not Sun session behavior. This removes the dependency on Sun module side effects for Light modals while preserving the existing runtime behavior and compatibility surface.

## Validation
- `node --check js/modal-lifecycle.js js/sun-active-session.js js/sun.js js/light-tool-camera-modals.js js/light-tools.js`
- `git diff --check`
- `node tests/test-audit.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-v1-6-shipped.js`
- `node tests/test-light-tools.js`
- `node tests/test-light-tools-flow.js`
- `node tests/test-sync-modal-refresh.js`
- `./run-tests.sh`