### PR TITLE
[codex] Delegate light camera modal close actions

### DIFF
--- a/js/light-tool-camera-modals.js
+++ b/js/light-tool-camera-modals.js
@@ -22,6 +22,54 @@ function queryOptional(root, selector) {
   return /** @type {T | null} */ (root.querySelector(selector));
 }
 
+function lightToolModalActionAttrs(action) {
+  return `data-light-tool-modal-action="${action}"`;
+}
+
+function _handleLightToolModalClick(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const actionEl = target.closest('[data-light-tool-modal-action]');
+  if (!(actionEl instanceof HTMLElement)) return;
+  const overlay = event.currentTarget;
+  if (!(overlay instanceof HTMLElement) || !overlay.contains(actionEl)) return;
+
+  const action = actionEl.dataset.lightToolModalAction || '';
+  if (action === 'close-lux') {
+    event.preventDefault();
+    window._closeLuxMeter?.();
+    return;
+  }
+  if (action === 'close-flicker') {
+    event.preventDefault();
+    window._closeFlicker?.();
+    return;
+  }
+  if (action === 'close-dark') {
+    event.preventDefault();
+    window._closeDark?.();
+    return;
+  }
+  if (action === 'close-cct') {
+    event.preventDefault();
+    window._closeCCT?.();
+    return;
+  }
+  if (action === 'close-spec') {
+    event.preventDefault();
+    window._closeSpec?.();
+    return;
+  }
+  if (action === 'close-glass') {
+    event.preventDefault();
+    window._closeGlass?.();
+  }
+}
+
+function installLightToolModalDelegates(overlay) {
+  overlay.addEventListener('click', _handleLightToolModalClick);
+}
+
 /** @param {{ saveMeasurement?: AnyFunction }} [deps] */
 function getSaveMeasurement(deps = {}) {
   const fn = deps.saveMeasurement || (typeof window !== 'undefined' ? window.saveMeasurement : null);
@@ -57,7 +105,7 @@ export async function openLuxMeter(opts = {}, deps = {}) {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Lux meter">
     <div class="modal-header">
       <h3>Lux Meter</h3>
-      <button class="modal-close" onclick="window._closeLuxMeter()" aria-label="Close">×</button>
+      <button class="modal-close" ${lightToolModalActionAttrs('close-lux')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${aimingGuideHTML('lux')}
@@ -87,11 +135,12 @@ export async function openLuxMeter(opts = {}, deps = {}) {
         </div>
       </details>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="window._closeLuxMeter()">Done</button>
+        <button class="import-btn import-btn-secondary" ${lightToolModalActionAttrs('close-lux')}>Done</button>
         <button class="import-btn import-btn-primary" id="lux-save">Save reading</button>
       </div>
     </div>
   </div>`;
+  installLightToolModalDelegates(overlay);
   let closed = false;
   window._closeLuxMeter = () => {
     closed = true;
@@ -321,7 +370,7 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Flicker detector">
     <div class="modal-header">
       <h3>Flicker Detector</h3>
-      <button class="modal-close" onclick="window._closeFlicker()" aria-label="Close">×</button>
+      <button class="modal-close" ${lightToolModalActionAttrs('close-flicker')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${aimingGuideHTML('flicker')}
@@ -329,11 +378,12 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
       <video id="flicker-video" autoplay playsinline muted style="width:100%;border-radius:var(--radius-sm);background:#000;max-height:240px"></video>
       <div class="flicker-result" id="flicker-result">Hold camera on a light for 5 seconds…</div>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="window._closeFlicker()">Done</button>
+        <button class="import-btn import-btn-secondary" ${lightToolModalActionAttrs('close-flicker')}>Done</button>
         <button class="import-btn import-btn-primary" id="flicker-save">Save reading</button>
       </div>
     </div>
     </div>`;
+  installLightToolModalDelegates(overlay);
   let closed = false;
   window._closeFlicker = () => {
     closed = true;
@@ -478,18 +528,19 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Sleep darkness meter">
     <div class="modal-header">
       <h3>Sleep Darkness Meter</h3>
-      <button class="modal-close" onclick="window._closeDark()" aria-label="Close">×</button>
+      <button class="modal-close" ${lightToolModalActionAttrs('close-dark')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${aimingGuideHTML('darkness')}
       <p class="modal-body-hint">Lights as you'll actually sleep — door cracked, hallway light on, etc.</p>
       <div class="dark-status" id="dark-status">Press Start when ready.</div>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="window._closeDark()">Cancel</button>
+        <button class="import-btn import-btn-secondary" ${lightToolModalActionAttrs('close-dark')}>Cancel</button>
         <button class="import-btn import-btn-primary" id="dark-start">Start 30-second read</button>
       </div>
     </div>
   </div>`;
+  installLightToolModalDelegates(overlay);
   openAppendedModalOverlay(overlay, () => window._closeDark());
 
   let result = null;
@@ -635,7 +686,7 @@ export async function openCCTMeter(opts = {}, deps = {}) {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Color temperature meter">
     <div class="modal-header">
       <h3>Color Temperature</h3>
-      <button class="modal-close" onclick="window._closeCCT()" aria-label="Close">×</button>
+      <button class="modal-close" ${lightToolModalActionAttrs('close-cct')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${aimingGuideHTML('cct')}
@@ -647,11 +698,12 @@ export async function openCCTMeter(opts = {}, deps = {}) {
         <div class="cct-coherence" id="cct-coherence"></div>
       </div>
       <div class="modal-actions" style="margin-top:14px">
-        <button class="import-btn import-btn-secondary" onclick="window._closeCCT()">Done</button>
+        <button class="import-btn import-btn-secondary" ${lightToolModalActionAttrs('close-cct')}>Done</button>
         <button class="import-btn import-btn-primary" id="cct-save">Save reading</button>
       </div>
     </div>
     </div>`;
+  installLightToolModalDelegates(overlay);
   let closed = false;
   window._closeCCT = () => {
     closed = true;
@@ -792,7 +844,7 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Spectrum classifier">
     <div class="modal-header">
       <h3>What kind of light is this?</h3>
-      <button class="modal-close" onclick="window._closeSpec()" aria-label="Close">×</button>
+      <button class="modal-close" ${lightToolModalActionAttrs('close-spec')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${aimingGuideHTML('spectrum')}
@@ -800,11 +852,12 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
       <video id="spec-video" autoplay playsinline muted style="width:100%;border-radius:var(--radius-sm);background:#000;max-height:200px"></video>
       <div class="spec-result" id="spec-result">Reading…</div>
       <div class="modal-actions" style="margin-top:14px">
-        <button class="import-btn import-btn-secondary" onclick="window._closeSpec()">Done</button>
+        <button class="import-btn import-btn-secondary" ${lightToolModalActionAttrs('close-spec')}>Done</button>
         <button class="import-btn import-btn-primary" id="spec-save">Save reading</button>
       </div>
     </div>
     </div>`;
+  installLightToolModalDelegates(overlay);
   let closed = false;
   window._closeSpec = () => {
     closed = true;
@@ -971,7 +1024,7 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Glass transmission test">
     <div class="modal-header">
       <h3>Window / Glass Transmission</h3>
-      <button class="modal-close" onclick="window._closeGlass()" aria-label="Close">×</button>
+      <button class="modal-close" ${lightToolModalActionAttrs('close-glass')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${aimingGuideHTML('glass-transmission')}
@@ -988,11 +1041,12 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
       </div>
       <div class="glass-result" id="glass-result"></div>
       <div class="modal-actions" style="margin-top:14px">
-        <button class="import-btn import-btn-secondary" onclick="window._closeGlass()">Done</button>
+        <button class="import-btn import-btn-secondary" ${lightToolModalActionAttrs('close-glass')}>Done</button>
         <button class="import-btn import-btn-primary" id="glass-save" disabled>Save reading</button>
       </div>
     </div>
     </div>`;
+  installLightToolModalDelegates(overlay);
   let closed = false;
   /** @type {Set<MediaStream>} */
   const activeGlassStreams = new Set();

--- a/js/light-tool-camera.js
+++ b/js/light-tool-camera.js
@@ -1,7 +1,7 @@
 // @ts-check
 // light-tool-camera.js — Shared camera/runtime helpers for Light tools.
 
-import { escapeHTML } from './utils.js';
+import { escapeAttr, escapeHTML } from './utils.js';
 
 // Per-tool "where to aim the camera" guide. Spelt out because the
 // difference between "what hits you" tools (lux, sleep darkness, eye-
@@ -50,6 +50,27 @@ const _AIMING_GUIDES = {
   },
 };
 
+let aimingGuideDelegatesInstalled = false;
+
+function _handleAimingGuideClick(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const actionEl = target.closest('[data-aiming-guide-action]');
+  if (!(actionEl instanceof HTMLElement)) return;
+  const action = actionEl.dataset.aimingGuideAction || '';
+  if (action !== 'dismiss') return;
+  const toolKey = actionEl.dataset.tool || '';
+  if (!toolKey) return;
+  event.preventDefault();
+  window._dismissAimingGuide?.(toolKey);
+}
+
+function installAimingGuideDelegates() {
+  if (aimingGuideDelegatesInstalled || typeof document === 'undefined') return;
+  aimingGuideDelegatesInstalled = true;
+  document.addEventListener('click', _handleAimingGuideClick);
+}
+
 // Returns a small expandable info card for the tool modal. Persists per-
 // tool dismissal in localStorage so users who've internalized the
 // guidance don't have to dismiss it on every open.
@@ -64,7 +85,7 @@ export function aimingGuideHTML(toolKey) {
     <div class="tool-aiming-guide-head">
       <span class="tool-aiming-guide-icon">📐</span>
       <span class="tool-aiming-guide-mode">${escapeHTML(g.mode)}</span>
-      <button type="button" class="tool-aiming-guide-dismiss" onclick="window._dismissAimingGuide && window._dismissAimingGuide('${escapeHTML(toolKey)}')" aria-label="Dismiss aiming guide">×</button>
+      <button type="button" class="tool-aiming-guide-dismiss" data-aiming-guide-action="dismiss" data-tool="${escapeAttr(toolKey)}" aria-label="Dismiss aiming guide">×</button>
     </div>
     <div class="tool-aiming-guide-body">${g.body}</div>
     ${g.webcam ? `<div class="tool-aiming-guide-webcam">${g.webcam}</div>` : ''}
@@ -72,6 +93,7 @@ export function aimingGuideHTML(toolKey) {
 }
 
 if (typeof window !== 'undefined') {
+  installAimingGuideDelegates();
   window._dismissAimingGuide = (toolKey) => {
     try { localStorage.setItem(`labcharts-aim-guide-${toolKey}`, 'dismissed'); } catch (_) {}
     // Hide the currently-rendered guide without re-rendering the whole modal.

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 447,
+  "inlineEventAttributes": 434,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js
+++ b/tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js
@@ -41,6 +41,17 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
       return false;
     };
     const dispatchInput = input => input.dispatchEvent(new Event('input', { bubbles: true }));
+    const delegatedModalChecks = [];
+    const recordDelegatedClose = (label, action) => {
+      const overlay = document.querySelector('.light-tool-overlay');
+      const html = overlay?.innerHTML || '';
+      delegatedModalChecks.push({
+        label,
+        ok: !!overlay
+          && !/\bon(?:click|keydown|submit|change|input)=/.test(html)
+          && overlay.querySelectorAll(`[data-light-tool-modal-action="${action}"]`).length >= 2,
+      });
+    };
 
     const deps = {
       saveMeasurement: async (kind, value, meta) => {
@@ -142,6 +153,7 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
 
       mode = 'lux-camera';
       await modals.openLuxMeter({ roomId: 'camera-room' }, deps);
+      recordDelegatedClose('lux camera modal', 'close-lux');
       await waitFor(
         () => document.getElementById('lux-value')?.textContent !== '\u2014',
         'camera lux reading'
@@ -177,6 +189,7 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
 
       mode = 'lux-manual';
       await modals.openLuxMeter({ roomId: 'manual-room' }, deps);
+      recordDelegatedClose('lux manual modal', 'close-lux');
       await waitFor(() => !!document.getElementById('lux-manual-input'), 'manual lux input');
       const manualInput = document.getElementById('lux-manual-input');
       manualInput.value = '55';
@@ -192,6 +205,7 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
 
       mode = 'flicker';
       await modals.openFlickerDetector({ roomId: 'flicker-room' }, deps);
+      recordDelegatedClose('flicker modal', 'close-flicker');
       await waitFor(
         () => /flicker|banding/i.test(document.getElementById('flicker-result')?.textContent || ''),
         'flicker result'
@@ -210,6 +224,7 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
 
       mode = 'cct';
       await modals.openCCTMeter({ roomId: 'cct-room' }, deps);
+      recordDelegatedClose('cct modal', 'close-cct');
       await waitFor(() => /\d+\s*K$/.test(document.getElementById('cct-value')?.textContent || ''), 'cct result');
       document.getElementById('cct-save')?.click();
       await waitFor(() => savedReadings.some(item => item.kind === 'cct'), 'cct save');
@@ -223,6 +238,7 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
 
       mode = 'spectrum-camera';
       await modals.openSpectrumClassifier({ roomId: 'spectrum-camera-room' }, deps);
+      recordDelegatedClose('spectrum camera modal', 'close-spec');
       await waitFor(
         () => /Fluorescent|confidence/i.test(document.getElementById('spec-result')?.textContent || ''),
         'spectrum camera classification'
@@ -241,6 +257,7 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
 
       mode = 'spectrum-manual';
       await modals.openSpectrumClassifier({ roomId: 'spectrum-room' }, deps);
+      recordDelegatedClose('spectrum manual modal', 'close-spec');
       await waitFor(() => !!document.querySelector('[data-spec-manual="Cool LED (4000K+)"]'), 'spectrum manual choices');
       document.querySelector('[data-spec-manual="Cool LED (4000K+)"]')?.click();
       document.getElementById('spec-save')?.click();
@@ -254,6 +271,7 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
 
       mode = 'glass';
       await modals.openGlassTransmission({ roomId: 'glass-room' }, deps);
+      recordDelegatedClose('glass modal', 'close-glass');
       document.getElementById('glass-measure-inside')?.click();
       await waitFor(() => /lux/.test(document.getElementById('glass-reading-inside')?.textContent || ''), 'glass inside reading');
       document.getElementById('glass-measure-outside')?.click();
@@ -267,6 +285,10 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
         && glass.meta.roomId === 'glass-room'
         && glass.meta.confidence === 0.7
         && glass.meta.extra.inside < glass.meta.extra.outside);
+      const failedDelegatedChecks = delegatedModalChecks.filter(item => !item.ok);
+      check('Camera tool modals render delegated close controls without inline handlers',
+        failedDelegatedChecks.length === 0,
+        failedDelegatedChecks.map(item => item.label).join(', '));
     } finally {
       Object.defineProperty(navigator, 'mediaDevices', {
         configurable: true,

--- a/tests/test-light-tool-camera-modal-delegates.js
+++ b/tests/test-light-tool-camera-modal-delegates.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Static guards for light camera modal close controls.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const modalSrc = fs.readFileSync(path.join(root, 'js/light-tool-camera-modals.js'), 'utf8');
+const cameraSrc = fs.readFileSync(path.join(root, 'js/light-tool-camera.js'), 'utf8');
+const src = `${modalSrc}\n${cameraSrc}`;
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+function countNeedle(needle) {
+  return src.split(needle).length - 1;
+}
+
+const closeActions = [
+  'close-lux',
+  'close-flicker',
+  'close-dark',
+  'close-cct',
+  'close-spec',
+  'close-glass',
+];
+const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
+
+console.log('=== Light Tool Camera Modal Delegates ===');
+
+assert('light camera modal templates render no inline event attributes',
+  !inlineHandlerRe.test(src));
+assert('light camera modals use shared delegated action helper',
+  modalSrc.includes('function lightToolModalActionAttrs') &&
+    modalSrc.includes('data-light-tool-modal-action') &&
+    modalSrc.includes('function _handleLightToolModalClick') &&
+    modalSrc.includes("overlay.addEventListener('click', _handleLightToolModalClick);"));
+assert('light camera aiming guide dismiss uses delegated action helper',
+  cameraSrc.includes('data-aiming-guide-action="dismiss"') &&
+    cameraSrc.includes('function _handleAimingGuideClick') &&
+    cameraSrc.includes("document.addEventListener('click', _handleAimingGuideClick)") &&
+    cameraSrc.includes('window._dismissAimingGuide?.(toolKey);'));
+
+for (const action of closeActions) {
+  assert(`light camera close action ${action} is rendered twice`,
+    modalSrc.split(`lightToolModalActionAttrs('${action}')`).length - 1 === 2);
+  assert(`light camera close action ${action} is handled`,
+    modalSrc.includes(`action === '${action}'`));
+}
+
+assert('light camera close delegates are installed for each modal',
+  modalSrc.split('installLightToolModalDelegates(overlay);').length - 1 === 6);
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.493';
+self.APP_VERSION = '1.8.494';


### PR DESCRIPTION
## Summary
- Convert light camera tool modal close/done/cancel controls to delegated `data-light-tool-modal-action` handlers.
- Convert the shared light camera aiming-guide dismiss control to a delegated action.
- Add static and browser coverage that live light camera modal DOM no longer renders inline handlers, ratchet the inline-handler baseline to 434, and bump `APP_VERSION` to `1.8.494`.

## Validation
- `node tests/test-light-tool-camera-modal-delegates.js`
- `npm run quality`
- `npm run typecheck`
- `npm test`
- `npx playwright test tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js --project=chromium`
- `npx playwright test tests/playwright/light-tools-browser-coverage.spec.js --project=chromium`
- `npx playwright test tests/playwright/light-sun-coverage-batch.spec.js --project=chromium --grep "light camera tool modals"`
- `git diff --check`
- `./run-tests.sh`
