### PR TITLE
Use modal lifecycle for utility dialogs

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -88,7 +88,7 @@ function handleAppKeydown(e) {
     if (emfInterpOverlay && emfInterpOverlay.classList.contains("show")) { window.closeEMFInterpretation(); return; }
     const confirmOverlay = document.getElementById("confirm-dialog-overlay");
     if (confirmOverlay && confirmOverlay.classList.contains("show")) {
-      if (confirmOverlay.dataset.escapeOwner === 'preflight') return;
+      if (confirmOverlay.dataset.escapeOwner) return;
       confirmOverlay.classList.remove("show");
       return;
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,8 @@
 // @ts-check
 // utils.js — Pure utility functions, notifications, dialogs
 
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+
 /// Encode all five HTML-special characters — &, <, >, ", '. Safe to use
 /// in both text content AND attribute contexts. The prior implementation
 /// (textContent → innerHTML) only encoded & < >, which made every
@@ -447,11 +449,40 @@ export function showConfirmDialog(message) {
       <button class="confirm-btn confirm-btn-cancel" id="confirm-cancel">Cancel</button>
       <button class="confirm-btn confirm-btn-danger" id="confirm-ok">Confirm</button>
     </div></div>`;
-    overlay.classList.add("show");
-    document.getElementById("confirm-ok").onclick = () => { overlay.classList.remove("show"); resolve(true); };
-    document.getElementById("confirm-cancel").onclick = () => { overlay.classList.remove("show"); resolve(false); };
-    overlay.onclick = (e) => { if (e.target === overlay) { const d = overlay.querySelector('.confirm-dialog'); if (d) { d.classList.add('modal-nudge'); d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true }); } } };
-    document.getElementById("confirm-cancel").focus();
+    let settled = false;
+    const previousOnclick = overlay.onclick;
+    overlay.dataset.escapeOwner = 'utils-confirm';
+    const cleanup = () => {
+      document.removeEventListener('keydown', onKey);
+      overlay.onclick = previousOnclick;
+      delete overlay.dataset.escapeOwner;
+    };
+    const close = (result) => {
+      if (settled) return;
+      settled = true;
+      closeModalOverlay(overlay);
+      cleanup();
+      resolve(result);
+    };
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close(false);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    overlay.onclick = (e) => {
+      if (e.target === overlay) {
+        const d = overlay.querySelector('.confirm-dialog');
+        if (d) {
+          d.classList.add('modal-nudge');
+          d.addEventListener('animationend', () => d.classList.remove('modal-nudge'), { once: true });
+        }
+      }
+    };
+    openModalOverlay(overlay, { initialFocus: '#confirm-cancel', focusDelay: 0 });
+    document.getElementById("confirm-ok").onclick = () => close(true);
+    document.getElementById("confirm-cancel").onclick = () => close(false);
   });
 }
 
@@ -482,15 +513,19 @@ export function showPromptDialog(message, { defaultValue = '', okLabel = 'OK', c
         <button class="confirm-btn confirm-btn-cancel" id="prompt-cancel">${escapeHTML(cancelLabel)}</button>
         <button class="confirm-btn confirm-btn-danger" id="prompt-ok" style="background:var(--accent)">${escapeHTML(okLabel)}</button>
       </div></div>`;
-    overlay.classList.add('show');
 
     const input = /** @type {HTMLInputElement} */ (document.getElementById('prompt-dialog-input'));
     const ok = document.getElementById('prompt-ok');
     const cancel = document.getElementById('prompt-cancel');
+    let settled = false;
+    const previousOnclick = overlay.onclick;
 
     const close = (value) => {
-      overlay.classList.remove('show');
+      if (settled) return;
+      settled = true;
+      closeModalOverlay(overlay);
       document.removeEventListener('keydown', onKey);
+      overlay.onclick = previousOnclick;
       resolve(value);
     };
     const readValue = () => {
@@ -506,8 +541,9 @@ export function showPromptDialog(message, { defaultValue = '', okLabel = 'OK', c
     cancel.onclick = () => close(null);
     overlay.onclick = (e) => { if (e.target === overlay) close(null); };
     document.addEventListener('keydown', onKey);
-    // Autofocus the input + select default text so the user can just type.
-    setTimeout(() => { input.focus(); input.select(); }, 0);
+    openModalOverlay(overlay, { initialFocus: input, focusDelay: 0 });
+    // Select default text so the user can just type.
+    setTimeout(() => { if (overlay.classList.contains('show')) input.select(); }, 0);
   });
 }
 

--- a/tests/playwright/coverage-stragglers-dom.spec.js
+++ b/tests/playwright/coverage-stragglers-dom.spec.js
@@ -32,6 +32,26 @@ test('coverage straggler browser rails reject and clean up correctly', async ({ 
       await promise.catch(() => {});
       outcomes.confirmBackdropNudges = nudgeApplied;
       outcomes.confirmAnimationEndClearsNudge = nudgeCleared;
+
+      const escapePromise = utils.showConfirmDialog('escape probe');
+      await new Promise(resolve => setTimeout(resolve, 50));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+      const escapeResult = await Promise.race([
+        escapePromise,
+        new Promise(resolve => setTimeout(() => resolve('timeout'), 500)),
+      ]);
+      outcomes.confirmEscapeResolvesFalse = escapeResult === false
+        && document.getElementById('confirm-dialog-overlay')?.classList.contains('show') === false;
+
+      const promptPromise = utils.showPromptDialog('prompt escape', { defaultValue: 'abc' });
+      await new Promise(resolve => setTimeout(resolve, 50));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+      const promptResult = await Promise.race([
+        promptPromise,
+        new Promise(resolve => setTimeout(() => resolve('timeout'), 500)),
+      ]);
+      outcomes.promptEscapeResolvesNull = promptResult === null
+        && document.getElementById('prompt-dialog-overlay')?.classList.contains('show') === false;
     }
 
     {

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -23,6 +23,7 @@ const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.j
 const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const settingsSyncPanelSrc = fs.readFileSync(path.join(root, 'js/settings-sync-panel.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
+const utilsSrc = fs.readFileSync(path.join(root, 'js/utils.js'), 'utf8');
 const knowledgeBaseModalSrc = lensSrc.slice(
   lensSrc.indexOf('export function openKnowledgeBaseModal'),
   lensSrc.indexOf('function _kbModalKeydown')
@@ -137,11 +138,23 @@ assert('PDF import preflight dialogs use shared lifecycle helpers',
     pdfImportPreflightSrc.includes("overlay.dataset.escapeOwner = 'preflight'") &&
     pdfImportPreflightSrc.includes('overlay.onclick = previousOnclick') &&
     pdfImportPreflightSrc.includes('delete overlay.dataset.escapeOwner') &&
-    appEventsSrc.includes("confirmOverlay.dataset.escapeOwner === 'preflight'") &&
+    appEventsSrc.includes('confirmOverlay.dataset.escapeOwner') &&
     pdfImportPreflightSrc.includes('document.addEventListener(\'keydown\', onKey)') &&
     pdfImportPreflightSrc.includes("cleanup = openPreflightOverlay(overlay, () => close('cancel'))") &&
     !pdfImportPreflightSrc.includes("overlay.classList.add('show')") &&
     !pdfImportPreflightSrc.includes("overlay.classList.remove('show')"));
+
+assert('utility confirm and prompt dialogs use shared lifecycle helpers',
+  utilsSrc.includes("from './modal-lifecycle.js'") &&
+    utilsSrc.includes("overlay.dataset.escapeOwner = 'utils-confirm'") &&
+    (utilsSrc.match(/openModalOverlay\(overlay/g) || []).length >= 2 &&
+    (utilsSrc.match(/closeModalOverlay\(overlay\)/g) || []).length >= 2 &&
+    utilsSrc.includes('overlay.onclick = previousOnclick') &&
+    utilsSrc.includes('delete overlay.dataset.escapeOwner') &&
+    !utilsSrc.includes('overlay.classList.add("show")') &&
+    !utilsSrc.includes("overlay.classList.add('show')") &&
+    !utilsSrc.includes('overlay.classList.remove("show")') &&
+    !utilsSrc.includes("overlay.classList.remove('show')"));
 
 assert('light environment assessment uses shared overlay lifecycle before removal',
   lightEnvSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.474';
+self.APP_VERSION = '1.8.475';


### PR DESCRIPTION
## Summary
- Route shared confirm and prompt dialogs through modal lifecycle helpers
- Let dialog-owned Escape handlers resolve promises instead of only hiding overlays
- Add browser coverage for confirm/prompt Escape cancellation and lifecycle source guards

## Tests
- `npm run typecheck`
- `node tests/test-modal-lifecycle-integrations.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`
- `npm run test:playwright -- coverage-stragglers-dom.spec.js`

Note: Vercel deployment checks may fail due to the current deployment limit; GitHub Actions and Greptile are the merge gates for this batch.