### PR TITLE
Cover mobile wearable priority order

### DIFF
--- a/tests/playwright/mobile-dashboard-browser-coverage.spec.js
+++ b/tests/playwright/mobile-dashboard-browser-coverage.spec.js
@@ -102,6 +102,12 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
       outcomes.breakpointListenerWasRegistered = mediaListeners.length > 0
         && mobileDashboard.isMobileDashboardViewport() === true;
 
+      const wearablePriority = mobileDashboard.getMobileWearablePriority();
+      outcomes.mobileWearablePriorityKeepsHighSignalOrder =
+        wearablePriority.slice(0, 4).join('|') === 'hrv_rmssd|sleep_score|readiness_score|steps'
+        && wearablePriority.includes('bp_systolic')
+        && wearablePriority.indexOf('steps') < wearablePriority.indexOf('bp_systolic');
+
       state.currentView = 'dashboard';
       mediaListeners[0]?.({ matches: true });
       state.currentView = 'labs';


### PR DESCRIPTION
## Summary
- Add a Playwright assertion for `getMobileWearablePriority` in the existing mobile dashboard browser coverage spec.
- Verify high-signal wearable metrics keep their expected priority order before lower-priority blood pressure tiles.

## Validation
- `npm run test:playwright -- tests/playwright/mobile-dashboard-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-mobile-wearable-priority-coverage npm run test:playwright -- tests/playwright/mobile-dashboard-browser-coverage.spec.js`

Suite coverage confirmed:
- `/js/mobile-dashboard.js` `getMobileWearablePriority`: 1