### PR TITLE
Cover wearable adapter helper browser paths

### DIFF
--- a/tests/playwright/wearables-connect-browser-coverage.spec.js
+++ b/tests/playwright/wearables-connect-browser-coverage.spec.js
@@ -309,9 +309,11 @@ test('wearables connect browser coverage exercises runtime config, stale sync, P
     };
 
     try {
-      check('adapterSupportsMetric detects real missing and unknown adapter metrics',
-        adapters.adapterSupportsMetric('oura', 'hrv_rmssd') === true &&
-        adapters.adapterSupportsMetric('oura', 'not_a_metric') === false &&
+      check('adapterSupportsMetric returns true for a supported metric',
+        adapters.adapterSupportsMetric('oura', 'hrv_rmssd') === true);
+      check('adapterSupportsMetric returns false for an unknown metric',
+        adapters.adapterSupportsMetric('oura', 'not_a_metric') === false);
+      check('adapterSupportsMetric returns false for an unknown adapter',
         adapters.adapterSupportsMetric('not-a-real-adapter', 'steps') === false);
 
       await connect.loadWearableRuntimeConfig();
@@ -324,6 +326,8 @@ test('wearables connect browser coverage exercises runtime config, stale sync, P
 
       const withingsBaselineClient = adapters.adapterById('withings')?.oauth?.clientId || null;
       adapters.applyOAuthOverrides({ withings: 'browser-withings-client' });
+      check('apply OAuth overrides updates adapter client before reset',
+        adapters.getOAuthClientId('withings') === 'browser-withings-client');
       adapters._resetOAuthOverrides();
       check('reset OAuth overrides restores adapter baseline in browser',
         adapters.getOAuthClientId('withings') === withingsBaselineClient);

--- a/tests/playwright/wearables-connect-browser-coverage.spec.js
+++ b/tests/playwright/wearables-connect-browser-coverage.spec.js
@@ -309,6 +309,11 @@ test('wearables connect browser coverage exercises runtime config, stale sync, P
     };
 
     try {
+      check('adapterSupportsMetric detects real missing and unknown adapter metrics',
+        adapters.adapterSupportsMetric('oura', 'hrv_rmssd') === true &&
+        adapters.adapterSupportsMetric('oura', 'not_a_metric') === false &&
+        adapters.adapterSupportsMetric('not-a-real-adapter', 'steps') === false);
+
       await connect.loadWearableRuntimeConfig();
       check('runtime config applies OAuth client overrides',
         runtimeConfigCalls === 1 &&
@@ -316,6 +321,13 @@ test('wearables connect browser coverage exercises runtime config, stale sync, P
         adapters.getOAuthClientId('polar') === 'runtime-polar-client');
       await connect.loadWearableRuntimeConfig();
       check('runtime config promise is reused', runtimeConfigCalls === 1);
+
+      const withingsBaselineClient = adapters.adapterById('withings')?.oauth?.clientId || null;
+      adapters.applyOAuthOverrides({ withings: 'browser-withings-client' });
+      adapters._resetOAuthOverrides();
+      check('reset OAuth overrides restores adapter baseline in browser',
+        adapters.getOAuthClientId('withings') === withingsBaselineClient);
+      adapters.applyOAuthOverrides({ oura: 'runtime-oura-client', polar: 'runtime-polar-client' });
 
       sessionStorage.setItem('polar-oauth-pending', JSON.stringify({
         state: 'polar-state-ok',


### PR DESCRIPTION
## Summary
- Extend wearable connect browser coverage for adapter metric support checks.
- Cover runtime OAuth override reuse and reset behavior through the browser harness.

## Validation
- `npm run test:playwright -- tests/playwright/wearables-connect-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-wearable-adapter-helper-browser-coverage npm run test:playwright -- tests/playwright/wearables-connect-browser-coverage.spec.js`

## Coverage counters
- `_resetOAuthOverrides`: 4
- `adapterSupportsMetric`: 5