### PR TITLE
[codex] Fix theme CTA hover contrast

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -6,6 +6,14 @@ import { escapeHTML } from './utils.js';
 
 const CHANGELOG = [
   {
+    version: '1.8.455', date: '2026-06-13', title: 'XLSX lab imports and improvements',
+    items: [
+      '<b>XLSX lab import support.</b> Excel lab reports can now be imported alongside PDFs and CSVs.',
+      '<b>Bugfixes and improvements.</b> Improved import reliability and fixed theme CTA hover contrast issues.',
+      '<b>Substantial codebase improvements.</b> Expanded browser test coverage and cleaned up shared app behavior.',
+    ]
+  },
+  {
     version: '1.8.358', date: '2026-06-03', title: 'Private profile sharing',
     items: [
       '<b>Password-protected profile links.</b> Share an encrypted profile copy with someone else, then keep the link and password separate.',

--- a/tests/playwright/theme-cta-hover-contrast.spec.js
+++ b/tests/playwright/theme-cta-hover-contrast.spec.js
@@ -40,16 +40,14 @@ test('custom dark theme primary dashboard CTA hover text stays readable', async 
   await page.goto('/app', { waitUntil: 'networkidle' });
 
   for (const theme of THEMES) {
-    const result = await page.evaluate(async (nextTheme) => {
+    await page.evaluate(async (nextTheme) => {
       document.documentElement.dataset.theme = nextTheme;
       document.body.insertAdjacentHTML(
         'beforeend',
         `<button id="hover-contrast-cta" class="dashboard-action-btn dashboard-action-btn-primary" style="position:fixed;left:24px;top:24px;z-index:9999">Primary CTA</button>`
       );
       await new Promise(requestAnimationFrame);
-      return true;
     }, theme);
-    expect(result).toBe(true);
 
     const button = page.locator('#hover-contrast-cta');
     await button.hover();

--- a/tests/playwright/theme-cta-hover-contrast.spec.js
+++ b/tests/playwright/theme-cta-hover-contrast.spec.js
@@ -1,0 +1,77 @@
+import { expect, test } from './coverage-fixture.js';
+
+const THEMES = ['cyberterm', 'glass', 'synth-sunrise', 'neuromancer'];
+
+function parseCssColor(value) {
+  const match = String(value || '').match(/rgba?\(([^)]+)\)/i);
+  if (!match) return null;
+  const parts = match[1].split(',').map(part => part.trim());
+  return {
+    r: Number(parts[0]),
+    g: Number(parts[1]),
+    b: Number(parts[2]),
+    a: parts[3] === undefined ? 1 : Number(parts[3]),
+  };
+}
+
+function compositeOver(color, under) {
+  const alpha = Number.isFinite(color.a) ? color.a : 1;
+  return {
+    r: color.r * alpha + under.r * (1 - alpha),
+    g: color.g * alpha + under.g * (1 - alpha),
+    b: color.b * alpha + under.b * (1 - alpha),
+  };
+}
+
+function luminance(channel) {
+  const value = channel / 255;
+  return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function contrastRatio(foreground, background) {
+  const fg = 0.2126 * luminance(foreground.r) + 0.7152 * luminance(foreground.g) + 0.0722 * luminance(foreground.b);
+  const bg = 0.2126 * luminance(background.r) + 0.7152 * luminance(background.g) + 0.0722 * luminance(background.b);
+  const light = Math.max(fg, bg);
+  const dark = Math.min(fg, bg);
+  return (light + 0.05) / (dark + 0.05);
+}
+
+test('custom dark theme primary dashboard CTA hover text stays readable', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'networkidle' });
+
+  for (const theme of THEMES) {
+    const result = await page.evaluate(async (nextTheme) => {
+      document.documentElement.dataset.theme = nextTheme;
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        `<button id="hover-contrast-cta" class="dashboard-action-btn dashboard-action-btn-primary" style="position:fixed;left:24px;top:24px;z-index:9999">Primary CTA</button>`
+      );
+      await new Promise(requestAnimationFrame);
+      return true;
+    }, theme);
+    expect(result).toBe(true);
+
+    const button = page.locator('#hover-contrast-cta');
+    await button.hover();
+    const styles = await button.evaluate((el) => {
+      const buttonStyle = getComputedStyle(el);
+      const bodyStyle = getComputedStyle(document.body);
+      return {
+        color: buttonStyle.color,
+        backgroundColor: buttonStyle.backgroundColor,
+        bodyBackgroundColor: bodyStyle.backgroundColor,
+      };
+    });
+    await button.evaluate(el => el.remove());
+
+    const foreground = parseCssColor(styles.color);
+    const background = parseCssColor(styles.backgroundColor);
+    const bodyBackground = parseCssColor(styles.bodyBackgroundColor) || { r: 0, g: 0, b: 0, a: 1 };
+    expect(foreground, `${theme} foreground ${styles.color}`).toBeTruthy();
+    expect(background, `${theme} background ${styles.backgroundColor}`).toBeTruthy();
+
+    const compositedBackground = compositeOver(background, bodyBackground);
+    const ratio = contrastRatio(foreground, compositedBackground);
+    expect(ratio, `${theme} hover contrast ${ratio.toFixed(2)} (${styles.color} on ${styles.backgroundColor})`).toBeGreaterThanOrEqual(4.5);
+  }
+});

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -188,6 +188,11 @@ console.log('=== Phase 3 A11y Tests ===\n');
     synthPrimaryHoverRule[0].includes('.light-today-cta:not(.light-today-cta-secondary):hover') &&
     synthPrimaryHoverRule[0].includes('.sun-session-ctl-stop:hover') &&
     synthPrimaryHoverRule[0].includes('.import-btn-primary:hover'));
+  const darkCtaHoverRule = themesSrc.match(/\[data-theme="cyberterm"\]\s+\.dashboard-action-btn-primary:hover,[\s\S]*?\{[^}]*color:\s*#fff/);
+  assert('terminal glass neuromancer primary dashboard CTA hovers use light text',
+    !!darkCtaHoverRule &&
+    darkCtaHoverRule[0].includes('[data-theme="glass"] .dashboard-action-btn-primary:hover') &&
+    darkCtaHoverRule[0].includes('[data-theme="neuromancer"] .dashboard-action-btn-primary:hover'));
 
   // ─── 12. Weight input respects unit system ───
   const wearSrc = read('/js/wearables.js');

--- a/themes-extra.css
+++ b/themes-extra.css
@@ -359,11 +359,23 @@
 /* #ff2bd6 with white foreground is under AA for normal text; this dark
    foreground keeps synth active controls readable. */
 [data-theme="synth-sunrise"] { --on-accent: #0d0524; }
+[data-theme="neuromancer"] { --on-accent: #050608; }
+[data-theme="cyberterm"] .dashboard-action-btn-primary,
+[data-theme="glass"] .dashboard-action-btn-primary,
+[data-theme="neuromancer"] .dashboard-action-btn-primary {
+  transition: border-color 0.15s, transform 0.05s;
+}
+[data-theme="cyberterm"] .dashboard-action-btn-primary:hover,
+[data-theme="glass"] .dashboard-action-btn-primary:hover,
+[data-theme="neuromancer"] .dashboard-action-btn-primary:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+  color: #fff;
+}
 [data-theme="synth-sunrise"] .dashboard-action-btn-primary:hover,
 [data-theme="synth-sunrise"] .light-today-cta:not(.light-today-cta-secondary):hover,
 [data-theme="synth-sunrise"] .sun-session-ctl-stop:hover,
 [data-theme="synth-sunrise"] .import-btn-primary:hover { color: #fff; }
-[data-theme="neuromancer"] { --on-accent: #050608; }
 
 [data-theme="cyberterm"] .brand-mark::before {
   content: "$ ";

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.454';
+self.APP_VERSION = '1.8.455';


### PR DESCRIPTION
## Summary
- Fix primary dashboard CTA hover contrast in Cypherpunk Terminal, Glass Liquid, and Neuromancer.
- Add a Playwright browser regression test for custom theme CTA hover contrast.
- Add the 1.8.455 changelog entry for XLSX lab imports, bugfixes, and codebase improvements.

## Validation
- `node tests/test-changelog.js`
- `node tests/test-a11y-phase3.js`
- `npm run test:playwright -- theme-cta-hover-contrast.spec.js`
- `git diff --check`