### PR TITLE
[codex] Add setup onboarding Playwright coverage

### DIFF
--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -1,0 +1,431 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?setupOnboardingCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+test('Light setup overlay covers location refresh, score, save, edit, and skip paths', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#notification-container', { state: 'attached' });
+
+  const results = await page.evaluate(async ({ sunDefaultsUrl }) => {
+    const [sunDefaults, { state }, data] = await Promise.all([
+      import(sunDefaultsUrl),
+      import('/js/state.js'),
+      import('/js/data.js'),
+    ]);
+    const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
+    const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
+    const waitFor = async (selector, label = selector) => {
+      for (let i = 0; i < 80; i += 1) {
+        const el = document.querySelector(selector);
+        if (el) return el;
+        await wait(25);
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+    const waitUntil = async (predicate, label) => {
+      for (let i = 0; i < 80; i += 1) {
+        if (predicate()) return;
+        await wait(25);
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+    const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
+      const key = localStorage.key(i);
+      return [key, localStorage.getItem(key)];
+    }));
+    const sessionSnapshot = new Map(Array.from({ length: sessionStorage.length }, (_, i) => {
+      const key = sessionStorage.key(i);
+      return [key, sessionStorage.getItem(key)];
+    }));
+    const saved = {
+      importedData: clone(state.importedData),
+      currentProfile: state.currentProfile,
+      profileSex: state.profileSex,
+      profileDob: state.profileDob,
+      navigate: window.navigate,
+      getSunCoords: window.getSunCoords,
+      getProfileLocation: window.getProfileLocation,
+      openProfileLocationEditor: window.openProfileLocationEditor,
+      openClientList: window.openClientList,
+      requestPreciseLocation: window.requestPreciseLocation,
+      maybeAnalyzeOnboardingAfterSave: window.maybeAnalyzeOnboardingAfterSave,
+      renderOnboardingAIBlock: window.renderOnboardingAIBlock,
+    };
+    const calls = [];
+    const outcomes = {};
+    let precise = false;
+
+    try {
+      state.currentProfile = 'setup-onboarding-coverage';
+      state.profileSex = null;
+      state.profileDob = null;
+      state.importedData = {
+        entries: [],
+        notes: [],
+        supplements: [],
+        lightCircadian: null,
+        sunDefaults: {},
+      };
+      data.invalidateActiveDataCache();
+
+      window.navigate = route => calls.push(['navigate', route]);
+      window.getSunCoords = () => precise
+        ? { source: 'profile-precise', lat: 50.087 }
+        : { source: 'country-band', lat: 49.2 };
+      window.getProfileLocation = () => ({ country: 'Czechia' });
+      window.openProfileLocationEditor = () => calls.push(['profile-location']);
+      window.openClientList = () => calls.push(['client-list']);
+      window.requestPreciseLocation = async () => {
+        calls.push(['precise-location']);
+        await wait(0);
+        precise = true;
+        return { lat: 50.087, lon: 14.421 };
+      };
+      window.maybeAnalyzeOnboardingAfterSave = () => calls.push(['onboarding-ai']);
+      window.renderOnboardingAIBlock = () => '<div id="setup-ai-block">AI setup block</div>';
+
+      const promptHost = document.createElement('div');
+      promptHost.id = 'setup-prompt-render-host';
+      promptHost.innerHTML = sunDefaults.renderSetupCard();
+      document.body.appendChild(promptHost);
+      outcomes.initialSetupPromptRendersActions =
+        promptHost.querySelector('.light-setup-prompt')?.textContent.includes('Set up your light assumptions')
+        && !!promptHost.querySelector('.light-widget-prompt-cta')
+        && !!promptHost.querySelector('.dashboard-action-btn');
+      promptHost.querySelector('.light-widget-prompt-cta')?.click();
+      await waitFor('#light-setup-focus-overlay');
+      promptHost.remove();
+      outcomes.overlayShowsProfileLocationEstimate =
+        document.querySelector('.light-setup-location-status')?.textContent.includes('Profile estimate')
+        && document.querySelector('.light-setup-location-status')?.textContent.includes('Czechia');
+
+      document.querySelector('.light-setup-location-actions button:nth-child(2)')?.click();
+      await waitUntil(
+        () => document.querySelector('.light-setup-location-status')?.textContent.includes('Precise location saved'),
+        'precise location status'
+      );
+      outcomes.preciseLocationRefreshUpdatesStatus =
+        calls.some(call => call[0] === 'precise-location')
+        && document.querySelector('.light-setup-location-status')?.textContent.includes('highest accuracy');
+
+      document.querySelector('.light-setup-save-btn')?.click();
+      await wait(0);
+      outcomes.emptySaveBlocksOnSkinType =
+        document.querySelector('.light-setup-focus-modal')?.dataset.setupStep === 'core'
+        && state.importedData.sunDefaults.completedAt == null
+        && Array.from(document.querySelectorAll('.notification-toast'))
+          .some(toast => toast.textContent.includes('Tap a face'));
+
+      const defaultFace = /** @type {HTMLElement | null} */ (document.querySelector('.ctx-skin-face[data-idx="2"]'));
+      defaultFace?.focus();
+      defaultFace?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }));
+      const nextFace = /** @type {HTMLElement | null} */ (document.querySelector('.ctx-skin-face[data-idx="3"]'));
+      nextFace?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
+      await wait(0);
+      document.querySelector('[data-choice-group="setup-photosensitive"][data-value="severe"]')?.click();
+      document.querySelector('[data-choice-group="setup-homelight"][data-value="led-warm"]')?.click();
+      document.querySelector('[data-choice-group="setup-eyewear"][data-value="sunglasses"]')?.click();
+      outcomes.coreChoicesUpdateProgressAndAria =
+        document.getElementById('setup-skin-range')?.dataset.set === '1'
+        && document.querySelector('.light-setup-progress')?.textContent.trim() === '3/3 done'
+        && document.querySelector('[data-choice-group="setup-eyewear"][data-value="sunglasses"]')?.getAttribute('aria-pressed') === 'true';
+
+      document.querySelector('.light-setup-next-btn')?.click();
+      await wait(0);
+      outcomes.stepTabsSwitchToScorePane =
+        document.querySelector('.light-setup-focus-modal')?.dataset.setupStep === 'score'
+        && document.querySelector('[data-setup-tab="score"]')?.getAttribute('aria-selected') === 'true'
+        && document.querySelector('[data-setup-pane="core"]')?.hasAttribute('hidden');
+
+      document.querySelector('input[data-ott="morning-light-deficit"]')?.click();
+      document.querySelector('input[data-ott="dim-workspace"]')?.click();
+      await wait(0);
+      outcomes.scoreMeterUpdatesFromCheckedCards =
+        document.getElementById('ott-running-value')?.textContent.trim() === '2/10'
+        && document.getElementById('ott-summary-score')?.textContent.trim() === '8/10 aligned'
+        && document.querySelector('input[data-ott="dim-workspace"]')?.closest('.light-setup-ott-card')?.classList.contains('is-flagged');
+
+      document.querySelector('.light-setup-save-btn')?.click();
+      await waitUntil(() => !document.getElementById('light-setup-focus-overlay'), 'saved overlay close');
+      outcomes.savePersistsSetupAndMirrorsContext =
+        state.importedData.sunDefaults.fitzpatrick === 'IV'
+        && state.importedData.sunDefaults.photosensitiveMeds === 'severe'
+        && state.importedData.sunDefaults.homeLight === 'led-warm'
+        && state.importedData.sunDefaults.eyewear === 'sunglasses'
+        && state.importedData.sunDefaults.ottScore === 2
+        && state.importedData.sunDefaults.ott?.['morning-light-deficit'] === true
+        && state.importedData.lightCircadian?.skinType?.startsWith('IV')
+        && calls.some(call => call[0] === 'onboarding-ai')
+        && calls.some(call => call[0] === 'navigate' && call[1] === 'light');
+
+      const host = document.createElement('div');
+      host.id = 'setup-card-render-host';
+      host.innerHTML = sunDefaults.renderSetupCard();
+      document.body.appendChild(host);
+      outcomes.savedSummaryIncludesBannerAndAiBlock =
+        host.querySelector('.light-setup-summary')?.textContent.includes('Your light setup')
+        && host.querySelector('.light-setup-photo-banner')?.textContent.includes('Severe photosensitizer')
+        && !!host.querySelector('#setup-ai-block');
+
+      host.querySelector('.light-setup-summary-edit')?.click();
+      await waitFor('#light-setup-focus-overlay', 'edit setup overlay');
+      outcomes.summaryEditReopensCompletedOverlay =
+        document.querySelector('.light-setup-save-btn')?.textContent.trim() === 'Save changes';
+      document.querySelector('.modal-close')?.click();
+      await waitUntil(() => !document.getElementById('light-setup-focus-overlay'), 'cancel edit overlay close');
+      host.remove();
+
+      window.reopenSunSetup();
+      await waitFor('#light-setup-focus-overlay');
+      document.querySelector('.light-setup-location-actions button:first-child')?.click();
+      await wait(0);
+      outcomes.profileLocationActionClosesOverlayAndOpensProfile =
+        !document.getElementById('light-setup-focus-overlay')
+        && calls.some(call => call[0] === 'profile-location');
+
+      state.importedData.sunDefaults = {};
+      window.reopenSunSetup();
+      await waitFor('#light-setup-focus-overlay');
+      document.querySelector('.light-setup-skip-btn')?.click();
+      await waitUntil(() => !document.getElementById('light-setup-focus-overlay'), 'skip overlay close');
+      outcomes.skipPersistsDefaultAndNavigatesLight =
+        state.importedData.sunDefaults.fitzpatrick === 'III'
+        && state.importedData.sunDefaults.skipped === true
+        && calls.filter(call => call[0] === 'navigate' && call[1] === 'light').length >= 2;
+    } finally {
+      document.getElementById('light-setup-focus-overlay')?.remove();
+      document.getElementById('setup-prompt-render-host')?.remove();
+      document.getElementById('setup-card-render-host')?.remove();
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+      state.importedData = saved.importedData;
+      state.currentProfile = saved.currentProfile;
+      state.profileSex = saved.profileSex;
+      state.profileDob = saved.profileDob;
+      data.invalidateActiveDataCache();
+      Object.assign(window, {
+        navigate: saved.navigate,
+        getSunCoords: saved.getSunCoords,
+        getProfileLocation: saved.getProfileLocation,
+        openProfileLocationEditor: saved.openProfileLocationEditor,
+        openClientList: saved.openClientList,
+        requestPreciseLocation: saved.requestPreciseLocation,
+        maybeAnalyzeOnboardingAfterSave: saved.maybeAnalyzeOnboardingAfterSave,
+        renderOnboardingAIBlock: saved.renderOnboardingAIBlock,
+      });
+      localStorage.clear();
+      for (const [key, value] of storage) {
+        if (key && value != null) localStorage.setItem(key, value);
+      }
+      sessionStorage.clear();
+      for (const [key, value] of sessionSnapshot) {
+        if (key && value != null) sessionStorage.setItem(key, value);
+      }
+    }
+
+    return outcomes;
+  }, { sunDefaultsUrl: moduleUrl('/js/sun-defaults.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('dashboard onboarding covers profile save, dismissal, focus modes, and AI reminder actions', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#notification-container', { state: 'attached' });
+
+  const results = await page.evaluate(async ({ onboardingUrl }) => {
+    const [onboarding, { state }, profile, data, crypto] = await Promise.all([
+      import(onboardingUrl),
+      import('/js/state.js'),
+      import('/js/profile.js'),
+      import('/js/data.js'),
+      import('/js/crypto.js'),
+    ]);
+    const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
+    const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
+    const waitUntil = async (predicate, label) => {
+      for (let i = 0; i < 80; i += 1) {
+        if (predicate()) return;
+        await wait(25);
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+    const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
+      const key = localStorage.key(i);
+      return [key, localStorage.getItem(key)];
+    }));
+    const sessionSnapshot = new Map(Array.from({ length: sessionStorage.length }, (_, i) => {
+      const key = sessionStorage.key(i);
+      return [key, sessionStorage.getItem(key)];
+    }));
+    const saved = {
+      importedData: clone(state.importedData),
+      currentProfile: state.currentProfile,
+      profileSex: state.profileSex,
+      profileDob: state.profileDob,
+      buildSidebar: window.buildSidebar,
+      openChatPanel: window.openChatPanel,
+      toggleChatPanel: window.toggleChatPanel,
+      renderChatMessages: window.renderChatMessages,
+      scrollIntoView: Element.prototype.scrollIntoView,
+    };
+    const outcomes = {};
+    const calls = [];
+    const host = document.createElement('div');
+    host.id = 'onboarding-coverage-host';
+
+    try {
+      document.body.appendChild(host);
+      state.currentProfile = 'onboarding-coverage';
+      state.profileSex = null;
+      state.profileDob = null;
+      state.importedData = profile.createDefaultProfileData();
+      data.invalidateActiveDataCache();
+      onboarding.configureOnboardingView({
+        navigate: (route, payload) => calls.push(['navigate', route, !!payload]),
+      });
+      window.buildSidebar = payload => calls.push(['sidebar', !!payload]);
+
+      const onboardedKey = profile.profileStorageKey(state.currentProfile, 'onboarded');
+      localStorage.removeItem(onboardedKey);
+      host.innerHTML = onboarding.renderOnboardingBanner();
+      outcomes.bannerRendersProfileStep =
+        !!host.querySelector('#onboarding-banner')
+        && host.querySelector('.onboarding-title')?.textContent.includes('Set up your profile');
+
+      onboarding.completeOnboardingSex('female');
+      host.querySelector('#onboarding-dob').value = '1990-04-05';
+      onboarding.completeOnboardingProfile();
+      outcomes.profileSavePersistsAndNavigates =
+        localStorage.getItem(onboardedKey) === 'profile-set'
+        && state.profileSex === 'female'
+        && state.profileDob === '1990-04-05'
+        && calls.some(call => call[0] === 'sidebar' && call[1])
+        && calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard' && call[2])
+        && Array.from(document.querySelectorAll('.notification-toast'))
+          .some(toast => toast.textContent.includes('Profile set up'));
+      outcomes.bannerSuppressesAfterProfileSet = onboarding.renderOnboardingBanner() === '';
+
+      localStorage.removeItem(onboardedKey);
+      state.profileSex = null;
+      state.profileDob = null;
+      host.innerHTML = onboarding.renderOnboardingBanner();
+      onboarding.dismissOnboarding();
+      outcomes.dismissOnboardingStoresChoiceAndAnimates =
+        localStorage.getItem(onboardedKey) === 'dismissed'
+        && host.querySelector('#onboarding-banner')?.style.opacity === '0';
+      await waitUntil(() => !host.querySelector('#onboarding-banner'), 'onboarding banner removal');
+
+      localStorage.setItem('labcharts-ai-provider', 'openrouter');
+      localStorage.removeItem('labcharts-openrouter-key');
+      crypto.updateKeyCache('labcharts-openrouter-key', '');
+      const providerSkipKey = `labcharts-onboard-provider-skipped-${state.currentProfile}`;
+      const reminderDismissKey = profile.profileStorageKey(state.currentProfile, 'ai-reminder-dismissed');
+      localStorage.setItem(providerSkipKey, '1');
+      localStorage.removeItem(reminderDismissKey);
+      host.innerHTML = onboarding.renderAIConnectionReminder();
+      outcomes.aiReminderRendersWhenProviderSkipped =
+        !!host.querySelector('#ai-reminder-banner')
+        && host.querySelector('.ai-reminder-cta')?.textContent.includes('Connect now');
+
+      window.openChatPanel = () => calls.push(['open-chat']);
+      window.toggleChatPanel = () => calls.push(['toggle-chat']);
+      window.renderChatMessages = () => calls.push(['render-chat']);
+      sessionStorage.setItem(`chat-onboard-provider-branch-${state.currentProfile}`, 'manual');
+      onboarding.openChatProviderQuiz();
+      outcomes.providerQuizClearsSkipAndOpensChat =
+        localStorage.getItem(providerSkipKey) == null
+        && sessionStorage.getItem(`chat-onboard-provider-requested-${state.currentProfile}`) === '1'
+        && sessionStorage.getItem(`chat-onboard-provider-branch-${state.currentProfile}`) == null
+        && calls.some(call => call[0] === 'open-chat')
+        && calls.some(call => call[0] === 'render-chat');
+
+      localStorage.setItem(providerSkipKey, '1');
+      localStorage.removeItem(reminderDismissKey);
+      host.innerHTML = onboarding.renderAIConnectionReminder();
+      onboarding.dismissAIReminder();
+      outcomes.dismissAiReminderStoresDismissal =
+        localStorage.getItem(reminderDismissKey) === '1'
+        && host.querySelector('#ai-reminder-banner')?.style.opacity === '0';
+      await waitUntil(() => !host.querySelector('#ai-reminder-banner'), 'AI reminder removal');
+
+      const scrolled = [];
+      Element.prototype.scrollIntoView = function scrollIntoViewStub(options) {
+        scrolled.push([this.className || this.id || this.tagName, options?.block || null]);
+      };
+      document.body.classList.add('chat-fullscreen');
+      localStorage.setItem('labcharts-chat-fullscreen', 'true');
+      const cards = document.createElement('div');
+      cards.className = 'profile-context-cards';
+      const importTarget = document.createElement('button');
+      importTarget.className = 'welcome-direct-import-btn';
+      document.body.append(cards, importTarget);
+
+      onboarding.setOnboardingFocus('cards');
+      await wait(140);
+      outcomes.cardsFocusSetsClassStorageAndScroll =
+        document.body.classList.contains('cards-focus')
+        && !document.body.classList.contains('chat-fullscreen')
+        && localStorage.getItem('labcharts-chat-fullscreen') === 'false'
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${state.currentProfile}`) === '1'
+        && scrolled.some(call => String(call[0]).includes('profile-context-cards') && call[1] === 'start');
+
+      onboarding.setOnboardingFocus('import');
+      await waitUntil(
+        () => scrolled.some(call => (
+          String(call[0]).includes('welcome-direct-import-btn')
+          || String(call[0]).includes('welcome-primary-panel')
+        ) && call[1] === 'center'),
+        'import focus scroll'
+      );
+      outcomes.importFocusReplacesClassAndScrollsImportTarget =
+        !document.body.classList.contains('cards-focus')
+        && document.body.classList.contains('import-focus')
+        && scrolled.some(call => (
+          String(call[0]).includes('welcome-direct-import-btn')
+          || String(call[0]).includes('welcome-primary-panel')
+        ) && call[1] === 'center');
+
+      onboarding.setOnboardingFocus('');
+      outcomes.blankFocusClearsFocusClasses =
+        !document.body.classList.contains('cards-focus')
+        && !document.body.classList.contains('import-focus');
+      cards.remove();
+      importTarget.remove();
+    } finally {
+      host.remove();
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+      document.body.classList.remove('cards-focus', 'import-focus', 'chat-fullscreen');
+      state.importedData = saved.importedData;
+      state.currentProfile = saved.currentProfile;
+      state.profileSex = saved.profileSex;
+      state.profileDob = saved.profileDob;
+      data.invalidateActiveDataCache();
+      onboarding.configureOnboardingView({ navigate: null });
+      Object.assign(window, {
+        buildSidebar: saved.buildSidebar,
+        openChatPanel: saved.openChatPanel,
+        toggleChatPanel: saved.toggleChatPanel,
+        renderChatMessages: saved.renderChatMessages,
+      });
+      Element.prototype.scrollIntoView = saved.scrollIntoView;
+      localStorage.clear();
+      for (const [key, value] of storage) {
+        if (key && value != null) localStorage.setItem(key, value);
+      }
+      sessionStorage.clear();
+      for (const [key, value] of sessionSnapshot) {
+        if (key && value != null) sessionStorage.setItem(key, value);
+      }
+    }
+
+    return outcomes;
+  }, { onboardingUrl: moduleUrl('/js/onboarding-view.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -365,7 +365,10 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       document.body.append(cards, importTarget);
 
       onboarding.setOnboardingFocus('cards');
-      await wait(140);
+      await waitUntil(
+        () => scrolled.some(call => String(call[0]).includes('profile-context-cards') && call[1] === 'start'),
+        'cards focus scroll'
+      );
       outcomes.cardsFocusSetsClassStorageAndScroll =
         document.body.classList.contains('cards-focus')
         && !document.body.classList.contains('chat-fullscreen')

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -266,6 +266,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       currentProfile: state.currentProfile,
       profileSex: state.profileSex,
       profileDob: state.profileDob,
+      navigate: window.navigate,
       buildSidebar: window.buildSidebar,
       openChatPanel: window.openChatPanel,
       toggleChatPanel: window.toggleChatPanel,
@@ -276,6 +277,8 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
     const calls = [];
     const host = document.createElement('div');
     host.id = 'onboarding-coverage-host';
+    let cards = null;
+    let importTarget = null;
 
     try {
       document.body.appendChild(host);
@@ -358,9 +361,9 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       };
       document.body.classList.add('chat-fullscreen');
       localStorage.setItem('labcharts-chat-fullscreen', 'true');
-      const cards = document.createElement('div');
+      cards = document.createElement('div');
       cards.className = 'profile-context-cards';
-      const importTarget = document.createElement('button');
+      importTarget = document.createElement('button');
       importTarget.className = 'welcome-direct-import-btn';
       document.body.append(cards, importTarget);
 
@@ -396,9 +399,9 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       outcomes.blankFocusClearsFocusClasses =
         !document.body.classList.contains('cards-focus')
         && !document.body.classList.contains('import-focus');
-      cards.remove();
-      importTarget.remove();
     } finally {
+      cards?.remove();
+      importTarget?.remove();
       host.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       document.body.classList.remove('cards-focus', 'import-focus', 'chat-fullscreen');
@@ -407,7 +410,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       data.invalidateActiveDataCache();
-      onboarding.configureOnboardingView({ navigate: null });
+      onboarding.configureOnboardingView({ navigate: saved.navigate });
       Object.assign(window, {
         buildSidebar: saved.buildSidebar,
         openChatPanel: saved.openChatPanel,


### PR DESCRIPTION
## Summary
- Add Playwright browser coverage for the Light setup prompt and focused setup overlay, including location refresh, skin/choice controls, score meter, save, edit, profile-location, and skip paths.
- Add Playwright browser coverage for dashboard onboarding profile save/dismissal, AI provider reminder actions, and onboarding focus modes.

## Coverage Signal
- Targeted Playwright shard coverage: `js/sun-defaults.js` 35/35 functions, `js/onboarding-view.js` 9/9 functions.

## Validation
- `node --check tests/playwright/setup-onboarding-coverage-batch.spec.js`
- `npm run test:playwright -- tests/playwright/setup-onboarding-coverage-batch.spec.js` (2 passed)
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-setup-onboarding-pw-coverage-20260608b npm run test:playwright -- tests/playwright/setup-onboarding-coverage-batch.spec.js` (2 passed)
- `PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-setup-onboarding-pw-coverage-20260608b REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 node scripts/playwright-coverage.mjs`
- `git diff --check`
- `./run-tests.sh` (Vitest 170 passed, dev-server guard 18 passed, Playwright 104 passed)