### PR TITLE
Delegate PDF import review actions

### DIFF
--- a/js/pdf-import-review.js
+++ b/js/pdf-import-review.js
@@ -29,6 +29,81 @@ function hideImportOverlay() {
   closeModalOverlay('import-modal-overlay');
 }
 
+function importReviewActionAttrs(action, extra = '') {
+  return `data-import-review-action="${action}"${extra ? ` ${extra}` : ''}`;
+}
+
+function closestImportReviewElement(target, selector) {
+  const el = target instanceof Element ? target.closest(selector) : null;
+  return el instanceof HTMLElement && el.closest('#import-modal') ? el : null;
+}
+
+function getImportReviewWindow() {
+  return typeof window !== 'undefined' ? /** @type {any} */ (window) : {};
+}
+
+/** @param {MouseEvent} event */
+function handleImportReviewClick(event) {
+  const actionEl = closestImportReviewElement(event.target, '[data-import-review-action]');
+  if (!actionEl) return;
+  switch (actionEl.dataset.importReviewAction || '') {
+    case 'close':
+      closeImportModal();
+      break;
+    case 'filter':
+      setImportReviewFilter(actionEl);
+      break;
+    case 'toggle-row':
+      toggleImportRow(actionEl);
+      break;
+    case 'privacy-details': {
+      const appWindow = getImportReviewWindow();
+      const pending = getPendingImport();
+      if (typeof appWindow.showPIIDiffViewer === 'function' && pending?.privacyOriginal && pending?.privacyObfuscated) {
+        appWindow.showPIIDiffViewer(pending.privacyOriginal, pending.privacyObfuscated);
+      }
+      break;
+    }
+    case 'confirm': {
+      const appWindow = getImportReviewWindow();
+      if (typeof appWindow.confirmImport === 'function') appWindow.confirmImport();
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+/** @param {Event} event */
+function handleImportReviewInput(event) {
+  if (closestImportReviewElement(event.target, '[data-import-review-action="search"]')) {
+    applyImportReviewFilters();
+  }
+}
+
+/** @param {Event} event */
+function handleImportReviewChange(event) {
+  const dateInput = closestImportReviewElement(event.target, '[data-import-review-action="manual-date"]');
+  if (dateInput instanceof HTMLInputElement) {
+    applyManualImportDate(dateInput.value);
+    return;
+  }
+  const mapInput = closestImportReviewElement(event.target, '[data-import-review-action="map-marker"]');
+  if (mapInput instanceof HTMLInputElement) mapUnmatchedMarkerInput(mapInput);
+}
+
+function initImportReviewDelegates() {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  const appWindow = getImportReviewWindow();
+  if (appWindow.__importReviewDelegatesBound) return;
+  appWindow.__importReviewDelegatesBound = true;
+  document.addEventListener('click', handleImportReviewClick);
+  document.addEventListener('input', handleImportReviewInput);
+  document.addEventListener('change', handleImportReviewChange);
+}
+
+initImportReviewDelegates();
+
 export function getPendingImport() {
   return window._pendingImport || null;
 }
@@ -61,7 +136,7 @@ export function showImportPreview(parseResult) {
       <div class="gb-modal-kicker">${escapeHTML(batchLabel)}</div>
       <div class="gb-modal-title">Review &amp; Edit Import</div>
     </div>
-    <button type="button" class="modal-close" onclick="closeImportModal()" aria-label="Close import review">&times;</button>
+    <button type="button" class="modal-close" ${importReviewActionAttrs('close')} aria-label="Close import review">&times;</button>
   </div>
   <div class="gb-form-body import-review-body">
     <div class="import-review-summary">
@@ -71,7 +146,7 @@ export function showImportPreview(parseResult) {
       </div>
       <div class="import-review-file">
         <span class="import-review-label">Collection date</span>
-        <input type="date" id="import-manual-date" value="${escapeHTML(date || '')}" onchange="applyManualImportDate(this.value)" aria-label="Collection date">
+        <input type="date" id="import-manual-date" value="${escapeHTML(date || '')}" ${importReviewActionAttrs('manual-date')} aria-label="Collection date">
       </div>
       <div class="import-review-stats" aria-label="Import mapping summary">
         <span class="import-review-stat import-review-stat-matched"><strong>${matched.length}</strong> matched</span>
@@ -100,15 +175,15 @@ export function showImportPreview(parseResult) {
 
   html += `<div class="import-review-controls">
     <div class="import-filter-group" role="group" aria-label="Filter import rows">
-      <button type="button" class="import-filter-btn active" data-filter="all" onclick="setImportReviewFilter(this)">All</button>
-      <button type="button" class="import-filter-btn" data-filter="matched" onclick="setImportReviewFilter(this)">Matched</button>
-      <button type="button" class="import-filter-btn" data-filter="new" onclick="setImportReviewFilter(this)">New</button>
-      <button type="button" class="import-filter-btn" data-filter="unmatched" onclick="setImportReviewFilter(this)">Unmatched</button>
-      <button type="button" class="import-filter-btn" data-filter="excluded" onclick="setImportReviewFilter(this)">Excluded</button>
+      <button type="button" class="import-filter-btn active" data-filter="all" ${importReviewActionAttrs('filter')}>All</button>
+      <button type="button" class="import-filter-btn" data-filter="matched" ${importReviewActionAttrs('filter')}>Matched</button>
+      <button type="button" class="import-filter-btn" data-filter="new" ${importReviewActionAttrs('filter')}>New</button>
+      <button type="button" class="import-filter-btn" data-filter="unmatched" ${importReviewActionAttrs('filter')}>Unmatched</button>
+      <button type="button" class="import-filter-btn" data-filter="excluded" ${importReviewActionAttrs('filter')}>Excluded</button>
     </div>
     <label class="import-review-search-wrap">
       <span class="sr-only">Search import rows</span>
-      <input type="search" id="import-review-search" class="import-review-search" placeholder="Search markers" oninput="applyImportReviewFilters()" autocomplete="off">
+      <input type="search" id="import-review-search" class="import-review-search" placeholder="Search markers" ${importReviewActionAttrs('search')} autocomplete="off">
     </label>
     <span class="import-visible-count" id="import-visible-count" aria-live="polite"></span>
   </div>`;
@@ -123,7 +198,7 @@ export function showImportPreview(parseResult) {
       <td data-label="Value">${escapeHTML(String(m.value))}</td>
       <td class="import-range-cell" data-label="Lab range">${escapeHTML(labRange || '—')}</td>
       <td class="import-map-cell" data-label="Maps to">${escapeHTML(m.mappedKey)}</td>
-      <td class="import-row-action" data-label="Action"><button type="button" class="import-exclude-btn" onclick="toggleImportRow(this)" title="Exclude from import" aria-label="Exclude ${escapeHTML(m.rawName)} from import">Exclude</button></td>
+      <td class="import-row-action" data-label="Action"><button type="button" class="import-exclude-btn" ${importReviewActionAttrs('toggle-row')} title="Exclude from import" aria-label="Exclude ${escapeHTML(m.rawName)} from import">Exclude</button></td>
     </tr>`;
   }
   for (const m of newMarkers) {
@@ -135,7 +210,7 @@ export function showImportPreview(parseResult) {
       <td data-label="Value">${escapeHTML(String(m.value))}</td>
       <td class="import-range-cell" data-label="Lab range">${escapeHTML(labRange || '—')}</td>
       <td class="import-map-cell" data-label="Maps to">${escapeHTML(m.suggestedKey)}</td>
-      <td class="import-row-action" data-label="Action"><button type="button" class="import-exclude-btn" onclick="toggleImportRow(this)" title="Exclude from import" aria-label="Exclude ${escapeHTML(m.rawName)} from import">Exclude</button></td>
+      <td class="import-row-action" data-label="Action"><button type="button" class="import-exclude-btn" ${importReviewActionAttrs('toggle-row')} title="Exclude from import" aria-label="Exclude ${escapeHTML(m.rawName)} from import">Exclude</button></td>
     </tr>`;
   }
   if (unmatched.length > 0) {
@@ -148,7 +223,7 @@ export function showImportPreview(parseResult) {
         <td data-label="Value">${escapeHTML(String(m.value))}</td>
         <td class="import-range-cell" data-label="Lab range">${escapeHTML(labRange || '—')}</td>
         <td class="import-map-cell" data-label="Maps to">
-          <input type="text" class="import-map-input" list="import-marker-options" data-marker-idx="${origIdx}" onchange="mapUnmatchedMarkerInput(this)" placeholder="Search marker" autocomplete="off" aria-label="Map ${escapeHTML(m.rawName)} to an existing marker">
+          <input type="text" class="import-map-input" list="import-marker-options" data-marker-idx="${origIdx}" ${importReviewActionAttrs('map-marker')} placeholder="Search marker" autocomplete="off" aria-label="Map ${escapeHTML(m.rawName)} to an existing marker">
         </td>
         <td class="import-row-action" data-label="Action"><span class="import-skip-note">Skipped unless mapped</span></td>
       </tr>`;
@@ -198,7 +273,7 @@ export function showImportPreview(parseResult) {
       html += `<div class="import-debug-note">&#9202; ${piiLabel} &nbsp;|&nbsp; Analysis: ${t.analysis}s (${modelLabel})</div>`;
     }
     if (parseResult.privacyOriginal && parseResult.privacyObfuscated) {
-      html += '<button type="button" class="import-btn import-btn-secondary import-privacy-details-btn" onclick="showPIIDiffViewer(window._pendingImport.privacyOriginal, window._pendingImport.privacyObfuscated)">&#128269; View privacy details</button>';
+      html += `<button type="button" class="import-btn import-btn-secondary import-privacy-details-btn" ${importReviewActionAttrs('privacy-details')}>&#128269; View privacy details</button>`;
     }
   }
 
@@ -206,8 +281,8 @@ export function showImportPreview(parseResult) {
   const importDisabled = !date ? ' disabled' : '';
   html += `</div>
     <div class="import-review-actions">
-      <button type="button" class="import-btn import-btn-secondary" onclick="closeImportModal()">${cancelLabel}</button>
-      <button type="button" class="import-btn import-btn-primary" id="import-confirm-btn" onclick="confirmImport()"${importDisabled}>Import ${importCount} Marker${importCount !== 1 ? 's' : ''}</button>
+      <button type="button" class="import-btn import-btn-secondary" ${importReviewActionAttrs('close')}>${cancelLabel}</button>
+      <button type="button" class="import-btn import-btn-primary" id="import-confirm-btn" ${importReviewActionAttrs('confirm')}${importDisabled}>Import ${importCount} Marker${importCount !== 1 ? 's' : ''}</button>
     </div>`;
   if (!parseResult._importProfileId) parseResult._importProfileId = state.currentProfile;
   window._pendingImport = parseResult;
@@ -273,7 +348,7 @@ function applyImportMarkerMapping(controlEl, key) {
         statusCell.innerHTML = '<span class="import-status-pill">Matched</span>';
       }
       if (actionCell && !actionCell.querySelector('.import-exclude-btn')) {
-        actionCell.innerHTML = '<button type="button" class="import-exclude-btn" onclick="toggleImportRow(this)" title="Exclude from import" aria-label="Exclude from import">Exclude</button>';
+        actionCell.innerHTML = `<button type="button" class="import-exclude-btn" ${importReviewActionAttrs('toggle-row')} title="Exclude from import" aria-label="Exclude from import">Exclude</button>`;
       }
     } else {
       row.dataset.importStatus = 'unmatched';

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 282,
+  "inlineEventAttributes": 267,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -133,6 +133,8 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
     const originalProfile = state.currentProfile;
     const dropZone = document.getElementById('drop-zone');
     const originalDropDisplay = dropZone?.style.display || '';
+    const dispatchChange = el => el?.dispatchEvent(new Event('change', { bubbles: true }));
+    const dispatchInput = el => el?.dispatchEvent(new Event('input', { bubbles: true }));
     const baseMarkers = [
       {
         rawName: 'Glucose <fasting>',
@@ -183,50 +185,57 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
         && !!modal.querySelector('.import-review-date-warning')
         && !!modal.querySelector('.import-review-warning:not(.import-review-date-warning)');
       outcomes.missingDateDisablesImport = confirmBtn?.disabled === true;
+      outcomes.renderedControlsUseDelegatedActions = modal?.querySelectorAll('[onclick],[onchange],[oninput]').length === 0
+        && modal?.querySelectorAll('[data-import-review-action]').length >= 13;
 
-      review.applyManualImportDate('2026-06-01');
+      const dateInput = document.getElementById('import-manual-date');
+      dateInput.value = '2026-06-01';
+      dispatchChange(dateInput);
       outcomes.manualDateUpdatesPendingAndButton = review.getPendingImport()?.date === '2026-06-01'
         && confirmBtn?.disabled === false;
-      review.applyManualImportDate('');
+      dateInput.value = '';
+      dispatchChange(dateInput);
       outcomes.emptyManualDateDisablesImport = review.getPendingImport()?.date === ''
         && confirmBtn?.disabled === true;
-      review.applyManualImportDate('2026-06-01');
+      dateInput.value = '2026-06-01';
+      dispatchChange(dateInput);
 
-      review.setImportReviewFilter(document.querySelector('.import-filter-btn[data-filter="unmatched"]'));
+      document.querySelector('.import-filter-btn[data-filter="unmatched"]').click();
       outcomes.unmatchedFilterCountsRows = document.getElementById('import-visible-count')?.textContent === '11/13 shown';
 
       const searchInput = document.getElementById('import-review-search');
       searchInput.value = 'mystery marker 7';
-      review.applyImportReviewFilters();
+      dispatchInput(searchInput);
       outcomes.searchNarrowsFilteredRows = document.getElementById('import-visible-count')?.textContent === '1/13 shown';
 
       searchInput.value = '';
-      review.setImportReviewFilter(document.querySelector('.import-filter-btn[data-filter="all"]'));
+      dispatchInput(searchInput);
+      document.querySelector('.import-filter-btn[data-filter="all"]').click();
       const mapInput = document.querySelector('tr[data-import-status="unmatched"] .import-map-input');
       mapInput.value = 'Glucose (biochemistry.glucose)';
-      review.mapUnmatchedMarkerInput(mapInput);
+      dispatchChange(mapInput);
       outcomes.mapUnmatchedByLabel = mapInput.value === 'biochemistry.glucose'
         && mapInput.closest('tr')?.dataset.importStatus === 'matched'
         && review.getPendingImport().markers[2].mappedKey === 'biochemistry.glucose';
 
       const invalidInput = document.querySelector('tr[data-import-status="unmatched"] .import-map-input');
       invalidInput.value = 'Not a real marker';
-      review.mapUnmatchedMarkerInput(invalidInput);
+      dispatchChange(invalidInput);
       outcomes.invalidMappingClearsAndNotifies = invalidInput.value === ''
         && Array.from(document.querySelectorAll('.notification-toast.error'))
           .some(toast => toast.textContent.includes('Choose a marker from the list'));
 
       const excludeBtn = document.querySelector('tr[data-import-idx="0"] .import-exclude-btn');
-      review.toggleImportRow(excludeBtn);
+      excludeBtn.click();
       outcomes.excludeUpdatesRowAndCount = excludeBtn.textContent === 'Include'
         && excludeBtn.closest('tr')?.classList.contains('import-excluded') === true
         && confirmBtn?.textContent === 'Import 2 Markers'
         && review.getExcludedImportIndices().has(0) === true;
 
-      review.setImportReviewFilter(document.querySelector('.import-filter-btn[data-filter="excluded"]'));
+      document.querySelector('.import-filter-btn[data-filter="excluded"]').click();
       outcomes.excludedFilterCountsRows = document.getElementById('import-visible-count')?.textContent === '1/13 shown';
 
-      review.setImportReviewFilter(document.querySelector('.import-filter-btn[data-filter="all"]'));
+      document.querySelector('.import-filter-btn[data-filter="all"]').click();
       const selectRow = document.querySelector('tr[data-import-status="unmatched"]');
       const select = document.createElement('select');
       select.dataset.markerIdx = selectRow.dataset.importIdx;
@@ -238,7 +247,7 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
         && review.getPendingImport().markers[Number(select.dataset.markerIdx)].mappedKey === 'iron.ferritin'
         && confirmBtn?.textContent === 'Import 3 Markers';
 
-      review.closeImportModal();
+      document.querySelector('#import-modal .import-review-actions [data-import-review-action="close"]').click();
       outcomes.closeClearsPending = overlay?.classList.contains('show') === false
         && review.getPendingImport() === null;
 
@@ -251,7 +260,7 @@ test('PDF import review modal covers filtering mapping exclusion and batch close
       }, 2, 5);
       outcomes.asyncPreviewHidesDropZone = dropZone?.style.display === 'none'
         && document.getElementById('import-modal')?.textContent.includes('File 2 of 5') === true;
-      review.closeImportModal();
+      document.querySelector('#import-modal .import-review-actions [data-import-review-action="close"]').click();
       outcomes.asyncCloseResolvesSkip = await batchPromise === 'skip'
         && dropZone?.style.display === '';
 
@@ -294,6 +303,8 @@ test('PDF import review modal covers privacy cost and debug details', async ({ p
     const review = await import(reviewUrl);
     const outcomes = {};
     const savedStorage = {};
+    const savedPIIDiffViewer = window.showPIIDiffViewer;
+    let piiDiffArgs = null;
     const storageKeys = [
       'labcharts-debug',
       'labcharts-ai-provider',
@@ -307,6 +318,9 @@ test('PDF import review modal covers privacy cost and debug details', async ({ p
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ollama-model', 'llama-debug');
       localStorage.setItem('labcharts-ollama-pii-model', 'pii-debug');
+      window.showPIIDiffViewer = (originalText, obfuscatedText) => {
+        piiDiffArgs = [originalText, obfuscatedText];
+      };
 
       review.showImportPreview({
         date: '2026-06-04',
@@ -341,8 +355,12 @@ test('PDF import review modal covers privacy cost and debug details', async ({ p
       outcomes.debugDetailsRenderTimingAndPrivacyButton = modal?.textContent.includes('PII: 2s (pii-debug)') === true
         && modal?.textContent.includes('Analysis: 3s (llama-debug)') === true
         && modal?.querySelector('.import-privacy-details-btn') !== null;
+      modal?.querySelector('.import-privacy-details-btn')?.click();
+      outcomes.privacyDetailsButtonDelegatesToViewer = piiDiffArgs?.[0] === 'Patient: Jane Example'
+        && piiDiffArgs?.[1] === 'Patient: [NAME]';
       outcomes.rangeAdoptionOptionRendersWhenLabRangesDiffer = modal?.querySelector('#import-adopt-ranges') !== null;
     } finally {
+      window.showPIIDiffViewer = savedPIIDiffViewer;
       for (const key of storageKeys) {
         if (savedStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, savedStorage[key]);

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -635,6 +635,10 @@ console.log('8. Code Cleanup');
 assert('pdf-import-review.js imports formatCost from schema', pdfReviewSrc.includes('formatCost') && pdfReviewSrc.includes("from './schema.js'"));
 const localFormatCost = `${pdfSrc}\n${pdfReviewSrc}`.match(/^function formatCost/m);
 assert('PDF import modules have no local formatCost', !localFormatCost);
+assert('PDF import review modal uses delegated actions',
+  pdfReviewSrc.includes('function initImportReviewDelegates()') &&
+  pdfReviewSrc.includes('data-import-review-action') &&
+  !/\son(?:click|change|input)\s*=/.test(pdfReviewSrc));
 
 // ═══════════════════════════════════════
 // 9. OpenRouter curated prefixes

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.501';
+self.APP_VERSION = '1.8.502';


### PR DESCRIPTION
## Summary
- Delegate PDF import review modal click, input, and change actions through scoped document listeners.
- Replace close, filter, row exclude, date/search, unmatched mapping, privacy-details, and confirm inline handlers with data-import-review-action attributes.
- Update browser/audit coverage and lower the inline event attribute baseline from 282 to 267.

## Validation
- npm run quality
- npm run typecheck
- npm test
- node tests/test-audit.js
- npx playwright test tests/playwright/import-review-browser-coverage.spec.js
- ./run-tests.sh
