### PR TITLE
[codex] Typecheck wearables UI modules

### DIFF
--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-apple-health.js — Apple Health XML import pipeline
 //
 // Apple's export format: a .zip containing `apple_health_export/export.xml`

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { state } from './state.js';
 import {
@@ -13,7 +15,7 @@ import { MANUAL_METRICS } from './wearables-manual.js';
 import { getChartColors } from './theme.js';
 import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
-import { _collectActiveChips, _renderNoteField, _renderTagChips } from './wearables-manual-form-ui.js';
+import { _collectActiveChips, _renderNoteField, _renderTagChips, inputValueById, inputValueFromElement } from './wearables-manual-form-ui.js';
 
 const WEARABLE_DETAIL_RANGES = [
   { key: '90d', days: 90, label: '90d', coverageSuffix: 'of last 90 days', emptyWindow: 'the last 90 days' },
@@ -136,12 +138,12 @@ export async function openWearableDetail(metricId, opts = {}) {
   const focusTarget = opts.fromRangeToggle
     ? modal.querySelector('.wearable-detail-range .ctx-btn-option.active')
     : modal.querySelector('.modal-close');
-  focusTarget?.focus?.();
+  if (focusTarget instanceof HTMLElement) focusTarget.focus();
   _installWearableModalFocusTrap(modal);
 
   const canvas = document.getElementById('chart-modal');
   if (canvas && (series.length > 0 || manualChartEntries.length > 0)) {
-    renderWearableChart(canvas, canon, m, series, manualChartEntries);
+    if (canvas instanceof HTMLCanvasElement) renderWearableChart(canvas, canon, m, series, manualChartEntries);
   }
 }
 
@@ -559,7 +561,8 @@ export function openManualAddFromDetail(metricId, event) {
       <button type="button" class="wearable-log-cancel" ${wearableActionAttrs('close-detail-manual-add')}>✕</button>
     </form>`;
   }
-  slot.querySelector('input[type="number"]')?.focus?.();
+  const firstNumberInput = slot.querySelector('input[type="number"]');
+  if (firstNumberInput instanceof HTMLElement) firstNumberInput.focus();
 }
 
 export function closeManualAddFromDetail() {
@@ -583,17 +586,17 @@ export async function saveManualEntryFromDetail(metricId, kind) {
   const op = _bumpManualEntryOp(metricId);
   const { logManualMetric, logManualBP, refreshManualSummary } = await import('./wearables-manual.js');
   const profileId = getActiveProfileId();
-  const date = document.getElementById('wlad-date')?.value;
+  const date = inputValueById('wlad-date');
   if (!date) {
     showNotification?.('Pick a date', 'error');
     return;
   }
   const formEl = document.querySelector('.wearable-manual-add-form');
   const tags = formEl ? _collectActiveChips(formEl) : [];
-  const note = document.getElementById('wlad-note')?.value || '';
+  const note = inputValueFromElement(document.getElementById('wlad-note'));
   try {
     if (kind === 'weight') {
-      const val = parseFloat(document.getElementById('wlad-val')?.value);
+      const val = parseFloat(inputValueById('wlad-val'));
       if (!val || val <= 0) {
         showNotification?.('Enter a weight', 'error');
         return;
@@ -604,7 +607,7 @@ export async function saveManualEntryFromDetail(metricId, kind) {
       }
       await logManualMetric(profileId, 'weight', { date, value: val, tags, note });
     } else if (kind === 'rhr') {
-      const val = parseInt(document.getElementById('wlad-val')?.value, 10);
+      const val = parseInt(inputValueById('wlad-val'), 10);
       if (!val || val <= 0) {
         showNotification?.('Enter a pulse', 'error');
         return;
@@ -615,9 +618,9 @@ export async function saveManualEntryFromDetail(metricId, kind) {
       }
       await logManualMetric(profileId, 'rhr', { date, value: val, tags, note });
     } else if (kind === 'bp') {
-      const sys = parseInt(document.getElementById('wlad-sys')?.value, 10);
-      const dia = parseInt(document.getElementById('wlad-dia')?.value, 10);
-      const pulse = parseInt(document.getElementById('wlad-pulse')?.value, 10);
+      const sys = parseInt(inputValueById('wlad-sys'), 10);
+      const dia = parseInt(inputValueById('wlad-dia'), 10);
+      const pulse = parseInt(inputValueById('wlad-pulse'), 10);
       if (!sys || !dia || sys <= 0 || dia <= 0) {
         showNotification?.('Enter systolic and diastolic', 'error');
         return;

--- a/js/wearables-manual-form-ui.js
+++ b/js/wearables-manual-form-ui.js
@@ -26,6 +26,15 @@ export function _collectActiveChips(card) {
   return Array.from(card.querySelectorAll('.wearable-log-chip.active')).map(b => b.dataset.tag);
 }
 
+export function inputValueFromElement(el) {
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) return el.value;
+  return '';
+}
+
+export function inputValueById(id) {
+  return inputValueFromElement(document.getElementById(id));
+}
+
 // Shared note-textarea snippet for both manual-log forms. The `idSuffix`
 // disambiguates dashboard-card (`wl-...-note`) vs detail-modal (`wlad-note`).
 export function _renderNoteField(idSuffix = 'wl-note') {

--- a/js/wearables-manual.js
+++ b/js/wearables-manual.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-manual.js — Manual entry as a first-class wearable source.
 //
 // Treats user-entered weight / BP / pulse as rows in the wearables IndexedDB

--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables-settings-panel.js — Settings → Wearables integrations panel.
 // Keeps provider rows, connection actions, Apple Health import controls, and
 // manual-source management out of the dashboard strip renderer.
@@ -352,7 +353,9 @@ async function _updateManualCounts() {
 // Fire when the details element opens (delegated — the Settings section is
 // re-rendered on demand so we can't bind once at module load).
 document.addEventListener('toggle', (e) => {
-  if (e.target?.matches?.('details.wearable-row[data-adapter="manual"]') && e.target.open) {
+  if (e.target instanceof HTMLDetailsElement
+      && e.target.matches('details.wearable-row[data-adapter="manual"]')
+      && e.target.open) {
     _updateManualCounts();
   }
 }, true);
@@ -393,7 +396,7 @@ async function importAppleHealthFlow(file) {
   if (wrap) wrap.style.display = 'block';
   try {
     const res = await importAppleHealthFile(file, ({ stage, pct, rows, startDate, endDate }) => {
-      if (bar) bar.style.width = (pct ?? 0) + '%';
+      if (bar instanceof HTMLElement) bar.style.width = (pct ?? 0) + '%';
       if (text) text.textContent = stage === 'done'
         ? `${rows} days imported (${startDate} – ${endDate})`
         : `${stage}… ${pct ?? 0}%`;

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -1,3 +1,4 @@
+// @ts-check
 // wearables.js — Dashboard wearable strip
 // Source-agnostic: reads `wearableSummary` (the L2 shape that ships to Evolu)
 // and walks CANONICAL_METRICS via the registry in wearable-adapters.js.
@@ -27,6 +28,8 @@ import {
   _collectActiveChips,
   _renderNoteField,
   _renderTagChips,
+  inputValueById,
+  inputValueFromElement,
   toggleManualLogChip,
 } from './wearables-manual-form-ui.js';
 import {
@@ -139,7 +142,10 @@ function rerenderCurrentView() {
 
 function resetOpenManualLogForms({ exceptMetricId = '' } = {}) {
   const openForms = Array.from(document.querySelectorAll('.wearable-card-empty .wearable-log-form'));
-  const shouldReset = openForms.some(form => form.closest('.wearable-card-empty')?.dataset.emptyMetric !== exceptMetricId);
+  const shouldReset = openForms.some(form => {
+    const card = form.closest('.wearable-card-empty');
+    return !(card instanceof HTMLElement) || card.dataset.emptyMetric !== exceptMetricId;
+  });
   if (!shouldReset) return false;
   rerenderCurrentView();
   return true;
@@ -830,6 +836,7 @@ async function chooseWearableSource(metricId, event) {
 
   // Wire clicks — pick a source, persist override, re-render strip.
   picker.querySelectorAll('[data-source]').forEach(btn => {
+    if (!(btn instanceof HTMLElement)) return;
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();
       const sid = btn.dataset.source;
@@ -1008,12 +1015,16 @@ function openManualLogForm(metricId, event, opts = {}) {
       </div>`;
   }
   // Focus the first input.
-  setTimeout(() => card.querySelector('input[type="number"]')?.focus(), 0);
+  setTimeout(() => {
+    const firstNumberInput = card.querySelector('input[type="number"]');
+    if (firstNumberInput instanceof HTMLElement) firstNumberInput.focus();
+  }, 0);
   // Enter-to-save on the number inputs.
   card.querySelectorAll('input[type="number"]').forEach((el) => {
     el.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') { e.preventDefault(); saveManualLog(metricId === 'bp_systolic' ? 'bp' : metricId, e); }
-      if (e.key === 'Escape') { e.preventDefault(); cancelManualLog(e); }
+      const keyEvent = /** @type {KeyboardEvent} */ (e);
+      if (keyEvent.key === 'Enter') { e.preventDefault(); saveManualLog(metricId === 'bp_systolic' ? 'bp' : metricId, e); }
+      if (keyEvent.key === 'Escape') { e.preventDefault(); cancelManualLog(e); }
     });
   });
 }
@@ -1029,26 +1040,25 @@ async function saveManualLog(kind, event) {
     kind === 'bp'     ? document.querySelector('.wearable-card-empty[data-empty-metric="bp_systolic"]') : null;
   const tags = cardForTags ? _collectActiveChips(cardForTags) : [];
   // Note field — id varies by kind ('wl-weight-note' / 'wl-bp-note' / 'wl-rhr-note').
-  const noteEl = document.getElementById(`wl-${kind === 'bp' ? 'bp' : kind}-note`);
-  const note = noteEl ? noteEl.value : '';
+  const note = inputValueFromElement(document.getElementById(`wl-${kind === 'bp' ? 'bp' : kind}-note`));
   try {
     if (kind === 'weight') {
-      const val = parseFloat(document.getElementById('wl-weight-val')?.value);
-      const date = document.getElementById('wl-weight-date')?.value;
+      const val = parseFloat(inputValueById('wl-weight-val'));
+      const date = inputValueById('wl-weight-date');
       if (!val || val <= 0 || !date) { showNotification?.('Enter a weight and date', 'error'); return; }
       if (val > 500) { showNotification?.('Weight over 500 kg seems unlikely', 'error'); return; }
       await logManualMetric(profileId, 'weight', { date, value: val, tags, note });
     } else if (kind === 'rhr') {
-      const val = parseInt(document.getElementById('wl-rhr-val')?.value, 10);
-      const date = document.getElementById('wl-rhr-date')?.value;
+      const val = parseInt(inputValueById('wl-rhr-val'), 10);
+      const date = inputValueById('wl-rhr-date');
       if (!val || val <= 0 || !date) { showNotification?.('Enter a pulse and date', 'error'); return; }
       if (val > 250) { showNotification?.('Pulse over 250 bpm seems unlikely', 'error'); return; }
       await logManualMetric(profileId, 'rhr', { date, value: val, tags, note });
     } else if (kind === 'bp') {
-      const sys = parseInt(document.getElementById('wl-bp-sys')?.value, 10);
-      const dia = parseInt(document.getElementById('wl-bp-dia')?.value, 10);
-      const pulse = parseInt(document.getElementById('wl-bp-pulse')?.value, 10);
-      const date = document.getElementById('wl-bp-date')?.value;
+      const sys = parseInt(inputValueById('wl-bp-sys'), 10);
+      const dia = parseInt(inputValueById('wl-bp-dia'), 10);
+      const pulse = parseInt(inputValueById('wl-bp-pulse'), 10);
+      const date = inputValueById('wl-bp-date');
       if (!sys || !dia || sys <= 0 || dia <= 0 || !date) { showNotification?.('Enter systolic, diastolic, and date', 'error'); return; }
       if (sys > 300 || dia > 200) { showNotification?.('BP values seem too high', 'error'); return; }
       if (dia >= sys) { showNotification?.('Diastolic should be lower than systolic', 'error'); return; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,15 +39,19 @@
     "js/url-safety.js",
     "js/utils.js",
     "js/wearable-adapters.js",
+    "js/wearables-apple-health.js",
     "js/wearables-connect.js",
+    "js/wearables-detail-modal.js",
     "js/wearables-fitbit-auth.js",
     "js/wearables-fitbit.js",
     "js/wearables-formatters.js",
+    "js/wearables-manual.js",
     "js/wearables-manual-form-ui.js",
     "js/wearables-oura-auth.js",
     "js/wearables-oura.js",
     "js/wearables-polar-auth.js",
     "js/wearables-polar.js",
+    "js/wearables-settings-panel.js",
     "js/wearables-store.js",
     "js/wearables-summary.js",
     "js/wearables-ultrahuman-auth.js",
@@ -56,6 +60,7 @@
     "js/wearables-whoop.js",
     "js/wearables-withings-auth.js",
     "js/wearables-withings.js",
+    "js/wearables.js",
     "types/**/*.d.ts"
   ]
 }

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -19,6 +19,9 @@ interface Window {
   cashuGetMintUrl?: () => Promise<string | null> | string | null;
   cashuRestoreWalletFromSeed?: (seed: string) => Promise<void> | void;
   cashuSetMintUrl?: (url: string) => Promise<void> | void;
+  Chart?: new (canvas: HTMLCanvasElement, config: unknown) => { destroy(): void };
+  closeModal?: () => void;
+  closeSettings?: () => void;
   destroyAllCharts?: () => void;
   detectDNAFile?: (header: string) => string | null;
   ensureActiveThread?: () => void;
@@ -55,10 +58,13 @@ interface Window {
   nostrSetSelectedNode?: (url: string) => void;
   openClientList?: () => void;
   closeClientList?: () => void;
+  openEMFAssessmentEditor?: () => void;
+  openSettingsModal?: (tab?: string) => void;
   pdfjsLib?: unknown;
   openProfileShareModal?: (profileId?: string) => void;
   refreshChartThemeColors?: (options?: { batchSize?: number }) => void;
   refreshSettingsWearables?: () => void;
+  rememberModalTrigger?: () => void;
   renderProfileButton?: () => void;
   renderThreadList?: () => void;
   scheduleChartThemeRefresh?: () => void;
@@ -66,6 +72,7 @@ interface Window {
   showConfirmDialog?: (message: string) => Promise<boolean> | boolean;
   showNotification?: (message: string, type?: string, timeoutMs?: number) => void;
   _fitbitAuth?: unknown;
+  _appleHealth?: unknown;
   _ouraAuth?: unknown;
   _polarAuth?: unknown;
   _ultrahumanAuth?: unknown;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.386';
+self.APP_VERSION = '1.8.387';


### PR DESCRIPTION
## Summary
- opt the remaining wearables UI/import modules into `// @ts-check`
- include the wearables facade, settings panel, detail modal, manual source, and Apple Health importer in `tsconfig.json`
- add minimal declarations for existing app globals used by the checked modules
- narrow queried DOM elements before reading `dataset`, `value`, `style`, `focus`, or constructing charts
- bump the app version for cache invalidation

## Validation
- `git diff --check`
- `npm run typecheck`
- `node tests/test-wearables-delegated-actions.js`
- `node tests/test-wearables-bp-merge.js`
- `node tests/test-wearables-runtime-config.js`
- `node tests/test-wearables.js`
- `node tests/test-wearables-manual.js`
- `node tests/test-wearables-sync-flow.js`
- `npm test`
- `./run-tests.sh`

## Manual testing
- None required; optional smoke is opening Settings -> Wearables, expanding Manual/Apple Health rows, and opening a wearable detail card.