### PR TITLE
[codex] Delegate chat thread actions

### DIFF
--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -38,6 +38,7 @@ const MAX_THREADS = 50;
 const THREAD_ICON_EDIT = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>';
 const THREAD_ICON_DELETE = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>';
 const CHAT_DELETED_PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+let chatThreadDelegatesInstalled = false;
 
 export function getChatThreadsKey() {
   return `labcharts-${state.currentProfile}-chat-threads`;
@@ -262,6 +263,46 @@ export function pruneOldThreads() {
 // ═══════════════════════════════════════════════
 // THREAD RAIL UI
 // ═══════════════════════════════════════════════
+function closestThreadAction(event) {
+  const target = event.target;
+  if (typeof Element === 'undefined' || !(target instanceof Element)) return null;
+  return target.closest('[data-chat-thread-action]');
+}
+
+function getThreadActionId(actionEl) {
+  return actionEl.dataset.threadId || actionEl.closest('[data-thread-id]')?.dataset.threadId || '';
+}
+
+function handleThreadActionClick(event) {
+  const actionEl = closestThreadAction(event);
+  if (!actionEl) return;
+  const list = document.getElementById('chat-thread-list');
+  if (!list || !list.contains(actionEl)) return;
+
+  const action = actionEl.dataset.chatThreadAction;
+  const threadId = getThreadActionId(actionEl);
+  if (!action || !threadId) return;
+
+  if (action === 'switch') {
+    event.preventDefault();
+    switchToThread(threadId);
+  } else if (action === 'rename') {
+    event.preventDefault();
+    event.stopPropagation();
+    renameThreadPrompt(threadId);
+  } else if (action === 'delete') {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteThread(threadId);
+  }
+}
+
+export function installChatThreadDelegates() {
+  if (chatThreadDelegatesInstalled || typeof document === 'undefined') return;
+  chatThreadDelegatesInstalled = true;
+  document.addEventListener('click', handleThreadActionClick);
+}
+
 export function renderThreadList(filter) {
   const list = document.getElementById('chat-thread-list');
   if (!list) return;
@@ -284,7 +325,7 @@ export function renderThreadList(filter) {
     const dateStr = formatThreadDate(date);
     const icon = t.personalityIcon || personalityMap[t.personality] || personalityMap.default || '';
     const iconTitle = t.personalityName ? ` title="${escapeHTML(t.personalityName)}"` : '';
-    return `<div class="chat-thread-item${isActive ? ' active' : ''}" onclick="switchToThread('${escapeHTML(t.id)}')" data-thread-id="${escapeHTML(t.id)}">
+    return `<div class="chat-thread-item${isActive ? ' active' : ''}" data-chat-thread-action="switch" data-thread-id="${escapeHTML(t.id)}">
       <div class="chat-thread-item-name">${escapeHTML(t.name)}</div>
       <div class="chat-thread-item-meta">
         <span${iconTitle}>${icon}</span>
@@ -292,8 +333,8 @@ export function renderThreadList(filter) {
         <span>${t.messageCount} msg${t.messageCount !== 1 ? 's' : ''}</span>
       </div>
       <div class="chat-thread-item-actions">
-        <button class="chat-thread-item-action" onclick="event.stopPropagation();renameThreadPrompt('${escapeHTML(t.id)}')" title="Rename" aria-label="Rename thread">${THREAD_ICON_EDIT}</button>
-        <button class="chat-thread-item-action delete" onclick="event.stopPropagation();deleteThread('${escapeHTML(t.id)}')" title="Delete" aria-label="Delete thread">${THREAD_ICON_DELETE}</button>
+        <button class="chat-thread-item-action" data-chat-thread-action="rename" data-thread-id="${escapeHTML(t.id)}" title="Rename" aria-label="Rename thread">${THREAD_ICON_EDIT}</button>
+        <button class="chat-thread-item-action delete" data-chat-thread-action="delete" data-thread-id="${escapeHTML(t.id)}" title="Delete" aria-label="Delete thread">${THREAD_ICON_DELETE}</button>
       </div>
     </div>`;
   }).join('');
@@ -335,8 +376,9 @@ configureChatThreadSearch({
   renderThreadList,
   switchToThread,
 });
+installChatThreadDelegates();
 
-// HTML onclick handlers + chat.js call sites hit these names.
+// Delegated thread actions + chat.js call sites hit these names.
 Object.assign(window, {
   loadChatThreads,
   saveChatThreadIndex,
@@ -346,6 +388,7 @@ Object.assign(window, {
   deleteThread,
   renameThread,
   renameThreadPrompt,
+  installChatThreadDelegates,
   autoNameThread,
   pruneOldThreads,
   renderThreadList,

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -288,11 +288,9 @@ function handleThreadActionClick(event) {
     switchToThread(threadId);
   } else if (action === 'rename') {
     event.preventDefault();
-    event.stopPropagation();
     renameThreadPrompt(threadId);
   } else if (action === 'delete') {
     event.preventDefault();
-    event.stopPropagation();
     deleteThread(threadId);
   }
 }

--- a/tests/test-chat-threads-dom.js
+++ b/tests/test-chat-threads-dom.js
@@ -73,11 +73,12 @@ return (async function() {
   // 11. Search Filtering
   // ═══════════════════════════════════════════════
   console.group('%c11. Search Filtering', 'font-weight:bold');
-  st.chatThreads = [
+  const threadFixtures = [
     { id: 't_a', name: 'Thyroid Panel Discussion', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), messageCount: 5, personality: 'default' },
     { id: 't_b', name: 'Vitamin D Levels', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), messageCount: 3, personality: 'default' },
     { id: 't_c', name: 'Cholesterol Overview', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), messageCount: 2, personality: 'default' }
   ];
+  st.chatThreads = threadFixtures.map(t => ({ ...t }));
   window.saveChatThreadIndex();
   window.renderThreadList();
   const allItems = document.querySelectorAll('.chat-thread-item');
@@ -111,6 +112,15 @@ return (async function() {
   assert('delegated rename button renames thread',
     await waitFor(() => st.chatThreads.find(t => t.id === 't_a')?.name === 'Renamed Thread'));
   st.chatThreads.find(t => t.id === 't_a').name = 'Thyroid Panel Discussion';
+  window.renderThreadList();
+  document.querySelector('.chat-thread-item[data-thread-id="t_c"] .chat-thread-item-action.delete')?.click();
+  const confirmOk = await waitFor(() => document.getElementById('confirm-ok'));
+  document.getElementById('confirm-ok')?.click();
+  let deleted = false;
+  if (confirmOk) deleted = await waitFor(() => !st.chatThreads.some(t => t.id === 't_c'));
+  assert('delegated delete button removes thread after confirmation',
+    deleted);
+  st.chatThreads = threadFixtures.map(t => ({ ...t }));
   window.renderThreadList();
 
   window.filterThreadList('thyroid');

--- a/tests/test-chat-threads-dom.js
+++ b/tests/test-chat-threads-dom.js
@@ -15,6 +15,14 @@ return (async function() {
     if (condition) { passed++; console.log(`  %c✓ ${name}`, 'color:#22c55e', detail || ''); }
     else { failed++; console.error(`  %c✗ ${name}`, 'color:#ef4444', detail || ''); }
   }
+  async function waitFor(fn, timeoutMs = 500) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (fn()) return true;
+      await new Promise(r => setTimeout(r, 20));
+    }
+    return false;
+  }
 
   console.log('%c Chat Threads DOM Tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
@@ -23,6 +31,11 @@ return (async function() {
   const profileId = st.currentProfile;
   const origThreads = st.chatThreads.slice();
   const origThreadId = st.currentThreadId;
+  const origSaveChatHistory = window.saveChatHistory;
+  const origLoadChatHistory = window.loadChatHistory;
+  const origCleanupDiscussionState = window.cleanupDiscussionState;
+  const origRestoreDiscussionContinuePrompt = window.restoreDiscussionContinuePrompt;
+  const origShowPromptDialog = window.showPromptDialog;
 
   // ═══════════════════════════════════════════════
   // 3. HTML Structure
@@ -69,6 +82,37 @@ return (async function() {
   window.renderThreadList();
   const allItems = document.querySelectorAll('.chat-thread-item');
   assert('all 3 threads rendered', allItems.length === 3);
+  const threadItem = document.querySelector('.chat-thread-item[data-thread-id="t_a"]');
+  assert('rendered thread item uses delegated switch action',
+    threadItem && threadItem.getAttribute('data-chat-thread-action') === 'switch');
+  assert('rendered thread item has no inline onclick',
+    threadItem && !threadItem.hasAttribute('onclick'));
+  const renameBtn = document.querySelector('.chat-thread-item[data-thread-id="t_a"] .chat-thread-item-action');
+  assert('rendered rename button uses delegated action',
+    renameBtn && renameBtn.getAttribute('data-chat-thread-action') === 'rename');
+  assert('rendered rename button has no inline onclick',
+    renameBtn && !renameBtn.hasAttribute('onclick'));
+  const deleteBtn = document.querySelector('.chat-thread-item[data-thread-id="t_a"] .chat-thread-item-action.delete');
+  assert('rendered delete button uses delegated action',
+    deleteBtn && deleteBtn.getAttribute('data-chat-thread-action') === 'delete');
+  assert('rendered delete button has no inline onclick',
+    deleteBtn && !deleteBtn.hasAttribute('onclick'));
+
+  window.saveChatHistory = async () => {};
+  window.loadChatHistory = async () => {};
+  window.cleanupDiscussionState = () => {};
+  window.restoreDiscussionContinuePrompt = () => {};
+  st.currentThreadId = 't_b';
+  threadItem.click();
+  assert('delegated thread item click switches active thread',
+    await waitFor(() => st.currentThreadId === 't_a'));
+  window.showPromptDialog = async () => 'Renamed Thread';
+  document.querySelector('.chat-thread-item[data-thread-id="t_a"] .chat-thread-item-action')?.click();
+  assert('delegated rename button renames thread',
+    await waitFor(() => st.chatThreads.find(t => t.id === 't_a')?.name === 'Renamed Thread'));
+  st.chatThreads.find(t => t.id === 't_a').name = 'Thyroid Panel Discussion';
+  window.renderThreadList();
+
   window.filterThreadList('thyroid');
   const filteredItems = document.querySelectorAll('.chat-thread-item');
   assert('search filter shows 1 result', filteredItems.length === 1, 'Expected 1 got ' + filteredItems.length);
@@ -87,6 +131,11 @@ return (async function() {
   // ═══════════════════════════════════════════════
   st.chatThreads = origThreads;
   st.currentThreadId = origThreadId;
+  window.saveChatHistory = origSaveChatHistory;
+  window.loadChatHistory = origLoadChatHistory;
+  window.cleanupDiscussionState = origCleanupDiscussionState;
+  window.restoreDiscussionContinuePrompt = origRestoreDiscussionContinuePrompt;
+  window.showPromptDialog = origShowPromptDialog;
   if (origThreads.length > 0) window.saveChatThreadIndex();
   else localStorage.removeItem(window.getChatThreadsKey());
 

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -61,6 +61,7 @@ const threadFns = [
   'renameThread', 'renameThreadPrompt',
   'autoNameThread', 'pruneOldThreads',
   'renderThreadList', 'filterThreadList',
+  'installChatThreadDelegates',
   'toggleThreadRail'
 ];
 for (const fn of threadFns) {
@@ -292,6 +293,7 @@ assert('loadProfile rerenders chat rail after profile switch', profileSrc.includ
 console.log('16. Thread Search Extraction (source inspection)');
 const chatThreadsSrc = read('js/chat-threads.js');
 const chatThreadSearchSrc = read('js/chat-thread-search.js');
+const inlineHandlerRe = /\bon(?:click|change|input|search|keydown|keyup|submit)=/;
 assert('chat-threads imports search module',
   chatThreadsSrc.includes("from './chat-thread-search.js'"));
 assert('chat-threads configures search callbacks',
@@ -311,6 +313,15 @@ assert('chat-thread-search uses overflow sentinel before truncation banner',
   chatThreadSearchSrc.includes('const SEARCH_RESULT_LIMIT = 30') &&
   chatThreadSearchSrc.includes('results.length > SEARCH_RESULT_LIMIT') &&
   chatThreadSearchSrc.includes('results.slice(0, SEARCH_RESULT_LIMIT)'));
+assert('chat-threads render path uses delegated thread actions',
+  !inlineHandlerRe.test(chatThreadsSrc) &&
+  chatThreadsSrc.includes('data-chat-thread-action="switch"') &&
+  chatThreadsSrc.includes('data-chat-thread-action="rename"') &&
+  chatThreadsSrc.includes('data-chat-thread-action="delete"'));
+assert('chat-threads installs an idempotent click delegate',
+  chatThreadsSrc.includes('let chatThreadDelegatesInstalled = false') &&
+  chatThreadsSrc.includes("document.addEventListener('click', handleThreadActionClick)") &&
+  chatThreadsSrc.includes('installChatThreadDelegates();'));
 
 // ═══════════════════════════════════════════════
 // 17. CSS Inspection

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.315';
+self.APP_VERSION = '1.8.316';


### PR DESCRIPTION
## Summary
- Replace `renderThreadList()` inline `onclick` handlers with `data-chat-thread-action` attributes for switch, rename, and delete actions.
- Add an idempotent `chat-threads.js` click delegate scoped to `#chat-thread-list`.
- Extend chat thread source and DOM tests to verify delegated actions, no inline handlers, click-to-switch, and click-to-rename behavior.
- Bump `version.js` for cache invalidation.

## Validation
- `node --check js/chat-threads.js`
- `node tests/test-chat-threads.js`
- Focused Puppeteer run of `tests/test-chat-threads-dom.js`
- `npm test`
- `git diff --check`
- `./run-tests.sh`