### PR TITLE
[codex] Delegate DNA actions

### DIFF
--- a/css/genetics.css
+++ b/css/genetics.css
@@ -68,8 +68,24 @@
 .genetics-mtdna-mismatch.mismatch-moderate { background: rgba(234, 179, 8, 0.08); border-color: var(--status-low); color: var(--text-secondary); }
 .genetics-mtdna-match { font-size: 12px; color: var(--green, #22c55e); margin-top: 4px; }
 .genetics-mtdna-refs { font-size: 10px; color: var(--text-muted); margin-top: 4px; }
-.genetics-mtdna-refs a { color: inherit; text-decoration: none; border-bottom: 1px dotted currentColor; }
-.genetics-mtdna-refs a:hover { color: var(--accent); border-color: var(--accent); }
+.genetics-mtdna-refs a,
+.genetics-mtdna-refs button {
+  color: inherit;
+  text-decoration: none;
+  border: 0;
+  border-bottom: 1px dotted currentColor;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+.genetics-mtdna-refs a:hover,
+.genetics-mtdna-refs button:hover { color: var(--accent); border-color: var(--accent); }
+.genetics-mtdna-refs button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
 /* mtDNA Import Preview */
 .mtdna-preview-haplogroup { text-align: center; padding: 16px 0 12px; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
 .mtdna-hg-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-muted); }
@@ -278,7 +294,7 @@
 .genetics-cat-group-secondary { margin-bottom: 0; }
 .genetics-stale-hint { font-size: 12px; color: var(--text-secondary); background: rgba(234, 179, 8, 0.06); border-left: 3px solid var(--yellow); padding: 6px 10px; border-radius: var(--radius-sm); margin-top: 12px; }
 .genetics-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 4px; }
-.genetics-action-link { font-size: 11px; color: var(--text-muted); cursor: pointer; }
+.genetics-action-link { font: inherit; font-size: 11px; color: var(--text-muted); cursor: pointer; background: transparent; border: 0; padding: 0; }
 .genetics-action-link:hover { color: var(--text-secondary); }
 .genetics-action-delete:hover { color: var(--status-high); }
 @media (max-width: 600px) {

--- a/js/dna-actions.js
+++ b/js/dna-actions.js
@@ -1,0 +1,81 @@
+// @ts-check
+// dna-actions.js - delegated actions for DNA and genetics UI
+
+import { escapeAttr } from './utils.js';
+
+let dnaDelegatesInstalled = false;
+let dnaActionHandlers = {};
+
+export function dnaActionAttrs(action, attrs = {}) {
+  return [
+    `data-dna-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-dna-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function isDnaActionScope(actionEl) {
+  return !!actionEl.closest('.genetics-empty-stub, .genetics-section, #dna-modal-overlay');
+}
+
+function handleDnaActionClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-dna-action]'));
+  if (!actionEl || !isDnaActionScope(actionEl)) return;
+
+  const action = actionEl.dataset.dnaAction || '';
+  if (action === 'import-file') {
+    event.preventDefault();
+    dnaActionHandlers.triggerDNAFilePicker?.();
+  } else if (action === 'toggle-genetics-collapse') {
+    event.preventDefault();
+    dnaActionHandlers.toggleGeneticsCollapse?.();
+  } else if (action === 'delete-mtdna') {
+    event.preventDefault();
+    dnaActionHandlers.deleteMtDNAData?.();
+  } else if (action === 'toggle-genetics-expand') {
+    event.preventDefault();
+    dnaActionHandlers.toggleGeneticsExpand?.(actionEl);
+  } else if (action === 'reimport-dna') {
+    event.preventDefault();
+    dnaActionHandlers.reimportDNA?.();
+  } else if (action === 'delete-dna') {
+    event.preventDefault();
+    dnaActionHandlers.confirmDeleteDNA?.();
+  } else if (action === 'toggle-preview-group') {
+    event.preventDefault();
+    actionEl.parentElement?.classList.toggle('expanded');
+  } else if (action === 'close-preview') {
+    event.preventDefault();
+    dnaActionHandlers.closeDNAImportPreview?.();
+  } else if (action === 'confirm-import') {
+    event.preventDefault();
+    dnaActionHandlers.confirmDNAImport?.();
+  } else if (action === 'close-mtdna-preview') {
+    event.preventDefault();
+    dnaActionHandlers.closeMtDNAPreview?.();
+  } else if (action === 'confirm-mtdna-import') {
+    event.preventDefault();
+    dnaActionHandlers.confirmMtDNAImport?.();
+  }
+}
+
+function handleDnaActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-dna-action][role="button"]'));
+  if (!actionEl || !isDnaActionScope(actionEl)) return;
+  event.preventDefault();
+  actionEl.click();
+}
+
+export function initDnaActionDelegates(handlers = {}) {
+  dnaActionHandlers = { ...dnaActionHandlers, ...handlers };
+  if (dnaDelegatesInstalled || typeof document === 'undefined') return;
+  dnaDelegatesInstalled = true;
+  document.addEventListener('click', handleDnaActionClick);
+  document.addEventListener('keydown', handleDnaActionKeydown);
+}

--- a/js/dna.js
+++ b/js/dna.js
@@ -6,6 +6,7 @@ import { state } from './state.js';
 import { escapeAttr, escapeHTML, hashString, showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { dnaActionAttrs, initDnaActionDelegates } from './dna-actions.js';
 /** @typedef {Window & typeof globalThis & {
  *   _pendingDNAImport?: any,
  *   _pendingMtDNA?: any,
@@ -714,7 +715,7 @@ export function renderGeneticsSection() {
   // DNA step have an in-context path back. Below the fold on first paint
   // but appears for any user scrolling past supplements/charts.
   if (!hasSnps && !hasMtdna) {
-    return `<div class="genetics-empty-stub" onclick="triggerDNAFilePicker()" role="button" tabindex="0" aria-label="Add DNA data" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
+    return `<div class="genetics-empty-stub" ${dnaActionAttrs('import-file')} role="button" tabindex="0" aria-label="Add DNA data">
       <span class="genetics-empty-stub-icon" aria-hidden="true">&#129516;</span>
       <span class="genetics-empty-stub-body">
         <span class="genetics-empty-stub-title">Add your DNA data</span>
@@ -799,7 +800,7 @@ export function renderGeneticsSection() {
   if (latestDate) metaParts.push(latestDate);
 
   let html = `<div class="dashboard-section genetics-section" id="genetics-section">
-    <div class="section-header" role="button" tabindex="0" aria-label="Expand or collapse genetics section" onclick="toggleGeneticsCollapse()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}" style="cursor:pointer">
+    <div class="section-header" role="button" tabindex="0" aria-label="Expand or collapse genetics section" ${dnaActionAttrs('toggle-genetics-collapse')} style="cursor:pointer">
       <span>\uD83E\uDDEC Genetics</span>
       <span class="section-meta">${metaParts.join(' \u00B7 ')}
         <span class="genetics-collapse-arrow${collapsed ? ' collapsed' : ''}">\u25BE</span></span>
@@ -855,7 +856,7 @@ export function renderGeneticsSection() {
       html += `<div class="genetics-mtdna-match">${escapeHTML(mismatch.message)}</div>`;
     }
     html += `<div class="genetics-mtdna-refs">Wallace 2015 (<a href="https://pubmed.ncbi.nlm.nih.gov/26406369/" target="_blank" rel="noopener">PMID: 26406369</a>)
-      \u00B7 <a href="#" onclick="window.deleteMtDNAData();return false" style="color:var(--text-muted)">remove</a></div>`;
+      \u00B7 <button type="button" ${dnaActionAttrs('delete-mtdna')}>remove</button></div>`;
     html += `</div>`;
   }
 
@@ -908,7 +909,7 @@ export function renderGeneticsSection() {
       html += `</div>`;
     }
     if (totalFindings > INITIAL_LIMIT) {
-      html += `<button class="genetics-show-all" onclick="toggleGeneticsExpand(this)">${totalFindings - INITIAL_LIMIT} more findings</button>`;
+      html += `<button class="genetics-show-all" ${dnaActionAttrs('toggle-genetics-expand')}>${totalFindings - INITIAL_LIMIT} more findings</button>`;
     }
     html += `</div>`;
   }
@@ -946,8 +947,8 @@ export function renderGeneticsSection() {
   }
 
   html += `<div class="genetics-actions">
-    <label class="genetics-action-link" onclick="reimportDNA()">Re-import</label>
-    <label class="genetics-action-link genetics-action-delete" onclick="window.confirmDeleteDNA()">Delete</label>
+    <button type="button" class="genetics-action-link" ${dnaActionAttrs('reimport-dna')}>Re-import</button>
+    <button type="button" class="genetics-action-link genetics-action-delete" ${dnaActionAttrs('delete-dna')}>Delete</button>
   </div>`;
   html += `</div></div>`;
 
@@ -1050,7 +1051,7 @@ function showDNAImportPreview(result, fileName) {
   function renderCollapsedGroup(items, label) {
     if (items.length === 0) return '';
     return `<div class="dna-preview-group">
-      <div class="dna-preview-group-title dna-preview-collapsible" role="button" tabindex="0" onclick="this.parentElement.classList.toggle('expanded')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.parentElement.classList.toggle('expanded')}">
+      <div class="dna-preview-group-title dna-preview-collapsible" role="button" tabindex="0" ${dnaActionAttrs('toggle-preview-group')}>
         ${label} (${items.length}) <span class="dna-preview-expand-hint">show</span>
       </div>
       <div class="dna-preview-collapsed-items">
@@ -1080,8 +1081,8 @@ function showDNAImportPreview(result, fileName) {
       Processed locally \u2014 your DNA file was never transmitted. Only matched SNPs are stored.
     </div>
     <div class="dna-preview-actions">
-      <button class="import-btn import-btn-secondary" onclick="closeDNAImportPreview()">Cancel</button>
-      <button class="import-btn import-btn-primary" onclick="confirmDNAImport()">Import ${result.coverage.found} SNPs</button>
+      <button class="import-btn import-btn-secondary" ${dnaActionAttrs('close-preview')}>Cancel</button>
+      <button class="import-btn import-btn-primary" ${dnaActionAttrs('confirm-import')}>Import ${result.coverage.found} SNPs</button>
     </div>`;
 
   // Use a dedicated overlay — don't clobber the PDF import modal
@@ -1361,8 +1362,8 @@ function _showMtDNAPreview(resolved, coupling, mutations, fileName) {
   html += `</div>
   <div class="dna-preview-disclaimer">Processed locally. Coupling classification follows the Wallace mitochondrial paradigm — a research framework, not an established clinical standard.</div>
   <div class="dna-preview-actions">
-    <button class="import-btn import-btn-secondary" onclick="window.closeMtDNAPreview()">Cancel</button>
-    <button class="import-btn import-btn-primary" onclick="window.confirmMtDNAImport()">Import Haplogroup ${escapeHTML(resolved.haplogroup)}</button>
+    <button class="import-btn import-btn-secondary" ${dnaActionAttrs('close-mtdna-preview')}>Cancel</button>
+    <button class="import-btn import-btn-primary" ${dnaActionAttrs('confirm-mtdna-import')}>Import Haplogroup ${escapeHTML(resolved.haplogroup)}</button>
   </div>`;
 
   let overlay = document.getElementById('dna-modal-overlay');
@@ -1470,6 +1471,8 @@ async function confirmDeleteDNA() {
     await dnaWindow._saveAndRefresh();
   }
 }
+
+initDnaActionDelegates({ triggerDNAFilePicker: () => window.triggerDNAFilePicker?.(), closeDNAImportPreview, closeMtDNAPreview, confirmDeleteDNA, confirmDNAImport, confirmMtDNAImport, deleteMtDNAData, reimportDNA, toggleGeneticsCollapse, toggleGeneticsExpand });
 
 // ═══════════════════════════════════════════════
 // WINDOW EXPORTS

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 241,
+  "inlineEventAttributes": 227,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/service-worker.js
+++ b/service-worker.js
@@ -203,6 +203,7 @@ const APP_SHELL = [
   '/js/provider-panel-renderers.js',
   '/js/provider-model-controls.js',
   '/js/provider-panels.js',
+  '/js/dna-actions.js',
   '/js/dna.js',
   '/js/hardware.js',
   '/js/sync.js',

--- a/tests/playwright/dna-browser-coverage.spec.js
+++ b/tests/playwright/dna-browser-coverage.spec.js
@@ -170,6 +170,13 @@ test('DNA autosomal import UI coverage exercises preview, confirm, render, and d
     };
     const textFile = (content, name, type = 'text/plain') => new File([content], name, { type });
     const wait = () => new Promise(resolve => setTimeout(resolve, 0));
+    const waitFor = async (predicate) => {
+      for (let i = 0; i < 30; i++) {
+        if (predicate()) return true;
+        await wait();
+      }
+      return false;
+    };
 
     const { state } = await import('/js/state.js');
     const dna = await import(`/js/dna.js?dnaAutosomalCoverage=${Date.now()}-${Math.random()}`);
@@ -212,17 +219,20 @@ rs999999\t1\t100\tAG
     let overlay = document.getElementById('dna-modal-overlay');
     check('valid file opens DNA preview', overlay?.classList.contains('show') === true);
     check('preview stores pending import', window._pendingDNAImport?.coverage?.found > 0);
+    check('DNA preview uses delegated actions', !overlay?.querySelector('[onclick], [onkeydown]'));
     overlay?.querySelector('.dna-preview-collapsible')?.click();
     check('collapsible preview group toggles', overlay?.querySelector('.dna-preview-group.expanded') != null);
-    window.closeDNAImportPreview();
+    overlay?.querySelector('[data-dna-action="close-preview"]')?.click();
+    await wait();
     check('close preview clears pending import', window._pendingDNAImport == null && !overlay?.classList.contains('show'));
 
     await window.handleDNAFile(textFile(validContent, 'ancestry-confirm.txt'));
     await wait();
-    await window.confirmDNAImport();
     overlay = document.getElementById('dna-modal-overlay');
+    overlay?.querySelector('[data-dna-action="confirm-import"]')?.click();
+    const importFinished = await waitFor(() => !overlay?.classList.contains('show') && calls.includes('navigate:dashboard'));
     check('confirmDNAImport stores genetics', state.importedData.genetics?.snps?.rs1801133?.genotype === 'GA');
-    check('confirmDNAImport closes preview and refreshes', !overlay?.classList.contains('show') && calls.includes('sidebar') && calls.includes('navigate:dashboard'));
+    check('confirmDNAImport closes preview and refreshes', importFinished && calls.includes('sidebar'));
     check('chat onboarding confirmation updated', document.querySelector('.chat-onboard-dna')?.textContent.includes('SNPs imported'));
 
     const html = dna.renderGeneticsSection();
@@ -230,13 +240,14 @@ rs999999\t1\t100\tAG
     check('renderGeneticsSection returns populated genetics UI',
       document.querySelector('.genetics-section') != null &&
       document.querySelector('.genetics-overview-card')?.textContent.includes('Imported SNPs'));
-    window.toggleGeneticsCollapse();
+    check('renderGeneticsSection uses delegated actions', !document.querySelector('.genetics-section')?.querySelector('[onclick], [onkeydown]'));
+    document.querySelector('.section-header')?.click();
     check('toggleGeneticsCollapse hides body', document.querySelector('.genetics-body')?.classList.contains('hidden'));
-    window.toggleGeneticsCollapse();
+    document.querySelector('.section-header')?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
     check('toggleGeneticsCollapse shows body', !document.querySelector('.genetics-body')?.classList.contains('hidden'));
 
-    document.body.insertAdjacentHTML('beforeend', '<div class="genetics-findings"></div><button id="expand">More</button>');
-    window.toggleGeneticsExpand(document.getElementById('expand'));
+    document.querySelector('.genetics-section')?.insertAdjacentHTML('beforeend', '<button id="expand" data-dna-action="toggle-genetics-expand">More</button>');
+    document.getElementById('expand')?.click();
     check('toggleGeneticsExpand expands fixture', document.querySelector('.genetics-findings')?.classList.contains('expanded') && document.getElementById('expand').textContent === 'Show less');
 
     const originalCreateElement = document.createElement.bind(document);
@@ -248,15 +259,15 @@ rs999999\t1\t100\tAG
       }
       return el;
     };
-    window.reimportDNA();
+    document.querySelector('[data-dna-action="reimport-dna"]')?.click();
     document.createElement = originalCreateElement;
     check('reimportDNA opens file picker', clickedSyntheticInput);
 
-    const confirmPromise = window.confirmDeleteDNA();
+    document.querySelector('[data-dna-action="delete-dna"]')?.click();
     await wait();
     document.getElementById('confirm-ok')?.click();
-    await confirmPromise;
-    check('confirmDeleteDNA deletes genetics and refreshes', state.importedData.genetics === undefined && calls.filter(item => item === 'navigate:dashboard').length >= 2);
+    const deleteFinished = await waitFor(() => state.importedData.genetics === undefined && calls.filter(item => item === 'navigate:dashboard').length >= 2);
+    check('confirmDeleteDNA deletes genetics and refreshes', deleteFinished);
 
     const toastText = document.getElementById('notification-container')?.textContent || '';
     check('notifications rendered during flow', /DNA import|Imported|health-relevant/.test(toastText));
@@ -277,6 +288,13 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     };
     const textFile = (content, name, type = 'text/plain') => new File([content], name, { type });
     const wait = () => new Promise(resolve => setTimeout(resolve, 0));
+    const waitFor = async (predicate) => {
+      for (let i = 0; i < 30; i++) {
+        if (predicate()) return true;
+        await wait();
+      }
+      return false;
+    };
 
     const { state } = await import('/js/state.js');
     const dna = await import(`/js/dna.js?dnaMtdnaCoverage=${Date.now()}-${Math.random()}`);
@@ -329,20 +347,26 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     let overlay = document.getElementById('dna-modal-overlay');
     check('handleMtDNAFile opens preview', overlay?.classList.contains('show') === true && window._pendingMtDNA?.resolved?.haplogroup === 'J');
     check('mtDNA preview includes mismatch', overlay?.textContent.includes('Environment mismatch'));
-    window.closeMtDNAPreview();
+    check('mtDNA preview uses delegated actions', !overlay?.querySelector('[onclick], [onkeydown]'));
+    overlay?.querySelector('[data-dna-action="close-mtdna-preview"]')?.click();
+    await wait();
     check('closeMtDNAPreview clears pending', window._pendingMtDNA == null && !overlay?.classList.contains('show'));
 
     await window.handleMtDNAFile(textFile(jText, 'genome-mtdna.txt'));
     await wait();
-    await window.confirmMtDNAImport();
-    check('confirmMtDNAImport stores mtdna', state.importedData.genetics?.mtdna?.haplogroup === 'J' && calls.includes('navigate:dashboard'));
+    overlay = document.getElementById('dna-modal-overlay');
+    overlay?.querySelector('[data-dna-action="confirm-mtdna-import"]')?.click();
+    const mtImportFinished = await waitFor(() => state.importedData.genetics?.mtdna?.haplogroup === 'J' && calls.includes('navigate:dashboard'));
+    check('confirmMtDNAImport stores mtdna', mtImportFinished);
     const context = window._buildGeneticsContext(state.importedData.genetics, null);
     check('mtDNA context includes mismatch detail', context.includes('mtDNA Haplogroup: J') && context.includes('ENVIRONMENT MISMATCH'));
     const rendered = dna.renderGeneticsSection();
     document.getElementById('fixture').innerHTML = rendered;
     check('renderGeneticsSection includes mtDNA card', document.querySelector('.genetics-mtdna-hg')?.textContent.includes('J'));
+    check('mtDNA remove action is a semantic button', document.querySelector('[data-dna-action="delete-mtdna"]')?.tagName === 'BUTTON');
 
-    await window.deleteMtDNAData();
+    document.querySelector('[data-dna-action="delete-mtdna"]')?.click();
+    await wait();
     check('deleteMtDNAData removes mtdna only', state.importedData.genetics?.mtdna == null && state.importedData.genetics?.snps != null);
 
     await window.setManualHaplogroup('bad');
@@ -374,7 +398,11 @@ test('DNA genetics renderer covers empty and lazy-catalog branches', async ({ pa
 
     state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, genetics: null, customMarkers: {}, markerNotes: {}, markerValueNotes: {}, changeHistory: [] };
     const emptyHtml = dna.renderGeneticsSection();
-    check('empty renderer returns upload stub', emptyHtml.includes('genetics-empty-stub') && emptyHtml.includes('Add your DNA data'));
+    check('empty renderer returns delegated upload stub',
+      emptyHtml.includes('genetics-empty-stub') &&
+      emptyHtml.includes('Add your DNA data') &&
+      emptyHtml.includes('data-dna-action="import-file"') &&
+      !emptyHtml.includes('onclick='));
 
     state.importedData.genetics = {
       source: 'Imported',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -74,6 +74,7 @@ assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes(
 assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.includes("'/js/context-card-editor-ui.js'"));
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));
 assert('SW APP_SHELL includes lens action delegates module', swAuditSrc.includes("'/js/lens-actions.js'"));
+assert('SW APP_SHELL includes DNA action delegates module', swAuditSrc.includes("'/js/dna-actions.js'"));
 assert('index loads app shell CSS bundle', indexSrc.includes('href="css/app-shell.css"'));
 assert('SW APP_SHELL includes app shell CSS bundle', swAuditSrc.includes("'/css/app-shell.css'"));
 assert('app shell CSS loads after core CSS and before feature CSS',
@@ -197,6 +198,7 @@ const lensPageShellSrc = read('js/lens-page-shell.js');
 const lensSrc = read('js/lens.js');
 const lensActionsSrc = read('js/lens-actions.js');
 const lensPagesSrc = read('js/lens-pages.js');
+const dnaActionsSrc = read('js/dna-actions.js');
 const categoryPageViewSrc = read('js/category-page-view.js');
 const categoryViewRenderersSrc = read('js/category-view-renderers.js');
 const categoryCustomizationSrc = read('js/category-customization.js');
@@ -314,6 +316,12 @@ assert('Lens page controls use delegated shell actions',
     && lensPageShellSrc.includes('open-wearables-settings')
     && lensPageShellSrc.includes('open-privacy-settings')
     && !/\son(?:click|change|input)\s*=/.test(lensPagesSrc));
+assert('DNA controls use delegated actions',
+  dnaSrc.includes("from './dna-actions.js'")
+    && dnaActionsSrc.includes('function handleDnaActionClick')
+    && dnaActionsSrc.includes('function handleDnaActionKeydown')
+    && dnaActionsSrc.includes('export function dnaActionAttrs')
+    && !/\son(?:click|keydown|change|input)\s*=/.test(dnaSrc));
 
 const _SANITIZER_RE = /(escapeHTML|safeMarkerId|escapeAttr|applyInlineMarkdown|renderMarkdown)\s*\(/;
 const _SAFE_HELPERS = new Set([

--- a/tests/test-dashboard-genetics-empty.js
+++ b/tests/test-dashboard-genetics-empty.js
@@ -32,8 +32,8 @@ await import('../js/context-cards.js');
         /Add your DNA data/i.test(html));
       assert('no DNA: CTA mentions privacy assurance',
         /stay on this device|locally/i.test(html));
-      assert('no DNA: click target wired to triggerDNAFilePicker',
-        html.includes('triggerDNAFilePicker()'));
+      assert('no DNA: click target uses delegated DNA action',
+        html.includes('data-dna-action="import-file"') && !html.includes('onclick='));
       assert('no DNA: keyboard-activatable (role + tabindex)',
         /role="button"/.test(html) && /tabindex="0"/.test(html));
     }
@@ -60,7 +60,7 @@ await import('../js/context-cards.js');
         !html.includes('genetics-empty-stub'));
     }
 
-    // ─── 4. window.triggerDNAFilePicker exists (used by stub onclick) ───
+    // ─── 4. window.triggerDNAFilePicker exists (used by stub delegate) ───
     {
       assert('window.triggerDNAFilePicker is a function',
         typeof window.triggerDNAFilePicker === 'function');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.503';
+self.APP_VERSION = '1.8.504';


### PR DESCRIPTION
## Summary
- move DNA and genetics UI click/key handling into a delegated `js/dna-actions.js` module
- replace DNA inline handlers with `data-dna-action` attributes and semantic buttons
- update tests, service worker precache, version, and inline-handler quality baseline

## Validation
- npm run quality
- node tests/test-audit.js
- node tests/test-dashboard-genetics-empty.js
- node tests/test-dna.js
- npx playwright test tests/playwright/dna-browser-coverage.spec.js
- npm run typecheck
- npm test
- ./run-tests.sh