### PR TITLE
Use modal lifecycle for chat summaries

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -102,6 +102,8 @@ function handleAppKeydown(e) {
       else syncSetupOverlay.classList.remove("show");
       return;
     }
+    const summaryOverlay = document.getElementById("summary-modal-overlay");
+    if (summaryOverlay && summaryOverlay.classList.contains("show")) { window.closeSummaryModal?.(); return; }
     const chatPanel = document.getElementById("chat-panel");
     if (chatPanel && chatPanel.classList.contains("open")) { window.closeChatPanel(); return; }
     const importOverlay = document.getElementById("import-modal-overlay");
@@ -141,7 +143,7 @@ function handleAppKeydown(e) {
 
   // Focus trap for open modals. Sync overlays use `.confirm-overlay` too.
   if (e.key === "Tab") {
-    const overlayIds = ["client-list-overlay", "changelog-modal-overlay", "report-builder-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "light-env-assessment-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "data-protection-picker-overlay"];
+    const overlayIds = ["client-list-overlay", "changelog-modal-overlay", "report-builder-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "summary-modal-overlay", "light-env-assessment-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "data-protection-picker-overlay"];
     for (const oid of overlayIds) {
       const ov = document.getElementById(oid);
       if (ov && ov.classList.contains("show")) {

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -8,6 +8,7 @@ import { saveImportedData } from './data.js';
 import { callClaudeAPI, getActiveModelDisplay, getActiveModelId, getAIProvider, hasAIProvider, isAIPaused } from './api.js';
 import { renderThreadList, saveChatThreadIndex } from './chat-threads.js';
 import { renderMarkdown } from './markdown.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   appendImportedArrayItem,
   deleteImportedArrayItems,
@@ -249,13 +250,13 @@ function _showSummaryModal(summaryText, thread, loading = false, usageInfo = nul
   if (!overlay) {
     overlay = document.createElement('div');
     overlay.id = 'summary-modal-overlay';
-    overlay.className = 'modal-overlay show';
+    overlay.className = 'modal-overlay';
     let mdInside = false;
     overlay.addEventListener('mousedown', (e) => { mdInside = e.target !== overlay; });
     overlay.onclick = (e) => { if (e.target === overlay && !mdInside) _closeSummaryModal(); mdInside = false; };
     document.body.appendChild(overlay);
-  } else {
-    overlay.className = 'modal-overlay show';
+  } else if (!overlay.classList.contains('show')) {
+    overlay.className = 'modal-overlay';
   }
   overlay.dataset.syncRefreshKind = 'chat-summary';
   overlay.dataset.syncRefreshSummaryId = thread?._savedId || '';
@@ -293,6 +294,7 @@ function _showSummaryModal(summaryText, thread, loading = false, usageInfo = nul
       ${thread?._savedId ? `<button class="summary-action-btn secondary delete" onclick="deleteSavedSummary('${escapeHTML(thread._savedId)}')" title="Delete summary">Delete</button>` : ''}
     </div>
   </div>`;
+  openModalOverlay(overlay);
 }
 
 function _closeSummaryModal() {
@@ -303,7 +305,7 @@ function _closeSummaryModal() {
   _activeSummary = null;
   const overlay = document.getElementById('summary-modal-overlay');
   if (overlay) {
-    overlay.classList.remove('show');
+    closeModalOverlay(overlay);
     setTimeout(() => overlay.remove(), 300);
   }
 }

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
+const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
+const chatSummariesSrc = fs.readFileSync(path.join(root, 'js/chat-summaries.js'), 'utf8');
 const contextCardsSrc = fs.readFileSync(path.join(root, 'js/context-cards.js'), 'utf8');
 const contextLifestyleSrc = fs.readFileSync(path.join(root, 'js/context-card-lifestyle-editors.js'), 'utf8');
 const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medical-history-editor.js'), 'utf8');
@@ -63,6 +65,18 @@ assert('lifestyle context editors open through shared overlay lifecycle helper',
     (contextLifestyleSrc.match(/openModalOverlay\(overlay\)/g) || []).length >= 10 &&
     !contextLifestyleSrc.includes('overlay.classList.add("show")') &&
     !contextLifestyleSrc.includes("overlay.classList.add('show')"));
+
+assert('chat summary modal uses shared overlay lifecycle helpers',
+  chatSummariesSrc.includes("from './modal-lifecycle.js'") &&
+    chatSummariesSrc.includes("overlay.className = 'modal-overlay'") &&
+    chatSummariesSrc.includes('openModalOverlay(overlay)') &&
+    chatSummariesSrc.includes('closeModalOverlay(overlay)') &&
+    !chatSummariesSrc.includes("overlay.className = 'modal-overlay show'") &&
+    !chatSummariesSrc.includes("overlay.classList.remove('show')"));
+
+assert('chat summary modal participates in global keyboard modal handling',
+  appEventsSrc.includes('"summary-modal-overlay"') &&
+    appEventsSrc.includes('window.closeSummaryModal?.()'));
 
 assert('card tips modal closes through shared detail modal close path',
   recommendationsSrc.includes('onclick="window.closeModal()"') &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -67,6 +67,7 @@ interface Window {
   closeRestoreMnemonicDialog?: () => void;
   closeSettings?: () => void;
   closeSettingsModal: () => void;
+  closeSummaryModal?: () => void;
   closeSyncSetup?: () => Promise<void> | void;
   closeTweaksPanel: () => void;
   clearE2EESession?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.469';
+self.APP_VERSION = '1.8.470';


### PR DESCRIPTION
## Summary
- Route the chat summary modal through shared `openModalOverlay` / `closeModalOverlay` helpers.
- Preserve the existing delayed DOM removal behavior after close.
- Extend modal lifecycle source guards for the chat summary overlay.
- Bump the app version for cache invalidation.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-chat-actions.js`
- `node tests/test-sync.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `npm run test:playwright -- chat-summary-browser-coverage.spec.js chat-ui-browser-coverage.spec.js`
- `git diff --check`