### PR TITLE
[codex] Delegate lens actions

### DIFF
--- a/js/lens-actions.js
+++ b/js/lens-actions.js
@@ -1,0 +1,85 @@
+// @ts-check
+// lens-actions.js - delegated actions for the Knowledge Base settings surface
+
+import { escapeAttr } from './utils.js';
+
+let lensActionDelegatesInstalled = false;
+let lensActionHandlers = {};
+
+export function lensActionAttrs(action, attrs = {}) {
+  return [
+    `data-lens-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-lens-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function isLensActionScope(actionEl) {
+  return !!actionEl.closest('#custom-lens-section, #kb-modal');
+}
+
+function handleLensActionClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-lens-action]'));
+  if (!actionEl || !isLensActionScope(actionEl)) return;
+
+  const action = actionEl.dataset.lensAction || '';
+  if (action === 'set-backend') {
+    event.preventDefault();
+    lensActionHandlers.handleLensBackendChange?.(actionEl.dataset.lensBackend || 'in-browser');
+  } else if (action === 'new-library') {
+    event.preventDefault();
+    lensActionHandlers.handleLibraryNew?.();
+  } else if (action === 'rename-library') {
+    event.preventDefault();
+    lensActionHandlers.handleLibraryRename?.();
+  } else if (action === 'delete-library') {
+    event.preventDefault();
+    lensActionHandlers.handleLibraryDelete?.();
+  } else if (action === 'open-local-filepick') {
+    event.preventDefault();
+    lensActionHandlers.openLocalFilePicker?.();
+  } else if (action === 'save-config') {
+    event.preventDefault();
+    lensActionHandlers.handleSaveLensConfig?.();
+  } else if (action === 'clear-cache') {
+    event.preventDefault();
+    lensActionHandlers.handleClearLensCache?.();
+  } else if (action === 'remove-lens') {
+    event.preventDefault();
+    lensActionHandlers.handleRemoveLens?.();
+  } else if (action === 'close-kb') {
+    event.preventDefault();
+    lensActionHandlers.closeKnowledgeBaseModal?.();
+  } else if (action === 'delete-doc') {
+    event.preventDefault();
+    lensActionHandlers.handleLocalLensDeleteDoc?.(actionEl.dataset.lensSource || '');
+  } else if (action === 'clear-local') {
+    event.preventDefault();
+    lensActionHandlers.handleLocalLensClear?.();
+  }
+}
+
+function handleLensActionChange(event) {
+  const target = event.target instanceof HTMLElement ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-lens-action]'));
+  if (!actionEl || !isLensActionScope(actionEl)) return;
+
+  const action = actionEl.dataset.lensAction || '';
+  if (action === 'toggle-enabled') {
+    lensActionHandlers.handleToggleLens?.(!!(actionEl instanceof HTMLInputElement && actionEl.checked));
+  } else if (action === 'activate-library') {
+    lensActionHandlers.handleLibraryActivate?.(actionEl instanceof HTMLSelectElement ? actionEl.value : '');
+  }
+}
+
+export function initLensActionDelegates(handlers = {}) {
+  lensActionHandlers = { ...lensActionHandlers, ...handlers };
+  if (lensActionDelegatesInstalled || typeof document === 'undefined') return;
+  lensActionDelegatesInstalled = true;
+  document.addEventListener('click', handleLensActionClick);
+  document.addEventListener('change', handleLensActionChange);
+}

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -44,6 +44,25 @@ function handleLensPageShellClick(event) {
     appWindow.addDashboardWidgetFromLens?.(id);
   } else if (action === 'remove-dashboard-widget') {
     appWindow.removeDashboardWidgetFromLens?.(id);
+  } else if (action === 'import-dna') {
+    appWindow.triggerDNAFilePicker?.();
+  } else if (action === 'reimport-dna') {
+    if (typeof appWindow.reimportDNA === 'function') appWindow.reimportDNA();
+    else appWindow.triggerDNAFilePicker?.();
+  } else if (action === 'delete-dna') {
+    appWindow.confirmDeleteDNA?.();
+  } else if (action === 'open-wearables-settings') {
+    appWindow.openSettingsModal?.('wearables');
+  } else if (action === 'open-biometric-picker') {
+    appWindow.openDashboardBiometricPicker?.();
+  } else if (action === 'open-ai-chat') {
+    appWindow.openChatPanel?.();
+  } else if (action === 'open-emf-assessment') {
+    appWindow.openEMFAssessmentEditor?.();
+  } else if (action === 'open-recommendations') {
+    appWindow.navigate?.('recommendations');
+  } else if (action === 'open-privacy-settings') {
+    appWindow.openSettingsModal?.('privacy');
   }
 }
 

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -21,7 +21,7 @@ function hasAnyLabData(data) {
   );
 }
 
-function renderGenomeImportDetailsWidget() {
+function renderGenomeImportDetailsWidget(lensPageActionAttrs) {
   const genetics = state.importedData?.genetics;
   const snps = genetics?.snps || {};
   const snpCount = Object.keys(snps).length;
@@ -69,18 +69,18 @@ function renderGenomeImportDetailsWidget() {
     </div>
     ${mtdnaDetail}
     <div class="dashboard-widget-inline-controls">
-      <button type="button" class="dashboard-action-btn" onclick="window.reimportDNA ? window.reimportDNA() : (window.triggerDNAFilePicker && window.triggerDNAFilePicker())">Re-import</button>
-      <button type="button" class="dashboard-action-btn" onclick="window.confirmDeleteDNA && window.confirmDeleteDNA()">Delete genome data</button>
+      <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('reimport-dna')}>Re-import</button>
+      <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('delete-dna')}>Delete genome data</button>
     </div>
   </div>`;
 }
 
-function renderBodySourcesWidget() {
+function renderBodySourcesWidget(lensPageActionAttrs) {
   const connections = state.importedData?.wearableConnections || {};
   const summary = state.importedData?.wearableSummary || null;
   const ids = Object.keys(connections);
   if (!ids.length && !summary?.sources) {
-    return `<button type="button" class="db-correlation-empty" onclick="window.openSettingsModal && window.openSettingsModal('wearables')">
+    return `<button type="button" class="db-correlation-empty" ${lensPageActionAttrs('open-wearables-settings')}>
       <strong>Connect body data</strong>
       <span>Oura, Withings, Fitbit, Polar, Apple Health, or manual logging can feed HRV, sleep, recovery, blood pressure, and body composition.</span>
     </button>`;
@@ -90,7 +90,7 @@ function renderBodySourcesWidget() {
     const source = connections[id] || summary?.sources?.[id] || {};
     const lastSync = source.lastSyncAt ? new Date(source.lastSyncAt).toLocaleDateString() : 'not synced';
     const coverage = source.coverageDays ? `${source.coverageDays}d coverage` : 'coverage pending';
-    return `<button type="button" class="dashboard-widget-picker-card" onclick="window.openSettingsModal && window.openSettingsModal('wearables')">
+    return `<button type="button" class="dashboard-widget-picker-card" ${lensPageActionAttrs('open-wearables-settings')}>
       <span class="dashboard-widget-picker-title">${escapeHTML(id === 'manual' ? 'Manual logs' : id)}</span>
       <span class="dashboard-widget-picker-sub">${escapeHTML(lastSync)} · ${escapeHTML(coverage)}</span>
       <span class="dashboard-widget-picker-action">Manage source</span>
@@ -157,9 +157,9 @@ export function createLensPageHandlers(deps) {
     const main = document.getElementById("main-content");
     if (!main) return;
     document.body.classList.remove('mobile-dashboard-active');
-    const importDetails = renderGenomeImportDetailsWidget();
+    const importDetails = renderGenomeImportDetailsWidget(lensPageActionAttrs);
     let html = renderLensHeader('Genome', 'Dedicated DNA workspace: actionable genetic modifiers, import status, mtDNA, and lab-linked context.',
-      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="window.triggerDNAFilePicker && window.triggerDNAFilePicker()">Import DNA</button>`);
+      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('import-dna')}>Import DNA</button>`);
     html += renderLensPageWidgets('genome', [
       { id: 'genome', title: 'Actionable Genetic Modifiers', description: 'Priority SNP context relevant to labs and goals', body: renderDashboardGenomeWidget(), size: 'full', opts: { source: 'Genome' } },
       importDetails ? { id: 'genome-import', title: 'Import Details', description: 'Source, counts, mtDNA, and file management', body: importDetails, size: 'full', opts: { source: 'Genome', dashboardId: '' } } : null,
@@ -172,11 +172,11 @@ export function createLensPageHandlers(deps) {
     if (!main) return;
     document.body.classList.remove('mobile-dashboard-active');
     let html = renderLensHeader('Body', 'Dedicated biometrics workspace: wearable signals, manual body metrics, sync state, and metric history.',
-      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="window.openSettingsModal && window.openSettingsModal('wearables')">Connect source</button>
-       <button type="button" class="dashboard-action-btn" onclick="window.openDashboardBiometricPicker && window.openDashboardBiometricPicker()">Choose metrics</button>`);
+      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('open-wearables-settings')}>Connect source</button>
+       <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('open-biometric-picker')}>Choose metrics</button>`);
     html += renderLensPageWidgets('body', [
       { id: 'wearables', title: 'Biometrics Overview', description: 'User-selected body signal tiles', body: renderDashboardWearableTilesWidget(), size: 'full', opts: { source: 'Body' } },
-      { id: 'body-sources', title: 'Connected Sources', description: 'Wearable and manual sources feeding body context', body: renderBodySourcesWidget(), size: 'full', opts: { source: 'Body', dashboardId: '' } },
+      { id: 'body-sources', title: 'Connected Sources', description: 'Wearable and manual sources feeding body context', body: renderBodySourcesWidget(lensPageActionAttrs), size: 'full', opts: { source: 'Body', dashboardId: '' } },
       { id: 'supplements', title: 'Supplements & Meds', description: 'Tracked supplements and medications that feed lab and AI context', body: renderSupplementsSection(), size: 'full', opts: { source: 'Body' } },
       state.profileSex === 'female' ? { id: 'cycle', title: 'Cycle', description: 'Menstrual cycle context for hormone, iron, and inflammation interpretation', body: renderMenstrualCycleSection(getActiveData()), size: 'full', opts: { source: 'Body' } } : null,
     ]);
@@ -190,9 +190,9 @@ export function createLensPageHandlers(deps) {
     document.body.classList.remove('mobile-dashboard-active');
     const ctx = buildDashboardWidgetContext(rawData);
     let html = renderLensHeader('Insight', 'Dedicated synthesis workspace: AI focus, trend interpretation, context, and next-step surfaces.',
-      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="window.openChatPanel && window.openChatPanel()">Open AI chat</button>
-       <button type="button" class="dashboard-action-btn" onclick="window.openEMFAssessmentEditor && window.openEMFAssessmentEditor()">EMF assessment</button>
-       <button type="button" class="dashboard-action-btn" onclick="window.navigate && window.navigate('recommendations')">Recommendations</button>`);
+      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('open-ai-chat')}>Open AI chat</button>
+       <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('open-emf-assessment')}>EMF assessment</button>
+       <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('open-recommendations')}>Recommendations</button>`);
     html += renderLensPageWidgets('insight', [
       { id: 'focus', title: 'Current Focus', description: 'One synthesized read on the latest data', body: renderFocusCard(), size: 'full', opts: { source: 'Insight' } },
       { id: 'recommendations', title: 'Recommended Next Steps', description: 'Top data-linked actions across lenses', body: renderDashboardRecommendationsWidget(ctx), size: 'half', opts: { source: 'Insight' } },
@@ -247,11 +247,11 @@ export function createLensPageHandlers(deps) {
     const dashboardAction = recommendationsVisible ? 'remove-dashboard-widget' : 'add-dashboard-widget';
     const dashboardLabel = recommendationsVisible ? 'Remove from Dashboard' : 'Add to Dashboard';
     const actions = `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs(dashboardAction, { id: 'recommendations' })}>${dashboardLabel}</button>
-      <button type="button" class="dashboard-action-btn" onclick="window.openSettingsModal && window.openSettingsModal('privacy')">Disclosure & settings</button>`;
+      <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('open-privacy-settings')}>Disclosure & settings</button>`;
     let html = `<div id="recommendations-page">`;
     html += renderLensHeader('Recommendations', 'A global action plan built from Labs, Body, Light, Genome, and Insight signals. Product links stay behind the existing disclosure.', actions);
     if (!window.isProductRecsEnabled?.()) {
-      html += renderLensWidget('recommendations-disabled', 'Recommendations are off', 'Enable Tips & Recommendations to build this action surface', `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="window.openSettingsModal && window.openSettingsModal('privacy')">Open settings</button>`, 'full', { source: 'Recommendations', dashboardId: '' });
+      html += renderLensWidget('recommendations-disabled', 'Recommendations are off', 'Enable Tips & Recommendations to build this action surface', `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('open-privacy-settings')}>Open settings</button>`, 'full', { source: 'Recommendations', dashboardId: '' });
       html += `</div>`;
       main.innerHTML = html;
       return;

--- a/js/lens.js
+++ b/js/lens.js
@@ -6,6 +6,7 @@ import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
 import { hashString, showNotification, showConfirmDialog, showPromptDialog, isDebugMode, escapeHTML, escapeAttr } from './utils.js';
 import { hasAIProvider, callClaudeAPI } from './api.js';
 import { closeModalOverlay, openModalOverlay, wireBackdropClose } from './modal-lifecycle.js';
+import { initLensActionDelegates, lensActionAttrs } from './lens-actions.js';
 const CONFIG_KEY = 'labcharts-lens-config';
 const SECRET_KEY = 'labcharts-lens-key';
 /** @typedef {Window & typeof globalThis & { _lensIngestRunning?: boolean }} LensWindow */
@@ -49,6 +50,13 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX = 20;
 const MAX_CHUNKS = 10;
 const MAX_RESPONSE_BYTES = 32 * 1024;
+initLensActionDelegates({
+  closeKnowledgeBaseModal, handleClearLensCache, handleLensBackendChange,
+  handleLibraryActivate, handleLibraryDelete, handleLibraryNew, handleLibraryRename,
+  handleLocalLensClear, handleLocalLensDeleteDoc, handleRemoveLens, handleSaveLensConfig,
+  handleToggleLens,
+  openLocalFilePicker: () => document.getElementById('lens-local-filepick')?.click(),
+});
 // ─── Config storage ───────────────────────────────────────────
 export function getLensConfig() {
   try {
@@ -556,8 +564,8 @@ export function renderCustomLensSection() {
     <div style="margin-top:10px">
       <div style="font-size:12px;color:var(--text-muted);margin-bottom:6px">Where to run it</div>
       <div class="ctx-btn-group" role="radiogroup" aria-label="Knowledge Base engine">
-        <button type="button" class="ctx-btn-option ${isBrowser ? 'active' : ''}" role="radio" aria-checked="${isBrowser}" onclick="handleLensBackendChange('in-browser')">On this device</button>
-        <button type="button" class="ctx-btn-option ${isExternal ? 'active' : ''}" role="radio" aria-checked="${isExternal}" onclick="handleLensBackendChange('external-server')">External server</button>
+        <button type="button" class="ctx-btn-option ${isBrowser ? 'active' : ''}" role="radio" aria-checked="${isBrowser}" ${lensActionAttrs('set-backend', { backend: 'in-browser' })}>On this device</button>
+        <button type="button" class="ctx-btn-option ${isExternal ? 'active' : ''}" role="radio" aria-checked="${isExternal}" ${lensActionAttrs('set-backend', { backend: 'external-server' })}>External server</button>
       </div>
       <div style="font-size:11px;color:var(--text-muted);margin-top:6px">
         ${isBrowser
@@ -568,7 +576,7 @@ export function renderCustomLensSection() {
 
     <div style="margin-top:10px;display:flex;align-items:center;gap:10px">
       <label class="toggle-switch" for="lens-enabled-toggle">
-        <input type="checkbox" id="lens-enabled-toggle" ${cfg.enabled ? 'checked' : ''} onchange="handleToggleLens(this.checked)">
+        <input type="checkbox" id="lens-enabled-toggle" ${cfg.enabled ? 'checked' : ''} ${lensActionAttrs('toggle-enabled')}>
         <span class="toggle-slider"></span>
       </label>
       <label for="lens-enabled-toggle" style="font-size:13px;cursor:pointer">Enable Knowledge Source</label>
@@ -582,13 +590,13 @@ export function renderCustomLensSection() {
     <div id="lens-library-picker" style="margin-top:12px">
       <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px" for="lens-library-select">Library</label>
       <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
-        <select id="lens-library-select" onchange="handleLibraryActivate(this.value)"
+        <select id="lens-library-select" ${lensActionAttrs('activate-library')}
                 style="flex:1;min-width:180px;padding:6px 8px;background:var(--select-surface);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;font-size:13px">
           <option value="">Loading…</option>
         </select>
-        <button class="import-btn import-btn-secondary" onclick="handleLibraryNew()" style="font-size:12px;padding:6px 10px" title="New library">+ New</button>
-        <button class="import-btn import-btn-secondary" onclick="handleLibraryRename()" style="font-size:12px;padding:6px 10px" title="Rename active library">Rename</button>
-        <button class="import-btn import-btn-secondary" onclick="handleLibraryDelete()" style="font-size:12px;padding:6px 10px" title="Delete active library">Delete</button>
+        <button class="import-btn import-btn-secondary" ${lensActionAttrs('new-library')} style="font-size:12px;padding:6px 10px" title="New library">+ New</button>
+        <button class="import-btn import-btn-secondary" ${lensActionAttrs('rename-library')} style="font-size:12px;padding:6px 10px" title="Rename active library">Rename</button>
+        <button class="import-btn import-btn-secondary" ${lensActionAttrs('delete-library')} style="font-size:12px;padding:6px 10px" title="Delete active library">Delete</button>
       </div>
       <div style="font-size:11px;color:var(--text-muted);margin-top:4px">Keep different collections separate — research papers, clinical guides, personal notes. Chat grounds its answers in the active library only.</div>
     </div>
@@ -668,7 +676,7 @@ export function renderCustomLensSection() {
            role="button" tabindex="0"
            aria-label="Add documents — drop files here or press Enter to open the file picker"
            style="margin-top:10px;padding:18px;border:2px dashed var(--border);border-radius:8px;text-align:center;font-size:13px;color:var(--text-muted);cursor:pointer;transition:border-color 0.15s"
-           onclick="document.getElementById('lens-local-filepick').click()">
+           ${lensActionAttrs('open-local-filepick')}>
         <div style="font-size:20px;pointer-events:none" aria-hidden="true">📁</div>
         <div style="margin-top:4px;pointer-events:none">Drop documents or click to add</div>
         <div style="font-size:11px;margin-top:2px;opacity:0.7;pointer-events:none">PDF · Markdown · Text · Word · JSON · ZIP</div>
@@ -700,9 +708,9 @@ export function renderCustomLensSection() {
     </div>
 
     <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
-      <button class="import-btn import-btn-primary" onclick="handleSaveLensConfig()">${isExternal ? 'Save + connect' : 'Save'}</button>
-      ${connected ? '<button class="import-btn import-btn-secondary" onclick="handleClearLensCache()">Clear cache</button>' : ''}
-      ${connected ? '<button class="import-btn import-btn-secondary" onclick="handleRemoveLens()">Remove</button>' : ''}
+      <button class="import-btn import-btn-primary" ${lensActionAttrs('save-config')}>${isExternal ? 'Save + connect' : 'Save'}</button>
+      ${connected ? `<button class="import-btn import-btn-secondary" ${lensActionAttrs('clear-cache')}>Clear cache</button>` : ''}
+      ${connected ? `<button class="import-btn import-btn-secondary" ${lensActionAttrs('remove-lens')}>Remove</button>` : ''}
     </div>
 
     <div class="api-key-notice" style="margin-top:12px">
@@ -748,7 +756,7 @@ export function openKnowledgeBaseModal() {
         <div class="gb-modal-kicker">Local context</div>
         <div class="gb-modal-title">Knowledge Base</div>
       </div>
-      <button class="modal-close" onclick="closeKnowledgeBaseModal()" aria-label="Close">&times;</button>
+      <button class="modal-close" ${lensActionAttrs('close-kb')} aria-label="Close">&times;</button>
     </div>
     <div class="gb-form-body">
     <div class="settings-section" id="custom-lens-section">
@@ -961,13 +969,13 @@ function _renderLocalDocList(docs) {
     <div style="display:flex;align-items:center;justify-content:space-between;padding:6px 10px;border-bottom:1px solid var(--border);font-size:12px">
       <span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${escapeAttr(d.source)}">${escapeHTML(d.source)}</span>
       <span style="color:var(--text-muted);margin:0 10px;font-variant-numeric:tabular-nums">${d.chunks}</span>
-      <button class="kb-doc-delete" onclick="handleLocalLensDeleteDoc(${JSON.stringify(d.source).replace(/"/g, '&quot;')})" aria-label="Delete ${escapeAttr(d.source)}" title="Delete" style="background:transparent;border:0;color:var(--text-muted);cursor:pointer;font-size:16px;padding:2px 6px">×</button>
+      <button class="kb-doc-delete" ${lensActionAttrs('delete-doc', { source: d.source })} aria-label="Delete ${escapeAttr(d.source)}" title="Delete" style="background:transparent;border:0;color:var(--text-muted);cursor:pointer;font-size:16px;padding:2px 6px">×</button>
     </div>
   `).join('');
   return `
     <div style="margin-top:4px;max-height:220px;overflow-y:auto;border:1px solid var(--border);border-radius:6px">${rows}</div>
     <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap">
-      <button class="import-btn import-btn-secondary" onclick="handleLocalLensClear()" style="font-size:12px;padding:4px 10px">Clear all</button>
+      <button class="import-btn import-btn-secondary" ${lensActionAttrs('clear-local')} style="font-size:12px;padding:4px 10px">Clear all</button>
     </div>
   `;
 }

--- a/js/lens.js
+++ b/js/lens.js
@@ -50,13 +50,6 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX = 20;
 const MAX_CHUNKS = 10;
 const MAX_RESPONSE_BYTES = 32 * 1024;
-initLensActionDelegates({
-  closeKnowledgeBaseModal, handleClearLensCache, handleLensBackendChange,
-  handleLibraryActivate, handleLibraryDelete, handleLibraryNew, handleLibraryRename,
-  handleLocalLensClear, handleLocalLensDeleteDoc, handleRemoveLens, handleSaveLensConfig,
-  handleToggleLens,
-  openLocalFilePicker: () => document.getElementById('lens-local-filepick')?.click(),
-});
 // ─── Config storage ───────────────────────────────────────────
 export function getLensConfig() {
   try {
@@ -1497,6 +1490,14 @@ export async function handleRemoveLens() {
     );
   }
 }
+
+// Register delegates after handler declarations so this wiring does not rely on hoisting.
+initLensActionDelegates({
+  closeKnowledgeBaseModal, handleClearLensCache, handleLensBackendChange,
+  handleLibraryActivate, handleLibraryDelete, handleLibraryNew, handleLibraryRename,
+  handleLocalLensClear, handleLocalLensDeleteDoc, handleRemoveLens, handleSaveLensConfig,
+  handleToggleLens, openLocalFilePicker: () => document.getElementById('lens-local-filepick')?.click(),
+});
 
 Object.assign(window, {
   getLensConfig, saveLensConfig, getLensKey, saveLensKey,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 267,
+  "inlineEventAttributes": 241,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/service-worker.js
+++ b/service-worker.js
@@ -349,6 +349,7 @@ const APP_SHELL = [
   '/js/chat-images.js',
   '/js/chat-threads.js',
   '/js/chat-thread-search.js',
+  '/js/lens-actions.js',
   '/js/lens.js',
   '/js/lens-local.js',
   '/js/lens-local-worker.js',

--- a/tests/playwright/custom-lens.spec.js
+++ b/tests/playwright/custom-lens.spec.js
@@ -40,7 +40,8 @@ test('knowledge base modal renders lens controls and settings AI does not', asyn
   await expect(page.locator('#lens-key-input')).toHaveCount(1);
   await expect(page.locator('#lens-topk-input')).toHaveCount(1);
   await expect(page.locator('#lens-enabled-toggle')).toHaveCount(1);
-  expect(await lensSection.evaluate((section) => section.innerHTML.includes('handleSaveLensConfig'))).toBe(true);
+  await expect(lensSection.locator('[data-lens-action="save-config"]')).toHaveCount(1);
+  expect(await lensSection.evaluate((section) => !section.querySelector('[onclick], [onchange], [oninput]'))).toBe(true);
 
   await page.evaluate(() => {
     window.closeKnowledgeBaseModal?.();

--- a/tests/playwright/lens-hardware-browser-coverage.spec.js
+++ b/tests/playwright/lens-hardware-browser-coverage.spec.js
@@ -417,12 +417,23 @@ test('in-browser lens render covers local panel status and backend switching wit
         && summary.displayName === 'Local Papers'
         && summary.aiAvailable === false
         && summary.multiQueryOn === false;
+      outcomes.customLensSettingsUseDelegatedActions = !section.querySelector('[onclick], [onchange], [oninput]')
+        && !!section.querySelector('[data-lens-action="set-backend"][data-lens-backend="external-server"]')
+        && !!section.querySelector('#lens-enabled-toggle[data-lens-action="toggle-enabled"]')
+        && !!section.querySelector('[data-lens-action="save-config"]');
 
-      lens.handleToggleLens(false);
+      const enabledToggle = /** @type {HTMLInputElement | null} */ (section.querySelector('#lens-enabled-toggle'));
+      if (enabledToggle) {
+        enabledToggle.checked = false;
+        enabledToggle.dispatchEvent(new Event('change', { bubbles: true }));
+      }
       outcomes.toggleUpdatesConfigAndStatusChipWithoutRerender = lens.getLensConfig().enabled === false
         && document.getElementById('lens-status-chip')?.textContent.includes('Configured (disabled)');
 
-      lens.handleLensBackendChange('external-server');
+      section.querySelector('[data-lens-action="clear-cache"]')?.click();
+      outcomes.clearCacheKeepsStatusCallable = typeof lens.getLensStatus().state === 'string';
+
+      section.querySelector('[data-lens-action="set-backend"][data-lens-backend="external-server"]')?.click();
       const remoteFieldsAfterSwitch = /** @type {HTMLElement | null} */ (section.querySelector('#lens-remote-fields'));
       const localFieldsAfterSwitch = /** @type {HTMLElement | null} */ (section.querySelector('#lens-local-fields'));
       outcomes.backendSwitchRerendersRemoteFieldsAndIndicator = lens.getLensConfig().backend === 'external-server'
@@ -434,9 +445,6 @@ test('in-browser lens render covers local panel status and backend switching wit
         && localFieldsAfterSwitch
         && getComputedStyle(localFieldsAfterSwitch).display === 'none'
         && document.getElementById('chat-lens-indicator')?.style.display === 'none';
-
-      lens.handleClearLensCache();
-      outcomes.clearCacheKeepsStatusCallable = typeof lens.getLensStatus().state === 'string';
     } finally {
       window.requestAnimationFrame = originalRAF;
       section.remove();

--- a/tests/playwright/lens-local-library-browser-coverage.spec.js
+++ b/tests/playwright/lens-local-library-browser-coverage.spec.js
@@ -311,12 +311,15 @@ test('knowledge base modal covers local document ingest and library controls', a
       const libraryOptions = [...document.querySelectorAll('#lens-library-select option')].map(option => option.textContent);
       outcomes.modalHydratesLocalStatsDocsAndLibraries = initialRendered
         && libraryOptions.includes('Alpha Papers')
-        && document.querySelector('.kb-doc-delete')?.getAttribute('aria-label') === 'Delete alpha "quote".md';
+        && document.querySelector('.kb-doc-delete')?.getAttribute('aria-label') === 'Delete alpha "quote".md'
+        && !document.querySelector('#kb-modal [onclick], #kb-modal [onchange], #kb-modal [oninput]')
+        && document.querySelector('.kb-doc-delete')?.dataset.lensSource === 'alpha "quote".md';
 
       const drop = document.getElementById('lens-local-drop');
       const picker = document.getElementById('lens-local-filepick');
       let pickerClicked = false;
       picker.click = () => { pickerClicked = true; };
+      drop.click();
       drop.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       drop.dispatchEvent(new Event('dragenter', { bubbles: true, cancelable: true }));
       drop.dispatchEvent(new Event('dragleave', { bubbles: true, cancelable: true }));
@@ -332,22 +335,19 @@ test('knowledge base modal covers local document ingest and library controls', a
         && progressHidden
         && calls.some(call => call.type === 'ingest' && call.files?.[0]?.name === 'berberine.md');
 
-      await lens.handleLocalLensDeleteDoc('');
-      const deletePromise = lens.handleLocalLensDeleteDoc('alpha "quote".md');
+      document.querySelector('.kb-doc-delete')?.click();
       await waitFor(() => document.getElementById('confirm-dialog-overlay')?.classList.contains('show'));
       const deletePrompt = document.getElementById('confirm-dialog-overlay')?.textContent || '';
       document.getElementById('confirm-ok')?.click();
-      await deletePromise;
       const deletedRendered = await waitFor(() => !document.getElementById('lens-local-doc-list')?.textContent.includes('alpha "quote".md'));
 
-      const clearCancelPromise = lens.handleLocalLensClear();
+      document.querySelector('[data-lens-action="clear-local"]')?.click();
       await waitFor(() => document.getElementById('confirm-dialog-overlay')?.classList.contains('show'));
       document.getElementById('confirm-cancel')?.click();
-      await clearCancelPromise;
-      const clearPromise = lens.handleLocalLensClear();
+      await waitFor(() => !document.getElementById('confirm-dialog-overlay')?.classList.contains('show'));
+      document.querySelector('[data-lens-action="clear-local"]')?.click();
       await waitFor(() => document.getElementById('confirm-dialog-overlay')?.classList.contains('show'));
       document.getElementById('confirm-ok')?.click();
-      await clearPromise;
       const clearedRendered = await waitFor(() => document.getElementById('lens-local-stats')?.textContent.includes('No documents indexed yet'));
       outcomes.deleteAndClearConfirmFlows = deletePrompt.includes('alpha "quote".md')
         && deletedRendered
@@ -355,26 +355,26 @@ test('knowledge base modal covers local document ingest and library controls', a
         && calls.some(call => call.type === 'delete' && call.source === 'alpha "quote".md')
         && calls.filter(call => call.type === 'clear').length === 1;
 
-      const createPromise = lens.handleLibraryNew();
+      document.querySelector('[data-lens-action="new-library"]')?.click();
       await waitFor(() => document.getElementById('lens-library-create-overlay')?.classList.contains('show'));
       const recommended = document.querySelector('input[name="lens-create-model"]:checked')?.value;
       document.getElementById('lens-create-name').value = 'Protocols';
       document.getElementById('lens-create-ok')?.click();
-      await createPromise;
       const createdRendered = await waitFor(() => document.getElementById('lens-library-select')?.textContent.includes('Protocols'));
 
-      await lens.handleLibraryActivate('lib-beta');
-      const renamePromise = lens.handleLibraryRename();
+      const librarySelect = document.getElementById('lens-library-select');
+      librarySelect.value = 'lib-beta';
+      librarySelect.dispatchEvent(new Event('change', { bubbles: true }));
+      await waitFor(() => calls.some(call => call.type === 'activate_library' && call.libraryId === 'lib-beta'));
+      document.querySelector('[data-lens-action="rename-library"]')?.click();
       await waitFor(() => document.getElementById('prompt-dialog-overlay')?.classList.contains('show'));
       document.getElementById('prompt-dialog-input').value = 'Renamed Beta';
       document.getElementById('prompt-ok')?.click();
-      await renamePromise;
       const renamedRendered = await waitFor(() => document.getElementById('lens-library-select')?.textContent.includes('Renamed Beta'));
 
-      const deleteLibraryPromise = lens.handleLibraryDelete();
+      document.querySelector('[data-lens-action="delete-library"]')?.click();
       await waitFor(() => document.getElementById('confirm-dialog-overlay')?.classList.contains('show'));
       document.getElementById('confirm-ok')?.click();
-      await deleteLibraryPromise;
       const deletedLibraryRendered = await waitFor(() => !document.getElementById('lens-library-select')?.textContent.includes('Renamed Beta'));
       outcomes.libraryCreateActivateRenameDeleteFlows = recommended === 'bge-en'
         && createdRendered

--- a/tests/playwright/lens-local-library-browser-coverage.spec.js
+++ b/tests/playwright/lens-local-library-browser-coverage.spec.js
@@ -335,6 +335,10 @@ test('knowledge base modal covers local document ingest and library controls', a
         && progressHidden
         && calls.some(call => call.type === 'ingest' && call.files?.[0]?.name === 'berberine.md');
 
+      await lens.handleLocalLensDeleteDoc('');
+      outcomes.emptySourceDeleteGuard = !document.getElementById('confirm-dialog-overlay')?.classList.contains('show')
+        && !calls.some(call => call.type === 'delete' && call.source === '');
+
       document.querySelector('.kb-doc-delete')?.click();
       await waitFor(() => document.getElementById('confirm-dialog-overlay')?.classList.contains('show'));
       const deletePrompt = document.getElementById('confirm-dialog-overlay')?.textContent || '';

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -59,6 +59,14 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
     const originalView = state.currentView;
     const originalAddDashboard = window.addDashboardWidgetFromLens;
     const originalRemoveDashboard = window.removeDashboardWidgetFromLens;
+    const originalTriggerDNA = window.triggerDNAFilePicker;
+    const originalReimportDNA = window.reimportDNA;
+    const originalConfirmDeleteDNA = window.confirmDeleteDNA;
+    const originalOpenSettings = window.openSettingsModal;
+    const originalOpenBiometricPicker = window.openDashboardBiometricPicker;
+    const originalOpenChat = window.openChatPanel;
+    const originalOpenEMF = window.openEMFAssessmentEditor;
+    const originalNavigate = window.navigate;
     const profileId = window.getActiveProfileId?.() || state.currentProfile || 'default';
     const labsOrderKey = `labcharts-${profileId}-lensPageOrder-labs-v1`;
     const savedLabsOrder = localStorage.getItem(labsOrderKey);
@@ -93,6 +101,31 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       dashboardToggle?.click();
       await delay(50);
 
+      window.triggerDNAFilePicker = () => calls.push(['trigger-dna']);
+      window.reimportDNA = () => calls.push(['reimport-dna']);
+      window.confirmDeleteDNA = () => calls.push(['delete-dna']);
+      window.openSettingsModal = pane => calls.push(['settings', pane]);
+      window.openDashboardBiometricPicker = () => calls.push(['biometrics']);
+      window.openChatPanel = () => calls.push(['chat']);
+      window.openEMFAssessmentEditor = () => calls.push(['emf']);
+      window.navigate = route => calls.push(['navigate', route]);
+      const actionFixture = document.createElement('div');
+      actionFixture.className = 'lens-page-header';
+      actionFixture.innerHTML = `
+        <button type="button" data-lens-page-action="import-dna"></button>
+        <button type="button" data-lens-page-action="reimport-dna"></button>
+        <button type="button" data-lens-page-action="delete-dna"></button>
+        <button type="button" data-lens-page-action="open-wearables-settings"></button>
+        <button type="button" data-lens-page-action="open-biometric-picker"></button>
+        <button type="button" data-lens-page-action="open-ai-chat"></button>
+        <button type="button" data-lens-page-action="open-emf-assessment"></button>
+        <button type="button" data-lens-page-action="open-recommendations"></button>
+        <button type="button" data-lens-page-action="open-privacy-settings"></button>`;
+      document.body.appendChild(actionFixture);
+      actionFixture.querySelectorAll('button').forEach(button => button.click());
+      actionFixture.remove();
+      await delay(50);
+
       return {
         shellRenders: !!widgets,
         noInlineHandlers: !!widgets && !widgets.querySelector('.dashboard-widget-tools [onclick], .dashboard-widget-tools [onkeydown]'),
@@ -100,13 +133,32 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
         moveReordersSections: !!beforeFirst && !!afterFirst && beforeFirst !== afterFirst,
         dashboardToggleCallsBridge: !!toggleAction && !!toggleId
           && calls.some(([kind, id]) => id === toggleId && `${kind}-dashboard-widget` === toggleAction),
+        headerActionsCallBridges: [
+          ['trigger-dna'],
+          ['reimport-dna'],
+          ['delete-dna'],
+          ['settings', 'wearables'],
+          ['biometrics'],
+          ['chat'],
+          ['emf'],
+          ['navigate', 'recommendations'],
+          ['settings', 'privacy'],
+        ].every(expected => calls.some(call => call[0] === expected[0] && (expected.length < 2 || call[1] === expected[1]))),
       };
     } finally {
       window.addDashboardWidgetFromLens = originalAddDashboard;
       window.removeDashboardWidgetFromLens = originalRemoveDashboard;
+      window.triggerDNAFilePicker = originalTriggerDNA;
+      window.reimportDNA = originalReimportDNA;
+      window.confirmDeleteDNA = originalConfirmDeleteDNA;
+      window.openSettingsModal = originalOpenSettings;
+      window.openDashboardBiometricPicker = originalOpenBiometricPicker;
+      window.openChatPanel = originalOpenChat;
+      window.openEMFAssessmentEditor = originalOpenEMF;
+      window.navigate = originalNavigate;
       if (savedLabsOrder == null) localStorage.removeItem(labsOrderKey);
       else localStorage.setItem(labsOrderKey, savedLabsOrder);
-      if (originalView) window.navigate?.(originalView);
+      if (originalView) originalNavigate?.(originalView);
     }
   });
 
@@ -228,7 +280,9 @@ test('lens page browser coverage renders genome details and marker-backed labs',
         genomeCoverageAndMtdnaRender: genomeText.includes('1,234 / 5,678 catalog SNPs matched')
           && genomeText.includes('mtDNA H1')
           && genomeText.includes('Stored maternal lineage'),
-        genomeControlsRender: genomeHtml.includes('window.reimportDNA') && genomeHtml.includes('window.confirmDeleteDNA'),
+        genomeControlsRender: genomeHtml.includes('data-lens-page-action="reimport-dna"')
+          && genomeHtml.includes('data-lens-page-action="delete-dna"')
+          && !genomeHtml.includes('onclick='),
         emptyGenomeOmitsImportDetails: !emptyGenomeHtml.includes('genome-import-details'),
         markerBackedLabsSkipDropZone: markerBackedLabsHtml.includes('data-testid="labs-priority"')
           && !markerBackedLabsHtml.includes('id="drop-zone"'),

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -73,6 +73,7 @@ assert('SW APP_SHELL includes PDF import support modules',
 assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes("'/js/context-card-summaries.js'"));
 assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.includes("'/js/context-card-editor-ui.js'"));
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));
+assert('SW APP_SHELL includes lens action delegates module', swAuditSrc.includes("'/js/lens-actions.js'"));
 assert('index loads app shell CSS bundle', indexSrc.includes('href="css/app-shell.css"'));
 assert('SW APP_SHELL includes app shell CSS bundle', swAuditSrc.includes("'/css/app-shell.css'"));
 assert('app shell CSS loads after core CSS and before feature CSS',
@@ -193,6 +194,9 @@ console.log('3. XSS Prevention');
 const viewsSrc = read('js/views.js');
 const dashboardPageViewSrc = read('js/dashboard-page-view.js');
 const lensPageShellSrc = read('js/lens-page-shell.js');
+const lensSrc = read('js/lens.js');
+const lensActionsSrc = read('js/lens-actions.js');
+const lensPagesSrc = read('js/lens-pages.js');
 const categoryPageViewSrc = read('js/category-page-view.js');
 const categoryViewRenderersSrc = read('js/category-view-renderers.js');
 const categoryCustomizationSrc = read('js/category-customization.js');
@@ -299,6 +303,17 @@ assert('Lifestyle context actions use delegated handlers',
   contextCardLifestyleSrc.includes('initLifestyleContextDelegates')
     && contextCardLifestyleSrc.includes('lifestyleActionAttrs')
     && !/\son(?:click|keydown)\s*=/.test(contextCardLifestyleSrc));
+assert('Lens settings controls use delegated handlers',
+  lensSrc.includes("from './lens-actions.js'")
+    && lensActionsSrc.includes('function handleLensActionClick')
+    && lensActionsSrc.includes('function handleLensActionChange')
+    && lensActionsSrc.includes('export function lensActionAttrs')
+    && !/\son(?:click|change|input)\s*=/.test(lensSrc));
+assert('Lens page controls use delegated shell actions',
+  lensPagesSrc.includes('lensPageActionAttrs')
+    && lensPageShellSrc.includes('open-wearables-settings')
+    && lensPageShellSrc.includes('open-privacy-settings')
+    && !/\son(?:click|change|input)\s*=/.test(lensPagesSrc));
 
 const _SANITIZER_RE = /(escapeHTML|safeMarkerId|escapeAttr|applyInlineMarkdown|renderMarkdown)\s*\(/;
 const _SAFE_HELPERS = new Set([

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -165,7 +165,7 @@ assert('45j. EMF launcher has dedicated context CSS',
   contextProfileCss.includes('.ctx-emf-launcher-action') &&
   contextProfileCss.includes('.ctx-emf-launcher.has-data'));
 assert('45k. Insight lens exposes EMF assessment action',
-  lensPagesSrc.includes('EMF assessment') && lensPagesSrc.includes('window.openEMFAssessmentEditor'));
+  lensPagesSrc.includes('EMF assessment') && lensPagesSrc.includes("lensPageActionAttrs('open-emf-assessment')"));
 assert('45l. EMF PII review streams current PDF text',
   emfSrc.includes('streamFn: (onChunk, signal, onThinking) => sanitizeWithOllamaStreaming(pdfText, onChunk, signal, onThinking)'));
 assert('45m. EMF PII review provides regex fallback text',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.502';
+self.APP_VERSION = '1.8.503';


### PR DESCRIPTION
## Summary
- add a scoped lens-actions delegate module for Knowledge Base settings controls
- replace lens and lens page inline handlers with data-lens-action / data-lens-page-action flows
- update service worker precache, quality baseline, version, and targeted regression coverage

## Validation
- npm run quality
- node tests/test-audit.js
- npm run typecheck
- npm test
- npx playwright test tests/playwright/custom-lens.spec.js tests/playwright/lens-page-shell.spec.js tests/playwright/lens-hardware-browser-coverage.spec.js tests/playwright/lens-local-library-browser-coverage.spec.js
- ./run-tests.sh