### PR TITLE
[codex] Delegate sun session actions

### DIFF
--- a/js/sun-session-actions.js
+++ b/js/sun-session-actions.js
@@ -1,0 +1,102 @@
+// sun-session-actions.js - delegated action contract for sun session UI.
+
+import { escapeAttr } from './utils.js';
+
+const sunSessionActionDelegateRoots = new WeakSet();
+const SUN_SESSION_KEYBOARD_ACTIONS = new Set([
+  'open-detail',
+  'forgot-stop',
+  'open-channel',
+]);
+
+function dataAttrName(name) {
+  return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+export function sunSessionActionAttrs(action, attrs = {}) {
+  return [
+    `data-sun-session-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-sun-session-${escapeAttr(dataAttrName(name))}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function closestSunSessionAction(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return null;
+  const actionEl = target.closest('[data-sun-session-action]');
+  if (!actionEl) return null;
+  return event.currentTarget?.contains(actionEl) ? actionEl : null;
+}
+
+function closeContainingOverlay(actionEl) {
+  actionEl.closest('.modal-overlay')?.remove();
+}
+
+function handleSunSessionAction(actionEl, actions) {
+  const action = actionEl.dataset.sunSessionAction || '';
+  const id = actionEl.dataset.sunSessionId || '';
+  const channel = actionEl.dataset.sunSessionChannel || '';
+
+  if (action === 'ignore') {
+    return;
+  } else if (action === 'open-detail') {
+    actions.openSunSessionDetail?.(id);
+  } else if (action === 'delete-session') {
+    if (actionEl.dataset.sunSessionCloseModal === 'true') closeContainingOverlay(actionEl);
+    void actions.deleteSunSession?.(id);
+  } else if (action === 'quick-log-sun') {
+    window.quickLogSunSession?.();
+  } else if (action === 'pause-session') {
+    window.pauseSunSession?.(id);
+  } else if (action === 'resume-session') {
+    window.resumeSunSession?.(id);
+  } else if (action === 'flip-sides') {
+    window.flipSidesMidSession?.(id);
+  } else if (action === 'change-coverage') {
+    window.changeCoverageMidSession?.(id);
+  } else if (action === 'apply-sunscreen') {
+    window.applySunscreenMidSession?.(id);
+  } else if (action === 'override-ozone') {
+    window.setOzoneOverrideMidSession?.();
+  } else if (action === 'forgot-stop') {
+    window._forgotStopPrompt?.(id);
+  } else if (action === 'open-channel') {
+    closeContainingOverlay(actionEl);
+    window._openChannelOnLightPage?.(channel);
+  } else if (action === 'close-modal') {
+    closeContainingOverlay(actionEl);
+  } else if (action === 'edit-duration') {
+    closeContainingOverlay(actionEl);
+    void actions.editSunSessionDuration?.(id);
+  } else if (action === 'toggle-chips') {
+    actionEl.parentElement?.classList.toggle('sun-chips-expanded');
+  }
+}
+
+function handleSunSessionClick(event, actions) {
+  const actionEl = closestSunSessionAction(event);
+  if (!actionEl) return;
+  event.preventDefault();
+  event.stopPropagation();
+  handleSunSessionAction(actionEl, actions);
+}
+
+function handleSunSessionKeydown(event, actions) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestSunSessionAction(event);
+  if (!actionEl) return;
+  if (event.target?.closest?.('button, a, input, textarea, select')) return;
+  if (!SUN_SESSION_KEYBOARD_ACTIONS.has(actionEl.dataset.sunSessionAction || '')) return;
+  event.preventDefault();
+  event.stopPropagation();
+  handleSunSessionAction(actionEl, actions);
+}
+
+export function installSunSessionActionDelegates(actions = {}, root = (typeof document !== 'undefined' ? document : null)) {
+  if (!root || sunSessionActionDelegateRoots.has(root)) return;
+  sunSessionActionDelegateRoots.add(root);
+  root.addEventListener('click', event => handleSunSessionClick(event, actions));
+  root.addEventListener('keydown', event => handleSunSessionKeydown(event, actions));
+}

--- a/js/sun-session-actions.js
+++ b/js/sun-session-actions.js
@@ -17,7 +17,7 @@ export function sunSessionActionAttrs(action, attrs = {}) {
   return [
     `data-sun-session-action="${escapeAttr(action)}"`,
     ...Object.entries(attrs)
-      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .filter(([, value]) => value !== undefined && value !== null && value !== '' && value !== false)
       .map(([name, value]) => `data-sun-session-${escapeAttr(dataAttrName(name))}="${escapeAttr(String(value))}"`),
   ].join(' ');
 }
@@ -71,7 +71,7 @@ function handleSunSessionAction(actionEl, actions) {
     closeContainingOverlay(actionEl);
     void actions.editSunSessionDuration?.(id);
   } else if (action === 'toggle-chips') {
-    actionEl.parentElement?.classList.toggle('sun-chips-expanded');
+    actionEl.closest('.sun-channel-chips')?.classList.toggle('sun-chips-expanded');
   }
 }
 

--- a/js/sun-session-ui.js
+++ b/js/sun-session-ui.js
@@ -6,6 +6,7 @@
 import { state } from './state.js';
 import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
 import { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette } from './sun-body-silhouette.js';
+import { installSunSessionActionDelegates, sunSessionActionAttrs } from './sun-session-actions.js';
 
 const uiDeps = {
   getSessions: () => [],
@@ -30,6 +31,14 @@ const uiDeps = {
   formatChannelUnit: () => '',
   tooShortForChannelVerdictMin: 2,
 };
+
+if (typeof document !== 'undefined') {
+  installSunSessionActionDelegates({
+    openSunSessionDetail,
+    deleteSunSession,
+    editSunSessionDuration,
+  });
+}
 
 export function configureSunSessionUI(deps = {}) {
   Object.assign(uiDeps, deps);
@@ -60,45 +69,43 @@ export function renderSunSessionRow(sess) {
     medStr = `<span class="sun-session-med ${cls}" title="Burn dose: ${pct}% of your burn threshold (Fitzpatrick ${escapeAttr(sess.safety.fitzpatrick || 'III')})">Burn dose: ${escapeHTML(label)}</span>`;
   }
   const channelChips = renderChannelChips(sess.doses, sess);
-  // Active-session controls: Pause/Resume + Sunscreen re-applied + Set
-  // ozone. Stop propagation so the row's open-detail click handler
-  // doesn't fire when these are tapped.
+  // Active-session controls own their delegated actions so tapping them
+  // does not fall through to the row-level open-detail action.
   let activeControls = '';
   if (isActive) {
     const isPaused = !!sess.paused;
-    const pauseLabel = isPaused ? '▶ Resume' : '⏸ Pause';
-    const pauseAction = isPaused ? `window.resumeSunSession('${escapeAttr(sess.id)}')` : `window.pauseSunSession('${escapeAttr(sess.id)}')`;
+    const pauseAction = isPaused ? 'resume-session' : 'pause-session';
     const isRotated = !!sess.bodyExposure?.rotatedSides;
     const flipBtn = isRotated
-      ? `<button class="sun-session-ctl" disabled title="Already logged as rotated — vit-D IU already counts both sides." aria-label="Rotated"><span aria-hidden="true">🔄</span> <span class="sun-session-ctl-label">Rotated ✓</span></button>`
-      : `<button class="sun-session-ctl" onclick="event.stopPropagation();window.flipSidesMidSession('${escapeAttr(sess.id)}')" title="Tap when you flip front↔back. Doubles vit-D IU to reflect that both sides got exposure." aria-label="Flip front-back"><span aria-hidden="true">🔄</span> <span class="sun-session-ctl-label">Flip</span></button>`;
-    activeControls = `<div class="sun-session-active-controls" onclick="event.stopPropagation()">
+      ? `<button type="button" class="sun-session-ctl" disabled title="Already logged as rotated — vit-D IU already counts both sides." aria-label="Rotated"><span aria-hidden="true">🔄</span> <span class="sun-session-ctl-label">Rotated ✓</span></button>`
+      : `<button type="button" class="sun-session-ctl" ${sunSessionActionAttrs('flip-sides', { id: sess.id })} title="Tap when you flip front↔back. Doubles vit-D IU to reflect that both sides got exposure." aria-label="Flip front-back"><span aria-hidden="true">🔄</span> <span class="sun-session-ctl-label">Flip</span></button>`;
+    activeControls = `<div class="sun-session-active-controls" ${sunSessionActionAttrs('ignore')}>
       <div class="sun-session-ctl-primary">
-        <button class="sun-session-ctl sun-session-ctl-stop" onclick="event.stopPropagation();window.quickLogSunSession()" title="Stop and save the current session"><span aria-hidden="true">⏹</span> <span class="sun-session-ctl-label">Stop &amp; save</span></button>
-        <button class="sun-session-ctl" onclick="event.stopPropagation();${pauseAction}" title="${isPaused ? 'Resume dose accrual' : 'Pause dose accrual (shade break, indoors)'}" aria-label="${isPaused ? 'Resume' : 'Pause'} session"><span aria-hidden="true">${isPaused ? '▶' : '⏸'}</span> <span class="sun-session-ctl-label">${isPaused ? 'Resume' : 'Pause'}</span></button>
+        <button type="button" class="sun-session-ctl sun-session-ctl-stop" ${sunSessionActionAttrs('quick-log-sun')} title="Stop and save the current session"><span aria-hidden="true">⏹</span> <span class="sun-session-ctl-label">Stop &amp; save</span></button>
+        <button type="button" class="sun-session-ctl" ${sunSessionActionAttrs(pauseAction, { id: sess.id })} title="${isPaused ? 'Resume dose accrual' : 'Pause dose accrual (shade break, indoors)'}" aria-label="${isPaused ? 'Resume' : 'Pause'} session"><span aria-hidden="true">${isPaused ? '▶' : '⏸'}</span> <span class="sun-session-ctl-label">${isPaused ? 'Resume' : 'Pause'}</span></button>
       </div>
       <div class="sun-session-ctl-secondary">
         ${flipBtn}
-        <button class="sun-session-ctl" onclick="event.stopPropagation();window.changeCoverageMidSession('${escapeAttr(sess.id)}')" title="Dressed or undressed — opens the body-region picker, commits the dose accrued so far, applies the new coverage from this moment forward" aria-label="Change coverage"><span aria-hidden="true">👕</span> <span class="sun-session-ctl-label">Coverage</span></button>
-        <button class="sun-session-ctl" onclick="event.stopPropagation();window.applySunscreenMidSession('${escapeAttr(sess.id)}')" title="Reapplied sunscreen — commits current slice and starts a new one with the new SPF" aria-label="Reapply sunscreen"><span aria-hidden="true">🧴</span> <span class="sun-session-ctl-label">Sunscreen</span></button>
-        <button class="sun-session-ctl" onclick="event.stopPropagation();window.setOzoneOverrideMidSession()" title="Calibrate ozone column from a meter / weather station" aria-label="Override ozone"><span aria-hidden="true">🛰</span> <span class="sun-session-ctl-label">Ozone</span></button>
+        <button type="button" class="sun-session-ctl" ${sunSessionActionAttrs('change-coverage', { id: sess.id })} title="Dressed or undressed — opens the body-region picker, commits the dose accrued so far, applies the new coverage from this moment forward" aria-label="Change coverage"><span aria-hidden="true">👕</span> <span class="sun-session-ctl-label">Coverage</span></button>
+        <button type="button" class="sun-session-ctl" ${sunSessionActionAttrs('apply-sunscreen', { id: sess.id })} title="Reapplied sunscreen — commits current slice and starts a new one with the new SPF" aria-label="Reapply sunscreen"><span aria-hidden="true">🧴</span> <span class="sun-session-ctl-label">Sunscreen</span></button>
+        <button type="button" class="sun-session-ctl" ${sunSessionActionAttrs('override-ozone')} title="Calibrate ozone column from a meter / weather station" aria-label="Override ozone"><span aria-hidden="true">🛰</span> <span class="sun-session-ctl-label">Ozone</span></button>
       </div>
     </div>`;
   }
   const pausedBadge = isActive && sess.paused ? `<span class="sun-session-paused" title="Dose accrual paused — elapsed time still ticks but channel + burn totals stay frozen.">⏸ paused</span>` : '';
   const forgotBanner = isActive && (Date.now() - sess.startedAt > 12 * 3600 * 1000)
-    ? `<div class="sun-session-forgot" onclick="event.stopPropagation();window._forgotStopPrompt && window._forgotStopPrompt('${escapeAttr(sess.id)}')" role="button" tabindex="0">⚠ This session has been running for ${Math.round((Date.now() - sess.startedAt) / 3600000)}h. Tap to end it.</div>`
+    ? `<div class="sun-session-forgot" ${sunSessionActionAttrs('forgot-stop', { id: sess.id })} role="button" tabindex="0">⚠ This session has been running for ${Math.round((Date.now() - sess.startedAt) / 3600000)}h. Tap to end it.</div>`
     : '';
-  // Click anywhere on the card (except the × delete) to open the detail
-  // modal. Each delete button stops propagation so it only deletes.
-  return `<div class="sun-session light-session-row light-session-sun" data-id="${escapeAttr(sess.id)}" role="button" tabindex="0" aria-label="Open ${start} session details" onclick="window.openSunSessionDetail && window.openSunSessionDetail('${escapeAttr(sess.id)}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.openSunSessionDetail && window.openSunSessionDetail('${escapeAttr(sess.id)}')}">
+  // Click anywhere on the card (except nested delegated controls) to open
+  // the detail modal. Specific controls declare their own data action.
+  return `<div class="sun-session light-session-row light-session-sun" data-id="${escapeAttr(sess.id)}" role="button" tabindex="0" aria-label="Open ${start} session details" ${sunSessionActionAttrs('open-detail', { id: sess.id })}>
     <div class="sun-session-head">
       <span class="light-session-icon" aria-hidden="true">☀</span>
       <span class="sun-session-date">${start}</span>
       <span class="sun-session-duration"${isActive ? ' aria-live="off"' : ''}>${dur}</span>
       ${pausedBadge}
       ${medStr}
-      <button class="sun-session-delete" onclick="event.stopPropagation();window.deleteSunSession('${escapeAttr(sess.id)}')" title="Delete session" aria-label="Delete session">×</button>
+      <button type="button" class="sun-session-delete" ${sunSessionActionAttrs('delete-session', { id: sess.id })} title="Delete session" aria-label="Delete session">×</button>
     </div>
     <div class="sun-session-meta">
       ${escapeHTML(uiDeps.summarizeBodyExposure(sess))} · ${sess.eyeExposure?.mode === 'direct' ? `<span class="sun-eye-warn" title="Never look directly at the sun">⚠</span> ` : ''}${escapeHTML(eyeLabels[sess.eyeExposure?.mode] || 'Eyes unset')}${sess.bodyExposure?.glassBetween ? ' · through glass' : ''}${sess.bodyExposure?.sunscreenSPF ? ` · SPF ${sess.bodyExposure.sunscreenSPF}` : ''}
@@ -115,7 +122,7 @@ export function renderSessionsList() {
   if (sessions.length === 0) {
     return `<div class="sun-empty">
       <p>No sun sessions logged yet.</p>
-      <button class="import-btn import-btn-primary" onclick="window.quickLogSunSession()">Log your first session</button>
+      <button type="button" class="import-btn import-btn-primary" ${sunSessionActionAttrs('quick-log-sun')}>Log your first session</button>
     </div>`;
   }
   let html = `<div class="sun-sessions-list">`;
@@ -193,7 +200,7 @@ export function openSunSessionDetail(id) {
     const pctOfTarget = (target > 0 && v > 0) ? Math.round(100 * v / target) : null;
     const unitText = uiDeps.formatChannelUnit(k, v, sess.durationMin || 0, sess.safety?.fitzpatrick || 'III', sess.atmosphere?.uvIndex, sessZenith, !!sess.bodyExposure?.rotatedSides, sess.bodyExposure?.fraction || null);
     const ariaLabel = `${meta.label || k} — ${tlabel}${unitText ? ', ' + unitText : ''}. Open channel details.`;
-    return `<div class="sun-detail-channel-row sun-detail-channel-row-clickable sun-chip-tier-${t}" data-channel="${escapeAttr(k)}" role="button" tabindex="0" aria-label="${escapeAttr(ariaLabel)}" onclick="this.closest('.modal-overlay')?.remove();window._openChannelOnLightPage && window._openChannelOnLightPage('${escapeAttr(k)}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.closest('.modal-overlay')?.remove();window._openChannelOnLightPage && window._openChannelOnLightPage('${escapeAttr(k)}')}">
+    return `<div class="sun-detail-channel-row sun-detail-channel-row-clickable sun-chip-tier-${t}" data-channel="${escapeAttr(k)}" ${sunSessionActionAttrs('open-channel', { channel: k })} role="button" tabindex="0" aria-label="${escapeAttr(ariaLabel)}">
       <span class="sun-detail-channel-icon" aria-hidden="true">${meta.icon || '·'}</span>
       <span class="sun-detail-channel-label">${escapeHTML(meta.label || k)}</span>
       <span class="sun-detail-channel-value"${pctOfTarget != null && !unitText ? ` title="${escapeAttr(pctOfTarget + '% of typical-active-day target — calibrated to roughly 30-60 min of moderate-body-fraction midday exposure (skin channels) or 10-30 min eye-direct outdoor light (eye channels). Over 100% means you got more than typical, NOT more than safe — burn risk is the % MED chip, not this. Targets are dosing references, not exposure ceilings.')}"` : ''}>${unitText || (pctOfTarget != null ? `${pctOfTarget}%` : '')}</span>
@@ -311,7 +318,7 @@ export function openSunSessionDetail(id) {
   overlay.innerHTML = `<div class="modal sun-detail-modal" data-session-kind="sun" role="dialog" aria-label="Sun session details">
     <div class="modal-header">
       <h3>Sun session · ${escapeHTML(fmtTitleDate(start))}</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button type="button" class="modal-close" ${sunSessionActionAttrs('close-modal')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${typeof window !== 'undefined' && window.renderSessionAIDetail ? window.renderSessionAIDetail(sess) : ''}
@@ -371,8 +378,8 @@ export function openSunSessionDetail(id) {
       ` : ''}
 
       <div class="modal-actions" style="margin-top:18px">
-        ${sess.endedAt ? `<button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove();window.editSunSessionDuration('${escapeAttr(sess.id)}')" title="Override the session duration. Use when a re-end on a second device set it wrong, or you forgot to stop on time.">Edit duration</button>` : ''}
-        <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" onclick="this.closest('.modal-overlay').remove();window.deleteSunSession('${escapeAttr(sess.id)}')">Delete session</button>
+        ${sess.endedAt ? `<button type="button" class="import-btn import-btn-secondary" ${sunSessionActionAttrs('edit-duration', { id: sess.id })} title="Override the session duration. Use when a re-end on a second device set it wrong, or you forgot to stop on time.">Edit duration</button>` : ''}
+        <button type="button" class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" ${sunSessionActionAttrs('delete-session', { id: sess.id, closeModal: true })}>Delete session</button>
       </div>
     </div>
   </div>`;
@@ -473,7 +480,7 @@ export function renderChannelChips(doses, sess = null) {
   let html = `<div class="sun-channel-chips">`;
   for (const r of visible) html += chipFor(r);
   if (showAll) {
-    html += `<button class="sun-chip-more" onclick="this.parentElement.classList.toggle('sun-chips-expanded')">+ ${ranked.length - 3} more</button>`;
+    html += `<button type="button" class="sun-chip-more" ${sunSessionActionAttrs('toggle-chips')}>+ ${ranked.length - 3} more</button>`;
     for (const r of ranked.slice(3)) html += chipFor(r, ' sun-chip-extra');
   }
   html += `</div>`;
@@ -510,7 +517,7 @@ export function openDetailedSessionDialog() {
   overlay.innerHTML = `<div class="modal sun-detailed-modal" role="dialog" aria-label="Past session log">
     <div class="modal-header">
       <h3>Log a past session</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button type="button" class="modal-close" ${sunSessionActionAttrs('close-modal')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       <p class="modal-body-hint">For sessions that already happened. Tap each body region that was uncovered.${lastUsed ? ' Body regions, eyewear, and lens tint default to your last session.' : ''}</p>
@@ -573,8 +580,8 @@ export function openDetailedSessionDialog() {
       </label>
 
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
-        <button class="import-btn import-btn-primary" id="det-save">Save session</button>
+        <button type="button" class="import-btn import-btn-secondary" ${sunSessionActionAttrs('close-modal')}>Cancel</button>
+        <button type="button" class="import-btn import-btn-primary" id="det-save">Save session</button>
       </div>
     </div>
   </div>`;
@@ -684,7 +691,7 @@ export function openDetailedSessionDialog() {
   });
 }
 
-// Delete from window for inline onclick
+// User-facing delete entry point shared by delegated UI actions.
 export async function deleteSunSession(id) {
   if (await showConfirmDialog('Delete this sun session?')) {
     await uiDeps.deleteSession(id);
@@ -692,7 +699,7 @@ export async function deleteSunSession(id) {
   }
 }
 
-// ─── Window-backed actions ─────────────────────────────────────────────
+// ─── Session actions ───────────────────────────────────────────────────
 
 // User-facing edit-duration entry point — prompts for a new minutes
 // value, validates the range, calls updateSession (which bumps

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
-  "inlineEventAttributes": 592,
-  "windowReferences": 1915,
+  "inlineEventAttributes": 572,
+  "windowReferences": 1903,
   "largeJsFilesOver800Lines": 28,
-  "maxJsFileLines": 1600
+  "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -306,6 +306,7 @@ const APP_SHELL = [
   '/js/sun-session-model.js',
   '/js/sun-sessions-store.js',
   '/js/sun-session-ui.js',
+  '/js/sun-session-actions.js',
   '/js/sun-body-silhouette.js',
   '/js/sun-ai-analysis.js',
   '/js/sun-context.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -171,6 +171,7 @@ const LEGACY_TESTS = [
   './test-dashboard-widget-delegated-actions.js',
   './test-lens-page-shell-delegated-actions.js',
   './test-light-page-view-delegated-actions.js',
+  './test-sun-session-ui-delegated-actions.js',
   './test-wearables-delegated-actions.js',
   './test-client-list-delegated-actions.js',
   './test-provider-wallet-delegated-actions.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -154,6 +154,7 @@ const pwaAppShellAssets = [
   '/js/sun-session-model.js',
   '/js/sun-sessions-store.js',
   '/js/sun-session-ui.js',
+  '/js/sun-session-actions.js',
   '/js/sun-spectrum.js',
   '/js/sun-uvdata.js',
   '/js/chat-window-bindings.js',

--- a/tests/test-sun-session-ui-delegated-actions.js
+++ b/tests/test-sun-session-ui-delegated-actions.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Static sun-session UI delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const uiSrc = fs.readFileSync(path.join(root, 'js/sun-session-ui.js'), 'utf8');
+const actionSrc = fs.readFileSync(path.join(root, 'js/sun-session-actions.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Sun Session UI Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
+
+assert('sun-session-ui renders no inline event attributes',
+  !inlineHandlerRe.test(uiSrc));
+assert('sun-session-actions defines one shared action attribute helper',
+  (actionSrc.match(/\bfunction\s+sunSessionActionAttrs\b/g) || []).length === 1 &&
+    actionSrc.includes('data-sun-session-action=') &&
+    actionSrc.includes('data-sun-session-${escapeAttr(dataAttrName(name))}=') &&
+    actionSrc.includes("replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)"));
+assert('sun-session-ui imports and installs idempotent action delegates',
+  uiSrc.includes("from './sun-session-actions.js'") &&
+    uiSrc.includes('installSunSessionActionDelegates({') &&
+    actionSrc.includes('const sunSessionActionDelegateRoots = new WeakSet();') &&
+    actionSrc.includes("root.addEventListener('click', event => handleSunSessionClick(event, actions))") &&
+    actionSrc.includes("root.addEventListener('keydown', event => handleSunSessionKeydown(event, actions))"));
+assert('sun-session-actions scopes delegated actions to the installed root',
+  actionSrc.includes('event.currentTarget?.contains(actionEl)'));
+assert('sun-session-actions keyboard delegate supports role-button rows and ignores form controls',
+  actionSrc.includes('const SUN_SESSION_KEYBOARD_ACTIONS = new Set') &&
+    actionSrc.includes("'open-detail'") &&
+    actionSrc.includes("'forgot-stop'") &&
+    actionSrc.includes("'open-channel'") &&
+    actionSrc.includes("event.target?.closest?.('button, a, input, textarea, select')"));
+assert('sun-session-ui direct module actions no longer route through window globals',
+  !uiSrc.includes('window.openSunSessionDetail') &&
+    !uiSrc.includes('window.deleteSunSession') &&
+    !uiSrc.includes('window.editSunSessionDuration'));
+
+[
+  'ignore',
+  'open-detail',
+  'delete-session',
+  'quick-log-sun',
+  'pause-session',
+  'resume-session',
+  'flip-sides',
+  'change-coverage',
+  'apply-sunscreen',
+  'override-ozone',
+  'forgot-stop',
+  'open-channel',
+  'close-modal',
+  'edit-duration',
+  'toggle-chips',
+].forEach(action => {
+  assert(`sun session action ${action} is handled`,
+    actionSrc.includes(`action === '${action}'`));
+});
+
+[
+  "sunSessionActionAttrs('open-detail', { id: sess.id })",
+  "sunSessionActionAttrs('delete-session', { id: sess.id })",
+  "sunSessionActionAttrs('quick-log-sun')",
+  'sunSessionActionAttrs(pauseAction, { id: sess.id })',
+  "sunSessionActionAttrs('flip-sides', { id: sess.id })",
+  "sunSessionActionAttrs('change-coverage', { id: sess.id })",
+  "sunSessionActionAttrs('apply-sunscreen', { id: sess.id })",
+  "sunSessionActionAttrs('forgot-stop', { id: sess.id })",
+  "sunSessionActionAttrs('open-channel', { channel: k })",
+  "sunSessionActionAttrs('edit-duration', { id: sess.id })",
+  "sunSessionActionAttrs('delete-session', { id: sess.id, closeModal: true })",
+  "sunSessionActionAttrs('toggle-chips')",
+].forEach(renderedAction => {
+  assert(`sun-session-ui renders ${renderedAction}`,
+    uiSrc.includes(renderedAction));
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-sun-session-ui-delegated-actions.js
+++ b/tests/test-sun-session-ui-delegated-actions.js
@@ -33,7 +33,8 @@ assert('sun-session-actions defines one shared action attribute helper',
   (actionSrc.match(/\bfunction\s+sunSessionActionAttrs\b/g) || []).length === 1 &&
     actionSrc.includes('data-sun-session-action=') &&
     actionSrc.includes('data-sun-session-${escapeAttr(dataAttrName(name))}=') &&
-    actionSrc.includes("replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)"));
+    actionSrc.includes("replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)") &&
+    actionSrc.includes("value !== false"));
 assert('sun-session-ui imports and installs idempotent action delegates',
   uiSrc.includes("from './sun-session-actions.js'") &&
     uiSrc.includes('installSunSessionActionDelegates({') &&
@@ -48,6 +49,9 @@ assert('sun-session-actions keyboard delegate supports role-button rows and igno
     actionSrc.includes("'forgot-stop'") &&
     actionSrc.includes("'open-channel'") &&
     actionSrc.includes("event.target?.closest?.('button, a, input, textarea, select')"));
+assert('sun-session-actions expands chips via the owning chips container',
+  actionSrc.includes("actionEl.closest('.sun-channel-chips')?.classList.toggle('sun-chips-expanded')") &&
+    !actionSrc.includes("actionEl.parentElement?.classList.toggle('sun-chips-expanded')"));
 assert('sun-session-ui direct module actions no longer route through window globals',
   !uiSrc.includes('window.openSunSessionDetail') &&
     !uiSrc.includes('window.deleteSunSession') &&

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -118,6 +118,27 @@ return (async function() {
     main.querySelector('.light-channels-section') !== null);
   assert('Light page lists at least one session row',
     main.innerHTML.includes(id) || main.innerHTML.includes('30 min') || main.querySelector('.sun-session-row, .sun-sessions-list'));
+  const sunRows = Array.from(main.querySelectorAll('.light-session-sun'));
+  const sunRow = sunRows.find(row => row.dataset.id === id) || sunRows[0];
+  const rowDelete = sunRow?.querySelector('.sun-session-delete');
+  assert('Sun session row uses delegated open-detail action',
+    sunRow?.dataset.sunSessionAction === 'open-detail' &&
+      sunRow?.dataset.sunSessionId === id);
+  assert('Sun session delete uses delegated action',
+    rowDelete?.dataset.sunSessionAction === 'delete-session' &&
+      rowDelete?.dataset.sunSessionId === id);
+  assert('Sun session row and delete control have no inline event attributes',
+    !!sunRow &&
+      !sunRow.hasAttribute('onclick') &&
+      !sunRow.hasAttribute('onkeydown') &&
+      !!rowDelete &&
+      !rowDelete.hasAttribute('onclick'));
+  sunRow?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  await wait(80);
+  const delegatedDetailOverlay = document.querySelector('.sun-detail-modal')?.closest('.modal-overlay');
+  assert('Delegated sun session row click opens detail modal',
+    !!delegatedDetailOverlay);
+  delegatedDetailOverlay?.remove();
 
   // ─── 4. Session detail modal opens + has a working delete button ─────
   console.log('%c 4. Session detail modal ', 'font-weight:bold;color:#6366f1');
@@ -125,30 +146,57 @@ return (async function() {
   if (typeof window.openSunSessionDetail === 'function') {
     window.openSunSessionDetail(id);
     await wait(100);
-    const overlay = document.querySelector('.modal-overlay');
+    let overlay = document.querySelector('.modal-overlay');
     assert('Session detail modal mounts an overlay', !!overlay);
     if (overlay) {
-      // Modal has a Delete button
-      assert('Modal renders a Delete control',
-        /Delete/i.test(overlay.innerHTML),
-        'no "Delete" text found in modal');
-      // Backdrop click closes the modal — recent fix in 8885589
-      // Simulate the backdrop click; the click handler is on the overlay
-      // and only fires when clicked on itself (not bubbled from children).
-      const evt = new MouseEvent('mousedown', { bubbles: true });
-      // Spoof event.target === overlay
-      Object.defineProperty(evt, 'target', { writable: false, value: overlay });
-      overlay.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, target: overlay }));
-      // Some impls bind on click, not mousedown — try click too
-      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      const closeBtn = overlay.querySelector('.sun-detail-modal .modal-close');
+      const channelRow = overlay.querySelector('.sun-detail-channel-row-clickable');
+      const actionButtons = Array.from(overlay.querySelectorAll('.sun-detail-modal .modal-actions button'));
+      const editButton = actionButtons.find(btn => /Edit duration/i.test(btn.textContent || ''));
+      const deleteButton = actionButtons.find(btn => /Delete session/i.test(btn.textContent || ''));
+      assert('Session detail modal renders delegated controls',
+        closeBtn?.dataset.sunSessionAction === 'close-modal' &&
+          channelRow?.dataset.sunSessionAction === 'open-channel' &&
+          channelRow?.dataset.sunSessionChannel === channelRow?.dataset.channel &&
+          editButton?.dataset.sunSessionAction === 'edit-duration' &&
+          editButton?.dataset.sunSessionId === id &&
+          deleteButton?.dataset.sunSessionAction === 'delete-session' &&
+          deleteButton?.dataset.sunSessionId === id &&
+          deleteButton?.dataset.sunSessionCloseModal === 'true');
+      assert('Session detail delegated controls have no inline event attributes',
+        overlay.querySelectorAll('.sun-detail-modal .modal-close[onclick], .sun-detail-channel-row-clickable[onclick], .sun-detail-channel-row-clickable[onkeydown], .sun-detail-modal .modal-actions button[onclick]').length === 0);
+      closeBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
       await wait(60);
-      // Modal still in DOM is OK — different impls keep the node and just
-      // remove .show. Just assert SOMETHING happened (still-mounted is fine
-      // as long as it's not blocking).
-      assert('Backdrop interaction did not throw',
-        true, 'no error firing backdrop events');
-      // Tear down explicitly so the next test gets a clean DOM
-      overlay.remove();
+      assert('Delegated detail close button removes the modal',
+        !document.body.contains(overlay));
+
+      window.openSunSessionDetail(id);
+      await wait(80);
+      overlay = document.querySelector('.modal-overlay');
+      assert('Session detail modal remounts after delegated close', !!overlay);
+      if (overlay) {
+        // Modal has a Delete button
+        assert('Modal renders a Delete control',
+          /Delete/i.test(overlay.innerHTML),
+          'no "Delete" text found in modal');
+        // Backdrop click closes the modal — recent fix in 8885589
+        // Simulate the backdrop click; the click handler is on the overlay
+        // and only fires when clicked on itself (not bubbled from children).
+        const evt = new MouseEvent('mousedown', { bubbles: true });
+        // Spoof event.target === overlay
+        Object.defineProperty(evt, 'target', { writable: false, value: overlay });
+        overlay.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, target: overlay }));
+        // Some impls bind on click, not mousedown — try click too
+        overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await wait(60);
+        // Modal still in DOM is OK — different impls keep the node and just
+        // remove .show. Just assert SOMETHING happened (still-mounted is fine
+        // as long as it's not blocking).
+        assert('Backdrop interaction did not throw',
+          true, 'no error firing backdrop events');
+        // Tear down explicitly so the next test gets a clean DOM
+        overlay.remove();
+      }
     }
   } else {
     assert('window.openSunSessionDetail exists (UI wired)', false,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.336';
+self.APP_VERSION = '1.8.337';


### PR DESCRIPTION
## Summary
- Added `js/sun-session-actions.js` as the delegated action contract for sun session rows, detail modals, active-session controls, and chip expansion.
- Replaced the remaining inline event attributes in `js/sun-session-ui.js` with `data-sun-session-action` attributes while keeping direct module-owned actions off `window.*`.
- Updated PWA precache, cache version, quality baseline, and focused source/browser coverage.

## Validation
- `node --check js/sun-session-ui.js`
- `node --check js/sun-session-actions.js`
- `node tests/test-sun-session-ui-delegated-actions.js`
- `npm run quality`
- `npm test`
- `./run-tests.sh`