### PR TITLE
[codex] Use modal lifecycle for PDF import overlays

### DIFF
--- a/js/pdf-import-review.js
+++ b/js/pdf-import-review.js
@@ -12,6 +12,7 @@ import {
   getActiveModelDisplay,
   getOllamaPIIModel,
 } from './api.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { buildMarkerReference, normalizeToSI } from './pdf-import-marker-mapping.js';
 
 function clearPendingImport() {
@@ -25,7 +26,7 @@ function restoreDropZoneVisibility() {
 }
 
 function hideImportOverlay() {
-  document.getElementById('import-modal-overlay')?.classList.remove('show');
+  closeModalOverlay('import-modal-overlay');
 }
 
 export function getPendingImport() {
@@ -212,7 +213,7 @@ export function showImportPreview(parseResult) {
   window._pendingImport = parseResult;
   window._pendingImportRefLookup = refLookup;
   modal.innerHTML = html;
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
   applyImportReviewFilters();
 }
 

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -186,7 +186,6 @@ export function showAINeededDialog(action = 'import') {
   };
   document.getElementById('ai-needed-cancel').onclick = close;
   overlay.onclick = (e) => { if (e.target === overlay) close(); };
-  document.getElementById('ai-needed-or').focus();
 }
 
 // ═══════════════════════════════════════════════

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -11,6 +11,7 @@ import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
 import { setLabEntryMarker, syncLabEntryInsulinMirror } from './lab-entry.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { runPreflightChecks } from './pdf-import-preflight.js';
 import { normalizeParsedImportMarkers } from './pdf-import-marker-normalization.js';
 import {
@@ -172,8 +173,8 @@ export function showAINeededDialog(action = 'import') {
       <button class="confirm-btn confirm-btn-cancel" id="ai-needed-cancel">Not now</button>
     </div>
   </div>`;
-  overlay.classList.add('show');
-  const close = () => overlay.classList.remove('show');
+  openModalOverlay(overlay, { initialFocus: '#ai-needed-or', focusDelay: 50 });
+  const close = () => closeModalOverlay(overlay);
   document.getElementById('ai-needed-or').onclick = () => { close(); if (pdfImportWindow.startOpenRouterOAuth) pdfImportWindow.startOpenRouterOAuth(); };
   document.getElementById('ai-needed-key').onclick = () => { close(); if (pdfImportWindow.openSettingsModal) pdfImportWindow.openSettingsModal('ai'); };
   document.getElementById('ai-needed-demo').onclick = () => {
@@ -797,19 +798,25 @@ async function _showImageModeDialog() {
         <button class="btn" style="padding:7px 16px;border-radius:6px;border:1px solid var(--border);background:var(--bg-card);color:var(--text-primary);cursor:pointer">Try text anyway</button>
         <button class="btn" style="padding:7px 16px;border-radius:6px;border:none;background:var(--accent-gradient);color:white;cursor:pointer;font-weight:500">Use image mode</button>
       </div>`;
-    const onKey = (e) => { if (e.key === 'Escape') { overlay.classList.remove('show'); resolve('cancel'); } };
+    let settled = false;
+    const closeWithChoice = (choice) => {
+      if (settled) return;
+      settled = true;
+      document.removeEventListener('keydown', onKey);
+      closeModalOverlay(overlay);
+      resolve(choice);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') closeWithChoice('cancel'); };
     document.addEventListener('keydown', onKey, { once: true });
     dialog.querySelectorAll('button').forEach(btn => {
       btn.addEventListener('click', () => {
-        document.removeEventListener('keydown', onKey);
         const action = btn.textContent.trim();
-        overlay.classList.remove('show');
-        if (action === 'Cancel') resolve('cancel');
-        else if (action === 'Try text anyway') resolve('text');
-        else resolve('image');
+        if (action === 'Cancel') closeWithChoice('cancel');
+        else if (action === 'Try text anyway') closeWithChoice('text');
+        else closeWithChoice('image');
       }, { once: true });
     });
-    overlay.classList.add('show');
+    openModalOverlay(overlay, { initialFocus: 'button', focusDelay: 50 });
   });
 }
 

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -27,7 +27,9 @@ const lightToolCameraModalsSrc = fs.readFileSync(path.join(root, 'js/light-tool-
 const lightToolsSrc = fs.readFileSync(path.join(root, 'js/light-tools.js'), 'utf8');
 const modalLifecycleSrc = fs.readFileSync(path.join(root, 'js/modal-lifecycle.js'), 'utf8');
 const markerDetailSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
+const pdfImportSrc = fs.readFileSync(path.join(root, 'js/pdf-import.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
+const pdfImportReviewSrc = fs.readFileSync(path.join(root, 'js/pdf-import-review.js'), 'utf8');
 const profileShareSrc = fs.readFileSync(path.join(root, 'js/profile-share.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
@@ -283,6 +285,19 @@ assert('report builder, profile share, and dashboard widget picker use shared ov
         !src.includes('modal show') &&
         !src.includes('insertAdjacentHTML') &&
         !src.includes('?.remove()')));
+
+assert('PDF import dialogs and review modal use shared overlay lifecycle helpers',
+  pdfImportSrc.includes("import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';") &&
+    pdfImportReviewSrc.includes("import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';") &&
+    pdfImportSrc.includes("openModalOverlay(overlay, { initialFocus: '#ai-needed-or', focusDelay: 50 })") &&
+    pdfImportSrc.includes("openModalOverlay(overlay, { initialFocus: 'button', focusDelay: 50 })") &&
+    (pdfImportSrc.match(/closeModalOverlay\(overlay\)/g) || []).length >= 2 &&
+    pdfImportReviewSrc.includes("closeModalOverlay('import-modal-overlay')") &&
+    pdfImportReviewSrc.includes('openModalOverlay(overlay)') &&
+    [pdfImportSrc, pdfImportReviewSrc].every(src =>
+      !src.includes("overlay.classList.add('show')") &&
+        !src.includes("overlay.classList.remove('show')") &&
+        !src.includes("document.getElementById('import-modal-overlay')?.classList.remove('show')")));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -297,7 +297,8 @@ assert('PDF import dialogs and review modal use shared overlay lifecycle helpers
     [pdfImportSrc, pdfImportReviewSrc].every(src =>
       !src.includes("overlay.classList.add('show')") &&
         !src.includes("overlay.classList.remove('show')") &&
-        !src.includes("document.getElementById('import-modal-overlay')?.classList.remove('show')")));
+        !src.includes("document.getElementById('import-modal-overlay')?.classList.remove('show')")) &&
+    !pdfImportSrc.includes("document.getElementById('ai-needed-or').focus()"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.484';
+self.APP_VERSION = '1.8.485';


### PR DESCRIPTION
## Summary
- migrate PDF import review, AI-needed, and scanned-PDF choice overlays to `openModalOverlay` / `closeModalOverlay`
- preserve the existing static overlay DOM and confirm-dialog behavior while centralizing show/hide lifecycle handling
- extend the modal lifecycle source guard and bump `version.js` for cache invalidation

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-unit-import.js`
- `node tests/test-audit.js`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npx playwright test tests/playwright/import-review-browser-coverage.spec.js tests/playwright/pdf-import-browser-coverage.spec.js --project=chromium`
- `./run-tests.sh`