### PR TITLE
[codex] Delegate chat onboarding provider actions

### DIFF
--- a/css/chat-onboarding.css
+++ b/css/chat-onboarding.css
@@ -32,6 +32,16 @@
   font-size: 12px; cursor: pointer; padding: 0 0 8px;
 }
 .chat-quiz-back:hover { color: var(--accent); }
+.chat-quiz-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+}
+.chat-quiz-link:hover { color: var(--accent); }
+.chat-quiz-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
 .chat-quiz-skip { text-align: center; margin-top: 14px; }
 .chat-quiz-skip-btn {
   background: transparent; border: 1px solid var(--border); border-radius: 8px;

--- a/js/chat-onboarding.js
+++ b/js/chat-onboarding.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { LATITUDE_BANDS } from './constants.js';
-import { escapeHTML, showNotification } from './utils.js';
+import { escapeAttr, escapeHTML, showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
   appendImportedArrayItem,
@@ -30,6 +30,67 @@ const onboardingCallbacks = {
   setChatNudge: () => {},
   updateChatNudge: () => {},
 };
+
+let chatOnboardingDelegatesInstalled = false;
+const CHAT_ONBOARDING_SETTING_PROVIDERS = new Set(['openrouter', 'ollama', 'routstr', 'ppq']);
+
+export function chatOnboardingActionAttrs(action, attrs = {}) {
+  return [
+    `data-chat-onboarding-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-chat-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function isChatOnboardingActionScope(actionEl) {
+  return !!actionEl.closest('#chat-panel, .chat-provider-quiz');
+}
+
+function openAiSettings() {
+  closeChatPanel();
+  setTimeout(() => {
+    if (window.openSettingsModal) window.openSettingsModal('ai');
+  }, 300);
+}
+
+function openAiProviderSettings(provider) {
+  closeChatPanel();
+  setTimeout(() => {
+    if (window.openSettingsModal) window.openSettingsModal('ai');
+    if (CHAT_ONBOARDING_SETTING_PROVIDERS.has(provider) && window.switchAIProvider) window.switchAIProvider(provider);
+  }, 300);
+}
+
+function handleChatOnboardingClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-chat-onboarding-action]'));
+  if (!actionEl || !isChatOnboardingActionScope(actionEl)) return;
+  const action = actionEl.dataset.chatOnboardingAction || '';
+  event.preventDefault();
+
+  if (action === 'back-to-provider-quiz') {
+    backToProviderQuiz();
+  } else if (action === 'start-openrouter-oauth') {
+    const appWindow = /** @type {Window & typeof globalThis & { startOpenRouterOAuth?: () => void }} */ (window);
+    appWindow.startOpenRouterOAuth?.();
+  } else if (action === 'open-ai-settings') {
+    openAiSettings();
+  } else if (action === 'open-provider-settings') {
+    openAiProviderSettings(actionEl.dataset.chatProvider || '');
+  } else if (action === 'set-provider-branch') {
+    setProviderQuizBranch(actionEl.dataset.chatProviderBranch || '');
+  } else if (action === 'skip-provider-setup') {
+    skipProviderSetup();
+  }
+}
+
+function initChatOnboardingDelegates() {
+  if (chatOnboardingDelegatesInstalled || typeof document === 'undefined') return;
+  chatOnboardingDelegatesInstalled = true;
+  document.addEventListener('click', handleChatOnboardingClick);
+}
 
 /** @param {Partial<typeof onboardingCallbacks>} [callbacks] */
 export function configureChatOnboarding(callbacks = {}) {
@@ -386,44 +447,44 @@ export function _renderOnboardCrumbs(currentStep, totalSteps = 4) {
 export function _renderProviderQuiz(branch, name) {
   const safeName = escapeHTML(name);
   if (branch === 'card') {
-    return `<button class="chat-quiz-back" onclick="window.backToProviderQuiz()" aria-label="Back to provider options">&larr; Back</button>
+    return `<div class="chat-provider-quiz"><button type="button" class="chat-quiz-back" ${chatOnboardingActionAttrs('back-to-provider-quiz')} aria-label="Back to provider options">&larr; Back</button>
       <p><strong>Pay with a card &rarr; OpenRouter</strong></p>
       <p style="font-size:13px">Click below &mdash; log in with Google or email, top up with your card, you&rsquo;re done. You&rsquo;ll come right back here.</p>
-      <button class="or-oauth-btn" onclick="startOpenRouterOAuth()">Connect with OpenRouter</button>
+      <button type="button" class="or-oauth-btn" ${chatOnboardingActionAttrs('start-openrouter-oauth')}>Connect with OpenRouter</button>
       <div style="font-size:11px;color:var(--text-muted);margin-top:10px;text-align:center">
-        <a href="#" onclick="event.preventDefault();closeChatPanel();setTimeout(()=>{window.openSettingsModal('ai');window.switchAIProvider('openrouter')},300)" style="color:var(--text-muted)">or paste a key manually</a>
-      </div>`;
+        <button type="button" class="chat-quiz-link" ${chatOnboardingActionAttrs('open-provider-settings', { provider: 'openrouter' })}>or paste a key manually</button>
+      </div></div>`;
   }
   if (branch === 'local') {
-    return `<button class="chat-quiz-back" onclick="window.backToProviderQuiz()" aria-label="Back to provider options">&larr; Back</button>
+    return `<div class="chat-provider-quiz"><button type="button" class="chat-quiz-back" ${chatOnboardingActionAttrs('back-to-provider-quiz')} aria-label="Back to provider options">&larr; Back</button>
       <p><strong>Runs on your computer &rarr; Local AI</strong></p>
       <p style="font-size:13px">Install <a href="https://ollama.com" target="_blank" rel="noopener" style="color:var(--accent)">Ollama</a>, <a href="https://lmstudio.ai" target="_blank" rel="noopener" style="color:var(--accent)">LM Studio</a>, or <a href="https://jan.ai" target="_blank" rel="noopener" style="color:var(--accent)">Jan</a> on your computer &mdash; they run AI models locally. Nothing leaves your machine, free forever. After install, point getbased at it.</p>
-      <button class="chat-setup-btn" onclick="closeChatPanel();setTimeout(()=>{window.openSettingsModal('ai');window.switchAIProvider('ollama')},300)">Open Local AI setup &rarr;</button>`;
+      <button type="button" class="chat-setup-btn" ${chatOnboardingActionAttrs('open-provider-settings', { provider: 'ollama' })}>Open Local AI setup &rarr;</button></div>`;
   }
   if (branch === 'bitcoin') {
-    return `<button class="chat-quiz-back" onclick="window.backToProviderQuiz()" aria-label="Back to provider options">&larr; Back</button>
+    return `<div class="chat-provider-quiz"><button type="button" class="chat-quiz-back" ${chatOnboardingActionAttrs('back-to-provider-quiz')} aria-label="Back to provider options">&larr; Back</button>
       <p><strong>Pay with Bitcoin &rarr; 2 options</strong></p>
       <div class="chat-quiz-options" style="margin-top:8px">
-        <button class="chat-quiz-option" onclick="closeChatPanel();setTimeout(()=>{window.openSettingsModal('ai');window.switchAIProvider('routstr')},300)">
+        <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('open-provider-settings', { provider: 'routstr' })}>
           <span class="chat-quiz-body">
             <strong>Routstr</strong>
             <span>Lightning + Cashu eCash. No account. Top up with a QR code.</span>
           </span>
           <span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
         </button>
-        <button class="chat-quiz-option" onclick="closeChatPanel();setTimeout(()=>{window.openSettingsModal('ai');window.switchAIProvider('ppq')},300)">
+        <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('open-provider-settings', { provider: 'ppq' })}>
           <span class="chat-quiz-body">
             <strong>PPQ</strong>
             <span>300+ models. Pay with BTC, Lightning, Monero, or Litecoin.</span>
           </span>
           <span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
         </button>
-      </div>`;
+      </div></div>`;
   }
   // Root question
-  return `<p>Welcome, ${safeName}! One more step &mdash; pick how you want to power the AI:</p>
+  return `<div class="chat-provider-quiz"><p>Welcome, ${safeName}! One more step &mdash; pick how you want to power the AI:</p>
     <div class="chat-quiz-options">
-      <button class="chat-quiz-option chat-quiz-recommended" onclick="window.setProviderQuizBranch('card')">
+      <button type="button" class="chat-quiz-option chat-quiz-recommended" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'card' })}>
         <span class="chat-quiz-icon" aria-hidden="true">&#128179;</span>
         <span class="chat-quiz-body">
           <strong>Easiest &mdash; pay with a card</strong>
@@ -431,7 +492,7 @@ export function _renderProviderQuiz(branch, name) {
         </span>
         <span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
       </button>
-      <button class="chat-quiz-option" onclick="window.setProviderQuizBranch('local')">
+      <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'local' })}>
         <span class="chat-quiz-icon" aria-hidden="true">&#128274;</span>
         <span class="chat-quiz-body">
           <strong>Most private &mdash; runs on my computer</strong>
@@ -439,7 +500,7 @@ export function _renderProviderQuiz(branch, name) {
         </span>
         <span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
       </button>
-      <button class="chat-quiz-option" onclick="window.setProviderQuizBranch('bitcoin')">
+      <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'bitcoin' })}>
         <span class="chat-quiz-icon" aria-hidden="true">&#8383;</span>
         <span class="chat-quiz-body">
           <strong>No account &mdash; pay with Bitcoin</strong>
@@ -447,7 +508,7 @@ export function _renderProviderQuiz(branch, name) {
         </span>
         <span class="chat-quiz-arrow" aria-hidden="true">&rarr;</span>
       </button>
-      <button class="chat-quiz-option" onclick="closeChatPanel();setTimeout(()=>window.openSettingsModal('ai'),300)">
+      <button type="button" class="chat-quiz-option" ${chatOnboardingActionAttrs('open-ai-settings')}>
         <span class="chat-quiz-icon" aria-hidden="true">&#128273;</span>
         <span class="chat-quiz-body">
           <strong>Advanced: I have an API key</strong>
@@ -457,8 +518,8 @@ export function _renderProviderQuiz(branch, name) {
       </button>
     </div>
     <div class="chat-quiz-skip">
-      <button class="chat-quiz-skip-btn" onclick="window.skipProviderSetup()">Try the app first &mdash; I&rsquo;ll connect AI later</button>
-    </div>`;
+      <button type="button" class="chat-quiz-skip-btn" ${chatOnboardingActionAttrs('skip-provider-setup')}>Try the app first &mdash; I&rsquo;ll connect AI later</button>
+    </div></div>`;
 }
 
 export function setProviderQuizBranch(branch) {
@@ -510,3 +571,5 @@ export function onContextCardSaved() {
     renderChatMessages();
   }
 }
+
+initChatOnboardingDelegates();

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 227,
+  "inlineEventAttributes": 214,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/chat-onboarding-browser-coverage.spec.js
+++ b/tests/playwright/chat-onboarding-browser-coverage.spec.js
@@ -374,6 +374,9 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
       getActiveData: window.getActiveData,
       renderSupplementsSection: window.renderSupplementsSection,
       navigate: window.navigate,
+      openSettingsModal: window.openSettingsModal,
+      switchAIProvider: window.switchAIProvider,
+      startOpenRouterOAuth: window.startOpenRouterOAuth,
     };
     const host = document.createElement('div');
     const calls = [];
@@ -386,6 +389,7 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
         if (key && value != null) storage.setItem(key, value);
       }
     };
+    const waitForProviderTimer = () => new Promise(resolve => setTimeout(resolve, 350));
 
     try {
       host.innerHTML = `
@@ -450,6 +454,9 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
         return '<div class="supp-timeline-section">supps refreshed</div>';
       };
       window.navigate = view => { calls.push(`navigate:${view}`); };
+      window.openSettingsModal = tab => { calls.push(`settings:${tab}`); };
+      window.switchAIProvider = provider => { calls.push(`provider:${provider}`); };
+      window.startOpenRouterOAuth = () => { calls.push('oauth'); };
 
       const crumbs = onboarding._renderOnboardCrumbs(3, 5);
       const quizRoot = onboarding._renderProviderQuiz(null, '<Ada>');
@@ -464,6 +471,43 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
         && quizLocal.includes('Local AI setup')
         && quizBitcoin.includes('Routstr')
         && quizBitcoin.includes('PPQ');
+
+      const quizHost = document.createElement('div');
+      host.appendChild(quizHost);
+      quizHost.innerHTML = quizRoot + quizCard + quizLocal + quizBitcoin;
+      const delegatedMarkup = !quizHost.querySelector('[onclick], [onkeydown], [onchange], [oninput]')
+        && quizHost.querySelectorAll('[data-chat-onboarding-action]').length >= 13;
+      quizHost.innerHTML = quizRoot;
+      quizHost.querySelector('[data-chat-onboarding-action="set-provider-branch"][data-chat-provider-branch="card"]')?.click();
+      const delegatedBranchClick = sessionStorage.getItem(`chat-onboard-provider-branch-${profileId}`) === 'card';
+      quizHost.innerHTML = quizCard;
+      quizHost.querySelector('[data-chat-onboarding-action="back-to-provider-quiz"]')?.click();
+      const delegatedBackClick = sessionStorage.getItem(`chat-onboard-provider-branch-${profileId}`) === null;
+      quizHost.querySelector('[data-chat-onboarding-action="start-openrouter-oauth"]')?.click();
+      quizHost.querySelector('[data-chat-onboarding-action="open-provider-settings"][data-chat-provider="openrouter"]')?.click();
+      await waitForProviderTimer();
+      quizHost.innerHTML = quizLocal;
+      quizHost.querySelector('[data-chat-onboarding-action="open-provider-settings"][data-chat-provider="ollama"]')?.click();
+      await waitForProviderTimer();
+      quizHost.innerHTML = quizBitcoin;
+      quizHost.querySelector('[data-chat-onboarding-action="open-provider-settings"][data-chat-provider="routstr"]')?.click();
+      await waitForProviderTimer();
+      quizHost.querySelector('[data-chat-onboarding-action="open-provider-settings"][data-chat-provider="ppq"]')?.click();
+      await waitForProviderTimer();
+      quizHost.innerHTML = quizRoot;
+      quizHost.querySelector('[data-chat-onboarding-action="open-ai-settings"]')?.click();
+      await waitForProviderTimer();
+      quizHost.querySelector('[data-chat-onboarding-action="skip-provider-setup"]')?.click();
+      outcomes.providerQuizDelegatesAllActions = delegatedMarkup
+        && delegatedBranchClick
+        && delegatedBackClick
+        && calls.includes('oauth')
+        && calls.includes('provider:openrouter')
+        && calls.includes('provider:ollama')
+        && calls.includes('provider:routstr')
+        && calls.includes('provider:ppq')
+        && calls.filter(call => call === 'settings:ai').length >= 5
+        && localStorage.getItem(`labcharts-onboard-provider-skipped-${profileId}`) === '1';
 
       onboarding.setProviderQuizBranch('bitcoin');
       outcomes.providerBranchPersistsInSession =

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -318,7 +318,9 @@ assert('provider renderer renders or-oauth-btn in OpenRouter panel', providerRen
 assert('provider renderer renders or-oauth-divider', providerRenderSrc.includes('or-oauth-divider'));
 assert('OAuth button conditional on !currentKey', providerRenderSrc.includes("currentKey ? '' : '<button class=\"or-oauth-btn\""));
 assert('Chat setup guide has or-oauth-btn', chatOnboardingSrc.includes('or-oauth-btn'));
-assert('Chat setup guide has startOpenRouterOAuth onclick', chatOnboardingSrc.includes("onclick=\"startOpenRouterOAuth()\""));
+assert('Chat setup guide has delegated startOpenRouterOAuth action',
+  chatOnboardingSrc.includes('data-chat-onboarding-action') &&
+  chatOnboardingSrc.includes('start-openrouter-oauth'));
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -294,12 +294,15 @@ const onboardingViewSrc = read('js/onboarding-view.js');
     'Onboarding cards should stay readable in glass/synth themes');
   assert('Chat onboarding has OpenRouter OAuth', chatOnboardingSrc.includes('startOpenRouterOAuth') && chatOnboardingSrc.includes('paste a key manually'),
     'Should have OAuth button and manual key option for API step');
-  assert('Chat onboarding has PPQ', chatOnboardingSrc.includes("switchAIProvider('ppq')"),
+  const hasDelegatedProviderSetup = (provider) =>
+    chatOnboardingSrc.includes(`chatOnboardingActionAttrs('open-provider-settings', { provider: '${provider}' })`) &&
+    chatOnboardingSrc.includes(`'${provider}'`);
+  assert('Chat onboarding has PPQ', hasDelegatedProviderSetup('ppq'),
     'Should have PPQ setup link');
   // Venice is intentionally NOT in the onboarding quiz — its
   // uncensored/E2EE positioning hurts non-tech onboarding clarity.
   // Reachable from Settings → AI (provider-panels.js + settings.js).
-  assert('Chat onboarding has Local AI', chatOnboardingSrc.includes("switchAIProvider('ollama')"),
+  assert('Chat onboarding has Local AI', hasDelegatedProviderSetup('ollama'),
     'Should have Local AI setup link');
   assert('Chat onboarding has settings opener', chatOnboardingSrc.includes("openSettingsModal('ai')"),
     'Should have link that opens AI settings tab directly');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.504';
+self.APP_VERSION = '1.8.505';


### PR DESCRIPTION
## Summary
- replace chat onboarding provider quiz inline handlers with delegated data-action buttons
- keep provider/settings/OAuth setup flows scoped to the chat onboarding quiz container
- update quality baseline, version, and browser/OpenRouter coverage for delegated actions

## Tests
- npm run quality
- node tests/test-audit.js
- node tests/test-chat-actions.js
- node tests/test-openrouter.js
- node tests/test-prelab.js
- npm run typecheck
- npm test
- npx playwright test tests/playwright/chat-onboarding-browser-coverage.spec.js
- ./run-tests.sh