### PR TITLE
[codex] Typecheck charts module

### DIFF
--- a/js/charts.js
+++ b/js/charts.js
@@ -1,3 +1,4 @@
+// @ts-check
 // charts.js — Chart.js plugins, chart creation, marker descriptions
 
 import { state } from './state.js';
@@ -8,11 +9,15 @@ import { getEffectiveRange, getEffectiveRangeForDate, getPhaseRefEnvelope } from
 const CHART_JS_SRC = '/vendor/chart.min.js';
 const CHART_DATE_ADAPTER_SRC = '/vendor/chartjs-adapter-native.js';
 
+const chartWindow = /** @type {Window & typeof globalThis & {
+  __labChartDateAdapterLoaded?: boolean
+}} */ (window);
+
 let _chartJsLoad = null;
 let _chartDateAdapterLoad = null;
 
 export function isChartDateAdapterReady() {
-  return window.__labChartDateAdapterLoaded === true;
+  return chartWindow.__labChartDateAdapterLoaded === true;
 }
 
 function ensureChartDateAdapter() {
@@ -20,7 +25,7 @@ function ensureChartDateAdapter() {
   if (!_chartDateAdapterLoad) {
     _chartDateAdapterLoad = loadScriptOnce(CHART_DATE_ADAPTER_SRC)
       .then(() => {
-        window.__labChartDateAdapterLoaded = true;
+        chartWindow.__labChartDateAdapterLoaded = true;
         return window.Chart;
       })
       .catch(err => {
@@ -491,7 +496,7 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
   if (!marker.singlePoint && chartDates && chartDates.length > 0) {
     const today = new Date().toISOString().slice(0, 10);
     const lastDate = chartDates[chartDates.length - 1];
-    const daysSince = Math.round((new Date(today) - new Date(lastDate + 'T00:00:00')) / 86400000);
+    const daysSince = Math.round((new Date(today).getTime() - new Date(lastDate + 'T00:00:00').getTime()) / 86400000);
     if (daysSince >= 30) {
       chartDates = [...chartDates, today];
       dates = [...dates, 'Today'];
@@ -507,7 +512,7 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
     const dobDate = new Date(state.profileDob + 'T00:00:00');
     chronoAgeValues = chartDates.map(d => {
       const draw = new Date(d + 'T00:00:00');
-      const age = (draw - dobDate) / (365.25 * 24 * 60 * 60 * 1000);
+      const age = (draw.getTime() - dobDate.getTime()) / (365.25 * 24 * 60 * 60 * 1000);
       return age > 0 ? Math.round(age * 10) / 10 : null;
     });
   }
@@ -534,13 +539,13 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
   const rawDates = chartDates || [];
   const chartNotes = marker.singlePoint ? [] : getNotesForChart(rawDates);
   const chartSupps = marker.singlePoint ? [] : getSupplementsForChart(rawDates);
-  const datasets = [{
+  const datasets = /** @type {Array<Record<string, any>>} */ ([{
     data: values, borderColor: tc.lineColor, backgroundColor: tc.lineFill,
     borderWidth: 2.5, pointBackgroundColor: ptColors, pointBorderColor: ptColors,
     pointStyle: ptStyles, pointRadius: 6, pointHoverRadius: 8, tension: 0.3, fill: false, spanGaps: true,
     label: isPhenoAge ? 'Biological Age' : '',
     _gbPointStatuses: ptStatuses
-  }];
+  }]);
   if (chronoAgeValues) {
     datasets.push({
       data: chronoAgeValues, borderColor: tc.chronoLineColor, backgroundColor: "transparent",
@@ -562,7 +567,7 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
         ticks: { color: tc.tickColor, font: { size: 11 }, maxTicksLimit: 6, autoSkip: true, maxRotation: 0 },
         grid: { display: false } }
     : { ticks: { color: tc.tickColor, font: { size: 11 }, maxRotation: 0, autoSkip: true }, grid: { display: false } };
-  state.chartInstances[id] = new window.Chart(canvas, {
+  state.chartInstances[id] = new window.Chart(/** @type {HTMLCanvasElement} */ (canvas), {
     type: "line",
     data: { labels: chartLabels, datasets },
     options: { responsive:true, maintainAspectRatio:false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "js/category-page-view.js",
     "js/category-view-renderers.js",
     "js/chart-card-recs.js",
+    "js/charts.js",
     "js/chat-actions.js",
     "js/chat-attestation.js",
     "js/chat-continuation.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.420';
+self.APP_VERSION = '1.8.421';


### PR DESCRIPTION
## Summary
- Enroll `js/charts.js` in TypeScript checking with `// @ts-check`.
- Add a narrow window cast for the Chart.js date-adapter readiness flag.
- Replace implicit `Date` subtraction with explicit `getTime()` math.
- Type the mixed chart dataset array and cast the chart canvas before constructing `Chart`.
- Bump `version.js` to `1.8.421` for the app-file change.

## Typecheck coverage
- `tsconfig` JS coverage: `277/289 (95.8%)` -> `278/289 (96.2%)`.
- Remaining files: `js/api.js`, `js/cashu-wallet.js`, `js/data.js`, `js/dna.js`, `js/emf.js`, `js/lab-context.js`, `js/lens-local-worker.js`, `js/lens.js`, `js/pdf-import.js`, `js/recommendations.js`, `js/settings.js`.

## Validation
- `npm run typecheck`
- `git diff --check`
- `node tests/test-cycle-improvements.js`
- `node tests/test-phase-ranges.js`
- `node tests/test-audit.js`
- `./run-tests.sh`

Note: I did not run local Greptile for this PR; relying on the GitHub-side review flow.