### PR TITLE
[codex] Add JavaScript typecheck baseline

### DIFF
--- a/js/profile-share.js
+++ b/js/profile-share.js
@@ -1,3 +1,4 @@
+// @ts-check
 // profile-share.js — encrypted single-profile share links
 
 import { state } from './state.js';
@@ -328,6 +329,14 @@ function getProfileShareRecords(profileId = state.currentProfile) {
   return readShareRecords().filter(record => record.profileId === profileId);
 }
 
+/**
+ * @typedef {Object} CreateProfileShareOptions
+ * @property {string=} profileId
+ * @property {string=} password
+ * @property {number|string=} expiresDays
+ */
+
+/** @param {CreateProfileShareOptions} [options] */
 export async function createProfileShare({ profileId = state.currentProfile, password, expiresDays = 7 } = {}) {
   const secret = validateSharePassword(password);
   const id = createProfileShareId();
@@ -547,7 +556,8 @@ function renderProfileShareShell({ title, kicker = 'Share Profile', body }) {
   `);
   const overlay = document.getElementById(SHARE_OVERLAY_ID);
   installProfileShareDelegates(overlay);
-  overlay?.querySelector('input, button, select')?.focus();
+  const firstControl = /** @type {HTMLElement | null} */ (overlay?.querySelector('input, button, select'));
+  firstControl?.focus();
 }
 
 export function openProfileShareModal(profileId = state.currentProfile) {
@@ -573,8 +583,10 @@ export function openSharedProfileImportModal(id) {
 async function handleCreateSubmit(form) {
   const overlay = document.getElementById(SHARE_OVERLAY_ID);
   const profileId = form.dataset.profileId || state.currentProfile;
-  const password = form.querySelector('#profile-share-password')?.value || '';
-  const expiresDays = form.querySelector('#profile-share-expires')?.value || 7;
+  const passwordInput = /** @type {HTMLInputElement | null} */ (form.querySelector('#profile-share-password'));
+  const expiresInput = /** @type {HTMLSelectElement | null} */ (form.querySelector('#profile-share-expires'));
+  const password = passwordInput?.value || '';
+  const expiresDays = expiresInput?.value || 7;
   try {
     setBusy(overlay, true, 'Creating...');
     setStatus('Encrypting profile and creating link...', 'info');
@@ -601,7 +613,8 @@ async function handleCreateSubmit(form) {
 async function handleLoadSubmit(form) {
   const overlay = document.getElementById(SHARE_OVERLAY_ID);
   const id = form.dataset.shareId || '';
-  const password = form.querySelector('#profile-share-load-password')?.value || '';
+  const passwordInput = /** @type {HTMLInputElement | null} */ (form.querySelector('#profile-share-load-password'));
+  const password = passwordInput?.value || '';
   try {
     setBusy(overlay, true, 'Loading...');
     setStatus('Fetching encrypted profile...', 'info');
@@ -671,11 +684,11 @@ function installProfileShareDelegates(overlay) {
       closeProfileShareModal();
     } else if (action === 'regenerate') {
       event.preventDefault();
-      const input = document.getElementById('profile-share-password');
+      const input = /** @type {HTMLInputElement | null} */ (document.getElementById('profile-share-password'));
       if (input) input.value = generateProfileSharePassword();
     } else if (action === 'copy') {
       event.preventDefault();
-      const target = document.getElementById(actionEl.dataset.copyTarget || '');
+      const target = /** @type {HTMLInputElement | HTMLTextAreaElement | null} */ (document.getElementById(actionEl.dataset.copyTarget || ''));
       copyText(actionEl.dataset.copyValue || target?.value || '', actionEl.dataset.copyLabel || 'Copied');
     } else if (action === 'delete-link') {
       event.preventDefault();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^25.0.1",
         "puppeteer": "^24.42.0",
+        "typescript": "^6.0.3",
         "vite": "^8.0.10",
         "vitest": "^4.1.6"
       }
@@ -2883,6 +2884,20 @@
       "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici": {
       "version": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "dev-server": "node dev-server.js",
     "quality": "node scripts/quality-guardrails.mjs",
     "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json",
     "test:watch": "vitest"
   },
   "devDependencies": {
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^25.0.1",
     "puppeteer": "^24.42.0",
+    "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.6"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "strict": false
+  },
+  "include": [
+    "js/profile-share.js",
+    "types/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
     "checkJs": false,
     "noEmit": true,
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "strict": false

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,0 +1,5 @@
+declare const Buffer: {
+  from(value: ArrayBuffer | ArrayLike<number> | string, encoding?: string): {
+    toString(encoding?: string): string;
+  };
+};

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.358';
+self.APP_VERSION = '1.8.359';


### PR DESCRIPTION
## Summary
- Add TypeScript as a dev dependency with a `npm run typecheck` script.
- Add a narrow `tsconfig.json` baseline that checks the profile-sharing module through `@ts-check` without changing the app runtime or adding a build step.
- Add small JSDoc/DOM narrowing in `js/profile-share.js` and bump `version.js` for cache invalidation.

## Why
This starts the TypeScript runway as checkable JavaScript first, keeping the current static ES module architecture intact while catching contract drift in a high-risk shared workflow.

## Validation
- `npm run typecheck`
- `node tests/test-profile-share.js`
- `node tests/test-changelog.js`
- `npm test`