### PR TITLE
[codex] Use modal lifecycle for sun session modals

### DIFF
--- a/js/sun-active-session.js
+++ b/js/sun-active-session.js
@@ -6,7 +6,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette } from './sun-body-silhouette.js';
 import { POSTURE_MULTIPLIERS, SURFACE_ALBEDO } from './sun-session-model.js';
 import { renderChannelChips } from './sun-session-ui.js';
@@ -139,11 +139,11 @@ export async function openStartSunSessionDialog() {
   let latestPreflightUvi = null;
 
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
   overlay.innerHTML = `<div class="modal sun-start-modal" role="dialog" aria-label="Start sun session">
     <div class="modal-header">
       <h3>Start a sun session</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button type="button" class="modal-close" data-sun-start-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       <div id="sun-start-uvi-banner" class="sun-start-uvi-banner" hidden></div>
@@ -200,14 +200,16 @@ export async function openStartSunSessionDialog() {
       </details>
 
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button type="button" class="import-btn import-btn-secondary" data-sun-start-close>Cancel</button>
         <button class="import-btn import-btn-primary" id="start-confirm">☀ Start session</button>
       </div>
     </div>
   </div>`;
-  wireBackdropClose(overlay);
-  document.body.appendChild(overlay);
-  trapModalFocus(overlay);
+  const closeDialog = () => removeModalOverlay(overlay);
+  overlay.querySelectorAll('[data-sun-start-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
+  });
+  openAppendedModalOverlay(overlay, closeDialog);
 
   const selected = new Set(lastRegions);
   const slot = overlay.querySelector('#sun-start-silhouette-slot');
@@ -261,7 +263,7 @@ export async function openStartSunSessionDialog() {
     }
     const coords = activeDeps.getSunCoords();
     const id = await activeDeps.startSession({ regions, eyeMode, lensTint, glassBetween, posture, surfaceAlbedo, rotatedSides, location: coords });
-    overlay.remove();
+    closeDialog();
     showNotification(_buildStartSessionToast({
       regionCount: regions.length,
       uvi: latestPreflightUvi,

--- a/js/sun-defaults.js
+++ b/js/sun-defaults.js
@@ -10,7 +10,7 @@
 
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
-import { trapModalFocus, wireBackdropClose } from './modal-lifecycle.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { SKIN_TYPE } from './constants.js';
 
@@ -496,11 +496,11 @@ function renderSetupEditor({ includeActions = true } = {}) {
 function openSunSetupOverlay() {
   if (typeof document === 'undefined') return;
   const existing = document.getElementById(LIGHT_SETUP_OVERLAY_ID);
-  if (existing) existing.remove();
+  if (existing) removeModalOverlay(existing);
 
   const overlay = document.createElement('div');
   overlay.id = LIGHT_SETUP_OVERLAY_ID;
-  overlay.className = 'modal-overlay show light-setup-focus-overlay';
+  overlay.className = 'modal-overlay light-setup-focus-overlay';
   overlay.innerHTML = `<div class="modal light-setup-focus-modal" data-setup-step="core" role="dialog" aria-modal="true" aria-labelledby="light-setup-focus-title">
     <header class="light-setup-focus-head">
       <div>
@@ -508,7 +508,7 @@ function openSunSetupOverlay() {
         <h3 id="light-setup-focus-title">Light setup</h3>
         <p>Calibrate burn math, indoor-light context, and circadian assumptions for this profile.</p>
       </div>
-      <button type="button" class="modal-close" aria-label="Close light setup" onclick="window.cancelReopenSunSetup && window.cancelReopenSunSetup()">&times;</button>
+      <button type="button" class="modal-close" aria-label="Close light setup" data-light-setup-close>&times;</button>
     </header>
     <div class="light-setup-focus-body" tabindex="-1">
       ${renderSetupEditor({ includeActions: false })}
@@ -516,9 +516,8 @@ function openSunSetupOverlay() {
     ${renderSetupActions()}
   </div>`;
 
-  try { wireBackdropClose(overlay, closeSunSetupOverlay); } catch (_) {}
-
-  document.body.appendChild(overlay);
+  overlay.querySelector('[data-light-setup-close]')?.addEventListener('click', closeSunSetupOverlay);
+  openAppendedModalOverlay(overlay, closeSunSetupOverlay);
 
   const obs = new MutationObserver(() => {
     if (!document.body.contains(overlay)) {
@@ -528,7 +527,6 @@ function openSunSetupOverlay() {
   });
   obs.observe(document.body, { childList: true, subtree: true });
 
-  try { trapModalFocus(overlay); } catch (_) {}
   setLightSetupStep('core', { focus: false });
   const focusBody = () => {
     const body = /** @type {HTMLElement | null} */ (overlay.querySelector('.light-setup-focus-body'));
@@ -545,7 +543,7 @@ function closeSunSetupOverlay() {
   const overlay = typeof document !== 'undefined'
     ? document.getElementById(LIGHT_SETUP_OVERLAY_ID)
     : null;
-  if (overlay) overlay.remove();
+  if (overlay) removeModalOverlay(overlay);
   _setupForceOpen = false;
 }
 

--- a/js/sun-session-actions.js
+++ b/js/sun-session-actions.js
@@ -2,6 +2,7 @@
 // sun-session-actions.js - delegated action contract for sun session UI.
 
 import { escapeAttr } from './utils.js';
+import { removeModalOverlay } from './modal-lifecycle.js';
 
 const sunSessionActionDelegateRoots = new WeakSet();
 const SUN_SESSION_KEYBOARD_ACTIONS = new Set([
@@ -32,7 +33,8 @@ function closestSunSessionAction(event) {
 }
 
 function closeContainingOverlay(actionEl) {
-  actionEl.closest('.modal-overlay')?.remove();
+  const overlay = actionEl.closest('.modal-overlay');
+  if (overlay) removeModalOverlay(overlay);
 }
 
 function handleSunSessionAction(actionEl, actions) {

--- a/js/sun-session-ui.js
+++ b/js/sun-session-ui.js
@@ -6,6 +6,7 @@
 
 import { state } from './state.js';
 import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette } from './sun-body-silhouette.js';
 import { installSunSessionActionDelegates, sunSessionActionAttrs } from './sun-session-actions.js';
 
@@ -18,8 +19,6 @@ import { installSunSessionActionDelegates, sunSessionActionAttrs } from './sun-s
  * @property {(id: any, coords?: any) => Promise<any>} hydrateSession
  * @property {() => any} getSunCoords
  * @property {() => void} refreshSurfaces
- * @property {(overlay: HTMLElement) => void} wireBackdropClose
- * @property {(overlay: HTMLElement) => void} trapModalFocus
  * @property {(sess: any) => string} summarizeBodyExposure
  * @property {(ms: number) => string} formatElapsed
  * @property {Array<{ key: string, label: string }>} exposurePresets
@@ -43,8 +42,6 @@ const uiDeps = {
   hydrateSession: async () => null,
   getSunCoords: () => null,
   refreshSurfaces: () => {},
-  wireBackdropClose: () => {},
-  trapModalFocus: () => {},
   summarizeBodyExposure: () => 'Body unset',
   formatElapsed: () => '0:00',
   exposurePresets: [],
@@ -324,7 +321,7 @@ export function openSunSessionDetail(id) {
     : 'Location not recorded';
 
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
   // Body summary — combine fraction + regions onto one line so the section
   // doesn't flag the percent as a label decoration. Also consolidate Eyes
   // + Modifiers into the same section when both fit cleanly.
@@ -411,9 +408,8 @@ export function openSunSessionDetail(id) {
       </div>
     </div>
   </div>`;
-  uiDeps.wireBackdropClose(overlay);
-  document.body.appendChild(overlay);
-  uiDeps.trapModalFocus(overlay);
+  const closeDialog = () => removeModalOverlay(overlay);
+  openAppendedModalOverlay(overlay, closeDialog);
   bindDetachedModalSyncRefresh({
     overlay,
     id,
@@ -519,7 +515,7 @@ export function renderChannelChips(doses, sess = null) {
 
 export function openDetailedSessionDialog() {
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
   const lastUsed = uiDeps.getSessions().filter(s => s.endedAt).slice(-1)[0];
   const eyeMode = lastUsed?.eyeExposure?.mode || 'direct';
   const lensTint = lastUsed?.eyeExposure?.lensTint || 'clear';
@@ -613,9 +609,8 @@ export function openDetailedSessionDialog() {
       </div>
     </div>
   </div>`;
-  uiDeps.wireBackdropClose(overlay);
-  document.body.appendChild(overlay);
-  uiDeps.trapModalFocus(overlay);
+  const closeDialog = () => removeModalOverlay(overlay);
+  openAppendedModalOverlay(overlay, closeDialog);
 
   const selected = new Set(lastRegions);
   const slot = overlay.querySelector('#sun-silhouette-slot');
@@ -713,7 +708,7 @@ export function openDetailedSessionDialog() {
       notes,
     });
     if (sessId) await uiDeps.hydrateSession(sessId);
-    overlay.remove();
+    closeDialog();
     showNotification(`Detailed session saved: ${durationMin} min, ${regions.length} regions.`);
     if (window.navigate && state.currentView === 'light') window.navigate('light');
   });

--- a/js/sun.js
+++ b/js/sun.js
@@ -15,7 +15,12 @@ import { escapeHTML, escapeAttr, showNotification, showPromptDialog, showConfirm
 import { saveImportedData } from './data.js';
 import { getProfileLocation } from './profile.js';
 import { COUNTRY_LATITUDES, COUNTRY_CENTROIDS } from './constants.js';
-import { wireBackdropClose as _wireBackdropClose, trapModalFocus } from './modal-lifecycle.js';
+import {
+  wireBackdropClose as _wireBackdropClose,
+  trapModalFocus,
+  openAppendedModalOverlay,
+  removeModalOverlay,
+} from './modal-lifecycle.js';
 import {
   BODY_REGIONS,
   renderBodySilhouette,
@@ -378,25 +383,27 @@ export async function changeCoverageMidSession(id) {
 
   const currentRegions = new Set(sess.bodyExposure?.regions || []);
   const overlay = document.createElement('div');
-  overlay.className = 'modal-overlay show';
+  overlay.className = 'modal-overlay';
   overlay.innerHTML = `<div class="modal sun-start-modal" role="dialog" aria-label="Change coverage">
     <div class="modal-header">
       <h3>Update coverage mid-session</h3>
-      <button class="modal-close" onclick="this.closest('.modal-overlay').remove()" aria-label="Close">×</button>
+      <button type="button" class="modal-close" data-sun-coverage-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       <p class="modal-body-hint">Tap each body region that's uncovered <strong>now</strong>. The dose accrued under the previous coverage stays — the change applies from this moment forward.</p>
       <div class="sun-silhouette-wrap" id="sun-coverage-silhouette-slot">${renderBodySilhouette(currentRegions)}</div>
       <div class="sun-silhouette-hint" id="sun-coverage-hint"></div>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="this.closest('.modal-overlay').remove()">Cancel</button>
+        <button type="button" class="import-btn import-btn-secondary" data-sun-coverage-close>Cancel</button>
         <button class="import-btn import-btn-primary" id="coverage-confirm">Apply coverage</button>
       </div>
     </div>
   </div>`;
-  _wireBackdropClose(overlay);
-  document.body.appendChild(overlay);
-  trapModalFocus(overlay);
+  const closeDialog = () => removeModalOverlay(overlay);
+  overlay.querySelectorAll('[data-sun-coverage-close]').forEach(btn => {
+    btn.addEventListener('click', closeDialog);
+  });
+  openAppendedModalOverlay(overlay, closeDialog);
 
   const selected = new Set(currentRegions);
   const slot = overlay.querySelector('#sun-coverage-silhouette-slot');
@@ -424,7 +431,7 @@ export async function changeCoverageMidSession(id) {
     const regions = Array.from(selected);
     const updated = await setSessionCoverage(id, regions);
     const fraction = updated?.bodyExposure?.fraction || 0;
-    overlay.remove();
+    closeDialog();
     if (!updated) return;
     showNotification(
       updated.bodyExposure?.regions?.length === 0
@@ -1051,8 +1058,6 @@ configureSunSessionUI({
   hydrateSession,
   getSunCoords,
   refreshSurfaces: _refreshSurfaces,
-  wireBackdropClose: _wireBackdropClose,
-  trapModalFocus,
   summarizeBodyExposure: _summarizeBodyExposure,
   formatElapsed: _formatElapsed,
   exposurePresets: EXPOSURE_PRESETS,

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -32,6 +32,11 @@ const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.j
 const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const settingsSyncPanelSrc = fs.readFileSync(path.join(root, 'js/settings-sync-panel.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
+const sunSrc = fs.readFileSync(path.join(root, 'js/sun.js'), 'utf8');
+const sunActiveSessionSrc = fs.readFileSync(path.join(root, 'js/sun-active-session.js'), 'utf8');
+const sunDefaultsSrc = fs.readFileSync(path.join(root, 'js/sun-defaults.js'), 'utf8');
+const sunSessionActionsSrc = fs.readFileSync(path.join(root, 'js/sun-session-actions.js'), 'utf8');
+const sunSessionUiSrc = fs.readFileSync(path.join(root, 'js/sun-session-ui.js'), 'utf8');
 const syncDiagnoseIdentitySrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-identity-actions.js'), 'utf8');
 const syncDiagnoseRenderSrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-render.js'), 'utf8');
 const syncDiagnoseUiSrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-ui.js'), 'utf8');
@@ -239,6 +244,27 @@ assert('light device and session modals use shared overlay lifecycle helpers',
         !src.includes("this.closest('.modal-overlay').remove()") &&
         !src.includes('overlay.remove()') &&
         !src.includes('wireBackdropClose') &&
+        !src.includes('trapModalFocus')));
+
+assert('sun session and setup modals use shared overlay lifecycle helpers',
+  sunSrc.includes('openAppendedModalOverlay') &&
+    sunSrc.includes('removeModalOverlay') &&
+    sunActiveSessionSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    sunDefaultsSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    sunSessionActionsSrc.includes("import { removeModalOverlay } from './modal-lifecycle.js';") &&
+    sunSessionUiSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    (sunSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    (sunActiveSessionSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    (sunDefaultsSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 1 &&
+    (sunSessionUiSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 2 &&
+    sunSessionActionsSrc.includes('removeModalOverlay(overlay)') &&
+    !sunSessionActionsSrc.includes("closest('.modal-overlay')?.remove()") &&
+    [sunSrc, sunActiveSessionSrc, sunDefaultsSrc, sunSessionUiSrc].every(src =>
+      !src.includes('modal-overlay show') &&
+        !src.includes("this.closest('.modal-overlay').remove()") &&
+        !src.includes('overlay.remove()')) &&
+    [sunActiveSessionSrc, sunDefaultsSrc, sunSessionUiSrc].every(src =>
+      !src.includes('wireBackdropClose') &&
         !src.includes('trapModalFocus')));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/tests/test-sun-session-ui-delegated-actions.js
+++ b/tests/test-sun-session-ui-delegated-actions.js
@@ -52,6 +52,10 @@ assert('sun-session-actions keyboard delegate supports role-button rows and igno
 assert('sun-session-actions expands chips via the owning chips container',
   actionSrc.includes("actionEl.closest('.sun-channel-chips')?.classList.toggle('sun-chips-expanded')") &&
     !actionSrc.includes("actionEl.parentElement?.classList.toggle('sun-chips-expanded')"));
+assert('sun-session-actions closes overlays through the shared lifecycle removal helper',
+  actionSrc.includes("import { removeModalOverlay } from './modal-lifecycle.js';") &&
+    actionSrc.includes('removeModalOverlay(overlay)') &&
+    !actionSrc.includes("closest('.modal-overlay')?.remove()"));
 assert('sun-session-ui direct module actions no longer route through window globals',
   !uiSrc.includes('window.openSunSessionDetail') &&
     !uiSrc.includes('window.deleteSunSession') &&

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -247,9 +247,11 @@ return (async function() {
   assert('modal-lifecycle.js owns modal backdrop and focus helpers',
     /export function wireBackdropClose/.test(modalLifecycleSrc)
       && /export function trapModalFocus/.test(modalLifecycleSrc));
-  assert('sun-active-session.js imports shared modal lifecycle helpers',
+  assert('sun-active-session.js opens through shared appended modal lifecycle helpers',
     /from '\.\/modal-lifecycle\.js'/.test(sunActiveSrc)
-      && /wireBackdropClose\s*\(/.test(sunActiveSrc));
+      && /openAppendedModalOverlay\(overlay/.test(sunActiveSrc)
+      && /removeModalOverlay\(overlay\)/.test(sunActiveSrc)
+      && !/wireBackdropClose\s*\(/.test(sunActiveSrc));
   {
     const globalModalDeps = [];
     for (const file of [

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.482';
+self.APP_VERSION = '1.8.483';


### PR DESCRIPTION
## Summary
- Move sun start, coverage, session detail, detailed log, and setup overlays onto the shared modal lifecycle helpers.
- Route delegated sun modal close actions through `removeModalOverlay` so lifecycle close/teardown behavior is consistent.
- Add static guards for the migrated sun modal paths and bump `version.js` for cache invalidation.

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-sun-session-ui-delegated-actions.js`
- `node tests/test-audit.js`
- `npm run typecheck`
- `npm test`
- `git diff --check`
- `./run-tests.sh`