### PR TITLE
[codex] Port legacy browser clusters to Playwright

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -62,10 +62,9 @@ const TEST_FILES = [
   // Worker shim in _node-shim.js; renderGeneticsSection is a pure HTML-string
   // builder.
   // test-wearables.js (~549 asserts) ported to Vitest (batch 32) — IDB CRUD
-  // runs via fake-indexeddb. The openWearableDetail Chart.js modal islands +
-  // JSZip script-injection smoke live in test-wearables-dom.js below.
-  'tests/test-wearables-dom.js',
-  'tests/test-wearables-ui-flows.js',
+  // runs via fake-indexeddb. The openWearableDetail Chart.js modal islands,
+  // JSZip script-injection smoke, and click-driven wearable UI flows moved
+  // to Playwright in tests/playwright/legacy-wearables.spec.js.
   // test-dashboard-knowledge-base.js HTML-string rendering checks ported to
   // Vitest (batch 27). Section 5 (picker open/dismiss — live DOM overlay +
   // click) moved to Playwright in tests/playwright/dashboard-knowledge-base.spec.js.
@@ -94,9 +93,9 @@ const TEST_FILES = [
   // (batch 37). The img.onerror / showConfirmDialog / handleSSELine /
   // cashu _openDB browser-runtime sections moved to Playwright in
   // tests/playwright/coverage-stragglers-dom.spec.js.
-  'tests/test-silhouette-picker.js',
-  'tests/test-silhouette-region-map.js',
-  'tests/test-sun-ui-flow.js',
+  // test-silhouette-picker.js, test-silhouette-region-map.js, and
+  // test-sun-ui-flow.js moved to Playwright in
+  // tests/playwright/legacy-light-sun.spec.js.
   'tests/test-audit-fixes.js',
   // test-family-history.js source-inspection + getConditionsSummary ported
   // to Vitest (batch 36). DOM-runtime sections moved to Playwright in

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -182,7 +182,7 @@ const LEGACY_TESTS = [
   // Batch 32 — test-wearables (~549 asserts: registry, IDB CRUD via
   // fake-indexeddb, summary math, write gate, 7 vendor OAuth/PKCE modules,
   // Apple Health parser, source-inspection sweep). The openWearableDetail
-  // Chart.js modal islands stay on puppeteer in test-wearables-dom.js.
+  // Chart.js modal islands live in Playwright's legacy-wearables spec.
   './test-wearables.js',
   // Batch 33 — the remaining IDB tail, full ports (no DOM): blob-storage
   // (IDB k/v + localStorage→IDB migration), wearables-manual (manual-source

--- a/tests/playwright/legacy-browser-runner.js
+++ b/tests/playwright/legacy-browser-runner.js
@@ -1,0 +1,120 @@
+import { expect } from '@playwright/test';
+
+function buildFailureMessage(testPath, failures, pageErrors, recentMessages) {
+  const parts = [`${testPath} reported browser-test failures.`];
+  if (failures.length) {
+    parts.push('\nFailures:');
+    parts.push(failures.map(line => `- ${line}`).join('\n'));
+  }
+  if (pageErrors.length) {
+    parts.push('\nPage errors:');
+    parts.push(pageErrors.map(line => `- ${line}`).join('\n'));
+  }
+  if (recentMessages.length) {
+    parts.push('\nRecent browser console:');
+    parts.push(recentMessages.slice(-20).map(({ kind, text }) => `- ${kind}: ${text}`).join('\n'));
+  }
+  return parts.join('\n');
+}
+
+export async function runLegacyBrowserScript(page, testPath, options = {}) {
+  const pageErrors = [];
+  const onPageError = error => {
+    pageErrors.push(error?.message || String(error));
+  };
+  page.on('pageerror', onPageError);
+
+  try {
+    if (options.viewport) await page.setViewportSize(options.viewport);
+    await page.goto('/app', { waitUntil: 'load' });
+    await page.waitForFunction(() => window._labState && typeof window.navigate === 'function', null, {
+      timeout: options.readyTimeout ?? 15_000,
+    });
+
+    const result = await page.evaluate(async ({ testPath, settleMs }) => {
+      const failures = [];
+      const messages = [];
+      const originalLog = console.log;
+      const originalError = console.error;
+
+      function cleanConsoleTextInPage(args) {
+        return args
+          .map(value => {
+            if (typeof value === 'string') return value;
+            try { return JSON.stringify(value); }
+            catch (_) { return String(value); }
+          })
+          .join(' ')
+          .replace(/%c/g, '')
+          .replace(/(?:color|background|font-weight|font-size|font-family|padding|border-radius|margin|display)\s*:[^;]+;?/g, '')
+          .trim();
+      }
+
+      function collectResultFailuresInPage(results, prefix = 'window.__TEST_RESULTS') {
+        if (!results || typeof results !== 'object') return;
+        const failed = Number(results.fail ?? results.failed);
+        if (Number.isFinite(failed) && failed > 0) {
+          const passed = Number(results.pass ?? results.passed ?? 0);
+          failures.push(`${prefix}: ${passed} passed, ${failed} failed`);
+        }
+        for (const [key, value] of Object.entries(results)) {
+          if (value && typeof value === 'object') collectResultFailuresInPage(value, `${prefix}.${key}`);
+        }
+      }
+
+      function record(kind, args) {
+        const clean = cleanConsoleTextInPage(args);
+        if (!clean) return;
+        messages.push({ kind, text: clean });
+        for (const line of clean.split('\n').map(part => part.trim()).filter(Boolean)) {
+          if (line.startsWith('FAIL ') || line.startsWith('FAIL:') || line.includes('\u274c') || line.includes('\u274C')) {
+            failures.push(line);
+          }
+          const summary = line.match(/(\d+)\s+passed[,\s]+(\d+)\s+failed/i);
+          if (summary && Number(summary[2]) > 0) {
+            failures.push(`SUMMARY: ${summary[2]} failed - ${line}`);
+          }
+        }
+      }
+
+      console.log = (...args) => {
+        record('log', args);
+        originalLog(...args);
+      };
+      console.error = (...args) => {
+        record('error', args);
+        originalError(...args);
+      };
+
+      let returnValue = null;
+      try {
+        const response = await fetch(testPath);
+        if (!response.ok) throw new Error(`Failed to fetch ${testPath}: ${response.status}`);
+        const source = await response.text();
+        returnValue = await Function(source)();
+        await new Promise(resolve => setTimeout(resolve, settleMs));
+        collectResultFailuresInPage(returnValue, 'returnValue');
+        collectResultFailuresInPage(window.__TEST_RESULTS);
+        collectResultFailuresInPage(window.__testResults, 'window.__testResults');
+      } catch (error) {
+        failures.push(`CRASH ${testPath}: ${error?.message || String(error)}`);
+      } finally {
+        console.log = originalLog;
+        console.error = originalError;
+      }
+
+      return { failures, messages, returnValue };
+    }, {
+      testPath,
+      settleMs: options.settleMs ?? 150,
+    });
+
+    const failures = [...result.failures, ...pageErrors.map(error => `PAGE ERROR: ${error}`)];
+    const failureText = buildFailureMessage(testPath, result.failures, pageErrors, result.messages);
+    expect(failures, failureText).toEqual([]);
+
+    return result;
+  } finally {
+    page.off('pageerror', onPageError);
+  }
+}

--- a/tests/playwright/legacy-light-sun.spec.js
+++ b/tests/playwright/legacy-light-sun.spec.js
@@ -1,0 +1,15 @@
+import { test } from '@playwright/test';
+import { runLegacyBrowserScript } from './legacy-browser-runner.js';
+
+const LIGHT_SUN_BROWSER_TESTS = [
+  ['Light and Sun UI flow legacy browser script', 'tests/test-sun-ui-flow.js'],
+  ['silhouette picker legacy browser script', 'tests/test-silhouette-picker.js'],
+  ['silhouette region-map legacy browser script', 'tests/test-silhouette-region-map.js'],
+];
+
+for (const [name, path] of LIGHT_SUN_BROWSER_TESTS) {
+  test(name, async ({ page }) => {
+    test.setTimeout(60_000);
+    await runLegacyBrowserScript(page, path);
+  });
+}

--- a/tests/playwright/legacy-light-sun.spec.js
+++ b/tests/playwright/legacy-light-sun.spec.js
@@ -8,8 +8,7 @@ const LIGHT_SUN_BROWSER_TESTS = [
 ];
 
 for (const [name, path] of LIGHT_SUN_BROWSER_TESTS) {
-  test(name, async ({ page }) => {
-    test.setTimeout(60_000);
+  test(name, { timeout: 60_000 }, async ({ page }) => {
     await runLegacyBrowserScript(page, path);
   });
 }

--- a/tests/playwright/legacy-wearables.spec.js
+++ b/tests/playwright/legacy-wearables.spec.js
@@ -1,0 +1,14 @@
+import { test } from '@playwright/test';
+import { runLegacyBrowserScript } from './legacy-browser-runner.js';
+
+const WEARABLES_BROWSER_TESTS = [
+  ['wearables detail modal and browser DOM islands', 'tests/test-wearables-dom.js'],
+  ['wearables click-driven UI flows', 'tests/test-wearables-ui-flows.js'],
+];
+
+for (const [name, path] of WEARABLES_BROWSER_TESTS) {
+  test(name, async ({ page }) => {
+    test.setTimeout(60_000);
+    await runLegacyBrowserScript(page, path);
+  });
+}

--- a/tests/playwright/legacy-wearables.spec.js
+++ b/tests/playwright/legacy-wearables.spec.js
@@ -7,8 +7,7 @@ const WEARABLES_BROWSER_TESTS = [
 ];
 
 for (const [name, path] of WEARABLES_BROWSER_TESTS) {
-  test(name, async ({ page }) => {
-    test.setTimeout(60_000);
+  test(name, { timeout: 60_000 }, async ({ page }) => {
     await runLegacyBrowserScript(page, path);
   });
 }

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -1,8 +1,8 @@
 // test-wearables-dom.js — DOM-runtime islands extracted from test-wearables.js.
-// Stays in the puppeteer runner: the openWearableDetail() sections build a
-// live #detail-modal with a Chart.js instance, and the JSZip smoke needs a
-// real <script> injection to load /vendor/jszip.min.js. Everything else from
-// test-wearables.js (~549 asserts) runs in Vitest.
+// Runs through Playwright's legacy browser runner: the openWearableDetail()
+// sections build a live #detail-modal with a Chart.js instance, and the JSZip
+// smoke needs a real <script> injection to load /vendor/jszip.min.js.
+// Everything else from test-wearables.js (~549 asserts) runs in Vitest.
 //
 // Four islands:
 //   A. Detail modal — HRV + activity_score: modal-overlay show class,

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -9,8 +9,7 @@
 // Run: node tests/test-wearables.js  (or via npm test)
 //
 // DOM-runtime islands (the openWearableDetail Chart.js modal sections + the
-// JSZip script-injection smoke) live in tests/test-wearables-dom.js on the
-// puppeteer runner.
+// JSZip script-injection smoke) live in the Playwright legacy-wearables spec.
 
 import './_node-shim.js';
 
@@ -622,7 +621,7 @@ assert('Staleness hint carries an explanatory tooltip on hover',
 delete window._labState.importedData.wearableSummary;
 
 // Section 9b (Detail Modal — openWearableDetail + Chart.js + live modal
-// DOM) lives in test-wearables-dom.js on the puppeteer runner.
+// DOM) lives in Playwright's legacy-wearables spec.
 
 // ═══════════════════════════════════════
 // 10. Window exports for render handlers


### PR DESCRIPTION
## Summary

- Add a reusable Playwright legacy-browser runner that preserves the old browser-script console failure semantics.
- Move the Wearables DOM/UI flow scripts and Light & Sun silhouette/UI scripts into Playwright specs.
- Remove those five scripts from the Puppeteer runner list and update stale comments.

## Impact

This continues the Puppeteer-to-Playwright migration with a clustered but safe move: the legacy script bodies stay intact, while Playwright owns launching, isolation, failure reporting, and normal suite integration.

## Validation

- `npm run test:playwright -- tests/playwright/legacy-wearables.spec.js tests/playwright/legacy-light-sun.spec.js` -> 5 passed
- `npm run test:playwright` -> 34 passed
- `npm test` -> 105 passed
- `git diff --check` -> clean
- `node --check run-tests.js` -> clean