### PR TITLE
[codex] Typecheck lighting caveats module

### DIFF
--- a/js/lighting-hardware-caveats.js
+++ b/js/lighting-hardware-caveats.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // lighting-hardware-caveats.js — load-bearing prompt block shared by
 // every Light & Sun AI surface that recommends fixtures or dimming.
 //

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "js/import-loader.js",
     "js/lens-local-parsers.js",
     "js/lens-local-utils.js",
+    "js/lighting-hardware-caveats.js",
     "js/markdown.js",
     "js/pdfjs-loader.js",
     "js/profile.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.376';
+self.APP_VERSION = '1.8.377';


### PR DESCRIPTION
## Summary
- opt `js/lighting-hardware-caveats.js` into `// @ts-check`
- include the lighting caveats module in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-lighting-hardware-caveats.js`
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is running a Light/Sun AI analysis and confirming the generated guidance still includes the hardware caveats context.