### PR TITLE
[codex] Delegate lens page shell actions

### DIFF
--- a/css/dashboard-widgets.css
+++ b/css/dashboard-widgets.css
@@ -80,6 +80,7 @@
   padding: 12px; border: 1px dashed var(--border); border-radius: var(--radius);
   background: color-mix(in srgb, var(--bg-card) 46%, transparent);
 }
+.dashboard-widgets.is-organizing { grid-auto-flow: row; }
 .dashboard-widgets.is-organizing .dashboard-widget:hover {
   border-color: var(--accent); background: color-mix(in srgb, var(--accent) 5%, var(--bg-card));
 }

--- a/dev-docs/module-reference.md
+++ b/dev-docs/module-reference.md
@@ -1009,14 +1009,14 @@ Dashboard route, widget, mobile handoff, marker-modal, and lens-shell compositio
 
 ### `lens-page-shell.js`
 
-Shared lens page chrome and ordering helpers used by `views.js` and `lens-pages.js`. The module owns lens headers, reorderable page widget wrappers, per-profile lens widget order persistence, page-section move controls, dashboard add/remove toggles, and quote-safe inline handler generation.
+Shared lens page chrome and ordering helpers used by `views.js` and `lens-pages.js`. The module owns lens headers, reorderable page widget wrappers, per-profile lens widget order persistence, page-section move controls, dashboard add/remove toggles, and the delegated action attributes/listener used by shared lens chrome.
 
 **Key exports:**
 - `configureLensPageShell(deps)` — injects dashboard widget visibility helpers without importing dashboard modules directly
 - `renderLensHeader(title, subtitle, actions?)` — renders the shared lens page header
 - `renderLensPageWidgets(route, widgets)` / `renderLensWidget(...)` — render reorderable page widgets and their chrome
 - `moveLensPageWidget(route, id, direction)` — persists per-profile page section order and refreshes the active route
-- `inlineHandlerCall(fnName, ...args)` — builds escaped `window.*` inline handlers for existing template surfaces
+- `lensPageActionAttrs(action, attrs?)` — builds escaped `data-lens-page-*` attributes consumed by the shared delegated click listener
 
 ---
 

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -10,17 +10,45 @@ let _shellDeps = {
   getAvailableDashboardFixedWidgetIds: () => [],
   getDashboardWidgetPrefs: () => ({ hidden: [] }),
 };
+let lensPageShellDelegatesInstalled = false;
 
 export function configureLensPageShell(deps = {}) {
   _shellDeps = { ..._shellDeps, ...deps };
+  installLensPageShellDelegates();
 }
 
-function inlineJsString(value) {
-  return JSON.stringify(String(value ?? '')).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
+export function lensPageActionAttrs(action, attrs = {}) {
+  return [
+    `data-lens-page-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-lens-page-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
 }
 
-export function inlineHandlerCall(fnName, ...args) {
-  return escapeAttr(`window.${fnName}(${args.map(inlineJsString).join(', ')})`);
+function handleLensPageShellClick(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const actionEl = target.closest('[data-lens-page-action]');
+  if (!actionEl) return;
+  if (!actionEl.closest('.lens-page-header, .lens-page-widgets, #recommendations-page')) return;
+  event.preventDefault();
+
+  const action = actionEl.dataset.lensPageAction || '';
+  const id = actionEl.dataset.lensPageId || '';
+  if (action === 'move-widget') {
+    moveLensPageWidget(actionEl.dataset.lensPageRoute || '', id, actionEl.dataset.lensPageDirection || 0);
+  } else if (action === 'add-dashboard-widget') {
+    window.addDashboardWidgetFromLens?.(id);
+  } else if (action === 'remove-dashboard-widget') {
+    window.removeDashboardWidgetFromLens?.(id);
+  }
+}
+
+function installLensPageShellDelegates() {
+  if (lensPageShellDelegatesInstalled || typeof document === 'undefined') return;
+  lensPageShellDelegatesInstalled = true;
+  document.addEventListener('click', handleLensPageShellClick);
 }
 
 export function renderLensHeader(title, subtitle, actions = '') {
@@ -57,8 +85,8 @@ function orderLensPageWidgets(route, widgets) {
 
 function renderLensPageMoveControls(route, id, index, count) {
   if (!route || count < 2) return '';
-  return `<button type="button" class="dashboard-widget-tool" ${index <= 0 ? 'disabled' : ''} onclick="${inlineHandlerCall('moveLensPageWidget', route, id, '-1')}" aria-label="Move page section up">↑</button>
-    <button type="button" class="dashboard-widget-tool" ${index >= count - 1 ? 'disabled' : ''} onclick="${inlineHandlerCall('moveLensPageWidget', route, id, '1')}" aria-label="Move page section down">↓</button>`;
+  return `<button type="button" class="dashboard-widget-tool" ${index <= 0 ? 'disabled' : ''} ${lensPageActionAttrs('move-widget', { route, id, direction: -1 })} aria-label="Move page section up">↑</button>
+    <button type="button" class="dashboard-widget-tool" ${index >= count - 1 ? 'disabled' : ''} ${lensPageActionAttrs('move-widget', { route, id, direction: 1 })} aria-label="Move page section down">↓</button>`;
 }
 
 export function renderLensPageWidgets(route, widgets) {
@@ -99,8 +127,8 @@ function renderLensDashboardToggle(dashboardId) {
   const hidden = Array.isArray(prefs?.hidden) ? prefs.hidden : [];
   const isVisible = !hidden.includes(dashboardId);
   const label = isVisible ? 'Remove from Dashboard' : 'Add to Dashboard';
-  const action = isVisible ? 'removeDashboardWidgetFromLens' : 'addDashboardWidgetFromLens';
-  return `<button type="button" class="dashboard-widget-tool lens-widget-dashboard-toggle" onclick="${inlineHandlerCall(action, dashboardId)}">${label}</button>`;
+  const action = isVisible ? 'remove-dashboard-widget' : 'add-dashboard-widget';
+  return `<button type="button" class="dashboard-widget-tool lens-widget-dashboard-toggle" ${lensPageActionAttrs(action, { id: dashboardId })}>${label}</button>`;
 }
 
 export function renderLensWidget(id, title, description, body, size = 'full', opts = {}) {
@@ -120,3 +148,5 @@ export function renderLensWidget(id, title, description, body, size = 'full', op
     <div class="dashboard-widget-body">${body || '<div class="dashboard-widget-empty">No data available yet.</div>'}</div>
   </section>`;
 }
+
+installLensPageShellDelegates();

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -117,7 +117,7 @@ export function createLensPageHandlers(deps) {
     getGlobalRecommendationCandidates,
     renderRecommendationCard,
     renderRecommendationsEmpty,
-    inlineHandlerCall,
+    lensPageActionAttrs,
     renderLensHeader,
     renderLensPageWidgets,
     renderLensWidget,
@@ -243,9 +243,9 @@ export function createLensPageHandlers(deps) {
     document.body.classList.remove('mobile-dashboard-active');
     const prefs = getDashboardWidgetPrefs();
     const recommendationsVisible = !prefs.hidden.includes('recommendations');
-    const dashboardAction = recommendationsVisible ? 'removeDashboardWidgetFromLens' : 'addDashboardWidgetFromLens';
+    const dashboardAction = recommendationsVisible ? 'remove-dashboard-widget' : 'add-dashboard-widget';
     const dashboardLabel = recommendationsVisible ? 'Remove from Dashboard' : 'Add to Dashboard';
-    const actions = `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="${inlineHandlerCall(dashboardAction, 'recommendations')}">${dashboardLabel}</button>
+    const actions = `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs(dashboardAction, { id: 'recommendations' })}>${dashboardLabel}</button>
       <button type="button" class="dashboard-action-btn" onclick="window.openSettingsModal && window.openSettingsModal('privacy')">Disclosure & settings</button>`;
     let html = `<div id="recommendations-page">`;
     html += renderLensHeader('Recommendations', 'A global action plan built from Labs, Body, Light, Genome, and Insight signals. Product links stay behind the existing disclosure.', actions);

--- a/js/views.js
+++ b/js/views.js
@@ -6,7 +6,7 @@ import { createRecommendationActions } from './recommendation-actions.js';
 import { createNavigate, getInitialView as getRouterInitialView } from './views-router.js';
 import { createDashboardViewComposition } from './dashboard-view-composition.js';
 import { createLensPageHandlers } from './lens-pages.js';
-import { inlineHandlerCall, renderLensHeader, renderLensPageWidgets, renderLensWidget, moveLensPageWidget } from './lens-page-shell.js';
+import { lensPageActionAttrs, renderLensHeader, renderLensPageWidgets, renderLensWidget, moveLensPageWidget } from './lens-page-shell.js';
 import { renderFocusCard, buildFocusContext, loadFocusCard, refreshFocusCard } from './focus-card.js';
 import { configureOnboardingView, renderOnboardingBanner, renderAIConnectionReminder, dismissAIReminder, openChatProviderQuiz, setOnboardingFocus, completeOnboardingSex, completeOnboardingProfile, dismissOnboarding } from './onboarding-view.js';
 import { renderCategoryGlyph } from './category-glyphs.js';
@@ -247,7 +247,7 @@ const lensPageHandlers = createLensPageHandlers({
   getGlobalRecommendationCandidates,
   renderRecommendationCard,
   renderRecommendationsEmpty,
-  inlineHandlerCall,
+  lensPageActionAttrs,
   renderLensHeader,
   renderLensPageWidgets,
   renderLensWidget,

--- a/run-tests.js
+++ b/run-tests.js
@@ -47,6 +47,7 @@ const TEST_FILES = [
   'tests/test-audit-dom.js',
   'tests/test-nav-delegated-actions-dom.js',
   'tests/test-dashboard-widget-delegated-actions-dom.js',
+  'tests/test-lens-page-shell-delegated-actions-dom.js',
   // test-image-utils.js source-inspection + module-export checks ported to
   // Vitest (PR for batch 19). DOM-runtime assertions (sections 6 + 7) live
   // in test-image-utils-dom.js below.

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -169,6 +169,7 @@ const LEGACY_TESTS = [
   './test-shell-delegated-actions.js',
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',
+  './test-lens-page-shell-delegated-actions.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',
   // Batch 32 — test-wearables (~549 asserts: registry, IDB CRUD via

--- a/tests/test-dashboard-widget-delegated-actions-dom.js
+++ b/tests/test-dashboard-widget-delegated-actions-dom.js
@@ -39,6 +39,8 @@ return (async function() {
 
     assert('delegated customize click enters organize mode',
       !!document.querySelector('.dashboard-widgets.is-organizing'));
+    assert('organize mode uses visual order matching widget order',
+      getComputedStyle(document.querySelector('.dashboard-widgets.is-organizing')).gridAutoFlow === 'row');
     assert('dashboard widget chrome has no inline handlers in organize mode',
       !document.querySelector('.dashboard-sticky-actions [onclick], .dashboard-organize-footer [onclick], .dashboard-widget-chrome [onclick], .dashboard-widget[ondragstart], .dashboard-widget[ondragover], .dashboard-widget[ondrop]'));
     assert('organize controls render move/hide data actions',

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const controlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
 const compositionSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
+const dashboardWidgetsCss = fs.readFileSync(path.join(root, 'css/dashboard-widgets.css'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -54,6 +55,8 @@ assert('dashboard widget controls install idempotent click/input/drag delegates'
 assert('dashboard widget picker backdrop stays target-only',
   controlsSrc.includes("target.closest('#dashboard-widget-picker-overlay[data-dashboard-widget-overlay]')") &&
     controlsSrc.includes('overlay && target === overlay'));
+assert('dashboard organize mode disables dense grid packing',
+  /\.dashboard-widgets\.is-organizing\s*\{[^}]*grid-auto-flow:\s*row;[^}]*\}/.test(dashboardWidgetsCss));
 
 [
   'toggle-organize',

--- a/tests/test-lens-page-shell-delegated-actions-dom.js
+++ b/tests/test-lens-page-shell-delegated-actions-dom.js
@@ -1,0 +1,77 @@
+// test-lens-page-shell-delegated-actions-dom.js — live lens shell delegate coverage.
+//
+// Run: fetch('tests/test-lens-page-shell-delegated-actions-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Lens Page Shell Delegated Actions DOM ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const stateModule = await import('./js/state.js');
+  const st = stateModule.state;
+  const originalView = st.currentView;
+  const originalAddDashboard = window.addDashboardWidgetFromLens;
+  const originalRemoveDashboard = window.removeDashboardWidgetFromLens;
+  const profileId = window.getActiveProfileId?.() || st.currentProfile || 'default';
+  const labsOrderKey = `labcharts-${profileId}-lensPageOrder-labs-v1`;
+  const savedLabsOrder = localStorage.getItem(labsOrderKey);
+
+  try {
+    if (!window.getActiveData?.()?.dates?.length) {
+      const resp = await fetch('data/demo-male.json');
+      st.importedData = await resp.json();
+      st.profileSex = 'male';
+      st.profileDob = '1987-11-22';
+      window.saveImportedData?.();
+      window.buildSidebar?.();
+    }
+
+    localStorage.removeItem(labsOrderKey);
+    window.navigate?.('labs');
+    await delay(120);
+
+    const widgets = document.querySelector('.lens-page-widgets[data-lens-route="labs"]');
+    assert('Labs lens renders through shared page widget shell', !!widgets);
+    assert('lens page shell controls have no inline handlers',
+      !!widgets && !widgets.querySelector('.dashboard-widget-tools [onclick], .dashboard-widget-tools [onkeydown]'));
+    assert('lens page shell renders move action data attributes',
+      !!widgets?.querySelector('[data-lens-page-action="move-widget"][data-lens-page-direction="1"]'));
+
+    const beforeFirst = widgets?.querySelector('.dashboard-widget[data-widget-id]')?.dataset.widgetId || '';
+    widgets?.querySelector('.dashboard-widget[data-widget-id] [data-lens-page-action="move-widget"][data-lens-page-direction="1"]')?.click();
+    await delay(120);
+    const afterFirst = document.querySelector('.lens-page-widgets[data-lens-route="labs"] .dashboard-widget[data-widget-id]')?.dataset.widgetId || '';
+    assert('delegated move action reorders lens page sections',
+      !!beforeFirst && !!afterFirst && beforeFirst !== afterFirst,
+      `${beforeFirst} -> ${afterFirst}`);
+
+    const calls = [];
+    window.addDashboardWidgetFromLens = id => calls.push(['add', id]);
+    window.removeDashboardWidgetFromLens = id => calls.push(['remove', id]);
+    const dashboardToggle = document.querySelector('.lens-page-widgets[data-lens-route="labs"] .lens-widget-dashboard-toggle[data-lens-page-action]');
+    const toggleAction = dashboardToggle?.dataset.lensPageAction || '';
+    const toggleId = dashboardToggle?.dataset.lensPageId || '';
+    dashboardToggle?.click();
+    await delay(50);
+    assert('delegated dashboard toggle calls the matching dashboard bridge',
+      !!toggleAction && !!toggleId &&
+        calls.some(([kind, id]) => id === toggleId && `${kind}-dashboard-widget` === toggleAction),
+      JSON.stringify({ toggleAction, toggleId, calls }));
+  } finally {
+    window.addDashboardWidgetFromLens = originalAddDashboard;
+    window.removeDashboardWidgetFromLens = originalRemoveDashboard;
+    if (savedLabsOrder == null) localStorage.removeItem(labsOrderKey);
+    else localStorage.setItem(labsOrderKey, savedLabsOrder);
+    if (originalView) window.navigate?.(originalView);
+  }
+
+  console.log(`\n%c Lens Page Shell Delegated Actions DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-lens-page-shell-delegated-actions-dom'] = { pass, fail };
+})();

--- a/tests/test-lens-page-shell-delegated-actions.js
+++ b/tests/test-lens-page-shell-delegated-actions.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Static lens page shell delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const shellSrc = fs.readFileSync(path.join(root, 'js/lens-page-shell.js'), 'utf8');
+const lensPagesSrc = fs.readFileSync(path.join(root, 'js/lens-pages.js'), 'utf8');
+const viewsSrc = fs.readFileSync(path.join(root, 'js/views.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Lens Page Shell Delegated Actions ===');
+
+assert('lens-page-shell renders no inline event attributes',
+  !/\bon(?:click|input|change|submit|keydown|keyup)=/.test(shellSrc));
+assert('lens-page-shell no longer exports inlineHandlerCall',
+  !shellSrc.includes('inlineHandlerCall') &&
+    !viewsSrc.includes('inlineHandlerCall') &&
+    !lensPagesSrc.includes('inlineHandlerCall'));
+assert('lens-page-shell renders delegated action attributes',
+  shellSrc.includes('export function lensPageActionAttrs') &&
+    shellSrc.includes('data-lens-page-action=') &&
+    shellSrc.includes("lensPageActionAttrs('move-widget'") &&
+    shellSrc.includes("lensPageActionAttrs(action, { id: dashboardId })"));
+assert('lens-page-shell installs an idempotent click delegate',
+  shellSrc.includes('let lensPageShellDelegatesInstalled = false') &&
+    shellSrc.includes("document.addEventListener('click', handleLensPageShellClick)") &&
+    shellSrc.includes('installLensPageShellDelegates();'));
+assert('lens-page-shell scopes delegated clicks to lens surfaces',
+  shellSrc.includes("closest('.lens-page-header, .lens-page-widgets, #recommendations-page')"));
+
+[
+  'move-widget',
+  'add-dashboard-widget',
+  'remove-dashboard-widget',
+].forEach(action => {
+  assert(`lens page action ${action} is handled`, shellSrc.includes(`action === '${action}'`));
+});
+
+assert('views.js passes lensPageActionAttrs into lens page handlers',
+  viewsSrc.includes('lensPageActionAttrs') &&
+    viewsSrc.includes("from './lens-page-shell.js'") &&
+    viewsSrc.includes('lensPageActionAttrs,'));
+assert('recommendations page dashboard toggle uses lens delegated action',
+  lensPagesSrc.includes("lensPageActionAttrs(dashboardAction, { id: 'recommendations' })") &&
+    !lensPagesSrc.includes("inlineHandlerCall(dashboardAction, 'recommendations')"));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -250,7 +250,7 @@ globalThis.fetch = async (url, opts) => {
   assert('dismissRecommendation can restore a dismissed recommendation',
     /function dismissRecommendation\(id, on = true\)[\s\S]{0,120}setRecommendationState\('dismissed', id, !!on\)/.test(recommendationActionsSrc));
   assert('Recommendations page header directly toggles its dashboard widget',
-    lensPagesSrc.includes("inlineHandlerCall(dashboardAction, 'recommendations')") &&
+    lensPagesSrc.includes("lensPageActionAttrs(dashboardAction, { id: 'recommendations' })") &&
     !viewsSrc.includes("openDashboardWidgetPicker && window.openDashboardWidgetPicker()\">Add to Dashboard"));
 
   // ═══════════════════════════════════════

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.318';
+self.APP_VERSION = '1.8.320';


### PR DESCRIPTION
## Summary
- Replaces shared lens page shell inline move/dashboard handlers with `data-lens-page-*` attributes and one delegated click listener.
- Removes `inlineHandlerCall` from the lens shell path and recommendation page dashboard toggle wiring.
- Keeps dashboard organize mode in normal row placement so move arrows match the visible widget order instead of dense grid backfilling.
- Adds static and browser regression coverage for delegated lens page actions and dashboard organize placement.
- Updates the module reference and bumps `version.js` to `1.8.320` for cache invalidation.

## Validation
- `node --check js/lens-page-shell.js`
- `node --check js/lens-pages.js`
- `node --check js/views.js`
- `node tests/test-lens-page-shell-delegated-actions.js`
- `node tests/test-recommendations.js`
- `node tests/test-dashboard-widget-delegated-actions.js`
- `npm test -- --run tests/_vitest-legacy.test.js`
- focused Puppeteer dashboard widget DOM regression
- wide-screen Puppeteer reproduction of moving Recommendations to bottom
- `git diff --check`
- `./run-tests.sh`