### PR TITLE
[codex] Cover light AI refresh adapters

### DIFF
--- a/tests/playwright/light-ai-analysis-coverage-batch.spec.js
+++ b/tests/playwright/light-ai-analysis-coverage-batch.spec.js
@@ -545,6 +545,15 @@ test('light environment AI analysis covers audit room screen and onboarding verd
         && screenAI.renderScreenAIBlock(phoneScreen).includes('screen failed')
         && onboarding.renderOnboardingAIBlock().includes('setup failed');
 
+      delete bedroom.aiAnalysis;
+      const roomRefresh = await roomAI.refreshRoomAIAnalysis('bedroom');
+      let missingRoomRefreshCrashed = false;
+      try { await roomAI.refreshRoomAIAnalysis('missing-room'); }
+      catch (_) { missingRoomRefreshCrashed = true; }
+      outcomes.roomRefreshResolvesByIdAndWritesVerdict = roomRefresh?.status === 'ok'
+        && bedroom.aiAnalysis?.tip === 'auto tip';
+      outcomes.roomRefreshMissingIdNoops = !missingRoomRefreshCrashed;
+
       delete state.importedData.sunDefaults.aiAnalysis;
       const analyzeResult = await onboarding.analyzeOnboardingAI({ force: true });
       outcomes.onboardingAnalyzeParsesActions = analyzeResult?.status === 'ok'
@@ -905,6 +914,15 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       const dayAnalysis = await todayAI.analyzeDayAI(today, { force: true });
       outcomes.dayAnalyzeWritesDailyVerdict = dayAnalysis?.status === 'ok'
         && state.importedData.lightDailyVerdicts[todayKey]?.tip === 'aggregate tip';
+
+      queuedAIResponses.push({ dot: 'red', tip: 'today refresh tip', detail: 'today refresh detail' });
+      const dayRefresh = await todayAI.refreshDayAIAnalysis(todayKey);
+      let invalidDayRefreshCrashed = false;
+      try { await todayAI.refreshDayAIAnalysis('not-a-date'); }
+      catch (_) { invalidDayRefreshCrashed = true; }
+      outcomes.dayRefreshUsesDateKeyAndWritesDailyVerdict = dayRefresh?.status === 'ok'
+        && state.importedData.lightDailyVerdicts[todayKey]?.tip === 'today refresh tip';
+      outcomes.dayRefreshInvalidKeyNoops = !invalidDayRefreshCrashed;
     } finally {
       state.importedData = saved.importedData;
       window.fetch = saved.fetch;

--- a/tests/playwright/light-coverage-batch-2.spec.js
+++ b/tests/playwright/light-coverage-batch-2.spec.js
@@ -529,11 +529,36 @@ test('light tools AI analysis covers per-tool contexts fingerprints and inline s
       const analyzingHtml = analysis.renderMeasurementAIInline(samples[1]);
       releaseFetch();
       await analyzingPromise;
+      let refreshFetchCalls = 0;
+      window.fetch = async (url, options = {}) => {
+        if (String(url).includes('/v1/chat/completions')) {
+          refreshFetchCalls += 1;
+          return new Response(JSON.stringify({
+            choices: [{ message: { content: '{"dot":"red","tip":"refresh tip","detail":"refresh detail"}' } }],
+            usage: { prompt_tokens: 4, completion_tokens: 3 },
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+        return saved.fetch(url, options);
+      };
+      const refreshedMeasurement = await analysis.refreshMeasurementAIAnalysis('lux-one');
+      const callsAfterRefresh = refreshFetchCalls;
+      let missingMeasurementRefreshCrashed = false;
+      try { await analysis.refreshMeasurementAIAnalysis('missing-measurement'); }
+      catch (_) { missingMeasurementRefreshCrashed = true; }
+      const callsAfterMissingRefresh = refreshFetchCalls;
+      analysis.maybeAnalyzeMeasurementAfterSave(samples[6]);
+      await new Promise(resolve => setTimeout(resolve, 20));
       const okSample = { ...samples[2], aiAnalysis: { status: 'ok', dot: 'green', tip: '<bright>', detail: '<script>x</script>', fingerprint: analysis.getMeasurementFingerprint(samples[2]) } };
       const okHtml = analysis.renderMeasurementAIInline(okSample);
       const errorSample = { ...samples[3], aiAnalysis: { status: 'error', error: 'bad', fingerprint: analysis.getMeasurementFingerprint(samples[3]) } };
       const errorHtml = analysis.renderMeasurementAIInline(errorSample);
       const auditHtml = analysis.renderMeasurementAIInline(samples[6]);
+      outcomes.refreshMeasurementResolvesByIdAndWritesVerdict = refreshedMeasurement?.status === 'ok'
+        && samples[0].aiAnalysis?.tip === 'refresh tip';
+      outcomes.refreshMeasurementUsesSingleApiCall = callsAfterRefresh === 1;
+      outcomes.refreshMeasurementMissingIdNoops = !missingMeasurementRefreshCrashed;
+      outcomes.refreshMeasurementMissingIdSkipsApiCall = callsAfterMissingRefresh === callsAfterRefresh;
+      outcomes.auditMeasurementAutoFireSkipsAggregateRows = refreshFetchCalls === callsAfterMissingRefresh;
       outcomes.inlineIdleShowsAnalyzeButton = idleHtml.includes('Get AI verdict');
       outcomes.inlineAnalyzingShowsProgress = analyzingHtml.includes('Analyzing');
       outcomes.inlineOkShowsGreenDot = okHtml.includes('sun-session-ai-dot-green');


### PR DESCRIPTION
## Summary
- Add Playwright coverage for room AI refresh resolving targets by id and writing verdicts.
- Add daily verdict refresh coverage for date-key lookup and invalid-key no-op behavior.
- Add measurement AI refresh coverage plus the audit-row auto-fire skip.

## Validation
- `npm run test:playwright -- tests/playwright/light-ai-analysis-coverage-batch.spec.js tests/playwright/light-coverage-batch-2.spec.js`