### PR TITLE
[codex] Typecheck markdown

### DIFF
--- a/js/markdown.js
+++ b/js/markdown.js
@@ -1,3 +1,4 @@
+// @ts-check
 // markdown.js — Markdown rendering for chat messages, focus card, EMF reports
 
 import { escapeHTML } from './utils.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
   "include": [
     "js/client-list.js",
     "js/export.js",
+    "js/markdown.js",
     "js/profile.js",
     "js/profile-share.js",
     "js/utils.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.363';
+self.APP_VERSION = '1.8.364';


### PR DESCRIPTION
## Summary
- Opt `js/markdown.js` into project typechecking with `// @ts-check`.
- Add `js/markdown.js` to `tsconfig.json` so markdown rendering stays covered by `npm run typecheck`.
- Bump `version.js` to `1.8.364` for cache invalidation.

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-markdown.js`
- `node tests/test-changelog.js`
- `npm test`
- `./run-tests.sh`