### PR TITLE
Use modal lifecycle for cycle and supplements

### DIFF
--- a/js/cycle.js
+++ b/js/cycle.js
@@ -4,6 +4,7 @@ import { state } from './state.js';
 import { PERIOD_SYMPTOMS } from './constants.js';
 import { escapeHTML, showNotification, showConfirmDialog, linearRegression } from './utils.js';
 import { saveImportedData } from './data.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 
 const CYCLE_ACTIVE_STATUSES = new Set(['regular', 'perimenopause']);
 const CYCLE_KEY_ACTIVATE_EDITOR = "if(event.key==='Enter'||event.key===' '){event.preventDefault();openMenstrualCycleEditor()}";
@@ -491,7 +492,7 @@ export function openMenstrualCycleEditor() {
       <button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="saveMenstrualCycle()">Save</button>
     </div>`;
   modal.innerHTML = html;
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function saveMenstrualCycle() {

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -12,6 +12,7 @@ import {
 } from './data-merge.js';
 import { callClaudeAPI, getAIProvider, hasAIProvider, supportsVision } from './api.js';
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
 import {
   computeAllImpacts,
@@ -587,7 +588,7 @@ export function openSupplementsEditor(editIdx) {
   modal.dataset.syncRefreshKind = 'supplements';
   modal.dataset.syncRefreshEditIdx = isEdit ? String(editIdx) : '';
   modal.dataset.syncRefreshItemId = isEdit ? (getConfiguredArrayItemId('supplements', supps[editIdx]) || '') : '';
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
   if (isEdit) {
     const expanded = document.querySelector('.supp-list-expanded');
     if (expanded) setTimeout(() => expanded.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 100);

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -176,6 +176,7 @@ const LEGACY_TESTS = [
   './test-provider-wallet-delegated-actions.js',
   './test-provider-panel-delegated-actions.js',
   './test-chat-empty-state-delegated-actions.js',
+  './test-modal-lifecycle-integrations.js',
   './test-quality-guardrails.js',
   './test-chat-threads.js',
   './test-wearables-bp-merge.js',

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Static source guards for modules migrated to shared modal overlay helpers.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
+const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Modal Lifecycle Integrations ===');
+
+assert('cycle editor opens through shared overlay lifecycle helper',
+  cycleSrc.includes("from './modal-lifecycle.js'") &&
+    cycleSrc.includes('openModalOverlay(overlay)') &&
+    !cycleSrc.includes('overlay.classList.add("show")'));
+
+assert('supplements editor opens through shared overlay lifecycle helper',
+  supplementsSrc.includes("from './modal-lifecycle.js'") &&
+    supplementsSrc.includes('openModalOverlay(overlay)') &&
+    !supplementsSrc.includes('overlay.classList.add("show")'));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.463';
+self.APP_VERSION = '1.8.464';


### PR DESCRIPTION
## Summary
- Open the menstrual cycle and supplements editors through the shared modal lifecycle helper.
- Add a static integration guard so these editor opens stay on the shared overlay path.
- Bump the app version for cache invalidation.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `npm run test:playwright -- cycle-browser-coverage.spec.js supplements-browser-coverage.spec.js`

Note: the first Playwright attempt failed because the sandbox blocked binding `127.0.0.1:8000`; the rerun outside the sandbox passed.