### PR TITLE
Use modal lifecycle for dashboard AI pickers

### DIFF
--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -7,6 +7,7 @@ import { getLensSummary } from './lens.js';
 import { state } from './state.js';
 import { isSyncEnabled } from './sync.js';
 import { escapeHTML } from './utils.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 // Dashboard "AI personalization" zone:
 //   - Full-width row for the Interpretive Lens, only if it is set.
@@ -168,7 +169,7 @@ export function openDataProtectionPicker() {
     document.body.appendChild(overlay);
   }
   const close = () => {
-    overlay.classList.remove('show');
+    closeModalOverlay(overlay);
     document.removeEventListener('keydown', onKey);
   };
   const onKey = (e) => { if (e.key === 'Escape') close(); };
@@ -193,15 +194,14 @@ export function openDataProtectionPicker() {
       <button class="confirm-btn confirm-btn-cancel" id="data-protection-picker-cancel">Close</button>
     </div>
   </div>`;
-  overlay.classList.add('show');
+  openModalOverlay(overlay, {
+    initialFocus: '.dashboard-picker-card:not([data-configured="true"]),.dashboard-picker-card,#data-protection-picker-cancel',
+    focusDelay: 50,
+  });
   document.addEventListener('keydown', onKey);
   overlay.onclick = (e) => { if (e.target === overlay) close(); };
   const cancelButton = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#data-protection-picker-cancel'));
   if (cancelButton) cancelButton.onclick = close;
-  setTimeout(() => {
-    const focusTarget = /** @type {HTMLElement | null} */ (overlay.querySelector('.dashboard-picker-card:not([data-configured="true"]),.dashboard-picker-card,#data-protection-picker-cancel'));
-    focusTarget?.focus();
-  }, 50);
   overlay.querySelectorAll('.dashboard-picker-card').forEach(btn => {
     const button = /** @type {HTMLButtonElement} */ (btn);
     button.onclick = () => {
@@ -226,7 +226,7 @@ export function openPersonalizeAIPicker() {
     document.body.appendChild(overlay);
   }
   const close = () => {
-    overlay.classList.remove('show');
+    closeModalOverlay(overlay);
     document.removeEventListener('keydown', onKey);
   };
   const onKey = (e) => { if (e.key === 'Escape') close(); };
@@ -248,15 +248,14 @@ export function openPersonalizeAIPicker() {
       <button class="confirm-btn confirm-btn-cancel" id="ai-personalize-picker-cancel">Cancel</button>
     </div>
   </div>`;
-  overlay.classList.add('show');
+  openModalOverlay(overlay, {
+    initialFocus: '.ai-picker-card,#ai-personalize-picker-cancel',
+    focusDelay: 50,
+  });
   document.addEventListener('keydown', onKey);
   overlay.onclick = (e) => { if (e.target === overlay) close(); };
   const cancelButton = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#ai-personalize-picker-cancel'));
   if (cancelButton) cancelButton.onclick = close;
-  setTimeout(() => {
-    const focusTarget = /** @type {HTMLElement | null} */ (overlay.querySelector('.ai-picker-card,#ai-personalize-picker-cancel'));
-    focusTarget?.focus();
-  }, 50);
   overlay.querySelectorAll('.ai-picker-card').forEach(btn => {
     const button = /** @type {HTMLButtonElement} */ (btn);
     button.onclick = () => {

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
+const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
 
@@ -34,6 +35,13 @@ assert('supplements editor opens through shared overlay lifecycle helper',
   supplementsSrc.includes("from './modal-lifecycle.js'") &&
     supplementsSrc.includes('openModalOverlay(overlay)') &&
     !supplementsSrc.includes('overlay.classList.add("show")'));
+
+assert('dashboard AI pickers use shared overlay lifecycle helpers',
+  dashboardAiSrc.includes("from './modal-lifecycle.js'") &&
+    dashboardAiSrc.includes('openModalOverlay(overlay, {') &&
+    dashboardAiSrc.includes('closeModalOverlay(overlay)') &&
+    !dashboardAiSrc.includes("overlay.classList.add('show')") &&
+    !dashboardAiSrc.includes("overlay.classList.remove('show')"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.464';
+self.APP_VERSION = '1.8.465';


### PR DESCRIPTION
## Summary
- Move the dashboard data-protection and Personalize AI picker overlays onto the shared modal lifecycle helpers.
- Use the helper focus option instead of local focus timers for both pickers.
- Extend the modal lifecycle integration guard and bump the app version for cache invalidation.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `npm run test:playwright -- dashboard-ai-browser-coverage.spec.js dashboard-data-protection.spec.js dashboard-knowledge-base.spec.js`