### PR TITLE
Use modal lifecycle helpers for client list

### DIFF
--- a/js/client-list.js
+++ b/js/client-list.js
@@ -6,6 +6,7 @@ import { escapeHTML, escapeAttr } from './utils.js';
 import { getProfiles, getActiveProfileId, createProfile, switchProfile, deleteProfile, updateProfileMeta, getAllTags, getLocationCache, latitudeToBand, getLatitudeFromLocation, detectLatitudeWithAI, getProfileHeight } from './profile.js';
 import { LATITUDE_BANDS } from './constants.js';
 import { getAvatarColor } from './nav.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 let _search = '';
 let _sort = 'lastUpdated';
@@ -129,17 +130,12 @@ export function openClientList() {
   const overlay = document.getElementById('client-list-overlay');
   if (!overlay) return;
   renderClientList();
-  overlay.classList.add('show');
+  openModalOverlay(overlay, { initialFocus: '#cl-search' });
   document.body.style.overflow = 'hidden';
-  requestAnimationFrame(() => {
-    const input = document.getElementById('cl-search');
-    if (input) input.focus();
-  });
 }
 
 export function closeClientList() {
-  const overlay = document.getElementById('client-list-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('client-list-overlay');
   document.body.style.overflow = '';
   _editingId = null;
 }

--- a/tests/test-client-list-delegated-actions.js
+++ b/tests/test-client-list-delegated-actions.js
@@ -48,6 +48,10 @@ assert('client-list menu buttons are data-driven',
 assert('client-list can open share modal for selected profile',
   clientListSrc.includes('function _clShare(id)') &&
     clientListSrc.includes('window.openProfileShareModal?.(id)'));
+assert('client-list modal uses shared overlay lifecycle helpers',
+  clientListSrc.includes("from './modal-lifecycle.js'") &&
+    clientListSrc.includes('openModalOverlay(') &&
+    clientListSrc.includes('closeModalOverlay('));
 assert('dynamic avatar and tag buttons avoid direct onclick assignment',
   clientListSrc.includes("btn.setAttribute('data-cl-action', 'remove-avatar')") &&
     !clientListSrc.includes('.onclick'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.459';
+self.APP_VERSION = '1.8.460';


### PR DESCRIPTION
## Summary
- migrate client-list overlay open/close to shared modal lifecycle helpers
- keep client-list body scroll locking unchanged
- add a static guard that client-list uses the shared helpers
- bump `version.js` to `1.8.460`

## Tests
- `node tests/test-client-list-delegated-actions.js`
- `npm test -- tests/client-list-runtime.test.js`
- `npm run test:playwright -- client-list-browser-coverage.spec.js`