### PR TITLE
[codex] Use modal lifecycle for EMF overlays

### DIFF
--- a/js/emf.js
+++ b/js/emf.js
@@ -16,6 +16,7 @@ import { renderMarkdown } from './markdown.js';
 import { extractPDFText } from './pdf-import.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { loadEMFCatalog, renderEMFMeterRecs, renderEMFMitigationRecs, isProductRecsEnabled, detectMitigationsInText } from './recommendations.js';
+import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
 
 /**
  * @typedef {{ text?: string, model?: string, provider?: string, modelId?: string, inputTokens?: number, outputTokens?: number, date?: string }} EMFInterpretation
@@ -125,10 +126,10 @@ export function openEMFAssessmentEditor() {
   const overlay = document.getElementById('modal-overlay');
   _editingAssessmentId = null;
   renderEMFEditor(modal);
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
   // Save tags when modal closes (before DOM is torn down)
   const closeBtn = modal.querySelector('.modal-close');
-  if (closeBtn) closeBtn.addEventListener('click', () => { collectActiveAssessmentState(); saveImportedData(); document.querySelectorAll('.emf-lightbox').forEach(el => el.remove()); }, { once: true });
+  if (closeBtn) closeBtn.addEventListener('click', () => { collectActiveAssessmentState(); saveImportedData(); document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el)); }, { once: true });
 }
 
 function renderEMFEditor(modal) {
@@ -702,7 +703,7 @@ function showEMFImportPreview(parsed) {
   </div>`;
 
   modal.innerHTML = html;
-  overlay.classList.add('show');
+  openModalOverlay(overlay);
 
   document.getElementById('emf-confirm-btn').addEventListener('click', () => {
     const assessments = ensureAssessments();
@@ -862,7 +863,6 @@ function openInterpretationModal(title, existingInterp, onGenerate, onSave, miti
     overlay = /** @type {EMFInterpretationOverlay} */ (document.createElement('div'));
     overlay.id = 'emf-interp-overlay';
     overlay.className = 'emf-interp-overlay';
-    document.body.appendChild(overlay);
   }
 
   const hasExisting = existingInterp && existingInterp.text;
@@ -889,7 +889,9 @@ function openInterpretationModal(title, existingInterp, onGenerate, onSave, miti
   </div>`;
 
   overlay.innerHTML = html;
-  overlay.classList.add('show');
+  if (!overlay.isConnected) document.body.appendChild(overlay);
+  openModalOverlay(overlay);
+  try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}
 
   // Close on backdrop click (but not drag-from-inside, #87)
   let mdInside = false;
@@ -1019,7 +1021,7 @@ function streamInterpretation(prompt, onComplete) {
 export function closeEMFInterpretation() {
   if (_aiAbortController) { _aiAbortController.abort(); _aiAbortController = null; }
   const overlay = document.getElementById('emf-interp-overlay');
-  if (overlay) { overlay.classList.remove('show'); overlay.innerHTML = ''; }
+  if (overlay) removeModalOverlay(overlay);
 }
 
 export function discussEMFInterpretation() {
@@ -1140,9 +1142,11 @@ export function viewEMFPhoto(assessmentId, roomIdx, photoIdx) {
   // Simple lightbox using the existing modal overlay pattern
   const overlay = document.createElement('div');
   overlay.className = 'emf-lightbox';
-  overlay.onclick = () => overlay.remove();
+  overlay.addEventListener('click', () => removeModalOverlay(overlay));
   overlay.innerHTML = `<img src="data:${safeMediaType(photo.mediaType)};base64,${photo.base64}" alt="${escapeHTML(photo.name || 'Photo')}">`;
   document.body.appendChild(overlay);
+  openModalOverlay(overlay);
+  try { trapModalFocus(overlay); } catch (_) {}
 }
 
 // ═══════════════════════════════════════════════

--- a/js/emf.js
+++ b/js/emf.js
@@ -889,9 +889,10 @@ function openInterpretationModal(title, existingInterp, onGenerate, onSave, miti
   </div>`;
 
   overlay.innerHTML = html;
-  if (!overlay.isConnected) document.body.appendChild(overlay);
+  const wasConnected = overlay.isConnected;
+  if (!wasConnected) document.body.appendChild(overlay);
   openModalOverlay(overlay);
-  try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}
+  if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}
 
   // Close on backdrop click (but not drag-from-inside, #87)
   let mdInside = false;

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -16,6 +16,7 @@ const contextMedicalSrc = fs.readFileSync(path.join(root, 'js/context-card-medic
 const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboard-ai.js'), 'utf8');
 const dashboardWidgetControlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
+const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
 const exportReportBuilderSrc = fs.readFileSync(path.join(root, 'js/export-report-builder.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lightConditionsNowSrc = fs.readFileSync(path.join(root, 'js/light-conditions-now.js'), 'utf8');
@@ -226,6 +227,17 @@ assert('light environment assessment uses shared overlay lifecycle before remova
     lightEnvSrc.includes('overlay.remove()') &&
     !lightEnvSrc.includes("overlay.className = 'modal-overlay show light-env-assessment-overlay'") &&
     !lightEnvSrc.includes("overlay.classList.add('show')"));
+
+assert('EMF editor, interpretation, and photo overlays use shared lifecycle helpers',
+  emfSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
+    (emfSrc.match(/openModalOverlay\(overlay\)/g) || []).length >= 4 &&
+    (emfSrc.match(/removeModalOverlay\(overlay\)/g) || []).length >= 2 &&
+    emfSrc.includes("trapModalFocus(overlay, { closeOnEscape: false })") &&
+    emfSrc.includes('trapModalFocus(overlay)') &&
+    emfSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el))") &&
+    !emfSrc.includes("overlay.classList.add('show')") &&
+    !emfSrc.includes("overlay.classList.remove('show')") &&
+    !emfSrc.includes('overlay.onclick = () => overlay.remove()'));
 
 assert('light tool modals use shared overlay lifecycle helpers',
   modalLifecycleSrc.includes('export function openAppendedModalOverlay') &&

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -232,6 +232,9 @@ assert('EMF editor, interpretation, and photo overlays use shared lifecycle help
   emfSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
     (emfSrc.match(/openModalOverlay\(overlay\)/g) || []).length >= 4 &&
     (emfSrc.match(/removeModalOverlay\(overlay\)/g) || []).length >= 2 &&
+    emfSrc.includes('const wasConnected = overlay.isConnected;') &&
+    emfSrc.includes('if (!wasConnected) document.body.appendChild(overlay);') &&
+    emfSrc.includes("if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}") &&
     emfSrc.includes("trapModalFocus(overlay, { closeOnEscape: false })") &&
     emfSrc.includes('trapModalFocus(overlay)') &&
     emfSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el))") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.487';
+self.APP_VERSION = '1.8.488';


### PR DESCRIPTION
## Summary
- migrate EMF editor and import preview opens to the shared modal overlay lifecycle
- route EMF interpretation and photo lightbox close paths through shared remove/focus lifecycle helpers
- add a modal lifecycle source guard for EMF overlays
- bump `version.js` for cache invalidation

## Validation
- `node tests/test-emf-flow.js`
- `node tests/test-emf.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `git diff --check`
- `npx playwright test tests/playwright/environment-coverage-batch.spec.js tests/playwright/emf-edge-browser-coverage.spec.js --project=chromium`
- `npm run typecheck`
- `npm test`