### PR TITLE
Use modal lifecycle for light tools

### DIFF
--- a/js/light-tool-camera-modals.js
+++ b/js/light-tool-camera-modals.js
@@ -2,7 +2,7 @@
 // light-tool-camera-modals.js — Camera-backed Light tool modal flows.
 
 import { escapeHTML, queryRequired, showNotification } from './utils.js';
-import { closeModalOverlay, openModalOverlay, trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import {
   aimingGuideHTML,
   lockCameraForMeasurement,
@@ -27,18 +27,6 @@ function getSaveMeasurement(deps = {}) {
   const fn = deps.saveMeasurement || (typeof window !== 'undefined' ? window.saveMeasurement : null);
   if (typeof fn !== 'function') throw new Error('saveMeasurement dependency is required');
   return fn;
-}
-
-function openLightToolOverlay(overlay, closeFn) {
-  try { wireBackdropClose(overlay, closeFn); } catch (e) {}
-  document.body.appendChild(overlay);
-  openModalOverlay(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
-}
-
-function removeLightToolOverlay(overlay) {
-  closeModalOverlay(overlay);
-  overlay.remove();
 }
 
 // ─── Tool 1: Lux Meter ─────────────────────────────────────────────────
@@ -111,9 +99,9 @@ export async function openLuxMeter(opts = {}, deps = {}) {
     if (_luxState.sensor) { try { _luxState.sensor.stop(); } catch (e) {} _luxState.sensor = null; }
     if (_luxState.stream) { try { _luxState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _luxState.stream = null; }
     _luxState.video = null;
-    removeLightToolOverlay(overlay);
+    removeModalOverlay(overlay);
   };
-  openLightToolOverlay(overlay, () => window._closeLuxMeter());
+  openAppendedModalOverlay(overlay, () => window._closeLuxMeter());
 
   let currentLux = null;
   // Snapshot of the LATEST raw camera luma (before calibration multiply).
@@ -351,9 +339,9 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
     closed = true;
     _flickerState.running = false;
     if (_flickerState.stream) { try { _flickerState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _flickerState.stream = null; }
-    removeLightToolOverlay(overlay);
+    removeModalOverlay(overlay);
   };
-  openLightToolOverlay(overlay, () => window._closeFlicker());
+  openAppendedModalOverlay(overlay, () => window._closeFlicker());
 
   let lastResult = null;
   const resultEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#flicker-result'));
@@ -502,7 +490,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
       </div>
     </div>
   </div>`;
-  openLightToolOverlay(overlay, () => window._closeDark());
+  openAppendedModalOverlay(overlay, () => window._closeDark());
 
   let result = null;
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#dark-status'));
@@ -631,7 +619,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
   window._closeDark = () => {
     _darkState.running = false;
     if (_darkState.stream) { try { _darkState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _darkState.stream = null; }
-    removeLightToolOverlay(overlay);
+    removeModalOverlay(overlay);
   };
 }
 
@@ -669,9 +657,9 @@ export async function openCCTMeter(opts = {}, deps = {}) {
     closed = true;
     _cctState.running = false;
     if (_cctState.stream) { try { _cctState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _cctState.stream = null; }
-    removeLightToolOverlay(overlay);
+    removeModalOverlay(overlay);
   };
-  openLightToolOverlay(overlay, () => window._closeCCT());
+  openAppendedModalOverlay(overlay, () => window._closeCCT());
 
   let currentCCT = null;
   let currentMelanopic = null;
@@ -822,9 +810,9 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
     closed = true;
     _specState.running = false;
     if (_specState.stream) { try { _specState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _specState.stream = null; }
-    removeLightToolOverlay(overlay);
+    removeModalOverlay(overlay);
   };
-  openLightToolOverlay(overlay, () => window._closeSpec());
+  openAppendedModalOverlay(overlay, () => window._closeSpec());
 
   let result = null;
   const resultEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#spec-result'));
@@ -1014,9 +1002,9 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
       try { stream.getTracks().forEach(t => t.stop()); } catch (e) {}
     }
     activeGlassStreams.clear();
-    removeLightToolOverlay(overlay);
+    removeModalOverlay(overlay);
   };
-  openLightToolOverlay(overlay, () => window._closeGlass());
+  openAppendedModalOverlay(overlay, () => window._closeGlass());
 
   _glassReadings = { inside: null, outside: null };
 

--- a/js/light-tool-camera-modals.js
+++ b/js/light-tool-camera-modals.js
@@ -2,7 +2,7 @@
 // light-tool-camera-modals.js — Camera-backed Light tool modal flows.
 
 import { escapeHTML, queryRequired, showNotification } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { closeModalOverlay, openModalOverlay, trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import {
   aimingGuideHTML,
   lockCameraForMeasurement,
@@ -29,6 +29,18 @@ function getSaveMeasurement(deps = {}) {
   return fn;
 }
 
+function openLightToolOverlay(overlay, closeFn) {
+  try { wireBackdropClose(overlay, closeFn); } catch (e) {}
+  document.body.appendChild(overlay);
+  openModalOverlay(overlay);
+  try { trapModalFocus(overlay); } catch (e) {}
+}
+
+function removeLightToolOverlay(overlay) {
+  closeModalOverlay(overlay);
+  overlay.remove();
+}
+
 // ─── Tool 1: Lux Meter ─────────────────────────────────────────────────
 
 const LUX_ZONES = [
@@ -53,7 +65,7 @@ export async function openLuxMeter(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
   const roomId = opts.roomId || null;
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Lux meter">
     <div class="modal-header">
       <h3>Lux Meter</h3>
@@ -99,11 +111,9 @@ export async function openLuxMeter(opts = {}, deps = {}) {
     if (_luxState.sensor) { try { _luxState.sensor.stop(); } catch (e) {} _luxState.sensor = null; }
     if (_luxState.stream) { try { _luxState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _luxState.stream = null; }
     _luxState.video = null;
-    overlay.remove();
+    removeLightToolOverlay(overlay);
   };
-  try { wireBackdropClose(overlay, () => window._closeLuxMeter()); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openLightToolOverlay(overlay, () => window._closeLuxMeter());
 
   let currentLux = null;
   // Snapshot of the LATEST raw camera luma (before calibration multiply).
@@ -319,7 +329,7 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
   const roomId = opts.roomId || null;
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Flicker detector">
     <div class="modal-header">
       <h3>Flicker Detector</h3>
@@ -341,11 +351,9 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
     closed = true;
     _flickerState.running = false;
     if (_flickerState.stream) { try { _flickerState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _flickerState.stream = null; }
-    overlay.remove();
+    removeLightToolOverlay(overlay);
   };
-  try { wireBackdropClose(overlay, () => window._closeFlicker()); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openLightToolOverlay(overlay, () => window._closeFlicker());
 
   let lastResult = null;
   const resultEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#flicker-result'));
@@ -478,7 +486,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
   const roomId = opts.roomId || null;
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Sleep darkness meter">
     <div class="modal-header">
       <h3>Sleep Darkness Meter</h3>
@@ -494,9 +502,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
       </div>
     </div>
   </div>`;
-  try { wireBackdropClose(overlay, () => window._closeDark()); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openLightToolOverlay(overlay, () => window._closeDark());
 
   let result = null;
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#dark-status'));
@@ -625,7 +631,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
   window._closeDark = () => {
     _darkState.running = false;
     if (_darkState.stream) { try { _darkState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _darkState.stream = null; }
-    overlay.remove();
+    removeLightToolOverlay(overlay);
   };
 }
 
@@ -637,7 +643,7 @@ export async function openCCTMeter(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
   const roomId = opts.roomId || null;
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Color temperature meter">
     <div class="modal-header">
       <h3>Color Temperature</h3>
@@ -663,11 +669,9 @@ export async function openCCTMeter(opts = {}, deps = {}) {
     closed = true;
     _cctState.running = false;
     if (_cctState.stream) { try { _cctState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _cctState.stream = null; }
-    overlay.remove();
+    removeLightToolOverlay(overlay);
   };
-  try { wireBackdropClose(overlay, () => window._closeCCT()); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openLightToolOverlay(overlay, () => window._closeCCT());
 
   let currentCCT = null;
   let currentMelanopic = null;
@@ -796,7 +800,7 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
   const roomId = opts.roomId || null;
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Spectrum classifier">
     <div class="modal-header">
       <h3>What kind of light is this?</h3>
@@ -818,11 +822,9 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
     closed = true;
     _specState.running = false;
     if (_specState.stream) { try { _specState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _specState.stream = null; }
-    overlay.remove();
+    removeLightToolOverlay(overlay);
   };
-  try { wireBackdropClose(overlay, () => window._closeSpec()); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openLightToolOverlay(overlay, () => window._closeSpec());
 
   let result = null;
   const resultEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#spec-result'));
@@ -977,7 +979,7 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
   const saveMeasurement = getSaveMeasurement(deps);
   const roomId = opts.roomId || null;
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Glass transmission test">
     <div class="modal-header">
       <h3>Window / Glass Transmission</h3>
@@ -1012,11 +1014,9 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
       try { stream.getTracks().forEach(t => t.stop()); } catch (e) {}
     }
     activeGlassStreams.clear();
-    overlay.remove();
+    removeLightToolOverlay(overlay);
   };
-  try { wireBackdropClose(overlay, () => window._closeGlass()); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openLightToolOverlay(overlay, () => window._closeGlass());
 
   _glassReadings = { inside: null, outside: null };
 

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -21,7 +21,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, queryRequired, showNotification } from './utils.js';
-import { closeModalOverlay, openModalOverlay, trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItem } from './data-merge.js';
 import {
@@ -214,19 +214,6 @@ export async function deleteMeasurement(id) {
   return true;
 }
 
-function openLightToolOverlay(overlay, closeFn) {
-  try { wireBackdropClose(overlay, closeFn); } catch (e) {}
-  document.body.appendChild(overlay);
-  openModalOverlay(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
-}
-
-function removeLightToolOverlay(overlay) {
-  closeModalOverlay(overlay);
-  overlay.remove();
-}
-
-
 // ─── Camera-backed tool modal facade ──────────────────────────────────
 
 export async function openLuxMeter(opts = {}) {
@@ -355,8 +342,8 @@ export function openSunriseLogger() {
       </div>
     </div>
   </div>`;
-  const closeSunriseLogger = () => removeLightToolOverlay(overlay);
-  openLightToolOverlay(overlay, closeSunriseLogger);
+  const closeSunriseLogger = () => removeModalOverlay(overlay);
+  openAppendedModalOverlay(overlay, closeSunriseLogger);
   queryRequired(overlay, '#sunrise-close').addEventListener('click', closeSunriseLogger);
   queryRequired(overlay, '#sunrise-cancel').addEventListener('click', closeSunriseLogger);
 
@@ -404,7 +391,7 @@ export async function openEyeLevelAudit() {
       </div>
     </div>
   </div>`;
-  openLightToolOverlay(overlay, () => window._closeAudit());
+  openAppendedModalOverlay(overlay, () => window._closeAudit());
 
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-status'));
   const listEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-room-list'));
@@ -567,7 +554,7 @@ export async function openEyeLevelAudit() {
   window._closeAudit = () => {
     _auditState.running = false;
     if (_auditState.stream) { try { _auditState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _auditState.stream = null; }
-    removeLightToolOverlay(overlay);
+    removeModalOverlay(overlay);
   };
 }
 

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -21,7 +21,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, queryRequired, showNotification } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { closeModalOverlay, openModalOverlay, trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItem } from './data-merge.js';
 import {
@@ -214,6 +214,18 @@ export async function deleteMeasurement(id) {
   return true;
 }
 
+function openLightToolOverlay(overlay, closeFn) {
+  try { wireBackdropClose(overlay, closeFn); } catch (e) {}
+  document.body.appendChild(overlay);
+  openModalOverlay(overlay);
+  try { trapModalFocus(overlay); } catch (e) {}
+}
+
+function removeLightToolOverlay(overlay) {
+  closeModalOverlay(overlay);
+  overlay.remove();
+}
+
 
 // ─── Camera-backed tool modal facade ──────────────────────────────────
 
@@ -312,7 +324,7 @@ export function normalizeGoldenHourMinutes(value) {
 
 export function openSunriseLogger() {
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   const coords = (window.getSunCoords && window.getSunCoords()) || null;
   const cls = _classifyDayWindow(coords, new Date());
   const subtitleHtml = cls.kind === 'unknown'
@@ -329,7 +341,7 @@ export function openSunriseLogger() {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Golden hour log">
     <div class="modal-header">
       <h3>Golden hour log <span style="font-weight:400;color:var(--text-muted);font-size:13px">— ${escapeHTML(cls.label)}</span></h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button class="modal-close" id="sunrise-close" aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       <p class="modal-body-hint">${headerHint}</p>
@@ -338,14 +350,15 @@ export function openSunriseLogger() {
         <input type="number" id="sunrise-duration" class="ctx-input" min="1" max="120" value="15" />
       </label>
       <div class="modal-actions" style="margin-top:14px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button class="import-btn import-btn-secondary" id="sunrise-cancel">Cancel</button>
         <button class="import-btn import-btn-primary" id="sunrise-save">Log session</button>
       </div>
     </div>
   </div>`;
-  try { wireBackdropClose(overlay); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  const closeSunriseLogger = () => removeLightToolOverlay(overlay);
+  openLightToolOverlay(overlay, closeSunriseLogger);
+  queryRequired(overlay, '#sunrise-close').addEventListener('click', closeSunriseLogger);
+  queryRequired(overlay, '#sunrise-cancel').addEventListener('click', closeSunriseLogger);
 
   queryRequired(overlay, '#sunrise-save').addEventListener('click', async () => {
     const durationInput = /** @type {HTMLInputElement} */ (queryRequired(overlay, '#sunrise-duration'));
@@ -363,7 +376,7 @@ export function openSunriseLogger() {
       if (id && window.hydrateSession) await window.hydrateSession(id);
     }
     showNotification(`${cls.label} logged: ${minutes} min`);
-    overlay.remove();
+    closeSunriseLogger();
     if (window.navigate && state.currentView === 'light') window.navigate('light');
   });
 }
@@ -374,7 +387,7 @@ let _auditState = { running: false, stream: null, samples: [] };
 
 export async function openEyeLevelAudit() {
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-tool-overlay';
+  overlay.className = 'modal-overlay light-tool-overlay';
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Home audit">
     <div class="modal-header">
       <h3>Home audit <span style="font-weight:400;color:var(--text-muted);font-size:13px">— 10 min walkthrough</span></h3>
@@ -391,9 +404,7 @@ export async function openEyeLevelAudit() {
       </div>
     </div>
   </div>`;
-  try { wireBackdropClose(overlay, () => window._closeAudit()); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openLightToolOverlay(overlay, () => window._closeAudit());
 
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-status'));
   const listEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-room-list'));
@@ -556,7 +567,7 @@ export async function openEyeLevelAudit() {
   window._closeAudit = () => {
     _auditState.running = false;
     if (_auditState.stream) { try { _auditState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _auditState.stream = null; }
-    overlay.remove();
+    removeLightToolOverlay(overlay);
   };
 }
 

--- a/js/modal-lifecycle.js
+++ b/js/modal-lifecycle.js
@@ -15,6 +15,18 @@ export function wireBackdropClose(overlay, closeFn) {
 
 export const _wireBackdropClose = wireBackdropClose;
 
+/**
+ * @param {Element} overlay
+ * @param {Function} [closeFn]
+ * @param {object} [options]
+ */
+export function openAppendedModalOverlay(overlay, closeFn, options = {}) {
+  try { wireBackdropClose(overlay, closeFn); } catch (_) {}
+  document.body.appendChild(overlay);
+  openModalOverlay(overlay, options);
+  try { trapModalFocus(overlay); } catch (_) {}
+}
+
 const _modalScrollState = (() => {
   const fallback = { locks: new Set(), priorOverflow: '' };
   if (typeof window === 'undefined') return fallback;
@@ -116,6 +128,12 @@ export function closeModalOverlay(overlayOrId, options = {}) {
   }
 
   return overlay;
+}
+
+/** @param {Element} overlay */
+export function removeModalOverlay(overlay) {
+  closeModalOverlay(overlay);
+  overlay.remove();
 }
 
 function _pruneDetachedModalScrollLocks() {

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -18,6 +18,7 @@ const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
 const lightToolCameraModalsSrc = fs.readFileSync(path.join(root, 'js/light-tool-camera-modals.js'), 'utf8');
 const lightToolsSrc = fs.readFileSync(path.join(root, 'js/light-tools.js'), 'utf8');
+const modalLifecycleSrc = fs.readFileSync(path.join(root, 'js/modal-lifecycle.js'), 'utf8');
 const markerDetailSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
@@ -203,16 +204,16 @@ assert('light environment assessment uses shared overlay lifecycle before remova
     !lightEnvSrc.includes("overlay.classList.add('show')"));
 
 assert('light tool modals use shared overlay lifecycle helpers',
-  lightToolCameraModalsSrc.includes("from './modal-lifecycle.js'") &&
-    lightToolCameraModalsSrc.includes('openModalOverlay(overlay)') &&
-    lightToolCameraModalsSrc.includes('closeModalOverlay(overlay)') &&
-    (lightToolCameraModalsSrc.match(/openLightToolOverlay\(overlay/g) || []).length >= 6 &&
-    (lightToolCameraModalsSrc.match(/removeLightToolOverlay\(overlay\)/g) || []).length >= 6 &&
-    lightToolsSrc.includes("from './modal-lifecycle.js'") &&
-    lightToolsSrc.includes('openModalOverlay(overlay)') &&
-    lightToolsSrc.includes('closeModalOverlay(overlay)') &&
-    (lightToolsSrc.match(/openLightToolOverlay\(overlay/g) || []).length >= 2 &&
-    (lightToolsSrc.match(/removeLightToolOverlay\(overlay\)/g) || []).length >= 2 &&
+  modalLifecycleSrc.includes('export function openAppendedModalOverlay') &&
+    modalLifecycleSrc.includes('export function removeModalOverlay') &&
+    lightToolCameraModalsSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    (lightToolCameraModalsSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 6 &&
+    (lightToolCameraModalsSrc.match(/removeModalOverlay\(overlay\)/g) || []).length >= 6 &&
+    lightToolsSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    (lightToolsSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 2 &&
+    (lightToolsSrc.match(/removeModalOverlay\(overlay\)/g) || []).length >= 2 &&
+    !lightToolCameraModalsSrc.includes('function openLightToolOverlay') &&
+    !lightToolsSrc.includes('function openLightToolOverlay') &&
     !lightToolCameraModalsSrc.includes("overlay.className = 'modal-overlay show light-tool-overlay'") &&
     !lightToolsSrc.includes("overlay.className = 'modal-overlay show light-tool-overlay'") &&
     !lightToolsSrc.includes("this.closest('.modal-overlay').remove()"));

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -16,6 +16,8 @@ const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboar
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
+const lightToolCameraModalsSrc = fs.readFileSync(path.join(root, 'js/light-tool-camera-modals.js'), 'utf8');
+const lightToolsSrc = fs.readFileSync(path.join(root, 'js/light-tools.js'), 'utf8');
 const markerDetailSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
@@ -199,6 +201,21 @@ assert('light environment assessment uses shared overlay lifecycle before remova
     lightEnvSrc.includes('overlay.remove()') &&
     !lightEnvSrc.includes("overlay.className = 'modal-overlay show light-env-assessment-overlay'") &&
     !lightEnvSrc.includes("overlay.classList.add('show')"));
+
+assert('light tool modals use shared overlay lifecycle helpers',
+  lightToolCameraModalsSrc.includes("from './modal-lifecycle.js'") &&
+    lightToolCameraModalsSrc.includes('openModalOverlay(overlay)') &&
+    lightToolCameraModalsSrc.includes('closeModalOverlay(overlay)') &&
+    (lightToolCameraModalsSrc.match(/openLightToolOverlay\(overlay/g) || []).length >= 6 &&
+    (lightToolCameraModalsSrc.match(/removeLightToolOverlay\(overlay\)/g) || []).length >= 6 &&
+    lightToolsSrc.includes("from './modal-lifecycle.js'") &&
+    lightToolsSrc.includes('openModalOverlay(overlay)') &&
+    lightToolsSrc.includes('closeModalOverlay(overlay)') &&
+    (lightToolsSrc.match(/openLightToolOverlay\(overlay/g) || []).length >= 2 &&
+    (lightToolsSrc.match(/removeLightToolOverlay\(overlay\)/g) || []).length >= 2 &&
+    !lightToolCameraModalsSrc.includes("overlay.className = 'modal-overlay show light-tool-overlay'") &&
+    !lightToolsSrc.includes("overlay.className = 'modal-overlay show light-tool-overlay'") &&
+    !lightToolsSrc.includes("this.closest('.modal-overlay').remove()"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.480';
+self.APP_VERSION = '1.8.481';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.479';
+self.APP_VERSION = '1.8.480';


### PR DESCRIPTION
## Summary
- Route Light Tools modal open/close paths through shared modal lifecycle helpers.
- Consolidate the append/open/trap and close/remove flow into generic helpers in `modal-lifecycle.js` so Light Tool modules do not duplicate lifecycle wrappers.
- Preserve the existing camera/tool cleanup functions while removing hard-coded `modal-overlay show` setup and bump the app version to 1.8.481.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-light-tools.js`
- `npm run typecheck`
- `npm test`
- `npx playwright test tests/playwright/light-tool-camera-modals-browser-coverage.spec.js tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js tests/playwright/light-tools-browser-coverage.spec.js tests/playwright/light-coverage-batch-2.spec.js --project=chromium`