### PR TITLE
[codex] Add PDF import Playwright coverage

### DIFF
--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -187,6 +187,10 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
       review.applyManualImportDate('2026-06-01');
       outcomes.manualDateUpdatesPendingAndButton = review.getPendingImport()?.date === '2026-06-01'
         && confirmBtn?.disabled === false;
+      review.applyManualImportDate('');
+      outcomes.emptyManualDateDisablesImport = review.getPendingImport()?.date === ''
+        && confirmBtn?.disabled === true;
+      review.applyManualImportDate('2026-06-01');
 
       review.setImportReviewFilter(document.querySelector('.import-filter-btn[data-filter="unmatched"]'));
       outcomes.unmatchedFilterCountsRows = document.getElementById('import-visible-count')?.textContent === '11/13 shown';
@@ -216,14 +220,29 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
       review.toggleImportRow(excludeBtn);
       outcomes.excludeUpdatesRowAndCount = excludeBtn.textContent === 'Include'
         && excludeBtn.closest('tr')?.classList.contains('import-excluded') === true
-        && confirmBtn?.textContent === 'Import 2 Markers';
+        && confirmBtn?.textContent === 'Import 2 Markers'
+        && review.getExcludedImportIndices().has(0) === true;
 
       review.setImportReviewFilter(document.querySelector('.import-filter-btn[data-filter="excluded"]'));
       outcomes.excludedFilterCountsRows = document.getElementById('import-visible-count')?.textContent === '1/13 shown';
 
+      review.setImportReviewFilter(document.querySelector('.import-filter-btn[data-filter="all"]'));
+      const selectRow = document.querySelector('tr[data-import-status="unmatched"]');
+      const select = document.createElement('select');
+      select.dataset.markerIdx = selectRow.dataset.importIdx;
+      select.innerHTML = '<option value="iron.ferritin">Ferritin</option>';
+      select.value = 'iron.ferritin';
+      selectRow.querySelector('.import-map-cell').append(select);
+      review.mapUnmatchedMarker(select);
+      outcomes.mapUnmatchedBySelect = selectRow.dataset.importStatus === 'matched'
+        && review.getPendingImport().markers[Number(select.dataset.markerIdx)].mappedKey === 'iron.ferritin'
+        && confirmBtn?.textContent === 'Import 3 Markers';
+
       review.closeImportModal();
       outcomes.closeClearsPending = overlay?.classList.contains('show') === false
         && review.getPendingImport() === null;
+
+      outcomes.resolveWithoutBatchReturnsFalse = review.resolveImportPreviewBatch('import') === false;
 
       const batchPromise = review.showImportPreviewAsync({
         date: '2026-06-02',
@@ -235,6 +254,18 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
       review.closeImportModal();
       outcomes.asyncCloseResolvesSkip = await batchPromise === 'skip'
         && dropZone?.style.display === '';
+
+      const importBatchPromise = review.showImportPreviewAsync({
+        date: '2026-06-03',
+        fileName: 'batch-import-review.pdf',
+        markers: [baseMarkers[0]],
+      }, 3, 5);
+      const resolvedImport = review.resolveImportPreviewBatch('import');
+      outcomes.asyncResolveImportClearsModal = resolvedImport === true
+        && await importBatchPromise === 'import'
+        && overlay?.classList.contains('show') === false
+        && review.getPendingImport() === null
+        && dropZone?.style.display === '';
     } finally {
       state.currentProfile = originalProfile;
       window._pendingImport = null;
@@ -243,6 +274,82 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
       window._batchImportContext = null;
       document.getElementById('import-modal-overlay')?.classList.remove('show');
       if (dropZone) dropZone.style.display = originalDropDisplay;
+    }
+
+    return outcomes;
+  }, {
+    reviewUrl: moduleUrl('/js/pdf-import-review.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('PDF import review modal covers privacy cost and debug details', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#import-modal-overlay', { state: 'attached' });
+
+  const results = await page.evaluate(async ({ reviewUrl }) => {
+    const review = await import(reviewUrl);
+    const outcomes = {};
+    const savedStorage = {};
+    const storageKeys = [
+      'labcharts-debug',
+      'labcharts-ai-provider',
+      'labcharts-ollama-model',
+      'labcharts-ollama-pii-model',
+    ];
+
+    try {
+      for (const key of storageKeys) savedStorage[key] = localStorage.getItem(key);
+      localStorage.setItem('labcharts-debug', 'true');
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      localStorage.setItem('labcharts-ollama-model', 'llama-debug');
+      localStorage.setItem('labcharts-ollama-pii-model', 'pii-debug');
+
+      review.showImportPreview({
+        date: '2026-06-04',
+        fileName: 'debug-review.pdf',
+        markers: [{
+          rawName: 'Glucose',
+          value: 5.4,
+          unit: 'mmol/l',
+          matched: true,
+          mappedKey: 'biochemistry.glucose',
+          refMin: 3.0,
+          refMax: 6.0,
+        }],
+        privacyMethod: 'ollama+review',
+        costInfo: {
+          provider: 'ollama',
+          modelId: 'llama-debug',
+          inputTokens: 1000,
+          outputTokens: 500,
+          cost: 0,
+        },
+        timings: { pii: 2, analysis: 3 },
+        privacyOriginal: 'Patient: Jane Example',
+        privacyObfuscated: 'Patient: [NAME]',
+      });
+
+      const modal = document.getElementById('import-modal');
+      outcomes.ollamaPrivacyNoticeRendersReviewedState = modal?.textContent.includes('Personal information scrubbed by local AI (reviewed)') === true;
+      outcomes.costInfoRendersModelTokensAndCost = modal?.textContent.includes('llama-debug') === true
+        && modal?.textContent.includes('1,500 tokens') === true
+        && modal?.textContent.includes('Free') === true;
+      outcomes.debugDetailsRenderTimingAndPrivacyButton = modal?.textContent.includes('PII: 2s (pii-debug)') === true
+        && modal?.textContent.includes('Analysis: 3s (llama-debug)') === true
+        && modal?.querySelector('.import-privacy-details-btn') !== null;
+      outcomes.rangeAdoptionOptionRendersWhenLabRangesDiffer = modal?.querySelector('#import-adopt-ranges') !== null;
+    } finally {
+      for (const key of storageKeys) {
+        if (savedStorage[key] == null) localStorage.removeItem(key);
+        else localStorage.setItem(key, savedStorage[key]);
+      }
+      window._pendingImport = null;
+      window._pendingImportRefLookup = null;
+      document.getElementById('import-modal-overlay')?.classList.remove('show');
     }
 
     return outcomes;

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -101,6 +101,82 @@ test('PDF import progress and AI-needed dialog cover browser UI states', async (
   }
 });
 
+test('PDF import helpers cover JSON repair, text quality, and file classification', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#drop-zone', { state: 'attached' });
+
+  const results = await page.evaluate(async ({ pdfImportUrl }) => {
+    const pdfImport = await import(pdfImportUrl);
+    const outcomes = {};
+    const originals = {
+      isDNAFile: window.isDNAFile,
+      isDNAFileByContent: window.isDNAFileByContent,
+    };
+
+    try {
+      const trailingJson = pdfImport.tryParseJSON('{"date":"2026-06-01"} extra model prose');
+      const repairedJson = pdfImport.tryParseJSON('{"date":"2026-06-02","markers":[{"rawName":"Glucose","value":5.2}');
+      const repairedString = pdfImport.tryParseJSON('{"date":"2026-06-');
+      let invalidJsonThrows = false;
+      try {
+        pdfImport.tryParseJSON('not json');
+      } catch (err) {
+        invalidJsonThrows = String(err?.message || err).includes('invalid JSON');
+      }
+
+      outcomes.jsonParserTrimsTrailingText = trailingJson.date === '2026-06-01';
+      outcomes.jsonParserRepairsTruncatedObjects = repairedJson.date === '2026-06-02'
+        && repairedJson.markers?.[0]?.rawName === 'Glucose';
+      outcomes.jsonParserRepairsOpenStrings = repairedString.date === '2026-06-';
+      outcomes.jsonParserRejectsUnrepairableInput = invalidJsonThrows;
+
+      const goodText = Array.from({ length: 31 }, () => 'glucose').join(' ');
+      const garbledText = Array.from({ length: 31 }, () => '1234567890').join(' ');
+      outcomes.textQualityClassifiesEmptyPoorAndGood = pdfImport.assessTextQuality('') === 'empty'
+        && pdfImport.assessTextQuality('glucose ferritin') === 'poor'
+        && pdfImport.assessTextQuality(garbledText) === 'poor'
+        && pdfImport.assessTextQuality(goodText) === 'good';
+
+      window.isDNAFile = file => file.name.endsWith('.dna');
+      window.isDNAFileByContent = async file => (await file.text()).includes('DNA RAW');
+
+      const magicPdf = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d])], 'extensionless', {
+        type: 'application/octet-stream',
+      });
+      const classified = await pdfImport.classifyImportFiles([
+        new File(['{"ok":true}'], 'profile.json', { type: 'application/json' }),
+        new File(['pdf by name'], 'report.pdf', { type: '' }),
+        new File(['pdf by type'], 'report.bin', { type: 'application/pdf' }),
+        magicPdf,
+        new File(['image'], 'photo.webp', { type: '' }),
+        new File(['dna hook'], 'genome.dna', { type: 'text/plain' }),
+        new File(['DNA RAW content'], 'ancestry.csv', { type: 'text/csv' }),
+        new File(['plain notes'], 'notes.txt', { type: 'text/plain' }),
+        new File(['unsupported'], 'archive.bin', { type: 'application/octet-stream' }),
+      ]);
+      outcomes.classifierBucketsKnownFileTypes = classified.jsonFiles.length === 1
+        && classified.pdfFiles.length === 3
+        && classified.imageFiles.length === 1
+        && classified.dnaFiles.length === 2
+        && classified.textFiles.length === 1
+        && classified.unsupportedCount === 1;
+      outcomes.pdfMagicSniffChecksHeader = await pdfImport.isPdfByMagic(magicPdf) === true
+        && await pdfImport.isPdfByMagic(new File(['NOPE'], 'not-pdf.bin')) === false;
+    } finally {
+      window.isDNAFile = originals.isDNAFile;
+      window.isDNAFileByContent = originals.isDNAFileByContent;
+    }
+
+    return outcomes;
+  }, {
+    pdfImportUrl: moduleUrl('/js/pdf-import.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
 test('PDF import preflight covers model mismatch and unsupported lab dialogs', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#import-status-fab', { state: 'attached' });
@@ -212,6 +288,148 @@ test('PDF import preflight covers model mismatch and unsupported lab dialogs', a
     return outcomes;
   }, {
     preflightUrl: moduleUrl('/js/pdf-import-preflight.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('PDF import preflight covers duplicate prompts, cancellation, and supported classifications', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#import-status-fab', { state: 'attached' });
+
+  const results = await page.evaluate(async ({ preflightUrl, utilsUrl }) => {
+    const [preflight, utils] = await Promise.all([
+      import(preflightUrl),
+      import(utilsUrl),
+    ]);
+    const state = window._labState;
+    const outcomes = {};
+    const originals = {
+      importedData: JSON.parse(JSON.stringify(state.importedData || {})),
+      fetch: window.fetch,
+    };
+    const savedStorage = {};
+    const storageKeys = [
+      'labcharts-ai-provider',
+      'labcharts-ai-paused',
+      'labcharts-ollama-model',
+      'labcharts-openrouter-model',
+      'labcharts-venice-model',
+      'labcharts-routstr-model',
+      'labcharts-ppq-model',
+      'labcharts-custom-model',
+    ];
+    const waitForButton = async id => {
+      for (let i = 0; i < 80; i += 1) {
+        const button = document.getElementById(id);
+        const overlay = document.getElementById('confirm-dialog-overlay');
+        if (button && overlay?.classList.contains('show')) return button;
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+      throw new Error(`${id} not found`);
+    };
+
+    try {
+      for (const key of storageKeys) savedStorage[key] = localStorage.getItem(key);
+      state.importedData = { ...state.importedData, entries: [] };
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      localStorage.setItem('labcharts-ai-paused', 'false');
+      localStorage.setItem('labcharts-ollama-model', 'llama-current');
+
+      outcomes.modelNormalizationMatchesAcrossProviders = preflight.normalizeImportModelId('anthropic/claude-sonnet-4.6-20260201') === 'claude-sonnet-4-6'
+        && preflight.normalizeImportModelId('claude.sonnet.4.6') === 'claude-sonnet-4-6';
+
+      const duplicateText = 'OmegaQuant Complete fatty acid report with EPA DHA';
+      state.importedData.entries = [{
+        date: '2026-06-01',
+        importHash: utils.hashString(duplicateText),
+      }];
+      const duplicateCancelPromise = preflight.runPreflightChecks(duplicateText, 'omegaquant.pdf');
+      const duplicateCancel = await waitForButton('confirm-cancel');
+      outcomes.duplicateDialogShowsImportedDate = document.getElementById('confirm-dialog-overlay')?.textContent.includes('Jun 1, 2026') === true;
+      duplicateCancel.click();
+      outcomes.duplicateCancelStopsImport = await duplicateCancelPromise === false;
+
+      const duplicateProceedPromise = preflight.runPreflightChecks(duplicateText, 'omegaquant.pdf');
+      const duplicateProceed = await waitForButton('confirm-ok');
+      duplicateProceed.click();
+      outcomes.duplicateProceedContinuesImport = await duplicateProceedPromise === true;
+
+      state.importedData.entries = [{
+        date: '2026-05-20',
+        importedWith: { provider: 'ollama', modelId: 'llama-previous' },
+      }];
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      localStorage.setItem('labcharts-ollama-model', 'llama-current');
+      const mismatchCancelPromise = preflight.runPreflightChecks(duplicateText, 'omegaquant.pdf');
+      const mismatchCancel = await waitForButton('confirm-cancel');
+      mismatchCancel.click();
+      outcomes.modelMismatchCancelStopsImport = await mismatchCancelPromise === false
+        && localStorage.getItem('labcharts-ollama-model') === 'llama-current';
+
+      state.importedData.entries = [{
+        date: '2026-05-21',
+        importedWith: { provider: 'openrouter', modelId: 'anthropic/claude-sonnet-4.6' },
+      }];
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      localStorage.setItem('labcharts-ollama-model', 'llama-current');
+      localStorage.setItem('labcharts-openrouter-model', 'anthropic/claude-opus-4.7');
+      const switchProviderPromise = preflight.runPreflightChecks(duplicateText, 'omegaquant.pdf');
+      const switchProvider = await waitForButton('confirm-switch');
+      switchProvider.click();
+      outcomes.modelMismatchSwitchCanRestorePreviousProvider = await switchProviderPromise === true
+        && localStorage.getItem('labcharts-ai-provider') === 'openrouter'
+        && localStorage.getItem('labcharts-openrouter-model') === 'anthropic/claude-sonnet-4.6';
+
+      state.importedData.entries = [];
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      localStorage.setItem('labcharts-ollama-model', 'llama-current');
+      const classificationResponses = [
+        '{"testType":"blood"}',
+        '{"testType":"OAT"}',
+        'not JSON',
+      ];
+      let fetchCalls = 0;
+      window.fetch = async () => {
+        fetchCalls += 1;
+        const content = classificationResponses.shift();
+        return new Response(JSON.stringify({
+          choices: [{
+            message: { content },
+            finish_reason: 'stop',
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 4 },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      };
+
+      outcomes.bloodClassificationSkipsUnsupportedDialog = await preflight.runPreflightChecks('plain mystery report text', 'mystery.pdf') === true
+        && fetchCalls === 1
+        && document.getElementById('confirm-dialog-overlay')?.classList.contains('show') === false;
+      outcomes.adapterClassificationSkipsUnsupportedDialog = await preflight.runPreflightChecks('specialty urine metabolite report text', 'specialty.pdf') === true
+        && fetchCalls === 2
+        && document.getElementById('confirm-dialog-overlay')?.classList.contains('show') === false;
+      outcomes.invalidClassificationResponseFailsOpen = await preflight.runPreflightChecks('unclassified report text', 'unclassified.pdf') === true
+        && fetchCalls === 3
+        && document.getElementById('confirm-dialog-overlay')?.classList.contains('show') === false;
+    } finally {
+      state.importedData = originals.importedData;
+      window.fetch = originals.fetch;
+      for (const key of storageKeys) {
+        if (savedStorage[key] == null) localStorage.removeItem(key);
+        else localStorage.setItem(key, savedStorage[key]);
+      }
+      document.getElementById('confirm-dialog-overlay')?.classList.remove('show');
+    }
+
+    return outcomes;
+  }, {
+    preflightUrl: moduleUrl('/js/pdf-import-preflight.js'),
+    utilsUrl: moduleUrl('/js/utils.js'),
   });
 
   for (const [name, passed] of Object.entries(results)) {


### PR DESCRIPTION
## Summary
- Add browser coverage for PDF import JSON repair, text quality assessment, magic-byte file classification, and preflight duplicate/model/classification decisions.
- Expand import review coverage for manual date clearing, excluded-index tracking, select-based mapping, batch import resolution, and privacy/cost/debug rendering.

## Validation
- `node --check tests/playwright/pdf-import-browser-coverage.spec.js`
- `node --check tests/playwright/import-review-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/pdf-import-browser-coverage.spec.js tests/playwright/import-review-browser-coverage.spec.js` (8 passed)
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-pdf-import-pw-coverage.k9dq01 npm run test:playwright -- tests/playwright/pdf-import-browser-coverage.spec.js tests/playwright/import-review-browser-coverage.spec.js` (8 passed)
- `PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-pdf-import-pw-coverage.k9dq01 INCLUDE_VITEST_COVERAGE=1 REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 node scripts/playwright-coverage.mjs` (targeted-only report)
- `git diff --check`
- `./run-tests.sh` (Vitest, origin guard, 98 Playwright tests passed)