### PR TITLE
Delegate wearables settings actions

### DIFF
--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -3,7 +3,7 @@
 // Keeps provider rows, connection actions, Apple Health import controls, and
 // manual-source management out of the dashboard strip renderer.
 
-import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
+import { escapeHTML, escapeAttr, showNotification, showConfirmDialog } from './utils.js';
 import { state } from './state.js';
 import { adapterById, visibleAdapters, getOAuthClientId } from './wearable-adapters.js';
 import { brandMarkMono } from './brand-assets.js';
@@ -17,6 +17,123 @@ import {
 } from './wearables-connect.js';
 import { syncWearableSummary } from './wearables-summary.js';
 import { getActiveProfileId } from './profile.js';
+
+let wearableSettingsDelegatesInstalled = false;
+
+function wearableSettingsActionAttrs(action, data = {}, opts = {}) {
+  const attrs = [`data-wearable-settings-action="${escapeAttr(action)}"`];
+  for (const [key, value] of Object.entries(data)) {
+    if (value != null && value !== '') attrs.push(`data-wearable-settings-${key}="${escapeAttr(String(value))}"`);
+  }
+  if (opts.stopPropagation) attrs.push('data-wearable-settings-stop-propagation="true"');
+  return attrs.join(' ');
+}
+
+function wearableSettingsInputAttrs(input) {
+  return `data-wearable-settings-input="${escapeAttr(input)}"`;
+}
+
+function clickAppleHealthFileInput() {
+  document.getElementById('apple-health-file-input')?.click();
+}
+
+function handleWearableSettingsClick(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-wearable-settings-action]'));
+  if (!actionEl?.dataset) return;
+
+  const action = actionEl.dataset.wearableSettingsAction || '';
+  if (actionEl.dataset.wearableSettingsStopPropagation === 'true') {
+    event.stopPropagation();
+  }
+
+  const adapterId = actionEl.dataset.wearableSettingsAdapter || '';
+  switch (action) {
+    case 'connect':
+      event.preventDefault();
+      handleWearableConnect(adapterId);
+      break;
+    case 'pick-apple-health-file':
+      event.preventDefault();
+      clickAppleHealthFileInput();
+      break;
+    case 'sync-now':
+      event.preventDefault();
+      handleWearableSyncNow(adapterId, /** @type {HTMLButtonElement} */ (actionEl));
+      break;
+    case 'backfill':
+      event.preventDefault();
+      handleWearableBackfill(adapterId);
+      break;
+    case 'disconnect':
+      event.preventDefault();
+      handleWearableDisconnect(adapterId);
+      break;
+    case 'manual-dashboard':
+      event.preventDefault();
+      handleManualOpenDashboard();
+      break;
+    case 'manual-disconnect':
+      event.preventDefault();
+      handleManualDisconnect();
+      break;
+  }
+}
+
+function handleWearableSettingsChange(event) {
+  const target = event.target;
+  const inputEl = /** @type {HTMLInputElement | null} */ (target);
+  if (!inputEl?.dataset?.wearableSettingsInput) return;
+
+  switch (inputEl.dataset.wearableSettingsInput) {
+    case 'strip-hidden':
+      setWearableStripHidden(!inputEl.checked);
+      break;
+    case 'apple-health-file':
+      handleAppleHealthFilePick(inputEl);
+      break;
+  }
+}
+
+function appleHealthDropzoneFromEvent(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return null;
+  return /** @type {HTMLElement | null} */ (target.closest('[data-wearable-settings-dropzone="apple-health"]'));
+}
+
+function handleWearableSettingsDragOver(event) {
+  const dropzone = appleHealthDropzoneFromEvent(event);
+  if (!dropzone) return;
+  event.preventDefault();
+  dropzone.classList.add('drag-over');
+}
+
+function handleWearableSettingsDragLeave(event) {
+  const dropzone = appleHealthDropzoneFromEvent(event);
+  if (!dropzone) return;
+  dropzone.classList.remove('drag-over');
+}
+
+function handleWearableSettingsDrop(event) {
+  const dropzone = appleHealthDropzoneFromEvent(event);
+  if (!dropzone) return;
+  event.preventDefault();
+  dropzone.classList.remove('drag-over');
+  handleAppleHealthDrop(/** @type {DragEvent} */ (event));
+}
+
+export function installWearableSettingsDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || wearableSettingsDelegatesInstalled) return;
+  wearableSettingsDelegatesInstalled = true;
+  // Capture is required for action buttons nested inside <summary>; stopping
+  // at document capture prevents the summary disclosure from toggling.
+  root.addEventListener('click', handleWearableSettingsClick, true);
+  root.addEventListener('change', handleWearableSettingsChange);
+  root.addEventListener('dragover', handleWearableSettingsDragOver);
+  root.addEventListener('dragleave', handleWearableSettingsDragLeave);
+  root.addEventListener('drop', handleWearableSettingsDrop);
+}
 
 function formatAgo(ts) {
   if (!ts) return 'never';
@@ -71,7 +188,7 @@ export function renderWearablesSettingsSection() {
       <div style="font-size:11px;color:var(--text-muted);margin-top:2px">Show data from connected wearables (Oura, Withings, Fitbit, etc.) on the dashboard. Off keeps the strip as a Biometrics strip — your manual weight, BP, and pulse entries still appear.</div>
     </div>
     <label class="toggle-switch">
-      <input type="checkbox" id="wearables-strip-hidden-toggle" ${hidden ? '' : 'checked'} onchange="window.setWearableStripHidden(!this.checked)">
+      <input type="checkbox" id="wearables-strip-hidden-toggle" ${hidden ? '' : 'checked'} ${wearableSettingsInputAttrs('strip-hidden')}>
       <span class="toggle-slider"></span>
     </label>
   </div>
@@ -171,19 +288,16 @@ function renderRowAction(adapter, conn, { isPendingClient, isFileImport }) {
     return `<span class="wearable-row-chevron" aria-hidden="true">▾</span>`;
   }
   if (conn && conn.needsReauth) {
-    return `<button type="button" class="wearable-action-row-btn" onclick="event.stopPropagation();handleWearableConnect('${escapeHTML(adapter.id)}')" aria-label="Reconnect ${escapeHTML(adapter.displayName)}">Reconnect</button>`;
+    return `<button type="button" class="wearable-action-row-btn" ${wearableSettingsActionAttrs('connect', { adapter: adapter.id }, { stopPropagation: true })} aria-label="Reconnect ${escapeHTML(adapter.displayName)}">Reconnect</button>`;
   }
   if (isPendingClient) {
-    const docs = adapter.authDocsUrl
-      ? `<a class="wearable-row-link" href="${escapeHTML(adapter.authDocsUrl)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">docs&nbsp;↗</a>`
-      : '';
-    return docs;
+    return `<span class="wearable-row-chevron" aria-hidden="true">▾</span>`;
   }
   if (isFileImport) {
-    return `<button type="button" class="wearable-action-row-btn" onclick="event.stopPropagation();document.getElementById('apple-health-file-input').click()">Import</button>`;
+    return `<button type="button" class="wearable-action-row-btn" ${wearableSettingsActionAttrs('pick-apple-health-file', {}, { stopPropagation: true })}>Import</button>`;
   }
   if (adapter.authType === 'oauth2') {
-    return `<button type="button" class="wearable-action-row-btn" onclick="event.stopPropagation();handleWearableConnect('${escapeHTML(adapter.id)}')" aria-label="Connect ${escapeHTML(adapter.displayName)}">Connect</button>`;
+    return `<button type="button" class="wearable-action-row-btn" ${wearableSettingsActionAttrs('connect', { adapter: adapter.id }, { stopPropagation: true })} aria-label="Connect ${escapeHTML(adapter.displayName)}">Connect</button>`;
   }
   return '';
 }
@@ -209,12 +323,12 @@ function renderRowDetail(adapter, conn, { isPendingClient, isFileImport }) {
     return `<div class="wearable-adapter-identity">${identity}</div>
       <div class="wearable-adapter-meta">Last sync: ${escapeHTML(when)}</div>
       <div class="wearable-adapter-actions">
-        <button class="wearable-action wearable-action-primary" title="Refetches the last 7 days — catches today's reading even if you synced earlier." onclick="handleWearableSyncNow('${escapeHTML(adapter.id)}', this)" aria-label="Sync ${escapeHTML(adapter.displayName)} now">
+        <button class="wearable-action wearable-action-primary" title="Refetches the last 7 days — catches today's reading even if you synced earlier." ${wearableSettingsActionAttrs('sync-now', { adapter: adapter.id })} aria-label="Sync ${escapeHTML(adapter.displayName)} now">
           <svg class="wearable-action-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><polyline points="21 4 21 12 13 12"/></svg>
           <span>Sync now <span class="wearable-action-hint">(catches today)</span></span>
         </button>
-        <button class="wearable-action wearable-action-secondary" title="Refetches 90 days of history — useful after a long absence or to recover missing days. May take 30s+." onclick="handleWearableBackfill('${escapeHTML(adapter.id)}')">Backfill 90 days <span class="wearable-action-hint">(slower, fills gaps)</span></button>
-        <button class="wearable-action wearable-action-danger" onclick="handleWearableDisconnect('${escapeHTML(adapter.id)}')">Disconnect</button>
+        <button class="wearable-action wearable-action-secondary" title="Refetches 90 days of history — useful after a long absence or to recover missing days. May take 30s+." ${wearableSettingsActionAttrs('backfill', { adapter: adapter.id })}>Backfill 90 days <span class="wearable-action-hint">(slower, fills gaps)</span></button>
+        <button class="wearable-action wearable-action-danger" ${wearableSettingsActionAttrs('disconnect', { adapter: adapter.id })}>Disconnect</button>
       </div>`;
   }
   // Apple Health connected — different actions
@@ -224,14 +338,14 @@ function renderRowDetail(adapter, conn, { isPendingClient, isFileImport }) {
     return `<div class="wearable-adapter-identity">Imported from ${fileName}</div>
       <div class="wearable-adapter-meta">Last import: ${escapeHTML(when)} · ${conn.coverageDays ?? '?'} days</div>
       <div class="wearable-adapter-actions">
-        <button class="wearable-action wearable-action-primary" onclick="document.getElementById('apple-health-file-input').click()">Re-import new export</button>
-        <button class="wearable-action wearable-action-danger" onclick="handleWearableDisconnect('${escapeHTML(adapter.id)}')">Remove data</button>
+        <button class="wearable-action wearable-action-primary" ${wearableSettingsActionAttrs('pick-apple-health-file')}>Re-import new export</button>
+        <button class="wearable-action wearable-action-danger" ${wearableSettingsActionAttrs('disconnect', { adapter: adapter.id })}>Remove data</button>
       </div>
       <div id="apple-health-progress" class="apple-health-progress" style="display:none">
         <div class="apple-health-progress-bar"><div class="apple-health-progress-fill"></div></div>
         <div class="apple-health-progress-text"></div>
       </div>
-      <input type="file" id="apple-health-file-input" accept=".zip,.xml,application/zip,application/xml" style="display:none" onchange="handleAppleHealthFilePick(this)">`;
+      <input type="file" id="apple-health-file-input" accept=".zip,.xml,application/zip,application/xml" style="display:none" ${wearableSettingsInputAttrs('apple-health-file')}>`;
   }
   // Apple Health disconnected — full how-to-export + dropzone
   if (isFileImport) {
@@ -247,10 +361,8 @@ function renderRowDetail(adapter, conn, { isPendingClient, isFileImport }) {
         <p class="apple-health-privacy">Parsing runs entirely in your browser — the file never leaves this device.</p>
       </details>
       <div class="apple-health-dropzone"
-           ondragover="event.preventDefault();this.classList.add('drag-over')"
-           ondragleave="this.classList.remove('drag-over')"
-           ondrop="event.preventDefault();this.classList.remove('drag-over');handleAppleHealthDrop(event)"
-           onclick="document.getElementById('apple-health-file-input').click()">
+           data-wearable-settings-dropzone="apple-health"
+           ${wearableSettingsActionAttrs('pick-apple-health-file')}>
         <div class="apple-health-dropzone-icon">📂</div>
         <div class="apple-health-dropzone-text">Drop <code>export.zip</code> or <code>export.xml</code> here — or click to pick a file</div>
       </div>
@@ -258,11 +370,14 @@ function renderRowDetail(adapter, conn, { isPendingClient, isFileImport }) {
         <div class="apple-health-progress-bar"><div class="apple-health-progress-fill"></div></div>
         <div class="apple-health-progress-text"></div>
       </div>
-      <input type="file" id="apple-health-file-input" accept=".zip,.xml,application/zip,application/xml" style="display:none" onchange="handleAppleHealthFilePick(this)">`;
+      <input type="file" id="apple-health-file-input" accept=".zip,.xml,application/zip,application/xml" style="display:none" ${wearableSettingsInputAttrs('apple-health-file')}>`;
   }
   // Pending OAuth client — explanation
   if (isPendingClient) {
-    return `<p class="wearable-adapter-hint">${escapeHTML(adapter.displayName)} support is in progress — still waiting on partner credentials. Check back soon or watch the changelog.</p>`;
+    const docs = adapter.authDocsUrl
+      ? ` <a class="wearable-row-link" href="${escapeAttr(adapter.authDocsUrl)}" target="_blank" rel="noopener">docs&nbsp;↗</a>`
+      : '';
+    return `<p class="wearable-adapter-hint">${escapeHTML(adapter.displayName)} support is in progress — still waiting on partner credentials. Check back soon or watch the changelog.${docs}</p>`;
   }
   // Manual source — entry counts + entry points + disconnect. Unlike OAuth,
   // manual has no credential to reconnect; "disconnect" means wipe all rows.
@@ -276,8 +391,8 @@ function renderRowDetail(adapter, conn, { isPendingClient, isFileImport }) {
         weight / BP / resting HR card to open its detail view.
       </p>
       <div class="wearable-adapter-actions">
-        <button class="wearable-action wearable-action-primary" onclick="handleManualOpenDashboard()">Open dashboard</button>
-        <button class="wearable-action wearable-action-danger" onclick="handleManualDisconnect()">Delete all manual entries</button>
+        <button class="wearable-action wearable-action-primary" ${wearableSettingsActionAttrs('manual-dashboard')}>Open dashboard</button>
+        <button class="wearable-action wearable-action-danger" ${wearableSettingsActionAttrs('manual-disconnect')}>Delete all manual entries</button>
       </div>`;
   }
   // Disconnected OAuth (default) — no detail to expand. The Connect button
@@ -456,6 +571,8 @@ function refreshSettingsWearables() {
   const section = document.getElementById('wearables-section');
   if (section) section.innerHTML = renderWearablesSettingsSection();
 }
+
+installWearableSettingsDelegates();
 
 Object.assign(window, {
   setWearableStripHidden,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 371,
+  "inlineEventAttributes": 356,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -27,8 +27,10 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
 
     const profileId = `wearables-settings-render-${Date.now()}`;
     const hiddenKey = `wearables-strip-hidden-${profileId}`;
+    const betaFlagKey = 'labcharts-show-beta-wearables';
     const oldActiveProfile = localStorage.getItem('labcharts-active-profile');
     const oldHiddenValue = localStorage.getItem(hiddenKey);
+    const oldBetaFlag = localStorage.getItem(betaFlagKey);
     const oldCurrentProfile = state.currentProfile;
     const oldProfiles = state.profiles;
     const oldImportedData = state.importedData;
@@ -36,11 +38,13 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
     const oldCloseSettings = window.closeSettings;
     const oldScrollIntoView = Element.prototype.scrollIntoView;
     const navigations = [];
+    const docsClicks = [];
     let closedSettings = 0;
     let scrolledToStrip = 0;
 
     try {
       localStorage.setItem('labcharts-active-profile', profileId);
+      localStorage.setItem(betaFlagKey, 'true');
       localStorage.removeItem(hiddenKey);
       state.currentProfile = profileId;
       state.profiles = [{
@@ -115,6 +119,7 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       const toggle = document.getElementById('wearables-strip-hidden-toggle');
       const ouraRow = section.querySelector('[data-adapter="oura"]');
       const fitbitRow = section.querySelector('[data-adapter="fitbit"]');
+      const ultrahumanRow = section.querySelector('[data-adapter="ultrahuman"]');
       const manualRow = section.querySelector('[data-adapter="manual"]');
       const appleRow = section.querySelector('[data-adapter="apple_health"]');
       const manualCounts = section.querySelector('[data-role="manual-counts"]')?.textContent || '';
@@ -124,6 +129,11 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
         ouraRow?.textContent.includes('connected') && ouraRow?.textContent.includes('oura@example.test'));
       check('needs reauth row renders reconnect action',
         fitbitRow?.textContent.includes('needs reconnection') && fitbitRow?.textContent.includes('Reconnect'));
+      const ultrahumanDocsLink = ultrahumanRow?.querySelector('.wearable-row-detail a.wearable-row-link');
+      check('pending client row renders native docs link in detail drawer',
+        ultrahumanRow?.textContent.includes('waiting on partner credentials')
+        && ultrahumanDocsLink?.getAttribute('href') === 'https://vision.ultrahuman.com/developer-docs?type=oauth'
+        && !ultrahumanRow?.querySelector('summary a[href]'));
       check('manual row renders browser-populated counts',
         manualRow?.textContent.includes('Manual')
         && manualCounts.includes('1 weight')
@@ -134,22 +144,39 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
         && appleRow?.textContent.includes('42 days')
         && !!section.querySelector('#apple-health-file-input'));
 
-      settings.setWearableStripHidden(true);
-      check('setWearableStripHidden stores per-profile hidden preference',
+      toggle.checked = false;
+      toggle.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+      check('delegated strip visibility toggle stores per-profile hidden preference',
         settings.isWearableStripHidden() === true && localStorage.getItem(hiddenKey) === '1');
-      settings.setWearableStripHidden(false);
-      check('setWearableStripHidden removes hidden preference',
+      toggle.checked = true;
+      toggle.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+      check('delegated strip visibility toggle removes hidden preference',
         settings.isWearableStripHidden() === false && localStorage.getItem(hiddenKey) == null);
 
       const dashboardNavBefore = navigations.filter(route => route === 'dashboard').length;
-      window.handleManualOpenDashboard();
+      section.querySelector('[data-wearable-settings-action="manual-dashboard"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
       await new Promise(resolve => requestAnimationFrame(resolve));
       const dashboardNavAfter = navigations.filter(route => route === 'dashboard').length;
-      check('manual dashboard handler closes settings navigates and scrolls strip',
+      check('delegated manual dashboard action closes settings navigates and scrolls strip',
         closedSettings === 1
         && dashboardNavAfter === dashboardNavBefore + 1
         && scrolledToStrip === 1,
         JSON.stringify({ closedSettings, navigations, dashboardNavBefore, dashboardNavAfter, scrolledToStrip }));
+
+      ultrahumanDocsLink?.addEventListener('click', event => {
+        docsClicks.push({
+          defaultPrevented: event.defaultPrevented,
+          currentTarget: event.currentTarget === ultrahumanDocsLink,
+        });
+      });
+      ultrahumanDocsLink?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      check('pending docs link reaches target uncanceled without toggling row',
+        docsClicks.length === 1
+        && docsClicks[0].currentTarget === true
+        && docsClicks[0].defaultPrevented === false
+        && !ultrahumanRow?.hasAttribute('open'),
+        JSON.stringify({ docsClicks, rowOpen: ultrahumanRow?.hasAttribute('open') }));
     } finally {
       document.getElementById('wearables-section')?.remove();
       document.getElementById('wearable-strip')?.remove();
@@ -158,6 +185,8 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       else localStorage.setItem('labcharts-active-profile', oldActiveProfile);
       if (oldHiddenValue == null) localStorage.removeItem(hiddenKey);
       else localStorage.setItem(hiddenKey, oldHiddenValue);
+      if (oldBetaFlag == null) localStorage.removeItem(betaFlagKey);
+      else localStorage.setItem(betaFlagKey, oldBetaFlag);
       state.currentProfile = oldCurrentProfile;
       state.profiles = oldProfiles;
       state.importedData = oldImportedData;
@@ -179,6 +208,15 @@ test('wearables settings panel browser coverage deletes manual data after confir
     const failures = [];
     const check = (name, condition, detail = '') => {
       if (!condition) failures.push(detail ? `${name}: ${detail}` : name);
+    };
+    const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const waitUntil = async (predicate, label) => {
+      for (let attempt = 0; attempt < 80; attempt += 1) {
+        if (predicate()) return true;
+        await wait(25);
+      }
+      failures.push(`Timed out waiting for ${label}`);
+      return false;
     };
 
     const [{ state }, settings, store] = await Promise.all([
@@ -248,7 +286,14 @@ test('wearables settings panel browser coverage deletes manual data after confir
         <section id="wearables-section">${settings.renderWearablesSettingsSection()}</section>
       `);
 
-      await window.handleManualDisconnect();
+      document.querySelector('[data-wearable-settings-action="manual-disconnect"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      await waitUntil(
+        () => state.importedData.wearableConnections?.manual == null
+          && navigations.includes('dashboard')
+          && (document.getElementById('notification-container')?.textContent || '').includes('All manual entries deleted'),
+        'delegated manual disconnect to finish'
+      );
 
       const rows = await store.getDailyRange(profileId, 'manual', '2000-01-01', '2099-12-31');
       const sectionText = document.getElementById('wearables-section')?.textContent || '';

--- a/tests/test-wearables-delegated-actions.js
+++ b/tests/test-wearables-delegated-actions.js
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const stripSrc = fs.readFileSync(path.join(root, 'js/wearables.js'), 'utf8');
 const detailSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-modal.js'), 'utf8');
+const settingsPanelSrc = fs.readFileSync(path.join(root, 'js/wearables-settings-panel.js'), 'utf8');
 const stripImportsSharedActionHelper = /import\s*{[^}]*\bwearableActionAttrs\b[^}]*}\s*from\s+'\.\/wearables-detail-modal\.js';/s.test(stripSrc);
 
 let passed = 0;
@@ -32,6 +33,8 @@ assert('wearables strip renders no inline event attributes',
   !inlineHandlerRe.test(stripSrc));
 assert('wearables detail modal renders no inline event attributes',
   !inlineHandlerRe.test(detailSrc));
+assert('wearables settings panel renders no inline event attributes',
+  !inlineHandlerRe.test(settingsPanelSrc));
 assert('wearables strip renders delegated action attributes',
   stripImportsSharedActionHelper &&
     stripSrc.includes("wearableActionAttrs('open-manual-log'") &&
@@ -71,6 +74,20 @@ assert('wearables delegated manual log open bypasses only the legacy inline-card
     !stripSrc.includes("if (event?.target?.closest?.('[data-wearable-action]')) return;"));
 assert('wearables delegated keyboard ignores form controls',
   stripSrc.includes("target.closest('input, textarea, select, button, a')"));
+assert('wearables settings panel installs delegated click change and drop handlers',
+  settingsPanelSrc.includes('let wearableSettingsDelegatesInstalled = false') &&
+    settingsPanelSrc.includes("root.addEventListener('click', handleWearableSettingsClick, true)") &&
+    settingsPanelSrc.includes("root.addEventListener('change', handleWearableSettingsChange)") &&
+    settingsPanelSrc.includes("root.addEventListener('drop', handleWearableSettingsDrop)") &&
+    settingsPanelSrc.includes('installWearableSettingsDelegates();'));
+assert('wearables settings panel renders delegated action and input attributes',
+  settingsPanelSrc.includes('function wearableSettingsActionAttrs') &&
+    settingsPanelSrc.includes('function wearableSettingsInputAttrs') &&
+    settingsPanelSrc.includes('data-wearable-settings-action=') &&
+    settingsPanelSrc.includes('data-wearable-settings-input=') &&
+    settingsPanelSrc.includes("wearableSettingsActionAttrs('manual-dashboard'") &&
+    settingsPanelSrc.includes("wearableSettingsActionAttrs('sync-now'") &&
+    settingsPanelSrc.includes("wearableSettingsInputAttrs('apple-health-file'"));
 
 [
   'open-manual-log',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.496';
+self.APP_VERSION = '1.8.497';


### PR DESCRIPTION
Summary:
- Replace Wearables settings panel inline handlers with delegated data-wearable-settings-* actions/inputs, including Apple Health drag/drop.
- Add source and browser coverage for delegated settings panel actions.
- Ratchet inline-handler baseline to 356 and bump app version.

Tests:
- node tests/test-wearables-delegated-actions.js
- npm run typecheck
- npm run quality
- npx playwright test tests/playwright/wearables-settings-panel-browser-coverage.spec.js --project=chromium
- ./run-tests.sh