### PR TITLE
[codex] Add EMF edge browser coverage

### DIFF
--- a/tests/playwright/emf-edge-browser-coverage.spec.js
+++ b/tests/playwright/emf-edge-browser-coverage.spec.js
@@ -1,0 +1,276 @@
+import { expect, test } from './coverage-fixture.js';
+
+function moduleUrl(path) {
+  return `${path}?emfEdgeCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function openIsolatedEMFPage(page) {
+  await page.route('**/emf-edge-browser-coverage', route => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: `<!doctype html>
+      <html>
+        <body>
+          <div id="modal-overlay"><div id="detail-modal"></div></div>
+          <div id="notification-container"></div>
+        </body>
+      </html>`,
+  }));
+  await page.route('**/js/api.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export function hasAIProvider() { return true; }
+      export function getAIProvider() { return 'ollama'; }
+      export function getActiveModelId() { return 'emf-edge-model'; }
+      export function getActiveModelDisplay() { return 'EMF Edge Model'; }
+      export async function callClaudeAPI(opts) {
+        window.__emfApiCalls = window.__emfApiCalls || [];
+        window.__emfApiCalls.push({
+          hasStream: typeof opts.onStream === 'function',
+          system: opts.system || '',
+          user: opts.messages?.[0]?.content || '',
+          signalPresent: !!opts.signal,
+        });
+        if (typeof opts.onStream === 'function') {
+          opts.onStream('<think>hidden chain</think>\\n## Draft EMF interpretation\\nShield the bedroom first.');
+          await Promise.resolve();
+          return {
+            text: '<think>hidden final</think>\\n## Final EMF interpretation\\nShielding paint and WiFi off at night are the priority.',
+            usage: { inputTokens: 80, outputTokens: 24 },
+          };
+        }
+        return {
+          text: JSON.stringify({
+            date: '2026-06-20',
+            consultant: 'Edge Consultant',
+            rooms: [{
+              name: 'Bedroom',
+              location: 'Pillow wall',
+              measurements: {
+                acElectric: { value: 35, meter: 'NFA1000' },
+                rfMicrowave: { value: 12, meter: 'Safe Living' },
+              },
+              sources: ['WiFi router'],
+              mitigations: ['WiFi off at night'],
+            }],
+            note: 'Imported edge report note',
+          }),
+          usage: { inputTokens: 16, outputTokens: 12 },
+        };
+      }
+    `,
+  }));
+  await page.route('**/js/data.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export async function saveImportedData() {
+        window.__emfDataSaves = (window.__emfDataSaves || 0) + 1;
+        return true;
+      }
+    `,
+  }));
+  await page.route('**/js/pdf-import.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export async function extractPDFText(file) {
+        window.__emfExtractedPdfName = file?.name || '';
+        return 'Client bedroom report with WiFi router, RF microwave readings, and mitigation recommendations.';
+      }
+    `,
+  }));
+  await page.route('**/js/pii.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export function obfuscatePDFText(text) {
+        window.__emfObfuscations = (window.__emfObfuscations || 0) + 1;
+        return { obfuscated: text.replace(/Client/g, 'Person') };
+      }
+      export async function sanitizeWithOllama(text) { return text; }
+      export function sanitizeWithOllamaStreaming() {}
+      export async function checkOllamaPII() { return { available: false }; }
+      export async function reviewPIIBeforeSend() { return 'cancel'; }
+    `,
+  }));
+  await page.route('**/js/image-utils.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export function isValidImageType(type) {
+        return /^image\\//.test(type || '');
+      }
+      export async function resizeImage(file) {
+        window.__emfResizeCalls = window.__emfResizeCalls || [];
+        window.__emfResizeCalls.push(file.name);
+        return { base64: btoa(file.name || 'photo'), mediaType: file.type || 'image/png' };
+      }
+    `,
+  }));
+  await page.route('**/js/recommendations.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: `
+      export async function loadEMFCatalog() {
+        window.__emfCatalogLoads = (window.__emfCatalogLoads || 0) + 1;
+        return { products: [{ name: 'Shielding paint' }] };
+      }
+      export function renderEMFMeterRecs() {
+        return '<div class="meter-rec">Meter recommendation</div>';
+      }
+      export function renderEMFMitigationRecs() {
+        return '<div class="mitigation-rec">Products to consider</div>';
+      }
+      export function isProductRecsEnabled() { return true; }
+      export function detectMitigationsInText(text) {
+        return /shielding paint/i.test(text || '') ? ['shielding paint'] : [];
+      }
+    `,
+  }));
+  await page.goto('/emf-edge-browser-coverage', { waitUntil: 'load' });
+}
+
+test('EMF edge browser coverage imports PDFs photos rooms and streams interpretations', async ({ page }) => {
+  await openIsolatedEMFPage(page);
+
+  const results = await page.evaluate(async ({ emfUrl }) => {
+    const [{ state }] = await Promise.all([
+      import('/js/state.js'),
+      import(emfUrl),
+    ]);
+    const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const waitUntil = async (predicate, label) => {
+      for (let i = 0; i < 80; i += 1) {
+        if (predicate()) return true;
+        await wait(25);
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
+    const outcomes = {};
+    const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
+      const key = localStorage.key(i);
+      return [key, localStorage.getItem(key)];
+    }));
+    const original = {
+      importedData: state.importedData,
+      currentProfile: state.currentProfile,
+      closeModal: window.closeModal,
+    };
+    const assessments = () => state.importedData.emfAssessment?.assessments || [];
+
+    try {
+      window.__emfApiCalls = [];
+      window.__emfDataSaves = 0;
+      window.__emfResizeCalls = [];
+      window.__emfCatalogLoads = 0;
+      state.currentProfile = 'emf-edge-browser-coverage';
+      state.importedData = {
+        entries: [],
+        notes: [],
+        supplements: [],
+        healthGoals: [],
+        diagnoses: null,
+        customMarkers: {},
+        markerNotes: {},
+        markerValueNotes: {},
+        changeHistory: [],
+        emfAssessment: { assessments: [] },
+      };
+      window.closeModal = () => document.getElementById('modal-overlay')?.classList.remove('show');
+      localStorage.setItem('labcharts-pii-review', 'false');
+
+      window.openEMFAssessmentEditor();
+      await waitUntil(() => !!document.querySelector('#detail-modal .emf-editor-actions'), 'EMF editor');
+      document.querySelector('#detail-modal .modal-close')?.click();
+      outcomes.closeButtonOnceHandlerSavesEditorState =
+        window.__emfDataSaves >= 1
+        && !document.getElementById('modal-overlay')?.classList.contains('show');
+
+      window.openEMFAssessmentEditor();
+      await waitUntil(() => !!document.querySelector('.emf-editor-actions'), 'reopened EMF editor');
+      document.querySelector('.emf-editor-actions .import-btn-primary')?.click();
+      await waitUntil(() => assessments().length === 1, 'manual assessment created');
+      const manualId = assessments()[0].id;
+      window.addEMFRoom(manualId);
+      await waitUntil(() => assessments()[0].rooms.length === 2, 'explicit EMF room added');
+      outcomes.addEMFRoomAddsBlankRoomAndSelectsIt =
+        assessments()[0].rooms[1].name === 'Bedroom'
+        && document.querySelector('.emf-room-tab.active')?.textContent.includes('Bedroom') === true;
+
+      await window.handleEMFPDF(new File(['fake pdf bytes'], 'edge-emf-report.pdf', { type: 'application/pdf' }));
+      await waitUntil(() => !!document.getElementById('emf-confirm-btn'), 'EMF import preview');
+      outcomes.pdfPreviewRendersParsedRoomAndUsesPiiFallback =
+        window.__emfExtractedPdfName === 'edge-emf-report.pdf'
+        && window.__emfObfuscations === 1
+        && document.getElementById('detail-modal')?.textContent.includes('Edge Consultant') === true
+        && document.getElementById('detail-modal')?.textContent.includes('WiFi router') === true;
+
+      document.getElementById('emf-confirm-btn').click();
+      await waitUntil(() => assessments().some(a => a.consultant === 'Edge Consultant'), 'EMF import confirmed');
+      const imported = assessments().find(a => a.consultant === 'Edge Consultant');
+      outcomes.confirmImportPersistsUnitsAndRendersEditor =
+        imported?.date === '2026-06-20'
+        && imported.rooms[0].measurements.acElectric.unit === 'V/m'
+        && imported.rooms[0].measurements.rfMicrowave.unit === '\u00b5W/m\u00b2'
+        && document.querySelector('.emf-assessment-card.expanded')?.textContent.includes('Edge Consultant') === true;
+
+      const files = [
+        new File(['one'], 'one.jpg', { type: 'image/jpeg' }),
+        new File(['two'], 'two.png', { type: 'image/png' }),
+        new File(['three'], 'three.webp', { type: 'image/webp' }),
+        new File(['four'], 'four.gif', { type: 'image/gif' }),
+        new File(['five'], 'five.jpg', { type: 'image/jpeg' }),
+        new File(['six'], 'six.jpg', { type: 'image/jpeg' }),
+        new File(['seven'], 'seven.jpg', { type: 'image/jpeg' }),
+        new File(['skip'], 'skip.txt', { type: 'text/plain' }),
+      ];
+      await window.addEMFPhotos(imported.id, 0, files);
+      await waitUntil(() => imported.rooms[0].photos?.length === 6, 'EMF photos capped');
+      outcomes.addEMFPhotosResizesValidImagesAndCapsAtSix =
+        imported.rooms[0].photos.length === 6
+        && window.__emfResizeCalls.length === 6
+        && imported.rooms[0].photos[0].name === 'one.jpg'
+        && document.querySelectorAll('.emf-photo-thumb').length === 6;
+
+      window.interpretEMFAssessment(imported.id);
+      await waitUntil(() => !!document.querySelector('#emf-interp-overlay.show #emf-interp-generate'), 'EMF interpretation modal');
+      document.getElementById('emf-interp-generate').click();
+      await waitUntil(
+        () => imported.interpretation?.text.includes('Final EMF interpretation'),
+        'EMF streamed interpretation saved'
+      );
+      const interpBody = document.getElementById('emf-interp-body')?.textContent || '';
+      outcomes.streamInterpretationStripsThinkingSavesUsageAndAddsDiscuss =
+        !interpBody.includes('hidden final')
+        && interpBody.includes('Final EMF interpretation')
+        && imported.interpretation.model === 'EMF Edge Model'
+        && imported.interpretation.inputTokens === 80
+        && imported.interpretation.outputTokens === 24
+        && window.__emfApiCalls.some(call => call.hasStream && call.signalPresent)
+        && !!document.querySelector('#emf-interp-overlay button.import-btn-secondary');
+
+      await waitUntil(() => document.getElementById('emf-interp-recs')?.textContent.includes('Products to consider'), 'mitigation recs');
+      outcomes.productRecsLoadForMitigationTags = window.__emfCatalogLoads >= 1;
+    } finally {
+      document.getElementById('emf-interp-overlay')?.remove();
+      document.querySelectorAll('.notification-toast').forEach(el => el.remove());
+      state.importedData = original.importedData;
+      state.currentProfile = original.currentProfile;
+      window.closeModal = original.closeModal;
+      localStorage.clear();
+      for (const [key, value] of storage) {
+        if (key && value != null) localStorage.setItem(key, value);
+      }
+    }
+
+    return outcomes;
+  }, {
+    emfUrl: moduleUrl('/js/emf.js'),
+  });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- add isolated Playwright coverage for EMF edge paths
- cover PDF preview/import, explicit room adding, photo ingestion/capping, close-save handling, and streamed AI interpretation cleanup

## Validation
- `node --check tests/playwright/emf-edge-browser-coverage.spec.js`
- `git diff --check -- tests/playwright/emf-edge-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/emf-edge-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-emf-edge-coverage npm run test:playwright -- tests/playwright/emf-edge-browser-coverage.spec.js`