### PR TITLE
[codex] Port legacy UI regressions to Playwright

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -20,7 +20,8 @@ const TEST_FILES = [
   // checks ported to Vitest (batch 29). DOM-runtime sections (4 / 10 / 12 —
   // renderChatMessages/DOMParser, navigator.clipboard, context-toggle live
   // DOM) moved to Playwright in tests/playwright/chat-actions-dom.spec.js.
-  'tests/test-mobile.js',
+  // test-mobile.js moved to Playwright in
+  // tests/playwright/legacy-ui-regressions.spec.js.
   // test-openrouter.js source-inspection + behavioral ported to Vitest
   // (batch 21). Settings modal DOM moved to Playwright in
   // tests/playwright/openrouter-settings.spec.js.
@@ -71,7 +72,8 @@ const TEST_FILES = [
   // test-dashboard-data-protection.js HTML-string rendering checks ported to
   // Vitest (batch 28). Section 6 (picker open/dismiss — live DOM overlay +
   // click) moved to Playwright in tests/playwright/dashboard-data-protection.spec.js.
-  'tests/test-chat-panel-ux.js',
+  // test-chat-panel-ux.js moved to Playwright in
+  // tests/playwright/legacy-ui-regressions.spec.js.
   // test-chat-empty-state-dom.js moved to Playwright in
   // tests/playwright/chat-empty-state.spec.js.
   // test-custom-api.js source-inspection + behavioral ported to Vitest
@@ -82,7 +84,8 @@ const TEST_FILES = [
   // tests/playwright/custom-lens.spec.js.
   'tests/test-export-import.js',
   'tests/test-ui-flows.js',
-  'tests/test-lens-local-worker.js',
+  // test-lens-local-worker.js moved to Playwright in
+  // tests/playwright/legacy-ui-regressions.spec.js.
   // test-ai-verdict-engine.js stays on the puppeteer runner — the engine has
   // process-global concurrency-slot + inflight state shared with the
   // per-feature AI-verdict tests already in Vitest, which leaves its slots
@@ -96,7 +99,8 @@ const TEST_FILES = [
   // test-silhouette-picker.js, test-silhouette-region-map.js, and
   // test-sun-ui-flow.js moved to Playwright in
   // tests/playwright/legacy-light-sun.spec.js.
-  'tests/test-audit-fixes.js',
+  // test-audit-fixes.js moved to Playwright in
+  // tests/playwright/legacy-ui-regressions.spec.js.
   // test-family-history.js source-inspection + getConditionsSummary ported
   // to Vitest (batch 36). DOM-runtime sections moved to Playwright in
   // tests/playwright/family-history-dom.spec.js.

--- a/tests/playwright/legacy-browser-runner.js
+++ b/tests/playwright/legacy-browser-runner.js
@@ -88,6 +88,21 @@ export async function runLegacyBrowserScript(page, testPath, options = {}) {
 
       let returnValue = null;
       try {
+        if (!window.fetchWithRetry) {
+          window.fetchWithRetry = async function(url, retries = 3) {
+            for (let i = 0; i < retries; i++) {
+              try {
+                return await fetch(url).then(response => {
+                  if (!response.ok) throw new Error(response.status);
+                  return response.text();
+                });
+              } catch (error) {
+                if (i === retries - 1) throw new Error(`Failed to fetch ${url} after ${retries} attempts`);
+              }
+            }
+            return '';
+          };
+        }
         const response = await fetch(testPath);
         if (!response.ok) throw new Error(`Failed to fetch ${testPath}: ${response.status}`);
         const source = await response.text();

--- a/tests/playwright/legacy-ui-regressions.spec.js
+++ b/tests/playwright/legacy-ui-regressions.spec.js
@@ -1,0 +1,15 @@
+import { test } from '@playwright/test';
+import { runLegacyBrowserScript } from './legacy-browser-runner.js';
+
+const UI_REGRESSION_BROWSER_TESTS = [
+  ['mobile browser regression script', 'tests/test-mobile.js'],
+  ['chat panel UX legacy browser script', 'tests/test-chat-panel-ux.js'],
+  ['Lens local worker legacy browser script', 'tests/test-lens-local-worker.js'],
+  ['audit-fix legacy browser script', 'tests/test-audit-fixes.js'],
+];
+
+for (const [name, path] of UI_REGRESSION_BROWSER_TESTS) {
+  test(name, { timeout: 60_000 }, async ({ page }) => {
+    await runLegacyBrowserScript(page, path);
+  });
+}


### PR DESCRIPTION
## Summary

- Add a Playwright wrapper for four legacy browser regression scripts: mobile, chat panel UX, Lens local worker, and audit fixes.
- Move those scripts out of the Puppeteer runner list so Playwright owns their browser isolation and reporting.
- Add the old runner's `fetchWithRetry` compatibility helper to the reusable Playwright legacy-browser runner for scripts that still expect it.

## Impact

This continues the Puppeteer-to-Playwright migration with another clustered but low-risk batch. The legacy script bodies remain unchanged; only their browser harness changes.

## Coverage

Coverage-enabled full-suite run reports:

- Global function coverage: **74.92%** (`908 / 1,212` functions)
- Global byte coverage: **22.47%** (`668,532 / 2,975,592` bytes)

Note: coverage is still collected by the remaining Puppeteer coverage runner, so moving browser scripts to Playwright reduces the instrumented runner surface until Playwright-side coverage is wired in.

## Validation

- `npm run test:playwright -- tests/playwright/legacy-ui-regressions.spec.js` -> 4 passed
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh` -> passed
- `git diff --check` -> clean
- `node --check run-tests.js` -> clean