### PR TITLE
Use modal lifecycle for sync dialogs

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -147,7 +147,7 @@ function handleAppKeydown(e) {
     for (const oid of overlayIds) {
       const ov = document.getElementById(oid);
       if (ov && ov.classList.contains("show")) {
-        const openOverlays = Array.from(document.querySelectorAll('.modal-overlay.show'));
+        const openOverlays = Array.from(document.querySelectorAll('.modal-overlay.show, .confirm-overlay.show'));
         if (openOverlays.length && openOverlays[openOverlays.length - 1] !== ov) continue;
         const modal = ov.querySelector('[role="dialog"]') || ov.querySelector('.modal') || ov.querySelector('.confirm-dialog') || ov;
         const focusable = modal.querySelectorAll('button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),a[href],[tabindex]:not([tabindex="-1"])');

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -19,6 +19,7 @@ import {
   revokeMessengerToken,
   pushContextToGateway,
 } from './sync.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
   applyPendingTombstone?: (id: string) => Promise<void>,
@@ -316,12 +317,11 @@ export function showSyncSetupModal() {
       <button class="confirm-btn confirm-btn-cancel" data-sync-setup-action="setup-cancel">Cancel</button>
     </div>
   </div>`;
-  overlay.classList.add('show');
+  openModalOverlay(overlay, { initialFocus: '[data-sync-setup-action="setup-new"]', focusDelay: 50 });
 }
 
 async function closeSyncSetup() {
-  const overlay = document.getElementById('sync-setup-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('sync-setup-overlay');
   // If sync was started during setup but user cancelled, clean up
   if (isSyncEnabled()) {
     _mnemonicCache = null;
@@ -391,8 +391,7 @@ function updateSyncSetupAck(ack = document.getElementById('sync-setup-ack')) {
 }
 
 function syncSetupDone() {
-  const overlay = document.getElementById('sync-setup-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('sync-setup-overlay');
   _releaseSyncToggle();
   const el = document.getElementById('sync-section');
   if (el) el.innerHTML = renderSyncSection();
@@ -557,12 +556,11 @@ function openRestoreMnemonicDialog() {
       <button id="sync-restore-dialog-go" class="import-btn import-btn-primary" style="padding:8px 16px;font-size:13px" data-sync-action="confirm-restore">Restore &amp; reload</button>
     </div>
   </div>`;
-  overlay.classList.add('show');
+  openModalOverlay(overlay, { initialFocus: '#sync-restore-dialog-input', focusDelay: 50 });
   // Live word count + button enable so the user gets immediate feedback as
   // they paste — much friendlier than only finding out on submit.
   const input = document.getElementById('sync-restore-dialog-input');
   if (input) {
-    input.focus();
     updateRestoreMnemonicDialogState(input instanceof HTMLTextAreaElement ? input : null);
   }
 }
@@ -588,8 +586,7 @@ function updateRestoreMnemonicDialogState(input = /** @type {HTMLTextAreaElement
 }
 
 function closeRestoreMnemonicDialog() {
-  const overlay = document.getElementById('sync-restore-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('sync-restore-overlay');
 }
 
 async function confirmRestoreMnemonic() {

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -19,6 +19,7 @@ const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
 const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.js'), 'utf8');
 const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
+const settingsSyncPanelSrc = fs.readFileSync(path.join(root, 'js/settings-sync-panel.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
 
 let passed = 0;
@@ -102,6 +103,18 @@ assert('settings modal opens and closes through shared overlay lifecycle helpers
     settingsSrc.includes("closeModalOverlay('settings-modal-overlay')") &&
     !settingsSrc.includes("overlay.classList.add('show')") &&
     !settingsSrc.includes("document.getElementById('settings-modal-overlay').classList.remove('show')"));
+
+assert('sync setup and restore dialogs use shared lifecycle helpers',
+  settingsSyncPanelSrc.includes("from './modal-lifecycle.js'") &&
+    settingsSyncPanelSrc.includes("openModalOverlay(overlay, { initialFocus: '[data-sync-setup-action=\"setup-new\"]', focusDelay: 50 })") &&
+    settingsSyncPanelSrc.includes("openModalOverlay(overlay, { initialFocus: '#sync-restore-dialog-input', focusDelay: 50 })") &&
+    (settingsSyncPanelSrc.match(/closeModalOverlay\('sync-setup-overlay'\)/g) || []).length >= 2 &&
+    settingsSyncPanelSrc.includes("closeModalOverlay('sync-restore-overlay')") &&
+    !settingsSyncPanelSrc.includes("overlay.classList.add('show')") &&
+    !settingsSyncPanelSrc.includes("overlay.classList.remove('show')"));
+
+assert('global focus trap top-overlay check includes confirm overlays',
+  appEventsSrc.includes("'.modal-overlay.show, .confirm-overlay.show'"));
 
 assert('light environment assessment uses shared overlay lifecycle before removal',
   lightEnvSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.471';
+self.APP_VERSION = '1.8.472';


### PR DESCRIPTION
## Summary
- route sync setup and restore dialogs through shared modal lifecycle helpers
- include confirm overlays in the global focus-trap top-overlay check
- add source guards and bump the app version to 1.8.472

## Validation
- `npm run typecheck`
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-sync.js`
- `node tests/test-settings-sync-delegated-actions.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `npm run test:playwright -- settings-sync-setup-browser-coverage.spec.js settings-provider-browser-coverage.spec.js settings-toggles.spec.js`