### PR TITLE
[codex] Add helper browser coverage

### DIFF
--- a/tests/playwright/chat-discussion-browser-coverage.spec.js
+++ b/tests/playwright/chat-discussion-browser-coverage.spec.js
@@ -114,6 +114,96 @@ test('chat prompt context attestation and discussion prompt helpers cover browse
   }
 });
 
+test('discussion round state persists active and inactive thread histories', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#chat-input');
+
+  const results = await page.evaluate(async ({ roundStateUrl }) => {
+    const [roundState, chatThreads, { state }] = await Promise.all([
+      import(roundStateUrl),
+      import('/js/chat-threads.js'),
+      import('/js/state.js'),
+    ]);
+    const outcomes = {};
+    const profileId = 'discussion-round-state-coverage';
+    const saved = {
+      currentProfile: state.currentProfile,
+      currentThreadId: state.currentThreadId,
+      chatThreads: state.chatThreads,
+      chatHistory: state.chatHistory,
+      encryptionEnabled: localStorage.getItem('labcharts-encryption-enabled'),
+    };
+    const removeProfileChatKeys = () => {
+      for (const key of Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index)).filter(Boolean)) {
+        if (key.startsWith(`labcharts-${profileId}-chat`)) localStorage.removeItem(key);
+      }
+    };
+    const initialUpdatedAt = new Date(Date.now() - 86400000).toISOString();
+
+    try {
+      localStorage.setItem('labcharts-encryption-enabled', 'false');
+      removeProfileChatKeys();
+      state.currentProfile = profileId;
+      state.currentThreadId = 'active-thread';
+      state.chatHistory = [{ role: 'user', content: 'before' }];
+      state.chatThreads = [
+        { id: 'active-thread', title: 'Active', messageCount: 1, updatedAt: initialUpdatedAt },
+        { id: 'inactive-thread', title: 'Inactive', messageCount: 1, updatedAt: initialUpdatedAt },
+      ];
+
+      let renderCalls = 0;
+      const activeMessages = [{ role: 'assistant', content: 'active render' }];
+      const inactiveMessages = [{ role: 'assistant', content: 'inactive render' }];
+      roundState.renderRoundMessages('inactive-thread', inactiveMessages, () => { renderCalls += 1; });
+      const inactiveRenderSkipped = renderCalls === 0
+        && state.chatHistory[0].content === 'before';
+      roundState.renderRoundMessages('active-thread', activeMessages, () => { renderCalls += 1; });
+      outcomes.renderRoundMessagesOnlyRendersActiveThread = inactiveRenderSkipped
+        && renderCalls === 1
+        && state.chatHistory === activeMessages;
+
+      await roundState.saveRoundChatHistory(null, [{ role: 'assistant', content: 'ignored' }]);
+      const activeSaveMessages = [{ role: 'assistant', content: 'active saved' }];
+      await roundState.saveRoundChatHistory('active-thread', activeSaveMessages);
+      outcomes.activeRoundSaveUsesSharedChatHistory =
+        state.chatHistory === activeSaveMessages;
+
+      const inactiveSaveMessages = [
+        { role: 'assistant', content: 'inactive saved' },
+        { role: 'user', content: 'follow up' },
+      ];
+      const beforeUpdatedAt = state.chatThreads.find(thread => thread.id === 'inactive-thread')?.updatedAt;
+      await roundState.saveRoundChatHistory('inactive-thread', inactiveSaveMessages);
+      const inactiveThread = state.chatThreads.find(thread => thread.id === 'inactive-thread');
+      const inactiveStored = JSON.parse(localStorage.getItem(chatThreads.getChatThreadKey('inactive-thread')) || '[]');
+      const savedThreadIndex = JSON.parse(localStorage.getItem(chatThreads.getChatThreadsKey()) || '[]');
+      outcomes.inactiveRoundSavePersistsThreadAndUpdatesIndex =
+        inactiveStored.length === 2
+        && inactiveStored[0].content === 'inactive saved'
+        && inactiveThread.messageCount === 2
+        && inactiveThread.updatedAt !== beforeUpdatedAt
+        && savedThreadIndex.some(thread => thread.id === 'inactive-thread' && thread.messageCount === 2);
+    } finally {
+      removeProfileChatKeys();
+      state.currentProfile = saved.currentProfile;
+      state.currentThreadId = saved.currentThreadId;
+      state.chatThreads = saved.chatThreads;
+      state.chatHistory = saved.chatHistory;
+      if (saved.encryptionEnabled == null) localStorage.removeItem('labcharts-encryption-enabled');
+      else localStorage.setItem('labcharts-encryption-enabled', saved.encryptionEnabled);
+      window.renderThreadList?.();
+    }
+
+    return outcomes;
+  }, {
+    roundStateUrl: moduleUrl('/js/chat-discussion-round-state.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
 test('chat discussion request builder covers personality model assistant and usage metadata', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#chat-input');

--- a/tests/playwright/image-utils-dom.spec.js
+++ b/tests/playwright/image-utils-dom.spec.js
@@ -37,3 +37,32 @@ test('chat image attachment DOM and CSS are loaded', async ({ page }) => {
     '.chat-drop-active': true,
   });
 });
+
+test('image utility content builders format provider-compatible vision messages', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async () => {
+    const imageUtils = await import(`/js/image-utils.js?imageUtilsCoverage=${Date.now()}`);
+    const outcomes = {};
+    const block = imageUtils.formatImageBlock('abc123', 'image/png', 'ollama');
+    const contentWithText = imageUtils.buildVisionContent([block], 'Read the marker table.', 'openrouter');
+    const contentWithoutText = imageUtils.buildVisionContent([block], '', 'venice');
+
+    outcomes.formatImageBlockUsesDataUrlImageBlock =
+      block.type === 'image_url'
+      && block.image_url.url === 'data:image/png;base64,abc123';
+    outcomes.buildVisionContentAppendsTextOnlyWhenProvided =
+      contentWithText.length === 2
+      && contentWithText[0] === block
+      && contentWithText[1].type === 'text'
+      && contentWithText[1].text === 'Read the marker table.'
+      && contentWithoutText.length === 1
+      && contentWithoutText[0] === block;
+
+    return outcomes;
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});

--- a/tests/playwright/sync-delta-helper-browser-coverage.spec.js
+++ b/tests/playwright/sync-delta-helper-browser-coverage.spec.js
@@ -256,6 +256,7 @@ test('sync delta facade covers default provider guards', async ({ page }) => {
       });
     }
 
+    outcomes.allOutcomesReached = true;
     return outcomes;
   }, {
     deltaUrl: moduleUrl('/js/sync-delta.js'),

--- a/tests/playwright/sync-delta-helper-browser-coverage.spec.js
+++ b/tests/playwright/sync-delta-helper-browser-coverage.spec.js
@@ -227,3 +227,41 @@ test('sync delta helper browser coverage exercises observability context and rea
     expect(passed, name).toBe(true);
   }
 });
+
+test('sync delta facade covers default provider guards', async ({ page }) => {
+  await openBlankPage(page, '/sync-delta-facade-coverage');
+
+  const results = await page.evaluate(async ({ deltaUrl }) => {
+    const delta = await import(deltaUrl);
+    const outcomes = {};
+
+    try {
+      delta.configureSyncDelta();
+      const today = new Date().toISOString().slice(0, 10);
+      outcomes.applyArrayDeltaWithoutRuntimeReturnsFalse =
+        delta._applyArrayDelta('entries', { ops: [{ kind: 'insert', args: { profileId: 'missing-runtime' } }] }) === false;
+
+      const readiness = delta.getDeltaCutoverReadiness('default-provider-profile', {
+        entries: [{ date: today, markers: { 'biochemistry.glucose': 5.4 } }],
+      });
+      outcomes.defaultProviderReadinessUsesNullQueryState =
+        readiness.ready === false
+        && readiness.surfaces.entries.localCount === 1
+        && readiness.surfaces.entries.rowCount === 0
+        && readiness.surfaces.entries.status === 'missing-rows';
+    } finally {
+      delta.configureSyncDelta({
+        getEvolu: () => null,
+        getItemRowQuery: () => null,
+      });
+    }
+
+    return outcomes;
+  }, {
+    deltaUrl: moduleUrl('/js/sync-delta.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- Add Playwright coverage for image utility vision content helpers.
- Add browser coverage for discussion round state rendering and active/inactive thread persistence.
- Add sync delta facade coverage for default provider guards when no Evolu runtime/query is configured.

## Validation
- `npm run test:playwright -- tests/playwright/image-utils-dom.spec.js`
- `npm run test:playwright -- tests/playwright/sync-delta-helper-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/chat-discussion-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/image-utils-dom.spec.js tests/playwright/chat-discussion-browser-coverage.spec.js tests/playwright/sync-delta-helper-browser-coverage.spec.js`