### PR TITLE
Add browser coverage for lens local worker

### DIFF
--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -165,17 +165,17 @@ self.addEventListener('message', async (e) => {
   const msg = e.data || {};
   try {
     switch (msg.type) {
-      case 'init':              return handleInit();
-      case 'ingest':            return handleIngest(msg.files || []);
-      case 'query':             return handleQuery(msg.text, msg.topK || 10);
+      case 'init':              return await handleInit();
+      case 'ingest':            return await handleIngest(msg.files || []);
+      case 'query':             return await handleQuery(msg.text, msg.topK || 10);
       case 'stats':             return handleStats();
-      case 'delete':            return handleDelete(msg.source);
-      case 'clear':             return handleClear();
+      case 'delete':            return await handleDelete(msg.source);
+      case 'clear':             return await handleClear();
       case 'list_libraries':    return handleListLibraries();
-      case 'activate_library':  return handleActivateLibrary(msg.libraryId);
-      case 'create_library':    return handleCreateLibrary(msg.name, msg.model);
-      case 'rename_library':    return handleRenameLibrary(msg.libraryId, msg.name);
-      case 'delete_library':    return handleDeleteLibrary(msg.libraryId);
+      case 'activate_library':  return await handleActivateLibrary(msg.libraryId);
+      case 'create_library':    return await handleCreateLibrary(msg.name, msg.model);
+      case 'rename_library':    return await handleRenameLibrary(msg.libraryId, msg.name);
+      case 'delete_library':    return await handleDeleteLibrary(msg.libraryId);
       // Abort is a side-channel signal — skips the serial queue on the
       // main thread so it can interrupt an in-flight ingest. handleIngest
       // polls _abortRequested between embeds and commits whatever's been

--- a/tests/playwright/coverage-fixture.js
+++ b/tests/playwright/coverage-fixture.js
@@ -7,6 +7,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const coverageDir = process.env.PLAYWRIGHT_COVERAGE_DIR ||
   path.join(repoRoot, 'tests', '.playwright-coverage');
 const startedPages = new WeakSet();
+const coverageStates = new WeakMap();
 
 function isCoverageEnabled() {
   return process.env.PLAYWRIGHT_SUITE_COVERAGE === '1' ||
@@ -50,24 +51,139 @@ function shrinkEntry(entry) {
   };
 }
 
+async function startWorkerCoverage(page) {
+  const client = await page.context().newCDPSession(page);
+  const sessions = new Map();
+  const pending = new Map();
+  let nextId = 1;
+
+  const sendToTarget = async (sessionId, method, params = {}) => {
+    const id = nextId;
+    nextId += 1;
+    const key = `${sessionId}:${id}`;
+    const response = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(key);
+        reject(new Error(`CDP ${method} timed out for worker target`));
+      }, 5000);
+      pending.set(key, { resolve, reject, timer });
+    });
+    await client.send('Target.sendMessageToTarget', {
+      sessionId,
+      message: JSON.stringify({ id, method, params }),
+    });
+    return response;
+  };
+
+  client.on('Target.receivedMessageFromTarget', ({ sessionId, message }) => {
+    let parsed;
+    try {
+      parsed = JSON.parse(message);
+    } catch {
+      return;
+    }
+    if (!parsed.id) return;
+    const key = `${sessionId}:${parsed.id}`;
+    const waiter = pending.get(key);
+    if (!waiter) return;
+    pending.delete(key);
+    clearTimeout(waiter.timer);
+    if (parsed.error) waiter.reject(new Error(parsed.error.message || JSON.stringify(parsed.error)));
+    else waiter.resolve(parsed.result || {});
+  });
+
+  client.on('Target.attachedToTarget', async ({ sessionId, targetInfo }) => {
+    const isWorker = targetInfo?.type === 'worker' || targetInfo?.type === 'shared_worker';
+    if (isWorker) sessions.set(sessionId, { targetInfo, started: false, detached: false });
+    try {
+      if (isWorker) {
+        await sendToTarget(sessionId, 'Profiler.enable');
+        await sendToTarget(sessionId, 'Profiler.startPreciseCoverage', {
+          callCount: true,
+          detailed: true,
+        });
+        const session = sessions.get(sessionId);
+        if (session) session.started = true;
+      }
+    } finally {
+      await sendToTarget(sessionId, 'Runtime.runIfWaitingForDebugger').catch(() => {});
+    }
+  });
+
+  client.on('Target.detachedFromTarget', ({ sessionId }) => {
+    const session = sessions.get(sessionId);
+    if (session) session.detached = true;
+  });
+
+  await client.send('Target.setAutoAttach', {
+    autoAttach: true,
+    waitForDebuggerOnStart: true,
+    flatten: false,
+  });
+
+  return { client, sessions, sendToTarget };
+}
+
+async function stopWorkerCoverage(workerState) {
+  if (!workerState) return [];
+  const entries = [];
+  try {
+    for (const [sessionId, session] of workerState.sessions) {
+      if (!session.started || session.detached) continue;
+      try {
+        const coverage = await workerState.sendToTarget(sessionId, 'Profiler.takePreciseCoverage');
+        for (const entry of coverage.result || []) {
+          entries.push({
+            url: entry.url,
+            functions: entry.functions,
+            rawScriptCoverage: { functions: entry.functions },
+          });
+        }
+        await workerState.sendToTarget(sessionId, 'Profiler.stopPreciseCoverage').catch(() => {});
+        await workerState.sendToTarget(sessionId, 'Profiler.disable').catch(() => {});
+      } catch {
+        // Workers can disappear during page teardown; page coverage remains useful.
+      }
+    }
+  } finally {
+    await workerState.client.send('Target.setAutoAttach', {
+      autoAttach: false,
+      waitForDebuggerOnStart: false,
+      flatten: false,
+    }).catch(() => {});
+    await workerState.client.detach().catch(() => {});
+  }
+  return entries;
+}
+
 export async function startPageCoverage(page) {
   if (!isCoverageEnabled() || startedPages.has(page)) return;
+  let workerState = null;
+  try {
+    workerState = await startWorkerCoverage(page);
+  } catch {
+    workerState = null;
+  }
   await page.coverage.startJSCoverage({
     resetOnNavigation: false,
     reportAnonymousScripts: false,
     includeRawScriptCoverage: true,
   });
   startedPages.add(page);
+  coverageStates.set(page, { workerState });
 }
 
 export async function stopPageCoverage(page, testInfo, label = 'page') {
   if (!isCoverageEnabled() || !startedPages.has(page)) return;
+  const state = coverageStates.get(page) || {};
   let entries = [];
   try {
     entries = await page.coverage.stopJSCoverage();
   } finally {
     startedPages.delete(page);
+    coverageStates.delete(page);
   }
+  entries.push(...await stopWorkerCoverage(state.workerState));
   fs.mkdirSync(coverageDir, { recursive: true });
   fs.writeFileSync(coverageFile(testInfo, label), JSON.stringify({
     title: testInfo.title,

--- a/tests/playwright/lens-local-worker-browser-coverage.spec.js
+++ b/tests/playwright/lens-local-worker-browser-coverage.spec.js
@@ -1,0 +1,160 @@
+import { expect, test } from './coverage-fixture.js';
+
+test('lens local worker browser coverage exercises mocked protocol and libraries', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const failures = await page.evaluate(async () => {
+    const failures = [];
+    const events = [];
+    const check = (name, condition, detail = '') => {
+      if (!condition) failures.push(detail ? `${name}: ${detail}` : name);
+    };
+
+    try {
+      const root = await navigator.storage.getDirectory();
+      await root.removeEntry('lens-local', { recursive: true }).catch(() => {});
+    } catch (error) {
+      failures.push(`opfs setup failed: ${error?.message || String(error)}`);
+      return failures;
+    }
+    localStorage.removeItem('labcharts-lens-local-count');
+
+    const worker = new Worker('/js/lens-local-worker.js?mock=1', { type: 'module' });
+    const roundTrip = (msg, expectedType, timeoutMs = 5000) => new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        worker.removeEventListener('message', onMessage);
+        reject(new Error(`worker did not respond with ${expectedType}`));
+      }, timeoutMs);
+      const onMessage = (event) => {
+        const data = event.data || {};
+        events.push(data);
+        if (data.type === 'progress') return;
+        clearTimeout(timer);
+        worker.removeEventListener('message', onMessage);
+        if (data.type === 'error') reject(new Error(data.message || 'worker error'));
+        else if (data.type === expectedType) resolve(data);
+        else reject(new Error(`expected ${expectedType}, got ${data.type || 'unknown'}`));
+      };
+      worker.addEventListener('message', onMessage);
+      worker.postMessage(msg);
+    });
+    const expectWorkerError = async (msg, pattern) => {
+      try {
+        await roundTrip(msg, '__not_expected__', 1500);
+        return { ok: false, message: 'no error returned' };
+      } catch (error) {
+        const message = error?.message || String(error);
+        return { ok: pattern.test(message), message };
+      }
+    };
+
+    try {
+      const ready = await roundTrip({ type: 'init' }, 'ready');
+      check('init starts with empty default library',
+        ready.numChunks === 0
+        && ready.numDocs === 0
+        && ready.activeId === 'default'
+        && ready.activeModel === 'all-minilm'
+        && ready.models?.['all-minilm']?.dim === 384
+        && ready.libraries?.some(lib => lib.id === 'default'));
+
+      const unknownType = await expectWorkerError({ type: 'not-a-real-worker-message' }, /unknown message type/i);
+      check('unknown message type reports error', unknownType.ok, unknownType.message);
+
+      const files = [
+        { name: 'vitamin-d.md', text: 'Vitamin D and UVB signaling support circadian timing. '.repeat(24) },
+        { name: 'mitochondria.md', text: 'Near infrared light and cytochrome c oxidase support mitochondrial signaling. '.repeat(24) },
+        { name: 'sleep.md', text: 'Blue light around 480 nanometers suppresses melatonin at night. '.repeat(24) },
+      ];
+      const ingest = await roundTrip({ type: 'ingest', files }, 'ingest_done', 10000);
+      check('ingest indexes chunks and emits progress',
+        ingest.stats?.files_seen === 3
+        && ingest.stats?.chunks_indexed > 0
+        && ingest.stats?.chunks_planned >= ingest.stats?.chunks_indexed
+        && ingest.stats?.cancelled === false
+        && events.some(event => event.type === 'progress' && event.stage === 'start')
+        && events.some(event => event.type === 'progress' && event.stage === 'embed'));
+
+      const stats = await roundTrip({ type: 'stats' }, 'stats_result');
+      check('stats reflect ingest and model metadata',
+        stats.total_chunks === ingest.stats.chunks_indexed
+        && stats.documents?.length === 3
+        && stats.dim === 384
+        && stats.model === 'Xenova/all-MiniLM-L6-v2'
+        && (stats.backend === 'wasm' || stats.backend === 'webgpu'));
+
+      const query = await roundTrip({ type: 'query', text: 'vitamin D light mitochondria', topK: 2 }, 'query_result');
+      const firstChunk = query.chunks?.[0];
+      check('query returns scored chunk matches',
+        query.chunks?.length > 0
+        && query.chunks.length <= 2
+        && typeof firstChunk?.text === 'string'
+        && typeof firstChunk?.source === 'string'
+        && typeof firstChunk?.score === 'number'
+        && firstChunk.score >= -1
+        && firstChunk.score <= 1);
+
+      const missingDelete = await roundTrip({ type: 'delete', source: 'missing.md' }, 'delete_done');
+      check('delete missing source is a no-op', missingDelete.deleted_chunks === 0);
+
+      const deleted = await roundTrip({ type: 'delete', source: 'mitochondria.md' }, 'delete_done');
+      const afterDelete = await roundTrip({ type: 'stats' }, 'stats_result');
+      check('delete removes source chunks and stats',
+        deleted.deleted_chunks > 0
+        && afterDelete.total_chunks === stats.total_chunks - deleted.deleted_chunks
+        && !afterDelete.documents.some(doc => doc.source === 'mitochondria.md'));
+
+      await roundTrip({ type: 'clear' }, 'clear_done');
+      const emptyQuery = await roundTrip({ type: 'query', text: 'anything', topK: 5 }, 'query_result');
+      check('clear empties corpus and empty query returns no chunks',
+        Array.isArray(emptyQuery.chunks) && emptyQuery.chunks.length === 0);
+
+      const bge = await roundTrip({ type: 'create_library', name: 'Research', model: 'bge-small-en' }, 'library_created');
+      const fallback = await roundTrip({ type: 'create_library', name: '', model: 'typo-model' }, 'library_created');
+      const unnamed = await roundTrip({ type: 'create_library' }, 'library_created');
+      check('create library persists model choices and fallback labels',
+        bge.name === 'Research'
+        && bge.model === 'bge-small-en'
+        && fallback.name === 'Untitled library'
+        && fallback.model === 'all-minilm'
+        && unnamed.name === 'Untitled library'
+        && unnamed.model === 'all-minilm');
+
+      const listed = await roundTrip({ type: 'list_libraries' }, 'libraries_list');
+      check('list libraries includes valid model metadata',
+        listed.libraries.length >= 4
+        && listed.libraries.every(lib => typeof lib.model === 'string'));
+
+      const renamed = await roundTrip({ type: 'rename_library', libraryId: bge.id, name: 'Kruse Research' }, 'library_renamed');
+      const activeBge = await roundTrip({ type: 'activate_library', libraryId: bge.id }, 'ready');
+      const sameActive = await roundTrip({ type: 'activate_library', libraryId: bge.id }, 'ready');
+      check('rename and activate library update active context',
+        renamed.name === 'Kruse Research'
+        && activeBge.activeId === bge.id
+        && activeBge.activeModel === 'bge-small-en'
+        && sameActive.activeId === bge.id);
+
+      const missingActivate = await expectWorkerError({ type: 'activate_library', libraryId: 'missing-library' }, /no library/i);
+      const missingRename = await expectWorkerError({ type: 'rename_library', libraryId: 'missing-library', name: 'Nope' }, /no library/i);
+      const missingDeleteLibrary = await expectWorkerError({ type: 'delete_library', libraryId: 'missing-library' }, /no library/i);
+      check('missing activate library reports error', missingActivate.ok, missingActivate.message);
+      check('missing rename library reports error', missingRename.ok, missingRename.message);
+      check('missing delete library reports error', missingDeleteLibrary.ok, missingDeleteLibrary.message);
+
+      await roundTrip({ type: 'activate_library', libraryId: 'default' }, 'ready');
+      const deleteFallback = await roundTrip({ type: 'delete_library', libraryId: fallback.id }, 'library_deleted');
+      const deleteUnnamed = await roundTrip({ type: 'delete_library', libraryId: unnamed.id }, 'library_deleted');
+      check('delete library removes non-active libraries',
+        !deleteFallback.libraries.some(lib => lib.id === fallback.id)
+        && !deleteUnnamed.libraries.some(lib => lib.id === unnamed.id));
+
+      await roundTrip({ type: 'clear' }, 'clear_done');
+    } catch (error) {
+      failures.push(error?.message || String(error));
+    }
+
+    return failures;
+  });
+
+  expect(failures, failures.join('\n')).toEqual([]);
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.440';
+self.APP_VERSION = '1.8.441';


### PR DESCRIPTION
## Summary
- add a Playwright protocol spec for the mocked in-browser Lens local worker covering init, ingest/query, stats, delete/clear, library management, and error responses
- capture active worker targets in Playwright coverage shards so `lens-local-worker.js` contributes to coverage instead of staying at 0%
- fix Lens worker async message handlers so rejected async operations post `{ type: 'error' }` instead of timing out via unhandled rejection
- bump `version.js` for the worker runtime change

## Tests
- `npm run test:playwright -- tests/playwright/lens-local-worker-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/ui-regression-browser-flows.spec.js -g "Lens local worker browser fixture"`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-worker-coverage npm run test:playwright -- tests/playwright/lens-local-worker-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/lens-local-worker-browser-coverage.spec.js tests/playwright/ui-regression-browser-flows.spec.js -g "lens local worker browser coverage|Lens local worker browser fixture"`