### PR TITLE
[codex] Restore Playwright coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ out/
 release/
 # Coverage output from `COVERAGE=1 ./run-tests.sh` — regenerated on every run
 tests/.coverage.json
+tests/.vitest-coverage/
 labcharts-*.json
 test-*.json
 node_modules/

--- a/dev-docs/testing.md
+++ b/dev-docs/testing.md
@@ -173,9 +173,9 @@ The script:
 
 ## Coverage status
 
-The old Puppeteer `JSCoverage` reporter was retired when the final standalone browser runner moved to Playwright. `./run-tests.sh` no longer emits function/byte coverage percentages; if `COVERAGE=1` is set, it prints a retirement notice after the suite passes. Browser regression status is currently tracked through the Playwright pass count and the native/Vitest fixture coverage represented by the test inventory.
+`COVERAGE=1 ./run-tests.sh` runs the normal suite first, then runs a Playwright Chromium coverage sampler over the high-surface browser fixtures. The sampler writes `tests/.coverage.json` and prints global function and byte coverage percentages for loaded app-source JavaScript.
 
-If coverage gating comes back, it should be implemented in the Playwright layer rather than reintroducing a separate Puppeteer runner.
+Coverage is report-only by default. Set `COVERAGE_MIN=90` or another percentage to fail the run when global function coverage falls below that floor.
 
 ## Accessibility regression scan
 

--- a/dev-docs/testing.md
+++ b/dev-docs/testing.md
@@ -173,9 +173,9 @@ The script:
 
 ## Coverage status
 
-`COVERAGE=1 ./run-tests.sh` runs the normal suite first, then runs a Playwright Chromium coverage sampler over the high-surface browser fixtures. The sampler writes `tests/.coverage.json` and prints global function and byte coverage percentages for loaded app-source JavaScript.
+`COVERAGE=1 ./run-tests.sh` runs Vitest with V8 coverage enabled, runs the normal Playwright suite, then runs a Playwright Chromium coverage sampler over the high-surface browser fixtures. The sampler merges `tests/.vitest-coverage/coverage-final.json` with its browser coverage, writes `tests/.coverage.json`, and prints separate Playwright, Vitest/Node, and combined global function/byte coverage percentages for app-source JavaScript.
 
-Coverage is report-only by default. Set `COVERAGE_MIN=90` or another percentage to fail the run when global function coverage falls below that floor.
+Coverage is report-only by default. Set `COVERAGE_MIN=90` or another percentage to fail the run when combined global function coverage falls below that floor.
 
 ## Accessibility regression scan
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@vitest/coverage-v8": "^4.1.8",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "typescript": "^6.0.3",
@@ -68,6 +69,66 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -274,12 +335,33 @@
         }
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -649,6 +731,37 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -770,6 +883,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/async-retry": {
@@ -936,6 +1061,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -948,6 +1083,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-buffer": {
       "version": "2.0.5",
@@ -982,6 +1124,52 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1317,6 +1505,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -1546,6 +1762,19 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1576,6 +1805,19 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@vitest/coverage-v8": "^4.1.8",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "typescript": "^6.0.3",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -6,6 +6,10 @@ set -e
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 PORT=${PORT:-8000}
+COVERAGE_ENABLED=0
+if [ "$COVERAGE" = "1" ] || [ "$COVERAGE" = "true" ]; then
+  COVERAGE_ENABLED=1
+fi
 
 # Start server if not already running. nohup + disown fully detaches it
 # from the shell — signals sent to the shell's process group won't
@@ -46,13 +50,18 @@ trap cleanup EXIT
 
 # Vitest covers pure-logic node-side tests — fastest fail-fast layer.
 # The legacy node-side files are wrapped by tests/_vitest-legacy.test.js.
-npm test || exit 1
+if [ "$COVERAGE_ENABLED" = "1" ]; then
+  rm -rf "$DIR/tests/.vitest-coverage"
+  npm test -- --coverage || exit 1
+else
+  npm test || exit 1
+fi
 ensure_server
 # HTTP-reliant test before the browser suite (needs the dev server up).
 PORT=$PORT node "$DIR/tests/test-dev-server-origin.js" || exit 1
 PORT=$PORT npm run test:playwright || exit 1
-if [ "$COVERAGE" = "1" ] || [ "$COVERAGE" = "true" ]; then
+if [ "$COVERAGE_ENABLED" = "1" ]; then
   : "${COVERAGE_MIN:=0}"
   export COVERAGE_MIN
-  PORT=$PORT node "$DIR/scripts/playwright-coverage.mjs" || exit 1
+  INCLUDE_VITEST_COVERAGE=1 PORT=$PORT node "$DIR/scripts/playwright-coverage.mjs" || exit 1
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,5 +52,7 @@ ensure_server
 PORT=$PORT node "$DIR/tests/test-dev-server-origin.js" || exit 1
 PORT=$PORT npm run test:playwright || exit 1
 if [ "$COVERAGE" = "1" ] || [ "$COVERAGE" = "true" ]; then
-  echo "Coverage reporter retired with the Puppeteer runner; Playwright passed without function/byte percentages."
+  : "${COVERAGE_MIN:=0}"
+  export COVERAGE_MIN
+  PORT=$PORT node "$DIR/scripts/playwright-coverage.mjs" || exit 1
 fi

--- a/scripts/playwright-coverage.mjs
+++ b/scripts/playwright-coverage.mjs
@@ -98,11 +98,10 @@ function writeCoverageReport(entries, fixtures) {
     const file = canonicalFile(entry.url);
     const total = entrySource(entry).length;
     if (!total) continue;
-    const covered = unionLength(calledRanges(entry));
-    const prev = perFile.get(file) || { total: 0, covered: 0 };
-    perFile.set(file, total > prev.total
-      ? { total, covered: Math.max(covered, prev.covered) }
-      : { total: prev.total, covered: Math.max(covered, prev.covered) });
+    const prev = perFile.get(file) || { total: 0, ranges: [] };
+    prev.total = Math.max(prev.total, total);
+    prev.ranges.push(...calledRanges(entry));
+    perFile.set(file, prev);
 
     const prevCanonical = canonical.get(file);
     if (!prevCanonical || total > entrySource(prevCanonical).length) {
@@ -137,12 +136,13 @@ function writeCoverageReport(entries, fixtures) {
   const rows = [...perFile.entries()].map(([file, metrics]) => {
     const fns = fnPerFile.get(file) || [];
     const fnCalled = fns.filter(fn => fn.called).length;
+    const covered = unionLength(metrics.ranges);
     return {
       file,
       total: metrics.total,
-      covered: metrics.covered,
-      pct: metrics.total > 0 ? (metrics.covered / metrics.total) * 100 : 0,
-      uncovered: metrics.total - metrics.covered,
+      covered,
+      pct: metrics.total > 0 ? (covered / metrics.total) * 100 : 0,
+      uncovered: metrics.total - covered,
       fnTotal: fns.length,
       fnCalled,
       fnPct: fns.length > 0 ? (fnCalled / fns.length) * 100 : 100,
@@ -211,42 +211,74 @@ function writeCoverageReport(entries, fixtures) {
 }
 
 async function main() {
-  const browser = await chromium.launch({
-    headless: true,
-    executablePath: chromiumExecutable || undefined,
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  });
-  const smokeContext = await browser.newContext({
+  let browser = null;
+  try {
+    browser = await chromium.launch({
+      headless: true,
+      executablePath: chromiumExecutable || undefined,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    await smokeTestApp(browser);
+
+    const entries = [];
+    let firstFailure = null;
+    console.log(`Running Playwright coverage sampler against ${BASE_URL}`);
+    for (const [name, testPath, options = {}] of COVERAGE_FIXTURES) {
+      console.log(`  - ${name}`);
+      const result = await runCoverageFixture(browser, testPath, options);
+      entries.push(...result.entries);
+      if (result.failure) {
+        firstFailure = result.failure;
+        break;
+      }
+    }
+
+    const report = writeCoverageReport(entries, COVERAGE_FIXTURES);
+    if (firstFailure) throw firstFailure;
+
+    const minPct = Number.parseFloat(process.env.COVERAGE_MIN || '0');
+    if (Number.isFinite(minPct) && minPct > 0 && report.globalFnPct < minPct) {
+      throw new Error(`Coverage gate failed: function coverage ${report.globalFnPct.toFixed(2)}% is below COVERAGE_MIN=${minPct}.`);
+    }
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+}
+
+async function smokeTestApp(browser) {
+  const context = await browser.newContext({
     baseURL: BASE_URL,
     serviceWorkers: 'block',
   });
-
   try {
-    const page = await smokeContext.newPage();
+    const page = await context.newPage();
     const response = await page.goto('/app', { waitUntil: 'load', timeout: 15_000 });
-    await smokeContext.close();
     if (!response?.ok()) throw new Error(`GET /app returned ${response?.status() || 'no response'}`);
   } catch (error) {
-    await smokeContext.close().catch(() => {});
-    await browser.close();
     console.error(`Cannot connect to ${BASE_URL}/app: ${error.message}`);
     console.error(`Start it with: node dev-server.js ${PORT}`);
-    process.exit(2);
+    error.exitCode = 2;
+    throw error;
+  } finally {
+    await context.close().catch(() => {});
   }
+}
 
-  const entries = [];
-  console.log(`Running Playwright coverage sampler against ${BASE_URL}`);
-  for (const [name, testPath, options = {}] of COVERAGE_FIXTURES) {
-    console.log(`  - ${name}`);
-    const context = await browser.newContext({
-      baseURL: BASE_URL,
-      serviceWorkers: 'block',
-    });
-    const page = await context.newPage();
-    const pageErrors = [];
-    page.on('pageerror', error => {
-      pageErrors.push(error?.message || String(error));
-    });
+async function runCoverageFixture(browser, testPath, options) {
+  const context = await browser.newContext({
+    baseURL: BASE_URL,
+    serviceWorkers: 'block',
+  });
+  const page = await context.newPage();
+  const pageErrors = [];
+  let entries = [];
+  let failure = null;
+
+  page.on('pageerror', error => {
+    pageErrors.push(error?.message || String(error));
+  });
+
+  try {
     await page.coverage.startJSCoverage({
       resetOnNavigation: false,
       reportAnonymousScripts: false,
@@ -255,29 +287,27 @@ async function main() {
     try {
       await runBrowserScript(page, testPath, options);
       await page.waitForTimeout(250);
-      entries.push(...await page.coverage.stopJSCoverage());
+    } catch (error) {
+      failure = error;
     } finally {
-      await context.close();
+      try {
+        entries = await page.coverage.stopJSCoverage();
+      } catch (error) {
+        if (!failure) failure = error;
+      }
     }
-    if (pageErrors.length) {
-      console.error(`\nPage errors observed during ${testPath}:`);
-      for (const error of pageErrors) console.error(`  - ${error}`);
-      await browser.close();
-      process.exit(1);
-    }
+  } finally {
+    await context.close().catch(() => {});
   }
 
-  const report = writeCoverageReport(entries, COVERAGE_FIXTURES);
-  await browser.close();
-
-  const minPct = Number.parseFloat(process.env.COVERAGE_MIN || '0');
-  if (Number.isFinite(minPct) && minPct > 0 && report.globalFnPct < minPct) {
-    console.error(`\nCoverage gate failed: function coverage ${report.globalFnPct.toFixed(2)}% is below COVERAGE_MIN=${minPct}.`);
-    process.exit(1);
+  if (pageErrors.length && !failure) {
+    failure = new Error(`Page errors observed during ${testPath}:\n${pageErrors.map(error => `  - ${error}`).join('\n')}`);
   }
+
+  return { entries, failure };
 }
 
 main().catch(error => {
   console.error(error?.stack || error?.message || String(error));
-  process.exit(1);
+  process.exit(error?.exitCode || 1);
 });

--- a/scripts/playwright-coverage.mjs
+++ b/scripts/playwright-coverage.mjs
@@ -11,9 +11,16 @@ import { fileURLToPath } from 'url';
 import { chromium } from 'playwright';
 import { runBrowserScript } from '../tests/playwright/browser-script-runner.js';
 
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PORT = process.env.PORT || '8000';
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
+const jsonPath = path.join(repoRoot, 'tests', '.coverage.json');
+const vitestCoveragePath = process.env.VITEST_COVERAGE_JSON ||
+  path.join(repoRoot, 'tests', '.vitest-coverage', 'coverage-final.json');
+const includeVitestCoverage = process.env.INCLUDE_VITEST_COVERAGE === '1' ||
+  process.env.INCLUDE_VITEST_COVERAGE === 'true';
+const sourceCache = new Map();
 
 const COVERAGE_FIXTURES = [
   ['export/import browser fixture', 'tests/test-export-import.js'],
@@ -57,16 +64,25 @@ function cleanUrl(url) {
   return (url || '').replace(/^https?:\/\/[^/]+/, '').split('?')[0];
 }
 
-function isAppSource(url) {
-  const rel = cleanUrl(url);
-  return /\/js\/.*\.m?js$/.test(rel) ||
-    /\/api\/.*\.js$/.test(rel) ||
-    rel === '/service-worker.js' ||
-    rel === '/version.js';
+function canonicalFile(url) {
+  let rel = cleanUrl(url);
+  if (rel.startsWith('file://')) rel = fileURLToPath(rel);
+  if (path.isAbsolute(rel)) {
+    const fromRepo = path.relative(repoRoot, rel);
+    if (!fromRepo.startsWith('..') && !path.isAbsolute(fromRepo)) {
+      return fromRepo.split(path.sep).join('/');
+    }
+  }
+  return rel.replace(/^\//, '');
 }
 
-function canonicalFile(url) {
-  return cleanUrl(url).replace(/^\//, '');
+function isAppSource(url) {
+  const rel = canonicalFile(url);
+  return /^js\/.*\.m?js$/.test(rel) ||
+    /^api\/.*\.js$/.test(rel) ||
+    rel === 'dev-server.js' ||
+    rel === 'service-worker.js' ||
+    rel === 'version.js';
 }
 
 function entrySource(entry) {
@@ -78,7 +94,12 @@ function coverageFunctions(entry) {
 }
 
 function calledRanges(entry) {
-  if (Array.isArray(entry.ranges)) return entry.ranges;
+  if (Array.isArray(entry.ranges)) {
+    return entry.ranges.map(range => ({
+      start: range.start ?? range.startOffset ?? 0,
+      end: range.end ?? range.endOffset ?? 0,
+    }));
+  }
   return coverageFunctions(entry)
     .filter(fn => fn.functionName)
     .flatMap(fn => (fn.ranges || [])
@@ -89,54 +110,178 @@ function calledRanges(entry) {
       })));
 }
 
-function writeCoverageReport(entries, fixtures) {
-  const perFile = new Map();
+function sourceForFile(file) {
+  if (sourceCache.has(file)) return sourceCache.get(file);
+  let source = '';
+  try {
+    source = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+  } catch (_) {
+    source = '';
+  }
+  sourceCache.set(file, source);
+  return source;
+}
+
+function lineOffsets(source) {
+  const offsets = [0];
+  for (let i = 0; i < source.length; i += 1) {
+    if (source[i] === '\n') offsets.push(i + 1);
+  }
+  return offsets;
+}
+
+function locToOffset(source, loc, offsets = lineOffsets(source)) {
+  if (!loc || !Number.isFinite(loc.line)) return 0;
+  const lineIndex = Math.max(0, loc.line - 1);
+  const lineStart = offsets[lineIndex] ?? source.length;
+  return Math.min(source.length, Math.max(0, lineStart + (loc.column || 0)));
+}
+
+function locToRange(source, loc, offsets = lineOffsets(source)) {
+  const start = locToOffset(source, loc?.start, offsets);
+  const end = locToOffset(source, loc?.end, offsets);
+  return end > start ? { start, end } : null;
+}
+
+function getFileMetrics(model, file, total = 0, source = null) {
+  const metrics = model.get(file) || {
+    file,
+    total: 0,
+    ranges: [],
+    functions: new Map(),
+    sources: new Set(),
+  };
+  metrics.total = Math.max(metrics.total, total);
+  if (source) metrics.sources.add(source);
+  model.set(file, metrics);
+  return metrics;
+}
+
+function addCoveredRanges(metrics, ranges) {
+  for (const range of ranges) {
+    const start = Math.max(0, range.start ?? 0);
+    const end = Math.max(start, range.end ?? 0);
+    if (end > start) metrics.ranges.push({ start, end });
+  }
+}
+
+function addFunction(metrics, key, name, called, matchByName = false) {
+  let targetKey = key;
+  if (!metrics.functions.has(targetKey) && matchByName) {
+    const match = [...metrics.functions.entries()]
+      .find(([, fn]) => fn.name === name);
+    if (match) targetKey = match[0];
+  }
+
+  const existing = metrics.functions.get(targetKey);
+  if (existing) {
+    existing.called = existing.called || called;
+    return;
+  }
+
+  metrics.functions.set(targetKey, { name, called: Boolean(called) });
+}
+
+function addBrowserEntriesToModel(model, entries) {
   const canonical = new Map();
 
   for (const entry of entries) {
     if (!isAppSource(entry.url)) continue;
     const file = canonicalFile(entry.url);
-    const total = entrySource(entry).length;
+    const total = entrySource(entry).length || sourceForFile(file).length;
     if (!total) continue;
-    const prev = perFile.get(file) || { total: 0, ranges: [] };
-    prev.total = Math.max(prev.total, total);
-    prev.ranges.push(...calledRanges(entry));
-    perFile.set(file, prev);
+
+    const metrics = getFileMetrics(model, file, total, 'playwright');
+    addCoveredRanges(metrics, calledRanges(entry));
 
     const prevCanonical = canonical.get(file);
-    if (!prevCanonical || total > entrySource(prevCanonical).length) {
+    if (!prevCanonical || total > (entrySource(prevCanonical).length || sourceForFile(file).length)) {
       canonical.set(file, entry);
     }
   }
 
-  const fnPerFile = new Map();
   for (const [file, entry] of canonical) {
-    const fns = coverageFunctions(entry)
+    const metrics = getFileMetrics(model, file, entrySource(entry).length || sourceForFile(file).length, 'playwright');
+    coverageFunctions(entry)
       .filter(fn => fn.functionName)
-      .map(fn => ({
-        name: fn.functionName,
-        called: (fn.ranges?.[0]?.count || 0) > 0,
-      }));
-    fnPerFile.set(file, fns);
+      .forEach((fn, index) => {
+        const called = (fn.ranges || []).some(fnRange => (fnRange.count || 0) > 0);
+        addFunction(metrics, `${fn.functionName}:${index}`, fn.functionName, called);
+      });
   }
 
   for (const entry of entries) {
     if (!isAppSource(entry.url)) continue;
     const file = canonicalFile(entry.url);
     if (entry === canonical.get(file)) continue;
-    const fns = fnPerFile.get(file);
-    if (!fns) continue;
+    const metrics = model.get(file);
+    if (!metrics) continue;
+
     for (const fn of coverageFunctions(entry)) {
-      if (!fn.functionName || !((fn.ranges?.[0]?.count || 0) > 0)) continue;
-      const target = fns.find(candidate => candidate.name === fn.functionName && !candidate.called);
+      const called = fn.functionName && (fn.ranges || []).some(fnRange => (fnRange.count || 0) > 0);
+      if (!called) continue;
+      const target = [...metrics.functions.values()]
+        .find(candidate => candidate.name === fn.functionName && !candidate.called);
       if (target) target.called = true;
     }
   }
+}
 
-  const rows = [...perFile.entries()].map(([file, metrics]) => {
-    const fns = fnPerFile.get(file) || [];
+function readVitestCoverageModel() {
+  if (!includeVitestCoverage) return null;
+  if (!fs.existsSync(vitestCoveragePath)) return null;
+
+  const coverage = JSON.parse(fs.readFileSync(vitestCoveragePath, 'utf8'));
+  const model = new Map();
+
+  for (const [coveragePath, fileCoverage] of Object.entries(coverage)) {
+    const file = canonicalFile(fileCoverage.path || coveragePath);
+    if (!isAppSource(file)) continue;
+
+    const source = sourceForFile(file);
+    if (!source) continue;
+    const offsets = lineOffsets(source);
+    const metrics = getFileMetrics(model, file, source.length, 'vitest');
+
+    for (const [id, loc] of Object.entries(fileCoverage.statementMap || {})) {
+      if (!((fileCoverage.s?.[id] || 0) > 0)) continue;
+      const range = locToRange(source, loc, offsets);
+      if (range) addCoveredRanges(metrics, [range]);
+    }
+
+    for (const [id, fn] of Object.entries(fileCoverage.fnMap || {})) {
+      if (!fn.name) continue;
+      const range = locToRange(source, fn.loc, offsets) || locToRange(source, fn.decl, offsets) || { start: 0, end: 0 };
+      addFunction(metrics, `${fn.name}:${range.start}:${range.end}`, fn.name, (fileCoverage.f?.[id] || 0) > 0);
+    }
+  }
+
+  return model;
+}
+
+function mergeCoverageModels(...models) {
+  const combined = new Map();
+
+  for (const model of models) {
+    if (!model) continue;
+    for (const [file, metrics] of model) {
+      const target = getFileMetrics(combined, file, metrics.total);
+      for (const source of metrics.sources) target.sources.add(source);
+      addCoveredRanges(target, metrics.ranges);
+      for (const [key, fn] of metrics.functions) {
+        addFunction(target, key, fn.name, fn.called, true);
+      }
+    }
+  }
+
+  return combined;
+}
+
+function summarizeCoverageModel(model) {
+  const rows = [...model.entries()].map(([file, metrics]) => {
+    const fns = [...metrics.functions.values()];
     const fnCalled = fns.filter(fn => fn.called).length;
-    const covered = unionLength(metrics.ranges);
+    const covered = Math.min(metrics.total, unionLength(metrics.ranges));
     return {
       file,
       total: metrics.total,
@@ -147,6 +292,7 @@ function writeCoverageReport(entries, fixtures) {
       fnCalled,
       fnPct: fns.length > 0 ? (fnCalled / fns.length) * 100 : 100,
       uncalledFns: fns.filter(fn => !fn.called).map(fn => fn.name),
+      sources: [...metrics.sources].sort(),
     };
   });
   rows.sort((a, b) => a.fnPct - b.fnPct || b.fnTotal - a.fnTotal);
@@ -160,34 +306,64 @@ function writeCoverageReport(entries, fixtures) {
 
   const globalPct = totals.total > 0 ? (totals.covered / totals.total) * 100 : 0;
   const globalFnPct = totals.fnTotal > 0 ? (totals.fnCalled / totals.fnTotal) * 100 : 0;
-  const jsonPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'tests', '.coverage.json');
+
+  return { globalFnPct, globalPct, totals, rows };
+}
+
+function printableTotals(label, report) {
+  if (!report) return null;
+  return [
+    `  ${label} FUNCTIONS: ${report.totals.fnCalled.toLocaleString()} / ${report.totals.fnTotal.toLocaleString()} = ${report.globalFnPct.toFixed(2)}%`,
+    `  ${label} BYTES:     ${report.totals.covered.toLocaleString()} / ${report.totals.total.toLocaleString()} = ${report.globalPct.toFixed(2)}%`,
+  ];
+}
+
+function writeCoverageReport(entries, fixtures) {
+  const playwrightModel = new Map();
+  addBrowserEntriesToModel(playwrightModel, entries);
+  const playwright = summarizeCoverageModel(playwrightModel);
+
+  const vitestModel = readVitestCoverageModel();
+  const vitest = vitestModel ? summarizeCoverageModel(vitestModel) : null;
+  const combined = vitest
+    ? summarizeCoverageModel(mergeCoverageModels(vitestModel, playwrightModel))
+    : playwright;
+  const runner = vitest ? 'vitest-playwright' : 'playwright';
 
   let priorFnPct = null;
   try {
     const prior = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-    if (Number.isFinite(prior.globalFnPct)) priorFnPct = prior.globalFnPct;
-    else if (prior?.totals?.fnTotal > 0) priorFnPct = (prior.totals.fnCalled / prior.totals.fnTotal) * 100;
+    if (prior.runner === runner && Number.isFinite(prior.globalFnPct)) priorFnPct = prior.globalFnPct;
   } catch (_) {
     // First coverage run on this checkout.
   }
 
   fs.writeFileSync(jsonPath, JSON.stringify({
-    runner: 'playwright',
-    scope: 'loaded app-source JavaScript from sampled browser fixtures',
-    globalPct,
-    globalFnPct,
-    totals,
+    runner,
+    scope: vitest
+      ? 'app-source JavaScript covered by Vitest/Node V8 coverage plus sampled Playwright Chromium fixtures'
+      : 'loaded app-source JavaScript from sampled Playwright Chromium fixtures',
+    globalPct: combined.globalPct,
+    globalFnPct: combined.globalFnPct,
+    totals: combined.totals,
     fixtures: fixtures.map(([name, testPath]) => ({ name, path: testPath })),
-    rows,
+    rows: combined.rows,
+    reports: {
+      combined,
+      playwright,
+      vitest,
+    },
     generatedAt: new Date().toISOString(),
   }, null, 2));
 
   console.log('\n' + '='.repeat(92));
-  console.log('  PLAYWRIGHT COVERAGE REPORT (function coverage primary; byte coverage secondary)');
+  console.log(vitest
+    ? '  COMBINED COVERAGE REPORT (Vitest/Node + Playwright; function coverage primary)'
+    : '  PLAYWRIGHT COVERAGE REPORT (function coverage primary; byte coverage secondary)');
   console.log('='.repeat(92));
   console.log(['File'.padEnd(50), 'Fns'.padStart(6), 'Called'.padStart(8), 'Fn%'.padStart(8), 'Byte%'.padStart(10)].join(''));
   console.log('-'.repeat(92));
-  for (const row of rows.slice(0, 30)) {
+  for (const row of combined.rows.slice(0, 30)) {
     console.log([
       row.file.padEnd(50).slice(0, 50),
       String(row.fnTotal).padStart(6),
@@ -196,18 +372,21 @@ function writeCoverageReport(entries, fixtures) {
       `${row.pct.toFixed(1)}%`.padStart(10),
     ].join(''));
   }
-  if (rows.length > 30) console.log(`  ... ${rows.length - 30} more files (full data in tests/.coverage.json)`);
+  if (combined.rows.length > 30) console.log(`  ... ${combined.rows.length - 30} more files (full data in tests/.coverage.json)`);
   console.log('-'.repeat(92));
-  console.log(`  GLOBAL FUNCTIONS: ${totals.fnCalled.toLocaleString()} / ${totals.fnTotal.toLocaleString()} = ${globalFnPct.toFixed(2)}%`);
-  console.log(`  GLOBAL BYTES:     ${totals.covered.toLocaleString()} / ${totals.total.toLocaleString()} = ${globalPct.toFixed(2)}%`);
+  if (vitest) {
+    for (const line of printableTotals('PLAYWRIGHT', playwright)) console.log(line);
+    for (const line of printableTotals('VITEST/NODE', vitest)) console.log(line);
+  }
+  for (const line of printableTotals('GLOBAL', combined)) console.log(line);
   if (priorFnPct != null) {
-    const drift = globalFnPct - priorFnPct;
-    if (drift <= -0.5) console.log(`  DRIFT WARNING: function coverage dropped ${drift.toFixed(2)}pt vs prior run (${priorFnPct.toFixed(2)}% -> ${globalFnPct.toFixed(2)}%)`);
-    else if (drift >= 0.5) console.log(`  DELTA: +${drift.toFixed(2)}pt vs prior run (${priorFnPct.toFixed(2)}% -> ${globalFnPct.toFixed(2)}%)`);
+    const drift = combined.globalFnPct - priorFnPct;
+    if (drift <= -0.5) console.log(`  DRIFT WARNING: function coverage dropped ${drift.toFixed(2)}pt vs prior run (${priorFnPct.toFixed(2)}% -> ${combined.globalFnPct.toFixed(2)}%)`);
+    else if (drift >= 0.5) console.log(`  DELTA: +${drift.toFixed(2)}pt vs prior run (${priorFnPct.toFixed(2)}% -> ${combined.globalFnPct.toFixed(2)}%)`);
   }
   console.log('='.repeat(92));
 
-  return { globalFnPct, globalPct, totals, rows };
+  return combined;
 }
 
 async function main() {

--- a/scripts/playwright-coverage.mjs
+++ b/scripts/playwright-coverage.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+// Playwright coverage sampler for Get Based.
+//
+// This intentionally runs after the normal test suite when COVERAGE=1 is set.
+// It samples high-surface browser-script fixtures under Chromium coverage and
+// reports loaded app-source JS function and byte coverage.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { chromium } from 'playwright';
+import { runBrowserScript } from '../tests/playwright/browser-script-runner.js';
+
+const PORT = process.env.PORT || '8000';
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
+
+const COVERAGE_FIXTURES = [
+  ['export/import browser fixture', 'tests/test-export-import.js'],
+  ['UI flows browser fixture', 'tests/test-ui-flows.js'],
+  ['mobile browser regression fixture', 'tests/test-mobile.js'],
+  ['chat panel UX browser fixture', 'tests/test-chat-panel-ux.js'],
+  ['Lens local worker browser fixture', 'tests/test-lens-local-worker.js'],
+  ['audit-fix browser fixture', 'tests/test-audit-fixes.js'],
+  ['AI verdict engine browser contract', 'tests/test-ai-verdict-engine.js', { settleMs: 500 }],
+  ['Light and Sun UI flow browser fixture', 'tests/test-sun-ui-flow.js'],
+  ['silhouette picker browser fixture', 'tests/test-silhouette-picker.js'],
+  ['silhouette region-map browser fixture', 'tests/test-silhouette-region-map.js'],
+  ['wearables detail modal and browser DOM islands', 'tests/test-wearables-dom.js'],
+  ['wearables click-driven UI flows', 'tests/test-wearables-ui-flows.js'],
+  ['axe accessibility browser scan', 'tests/test-a11y-axe.js', {
+    viewport: { width: 800, height: 600 },
+    readyTimeout: 20_000,
+    settleMs: 250,
+  }],
+];
+
+function unionLength(ranges) {
+  if (!ranges.length) return 0;
+  const sorted = [...ranges].sort((a, b) => a.start - b.start);
+  let covered = 0;
+  let curStart = sorted[0].start;
+  let curEnd = sorted[0].end;
+  for (let i = 1; i < sorted.length; i += 1) {
+    if (sorted[i].start <= curEnd) {
+      curEnd = Math.max(curEnd, sorted[i].end);
+    } else {
+      covered += curEnd - curStart;
+      curStart = sorted[i].start;
+      curEnd = sorted[i].end;
+    }
+  }
+  return covered + (curEnd - curStart);
+}
+
+function cleanUrl(url) {
+  return (url || '').replace(/^https?:\/\/[^/]+/, '').split('?')[0];
+}
+
+function isAppSource(url) {
+  const rel = cleanUrl(url);
+  return /\/js\/.*\.m?js$/.test(rel) ||
+    /\/api\/.*\.js$/.test(rel) ||
+    rel === '/service-worker.js' ||
+    rel === '/version.js';
+}
+
+function canonicalFile(url) {
+  return cleanUrl(url).replace(/^\//, '');
+}
+
+function entrySource(entry) {
+  return entry.text || entry.source || '';
+}
+
+function coverageFunctions(entry) {
+  return entry.rawScriptCoverage?.functions || entry.functions || [];
+}
+
+function calledRanges(entry) {
+  if (Array.isArray(entry.ranges)) return entry.ranges;
+  return coverageFunctions(entry)
+    .filter(fn => fn.functionName)
+    .flatMap(fn => (fn.ranges || [])
+      .filter(range => (range.count || 0) > 0)
+      .map(range => ({
+        start: range.start ?? range.startOffset ?? 0,
+        end: range.end ?? range.endOffset ?? 0,
+      })));
+}
+
+function writeCoverageReport(entries, fixtures) {
+  const perFile = new Map();
+  const canonical = new Map();
+
+  for (const entry of entries) {
+    if (!isAppSource(entry.url)) continue;
+    const file = canonicalFile(entry.url);
+    const total = entrySource(entry).length;
+    if (!total) continue;
+    const covered = unionLength(calledRanges(entry));
+    const prev = perFile.get(file) || { total: 0, covered: 0 };
+    perFile.set(file, total > prev.total
+      ? { total, covered: Math.max(covered, prev.covered) }
+      : { total: prev.total, covered: Math.max(covered, prev.covered) });
+
+    const prevCanonical = canonical.get(file);
+    if (!prevCanonical || total > entrySource(prevCanonical).length) {
+      canonical.set(file, entry);
+    }
+  }
+
+  const fnPerFile = new Map();
+  for (const [file, entry] of canonical) {
+    const fns = coverageFunctions(entry)
+      .filter(fn => fn.functionName)
+      .map(fn => ({
+        name: fn.functionName,
+        called: (fn.ranges?.[0]?.count || 0) > 0,
+      }));
+    fnPerFile.set(file, fns);
+  }
+
+  for (const entry of entries) {
+    if (!isAppSource(entry.url)) continue;
+    const file = canonicalFile(entry.url);
+    if (entry === canonical.get(file)) continue;
+    const fns = fnPerFile.get(file);
+    if (!fns) continue;
+    for (const fn of coverageFunctions(entry)) {
+      if (!fn.functionName || !((fn.ranges?.[0]?.count || 0) > 0)) continue;
+      const target = fns.find(candidate => candidate.name === fn.functionName && !candidate.called);
+      if (target) target.called = true;
+    }
+  }
+
+  const rows = [...perFile.entries()].map(([file, metrics]) => {
+    const fns = fnPerFile.get(file) || [];
+    const fnCalled = fns.filter(fn => fn.called).length;
+    return {
+      file,
+      total: metrics.total,
+      covered: metrics.covered,
+      pct: metrics.total > 0 ? (metrics.covered / metrics.total) * 100 : 0,
+      uncovered: metrics.total - metrics.covered,
+      fnTotal: fns.length,
+      fnCalled,
+      fnPct: fns.length > 0 ? (fnCalled / fns.length) * 100 : 100,
+      uncalledFns: fns.filter(fn => !fn.called).map(fn => fn.name),
+    };
+  });
+  rows.sort((a, b) => a.fnPct - b.fnPct || b.fnTotal - a.fnTotal);
+
+  const totals = rows.reduce((acc, row) => ({
+    total: acc.total + row.total,
+    covered: acc.covered + row.covered,
+    fnTotal: acc.fnTotal + row.fnTotal,
+    fnCalled: acc.fnCalled + row.fnCalled,
+  }), { total: 0, covered: 0, fnTotal: 0, fnCalled: 0 });
+
+  const globalPct = totals.total > 0 ? (totals.covered / totals.total) * 100 : 0;
+  const globalFnPct = totals.fnTotal > 0 ? (totals.fnCalled / totals.fnTotal) * 100 : 0;
+  const jsonPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'tests', '.coverage.json');
+
+  let priorFnPct = null;
+  try {
+    const prior = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    if (Number.isFinite(prior.globalFnPct)) priorFnPct = prior.globalFnPct;
+    else if (prior?.totals?.fnTotal > 0) priorFnPct = (prior.totals.fnCalled / prior.totals.fnTotal) * 100;
+  } catch (_) {
+    // First coverage run on this checkout.
+  }
+
+  fs.writeFileSync(jsonPath, JSON.stringify({
+    runner: 'playwright',
+    scope: 'loaded app-source JavaScript from sampled browser fixtures',
+    globalPct,
+    globalFnPct,
+    totals,
+    fixtures: fixtures.map(([name, testPath]) => ({ name, path: testPath })),
+    rows,
+    generatedAt: new Date().toISOString(),
+  }, null, 2));
+
+  console.log('\n' + '='.repeat(92));
+  console.log('  PLAYWRIGHT COVERAGE REPORT (function coverage primary; byte coverage secondary)');
+  console.log('='.repeat(92));
+  console.log(['File'.padEnd(50), 'Fns'.padStart(6), 'Called'.padStart(8), 'Fn%'.padStart(8), 'Byte%'.padStart(10)].join(''));
+  console.log('-'.repeat(92));
+  for (const row of rows.slice(0, 30)) {
+    console.log([
+      row.file.padEnd(50).slice(0, 50),
+      String(row.fnTotal).padStart(6),
+      String(row.fnCalled).padStart(8),
+      `${row.fnPct.toFixed(1)}%`.padStart(8),
+      `${row.pct.toFixed(1)}%`.padStart(10),
+    ].join(''));
+  }
+  if (rows.length > 30) console.log(`  ... ${rows.length - 30} more files (full data in tests/.coverage.json)`);
+  console.log('-'.repeat(92));
+  console.log(`  GLOBAL FUNCTIONS: ${totals.fnCalled.toLocaleString()} / ${totals.fnTotal.toLocaleString()} = ${globalFnPct.toFixed(2)}%`);
+  console.log(`  GLOBAL BYTES:     ${totals.covered.toLocaleString()} / ${totals.total.toLocaleString()} = ${globalPct.toFixed(2)}%`);
+  if (priorFnPct != null) {
+    const drift = globalFnPct - priorFnPct;
+    if (drift <= -0.5) console.log(`  DRIFT WARNING: function coverage dropped ${drift.toFixed(2)}pt vs prior run (${priorFnPct.toFixed(2)}% -> ${globalFnPct.toFixed(2)}%)`);
+    else if (drift >= 0.5) console.log(`  DELTA: +${drift.toFixed(2)}pt vs prior run (${priorFnPct.toFixed(2)}% -> ${globalFnPct.toFixed(2)}%)`);
+  }
+  console.log('='.repeat(92));
+
+  return { globalFnPct, globalPct, totals, rows };
+}
+
+async function main() {
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: chromiumExecutable || undefined,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const smokeContext = await browser.newContext({
+    baseURL: BASE_URL,
+    serviceWorkers: 'block',
+  });
+
+  try {
+    const page = await smokeContext.newPage();
+    const response = await page.goto('/app', { waitUntil: 'load', timeout: 15_000 });
+    await smokeContext.close();
+    if (!response?.ok()) throw new Error(`GET /app returned ${response?.status() || 'no response'}`);
+  } catch (error) {
+    await smokeContext.close().catch(() => {});
+    await browser.close();
+    console.error(`Cannot connect to ${BASE_URL}/app: ${error.message}`);
+    console.error(`Start it with: node dev-server.js ${PORT}`);
+    process.exit(2);
+  }
+
+  const entries = [];
+  console.log(`Running Playwright coverage sampler against ${BASE_URL}`);
+  for (const [name, testPath, options = {}] of COVERAGE_FIXTURES) {
+    console.log(`  - ${name}`);
+    const context = await browser.newContext({
+      baseURL: BASE_URL,
+      serviceWorkers: 'block',
+    });
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on('pageerror', error => {
+      pageErrors.push(error?.message || String(error));
+    });
+    await page.coverage.startJSCoverage({
+      resetOnNavigation: false,
+      reportAnonymousScripts: false,
+      includeRawScriptCoverage: true,
+    });
+    try {
+      await runBrowserScript(page, testPath, options);
+      await page.waitForTimeout(250);
+      entries.push(...await page.coverage.stopJSCoverage());
+    } finally {
+      await context.close();
+    }
+    if (pageErrors.length) {
+      console.error(`\nPage errors observed during ${testPath}:`);
+      for (const error of pageErrors) console.error(`  - ${error}`);
+      await browser.close();
+      process.exit(1);
+    }
+  }
+
+  const report = writeCoverageReport(entries, COVERAGE_FIXTURES);
+  await browser.close();
+
+  const minPct = Number.parseFloat(process.env.COVERAGE_MIN || '0');
+  if (Number.isFinite(minPct) && minPct > 0 && report.globalFnPct < minPct) {
+    console.error(`\nCoverage gate failed: function coverage ${report.globalFnPct.toFixed(2)}% is below COVERAGE_MIN=${minPct}.`);
+    process.exit(1);
+  }
+}
+
+main().catch(error => {
+  console.error(error?.stack || error?.message || String(error));
+  process.exit(1);
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -30,5 +30,25 @@ export default defineConfig({
     ],
     setupFiles: ['./tests/_vitest-setup.js'],
     reporters: ['default'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['json-summary', 'json'],
+      reportsDirectory: 'tests/.vitest-coverage',
+      all: true,
+      include: [
+        'js/**/*.js',
+        'api/**/*.js',
+        'dev-server.js',
+        'service-worker.js',
+        'version.js',
+      ],
+      exclude: [
+        '**/node_modules/**',
+        'vendor/**',
+        'docs/**',
+        'dist-docs/**',
+        'tests/**',
+      ],
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Adds a Playwright Chromium coverage sampler that runs after the normal suite when `COVERAGE=1` is set.
- Enables Vitest V8 coverage for the Node-side test layer and merges it with sampled Playwright browser coverage in `tests/.coverage.json`.
- Replaces the retired Puppeteer coverage notice in `run-tests.sh` and updates testing docs with the new combined `COVERAGE_MIN` gate option.
- Unions called byte ranges across fixtures and preserves/flushes coverage data before reporting fixture failures.

## Validation

- `npm run typecheck`
- `npm run quality`
- `node --check scripts/playwright-coverage.mjs`
- `PORT=8003 COVERAGE=1 ./run-tests.sh`

Coverage sampler baseline from the full harness:

- Playwright functions `1,334 / 3,831 = 34.82%`; bytes `1,336,827 / 4,183,674 = 31.95%`
- Vitest/Node functions `1,945 / 6,990 = 27.83%`; bytes `1,187,336 / 4,363,830 = 27.21%`
- Combined functions `2,712 / 7,350 = 36.90%`; bytes `2,149,875 / 4,363,830 = 49.27%`