### PR TITLE
[codex] Cover sync save default callbacks

### DIFF
--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -89,6 +89,19 @@ test('sync save hooks and messenger cover debounce and gateway paths', async ({ 
       outcomes.defaultSaveHookDependenciesGateWork = pushes.length === 0 && timers.size === 0;
 
       saveHooks.configureSyncSaveHooks({
+        isSyncEnabled: () => true,
+      });
+      saveHooks.onDataSaved({ immediate: true });
+      outcomes.defaultEvoluReadyGateSkipsDataPush = pushes.length === 0 && timers.size === 0;
+
+      saveHooks.configureSyncSaveHooks({
+        isEvoluReady: () => true,
+      });
+      saveHooks.onDataSaved({ immediate: true });
+      await Promise.resolve();
+      outcomes.defaultPushProfileNoopAllowsImmediateDataSave = pushes.length === 0 && timers.size === 0;
+
+      saveHooks.configureSyncSaveHooks({
         pushProfile: async (id, data, options) => {
           pushes.push({ id, data: clone(data), options: clone(options || null) });
         },


### PR DESCRIPTION
## Summary
- Extend the sync actions Playwright coverage to exercise `sync-save-hooks` default callback paths.
- Cover the default Evolu-ready gate and default push-profile no-op before injecting the normal test sync deps.

## Validation
- `npm run test:playwright -- tests/playwright/sync-actions-browser-coverage.spec.js`