### PR TITLE
[codex] Port legacy axe scan to Playwright

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -109,11 +109,8 @@ const TEST_FILES = [
   // test-wearables-bp-merge.js source-inspection ported to Vitest (batch 30).
   // Section-4 live idempotency probe moved to Playwright in
   // tests/playwright/wearables-bp-merge.spec.js.
-  // axe-core runtime scan runs LAST. It rebuilds the DOM extensively and
-  // mutates state in ways that are expensive to fully reverse (creates a
-  // demo profile, swaps currentProfile, opens/closes 8 modals), so anything
-  // depending on a specific upstream state would have been observed by now.
-  'tests/test-a11y-axe.js',
+  // axe-core runtime scan moved to Playwright in
+  // tests/playwright/legacy-a11y-axe.spec.js.
 ];
 
 const PORT = process.env.PORT || 8000;

--- a/tests/playwright/legacy-a11y-axe.spec.js
+++ b/tests/playwright/legacy-a11y-axe.spec.js
@@ -1,0 +1,17 @@
+import { test } from '@playwright/test';
+import { runLegacyBrowserScript } from './legacy-browser-runner.js';
+
+test('axe accessibility legacy browser scan', { timeout: 120_000 }, async ({ page }) => {
+  const rebaseline = process.env.A11Y_REBASELINE === '1' || process.env.A11Y_REBASELINE === 'true';
+  if (rebaseline) {
+    await page.addInitScript(() => {
+      window.A11Y_REBASELINE = true;
+    });
+  }
+
+  await runLegacyBrowserScript(page, 'tests/test-a11y-axe.js', {
+    viewport: { width: 800, height: 600 },
+    readyTimeout: 20_000,
+    settleMs: 250,
+  });
+});


### PR DESCRIPTION
## Summary
- Move the legacy axe accessibility browser scan into Playwright with `tests/playwright/legacy-a11y-axe.spec.js`.
- Preserve the old Puppeteer viewport (`800x600`) for the baseline-relative scan so existing axe contrast behavior stays stable.
- Keep `A11Y_REBASELINE=1` support by wiring the env flag through `page.addInitScript` before the legacy script runs.
- Remove `tests/test-a11y-axe.js` from the legacy Puppeteer coverage runner list, leaving `test-ai-verdict-engine.js` as the sole remaining Puppeteer browser script.

## Coverage
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh`: function coverage 91.23% (`104 / 114`), byte coverage 10.82% (`93,370 / 862,776`).
- This is now runner-scope coverage for the final remaining Puppeteer file, not aggregate Playwright coverage. It moved from 64.13% because the axe scan no longer contributes loaded app modules to the Puppeteer coverage collector.

## Validation
- `git diff --check`
- `node --check run-tests.js`
- `node --check tests/playwright/legacy-a11y-axe.spec.js`
- `npm run test:playwright -- tests/playwright/legacy-a11y-axe.spec.js`
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh`