### PR TITLE
[codex] Delegate light page view actions

### DIFF
--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -14,6 +14,52 @@ import {
   renderSuggestion,
 } from './light-channel-view.js';
 
+function closestLightPageAction(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const actionEl = target.closest('[data-light-page-action]');
+  if (!actionEl) return null;
+  return event.currentTarget?.contains(actionEl) ? actionEl : null;
+}
+
+function handleLightPageActionClick(event) {
+  const actionEl = closestLightPageAction(event);
+  if (!actionEl) return;
+  const action = actionEl.dataset.lightPageAction;
+  if (!action) return;
+
+  if (typeof HTMLAnchorElement !== 'undefined' && actionEl instanceof HTMLAnchorElement) event.preventDefault();
+
+  if (action === 'open-channel') {
+    window._openChannelOnLightPage?.(actionEl.dataset.channel || '');
+  } else if (action === 'quick-log-device') {
+    window.quickLogDeviceSession?.();
+  } else if (action === 'open-add-device') {
+    window.openAddDeviceDialog?.();
+  } else if (action === 'quick-log-sun') {
+    window.quickLogSunSession?.();
+  } else if (action === 'open-detailed-session') {
+    window.openDetailedSessionDialog?.();
+  } else if (action === 'navigate-light') {
+    window.navigate?.('light');
+  } else if (action === 'request-precise-location') {
+    window.requestPreciseLocation?.();
+  } else if (action === 'open-light-environment') {
+    window.openLightEnvironmentAssessment?.();
+  } else if (action === 'expand-light-tools') {
+    _expandLightToolsSection();
+  }
+}
+
+let lightPageActionDelegatesInstalled = false;
+export function installLightPageActionDelegates(root = (typeof document !== 'undefined' ? document : null)) {
+  if (!root || lightPageActionDelegatesInstalled) return;
+  lightPageActionDelegatesInstalled = true;
+  root.addEventListener('click', handleLightPageActionClick);
+}
+
+if (typeof document !== 'undefined') installLightPageActionDelegates();
+
 // ═══════════════════════════════════════════════
 // LIGHT TODAY STRIP — legacy compact surface used by welcome/embedded views
 // ═══════════════════════════════════════════════
@@ -33,7 +79,7 @@ export function renderDashboardLightChannelPills() {
       const t = tier(combinedTotals7d[k] || 0, k);
       const dc = _channelDayCount(k);
       const tip = `${meta.what || ''} — ${dc.n} of 7 days hit target this week. Tap for details.`;
-      return `<button type="button" class="light-pill light-pill-tier-${t} light-pill-dashboard" data-channel="${escapeAttr(k)}" title="${escapeHTML(tip)}" onclick="window._openChannelOnLightPage && window._openChannelOnLightPage('${escapeAttr(k)}')" aria-label="${escapeHTML((meta.label || k) + ', ' + dc.n + ' of 7 days hit target, tap to open detail')}">
+      return `<button type="button" class="light-pill light-pill-tier-${t} light-pill-dashboard" data-light-page-action="open-channel" data-channel="${escapeAttr(k)}" title="${escapeHTML(tip)}" aria-label="${escapeHTML((meta.label || k) + ', ' + dc.n + ' of 7 days hit target, tap to open detail')}">
         <span class="light-pill-icon" aria-hidden="true">${meta.icon || '·'}</span>
         <span class="light-pill-label">${escapeHTML(meta.label || k)}</span>
         ${_channelSparkline(k)}
@@ -60,33 +106,33 @@ export function renderLightSessionLogActions() {
     // Stop controls live in the pinned active-session card; this widget keeps
     // the remaining logging actions available without duplicating Stop.
     if (hasDevices) {
-      ctaButtons = `<button class="dashboard-action-btn dashboard-action-btn-primary light-log-action" onclick="window.quickLogDeviceSession && window.quickLogDeviceSession()">Start device session</button>`;
+      ctaButtons = `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary light-log-action" data-light-page-action="quick-log-device">Start device session</button>`;
     } else {
-      ctaButtons = `<button class="dashboard-action-btn light-log-action" onclick="window.openAddDeviceDialog && window.openAddDeviceDialog()">Add light device</button>`;
+      ctaButtons = `<button type="button" class="dashboard-action-btn light-log-action" data-light-page-action="open-add-device">Add light device</button>`;
     }
   } else if (hasDevices) {
-    ctaButtons = `<button class="dashboard-action-btn dashboard-action-btn-primary light-log-action" onclick="window.quickLogSunSession()">Start sun session</button>
-      <button class="dashboard-action-btn dashboard-action-btn-primary light-log-action" onclick="window.quickLogDeviceSession && window.quickLogDeviceSession()">Start device session</button>`;
+    ctaButtons = `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary light-log-action" data-light-page-action="quick-log-sun">Start sun session</button>
+      <button type="button" class="dashboard-action-btn dashboard-action-btn-primary light-log-action" data-light-page-action="quick-log-device">Start device session</button>`;
   } else {
-    ctaButtons = `<button class="dashboard-action-btn dashboard-action-btn-primary light-log-action" onclick="window.quickLogSunSession()">Start sun session</button>
-      <button class="dashboard-action-btn light-log-action" onclick="window.openAddDeviceDialog && window.openAddDeviceDialog()">Add light device</button>`;
+    ctaButtons = `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary light-log-action" data-light-page-action="quick-log-sun">Start sun session</button>
+      <button type="button" class="dashboard-action-btn light-log-action" data-light-page-action="open-add-device">Add light device</button>`;
   }
   return `<div class="light-session-log-actions">
     <div class="light-quicklog-row">
       ${ctaButtons}
-      <button class="dashboard-action-btn light-log-action" onclick="window.openDetailedSessionDialog && window.openDetailedSessionDialog()">Log past session</button>
+      <button type="button" class="dashboard-action-btn light-log-action" data-light-page-action="open-detailed-session">Log past session</button>
       ${totalSessions === 0 ? `<span class="light-summary-tally"${tallyDetail ? ` title="${tallyDetail}"` : ''}>No sessions yet</span>` : ''}
     </div>
   </div>`;
 }
 
-function renderLightWidgetPrompt(status, ctaLabel, ctaJs, hint, extraClass = '') {
-  return `<div class="light-widget-prompt ${extraClass}">
+function renderLightWidgetPrompt(status, ctaLabel, ctaAction, hint, extraClass = '') {
+  return `<div class="light-widget-prompt ${escapeAttr(extraClass)}">
     <div class="light-widget-prompt-copy">
       <strong>${escapeHTML(status)}</strong>
       <p>${escapeHTML(hint)}</p>
     </div>
-    <button class="dashboard-action-btn dashboard-action-btn-primary light-widget-prompt-cta" onclick="${escapeAttr(ctaJs)}">${escapeHTML(ctaLabel)}</button>
+    <button type="button" class="dashboard-action-btn dashboard-action-btn-primary light-widget-prompt-cta" data-light-page-action="${escapeAttr(ctaAction)}">${escapeHTML(ctaLabel)}</button>
   </div>`;
 }
 
@@ -139,9 +185,9 @@ export function renderLightTodayStrip() {
     if (devicesArr.length === 1) {
       const d = devicesArr[0];
       const label = `🔴 ${d.brand || ''} ${d.model || ''}`.trim();
-      deviceBtn = `<button class="light-today-cta light-today-cta-secondary" onclick="window.quickLogDeviceSession && window.quickLogDeviceSession()" title="Log a session on your ${escapeHTML(d.brand || '')} ${escapeHTML(d.model || '')}">${escapeHTML(label)}</button>`;
+      deviceBtn = `<button type="button" class="light-today-cta light-today-cta-secondary" data-light-page-action="quick-log-device" title="Log a session on your ${escapeAttr(d.brand || '')} ${escapeAttr(d.model || '')}">${escapeHTML(label)}</button>`;
     } else {
-      deviceBtn = `<button class="light-today-cta light-today-cta-secondary" onclick="window.quickLogDeviceSession && window.quickLogDeviceSession()" title="Pick from your ${devicesArr.length} devices">🔴 Device <span aria-hidden="true">▼</span></button>`;
+      deviceBtn = `<button type="button" class="light-today-cta light-today-cta-secondary" data-light-page-action="quick-log-device" title="Pick from your ${devicesArr.length} devices">🔴 Device <span aria-hidden="true">▼</span></button>`;
     }
   }
   // Onboarding CTA — graduated by what's already filled in:
@@ -162,9 +208,9 @@ export function renderLightTodayStrip() {
   const hasRooms = lightEnv && Array.isArray(lightEnv.rooms) && lightEnv.rooms.length > 0;
   let setupBtn = '';
   if (!hasSetup) {
-    setupBtn = `<button class="light-today-cta light-today-cta-secondary" onclick="window.navigate && window.navigate('light')" title="Skin type, location, indoor light, photosensitive meds — 30 seconds. Drives every Light & Sun calculation.">🌞 Set up Light & Sun</button>`;
+    setupBtn = `<button type="button" class="light-today-cta light-today-cta-secondary" data-light-page-action="navigate-light" title="Skin type, location, indoor light, photosensitive meds — 30 seconds. Drives every Light & Sun calculation.">🌞 Set up Light & Sun</button>`;
   } else if (!hasRooms) {
-    setupBtn = `<button class="light-today-cta light-today-cta-secondary" onclick="window.navigate && window.navigate('light')" title="Map your rooms — most of your day is under indoor lights">🛋 Map a room</button>`;
+    setupBtn = `<button type="button" class="light-today-cta light-today-cta-secondary" data-light-page-action="navigate-light" title="Map your rooms — most of your day is under indoor lights">🛋 Map a room</button>`;
   }
   // Keep the legacy roomBtn name so the template strings below don't change.
   const roomBtn = setupBtn;
@@ -175,14 +221,14 @@ export function renderLightTodayStrip() {
     // element every second via the [data-live-elapsed-for] selector.
     const elapsedMs = Date.now() - active.startedAt;
     const elapsed = _formatElapsedShort(elapsedMs);
-    cta = `<div class="light-today-cta-group"><button class="light-today-cta light-today-cta-active" onclick="window.quickLogSunSession()" aria-label="Stop active sun session"><span aria-hidden="true">⏹ Stop session — </span><span data-live-elapsed-for="${active.id}" aria-live="off">${elapsed}</span></button></div>`;
+    cta = `<div class="light-today-cta-group"><button type="button" class="light-today-cta light-today-cta-active" data-light-page-action="quick-log-sun" aria-label="Stop active sun session"><span aria-hidden="true">⏹ Stop session — </span><span data-live-elapsed-for="${active.id}" aria-live="off">${elapsed}</span></button></div>`;
   } else if (inSolarWindow) {
     const wlabel = solarWindowLabel();
-    cta = `<div class="light-today-cta-group"><button class="light-today-cta" onclick="window.quickLogSunSession()"><span aria-hidden="true">☀</span> ${wlabel} — log a session</button>${deviceBtn}${roomBtn}</div>`;
+    cta = `<div class="light-today-cta-group"><button type="button" class="light-today-cta" data-light-page-action="quick-log-sun"><span aria-hidden="true">☀</span> ${wlabel} — log a session</button>${deviceBtn}${roomBtn}</div>`;
   } else if (hasDevices) {
-    cta = `<div class="light-today-cta-group"><button class="light-today-cta" onclick="window.quickLogSunSession()"><span aria-hidden="true">☀</span> Log sun</button>${deviceBtn}${roomBtn}</div>`;
+    cta = `<div class="light-today-cta-group"><button type="button" class="light-today-cta" data-light-page-action="quick-log-sun"><span aria-hidden="true">☀</span> Log sun</button>${deviceBtn}${roomBtn}</div>`;
   } else {
-    cta = `<div class="light-today-cta-group"><button class="light-today-cta" onclick="window.quickLogSunSession()">☀ Log a sun session</button>${roomBtn}</div>`;
+    cta = `<div class="light-today-cta-group"><button type="button" class="light-today-cta" data-light-page-action="quick-log-sun">☀ Log a sun session</button>${roomBtn}</div>`;
   }
 
   // Burn-risk gauge — qualitative, plain English, no acronyms
@@ -253,7 +299,7 @@ export function renderLightTodayStrip() {
       <span class="light-today-title">Light Today</span>
       <span class="light-today-sub" title="${sunWeek} sun + ${devWeek} device · last 7 days">${weekTotal} light session${weekTotal !== 1 ? 's' : ''} this week</span>
       ${altChip}
-      <a href="#" class="light-today-link" onclick="event.preventDefault();window.navigate('light')">Open Light &amp; Sun →</a>
+      <a href="#" class="light-today-link" data-light-page-action="navigate-light">Open Light &amp; Sun →</a>
     </div>
     ${typeof window !== 'undefined' && window.renderLightTodayDashboardChip ? window.renderLightTodayDashboardChip() : ''}
     ${renderConditionsNow({ variant: 'compact' })}
@@ -637,30 +683,30 @@ export function showLight(_data) {
       const devices = (window.getDevices && window.getDevices()) || [];
       slot.outerHTML = devices.length > 0
         ? devHtml
-        : renderLightWidgetPrompt('No devices added', 'Add device', "window.openAddDeviceDialog && window.openAddDeviceDialog()", 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
+        : renderLightWidgetPrompt('No devices added', 'Add device', 'open-add-device', 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
     }).catch(() => {});
   } else {
     const slot = document.getElementById(devicesSlotId);
     if (slot) {
-      slot.outerHTML = renderLightWidgetPrompt('No devices added', 'Add device', "window.openAddDeviceDialog && window.openAddDeviceDialog()", 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
+      slot.outerHTML = renderLightWidgetPrompt('No devices added', 'Add device', 'open-add-device', 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
     }
   }
   const envSlot = document.getElementById(environmentSlotId);
   if (envSlot) {
     envSlot.outerHTML = window.renderEnvironmentAssessmentSummary
       ? (window.renderEnvironmentAssessmentSummary() || '')
-      : renderLightWidgetPrompt('No rooms mapped', 'Open assessment', "window.openLightEnvironmentAssessment && window.openLightEnvironmentAssessment()", 'Map bedroom, office, screens, and evening light so Light can interpret your indoor day.', 'light-environment-prompt');
+      : renderLightWidgetPrompt('No rooms mapped', 'Open assessment', 'open-light-environment', 'Map bedroom, office, screens, and evening light so Light can interpret your indoor day.', 'light-environment-prompt');
   }
   const toolsSlot = document.getElementById(toolsSlotId);
   if (toolsSlot) {
     toolsSlot.outerHTML = window.renderLightTools
       ? (window.renderLightTools() || '')
-      : renderLightWidgetPrompt('No measurements yet', 'Open light tools', 'window._expandLightToolsSection && window._expandLightToolsSection()', 'Run lux, flicker, color temperature, glass, and sleep-darkness checks on this device. Camera frames stay local.', 'light-tools-section-collapsed');
+      : renderLightWidgetPrompt('No measurements yet', 'Open light tools', 'expand-light-tools', 'Run lux, flicker, color temperature, glass, and sleep-darkness checks on this device. Camera frames stay local.', 'light-tools-section-collapsed');
   }
 }
 
 // Expand the collapsed Light tools placeholder into the full 8-card grid.
-// Named function so the inline onclick can stay short and quote-safe.
+// Named function so delegated Light page actions can expand the placeholder.
 export function _expandLightToolsSection() {
   const collapsed = document.querySelector('.light-tools-section-collapsed');
   if (!collapsed || typeof window.renderLightTools !== 'function') return;
@@ -673,10 +719,10 @@ function getSunCoordsHint() {
   if (typeof window === 'undefined' || !window.getSunCoords) return '';
   const c = window.getSunCoords();
   if (!c) {
-    return `<p class="light-intro-hint">Tip: set your country in the profile editor for accurate sun calculations, or <a href="#" onclick="event.preventDefault();window.requestPreciseLocation && window.requestPreciseLocation()">share your precise location</a> once.</p>`;
+    return `<p class="light-intro-hint">Tip: set your country in the profile editor for accurate sun calculations, or <a href="#" data-light-page-action="request-precise-location">share your precise location</a> once.</p>`;
   }
   if (c.source === 'country-band') {
-    return `<p class="light-intro-hint">Calculations use your country (~${c.lat}° lat). <a href="#" onclick="event.preventDefault();window.requestPreciseLocation && window.requestPreciseLocation()">Use precise location</a> for sharper results.</p>`;
+    return `<p class="light-intro-hint">Calculations use your country (~${c.lat}° lat). <a href="#" data-light-page-action="request-precise-location">Use precise location</a> for sharper results.</p>`;
   }
   return '';
 }

--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -51,10 +51,10 @@ function handleLightPageActionClick(event) {
   }
 }
 
-let lightPageActionDelegatesInstalled = false;
+const lightPageActionDelegateRoots = new WeakSet();
 export function installLightPageActionDelegates(root = (typeof document !== 'undefined' ? document : null)) {
-  if (!root || lightPageActionDelegatesInstalled) return;
-  lightPageActionDelegatesInstalled = true;
+  if (!root || lightPageActionDelegateRoots.has(root)) return;
+  lightPageActionDelegateRoots.add(root);
   root.addEventListener('click', handleLightPageActionClick);
 }
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -48,6 +48,7 @@ const TEST_FILES = [
   'tests/test-nav-delegated-actions-dom.js',
   'tests/test-dashboard-widget-delegated-actions-dom.js',
   'tests/test-lens-page-shell-delegated-actions-dom.js',
+  'tests/test-light-page-view-delegated-actions-dom.js',
   // test-image-utils.js source-inspection + module-export checks ported to
   // Vitest (PR for batch 19). DOM-runtime assertions (sections 6 + 7) live
   // in test-image-utils-dom.js below.

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
-  "inlineEventAttributes": 631,
-  "windowReferences": 1960,
+  "inlineEventAttributes": 611,
+  "windowReferences": 1929,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1600
 }

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -170,6 +170,7 @@ const LEGACY_TESTS = [
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',
   './test-lens-page-shell-delegated-actions.js',
+  './test-light-page-view-delegated-actions.js',
   './test-wearables-delegated-actions.js',
   './test-client-list-delegated-actions.js',
   './test-provider-wallet-delegated-actions.js',

--- a/tests/test-light-page-view-delegated-actions-dom.js
+++ b/tests/test-light-page-view-delegated-actions-dom.js
@@ -1,0 +1,105 @@
+// test-light-page-view-delegated-actions-dom.js - live Light page view delegate coverage.
+//
+// Run: fetch('tests/test-light-page-view-delegated-actions-dom.js').then(r=>r.text()).then(s=>Function(s)())
+
+return (async function() {
+  let pass = 0, fail = 0;
+  function assert(name, condition, detail) {
+    if (condition) { pass++; console.log(`%c PASS %c ${name}`, 'background:#22c55e;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+    else { fail++; console.error(`%c FAIL %c ${name}`, 'background:#ef4444;color:#fff;padding:2px 6px;border-radius:3px', '', detail || ''); }
+  }
+
+  console.log('%c Light Page View Delegated Actions DOM ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+
+  const { renderDashboardLightChannelPills, renderLightSessionLogActions } = await import('/js/light-page-view.js');
+  const savedFns = {
+    getSessions: window.getSessions,
+    getDevices: window.getDevices,
+    getDeviceSessions: window.getDeviceSessions,
+    getActiveSession: window.getActiveSession,
+    _openChannelOnLightPage: window._openChannelOnLightPage,
+    quickLogSunSession: window.quickLogSunSession,
+    quickLogDeviceSession: window.quickLogDeviceSession,
+    openAddDeviceDialog: window.openAddDeviceDialog,
+    openDetailedSessionDialog: window.openDetailedSessionDialog,
+    navigate: window.navigate,
+    requestPreciseLocation: window.requestPreciseLocation,
+    openLightEnvironmentAssessment: window.openLightEnvironmentAssessment,
+    renderLightTools: window.renderLightTools,
+  };
+  const calls = [];
+  const host = document.createElement('div');
+
+  try {
+    window.getSessions = () => [];
+    window.getDevices = () => [];
+    window.getDeviceSessions = () => [];
+    window.getActiveSession = () => null;
+    window._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
+    window.quickLogSunSession = () => calls.push(['quick-log-sun']);
+    window.quickLogDeviceSession = () => calls.push(['quick-log-device']);
+    window.openAddDeviceDialog = () => calls.push(['open-add-device']);
+    window.openDetailedSessionDialog = () => calls.push(['open-detailed-session']);
+    window.navigate = route => calls.push(['navigate', route]);
+    window.requestPreciseLocation = () => calls.push(['request-precise-location']);
+    window.openLightEnvironmentAssessment = () => calls.push(['open-light-environment']);
+    window.renderLightTools = () => '<section id="light-tools-expanded-test">Expanded tools</section>';
+
+    document.body.appendChild(host);
+    host.innerHTML = `
+      ${renderLightSessionLogActions()}
+      ${renderDashboardLightChannelPills()}
+      <a href="#light-test" data-light-page-action="navigate-light">Open Light</a>
+      <a href="#precise-test" data-light-page-action="request-precise-location">Use precise location</a>
+      <button type="button" data-light-page-action="quick-log-device">Device</button>
+      <button type="button" data-light-page-action="open-light-environment">Environment</button>
+      <button type="button" data-light-page-action="expand-light-tools">Tools</button>
+      <div class="light-widget-prompt light-tools-section-collapsed">Collapsed tools</div>
+    `;
+
+    assert('rendered Light page view action surface has no inline handlers',
+      !host.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onkeyup],[onsubmit]'));
+    assert('rendered Light page view action surface uses data actions',
+      !!host.querySelector('[data-light-page-action="quick-log-sun"]')
+        && !!host.querySelector('[data-light-page-action="open-channel"][data-channel]'));
+
+    host.querySelector('[data-light-page-action="quick-log-sun"]')?.click();
+    host.querySelector('[data-light-page-action="quick-log-device"]')?.click();
+    host.querySelector('[data-light-page-action="open-add-device"]')?.click();
+    host.querySelector('[data-light-page-action="open-detailed-session"]')?.click();
+    host.querySelector('[data-light-page-action="open-channel"][data-channel]')?.click();
+    host.querySelector('[data-light-page-action="open-light-environment"]')?.click();
+
+    const navLink = host.querySelector('a[data-light-page-action="navigate-light"]');
+    const navEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    navLink?.dispatchEvent(navEvent);
+    const preciseLink = host.querySelector('a[data-light-page-action="request-precise-location"]');
+    const preciseEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    preciseLink?.dispatchEvent(preciseEvent);
+
+    host.querySelector('[data-light-page-action="expand-light-tools"]')?.click();
+
+    assert('delegated session and dashboard actions call their handlers',
+      calls.some(c => c[0] === 'quick-log-sun')
+        && calls.some(c => c[0] === 'quick-log-device')
+        && calls.some(c => c[0] === 'open-add-device')
+        && calls.some(c => c[0] === 'open-detailed-session')
+        && calls.some(c => c[0] === 'open-channel' && c[1]));
+    assert('delegated link actions prevent default and call scoped handlers',
+      navEvent.defaultPrevented
+        && preciseEvent.defaultPrevented
+        && calls.some(c => c[0] === 'navigate' && c[1] === 'light')
+        && calls.some(c => c[0] === 'request-precise-location'));
+    assert('delegated prompt actions call environment/tools handlers',
+      calls.some(c => c[0] === 'open-light-environment')
+        && !!document.getElementById('light-tools-expanded-test'));
+  } finally {
+    Object.assign(window, savedFns);
+    host.remove();
+    document.getElementById('light-tools-expanded-test')?.remove();
+  }
+
+  console.log(`\n%c Light Page View Delegated Actions DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  if (typeof window.__TEST_RESULTS === 'undefined') window.__TEST_RESULTS = {};
+  window.__TEST_RESULTS['test-light-page-view-delegated-actions-dom'] = { pass, fail };
+})();

--- a/tests/test-light-page-view-delegated-actions-dom.js
+++ b/tests/test-light-page-view-delegated-actions-dom.js
@@ -26,6 +26,9 @@ return (async function() {
     requestPreciseLocation: window.requestPreciseLocation,
     openLightEnvironmentAssessment: window.openLightEnvironmentAssessment,
     renderLightTools: window.renderLightTools,
+    CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
+    weeklyChannelTier: window.weeklyChannelTier,
+    dailyChannelBreakdown: window.dailyChannelBreakdown,
   };
   const calls = [];
   const host = document.createElement('div');
@@ -44,6 +47,19 @@ return (async function() {
     window.requestPreciseLocation = () => calls.push(['request-precise-location']);
     window.openLightEnvironmentAssessment = () => calls.push(['open-light-environment']);
     window.renderLightTools = () => '<section id="light-tools-expanded-test">Expanded tools</section>';
+    window.CHANNEL_DISPLAY = {
+      vitamin_d: { label: 'Vitamin D', icon: 'D', what: 'Vitamin D', dailyTarget: 100 },
+      circadian: { label: 'Circadian', icon: 'C', what: 'Circadian', dailyTarget: 100 },
+      nir_solar: { label: 'NIR', icon: 'N', what: 'NIR', dailyTarget: 100 },
+      no_cv: { label: 'NO', icon: 'NO', what: 'Nitric oxide', dailyTarget: 100 },
+      pomc: { label: 'POMC', icon: 'P', what: 'POMC', dailyTarget: 100 },
+      violet_eye: { label: 'Violet', icon: 'V', what: 'Violet', dailyTarget: 100 },
+    };
+    window.weeklyChannelTier = () => 0;
+    window.dailyChannelBreakdown = () => Array.from({ length: 7 }, (_, i) => ({
+      sun: i === 0 ? 10 : 0,
+      device: 0,
+    }));
 
     document.body.appendChild(host);
     host.innerHTML = `

--- a/tests/test-light-page-view-delegated-actions.js
+++ b/tests/test-light-page-view-delegated-actions.js
@@ -31,8 +31,11 @@ assert('light-page-view.js has no inline event attributes',
   !inlineHandlerRe.test(src));
 assert('light-page-view.js avoids direct event property assignment',
   !directAssignmentRe.test(src));
-assert('Light page view installs one click delegate',
-  /root\.addEventListener\('click', handleLightPageActionClick\)/.test(src)
+assert('Light page view installs one click delegate per root',
+  /const lightPageActionDelegateRoots = new WeakSet\(\);/.test(src)
+    && /lightPageActionDelegateRoots\.has\(root\)/.test(src)
+    && /lightPageActionDelegateRoots\.add\(root\)/.test(src)
+    && /root\.addEventListener\('click', handleLightPageActionClick\)/.test(src)
     && /installLightPageActionDelegates\(\)/.test(src));
 assert('Light page actions are scoped through closest data action lookup',
   /target\.closest\('\[data-light-page-action\]'\)/.test(src)

--- a/tests/test-light-page-view-delegated-actions.js
+++ b/tests/test-light-page-view-delegated-actions.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Light page view delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const src = fs.readFileSync(path.join(root, 'js/light-page-view.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Light Page View Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
+const directAssignmentRe = /\.(?:onclick|onchange|oninput)\s*=/;
+
+assert('light-page-view.js has no inline event attributes',
+  !inlineHandlerRe.test(src));
+assert('light-page-view.js avoids direct event property assignment',
+  !directAssignmentRe.test(src));
+assert('Light page view installs one click delegate',
+  /root\.addEventListener\('click', handleLightPageActionClick\)/.test(src)
+    && /installLightPageActionDelegates\(\)/.test(src));
+assert('Light page actions are scoped through closest data action lookup',
+  /target\.closest\('\[data-light-page-action\]'\)/.test(src)
+    && /event\.currentTarget\?\.contains\(actionEl\)/.test(src));
+
+[
+  'open-channel',
+  'quick-log-device',
+  'open-add-device',
+  'quick-log-sun',
+  'open-detailed-session',
+  'navigate-light',
+  'request-precise-location',
+  'open-light-environment',
+  'expand-light-tools',
+].forEach(action => {
+  assert(`Light page action ${action} is rendered or handled`,
+    src.includes(`data-light-page-action="${action}"`) || src.includes(`action === '${action}'`));
+});
+
+assert('Light widget prompt receives action ids instead of JavaScript snippets',
+  /function renderLightWidgetPrompt\(status, ctaLabel, ctaAction/.test(src)
+    && /data-light-page-action="\$\{escapeAttr\(ctaAction\)\}"/.test(src)
+    && !/function renderLightWidgetPrompt\(status, ctaLabel, ctaJs/.test(src));
+assert('Dashboard channel pill action passes channel through data attribute',
+  /data-light-page-action="open-channel" data-channel="\$\{escapeAttr\(k\)\}"/.test(src)
+    && /_openChannelOnLightPage\?\.\(actionEl\.dataset\.channel/.test(src));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.333';
+self.APP_VERSION = '1.8.334';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.334';
+self.APP_VERSION = '1.8.335';


### PR DESCRIPTION
## Summary
- Route Light page/dashboard Light CTAs through a scoped `data-light-page-action` click delegate in `js/light-page-view.js`
- Remove the file's inline event attributes from Light Today, session logging, channel pills, precise-location links, and fallback prompt buttons
- Add source and live DOM regression coverage for the delegated Light page actions
- Tighten quality baselines: inline handlers `631 -> 611`, `window.*` references `1960 -> 1929`, and bump `version.js`

## Validation
- `node --check js/light-page-view.js`
- `node tests/test-light-page-view-delegated-actions.js`
- focused Puppeteer run of `tests/test-light-page-view-delegated-actions-dom.js`
- `npm run quality`
- `npm test -- --run tests/_vitest-legacy.test.js --testNamePattern "light-page-view-delegated-actions"`
- `git diff --check`
- `./run-tests.sh`