### PR TITLE
[codex] Delegate sidebar nav actions

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -87,7 +87,7 @@ function handleNavActionClick(event) {
 function handleNavInput(event) {
   const target = event.target instanceof Element ? event.target : null;
   if (!target || !_navActionScope(target)) return;
-  if (target.getAttribute('data-nav-input-action') === 'filter-sidebar') {
+  if (target.dataset.navInputAction === 'filter-sidebar') {
     filterSidebar();
   }
 }

--- a/js/nav.js
+++ b/js/nav.js
@@ -26,16 +26,84 @@ function _iconSvg(name) {
   return icons[name] || escapeHTML(String(name || ''));
 }
 
-// Render a compact sidebar entry for modules whose visibility depends on data.
-function _renderConditionalNavItem({ key, icon, label, navigate = 'dashboard', badge }) {
-  let onclick;
-  if (navigate.startsWith('fn:')) {
-    onclick = navigate.slice(3); // raw JS fragment
+let navDelegatesInstalled = false;
+
+function _navActionAttrs(action, attrs = {}) {
+  const extraAttrs = Object.entries(attrs)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([name, value]) => ` data-nav-${name}="${escapeAttr(String(value))}"`)
+    .join('');
+  return `data-nav-action="${escapeAttr(action)}"${extraAttrs}`;
+}
+
+function _navNavigateAttrs(route) {
+  return _navActionAttrs('navigate', { route });
+}
+
+function _navActionScope(el) {
+  return !!el.closest('#sidebar-nav, #profile-selector');
+}
+
+function _findGroupHeader(groupName) {
+  return Array.from(document.querySelectorAll('.sidebar-group-header'))
+    .find(el => el.dataset.groupName === groupName) || null;
+}
+
+function _findGroupItems(groupName) {
+  return Array.from(document.querySelectorAll('.sidebar-group-items'))
+    .find(el => el.dataset.groupItems === groupName) || null;
+}
+
+function handleNavActionClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  const actionEl = target?.closest('[data-nav-action]');
+  if (!actionEl || !_navActionScope(actionEl)) return;
+
+  const action = actionEl.dataset.navAction;
+  let handled = true;
+  if (action === 'navigate') {
+    window.navigate?.(actionEl.dataset.navRoute || actionEl.dataset.category || 'dashboard');
+  } else if (action === 'open-emf-assessment') {
+    window.openEMFAssessmentEditor?.();
+  } else if (action === 'open-light-assessment') {
+    window.openLightEnvironmentAssessment?.();
+  } else if (action === 'open-knowledge-base') {
+    window.openKnowledgeBaseModal?.();
+  } else if (action === 'open-custom-marker') {
+    window.openCreateMarkerModal?.();
+  } else if (action === 'toggle-group') {
+    toggleNavGroup(actionEl.dataset.navGroup || '');
+  } else if (action === 'toggle-group-ai') {
+    toggleGroupAIContext(actionEl.dataset.navGroup || '');
+  } else if (action === 'open-client-list') {
+    window.openClientList?.();
   } else {
-    onclick = `window.navigate('${navigate}')`;
+    handled = false;
   }
+
+  if (handled) event.preventDefault();
+}
+
+function handleNavInput(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target || !_navActionScope(target)) return;
+  if (target.getAttribute('data-nav-input-action') === 'filter-sidebar') {
+    filterSidebar();
+  }
+}
+
+export function installNavActionDelegates() {
+  if (navDelegatesInstalled || typeof document === 'undefined') return;
+  navDelegatesInstalled = true;
+  document.addEventListener('click', handleNavActionClick);
+  document.addEventListener('input', handleNavInput);
+}
+
+// Render a compact sidebar entry for modules whose visibility depends on data.
+function _renderConditionalNavItem({ key, icon, label, route = 'dashboard', action = 'navigate', badge }) {
   const badgeHtml = badge ? `<span class="nav-item-count nav-count">${escapeHTML(String(badge))}</span>` : '<span class="nav-item-dot"></span>';
-  return `<div class="nav-item" data-category="${key}" tabindex="0" role="button" onclick="${onclick}" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
+  const actionAttrs = action === 'navigate' ? _navNavigateAttrs(route) : _navActionAttrs(action);
+  return `<div class="nav-item" data-category="${escapeAttr(key)}" tabindex="0" role="button" ${actionAttrs}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg(icon)}</span>
     <span class="nav-item-label">${escapeHTML(label)}</span>
     ${badgeHtml}</div>`;
@@ -70,13 +138,14 @@ function _buildNavItem(key, cat) {
   if (cat.group && label.startsWith(cat.group + ': ')) {
     label = label.slice(cat.group.length + 2);
   }
-  return { withData, flagged, html: `<div class="nav-item" data-category="${key}" data-markers="${escapeHTML(markerNames)}" data-group="${escapeHTML(cat.group || '')}" tabindex="0" role="button" onclick="window.navigate('${key}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('${key}')}">
+  return { withData, flagged, html: `<div class="nav-item" data-category="${escapeAttr(key)}" data-markers="${escapeAttr(markerNames)}" data-group="${escapeAttr(cat.group || '')}" tabindex="0" role="button" ${_navNavigateAttrs(key)}>
       <span class="nav-item-dot" aria-hidden="true"></span>
       <span class="nav-item-label">${escapeHTML(label)}</span>
       ${flagHtml}</div>` };
 }
 
 export function buildSidebar(data) {
+  installNavActionDelegates();
   if (!data) data = getActiveData();
   data = filterDatesByRange(data);
   const nav = document.getElementById("sidebar-nav");
@@ -91,15 +160,15 @@ export function buildSidebar(data) {
   })();
   let html = `<div class="sidebar-search-wrap">
     <span class="sidebar-search-icon" aria-hidden="true">${_iconSvg('search')}</span>
-    <input type="text" class="sidebar-search" id="sidebar-search" placeholder="Search markers..." oninput="filterSidebar()">
+    <input type="text" class="sidebar-search" id="sidebar-search" placeholder="Search markers..." data-nav-input-action="filter-sidebar">
   </div>`;
   html += `<div class="nav-section">Home</div>`;
-  html += `<div class="nav-item active is-active" data-category="dashboard" tabindex="0" role="button" onclick="window.navigate('dashboard')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('dashboard')}">
+  html += `<div class="nav-item active is-active" data-category="dashboard" tabindex="0" role="button" ${_navNavigateAttrs('dashboard')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('dashboard')}</span>
     <span class="nav-item-label">Dashboard</span>
     <span class="nav-item-count">${counts}</span></div>`;
   html += `<div class="nav-section">Lenses</div>`;
-  html += `<div class="nav-item" data-category="labs" tabindex="0" role="button" onclick="window.navigate('labs')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('labs')}">
+  html += `<div class="nav-item" data-category="labs" tabindex="0" role="button" ${_navNavigateAttrs('labs')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('labs')}</span>
     <span class="nav-item-label">Labs</span>
     <span class="nav-item-count">${counts}</span></div>`;
@@ -114,14 +183,14 @@ export function buildSidebar(data) {
     if (genetics.snps && Object.keys(genetics.snps).length > 0) gParts.push(Object.keys(genetics.snps).length);
     if (genetics.mtdna) gParts.push(genetics.mtdna.haplogroup);
   }
-  html += `<div class="nav-item" data-category="genome" tabindex="0" role="button" onclick="window.navigate('genome')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('genome')}">
+  html += `<div class="nav-item" data-category="genome" tabindex="0" role="button" ${_navNavigateAttrs('genome')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('genome')}</span>
     <span class="nav-item-label">Genome</span>
     ${gParts.length ? `<span class="nav-item-count">${escapeHTML(gParts.join(' '))}</span>` : '<span class="nav-item-dot"></span>'}</div>`;
 
   const wearableConn = state.importedData?.wearableConnections || {};
   const wearableCount = Object.keys(wearableConn).length;
-  html += `<div class="nav-item" data-category="body" tabindex="0" role="button" onclick="window.navigate('body')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('body')}">
+  html += `<div class="nav-item" data-category="body" tabindex="0" role="button" ${_navNavigateAttrs('body')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('body')}</span>
     <span class="nav-item-label">Body</span>
     ${wearableCount ? `<span class="nav-item-count">${wearableCount}</span>` : '<span class="nav-item-dot"></span>'}</div>`;
@@ -136,21 +205,21 @@ export function buildSidebar(data) {
     key: 'light',
     icon: 'light',
     label: 'Light',
-    navigate: 'light',
+    route: 'light',
     badge: weekCount > 0 ? (weekCount > 9 ? '9+' : weekCount) : null,
   });
 
-  html += `<div class="nav-item" data-category="insight" tabindex="0" role="button" onclick="window.navigate('insight')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('insight')}">
+  html += `<div class="nav-item" data-category="insight" tabindex="0" role="button" ${_navNavigateAttrs('insight')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('insight')}</span>
     <span class="nav-item-label">Insight</span>
     <span class="nav-item-dot"></span></div>`;
-  html += `<div class="nav-item" data-category="recommendations" tabindex="0" role="button" onclick="window.navigate('recommendations')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('recommendations')}">
+  html += `<div class="nav-item" data-category="recommendations" tabindex="0" role="button" ${_navNavigateAttrs('recommendations')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('recommendations')}</span><span class="nav-item-label">Recommendations</span><span class="nav-item-dot"></span></div>`;
 
   html += `<div class="nav-section">Analysis tools</div>`;
-  html += `<div class="nav-item" data-category="compare" tabindex="0" role="button" onclick="window.navigate('compare')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('compare')}">
+  html += `<div class="nav-item" data-category="compare" tabindex="0" role="button" ${_navNavigateAttrs('compare')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('compare')}</span><span class="nav-item-label">Compare dates</span><span class="nav-item-dot"></span></div>`;
-  html += `<div class="nav-item" data-category="correlations" tabindex="0" role="button" onclick="window.navigate('correlations')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.navigate('correlations')}">
+  html += `<div class="nav-item" data-category="correlations" tabindex="0" role="button" ${_navNavigateAttrs('correlations')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('correlations')}</span><span class="nav-item-label">Correlations</span><span class="nav-item-dot"></span></div>`;
   const emfAssessments = state.importedData?.emfAssessment?.assessments;
   const emfAssessmentCount = Array.isArray(emfAssessments) ? emfAssessments.length : 0;
@@ -158,7 +227,7 @@ export function buildSidebar(data) {
     key: 'emf',
     icon: 'emf',
     label: 'EMF assessment',
-    navigate: 'fn:window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()',
+    action: 'open-emf-assessment',
     badge: emfAssessmentCount > 0 ? emfAssessmentCount : null,
   });
   const lightRoomCount = Array.isArray(state.importedData?.lightEnvironment?.rooms) ? state.importedData.lightEnvironment.rooms.length : 0;
@@ -167,14 +236,14 @@ export function buildSidebar(data) {
     key: 'light-env-assessment',
     icon: 'light',
     label: 'Light assessment',
-    navigate: 'fn:window.openLightEnvironmentAssessment&&window.openLightEnvironmentAssessment()',
+    action: 'open-light-assessment',
     badge: lightRoomCount > 0 && lightAuditCount > 0 ? lightAuditCount : null,
   });
 
   html += `<div class="nav-section">Manage</div>`;
-  html += `<div class="nav-item" data-category="knowledge" tabindex="0" role="button" onclick="window.openKnowledgeBaseModal&&window.openKnowledgeBaseModal()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
+  html += `<div class="nav-item" data-category="knowledge" tabindex="0" role="button" ${_navActionAttrs('open-knowledge-base')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('knowledge')}</span><span class="nav-item-label">Knowledge Base</span><span class="nav-item-dot"></span></div>`;
-  html += `<div class="nav-item" data-category="custom-markers" tabindex="0" role="button" onclick="window.openCreateMarkerModal&&window.openCreateMarkerModal()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
+  html += `<div class="nav-item" data-category="custom-markers" tabindex="0" role="button" ${_navActionAttrs('open-custom-marker')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('plus')}</span><span class="nav-item-label">Custom markers</span><span class="nav-item-dot"></span></div>`;
 
   // Separate categories into blood work (no group) and specialty groups
@@ -195,7 +264,7 @@ export function buildSidebar(data) {
   // Lab category shortcuts stay in the sidebar because they are the fastest
   // way to jump into a biomarker table, but the Labs lens itself is the
   // all-biomarker entry point.
-  html += `<div class="nav-section sidebar-title">Lab categories <button class="sidebar-add-marker" onclick="event.stopPropagation();openCreateMarkerModal()" title="Create custom biomarker">+</button></div>`;
+  html += `<div class="nav-section sidebar-title">Lab categories <button class="sidebar-add-marker" ${_navActionAttrs('open-custom-marker')} title="Create custom biomarker">+</button></div>`;
   for (const item of bloodWork) html += item.html;
 
   // Render specialty groups
@@ -211,15 +280,15 @@ export function buildSidebar(data) {
     // span, aria-hidden) AFTER the AI toggle — restores the original
     // [label flag] [AI] [arrow] visual order. Sighted users still see
     // the rotation cue; keyboard users use the toggle button.
-    html += `<div class="sidebar-group-header${collapsed ? ' collapsed' : ''}" data-group-name="${escapeAttr(groupName)}" onclick="toggleNavGroup('${escapeAttr(groupName)}')">
-      <button class="sidebar-group-toggle" onclick="event.stopPropagation();toggleNavGroup('${escapeAttr(groupName)}')" aria-expanded="${!collapsed}" aria-label="${escapeAttr(groupName)} group">
+    html += `<div class="sidebar-group-header${collapsed ? ' collapsed' : ''}" data-group-name="${escapeAttr(groupName)}" ${_navActionAttrs('toggle-group', { group: groupName })}>
+      <button class="sidebar-group-toggle" ${_navActionAttrs('toggle-group', { group: groupName })} aria-expanded="${!collapsed}" aria-label="${escapeAttr(groupName)} group">
         <span class="sidebar-group-label">${escapeHTML(groupName)}</span>
         ${flagHtml}
       </button>
-      <button class="sidebar-ai-toggle${aiOn ? ' active' : ''}" title="${aiOn ? 'Included in AI context' : 'Excluded from AI context — click to include'}" onclick="event.stopPropagation();toggleGroupAIContext('${escapeAttr(groupName)}')" aria-label="Toggle AI context for ${escapeHTML(groupName)}">AI</button>
+      <button class="sidebar-ai-toggle${aiOn ? ' active' : ''}" title="${aiOn ? 'Included in AI context' : 'Excluded from AI context — click to include'}" ${_navActionAttrs('toggle-group-ai', { group: groupName })} aria-label="Toggle AI context for ${escapeHTML(groupName)}">AI</button>
       <span class="sidebar-group-arrow" aria-hidden="true">\u25B8</span>
     </div>`;
-    html += `<div class="sidebar-group-items" data-group-items="${escapeHTML(groupName)}"${collapsed ? ' style="display:none"' : ''}>`;
+    html += `<div class="sidebar-group-items" data-group-items="${escapeAttr(groupName)}"${collapsed ? ' style="display:none"' : ''}>`;
     for (const item of group.items) html += item.html;
     html += `</div>`;
   }
@@ -235,7 +304,7 @@ function _getGroupCollapsed(groupName) {
 export function toggleGroupAIContext(groupName) {
   const isOn = window.isGroupInAIContext && window.isGroupInAIContext(groupName);
   window.setGroupInAIContext(groupName, !isOn);
-  const btn = document.querySelector(`.sidebar-group-header[data-group-name="${groupName}"] .sidebar-ai-toggle`);
+  const btn = _findGroupHeader(groupName)?.querySelector('.sidebar-ai-toggle');
   if (btn) {
     btn.classList.toggle('active', !isOn);
     btn.title = !isOn ? 'Included in AI context' : 'Excluded from AI context — click to include';
@@ -243,8 +312,8 @@ export function toggleGroupAIContext(groupName) {
 }
 
 export function toggleNavGroup(groupName) {
-  const header = document.querySelector(`.sidebar-group-header[data-group-name="${groupName}"]`);
-  const items = document.querySelector(`.sidebar-group-items[data-group-items="${groupName}"]`);
+  const header = _findGroupHeader(groupName);
+  const items = _findGroupItems(groupName);
   if (!header || !items) return;
   const isCollapsed = header.classList.toggle('collapsed');
   items.style.display = isCollapsed ? 'none' : '';
@@ -271,6 +340,7 @@ export function filterSidebar() {
       const collapsed = _getGroupCollapsed(gn);
       el.style.display = '';
       el.classList.toggle('collapsed', collapsed);
+      el.querySelector('.sidebar-group-toggle')?.setAttribute('aria-expanded', String(!collapsed));
     });
     groupItemContainers.forEach(el => {
       const gn = el.dataset.groupItems;
@@ -291,10 +361,14 @@ export function filterSidebar() {
   groupItemContainers.forEach(el => {
     const gn = el.dataset.groupItems;
     const visibleItems = el.querySelectorAll('.nav-item:not([style*="display: none"])');
-    const header = document.querySelector(`.sidebar-group-header[data-group-name="${gn}"]`);
+    const header = _findGroupHeader(gn);
     if (visibleItems.length > 0) {
       el.style.display = '';
-      if (header) { header.style.display = ''; header.classList.remove('collapsed'); }
+      if (header) {
+        header.style.display = '';
+        header.classList.remove('collapsed');
+        header.querySelector('.sidebar-group-toggle')?.setAttribute('aria-expanded', 'true');
+      }
     } else {
       el.style.display = 'none';
       if (header) header.style.display = 'none';
@@ -311,6 +385,7 @@ export function getAvatarColor(id) {
 }
 
 export function renderProfileButton() {
+  installNavActionDelegates();
   const container = document.getElementById('profile-selector');
   if (!container) return;
   const profiles = getProfiles();
@@ -319,7 +394,7 @@ export function renderProfileButton() {
   const dot = active.avatar
     ? `<img class="profile-compact-dot profile-compact-img" src="${escapeAttr(active.avatar)}" alt="">`
     : `<span class="profile-compact-dot" style="background:${getAvatarColor(active.id)}">${escapeHTML((active.name || '?')[0].toUpperCase())}</span>`;
-  container.innerHTML = `<button class="profile-compact-btn" onclick="openClientList()" title="Manage clients">
+  container.innerHTML = `<button class="profile-compact-btn" ${_navActionAttrs('open-client-list')} title="Manage clients">
     ${dot}
     <span class="profile-compact-name">${escapeHTML(active.name)}</span>
     <span class="profile-compact-arrow">\u25BC</span>
@@ -351,4 +426,4 @@ export function closeMobileSidebar() {
   document.body.style.overflow = '';
 }
 
-Object.assign(window, { buildSidebar, filterSidebar, toggleNavGroup, toggleGroupAIContext, renderProfileDropdown, renderProfileButton, getAvatarColor, syncSidebarActive, toggleMobileSidebar, closeMobileSidebar, openRecommendationsFromSidebar });
+Object.assign(window, { buildSidebar, filterSidebar, toggleNavGroup, toggleGroupAIContext, renderProfileDropdown, renderProfileButton, getAvatarColor, syncSidebarActive, toggleMobileSidebar, closeMobileSidebar, openRecommendationsFromSidebar, installNavActionDelegates });

--- a/run-tests.js
+++ b/run-tests.js
@@ -45,6 +45,7 @@ const TEST_FILES = [
   // to Vitest (batch 22). The section-3b functional safeMarkerId-guard probes
   // (need live DOM + populated state) live in test-audit-dom.js below.
   'tests/test-audit-dom.js',
+  'tests/test-nav-delegated-actions-dom.js',
   // test-image-utils.js source-inspection + module-export checks ported to
   // Vitest (PR for batch 19). DOM-runtime assertions (sections 6 + 7) live
   // in test-image-utils-dom.js below.

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -167,6 +167,7 @@ const LEGACY_TESTS = [
   './test-tour.js',
   './test-settings-delegated-actions.js',
   './test-shell-delegated-actions.js',
+  './test-nav-delegated-actions.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',
   // Batch 32 — test-wearables (~549 asserts: registry, IDB CRUD via

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -651,12 +651,18 @@ assert('Skip link targets #main-content', indexSrc.includes('href="#main-content
 assert('Skip link CSS', cssSrc.includes('.skip-link'));
 
 const navSrc = read('js/nav.js');
+const appEventsSrc = read('js/app-event-listeners.js');
 assert('Nav items have tabindex', navSrc.includes('tabindex="0"'));
 assert('Nav items have role=button', navSrc.includes('role="button"'));
-assert('Nav items have keyboard handler', navSrc.includes('onkeydown'));
+assert('Nav items use delegated actions instead of inline handlers',
+  navSrc.includes('data-nav-action') &&
+    navSrc.includes('installNavActionDelegates') &&
+    !/\bon(?:click|input|keydown)=/.test(navSrc));
+assert('Nav role-button keyboard activation remains delegated globally',
+  appEventsSrc.includes('function handleRoleButtonKeydown') &&
+    appEventsSrc.includes('t.click()'));
 assert('Category labels escaped in sidebar', navSrc.includes('escapeHTML(label)') || navSrc.includes('escapeHTML(cat.label)'));
 
-const appEventsSrc = read('js/app-event-listeners.js');
 assert('Focus trap for modals', appEventsSrc.includes('e.key === "Tab"') && appEventsSrc.includes('focusable'));
 
 // ═══════════════════════════════════════

--- a/tests/test-nav-delegated-actions-dom.js
+++ b/tests/test-nav-delegated-actions-dom.js
@@ -1,0 +1,149 @@
+// test-nav-delegated-actions-dom.js — live sidebar delegate coverage.
+//
+// Run: fetch('tests/test-nav-delegated-actions-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Sidebar Nav Delegated Actions DOM ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const stateModule = await import('./js/state.js');
+  const st = stateModule.state;
+  const origDateRangeFilter = st.dateRangeFilter;
+  const origCurrentView = st.currentView;
+  const origProfiles = st.profiles;
+  const origNavigate = window.navigate;
+  const origOpenEMF = window.openEMFAssessmentEditor;
+  const origOpenLightEnv = window.openLightEnvironmentAssessment;
+  const origOpenKB = window.openKnowledgeBaseModal;
+  const origOpenCreateMarker = window.openCreateMarkerModal;
+  const origOpenClientList = window.openClientList;
+  const origIsGroupInAI = window.isGroupInAIContext;
+  const origSetGroupInAI = window.setGroupInAIContext;
+  const origGroupStorage = localStorage.getItem('labcharts-navgroup-Hormones');
+
+  try {
+    const fixtureData = {
+      dates: ['2026-05-15'],
+      dateLabels: ['May 15'],
+      categories: {
+        metabolic: {
+          label: 'Metabolic',
+          markers: {
+            glucose: { name: 'Glucose', values: [5.1], refMin: 3.5, refMax: 6.0, unit: 'mmol/L' }
+          }
+        },
+        thyroid: {
+          label: 'Hormones: Thyroid',
+          group: 'Hormones',
+          markers: {
+            tsh: { name: 'TSH', values: [2.1], refMin: 0.4, refMax: 4.0, unit: 'mIU/L' }
+          }
+        }
+      }
+    };
+
+    st.dateRangeFilter = 'all';
+    st.currentView = 'dashboard';
+    st.profiles = [{ id: st.currentProfile || 'default', name: 'Demo Client' }];
+    localStorage.removeItem('labcharts-navgroup-Hormones');
+
+    const calls = [];
+    const aiGroups = new Set();
+    window.navigate = route => {
+      calls.push(['navigate', route]);
+      st.currentView = route;
+      window.syncSidebarActive?.(route);
+    };
+    window.openEMFAssessmentEditor = () => calls.push(['open-emf']);
+    window.openLightEnvironmentAssessment = () => calls.push(['open-light-env']);
+    window.openKnowledgeBaseModal = () => calls.push(['open-kb']);
+    window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
+    window.openClientList = () => calls.push(['open-client-list']);
+    window.isGroupInAIContext = group => aiGroups.has(group);
+    window.setGroupInAIContext = (group, on) => {
+      calls.push(['set-group-ai', group, on]);
+      if (on) aiGroups.add(group);
+      else aiGroups.delete(group);
+    };
+
+    window.buildSidebar(fixtureData);
+    window.renderProfileButton();
+
+    const inlineHandler = document.querySelector('#sidebar-nav [onclick], #sidebar-nav [oninput], #sidebar-nav [onkeydown], #profile-selector [onclick]');
+    assert('rendered sidebar/profile surfaces have no inline handlers', !inlineHandler, inlineHandler?.outerHTML || '');
+
+    document.querySelector('#sidebar-nav .nav-item[data-category="labs"]')?.click();
+    assert('delegated nav item click routes to labs',
+      calls.some(c => c[0] === 'navigate' && c[1] === 'labs'));
+
+    const compareItem = document.querySelector('#sidebar-nav .nav-item[data-category="compare"]');
+    compareItem?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    assert('role-button keyboard activation still routes nav items',
+      calls.some(c => c[0] === 'navigate' && c[1] === 'compare'));
+
+    const search = document.getElementById('sidebar-search');
+    if (search) {
+      search.value = 'thyroid';
+      search.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    assert('delegated search input filters non-matching lab categories',
+      document.querySelector('#sidebar-nav .nav-item[data-category="metabolic"]')?.style.display === 'none');
+    assert('delegated search input keeps matching grouped category visible',
+      document.querySelector('#sidebar-nav .nav-item[data-category="thyroid"]')?.style.display !== 'none');
+
+    const groupHeader = document.querySelector('.sidebar-group-header[data-group-name="Hormones"]');
+    groupHeader?.click();
+    assert('delegated group header click collapses group',
+      groupHeader?.classList.contains('collapsed') &&
+        document.querySelector('.sidebar-group-items[data-group-items="Hormones"]')?.style.display === 'none' &&
+        groupHeader.querySelector('.sidebar-group-toggle')?.getAttribute('aria-expanded') === 'false');
+    groupHeader?.click();
+    assert('delegated group header click expands group',
+      !groupHeader?.classList.contains('collapsed') &&
+        document.querySelector('.sidebar-group-items[data-group-items="Hormones"]')?.style.display !== 'none' &&
+        groupHeader?.querySelector('.sidebar-group-toggle')?.getAttribute('aria-expanded') === 'true');
+
+    document.querySelector('.sidebar-group-header[data-group-name="Hormones"] .sidebar-ai-toggle')?.click();
+    assert('delegated group AI toggle updates group context',
+      aiGroups.has('Hormones') &&
+        calls.some(c => c[0] === 'set-group-ai' && c[1] === 'Hormones' && c[2] === true));
+
+    document.querySelector('#sidebar-nav .nav-item[data-category="emf"]')?.click();
+    document.querySelector('#sidebar-nav .nav-item[data-category="light-env-assessment"]')?.click();
+    document.querySelector('#sidebar-nav .nav-item[data-category="knowledge"]')?.click();
+    document.querySelector('#sidebar-nav .nav-item[data-category="custom-markers"]')?.click();
+    document.querySelector('#sidebar-nav .sidebar-add-marker')?.click();
+    document.querySelector('#profile-selector .profile-compact-btn')?.click();
+    assert('delegated utility actions call their handlers',
+      calls.some(c => c[0] === 'open-emf') &&
+        calls.some(c => c[0] === 'open-light-env') &&
+        calls.some(c => c[0] === 'open-kb') &&
+        calls.filter(c => c[0] === 'open-custom-marker').length >= 2 &&
+        calls.some(c => c[0] === 'open-client-list'));
+  } finally {
+    st.dateRangeFilter = origDateRangeFilter;
+    st.currentView = origCurrentView;
+    st.profiles = origProfiles;
+    window.navigate = origNavigate;
+    window.openEMFAssessmentEditor = origOpenEMF;
+    window.openLightEnvironmentAssessment = origOpenLightEnv;
+    window.openKnowledgeBaseModal = origOpenKB;
+    window.openCreateMarkerModal = origOpenCreateMarker;
+    window.openClientList = origOpenClientList;
+    window.isGroupInAIContext = origIsGroupInAI;
+    window.setGroupInAIContext = origSetGroupInAI;
+    if (origGroupStorage == null) localStorage.removeItem('labcharts-navgroup-Hormones');
+    else localStorage.setItem('labcharts-navgroup-Hormones', origGroupStorage);
+    window.buildSidebar?.();
+    window.renderProfileButton?.();
+  }
+
+  console.log(`\n%c Sidebar Nav Delegated Actions DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-nav-delegated-actions-dom'] = { pass, fail };
+})();

--- a/tests/test-nav-delegated-actions.js
+++ b/tests/test-nav-delegated-actions.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Static sidebar nav delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const navSrc = fs.readFileSync(path.join(root, 'js/nav.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Sidebar Nav Delegated Actions ===');
+
+assert('nav.js renders no inline event attributes',
+  !/\bon(?:click|change|input|search|keydown|keyup|submit)=/.test(navSrc));
+assert('nav.js renders delegated click actions',
+  navSrc.includes('data-nav-action=') &&
+    navSrc.includes("_navActionAttrs('navigate'") &&
+    navSrc.includes("_navActionAttrs('toggle-group'") &&
+    navSrc.includes("_navActionAttrs('toggle-group-ai'"));
+assert('nav.js renders delegated search input action',
+  navSrc.includes('data-nav-input-action="filter-sidebar"'));
+assert('nav.js installs idempotent click and input delegates',
+  navSrc.includes('let navDelegatesInstalled = false') &&
+    navSrc.includes("document.addEventListener('click', handleNavActionClick)") &&
+    navSrc.includes("document.addEventListener('input', handleNavInput)"));
+
+[
+  'navigate',
+  'open-emf-assessment',
+  'open-light-assessment',
+  'open-knowledge-base',
+  'open-custom-marker',
+  'toggle-group',
+  'toggle-group-ai',
+  'open-client-list',
+].forEach(action => {
+  assert(`nav action ${action} is handled`, navSrc.includes(`action === '${action}'`));
+});
+
+assert('nav delegates are scoped to sidebar/profile surfaces',
+  navSrc.includes("el.closest('#sidebar-nav, #profile-selector')"));
+assert('group lookup avoids selector interpolation',
+  navSrc.includes('function _findGroupHeader') &&
+    navSrc.includes('el.dataset.groupName === groupName'));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -235,7 +235,9 @@ globalThis.fetch = async (url, opts) => {
   assert('loadCatalog on window', typeof window.loadCatalog === 'function');
   assert('nav.js exposes recommendations sidebar helper', navSrc.includes('openRecommendationsFromSidebar'));
   const recNavMarkup = navSrc.match(/data-category="recommendations"[\s\S]{0,500}/)?.[0] || '';
-  assert('Recommendations sidebar routes to dedicated page', recNavMarkup.includes("window.navigate('recommendations')"));
+  assert('Recommendations sidebar routes to dedicated page',
+    recNavMarkup.includes("_navNavigateAttrs('recommendations')") &&
+    navSrc.includes("return _navActionAttrs('navigate', { route })"));
   assert('Recommendations sidebar item does not open Settings', !recNavMarkup.includes('openSettingsModal'));
   assert('views.js exposes dedicated Recommendations page', viewsSrc.includes('export function showRecommendations') && viewsSrc.includes('openRecommendationDetail'));
   assert('views.js delegates recommendation actions to recommendation-actions.js',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.316';
+self.APP_VERSION = '1.8.317';


### PR DESCRIPTION
## Summary
- Replace `nav.js` sidebar/profile inline event attributes with `data-nav-*` attributes and one idempotent delegated action layer.
- Preserve sidebar navigation, keyboard activation, search filtering, group expand/collapse, AI-context toggles, assessment shortcuts, custom-marker shortcuts, and profile button behavior.
- Add source and browser DOM tests covering the delegated sidebar actions and no-inline-handler rendering.
- Bump `version.js` for cache invalidation.

## Validation
- `node --check js/nav.js`
- `node tests/test-nav-delegated-actions.js`
- Focused Puppeteer run of `tests/test-nav-delegated-actions-dom.js`
- `npm test`
- `git diff --check`
- `./run-tests.sh`