### PR TITLE
Delegate medical history editor actions

### DIFF
--- a/js/context-card-medical-history-editor.js
+++ b/js/context-card-medical-history-editor.js
@@ -10,6 +10,7 @@ import {
   renderContextEditorModal,
   getSelectedOption,
   renderNoteField,
+  selectCtxOption,
 } from './context-card-editor-ui.js';
 
 /** @type {(field: string) => void} */
@@ -18,6 +19,147 @@ let recordContextChange = () => {};
 let saveContextAndRefresh = () => {};
 let editingConditionIndex = -1;
 let editingFamilyHistoryIndex = -1;
+
+const MEDICAL_HISTORY_ROOT = '#detail-modal';
+
+/**
+ * @param {string} action
+ * @param {string} [extra]
+ * @returns {string}
+ */
+function medicalHistoryActionAttrs(action, extra = '') {
+  return `data-medical-history-action="${action}"${extra ? ` ${extra}` : ''}`;
+}
+
+/**
+ * @param {EventTarget | null} target
+ * @param {string} selector
+ * @returns {HTMLElement | null}
+ */
+function closestMedicalHistoryElement(target, selector) {
+  if (!(target instanceof Element)) return null;
+  const el = target.closest(selector);
+  if (!(el instanceof HTMLElement)) return null;
+  return el.closest(MEDICAL_HISTORY_ROOT) ? el : null;
+}
+
+/**
+ * @param {HTMLElement} el
+ * @returns {number}
+ */
+function getMedicalHistoryIndex(el) {
+  const idx = Number.parseInt(el.dataset.medicalHistoryIndex || '', 10);
+  return Number.isInteger(idx) ? idx : -1;
+}
+
+/** @param {MouseEvent} event */
+function handleMedicalHistoryClick(event) {
+  const actionEl = closestMedicalHistoryElement(event.target, '[data-medical-history-action]');
+  if (!actionEl) return;
+  const action = actionEl.dataset.medicalHistoryAction || '';
+  const idx = getMedicalHistoryIndex(actionEl);
+  switch (action) {
+    case 'edit-condition':
+      if (idx >= 0) editCondition(idx);
+      break;
+    case 'delete-condition':
+      if (idx >= 0) deleteCondition(idx);
+      break;
+    case 'add-condition':
+      addCondition();
+      break;
+    case 'cancel-condition-edit':
+      cancelConditionEdit();
+      break;
+    case 'select-condition-severity':
+      selectCtxOption(actionEl, 'condition-severity');
+      break;
+    case 'edit-family-history':
+      if (idx >= 0) editFamilyHistoryEntry(idx);
+      break;
+    case 'delete-family-history':
+      if (idx >= 0) deleteFamilyHistoryEntry(idx);
+      break;
+    case 'add-family-history':
+      addFamilyHistoryEntry();
+      break;
+    case 'cancel-family-history-edit':
+      cancelFamilyHistoryEdit();
+      break;
+    case 'save':
+      saveDiagnoses();
+      break;
+    case 'close':
+      closeDiagnoses();
+      break;
+    case 'clear':
+      clearDiagnoses();
+      break;
+    default:
+      break;
+  }
+}
+
+/** @param {InputEvent} event */
+function handleMedicalHistoryInput(event) {
+  const input = closestMedicalHistoryElement(event.target, '#condition-input, #fh-condition');
+  if (!input) return;
+  if (input.id === 'condition-input') {
+    filterConditionSuggestions();
+  } else {
+    filterFamilyConditionSuggestions();
+  }
+}
+
+/** @param {FocusEvent} event */
+function handleMedicalHistoryFocusIn(event) {
+  const input = closestMedicalHistoryElement(event.target, '#condition-input, #fh-condition');
+  if (!input) return;
+  if (input.id === 'condition-input') {
+    filterConditionSuggestions();
+  } else {
+    filterFamilyConditionSuggestions();
+  }
+}
+
+/** @param {KeyboardEvent} event */
+function handleMedicalHistoryKeydown(event) {
+  const input = closestMedicalHistoryElement(event.target, '#condition-input, #fh-condition');
+  if (!input || event.key !== 'Enter') return;
+  event.preventDefault();
+  if (input.id === 'condition-input') {
+    addCondition();
+  } else {
+    addFamilyHistoryEntry();
+  }
+}
+
+/** @param {MouseEvent} event */
+function handleMedicalHistoryMouseDown(event) {
+  const item = closestMedicalHistoryElement(event.target, '[data-medical-history-suggestion]');
+  if (!item) return;
+  event.preventDefault();
+  const value = item.dataset.medicalHistoryValue || '';
+  if (item.dataset.medicalHistorySuggestion === 'family-condition') {
+    selectFamilyConditionSuggestion(value);
+  } else {
+    selectConditionSuggestion(value);
+  }
+}
+
+let medicalHistoryDelegatesBound = false;
+
+function initMedicalHistoryActionDelegates() {
+  if (medicalHistoryDelegatesBound || typeof document === 'undefined') return;
+  medicalHistoryDelegatesBound = true;
+  document.addEventListener('click', handleMedicalHistoryClick);
+  document.addEventListener('input', handleMedicalHistoryInput);
+  document.addEventListener('focusin', handleMedicalHistoryFocusIn);
+  document.addEventListener('keydown', handleMedicalHistoryKeydown);
+  document.addEventListener('mousedown', handleMedicalHistoryMouseDown);
+}
+
+initMedicalHistoryActionDelegates();
 
 /**
  * @param {{ recordChange?: (field: string) => void, saveAndRefresh?: (msg: string, field?: string) => void }} [deps]
@@ -97,8 +239,8 @@ export function renderDiagnosesModal(modal, current) {
         ${c.severity ? `<span class="goals-severity-badge severity-${c.severity}">${c.severity}</span>` : ''}
         ${c.since ? `<span class="ctx-condition-since">since ${escapeHTML(c.since)}</span>` : ''}
         <span class="ctx-condition-actions">
-          <button class="ctx-row-action-btn ctx-row-edit-btn" onclick="editCondition(${i})" aria-label="Edit condition" title="Edit condition">✎</button>
-          <button class="ctx-row-action-btn goals-delete-btn" onclick="deleteCondition(${i})" aria-label="Remove condition" title="Remove condition">&times;</button>
+          <button class="ctx-row-action-btn ctx-row-edit-btn" ${medicalHistoryActionAttrs('edit-condition', `data-medical-history-index="${i}"`)} aria-label="Edit condition" title="Edit condition">✎</button>
+          <button class="ctx-row-action-btn goals-delete-btn" ${medicalHistoryActionAttrs('delete-condition', `data-medical-history-index="${i}"`)} aria-label="Remove condition" title="Remove condition">&times;</button>
         </span>
       </div>`;
     }
@@ -107,17 +249,17 @@ export function renderDiagnosesModal(modal, current) {
   html += `<div class="ctx-field-group"><label class="ctx-field-label">Add condition</label>
     <div class="ctx-add-condition">
       <div class="ctx-autocomplete-wrapper">
-        <input type="text" class="ctx-note-input" id="condition-input" value="${escapeHTML(editingCondition?.name || '')}" placeholder="Type condition name..." oninput="filterConditionSuggestions()" onfocus="filterConditionSuggestions()">
+        <input type="text" class="ctx-note-input" id="condition-input" value="${escapeHTML(editingCondition?.name || '')}" placeholder="Type condition name...">
         <div class="ctx-suggestions" id="condition-suggestions"></div>
       </div>
       <input type="text" class="ctx-note-input" id="condition-since" value="${escapeHTML(editingCondition?.since || '')}" placeholder="Since (e.g. 2020)" style="width:100px">
-      <button class="import-btn import-btn-primary" onclick="addCondition()">${editingCondition ? 'Update' : 'Add'}</button>
-      ${editingCondition ? '<button class="import-btn import-btn-secondary ctx-edit-cancel-btn" onclick="cancelConditionEdit()">Cancel edit</button>' : ''}
+      <button class="import-btn import-btn-primary" ${medicalHistoryActionAttrs('add-condition')}>${editingCondition ? 'Update' : 'Add'}</button>
+      ${editingCondition ? `<button class="import-btn import-btn-secondary ctx-edit-cancel-btn" ${medicalHistoryActionAttrs('cancel-condition-edit')}>Cancel edit</button>` : ''}
     </div>
     <div class="ctx-btn-group" id="condition-severity" style="margin-top:8px">
-      <button type="button" class="ctx-btn-option${_activeClass(conditionSeverity, 'major')}" onclick="selectCtxOption(this,'condition-severity')">major</button>
-      <button type="button" class="ctx-btn-option${_activeClass(conditionSeverity, 'mild')}" onclick="selectCtxOption(this,'condition-severity')">mild</button>
-      <button type="button" class="ctx-btn-option${_activeClass(conditionSeverity, 'minor')}" onclick="selectCtxOption(this,'condition-severity')">minor</button>
+      <button type="button" class="ctx-btn-option${_activeClass(conditionSeverity, 'major')}" ${medicalHistoryActionAttrs('select-condition-severity')}>major</button>
+      <button type="button" class="ctx-btn-option${_activeClass(conditionSeverity, 'mild')}" ${medicalHistoryActionAttrs('select-condition-severity')}>mild</button>
+      <button type="button" class="ctx-btn-option${_activeClass(conditionSeverity, 'minor')}" ${medicalHistoryActionAttrs('select-condition-severity')}>minor</button>
     </div>
   </div>`;
 
@@ -148,8 +290,8 @@ export function renderDiagnosesModal(modal, current) {
           ${e.note ? `<span class="ctx-family-note" title="${escapeHTML(e.note)}">${escapeHTML(e.note)}</span>` : ''}
         </div>
         <span class="ctx-family-actions">
-          <button class="ctx-row-action-btn ctx-row-edit-btn" onclick="editFamilyHistoryEntry(${i})" aria-label="Edit family history entry" title="Edit entry">✎</button>
-          <button class="ctx-row-action-btn goals-delete-btn" onclick="deleteFamilyHistoryEntry(${i})" aria-label="Remove entry" title="Remove entry">&times;</button>
+          <button class="ctx-row-action-btn ctx-row-edit-btn" ${medicalHistoryActionAttrs('edit-family-history', `data-medical-history-index="${i}"`)} aria-label="Edit family history entry" title="Edit entry">✎</button>
+          <button class="ctx-row-action-btn goals-delete-btn" ${medicalHistoryActionAttrs('delete-family-history', `data-medical-history-index="${i}"`)} aria-label="Remove entry" title="Remove entry">&times;</button>
         </span>
       </div>`;
     }
@@ -176,37 +318,27 @@ export function renderDiagnosesModal(modal, current) {
         </optgroup>
       </select>
       <div class="ctx-autocomplete-wrapper ctx-family-condition-wrap">
-        <input type="text" class="ctx-note-input" id="fh-condition" value="${escapeHTML(editingFamily?.condition || '')}" placeholder="Condition (e.g. heart attack, Alzheimer's, breast cancer)" oninput="filterFamilyConditionSuggestions()" onfocus="filterFamilyConditionSuggestions()" aria-label="Condition">
+        <input type="text" class="ctx-note-input" id="fh-condition" value="${escapeHTML(editingFamily?.condition || '')}" placeholder="Condition (e.g. heart attack, Alzheimer's, breast cancer)" aria-label="Condition">
         <div class="ctx-suggestions" id="fh-condition-suggestions"></div>
       </div>
     </div>
     <div class="ctx-family-add-row">
       <input type="number" min="0" max="120" class="ctx-note-input ctx-family-age-input" id="fh-age" value="${editingFamily?.onsetAge != null ? escapeHTML(String(editingFamily.onsetAge)) : ''}" placeholder="Age at onset" aria-label="Age at onset">
       <input type="text" class="ctx-note-input ctx-family-note-input" id="fh-note" value="${escapeHTML(editingFamily?.note || '')}" placeholder="Note — outcome, treatment, etc. (optional)" aria-label="Note">
-      <button class="import-btn import-btn-primary" onclick="addFamilyHistoryEntry()">${editingFamily ? 'Update' : '+ Add'}</button>
-      ${editingFamily ? '<button class="import-btn import-btn-secondary ctx-edit-cancel-btn" onclick="cancelFamilyHistoryEdit()">Cancel edit</button>' : ''}
+      <button class="import-btn import-btn-primary" ${medicalHistoryActionAttrs('add-family-history')}>${editingFamily ? 'Update' : '+ Add'}</button>
+      ${editingFamily ? `<button class="import-btn import-btn-secondary ctx-edit-cancel-btn" ${medicalHistoryActionAttrs('cancel-family-history-edit')}>Cancel edit</button>` : ''}
     </div>
   </div></div>`;
   html += renderNoteField(current.note);
   const hasCurrent = conditions.length > 0 || familyHistory.length > 0 || current.note;
   html += `<div class="ctx-editor-actions">
-    <button class="import-btn import-btn-primary" onclick="saveDiagnoses()">Save</button>
-    <button class="import-btn import-btn-secondary" onclick="closeDiagnoses()">Cancel</button>
-    ${hasCurrent ? '<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" onclick="clearDiagnoses()">Clear</button>' : ''}
+    <button class="import-btn import-btn-primary" ${medicalHistoryActionAttrs('save')}>Save</button>
+    <button class="import-btn import-btn-secondary" ${medicalHistoryActionAttrs('close')}>Cancel</button>
+    ${hasCurrent ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${medicalHistoryActionAttrs('clear')}>Clear</button>` : ''}
   </div>`;
   renderContextEditorModal(modal, 'Medical History', 'Your diagnoses and family history. The AI considers both when interpreting your labs.', html, 'closeDiagnoses');
-  setTimeout(() => {
-    const input = getFormControl('condition-input');
-    if (input) {
-      input.onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); addCondition(); } };
-    }
-    const fhCond = getFormControl('fh-condition');
-    if (fhCond) {
-      fhCond.onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); addFamilyHistoryEntry(); } };
-    }
-    document.removeEventListener('click', closeSuggestionsOnClickOutside);
-    document.addEventListener('click', closeSuggestionsOnClickOutside);
-  }, 50);
+  document.removeEventListener('click', closeSuggestionsOnClickOutside);
+  document.addEventListener('click', closeSuggestionsOnClickOutside);
 }
 
 export function filterConditionSuggestions() {
@@ -221,11 +353,7 @@ export function filterConditionSuggestions() {
   });
   const matches = val ? sexFiltered.filter(c => c.toLowerCase().includes(val) && !existing.includes(c.toLowerCase())) : sexFiltered.filter(c => !existing.includes(c.toLowerCase()));
   if (matches.length === 0 || !val) { container.innerHTML = ''; return; }
-  // JSON.stringify + escapeHTML so conditions with apostrophes (Alzheimer's,
-  // Hashimoto's, Crohn's, etc.) survive both the JS-string-in-HTML-attribute
-  // round-trip. escapeHTML alone would convert `'` -> `&#39;` which the HTML
-  // parser then decodes before JS sees it, breaking the JS string literal.
-  container.innerHTML = matches.slice(0, 8).map(m => `<div class="ctx-suggestion-item" onmousedown="selectConditionSuggestion(${escapeHTML(JSON.stringify(m))})">${escapeHTML(m)}</div>`).join('');
+  container.innerHTML = matches.slice(0, 8).map(m => `<div class="ctx-suggestion-item" data-medical-history-suggestion="condition" data-medical-history-value="${escapeHTML(m)}">${escapeHTML(m)}</div>`).join('');
 }
 
 export function selectConditionSuggestion(name) {
@@ -363,7 +491,7 @@ export function filterFamilyConditionSuggestions() {
   const val = input.value.toLowerCase().trim();
   const matches = val ? COMMON_CONDITIONS.filter(c => c.toLowerCase().includes(val)) : COMMON_CONDITIONS;
   if (matches.length === 0 || !val) { container.innerHTML = ''; return; }
-  container.innerHTML = matches.slice(0, 8).map(m => `<div class="ctx-suggestion-item" onmousedown="selectFamilyConditionSuggestion(${escapeHTML(JSON.stringify(m))})">${escapeHTML(m)}</div>`).join('');
+  container.innerHTML = matches.slice(0, 8).map(m => `<div class="ctx-suggestion-item" data-medical-history-suggestion="family-condition" data-medical-history-value="${escapeHTML(m)}">${escapeHTML(m)}</div>`).join('');
 }
 
 export function selectFamilyConditionSuggestion(name) {

--- a/js/context-card-medical-history-editor.js
+++ b/js/context-card-medical-history-editor.js
@@ -100,8 +100,8 @@ function handleMedicalHistoryClick(event) {
   }
 }
 
-/** @param {InputEvent} event */
-function handleMedicalHistoryInput(event) {
+/** @param {Event} event */
+function handleMedicalHistoryFieldActivity(event) {
   const input = closestMedicalHistoryElement(event.target, '#condition-input, #fh-condition');
   if (!input) return;
   if (input.id === 'condition-input') {
@@ -111,15 +111,14 @@ function handleMedicalHistoryInput(event) {
   }
 }
 
+/** @param {InputEvent} event */
+function handleMedicalHistoryInput(event) {
+  handleMedicalHistoryFieldActivity(event);
+}
+
 /** @param {FocusEvent} event */
 function handleMedicalHistoryFocusIn(event) {
-  const input = closestMedicalHistoryElement(event.target, '#condition-input, #fh-condition');
-  if (!input) return;
-  if (input.id === 'condition-input') {
-    filterConditionSuggestions();
-  } else {
-    filterFamilyConditionSuggestions();
-  }
+  handleMedicalHistoryFieldActivity(event);
 }
 
 /** @param {KeyboardEvent} event */
@@ -153,6 +152,7 @@ function initMedicalHistoryActionDelegates() {
   if (medicalHistoryDelegatesBound || typeof document === 'undefined') return;
   medicalHistoryDelegatesBound = true;
   document.addEventListener('click', handleMedicalHistoryClick);
+  document.addEventListener('click', closeSuggestionsOnClickOutside);
   document.addEventListener('input', handleMedicalHistoryInput);
   document.addEventListener('focusin', handleMedicalHistoryFocusIn);
   document.addEventListener('keydown', handleMedicalHistoryKeydown);
@@ -337,8 +337,6 @@ export function renderDiagnosesModal(modal, current) {
     ${hasCurrent ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${medicalHistoryActionAttrs('clear')}>Clear</button>` : ''}
   </div>`;
   renderContextEditorModal(modal, 'Medical History', 'Your diagnoses and family history. The AI considers both when interpreting your labs.', html, 'closeDiagnoses');
-  document.removeEventListener('click', closeSuggestionsOnClickOutside);
-  document.addEventListener('click', closeSuggestionsOnClickOutside);
 }
 
 export function filterConditionSuggestions() {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 335,
+  "inlineEventAttributes": 319,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/family-history-dom.spec.js
+++ b/tests/playwright/family-history-dom.spec.js
@@ -117,26 +117,6 @@ test('family history DOM handlers round-trip and mutate entries', async ({ page 
     const { state } = await import('/js/state.js');
     const outcomes = {};
 
-    const probe = document.createElement('div');
-    probe.innerHTML = '<input id="probe-cond-input"><div id="probe-target"></div>';
-    document.body.appendChild(probe);
-    try {
-      const condition = "Alzheimer's Disease";
-      const escapeHTML = value => String(value).replace(/[&<>"']/g, c => ({
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;',
-      }[c]));
-      const target = document.getElementById('probe-target');
-      target.innerHTML = `<div class="ctx-suggestion-item" id="probe-suggest" onmousedown="document.getElementById('probe-cond-input').value = ${escapeHTML(JSON.stringify(condition))}">${escapeHTML(condition)}</div>`;
-      document.getElementById('probe-suggest').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
-      outcomes.apostropheConditionRoundTrips = document.getElementById('probe-cond-input').value === condition;
-    } finally {
-      probe.remove();
-    }
-
     const originalDiagnoses = state.importedData?.diagnoses;
     state.importedData = state.importedData || {};
     state.importedData.diagnoses = { conditions: [], note: '', familyHistory: [] };
@@ -147,6 +127,15 @@ test('family history DOM handlers round-trip and mutate entries', async ({ page 
       detachedModal.id = 'detail-modal';
       document.body.appendChild(detachedModal);
     }
+
+    cards.renderDiagnosesModal(document.getElementById('detail-modal'), state.importedData.diagnoses);
+    const conditionInput = document.getElementById('condition-input');
+    conditionInput.value = 'Alzheimer';
+    conditionInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    const suggestion = document.querySelector('#condition-suggestions .ctx-suggestion-item');
+    suggestion.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    outcomes.apostropheConditionRoundTrips = conditionInput.value === "Alzheimer's Disease";
+    document.getElementById('detail-modal').innerHTML = '';
 
     const probe2 = document.createElement('div');
     document.body.appendChild(probe2);
@@ -324,11 +313,9 @@ test('medical history editor handlers cover autocomplete save clear and close fl
         'ctx-note-input',
       ].every(id => document.getElementById(id)));
       if (!editorReady) throw new Error('Medical history editor controls did not render');
-      const editorHooksReady = await waitFor(() =>
-        typeof byId('condition-input').onkeydown === 'function'
-          && typeof byId('fh-condition').onkeydown === 'function'
-      );
-      if (!editorHooksReady) throw new Error('Medical history editor deferred handlers did not install');
+      outcomes.medicalHistoryInputsUseDelegatedKeydown =
+        byId('condition-input').onkeydown === null &&
+        byId('fh-condition').onkeydown === null;
       outcomes.openDiagnosesEditorShowsSeededModal = overlay.classList.contains('show') === true
         && modal.getAttribute('aria-label') === 'Medical History'
         && modal.textContent.includes('Hypertension')
@@ -465,10 +452,6 @@ test('medical history editor handlers cover autocomplete save clear and close fl
       outcomes.closeDiagnosesDelegatesToCloseModal = overlay.classList.contains('show') === false
         && calls.some(call => call[0] === 'close');
     } finally {
-      await waitFor(() => {
-        const input = document.getElementById('condition-input');
-        return !input || typeof input.onkeydown === 'function';
-      }, 20);
       document.removeEventListener('click', editor.closeSuggestionsOnClickOutside);
       state.importedData = saved.importedData;
       state.profileSex = saved.profileSex;

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -672,7 +672,9 @@ console.log('11. Event Listener Leak Fix');
 
 const ctxSrc = read('js/context-cards.js');
 const ctxMedicalHistorySrc = read('js/context-card-medical-history-editor.js');
-assert('Diagnoses editor removes old listener before adding', ctxMedicalHistorySrc.includes("document.removeEventListener('click', closeSuggestionsOnClickOutside)"));
+assert('Diagnoses editor binds suggestion closer once with delegates',
+  /function initMedicalHistoryActionDelegates[\s\S]{0,500}document\.addEventListener\('click', closeSuggestionsOnClickOutside\)/.test(ctxMedicalHistorySrc) &&
+    !ctxMedicalHistorySrc.includes("document.removeEventListener('click', closeSuggestionsOnClickOutside)"));
 
 // ═══════════════════════════════════════
 // 12. Cycle stats NaN guard

--- a/tests/test-family-history.js
+++ b/tests/test-family-history.js
@@ -82,13 +82,12 @@ const ctxSrc = await fetch('js/context-cards.js').then(r => r.text());
 const ctxSummarySrc = await fetch('js/context-card-summaries.js').then(r => r.text());
 const ctxMedicalSrc = await fetch('js/context-card-medical-history-editor.js').then(r => r.text());
 const ctxCardSrc = `${ctxSrc}\n${ctxSummarySrc}\n${ctxMedicalSrc}`;
-// filterConditionSuggestions must wrap the inline call arg in JSON.stringify
-// so apostrophes survive the HTML-attribute → JS-string round-trip. The
-// live DOM round-trip probe lives in tests/playwright/family-history-dom.spec.js.
-assert("filterConditionSuggestions uses JSON.stringify(m) for inline onclick arg",
-  /selectConditionSuggestion\(\$\{escapeHTML\(JSON\.stringify\(m\)\)\}\)/.test(ctxMedicalSrc));
-assert("filterFamilyConditionSuggestions uses JSON.stringify(m) for inline onclick arg",
-  /selectFamilyConditionSuggestion\(\$\{escapeHTML\(JSON\.stringify\(m\)\)\}\)/.test(ctxMedicalSrc));
+assert('Condition suggestions use delegated data values',
+  /data-medical-history-suggestion="condition" data-medical-history-value="\$\{escapeHTML\(m\)\}"/.test(ctxMedicalSrc));
+assert('Family condition suggestions use delegated data values',
+  /data-medical-history-suggestion="family-condition" data-medical-history-value="\$\{escapeHTML\(m\)\}"/.test(ctxMedicalSrc));
+assert('Medical history editor has no inline event attributes',
+  !/\son[a-z]+\s*=/.test(ctxMedicalSrc));
 
 // ═══════════════════════════════════════
 // 3. FAMILY_RELATIVES allowlist + addFamilyHistoryEntry guards (source)
@@ -213,10 +212,10 @@ assert('Relative chip emoji mapping defined',
   /RELATIVE_EMOJI\s*=\s*\{/.test(ctxMedicalSrc));
 assert("Closing-suggestions handler also clears fh-condition-suggestions",
   /fh-condition-suggestions[\s\S]{0,200}fhContainer\.innerHTML\s*=\s*''/.test(ctxMedicalSrc));
-assert('Condition rows expose edit action',
-  ctxMedicalSrc.includes('onclick="editCondition(${i})"'));
-assert('Family rows expose edit action',
-  ctxMedicalSrc.includes('onclick="editFamilyHistoryEntry(${i})"'));
+assert('Condition rows expose delegated edit action',
+  ctxMedicalSrc.includes("medicalHistoryActionAttrs('edit-condition'"));
+assert('Family rows expose delegated edit action',
+  ctxMedicalSrc.includes("medicalHistoryActionAttrs('edit-family-history'"));
 assert('Condition edit updates existing row instead of appending',
   /diagnoses\.conditions\[editingConditionIndex\] = cond/.test(ctxMedicalSrc));
 assert('Family history edit updates existing row instead of appending',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.498';
+self.APP_VERSION = '1.8.499';


### PR DESCRIPTION
## Summary
- Replace medical history editor inline event attributes with delegated data-action handlers scoped to the detail modal.
- Keep autocomplete, Enter-key add, severity selection, row edit/delete, save/cancel/clear behavior covered through delegated events.
- Lower the inline event attribute quality baseline from 335 to 319 and bump `version.js` for app cache invalidation.

## Validation
- `npm run quality`
- `node tests/test-family-history.js`
- `npm run typecheck`
- `npx playwright test tests/playwright/family-history-dom.spec.js`
- `./run-tests.sh`