### PR TITLE
[codex] Typecheck wearables formatters

### DIFF
--- a/js/wearables-formatters.js
+++ b/js/wearables-formatters.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { isoDay } from './wearable-adapters.js';
 
 // Single formatter used by the strip cards and detail modals so a number
@@ -17,6 +18,7 @@ export function shortDate(iso) {
   const d = new Date(iso + 'T00:00:00Z');
   if (isNaN(d.getTime())) return iso;
   const sameYear = d.getUTCFullYear() === Number(isoDay().slice(0, 4));
+  /** @type {Intl.DateTimeFormatOptions} */
   const fmt = sameYear
     ? { month: 'short', day: 'numeric', timeZone: 'UTC' }
     : { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     "js/touch-tooltip.js",
     "js/url-safety.js",
     "js/utils.js",
+    "js/wearables-formatters.js",
     "types/**/*.d.ts"
   ]
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.383';
+self.APP_VERSION = '1.8.384';


### PR DESCRIPTION
## Summary
- opt `js/wearables-formatters.js` into `// @ts-check`
- type the compact date formatter options for TypeScript
- include the formatter in `tsconfig.json`
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- wearables formatter import smoke
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is opening the Wearables view and confirming metric values and latest-date labels still render normally.
