### PR TITLE
Use modal lifecycle for light device modals

### DIFF
--- a/js/light-conditions-now.js
+++ b/js/light-conditions-now.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 export function renderLightConditionsWidgetBody({ variant = 'full', slotId = '' } = {}) {
   const conditionsOpts = { variant };
@@ -275,7 +275,8 @@ export function _inspectConditionsNow() {
   const atm = (_conditionsCache && _conditionsCache.coordKey === key) ? _conditionsCache.atm : null;
   const warnings = atm ? _sanityCheckAtmosphere(atm, coords) : [];
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
+  const closeDialog = () => removeModalOverlay(overlay);
   const cacheKeys = [];
   try {
     for (let i = 0; i < localStorage.length; i++) {
@@ -286,7 +287,7 @@ export function _inspectConditionsNow() {
   overlay.innerHTML = `<div class="modal" role="dialog" aria-label="Inspect conditions data" style="max-width:640px">
     <div class="modal-header">
       <h3>Inspect conditions data</h3>
-      <button class="modal-close" aria-label="Close" onclick="this.closest('.modal-overlay').remove()">×</button>
+      <button class="modal-close" aria-label="Close" data-conditions-inspect-close>×</button>
     </div>
     <div class="modal-body">
       <p class="modal-body-hint">Last response from the conditions provider, exactly as parsed. Use this to verify the math is using the values you expect.</p>
@@ -363,14 +364,19 @@ export function _inspectConditionsNow() {
       </div>
 
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Close</button>
-        <button class="import-btn import-btn-primary" onclick="this.closest('.modal-overlay').remove();window._refreshConditionsNow();">↻ Force refresh</button>
+        <button class="import-btn import-btn-secondary" data-conditions-inspect-close>Close</button>
+        <button class="import-btn import-btn-primary" id="conditions-inspect-refresh">↻ Force refresh</button>
       </div>
     </div>
   </div>`;
-  try { wireBackdropClose(overlay); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openAppendedModalOverlay(overlay, closeDialog);
+  overlay.querySelectorAll('[data-conditions-inspect-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
+  });
+  overlay.querySelector('#conditions-inspect-refresh')?.addEventListener('click', () => {
+    closeDialog();
+    /** @type {any} */ (window)._refreshConditionsNow?.();
+  });
   // Manually drive scroll + halt propagation on the Raw payload <pre>.
   // CSS-only `overflow:auto`/`overscroll-behavior:contain` couldn't beat
   // the modal's own scroll container — wheel deltas were being claimed

--- a/js/light-device-session-modal.js
+++ b/js/light-device-session-modal.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { BODY_REGIONS } from './sun.js';
 
 /**
@@ -15,11 +15,9 @@ function _input(root, selector) {
   return /** @type {HTMLInputElement|null} */ (root.querySelector(selector));
 }
 
-function _wireDeviceSessionModal(overlay) {
+function _wireDeviceSessionModal(overlay, closeFn) {
   if (typeof window === 'undefined') { document.body.appendChild(overlay); return; }
-  try { wireBackdropClose(overlay); } catch (_) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (_) {}
+  openAppendedModalOverlay(overlay, closeFn);
 }
 
 function _defaultRegionsForLastSession(last) {
@@ -107,11 +105,12 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
   }
 
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
+  const closeDialog = () => removeModalOverlay(overlay);
   overlay.innerHTML = `<div class="modal" role="dialog" aria-label="Log device session">
     <div class="modal-header">
       <h3>Log session — ${escapeHTML(device.brand)} ${escapeHTML(device.model)}</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button class="modal-close" data-device-session-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${showModePicker ? `
@@ -163,13 +162,16 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
       </div>
       <p class="modal-body-hint" style="margin-top:8px">Save now to log a finished session, or Start to run a live timer (matches the sun-session pattern — handy when you want to walk away and come back).</p>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button class="import-btn import-btn-secondary" data-device-session-close>Cancel</button>
         <button class="import-btn import-btn-secondary" id="dev-session-start">Start timer</button>
         <button class="import-btn import-btn-primary" id="dev-session-save">Save session</button>
       </div>
     </div>
   </div>`;
-  _wireDeviceSessionModal(overlay);
+  _wireDeviceSessionModal(overlay, closeDialog);
+  overlay.querySelectorAll('[data-device-session-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
+  });
 
   let lastModePointerActivation = 0;
   /**
@@ -273,7 +275,7 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     const eyesProtected = !!_input(overlay, '#dev-session-eyes')?.checked;
     const mode = showModePicker ? _input(overlay, '#dev-session-mode')?.value || null : null;
     await logDeviceSession({ deviceId, durationMin, distanceCm, bodyArea, bodyAreas, eyesProtected, mode });
-    overlay.remove();
+    closeDialog();
     showNotification(`${durationMin} min ${escapeHTML(device.brand)} session saved.`);
     if (window.navigate) window.navigate('light');
   });
@@ -293,7 +295,7 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     const eyesProtected = !!_input(overlay, '#dev-session-eyes')?.checked;
     const mode = showModePicker ? _input(overlay, '#dev-session-mode')?.value || null : null;
     await startDeviceSession({ deviceId, distanceCm, bodyAreas, bodyArea, eyesProtected, mode });
-    overlay.remove();
+    closeDialog();
     showNotification(`Live ${escapeHTML(device.brand)} session started — tap Stop & save when finished.`);
     ensureActiveDeviceTicker();
     if (window.navigate) window.navigate('light');

--- a/js/light-device-setup-modal.js
+++ b/js/light-device-setup-modal.js
@@ -9,6 +9,7 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, isDebugMode } from './utils.js';
 import { callClaudeAPI, hasAIProvider, supportsVision } from './api.js';
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 /**
  * @param {ParentNode} root
@@ -42,7 +43,7 @@ const setupDeps = {
   loadPresets: async () => ({ presets: [], types: {} }),
   addDeviceFromPreset: async () => null,
   addCustomDevice: async () => null,
-  wireModal: (overlay) => document.body.appendChild(overlay),
+  wireModal: (overlay, closeFn) => openAppendedModalOverlay(overlay, closeFn),
   refreshLightView: () => {},
 };
 
@@ -90,11 +91,12 @@ export async function openAddDeviceDialog() {
     : 'Don\'t see your device? Set up an AI provider in Settings to auto-extract specs from a URL or photo, or click below to enter manually.';
 
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
+  const closeDialog = () => removeModalOverlay(overlay);
   overlay.innerHTML = `<div class="modal light-device-add-modal" role="dialog" aria-label="Add light device">
     <div class="modal-header">
       <h3>Add a light device</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button class="modal-close" data-light-device-setup-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       <p class="modal-body-hint">Pick from the curated brand presets — Mitochondriak, Chroma, EMR-Tek. Anything else uses the custom-add flow below.</p>
@@ -102,7 +104,7 @@ export async function openAddDeviceDialog() {
         ${presetSections}
       </div>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button class="import-btn import-btn-secondary" data-light-device-setup-close>Cancel</button>
         <button class="import-btn import-btn-primary" id="add-device-confirm" disabled>Add device</button>
       </div>
 
@@ -112,20 +114,16 @@ export async function openAddDeviceDialog() {
       <button type="button" class="import-btn import-btn-secondary" id="add-device-custom" style="width:100%;margin-top:8px">+ Custom device (paste link or scan photo)</button>
     </div>
   </div>`;
-  setupDeps.wireModal(overlay);
+  setupDeps.wireModal(overlay, closeDialog);
+  overlay.querySelectorAll('[data-light-device-setup-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
+  });
 
   overlay.querySelector('#add-device-custom').addEventListener('click', () => {
-    overlay.remove();
+    closeDialog();
     openCustomDeviceDialog();
   });
 
-  // Backdrop-click closes — this is a browse/pick modal (single select, no
-  // typed input), so accidental dismissal doesn't lose any data the user
-  // hasn't already chosen via dropdown. Escape is handled globally in
-  // main.js's anonymous-overlay fallback.
-  overlay.addEventListener('click', (e) => {
-    if (e.target === overlay) overlay.remove();
-  });
   overlay.addEventListener('wheel', (event) => {
     const modal = overlay.querySelector('.light-device-add-modal');
     if (!modal) return;
@@ -155,7 +153,7 @@ export async function openAddDeviceDialog() {
     const presetId = selectedPresetId;
     if (!presetId) return;
     await setupDeps.addDeviceFromPreset(presetId);
-    overlay.remove();
+    closeDialog();
     showNotification('Device added.');
     setupDeps.refreshLightView();
   });
@@ -184,11 +182,12 @@ export async function openCustomDeviceDialog() {
   const hasAI = hasAIProvider();
   const hasVision = hasAI && supportsVision();
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
+  const closeDialog = () => removeModalOverlay(overlay);
   overlay.innerHTML = `<div class="modal" role="dialog" aria-label="Add custom light device">
     <div class="modal-header">
       <h3>Add a custom device</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button class="modal-close" data-light-device-custom-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${hasAI ? `
@@ -246,12 +245,15 @@ export async function openCustomDeviceDialog() {
         </label>
       </div>
       <div class="modal-actions" style="margin-top:18px">
-        <button type="button" class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button type="button" class="import-btn import-btn-secondary" data-light-device-custom-close>Cancel</button>
         <button type="button" class="import-btn import-btn-primary" id="custom-dev-save">Add device</button>
       </div>
     </div>
   </div>`;
-  setupDeps.wireModal(overlay);
+  setupDeps.wireModal(overlay, closeDialog);
+  overlay.querySelectorAll('[data-light-device-custom-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
+  });
 
   // Per-field unit toggle on the Vendor reference distance input — same
   // in-place conversion as the session dialog.
@@ -292,7 +294,7 @@ export async function openCustomDeviceDialog() {
       return;
     }
     await setupDeps.addCustomDevice(spec);
-    overlay.remove();
+    closeDialog();
     showNotification('Device added.');
     setupDeps.refreshLightView();
   });

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -20,7 +20,7 @@
 
 import { state } from './state.js';
 import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showConfirmDialog } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { CHANNEL_DISPLAY } from './sun.js';
 import { BODY_REGIONS } from './sun-body-silhouette.js';
 import {
@@ -66,11 +66,9 @@ let _PRESET_TYPES = null;
 
 // Standard modal-mount pattern shared by every modal opener in this file:
 // wire backdrop-click close, append, then trap focus.
-function _wireModal(overlay) {
+function _wireModal(overlay, closeFn) {
   if (typeof window === 'undefined') { document.body.appendChild(overlay); return; }
-  try { wireBackdropClose(overlay); } catch (_) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (_) {}
+  openAppendedModalOverlay(overlay, closeFn);
 }
 
 async function loadPresets() {
@@ -138,11 +136,12 @@ export async function editDeviceSessionMode(id) {
   }
   const currentMode = sess.mode || (device.modes.find(m => m.default) || device.modes[0])?.id;
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
+  const closeDialog = () => removeModalOverlay(overlay);
   overlay.innerHTML = `<div class="modal" role="dialog" aria-label="Edit session mode">
     <div class="modal-header">
       <h3>Edit mode — ${escapeHTML(device.brand)} ${escapeHTML(device.model)}</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button class="modal-close" data-device-mode-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       <p class="modal-body-hint">Pick the LED-group mode that actually fired during this session. Doses will be recomputed on save.</p>
@@ -152,15 +151,18 @@ export async function editDeviceSessionMode(id) {
         </select>
       </label>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button class="import-btn import-btn-secondary" data-device-mode-close>Cancel</button>
         <button class="import-btn import-btn-primary" id="dev-edit-mode-save">Save</button>
       </div>
     </div>
   </div>`;
-  _wireModal(overlay);
+  _wireModal(overlay, closeDialog);
+  overlay.querySelectorAll('[data-device-mode-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
+  });
   overlay.querySelector('#dev-edit-mode-save').addEventListener('click', async () => {
     const next = _select(overlay, '#dev-edit-mode')?.value || '';
-    overlay.remove();
+    closeDialog();
     if (next === sess.mode) return;
     await updateDeviceSession(id, { mode: next });
     showNotification('Mode updated. Doses recomputed.', 'success');
@@ -224,6 +226,7 @@ export function openDeviceSessionDetail(id) {
   const sessions = getDeviceSessions();
   const sess = sessions.find(s => s.id === id);
   if (!sess) return;
+  const appWindow = /** @type {any} */ (window);
   const device = getDevices().find(d => d.id === sess.deviceId) || null;
   /** @type {(value: any, channelKey?: string) => number} */
   const channelTier = window.channelTier || (() => 0);
@@ -289,7 +292,7 @@ export function openDeviceSessionDetail(id) {
       const tlabel = tierLabel(t);
       const unitText = formatChannelUnit(k, v, sess.durationMin || 0, 'III', null, null, false, _sessBodyFrac);
       const ariaLabel = `${meta.label || k} — ${tlabel}${unitText ? ', ' + unitText : ''}. Open channel details.`;
-      return `<div class="sun-detail-channel-row sun-detail-channel-row-clickable sun-chip-tier-${t}" data-channel="${escapeAttr(k)}" role="button" tabindex="0" aria-label="${escapeAttr(ariaLabel)}" onclick="this.closest('.modal-overlay')?.remove();window._openChannelOnLightPage && window._openChannelOnLightPage('${escapeAttr(k)}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.closest('.modal-overlay')?.remove();window._openChannelOnLightPage && window._openChannelOnLightPage('${escapeAttr(k)}')}">
+      return `<div class="sun-detail-channel-row sun-detail-channel-row-clickable sun-chip-tier-${t}" data-channel="${escapeAttr(k)}" role="button" tabindex="0" aria-label="${escapeAttr(ariaLabel)}">
         <span class="sun-detail-channel-icon" aria-hidden="true">${meta.icon || '·'}</span>
         <span class="sun-detail-channel-label">${escapeHTML(meta.label || k)}</span>
         <span class="sun-detail-channel-value">${escapeHTML(unitText || '')}</span>
@@ -299,11 +302,12 @@ export function openDeviceSessionDetail(id) {
     }).join('') : '';
 
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
+  const closeDialog = () => removeModalOverlay(overlay);
   overlay.innerHTML = `<div class="modal sun-detail-modal" data-session-kind="device" role="dialog" aria-label="Device session details">
     <div class="modal-header">
       <h3>Device session — ${escapeHTML(start)}</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button class="modal-close" data-device-session-detail-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${window.renderDeviceSessionAIDetail ? window.renderDeviceSessionAIDetail(sess) : ''}
@@ -355,13 +359,52 @@ export function openDeviceSessionDetail(id) {
       ` : ''}
 
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove();window.editDeviceSessionDuration('${escapeAttr(sess.id)}')" title="Override the session duration. Use when you forgot to stop the timer or stopped late.">Edit duration</button>
-        ${canEditMode ? `<button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove();window.editDeviceSessionMode && window.editDeviceSessionMode('${escapeAttr(sess.id)}')" title="Change which LED-group mode the session ran in. Doses recompute on save.">Edit mode</button>` : ''}
-        <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" onclick="this.closest('.modal-overlay').remove();window.deleteDeviceSession && window.deleteDeviceSession('${escapeAttr(sess.id)}')">Delete session</button>
+        <button class="import-btn import-btn-secondary" id="device-detail-edit-duration" title="Override the session duration. Use when you forgot to stop the timer or stopped late.">Edit duration</button>
+        ${canEditMode ? `<button class="import-btn import-btn-secondary" id="device-detail-edit-mode" title="Change which LED-group mode the session ran in. Doses recompute on save.">Edit mode</button>` : ''}
+        <button class="import-btn import-btn-secondary" id="device-detail-delete" style="color:var(--red);border-color:var(--red)">Delete session</button>
       </div>
     </div>
   </div>`;
-  _wireModal(overlay);
+  _wireModal(overlay, closeDialog);
+  overlay.addEventListener('click', (event) => {
+    const target = /** @type {Element|null} */ (event.target instanceof Element ? event.target : null);
+    if (!target) return;
+    if (target.closest('[data-device-session-detail-close]')) {
+      closeDialog();
+      return;
+    }
+    const channelRow = target.closest('.sun-detail-channel-row-clickable[data-channel]');
+    if (channelRow && overlay.contains(channelRow)) {
+      const channel = channelRow.getAttribute('data-channel') || '';
+      closeDialog();
+      appWindow._openChannelOnLightPage?.(channel);
+      return;
+    }
+    if (target.closest('#device-detail-edit-duration')) {
+      closeDialog();
+      appWindow.editDeviceSessionDuration?.(sess.id);
+      return;
+    }
+    if (target.closest('#device-detail-edit-mode')) {
+      closeDialog();
+      appWindow.editDeviceSessionMode?.(sess.id);
+      return;
+    }
+    if (target.closest('#device-detail-delete')) {
+      closeDialog();
+      appWindow.deleteDeviceSession?.(sess.id);
+    }
+  });
+  overlay.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const target = /** @type {Element|null} */ (event.target instanceof Element ? event.target : null);
+    const channelRow = target?.closest?.('.sun-detail-channel-row-clickable[data-channel]');
+    if (!channelRow || !overlay.contains(channelRow)) return;
+    event.preventDefault();
+    const channel = channelRow.getAttribute('data-channel') || '';
+    closeDialog();
+    appWindow._openChannelOnLightPage?.(channel);
+  });
   bindDetachedModalSyncRefresh({
     overlay,
     id,
@@ -629,7 +672,8 @@ function _openDevicePicker(devices) {
   // embeds Date.now() base36, monotonically increasing.)
   const ordered = devices.slice().sort((a, b) => (b.id || '').localeCompare(a.id || ''));
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
+  const closeDialog = () => removeModalOverlay(overlay);
   let rows = '';
   for (const dev of ordered) {
     const meta = `${escapeHTML(dev.type || '')}${dev.peakWavelengths?.length ? ' · ' + dev.peakWavelengths.join('/') + 'nm' : ''}${dev.mwPerCm2At15cm ? ' · ' + dev.mwPerCm2At15cm + ' mW/cm²' : ''}`;
@@ -641,24 +685,23 @@ function _openDevicePicker(devices) {
   overlay.innerHTML = `<div class="modal" role="dialog" aria-label="Pick a device to log a session">
     <div class="modal-header">
       <h3>Which device?</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button class="modal-close" data-device-picker-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       <div class="light-device-picker-list">${rows}</div>
       <div class="modal-actions" style="margin-top:14px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button class="import-btn import-btn-secondary" data-device-picker-close>Cancel</button>
       </div>
     </div>
   </div>`;
-  _wireModal(overlay);
-  // Backdrop-click closes — browse-style modal, no user-entered data.
-  overlay.addEventListener('click', (e) => {
-    if (e.target === overlay) overlay.remove();
+  _wireModal(overlay, closeDialog);
+  overlay.querySelectorAll('[data-device-picker-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
   });
   for (const btn of overlay.querySelectorAll('.light-device-picker-row')) {
     btn.addEventListener('click', () => {
       const id = btn.getAttribute('data-device-id');
-      overlay.remove();
+      closeDialog();
       openDeviceSessionDialog(id);
     });
   }

--- a/js/light-sessions-view.js
+++ b/js/light-sessions-view.js
@@ -2,7 +2,7 @@
 // light-sessions-view.js — Unified Light & Sun session list and modal
 
 import { bindModalSyncRefresh, escapeHTML, escapeAttr, formatDate } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 // Inline cap on the historical sessions list. 3 is enough for
 // at-a-glance context ("what did I do recently"); the full history
@@ -129,12 +129,22 @@ export function renderUnifiedSessionsList() {
 // renderer as the inline list.
 export function _openAllSessionsModal() {
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show light-sessions-modal-overlay';
+  overlay.className = 'modal-overlay light-sessions-modal-overlay';
   let _detach = () => {};
+  let _detached = false;
+  const detachListeners = () => {
+    if (_detached) return;
+    _detached = true;
+    _detach();
+  };
   const _removeOverlay = overlay.remove.bind(overlay);
   overlay.remove = () => {
-    _detach();
+    detachListeners();
     _removeOverlay();
+  };
+  const closeOverlay = () => {
+    detachListeners();
+    removeModalOverlay(overlay);
   };
   const renderInto = () => {
     const { rows, hasDeviceRows } = _collectUnifiedSessionRows();
@@ -150,7 +160,7 @@ export function _openAllSessionsModal() {
           <h3 id="light-all-sessions-title">${escapeHTML(title)}</h3>
           <p>Outdoor sun and therapy device history</p>
         </div>
-        <button class="modal-close" aria-label="Close" onclick="this.closest('.modal-overlay').remove()">×</button>
+        <button class="modal-close" aria-label="Close" data-light-sessions-close>×</button>
       </header>
       <div class="light-sessions-modal-summary" aria-label="Session summary">
         <div><span>Total</span><strong>${rows.length}</strong></div>
@@ -191,17 +201,21 @@ export function _openAllSessionsModal() {
   };
   overlay.addEventListener('click', (event) => {
     const target = eventElement(event.target);
+    if (target?.closest?.('[data-light-sessions-close]')) {
+      closeOverlay();
+      return;
+    }
     const row = target?.closest?.('.sun-session[role="button"]');
     if (!row || !overlay.contains(row)) return;
     if (target?.closest?.('button, a, input, select, textarea, [role="menuitem"]')) return;
-    setTimeout(() => overlay.remove(), 0);
+    setTimeout(closeOverlay, 0);
   });
   overlay.addEventListener('keydown', (event) => {
     if (event.key !== 'Enter' && event.key !== ' ') return;
     const target = eventElement(event.target);
     const row = target?.closest?.('.sun-session[role="button"]');
     if (!row || !overlay.contains(row)) return;
-    setTimeout(() => overlay.remove(), 0);
+    setTimeout(closeOverlay, 0);
   });
   overlay.addEventListener('wheel', (event) => {
     const body = overlay.querySelector('.light-sessions-modal-body');
@@ -216,7 +230,5 @@ export function _openAllSessionsModal() {
     });
     event.preventDefault();
   }, { passive: false });
-  try { wireBackdropClose(overlay); } catch (e) {}
-  document.body.appendChild(overlay);
-  try { trapModalFocus(overlay); } catch (e) {}
+  openAppendedModalOverlay(overlay, closeOverlay);
 }

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -314,21 +314,27 @@ console.log('=== Phase 3 A11y Tests ===\n');
     lightDevSetupSrc.includes('if (!res.ok) throw new Error(`Proxy error ${res.status}`);'));
   assert('custom-device async extraction suppresses stale detached-overlay notifications',
     (lightDevSetupSrc.match(/if \(!overlay\.isConnected\) return;/g) || []).length >= 3);
-  // Browse modals get backdrop-close listeners guarded by `e.target === overlay`
-  // so child clicks don't bubble out. Add-device lives in the setup module;
-  // the quick-log device picker remains in light-devices.js.
-  const setupBackdropMatches = lightDevSetupSrc.match(/overlay\.addEventListener\('click', \(e\) => \{\s*if \(e\.target === overlay\) overlay\.remove\(\);/g) || [];
-  const deviceBackdropMatches = lightDevSrc.match(/overlay\.addEventListener\('click', \(e\) => \{\s*if \(e\.target === overlay\) overlay\.remove\(\);/g) || [];
-  assert('Add-device + device-picker modals each have backdrop-click close',
-    setupBackdropMatches.length >= 1 && deviceBackdropMatches.length >= 1,
-    `setup=${setupBackdropMatches.length}, device=${deviceBackdropMatches.length}`);
-  // openDeviceSessionDialog is a form modal — must NOT have backdrop-close
-  // (would lose typed duration/distance/notes on stray click).
+  // Browse modals delegate backdrop close through the shared modal
+  // lifecycle helper, so child clicks stay guarded by wireBackdropClose
+  // while close buttons and save paths share the same close handler.
+  const setupLifecycleMatches = (lightDevSetupSrc.match(/setupDeps\.wireModal\(overlay, closeDialog\)/g) || []).length;
+  const devicePickerStart = lightDevSrc.indexOf('function _openDevicePicker');
+  const devicePickerBody = lightDevSrc.slice(devicePickerStart);
+  assert('Add-device + device-picker modals route close through shared lifecycle',
+    setupLifecycleMatches >= 2 &&
+      lightDevSetupSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+      devicePickerBody.includes('const closeDialog = () => removeModalOverlay(overlay);') &&
+      devicePickerBody.includes('_wireModal(overlay, closeDialog)'),
+    `setup=${setupLifecycleMatches}`);
+  // openDeviceSessionDialog is a form modal; it should not hand-roll an
+  // overlay click listener, and should route closure through the same
+  // lifecycle close handler as the explicit controls.
   const sessionDialogStart = lightDevSessionSrc.indexOf('export async function openDeviceSessionDialog');
   const sessionDialogEnd = lightDevSessionSrc.indexOf('export', sessionDialogStart + 1);
   const sessionDialogBody = lightDevSessionSrc.slice(sessionDialogStart, sessionDialogEnd > 0 ? sessionDialogEnd : undefined);
-  assert('openDeviceSessionDialog (form modal) has NO backdrop-close listener',
-    !/overlay\.addEventListener\('click'/.test(sessionDialogBody));
+  assert('openDeviceSessionDialog routes closure through shared lifecycle handler',
+    sessionDialogBody.includes('_wireDeviceSessionModal(overlay, closeDialog)') &&
+      !/overlay\.addEventListener\('click'/.test(sessionDialogBody));
 
   // ─── 13. Light-page channel pill drill-down a11y ───
   // Pills are <button>s (native focusable + Enter/Space) with aria-expanded

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -15,7 +15,12 @@ const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medic
 const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
+const lightConditionsNowSrc = fs.readFileSync(path.join(root, 'js/light-conditions-now.js'), 'utf8');
+const lightDeviceSessionModalSrc = fs.readFileSync(path.join(root, 'js/light-device-session-modal.js'), 'utf8');
+const lightDeviceSetupModalSrc = fs.readFileSync(path.join(root, 'js/light-device-setup-modal.js'), 'utf8');
+const lightDevicesSrc = fs.readFileSync(path.join(root, 'js/light-devices.js'), 'utf8');
 const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
+const lightSessionsViewSrc = fs.readFileSync(path.join(root, 'js/light-sessions-view.js'), 'utf8');
 const lightToolCameraModalsSrc = fs.readFileSync(path.join(root, 'js/light-tool-camera-modals.js'), 'utf8');
 const lightToolsSrc = fs.readFileSync(path.join(root, 'js/light-tools.js'), 'utf8');
 const modalLifecycleSrc = fs.readFileSync(path.join(root, 'js/modal-lifecycle.js'), 'utf8');
@@ -217,6 +222,24 @@ assert('light tool modals use shared overlay lifecycle helpers',
     !lightToolCameraModalsSrc.includes("overlay.className = 'modal-overlay show light-tool-overlay'") &&
     !lightToolsSrc.includes("overlay.className = 'modal-overlay show light-tool-overlay'") &&
     !lightToolsSrc.includes("this.closest('.modal-overlay').remove()"));
+
+assert('light device and session modals use shared overlay lifecycle helpers',
+  lightDeviceSessionModalSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    lightDeviceSetupModalSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    lightDevicesSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    lightConditionsNowSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    lightSessionsViewSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    (lightDeviceSessionModalSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    (lightDeviceSetupModalSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    (lightDevicesSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    (lightConditionsNowSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    (lightSessionsViewSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    [lightDeviceSessionModalSrc, lightDeviceSetupModalSrc, lightDevicesSrc, lightConditionsNowSrc, lightSessionsViewSrc]
+      .every(src => !src.includes('modal-overlay show') &&
+        !src.includes("this.closest('.modal-overlay').remove()") &&
+        !src.includes('overlay.remove()') &&
+        !src.includes('wireBackdropClose') &&
+        !src.includes('trapModalFocus')));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.481';
+self.APP_VERSION = '1.8.482';


### PR DESCRIPTION
## Summary
- migrate light device/session/setup/detail modals onto shared modal lifecycle helpers
- replace inline close handlers/direct overlay removal with scoped close callbacks
- extend lifecycle integration/static accessibility tests for the light device modal batch
- bump `version.js` for app-file cache invalidation

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-light-devices.js`
- `node tests/test-light-devices-store.js`
- `node tests/test-sync.js`
- `node tests/test-a11y-phase3.js`
- `npm run typecheck`
- `npm test`
- `npx playwright test tests/playwright/light-devices-browser-coverage.spec.js tests/playwright/modal-session-coverage-batch.spec.js tests/playwright/light-sessions-view-edge-browser-coverage.spec.js tests/playwright/all-sessions-modal.spec.js tests/playwright/light-conditions-now-browser-coverage.spec.js tests/playwright/light-coverage-batch-2.spec.js --project=chromium