### PR TITLE
Add supplement warnings browser coverage

### DIFF
--- a/tests/playwright/supplement-warnings-browser-coverage.spec.js
+++ b/tests/playwright/supplement-warnings-browser-coverage.spec.js
@@ -1,0 +1,133 @@
+import { expect, test } from './coverage-fixture.js';
+
+const moduleUrl = (path, label = 'supplementWarningsCoverage') =>
+  `${path}?${label}=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+async function openBlankPage(page, path) {
+  await page.route(`**${path}`, route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><body></body></html>',
+  }));
+  await page.goto(path, { waitUntil: 'load' });
+}
+
+function expectAll(outcomes) {
+  for (const [name, passed] of Object.entries(outcomes)) {
+    expect.soft(passed, name).toBe(true);
+  }
+}
+
+test('supplement warning browser coverage exercises lookup scan urls and effect labels', async ({ page }) => {
+  test.setTimeout(30_000);
+  await openBlankPage(page, '/supplement-warnings-browser-coverage');
+
+  const results = await page.evaluate(async ({ successUrl, notOkUrl, throwUrl }) => {
+    const outcomes = {};
+    const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
+    const waitUntil = async (predicate, label) => {
+      for (let i = 0; i < 100; i += 1) {
+        if (predicate()) return;
+        await wait(25);
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+    const savedFetch = window.fetch;
+
+    try {
+      window.fetch = async () => new Response('[]', { status: 503 });
+      const notOk = await import(notOkUrl);
+      await wait(0);
+      outcomes.notOkDataLoadLeavesLookupEmpty = notOk.lookupMitoCompound('metformin') === null;
+      outcomes.notOkDataLoadLeavesScanEmpty =
+        notOk.scanSupplementsForWarnings([{ name: 'Metformin' }]).length === 0;
+
+      window.fetch = async () => { throw new Error('offline'); };
+      const thrown = await import(throwUrl);
+      await wait(0);
+      outcomes.throwingDataLoadLeavesLookupEmpty = thrown.lookupMitoCompound('metformin') === null;
+      outcomes.throwingDataLoadLeavesScanEmpty =
+        thrown.scanSupplementsForWarnings([{ name: 'Metformin' }]).length === 0;
+
+      window.fetch = savedFetch;
+      const warnings = await import(successUrl);
+      await waitUntil(
+        () => warnings.lookupMitoCompound('metformin') !== null,
+        'mitochondrial compound data',
+      );
+
+      const metformin = warnings.lookupMitoCompound(' METFORMIN ');
+      const tylenol = warnings.lookupMitoCompound('daily tylenol tablets');
+      const shortAliasExact = warnings.lookupMitoCompound('nac');
+      const shortAliasInPhrase = warnings.lookupMitoCompound('daily nac');
+      const escapedKeyword = warnings.lookupMitoCompound('alpha-lipoic acid 600mg');
+
+      outcomes.lookupExactNormalizesCaseAndTrim = metformin?.name === 'Metformin';
+      outcomes.lookupWordBoundaryFindsKeywordInPhrase = tylenol?.name === 'Acetaminophen';
+      outcomes.lookupShortExactKeywordWorks = shortAliasExact?.name === 'N-Acetylcysteine';
+      outcomes.lookupShortKeywordDoesNotWordMatch = shortAliasInPhrase === null;
+      outcomes.lookupEscapesRegexCharacters = escapedKeyword?.name === 'Alpha-Lipoic Acid';
+      outcomes.lookupRejectsTooShortQueries = warnings.lookupMitoCompound('nr') === null;
+      outcomes.lookupMissReturnsNull = warnings.lookupMitoCompound('made-up-compound') === null;
+
+      outcomes.pubmedUrlFormatsPmid =
+        warnings.pubmedUrl(39693440) === 'https://pubmed.ncbi.nlm.nih.gov/39693440/';
+      outcomes.pubmedSearchUrlDecodesPlusBeforeEncoding =
+        warnings.pubmedSearchUrl('alpha+lipoic acid+ROS') ===
+        'https://pubmed.ncbi.nlm.nih.gov/?term=alpha%20lipoic%20acid%20ROS';
+
+      const emptyWarnings = warnings.scanSupplementsForWarnings(null);
+      const metforminWarnings = warnings.scanSupplementsForWarnings([
+        { name: 'Metformin' },
+        { name: 'glucophage' },
+        { name: 'Coenzyme Q10' },
+        { name: 'unknown thing' },
+      ]);
+      const paraquatWarnings = warnings.scanSupplementsForWarnings([{ name: 'Paraquat' }]);
+      const fluoxetineWarnings = warnings.scanSupplementsForWarnings([{ name: 'fluoxetine' }]);
+      const protectiveWarnings = warnings.scanSupplementsForWarnings([
+        { name: 'CoQ10' },
+        { name: 'Melatonin' },
+        { name: 'Alpha-Lipoic Acid' },
+      ]);
+
+      outcomes.scanNullReturnsEmpty = Array.isArray(emptyWarnings) && emptyWarnings.length === 0;
+      outcomes.scanDedupesAliases = metforminWarnings.length === 1;
+      outcomes.scanUsesOriginalSupplementName = metforminWarnings[0]?.match === 'Metformin';
+      outcomes.scanBuildsWarningText = metforminWarnings[0]?.warning.includes('Metformin: inhibits Complex I');
+      outcomes.scanIncludesPubMedUrls =
+        metforminWarnings[0]?.url === 'https://pubmed.ncbi.nlm.nih.gov/39693440/';
+      outcomes.scanIncludesSearchUrls = metforminWarnings[0]?.searchUrl.includes('metformin%20mitochondrial');
+      outcomes.scanIgnoresProtectiveEffects = protectiveWarnings.length === 0;
+      outcomes.scanTreatsRedoxCyclesAsHarmful =
+        paraquatWarnings[0]?.effects.some(effect => effect.a === 'redox cycles') === true;
+      outcomes.scanTreatsIncreasedRosAsHarmful =
+        paraquatWarnings[0]?.effects.some(effect => effect.a === 'increases' && effect.f === 'ROS') === true;
+      outcomes.scanTreatsDecreasedMembranePotentialAsHarmful =
+        fluoxetineWarnings[0]?.effects.some(
+          effect => effect.a === 'decreases' && effect.f === 'Membrane potential',
+        ) === true;
+
+      outcomes.humanizeMappedVerbWithContext =
+        warnings.humanizeEffect(
+          { a: 'inhibits', f: 'Complex I', t: 'high dose' },
+          { showContext: true },
+        ) === 'may inhibit Complex I (high dose)';
+      outcomes.humanizeMappedVerbWithoutContext =
+        warnings.humanizeEffect({ a: 'binds', f: 'CoQ10' }, { showContext: true }) === 'binds CoQ10';
+      outcomes.humanizeUnknownVerbSingularizes =
+        warnings.humanizeEffect({ a: 'protects', f: 'Complex I' }) === 'may protect Complex I';
+      outcomes.humanizeMissingActionDefaults =
+        warnings.humanizeEffect({ f: 'Mitochondria' }) === 'may affect Mitochondria';
+    } finally {
+      window.fetch = savedFetch;
+    }
+
+    return outcomes;
+  }, {
+    successUrl: moduleUrl('/js/supplement-warnings.js', 'success'),
+    notOkUrl: moduleUrl('/js/supplement-warnings.js', 'notOk'),
+    throwUrl: moduleUrl('/js/supplement-warnings.js', 'throwing'),
+  });
+
+  expectAll(results);
+});

--- a/tests/playwright/supplement-warnings-browser-coverage.spec.js
+++ b/tests/playwright/supplement-warnings-browser-coverage.spec.js
@@ -59,13 +59,13 @@ test('supplement warning browser coverage exercises lookup scan urls and effect 
       const tylenol = warnings.lookupMitoCompound('daily tylenol tablets');
       const shortAliasExact = warnings.lookupMitoCompound('nac');
       const shortAliasInPhrase = warnings.lookupMitoCompound('daily nac');
-      const escapedKeyword = warnings.lookupMitoCompound('alpha-lipoic acid 600mg');
+      const hyphenatedKeyword = warnings.lookupMitoCompound('alpha-lipoic acid 600mg');
 
       outcomes.lookupExactNormalizesCaseAndTrim = metformin?.name === 'Metformin';
       outcomes.lookupWordBoundaryFindsKeywordInPhrase = tylenol?.name === 'Acetaminophen';
       outcomes.lookupShortExactKeywordWorks = shortAliasExact?.name === 'N-Acetylcysteine';
       outcomes.lookupShortKeywordDoesNotWordMatch = shortAliasInPhrase === null;
-      outcomes.lookupEscapesRegexCharacters = escapedKeyword?.name === 'Alpha-Lipoic Acid';
+      outcomes.lookupHyphenatedKeywordMatches = hyphenatedKeyword?.name === 'Alpha-Lipoic Acid';
       outcomes.lookupRejectsTooShortQueries = warnings.lookupMitoCompound('nr') === null;
       outcomes.lookupMissReturnsNull = warnings.lookupMitoCompound('made-up-compound') === null;
 
@@ -89,14 +89,20 @@ test('supplement warning browser coverage exercises lookup scan urls and effect 
         { name: 'Melatonin' },
         { name: 'Alpha-Lipoic Acid' },
       ]);
+      const metforminWarning = metforminWarnings[0];
+      const metforminSearchUrl = metforminWarning?.searchUrl ? new URL(metforminWarning.searchUrl) : null;
 
       outcomes.scanNullReturnsEmpty = Array.isArray(emptyWarnings) && emptyWarnings.length === 0;
       outcomes.scanDedupesAliases = metforminWarnings.length === 1;
-      outcomes.scanUsesOriginalSupplementName = metforminWarnings[0]?.match === 'Metformin';
-      outcomes.scanBuildsWarningText = metforminWarnings[0]?.warning.includes('Metformin: inhibits Complex I');
+      outcomes.scanUsesOriginalSupplementName = metforminWarning?.match === 'Metformin';
+      outcomes.scanBuildsWarningFromLoadedEntry =
+        metforminWarning?.warning.startsWith(`${metformin?.name}: `) === true
+        && metforminWarning.effects.every(effect => metforminWarning.warning.includes(effect.f));
       outcomes.scanIncludesPubMedUrls =
-        metforminWarnings[0]?.url === 'https://pubmed.ncbi.nlm.nih.gov/39693440/';
-      outcomes.scanIncludesSearchUrls = metforminWarnings[0]?.searchUrl.includes('metformin%20mitochondrial');
+        /^https:\/\/pubmed\.ncbi\.nlm\.nih\.gov\/\d+\/$/.test(metforminWarning?.url || '');
+      outcomes.scanIncludesSearchUrls =
+        metforminSearchUrl?.hostname === 'pubmed.ncbi.nlm.nih.gov'
+        && !!metforminSearchUrl.searchParams.get('term');
       outcomes.scanIgnoresProtectiveEffects = protectiveWarnings.length === 0;
       outcomes.scanTreatsRedoxCyclesAsHarmful =
         paraquatWarnings[0]?.effects.some(effect => effect.a === 'redox cycles') === true;
@@ -112,7 +118,7 @@ test('supplement warning browser coverage exercises lookup scan urls and effect 
           { a: 'inhibits', f: 'Complex I', t: 'high dose' },
           { showContext: true },
         ) === 'may inhibit Complex I (high dose)';
-      outcomes.humanizeMappedVerbWithoutContext =
+      outcomes.humanizeMappedVerbNoContextField =
         warnings.humanizeEffect({ a: 'binds', f: 'CoQ10' }, { showContext: true }) === 'binds CoQ10';
       outcomes.humanizeUnknownVerbSingularizes =
         warnings.humanizeEffect({ a: 'protects', f: 'Complex I' }) === 'may protect Complex I';

--- a/tests/playwright/supplement-warnings-browser-coverage.spec.js
+++ b/tests/playwright/supplement-warnings-browser-coverage.spec.js
@@ -59,13 +59,11 @@ test('supplement warning browser coverage exercises lookup scan urls and effect 
       const tylenol = warnings.lookupMitoCompound('daily tylenol tablets');
       const shortAliasExact = warnings.lookupMitoCompound('nac');
       const shortAliasInPhrase = warnings.lookupMitoCompound('daily nac');
-      const hyphenatedKeyword = warnings.lookupMitoCompound('alpha-lipoic acid 600mg');
 
       outcomes.lookupExactNormalizesCaseAndTrim = metformin?.name === 'Metformin';
       outcomes.lookupWordBoundaryFindsKeywordInPhrase = tylenol?.name === 'Acetaminophen';
       outcomes.lookupShortExactKeywordWorks = shortAliasExact?.name === 'N-Acetylcysteine';
       outcomes.lookupShortKeywordDoesNotWordMatch = shortAliasInPhrase === null;
-      outcomes.lookupHyphenatedKeywordMatches = hyphenatedKeyword?.name === 'Alpha-Lipoic Acid';
       outcomes.lookupRejectsTooShortQueries = warnings.lookupMitoCompound('nr') === null;
       outcomes.lookupMissReturnsNull = warnings.lookupMitoCompound('made-up-compound') === null;
 


### PR DESCRIPTION
## Summary
- Add a focused Playwright browser coverage spec for `js/supplement-warnings.js`.
- Exercise mitochondrial data load failure paths, exact and word-boundary compound lookup, PubMed URL helpers, warning scan deduping, harmful/protective effect filtering, and humanized effect labels.

## Tests
- `npm run test:playwright -- tests/playwright/supplement-warnings-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/supplement-warnings-pw-cov-20260609-v2 npm run test:playwright -- tests/playwright/supplement-warnings-browser-coverage.spec.js`
- `PLAYWRIGHT_COVERAGE_DIR=/tmp/supplement-warnings-pw-cov-20260609-v2 REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 node scripts/playwright-coverage.mjs`

Focused row: `js/supplement-warnings.js` reached 7/7 functions covered (100%) and 54.48% byte coverage.