### PR TITLE
Add sync identity browser coverage

### DIFF
--- a/tests/playwright/sync-identity-browser-coverage.spec.js
+++ b/tests/playwright/sync-identity-browser-coverage.spec.js
@@ -1,0 +1,250 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?syncIdentityCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openIdentityPage(page) {
+  let bip39Requests = 0;
+  let qrRequests = 0;
+  await page.route('**/vendor/bip39-minimal.js', async route => {
+    bip39Requests += 1;
+    if (bip39Requests === 1) {
+      await route.abort();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/javascript',
+      body: 'window.bip39 = { loadedFromRoute: true, generateMnemonic: async () => "seed phrase" };',
+    });
+  });
+  await page.route('**/vendor/qrcode-generator.js', async route => {
+    qrRequests += 1;
+    if (qrRequests === 1) {
+      await route.abort();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/javascript',
+      body: `window.qrcode = function routedQRCode() {
+        return {
+          addData() {},
+          make() {},
+          createSvgTag() { return '<svg data-routed-qr="1"></svg>'; },
+        };
+      };`,
+    });
+  });
+  await page.route('**/sync-identity-browser-coverage', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><html><head></head><body><div id="notification-container"></div></body></html>',
+    });
+  });
+  await page.goto('/sync-identity-browser-coverage', { waitUntil: 'load' });
+}
+
+test('sync identity browser coverage handles libraries getters pending restore and failures', async ({ page }) => {
+  await openIdentityPage(page);
+
+  const results = await page.evaluate(async ({ identityUrl }) => {
+    const identity = await import(identityUrl);
+    const expectedOutcomes = [
+      'defaultInjectedDepsReturnEmpty',
+      'defaultSeedLocalDependencyIsCallable',
+      'ensureBip39UsesExistingGlobal',
+      'ensureBip39RetriesAfterFailure',
+      'ensureQRCodeUsesExistingGlobal',
+      'ensureQRCodeRetriesAfterFailure',
+      'mnemonicGettersUseInjectedOwner',
+      'mnemonicGettersHandleThrownDeps',
+      'pendingFlagReadsAndClears',
+      'restoreJoinClearsSyncStorageAndMarksPending',
+      'restoreSeedLocalClearsPendingAndSeeds',
+      'restoreFailureNotifiesAndReturnsFalse',
+      'restoreWithoutEvoluReturnsFalse',
+    ];
+    const outcomes = Object.fromEntries(expectedOutcomes.map(name => [name, false]));
+    const storage = new Map(
+      Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index))
+        .filter(key => key !== null)
+        .map(key => [key, localStorage.getItem(key)])
+    );
+    const hadBip39 = Object.prototype.hasOwnProperty.call(window, 'bip39');
+    const savedBip39 = window.bip39;
+    const hadQRCode = Object.prototype.hasOwnProperty.call(window, 'qrcode');
+    const savedQRCode = window.qrcode;
+    const savedSetTimeout = window.setTimeout;
+    const savedBody = document.body.innerHTML;
+    const savedScripts = Array.from(document.scripts).map(script => script.getAttribute('src')).filter(Boolean);
+    const notifications = () => document.getElementById('notification-container')?.textContent || '';
+    const clearNotifications = () => {
+      document.getElementById('notification-container').innerHTML = '';
+      document.querySelectorAll('.notification-toast').forEach(toast => toast.remove());
+    };
+    const scheduledDelays = [];
+
+    try {
+      localStorage.clear();
+      document.body.innerHTML = '<div id="notification-container"></div>';
+      window.setTimeout = (_fn, delay = 0) => {
+        scheduledDelays.push(delay);
+        return scheduledDelays.length;
+      };
+
+      outcomes.defaultInjectedDepsReturnEmpty = identity.getMnemonic() === null
+        && identity.getMnemonicResolutionError() === null
+        && await identity.restoreFromMnemonic('missing evolu') === false;
+
+      identity.configureSyncIdentity({
+        getEvolu: () => ({ restoreAppOwner: async () => {} }),
+      });
+      clearNotifications();
+      scheduledDelays.length = 0;
+      const defaultSeedResult = await identity.restoreFromMnemonic('default seed mnemonic', { seedLocal: true });
+      outcomes.defaultSeedLocalDependencyIsCallable = defaultSeedResult === true
+        && identity.isRestoreJoinPending() === false
+        && scheduledDelays.includes(500)
+        && notifications().includes('seeded this device');
+
+      window.bip39 = { existing: true };
+      outcomes.ensureBip39UsesExistingGlobal = await identity.ensureBip39() === window.bip39;
+      delete window.bip39;
+      let bip39LoadFailed = false;
+      try {
+        await identity.ensureBip39();
+      } catch (error) {
+        bip39LoadFailed = String(error?.message || error).includes('Failed to load');
+      }
+      document.querySelector('script[src="/vendor/bip39-minimal.js"]')?.remove();
+      const loadedBip39 = await identity.ensureBip39();
+      outcomes.ensureBip39RetriesAfterFailure = bip39LoadFailed
+        && loadedBip39?.loadedFromRoute === true
+        && window.bip39 === loadedBip39;
+
+      window.qrcode = function existingQRCode() {};
+      outcomes.ensureQRCodeUsesExistingGlobal = await identity.ensureQRCode() === window.qrcode;
+      delete window.qrcode;
+      let qrLoadFailed = false;
+      try {
+        await identity.ensureQRCode();
+      } catch (error) {
+        qrLoadFailed = String(error?.message || error).includes('Failed to load');
+      }
+      document.querySelector('script[src="/vendor/qrcode-generator.js"]')?.remove();
+      const loadedQRCode = await identity.ensureQRCode();
+      outcomes.ensureQRCodeRetriesAfterFailure = qrLoadFailed
+        && typeof loadedQRCode === 'function'
+        && loadedQRCode().createSvgTag().includes('data-routed-qr');
+
+      identity.configureSyncIdentity({
+        getAppOwner: () => ({ mnemonic: 'alpha bravo charlie' }),
+        getAppOwnerError: () => 'owner blocked',
+      });
+      outcomes.mnemonicGettersUseInjectedOwner = identity.getMnemonic() === 'alpha bravo charlie'
+        && identity.getMnemonicResolutionError() === 'owner blocked';
+
+      identity.configureSyncIdentity({
+        getAppOwner: () => { throw new Error('owner getter failed'); },
+        getAppOwnerError: () => { throw new Error('error getter failed'); },
+      });
+      outcomes.mnemonicGettersHandleThrownDeps = identity.getMnemonic() === null
+        && identity.getMnemonicResolutionError() === null;
+
+      localStorage.setItem(identity.RESTORE_JOIN_PENDING_KEY, '1');
+      outcomes.pendingFlagReadsAndClears = identity.isRestoreJoinPending() === true;
+      identity.clearRestoreJoinPending();
+      outcomes.pendingFlagReadsAndClears &&= identity.isRestoreJoinPending() === false;
+
+      const cleanupKeys = [
+        'coverage-profile-sync-ts',
+        'coverage-profile-delta-snapshot',
+        'coverage-profile-sync-cutover-v2',
+        'coverage-profile-relay-bytes-owner',
+        'labcharts-relay-quota-warned',
+        identity.RESTORE_JOIN_PENDING_KEY,
+      ];
+      const cleanupKeysClearedByJoinRestore = cleanupKeys
+        .filter(key => key !== identity.RESTORE_JOIN_PENDING_KEY);
+      for (const key of cleanupKeys) localStorage.setItem(key, 'remove-me');
+      localStorage.setItem('coverage-keep-key', 'keep-me');
+
+      scheduledDelays.length = 0;
+      const restoreCalls = [];
+      let seedCalls = 0;
+      const evolu = {
+        restoreAppOwner: async mnemonic => { restoreCalls.push(mnemonic); },
+      };
+      identity.configureSyncIdentity({
+        getEvolu: () => evolu,
+        seedLocalProfiles: async () => { seedCalls += 1; },
+      });
+
+      clearNotifications();
+      const joinResult = await identity.restoreFromMnemonic('join owner mnemonic');
+      outcomes.restoreJoinClearsSyncStorageAndMarksPending = joinResult === true
+        && restoreCalls[0] === 'join owner mnemonic'
+        && seedCalls === 0
+        && identity.isRestoreJoinPending() === true
+        && cleanupKeysClearedByJoinRestore.every(key => localStorage.getItem(key) === null)
+        && localStorage.getItem(identity.RESTORE_JOIN_PENDING_KEY) !== null
+        && localStorage.getItem(identity.RESTORE_JOIN_PENDING_KEY) !== 'remove-me'
+        && localStorage.getItem('coverage-keep-key') === 'keep-me'
+        && scheduledDelays.includes(500)
+        && notifications().includes('Restored from mnemonic');
+
+      clearNotifications();
+      scheduledDelays.length = 0;
+      const seededResult = await identity.restoreFromMnemonic('seed local mnemonic', { seedLocal: true });
+      outcomes.restoreSeedLocalClearsPendingAndSeeds = seededResult === true
+        && restoreCalls[1] === 'seed local mnemonic'
+        && seedCalls === 1
+        && identity.isRestoreJoinPending() === false
+        && scheduledDelays.includes(500)
+        && notifications().includes('seeded this device');
+
+      clearNotifications();
+      identity.configureSyncIdentity({
+        getEvolu: () => ({ restoreAppOwner: async () => { throw new Error('bad seed'); } }),
+      });
+      const failureResult = await identity.restoreFromMnemonic('bad mnemonic');
+      outcomes.restoreFailureNotifiesAndReturnsFalse = failureResult === false
+        && notifications().includes('Invalid mnemonic');
+
+      identity.configureSyncIdentity({ getEvolu: () => null });
+      outcomes.restoreWithoutEvoluReturnsFalse = await identity.restoreFromMnemonic('missing evolu') === false;
+    } finally {
+      window.setTimeout = savedSetTimeout;
+      if (hadBip39) window.bip39 = savedBip39;
+      else delete window.bip39;
+      if (hadQRCode) window.qrcode = savedQRCode;
+      else delete window.qrcode;
+      identity.configureSyncIdentity({
+        getAppOwner: () => null,
+        getAppOwnerError: () => null,
+        getEvolu: () => null,
+        seedLocalProfiles: async () => {},
+      });
+      localStorage.clear();
+      for (const [key, value] of storage) {
+        if (key && value != null) localStorage.setItem(key, value);
+      }
+      for (const script of Array.from(document.scripts)) {
+        const src = script.getAttribute('src');
+        if (src && !savedScripts.includes(src)) script.remove();
+      }
+      document.body.innerHTML = savedBody;
+    }
+
+    return outcomes;
+  }, {
+    identityUrl: moduleUrl('/js/sync-identity.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- add a focused Playwright browser coverage spec for sync identity restore flows
- cover lazy BIP39/QRCode loader success, failure, and retry paths
- cover mnemonic getter injection, restore pending storage, local seed restore, join restore, cleanup, and failure notifications
- address Greptile feedback by pre-initializing expected outcomes and covering the restore-pending cleanup key branch

## Focused coverage
- `js/sync-identity.js`: 15/15 functions (100.0%), 75.6% bytes
- `js/sync-disable-cleanup.js`: 2/2 functions (100.0%), 86.3% bytes

## Tests
- `npm run test:playwright -- tests/playwright/sync-identity-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/sync-identity-pw-cov-20260609e npm run test:playwright -- tests/playwright/sync-identity-browser-coverage.spec.js`
- `PLAYWRIGHT_COVERAGE_DIR=/tmp/sync-identity-pw-cov-20260609e REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 node scripts/playwright-coverage.mjs`