### PR TITLE
[codex] Cover sync default enabled guards

### DIFF
--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -246,7 +246,12 @@ test('sync action delegates push force pull and all-profile paths', async ({ pag
       await actions.syncNow();
       await actions.forceResendCurrentProfile();
       outcomes.defaultActionDependenciesAreSafeNoops = pushes.length === 0 && pulls.length === 0;
-      actions.configureSyncActions({ isEvoluReady: () => true });
+      actions.configureSyncActions({
+        isEvoluReady: () => true,
+        pushProfile: async (id, data, options) => {
+          pushes.push({ id, data: clone(data), options: clone(options || null) });
+        },
+      });
       await actions.forceResendCurrentProfile();
       outcomes.defaultSyncEnabledDependencyGatesForceResend = pushes.length === 0;
 

--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -246,6 +246,9 @@ test('sync action delegates push force pull and all-profile paths', async ({ pag
       await actions.syncNow();
       await actions.forceResendCurrentProfile();
       outcomes.defaultActionDependenciesAreSafeNoops = pushes.length === 0 && pulls.length === 0;
+      actions.configureSyncActions({ isEvoluReady: () => true });
+      await actions.forceResendCurrentProfile();
+      outcomes.defaultSyncEnabledDependencyGatesForceResend = pushes.length === 0;
 
       let enabled = false;
       let ready = false;
@@ -347,6 +350,11 @@ test('sync indicator popover renders debug actions and copies activity', async (
       if (!slot.parentNode) document.body.appendChild(slot);
       localStorage.setItem('labcharts-debug', 'true');
       syncState.resetSyncStatus();
+
+      slot.innerHTML = '<span>stale</span>';
+      syncUi.renderSyncIndicator();
+      outcomes.defaultSyncUIEnabledDependencyClearsSlot = slot.innerHTML === '';
+
       syncUi.configureSyncUI({ isSyncEnabled: () => enabled });
 
       syncUi.renderSyncIndicator();


### PR DESCRIPTION
## Summary
- exercise the default sync-enabled dependency in `sync-actions.js` by forcing the readiness gate open before configuration
- exercise the default sync-enabled dependency in `sync-ui.js` by rendering the sync indicator before injecting a custom enabled predicate
- keep both checks in the existing sync browser coverage spec

## Validation
- `npm run test:playwright -- tests/playwright/sync-actions-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-sync-default-enabled-coverage npm run test:playwright -- tests/playwright/sync-actions-browser-coverage.spec.js`