### PR TITLE
[codex] Typecheck URL safety

### DIFF
--- a/js/url-safety.js
+++ b/js/url-safety.js
@@ -73,6 +73,17 @@ export function isValidExternalUrl(raw, { requireHttps = true, allowLocalhost = 
         return isValidExternalUrl(`${u.protocol}//${a}.${b}.${c}.${d}${u.pathname || ''}`, { requireHttps, allowLocalhost });
       }
     }
+    // 6to4 = 2002:WWXX:YYZZ::/48, with WWXX:YYZZ encoding an IPv4 address.
+    const sixToFour = /^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4})(?::|$)/.exec(host);
+    if (sixToFour) {
+      const g0 = parseInt(sixToFour[1], 16);
+      const g1 = parseInt(sixToFour[2], 16);
+      const a = (g0 >> 8) & 0xff;
+      const b = g0 & 0xff;
+      const c = (g1 >> 8) & 0xff;
+      const d = g1 & 0xff;
+      return isValidExternalUrl(`${u.protocol}//${a}.${b}.${c}.${d}${u.pathname || ''}`, { requireHttps, allowLocalhost });
+    }
     if (!/^[23][0-9a-f]{3}:/.test(host)) return false;          // only globally-routable IPv6
   }
 

--- a/js/url-safety.js
+++ b/js/url-safety.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Shared SSRF-style validation for user-supplied URLs that the browser
 // will fetch directly (mint URLs, Routstr nodes, self-host UV data, etc.).
 //

--- a/tests/test-cashu-wallet.js
+++ b/tests/test-cashu-wallet.js
@@ -328,6 +328,8 @@ await expectMintRejection('https://[::ffff:7f00:1]/mint', 'IPv4-mapped IPv6 abbr
 await expectMintRejection('https://[::ffff:a9fe:a9fe]/mint', 'IPv4-mapped IPv6 → 169.254.169.254 (cloud metadata)');
 await expectMintRejection('https://[::ffff:a00:1]/mint', 'IPv4-mapped IPv6 abbreviated → 10.0.0.1 (RFC-1918 10/8)');
 await expectMintRejection('https://[::ffff:ac10:1]/mint', 'IPv4-mapped IPv6 abbreviated → 172.16.0.1 (RFC-1918 172.16/12)');
+await expectMintRejection('https://[2002:c0a8:0101::]/mint', '6to4 IPv6 embeds RFC1918 192.168.1.1');
+await expectMintRejection('https://[2002:7f00:0001::]/mint', '6to4 IPv6 embeds loopback 127.0.0.1');
 
 const origNode = discovery.getSelectedNodeUrl();
 function expectNodeRejection(url, label) {

--- a/tests/test-sun-uvdata.js
+++ b/tests/test-sun-uvdata.js
@@ -104,6 +104,8 @@ const {
   await expectSelfhostRejected('http://100.64.0.1/api', 'CGNAT 100.64.0.0/10');
   await expectSelfhostRejected('http://224.0.0.1/api', 'multicast 224.0.0.0/4');
   await expectSelfhostRejected('http://[fe80::1]/api', 'IPv6 link-local literal');
+  await expectSelfhostRejected('http://[2002:c0a8:0101::]/api', '6to4 IPv6 embeds RFC1918 192.168.1.1');
+  await expectSelfhostRejected('http://[2002:a9fe:a9fe::]/api', '6to4 IPv6 embeds link-local 169.254.169.254');
   await expectSelfhostRejected('ftp://example.com/api', 'non-http(s) protocol');
   await expectSelfhostRejected('not a url', 'unparseable URL');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "js/markdown.js",
     "js/profile.js",
     "js/profile-share.js",
+    "js/url-safety.js",
     "js/utils.js",
     "types/**/*.d.ts"
   ]

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.365';
+self.APP_VERSION = '1.8.366';


### PR DESCRIPTION
## Summary
- Opt `js/url-safety.js` into project typechecking with `// @ts-check`.
- Add `js/url-safety.js` to `tsconfig.json` so the shared external URL validator stays covered by `npm run typecheck`.
- Decode 6to4 IPv6 addresses (`2002::/16`) through the existing IPv4 guard so embedded loopback, RFC1918, and link-local addresses are rejected.
- Bump `version.js` to `1.8.366` for cache invalidation.

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-sun-uvdata.js`
- `node tests/test-cashu-wallet.js`
- `node tests/test-security-phase1.js`
- `npm test`
- `./run-tests.sh`