### PR TITLE
[codex] Typecheck brand assets module

### DIFF
--- a/js/brand-assets.js
+++ b/js/brand-assets.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // brand-assets.js — Wearable vendor brand asset registry.
 //
 // Maps adapterId → { mode, brandColor?, mono, full?, signInLight?, signInDark? }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "include": [
     "js/blob-storage.js",
+    "js/brand-assets.js",
     "js/category-glyphs.js",
     "js/client-list.js",
     "js/commit-hash.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.374';
+self.APP_VERSION = '1.8.375';


### PR DESCRIPTION
## Summary
- opt `js/brand-assets.js` into `// @ts-check`
- include the brand assets module in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-wearables.js`
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is opening the wearable integrations/settings surface and confirming vendor icons still render.