### PR TITLE
[codex] Delegate remaining settings actions

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -5,7 +5,7 @@ import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isDebugMod
 import { getTheme, setTheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, getTimeFormat, setTimeFormat, THEMES } from './theme.js';
 import { switchUnitSystem, toggleAltUnits, switchRangeMode } from './data.js';
 import { formatCost, getProfileUsage, getGlobalUsage, resetProfileUsage } from './schema.js';
-import { getAIProvider, setAIProvider, isAIPaused, getOllamaPIIUrl, getOllamaPIIModel, getOpenRouterKey, rememberOpenRouterOAuthPreviousProvider, clearOpenRouterOAuthSession } from './api.js';
+import { getAIProvider, setAIProvider, isAIPaused, getOllamaPIIUrl, getOllamaPIIModel, setOllamaPIIModel, getOpenRouterKey, rememberOpenRouterOAuthPreviousProvider, clearOpenRouterOAuthSession } from './api.js';
 import { isOllamaPIIEnabled, setOllamaPIIEnabled, getOllamaConfig, checkOpenAICompatible } from './pii.js';
 import { renderEncryptionSection, renderBackupSection, loadBackupSnapshots } from './crypto.js';
 import { renderSyncSection, renderMessengerSection, hydrateSettingsSyncPanel } from './settings-sync-panel.js';
@@ -308,13 +308,38 @@ function applySettingsToggle(actionEl) {
   if (actionEl instanceof HTMLInputElement && actionEl.disabled) return false;
 
   const action = actionEl.dataset.settingsAction;
+  const checked = actionEl instanceof HTMLInputElement && actionEl.checked;
   if (action === 'set-product-recs') {
-    setProductRecsEnabled(actionEl instanceof HTMLInputElement && actionEl.checked);
+    setProductRecsEnabled(checked);
     window.navigate?.('dashboard');
     return true;
   }
   if (action === 'set-debug-mode') {
-    setDebugMode(actionEl instanceof HTMLInputElement && actionEl.checked);
+    setDebugMode(checked);
+    return true;
+  }
+  if (action === 'toggle-ai-pause') {
+    window.toggleAIPause?.(checked);
+    return true;
+  }
+  if (action === 'set-wearable-context') {
+    window.setWearableContextEnabled?.(checked);
+    return true;
+  }
+  if (action === 'set-body-regions-context') {
+    window.setBodyRegionsInAIContext?.(checked);
+    return true;
+  }
+  if (action === 'toggle-pii-local') {
+    toggleOllamaPII(checked);
+    return true;
+  }
+  if (action === 'toggle-pii-review') {
+    if (actionEl instanceof HTMLInputElement) void confirmDisablePIIReview(actionEl);
+    return true;
+  }
+  if (action === 'set-analytics') {
+    setAnalyticsEnabled(checked);
     return true;
   }
   return false;
@@ -322,7 +347,13 @@ function applySettingsToggle(actionEl) {
 
 function isSettingsToggleAction(actionEl) {
   return actionEl.dataset.settingsAction === 'set-product-recs'
-    || actionEl.dataset.settingsAction === 'set-debug-mode';
+    || actionEl.dataset.settingsAction === 'set-debug-mode'
+    || actionEl.dataset.settingsAction === 'toggle-ai-pause'
+    || actionEl.dataset.settingsAction === 'set-wearable-context'
+    || actionEl.dataset.settingsAction === 'set-body-regions-context'
+    || actionEl.dataset.settingsAction === 'toggle-pii-local'
+    || actionEl.dataset.settingsAction === 'toggle-pii-review'
+    || actionEl.dataset.settingsAction === 'set-analytics';
 }
 
 function applyTweaksToggle(actionEl) {
@@ -404,6 +435,36 @@ function handleSettingsClick(event) {
     event.preventDefault();
     closeSettingsModal();
     setTimeout(() => window.openChangelog?.(true), 300);
+  } else if (action === 'switch-ai-provider') {
+    event.preventDefault();
+    switchAIProviderBridge(actionEl.dataset.provider || 'openrouter');
+  } else if (action === 'toggle-privacy-configure') {
+    event.preventDefault();
+    togglePrivacyConfigure();
+  } else if (action === 'test-pii-ollama') {
+    event.preventDefault();
+    window.testPIIOllamaConnection?.();
+  } else if (action === 'rename-imported-entry') {
+    event.preventDefault();
+    void renameImportedEntryDateFromSettings(actionEl.dataset.entryDate || '');
+  } else if (action === 'remove-imported-entry') {
+    event.preventDefault();
+    void removeImportedEntryFromSettings(actionEl.dataset.entryDate || '');
+  } else if (action === 'export-client') {
+    event.preventDefault();
+    window.exportClientJSON?.(window.getActiveProfileId?.());
+  } else if (action === 'export-all-clients') {
+    event.preventDefault();
+    window.exportAllDataJSON?.();
+  } else if (action === 'export-report') {
+    event.preventDefault();
+    window.exportPDFReport?.();
+  } else if (action === 'clear-all-data') {
+    event.preventDefault();
+    window.clearAllData?.();
+  } else if (action === 'reset-profile-usage') {
+    event.preventDefault();
+    resetCurrentProfileUsage();
   }
 }
 
@@ -415,6 +476,13 @@ function handleSettingsChange(event) {
 
   if (isSettingsToggleAction(actionEl)) {
     applySettingsToggle(actionEl);
+    return;
+  }
+
+  const action = actionEl.dataset.settingsAction;
+  if (action === 'set-pii-model') {
+    setOllamaPIIModel(actionEl.value);
+    updatePrivacyStatusCard();
   }
 }
 
@@ -423,6 +491,34 @@ function installSettingsDelegates(modal) {
   modal.dataset.delegatedActions = '1';
   modal.addEventListener('click', handleSettingsClick);
   modal.addEventListener('change', handleSettingsChange);
+}
+
+let sunDataSourceDelegatesInstalled = false;
+
+function closestSunDataSourceControl(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const el = target.closest('[data-sun-source-action]');
+  return el && el.closest('#sun-data-source-section') ? el : null;
+}
+
+function handleSunDataSourceChange(event) {
+  const el = closestSunDataSourceControl(event);
+  if (!el) return;
+  const action = el.dataset.sunSourceAction;
+  if (action === 'set-meteo-mode') {
+    setMeteoMode(el.value || 'auto');
+  } else if (action === 'save-meteo-selfhost') {
+    saveMeteoSelfhost();
+  } else if (action === 'toggle-meteo-rounding') {
+    toggleMeteoRounding(el instanceof HTMLInputElement && el.checked);
+  }
+}
+
+function installSunDataSourceDelegates() {
+  if (sunDataSourceDelegatesInstalled || typeof document === 'undefined') return;
+  sunDataSourceDelegatesInstalled = true;
+  document.addEventListener('change', handleSunDataSourceChange);
 }
 
 function handleTweaksClick(event) {
@@ -648,6 +744,7 @@ applyAccentOverride();
 if (typeof window !== 'undefined') {
   window.addEventListener('labcharts-themechange', () => applyAccentOverride());
 }
+installSunDataSourceDelegates();
 
 export function openSettingsModal(tab) {
   window._settingsHadProvider = !!window.hasAIProvider?.();
@@ -785,18 +882,18 @@ export function openSettingsModal(tab) {
             <div class="settings-copy-title">AI features</div>
           </div>
           <label class="toggle-switch">
-            <input type="checkbox" id="ai-pause-toggle" ${isAIPaused() ? '' : 'checked'} onchange="toggleAIPause(this.checked)">
+            <input type="checkbox" id="ai-pause-toggle" ${isAIPaused() ? '' : 'checked'} data-settings-action="toggle-ai-pause">
             <span class="toggle-slider"></span>
           </label>
         </div>
         <div class="ai-model-tip">Use a state-of-the-art model (Claude, GPT, Gemini) for medical data.<br>Stick with the same model across imports to keep marker keys consistent.</div>
         <div class="ai-provider-toggle">
-          <button class="ai-provider-btn${provider === 'ppq' ? ' active' : ''}" data-provider="ppq" onclick="switchAIProvider('ppq')"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 23c-3.2 0-7-2.4-7-7 0-3.1 2.1-5.7 4-7.6.3-.3.8-.1.8.4v2.5c0 .2.2.3.3.2C12 9.6 13.5 5.3 13.6 2.2c0-.3.4-.5.6-.2C17.3 5.7 21 10.3 21 14.5 21 19.6 17 23 12 23z"/></svg> PPQ</button>
-          <button class="ai-provider-btn${provider === 'routstr' ? ' active' : ''}" data-provider="routstr" onclick="switchAIProvider('routstr')"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 14 4 4-4 4"/><path d="m18 2 4 4-4 4"/><path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22"/><path d="M2 6h1.972a4 4 0 0 1 3.6 2.2"/><path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45"/></svg> Routstr</button>
-          <button class="ai-provider-btn${provider === 'openrouter' ? ' active' : ''}" data-provider="openrouter" onclick="switchAIProvider('openrouter')"><svg class="ai-provider-logo" viewBox="0 0 512 512" fill="currentColor" stroke="currentColor"><path d="M3 248.945C18 248.945 76 236 106 219C136 202 136 202 198 158C276.497 102.293 332 120.945 423 120.945" stroke-width="90" fill="none"/><path d="M511 121.5L357.25 210.268L357.25 32.7324L511 121.5Z" stroke="none"/><path d="M0 249C15 249 73 261.945 103 278.945C133 295.945 133 295.945 195 339.945C273.497 395.652 329 377 420 377" stroke-width="90" fill="none"/><path d="M508 376.445L354.25 287.678L354.25 465.213L508 376.445Z" stroke="none"/></svg> OpenRouter</button>
-          <button class="ai-provider-btn${provider === 'venice' ? ' active' : ''}" data-provider="venice" onclick="switchAIProvider('venice')"><svg class="ai-provider-logo" viewBox="0 0 326 366" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M105.481 245.984C99.4744 241.518 92.2244 237.777 84.2074 235.504C76.1903 233.231 67.406 232.427 58.8167 233.38C50.2272 234.332 41.8327 237.042 34.5086 241.017C27.1847 244.991 20.931 250.231 16.0487 255.905C11.1531 261.567 6.88803 268.522 4.0314 276.35C1.17477 284.178-0.273403 292.879 0.0448796 301.515C0.36299 310.152 2.44756 318.723 5.87231 326.319C9.29724 333.916 14.0625 340.538 19.3617 345.825C24.6482 351.124 31.2704 355.889 38.867 359.314C46.4637 362.739 55.0349 364.823 63.671 365.142C72.3073 365.46 81.0085 364.012 88.8366 361.155C96.6647 358.298 103.62 354.033 109.282 349.138C114.956 344.256 120.195 338.002 124.17 330.678C128.144 323.354 130.854 314.959 131.807 306.37C132.76 297.781 131.956 288.996 129.683 280.979C127.41 272.962 123.668 265.712 119.203 259.705L133.953 244.954L144.69 255.691H150.789L158.149 248.331V242.233L147.412 231.496L163 215.908L178.588 231.496L167.851 242.233V248.331L175.211 255.691H181.31L192.047 244.954L206.797 259.705C202.332 265.712 198.59 272.962 196.317 280.979C194.044 288.996 193.24 297.781 194.193 306.37C195.146 314.959 197.856 323.354 201.83 330.678C205.805 338.002 211.044 344.256 216.718 349.138C222.38 354.033 229.335 358.298 237.163 361.155C244.991 364.012 253.693 365.46 262.329 365.142C270.965 364.823 279.536 362.739 287.133 359.314C294.73 355.889 301.352 351.124 306.638 345.825C311.937 340.538 316.703 333.916 320.128 326.319C323.552 318.723 325.637 310.152 325.955 301.515C326.273 292.879 324.825 284.178 321.969 276.35C319.112 268.522 314.847 261.567 309.951 255.905C305.069 250.231 298.815 244.991 291.491 241.017C284.167 237.042 275.773 234.332 267.183 233.38C258.594 232.427 249.81 233.231 241.793 235.504C233.776 237.777 226.526 241.518 220.519 245.984L206.042 231.484L216.773 220.753V214.655L209.151 207.032H203.052L192.315 217.769L176.721 202.186L258.473 120.434L291.567 153.528V119.095H326L292.907 86.0012L326 52.9077V46.8095L318.377 39.1865H312.279L163 188.465L13.7212 39.1865H7.62295L0 46.8095V52.9077L33.0934 86.0012L0 119.095H34.4331V153.528L67.5263 120.434L149.279 202.186L133.685 217.769L122.948 207.032H116.849L109.226 214.655V220.753L119.958 231.484L105.481 245.984ZM238.144 321.715C234.778 328.62 235.477 338.188 239.811 344.531C243.793 351.1 252.216 355.693 259.895 355.484C267.574 355.693 275.997 351.1 279.979 344.531C284.313 338.188 285.012 328.62 281.646 321.715L282.484 320.812C289.389 324.196 298.971 323.511 305.324 319.178C311.904 315.2 316.508 306.768 316.297 299.081C316.508 291.395 311.904 282.963 305.324 278.984C298.971 274.652 289.389 273.966 282.484 277.351L281.646 276.448C285.012 269.543 284.313 259.974 279.979 253.632C275.997 247.063 267.574 242.469 259.895 242.679C252.216 242.469 243.793 247.063 239.811 253.632C235.477 259.974 234.778 269.543 238.144 276.448L237.306 277.351C230.401 273.966 220.818 274.652 214.466 278.984C207.886 282.963 203.282 291.395 203.492 299.081C203.282 306.768 207.886 315.2 214.466 319.178C220.818 323.511 230.401 324.196 237.306 320.812L238.144 321.715ZM86.1857 344.531C90.52 338.188 91.2191 328.62 87.8528 321.715L88.6913 320.812C95.5956 324.196 105.178 323.511 111.531 319.178C118.11 315.2 122.715 306.768 122.504 299.081C122.715 291.395 118.11 282.963 111.531 278.984C105.178 274.652 95.5956 273.966 88.6913 277.351L87.8528 276.448C91.2191 269.543 90.52 259.974 86.1857 253.632C82.2037 247.063 73.7808 242.469 66.1018 242.679C58.423 242.469 50.0001 247.063 46.0181 253.632C41.6839 259.974 40.9847 269.543 44.351 276.448L43.5126 277.351C36.6082 273.966 27.0255 274.652 20.6731 278.984C14.0932 282.963 9.48904 291.395 9.69934 299.081C9.48904 306.768 14.0932 315.2 20.6731 319.178C27.0255 323.511 36.6082 324.196 43.5126 320.812L44.351 321.715C40.9847 328.62 41.6839 338.188 46.0181 344.531C50.0001 351.1 58.423 355.693 66.1018 355.484C73.7808 355.693 82.2037 351.1 86.1857 344.531Z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M162.891 39.1864L202.078 0L221.482 19.4047V84.8147L167.742 138.555H158.04L104.3 84.8147V19.4047L123.705 0L162.891 39.1864ZM123.705 13.7213L158.04 48.0567V111.112L123.705 76.7773V13.7213ZM167.744 48.0567L202.079 13.7213V76.7773L167.744 111.112V48.0567Z"/></svg> Venice</button>
-          <button class="ai-provider-btn${provider === 'custom' ? ' active' : ''}" data-provider="custom" onclick="switchAIProvider('custom')"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg> Custom</button>
-          <button class="ai-provider-btn${provider === 'ollama' ? ' active' : ''}" data-provider="ollama" onclick="switchAIProvider('ollama')"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15h-2v-6h2v6zm4 0h-2v-6h2v6zm-3-8c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1z"/></svg> Local</button>
+          <button class="ai-provider-btn${provider === 'ppq' ? ' active' : ''}" data-provider="ppq" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 23c-3.2 0-7-2.4-7-7 0-3.1 2.1-5.7 4-7.6.3-.3.8-.1.8.4v2.5c0 .2.2.3.3.2C12 9.6 13.5 5.3 13.6 2.2c0-.3.4-.5.6-.2C17.3 5.7 21 10.3 21 14.5 21 19.6 17 23 12 23z"/></svg> PPQ</button>
+          <button class="ai-provider-btn${provider === 'routstr' ? ' active' : ''}" data-provider="routstr" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 14 4 4-4 4"/><path d="m18 2 4 4-4 4"/><path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22"/><path d="M2 6h1.972a4 4 0 0 1 3.6 2.2"/><path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45"/></svg> Routstr</button>
+          <button class="ai-provider-btn${provider === 'openrouter' ? ' active' : ''}" data-provider="openrouter" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 512 512" fill="currentColor" stroke="currentColor"><path d="M3 248.945C18 248.945 76 236 106 219C136 202 136 202 198 158C276.497 102.293 332 120.945 423 120.945" stroke-width="90" fill="none"/><path d="M511 121.5L357.25 210.268L357.25 32.7324L511 121.5Z" stroke="none"/><path d="M0 249C15 249 73 261.945 103 278.945C133 295.945 133 295.945 195 339.945C273.497 395.652 329 377 420 377" stroke-width="90" fill="none"/><path d="M508 376.445L354.25 287.678L354.25 465.213L508 376.445Z" stroke="none"/></svg> OpenRouter</button>
+          <button class="ai-provider-btn${provider === 'venice' ? ' active' : ''}" data-provider="venice" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 326 366" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M105.481 245.984C99.4744 241.518 92.2244 237.777 84.2074 235.504C76.1903 233.231 67.406 232.427 58.8167 233.38C50.2272 234.332 41.8327 237.042 34.5086 241.017C27.1847 244.991 20.931 250.231 16.0487 255.905C11.1531 261.567 6.88803 268.522 4.0314 276.35C1.17477 284.178-0.273403 292.879 0.0448796 301.515C0.36299 310.152 2.44756 318.723 5.87231 326.319C9.29724 333.916 14.0625 340.538 19.3617 345.825C24.6482 351.124 31.2704 355.889 38.867 359.314C46.4637 362.739 55.0349 364.823 63.671 365.142C72.3073 365.46 81.0085 364.012 88.8366 361.155C96.6647 358.298 103.62 354.033 109.282 349.138C114.956 344.256 120.195 338.002 124.17 330.678C128.144 323.354 130.854 314.959 131.807 306.37C132.76 297.781 131.956 288.996 129.683 280.979C127.41 272.962 123.668 265.712 119.203 259.705L133.953 244.954L144.69 255.691H150.789L158.149 248.331V242.233L147.412 231.496L163 215.908L178.588 231.496L167.851 242.233V248.331L175.211 255.691H181.31L192.047 244.954L206.797 259.705C202.332 265.712 198.59 272.962 196.317 280.979C194.044 288.996 193.24 297.781 194.193 306.37C195.146 314.959 197.856 323.354 201.83 330.678C205.805 338.002 211.044 344.256 216.718 349.138C222.38 354.033 229.335 358.298 237.163 361.155C244.991 364.012 253.693 365.46 262.329 365.142C270.965 364.823 279.536 362.739 287.133 359.314C294.73 355.889 301.352 351.124 306.638 345.825C311.937 340.538 316.703 333.916 320.128 326.319C323.552 318.723 325.637 310.152 325.955 301.515C326.273 292.879 324.825 284.178 321.969 276.35C319.112 268.522 314.847 261.567 309.951 255.905C305.069 250.231 298.815 244.991 291.491 241.017C284.167 237.042 275.773 234.332 267.183 233.38C258.594 232.427 249.81 233.231 241.793 235.504C233.776 237.777 226.526 241.518 220.519 245.984L206.042 231.484L216.773 220.753V214.655L209.151 207.032H203.052L192.315 217.769L176.721 202.186L258.473 120.434L291.567 153.528V119.095H326L292.907 86.0012L326 52.9077V46.8095L318.377 39.1865H312.279L163 188.465L13.7212 39.1865H7.62295L0 46.8095V52.9077L33.0934 86.0012L0 119.095H34.4331V153.528L67.5263 120.434L149.279 202.186L133.685 217.769L122.948 207.032H116.849L109.226 214.655V220.753L119.958 231.484L105.481 245.984ZM238.144 321.715C234.778 328.62 235.477 338.188 239.811 344.531C243.793 351.1 252.216 355.693 259.895 355.484C267.574 355.693 275.997 351.1 279.979 344.531C284.313 338.188 285.012 328.62 281.646 321.715L282.484 320.812C289.389 324.196 298.971 323.511 305.324 319.178C311.904 315.2 316.508 306.768 316.297 299.081C316.508 291.395 311.904 282.963 305.324 278.984C298.971 274.652 289.389 273.966 282.484 277.351L281.646 276.448C285.012 269.543 284.313 259.974 279.979 253.632C275.997 247.063 267.574 242.469 259.895 242.679C252.216 242.469 243.793 247.063 239.811 253.632C235.477 259.974 234.778 269.543 238.144 276.448L237.306 277.351C230.401 273.966 220.818 274.652 214.466 278.984C207.886 282.963 203.282 291.395 203.492 299.081C203.282 306.768 207.886 315.2 214.466 319.178C220.818 323.511 230.401 324.196 237.306 320.812L238.144 321.715ZM86.1857 344.531C90.52 338.188 91.2191 328.62 87.8528 321.715L88.6913 320.812C95.5956 324.196 105.178 323.511 111.531 319.178C118.11 315.2 122.715 306.768 122.504 299.081C122.715 291.395 118.11 282.963 111.531 278.984C105.178 274.652 95.5956 273.966 88.6913 277.351L87.8528 276.448C91.2191 269.543 90.52 259.974 86.1857 253.632C82.2037 247.063 73.7808 242.469 66.1018 242.679C58.423 242.469 50.0001 247.063 46.0181 253.632C41.6839 259.974 40.9847 269.543 44.351 276.448L43.5126 277.351C36.6082 273.966 27.0255 274.652 20.6731 278.984C14.0932 282.963 9.48904 291.395 9.69934 299.081C9.48904 306.768 14.0932 315.2 20.6731 319.178C27.0255 323.511 36.6082 324.196 43.5126 320.812L44.351 321.715C40.9847 328.62 41.6839 338.188 46.0181 344.531C50.0001 351.1 58.423 355.693 66.1018 355.484C73.7808 355.693 82.2037 351.1 86.1857 344.531Z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M162.891 39.1864L202.078 0L221.482 19.4047V84.8147L167.742 138.555H158.04L104.3 84.8147V19.4047L123.705 0L162.891 39.1864ZM123.705 13.7213L158.04 48.0567V111.112L123.705 76.7773V13.7213ZM167.744 48.0567L202.079 13.7213V76.7773L167.744 111.112V48.0567Z"/></svg> Venice</button>
+          <button class="ai-provider-btn${provider === 'custom' ? ' active' : ''}" data-provider="custom" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg> Custom</button>
+          <button class="ai-provider-btn${provider === 'ollama' ? ' active' : ''}" data-provider="ollama" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15h-2v-6h2v6zm4 0h-2v-6h2v6zm-3-8c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1z"/></svg> Local</button>
         </div>
         <div id="ai-provider-panel">${window.renderAIProviderPanel(provider)}</div>
       </div>
@@ -810,7 +907,7 @@ export function openSettingsModal(tab) {
             <div class="settings-copy-desc">~200 tokens summarising HRV, sleep, recovery and trends from your connected wearables.</div>
           </div>
           <label class="toggle-switch">
-            <input type="checkbox" id="ai-ctx-wearables-toggle" ${window.isWearableContextEnabled?.() ? 'checked' : ''} onchange="window.setWearableContextEnabled(this.checked)">
+            <input type="checkbox" id="ai-ctx-wearables-toggle" ${window.isWearableContextEnabled?.() ? 'checked' : ''} data-settings-action="set-wearable-context">
             <span class="toggle-slider"></span>
           </label>
         </div>
@@ -820,7 +917,7 @@ export function openSettingsModal(tab) {
             <div class="settings-copy-desc">Off by default. When on, specific anatomical regions you logged (face, chest, genitals…) are included in chat context and agent slices. Off keeps coverage fraction + preset names but strips the per-region anatomy.</div>
           </div>
           <label class="toggle-switch">
-            <input type="checkbox" id="ai-ctx-body-regions-toggle" ${window.isBodyRegionsInAIContext?.() ? 'checked' : ''} onchange="window.setBodyRegionsInAIContext(this.checked)">
+            <input type="checkbox" id="ai-ctx-body-regions-toggle" ${window.isBodyRegionsInAIContext?.() ? 'checked' : ''} data-settings-action="set-body-regions-context">
             <span class="toggle-slider"></span>
           </label>
         </div>
@@ -982,7 +1079,7 @@ export function renderPrivacySection() {
         <div class="privacy-status-detail" id="privacy-status-detail"></div>
       </div>
     </div>
-    <div class="privacy-configure-toggle" onclick="togglePrivacyConfigure()" style="margin-top:12px">
+    <div class="privacy-configure-toggle" data-settings-action="toggle-privacy-configure" style="margin-top:12px">
       <span class="privacy-configure-arrow" id="privacy-configure-arrow">&#9654;</span>
       Configure Local AI
     </div>
@@ -996,26 +1093,26 @@ export function renderPrivacySection() {
           <label style="font-size:12px;color:var(--text-muted)">Server address</label>
           <div style="display:flex;gap:8px;align-items:center;margin-top:4px">
             <input type="text" class="api-key-input" id="pii-local-url-input" value="${piiUrl}" placeholder="http://localhost:11434" style="flex:1">
-            <button class="import-btn import-btn-secondary" onclick="testPIIOllamaConnection()" style="white-space:nowrap">Test</button>
+            <button class="import-btn import-btn-secondary" data-settings-action="test-pii-ollama" style="white-space:nowrap">Test</button>
           </div>
         </div>
         <div id="pii-model-dropdown" style="margin-top:8px;display:none">
           <label style="font-size:12px;color:var(--text-muted)">Privacy model <span style="font-size:11px">(can be a smaller, faster model)</span></label>
-          <select class="api-key-input" id="pii-model-select" style="margin-top:4px" onchange="setOllamaPIIModel(this.value)"></select>
+          <select class="api-key-input" id="pii-model-select" style="margin-top:4px" data-settings-action="set-pii-model"></select>
         </div>
       </div>
     </div>
     <div style="display:flex;align-items:start;justify-content:space-between;gap:12px;margin-top:14px">
       <span style="font-size:13px">Use local AI for privacy protection<br><span style="font-size:11px;color:var(--text-muted)">Requires a local AI server (configure above). When disabled, regex pattern matching is used instead.</span></span>
       <label class="toggle-switch" style="margin-top:2px">
-        <input type="checkbox" id="pii-local-toggle" ${piiEnabled ? 'checked' : ''} onchange="toggleOllamaPII(this.checked)">
+        <input type="checkbox" id="pii-local-toggle" ${piiEnabled ? 'checked' : ''} data-settings-action="toggle-pii-local">
         <span class="toggle-slider"></span>
       </label>
     </div>
     <div style="display:flex;align-items:start;justify-content:space-between;gap:12px;margin-top:8px">
       <span style="font-size:13px">Review obfuscated text before sending to AI<br><span style="font-size:11px;color:var(--text-muted)">Pause after privacy protection runs so you can inspect what the AI is about to receive. Adds one click per import — recommended.</span></span>
       <label class="toggle-switch" style="margin-top:2px">
-        <input type="checkbox" id="pii-review-toggle" ${isPIIReviewEnabled() ? 'checked' : ''} onchange="confirmDisablePIIReview(this)">
+        <input type="checkbox" id="pii-review-toggle" ${isPIIReviewEnabled() ? 'checked' : ''} data-settings-action="toggle-pii-review">
         <span class="toggle-slider"></span>
       </label>
     </div>
@@ -1027,7 +1124,7 @@ export function renderPrivacySection() {
     <div style="display:flex;align-items:start;justify-content:space-between;gap:12px">
       <span style="font-size:13px">Send anonymous usage stats<br><span style="font-size:11px;color:var(--text-muted)">Toggle takes effect on next launch.</span></span>
       <label class="toggle-switch" style="margin-top:2px">
-        <input type="checkbox" id="analytics-toggle" ${isAnalyticsEnabled() ? 'checked' : ''} onchange="setAnalyticsEnabled(this.checked)">
+        <input type="checkbox" id="analytics-toggle" ${isAnalyticsEnabled() ? 'checked' : ''} data-settings-action="set-analytics">
         <span class="toggle-slider"></span>
       </label>
     </div>
@@ -1038,7 +1135,7 @@ function _renderMeteoModeOption(mode, label, desc) {
   const cur = (typeof window !== 'undefined' && window.getMeteoConfig) ? window.getMeteoConfig().mode : 'auto';
   const checked = cur === mode;
   return `<label style="display:flex;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:var(--radius-sm);cursor:pointer;${checked ? 'background:var(--bg-card);border-color:var(--accent);' : ''}">
-    <input type="radio" name="meteo-mode" value="${mode}" ${checked ? 'checked' : ''} onchange="window._setMeteoMode('${mode}')" style="margin-top:3px">
+    <input type="radio" name="meteo-mode" value="${mode}" ${checked ? 'checked' : ''} data-sun-source-action="set-meteo-mode" style="margin-top:3px">
     <span>
       <span style="font-size:13px;font-weight:500;color:var(--text-primary)">${label}</span>
       <br><span style="font-size:11px;color:var(--text-muted);line-height:1.4">${desc}</span>
@@ -1065,45 +1162,48 @@ export function renderSunDataSourceSettings() {
     </div>
     <div id="meteo-selfhost-fields" style="margin-top:10px;${cfg.mode === 'selfhost' ? '' : 'display:none'}">
       <label style="font-size:12px;color:var(--text-muted)">Server URL</label>
-      <input type="text" class="api-key-input" id="meteo-selfhost-url" value="${escapeAttr(cfg.selfhostUrl || '')}" placeholder="https://meteo.example.com" style="width:100%;margin-top:4px" onchange="window._saveMeteoSelfhost()">
+      <input type="text" class="api-key-input" id="meteo-selfhost-url" value="${escapeAttr(cfg.selfhostUrl || '')}" placeholder="https://meteo.example.com" style="width:100%;margin-top:4px" data-sun-source-action="save-meteo-selfhost">
       <label style="font-size:12px;color:var(--text-muted);margin-top:8px;display:block">Bearer token (optional)</label>
-      <input type="password" class="api-key-input" id="meteo-selfhost-bearer" value="${escapeAttr(cfg.selfhostBearer || '')}" placeholder="••••••••" style="width:100%;margin-top:4px" onchange="window._saveMeteoSelfhost()">
+      <input type="password" class="api-key-input" id="meteo-selfhost-bearer" value="${escapeAttr(cfg.selfhostBearer || '')}" placeholder="••••••••" style="width:100%;margin-top:4px" data-sun-source-action="save-meteo-selfhost">
     </div>
     <div style="display:flex;align-items:start;justify-content:space-between;gap:12px;margin-top:14px">
       <span style="font-size:13px">Round location to ~11 km grid before sending<br><span style="font-size:11px;color:var(--text-muted)">Default ON. Stops the data source from seeing your exact address. Disable for slightly sharper UV math.</span></span>
       <label class="toggle-switch" style="margin-top:2px">
-        <input type="checkbox" id="meteo-privacy-rounding" ${(cfg.privacyRounding ?? 0.1) > 0 ? 'checked' : ''} onchange="window._toggleMeteoRounding(this.checked)">
+        <input type="checkbox" id="meteo-privacy-rounding" ${(cfg.privacyRounding ?? 0.1) > 0 ? 'checked' : ''} data-sun-source-action="toggle-meteo-rounding">
         <span class="toggle-slider"></span>
       </label>
     </div>
   </div>`;
 }
 
+function setMeteoMode(mode) {
+  if (!window.getMeteoConfig || !window.saveMeteoConfig) return;
+  const cfg = window.getMeteoConfig();
+  cfg.mode = mode;
+  window.saveMeteoConfig(cfg);
+  const fields = document.getElementById('meteo-selfhost-fields');
+  if (fields) fields.style.display = mode === 'selfhost' ? '' : 'none';
+}
+
+function saveMeteoSelfhost() {
+  if (!window.getMeteoConfig || !window.saveMeteoConfig) return;
+  const cfg = window.getMeteoConfig();
+  const url = document.getElementById('meteo-selfhost-url')?.value?.trim() || '';
+  const bearer = document.getElementById('meteo-selfhost-bearer')?.value?.trim() || '';
+  cfg.selfhostUrl = url;
+  cfg.selfhostBearer = bearer;
+  window.saveMeteoConfig(cfg);
+}
+
+function toggleMeteoRounding(enabled) {
+  if (!window.getMeteoConfig || !window.saveMeteoConfig) return;
+  const cfg = window.getMeteoConfig();
+  cfg.privacyRounding = enabled ? 0.1 : 0;
+  window.saveMeteoConfig(cfg);
+}
+
 if (typeof window !== 'undefined') {
   window.renderSunDataSourceSettings = renderSunDataSourceSettings;
-  window._setMeteoMode = (mode) => {
-    if (!window.getMeteoConfig || !window.saveMeteoConfig) return;
-    const cfg = window.getMeteoConfig();
-    cfg.mode = mode;
-    window.saveMeteoConfig(cfg);
-    const fields = document.getElementById('meteo-selfhost-fields');
-    if (fields) fields.style.display = mode === 'selfhost' ? '' : 'none';
-  };
-  window._saveMeteoSelfhost = () => {
-    if (!window.getMeteoConfig || !window.saveMeteoConfig) return;
-    const cfg = window.getMeteoConfig();
-    const url = document.getElementById('meteo-selfhost-url')?.value?.trim() || '';
-    const bearer = document.getElementById('meteo-selfhost-bearer')?.value?.trim() || '';
-    cfg.selfhostUrl = url;
-    cfg.selfhostBearer = bearer;
-    window.saveMeteoConfig(cfg);
-  };
-  window._toggleMeteoRounding = (enabled) => {
-    if (!window.getMeteoConfig || !window.saveMeteoConfig) return;
-    const cfg = window.getMeteoConfig();
-    cfg.privacyRounding = enabled ? 0.1 : 0;
-    window.saveMeteoConfig(cfg);
-  };
 }
 
 export function togglePrivacyConfigure() {
@@ -1211,20 +1311,20 @@ export function renderDataEntriesSection() {
         : manualCount > 0
           ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${manualCount} manual</span>`
           : '';
-    const dateArg = escapeAttr(JSON.stringify(entry.date));
+    const dateAttr = escapeAttr(entry.date);
     html += `<div class="imported-entry">
       <span class="ie-info"><span class="ie-date">${d}</span><span class="ie-count">${cnt} markers</span>${fileLabel}${sourceLabel}</span>
       <div class="ie-actions">
-        <button class="ie-edit" onclick="renameImportedEntryDateFromSettings(${dateArg})" title="Edit collection date">Edit date</button>
-        <button class="ie-remove" onclick="removeImportedEntryFromSettings(${dateArg})">Remove</button>
+        <button class="ie-edit" data-settings-action="rename-imported-entry" data-entry-date="${dateAttr}" title="Edit collection date">Edit date</button>
+        <button class="ie-remove" data-settings-action="remove-imported-entry" data-entry-date="${dateAttr}">Remove</button>
       </div>
     </div>`;
   }
   html += `<div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
-    <button class="import-btn import-btn-secondary" onclick="exportClientJSON(window.getActiveProfileId())">Export Client</button>
-    <button class="import-btn import-btn-secondary" onclick="exportAllDataJSON()" title="Full backup — all profiles, data, and chat history">Export All Clients</button>
-    <button class="import-btn import-btn-secondary" onclick="exportPDFReport()">Export Report</button>
-    <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" onclick="clearAllData()">Clear All Data</button></div>`;
+    <button class="import-btn import-btn-secondary" data-settings-action="export-client">Export Client</button>
+    <button class="import-btn import-btn-secondary" data-settings-action="export-all-clients" title="Full backup — all profiles, data, and chat history">Export All Clients</button>
+    <button class="import-btn import-btn-secondary" data-settings-action="export-report">Export Report</button>
+    <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" data-settings-action="clear-all-data">Clear All Data</button></div>`;
   return html;
 }
 
@@ -1270,7 +1370,7 @@ function renderAIUsageSection() {
   html += `<div><strong>All profiles</strong>: ${formatCost(gu.totalCost)} · ${gu.requestCount} request${gu.requestCount !== 1 ? 's' : ''} · ${formatTokens(gu.totalInputTokens + gu.totalOutputTokens)} tokens</div>`;
   html += '</div>';
   if (pu.requestCount > 0) {
-    html += `<button class="import-btn import-btn-secondary" style="margin-top:8px;font-size:11px" onclick="resetCurrentProfileUsage()">Reset profile usage</button>`;
+    html += `<button class="import-btn import-btn-secondary" style="margin-top:8px;font-size:11px" data-settings-action="reset-profile-usage">Reset profile usage</button>`;
   }
   return html;
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 710,
+  "inlineEventAttributes": 684,
   "windowReferences": 1975,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1600

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -220,7 +220,8 @@ const panelRenderSrc = read('js/provider-panel-renderers.js');
 const providerModelControlsSrc = read('js/provider-model-controls.js');
 const providerUiSrc = panelsSrc + panelRenderSrc + providerModelControlsSrc;
 assert('settings.js has data-provider="custom" button', settingsSrc.includes('data-provider="custom"'));
-assert("settings.js wires switchAIProvider('custom')", settingsSrc.includes("switchAIProvider('custom')"));
+assert('settings.js wires custom provider through delegated action',
+  /<button[^>]*data-provider="custom"[^>]*data-settings-action="switch-ai-provider"/.test(settingsSrc));
 assert('provider code imports getCustomApiUrl', providerUiSrc.includes('getCustomApiUrl'));
 assert('provider-panels imports setCustomApiUrl', panelsSrc.includes('setCustomApiUrl'));
 assert('provider code imports getCustomApiKey', providerUiSrc.includes('getCustomApiKey'));

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -109,7 +109,8 @@ assert('imports validateOpenRouterKey', ppSrc.includes('validateOpenRouterKey'))
 assert('imports fetchOpenRouterModels', ppSrc.includes('fetchOpenRouterModels'));
 const settingsSrc = read('js/settings.js');
 assert('provider button with data-provider="openrouter"', settingsSrc.includes('data-provider="openrouter"'));
-assert("switchAIProvider('openrouter') in onclick", settingsSrc.includes("switchAIProvider('openrouter')"));
+assert('OpenRouter provider button uses delegated settings action',
+  /<button[^>]*data-provider="openrouter"[^>]*data-settings-action="switch-ai-provider"/.test(settingsSrc));
 assert('settings has eager provider switch bridge', settingsSrc.includes('function switchAIProviderBridge(provider)'));
 assert('eager provider bridge persists selection synchronously', settingsSrc.includes('setAIProvider(provider);'));
 assert('renderAIProviderPanel handles openrouter', providerRenderSrc.includes("provider === 'openrouter'"));

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -36,6 +36,8 @@ const renderThemeButtonBlock = matchBlock('renderThemeButton', /function renderT
 
 const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
 
+assert('settings.js has no inline event attributes',
+  !inlineHandlerRe.test(src));
 assert('Display tab has no inline event attributes',
   displayBlock && !inlineHandlerRe.test(displayBlock));
 assert('Tweaks panel has no inline event attributes',
@@ -67,6 +69,28 @@ assert('Tweaks panel installs delegated change listener',
 });
 
 [
+  'toggle-ai-pause',
+  'switch-ai-provider',
+  'set-wearable-context',
+  'set-body-regions-context',
+  'toggle-privacy-configure',
+  'test-pii-ollama',
+  'set-pii-model',
+  'toggle-pii-local',
+  'toggle-pii-review',
+  'set-analytics',
+  'rename-imported-entry',
+  'remove-imported-entry',
+  'export-client',
+  'export-all-clients',
+  'export-report',
+  'clear-all-data',
+  'reset-profile-usage',
+].forEach(action => {
+  assert(`Settings action ${action} is rendered`, src.includes(`data-settings-action="${action}"`));
+});
+
+[
   'select-theme',
   'select-accent',
   'toggle-sunset',
@@ -79,6 +103,14 @@ assert('Tweaks panel installs delegated change listener',
   assert(`Tweaks action ${action} is rendered`, src.includes(`data-tweaks-action="${action}"`));
 });
 
+[
+  'set-meteo-mode',
+  'save-meteo-selfhost',
+  'toggle-meteo-rounding',
+].forEach(action => {
+  assert(`Sun data-source action ${action} is rendered`, src.includes(`data-sun-source-action="${action}"`));
+});
+
 assert('Settings tabs use data-settings-tab',
   /class="settings-tab-btn[\s\S]*data-settings-tab="display"/.test(src)
     && /class="settings-tab-btn[\s\S]*data-settings-tab="agent"/.test(src));
@@ -86,6 +118,18 @@ assert('Delegated settings handler switches tabs',
   /closestWithin\(event, '\[data-settings-tab\]', modal\)[\s\S]*switchSettingsTab/.test(src));
 assert('Delegated tweaks handler closes on backdrop click',
   /event\.target === overlay[\s\S]*closeTweaksPanel\(\)/.test(src));
+assert('Delegated settings handler switches AI providers',
+  /action === 'switch-ai-provider'[\s\S]*switchAIProviderBridge\(actionEl\.dataset\.provider/.test(src));
+assert('Delegated settings handler updates PII model selection',
+  /action === 'set-pii-model'[\s\S]*setOllamaPIIModel\(actionEl\.value\)/.test(src));
+assert('Sun data-source delegate is installed on document change',
+  /document\.addEventListener\('change', handleSunDataSourceChange\)/.test(src));
+assert('Sun data-source delegate is scoped to its section',
+  /function closestSunDataSourceControl[\s\S]*closest\('#sun-data-source-section'\)/.test(src));
+assert('Legacy Sun data-source window handlers are removed',
+  !src.includes('window._setMeteoMode')
+    && !src.includes('window._saveMeteoSelfhost')
+    && !src.includes('window._toggleMeteoRounding'));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -71,8 +71,10 @@ return (async function() {
     const entriesHtml = window.renderDataEntriesSection();
     assert('Settings Data remove wrapper is callable', typeof window.removeImportedEntryFromSettings === 'function');
     assert('Settings Data legacy remove bridge is callable', typeof window.removeImportedEntry === 'function');
-    assert('Settings Data remove button uses lazy wrapper', entriesHtml.includes('removeImportedEntryFromSettings(&quot;2099-12-31&quot;)'));
-    assert('Settings Data edit button uses lazy wrapper', entriesHtml.includes('renameImportedEntryDateFromSettings(&quot;2099-12-31&quot;)'));
+    assert('Settings Data remove button uses delegated action',
+      entriesHtml.includes('data-settings-action="remove-imported-entry"') && entriesHtml.includes('data-entry-date="2099-12-31"'));
+    assert('Settings Data edit button uses delegated action',
+      entriesHtml.includes('data-settings-action="rename-imported-entry"') && entriesHtml.includes('data-entry-date="2099-12-31"'));
     assert('Settings Data hides marker-tombstone-only sync rows', !entriesHtml.includes('0 markers'));
     await window.removeImportedEntryFromSettings('2099-12-31');
     await wait(50);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.328';
+self.APP_VERSION = '1.8.329';


### PR DESCRIPTION
## Summary
- Route the remaining Settings modal actions through the existing delegated click/change handlers instead of inline DOM attributes.
- Move the Light & Sun data-source controls to scoped delegated change handling and remove the temporary `window._setMeteoMode`/`_saveMeteoSelfhost`/`_toggleMeteoRounding` handlers.
- Update source guards and provider/data-flow tests, lower the inline event baseline from 710 to 684, and bump `version.js` for cache invalidation.

## Validation
- `node --check js/settings.js`
- `node tests/test-settings-delegated-actions.js`
- `node tests/test-openrouter.js`
- `node tests/test-custom-api.js`
- `npm run quality`
- `npm test -- --run tests/_vitest-legacy.test.js`
- `./run-tests.sh`