### PR TITLE
Support XLSX lab import

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
     </div>
   </div>
 
-  <input type="file" id="pdf-input" aria-label="Import PDF or data file" accept=".pdf,.json,.txt,.csv,.jpg,.jpeg,.png,.webp" style="display:none" multiple>
+  <input type="file" id="pdf-input" aria-label="Import PDF or data file" accept=".pdf,.json,.txt,.csv,.xlsx,.jpg,.jpeg,.png,.webp" style="display:none" multiple>
   <div class="notification-container" id="notification-container" aria-live="polite" role="status"></div>
 
   <script src="version.js" defer></script>

--- a/js/import-drop-zone.js
+++ b/js/import-drop-zone.js
@@ -37,7 +37,7 @@ export function setupDropZone() {
     }
     const { jsonFiles, pdfFiles, imageFiles, dnaFiles, textFiles, unsupportedCount } = await importMod.classifyImportFiles(files);
     if (unsupportedCount > 0 && jsonFiles.length === 0 && pdfFiles.length === 0 && imageFiles.length === 0 && dnaFiles.length === 0 && textFiles.length === 0) {
-      window.showNotification?.("Unsupported file type. Use PDF, text, image, JSON, or DNA raw data (.txt/.csv).", "error");
+      window.showNotification?.("Unsupported file type. Use PDF, Excel (.xlsx), text, CSV, image, JSON, or DNA raw data (.txt/.csv).", "error");
       return;
     }
     for (const f of jsonFiles) window.importDataJSON(f);

--- a/js/import-file-input.js
+++ b/js/import-file-input.js
@@ -25,7 +25,7 @@ export async function handleImportInputChange(e) {
   const files = Array.from(e.target.files);
   const { jsonFiles, pdfFiles, imageFiles, dnaFiles, textFiles, unsupportedCount } = await importMod.classifyImportFiles(files);
   if (unsupportedCount > 0 && jsonFiles.length === 0 && pdfFiles.length === 0 && imageFiles.length === 0 && dnaFiles.length === 0 && textFiles.length === 0) {
-    window.showNotification?.("Unsupported file type. Use PDF, text, image, JSON, or DNA raw data (.txt/.csv).", "error");
+    window.showNotification?.("Unsupported file type. Use PDF, Excel (.xlsx), text, CSV, image, JSON, or DNA raw data (.txt/.csv).", "error");
     e.target.value = '';
     return;
   }

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -90,6 +90,9 @@ function loadJSZip() {
     script.onload = () => window.JSZip ? resolve(window.JSZip) : reject(new Error('JSZip failed to load'));
     script.onerror = () => reject(new Error('Failed to load /vendor/jszip.min.js'));
     document.head.appendChild(script);
+  }).catch(err => {
+    _jszipLoad = null;
+    return Promise.reject(err);
   });
   return _jszipLoad;
 }
@@ -1238,7 +1241,12 @@ function isDateFormatCode(formatCode) {
     .replace(/_.?/g, '')
     .replace(/\*.?/g, '')
     .toLowerCase();
-  return /[dy]/.test(cleaned) || /h{1,2}:?m{1,2}/.test(cleaned);
+  const tokens = cleaned.match(/[a-z]+/g) || [];
+  const hasYear = tokens.some(token => /^y{2,4}$/.test(token));
+  const hasDay = tokens.some(token => /^d{1,4}$/.test(token));
+  const hasMonth = tokens.some(token => /^m{1,5}$/.test(token));
+  const hasTime = /(^|[^a-z])h{1,2}:?m{1,2}([^a-z]|$)/.test(cleaned);
+  return hasTime || (hasYear && (hasDay || hasMonth)) || (hasDay && hasMonth);
 }
 
 function getDateStyleIndexes(stylesXml) {

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -71,8 +71,27 @@ function isCsvTextFile(file) {
   return /\.csv$/i.test(file.name) || file.type === 'text/csv';
 }
 
+function isXlsxFile(file) {
+  return /\.xlsx$/i.test(file.name)
+    || file.type === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+}
+
 function isTextImportFile(file) {
-  return isCsvTextFile(file) || /\.txt$/i.test(file.name) || file.type?.startsWith('text/');
+  return isCsvTextFile(file) || isXlsxFile(file) || /\.txt$/i.test(file.name) || file.type?.startsWith('text/');
+}
+
+let _jszipLoad = null;
+function loadJSZip() {
+  if (window.JSZip) return Promise.resolve(window.JSZip);
+  if (_jszipLoad) return _jszipLoad;
+  _jszipLoad = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = '/vendor/jszip.min.js';
+    script.onload = () => window.JSZip ? resolve(window.JSZip) : reject(new Error('JSZip failed to load'));
+    script.onerror = () => reject(new Error('Failed to load /vendor/jszip.min.js'));
+    document.head.appendChild(script);
+  });
+  return _jszipLoad;
 }
 
 export { buildMarkerReference, reconcileImportMarkerMappings } from './pdf-import-marker-mapping.js';
@@ -114,7 +133,9 @@ export function showAINeededDialog(action = 'import') {
       ? 'Reading lab values from a CSV'
       : action === 'text'
         ? 'Reading lab values from a text file'
-        : 'Reading lab values from a PDF';
+        : action === 'xlsx'
+          ? 'Reading lab values from an Excel workbook'
+          : 'Reading lab values from a PDF';
   overlay.innerHTML = `<div class="confirm-dialog ai-needed-dialog" role="dialog" aria-modal="true" aria-label="AI needed to import">
     <p class="confirm-message"><strong>${verb} needs an AI to parse them.</strong></p>
     <p style="font-size:13px;color:var(--text-muted);margin:0 0 14px">Quickest setup is the &ldquo;card&rdquo; option below &mdash; one-click login, charge to your card, you&rsquo;re done in about 30 seconds.</p>
@@ -585,6 +606,8 @@ export async function classifyImportFiles(files) {
     if (/\.(txt|csv)$/i.test(f.name)) {
       if (pdfImportWindow.isDNAFileByContent && await pdfImportWindow.isDNAFileByContent(f)) dnaFiles.push(f);
       else textFiles.push(f);
+    } else if (isXlsxFile(f)) {
+      textFiles.push(f);
     } else if (await isPdfByMagic(f)) {
       pdfFiles.push(f);
     }
@@ -609,7 +632,7 @@ export function setupDropZone() {
     if (files.length === 0) return;
     const { jsonFiles, pdfFiles, imageFiles, dnaFiles, textFiles, unsupportedCount } = await classifyImportFiles(files);
     if (unsupportedCount > 0 && jsonFiles.length === 0 && pdfFiles.length === 0 && imageFiles.length === 0 && dnaFiles.length === 0 && textFiles.length === 0) {
-      showNotification("Unsupported file type. Use PDF, text, image, JSON, or DNA raw data (.txt/.csv).", "error");
+      showNotification("Unsupported file type. Use PDF, Excel (.xlsx), text, CSV, image, JSON, or DNA raw data (.txt/.csv).", "error");
       return;
     }
     for (const f of jsonFiles) pdfImportWindow.importDataJSON(f);
@@ -791,9 +814,10 @@ export async function handlePDFFile(file, forceImageMode = false, preExtractedTe
   const _startProfileId = state.currentProfile;
   const hasPreExtractedText = preExtractedText !== null;
   const isCsvImport = isCsvTextFile(file);
+  const isXlsxImport = isXlsxFile(file);
   const isTextFileImport = isTextImportFile(file);
-  const textImportKind = isCsvImport ? 'CSV' : isTextFileImport ? 'text file' : 'PDF';
-  const textAction = isCsvImport ? 'csv' : isTextFileImport ? 'text' : 'import';
+  const textImportKind = isXlsxImport ? 'Excel workbook' : isCsvImport ? 'CSV' : isTextFileImport ? 'text file' : 'PDF';
+  const textAction = isXlsxImport ? 'xlsx' : isCsvImport ? 'csv' : isTextFileImport ? 'text' : 'import';
   try {
     await showImportProgress(0, file.name);
     const pdfText = hasPreExtractedText ? preExtractedText : await extractPDFText(file);
@@ -1162,13 +1186,209 @@ export async function handleImageFile(file) {
   }
 }
 
+function getXmlElements(root, localName) {
+  return Array.from(root.getElementsByTagName('*')).filter(el => el.localName === localName);
+}
+
+function parseXmlDocument(xml, label) {
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
+  if (getXmlElements(doc, 'parsererror').length > 0) throw new Error(`Could not parse ${label}`);
+  return doc;
+}
+
+async function readZipText(zip, path) {
+  const entry = zip.file(path);
+  return entry ? await entry.async('text') : null;
+}
+
+function normalizeSpreadsheetCellText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function getRelationshipId(element) {
+  return element.getAttribute('r:id')
+    || element.getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', 'id');
+}
+
+function resolveZipPath(baseDir, target) {
+  const raw = String(target || '').replace(/^\/+/, '');
+  const parts = (String(target || '').startsWith('/') ? raw : `${baseDir}/${raw}`).split('/');
+  const stack = [];
+  for (const part of parts) {
+    if (!part || part === '.') continue;
+    if (part === '..') stack.pop();
+    else stack.push(part);
+  }
+  return stack.join('/');
+}
+
+const BUILT_IN_EXCEL_DATE_FORMAT_IDS = new Set([
+  14, 15, 16, 17, 18, 19, 20, 21, 22,
+  27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+  45, 46, 47, 50, 51, 52, 53, 54, 55, 56, 57, 58,
+  71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
+]);
+
+function isDateFormatCode(formatCode) {
+  const firstSection = String(formatCode || '').split(';')[0];
+  const cleaned = firstSection
+    .replace(/"[^"]*"/g, '')
+    .replace(/\[[^\]]*\]/g, '')
+    .replace(/\\./g, '')
+    .replace(/_.?/g, '')
+    .replace(/\*.?/g, '')
+    .toLowerCase();
+  return /[dy]/.test(cleaned) || /h{1,2}:?m{1,2}/.test(cleaned);
+}
+
+function getDateStyleIndexes(stylesXml) {
+  if (!stylesXml) return new Set();
+  const doc = parseXmlDocument(stylesXml, 'Excel styles');
+  const customFormats = new Map();
+  for (const numFmt of getXmlElements(doc, 'numFmt')) {
+    const id = Number(numFmt.getAttribute('numFmtId'));
+    const code = numFmt.getAttribute('formatCode') || '';
+    if (Number.isFinite(id)) customFormats.set(id, code);
+  }
+
+  const cellXfs = getXmlElements(doc, 'cellXfs')[0];
+  const xfs = cellXfs ? Array.from(cellXfs.children).filter(el => el.localName === 'xf') : [];
+  const dateStyleIndexes = new Set();
+  xfs.forEach((xf, index) => {
+    const numFmtId = Number(xf.getAttribute('numFmtId'));
+    if (BUILT_IN_EXCEL_DATE_FORMAT_IDS.has(numFmtId) || isDateFormatCode(customFormats.get(numFmtId))) {
+      dateStyleIndexes.add(index);
+    }
+  });
+  return dateStyleIndexes;
+}
+
+function excelSerialDateToISO(value, date1904 = false) {
+  const serial = Number(value);
+  if (!Number.isFinite(serial)) return String(value || '');
+  const dayMs = 24 * 60 * 60 * 1000;
+  const epochMs = date1904 ? Date.UTC(1904, 0, 1) : Date.UTC(1899, 11, 30);
+  return new Date(epochMs + Math.round(serial * dayMs)).toISOString().slice(0, 10);
+}
+
+function getCellColumnIndex(cell, fallbackIndex) {
+  const ref = cell.getAttribute('r') || '';
+  const letters = ref.match(/^[A-Z]+/i)?.[0];
+  if (!letters) return fallbackIndex;
+  let index = 0;
+  for (const char of letters.toUpperCase()) index = index * 26 + char.charCodeAt(0) - 64;
+  return index - 1;
+}
+
+function getFirstChildText(element, localName) {
+  return getXmlElements(element, localName)[0]?.textContent || '';
+}
+
+function getXlsxCellValue(cell, sharedStrings, dateStyleIndexes, date1904) {
+  const type = cell.getAttribute('t');
+  const rawValue = getFirstChildText(cell, 'v');
+  if (type === 's') return sharedStrings[Number(rawValue)] || '';
+  if (type === 'inlineStr') return normalizeSpreadsheetCellText(getFirstChildText(cell, 'is'));
+  if (type === 'b') return rawValue === '1' ? 'TRUE' : rawValue === '0' ? 'FALSE' : rawValue;
+
+  const styleIndex = Number(cell.getAttribute('s'));
+  if (dateStyleIndexes.has(styleIndex) && rawValue) return excelSerialDateToISO(rawValue, date1904);
+  return normalizeSpreadsheetCellText(rawValue);
+}
+
+function extractWorksheetRows(worksheetXml, sharedStrings, dateStyleIndexes, date1904) {
+  const doc = parseXmlDocument(worksheetXml, 'Excel worksheet');
+  const rows = [];
+  for (const row of getXmlElements(doc, 'row')) {
+    const values = [];
+    let fallbackColumn = 0;
+    const cells = Array.from(row.children).filter(el => el.localName === 'c');
+    for (const cell of cells) {
+      const columnIndex = getCellColumnIndex(cell, fallbackColumn);
+      fallbackColumn = columnIndex + 1;
+      values[columnIndex] = getXlsxCellValue(cell, sharedStrings, dateStyleIndexes, date1904);
+    }
+    const normalized = values.map(value => normalizeSpreadsheetCellText(value));
+    if (normalized.some(Boolean)) rows.push(normalized);
+  }
+  return rows;
+}
+
+async function getWorkbookSheets(zip, workbookDoc) {
+  const relsXml = await readZipText(zip, 'xl/_rels/workbook.xml.rels');
+  const relationshipTargets = new Map();
+  if (relsXml) {
+    const relsDoc = parseXmlDocument(relsXml, 'Excel workbook relationships');
+    for (const rel of getXmlElements(relsDoc, 'Relationship')) {
+      relationshipTargets.set(rel.getAttribute('Id'), rel.getAttribute('Target'));
+    }
+  }
+
+  const sheets = getXmlElements(workbookDoc, 'sheet').map((sheet, index) => {
+    const relId = getRelationshipId(sheet);
+    const target = relId ? relationshipTargets.get(relId) : null;
+    return {
+      name: sheet.getAttribute('name') || `Sheet ${index + 1}`,
+      path: target ? resolveZipPath('xl', target) : `xl/worksheets/sheet${index + 1}.xml`,
+    };
+  });
+
+  if (sheets.length > 0) return sheets;
+  return Object.keys(zip.files || {})
+    .filter(path => /^xl\/worksheets\/sheet\d+\.xml$/i.test(path))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    .map((path, index) => ({ name: `Sheet ${index + 1}`, path }));
+}
+
+export async function extractXLSXText(file) {
+  const JSZip = await loadJSZip();
+  const zip = await JSZip.loadAsync(await file.arrayBuffer());
+  const workbookXml = await readZipText(zip, 'xl/workbook.xml');
+  if (!workbookXml) throw new Error('Workbook metadata is missing');
+
+  const workbookDoc = parseXmlDocument(workbookXml, 'Excel workbook');
+  const workbookPr = getXmlElements(workbookDoc, 'workbookPr')[0];
+  const date1904 = ['1', 'true'].includes(String(workbookPr?.getAttribute('date1904') || '').toLowerCase());
+  const sharedStringsXml = await readZipText(zip, 'xl/sharedStrings.xml');
+  const sharedStrings = sharedStringsXml
+    ? getXmlElements(parseXmlDocument(sharedStringsXml, 'Excel shared strings'), 'si')
+      .map(si => normalizeSpreadsheetCellText(si.textContent || ''))
+    : [];
+  const dateStyleIndexes = getDateStyleIndexes(await readZipText(zip, 'xl/styles.xml'));
+  const sheets = await getWorkbookSheets(zip, workbookDoc);
+  const blocks = [];
+
+  for (const sheet of sheets) {
+    const worksheetXml = await readZipText(zip, sheet.path);
+    if (!worksheetXml) continue;
+    const rows = extractWorksheetRows(worksheetXml, sharedStrings, dateStyleIndexes, date1904);
+    if (rows.length === 0) continue;
+    blocks.push([
+      `Sheet: ${sheet.name}`,
+      ...rows.map(row => row.map(value => normalizeSpreadsheetCellText(value)).join('\t')),
+    ].join('\n'));
+  }
+
+  if (blocks.length === 0) return '';
+  return [`Workbook: ${file.name}`, ...blocks].join('\n\n');
+}
+
 // ═══════════════════════════════════════════════
 // TEXT FILE IMPORT
 // ═══════════════════════════════════════════════
 export async function handleTextFile(file) {
-  const text = await file.text();
+  const isXlsx = isXlsxFile(file);
   const isCsv = isCsvTextFile(file);
-  if (!text.trim()) { showNotification(`${isCsv ? 'CSV' : 'Text file'} is empty`, "error"); return; }
+  let text = '';
+  try {
+    text = isXlsx ? await extractXLSXText(file) : await file.text();
+  } catch (err) {
+    const message = err?.message || String(err);
+    showNotification(isXlsx ? `Could not read Excel workbook: ${message}` : `Could not read text file: ${message}`, 'error');
+    return;
+  }
+  const fileKind = isXlsx ? 'Excel workbook' : isCsv ? 'CSV' : 'Text file';
+  if (!text.trim()) { showNotification(`${fileKind} is empty`, "error"); return; }
   await handlePDFFile(file, false, text);
 }
 

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -191,6 +191,7 @@ test('PDF import helpers cover JSON repair, text quality, and file classificatio
         new File(['dna hook'], 'genome.dna', { type: 'text/plain' }),
         new File(['DNA RAW content'], 'ancestry.csv', { type: 'text/csv' }),
         new File(['date,marker,value\n2026-06-01,Glucose,5.4'], 'lab-results.csv', { type: 'text/csv' }),
+        new File(['xlsx bytes'], 'lab-results.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }),
         new File(['plain notes'], 'notes.txt', { type: 'text/plain' }),
         new File(['unsupported'], 'archive.bin', { type: 'application/octet-stream' }),
       ]);
@@ -198,7 +199,7 @@ test('PDF import helpers cover JSON repair, text quality, and file classificatio
         && classified.pdfFiles.length === 3
         && classified.imageFiles.length === 1
         && classified.dnaFiles.length === 2
-        && classified.textFiles.length === 2
+        && classified.textFiles.length === 3
         && classified.unsupportedCount === 1;
       outcomes.pdfMagicSniffChecksHeader = await pdfImport.isPdfByMagic(magicPdf) === true
         && await pdfImport.isPdfByMagic(new File(['NOPE'], 'not-pdf.bin')) === false;
@@ -243,6 +244,8 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       currentProfile: state.currentProfile,
       profileSex: state.profileSex,
+      jszip: window.JSZip,
+      hadJSZip: Object.prototype.hasOwnProperty.call(window, 'JSZip'),
     };
     const encoder = new TextEncoder();
     const fetchCalls = [];
@@ -397,6 +400,53 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
         && csvFilePending.privacyMethod === 'regex';
       review.closeImportModal();
 
+      const xlsxEntries = {
+        'xl/workbook.xml': `<?xml version="1.0" encoding="UTF-8"?>
+          <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+            <sheets><sheet name="Results" sheetId="1" r:id="rId1"/></sheets>
+          </workbook>`,
+        'xl/_rels/workbook.xml.rels': `<?xml version="1.0" encoding="UTF-8"?>
+          <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+            <Relationship Id="rId1" Type="worksheet" Target="worksheets/sheet1.xml"/>
+          </Relationships>`,
+        'xl/sharedStrings.xml': `<?xml version="1.0" encoding="UTF-8"?>
+          <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+            <si><t>Date</t></si><si><t>Marker</t></si><si><t>Value</t></si>
+            <si><t>2026-06-01</t></si><si><t>Glucose</t></si><si><t>5.4</t></si>
+          </sst>`,
+        'xl/worksheets/sheet1.xml': `<?xml version="1.0" encoding="UTF-8"?>
+          <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+            <sheetData>
+              <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c></row>
+              <row r="2"><c r="A2" t="s"><v>3</v></c><c r="B2" t="s"><v>4</v></c><c r="C2" t="s"><v>5</v></c></row>
+            </sheetData>
+          </worksheet>`,
+      };
+      window.JSZip = {
+        loadAsync: async () => ({
+          files: Object.fromEntries(Object.keys(xlsxEntries).map(path => [path, {}])),
+          file(path) {
+            return xlsxEntries[path] == null ? null : { async: async () => xlsxEntries[path] };
+          },
+        }),
+      };
+      const xlsxFile = new File(
+        [new Uint8Array([0x50, 0x4b, 0x03, 0x04])],
+        'lab-results.xlsx',
+        { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
+      );
+      const extractedXlsxText = await pdfImport.extractXLSXText(xlsxFile);
+      outcomes.xlsxExtractorReadsWorkbookCells = extractedXlsxText.includes('Workbook: lab-results.xlsx')
+        && extractedXlsxText.includes('Sheet: Results')
+        && extractedXlsxText.includes('Glucose');
+      await pdfImport.handleTextFile(xlsxFile);
+      const xlsxFilePending = review.getPendingImport();
+      outcomes.xlsxFileRoutesThroughTextImportPipeline = xlsxFilePending?.fileName === 'lab-results.xlsx'
+        && xlsxFilePending.markers.length === 2
+        && xlsxFilePending.privacyMethod === 'regex';
+      review.closeImportModal();
+
       await pdfImport.handleImageFile(new File(['image bytes'], 'scan.png', { type: 'image/png' }));
       const imagePending = review.getPendingImport();
       outcomes.imageFileHandlerOpensPreview = imagePending?.fileName === 'scan.png'
@@ -419,6 +469,8 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;
       state.profileSex = original.profileSex;
+      if (original.hadJSZip) window.JSZip = original.jszip;
+      else delete window.JSZip;
       for (const [key, value] of Object.entries(savedStorage)) {
         if (value == null) localStorage.removeItem(key);
         else localStorage.setItem(key, value);

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -219,6 +219,26 @@ test('PDF import helpers cover JSON repair, text quality, and file classificatio
 });
 
 test('PDF import runtime handlers cover AI parse fallback text and image routes', async ({ page }) => {
+  let jszipVendorRequests = 0;
+  await page.route('**/vendor/jszip.min.js', route => {
+    jszipVendorRequests += 1;
+    if (jszipVendorRequests === 1) {
+      route.abort('failed');
+      return;
+    }
+    route.fulfill({
+      contentType: 'text/javascript',
+      body: `
+        window.JSZip = {
+          loadAsync: async () => ({
+            files: {},
+            file() { return null; },
+          }),
+        };
+      `,
+    });
+  });
+
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#drop-zone', { state: 'attached' });
   await page.waitForSelector('#import-modal-overlay', { state: 'attached' });
@@ -400,6 +420,27 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
         && csvFilePending.privacyMethod === 'regex';
       review.closeImportModal();
 
+      delete window.JSZip;
+      const retryXlsxFile = new File(
+        [new Uint8Array([0x50, 0x4b, 0x03, 0x04])],
+        'retry.xlsx',
+        { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
+      );
+      let firstLoaderError = '';
+      let secondLoaderError = '';
+      try {
+        await pdfImport.extractXLSXText(retryXlsxFile);
+      } catch (err) {
+        firstLoaderError = err?.message || String(err);
+      }
+      try {
+        await pdfImport.extractXLSXText(retryXlsxFile);
+      } catch (err) {
+        secondLoaderError = err?.message || String(err);
+      }
+      outcomes.xlsxJsZipLoaderRetriesAfterScriptFailure = firstLoaderError.includes('Failed to load /vendor/jszip.min.js')
+        && secondLoaderError.includes('Workbook metadata is missing');
+
       const xlsxEntries = {
         'xl/workbook.xml': `<?xml version="1.0" encoding="UTF-8"?>
           <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -413,13 +454,18 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
         'xl/sharedStrings.xml': `<?xml version="1.0" encoding="UTF-8"?>
           <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
             <si><t>Date</t></si><si><t>Marker</t></si><si><t>Value</t></si>
-            <si><t>2026-06-01</t></si><si><t>Glucose</t></si><si><t>5.4</t></si>
+            <si><t>2026-06-01</t></si><si><t>Glucose</t></si><si><t>5.4</t></si><si><t>Flag</t></si>
           </sst>`,
+        'xl/styles.xml': `<?xml version="1.0" encoding="UTF-8"?>
+          <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+            <numFmts count="1"><numFmt numFmtId="164" formatCode="body"/></numFmts>
+            <cellXfs count="2"><xf numFmtId="0"/><xf numFmtId="164"/></cellXfs>
+          </styleSheet>`,
         'xl/worksheets/sheet1.xml': `<?xml version="1.0" encoding="UTF-8"?>
           <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
             <sheetData>
-              <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c></row>
-              <row r="2"><c r="A2" t="s"><v>3</v></c><c r="B2" t="s"><v>4</v></c><c r="C2" t="s"><v>5</v></c></row>
+              <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c><c r="D1" t="s"><v>6</v></c></row>
+              <row r="2"><c r="A2" t="s"><v>3</v></c><c r="B2" t="s"><v>4</v></c><c r="C2" t="s"><v>5</v></c><c r="D2" s="1"><v>7</v></c></row>
             </sheetData>
           </worksheet>`,
       };
@@ -439,7 +485,9 @@ test('PDF import runtime handlers cover AI parse fallback text and image routes'
       const extractedXlsxText = await pdfImport.extractXLSXText(xlsxFile);
       outcomes.xlsxExtractorReadsWorkbookCells = extractedXlsxText.includes('Workbook: lab-results.xlsx')
         && extractedXlsxText.includes('Sheet: Results')
-        && extractedXlsxText.includes('Glucose');
+        && extractedXlsxText.includes('Glucose')
+        && extractedXlsxText.includes('\t7')
+        && !extractedXlsxText.includes('1900-01');
       await pdfImport.handleTextFile(xlsxFile);
       const xlsxFilePending = review.getPendingImport();
       outcomes.xlsxFileRoutesThroughTextImportPipeline = xlsxFilePending?.fileName === 'lab-results.xlsx'

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.453';
+self.APP_VERSION = '1.8.454';


### PR DESCRIPTION
## Summary
- Add `.xlsx` to the lab import picker and route Excel workbooks through the existing AI text import pipeline.
- Extract workbook cells locally with lazy-loaded `vendor/jszip.min.js`, including sheet names and basic Excel date-style conversion.
- Update unsupported-file copy and Playwright coverage for XLSX classification, extraction, and preview routing.

## Validation
- `npm run typecheck`
- `npm run quality`
- `npm test`
- `npm run test:playwright -- pdf-import-browser-coverage.spec.js`
- `git diff --check`