### PR TITLE
Use modal lifecycle for settings modal

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -13,6 +13,7 @@ import { renderSyncSection, renderMessengerSection, hydrateSettingsSyncPanel } f
 import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
 import { loadPdfImport } from './import-loader.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 /** @typedef {Window & typeof globalThis & Record<string, any>} SettingsWindow */
 
@@ -1007,7 +1008,7 @@ export function openSettingsModal(tab) {
     </div>
     </div>`;
   installSettingsDelegates(modal);
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
   settingsWindow.initSettingsOllamaCheck();
   settingsWindow.initSettingsModelFetch();
   loadBackupSnapshots();
@@ -1308,7 +1309,7 @@ export function updateSettingsUI() {
 }
 
 export function closeSettingsModal() {
-  document.getElementById('settings-modal-overlay').classList.remove('show');
+  closeModalOverlay('settings-modal-overlay');
   if (settingsWindow.updateChatNudge) settingsWindow.updateChatNudge();
   settingsWindow.refreshMobileDashboardActiveTab?.();
 }

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -18,6 +18,7 @@ const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
 const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.js'), 'utf8');
+const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
 
 let passed = 0;
@@ -94,6 +95,13 @@ assert('OpenRouter balance dialog uses shared overlay lifecycle helpers',
     providerPanelsSrc.includes('closeModalOverlay(overlay)') &&
     !providerPanelsSrc.includes("overlay.classList.add('show')") &&
     !providerPanelsSrc.includes("overlay.classList.remove('show')"));
+
+assert('settings modal opens and closes through shared overlay lifecycle helpers',
+  settingsSrc.includes("from './modal-lifecycle.js'") &&
+    settingsSrc.includes('openModalOverlay(overlay)') &&
+    settingsSrc.includes("closeModalOverlay('settings-modal-overlay')") &&
+    !settingsSrc.includes("overlay.classList.add('show')") &&
+    !settingsSrc.includes("document.getElementById('settings-modal-overlay').classList.remove('show')"));
 
 assert('light environment assessment uses shared overlay lifecycle before removal',
   lightEnvSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.470';
+self.APP_VERSION = '1.8.471';


### PR DESCRIPTION
## Summary
- route the settings modal open/close path through the shared modal lifecycle helpers
- add a source guard for the settings modal lifecycle integration
- bump the app version to 1.8.471 for cache invalidation

## Validation
- `npm run typecheck`
- `node tests/test-modal-lifecycle-integrations.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `node tests/test-crypto.js`
- `npm run test:playwright -- settings-toggles.spec.js settings-browser-coverage.spec.js theme-responsive-e2e.spec.js`