### PR TITLE
[codex] Cover sync window bindings

### DIFF
--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -660,11 +660,9 @@ test('sync window bindings expose browser globals and injected callbacks', async
         && window.disableSync() === 'disabled';
       outcomes.importedSyncGlobalsAreFunctions =
         expectedFunctionNames.every(name => typeof window[name] === 'function');
-      outcomes.forcePullAliasAndTelemetryBindingsExist =
+      outcomes.forcePullIsExposedOnlyViaAlias =
         typeof window._forcePull === 'function'
-        && typeof window.getDeltaTelemetry === 'function'
-        && typeof window.getRelayQuotaEstimate === 'function'
-        && typeof window.confirmBackfillBlockers === 'function';
+        && window.forcePull === undefined;
     } finally {
       for (const [name, descriptor] of savedDescriptors.entries()) {
         if (descriptor) Object.defineProperty(window, name, descriptor);

--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -588,3 +588,94 @@ test('sync identity rotation modal covers cancel copy malformed and apply paths'
     expect(passed, name).toBe(true);
   }
 });
+
+test('sync window bindings expose browser globals and injected callbacks', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async ({ bindingsUrl }) => {
+    const bindings = await import(bindingsUrl);
+    const outcomes = {};
+    const expectedFunctionNames = [
+      'getMnemonic',
+      'getMnemonicResolutionError',
+      'getSyncBlocker',
+      'restoreFromMnemonic',
+      'isSyncEnabled',
+      'pushCurrentProfile',
+      'forceResendCurrentProfile',
+      'cleanStorage',
+      'syncNow',
+      'showSyncDiagnose',
+      'deleteProfileFromRelay',
+      'listPendingTombstones',
+      'applyPendingTombstone',
+      'rejectPendingTombstone',
+      'checkRelayConnection',
+      'isMessengerEnabled',
+      'getMessengerToken',
+      'generateMessengerToken',
+      'revokeMessengerToken',
+      'pushContextToGateway',
+      '_syncDiag',
+      '_forcePull',
+      'renderSyncIndicator',
+      'updateSyncIndicator',
+      'toggleSyncDetail',
+      'copySyncEvents',
+      'copySyncDiagnose',
+      'confirmCompactRelay',
+      'confirmRotateIdentity',
+      'refreshRelayStorage',
+      'fetchOwnerStorageFromRelay',
+      'verifyPushLanded',
+      'getRelayHealthVerdict',
+      'compactOwnerSelfServe',
+      'getRelayQuotaEstimate',
+      'resetRelayQuotaEstimate',
+      'getDeltaTelemetry',
+      'resetDeltaTelemetry',
+      'confirmResetDeltaTelemetry',
+      'getDeltaCutoverReadiness',
+      'isPhase2CutoverEnabled',
+      'enablePhase2Cutover',
+      'disablePhase2Cutover',
+      'confirmEnablePhase2',
+      'confirmDisablePhase2',
+      'confirmBackfillBlockers',
+    ];
+    const allNames = ['enableSync', 'disableSync', ...expectedFunctionNames];
+    const savedDescriptors = new Map(allNames.map(name => [
+      name,
+      Object.getOwnPropertyDescriptor(window, name),
+    ]));
+    const enableSync = () => 'enabled';
+    const disableSync = () => 'disabled';
+
+    try {
+      bindings.bindSyncWindowActions({ enableSync, disableSync });
+      outcomes.injectedCallbacksAreAssigned =
+        window.enableSync === enableSync
+        && window.disableSync === disableSync
+        && window.enableSync() === 'enabled'
+        && window.disableSync() === 'disabled';
+      outcomes.importedSyncGlobalsAreFunctions =
+        expectedFunctionNames.every(name => typeof window[name] === 'function');
+      outcomes.forcePullAliasAndTelemetryBindingsExist =
+        typeof window._forcePull === 'function'
+        && typeof window.getDeltaTelemetry === 'function'
+        && typeof window.getRelayQuotaEstimate === 'function'
+        && typeof window.confirmBackfillBlockers === 'function';
+    } finally {
+      for (const [name, descriptor] of savedDescriptors.entries()) {
+        if (descriptor) Object.defineProperty(window, name, descriptor);
+        else delete window[name];
+      }
+    }
+
+    return outcomes;
+  }, { bindingsUrl: moduleUrl('/js/sync-window-bindings.js') });
+
+  for (const [name, passed] of Object.entries(results)) {
+    expect(passed, name).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary

- Add Playwright coverage for `bindSyncWindowActions`.
- Assert injected enable/disable callbacks and the exported sync browser globals, including the `_forcePull` alias and telemetry/relay bindings.
- Restore prior window descriptors after the probe so the app globals are not left mutated.

## Validation

- `npm run test:playwright -- sync-actions-browser-coverage.spec.js`
- `npm test`