### PR TITLE
[codex] Typecheck light device core

### DIFF
--- a/js/light-device-session-engine.js
+++ b/js/light-device-session-engine.js
@@ -1,3 +1,4 @@
+// @ts-check
 // light-device-session-engine.js — shared dose math for light-device sessions.
 //
 // UI/store modules own dialogs and persistence. This module owns the repeated
@@ -5,6 +6,17 @@
 // spectrum synthesis, and SAD-lux fallback.
 
 import { BODY_REGIONS } from './sun-body-silhouette.js';
+
+/**
+ * @typedef {object} DeviceSessionDoseInput
+ * @property {any} [device]
+ * @property {number} [durationMin]
+ * @property {number} [distanceCm]
+ * @property {string} [bodyArea]
+ * @property {string[]|null} [bodyAreas]
+ * @property {boolean} [eyesProtected]
+ * @property {string|null} [mode]
+ */
 
 export const DEVICE_BODY_AREA_FRACTIONS = {
   face: 0.04,
@@ -64,6 +76,10 @@ export function deviceDistanceFactor(device, distanceCm = 15) {
   return Math.min(rawDistFactor, 3.0);
 }
 
+/**
+ * @param {DeviceSessionDoseInput} [input]
+ * @param {any} [deps]
+ */
 export function computeDeviceSessionDoses({
   device,
   durationMin,

--- a/js/light-devices-store.js
+++ b/js/light-devices-store.js
@@ -1,3 +1,4 @@
+// @ts-check
 // light-devices-store.js - persisted light-device and device-session mutations.
 //
 // UI modules own preset loading, dialogs, rendering, and notifications. This
@@ -107,6 +108,9 @@ export async function deleteDevice(id) {
   return true;
 }
 
+/**
+ * @param {{deviceId?: string, durationMin?: number, distanceCm?: number, bodyArea?: string, bodyAreas?: string[]|null, eyesProtected?: boolean, notes?: string, mode?: string|null}} [input]
+ */
 export async function logDeviceSession({ deviceId, durationMin, distanceCm = 15, bodyArea = 'torso', bodyAreas = null, eyesProtected = true, notes = '', mode = null } = {}) {
   const device = getDevices().find(d => d.id === deviceId);
   if (!device) return null;
@@ -152,6 +156,9 @@ export function getActiveDeviceSession() {
   return getDeviceSessions().find(s => !s.endedAt) || null;
 }
 
+/**
+ * @param {{deviceId?: string, distanceCm?: number, bodyAreas?: string[]|null, bodyArea?: string, eyesProtected?: boolean, mode?: string|null}} [input]
+ */
 export async function startDeviceSession({ deviceId, distanceCm = 15, bodyAreas = null, bodyArea = 'torso', eyesProtected = true, mode = null } = {}) {
   // Reject a second active timer - one session at a time keeps the
   // active-card UI unambiguous and matches sun-session semantics.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,8 @@
     "js/light-audit-ai-analysis.js",
     "js/light-burden-ai-analysis.js",
     "js/light-channels-ai-analysis.js",
+    "js/light-device-session-engine.js",
+    "js/light-devices-store.js",
     "js/light-device-ai-analysis.js",
     "js/light-env-ai-analysis.js",
     "js/light-screen-ai-analysis.js",

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -38,6 +38,9 @@ interface Window {
   fetchAtmosphere?: AnyFunction;
   reconstructSpectrum?: AnyFunction;
   computeChannelDoses?: AnyFunction;
+  synthesizeDeviceSpectrum?: AnyFunction;
+  effectiveDeviceForMode?: AnyFunction;
+  validateModeCoupling?: AnyFunction;
   erythemalSED?: AnyFunction;
   fractionOfMED?: AnyFunction;
   retinalUVdose?: AnyFunction;
@@ -60,6 +63,7 @@ interface Window {
   tierLabel?: (tier: number) => string;
   getSessions?: () => any[];
   getDeviceSessions?: () => any[];
+  maybeAnalyzeDeviceSessionAfterFinish?: AnyFunction;
   maybeAnalyzeSessionAfterFinish?: AnyFunction;
   _labState?: { currentProfile?: string | null };
   handleDNAFile: (file: File) => Promise<void> | void;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.391';
+self.APP_VERSION = '1.8.392';


### PR DESCRIPTION
## Summary
- Add `// @ts-check` coverage for the Light device session engine and persisted device-session store.
- Add narrow JSDoc parameter shapes for the public store/session functions TypeScript checks could not infer from destructured defaults.
- Declare the existing browser globals used by the newly checked Light device core (`maybeAnalyzeDeviceSessionAfterFinish`, `synthesizeDeviceSpectrum`, `effectiveDeviceForMode`, and `validateModeCoupling`) and bump `APP_VERSION` to `1.8.392` for cache invalidation.

## Validation
- `npm run typecheck`
- `node tests/test-light-devices.js`
- `node tests/test-light-devices-store.js`
- `npm test`
- `git diff --check`

Manual testing: not required; this is a typecheck-only annotation/config/declaration change with targeted automated coverage.