### PR TITLE
[codex] Add full Playwright suite coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ release/
 # Coverage output from `COVERAGE=1 ./run-tests.sh` — regenerated on every run
 tests/.coverage.json
 tests/.vitest-coverage/
+tests/.playwright-coverage/
 labcharts-*.json
 test-*.json
 node_modules/

--- a/dev-docs/testing.md
+++ b/dev-docs/testing.md
@@ -173,7 +173,9 @@ The script:
 
 ## Coverage status
 
-`COVERAGE=1 ./run-tests.sh` runs Vitest with V8 coverage enabled, runs the normal Playwright suite, then runs a Playwright Chromium coverage sampler over the high-surface browser fixtures. The sampler merges `tests/.vitest-coverage/coverage-final.json` with its browser coverage, writes `tests/.coverage.json`, and prints separate Playwright, Vitest/Node, and combined global function/byte coverage percentages for app-source JavaScript.
+`COVERAGE=1 ./run-tests.sh` runs Vitest with V8 coverage enabled, runs the normal Playwright suite with Chromium JS coverage enabled, then merges the Playwright suite shards from `tests/.playwright-coverage/` with `tests/.vitest-coverage/coverage-final.json`. The reporter writes `tests/.coverage.json` and prints separate Playwright, Vitest/Node, and combined global function/byte coverage percentages for app-source JavaScript.
+
+Running `node scripts/playwright-coverage.mjs` directly still falls back to the legacy high-surface Chromium sampler when no Playwright suite shards are present. The full `COVERAGE=1 ./run-tests.sh` path requires suite shards so coverage regressions in the Playwright instrumentation fail clearly.
 
 Coverage is report-only by default. Set `COVERAGE_MIN=90` or another percentage to fail the run when combined global function coverage falls below that floor.
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,6 +52,7 @@ trap cleanup EXIT
 # The legacy node-side files are wrapped by tests/_vitest-legacy.test.js.
 if [ "$COVERAGE_ENABLED" = "1" ]; then
   rm -rf "$DIR/tests/.vitest-coverage"
+  rm -rf "$DIR/tests/.playwright-coverage"
   npm test -- --coverage || exit 1
 else
   npm test || exit 1
@@ -59,9 +60,13 @@ fi
 ensure_server
 # HTTP-reliant test before the browser suite (needs the dev server up).
 PORT=$PORT node "$DIR/tests/test-dev-server-origin.js" || exit 1
-PORT=$PORT npm run test:playwright || exit 1
+if [ "$COVERAGE_ENABLED" = "1" ]; then
+  PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR="$DIR/tests/.playwright-coverage" PORT=$PORT npm run test:playwright || exit 1
+else
+  PORT=$PORT npm run test:playwright || exit 1
+fi
 if [ "$COVERAGE_ENABLED" = "1" ]; then
   : "${COVERAGE_MIN:=0}"
   export COVERAGE_MIN
-  INCLUDE_VITEST_COVERAGE=1 PORT=$PORT node "$DIR/scripts/playwright-coverage.mjs" || exit 1
+  INCLUDE_VITEST_COVERAGE=1 REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 PLAYWRIGHT_COVERAGE_DIR="$DIR/tests/.playwright-coverage" PORT=$PORT node "$DIR/scripts/playwright-coverage.mjs" || exit 1
 fi

--- a/scripts/playwright-coverage.mjs
+++ b/scripts/playwright-coverage.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// Playwright coverage sampler for Get Based.
+// Playwright coverage reporter for Get Based.
 //
 // This intentionally runs after the normal test suite when COVERAGE=1 is set.
-// It samples high-surface browser-script fixtures under Chromium coverage and
-// reports loaded app-source JS function and byte coverage.
+// It prefers coverage shards emitted by the Playwright suite and falls back to
+// high-surface browser-script fixtures when no suite shards are available.
 
 import fs from 'fs';
 import path from 'path';
@@ -16,10 +16,14 @@ const PORT = process.env.PORT || '8000';
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
 const jsonPath = path.join(repoRoot, 'tests', '.coverage.json');
+const playwrightCoverageDir = process.env.PLAYWRIGHT_COVERAGE_DIR ||
+  path.join(repoRoot, 'tests', '.playwright-coverage');
 const vitestCoveragePath = process.env.VITEST_COVERAGE_JSON ||
   path.join(repoRoot, 'tests', '.vitest-coverage', 'coverage-final.json');
 const includeVitestCoverage = process.env.INCLUDE_VITEST_COVERAGE === '1' ||
   process.env.INCLUDE_VITEST_COVERAGE === 'true';
+const requirePlaywrightCoverageShards = process.env.REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS === '1' ||
+  process.env.REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS === 'true';
 const sourceCache = new Map();
 
 const COVERAGE_FIXTURES = [
@@ -318,7 +322,44 @@ function printableTotals(label, report) {
   ];
 }
 
-function writeCoverageReport(entries, fixtures) {
+function normalizeFixture(fixture) {
+  if (Array.isArray(fixture)) return { name: fixture[0], path: fixture[1] };
+  return fixture;
+}
+
+function readPlaywrightCoverageShards() {
+  if (!fs.existsSync(playwrightCoverageDir)) return { entries: [], fixtures: [], files: [] };
+
+  const files = fs.readdirSync(playwrightCoverageDir)
+    .filter(file => file.endsWith('.json'))
+    .sort();
+  const entries = [];
+  const fixtures = [];
+
+  for (const file of files) {
+    const shardPath = path.join(playwrightCoverageDir, file);
+    const shard = JSON.parse(fs.readFileSync(shardPath, 'utf8'));
+    const shardEntries = Array.isArray(shard.entries) ? shard.entries : [];
+    entries.push(...shardEntries);
+    fixtures.push({
+      name: shard.titlePath?.slice(-1)[0] || shard.title || path.basename(file, '.json'),
+      path: shard.file || path.relative(repoRoot, shardPath).split(path.sep).join('/'),
+      label: shard.label || null,
+      entryCount: shardEntries.length,
+    });
+  }
+
+  return { entries, fixtures, files };
+}
+
+function enforceCoverageGate(report) {
+  const minPct = Number.parseFloat(process.env.COVERAGE_MIN || '0');
+  if (Number.isFinite(minPct) && minPct > 0 && report.globalFnPct < minPct) {
+    throw new Error(`Coverage gate failed: function coverage ${report.globalFnPct.toFixed(2)}% is below COVERAGE_MIN=${minPct}.`);
+  }
+}
+
+function writeCoverageReport(entries, fixtures, options = {}) {
   const playwrightModel = new Map();
   addBrowserEntriesToModel(playwrightModel, entries);
   const playwright = summarizeCoverageModel(playwrightModel);
@@ -341,12 +382,12 @@ function writeCoverageReport(entries, fixtures) {
   fs.writeFileSync(jsonPath, JSON.stringify({
     runner,
     scope: vitest
-      ? 'app-source JavaScript covered by Vitest/Node V8 coverage plus sampled Playwright Chromium fixtures'
-      : 'loaded app-source JavaScript from sampled Playwright Chromium fixtures',
+      ? `app-source JavaScript covered by Vitest/Node V8 coverage plus ${options.playwrightScope || 'sampled Playwright Chromium fixtures'}`
+      : `loaded app-source JavaScript from ${options.playwrightScope || 'sampled Playwright Chromium fixtures'}`,
     globalPct: combined.globalPct,
     globalFnPct: combined.globalFnPct,
     totals: combined.totals,
-    fixtures: fixtures.map(([name, testPath]) => ({ name, path: testPath })),
+    fixtures: fixtures.map(normalizeFixture),
     rows: combined.rows,
     reports: {
       combined,
@@ -390,6 +431,20 @@ function writeCoverageReport(entries, fixtures) {
 }
 
 async function main() {
+  const suiteCoverage = readPlaywrightCoverageShards();
+  if (suiteCoverage.files.length) {
+    console.log(`Reading ${suiteCoverage.files.length} Playwright coverage shard(s) from ${path.relative(repoRoot, playwrightCoverageDir)}`);
+    const report = writeCoverageReport(suiteCoverage.entries, suiteCoverage.fixtures, {
+      playwrightScope: 'Playwright suite coverage shards',
+    });
+    enforceCoverageGate(report);
+    return;
+  }
+
+  if (requirePlaywrightCoverageShards) {
+    throw new Error(`No Playwright coverage shards found in ${playwrightCoverageDir}.`);
+  }
+
   let browser = null;
   try {
     browser = await chromium.launch({
@@ -412,13 +467,12 @@ async function main() {
       }
     }
 
-    const report = writeCoverageReport(entries, COVERAGE_FIXTURES);
+    const report = writeCoverageReport(entries, COVERAGE_FIXTURES, {
+      playwrightScope: 'sampled Playwright Chromium fixtures',
+    });
     if (firstFailure) throw firstFailure;
 
-    const minPct = Number.parseFloat(process.env.COVERAGE_MIN || '0');
-    if (Number.isFinite(minPct) && minPct > 0 && report.globalFnPct < minPct) {
-      throw new Error(`Coverage gate failed: function coverage ${report.globalFnPct.toFixed(2)}% is below COVERAGE_MIN=${minPct}.`);
-    }
+    enforceCoverageGate(report);
   } finally {
     if (browser) await browser.close().catch(() => {});
   }

--- a/scripts/playwright-coverage.mjs
+++ b/scripts/playwright-coverage.mjs
@@ -328,17 +328,24 @@ function normalizeFixture(fixture) {
 }
 
 function readPlaywrightCoverageShards() {
-  if (!fs.existsSync(playwrightCoverageDir)) return { entries: [], fixtures: [], files: [] };
+  if (!fs.existsSync(playwrightCoverageDir)) return { entries: [], fixtures: [], files: [], unreadable: [] };
 
   const files = fs.readdirSync(playwrightCoverageDir)
     .filter(file => file.endsWith('.json'))
     .sort();
   const entries = [];
   const fixtures = [];
+  const unreadable = [];
 
   for (const file of files) {
     const shardPath = path.join(playwrightCoverageDir, file);
-    const shard = JSON.parse(fs.readFileSync(shardPath, 'utf8'));
+    let shard;
+    try {
+      shard = JSON.parse(fs.readFileSync(shardPath, 'utf8'));
+    } catch (error) {
+      unreadable.push({ file, error: error.message });
+      continue;
+    }
     const shardEntries = Array.isArray(shard.entries) ? shard.entries : [];
     entries.push(...shardEntries);
     fixtures.push({
@@ -349,7 +356,7 @@ function readPlaywrightCoverageShards() {
     });
   }
 
-  return { entries, fixtures, files };
+  return { entries, fixtures, files, unreadable };
 }
 
 function enforceCoverageGate(report) {
@@ -433,7 +440,13 @@ function writeCoverageReport(entries, fixtures, options = {}) {
 async function main() {
   const suiteCoverage = readPlaywrightCoverageShards();
   if (suiteCoverage.files.length) {
-    console.log(`Reading ${suiteCoverage.files.length} Playwright coverage shard(s) from ${path.relative(repoRoot, playwrightCoverageDir)}`);
+    for (const { file, error } of suiteCoverage.unreadable) {
+      console.warn(`  Warning: skipping unreadable coverage shard ${file}: ${error}`);
+    }
+    if (!suiteCoverage.fixtures.length && requirePlaywrightCoverageShards) {
+      throw new Error(`No readable Playwright coverage shards found in ${playwrightCoverageDir}.`);
+    }
+    console.log(`Reading ${suiteCoverage.fixtures.length} readable Playwright coverage shard(s) from ${path.relative(repoRoot, playwrightCoverageDir)}`);
     const report = writeCoverageReport(suiteCoverage.entries, suiteCoverage.fixtures, {
       playwrightScope: 'Playwright suite coverage shards',
     });

--- a/tests/playwright/a11y-axe-browser.spec.js
+++ b/tests/playwright/a11y-axe-browser.spec.js
@@ -1,7 +1,8 @@
-import { test } from '@playwright/test';
+import { test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
 
-test('axe accessibility browser scan', { timeout: 120_000 }, async ({ page }) => {
+test('axe accessibility browser scan', async ({ page }, testInfo) => {
+  testInfo.setTimeout(120_000);
   const rebaseline = process.env.A11Y_REBASELINE === '1' || process.env.A11Y_REBASELINE === 'true';
   if (rebaseline) {
     await page.addInitScript(() => {

--- a/tests/playwright/ai-verdict-engine-browser.spec.js
+++ b/tests/playwright/ai-verdict-engine-browser.spec.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
 
 test('AI verdict engine browser contract', { timeout: 120_000 }, async ({ page }) => {

--- a/tests/playwright/all-sessions-modal.spec.js
+++ b/tests/playwright/all-sessions-modal.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const SESSION_COUNT = 12;
 

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('audit runtime guards no-op on adversarial marker ids', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/changelog.spec.js
+++ b/tests/playwright/changelog.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const SHOW_CLASS_TOKEN = /(^|\s)show(\s|$)/;
 

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('chat action bars, clipboard, and context toggles work in the live DOM', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('chat empty-state delegated actions update scoped profile UI', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/chat-threads-dom.spec.js
+++ b/tests/playwright/chat-threads-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('chat thread rail and delegated thread actions work in the live DOM', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/core-browser-flows.spec.js
+++ b/tests/playwright/core-browser-flows.spec.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
 
 const CORE_FLOW_BROWSER_TESTS = [

--- a/tests/playwright/coverage-fixture.js
+++ b/tests/playwright/coverage-fixture.js
@@ -34,6 +34,7 @@ function coverageFile(testInfo, label) {
     `r${testInfo.repeatEachIndex}`,
     process.pid,
     Date.now(),
+    Math.random().toString(36).slice(2, 8),
   ].join('-');
   return path.join(coverageDir, `${title}-${suffix}.json`);
 }

--- a/tests/playwright/coverage-fixture.js
+++ b/tests/playwright/coverage-fixture.js
@@ -1,0 +1,97 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test as base } from '@playwright/test';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const coverageDir = process.env.PLAYWRIGHT_COVERAGE_DIR ||
+  path.join(repoRoot, 'tests', '.playwright-coverage');
+const startedPages = new WeakSet();
+
+function isCoverageEnabled() {
+  return process.env.PLAYWRIGHT_SUITE_COVERAGE === '1' ||
+    process.env.PLAYWRIGHT_SUITE_COVERAGE === 'true';
+}
+
+function safeName(value) {
+  return String(value || 'test')
+    .replace(/[^a-z0-9_.-]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 140) || 'test';
+}
+
+function titlePathFor(testInfo) {
+  if (typeof testInfo.titlePath === 'function') return testInfo.titlePath();
+  if (Array.isArray(testInfo.titlePath)) return testInfo.titlePath;
+  return [testInfo.title];
+}
+
+function coverageFile(testInfo, label) {
+  const title = safeName(titlePathFor(testInfo).join(' '));
+  const suffix = [
+    safeName(label),
+    `w${testInfo.workerIndex}`,
+    `r${testInfo.repeatEachIndex}`,
+    process.pid,
+    Date.now(),
+  ].join('-');
+  return path.join(coverageDir, `${title}-${suffix}.json`);
+}
+
+function shrinkEntry(entry) {
+  return {
+    url: entry.url,
+    ranges: entry.ranges,
+    functions: entry.functions,
+    rawScriptCoverage: entry.rawScriptCoverage
+      ? { functions: entry.rawScriptCoverage.functions }
+      : undefined,
+  };
+}
+
+export async function startPageCoverage(page) {
+  if (!isCoverageEnabled() || startedPages.has(page)) return;
+  await page.coverage.startJSCoverage({
+    resetOnNavigation: false,
+    reportAnonymousScripts: false,
+    includeRawScriptCoverage: true,
+  });
+  startedPages.add(page);
+}
+
+export async function stopPageCoverage(page, testInfo, label = 'page') {
+  if (!isCoverageEnabled() || !startedPages.has(page)) return;
+  let entries = [];
+  try {
+    entries = await page.coverage.stopJSCoverage();
+  } finally {
+    startedPages.delete(page);
+  }
+  fs.mkdirSync(coverageDir, { recursive: true });
+  fs.writeFileSync(coverageFile(testInfo, label), JSON.stringify({
+    title: testInfo.title,
+    titlePath: titlePathFor(testInfo),
+    file: path.relative(repoRoot, testInfo.file).split(path.sep).join('/'),
+    label,
+    generatedAt: new Date().toISOString(),
+    entries: entries.map(shrinkEntry),
+  }));
+}
+
+export const test = base.extend({
+  page: async ({ page }, use, testInfo) => {
+    if (!isCoverageEnabled()) {
+      await use(page);
+      return;
+    }
+
+    await startPageCoverage(page);
+    try {
+      await use(page);
+    } finally {
+      await stopPageCoverage(page, testInfo);
+    }
+  },
+});
+
+export { expect };

--- a/tests/playwright/coverage-stragglers-dom.spec.js
+++ b/tests/playwright/coverage-stragglers-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('coverage straggler browser rails reject and clean up correctly', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/custom-api-settings.spec.js
+++ b/tests/playwright/custom-api-settings.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('custom API provider panel renders from Settings AI', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/custom-lens.spec.js
+++ b/tests/playwright/custom-lens.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('chat lens indicator hides when no lens is configured', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/custom-personality-dom.spec.js
+++ b/tests/playwright/custom-personality-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('custom personality DOM renders editor controls and delegated discuss action', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/dashboard-data-protection.spec.js
+++ b/tests/playwright/dashboard-data-protection.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('data protection picker opens and dismisses', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('personalize AI picker opens and dismisses', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('dashboard widget delegated actions cover organize, picker, biometrics, and body actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/family-history-dom.spec.js
+++ b/tests/playwright/family-history-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('family history DOM handlers round-trip and mutate entries', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/image-utils-dom.spec.js
+++ b/tests/playwright/image-utils-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('chat image attachment DOM and CSS are loaded', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 async function prepareApp(page) {
   await page.addInitScript(() => {

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('Light page view delegates session, link, channel, and prompt actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/light-sun-browser-flows.spec.js
+++ b/tests/playwright/light-sun-browser-flows.spec.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
 
 const LIGHT_SUN_BROWSER_TESTS = [

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 async function prepareApp(page) {
   await page.addInitScript(() => {

--- a/tests/playwright/openrouter-settings.spec.js
+++ b/tests/playwright/openrouter-settings.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('OpenRouter provider controls render from Settings AI', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/settings-toggles.spec.js
+++ b/tests/playwright/settings-toggles.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 const SHOW_CLASS_TOKEN = /(^|\s)show(\s|$)/;
 

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -403,9 +403,11 @@ async function run(browser, testInfo) {
     console.log('=== Two-Device Sync E2E Tests ===\n');
     const base = buildImportedData();
     const deviceA = await makePage(browser, 'A', clone(base), recordPageError, testInfo);
+    devices.push(deviceA);
+    contexts.push(deviceA.context);
     const deviceB = await makePage(browser, 'B', clone(base), recordPageError, testInfo);
-    devices.push(deviceA, deviceB);
-    contexts.push(deviceA.context, deviceB.context);
+    devices.push(deviceB);
+    contexts.push(deviceB.context);
     const { page: pageA } = deviceA;
     const { page: pageB } = deviceB;
 

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -5,7 +5,7 @@
 // same post-merge active-profile refresh path that sync-pull.js calls after a
 // pull, plus the real merge helper for stale-pull protection.
 
-import { test } from '@playwright/test';
+import { startPageCoverage, stopPageCoverage, test } from './coverage-fixture.js';
 
 const PORT = process.env.PORT || 8000;
 const BASE_URL = `http://localhost:${PORT}/app`;
@@ -96,66 +96,73 @@ async function makeContext(browser) {
   return browser.newContext({ serviceWorkers: 'block' });
 }
 
-async function makePage(browser, label, importedData, recordPageError) {
+async function makePage(browser, label, importedData, recordPageError, testInfo) {
   const context = await makeContext(browser);
   const page = await context.newPage();
-  page.setDefaultTimeout(15000);
-  page.on('pageerror', err => {
-    recordPageError(label, err);
-  });
-  await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
-  await page.evaluate(async () => {
-    try {
-      const regs = await navigator.serviceWorker.getRegistrations();
-      for (const reg of regs) await reg.unregister();
-    } catch (_) {}
-  });
-  await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
-  await page.waitForFunction(
-    () => window._labState
-      && typeof window.saveImportedData === 'function'
-      && typeof window.showDetailModal === 'function'
-      && typeof window.navigate === 'function'
-      && typeof window.openSunSessionDetail === 'function'
-      && typeof window.openDeviceSessionDetail === 'function',
-    null,
-    { timeout: 15000 }
-  );
-  const helperBust = `syncE2E=${Date.now()}_${Math.random().toString(36).slice(2)}`;
-  await page.addScriptTag({
-    type: 'module',
-    content: `
-      import { mergePulledImportedData, persistPulledImportedData } from '/js/sync-pull-merge.js?${helperBust}';
-      import { refreshActiveProfileAfterPull } from '/js/sync-pull-active-refresh.js?${helperBust}';
-      window.__syncE2EMergePulledImportedData = mergePulledImportedData;
-      window.__syncE2EPersistPulledImportedData = persistPulledImportedData;
-      window.__syncE2ERefreshActiveProfileAfterPull = refreshActiveProfileAfterPull;
-    `,
-  });
-  await page.waitForFunction(
-    () => typeof window.__syncE2EMergePulledImportedData === 'function'
-      && typeof window.__syncE2EPersistPulledImportedData === 'function'
-      && typeof window.__syncE2ERefreshActiveProfileAfterPull === 'function',
-    null,
-    { timeout: 15000 }
-  );
-  await page.evaluate(async ({ profileId, imported }) => {
-    localStorage.clear();
-    sessionStorage.clear();
-    localStorage.setItem('labcharts-active-profile', profileId);
-    window._labState.currentProfile = profileId;
-    window._labState.currentView = 'dashboard';
-    window._labState.importedData = JSON.parse(JSON.stringify(imported));
-    window._labState.markerRegistry = {};
-    window._labState._activeDetailMarkerId = null;
-    document.querySelectorAll('.modal-overlay').forEach(el => {
-      if (el.id) el.classList.remove('show');
-      else el.remove();
+  try {
+    page.setDefaultTimeout(15000);
+    page.on('pageerror', err => {
+      recordPageError(label, err);
     });
-    await window.saveImportedData({ immediate: true });
-    window.navigate('dashboard');
-  }, { profileId: PROFILE_ID, imported: importedData });
-  return { context, page };
+    await startPageCoverage(page);
+    await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
+    await page.evaluate(async () => {
+      try {
+        const regs = await navigator.serviceWorker.getRegistrations();
+        for (const reg of regs) await reg.unregister();
+      } catch (_) {}
+    });
+    await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
+    await page.waitForFunction(
+      () => window._labState
+        && typeof window.saveImportedData === 'function'
+        && typeof window.showDetailModal === 'function'
+        && typeof window.navigate === 'function'
+        && typeof window.openSunSessionDetail === 'function'
+        && typeof window.openDeviceSessionDetail === 'function',
+      null,
+      { timeout: 15000 }
+    );
+    const helperBust = `syncE2E=${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    await page.addScriptTag({
+      type: 'module',
+      content: `
+        import { mergePulledImportedData, persistPulledImportedData } from '/js/sync-pull-merge.js?${helperBust}';
+        import { refreshActiveProfileAfterPull } from '/js/sync-pull-active-refresh.js?${helperBust}';
+        window.__syncE2EMergePulledImportedData = mergePulledImportedData;
+        window.__syncE2EPersistPulledImportedData = persistPulledImportedData;
+        window.__syncE2ERefreshActiveProfileAfterPull = refreshActiveProfileAfterPull;
+      `,
+    });
+    await page.waitForFunction(
+      () => typeof window.__syncE2EMergePulledImportedData === 'function'
+        && typeof window.__syncE2EPersistPulledImportedData === 'function'
+        && typeof window.__syncE2ERefreshActiveProfileAfterPull === 'function',
+      null,
+      { timeout: 15000 }
+    );
+    await page.evaluate(async ({ profileId, imported }) => {
+      localStorage.clear();
+      sessionStorage.clear();
+      localStorage.setItem('labcharts-active-profile', profileId);
+      window._labState.currentProfile = profileId;
+      window._labState.currentView = 'dashboard';
+      window._labState.importedData = JSON.parse(JSON.stringify(imported));
+      window._labState.markerRegistry = {};
+      window._labState._activeDetailMarkerId = null;
+      document.querySelectorAll('.modal-overlay').forEach(el => {
+        if (el.id) el.classList.remove('show');
+        else el.remove();
+      });
+      await window.saveImportedData({ immediate: true });
+      window.navigate('dashboard');
+    }, { profileId: PROFILE_ID, imported: importedData });
+    return { context, page, label };
+  } catch (error) {
+    await stopPageCoverage(page, testInfo, `device-${label.toLowerCase()}`).catch(() => {});
+    await context.close().catch(() => {});
+    throw error;
+  }
 }
 
 async function getImportedData(page) {
@@ -369,11 +376,12 @@ async function closeFloatingModals(page) {
   });
 }
 
-async function run(browser) {
+async function run(browser, testInfo) {
   let pass = 0;
   let fail = 0;
   const failures = [];
   const contexts = [];
+  const devices = [];
   function assert(name, condition, detail = '') {
     if (condition) {
       pass++;
@@ -394,8 +402,9 @@ async function run(browser) {
   try {
     console.log('=== Two-Device Sync E2E Tests ===\n');
     const base = buildImportedData();
-    const deviceA = await makePage(browser, 'A', clone(base), recordPageError);
-    const deviceB = await makePage(browser, 'B', clone(base), recordPageError);
+    const deviceA = await makePage(browser, 'A', clone(base), recordPageError, testInfo);
+    const deviceB = await makePage(browser, 'B', clone(base), recordPageError, testInfo);
+    devices.push(deviceA, deviceB);
     contexts.push(deviceA.context, deviceB.context);
     const { page: pageA } = deviceA;
     const { page: pageB } = deviceB;
@@ -473,6 +482,9 @@ async function run(browser) {
       deviceSnap.open && deviceSnap.durationMin === 18 && deviceSnap.text.includes('18 min'),
       JSON.stringify(deviceSnap));
   } finally {
+    for (const device of devices) {
+      await stopPageCoverage(device.page, testInfo, `device-${device.label.toLowerCase()}`).catch(() => {});
+    }
     for (const context of contexts) {
       try {
         await context?.close();
@@ -490,5 +502,5 @@ async function run(browser) {
 
 test('two-device sync E2E', async ({ browser }, testInfo) => {
   testInfo.setTimeout(90_000);
-  await run(browser);
+  await run(browser, testInfo);
 });

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -7,7 +7,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { test } from '@playwright/test';
+import { startPageCoverage, stopPageCoverage, test } from './coverage-fixture.js';
 
 const PORT = process.env.PORT || 8000;
 const BASE_URL = `http://localhost:${PORT}/app`;
@@ -1100,7 +1100,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
   }
 }
 
-async function makeScenarioPage(browser, viewport, recordFailure) {
+async function makeScenarioPage(browser, viewport, recordFailure, testInfo, label) {
   const context = await browser.newContext({
     viewport: { width: viewport.width, height: viewport.height },
     isMobile: viewport.mobile,
@@ -1109,13 +1109,20 @@ async function makeScenarioPage(browser, viewport, recordFailure) {
     serviceWorkers: 'block',
   });
   const page = await context.newPage();
-  page.on('pageerror', err => {
-    recordFailure(`PAGE ERROR ${err.message}`);
-  });
-  return { context, page };
+  try {
+    page.on('pageerror', err => {
+      recordFailure(`PAGE ERROR ${err.message}`);
+    });
+    await startPageCoverage(page);
+    return { context, page, label };
+  } catch (error) {
+    await stopPageCoverage(page, testInfo, label).catch(() => {});
+    await context.close().catch(() => {});
+    throw error;
+  }
 }
 
-async function run(browser) {
+async function run(browser, testInfo) {
   let pass = 0;
   let fail = 0;
   const failures = [];
@@ -1138,7 +1145,8 @@ async function run(browser) {
 
   for (const theme of THEMES) {
     for (const viewport of VIEWPORTS) {
-      const { context, page } = await makeScenarioPage(browser, viewport, recordFailure);
+      const label = `${theme}-${viewport.name}`;
+      const { context, page } = await makeScenarioPage(browser, viewport, recordFailure, testInfo, label);
       try {
         console.log(`\n▶ Theme Responsive E2E ${theme}/${viewport.name}`);
         await prepareScenario(page, theme, viewport);
@@ -1153,13 +1161,15 @@ async function run(browser) {
         else await checkDesktopModals(page, theme, viewport.name, assert);
         await captureArtifact(page, theme, viewport.name, assert);
       } finally {
+        await stopPageCoverage(page, testInfo, label).catch(() => {});
         await context.close();
       }
     }
   }
 
   for (const viewport of BOUNDARY_VIEWPORTS) {
-    const { context, page } = await makeScenarioPage(browser, viewport, recordFailure);
+    const label = `dark-${viewport.name}`;
+    const { context, page } = await makeScenarioPage(browser, viewport, recordFailure, testInfo, label);
     try {
       console.log(`\n▶ Theme Responsive E2E dark/${viewport.name}`);
       await prepareScenario(page, 'dark', viewport);
@@ -1176,6 +1186,7 @@ async function run(browser) {
         result.mainText > 40 && (viewport.mobile ? result.mobileShell : !result.mobileShell),
         JSON.stringify(result));
     } finally {
+      await stopPageCoverage(page, testInfo, label).catch(() => {});
       await context.close();
     }
   }
@@ -1190,5 +1201,5 @@ async function run(browser) {
 
 test('theme responsive E2E', async ({ browser }, testInfo) => {
   testInfo.setTimeout(240_000);
-  await run(browser);
+  await run(browser, testInfo);
 });

--- a/tests/playwright/tour-dom.spec.js
+++ b/tests/playwright/tour-dom.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('guided tour DOM creates, navigates, layers, and restores the empty tour overlay', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/ui-regression-browser-flows.spec.js
+++ b/tests/playwright/ui-regression-browser-flows.spec.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
 
 const UI_REGRESSION_BROWSER_TESTS = [

--- a/tests/playwright/wearables-bp-merge.spec.js
+++ b/tests/playwright/wearables-bp-merge.spec.js
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage-fixture.js';
 
 test('blood pressure manual log form is idempotent', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });

--- a/tests/playwright/wearables-browser-flows.spec.js
+++ b/tests/playwright/wearables-browser-flows.spec.js
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from './coverage-fixture.js';
 import { runBrowserScript } from './browser-script-runner.js';
 
 const WEARABLES_BROWSER_TESTS = [


### PR DESCRIPTION
## Summary

- Add a shared Playwright fixture that records Chromium JS coverage shards during the normal Playwright suite.
- Wire `COVERAGE=1 ./run-tests.sh` to require and merge Playwright suite shards instead of relying on the old 13-fixture sampler path.
- Include manually-created Playwright pages in sync/theme E2E coverage and document the new coverage flow.

## Coverage

Final `PORT=8003 COVERAGE=1 ./run-tests.sh` baseline:

- Playwright functions: `1,635 / 3,819 = 42.81%`
- Playwright bytes: `1,610,496 / 4,183,674 = 38.49%`
- Vitest/Node functions: `1,945 / 6,990 = 27.83%`
- Vitest/Node bytes: `1,187,336 / 4,363,830 = 27.21%`
- Combined functions: `2,918 / 7,351 = 39.70%`
- Combined bytes: `2,382,630 / 4,363,830 = 54.60%`
- Delta vs previous combined function report: `+2.80pt` (`36.90% -> 39.70%`)

## Validation

- `npm run quality`
- `npm run typecheck`
- `PORT=8003 COVERAGE=1 ./run-tests.sh`