### PR TITLE
Use modal lifecycle helpers for detail notes

### DIFF
--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -12,6 +12,7 @@ import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from '.
 import { deleteEmptyLabEntries, deleteLabEntryMarkerValues } from './lab-entry-mutations.js';
 import { getInsulinMirrorMarkerKey } from './lab-entry.js';
 import { installMarkerDetailActionDelegates, markerDetailActionAttrs } from './marker-detail-actions.js';
+import { closeModalOverlay } from './modal-lifecycle.js';
 import {
   configureMarkerDetailEditing,
   editRefRange,
@@ -1066,7 +1067,7 @@ export async function deleteCustomMarker(id) {
 }
 
 export function closeModal() {
-  document.getElementById("modal-overlay").classList.remove("show");
+  closeModalOverlay('modal-overlay');
   const detailModal = document.getElementById("detail-modal");
   if (detailModal) {
     detailModal.className = 'modal';

--- a/js/modal-lifecycle.js
+++ b/js/modal-lifecycle.js
@@ -79,8 +79,9 @@ export function openModalOverlay(overlayOrId, options = {}) {
   const overlay = _resolveOverlay(overlayOrId);
   if (!overlay) return null;
   const showClass = options.showClass || 'show';
+  const alreadyShown = overlay.classList.contains(showClass);
   const activeElement = document.activeElement;
-  if (_isRestorableFocusTarget(activeElement)) {
+  if (!alreadyShown && _isRestorableFocusTarget(activeElement)) {
     _overlayFocusTargets.set(overlay, activeElement);
   }
   overlay.classList.add(showClass);

--- a/js/notes.js
+++ b/js/notes.js
@@ -9,6 +9,7 @@ import {
   ensureImportedArray,
   replaceImportedArrayItem,
 } from './data-merge.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 
 /** @param {{ modal: HTMLElement }} context */
 function refreshOpenNoteEditorOnSync({ modal }) {
@@ -43,6 +44,7 @@ export function openNoteEditor(date, existingIdx) {
   const modal = document.getElementById("detail-modal");
   const overlay = document.getElementById("modal-overlay");
   if (!modal || !overlay) return;
+  const wasOpen = overlay.classList.contains('show');
   const isEditing = existingIdx !== undefined && existingIdx !== null;
   const existing = isEditing ? (state.importedData.notes || [])[existingIdx] : null;
   const defaultDate = existing ? existing.date : (date || new Date().toISOString().slice(0, 10));
@@ -65,11 +67,8 @@ export function openNoteEditor(date, existingIdx) {
   modal.dataset.syncRefreshMode = isEditing ? 'edit' : 'add';
   modal.dataset.syncRefreshIndex = isEditing ? String(existingIdx) : '';
   modal.dataset.syncRefreshDate = defaultDate || '';
-  overlay.classList.add("show");
-  setTimeout(() => {
-    const ta = document.getElementById('note-textarea');
-    if (ta) ta.focus();
-  }, 50);
+  if (!wasOpen) window.rememberModalTrigger?.();
+  openModalOverlay(overlay, { initialFocus: '#note-textarea', focusDelay: 50 });
 }
 
 /** @param {number | null | undefined} idx */

--- a/tests/playwright/modal-lifecycle-browser-coverage.spec.js
+++ b/tests/playwright/modal-lifecycle-browser-coverage.spec.js
@@ -78,10 +78,16 @@ test('modal lifecycle browser coverage handles backdrop focus trap and scroll lo
       const helperOpenedAndFocused =
         classOverlay.classList.contains('show')
         && document.activeElement?.id === 'open-helper-input';
+      modalLifecycle.openModalOverlay(classOverlay, { initialFocus: '#open-helper-close', focusDelay: 0 });
+      await waitUntil(() => document.activeElement?.id === 'open-helper-close', 'repeat open helper focus target');
+      const repeatOpenKeptOverlayShownAndFocused =
+        classOverlay.classList.contains('show')
+        && document.activeElement?.id === 'open-helper-close';
       modalLifecycle.closeModalOverlay('missing-overlay');
       modalLifecycle.closeModalOverlay(classOverlay);
       outcomes.openCloseOverlayHelpersToggleClassFocusAndRestore =
         helperOpenedAndFocused
+        && repeatOpenKeptOverlayShownAndFocused
         && !classOverlay.classList.contains('show')
         && document.activeElement?.id === 'open-helper-opener';
       classOverlay.remove();

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -716,6 +716,10 @@ await import('../js/settings.js');
     markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshKind')
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshDate')
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshEditIdx'));
+  assert('notes editor opens through shared overlay lifecycle helper',
+    notesSrc.includes("from './modal-lifecycle.js'") &&
+      notesSrc.includes("openModalOverlay(overlay, { initialFocus: '#note-textarea', focusDelay: 50 })") &&
+      notesSrc.includes('window.rememberModalTrigger?.()'));
   assert('active-profile sync broadcasts shared modal refresh event without marker special-casing',
     syncPullActiveRefreshSrc.includes("new CustomEvent('labcharts-sync-applied')")
       && !syncPullActiveRefreshSrc.includes('marker-detail-modal')

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -105,6 +105,9 @@ return (async function() {
   assert('marker-detail-modal.js defines restoreModalTrigger', /function restoreModalTrigger\s*\(/.test(markerDetailSrc));
   assert('showDetailModal captures trigger before opening', /showDetailModal[\s\S]*?rememberModalTrigger\(\)/.test(markerDetailSrc));
   assert('closeModal restores trigger on close', /function closeModal\(\)[\s\S]*?restoreModalTrigger\(\)/.test(markerDetailSrc));
+  assert('closeModal uses shared overlay lifecycle helper',
+    markerDetailSrc.includes("from './modal-lifecycle.js'") &&
+      /function closeModal\(\)[\s\S]{0,180}closeModalOverlay\('modal-overlay'\)/.test(markerDetailSrc));
   assert('rememberModalTrigger exported', markerDetailSrc.includes('export function rememberModalTrigger'));
   assert('rememberModalTrigger on window', /window\s*,\s*\{[\s\S]*?rememberModalTrigger/.test(viewsSrc));
   assert('wearable detail modal captures trigger', wearablesDetailSrc.includes('window.rememberModalTrigger?.()'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.461';
+self.APP_VERSION = '1.8.462';


### PR DESCRIPTION
## Summary
- route the shared detail modal close path through `closeModalOverlay`
- open the notes editor through `openModalOverlay` while preserving detail-modal trigger capture on first open
- keep `openModalOverlay` from replacing the stored restore target when an overlay is already shown
- add source/browser guards for the shared lifecycle usage and bump `version.js` to `1.8.462`

## Tests
- `node tests/test-sync.js`
- `node tests/test-changelog.js`
- `npm run test:playwright -- modal-lifecycle-browser-coverage.spec.js browser-coverage-batch.spec.js modal-session-coverage-batch.spec.js core-browser-flows.spec.js`

## Notes
- `node tests/test-multi-unit.js` still reports two unrelated pre-existing settings/data source-shape failures outside this change scope.