### PR TITLE
[codex] Delegate static shell actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <header class="header">
     <div class="brand header-left">
-      <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleMobileSidebar()" aria-label="Menu"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button>
+      <button class="sidebar-toggle" id="sidebar-toggle" data-shell-action="toggle-mobile-sidebar" aria-label="Menu"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button>
       <a href="/" class="logo-link"><h1 class="brand-mark">getbased</h1></a>
     </div>
     <div class="header-info header-mid">
@@ -108,16 +108,16 @@
     </div>
     <div class="header-group header-right">
       <span id="sync-indicator-slot"></span>
-      <button class="header-icon-btn header-import-btn" onclick="document.getElementById('pdf-input').click()" title="Import" aria-label="Import lab results"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><polyline points="9 15 12 12 15 15"/></svg></button>
-      <button class="header-icon-btn tweaks-btn" onclick="openTweaksPanel()" title="Tweaks" aria-label="Tweaks"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg></button>
-        <button class="header-icon-btn settings-btn" onclick="openSettingsModal()" title="Settings" aria-label="Settings"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
-        <button class="header-icon-btn feedback-btn" onclick="openFeedbackModal()" title="Send Feedback" aria-label="Send Feedback"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="6" width="8" height="14" rx="4"/><line x1="6" y1="9" x2="8" y2="9"/><line x1="16" y1="9" x2="18" y2="9"/><line x1="6" y1="15" x2="8" y2="15"/><line x1="16" y1="15" x2="18" y2="15"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="9" y1="4" x2="9" y2="2"/><line x1="15" y1="4" x2="15" y2="2"/><line x1="12" y1="13" x2="12" y2="13.01"/></svg></button>
+      <button class="header-icon-btn header-import-btn" data-shell-action="trigger-import" title="Import" aria-label="Import lab results"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><polyline points="9 15 12 12 15 15"/></svg></button>
+      <button class="header-icon-btn tweaks-btn" data-shell-action="open-tweaks" title="Tweaks" aria-label="Tweaks"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg></button>
+        <button class="header-icon-btn settings-btn" data-shell-action="open-settings" title="Settings" aria-label="Settings"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
+        <button class="header-icon-btn feedback-btn" data-shell-action="open-feedback" title="Send Feedback" aria-label="Send Feedback"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="6" width="8" height="14" rx="4"/><line x1="6" y1="9" x2="8" y2="9"/><line x1="16" y1="9" x2="18" y2="9"/><line x1="6" y1="15" x2="8" y2="15"/><line x1="16" y1="15" x2="18" y2="15"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="9" y1="4" x2="9" y2="2"/><line x1="15" y1="4" x2="15" y2="2"/><line x1="12" y1="13" x2="12" y2="13.01"/></svg></button>
         <a href="https://hydranode.org/btcpay/api/v1/invoices?storeId=BfxZicwEaRcJvJnkBPHdzGuCAonAhwLBb5vbWfjT2ZR1&checkoutDesc=Donate%20to%20getbased.health&price=&currency=USD&redirectURL=https%3A%2F%2Fgetbased.health%2Fthank-you" target="_blank" rel="noopener" class="header-icon-btn donate-btn" title="Donate" aria-label="Donate" style="text-decoration:none">&#x20bf; Donate</a>
     </div>
   </header>
 
   <div class="layout">
-    <div class="sidebar-backdrop" id="sidebar-backdrop" onclick="closeMobileSidebar()"></div>
+    <div class="sidebar-backdrop" id="sidebar-backdrop" data-shell-action="close-mobile-sidebar"></div>
     <nav class="sidebar" id="sidebar-nav"></nav>
     <main class="main" id="main-content"></main>
   </div>
@@ -172,32 +172,32 @@
   </div>
 
   <div class="chat-backdrop" id="chat-backdrop"></div>
-  <button class="import-status-fab hidden" id="import-status-fab" onclick="window.handleImportStatusClick()" aria-label="Import in progress" title="Import in progress">
+  <button class="import-status-fab hidden" id="import-status-fab" data-shell-action="import-status" aria-label="Import in progress" title="Import in progress">
     <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
     <span class="import-status-label"></span>
   </button>
-  <button class="chat-fab" id="chat-fab" onclick="toggleChatPanel()" aria-label="Ask AI" title="Ask AI">
+  <button class="chat-fab" id="chat-fab" data-chat-action="toggle-panel" aria-label="Ask AI" title="Ask AI">
     <svg viewBox="0 0 24 24"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
   </button>
   <div class="chat-panel" id="chat-panel" role="complementary" aria-label="AI Lab Analyst">
     <div class="chat-thread-rail" id="chat-thread-rail">
       <div class="chat-thread-rail-header">
-        <button class="chat-rail-back" onclick="toggleThreadRail()" aria-label="Close conversations">
+        <button class="chat-rail-back" data-chat-action="toggle-thread-rail" aria-label="Close conversations">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg>
         </button>
         <span class="chat-thread-rail-title">Conversations</span>
-        <button class="chat-thread-new-btn" onclick="createNewThread()" title="New conversation" aria-label="New conversation">
+        <button class="chat-thread-new-btn" data-chat-action="create-thread" title="New conversation" aria-label="New conversation">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
         </button>
       </div>
-      <input type="search" class="chat-thread-search" id="chat-thread-search" placeholder="Search conversations..." aria-label="Search conversations and messages" oninput="filterThreadList(this.value)" onsearch="filterThreadList(this.value)">
+      <input type="search" class="chat-thread-search" id="chat-thread-search" placeholder="Search conversations..." aria-label="Search conversations and messages" data-chat-input-action="filter-thread-list">
       <div class="chat-thread-list" id="chat-thread-list" tabindex="0" aria-label="Conversation list"></div>
       <div id="chat-saved-summaries"></div>
     </div>
     <div class="chat-panel-conversation">
       <div class="chat-header">
         <div class="chat-header-left">
-          <button class="chat-rail-toggle" onclick="toggleThreadRail()" title="Conversations" aria-label="Toggle conversations">
+          <button class="chat-rail-toggle" data-chat-action="toggle-thread-rail" title="Conversations" aria-label="Toggle conversations">
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/></svg>
           </button>
           <div class="chat-header-info">
@@ -209,32 +209,32 @@
           <label class="chat-websearch-toggle-label" title="Let AI search the web for current information (Venice &amp; OpenRouter)" style="display:none">
             <span class="chat-toggle-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 0 20"/><path d="M12 2a15.3 15.3 0 0 0 0 20"/></svg></span>
             <span class="chat-toggle-text">Web</span>
-            <input type="checkbox" id="chat-websearch-checkbox" aria-label="Toggle web search" onchange="setChatWebSearchEnabled(this.checked)">
+            <input type="checkbox" id="chat-websearch-checkbox" aria-label="Toggle web search" data-chat-change-action="set-websearch">
             <span class="chat-toggle-slider"></span>
           </label>
-          <button type="button" class="chat-lens-indicator" id="chat-lens-indicator" onclick="openSettingsModal('ai')" title="Custom Knowledge Source" aria-label="Knowledge Source status — click to open settings" style="display:none">
+          <button type="button" class="chat-lens-indicator" id="chat-lens-indicator" data-shell-action="open-ai-settings" title="Custom Knowledge Source" aria-label="Knowledge Source status — click to open settings" style="display:none">
             <span class="chat-lens-dot" id="chat-lens-dot"></span>
             <span class="chat-lens-label">Lens</span>
           </button>
           <span class="sr-only" aria-live="polite" id="chat-lens-status"></span>
-          <button class="chat-summary-btn" onclick="summarizeThread()" title="Summarize this conversation" aria-label="Summarize this conversation"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16"/><path d="M4 9h10"/><path d="M4 14h16"/><path d="M4 19h10"/></svg></button>
-          <button class="chat-clear-btn" onclick="clearChatHistory()" title="Clear history" aria-label="Clear history"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg></button>
-          <button class="chat-fullscreen-btn" onclick="toggleChatFullscreen()" aria-label="Toggle fullscreen chat" title="Toggle fullscreen">
+          <button class="chat-summary-btn" data-chat-action="summarize-thread" title="Summarize this conversation" aria-label="Summarize this conversation"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16"/><path d="M4 9h10"/><path d="M4 14h16"/><path d="M4 19h10"/></svg></button>
+          <button class="chat-clear-btn" data-chat-action="clear-history" title="Clear history" aria-label="Clear history"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg></button>
+          <button class="chat-fullscreen-btn" data-chat-action="toggle-fullscreen" aria-label="Toggle fullscreen chat" title="Toggle fullscreen">
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M16 3h3a2 2 0 0 1 2 2v3"/><path d="M8 21H5a2 2 0 0 1-2-2v-3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg>
           </button>
-          <button class="chat-close-btn" onclick="closeChatPanel()" aria-label="Close chat">
+          <button class="chat-close-btn" data-chat-action="close-panel" aria-label="Close chat">
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
           </button>
         </div>
       </div>
       <div class="chat-personality-bar">
-        <div class="chat-personality-current" tabindex="0" role="button" aria-expanded="false" onclick="togglePersonalityBar()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();togglePersonalityBar()}">
+        <div class="chat-personality-current" tabindex="0" role="button" aria-expanded="false" data-chat-action="toggle-personality" data-chat-key-action="toggle-personality">
           <span class="chat-personality-current-icon">&#128300;</span>
           <span class="chat-personality-current-name">AI Lab Analyst</span>
           <span class="chat-personality-current-arrow">&#9662;</span>
         </div>
         <div class="chat-personality-options">
-          <button class="chat-personality-opt active" data-personality="default" onclick="setChatPersonality('default')">
+          <button class="chat-personality-opt active" data-personality="default" data-chat-action="set-personality">
             <span class="chat-personality-opt-icon">&#128300;</span>
             <div class="chat-personality-opt-info">
               <span class="chat-personality-opt-name">AI Lab Analyst</span>
@@ -243,7 +243,7 @@
             <span class="chat-personality-opt-check">&#10003;</span>
           </button>
           <div class="chat-personality-divider">Fictional Characters</div>
-          <button class="chat-personality-opt" data-personality="house" onclick="setChatPersonality('house')">
+          <button class="chat-personality-opt" data-personality="house" data-chat-action="set-personality">
             <span class="chat-personality-opt-icon">&#129455;</span>
             <div class="chat-personality-opt-info">
               <span class="chat-personality-opt-name">Dr. Gregory House</span>
@@ -258,13 +258,13 @@
       <div class="chat-input-area">
         <div class="chat-attach-preview" id="chat-attach-preview"></div>
         <div class="chat-input-row">
-          <button class="chat-attach-btn" id="chat-attach-btn" onclick="document.getElementById('chat-image-input').click()" aria-label="Attach image" title="Attach image" style="display:none"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
-          <button class="chat-hd-btn" id="chat-hd-btn" onclick="toggleHDMode()" aria-label="Toggle HD image mode" title="Standard quality" style="display:none">HD</button>
-          <textarea class="chat-input" id="chat-input" placeholder="Ask about your lab results..." aria-label="Chat message" rows="2" onkeydown="handleChatKeydown(event)"></textarea>
-          <button class="chat-discuss-btn" id="chat-discuss-btn" onclick="startDiscussion()" style="display:none" aria-label="Start discussion" title="Personas discuss your results">
+          <button class="chat-attach-btn" id="chat-attach-btn" data-chat-action="attach-image" aria-label="Attach image" title="Attach image" style="display:none"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg></button>
+          <button class="chat-hd-btn" id="chat-hd-btn" data-chat-action="toggle-hd" aria-label="Toggle HD image mode" title="Standard quality" style="display:none">HD</button>
+          <textarea class="chat-input" id="chat-input" placeholder="Ask about your lab results..." aria-label="Chat message" rows="2" data-chat-key-action="message-input"></textarea>
+          <button class="chat-discuss-btn" id="chat-discuss-btn" data-chat-action="start-discussion" style="display:none" aria-label="Start discussion" title="Personas discuss your results">
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"/></svg>
           </button>
-          <button class="chat-send-btn" id="chat-send-btn" onclick="sendChatMessage()" aria-label="Send message">
+          <button class="chat-send-btn" id="chat-send-btn" data-chat-action="send-message" aria-label="Send message">
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m22 2-7 20-4-9-9-4Z"/><path d="M22 2 11 13"/></svg>
           </button>
         </div>

--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -67,8 +67,8 @@ function handleRoleButtonKeydown(e) {
   // Skip native interactives; they handle Space/Enter themselves.
   const tag = t.tagName;
   if (tag === 'BUTTON' || tag === 'A' || tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
-  // Don't fire twice if the element already has its own onkeydown shim.
-  if (t.hasAttribute('onkeydown')) return;
+  // Don't fire twice if the element already has its own keydown wiring.
+  if (t.hasAttribute('onkeydown') || t.hasAttribute('data-chat-key-action')) return;
   e.preventDefault();
   t.click();
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,8 @@
 // main.js — Thin entry point
 
 import './app-feature-modules.js';
+import { installShellActionDelegates } from './shell-actions.js';
 import { startApp } from './startup-orchestrator.js';
 
+installShellActionDelegates();
 startApp();

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -16,51 +16,74 @@ function clickFileInput(id) {
 function runShellAction(action) {
   if (action === 'toggle-mobile-sidebar') {
     window.toggleMobileSidebar?.();
+    return true;
   } else if (action === 'close-mobile-sidebar') {
     window.closeMobileSidebar?.();
+    return true;
   } else if (action === 'trigger-import') {
     clickFileInput('pdf-input');
+    return true;
   } else if (action === 'open-tweaks') {
     window.openTweaksPanel?.();
+    return true;
   } else if (action === 'open-settings') {
     window.openSettingsModal?.();
+    return true;
   } else if (action === 'open-ai-settings') {
     window.openSettingsModal?.('ai');
+    return true;
   } else if (action === 'open-feedback') {
     window.openFeedbackModal?.();
+    return true;
   } else if (action === 'import-status') {
     window.handleImportStatusClick?.();
+    return true;
   }
+  return false;
 }
 
 function runChatAction(action, actionEl) {
   if (action === 'toggle-panel') {
     window.toggleChatPanel?.();
+    return true;
   } else if (action === 'close-panel') {
     window.closeChatPanel?.();
+    return true;
   } else if (action === 'toggle-thread-rail') {
     window.toggleThreadRail?.();
+    return true;
   } else if (action === 'create-thread') {
     window.createNewThread?.();
+    return true;
   } else if (action === 'summarize-thread') {
     window.summarizeThread?.();
+    return true;
   } else if (action === 'clear-history') {
     window.clearChatHistory?.();
+    return true;
   } else if (action === 'toggle-fullscreen') {
     window.toggleChatFullscreen?.();
+    return true;
   } else if (action === 'toggle-personality') {
     window.togglePersonalityBar?.();
+    return true;
   } else if (action === 'set-personality') {
     window.setChatPersonality?.(actionEl.dataset.personality || 'default');
+    return true;
   } else if (action === 'attach-image') {
     clickFileInput('chat-image-input');
+    return true;
   } else if (action === 'toggle-hd') {
     window.toggleHDMode?.();
+    return true;
   } else if (action === 'start-discussion') {
     window.startDiscussion?.();
+    return true;
   } else if (action === 'send-message') {
     window.sendChatMessage?.();
+    return true;
   }
+  return false;
 }
 
 function handleShellClick(event) {
@@ -71,9 +94,10 @@ function handleShellClick(event) {
   const chatAction = actionEl.dataset.chatAction;
   if (!shellAction && !chatAction) return;
 
-  event.preventDefault();
-  if (shellAction) runShellAction(shellAction);
-  else runChatAction(chatAction, actionEl);
+  const handled = shellAction
+    ? runShellAction(shellAction)
+    : runChatAction(chatAction, actionEl);
+  if (handled) event.preventDefault();
 }
 
 function handleShellInput(event) {

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -1,0 +1,117 @@
+// shell-actions.js - delegated actions for static index.html controls
+
+let shellDelegatesInstalled = false;
+
+function closestAction(event, selector) {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  return target.closest(selector);
+}
+
+function clickFileInput(id) {
+  const input = document.getElementById(id);
+  if (input instanceof HTMLInputElement) input.click();
+}
+
+function runShellAction(action) {
+  if (action === 'toggle-mobile-sidebar') {
+    window.toggleMobileSidebar?.();
+  } else if (action === 'close-mobile-sidebar') {
+    window.closeMobileSidebar?.();
+  } else if (action === 'trigger-import') {
+    clickFileInput('pdf-input');
+  } else if (action === 'open-tweaks') {
+    window.openTweaksPanel?.();
+  } else if (action === 'open-settings') {
+    window.openSettingsModal?.();
+  } else if (action === 'open-ai-settings') {
+    window.openSettingsModal?.('ai');
+  } else if (action === 'open-feedback') {
+    window.openFeedbackModal?.();
+  } else if (action === 'import-status') {
+    window.handleImportStatusClick?.();
+  }
+}
+
+function runChatAction(action, actionEl) {
+  if (action === 'toggle-panel') {
+    window.toggleChatPanel?.();
+  } else if (action === 'close-panel') {
+    window.closeChatPanel?.();
+  } else if (action === 'toggle-thread-rail') {
+    window.toggleThreadRail?.();
+  } else if (action === 'create-thread') {
+    window.createNewThread?.();
+  } else if (action === 'summarize-thread') {
+    window.summarizeThread?.();
+  } else if (action === 'clear-history') {
+    window.clearChatHistory?.();
+  } else if (action === 'toggle-fullscreen') {
+    window.toggleChatFullscreen?.();
+  } else if (action === 'toggle-personality') {
+    window.togglePersonalityBar?.();
+  } else if (action === 'set-personality') {
+    window.setChatPersonality?.(actionEl.dataset.personality || 'default');
+  } else if (action === 'attach-image') {
+    clickFileInput('chat-image-input');
+  } else if (action === 'toggle-hd') {
+    window.toggleHDMode?.();
+  } else if (action === 'start-discussion') {
+    window.startDiscussion?.();
+  } else if (action === 'send-message') {
+    window.sendChatMessage?.();
+  }
+}
+
+function handleShellClick(event) {
+  const actionEl = closestAction(event, '[data-shell-action], [data-chat-action]');
+  if (!actionEl) return;
+
+  const shellAction = actionEl.dataset.shellAction;
+  const chatAction = actionEl.dataset.chatAction;
+  if (!shellAction && !chatAction) return;
+
+  event.preventDefault();
+  if (shellAction) runShellAction(shellAction);
+  else runChatAction(chatAction, actionEl);
+}
+
+function handleShellInput(event) {
+  const input = event.target;
+  if (!(input instanceof HTMLInputElement)) return;
+  if (input.dataset.chatInputAction === 'filter-thread-list') {
+    window.filterThreadList?.(input.value);
+  }
+}
+
+function handleShellChange(event) {
+  const input = event.target;
+  if (!(input instanceof HTMLInputElement)) return;
+  if (input.dataset.chatChangeAction === 'set-websearch') {
+    window.setChatWebSearchEnabled?.(input.checked);
+  }
+}
+
+function handleShellKeydown(event) {
+  const actionEl = closestAction(event, '[data-chat-key-action]');
+  if (!actionEl) return;
+
+  const action = actionEl.dataset.chatKeyAction;
+  if (action === 'message-input') {
+    window.handleChatKeydown?.(event);
+  } else if (action === 'toggle-personality' && (event.key === 'Enter' || event.key === ' ')) {
+    event.preventDefault();
+    window.togglePersonalityBar?.();
+  }
+}
+
+export function installShellActionDelegates() {
+  if (shellDelegatesInstalled || typeof document === 'undefined') return;
+  shellDelegatesInstalled = true;
+
+  document.addEventListener('click', handleShellClick);
+  document.addEventListener('input', handleShellInput);
+  document.addEventListener('search', handleShellInput);
+  document.addEventListener('change', handleShellChange);
+  document.addEventListener('keydown', handleShellKeydown);
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -65,6 +65,7 @@ const APP_SHELL = [
   '/css/chat-redesign.css',
   '/themes-extra.css',
   '/js/main.js',
+  '/js/shell-actions.js',
   '/js/app-feature-modules.js',
   '/js/app-foundation-modules.js',
   '/js/app-health-data-modules.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -166,6 +166,7 @@ const LEGACY_TESTS = [
   // *-dom.js files stay on puppeteer.
   './test-tour.js',
   './test-settings-delegated-actions.js',
+  './test-shell-delegated-actions.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',
   // Batch 32 — test-wearables (~549 asserts: registry, IDB CRUD via

--- a/tests/test-chat-panel-ux.js
+++ b/tests/test-chat-panel-ux.js
@@ -43,8 +43,8 @@ return (async function() {
         btn?.getAttribute('aria-label')?.length > 0);
       assert('fullscreen button has title (tooltip on hover)',
         btn?.getAttribute('title')?.length > 0);
-      assert('fullscreen button onclick wired to toggleChatFullscreen',
-        btn?.getAttribute('onclick') === 'toggleChatFullscreen()');
+      assert('fullscreen button uses delegated toggle action',
+        btn?.getAttribute('data-chat-action') === 'toggle-fullscreen');
     }
 
     // ─── 3. Backdrop is pointer-events: none (dashboard interactive) ─

--- a/tests/test-custom-personality-dom.js
+++ b/tests/test-custom-personality-dom.js
@@ -113,7 +113,8 @@ return (async function() {
   const discussBtnEl = document.getElementById('chat-discuss-btn');
   assert('Discuss button exists', !!discussBtnEl);
   assert('Discuss button hidden by default', discussBtnEl && discussBtnEl.style.display === 'none');
-  assert('Discuss button has onclick', discussBtnEl && discussBtnEl.getAttribute('onclick') === 'startDiscussion()');
+  assert('Discuss button uses delegated action',
+    discussBtnEl && discussBtnEl.getAttribute('data-chat-action') === 'start-discussion');
 
   // ── Restore ──
   if (origVal !== null) localStorage.setItem(key, origVal);

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -149,7 +149,8 @@ return (async function() {
   const railBack = document.querySelector('.chat-rail-back');
   assert('chat-rail-back button exists in DOM', !!railBack);
   assert('chat-rail-back hidden by default', railBack && getComputedStyle(railBack).display === 'none');
-  assert('chat-rail-back has onclick=toggleThreadRail', railBack && railBack.getAttribute('onclick') === 'toggleThreadRail()');
+  assert('chat-rail-back uses delegated toggleThreadRail action',
+    railBack && railBack.getAttribute('data-chat-action') === 'toggle-thread-rail');
 
   // ═══ Section 11: 480px and 375px breakpoints exist ═══
   console.log('%c[11] Small Screen Breakpoints', 'font-weight:bold');

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -315,8 +315,8 @@ const onboardingViewSrc = read('js/onboarding-view.js');
 
   assert('FAB button exists in HTML', htmlSrc.includes('id="chat-fab"') && htmlSrc.includes('class="chat-fab"'),
     'index.html should have #chat-fab with .chat-fab class');
-  assert('FAB has onclick=toggleChatPanel', htmlSrc.includes('chat-fab') && htmlSrc.includes('onclick="toggleChatPanel()"'),
-    'FAB should call toggleChatPanel on click');
+  assert('FAB uses delegated toggleChatPanel action', htmlSrc.includes('chat-fab') && htmlSrc.includes('data-chat-action="toggle-panel"'),
+    'FAB should route toggleChatPanel through the shell delegate');
   assert('FAB has aria-label', htmlSrc.includes('chat-fab') && htmlSrc.includes('aria-label="Ask AI"'),
     'FAB should be accessible');
   assert('FAB contains SVG icon', (() => {

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Static shell delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
+const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
+const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Static Shell Delegated Actions ===');
+
+const body = (html.match(/<body>[\s\S]*?<script src="version\.js"/) || [''])[0];
+const inlineHandlerRe = /\bon(?:click|change|input|search|keydown|keyup|submit)=/;
+
+assert('Static body shell has no inline event attributes',
+  body && !inlineHandlerRe.test(body));
+assert('main installs shell action delegates',
+  mainSrc.includes("import { installShellActionDelegates } from './shell-actions.js'")
+    && mainSrc.includes('installShellActionDelegates();'));
+
+[
+  'toggle-mobile-sidebar',
+  'close-mobile-sidebar',
+  'trigger-import',
+  'open-tweaks',
+  'open-settings',
+  'open-ai-settings',
+  'open-feedback',
+  'import-status',
+].forEach(action => {
+  assert(`Shell action ${action} is rendered`, html.includes(`data-shell-action="${action}"`));
+  assert(`Shell action ${action} is handled`, shellSrc.includes(`action === '${action}'`));
+});
+
+[
+  'toggle-panel',
+  'close-panel',
+  'toggle-thread-rail',
+  'create-thread',
+  'summarize-thread',
+  'clear-history',
+  'toggle-fullscreen',
+  'toggle-personality',
+  'set-personality',
+  'attach-image',
+  'toggle-hd',
+  'start-discussion',
+  'send-message',
+].forEach(action => {
+  assert(`Chat action ${action} is rendered`, html.includes(`data-chat-action="${action}"`));
+  assert(`Chat action ${action} is handled`, shellSrc.includes(`action === '${action}'`));
+});
+
+assert('Thread search uses delegated input/search action',
+  html.includes('data-chat-input-action="filter-thread-list"')
+    && shellSrc.includes("document.addEventListener('input', handleShellInput)")
+    && shellSrc.includes("document.addEventListener('search', handleShellInput)")
+    && shellSrc.includes('window.filterThreadList?.(input.value)'));
+assert('Web search toggle uses delegated change action',
+  html.includes('data-chat-change-action="set-websearch"')
+    && shellSrc.includes("document.addEventListener('change', handleShellChange)")
+    && shellSrc.includes('window.setChatWebSearchEnabled?.(input.checked)'));
+assert('Chat key handlers are delegated',
+  html.includes('data-chat-key-action="message-input"')
+    && html.includes('data-chat-key-action="toggle-personality"')
+    && shellSrc.includes("document.addEventListener('keydown', handleShellKeydown)")
+    && shellSrc.includes('window.handleChatKeydown?.(event)')
+    && shellSrc.includes('window.togglePersonalityBar?.()'));
+assert('Generic role-button key shim skips delegated chat key actions',
+  appEventsSrc.includes("t.hasAttribute('data-chat-key-action')"));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -84,6 +84,11 @@ assert('Chat key handlers are delegated',
     && shellSrc.includes("document.addEventListener('keydown', handleShellKeydown)")
     && shellSrc.includes('window.handleChatKeydown?.(event)')
     && shellSrc.includes('window.togglePersonalityBar?.()'));
+assert('Click delegate only prevents default for handled actions',
+  shellSrc.includes('const handled = shellAction')
+    && shellSrc.includes('if (handled) event.preventDefault();')
+    && shellSrc.includes('return false;')
+    && !shellSrc.includes('event.preventDefault();\n  if (shellAction)'));
 assert('Generic role-button key shim skips delegated chat key actions',
   appEventsSrc.includes("t.hasAttribute('data-chat-key-action')"));
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.314';
+self.APP_VERSION = '1.8.315';


### PR DESCRIPTION
## Summary
- Replace static `index.html` shell/chat inline handlers with delegated `data-*` action attributes.
- Add `js/shell-actions.js` and install it from `main.js` for click/input/search/change/keydown routing.
- Update the generic role-button key shim to avoid double-firing delegated chat key actions, and bump the app cache version/precache.
- Add source guard coverage and update DOM expectations for the delegated actions.

## Validation
- `node --check js/shell-actions.js`
- `node --check js/main.js`
- `node --check js/app-event-listeners.js`
- `node tests/test-shell-delegated-actions.js`
- `node tests/test-prelab.js`
- Focused Puppeteer smoke for shell/chat delegated actions against `http://127.0.0.1:8000/app`
- `npm test`
- `./run-tests.sh`