### PR TITLE
Use modal lifecycle for remaining small overlays

### DIFF
--- a/js/light-env.js
+++ b/js/light-env.js
@@ -49,6 +49,7 @@ import {
   renderLightAuditsBlock,
 } from './light-env-audits.js';
 import { installLightEnvActionDelegates, lightEnvActionAttrs } from './light-env-actions.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 export { getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit } from './light-env-audits.js';
 export {
@@ -568,16 +569,16 @@ function isLightEnvironmentAssessmentOpen() {
 
 function renderLightEnvironmentAssessmentModal() {
   let overlay = getLightEnvironmentAssessmentOverlay();
+  const wasOpen = overlay?.classList?.contains('show') === true;
   if (!overlay) {
     overlay = document.createElement('div');
     overlay.id = LIGHT_ENV_ASSESSMENT_OVERLAY_ID;
-    overlay.className = 'modal-overlay show light-env-assessment-overlay';
+    overlay.className = 'modal-overlay light-env-assessment-overlay';
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) closeLightEnvironmentAssessment();
     });
     document.body.appendChild(overlay);
   }
-  overlay.classList.add('show');
   overlay.innerHTML = `<div class="modal light-env-assessment-modal" role="dialog" aria-modal="true" aria-labelledby="light-env-assessment-title">
     <button class="modal-close" ${lightEnvActionAttrs('close-assessment')} aria-label="Close">×</button>
     <div class="modal-header">
@@ -586,6 +587,7 @@ function renderLightEnvironmentAssessmentModal() {
     <p class="light-env-assessment-modal-copy">Map the rooms, screens, and readings that shape your indoor day. Save audit snapshots before and after changes to compare what moved.</p>
     ${renderEnvironmentSection({ embedded: true })}
   </div>`;
+  openModalOverlay(overlay, wasOpen ? {} : { initialFocus: '.modal-close', focusDelay: 50 });
 }
 
 export function openLightEnvironmentAssessment() {
@@ -593,7 +595,10 @@ export function openLightEnvironmentAssessment() {
 }
 
 export function closeLightEnvironmentAssessment() {
-  getLightEnvironmentAssessmentOverlay()?.remove();
+  const overlay = getLightEnvironmentAssessmentOverlay();
+  if (!overlay) return;
+  closeModalOverlay(overlay);
+  overlay.remove();
 }
 
 export function refreshLightEnvironmentAssessment() {

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -16,6 +16,7 @@ import {
   rememberOpenRouterOAuthPreviousProvider, clearOpenRouterOAuthSession, startOpenRouterOAuth
 } from './api.js';
 import { updateKeyCache, encryptedSetItem } from './crypto.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { installProviderPanelDelegates } from './provider-panel-delegates.js';
 import { renderAIProviderPanel } from './provider-panel-renderers.js';
 import {
@@ -439,8 +440,8 @@ export function showInsufficientBalanceDialog() {
       '<button class="confirm-btn confirm-btn-cancel" id="or-nb-cancel">Not now</button>' +
     '</div>' +
   '</div>';
-  overlay.classList.add('show');
-  const close = function() { overlay.classList.remove('show'); };
+  openModalOverlay(overlay, { initialFocus: '#or-add-credits', focusDelay: 50 });
+  const close = function() { closeModalOverlay(overlay); };
   document.getElementById('or-add-credits').onclick = function() {
     close();
     window.open('https://openrouter.ai/settings/credits', '_blank', 'noopener');

--- a/js/recommendation-actions.js
+++ b/js/recommendation-actions.js
@@ -2,6 +2,7 @@
 // recommendation-actions.js - recommendation modal and action handlers
 
 import { escapeHTML } from './utils.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 
 function setDetailModalShell(...classes) {
   const modal = document.getElementById('detail-modal');
@@ -24,7 +25,7 @@ export function createRecommendationActions({
     modal.innerHTML = `<button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>
       <h3>${escapeHTML(label || 'Recommendation')}</h3>
       <div class="dashboard-widget-empty">Loading options...</div>`;
-    overlay.classList.add("show");
+    openModalOverlay(overlay);
     Promise.resolve(window.renderRecommendationSection?.(slotKey, { label: 'Options', maxProducts: 4, markerStatus }))
       .then(html => {
         modal.innerHTML = `<button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -155,12 +155,20 @@ test('light environment browser coverage handles summary modal prompt and source
 
       window.openLightEnvironmentAssessment();
       await waitUntil(() => !!document.querySelector('#light-env-assessment-overlay.show .light-env-assessment-modal'), 'assessment modal reopened');
+      await wait(70);
+      const focusedRoomName = document.querySelector('#light-env-assessment-overlay .light-env-room-name-input');
+      focusedRoomName?.focus();
       env().rooms.find(r => r.id === bedroom.id).name = 'Synced Bedroom';
       window.dispatchEvent(new Event('labcharts-sync-applied'));
       await waitUntil(() => (document.querySelector('#light-env-assessment-overlay .light-env-assessment-modal')?.textContent || '').includes('Synced Bedroom'), 'sync refresh render');
+      await wait(90);
+      const closeButtonAfterSyncRefresh = document.querySelector('#light-env-assessment-overlay .modal-close');
       outcomes.syncRefreshRebuildsOpenAssessment =
         !!document.querySelector('#light-env-assessment-overlay.show .light-env-assessment-modal')
         && (document.querySelector('#light-env-assessment-overlay .light-env-assessment-modal')?.textContent || '').includes('Synced Bedroom');
+      outcomes.syncRefreshDoesNotMoveFocusToClose =
+        !!focusedRoomName
+        && document.activeElement !== closeButtonAfterSyncRefresh;
     } finally {
       document.getElementById('light-env-assessment-overlay')?.remove();
       document.getElementById('prompt-dialog-overlay')?.remove();

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -11,6 +11,9 @@ const contextCardsSrc = fs.readFileSync(path.join(root, 'js/context-cards.js'), 
 const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medical-history-editor.js'), 'utf8');
 const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
+const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
+const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
+const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
 const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
 
@@ -58,6 +61,28 @@ assert('card tips modal closes through shared detail modal close path',
   recommendationsSrc.includes('onclick="window.closeModal()"') &&
     recommendationsSrc.includes('event.preventDefault();window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor(),100);') &&
     !recommendationsSrc.includes("document.getElementById('modal-overlay').classList.remove('show')"));
+
+assert('recommendation detail modal opens through shared overlay lifecycle helper',
+  recommendationActionsSrc.includes("from './modal-lifecycle.js'") &&
+    recommendationActionsSrc.includes('openModalOverlay(overlay)') &&
+    !recommendationActionsSrc.includes('overlay.classList.add("show")'));
+
+assert('OpenRouter balance dialog uses shared overlay lifecycle helpers',
+  providerPanelsSrc.includes("from './modal-lifecycle.js'") &&
+    providerPanelsSrc.includes("openModalOverlay(overlay, { initialFocus: '#or-add-credits', focusDelay: 50 })") &&
+    providerPanelsSrc.includes('closeModalOverlay(overlay)') &&
+    !providerPanelsSrc.includes("overlay.classList.add('show')") &&
+    !providerPanelsSrc.includes("overlay.classList.remove('show')"));
+
+assert('light environment assessment uses shared overlay lifecycle before removal',
+  lightEnvSrc.includes("from './modal-lifecycle.js'") &&
+    lightEnvSrc.includes("const wasOpen = overlay?.classList?.contains('show') === true;") &&
+    lightEnvSrc.includes("overlay.className = 'modal-overlay light-env-assessment-overlay'") &&
+    lightEnvSrc.includes("openModalOverlay(overlay, wasOpen ? {} : { initialFocus: '.modal-close', focusDelay: 50 })") &&
+    lightEnvSrc.includes('closeModalOverlay(overlay)') &&
+    lightEnvSrc.includes('overlay.remove()') &&
+    !lightEnvSrc.includes("overlay.className = 'modal-overlay show light-env-assessment-overlay'") &&
+    !lightEnvSrc.includes("overlay.classList.add('show')"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -136,7 +136,7 @@ globalThis.fetch = async (url, opts) => {
   const { createRecommendationActions } = await import('../js/recommendation-actions.js');
   const originalGetElementById = document.getElementById;
   const modalStub = { className: 'modal', innerHTML: '' };
-  const overlayStub = { classList: { add: () => {} } };
+  const overlayStub = { classList: { add: () => {}, contains: () => false } };
   document.getElementById = (id) => id === 'detail-modal' ? modalStub : id === 'modal-overlay' ? overlayStub : null;
   createRecommendationActions({
     getActiveData: () => ({}),

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.467';
+self.APP_VERSION = '1.8.468';


### PR DESCRIPTION
## Summary
- Route recommendation detail modal opens through the shared modal lifecycle helper.
- Route the OpenRouter balance dialog through shared open/close lifecycle helpers.
- Route the light environment assessment overlay through shared lifecycle helpers before its existing remove-on-close cleanup.
- Preserve focus on light assessment re-renders by only applying initial focus on first open.
- Extend modal lifecycle source guards and add a browser regression for the light assessment refresh focus path.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-provider-panel-delegated-actions.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-recommendations.js`
- `npm test`
- `npm run test:playwright -- recommendation-actions-browser-coverage.spec.js provider-coverage-batch.spec.js light-env-actions-browser-coverage.spec.js light-env-browser-coverage.spec.js`
- `npm run test:playwright -- light-env-browser-coverage.spec.js`
- `git diff --check`