### PR TITLE
Add mobile dashboard browser coverage

### DIFF
--- a/tests/playwright/mobile-dashboard-browser-coverage.spec.js
+++ b/tests/playwright/mobile-dashboard-browser-coverage.spec.js
@@ -1,0 +1,189 @@
+import { expect, test } from './coverage-fixture.js';
+
+const moduleUrl = (path) => `${path}?mobileDashboardCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+async function openBlankPage(page) {
+  await page.route('**/mobile-dashboard-browser-coverage', route => route.fulfill({
+    contentType: 'text/html',
+    body: '<!doctype html><html><head></head><body><main id="main-content"></main><input id="sidebar-search"></body></html>',
+  }));
+  await page.goto('/mobile-dashboard-browser-coverage', { waitUntil: 'load' });
+}
+
+test('mobile dashboard browser coverage exercises defaults breakpoint search and jumps', async ({ page }) => {
+  await openBlankPage(page);
+
+  const results = await page.evaluate(async ({ mobileDashboardUrl }) => {
+    const calls = [];
+    const mediaListeners = [];
+    const saved = {
+      matchMedia: window.matchMedia,
+      navigate: window.navigate,
+      toggleMobileSidebar: window.toggleMobileSidebar,
+      loadContextCardTips: window.loadContextCardTips,
+      loadCatalog: window.loadCatalog,
+      scrollTo: window.scrollTo,
+    };
+
+    window.matchMedia = query => ({
+      media: query,
+      matches: true,
+      onchange: null,
+      addEventListener: (type, callback) => {
+        if (type === 'change') mediaListeners.push(callback);
+      },
+      removeEventListener: () => {},
+      addListener: callback => mediaListeners.push(callback),
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    });
+    window.navigate = route => calls.push(['navigate', route]);
+    window.toggleMobileSidebar = () => calls.push(['toggleMobileSidebar']);
+    window.scrollTo = (...args) => calls.push(['scrollTo', ...args]);
+
+    const mobileDashboard = await import(mobileDashboardUrl);
+    window.loadContextCardTips = () => calls.push(['loadContextCardTips']);
+    window.loadCatalog = async () => {
+      calls.push(['loadCatalog']);
+      return { catalog: true };
+    };
+    const state = window._labState;
+    const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
+    const originalState = {
+      importedData: clone(state.importedData),
+      currentProfile: state.currentProfile,
+      currentView: state.currentView,
+      markerRegistry: clone(state.markerRegistry),
+    };
+    const profilesStorage = localStorage.getItem('labcharts-profiles');
+    const activeProfile = localStorage.getItem('labcharts-active-profile');
+    const outcomes = {};
+    const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    const mobileData = {
+      dates: ['2026-01-01', '2026-02-01'],
+      dateLabels: ['Jan 1, 2026', 'Feb 1, 2026'],
+      categories: {
+        metabolic: {
+          label: 'Metabolic',
+          markers: {
+            glucose: {
+              name: 'Glucose',
+              unit: 'mg/dL',
+              values: [82, 108],
+              refMin: 70,
+              refMax: 99,
+            },
+          },
+        },
+      },
+    };
+
+    try {
+      localStorage.setItem('labcharts-profiles', JSON.stringify([{ id: 'mobile-profile', name: 'Mobile Tester' }]));
+      localStorage.setItem('labcharts-active-profile', 'mobile-profile');
+      state.currentProfile = 'mobile-profile';
+      state.importedData = {
+        ...state.importedData,
+        entries: [],
+        notes: [],
+        supplements: [],
+        customMarkers: {},
+        wearableSummary: {
+          sources: { fitbit: true },
+          metrics: {
+            steps: { latest: 12345, baseline: 10000 },
+            bp_systolic: { latest: 118, baseline: 122 },
+            bp_diastolic: { latest: 76, baseline: 78 },
+          },
+        },
+      };
+
+      outcomes.breakpointListenerWasRegistered = mediaListeners.length > 0
+        && mobileDashboard.isMobileDashboardViewport() === true;
+
+      state.currentView = 'dashboard';
+      mediaListeners[0]?.({ matches: true });
+      state.currentView = 'labs';
+      mediaListeners[0]?.({ matches: true });
+      outcomes.breakpointRefreshNavigatesOrSyncsTabs = calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard')
+        && document.getElementById('mobile-bottom-tabs')?.querySelector('[data-tab="labs"]')?.classList.contains('active') === true;
+
+      mobileDashboard.renderMobileDashboard(mobileData, { resetScroll: true });
+      const firstRenderHtml = document.getElementById('main-content')?.innerHTML || '';
+      const defaultDepsOk = document.body.classList.contains('mobile-dashboard-active') === true
+        && document.documentElement.classList.contains('mobile-dashboard-active') === true
+        && firstRenderHtml.includes('Hey Mobile.')
+        && firstRenderHtml.includes('No widgets are visible.')
+        && calls.some(call => call[0] === 'scrollTo' && call[1] === 0 && call[2] === 0)
+        && calls.some(call => call[0] === 'loadContextCardTips')
+        && calls.some(call => call[0] === 'loadCatalog');
+      outcomes.defaultDepsRenderEmptyWidgetStackAndRunShellHooks = defaultDepsOk || {
+        bodyActive: document.body.classList.contains('mobile-dashboard-active'),
+        rootActive: document.documentElement.classList.contains('mobile-dashboard-active'),
+        greeting: firstRenderHtml.match(/Hey [^<]+/)?.[0] || '',
+        hasEmptyWidget: firstRenderHtml.includes('No widgets are visible.'),
+        calls,
+      };
+
+      mobileDashboard.configureMobileDashboardView({
+        getVisibleDashboardWidgetEntries: () => [{ def: { id: 'coverage-widget' }, body: '<p>custom body ignored by default renderer</p>' }],
+      });
+      mobileDashboard.renderMobileDashboard(mobileData);
+      const secondRenderHtml = document.getElementById('main-content')?.innerHTML || '';
+      outcomes.defaultRenderDashboardWidgetCallbackHandlesVisibleEntries = secondRenderHtml.includes('Dashboard widgets')
+        && secondRenderHtml.includes('m-dashboard-widgets')
+        && !secondRenderHtml.includes('custom body ignored by default renderer')
+        && !secondRenderHtml.includes('No widgets are visible.');
+
+      mobileDashboard.mobileDashboardSetTab('labs');
+      const activeLabs = document.querySelector('.m-tab[data-tab="labs"]');
+      const activeDashboard = document.querySelector('.m-tab[data-tab="dashboard"]');
+      outcomes.mobileDashboardSetTabUpdatesActiveState = activeLabs?.classList.contains('active') === true
+        && activeLabs?.getAttribute('aria-current') === 'page'
+        && activeDashboard?.getAttribute('aria-current') === 'false';
+
+      mobileDashboard.openMobileDashboardSearch();
+      await wait(100);
+      outcomes.openMobileDashboardSearchTogglesSidebarAndFocusesSearch = calls.some(call => call[0] === 'toggleMobileSidebar')
+        && document.activeElement?.id === 'sidebar-search';
+
+      mobileDashboard.mobileDashboardJump('body');
+      mobileDashboard.mobileDashboardJump('recommendations');
+      mobileDashboard.mobileDashboardJump('unknown-route');
+      outcomes.mobileDashboardJumpNormalizesRoutesAndTabs = calls.some(call => call[0] === 'navigate' && call[1] === 'body')
+        && calls.some(call => call[0] === 'navigate' && call[1] === 'recommendations')
+        && calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard')
+        && document.querySelector('.m-tab[data-tab="dashboard"]')?.classList.contains('active') === true;
+    } finally {
+      state.importedData = originalState.importedData;
+      state.currentProfile = originalState.currentProfile;
+      state.currentView = originalState.currentView;
+      state.markerRegistry = originalState.markerRegistry;
+      if (profilesStorage == null) localStorage.removeItem('labcharts-profiles');
+      else localStorage.setItem('labcharts-profiles', profilesStorage);
+      if (activeProfile == null) localStorage.removeItem('labcharts-active-profile');
+      else localStorage.setItem('labcharts-active-profile', activeProfile);
+      window.matchMedia = saved.matchMedia;
+      if (saved.navigate) window.navigate = saved.navigate;
+      else delete window.navigate;
+      if (saved.toggleMobileSidebar) window.toggleMobileSidebar = saved.toggleMobileSidebar;
+      else delete window.toggleMobileSidebar;
+      if (saved.loadContextCardTips) window.loadContextCardTips = saved.loadContextCardTips;
+      else delete window.loadContextCardTips;
+      if (saved.loadCatalog) window.loadCatalog = saved.loadCatalog;
+      else delete window.loadCatalog;
+      if (saved.scrollTo) window.scrollTo = saved.scrollTo;
+      else delete window.scrollTo;
+      document.body.classList.remove('mobile-dashboard-active', 'mobile-tabs-active');
+      document.documentElement.classList.remove('mobile-dashboard-active', 'mobile-tabs-active');
+      document.documentElement.style.removeProperty('--mobile-visual-bottom-offset');
+    }
+
+    return outcomes;
+  }, { mobileDashboardUrl: moduleUrl('/js/mobile-dashboard.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, `${name}: ${JSON.stringify(passed)}`).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds isolated Playwright browser coverage for `js/mobile-dashboard.js`.
- Covers default dashboard dependency callbacks, mobile breakpoint refresh, bottom-nav tab state, search focus behavior, and route normalization through mobile dashboard jumps.
- Brings `js/mobile-dashboard.js` to 100% Playwright function coverage in the local merged shard estimate.

## Validation
- `npm run test:playwright -- tests/playwright/mobile-dashboard-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-mobile-dashboard-coverage-20260610b npm run test:playwright -- tests/playwright/mobile-dashboard-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/mobile-dashboard-browser-coverage.spec.js --repeat-each=2`

## Coverage
- Playwright functions: `3476/3877` (`89.66%`) -> `3487/3877` (`89.94%`)
- Playwright bytes: `72.99%` -> `73.01%`
- `js/mobile-dashboard.js`: `40/40` functions