### PR TITLE
Use modal lifecycle helper for wearables detail

### DIFF
--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -16,6 +16,7 @@ import { getChartColors } from './theme.js';
 import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
 import { _collectActiveChips, _renderNoteField, _renderTagChips, inputValueById, inputValueFromElement } from './wearables-manual-form-ui.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 
 const WEARABLE_DETAIL_RANGES = [
   { key: '90d', days: 90, label: '90d', coverageSuffix: 'of last 90 days', emptyWindow: 'the last 90 days' },
@@ -133,7 +134,7 @@ export async function openWearableDetail(metricId, opts = {}) {
   }
 
   modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries, { allZeroActivity, rangeKey });
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
 
   const focusTarget = opts.fromRangeToggle
     ? modal.querySelector('.wearable-detail-range .ctx-btn-option.active')

--- a/tests/test-wearables-delegated-actions.js
+++ b/tests/test-wearables-delegated-actions.js
@@ -46,6 +46,9 @@ assert('wearables detail modal renders delegated action and form attributes',
     detailSrc.includes("wearableActionAttrs('set-detail-range'") &&
     detailSrc.includes("wearableActionAttrs('delete-detail-manual-entry'") &&
     detailSrc.includes("wearableFormAttrs('detail-manual-add'"));
+assert('wearables detail modal opens through shared overlay lifecycle helper',
+  detailSrc.includes("from './modal-lifecycle.js'") &&
+    detailSrc.includes('openModalOverlay(overlay)'));
 assert('wearable action attr helper has one shared definition',
   (stripSrc.match(/\bfunction\s+wearableActionAttrs\b/g) || []).length === 0 &&
     (detailSrc.match(/\bfunction\s+wearableActionAttrs\b/g) || []).length === 1 &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.462';
+self.APP_VERSION = '1.8.463';


### PR DESCRIPTION
## Summary
- open the wearables detail modal through `openModalOverlay`
- add a source guard for the shared overlay lifecycle usage
- bump `version.js` to `1.8.463`

## Tests
- `node tests/test-wearables-delegated-actions.js`
- `npm run test:playwright -- wearables-detail-manual-browser-coverage.spec.js wearables-browser-flows.spec.js`