### PR TITLE
[codex] Typecheck image utilities module

### DIFF
--- a/js/image-utils.js
+++ b/js/image-utils.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // image-utils.js — Shared image utilities for chat attachments and PDF image fallback
 // No app imports (no circular deps)
 
@@ -5,11 +7,22 @@
 // RESIZE IMAGE
 // ═══════════════════════════════════════════════
 /**
+ * @typedef {object} ResizedImage
+ * @property {string} base64
+ * @property {string} mediaType
+ * @property {number} width
+ * @property {number} height
+ * @property {number} origWidth
+ * @property {number} origHeight
+ * @property {string[]} quality_warnings
+ */
+
+/**
  * Resize an image file to fit within maxDim, return base64 JPEG.
  * @param {File} file
  * @param {number} maxDim - max long-side pixels (default 1024 for chat, 2048 for PDF)
  * @param {number} quality - JPEG quality 0-1
- * @returns {Promise<{base64: string, mediaType: string, width: number, height: number}>}
+ * @returns {Promise<ResizedImage>}
  */
 export function resizeImage(file, maxDim = 1024, quality = 0.85) {
   return new Promise((resolve, reject) => {
@@ -48,6 +61,12 @@ export function resizeImage(file, maxDim = 1024, quality = 0.85) {
 // ═══════════════════════════════════════════════
 // IMAGE QUALITY ANALYSIS
 // ═══════════════════════════════════════════════
+/**
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} width
+ * @param {number} height
+ * @returns {string[]}
+ */
 function analyzeImageQuality(ctx, width, height) {
   const warnings = [];
   // Sample a grid of pixels (max ~100k pixels for performance)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "js/client-list.js",
     "js/commit-hash.js",
     "js/export.js",
+    "js/image-utils.js",
     "js/import-drop-zone.js",
     "js/import-file-input.js",
     "js/import-loader.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.375';
+self.APP_VERSION = '1.8.376';


### PR DESCRIPTION
## Summary
- opt `js/image-utils.js` into `// @ts-check`
- document the full `resizeImage` result shape used by callers
- include the image utilities module in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-image-utils.js`
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is attaching or uploading an image in chat and confirming the preview still appears.