### PR TITLE
Add category view renderer browser coverage

### DIFF
--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -255,7 +255,8 @@ export function renderFattyAcidsCharts(cat) {
   }
   const tc = getChartColors();
   const names=[], vals=[], mins=[], maxs=[], bgC=[], brC=[];
-  for (const m of Object.values(cat.markers)) {
+  for (const [key, m] of Object.entries(cat.markers)) {
+    if (!safeMarkerId(key)) continue;
     const r = getEffectiveRange(m);
     names.push(m.name.replace(/\(.+\)/,"").trim());
     vals.push(m.values[0]); mins.push(r.min); maxs.push(r.max);

--- a/tests/playwright/category-view-renderers-browser-coverage.spec.js
+++ b/tests/playwright/category-view-renderers-browser-coverage.spec.js
@@ -1,0 +1,228 @@
+import { expect, test } from './coverage-fixture.js';
+
+const moduleUrl = path => `${path}?categoryViewRendererCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+async function openBlankPage(page) {
+  await page.route('**/category-view-renderers-browser-coverage', route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><main id="fixture"></main></body></html>',
+  }));
+  await page.goto('/category-view-renderers-browser-coverage', { waitUntil: 'load' });
+}
+
+test('category view renderers browser coverage exercises chart table heatmap and fatty-acid markup', async ({ page }) => {
+  await openBlankPage(page);
+
+  const results = await page.evaluate(async ({ renderersUrl }) => {
+    const [renderers, { state }] = await Promise.all([
+      import(renderersUrl),
+      import('/js/state.js'),
+    ]);
+    const outcomes = {};
+    const fixture = document.getElementById('fixture');
+    const saved = {
+      rangeMode: state.rangeMode,
+      markerRegistry: state.markerRegistry,
+      chartInstances: state.chartInstances,
+      Chart: window.Chart,
+    };
+    const dateLabels = ['Jan 1', 'Feb 1', 'Mar 1', 'Apr 1', 'May 1'];
+    const dates = ['2026-01-01', '2026-02-01', '2026-03-01', '2026-04-01', '2026-05-01'];
+    const apoBMarker = {
+      name: 'ApoB <script>',
+      unit: 'mg/dL',
+      values: [80, null, 130, 110, 90],
+      refMin: 60,
+      refMax: 100,
+      optimalMin: 60,
+      optimalMax: 90,
+    };
+    const category = {
+      singleDate: false,
+      markers: {
+        apob: apoBMarker,
+        hdl: {
+          name: 'HDL',
+          unit: 'mg/dL',
+          values: [40, 42, 38, 41, 45],
+          refMin: 40,
+          refMax: 60,
+        },
+        empty: {
+          name: 'Empty Marker',
+          unit: '',
+          values: [null, null, null, null, null],
+          refMin: null,
+          refMax: null,
+        },
+      },
+    };
+
+    try {
+      state.rangeMode = 'both';
+      state.markerRegistry = {};
+      state.chartInstances = {};
+
+      fixture.innerHTML = renderers.renderChartCard('lipids_apob', apoBMarker, dateLabels);
+      const card = fixture.querySelector('.chart-card');
+      outcomes.chartCardEscapesMarkerStoresRegistryAndShowsLatest =
+        state.markerRegistry.lipids_apob === apoBMarker
+        && card?.getAttribute('aria-label') === 'ApoB <script> - Normal'
+        && card.querySelector('.chart-card-title-text')?.textContent === 'ApoB <script>'
+        && card.querySelector('.chart-card-latest-value')?.textContent === '90'
+        && card.querySelector('#chart-rec-lipids_apob')
+        && !card.querySelector('script');
+      outcomes.chartCardRejectsUnsafeIds =
+        renderers.renderChartCard('lipids_bad"id', apoBMarker, dateLabels) === '';
+
+      fixture.innerHTML = renderers.renderScrollableTableShell(
+        'tiny',
+        'tiny-wrap',
+        'tiny-table',
+        renderers.renderTableColgroup(['safe-col', 'bad" onclick="alert(1)']),
+        '<tr><th>A</th></tr>',
+        '<tr><td>B</td></tr>',
+        120
+      );
+      const tinyShell = fixture.querySelector('.gb-table-shell-tiny');
+      const tinyScroll = fixture.querySelector('.tiny-wrap');
+      const tinyTable = tinyScroll.querySelector('table');
+      tinyScroll.style.width = '40px';
+      tinyScroll.style.overflow = 'auto';
+      tinyTable.style.width = '240px';
+      tinyScroll.scrollLeft = 42;
+      tinyScroll.dispatchEvent(new Event('scroll'));
+      const syncedScroll = tinyShell?.style.getPropertyValue('--gb-table-scroll-x');
+      outcomes.scrollableTableShellClampsWidthEscapesColsAndSyncsScroll =
+        tinyShell?.style.getPropertyValue('--gb-table-min-width') === '660px'
+        && syncedScroll === `${tinyScroll.scrollLeft}px`
+        && tinyScroll.scrollLeft > 0
+        && fixture.querySelectorAll('col').length === 4
+        && !fixture.querySelector('col[onclick]');
+
+      fixture.innerHTML = renderers.renderTableView(category, dateLabels, 'lipids', dates);
+      const tableText = fixture.textContent || '';
+      const emptyValueCell = fixture.querySelector('.data-table .value-cell.val-missing[title]');
+      outcomes.tableViewFiltersEmptyMarkersEscapesNamesAndAddsManualEntryCells =
+        !!fixture.querySelector('.gb-table-shell-data')
+        && tableText.includes('ApoB <script>')
+        && !tableText.includes('Empty Marker')
+        && !fixture.querySelector('script')
+        && emptyValueCell?.getAttribute('onclick')?.includes('openManualEntryForm')
+        && emptyValueCell.getAttribute('onclick')?.includes('lipids_apob')
+        && emptyValueCell.getAttribute('onclick')?.includes('2026-02-01');
+
+      fixture.innerHTML = renderers.renderTableView({ singleDate: false, markers: {} }, dateLabels, 'empty', dates);
+      outcomes.tableViewEmptyStateExplainsNoData =
+        fixture.textContent.includes('No data yet for this category');
+
+      state.markerRegistry = {};
+      fixture.innerHTML = renderers.renderHeatmapView(category, dateLabels, dates, 'lipids');
+      const highHeatmapCell = fixture.querySelector('.heatmap-high');
+      const missingHeatmapCell = fixture.querySelector('.heatmap-missing');
+      outcomes.heatmapViewRegistersMarkersAndRendersStatusCells =
+        state.markerRegistry.lipids_apob === apoBMarker
+        && !!fixture.querySelector('.gb-table-shell-heatmap')
+        && highHeatmapCell?.textContent === '130'
+        && missingHeatmapCell?.textContent?.charCodeAt(0) === 8212
+        && highHeatmapCell.getAttribute('onclick')?.includes('lipids_apob')
+        && highHeatmapCell.getAttribute('aria-label')?.includes('ApoB <script> Mar 1: 130');
+
+      fixture.innerHTML = renderers.renderHeatmapView({ singleDate: false, markers: {} }, dateLabels, dates, 'empty');
+      outcomes.heatmapViewEmptyStateExplainsNoData =
+        fixture.textContent.includes('No data yet for this category');
+
+      state.rangeMode = 'optimal';
+      const fattyAcids = {
+        singleDate: '2026-06-01',
+        markers: {
+          omega3: {
+            name: 'Omega 3 (EPA/DHA)',
+            unit: '%',
+            values: [7],
+            refMin: 4,
+            refMax: 12,
+            optimalMin: 8,
+            optimalMax: 12,
+          },
+          omega6: {
+            name: 'Omega 6',
+            unit: '%',
+            values: [18],
+            refMin: 6,
+            refMax: 14,
+            optimalMin: 6,
+            optimalMax: 10,
+          },
+          'bad"id': {
+            name: 'Unsafe',
+            unit: '%',
+            values: [1],
+            refMin: 0,
+            refMax: 2,
+          },
+        },
+      };
+      fixture.innerHTML = renderers.renderFattyAcidsView(fattyAcids, 'fatty');
+      outcomes.fattyAcidsViewRendersSafeCardsDateAndOptimalRanges =
+        fixture.querySelectorAll('.fa-card').length === 2
+        && fixture.textContent.includes('June 1, 2026')
+        && fixture.textContent.includes('Omega 3')
+        && fixture.textContent.includes('Optimal: 8')
+        && fixture.textContent.includes('12')
+        && !fixture.textContent.includes('Unsafe')
+        && fixture.querySelector('.fa-card')?.getAttribute('onclick')?.includes('fatty_omega3');
+      outcomes.fattyAcidsViewRejectsUnsafeCategoryKey =
+        renderers.renderFattyAcidsView(fattyAcids, 'bad"cat') === '';
+
+      const chartCalls = [];
+      window.Chart = class {
+        constructor(ctx, config) {
+          this.ctx = ctx;
+          this.config = config;
+          chartCalls.push(this);
+        }
+      };
+      fixture.innerHTML = '<canvas id="chart-fa-bar"></canvas>';
+      renderers.renderFattyAcidsCharts(fattyAcids);
+      outcomes.fattyAcidsChartsBuildsStubbedChart =
+        chartCalls.length === 1
+        && chartCalls[0].ctx.id === 'chart-fa-bar'
+        && chartCalls[0].config.type === 'bar'
+        && chartCalls[0].config.data.labels.includes('Omega 3')
+        && chartCalls[0].config.data.labels.includes('Omega 6')
+        && chartCalls[0].config.data.labels.length === 2
+        && !chartCalls[0].config.data.labels.includes('Unsafe')
+        && chartCalls[0].config.data.datasets.length === 3
+        && state.chartInstances['fa-bar'] === chartCalls[0];
+    } finally {
+      state.rangeMode = saved.rangeMode;
+      state.markerRegistry = saved.markerRegistry;
+      state.chartInstances = saved.chartInstances;
+      if (saved.Chart === undefined) delete window.Chart;
+      else window.Chart = saved.Chart;
+    }
+
+    return outcomes;
+  }, {
+    renderersUrl: moduleUrl('/js/category-view-renderers.js'),
+  });
+
+  const expectedOutcomeKeys = [
+    'chartCardEscapesMarkerStoresRegistryAndShowsLatest',
+    'chartCardRejectsUnsafeIds',
+    'scrollableTableShellClampsWidthEscapesColsAndSyncsScroll',
+    'tableViewFiltersEmptyMarkersEscapesNamesAndAddsManualEntryCells',
+    'tableViewEmptyStateExplainsNoData',
+    'heatmapViewRegistersMarkersAndRendersStatusCells',
+    'heatmapViewEmptyStateExplainsNoData',
+    'fattyAcidsViewRendersSafeCardsDateAndOptimalRanges',
+    'fattyAcidsViewRejectsUnsafeCategoryKey',
+    'fattyAcidsChartsBuildsStubbedChart',
+  ];
+  expect(Object.keys(results)).toEqual(expectedOutcomeKeys);
+  for (const [name, passed] of Object.entries(results)) {
+    expect.soft(passed, name).toBe(true);
+  }
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.447';
+self.APP_VERSION = '1.8.448';


### PR DESCRIPTION
## Summary
- Add Playwright browser coverage for `category-view-renderers.js`
- Exercise chart card escaping and registry updates, table shell/empty/manual-entry paths, and heatmap rendering
- Cover fatty-acid card markup plus the stubbed Chart.js render path

## Tests
- `node --check tests/playwright/category-view-renderers-browser-coverage.spec.js`
- `git diff --check`
- `npm run test:playwright -- tests/playwright/category-view-renderers-browser-coverage.spec.js`