### PR TITLE
Share modal overlay lifecycle helpers

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -3,6 +3,7 @@
 // APP_VERSION comes from /version.js (loaded as classic script before modules)
 
 import { escapeHTML } from './utils.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 const CHANGELOG = [
   {
@@ -295,12 +296,11 @@ export function openChangelog(showAll) {
 
   html += `</div>`;
   modal.innerHTML = html;
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
 }
 
 export function closeChangelog() {
-  const overlay = document.getElementById('changelog-modal-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('changelog-modal-overlay');
   markChangelogSeen();
 }
 

--- a/js/feedback.js
+++ b/js/feedback.js
@@ -4,6 +4,7 @@
 import { escapeHTML, showNotification } from './utils.js';
 import { getTheme } from './theme.js';
 import { getAIProvider } from './api.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 const FEEDBACK_TYPES = [
   { value: 'bug', label: 'Bug Report', prefix: '[Bug]', ghLabel: 'bug', placeholder: 'Brief description of the bug' },
@@ -49,13 +50,11 @@ export function openFeedbackModal() {
       </div>
     </form>
     </div>`;
-  overlay.classList.add('show');
-  // Focus the title input
-  setTimeout(() => document.getElementById('feedback-title')?.focus(), 50);
+  openModalOverlay(overlay, { initialFocus: '#feedback-title', focusDelay: 50 });
 }
 
 export function closeFeedbackModal() {
-  document.getElementById('feedback-modal-overlay')?.classList.remove('show');
+  closeModalOverlay('feedback-modal-overlay');
 }
 
 export function submitFeedback() {

--- a/js/modal-lifecycle.js
+++ b/js/modal-lifecycle.js
@@ -35,6 +35,88 @@ const _modalScrollState = (() => {
 
 const _modalScrollLocks = _modalScrollState.locks;
 
+const _overlayFocusTargets = (() => {
+  if (typeof window === 'undefined') return new WeakMap();
+  const appWindow = /** @type {any} */ (window);
+  if (appWindow.__labModalOverlayFocusTargets instanceof WeakMap) {
+    return appWindow.__labModalOverlayFocusTargets;
+  }
+  const focusTargets = new WeakMap();
+  try {
+    Object.defineProperty(appWindow, '__labModalOverlayFocusTargets', {
+      value: focusTargets,
+      configurable: true,
+    });
+  } catch (_) {
+    appWindow.__labModalOverlayFocusTargets = focusTargets;
+  }
+  return focusTargets;
+})();
+
+function _resolveOverlay(overlayOrId) {
+  if (!overlayOrId || typeof document === 'undefined') return null;
+  if (typeof overlayOrId === 'string') return document.getElementById(overlayOrId);
+  return overlayOrId;
+}
+
+function _isRestorableFocusTarget(target) {
+  return typeof HTMLElement !== 'undefined'
+    && target instanceof HTMLElement
+    && target !== document.body
+    && target !== document.documentElement
+    && document.contains(target);
+}
+
+function _resolveFocusTarget(target, overlay) {
+  if (!target) return null;
+  if (typeof target === 'string') {
+    return overlay.querySelector(target) || document.querySelector(target);
+  }
+  return target;
+}
+
+export function openModalOverlay(overlayOrId, options = {}) {
+  const overlay = _resolveOverlay(overlayOrId);
+  if (!overlay) return null;
+  const showClass = options.showClass || 'show';
+  const activeElement = document.activeElement;
+  if (_isRestorableFocusTarget(activeElement)) {
+    _overlayFocusTargets.set(overlay, activeElement);
+  }
+  overlay.classList.add(showClass);
+
+  if (options.initialFocus) {
+    const delay = Number.isFinite(options.focusDelay) ? Math.max(0, options.focusDelay) : 30;
+    setTimeout(() => {
+      const currentOverlay = _resolveOverlay(overlayOrId);
+      if (!currentOverlay || !currentOverlay.classList.contains(showClass)) return;
+      const target = _resolveFocusTarget(options.initialFocus, currentOverlay);
+      if (target && typeof target.focus === 'function') {
+        try { target.focus(); } catch (_) {}
+      }
+    }, delay);
+  }
+
+  return overlay;
+}
+
+export function closeModalOverlay(overlayOrId, options = {}) {
+  const overlay = _resolveOverlay(overlayOrId);
+  if (!overlay) return null;
+  const showClass = options.showClass || 'show';
+  overlay.classList.remove(showClass);
+
+  if (options.restoreFocus !== false) {
+    const focusTarget = _overlayFocusTargets.get(overlay);
+    _overlayFocusTargets.delete(overlay);
+    if (_isRestorableFocusTarget(focusTarget)) {
+      try { focusTarget.focus(); } catch (_) {}
+    }
+  }
+
+  return overlay;
+}
+
 function _pruneDetachedModalScrollLocks() {
   for (const lock of Array.from(_modalScrollLocks)) {
     if (!document.body.contains(lock)) _modalScrollLocks.delete(lock);

--- a/tests/playwright/modal-lifecycle-browser-coverage.spec.js
+++ b/tests/playwright/modal-lifecycle-browser-coverage.spec.js
@@ -59,6 +59,34 @@ test('modal lifecycle browser coverage handles backdrop focus trap and scroll lo
       click(defaultCloseOverlay);
       outcomes.defaultBackdropCloseRemovesOverlay = !document.body.contains(defaultCloseOverlay);
 
+      const opener = document.createElement('button');
+      opener.id = 'open-helper-opener';
+      opener.textContent = 'Open helper opener';
+      document.body.append(opener);
+      opener.focus();
+      const classOverlay = document.createElement('div');
+      classOverlay.className = 'modal-overlay';
+      classOverlay.innerHTML = `
+        <div class="modal">
+          <button id="open-helper-close">Close</button>
+          <input id="open-helper-input">
+        </div>
+      `;
+      document.body.append(classOverlay);
+      modalLifecycle.openModalOverlay(classOverlay, { initialFocus: '#open-helper-input', focusDelay: 0 });
+      await waitUntil(() => document.activeElement?.id === 'open-helper-input', 'open helper focus target');
+      const helperOpenedAndFocused =
+        classOverlay.classList.contains('show')
+        && document.activeElement?.id === 'open-helper-input';
+      modalLifecycle.closeModalOverlay('missing-overlay');
+      modalLifecycle.closeModalOverlay(classOverlay);
+      outcomes.openCloseOverlayHelpersToggleClassFocusAndRestore =
+        helperOpenedAndFocused
+        && !classOverlay.classList.contains('show')
+        && document.activeElement?.id === 'open-helper-opener';
+      classOverlay.remove();
+      opener.remove();
+
       const beforeModal = document.getElementById('before-modal');
       beforeModal.focus();
       const overlayA = document.createElement('div');

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -81,6 +81,16 @@ console.log('=== Phase 3 A11y Tests ===\n');
       closeButtons === labelled,
       `${labelled}/${closeButtons} labelled`);
   }
+  const feedbackSrc = read('/js/feedback.js');
+  const changelogSrc = read('/js/changelog.js');
+  assert('feedback modal uses shared overlay lifecycle helpers',
+    feedbackSrc.includes("from './modal-lifecycle.js'")
+      && feedbackSrc.includes('openModalOverlay(')
+      && feedbackSrc.includes('closeModalOverlay('));
+  assert('changelog modal uses shared overlay lifecycle helpers',
+    changelogSrc.includes("from './modal-lifecycle.js'")
+      && changelogSrc.includes('openModalOverlay(')
+      && changelogSrc.includes('closeModalOverlay('));
 
   // ─── 4. Brand-voice "we/us" eliminated from key sites ───
   const utilsSrc = read('/js/utils.js');

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -36,6 +36,7 @@ const startupUiSrc = await fetchWithRetry('js/startup-ui.js');
 const appEventsSrc = await fetchWithRetry('js/app-event-listeners.js');
 const settingsSrc = await fetchWithRetry('js/settings.js');
 const swSrc = await fetchWithRetry('service-worker.js');
+const modalLifecycleSrc = await fetchWithRetry('js/modal-lifecycle.js');
 // Original test fetched '/app' (dev-server alias for index.html); read
 // index.html directly in Node.
 const indexSrc = await fetchWithRetry('index.html');
@@ -51,6 +52,10 @@ assert('changelog.js has CHANGELOG array', changelogSrc.includes('const CHANGELO
 assert('changelog.js exports openChangelog', changelogSrc.includes('export function openChangelog'));
 assert('changelog.js exports closeChangelog', changelogSrc.includes('export function closeChangelog'));
 assert('changelog.js exports maybeShowChangelog', changelogSrc.includes('export function maybeShowChangelog'));
+assert('changelog.js uses shared modal overlay lifecycle helpers',
+  changelogSrc.includes("from './modal-lifecycle.js'")
+    && changelogSrc.includes('openModalOverlay(')
+    && changelogSrc.includes('closeModalOverlay('));
 assert('changelog.js has getMajorMinor helper', changelogSrc.includes('function getMajorMinor'));
 assert('maybeShowChangelog compares major.minor only', changelogSrc.includes('getMajorMinor(seen) !== getMajorMinor('));
 // forceShow patch-bump escape hatch — when a maintainer flags an entry as
@@ -80,6 +85,9 @@ assert('SW imports version.js', swSrc.includes("importScripts('/version.js')"));
 assert('SW CACHE_NAME uses template literal', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
 assert('SW APP_SHELL includes version.js', swSrc.includes("'/version.js'"));
 assert('index.html loads version.js', indexSrc.includes('src="version.js"'));
+assert('modal-lifecycle.js exports overlay show/hide helpers',
+  modalLifecycleSrc.includes('export function openModalOverlay')
+    && modalLifecycleSrc.includes('export function closeModalOverlay'));
 
 // ═══════════════════════════════════════
 // 3. HTML: changelog modal exists in source

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.458';
+self.APP_VERSION = '1.8.459';


### PR DESCRIPTION
## Summary
- add shared `openModalOverlay` / `closeModalOverlay` helpers to `modal-lifecycle.js`
- migrate Feedback and What's New modals to the shared overlay helper
- add static and browser coverage for the new helper contract
- bump `version.js` to `1.8.459`

## Tests
- `node tests/test-changelog.js`
- `node tests/test-a11y-phase3.js`
- `npm run test:playwright -- modal-lifecycle-browser-coverage.spec.js`
- `npm run test:playwright -- browser-coverage-batch.spec.js changelog.spec.js`