### PR TITLE
[codex] Typecheck data pipeline

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -36,9 +36,9 @@ export {
  * @typedef {() => Array<number | null | undefined> | undefined} MarkerValueGetter
  * @typedef {[MarkerValueGetter | 'age' | 'crp', number, number, boolean, number | null, 'ceil' | 'floor' | null, (number | undefined)?]} BortzFeature
  * @typedef {{
- *   buildSidebar?: (data?: unknown) => void,
+ *   buildSidebar: (data?: unknown) => void,
  *   invalidateLabContextCache?: () => void,
- *   navigate?: (route?: string, data?: unknown) => void,
+ *   navigate: (route?: string, data?: unknown) => void,
  *   showDetailModal?: (id: string) => void,
  * }} DataWindowHooks
  */
@@ -694,8 +694,8 @@ export function setDateRange(range) {
   // re-applies the correct active class. Source the target view from
   // state.currentView (set by navigate) rather than the DOM, since the
   // DOM's active class has just been clobbered by buildSidebar.
-  window.buildSidebar();
-  window.navigate(state.currentView || 'dashboard');
+  dataWindow.buildSidebar();
+  dataWindow.navigate(state.currentView || 'dashboard');
 }
 
 export function renderChartLayersDropdown() {
@@ -765,21 +765,21 @@ export function setSuppOverlay(mode) {
   state.suppOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'suppOverlay'), state.suppOverlayMode);
   const activeCat = _getActiveNavCategory();
-  window.navigate(activeCat);
+  dataWindow.navigate(activeCat);
 }
 
 export function setNoteOverlay(mode) {
   state.noteOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'noteOverlay'), state.noteOverlayMode);
   const activeCat = _getActiveNavCategory();
-  window.navigate(activeCat);
+  dataWindow.navigate(activeCat);
 }
 
 export function setPhaseOverlay(mode) {
   state.phaseOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'phaseOverlay'), state.phaseOverlayMode);
   const activeCat = _getActiveNavCategory();
-  window.navigate(activeCat);
+  dataWindow.navigate(activeCat);
 }
 
 export function recalculateHOMAIR(entry) {
@@ -811,11 +811,11 @@ export function switchUnitSystem(system) {
   // Matches the pattern in toggleAltUnits().
   const openId = state._activeDetailMarkerId;
   const data = getActiveData();
-  window.buildSidebar(data);
+  dataWindow.buildSidebar(data);
   updateHeaderDates(data);
-  window.navigate(state.currentView || 'dashboard', data);
-  if (openId && typeof window.showDetailModal === 'function') {
-    window.showDetailModal(openId);
+  dataWindow.navigate(state.currentView || 'dashboard', data);
+  if (openId && typeof dataWindow.showDetailModal === 'function') {
+    dataWindow.showDetailModal(openId);
   }
 }
 
@@ -834,8 +834,8 @@ export function toggleAltUnits(force) {
   // Refresh the currently-visible detail modal so the alt-unit lines update
   // without a full navigate (the modal lives outside the page rebuild).
   const openId = state._activeDetailMarkerId;
-  if (openId && typeof window.showDetailModal === 'function') {
-    window.showDetailModal(openId);
+  if (openId && typeof dataWindow.showDetailModal === 'function') {
+    dataWindow.showDetailModal(openId);
   }
 }
 
@@ -878,10 +878,10 @@ export function switchRangeMode(mode) {
   _afterNextPaint(() => {
     if (token !== _rangeModeRefreshToken || state.rangeMode !== nextMode) return;
     const data = getActiveData();
-    window.buildSidebar(data);
-    window.navigate(state.currentView || 'dashboard', data);
-    if (openId && state._activeDetailMarkerId === openId && typeof window.showDetailModal === 'function') {
-      window.showDetailModal(openId);
+    dataWindow.buildSidebar(data);
+    dataWindow.navigate(state.currentView || 'dashboard', data);
+    if (openId && state._activeDetailMarkerId === openId && typeof dataWindow.showDetailModal === 'function') {
+      dataWindow.showDetailModal(openId);
     }
   });
 }

--- a/js/data.js
+++ b/js/data.js
@@ -1,3 +1,4 @@
+// @ts-check
 // data.js — Data pipeline, unit conversion, date range, trend detection
 
 import { state } from './state.js';
@@ -30,6 +31,20 @@ export {
   statusIcon,
 } from './marker-analysis.js';
 
+/**
+ * @typedef {Record<string, any>} ImportedDataRecord
+ * @typedef {() => Array<number | null | undefined> | undefined} MarkerValueGetter
+ * @typedef {[MarkerValueGetter | 'age' | 'crp', number, number, boolean, number | null, 'ceil' | 'floor' | null, (number | undefined)?]} BortzFeature
+ * @typedef {{
+ *   buildSidebar?: (data?: unknown) => void,
+ *   invalidateLabContextCache?: () => void,
+ *   navigate?: (route?: string, data?: unknown) => void,
+ *   showDetailModal?: (id: string) => void,
+ * }} DataWindowHooks
+ */
+
+const dataWindow = /** @type {Window & typeof globalThis & DataWindowHooks} */ (window);
+
 // ═══════════════════════════════════════════════
 // PRIVATE CYCLE PHASE HELPER (avoids circular dep with cycle.js)
 // ═══════════════════════════════════════════════
@@ -43,7 +58,7 @@ function _getCyclePhase(dateStr, mc) {
   }
   if (!periodStart) return null;
   const startDate = new Date(periodStart + 'T00:00:00');
-  const cycleDay = Math.floor((target - startDate) / 86400000) + 1;
+  const cycleDay = Math.floor((target.getTime() - startDate.getTime()) / 86400000) + 1;
   const cycleLen = mc.cycleLength || 28;
   if (cycleDay > cycleLen + 7) return null;
   const periodLen = mc.periodLength || 5;
@@ -92,7 +107,7 @@ function _activeDataCacheMatches(meta) {
 }
 
 function _makeActiveDataCacheMeta() {
-  const importedData = state.importedData || {};
+  const importedData = /** @type {ImportedDataRecord} */ (state.importedData || {});
   const entries = importedData.entries || null;
   const biometrics = importedData.biometrics || null;
   const wearableSummary = importedData.wearableSummary || null;
@@ -138,7 +153,7 @@ export async function saveImportedData(options = {}) {
     broadcastDataChanged(state.currentProfile);
     scheduleAutoBackup();
     touchProfileTimestamp(state.currentProfile);
-    if (window.invalidateLabContextCache) window.invalidateLabContextCache();
+    if (dataWindow.invalidateLabContextCache) dataWindow.invalidateLabContextCache();
     onDataSaved(options);
     return true;
   } catch (e) {
@@ -452,7 +467,7 @@ export function getActiveData() {
       if (!state.profileDob) return null;
       const dob = new Date(state.profileDob + 'T00:00:00');
       const draw = new Date(dateStr + 'T00:00:00');
-      const age = (draw - dob) / (365.25 * 24 * 60 * 60 * 1000);
+      const age = (draw.getTime() - dob.getTime()) / (365.25 * 24 * 60 * 60 * 1000);
       return age > 0 ? age : null;
     };
 
@@ -503,7 +518,7 @@ export function getActiveData() {
     // Coefficients and means from longevityworldcup.com (inspired by their open implementation)
     // Units: all SI as stored in schema, except ALP/GGT/ALT which need µkat/L→U/L (×60)
     // and lymphocytesPct which needs fraction→% (×100)
-    const _bortzFeatures = [
+    const _bortzFeatures = /** @type {BortzFeature[]} */ ([
       // [getValue fn,                                    mean,     coeff,   log, capVal, capMode]
       ['age',                                             56.049,  -0.026,  false, null,  null],
       [() => getVals('proteins', 'albumin'),              45.124,  -0.011,  false, 54,    'ceil'],
@@ -527,7 +542,7 @@ export function getActiveData() {
       [() => getVals('biochemistry', 'glucose'),            4.956,  0.0322, false, 4.44,  'floor'],
       [() => getVals('hematology', 'mch'),                 31.840,  0.0275, false, 25.7,  'floor'],
       [() => getVals('lipids', 'apoAI'),                    1.524, -0.185,  false, 1.82,  'ceil'],
-    ];
+    ]);
 
     ratios.markers.bortzAge.values = sortedDates.map((dateStr, i) => {
       const age = _ageAt(dateStr);
@@ -707,11 +722,16 @@ export function renderChartLayersDropdown() {
   </div>`;
 }
 
+function _getActiveNavCategory() {
+  const activeNav = /** @type {HTMLElement | null} */ (document.querySelector('.nav-item.active'));
+  return activeNav?.dataset.category || 'dashboard';
+}
+
 export function toggleChartLayersDropdown(e) {
   e.stopPropagation();
   const dd = document.getElementById('chart-layers-dropdown');
   if (!dd) return;
-  const trigger = dd.parentElement?.querySelector('.chart-layers-trigger');
+  const trigger = /** @type {HTMLButtonElement | null} */ (dd.parentElement?.querySelector('.chart-layers-trigger') || null);
   const isOpen = dd.classList.contains('open');
   dd.classList.toggle('open', !isOpen);
   if (trigger) trigger.setAttribute('aria-expanded', String(!isOpen));
@@ -744,24 +764,21 @@ export function toggleChartLayersDropdown(e) {
 export function setSuppOverlay(mode) {
   state.suppOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'suppOverlay'), state.suppOverlayMode);
-  const activeNav = document.querySelector('.nav-item.active');
-  const activeCat = activeNav ? activeNav.dataset.category : 'dashboard';
+  const activeCat = _getActiveNavCategory();
   window.navigate(activeCat);
 }
 
 export function setNoteOverlay(mode) {
   state.noteOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'noteOverlay'), state.noteOverlayMode);
-  const activeNav = document.querySelector('.nav-item.active');
-  const activeCat = activeNav ? activeNav.dataset.category : 'dashboard';
+  const activeCat = _getActiveNavCategory();
   window.navigate(activeCat);
 }
 
 export function setPhaseOverlay(mode) {
   state.phaseOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'phaseOverlay'), state.phaseOverlayMode);
-  const activeNav = document.querySelector('.nav-item.active');
-  const activeCat = activeNav ? activeNav.dataset.category : 'dashboard';
+  const activeCat = _getActiveNavCategory();
   window.navigate(activeCat);
 }
 
@@ -888,7 +905,7 @@ export function updateHeaderRangeToggle() {
   const el = document.getElementById('header-range-toggle');
   if (!el) return;
   const modes = ['optimal', 'reference', 'both'];
-  const buttons = Array.from(el.querySelectorAll('.range-toggle-btn'));
+  const buttons = /** @type {HTMLButtonElement[]} */ (Array.from(el.querySelectorAll('.range-toggle-btn')));
   const canPatch = buttons.length === modes.length && modes.every(m => buttons.some(btn => btn.dataset.range === m));
   if (!canPatch) {
     el.innerHTML = modes.map(m =>

--- a/tests/test-manual-entry-flow.js
+++ b/tests/test-manual-entry-flow.js
@@ -216,11 +216,11 @@ console.log('=== Manual Entry Flow Tests ===\n');
 
   const dataSrc = read('js/data.js');
   assert('switchUnitSystem uses state.currentView (no .nav-item.active query)',
-    /switchUnitSystem[\s\S]{0,800}window\.navigate\(state\.currentView \|\| 'dashboard'/.test(dataSrc) &&
+    /switchUnitSystem[\s\S]{0,800}dataWindow\.navigate\(state\.currentView \|\| 'dashboard'/.test(dataSrc) &&
     !/switchUnitSystem[\s\S]{0,800}document\.querySelector\(".nav-item\.active"\)/.test(dataSrc));
   const switchRangeModeBody = dataSrc.match(/export function switchRangeMode\(mode\)[\s\S]*?\n}\n\nexport function updateHeaderDates/)?.[0] || '';
   assert('switchRangeMode uses state.currentView (no .nav-item.active query)',
-    /window\.navigate\(state\.currentView \|\| 'dashboard'/.test(switchRangeModeBody) &&
+    /dataWindow\.navigate\(state\.currentView \|\| 'dashboard'/.test(switchRangeModeBody) &&
     !/document\.querySelector\(["']\.nav-item\.active["']\)/.test(switchRangeModeBody));
   assert('setDateRange uses state.currentView',
     /setDateRange[\s\S]{0,1500}navigate\(state\.currentView \|\| 'dashboard'/.test(dataSrc));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -753,8 +753,8 @@ return (async function() {
   await wait(50);
   const staticNavCategories = new Set([
     'dashboard', 'labs', 'correlations', 'compare', 'recommendations',
-    'knowledge', 'custom-markers', 'light', 'body', 'wearables', 'emf',
-    'genome', 'genetics', 'insight',
+    'reports', 'knowledge', 'custom-markers', 'light', 'body', 'wearables',
+    'emf', 'light-env-assessment', 'genome', 'genetics', 'insight',
   ]);
   const getFilterableNavItems = () => [...sidebar.querySelectorAll('.nav-item')]
     .filter(el => !staticNavCategories.has(el.dataset.category || ''));

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -577,7 +577,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /function _afterNextPaint\(fn\)/.test(dataSrc)
       && /window\.requestAnimationFrame\(\(\) => setTimeout\(fn,\s*0\)\)/.test(dataSrc)
       && /const token\s*=\s*\+\+_rangeModeRefreshToken/.test(dataSrc)
-      && /_afterNextPaint\(\(\) => \{[\s\S]{0,500}window\.navigate\(state\.currentView \|\| 'dashboard',\s*data\)/.test(dataSrc));
+      && /_afterNextPaint\(\(\) => \{[\s\S]{0,500}dataWindow\.navigate\(state\.currentView \|\| 'dashboard',\s*data\)/.test(dataSrc));
     assert('range mode refresh preserves current category card order',
       /function _captureCategoryCardOrderForRangeRefresh\(route\)/.test(dataSrc)
       && /state\._preserveCategoryCardOrder\s*=\s*preservedOrder/.test(dataSrc)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,6 +85,7 @@
     "js/dashboard-widget-renderers.js",
     "js/dashboard-widgets.js",
     "js/data-merge.js",
+    "js/data.js",
     "js/emf.js",
     "js/emf-facade.js",
     "js/export.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.430';
+self.APP_VERSION = '1.8.431';


### PR DESCRIPTION
## Summary
- Enable `@ts-check` for `js/data.js` and add the file to `tsconfig.json`.
- Add local JSDoc typedefs for imported-data cache metadata, Bortz feature tuples, and typed window hooks.
- Convert Date subtraction to `.getTime()` arithmetic for typecheck compatibility.
- Narrow DOM element types for chart-layer and range-toggle controls.
- Align the sidebar search UI-flow test static-category list with always-visible nav entries after CI exposed the mismatch.
- Address Greptile's typed-hook review by routing `buildSidebar`, `navigate`, and `showDetailModal` calls through `dataWindow`.
- Bump `version.js` for service-worker cache invalidation.

## Typecheck Coverage
- Before: 284/289 JS files (98.3%)
- After: 285/289 JS files (98.6%)
- Remaining: `js/api.js`, `js/dna.js`, `js/lens.js`, `js/settings.js`

## Validation
- `npm run typecheck`
- `npm test`
- `node tests/test-data-pipeline.js`
- `node tests/test-data-merge.js`
- `node tests/test-prelab.js`
- `node tests/test-audit.js`
- `git diff --check`
- `./run-tests.sh`
- `./run-tests.sh` again after the CI follow-up test patch
- `./run-tests.sh` again after the Greptile typed-hook patch