### PR TITLE
[codex] Separate dashboard widget actions

### DIFF
--- a/js/dashboard-widget-controls.js
+++ b/js/dashboard-widget-controls.js
@@ -442,7 +442,6 @@ export function createDashboardWidgetControls(deps) {
   }
 
   function openDashboardWidgetPicker() {
-    installDashboardWidgetControlDelegates();
     closeDashboardWidgetPicker();
     const prefs = getDashboardWidgetPrefs();
     const hidden = getAvailableDashboardFixedWidgets().filter(def => prefs.hidden.includes(def.id));
@@ -480,7 +479,6 @@ export function createDashboardWidgetControls(deps) {
   }
 
   function openDashboardBiometricPicker() {
-    installDashboardWidgetControlDelegates();
     closeDashboardWidgetPicker();
     const prefs = getDashboardWidgetPrefs();
     const biometricOptions = getDashboardBiometricWidgetOptions(prefs);

--- a/js/dashboard-widget-controls.js
+++ b/js/dashboard-widget-controls.js
@@ -6,6 +6,7 @@ import { escapeAttr, escapeHTML, formatValue, getStatus, safeMarkerId, showNotif
 export function createDashboardWidgetControls(deps) {
   let organizeMode = false;
   let draggingWidgetId = null;
+  let dashboardWidgetDelegatesInstalled = false;
 
   const {
     state,
@@ -34,11 +35,29 @@ export function createDashboardWidgetControls(deps) {
     return organizeMode;
   }
 
+  function dashboardWidgetActionAttrs(action, attrs = {}) {
+    return [
+      `data-dashboard-widget-action="${escapeAttr(action)}"`,
+      ...Object.entries(attrs)
+        .filter(([, value]) => value !== undefined && value !== null && value !== '')
+        .map(([name, value]) => `data-dashboard-widget-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+    ].join(' ');
+  }
+
+  function dashboardWidgetInputAttrs(action) {
+    return `data-dashboard-widget-input="${escapeAttr(action)}"`;
+  }
+
+  function dashboardWidgetDragAttrs(id) {
+    const safeId = escapeAttr(id);
+    return `data-dashboard-widget-drag-id="${safeId}" data-dashboard-widget-drop-id="${safeId}"`;
+  }
+
   function renderDashboardControlButtons({ includeReset = false } = {}) {
     const organizeLabel = organizeMode ? 'Done' : 'Customize';
-    return `<button class="dashboard-action-btn" type="button" onclick="window.toggleDashboardOrganizeMode()">${organizeLabel}</button>
-      <button class="dashboard-action-btn dashboard-action-btn-primary" type="button" onclick="window.openDashboardWidgetPicker()">+ Add widget</button>
-      ${includeReset || organizeMode ? `<button type="button" class="dashboard-action-btn" onclick="window.resetDashboardWidgets()">Reset layout</button>` : ''}`;
+    return `<button class="dashboard-action-btn" type="button" ${dashboardWidgetActionAttrs('toggle-organize')}>${organizeLabel}</button>
+      <button class="dashboard-action-btn dashboard-action-btn-primary" type="button" ${dashboardWidgetActionAttrs('open-picker')}>+ Add widget</button>
+      ${includeReset || organizeMode ? `<button type="button" class="dashboard-action-btn" ${dashboardWidgetActionAttrs('reset-widgets')}>Reset layout</button>` : ''}`;
   }
 
   function renderDashboardStickyControls() {
@@ -53,13 +72,13 @@ export function createDashboardWidgetControls(deps) {
     const canMoveDown = index < visibleEntries.length - 1;
     const removeLabel = def.customMarkerWidget ? 'Remove' : 'Hide';
     const controls = organizeMode ? `<div class="dashboard-widget-tools">
-        <button type="button" class="dashboard-widget-tool" ${canMoveUp ? '' : 'disabled'} onclick="window.moveDashboardWidget('${def.id}', -1)" aria-label="Move ${escapeHTML(def.title)} up">↑</button>
-        <button type="button" class="dashboard-widget-tool" ${canMoveDown ? '' : 'disabled'} onclick="window.moveDashboardWidget('${def.id}', 1)" aria-label="Move ${escapeHTML(def.title)} down">↓</button>
-        <button type="button" class="dashboard-widget-tool" onclick="window.hideDashboardWidget('${def.id}')" aria-label="${removeLabel} ${escapeHTML(def.title)}">${removeLabel}</button>
+        <button type="button" class="dashboard-widget-tool" ${canMoveUp ? '' : 'disabled'} ${dashboardWidgetActionAttrs('move-widget', { id: def.id, direction: -1 })} aria-label="Move ${escapeHTML(def.title)} up">↑</button>
+        <button type="button" class="dashboard-widget-tool" ${canMoveDown ? '' : 'disabled'} ${dashboardWidgetActionAttrs('move-widget', { id: def.id, direction: 1 })} aria-label="Move ${escapeHTML(def.title)} down">↓</button>
+        <button type="button" class="dashboard-widget-tool" ${dashboardWidgetActionAttrs('hide-widget', { id: def.id })} aria-label="${removeLabel} ${escapeHTML(def.title)}">${removeLabel}</button>
       </div>` : '';
     return `<section class="dashboard-widget dashboard-widget-${def.size || 'full'}${organizeMode ? ' is-organizing' : ''}${body ? '' : ' is-empty'}"
         data-widget-id="${escapeAttr(def.id)}"
-        ${organizeMode ? `draggable="true" ondragstart="window.startDashboardWidgetDrag(event, '${def.id}')" ondragover="window.allowDashboardWidgetDrop(event)" ondrop="window.dropDashboardWidget(event, '${def.id}')"` : ''}>
+        ${organizeMode ? `draggable="true" ${dashboardWidgetDragAttrs(def.id)}` : ''}>
       <div class="dashboard-widget-chrome">
         <div class="dashboard-widget-handle" aria-hidden="true">⋮⋮</div>
         <div class="dashboard-widget-heading">
@@ -150,7 +169,7 @@ export function createDashboardWidgetControls(deps) {
 
   function renderDashboardMarkerWidgetOption(option) {
     const searchText = `${option.name} ${option.category} ${option.value} ${option.unit}`.toLowerCase();
-    return `<button type="button" class="dashboard-widget-picker-card dashboard-marker-widget-option" data-marker-search="${escapeAttr(searchText)}" onclick="window.addDashboardMarkerWidget('${option.id}')">
+    return `<button type="button" class="dashboard-widget-picker-card dashboard-marker-widget-option" data-marker-search="${escapeAttr(searchText)}" ${dashboardWidgetActionAttrs('add-marker-widget', { id: option.id })}>
       <span class="dashboard-widget-picker-title">${escapeHTML(option.name)}</span>
       <span class="dashboard-widget-picker-sub">${escapeHTML(option.category)} · ${escapeHTML(option.value)}${option.unit ? ` ${escapeHTML(option.unit)}` : ''}</span>
       <span class="dashboard-widget-picker-action">Add marker widget</span>
@@ -159,7 +178,7 @@ export function createDashboardWidgetControls(deps) {
 
   function renderDashboardBiometricWidgetOption(option) {
     const searchText = `${option.label} ${option.sub} ${option.value} ${option.unit} ${option.change}`.toLowerCase();
-    return `<button type="button" class="dashboard-widget-picker-card dashboard-biometric-widget-option" data-biometric-search="${escapeAttr(searchText)}" onclick="window.addDashboardBiometricMetric('${option.id}')">
+    return `<button type="button" class="dashboard-widget-picker-card dashboard-biometric-widget-option" data-biometric-search="${escapeAttr(searchText)}" ${dashboardWidgetActionAttrs('add-biometric-metric', { id: option.id })}>
       <span class="dashboard-widget-picker-title">${escapeHTML(option.label)}${option.sub ? ` <small>${escapeHTML(option.sub)}</small>` : ''}</span>
       <span class="dashboard-widget-picker-sub">${escapeHTML(option.value)}${option.unit ? ` ${escapeHTML(option.unit)}` : ''} · ${escapeHTML(option.change || 'latest')}</span>
       <span class="dashboard-widget-picker-action">Add to Biometrics Overview</span>
@@ -182,7 +201,7 @@ export function createDashboardWidgetControls(deps) {
       .filter(source => groups.has(source))
       .map(source => `<div class="dashboard-widget-picker-source">
         <div class="dashboard-widget-picker-label">${escapeHTML(source)}</div>
-        <div class="dashboard-widget-picker-grid">${groups.get(source).map(def => `<button type="button" class="dashboard-widget-picker-card" onclick="window.showDashboardWidget('${def.id}')">
+        <div class="dashboard-widget-picker-grid">${groups.get(source).map(def => `<button type="button" class="dashboard-widget-picker-card" ${dashboardWidgetActionAttrs('show-widget', { id: def.id })}>
           <span class="dashboard-widget-picker-title">${escapeHTML(def.title)}</span>
           <span class="dashboard-widget-picker-sub">${escapeHTML(def.description || '')}</span>
           <span class="dashboard-widget-picker-action">Add dashboard widget</span>
@@ -201,6 +220,99 @@ export function createDashboardWidgetControls(deps) {
     });
     const empty = document.getElementById(emptyId);
     if (empty) empty.hidden = visible > 0;
+  }
+
+  function handleDashboardWidgetAction(actionEl) {
+    const action = actionEl.dataset.dashboardWidgetAction || '';
+    const id = actionEl.dataset.dashboardWidgetId || '';
+    if (action === 'toggle-organize') {
+      toggleDashboardOrganizeMode();
+    } else if (action === 'open-picker') {
+      openDashboardWidgetPicker();
+    } else if (action === 'reset-widgets') {
+      resetDashboardWidgets();
+    } else if (action === 'move-widget') {
+      moveDashboardWidget(id, Number(actionEl.dataset.dashboardWidgetDirection || 0));
+    } else if (action === 'hide-widget') {
+      hideDashboardWidget(id);
+    } else if (action === 'show-widget') {
+      showDashboardWidget(id);
+    } else if (action === 'add-marker-widget') {
+      addDashboardMarkerWidget(id);
+    } else if (action === 'add-biometric-metric') {
+      addDashboardBiometricMetric(id);
+    } else if (action === 'close-picker') {
+      closeDashboardWidgetPicker();
+    } else if (action === 'customize-layout') {
+      toggleDashboardOrganizeMode(true);
+      closeDashboardWidgetPicker();
+    } else if (action === 'reset-layout') {
+      resetDashboardWidgets();
+      closeDashboardWidgetPicker();
+    } else if (action === 'connect-source') {
+      window.openSettingsModal?.('wearables');
+      closeDashboardWidgetPicker();
+    }
+  }
+
+  function handleDashboardWidgetClick(event) {
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+    const overlay = target.closest('#dashboard-widget-picker-overlay[data-dashboard-widget-overlay]');
+    if (overlay && target === overlay) {
+      closeDashboardWidgetPicker();
+      return;
+    }
+    const actionEl = target.closest('[data-dashboard-widget-action]');
+    if (!actionEl) return;
+    event.preventDefault();
+    handleDashboardWidgetAction(actionEl);
+  }
+
+  function handleDashboardWidgetInput(event) {
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+    const input = target.closest('[data-dashboard-widget-input]');
+    if (!input) return;
+    const action = input.dataset.dashboardWidgetInput || '';
+    if (action === 'filter-marker-picker') {
+      filterDashboardMarkerWidgetPicker(input.value);
+    } else if (action === 'filter-biometric-picker') {
+      filterDashboardBiometricWidgetPicker(input.value);
+    }
+  }
+
+  function handleDashboardWidgetDragStart(event) {
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+    const dragEl = target.closest('[data-dashboard-widget-drag-id]');
+    if (!dragEl) return;
+    startDashboardWidgetDrag(event, dragEl.dataset.dashboardWidgetDragId || '', dragEl);
+  }
+
+  function handleDashboardWidgetDragOver(event) {
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+    if (!target.closest('[data-dashboard-widget-drop-id]')) return;
+    allowDashboardWidgetDrop(event);
+  }
+
+  function handleDashboardWidgetDrop(event) {
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+    const dropEl = target.closest('[data-dashboard-widget-drop-id]');
+    if (!dropEl) return;
+    dropDashboardWidget(event, dropEl.dataset.dashboardWidgetDropId || '');
+  }
+
+  function installDashboardWidgetControlDelegates() {
+    if (dashboardWidgetDelegatesInstalled || typeof document === 'undefined') return;
+    dashboardWidgetDelegatesInstalled = true;
+    document.addEventListener('click', handleDashboardWidgetClick);
+    document.addEventListener('input', handleDashboardWidgetInput);
+    document.addEventListener('dragstart', handleDashboardWidgetDragStart);
+    document.addEventListener('dragover', handleDashboardWidgetDragOver);
+    document.addEventListener('drop', handleDashboardWidgetDrop);
   }
 
   function toggleDashboardOrganizeMode(force) {
@@ -330,6 +442,7 @@ export function createDashboardWidgetControls(deps) {
   }
 
   function openDashboardWidgetPicker() {
+    installDashboardWidgetControlDelegates();
     closeDashboardWidgetPicker();
     const prefs = getDashboardWidgetPrefs();
     const hidden = getAvailableDashboardFixedWidgets().filter(def => prefs.hidden.includes(def.id));
@@ -338,9 +451,9 @@ export function createDashboardWidgetControls(deps) {
     const biometricList = biometricOptions.length ? biometricOptions.map(renderDashboardBiometricWidgetOption).join('') : '';
     const markerOptions = getDashboardMarkerWidgetOptions(getActiveData(), prefs);
     const markerList = markerOptions.length ? markerOptions.map(renderDashboardMarkerWidgetOption).join('') : '';
-    document.body.insertAdjacentHTML('beforeend', `<div class="modal-overlay show" id="dashboard-widget-picker-overlay" onclick="if(event.target===this)window.closeDashboardWidgetPicker()">
+    document.body.insertAdjacentHTML('beforeend', `<div class="modal-overlay show" id="dashboard-widget-picker-overlay" data-dashboard-widget-overlay>
       <div class="modal show dashboard-widget-picker" role="dialog" aria-modal="true" aria-labelledby="dashboard-widget-picker-title">
-        <button class="modal-close" aria-label="Close" onclick="window.closeDashboardWidgetPicker()">&times;</button>
+        <button class="modal-close" aria-label="Close" ${dashboardWidgetActionAttrs('close-picker')}>&times;</button>
         <h3 id="dashboard-widget-picker-title">Add dashboard widget</h3>
         <div class="dashboard-widget-picker-section">
           <div class="dashboard-widget-picker-label">Lens and tool widgets</div>
@@ -348,41 +461,42 @@ export function createDashboardWidgetControls(deps) {
         </div>
         <div class="dashboard-widget-picker-section">
           <label class="dashboard-widget-picker-label" for="dashboard-biometric-widget-search">Body / Biometrics Overview metrics</label>
-          <input id="dashboard-biometric-widget-search" class="dashboard-widget-picker-search" type="search" placeholder="Search biometrics to add" oninput="window.filterDashboardBiometricWidgetPicker(this.value)">
+          <input id="dashboard-biometric-widget-search" class="dashboard-widget-picker-search" type="search" placeholder="Search biometrics to add" ${dashboardWidgetInputAttrs('filter-biometric-picker')}>
           <div class="dashboard-widget-picker-grid dashboard-biometric-widget-grid">${biometricList}</div>
           <div class="dashboard-widget-picker-empty" id="dashboard-biometric-widget-empty" ${biometricOptions.length ? 'hidden' : ''}>All available biometrics are already in the overview.</div>
         </div>
         <div class="dashboard-widget-picker-section">
           <label class="dashboard-widget-picker-label" for="dashboard-marker-widget-search">Labs / Single marker widgets</label>
-          <input id="dashboard-marker-widget-search" class="dashboard-widget-picker-search" type="search" placeholder="Search markers" oninput="window.filterDashboardMarkerWidgetPicker(this.value)">
+          <input id="dashboard-marker-widget-search" class="dashboard-widget-picker-search" type="search" placeholder="Search markers" ${dashboardWidgetInputAttrs('filter-marker-picker')}>
           <div class="dashboard-widget-picker-grid dashboard-marker-widget-grid">${markerList}</div>
           <div class="dashboard-widget-picker-empty" id="dashboard-marker-widget-empty" ${markerOptions.length ? 'hidden' : ''}>No available markers to add.</div>
         </div>
         <div class="dashboard-widget-picker-actions">
-          <button type="button" class="dashboard-action-btn" onclick="window.toggleDashboardOrganizeMode(true);window.closeDashboardWidgetPicker()">Customize layout</button>
-          <button type="button" class="dashboard-action-btn" onclick="window.resetDashboardWidgets();window.closeDashboardWidgetPicker()">Reset layout</button>
+          <button type="button" class="dashboard-action-btn" ${dashboardWidgetActionAttrs('customize-layout')}>Customize layout</button>
+          <button type="button" class="dashboard-action-btn" ${dashboardWidgetActionAttrs('reset-layout')}>Reset layout</button>
         </div>
       </div>
     </div>`);
   }
 
   function openDashboardBiometricPicker() {
+    installDashboardWidgetControlDelegates();
     closeDashboardWidgetPicker();
     const prefs = getDashboardWidgetPrefs();
     const biometricOptions = getDashboardBiometricWidgetOptions(prefs);
     const biometricList = biometricOptions.length ? biometricOptions.map(renderDashboardBiometricWidgetOption).join('') : '';
-    document.body.insertAdjacentHTML('beforeend', `<div class="modal-overlay show" id="dashboard-widget-picker-overlay" onclick="if(event.target===this)window.closeDashboardWidgetPicker()">
+    document.body.insertAdjacentHTML('beforeend', `<div class="modal-overlay show" id="dashboard-widget-picker-overlay" data-dashboard-widget-overlay>
       <div class="modal show dashboard-widget-picker dashboard-biometric-picker" role="dialog" aria-modal="true" aria-labelledby="dashboard-biometric-picker-title">
-        <button class="modal-close" aria-label="Close" onclick="window.closeDashboardWidgetPicker()">&times;</button>
+        <button class="modal-close" aria-label="Close" ${dashboardWidgetActionAttrs('close-picker')}>&times;</button>
         <h3 id="dashboard-biometric-picker-title">Add biometric metrics</h3>
         <div class="dashboard-widget-picker-section">
           <label class="dashboard-widget-picker-label" for="dashboard-biometric-widget-search">Manual and wearable metrics</label>
-          <input id="dashboard-biometric-widget-search" class="dashboard-widget-picker-search" type="search" placeholder="Search biometrics to add" oninput="window.filterDashboardBiometricWidgetPicker(this.value)">
+          <input id="dashboard-biometric-widget-search" class="dashboard-widget-picker-search" type="search" placeholder="Search biometrics to add" ${dashboardWidgetInputAttrs('filter-biometric-picker')}>
           <div class="dashboard-widget-picker-grid dashboard-biometric-widget-grid">${biometricList}</div>
           <div class="dashboard-widget-picker-empty" id="dashboard-biometric-widget-empty" ${biometricOptions.length ? 'hidden' : ''}>All available biometrics are already in the overview.</div>
         </div>
         <div class="dashboard-widget-picker-actions">
-          <button type="button" class="dashboard-action-btn" onclick="window.openSettingsModal && window.openSettingsModal('wearables');window.closeDashboardWidgetPicker()">Connect source</button>
+          <button type="button" class="dashboard-action-btn" ${dashboardWidgetActionAttrs('connect-source')}>Connect source</button>
         </div>
       </div>
     </div>`);
@@ -393,10 +507,10 @@ export function createDashboardWidgetControls(deps) {
     document.getElementById('dashboard-widget-picker-overlay')?.remove();
   }
 
-  function startDashboardWidgetDrag(event, id) {
+  function startDashboardWidgetDrag(event, id, dragEl = event.currentTarget) {
     draggingWidgetId = id;
     event.dataTransfer?.setData('text/plain', id);
-    event.dataTransfer?.setDragImage?.(event.currentTarget, 20, 20);
+    event.dataTransfer?.setDragImage?.(dragEl, 20, 20);
   }
 
   function allowDashboardWidgetDrop(event) {
@@ -419,6 +533,8 @@ export function createDashboardWidgetControls(deps) {
     saveDashboardWidgetPrefs(prefs);
     rerenderDashboardFromWidgetChange();
   }
+
+  installDashboardWidgetControlDelegates();
 
   return {
     isOrganizeMode,

--- a/run-tests.js
+++ b/run-tests.js
@@ -46,6 +46,7 @@ const TEST_FILES = [
   // (need live DOM + populated state) live in test-audit-dom.js below.
   'tests/test-audit-dom.js',
   'tests/test-nav-delegated-actions-dom.js',
+  'tests/test-dashboard-widget-delegated-actions-dom.js',
   // test-image-utils.js source-inspection + module-export checks ported to
   // Vitest (PR for batch 19). DOM-runtime assertions (sections 6 + 7) live
   // in test-image-utils-dom.js below.

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -168,6 +168,7 @@ const LEGACY_TESTS = [
   './test-settings-delegated-actions.js',
   './test-shell-delegated-actions.js',
   './test-nav-delegated-actions.js',
+  './test-dashboard-widget-delegated-actions.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',
   // Batch 32 — test-wearables (~549 asserts: registry, IDB CRUD via

--- a/tests/test-dashboard-widget-delegated-actions-dom.js
+++ b/tests/test-dashboard-widget-delegated-actions-dom.js
@@ -1,0 +1,90 @@
+// test-dashboard-widget-delegated-actions-dom.js — live dashboard widget delegate coverage.
+//
+// Run: fetch('tests/test-dashboard-widget-delegated-actions-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Dashboard Widget Delegated Actions DOM ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const stateModule = await import('./js/state.js');
+  const st = stateModule.state;
+  const originalView = st.currentView;
+
+  try {
+    if (!window.getActiveData?.()?.dates?.length) {
+      const resp = await fetch('data/demo-male.json');
+      st.importedData = await resp.json();
+      st.profileSex = 'male';
+      st.profileDob = '1987-11-22';
+      window.saveImportedData?.();
+      window.buildSidebar?.();
+    }
+
+    window.closeDashboardWidgetPicker?.();
+    window.toggleDashboardOrganizeMode?.(false);
+    window.navigate?.('dashboard');
+    await delay(100);
+
+    const customizeBtn = document.querySelector('.dashboard-sticky-actions [data-dashboard-widget-action="toggle-organize"]');
+    assert('dashboard sticky controls render delegated actions', !!customizeBtn);
+    customizeBtn?.click();
+    await delay(100);
+
+    assert('delegated customize click enters organize mode',
+      !!document.querySelector('.dashboard-widgets.is-organizing'));
+    assert('dashboard widget chrome has no inline handlers in organize mode',
+      !document.querySelector('.dashboard-sticky-actions [onclick], .dashboard-organize-footer [onclick], .dashboard-widget-chrome [onclick], .dashboard-widget[ondragstart], .dashboard-widget[ondragover], .dashboard-widget[ondrop]'));
+    assert('organize controls render move/hide data actions',
+      !!document.querySelector('.dashboard-widget-tool[data-dashboard-widget-action="move-widget"][data-dashboard-widget-direction]') &&
+        !!document.querySelector('.dashboard-widget-tool[data-dashboard-widget-action="hide-widget"]'));
+
+    const addBtn = document.querySelector('.dashboard-sticky-actions [data-dashboard-widget-action="open-picker"]');
+    addBtn?.click();
+    await delay(100);
+    let overlay = document.getElementById('dashboard-widget-picker-overlay');
+    assert('delegated add-widget click opens picker', !!overlay);
+    assert('dashboard widget picker has no inline handlers',
+      !!overlay && !overlay.querySelector('[onclick], [oninput], [ondragstart], [ondragover], [ondrop]'));
+
+    overlay?.querySelector('[data-dashboard-widget-action="close-picker"]')?.click();
+    await delay(50);
+    assert('delegated picker close action removes overlay',
+      !document.getElementById('dashboard-widget-picker-overlay'));
+
+    window.openDashboardWidgetPicker?.();
+    await delay(100);
+    overlay = document.getElementById('dashboard-widget-picker-overlay');
+    const markerSearch = document.getElementById('dashboard-marker-widget-search');
+    const markerOptions = Array.from(document.querySelectorAll('.dashboard-marker-widget-option'));
+    if (markerSearch && markerOptions.length) {
+      markerSearch.value = 'zzzz-no-marker-match';
+      markerSearch.dispatchEvent(new Event('input', { bubbles: true }));
+      await delay(50);
+      assert('delegated marker search input filters picker cards',
+        markerOptions.every(option => option.hidden) &&
+          document.getElementById('dashboard-marker-widget-empty')?.hidden === false);
+    } else {
+      assert('delegated marker search input is optional when no marker cards exist', !!markerSearch);
+    }
+
+    overlay?.click();
+    await delay(50);
+    assert('picker backdrop click closes only through delegated target check',
+      !document.getElementById('dashboard-widget-picker-overlay'));
+  } finally {
+    window.closeDashboardWidgetPicker?.();
+    window.toggleDashboardOrganizeMode?.(false);
+    if (originalView) window.navigate?.(originalView);
+  }
+
+  console.log(`\n%c Dashboard Widget Delegated Actions DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-dashboard-widget-delegated-actions-dom'] = { pass, fail };
+})();

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Static dashboard widget delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const controlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
+const compositionSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Dashboard Widget Delegated Actions ===');
+
+assert('dashboard widget controls render no inline event attributes',
+  !/\bon(?:click|input|dragstart|dragover|drop)=/.test(controlsSrc));
+assert('dashboard widget controls render delegated action attributes',
+  controlsSrc.includes('function dashboardWidgetActionAttrs') &&
+    controlsSrc.includes('data-dashboard-widget-action=') &&
+    controlsSrc.includes("dashboardWidgetActionAttrs('toggle-organize'") &&
+    controlsSrc.includes("dashboardWidgetActionAttrs('open-picker'") &&
+    controlsSrc.includes("dashboardWidgetActionAttrs('move-widget'") &&
+    controlsSrc.includes("dashboardWidgetActionAttrs('hide-widget'") &&
+    controlsSrc.includes("dashboardWidgetActionAttrs('show-widget'"));
+assert('dashboard widget controls render delegated picker inputs',
+  controlsSrc.includes('function dashboardWidgetInputAttrs') &&
+    controlsSrc.includes('data-dashboard-widget-input=') &&
+    controlsSrc.includes("dashboardWidgetInputAttrs('filter-biometric-picker')") &&
+    controlsSrc.includes("dashboardWidgetInputAttrs('filter-marker-picker')"));
+assert('dashboard widget controls render delegated drag/drop attributes',
+  controlsSrc.includes('function dashboardWidgetDragAttrs') &&
+    controlsSrc.includes('data-dashboard-widget-drag-id') &&
+    controlsSrc.includes('data-dashboard-widget-drop-id'));
+assert('dashboard widget controls install idempotent click/input/drag delegates',
+  controlsSrc.includes('let dashboardWidgetDelegatesInstalled = false') &&
+    controlsSrc.includes("document.addEventListener('click', handleDashboardWidgetClick)") &&
+    controlsSrc.includes("document.addEventListener('input', handleDashboardWidgetInput)") &&
+    controlsSrc.includes("document.addEventListener('dragstart', handleDashboardWidgetDragStart)") &&
+    controlsSrc.includes("document.addEventListener('dragover', handleDashboardWidgetDragOver)") &&
+    controlsSrc.includes("document.addEventListener('drop', handleDashboardWidgetDrop)"));
+assert('dashboard widget picker backdrop stays target-only',
+  controlsSrc.includes("target.closest('#dashboard-widget-picker-overlay[data-dashboard-widget-overlay]')") &&
+    controlsSrc.includes('overlay && target === overlay'));
+
+[
+  'toggle-organize',
+  'open-picker',
+  'reset-widgets',
+  'move-widget',
+  'hide-widget',
+  'show-widget',
+  'add-marker-widget',
+  'add-biometric-metric',
+  'close-picker',
+  'customize-layout',
+  'reset-layout',
+  'connect-source',
+].forEach(action => {
+  assert(`dashboard widget action ${action} is handled`, controlsSrc.includes(`action === '${action}'`));
+});
+
+[
+  'toggleDashboardOrganizeMode',
+  'moveDashboardWidget',
+  'hideDashboardWidget',
+  'showDashboardWidget',
+  'addDashboardMarkerWidget',
+  'addDashboardBiometricMetric',
+  'openDashboardWidgetPicker',
+  'openDashboardBiometricPicker',
+  'closeDashboardWidgetPicker',
+  'startDashboardWidgetDrag',
+  'allowDashboardWidgetDrop',
+  'dropDashboardWidget',
+].forEach(name => {
+  assert(`${name} remains forwarded through dashboard composition`,
+    compositionSrc.includes(`${name}: (...args) => dashboardWidgetControls.${name}(...args)`));
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.317';
+self.APP_VERSION = '1.8.318';


### PR DESCRIPTION
## Summary
- Replaces dashboard widget inline `onclick`/`oninput`/drag handlers with `data-dashboard-widget-*` attributes and one delegated action layer.
- Keeps the existing dashboard widget public functions forwarded through composition for compatibility.
- Adds static and browser regression coverage for dashboard widget delegated controls and picker interactions.
- Bumps `version.js` to `1.8.318` for cache invalidation.

## Validation
- `node --check js/dashboard-widget-controls.js`
- `node tests/test-dashboard-widget-delegated-actions.js`
- `npm test -- --run tests/_vitest-legacy.test.js`
- Browser smoke for `tests/test-dashboard-widget-delegated-actions-dom.js`
- `./run-tests.sh`