### PR TITLE
[codex] Fix Fitbit live redirect URI

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -306,12 +306,10 @@ export const ADAPTERS = [
       // character-for-character.
       clientId: '23VBN8',
       redirectUris: [
-        'https://app.getbased.health/app',
-        'https://app.getbased.health/',
+        'https://app.getbased.health',
+        'http://localhost:8000/app',
         'https://getbased.health/app',
         'https://beta.getbased.health/',
-        'https://beta.getbased.health/app',
-        'http://localhost:8000/app',
       ],
       scopes: ['profile', 'activity', 'heartrate', 'sleep', 'oxygen_saturation', 'respiratory_rate', 'temperature', 'weight'],
       pkce: true,

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1009,10 +1009,13 @@ assert('Fitbit scopes include temperature + weight (for skin Δ + scale readings
 assert('Fitbit adapter scope list matches DEFAULT_FITBIT_SCOPES (no drift)',
   JSON.stringify([...fitbitReg.oauth.scopes].sort()) ===
   JSON.stringify([...fitbitAuth.DEFAULT_FITBIT_SCOPES].sort()));
-assert('Fitbit hosted /app route is registered before origin fallback',
-  fitbitReg.oauth.redirectUris.includes('https://app.getbased.health/app'));
-assert('Fitbit redirect picker keeps hosted /app instead of falling back to origin root',
-  fitbitAuth.pickRedirectUri(fitbitReg.oauth.redirectUris, { origin: 'https://app.getbased.health', pathname: '/app' }) === 'https://app.getbased.health/app');
+assert('Fitbit hosted redirect matches dev-console value exactly',
+  fitbitReg.oauth.redirectUris.includes('https://app.getbased.health'));
+assert('Fitbit redirect picker uses exact registered live-host URI without adding slash or /app',
+  fitbitAuth.pickRedirectUri(fitbitReg.oauth.redirectUris, { origin: 'https://app.getbased.health', pathname: '/app' }) === 'https://app.getbased.health');
+assert('Fitbit redirect registry does not include unregistered hosted /app or slash variants',
+  !fitbitReg.oauth.redirectUris.includes('https://app.getbased.health/app') &&
+  !fitbitReg.oauth.redirectUris.includes('https://app.getbased.health/'));
 
 const fbUrl = await fitbitAuth.buildAuthorizeUrl({
   clientId: 'fb-test-client', redirectUri: 'http://localhost:8000/app',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.343';
+self.APP_VERSION = '1.8.344';


### PR DESCRIPTION
## Summary
- send the exact Fitbit dev-console redirect URI for the live app: `https://app.getbased.health`
- remove unregistered hosted variants `https://app.getbased.health/` and `https://app.getbased.health/app` from the Fitbit registry
- keep localhost, `getbased.health/app`, and beta redirect entries aligned with the configured Fitbit account
- bump `version.js` to invalidate the cached adapter registry

## Validation
- `node tests/test-wearables.js`
- `git diff --check`
- confirmed `https://app.getbased.health` returns the app shell for the callback target