### PR TITLE
Use modal lifecycle for sync diagnose dialogs

### DIFF
--- a/js/sync-diagnose-identity-actions.js
+++ b/js/sync-diagnose-identity-actions.js
@@ -3,6 +3,7 @@
 
 import { showNotification, escapeHTML } from './utils.js';
 import { ensureBip39, ensureQRCode } from './sync-identity.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   currentSyncEnabled,
   enableSyncForDiagnose,
@@ -51,7 +52,10 @@ export async function confirmRotateIdentity(btn) {
   // phone-side entry, copy button, and a save-confirmation checkbox
   // that gates the Apply button.
   const existing = btn?.closest?.('.modal-overlay');
-  if (existing) existing.remove();
+  if (existing) {
+    closeModalOverlay(existing);
+    existing.remove();
+  }
 
   let qrSvg = '';
   try {
@@ -71,7 +75,7 @@ export async function confirmRotateIdentity(btn) {
     .join(' ');
 
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
   overlay.innerHTML = `<div class="modal" role="dialog" aria-label="Rotate sync identity" style="max-width:560px">
     <div class="modal-header"><h3>Rotate sync identity — save your new mnemonic</h3><button class="modal-close" aria-label="Close">×</button></div>
     <div class="modal-body" style="font-size:13px">
@@ -98,6 +102,7 @@ export async function confirmRotateIdentity(btn) {
     </div>
   </div>`;
   document.body.appendChild(overlay);
+  openModalOverlay(overlay);
 
   const closeBtn = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('.modal-close'));
   const cancelBtn = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#rotate-cancel-btn'));
@@ -110,6 +115,7 @@ export async function confirmRotateIdentity(btn) {
       words.fill('');
       words.length = 0;
     }
+    closeModalOverlay(overlay);
     overlay.remove();
   };
   closeBtn?.addEventListener('click', cleanup);

--- a/js/sync-diagnose-render.js
+++ b/js/sync-diagnose-render.js
@@ -154,7 +154,7 @@ export function renderSyncDiagnoseModal({
   const d = diagnostics;
   const rowsHtml = renderRowsHtml(d.rows);
   return `<div class="modal" role="dialog" aria-label="Sync diagnose" style="max-width:640px">
-    <div class="modal-header"><h3>Sync diagnose</h3><button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button></div>
+    <div class="modal-header"><h3>Sync diagnose</h3><button class="modal-close" data-sync-diagnose-close aria-label="Close">×</button></div>
     <div class="modal-body" style="font-size:13px">
       <div style="margin-bottom:12px">
         <div><b>Sync enabled:</b> ${d.syncEnabled ? 'yes' : 'no'}</div>
@@ -181,7 +181,7 @@ export function renderSyncDiagnoseModal({
       </div>
       <div style="margin-top:14px;display:flex;gap:8px;justify-content:flex-end">
         <button class="ctx-btn-option" onclick="window.copySyncDiagnose(this)" title="Copy this snapshot to the clipboard so you can paste it elsewhere">Copy</button>
-        <button class="ctx-btn-option" onclick="this.closest('.modal-overlay').remove()">Close</button>
+        <button class="ctx-btn-option" data-sync-diagnose-close>Close</button>
       </div>
     </div>
   </div>`;

--- a/js/sync-diagnose-ui.js
+++ b/js/sync-diagnose-ui.js
@@ -6,6 +6,7 @@ import { _evoluDiagnosticsText, getEvoluDiagnostics } from './sync-diagnostics.j
 import { getRelayQuotaEstimate, verifyPushLanded } from './sync-relay-health.js';
 import { configureSyncDiagnoseActions } from './sync-diagnose-actions.js';
 import { renderSyncDiagnoseModal } from './sync-diagnose-render.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 export {
   confirmBackfillBlockers, confirmCompactRelay, confirmDisablePhase2,
@@ -59,7 +60,7 @@ export async function showSyncDiagnose() {
   try { healthVerdict = await verifyPushLanded(); } catch {}
 
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
   overlay.innerHTML = renderSyncDiagnoseModal({
     diagnostics,
     healthVerdict,
@@ -71,7 +72,17 @@ export async function showSyncDiagnose() {
   // the same snapshot the user is staring at (avoids racing a re-fetch).
   overlay.dataset.copyText = _evoluDiagnosticsText(diagnostics);
   document.body.appendChild(overlay);
-  overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+  openModalOverlay(overlay);
+  const close = () => {
+    closeModalOverlay(overlay);
+    overlay.remove();
+  };
+  overlay.querySelectorAll('[data-sync-diagnose-close]').forEach((btn) => {
+    btn.addEventListener('click', close);
+  });
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) close();
+  });
 }
 
 // Copies the Sync diagnose snapshot to the clipboard. Walks up to find

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -24,6 +24,9 @@ const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.j
 const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const settingsSyncPanelSrc = fs.readFileSync(path.join(root, 'js/settings-sync-panel.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
+const syncDiagnoseIdentitySrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-identity-actions.js'), 'utf8');
+const syncDiagnoseRenderSrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-render.js'), 'utf8');
+const syncDiagnoseUiSrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-ui.js'), 'utf8');
 const utilsSrc = fs.readFileSync(path.join(root, 'js/utils.js'), 'utf8');
 const knowledgeBaseModalSrc = lensSrc.slice(
   lensSrc.indexOf('export function openKnowledgeBaseModal'),
@@ -165,6 +168,20 @@ assert('marker detail modals open and close through shared lifecycle helpers',
     markerDetailSrc.includes("closeModalOverlay('modal-overlay')") &&
     !markerDetailSrc.includes('overlay.classList.add("show")') &&
     !markerDetailSrc.includes("overlay.classList.add('show')"));
+
+assert('sync diagnose overlays use shared lifecycle helpers',
+  syncDiagnoseUiSrc.includes("from './modal-lifecycle.js'") &&
+    syncDiagnoseUiSrc.includes("overlay.className = 'modal-overlay'") &&
+    syncDiagnoseUiSrc.includes('openModalOverlay(overlay)') &&
+    syncDiagnoseUiSrc.includes('closeModalOverlay(overlay)') &&
+    syncDiagnoseIdentitySrc.includes("from './modal-lifecycle.js'") &&
+    syncDiagnoseIdentitySrc.includes("overlay.className = 'modal-overlay'") &&
+    syncDiagnoseIdentitySrc.includes('openModalOverlay(overlay)') &&
+    (syncDiagnoseIdentitySrc.match(/closeModalOverlay\(/g) || []).length >= 2 &&
+    (syncDiagnoseRenderSrc.match(/data-sync-diagnose-close/g) || []).length >= 2 &&
+    !syncDiagnoseRenderSrc.includes("this.closest('.modal-overlay').remove()") &&
+    !syncDiagnoseUiSrc.includes("overlay.className = 'modal-overlay show'") &&
+    !syncDiagnoseIdentitySrc.includes("overlay.className = 'modal-overlay show'"));
 
 assert('light environment assessment uses shared overlay lifecycle before removal',
   lightEnvSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.476';
+self.APP_VERSION = '1.8.477';


### PR DESCRIPTION
## Summary
- Route the Sync Diagnose modal through the shared modal lifecycle helper instead of constructing it with `modal-overlay show`.
- Route the sync identity rotation modal through the same lifecycle helper, including close-before-remove cleanup for restored focus.
- Add a modal lifecycle guard for both Sync Diagnose overlays and bump the app version to 1.8.477.

## Validation
- `npm run typecheck`
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-sync.js`
- `npm run test:playwright -- sync-diagnose-identity-actions-browser-coverage.spec.js chat-history-diagnose-browser-coverage.spec.js`
- `npm test -- tests/_vitest-legacy.test.js -t test-modal-lifecycle-integrations`