### PR TITLE
[codex] Complete Playwright browser coverage

### DIFF
--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -1156,6 +1156,11 @@ function isUSCoords(lat, lon) {
   return false;
 }
 
+export {
+  shapeNoaaResponse as _testShapeNoaaResponse,
+  isUSCoords as _testIsUSCoords,
+};
+
 // Expose for window.fn calls from inline HTML handlers
 if (typeof window !== 'undefined') {
   Object.assign(window, {

--- a/tests/playwright/sun-uvdata-browser-coverage.spec.js
+++ b/tests/playwright/sun-uvdata-browser-coverage.spec.js
@@ -373,6 +373,18 @@ test('sun uvdata browser coverage drives provider chain cache stale and offline 
         && legacyNoaaCalls.length === 1
         && legacyNoaaCalls[0] === '/api/proxy';
 
+      const shapedNoaa = mod._testShapeNoaaResponse({ UVI: 6.1, ozone: 307 }, iso);
+      outcomes.noaaTestHooksCoverLegacyShaperAndUsPredicate =
+        shapedNoaa?.source === 'noaa_nws'
+        && shapedNoaa.uvIndex === 6.1
+        && shapedNoaa.ozoneDU === 307
+        && shapedNoaa.confidence === mod.UV_SOURCE_CONFIDENCE.noaa_nws
+        && mod._testShapeNoaaResponse({}, iso) === null
+        && mod._testIsUSCoords(40, -100) === true
+        && mod._testIsUSCoords(61, -150) === true
+        && mod._testIsUSCoords(20.5, -157) === true
+        && mod._testIsUSCoords(50, 14) === false;
+
       saveConfig({ mode: 'open-meteo' });
       cleanupCache();
       let cacheFetches = 0;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.451';
+self.APP_VERSION = '1.8.452';


### PR DESCRIPTION
## Summary

- Add narrow test hooks for the private legacy NOAA UV shaper and US-coordinate predicate.
- Extend the Playwright sun UV data coverage spec to exercise those remaining browser coverage paths.
- Bump `version.js` for cache invalidation after touching app JavaScript.

## Validation

- `PLAYWRIGHT_SUITE_COVERAGE=1 PLAYWRIGHT_COVERAGE_DIR=/tmp/getbased-sun-uvdata-coverage npm run test:playwright -- tests/playwright/sun-uvdata-browser-coverage.spec.js`
- `COVERAGE=1 ./run-tests.sh`

Final local coverage report: Playwright browser function coverage is `3,882 / 3,882 = 100.00%`.