### PR TITLE
[codex] Port legacy AI verdict engine to Playwright

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -86,12 +86,8 @@ const TEST_FILES = [
   // tests/playwright/legacy-core-flows.spec.js.
   // test-lens-local-worker.js moved to Playwright in
   // tests/playwright/legacy-ui-regressions.spec.js.
-  // test-ai-verdict-engine.js stays on the puppeteer runner — the engine has
-  // process-global concurrency-slot + inflight state shared with the
-  // per-feature AI-verdict tests already in Vitest, which leaves its slots
-  // dirty in the legacy worker. See tests/_vitest-legacy.test.js for the
-  // full rationale.
-  'tests/test-ai-verdict-engine.js',
+  // test-ai-verdict-engine.js moved to Playwright in
+  // tests/playwright/legacy-ai-verdict-engine.spec.js.
   // test-coverage-stragglers.js stub-based probes ported to Vitest
   // (batch 37). The img.onerror / showConfirmDialog / handleSSELine /
   // cashu _openDB browser-runtime sections moved to Playwright in
@@ -114,6 +110,13 @@ const TEST_FILES = [
 ];
 
 const PORT = process.env.PORT || 8000;
+const COVERAGE = process.env.COVERAGE === '1' || process.env.COVERAGE === 'true';
+
+if (TEST_FILES.length === 0) {
+  console.log('No legacy Puppeteer test files remain; browser regressions run under Playwright.');
+  if (COVERAGE) writeRetiredCoverageReport();
+  process.exit(0);
+}
 
 (async () => {
   const browser = await puppeteer.launch({
@@ -193,7 +196,6 @@ const PORT = process.env.PORT || 8000;
   // Reload clean (no SW interference)
   await page.goto(`http://localhost:${PORT}/app`, { waitUntil: 'networkidle2', timeout: 15000 });
 
-  const COVERAGE = process.env.COVERAGE === '1' || process.env.COVERAGE === 'true';
   if (COVERAGE) {
     // resetOnNavigation: false keeps the accumulator alive across the page
     // reloads we do on context destruction below — otherwise we'd lose
@@ -288,6 +290,29 @@ const PORT = process.env.PORT || 8000;
 
   process.exit((fails.length > 0 || coverageGateFailure) ? 1 : 0);
 })();
+
+function writeRetiredCoverageReport() {
+  const outDir = path.dirname(fileURLToPath(import.meta.url));
+  const jsonPath = path.join(outDir, 'tests', '.coverage.json');
+  const generatedAt = new Date().toISOString();
+  fs.writeFileSync(jsonPath, JSON.stringify({
+    retired: true,
+    reason: 'No legacy Puppeteer test files remain; browser regressions run under Playwright.',
+    globalPct: null,
+    globalFnPct: null,
+    totals: { total: 0, covered: 0, fnTotal: 0, fnCalled: 0 },
+    rows: [],
+    generatedAt,
+  }, null, 2));
+
+  console.log('\n' + '='.repeat(88));
+  console.log('\x1b[35m\x1b[1m  COVERAGE REPORT (legacy Puppeteer runner retired)\x1b[0m');
+  console.log('='.repeat(88));
+  console.log('  No legacy Puppeteer test files remain. Use Playwright results for browser coverage.');
+  console.log('  GLOBAL FUNCTIONS: n/a (0 / 0)');
+  console.log('  GLOBAL BYTES:     n/a (0 / 0)');
+  console.log('='.repeat(88));
+}
 
 // Merge overlapping/adjacent [start, end) ranges and return their total length.
 function unionLength(ranges) {

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -196,13 +196,10 @@ const LEGACY_TESTS = [
   // cashu-wallet (wallet + Nostr discovery + BIP-39 + SSRF wiring; cashu-ts
   // IIFE loaded via indirect eval, bip39-minimal self-assigns).
   //
-  // test-ai-verdict-engine.js deliberately stays on the puppeteer runner:
-  // the engine has process-global concurrency-slot + inflight state that the
-  // per-feature AI-verdict tests (test-sun-ai-analysis et al., already in
-  // Vitest) share. Ported in isolation it's 35/35 green, but in the legacy
-  // runner's shared worker the earlier tests leave the engine's global slots
-  // dirty → hangs. Puppeteer's real async timing releases them; Node's
-  // doesn't. Left puppeteer-side until the engine exposes a state reset.
+  // test-ai-verdict-engine.js runs in Playwright's isolated browser context
+  // (tests/playwright/legacy-ai-verdict-engine.spec.js). It stays out of
+  // this shared Vitest worker because the engine owns global concurrency-slot
+  // and inflight state also touched by the per-feature AI-verdict tests.
   './test-crypto.js',
   './test-cashu-wallet.js',
   // Batch 35 — DNA adapter + Illumina/valence. parseDNAFile spins a

--- a/tests/playwright/legacy-ai-verdict-engine.spec.js
+++ b/tests/playwright/legacy-ai-verdict-engine.spec.js
@@ -1,0 +1,8 @@
+import { test } from '@playwright/test';
+import { runLegacyBrowserScript } from './legacy-browser-runner.js';
+
+test('AI verdict engine legacy browser contract', { timeout: 120_000 }, async ({ page }) => {
+  await runLegacyBrowserScript(page, 'tests/test-ai-verdict-engine.js', {
+    settleMs: 500,
+  });
+});


### PR DESCRIPTION
## Summary
- Move `tests/test-ai-verdict-engine.js` into Playwright via `tests/playwright/legacy-ai-verdict-engine.spec.js`.
- Remove the final file from the legacy Puppeteer browser runner list.
- Turn `run-tests.js` into an explicit no-op when no legacy Puppeteer files remain, including a retired coverage banner instead of a misleading startup-only percentage.
- Update the Vitest legacy wrapper comments to point at the isolated Playwright context for the AI verdict engine contract.

## Coverage
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh` now reports legacy Puppeteer coverage as retired: `n/a (0 / 0)` for functions and bytes.
- Previous runner-scope coverage was 91.23% while `test-ai-verdict-engine.js` was still the sole Puppeteer file. After this PR there are no Puppeteer browser test files left, so that percentage is no longer a meaningful metric.

## Validation
- `git diff --check`
- `node --check run-tests.js`
- `node --check tests/playwright/legacy-ai-verdict-engine.spec.js`
- `node --check tests/_vitest-legacy.test.js`
- `npm run test:playwright -- tests/playwright/legacy-ai-verdict-engine.spec.js`
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh`