### PR TITLE
[codex] Add Light/Sun modal Playwright coverage

### DIFF
--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -561,7 +561,7 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
     let rafId = 0;
     const rafTimers = new Map();
     const delay = ms => new Promise(resolve => savedSetTimeout(resolve, ms));
-    const waitFor = async (predicate, attempts = 80) => {
+    const waitFor = async (predicate, attempts = 400) => {
       for (let i = 0; i < attempts; i++) {
         if (predicate()) return true;
         await delay(5);
@@ -597,8 +597,8 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
       }
       return data;
     };
-    const makeTrack = () => ({
-      stop: () => streamStops.push('stop'),
+    const makeTrack = label => ({
+      stop: () => streamStops.push(label),
       getSettings: () => ({
         frameRate: 120,
         exposureMode: 'manual',
@@ -618,8 +618,8 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
           && constraints.advanced.length > 0;
       },
     });
-    const makeStream = () => {
-      const track = makeTrack();
+    const makeStream = label => {
+      const track = makeTrack(label);
       const stream = new MediaStream();
       Object.defineProperty(stream, 'getTracks', { configurable: true, value: () => [track] });
       Object.defineProperty(stream, 'getVideoTracks', { configurable: true, value: () => [track] });
@@ -627,6 +627,7 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
     };
     const deps = {
       saveMeasurement: async (kind, value, meta) => {
+        await delay(0);
         savedReadings.push({ kind, value, meta });
       },
     };
@@ -634,7 +635,7 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
     try {
       Object.defineProperty(navigator, 'mediaDevices', {
         configurable: true,
-        value: { getUserMedia: async () => makeStream() },
+        value: { getUserMedia: async () => makeStream(cameraPattern) },
       });
       delete window.AmbientLightSensor;
       HTMLMediaElement.prototype.play = async function play() {
@@ -648,7 +649,6 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
           getImageData: () => ({ data: makeFrame(canvas.width, canvas.height) }),
         };
       };
-      window.setTimeout = (handler, timeout, ...args) => savedSetTimeout(handler, Math.min(Number(timeout) || 0, 1), ...args);
       window.requestAnimationFrame = callback => {
         const id = ++rafId;
         const timer = savedSetTimeout(() => {
@@ -673,7 +673,7 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
       document.getElementById('lux-cal-apply')?.click();
       await delay(5);
       document.getElementById('lux-save')?.click();
-      await Promise.resolve();
+      await waitFor(() => savedReadings.some(item => item.kind === 'lux'));
       const luxSaved = savedReadings.find(item => item.kind === 'lux');
       outcomes.luxCameraPathCalibratesAndSaves = luxReady
         && !!luxSaved
@@ -686,7 +686,7 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
       await modals.openFlickerDetector({ roomId: 'bench' }, deps);
       const flickerReady = await waitFor(() => document.getElementById('flicker-result')?.textContent.includes('flicker'));
       document.getElementById('flicker-save')?.click();
-      await Promise.resolve();
+      await waitFor(() => savedReadings.some(item => item.kind === 'flicker'));
       const flickerSaved = savedReadings.find(item => item.kind === 'flicker');
       outcomes.flickerCameraPathScoresAndSaves = flickerReady
         && !!flickerSaved
@@ -698,7 +698,7 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
       await modals.openCCTMeter({ roomId: 'bench' }, deps);
       const cctReady = await waitFor(() => /^\d+ K$/.test(document.getElementById('cct-value')?.textContent || ''));
       document.getElementById('cct-save')?.click();
-      await Promise.resolve();
+      await waitFor(() => savedReadings.some(item => item.kind === 'cct'));
       const cctSaved = savedReadings.find(item => item.kind === 'cct');
       outcomes.cctCameraPathComputesMelanopicPwmAndSaves = cctReady
         && !!cctSaved
@@ -714,7 +714,7 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
       document.getElementById('glass-measure-outside')?.click();
       const outsideReady = await waitFor(() => document.getElementById('glass-save')?.disabled === false);
       document.getElementById('glass-save')?.click();
-      await Promise.resolve();
+      await waitFor(() => savedReadings.some(item => item.kind === 'glass-transmission'));
       const glassSaved = savedReadings.find(item => item.kind === 'glass-transmission');
       outcomes.glassCameraPathComputesRatioAndSaves = insideReady
         && outsideReady
@@ -723,7 +723,16 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
         && glassSaved.value < 0.45
         && glassSaved.meta.extra.lockMode === 'manual'
         && glassSaved.meta.roomId === 'window';
-      outcomes.cameraStreamsAreStoppedOnClose = streamStops.length >= 5;
+      const stopCounts = streamStops.reduce((acc, label) => {
+        acc[label] = (acc[label] || 0) + 1;
+        return acc;
+      }, {});
+      outcomes.cameraStreamsAreStoppedOnClose = streamStops.length === 5
+        && stopCounts.lux === 1
+        && stopCounts.flicker === 1
+        && stopCounts.cct === 1
+        && stopCounts['glass-inside'] === 1
+        && stopCounts['glass-outside'] === 1;
     } finally {
       Object.defineProperty(navigator, 'mediaDevices', {
         configurable: true,
@@ -733,7 +742,6 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
       HTMLCanvasElement.prototype.getContext = savedGetContext;
       window.requestAnimationFrame = savedRaf;
       window.cancelAnimationFrame = savedCancelRaf;
-      window.setTimeout = savedSetTimeout;
       if (hadALS) window.AmbientLightSensor = originalALS;
       else delete window.AmbientLightSensor;
       ['_closeLuxMeter', '_closeFlicker', '_closeCCT', '_closeGlass'].forEach(name => {

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -541,6 +541,217 @@ test('light camera tool modals cover denied and manual fallback contracts', asyn
   }
 });
 
+test('light camera tool modals cover mocked camera readings and save paths', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async ({ modalsUrl }) => {
+    const modals = await import(modalsUrl);
+    const outcomes = {};
+    const savedReadings = [];
+    const savedMediaDevices = navigator.mediaDevices;
+    const savedPlay = HTMLMediaElement.prototype.play;
+    const savedGetContext = HTMLCanvasElement.prototype.getContext;
+    const savedRaf = window.requestAnimationFrame;
+    const savedCancelRaf = window.cancelAnimationFrame;
+    const savedSetTimeout = window.setTimeout;
+    const hadALS = Object.prototype.hasOwnProperty.call(window, 'AmbientLightSensor');
+    const originalALS = window.AmbientLightSensor;
+    const streamStops = [];
+    let cameraPattern = 'lux';
+    let rafId = 0;
+    const rafTimers = new Map();
+    const delay = ms => new Promise(resolve => savedSetTimeout(resolve, ms));
+    const waitFor = async (predicate, attempts = 80) => {
+      for (let i = 0; i < attempts; i++) {
+        if (predicate()) return true;
+        await delay(5);
+      }
+      return false;
+    };
+    const makeFrame = (width, height) => {
+      const data = new Uint8ClampedArray(width * height * 4);
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          let r = 80;
+          let g = 80;
+          let b = 80;
+          if (cameraPattern === 'flicker') {
+            const v = y % 4 < 2 ? 240 : 24;
+            r = v; g = v; b = v;
+          } else if (cameraPattern === 'cct') {
+            const bright = y % 4 < 2;
+            r = bright ? 20 : 6;
+            g = bright ? 80 : 24;
+            b = bright ? 230 : 90;
+          } else if (cameraPattern === 'glass-inside') {
+            r = 40; g = 40; b = 40;
+          } else if (cameraPattern === 'glass-outside') {
+            r = 100; g = 100; b = 100;
+          }
+          data[i] = r;
+          data[i + 1] = g;
+          data[i + 2] = b;
+          data[i + 3] = 255;
+        }
+      }
+      return data;
+    };
+    const makeTrack = () => ({
+      stop: () => streamStops.push('stop'),
+      getSettings: () => ({
+        frameRate: 120,
+        exposureMode: 'manual',
+        whiteBalanceMode: 'manual',
+        focusMode: 'manual',
+      }),
+      getCapabilities: () => ({
+        exposureMode: ['manual'],
+        whiteBalanceMode: ['manual'],
+        focusMode: ['manual'],
+        exposureTime: { min: 1, max: 500 },
+        iso: { min: 50, max: 800 },
+        colorTemperature: { min: 2000, max: 8000 },
+      }),
+      applyConstraints: async constraints => {
+        outcomes.cameraLockRequestsAdvancedConstraints = Array.isArray(constraints?.advanced)
+          && constraints.advanced.length > 0;
+      },
+    });
+    const makeStream = () => {
+      const track = makeTrack();
+      const stream = new MediaStream();
+      Object.defineProperty(stream, 'getTracks', { configurable: true, value: () => [track] });
+      Object.defineProperty(stream, 'getVideoTracks', { configurable: true, value: () => [track] });
+      return stream;
+    };
+    const deps = {
+      saveMeasurement: async (kind, value, meta) => {
+        savedReadings.push({ kind, value, meta });
+      },
+    };
+
+    try {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: { getUserMedia: async () => makeStream() },
+      });
+      delete window.AmbientLightSensor;
+      HTMLMediaElement.prototype.play = async function play() {
+        return undefined;
+      };
+      HTMLCanvasElement.prototype.getContext = function getContext(type, options) {
+        if (type !== '2d') return savedGetContext.call(this, type, options);
+        const canvas = this;
+        return {
+          drawImage: () => {},
+          getImageData: () => ({ data: makeFrame(canvas.width, canvas.height) }),
+        };
+      };
+      window.setTimeout = (handler, timeout, ...args) => savedSetTimeout(handler, Math.min(Number(timeout) || 0, 1), ...args);
+      window.requestAnimationFrame = callback => {
+        const id = ++rafId;
+        const timer = savedSetTimeout(() => {
+          rafTimers.delete(id);
+          callback(performance.now());
+        }, 1);
+        rafTimers.set(id, timer);
+        return id;
+      };
+      window.cancelAnimationFrame = id => {
+        const timer = rafTimers.get(id);
+        if (timer) clearTimeout(timer);
+        rafTimers.delete(id);
+      };
+
+      cameraPattern = 'lux';
+      localStorage.removeItem('labcharts-lux-calibration');
+      await modals.openLuxMeter({ roomId: 'workbench' }, deps);
+      const luxReady = await waitFor(() => document.getElementById('lux-value')?.textContent !== '—');
+      const calInput = document.getElementById('lux-cal-reference');
+      if (calInput) calInput.value = '6400';
+      document.getElementById('lux-cal-apply')?.click();
+      await delay(5);
+      document.getElementById('lux-save')?.click();
+      await Promise.resolve();
+      const luxSaved = savedReadings.find(item => item.kind === 'lux');
+      outcomes.luxCameraPathCalibratesAndSaves = luxReady
+        && !!luxSaved
+        && luxSaved.meta.roomId === 'workbench'
+        && luxSaved.meta.extra.source === 'camera-estimate'
+        && luxSaved.meta.extra.calibrationFactor >= 1.9
+        && !document.querySelector('[aria-label="Lux meter"]');
+
+      cameraPattern = 'flicker';
+      await modals.openFlickerDetector({ roomId: 'bench' }, deps);
+      const flickerReady = await waitFor(() => document.getElementById('flicker-result')?.textContent.includes('flicker'));
+      document.getElementById('flicker-save')?.click();
+      await Promise.resolve();
+      const flickerSaved = savedReadings.find(item => item.kind === 'flicker');
+      outcomes.flickerCameraPathScoresAndSaves = flickerReady
+        && !!flickerSaved
+        && flickerSaved.value >= 2
+        && flickerSaved.meta.extra.bandingRatio > 0.1
+        && flickerSaved.meta.roomId === 'bench';
+
+      cameraPattern = 'cct';
+      await modals.openCCTMeter({ roomId: 'bench' }, deps);
+      const cctReady = await waitFor(() => /^\d+ K$/.test(document.getElementById('cct-value')?.textContent || ''));
+      document.getElementById('cct-save')?.click();
+      await Promise.resolve();
+      const cctSaved = savedReadings.find(item => item.kind === 'cct');
+      outcomes.cctCameraPathComputesMelanopicPwmAndSaves = cctReady
+        && !!cctSaved
+        && cctSaved.value >= 5000
+        && cctSaved.meta.extra.melanopic > 0.5
+        && cctSaved.meta.extra.pwmActive === true;
+
+      await modals.openGlassTransmission({ roomId: 'window' }, deps);
+      cameraPattern = 'glass-inside';
+      document.getElementById('glass-measure-inside')?.click();
+      const insideReady = await waitFor(() => document.getElementById('glass-reading-inside')?.textContent.includes('lux'));
+      cameraPattern = 'glass-outside';
+      document.getElementById('glass-measure-outside')?.click();
+      const outsideReady = await waitFor(() => document.getElementById('glass-save')?.disabled === false);
+      document.getElementById('glass-save')?.click();
+      await Promise.resolve();
+      const glassSaved = savedReadings.find(item => item.kind === 'glass-transmission');
+      outcomes.glassCameraPathComputesRatioAndSaves = insideReady
+        && outsideReady
+        && !!glassSaved
+        && glassSaved.value > 0.35
+        && glassSaved.value < 0.45
+        && glassSaved.meta.extra.lockMode === 'manual'
+        && glassSaved.meta.roomId === 'window';
+      outcomes.cameraStreamsAreStoppedOnClose = streamStops.length >= 5;
+    } finally {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: savedMediaDevices,
+      });
+      HTMLMediaElement.prototype.play = savedPlay;
+      HTMLCanvasElement.prototype.getContext = savedGetContext;
+      window.requestAnimationFrame = savedRaf;
+      window.cancelAnimationFrame = savedCancelRaf;
+      window.setTimeout = savedSetTimeout;
+      if (hadALS) window.AmbientLightSensor = originalALS;
+      else delete window.AmbientLightSensor;
+      ['_closeLuxMeter', '_closeFlicker', '_closeCCT', '_closeGlass'].forEach(name => {
+        try { if (typeof window[name] === 'function') window[name](); } catch (_) {}
+      });
+      document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
+    }
+
+    return outcomes;
+  }, {
+    modalsUrl: moduleUrl('/js/light-tool-camera-modals.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
 test('light devices cover session detail edit log active card and rendered list paths', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -322,6 +322,166 @@ test('sun session UI covers chip units and detailed dialog validation paths', as
   }
 });
 
+test('device session dialog covers validation unit mode start and save paths', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async ({ deviceSessionUrl }) => {
+    const [{ state }, deviceSessionModal] = await Promise.all([
+      import('/js/state.js'),
+      import(deviceSessionUrl),
+    ]);
+    const outcomes = {};
+    const calls = [];
+    const saved = {
+      unitSystem: state.unitSystem,
+      navigate: window.navigate,
+      validateModeCoupling: window.validateModeCoupling,
+      renderBodySilhouette: window.renderBodySilhouette,
+      bindBodySilhouette: window.bindBodySilhouette,
+    };
+    let activeSession = null;
+    const devices = [{
+      id: 'panel-coverage',
+      brand: 'CoverageLight',
+      model: 'Dual 900',
+      recommendedDistanceCm: 30,
+      lastSession: {
+        durationMin: 18,
+        distanceCm: 30,
+        bodyArea: 'legs',
+        eyesProtected: false,
+        mode: 'red',
+      },
+      modes: [
+        { id: 'combo', label: 'Combo', default: true },
+        { id: 'red', label: 'Red only' },
+        { id: 'nir', label: 'NIR only' },
+        { id: 'blocked', label: 'Blocked' },
+      ],
+    }];
+
+    try {
+      state.unitSystem = 'US';
+      window.navigate = route => calls.push(['navigate', route]);
+      window.validateModeCoupling = (_device, mode) => ({ ok: mode !== 'blocked' });
+      window.renderBodySilhouette = selected => `
+        <button type="button" class="body-region-test" data-region="legs-front" aria-pressed="${selected.has('legs-front')}">Legs front</button>
+        <button type="button" class="body-region-test" data-region="arms-front" aria-pressed="${selected.has('arms-front')}">Arms front</button>
+      `;
+      window.bindBodySilhouette = (slot, selected, callback) => {
+        slot.querySelectorAll('[data-region]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const region = btn.dataset.region;
+            if (!region) return;
+            if (selected.has(region)) selected.delete(region);
+            else selected.add(region);
+            callback(selected);
+          });
+        });
+      };
+
+      const deps = {
+        hydrateDevicesFromPresets: async () => calls.push(['hydrate-devices']),
+        getDevices: () => devices,
+        logDeviceSession: async payload => calls.push(['log', payload]),
+        getActiveDeviceSession: () => activeSession,
+        startDeviceSession: async payload => {
+          calls.push(['start', payload]);
+          activeSession = { id: 'active-device' };
+        },
+        ensureActiveDeviceTicker: () => calls.push(['ticker']),
+      };
+
+      await deviceSessionModal.openDeviceSessionDialog('panel-coverage', deps);
+      let overlay = document.querySelector('[aria-label="Log device session"]')?.closest('.modal-overlay');
+      const modeButtons = overlay?.querySelectorAll('.dev-mode-btn') || [];
+      const distance = overlay?.querySelector('#dev-session-distance');
+      outcomes.dialogUsesLastSessionAndFiltersModes = !!overlay
+        && overlay.querySelector('#dev-session-duration')?.value === '18'
+        && overlay.querySelector('#dev-session-mode')?.value === 'red'
+        && modeButtons.length === 3
+        && !overlay.textContent.includes('Blocked')
+        && overlay.querySelector('#dev-session-eyes')?.checked === false
+        && overlay.querySelector('#dev-session-area-hint')?.textContent.includes('Legs');
+
+      overlay?.querySelector('.dev-mode-btn[data-mode="nir"]')?.click();
+      outcomes.modeClickUpdatesHiddenInputAndAria = overlay?.querySelector('#dev-session-mode')?.value === 'nir'
+        && overlay.querySelector('.dev-mode-btn[data-mode="nir"]')?.getAttribute('aria-checked') === 'true';
+
+      if (distance) {
+        const initialInches = Number(distance.value);
+        overlay.querySelector('.dev-unit-btn[data-unit="cm"]')?.click();
+        const convertedCm = Number(distance.value);
+        overlay.querySelector('.dev-unit-btn[data-unit="in"]')?.click();
+        outcomes.unitToggleConvertsBothDirections = distance.dataset.unit === 'in'
+          && Math.abs(initialInches - 11.8) < 0.05
+          && Math.abs(convertedCm - 30) < 0.05
+          && overlay.querySelector('.dev-unit-btn[data-unit="in"]')?.getAttribute('aria-selected') === 'true';
+      } else {
+        outcomes.unitToggleConvertsBothDirections = false;
+      }
+
+      overlay?.querySelector('#dev-session-clear')?.click();
+      overlay?.querySelector('#dev-session-save')?.click();
+      outcomes.emptyRegionBlocksSave = !calls.some(call => call[0] === 'log')
+        && overlay?.querySelector('#dev-session-area-hint')?.textContent.includes('Pick at least one region');
+      overlay?.remove();
+
+      activeSession = { id: 'already-running' };
+      await deviceSessionModal.openDeviceSessionDialog('panel-coverage', deps);
+      overlay = document.querySelector('[aria-label="Log device session"]')?.closest('.modal-overlay');
+      overlay?.querySelector('#dev-session-start')?.click();
+      await Promise.resolve();
+      outcomes.activeSessionBlocksNewTimer = !!overlay
+        && document.body.contains(overlay)
+        && !calls.some(call => call[0] === 'start');
+      activeSession = null;
+      overlay?.querySelector('#dev-session-start')?.click();
+      await Promise.resolve();
+      const startPayload = calls.find(call => call[0] === 'start')?.[1];
+      outcomes.startTimerUsesDefaultsAndNavigates = !!startPayload
+        && startPayload.deviceId === 'panel-coverage'
+        && startPayload.mode === 'red'
+        && startPayload.bodyArea === 'legs'
+        && startPayload.bodyAreas.includes('legs-front')
+        && calls.some(call => call[0] === 'ticker')
+        && calls.some(call => call[0] === 'navigate' && call[1] === 'light');
+
+      await deviceSessionModal.openDeviceSessionDialog('panel-coverage', deps);
+      overlay = document.querySelector('[aria-label="Log device session"]')?.closest('.modal-overlay');
+      overlay.querySelector('#dev-session-duration').value = '7';
+      overlay.querySelector('.dev-mode-btn[data-mode="combo"]')?.click();
+      overlay.querySelector('#dev-session-save')?.click();
+      await Promise.resolve();
+      const logPayload = calls.find(call => call[0] === 'log')?.[1];
+      outcomes.saveSessionUsesModeDurationAndRegions = !!logPayload
+        && logPayload.durationMin === 7
+        && logPayload.mode === 'combo'
+        && logPayload.bodyArea === 'legs'
+        && Math.abs(logPayload.distanceCm - 30) < 0.1
+        && logPayload.eyesProtected === false;
+      outcomes.hydratesDevicesOnEachOpen = calls.filter(call => call[0] === 'hydrate-devices').length === 3;
+    } finally {
+      state.unitSystem = saved.unitSystem;
+      if (saved.navigate) window.navigate = saved.navigate;
+      else delete window.navigate;
+      if (saved.validateModeCoupling) window.validateModeCoupling = saved.validateModeCoupling;
+      else delete window.validateModeCoupling;
+      if (saved.renderBodySilhouette) window.renderBodySilhouette = saved.renderBodySilhouette;
+      else delete window.renderBodySilhouette;
+      if (saved.bindBodySilhouette) window.bindBodySilhouette = saved.bindBodySilhouette;
+      else delete window.bindBodySilhouette;
+      document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
+    }
+
+    return outcomes;
+  }, { deviceSessionUrl: moduleUrl('/js/light-device-session-modal.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
 test('light sessions view covers all-sessions modal refresh scroll and row events', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -359,6 +359,18 @@ test('device session dialog covers validation unit mode start and save paths', a
         { id: 'blocked', label: 'Blocked' },
       ],
     }];
+    const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const waitFor = async (predicate, attempts = 80) => {
+      for (let i = 0; i < attempts; i++) {
+        if (predicate()) return true;
+        await delay(5);
+      }
+      return false;
+    };
+    const waitForCall = async kind => {
+      await waitFor(() => calls.some(call => call[0] === kind));
+      return calls.find(call => call[0] === kind)?.[1] || null;
+    };
 
     try {
       state.unitSystem = 'US';
@@ -383,9 +395,13 @@ test('device session dialog covers validation unit mode start and save paths', a
       const deps = {
         hydrateDevicesFromPresets: async () => calls.push(['hydrate-devices']),
         getDevices: () => devices,
-        logDeviceSession: async payload => calls.push(['log', payload]),
+        logDeviceSession: async payload => {
+          await delay(0);
+          calls.push(['log', payload]);
+        },
         getActiveDeviceSession: () => activeSession,
         startDeviceSession: async payload => {
+          await delay(0);
           calls.push(['start', payload]);
           activeSession = { id: 'active-device' };
         },
@@ -431,14 +447,13 @@ test('device session dialog covers validation unit mode start and save paths', a
       await deviceSessionModal.openDeviceSessionDialog('panel-coverage', deps);
       overlay = document.querySelector('[aria-label="Log device session"]')?.closest('.modal-overlay');
       overlay?.querySelector('#dev-session-start')?.click();
-      await Promise.resolve();
+      await delay(20);
       outcomes.activeSessionBlocksNewTimer = !!overlay
         && document.body.contains(overlay)
         && !calls.some(call => call[0] === 'start');
       activeSession = null;
       overlay?.querySelector('#dev-session-start')?.click();
-      await Promise.resolve();
-      const startPayload = calls.find(call => call[0] === 'start')?.[1];
+      const startPayload = await waitForCall('start');
       outcomes.startTimerUsesDefaultsAndNavigates = !!startPayload
         && startPayload.deviceId === 'panel-coverage'
         && startPayload.mode === 'red'
@@ -452,8 +467,7 @@ test('device session dialog covers validation unit mode start and save paths', a
       overlay.querySelector('#dev-session-duration').value = '7';
       overlay.querySelector('.dev-mode-btn[data-mode="combo"]')?.click();
       overlay.querySelector('#dev-session-save')?.click();
-      await Promise.resolve();
-      const logPayload = calls.find(call => call[0] === 'log')?.[1];
+      const logPayload = await waitForCall('log');
       outcomes.saveSessionUsesModeDurationAndRegions = !!logPayload
         && logPayload.durationMin === 7
         && logPayload.mode === 'combo'


### PR DESCRIPTION
## Summary
- Add browser coverage for camera-backed Light tool modal save paths with deterministic mocked media/canvas readings.
- Add direct coverage for the device-session logging modal: mode filtering, distance units, empty-region validation, active-timer guard, start, and save payloads.

## Validation
- `node --check tests/playwright/light-sun-coverage-batch.spec.js`
- `node --check tests/playwright/modal-session-coverage-batch.spec.js`
- `npm run test:playwright -- tests/playwright/modal-session-coverage-batch.spec.js tests/playwright/light-sun-coverage-batch.spec.js` (10 passed)
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-light-sun-modal-pw-coverage npm run test:playwright -- tests/playwright/modal-session-coverage-batch.spec.js tests/playwright/light-sun-coverage-batch.spec.js` (10 passed)
- `PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-combined-pw-coverage.ocX1RY INCLUDE_VITEST_COVERAGE=1 REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 node scripts/playwright-coverage.mjs` (combined shard approximation)
- `git diff --check`
- `./run-tests.sh` (Vitest 170 passed, server guard 18 passed, Playwright 102 passed)