### PR TITLE
[codex] Delegate biometric overview actions

### DIFF
--- a/js/dashboard-widget-controls.js
+++ b/js/dashboard-widget-controls.js
@@ -3,6 +3,24 @@
 import { DASHBOARD_WIDGET_SOURCE_ORDER, dashboardBiometricSelectionKey } from './dashboard-widgets.js';
 import { escapeAttr, escapeHTML, formatValue, getStatus, safeMarkerId, showNotification } from './utils.js';
 
+export function dashboardWidgetActionAttrs(action, attrs = {}) {
+  return [
+    `data-dashboard-widget-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-dashboard-widget-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+export function dashboardWidgetInputAttrs(action) {
+  return `data-dashboard-widget-input="${escapeAttr(action)}"`;
+}
+
+export function dashboardWidgetDragAttrs(id) {
+  const safeId = escapeAttr(id);
+  return `data-dashboard-widget-drag-id="${safeId}" data-dashboard-widget-drop-id="${safeId}"`;
+}
+
 export function createDashboardWidgetControls(deps) {
   let organizeMode = false;
   let draggingWidgetId = null;
@@ -33,24 +51,6 @@ export function createDashboardWidgetControls(deps) {
 
   function isOrganizeMode() {
     return organizeMode;
-  }
-
-  function dashboardWidgetActionAttrs(action, attrs = {}) {
-    return [
-      `data-dashboard-widget-action="${escapeAttr(action)}"`,
-      ...Object.entries(attrs)
-        .filter(([, value]) => value !== undefined && value !== null && value !== '')
-        .map(([name, value]) => `data-dashboard-widget-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
-    ].join(' ');
-  }
-
-  function dashboardWidgetInputAttrs(action) {
-    return `data-dashboard-widget-input="${escapeAttr(action)}"`;
-  }
-
-  function dashboardWidgetDragAttrs(id) {
-    const safeId = escapeAttr(id);
-    return `data-dashboard-widget-drag-id="${safeId}" data-dashboard-widget-drop-id="${safeId}"`;
   }
 
   function renderDashboardControlButtons({ includeReset = false } = {}) {
@@ -222,7 +222,7 @@ export function createDashboardWidgetControls(deps) {
     if (empty) empty.hidden = visible > 0;
   }
 
-  function handleDashboardWidgetAction(actionEl) {
+  function handleDashboardWidgetAction(actionEl, event) {
     const action = actionEl.dataset.dashboardWidgetAction || '';
     const id = actionEl.dataset.dashboardWidgetId || '';
     if (action === 'toggle-organize') {
@@ -252,6 +252,17 @@ export function createDashboardWidgetControls(deps) {
     } else if (action === 'connect-source') {
       window.openSettingsModal?.('wearables');
       closeDashboardWidgetPicker();
+    } else if (action === 'open-biometric-picker') {
+      openDashboardBiometricPicker();
+    } else if (action === 'sync-biometric-now') {
+      window.syncWearableNow?.(actionEl);
+    } else if (action === 'remove-biometric-metric') {
+      removeDashboardBiometricMetric(id);
+    } else if (action === 'open-biometric-detail') {
+      if (window.openWearableDetail) window.openWearableDetail(id);
+      else window.openSettingsModal?.('wearables');
+    } else if (action === 'open-biometric-manual-log') {
+      window.openManualLogForm?.(id, event);
     }
   }
 
@@ -265,8 +276,22 @@ export function createDashboardWidgetControls(deps) {
     }
     const actionEl = target.closest('[data-dashboard-widget-action]');
     if (!actionEl) return;
+    const wearableActionEl = target.closest('[data-wearable-action]');
+    if (wearableActionEl && actionEl.contains(wearableActionEl)) return;
     event.preventDefault();
-    handleDashboardWidgetAction(actionEl);
+    handleDashboardWidgetAction(actionEl, event);
+  }
+
+  function handleDashboardWidgetKeydown(event) {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+    if (target.closest('input, textarea, select, button, a')) return;
+    const actionEl = target.closest('[data-dashboard-widget-action]');
+    if (!actionEl) return;
+    if ((actionEl.dataset.dashboardWidgetAction || '') !== 'open-biometric-manual-log') return;
+    event.preventDefault();
+    actionEl.click();
   }
 
   function handleDashboardWidgetInput(event) {
@@ -309,6 +334,7 @@ export function createDashboardWidgetControls(deps) {
     if (dashboardWidgetDelegatesInstalled || typeof document === 'undefined') return;
     dashboardWidgetDelegatesInstalled = true;
     document.addEventListener('click', handleDashboardWidgetClick);
+    document.addEventListener('keydown', handleDashboardWidgetKeydown);
     document.addEventListener('input', handleDashboardWidgetInput);
     document.addEventListener('dragstart', handleDashboardWidgetDragStart);
     document.addEventListener('dragover', handleDashboardWidgetDragOver);

--- a/js/dashboard-widget-renderers.js
+++ b/js/dashboard-widget-renderers.js
@@ -2,6 +2,7 @@
 
 import { state } from './state.js';
 import { DEFAULT_METRIC_ORDER, canonicalMetric, metricsForSources } from './wearable-adapters.js';
+import { dashboardWidgetActionAttrs } from './dashboard-widget-controls.js';
 import { dashboardBiometricSelectionKey, DASHBOARD_MANUAL_BIOMETRIC_METRICS } from './dashboard-widgets.js';
 import { createDashboardRecommendationWidget } from './dashboard-recommendation-widget.js';
 import { ensureSNPTable, findGenotypeInfo, getSnpCategoryLabel } from './dna.js';
@@ -734,7 +735,7 @@ export function createDashboardWidgetRenderers(deps) {
     if (!syncState.lastSyncAt && !syncState.showSync) return '';
     const label = syncState.lastSyncAt ? `Updated ${formatDashboardRelativeTime(syncState.lastSyncAt)}` : 'Not synced yet';
     return `<span class="db-biometric-sync-status${syncState.showSync ? ' is-stale' : ''}">${escapeHTML(label)}</span>
-      ${syncState.showSync ? `<button type="button" class="dashboard-action-btn db-biometric-sync-btn" onclick="event.stopPropagation();window.syncWearableNow?.(this)">Sync stale data</button>` : ''}`;
+      ${syncState.showSync ? `<button type="button" class="dashboard-action-btn db-biometric-sync-btn" ${dashboardWidgetActionAttrs('sync-biometric-now')}>Sync stale data</button>` : ''}`;
   }
 
   function getDashboardBiometricTile(metricId, { allowEmptyManual = false } = {}) {
@@ -764,10 +765,10 @@ export function createDashboardWidgetRenderers(deps) {
   }
 
   function renderDashboardBiometricTile(tile) {
-    const remove = `<button type="button" class="db-biometric-remove" onclick="event.stopPropagation();window.removeDashboardBiometricMetric('${escapeAttr(tile.id)}')" aria-label="Remove ${escapeAttr(tile.label)} from Biometrics Overview" title="Remove metric">&times;</button>`;
+    const remove = `<button type="button" class="db-biometric-remove" ${dashboardWidgetActionAttrs('remove-biometric-metric', { id: tile.id })} aria-label="Remove ${escapeAttr(tile.label)} from Biometrics Overview" title="Remove metric">&times;</button>`;
     if (tile.empty) {
       return `<div class="db-biometric-tile-wrap">
-        <div class="wearable-card wearable-card-empty db-biometric-manual-empty" data-empty-metric="${escapeAttr(tile.id)}" onclick="window.openManualLogForm?.('${escapeAttr(tile.id)}',event)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.openManualLogForm?.('${escapeAttr(tile.id)}',event)}" role="button" tabindex="0" aria-label="Log ${escapeAttr(tile.label.toLowerCase())} manually">
+        <div class="wearable-card wearable-card-empty db-biometric-manual-empty" data-empty-metric="${escapeAttr(tile.id)}" ${dashboardWidgetActionAttrs('open-biometric-manual-log', { id: tile.id })} role="button" tabindex="0" aria-label="Log ${escapeAttr(tile.label.toLowerCase())} manually">
           <div class="wearable-card-top"><span class="wearable-metric-name">${escapeHTML(tile.label)}</span></div>
           <div class="wearable-value-row wearable-value-row-empty"><span class="wearable-value wearable-value-dash">-</span></div>
           <div class="wearable-card-bottom"><div class="wearable-empty-cta">+ Log</div></div>
@@ -776,7 +777,7 @@ export function createDashboardWidgetRenderers(deps) {
       </div>`;
     }
     return `<div class="db-biometric-tile-wrap">
-      <button type="button" class="db-wearable-tile db-biometric-widget" onclick="window.openWearableDetail ? window.openWearableDetail('${escapeAttr(tile.id)}') : window.openSettingsModal?.('wearables')" aria-label="${escapeAttr(tile.label + ': ' + tile.value + ' ' + tile.unit)}">
+      <button type="button" class="db-wearable-tile db-biometric-widget" ${dashboardWidgetActionAttrs('open-biometric-detail', { id: tile.id })} aria-label="${escapeAttr(tile.label + ': ' + tile.value + ' ' + tile.unit)}">
         <span class="db-wearable-label">${escapeHTML(tile.label)}</span>
         <strong>${escapeHTML(tile.value)}</strong>
         <span class="db-wearable-foot"><small>${escapeHTML(tile.unit || '')}</small><em>${escapeHTML(tile.change || 'latest')}</em></span>
@@ -795,7 +796,7 @@ export function createDashboardWidgetRenderers(deps) {
       <span>${escapeHTML(String(tiles.length))} metric${tiles.length === 1 ? '' : 's'} selected</span>
       <div class="db-biometric-overview-actions">
         ${syncStatus}
-        <button type="button" class="dashboard-action-btn" onclick="window.openDashboardBiometricPicker()">Add metrics</button>
+        <button type="button" class="dashboard-action-btn" ${dashboardWidgetActionAttrs('open-biometric-picker')}>Add metrics</button>
       </div>
     </div>`;
     if (!tiles.length) {

--- a/js/profile.js
+++ b/js/profile.js
@@ -534,6 +534,7 @@ export async function loadProfile(profileId) {
     if (state.currentProfile !== profileId) return;
     try { await summaryMod.syncWearableSummary(profileId, connectMod.listConnectedSources()); } catch {}
     if (state.currentProfile !== profileId) return; // re-check post-await — sync also takes IDB time
+    connectMod.syncStaleWearablesNow?.().catch(() => {});
   }).catch(() => {});
 }
 

--- a/js/startup-maintenance.js
+++ b/js/startup-maintenance.js
@@ -1,7 +1,7 @@
 // startup-maintenance.js - startup service boot and non-blocking maintenance
 
 import { state } from './state.js';
-import { initWearableScheduler, loadWearableRuntimeConfig } from './wearables-connect.js';
+import { initWearableScheduler, loadWearableRuntimeConfig, syncStaleWearablesNow } from './wearables-connect.js';
 import { migrateBiometricsToManual, hasManualData } from './wearables-manual.js';
 
 export function initializeStartupServices() {
@@ -15,6 +15,7 @@ export function initializeStartupServices() {
 }
 
 export function runPostProfileStartupMaintenance() {
+  syncStaleWearablesNow().catch(() => {});
   scheduleSunSessionRehydrate();
   hydrateUserLightDevicesFromPresets();
   migrateLegacyBiometrics();

--- a/js/wearables-connect.js
+++ b/js/wearables-connect.js
@@ -510,6 +510,7 @@ const STALE_MS         = 12 * 60 * 60 * 1000;
 
 let _pollTimer = null;
 let _schedulerInstalled = false;
+let _staleSyncInFlight = null;
 
 async function maybeSyncStaleSources() {
   // Wait for the runtime-config fetch (or its 1.5s timeout) so a self-hoster's
@@ -531,14 +532,21 @@ async function maybeSyncStaleSources() {
   }
 }
 
+export function syncStaleWearablesNow() {
+  if (_staleSyncInFlight) return _staleSyncInFlight;
+  _staleSyncInFlight = maybeSyncStaleSources()
+    .finally(() => { _staleSyncInFlight = null; });
+  return _staleSyncInFlight;
+}
+
 export function initWearableScheduler() {
   if (_schedulerInstalled) return;
   _schedulerInstalled = true;
-  maybeSyncStaleSources();
+  syncStaleWearablesNow();
   document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible') maybeSyncStaleSources();
+    if (document.visibilityState === 'visible') syncStaleWearablesNow();
   });
-  _pollTimer = setInterval(maybeSyncStaleSources, POLL_INTERVAL_MS);
+  _pollTimer = setInterval(syncStaleWearablesNow, POLL_INTERVAL_MS);
   window.addEventListener('beforeunload', () => { if (_pollTimer) clearInterval(_pollTimer); });
 }
 

--- a/tests/test-dashboard-widget-delegated-actions-dom.js
+++ b/tests/test-dashboard-widget-delegated-actions-dom.js
@@ -14,8 +14,16 @@ return (async function() {
   console.log('%c Dashboard Widget Delegated Actions DOM ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
   const stateModule = await import('./js/state.js');
+  const dashboardWidgetsModule = await import('./js/dashboard-widgets.js');
   const st = stateModule.state;
   const originalView = st.currentView;
+  const biometricSelectionKey = dashboardWidgetsModule.dashboardBiometricSelectionKey();
+  let originalSyncWearableNow;
+  let originalBiometricSelection;
+  let originalWearableSummary;
+  let originalWearableConnections;
+  let hadWearableSummary = false;
+  let hadWearableConnections = false;
 
   try {
     if (!window.getActiveData?.()?.dates?.length) {
@@ -80,7 +88,102 @@ return (async function() {
     await delay(50);
     assert('picker backdrop click closes only through delegated target check',
       !document.getElementById('dashboard-widget-picker-overlay'));
+
+    originalSyncWearableNow = window.syncWearableNow;
+    originalBiometricSelection = localStorage.getItem(biometricSelectionKey);
+    st.importedData = st.importedData || {};
+    hadWearableSummary = Object.prototype.hasOwnProperty.call(st.importedData, 'wearableSummary');
+    hadWearableConnections = Object.prototype.hasOwnProperty.call(st.importedData, 'wearableConnections');
+    originalWearableSummary = st.importedData.wearableSummary;
+    originalWearableConnections = st.importedData.wearableConnections;
+
+    st.importedData.wearableConnections = {
+      oura: {
+        source: 'oura',
+        connectedAt: '2026-01-01T00:00:00.000Z',
+        lastSyncAt: Date.now() - (13 * 60 * 60 * 1000),
+        coverageDays: 1,
+        accessToken: 'test-token',
+      },
+    };
+    st.importedData.wearableSummary = {
+      summaryUpdatedAt: new Date().toISOString(),
+      sources: {
+        manual: { connectedSince: '2026-01-01T00:00:00.000Z', lastSyncAt: Date.now(), coverageDays: 1 },
+        oura: { connectedSince: '2026-01-01T00:00:00.000Z', lastSyncAt: Date.now() - (13 * 60 * 60 * 1000), coverageDays: 1 },
+      },
+      metrics: {
+        rhr: {
+          primarySource: 'manual',
+          latest: 62,
+          latestDate: '2026-04-22',
+          baseline: 60,
+          baselineP25: 58,
+          baselineP75: 62,
+          rolling: { d7: 62, d30: 60, d90: 60 },
+          trend30d: 'flat',
+          weekly: [60, 61, 62],
+        },
+      },
+    };
+    localStorage.setItem(biometricSelectionKey, JSON.stringify(['bp_systolic', 'rhr']));
+    window.addDashboardBiometricMetric?.('rhr');
+    window.navigate?.('dashboard');
+    await delay(250);
+
+    const biometricWidget = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
+    assert('Biometrics Overview widget renders for delegated action checks',
+      !!biometricWidget);
+    assert('Biometrics Overview action surface has no inline handlers',
+      !!biometricWidget &&
+        !biometricWidget.querySelector('.db-biometric-overview-actions [onclick], .db-biometric-overview-grid [onclick], .db-biometric-overview-grid [onkeydown]'));
+
+    let syncCalled = false;
+    window.syncWearableNow = (button) => { syncCalled = button?.classList?.contains('db-biometric-sync-btn'); };
+    const syncBtn = biometricWidget?.querySelector('[data-dashboard-widget-action="sync-biometric-now"]');
+    assert('Biometrics Overview sync button renders delegated action',
+      !!syncBtn);
+    syncBtn?.click();
+    await delay(50);
+    assert('Delegated Biometrics Overview sync click calls syncWearableNow',
+      syncCalled);
+
+    biometricWidget?.querySelector('[data-dashboard-widget-action="open-biometric-picker"]')?.click();
+    await delay(100);
+    assert('Delegated Biometrics Overview add-metrics click opens biometric picker',
+      !!document.querySelector('.dashboard-biometric-picker'));
+    window.closeDashboardWidgetPicker?.();
+    await delay(50);
+
+    const bpCard = document.querySelector('.db-biometric-overview-grid [data-dashboard-widget-action="open-biometric-manual-log"][data-dashboard-widget-id="bp_systolic"]');
+    assert('Empty BP overview card renders delegated manual-log action',
+      !!bpCard);
+    bpCard?.click();
+    await delay(150);
+    assert('Delegated empty BP overview click opens manual BP form',
+      !!document.getElementById('wl-bp-sys') && !!document.getElementById('wl-bp-dia'));
+    document.querySelector('.db-biometric-overview-grid .wearable-log-cancel')?.click();
+    await delay(200);
+    assert('Wearable cancel still closes BP form inside dashboard delegate surface',
+      !document.getElementById('wl-bp-sys') &&
+        !!document.querySelector('.db-biometric-overview-grid [data-dashboard-widget-action="open-biometric-manual-log"][data-dashboard-widget-id="bp_systolic"]'));
+
+    const removeRhr = document.querySelector('.db-biometric-overview-grid .db-biometric-remove[data-dashboard-widget-action="remove-biometric-metric"][data-dashboard-widget-id="rhr"]');
+    assert('Biometrics Overview remove button renders delegated action',
+      !!removeRhr);
+    removeRhr?.click();
+    await delay(150);
+    const selectedAfterRemove = JSON.parse(localStorage.getItem(biometricSelectionKey) || '[]');
+    assert('Delegated remove-metric click updates biometric selection',
+      !selectedAfterRemove.includes('rhr'));
   } finally {
+    if (typeof originalSyncWearableNow !== 'undefined') window.syncWearableNow = originalSyncWearableNow;
+    if (typeof originalBiometricSelection === 'string') localStorage.setItem(biometricSelectionKey, originalBiometricSelection);
+    else localStorage.removeItem(biometricSelectionKey);
+    if (hadWearableSummary) st.importedData.wearableSummary = originalWearableSummary;
+    else if (st.importedData) delete st.importedData.wearableSummary;
+    if (hadWearableConnections) st.importedData.wearableConnections = originalWearableConnections;
+    else if (st.importedData) delete st.importedData.wearableConnections;
     window.closeDashboardWidgetPicker?.();
     window.toggleDashboardOrganizeMode?.(false);
     if (originalView) window.navigate?.(originalView);

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -9,7 +9,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const controlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
 const compositionSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
+const renderersSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-renderers.js'), 'utf8');
 const dashboardWidgetsCss = fs.readFileSync(path.join(root, 'css/dashboard-widgets.css'), 'utf8');
+const biometricOverviewSrc = renderersSrc.slice(
+  renderersSrc.indexOf('function renderDashboardBiometricSyncStatus'),
+  renderersSrc.indexOf('function getDashboardGenomeImpact'),
+);
 
 let passed = 0;
 let failed = 0;
@@ -48,10 +53,24 @@ assert('dashboard widget controls render delegated drag/drop attributes',
 assert('dashboard widget controls install idempotent click/input/drag delegates',
   controlsSrc.includes('let dashboardWidgetDelegatesInstalled = false') &&
     controlsSrc.includes("document.addEventListener('click', handleDashboardWidgetClick)") &&
+    controlsSrc.includes("document.addEventListener('keydown', handleDashboardWidgetKeydown)") &&
     controlsSrc.includes("document.addEventListener('input', handleDashboardWidgetInput)") &&
     controlsSrc.includes("document.addEventListener('dragstart', handleDashboardWidgetDragStart)") &&
     controlsSrc.includes("document.addEventListener('dragover', handleDashboardWidgetDragOver)") &&
     controlsSrc.includes("document.addEventListener('drop', handleDashboardWidgetDrop)"));
+assert('dashboard biometric overview renders no inline event attributes',
+  !/\bon(?:click|keydown|submit|change|input)=/.test(biometricOverviewSrc));
+assert('dashboard biometric overview renders delegated widget actions',
+  renderersSrc.includes("import { dashboardWidgetActionAttrs } from './dashboard-widget-controls.js'") &&
+    biometricOverviewSrc.includes("dashboardWidgetActionAttrs('sync-biometric-now'") &&
+    biometricOverviewSrc.includes("dashboardWidgetActionAttrs('remove-biometric-metric'") &&
+    biometricOverviewSrc.includes("dashboardWidgetActionAttrs('open-biometric-manual-log'") &&
+    biometricOverviewSrc.includes("dashboardWidgetActionAttrs('open-biometric-detail'") &&
+    biometricOverviewSrc.includes("dashboardWidgetActionAttrs('open-biometric-picker'"));
+assert('dashboard widget click delegate lets nested wearable actions handle inline forms',
+  controlsSrc.includes("target.closest('[data-wearable-action]')") &&
+    controlsSrc.includes('actionEl.contains(wearableActionEl)') &&
+    controlsSrc.includes("actionEl.click();"));
 assert('dashboard widget picker backdrop stays target-only',
   controlsSrc.includes("target.closest('#dashboard-widget-picker-overlay[data-dashboard-widget-overlay]')") &&
     controlsSrc.includes('overlay && target === overlay'));
@@ -71,6 +90,11 @@ assert('dashboard organize mode disables dense grid packing',
   'customize-layout',
   'reset-layout',
   'connect-source',
+  'open-biometric-picker',
+  'sync-biometric-now',
+  'remove-biometric-metric',
+  'open-biometric-detail',
+  'open-biometric-manual-log',
 ].forEach(action => {
   assert(`dashboard widget action ${action} is handled`, controlsSrc.includes(`action === '${action}'`));
 });

--- a/tests/test-wearables-sync-flow.js
+++ b/tests/test-wearables-sync-flow.js
@@ -253,6 +253,29 @@ try {
     `observed start_date=${observedStartForce}, expected ≤ ${sevenDaysAgo}`);
 } finally { restore(); }
 
+// 3c. Startup/visibility stale-sync path — should sync stale connections
+// after profile data is available, but skip fresh ones.
+try {
+  installRoutes([
+    { matcher: 'usercollection/sleep', body: { data: [], next_token: null }},
+    { matcher: /heartrate.*start_datetime/, body: { data: [], next_token: null }},
+    { matcher: /usercollection\//, body: { data: [], next_token: null }},
+  ]);
+  window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now() - (13 * 60 * 60 * 1000);
+  await connect.syncStaleWearablesNow();
+  const afterStaleAuto = window._labState.importedData.wearableConnections.oura.lastSyncAt || 0;
+  assert('syncStaleWearablesNow auto-syncs stale connected sources',
+    calls.length > 0 && Date.now() - afterStaleAuto < 60 * 1000,
+    `calls=${calls.length}, lastSyncAt=${afterStaleAuto}`);
+
+  calls = [];
+  window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now();
+  await connect.syncStaleWearablesNow();
+  assert('syncStaleWearablesNow skips fresh connected sources',
+    calls.length === 0,
+    `calls=${calls.length}`);
+} finally { restore(); }
+
 // ═══════════════════════════════════════
 // 4. backfill error recovery — rows write even when one endpoint 500s
 // ═══════════════════════════════════════

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1608,7 +1608,8 @@ console.log('17w. P2 Cleanup');
 const profileSrcP2 = await fetch('/js/profile.js').then(r => r.text());
 assert('loadProfile dispatches migrateBiometricsToManual + syncWearableSummary on every load',
   /export\s+async\s+function\s+loadProfile[\s\S]*?migrateBiometricsToManual\(profileId/.test(profileSrcP2) &&
-  /loadProfile[\s\S]*?syncWearableSummary\(profileId,\s*connectMod\.listConnectedSources\(\)\)/.test(profileSrcP2));
+  /loadProfile[\s\S]*?syncWearableSummary\(profileId,\s*connectMod\.listConnectedSources\(\)\)/.test(profileSrcP2) &&
+  /loadProfile[\s\S]*?connectMod\.syncStaleWearablesNow\?\.\(\)\.catch/.test(profileSrcP2));
 
 // P2: deleteWearablesDB closes the cached connection before deleting
 // (otherwise indexedDB.deleteDatabase hits onblocked).
@@ -1629,10 +1630,19 @@ assert('importDataJSON prunes wearablePrimaryOverride to live sources only',
 
 // P2: commitAfterWriteIfAny accepts pre-await connection snapshot.
 const connectSrcP2 = await fetch('/js/wearables-connect.js').then(r => r.text());
+const startupMaintenanceSrcP2 = await fetch('/js/startup-maintenance.js').then(r => r.text());
 assert('commitAfterWriteIfAny accepts a connection snapshot (profile-swap safety)',
   /async function commitAfterWriteIfAny\(adapterId,\s*rows,\s*connSnapshot\)/.test(connectSrcP2));
 assert('Backfill + incremental pass the pre-await `conn` snapshot to commitAfterWriteIfAny',
   /commitAfterWriteIfAny\(adapterId,\s*rows,\s*conn\)/.test(connectSrcP2));
+assert('Post-profile startup kicks stale wearable sync after importedData loads',
+  /import\s*\{[^}]*syncStaleWearablesNow[^}]*\}\s*from\s*['"]\.\/wearables-connect\.js['"]/.test(startupMaintenanceSrcP2) &&
+  /runPostProfileStartupMaintenance[\s\S]*?syncStaleWearablesNow\(\)\.catch/.test(startupMaintenanceSrcP2));
+assert('Wearable scheduler routes stale sync through a shared in-flight guard',
+  /let\s+_staleSyncInFlight\s*=\s*null/.test(connectSrcP2) &&
+  /export\s+function\s+syncStaleWearablesNow\(\)/.test(connectSrcP2) &&
+  /if\s*\(_staleSyncInFlight\)\s*return\s+_staleSyncInFlight/.test(connectSrcP2) &&
+  /setInterval\(syncStaleWearablesNow,\s*POLL_INTERVAL_MS\)/.test(connectSrcP2));
 
 // P2: per-metric monotonic op token for manual save/delete.
 const wearablesSrcP2 = await fetch('/js/wearables.js').then(r => r.text());

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.322';
+self.APP_VERSION = '1.8.323';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.323';
+self.APP_VERSION = '1.8.324';


### PR DESCRIPTION
## Summary
- Route Biometrics Overview sync/add/remove/detail/manual-log controls through the existing dashboard widget delegate.
- Export and reuse dashboard widget action attribute helpers so this renderer surface no longer needs inline handlers.
- Kick stale wearable sync after profile data loads and on profile switches, with a shared in-flight guard so the first-load scheduler does not miss `wearableConnections`.
- Add static, browser, and sync-flow regressions for the delegated Biometrics Overview surface and stale wearable auto-sync behavior.

## Validation
- `node --check js/dashboard-widget-controls.js`
- `node --check js/dashboard-widget-renderers.js`
- `node --check js/wearables-connect.js`
- `node --check js/startup-maintenance.js`
- `node --check js/profile.js`
- `node tests/test-dashboard-widget-delegated-actions.js`
- `node tests/test-wearables-sync-flow.js`
- `node tests/test-wearables.js`
- Focused Puppeteer run for `tests/test-dashboard-widget-delegated-actions-dom.js`
- `npm test -- --run tests/_vitest-legacy.test.js`
- `./run-tests.sh`