### PR TITLE
Use modal lifecycle for marker detail modals

### DIFF
--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -12,7 +12,7 @@ import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId } from '.
 import { deleteEmptyLabEntries, deleteLabEntryMarkerValues } from './lab-entry-mutations.js';
 import { getInsulinMirrorMarkerKey } from './lab-entry.js';
 import { installMarkerDetailActionDelegates, markerDetailActionAttrs } from './marker-detail-actions.js';
-import { closeModalOverlay } from './modal-lifecycle.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   configureMarkerDetailEditing,
   editRefRange,
@@ -727,7 +727,7 @@ export function showDetailModal(id, opts = {}) {
     html += `<div style="text-align:center;margin-top:8px"><a href="#" style="color:var(--text-muted);font-size:0.8rem" ${markerDetailActionAttrs('delete-custom-marker', { id })}>Delete this marker</a></div>`;
   }
   modal.innerHTML = html;
-  overlay.classList.add("show");
+  openModalOverlay(overlay);
   if (opts.scrollToHistory) {
     setTimeout(() => {
       const historyEl = modal.querySelector('.marker-history-list');
@@ -860,11 +860,10 @@ export function openManualEntryForm(id, prefillDate) {
       </div>
     </div>
     </div>`;
-  overlay.classList.add("show");
+  openModalOverlay(overlay, { initialFocus: '#me-value', focusDelay: 50 });
   setTimeout(() => {
     const el = document.getElementById('me-value');
     if (el) {
-      el.focus();
       // Enter-to-save / Esc-to-cancel for keyboard users.
       const onKey = (e) => {
         if (e.key === 'Enter') { e.preventDefault(); saveManualEntry(id); }
@@ -938,8 +937,7 @@ export function openCreateMarkerModal() {
       </div>
     </div>
     </div>`;
-  overlay.classList.add("show");
-  setTimeout(() => { const el = document.getElementById('cm-name'); if (el) el.focus(); }, 50);
+  openModalOverlay(overlay, { initialFocus: '#cm-name', focusDelay: 50 });
 }
 
 export function pickNewCatIcon(el) {

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -16,6 +16,7 @@ const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboar
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
+const markerDetailSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
@@ -155,6 +156,15 @@ assert('utility confirm and prompt dialogs use shared lifecycle helpers',
     !utilsSrc.includes("overlay.classList.add('show')") &&
     !utilsSrc.includes('overlay.classList.remove("show")') &&
     !utilsSrc.includes("overlay.classList.remove('show')"));
+
+assert('marker detail modals open and close through shared lifecycle helpers',
+  markerDetailSrc.includes("from './modal-lifecycle.js'") &&
+    (markerDetailSrc.match(/openModalOverlay\(overlay/g) || []).length >= 3 &&
+    markerDetailSrc.includes("openModalOverlay(overlay, { initialFocus: '#me-value', focusDelay: 50 })") &&
+    markerDetailSrc.includes("openModalOverlay(overlay, { initialFocus: '#cm-name', focusDelay: 50 })") &&
+    markerDetailSrc.includes("closeModalOverlay('modal-overlay')") &&
+    !markerDetailSrc.includes('overlay.classList.add("show")') &&
+    !markerDetailSrc.includes("overlay.classList.add('show')"));
 
 assert('light environment assessment uses shared overlay lifecycle before removal',
   lightEnvSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.475';
+self.APP_VERSION = '1.8.476';


### PR DESCRIPTION
## Summary
- Route marker detail, manual-entry, and create-marker modal opens through the shared modal lifecycle helper.
- Preserve delayed initial focus for manual entry and custom marker creation via lifecycle options.
- Add a modal lifecycle integration guard for marker detail modals and bump the app version to 1.8.476.

## Validation
- `npm run typecheck`
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-marker-detail-delegated-actions.js`
- `npm run test:playwright -- marker-detail-browser-coverage.spec.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`