### PR TITLE
[codex] Cover correlation dropdown helper in browser

### DIFF
--- a/tests/playwright/compare-correlations-browser-coverage.spec.js
+++ b/tests/playwright/compare-correlations-browser-coverage.spec.js
@@ -252,6 +252,11 @@ test('correlations browser contract filters markers toggles chips and builds cha
       const ldlMarker = activeData.categories.lipids.markers.ldl;
       const expectedLdlPct = ((2.3 - ldlMarker.refMin) / (ldlMarker.refMax - ldlMarker.refMin)) * 100;
       const optionCount = document.querySelectorAll('.corr-option').length;
+      const dropdown = document.getElementById('corr-options');
+      dropdown?.classList.remove('show');
+      compare.showCorrelationDropdown();
+      outcomes.showCorrelationDropdownOpensOptions = dropdown?.classList.contains('show') === true;
+      dropdown?.classList.remove('show');
       document.getElementById('corr-search').value = 'vitamin';
       compare.filterCorrelationOptions();
       const vitaminOption = Array.from(document.querySelectorAll('.corr-option'))
@@ -343,6 +348,7 @@ test('correlations browser contract filters markers toggles chips and builds cha
   });
 
   const expectedOutcomeKeys = [
+    'showCorrelationDropdownOpensOptions',
     'searchDropdownFiltersByMarkerOrCategory',
     'singleMarkerRendersChipWithoutChart',
     'secondMarkerBuildsNormalizedChart',


### PR DESCRIPTION
## Summary
- Add a direct Playwright browser assertion for `showCorrelationDropdown()` in the existing compare/correlations coverage spec.
- Keep the existing filter assertions decoupled by clearing the dropdown class before invoking `filterCorrelationOptions()`.

## Validation
- `npm run test:playwright -- tests/playwright/compare-correlations-browser-coverage.spec.js`
- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-correlation-dropdown-browser-coverage npm run test:playwright -- tests/playwright/compare-correlations-browser-coverage.spec.js`
- `PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-correlation-dropdown-browser-coverage REQUIRE_PLAYWRIGHT_COVERAGE_SHARDS=1 node scripts/playwright-coverage.mjs`