### PR TITLE
Add light sessions view edge coverage

### DIFF
--- a/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
+++ b/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
@@ -1,0 +1,139 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?lightSessionsViewEdgeCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+test('light sessions view edge coverage handles empty and compact device history states', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('body');
+
+  const results = await page.evaluate(async ({ sessionsUrl }) => {
+    const sessionsView = await import(sessionsUrl);
+    const outcomes = {};
+    const calls = [];
+    const base = Date.UTC(2026, 5, 10, 10, 0);
+    const saved = {
+      getSessions: window.getSessions,
+      getDeviceSessions: window.getDeviceSessions,
+      getDevices: window.getDevices,
+      renderSunSessionRow: window.renderSunSessionRow,
+      openDeviceSessionDetail: window.openDeviceSessionDetail,
+      deleteDeviceSession: window.deleteDeviceSession,
+      renderDeviceSessionAIInline: window.renderDeviceSessionAIInline,
+      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
+      channelTier: window.channelTier,
+      formatChannelUnit: window.formatChannelUnit,
+    };
+    const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    try {
+      window.getSessions = () => [];
+      window.getDeviceSessions = () => [];
+      window.getDevices = () => [];
+      window.renderSunSessionRow = sess => `<div class="sun-session light-session-row light-session-sun" data-id="${sess.id}" role="button">${sess.id}</div>`;
+      window.openDeviceSessionDetail = id => calls.push(['detail', id]);
+      window.deleteDeviceSession = id => calls.push(['delete', id]);
+      window.renderDeviceSessionAIInline = sess => `<span class="ai-inline">AI ${sess.id}</span>`;
+      window.CHANNEL_DISPLAY = {
+        pbm_red: { icon: 'R', label: 'Red <unsafe>', what: 'Red channel' },
+        pbm_nir: { icon: 'N', label: 'NIR', what: 'Near infrared' },
+      };
+      window.channelTier = (value, key) => key === 'pbm_nir' && value > 0 ? 3 : 0;
+      window.formatChannelUnit = (key, value) => `${Math.round(value)} ${key}`;
+
+      outcomes.emptyInlineReturnsBlank = sessionsView.renderUnifiedSessionsList() === '';
+      sessionsView._openAllSessionsModal();
+      let overlay = document.querySelector('.light-sessions-modal-overlay');
+      outcomes.emptyModalRendersSummaryAndEmptyState = overlay?.textContent.includes('All sessions (0)') === true
+        && overlay?.textContent.includes('No completed sessions yet.') === true
+        && overlay?.querySelectorAll('.sun-session').length === 0;
+      overlay?.remove();
+
+      window.getSessions = () => [
+        { id: 'sun-only-a', startedAt: base - 60000, endedAt: base, durationMin: 10 },
+        { id: 'sun-active', startedAt: base + 1000, endedAt: null, durationMin: 0 },
+      ];
+      window.getDeviceSessions = () => [];
+      const sunOnlyHost = document.createElement('div');
+      sunOnlyHost.innerHTML = sessionsView.renderUnifiedSessionsList();
+      outcomes.sunOnlyInlineHasNoUnifiedClassOrShowMore = sunOnlyHost.querySelectorAll('.sun-session').length === 1
+        && !sunOnlyHost.querySelector('.light-sessions-list-unified')
+        && !sunOnlyHost.querySelector('.light-sessions-show-more');
+
+      window.getSessions = () => [];
+      window.getDevices = () => [{
+        id: 'panel-a',
+        brand: 'Panel <Co>',
+        model: 'Red & NIR',
+        modes: [
+          { id: 'red', label: 'Red only', default: true },
+          { id: 'nir', label: 'NIR boost' },
+        ],
+      }];
+      window.getDeviceSessions = () => [
+        {
+          id: 'dev-nir',
+          deviceId: 'panel-a',
+          startedAt: base,
+          endedAt: base + 60000,
+          durationMin: 9.6,
+          distanceCm: 18,
+          bodyArea: 'hands',
+          eyesProtected: true,
+          doses: { pbm_red: 0, pbm_nir: 4.2 },
+          mode: 'nir',
+        },
+        {
+          id: 'dev-removed',
+          deviceId: 'missing-panel',
+          startedAt: base - 60000,
+          endedAt: base,
+          durationMin: 0,
+          distanceCm: 30,
+          bodyArea: '',
+          eyesProtected: false,
+          doses: {},
+        },
+        { id: 'dev-active', deviceId: 'panel-a', startedAt: base + 1000, endedAt: null },
+      ];
+      const mixedHost = document.createElement('div');
+      mixedHost.innerHTML = sessionsView.renderUnifiedSessionsList();
+      const nirRow = mixedHost.querySelector('.light-session-device[data-id="dev-nir"]');
+      const removedRow = mixedHost.querySelector('.light-session-device[data-id="dev-removed"]');
+      outcomes.deviceInlineRendersEscapedModeChipsAndFallbacks =
+        mixedHost.querySelectorAll('.sun-session').length === 2
+        && mixedHost.querySelector('.light-sessions-list-unified') !== null
+        && !mixedHost.querySelector('.light-sessions-show-more')
+        && nirRow?.getAttribute('aria-label')?.includes('Panel <Co> Red & NIR mode NIR boost') === true
+        && nirRow?.querySelector('.light-session-mode-chip-accent')?.textContent === 'NIR boost'
+        && nirRow?.querySelector('.sun-chip[data-channel="pbm_nir"]')?.getAttribute('title') === 'Near infrared — this session: 4 pbm_nir'
+        && nirRow?.querySelectorAll('.sun-chip').length === 1
+        && removedRow?.textContent.includes('Removed device') === true
+        && removedRow?.textContent.includes('— @ 30cm') === true;
+
+      nirRow?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      nirRow?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+      outcomes.inlineRowClickAndEnterCallDetail = calls.filter(call => call[0] === 'detail' && call[1] === 'dev-nir').length === 2;
+
+      sessionsView._openAllSessionsModal();
+      overlay = document.querySelector('.light-sessions-modal-overlay');
+      const modalRow = overlay?.querySelector('.light-session-device[data-id="dev-nir"]');
+      modalRow?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+      await delay(0);
+      outcomes.modalEnterClosesAfterOpeningDetail = !document.body.contains(overlay)
+        && calls.some(call => call[0] === 'detail' && call[1] === 'dev-nir');
+    } finally {
+      Object.assign(window, saved);
+      document.querySelectorAll('.light-sessions-modal-overlay').forEach(el => el.remove());
+    }
+
+    return outcomes;
+  }, {
+    sessionsUrl: moduleUrl('/js/light-sessions-view.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});

--- a/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
+++ b/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
@@ -119,10 +119,11 @@ test('light sessions view edge coverage handles empty and compact device history
       sessionsView._openAllSessionsModal();
       overlay = document.querySelector('.light-sessions-modal-overlay');
       const modalRow = overlay?.querySelector('.light-session-device[data-id="dev-nir"]');
+      const detailCallsBeforeModalEnter = calls.filter(call => call[0] === 'detail' && call[1] === 'dev-nir').length;
       modalRow?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
       await delay(0);
       outcomes.modalEnterClosesAfterOpeningDetail = !document.body.contains(overlay)
-        && calls.some(call => call[0] === 'detail' && call[1] === 'dev-nir');
+        && calls.filter(call => call[0] === 'detail' && call[1] === 'dev-nir').length === detailCallsBeforeModalEnter + 1;
     } finally {
       Object.assign(window, saved);
       document.querySelectorAll('.light-sessions-modal-overlay').forEach(el => el.remove());

--- a/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
+++ b/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
@@ -28,7 +28,7 @@ test('wearables detail modal covers delegated manual add save and cancel flows',
     const originalRange = localStorage.getItem('wearable-detail-range');
     const calls = [];
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-    const waitFor = async (predicate, attempts = 120) => {
+    const waitFor = async (predicate, attempts = 300) => {
       for (let i = 0; i < attempts; i += 1) {
         if (await predicate()) return true;
         await delay(10);
@@ -37,10 +37,13 @@ test('wearables detail modal covers delegated manual add save and cancel flows',
     };
     const openAddForm = async metric => {
       await window.openWearableDetail(metric);
-      await waitFor(() => document.getElementById('modal-overlay')?.classList.contains('show')
-        && !!document.querySelector(`#detail-modal [data-wearable-action="open-detail-manual-add"][data-wearable-metric="${metric}"]`));
-      document.querySelector(`#detail-modal [data-wearable-action="open-detail-manual-add"][data-wearable-metric="${metric}"]`)?.click();
-      await waitFor(() => !!document.querySelector('#detail-modal .wearable-manual-add-form'));
+      const triggerSelector = `#detail-modal [data-wearable-action="open-detail-manual-add"][data-wearable-metric="${metric}"]`;
+      const triggerReady = await waitFor(() => document.getElementById('modal-overlay')?.classList.contains('show')
+        && !!document.querySelector(triggerSelector));
+      if (!triggerReady) throw new Error(`manual add trigger not ready for ${metric}`);
+      document.querySelector(triggerSelector)?.click();
+      const formReady = await waitFor(() => !!document.querySelector('#detail-modal .wearable-manual-add-form'));
+      if (!formReady) throw new Error(`manual add form not ready for ${metric}`);
       return document.querySelector('#detail-modal .wearable-manual-add-form');
     };
 

--- a/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
+++ b/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
@@ -35,12 +35,20 @@ test('wearables detail modal covers delegated manual add save and cancel flows',
       }
       return false;
     };
+    const closeDetailModal = async () => {
+      try { window.closeModal?.(); } catch (_) {}
+      await waitFor(() => !document.getElementById('modal-overlay')?.classList.contains('show'), 100);
+    };
+    const debugManualButtons = () => Array.from(document.querySelectorAll('#detail-modal [data-wearable-action="open-detail-manual-add"]'))
+      .map(el => el.dataset.wearableMetric || 'unknown')
+      .join(',') || 'none';
     const openAddForm = async metric => {
+      await closeDetailModal();
       await window.openWearableDetail(metric);
       const triggerSelector = `#detail-modal [data-wearable-action="open-detail-manual-add"][data-wearable-metric="${metric}"]`;
       const triggerReady = await waitFor(() => document.getElementById('modal-overlay')?.classList.contains('show')
         && !!document.querySelector(triggerSelector));
-      if (!triggerReady) throw new Error(`manual add trigger not ready for ${metric}`);
+      if (!triggerReady) throw new Error(`manual add trigger not ready for ${metric}; available add buttons: ${debugManualButtons()}`);
       document.querySelector(triggerSelector)?.click();
       const formReady = await waitFor(() => !!document.querySelector('#detail-modal .wearable-manual-add-form'));
       if (!formReady) throw new Error(`manual add form not ready for ${metric}`);


### PR DESCRIPTION
## Summary
- add Playwright coverage for light sessions view edge states
- cover empty inline/modal states, compact sun-only history, missing-device fallback rows, non-default mode chips, channel chip filtering, and keyboard modal close behavior
- harden the existing wearables detail manual coverage helper after CI exposed a slow modal readiness race

## Tests
- `npm run test:playwright -- tests/playwright/light-sessions-view-edge-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/light-sessions-view-edge-browser-coverage.spec.js tests/playwright/all-sessions-modal.spec.js tests/playwright/modal-session-coverage-batch.spec.js`
- `npm run test:playwright -- tests/playwright/wearables-detail-manual-browser-coverage.spec.js tests/playwright/light-sessions-view-edge-browser-coverage.spec.js`