### PR TITLE
[codex] Port standalone E2E scripts to Playwright

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -7,7 +7,6 @@
 // via Puppeteer's CDP-backed JSCoverage API, writes tests/.coverage.json plus
 // a sorted report. Off by default (~3s slower per run when enabled).
 
-import puppeteer from 'puppeteer';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -119,6 +118,7 @@ if (TEST_FILES.length === 0) {
 }
 
 (async () => {
+  const { default: puppeteer } = await import('puppeteer');
   const browser = await puppeteer.launch({
     headless: 'new',
     args: ['--no-sandbox', '--disable-setuid-sandbox']

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,19 +7,6 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
 PORT=${PORT:-8000}
 
-# Find Puppeteer — check npx cache, then local node_modules
-NODE_PATH_EXTRA=""
-if [ -d "$HOME/.npm/_npx" ]; then
-  NPX_DIR=$(find "$HOME/.npm/_npx" -path "*/node_modules/puppeteer" -type d 2>/dev/null | head -1 | sed 's|/puppeteer$||')
-  [ -n "$NPX_DIR" ] && NODE_PATH_EXTRA="$NPX_DIR"
-fi
-[ -d "$DIR/node_modules/puppeteer" ] && NODE_PATH_EXTRA="$DIR/node_modules"
-
-if [ -z "$NODE_PATH_EXTRA" ]; then
-  echo "Puppeteer not found. Install with: npm i -g puppeteer"
-  exit 2
-fi
-
 # Start server if not already running. nohup + disown fully detaches it
 # from the shell — signals sent to the shell's process group won't
 # propagate. Log to /tmp so we can inspect if it ever dies unexpectedly.
@@ -71,8 +58,4 @@ if [ "$COVERAGE" = "1" ] || [ "$COVERAGE" = "true" ]; then
   : "${COVERAGE_MIN:=90}"
   export COVERAGE COVERAGE_MIN
 fi
-PORT=$PORT NODE_PATH="$NODE_PATH_EXTRA" node "$DIR/run-tests.js"
-PORT=$PORT NODE_PATH="$NODE_PATH_EXTRA" node "$DIR/tests/test-sync-two-device-e2e.js"
-if [ -f "$DIR/tests/test-theme-responsive-e2e.js" ]; then
-  PORT=$PORT NODE_PATH="$NODE_PATH_EXTRA" node "$DIR/tests/test-theme-responsive-e2e.js"
-fi
+PORT=$PORT node "$DIR/run-tests.js"

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // Two-device sync E2E regression harness.
 //
 // Uses two isolated browser contexts to model device A and device B. The
@@ -6,7 +5,7 @@
 // same post-merge active-profile refresh path that sync-pull.js calls after a
 // pull, plus the real merge helper for stale-pull protection.
 
-import puppeteer from 'puppeteer';
+import { test } from '@playwright/test';
 
 const PORT = process.env.PORT || 8000;
 const BASE_URL = `http://localhost:${PORT}/app`;
@@ -110,13 +109,16 @@ function buildImportedData() {
 }
 
 async function makeContext(browser) {
+  if (typeof browser.newContext === 'function') {
+    return browser.newContext({ serviceWorkers: 'block' });
+  }
   if (typeof browser.createBrowserContext === 'function') {
     return browser.createBrowserContext();
   }
   if (typeof browser.createIncognitoBrowserContext === 'function') {
     return browser.createIncognitoBrowserContext();
   }
-  throw new Error('Puppeteer does not expose isolated browser contexts; refusing to run two-device sync E2E in shared localStorage.');
+  throw new Error('Browser does not expose isolated contexts; refusing to run two-device sync E2E in shared localStorage.');
 }
 
 async function makePage(browser, label, importedData) {
@@ -128,15 +130,14 @@ async function makePage(browser, label, importedData) {
     fail++;
     console.error(`  FAIL ${label} page error -- ${err.message}`);
   });
-  await page.setBypassServiceWorker(true);
-  await page.goto(BASE_URL, { waitUntil: 'networkidle2', timeout: 20000 });
+  await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
   await page.evaluate(async () => {
     try {
       const regs = await navigator.serviceWorker.getRegistrations();
       for (const reg of regs) await reg.unregister();
     } catch (_) {}
   });
-  await page.goto(BASE_URL, { waitUntil: 'networkidle2', timeout: 20000 });
+  await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
   await page.waitForFunction(
     () => window._labState
       && typeof window.saveImportedData === 'function'
@@ -144,6 +145,7 @@ async function makePage(browser, label, importedData) {
       && typeof window.navigate === 'function'
       && typeof window.openSunSessionDetail === 'function'
       && typeof window.openDeviceSessionDetail === 'function',
+    null,
     { timeout: 15000 }
   );
   const helperBust = `syncE2E=${Date.now()}_${Math.random().toString(36).slice(2)}`;
@@ -161,6 +163,7 @@ async function makePage(browser, label, importedData) {
     () => typeof window.__syncE2EMergePulledImportedData === 'function'
       && typeof window.__syncE2EPersistPulledImportedData === 'function'
       && typeof window.__syncE2ERefreshActiveProfileAfterPull === 'function',
+    null,
     { timeout: 15000 }
   );
   await page.evaluate(async ({ profileId, imported }) => {
@@ -229,6 +232,7 @@ async function openMarkerModal(page) {
   await page.waitForFunction(
     () => document.getElementById('modal-overlay')?.classList?.contains('show')
       && document.getElementById('detail-modal')?.classList?.contains('marker-detail-modal'),
+    null,
     { timeout: 5000 }
   );
 }
@@ -329,7 +333,7 @@ async function markerModalSnapshot(page) {
 
 async function navigateLight(page) {
   await page.evaluate(() => window.navigate('light'));
-  await page.waitForFunction(() => window._labState.currentView === 'light', { timeout: 5000 });
+  await page.waitForFunction(() => window._labState.currentView === 'light', null, { timeout: 5000 });
 }
 
 async function openSunSessionModal(page) {
@@ -337,6 +341,7 @@ async function openSunSessionModal(page) {
   await page.evaluate(({ id }) => window.openSunSessionDetail(id), { id: SUN_SESSION_ID });
   await page.waitForFunction(
     () => document.querySelector('.modal-overlay.show .sun-detail-modal[data-session-kind="sun"]'),
+    null,
     { timeout: 5000 }
   );
 }
@@ -346,6 +351,7 @@ async function openDeviceSessionModal(page) {
   await page.evaluate(({ id }) => window.openDeviceSessionDetail(id), { id: DEVICE_SESSION_ID });
   await page.waitForFunction(
     () => document.querySelector('.modal-overlay.show .sun-detail-modal[data-session-kind="device"]'),
+    null,
     { timeout: 5000 }
   );
 }
@@ -390,11 +396,7 @@ async function closeFloatingModals(page) {
   });
 }
 
-async function run() {
-  const browser = await puppeteer.launch({
-    headless: 'new',
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  });
+async function run(browser) {
   const contexts = [];
 
   try {
@@ -481,21 +483,22 @@ async function run() {
   } finally {
     for (const context of contexts) {
       try {
-        if (context && context !== browser.defaultBrowserContext()) await context.close();
+        await context?.close();
       } catch (_) {}
     }
-    await browser.close();
   }
 
   console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
   if (fail) {
     console.error('\nFailures:');
     for (const f of failures) console.error(`  - ${f}`);
-    process.exit(1);
+    throw new Error(`Two-device sync E2E failed: ${fail} failed`);
   }
 }
 
-run().catch(err => {
-  console.error(`\nFAIL two-device sync E2E crashed -- ${err.stack || err.message || err}`);
-  process.exit(1);
+test('two-device sync E2E', { timeout: 90_000 }, async ({ browser }) => {
+  pass = 0;
+  fail = 0;
+  failures.length = 0;
+  await run(browser);
 });

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -21,22 +21,6 @@ const DEVICE_ID = 'device-e2e-panel';
 const DEVICE_SESSION_ID = 'devsess-e2e-duration';
 const BASE_AT = Date.parse('2026-05-01T08:00:00.000Z');
 
-let pass = 0;
-let fail = 0;
-const failures = [];
-
-function assert(name, condition, detail = '') {
-  if (condition) {
-    pass++;
-    console.log(`  PASS ${name}`);
-  } else {
-    fail++;
-    const msg = `${name}${detail ? ` -- ${detail}` : ''}`;
-    failures.push(msg);
-    console.error(`  FAIL ${msg}`);
-  }
-}
-
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -109,26 +93,15 @@ function buildImportedData() {
 }
 
 async function makeContext(browser) {
-  if (typeof browser.newContext === 'function') {
-    return browser.newContext({ serviceWorkers: 'block' });
-  }
-  if (typeof browser.createBrowserContext === 'function') {
-    return browser.createBrowserContext();
-  }
-  if (typeof browser.createIncognitoBrowserContext === 'function') {
-    return browser.createIncognitoBrowserContext();
-  }
-  throw new Error('Browser does not expose isolated contexts; refusing to run two-device sync E2E in shared localStorage.');
+  return browser.newContext({ serviceWorkers: 'block' });
 }
 
-async function makePage(browser, label, importedData) {
+async function makePage(browser, label, importedData, recordPageError) {
   const context = await makeContext(browser);
   const page = await context.newPage();
   page.setDefaultTimeout(15000);
   page.on('pageerror', err => {
-    failures.push(`${label} page error: ${err.message}`);
-    fail++;
-    console.error(`  FAIL ${label} page error -- ${err.message}`);
+    recordPageError(label, err);
   });
   await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
   await page.evaluate(async () => {
@@ -397,13 +370,32 @@ async function closeFloatingModals(page) {
 }
 
 async function run(browser) {
+  let pass = 0;
+  let fail = 0;
+  const failures = [];
   const contexts = [];
+  function assert(name, condition, detail = '') {
+    if (condition) {
+      pass++;
+      console.log(`  PASS ${name}`);
+    } else {
+      fail++;
+      const msg = `${name}${detail ? ` -- ${detail}` : ''}`;
+      failures.push(msg);
+      console.error(`  FAIL ${msg}`);
+    }
+  }
+  function recordPageError(label, err) {
+    failures.push(`${label} page error: ${err.message}`);
+    fail++;
+    console.error(`  FAIL ${label} page error -- ${err.message}`);
+  }
 
   try {
     console.log('=== Two-Device Sync E2E Tests ===\n');
     const base = buildImportedData();
-    const deviceA = await makePage(browser, 'A', clone(base));
-    const deviceB = await makePage(browser, 'B', clone(base));
+    const deviceA = await makePage(browser, 'A', clone(base), recordPageError);
+    const deviceB = await makePage(browser, 'B', clone(base), recordPageError);
     contexts.push(deviceA.context, deviceB.context);
     const { page: pageA } = deviceA;
     const { page: pageB } = deviceB;
@@ -496,9 +488,7 @@ async function run(browser) {
   }
 }
 
-test('two-device sync E2E', { timeout: 90_000 }, async ({ browser }) => {
-  pass = 0;
-  fail = 0;
-  failures.length = 0;
+test('two-device sync E2E', async ({ browser }, testInfo) => {
+  testInfo.setTimeout(90_000);
   await run(browser);
 });

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // Theme/responsive E2E smoke: real Chrome, real viewport changes, every shipped theme.
 //
 // This complements the legacy in-page tests. Those cover behavior well, but
@@ -8,7 +7,9 @@
 
 import fs from 'fs';
 import path from 'path';
-import puppeteer from 'puppeteer';
+import { test } from '@playwright/test';
+
+test.setTimeout(240_000);
 
 const PORT = process.env.PORT || 8000;
 const BASE_URL = `http://localhost:${PORT}/app`;
@@ -65,6 +66,7 @@ async function waitForApp(page) {
     () => typeof window.navigate === 'function'
       && window._labState
       && typeof window.buildSidebar === 'function',
+    null,
     { timeout: 15000 }
   );
 }
@@ -76,11 +78,24 @@ async function seedDemoData(page) {
     const profiles = window.getProfiles?.() || [];
     let profile = profiles.find(p => p.id === profileId);
     if (!profile) {
-      profile = { id: profileId, name: 'Test Profile' };
+      profile = { id: profileId, name: 'E2E Dashboard' };
       profiles.push(profile);
     }
+    profile.name = 'E2E Dashboard';
+    profile.sex = 'male';
+    profile.dob = '1987-11-22';
     profile.location = { country: 'united states', zip: '10001' };
+    profile.tags = Array.from(new Set([...(Array.isArray(profile.tags) ? profile.tags : []), 'demo']));
     await window.saveProfiles?.(profiles);
+    const profileKey = window.profileStorageKey || ((id, suffix) => `labcharts-${id}-${suffix}`);
+    localStorage.setItem(profileKey(profileId, 'onboarded'), 'profile-set');
+    localStorage.setItem(profileKey(profileId, 'emptyTour'), 'completed');
+    localStorage.setItem(profileKey(profileId, 'tour'), 'completed');
+    localStorage.setItem(profileKey(profileId, 'ai-reminder-dismissed'), '1');
+    localStorage.setItem(`labcharts-onboard-extras-done-${profileId}`, '1');
+    localStorage.setItem(`labcharts-onboard-provider-skipped-${profileId}`, '1');
+    localStorage.setItem('labcharts-analytics-consent-seen', '1');
+    localStorage.setItem('labcharts-changelog-seen', window.APP_VERSION || 'test');
     window.fetchAtmosphere = async () => {
       const now = Date.now();
       return {
@@ -107,6 +122,7 @@ async function seedDemoData(page) {
     window.saveImportedData?.();
     window.buildSidebar?.();
     window.navigate?.('dashboard');
+    window.closeChatPanel?.();
   });
   await page.waitForSelector('#main-content', { timeout: 10000 });
   await delay(200);
@@ -164,20 +180,18 @@ async function seedMobileLightSessions(page) {
 }
 
 async function prepareScenario(page, theme, viewport) {
-  await page.setViewport({
+  await page.setViewportSize({
     width: viewport.width,
     height: viewport.height,
-    isMobile: viewport.mobile,
-    hasTouch: viewport.mobile,
-    deviceScaleFactor: viewport.mobile ? 2 : 1,
   });
-  await page.goto(BASE_URL, { waitUntil: 'networkidle2', timeout: 20000 });
+  await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
   await waitForApp(page);
   await page.evaluate((nextTheme) => {
     window.closeModal?.();
     window.closeSettingsModal?.();
     window.closeChatPanel?.();
     window.closeMobileSidebar?.();
+    document.querySelectorAll('#tour-overlay, #tour-spotlight, #tour-tooltip').forEach(el => el.remove());
     document.querySelectorAll('.modal-overlay.show').forEach(el => el.classList.remove('show'));
     localStorage.removeItem('labcharts-accent-override');
     localStorage.removeItem('labcharts-sunset-mode');
@@ -192,6 +206,11 @@ async function prepareScenario(page, theme, viewport) {
     if (typeof window.setTheme === 'function') window.setTheme(nextTheme);
   }, theme);
   await seedDemoData(page);
+  await page.evaluate(() => {
+    window.endTour?.();
+    window.closeChatPanel?.();
+    document.querySelectorAll('#tour-overlay, #tour-spotlight, #tour-tooltip').forEach(el => el.remove());
+  });
 }
 
 async function captureArtifact(page, theme, viewport) {
@@ -897,10 +916,11 @@ async function checkMobileInteractions(page, theme, viewportName) {
     if (tab === 'light') {
       await page.waitForFunction(
         () => !!document.querySelector('.lens-page-widgets[data-lens-route="light"] .conditions-now-grid'),
+        null,
         { timeout: 2500 }
       ).catch(() => {});
     }
-    result = await page.evaluate((tab, theme) => {
+    result = await page.evaluate(({ tab, theme }) => {
       const active = document.querySelector(`#mobile-bottom-tabs .m-tab[data-tab="${tab}"], .m-tabbar .m-tab[data-tab="${tab}"]`);
       const conditionsGrid = document.querySelector('.lens-page-widgets[data-lens-route="light"] .conditions-now-grid') || document.querySelector('.conditions-now-grid');
       const supportColumns = conditionsGrid
@@ -1002,7 +1022,7 @@ async function checkMobileInteractions(page, theme, viewportName) {
           getComputedStyle(sessionWidget.querySelector('.light-session-device .light-session-kind')).whiteSpace !== 'nowrap',
         supportColumns,
       };
-    }, tab, theme);
+    }, { tab, theme });
     assert(testName(theme, viewportName, `tab ${tab} navigates and stays active`),
       result.active && result.hasBottomTabs && result.visibleMain,
       JSON.stringify(result));
@@ -1033,7 +1053,7 @@ async function checkMobileInteractions(page, theme, viewportName) {
     window.scrollTo(0, 0);
     window.showCategory?.('biochemistry');
   });
-  await page.waitForSelector('.category-header');
+  await page.waitForSelector('.category-header', { timeout: 5000 });
   for (const view of ['table', 'heatmap']) {
     const shellKind = view === 'table' ? 'data' : 'heatmap';
     const wrapperClass = view === 'table' ? 'data-table-wrapper' : 'heatmap-wrapper';
@@ -1043,7 +1063,7 @@ async function checkMobileInteractions(page, theme, viewportName) {
       window.switchView?.(view, 'biochemistry', btn);
       window.scrollTo(0, 0);
     }, view);
-    await page.waitForSelector(`.gb-table-shell-${shellKind} .gb-table-sticky-head`);
+    await page.waitForSelector(`.gb-table-shell-${shellKind} .gb-table-sticky-head`, { state: 'attached', timeout: 5000 });
     await delay(120);
     result = await page.evaluate(({ shellKind, wrapperClass }) => {
       const maxScroll = Math.max(0, document.scrollingElement.scrollHeight - window.innerHeight);
@@ -1098,34 +1118,29 @@ async function checkMobileInteractions(page, theme, viewportName) {
   }
 }
 
-async function run() {
-  const launchOptions = {
-    headless: 'new',
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  };
-  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
-    launchOptions.executablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
-  }
-  const browser = await puppeteer.launch(launchOptions);
-  const page = await browser.newPage();
-
+async function makeScenarioPage(browser, viewport) {
+  const context = await browser.newContext({
+    viewport: { width: viewport.width, height: viewport.height },
+    isMobile: viewport.mobile,
+    hasTouch: viewport.mobile,
+    deviceScaleFactor: viewport.mobile ? 2 : 1,
+    serviceWorkers: 'block',
+  });
+  const page = await context.newPage();
   page.on('pageerror', err => {
     fail++;
     const msg = `PAGE ERROR ${err.message}`;
     failures.push(msg);
     console.error(`  FAIL ${msg}`);
   });
+  return { context, page };
+}
 
-  try {
-    await page.goto(BASE_URL, { waitUntil: 'networkidle2', timeout: 20000 });
-    await page.setBypassServiceWorker(true);
-    await page.evaluate(async () => {
-      const regs = await navigator.serviceWorker.getRegistrations();
-      for (const reg of regs) await reg.unregister();
-    }).catch(() => {});
-
-    for (const theme of THEMES) {
-      for (const viewport of VIEWPORTS) {
+async function run(browser) {
+  for (const theme of THEMES) {
+    for (const viewport of VIEWPORTS) {
+      const { context, page } = await makeScenarioPage(browser, viewport);
+      try {
         console.log(`\n▶ Theme Responsive E2E ${theme}/${viewport.name}`);
         await prepareScenario(page, theme, viewport);
         const base = await evaluateBaseChecks(page, theme, viewport);
@@ -1138,10 +1153,15 @@ async function run() {
         if (viewport.mobile) await checkMobileInteractions(page, theme, viewport.name);
         else await checkDesktopModals(page, theme, viewport.name);
         await captureArtifact(page, theme, viewport.name);
+      } finally {
+        await context.close();
       }
     }
+  }
 
-    for (const viewport of BOUNDARY_VIEWPORTS) {
+  for (const viewport of BOUNDARY_VIEWPORTS) {
+    const { context, page } = await makeScenarioPage(browser, viewport);
+    try {
       console.log(`\n▶ Theme Responsive E2E dark/${viewport.name}`);
       await prepareScenario(page, 'dark', viewport);
       const result = await page.evaluate((expectedMobile) => ({
@@ -1156,20 +1176,22 @@ async function run() {
       assert(testName('dark', viewport.name, 'breakpoint renders usable content'),
         result.mainText > 40 && (viewport.mobile ? result.mobileShell : !result.mobileShell),
         JSON.stringify(result));
+    } finally {
+      await context.close();
     }
-  } finally {
-    await browser.close();
   }
 
   console.log(`\nTheme Responsive E2E: ${pass} passed, ${fail} failed`);
   if (fail) {
     console.error('\nFailures:');
     for (const item of failures) console.error(`  - ${item}`);
-    process.exit(1);
+    throw new Error(`Theme Responsive E2E failed: ${fail} failed`);
   }
 }
 
-run().catch(err => {
-  console.error(`Theme Responsive E2E crashed: ${err.stack || err.message}`);
-  process.exit(1);
+test('theme responsive E2E', async ({ browser }) => {
+  pass = 0;
+  fail = 0;
+  failures.length = 0;
+  await run(browser);
 });

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -9,8 +9,6 @@ import fs from 'fs';
 import path from 'path';
 import { test } from '@playwright/test';
 
-test.setTimeout(240_000);
-
 const PORT = process.env.PORT || 8000;
 const BASE_URL = `http://localhost:${PORT}/app`;
 const THEMES = ['dark', 'light', 'cyberterm', 'glass', 'synth-sunrise', 'neuromancer'];
@@ -36,22 +34,6 @@ const BOUNDARY_VIEWPORTS = [
 const ARTIFACTS_DIR = process.env.REDESIGN_E2E_ARTIFACTS
   ? path.resolve(process.env.REDESIGN_E2E_ARTIFACTS)
   : '';
-
-let pass = 0;
-let fail = 0;
-const failures = [];
-
-function assert(name, condition, detail = '') {
-  if (condition) {
-    pass++;
-    console.log(`  PASS ${name}`);
-  } else {
-    fail++;
-    const msg = `${name}${detail ? ` -- ${detail}` : ''}`;
-    failures.push(msg);
-    console.error(`  FAIL ${msg}`);
-  }
-}
 
 function testName(theme, viewport, label) {
   return `${theme}/${viewport}: ${label}`;
@@ -213,7 +195,7 @@ async function prepareScenario(page, theme, viewport) {
   });
 }
 
-async function captureArtifact(page, theme, viewport) {
+async function captureArtifact(page, theme, viewport, assert) {
   const shot = await page.screenshot({ fullPage: false });
   assert(testName(theme, viewport, 'Chrome screenshot is non-empty'), shot.length > 10000, `bytes=${shot.length}`);
   if (ARTIFACTS_DIR) {
@@ -489,7 +471,7 @@ async function evaluateBaseChecks(page, theme, viewport) {
   }, { theme, viewport, themeBarColors: THEME_BAR_COLORS });
 }
 
-async function checkDesktopModals(page, theme, viewportName) {
+async function checkDesktopModals(page, theme, viewportName, assert) {
   await page.evaluate(() => window.openSettingsModal?.('display'));
   await delay(200);
   let result = await page.evaluate(() => {
@@ -715,7 +697,7 @@ async function checkDesktopModals(page, theme, viewportName) {
   }
 }
 
-async function checkMobileInteractions(page, theme, viewportName) {
+async function checkMobileInteractions(page, theme, viewportName, assert) {
   await page.click('#sidebar-toggle');
   await delay(150);
   let result = await page.evaluate(() => ({
@@ -1118,7 +1100,7 @@ async function checkMobileInteractions(page, theme, viewportName) {
   }
 }
 
-async function makeScenarioPage(browser, viewport) {
+async function makeScenarioPage(browser, viewport, recordFailure) {
   const context = await browser.newContext({
     viewport: { width: viewport.width, height: viewport.height },
     isMobile: viewport.mobile,
@@ -1128,18 +1110,35 @@ async function makeScenarioPage(browser, viewport) {
   });
   const page = await context.newPage();
   page.on('pageerror', err => {
-    fail++;
-    const msg = `PAGE ERROR ${err.message}`;
-    failures.push(msg);
-    console.error(`  FAIL ${msg}`);
+    recordFailure(`PAGE ERROR ${err.message}`);
   });
   return { context, page };
 }
 
 async function run(browser) {
+  let pass = 0;
+  let fail = 0;
+  const failures = [];
+  function assert(name, condition, detail = '') {
+    if (condition) {
+      pass++;
+      console.log(`  PASS ${name}`);
+    } else {
+      fail++;
+      const msg = `${name}${detail ? ` -- ${detail}` : ''}`;
+      failures.push(msg);
+      console.error(`  FAIL ${msg}`);
+    }
+  }
+  function recordFailure(msg) {
+    fail++;
+    failures.push(msg);
+    console.error(`  FAIL ${msg}`);
+  }
+
   for (const theme of THEMES) {
     for (const viewport of VIEWPORTS) {
-      const { context, page } = await makeScenarioPage(browser, viewport);
+      const { context, page } = await makeScenarioPage(browser, viewport, recordFailure);
       try {
         console.log(`\n▶ Theme Responsive E2E ${theme}/${viewport.name}`);
         await prepareScenario(page, theme, viewport);
@@ -1150,9 +1149,9 @@ async function run(browser) {
         if (base.failures.length === 0) {
           assert(testName(theme, viewport.name, 'base layout/theme checks passed'), true);
         }
-        if (viewport.mobile) await checkMobileInteractions(page, theme, viewport.name);
-        else await checkDesktopModals(page, theme, viewport.name);
-        await captureArtifact(page, theme, viewport.name);
+        if (viewport.mobile) await checkMobileInteractions(page, theme, viewport.name, assert);
+        else await checkDesktopModals(page, theme, viewport.name, assert);
+        await captureArtifact(page, theme, viewport.name, assert);
       } finally {
         await context.close();
       }
@@ -1160,7 +1159,7 @@ async function run(browser) {
   }
 
   for (const viewport of BOUNDARY_VIEWPORTS) {
-    const { context, page } = await makeScenarioPage(browser, viewport);
+    const { context, page } = await makeScenarioPage(browser, viewport, recordFailure);
     try {
       console.log(`\n▶ Theme Responsive E2E dark/${viewport.name}`);
       await prepareScenario(page, 'dark', viewport);
@@ -1189,9 +1188,7 @@ async function run(browser) {
   }
 }
 
-test('theme responsive E2E', async ({ browser }) => {
-  pass = 0;
-  fail = 0;
-  failures.length = 0;
+test('theme responsive E2E', async ({ browser }, testInfo) => {
+  testInfo.setTimeout(240_000);
   await run(browser);
 });


### PR DESCRIPTION
## Summary
- Move the two standalone Puppeteer E2E scripts into Playwright specs:
  - `tests/playwright/sync-two-device-e2e.spec.js`
  - `tests/playwright/theme-responsive-e2e.spec.js`
- Remove the old standalone script calls from `run-tests.sh`.
- Keep the retired legacy runner no-op, but make its Puppeteer import lazy so it does not load Puppeteer when there are no legacy files.

## Coverage status
- Playwright browser suite now runs 44 tests, up from 42.
- Legacy Puppeteer runner has no remaining test files and reports retired coverage:
  - `GLOBAL FUNCTIONS: n/a (0 / 0)`
  - `GLOBAL BYTES: n/a (0 / 0)`
- `playwright.config.js` still uses Puppeteer only as the Chromium executable provider because local Playwright browser binaries are not installed.

## Validation
- `bash -n run-tests.sh`
- `node --check run-tests.js`
- `node --check tests/playwright/sync-two-device-e2e.spec.js`
- `node --check tests/playwright/theme-responsive-e2e.spec.js`
- `npm run test:playwright -- tests/playwright/sync-two-device-e2e.spec.js tests/playwright/theme-responsive-e2e.spec.js`
- `COVERAGE=1 COVERAGE_MIN=0 ./run-tests.sh`