### PR TITLE
Add startup helper browser coverage

### DIFF
--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -1,0 +1,493 @@
+import { expect, test } from './coverage-fixture.js';
+
+test.setTimeout(30_000);
+
+function moduleUrl(path) {
+  return `${path}?startupHelpersCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openStartupFixture(page, dependencyRoutes) {
+  await page.route('**/startup-helpers-browser-coverage', route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><main id="fixture"></main></body></html>',
+  }));
+
+  for (const [glob, body] of Object.entries(dependencyRoutes)) {
+    await page.route(glob, route => route.fulfill({
+      contentType: 'application/javascript',
+      body,
+    }));
+  }
+
+  await page.goto('/startup-helpers-browser-coverage', { waitUntil: 'load' });
+}
+
+function expectOutcomes(outcomes) {
+  for (const [name, passed] of Object.entries(outcomes)) {
+    expect(passed, name).toBe(true);
+  }
+}
+
+test('startup foundation initializes blocking services in order', async ({ page }) => {
+  await openStartupFixture(page, {
+    '**/js/crypto.js*': `
+      export async function initEncryption() {
+        window.__startupFoundationCalls.push('initEncryption');
+      }
+      export function initBroadcastChannel() {
+        window.__startupFoundationCalls.push('initBroadcastChannel');
+      }
+      export async function initFolderBackup() {
+        window.__startupFoundationCalls.push('initFolderBackup');
+      }
+    `,
+    '**/js/sun-uvdata.js*': `
+      export async function initMeteoConfigCache() {
+        window.__startupFoundationCalls.push('initMeteoConfigCache');
+      }
+    `,
+  });
+
+  const outcomes = await page.evaluate(async ({ foundationUrl }) => {
+    window.__startupFoundationCalls = [];
+    const foundation = await import(foundationUrl);
+    await foundation.initializeStartupFoundation();
+
+    return {
+      initializesServicesInBlockingOrder: JSON.stringify(window.__startupFoundationCalls) === JSON.stringify([
+        'initEncryption',
+        'initMeteoConfigCache',
+        'initBroadcastChannel',
+        'initFolderBackup',
+      ]),
+    };
+  }, {
+    foundationUrl: moduleUrl('/js/startup-foundation.js'),
+  });
+
+  expectOutcomes(outcomes);
+});
+
+test('startup profile migrates legacy storage and applies saved display state', async ({ page }) => {
+  await openStartupFixture(page, {
+    '**/js/state.js*': `
+      export const state = window.__startupProfileState;
+    `,
+    '**/js/profile.js*': `
+      export async function saveProfiles(profiles) {
+        window.__startupProfileCalls.push(['saveProfiles', profiles.length, profiles[0]?.id]);
+        localStorage.setItem('labcharts-profiles', JSON.stringify(profiles));
+      }
+      export function getActiveProfileId() {
+        window.__startupProfileCalls.push(['getActiveProfileId']);
+        return window.__activeProfileId || 'default';
+      }
+      export function setActiveProfileId(id) {
+        window.__startupProfileCalls.push(['setActiveProfileId', id]);
+        window.__activeProfileId = id;
+      }
+      export function getProfileSex(profileId) {
+        window.__startupProfileCalls.push(['getProfileSex', profileId]);
+        return window.__profileSex;
+      }
+      export function getProfileDob(profileId) {
+        window.__startupProfileCalls.push(['getProfileDob', profileId]);
+        return window.__profileDob;
+      }
+      export function profileStorageKey(profileId, key) {
+        return 'labcharts-' + profileId + '-' + key;
+      }
+      export function migrateProfileData(importedData) {
+        window.__startupProfileCalls.push(['migrateProfileData', Array.isArray(importedData.notes)]);
+        importedData.migratedByProfileStub = true;
+      }
+      export async function initProfilesCache() {
+        window.__startupProfileCalls.push(['initProfilesCache']);
+      }
+    `,
+    '**/js/crypto.js*': `
+      export async function encryptedGetItem(key) {
+        window.__encryptedReads.push(key);
+        return localStorage.getItem(key);
+      }
+      export async function encryptedSetItem(key, value) {
+        window.__encryptedWrites.push([key, value]);
+        localStorage.setItem(key, value);
+      }
+    `,
+    '**/js/data-merge.js*': `
+      export function ensureImportedArray(importedData, key) {
+        window.__startupProfileCalls.push(['ensureImportedArray', key]);
+        if (!Array.isArray(importedData[key])) importedData[key] = [];
+      }
+    `,
+  });
+
+  const outcomes = await page.evaluate(async ({ profileUrl }) => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <button class="unit-toggle-btn" data-unit="SI"></button>
+      <button class="unit-toggle-btn" data-unit="US"></button>
+      <button class="sex-toggle-btn" data-sex="male"></button>
+      <button class="sex-toggle-btn" data-sex="female"></button>
+      <button class="range-toggle-btn" data-range="optimal"></button>
+      <button class="range-toggle-btn" data-range="both"></button>
+      <input id="dob-input">
+    `;
+    window.__startupProfileCalls = [];
+    window.__encryptedReads = [];
+    window.__encryptedWrites = [];
+    window.__activeProfileId = null;
+    window.__profileSex = 'female';
+    window.__profileDob = '1990-02-03';
+    window.__startupProfileState = {
+      currentProfile: '',
+      importedData: {},
+      unitSystem: 'SI',
+      rangeMode: 'optimal',
+      profileSex: null,
+      profileDob: null,
+    };
+    localStorage.setItem('labcharts-imported', JSON.stringify({ entries: [{ date: '2026-06-01' }] }));
+    localStorage.setItem('labcharts-units', 'US');
+    localStorage.setItem('labcharts-default-rangeMode', 'both');
+
+    const profile = await import(profileUrl);
+    await profile.initializeProfileData();
+    profile.applyProfileDisplayState();
+
+    const activeUnit = document.querySelector('.unit-toggle-btn[data-unit="US"]');
+    const inactiveUnit = document.querySelector('.unit-toggle-btn[data-unit="SI"]');
+    const activeSex = document.querySelector('.sex-toggle-btn[data-sex="female"]');
+    const activeRange = document.querySelector('.range-toggle-btn[data-range="both"]');
+    const dobInput = document.getElementById('dob-input');
+
+    return {
+      legacyProfileStorageIsCreatedAndOldKeysRemoved:
+        JSON.parse(localStorage.getItem('labcharts-profiles') || '[]')[0]?.id === 'default'
+        && window.__activeProfileId === 'default'
+        && localStorage.getItem('labcharts-imported') === null
+        && localStorage.getItem('labcharts-units') === null,
+      legacyImportedDataMovesThroughEncryptedStorage:
+        window.__encryptedWrites.some(([key, value]) => key === 'labcharts-default-imported' && value.includes('2026-06-01'))
+        && window.__encryptedReads.includes('labcharts-default-imported'),
+      activeProfileDataLoadsAndMigrates:
+        window.__startupProfileState.currentProfile === 'default'
+        && Array.isArray(window.__startupProfileState.importedData.notes)
+        && window.__startupProfileState.importedData.migratedByProfileStub === true
+        && window.__startupProfileCalls.some(call => call[0] === 'initProfilesCache')
+        && window.__startupProfileCalls.some(call => call[0] === 'ensureImportedArray' && call[1] === 'notes'),
+      savedDisplayStateUpdatesStateAndControls:
+        window.__startupProfileState.unitSystem === 'US'
+        && window.__startupProfileState.rangeMode === 'both'
+        && window.__startupProfileState.profileSex === 'female'
+        && window.__startupProfileState.profileDob === '1990-02-03'
+        && activeUnit.classList.contains('active')
+        && !inactiveUnit.classList.contains('active')
+        && activeSex.classList.contains('active')
+        && activeRange.classList.contains('active')
+        && dobInput.value === '1990-02-03',
+    };
+  }, {
+    profileUrl: moduleUrl('/js/startup-profile.js'),
+  });
+
+  expectOutcomes(outcomes);
+});
+
+test('startup maintenance starts services and runs non-blocking migrations', async ({ page }) => {
+  await openStartupFixture(page, {
+    '**/js/state.js*': `
+      export const state = window.__startupMaintenanceState;
+    `,
+    '**/js/wearables-connect.js*': `
+      export function loadWearableRuntimeConfig() {
+        window.__startupMaintenanceCalls.push('loadWearableRuntimeConfig');
+      }
+      export function initWearableScheduler() {
+        window.__startupMaintenanceCalls.push('initWearableScheduler');
+      }
+      export function syncStaleWearablesNow() {
+        window.__startupMaintenanceCalls.push('syncStaleWearablesNow');
+        return Promise.reject(new Error('offline'));
+      }
+      export function listConnectedSources() {
+        window.__startupMaintenanceCalls.push('listConnectedSources');
+        return ['manual', 'oura'];
+      }
+    `,
+    '**/js/wearables-manual.js*': `
+      export async function migrateBiometricsToManual(profileId, biometrics) {
+        window.__startupMaintenanceCalls.push(['migrateBiometricsToManual', profileId, biometrics?.weight]);
+      }
+      export async function hasManualData(profileId) {
+        window.__startupMaintenanceCalls.push(['hasManualData', profileId]);
+        return true;
+      }
+    `,
+    '**/js/wearables-summary.js*': `
+      export async function syncWearableSummary(profileId, sources) {
+        window.__startupMaintenanceCalls.push(['syncWearableSummary', profileId, sources]);
+      }
+    `,
+  });
+
+  const outcomes = await page.evaluate(async ({ maintenanceUrl }) => {
+    const originalSetTimeout = window.setTimeout;
+    const originalConsoleLog = console.log;
+    const originalRehydrate = window.rehydrateStaleSessions;
+    const originalHydrate = window.hydrateDevicesFromPresets;
+    const originalEngineVersion = window.SUN_ENGINE_VERSION;
+    const logs = [];
+
+    window.__startupMaintenanceCalls = [];
+    window.__startupMaintenanceState = {
+      currentProfile: 'startup-maintenance-profile',
+      importedData: { biometrics: { weight: 70 } },
+    };
+    window.setTimeout = (callback, delay, ...args) => {
+      window.__startupMaintenanceCalls.push(['setTimeout', delay]);
+      callback(...args);
+      return 1;
+    };
+    console.log = (...args) => {
+      logs.push(args.map(arg => String(arg)).join(' '));
+    };
+    window.SUN_ENGINE_VERSION = 'maintenance-test';
+    window.rehydrateStaleSessions = async () => {
+      window.__startupMaintenanceCalls.push('rehydrateStaleSessions');
+      return { rehydrated: 2 };
+    };
+    window.hydrateDevicesFromPresets = async () => {
+      window.__startupMaintenanceCalls.push('hydrateDevicesFromPresets');
+      return true;
+    };
+
+    const waitUntil = async predicate => {
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        if (predicate()) return true;
+        await new Promise(resolve => originalSetTimeout(resolve, 10));
+      }
+      return false;
+    };
+
+    try {
+      const maintenance = await import(maintenanceUrl);
+      maintenance.initializeStartupServices();
+      maintenance.runPostProfileStartupMaintenance();
+      const summarySynced = await waitUntil(() => window.__startupMaintenanceCalls
+        .some(call => Array.isArray(call) && call[0] === 'syncWearableSummary'));
+
+      return {
+        startupServicesInitializeWearableConfigAndScheduler:
+          window.__startupMaintenanceCalls.includes('loadWearableRuntimeConfig')
+          && window.__startupMaintenanceCalls.includes('initWearableScheduler'),
+        staleWearableSyncIsStartedAndIgnoredOnFailure:
+          window.__startupMaintenanceCalls.includes('syncStaleWearablesNow'),
+        sunSessionRehydrateIsDeferredAndLogged:
+          window.__startupMaintenanceCalls.some(call => Array.isArray(call) && call[0] === 'setTimeout' && call[1] === 1500)
+          && window.__startupMaintenanceCalls.includes('rehydrateStaleSessions')
+          && logs.some(line => line.includes('[sun] self-healed 2 session(s) under vmaintenance-test')),
+        lightDeviceHydrationRunsAndLogsDirtyState:
+          window.__startupMaintenanceCalls.includes('hydrateDevicesFromPresets')
+          && logs.some(line => line.includes('[light] hydrated user devices from preset library')),
+        legacyBiometricsMigrationRefreshesManualSummary:
+          summarySynced
+          && window.__startupMaintenanceCalls.some(call => Array.isArray(call)
+            && call[0] === 'migrateBiometricsToManual'
+            && call[1] === 'startup-maintenance-profile'
+            && call[2] === 70)
+          && window.__startupMaintenanceCalls.some(call => Array.isArray(call)
+            && call[0] === 'syncWearableSummary'
+            && call[1] === 'startup-maintenance-profile'
+            && JSON.stringify(call[2]) === JSON.stringify(['manual', 'oura'])),
+      };
+    } finally {
+      window.setTimeout = originalSetTimeout;
+      console.log = originalConsoleLog;
+      if (originalRehydrate) window.rehydrateStaleSessions = originalRehydrate;
+      else delete window.rehydrateStaleSessions;
+      if (originalHydrate) window.hydrateDevicesFromPresets = originalHydrate;
+      else delete window.hydrateDevicesFromPresets;
+      if (originalEngineVersion === undefined) delete window.SUN_ENGINE_VERSION;
+      else window.SUN_ENGINE_VERSION = originalEngineVersion;
+    }
+  }, {
+    maintenanceUrl: moduleUrl('/js/startup-maintenance.js'),
+  });
+
+  expectOutcomes(outcomes);
+});
+
+test('startup UI renders chrome and schedules deferred startup work', async ({ page }) => {
+  await openStartupFixture(page, {
+    '**/js/startup-profile.js*': `
+      export function applyProfileDisplayState() {
+        window.__startupUICalls.push('applyProfileDisplayState');
+      }
+    `,
+    '**/js/theme.js*': `
+      export function getTheme() {
+        window.__startupUICalls.push('getTheme');
+        return 'glass';
+      }
+      export function setTheme(theme) {
+        window.__startupUICalls.push(['setTheme', theme]);
+      }
+    `,
+    '**/js/data.js*': `
+      export function updateHeaderDates() {
+        window.__startupUICalls.push('updateHeaderDates');
+      }
+      export function updateHeaderRangeToggle() {
+        window.__startupUICalls.push('updateHeaderRangeToggle');
+      }
+    `,
+    '**/js/import-file-input.js*': `
+      export function bindImportFileInput() {
+        window.__startupUICalls.push('bindImportFileInput');
+      }
+    `,
+    '**/js/dna.js*': `
+      export function ensureSNPTable() {
+        window.__startupUICalls.push('ensureSNPTable');
+      }
+      export function ensureHaplogroupTable() {
+        window.__startupUICalls.push('ensureHaplogroupTable');
+      }
+    `,
+    '**/js/changelog.js*': `
+      export function maybeShowChangelog() {
+        window.__startupUICalls.push('maybeShowChangelog');
+      }
+    `,
+    '**/js/nav.js*': `
+      export function buildSidebar() {
+        window.__startupUICalls.push('buildSidebar');
+      }
+      export function renderProfileDropdown() {
+        window.__startupUICalls.push('renderProfileDropdown');
+      }
+    `,
+    '**/js/crypto.js*': `
+      export function maybeShowBackupNudge() {
+        window.__startupUICalls.push('maybeShowBackupNudge');
+      }
+    `,
+    '**/js/sync.js*': `
+      export function primeSyncState() {
+        window.__startupUICalls.push('primeSyncState');
+      }
+      export async function initSync() {
+        window.__startupUICalls.push('initSync');
+      }
+      export function renderSyncIndicator() {
+        window.__startupUICalls.push('renderSyncIndicator');
+      }
+    `,
+  });
+
+  const outcomes = await page.evaluate(async ({ startupUiUrl }) => {
+    const originalSetTimeout = window.setTimeout;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    window.__startupUICalls = [];
+    document.body.innerHTML = `
+      <span id="app-version-text"></span>
+      <div id="passphrase-overlay" style="display: none;"></div>
+    `;
+    window.APP_VERSION = 'startup-ui-test-version';
+    window.getInitialView = () => 'light';
+    window.navigate = view => {
+      window.__startupUICalls.push(['navigate', view]);
+    };
+    window.maybeShowAnalyticsConsent = () => {
+      window.__startupUICalls.push('maybeShowAnalyticsConsent');
+    };
+    window.openSettingsModal = section => {
+      window.__startupUICalls.push(['openSettingsModal', section]);
+    };
+    window.openChatPanel = () => {
+      window.__startupUICalls.push('openChatPanel');
+    };
+    window.initChatImageHandlers = () => {
+      window.__startupUICalls.push('initChatImageHandlers');
+    };
+    window.updateAttachButtonVisibility = () => {
+      window.__startupUICalls.push('updateAttachButtonVisibility');
+    };
+    window.updateChatNudge = () => {
+      window.__startupUICalls.push('updateChatNudge');
+    };
+    window._openSettingsAfterInit = 'display';
+    window._openChatAfterInit = true;
+    window.requestAnimationFrame = callback => {
+      window.__startupUICalls.push('requestAnimationFrame');
+      callback(performance.now());
+      return 1;
+    };
+    window.setTimeout = (callback, delay, ...args) => {
+      window.__startupUICalls.push(['setTimeout', delay]);
+      callback(...args);
+      return 1;
+    };
+
+    const waitUntil = async predicate => {
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        if (predicate()) return true;
+        await new Promise(resolve => originalSetTimeout(resolve, 10));
+      }
+      return false;
+    };
+
+    try {
+      const startupUi = await import(startupUiUrl);
+      startupUi.renderStartupUI();
+      const deferredWorkCompleted = await waitUntil(() => window.__startupUICalls
+        .filter(call => call === 'renderSyncIndicator').length >= 2);
+
+      return {
+        footerVersionRendersFromAppVersion:
+          document.getElementById('app-version-text')?.textContent === 'startup-ui-test-version',
+        firstPaintChromeAndNavigationRun:
+          window.__startupUICalls.includes('primeSyncState')
+          && window.__startupUICalls.includes('applyProfileDisplayState')
+          && window.__startupUICalls.some(call => Array.isArray(call) && call[0] === 'setTheme' && call[1] === 'glass')
+          && window.__startupUICalls.includes('buildSidebar')
+          && window.__startupUICalls.some(call => Array.isArray(call) && call[0] === 'navigate' && call[1] === 'light'),
+        deferredSyncAndCatalogWarmupRun:
+          deferredWorkCompleted
+          && window.__startupUICalls.includes('requestAnimationFrame')
+          && window.__startupUICalls.some(call => Array.isArray(call) && call[0] === 'setTimeout' && call[1] === 0)
+          && window.__startupUICalls.includes('initSync')
+          && window.__startupUICalls.includes('ensureSNPTable')
+          && window.__startupUICalls.includes('ensureHaplogroupTable'),
+        changelogNudgesAndDeferredDestinationsRun:
+          window.__startupUICalls.includes('maybeShowChangelog')
+          && window.__startupUICalls.includes('maybeShowAnalyticsConsent')
+          && window.__startupUICalls.includes('maybeShowBackupNudge')
+          && window.__startupUICalls.some(call => Array.isArray(call) && call[0] === 'openSettingsModal' && call[1] === 'display')
+          && window.__startupUICalls.includes('openChatPanel')
+          && !('_openSettingsAfterInit' in window)
+          && !('_openChatAfterInit' in window),
+        chromeRefreshAndChatAttachmentsRun:
+          window.__startupUICalls.includes('updateHeaderDates')
+          && window.__startupUICalls.includes('updateHeaderRangeToggle')
+          && window.__startupUICalls.includes('renderProfileDropdown')
+          && window.__startupUICalls.includes('initChatImageHandlers')
+          && window.__startupUICalls.includes('updateAttachButtonVisibility')
+          && window.__startupUICalls.includes('updateChatNudge')
+          && window.__startupUICalls.includes('bindImportFileInput'),
+      };
+    } finally {
+      window.setTimeout = originalSetTimeout;
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      delete window._openSettingsAfterInit;
+      delete window._openChatAfterInit;
+    }
+  }, {
+    startupUiUrl: moduleUrl('/js/startup-ui.js'),
+  });
+
+  expectOutcomes(outcomes);
+});


### PR DESCRIPTION
## Summary
- Add focused Playwright browser coverage for startup foundation ordering, profile legacy migration/display state, maintenance background work, and startup UI scheduling/chrome setup.
- Use route-stubbed dependencies so the actual startup helper modules run in-browser without booting unrelated app flows.

## Tests
- `node --check tests/playwright/startup-helpers-browser-coverage.spec.js`
- `git diff --check`
- `npm run test:playwright -- tests/playwright/startup-helpers-browser-coverage.spec.js`