### PR TITLE
[codex] Use modal lifecycle for tweaks panel

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -13,7 +13,7 @@ import { renderSyncSection, renderMessengerSection, hydrateSettingsSyncPanel } f
 import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
 import { loadPdfImport } from './import-loader.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
-import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
 /** @typedef {Window & typeof globalThis & Record<string, any>} SettingsWindow */
 
@@ -677,14 +677,9 @@ export function updateTweaksUI() {
   });
 }
 
-let _tweaksPriorBodyOverflow = null;
-
 export function closeTweaksPanel() {
-  document.getElementById('tweaks-panel-overlay')?.remove();
-  if (_tweaksPriorBodyOverflow !== null) {
-    document.body.style.overflow = _tweaksPriorBodyOverflow;
-    _tweaksPriorBodyOverflow = null;
-  }
+  const overlay = document.getElementById('tweaks-panel-overlay');
+  if (overlay) removeModalOverlay(overlay);
 }
 
 export function openTweaksPanel() {
@@ -703,7 +698,7 @@ export function openTweaksPanel() {
     </button>`;
   }).join('');
   document.body.insertAdjacentHTML('beforeend', `
-    <div class="tweaks-overlay show" id="tweaks-panel-overlay">
+    <div class="tweaks-overlay" id="tweaks-panel-overlay">
       <aside class="tweaks-panel" id="tweaks-panel" role="dialog" aria-modal="true" aria-label="Tweaks">
         <div class="tweaks-head">
           <div>
@@ -757,13 +752,16 @@ export function openTweaksPanel() {
       </aside>
     </div>
   `);
-  if (window.matchMedia?.('(max-width: 768px)').matches) {
-    _tweaksPriorBodyOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-  }
-  installTweaksDelegates(document.getElementById('tweaks-panel-overlay'));
+  const overlay = document.getElementById('tweaks-panel-overlay');
+  installTweaksDelegates(overlay);
   updateTweaksUI();
-  /** @type {HTMLButtonElement | null} */ (document.querySelector('#tweaks-panel button'))?.focus();
+  if (overlay) {
+    openModalOverlay(overlay, {
+      initialFocus: '#tweaks-panel button',
+      focusDelay: 0,
+      scrollLock: window.matchMedia?.('(max-width: 768px)').matches === true,
+    });
+  }
 }
 
 applyAccentOverride();

--- a/tests/playwright/settings-toggles.spec.js
+++ b/tests/playwright/settings-toggles.spec.js
@@ -121,3 +121,22 @@ test('Tweaks panel toggles sunset and CRT effects with theme gating', async ({ p
   });
   await expect(crtInput).not.toBeChecked();
 });
+
+test('Tweaks panel uses lifecycle scroll lock on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await preparePage(page);
+
+  await page.evaluate(() => {
+    if (typeof window.openTweaksPanel !== 'function') throw new Error('window.openTweaksPanel unavailable');
+    document.body.style.overflow = 'auto';
+    window.openTweaksPanel();
+  });
+
+  const tweaksOverlay = page.locator('#tweaks-panel-overlay');
+  await expect(tweaksOverlay).toHaveClass(SHOW_CLASS_TOKEN);
+  await expect.poll(async () => page.evaluate(() => document.body.style.overflow)).toBe('hidden');
+
+  await page.evaluate(() => window.closeTweaksPanel?.());
+  await expect(tweaksOverlay).toHaveCount(0);
+  await expect.poll(async () => page.evaluate(() => document.body.style.overflow)).toBe('auto');
+});

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -143,6 +143,13 @@ assert('settings modal opens and closes through shared overlay lifecycle helpers
     !settingsSrc.includes("overlay.classList.add('show')") &&
     !settingsSrc.includes("document.getElementById('settings-modal-overlay').classList.remove('show')"));
 
+assert('settings tweaks panel uses shared overlay lifecycle helpers',
+  settingsSrc.includes("from './modal-lifecycle.js'") &&
+    settingsSrc.includes('removeModalOverlay(overlay)') &&
+    /openModalOverlay\s*\(\s*overlay\s*,\s*\{[\s\S]*initialFocus:\s*['"]#tweaks-panel button['"][\s\S]*scrollLock:\s*window\.matchMedia\?\.\(['"]\(max-width: 768px\)['"]\)\.matches === true[\s\S]*\}\s*\)/.test(settingsSrc) &&
+    !settingsSrc.includes('_tweaksPriorBodyOverflow') &&
+    !settingsSrc.includes("document.body.style.overflow = 'hidden'"));
+
 assert('sync setup and restore dialogs use shared lifecycle helpers',
   settingsSyncPanelSrc.includes("from './modal-lifecycle.js'") &&
     settingsSyncPanelSrc.includes("openModalOverlay(overlay, { initialFocus: '[data-sync-setup-action=\"setup-new\"]', focusDelay: 50 })") &&

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -35,6 +35,7 @@ const tweaksBlock = matchBlock('Tweaks panel', /export function openTweaksPanel\
 const renderThemeButtonBlock = matchBlock('renderThemeButton', /function renderThemeButton[\s\S]*?\n}\n\nfunction getAccentOverride/);
 
 const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
+const tweaksLifecycleOpenRe = /openModalOverlay\s*\(\s*overlay\s*,\s*\{[\s\S]*initialFocus:\s*['"]#tweaks-panel button['"][\s\S]*focusDelay:\s*0[\s\S]*scrollLock:\s*window\.matchMedia\?\.\(['"]\(max-width: 768px\)['"]\)\.matches === true[\s\S]*\}\s*\)/;
 
 assert('settings.js has no inline event attributes',
   !inlineHandlerRe.test(src));
@@ -53,6 +54,12 @@ assert('Tweaks panel installs delegated click listener',
   /overlay\.addEventListener\('click', handleTweaksClick\)/.test(src));
 assert('Tweaks panel installs delegated change listener',
   /overlay\.addEventListener\('change', handleTweaksChange\)/.test(src));
+assert('Tweaks panel uses shared overlay lifecycle helpers',
+  src.includes("from './modal-lifecycle.js'") &&
+    tweaksBlock &&
+    tweaksLifecycleOpenRe.test(tweaksBlock) &&
+    /removeModalOverlay\(overlay\)/.test(src) &&
+    !tweaksBlock.includes('document.body.style.overflow'));
 
 [
   'switch-unit',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.489';
+self.APP_VERSION = '1.8.490';


### PR DESCRIPTION
Summary: Move the Tweaks panel close/open/mobile scroll lock onto shared modal lifecycle helpers, add static lifecycle guards and a mobile browser scroll-lock regression test, and bump version.js. Validation: node tests/test-settings-delegated-actions.js; node tests/test-modal-lifecycle-integrations.js; git diff --check; npx playwright test tests/playwright/settings-toggles.spec.js tests/playwright/settings-browser-coverage.spec.js --project=chromium; npm run typecheck; npm test; ./run-tests.sh.