### PR TITLE
Use modal lifecycle for knowledge base modal

### DIFF
--- a/js/lens.js
+++ b/js/lens.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
 import { hashString, showNotification, showConfirmDialog, showPromptDialog, isDebugMode, escapeHTML, escapeAttr } from './utils.js';
 import { hasAIProvider, callClaudeAPI } from './api.js';
+import { closeModalOverlay, openModalOverlay, wireBackdropClose } from './modal-lifecycle.js';
 const CONFIG_KEY = 'labcharts-lens-config';
 const SECRET_KEY = 'labcharts-lens-key';
 /** @typedef {Window & typeof globalThis & { _lensIngestRunning?: boolean }} LensWindow */
@@ -733,7 +734,7 @@ export function openKnowledgeBaseModal() {
     overlay.id = 'kb-modal-overlay';
     overlay.className = 'modal-overlay';
     document.body.appendChild(overlay);
-    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeKnowledgeBaseModal(); });
+    wireBackdropClose(overlay, closeKnowledgeBaseModal);
   }
   if (!modal) {
     modal = document.createElement('div');
@@ -755,24 +756,19 @@ export function openKnowledgeBaseModal() {
     </div>
     </div>
   `;
-  overlay.classList.add('show');
+  openModalOverlay(overlay, {
+    initialFocus: 'input:not([disabled]),button:not([disabled]),[tabindex="0"]',
+    focusDelay: 50
+  });
   document.addEventListener('keydown', _kbModalKeydown);
   // Hydrate stats async without blocking the open.
   if (getLensConfig().backend === 'in-browser') {
     _loadLocalLensStats().catch(() => {});
   }
-  // Move focus into the modal so keyboard users land inside, not on
-  // the trigger button. Defer one tick so the .show class transition
-  // doesn't fight the focus call.
-  setTimeout(() => {
-    const firstFocusable = /** @type {HTMLElement | null} */ (modal.querySelector('input:not([disabled]),button:not([disabled]),[tabindex="0"]'));
-    firstFocusable?.focus();
-  }, 50);
 }
 
 export function closeKnowledgeBaseModal() {
-  const overlay = document.getElementById('kb-modal-overlay');
-  if (overlay) overlay.classList.remove('show');
+  closeModalOverlay('kb-modal-overlay');
   document.removeEventListener('keydown', _kbModalKeydown);
 }
 

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -14,6 +14,7 @@ const contextLifestyleSrc = fs.readFileSync(path.join(root, 'js/context-card-lif
 const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medical-history-editor.js'), 'utf8');
 const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
+const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
@@ -21,6 +22,10 @@ const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.j
 const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const settingsSyncPanelSrc = fs.readFileSync(path.join(root, 'js/settings-sync-panel.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
+const knowledgeBaseModalSrc = lensSrc.slice(
+  lensSrc.indexOf('export function openKnowledgeBaseModal'),
+  lensSrc.indexOf('function _kbModalKeydown')
+);
 
 let passed = 0;
 let failed = 0;
@@ -115,6 +120,14 @@ assert('sync setup and restore dialogs use shared lifecycle helpers',
 
 assert('global focus trap top-overlay check includes confirm overlays',
   appEventsSrc.includes("'.modal-overlay.show, .confirm-overlay.show'"));
+
+assert('knowledge base modal uses shared lifecycle helpers',
+  lensSrc.includes("from './modal-lifecycle.js'") &&
+    knowledgeBaseModalSrc.includes('wireBackdropClose(overlay, closeKnowledgeBaseModal)') &&
+    knowledgeBaseModalSrc.includes('openModalOverlay(overlay, {') &&
+    knowledgeBaseModalSrc.includes("closeModalOverlay('kb-modal-overlay')") &&
+    !knowledgeBaseModalSrc.includes("overlay.classList.add('show')") &&
+    !knowledgeBaseModalSrc.includes("overlay.classList.remove('show')"));
 
 assert('light environment assessment uses shared overlay lifecycle before removal',
   lightEnvSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.472';
+self.APP_VERSION = '1.8.473';


### PR DESCRIPTION
## Summary
- Route the Knowledge Base modal through shared modal lifecycle helpers
- Use shared backdrop handling and close helper for focus restoration
- Add a modal lifecycle source guard and bump the app version

## Tests
- `npm run typecheck`
- `node tests/test-modal-lifecycle-integrations.js`
- `npm run test:playwright -- custom-lens.spec.js lens-hardware-browser-coverage.spec.js`

Note: Vercel deployment checks may hit the current free-tier deployment rate limit; GitHub Actions and Greptile are the merge gates for this batch.