### PR TITLE
[codex] Run typecheck in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run typecheck
+        run: npm run typecheck
+
       - name: Cache Puppeteer Chromium
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary
- Add `npm run typecheck` as a dedicated step in the main CI workflow.

## Why
The JavaScript typecheck baseline is now enforced on PRs and pushes to `main`, so typed modules cannot silently drift without breaking CI.

## Validation
- `npm run typecheck`