### PR TITLE
[codex] Use modal lifecycle scroll lock for mobile sidebar

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -6,6 +6,7 @@ import { escapeHTML, escapeAttr, hashString } from './utils.js';
 import { getActiveData, filterDatesByRange } from './data.js';
 import { countFlagged } from './marker-analysis.js';
 import { getProfiles } from './profile.js';
+import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 function _iconSvg(name) {
   const attrs = 'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"';
@@ -426,15 +427,13 @@ export function toggleMobileSidebar() {
     closeMobileSidebar();
   } else {
     sidebar.classList.add('mobile-open');
-    backdrop.classList.add('show');
-    document.body.style.overflow = 'hidden';
+    openModalOverlay(backdrop, { scrollLock: true });
   }
 }
 
 export function closeMobileSidebar() {
   document.getElementById('sidebar-nav').classList.remove('mobile-open');
-  document.getElementById('sidebar-backdrop').classList.remove('show');
-  document.body.style.overflow = '';
+  closeModalOverlay('sidebar-backdrop', { restoreFocus: false });
 }
 
 Object.assign(window, { buildSidebar, filterSidebar, toggleNavGroup, toggleGroupAIContext, renderProfileDropdown, renderProfileButton, getAvatarColor, syncSidebarActive, toggleMobileSidebar, closeMobileSidebar, openRecommendationsFromSidebar, installNavActionDelegates });

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -164,3 +164,31 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     expect(passed, name).toBe(true);
   }
 });
+
+test('mobile sidebar uses shared lifecycle scroll lock', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await prepareApp(page);
+
+  const results = await page.evaluate(() => {
+    const sidebar = document.getElementById('sidebar-nav');
+    const backdrop = document.getElementById('sidebar-backdrop');
+    if (!sidebar || !backdrop) throw new Error('mobile sidebar fixture missing');
+
+    document.body.style.overflow = 'auto';
+    window.toggleMobileSidebar?.();
+    const opened = sidebar.classList.contains('mobile-open')
+      && backdrop.classList.contains('show')
+      && document.body.style.overflow === 'hidden';
+
+    window.closeMobileSidebar?.();
+    const closed = !sidebar.classList.contains('mobile-open')
+      && !backdrop.classList.contains('show')
+      && document.body.style.overflow === 'auto';
+
+    document.body.style.overflow = '';
+    return { opened, closed };
+  });
+
+  expect(results.opened, 'opens sidebar and locks body scroll').toBe(true);
+  expect(results.closed, 'closes sidebar and restores body scroll').toBe(true);
+});

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -28,6 +28,7 @@ const lightSessionsViewSrc = fs.readFileSync(path.join(root, 'js/light-sessions-
 const lightToolCameraModalsSrc = fs.readFileSync(path.join(root, 'js/light-tool-camera-modals.js'), 'utf8');
 const lightToolsSrc = fs.readFileSync(path.join(root, 'js/light-tools.js'), 'utf8');
 const modalLifecycleSrc = fs.readFileSync(path.join(root, 'js/modal-lifecycle.js'), 'utf8');
+const navSrc = fs.readFileSync(path.join(root, 'js/nav.js'), 'utf8');
 const markerDetailSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
 const pdfImportSrc = fs.readFileSync(path.join(root, 'js/pdf-import.js'), 'utf8');
 const pdfImportPreflightSrc = fs.readFileSync(path.join(root, 'js/pdf-import-preflight.js'), 'utf8');
@@ -149,6 +150,13 @@ assert('settings tweaks panel uses shared overlay lifecycle helpers',
     /openModalOverlay\s*\(\s*overlay\s*,\s*\{[\s\S]*initialFocus:\s*['"]#tweaks-panel button['"][\s\S]*scrollLock:\s*window\.matchMedia\?\.\(['"]\(max-width: 768px\)['"]\)\.matches === true[\s\S]*\}\s*\)/.test(settingsSrc) &&
     !settingsSrc.includes('_tweaksPriorBodyOverflow') &&
     !settingsSrc.includes("document.body.style.overflow = 'hidden'"));
+
+assert('mobile sidebar uses shared scroll lock lifecycle helpers',
+  navSrc.includes("from './modal-lifecycle.js'") &&
+    navSrc.includes('openModalOverlay(backdrop, { scrollLock: true })') &&
+    navSrc.includes("closeModalOverlay('sidebar-backdrop', { restoreFocus: false })") &&
+    !navSrc.includes("document.body.style.overflow = 'hidden'") &&
+    !navSrc.includes("document.body.style.overflow = ''"));
 
 assert('sync setup and restore dialogs use shared lifecycle helpers',
   settingsSyncPanelSrc.includes("from './modal-lifecycle.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.490';
+self.APP_VERSION = '1.8.491';


### PR DESCRIPTION
Summary:
- Move mobile sidebar backdrop show and body scroll lock onto shared modal lifecycle helpers.
- Add static and browser guards for sidebar scroll-lock behavior.
- Bump version.js for cache invalidation.

Validation:
- node tests/test-modal-lifecycle-integrations.js
- git diff --check
- npx playwright test tests/playwright/nav-delegated-actions.spec.js --project=chromium
- npm run typecheck
- npm test
- ./run-tests.sh