### PR TITLE
[codex] Typecheck sync delta observability context

### DIFF
--- a/js/sync-delta-observability-context.js
+++ b/js/sync-delta-observability-context.js
@@ -1,8 +1,18 @@
+// @ts-check
 // sync-delta-observability-context.js - Shared Evolu query access for delta observability.
 
 let _getEvolu = () => null;
 let _getItemRowQuery = () => null;
 
+/**
+ * @typedef {object} SyncDeltaObservabilityContextOptions
+ * @property {(() => any)=} getEvolu
+ * @property {(() => any)=} getItemRowQuery
+ */
+
+/**
+ * @param {SyncDeltaObservabilityContextOptions} [options]
+ */
 export function configureSyncDeltaObservabilityContext({ getEvolu, getItemRowQuery } = {}) {
   if (typeof getEvolu === 'function') _getEvolu = getEvolu;
   if (typeof getItemRowQuery === 'function') _getItemRowQuery = getItemRowQuery;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "js/profile-share.js",
     "js/silhouette-paths.js",
     "js/sync-delta-id.js",
+    "js/sync-delta-observability-context.js",
     "js/sync-schema.js",
     "js/theme.js",
     "js/touch-tooltip.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.381';
+self.APP_VERSION = '1.8.382';


### PR DESCRIPTION
## Summary
- opt `js/sync-delta-observability-context.js` into `// @ts-check`
- add a small JSDoc type for the observability context options
- include the helper in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- sync delta observability context import smoke
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is enabling sync on a test profile and confirming sync status/readiness still renders normally.
