### PR TITLE
[codex] Use modal lifecycle for chat image lightbox

### DIFF
--- a/js/chat-images.js
+++ b/js/chat-images.js
@@ -14,6 +14,7 @@
 import { escapeHTML, showNotification } from './utils.js';
 import { resizeImage, isValidImageType } from './image-utils.js';
 import { hasAIProvider, supportsVision } from './api.js';
+import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 const MAX_ATTACHMENTS = 5;
 const THUMB_SIZE = 80;
@@ -121,10 +122,22 @@ export function openImageLightbox(src) {
   img.src = src;
   img.alt = 'Full image';
   overlay.appendChild(img);
-  overlay.addEventListener('click', () => overlay.remove());
-  const close = (e) => { if (e.key === 'Escape') { overlay.remove(); document.removeEventListener('keydown', close); } };
-  document.addEventListener('keydown', close);
-  document.body.appendChild(overlay);
+  let closed = false;
+  const closeLightbox = () => {
+    if (closed) return;
+    closed = true;
+    document.removeEventListener('keydown', onKeydown);
+    removeModalOverlay(overlay);
+  };
+  const onKeydown = (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeLightbox();
+    }
+  };
+  overlay.addEventListener('click', closeLightbox);
+  document.addEventListener('keydown', onKeydown);
+  openAppendedModalOverlay(overlay, closeLightbox);
 }
 
 export function clearAttachments() {

--- a/js/chat-images.js
+++ b/js/chat-images.js
@@ -14,7 +14,7 @@
 import { escapeHTML, showNotification } from './utils.js';
 import { resizeImage, isValidImageType } from './image-utils.js';
 import { hasAIProvider, supportsVision } from './api.js';
-import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 const MAX_ATTACHMENTS = 5;
 const THUMB_SIZE = 80;
@@ -137,7 +137,8 @@ export function openImageLightbox(src) {
   };
   overlay.addEventListener('click', closeLightbox);
   document.addEventListener('keydown', onKeydown);
-  openAppendedModalOverlay(overlay, closeLightbox);
+  document.body.appendChild(overlay);
+  openModalOverlay(overlay);
 }
 
 export function clearAttachments() {

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -110,10 +110,10 @@ assert('chat summary modal participates in global keyboard modal handling',
   appEventsSrc.includes('"summary-modal-overlay"') &&
     appEventsSrc.includes('window.closeSummaryModal?.()'));
 
-assert('chat image lightbox uses shared appended overlay lifecycle helpers',
-  chatImagesSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+assert('chat image lightbox uses shared overlay lifecycle helpers',
+  chatImagesSrc.includes("import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
     chatImagesSrc.includes("overlay.className = 'chat-lightbox'") &&
-    chatImagesSrc.includes('openAppendedModalOverlay(overlay, closeLightbox)') &&
+    chatImagesSrc.includes('openModalOverlay(overlay)') &&
     chatImagesSrc.includes('removeModalOverlay(overlay)') &&
     !chatImagesSrc.includes('overlay.remove()'));
 

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
+const chatImagesSrc = fs.readFileSync(path.join(root, 'js/chat-images.js'), 'utf8');
 const chatSummariesSrc = fs.readFileSync(path.join(root, 'js/chat-summaries.js'), 'utf8');
 const contextCardsSrc = fs.readFileSync(path.join(root, 'js/context-cards.js'), 'utf8');
 const contextLifestyleSrc = fs.readFileSync(path.join(root, 'js/context-card-lifestyle-editors.js'), 'utf8');
@@ -108,6 +109,13 @@ assert('chat summary modal uses shared overlay lifecycle helpers',
 assert('chat summary modal participates in global keyboard modal handling',
   appEventsSrc.includes('"summary-modal-overlay"') &&
     appEventsSrc.includes('window.closeSummaryModal?.()'));
+
+assert('chat image lightbox uses shared appended overlay lifecycle helpers',
+  chatImagesSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    chatImagesSrc.includes("overlay.className = 'chat-lightbox'") &&
+    chatImagesSrc.includes('openAppendedModalOverlay(overlay, closeLightbox)') &&
+    chatImagesSrc.includes('removeModalOverlay(overlay)') &&
+    !chatImagesSrc.includes('overlay.remove()'));
 
 assert('card tips modal closes through shared detail modal close path',
   recommendationsSrc.includes('onclick="window.closeModal()"') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.485';
+self.APP_VERSION = '1.8.486';


### PR DESCRIPTION
## Summary
- migrate the chat image lightbox show/close path to `openModalOverlay` / `removeModalOverlay`
- preserve the existing click-anywhere and Escape close behavior with an idempotent close path
- add a modal lifecycle static guard and bump `version.js` for cache invalidation

## Validation
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-image-utils.js`
- `git diff --check`
- `npx playwright test tests/playwright/chat-ui-browser-coverage.spec.js --project=chromium`
- `npm run typecheck`
- `npm test`