### PR TITLE
[codex] Typecheck wearables core modules

### DIFF
--- a/js/wearable-adapters.js
+++ b/js/wearable-adapters.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearable-adapters.js — Canonical wearable-metric registry + vendor adapters
 //
 // Contract: the rest of the app reads **canonical** metric ids (hrv_rmssd,

--- a/js/wearables-fitbit.js
+++ b/js/wearables-fitbit.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-fitbit.js — Fitbit Web API data layer
 //
 // Fitbit has a hard 150 req/hour per user rate limit. A naive per-day
@@ -34,6 +35,7 @@ async function fbGET(path, accessToken) {
   if (!res.ok) {
     let err; try { err = await res.json(); } catch { err = { error: res.statusText }; }
     const msg = err?.errors?.[0]?.message || err?.detail || err?.message || err?.error || res.statusText || 'Fitbit request failed';
+    /** @type {Error & { status?: number }} */
     const e = new Error(msg); e.status = res.status; throw e;
   }
   return res.json();

--- a/js/wearables-manual-form-ui.js
+++ b/js/wearables-manual-form-ui.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { escapeHTML } from './utils.js';
 
 // Chip row for optional context tags. Tags are informational; sensors cannot

--- a/js/wearables-oura.js
+++ b/js/wearables-oura.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-oura.js — Oura API data-layer (OAuth2 server-side flow)
 //
 // Pure data-layer: talks to Oura's /v2/usercollection/* endpoints via the
@@ -34,6 +35,7 @@ async function ouraGET(path, accessToken, params = {}) {
     let err;
     try { err = await res.json(); } catch { err = { error: res.statusText }; }
     const msg = err?.detail || err?.error || res.statusText || 'Oura request failed';
+    /** @type {Error & { status?: number }} */
     const e = new Error(msg);
     e.status = res.status;
     throw e;

--- a/js/wearables-polar.js
+++ b/js/wearables-polar.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-polar.js — Polar AccessLink data layer
 //
 // BETA. AccessLink has two unusual quirks that shape this module:
@@ -37,6 +38,7 @@ async function polarGET(url, accessToken) {
   });
   if (!res.ok) {
     let err; try { err = await res.json(); } catch { err = { error: res.statusText }; }
+    /** @type {Error & { status?: number }} */
     const e = new Error(err?.error || err?.detail || res.statusText || 'Polar request failed');
     e.status = res.status; throw e;
   }
@@ -62,6 +64,7 @@ async function polarSend(url, method, accessToken, body) {
   });
   if (!res.ok) {
     let err; try { err = await res.json(); } catch { err = { error: res.statusText }; }
+    /** @type {Error & { status?: number }} */
     const e = new Error(err?.error || err?.detail || res.statusText || `Polar ${method} failed`);
     e.status = res.status; throw e;
   }
@@ -112,6 +115,7 @@ export async function fetchPolarPersonalInfo(accessToken, userId) {
 export async function fetchPolarDailyRange(accessToken, startDate, endDate, connection = {}) {
   const userId = connection.userId;
   if (!userId) {
+    /** @type {Error & { code?: string }} */
     const e = new Error('Polar connection missing userId — reconnect to obtain one');
     e.code = 'needs-reauth'; throw e;
   }

--- a/js/wearables-store.js
+++ b/js/wearables-store.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-store.js — L1 IndexedDB for raw wearable daily rows
 //
 // Per-profile database so wearable history doesn't leak across profiles.
@@ -97,6 +98,7 @@ async function _encryptRowIfEnabled(row) {
     // silently writing cleartext. The error propagates up to the adapter
     // sync orchestrator, which logs + shows a toast asking the user to
     // unlock. Better than silent downgrade.
+    /** @type {Error & { code?: string }} */
     const e = new Error('Wearable storage is encrypted; unlock with your passphrase before syncing.');
     e.code = 'session-locked';
     throw e;

--- a/js/wearables-summary.js
+++ b/js/wearables-summary.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-summary.js — L2 summary derivation + change gate
 //
 // Pure functions where possible so the gate logic is testable without IDB or DOM.
@@ -92,7 +93,7 @@ function isoWeekOf(dateStr) {
   const day = d.getUTCDay() || 7; // Sun=0 → 7
   d.setUTCDate(d.getUTCDate() + 4 - day);
   const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  const weekNum = Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+  const weekNum = Math.ceil((((d.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
   return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
 }
 

--- a/js/wearables-ultrahuman.js
+++ b/js/wearables-ultrahuman.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-ultrahuman.js — Ultrahuman Ring Air data layer (OAuth2)
 //
 // Targets the new OAuth2 partner API under /api/partners/v1/user_data/*,
@@ -29,6 +30,7 @@ async function uhGET(path, accessToken, params = {}) {
     let err;
     try { err = await res.json(); } catch { err = { error: res.statusText }; }
     const msg = err?.detail || err?.message || err?.error || res.statusText || 'Ultrahuman request failed';
+    /** @type {Error & { status?: number }} */
     const e = new Error(msg); e.status = res.status; throw e;
   }
   return res.json();

--- a/js/wearables-whoop.js
+++ b/js/wearables-whoop.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-whoop.js — WHOOP data layer
 //
 // BETA. WHOOP's API is a clean REST JSON API with cursor pagination. All
@@ -29,6 +30,7 @@ async function whoopGET(path, accessToken, params = {}) {
     let err;
     try { err = await res.json(); } catch { err = { error: res.statusText }; }
     const msg = err?.detail || err?.message || err?.error || res.statusText || 'WHOOP request failed';
+    /** @type {Error & { status?: number }} */
     const e = new Error(msg); e.status = res.status; throw e;
   }
   return res.json();

--- a/js/wearables-withings.js
+++ b/js/wearables-withings.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-withings.js — Withings data layer
 //
 // BETA. Withings's REST API quirks:
@@ -152,6 +153,7 @@ async function withingsPOST(action, accessToken, params = {}) {
   });
   if (!res.ok) {
     let err; try { err = await res.json(); } catch { err = { error: res.statusText }; }
+    /** @type {Error & { status?: number }} */
     const e = new Error(err?.error || err?.detail || res.statusText || 'Withings request failed');
     e.status = res.status; throw e;
   }
@@ -162,6 +164,7 @@ async function withingsPOST(action, accessToken, params = {}) {
     const msg = mapped
       ? `Withings ${code}: ${mapped}`
       : `Withings status ${code}: ${payload?.error || 'unknown'}`;
+    /** @type {Error & { status?: number, withingsCode?: number }} */
     const e = new Error(msg);
     // Codes 100, 101, 102, 243, 283, 284 all mean "token dead — reconnect"
     // → surface as 401 so the auth-refresh middleware retries once.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,17 @@
     "js/touch-tooltip.js",
     "js/url-safety.js",
     "js/utils.js",
+    "js/wearable-adapters.js",
+    "js/wearables-fitbit.js",
     "js/wearables-formatters.js",
+    "js/wearables-manual-form-ui.js",
+    "js/wearables-oura.js",
+    "js/wearables-polar.js",
+    "js/wearables-store.js",
+    "js/wearables-summary.js",
+    "js/wearables-ultrahuman.js",
+    "js/wearables-whoop.js",
+    "js/wearables-withings.js",
     "types/**/*.d.ts"
   ]
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.384';
+self.APP_VERSION = '1.8.385';


### PR DESCRIPTION
## Summary
- opt the core wearable registry, L1 store, L2 summary, manual form helper, and vendor fetcher modules into `// @ts-check`
- include the wearables core/fetcher cluster in `tsconfig.json`
- document existing custom error shapes for `status`, `code`, and `withingsCode` fields
- use numeric Date timestamps for ISO-week arithmetic in the checked summary module
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-wearables-fetchers.js`
- `node tests/test-wearables-manual.js`
- `node tests/test-wearables-sync-flow.js`
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is connecting or syncing a wearable source and confirming dashboard wearable cards still render normally.