### PR TITLE
Add sun session browser coverage

### DIFF
--- a/tests/playwright/sun-active-session-browser-coverage.spec.js
+++ b/tests/playwright/sun-active-session-browser-coverage.spec.js
@@ -1,0 +1,180 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?sunActiveSessionCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function expectAll(outcomes) {
+  const failed = Object.entries(outcomes)
+    .filter(([, value]) => value !== true)
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`);
+  expect(failed).toEqual([]);
+}
+
+test('sun active session covers default dependencies and live ticker card branches', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async ({ activeUrl }) => {
+    const [{ state }, active] = await Promise.all([
+      import('/js/state.js'),
+      import(activeUrl),
+    ]);
+    const outcomes = {};
+    const saved = {
+      importedData: JSON.parse(JSON.stringify(state.importedData || {})),
+      currentView: state.currentView,
+    };
+    const windowKeys = [
+      'fetchAtmosphere',
+      'vitaminDIU',
+      'vitaminDIUPerSession',
+      'renderLightChannelsLive',
+    ];
+    const savedWindow = Object.fromEntries(windowKeys.map(key => [
+      key,
+      { had: Object.prototype.hasOwnProperty.call(window, key), value: window[key] },
+    ]));
+    const waitFor = async predicate => {
+      for (let i = 0; i < 40; i += 1) {
+        if (predicate()) return true;
+        await new Promise(resolve => setTimeout(resolve, 0));
+      }
+      return false;
+    };
+    const toasts = () => Array.from(document.querySelectorAll('.notification-toast')).map(el => el.textContent || '');
+    const clickRegion = (overlay, region = 'face') => {
+      overlay?.querySelector(`[data-region="${region}"]`)?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    };
+
+    try {
+      state.importedData = {
+        ...state.importedData,
+        genetics: { snps: [] },
+        sunDefaults: { fitzpatrick: 'I', photosensitiveMeds: 'severe' },
+      };
+
+      await active.quickLogSunSession();
+      const defaultOverlay = document.querySelector('.sun-start-modal')?.closest('.modal-overlay');
+      defaultOverlay?.querySelector('#start-confirm')?.click();
+      outcomes.defaultStartDialogUsesGetActiveAndEmptyRegionFallbacks = defaultOverlay?.querySelector('#sun-start-hint')?.textContent.includes('Tap at least one region');
+      defaultOverlay?.remove();
+
+      window.fetchAtmosphere = async () => ({ uvIndex: 9.1, ozoneDU: 285, cloudCover: 15, source: 'manual' });
+      active.configureSunActiveSession({
+        getSunCoords: () => ({ lat: 50.08, lon: 14.43, source: 'profile' }),
+      });
+      await active.openStartSunSessionDialog();
+      await waitFor(() => document.querySelector('#sun-start-uvi-banner')?.hidden === false);
+      const startOverlay = document.querySelector('.sun-start-modal')?.closest('.modal-overlay');
+      const preflightText = startOverlay?.querySelector('#sun-start-uvi-banner')?.textContent || '';
+      clickRegion(startOverlay);
+      startOverlay?.querySelector('#start-confirm')?.click();
+      await waitFor(() => !document.body.contains(startOverlay));
+      outcomes.defaultStartSessionUsesPreflightAndStartFallbacks = preflightText.includes('Very high UV')
+        && toasts().some(text => text.includes('high UV 9.1') && text.includes('severe photosensitizer'));
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+      active.resetSunActiveSessionState();
+
+      const stoppingSession = {
+        id: 'default-stop-session',
+        startedAt: Date.now() - 6 * 60000,
+        endedAt: null,
+        durationMin: 6,
+        bodyExposure: { fraction: 0.08, regions: ['face'], glassBetween: true },
+        eyeExposure: { mode: 'indirect', lensTint: 'clear' },
+        atmosphere: { uvIndex: 1.4 },
+        doses: {},
+        safety: { medFraction: 0.12, fitzpatrick: 'III' },
+      };
+      active.configureSunActiveSession({
+        getActiveSession: () => stoppingSession,
+        getSessions: () => [stoppingSession],
+        getSunCoords: () => ({ lat: 49.2, lon: 16.6, source: 'profile' }),
+      });
+      await active.quickLogSunSession();
+      outcomes.defaultStopPathUsesStopSaveHydrateAndRefreshFallbacks = stoppingSession.location?.source === 'profile'
+        && toasts().some(text => text.includes('no vitamin D') && text.includes('glass blocks UVB'));
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+      active.resetSunActiveSessionState();
+
+      const tickerSession = {
+        id: 'ticker-session',
+        startedAt: Date.now() - 45 * 60000,
+        endedAt: null,
+        paused: true,
+        bodyExposure: { fraction: 0.22, regions: ['face', 'arms-front'], rotatedSides: true },
+        eyeExposure: { mode: 'direct', lensTint: 'clear' },
+        atmosphere: { uvIndex: 8.8 },
+        safety: { fitzpatrick: 'II' },
+      };
+      state.currentView = 'light';
+      window.vitaminDIU = () => 1400;
+      window.vitaminDIUPerSession = () => 1400;
+      window.renderLightChannelsLive = () => {
+        outcomes.liveChannelRefreshCalled = true;
+      };
+      active.configureSunActiveSession({
+        getSessions: () => [tickerSession],
+        getActiveSession: () => tickerSession,
+      });
+      active.setSunLiveState(tickerSession.id, {
+        committedDoses: { vitamin_d: 20, circadian: 15, nir_solar: 10 },
+        committedSED: 4,
+        committedRetinalUV: 35,
+        fractionOfMEDFn: () => 1.1,
+        fitzpatrick: 'II',
+        medScale: 1,
+        psmTier: 'none',
+        atm: { uvIndex: 8.8, temperatureC: 34, source: 'manual' },
+        pending: false,
+      });
+      localStorage.removeItem('gb_jargon_seen_med');
+      const card = document.createElement('div');
+      card.dataset.id = tickerSession.id;
+      card.innerHTML = '<div class="sun-session-head"><span class="sun-session-duration">old</span></div><div class="sun-channel-chips"><span>old chips</span></div>';
+      const elapsed = document.createElement('span');
+      elapsed.dataset.liveElapsedFor = tickerSession.id;
+      elapsed.textContent = 'old elapsed';
+      document.body.append(card, elapsed);
+      active.ensureActiveTicker();
+      await waitFor(() => card.textContent.includes('burn dose') && card.textContent.includes('vit D'));
+      outcomes.liveTickerPatchesActiveCardsAndJargonAlerts = card.textContent.includes('110% burn dose')
+        && card.textContent.includes('vit D')
+        && card.textContent.includes('take a break')
+        && card.textContent.includes('eye UV')
+        && elapsed.textContent !== 'old elapsed'
+        && toasts().some(text => text.includes('MED ='));
+      outcomes.liveChannelRefreshCalled = outcomes.liveChannelRefreshCalled === true;
+    } finally {
+      state.importedData = saved.importedData;
+      state.currentView = saved.currentView;
+      for (const [key, info] of Object.entries(savedWindow)) {
+        if (info.had) window[key] = info.value;
+        else delete window[key];
+      }
+      active.resetSunActiveSessionState();
+      active.configureSunActiveSession({
+        getSessions: () => [],
+        getActiveSession: () => null,
+        startSession: async () => null,
+        stopSession: async () => null,
+        hydrateSession: async () => null,
+        getSunCoords: () => null,
+        saveImportedData: async () => {},
+        applyAtmOverrides: atm => atm,
+        refreshSurfaces: () => {},
+        normalizePSMTier: raw => raw || 'none',
+        photosensitiveMedScale: () => 1,
+        eyeModes: [],
+        lensTints: [],
+        postureOptions: [],
+        surfaceOptions: [],
+      });
+      document.querySelectorAll('.modal-overlay,.notification-container,.notification-toast,[data-id="ticker-session"],[data-live-elapsed-for="ticker-session"]').forEach(el => el.remove());
+    }
+
+    return outcomes;
+  }, { activeUrl: moduleUrl('/js/sun-active-session.js') });
+
+  expectAll(results);
+});

--- a/tests/playwright/sun-active-session-browser-coverage.spec.js
+++ b/tests/playwright/sun-active-session-browser-coverage.spec.js
@@ -5,10 +5,9 @@ function moduleUrl(path) {
 }
 
 function expectAll(outcomes) {
-  const failed = Object.entries(outcomes)
-    .filter(([, value]) => value !== true)
-    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`);
-  expect(failed).toEqual([]);
+  for (const [name, passed] of Object.entries(outcomes)) {
+    expect(passed, name).toBe(true);
+  }
 }
 
 test('sun active session covers default dependencies and live ticker card branches', async ({ page }) => {

--- a/tests/playwright/sun-session-ui-browser-coverage.spec.js
+++ b/tests/playwright/sun-session-ui-browser-coverage.spec.js
@@ -527,3 +527,126 @@ test('sun session UI covers detailed dialog and edit delete guard rails', async 
 
   expectAll(results);
 });
+
+test('sun session UI covers default dependency callbacks', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async ({ sunSessionUrl }) => {
+    const [{ state }, sunUI] = await Promise.all([
+      import('/js/state.js'),
+      import(sunSessionUrl),
+    ]);
+    const outcomes = {};
+    const saved = {
+      currentView: state.currentView,
+      navigate: window.navigate,
+      solarZenithAngle: window.solarZenithAngle,
+      geneticVitaminDMultiplier: window.geneticVitaminDMultiplier,
+    };
+    const session = {
+      id: 'default-deps-session',
+      startedAt: Date.now() - 20 * 60000,
+      endedAt: Date.now(),
+      durationMin: 20,
+      location: { lat: 50.08, lon: 14.43, source: 'test' },
+      bodyExposure: { preset: 'face_hands', fraction: 0.05, regions: [], glassBetween: false },
+      eyeExposure: { mode: 'direct', lensTint: 'clear' },
+      atmosphere: { uvIndex: 4.2, source: 'manual' },
+      safety: { medFraction: 0.25, fitzpatrick: 'III' },
+      doses: { vitamin_d: 12, circadian: 6, nir_solar: 3 },
+    };
+    const waitFor = async predicate => {
+      for (let i = 0; i < 30; i += 1) {
+        if (predicate()) return true;
+        await new Promise(resolve => setTimeout(resolve, 0));
+      }
+      return false;
+    };
+    const toasts = () => Array.from(document.querySelectorAll('.notification-toast')).map(el => el.textContent || '');
+
+    try {
+      state.currentView = 'dashboard';
+      window.navigate = route => {
+        outcomes.unexpectedNavigate = route;
+      };
+      window.solarZenithAngle = () => 48;
+      window.geneticVitaminDMultiplier = () => ({ mult: 1, contributors: [] });
+
+      const emptyList = sunUI.renderSessionsList();
+      outcomes.defaultEmptyListUsesGetSessions = emptyList.includes('No sun sessions logged yet');
+
+      const activeHost = document.createElement('div');
+      activeHost.innerHTML = sunUI.renderSunSessionRow({
+        id: 'default-active',
+        startedAt: Date.now() - 60000,
+        endedAt: null,
+        bodyExposure: { fraction: 0.05, regions: ['face'] },
+        eyeExposure: { mode: 'unknown' },
+        safety: { medFraction: 0.1, fitzpatrick: 'III' },
+        doses: { vitamin_d: 4, pomc: 2 },
+      });
+      outcomes.defaultRowUsesSummaryElapsedAndChipHelpers = activeHost.textContent.includes('0:00')
+        && activeHost.textContent.includes('Body unset')
+        && activeHost.textContent.includes('Eyes unset')
+        && activeHost.textContent.includes('vitamin d')
+        && !!activeHost.querySelector('.sun-chip-tier-0');
+
+      sunUI.configureSunSessionUI({ getSessions: () => [session] });
+      sunUI.openSunSessionDetail(session.id);
+      const detailOverlay = document.querySelector('.sun-detail-modal')?.closest('.modal-overlay');
+      outcomes.defaultDetailUsesModalAndChannelDeps = !!detailOverlay
+        && detailOverlay.textContent.includes('Sun session')
+        && detailOverlay.textContent.includes('none');
+      detailOverlay?.remove();
+
+      sunUI.openDetailedSessionDialog();
+      const defaultLogOverlay = document.querySelector('.sun-detailed-modal')?.closest('.modal-overlay');
+      defaultLogOverlay?.querySelector('[data-region="face"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      defaultLogOverlay?.querySelector('#det-save')?.click();
+      await waitFor(() => !document.body.contains(defaultLogOverlay));
+      outcomes.defaultDetailedSaveUsesLogAndCoordsFallbacks = toasts().some(text => text.includes('Detailed session saved'));
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+
+      sunUI.configureSunSessionUI({
+        getSessions: () => [session],
+        logCompletedSession: async () => 'default-hydrate-session',
+      });
+      sunUI.openDetailedSessionDialog();
+      const defaultHydrateOverlay = document.querySelector('.sun-detailed-modal')?.closest('.modal-overlay');
+      defaultHydrateOverlay?.querySelector('[data-region="face"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      defaultHydrateOverlay?.querySelector('#det-save')?.click();
+      await waitFor(() => !document.body.contains(defaultHydrateOverlay));
+      outcomes.defaultDetailedSaveUsesHydrateFallback = toasts().some(text => text.includes('Detailed session saved'));
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+
+      const deletePromise = sunUI.deleteSunSession(session.id);
+      await waitFor(() => !!document.getElementById('confirm-ok'));
+      document.getElementById('confirm-ok')?.click();
+      await deletePromise;
+      outcomes.defaultDeleteUsesDeleteAndRefreshFallbacks = !document.getElementById('confirm-dialog-overlay')?.classList.contains('show');
+
+      const editPromise = sunUI.editSunSessionDuration(session.id);
+      await waitFor(() => !!document.getElementById('prompt-dialog-input'));
+      const input = document.getElementById('prompt-dialog-input');
+      if (input) {
+        input.value = '21';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      document.getElementById('prompt-ok')?.click();
+      await editPromise;
+      outcomes.defaultEditUsesUpdateFallback = toasts().some(text => text.includes('Session duration set to 21 min'))
+        && !outcomes.unexpectedNavigate;
+    } finally {
+      state.currentView = saved.currentView;
+      if (saved.navigate) window.navigate = saved.navigate;
+      else delete window.navigate;
+      window.solarZenithAngle = saved.solarZenithAngle;
+      window.geneticVitaminDMultiplier = saved.geneticVitaminDMultiplier;
+      document.querySelectorAll('.modal-overlay,.confirm-overlay,.notification-container,.notification-toast').forEach(el => el.remove());
+    }
+
+    return outcomes;
+  }, { sunSessionUrl: moduleUrl('/js/sun-session-ui.js') });
+
+  expectAll(results);
+});

--- a/tests/playwright/sun-session-ui-browser-coverage.spec.js
+++ b/tests/playwright/sun-session-ui-browser-coverage.spec.js
@@ -539,10 +539,16 @@ test('sun session UI covers default dependency callbacks', async ({ page }) => {
     const outcomes = {};
     const saved = {
       currentView: state.currentView,
-      navigate: window.navigate,
-      solarZenithAngle: window.solarZenithAngle,
-      geneticVitaminDMultiplier: window.geneticVitaminDMultiplier,
     };
+    const windowKeys = [
+      'navigate',
+      'solarZenithAngle',
+      'geneticVitaminDMultiplier',
+    ];
+    const savedWindow = Object.fromEntries(windowKeys.map(key => [
+      key,
+      { had: Object.prototype.hasOwnProperty.call(window, key), value: window[key] },
+    ]));
     const session = {
       id: 'default-deps-session',
       startedAt: Date.now() - 20 * 60000,
@@ -638,10 +644,10 @@ test('sun session UI covers default dependency callbacks', async ({ page }) => {
         && !outcomes.unexpectedNavigate;
     } finally {
       state.currentView = saved.currentView;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
-      window.solarZenithAngle = saved.solarZenithAngle;
-      window.geneticVitaminDMultiplier = saved.geneticVitaminDMultiplier;
+      for (const [key, info] of Object.entries(savedWindow)) {
+        if (info.had) window[key] = info.value;
+        else delete window[key];
+      }
       document.querySelectorAll('.modal-overlay,.confirm-overlay,.notification-container,.notification-toast').forEach(el => el.remove());
     }
 


### PR DESCRIPTION
## Summary
- Adds Playwright browser coverage for `sun-active-session.js` default dependency, start/stop, and live ticker branches.
- Extends `sun-session-ui` browser coverage for default dependency callbacks, detailed-session save fallbacks, delete, and edit paths.
- Brings both targeted modules to 100% Playwright function coverage in the local merged shard estimate.

## Validation
- `npm run test:playwright -- tests/playwright/sun-session-ui-browser-coverage.spec.js tests/playwright/sun-active-session-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-sun-session-coverage-20260610 npm run test:playwright -- tests/playwright/sun-session-ui-browser-coverage.spec.js tests/playwright/sun-active-session-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/sun-session-ui-browser-coverage.spec.js tests/playwright/sun-active-session-browser-coverage.spec.js --repeat-each=2`

## Coverage
- Playwright functions: `3423/3877` (`88.29%`) -> `3450/3877` (`88.99%`)
- Playwright bytes: `72.58%` -> `72.67%`
- `js/sun-session-ui.js`: `23/23` functions
- `js/sun-active-session.js`: `37/37` functions