### PR TITLE
[codex] Use modal lifecycle for PII overlays

### DIFF
--- a/js/modal-lifecycle.js
+++ b/js/modal-lifecycle.js
@@ -142,9 +142,10 @@ function _pruneDetachedModalScrollLocks() {
   }
 }
 
-export function trapModalFocus(overlay) {
+export function trapModalFocus(overlay, options = {}) {
   _pruneDetachedModalScrollLocks();
   const previouslyFocused = document.activeElement;
+  const closeOnEscape = options.closeOnEscape !== false;
   if (_modalScrollLocks.size === 0) {
     _modalScrollState.priorOverflow = document.body.style.overflow;
   }
@@ -159,7 +160,7 @@ export function trapModalFocus(overlay) {
     if (firstFocusable) try { firstFocusable.focus(); } catch (e) {}
   }, 30);
   const onKeydown = (e) => {
-    if (e.key === 'Escape' && document.body.contains(overlay)) {
+    if (closeOnEscape && e.key === 'Escape' && document.body.contains(overlay)) {
       e.preventDefault();
       try { overlay.remove(); } catch (_) {}
     }

--- a/js/pii.js
+++ b/js/pii.js
@@ -4,7 +4,7 @@
 import { showNotification, escapeHTML } from './utils.js';
 import { getOllamaPIIModel, getOllamaPIIUrl } from './api.js';
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
-import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
 import { state } from './state.js';
 
 // ═══════════════════════════════════════════════
@@ -525,12 +525,14 @@ export function buildPIIDiffHTML(originalText, obfuscatedText) {
 
 function openPIIOverlay(overlay, options = {}) {
   document.body.appendChild(overlay);
-  document.body.style.overflow = 'hidden';
-  openModalOverlay(overlay, options);
+  requestAnimationFrame(() => {
+    if (!overlay.isConnected) return;
+    openModalOverlay(overlay, options);
+    try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}
+  });
 }
 
 function closePIIOverlay(overlay) {
-  document.body.style.overflow = '';
   removeModalOverlay(overlay);
 }
 

--- a/js/pii.js
+++ b/js/pii.js
@@ -4,6 +4,7 @@
 import { showNotification, escapeHTML } from './utils.js';
 import { getOllamaPIIModel, getOllamaPIIUrl } from './api.js';
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
+import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { state } from './state.js';
 
 // ═══════════════════════════════════════════════
@@ -522,25 +523,37 @@ export function buildPIIDiffHTML(originalText, obfuscatedText) {
   return { leftHtml, rightHtml };
 }
 
+function openPIIOverlay(overlay, options = {}) {
+  document.body.appendChild(overlay);
+  document.body.style.overflow = 'hidden';
+  openModalOverlay(overlay, options);
+}
+
+function closePIIOverlay(overlay) {
+  document.body.style.overflow = '';
+  removeModalOverlay(overlay);
+}
+
 export function showPIIDiffViewer(originalText, obfuscatedText) {
   const overlay = document.createElement('div');
   overlay.className = 'pii-warning-overlay';
   const { leftHtml, rightHtml } = buildPIIDiffHTML(originalText, obfuscatedText);
   overlay.innerHTML = `
     <div class="pii-diff-modal" role="dialog" aria-modal="true" aria-label="Privacy Diff">
-      <button type="button" class="modal-close" onclick="document.body.style.overflow='';this.closest('.pii-warning-overlay').remove()" aria-label="Close privacy diff">&times;</button>
+      <button type="button" class="modal-close" aria-label="Close privacy diff">&times;</button>
       <h3>&#128269; Privacy Diff — Before / After</h3>
       <div class="pii-diff-viewer">
         <div class="pii-diff-left"><div class="pii-diff-header">Original</div>${leftHtml}</div>
         <div class="pii-diff-right"><div class="pii-diff-header">Obfuscated</div>${rightHtml}</div>
       </div>
       <div class="pii-review-actions pii-review-actions-simple">
-        <button type="button" class="import-btn import-btn-secondary" onclick="document.body.style.overflow='';this.closest('.pii-warning-overlay').remove()">Close</button>
+        <button type="button" class="import-btn import-btn-secondary" data-pii-diff-close>Close</button>
       </div>
     </div>`;
-  document.body.appendChild(overlay);
-  document.body.style.overflow = 'hidden';
-  requestAnimationFrame(() => overlay.classList.add('show'));
+  const close = () => closePIIOverlay(overlay);
+  overlay.querySelector('.modal-close')?.addEventListener('click', close);
+  overlay.querySelector('[data-pii-diff-close]')?.addEventListener('click', close);
+  openPIIOverlay(overlay);
 }
 
 // extractPatientName dropped — too unreliable across PDF layouts
@@ -600,10 +613,8 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
           <button type="button" class="import-btn import-btn-primary" id="pii-review-send"${isStreaming ? ' disabled' : ''}>Send to AI</button>
         </div>
       </div>`;
-    document.body.appendChild(overlay);
-    document.body.style.overflow = 'hidden';
     wirePIIOverlayNudge(overlay);
-    requestAnimationFrame(() => overlay.classList.add('show'));
+    openPIIOverlay(overlay);
 
     const searchInput = /** @type {HTMLInputElement} */ (overlay.querySelector('#pii-search-input'));
     const searchCount = /** @type {HTMLElement} */ (overlay.querySelector('#pii-search-count'));
@@ -715,12 +726,11 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
     });
 
     // Send & cancel
-    sendBtn.addEventListener('click', () => { document.body.style.overflow = ''; overlay.remove(); resolve(textarea.value); });
+    sendBtn.addEventListener('click', () => { closePIIOverlay(overlay); resolve(textarea.value); });
     /** @type {HTMLButtonElement} */ (overlay.querySelector('#pii-review-cancel')).addEventListener('click', () => {
       if (abortController) abortController.abort();
       unloadOllamaPIIModel();
-      document.body.style.overflow = '';
-      overlay.remove();
+      closePIIOverlay(overlay);
       resolve('cancel');
     });
 
@@ -728,15 +738,13 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
     let abortController = null;
     if (isStreaming) {
       if (!statusEl || !stopBtn) {
-        document.body.style.overflow = '';
-        overlay.remove();
+        closePIIOverlay(overlay);
         resolve('cancel');
         return;
       }
       const retryBtn = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#pii-stream-retry'));
       if (!retryBtn) {
-        document.body.style.overflow = '';
-        overlay.remove();
+        closePIIOverlay(overlay);
         resolve('cancel');
         return;
       }

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -31,6 +31,7 @@ const markerDetailSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.
 const pdfImportSrc = fs.readFileSync(path.join(root, 'js/pdf-import.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
 const pdfImportReviewSrc = fs.readFileSync(path.join(root, 'js/pdf-import-review.js'), 'utf8');
+const piiSrc = fs.readFileSync(path.join(root, 'js/pii.js'), 'utf8');
 const profileShareSrc = fs.readFileSync(path.join(root, 'js/profile-share.js'), 'utf8');
 const providerPanelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
 const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendation-actions.js'), 'utf8');
@@ -307,6 +308,16 @@ assert('PDF import dialogs and review modal use shared overlay lifecycle helpers
         !src.includes("overlay.classList.remove('show')") &&
         !src.includes("document.getElementById('import-modal-overlay')?.classList.remove('show')")) &&
     !pdfImportSrc.includes("document.getElementById('ai-needed-or').focus()"));
+
+assert('PII diff and review overlays use shared overlay lifecycle helpers',
+  piiSrc.includes("import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+    piiSrc.includes('function openPIIOverlay(overlay, options = {})') &&
+    piiSrc.includes('openModalOverlay(overlay, options)') &&
+    piiSrc.includes('function closePIIOverlay(overlay)') &&
+    (piiSrc.match(/closePIIOverlay\(overlay\)/g) || []).length >= 5 &&
+    !piiSrc.includes("overlay.classList.add('show')") &&
+    !piiSrc.includes('overlay.remove()') &&
+    !piiSrc.includes("this.closest('.pii-warning-overlay').remove()"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -230,6 +230,8 @@ assert('light environment assessment uses shared overlay lifecycle before remova
 assert('light tool modals use shared overlay lifecycle helpers',
   modalLifecycleSrc.includes('export function openAppendedModalOverlay') &&
     modalLifecycleSrc.includes('export function removeModalOverlay') &&
+    modalLifecycleSrc.includes('const closeOnEscape = options.closeOnEscape !== false;') &&
+    modalLifecycleSrc.includes("if (closeOnEscape && e.key === 'Escape'") &&
     lightToolCameraModalsSrc.includes("import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
     (lightToolCameraModalsSrc.match(/openAppendedModalOverlay\(overlay/g) || []).length >= 6 &&
     (lightToolCameraModalsSrc.match(/removeModalOverlay\(overlay\)/g) || []).length >= 6 &&
@@ -310,11 +312,16 @@ assert('PDF import dialogs and review modal use shared overlay lifecycle helpers
     !pdfImportSrc.includes("document.getElementById('ai-needed-or').focus()"));
 
 assert('PII diff and review overlays use shared overlay lifecycle helpers',
-  piiSrc.includes("import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&
+  piiSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
     piiSrc.includes('function openPIIOverlay(overlay, options = {})') &&
+    piiSrc.includes('requestAnimationFrame(() => {') &&
+    piiSrc.includes('if (!overlay.isConnected) return;') &&
     piiSrc.includes('openModalOverlay(overlay, options)') &&
+    piiSrc.includes('trapModalFocus(overlay, { closeOnEscape: false })') &&
     piiSrc.includes('function closePIIOverlay(overlay)') &&
     (piiSrc.match(/closePIIOverlay\(overlay\)/g) || []).length >= 5 &&
+    !piiSrc.includes("document.body.style.overflow = 'hidden'") &&
+    !piiSrc.includes("document.body.style.overflow = ''") &&
     !piiSrc.includes("overlay.classList.add('show')") &&
     !piiSrc.includes('overlay.remove()') &&
     !piiSrc.includes("this.closest('.pii-warning-overlay').remove()"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.486';
+self.APP_VERSION = '1.8.487';


### PR DESCRIPTION
## Summary
- migrate PII diff and review overlays to `openModalOverlay` / `removeModalOverlay`
- centralize PII overlay open/close handling while preserving the existing scroll lock and review outcomes
- replace inline close handlers in the privacy diff viewer and add a modal lifecycle source guard
- bump `version.js` for cache invalidation

## Validation
- `node tests/test-pii.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `git diff --check`
- `npx playwright test tests/playwright/pii-browser-coverage.spec.js --project=chromium`
- `npm run typecheck`
- `npm test`