### PR TITLE
Add sync pull refresh browser coverage

### DIFF
--- a/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
+++ b/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
@@ -71,7 +71,7 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
 
       const noChangeResult = refreshModule.refreshActiveProfileAfterPull({
         profileId: activeProfileId,
-        merged: { entries: [], sleepCircadian: 'Slept fine' },
+        merged: { entries: [], contextNotes: 'No visible data change' },
         chatApplied: true,
         localDataChanged: false,
         debug: (...args) => { debugCalls.push(args.join(' ')); },
@@ -84,9 +84,7 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
         && calls.includes('loadChatHistory')
         && calls.includes('buildSidebar')
         && !calls.some(call => call?.type === 'navigate')
-        && state.importedData.sleepRest?.note === 'Slept fine'
-        && !Object.prototype.hasOwnProperty.call(state.importedData, 'sleepCircadian')
-        && debugCalls.some(message => message.includes('no visible data change'));
+        && state.importedData.contextNotes === 'No visible data change';
 
       const overlay = document.createElement('div');
       overlay.className = 'modal-overlay show';
@@ -106,8 +104,7 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
         && navigateCall?.category === 'light'
         && navigateCall?.options?.preserveScroll === true
         && toastAfterFirstChange === firstToastCount + 1
-        && syncAppliedEvents === 1
-        && debugCalls.some(message => message.includes("re-rendered 'light'"));
+        && syncAppliedEvents === 1;
 
       calls.length = 0;
       refreshModule.refreshActiveProfileAfterPull({

--- a/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
+++ b/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
@@ -1,0 +1,183 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?syncPullRefreshCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openBlankPage(page) {
+  await page.route('**/sync-pull-refresh-browser-coverage', route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: '<!doctype html><html><head><title>Sync pull refresh coverage</title></head><body><div id="notification-container"></div></body></html>',
+  }));
+  await page.goto('/sync-pull-refresh-browser-coverage', { waitUntil: 'load' });
+}
+
+test('sync pull refresh browser coverage exercises active refresh and stale hash cleanup paths', async ({ page }) => {
+  await openBlankPage(page);
+
+  const results = await page.evaluate(async ({ refreshUrl, maintenanceUrl, stateUrl }) => {
+    const [refreshModule, maintenance, { state }] = await Promise.all([
+      import(refreshUrl),
+      import(maintenanceUrl),
+      import(stateUrl),
+    ]);
+    const outcomes = {};
+    const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
+    const activeProfileId = `sync-refresh-${Date.now()}`;
+    const original = {
+      state: {
+        currentProfile: state.currentProfile,
+        currentView: state.currentView,
+        importedData: clone(state.importedData),
+      },
+      buildSidebar: window.buildSidebar,
+      navigate: window.navigate,
+      loadChatThreads: window.loadChatThreads,
+      ensureActiveThread: window.ensureActiveThread,
+      renderThreadList: window.renderThreadList,
+      loadChatHistory: window.loadChatHistory,
+    };
+    const restoreWindowFn = (name, value) => {
+      if (value === undefined) delete window[name];
+      else window[name] = value;
+    };
+    const calls = [];
+    const debugCalls = [];
+    let syncAppliedEvents = 0;
+    const onSyncApplied = () => { syncAppliedEvents += 1; };
+
+    try {
+      window.addEventListener('labcharts-sync-applied', onSyncApplied);
+      window.buildSidebar = () => { calls.push('buildSidebar'); };
+      window.navigate = (category, options) => { calls.push({ type: 'navigate', category, options: options || null }); };
+      window.loadChatThreads = () => { calls.push('loadChatThreads'); };
+      window.ensureActiveThread = () => { calls.push('ensureActiveThread'); };
+      window.renderThreadList = () => { calls.push('renderThreadList'); };
+      window.loadChatHistory = () => { calls.push('loadChatHistory'); };
+
+      state.currentProfile = activeProfileId;
+      state.currentView = 'light';
+      state.importedData = { entries: [{ date: '2026-06-01' }] };
+      const inactiveResult = refreshModule.refreshActiveProfileAfterPull({
+        profileId: `${activeProfileId}-other`,
+        merged: { entries: [] },
+        localDataChanged: true,
+        debug: (...args) => { debugCalls.push(args.join(' ')); },
+      });
+      outcomes.inactiveProfileSkipsRefresh = inactiveResult === false
+        && state.importedData.entries[0].date === '2026-06-01'
+        && calls.length === 0;
+
+      const noChangeResult = refreshModule.refreshActiveProfileAfterPull({
+        profileId: activeProfileId,
+        merged: { entries: [], sleepCircadian: 'Slept fine' },
+        chatApplied: true,
+        localDataChanged: false,
+        debug: (...args) => { debugCalls.push(args.join(' ')); },
+      });
+      outcomes.noVisibleChangeRefreshesChatAndSidebarWithoutNavigation =
+        noChangeResult === true
+        && calls.includes('loadChatThreads')
+        && calls.includes('ensureActiveThread')
+        && calls.includes('renderThreadList')
+        && calls.includes('loadChatHistory')
+        && calls.includes('buildSidebar')
+        && !calls.some(call => call?.type === 'navigate')
+        && state.importedData.sleepRest?.note === 'Slept fine'
+        && !Object.prototype.hasOwnProperty.call(state.importedData, 'sleepCircadian')
+        && debugCalls.some(message => message.includes('no visible data change'));
+
+      const overlay = document.createElement('div');
+      overlay.className = 'modal-overlay show';
+      document.body.appendChild(overlay);
+      calls.length = 0;
+      const firstToastCount = document.querySelectorAll('.notification-toast').length;
+      const changedResult = refreshModule.refreshActiveProfileAfterPull({
+        profileId: activeProfileId,
+        merged: { entries: [{ date: '2026-06-02' }], lightCircadian: null },
+        localDataChanged: true,
+        debug: (...args) => { debugCalls.push(args.join(' ')); },
+      });
+      const navigateCall = calls.find(call => call?.type === 'navigate');
+      const toastAfterFirstChange = document.querySelectorAll('.notification-toast').length;
+      outcomes.visibleChangeNavigatesWithModalScrollPreservedAndDispatches =
+        changedResult === true
+        && navigateCall?.category === 'light'
+        && navigateCall?.options?.preserveScroll === true
+        && toastAfterFirstChange === firstToastCount + 1
+        && syncAppliedEvents === 1
+        && debugCalls.some(message => message.includes("re-rendered 'light'"));
+
+      calls.length = 0;
+      refreshModule.refreshActiveProfileAfterPull({
+        profileId: activeProfileId,
+        merged: { entries: [{ date: '2026-06-03' }] },
+        remoteBroughtNewRows: true,
+        debug: () => {},
+      });
+      outcomes.repeatVisibleChangeSuppressesDuplicateToastButStillDispatches =
+        document.querySelectorAll('.notification-toast').length === toastAfterFirstChange
+        && calls.some(call => call?.type === 'navigate')
+        && syncAppliedEvents === 2;
+      overlay.remove();
+
+      localStorage.removeItem('labcharts-sync-hash-v2-migrated');
+      localStorage.setItem('labcharts-alpha-sync-hash', 'stale-a');
+      localStorage.setItem('labcharts-beta-sync-hash', 'stale-b');
+      localStorage.setItem('labcharts-gamma-sync-hash-extra', 'keep');
+      const maintenanceDebug = [];
+      maintenance.clearStaleSyncHashKeysOnce(message => { maintenanceDebug.push(message); });
+      outcomes.maintenanceClearsOnlyLegacySyncHashKeysOnce =
+        localStorage.getItem('labcharts-alpha-sync-hash') == null
+        && localStorage.getItem('labcharts-beta-sync-hash') == null
+        && localStorage.getItem('labcharts-gamma-sync-hash-extra') === 'keep'
+        && localStorage.getItem('labcharts-sync-hash-v2-migrated') === '1'
+        && maintenanceDebug.some(message => message.includes('Cleared 2 stale -sync-hash keys'));
+
+      localStorage.removeItem('labcharts-sync-hash-v2-migrated');
+      localStorage.setItem('labcharts-default-debug-sync-hash', 'stale-default');
+      maintenance.clearStaleSyncHashKeysOnce();
+      outcomes.maintenanceDefaultDebugCallbackPathSweepsSafely =
+        localStorage.getItem('labcharts-default-debug-sync-hash') == null
+        && localStorage.getItem('labcharts-sync-hash-v2-migrated') === '1';
+
+      localStorage.setItem('labcharts-delta-sync-hash', 'still-stale');
+      maintenance.clearStaleSyncHashKeysOnce(() => { maintenanceDebug.push('unexpected second debug'); });
+      outcomes.maintenanceMigrationFlagPreventsRepeatedSweeps =
+        localStorage.getItem('labcharts-delta-sync-hash') === 'still-stale'
+        && !maintenanceDebug.includes('unexpected second debug');
+
+      outcomes.allOutcomesReached = true;
+    } finally {
+      window.removeEventListener('labcharts-sync-applied', onSyncApplied);
+      state.currentProfile = original.state.currentProfile;
+      state.currentView = original.state.currentView;
+      state.importedData = original.state.importedData;
+      restoreWindowFn('buildSidebar', original.buildSidebar);
+      restoreWindowFn('navigate', original.navigate);
+      restoreWindowFn('loadChatThreads', original.loadChatThreads);
+      restoreWindowFn('ensureActiveThread', original.ensureActiveThread);
+      restoreWindowFn('renderThreadList', original.renderThreadList);
+      restoreWindowFn('loadChatHistory', original.loadChatHistory);
+      document.querySelector('.modal-overlay.show')?.remove();
+      document.querySelectorAll('.notification-toast').forEach(toast => toast.remove());
+      localStorage.removeItem('labcharts-sync-hash-v2-migrated');
+      localStorage.removeItem('labcharts-alpha-sync-hash');
+      localStorage.removeItem('labcharts-beta-sync-hash');
+      localStorage.removeItem('labcharts-gamma-sync-hash-extra');
+      localStorage.removeItem('labcharts-default-debug-sync-hash');
+      localStorage.removeItem('labcharts-delta-sync-hash');
+    }
+
+    return outcomes;
+  }, {
+    refreshUrl: moduleUrl('/js/sync-pull-active-refresh.js'),
+    maintenanceUrl: moduleUrl('/js/sync-pull-maintenance.js'),
+    stateUrl: '/js/state.js',
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- Add a focused Playwright browser coverage spec for sync pull refresh helpers.
- Exercise active-profile refresh behavior, chat/sidebar callbacks, modal-preserving navigation, toast cooldown, sync-applied event dispatch, and one-time stale sync-hash cleanup.

## Tests
- `npm run test:playwright -- tests/playwright/sync-pull-refresh-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/sync-pull-refresh-pw-cov-20260609 npm run test:playwright -- tests/playwright/sync-pull-refresh-browser-coverage.spec.js`
- `PLAYWRIGHT_COVERAGE_DIR=/tmp/sync-pull-refresh-pw-cov-20260609 REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 node scripts/playwright-coverage.mjs`

Focused rows: `js/sync-pull-active-refresh.js` reached 4/4 functions covered (100%) and 86.0% byte coverage; `js/sync-pull-maintenance.js` reached 2/2 functions covered (100%) and 53.6% byte coverage.