### PR TITLE
[codex] Delegate wearables UI actions

### DIFF
--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -1,4 +1,4 @@
-import { escapeHTML, showNotification } from './utils.js';
+import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { state } from './state.js';
 import {
   adapterById,
@@ -23,6 +23,24 @@ const WEARABLE_DETAIL_RANGES = [
 ];
 const WEARABLE_ALL_HISTORY_START_DATE = '1970-01-01';
 const WEARABLE_DETAIL_RANGE_KEY = 'wearable-detail-range';
+
+export function wearableActionAttrs(action, attrs = {}) {
+  return [
+    `data-wearable-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-wearable-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function wearableFormAttrs(form, attrs = {}) {
+  return [
+    `data-wearable-form="${escapeAttr(form)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-wearable-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
 
 function getWearableDetailRange() {
   const stored = localStorage.getItem(WEARABLE_DETAIL_RANGE_KEY);
@@ -169,14 +187,14 @@ function buildManualEntriesSection(metricId, manualEntries, primarySource) {
   if (manualEntries.length === 0) {
     if (primarySource && primarySource !== 'manual') {
       return `<section class="wearable-manual-entries wearable-manual-entries-compact">
-        <button type="button" class="wearable-manual-add-btn" onclick="openManualAddFromDetail('${escapeHTML(metricId)}')">+ Add a manual reading</button>
+        <button type="button" class="wearable-manual-add-btn" ${wearableActionAttrs('open-detail-manual-add', { metric: metricId })}>+ Add a manual reading</button>
         <div id="wearable-manual-add-slot"></div>
       </section>`;
     }
     return `<section class="wearable-manual-entries">
       <div class="wearable-manual-entries-head">
         <span class="wearable-manual-entries-title">Manual entries</span>
-        <button type="button" class="wearable-manual-add-btn" onclick="openManualAddFromDetail('${escapeHTML(metricId)}')">+ Add reading</button>
+        <button type="button" class="wearable-manual-add-btn" ${wearableActionAttrs('open-detail-manual-add', { metric: metricId })}>+ Add reading</button>
       </div>
       <div class="wearable-manual-entries-empty">No manual entries for this metric yet.</div>
       <div id="wearable-manual-add-slot"></div>
@@ -207,14 +225,14 @@ function buildManualEntriesSection(metricId, manualEntries, primarySource) {
       <span class="wearable-manual-entry-date">${escapeHTML(shortDate(e.date))}</span>
       <span class="wearable-manual-entry-val">${valueRead}${unit ? ` <span class="wearable-manual-entry-unit">${escapeHTML(unit)}</span>` : ''}</span>
       ${tagChips}
-      <button type="button" class="wearable-manual-entry-del" title="Delete this reading" aria-label="${escapeHTML(ariaText)}" onclick="deleteManualEntryFromDetail('${escapeHTML(metricId)}','${escapeHTML(e.date)}')">×</button>
+      <button type="button" class="wearable-manual-entry-del" title="Delete this reading" aria-label="${escapeHTML(ariaText)}" ${wearableActionAttrs('delete-detail-manual-entry', { metric: metricId, date: e.date })}>×</button>
       ${noteRow}
     </li>`;
   }).join('');
   return `<section class="wearable-manual-entries">
     <div class="wearable-manual-entries-head">
       <span class="wearable-manual-entries-title">Manual entries <span class="wearable-manual-entries-count">${manualEntries.length}</span></span>
-      <button type="button" class="wearable-manual-add-btn" onclick="openManualAddFromDetail('${escapeHTML(metricId)}')">+ Add reading</button>
+      <button type="button" class="wearable-manual-add-btn" ${wearableActionAttrs('open-detail-manual-add', { metric: metricId })}>+ Add reading</button>
     </div>
     <div id="wearable-manual-add-slot"></div>
     <ul class="wearable-manual-entries-list">${rows}</ul>
@@ -329,15 +347,15 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
   const connectedSources = state.importedData?.wearableSummary?.sources || {};
   const showSwapButton = Object.keys(connectedSources).length > 1 && !!adapter;
   const swapButton = showSwapButton
-    ? `<button type="button" class="wearable-source-badge wearable-source-badge-btn wearable-modal-source-swap" onclick="chooseWearableSource('${escapeHTML(metricId)}',event)" title="Switch source for this metric">via ${escapeHTML(adapter.displayName)} · swap</button>`
+    ? `<button type="button" class="wearable-source-badge wearable-source-badge-btn wearable-modal-source-swap" ${wearableActionAttrs('choose-source', { metric: metricId })} title="Switch source for this metric">via ${escapeHTML(adapter.displayName)} · swap</button>`
     : '';
 
   const emfSleepHint = _buildEMFSleepHint(metricId, m);
   const rangePills = WEARABLE_DETAIL_RANGES.map(r =>
-    `<button type="button" class="ctx-btn-option${r.key === rangeKey ? ' active' : ''}" aria-pressed="${r.key === rangeKey}" onclick="setWearableDetailRange('${escapeHTML(metricId)}','${r.key}')">${escapeHTML(r.label)}</button>`
+    `<button type="button" class="ctx-btn-option${r.key === rangeKey ? ' active' : ''}" aria-pressed="${r.key === rangeKey}" ${wearableActionAttrs('set-detail-range', { metric: metricId, range: r.key })}>${escapeHTML(r.label)}</button>`
   ).join('');
 
-  return `<button class="modal-close" onclick="closeModal()">&times;</button>
+  return `<button class="modal-close" ${wearableActionAttrs('modal-close')}>&times;</button>
     <h3>${escapeHTML(canon.label)}${subLabel}</h3>
     <div class="modal-unit">
       ${escapeHTML(sourceName)}${deltaStr ? ` · ${deltaStr} vs baseline` : ''} · ${escapeHTML(trendWord)} 30d
@@ -368,8 +386,7 @@ function _buildEMFSleepHint(metricId, m) {
     const ageDays = (Date.now() - new Date(latest.date + 'T00:00:00').getTime()) / 86400000;
     if (ageDays < 120) return '';
   }
-  const openHandler = `event.preventDefault();window.closeModal&&window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor(),100);`;
-  return `<div class="wearable-detail-emf-hint"><span aria-hidden="true">💡</span> Sleep regressing? Sometimes it's the room. <a href="#" onclick="${openHandler}" data-umami-event="emf-nudge-wearable-sleep">Check your EMF environment →</a></div>`;
+  return `<div class="wearable-detail-emf-hint"><span aria-hidden="true">💡</span> Sleep regressing? Sometimes it's the room. <a href="#" ${wearableActionAttrs('open-emf-assessment')} data-umami-event="emf-nudge-wearable-sleep">Check your EMF environment →</a></div>`;
 }
 
 function renderWearableChart(canvas, canon, m, series, manualSeries = []) {
@@ -511,24 +528,24 @@ export function openManualAddFromDetail(metricId, event) {
   if (!kind) return;
   if (kind === 'weight') {
     const weightUnit = state.unitSystem === 'US' ? 'lb' : 'kg';
-    slot.innerHTML = `<form class="wearable-manual-add-form" onsubmit="event.preventDefault();saveManualEntryFromDetail('${escapeHTML(metricId)}','weight')">
+    slot.innerHTML = `<form class="wearable-manual-add-form" ${wearableFormAttrs('detail-manual-add', { metric: metricId, kind: 'weight' })}>
       <input type="number" step="0.1" inputmode="decimal" class="wearable-log-input" id="wlad-val" placeholder="${weightUnit}" aria-label="Weight in ${weightUnit === 'lb' ? 'pounds' : 'kilograms'}" autofocus>
       ${_renderNoteField('wlad-note')}
       <input type="date" class="wearable-log-date" id="wlad-date" value="${today}">
       <button type="submit" class="wearable-log-save">Save</button>
-      <button type="button" class="wearable-log-cancel" onclick="closeManualAddFromDetail()">✕</button>
+      <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('close-detail-manual-add')}>✕</button>
     </form>`;
   } else if (kind === 'rhr') {
-    slot.innerHTML = `<form class="wearable-manual-add-form" onsubmit="event.preventDefault();saveManualEntryFromDetail('${escapeHTML(metricId)}','rhr')">
+    slot.innerHTML = `<form class="wearable-manual-add-form" ${wearableFormAttrs('detail-manual-add', { metric: metricId, kind: 'rhr' })}>
       <input type="number" inputmode="numeric" class="wearable-log-input" id="wlad-val" placeholder="bpm" autofocus>
       ${_renderTagChips('rhr')}
       ${_renderNoteField('wlad-note')}
       <input type="date" class="wearable-log-date" id="wlad-date" value="${today}">
       <button type="submit" class="wearable-log-save">Save</button>
-      <button type="button" class="wearable-log-cancel" onclick="closeManualAddFromDetail()">✕</button>
+      <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('close-detail-manual-add')}>✕</button>
     </form>`;
   } else if (kind === 'bp') {
-    slot.innerHTML = `<form class="wearable-manual-add-form wearable-manual-add-form-bp" onsubmit="event.preventDefault();saveManualEntryFromDetail('${escapeHTML(metricId)}','bp')">
+    slot.innerHTML = `<form class="wearable-manual-add-form wearable-manual-add-form-bp" ${wearableFormAttrs('detail-manual-add', { metric: metricId, kind: 'bp' })}>
       <span class="wearable-log-bp-row">
         <input type="number" inputmode="numeric" class="wearable-log-input wearable-log-bp" id="wlad-sys" placeholder="sys" autofocus>
         <span class="wearable-log-sep">/</span>
@@ -539,7 +556,7 @@ export function openManualAddFromDetail(metricId, event) {
       ${_renderNoteField('wlad-note')}
       <input type="date" class="wearable-log-date" id="wlad-date" value="${today}">
       <button type="submit" class="wearable-log-save">Save</button>
-      <button type="button" class="wearable-log-cancel" onclick="closeManualAddFromDetail()">✕</button>
+      <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('close-detail-manual-add')}>✕</button>
     </form>`;
   }
   slot.querySelector('input[type="number"]')?.focus?.();

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -15,7 +15,7 @@
 //                  weekly: number[]         // up to 12 weekly means (oldest → newest)
 //                } }
 
-import { escapeHTML, showNotification } from './utils.js';
+import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { state } from './state.js';
 import { ADAPTERS, adapterById, canonicalMetric, metricsForSources, isMetricValueMeaningful, isoDay } from './wearable-adapters.js';
 import { syncNow, listConnectedSources } from './wearables-connect.js';
@@ -37,9 +37,118 @@ import {
   openWearableDetail,
   saveManualEntryFromDetail,
   setWearableDetailRange,
+  wearableActionAttrs,
 } from './wearables-detail-modal.js';
 
 export { isWearableStripHidden, setWearableStripHidden, renderWearablesSettingsSection } from './wearables-settings-panel.js';
+
+let wearableDelegatesInstalled = false;
+
+function isWearableActionScope(actionEl) {
+  return !!actionEl.closest('.wearable-strip, #detail-modal, .db-biometric-overview-grid');
+}
+
+function handleWearableActionClick(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const actionEl = target.closest('[data-wearable-action]');
+  if (!actionEl || !isWearableActionScope(actionEl)) return;
+
+  const action = actionEl.dataset.wearableAction || '';
+  const metricId = actionEl.dataset.wearableMetric || '';
+  let handled = true;
+
+  if (action === 'open-manual-log') {
+    if (actionEl.closest('.wearable-card-reorder-wrap')) return;
+    openManualLogForm(metricId, event, { delegated: true });
+  } else if (action === 'open-detail') {
+    if (actionEl.closest('.wearable-card-reorder-wrap')) return;
+    openWearableDetailFromDashboard(metricId);
+  } else if (action === 'choose-source') {
+    chooseWearableSource(metricId, event);
+  } else if (action === 'open-settings-wearables') {
+    window.openSettingsModal?.('wearables');
+  } else if (action === 'dismiss-stub') {
+    dismissWearableStub();
+  } else if (action === 'toggle-strip') {
+    toggleWearableStrip();
+  } else if (action === 'sync-now') {
+    syncWearableNow(actionEl);
+  } else if (action === 'toggle-reorder') {
+    toggleWearableReorder();
+  } else if (action === 'move-card') {
+    moveWearableCard(metricId, Number(actionEl.dataset.wearableDelta || 0));
+  } else if (action === 'manual-log-save') {
+    saveManualLog(actionEl.dataset.wearableKind || '', event);
+  } else if (action === 'manual-log-cancel') {
+    cancelManualLog(event);
+  } else if (action === 'modal-close') {
+    window.closeModal?.();
+  } else if (action === 'set-detail-range') {
+    setWearableDetailRange(metricId, actionEl.dataset.wearableRange || '');
+  } else if (action === 'open-detail-manual-add') {
+    openManualAddFromDetail(metricId, event);
+  } else if (action === 'delete-detail-manual-entry') {
+    deleteManualEntryFromDetail(metricId, actionEl.dataset.wearableDate || '');
+  } else if (action === 'close-detail-manual-add') {
+    closeManualAddFromDetail();
+  } else if (action === 'open-emf-assessment') {
+    window.closeModal?.();
+    setTimeout(() => window.openEMFAssessmentEditor?.(), 100);
+  } else {
+    handled = false;
+  }
+
+  if (handled) event.preventDefault();
+}
+
+function handleWearableActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  if (target.closest('input, textarea, select, button, a')) return;
+  const actionEl = target.closest('[data-wearable-action]');
+  if (!actionEl || !isWearableActionScope(actionEl)) return;
+  const action = actionEl.dataset.wearableAction || '';
+  if (action !== 'open-manual-log' && action !== 'open-detail') return;
+  event.preventDefault();
+  actionEl.click();
+}
+
+function handleWearableFormSubmit(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const form = target.closest('[data-wearable-form]');
+  if (!form || !form.closest('#detail-modal')) return;
+  if (form.dataset.wearableForm !== 'detail-manual-add') return;
+  event.preventDefault();
+  saveManualEntryFromDetail(form.dataset.wearableMetric || '', form.dataset.wearableKind || '');
+}
+
+function installWearableDelegates() {
+  if (wearableDelegatesInstalled || typeof document === 'undefined') return;
+  wearableDelegatesInstalled = true;
+  document.addEventListener('click', handleWearableActionClick);
+  document.addEventListener('keydown', handleWearableActionKeydown);
+  document.addEventListener('submit', handleWearableFormSubmit);
+}
+
+function rerenderCurrentView() {
+  if (window.navigate) window.navigate(state.currentView || 'dashboard');
+}
+
+function resetOpenManualLogForms({ exceptMetricId = '' } = {}) {
+  const openForms = Array.from(document.querySelectorAll('.wearable-card-empty .wearable-log-form'));
+  const shouldReset = openForms.some(form => form.closest('.wearable-card-empty')?.dataset.emptyMetric !== exceptMetricId);
+  if (!shouldReset) return false;
+  rerenderCurrentView();
+  return true;
+}
+
+function openWearableDetailFromDashboard(metricId, opts = {}) {
+  resetOpenManualLogForms();
+  return openWearableDetail(metricId, opts);
+}
 
 // ─────────────────────────────────────────────────────────
 // MOCK SUMMARY — remove once the real L2 pipeline ships
@@ -230,10 +339,13 @@ function sparklineSVG(series, baseline, worseWhen) {
 // optional pulse) on one card; bp_diastolic and rhr are folded into that
 // same card when BP is empty, so the user sees ONE "BP" affordance rather
 // than three.
-function renderEmptyManualCard(metricId, canon) {
+function renderEmptyManualCard(metricId, canon, opts = {}) {
   const subLabel = canon.sub ? ` <span class="wearable-metric-sub">${escapeHTML(canon.sub)}</span>` : '';
   const label = metricId === 'bp_systolic' ? 'Blood pressure' : canon.label;
-  return `<div class="wearable-card wearable-card-empty" data-empty-metric="${escapeHTML(metricId)}" onclick="openManualLogForm('${escapeHTML(metricId)}',event)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openManualLogForm('${escapeHTML(metricId)}',event)}" role="button" tabindex="0" aria-label="Log ${escapeHTML(label.toLowerCase())} manually">
+  const actionAttrs = opts.interactive === false
+    ? 'aria-disabled="true"'
+    : `${wearableActionAttrs('open-manual-log', { metric: metricId })} role="button" tabindex="0"`;
+  return `<div class="wearable-card wearable-card-empty" data-empty-metric="${escapeAttr(metricId)}" ${actionAttrs} aria-label="Log ${escapeHTML(label.toLowerCase())} manually">
     <div class="wearable-card-top">
       <span class="wearable-metric-name">${escapeHTML(label)}${metricId === 'bp_systolic' ? '' : subLabel}</span>
     </div>
@@ -248,6 +360,7 @@ function renderEmptyManualCard(metricId, canon) {
 
 function renderCard(metricId, canon, metric, showSourceBadge, sourceMaxDate, opts = {}) {
   const pairedMetric = opts.pairedMetric || null;
+  const interactive = opts.interactive !== false;
   // Paired BP card: relabel "BP sys" → "Blood pressure", swap latest/baseline
   // for the "sys/dia" pair string. Trend/sparkline/delta stay sys-based —
   // sys is the more clinically actionable of the two and adding a dual-line
@@ -283,8 +396,8 @@ function renderCard(metricId, canon, metric, showSourceBadge, sourceMaxDate, opt
   // Without the override, the summary picker auto-picks by most-recent
   // non-null value, which can feel arbitrary when two sources report similar
   // freshness. The override is per-metric, persisted in importedData.
-  const sourceBadge = (showSourceBadge && adapter)
-    ? `<button type="button" class="wearable-source-badge wearable-source-badge-btn" onclick="event.stopPropagation();chooseWearableSource('${escapeHTML(metricId)}',event)" title="Click to switch source for this metric">via ${escapeHTML(adapter.displayName)}</button>` : '';
+  const sourceBadge = (interactive && showSourceBadge && adapter)
+    ? `<button type="button" class="wearable-source-badge wearable-source-badge-btn" ${wearableActionAttrs('choose-source', { metric: metricId })} title="Click to switch source for this metric">via ${escapeHTML(adapter.displayName)}</button>` : '';
   // Build a meaningful aria-label: value + unit + trend direction + metric
   // name so screen readers can read the card at a glance without entering it.
   const sysRead = formatValue(metric.latest, canon.unit);
@@ -309,7 +422,10 @@ function renderCard(metricId, canon, metric, showSourceBadge, sourceMaxDate, opt
     ? `${deltaText.replace('↑', 'up').replace('↓', 'down').replace('→', 'flat at')} vs baseline, `
     : '';
   const ariaLabel = `${canonRead} ${valueRead}${canon.unit ? ' ' + canon.unit : ''}, ${deltaRead}${trendRead} — open detail`;
-  return `<div class="wearable-card" onclick="openWearableDetail('${escapeHTML(metricId)}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openWearableDetail('${escapeHTML(metricId)}')}" role="button" tabindex="0" aria-label="${escapeHTML(ariaLabel)}">
+  const actionAttrs = interactive
+    ? ` ${wearableActionAttrs('open-detail', { metric: metricId })} role="button" tabindex="0"`
+    : '';
+  return `<div class="wearable-card"${actionAttrs} aria-label="${escapeAttr(ariaLabel)}">
     <div class="wearable-card-top">
       <span class="wearable-metric-name">${escapeHTML(cardLabel)}${subLabel}</span>
       ${deltaText ? `<span class="wearable-delta ${deltaCls}">${deltaText}</span>` : ''}
@@ -344,8 +460,8 @@ function renderWearableStripStub() {
         <span class="wearable-strip-stub-brands">Oura · Withings · Fitbit · Polar · Apple Health</span>
       </div>
       <div class="wearable-strip-stub-actions">
-        <button class="wearable-strip-stub-cta" onclick="window.openSettingsModal('wearables')">Connect</button>
-        <button class="wearable-strip-stub-dismiss" title="Hide this hint" aria-label="Dismiss wearable hint" onclick="dismissWearableStub()">×</button>
+        <button class="wearable-strip-stub-cta" ${wearableActionAttrs('open-settings-wearables')}>Connect</button>
+        <button class="wearable-strip-stub-dismiss" title="Hide this hint" aria-label="Dismiss wearable hint" ${wearableActionAttrs('dismiss-stub')}>×</button>
       </div>
     </div>
   </section>`;
@@ -357,6 +473,7 @@ function dismissWearableStub() {
 }
 
 export function renderWearableStrip() {
+  installWearableDelegates();
   const wearablesHidden = isWearableStripHidden();
   let summary = getWearableSummary();
   // Wearables-off mode: drop the demo summary (no mock vendor cards) so
@@ -520,7 +637,7 @@ export function renderWearableStrip() {
     : `<span>Wearables: <span class="wearable-source-label">${escapeHTML(sourceLabel)}${coverageLabel}</span></span>`;
   const hasStaleSource = !manualOnly && sourceIds.some(s => s !== 'manual' && Date.now() - (summary.sources?.[s]?.lastSyncAt || 0) >= 12 * 60 * 60 * 1000);
   const lastSyncHTML = manualOnly ? '' : `<span class="wearable-strip-lastsync">last synced ${formatAgo(lastSyncAt)}</span>`;
-  const syncBtnHTML = manualOnly || !hasStaleSource ? '' : `<button type="button" class="wearable-strip-sync" aria-label="Sync stale wearables now" onclick="event.stopPropagation();syncWearableNow(this);return false">
+  const syncBtnHTML = manualOnly || !hasStaleSource ? '' : `<button type="button" class="wearable-strip-sync" aria-label="Sync stale wearables now" ${wearableActionAttrs('sync-now')}>
     <svg class="wearable-strip-sync-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><polyline points="21 4 21 12 13 12"/></svg>
     <span>Sync stale data</span>
   </button>`;
@@ -528,25 +645,24 @@ export function renderWearableStrip() {
     ? (collapsed ? 'Expand biometrics strip' : 'Collapse biometrics strip')
     : (collapsed ? 'Expand wearables strip' : 'Collapse wearables strip');
 
-  // axe nested-interactive: parent is mouse-clickable but keyboard
-  // toggle lives on the chevron button below. The other action buttons
-  // (sync, reorder, demo-pill) keep stopPropagation so they don't trip
-  // the row-click collapse handler.
+  // axe nested-interactive: parent is mouse-clickable but keyboard toggle
+  // lives on the chevron button below. Nested buttons carry their own
+  // delegated actions, so the document handler only runs the closest action.
   let html = `<section class="wearable-strip" id="wearable-strip">
-    <div class="wearable-strip-header" onclick="toggleWearableStrip()" style="cursor:pointer">
+    <div class="wearable-strip-header" ${wearableActionAttrs('toggle-strip')} style="cursor:pointer">
       <div class="wearable-strip-title">
         <span class="wearable-strip-icon" aria-hidden="true">⌬</span>
         ${titleHTML}
-        ${!manualOnly && showDemoPill ? '<button type="button" class="wearable-strip-demo-pill" onclick="event.stopPropagation();window.openSettingsModal(\'wearables\')" title="This is a sample. Connect your own wearable to see real data here.">demo data — connect yours</button>' : ''}
+        ${!manualOnly && showDemoPill ? `<button type="button" class="wearable-strip-demo-pill" ${wearableActionAttrs('open-settings-wearables')} title="This is a sample. Connect your own wearable to see real data here.">demo data — connect yours</button>` : ''}
         ${reorderMode ? '<span class="wearable-strip-reorder-pill">⇄ Reorder mode — use ◀ ▶ on each card</span>' : ''}
       </div>
       <div class="wearable-strip-meta">
         ${lastSyncHTML}
         ${syncBtnHTML}
-        <button type="button" class="wearable-strip-reorder${reorderMode ? ' active' : ''}" aria-label="${reorderMode ? 'Done reordering' : 'Reorder cards'}" title="${reorderMode ? 'Done reordering' : 'Reorder cards'}" onclick="event.stopPropagation();toggleWearableReorder()">
+        <button type="button" class="wearable-strip-reorder${reorderMode ? ' active' : ''}" aria-label="${reorderMode ? 'Done reordering' : 'Reorder cards'}" title="${reorderMode ? 'Done reordering' : 'Reorder cards'}" ${wearableActionAttrs('toggle-reorder')}>
           ${reorderMode ? 'Done' : '⇄ Reorder'}
         </button>
-        <button type="button" class="wearable-collapse-arrow${collapsed ? ' collapsed' : ''}" aria-expanded="${!collapsed}" aria-label="${ariaLabel}" onclick="event.stopPropagation();toggleWearableStrip()">▾</button>
+        <button type="button" class="wearable-collapse-arrow${collapsed ? ' collapsed' : ''}" aria-expanded="${!collapsed}" aria-label="${ariaLabel}" ${wearableActionAttrs('toggle-strip')}>▾</button>
       </div>
     </div>
     <div class="wearable-card-grid${collapsed ? ' hidden' : ''}${reorderMode ? ' wearable-card-grid-reorder' : ''}">`;
@@ -561,7 +677,7 @@ export function renderWearableStrip() {
     if (!canon) continue;
     let cardHtml;
     if (empty) {
-      cardHtml = renderEmptyManualCard(metricId, canon);
+      cardHtml = renderEmptyManualCard(metricId, canon, { interactive: !reorderMode });
     } else {
       const metric = summary.metrics[metricId];
       if (!metric) continue;
@@ -573,16 +689,16 @@ export function renderWearableStrip() {
       // redundancy with the header.
       // BP card: pull the dia partner so renderCard can format "120/80".
       const pairedMetric = (metricId === 'bp_systolic') ? summary.metrics?.bp_diastolic : null;
-      cardHtml = renderCard(metricId, canon, metric, showSourceBadges, sourceMaxDate[metric.primarySource], { pairedMetric });
+      cardHtml = renderCard(metricId, canon, metric, showSourceBadges, sourceMaxDate[metric.primarySource], { pairedMetric, interactive: !reorderMode });
     }
     if (reorderMode) {
       const canLeft = i > 0;
       const canRight = i < finalOrder.length - 1;
       cardHtml = `<div class="wearable-card-reorder-wrap" data-reorder-metric="${escapeHTML(metricId)}">
-        ${cardHtml.replace(/ onclick="[^"]*"/, '').replace(/ onkeydown="[^"]*"/, '').replace(/ tabindex="0"/, '')}
+        ${cardHtml}
         <div class="wearable-reorder-arrows">
-          <button type="button" class="wearable-reorder-arrow" aria-label="Move ${escapeHTML(canon.label)} left" ${canLeft ? '' : 'disabled'} onclick="event.stopPropagation();moveWearableCard('${escapeHTML(metricId)}',-1)">◀</button>
-          <button type="button" class="wearable-reorder-arrow" aria-label="Move ${escapeHTML(canon.label)} right" ${canRight ? '' : 'disabled'} onclick="event.stopPropagation();moveWearableCard('${escapeHTML(metricId)}',1)">▶</button>
+          <button type="button" class="wearable-reorder-arrow" aria-label="Move ${escapeHTML(canon.label)} left" ${canLeft ? '' : 'disabled'} ${wearableActionAttrs('move-card', { metric: metricId, delta: -1 })}>◀</button>
+          <button type="button" class="wearable-reorder-arrow" aria-label="Move ${escapeHTML(canon.label)} right" ${canRight ? '' : 'disabled'} ${wearableActionAttrs('move-card', { metric: metricId, delta: 1 })}>▶</button>
         </div>
       </div>`;
     }
@@ -832,15 +948,20 @@ async function moveWearableCard(metricId, delta) {
 // ─────────────────────────────────────────────────────────
 
 
-function openManualLogForm(metricId, event) {
+function openManualLogForm(metricId, event, opts = {}) {
+  if (!opts.delegated && event?.target?.closest?.('[data-wearable-action]')) return;
   if (event) event.stopPropagation();
-  const card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
+  let card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
   if (!card) return;
   // Idempotent: clicks inside the form (e.g. tapping the dia field on the
-  // BP card) bubble to the card's onclick. Without this guard we'd rebuild
+  // BP card) bubble to the card's delegated action. Without this guard we'd rebuild
   // innerHTML and refocus the first input — yanking the cursor off whatever
   // the user actually clicked.
   if (card.querySelector('.wearable-log-form')) return;
+  if (resetOpenManualLogForms({ exceptMetricId: metricId })) {
+    card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
+    if (!card) return;
+  }
   const today = isoDay();
   if (metricId === 'weight') {
     card.innerHTML = `
@@ -850,8 +971,8 @@ function openManualLogForm(metricId, event) {
         ${_renderNoteField('wl-weight-note')}
         <div class="wearable-log-row">
           <input type="date" class="wearable-log-date" id="wl-weight-date" value="${today}" max="${today}" aria-label="Date">
-          <button type="button" class="wearable-log-save" onclick="saveManualLog('weight',event)">Save</button>
-          <button type="button" class="wearable-log-cancel" onclick="cancelManualLog(event)" aria-label="Cancel">✕</button>
+          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'weight' })}>Save</button>
+          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
         </div>
       </div>`;
   } else if (metricId === 'bp_systolic') {
@@ -868,8 +989,8 @@ function openManualLogForm(metricId, event) {
         ${_renderNoteField('wl-bp-note')}
         <div class="wearable-log-row">
           <input type="date" class="wearable-log-date" id="wl-bp-date" value="${today}" max="${today}" aria-label="Date">
-          <button type="button" class="wearable-log-save" onclick="saveManualLog('bp',event)">Save</button>
-          <button type="button" class="wearable-log-cancel" onclick="cancelManualLog(event)" aria-label="Cancel">✕</button>
+          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'bp' })}>Save</button>
+          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
         </div>
       </div>`;
   } else if (metricId === 'rhr') {
@@ -881,8 +1002,8 @@ function openManualLogForm(metricId, event) {
         ${_renderNoteField('wl-rhr-note')}
         <div class="wearable-log-row">
           <input type="date" class="wearable-log-date" id="wl-rhr-date" value="${today}" max="${today}" aria-label="Date">
-          <button type="button" class="wearable-log-save" onclick="saveManualLog('rhr',event)">Save</button>
-          <button type="button" class="wearable-log-cancel" onclick="cancelManualLog(event)" aria-label="Cancel">✕</button>
+          <button type="button" class="wearable-log-save" ${wearableActionAttrs('manual-log-save', { kind: 'rhr' })}>Save</button>
+          <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('manual-log-cancel')} aria-label="Cancel">✕</button>
         </div>
       </div>`;
   }
@@ -934,7 +1055,7 @@ async function saveManualLog(kind, event) {
       await logManualBP(profileId, { date, systolic: sys, diastolic: dia, pulse: isFinite(pulse) && pulse > 0 ? pulse : undefined, tags, note });
     }
     await refreshManualSummary(profileId);
-    if (window.navigate) window.navigate('dashboard');
+    rerenderCurrentView();
     showNotification?.('Saved', 'success');
   } catch (e) {
     showNotification?.('Could not save: ' + e.message, 'error');
@@ -943,9 +1064,11 @@ async function saveManualLog(kind, event) {
 
 function cancelManualLog(event) {
   if (event) event.stopPropagation();
-  // Re-render strip to restore the empty card.
-  if (window.navigate) window.navigate('dashboard');
+  // Re-render the current dashboard/body surface to restore the empty card.
+  rerenderCurrentView();
 }
+
+installWearableDelegates();
 
 Object.assign(window, {
   renderWearableStrip,
@@ -953,7 +1076,7 @@ Object.assign(window, {
   isWearableStripHidden,
   dismissWearableStub,
   toggleWearableStrip,
-  openWearableDetail,
+  openWearableDetail: openWearableDetailFromDashboard,
   setWearableDetailRange,
   _uninstallWearableModalFocusTrap,
   syncWearableNow,

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -170,6 +170,7 @@ const LEGACY_TESTS = [
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',
   './test-lens-page-shell-delegated-actions.js',
+  './test-wearables-delegated-actions.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',
   // Batch 32 — test-wearables (~549 asserts: registry, IDB CRUD via

--- a/tests/test-wearables-bp-merge.js
+++ b/tests/test-wearables-bp-merge.js
@@ -78,7 +78,7 @@ assert('moveWearableCard mirrors the same dia-skip when sys present',
 console.log('4. Form idempotency (source)');
 
 assert('openManualLogForm returns early when the form is already rendered',
-  /openManualLogForm[\s\S]{0,500}if \(card\.querySelector\('\.wearable-log-form'\)\) return/.test(wearablesSrc));
+  /openManualLogForm[\s\S]{0,700}if \(card\.querySelector\('\.wearable-log-form'\)\) return/.test(wearablesSrc));
 assert('Idempotency guard has a comment explaining the dia-click bug',
   /clicks inside the form \(e\.g\. tapping the dia field on the[\s\S]{0,200}Without this guard we'd rebuild/.test(wearablesSrc));
 

--- a/tests/test-wearables-delegated-actions.js
+++ b/tests/test-wearables-delegated-actions.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Static wearables delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const stripSrc = fs.readFileSync(path.join(root, 'js/wearables.js'), 'utf8');
+const detailSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-modal.js'), 'utf8');
+const stripImportsSharedActionHelper = /import\s*{[^}]*\bwearableActionAttrs\b[^}]*}\s*from\s+'\.\/wearables-detail-modal\.js';/s.test(stripSrc);
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Wearables Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
+
+assert('wearables strip renders no inline event attributes',
+  !inlineHandlerRe.test(stripSrc));
+assert('wearables detail modal renders no inline event attributes',
+  !inlineHandlerRe.test(detailSrc));
+assert('wearables strip renders delegated action attributes',
+  stripImportsSharedActionHelper &&
+    stripSrc.includes("wearableActionAttrs('open-manual-log'") &&
+    stripSrc.includes("wearableActionAttrs('open-detail'") &&
+    stripSrc.includes("wearableActionAttrs('move-card'") &&
+    stripSrc.includes("wearableActionAttrs('manual-log-save'"));
+assert('wearables detail modal renders delegated action and form attributes',
+  detailSrc.includes('export function wearableActionAttrs') &&
+    detailSrc.includes('function wearableFormAttrs') &&
+    detailSrc.includes('data-wearable-action=') &&
+    detailSrc.includes('data-wearable-form=') &&
+    detailSrc.includes("wearableActionAttrs('set-detail-range'") &&
+    detailSrc.includes("wearableActionAttrs('delete-detail-manual-entry'") &&
+    detailSrc.includes("wearableFormAttrs('detail-manual-add'"));
+assert('wearable action attr helper has one shared definition',
+  (stripSrc.match(/\bfunction\s+wearableActionAttrs\b/g) || []).length === 0 &&
+    (detailSrc.match(/\bfunction\s+wearableActionAttrs\b/g) || []).length === 1 &&
+    stripImportsSharedActionHelper);
+assert('wearables module installs idempotent click keydown and submit delegates',
+  stripSrc.includes('let wearableDelegatesInstalled = false') &&
+    stripSrc.includes("document.addEventListener('click', handleWearableActionClick)") &&
+    stripSrc.includes("document.addEventListener('keydown', handleWearableActionKeydown)") &&
+    stripSrc.includes("document.addEventListener('submit', handleWearableFormSubmit)") &&
+    stripSrc.includes('installWearableDelegates();'));
+assert('wearables delegated clicks are scoped to wearables surfaces',
+  stripSrc.includes("closest('.wearable-strip, #detail-modal, .db-biometric-overview-grid')"));
+assert('wearables detail opens reset any active manual inline form',
+  stripSrc.includes('function openWearableDetailFromDashboard') &&
+    stripSrc.includes('resetOpenManualLogForms();') &&
+    stripSrc.includes('openWearableDetail: openWearableDetailFromDashboard'));
+assert('wearables delegated manual log open bypasses only the legacy inline-card guard',
+  stripSrc.includes("openManualLogForm(metricId, event, { delegated: true })") &&
+    stripSrc.includes("!opts.delegated && event?.target?.closest?.('[data-wearable-action]')") &&
+    !stripSrc.includes("if (event?.target?.closest?.('[data-wearable-action]')) return;"));
+assert('wearables delegated keyboard ignores form controls',
+  stripSrc.includes("target.closest('input, textarea, select, button, a')"));
+
+[
+  'open-manual-log',
+  'open-detail',
+  'choose-source',
+  'open-settings-wearables',
+  'dismiss-stub',
+  'toggle-strip',
+  'sync-now',
+  'toggle-reorder',
+  'move-card',
+  'manual-log-save',
+  'manual-log-cancel',
+  'modal-close',
+  'set-detail-range',
+  'open-detail-manual-add',
+  'delete-detail-manual-entry',
+  'close-detail-manual-add',
+  'open-emf-assessment',
+].forEach(action => {
+  assert(`wearables action ${action} is handled`, stripSrc.includes(`action === '${action}'`));
+});
+
+assert('reorder mode renders non-interactive cards and delegated arrows',
+  stripSrc.includes('interactive: !reorderMode') &&
+    !stripSrc.includes('replace(/ onclick=') &&
+    stripSrc.includes("wearableActionAttrs('move-card'"));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -43,6 +43,33 @@ return (async function() {
   localStorage.removeItem('wearable-detail-range');
 
   // ═══════════════════════════════════════
+  // 0. Strip empty-card manual log delegate
+  // ═══════════════════════════════════════
+  console.log('%c 0. Strip Manual Delegate ', 'font-weight:bold;color:#f59e0b');
+  const priorSummary = window._labState.importedData.wearableSummary;
+  const stripHost = document.createElement('div');
+  try {
+    window._labState.importedData.wearableSummary = {
+      sources: { oura: { connectedSince: '2026-01-01', lastSyncAt: Date.now(), coverageDays: 5 } },
+      metrics: {
+        hrv_rmssd: { primarySource: 'oura', latest: 42, latestDate: '2026-04-22', baseline: 40, baselineP25: 36, baselineP75: 44, rolling: { d7: 42, d30: 40, d90: 40 }, trend30d: 'rising', weekly: [38, 40, 42] },
+      },
+    };
+    stripHost.innerHTML = window.renderWearableStrip();
+    document.body.prepend(stripHost);
+    const emptyWeightCard = stripHost.querySelector('.wearable-card-empty[data-empty-metric="weight"]');
+    assert('Strip renders empty manual card with delegated open action',
+      emptyWeightCard?.dataset?.wearableAction === 'open-manual-log');
+    emptyWeightCard?.click();
+    await waitFor(() => !!stripHost.querySelector('#wl-weight-val'));
+    assert('Delegated empty strip card opens the inline manual form',
+      !!stripHost.querySelector('#wl-weight-val'));
+  } finally {
+    stripHost.remove();
+    window._labState.importedData.wearableSummary = priorSummary;
+  }
+
+  // ═══════════════════════════════════════
   // A. Detail modal — HRV + activity_score
   // ═══════════════════════════════════════
   console.log('%c A. Detail Modal ', 'font-weight:bold;color:#f59e0b');

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -311,6 +311,46 @@ return (async function() {
       !!document.querySelector('.db-biometric-sync-btn'));
   }
 
+  // ═══════════════════════════════════════
+  // 9. Empty BP card cancel/reset inside Biometrics Overview
+  // ═══════════════════════════════════════
+  console.log('%c 9. Manual BP Card Reset ', 'font-weight:bold;color:#f59e0b');
+  localStorage.setItem(BIOMETRIC_SELECTION_KEY, JSON.stringify(['bp_systolic', 'rhr']));
+  const resetSummary = window._labState.importedData.wearableSummary;
+  if (resetSummary?.metrics) {
+    delete resetSummary.metrics.bp_systolic;
+    delete resetSummary.metrics.bp_diastolic;
+  }
+  if (window.navigate) window.navigate('dashboard');
+  await new Promise(r => setTimeout(r, 300));
+  const bpEmptyCard = document.querySelector('.db-biometric-overview-grid .wearable-card-empty[data-empty-metric="bp_systolic"]');
+  assert('Empty BP card renders inside Biometrics Overview',
+    !!bpEmptyCard);
+  bpEmptyCard?.click();
+  await new Promise(r => setTimeout(r, 200));
+  assert('Clicking empty BP card opens the inline BP form',
+    !!document.getElementById('wl-bp-sys') && !!document.getElementById('wl-bp-dia'));
+  document.getElementById('wl-bp-dia')?.click();
+  await new Promise(r => setTimeout(r, 50));
+  assert('Clicking inside BP fields does not rebuild or duplicate the form',
+    document.querySelectorAll('.db-biometric-overview-grid .wearable-log-form').length === 1 &&
+    !!document.getElementById('wl-bp-sys') &&
+    !!document.getElementById('wl-bp-dia'));
+  document.querySelector('.db-biometric-overview-grid .wearable-log-cancel')?.click();
+  await new Promise(r => setTimeout(r, 300));
+  assert('BP card cancel restores the empty card in Biometrics Overview',
+    !document.getElementById('wl-bp-sys') &&
+    !!document.querySelector('.db-biometric-overview-grid .wearable-card-empty[data-empty-metric="bp_systolic"]'));
+  document.querySelector('.db-biometric-overview-grid .wearable-card-empty[data-empty-metric="bp_systolic"]')?.click();
+  await new Promise(r => setTimeout(r, 200));
+  document.querySelector('.db-biometric-overview-grid .db-biometric-widget')?.click();
+  await new Promise(r => setTimeout(r, 400));
+  assert('Opening another biometric card closes any active BP inline form',
+    !document.getElementById('wl-bp-sys') &&
+    document.getElementById('modal-overlay')?.classList?.contains('show'));
+  if (window.closeModal) window.closeModal();
+  await new Promise(r => setTimeout(r, 200));
+
   // ─────────────────────────────────────────────────────────
   // Cleanup — delete IDB rows + restore live state
   // ─────────────────────────────────────────────────────────

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.320';
+self.APP_VERSION = '1.8.322';


### PR DESCRIPTION
## Summary
- Replace wearables strip and detail-modal inline event attributes with a scoped `data-wearable-action` / `data-wearable-form` delegate.
- Keep existing window-exported wearables functions as compatibility wrappers while routing rendered controls through the delegate.
- Add a static regression guard for the wearables delegated-action contract and bump `version.js` for cache invalidation.

## Validation
- `node tests/test-wearables-delegated-actions.js`
- `node tests/test-wearables-bp-merge.js`
- `npm test -- --run tests/_vitest-legacy.test.js`
- `./run-tests.sh`