### PR TITLE
[codex] Add light page view browser coverage

### DIFF
--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -1,5 +1,9 @@
 import { expect, test } from './coverage-fixture.js';
 
+function moduleUrl(path) {
+  return `${path}?lightPageViewCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 test('Light page view delegates session, link, channel, and prompt actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForFunction(() => typeof window.navigate === 'function');
@@ -104,6 +108,195 @@ test('Light page view delegates session, link, channel, and prompt actions', asy
       host.remove();
       document.getElementById('light-tools-expanded-test')?.remove();
     }
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});
+
+test('Light page today strip and empty-state hints cover adaptive branches', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  await page.waitForSelector('#main-content');
+
+  const results = await page.evaluate(async ({ lightPageUrl }) => {
+    const [{ state }, lightPage] = await Promise.all([
+      import('/js/state.js'),
+      import(lightPageUrl),
+    ]);
+    const outcomes = {};
+    const RealDate = Date;
+    const main = document.getElementById('main-content');
+    const saved = {
+      importedData: state.importedData,
+      mainHTML: main?.innerHTML,
+      Date: window.Date,
+      getSessions: window.getSessions,
+      getDeviceSessions: window.getDeviceSessions,
+      getDevices: window.getDevices,
+      getActiveSession: window.getActiveSession,
+      cumulativeMEDToday: window.cumulativeMEDToday,
+      cumulativeMEDYesterday: window.cumulativeMEDYesterday,
+      rollingVitaminDIU: window.rollingVitaminDIU,
+      vitaminDBudgetStatus: window.vitaminDBudgetStatus,
+      getSunCoords: window.getSunCoords,
+      renderLightTodayDashboardChip: window.renderLightTodayDashboardChip,
+      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
+      weeklyChannelTier: window.weeklyChannelTier,
+      channelTier: window.channelTier,
+      dailyChannelBreakdown: window.dailyChannelBreakdown,
+      rollingChannelTotals: window.rollingChannelTotals,
+      rollingDeviceTotals: window.rollingDeviceTotals,
+      renderLightTodayHero: window.renderLightTodayHero,
+      renderSunSetupCard: window.renderSunSetupCard,
+      renderDevicesSection: window.renderDevicesSection,
+      renderEnvironmentAssessmentSummary: window.renderEnvironmentAssessmentSummary,
+      renderLightTools: window.renderLightTools,
+    };
+    const setHour = (hour) => {
+      const fixed = new RealDate(`2026-06-11T${String(hour).padStart(2, '0')}:15:00`);
+      class FixedDate extends RealDate {
+        constructor(...args) {
+          if (args.length) return super(...args);
+          return new RealDate(fixed);
+        }
+
+        static now() { return fixed.getTime(); }
+      }
+      FixedDate.UTC = RealDate.UTC;
+      FixedDate.parse = RealDate.parse;
+      window.Date = FixedDate;
+    };
+    const channelMeta = {
+      vitamin_d: { label: 'Vitamin D', icon: 'D', what: 'Vitamin D', dailyTarget: 100 },
+      circadian: { label: 'Circadian', icon: 'C', what: 'Circadian', dailyTarget: 100 },
+      nir_solar: { label: 'NIR', icon: 'N', what: 'Near infrared', dailyTarget: 100 },
+      no_cv: { label: 'NO', icon: 'NO', what: 'Nitric oxide', dailyTarget: 100 },
+      pomc: { label: 'POMC', icon: 'P', what: 'POMC', dailyTarget: 100 },
+      violet_eye: { label: 'Violet', icon: 'V', what: 'Violet eye', dailyTarget: 100 },
+    };
+
+    try {
+      state.importedData = {
+        ...(state.importedData || {}),
+        sunDefaults: null,
+        lightEnvironment: null,
+      };
+      window.CHANNEL_DISPLAY = channelMeta;
+      window.weeklyChannelTier = value => value > 100 ? 2 : 0;
+      window.channelTier = window.weeklyChannelTier;
+      window.dailyChannelBreakdown = () => Array.from({ length: 7 }, (_, index) => ({
+        sun: index === 0 ? 120 : 0,
+        device: index === 1 ? 80 : 0,
+      }));
+      window.rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
+      window.rollingDeviceTotals = () => ({ nir_solar: 120 });
+      window.getSessions = () => [];
+      window.getDeviceSessions = () => [];
+      window.getDevices = () => [];
+      window.getActiveSession = () => null;
+      window.cumulativeMEDToday = () => 0.72;
+      window.cumulativeMEDYesterday = () => 0.4;
+      window.rollingVitaminDIU = () => 1800;
+      window.vitaminDBudgetStatus = () => ({
+        supplementIU: 5000,
+        sunIU: 1200,
+        total: 6200,
+        exceedsSupplementUL: true,
+      });
+      window.getSunCoords = () => ({ lat: 50, lon: 14, altitudeM: 1700, source: 'profile-precise' });
+      window.renderLightTodayDashboardChip = () => '<div class="light-dashboard-chip-test">chip</div>';
+
+      setHour(6);
+      const morning = lightPage.renderLightTodayStrip();
+      setHour(12);
+      const midday = lightPage.renderLightTodayStrip();
+      setHour(18);
+      const evening = lightPage.renderLightTodayStrip();
+      outcomes.solarWindowLabelsRenderByTime =
+        morning.includes('Morning sun window')
+        && midday.includes('Midday window')
+        && evening.includes('Evening sun window');
+      outcomes.noSetupStripShowsSetupCta = morning.includes('Set up Light');
+      outcomes.noSetupStripShowsBurnRisk = morning.includes('approaching burn threshold');
+      outcomes.noSetupStripShowsAltitudeChip = morning.includes('+17% UV');
+      outcomes.noSetupStripShowsWeeklyVitD = morning.includes('~1800 IU vitamin D this week');
+      outcomes.noSetupStripShowsDashboardChip = morning.includes('light-dashboard-chip-test');
+
+      state.importedData = {
+        ...(state.importedData || {}),
+        sunDefaults: { completedAt: '2026-06-11T00:00:00.000Z', fitzpatrick: 'II' },
+        lightEnvironment: { rooms: [] },
+      };
+      setHour(22);
+      window.getDevices = () => [{ brand: 'Joovv', model: 'Solo' }];
+      const oneDevice = lightPage.renderLightTodayStrip();
+      window.getDevices = () => [{ brand: 'Joovv', model: 'Solo' }, { brand: 'SAD', model: 'Desk' }];
+      const manyDevices = lightPage.renderLightTodayStrip();
+      window.getDevices = () => [];
+      const noDevices = lightPage.renderLightTodayStrip();
+      outcomes.nonSolarCtasAdaptToDeviceAndRoomState =
+        oneDevice.includes('Joovv Solo')
+        && manyDevices.includes('Device <span aria-hidden="true">▼</span>')
+        && noDevices.includes('Log a sun session')
+        && oneDevice.includes('Map a room');
+
+      setHour(10);
+      window.getActiveSession = () => ({ id: 'active-sun', startedAt: Date.now() - 95_000 });
+      const activeStrip = lightPage.renderLightTodayStrip();
+      outcomes.activeSessionStripShowsStopElapsed =
+        activeStrip.includes('Stop session')
+        && activeStrip.includes('data-live-elapsed-for="active-sun"');
+
+      window.renderLightTodayHero = () => '';
+      window.renderSunSetupCard = () => '<div class="setup-card-test">setup</div>';
+      window.renderDevicesSection = () => '<div class="devices-section-test">devices</div>';
+      window.renderEnvironmentAssessmentSummary = () => '';
+      window.renderLightTools = () => '';
+      window.getActiveSession = () => null;
+      window.getDevices = () => [];
+      window.getSessions = () => [];
+      window.getDeviceSessions = () => [];
+      window.getSunCoords = () => null;
+      lightPage.showLight(state.importedData);
+      outcomes.emptyLightPagePromptsForMissingCoords =
+        main?.textContent.includes('set your country in the profile editor') === true
+        && main?.querySelector('[data-light-page-action="request-precise-location"]') !== null;
+
+      window.getSunCoords = () => ({ source: 'country-band', lat: 49.2, lon: 16.6 });
+      lightPage.showLight(state.importedData);
+      outcomes.emptyLightPageShowsCountryBandHint =
+        main?.textContent.includes('Calculations use your country (~49.2° lat)') === true;
+    } finally {
+      state.importedData = saved.importedData;
+      if (main && saved.mainHTML != null) main.innerHTML = saved.mainHTML;
+      window.Date = saved.Date || RealDate;
+      window.getSessions = saved.getSessions;
+      window.getDeviceSessions = saved.getDeviceSessions;
+      window.getDevices = saved.getDevices;
+      window.getActiveSession = saved.getActiveSession;
+      window.cumulativeMEDToday = saved.cumulativeMEDToday;
+      window.cumulativeMEDYesterday = saved.cumulativeMEDYesterday;
+      window.rollingVitaminDIU = saved.rollingVitaminDIU;
+      window.vitaminDBudgetStatus = saved.vitaminDBudgetStatus;
+      window.getSunCoords = saved.getSunCoords;
+      window.renderLightTodayDashboardChip = saved.renderLightTodayDashboardChip;
+      window.CHANNEL_DISPLAY = saved.CHANNEL_DISPLAY;
+      window.weeklyChannelTier = saved.weeklyChannelTier;
+      window.channelTier = saved.channelTier;
+      window.dailyChannelBreakdown = saved.dailyChannelBreakdown;
+      window.rollingChannelTotals = saved.rollingChannelTotals;
+      window.rollingDeviceTotals = saved.rollingDeviceTotals;
+      window.renderLightTodayHero = saved.renderLightTodayHero;
+      window.renderSunSetupCard = saved.renderSunSetupCard;
+      window.renderDevicesSection = saved.renderDevicesSection;
+      window.renderEnvironmentAssessmentSummary = saved.renderEnvironmentAssessmentSummary;
+      window.renderLightTools = saved.renderLightTools;
+    }
+
+    return outcomes;
+  }, {
+    lightPageUrl: moduleUrl('/js/light-page-view.js'),
   });
 
   for (const [name, passed] of Object.entries(results)) {


### PR DESCRIPTION
## Summary

Adds focused Playwright browser coverage for `light-page-view.js` adaptive rendering branches:

- covers Light Today strip solar-window labels, burn risk, altitude, weekly vitamin D, setup CTA, device CTA, and active-session output
- covers empty Light page coordinate hints for missing coordinates and country-band coordinates
- keeps the change test-only and scoped to the existing `light-page-view.spec.js`

## Validation

- `node --check tests/playwright/light-page-view.spec.js`
- `git diff --check`
- `npm run test:playwright -- tests/playwright/light-page-view.spec.js`