### PR TITLE
[codex] Typecheck blob storage

### DIFF
--- a/js/blob-storage.js
+++ b/js/blob-storage.js
@@ -1,3 +1,4 @@
+// @ts-check
 // blob-storage.js — IndexedDB-backed key/value store for big blobs.
 //
 // localStorage's typical 5 MB cap is too small for the imported profile

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": false
   },
   "include": [
+    "js/blob-storage.js",
     "js/client-list.js",
     "js/export.js",
     "js/markdown.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.364';
+self.APP_VERSION = '1.8.365';


### PR DESCRIPTION
## Summary
- Opt `js/blob-storage.js` into project typechecking with `// @ts-check`.
- Add `js/blob-storage.js` to `tsconfig.json` so the IndexedDB blob storage helper stays covered by `npm run typecheck`.
- Bump `version.js` to `1.8.365` for cache invalidation.

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-blob-storage.js`
- `node tests/test-crypto.js`
- `node tests/test-data-merge.js`
- `npm test`
- `./run-tests.sh`

Note: a direct standalone run of `node tests/test-coverage-stragglers.js` reached the blob-storage IDB error-rail assertions, then exited with Node's existing unsettled top-level-await warning in the later cashu section. The same test file passes through the normal Vitest harness above.