### PR TITLE
[codex] Use modal lifecycle for report and picker modals

### DIFF
--- a/js/dashboard-widget-controls.js
+++ b/js/dashboard-widget-controls.js
@@ -3,6 +3,7 @@
 
 import { DASHBOARD_WIDGET_SOURCE_ORDER, dashboardBiometricSelectionKey } from './dashboard-widgets.js';
 import { escapeAttr, escapeHTML, formatValue, getStatus, safeMarkerId, showNotification } from './utils.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 const DASHBOARD_WIDGET_KEYBOARD_ACTIONS = new Set([
   'open-biometric-manual-log',
@@ -494,6 +495,15 @@ export function createDashboardWidgetControls(deps) {
     rerenderDashboardFromWidgetChange();
   }
 
+  function openDashboardWidgetPickerOverlay(html, options = {}) {
+    const template = document.createElement('template');
+    template.innerHTML = html.trim();
+    const overlay = template.content.firstElementChild;
+    if (!(overlay instanceof HTMLElement)) return null;
+    openAppendedModalOverlay(overlay, closeDashboardWidgetPicker, options);
+    return overlay;
+  }
+
   function openDashboardWidgetPicker() {
     closeDashboardWidgetPicker();
     const prefs = getDashboardWidgetPrefs();
@@ -503,8 +513,8 @@ export function createDashboardWidgetControls(deps) {
     const biometricList = biometricOptions.length ? biometricOptions.map(renderDashboardBiometricWidgetOption).join('') : '';
     const markerOptions = getDashboardMarkerWidgetOptions(getActiveData(), prefs);
     const markerList = markerOptions.length ? markerOptions.map(renderDashboardMarkerWidgetOption).join('') : '';
-    document.body.insertAdjacentHTML('beforeend', `<div class="modal-overlay show" id="dashboard-widget-picker-overlay" data-dashboard-widget-overlay>
-      <div class="modal show dashboard-widget-picker" role="dialog" aria-modal="true" aria-labelledby="dashboard-widget-picker-title">
+    openDashboardWidgetPickerOverlay(`<div class="modal-overlay" id="dashboard-widget-picker-overlay" data-dashboard-widget-overlay>
+      <div class="modal dashboard-widget-picker" role="dialog" aria-modal="true" aria-labelledby="dashboard-widget-picker-title">
         <button class="modal-close" aria-label="Close" ${dashboardWidgetActionAttrs('close-picker')}>&times;</button>
         <h3 id="dashboard-widget-picker-title">Add dashboard widget</h3>
         <div class="dashboard-widget-picker-section">
@@ -536,8 +546,8 @@ export function createDashboardWidgetControls(deps) {
     const prefs = getDashboardWidgetPrefs();
     const biometricOptions = getDashboardBiometricWidgetOptions(prefs);
     const biometricList = biometricOptions.length ? biometricOptions.map(renderDashboardBiometricWidgetOption).join('') : '';
-    document.body.insertAdjacentHTML('beforeend', `<div class="modal-overlay show" id="dashboard-widget-picker-overlay" data-dashboard-widget-overlay>
-      <div class="modal show dashboard-widget-picker dashboard-biometric-picker" role="dialog" aria-modal="true" aria-labelledby="dashboard-biometric-picker-title">
+    openDashboardWidgetPickerOverlay(`<div class="modal-overlay" id="dashboard-widget-picker-overlay" data-dashboard-widget-overlay>
+      <div class="modal dashboard-widget-picker dashboard-biometric-picker" role="dialog" aria-modal="true" aria-labelledby="dashboard-biometric-picker-title">
         <button class="modal-close" aria-label="Close" ${dashboardWidgetActionAttrs('close-picker')}>&times;</button>
         <h3 id="dashboard-biometric-picker-title">Add biometric metrics</h3>
         <div class="dashboard-widget-picker-section">
@@ -550,12 +560,12 @@ export function createDashboardWidgetControls(deps) {
           <button type="button" class="dashboard-action-btn" ${dashboardWidgetActionAttrs('connect-source')}>Connect source</button>
         </div>
       </div>
-    </div>`);
-    setTimeout(() => document.getElementById('dashboard-biometric-widget-search')?.focus(), 0);
+    </div>`, { initialFocus: '#dashboard-biometric-widget-search', focusDelay: 50 });
   }
 
   function closeDashboardWidgetPicker() {
-    document.getElementById('dashboard-widget-picker-overlay')?.remove();
+    const overlay = document.getElementById('dashboard-widget-picker-overlay');
+    if (overlay) removeModalOverlay(overlay);
   }
 
   function startDashboardWidgetDrag(event, id, dragEl = event.currentTarget) {

--- a/js/export-report-builder.js
+++ b/js/export-report-builder.js
@@ -4,6 +4,7 @@
 import { getActiveData } from './data.js';
 import { getAllFlaggedMarkers } from './marker-analysis.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import {
   DEFAULT_REPORT_PRESET,
   REPORT_BUILDER_OVERLAY_ID,
@@ -101,8 +102,8 @@ function renderReportBuilder(presetId = DEFAULT_REPORT_PRESET) {
     `<option value="${escapeAttr(option.value)}" ${preset.dateRange === option.value ? 'selected' : ''}>${escapeHTML(option.label)}</option>`
   ).join('');
 
-  return `<div class="modal-overlay show" id="${REPORT_BUILDER_OVERLAY_ID}" data-report-builder-overlay data-report-preset="${escapeAttr(presetId)}">
-    <div class="modal show gb-form-modal report-builder-modal" role="dialog" aria-modal="true" aria-labelledby="report-builder-title">
+  return `<div class="modal-overlay" id="${REPORT_BUILDER_OVERLAY_ID}" data-report-builder-overlay data-report-preset="${escapeAttr(presetId)}">
+    <div class="modal gb-form-modal report-builder-modal" role="dialog" aria-modal="true" aria-labelledby="report-builder-title">
       <div class="gb-modal-head">
         <div>
           <div class="gb-modal-kicker">Export</div>
@@ -323,13 +324,14 @@ export function openReportBuilder(presetId = DEFAULT_REPORT_PRESET) {
   const normalizedPresetId = REPORT_PRESETS[presetId] ? presetId : DEFAULT_REPORT_PRESET;
   closeReportBuilder();
   installReportBuilderDelegates();
-  document.body.insertAdjacentHTML('beforeend', renderReportBuilder(normalizedPresetId));
-  setTimeout(() => {
-    const activePreset = /** @type {HTMLElement | null} */ (document.querySelector(`#${REPORT_BUILDER_OVERLAY_ID} .report-preset-btn.active`));
-    activePreset?.focus();
-  }, 0);
+  const template = document.createElement('template');
+  template.innerHTML = renderReportBuilder(normalizedPresetId).trim();
+  const overlay = template.content.firstElementChild;
+  if (!(overlay instanceof HTMLElement)) return;
+  openAppendedModalOverlay(overlay, closeReportBuilder, { initialFocus: '.report-preset-btn.active', focusDelay: 50 });
 }
 
 export function closeReportBuilder() {
-  document.getElementById(REPORT_BUILDER_OVERLAY_ID)?.remove();
+  const overlay = document.getElementById(REPORT_BUILDER_OVERLAY_ID);
+  if (overlay) removeModalOverlay(overlay);
 }

--- a/js/profile-share.js
+++ b/js/profile-share.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { getProfiles } from './profile.js';
 import { buildClientExportObject, importDataJSON } from './export.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 export const PROFILE_SHARE_SCHEMA = 'getbased-profile-share';
 export const PROFILE_SHARE_VERSION = 1;
@@ -540,21 +541,24 @@ function renderLoadShareBody(id) {
 
 function renderProfileShareShell({ title, kicker = 'Share Profile', body }) {
   closeProfileShareModal();
-  document.body.insertAdjacentHTML('beforeend', `
-    <div class="modal-overlay show" id="${SHARE_OVERLAY_ID}">
+  const template = document.createElement('template');
+  template.innerHTML = `
+    <div class="modal-overlay" id="${SHARE_OVERLAY_ID}">
       <div class="modal gb-form-modal profile-share-modal" role="dialog" aria-modal="true" aria-label="${escapeAttr(title)}">
         <div class="gb-modal-head">
           <div>
             <div class="gb-modal-kicker">${escapeHTML(kicker)}</div>
             <div class="gb-modal-title">${escapeHTML(title)}</div>
           </div>
-          <button class="modal-close" aria-label="Close" data-profile-share-action="close">&times;</button>
+          <button type="button" class="modal-close" aria-label="Close" data-profile-share-action="close">&times;</button>
         </div>
         ${body}
       </div>
     </div>
-  `);
-  const overlay = document.getElementById(SHARE_OVERLAY_ID);
+  `.trim();
+  const overlay = template.content.firstElementChild;
+  if (!(overlay instanceof HTMLElement)) return;
+  openAppendedModalOverlay(overlay, closeProfileShareModal);
   installProfileShareDelegates(overlay);
   const firstControl = /** @type {HTMLElement | null} */ (overlay?.querySelector('input, button, select'));
   firstControl?.focus();
@@ -568,7 +572,8 @@ export function openProfileShareModal(profileId = state.currentProfile) {
 }
 
 export function closeProfileShareModal() {
-  document.getElementById(SHARE_OVERLAY_ID)?.remove();
+  const overlay = document.getElementById(SHARE_OVERLAY_ID);
+  if (overlay) removeModalOverlay(overlay);
 }
 
 export function openSharedProfileImportModal(id) {

--- a/js/profile-share.js
+++ b/js/profile-share.js
@@ -560,8 +560,6 @@ function renderProfileShareShell({ title, kicker = 'Share Profile', body }) {
   if (!(overlay instanceof HTMLElement)) return;
   openAppendedModalOverlay(overlay, closeProfileShareModal);
   installProfileShareDelegates(overlay);
-  const firstControl = /** @type {HTMLElement | null} */ (overlay?.querySelector('input, button, select'));
-  firstControl?.focus();
 }
 
 export function openProfileShareModal(profileId = state.currentProfile) {

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -13,7 +13,9 @@ const contextCardsSrc = fs.readFileSync(path.join(root, 'js/context-cards.js'), 
 const contextLifestyleSrc = fs.readFileSync(path.join(root, 'js/context-card-lifestyle-editors.js'), 'utf8');
 const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medical-history-editor.js'), 'utf8');
 const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
+const dashboardWidgetControlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
+const exportReportBuilderSrc = fs.readFileSync(path.join(root, 'js/export-report-builder.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lightConditionsNowSrc = fs.readFileSync(path.join(root, 'js/light-conditions-now.js'), 'utf8');
 const lightDeviceSessionModalSrc = fs.readFileSync(path.join(root, 'js/light-device-session-modal.js'), 'utf8');
@@ -26,6 +28,7 @@ const lightToolsSrc = fs.readFileSync(path.join(root, 'js/light-tools.js'), 'utf
 const modalLifecycleSrc = fs.readFileSync(path.join(root, 'js/modal-lifecycle.js'), 'utf8');
 const markerDetailSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
+const profileShareSrc = fs.readFileSync(path.join(root, 'js/profile-share.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
 const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.js'), 'utf8');
@@ -266,6 +269,20 @@ assert('sun session and setup modals use shared overlay lifecycle helpers',
     [sunActiveSessionSrc, sunDefaultsSrc, sunSessionUiSrc].every(src =>
       !src.includes('wireBackdropClose') &&
         !src.includes('trapModalFocus')));
+
+assert('report builder, profile share, and dashboard widget picker use shared overlay lifecycle helpers',
+  exportReportBuilderSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    profileShareSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    dashboardWidgetControlsSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    exportReportBuilderSrc.includes("openAppendedModalOverlay(overlay, closeReportBuilder, { initialFocus: '.report-preset-btn.active', focusDelay: 50 })") &&
+    profileShareSrc.includes('openAppendedModalOverlay(overlay, closeProfileShareModal)') &&
+    dashboardWidgetControlsSrc.includes('openAppendedModalOverlay(overlay, closeDashboardWidgetPicker, options)') &&
+    dashboardWidgetControlsSrc.includes("initialFocus: '#dashboard-biometric-widget-search', focusDelay: 50") &&
+    [exportReportBuilderSrc, profileShareSrc, dashboardWidgetControlsSrc].every(src =>
+      !src.includes('modal-overlay show') &&
+        !src.includes('modal show') &&
+        !src.includes('insertAdjacentHTML') &&
+        !src.includes('?.remove()')));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.483';
+self.APP_VERSION = '1.8.484';


### PR DESCRIPTION
## Summary
- migrate the report builder, profile share modal, and dashboard widget pickers to the shared modal lifecycle helpers
- remove static `show` overlay/modal classes and direct `insertAdjacentHTML`/remove paths for these modals
- extend the modal lifecycle integration guard and bump `version.js` for cache invalidation

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-dashboard-widget-delegated-actions.js`
- `node tests/test-crypto.js`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npx playwright test tests/playwright/report-export-browser-coverage.spec.js tests/playwright/profile-share-browser-coverage.spec.js tests/playwright/profile-share-load-browser-coverage.spec.js tests/playwright/dashboard-widget-controls-browser-coverage.spec.js tests/playwright/dashboard-widget-delegated-actions-dom.spec.js --project=chromium`