### PR TITLE
[codex] Typecheck export boundary

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -1,7 +1,8 @@
+// @ts-check
 // export.js — PDF report, JSON export/import, clear all data
 
 import { state } from './state.js';
-import { getStatus, formatValue, showNotification, showConfirmDialog, getTrend, escapeHTML, escapeAttr } from './utils.js';
+import { getStatus, formatValue, showNotification, showConfirmDialog, getTrend, escapeHTML, escapeAttr, isDebugMode } from './utils.js';
 import { getActiveData, saveImportedData } from './data.js';
 import { getAllFlaggedMarkers, getEffectiveRange } from './marker-analysis.js';
 import { getProfiles, profileStorageKey, createProfile, updateProfileMeta, loadProfile, saveProfiles, migrateProfileData, getProfileHeight } from './profile.js';
@@ -1535,7 +1536,10 @@ export function openReportBuilder(presetId = DEFAULT_REPORT_PRESET) {
   closeReportBuilder();
   installReportBuilderDelegates();
   document.body.insertAdjacentHTML('beforeend', renderReportBuilder(normalizedPresetId));
-  setTimeout(() => document.querySelector(`#${REPORT_BUILDER_OVERLAY_ID} .report-preset-btn.active`)?.focus(), 0);
+  setTimeout(() => {
+    const activePreset = /** @type {HTMLElement | null} */ (document.querySelector(`#${REPORT_BUILDER_OVERLAY_ID} .report-preset-btn.active`));
+    activePreset?.focus();
+  }, 0);
 }
 
 export function closeReportBuilder() {
@@ -1599,10 +1603,46 @@ async function _importChatData(profileId, chat) {
 
 // ═══════════════════════════════════════════════
 // Legacy alias — calls exportClientJSON for the active profile
+/**
+ * @typedef {Object} ClientExportProfile
+ * @property {string} name
+ * @property {string | null} sex
+ * @property {string | null} dob
+ * @property {unknown} location
+ * @property {string[]} tags
+ * @property {string} notes
+ * @property {string} status
+ * @property {string | null} avatar
+ * @property {boolean} pinned
+ * @property {number | string | null} height
+ * @property {string} heightUnit
+ */
+
+/**
+ * @typedef {Object} ClientExportObject
+ * @property {number} version
+ * @property {string} exportedAt
+ * @property {ClientExportProfile} profile
+ * @property {Array<Object.<string, unknown>>} entries
+ * @property {Array<Object.<string, unknown>>} notes
+ * @property {Array<Object.<string, unknown>>} supplements
+ * @property {unknown} [chat]
+ */
+
+/** @returns {void} */
 export function exportDataJSON() {
   exportClientJSON(state.currentProfile);
 }
 
+/**
+ * Builds the JSON-safe client export object used by downloads and encrypted
+ * profile shares. Token-bearing wearable connection records are deliberately
+ * excluded from this shape.
+ *
+ * @param {string} profileId
+ * @param {boolean} [includeChat]
+ * @returns {Promise<ClientExportObject>}
+ */
 export async function buildClientExportObject(profileId, includeChat = false) {
   const profiles = getProfiles();
   const profile = profiles.find(p => p.id === profileId);
@@ -1663,6 +1703,13 @@ export async function buildClientExportObject(profileId, includeChat = false) {
   return exportObj;
 }
 
+/**
+ * Downloads a single-profile JSON backup.
+ *
+ * @param {string} profileId
+ * @param {boolean} [includeChat]
+ * @returns {Promise<void>}
+ */
 export async function exportClientJSON(profileId, includeChat = false) {
   let exportObj;
   try {
@@ -1685,6 +1732,7 @@ export async function exportClientJSON(profileId, includeChat = false) {
   showNotification(`Exported "${profileName}"`, 'success');
 }
 
+/** @returns {Promise<string | null>} */
 export async function buildAllDataBundle() {
   const profiles = getProfiles();
   if (profiles.length === 0) return null;
@@ -1713,6 +1761,7 @@ export async function buildAllDataBundle() {
   return JSON.stringify(bundle, null, 2);
 }
 
+/** @returns {Promise<void>} */
 export async function exportAllDataJSON() {
   const json = await buildAllDataBundle();
   if (!json) { showNotification('No profiles to export', 'error'); return; }
@@ -1729,6 +1778,12 @@ export async function exportAllDataJSON() {
   showNotification(`Exported ${bundle.profiles.length} client${bundle.profiles.length !== 1 ? 's' : ''}`, 'success');
 }
 
+/**
+ * Imports a JSON file produced by the single-client or all-data export paths.
+ *
+ * @param {File} file
+ * @returns {Promise<void>}
+ */
 export function importDataJSON(file) {
   // Returns a Promise that resolves when the FileReader pipeline finishes
   // (success OR error). Existing fire-and-forget callers (`importDataJSON(file)`)
@@ -1739,7 +1794,7 @@ export function importDataJSON(file) {
     reader.onerror = () => resolve();
     reader.onload = async (e) => {
       try {
-        const json = JSON.parse(e.target.result);
+        const json = JSON.parse(/** @type {string} */ (reader.result));
       // Database bundle — multi-profile import
       if (json.type === 'database' && Array.isArray(json.profiles)) {
         await _importDatabaseBundle(json);
@@ -2338,7 +2393,7 @@ export async function clearAllData() {
     const defaultId = profiles[0]?.id || 'default';
     const defaultName = profiles[0]?.name || 'Profile 1';
     saveProfiles([{ id: defaultId, name: defaultName, sex: null, dob: null, location: { country: '', zip: '' }, tags: [], notes: '', status: 'active', avatar: null, createdAt: Date.now(), lastUpdated: Date.now(), pinned: false }]);
-    state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, diet: null, exercise: null, sleepRest: null, lightCircadian: null, stress: null, loveLife: null, environment: null, interpretiveLens: '', contextNotes: '', customMarkers: {}, refOverrides: {}, menstrualCycle: null, emfAssessment: null, genetics: null, biometrics: null };
+    state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, diet: null, exercise: null, sleepRest: null, lightCircadian: null, stress: null, loveLife: null, environment: null, interpretiveLens: '', contextNotes: '', customMarkers: {}, refOverrides: {}, menstrualCycle: null, emfAssessment: null, genetics: null, biometrics: null, markerNotes: {}, markerValueNotes: {}, changeHistory: [] };
     state.currentProfile = defaultId;
     localStorage.setItem('labcharts-active-profile', defaultId);
     // Clear Cashu wallet database

--- a/js/export.js
+++ b/js/export.js
@@ -1626,6 +1626,45 @@ async function _importChatData(profileId, chat) {
  * @property {Array<Object.<string, unknown>>} entries
  * @property {Array<Object.<string, unknown>>} notes
  * @property {Array<Object.<string, unknown>>} supplements
+ * @property {unknown} diagnoses
+ * @property {unknown} diet
+ * @property {unknown} exercise
+ * @property {unknown} sleepRest
+ * @property {unknown} lightCircadian
+ * @property {unknown} stress
+ * @property {unknown} loveLife
+ * @property {unknown} environment
+ * @property {string} interpretiveLens
+ * @property {string} contextNotes
+ * @property {Array<unknown>} healthGoals
+ * @property {Object.<string, unknown>} customMarkers
+ * @property {Object.<string, unknown>} refOverrides
+ * @property {unknown} categoryLabels
+ * @property {unknown} categoryIcons
+ * @property {unknown} markerLabels
+ * @property {unknown} menstrualCycle
+ * @property {unknown} emfAssessment
+ * @property {unknown} genetics
+ * @property {unknown} biometrics
+ * @property {Object.<string, unknown>} markerNotes
+ * @property {Object.<string, unknown>} markerValueNotes
+ * @property {Object.<string, unknown>} manualValues
+ * @property {Array<unknown>} changeHistory
+ * @property {Array<unknown>} chatSummaries
+ * @property {unknown} wearableSummary
+ * @property {unknown} wearableCardOrder
+ * @property {unknown} wearablePrimaryOverride
+ * @property {Array<unknown>} sunSessions
+ * @property {Array<unknown>} deviceSessions
+ * @property {Array<unknown>} lightDevices
+ * @property {Array<unknown>} lightAudits
+ * @property {Array<unknown>} lightMeasurements
+ * @property {unknown} lightEnvironment
+ * @property {unknown} sunDefaults
+ * @property {unknown} sunCorrelations
+ * @property {unknown} lifelightProfile
+ * @property {unknown} lightDailyVerdicts
+ * @property {unknown} channelMixAI
  * @property {unknown} [chat]
  */
 
@@ -2175,9 +2214,9 @@ export function importDataJSON(file) {
       if (window._demoLoadingProfileId === state.currentProfile) {
         delete window._demoLoadingProfileId;
       }
-      window.buildSidebar();
-      window.updateHeaderDates();
-      window.navigate('dashboard');
+      if (window.buildSidebar) window.buildSidebar();
+      if (window.updateHeaderDates) window.updateHeaderDates();
+      if (window.navigate) window.navigate('dashboard');
       const profileMsg = json.profile?.name ? ` into "${json.profile.name}"` : '';
       showNotification(`Imported ${count} date entr${count === 1 ? 'y' : 'ies'}${profileMsg}`, 'success');
     } catch (err) {
@@ -2406,10 +2445,10 @@ export async function clearAllData() {
     localStorage.removeItem('labcharts-routstr-key');
     localStorage.removeItem('labcharts-routstr-model');
     localStorage.removeItem('labcharts-routstr-models');
-    window.buildSidebar();
-    window.updateHeaderDates();
-    window.renderProfileButton();
-    window.navigate('dashboard');
+    if (window.buildSidebar) window.buildSidebar();
+    if (window.updateHeaderDates) window.updateHeaderDates();
+    if (window.renderProfileButton) window.renderProfileButton();
+    if (window.navigate) window.navigate('dashboard');
     showNotification('All data cleared', 'info');
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": false
   },
   "include": [
+    "js/export.js",
     "js/profile-share.js",
     "types/**/*.d.ts"
   ]

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -3,3 +3,20 @@ declare const Buffer: {
     toString(encoding?: string): string;
   };
 };
+
+interface Window {
+  _demoLoadingProfileId?: string;
+  _snpTableCache?: unknown;
+  buildSidebar(): void;
+  cashuDestroyWalletDB?: () => Promise<void> | void;
+  cashuGetMintUrl?: () => Promise<string | null> | string | null;
+  cashuRestoreWalletFromSeed?: (seed: string) => Promise<void> | void;
+  cashuSetMintUrl?: (url: string) => Promise<void> | void;
+  getProfileHeight?: (profileId: string) => { height?: number | string | null; unit?: string | null };
+  loadChatThreads?: () => void;
+  navigate(route: string): void;
+  nostrGetSelectedNode?: () => string | null;
+  nostrSetSelectedNode?: (url: string) => void;
+  renderProfileButton(): void;
+  updateHeaderDates(): void;
+}

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -7,16 +7,16 @@ declare const Buffer: {
 interface Window {
   _demoLoadingProfileId?: string;
   _snpTableCache?: unknown;
-  buildSidebar(): void;
+  buildSidebar?: () => void;
   cashuDestroyWalletDB?: () => Promise<void> | void;
   cashuGetMintUrl?: () => Promise<string | null> | string | null;
   cashuRestoreWalletFromSeed?: (seed: string) => Promise<void> | void;
   cashuSetMintUrl?: (url: string) => Promise<void> | void;
   getProfileHeight?: (profileId: string) => { height?: number | string | null; unit?: string | null };
   loadChatThreads?: () => void;
-  navigate(route: string): void;
+  navigate?: (route: string) => void;
   nostrGetSelectedNode?: () => string | null;
   nostrSetSelectedNode?: (url: string) => void;
-  renderProfileButton(): void;
-  updateHeaderDates(): void;
+  renderProfileButton?: () => void;
+  updateHeaderDates?: () => void;
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.359';
+self.APP_VERSION = '1.8.360';


### PR DESCRIPTION
## Summary
- Opt `js/export.js` into `// @ts-check` and include it in the TypeScript baseline.
- Add JSDoc for the client export/import boundary used by JSON downloads and profile sharing.
- Add ambient browser-global declarations needed by checked export code.
- Bump `version.js` to `1.8.360` for cache invalidation.

## Why
This expands the typecheck from profile sharing into the export/import contract it depends on, catching drift around reusable client export objects and JSON import handling without changing the no-build static ES module architecture.

## Validation
- `npm run typecheck`
- `node tests/test-profile-share.js`
- `node tests/test-changelog.js`
- focused browser run of `tests/test-export-import.js` through Puppeteer: 245 passed, 0 failed
- `npm test`
- `./run-tests.sh`