### PR TITLE
[codex] Port legacy core flows to Playwright

### DIFF
--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -366,7 +366,7 @@ function renderGeneticsTask(hasSnps, hasMtdna, dnaSummary) {
     <span class="chat-onboard-mini-actions">
       ${!hasSnps ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Import</button>` : ''}
       ${!hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-mtdna">mtDNA</button>
-      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" data-chat-empty-action="import-mtdna-file">` : ''}
+      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" aria-label="Import mtDNA file" data-chat-empty-action="import-mtdna-file">` : ''}
       ${hasSnps && hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Re-import</button>` : ''}
     </span>
   </article>`;

--- a/run-tests.js
+++ b/run-tests.js
@@ -82,8 +82,8 @@ const TEST_FILES = [
   // test-custom-lens.js source-inspection + behavioral ported to Vitest
   // (batch 25). Chat-header + KB modal DOM moved to Playwright in
   // tests/playwright/custom-lens.spec.js.
-  'tests/test-export-import.js',
-  'tests/test-ui-flows.js',
+  // test-export-import.js and test-ui-flows.js moved to Playwright in
+  // tests/playwright/legacy-core-flows.spec.js.
   // test-lens-local-worker.js moved to Playwright in
   // tests/playwright/legacy-ui-regressions.spec.js.
   // test-ai-verdict-engine.js stays on the puppeteer runner — the engine has

--- a/tests/playwright/legacy-core-flows.spec.js
+++ b/tests/playwright/legacy-core-flows.spec.js
@@ -1,0 +1,13 @@
+import { test } from '@playwright/test';
+import { runLegacyBrowserScript } from './legacy-browser-runner.js';
+
+const CORE_FLOW_BROWSER_TESTS = [
+  ['export/import legacy browser script', 'tests/test-export-import.js'],
+  ['UI flows legacy browser script', 'tests/test-ui-flows.js'],
+];
+
+for (const [name, path] of CORE_FLOW_BROWSER_TESTS) {
+  test(name, { timeout: 120_000 }, async ({ page }) => {
+    await runLegacyBrowserScript(page, path);
+  });
+}

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.435';
+self.APP_VERSION = '1.8.436';


### PR DESCRIPTION
## Summary
- Port the legacy export/import and UI flow browser scripts into Playwright via `tests/playwright/legacy-core-flows.spec.js`.
- Remove those scripts from the legacy Puppeteer coverage runner list so only the remaining hard-to-port browser files stay there.
- Fix the hidden mtDNA onboarding file input accessible name exposed by the smaller Puppeteer a11y run, and bump `version.js` for cache invalidation.

## Coverage
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh`: function coverage 64.13% (`565 / 881`), byte coverage 16.85% (`432,516 / 2,566,750`).
- The drop from the previous 74.92% function coverage is expected because coverage is still collected only from the remaining Puppeteer runner files after this migration.

## Validation
- `git diff --check`
- `node --check run-tests.js`
- `node --check js/chat-empty-state.js`
- `npm run test:playwright -- tests/playwright/legacy-core-flows.spec.js`
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh`