### PR TITLE
Delegate lifestyle context actions

### DIFF
--- a/js/context-card-editor-ui.js
+++ b/js/context-card-editor-ui.js
@@ -3,6 +3,68 @@
 
 import { escapeHTML } from './utils.js';
 
+/**
+ * @param {string} action
+ * @param {string} [extra]
+ * @returns {string}
+ */
+export function contextEditorActionAttrs(action, extra = '') {
+  return `data-ctx-editor-action="${action}"${extra ? ` ${extra}` : ''}`;
+}
+
+/**
+ * @param {EventTarget | null} target
+ * @param {string} selector
+ * @returns {HTMLElement | null}
+ */
+function closestContextEditorElement(target, selector) {
+  if (!(target instanceof Element)) return null;
+  const el = target.closest(selector);
+  return el instanceof HTMLElement ? el : null;
+}
+
+/**
+ * @param {string | undefined} fnName
+ */
+function invokeContextEditorWindowFn(fnName) {
+  if (!fnName || typeof window === 'undefined') return;
+  const fn = /** @type {any} */ (window)[fnName];
+  if (typeof fn === 'function') fn();
+}
+
+/** @param {MouseEvent} event */
+function handleContextEditorClick(event) {
+  const actionEl = closestContextEditorElement(event.target, '[data-ctx-editor-action]');
+  if (!actionEl) return;
+  const action = actionEl.dataset.ctxEditorAction || '';
+  switch (action) {
+    case 'close':
+      invokeContextEditorWindowFn(actionEl.dataset.ctxEditorFn || 'closeModal');
+      break;
+    case 'invoke':
+      invokeContextEditorWindowFn(actionEl.dataset.ctxEditorFn);
+      break;
+    case 'select-option':
+      selectCtxOption(actionEl, actionEl.dataset.ctxEditorGroup || actionEl.parentElement?.id || '');
+      break;
+    case 'toggle-tag':
+      toggleCtxTag(actionEl);
+      break;
+    default:
+      break;
+  }
+}
+
+function initContextEditorDelegates() {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  const appWindow = /** @type {any} */ (window);
+  if (appWindow.__contextEditorDelegatesBound) return;
+  appWindow.__contextEditorDelegatesBound = true;
+  document.addEventListener('click', handleContextEditorClick);
+}
+
+initContextEditorDelegates();
+
 export function renderContextEditorModal(modal, title, subtitle, bodyHtml, closeFn = 'closeModal') {
   if (!modal) return;
   modal.className = 'modal gb-form-modal ctx-editor-modal';
@@ -12,7 +74,7 @@ export function renderContextEditorModal(modal, title, subtitle, bodyHtml, close
       <div class="gb-modal-kicker">Profile context</div>
       <h3 class="gb-modal-title">${escapeHTML(title)}</h3>
     </div>
-    <button type="button" class="modal-close" onclick="${closeFn}()" aria-label="Close ${escapeHTML(title)}">&times;</button>
+    <button type="button" class="modal-close" ${contextEditorActionAttrs('close', `data-ctx-editor-fn="${escapeHTML(closeFn)}"`)} aria-label="Close ${escapeHTML(title)}">&times;</button>
   </div>
   <div class="gb-form-body ctx-editor-body">
     ${subtitle ? `<div class="modal-unit">${escapeHTML(subtitle)}</div>` : ''}
@@ -23,7 +85,7 @@ export function renderContextEditorModal(modal, title, subtitle, bodyHtml, close
 export function renderSelectField(label, id, options, current) {
   return `<div class="ctx-field-group"><label class="ctx-field-label">${escapeHTML(label)}</label>
     <div class="ctx-btn-group" id="${id}">
-      ${options.map(o => `<button type="button" class="ctx-btn-option${current === o ? ' active' : ''}" onclick="selectCtxOption(this,'${id}')">${escapeHTML(o)}</button>`).join('')}
+      ${options.map(o => `<button type="button" class="ctx-btn-option${current === o ? ' active' : ''}" ${contextEditorActionAttrs('select-option', `data-ctx-editor-group="${escapeHTML(id)}"`)}>${escapeHTML(o)}</button>`).join('')}
     </div></div>`;
 }
 
@@ -46,7 +108,7 @@ export function renderTagsField(label, id, options, selected) {
   const sel = selected || [];
   return `<div class="ctx-field-group"><label class="ctx-field-label">${escapeHTML(label)}</label>
     <div class="ctx-tags" id="${id}">
-      ${options.map(o => `<button type="button" class="ctx-tag${sel.includes(o) ? ' active' : ''}" onclick="toggleCtxTag(this)">${escapeHTML(o)}</button>`).join('')}
+      ${options.map(o => `<button type="button" class="ctx-tag${sel.includes(o) ? ' active' : ''}" ${contextEditorActionAttrs('toggle-tag')}>${escapeHTML(o)}</button>`).join('')}
     </div></div>`;
 }
 
@@ -96,8 +158,8 @@ export function renderNoteField(value) {
 
 export function contextEditorActions(hasCurrent, saveFn, clearFn) {
   return `<div class="ctx-editor-actions">
-    <button class="import-btn import-btn-primary" onclick="${saveFn}()">Save</button>
-    <button class="import-btn import-btn-secondary" onclick="closeModal()">Cancel</button>
-    ${hasCurrent ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" onclick="${clearFn}()">Clear</button>` : ''}
+    <button class="import-btn import-btn-primary" ${contextEditorActionAttrs('invoke', `data-ctx-editor-fn="${escapeHTML(saveFn)}"`)}>Save</button>
+    <button class="import-btn import-btn-secondary" ${contextEditorActionAttrs('close')}>Cancel</button>
+    ${hasCurrent ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${contextEditorActionAttrs('invoke', `data-ctx-editor-fn="${escapeHTML(clearFn)}"`)}>Clear</button>` : ''}
   </div>`;
 }

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -130,12 +130,85 @@ function getActiveNavCategory() {
   return activeNav?.dataset.category || "dashboard";
 }
 
+function lifestyleActionAttrs(action, extra = '') { return `data-lifestyle-action="${action}"${extra ? ` ${extra}` : ''}`; }
+
+function closestLifestyleElement(target, selector) {
+  const el = target instanceof Element ? target.closest(selector) : null;
+  return el instanceof HTMLElement && el.closest('#detail-modal') ? el : null;
+}
+
+function getLifestyleIndex(el) {
+  const idx = Number.parseInt(el.dataset.lifestyleIndex || '', 10);
+  return Number.isInteger(idx) ? idx : -1;
+}
+
+function getAppWindow() { return typeof window !== 'undefined' ? /** @type {any} */ (window) : {}; }
+
+function openLightSetupFromContext() {
+  const appWindow = getAppWindow();
+  if (typeof appWindow.closeModal === 'function') appWindow.closeModal();
+  if (typeof appWindow.navigate === 'function') appWindow.navigate('light');
+  setTimeout(() => { if (typeof appWindow.reopenSunSetup === 'function') appWindow.reopenSunSetup(); }, 200);
+}
+
+function discussDietContaminants() {
+  const appWindow = getAppWindow();
+  if (typeof appWindow.closeModal === 'function') appWindow.closeModal();
+  if (typeof appWindow.openChatPanel === 'function') appWindow.openChatPanel();
+  setTimeout(() => { if (typeof appWindow.useChatPrompt === 'function') appWindow.useChatPrompt('What food contaminants should I be concerned about based on my diet?'); }, 300);
+}
+
+/** @param {MouseEvent} event */
+function handleLifestyleContextClick(event) {
+  const actionEl = closestLifestyleElement(event.target, '[data-lifestyle-action]');
+  if (!actionEl) return;
+  switch (actionEl.dataset.lifestyleAction || '') {
+    case 'show-diet-contaminants': event.stopPropagation(); showDietContaminantsModal(); break;
+    case 'open-light-setup': openLightSetupFromContext(); break;
+    case 'delete-health-goal': { const idx = getLifestyleIndex(actionEl); if (idx >= 0) deleteHealthGoal(idx); break; }
+    case 'add-health-goal': addHealthGoal(); break;
+    case 'select-goal-severity': selectCtxOption(actionEl, 'goal-severity-select'); break;
+    case 'close-health-goals': closeHealthGoals(); break;
+    case 'clear-health-goals': clearHealthGoals(); break;
+    case 'save-interpretive-lens': saveInterpretiveLens(); break;
+    case 'clear-interpretive-lens': clearInterpretiveLens(); break;
+    case 'discuss-diet-contaminants': discussDietContaminants(); break;
+    case 'close-modal': { const appWindow = getAppWindow(); if (typeof appWindow.closeModal === 'function') appWindow.closeModal(); break; }
+    default:
+      break;
+  }
+}
+
+/** @param {KeyboardEvent} event */
+function handleLifestyleContextKeydown(event) {
+  const badge = closestLifestyleElement(event.target, '[data-lifestyle-action="show-diet-contaminants"]');
+  if (badge && (event.key === 'Enter' || event.key === ' ')) {
+    event.preventDefault();
+    event.stopPropagation();
+    showDietContaminantsModal();
+    return;
+  }
+  const goalInput = closestLifestyleElement(event.target, '#goal-text-input');
+  if (goalInput && event.key === 'Enter') { event.preventDefault(); addHealthGoal(); }
+}
+
+function initLifestyleContextDelegates() {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  const appWindow = getAppWindow();
+  if (appWindow.__lifestyleContextDelegatesBound) return;
+  appWindow.__lifestyleContextDelegatesBound = true;
+  document.addEventListener('click', handleLifestyleContextClick);
+  document.addEventListener('keydown', handleLifestyleContextKeydown);
+}
+
+initLifestyleContextDelegates();
+
 export function renderDietContaminantsBadge() {
   const warnings = scanDietForContaminants(state.importedData.diet);
   if (warnings.length === 0) return '';
   const flagged = warnings.filter(w => w.type !== 'clean').length;
   if (flagged === 0) return '';
-  return `<div class="diet-contaminants" role="button" tabindex="0" onclick="event.stopPropagation(); showDietContaminantsModal()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">\u26A0\uFE0F ${flagged} food contaminant signal${flagged > 1 ? 's' : ''} detected</div>`;
+  return `<div class="diet-contaminants" role="button" tabindex="0" ${lifestyleActionAttrs('show-diet-contaminants')}>\u26A0\uFE0F ${flagged} food contaminant signal${flagged > 1 ? 's' : ''} detected</div>`;
 }
 
 function getTimePlaceholder() {
@@ -319,7 +392,7 @@ function renderLightSetupMirror(current) {
       <label class="ctx-field-label">Light lens setup</label>
       <div class="ctx-lightsetup-empty">
         <span>Not set yet — covers skin type, home lighting, eyewear, and indoor/outdoor lifestyle.</span>
-        <button type="button" class="ctx-lightsetup-edit" onclick="closeModal();window.navigate&&window.navigate('light');setTimeout(()=>window.reopenSunSetup&&window.reopenSunSetup(),200);">Set up Light lens →</button>
+        <button type="button" class="ctx-lightsetup-edit" ${lifestyleActionAttrs('open-light-setup')}>Set up Light lens →</button>
       </div>
     </div>`;
   }
@@ -327,7 +400,7 @@ function renderLightSetupMirror(current) {
   return `<div class="ctx-field-group ctx-lightsetup-mirror">
     <div class="ctx-lightsetup-head">
       <label class="ctx-field-label" style="margin:0">Light lens setup</label>
-      <button type="button" class="ctx-lightsetup-edit" onclick="closeModal();window.navigate&&window.navigate('light');setTimeout(()=>window.reopenSunSetup&&window.reopenSunSetup(),200);">Edit →</button>
+      <button type="button" class="ctx-lightsetup-edit" ${lifestyleActionAttrs('open-light-setup')}>Edit →</button>
     </div>
     <div class="ctx-lightsetup-grid">
       <div class="ctx-lightsetup-row"><span class="ctx-lightsetup-label">Skin type</span><span class="ctx-lightsetup-value">${skin ? escapeHTML(skin) : '—'}</span></div>
@@ -569,7 +642,7 @@ export function renderHealthGoalsModal(modal) {
       html += `<div class="goals-list-item">
         <span class="goals-severity-badge severity-${g.severity}">${g.severity}</span>
         <span class="goals-text">${escapeHTML(g.text)}</span>
-        <button class="goals-delete-btn" onclick="deleteHealthGoal(${i})" title="Remove">&times;</button>
+        <button class="goals-delete-btn" ${lifestyleActionAttrs('delete-health-goal', `data-lifestyle-index="${i}"`)} title="Remove">&times;</button>
       </div>`;
     }
     html += `</div>`;
@@ -577,25 +650,22 @@ export function renderHealthGoalsModal(modal) {
   html += `<div class="ctx-field-group"><label class="ctx-field-label">Add goal</label>
     <div class="goals-add-row">
       <input type="text" class="ctx-note-input" id="goal-text-input" placeholder="e.g. Improve insulin sensitivity, Optimize thyroid function" style="flex:1">
-      <button class="import-btn import-btn-primary" onclick="addHealthGoal()">Add</button>
+      <button class="import-btn import-btn-primary" ${lifestyleActionAttrs('add-health-goal')}>Add</button>
     </div>
     <div class="ctx-btn-group" id="goal-severity-select" style="margin-top:8px">
-      <button type="button" class="ctx-btn-option active" onclick="selectCtxOption(this,'goal-severity-select')">major</button>
-      <button type="button" class="ctx-btn-option" onclick="selectCtxOption(this,'goal-severity-select')">mild</button>
-      <button type="button" class="ctx-btn-option" onclick="selectCtxOption(this,'goal-severity-select')">minor</button>
+      <button type="button" class="ctx-btn-option active" ${lifestyleActionAttrs('select-goal-severity')}>major</button>
+      <button type="button" class="ctx-btn-option" ${lifestyleActionAttrs('select-goal-severity')}>mild</button>
+      <button type="button" class="ctx-btn-option" ${lifestyleActionAttrs('select-goal-severity')}>minor</button>
     </div>
   </div>
   <div class="ctx-editor-actions">
-    <button class="import-btn import-btn-secondary" onclick="closeHealthGoals()">Done</button>
-    ${goals.length > 0 ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" onclick="clearHealthGoals()">Clear All</button>` : ''}
+    <button class="import-btn import-btn-secondary" ${lifestyleActionAttrs('close-health-goals')}>Done</button>
+    ${goals.length > 0 ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${lifestyleActionAttrs('clear-health-goals')}>Clear All</button>` : ''}
   </div>`;
   renderContextEditorModal(modal, 'Health Goals', 'List things you want to solve or improve. The AI will prioritize analysis around your stated goals.', html);
   setTimeout(() => {
     const input = getTextInput('goal-text-input');
-    if (input) {
-      input.focus();
-      input.onkeydown = (e) => { if (e.key === 'Enter') { e.preventDefault(); addHealthGoal(); } };
-    }
+    if (input) input.focus();
   }, 50);
 }
 
@@ -644,9 +714,9 @@ export function openInterpretiveLensEditor() {
   renderContextEditorModal(modal, 'Interpretive Lens', 'List researchers, clinicians, or scientific paradigms whose frameworks you follow. The AI will consider their perspectives when interpreting your results.', `
     <textarea class="note-editor" id="interpretive-lens-textarea" placeholder="e.g. Longevity medicine, quantum biology, functional endocrinology framework...">${escapeHTML(current)}</textarea>
     <div class="ctx-editor-actions">
-      <button class="import-btn import-btn-primary" onclick="saveInterpretiveLens()">Save</button>
-      <button class="import-btn import-btn-secondary" onclick="closeModal()">Cancel</button>
-      ${current ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" onclick="clearInterpretiveLens()">Clear</button>` : ''}
+      <button class="import-btn import-btn-primary" ${lifestyleActionAttrs('save-interpretive-lens')}>Save</button>
+      <button class="import-btn import-btn-secondary" ${lifestyleActionAttrs('close-modal')}>Cancel</button>
+      ${current ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${lifestyleActionAttrs('clear-interpretive-lens')}>Clear</button>` : ''}
     </div>`);
   openModalOverlay(overlay);
   setTimeout(() => {
@@ -684,7 +754,7 @@ export function showDietContaminantsModal() {
   const pesticide = warnings.filter(w => w.type === 'pesticide');
   const plastic = warnings.filter(w => w.type === 'plastic');
   const clean = warnings.filter(w => w.type === 'clean');
-  let html = `<button class="modal-close" onclick="closeModal()">&times;</button>
+  let html = `<button class="modal-close" ${lifestyleActionAttrs('close-modal')}>&times;</button>
     <h3>Food Contaminant Signals</h3>
     <div class="modal-unit">Based on foods mentioned in your diet card, cross-referenced against public contaminant databases.</div>`;
   if (pesticide.length > 0) {
@@ -709,8 +779,8 @@ export function showDietContaminantsModal() {
     html += `</div>`;
   }
   html += `<div class="contaminant-actions">
-    <button class="import-btn import-btn-primary" onclick="closeModal(); window.openChatPanel(); setTimeout(() => window.useChatPrompt('What food contaminants should I be concerned about based on my diet?'), 300)">Discuss with AI</button>
-    <button class="import-btn import-btn-secondary" onclick="closeModal()">Close</button>
+    <button class="import-btn import-btn-primary" ${lifestyleActionAttrs('discuss-diet-contaminants')}>Discuss with AI</button>
+    <button class="import-btn import-btn-secondary" ${lifestyleActionAttrs('close-modal')}>Close</button>
   </div>
   <div class="contaminant-attribution">Sources: <a href="https://www.ewg.org/foodnews/" target="_blank" rel="noopener">EWG Shopper's Guide 2025</a> · <a href="https://www.plasticlist.org/report" target="_blank" rel="noopener">PlasticList</a></div>`;
   modal.innerHTML = html;

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -134,7 +134,9 @@ function lifestyleActionAttrs(action, extra = '') { return `data-lifestyle-actio
 
 function closestLifestyleElement(target, selector) {
   const el = target instanceof Element ? target.closest(selector) : null;
-  return el instanceof HTMLElement && el.closest('#detail-modal') ? el : null;
+  if (!(el instanceof HTMLElement)) return null;
+  if (el.closest('#detail-modal')) return el;
+  return el.dataset.lifestyleAction === 'show-diet-contaminants' ? el : null;
 }
 
 function getLifestyleIndex(el) {
@@ -163,7 +165,7 @@ function handleLifestyleContextClick(event) {
   const actionEl = closestLifestyleElement(event.target, '[data-lifestyle-action]');
   if (!actionEl) return;
   switch (actionEl.dataset.lifestyleAction || '') {
-    case 'show-diet-contaminants': event.stopPropagation(); showDietContaminantsModal(); break;
+    case 'show-diet-contaminants': event.preventDefault(); event.stopPropagation(); showDietContaminantsModal(); break;
     case 'open-light-setup': openLightSetupFromContext(); break;
     case 'delete-health-goal': { const idx = getLifestyleIndex(actionEl); if (idx >= 0) deleteHealthGoal(idx); break; }
     case 'add-health-goal': addHealthGoal(); break;
@@ -197,7 +199,7 @@ function initLifestyleContextDelegates() {
   const appWindow = getAppWindow();
   if (appWindow.__lifestyleContextDelegatesBound) return;
   appWindow.__lifestyleContextDelegatesBound = true;
-  document.addEventListener('click', handleLifestyleContextClick);
+  document.addEventListener('click', handleLifestyleContextClick, true);
   document.addEventListener('keydown', handleLifestyleContextKeydown);
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 305,
+  "inlineEventAttributes": 282,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -20,14 +20,18 @@ test('context editor select option helper toggles active buttons', async ({ page
         && editor.getSelectedOption('ctx-select-coverage') === 'major'
         && buttons[0].classList.contains('active');
 
-      editor.selectCtxOption(buttons[1], 'ctx-select-coverage');
+      outcomes.renderSelectFieldUsesDelegatedActions =
+        !host.querySelector('[onclick]')
+        && buttons.every(button => button.dataset.ctxEditorAction === 'select-option');
+
+      buttons[1]?.click();
       outcomes.selectCtxOptionMovesActiveState =
         editor.getSelectedOption('ctx-select-coverage') === 'mild'
         && !buttons[0].classList.contains('active')
         && buttons[1].classList.contains('active')
         && !buttons[2].classList.contains('active');
 
-      editor.selectCtxOption(buttons[1], 'ctx-select-coverage');
+      buttons[1]?.click();
       outcomes.selectCtxOptionTogglesActiveButtonOff =
         editor.getSelectedOption('ctx-select-coverage') === null
         && buttons.every(button => !button.classList.contains('active'));
@@ -210,14 +214,14 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       const btn = document.querySelectorAll(`#${id} .ctx-btn-option`)[index];
       const label = btn?.textContent?.trim() || '';
       outcomes[controlOutcomeName('option', id, index)] = !!btn && !!label;
-      btn?.classList.add('active');
+      btn?.click();
       return label;
     };
     const setTag = (id, index = 0) => {
       const btn = document.querySelectorAll(`#${id} .ctx-tag`)[index];
       const label = btn?.textContent?.trim() || '';
       outcomes[controlOutcomeName('tag', id, index)] = !!btn && !!label;
-      btn?.classList.add('active');
+      btn?.click();
       return label;
     };
 
@@ -254,6 +258,7 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       state.importedData.healthGoals = [{ text: 'Initial sync goal', severity: 'major' }];
       lifestyle.openHealthGoalsEditor();
       outcomes.healthGoalsModalStartsWithInitialSyncGoal = modal.textContent.includes('Initial sync goal');
+      outcomes.healthGoalsModalUsesDelegatedActions = !modal.querySelector('[onclick], [onkeydown]');
       state.importedData.healthGoals = [{ text: 'Synced goal from sync', severity: 'minor' }];
       window.dispatchEvent(new CustomEvent('labcharts-sync-applied'));
       await delay(0);
@@ -283,10 +288,14 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       const contaminantBadge = lifestyle.renderDietContaminantsBadge();
       outcomes.dietContaminantsBadgeCountsFlaggedSignals = contaminantBadge.includes('food contaminant signal')
         && contaminantBadge.includes('detected');
+      outcomes.dietContaminantsBadgeUsesDelegatedActions = contaminantBadge.includes('data-lifestyle-action="show-diet-contaminants"')
+        && !contaminantBadge.includes('onclick=')
+        && !contaminantBadge.includes('onkeydown=');
       lifestyle.showDietContaminantsModal();
       outcomes.dietContaminantsModalGroupsWarnings = modal.textContent.includes('Pesticide Residues')
         && modal.textContent.includes('Plastic Chemicals')
         && modal.textContent.includes('Low Contamination');
+      outcomes.dietContaminantsModalUsesDelegatedActions = !modal.querySelector('[onclick]');
       modal.querySelector('.contaminant-actions .import-btn-primary')?.click();
       await delay(350);
       outcomes.dietContaminantsDiscussesWithAI = calls.some(call => call[0] === 'chat')
@@ -376,30 +385,33 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       lifestyle.openHealthGoalsEditor();
       document.getElementById('goal-text-input').value = 'Improve sleep timing';
       document.querySelectorAll('#goal-severity-select .ctx-btn-option').forEach(btn => btn.classList.remove('active'));
-      document.querySelectorAll('#goal-severity-select .ctx-btn-option')[1]?.classList.add('active');
-      lifestyle.addHealthGoal();
+      document.querySelectorAll('#goal-severity-select .ctx-btn-option')[1]?.click();
+      document.querySelector('[data-lifestyle-action="add-health-goal"]')?.click();
       outcomes.addHealthGoalAppendsSeverity = state.importedData.healthGoals?.[0]?.text === 'Improve sleep timing'
         && state.importedData.healthGoals?.[0]?.severity === 'mild';
-      lifestyle.deleteHealthGoal(0);
+      document.querySelector('[data-lifestyle-action="delete-health-goal"][data-lifestyle-index="0"]')?.click();
       outcomes.deleteHealthGoalRemovesByIndex = state.importedData.healthGoals?.length === 0;
       document.getElementById('goal-text-input').value = 'Reduce eye strain';
-      lifestyle.addHealthGoal();
-      lifestyle.closeHealthGoals();
+      document.getElementById('goal-text-input').dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      document.querySelector('[data-lifestyle-action="close-health-goals"]')?.click();
       outcomes.closeHealthGoalsClosesAndNavigates = calls.some(call => call[0] === 'close')
         && calls.some(call => call[0] === 'navigate');
       lifestyle.openHealthGoalsEditor();
-      lifestyle.clearHealthGoals();
+      document.querySelector('[data-lifestyle-action="clear-health-goals"]')?.click();
       outcomes.clearHealthGoalsEmptiesArray = Array.isArray(state.importedData.healthGoals)
         && state.importedData.healthGoals.length === 0;
 
       lifestyle.openInterpretiveLensEditor();
       document.getElementById('interpretive-lens-textarea').value = 'Functional endocrinology';
-      lifestyle.saveInterpretiveLens();
+      document.querySelector('[data-lifestyle-action="save-interpretive-lens"]')?.click();
       outcomes.saveInterpretiveLensStoresTrimmedText = state.importedData.interpretiveLens === 'Functional endocrinology';
       lifestyle.openInterpretiveLensEditor();
-      lifestyle.clearInterpretiveLens();
+      document.querySelector('[data-lifestyle-action="clear-interpretive-lens"]')?.click();
       outcomes.clearInterpretiveLensBlanksText = state.importedData.interpretiveLens === '';
 
+      lifestyle.openHealthGoalsEditor();
+      document.getElementById('goal-text-input').value = 'Callback coverage goal';
+      lifestyle.addHealthGoal();
       outcomes.configureCallbacksWereUsed = calls.some(call => call[0] === 'save' && call[2] === 'diet')
         && calls.some(call => call[0] === 'record' && call[1] === 'healthGoals');
     } finally {

--- a/tests/playwright/food-contaminants-browser-coverage.spec.js
+++ b/tests/playwright/food-contaminants-browser-coverage.spec.js
@@ -100,7 +100,8 @@ test('food contaminant browser coverage scans diet fields and renders warning UI
       outcomes.dietBadgeCountsOnlyFlaggedSignals =
         badge.includes('2 food contaminant signals detected')
         && badge.includes('role="button"')
-        && badge.includes('showDietContaminantsModal()');
+        && badge.includes('data-lifestyle-action="show-diet-contaminants"')
+        && !badge.includes('onclick=');
 
       state.importedData.diet = { breakfast: 'avocado and pineapple' };
       outcomes.cleanOnlyDietDoesNotRenderBadge = lifestyle.renderDietContaminantsBadge() === '';
@@ -124,7 +125,8 @@ test('food contaminant browser coverage scans diet fields and renders warning UI
         && modalText.includes('EWG Shopper')
         && modalText.includes('PlasticList')
         && modal?.querySelectorAll('a[target="_blank"][rel="noopener"]').length >= 3
-        && modal?.innerHTML.includes('window.openChatPanel()');
+        && modal?.querySelector('[data-lifestyle-action="discuss-diet-contaminants"]')
+        && !modal?.querySelector('[onclick]');
 
       state.importedData.diet = { breakfast: '' };
       document.getElementById('detail-modal').innerHTML = 'unchanged';

--- a/tests/playwright/food-contaminants-browser-coverage.spec.js
+++ b/tests/playwright/food-contaminants-browser-coverage.spec.js
@@ -103,6 +103,23 @@ test('food contaminant browser coverage scans diet fields and renders warning UI
         && badge.includes('data-lifestyle-action="show-diet-contaminants"')
         && !badge.includes('onclick=');
 
+      let openedDietEditor = false;
+      window.openDietEditor = () => { openedDietEditor = true; };
+      const fixture = document.getElementById('fixture');
+      fixture.innerHTML = '';
+      const contextCard = document.createElement('div');
+      contextCard.className = 'context-card';
+      contextCard.setAttribute('onclick', 'window.openDietEditor()');
+      contextCard.innerHTML = badge;
+      fixture.append(contextCard);
+      contextCard.querySelector('.diet-contaminants')?.click();
+      outcomes.dashboardBadgeClickBypassesParentCard =
+        openedDietEditor === false
+        && document.getElementById('modal-overlay')?.classList.contains('show') === true
+        && (document.getElementById('detail-modal')?.textContent || '').includes('Food Contaminant Signals');
+      document.getElementById('modal-overlay')?.classList.remove('show');
+      document.getElementById('detail-modal').innerHTML = '';
+
       state.importedData.diet = { breakfast: 'avocado and pineapple' };
       outcomes.cleanOnlyDietDoesNotRenderBadge = lifestyle.renderDietContaminantsBadge() === '';
 
@@ -152,6 +169,7 @@ test('food contaminant browser coverage scans diet fields and renders warning UI
     'scanUsesWordBoundaries',
     'scanDeduplicatesVariantsPerWarning',
     'dietBadgeCountsOnlyFlaggedSignals',
+    'dashboardBadgeClickBypassesParentCard',
     'cleanOnlyDietDoesNotRenderBadge',
     'contaminantsModalGroupsSourcesAndActions',
     'emptyWarningsLeaveModalUntouched',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -286,10 +286,19 @@ assert('marker rename refreshes the backing view before reopening modal',
 console.log('3c. innerHTML sanitizer sweep');
 
 const contextCardEditorSrc = read('js/context-card-editor-ui.js');
+const contextCardLifestyleSrc = read('js/context-card-lifestyle-editors.js');
 assert('Context select field escapes label text',
   /function renderSelectField[\s\S]{0,220}<label class="ctx-field-label">\$\{escapeHTML\(label\)\}<\/label>/.test(contextCardEditorSrc));
 assert('Context tags field escapes label text',
   /function renderTagsField[\s\S]{0,220}<label class="ctx-field-label">\$\{escapeHTML\(label\)\}<\/label>/.test(contextCardEditorSrc));
+assert('Context editor controls use delegated data actions',
+  contextCardEditorSrc.includes('initContextEditorDelegates')
+    && contextCardEditorSrc.includes('contextEditorActionAttrs')
+    && !/\son(?:click|keydown|input|change)\s*=/.test(contextCardEditorSrc));
+assert('Lifestyle context actions use delegated handlers',
+  contextCardLifestyleSrc.includes('initLifestyleContextDelegates')
+    && contextCardLifestyleSrc.includes('lifestyleActionAttrs')
+    && !/\son(?:click|keydown)\s*=/.test(contextCardLifestyleSrc));
 
 const _SANITIZER_RE = /(escapeHTML|safeMarkerId|escapeAttr|applyInlineMarkdown|renderMarkdown)\s*\(/;
 const _SAFE_HELPERS = new Set([

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.500';
+self.APP_VERSION = '1.8.501';


### PR DESCRIPTION
## Summary
- Delegate shared context editor select, tag, save, clear, and close controls through document-level data-action handlers.
- Delegate lifestyle context modal actions for health goals, interpretive lens controls, light setup, and diet contaminant dialogs.
- Update browser/audit coverage and lower the inline event attribute baseline from 305 to 282.

## Validation
- npm run quality
- npm run typecheck
- npm test
- node tests/test-audit.js
- npx playwright test tests/playwright/context-coverage-batch.spec.js
- npx playwright test tests/playwright/food-contaminants-browser-coverage.spec.js
- ./run-tests.sh
