### PR TITLE
[codex] Delegate chat empty state actions

### DIFF
--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -15,6 +15,14 @@ import {
   useChatPrompt,
 } from './chat-onboarding.js';
 
+const CHAT_EMPTY_STOP_PROPAGATION_ACTIONS = new Set([
+  'open-cycle-editor',
+  'open-supplements-editor',
+  'import-dna',
+  'import-mtdna',
+  'open-wearables-settings',
+]);
+
 function closestChatEmptyAction(event, selector = '[data-chat-empty-action]') {
   const target = event.target;
   if (!(target instanceof Element)) return null;
@@ -33,8 +41,7 @@ function handleChatEmptyClick(event) {
   const action = actionEl.dataset.chatEmptyAction;
   if (!action) return;
 
-  event.preventDefault();
-  event.stopPropagation();
+  if (CHAT_EMPTY_STOP_PROPAGATION_ACTIONS.has(action)) event.stopPropagation();
 
   if (action === 'set-profile-sex') {
     setChatProfileSex(actionEl.dataset.sex || '');
@@ -54,7 +61,7 @@ function handleChatEmptyClick(event) {
     closeChatPanel();
     window.triggerDNAFilePicker?.();
   } else if (action === 'import-mtdna') {
-    const input = document.getElementById('mtdna-onboard-input');
+    const input = event.currentTarget?.querySelector('#mtdna-onboard-input');
     closeChatPanel();
     input?.click();
   } else if (action === 'open-wearables-settings') {
@@ -198,8 +205,8 @@ function renderProfileOnboardingState(container, panel, { personality, currentP 
         <div class="chat-onboard-row">
           <span class="chat-onboard-label" id="chat-onboard-sex-label">Sex</span>
           <div class="chat-onboard-sex" role="group" aria-labelledby="chat-onboard-sex-label">
-            <button class="welcome-sex-btn${pSex === 'male' ? ' active' : ''}" data-chat-empty-action="set-profile-sex" data-sex="male">Male</button>
-            <button class="welcome-sex-btn${pSex === 'female' ? ' active' : ''}" data-chat-empty-action="set-profile-sex" data-sex="female">Female</button>
+            <button type="button" class="welcome-sex-btn${pSex === 'male' ? ' active' : ''}" data-chat-empty-action="set-profile-sex" data-sex="male">Male</button>
+            <button type="button" class="welcome-sex-btn${pSex === 'female' ? ' active' : ''}" data-chat-empty-action="set-profile-sex" data-sex="female">Female</button>
           </div>
         </div>
         <div class="chat-onboard-row">
@@ -237,7 +244,7 @@ function renderProfileOnboardingState(container, panel, { personality, currentP 
             <div class="chat-onboard-help">Latitude affects vitamin D, circadian rhythm, and seasonal health patterns.</div>
           </div>
         </details>
-        <button class="chat-onboard-next" id="chat-onboard-next" data-chat-empty-action="save-profile-advance" disabled>Continue →</button>
+        <button type="button" class="chat-onboard-next" id="chat-onboard-next" data-chat-empty-action="save-profile-advance" disabled>Continue →</button>
       </div>
     </div>`;
   _updateOnboardNextBtn();
@@ -251,7 +258,7 @@ function renderAIPausedState(container, panel, { personality, name }) {
     <div class="chat-msg chat-ai">
       <p>${escapeHTML(name)}, AI features are currently paused. Turn them back on to chat, get insights, and import PDFs with AI.</p>
       <div style="margin-top:12px">
-        <button class="import-btn import-btn-primary" data-chat-empty-action="resume-ai">Enable AI</button>
+        <button type="button" class="import-btn import-btn-primary" data-chat-empty-action="resume-ai">Enable AI</button>
       </div>
     </div>`;
   return true;
@@ -278,8 +285,8 @@ function renderOptionalContextState(container, panel, { personality }) {
       <div class="chat-onboard-task-grid">${cards}</div>
       <div class="chat-onboard-note">You can change all of this later from the dashboard, settings, or client profile.</div>
       <div class="chat-onboard-actions chat-onboard-actions-row">
-        <button class="chat-onboard-cta" data-chat-empty-action="skip-extras">Continue to import</button>
-        <button class="chat-prompt-btn" data-chat-empty-action="skip-extras">Skip optional setup</button>
+        <button type="button" class="chat-onboard-cta" data-chat-empty-action="skip-extras">Continue to import</button>
+        <button type="button" class="chat-prompt-btn" data-chat-empty-action="skip-extras">Skip optional setup</button>
       </div>
     </div>`;
   return true;
@@ -376,10 +383,10 @@ function renderFullContextNoDataState(container, panel, { personality, name }) {
       <p>${escapeHTML(name)}, you filled everything in — I have a really complete picture of your lifestyle now. ${hasAIProvider() ? 'Even without lab data, I can already help:' : 'Import your labs or connect an AI provider to get personalized insights.'}</p>
       <div class="chat-onboard-actions">
         ${hasAIProvider()
-          ? `<button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on my full profile, what blood tests should I get and why?">What tests should I get?</button>
-             <button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="What can you tell about my health from my lifestyle info?">Analyze my lifestyle</button>`
-          : `<button class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
-             <button class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
+          ? `<button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on my full profile, what blood tests should I get and why?">What tests should I get?</button>
+             <button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="What can you tell about my health from my lifestyle info?">Analyze my lifestyle</button>`
+          : `<button type="button" class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
+             <button type="button" class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
       </div>
     </div>`;
   return true;
@@ -397,10 +404,10 @@ function renderPartialContextNoDataState(container, panel, { personality, name }
       <div class="chat-onboard-progress"><div class="chat-onboard-progress-bar" style="width:${progressPct}%"></div></div>
       <p style="font-size:12px;color:var(--text-muted);margin:4px 0 0">The more context I have, the better I can interpret results and recommend what to test. Everything is optional.</p>
       <div class="chat-onboard-actions">
-        <button class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Continue context cards - ${remaining} area${remaining !== 1 ? 's' : ''} left</button>
+        <button type="button" class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Continue context cards - ${remaining} area${remaining !== 1 ? 's' : ''} left</button>
         ${providerConnected
-          ? `<button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on what you know about me so far, what blood tests should I get?">Skip ahead - recommend tests</button>`
-          : `<button class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
+          ? `<button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on what you know about me so far, what blood tests should I get?">Skip ahead - recommend tests</button>`
+          : `<button type="button" class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
       </div>
       ${renderChatContextCards()}
     </div>`;
@@ -418,12 +425,12 @@ function renderInitialNoDataState(container, panel, { personality, name }) {
       <p style="font-size:13px;margin:4px 0"><strong>No labs yet?</strong> Add useful context below${providerConnected ? ', then ask for recommended tests when you are ready.' : ', then connect AI when you want recommendations.'}</p>
       <div class="chat-onboard-actions">
         ${providerConnected
-          ? `<button class="chat-onboard-cta" data-chat-empty-action="start-lab-import">Import a lab file</button>
-             <button class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
-             <button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="I don't have any labs yet. Based on my profile, what blood tests should I get and why?">Just tell me what to test</button>`
-          : `<button class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
-             <button class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
-             <button class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI when ready</button>`}
+          ? `<button type="button" class="chat-onboard-cta" data-chat-empty-action="start-lab-import">Import a lab file</button>
+             <button type="button" class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
+             <button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="I don't have any labs yet. Based on my profile, what blood tests should I get and why?">Just tell me what to test</button>`
+          : `<button type="button" class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
+             <button type="button" class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
+             <button type="button" class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI when ready</button>`}
       </div>
       ${renderChatContextCards()}
     </div>`;
@@ -435,8 +442,8 @@ function renderDataContextNudgeState(container, { personality }) {
     <div class="chat-msg chat-ai">
       <p>I can see your lab results — nice! 👋 I can already analyze these, but if you fill in a few lifestyle cards I'll give you much more personalized insights.</p>
       <div class="chat-onboard-actions">
-        <button class="chat-prompt-btn" data-chat-empty-action="set-onboarding-focus" data-focus="cards">📋 Fill in lifestyle cards</button>
-        <button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="What are my most concerning results?">Analyze my results now</button>
+        <button type="button" class="chat-prompt-btn" data-chat-empty-action="set-onboarding-focus" data-focus="cards">📋 Fill in lifestyle cards</button>
+        <button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="What are my most concerning results?">Analyze my results now</button>
       </div>
     </div>`;
   return true;
@@ -455,7 +462,7 @@ function renderGeneralPromptState(container, { personality }) {
     <div class="chat-empty-icon">${personality.icon}</div>
     <div>${escapeHTML(personality.greeting)}</div>
     <div class="chat-prompts">
-      ${prompts.map(p => `<button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="${escapeAttr(p)}">${escapeHTML(p)}</button>`).join('\n      ')}
+      ${prompts.map(p => `<button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="${escapeAttr(p)}">${escapeHTML(p)}</button>`).join('\n      ')}
     </div>
   </div>`;
   return true;

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -5,12 +5,108 @@ import { hasAIProvider, isAIPaused } from './api.js';
 import { getActiveData } from './data.js';
 import { getProfileLocation, getProfiles } from './profile.js';
 import { renderProfileContextCards } from './context-cards.js';
-import { escapeHTML, hasCardContent } from './utils.js';
+import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
 import { getActivePersonality } from './chat-personalities.js';
 import {
   _countFilledCards, _renderOnboardCrumbs, _renderProviderQuiz,
-  _updateOnboardNextBtn, saveChatLocation,
+  _updateOnboardNextBtn, onboardHeightUnitChanged,
+  requestOnboardingLabImportProvider, saveChatLocation, saveChatProfile,
+  setChatProfileSex, skipOnboardingExtras, startOnboardingLabImport,
+  useChatPrompt,
 } from './chat-onboarding.js';
+
+function closestChatEmptyAction(event, selector = '[data-chat-empty-action]') {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const actionEl = target.closest(selector);
+  if (!actionEl) return null;
+  return event.currentTarget?.contains(actionEl) ? actionEl : null;
+}
+
+function closeChatPanel() {
+  window.closeChatPanel?.();
+}
+
+function handleChatEmptyClick(event) {
+  const actionEl = closestChatEmptyAction(event);
+  if (!actionEl) return;
+  const action = actionEl.dataset.chatEmptyAction;
+  if (!action) return;
+
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (action === 'set-profile-sex') {
+    setChatProfileSex(actionEl.dataset.sex || '');
+  } else if (action === 'save-profile-advance') {
+    saveChatProfile(true);
+  } else if (action === 'resume-ai') {
+    window._resumeAI?.();
+  } else if (action === 'skip-extras') {
+    skipOnboardingExtras();
+  } else if (action === 'open-cycle-editor') {
+    closeChatPanel();
+    window.openMenstrualCycleEditor?.();
+  } else if (action === 'open-supplements-editor') {
+    closeChatPanel();
+    window.openSupplementsEditor?.();
+  } else if (action === 'import-dna') {
+    closeChatPanel();
+    window.triggerDNAFilePicker?.();
+  } else if (action === 'import-mtdna') {
+    const input = document.getElementById('mtdna-onboard-input');
+    closeChatPanel();
+    input?.click();
+  } else if (action === 'open-wearables-settings') {
+    closeChatPanel();
+    window.openSettingsModal?.('wearables');
+  } else if (action === 'use-prompt') {
+    useChatPrompt(actionEl.dataset.prompt || '');
+  } else if (action === 'request-lab-import-provider') {
+    requestOnboardingLabImportProvider();
+  } else if (action === 'open-provider-quiz') {
+    window.openChatProviderQuiz?.();
+  } else if (action === 'scroll-context-cards') {
+    event.currentTarget?.querySelector('.chat-context-cards')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } else if (action === 'start-lab-import') {
+    startOnboardingLabImport();
+  } else if (action === 'set-onboarding-focus') {
+    window.setOnboardingFocus?.(actionEl.dataset.focus || '');
+  }
+}
+
+function handleChatEmptyChange(event) {
+  const actionEl = closestChatEmptyAction(event);
+  if (!actionEl) return;
+  const action = actionEl.dataset.chatEmptyAction;
+  if (!action) return;
+
+  if (action === 'save-profile') {
+    saveChatProfile();
+  } else if (action === 'height-unit-changed') {
+    onboardHeightUnitChanged();
+  } else if (action === 'import-mtdna-file' && actionEl instanceof HTMLInputElement) {
+    const file = actionEl.files?.[0];
+    if (file) {
+      window.handleMtDNAFile?.(file);
+      actionEl.value = '';
+    }
+  }
+}
+
+function handleChatEmptyInput(event) {
+  const actionEl = closestChatEmptyAction(event);
+  if (!actionEl) return;
+  if (actionEl.dataset.chatEmptyAction === 'save-location') saveChatLocation();
+}
+
+function installChatEmptyStateDelegates(container) {
+  if (!container || container.dataset.chatEmptyDelegates === '1') return;
+  container.dataset.chatEmptyDelegates = '1';
+  container.addEventListener('click', handleChatEmptyClick);
+  container.addEventListener('change', handleChatEmptyChange);
+  container.addEventListener('input', handleChatEmptyInput);
+}
 
 export function _getNoDataPrompts() {
   const data = getActiveData();
@@ -38,6 +134,7 @@ export function _getNoDataPrompts() {
 }
 
 export function renderEmptyChatState(container, panel) {
+  installChatEmptyStateDelegates(container);
   const context = getEmptyChatContext();
 
   if (!context.hasProfile) return renderProfileOnboardingState(container, panel, context);
@@ -96,18 +193,18 @@ function renderProfileOnboardingState(container, panel, { personality, currentP 
       <div class="chat-onboard-form">
         <div class="chat-onboard-row">
           <label class="chat-onboard-label" for="chat-onboard-name">Name</label>
-          <input type="text" class="chat-onboard-input" id="chat-onboard-name" placeholder="your name" value="${escapeHTML(pName)}" onchange="window.saveChatProfile()">
+          <input type="text" class="chat-onboard-input" id="chat-onboard-name" placeholder="your name" value="${escapeAttr(pName)}" data-chat-empty-action="save-profile">
         </div>
         <div class="chat-onboard-row">
           <span class="chat-onboard-label" id="chat-onboard-sex-label">Sex</span>
           <div class="chat-onboard-sex" role="group" aria-labelledby="chat-onboard-sex-label">
-            <button class="welcome-sex-btn${pSex === 'male' ? ' active' : ''}" onclick="window.setChatProfileSex('male')">Male</button>
-            <button class="welcome-sex-btn${pSex === 'female' ? ' active' : ''}" onclick="window.setChatProfileSex('female')">Female</button>
+            <button class="welcome-sex-btn${pSex === 'male' ? ' active' : ''}" data-chat-empty-action="set-profile-sex" data-sex="male">Male</button>
+            <button class="welcome-sex-btn${pSex === 'female' ? ' active' : ''}" data-chat-empty-action="set-profile-sex" data-sex="female">Female</button>
           </div>
         </div>
         <div class="chat-onboard-row">
           <label class="chat-onboard-label" for="chat-onboard-dob">Born</label>
-          <input type="date" class="chat-onboard-input" id="chat-onboard-dob" value="${escapeHTML(pDob)}" min="1900-01-01" max="${new Date().toISOString().slice(0, 10)}">
+          <input type="date" class="chat-onboard-input" id="chat-onboard-dob" value="${escapeAttr(pDob)}" min="1900-01-01" max="${new Date().toISOString().slice(0, 10)}">
         </div>
         <details class="chat-onboard-more">
           <summary>Optional body and location context</summary>
@@ -116,7 +213,7 @@ function renderProfileOnboardingState(container, panel, { personality, currentP 
               <label class="chat-onboard-label" for="chat-onboard-height">Height</label>
               <div class="chat-onboard-input-with-unit">
                 <input type="number" class="chat-onboard-input" id="chat-onboard-height" placeholder="cm" step="0.1" value="${pHeight || ''}">
-                <select class="chat-onboard-input chat-onboard-unit-select" id="chat-onboard-height-unit" aria-label="Height unit" onchange="window.onboardHeightUnitChanged()">
+                <select class="chat-onboard-input chat-onboard-unit-select" id="chat-onboard-height-unit" aria-label="Height unit" data-chat-empty-action="height-unit-changed">
                   <option value="cm"${pHeightUnit !== 'in' ? ' selected' : ''}>cm</option>
                   <option value="in"${pHeightUnit === 'in' ? ' selected' : ''}>in</option>
                 </select>
@@ -134,13 +231,13 @@ function renderProfileOnboardingState(container, panel, { personality, currentP 
             </div>
             <div class="chat-onboard-row">
               <label class="chat-onboard-label" for="chat-onboard-country">Location</label>
-              <input type="text" class="chat-onboard-input" id="chat-onboard-country" placeholder="e.g. Germany" value="${escapeHTML(pLoc.country || '')}" oninput="window.saveChatLocation()">
+              <input type="text" class="chat-onboard-input" id="chat-onboard-country" placeholder="e.g. Germany" value="${escapeAttr(pLoc.country || '')}" data-chat-empty-action="save-location">
             </div>
             <div id="chat-onboard-lat" class="chat-onboard-lat"></div>
             <div class="chat-onboard-help">Latitude affects vitamin D, circadian rhythm, and seasonal health patterns.</div>
           </div>
         </details>
-        <button class="chat-onboard-next" id="chat-onboard-next" onclick="window.saveChatProfile(true)" disabled>Continue →</button>
+        <button class="chat-onboard-next" id="chat-onboard-next" data-chat-empty-action="save-profile-advance" disabled>Continue →</button>
       </div>
     </div>`;
   _updateOnboardNextBtn();
@@ -154,7 +251,7 @@ function renderAIPausedState(container, panel, { personality, name }) {
     <div class="chat-msg chat-ai">
       <p>${escapeHTML(name)}, AI features are currently paused. Turn them back on to chat, get insights, and import PDFs with AI.</p>
       <div style="margin-top:12px">
-        <button class="import-btn import-btn-primary" onclick="window._resumeAI()">Enable AI</button>
+        <button class="import-btn import-btn-primary" data-chat-empty-action="resume-ai">Enable AI</button>
       </div>
     </div>`;
   return true;
@@ -181,8 +278,8 @@ function renderOptionalContextState(container, panel, { personality }) {
       <div class="chat-onboard-task-grid">${cards}</div>
       <div class="chat-onboard-note">You can change all of this later from the dashboard, settings, or client profile.</div>
       <div class="chat-onboard-actions chat-onboard-actions-row">
-        <button class="chat-onboard-cta" onclick="window.skipOnboardingExtras()">Continue to import</button>
-        <button class="chat-prompt-btn" onclick="window.skipOnboardingExtras()">Skip optional setup</button>
+        <button class="chat-onboard-cta" data-chat-empty-action="skip-extras">Continue to import</button>
+        <button class="chat-prompt-btn" data-chat-empty-action="skip-extras">Skip optional setup</button>
       </div>
     </div>`;
   return true;
@@ -229,7 +326,7 @@ function renderCycleTask(hasCycle) {
       <strong>Cycle context</strong>
       <small>${hasCycle ? 'Cycle tracking is already set.' : 'Helps interpret hormones, iron, and inflammation.'}</small>
     </span>
-    <button type="button" class="chat-onboard-mini-btn" onclick="event.stopPropagation();closeChatPanel();window.openMenstrualCycleEditor?.()">${hasCycle ? 'Edit' : 'Set up'}</button>
+    <button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="open-cycle-editor">${hasCycle ? 'Edit' : 'Set up'}</button>
   </article>`;
 }
 
@@ -240,7 +337,7 @@ function renderSupplementsTask(supps, suppSummary) {
       <strong>Supplements &amp; meds</strong>
       <small>${escapeHTML(suppSummary)}</small>
     </span>
-    <button type="button" class="chat-onboard-mini-btn" onclick="event.stopPropagation();closeChatPanel();window.openSupplementsEditor?.()">${supps.length ? 'Edit' : 'Add'}</button>
+    <button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="open-supplements-editor">${supps.length ? 'Edit' : 'Add'}</button>
   </article>`;
 }
 
@@ -252,10 +349,10 @@ function renderGeneticsTask(hasSnps, hasMtdna, dnaSummary) {
       <small>${escapeHTML(dnaSummary)}</small>
     </span>
     <span class="chat-onboard-mini-actions">
-      ${!hasSnps ? `<button type="button" class="chat-onboard-mini-btn" onclick="event.stopPropagation();closeChatPanel();window.triggerDNAFilePicker?.()">Import</button>` : ''}
-      ${!hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" onclick="event.stopPropagation();const input=document.getElementById('mtdna-onboard-input');closeChatPanel();input?.click()">mtDNA</button>
-      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" onchange="if(this.files[0]){window.handleMtDNAFile?.(this.files[0]);this.value=''}">` : ''}
-      ${hasSnps && hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" onclick="event.stopPropagation();closeChatPanel();window.triggerDNAFilePicker?.()">Re-import</button>` : ''}
+      ${!hasSnps ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Import</button>` : ''}
+      ${!hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-mtdna">mtDNA</button>
+      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" data-chat-empty-action="import-mtdna-file">` : ''}
+      ${hasSnps && hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Re-import</button>` : ''}
     </span>
   </article>`;
 }
@@ -267,7 +364,7 @@ function renderWearableTask() {
       <strong>Wearables</strong>
       <small>Optional HRV, sleep, recovery, and body composition trends.</small>
     </span>
-    <button type="button" class="chat-onboard-mini-btn" onclick="event.stopPropagation();closeChatPanel();window.openSettingsModal('wearables')">Connect</button>
+    <button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="open-wearables-settings">Connect</button>
   </article>`;
 }
 
@@ -279,10 +376,10 @@ function renderFullContextNoDataState(container, panel, { personality, name }) {
       <p>${escapeHTML(name)}, you filled everything in — I have a really complete picture of your lifestyle now. ${hasAIProvider() ? 'Even without lab data, I can already help:' : 'Import your labs or connect an AI provider to get personalized insights.'}</p>
       <div class="chat-onboard-actions">
         ${hasAIProvider()
-          ? `<button class="chat-prompt-btn" onclick="useChatPrompt('Based on my full profile, what blood tests should I get and why?')">What tests should I get?</button>
-             <button class="chat-prompt-btn" onclick="useChatPrompt('What can you tell about my health from my lifestyle info?')">Analyze my lifestyle</button>`
-          : `<button class="chat-onboard-cta" onclick="window.requestOnboardingLabImportProvider()">Connect AI to import labs</button>
-             <button class="chat-prompt-btn" onclick="window.openChatProviderQuiz()">Connect AI for recommendations</button>`}
+          ? `<button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on my full profile, what blood tests should I get and why?">What tests should I get?</button>
+             <button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="What can you tell about my health from my lifestyle info?">Analyze my lifestyle</button>`
+          : `<button class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
+             <button class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
       </div>
     </div>`;
   return true;
@@ -300,10 +397,10 @@ function renderPartialContextNoDataState(container, panel, { personality, name }
       <div class="chat-onboard-progress"><div class="chat-onboard-progress-bar" style="width:${progressPct}%"></div></div>
       <p style="font-size:12px;color:var(--text-muted);margin:4px 0 0">The more context I have, the better I can interpret results and recommend what to test. Everything is optional.</p>
       <div class="chat-onboard-actions">
-        <button class="chat-onboard-cta" onclick="document.querySelector('.chat-context-cards')?.scrollIntoView({behavior:'smooth',block:'start'})">Continue context cards - ${remaining} area${remaining !== 1 ? 's' : ''} left</button>
+        <button class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Continue context cards - ${remaining} area${remaining !== 1 ? 's' : ''} left</button>
         ${providerConnected
-          ? `<button class="chat-prompt-btn" onclick="useChatPrompt('Based on what you know about me so far, what blood tests should I get?')">Skip ahead - recommend tests</button>`
-          : `<button class="chat-prompt-btn" onclick="window.openChatProviderQuiz()">Connect AI for recommendations</button>`}
+          ? `<button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on what you know about me so far, what blood tests should I get?">Skip ahead - recommend tests</button>`
+          : `<button class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
       </div>
       ${renderChatContextCards()}
     </div>`;
@@ -321,12 +418,12 @@ function renderInitialNoDataState(container, panel, { personality, name }) {
       <p style="font-size:13px;margin:4px 0"><strong>No labs yet?</strong> Add useful context below${providerConnected ? ', then ask for recommended tests when you are ready.' : ', then connect AI when you want recommendations.'}</p>
       <div class="chat-onboard-actions">
         ${providerConnected
-          ? `<button class="chat-onboard-cta" onclick="window.startOnboardingLabImport()">Import a lab file</button>
-             <button class="chat-onboard-cta" onclick="document.querySelector('.chat-context-cards')?.scrollIntoView({behavior:'smooth',block:'start'})">Add context below</button>
-             <button class="chat-prompt-btn" onclick="useChatPrompt('I don\\'t have any labs yet. Based on my profile, what blood tests should I get and why?')">Just tell me what to test</button>`
-          : `<button class="chat-onboard-cta" onclick="window.requestOnboardingLabImportProvider()">Connect AI to import labs</button>
-             <button class="chat-onboard-cta" onclick="document.querySelector('.chat-context-cards')?.scrollIntoView({behavior:'smooth',block:'start'})">Add context below</button>
-             <button class="chat-prompt-btn" onclick="window.openChatProviderQuiz()">Connect AI when ready</button>`}
+          ? `<button class="chat-onboard-cta" data-chat-empty-action="start-lab-import">Import a lab file</button>
+             <button class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
+             <button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="I don't have any labs yet. Based on my profile, what blood tests should I get and why?">Just tell me what to test</button>`
+          : `<button class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
+             <button class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
+             <button class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI when ready</button>`}
       </div>
       ${renderChatContextCards()}
     </div>`;
@@ -338,8 +435,8 @@ function renderDataContextNudgeState(container, { personality }) {
     <div class="chat-msg chat-ai">
       <p>I can see your lab results — nice! 👋 I can already analyze these, but if you fill in a few lifestyle cards I'll give you much more personalized insights.</p>
       <div class="chat-onboard-actions">
-        <button class="chat-prompt-btn" onclick="window.setOnboardingFocus('cards')">📋 Fill in lifestyle cards</button>
-        <button class="chat-prompt-btn" onclick="useChatPrompt('What are my most concerning results?')">Analyze my results now</button>
+        <button class="chat-prompt-btn" data-chat-empty-action="set-onboarding-focus" data-focus="cards">📋 Fill in lifestyle cards</button>
+        <button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="What are my most concerning results?">Analyze my results now</button>
       </div>
     </div>`;
   return true;
@@ -358,7 +455,7 @@ function renderGeneralPromptState(container, { personality }) {
     <div class="chat-empty-icon">${personality.icon}</div>
     <div>${escapeHTML(personality.greeting)}</div>
     <div class="chat-prompts">
-      ${prompts.map(p => `<button class="chat-prompt-btn" onclick="useChatPrompt('${escapeHTML(p)}')">${escapeHTML(p)}</button>`).join('\n      ')}
+      ${prompts.map(p => `<button class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="${escapeAttr(p)}">${escapeHTML(p)}</button>`).join('\n      ')}
     </div>
   </div>`;
   return true;

--- a/run-tests.js
+++ b/run-tests.js
@@ -76,6 +76,7 @@ const TEST_FILES = [
   // click) lives in test-dashboard-data-protection-dom.js below.
   'tests/test-dashboard-data-protection-dom.js',
   'tests/test-chat-panel-ux.js',
+  'tests/test-chat-empty-state-dom.js',
   // test-custom-api.js source-inspection + behavioral ported to Vitest
   // (batch 24). DOM-runtime sections (13/14 — Settings modal rendering,
   // Custom panel form fields, connected-state model dropdown) live in

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
-  "inlineEventAttributes": 663,
-  "windowReferences": 1975,
+  "inlineEventAttributes": 631,
+  "windowReferences": 1960,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1600
 }

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -174,6 +174,7 @@ const LEGACY_TESTS = [
   './test-client-list-delegated-actions.js',
   './test-provider-wallet-delegated-actions.js',
   './test-provider-panel-delegated-actions.js',
+  './test-chat-empty-state-delegated-actions.js',
   './test-quality-guardrails.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',

--- a/tests/test-chat-empty-state-delegated-actions.js
+++ b/tests/test-chat-empty-state-delegated-actions.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Chat empty-state delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const src = fs.readFileSync(path.join(root, 'js/chat-empty-state.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Chat Empty State Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
+const directAssignmentRe = /\.(?:onclick|onchange|oninput)\s*=/;
+
+assert('chat-empty-state.js has no inline event attributes',
+  !inlineHandlerRe.test(src));
+assert('chat-empty-state.js avoids direct event property assignment',
+  !directAssignmentRe.test(src));
+assert('Chat empty state installs click/change/input delegates on the container',
+  /container\.addEventListener\('click', handleChatEmptyClick\)/.test(src)
+    && /container\.addEventListener\('change', handleChatEmptyChange\)/.test(src)
+    && /container\.addEventListener\('input', handleChatEmptyInput\)/.test(src));
+assert('renderEmptyChatState installs delegates before rendering branches',
+  /export function renderEmptyChatState\(container, panel\) \{\s*installChatEmptyStateDelegates\(container\);/.test(src));
+assert('Chat empty actions are scoped to the current container',
+  /event\.currentTarget\?\.contains\(actionEl\)/.test(src));
+
+[
+  'save-profile',
+  'set-profile-sex',
+  'height-unit-changed',
+  'save-location',
+  'save-profile-advance',
+  'resume-ai',
+  'skip-extras',
+  'open-cycle-editor',
+  'open-supplements-editor',
+  'import-dna',
+  'import-mtdna',
+  'import-mtdna-file',
+  'open-wearables-settings',
+  'use-prompt',
+  'request-lab-import-provider',
+  'open-provider-quiz',
+  'scroll-context-cards',
+  'start-lab-import',
+  'set-onboarding-focus',
+].forEach(action => {
+  assert(`Chat empty action ${action} is rendered or handled`,
+    src.includes(`data-chat-empty-action="${action}"`) || src.includes(`action === '${action}'`));
+});
+
+assert('Profile sex action passes sex through data attribute',
+  /data-chat-empty-action="set-profile-sex" data-sex="male"/.test(src)
+    && /setChatProfileSex\(actionEl\.dataset\.sex/.test(src));
+assert('Prompt buttons store prompt text in data attributes',
+  /data-chat-empty-action="use-prompt" data-prompt=/.test(src)
+    && /useChatPrompt\(actionEl\.dataset\.prompt/.test(src));
+assert('mtDNA file import clears the file input after handoff',
+  /action === 'import-mtdna-file'[\s\S]*handleMtDNAFile[\s\S]*actionEl\.value = '';/.test(src));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-chat-empty-state-delegated-actions.js
+++ b/tests/test-chat-empty-state-delegated-actions.js
@@ -39,6 +39,15 @@ assert('renderEmptyChatState installs delegates before rendering branches',
   /export function renderEmptyChatState\(container, panel\) \{\s*installChatEmptyStateDelegates\(container\);/.test(src));
 assert('Chat empty actions are scoped to the current container',
   /event\.currentTarget\?\.contains\(actionEl\)/.test(src));
+assert('Chat empty click delegate does not blanket-prevent defaults',
+  !/event\.preventDefault\(\)/.test(src));
+assert('Chat empty click delegate only stops propagation for scoped action set',
+  /CHAT_EMPTY_STOP_PROPAGATION_ACTIONS\.has\(action\)[\s\S]*event\.stopPropagation\(\)/.test(src));
+assert('mtDNA import input lookup is scoped to the current container',
+  /event\.currentTarget\?\.querySelector\('#mtdna-onboard-input'\)/.test(src)
+    && !/document\.getElementById\('mtdna-onboard-input'\)/.test(src));
+assert('Rendered chat empty-state buttons declare button type',
+  !/<button(?! type=)/.test(src));
 
 [
   'save-profile',

--- a/tests/test-chat-empty-state-dom.js
+++ b/tests/test-chat-empty-state-dom.js
@@ -1,0 +1,145 @@
+// test-chat-empty-state-dom.js - live DOM coverage for chat empty-state delegates.
+//
+// Run: fetch('tests/test-chat-empty-state-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Chat Empty State DOM ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const [{ renderEmptyChatState }, { state }, { getProfileLocation }] = await Promise.all([
+    import('/js/chat-empty-state.js'),
+    import('/js/state.js'),
+    import('/js/profile.js'),
+  ]);
+
+  const saved = {
+    currentProfile: state.currentProfile,
+    profiles: state.profiles,
+    profileSex: state.profileSex,
+    profileDob: state.profileDob,
+    importedData: state.importedData,
+    profilesStorage: localStorage.getItem('labcharts-profiles'),
+  };
+  const savedFns = {
+    closeChatPanel: window.closeChatPanel,
+    openMenstrualCycleEditor: window.openMenstrualCycleEditor,
+    openSupplementsEditor: window.openSupplementsEditor,
+    triggerDNAFilePicker: window.triggerDNAFilePicker,
+    openSettingsModal: window.openSettingsModal,
+  };
+  const calls = [];
+  const container = document.createElement('div');
+  const panel = document.createElement('div');
+  const chatMessages = document.getElementById('chat-messages');
+  const savedChatMessagesHTML = chatMessages?.innerHTML;
+
+  try {
+    // Previous chat DOM tests can leave onboarding controls with the same
+    // document-level ids that chat-onboarding helpers query. Clear that host
+    // so this fixture is the only onboarding form in the document.
+    if (chatMessages) chatMessages.innerHTML = '';
+
+    window.closeChatPanel = () => calls.push('close-chat');
+    window.openMenstrualCycleEditor = () => calls.push('open-cycle');
+    window.openSupplementsEditor = () => calls.push('open-supplements');
+    window.triggerDNAFilePicker = () => calls.push('import-dna');
+    window.openSettingsModal = tab => calls.push(`open-settings:${tab}`);
+
+    state.currentProfile = 'chat-empty-test';
+    state.profiles = [{ id: 'chat-empty-test', name: 'Default', tags: [], notes: '', status: 'active' }];
+    state.profileSex = null;
+    state.profileDob = null;
+    state.importedData = {
+      entries: [],
+      notes: [],
+      supplements: [],
+      healthGoals: [],
+      diagnoses: null,
+      diet: null,
+      exercise: null,
+      sleepRest: null,
+      lightCircadian: null,
+      stress: null,
+      loveLife: null,
+      environment: null,
+      interpretiveLens: '',
+      contextNotes: '',
+      menstrualCycle: null,
+      emfAssessment: null,
+      genetics: null,
+      customMarkers: {},
+      markerNotes: {},
+      markerValueNotes: {},
+      changeHistory: [],
+    };
+
+    document.body.appendChild(panel);
+    panel.appendChild(container);
+
+    renderEmptyChatState(container, panel);
+    assert('renderEmptyChatState installs container delegates',
+      container.dataset.chatEmptyDelegates === '1');
+    assert('rendered profile onboarding has no inline event attributes',
+      !container.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onkeyup],[onsubmit]'));
+    assert('profile onboarding marks panel active',
+      panel.classList.contains('chat-onboarding-active'));
+
+    const nameInput = container.querySelector('#chat-onboard-name');
+    nameInput.value = 'Ada';
+    nameInput.dispatchEvent(new Event('change', { bubbles: true }));
+    assert('Name change delegates to saveChatProfile',
+      state.profiles[0]?.name === 'Ada');
+
+    container.querySelector('[data-chat-empty-action="set-profile-sex"][data-sex="female"]')?.click();
+    assert('Sex click delegates to setChatProfileSex',
+      state.profileSex === 'female'
+        && container.querySelector('[data-sex="female"]')?.classList.contains('active'));
+
+    const heightInput = container.querySelector('#chat-onboard-height');
+    const heightUnit = container.querySelector('#chat-onboard-height-unit');
+    heightInput.value = '180';
+    heightUnit.value = 'in';
+    heightUnit.dispatchEvent(new Event('change', { bubbles: true }));
+    assert('Height unit change delegates to onboardHeightUnitChanged',
+      heightInput.value === '70.9');
+
+    const countryInput = container.querySelector('#chat-onboard-country');
+    countryInput.value = 'Germany';
+    countryInput.dispatchEvent(new Event('input', { bubbles: true }));
+    assert('Country input delegates to saveChatLocation',
+      getProfileLocation('chat-empty-test').country === 'Germany');
+
+    renderEmptyChatState(container, panel);
+    container.querySelector('[data-chat-empty-action="open-cycle-editor"]')?.click();
+    container.querySelector('[data-chat-empty-action="open-supplements-editor"]')?.click();
+    container.querySelector('[data-chat-empty-action="import-dna"]')?.click();
+    container.querySelector('[data-chat-empty-action="open-wearables-settings"]')?.click();
+    assert('Optional task buttons delegate through scoped actions',
+      calls.includes('close-chat')
+        && calls.includes('open-cycle')
+        && calls.includes('open-supplements')
+        && calls.includes('import-dna')
+        && calls.includes('open-settings:wearables'));
+  } finally {
+    state.currentProfile = saved.currentProfile;
+    state.profiles = saved.profiles;
+    state.profileSex = saved.profileSex;
+    state.profileDob = saved.profileDob;
+    state.importedData = saved.importedData;
+    if (saved.profilesStorage === null) localStorage.removeItem('labcharts-profiles');
+    else localStorage.setItem('labcharts-profiles', saved.profilesStorage);
+    Object.assign(window, savedFns);
+    container.remove();
+    panel.remove();
+    if (chatMessages && savedChatMessagesHTML != null) chatMessages.innerHTML = savedChatMessagesHTML;
+  }
+
+  console.log(`\n%c Chat Empty State DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-chat-empty-state-dom'] = { pass, fail };
+})();

--- a/tests/test-chat-empty-state-dom.js
+++ b/tests/test-chat-empty-state-dom.js
@@ -33,10 +33,14 @@ return (async function() {
     openSettingsModal: window.openSettingsModal,
   };
   const calls = [];
+  const inputClicks = [];
   const container = document.createElement('div');
   const panel = document.createElement('div');
+  const strayMtDnaInput = document.createElement('input');
+  let bubbledClicks = 0;
   const chatMessages = document.getElementById('chat-messages');
   const savedChatMessagesHTML = chatMessages?.innerHTML;
+  const savedInputClick = HTMLInputElement.prototype.click;
 
   try {
     // Previous chat DOM tests can leave onboarding controls with the same
@@ -49,6 +53,9 @@ return (async function() {
     window.openSupplementsEditor = () => calls.push('open-supplements');
     window.triggerDNAFilePicker = () => calls.push('import-dna');
     window.openSettingsModal = tab => calls.push(`open-settings:${tab}`);
+    HTMLInputElement.prototype.click = function() {
+      inputClicks.push(this === strayMtDnaInput ? 'stray' : panel.contains(this) ? 'scoped' : 'other');
+    };
 
     state.currentProfile = 'chat-empty-test';
     state.profiles = [{ id: 'chat-empty-test', name: 'Default', tags: [], notes: '', status: 'active' }];
@@ -78,8 +85,12 @@ return (async function() {
       changeHistory: [],
     };
 
+    strayMtDnaInput.type = 'file';
+    strayMtDnaInput.id = 'mtdna-onboard-input';
+    document.body.appendChild(strayMtDnaInput);
     document.body.appendChild(panel);
     panel.appendChild(container);
+    panel.addEventListener('click', () => { bubbledClicks++; });
 
     renderEmptyChatState(container, panel);
     assert('renderEmptyChatState installs container delegates',
@@ -99,6 +110,8 @@ return (async function() {
     assert('Sex click delegates to setChatProfileSex',
       state.profileSex === 'female'
         && container.querySelector('[data-sex="female"]')?.classList.contains('active'));
+    assert('Non-panel-closing actions keep normal click bubbling',
+      bubbledClicks > 0);
 
     const heightInput = container.querySelector('#chat-onboard-height');
     const heightUnit = container.querySelector('#chat-onboard-height-unit');
@@ -115,9 +128,11 @@ return (async function() {
       getProfileLocation('chat-empty-test').country === 'Germany');
 
     renderEmptyChatState(container, panel);
+    const bubbledBeforeOptionalActions = bubbledClicks;
     container.querySelector('[data-chat-empty-action="open-cycle-editor"]')?.click();
     container.querySelector('[data-chat-empty-action="open-supplements-editor"]')?.click();
     container.querySelector('[data-chat-empty-action="import-dna"]')?.click();
+    container.querySelector('[data-chat-empty-action="import-mtdna"]')?.click();
     container.querySelector('[data-chat-empty-action="open-wearables-settings"]')?.click();
     assert('Optional task buttons delegate through scoped actions',
       calls.includes('close-chat')
@@ -125,6 +140,10 @@ return (async function() {
         && calls.includes('open-supplements')
         && calls.includes('import-dna')
         && calls.includes('open-settings:wearables'));
+    assert('mtDNA import delegates to the file input in the chat empty-state container',
+      inputClicks.includes('scoped') && !inputClicks.includes('stray'));
+    assert('Optional task buttons keep panel-closing clicks from bubbling',
+      bubbledClicks === bubbledBeforeOptionalActions);
   } finally {
     state.currentProfile = saved.currentProfile;
     state.profiles = saved.profiles;
@@ -134,6 +153,8 @@ return (async function() {
     if (saved.profilesStorage === null) localStorage.removeItem('labcharts-profiles');
     else localStorage.setItem('labcharts-profiles', saved.profilesStorage);
     Object.assign(window, savedFns);
+    HTMLInputElement.prototype.click = savedInputClick;
+    strayMtDnaInput.remove();
     container.remove();
     panel.remove();
     if (chatMessages && savedChatMessagesHTML != null) chatMessages.innerHTML = savedChatMessagesHTML;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.332';
+self.APP_VERSION = '1.8.333';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.331';
+self.APP_VERSION = '1.8.332';


### PR DESCRIPTION
## Summary
- Route chat empty-state and onboarding controls through a scoped container delegate in `chat-empty-state.js`
- Remove inline handler attributes from the chat empty-state renderer and import owned onboarding functions directly where practical
- Add source and live DOM regression coverage for the delegated empty-state actions
- Register the new tests in the Vitest legacy and Puppeteer runners
- Tighten quality baselines: inline handlers `663 -> 631`, `window.*` references `1975 -> 1960`, and bump `version.js`

## Validation
- `node --check js/chat-empty-state.js`
- `node tests/test-chat-empty-state-delegated-actions.js`
- `npm run quality`
- `git diff --check`
- focused Puppeteer run of `tests/test-chat-empty-state-dom.js`
- `npm test -- --run tests/_vitest-legacy.test.js --testNamePattern "chat-empty-state-delegated-actions"`
- `npm test -- --run tests/_vitest-legacy.test.js`
- `./run-tests.sh`