### PR TITLE
[codex] Add API Cashu client-list runtime coverage

### DIFF
--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -1,0 +1,308 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { updateKeyCache } from '../js/crypto.js';
+import {
+  callOpenRouterAPI,
+  exchangeOpenRouterCode,
+  fetchOpenRouterModelPricing,
+  fetchOpenRouterModels,
+  fetchPpqModels,
+  fetchRoutstrModels,
+  getOpenRouterBalance,
+  getPpqBalance,
+  getVeniceBalance,
+  isRecommendedModel,
+  needsMaxCompletionTokens,
+  setAIProvider,
+  setCustomApiModel,
+  setCustomApiUrl,
+  setOpenRouterModel,
+  setPpqModel,
+  setRoutstrModel,
+  setVeniceE2EE,
+  setVeniceModel,
+  supportsVision,
+  supportsWebSearch,
+  validateOpenRouterKey,
+  validatePpqKey,
+  validateRoutstrKey,
+} from '../js/api.js';
+
+const realFetch = globalThis.fetch;
+const realLocation = globalThis.location;
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status || 200,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+function clearKeyCaches() {
+  [
+    'labcharts-openrouter-key',
+    'labcharts-venice-key',
+    'labcharts-routstr-key',
+    'labcharts-ppq-key',
+    'labcharts-custom-key',
+  ].forEach(key => updateKeyCache(key, ''));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  clearKeyCaches();
+  globalThis.fetch = vi.fn();
+  globalThis.location = { origin: 'https://getbased.test', pathname: '/app' };
+  window.showInsufficientBalanceDialog = undefined;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  if (realLocation) globalThis.location = realLocation;
+  else delete globalThis.location;
+  clearKeyCaches();
+  vi.restoreAllMocks();
+});
+
+describe('API provider runtime behavior', () => {
+  it('filters OpenRouter models, caches pricing and vision metadata, and fetches fuzzy pricing', async () => {
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        {
+          id: 'openai/gpt-5.5',
+          name: 'GPT 5.5',
+          pricing: { prompt: '0.000004', completion: '0.000012' },
+          architecture: { modality: 'text->text' },
+        },
+        {
+          id: 'anthropic/claude-sonnet-4.6',
+          name: 'Claude Sonnet 4.6',
+          pricing: { prompt: '0.000003', completion: '0.000015' },
+          architecture: { modality: 'image->text' },
+        },
+        {
+          id: 'anthropic/claude-sonnet-4.6:2026-01-01',
+          name: 'Claude Sonnet dated duplicate',
+          pricing: { prompt: '0.000003', completion: '0.000015' },
+        },
+        { id: 'openai/gpt-5.5-codex', name: 'GPT Codex' },
+        { id: 'old/vendor-model', name: 'Old model' },
+      ],
+    }));
+
+    const models = await fetchOpenRouterModels('sk-or');
+
+    expect(fetch).toHaveBeenCalledWith('https://openrouter.ai/api/v1/models', {
+      headers: { Authorization: 'Bearer sk-or' },
+    });
+    expect(models.map(m => m.id)).toEqual([
+      'anthropic/claude-sonnet-4.6',
+      'openai/gpt-5.5',
+    ]);
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-pricing'))).toMatchObject({
+      'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
+      'openai/gpt-5.5': { input: 4, output: 12 },
+    });
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-4.6');
+    expect(localStorage.getItem('labcharts-openrouter-model')).toBe('anthropic/claude-sonnet-4.6');
+
+    expect(await fetchOpenRouterModelPricing('openai/gpt-5.5')).toEqual({ input: 4, output: 12 });
+
+    localStorage.setItem('labcharts-openrouter-pricing', '{}');
+    updateKeyCache('labcharts-openrouter-key', 'sk-or');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'anthropic/claude-sonnet-4.6-20260101', pricing: { prompt: '0.000003', completion: '0.000015' } },
+      ],
+    }));
+
+    await expect(fetchOpenRouterModelPricing('anthropic/claude-sonnet-4.6')).resolves.toEqual({ input: 3, output: 15 });
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-pricing'))).toMatchObject({
+      'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
+      'anthropic/claude-sonnet-4.6-20260101': { input: 3, output: 15 },
+    });
+  });
+
+  it('filters Routstr and PPQ models and preserves provider-specific pricing semantics', async () => {
+    localStorage.setItem('labcharts-routstr-node', 'https://node.example.com/');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'llama-3.1-8b', name: 'Llama', enabled: true, pricing: { prompt: '0.000001', completion: '0.000002' } },
+        { id: 'claude-sonnet-4.6', name: 'Claude', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' }, architecture: { input_modalities: ['text', 'image'] } },
+        { id: 'claude-sonnet-4.6-20260101', name: 'Claude duplicate', enabled: true },
+        { id: 'gpt-5-preview', name: 'Preview', enabled: true },
+        { id: 'grok-4', name: 'Disabled', enabled: false },
+      ],
+    }));
+
+    const routstrModels = await fetchRoutstrModels();
+
+    expect(fetch).toHaveBeenCalledWith('https://node.example.com/v1/models');
+    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'llama-3.1-8b']);
+    expect(localStorage.getItem('labcharts-routstr-model')).toBe('claude-sonnet-4.6');
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-4.6');
+
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'perplexity/sonar', name: 'Sonar', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '8' }, architecture: { modality: 'text->text' } },
+        { id: 'claude-sonnet-4.6', name: 'Claude', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' }, architecture: { modality: 'image->text' } },
+        { id: 'gpt-4-audio-preview', name: 'Audio' },
+      ],
+    }));
+
+    const ppqModels = await fetchPpqModels('sk-ppq');
+
+    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'perplexity/sonar']);
+    expect(localStorage.getItem('labcharts-ppq-model')).toBe('claude-sonnet-4.6');
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-4.6');
+  });
+
+  it('validates provider keys and reads balance endpoints defensively', async () => {
+    fetch
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockRejectedValueOnce(new TypeError('offline'));
+
+    await expect(validateOpenRouterKey('bad')).resolves.toEqual({ valid: false, error: 'Invalid API key' });
+    await expect(validatePpqKey('busy')).resolves.toEqual({ valid: true });
+    await expect(validatePpqKey('offline')).resolves.toEqual({ valid: false, error: 'Cannot reach PPQ API: offline' });
+
+    expect(await validateRoutstrKey('cashu:cashuA-token')).toEqual({ valid: true });
+    expect(await validateRoutstrKey('sk-routstr')).toEqual({ valid: true });
+    expect(await validateRoutstrKey('not-a-key')).toEqual({
+      valid: false,
+      error: 'Key should start with sk-... (session key) or cashu... (eCash token)',
+    });
+
+    updateKeyCache('labcharts-openrouter-key', 'sk-or');
+    updateKeyCache('labcharts-venice-key', 'sk-venice');
+    updateKeyCache('labcharts-ppq-key', 'sk-ppq');
+    localStorage.setItem('labcharts-ppq-credit-id', 'credit-1');
+    fetch
+      .mockResolvedValueOnce(jsonResponse({ data: { total_credits: 20, total_usage: 7 } }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200, headers: { 'x-venice-balance-diem': '12.5' } }))
+      .mockResolvedValueOnce(jsonResponse({ balance: { usd: 4.25 } }));
+
+    await expect(getOpenRouterBalance()).resolves.toEqual({ total: 20, used: 7, remaining: 13 });
+    await expect(getVeniceBalance()).resolves.toEqual({ diem: 12.5, canConsume: true });
+    await expect(getPpqBalance()).resolves.toEqual({ usd: 4.25 });
+  });
+
+  it('exchanges OpenRouter OAuth codes only with a matching tab state', async () => {
+    await expect(exchangeOpenRouterCode('code-without-verifier', 'state')).rejects.toThrow('Missing PKCE verifier');
+
+    sessionStorage.setItem('or_pkce_verifier', 'verifier-a');
+    sessionStorage.setItem('or_oauth_state', 'state-a');
+    await expect(exchangeOpenRouterCode('code-a', 'state-b')).rejects.toThrow('OAuth state mismatch');
+    expect(sessionStorage.getItem('or_pkce_verifier')).toBeNull();
+    expect(sessionStorage.getItem('or_oauth_state')).toBeNull();
+
+    sessionStorage.setItem('or_pkce_verifier', 'verifier-b');
+    sessionStorage.setItem('or_oauth_state', 'state-b');
+    fetch.mockResolvedValueOnce(jsonResponse({ key: 'sk-new' }));
+
+    await expect(exchangeOpenRouterCode('code-b', 'state-b')).resolves.toBe('sk-new');
+    expect(fetch).toHaveBeenLastCalledWith('https://openrouter.ai/api/v1/auth/keys', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'https://getbased.test',
+        'X-Title': 'getbased',
+      }),
+    }));
+    expect(JSON.parse(fetch.mock.calls.at(-1)[1].body)).toEqual({
+      code: 'code-b',
+      code_verifier: 'verifier-b',
+      code_challenge_method: 'S256',
+    });
+    expect(sessionStorage.getItem('or_pkce_verifier')).toBeNull();
+    expect(sessionStorage.getItem('or_oauth_state')).toBeNull();
+  });
+
+  it('builds OpenAI-compatible chat bodies and surfaces provider balance failures', async () => {
+    updateKeyCache('labcharts-openrouter-key', 'sk-or');
+    setOpenRouterModel('openai/gpt-5.5');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      choices: [{ message: { content: 'answer' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 11, completion_tokens: 13 },
+    }));
+
+    await expect(callOpenRouterAPI({
+      system: 'system',
+      messages: [{ role: 'user', content: 'hello' }],
+      maxTokens: 42,
+      webSearch: true,
+      requestTimeoutMs: 50,
+    })).resolves.toEqual({
+      text: 'answer',
+      usage: { inputTokens: 11, outputTokens: 13 },
+      finishReason: 'stop',
+      truncated: false,
+    });
+
+    const requestBody = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(requestBody).toMatchObject({
+      model: 'openai/gpt-5.5',
+      max_completion_tokens: 42,
+      plugins: [{ id: 'web' }],
+      messages: [
+        { role: 'system', content: 'system' },
+        { role: 'user', content: 'hello' },
+      ],
+    });
+    expect(requestBody).not.toHaveProperty('max_tokens');
+
+    window.showInsufficientBalanceDialog = vi.fn();
+    fetch.mockResolvedValueOnce(new Response('{}', { status: 402 }));
+    await expect(callOpenRouterAPI({
+      messages: [{ role: 'user', content: 'hello again' }],
+      requestTimeoutMs: 50,
+    })).rejects.toMatchObject({ _modalShown: true });
+    expect(window.showInsufficientBalanceDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports model capabilities across providers', () => {
+    expect(needsMaxCompletionTokens('openai/gpt-5.4')).toBe(true);
+    expect(needsMaxCompletionTokens('o3-mini')).toBe(true);
+    expect(needsMaxCompletionTokens('anthropic/claude-sonnet-4.6')).toBe(false);
+
+    expect(isRecommendedModel('openrouter', 'anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(isRecommendedModel('venice', 'e2ee-qwen3-5-122b')).toBe(true);
+    expect(isRecommendedModel('routstr', 'claude-sonnet-4.6')).toBe(true);
+    expect(isRecommendedModel('ppq', 'gemini-3-flash-preview')).toBe(true);
+
+    setAIProvider('openrouter');
+    setOpenRouterModel('anthropic/claude-sonnet-4.6:2026-01-01');
+    localStorage.setItem('labcharts-openrouter-vision-models', JSON.stringify(['anthropic/claude-sonnet-4.6']));
+    expect(supportsWebSearch()).toBe(true);
+    expect(supportsVision()).toBe(true);
+
+    setAIProvider('venice');
+    setVeniceModel('e2ee-qwen3-5-122b');
+    setVeniceE2EE(true);
+    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify([{ id: 'e2ee-qwen3-5-122b' }]));
+    expect(supportsWebSearch()).toBe(false);
+    expect(supportsVision()).toBe(false);
+
+    setAIProvider('routstr');
+    setRoutstrModel('grok-4-20260101');
+    localStorage.setItem('labcharts-routstr-vision-models', JSON.stringify(['grok-4']));
+    expect(supportsWebSearch()).toBe(false);
+    expect(supportsVision()).toBe(true);
+
+    setAIProvider('ppq');
+    setPpqModel('perplexity/sonar');
+    localStorage.setItem('labcharts-ppq-vision-models', 'not-json');
+    expect(supportsWebSearch()).toBe(true);
+    expect(supportsVision()).toBe(false);
+
+    setAIProvider('custom');
+    setCustomApiUrl('http://localhost:11434/v1');
+    setCustomApiModel('local-vision');
+    expect(supportsWebSearch()).toBe(false);
+    expect(supportsVision()).toBe(true);
+  });
+});

--- a/tests/cashu-wallet-runtime.test.js
+++ b/tests/cashu-wallet-runtime.test.js
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+
+let importId = 0;
+const realFetch = globalThis.fetch;
+
+function proof(secret, amount) {
+  return { secret, amount, C: `C-${secret}` };
+}
+
+function installCashuStub() {
+  const state = {
+    receiveProofs: [proof('rx-1', 10)],
+    meltQuotes: new Map(),
+    failMelt: false,
+    instances: [],
+  };
+
+  class Wallet {
+    constructor(url, opts = {}) {
+      this.url = url;
+      this.opts = opts;
+      state.instances.push(this);
+    }
+
+    async loadMint() {}
+
+    async groupProofsByState(proofs) {
+      return {
+        unspent: proofs.filter(p => !p.spent && !p.pending),
+        spent: proofs.filter(p => p.spent),
+        pending: proofs.filter(p => p.pending),
+      };
+    }
+
+    async receive() {
+      return state.receiveProofs.map(p => ({ ...p }));
+    }
+
+    async send(amount, proofs) {
+      const total = sumProofs(proofs);
+      return {
+        send: [proof(`send-${amount}-${state.instances.length}`, amount)],
+        keep: total > amount ? [proof(`keep-${total - amount}-${state.instances.length}`, total - amount)] : [],
+      };
+    }
+
+    async createMintQuoteBolt11(amount) {
+      return { quote: `mint-${amount}`, request: `invoice-${amount}`, amount, state: 'UNPAID' };
+    }
+
+    async checkMintQuoteBolt11(quoteId) {
+      return { state: 'PAID', amount: Number(String(quoteId).replace(/\D/g, '')) || 0 };
+    }
+
+    async mintProofsBolt11(amount, quoteId) {
+      return [proof(`minted-${quoteId}`, amount)];
+    }
+
+    async createMeltQuoteBolt11(invoice) {
+      const amount = Number(String(invoice).split(':').pop()) || 10;
+      const quote = { quote: `quote-${amount}`, amount, fee_reserve: 5, state: 'UNPAID' };
+      state.meltQuotes.set(quote.quote, quote);
+      return quote;
+    }
+
+    async checkMeltQuoteBolt11(quoteId) {
+      return state.meltQuotes.get(quoteId) || { quote: quoteId, amount: 10, fee_reserve: 2 };
+    }
+
+    async meltProofsBolt11() {
+      if (state.failMelt) throw new Error('melt failed');
+      return { change: [proof(`melt-change-${state.instances.length}`, 1)] };
+    }
+
+    async batchRestore(batchSize, gap, start) {
+      if (start > 0) return { proofs: [] };
+      return { proofs: [proof('restored-1', 7), { ...proof('restored-spent', 3), spent: true }] };
+    }
+  }
+
+  function sumProofs(proofs = []) {
+    return proofs.reduce((sum, p) => sum + (Number(p.amount) || 0), 0);
+  }
+
+  globalThis.cashuts = {
+    Wallet,
+    MintQuoteState: { PAID: 'PAID' },
+    sumProofs,
+    getEncodedToken: ({ mint, proofs }) => `cashu:${mint}:${sumProofs(proofs)}:${proofs.map(p => p.secret).join(',')}`,
+  };
+  window.cashuts = globalThis.cashuts;
+  return state;
+}
+
+async function loadWallet() {
+  return import(/* @vite-ignore */ `../js/cashu-wallet.js?runtime=${importId++}`);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  globalThis.fetch = realFetch;
+  globalThis.indexedDB = new IDBFactory();
+  globalThis.bip39 = {
+    generateMnemonic: vi.fn(async () => 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
+    validateMnemonic: vi.fn(async mnemonic => mnemonic.split(/\s+/).length === 12),
+    mnemonicToSeed: vi.fn(async () => new Uint8Array(64).buffer),
+  };
+  window.bip39 = globalThis.bip39;
+  installCashuStub();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('Cashu wallet runtime behavior', () => {
+  it('stores mint and seed metadata while rejecting unsafe mint URLs', async () => {
+    const wallet = await loadWallet();
+
+    await expect(wallet.getMintUrl()).resolves.toBe('https://mint.minibits.cash/Bitcoin');
+    await expect(wallet.setMintUrl('http://127.0.0.1:3338')).rejects.toThrow('public https');
+
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+    await expect(wallet.getMintUrl()).resolves.toBe('https://mint.getbased.test/Bitcoin');
+    expect(localStorage.getItem('labcharts-cashu-wallet-mint')).toBe('https://mint.getbased.test/Bitcoin');
+
+    await expect(wallet.hasWalletSeed()).resolves.toBe(false);
+    await expect(wallet.generateWalletSeed()).resolves.toEqual({
+      mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    });
+    await expect(wallet.hasWalletSeed()).resolves.toBe(true);
+    await expect(wallet.getWalletMnemonic()).resolves.toBe('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
+  });
+
+  it('receives, exports, sends, and restores proofs through the wallet store', async () => {
+    const wallet = await loadWallet();
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+
+    await expect(wallet.receiveToken('cashu-token')).resolves.toEqual({ received: 10, fee: 0, balance: 10 });
+    await expect(wallet.getWalletBalance()).resolves.toBe(10);
+    await expect(wallet.exportWallet()).resolves.toContain('cashu:https://mint.getbased.test/Bitcoin:10:rx-1');
+
+    await expect(wallet.sendAsToken(4)).resolves.toMatchObject({ amount: 4, remaining: 6 });
+    await expect(wallet.sendAsToken(99)).rejects.toThrow('Insufficient balance: 6 sats, need 99');
+
+    await expect(wallet.restoreWalletFromSeed('too short')).rejects.toThrow('Invalid mnemonic');
+    await expect(wallet.restoreWalletFromSeed('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about')).resolves.toEqual({
+      balance: 7,
+      restoredCount: 7,
+    });
+  });
+
+  it('keeps failed node deposits recoverable and clears pending tokens after success', async () => {
+    const wallet = await loadWallet();
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+    await wallet.receiveToken('cashu-token');
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(jsonResponse({
+      detail: [{ msg: 'token rejected' }, { msg: 'mint unavailable' }],
+    }, { status: 400 }));
+
+    await expect(wallet.depositToNode('https://node.getbased.test/', 5, 'sk-existing')).rejects.toThrow('token rejected; mint unavailable');
+    await expect(wallet.recoverPendingDeposit()).resolves.toContain('cashu:https://mint.getbased.test/Bitcoin:5:send-5');
+
+    await wallet.clearPendingDeposit();
+    await expect(wallet.recoverPendingDeposit()).resolves.toBeNull();
+
+    const stub = installCashuStub();
+    stub.receiveProofs = [proof('rx-2', 9)];
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+    await expect(wallet.receiveToken('another-token')).resolves.toEqual({ received: 9, fee: 0, balance: 14 });
+    fetch.mockResolvedValueOnce(jsonResponse({ api_key: 'sk-new', balance: 4000 }));
+
+    await expect(wallet.depositToNode('https://node.getbased.test///', 4)).resolves.toEqual({ api_key: 'sk-new', balance: 4000 });
+    expect(fetch.mock.calls.at(-1)[0]).toMatch(/^https:\/\/node\.getbased\.test\/v1\/balance\/create\?initial_balance_token=/);
+    await expect(wallet.recoverPendingDeposit()).resolves.toBeNull();
+    await expect(wallet.getWalletBalance()).resolves.toBe(10);
+  });
+
+  it('auto-reduces lightning-address withdrawals and exposes failed melt recovery', async () => {
+    const wallet = await loadWallet();
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+    const stub = installCashuStub();
+    stub.receiveProofs = [proof('rx-100', 100)];
+    await wallet.receiveToken('cashu-token');
+
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).includes('/.well-known/lnurlp/alice')) {
+        return jsonResponse({ callback: 'https://lnurl.getbased.test/cb', minSendable: 1000, maxSendable: 200000 });
+      }
+      if (String(url).startsWith('https://lnurl.getbased.test/cb')) {
+        const amountMsats = Number(new URL(String(url)).searchParams.get('amount'));
+        return jsonResponse({ pr: `invoice:${amountMsats / 1000}` });
+      }
+      return new Response('', { status: 404 });
+    });
+
+    await expect(wallet.getMaxWithdrawable()).resolves.toBe(96);
+    await expect(wallet.withdrawToAddress('alice@getbased.test', 98)).resolves.toMatchObject({
+      paid: true,
+      amount: 93,
+      balance: 3,
+    });
+
+    await wallet.receiveToken('cashu-token');
+    stub.failMelt = true;
+    const quote = await wallet.createWithdrawQuote('invoice:10');
+
+    await expect(wallet.executeWithdraw(quote.quote)).rejects.toThrow('melt failed');
+    await expect(wallet.recoverPendingWithdraw()).resolves.toContain('cashu:https://mint.getbased.test/Bitcoin:15:send-15');
+    await wallet.clearPendingWithdraw();
+    await expect(wallet.recoverPendingWithdraw()).resolves.toBeNull();
+  });
+
+  it('handles empty fee pools without mutating the wallet', async () => {
+    const wallet = await loadWallet();
+
+    expect(wallet.getFeePct()).toBe(0);
+    await expect(wallet.getFeeBalance()).resolves.toBe(0);
+    await expect(wallet.retryFeeAutoMelt()).resolves.toEqual({ melted: 0, remaining: 0 });
+    await expect(wallet.redeemFees('invoice:1')).rejects.toThrow('No fee proofs to redeem');
+  });
+});
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status || 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/tests/client-list-runtime.test.js
+++ b/tests/client-list-runtime.test.js
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { state } from '../js/state.js';
+
+let importId = 0;
+
+function profile(overrides) {
+  const now = Date.now();
+  return {
+    id: 'profile-' + Math.random().toString(36).slice(2),
+    name: 'Client',
+    sex: null,
+    dob: null,
+    location: { country: '', zip: '' },
+    tags: [],
+    notes: '',
+    status: 'active',
+    avatar: null,
+    height: null,
+    heightUnit: 'cm',
+    createdAt: now,
+    lastUpdated: now,
+    pinned: false,
+    ...overrides,
+  };
+}
+
+async function loadClientList() {
+  return import(/* @vite-ignore */ `../js/client-list.js?runtime=${importId++}`);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  document.body.innerHTML = `
+    <div id="modal-overlay" class="show"></div>
+    <div id="client-list-overlay"><div id="client-list-modal"></div></div>
+    <div id="wearable-strip"></div>
+  `;
+  window.requestAnimationFrame = (fn) => fn();
+  globalThis.requestAnimationFrame = window.requestAnimationFrame;
+  window.renderProfileButton = vi.fn();
+  window.showNotification = vi.fn();
+  window.hasAIProvider = vi.fn(() => false);
+  window.exportAllDataJSON = vi.fn();
+  window.exportClientJSON = vi.fn();
+  window.importDataJSON = vi.fn();
+  window.loadDemoData = vi.fn();
+  window.navigate = vi.fn();
+  window.showConfirmDialog = vi.fn(async () => false);
+  state.currentProfile = 'alice';
+  state.importedData = { wearableSummary: { metrics: { weight: { latest: 70 } } }, genetics: { mtdna: {} } };
+  state.profiles = [
+    profile({ id: 'alice', name: 'Alice', notes: 'sleep focus', tags: ['vip'], height: 170, heightUnit: 'cm', lastUpdated: Date.now() - 60_000 }),
+    profile({ id: 'bob', name: 'Bob', notes: 'metabolic panel', tags: ['metabolic'], status: 'flagged', lastUpdated: Date.now() - 120_000 }),
+    profile({ id: 'cara', name: 'Cara', status: 'archived', tags: ['archive'], lastUpdated: Date.now() - 180_000 }),
+  ];
+});
+
+describe('client list runtime behavior', () => {
+  it('drives list filters, row menus, and edit form through delegated handlers', async () => {
+    const clientList = await loadClientList();
+    const renderProfileButtonSpy = vi.fn();
+    const showNotificationSpy = vi.fn();
+    window.renderProfileButton = renderProfileButtonSpy;
+    window.showNotification = showNotificationSpy;
+    const topLevelNames = () => [...document.querySelectorAll('.cl-list > .cl-row .cl-row-name')].map(el => el.textContent);
+
+    clientList.openClientList();
+    expect(document.getElementById('client-list-overlay').classList.contains('show')).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(topLevelNames()).toEqual(['Alice', 'Bob']);
+    expect(document.querySelector('.cl-archived-section')).not.toBeNull();
+
+    const search = document.getElementById('cl-search');
+    search.value = 'metabolic';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(topLevelNames()).toEqual(['Bob']);
+
+    const clearedSearch = document.getElementById('cl-search');
+    clearedSearch.value = '';
+    clearedSearch.dispatchEvent(new Event('input', { bubbles: true }));
+    document.querySelector('[data-cl-action="tag-filter"][data-cl-tag="vip"]').click();
+    expect(topLevelNames()).toEqual(['Alice']);
+
+    document.querySelector('[data-cl-action="tag-filter"][data-cl-tag="vip"]').click();
+    const flaggedStatusFilter = document.querySelector('.cl-status-filter');
+    flaggedStatusFilter.value = 'flagged';
+    flaggedStatusFilter.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(topLevelNames()).toEqual(['Bob']);
+
+    const allStatusFilter = document.querySelector('.cl-status-filter');
+    allStatusFilter.value = 'all';
+    allStatusFilter.dispatchEvent(new Event('change', { bubbles: true }));
+    const sort = document.querySelector('.cl-sort');
+    sort.value = 'az';
+    sort.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(topLevelNames().slice(0, 3)).toEqual(['Alice', 'Bob', 'Cara']);
+
+    document.querySelector('[data-cl-action="toggle-menu"][data-cl-profile-id="alice"]').click();
+    expect(document.getElementById('cl-active-menu').classList.contains('show')).toBe(true);
+    document.querySelector('#cl-active-menu [data-cl-action="pin-profile"]').click();
+    expect(state.profiles.find(p => p.id === 'alice').pinned).toBe(true);
+    expect(document.querySelector('[data-id="alice"] .cl-badge-pinned')).not.toBeNull();
+
+    document.querySelector('[data-cl-action="edit-profile"][data-cl-profile-id="alice"]').click();
+    expect(document.querySelector('.cl-form')).not.toBeNull();
+
+    document.getElementById('cl-name').value = 'Alice Smith';
+    document.querySelector('[data-cl-action="set-sex"][data-cl-sex="female"]').click();
+    expect(document.querySelector('[data-sex="female"]').classList.contains('active')).toBe(true);
+
+    const tagInput = document.getElementById('cl-tag-input');
+    tagInput.value = 'longevity';
+    tagInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    expect([...document.querySelectorAll('.cl-tag-pill')].map(el => el.firstChild.textContent.trim())).toContain('longevity');
+
+    document.getElementById('cl-height').value = '170';
+    document.getElementById('cl-height-unit-toggle').click();
+    expect(document.getElementById('cl-height-unit').value).toBe('in');
+    expect(document.getElementById('cl-height').step).toBe('0.1');
+    expect(document.getElementById('cl-bmi-display').textContent).toMatch(/24\.[0-9]/);
+
+    document.querySelector('.cl-form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    const alice = state.profiles.find(p => p.id === 'alice');
+    expect(alice).toMatchObject({
+      name: 'Alice Smith',
+      sex: 'female',
+      tags: ['vip', 'longevity'],
+      status: 'active',
+      pinned: true,
+    });
+    expect(alice.height).toBeCloseTo(169.9, 1);
+    expect(alice.heightUnit).toBe('in');
+    expect(renderProfileButtonSpy).toHaveBeenCalled();
+    expect(showNotificationSpy).toHaveBeenCalledWith('"Alice Smith" updated', 'info');
+
+    clientList.closeClientList();
+    expect(document.getElementById('client-list-overlay').classList.contains('show')).toBe(false);
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/tests/playwright/tour-dom.spec.js
+++ b/tests/playwright/tour-dom.spec.js
@@ -9,6 +9,26 @@ test('guided tour DOM creates, navigates, layers, and restores the empty tour ov
       && typeof window.endTour === 'function'
       && typeof window._tourGoToStep === 'function'
   );
+  await page.waitForFunction(() => {
+    const isVisible = selector => Array.from(document.querySelectorAll(selector)).some(el => {
+      const rect = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      return rect.width > 0
+        && rect.height > 0
+        && rect.right > 0
+        && rect.left < window.innerWidth
+        && style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && style.opacity !== '0';
+    });
+
+    return [
+      '.welcome-primary-panel',
+      '.demo-cards',
+      '.profile-compact-btn',
+      '.settings-btn',
+    ].every(isVisible);
+  });
 
   const results = await page.evaluate(async () => {
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary
- Add focused Vitest runtime coverage for API provider model filtering, balances, OAuth exchange, chat request bodies, and capability helpers.
- Add Cashu wallet runtime coverage with a small cashu-ts stub for mint/seed metadata, proof receive/export/send/restore, node deposit recovery, Lightning withdraw recovery, and fee empty-state rails.
- Add jsdom client-list runtime coverage for delegated filters, row menus, pinning, edit form save, tags, sex toggle, BMI/height conversion, and close behavior.

## Coverage
- Combined function coverage: 42.05% (was 39.70%, +2.35pt).
- `js/api.js`: 86/121 functions, 71.07% function coverage.
- `js/cashu-wallet.js`: 80/135 functions, 59.26% function coverage.
- `js/client-list.js`: 59/93 functions, 63.44% function coverage.

## Validation
- `npm run quality`
- `npm run typecheck`
- `npm test`
- `COVERAGE=1 ./run-tests.sh`