### PR TITLE
[codex] Typecheck food contaminants module

### DIFF
--- a/js/food-contaminants.js
+++ b/js/food-contaminants.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // food-contaminants.js — Keyword-based food contaminant warnings from public databases
 // Sources: EWG Dirty Dozen/Clean Fifteen (2025 data), PlasticList (2024)
 // Update annually when EWG publishes new rankings at ewg.org/foodnews

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "js/client-list.js",
     "js/commit-hash.js",
     "js/export.js",
+    "js/food-contaminants.js",
     "js/image-utils.js",
     "js/import-drop-zone.js",
     "js/import-file-input.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.377';
+self.APP_VERSION = '1.8.378';


### PR DESCRIPTION
## Summary
- opt `js/food-contaminants.js` into `// @ts-check`
- include the food contaminants module in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- food contaminant import smoke
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is entering diet text with spinach or canned food and confirming contaminant warnings still appear in lifestyle/context surfaces.