### PR TITLE
[codex] Delegate sync actions

### DIFF
--- a/js/sync-configure.js
+++ b/js/sync-configure.js
@@ -11,7 +11,7 @@ import { configureSyncMessenger } from './sync-messenger.js';
 import { checkRelayConnection, getSyncRelay } from './sync-environment.js';
 import { configureSyncIdentity, restoreFromMnemonic } from './sync-identity.js';
 import { configureSyncDiagnostics } from './sync-diagnostics.js';
-import { bindSyncUIStatusUpdates, configureSyncUI } from './sync-ui.js';
+import { bindSyncUIStatusUpdates, configureSyncUI, initSyncUIDelegates } from './sync-ui.js';
 import { configureSyncDiagnoseUI } from './sync-diagnose-ui.js';
 import { configureSyncActions, pushAllProfiles, pushCurrentProfile } from './sync-actions.js';
 import { bindSyncSaveHookEvents, configureSyncSaveHooks } from './sync-save-hooks.js';
@@ -118,6 +118,7 @@ export function configureSyncModules({ enableSync, disableSync } = {}) {
   configureSyncUI({
     isSyncEnabled,
   });
+  initSyncUIDelegates();
   bindSyncUIStatusUpdates();
 
   configureSyncDiagnoseUI({

--- a/js/sync-diagnose-render.js
+++ b/js/sync-diagnose-render.js
@@ -1,7 +1,11 @@
 // @ts-check
 // sync-diagnose-render.js - Pure HTML render helpers for Sync Diagnose.
 
-import { escapeHTML } from './utils.js';
+import { escapeAttr, escapeHTML } from './utils.js';
+
+export function syncDiagnoseActionAttrs(action) {
+  return `data-sync-diagnose-action="${escapeAttr(action)}"`;
+}
 
 function renderRowsHtml(rows) {
   if (!rows.length) {
@@ -49,9 +53,9 @@ function renderRelayStoragePanel(q) {
     ? 'Approaching the per-account storage cap. No action needed yet — keeps trimming on its own as data ages.'
     : 'Healthy.';
   const buttons = `
-    <button class="ctx-btn-option" style="font-size:11px" onclick="window.refreshRelayStorage(this)" title="Probe the relay for the actual storedBytes for this owner — replaces the local estimate.">Refresh</button>
-    <button class="ctx-btn-option" style="font-size:11px" onclick="window.confirmCompactRelay(this)" title="Drops every Evolu message row for this owner on the relay and resets storedBytes to 0. Devices re-establish their state on the next push.">Compact storage</button>
-    <button class="ctx-btn-option" style="font-size:11px" onclick="window.confirmRotateIdentity(this)" title="Generate a fresh 24-word mnemonic for this owner. Use when this device's relay-health verdict shows 'wedged' (silent-reject pattern). You'll need to enter the new mnemonic on every other device.">Rotate identity</button>`;
+    <button class="ctx-btn-option" style="font-size:11px" ${syncDiagnoseActionAttrs('refresh-relay-storage')} title="Probe the relay for the actual storedBytes for this owner — replaces the local estimate.">Refresh</button>
+    <button class="ctx-btn-option" style="font-size:11px" ${syncDiagnoseActionAttrs('compact-relay')} title="Drops every Evolu message row for this owner on the relay and resets storedBytes to 0. Devices re-establish their state on the next push.">Compact storage</button>
+    <button class="ctx-btn-option" style="font-size:11px" ${syncDiagnoseActionAttrs('rotate-identity')} title="Generate a fresh 24-word mnemonic for this owner. Use when this device's relay-health verdict shows 'wedged' (silent-reject pattern). You'll need to enter the new mnemonic on every other device.">Rotate identity</button>`;
   return `<div style="margin-bottom:12px;padding:10px;border:1px solid var(--border);border-radius:6px">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;gap:8px;flex-wrap:wrap">
       <b>Relay storage:</b>
@@ -89,7 +93,7 @@ function renderDeltaTelemetryPanel(t, isDebug) {
   return `<div style="margin-bottom:12px;padding:10px;border:1px solid var(--border);border-radius:6px">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;gap:8px">
       <b>Push efficiency <span style="font-weight:normal;color:var(--text-muted);font-size:11px">(last ${s.count} pushes — lower % = leaner sync)</span></b>
-      <button class="ctx-btn-option" style="font-size:11px;flex-shrink:0" onclick="window.confirmResetDeltaTelemetry(this)" title="Clears just the recent-push log shown here. Your data and relay state aren't touched.">Reset</button>
+      <button class="ctx-btn-option" style="font-size:11px;flex-shrink:0" ${syncDiagnoseActionAttrs('reset-delta-telemetry')} title="Clears just the recent-push log shown here. Your data and relay state aren't touched.">Reset</button>
     </div>
     <div style="margin-bottom:4px">
       <span style="color:${ratioColor};font-weight:600">${pct}%</span>
@@ -115,7 +119,7 @@ function renderCutoverPanel(r, isDebug, cutoverEnabled) {
     <div style="margin-top:6px;padding:8px;background:var(--surface);border-left:3px solid var(--orange);border-radius:4px">
       <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:4px">
         <div style="color:var(--orange);font-weight:600;font-size:12px">These bits of data haven't been re-pushed yet:</div>
-        <button class="ctx-btn-option" style="font-size:11px" onclick="window.confirmBackfillBlockers(this)" title="Forces a fresh push so each pending item ships as new. Safe — no data loss.">Push now</button>
+        <button class="ctx-btn-option" style="font-size:11px" ${syncDiagnoseActionAttrs('backfill-blockers')} title="Forces a fresh push so each pending item ships as new. Safe — no data loss.">Push now</button>
       </div>
       <table style="width:100%;font-size:11px">
         ${blockers.map(([name, v]) => `<tr><td style="font-family:monospace;padding:2px 6px">${escapeHTML(name)}</td><td style="padding:2px 6px;color:var(--text-muted)">${escapeHTML(v.shape)}</td><td style="padding:2px 6px;text-align:right">local=${v.localCount} rows=${v.rowCount}</td></tr>`).join('')}
@@ -123,9 +127,9 @@ function renderCutoverPanel(r, isDebug, cutoverEnabled) {
       <div style="color:var(--text-muted);font-size:10px;margin-top:4px">Tap <b>Push now</b> to take care of all of them at once.</div>
     </div>`;
   const buttonHtml = cutoverEnabled
-    ? `<button class="ctx-btn-option" style="font-size:11px;color:var(--orange);border-color:var(--orange)" onclick="window.confirmDisablePhase2(this)" title="Switches back to full-blob sync. Use this if a peer device shows missing data.">Disable</button>`
+    ? `<button class="ctx-btn-option" style="font-size:11px;color:var(--orange);border-color:var(--orange)" ${syncDiagnoseActionAttrs('disable-phase2')} title="Switches back to full-blob sync. Use this if a peer device shows missing data.">Disable</button>`
     : (r.ready
-      ? `<button class="ctx-btn-option" style="font-size:11px;color:var(--green);border-color:var(--green)" onclick="window.confirmEnablePhase2(this)" title="Switch this device to lean sync (per-row deltas only). Reversible.">Enable</button>`
+      ? `<button class="ctx-btn-option" style="font-size:11px;color:var(--green);border-color:var(--green)" ${syncDiagnoseActionAttrs('enable-phase2')} title="Switch this device to lean sync (per-row deltas only). Reversible.">Enable</button>`
       : `<button class="ctx-btn-option" style="font-size:11px;opacity:0.5;cursor:not-allowed" disabled title="Push the pending items below first.">Enable</button>`);
   const cutoverBadge = cutoverEnabled
     ? `<span style="color:var(--green);font-size:10px;font-weight:600;padding:2px 6px;border:1px solid var(--green);border-radius:3px;margin-left:6px">ON</span>`
@@ -180,7 +184,7 @@ export function renderSyncDiagnoseModal({
         <div style="color:var(--text-muted);font-size:11px;margin-top:6px">Compare this table on phone vs desktop. Same profileId, same deleted state, same syncedAt(ms), same sun/dev counts → both devices already have the same data and the issue is rendering. Different counts → relay-replication isn't propagating between Evolu instances. <b>fmt</b> column: <span style="color:var(--green)">gz</span> = v1.6.4 gzip envelope, plain = pre-v1.6.4. <span style="color:var(--orange)">*</span> next to a profileId means it was recovered from the payload because the column was empty.</div>
       </div>
       <div style="margin-top:14px;display:flex;gap:8px;justify-content:flex-end">
-        <button class="ctx-btn-option" onclick="window.copySyncDiagnose(this)" title="Copy this snapshot to the clipboard so you can paste it elsewhere">Copy</button>
+        <button class="ctx-btn-option" ${syncDiagnoseActionAttrs('copy-snapshot')} title="Copy this snapshot to the clipboard so you can paste it elsewhere">Copy</button>
         <button class="ctx-btn-option" data-sync-diagnose-close>Close</button>
       </div>
     </div>

--- a/js/sync-diagnose-ui.js
+++ b/js/sync-diagnose-ui.js
@@ -4,7 +4,16 @@
 import { showNotification, isDebugMode } from './utils.js';
 import { _evoluDiagnosticsText, getEvoluDiagnostics } from './sync-diagnostics.js';
 import { getRelayQuotaEstimate, verifyPushLanded } from './sync-relay-health.js';
-import { configureSyncDiagnoseActions } from './sync-diagnose-actions.js';
+import {
+  configureSyncDiagnoseActions,
+  confirmBackfillBlockers,
+  confirmCompactRelay,
+  confirmDisablePhase2,
+  confirmEnablePhase2,
+  confirmResetDeltaTelemetry,
+  confirmRotateIdentity,
+  refreshRelayStorage,
+} from './sync-diagnose-actions.js';
 import { renderSyncDiagnoseModal } from './sync-diagnose-render.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
@@ -16,6 +25,33 @@ export {
 
 /** @type {(profileId?: any) => boolean} */
 let _isPhase2CutoverEnabled = () => false;
+
+function handleSyncDiagnoseActionClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-sync-diagnose-action]'));
+  if (!actionEl) return;
+  event.preventDefault();
+
+  const action = actionEl.dataset.syncDiagnoseAction || '';
+  if (action === 'refresh-relay-storage') {
+    void refreshRelayStorage(actionEl);
+  } else if (action === 'compact-relay') {
+    void confirmCompactRelay(actionEl);
+  } else if (action === 'rotate-identity') {
+    void confirmRotateIdentity(actionEl);
+  } else if (action === 'reset-delta-telemetry') {
+    void confirmResetDeltaTelemetry(actionEl);
+  } else if (action === 'backfill-blockers') {
+    void confirmBackfillBlockers(actionEl);
+  } else if (action === 'disable-phase2') {
+    void confirmDisablePhase2(actionEl);
+  } else if (action === 'enable-phase2') {
+    void confirmEnablePhase2(actionEl);
+  } else if (action === 'copy-snapshot') {
+    void copySyncDiagnose(actionEl);
+  }
+}
 
 /** @param {{
  *   enableSync?: (...args: any[]) => any,
@@ -80,6 +116,7 @@ export async function showSyncDiagnose() {
   overlay.querySelectorAll('[data-sync-diagnose-close]').forEach((btn) => {
     btn.addEventListener('click', close);
   });
+  overlay.addEventListener('click', handleSyncDiagnoseActionClick);
   overlay.addEventListener('click', (e) => {
     if (e.target === overlay) close();
   });

--- a/js/sync-ui.js
+++ b/js/sync-ui.js
@@ -1,7 +1,7 @@
 // @ts-check
 // sync-ui.js - header sync badge, popover, and activity-log copy helpers.
 
-import { showNotification, isDebugMode, escapeHTML } from './utils.js';
+import { showNotification, isDebugMode, escapeAttr, escapeHTML } from './utils.js';
 import { getSyncRelay } from './sync-environment.js';
 import { getRelayQuotaEstimate } from './sync-relay-health.js';
 import {
@@ -13,6 +13,55 @@ import {
 
 let _isSyncEnabled = () => false;
 let _statusBound = false;
+const SYNC_UI_DELEGATE_KEY = '__getbasedSyncUIDelegatesInstalled';
+
+export function syncUiActionAttrs(action) {
+  return `data-sync-ui-action="${escapeAttr(action)}"`;
+}
+
+function handleSyncUIClick(event) {
+  const target = event.target instanceof Element ? event.target : null;
+  if (!target) return;
+  const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-sync-ui-action]'));
+  if (!actionEl) return;
+
+  event.preventDefault();
+  const appWindow = /** @type {any} */ (window);
+  const action = actionEl.dataset.syncUiAction || '';
+  if (action === 'toggle-detail') {
+    toggleSyncDetail();
+  } else if (action === 'copy-events') {
+    void copySyncEvents(actionEl);
+  } else if (action === 'sync-now') {
+    void appWindow.syncNow?.();
+    toggleSyncDetail();
+  } else if (action === 'reload') {
+    appWindow.location?.reload?.();
+  } else if (action === 'open-settings') {
+    toggleSyncDetail();
+    appWindow.openSettingsModal?.('data');
+  } else if (action === 'force-resend') {
+    void appWindow.forceResendCurrentProfile?.();
+    toggleSyncDetail();
+  } else if (action === 'clean-storage') {
+    Promise.resolve(appWindow.cleanStorage?.()).then(() => toggleSyncDetail());
+  } else if (action === 'test-relay') {
+    Promise.resolve(appWindow.checkRelayConnection?.()).then(ok => {
+      showNotification(ok ? 'Relay reachable' : 'Relay UNREACHABLE', ok ? 'success' : 'error');
+    }).catch(err => {
+      showNotification(`Relay check failed: ${err?.message || err}`, 'error');
+    });
+  } else if (action === 'show-diagnose') {
+    appWindow.showSyncDiagnose?.();
+  }
+}
+
+export function initSyncUIDelegates() {
+  const appWindow = /** @type {any} */ (window);
+  if (appWindow[SYNC_UI_DELEGATE_KEY]) return;
+  document.addEventListener('click', handleSyncUIClick);
+  appWindow[SYNC_UI_DELEGATE_KEY] = true;
+}
 
 /** @param {{ isSyncEnabled?: () => boolean }} [deps] */
 export function configureSyncUI({ isSyncEnabled } = {}) {
@@ -43,7 +92,7 @@ export function renderSyncIndicator() {
   if (!currentSyncEnabled()) { slot.innerHTML = ''; return; }
   const ds = getSyncDisplayState();
   const titles = { synced: 'Synced', syncing: 'Syncing\u2026', offline: 'Offline \u2014 changes saved locally', error: 'Sync error', disabled: '' };
-  slot.innerHTML = `<button class="sync-indicator" id="sync-indicator-btn" onclick="toggleSyncDetail()" title="${titles[ds]}" aria-label="Sync status"><span class="sync-dot sync-dot-${ds}"></span></button>`;
+  slot.innerHTML = `<button class="sync-indicator" id="sync-indicator-btn" ${syncUiActionAttrs('toggle-detail')} title="${titles[ds]}" aria-label="Sync status"><span class="sync-dot sync-dot-${ds}"></span></button>`;
 }
 
 export function updateSyncIndicator() {
@@ -92,7 +141,7 @@ export function toggleSyncDetail() {
     <div style="margin-top:10px;padding-top:8px;border-top:1px solid var(--border);font-size:11px;color:var(--text-muted);max-height:160px;overflow-y:auto">
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
         <span style="font-weight:600;color:var(--text-secondary);flex:1">Recent activity</span>
-        <button class="ctx-btn-option" style="font-size:10px;padding:2px 8px" onclick="window.copySyncEvents(this)" title="Copy events to clipboard">Copy</button>
+        <button class="ctx-btn-option" style="font-size:10px;padding:2px 8px" ${syncUiActionAttrs('copy-events')} title="Copy events to clipboard">Copy</button>
       </div>
       ${events.map(e => `<div style="margin-bottom:3px"><span style="color:${eventColor[e.kind] || 'var(--text-muted)'};font-weight:600">${e.kind}</span> · ${_timeAgo(e.at)} · <span style="font-family:monospace;font-size:10px">${escapeHTML(e.text)}</span></div>`).join('')}
     </div>` : '';
@@ -118,14 +167,14 @@ export function toggleSyncDetail() {
     ${debugMode ? errorLine : ''}
     ${eventsHtml}
     <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
-      <button class="ctx-btn-option" style="font-size:12px" onclick="syncNow();toggleSyncDetail()">Sync now</button>
-      ${stuckPush ? `<button class="ctx-btn-option" style="font-size:12px;color:var(--red);border-color:var(--red)" onclick="window.location.reload()" title="Reloads the page to re-init the sync worker.">Reload</button>` : ''}
-      <button class="ctx-btn-option" style="font-size:12px" onclick="toggleSyncDetail();openSettingsModal('data')">Settings</button>
+      <button class="ctx-btn-option" style="font-size:12px" ${syncUiActionAttrs('sync-now')}>Sync now</button>
+      ${stuckPush ? `<button class="ctx-btn-option" style="font-size:12px;color:var(--red);border-color:var(--red)" ${syncUiActionAttrs('reload')} title="Reloads the page to re-init the sync worker.">Reload</button>` : ''}
+      <button class="ctx-btn-option" style="font-size:12px" ${syncUiActionAttrs('open-settings')}>Settings</button>
       ${isDebugMode() ? `
-        <button class="ctx-btn-option" style="font-size:12px${stuckPush ? ';color:var(--orange);border-color:var(--orange)' : ''}" onclick="forceResendCurrentProfile();toggleSyncDetail()" title="Bypasses the in-flight guard. Use when Sync now isn't reaching the relay (typically because a prior push got stuck and the worker still thinks it's running).">Force resend</button>
-        <button class="ctx-btn-option" style="font-size:12px" onclick="cleanStorage().then(()=>toggleSyncDetail())" title="Trim changeHistory to its 200-entry cap and clear cached AI model lists. Use when localStorage is full and pushes throw QuotaExceededError silently.">Clean storage</button>
-        <button class="ctx-btn-option" style="font-size:12px" onclick="checkRelayConnection().then(ok=>showNotification(ok?'Relay reachable':'Relay UNREACHABLE',ok?'success':'error'))">Test relay</button>
-        <button class="ctx-btn-option" style="font-size:12px" onclick="showSyncDiagnose()">Diagnose</button>
+        <button class="ctx-btn-option" style="font-size:12px${stuckPush ? ';color:var(--orange);border-color:var(--orange)' : ''}" ${syncUiActionAttrs('force-resend')} title="Bypasses the in-flight guard. Use when Sync now isn't reaching the relay (typically because a prior push got stuck and the worker still thinks it's running).">Force resend</button>
+        <button class="ctx-btn-option" style="font-size:12px" ${syncUiActionAttrs('clean-storage')} title="Trim changeHistory to its 200-entry cap and clear cached AI model lists. Use when localStorage is full and pushes throw QuotaExceededError silently.">Clean storage</button>
+        <button class="ctx-btn-option" style="font-size:12px" ${syncUiActionAttrs('test-relay')}>Test relay</button>
+        <button class="ctx-btn-option" style="font-size:12px" ${syncUiActionAttrs('show-diagnose')}>Diagnose</button>
       ` : ''}
     </div>`;
   btn.parentElement.style.position = 'relative';

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 193,
+  "inlineEventAttributes": 176,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -384,6 +384,16 @@ test('discussion round and sync diagnose render helpers cover active and empty s
         && fullHtml.includes('Lean sync mode')
         && fullHtml.includes('profileId column empty')
         && fullHtml.includes('notes(1/1/0)');
+      outcomes.syncDiagnoseRendererUsesDelegatedActions =
+        !/\son(?:click|change|input|keydown|submit)=["']/.test(fullHtml)
+        && fullHtml.includes('data-sync-diagnose-action="refresh-relay-storage"')
+        && fullHtml.includes('data-sync-diagnose-action="compact-relay"')
+        && fullHtml.includes('data-sync-diagnose-action="rotate-identity"')
+        && fullHtml.includes('data-sync-diagnose-action="reset-delta-telemetry"')
+        && fullHtml.includes('data-sync-diagnose-action="backfill-blockers"')
+        && fullHtml.includes('data-sync-diagnose-action="copy-snapshot"')
+        && fullHtml.includes('title="Push the pending items below first."')
+        && !fullHtml.includes('data-sync-diagnose-action="enable-phase2"');
 
       const emptyRowsHtml = syncRender.renderSyncDiagnoseModal({
         diagnostics: {

--- a/tests/playwright/chat-history-diagnose-browser-coverage.spec.js
+++ b/tests/playwright/chat-history-diagnose-browser-coverage.spec.js
@@ -264,6 +264,13 @@ test('sync diagnose browser coverage renders modal and copy fallbacks', async ({
         value,
       });
     };
+    const waitFor = async (predicate, label) => {
+      for (let attempt = 0; attempt < 60; attempt += 1) {
+        if (predicate()) return true;
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+      throw new Error(`Timed out waiting for ${label}`);
+    };
 
     try {
       localStorage.clear();
@@ -313,10 +320,20 @@ test('sync diagnose browser coverage renders modal and copy fallbacks', async ({
       outcomes.cutoverConfigFlowsIntoModal = overlay?.textContent.includes('Lean sync mode') === true
         && overlay.textContent.includes('ON') === true
         && overlay.textContent.includes('Disable') === true;
+      outcomes.modalUsesDelegatedDiagnoseActions =
+        !overlay.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onsubmit]')
+        && !!overlay.querySelector('[data-sync-diagnose-action="refresh-relay-storage"]')
+        && !!overlay.querySelector('[data-sync-diagnose-action="compact-relay"]')
+        && !!overlay.querySelector('[data-sync-diagnose-action="rotate-identity"]')
+        && !!overlay.querySelector('[data-sync-diagnose-action="disable-phase2"]')
+        && !!overlay.querySelector('[data-sync-diagnose-action="copy-snapshot"]')
+        && !overlay.querySelector('[data-sync-diagnose-action="enable-phase2"]')
+        && !overlay.querySelector('[data-sync-diagnose-action="reset-delta-telemetry"]');
 
       const copied = [];
       setClipboard({ writeText: async text => { copied.push(text); } });
-      await diagnoseUi.copySyncDiagnose(copyButton);
+      copyButton.click();
+      await waitFor(() => copied.length === 1, 'delegated diagnose copy');
       outcomes.clipboardCopyUsesOverlayText = copied[0] === overlay.dataset.copyText
         && copyButton.textContent === 'Copied';
 

--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -359,15 +359,33 @@ test('sync indicator popover renders debug actions and copies activity', async (
     const saved = {
       debug: localStorage.getItem('labcharts-debug'),
       clipboardOwn: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
+      syncNow: window.syncNow,
+      forceResendCurrentProfile: window.forceResendCurrentProfile,
+      cleanStorage: window.cleanStorage,
+      checkRelayConnection: window.checkRelayConnection,
+      showSyncDiagnose: window.showSyncDiagnose,
+      openSettingsModal: window.openSettingsModal,
     };
     let enabled = false;
     const slot = document.getElementById('sync-indicator-slot') || document.createElement('div');
+    const actionCalls = [];
 
     try {
+      window.syncNow = () => { actionCalls.push('sync-now'); };
+      window.forceResendCurrentProfile = () => { actionCalls.push('force-resend'); };
+      window.cleanStorage = async () => { actionCalls.push('clean-storage'); };
+      window.checkRelayConnection = async () => {
+        actionCalls.push('test-relay');
+        return true;
+      };
+      window.showSyncDiagnose = () => { actionCalls.push('diagnose'); };
+      window.openSettingsModal = tab => { actionCalls.push(`settings:${tab}`); };
+
       slot.id = 'sync-indicator-slot';
       if (!slot.parentNode) document.body.appendChild(slot);
       localStorage.setItem('labcharts-debug', 'true');
       syncState.resetSyncStatus();
+      syncUi.initSyncUIDelegates();
 
       slot.innerHTML = '<span>stale</span>';
       syncUi.renderSyncIndicator();
@@ -402,6 +420,14 @@ test('sync indicator popover renders debug actions and copies activity', async (
         && popover?.textContent.includes('Force resend') === true
         && popover?.textContent.includes('Reload') === true
         && popover?.textContent.includes('Diagnose') === true;
+      outcomes.popoverUsesDelegatedActions =
+        !popover.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onsubmit]')
+        && !!popover.querySelector('[data-sync-ui-action="copy-events"]')
+        && !!popover.querySelector('[data-sync-ui-action="sync-now"]')
+        && !!popover.querySelector('[data-sync-ui-action="force-resend"]')
+        && !!popover.querySelector('[data-sync-ui-action="clean-storage"]')
+        && !!popover.querySelector('[data-sync-ui-action="test-relay"]')
+        && !!popover.querySelector('[data-sync-ui-action="show-diagnose"]');
 
       Object.defineProperty(navigator, 'clipboard', {
         configurable: true,
@@ -409,7 +435,7 @@ test('sync indicator popover renders debug actions and copies activity', async (
       });
       const copyBtn = popover.querySelector('button[title="Copy events to clipboard"]');
       if (!copyBtn) throw new Error('sync activity copy button did not render');
-      await syncUi.copySyncEvents(copyBtn);
+      copyBtn.click();
       await waitFor(() => copied.length === 1, 'clipboard write');
       outcomes.copySyncEventsUsesClipboard = copied[0].includes('Sync activity')
         && copied[0].includes('profile abc pushed')
@@ -422,6 +448,47 @@ test('sync indicator popover renders debug actions and copies activity', async (
           .some(toast => toast.textContent.includes('Auto-copy blocked'));
       document.querySelector('textarea')?.dispatchEvent(new Event('blur'));
 
+      const clickPopoverAction = async action => {
+        const btn = document.querySelector(`#sync-popover [data-sync-ui-action="${action}"]`);
+        if (!btn) throw new Error(`missing sync popover action: ${action}`);
+        btn.click();
+        await Promise.resolve();
+      };
+      await clickPopoverAction('test-relay');
+      await waitFor(() => actionCalls.includes('test-relay'), 'test-relay delegate');
+      await waitFor(
+        () => Array.from(document.querySelectorAll('.notification-toast'))
+          .some(toast => toast.textContent.includes('Relay reachable')),
+        'test-relay success notification'
+      );
+      window.checkRelayConnection = async () => {
+        actionCalls.push('test-relay-error');
+        throw new Error('relay offline');
+      };
+      await clickPopoverAction('test-relay');
+      await waitFor(
+        () => Array.from(document.querySelectorAll('.notification-toast.error'))
+          .some(toast => toast.textContent.includes('Relay check failed: relay offline')),
+        'test-relay error notification'
+      );
+      await clickPopoverAction('show-diagnose');
+      await waitFor(() => actionCalls.includes('diagnose'), 'diagnose delegate');
+      await clickPopoverAction('open-settings');
+      await waitFor(() => !document.getElementById('sync-popover'), 'settings delegate closes popover');
+      syncUi.toggleSyncDetail();
+      await clickPopoverAction('sync-now');
+      await waitFor(() => actionCalls.includes('sync-now') && !document.getElementById('sync-popover'), 'sync-now delegate');
+      syncUi.toggleSyncDetail();
+      await clickPopoverAction('force-resend');
+      await waitFor(() => actionCalls.includes('force-resend') && !document.getElementById('sync-popover'), 'force-resend delegate');
+      syncUi.toggleSyncDetail();
+      await clickPopoverAction('clean-storage');
+      await waitFor(() => actionCalls.includes('clean-storage') && !document.getElementById('sync-popover'), 'clean-storage delegate');
+      outcomes.popoverDelegatesRouteActions = ['test-relay', 'diagnose', 'settings:data', 'sync-now', 'force-resend', 'clean-storage']
+        .every(action => actionCalls.includes(action));
+      outcomes.popoverRelayDelegateSurfacesErrors = actionCalls.includes('test-relay-error');
+
+      syncUi.toggleSyncDetail();
       syncUi.toggleSyncDetail();
       outcomes.secondToggleClosesPopover = !document.getElementById('sync-popover');
 
@@ -454,6 +521,12 @@ test('sync indicator popover renders debug actions and copies activity', async (
       else localStorage.setItem('labcharts-debug', saved.debug);
       if (saved.clipboardOwn) Object.defineProperty(navigator, 'clipboard', saved.clipboardOwn);
       else delete navigator.clipboard;
+      window.syncNow = saved.syncNow;
+      window.forceResendCurrentProfile = saved.forceResendCurrentProfile;
+      window.cleanStorage = saved.cleanStorage;
+      window.checkRelayConnection = saved.checkRelayConnection;
+      window.showSyncDiagnose = saved.showSyncDiagnose;
+      window.openSettingsModal = saved.openSettingsModal;
       document.getElementById('sync-popover')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       document.querySelectorAll('.notification-container').forEach(el => el.remove());

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -446,10 +446,13 @@ await import('../js/settings.js');
     serviceWorkerSrc.includes("'/js/sync-diagnose-ui.js'"));
   assert('sync-diagnose-render.js owns Sync Diagnose panel markup',
     syncDiagnoseRenderSrc.includes('export function renderSyncDiagnoseModal')
+      && syncDiagnoseRenderSrc.includes('export function syncDiagnoseActionAttrs')
+      && syncDiagnoseRenderSrc.includes('data-sync-diagnose-action')
       && syncDiagnoseRenderSrc.includes('function renderRelayHealthPanel')
       && syncDiagnoseRenderSrc.includes('function renderRelayStoragePanel')
       && syncDiagnoseRenderSrc.includes('function renderDeltaTelemetryPanel')
-      && syncDiagnoseRenderSrc.includes('function renderCutoverPanel'));
+      && syncDiagnoseRenderSrc.includes('function renderCutoverPanel')
+      && !/\son(?:click|change|input|keydown|submit)=["']/.test(syncDiagnoseRenderSrc));
   assert('service worker precaches sync-diagnose-render.js',
     serviceWorkerSrc.includes("'/js/sync-diagnose-render.js'"));
   assert('sync-diagnose-actions.js is the Sync Diagnose action facade',
@@ -782,11 +785,17 @@ await import('../js/settings.js');
   assert('sync-ui.js owns header sync status UI helpers',
     syncSrc.includes("from './sync-ui.js'")
       && syncUiSrc.includes('export function configureSyncUI')
+      && syncUiSrc.includes('export function syncUiActionAttrs')
+      && syncUiSrc.includes('export function initSyncUIDelegates')
       && syncUiSrc.includes('export function bindSyncUIStatusUpdates')
       && syncUiSrc.includes('export function renderSyncIndicator')
       && syncUiSrc.includes('export function updateSyncIndicator')
       && syncUiSrc.includes('export function toggleSyncDetail')
       && syncUiSrc.includes('export async function copySyncEvents')
+      && syncUiSrc.includes('data-sync-ui-action')
+      && syncConfigureSrc.includes('initSyncUIDelegates();')
+      && !syncUiSrc.includes('\ninitSyncUIDelegates();')
+      && !/\son(?:click|change|input|keydown|submit)=["']/.test(syncUiSrc)
       && exportBlockIncludes(syncSrc, ['renderSyncIndicator', 'updateSyncIndicator', 'toggleSyncDetail', 'copySyncEvents']));
   assert('service worker precaches sync-ui.js',
     serviceWorkerSrc.includes("'/js/sync-ui.js'"));
@@ -988,9 +997,13 @@ await import('../js/settings.js');
   // without SSH access. Refresh probes /self/owner-storage to replace
   // the local estimate with the relay's authoritative value.
   assert('Sync diagnose modal wires the self-serve Compact storage button',
-    /confirmCompactRelay\(this\)/.test(syncDiagnoseRenderSrc));
+    syncDiagnoseRenderSrc.includes("syncDiagnoseActionAttrs('compact-relay')")
+      && syncDiagnoseUiSrc.includes("action === 'compact-relay'")
+      && syncDiagnoseUiSrc.includes('confirmCompactRelay(actionEl)'));
   assert('Sync diagnose modal wires the Refresh-from-relay button',
-    /refreshRelayStorage\(this\)/.test(syncDiagnoseRenderSrc));
+    syncDiagnoseRenderSrc.includes("syncDiagnoseActionAttrs('refresh-relay-storage')")
+      && syncDiagnoseUiSrc.includes("action === 'refresh-relay-storage'")
+      && syncDiagnoseUiSrc.includes('refreshRelayStorage(actionEl)'));
   assert('Sync diagnose relay health is described as local outbound health',
     syncDiagnoseRenderSrc.includes('device pushed')
       && syncDiagnoseRenderSrc.includes('This verdict is local/outbound')
@@ -2139,7 +2152,7 @@ await import('../js/settings.js');
   assert('confirmEnablePhase2 re-checks readiness as defence-in-depth',
     /confirmEnablePhase2[\s\S]{0,400}getDeltaCutoverReadiness\(state\.currentProfile\)[\s\S]{0,200}!r\?\.ready/.test(deltaSearchSrc));
   assert('Cutover modal button gated when not ready (disabled attribute)',
-    /confirmEnablePhase2\(this\)[\s\S]{0,300}disabled/.test(syncDiagnoseRenderSrc));
+    /syncDiagnoseActionAttrs\('enable-phase2'\)[\s\S]{0,320}disabled/.test(syncDiagnoseRenderSrc));
   assert('Cutover modal shows lean-mode ON badge when enabled',
     /cutoverBadge\s*=\s*cutoverEnabled[\s\S]{0,400}>ON</.test(deltaSearchSrc));
   assert('Cutover handlers exposed on window',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.506';
+self.APP_VERSION = '1.8.507';


### PR DESCRIPTION
## Summary
- Replace sync popover inline handlers with delegated data-action buttons.
- Replace Sync Diagnose inline handlers with delegated modal actions.
- Add runtime and static coverage for delegated sync popover and diagnose buttons.
- Lower inline event baseline from 193 to 176 and bump version to 1.8.507.

## Validation
- npm run quality
- npm run typecheck
- node tests/test-sync.js
- npx playwright test tests/playwright/sync-actions-browser-coverage.spec.js tests/playwright/chat-history-diagnose-browser-coverage.spec.js tests/playwright/browser-coverage-batch.spec.js
- npm test
- git diff --check
- ./run-tests.sh