### PR TITLE
Use modal lifecycle for context modals

### DIFF
--- a/js/context-card-medical-history-editor.js
+++ b/js/context-card-medical-history-editor.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { COMMON_CONDITIONS } from './constants.js';
 import { escapeHTML } from './utils.js';
 import { saveImportedData } from './data.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 import {
   renderContextEditorModal,
   getSelectedOption,
@@ -41,7 +42,7 @@ export function openDiagnosesEditor() {
   const overlay = document.getElementById("modal-overlay");
   const current = state.importedData.diagnoses || { conditions: [], note: '' };
   renderDiagnosesModal(modal, current);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 // Relatives surfaced in the Family History subsection. First-degree

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { escapeHTML, showNotification } from './utils.js';
 import { saveImportedData, getActiveData } from './data.js';
 import { hasAIProvider } from './api.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 import {
   appendImportedArrayItem,
   ensureImportedArray,
@@ -369,7 +370,7 @@ function openCardTipsModal(cardKey) {
   const modal = document.getElementById('detail-modal');
   if (!overlay || !modal) return;
   modal.innerHTML = html;
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
 }
 
 // ── Window exports for onclick handlers ──

--- a/js/recommendations.js
+++ b/js/recommendations.js
@@ -616,7 +616,7 @@ export function renderCardTipsModal(cardKey) {
   }
   if (cardKey === 'environment') items += _buildEMFNudge();
   if (!items) return '';
-  return `<button class="modal-close" onclick="document.getElementById('modal-overlay').classList.remove('show')">\u00D7</button>
+  return `<button class="modal-close" onclick="window.closeModal()">\u00D7</button>
     <div class="ctx-tips-modal-header">${cardInfo.emoji} ${escapeHTML(cardInfo.label)} \u2014 Tips</div>
     <div class="ctx-tips-modal-body">${items}</div>
     <div class="rec-mini-disclaimer" style="margin-top:12px">For informational purposes only. Not medical advice. Consult your healthcare provider before starting any supplement.</div>`;
@@ -627,7 +627,7 @@ export function renderCardTipsModal(cardKey) {
 // than 120d. Empty otherwise so we don't nag users keeping up.
 function _buildEMFNudge() {
   const assessments = state.importedData?.emfAssessment?.assessments || [];
-  const openHandler = `event.preventDefault();document.getElementById('modal-overlay').classList.remove('show');setTimeout(()=>window.openEMFAssessmentEditor(),100);`;
+  const openHandler = `event.preventDefault();window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor(),100);`;
   if (!assessments.length) {
     return `<div class="ctx-tip-emf-nudge"><span aria-hidden="true">💡</span> Want to measure your home's EMF environment? <a href="#" onclick="${openHandler}" data-umami-event="emf-nudge-env-tips-noassessment">Open the EMF assessment →</a></div>`;
   }

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -7,8 +7,11 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
+const contextCardsSrc = fs.readFileSync(path.join(root, 'js/context-cards.js'), 'utf8');
+const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medical-history-editor.js'), 'utf8');
 const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
+const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
 
 let passed = 0;
@@ -42,6 +45,19 @@ assert('dashboard AI pickers use shared overlay lifecycle helpers',
     dashboardAiSrc.includes('closeModalOverlay(overlay)') &&
     !dashboardAiSrc.includes("overlay.classList.add('show')") &&
     !dashboardAiSrc.includes("overlay.classList.remove('show')"));
+
+assert('context medical history and card tips open through shared overlay lifecycle helper',
+  contextMedicalSrc.includes("from './modal-lifecycle.js'") &&
+    contextCardsSrc.includes("from './modal-lifecycle.js'") &&
+    contextMedicalSrc.includes('openModalOverlay(overlay)') &&
+    contextCardsSrc.includes('openModalOverlay(overlay)') &&
+    !contextMedicalSrc.includes('overlay.classList.add("show")') &&
+    !contextCardsSrc.includes("overlay.classList.add('show')"));
+
+assert('card tips modal closes through shared detail modal close path',
+  recommendationsSrc.includes('onclick="window.closeModal()"') &&
+    recommendationsSrc.includes('event.preventDefault();window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor(),100);') &&
+    !recommendationsSrc.includes("document.getElementById('modal-overlay').classList.remove('show')"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.465';
+self.APP_VERSION = '1.8.467';


### PR DESCRIPTION
## Summary
- Open the Medical History editor through the shared modal lifecycle helper.
- Open the context card tips modal through the shared modal lifecycle helper.
- Extend the modal lifecycle integration guard and bump the app version for cache invalidation.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `npm run test:playwright -- family-history-dom.spec.js context-cards-browser-coverage.spec.js`