### PR TITLE
Fix worker coverage teardown races

### DIFF
--- a/tests/playwright/coverage-fixture.js
+++ b/tests/playwright/coverage-fixture.js
@@ -115,8 +115,7 @@ async function startWorkerCoverage(page) {
         if (session) session.started = true;
       }
     } catch {
-      const session = sessions.get(sessionId);
-      if (session) session.started = false;
+      // Short-lived workers can detach before profiler setup completes.
     } finally {
       await sendToTarget(sessionId, 'Runtime.runIfWaitingForDebugger').catch(() => {});
     }
@@ -199,7 +198,6 @@ export async function stopPageCoverage(page, testInfo, label = 'page') {
     coverageStates.delete(page);
   }
   entries.push(...await stopWorkerCoverage(state.workerState));
-  if (coverageError) throw coverageError;
   fs.mkdirSync(coverageDir, { recursive: true });
   fs.writeFileSync(coverageFile(testInfo, label), JSON.stringify({
     title: testInfo.title,
@@ -209,6 +207,7 @@ export async function stopPageCoverage(page, testInfo, label = 'page') {
     generatedAt: new Date().toISOString(),
     entries: entries.map(shrinkEntry),
   }));
+  if (coverageError) throw coverageError;
 }
 
 export const test = base.extend({

--- a/tests/playwright/coverage-fixture.js
+++ b/tests/playwright/coverage-fixture.js
@@ -68,10 +68,19 @@ async function startWorkerCoverage(page) {
       }, 5000);
       pending.set(key, { resolve, reject, timer });
     });
-    await client.send('Target.sendMessageToTarget', {
-      sessionId,
-      message: JSON.stringify({ id, method, params }),
-    });
+    try {
+      await client.send('Target.sendMessageToTarget', {
+        sessionId,
+        message: JSON.stringify({ id, method, params }),
+      });
+    } catch (error) {
+      const waiter = pending.get(key);
+      if (waiter) {
+        pending.delete(key);
+        clearTimeout(waiter.timer);
+      }
+      throw error;
+    }
     return response;
   };
 
@@ -105,6 +114,9 @@ async function startWorkerCoverage(page) {
         const session = sessions.get(sessionId);
         if (session) session.started = true;
       }
+    } catch {
+      const session = sessions.get(sessionId);
+      if (session) session.started = false;
     } finally {
       await sendToTarget(sessionId, 'Runtime.runIfWaitingForDebugger').catch(() => {});
     }
@@ -177,13 +189,17 @@ export async function stopPageCoverage(page, testInfo, label = 'page') {
   if (!isCoverageEnabled() || !startedPages.has(page)) return;
   const state = coverageStates.get(page) || {};
   let entries = [];
+  let coverageError = null;
   try {
     entries = await page.coverage.stopJSCoverage();
+  } catch (error) {
+    coverageError = error;
   } finally {
     startedPages.delete(page);
     coverageStates.delete(page);
   }
   entries.push(...await stopWorkerCoverage(state.workerState));
+  if (coverageError) throw coverageError;
   fs.mkdirSync(coverageDir, { recursive: true });
   fs.writeFileSync(coverageFile(testInfo, label), JSON.stringify({
     title: testInfo.title,


### PR DESCRIPTION
## Summary
- follow up on Greptile review feedback from #682
- catch short-lived worker CDP coverage setup failures after unblocking the worker
- always tear down worker coverage auto-attach even when page coverage stop fails
- clear pending CDP timers when `Target.sendMessageToTarget` rejects before a worker response

## Tests
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-worker-coverage-fix npm run test:playwright -- tests/playwright/dna-browser-coverage.spec.js tests/playwright/lens-local-worker-browser-coverage.spec.js`

## Notes
- A full `COVERAGE=1 ./run-tests.sh` pass was run before this fix and failed only in the two DNA browser coverage specs with `Target.sendMessageToTarget: No session with given id`; the targeted coverage-enabled rerun above covers that failure mode after the fix.