### PR TITLE
Use modal lifecycle for lifestyle context editors

### DIFF
--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -60,6 +60,7 @@ import {
 import { bindDetailModalSyncRefresh, escapeHTML, showNotification } from './utils.js';
 import { formatTime, getTimeFormat, parseTimeInput } from './theme.js';
 import { saveImportedData } from './data.js';
+import { openModalOverlay } from './modal-lifecycle.js';
 import {
   appendImportedArrayItem,
   clearImportedArray,
@@ -174,7 +175,7 @@ export function openDietEditor() {
     ${renderTagsField('Food sensitivities', 'diet-sensitivities', FOOD_SENSITIVITIES, current.foodSensitivities || [])}
     ${renderNoteField(current.note)}
     ${contextEditorActions(state.importedData.diet != null, 'saveDiet', 'clearDiet')}`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function saveDiet() {
@@ -232,7 +233,7 @@ export function openSleepRestEditor() {
     ${renderTagsField('Sleep practices', 'sleep-practices', SLEEP_PRACTICES, current.practices)}
     ${renderNoteField(current.note)}
     ${contextEditorActions(state.importedData.sleepRest != null, 'saveSleepRest', 'clearSleepRest')}`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function saveSleepRest() {
@@ -282,7 +283,7 @@ export function openLightCircadianEditor() {
     ${lat ? `<div style="font-size:12px;color:var(--text-muted);margin-top:8px">📍 Latitude: <strong style="color:var(--text-primary)">${escapeHTML(lat)}</strong> <span style="font-size:11px">(from Settings → Location)</span></div>` : `<div style="font-size:12px;color:var(--text-muted);margin-top:8px">💡 Set your country in Settings → Profile for automatic latitude detection</div>`}
     ${renderNoteField(current.note)}
     ${contextEditorActions(state.importedData.lightCircadian != null, 'saveLightCircadian', 'clearLightCircadian')}`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 // Render a compact read-only summary of the user's Light lens setup —
@@ -381,7 +382,7 @@ export function openExerciseEditor() {
     ${renderSelectField('Daily movement', 'exercise-movement', DAILY_MOVEMENT, current.dailyMovement)}
     ${renderNoteField(current.note)}
     ${contextEditorActions(state.importedData.exercise != null, 'saveExercise', 'clearExercise')}`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function saveExercise() {
@@ -417,7 +418,7 @@ export function openStressEditor() {
     ${renderTagsField('Management', 'stress-mgmt', STRESS_MGMT, current.management)}
     ${renderNoteField(current.note)}
     ${contextEditorActions(state.importedData.stress != null, 'saveStress', 'clearStress')}`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function saveStress() {
@@ -462,7 +463,7 @@ export function openLoveLifeEditor() {
     }), current.concerns)}
     ${renderNoteField(current.note)}
     ${contextEditorActions(state.importedData.loveLife != null, 'saveLoveLife', 'clearLoveLife')}`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function saveLoveLife() {
@@ -517,7 +518,7 @@ export function openEnvironmentEditor() {
     ${renderSelectField('Building', 'env-building', ENV_BUILDING, current.building)}
     ${renderNoteField(current.note)}
     ${contextEditorActions(state.importedData.environment != null, 'saveEnvironment', 'clearEnvironment')}`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function saveEnvironment() {
@@ -554,7 +555,7 @@ export function openHealthGoalsEditor() {
   const modal = document.getElementById("detail-modal");
   const overlay = document.getElementById("modal-overlay");
   renderHealthGoalsModal(modal);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
 }
 
 export function renderHealthGoalsModal(modal) {
@@ -647,7 +648,7 @@ export function openInterpretiveLensEditor() {
       <button class="import-btn import-btn-secondary" onclick="closeModal()">Cancel</button>
       ${current ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" onclick="clearInterpretiveLens()">Clear</button>` : ''}
     </div>`);
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
   setTimeout(() => {
     const ta = getTextInput('interpretive-lens-textarea');
     if (ta) ta.focus();
@@ -713,5 +714,5 @@ export function showDietContaminantsModal() {
   </div>
   <div class="contaminant-attribution">Sources: <a href="https://www.ewg.org/foodnews/" target="_blank" rel="noopener">EWG Shopper's Guide 2025</a> · <a href="https://www.plasticlist.org/report" target="_blank" rel="noopener">PlasticList</a></div>`;
   modal.innerHTML = html;
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
 }

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const contextCardsSrc = fs.readFileSync(path.join(root, 'js/context-cards.js'), 'utf8');
+const contextLifestyleSrc = fs.readFileSync(path.join(root, 'js/context-card-lifestyle-editors.js'), 'utf8');
 const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medical-history-editor.js'), 'utf8');
 const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
@@ -56,6 +57,12 @@ assert('context medical history and card tips open through shared overlay lifecy
     contextCardsSrc.includes('openModalOverlay(overlay)') &&
     !contextMedicalSrc.includes('overlay.classList.add("show")') &&
     !contextCardsSrc.includes("overlay.classList.add('show')"));
+
+assert('lifestyle context editors open through shared overlay lifecycle helper',
+  contextLifestyleSrc.includes("from './modal-lifecycle.js'") &&
+    (contextLifestyleSrc.match(/openModalOverlay\(overlay\)/g) || []).length >= 10 &&
+    !contextLifestyleSrc.includes('overlay.classList.add("show")') &&
+    !contextLifestyleSrc.includes("overlay.classList.add('show')"));
 
 assert('card tips modal closes through shared detail modal close path',
   recommendationsSrc.includes('onclick="window.closeModal()"') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.468';
+self.APP_VERSION = '1.8.469';


### PR DESCRIPTION
## Summary
- Route lifestyle context editor modal opens through the shared modal lifecycle helper.
- Cover diet, sleep, light/circadian, exercise, stress, love life, environment, health goals, interpretive lens, and diet contaminant detail modals.
- Extend the modal lifecycle integration source guard for the migrated editors.
- Bump the app version for cache invalidation.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `node tests/test-emf.js`
- `npm run test:playwright -- context-coverage-batch.spec.js food-contaminants-browser-coverage.spec.js`
- `git diff --check`