### PR TITLE
[codex] Delegate light AI verdict actions

### DIFF
--- a/js/ai-action-delegates.js
+++ b/js/ai-action-delegates.js
@@ -5,9 +5,10 @@ import { escapeAttr } from './utils.js';
 
 let aiActionDelegatesInstalled = false;
 
-function callWindowAction(name, targetId = '') {
+function callWindowAction(name, targetId) {
   const fn = /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (window))[name];
   if (typeof fn !== 'function') return undefined;
+  if (targetId === undefined) return fn();
   return fn(targetId);
 }
 
@@ -53,6 +54,8 @@ function _handleAIActionClick(event) {
 export function installAIActionDelegates(root = typeof document !== 'undefined' ? document : null) {
   if (!root || aiActionDelegatesInstalled) return;
   aiActionDelegatesInstalled = true;
+  // Capture is intentional for data-ai-stop-propagation controls nested in
+  // clickable rows: it blocks row-level bubble delegates before they open.
   root.addEventListener('click', _handleAIActionClick, true);
 }
 

--- a/js/ai-action-delegates.js
+++ b/js/ai-action-delegates.js
@@ -19,10 +19,10 @@ const AI_ACTIONS = {
   'refresh-audit': (targetId) => callWindowAction('refreshAuditAIAnalysis', targetId),
   'refresh-room': (targetId) => callWindowAction('refreshRoomAIAnalysis', targetId),
   'refresh-screen': (targetId) => callWindowAction('refreshScreenAIAnalysis', targetId),
-  'refresh-day': (targetId) => callWindowAction('refreshDayAIAnalysis', targetId || undefined),
-  'refresh-channel-mix': () => callWindowAction('refreshChannelMixAI'),
-  'refresh-burden': () => callWindowAction('refreshBurdenAIAnalysis'),
-  'refresh-onboarding': () => callWindowAction('refreshOnboardingAIAnalysis'),
+  'refresh-day': (targetId) => callWindowAction('refreshDayAIAnalysis', targetId),
+  'refresh-channel-mix': () => callWindowAction('refreshChannelMixAI', undefined),
+  'refresh-burden': () => callWindowAction('refreshBurdenAIAnalysis', undefined),
+  'refresh-onboarding': () => callWindowAction('refreshOnboardingAIAnalysis', undefined),
 };
 
 export function aiActionAttrs(action, targetId = '', opts = {}) {
@@ -48,7 +48,7 @@ function _handleAIActionClick(event) {
   const handler = AI_ACTIONS[action];
   if (!handler) return;
   event.preventDefault();
-  handler(actionEl.dataset.aiTarget || '');
+  handler(actionEl.dataset.aiTarget);
 }
 
 export function installAIActionDelegates(root = typeof document !== 'undefined' ? document : null) {

--- a/js/ai-action-delegates.js
+++ b/js/ai-action-delegates.js
@@ -41,6 +41,8 @@ function _handleAIActionClick(event) {
   const action = actionEl.dataset.aiAction || '';
   if (!action) return;
   if (action === 'stop-propagation' || actionEl.dataset.aiStopPropagation === 'true') {
+    // This document-level capture listener intentionally stops downstream
+    // capture/target handlers as well as row-level bubble delegates.
     event.stopPropagation();
   }
   if (action === 'stop-propagation') return;
@@ -54,8 +56,6 @@ function _handleAIActionClick(event) {
 export function installAIActionDelegates(root = typeof document !== 'undefined' ? document : null) {
   if (!root || aiActionDelegatesInstalled) return;
   aiActionDelegatesInstalled = true;
-  // Capture is intentional for data-ai-stop-propagation controls nested in
-  // clickable rows: it blocks row-level bubble delegates before they open.
   root.addEventListener('click', _handleAIActionClick, true);
 }
 

--- a/js/ai-action-delegates.js
+++ b/js/ai-action-delegates.js
@@ -1,0 +1,61 @@
+// @ts-check
+// ai-action-delegates.js - shared delegated actions for AI verdict controls.
+
+import { escapeAttr } from './utils.js';
+
+let aiActionDelegatesInstalled = false;
+
+function callWindowAction(name, targetId = '') {
+  const fn = /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (window))[name];
+  if (typeof fn !== 'function') return undefined;
+  return fn(targetId);
+}
+
+const AI_ACTIONS = {
+  'refresh-sun-session': (targetId) => callWindowAction('refreshSessionAIAnalysis', targetId),
+  'refresh-device-session': (targetId) => callWindowAction('refreshDeviceSessionAIAnalysis', targetId),
+  'refresh-measurement': (targetId) => callWindowAction('refreshMeasurementAIAnalysis', targetId),
+  'refresh-audit': (targetId) => callWindowAction('refreshAuditAIAnalysis', targetId),
+  'refresh-room': (targetId) => callWindowAction('refreshRoomAIAnalysis', targetId),
+  'refresh-screen': (targetId) => callWindowAction('refreshScreenAIAnalysis', targetId),
+  'refresh-day': (targetId) => callWindowAction('refreshDayAIAnalysis', targetId || undefined),
+  'refresh-channel-mix': () => callWindowAction('refreshChannelMixAI'),
+  'refresh-burden': () => callWindowAction('refreshBurdenAIAnalysis'),
+  'refresh-onboarding': () => callWindowAction('refreshOnboardingAIAnalysis'),
+};
+
+export function aiActionAttrs(action, targetId = '', opts = {}) {
+  const attrs = [`data-ai-action="${escapeAttr(action)}"`];
+  if (targetId != null && targetId !== '') attrs.push(`data-ai-target="${escapeAttr(String(targetId))}"`);
+  if (opts.stopPropagation) attrs.push('data-ai-stop-propagation="true"');
+  return attrs.join(' ');
+}
+
+function _handleAIActionClick(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const actionEl = target.closest('[data-ai-action]');
+  if (!actionEl || !actionEl.dataset) return;
+
+  const action = actionEl.dataset.aiAction || '';
+  if (!action) return;
+  if (action === 'stop-propagation' || actionEl.dataset.aiStopPropagation === 'true') {
+    event.stopPropagation();
+  }
+  if (action === 'stop-propagation') return;
+
+  const handler = AI_ACTIONS[action];
+  if (!handler) return;
+  event.preventDefault();
+  handler(actionEl.dataset.aiTarget || '');
+}
+
+export function installAIActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || aiActionDelegatesInstalled) return;
+  aiActionDelegatesInstalled = true;
+  root.addEventListener('click', _handleAIActionClick, true);
+}
+
+if (typeof window !== 'undefined') {
+  installAIActionDelegates();
+}

--- a/js/light-audit-ai-analysis.js
+++ b/js/light-audit-ai-analysis.js
@@ -19,6 +19,7 @@ import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { getRoomEveningHoursAfterSunset } from './light-env-evening.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 function _getAudits() {
   if (!state.importedData) return [];
@@ -245,7 +246,7 @@ export function renderAuditAIBlock(a) {
         <div class="sun-detail-ai-head">
           <span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)}" aria-hidden="true"></span>
           <span class="sun-detail-ai-tip"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(verdict.tip || '')}</span>
-          <button class="sun-session-ai-refresh" onclick="window.refreshAuditAIAnalysis('${escapeAttr(a.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
+          <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-audit', a.id)} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
         </div>
         ${verdict.detail ? `<div class="sun-detail-ai-body">${escapeHTML(verdict.detail)}</div>` : ''}
       </div>
@@ -258,7 +259,7 @@ export function renderAuditAIBlock(a) {
       <div class="sun-detail-ai sun-detail-ai-error">
         <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
         <span>${escapeHTML(msg)}</span>
-        <button class="sun-session-ai-refresh" onclick="window.refreshAuditAIAnalysis('${escapeAttr(a.id)}')">Try again</button>
+        <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-audit', a.id)}>Try again</button>
       </div>
     </div>`;
   }
@@ -267,7 +268,7 @@ export function renderAuditAIBlock(a) {
     <div class="sun-detail-ai sun-detail-ai-idle">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>Get a circadian-friendliness verdict for this entire snapshot.</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshAuditAIAnalysis('${escapeAttr(a.id)}')">Analyze audit</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-audit', a.id)}>Analyze audit</button>
     </div>
   </div>`;
 }

--- a/js/light-burden-ai-analysis.js
+++ b/js/light-burden-ai-analysis.js
@@ -23,6 +23,7 @@ import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { computeDeficitAxes, computeIndoorBurden, isActiveToday } from './light-env.js';
 import { getRoomEveningHoursAfterSunset } from './light-env-evening.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 function _getEnv() {
   if (!state.importedData) return null;
@@ -237,14 +238,14 @@ export function renderBurdenInterp(burden) {
     return `<div class="light-env-summary-ai light-env-summary-ai-${dot}">
       <span class="sun-session-ai-dot sun-session-ai-dot-${dot}" aria-hidden="true"></span>
       <span class="light-env-summary-ai-tip"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(a.tip || '')}</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshBurdenAIAnalysis()" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-burden')} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
       ${a.detail ? `<div class="light-env-summary-ai-detail">${escapeHTML(a.detail)}</div>` : ''}
     </div>`;
   }
   if (status === 'error') {
     return `<div class="light-env-summary-ai">
       <p class="light-env-summary-interp">${escapeHTML(heuristic)}</p>
-      <button class="sun-session-ai-refresh light-env-summary-ai-cta" onclick="window.refreshBurdenAIAnalysis()">AI verdict failed — retry</button>
+      <button class="sun-session-ai-refresh light-env-summary-ai-cta" ${aiActionAttrs('refresh-burden')}>AI verdict failed — retry</button>
     </div>`;
   }
   // Idle, OR cached but stale (env changed since last analyze). Show the
@@ -253,7 +254,7 @@ export function renderBurdenInterp(burden) {
   const ctaLabel = stale ? 'Refresh AI verdict (your setup changed)' : '✨ Get AI verdict';
   return `<div class="light-env-summary-ai">
     <p class="light-env-summary-interp">${escapeHTML(heuristic)}</p>
-    <button class="sun-session-ai-refresh light-env-summary-ai-cta" onclick="window.refreshBurdenAIAnalysis()">${escapeHTML(ctaLabel)}</button>
+    <button class="sun-session-ai-refresh light-env-summary-ai-cta" ${aiActionAttrs('refresh-burden')}>${escapeHTML(ctaLabel)}</button>
   </div>`;
 }
 

--- a/js/light-channels-ai-analysis.js
+++ b/js/light-channels-ai-analysis.js
@@ -19,6 +19,7 @@ import { escapeHTML, escapeAttr } from './utils.js';
 import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 function _getMix() {
   return state.importedData?.channelMixAI || null;
@@ -235,7 +236,7 @@ export function renderChannelMixVerdict(staticFallback) {
         <div class="sun-detail-ai-head">
           <span class="sun-session-ai-dot sun-session-ai-dot-${dot}" aria-hidden="true"></span>
           <span class="sun-detail-ai-tip"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(a.tip || '')}</span>
-          <button class="sun-session-ai-refresh" onclick="window.refreshChannelMixAI()" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
+          <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-channel-mix')} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
         </div>
         ${a.detail ? `<div class="sun-detail-ai-body">${escapeHTML(a.detail)}</div>` : ''}
       </div>
@@ -245,14 +246,14 @@ export function renderChannelMixVerdict(staticFallback) {
     const msg = a?.errorMessage ? `Analysis failed — ${a.errorMessage}` : 'Analysis failed.';
     return `<div class="light-channel-mix-ai">
       ${staticFallback || ''}
-      <button class="sun-session-ai-refresh light-channel-mix-ai-cta" onclick="window.refreshChannelMixAI()">${escapeHTML(msg)} — retry</button>
+      <button class="sun-session-ai-refresh light-channel-mix-ai-cta" ${aiActionAttrs('refresh-channel-mix')}>${escapeHTML(msg)} — retry</button>
     </div>`;
   }
   // Idle, OR cached but stale (channels shifted since last run).
   const ctaLabel = stale ? '✨ Refresh AI verdict (your mix changed)' : '✨ Get AI synthesis of your mix';
   return `<div class="light-channel-mix-ai">
     ${staticFallback || ''}
-    <button class="sun-session-ai-refresh light-channel-mix-ai-cta" onclick="window.refreshChannelMixAI()">${escapeHTML(ctaLabel)}</button>
+    <button class="sun-session-ai-refresh light-channel-mix-ai-cta" ${aiActionAttrs('refresh-channel-mix')}>${escapeHTML(ctaLabel)}</button>
   </div>`;
 }
 

--- a/js/light-device-ai-analysis.js
+++ b/js/light-device-ai-analysis.js
@@ -14,6 +14,7 @@ import { getDevices, getDeviceSessions } from './light-devices.js';
 import { CHANNEL_DISPLAY, channelTier, tierLabel, formatChannelUnit, BODY_REGIONS } from './sun.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 // ─── Fingerprint ───────────────────────────────────────────────────────
 
@@ -251,16 +252,16 @@ export function renderDeviceSessionAIInline(sess) {
   if (!hasAIProvider() && !(sess.aiAnalysis?.status === 'ok' && sess.aiAnalysis?.dot)) return '';
   const status = engine.getStatus(sess);
   const a = sess.aiAnalysis;
-  const refreshBtn = `<button class="sun-session-ai-refresh" onclick="event.stopPropagation();window.refreshDeviceSessionAIAnalysis('${escapeAttr(sess.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`;
+  const refreshBtn = `<button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-device-session', sess.id, { stopPropagation: true })} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`;
   if (status === 'analyzing') {
-    return `<div class="sun-session-ai" onclick="event.stopPropagation()">
+    return `<div class="sun-session-ai" ${aiActionAttrs('stop-propagation')}>
       <span class="sun-session-ai-dot sun-session-ai-dot-shimmer" aria-hidden="true"></span>
       <span class="sun-session-ai-tip">Analyzing…</span>
     </div>`;
   }
   if (status === 'ok') {
     const dot = a.dot;
-    return `<div class="sun-session-ai" onclick="event.stopPropagation()">
+    return `<div class="sun-session-ai" ${aiActionAttrs('stop-propagation')}>
       <span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)}" aria-hidden="true"></span>
       <span class="sun-session-ai-tip sun-session-ai-tip-${escapeAttr(dot)}"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(a.tip || '')}</span>
       ${refreshBtn}
@@ -268,15 +269,15 @@ export function renderDeviceSessionAIInline(sess) {
   }
   if (status === 'error') {
     const msg = a?.errorMessage ? `Analysis failed — ${a.errorMessage}` : 'Analysis failed';
-    return `<div class="sun-session-ai sun-session-ai-error" onclick="event.stopPropagation()">
+    return `<div class="sun-session-ai sun-session-ai-error" ${aiActionAttrs('stop-propagation')}>
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span class="sun-session-ai-tip" title="${escapeAttr(msg)}">${escapeHTML(msg)}</span>
       ${refreshBtn}
     </div>`;
   }
-  return `<div class="sun-session-ai sun-session-ai-idle" onclick="event.stopPropagation()">
+  return `<div class="sun-session-ai sun-session-ai-idle" ${aiActionAttrs('stop-propagation')}>
     <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
-    <button class="sun-session-ai-cta" onclick="event.stopPropagation();window.refreshDeviceSessionAIAnalysis('${escapeAttr(sess.id)}')">Analyze this session</button>
+    <button class="sun-session-ai-cta" ${aiActionAttrs('refresh-device-session', sess.id, { stopPropagation: true })}>Analyze this session</button>
   </div>`;
 }
 
@@ -296,14 +297,14 @@ export function renderDeviceSessionAIDetail(sess) {
     return `<div class="sun-detail-ai sun-detail-ai-error">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>${escapeHTML(msg)}</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshDeviceSessionAIAnalysis('${escapeAttr(sess.id)}')">Try again</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-device-session', sess.id)}>Try again</button>
     </div>`;
   }
   if (status !== 'ok') {
     return `<div class="sun-detail-ai sun-detail-ai-idle">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>Not analyzed yet.</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshDeviceSessionAIAnalysis('${escapeAttr(sess.id)}')">Analyze now</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-device-session', sess.id)}>Analyze now</button>
     </div>`;
   }
   const dot = a.dot;
@@ -313,7 +314,7 @@ export function renderDeviceSessionAIDetail(sess) {
     <div class="sun-detail-ai-head">
       <span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)}" aria-hidden="true"></span>
       <span class="sun-detail-ai-tip">${escapeHTML(tip)}</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshDeviceSessionAIAnalysis('${escapeAttr(sess.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-device-session', sess.id)} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
     </div>
     ${detail ? `<div class="sun-detail-ai-body">${escapeHTML(detail)}</div>` : ''}
   </div>`;

--- a/js/light-env-ai-analysis.js
+++ b/js/light-env-ai-analysis.js
@@ -13,6 +13,7 @@ import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { getRoomEveningHoursAfterSunset } from './light-env-evening.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 function _getRooms() { return state.importedData?.lightEnvironment?.rooms || []; }
 function _getMeasurementsForRoom(roomId) {
@@ -236,7 +237,7 @@ export function renderRoomAIBlock(r) {
       <span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)}" aria-hidden="true"></span>
       <span class="light-env-room-ai-label">AI read</span>
       <span class="light-env-room-ai-tip"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(a.tip || '')}</span>
-      <button class="sun-session-ai-refresh light-env-room-ai-refresh" onclick="window.refreshRoomAIAnalysis('${escapeAttr(r.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`);
+      <button class="sun-session-ai-refresh light-env-room-ai-refresh" ${aiActionAttrs('refresh-room', r.id)} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`);
   }
   if (status === 'error') {
     const msg = a?.errorMessage ? `Analysis failed — ${a.errorMessage}` : 'Analysis failed.';
@@ -244,13 +245,13 @@ export function renderRoomAIBlock(r) {
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span class="light-env-room-ai-label">AI read</span>
       <span class="light-env-room-ai-tip">${escapeHTML(msg)}</span>
-      <button class="sun-session-ai-refresh light-env-room-ai-refresh" onclick="window.refreshRoomAIAnalysis('${escapeAttr(r.id)}')">Try again</button>`);
+      <button class="sun-session-ai-refresh light-env-room-ai-refresh" ${aiActionAttrs('refresh-room', r.id)}>Try again</button>`);
   }
   return renderInline('idle', `
     <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
     <span class="light-env-room-ai-label">AI read</span>
     <span class="light-env-room-ai-tip">Circadian-friendliness check for this room.</span>
-    <button class="sun-session-ai-refresh light-env-room-ai-refresh" onclick="window.refreshRoomAIAnalysis('${escapeAttr(r.id)}')">Analyze</button>`);
+    <button class="sun-session-ai-refresh light-env-room-ai-refresh" ${aiActionAttrs('refresh-room', r.id)}>Analyze</button>`);
 }
 
 Object.assign(window, {

--- a/js/light-screen-ai-analysis.js
+++ b/js/light-screen-ai-analysis.js
@@ -14,6 +14,7 @@ import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 function _getScreens() { return state.importedData?.lightEnvironment?.screens || []; }
 function _getRooms() { return state.importedData?.lightEnvironment?.rooms || []; }
@@ -163,7 +164,7 @@ export function renderScreenAIBlock(s) {
         <div class="sun-detail-ai-head">
           <span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)}" aria-hidden="true"></span>
           <span class="sun-detail-ai-tip"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(a.tip || '')}</span>
-          <button class="sun-session-ai-refresh" onclick="window.refreshScreenAIAnalysis('${escapeAttr(s.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
+          <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-screen', s.id)} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
         </div>
         ${a.detail ? `<div class="sun-detail-ai-body">${escapeHTML(a.detail)}</div>` : ''}
       </div>
@@ -176,7 +177,7 @@ export function renderScreenAIBlock(s) {
       <div class="sun-detail-ai sun-detail-ai-error">
         <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
         <span>${escapeHTML(msg)}</span>
-        <button class="sun-session-ai-refresh" onclick="window.refreshScreenAIAnalysis('${escapeAttr(s.id)}')">Try again</button>
+        <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-screen', s.id)}>Try again</button>
       </div>
     </div>`;
   }
@@ -185,7 +186,7 @@ export function renderScreenAIBlock(s) {
     <div class="sun-detail-ai sun-detail-ai-idle">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>Get a circadian-impact verdict for this screen.</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshScreenAIAnalysis('${escapeAttr(s.id)}')">Analyze screen</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-screen', s.id)}>Analyze screen</button>
     </div>
   </div>`;
 }

--- a/js/light-today-ai.js
+++ b/js/light-today-ai.js
@@ -13,6 +13,7 @@ import { CHANNEL_DISPLAY, formatChannelUnit, channelTier, tierLabel } from './su
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 // Cap user-supplied free-text fields fed into prompt context. A device named
 // "Glow\n[SYSTEM: ignore previous]" would otherwise break out of the prompt.
@@ -386,7 +387,7 @@ export function renderLightTodayHero() {
     return `<div class="light-today-hero light-today-hero-${dot}">
       <div class="light-today-hero-head">
         <span class="light-today-hero-label">Today's light</span>
-        <button class="sun-session-ai-refresh" onclick="window.refreshDayAIAnalysis()" title="Re-run today's verdict" aria-label="Re-run today's verdict">↻</button>
+        <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-day')} title="Re-run today's verdict" aria-label="Re-run today's verdict">↻</button>
       </div>
       <div class="sun-detail-ai sun-detail-ai-${dot}">
         <div class="sun-detail-ai-head">
@@ -405,7 +406,7 @@ export function renderLightTodayHero() {
       <div class="sun-detail-ai sun-detail-ai-error">
         <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
         <span>${escapeHTML(msg)}</span>
-        <button class="sun-session-ai-refresh" onclick="window.refreshDayAIAnalysis()">Try again</button>
+        <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-day')}>Try again</button>
       </div>
       ${trendBar}
     </div>`;
@@ -415,7 +416,7 @@ export function renderLightTodayHero() {
     <div class="sun-detail-ai sun-detail-ai-idle">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>Get an AI read on today's full picture — sun, devices, environment, trends.</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshDayAIAnalysis()">Run today's verdict</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-day')}>Run today's verdict</button>
     </div>
     ${trendBar}
   </div>`;
@@ -469,7 +470,7 @@ export function renderLightTodayDashboardChip() {
       <div class="light-today-dash-ai-row">
         <span class="sun-session-ai-dot sun-session-ai-dot-${dot}" aria-hidden="true"></span>
         <span class="light-today-dash-ai-tip"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(cached.tip || '')}</span>
-        <button class="sun-session-ai-refresh" onclick="window.refreshDayAIAnalysis()" title="Re-run today's verdict" aria-label="Re-run today's verdict">↻</button>
+        <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-day')} title="Re-run today's verdict" aria-label="Re-run today's verdict">↻</button>
       </div>
       ${cached.detail ? `<div class="light-today-dash-ai-body">
         <p>${escapeHTML(cached.detail)}</p>
@@ -478,12 +479,12 @@ export function renderLightTodayDashboardChip() {
   }
   if (status === 'error') {
     const msg = cached?.errorMessage || 'AI verdict failed — retry';
-    return `<button class="light-today-dash-ai light-today-dash-ai-cta" onclick="window.refreshDayAIAnalysis()">
+    return `<button class="light-today-dash-ai light-today-dash-ai-cta" ${aiActionAttrs('refresh-day')}>
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span class="light-today-dash-ai-tip">${escapeHTML(msg)}</span>
     </button>`;
   }
-  return `<button class="light-today-dash-ai light-today-dash-ai-cta" onclick="window.refreshDayAIAnalysis()">
+  return `<button class="light-today-dash-ai light-today-dash-ai-cta" ${aiActionAttrs('refresh-day')}>
     <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
     <span class="light-today-dash-ai-tip">✨ Get today's AI verdict</span>
   </button>`;

--- a/js/light-tools-ai-analysis.js
+++ b/js/light-tools-ai-analysis.js
@@ -13,6 +13,7 @@ import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 function _formatNumber(n, digits = 1) {
   if (n == null || !Number.isFinite(n)) return '—';
@@ -221,7 +222,7 @@ export function renderMeasurementAIInline(m) {
   if (!hasAIProvider() && !(m.aiAnalysis?.status === 'ok' && m.aiAnalysis?.dot)) return '';
   const status = engine.getStatus(m);
   const a = m.aiAnalysis;
-  const refreshBtn = `<button class="sun-session-ai-refresh" onclick="event.stopPropagation();window.refreshMeasurementAIAnalysis('${escapeAttr(m.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`;
+  const refreshBtn = `<button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-measurement', m.id, { stopPropagation: true })} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`;
   if (status === 'analyzing') {
     return `<div class="light-env-reading-ai">
       <span class="sun-session-ai-dot sun-session-ai-dot-shimmer" aria-hidden="true"></span>
@@ -245,7 +246,7 @@ export function renderMeasurementAIInline(m) {
   }
   return `<div class="light-env-reading-ai sun-session-ai-idle">
     <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
-    <button class="sun-session-ai-cta" onclick="event.stopPropagation();window.refreshMeasurementAIAnalysis('${escapeAttr(m.id)}')" title="Run an AI verdict on this measurement — flags significant issues and suggests fixes">Get AI verdict</button>
+    <button class="sun-session-ai-cta" ${aiActionAttrs('refresh-measurement', m.id, { stopPropagation: true })} title="Run an AI verdict on this measurement — flags significant issues and suggests fixes">Get AI verdict</button>
   </div>`;
 }
 

--- a/js/sun-ai-analysis.js
+++ b/js/sun-ai-analysis.js
@@ -17,6 +17,7 @@ import { getSunDefaults } from './sun-defaults.js';
 import { getSessions, formatChannelUnit, CHANNEL_DISPLAY, channelTier, tierLabel } from './sun.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 // ─── Fingerprint ───────────────────────────────────────────────────────
 //
@@ -275,16 +276,16 @@ export function renderSessionAIInline(sess) {
   if (!hasAIProvider() && !(sess.aiAnalysis?.status === 'ok' && sess.aiAnalysis?.dot)) return '';
   const status = engine.getStatus(sess);
   const a = sess.aiAnalysis;
-  const refreshBtn = `<button class="sun-session-ai-refresh" onclick="event.stopPropagation();window.refreshSessionAIAnalysis('${escapeAttr(sess.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`;
+  const refreshBtn = `<button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-sun-session', sess.id, { stopPropagation: true })} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>`;
   if (status === 'analyzing') {
-    return `<div class="sun-session-ai" onclick="event.stopPropagation()">
+    return `<div class="sun-session-ai" ${aiActionAttrs('stop-propagation')}>
       <span class="sun-session-ai-dot sun-session-ai-dot-shimmer" aria-hidden="true"></span>
       <span class="sun-session-ai-tip">Analyzing…</span>
     </div>`;
   }
   if (status === 'ok') {
     const dot = a.dot;
-    return `<div class="sun-session-ai" onclick="event.stopPropagation()">
+    return `<div class="sun-session-ai" ${aiActionAttrs('stop-propagation')}>
       <span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)}" aria-hidden="true"></span>
       <span class="sun-session-ai-tip sun-session-ai-tip-${escapeAttr(dot)}"><span class="sun-session-ai-prefix" aria-hidden="true">${dotPrefix(dot)}</span> ${escapeHTML(a.tip || '')}</span>
       ${refreshBtn}
@@ -292,15 +293,15 @@ export function renderSessionAIInline(sess) {
   }
   if (status === 'error') {
     const msg = a?.errorMessage ? `Analysis failed — ${a.errorMessage}` : 'Analysis failed';
-    return `<div class="sun-session-ai sun-session-ai-error" onclick="event.stopPropagation()">
+    return `<div class="sun-session-ai sun-session-ai-error" ${aiActionAttrs('stop-propagation')}>
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span class="sun-session-ai-tip" title="${escapeAttr(msg)}">${escapeHTML(msg)}</span>
       ${refreshBtn}
     </div>`;
   }
-  return `<div class="sun-session-ai sun-session-ai-idle" onclick="event.stopPropagation()">
+  return `<div class="sun-session-ai sun-session-ai-idle" ${aiActionAttrs('stop-propagation')}>
     <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
-    <button class="sun-session-ai-cta" onclick="event.stopPropagation();window.refreshSessionAIAnalysis('${escapeAttr(sess.id)}')">Analyze this session</button>
+    <button class="sun-session-ai-cta" ${aiActionAttrs('refresh-sun-session', sess.id, { stopPropagation: true })}>Analyze this session</button>
   </div>`;
 }
 
@@ -324,14 +325,14 @@ export function renderSessionAIDetail(sess) {
     return `<div class="sun-detail-ai sun-detail-ai-error">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>${escapeHTML(msg)}</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshSessionAIAnalysis('${escapeAttr(sess.id)}')">Try again</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-sun-session', sess.id)}>Try again</button>
     </div>`;
   }
   if (status !== 'ok') {
     return `<div class="sun-detail-ai sun-detail-ai-idle">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>Not analyzed yet.</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshSessionAIAnalysis('${escapeAttr(sess.id)}')">Analyze now</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-sun-session', sess.id)}>Analyze now</button>
     </div>`;
   }
   const dot = a.dot;
@@ -341,7 +342,7 @@ export function renderSessionAIDetail(sess) {
     <div class="sun-detail-ai-head">
       <span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)}" aria-hidden="true"></span>
       <span class="sun-detail-ai-tip">${escapeHTML(tip)}</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshSessionAIAnalysis('${escapeAttr(sess.id)}')" title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-sun-session', sess.id)} title="Re-run analysis" aria-label="Re-run AI analysis">↻</button>
     </div>
     ${detail ? `<div class="sun-detail-ai-body">${escapeHTML(detail)}</div>` : ''}
   </div>`;

--- a/js/sun-onboarding-ai.js
+++ b/js/sun-onboarding-ai.js
@@ -13,6 +13,7 @@ import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
+import { aiActionAttrs } from './ai-action-delegates.js';
 
 function _getDefaults() { return state.importedData?.sunDefaults || null; }
 
@@ -204,7 +205,7 @@ export function renderOnboardingAIBlock() {
     return `<div class="light-setup-ai-block light-setup-ai-block-${dot}">
       <div class="light-setup-ai-head">
         <span class="light-setup-ai-head-label">Your light context</span>
-        <button class="sun-session-ai-refresh" onclick="window.refreshOnboardingAIAnalysis()" title="Re-run analysis" aria-label="Re-run">↻</button>
+        <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-onboarding')} title="Re-run analysis" aria-label="Re-run">↻</button>
       </div>
       <div class="sun-detail-ai sun-detail-ai-${dot}">
         <div class="sun-detail-ai-head">
@@ -223,7 +224,7 @@ export function renderOnboardingAIBlock() {
       <div class="sun-detail-ai sun-detail-ai-error">
         <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
         <span>${escapeHTML(msg)}</span>
-        <button class="sun-session-ai-refresh" onclick="window.refreshOnboardingAIAnalysis()">Try again</button>
+        <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-onboarding')}>Try again</button>
       </div>
     </div>`;
   }
@@ -232,7 +233,7 @@ export function renderOnboardingAIBlock() {
     <div class="sun-detail-ai sun-detail-ai-idle">
       <span class="sun-session-ai-dot sun-session-ai-dot-gray" aria-hidden="true"></span>
       <span>Get a contextual read on your skin type, lighting environment, and goals.</span>
-      <button class="sun-session-ai-refresh" onclick="window.refreshOnboardingAIAnalysis()">Generate plan</button>
+      <button class="sun-session-ai-refresh" ${aiActionAttrs('refresh-onboarding')}>Generate plan</button>
     </div>
   </div>`;
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 434,
+  "inlineEventAttributes": 390,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/test-ai-action-delegates.js
+++ b/tests/test-ai-action-delegates.js
@@ -88,11 +88,19 @@ globalThis.window = dom.window;
 globalThis.document = dom.window.document;
 const { aiActionAttrs } = await import('../js/ai-action-delegates.js');
 
-let dayCalls = 0;
-window.refreshDayAIAnalysis = () => { dayCalls++; };
+let dayArgs = null;
+window.refreshDayAIAnalysis = (...args) => { dayArgs = args; };
 document.body.innerHTML = `<button id="day" ${aiActionAttrs('refresh-day')}>Run</button>`;
 document.getElementById('day')?.click();
-assert('delegated click routes action without a target id', dayCalls === 1);
+assert('delegated click routes action without a target id',
+  Array.isArray(dayArgs) && dayArgs.length === 0);
+
+let channelArgs = null;
+window.refreshChannelMixAI = (...args) => { channelArgs = args; };
+document.body.innerHTML = `<button id="channel" ${aiActionAttrs('refresh-channel-mix')}>Run</button>`;
+document.getElementById('channel')?.click();
+assert('delegated singleton action calls without an empty string argument',
+  Array.isArray(channelArgs) && channelArgs.length === 0);
 
 let routedSessionId = '';
 let rowOpened = false;

--- a/tests/test-ai-action-delegates.js
+++ b/tests/test-ai-action-delegates.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Static guards for delegated AI verdict controls.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { JSDOM } from 'jsdom';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const targetFiles = [
+  'js/sun-ai-analysis.js',
+  'js/light-device-ai-analysis.js',
+  'js/light-tools-ai-analysis.js',
+  'js/light-env-ai-analysis.js',
+  'js/light-screen-ai-analysis.js',
+  'js/light-audit-ai-analysis.js',
+  'js/light-today-ai.js',
+  'js/light-channels-ai-analysis.js',
+  'js/light-burden-ai-analysis.js',
+  'js/sun-onboarding-ai.js',
+];
+
+const actions = [
+  'refresh-sun-session',
+  'refresh-device-session',
+  'refresh-measurement',
+  'refresh-audit',
+  'refresh-room',
+  'refresh-screen',
+  'refresh-day',
+  'refresh-channel-mix',
+  'refresh-burden',
+  'refresh-onboarding',
+];
+
+const helperSrc = fs.readFileSync(path.join(root, 'js/ai-action-delegates.js'), 'utf8');
+const sources = Object.fromEntries(targetFiles.map(file => [
+  file,
+  fs.readFileSync(path.join(root, file), 'utf8'),
+]));
+const combined = Object.values(sources).join('\n');
+const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== AI Action Delegates ===');
+
+for (const [file, src] of Object.entries(sources)) {
+  assert(`${file} renders no inline event attributes`,
+    !inlineHandlerRe.test(src));
+  assert(`${file} imports shared AI action delegate`,
+    src.includes("from './ai-action-delegates.js'"));
+}
+
+assert('AI action helper installs one delegated capture click listener',
+  helperSrc.includes("root.addEventListener('click', _handleAIActionClick, true)") &&
+    helperSrc.includes('aiActionDelegatesInstalled'));
+assert('AI action helper escapes action and target attributes',
+  helperSrc.includes('escapeAttr(action)') &&
+    helperSrc.includes('escapeAttr(String(targetId))'));
+assert('AI action helper handles row-level stop propagation',
+  helperSrc.includes("action === 'stop-propagation'") &&
+    combined.includes("aiActionAttrs('stop-propagation')") &&
+    combined.includes('{ stopPropagation: true }'));
+
+for (const action of actions) {
+  assert(`AI action ${action} is mapped in helper`,
+    helperSrc.includes(`'${action}'`));
+  assert(`AI action ${action} is rendered by target modules`,
+    combined.includes(`aiActionAttrs('${action}'`));
+}
+
+const dom = new JSDOM('<!doctype html><body></body>');
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+const { aiActionAttrs } = await import('../js/ai-action-delegates.js');
+
+let dayCalls = 0;
+window.refreshDayAIAnalysis = () => { dayCalls++; };
+document.body.innerHTML = `<button id="day" ${aiActionAttrs('refresh-day')}>Run</button>`;
+document.getElementById('day')?.click();
+assert('delegated click routes action without a target id', dayCalls === 1);
+
+let routedSessionId = '';
+let rowOpened = false;
+window.refreshSessionAIAnalysis = id => { routedSessionId = id; };
+const row = document.createElement('div');
+row.addEventListener('click', () => { rowOpened = true; });
+row.innerHTML = `<button id="sun" ${aiActionAttrs('refresh-sun-session', 'sun-1', { stopPropagation: true })}>Refresh</button>`;
+document.body.append(row);
+document.getElementById('sun')?.click();
+assert('delegated row action routes target id',
+  routedSessionId === 'sun-1');
+assert('delegated row action stops parent row click before bubble phase',
+  rowOpened === false);
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-light-device-ai-analysis.js
+++ b/tests/test-light-device-ai-analysis.js
@@ -230,8 +230,8 @@ const {
     inlineGreen.includes('sun-session-ai-dot-green'));
   assert('inline emits the tip text',
     inlineGreen.includes('On-protocol UVB hit'));
-  assert('inline includes refresh button',
-    inlineGreen.includes('refreshDeviceSessionAIAnalysis'));
+  assert('inline includes delegated refresh action',
+    inlineGreen.includes('data-ai-action="refresh-device-session"'));
 
   // Yellow + red
   const inlineYellow = renderDeviceSessionAIInline(makeSess({

--- a/tests/test-sun-ai-analysis.js
+++ b/tests/test-sun-ai-analysis.js
@@ -231,7 +231,8 @@ const {
   assert('inline render emits tip text escaped',
     inlineGreen.includes('Solid 25-min midday hit, 42% MED.'),
     inlineGreen);
-  assert('inline render includes refresh button', inlineGreen.includes('refreshSessionAIAnalysis'));
+  assert('inline render includes delegated refresh action',
+    inlineGreen.includes('data-ai-action="refresh-sun-session"'));
 
   const inlineRed = renderSessionAIInline(makeSess({
     aiAnalysis: { dot: 'red', tip: 'Over MED at 105%.', status: 'ok', fingerprint: 'x', generatedAt: Date.now() },

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.494';
+self.APP_VERSION = '1.8.495';


### PR DESCRIPTION
## Summary
- Add a shared delegated `data-ai-action` click handler for light/sun AI verdict refresh and analyze controls.
- Convert sun sessions, device sessions, light measurement AI, room/screen/audit AI, Light Today, channel mix, burden, and onboarding AI controls away from inline handlers.
- Preserve row click behavior with capture-phase stop propagation for inline session verdict controls.
- Add static and jsdom runtime coverage for the delegate, ratchet the inline-handler baseline from 434 to 390, and bump `APP_VERSION` to `1.8.495`.

## Validation
- `node tests/test-ai-action-delegates.js`
- `node tests/test-sun-ai-analysis.js`
- `node tests/test-light-device-ai-analysis.js`
- `node tests/test-light-ai-renders.js`
- `npm run quality`
- `npm run typecheck`
- `npm test`
- `npx playwright test tests/playwright/light-ai-analysis-coverage-batch.spec.js --project=chromium`
- `git diff --check`
- `./run-tests.sh`
