### PR TITLE
[codex] Use modal lifecycle scroll lock for client list

### DIFF
--- a/js/client-list.js
+++ b/js/client-list.js
@@ -130,13 +130,11 @@ export function openClientList() {
   const overlay = document.getElementById('client-list-overlay');
   if (!overlay) return;
   renderClientList();
-  openModalOverlay(overlay, { initialFocus: '#cl-search' });
-  document.body.style.overflow = 'hidden';
+  openModalOverlay(overlay, { initialFocus: '#cl-search', scrollLock: true });
 }
 
 export function closeClientList() {
   closeModalOverlay('client-list-overlay');
-  document.body.style.overflow = '';
   _editingId = null;
 }
 

--- a/js/modal-lifecycle.js
+++ b/js/modal-lifecycle.js
@@ -47,6 +47,24 @@ const _modalScrollState = (() => {
 
 const _modalScrollLocks = _modalScrollState.locks;
 
+const _modalOverlayScrollLockTokens = (() => {
+  if (typeof window === 'undefined') return new WeakMap();
+  const appWindow = /** @type {any} */ (window);
+  if (appWindow.__labModalOverlayScrollLockTokens instanceof WeakMap) {
+    return appWindow.__labModalOverlayScrollLockTokens;
+  }
+  const tokens = new WeakMap();
+  try {
+    Object.defineProperty(appWindow, '__labModalOverlayScrollLockTokens', {
+      value: tokens,
+      configurable: true,
+    });
+  } catch (_) {
+    appWindow.__labModalOverlayScrollLockTokens = tokens;
+  }
+  return tokens;
+})();
+
 const _overlayFocusTargets = (() => {
   if (typeof window === 'undefined') return new WeakMap();
   const appWindow = /** @type {any} */ (window);
@@ -97,6 +115,7 @@ export function openModalOverlay(overlayOrId, options = {}) {
     _overlayFocusTargets.set(overlay, activeElement);
   }
   overlay.classList.add(showClass);
+  if (options.scrollLock === true) _acquireOverlayScrollLock(overlay);
 
   if (options.initialFocus) {
     const delay = Number.isFinite(options.focusDelay) ? Math.max(0, options.focusDelay) : 30;
@@ -118,6 +137,7 @@ export function closeModalOverlay(overlayOrId, options = {}) {
   if (!overlay) return null;
   const showClass = options.showClass || 'show';
   overlay.classList.remove(showClass);
+  _releaseOverlayScrollLock(overlay);
 
   if (options.restoreFocus !== false) {
     const focusTarget = _overlayFocusTargets.get(overlay);
@@ -136,21 +156,62 @@ export function removeModalOverlay(overlay) {
   overlay.remove();
 }
 
+function _modalScrollLockOverlay(lock) {
+  if (typeof Element !== 'undefined' && lock instanceof Element) return lock;
+  return lock?.overlay || null;
+}
+
 function _pruneDetachedModalScrollLocks() {
   for (const lock of Array.from(_modalScrollLocks)) {
-    if (!document.body.contains(lock)) _modalScrollLocks.delete(lock);
+    const overlay = _modalScrollLockOverlay(lock);
+    if (overlay && !document.body.contains(overlay)) {
+      _modalScrollLocks.delete(lock);
+      if (lock?.overlay === overlay) _modalOverlayScrollLockTokens.delete(overlay);
+    }
   }
 }
 
-export function trapModalFocus(overlay, options = {}) {
+function _restoreModalScrollLock() {
   _pruneDetachedModalScrollLocks();
-  const previouslyFocused = document.activeElement;
-  const closeOnEscape = options.closeOnEscape !== false;
+  if (_modalScrollLocks.size === 0) {
+    document.body.style.overflow = _modalScrollState.priorOverflow;
+  } else {
+    document.body.style.overflow = 'hidden';
+  }
+}
+
+function _acquireModalScrollLock(lock) {
+  _pruneDetachedModalScrollLocks();
   if (_modalScrollLocks.size === 0) {
     _modalScrollState.priorOverflow = document.body.style.overflow;
   }
-  _modalScrollLocks.add(overlay);
+  _modalScrollLocks.add(lock);
   document.body.style.overflow = 'hidden';
+}
+
+function _releaseModalScrollLock(lock) {
+  _modalScrollLocks.delete(lock);
+  _restoreModalScrollLock();
+}
+
+function _acquireOverlayScrollLock(overlay) {
+  if (_modalOverlayScrollLockTokens.has(overlay)) return;
+  const token = { overlay };
+  _modalOverlayScrollLockTokens.set(overlay, token);
+  _acquireModalScrollLock(token);
+}
+
+function _releaseOverlayScrollLock(overlay) {
+  const token = _modalOverlayScrollLockTokens.get(overlay);
+  if (!token) return;
+  _modalOverlayScrollLockTokens.delete(overlay);
+  _releaseModalScrollLock(token);
+}
+
+export function trapModalFocus(overlay, options = {}) {
+  const previouslyFocused = document.activeElement;
+  const closeOnEscape = options.closeOnEscape !== false;
+  _acquireModalScrollLock(overlay);
   let teardown = false;
   setTimeout(() => {
     const focusables = overlay.querySelectorAll(
@@ -170,13 +231,7 @@ export function trapModalFocus(overlay, options = {}) {
     if (teardown) return;
     teardown = true;
     document.removeEventListener('keydown', onKeydown);
-    _modalScrollLocks.delete(overlay);
-    _pruneDetachedModalScrollLocks();
-    if (_modalScrollLocks.size === 0) {
-      document.body.style.overflow = _modalScrollState.priorOverflow;
-    } else {
-      document.body.style.overflow = 'hidden';
-    }
+    _releaseModalScrollLock(overlay);
     const previousFocusTarget = /** @type {HTMLElement | null} */ (previouslyFocused instanceof HTMLElement ? previouslyFocused : null);
     if (previousFocusTarget && document.contains(previousFocusTarget)) {
       try { previousFocusTarget.focus(); } catch (e) {}

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -211,6 +211,30 @@ return (async function () {
     assert('body overflow restored after cross-instance modals closed',
       document.body.style.overflow === baseline);
 
+    // Persistent overlays close by hiding rather than DOM removal. Their
+    // scroll locks still need to share the same registry as trapModalFocus.
+    document.body.style.overflow = baseline;
+    const persistentOverlay = document.createElement('div');
+    persistentOverlay.className = 'modal-overlay';
+    persistentOverlay.innerHTML = '<button>Persistent</button>';
+    document.body.appendChild(persistentOverlay);
+    modalLifecycle.openModalOverlay(persistentOverlay, { scrollLock: true });
+    assert('openModalOverlay scrollLock locks body for persistent overlay',
+      document.body.style.overflow === 'hidden');
+    const nestedTrapOverlay = document.createElement('div');
+    nestedTrapOverlay.className = 'modal-overlay';
+    nestedTrapOverlay.innerHTML = '<button>Nested</button>';
+    document.body.appendChild(nestedTrapOverlay);
+    modalLifecycle.trapModalFocus(nestedTrapOverlay);
+    modalLifecycle.closeModalOverlay(persistentOverlay);
+    assert('closing persistent scrollLock overlay keeps nested trap locked',
+      document.body.style.overflow === 'hidden');
+    nestedTrapOverlay.remove();
+    await waitFor(() => document.body.style.overflow === baseline);
+    assert('persistent overlay scrollLock restores after nested trap closes',
+      document.body.style.overflow === baseline);
+    persistentOverlay.remove();
+
     // Detached-previouslyFocused guard — focus a button that's then removed
     // before the overlay is. The restore must not throw.
     const stash = document.createElement('button');

--- a/tests/test-client-list-delegated-actions.js
+++ b/tests/test-client-list-delegated-actions.js
@@ -50,8 +50,10 @@ assert('client-list can open share modal for selected profile',
     clientListSrc.includes('window.openProfileShareModal?.(id)'));
 assert('client-list modal uses shared overlay lifecycle helpers',
   clientListSrc.includes("from './modal-lifecycle.js'") &&
-    clientListSrc.includes('openModalOverlay(') &&
-    clientListSrc.includes('closeModalOverlay('));
+    clientListSrc.includes("openModalOverlay(overlay, { initialFocus: '#cl-search', scrollLock: true })") &&
+    clientListSrc.includes("closeModalOverlay('client-list-overlay')") &&
+    !clientListSrc.includes("document.body.style.overflow = 'hidden'") &&
+    !clientListSrc.includes("document.body.style.overflow = ''"));
 assert('dynamic avatar and tag buttons avoid direct onclick assignment',
   clientListSrc.includes("btn.setAttribute('data-cl-action', 'remove-avatar')") &&
     !clientListSrc.includes('.onclick'));

--- a/tests/test-client-list-delegated-actions.js
+++ b/tests/test-client-list-delegated-actions.js
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const clientListSrc = fs.readFileSync(path.join(root, 'js/client-list.js'), 'utf8');
+const clientListUsesScrollLockedOverlay = /openModalOverlay\s*\(\s*overlay\s*,\s*\{\s*initialFocus:\s*['"]#cl-search['"]\s*,\s*scrollLock:\s*true\s*,?\s*\}\s*\)/s.test(clientListSrc);
+const clientListClosesOverlay = /closeModalOverlay\s*\(\s*['"]client-list-overlay['"]\s*\)/.test(clientListSrc);
 
 let passed = 0;
 let failed = 0;
@@ -50,8 +52,8 @@ assert('client-list can open share modal for selected profile',
     clientListSrc.includes('window.openProfileShareModal?.(id)'));
 assert('client-list modal uses shared overlay lifecycle helpers',
   clientListSrc.includes("from './modal-lifecycle.js'") &&
-    clientListSrc.includes("openModalOverlay(overlay, { initialFocus: '#cl-search', scrollLock: true })") &&
-    clientListSrc.includes("closeModalOverlay('client-list-overlay')") &&
+    clientListUsesScrollLockedOverlay &&
+    clientListClosesOverlay &&
     !clientListSrc.includes("document.body.style.overflow = 'hidden'") &&
     !clientListSrc.includes("document.body.style.overflow = ''"));
 assert('dynamic avatar and tag buttons avoid direct onclick assignment',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.488';
+self.APP_VERSION = '1.8.489';


### PR DESCRIPTION
## Summary
- add a shared `scrollLock` option to `openModalOverlay` for persistent overlays
- move Client List scroll locking onto the modal lifecycle helper
- add audit/client-list regression guards and bump `version.js`

## Validation
- `node tests/test-client-list-delegated-actions.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `npx vitest run tests/client-list-runtime.test.js`
- `git diff --check`
- `npm run typecheck`
- `npm test`
- `npx playwright test tests/playwright/modal-lifecycle-browser-coverage.spec.js tests/playwright/client-list-browser-coverage.spec.js --project=chromium`
- `./run-tests.sh`