### PR TITLE
[codex] Cover sun uvdata provider availability

### DIFF
--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -35,6 +35,7 @@ import { isValidExternalUrl } from './url-safety.js';
 
 const STORAGE_KEY = 'labcharts-meteo-config';
 let _warnedAboutEmptySelfhost = false;
+let _warnedAboutRejectedSelfhostUrl = false;
 // Sync-friendly decrypted-config cache. Populated by initMeteoConfigCache()
 // on startup + after every saveMeteoConfig(). Lets the rest of the app
 // keep calling getMeteoConfig() synchronously even though the at-rest
@@ -322,7 +323,7 @@ export async function fetchAtmosphere({ lat, lon, isoTime, noCache } = {}) {
   }
 
   // Provider order based on config
-  const order = providerOrder(cfg);
+  const order = providerOrder(cfg, { lat: rLat, lon: rLon });
 
   let lastError = null;
   for (let i = 0; i < order.length; i++) {
@@ -546,7 +547,37 @@ const PROVIDERS = {
   },
 };
 
-function providerOrder(cfg) {
+function providerIsAvailable(provider, ctx) {
+  try {
+    if (!provider.available) return true;
+    const ok = provider.available(ctx);
+    if (!ok && provider.name === 'selfhost' && ctx?.mode === 'selfhost' && ctx.selfhostUrl && !_warnedAboutRejectedSelfhostUrl) {
+      try {
+        if (typeof console !== 'undefined' && console.warn) {
+          console.warn(ctx.selfhostBearer
+            ? '[meteo] selfhost URL rejected — bearer-bearing requests require https:// and public hosts; falling back to Open-Meteo.'
+            : '[meteo] selfhost URL rejected — must be public http(s), not loopback / RFC1918 / link-local; falling back to Open-Meteo.');
+        }
+      } catch {}
+      _warnedAboutRejectedSelfhostUrl = true;
+    }
+    return ok;
+  } catch (e) {
+    try {
+      if (typeof console !== 'undefined' && console.warn) {
+        console.warn('[meteo] provider availability check failed; skipping provider.', e?.name || e);
+      }
+    } catch {}
+    return false;
+  }
+}
+
+function availableProviders(candidates, ctx) {
+  return candidates.filter(provider => providerIsAvailable(provider, ctx));
+}
+
+function providerOrder(cfg, coords = {}) {
+  const ctx = Object.assign({}, cfg, coords);
   // NOAA NWS doesn't allow browser CORS, so it's explicit-only and only
   // useful for non-browser callers. CAMS now runs through the
   // getbased-uvdata relay (api/proxy?meteo=cams) — the deploy decides
@@ -554,10 +585,10 @@ function providerOrder(cfg) {
   // it isn't, CAMS returns 503 and the auto-fallback chain reaches
   // Open-Meteo so the user still gets data.
   if (cfg.mode === 'manual') return [];
-  if (cfg.mode === 'selfhost') return cfg.selfhostUrl ? [PROVIDERS.selfhost, PROVIDERS.openMeteo] : [PROVIDERS.openMeteo];
-  if (cfg.mode === 'cams') return [PROVIDERS.cams, PROVIDERS.openMeteo];
-  if (cfg.mode === 'noaa') return [PROVIDERS.noaa, PROVIDERS.openMeteo];
-  if (cfg.mode === 'open-meteo') return [PROVIDERS.openMeteo];
+  if (cfg.mode === 'selfhost') return availableProviders([PROVIDERS.selfhost, PROVIDERS.openMeteo], ctx);
+  if (cfg.mode === 'cams') return availableProviders([PROVIDERS.cams, PROVIDERS.openMeteo], ctx);
+  if (cfg.mode === 'noaa') return availableProviders([PROVIDERS.noaa, PROVIDERS.openMeteo], ctx);
+  if (cfg.mode === 'open-meteo') return availableProviders([PROVIDERS.openMeteo], ctx);
   // 'auto' — selfhost (if configured) → CAMS hosted relay → Open-Meteo.
   // CAMS goes ahead of Open-Meteo because the deploy controls whether
   // the upstream is reachable; if it isn't, it 503s fast and the chain
@@ -567,7 +598,7 @@ function providerOrder(cfg) {
   if (cfg.selfhostUrl) order.push(PROVIDERS.selfhost);
   order.push(PROVIDERS.cams);
   order.push(PROVIDERS.openMeteo);
-  return order;
+  return availableProviders(order, ctx);
 }
 
 // ─── Response shapers ──────────────────────────────────────────────────

--- a/tests/playwright/sun-uvdata-browser-coverage.spec.js
+++ b/tests/playwright/sun-uvdata-browser-coverage.spec.js
@@ -58,6 +58,24 @@ test('sun uvdata browser coverage handles config cache globals and purging', asy
         && window.solarZenithAngle === mod.solarZenithAngle
         && window.computeUVConfidence === mod.computeUVConfidence;
 
+      const manualMeter = mod.manualAtmosphere({
+        uvIndex: 5.8,
+        ozoneDU: 318,
+        hasMeter: true,
+        notes: 'meter reading',
+      });
+      const manualEntry = mod.manualAtmosphere({ uvIndex: 2.4 });
+      outcomes.manualAtmosphereBuildsMeterAndEntryRows =
+        manualMeter.source === 'manual_meter'
+        && manualMeter.confidence === 1
+        && manualMeter.uvClearSky === 5.8
+        && manualMeter.ozoneDU === 318
+        && manualMeter.notes === 'meter reading'
+        && manualEntry.source === 'manual_entry'
+        && manualEntry.confidence === 0.85
+        && manualEntry.ozoneDU === null
+        && manualEntry.cloudCover === null;
+
       localStorage.setItem(storageKey, '{bad json');
       const invalidConfig = mod.getMeteoConfig();
       outcomes.invalidStoredConfigFallsBackToDefaults =
@@ -161,6 +179,7 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
     const storageKey = 'labcharts-meteo-config';
     const originalConfig = localStorage.getItem(storageKey);
     const originalFetch = window.fetch;
+    const originalWarn = console.warn;
     const mod = await import(sunUrl);
     const iso = '2026-06-01T12:30:00.000Z';
     const jsonResponse = (json, init = {}) => new Response(JSON.stringify(json), {
@@ -270,6 +289,33 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
         && fallbackCalls.some(call => call.includes('api.open-meteo.com'))
         && fallbackCalls.some(call => call.includes('air-quality-api.open-meteo.com'));
 
+      saveConfig({
+        mode: 'selfhost',
+        selfhostUrl: 'http://127.0.0.1:9000',
+      });
+      const rejectedSelfhostCalls = [];
+      const rejectedSelfhostWarnings = [];
+      console.warn = (...args) => rejectedSelfhostWarnings.push(args.join(' '));
+      window.fetch = async (url) => {
+        const href = String(url);
+        rejectedSelfhostCalls.push(href);
+        if (href.includes('air-quality')) return jsonResponse(airQuality);
+        return jsonResponse(forecast(3.9));
+      };
+      const rejectedSelfhostFallback = await mod.fetchAtmosphere({
+        lat: 50,
+        lon: 14,
+        isoTime: iso,
+        noCache: true,
+      });
+      console.warn = originalWarn;
+      outcomes.rejectedSelfhostAvailabilityWarnsAndFallsBack =
+        rejectedSelfhostFallback.source === 'open_meteo'
+        && rejectedSelfhostFallback.uvIndex === 3.9
+        && !rejectedSelfhostCalls.some(call => call.startsWith('http://127.0.0.1'))
+        && rejectedSelfhostCalls.some(call => call.includes('api.open-meteo.com'))
+        && rejectedSelfhostWarnings.some(line => line.includes('selfhost URL rejected'));
+
       saveConfig({ mode: 'auto' });
       window.fetch = async (url) => {
         const href = String(url);
@@ -306,6 +352,26 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
         && merged.ozoneDU === 315
         && merged.airQuality?.aod === 0.07
         && Math.abs(merged.confidence - 0.65) < 0.01;
+
+      saveConfig({ mode: 'noaa' });
+      const legacyNoaaCalls = [];
+      window.fetch = async (url) => {
+        const href = String(url);
+        legacyNoaaCalls.push(href);
+        if (href.includes('air-quality')) return jsonResponse(airQuality);
+        return jsonResponse(forecast(2.8));
+      };
+      const legacyNoaa = await mod.fetchAtmosphere({
+        lat: 40,
+        lon: -100,
+        isoTime: iso,
+        noCache: true,
+      });
+      outcomes.legacyNoaaModeMigratesToAutoProviderOrder =
+        legacyNoaa.source === 'cams'
+        && legacyNoaa.uvIndex === 2.8
+        && legacyNoaaCalls.length === 1
+        && legacyNoaaCalls[0] === '/api/proxy';
 
       saveConfig({ mode: 'open-meteo' });
       cleanupCache();
@@ -357,6 +423,7 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
         && offline.ozoneDU === 300;
     } finally {
       window.fetch = originalFetch;
+      console.warn = originalWarn;
       cleanupCache();
       if (originalConfig == null) localStorage.removeItem(storageKey);
       else localStorage.setItem(storageKey, originalConfig);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.448';
+self.APP_VERSION = '1.8.449';


### PR DESCRIPTION
## Summary
- Route atmosphere provider selection through each provider's availability predicate.
- Add browser coverage for manual atmosphere rows and legacy NOAA-mode migration through the auto provider chain.
- Bump the app version for cache invalidation.

## Validation
- `npm run test:playwright -- tests/playwright/sun-uvdata-browser-coverage.spec.js`
- `npm test -- tests/_vitest-legacy.test.js`