### PR TITLE
[codex] Cover lens worker benchmark verdict

### DIFF
--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -200,6 +200,15 @@ async function handleInit() {
   if (params.has('mock')) {
     _embedder = mockEmbedder;
     console.log('[lens-local] mock embedder active (test mode)');
+    if (params.has('benchmark')) {
+      try {
+        _benchmarkVerdict = await _benchmarkEmbedder();
+        /** @type {any} */ (self)._lensLocalBenchmark = _benchmarkVerdict;
+      } catch (err) {
+        console.warn('[lens-local] mock benchmark failed:', err?.message || err);
+        _benchmarkVerdict = null;
+      }
+    }
     await openOpfs();
     await loadCorpusIntoMemory();
     self.postMessage(readyPayload());

--- a/tests/playwright/lens-local-worker-browser-coverage.spec.js
+++ b/tests/playwright/lens-local-worker-browser-coverage.spec.js
@@ -19,7 +19,7 @@ test('lens local worker browser coverage exercises mocked protocol and libraries
     }
     localStorage.removeItem('labcharts-lens-local-count');
 
-    const worker = new Worker('/js/lens-local-worker.js?mock=1', { type: 'module' });
+    const worker = new Worker('/js/lens-local-worker.js?mock=1&benchmark=1', { type: 'module' });
     const roundTrip = (msg, expectedType, timeoutMs = 5000) => new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         worker.removeEventListener('message', onMessage);
@@ -56,6 +56,13 @@ test('lens local worker browser coverage exercises mocked protocol and libraries
         && ready.activeId === 'default'
         && ready.activeModel === 'all-minilm'
         && ready.models?.['all-minilm']?.dim === 384
+        && ready.embedder?.backend === 'wasm'
+        && ready.embedder?.modelKey === 'all-minilm'
+        && ready.embedder?.dim === 384
+        && Number.isFinite(ready.embedder?.msPerEmbed)
+        && ready.embedder?.tier >= 1
+        && ready.embedder?.tier <= 3
+        && typeof ready.embedder?.tierLabel === 'string'
         && ready.libraries?.some(lib => lib.id === 'default'));
 
       const unknownType = await expectWorkerError({ type: 'not-a-real-worker-message' }, /unknown message type/i);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.449';
+self.APP_VERSION = '1.8.450';


### PR DESCRIPTION
## Summary
- Add an opt-in mocked-worker benchmark hook for lens local worker browser tests.
- Assert the ready payload exposes benchmark-backed embedder metadata.
- Bump the app version for cache invalidation.

## Validation
- `npm run test:playwright -- tests/playwright/lens-local-worker-browser-coverage.spec.js`
- `npm test -- tests/lens-local-runtime.test.js`