### PR TITLE
[codex] Delegate recommendation actions

### DIFF
--- a/js/dashboard-recommendation-widget.js
+++ b/js/dashboard-recommendation-widget.js
@@ -7,6 +7,54 @@ import { getEffectiveRangeForDate, getLatestValueIndex } from './marker-analysis
 import { profileStorageKey } from './profile.js';
 import { escapeAttr, escapeHTML, formatValue, getStatus } from './utils.js';
 
+let dashboardRecommendationDelegatesInstalled = false;
+
+export function dashboardRecommendationActionAttrs(action, attrs = {}) {
+  return [
+    `data-dashboard-rec-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-dashboard-rec-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function handleDashboardRecommendationClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-dashboard-rec-action]'));
+  if (!actionEl || !actionEl.closest('.rec-next-widget, .rec-next-card, .db-correlation-empty')) return;
+  const appWindow = /** @type {any} */ (window);
+  const action = actionEl.dataset.dashboardRecAction || '';
+  event.preventDefault();
+
+  if (action === 'view-marker') {
+    const markerId = actionEl.dataset.dashboardRecMarkerId || '';
+    if (markerId) appWindow.showDetailModal?.(markerId, { scrollToRec: true });
+  } else if (action === 'open-detail') {
+    appWindow.openRecommendationDetail?.(
+      actionEl.dataset.dashboardRecSlotKey || '',
+      actionEl.dataset.dashboardRecLabel || 'Recommendation',
+      actionEl.dataset.dashboardRecMarkerStatus || '',
+    );
+  } else if (action === 'discuss') {
+    appWindow.discussRecommendation?.(actionEl.dataset.dashboardRecId || '');
+  } else if (action === 'save') {
+    appWindow.saveRecommendation?.(actionEl.dataset.dashboardRecId || '', actionEl.dataset.dashboardRecOn === 'true');
+  } else if (action === 'dismiss') {
+    appWindow.dismissRecommendation?.(actionEl.dataset.dashboardRecId || '', actionEl.dataset.dashboardRecOn === 'true');
+  } else if (action === 'navigate') {
+    appWindow.navigate?.(actionEl.dataset.dashboardRecRoute || '');
+  } else if (action === 'open-privacy-settings') {
+    appWindow.openSettingsModal?.('privacy');
+  }
+}
+
+export function initDashboardRecommendationDelegates() {
+  if (dashboardRecommendationDelegatesInstalled) return;
+  document.addEventListener('click', handleDashboardRecommendationClick);
+  dashboardRecommendationDelegatesInstalled = true;
+}
+
 export function createDashboardRecommendationWidget({
   markerHasData,
   buildDashboardWidgetContext,
@@ -78,14 +126,6 @@ export function createDashboardRecommendationWidget({
       return `${name} is ${readable}; trend signal: ${code}.`;
     }
     return `${name} is ${readable} versus its active reference range.`;
-  }
-
-  function inlineJsString(value) {
-    return JSON.stringify(String(value ?? '')).replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
-  }
-
-  function inlineHandlerCall(fnName, ...args) {
-    return escapeAttr(`window.${fnName}(${args.map(inlineJsString).join(', ')})`);
   }
 
   function getGlobalRecommendationCandidates(ctx, catalog, { includeDismissed = false } = {}) {
@@ -188,15 +228,8 @@ export function createDashboardRecommendationWidget({
   function renderRecommendationCard(candidate, { compact = false } = {}) {
     const savedClass = candidate.saved ? ' is-saved' : '';
     const primaryAction = candidate.primaryAction ? `<div class="rec-next-primary">${escapeHTML(candidate.primaryAction)}</div>` : '';
-    const markerCall = candidate.markerId
-      ? escapeAttr(`window.showDetailModal(${inlineJsString(candidate.markerId)}, { scrollToRec: true })`)
-      : '';
-    const detailCall = inlineHandlerCall('openRecommendationDetail', candidate.slotKey, candidate.label, candidate.markerStatus || '');
-    const discussCall = inlineHandlerCall('discussRecommendation', candidate.id);
-    const saveCall = escapeAttr(`window.saveRecommendation(${inlineJsString(candidate.id)}, ${candidate.saved ? 'false' : 'true'})`);
-    const dismissCall = escapeAttr(`window.dismissRecommendation(${inlineJsString(candidate.id)}, ${candidate.dismissed ? 'false' : 'true'})`);
     const markerBtn = candidate.markerId
-      ? `<button type="button" class="dashboard-action-btn" onclick="${markerCall}">View marker</button>`
+      ? `<button type="button" class="dashboard-action-btn" ${dashboardRecommendationActionAttrs('view-marker', { 'marker-id': candidate.markerId })}>View marker</button>`
       : '';
     const saveLabel = candidate.saved ? 'Bookmarked' : 'Bookmark';
     const dismissLabel = candidate.dismissed ? 'Restore' : 'Dismiss';
@@ -209,17 +242,17 @@ export function createDashboardRecommendationWidget({
       ${candidate.meta ? `<div class="rec-next-meta">${escapeHTML(candidate.meta)}</div>` : ''}
       ${compact ? '' : primaryAction}
       <div class="rec-next-actions">
-        <button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="${detailCall}">View options</button>
+        <button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${dashboardRecommendationActionAttrs('open-detail', { 'slot-key': candidate.slotKey, label: candidate.label, 'marker-status': candidate.markerStatus || '' })}>View options</button>
         ${markerBtn}
-        <button type="button" class="dashboard-action-btn" onclick="${discussCall}">Discuss</button>
-        <button type="button" class="dashboard-action-btn" onclick="${saveCall}">${saveLabel}</button>
-        ${compact ? '' : `<button type="button" class="dashboard-action-btn" onclick="${dismissCall}">${dismissLabel}</button>`}
+        <button type="button" class="dashboard-action-btn" ${dashboardRecommendationActionAttrs('discuss', { id: candidate.id })}>Discuss</button>
+        <button type="button" class="dashboard-action-btn" ${dashboardRecommendationActionAttrs('save', { id: candidate.id, on: candidate.saved ? 'false' : 'true' })}>${saveLabel}</button>
+        ${compact ? '' : `<button type="button" class="dashboard-action-btn" ${dashboardRecommendationActionAttrs('dismiss', { id: candidate.id, on: candidate.dismissed ? 'false' : 'true' })}>${dismissLabel}</button>`}
       </div>
     </article>`;
   }
 
   function renderRecommendationsEmpty(message = 'No data-linked recommendations yet.') {
-    return `<button type="button" class="db-correlation-empty" onclick="window.navigate('labs')">
+    return `<button type="button" class="db-correlation-empty" ${dashboardRecommendationActionAttrs('navigate', { route: 'labs' })}>
       <strong>${escapeHTML(message)}</strong>
       <span>Import labs, connect body data, log light exposure, or add DNA to generate recommendation candidates.</span>
     </button>`;
@@ -227,7 +260,7 @@ export function createDashboardRecommendationWidget({
 
   function renderDashboardRecommendationsWidget(ctx) {
     if (!window.isProductRecsEnabled?.()) {
-      return `<button type="button" class="db-correlation-empty" onclick="window.openSettingsModal && window.openSettingsModal('privacy')">
+      return `<button type="button" class="db-correlation-empty" ${dashboardRecommendationActionAttrs('open-privacy-settings')}>
         <strong>Recommendations are off</strong>
         <span>Enable Tips & Recommendations in settings to show data-linked next steps.</span>
       </button>`;
@@ -241,7 +274,7 @@ export function createDashboardRecommendationWidget({
     if (!candidates.length) return renderRecommendationsEmpty();
     return `<div class="rec-next-widget">
       ${candidates.map(c => renderRecommendationCard(c, { compact: true })).join('')}
-      <button type="button" class="dashboard-action-btn dashboard-action-btn-primary" onclick="window.navigate('recommendations')">View all recommendations</button>
+      <button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${dashboardRecommendationActionAttrs('navigate', { route: 'recommendations' })}>View all recommendations</button>
     </div>`;
   }
 
@@ -255,3 +288,5 @@ export function createDashboardRecommendationWidget({
     setRecommendationState,
   };
 }
+
+initDashboardRecommendationDelegates();

--- a/js/recommendation-actions.js
+++ b/js/recommendation-actions.js
@@ -1,8 +1,31 @@
 // @ts-check
 // recommendation-actions.js - recommendation modal and action handlers
 
-import { escapeHTML } from './utils.js';
+import { escapeAttr, escapeHTML } from './utils.js';
 import { openModalOverlay } from './modal-lifecycle.js';
+
+let recommendationDetailDelegatesInstalled = false;
+
+function recommendationDetailActionAttrs(action) {
+  return `data-recommendation-detail-action="${escapeAttr(action)}"`;
+}
+
+function handleRecommendationDetailClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-recommendation-detail-action]'));
+  if (!actionEl || !actionEl.closest('#detail-modal')) return;
+  if (actionEl.dataset.recommendationDetailAction === 'close') {
+    event.preventDefault();
+    window.closeModal?.();
+  }
+}
+
+function initRecommendationDetailDelegates() {
+  if (recommendationDetailDelegatesInstalled) return;
+  document.addEventListener('click', handleRecommendationDetailClick);
+  recommendationDetailDelegatesInstalled = true;
+}
 
 function setDetailModalShell(...classes) {
   const modal = document.getElementById('detail-modal');
@@ -22,18 +45,18 @@ export function createRecommendationActions({
     const modal = setDetailModalShell('recommendation-detail-modal');
     const overlay = document.getElementById("modal-overlay");
     if (!modal || !overlay) return;
-    modal.innerHTML = `<button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>
+    modal.innerHTML = `<button type="button" class="modal-close" aria-label="Close" ${recommendationDetailActionAttrs('close')}>&times;</button>
       <h3>${escapeHTML(label || 'Recommendation')}</h3>
       <div class="dashboard-widget-empty">Loading options...</div>`;
     openModalOverlay(overlay);
     Promise.resolve(window.renderRecommendationSection?.(slotKey, { label: 'Options', maxProducts: 4, markerStatus }))
       .then(html => {
-        modal.innerHTML = `<button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>
+        modal.innerHTML = `<button type="button" class="modal-close" aria-label="Close" ${recommendationDetailActionAttrs('close')}>&times;</button>
           <h3>${escapeHTML(label || 'Recommendation')}</h3>
           ${html || '<div class="dashboard-widget-empty">No recommendation details available for this slot.</div>'}`;
       })
       .catch(() => {
-        modal.innerHTML = `<button class="modal-close" aria-label="Close" onclick="closeModal()">&times;</button>
+        modal.innerHTML = `<button type="button" class="modal-close" aria-label="Close" ${recommendationDetailActionAttrs('close')}>&times;</button>
           <h3>${escapeHTML(label || 'Recommendation')}</h3>
           <div class="dashboard-widget-empty">Could not load recommendation details.</div>`;
       });
@@ -64,3 +87,5 @@ export function createRecommendationActions({
     dismissRecommendation,
   };
 }
+
+initRecommendationDetailDelegates();

--- a/js/recommendations.js
+++ b/js/recommendations.js
@@ -1,7 +1,7 @@
 // @ts-check
 // recommendations.js — Catalog loading, slot matching, HTML rendering for supplement & lifestyle recs
 
-import { escapeHTML } from './utils.js';
+import { escapeAttr, escapeHTML } from './utils.js';
 import { getProfileLocation } from './profile.js';
 import { state } from './state.js';
 import { findGenotypeInfo, findSnpHint } from './dna.js';
@@ -11,6 +11,64 @@ import { findGenotypeInfo, findSnpHint } from './dna.js';
 // ═══════════════════════════════════════════════
 let _catalog = undefined; // undefined = not loaded, null = load failed
 let _catalogPromise = null; // deduplicates concurrent loads
+let _recommendationDelegatesInstalled = false;
+
+export function recActionAttrs(action, attrs = {}) {
+  return [
+    `data-rec-action="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== '')
+      .map(([name, value]) => `data-rec-${escapeAttr(name)}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+function handleRecommendationSectionGuardClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+
+  const guardedSection = target.closest('[data-rec-section-click-guard]');
+  if (guardedSection && !target.closest('a,button')) event.stopPropagation();
+}
+
+function handleRecommendationActionClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-rec-action]'));
+  if (!actionEl) return;
+  const appWindow = /** @type {any} */ (window);
+  const action = actionEl.dataset.recAction || '';
+
+  if (action === 'copy-coupon') {
+    event.preventDefault();
+    copyCouponCode(actionEl);
+  } else if (action === 'close-modal') {
+    event.preventDefault();
+    appWindow.closeModal?.();
+  } else if (action === 'open-emf-assessment') {
+    event.preventDefault();
+    appWindow.closeModal?.();
+    setTimeout(() => appWindow.openEMFAssessmentEditor?.(), 100);
+  } else if (action === 'edit-region') {
+    event.preventDefault();
+    (appWindow.openProfileLocationEditor || (() => {}))();
+  } else if (action === 'accept-disclosure') {
+    event.preventDefault();
+    event.stopPropagation();
+    markDisclosureSeen();
+    actionEl.closest('.rec-disclosure-banner')?.remove();
+    for (const el of document.querySelectorAll('.rec-section-gated')) el.classList.remove('rec-section-gated');
+  } else if (action === 'open-privacy-settings') {
+    event.preventDefault();
+    appWindow.openSettingsTab?.('privacy');
+  }
+}
+
+export function initRecommendationDelegates() {
+  if (_recommendationDelegatesInstalled) return;
+  document.addEventListener('click', handleRecommendationActionClick, true);
+  document.addEventListener('click', handleRecommendationSectionGuardClick);
+  _recommendationDelegatesInstalled = true;
+}
 
 export async function loadCatalog() {
   if (_catalog !== undefined) return _catalog;
@@ -338,10 +396,8 @@ function _buildCouponLine(catalogOrVendor, region) {
   const c = _resolveCouponForRegion(rawCoupon, region);
   if (!c?.code) return '';
   const code = escapeHTML(c.code);
-  // Click-to-copy: a global helper handles the work. Inline onclick stays
-  // tiny and safe to embed in an attribute (no quotes, no arrow funcs).
   // aria-live on the wrapper so the "✓ Copied" flash is announced to SR users.
-  return `<div class="rec-coupon" aria-live="polite" aria-atomic="true">Use code <button type="button" class="rec-coupon-code" onclick="copyCouponCode(this)" data-code="${code}" aria-label="Copy coupon code ${code} to clipboard" title="Click to copy">${code}</button> at checkout for ${escapeHTML(c.userDiscount || '10%')} off.</div>`;
+  return `<div class="rec-coupon" aria-live="polite" aria-atomic="true">Use code <button type="button" class="rec-coupon-code" ${recActionAttrs('copy-coupon')} data-code="${escapeAttr(c.code)}" aria-label="Copy coupon code ${code} to clipboard" title="Click to copy">${code}</button> at checkout for ${escapeHTML(c.userDiscount || '10%')} off.</div>`;
 }
 
 function copyCouponCode(btn) {
@@ -506,7 +562,7 @@ export function renderEMFMeterRecs(catalog, opts = {}) {
   const eventPrefix = opts.eventPrefix || 'meter-rec';
   const body = meters.map(m => _buildEMFProductRow(m, eventPrefix, getUserRegion(), catalog)).join('');
   const vendor = _resolveVendorForCoupon(catalog, meters);
-  return `${_buildDisclosureBanner()}<div class="rec-section rec-emf-section${gated}" onclick="if(!event.target.closest('a,button'))event.stopPropagation()">
+  return `${_buildDisclosureBanner()}<div class="rec-section rec-emf-section${gated}" data-rec-section-click-guard>
     <div class="rec-section-header">${heading}</div>
     <div class="rec-content">
       ${body}
@@ -529,7 +585,7 @@ export function renderEMFMitigationRecs(catalog, tags, opts = {}) {
   const eventPrefix = opts.eventPrefix || 'mitigation-rec';
   const body = products.map(p => _buildEMFProductRow(p, eventPrefix, getUserRegion(), catalog)).join('');
   const vendor = _resolveVendorForCoupon(catalog, products);
-  return `${_buildDisclosureBanner()}<div class="rec-section rec-emf-section${gated}" onclick="if(!event.target.closest('a,button'))event.stopPropagation()">
+  return `${_buildDisclosureBanner()}<div class="rec-section rec-emf-section${gated}" data-rec-section-click-guard>
     <div class="rec-section-header">${heading}</div>
     <div class="rec-content">
       ${body}
@@ -616,7 +672,7 @@ export function renderCardTipsModal(cardKey) {
   }
   if (cardKey === 'environment') items += _buildEMFNudge();
   if (!items) return '';
-  return `<button class="modal-close" onclick="window.closeModal()">\u00D7</button>
+  return `<button type="button" class="modal-close" ${recActionAttrs('close-modal')} aria-label="Close">\u00D7</button>
     <div class="ctx-tips-modal-header">${cardInfo.emoji} ${escapeHTML(cardInfo.label)} \u2014 Tips</div>
     <div class="ctx-tips-modal-body">${items}</div>
     <div class="rec-mini-disclaimer" style="margin-top:12px">For informational purposes only. Not medical advice. Consult your healthcare provider before starting any supplement.</div>`;
@@ -627,9 +683,8 @@ export function renderCardTipsModal(cardKey) {
 // than 120d. Empty otherwise so we don't nag users keeping up.
 function _buildEMFNudge() {
   const assessments = state.importedData?.emfAssessment?.assessments || [];
-  const openHandler = `event.preventDefault();window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor(),100);`;
   if (!assessments.length) {
-    return `<div class="ctx-tip-emf-nudge"><span aria-hidden="true">💡</span> Want to measure your home's EMF environment? <a href="#" onclick="${openHandler}" data-umami-event="emf-nudge-env-tips-noassessment">Open the EMF assessment →</a></div>`;
+    return `<div class="ctx-tip-emf-nudge"><span aria-hidden="true">💡</span> Want to measure your home's EMF environment? <a href="#" ${recActionAttrs('open-emf-assessment')} data-umami-event="emf-nudge-env-tips-noassessment">Open the EMF assessment →</a></div>`;
   }
   const latest = assessments.reduce((a, b) => (a.date > b.date ? a : b));
   const ageDays = (Date.now() - new Date(latest.date + 'T00:00:00').getTime()) / 86400000;
@@ -639,7 +694,7 @@ function _buildEMFNudge() {
   if (ageDays > 120) {
     const months = Math.round(ageDays / 30);
     const span = months >= 12 ? 'over a year' : `${months} ${months === 1 ? 'month' : 'months'}`;
-    return `<div class="ctx-tip-emf-nudge"><span aria-hidden="true">💡</span> Your last EMF check was ${span} ago. <a href="#" onclick="${openHandler}" data-umami-event="emf-nudge-env-tips-stale">Re-check the room →</a></div>`;
+    return `<div class="ctx-tip-emf-nudge"><span aria-hidden="true">💡</span> Your last EMF check was ${span} ago. <a href="#" ${recActionAttrs('open-emf-assessment')} data-umami-event="emf-nudge-env-tips-stale">Re-check the room →</a></div>`;
   }
   return '';
 }
@@ -752,7 +807,7 @@ function buildDisclosureFooter() {
   // Link points to wherever the user can change their country. Click handler
   // delegates to the host app via a global (window.openProfileLocationEditor)
   // so this module stays decoupled. Falls back to '#' if no host is wired.
-  const editLink = `<a href="#" class="rec-region-edit" onclick="event.preventDefault();(window.openProfileLocationEditor||(()=>{}))()" aria-label="Change country for product recommendations">change</a>`;
+  const editLink = `<a href="#" class="rec-region-edit" ${recActionAttrs('edit-region')} aria-label="Change country for product recommendations">change</a>`;
   return `<div class="rec-disclosure">Affiliate links are marked. Brands cannot pay for placement. <span class="rec-region-tag">Showing for ${escapeHTML(label)} · ${editLink}</span></div>`;
 }
 
@@ -764,7 +819,7 @@ function _buildDisclosureBanner() {
   if (hasSeenDisclosure()) return '';
   return `<div class="rec-disclosure-banner">
     For informational purposes only. This is not a medical device and does not diagnose, treat, or prevent disease. Consult your healthcare provider before starting any supplement, especially if pregnant, nursing, or taking medications. Intended for adults. Affiliate links are marked \u2014 brands cannot pay for placement.
-    <button class="rec-disclosure-btn" onclick="event.stopPropagation();markRecDisclosureSeen();this.closest('.rec-disclosure-banner').remove();for(const el of document.querySelectorAll('.rec-section-gated'))el.classList.remove('rec-section-gated')">Got it</button>
+    <button class="rec-disclosure-btn" ${recActionAttrs('accept-disclosure')}>Got it</button>
   </div>`;
 }
 
@@ -886,7 +941,7 @@ function _renderRecSection(slotKey, opts = {}) {
   // surface it where their products surface.
   const vendor = _resolveVendorForCoupon(_catalog, products);
   const couponLine = vendor && hasProducts ? _buildCouponLine(vendor, region) : '';
-  return `${_buildDisclosureBanner()}<div class="rec-section${gated}" onclick="if(!event.target.closest('a,button'))event.stopPropagation()">
+  return `${_buildDisclosureBanner()}<div class="rec-section${gated}" data-rec-section-click-guard>
     <div class="rec-section-header">${escapeHTML(label)}</div>
     <div class="rec-content">${statusNote}${inner}${couponLine}${suggestLink}${buildDisclosureFooter()}${_buildMiniDisclaimer()}</div>
   </div>`;
@@ -1177,13 +1232,15 @@ export function renderChannelDeficitDeviceRecs(catalog, channelKey, presets, opt
   return `<div class="rec-channel-deficit" role="region" aria-label="${humanLabel} channel device recommendations">
     <div class="rec-channel-deficit-head">Fill the ${humanLabel} channel with a device</div>
     <div class="rec-channel-deficit-list">${rows.join('')}</div>
-    <div class="rec-channel-deficit-foot">Affiliate links · <a href="#" onclick="event.preventDefault();window.openSettingsTab&&window.openSettingsTab('privacy')">turn off</a></div>
+    <div class="rec-channel-deficit-foot">Affiliate links · <a href="#" ${recActionAttrs('open-privacy-settings')}>turn off</a></div>
   </div>`;
 }
 
 // ═══════════════════════════════════════════════
 // WINDOW EXPORTS
 // ═══════════════════════════════════════════════
+initRecommendationDelegates();
+
 Object.assign(window, {
   isProductRecsEnabled,
   setProductRecsEnabled,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 214,
+  "inlineEventAttributes": 193,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
@@ -133,8 +133,7 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
       const disabledHtml = widget.renderDashboardRecommendationsWidget(activeCtx);
       outcomes.disabledStateLinksToPrivacySettings =
         disabledHtml.includes('Recommendations are off')
-        && disabledHtml.includes("openSettingsModal")
-        && disabledHtml.includes("'privacy'");
+        && disabledHtml.includes('data-dashboard-rec-action="open-privacy-settings"');
 
       productRecsEnabled = true;
       fixture.innerHTML = `
@@ -218,11 +217,11 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
       outcomes.renderCardsEscapeMarkupAndBuildActionHandlers =
         escapedCard.includes('&lt;script&gt;')
         && escapedCard.includes('Reason &lt;b&gt;bold&lt;/b&gt;')
-        && escapedCard.includes('window.showDetailModal')
-        && escapedCard.includes('window.openRecommendationDetail')
-        && escapedCard.includes('window.discussRecommendation')
-        && escapedCard.includes('window.saveRecommendation')
-        && escapedCard.includes('window.dismissRecommendation')
+        && escapedCard.includes('data-dashboard-rec-action="view-marker"')
+        && escapedCard.includes('data-dashboard-rec-action="open-detail"')
+        && escapedCard.includes('data-dashboard-rec-action="discuss"')
+        && escapedCard.includes('data-dashboard-rec-action="save"')
+        && escapedCard.includes('data-dashboard-rec-action="dismiss"')
         && compactCard.includes('rec-next-card-compact')
         && compactCard.includes('Bookmarked')
         && !compactCard.includes('Hidden when compact')
@@ -233,7 +232,7 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
       const customEmptyHtml = widget.renderRecommendationsEmpty('Nothing <ready>');
       outcomes.emptyStatesRenderSafeFallbackActions =
         emptyHtml.includes('No data-linked recommendations yet.')
-        && emptyHtml.includes("window.navigate('labs')")
+        && emptyHtml.includes('data-dashboard-rec-route="labs"')
         && customEmptyHtml.includes('Nothing &lt;ready&gt;')
         && customEmptyHtml.includes('Import labs');
     } finally {

--- a/tests/playwright/recommendations-browser-coverage.spec.js
+++ b/tests/playwright/recommendations-browser-coverage.spec.js
@@ -387,6 +387,36 @@ test('recommendations browser coverage exercises catalog renderers detectors and
         && couponBtn?.textContent === 'SK12';
       window.setTimeout = saved.setTimeout;
 
+      localStorage.removeItem('labcharts-rec-disclosure');
+      const chatWrapper = document.createElement('details');
+      chatWrapper.className = 'rec-chat-wrapper';
+      chatWrapper.open = true;
+      let chatWrapperStoppedBubble = false;
+      chatWrapper.onclick = event => {
+        chatWrapperStoppedBubble = true;
+        event.stopPropagation();
+      };
+      const chatBody = document.createElement('div');
+      chatBody.innerHTML = rec.renderRecommendationSectionSync('magnesium', { label: 'Chat recommendations' });
+      chatWrapper.appendChild(chatBody);
+      document.body.appendChild(chatWrapper);
+      copiedCode = '';
+      couponFlashCleanup = null;
+      window.setTimeout = (fn, _ms, ...args) => {
+        couponFlashCleanup = () => fn(...args);
+        return 1;
+      };
+      chatWrapper.querySelector('.rec-coupon-code')?.click();
+      await wait(0);
+      chatWrapper.querySelector('.rec-disclosure-btn')?.click();
+      outcomes.chatWrappedRecommendationActionsSurviveStopPropagation = chatWrapperStoppedBubble
+        && copiedCode === 'SK12'
+        && localStorage.getItem('labcharts-rec-disclosure') === 'seen'
+        && !chatWrapper.querySelector('.rec-section-gated');
+      couponFlashCleanup?.();
+      chatWrapper.remove();
+      window.setTimeout = saved.setTimeout;
+
       const asyncHtml = await rec.renderRecommendationSection('magnesium', { label: 'Async recommendations' });
       outcomes.asyncRenderUsesLoadedCatalog = asyncHtml.includes('Async recommendations')
         && asyncHtml.includes('Magnesium Glycinate');

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -284,7 +284,7 @@ assert('92. Empty for null/empty text', recsMod.detectMitigationsInText('').leng
 // ── Coupon click-to-copy renders as button, not <code> ──
 localStorage.setItem('labcharts-show-product-recs', 'true');
 const couponHtml = recsMod.renderEMFMeterRecs(emfCat);
-assert('93. Coupon renders as clickable button', couponHtml.includes('rec-coupon-code') && couponHtml.includes('copyCouponCode'));
+assert('93. Coupon renders as clickable button', couponHtml.includes('rec-coupon-code') && couponHtml.includes('data-rec-action="copy-coupon"'));
 assert('94. copyCouponCode exposed on window', typeof window.copyCouponCode === 'function');
 assert('94a. Coupon button has aria-label', /aria-label="Copy coupon code/.test(couponHtml));
 assert('94b. Coupon wrapper announces flash via aria-live', /aria-live="polite"/.test(couponHtml));
@@ -420,7 +420,7 @@ localStorage.setItem('labcharts-show-product-recs', 'true');
 const discMeterHtml = recsMod.renderEMFMeterRecs(emfCat);
 assert('94am. Disclosure footer renders region indicator', /Showing for /.test(discMeterHtml));
 assert('94an. Disclosure footer renders change link', /class="rec-region-edit"/.test(discMeterHtml));
-assert('94ao. Change link calls openProfileLocationEditor on click', /openProfileLocationEditor/.test(discMeterHtml));
+assert('94ao. Change link delegates location editor action', /data-rec-action="edit-region"/.test(discMeterHtml));
 
 // Vendor-name rendering in EMF row (was hardcoded to "Safe Living Technologies")
 assertCatalog('94ap. EMF row link copy uses vendor name (not hardcoded)', /View on Safe Living Technologies/.test(discMeterHtml));

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -121,8 +121,8 @@ assert('chat image lightbox uses shared overlay lifecycle helpers',
     !chatImagesSrc.includes('overlay.remove()'));
 
 assert('card tips modal closes through shared detail modal close path',
-  recommendationsSrc.includes('onclick="window.closeModal()"') &&
-    recommendationsSrc.includes('event.preventDefault();window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor(),100);') &&
+  recommendationsSrc.includes("recActionAttrs('close-modal')") &&
+    recommendationsSrc.includes("recActionAttrs('open-emf-assessment')") &&
     !recommendationsSrc.includes("document.getElementById('modal-overlay').classList.remove('show')"));
 
 assert('recommendation detail modal opens through shared overlay lifecycle helper',

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -246,7 +246,8 @@ globalThis.fetch = async (url, opts) => {
   assert('dashboard has Recommendations widget surface', dashboardWidgetsSrc.includes("id: 'recommendations'") && dashboardWidgetsSrc.includes('renderDashboardRecommendationsWidget'));
   assert('dismissed recommendations render a Restore action',
     dashboardRecommendationWidgetSrc.includes("candidate.dismissed ? 'Restore' : 'Dismiss'") &&
-    dashboardRecommendationWidgetSrc.includes("window.dismissRecommendation(${inlineJsString(candidate.id)}, ${candidate.dismissed ? 'false' : 'true'})"));
+    dashboardRecommendationWidgetSrc.includes("dashboardRecommendationActionAttrs('dismiss'") &&
+    dashboardRecommendationWidgetSrc.includes("on: candidate.dismissed ? 'false' : 'true'"));
   assert('dismissRecommendation can restore a dismissed recommendation',
     /function dismissRecommendation\(id, on = true\)[\s\S]{0,120}setRecommendationState\('dismissed', id, !!on\)/.test(recommendationActionsSrc));
   assert('Recommendations page header directly toggles its dashboard widget',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.505';
+self.APP_VERSION = '1.8.506';


### PR DESCRIPTION
## Summary
- Replace recommendation, recommendation detail, and dashboard recommendation widget inline handlers with delegated data-action handlers.
- Keep recommendation section click guards, coupon copy, EMF/profile/privacy flows, and detail modal close behavior intact.
- Update static/browser expectations, lower the inline-handler quality baseline from 214 to 193, and bump version.js.

## Validation
- npm run quality
- npm run typecheck
- npm test
- node tests/test-recommendations.js
- node tests/test-modal-lifecycle-integrations.js
- node tests/test-emf.js
- npx playwright test tests/playwright/recommendation-actions-browser-coverage.spec.js tests/playwright/recommendations-browser-coverage.spec.js tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
- ./run-tests.sh