### PR TITLE
[codex] Delegate marker detail actions

### DIFF
--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -91,7 +91,7 @@ export function createDashboardViewComposition({
     toggleDashboardQuickMarkerPin,
   } = dashboardWidgetRenderers;
 
-  configureMarkerDetailModal({ navigate, isDashboardQuickMarkerPinned, showEmojiPicker });
+  configureMarkerDetailModal({ navigate, isDashboardQuickMarkerPinned, toggleDashboardQuickMarkerPin, showEmojiPicker });
 
   function getDashboardMarkerWidgetDefinition(widgetId, ctx = null) {
     const markerId = dashboardMarkerIdFromWidgetId(widgetId);

--- a/js/marker-detail-actions.js
+++ b/js/marker-detail-actions.js
@@ -1,0 +1,119 @@
+// marker-detail-actions.js - delegated action contract for marker detail modals.
+
+import { escapeAttr } from './utils.js';
+
+const markerDetailActionDelegateRoots = new WeakSet();
+
+function dataAttrName(name) {
+  return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+export function markerDetailActionAttrs(action, attrs = {}) {
+  return [
+    `data-marker-detail-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '' && value !== false)
+      .map(([name, value]) => `data-marker-detail-${escapeAttr(dataAttrName(name))}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function closestMarkerDetailAction(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return null;
+  const actionEl = target.closest('[data-marker-detail-action]');
+  if (!actionEl) return null;
+  return typeof event.currentTarget?.contains === 'function' && event.currentTarget.contains(actionEl) ? actionEl : null;
+}
+
+function numberAttr(actionEl, name) {
+  const value = Number(actionEl.dataset[name]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function showDetailOptions(actionEl) {
+  const opts = {};
+  if (actionEl.dataset.markerDetailShowAllHistory === 'true') opts.showAllHistory = true;
+  if (actionEl.dataset.markerDetailScrollToHistory === 'true') opts.scrollToHistory = true;
+  const historyLimit = numberAttr(actionEl, 'markerDetailHistoryLimit');
+  if (historyLimit != null) opts.historyLimit = historyLimit;
+  return opts;
+}
+
+function handleMarkerDetailAction(actionEl, event, actions) {
+  const action = actionEl.dataset.markerDetailAction || '';
+  const id = actionEl.dataset.markerDetailId || '';
+  const date = actionEl.dataset.markerDetailDate || '';
+  const dotKey = actionEl.dataset.markerDetailDotKey || '';
+  const type = actionEl.dataset.markerDetailType || '';
+
+  if (action === 'close-modal') {
+    actions.closeModal?.();
+  } else if (action === 'quick-pin') {
+    actions.toggleDashboardQuickMarkerPin?.(id);
+  } else if (action === 'edit-ref-range') {
+    actions.editRefRange?.(id, type, event);
+  } else if (action === 'revert-ref-range') {
+    void actions.revertRefRange?.(id, type);
+  } else if (action === 'rename-marker') {
+    void actions.renameMarker?.(id);
+  } else if (action === 'revert-marker-name') {
+    void actions.revertMarkerName?.(id);
+  } else if (action === 'toggle-history-note') {
+    actionEl.closest('.marker-history-row')?.querySelector('.mv-note-text')?.classList.toggle('show');
+  } else if (action === 'edit-marker-value') {
+    const value = numberAttr(actionEl, 'markerDetailValue');
+    if (value != null) void actions.editMarkerValue?.(id, date, value, event);
+  } else if (action === 'delete-marker-value') {
+    void actions.deleteMarkerValue?.(id, date);
+  } else if (action === 'revert-marker-value') {
+    void actions.revertMarkerValue?.(id, date);
+  } else if (action === 'edit-value-note') {
+    void actions.editValueNote?.(id, date);
+  } else if (action === 'delete-value-note') {
+    void actions.deleteValueNote?.(id, date);
+  } else if (action === 'show-detail-modal') {
+    actions.showDetailModal?.(id, showDetailOptions(actionEl));
+  } else if (action === 'open-manual-entry') {
+    actions.openManualEntryForm?.(id);
+  } else if (action === 'ask-ai') {
+    actions.askAIAboutMarker?.(id);
+  } else if (action === 'toggle-marker-note-editor') {
+    actions.toggleMarkerNoteEditor?.(dotKey);
+  } else if (action === 'save-marker-note') {
+    void actions.saveMarkerNote?.(dotKey, id);
+  } else if (action === 'delete-marker-note') {
+    void actions.deleteMarkerNote?.(dotKey, id);
+  } else if (action === 'delete-custom-marker') {
+    void actions.deleteCustomMarker?.(id);
+  } else if (action === 'save-manual-entry') {
+    void actions.saveManualEntry?.(id);
+  } else if (action === 'save-and-add-manual-entry') {
+    void actions.saveAndAddAnotherManualEntry?.(id);
+  }
+}
+
+function handleMarkerDetailClick(event, actions) {
+  const actionEl = closestMarkerDetailAction(event);
+  if (!actionEl) return;
+  event.preventDefault();
+  event.stopPropagation();
+  handleMarkerDetailAction(actionEl, event, actions);
+}
+
+function handleMarkerDetailKeydown(event, actions) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestMarkerDetailAction(event);
+  if (!actionEl) return;
+  if (event.target?.closest?.('button, a, input, textarea, select')) return;
+  if (actionEl.getAttribute('role') !== 'button') return;
+  event.preventDefault();
+  event.stopPropagation();
+  handleMarkerDetailAction(actionEl, event, actions);
+}
+
+export function installMarkerDetailActionDelegates(actions = {}, root = (typeof document !== 'undefined' ? document : null)) {
+  if (!root || markerDetailActionDelegateRoots.has(root)) return;
+  markerDetailActionDelegateRoots.add(root);
+  root.addEventListener('click', event => handleMarkerDetailClick(event, actions));
+  root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions));
+}

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -10,6 +10,7 @@ import { closeSuggestionsOnClickOutside } from './context-cards.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from './api.js';
 import { deleteEmptyLabEntries, deleteLabEntryMarkerValues } from './lab-entry-mutations.js';
 import { getInsulinMirrorMarkerKey } from './lab-entry.js';
+import { installMarkerDetailActionDelegates, markerDetailActionAttrs } from './marker-detail-actions.js';
 import {
   configureMarkerDetailEditing,
   editRefRange,
@@ -46,6 +47,10 @@ export {
 const markerDetailDeps = {
   navigate: (category, data) => window.navigate?.(category, data),
   isDashboardQuickMarkerPinned: () => false,
+  toggleDashboardQuickMarkerPin: (id) => globalThis.toggleDashboardQuickMarkerPin?.(id),
+  renameMarker: (id) => globalThis.renameMarker?.(id),
+  revertMarkerName: (id) => globalThis.revertMarkerName?.(id),
+  askAIAboutMarker: (id) => globalThis.askAIAboutMarker?.(id),
   showEmojiPicker: () => {},
 };
 
@@ -59,6 +64,31 @@ configureMarkerDetailEditing({
   openManualEntryForm: (...args) => openManualEntryForm(...args),
   closeModal: () => closeModal(),
 });
+
+if (typeof document !== 'undefined') {
+  installMarkerDetailActionDelegates({
+    closeModal,
+    toggleDashboardQuickMarkerPin: (...args) => markerDetailDeps.toggleDashboardQuickMarkerPin(...args),
+    editRefRange,
+    revertRefRange,
+    renameMarker: (...args) => markerDetailDeps.renameMarker(...args),
+    revertMarkerName: (...args) => markerDetailDeps.revertMarkerName(...args),
+    editMarkerValue,
+    deleteMarkerValue,
+    revertMarkerValue,
+    editValueNote,
+    deleteValueNote,
+    showDetailModal,
+    openManualEntryForm,
+    askAIAboutMarker: (...args) => markerDetailDeps.askAIAboutMarker(...args),
+    toggleMarkerNoteEditor,
+    saveMarkerNote,
+    deleteMarkerNote,
+    deleteCustomMarker,
+    saveManualEntry,
+    saveAndAddAnotherManualEntry,
+  });
+}
 
 // Biological-age component inputs. Keep these in sync with the PhenoAge and
 // Bortz Age calculations in data.js so the detail modal can explain exactly
@@ -196,10 +226,9 @@ export async function fetchCustomMarkerDescription(markerId, markerName, unit) {
 }
 
 export function showDetailModal(id, opts = {}) {
-  // id is interpolated into multiple inline-onclick handlers in the modal
-  // body (Add Value, Save/Cancel/Delete note, Ask AI, Delete custom marker).
-  // Reject anything outside the strict allowlist so a poisoned customMarker
-  // key can't break out of the JS string context.
+  // id is interpolated into delegated data-action attributes throughout the
+  // modal body. Reject anything outside the strict allowlist so a poisoned
+  // customMarker key cannot break attribute context or state lookups.
   if (!safeMarkerId(id)) return;
   const data = getActiveData();
   const idx = id.indexOf('_');
@@ -318,10 +347,10 @@ export function showDetailModal(id, opts = {}) {
     const badgeLabel = source === 'manual' ? 'edited' : 'lab';
     const hasLabStash = type === 'optimal' ? 'labOptimalMin' in overrides : 'labRefMin' in overrides;
     const badgeTitle = source === 'manual' ? (hasLabStash ? 'Manually edited — click to revert to lab range' : 'Manually edited — click to revert to default') : 'Custom range from your lab — click to revert to default';
-    const editedBadge = isEdited ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="${badgeTitle}" title="${badgeTitle}" onclick="event.stopPropagation();revertRefRange('${id}','${type}')">${badgeLabel} \u00d7</span>` : '';
+    const editedBadge = isEdited ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="${badgeTitle}" title="${badgeTitle}" ${markerDetailActionAttrs('revert-ref-range', { id, type })}>${badgeLabel} \u00d7</span>` : '';
     const displayMin = min != null ? min : '–';
     const displayMax = max != null ? max : '–';
-    return ` &middot; ${type === 'optimal' ? '<span style="color:var(--green)">' : ''}${label}: <span class="ref-editable" role="button" tabindex="0" aria-label="Edit ${label} range" onclick="editRefRange('${id}','${type}',event)" title="Click to edit">${displayMin} \u2013 ${displayMax}</span>${editedBadge}${type === 'optimal' ? '</span>' : ''}`;
+    return ` &middot; ${type === 'optimal' ? '<span style="color:var(--green)">' : ''}${label}: <span class="ref-editable" role="button" tabindex="0" aria-label="Edit ${label} range" ${markerDetailActionAttrs('edit-ref-range', { id, type })} title="Click to edit">${displayMin} \u2013 ${displayMax}</span>${editedBadge}${type === 'optimal' ? '</span>' : ''}`;
   };
   const isCustom = !!state.importedData?.customMarkers?.[dotKey];
   const hasRef = marker.refMin != null || marker.refMax != null;
@@ -342,8 +371,8 @@ export function showDetailModal(id, opts = {}) {
   const rangeCardControls = rangeInfo ? rangeInfo.replace(/^ &middot; /, '') : '';
   const isRenamed = !!state.importedData?.markerLabels?.[dotKey];
   const renameLink = isRenamed
-    ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Revert renamed marker to original" title="Renamed — click to revert to original" onclick="event.stopPropagation();revertMarkerName('${id}')" style="cursor:pointer">renamed ×</span> <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Rename marker" title="Rename marker" onclick="event.stopPropagation();renameMarker('${id}')" style="cursor:pointer;font-size:12px">rename</span>`
-    : ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Rename marker" title="Rename marker" onclick="event.stopPropagation();renameMarker('${id}')" style="cursor:pointer;font-size:12px">rename</span>`;
+    ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Revert renamed marker to original" title="Renamed — click to revert to original" ${markerDetailActionAttrs('revert-marker-name', { id })} style="cursor:pointer">renamed ×</span> <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Rename marker" title="Rename marker" ${markerDetailActionAttrs('rename-marker', { id })} style="cursor:pointer;font-size:12px">rename</span>`
+    : ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Rename marker" title="Rename marker" ${markerDetailActionAttrs('rename-marker', { id })} style="cursor:pointer;font-size:12px">rename</span>`;
   // Dual-unit summary: render a secondary line under modal-unit when this marker
   // has a UNIT_CONVERSIONS entry AND the per-profile "show alt units" toggle is
   // on (Settings → Display). Mirrors the primary line's ranges in the other
@@ -387,10 +416,10 @@ export function showDetailModal(id, opts = {}) {
         ${altUnitInfo}
       </div>
       <div class="gb-detail-head-actions">
-        <button type="button" class="gb-detail-pin-btn${quickMarkerPinned ? ' is-pinned' : ''}" aria-pressed="${quickMarkerPinned ? 'true' : 'false'}" title="${escapeAttr(quickMarkerPinTitle)}" onclick="window.toggleDashboardQuickMarkerPin('${id}')">${escapeHTML(quickMarkerPinText)}</button>
+        <button type="button" class="gb-detail-pin-btn${quickMarkerPinned ? ' is-pinned' : ''}" aria-pressed="${quickMarkerPinned ? 'true' : 'false'}" title="${escapeAttr(quickMarkerPinTitle)}" ${markerDetailActionAttrs('quick-pin', { id })}>${escapeHTML(quickMarkerPinText)}</button>
         <span class="gb-detail-status gb-detail-status-${escapeAttr(latestStatus)}">${escapeHTML(statusText)}</span>
       </div>
-      <button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>
+      <button class="modal-close" aria-label="Close" ${markerDetailActionAttrs('close-modal')}>&times;</button>
     </div>
     <div class="marker-description" id="marker-desc"></div>
     <div class="gb-detail-summary">
@@ -419,8 +448,9 @@ export function showDetailModal(id, opts = {}) {
     const phaseLabel = marker.phaseLabels && marker.phaseLabels[i];
     const phaseInfo = phaseLabel ? `<div class="mv-phase">${phaseLabel} \u2022 ${formatValue(ri.min)}\u2013${formatValue(ri.max)}</div>` : '';
     const rawDate = marker.singlePoint ? null : data.dates[i];
+    const actionDate = rawDate == null ? 'null' : rawDate;
     const matchingNote = rawDate && state.importedData.notes ? state.importedData.notes.find(n => n.date === rawDate) : null;
-    const noteIcon = matchingNote ? `<button type="button" class="mv-note" onclick="event.stopPropagation();this.parentElement.parentElement.querySelector('.mv-note-text').classList.toggle('show')">Note</button><div class="mv-note-text">${escapeHTML(matchingNote.text)}</div>` : '';
+    const noteIcon = matchingNote ? `<button type="button" class="mv-note" ${markerDetailActionAttrs('toggle-history-note')}>Note</button><div class="mv-note-text">${escapeHTML(matchingNote.text)}</div>` : '';
     const mvKey = dotKey + ':' + rawDate;
     const srcEntry = rawDate ? state.importedData.entries?.find(e => e.date === rawDate) : null;
     const src = srcEntry?.markerSources?.[dotKey];
@@ -429,10 +459,10 @@ export function showDetailModal(id, opts = {}) {
     const isManual = isManualSource || (manualVal !== undefined && manualVal !== null);
     const canRevert = manualVal !== undefined && manualVal !== null && manualVal !== true;
     const manualBadge = canRevert
-      ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Revert manual value to imported value" title="Manual — click to revert to imported value" onclick="event.stopPropagation();revertMarkerValue('${id}','${rawDate}')">manual \u00d7</span>`
+      ? ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Revert manual value to imported value" title="Manual — click to revert to imported value" ${markerDetailActionAttrs('revert-marker-value', { id, date: actionDate })}>manual \u00d7</span>`
       : isManual ? ' <span class="ref-edited-badge" title="Manually entered">manual</span>' : '';
-    const deleteBtn = `<button class="mv-delete" onclick="event.stopPropagation();deleteMarkerValue('${id}','${rawDate}')" title="Remove this value">&times;</button>`;
-    const editClick = rawDate ? ` onclick="event.stopPropagation();editMarkerValue('${id}','${rawDate}',${v},event)" title="Click to edit" style="cursor:pointer"` : '';
+    const deleteBtn = `<button class="mv-delete" ${markerDetailActionAttrs('delete-marker-value', { id, date: actionDate })} title="Remove this value">&times;</button>`;
+    const editAction = rawDate ? ` ${markerDetailActionAttrs('edit-marker-value', { id, date: actionDate, value: v })} role="button" tabindex="0" title="Click to edit" style="cursor:pointer"` : '';
     // Provenance: which file imported this value
     let sourceHtml = '';
     if (rawDate) {
@@ -454,14 +484,14 @@ export function showDetailModal(id, opts = {}) {
     const valueNote = rawDate ? state.importedData.markerValueNotes?.[mvKey] : null;
     const valueNoteHtml = rawDate
       ? (valueNote
-          ? `<div class="mv-value-note has-note"><span class="mv-value-note-text" role="button" tabindex="0" title="Click to edit note" onclick="event.stopPropagation();editValueNote('${id}','${rawDate}')">${escapeHTML(valueNote)}</span> <button class="mv-value-note-delete" title="Remove note" onclick="event.stopPropagation();deleteValueNote('${id}','${rawDate}')">&times;</button></div>`
-          : `<div class="mv-value-note add-note" role="button" tabindex="0" title="Add a note for this value" onclick="event.stopPropagation();editValueNote('${id}','${rawDate}')">+ note</div>`)
+          ? `<div class="mv-value-note has-note"><span class="mv-value-note-text" role="button" tabindex="0" title="Click to edit note" ${markerDetailActionAttrs('edit-value-note', { id, date: actionDate })}>${escapeHTML(valueNote)}</span> <button class="mv-value-note-delete" title="Remove note" ${markerDetailActionAttrs('delete-value-note', { id, date: actionDate })}>&times;</button></div>`
+          : `<div class="mv-value-note add-note" role="button" tabindex="0" title="Add a note for this value" ${markerDetailActionAttrs('edit-value-note', { id, date: actionDate })}>+ note</div>`)
       : '';
     const altVal = (hasConv && state.showAltUnits) ? getAlternateUnit(dotKey, v, isUSMode) : null;
     const altLine = altVal ? `<div class="mv-alt" title="Same value, alternate unit">≈ ${formatValue(altVal.value)} ${escapeHTML(altVal.unit)}</div>` : '';
     html += `<div class="modal-value-card marker-history-row status-${s}">${deleteBtn}
       <div class="marker-history-date-row"><div class="mv-date">${dates[i]}${noteIcon}</div>${sourceHtml}</div>
-      <div class="marker-history-value-row"><div class="mv-value val-${s}"${editClick}>${formatValue(v)}${manualBadge}</div><div class="mv-status val-${s}">${sl}</div></div>
+      <div class="marker-history-value-row"><div class="mv-value val-${s}"${editAction}>${formatValue(v)}${manualBadge}</div><div class="mv-status val-${s}">${sl}</div></div>
       ${altLine}${phaseInfo}${valueNoteHtml}</div>`;
   }
   html += `</div>`;
@@ -475,9 +505,9 @@ export function showDetailModal(id, opts = {}) {
     const historyButtonLabel = showAllHistory
       ? `Show ${showCount} older ${showCount === 1 ? 'value' : 'values'}`
       : `View more history (${modalPoints.length} values)`;
-    html += `<button class="light-sessions-show-more marker-history-show-more" onclick="event.stopPropagation();showDetailModal('${id}', { showAllHistory: true, historyLimit: ${nextHistoryLimit}, scrollToHistory: true })">${historyButtonLabel}</button>`;
+    html += `<button class="light-sessions-show-more marker-history-show-more" ${markerDetailActionAttrs('show-detail-modal', { id, showAllHistory: true, historyLimit: nextHistoryLimit, scrollToHistory: true })}>${historyButtonLabel}</button>`;
   } else if (showAllHistory && modalPoints.length > MARKER_HISTORY_DEFAULT_CAP) {
-    html += `<button class="light-sessions-show-more marker-history-show-more" onclick="event.stopPropagation();showDetailModal('${id}', { scrollToHistory: true })">Show last ${MARKER_HISTORY_DEFAULT_CAP} values</button>`;
+    html += `<button class="light-sessions-show-more marker-history-show-more" ${markerDetailActionAttrs('show-detail-modal', { id, scrollToHistory: true })}>Show last ${MARKER_HISTORY_DEFAULT_CAP} values</button>`;
   }
   const nonNull = modalPoints;
   if (nonNull.length >= 2) {
@@ -646,20 +676,20 @@ export function showDetailModal(id, opts = {}) {
   const _inlineSNPs = (state.importedData.genetics?.snps && window._getRelevantSNPs) ? window._getRelevantSNPs(dotKey) : [];
   html += `<div class="gb-detail-actions">
     <div class="gb-detail-action-row">
-      <button class="manual-entry-btn" onclick="event.stopPropagation();openManualEntryForm('${id}')">+ Add Value Manually</button>
-      <button class="ask-ai-btn" onclick="event.stopPropagation();askAIAboutMarker('${id}')">Ask AI</button>
+      <button class="manual-entry-btn" ${markerDetailActionAttrs('open-manual-entry', { id })}>+ Add Value Manually</button>
+      <button class="ask-ai-btn" ${markerDetailActionAttrs('ask-ai', { id })}>Ask AI</button>
     </div>`;
   // Marker note
   const markerNote = state.importedData.markerNotes?.[dotKey] || '';
   html += `<div class="marker-note-section">
-    <div class="marker-note-header"><span class="marker-note-label">Note</span><button class="marker-note-edit-btn" onclick="event.stopPropagation();toggleMarkerNoteEditor('${dotKey}')">${markerNote ? 'Edit' : '+ Add note'}</button></div>
+    <div class="marker-note-header"><span class="marker-note-label">Note</span><button class="marker-note-edit-btn" ${markerDetailActionAttrs('toggle-marker-note-editor', { dotKey })}>${markerNote ? 'Edit' : '+ Add note'}</button></div>
     ${markerNote ? `<div class="marker-note-text">${escapeHTML(markerNote)}</div>` : ''}
     <div class="marker-note-editor" id="marker-note-editor" style="display:none">
       <textarea id="marker-note-input" placeholder="Your notes about this marker (e.g. why it's high, what to watch for, what you've learned...)" rows="3">${escapeHTML(markerNote)}</textarea>
       <div class="marker-note-actions">
-        <button class="import-btn import-btn-primary" onclick="event.stopPropagation();saveMarkerNote('${dotKey}','${id}')">Save</button>
-        <button class="import-btn import-btn-secondary" onclick="event.stopPropagation();toggleMarkerNoteEditor('${dotKey}')">Cancel</button>
-        ${markerNote ? `<button class="import-btn import-btn-secondary" style="color:var(--red)" onclick="event.stopPropagation();deleteMarkerNote('${dotKey}','${id}')">Delete</button>` : ''}
+        <button class="import-btn import-btn-primary" ${markerDetailActionAttrs('save-marker-note', { dotKey, id })}>Save</button>
+        <button class="import-btn import-btn-secondary" ${markerDetailActionAttrs('toggle-marker-note-editor', { dotKey })}>Cancel</button>
+        ${markerNote ? `<button class="import-btn import-btn-secondary" style="color:var(--red)" ${markerDetailActionAttrs('delete-marker-note', { dotKey, id })}>Delete</button>` : ''}
 	      </div>
 	    </div>
 	  </div>`;
@@ -670,7 +700,7 @@ export function showDetailModal(id, opts = {}) {
   html += `</div>`;
   // Show delete link for custom markers only
   if (state.importedData?.customMarkers?.[dotKey]) {
-    html += `<div style="text-align:center;margin-top:8px"><a href="#" style="color:var(--text-muted);font-size:0.8rem" onclick="event.preventDefault();event.stopPropagation();deleteCustomMarker('${id}')">Delete this marker</a></div>`;
+    html += `<div style="text-align:center;margin-top:8px"><a href="#" style="color:var(--text-muted);font-size:0.8rem" ${markerDetailActionAttrs('delete-custom-marker', { id })}>Delete this marker</a></div>`;
   }
   modal.innerHTML = html;
   overlay.classList.add("show");
@@ -782,7 +812,7 @@ export function openManualEntryForm(id, prefillDate) {
         <div class="gb-modal-kicker">${escapeHTML(data.categories[catKey]?.label || catKey)}</div>
         <div class="gb-modal-title">Add Value Manually</div>
       </div>
-      <button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>
+      <button class="modal-close" aria-label="Close" ${markerDetailActionAttrs('close-modal')}>&times;</button>
     </div>
     <div class="gb-form-body">
     <div class="modal-unit"><strong>${escapeHTML(marker.name)}</strong> \u00b7 ${escapeHTML(marker.unit)}${refText ? ' \u00b7 ' + refText : ''}</div>
@@ -800,9 +830,9 @@ export function openManualEntryForm(id, prefillDate) {
         <textarea id="me-note" rows="2" placeholder="Context for this value — e.g. fasted 14h, post-workout, different lab, retake of low value..."></textarea>
       </div>
       <div class="gb-form-actions">
-        <button class="import-btn import-btn-primary" onclick="saveManualEntry('${id}')">Save</button>
-        <button class="import-btn import-btn-secondary" onclick="saveAndAddAnotherManualEntry('${id}')" title="Save this value, then enter another marker for the same date">Save &amp; Add Another</button>
-        <button class="import-btn import-btn-secondary" onclick="showDetailModal('${id}')">Cancel</button>
+        <button class="import-btn import-btn-primary" ${markerDetailActionAttrs('save-manual-entry', { id })}>Save</button>
+        <button class="import-btn import-btn-secondary" ${markerDetailActionAttrs('save-and-add-manual-entry', { id })} title="Save this value, then enter another marker for the same date">Save &amp; Add Another</button>
+        <button class="import-btn import-btn-secondary" ${markerDetailActionAttrs('show-detail-modal', { id })}>Cancel</button>
       </div>
     </div>
     </div>`;
@@ -837,7 +867,7 @@ export function openCreateMarkerModal() {
         <div class="gb-modal-kicker">Custom marker</div>
         <div class="gb-modal-title">Create New Biomarker</div>
       </div>
-      <button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>
+      <button class="modal-close" aria-label="Close" ${markerDetailActionAttrs('close-modal')}>&times;</button>
     </div>
     <div class="gb-form-body">
     <div class="manual-entry-form">
@@ -880,7 +910,7 @@ export function openCreateMarkerModal() {
       </div>
       <div class="gb-form-actions">
         <button class="import-btn import-btn-primary" onclick="saveCustomMarker()">Create</button>
-        <button class="import-btn import-btn-secondary" onclick="closeModal()">Cancel</button>
+        <button class="import-btn import-btn-secondary" ${markerDetailActionAttrs('close-modal')}>Cancel</button>
       </div>
     </div>
     </div>`;

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
-  "inlineEventAttributes": 572,
-  "windowReferences": 1903,
+  "inlineEventAttributes": 543,
+  "windowReferences": 1902,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -175,6 +175,7 @@ const APP_SHELL = [
   '/js/category-customization.js',
   '/js/commit-hash.js',
   '/js/marker-detail-modal.js',
+  '/js/marker-detail-actions.js',
   '/js/marker-detail-editing.js',
   '/js/marker-detail-store.js',
   '/js/light-conditions-now.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -172,6 +172,7 @@ const LEGACY_TESTS = [
   './test-lens-page-shell-delegated-actions.js',
   './test-light-page-view-delegated-actions.js',
   './test-sun-session-ui-delegated-actions.js',
+  './test-marker-detail-delegated-actions.js',
   './test-wearables-delegated-actions.js',
   './test-client-list-delegated-actions.js',
   './test-provider-wallet-delegated-actions.js',

--- a/tests/test-manual-entry-flow.js
+++ b/tests/test-manual-entry-flow.js
@@ -97,7 +97,7 @@ console.log('=== Manual Entry Flow Tests ===\n');
   assert('Clickable manual badge reverts to imported value when original exists',
     /manual \\u00d7/.test(markerDetailSrc) &&
     /Revert manual value to imported value/.test(markerDetailSrc) &&
-    /revertMarkerValue\('\$\{id\}','\$\{rawDate\}'\)/.test(markerDetailSrc));
+    markerDetailSrc.includes("markerDetailActionAttrs('revert-marker-value', { id, date: actionDate })"));
   assert('Manual badge reads mirrored insulin original before falling back to plain manual state',
     /function getManualValueForMarker\(dotKey, date\)[\s\S]{0,800}getInsulinMirrorMarkerKey\(dotKey\)/.test(markerDetailSrc) &&
     /map\[key\] != null && map\[key\] !== true/.test(markerDetailSrc) &&
@@ -116,8 +116,8 @@ console.log('=== Manual Entry Flow Tests ===\n');
     /if \(keepOpen\)\s*\{[\s\S]{0,200}markerDetailDeps\.navigate\(navCat\)/.test(markerDetailEditingSrc));
   assert('Save & Add Another button rendered in form actions',
     /Save\s*&amp;\s*Add Another|Save & Add Another/.test(markerDetailSrc));
-  assert('Save & Add Another button onclick calls saveAndAddAnotherManualEntry',
-    /onclick="saveAndAddAnotherManualEntry\('\$\{id\}'\)"/.test(markerDetailSrc));
+  assert('Save & Add Another button delegates to saveAndAddAnotherManualEntry',
+    markerDetailSrc.includes("markerDetailActionAttrs('save-and-add-manual-entry', { id })"));
 
   // ═══════════════════════════════════════
   // 5. Session-remembered last date

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Static marker-detail delegated-action source guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const modalSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
+const actionSrc = fs.readFileSync(path.join(root, 'js/marker-detail-actions.js'), 'utf8');
+const dashboardSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
+const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Marker Detail Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/g;
+const inlineHandlers = modalSrc.match(inlineHandlerRe) || [];
+
+assert('marker-detail-modal only keeps the custom marker creation form inline handlers',
+  inlineHandlers.length === 3 &&
+    modalSrc.includes('onchange="document.getElementById') &&
+    modalSrc.includes('onclick="pickNewCatIcon(this)"') &&
+    modalSrc.includes('onclick="saveCustomMarker()"'),
+  `found ${inlineHandlers.length}`);
+assert('marker-detail-modal imports and installs the delegated action helper',
+  modalSrc.includes("from './marker-detail-actions.js'") &&
+    modalSrc.includes('installMarkerDetailActionDelegates({') &&
+    modalSrc.includes('markerDetailActionAttrs'));
+assert('marker-detail-actions defines one shared action attribute helper',
+  (actionSrc.match(/\bfunction\s+markerDetailActionAttrs\b/g) || []).length === 1 &&
+    actionSrc.includes('data-marker-detail-action=') &&
+    actionSrc.includes('data-marker-detail-${escapeAttr(dataAttrName(name))}=') &&
+    actionSrc.includes("replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)") &&
+    actionSrc.includes("value !== false"));
+assert('marker-detail-actions installs idempotent click and keyboard delegates',
+  actionSrc.includes('const markerDetailActionDelegateRoots = new WeakSet();') &&
+    actionSrc.includes("root.addEventListener('click', event => handleMarkerDetailClick(event, actions))") &&
+    actionSrc.includes("root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions))"));
+assert('marker-detail delegated actions are scoped to the installed root',
+  actionSrc.includes("event.currentTarget.contains(actionEl)"));
+assert('marker-detail keyboard delegate supports role-button spans and ignores form controls',
+  actionSrc.includes("event.target?.closest?.('button, a, input, textarea, select')") &&
+    actionSrc.includes("actionEl.getAttribute('role') !== 'button'"));
+assert('history note toggle no longer depends on brittle parentElement chaining',
+  actionSrc.includes("actionEl.closest('.marker-history-row')?.querySelector('.mv-note-text')?.classList.toggle('show')") &&
+    !modalSrc.includes("this.parentElement.parentElement.querySelector('.mv-note-text')"));
+assert('dashboard passes the quick-marker pin dependency instead of relying on an inline window handler',
+  dashboardSrc.includes('toggleDashboardQuickMarkerPin, showEmojiPicker') &&
+    modalSrc.includes("markerDetailActionAttrs('quick-pin', { id })"));
+assert('service worker precaches marker-detail-actions.js',
+  swSrc.includes("'/js/marker-detail-actions.js'"));
+
+[
+  'close-modal',
+  'quick-pin',
+  'edit-ref-range',
+  'revert-ref-range',
+  'rename-marker',
+  'revert-marker-name',
+  'toggle-history-note',
+  'edit-marker-value',
+  'delete-marker-value',
+  'revert-marker-value',
+  'edit-value-note',
+  'delete-value-note',
+  'show-detail-modal',
+  'open-manual-entry',
+  'ask-ai',
+  'toggle-marker-note-editor',
+  'save-marker-note',
+  'delete-marker-note',
+  'delete-custom-marker',
+  'save-manual-entry',
+  'save-and-add-manual-entry',
+].forEach(action => {
+  assert(`marker detail action ${action} is handled`,
+    actionSrc.includes(`action === '${action}'`));
+});
+
+[
+  "markerDetailActionAttrs('revert-ref-range', { id, type })",
+  "markerDetailActionAttrs('edit-ref-range', { id, type })",
+  "markerDetailActionAttrs('revert-marker-name', { id })",
+  "markerDetailActionAttrs('rename-marker', { id })",
+  "markerDetailActionAttrs('quick-pin', { id })",
+  "markerDetailActionAttrs('close-modal')",
+  "markerDetailActionAttrs('toggle-history-note')",
+  "markerDetailActionAttrs('delete-marker-value', { id, date: actionDate })",
+  "markerDetailActionAttrs('edit-marker-value', { id, date: actionDate, value: v })",
+  "markerDetailActionAttrs('edit-value-note', { id, date: actionDate })",
+  "markerDetailActionAttrs('delete-value-note', { id, date: actionDate })",
+  "markerDetailActionAttrs('show-detail-modal', { id, showAllHistory: true, historyLimit: nextHistoryLimit, scrollToHistory: true })",
+  "markerDetailActionAttrs('open-manual-entry', { id })",
+  "markerDetailActionAttrs('ask-ai', { id })",
+  "markerDetailActionAttrs('toggle-marker-note-editor', { dotKey })",
+  "markerDetailActionAttrs('save-marker-note', { dotKey, id })",
+  "markerDetailActionAttrs('delete-marker-note', { dotKey, id })",
+  "markerDetailActionAttrs('delete-custom-marker', { id })",
+  "markerDetailActionAttrs('save-manual-entry', { id })",
+  "markerDetailActionAttrs('save-and-add-manual-entry', { id })",
+].forEach(renderedAction => {
+  assert(`marker-detail-modal renders ${renderedAction}`,
+    modalSrc.includes(renderedAction));
+});
+
+[
+  'openManualEntryForm',
+  'askAIAboutMarker',
+  'deleteMarkerValue',
+  'editMarkerValue',
+  'editValueNote',
+  'deleteValueNote',
+  'toggleMarkerNoteEditor',
+  'saveMarkerNote',
+  'deleteMarkerNote',
+  'saveManualEntry',
+  'saveAndAddAnotherManualEntry',
+  'deleteCustomMarker',
+].forEach(fnName => {
+  assert(`marker-detail-modal has no inline onclick ${fnName} call`,
+    !modalSrc.includes(`onclick="${fnName}`) &&
+      !modalSrc.includes(`onclick="event.stopPropagation();${fnName}`) &&
+      !modalSrc.includes(`onclick="event.preventDefault();event.stopPropagation();${fnName}`));
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-marker-value-notes.js
+++ b/tests/test-marker-value-notes.js
@@ -114,9 +114,9 @@ const state = (await import('../js/state.js')).state;
     /export async function editValueNote\(id, date\)/.test(markerDetailEditingSrc));
   assert('deleteValueNote handler exported',
     /export async function deleteValueNote\(id, date\)/.test(markerDetailEditingSrc));
-  assert('editValueNote bound to window for inline onclicks',
+  assert('editValueNote remains exported for delegated value-note actions',
     /editValueNote,\s*$/m.test(viewsSrc) || viewsSrc.includes('editValueNote,'));
-  assert('deleteValueNote bound to window for inline onclicks',
+  assert('deleteValueNote remains exported for delegated value-note actions',
     viewsSrc.includes('deleteValueNote,'));
   assert('editValueNote re-renders the detail modal on save',
     /editValueNote[\s\S]{0,1500}showDetailModal\(id\)/.test(markerDetailEditingSrc));
@@ -196,9 +196,9 @@ const state = (await import('../js/state.js')).state;
   assert('Empty card shows "+ note" hint',
     /mv-value-note add-note[\s\S]{0,200}\+ note/.test(markerDetailSrc));
   assert('Populated card has × delete button',
-    /mv-value-note-delete[\s\S]{0,400}deleteValueNote\('/.test(markerDetailSrc));
-  assert('Inline onclicks stopPropagation so cell-edit doesn\'t fire',
-    /event\.stopPropagation\(\);editValueNote\('/.test(markerDetailSrc));
+    /mv-value-note-delete[\s\S]{0,400}markerDetailActionAttrs\('delete-value-note'/.test(markerDetailSrc));
+  assert('Value-note actions use delegated click handling so cell-edit does not fire',
+    markerDetailSrc.includes("markerDetailActionAttrs('edit-value-note', { id, date: actionDate })"));
 
   // ═══════════════════════════════════════
   // 8. AI context emission — section:markerValueNotes

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -616,12 +616,12 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       && /marker-history-row/.test(markerDetailSrc)
       && /gb-detail-actions/.test(markerDetailSrc)
       && !/&#128221;/.test(markerDetailSrc));
-    assert('marker-detail-modal.js: marker modal history defaults to last three with inline expansion',
+    assert('marker-detail-modal.js: marker modal history defaults to last three with delegated expansion',
       /MARKER_HISTORY_DEFAULT_CAP\s*=\s*3/.test(markerDetailSrc)
       && /MARKER_HISTORY_EXPANDED_CAP\s*=\s*40/.test(markerDetailSrc)
       && /modalPoints\.slice\(-MARKER_HISTORY_DEFAULT_CAP\)/.test(markerDetailSrc)
       && /modalPoints\.slice\(-expandedHistoryLimit\)/.test(markerDetailSrc)
-      && /historyLimit:\s*\$\{nextHistoryLimit\}/.test(markerDetailSrc)
+      && /markerDetailActionAttrs\('show-detail-modal', \{ id, showAllHistory: true, historyLimit: nextHistoryLimit, scrollToHistory: true \}\)/.test(markerDetailSrc)
       && /View more history \(\$\{modalPoints\.length\} values\)/.test(markerDetailSrc)
       && /Show \$\{showCount\} older/.test(markerDetailSrc)
       && /Show last \$\{MARKER_HISTORY_DEFAULT_CAP\} values/.test(markerDetailSrc));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.337';
+self.APP_VERSION = '1.8.338';


### PR DESCRIPTION
## Summary
- Added a small `marker-detail-actions.js` delegated action contract for marker detail modals.
- Replaced marker detail/history/note/manual-entry inline handlers with data-action attributes, leaving the custom marker creation form slice untouched.
- Wired quick-marker pinning through the modal dependency object and precached the new module.
- Updated source guards, quality baseline, and app version.

## Quality Movement
- Inline event attributes: `572 -> 543` (`-29`)
- `window.*` references: `1903 -> 1902` (`-1`)
- Large JS files >=800 lines: `28 -> 28` (unchanged)
- Largest JS file cap: `1513 -> 1513` (unchanged)

## Validation
- `npm run quality`
- `npm test`
- `./run-tests.sh`
- `git diff --check`