### PR TITLE
[codex] Typecheck theme module

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -1,3 +1,4 @@
+// @ts-check
 // theme.js — Theme management, chart colors, time format
 
 const VALID_THEMES = ['dark', 'light', 'cyberterm', 'glass', 'synth-sunrise', 'neuromancer'];
@@ -74,7 +75,7 @@ export function getThemeColorScheme(theme = getTheme()) {
 function applyThemeChrome(theme = getTheme()) {
   if (typeof document === 'undefined') return;
   document.querySelectorAll('meta[name="theme-color"]').forEach(meta => {
-    meta.content = getThemeColor(theme);
+    if (meta instanceof HTMLMetaElement) meta.content = getThemeColor(theme);
   });
   document.documentElement.style.colorScheme = getThemeColorScheme(theme);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "js/pdfjs-loader.js",
     "js/profile.js",
     "js/profile-share.js",
+    "js/theme.js",
     "js/url-safety.js",
     "js/utils.js",
     "types/**/*.d.ts"

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -7,6 +7,7 @@ declare const Buffer: {
 interface Window {
   _demoLoadingProfileId?: string;
   _snpTableCache?: unknown;
+  applyAccentOverride?: () => void;
   buildSidebar?: () => void;
   callClaudeAPI?: (request: {
     system?: string;
@@ -54,8 +55,11 @@ interface Window {
   closeClientList?: () => void;
   pdfjsLib?: unknown;
   openProfileShareModal?: (profileId?: string) => void;
+  refreshChartThemeColors?: (options?: { batchSize?: number }) => void;
+  refreshSettingsWearables?: () => void;
   renderProfileButton?: () => void;
   renderThreadList?: () => void;
+  scheduleChartThemeRefresh?: () => void;
   setManualHaplogroup?: (haplogroup: string) => Promise<void> | void;
   showConfirmDialog?: (message: string) => Promise<boolean> | boolean;
   showNotification?: (message: string, type?: string, timeoutMs?: number) => void;
@@ -64,4 +68,6 @@ interface Window {
   updateHeaderDates?: () => void;
   updateHeaderRangeToggle?: () => void;
   updatePersonalityBar?: () => void;
+  updateSettingsUI?: () => void;
+  updateTweaksUI?: () => void;
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.370';
+self.APP_VERSION = '1.8.371';


### PR DESCRIPTION
## Summary
- opt `js/theme.js` into `// @ts-check`
- narrow runtime theme-color meta updates to real `HTMLMetaElement` nodes
- declare the theme refresh globals used by the theme module and include it in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-a11y-phase3.js`
- `node tests/test-correctness-phase2.js`
- `npm test`
- `./run-tests.sh`