### PR TITLE
[codex] Typecheck lens parsers

### DIFF
--- a/js/lens-local-parsers.js
+++ b/js/lens-local-parsers.js
@@ -1,3 +1,4 @@
+// @ts-check
 // js/lens-local-parsers.js — main-thread document parsers for lens-local.
 //
 // Why main-thread: the worker is a module worker (type: 'module'), and the
@@ -13,10 +14,19 @@ import { getPdfDocument } from './pdfjs-loader.js';
 
 const SUPPORTED_TEXT_EXTS = new Set(['txt', 'md', 'markdown', 'rst', 'json', 'csv', 'log']);
 
-/// Turn a File (or File-like) into one or more { name, text } entries.
-/// Returns [] for unsupported types so callers can filter. ZIPs recurse:
-/// an entry's name is prefixed with the zip's name so the source filename
-/// the user sees in the doc list reflects the archive they dropped.
+/**
+ * @typedef {{ name: string, text: string }} ExtractedLensDocument
+ * @typedef {{ dir: boolean, name: string, async(type: 'blob'): Promise<Blob> }} ZipEntry
+ */
+
+/**
+ * Turn a File into one or more { name, text } entries.
+ * Returns [] for unsupported types so callers can filter. ZIPs recurse:
+ * an entry's name is prefixed with the zip's name so the source filename
+ * the user sees in the doc list reflects the archive they dropped.
+ * @param {File} file
+ * @returns {Promise<ExtractedLensDocument[]>}
+ */
 export async function extractFromFile(file) {
   const name = String(file.name || '');
   const ext = extOf(name);
@@ -31,6 +41,10 @@ export async function extractFromFile(file) {
   return [];
 }
 
+/**
+ * @param {string} name
+ * @returns {string}
+ */
 function extOf(name) {
   const i = name.lastIndexOf('.');
   return i === -1 ? '' : name.slice(i + 1).toLowerCase();
@@ -38,6 +52,10 @@ function extOf(name) {
 
 // ── PDF ──────────────────────────────────────────────────────────
 
+/**
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
 async function extractPdf(file) {
   const buffer = await file.arrayBuffer();
   const pdf = await getPdfDocument({ data: buffer });
@@ -49,13 +67,17 @@ async function extractPdf(file) {
     // — we lose line breaks and column structure — but it's good enough
     // for chunk-level retrieval and avoids false paragraph breaks that
     // a more literal reconstruction would introduce.
-    pages.push(content.items.map((i) => i.str).join(' '));
+    pages.push(content.items.map((i) => /** @type {{ str?: string }} */ (i).str).join(' '));
   }
   return pages.join('\n\n');
 }
 
 // ── DOCX ─────────────────────────────────────────────────────────
 
+/**
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
 async function extractDocx(file) {
   await loadScript('/vendor/mammoth.browser.min.js');
   const mammoth = window.mammoth;
@@ -69,6 +91,10 @@ async function extractDocx(file) {
 
 // ── ZIP ──────────────────────────────────────────────────────────
 
+/**
+ * @param {File} file
+ * @returns {Promise<ExtractedLensDocument[]>}
+ */
 async function extractZip(file) {
   await loadScript('/vendor/jszip.min.js');
   const JSZip = window.JSZip;
@@ -81,7 +107,7 @@ async function extractZip(file) {
   // recursion through extractFromFile; the name is prefixed with the
   // archive name so the doc list shows which .zip each chunk came from.
   const archiveName = String(file.name || 'archive.zip');
-  for (const entry of Object.values(zip.files)) {
+  for (const entry of /** @type {ZipEntry[]} */ (Object.values(zip.files))) {
     if (entry.dir) continue;
     const innerExt = extOf(entry.name);
     if (!SUPPORTED_TEXT_EXTS.has(innerExt) && !['pdf', 'docx'].includes(innerExt)) continue;
@@ -101,11 +127,16 @@ async function extractZip(file) {
 
 // ── Script loader ────────────────────────────────────────────────
 
+/** @type {Map<string, Promise<void>>} */
 const _scriptLoads = new Map(); // src → Promise
 
-/// Lazy-load a vendor script via <script src> and cache the Promise so
-/// concurrent callers share one fetch. No-ops if the script is already
-/// present on the page (e.g., pdf.js pre-loaded by the main app).
+/**
+ * Lazy-load a vendor script via <script src> and cache the Promise so
+ * concurrent callers share one fetch. No-ops if the script is already
+ * present on the page (e.g., pdf.js pre-loaded by the main app).
+ * @param {string} src
+ * @returns {Promise<void>}
+ */
 function loadScript(src) {
   if (_scriptLoads.has(src)) return _scriptLoads.get(src);
   // Already on the page? (Main app preloads pdf.js for the PDF-import

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "js/blob-storage.js",
     "js/client-list.js",
     "js/export.js",
+    "js/lens-local-parsers.js",
     "js/lens-local-utils.js",
     "js/markdown.js",
     "js/profile.js",

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -31,6 +31,18 @@ interface Window {
   loadChatHistory?: () => Promise<void> | void;
   loadChatPersonality?: () => void;
   loadChatThreads?: () => void;
+  JSZip?: {
+    loadAsync(input: ArrayBuffer | Blob): Promise<{
+      files: Record<string, {
+        dir: boolean;
+        name: string;
+        async(type: 'blob'): Promise<Blob>;
+      }>;
+    }>;
+  };
+  mammoth?: {
+    extractRawText(input: { arrayBuffer: ArrayBuffer }): Promise<{ value?: string }>;
+  };
   navigate?: (route: string) => void;
   nostrGetSelectedNode?: () => string | null;
   nostrSetSelectedNode?: (url: string) => void;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.367';
+self.APP_VERSION = '1.8.368';


### PR DESCRIPTION
## Summary
- opt `js/lens-local-parsers.js` into `// @ts-check`
- add JSDoc contracts for lens document extraction, PDF/DOCX/ZIP helper paths, and the script loader cache
- add minimal `mammoth` and `JSZip` browser globals for the typechecked parser path
- include the parser in `tsconfig.json` and bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-lens-parsers.js`
- `node tests/test-security-phase1.js`
- `node tests/test-correctness-phase2.js`
- `npm test`
- `./run-tests.sh`