### PR TITLE
[codex] Delegate settings sync panel actions

### DIFF
--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -20,6 +20,13 @@ import {
 } from './sync.js';
 
 let settingsSyncDelegatesInstalled = false;
+const SETTINGS_SYNC_STATE_ACTIONS = new Set([
+  'toggle-sync',
+  'setup-ack',
+  'restore-dialog-input',
+  'toggle-messenger',
+  'set-agent-wearable-series-days',
+]);
 
 function closestSettingsSyncAction(event, selector = '[data-sync-action],[data-sync-setup-action]') {
   const target = event.target;
@@ -52,6 +59,8 @@ async function handleSettingsSyncClick(event) {
 
   const action = actionEl.dataset.syncAction || actionEl.dataset.syncSetupAction;
   if (!action) return;
+
+  if (SETTINGS_SYNC_STATE_ACTIONS.has(action)) return;
 
   event.preventDefault();
 

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -19,6 +19,113 @@ import {
   pushContextToGateway,
 } from './sync.js';
 
+let settingsSyncDelegatesInstalled = false;
+
+function closestSettingsSyncAction(event, selector = '[data-sync-action],[data-sync-setup-action]') {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const el = target.closest(selector);
+  if (!el) return null;
+  return el.closest('#sync-section, #messenger-section, #sync-setup-overlay, #sync-restore-overlay') ? el : null;
+}
+
+function nudgeSyncSetupDialog() {
+  const d = document.querySelector('#sync-setup-overlay .confirm-dialog');
+  if (!d) return;
+  d.classList.add('modal-nudge');
+  d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true });
+}
+
+async function handleSettingsSyncClick(event) {
+  const target = event.target;
+  if (target instanceof Element && target.id === 'sync-setup-overlay') {
+    nudgeSyncSetupDialog();
+    return;
+  }
+  if (target instanceof Element && target.id === 'sync-restore-overlay') {
+    closeRestoreMnemonicDialog();
+    return;
+  }
+
+  const actionEl = closestSettingsSyncAction(event);
+  if (!actionEl) return;
+
+  const action = actionEl.dataset.syncAction || actionEl.dataset.syncSetupAction;
+  if (!action) return;
+
+  event.preventDefault();
+
+  if (action === 'apply-tombstone') {
+    await window.applyPendingTombstone?.(actionEl.dataset.tombId || '');
+    window.openSettingsModal?.('data');
+  } else if (action === 'reject-tombstone') {
+    await window.rejectPendingTombstone?.(actionEl.dataset.tombId || '');
+    window.openSettingsModal?.('data');
+  } else if (action === 'toggle-mnemonic') {
+    toggleMnemonicVisibility();
+  } else if (action === 'copy-mnemonic') {
+    copyMnemonic();
+  } else if (action === 'open-restore-dialog') {
+    openRestoreMnemonicDialog();
+  } else if (action === 'save-relay') {
+    saveSyncRelay();
+  } else if (action === 'setup-new') {
+    void syncSetupNew();
+  } else if (action === 'setup-restore') {
+    syncSetupRestore();
+  } else if (action === 'setup-do-restore') {
+    void syncSetupDoRestore();
+  } else if (action === 'setup-back') {
+    syncSetupBack();
+  } else if (action === 'setup-cancel') {
+    void closeSyncSetup();
+  } else if (action === 'setup-done') {
+    syncSetupDone();
+  } else if (action === 'close-restore-dialog') {
+    closeRestoreMnemonicDialog();
+  } else if (action === 'confirm-restore') {
+    void confirmRestoreMnemonic();
+  } else if (action === 'toggle-messenger-token') {
+    toggleMessengerToken();
+  } else if (action === 'copy-messenger-token') {
+    copyMessengerToken();
+  } else if (action === 'regenerate-messenger-token') {
+    regenerateMessengerToken();
+  }
+}
+
+function handleSettingsSyncChange(event) {
+  const actionEl = closestSettingsSyncAction(event);
+  if (!actionEl) return;
+  const action = actionEl.dataset.syncAction || actionEl.dataset.syncSetupAction;
+  if (!action) return;
+
+  if (action === 'toggle-sync' && actionEl instanceof HTMLInputElement) {
+    void toggleSync(actionEl.checked);
+  } else if (action === 'setup-ack' && actionEl instanceof HTMLInputElement) {
+    updateSyncSetupAck(actionEl);
+  } else if (action === 'toggle-messenger' && actionEl instanceof HTMLInputElement) {
+    toggleMessenger(actionEl.checked);
+  } else if (action === 'set-agent-wearable-series-days' && actionEl instanceof HTMLSelectElement) {
+    window.setAgentWearableSeriesDays?.(actionEl.value === 'off' ? 0 : Number(actionEl.value));
+    window.pushContextToGateway?.();
+  }
+}
+
+function handleSettingsSyncInput(event) {
+  const actionEl = closestSettingsSyncAction(event, '[data-sync-action]');
+  if (!actionEl || actionEl.dataset.syncAction !== 'restore-dialog-input') return;
+  if (actionEl instanceof HTMLTextAreaElement) updateRestoreMnemonicDialogState(actionEl);
+}
+
+function installSettingsSyncDelegates() {
+  if (settingsSyncDelegatesInstalled || typeof document === 'undefined') return;
+  settingsSyncDelegatesInstalled = true;
+  document.addEventListener('click', handleSettingsSyncClick);
+  document.addEventListener('change', handleSettingsSyncChange);
+  document.addEventListener('input', handleSettingsSyncInput);
+}
+
 function renderPendingTombstones() {
   const pending = window.listPendingTombstones?.() || [];
   if (pending.length === 0) return '';
@@ -26,8 +133,8 @@ function renderPendingTombstones() {
     <div class="sync-tombstone-row" data-tomb-id="${escapeAttr(p.id)}">
       <span class="sync-tombstone-name">${escapeHTML(p.name)}</span>
       <span class="sync-tombstone-meta">${p.at ? `flagged ${new Date(p.at).toLocaleDateString()}` : ''}</span>
-      <button class="sync-tombstone-btn sync-tombstone-apply" onclick="window.applyPendingTombstone('${escapeAttr(p.id)}').then(() => window.openSettingsModal('data'))">Apply delete</button>
-      <button class="sync-tombstone-btn sync-tombstone-reject" onclick="window.rejectPendingTombstone('${escapeAttr(p.id)}').then(() => window.openSettingsModal('data'))">Restore</button>
+      <button class="sync-tombstone-btn sync-tombstone-apply" data-sync-action="apply-tombstone" data-tomb-id="${escapeAttr(p.id)}">Apply delete</button>
+      <button class="sync-tombstone-btn sync-tombstone-reject" data-sync-action="reject-tombstone" data-tomb-id="${escapeAttr(p.id)}">Restore</button>
     </div>`).join('');
   return `
     <div class="sync-tombstone-banner">
@@ -61,7 +168,7 @@ export function renderSyncSection() {
         <div style="font-size:12px;color:var(--text-muted);margin-top:2px">E2E encrypted via Evolu CRDT</div>
       </div>
       <label class="chat-websearch-toggle-label" style="display:flex" aria-label="Toggle cross-device sync">
-        <input type="checkbox" ${enabled ? 'checked' : ''} onchange="toggleSync(this.checked)" style="display:none" ${blocker ? 'disabled' : ''}>
+        <input type="checkbox" ${enabled ? 'checked' : ''} data-sync-action="toggle-sync" style="display:none" ${blocker ? 'disabled' : ''}>
         <span class="chat-toggle-slider"></span>
       </label>
     </div>
@@ -75,8 +182,8 @@ export function renderSyncSection() {
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
           <label style="font-size:12px;font-weight:600;color:var(--text-secondary)">Your mnemonic</label>
           <div style="display:flex;gap:6px">
-            <button id="sync-mnemonic-toggle" class="import-btn import-btn-secondary" style="font-size:11px;padding:2px 10px" onclick="toggleMnemonicVisibility()" aria-label="Show mnemonic">Show</button>
-            <button class="import-btn import-btn-secondary" style="font-size:11px;padding:2px 10px" onclick="copyMnemonic()" aria-label="Copy mnemonic">Copy</button>
+            <button id="sync-mnemonic-toggle" class="import-btn import-btn-secondary" style="font-size:11px;padding:2px 10px" data-sync-action="toggle-mnemonic" aria-label="Show mnemonic">Show</button>
+            <button class="import-btn import-btn-secondary" style="font-size:11px;padding:2px 10px" data-sync-action="copy-mnemonic" aria-label="Copy mnemonic">Copy</button>
           </div>
         </div>
         <div id="sync-mnemonic" data-masked="true" style="font-family:var(--font-mono, monospace);font-size:11.5px;background:var(--bg-secondary);padding:10px 12px;border-radius:8px;border:1px solid var(--border);word-break:break-word;line-height:1.6;min-height:20px;user-select:none" aria-label="Mnemonic phrase">Loading...</div>
@@ -84,7 +191,7 @@ export function renderSyncSection() {
       </div>
 
       <div style="margin-bottom:16px">
-        <button class="import-btn import-btn-secondary" style="font-size:12px;padding:5px 14px;width:100%" onclick="openRestoreMnemonicDialog()">Restore from a different mnemonic…</button>
+        <button class="import-btn import-btn-secondary" style="font-size:12px;padding:5px 14px;width:100%" data-sync-action="open-restore-dialog">Restore from a different mnemonic…</button>
         <div style="font-size:11px;color:var(--text-muted);margin-top:4px;line-height:1.4">Replace this device's identity with a 24-word seed from another device. Your current data is overwritten.</div>
       </div>
 
@@ -94,7 +201,7 @@ export function renderSyncSection() {
           <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px">Relay server</label>
           <div style="display:flex;gap:8px">
             <input type="text" id="sync-relay-input" value="${escapeAttr(relay)}" style="flex:1;font-size:12px;border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:6px 10px;font-family:var(--font-mono, monospace)" placeholder="wss://...">
-            <button class="import-btn import-btn-secondary" style="font-size:12px;padding:4px 12px" onclick="saveSyncRelay()">Save</button>
+            <button class="import-btn import-btn-secondary" style="font-size:12px;padding:4px 12px" data-sync-action="save-relay">Save</button>
           </div>
         </div>
       </details>
@@ -167,11 +274,11 @@ export function showSyncSetupModal() {
     <h3 style="margin:0 0 6px;font-size:16px;color:var(--text-primary)">Set up sync</h3>
     <p style="font-size:13px;color:var(--text-muted);margin:0 0 20px;line-height:1.5">Your data is encrypted with a 24-word mnemonic. The relay server only sees ciphertext.</p>
     <div id="sync-setup-choices">
-      <button class="import-btn import-btn-primary" style="width:100%;padding:12px 16px;font-size:13px;margin-bottom:10px;text-align:left" onclick="syncSetupNew()">
+      <button class="import-btn import-btn-primary" style="width:100%;padding:12px 16px;font-size:13px;margin-bottom:10px;text-align:left" data-sync-setup-action="setup-new">
         <div style="font-weight:600">New setup</div>
         <div style="font-weight:400;opacity:0.8;margin-top:2px;font-size:12px">First time syncing — generate a new mnemonic</div>
       </button>
-      <button class="import-btn import-btn-secondary" style="width:100%;padding:12px 16px;font-size:13px;text-align:left" onclick="syncSetupRestore()">
+      <button class="import-btn import-btn-secondary" style="width:100%;padding:12px 16px;font-size:13px;text-align:left" data-sync-setup-action="setup-restore">
         <div style="font-weight:600">Join existing</div>
         <div style="font-weight:400;opacity:0.8;margin-top:2px;font-size:12px">I have a mnemonic from another device</div>
       </button>
@@ -180,16 +287,15 @@ export function showSyncSetupModal() {
     <div id="sync-setup-restore" style="display:none">
       <textarea id="sync-setup-restore-input" style="font-size:12px;width:100%;height:70px;resize:vertical;border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:10px 12px;font-family:var(--font-mono, monospace);box-sizing:border-box;margin-bottom:10px" placeholder="Paste your 24-word mnemonic here..."></textarea>
       <div style="display:flex;gap:8px">
-        <button class="import-btn import-btn-primary" style="flex:1;padding:8px 16px;font-size:13px" onclick="syncSetupDoRestore()">Restore</button>
-        <button class="import-btn import-btn-secondary" style="padding:8px 16px;font-size:13px" onclick="syncSetupBack()">Back</button>
+        <button class="import-btn import-btn-primary" style="flex:1;padding:8px 16px;font-size:13px" data-sync-setup-action="setup-do-restore">Restore</button>
+        <button class="import-btn import-btn-secondary" style="padding:8px 16px;font-size:13px" data-sync-setup-action="setup-back">Back</button>
       </div>
     </div>
     <div style="margin-top:16px;text-align:right">
-      <button class="confirm-btn confirm-btn-cancel" onclick="closeSyncSetup()">Cancel</button>
+      <button class="confirm-btn confirm-btn-cancel" data-sync-setup-action="setup-cancel">Cancel</button>
     </div>
   </div>`;
   overlay.classList.add('show');
-  overlay.onclick = (e) => { if (e.target === overlay) { const d = overlay.querySelector('.confirm-dialog'); if (d) { d.classList.add('modal-nudge'); d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true }); } } };
 }
 
 async function closeSyncSetup() {
@@ -244,24 +350,23 @@ async function syncSetupNew() {
         Write these 24 words down and store them offline. You will need them to sync another device. Anyone with this mnemonic can access your synced data.
       </div>
       <label style="display:flex;align-items:flex-start;gap:8px;cursor:pointer;font-size:12px;color:var(--text-primary);margin-bottom:14px">
-        <input type="checkbox" id="sync-setup-ack" style="margin-top:2px" onchange="document.getElementById('sync-setup-done-btn').disabled=!this.checked">
+        <input type="checkbox" id="sync-setup-ack" style="margin-top:2px" data-sync-setup-action="setup-ack">
         I have saved my mnemonic somewhere safe
       </label>
-      <button id="sync-setup-done-btn" class="import-btn import-btn-primary" style="width:100%;padding:8px 16px;font-size:13px;opacity:0.45;cursor:not-allowed" disabled onclick="syncSetupDone()">Done</button>
+      <button id="sync-setup-done-btn" class="import-btn import-btn-primary" style="width:100%;padding:8px 16px;font-size:13px;opacity:0.45;cursor:not-allowed" disabled data-sync-setup-action="setup-done">Done</button>
     `;
-    // Wire up disabled style toggle on checkbox
-    const ack = document.getElementById('sync-setup-ack');
-    const doneBtn = document.getElementById('sync-setup-done-btn');
-    if (ack && doneBtn) {
-      ack.onchange = () => {
-        doneBtn.disabled = !ack.checked;
-        doneBtn.style.opacity = ack.checked ? '1' : '0.45';
-        doneBtn.style.cursor = ack.checked ? 'pointer' : 'not-allowed';
-      };
-    }
+    updateSyncSetupAck();
   } finally {
     _syncSetupInProgress = false;
   }
+}
+
+function updateSyncSetupAck(ack = document.getElementById('sync-setup-ack')) {
+  const doneBtn = document.getElementById('sync-setup-done-btn');
+  if (!(ack instanceof HTMLInputElement) || !doneBtn) return;
+  doneBtn.disabled = !ack.checked;
+  doneBtn.style.opacity = ack.checked ? '1' : '0.45';
+  doneBtn.style.cursor = ack.checked ? 'pointer' : 'not-allowed';
 }
 
 function syncSetupDone() {
@@ -424,41 +529,41 @@ function openRestoreMnemonicDialog() {
   overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="sync-restore-title" style="max-width:480px">
     <h3 id="sync-restore-title" style="margin:0 0 6px;font-size:16px;color:var(--text-primary)">Restore from mnemonic</h3>
     <p style="font-size:13px;color:var(--text-muted);margin:0 0 14px;line-height:1.5">Paste your 24-word seed from another device. This replaces your current sync identity — anything synced under the old identity will no longer reach this device.</p>
-    <textarea id="sync-restore-dialog-input" autofocus aria-label="24-word mnemonic" style="font-size:12px;width:100%;height:90px;resize:vertical;border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:10px 12px;font-family:var(--font-mono, monospace);box-sizing:border-box" placeholder="word word word word word word word word word word word word word word word word word word word word word word word word"></textarea>
+    <textarea id="sync-restore-dialog-input" autofocus aria-label="24-word mnemonic" data-sync-action="restore-dialog-input" style="font-size:12px;width:100%;height:90px;resize:vertical;border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);padding:10px 12px;font-family:var(--font-mono, monospace);box-sizing:border-box" placeholder="word word word word word word word word word word word word word word word word word word word word word word word word"></textarea>
     <div id="sync-restore-dialog-msg" style="font-size:11px;color:var(--text-muted);margin-top:6px;min-height:14px"></div>
     <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">
-      <button class="confirm-btn confirm-btn-cancel" onclick="closeRestoreMnemonicDialog()">Cancel</button>
-      <button id="sync-restore-dialog-go" class="import-btn import-btn-primary" style="padding:8px 16px;font-size:13px" onclick="confirmRestoreMnemonic()">Restore &amp; reload</button>
+      <button class="confirm-btn confirm-btn-cancel" data-sync-action="close-restore-dialog">Cancel</button>
+      <button id="sync-restore-dialog-go" class="import-btn import-btn-primary" style="padding:8px 16px;font-size:13px" data-sync-action="confirm-restore">Restore &amp; reload</button>
     </div>
   </div>`;
   overlay.classList.add('show');
   // Live word count + button enable so the user gets immediate feedback as
   // they paste — much friendlier than only finding out on submit.
   const input = document.getElementById('sync-restore-dialog-input');
-  const msg = document.getElementById('sync-restore-dialog-msg');
-  const btn = document.getElementById('sync-restore-dialog-go');
   if (input) {
     input.focus();
-    const update = () => {
-      const raw = (input.value || '').trim();
-      if (!raw) {
-        if (msg) { msg.textContent = ''; msg.style.color = 'var(--text-muted)'; }
-        if (btn) btn.disabled = true;
-        return;
-      }
-      const words = raw.split(/\s+/);
-      if (words.length === 24) {
-        if (msg) { msg.textContent = '✓ 24 words detected'; msg.style.color = 'var(--green, #22c55e)'; }
-        if (btn) btn.disabled = false;
-      } else {
-        if (msg) { msg.textContent = `${words.length} word${words.length === 1 ? '' : 's'} so far — need exactly 24`; msg.style.color = '#fbbf24'; }
-        if (btn) btn.disabled = true;
-      }
-    };
-    input.addEventListener('input', update);
-    update();
+    updateRestoreMnemonicDialogState(input);
   }
-  overlay.onclick = (e) => { if (e.target === overlay) closeRestoreMnemonicDialog(); };
+}
+
+function updateRestoreMnemonicDialogState(input = document.getElementById('sync-restore-dialog-input')) {
+  const msg = document.getElementById('sync-restore-dialog-msg');
+  const btn = document.getElementById('sync-restore-dialog-go');
+  if (!input) return;
+  const raw = (input.value || '').trim();
+  if (!raw) {
+    if (msg) { msg.textContent = ''; msg.style.color = 'var(--text-muted)'; }
+    if (btn) btn.disabled = true;
+    return;
+  }
+  const words = raw.split(/\s+/);
+  if (words.length === 24) {
+    if (msg) { msg.textContent = '✓ 24 words detected'; msg.style.color = 'var(--green, #22c55e)'; }
+    if (btn) btn.disabled = false;
+  } else {
+    if (msg) { msg.textContent = `${words.length} word${words.length === 1 ? '' : 's'} so far — need exactly 24`; msg.style.color = '#fbbf24'; }
+    if (btn) btn.disabled = true;
+  }
 }
 
 function closeRestoreMnemonicDialog() {
@@ -513,7 +618,7 @@ export function renderMessengerSection() {
         <div class="settings-copy-desc">Let AI agents query your labs and context via MCP, Hermes Agent, or OpenClaw</div>
       </div>
       <label class="chat-websearch-toggle-label" style="display:flex" aria-label="Toggle Agent Access">
-        <input type="checkbox" ${enabled ? 'checked' : ''} onchange="toggleMessenger(this.checked)" style="display:none">
+        <input type="checkbox" ${enabled ? 'checked' : ''} data-sync-action="toggle-messenger" style="display:none">
         <span class="chat-toggle-slider"></span>
       </label>
     </div>
@@ -522,14 +627,14 @@ export function renderMessengerSection() {
         <div class="settings-token-head">
           <label style="font-size:12px;font-weight:600;color:var(--text-secondary)">Read-only token</label>
           <div class="settings-token-actions">
-            <button id="messenger-token-toggle" class="import-btn import-btn-secondary settings-mini-btn" onclick="toggleMessengerToken()" aria-label="Show token">Show</button>
-            <button class="import-btn import-btn-secondary settings-mini-btn" onclick="copyMessengerToken()" aria-label="Copy token">Copy</button>
+            <button id="messenger-token-toggle" class="import-btn import-btn-secondary settings-mini-btn" data-sync-action="toggle-messenger-token" aria-label="Show token">Show</button>
+            <button class="import-btn import-btn-secondary settings-mini-btn" data-sync-action="copy-messenger-token" aria-label="Copy token">Copy</button>
           </div>
         </div>
         <div id="messenger-token" class="settings-token-box" data-masked="true" aria-label="Agent Access token">${'\u2022'.repeat(64)}</div>
         <div class="settings-copy-desc" style="margin-top:6px">Use <a href="https://github.com/elkimek/getbased-agents/tree/main/packages/mcp" target="_blank" rel="noopener" style="color:var(--accent)">getbased-mcp</a> to connect <a href="https://github.com/hermes-agent/hermes-agent" target="_blank" rel="noopener" style="color:var(--accent)">Hermes Agent</a>, <a href="https://openclaw.ai" target="_blank" rel="noopener" style="color:var(--accent)">OpenClaw</a>, or any MCP-compatible agent. Paste this token into your agent's config.</div>
       </div>
-      <button class="import-btn import-btn-secondary settings-full-btn" onclick="regenerateMessengerToken()">Regenerate token</button>
+      <button class="import-btn import-btn-secondary settings-full-btn" data-sync-action="regenerate-messenger-token">Regenerate token</button>
       <div class="settings-divider">
         <div class="settings-action-row">
           <div class="settings-copy">
@@ -537,7 +642,7 @@ export function renderMessengerSection() {
             <div class="settings-copy-desc">Adds a pivoted daily-values matrix (HRV, RHR, sleep…) so agents can spot trends. ~100 / 400 / 1200 extra tokens for 7 / 30 / 90 days respectively (real-measured at 13 metrics); cached cleanly so the marginal cost per turn is small. Off by default — pick 7 days for cheap follow-ups, 30 for monthly reasoning, 90 for season-spanning analysis.</div>
           </div>
           <select id="agent-wearable-series-select"
-            onchange="window.setAgentWearableSeriesDays(this.value === 'off' ? 0 : Number(this.value)); window.pushContextToGateway && window.pushContextToGateway()"
+            data-sync-action="set-agent-wearable-series-days"
             aria-label="Wearable series window pushed to agent"
             class="settings-select">
             <option value="off"${(window.getAgentWearableSeriesDays?.() || 0) === 0 ? ' selected' : ''}>Off</option>
@@ -622,6 +727,8 @@ export function hydrateSettingsSyncPanel() {
   loadMnemonic();
   updateRelayStatus();
 }
+
+installSettingsSyncDelegates();
 
 Object.assign(window, {
   toggleSync,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 684,
+  "inlineEventAttributes": 663,
   "windowReferences": 1975,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1600

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -43,6 +43,9 @@ assert('Setup overlay backdrop nudges instead of closing',
   /target\.id === 'sync-setup-overlay'[\s\S]*nudgeSyncSetupDialog\(\)/.test(src));
 assert('Restore overlay backdrop closes restore dialog',
   /target\.id === 'sync-restore-overlay'[\s\S]*closeRestoreMnemonicDialog\(\)/.test(src));
+assert('Click delegate lets state controls reach change/input events',
+  /SETTINGS_SYNC_STATE_ACTIONS\.has\(action\)[\s\S]*return;[\s\S]*event\.preventDefault\(\);/.test(src)
+    && src.indexOf('SETTINGS_SYNC_STATE_ACTIONS.has(action)') < src.indexOf('event.preventDefault();'));
 
 [
   'apply-tombstone',

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Settings sync delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const src = fs.readFileSync(path.join(root, 'js/settings-sync-panel.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Settings Sync Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
+const directAssignmentRe = /\.(?:onclick|onchange|oninput)\s*=/;
+
+assert('settings-sync-panel.js has no inline event attributes',
+  !inlineHandlerRe.test(src));
+assert('settings-sync-panel.js avoids direct event property assignment',
+  !directAssignmentRe.test(src));
+assert('Settings sync delegates click events',
+  /document\.addEventListener\('click', handleSettingsSyncClick\)/.test(src));
+assert('Settings sync delegates change events',
+  /document\.addEventListener\('change', handleSettingsSyncChange\)/.test(src));
+assert('Settings sync delegates input events',
+  /document\.addEventListener\('input', handleSettingsSyncInput\)/.test(src));
+assert('Settings sync actions are scoped to panel and modal roots',
+  /closest\('#sync-section, #messenger-section, #sync-setup-overlay, #sync-restore-overlay'\)/.test(src));
+assert('Setup overlay backdrop nudges instead of closing',
+  /target\.id === 'sync-setup-overlay'[\s\S]*nudgeSyncSetupDialog\(\)/.test(src));
+assert('Restore overlay backdrop closes restore dialog',
+  /target\.id === 'sync-restore-overlay'[\s\S]*closeRestoreMnemonicDialog\(\)/.test(src));
+
+[
+  'apply-tombstone',
+  'reject-tombstone',
+  'toggle-sync',
+  'toggle-mnemonic',
+  'copy-mnemonic',
+  'open-restore-dialog',
+  'save-relay',
+  'restore-dialog-input',
+  'close-restore-dialog',
+  'confirm-restore',
+  'toggle-messenger',
+  'toggle-messenger-token',
+  'copy-messenger-token',
+  'regenerate-messenger-token',
+  'set-agent-wearable-series-days',
+].forEach(action => {
+  assert(`Sync action ${action} is rendered`, src.includes(`data-sync-action="${action}"`));
+});
+
+[
+  'setup-new',
+  'setup-restore',
+  'setup-do-restore',
+  'setup-back',
+  'setup-cancel',
+  'setup-ack',
+  'setup-done',
+].forEach(action => {
+  assert(`Sync setup action ${action} is rendered`, src.includes(`data-sync-setup-action="${action}"`));
+});
+
+assert('Delegated sync toggle calls toggleSync with checkbox state',
+  /action === 'toggle-sync'[\s\S]*toggleSync\(actionEl\.checked\)/.test(src));
+assert('Delegated setup acknowledgment updates Done state',
+  /action === 'setup-ack'[\s\S]*updateSyncSetupAck\(actionEl\)/.test(src));
+assert('Delegated Agent Access toggle calls toggleMessenger',
+  /action === 'toggle-messenger'[\s\S]*toggleMessenger\(actionEl\.checked\)/.test(src));
+assert('Delegated wearable-series select pushes context',
+  /action === 'set-agent-wearable-series-days'[\s\S]*setAgentWearableSeriesDays[\s\S]*pushContextToGateway/.test(src));
+assert('Existing window exports remain for external callers',
+  src.includes('Object.assign(window')
+    && src.includes('toggleSync,')
+    && src.includes('toggleMessenger,'));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-settings-toggles-dom.js
+++ b/tests/test-settings-toggles-dom.js
@@ -24,18 +24,23 @@ return (async function() {
     theme: localStorage.getItem('labcharts-theme'),
     sunset: localStorage.getItem('labcharts-sunset-mode'),
     crt: localStorage.getItem('labcharts-crt-effects'),
+    sync: localStorage.getItem('labcharts-sync-enabled'),
   };
+  let syncStateModule = null;
 
   try {
+    syncStateModule = await import('/js/sync-settings-state.js');
     window.endTour?.();
     document.getElementById('tour-overlay')?.remove();
     document.getElementById('tour-spotlight')?.remove();
     document.getElementById('tour-tooltip')?.remove();
+    document.getElementById('sync-setup-overlay')?.remove();
 
     localStorage.removeItem('labcharts-show-product-recs');
     localStorage.removeItem('labcharts-debug');
     localStorage.removeItem('labcharts-sunset-mode');
     localStorage.removeItem('labcharts-crt-effects');
+    syncStateModule.setSyncEnabled(false);
     window.setTheme?.('cyberterm');
 
     window.openSettingsModal('display');
@@ -51,6 +56,20 @@ return (async function() {
       localStorage.getItem('labcharts-show-product-recs') === 'false');
     assert('Verbose logging slider click persists on state',
       localStorage.getItem('labcharts-debug') === 'true');
+
+    window.openSettingsModal('data');
+    await delay(50);
+    const syncToggle = document.querySelector('#sync-section [data-sync-action="toggle-sync"] + .chat-toggle-slider');
+    syncToggle?.click();
+    await delay(50);
+    assert('Cross-device sync slider click opens setup modal',
+      document.getElementById('sync-setup-overlay')?.classList.contains('show'));
+    assert('Cross-device sync checkbox click reaches checked state',
+      document.querySelector('#sync-section [data-sync-action="toggle-sync"]')?.checked === true);
+    document.querySelector('#sync-setup-overlay [data-sync-setup-action="setup-cancel"]')?.click();
+    await delay(50);
+    assert('Cross-device sync setup cancel closes modal',
+      document.getElementById('sync-setup-overlay')?.classList.contains('show') !== true);
 
     window.openTweaksPanel();
     await delay(50);
@@ -96,6 +115,12 @@ return (async function() {
     else localStorage.setItem('labcharts-sunset-mode', saved.sunset);
     if (saved.crt === null) localStorage.removeItem('labcharts-crt-effects');
     else localStorage.setItem('labcharts-crt-effects', saved.crt);
+    if (syncStateModule) {
+      syncStateModule.setSyncEnabled(saved.sync === 'true');
+      if (saved.sync === null) localStorage.removeItem('labcharts-sync-enabled');
+    } else if (saved.sync === null) localStorage.removeItem('labcharts-sync-enabled');
+    else localStorage.setItem('labcharts-sync-enabled', saved.sync);
+    document.getElementById('sync-setup-overlay')?.remove();
     window.setTheme?.(localStorage.getItem('labcharts-theme') || 'dark');
     window.setSunsetMode?.(localStorage.getItem('labcharts-sunset-mode') === 'true');
     window.setCrtEffectsEnabled?.(localStorage.getItem('labcharts-crt-effects') === 'true');

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1521,8 +1521,9 @@ if (window._labState?.importedData?.wearableSummary) {
 const settingsSyncPanelV29 = await fetch('/js/settings-sync-panel.js').then(r => r.text());
 assert('Settings → Agent Access uses a <select> for the series window',
   /id="agent-wearable-series-select"/.test(settingsSyncPanelV29));
-assert('Settings select dispatches to setAgentWearableSeriesDays (not the boolean setter)',
-  /window\.setAgentWearableSeriesDays\(this\.value === 'off'/.test(settingsSyncPanelV29));
+assert('Settings select dispatches to setAgentWearableSeriesDays through delegated action',
+  /data-sync-action="set-agent-wearable-series-days"/.test(settingsSyncPanelV29) &&
+  /window\.setAgentWearableSeriesDays\?\.\(actionEl\.value === 'off'/.test(settingsSyncPanelV29));
 assert('Settings select offers Off / 7 / 30 / 90 options',
   /<option value="off"/.test(settingsSyncPanelV29) &&
   /<option value="7"/.test(settingsSyncPanelV29) &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.329';
+self.APP_VERSION = '1.8.330';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.330';
+self.APP_VERSION = '1.8.331';


### PR DESCRIPTION
## Summary
- Route Settings sync, setup, restore, tombstone, and Agent Access controls through scoped delegated listeners in `settings-sync-panel.js`
- Let checkbox/select/textarea actions pass through the click delegate so native `change`/`input` events still fire
- Remove inline handler attributes/direct event assignments from the sync panel while keeping existing window exports for compatibility
- Add source and live DOM regression coverage for delegated sync actions
- Update the quality baseline for inline handlers and bump `version.js`

## Validation
- `node --check js/settings-sync-panel.js`
- `node tests/test-settings-sync-delegated-actions.js`
- `npm run quality`
- `git diff --check`
- `npm test -- --run tests/_vitest-legacy.test.js`
- `./run-tests.sh`
- focused Puppeteer run of `tests/test-settings-toggles-dom.js`