### PR TITLE
[codex] Typecheck commit hash module

### DIFF
--- a/js/commit-hash.js
+++ b/js/commit-hash.js
@@ -1,3 +1,4 @@
+// @ts-check
 // commit-hash.js - Footer app version and commit hash hydration
 
 import { escapeHTML } from './utils.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "js/blob-storage.js",
     "js/category-glyphs.js",
     "js/client-list.js",
+    "js/commit-hash.js",
     "js/export.js",
     "js/import-drop-zone.js",
     "js/import-file-input.js",

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -7,6 +7,7 @@ declare const Buffer: {
 interface Window {
   _demoLoadingProfileId?: string;
   _snpTableCache?: unknown;
+  APP_VERSION?: string;
   applyAccentOverride?: () => void;
   buildSidebar?: () => void;
   callClaudeAPI?: (request: {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.373';
+self.APP_VERSION = '1.8.374';


### PR DESCRIPTION
## Summary
- opt `js/commit-hash.js` into `// @ts-check`
- declare `window.APP_VERSION` for checked modules
- include the commit hash module in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-correctness-phase2.js`
- `node tests/test-changelog.js`
- `npm test`
- `./run-tests.sh`