### PR TITLE
[codex] Typecheck lens local worker

### DIFF
--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -1,3 +1,4 @@
+// @ts-check
 // js/lens-local-worker.js — browser-side lens engine (no Python, no server).
 //
 // Runs in a module Web Worker. Owns all OPFS I/O and all calls into
@@ -238,7 +239,8 @@ async function _ensureTransformers() {
   // ESM locally via a bundler pass at vendor-update time; tracked as
   // phase 2c in project_browser_local_lens.md. Until then, trust is
   // rooted in jsdelivr + our CSP's cdn.jsdelivr.net allowlist.
-  const mod = await import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.1.0');
+  const transformersUrl = 'https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.1.0';
+  const mod = await import(transformersUrl);
   // ORT picks one of 4 WASM variants at runtime (plain / asyncify / jsep /
   // jspi) based on what the browser supports — SharedArrayBuffer gates
   // threaded, cross-origin isolation headers gate jsep, etc. Vendoring
@@ -342,7 +344,7 @@ async function _loadEmbedder(modelKey) {
       `[lens-local] Embedding benchmark: ${_modelKey} on ${_embedderBackend}, ` +
       `${_benchmarkVerdict.msPerEmbed.toFixed(0)} ms/embed median → tier ${_benchmarkVerdict.tier} (${_benchmarkVerdict.tierLabel})`
     );
-    self._lensLocalBenchmark = _benchmarkVerdict; // devtools inspection
+    /** @type {any} */ (self)._lensLocalBenchmark = _benchmarkVerdict; // devtools inspection
   } catch (err) {
     console.warn('[lens-local] benchmark failed:', err?.message || err);
     _benchmarkVerdict = null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -104,6 +104,7 @@
     "js/lens-local.js",
     "js/lens-local-parsers.js",
     "js/lens-local-utils.js",
+    "js/lens-local-worker.js",
     "js/light-audit-ai-analysis.js",
     "js/light-burden-ai-analysis.js",
     "js/light-channel-view.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.426';
+self.APP_VERSION = '1.8.427';


### PR DESCRIPTION
## Summary

- Enable `@ts-check` for the browser-local Lens worker.
- Add the worker to the TypeScript checked-file set.
- Keep runtime behavior unchanged by preserving the CDN dynamic import and casting only the devtools benchmark hook.
- Bump `version.js` for cache invalidation.

## Typecheck Coverage

- Before: 281/289 JS files checked (97.2%)
- After: 282/289 JS files checked (97.6%)
- Remaining unchecked: `js/api.js`, `js/data.js`, `js/dna.js`, `js/lab-context.js`, `js/lens.js`, `js/pdf-import.js`, `js/settings.js`

## Validation

- `npm run typecheck`
- `node tests/test-lens-local-utils.js`
- `node tests/test-lens-parsers.js`
- `git diff --check`
- `./run-tests.sh`