### PR TITLE
[codex] Delegate EMF interpretation actions

### DIFF
--- a/js/emf.js
+++ b/js/emf.js
@@ -1040,19 +1040,21 @@ function _handleEMFInterpretationClick(event) {
 
   const actionEl = target.closest('[data-emf-interp-action]');
   if (actionEl instanceof HTMLElement && overlay.contains(actionEl)) {
-    event.preventDefault();
     const action = actionEl.dataset.emfInterpAction || '';
     if (action === 'close') {
+      event.preventDefault();
       overlay._mouseDownInside = false;
       closeEMFInterpretation();
       return;
     }
     if (action === 'discuss') {
+      event.preventDefault();
       overlay._mouseDownInside = false;
       discussEMFInterpretation();
       return;
     }
     if (action === 'generate') {
+      event.preventDefault();
       overlay._mouseDownInside = false;
       if (!overlay._onGenerate) return;
       const btn = actionEl instanceof HTMLButtonElement ? actionEl : null;

--- a/js/emf.js
+++ b/js/emf.js
@@ -21,7 +21,7 @@ import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-li
 
 /**
  * @typedef {{ text?: string, model?: string, provider?: string, modelId?: string, inputTokens?: number, outputTokens?: number, date?: string }} EMFInterpretation
- * @typedef {HTMLElement & { _interpretText?: string, _onSave?: ((interp: EMFInterpretation) => void) | null }} EMFInterpretationOverlay
+ * @typedef {HTMLElement & { _interpretText?: string, _onGenerate?: ((onSave: (((interp: EMFInterpretation) => void) | null)) => void), _onSave?: ((interp: EMFInterpretation) => void) | null, _mouseDownInside?: boolean, _delegatesInstalled?: boolean }} EMFInterpretationOverlay
  */
 
 // ═══════════════════════════════════════════════
@@ -136,6 +136,10 @@ function emfActionAttrs(action, attrs = {}) {
 
 function emfChangeAttrs(action, attrs = {}) {
   return emfAttrString({ 'data-emf-change-action': action, ...attrs });
+}
+
+function emfInterpActionAttrs(action, attrs = {}) {
+  return emfAttrString({ 'data-emf-interp-action': action, ...attrs });
 }
 
 function isEMFEditorTarget(el) {
@@ -1018,6 +1022,60 @@ function stripThinking(text) {
 
 const EMF_SYSTEM = `You are a Baubiologie (Building Biology) consultant interpreting EMF assessment data rated against SBM-2015 standards. Be specific about health implications, prioritize concerns by severity (sleeping areas are most critical), and suggest actionable mitigations in priority order. Keep the response concise and practical. Use markdown formatting with headers and bullet points.`;
 
+function _handleEMFInterpretationMouseDown(event) {
+  const overlay = /** @type {EMFInterpretationOverlay | null} */ (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
+  if (!overlay) return;
+  overlay._mouseDownInside = event.target !== overlay;
+}
+
+function _handleEMFInterpretationClick(event) {
+  const overlay = /** @type {EMFInterpretationOverlay | null} */ (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
+  if (!overlay) return;
+
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    overlay._mouseDownInside = false;
+    return;
+  }
+
+  const actionEl = target.closest('[data-emf-interp-action]');
+  if (actionEl instanceof HTMLElement && overlay.contains(actionEl)) {
+    event.preventDefault();
+    const action = actionEl.dataset.emfInterpAction || '';
+    if (action === 'close') {
+      overlay._mouseDownInside = false;
+      closeEMFInterpretation();
+      return;
+    }
+    if (action === 'discuss') {
+      overlay._mouseDownInside = false;
+      discussEMFInterpretation();
+      return;
+    }
+    if (action === 'generate') {
+      overlay._mouseDownInside = false;
+      if (!overlay._onGenerate) return;
+      const btn = actionEl instanceof HTMLButtonElement ? actionEl : null;
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = 'Interpreting…';
+      }
+      overlay._onGenerate(overlay._onSave || null);
+      return;
+    }
+  }
+
+  if (target === overlay && !overlay._mouseDownInside) closeEMFInterpretation();
+  overlay._mouseDownInside = false;
+}
+
+function installEMFInterpretationDelegates(overlay) {
+  if (overlay._delegatesInstalled) return;
+  overlay._delegatesInstalled = true;
+  overlay.addEventListener('mousedown', _handleEMFInterpretationMouseDown);
+  overlay.addEventListener('click', _handleEMFInterpretationClick);
+}
+
 function openInterpretationModal(title, existingInterp, onGenerate, onSave, mitigationTags = []) {
   // Create overlay that sits on top of the EMF editor (z-index above modal-overlay)
   let overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
@@ -1032,7 +1090,7 @@ function openInterpretationModal(title, existingInterp, onGenerate, onSave, miti
   let html = `<div class="emf-interp-modal">
     <div class="emf-interp-header">
       <h3>${escapeHTML(title)}</h3>
-      <button class="modal-close" aria-label="Close" onclick="closeEMFInterpretation()">&times;</button>
+      <button class="modal-close" aria-label="Close" ${emfInterpActionAttrs('close')}>&times;</button>
     </div>
     <div class="emf-interp-body" id="emf-interp-body">
       ${hasExisting ? renderMarkdown(existingInterp.text) : '<div class="emf-interp-placeholder">Click Interpret to get an AI interpretation of this assessment.</div>'}
@@ -1043,9 +1101,9 @@ function openInterpretationModal(title, existingInterp, onGenerate, onSave, miti
         ${hasExisting ? buildMetaLine(existingInterp) : ''}
       </div>
       <div class="emf-interp-actions">
-        <button class="import-btn import-btn-primary" id="emf-interp-generate">${hasExisting ? 'Re-interpret' : 'Interpret'}</button>
-        ${hasExisting ? `<button class="import-btn import-btn-secondary" onclick="discussEMFInterpretation()">Discuss in Chat</button>` : ''}
-        <button class="import-btn import-btn-secondary" onclick="closeEMFInterpretation()">Close</button>
+        <button class="import-btn import-btn-primary" id="emf-interp-generate" ${emfInterpActionAttrs('generate')}>${hasExisting ? 'Re-interpret' : 'Interpret'}</button>
+        ${hasExisting ? `<button class="import-btn import-btn-secondary" ${emfInterpActionAttrs('discuss')}>Discuss in Chat</button>` : ''}
+        <button class="import-btn import-btn-secondary" ${emfInterpActionAttrs('close')}>Close</button>
       </div>
     </div>
   </div>`;
@@ -1056,26 +1114,12 @@ function openInterpretationModal(title, existingInterp, onGenerate, onSave, miti
   openModalOverlay(overlay);
   if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}
 
-  // Close on backdrop click (but not drag-from-inside, #87)
-  let mdInside = false;
-  overlay.onmousedown = (e) => { mdInside = e.target !== overlay; };
-  overlay.onclick = (e) => {
-    if (e.target === overlay && !mdInside) closeEMFInterpretation();
-    mdInside = false;
-  };
-
   // Store context for discuss button
   overlay._interpretText = hasExisting ? existingInterp.text : '';
+  overlay._onGenerate = onGenerate;
   overlay._onSave = onSave;
-
-  const generateBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('emf-interp-generate'));
-  generateBtn?.addEventListener('click', () => {
-    const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('emf-interp-generate'));
-    if (!btn) return;
-    btn.disabled = true;
-    btn.textContent = 'Interpreting…';
-    onGenerate(onSave);
-  });
+  overlay._mouseDownInside = false;
+  installEMFInterpretationDelegates(overlay);
 
   // Populate mitigation product recs alongside the AI interpretation
   if (mitigationTags && mitigationTags.length && isProductRecsEnabled()) {
@@ -1158,17 +1202,18 @@ function streamInterpretation(prompt, onComplete) {
     if (btn) { btn.disabled = false; btn.textContent = 'Re-interpret'; }
 
     // Add discuss button if not present
-    const actions = document.querySelector('.emf-interp-actions');
-    if (actions && !actions.querySelector('[onclick*="discussEMF"]')) {
+    const overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
+    const actions = overlay?.querySelector('.emf-interp-actions');
+    if (actions && !actions.querySelector('[data-emf-interp-action="discuss"]')) {
       const discussBtn = document.createElement('button');
+      discussBtn.type = 'button';
       discussBtn.className = 'import-btn import-btn-secondary';
+      discussBtn.dataset.emfInterpAction = 'discuss';
       discussBtn.textContent = 'Discuss in Chat';
-      discussBtn.onclick = () => discussEMFInterpretation();
       actions.appendChild(discussBtn);
     }
 
     // Store for discuss
-    const overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
     if (overlay) overlay._interpretText = finalText;
 
     if (onComplete) onComplete(interp);

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 450,
+  "inlineEventAttributes": 447,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/emf-edge-browser-coverage.spec.js
+++ b/tests/playwright/emf-edge-browser-coverage.spec.js
@@ -291,7 +291,12 @@ test('EMF edge browser coverage imports PDFs photos rooms and streams interpreta
         && imported.interpretation.inputTokens === 80
         && imported.interpretation.outputTokens === 24
         && window.__emfApiCalls.some(call => call.hasStream && call.signalPresent)
-        && !!document.querySelector('#emf-interp-overlay button.import-btn-secondary');
+        && !!document.querySelector('#emf-interp-overlay [data-emf-interp-action="discuss"]');
+      const interpHtml = document.getElementById('emf-interp-overlay')?.innerHTML || '';
+      outcomes.interpretationOverlayUsesDelegatedControls =
+        !/\bon(?:click|keydown|submit|change|input)=/.test(interpHtml)
+        && !!document.querySelector('#emf-interp-overlay [data-emf-interp-action="close"]')
+        && !!document.querySelector('#emf-interp-overlay [data-emf-interp-action="generate"]');
 
       await waitUntil(() => document.getElementById('emf-interp-recs')?.textContent.includes('Products to consider'), 'mitigation recs');
       outcomes.productRecsLoadForMitigationTags = window.__emfCatalogLoads >= 1;

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -194,7 +194,7 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
       window.closeModal = () => calls.push(['close-modal']);
       window.interpretEMFComparison();
       await waitFor('#emf-interp-overlay.show .emf-interp-modal', 'EMF existing interpretation modal');
-      document.querySelector('#emf-interp-overlay button[onclick*="discussEMFInterpretation"]')?.click();
+      document.querySelector('#emf-interp-overlay [data-emf-interp-action="discuss"]')?.click();
       await waitUntil(() => calls.some(call => call[0] === 'chat'), 'EMF discuss chat handoff');
       outcomes.existingComparisonInterpretationDiscussesInChat =
         calls.some(call => call[0] === 'close-modal')

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -31,6 +31,7 @@ function section(start, end) {
 const editorSrc = section('let _editingAssessmentId = null;', '// ═══════════════════════════════════════════════\n// CRUD OPERATIONS');
 const importPreviewSrc = section('function showEMFImportPreview(parsed)', '// ═══════════════════════════════════════════════\n// BEFORE / AFTER COMPARISON');
 const compareSrc = section('function renderComparisonView(sorted)', '// ═══════════════════════════════════════════════\n// AI INTERPRETATION');
+const interpretationSrc = section('function _handleEMFInterpretationMouseDown', 'function _collectMitigationTags');
 const closePreviewSrc = section('function closeEMFPreviewModal()', 'function closeEMFEditorModal()');
 const migratedEditorSurface = `${editorSrc}\n${importPreviewSrc}\n${compareSrc}`;
 const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
@@ -39,6 +40,8 @@ console.log('=== EMF Delegated Actions ===');
 
 assert('EMF editor migrated surface renders no inline event attributes',
   migratedEditorSurface.length > 0 && !inlineHandlerRe.test(migratedEditorSurface));
+assert('EMF interpretation modal renders no inline event attributes',
+  interpretationSrc.length > 0 && !inlineHandlerRe.test(interpretationSrc));
 assert('EMF editor imports shared tag toggle instead of inline global handler',
   emfSrc.includes("import { toggleCtxTag } from './context-card-editor-ui.js';") &&
     migratedEditorSurface.includes("if (action === 'toggle-tag') { toggleCtxTag(actionEl); return; }"));
@@ -76,6 +79,19 @@ assert('EMF editor delegates can be explicitly removed',
     emfSrc.includes("document.removeEventListener('click', _handleEMFEditorClick)") &&
     emfSrc.includes("document.removeEventListener('change', _handleEMFEditorChange)") &&
     emfSrc.includes("document.removeEventListener('keydown', _handleEMFEditorKeydown)"));
+assert('EMF interpretation modal installs scoped action delegates',
+  emfSrc.includes('function emfInterpActionAttrs') &&
+    interpretationSrc.includes('data-emf-interp-action') &&
+    interpretationSrc.includes('installEMFInterpretationDelegates(overlay);') &&
+    interpretationSrc.includes("overlay.addEventListener('mousedown', _handleEMFInterpretationMouseDown)") &&
+    interpretationSrc.includes("overlay.addEventListener('click', _handleEMFInterpretationClick)") &&
+    interpretationSrc.includes("if (action === 'close')") &&
+    interpretationSrc.includes("if (action === 'discuss')") &&
+    interpretationSrc.includes("if (action === 'generate')"));
+assert('EMF interpretation streamed discuss button uses delegated action',
+  interpretationSrc.includes("querySelector('[data-emf-interp-action=\"discuss\"]')") &&
+    interpretationSrc.includes("dataset.emfInterpAction = 'discuss'") &&
+    !interpretationSrc.includes('discussBtn.onclick'));
 
 [
   'close-editor',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.492';
+self.APP_VERSION = '1.8.493';


### PR DESCRIPTION
Summary:
- Convert the EMF interpretation modal close, discuss, generate, and backdrop behavior to scoped data-action delegates.
- Add static and browser coverage for delegated interpretation controls.
- Ratchet the inline-handler baseline to 447 and bump APP_VERSION to 1.8.493.

Validation:
- node tests/test-emf-delegated-actions.js
- node tests/test-emf-flow.js
- npm run quality
- npm run typecheck
- npm test
- npx playwright test tests/playwright/emf-edge-browser-coverage.spec.js --project=chromium
- npx playwright test tests/playwright/environment-coverage-batch.spec.js --project=chromium --grep "EMF assessment editor covers"
- git diff --check
- ./run-tests.sh