### PR TITLE
Use modal lifecycle helpers for DNA previews

### DIFF
--- a/js/dna.js
+++ b/js/dna.js
@@ -5,6 +5,7 @@
 import { state } from './state.js';
 import { escapeAttr, escapeHTML, hashString, showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 /** @typedef {Window & typeof globalThis & {
  *   _pendingDNAImport?: any,
  *   _pendingMtDNA?: any,
@@ -1092,14 +1093,13 @@ function showDNAImportPreview(result, fileName) {
     document.body.appendChild(overlay);
   }
   overlay.innerHTML = `<div class="modal dna-preview-modal" role="dialog">${html}</div>`;
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
 }
 
 function closeDNAImportPreview() {
   dnaWindow._pendingDNAImport = null;
   _dnaImportRunning = false;
-  const overlay = document.getElementById('dna-modal-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('dna-modal-overlay');
 }
 
 async function confirmDNAImport() {
@@ -1112,8 +1112,7 @@ async function confirmDNAImport() {
   }
   dnaWindow._pendingDNAImport = null;
   _dnaImportRunning = false;
-  const overlay = document.getElementById('dna-modal-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('dna-modal-overlay');
   showNotification(`Imported ${result.coverage.found} SNPs from ${result.source}`, 'success');
 
   // Build summary for chat confirmation
@@ -1374,12 +1373,11 @@ function _showMtDNAPreview(resolved, coupling, mutations, fileName) {
     document.body.appendChild(overlay);
   }
   overlay.innerHTML = `<div class="modal dna-preview-modal" role="dialog">${html}</div>`;
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
 }
 
 export function closeMtDNAPreview() {
-  const overlay = document.getElementById('dna-modal-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('dna-modal-overlay');
   dnaWindow._pendingMtDNA = null;
 }
 

--- a/tests/test-dna.js
+++ b/tests/test-dna.js
@@ -418,6 +418,10 @@ assert('dashboard genome SNP rows keep severity left border',
 const dnaSrc = await fetchWithRetry('js/dna.js');
 assert('genetics section collapses non-priority SNP calls', dnaSrc.includes('genetics-other-snps') && dnaSrc.includes('Other imported SNPs'));
 assert('DNA import preview separates beneficial findings', dnaSrc.includes('Beneficial findings') && dnaSrc.includes("impact: m.valence === 'protective' ? 'beneficial' : m.effect"));
+assert('DNA preview modal uses shared overlay lifecycle helpers',
+  dnaSrc.includes("from './modal-lifecycle.js'") &&
+    dnaSrc.includes('openModalOverlay(overlay)') &&
+    (dnaSrc.match(/closeModalOverlay\('dna-modal-overlay'\)/g) || []).length === 3);
 assert('DNA import success waits for persistence',
   /async function confirmDNAImport\(\)[\s\S]{0,220}await saveImportedData\(\)/.test(dnaSrc));
 const dnaSaveFailureBlock = (dnaSrc.match(/if \(!await saveImportedData\(\)\) \{([\s\S]*?)\n  \}/) || [null, ''])[1];

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.460';
+self.APP_VERSION = '1.8.461';


### PR DESCRIPTION
## Summary
- migrate DNA and mtDNA preview overlay show/close paths to shared modal lifecycle helpers
- add a DNA source guard for shared overlay helper usage
- bump `version.js` to `1.8.461`

## Tests
- `node tests/test-dna.js`
- `npm run test:playwright -- dna-browser-coverage.spec.js`