### PR TITLE
Use modal lifecycle for PDF preflight dialogs

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -87,7 +87,11 @@ function handleAppKeydown(e) {
     const emfInterpOverlay = document.getElementById("emf-interp-overlay");
     if (emfInterpOverlay && emfInterpOverlay.classList.contains("show")) { window.closeEMFInterpretation(); return; }
     const confirmOverlay = document.getElementById("confirm-dialog-overlay");
-    if (confirmOverlay && confirmOverlay.classList.contains("show")) { confirmOverlay.classList.remove("show"); return; }
+    if (confirmOverlay && confirmOverlay.classList.contains("show")) {
+      if (confirmOverlay.dataset.escapeOwner === 'preflight') return;
+      confirmOverlay.classList.remove("show");
+      return;
+    }
     // Sync restore dialog — single-step "paste your 24 words" modal.
     const syncRestoreOverlay = document.getElementById("sync-restore-overlay");
     if (syncRestoreOverlay && syncRestoreOverlay.classList.contains("show")) {

--- a/js/pdf-import-preflight.js
+++ b/js/pdf-import-preflight.js
@@ -5,26 +5,66 @@ import { state } from './state.js';
 import { callClaudeAPI, getActiveModelId, getAIProvider, hasAIProvider, setAIProvider, setCustomApiModel, setOllamaMainModel, setOpenRouterModel, setPpqModel, setRoutstrModel, setVeniceModel } from './api.js';
 import { detectProduct, getAdapterByTestType } from './adapters.js';
 import { escapeHTML, hashString, isDebugMode } from './utils.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+
+function ensurePreflightOverlay() {
+  let overlay = document.getElementById('confirm-dialog-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'confirm-dialog-overlay';
+    overlay.className = 'confirm-overlay';
+    document.body.appendChild(overlay);
+  }
+  return overlay;
+}
+
+function nudgePreflightDialog(overlay) {
+  const dialog = overlay.querySelector('.confirm-dialog');
+  if (!dialog) return;
+  dialog.classList.add('modal-nudge');
+  dialog.addEventListener('animationend', () => dialog.classList.remove('modal-nudge'), { once: true });
+}
+
+function openPreflightOverlay(overlay, cancel) {
+  openModalOverlay(overlay, { initialFocus: '#confirm-cancel', focusDelay: 30 });
+  const previousOnclick = overlay.onclick;
+  overlay.dataset.escapeOwner = 'preflight';
+  const onKey = (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+  document.addEventListener('keydown', onKey);
+  overlay.onclick = (e) => { if (e.target === overlay) nudgePreflightDialog(overlay); };
+  return () => {
+    document.removeEventListener('keydown', onKey);
+    overlay.onclick = previousOnclick;
+    delete overlay.dataset.escapeOwner;
+  };
+}
 
 function showPreflightConfirm(message, confirmLabel = 'Import Anyway') {
   return new Promise(resolve => {
-    let overlay = document.getElementById('confirm-dialog-overlay');
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = 'confirm-dialog-overlay';
-      overlay.className = 'confirm-overlay';
-      document.body.appendChild(overlay);
-    }
+    const overlay = ensurePreflightOverlay();
     overlay.innerHTML = `<div class="confirm-dialog" role="alertdialog" aria-modal="true">
       <p class="confirm-message">${message}</p>
       <div class="confirm-actions">
         <button class="confirm-btn confirm-btn-cancel" id="confirm-cancel">Cancel</button>
         <button class="confirm-btn confirm-btn-danger" id="confirm-ok">${escapeHTML(confirmLabel)}</button>
       </div></div>`;
-    overlay.classList.add('show');
-    document.getElementById('confirm-ok').onclick = () => { overlay.classList.remove('show'); resolve(true); };
-    document.getElementById('confirm-cancel').onclick = () => { overlay.classList.remove('show'); resolve(false); };
-    overlay.onclick = (e) => { if (e.target === overlay) { const d = overlay.querySelector('.confirm-dialog'); if (d) { d.classList.add('modal-nudge'); d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true }); } } };
+    let settled = false;
+    let cleanup = () => {};
+    const close = (result) => {
+      if (settled) return;
+      settled = true;
+      closeModalOverlay(overlay);
+      cleanup();
+      resolve(result);
+    };
+    cleanup = openPreflightOverlay(overlay, () => close(false));
+    document.getElementById('confirm-ok').onclick = () => close(true);
+    document.getElementById('confirm-cancel').onclick = () => close(false);
   });
 }
 
@@ -71,13 +111,7 @@ function tryAutoSwitchModel(prevModel, prevProvider) {
 
 function showModelMismatchDialog(mismatch) {
   return new Promise(resolve => {
-    let overlay = document.getElementById('confirm-dialog-overlay');
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = 'confirm-dialog-overlay';
-      overlay.className = 'confirm-overlay';
-      document.body.appendChild(overlay);
-    }
+    const overlay = ensurePreflightOverlay();
     overlay.innerHTML = `<div class="confirm-dialog" role="alertdialog" aria-modal="true">
       <p class="confirm-message">Previous imports used <strong>${escapeHTML(mismatch.prevModel)}</strong>. Using <strong>${escapeHTML(mismatch.currentModel)}</strong> may cause marker key mismatches and break trend lines.</p>
       <div class="confirm-actions" style="flex-wrap:wrap;gap:8px">
@@ -85,15 +119,22 @@ function showModelMismatchDialog(mismatch) {
         <button class="confirm-btn" id="confirm-continue" style="background:var(--yellow);color:#000">Continue Anyway</button>
         <button class="confirm-btn confirm-btn-danger" id="confirm-switch">Switch to ${escapeHTML(mismatch.prevModel.split('/').pop())}</button>
       </div></div>`;
-    overlay.classList.add('show');
+    let settled = false;
+    let cleanup = () => {};
+    const close = (result) => {
+      if (settled) return;
+      settled = true;
+      closeModalOverlay(overlay);
+      cleanup();
+      resolve(result);
+    };
+    cleanup = openPreflightOverlay(overlay, () => close('cancel'));
     document.getElementById('confirm-switch').onclick = () => {
       tryAutoSwitchModel(mismatch.prevModel, mismatch.prevProvider);
-      overlay.classList.remove('show');
-      resolve('switched');
+      close('switched');
     };
-    document.getElementById('confirm-continue').onclick = () => { overlay.classList.remove('show'); resolve('continue'); };
-    document.getElementById('confirm-cancel').onclick = () => { overlay.classList.remove('show'); resolve('cancel'); };
-    overlay.onclick = (e) => { if (e.target === overlay) { const d = overlay.querySelector('.confirm-dialog'); if (d) { d.classList.add('modal-nudge'); d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true }); } } };
+    document.getElementById('confirm-continue').onclick = () => close('continue');
+    document.getElementById('confirm-cancel').onclick = () => close('cancel');
   });
 }
 
@@ -140,13 +181,7 @@ ${snippet}` }],
 
 function showUnsupportedLabDialog(testType) {
   return new Promise(resolve => {
-    let overlay = document.getElementById('confirm-dialog-overlay');
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = 'confirm-dialog-overlay';
-      overlay.className = 'confirm-overlay';
-      document.body.appendChild(overlay);
-    }
+    const overlay = ensurePreflightOverlay();
     const displayType = escapeHTML(testType);
     overlay.innerHTML = `<div class="confirm-dialog" role="alertdialog" aria-modal="true" style="max-width:480px">
       <p class="confirm-message" style="margin-bottom:12px">
@@ -160,10 +195,18 @@ function showUnsupportedLabDialog(testType) {
         <button class="confirm-btn confirm-btn-cancel" id="confirm-cancel">Cancel</button>
         <button class="confirm-btn" id="confirm-ok" style="background:var(--yellow);color:#000">Import Anyway</button>
       </div></div>`;
-    overlay.classList.add('show');
-    document.getElementById('confirm-ok').onclick = () => { overlay.classList.remove('show'); resolve(true); };
-    document.getElementById('confirm-cancel').onclick = () => { overlay.classList.remove('show'); resolve(false); };
-    overlay.onclick = (e) => { if (e.target === overlay) { const d = overlay.querySelector('.confirm-dialog'); if (d) { d.classList.add('modal-nudge'); d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true }); } } };
+    let settled = false;
+    let cleanup = () => {};
+    const close = (result) => {
+      if (settled) return;
+      settled = true;
+      closeModalOverlay(overlay);
+      cleanup();
+      resolve(result);
+    };
+    cleanup = openPreflightOverlay(overlay, () => close(false));
+    document.getElementById('confirm-ok').onclick = () => close(true);
+    document.getElementById('confirm-cancel').onclick = () => close(false);
   });
 }
 

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -951,6 +951,12 @@ test('PDF import preflight covers duplicate prompts, cancellation, and supported
       duplicateCancel.click();
       outcomes.duplicateCancelStopsImport = await duplicateCancelPromise === false;
 
+      const duplicateEscapePromise = preflight.runPreflightChecks(duplicateText, 'omegaquant.pdf');
+      await waitForButton('confirm-cancel');
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+      outcomes.duplicateEscapeCancelsImport = await duplicateEscapePromise === false
+        && document.getElementById('confirm-dialog-overlay')?.classList.contains('show') === false;
+
       const duplicateProceedPromise = preflight.runPreflightChecks(duplicateText, 'omegaquant.pdf');
       const duplicateProceed = await waitForButton('confirm-ok');
       duplicateProceed.click();

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -16,6 +16,7 @@ const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboar
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
+const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
 const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.js'), 'utf8');
@@ -128,6 +129,19 @@ assert('knowledge base modal uses shared lifecycle helpers',
     knowledgeBaseModalSrc.includes("closeModalOverlay('kb-modal-overlay')") &&
     !knowledgeBaseModalSrc.includes("overlay.classList.add('show')") &&
     !knowledgeBaseModalSrc.includes("overlay.classList.remove('show')"));
+
+assert('PDF import preflight dialogs use shared lifecycle helpers',
+  pdfImportPreflightSrc.includes("from './modal-lifecycle.js'") &&
+    pdfImportPreflightSrc.includes("openModalOverlay(overlay, { initialFocus: '#confirm-cancel', focusDelay: 30 })") &&
+    (pdfImportPreflightSrc.match(/closeModalOverlay\(overlay\)/g) || []).length >= 3 &&
+    pdfImportPreflightSrc.includes("overlay.dataset.escapeOwner = 'preflight'") &&
+    pdfImportPreflightSrc.includes('overlay.onclick = previousOnclick') &&
+    pdfImportPreflightSrc.includes('delete overlay.dataset.escapeOwner') &&
+    appEventsSrc.includes("confirmOverlay.dataset.escapeOwner === 'preflight'") &&
+    pdfImportPreflightSrc.includes('document.addEventListener(\'keydown\', onKey)') &&
+    pdfImportPreflightSrc.includes("cleanup = openPreflightOverlay(overlay, () => close('cancel'))") &&
+    !pdfImportPreflightSrc.includes("overlay.classList.add('show')") &&
+    !pdfImportPreflightSrc.includes("overlay.classList.remove('show')"));
 
 assert('light environment assessment uses shared overlay lifecycle before removal',
   lightEnvSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.473';
+self.APP_VERSION = '1.8.474';


### PR DESCRIPTION
## Summary
- Route PDF import preflight dialogs through shared modal lifecycle helpers
- Deduplicate confirm overlay creation and nudge handling
- Resolve preflight dialogs on Escape so import flow promises cannot hang
- Add lifecycle/source and browser coverage for the Escape path

## Tests
- `npm run typecheck`
- `node tests/test-modal-lifecycle-integrations.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `npm run test:playwright -- pdf-import-browser-coverage.spec.js`

Note: Vercel deployment checks may hit the current free-tier deployment rate limit; GitHub Actions and Greptile are the merge gates for this batch.