### PR TITLE
[codex] Typecheck lens local utils

### DIFF
--- a/js/lens-local-utils.js
+++ b/js/lens-local-utils.js
@@ -1,3 +1,4 @@
+// @ts-check
 // js/lens-local-utils.js — pure helpers shared by the lens-local worker
 // and the test suite.
 //
@@ -6,34 +7,45 @@
 // these; run-tests.sh's browser harness and tests/test-lens-local-utils.js
 // exercise them directly.
 
-/// Split a text into chunks of at most maxSize chars, with `overlap` chars
-/// carried between adjacent chunks. Snaps to whitespace boundaries when
-/// possible so chunks don't end mid-word. Matches the lens Python
-/// chunker's defaults (getbased-rag's `packages/rag/src/lens/store.py::chunk_text`) so retrieval
-/// behavior stays consistent across backends.
+/**
+ * Split text into chunks with overlap, snapping to whitespace boundaries when
+ * possible so chunks do not end mid-word. Matches the lens Python chunker's
+ * defaults (`packages/rag/src/lens/store.py::chunk_text`) so retrieval
+ * behavior stays consistent across backends.
+ * @param {unknown} text
+ * @param {number} [maxSize]
+ * @param {number} [overlap]
+ * @param {number} [minSize]
+ * @returns {string[]}
+ */
 export function chunkText(text, maxSize = 800, overlap = 50, minSize = 50) {
-  text = String(text || '').trim();
-  if (text.length <= maxSize) return text.length >= minSize ? [text] : [];
+  const source = String(text || '').trim();
+  if (source.length <= maxSize) return source.length >= minSize ? [source] : [];
   const out = [];
   let pos = 0;
-  while (pos < text.length) {
-    let end = Math.min(pos + maxSize, text.length);
-    if (end < text.length) {
+  while (pos < source.length) {
+    let end = Math.min(pos + maxSize, source.length);
+    if (end < source.length) {
       for (const sep of ['\n\n', '\n', '. ', ' ']) {
-        const idx = text.lastIndexOf(sep, end);
+        const idx = source.lastIndexOf(sep, end);
         if (idx > pos + minSize) { end = idx + sep.length; break; }
       }
     }
-    const chunk = text.slice(pos, end).trim();
+    const chunk = source.slice(pos, end).trim();
     if (chunk.length >= minSize) out.push(chunk);
-    if (end >= text.length) break;
+    if (end >= source.length) break;
     pos = Math.max(end - overlap, pos + 1);
   }
   return out;
 }
 
-/// Dot product on two unit-normalized vectors = cosine similarity.
-/// Scalar so callers don't need to remember the normalization invariant.
+/**
+ * Dot product on two unit-normalized vectors = cosine similarity.
+ * Scalar so callers do not need to remember the normalization invariant.
+ * @param {ArrayLike<number>} a
+ * @param {ArrayLike<number>} b
+ * @returns {number}
+ */
 export function cosine(a, b) {
   const n = Math.min(a.length, b.length);
   let s = 0;
@@ -41,11 +53,17 @@ export function cosine(a, b) {
   return s;
 }
 
-/// Maximal Marginal Relevance selection. `candidates` is an array of
-/// { i, score } sorted by score desc. `getVec(i)` returns the unit-
-/// normalized vector for candidate index `i`. λ=0.5 balances relevance
-/// against diversity; closer to 1 favors relevance, closer to 0 favors
-/// diversity.
+/**
+ * Maximal Marginal Relevance selection. `candidates` is sorted by score desc.
+ * `getVec(i)` returns the unit-normalized vector for candidate index `i`.
+ * λ=0.5 balances relevance against diversity; closer to 1 favors relevance,
+ * closer to 0 favors diversity.
+ * @param {Array<{ i: number, score: number }>} candidates
+ * @param {number} topK
+ * @param {number} lambda
+ * @param {(index: number) => ArrayLike<number>} getVec
+ * @returns {Array<{ i: number, score: number }>}
+ */
 export function mmrSelect(candidates, topK, lambda, getVec) {
   if (candidates.length <= topK) return candidates;
   const chosen = [candidates[0]];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "js/blob-storage.js",
     "js/client-list.js",
     "js/export.js",
+    "js/lens-local-utils.js",
     "js/markdown.js",
     "js/profile.js",
     "js/profile-share.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.366';
+self.APP_VERSION = '1.8.367';


### PR DESCRIPTION
## Summary
- opt `js/lens-local-utils.js` into `// @ts-check`
- replace comment-only helper descriptions with JSDoc contracts for text chunking, cosine similarity, and MMR selection
- include the helper in `tsconfig.json` and bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-lens-local-utils.js`
- `npm test`
- `./run-tests.sh`