### PR TITLE
[codex] Delegate provider panel actions

### DIFF
--- a/js/provider-model-controls.js
+++ b/js/provider-model-controls.js
@@ -30,7 +30,7 @@ export function renderVeniceModelDropdown(models) {
   const currentModel = getVeniceModel();
   const opts = buildModelOptions('venice', models, currentModel, function(m) { return m.name || m.id; });
   area.innerHTML = '<label style="font-size:12px;color:var(--text-muted)">Model</label>' +
-    '<select class="api-key-input" id="venice-model-select" style="margin-top:4px" onchange="onVeniceModelDropdownChange(this.value)">' + opts + '</select>' +
+    '<select class="api-key-input" id="venice-model-select" style="margin-top:4px" data-provider-panel-change="venice-model">' + opts + '</select>' +
     '<div id="venice-model-pricing" style="margin-top:4px">' + renderModelPricingHint('venice', currentModel) + '</div>';
 }
 
@@ -75,8 +75,8 @@ export function renderOpenRouterModelDropdown(models) {
   const isCustom = !models.some(m => m.id === currentModel);
   const opts = buildModelOptions('openrouter', models, currentModel, function(m) { return m.name || m.id; });
   area.innerHTML = '<label style="font-size:12px;color:var(--text-muted)">Model</label>' +
-    '<select class="api-key-input" id="openrouter-model-select" style="margin-top:4px" onchange="onOpenRouterDropdownChange(this.value)">' + opts + '</select>' +
-    '<div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" class="api-key-input" id="openrouter-custom-model" placeholder="Or enter model ID (e.g. arcee-ai/trinity-large-preview:free)" style="font-size:12px;flex:1' + (isCustom ? ';border-color:var(--accent)' : '') + '" value="' + (isCustom ? escapeHTML(currentModel) : '') + '" onkeydown="if(event.key===\'Enter\'){applyCustomOpenRouterModel(this.value)}"><span id="openrouter-model-health" style="font-size:16px;min-width:20px;text-align:center"></span></div>' +
+    '<select class="api-key-input" id="openrouter-model-select" style="margin-top:4px" data-provider-panel-change="openrouter-model">' + opts + '</select>' +
+    '<div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" class="api-key-input" id="openrouter-custom-model" placeholder="Or enter model ID (e.g. arcee-ai/trinity-large-preview:free)" style="font-size:12px;flex:1' + (isCustom ? ';border-color:var(--accent)' : '') + '" value="' + (isCustom ? escapeHTML(currentModel) : '') + '" data-provider-panel-key="openrouter-custom-model"><span id="openrouter-model-health" style="font-size:16px;min-width:20px;text-align:center"></span></div>' +
     '<span style="font-size:11px;color:var(--text-muted);margin-top:2px;display:block">Press Enter to apply — checks model connectivity</span>' +
     '<div id="openrouter-model-pricing" style="margin-top:4px">' + renderModelPricingHint('openrouter', currentModel) + '</div>';
 }
@@ -151,7 +151,7 @@ export function renderRoutstrModelDropdown(models) {
   }
   const opts = buildModelOptions('routstr', models, currentModel, function(m) { return m.name || m.id; });
   area.innerHTML = '<label style="font-size:12px;color:var(--text-muted)">Model</label>' +
-    '<select class="api-key-input" id="routstr-model-select" style="margin-top:4px" onchange="setRoutstrModel(this.value);updateRoutstrModelPricing(this.value)">' + opts + '</select>' +
+    '<select class="api-key-input" id="routstr-model-select" style="margin-top:4px" data-provider-panel-change="routstr-model">' + opts + '</select>' +
     '<div id="routstr-model-pricing" style="margin-top:4px">' + renderModelPricingHint('routstr', currentModel) + '</div>';
 }
 
@@ -161,7 +161,7 @@ export function renderPpqModelDropdown(models) {
   const currentModel = getPpqModel();
   const opts = buildModelOptions('ppq', models, currentModel, function(m) { return m.name || m.id; });
   area.innerHTML = '<label style="font-size:12px;color:var(--text-muted)">Model</label>' +
-    '<select class="api-key-input" id="ppq-model-select" style="margin-top:4px" onchange="setPpqModel(this.value);updatePpqModelPricing(this.value)">' + opts + '</select>' +
+    '<select class="api-key-input" id="ppq-model-select" style="margin-top:4px" data-provider-panel-change="ppq-model">' + opts + '</select>' +
     '<div id="ppq-model-pricing" style="margin-top:4px">' + renderModelPricingHint('ppq', currentModel) + '</div>';
 }
 
@@ -177,8 +177,8 @@ export function renderCustomApiModelDropdown(models) {
   const opts = buildModelOptions('custom', models, currentModel, function(m) { return m.name || m.id; });
   const isCustom = !models.some(m => m.id === currentModel) && currentModel;
   area.innerHTML = `<label style="font-size:12px;color:var(--text-muted)">Model</label>
-    <select class="api-key-input" id="custom-model-select" style="margin-top:4px" onchange="setCustomApiModel(this.value);updateCustomModelPricing(this.value)">${isCustom ? '<option value="__custom" disabled selected>Using custom model</option>' : ''}${opts}</select>
-    <div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" id="custom-manual-model" placeholder="Or type any model ID and press Enter" style="font-size:11px;flex:1;padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-family:monospace${isCustom ? ';border-color:var(--accent)' : ''}" value="${isCustom ? escapeHTML(currentModel) : ''}" onkeydown="if(event.key==='Enter'){applyCustomApiManualModel()}"></div>
+    <select class="api-key-input" id="custom-model-select" style="margin-top:4px" data-provider-panel-change="custom-model">${isCustom ? '<option value="__custom" disabled selected>Using custom model</option>' : ''}${opts}</select>
+    <div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" id="custom-manual-model" placeholder="Or type any model ID and press Enter" style="font-size:11px;flex:1;padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-family:monospace${isCustom ? ';border-color:var(--accent)' : ''}" value="${isCustom ? escapeHTML(currentModel) : ''}" data-provider-panel-key="custom-manual-model"></div>
     <div id="custom-model-pricing" style="margin-top:4px">${renderModelPricingHint('custom', currentModel)}</div>`;
 }
 

--- a/js/provider-panel-delegates.js
+++ b/js/provider-panel-delegates.js
@@ -1,0 +1,87 @@
+// provider-panel-delegates.js - Delegated AI provider settings panel actions
+
+const PROVIDER_PANEL_ROOTS = '#ai-provider-panel';
+
+let providerPanelDelegatesInstalled = false;
+let providerPanelActions = {};
+
+export function installProviderPanelDelegates(actions = {}) {
+  Object.assign(providerPanelActions, actions);
+  if (providerPanelDelegatesInstalled || typeof document === 'undefined') return;
+  providerPanelDelegatesInstalled = true;
+  document.addEventListener('click', _handleProviderPanelClick);
+  document.addEventListener('change', _handleProviderPanelChange);
+  document.addEventListener('keydown', _handleProviderPanelKeydown);
+}
+
+function _call(name, ...args) {
+  const fn = providerPanelActions[name];
+  if (typeof fn === 'function') return fn(...args);
+}
+
+function _closestProviderPanelEl(event, selector) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return null;
+  const el = target.closest(selector);
+  return el && el.closest(PROVIDER_PANEL_ROOTS) ? el : null;
+}
+
+function _handleProviderPanelClick(event) {
+  const el = _closestProviderPanelEl(event, '[data-provider-panel-action]');
+  if (!el) return;
+  if (el.matches('a, button')) event.preventDefault();
+  const action = el.dataset.providerPanelAction;
+
+  if (action === 'start-openrouter-oauth') return _call('startOpenRouterOAuth');
+  if (action === 'save-openrouter-key') return _call('handleSaveOpenRouterKey');
+  if (action === 'remove-openrouter-key') return _call('handleRemoveOpenRouterKey');
+  if (action === 'refresh-openrouter-balance') return _call('refreshOpenRouterBalance');
+  if (action === 'refresh-cashu-wallet-balance') return _call('refreshCashuWalletBalance');
+  if (action === 'show-routstr-mint-edit') return _call('showRoutstrMintEdit');
+  if (action === 'refresh-routstr-balance') return _call('refreshRoutstrBalance');
+  if (action === 'save-venice-key') return _call('handleSaveVeniceKey');
+  if (action === 'remove-venice-key') return _call('handleRemoveVeniceKey');
+  if (action === 'refresh-venice-balance') return _call('refreshVeniceBalance');
+  if (action === 'refresh-ppq-balance') return _call('refreshPpqBalance');
+  if (action === 'show-ppq-topup') return _call('showPpqTopup');
+  if (action === 'create-ppq-account') return _call('handleCreatePpqAccount');
+  if (action === 'save-ppq-key') return _call('handleSavePpqKey');
+  if (action === 'remove-ppq-key') return _call('handleRemovePpqKey');
+  if (action === 'apply-custom-api-model') return _call('applyCustomApiManualModel');
+  if (action === 'save-custom-api') return _call('handleSaveCustomApi');
+  if (action === 'remove-custom-api') return _call('handleRemoveCustomApi');
+  if (action === 'test-ollama-connection') return _call('testOllamaConnection');
+}
+
+function _handleProviderPanelChange(event) {
+  const el = _closestProviderPanelEl(event, '[data-provider-panel-change]');
+  if (!el) return;
+  const action = el.dataset.providerPanelChange;
+
+  if (action === 'openrouter-model') return _call('onOpenRouterDropdownChange', el.value);
+  if (action === 'routstr-model') return _setModelAndPricing('setRoutstrModel', 'updateRoutstrModelPricing', el.value);
+  if (action === 'venice-model') return _call('onVeniceModelDropdownChange', el.value);
+  if (action === 'venice-e2ee') return _call('toggleVeniceE2EE', !!el.checked);
+  if (action === 'ppq-model') return _setModelAndPricing('setPpqModel', 'updatePpqModelPricing', el.value);
+  if (action === 'custom-model') return _setModelAndPricing('setCustomApiModel', 'updateCustomModelPricing', el.value);
+  if (action === 'local-ai-model') {
+    _call('setOllamaMainModel', el.value);
+    return _call('refreshModelAdvisor');
+  }
+}
+
+function _handleProviderPanelKeydown(event) {
+  if (event.key !== 'Enter') return;
+  const el = _closestProviderPanelEl(event, '[data-provider-panel-key]');
+  if (!el) return;
+  event.preventDefault();
+  const action = el.dataset.providerPanelKey;
+
+  if (action === 'openrouter-custom-model') return _call('applyCustomOpenRouterModel', el.value);
+  if (action === 'custom-manual-model') return _call('applyCustomApiManualModel');
+}
+
+function _setModelAndPricing(setterName, pricingName, value) {
+  _call(setterName, value);
+  return _call(pricingName, value);
+}

--- a/js/provider-panel-delegates.js
+++ b/js/provider-panel-delegates.js
@@ -2,6 +2,45 @@
 
 const PROVIDER_PANEL_ROOTS = '#ai-provider-panel';
 
+const CLICK_ACTIONS = Object.freeze({
+  'start-openrouter-oauth': 'startOpenRouterOAuth',
+  'save-openrouter-key': 'handleSaveOpenRouterKey',
+  'remove-openrouter-key': 'handleRemoveOpenRouterKey',
+  'refresh-openrouter-balance': 'refreshOpenRouterBalance',
+  'refresh-cashu-wallet-balance': 'refreshCashuWalletBalance',
+  'show-routstr-mint-edit': 'showRoutstrMintEdit',
+  'refresh-routstr-balance': 'refreshRoutstrBalance',
+  'save-venice-key': 'handleSaveVeniceKey',
+  'remove-venice-key': 'handleRemoveVeniceKey',
+  'refresh-venice-balance': 'refreshVeniceBalance',
+  'refresh-ppq-balance': 'refreshPpqBalance',
+  'show-ppq-topup': 'showPpqTopup',
+  'create-ppq-account': 'handleCreatePpqAccount',
+  'save-ppq-key': 'handleSavePpqKey',
+  'remove-ppq-key': 'handleRemovePpqKey',
+  'apply-custom-api-model': 'applyCustomApiManualModel',
+  'save-custom-api': 'handleSaveCustomApi',
+  'remove-custom-api': 'handleRemoveCustomApi',
+  'test-ollama-connection': 'testOllamaConnection'
+});
+
+const CHANGE_ACTIONS = Object.freeze({
+  'openrouter-model': 'onOpenRouterDropdownChange',
+  'venice-model': 'onVeniceModelDropdownChange',
+  'venice-e2ee': 'toggleVeniceE2EE'
+});
+
+const MODEL_PRICING_ACTIONS = Object.freeze({
+  'routstr-model': ['setRoutstrModel', 'updateRoutstrModelPricing'],
+  'ppq-model': ['setPpqModel', 'updatePpqModelPricing'],
+  'custom-model': ['setCustomApiModel', 'updateCustomModelPricing']
+});
+
+const KEY_ACTIONS = Object.freeze({
+  'openrouter-custom-model': 'applyCustomOpenRouterModel',
+  'custom-manual-model': 'applyCustomApiManualModel'
+});
+
 let providerPanelDelegatesInstalled = false;
 let providerPanelActions = {};
 
@@ -17,6 +56,13 @@ export function installProviderPanelDelegates(actions = {}) {
 function _call(name, ...args) {
   const fn = providerPanelActions[name];
   if (typeof fn === 'function') return fn(...args);
+  _warnProviderPanelDelegate(`Missing provider panel callback: ${name}`);
+}
+
+function _warnProviderPanelDelegate(message) {
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(message);
+  }
 }
 
 function _closestProviderPanelEl(event, selector) {
@@ -29,56 +75,41 @@ function _closestProviderPanelEl(event, selector) {
 function _handleProviderPanelClick(event) {
   const el = _closestProviderPanelEl(event, '[data-provider-panel-action]');
   if (!el) return;
-  if (el.matches('a, button')) event.preventDefault();
   const action = el.dataset.providerPanelAction;
+  const callbackName = CLICK_ACTIONS[action];
 
-  if (action === 'start-openrouter-oauth') return _call('startOpenRouterOAuth');
-  if (action === 'save-openrouter-key') return _call('handleSaveOpenRouterKey');
-  if (action === 'remove-openrouter-key') return _call('handleRemoveOpenRouterKey');
-  if (action === 'refresh-openrouter-balance') return _call('refreshOpenRouterBalance');
-  if (action === 'refresh-cashu-wallet-balance') return _call('refreshCashuWalletBalance');
-  if (action === 'show-routstr-mint-edit') return _call('showRoutstrMintEdit');
-  if (action === 'refresh-routstr-balance') return _call('refreshRoutstrBalance');
-  if (action === 'save-venice-key') return _call('handleSaveVeniceKey');
-  if (action === 'remove-venice-key') return _call('handleRemoveVeniceKey');
-  if (action === 'refresh-venice-balance') return _call('refreshVeniceBalance');
-  if (action === 'refresh-ppq-balance') return _call('refreshPpqBalance');
-  if (action === 'show-ppq-topup') return _call('showPpqTopup');
-  if (action === 'create-ppq-account') return _call('handleCreatePpqAccount');
-  if (action === 'save-ppq-key') return _call('handleSavePpqKey');
-  if (action === 'remove-ppq-key') return _call('handleRemovePpqKey');
-  if (action === 'apply-custom-api-model') return _call('applyCustomApiManualModel');
-  if (action === 'save-custom-api') return _call('handleSaveCustomApi');
-  if (action === 'remove-custom-api') return _call('handleRemoveCustomApi');
-  if (action === 'test-ollama-connection') return _call('testOllamaConnection');
+  if (!callbackName) return _warnProviderPanelDelegate(`Unknown provider panel click action: ${action}`);
+  if (el.matches('a, button')) event.preventDefault();
+  return _call(callbackName);
 }
 
 function _handleProviderPanelChange(event) {
   const el = _closestProviderPanelEl(event, '[data-provider-panel-change]');
   if (!el) return;
   const action = el.dataset.providerPanelChange;
+  const pricingActions = MODEL_PRICING_ACTIONS[action];
 
-  if (action === 'openrouter-model') return _call('onOpenRouterDropdownChange', el.value);
-  if (action === 'routstr-model') return _setModelAndPricing('setRoutstrModel', 'updateRoutstrModelPricing', el.value);
-  if (action === 'venice-model') return _call('onVeniceModelDropdownChange', el.value);
-  if (action === 'venice-e2ee') return _call('toggleVeniceE2EE', !!el.checked);
-  if (action === 'ppq-model') return _setModelAndPricing('setPpqModel', 'updatePpqModelPricing', el.value);
-  if (action === 'custom-model') return _setModelAndPricing('setCustomApiModel', 'updateCustomModelPricing', el.value);
+  if (pricingActions) return _setModelAndPricing(pricingActions[0], pricingActions[1], el.value);
+  if (action === 'venice-e2ee') return _call(CHANGE_ACTIONS[action], !!el.checked);
+  if (CHANGE_ACTIONS[action]) return _call(CHANGE_ACTIONS[action], el.value);
   if (action === 'local-ai-model') {
     _call('setOllamaMainModel', el.value);
     return _call('refreshModelAdvisor');
   }
+  return _warnProviderPanelDelegate(`Unknown provider panel change action: ${action}`);
 }
 
 function _handleProviderPanelKeydown(event) {
   if (event.key !== 'Enter') return;
   const el = _closestProviderPanelEl(event, '[data-provider-panel-key]');
   if (!el) return;
-  event.preventDefault();
   const action = el.dataset.providerPanelKey;
+  const callbackName = KEY_ACTIONS[action];
 
-  if (action === 'openrouter-custom-model') return _call('applyCustomOpenRouterModel', el.value);
-  if (action === 'custom-manual-model') return _call('applyCustomApiManualModel');
+  if (!callbackName) return _warnProviderPanelDelegate(`Unknown provider panel key action: ${action}`);
+  event.preventDefault();
+  if (action === 'openrouter-custom-model') return _call(callbackName, el.value);
+  return _call(callbackName);
 }
 
 function _setModelAndPricing(setterName, pricingName, value) {

--- a/js/provider-panel-renderers.js
+++ b/js/provider-panel-renderers.js
@@ -47,8 +47,8 @@ function renderOpenRouterProviderPanel() {
     const isCustom = !cachedORModels.some(m => m.id === orModel);
     orModelHtml = `<div style="margin-top:12px" id="openrouter-model-area">
       <label style="font-size:12px;color:var(--text-muted)">Model</label>
-      <select class="api-key-input" id="openrouter-model-select" style="margin-top:4px" onchange="onOpenRouterDropdownChange(this.value)">${isCustom ? '<option value="__custom" disabled selected>Using custom model</option>' : ''}${opts}</select>
-      <div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" id="openrouter-custom-model" placeholder="Or type any model ID and press Enter" style="font-size:11px;flex:1;padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-family:monospace${isCustom ? ';border-color:var(--accent)' : ''}" value="${isCustom ? escapeHTML(orModel) : ''}" onkeydown="if(event.key==='Enter'){applyCustomOpenRouterModel(this.value)}"><span id="openrouter-model-health" style="font-size:14px;min-width:18px;text-align:center"></span></div>
+      <select class="api-key-input" id="openrouter-model-select" style="margin-top:4px" data-provider-panel-change="openrouter-model">${isCustom ? '<option value="__custom" disabled selected>Using custom model</option>' : ''}${opts}</select>
+      <div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" id="openrouter-custom-model" placeholder="Or type any model ID and press Enter" style="font-size:11px;flex:1;padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-family:monospace${isCustom ? ';border-color:var(--accent)' : ''}" value="${isCustom ? escapeHTML(orModel) : ''}" data-provider-panel-key="openrouter-custom-model"><span id="openrouter-model-health" style="font-size:14px;min-width:18px;text-align:center"></span></div>
       <div id="openrouter-model-pricing" style="margin-top:4px">${renderModelPricingHint('openrouter', orModel)}</div>
     </div>`;
   } else {
@@ -56,16 +56,16 @@ function renderOpenRouterProviderPanel() {
   }
   return `<div class="ai-provider-panel">
     <div class="ai-provider-desc">API marketplace routing to 200+ models (Claude, GPT, Llama, Gemini, and more). Pay-per-use with a single key.</div>
-    ${currentKey ? '' : '<button class="or-oauth-btn" onclick="startOpenRouterOAuth()">Connect with OpenRouter</button><div class="or-oauth-divider"><span>or enter key manually</span></div>'}
+    ${currentKey ? '' : '<button class="or-oauth-btn" data-provider-panel-action="start-openrouter-oauth">Connect with OpenRouter</button><div class="or-oauth-divider"><span>or enter key manually</span></div>'}
     <div class="api-key-status" id="openrouter-key-status">
       ${currentKey ? '<span style="color:var(--green)">&#10003; Connected</span>' : '<span style="color:var(--text-muted)">No key set</span>'}
     </div>
     <input type="password" class="api-key-input" id="openrouter-key-input" placeholder="sk-or-..." value="${escapeAttr(currentKey)}">
     <div style="display:flex;gap:8px;margin-top:12px">
-      <button class="import-btn import-btn-primary" id="save-openrouter-key-btn" onclick="handleSaveOpenRouterKey()">Save & Validate</button>
-      ${currentKey ? '<button class="import-btn import-btn-secondary" onclick="handleRemoveOpenRouterKey()">Remove Key</button>' : ''}
+      <button class="import-btn import-btn-primary" id="save-openrouter-key-btn" data-provider-panel-action="save-openrouter-key">Save & Validate</button>
+      ${currentKey ? '<button class="import-btn import-btn-secondary" data-provider-panel-action="remove-openrouter-key">Remove Key</button>' : ''}
     </div>
-    ${currentKey ? `<div style="margin-top:8px;font-size:12px;color:var(--text-muted)"><span id="or-balance">Balance: loading...</span> <a href="#" onclick="refreshOpenRouterBalance();return false" style="color:var(--accent);font-size:11px;text-decoration:none">\u21bb</a></div>` : ''}
+    ${currentKey ? `<div style="margin-top:8px;font-size:12px;color:var(--text-muted)"><span id="or-balance">Balance: loading...</span> <a href="#" data-provider-panel-action="refresh-openrouter-balance" style="color:var(--accent);font-size:11px;text-decoration:none">\u21bb</a></div>` : ''}
     ${orModelHtml}
     <div class="api-key-notice">Your key is stored locally and sent directly to OpenRouter. <a href="https://openrouter.ai/keys" target="_blank" rel="noopener" style="color:var(--accent)">Get an API key</a> &middot; <a href="https://openrouter.ai/settings/credits" target="_blank" rel="noopener" style="color:var(--accent)">Add credits</a></div>
   </div>`;
@@ -81,7 +81,7 @@ function renderRoutstrProviderPanel() {
     const opts = buildModelOptions('routstr', cachedRSModels, rsModel, function(m) { return m.name || m.id; });
     rsModelHtml = `<div style="margin-top:12px" id="routstr-model-area">
       <label style="font-size:12px;color:var(--text-muted)">Model</label>
-      <select class="api-key-input" id="routstr-model-select" style="margin-top:4px" onchange="setRoutstrModel(this.value);updateRoutstrModelPricing(this.value)">${opts}</select>
+      <select class="api-key-input" id="routstr-model-select" style="margin-top:4px" data-provider-panel-change="routstr-model">${opts}</select>
       <div id="routstr-model-pricing" style="margin-top:4px">${renderModelPricingHint('routstr', rsModel)}</div>
     </div>`;
   } else {
@@ -93,14 +93,14 @@ function renderRoutstrProviderPanel() {
   const walletHtml = `<div style="padding:10px;background:var(--bg-secondary);border-radius:8px;border:1px solid var(--border);margin-bottom:10px">
     <div style="${sectionLabel}">\u26a1 Wallet</div>
     <div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:4px">
-      <div style="font-size:13px;font-weight:600;color:var(--text-primary)"><span id="routstr-wallet-balance">\u26a1 loading...</span> <a href="#" onclick="refreshCashuWalletBalance();return false" style="color:var(--accent);font-size:10px;text-decoration:none" title="Verify proofs against mint">\u21bb</a></div>
+      <div style="font-size:13px;font-weight:600;color:var(--text-primary)"><span id="routstr-wallet-balance">\u26a1 loading...</span> <a href="#" data-provider-panel-action="refresh-cashu-wallet-balance" style="color:var(--accent);font-size:10px;text-decoration:none" title="Verify proofs against mint">\u21bb</a></div>
       <div id="routstr-wallet-actions" style="display:flex;gap:4px;flex-wrap:wrap">
         ${routstrWalletActionButtons(null)}
       </div>
     </div>
     <div style="display:flex;align-items:center;gap:6px;margin-top:6px;padding-top:6px;border-top:1px solid var(--border)">
       <div style="font-size:10px;color:var(--text-muted)">Mint: <span id="routstr-mint-label" style="font-family:var(--font-mono,monospace);opacity:0.8">loading...</span></div>
-      <button class="import-btn import-btn-secondary" style="${pillStyle};font-size:9px;padding:1px 6px" onclick="showRoutstrMintEdit()">Change</button>
+      <button class="import-btn import-btn-secondary" style="${pillStyle};font-size:9px;padding:1px 6px" data-provider-panel-action="show-routstr-mint-edit">Change</button>
     </div>
     <div id="routstr-mint-edit" style="display:none"></div>
     <div id="routstr-wallet-fund-area" style="display:none"></div>
@@ -138,7 +138,7 @@ function renderRoutstrProviderPanel() {
         ${nodeActionsHtml}
       </div>
     </div>
-    ${currentKey ? '<div style="font-size:11px;color:var(--text-muted);margin-top:6px;padding-top:6px;border-top:1px solid var(--border)">Session: <span id="routstr-node-balance">\u26a1 loading...</span> <a href="#" onclick="refreshRoutstrBalance();return false" style="color:var(--accent);font-size:10px;text-decoration:none">\u21bb</a></div>' : ''}
+    ${currentKey ? '<div style="font-size:11px;color:var(--text-muted);margin-top:6px;padding-top:6px;border-top:1px solid var(--border)">Session: <span id="routstr-node-balance">\u26a1 loading...</span> <a href="#" data-provider-panel-action="refresh-routstr-balance" style="color:var(--accent);font-size:10px;text-decoration:none">\u21bb</a></div>' : ''}
     <div id="routstr-node-picker" style="display:none"></div>
   </div>`;
 
@@ -164,11 +164,11 @@ function renderVeniceProviderPanel() {
     const opts = buildModelOptions('venice', displayModels, veniceModel, function(m) { return m.name || m.id; });
     veniceModelHtml = `<div style="margin-top:12px" id="venice-model-area">
       <label style="font-size:12px;color:var(--text-muted)">Model</label>
-      <select class="api-key-input" id="venice-model-select" style="margin-top:4px" onchange="onVeniceModelDropdownChange(this.value)">${opts}</select>
+      <select class="api-key-input" id="venice-model-select" style="margin-top:4px" data-provider-panel-change="venice-model">${opts}</select>
       <div id="venice-model-pricing" style="margin-top:4px">${renderModelPricingHint('venice', veniceModel)}</div>
     </div>
     ${hasE2EEModels ? `<div style="margin-top:12px;display:flex;align-items:center;gap:8px">
-      <label class="toggle-switch" style="flex-shrink:0"><input type="checkbox" id="venice-e2ee-toggle" ${getVeniceE2EE() ? 'checked' : ''} onchange="toggleVeniceE2EE(this.checked)"><span class="toggle-slider"></span></label>
+      <label class="toggle-switch" style="flex-shrink:0"><input type="checkbox" id="venice-e2ee-toggle" ${getVeniceE2EE() ? 'checked' : ''} data-provider-panel-change="venice-e2ee"><span class="toggle-slider"></span></label>
       <span style="font-size:13px">End-to-End Encryption</span>
     </div>
     <div id="venice-e2ee-indicator" style="margin-top:6px;font-size:12px;${isVeniceE2EEActive() ? '' : 'display:none'}"><span style="color:var(--green)">&#128274;</span> Prompts encrypted in your browser, decrypted only inside a verified TEE. Web search and image attachments are disabled.</div>` : ''}`;
@@ -182,10 +182,10 @@ function renderVeniceProviderPanel() {
     </div>
     <input type="password" class="api-key-input" id="venice-key-input" placeholder="venice-..." value="${escapeAttr(currentKey)}">
     <div style="display:flex;gap:8px;margin-top:12px">
-      <button class="import-btn import-btn-primary" id="save-venice-key-btn" onclick="handleSaveVeniceKey()">Save & Validate</button>
-      ${currentKey ? '<button class="import-btn import-btn-secondary" onclick="handleRemoveVeniceKey()">Remove Key</button>' : ''}
+      <button class="import-btn import-btn-primary" id="save-venice-key-btn" data-provider-panel-action="save-venice-key">Save & Validate</button>
+      ${currentKey ? '<button class="import-btn import-btn-secondary" data-provider-panel-action="remove-venice-key">Remove Key</button>' : ''}
     </div>
-    ${currentKey ? '<div style="margin-top:8px;font-size:12px;color:var(--text-muted)"><span id="venice-balance">Balance: loading...</span> <a href="#" onclick="refreshVeniceBalance();return false" style="color:var(--accent);font-size:11px;text-decoration:none">\u21bb</a></div>' : ''}
+    ${currentKey ? '<div style="margin-top:8px;font-size:12px;color:var(--text-muted)"><span id="venice-balance">Balance: loading...</span> <a href="#" data-provider-panel-action="refresh-venice-balance" style="color:var(--accent);font-size:11px;text-decoration:none">\u21bb</a></div>' : ''}
     ${veniceModelHtml}
     <div class="api-key-notice">Your key is stored locally and sent directly to Venice AI. No data is stored on their servers. <a href="https://venice.ai/chat?ref=lZ4P1b" target="_blank" rel="noopener" style="color:var(--accent)">Get an API key</a></div>
   </div>`;
@@ -200,27 +200,27 @@ function renderPpqProviderPanel() {
     const opts = buildModelOptions('ppq', cachedPpqModels, ppqModel, function(m) { return m.name || m.id; });
     ppqModelHtml = `<div style="margin-top:12px" id="ppq-model-area">
       <label style="font-size:12px;color:var(--text-muted)">Model</label>
-      <select class="api-key-input" id="ppq-model-select" style="margin-top:4px" onchange="setPpqModel(this.value);updatePpqModelPricing(this.value)">${opts}</select>
+      <select class="api-key-input" id="ppq-model-select" style="margin-top:4px" data-provider-panel-change="ppq-model">${opts}</select>
       <div id="ppq-model-pricing" style="margin-top:4px">${renderModelPricingHint('ppq', ppqModel)}</div>
     </div>`;
   } else {
     ppqModelHtml = `<div style="margin-top:12px;font-size:12px;color:var(--text-muted)" id="ppq-model-area">Model: <span style="color:var(--text-primary)">${escapeHTML(getPpqModelDisplay())}</span>${currentKey ? ' <span style="font-size:11px">(save key to load models)</span>' : ''}</div>`;
   }
   const balanceHtml = currentKey ? `<div style="margin-top:8px;display:flex;align-items:center;gap:8px">
-      <div style="font-size:12px;color:var(--text-muted)"><span id="ppq-balance">Balance: loading...</span> <a href="#" onclick="refreshPpqBalance();return false" style="color:var(--accent);font-size:11px;text-decoration:none">\u21bb</a></div>
-      <button class="import-btn import-btn-secondary" id="ppq-topup-toggle" style="font-size:11px;padding:2px 10px" onclick="showPpqTopup()">Top Up</button>
+      <div style="font-size:12px;color:var(--text-muted)"><span id="ppq-balance">Balance: loading...</span> <a href="#" data-provider-panel-action="refresh-ppq-balance" style="color:var(--accent);font-size:11px;text-decoration:none">\u21bb</a></div>
+      <button class="import-btn import-btn-secondary" id="ppq-topup-toggle" style="font-size:11px;padding:2px 10px" data-provider-panel-action="show-ppq-topup">Top Up</button>
     </div>
     <div id="ppq-topup-area" style="display:none"></div>` : '';
   return `<div class="ai-provider-panel">
     <div class="ai-provider-desc">Pay-per-query AI aggregator. 300+ models, no subscription, no KYC. Top up with crypto or <a href="https://www.bitrefill.com/gift-cards/ppq-us/" target="_blank" rel="noopener" style="color:var(--accent)">gift cards</a>.</div>
-    ${currentKey ? '' : '<button class="import-btn import-btn-primary" style="width:100%;margin-bottom:8px" onclick="handleCreatePpqAccount()">Create Account (instant, no signup)</button><div class="or-oauth-divider"><span>or enter existing key</span></div>'}
+    ${currentKey ? '' : '<button class="import-btn import-btn-primary" style="width:100%;margin-bottom:8px" data-provider-panel-action="create-ppq-account">Create Account (instant, no signup)</button><div class="or-oauth-divider"><span>or enter existing key</span></div>'}
     <div class="api-key-status" id="ppq-key-status">
       ${currentKey ? '<span style="color:var(--green)">&#10003; Connected</span>' : '<span style="color:var(--text-muted)">No key set</span>'}
     </div>
     <input type="password" class="api-key-input" id="ppq-key-input" placeholder="sk-..." value="${escapeAttr(currentKey)}">
     <div style="display:flex;gap:8px;margin-top:12px">
-      <button class="import-btn import-btn-primary" id="save-ppq-key-btn" onclick="handleSavePpqKey()">Save & Validate</button>
-      ${currentKey ? '<button class="import-btn import-btn-secondary" onclick="handleRemovePpqKey()">Remove Key</button>' : ''}
+      <button class="import-btn import-btn-primary" id="save-ppq-key-btn" data-provider-panel-action="save-ppq-key">Save & Validate</button>
+      ${currentKey ? '<button class="import-btn import-btn-secondary" data-provider-panel-action="remove-ppq-key">Remove Key</button>' : ''}
     </div>
     ${balanceHtml}
     ${ppqModelHtml}
@@ -242,14 +242,14 @@ function renderCustomProviderPanel() {
     const isCustom = cachedModels.length && !cachedModels.some(m => m.id === customModel) && customModel;
     modelHtml = `<div style="margin-top:12px" id="custom-model-area">
       <label style="font-size:12px;color:var(--text-muted)">Model</label>
-      <select class="api-key-input" id="custom-model-select" style="margin-top:4px" onchange="setCustomApiModel(this.value);updateCustomModelPricing(this.value)">${isCustom ? '<option value="__custom" disabled selected>Using custom model</option>' : ''}${opts}</select>
-      <div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" id="custom-manual-model" placeholder="Or type any model ID and press Enter" style="font-size:11px;flex:1;padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-family:monospace${isCustom ? ';border-color:var(--accent)' : ''}" value="${isCustom ? escapeHTML(customModel) : ''}" onkeydown="if(event.key==='Enter'){applyCustomApiManualModel()}"></div>
+      <select class="api-key-input" id="custom-model-select" style="margin-top:4px" data-provider-panel-change="custom-model">${isCustom ? '<option value="__custom" disabled selected>Using custom model</option>' : ''}${opts}</select>
+      <div style="margin-top:6px;display:flex;align-items:center;gap:8px"><input type="text" id="custom-manual-model" placeholder="Or type any model ID and press Enter" style="font-size:11px;flex:1;padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-family:monospace${isCustom ? ';border-color:var(--accent)' : ''}" value="${isCustom ? escapeHTML(customModel) : ''}" data-provider-panel-key="custom-manual-model"></div>
       <div id="custom-model-pricing" style="margin-top:4px">${renderModelPricingHint('custom', customModel)}</div>
     </div>`;
   } else if (connected) {
     modelHtml = `<div style="margin-top:12px" id="custom-model-area">
       <label style="font-size:12px;color:var(--text-muted)">Model</label>
-      <div style="margin-top:4px;display:flex;gap:8px;align-items:center"><input type="text" class="api-key-input" id="custom-manual-model" value="${escapeAttr(customModel)}" placeholder="e.g. gpt-4o" style="flex:1"><button class="import-btn import-btn-secondary" onclick="applyCustomApiManualModel()" style="white-space:nowrap">Apply</button></div>
+      <div style="margin-top:4px;display:flex;gap:8px;align-items:center"><input type="text" class="api-key-input" id="custom-manual-model" value="${escapeAttr(customModel)}" placeholder="e.g. gpt-4o" style="flex:1"><button class="import-btn import-btn-secondary" data-provider-panel-action="apply-custom-api-model" style="white-space:nowrap">Apply</button></div>
       <div id="custom-model-pricing" style="margin-top:4px">${renderModelPricingHint('custom', customModel)}</div>
     </div>`;
   }
@@ -268,8 +268,8 @@ function renderCustomProviderPanel() {
       <input type="password" class="api-key-input" id="custom-key-input" value="${escapeAttr(currentKey)}" placeholder="sk-..." style="margin-top:4px">
     </div>
     <div style="display:flex;gap:8px;margin-top:12px">
-      <button class="import-btn import-btn-primary" onclick="handleSaveCustomApi()">Save & Validate</button>
-      ${connected ? '<button class="import-btn import-btn-secondary" onclick="handleRemoveCustomApi()">Remove</button>' : ''}
+      <button class="import-btn import-btn-primary" data-provider-panel-action="save-custom-api">Save & Validate</button>
+      ${connected ? '<button class="import-btn import-btn-secondary" data-provider-panel-action="remove-custom-api">Remove</button>' : ''}
     </div>
     ${modelHtml}
     <div class="api-key-notice">Your key is stored locally and sent directly to the endpoint you configure.</div>
@@ -289,7 +289,7 @@ function renderLocalAIProviderPanel() {
       <label style="font-size:12px;color:var(--text-muted)">Server address</label>
       <div style="display:flex;gap:8px;align-items:center;margin-top:4px">
         <input type="text" class="api-key-input" id="local-ai-url-input" value="${escapeAttr(config.url)}" placeholder="http://localhost:11434" style="flex:1">
-        <button class="import-btn import-btn-secondary" onclick="testOllamaConnection()" style="white-space:nowrap">Test</button>
+        <button class="import-btn import-btn-secondary" data-provider-panel-action="test-ollama-connection" style="white-space:nowrap">Test</button>
       </div>
     </div>
     <div style="margin-top:8px">
@@ -298,7 +298,7 @@ function renderLocalAIProviderPanel() {
     </div>
     <div id="local-ai-model-section" style="margin-top:8px;display:none">
       <label style="font-size:12px;color:var(--text-muted)">AI Model</label>
-      <select class="api-key-input" id="local-ai-model-select" style="margin-top:4px" onchange="setOllamaMainModel(this.value); refreshModelAdvisor()"></select>
+      <select class="api-key-input" id="local-ai-model-select" style="margin-top:4px" data-provider-panel-change="local-ai-model"></select>
       <div style="margin-top:4px">${renderModelPricingHint('ollama', '')}</div>
     </div>
     <div id="local-ai-advisor"></div>

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -8,12 +8,14 @@ import {
   getRoutstrKey, saveRoutstrKey,
   fetchRoutstrModels, validateRoutstrKey, createRoutstrAccount,
   setAIPaused,
+  setCustomApiModel, setOllamaMainModel, setPpqModel, setRoutstrModel,
   getVeniceE2EE,
   getCustomApiUrl, setCustomApiUrl, getCustomApiKey, saveCustomApiKey,
   fetchCustomApiModels, validateCustomApiKey,
-  rememberOpenRouterOAuthPreviousProvider, clearOpenRouterOAuthSession
+  rememberOpenRouterOAuthPreviousProvider, clearOpenRouterOAuthSession, startOpenRouterOAuth
 } from './api.js';
 import { updateKeyCache, encryptedSetItem } from './crypto.js';
+import { installProviderPanelDelegates } from './provider-panel-delegates.js';
 import { renderAIProviderPanel } from './provider-panel-renderers.js';
 import {
   applyHardwareOverride,
@@ -560,6 +562,40 @@ configureRoutstrWalletPanels({
   renderRoutstrModelDropdown,
   initSettingsModelFetch,
   returnToChatIfOnboarding: _returnToChatIfOnboarding
+});
+
+installProviderPanelDelegates({
+  startOpenRouterOAuth,
+  handleSaveOpenRouterKey,
+  handleRemoveOpenRouterKey,
+  refreshOpenRouterBalance,
+  refreshCashuWalletBalance,
+  showRoutstrMintEdit,
+  refreshRoutstrBalance,
+  handleSaveVeniceKey,
+  handleRemoveVeniceKey,
+  refreshVeniceBalance,
+  refreshPpqBalance,
+  showPpqTopup,
+  handleCreatePpqAccount,
+  handleSavePpqKey,
+  handleRemovePpqKey,
+  applyCustomApiManualModel,
+  handleSaveCustomApi,
+  handleRemoveCustomApi,
+  testOllamaConnection,
+  onOpenRouterDropdownChange,
+  setRoutstrModel,
+  updateRoutstrModelPricing,
+  onVeniceModelDropdownChange,
+  toggleVeniceE2EE,
+  setPpqModel,
+  updatePpqModelPricing,
+  setCustomApiModel,
+  updateCustomModelPricing,
+  setOllamaMainModel,
+  refreshModelAdvisor,
+  applyCustomOpenRouterModel
 });
 
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 745,
+  "inlineEventAttributes": 710,
   "windowReferences": 1975,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1600

--- a/service-worker.js
+++ b/service-worker.js
@@ -190,6 +190,7 @@ const APP_SHELL = [
   '/js/lab-context.js',
   '/js/markdown.js',
   '/js/provider-qr.js',
+  '/js/provider-panel-delegates.js',
   '/js/provider-wallet-panels.js',
   '/js/provider-wallet-delegates.js',
   '/js/provider-local-ai-controls.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -173,6 +173,7 @@ const LEGACY_TESTS = [
   './test-wearables-delegated-actions.js',
   './test-client-list-delegated-actions.js',
   './test-provider-wallet-delegated-actions.js',
+  './test-provider-panel-delegated-actions.js',
   './test-quality-guardrails.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',

--- a/tests/test-custom-api-dom.js
+++ b/tests/test-custom-api-dom.js
@@ -60,7 +60,7 @@ return (async function() {
     assert('selected model is test-model', select.value === 'test-model');
   }
   assert('manual model input exists in connected state', !!document.getElementById('custom-manual-model'));
-  assert('Remove button shown in connected state', document.querySelector('.ai-provider-panel')?.innerHTML.includes('handleRemoveCustomApi'));
+  assert('Remove button shown in connected state', !!document.querySelector('[data-provider-panel-action="remove-custom-api"]'));
   window.closeSettingsModal();
   if (sv_url) localStorage.setItem('labcharts-custom-url', sv_url); else localStorage.removeItem('labcharts-custom-url');
   if (sv_key) localStorage.setItem('labcharts-custom-key', sv_key); else localStorage.removeItem('labcharts-custom-key');

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -53,6 +53,19 @@ assert('provider panel delegates install idempotent listeners',
 assert('provider panel delegates are scoped to the provider panel',
   delegatesSrc.includes('PROVIDER_PANEL_ROOTS') &&
     delegatesSrc.includes('el.closest(PROVIDER_PANEL_ROOTS)'));
+assert('provider panel delegates dispatch through explicit action maps',
+  delegatesSrc.includes('const CLICK_ACTIONS = Object.freeze({') &&
+    delegatesSrc.includes('const CHANGE_ACTIONS = Object.freeze({') &&
+    delegatesSrc.includes('const MODEL_PRICING_ACTIONS = Object.freeze({') &&
+    delegatesSrc.includes('const KEY_ACTIONS = Object.freeze({'));
+assert('provider panel delegates warn on missing registry callbacks',
+  delegatesSrc.includes('Missing provider panel callback') &&
+    delegatesSrc.includes('console.warn(message)'));
+assert('provider panel delegates avoid preemptive default prevention',
+  delegatesSrc.indexOf('if (!callbackName) return _warnProviderPanelDelegate(`Unknown provider panel click action: ${action}`);') <
+    delegatesSrc.indexOf("if (el.matches('a, button')) event.preventDefault();") &&
+  delegatesSrc.indexOf('if (!callbackName) return _warnProviderPanelDelegate(`Unknown provider panel key action: ${action}`);') <
+    delegatesSrc.lastIndexOf('event.preventDefault();'));
 assert('service worker precaches provider panel delegate module',
   swSrc.includes('/js/provider-panel-delegates.js'));
 
@@ -77,7 +90,7 @@ assert('service worker precaches provider panel delegate module',
   'remove-custom-api',
   'test-ollama-connection',
 ].forEach(action => {
-  assert(`provider panel click action ${action} is handled`, delegatesSrc.includes(`action === '${action}'`));
+  assert(`provider panel click action ${action} is handled`, delegatesSrc.includes(`'${action}'`));
 });
 
 [
@@ -89,14 +102,14 @@ assert('service worker precaches provider panel delegate module',
   'custom-model',
   'local-ai-model',
 ].forEach(action => {
-  assert(`provider panel change action ${action} is handled`, delegatesSrc.includes(`action === '${action}'`));
+  assert(`provider panel change action ${action} is handled`, delegatesSrc.includes(`'${action}'`));
 });
 
 [
   'openrouter-custom-model',
   'custom-manual-model',
 ].forEach(action => {
-  assert(`provider panel key action ${action} is handled`, delegatesSrc.includes(`action === '${action}'`));
+  assert(`provider panel key action ${action} is handled`, delegatesSrc.includes(`'${action}'`));
 });
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Static provider panel delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const renderSrc = fs.readFileSync(path.join(root, 'js/provider-panel-renderers.js'), 'utf8');
+const modelControlsSrc = fs.readFileSync(path.join(root, 'js/provider-model-controls.js'), 'utf8');
+const delegatesSrc = fs.readFileSync(path.join(root, 'js/provider-panel-delegates.js'), 'utf8');
+const panelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
+const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Provider Panel Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|change|input|search|keydown|keyup|submit|blur)=/;
+assert('provider-panel-renderers.js renders no inline event attributes',
+  !inlineHandlerRe.test(renderSrc));
+assert('provider-model-controls.js renders no inline event attributes',
+  !inlineHandlerRe.test(modelControlsSrc));
+assert('provider panel renderers emit delegated action attributes',
+  renderSrc.includes('data-provider-panel-action') &&
+    renderSrc.includes('data-provider-panel-change') &&
+    renderSrc.includes('data-provider-panel-key'));
+assert('provider model controls emit delegated model attributes',
+  modelControlsSrc.includes('data-provider-panel-change') &&
+    modelControlsSrc.includes('data-provider-panel-key'));
+assert('provider-panels installs provider panel delegates',
+  panelsSrc.includes("import { installProviderPanelDelegates } from './provider-panel-delegates.js'") &&
+    panelsSrc.includes('installProviderPanelDelegates({') &&
+    panelsSrc.includes('handleSaveOpenRouterKey') &&
+    panelsSrc.includes('setOllamaMainModel'));
+assert('provider panel delegates install idempotent listeners',
+  delegatesSrc.includes('let providerPanelDelegatesInstalled = false') &&
+    delegatesSrc.includes("document.addEventListener('click', _handleProviderPanelClick)") &&
+    delegatesSrc.includes("document.addEventListener('change', _handleProviderPanelChange)") &&
+    delegatesSrc.includes("document.addEventListener('keydown', _handleProviderPanelKeydown)"));
+assert('provider panel delegates are scoped to the provider panel',
+  delegatesSrc.includes('PROVIDER_PANEL_ROOTS') &&
+    delegatesSrc.includes('el.closest(PROVIDER_PANEL_ROOTS)'));
+assert('service worker precaches provider panel delegate module',
+  swSrc.includes('/js/provider-panel-delegates.js'));
+
+[
+  'start-openrouter-oauth',
+  'save-openrouter-key',
+  'remove-openrouter-key',
+  'refresh-openrouter-balance',
+  'refresh-cashu-wallet-balance',
+  'show-routstr-mint-edit',
+  'refresh-routstr-balance',
+  'save-venice-key',
+  'remove-venice-key',
+  'refresh-venice-balance',
+  'refresh-ppq-balance',
+  'show-ppq-topup',
+  'create-ppq-account',
+  'save-ppq-key',
+  'remove-ppq-key',
+  'apply-custom-api-model',
+  'save-custom-api',
+  'remove-custom-api',
+  'test-ollama-connection',
+].forEach(action => {
+  assert(`provider panel click action ${action} is handled`, delegatesSrc.includes(`action === '${action}'`));
+});
+
+[
+  'openrouter-model',
+  'routstr-model',
+  'venice-model',
+  'venice-e2ee',
+  'ppq-model',
+  'custom-model',
+  'local-ai-model',
+].forEach(action => {
+  assert(`provider panel change action ${action} is handled`, delegatesSrc.includes(`action === '${action}'`));
+});
+
+[
+  'openrouter-custom-model',
+  'custom-manual-model',
+].forEach(action => {
+  assert(`provider panel key action ${action} is handled`, delegatesSrc.includes(`action === '${action}'`));
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -366,7 +366,10 @@ assert('provider renderer has venice-e2ee-toggle', providerRenderSrc.includes('v
 assert('provider renderer has venice-e2ee-indicator', providerRenderSrc.includes('venice-e2ee-indicator'));
 assert('provider model controls has toggleVeniceE2EE', providerModelControlsSrc.includes('function toggleVeniceE2EE'));
 assert('provider model controls has Venice model change handler', providerModelControlsSrc.includes('function onVeniceModelDropdownChange'));
-assert('Venice model dropdown uses change handler', (providerSrc + providerRenderSrc + providerModelControlsSrc).includes('onchange="onVeniceModelDropdownChange(this.value)"'));
+assert('Venice model dropdown uses delegated change handler',
+  providerRenderSrc.includes('data-provider-panel-change="venice-model"') &&
+    providerModelControlsSrc.includes('data-provider-panel-change="venice-model"') &&
+    providerSrc.includes('onVeniceModelDropdownChange,'));
 const chatSrc = read('js/chat.js');
 const chatSendSrc = read('js/chat-send.js');
 const chatAttestationSrc = read('js/chat-attestation.js');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.326';
+self.APP_VERSION = '1.8.327';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.327';
+self.APP_VERSION = '1.8.328';


### PR DESCRIPTION
## Summary
- Move AI provider panel click/change/Enter actions out of inline DOM attributes into a scoped delegated module.
- Cover dynamic model dropdown renderers so re-rendered provider controls keep using the same delegation boundary.
- Add a source guard, service worker cache entry, version bump, and quality baseline ratchet for inline event attributes.

## Quality impact
- Inline event attributes: 745 -> 710
- Window references: unchanged at 1975
- Large JS files over 800 lines: unchanged at 28

## Validation
- `node --check js/provider-panel-renderers.js`
- `node --check js/provider-model-controls.js`
- `node --check js/provider-panel-delegates.js`
- `node --check js/provider-panels.js`
- `node tests/test-provider-panel-delegated-actions.js`
- `npm run quality`
- `npm test -- --run tests/_vitest-legacy.test.js`
- `./run-tests.sh`