### PR TITLE
[codex] Typecheck pdfjs loader

### DIFF
--- a/js/pdfjs-loader.js
+++ b/js/pdfjs-loader.js
@@ -1,14 +1,34 @@
+// @ts-check
 // Cached dynamic loader for pdf.js (ESM-only since v4.x). Loads on first
 // PDF interaction rather than on every page load, and pins
 // `isEvalSupported: false` defense-in-depth at the entry point so call
 // sites can't forget it. Also exposes the module on `window.pdfjsLib`
 // for any legacy reference that hasn't migrated to the loader yet.
+
+/**
+ * @typedef {{ items: Array<{ str?: string }> }} PdfTextContent
+ * @typedef {{ getTextContent(): Promise<PdfTextContent> }} PdfPageProxy
+ * @typedef {{ numPages: number, getPage(pageNumber: number): Promise<PdfPageProxy> }} PdfDocumentProxy
+ * @typedef {{ promise: Promise<PdfDocumentProxy> }} PdfLoadingTask
+ * @typedef {{
+ *   GlobalWorkerOptions: { workerSrc?: string },
+ *   getDocument(options: Record<string, unknown>): PdfLoadingTask
+ * }} PdfJsModule
+ * @typedef {ArrayBuffer | ArrayBufferView | string | Record<string, unknown>} PdfDocumentInput
+ */
+
+const PDFJS_MODULE_URL = '/vendor/pdf.min.mjs';
+
+/** @type {Promise<PdfJsModule> | null} */
 let _pdfjsPromise = null;
 
+/**
+ * @returns {Promise<PdfJsModule>}
+ */
 export function loadPdfJs() {
   if (_pdfjsPromise) return _pdfjsPromise;
-  _pdfjsPromise = import('/vendor/pdf.min.mjs').then(mod => {
-    const pdfjs = mod.default || mod;
+  _pdfjsPromise = import(PDFJS_MODULE_URL).then(mod => {
+    const pdfjs = /** @type {PdfJsModule} */ (mod.default || mod);
     if (!pdfjs.GlobalWorkerOptions.workerSrc) {
       pdfjs.GlobalWorkerOptions.workerSrc = '/vendor/pdf.worker.min.mjs';
     }
@@ -23,6 +43,11 @@ export function loadPdfJs() {
 // motivates `isEvalSupported: false` even after the version bump — the
 // guard is applied AFTER the spread so a caller can't accidentally
 // re-enable eval through extraOpts.
+/**
+ * @param {PdfDocumentInput} input
+ * @param {Record<string, unknown>} [extraOpts]
+ * @returns {Promise<PdfDocumentProxy>}
+ */
 export async function getPdfDocument(input, extraOpts = {}) {
   const pdfjs = await loadPdfJs();
   const opts = typeof input === 'object' && !ArrayBuffer.isView(input) && !(input instanceof ArrayBuffer)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "js/lens-local-parsers.js",
     "js/lens-local-utils.js",
     "js/markdown.js",
+    "js/pdfjs-loader.js",
     "js/profile.js",
     "js/profile-share.js",
     "js/url-safety.js",

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -48,6 +48,7 @@ interface Window {
   nostrSetSelectedNode?: (url: string) => void;
   openClientList?: () => void;
   closeClientList?: () => void;
+  pdfjsLib?: unknown;
   openProfileShareModal?: (profileId?: string) => void;
   renderProfileButton?: () => void;
   renderThreadList?: () => void;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.368';
+self.APP_VERSION = '1.8.369';


### PR DESCRIPTION
## Summary
- opt `js/pdfjs-loader.js` into `// @ts-check`
- add minimal JSDoc contracts for the pdf.js module, loading task, document, page, and text-content shapes used by callers
- move the browser-served pdf.js module path into a constant so the dynamic import stays runtime-resolved while typecheck passes
- include the loader in `tsconfig.json`, declare the legacy `window.pdfjsLib` global, and bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-security-phase1.js`
- `node tests/test-lens-parsers.js`
- `node tests/test-correctness-phase2.js`
- `npm test`
- `./run-tests.sh`