### PR TITLE
Support lab CSV import

### DIFF
--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -100,7 +100,13 @@ export function showAINeededDialog(action = 'import') {
     overlay.className = 'confirm-overlay';
     document.body.appendChild(overlay);
   }
-  const verb = action === 'image' ? 'Reading lab values from an image' : 'Reading lab values from a PDF';
+  const verb = action === 'image'
+    ? 'Reading lab values from an image'
+    : action === 'csv'
+      ? 'Reading lab values from a CSV'
+      : action === 'text'
+        ? 'Reading lab values from a text file'
+        : 'Reading lab values from a PDF';
   overlay.innerHTML = `<div class="confirm-dialog ai-needed-dialog" role="dialog" aria-modal="true" aria-label="AI needed to import">
     <p class="confirm-message"><strong>${verb} needs an AI to parse them.</strong></p>
     <p style="font-size:13px;color:var(--text-muted);margin:0 0 14px">Quickest setup is the &ldquo;card&rdquo; option below &mdash; one-click login, charge to your card, you&rsquo;re done in about 30 seconds.</p>
@@ -570,7 +576,7 @@ export async function classifyImportFiles(files) {
   for (const f of unmatched) {
     if (/\.(txt|csv)$/i.test(f.name)) {
       if (pdfImportWindow.isDNAFileByContent && await pdfImportWindow.isDNAFileByContent(f)) dnaFiles.push(f);
-      else if (f.name.endsWith('.txt')) textFiles.push(f);
+      else textFiles.push(f);
     } else if (await isPdfByMagic(f)) {
       pdfFiles.push(f);
     }
@@ -775,6 +781,10 @@ async function _showImageModeDialog() {
 
 export async function handlePDFFile(file, forceImageMode = false, preExtractedText = null) {
   const _startProfileId = state.currentProfile;
+  const textImportKind = preExtractedText
+    ? (/\.(csv)$/i.test(file.name) || file.type === 'text/csv' ? 'CSV' : 'text file')
+    : 'PDF';
+  const textAction = textImportKind === 'CSV' ? 'csv' : textImportKind === 'text file' ? 'text' : 'import';
   try {
     await showImportProgress(0, file.name);
     const pdfText = preExtractedText || await extractPDFText(file);
@@ -827,11 +837,11 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
     }
 
     // Text mode path (original flow)
-    if (!pdfText.trim()) { hideImportProgress('error'); showNotification("PDF appears empty — no text extracted", "error"); return; }
+    if (!pdfText.trim()) { hideImportProgress('error'); showNotification(`${textImportKind} appears empty — no text extracted`, "error"); return; }
 
     if (!hasAIProvider()) {
       hideImportProgress('error');
-      showAINeededDialog('import');
+      showAINeededDialog(textAction);
       return;
     }
 
@@ -925,8 +935,8 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
     result.importHash = hashString(pdfText);
     result._importProfileId = _startProfileId;
     if (isDebugMode()) { result.privacyOriginal = privacyOriginal; result.privacyObfuscated = textForAI; }
-    if (!result.date) { showNotification("Could not find collection date in PDF", "error"); }
-    if (result.markers.length === 0) { hideImportProgress('error'); showNotification("No biomarkers found in PDF", "error"); return; }
+    if (!result.date) { showNotification(`Could not find collection date in ${textImportKind}`, "error"); }
+    if (result.markers.length === 0) { hideImportProgress('error'); showNotification(`No biomarkers found in ${textImportKind}`, "error"); return; }
     await showImportProgress(4, file.name);
     showImportPreview(result);
     hideImportProgress();
@@ -1148,7 +1158,8 @@ export async function handleImageFile(file) {
 // ═══════════════════════════════════════════════
 export async function handleTextFile(file) {
   const text = await file.text();
-  if (!text.trim()) { showNotification("Text file is empty", "error"); return; }
+  const isCsv = /\.(csv)$/i.test(file.name) || file.type === 'text/csv';
+  if (!text.trim()) { showNotification(`${isCsv ? 'CSV' : 'Text file'} is empty`, "error"); return; }
   await handlePDFFile(file, false, text);
 }
 

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -71,6 +71,10 @@ function isCsvTextFile(file) {
   return /\.csv$/i.test(file.name) || file.type === 'text/csv';
 }
 
+function isTextImportFile(file) {
+  return isCsvTextFile(file) || /\.txt$/i.test(file.name) || file.type?.startsWith('text/');
+}
+
 export { buildMarkerReference, reconcileImportMarkerMappings } from './pdf-import-marker-mapping.js';
 export {
   showImportPreview,
@@ -786,11 +790,10 @@ async function _showImageModeDialog() {
 export async function handlePDFFile(file, forceImageMode = false, preExtractedText = null) {
   const _startProfileId = state.currentProfile;
   const hasPreExtractedText = preExtractedText !== null;
-  const isCsvImport = hasPreExtractedText && isCsvTextFile(file);
-  const textImportKind = hasPreExtractedText
-    ? (isCsvImport ? 'CSV' : 'text file')
-    : 'PDF';
-  const textAction = hasPreExtractedText ? (isCsvImport ? 'csv' : 'text') : 'import';
+  const isCsvImport = isCsvTextFile(file);
+  const isTextFileImport = isTextImportFile(file);
+  const textImportKind = isCsvImport ? 'CSV' : isTextFileImport ? 'text file' : 'PDF';
+  const textAction = isCsvImport ? 'csv' : isTextFileImport ? 'text' : 'import';
   try {
     await showImportProgress(0, file.name);
     const pdfText = hasPreExtractedText ? preExtractedText : await extractPDFText(file);

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -67,6 +67,10 @@ import {
 
 const pdfImportWindow = /** @type {Window & typeof globalThis & PdfImportWindowHooks} */ (window);
 
+function isCsvTextFile(file) {
+  return /\.csv$/i.test(file.name) || file.type === 'text/csv';
+}
+
 export { buildMarkerReference, reconcileImportMarkerMappings } from './pdf-import-marker-mapping.js';
 export {
   showImportPreview,
@@ -781,14 +785,16 @@ async function _showImageModeDialog() {
 
 export async function handlePDFFile(file, forceImageMode = false, preExtractedText = null) {
   const _startProfileId = state.currentProfile;
-  const textImportKind = preExtractedText
-    ? (/\.(csv)$/i.test(file.name) || file.type === 'text/csv' ? 'CSV' : 'text file')
+  const hasPreExtractedText = preExtractedText !== null;
+  const isCsvImport = hasPreExtractedText && isCsvTextFile(file);
+  const textImportKind = hasPreExtractedText
+    ? (isCsvImport ? 'CSV' : 'text file')
     : 'PDF';
-  const textAction = textImportKind === 'CSV' ? 'csv' : textImportKind === 'text file' ? 'text' : 'import';
+  const textAction = hasPreExtractedText ? (isCsvImport ? 'csv' : 'text') : 'import';
   try {
     await showImportProgress(0, file.name);
-    const pdfText = preExtractedText || await extractPDFText(file);
-    const textQuality = preExtractedText ? 'good' : assessTextQuality(pdfText);
+    const pdfText = hasPreExtractedText ? preExtractedText : await extractPDFText(file);
+    const textQuality = hasPreExtractedText ? 'good' : assessTextQuality(pdfText);
 
     // Determine import mode — ask user for scanned/empty PDFs
     let useImageMode = forceImageMode;
@@ -1158,7 +1164,7 @@ export async function handleImageFile(file) {
 // ═══════════════════════════════════════════════
 export async function handleTextFile(file) {
   const text = await file.text();
-  const isCsv = /\.(csv)$/i.test(file.name) || file.type === 'text/csv';
+  const isCsv = isCsvTextFile(file);
   if (!text.trim()) { showNotification(`${isCsv ? 'CSV' : 'Text file'} is empty`, "error"); return; }
   await handlePDFFile(file, false, text);
 }

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -190,6 +190,7 @@ test('PDF import helpers cover JSON repair, text quality, and file classificatio
         new File(['image'], 'photo.webp', { type: '' }),
         new File(['dna hook'], 'genome.dna', { type: 'text/plain' }),
         new File(['DNA RAW content'], 'ancestry.csv', { type: 'text/csv' }),
+        new File(['date,marker,value\n2026-06-01,Glucose,5.4'], 'lab-results.csv', { type: 'text/csv' }),
         new File(['plain notes'], 'notes.txt', { type: 'text/plain' }),
         new File(['unsupported'], 'archive.bin', { type: 'application/octet-stream' }),
       ]);
@@ -197,7 +198,7 @@ test('PDF import helpers cover JSON repair, text quality, and file classificatio
         && classified.pdfFiles.length === 3
         && classified.imageFiles.length === 1
         && classified.dnaFiles.length === 2
-        && classified.textFiles.length === 1
+        && classified.textFiles.length === 2
         && classified.unsupportedCount === 1;
       outcomes.pdfMagicSniffChecksHeader = await pdfImport.isPdfByMagic(magicPdf) === true
         && await pdfImport.isPdfByMagic(new File(['NOPE'], 'not-pdf.bin')) === false;
@@ -387,6 +388,13 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
       const textFilePending = review.getPendingImport();
       outcomes.nonEmptyTextFileRoutesThroughPdfHandler = textFilePending?.fileName === 'notes.txt'
         && textFilePending.markers.length === 2;
+      review.closeImportModal();
+
+      await pdfImport.handleTextFile(new File([labText], 'lab-results.csv', { type: 'text/csv' }));
+      const csvFilePending = review.getPendingImport();
+      outcomes.csvFileRoutesThroughTextImportPipeline = csvFilePending?.fileName === 'lab-results.csv'
+        && csvFilePending.markers.length === 2
+        && csvFilePending.privacyMethod === 'regex';
       review.closeImportModal();
 
       await pdfImport.handleImageFile(new File(['image bytes'], 'scan.png', { type: 'image/png' }));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.452';
+self.APP_VERSION = '1.8.453';


### PR DESCRIPTION
## Summary
- Route non-DNA `.csv` files through the existing text-based lab import pipeline.
- Add CSV-specific empty-file and AI-needed copy while keeping DNA CSV detection first.
- Cover CSV classification and runtime import routing in the Playwright PDF import spec.

## Validation
- `npm run typecheck`
- `npm run quality`
- `npm run test:playwright -- pdf-import-browser-coverage.spec.js`
- `npm test`