### PR TITLE
[codex] Delegate provider panel actions

### DIFF
--- a/js/provider-panel-delegates.js
+++ b/js/provider-panel-delegates.js
@@ -19,6 +19,18 @@ const CLICK_ACTIONS = Object.freeze({
   'create-ppq-account': 'handleCreatePpqAccount',
   'save-ppq-key': 'handleSavePpqKey',
   'remove-ppq-key': 'handleRemovePpqKey',
+  'copy-ppq-key-reveal': 'copyPpqKeyReveal',
+  'dismiss-ppq-key-reveal': 'dismissPpqKeyReveal',
+  'select-ppq-method': 'handleSelectPpqMethod',
+  'ppq-topup-preset': 'handlePpqTopupPreset',
+  'show-ppq-custom-input': 'ppqShowCustomInput',
+  'copy-ppq-payment': 'copyPpqPayment',
+  'cancel-ppq-topup': 'cancelPpqTopup',
+  'recover-pending-deposit': 'recoverPendingDeposit',
+  'recover-pending-withdraw': 'recoverPendingWithdraw',
+  'copy-provider-panel-clipboard': 'copyProviderPanelClipboard',
+  'select-provider-panel-text': 'selectProviderPanelText',
+  'acknowledge-routstr-key': 'acknowledgeRoutstrKey',
   'apply-custom-api-model': 'applyCustomApiManualModel',
   'save-custom-api': 'handleSaveCustomApi',
   'remove-custom-api': 'handleRemoveCustomApi',
@@ -81,7 +93,7 @@ function _handleProviderPanelClick(event) {
 
   if (!callbackName) return _warnProviderPanelDelegate(`Unknown provider panel click action: ${action}`);
   if (el.matches('a, button')) event.preventDefault();
-  return _call(callbackName);
+  return _call(callbackName, el);
 }
 
 function _handleProviderPanelChange(event) {

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -50,12 +50,16 @@ import {
   cancelPpqTopup,
   clearPpqTopupTimers,
   configurePpqPanels,
+  copyPpqKeyReveal,
+  copyPpqPayment,
   dismissPpqKeyReveal,
   doPpqTopup,
   doPpqTopupCustom,
+  handlePpqTopupPreset,
   handleCreatePpqAccount,
   handleRemovePpqKey,
   handleSavePpqKey,
+  handleSelectPpqMethod,
   initSettingsPpqPanel,
   ppqShowCustomInput,
   refreshPpqBalance,
@@ -246,10 +250,10 @@ export function initSettingsModelFetch() {
         area.innerHTML = '<div style="margin-top:8px;padding:8px;background:rgba(255,160,0,0.1);border:1px solid var(--yellow, #f0a800);border-radius:6px">' +
           '<div style="font-size:11px;color:var(--yellow, #f0a800);margin-bottom:4px">\u26a0 Pending deposit recovery</div>' +
           '<div style="font-size:10px;color:var(--text-muted);margin-bottom:6px">A previous node deposit failed. Your sats are safe in this token:</div>' +
-          '<textarea class="api-key-input" style="font-size:10px;font-family:monospace;height:40px;resize:none;user-select:all" readonly onclick="this.select()">' + escapeHTML(token) + '</textarea>' +
+          '<textarea class="api-key-input" style="font-size:10px;font-family:monospace;height:40px;resize:none;user-select:all" readonly data-provider-panel-action="select-provider-panel-text">' + escapeHTML(token) + '</textarea>' +
           '<div style="display:flex;gap:4px;margin-top:4px">' +
-          '<button class="import-btn import-btn-primary" style="font-size:11px;padding:3px 10px;flex:1" onclick="cashuImportWallet(document.querySelector(\'#routstr-wallet-fund-area textarea\').value).then(()=>{cashuClearPendingDeposit();showNotification(\'Recovered!\',\'success\');location.reload()}).catch(e=>showNotification(e.message,\'error\'))">Recover to Wallet</button>' +
-          '<button class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 10px" data-token="' + escapeAttr(token) + '" onclick="navigator.clipboard.writeText(this.dataset.token);this.textContent=\'\u2713 Copied\'">Copy Token</button>' +
+          '<button class="import-btn import-btn-primary" style="font-size:11px;padding:3px 10px;flex:1" data-provider-panel-action="recover-pending-deposit" data-token="' + escapeAttr(token) + '">Recover to Wallet</button>' +
+          '<button class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 10px" data-provider-panel-action="copy-provider-panel-clipboard" data-clipboard-text="' + escapeAttr(token) + '" data-copied-text="\u2713 Copied">Copy Token</button>' +
           '</div></div>';
       }
     });
@@ -262,10 +266,10 @@ export function initSettingsModelFetch() {
       area.innerHTML = '<div style="margin-top:8px;padding:8px;background:rgba(255,160,0,0.1);border:1px solid var(--yellow, #f0a800);border-radius:6px">' +
         '<div style="font-size:11px;color:var(--yellow, #f0a800);margin-bottom:4px">\u26a0 Pending withdraw recovery</div>' +
         '<div style="font-size:10px;color:var(--text-muted);margin-bottom:6px">A previous Lightning withdrawal failed mid-operation. Your sats are safe in this token:</div>' +
-        '<textarea class="api-key-input" style="font-size:10px;font-family:monospace;height:40px;resize:none;user-select:all" readonly onclick="this.select()">' + escapeHTML(token) + '</textarea>' +
+        '<textarea class="api-key-input" style="font-size:10px;font-family:monospace;height:40px;resize:none;user-select:all" readonly data-provider-panel-action="select-provider-panel-text">' + escapeHTML(token) + '</textarea>' +
         '<div style="display:flex;gap:4px;margin-top:4px">' +
-        '<button class="import-btn import-btn-primary" style="font-size:11px;padding:3px 10px;flex:1" onclick="cashuImportWallet(document.querySelector(\'#routstr-wallet-fund-area textarea\').value).then(()=>{cashuClearPendingWithdraw();showNotification(\'Recovered!\',\'success\');location.reload()}).catch(e=>showNotification(e.message,\'error\'))">Recover to Wallet</button>' +
-        '<button class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 10px" onclick="navigator.clipboard.writeText(document.querySelector(\'#routstr-wallet-fund-area textarea\').value);this.textContent=\'\u2713 Copied\'">Copy Token</button>' +
+        '<button class="import-btn import-btn-primary" style="font-size:11px;padding:3px 10px;flex:1" data-provider-panel-action="recover-pending-withdraw" data-token="' + escapeAttr(token) + '">Recover to Wallet</button>' +
+        '<button class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 10px" data-provider-panel-action="copy-provider-panel-clipboard" data-clipboard-text="' + escapeAttr(token) + '" data-copied-text="\u2713 Copied">Copy Token</button>' +
         '</div></div>';
     });
   }
@@ -289,6 +293,74 @@ function _returnToChatIfOnboarding() {
   if (!window.hasAIProvider?.()) return;
   window.closeSettingsModal?.();
   setTimeout(() => window.openChatPanel?.(), 300);
+}
+
+function _setActionText(actionEl) {
+  if (actionEl instanceof HTMLElement) {
+    actionEl.textContent = actionEl.dataset.copiedText || '✓ Copied';
+  }
+}
+
+function _clipboardTextFromAction(actionEl) {
+  return actionEl?.dataset?.clipboardText || actionEl?.dataset?.token || '';
+}
+
+async function _copyProviderPanelText(text, actionEl) {
+  if (!text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    _setActionText(actionEl);
+    const timerKey = actionEl?.dataset?.clearTimerKey || '';
+    const clearMs = Number(actionEl?.dataset?.clearClipboardAfter || 0);
+    if (timerKey && clearMs > 0) {
+      const appWindow = /** @type {any} */ (window);
+      clearTimeout(appWindow[timerKey]);
+      appWindow[timerKey] = setTimeout(() => navigator.clipboard?.writeText?.(''), clearMs);
+    }
+  } catch (e) {
+    showNotification(`Copy failed: ${e?.message || e}`, 'error');
+  }
+}
+
+export function copyProviderPanelClipboard(actionEl) {
+  void _copyProviderPanelText(_clipboardTextFromAction(actionEl), actionEl);
+}
+
+export function selectProviderPanelText(actionEl) {
+  if (typeof actionEl?.select === 'function') actionEl.select();
+}
+
+async function _recoverPendingToken(actionEl, clearName) {
+  const appWindow = /** @type {any} */ (window);
+  const fallbackInput = /** @type {HTMLTextAreaElement | null} */ (
+    document.querySelector('#routstr-wallet-fund-area textarea')
+  );
+  const token = actionEl?.dataset?.token || fallbackInput?.value || '';
+  try {
+    if (typeof appWindow.cashuImportWallet !== 'function' || typeof appWindow[clearName] !== 'function') {
+      throw new Error('Wallet recovery is unavailable');
+    }
+    await appWindow.cashuImportWallet(token);
+    await appWindow[clearName]();
+    showNotification('Recovered!', 'success');
+    window.location.reload();
+  } catch (e) {
+    showNotification(e?.message || String(e), 'error');
+  }
+}
+
+export function recoverPendingDeposit(actionEl) {
+  void _recoverPendingToken(actionEl, 'cashuClearPendingDeposit');
+}
+
+export function recoverPendingWithdraw(actionEl) {
+  void _recoverPendingToken(actionEl, 'cashuClearPendingWithdraw');
+}
+
+export function acknowledgeRoutstrKey() {
+  const panel = document.getElementById('ai-provider-panel');
+  if (panel) panel.innerHTML = renderAIProviderPanel('routstr');
+  initSettingsModelFetch();
 }
 
 // ═══════════════════════════════════════════════
@@ -489,8 +561,8 @@ export async function handleSaveRoutstrKey() {
             <label style="font-size:11px;color:var(--text-muted)">Session Key</label>
             <div style="font-family:monospace;font-size:11px;word-break:break-all;background:var(--bg-primary);padding:8px;border-radius:6px;border:1px solid var(--border);color:var(--text-primary);user-select:all;cursor:text">${escapeHTML(finalKey)}</div>
             <div style="display:flex;gap:8px;margin-top:8px">
-              <button class="import-btn import-btn-primary" style="font-size:12px" onclick="navigator.clipboard.writeText('${escapeAttr(finalKey)}');this.textContent='\u2713 Copied (clears in 60s)';clearTimeout(window._rsClipTimer);window._rsClipTimer=setTimeout(()=>navigator.clipboard.writeText(''),60000)">Copy Key</button>
-              <button class="import-btn import-btn-secondary" style="font-size:12px" onclick="var p=document.getElementById('ai-provider-panel');if(p)p.innerHTML=renderAIProviderPanel('routstr');initSettingsModelFetch()">I\u2019ve saved it</button>
+              <button class="import-btn import-btn-primary" style="font-size:12px" data-provider-panel-action="copy-provider-panel-clipboard" data-clipboard-text="${escapeAttr(finalKey)}" data-copied-text="\u2713 Copied (clears in 60s)" data-clear-timer-key="_rsClipTimer" data-clear-clipboard-after="60000">Copy Key</button>
+              <button class="import-btn import-btn-secondary" style="font-size:12px" data-provider-panel-action="acknowledge-routstr-key">I\u2019ve saved it</button>
             </div>
           </div>
         </div>`;
@@ -588,6 +660,18 @@ installProviderPanelDelegates({
   handleCreatePpqAccount,
   handleSavePpqKey,
   handleRemovePpqKey,
+  copyPpqKeyReveal,
+  dismissPpqKeyReveal,
+  handleSelectPpqMethod,
+  handlePpqTopupPreset,
+  ppqShowCustomInput,
+  copyPpqPayment,
+  cancelPpqTopup,
+  recoverPendingDeposit,
+  recoverPendingWithdraw,
+  copyProviderPanelClipboard,
+  selectProviderPanelText,
+  acknowledgeRoutstrKey,
   applyCustomApiManualModel,
   handleSaveCustomApi,
   handleRemoveCustomApi,

--- a/js/provider-ppq-panels.js
+++ b/js/provider-ppq-panels.js
@@ -34,6 +34,48 @@ export function clearPpqTopupTimers() {
   if (_ppqCountdownTimer) { clearInterval(_ppqCountdownTimer); _ppqCountdownTimer = null; }
 }
 
+function _setCopiedText(actionEl, fallback = '✓ Copied') {
+  if (actionEl instanceof HTMLElement) {
+    actionEl.textContent = actionEl.dataset.copiedText || fallback;
+  }
+}
+
+async function _copyPanelText(text, actionEl) {
+  if (!text) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    _setCopiedText(actionEl);
+    return true;
+  } catch (e) {
+    showNotification(`Copy failed: ${e?.message || e}`, 'error');
+    return false;
+  }
+}
+
+export function copyPpqKeyReveal(actionEl) {
+  const text = actionEl?.dataset?.clipboardText || '';
+  const appWindow = /** @type {any} */ (window);
+  void _copyPanelText(text, actionEl).then((copied) => {
+    if (!copied) return;
+    clearTimeout(appWindow._ppqClipTimer);
+    appWindow._ppqClipTimer = setTimeout(() => navigator.clipboard?.writeText?.(''), 60000);
+  });
+}
+
+export function handleSelectPpqMethod(actionEl) {
+  const methodId = actionEl?.dataset?.ppqMethod || '';
+  if (methodId) selectPpqMethod(methodId);
+}
+
+export function handlePpqTopupPreset(actionEl) {
+  const amount = Number(actionEl?.dataset?.amount);
+  if (Number.isFinite(amount)) void doPpqTopup(amount);
+}
+
+export function copyPpqPayment(actionEl) {
+  void _copyPanelText(actionEl?.dataset?.clipboardText || '', actionEl);
+}
+
 function _ppqBalanceHtml(balance) {
   const v = parseFloat(balance);
   const color = v < 0.10 ? 'var(--red)' : v < 0.50 ? 'var(--yellow, #f0a800)' : 'var(--green)';
@@ -58,7 +100,7 @@ export function initSettingsPpqPanel() {
 export async function handleCreatePpqAccount() {
   if (_ppqCreating) return;
   _ppqCreating = true;
-  const createBtn = /** @type {HTMLButtonElement | null} */ (document.querySelector('[onclick="handleCreatePpqAccount()"]'));
+  const createBtn = /** @type {HTMLButtonElement | null} */ (document.querySelector('[data-provider-panel-action="create-ppq-account"]'));
   if (createBtn) { createBtn.disabled = true; createBtn.textContent = 'Creating\u2026'; }
   const status = document.getElementById('ppq-key-status');
   if (status) status.innerHTML = '<span style="color:var(--text-muted)">Creating account\u2026</span>';
@@ -79,8 +121,8 @@ export async function handleCreatePpqAccount() {
           <label style="font-size:11px;color:var(--text-muted);margin-top:8px;display:block">Credit ID <span style="font-size:10px">(enter at <a href="https://ppq.ai/invite/8f3017cd" target="_blank" rel="noopener" style="color:var(--accent)">ppq.ai</a> to access your account on the web)</span></label>
           <div style="font-family:monospace;font-size:11px;word-break:break-all;background:var(--bg-primary);padding:8px;border-radius:6px;border:1px solid var(--border);color:var(--text-primary);user-select:all;cursor:text">${escapeHTML(result.credit_id)}</div>
           <div style="display:flex;gap:8px;margin-top:8px">
-            <button class="import-btn import-btn-primary" style="font-size:12px" onclick="navigator.clipboard.writeText('API Key: ${escapeAttr(result.api_key)}\\nCredit ID: ${escapeAttr(result.credit_id)}');this.textContent='\u2713 Copied (clears in 60s)';clearTimeout(window._ppqClipTimer);window._ppqClipTimer=setTimeout(()=>navigator.clipboard.writeText(''),60000)">Copy Both</button>
-            <button class="import-btn import-btn-secondary" style="font-size:12px" onclick="dismissPpqKeyReveal()">I\u2019ve saved it</button>
+            <button class="import-btn import-btn-primary" style="font-size:12px" data-provider-panel-action="copy-ppq-key-reveal" data-clipboard-text="API Key: ${escapeAttr(result.api_key)}&#10;Credit ID: ${escapeAttr(result.credit_id)}" data-copied-text="\u2713 Copied (clears in 60s)">Copy Both</button>
+            <button class="import-btn import-btn-secondary" style="font-size:12px" data-provider-panel-action="dismiss-ppq-key-reveal">I\u2019ve saved it</button>
           </div>
         </div>
       </div>`;
@@ -177,7 +219,7 @@ const PPQ_METHODS = [
 let _ppqSelectedMethod = 'btc-lightning';
 
 function _ppqMethodBtn(m, active) {
-  return `<button class="${active ? 'ppq-method-btn active' : 'ppq-method-btn'}" onclick="selectPpqMethod('${m.id}')"><span class="ppq-method-icon">${m.svg}</span><span class="ppq-method-label">${m.label}</span></button>`;
+  return `<button class="${active ? 'ppq-method-btn active' : 'ppq-method-btn'}" data-provider-panel-action="select-ppq-method" data-ppq-method="${escapeAttr(m.id)}"><span class="ppq-method-icon">${m.svg}</span><span class="ppq-method-label">${m.label}</span></button>`;
 }
 
 export function showPpqTopup() {
@@ -215,8 +257,8 @@ function _renderPpqTopupPicker(area) {
   area.innerHTML = `<div style="margin-top:8px;padding:12px;background:var(--bg-secondary);border-radius:10px;border:1px solid var(--border)">
     <div style="display:flex;gap:6px;margin-bottom:10px">${PPQ_METHODS.map(function(m) { return _ppqMethodBtn(m, m.id === _ppqSelectedMethod); }).join('')}</div>
     <div style="display:flex;gap:6px">${method.amounts.map(function(v) {
-      return '<button class="ppq-amt-btn" onclick="doPpqTopup(' + v + ')">$' + v + '</button>';
-    }).join('')}<div id="ppq-custom-slot" style="flex:1;display:flex"><button class="ppq-amt-btn" style="width:100%;color:var(--text-muted)" onclick="ppqShowCustomInput()">$\u2026</button></div></div>
+      return '<button class="ppq-amt-btn" data-provider-panel-action="ppq-topup-preset" data-amount="' + v + '">$' + v + '</button>';
+    }).join('')}<div id="ppq-custom-slot" style="flex:1;display:flex"><button class="ppq-amt-btn" style="width:100%;color:var(--text-muted)" data-provider-panel-action="show-ppq-custom-input">$\u2026</button></div></div>
     <div style="font-size:10px;color:var(--text-muted);margin-top:5px;text-align:center">$2 is enough for onboarding, a few imports, and chats \u00b7 min $${method.min}</div>
   </div>`;
 }
@@ -230,9 +272,23 @@ export function selectPpqMethod(methodId) {
 export function ppqShowCustomInput() {
   const slot = document.getElementById('ppq-custom-slot');
   if (!slot) return;
-  slot.innerHTML = '<input type="text" inputmode="decimal" id="ppq-custom-amount" class="ppq-amt-btn" style="width:100%;text-align:center;cursor:text" placeholder="$" onkeydown="if(event.key===\'Enter\')doPpqTopupCustom();if(event.key===\'Escape\')selectPpqMethod(\'' + _ppqSelectedMethod + '\')" onblur="if(this.value.trim())doPpqTopupCustom()">';
+  slot.innerHTML = '<input type="text" inputmode="decimal" id="ppq-custom-amount" class="ppq-amt-btn" style="width:100%;text-align:center;cursor:text" placeholder="$">';
   const input = /** @type {HTMLInputElement | null} */ (document.getElementById('ppq-custom-amount'));
-  if (input) input.focus();
+  if (input) {
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        doPpqTopupCustom();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        selectPpqMethod(_ppqSelectedMethod);
+      }
+    });
+    input.addEventListener('blur', () => {
+      if (input.value.trim()) doPpqTopupCustom();
+    });
+    input.focus();
+  }
 }
 
 export function doPpqTopupCustom() {
@@ -282,9 +338,9 @@ export async function doPpqTopup(amount) {
           <div style="font-size:12px;font-weight:600;color:var(--text-primary);margin-bottom:2px;display:flex;align-items:center;gap:4px"><span style="width:16px;height:16px;display:inline-block">${method.svg}</span> ${method.label} \u2014 $${parseFloat(amount).toFixed(2)}</div>
           ${cryptoHint}
           <div style="display:flex;flex-direction:column;gap:4px;margin-top:6px">
-            <button class="import-btn import-btn-primary" style="font-size:11px;padding:4px 10px" onclick="navigator.clipboard.writeText('${escapeAttr(payString)}');this.textContent='\u2713 Copied!'">${copyLabel}</button>
+            <button class="import-btn import-btn-primary" style="font-size:11px;padding:4px 10px" data-provider-panel-action="copy-ppq-payment" data-clipboard-text="${escapeAttr(payString)}" data-copied-text="\u2713 Copied!">${copyLabel}</button>
             <a href="${walletUri}" class="import-btn import-btn-secondary" style="font-size:11px;padding:4px 10px;text-decoration:none;text-align:center">Open in Wallet</a>
-            <button class="import-btn import-btn-secondary" style="font-size:11px;padding:4px 10px" onclick="cancelPpqTopup()">Cancel</button>
+            <button class="import-btn import-btn-secondary" style="font-size:11px;padding:4px 10px" data-provider-panel-action="cancel-ppq-topup">Cancel</button>
           </div>
           <div id="ppq-topup-status" style="margin-top:6px;font-size:11px;color:var(--text-muted);display:flex;align-items:center;gap:5px"><span id="ppq-topup-dot" style="width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block;animation:ppq-pulse 1.5s ease-in-out infinite"></span> <span id="ppq-topup-countdown"></span></div>
         </div>

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 176,
+  "inlineEventAttributes": 159,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -621,6 +621,7 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
 
   const results = await page.evaluate(async ({ ppqUrl }) => {
     const ppq = await import(ppqUrl);
+    const delegates = await import('/js/provider-panel-delegates.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -642,8 +643,10 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
       setInterval: window.setInterval,
       clearInterval: window.clearInterval,
       openSettingsModal: window.openSettingsModal,
+      clipboard: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
     };
     const intervals = [];
+    const copied = [];
     let nextIntervalId = 1;
     let returnToChatCount = 0;
     let settingsOpened = 0;
@@ -689,10 +692,23 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
         if (href.includes('/topup/status/invoice-expired')) return jsonResponse({ status: 'expired' });
         return oldGlobals.fetch.call(window, url);
       };
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText: async text => { copied.push(String(text || '')); } },
+      });
+      delegates.installProviderPanelDelegates({
+        copyPpqKeyReveal: ppq.copyPpqKeyReveal,
+        dismissPpqKeyReveal: ppq.dismissPpqKeyReveal,
+        handleSelectPpqMethod: ppq.handleSelectPpqMethod,
+        handlePpqTopupPreset: ppq.handlePpqTopupPreset,
+        ppqShowCustomInput: ppq.ppqShowCustomInput,
+        copyPpqPayment: ppq.copyPpqPayment,
+        cancelPpqTopup: ppq.cancelPpqTopup,
+      });
 
       document.body.insertAdjacentHTML('beforeend', `
         <div id="ai-provider-panel">
-          <button onclick="handleCreatePpqAccount()">Create Account (instant, no signup)</button>
+          <button data-provider-panel-action="create-ppq-account">Create Account (instant, no signup)</button>
           <div id="ppq-key-status"></div>
         </div>
       `);
@@ -736,24 +752,35 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
       });
 
       panel.innerHTML = `
-        <button onclick="handleCreatePpqAccount()">Create Account (instant, no signup)</button>
+        <button data-provider-panel-action="create-ppq-account">Create Account (instant, no signup)</button>
         <div id="ppq-key-status"></div>
       `;
 
       await ppq.handleCreatePpqAccount();
-      const accountReveal = document.getElementById('ai-provider-panel')?.textContent.includes('Save your account details')
-        && document.getElementById('ai-provider-panel')?.textContent.includes('credit-123');
-      ppq.dismissPpqKeyReveal();
+      const revealPanel = document.getElementById('ai-provider-panel');
+      const accountReveal = revealPanel?.textContent.includes('Save your account details')
+        && revealPanel?.textContent.includes('credit-123')
+        && !revealPanel.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onblur],[onsubmit]')
+        && !!revealPanel.querySelector('[data-provider-panel-action="copy-ppq-key-reveal"]')
+        && !!revealPanel.querySelector('[data-provider-panel-action="dismiss-ppq-key-reveal"]');
+      revealPanel.querySelector('[data-provider-panel-action="copy-ppq-key-reveal"]')?.click();
+      await wait(0);
+      const accountRevealCopyDelegates = copied.some(text => text.includes('API Key: sk-created') && text.includes('Credit ID: credit-123'))
+        && revealPanel.querySelector('[data-provider-panel-action="copy-ppq-key-reveal"]')?.textContent.includes('Copied');
+      revealPanel.querySelector('[data-provider-panel-action="dismiss-ppq-key-reveal"]')?.click();
+      await wait(0);
       await ppq.refreshPpqBalance();
       await wait(0);
       const dismissRerendersTopup = document.getElementById('ppq-topup-area')?.style.display === 'block'
         && document.getElementById('ppq-topup-toggle')?.textContent === 'Close'
         && document.getElementById('ppq-balance')?.textContent.includes('$1.25');
 
-      ppq.selectPpqMethod('xmr');
+      document.querySelector('[data-provider-panel-action="select-ppq-method"][data-ppq-method="xmr"]')?.click();
+      await wait(0);
       const methodSelected = document.querySelector('.ppq-method-btn.active .ppq-method-label')?.textContent === 'Monero'
         && (document.getElementById('ppq-topup-area')?.textContent || '').includes('min $5');
-      ppq.ppqShowCustomInput();
+      document.querySelector('[data-provider-panel-action="show-ppq-custom-input"]')?.click();
+      await wait(0);
       const customInputRenders = !!document.getElementById('ppq-custom-amount');
       document.getElementById('ppq-custom-amount').value = '4';
       ppq.doPpqTopupCustom();
@@ -766,6 +793,13 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
       const invoiceRenders = (document.getElementById('ppq-topup-area')?.textContent || '').includes('Monero')
         && document.querySelector('#ppq-topup-area a[href^="monero:"]') !== null
         && (document.getElementById('ppq-topup-area')?.textContent || '').includes('Show address');
+      const topupArea = document.getElementById('ppq-topup-area');
+      const invoiceUsesDelegatedActions = !topupArea.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onblur],[onsubmit]')
+        && !!topupArea.querySelector('[data-provider-panel-action="copy-ppq-payment"]')
+        && !!topupArea.querySelector('[data-provider-panel-action="cancel-ppq-topup"]');
+      document.querySelector('#ppq-topup-area [data-provider-panel-action="copy-ppq-payment"]')?.click();
+      await wait(0);
+      const invoiceCopyDelegates = copied.includes('44AFFq5kSiGBoZ');
       const paidPoll = intervals.find(item => item.ms === 3000 && !item.cleared);
       const paidPollIntervalScheduled = !!paidPoll;
       if (paidPoll) await paidPoll.fn();
@@ -787,7 +821,8 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
       await ppq.doPpqTopup(2);
       const cancelPoll = [...intervals].reverse().find(item => item.ms === 3000 && !item.cleared);
       const cancelPollIntervalScheduled = !!cancelPoll;
-      ppq.cancelPpqTopup();
+      document.querySelector('#ppq-topup-area [data-provider-panel-action="cancel-ppq-topup"]')?.click();
+      await wait(0);
       const cancelHidesArea = document.getElementById('ppq-topup-area')?.style.display === 'none'
         && !!cancelPoll
         && intervals.find(item => item.id === cancelPoll.id)?.cleared === true;
@@ -796,11 +831,14 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
         defaultSaveUsesNoopReturnCallback,
         removePpqKeyClearsFundsWarningAndState,
         accountReveal,
+        accountRevealCopyDelegates,
         dismissRerendersTopup,
         methodSelected,
         customInputRenders,
         rejectsLowCustom,
         invoiceRenders,
+        invoiceUsesDelegatedActions,
+        invoiceCopyDelegates,
         paidPollIntervalScheduled,
         paidInvoiceUpdatesBalance,
         expiredPollIntervalScheduled,
@@ -816,6 +854,8 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
       window.setInterval = oldGlobals.setInterval;
       window.clearInterval = oldGlobals.clearInterval;
       window.openSettingsModal = oldGlobals.openSettingsModal;
+      if (oldGlobals.clipboard) Object.defineProperty(navigator, 'clipboard', oldGlobals.clipboard);
+      else delete navigator.clipboard;
       ppq.configurePpqPanels({ returnToChatIfOnboarding: () => {} });
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);

--- a/tests/test-ppq-provider.js
+++ b/tests/test-ppq-provider.js
@@ -28,6 +28,7 @@ const swSrc = read('service-worker.js');
 
 console.log('1. Extraction boundary');
 assert('PPQ panel module exists', ppqSrc.includes('provider-ppq-panels.js'));
+assert('PPQ panel module renders no inline event attributes', !/\bon(?:click|change|input|search|keydown|keyup|submit|blur)=/.test(ppqSrc));
 assert('provider-panels imports PPQ module', panelsSrc.includes("from './provider-ppq-panels.js'"));
 assert('provider-panels configures PPQ onboarding callback', panelsSrc.includes('configurePpqPanels({'));
 assert('provider-panels delegates PPQ init', panelsSrc.includes('initSettingsPpqPanel();'));

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -11,6 +11,7 @@ const renderSrc = fs.readFileSync(path.join(root, 'js/provider-panel-renderers.j
 const modelControlsSrc = fs.readFileSync(path.join(root, 'js/provider-model-controls.js'), 'utf8');
 const delegatesSrc = fs.readFileSync(path.join(root, 'js/provider-panel-delegates.js'), 'utf8');
 const panelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
+const ppqSrc = fs.readFileSync(path.join(root, 'js/provider-ppq-panels.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 
 let passed = 0;
@@ -33,6 +34,10 @@ assert('provider-panel-renderers.js renders no inline event attributes',
   !inlineHandlerRe.test(renderSrc));
 assert('provider-model-controls.js renders no inline event attributes',
   !inlineHandlerRe.test(modelControlsSrc));
+assert('provider-panels.js renders no inline event attributes',
+  !inlineHandlerRe.test(panelsSrc));
+assert('provider-ppq-panels.js renders no inline event attributes',
+  !inlineHandlerRe.test(ppqSrc));
 assert('provider panel renderers emit delegated action attributes',
   renderSrc.includes('data-provider-panel-action') &&
     renderSrc.includes('data-provider-panel-change') &&
@@ -85,6 +90,18 @@ assert('service worker precaches provider panel delegate module',
   'create-ppq-account',
   'save-ppq-key',
   'remove-ppq-key',
+  'copy-ppq-key-reveal',
+  'dismiss-ppq-key-reveal',
+  'select-ppq-method',
+  'ppq-topup-preset',
+  'show-ppq-custom-input',
+  'copy-ppq-payment',
+  'cancel-ppq-topup',
+  'recover-pending-deposit',
+  'recover-pending-withdraw',
+  'copy-provider-panel-clipboard',
+  'select-provider-panel-text',
+  'acknowledge-routstr-key',
   'apply-custom-api-model',
   'save-custom-api',
   'remove-custom-api',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.507';
+self.APP_VERSION = '1.8.508';


### PR DESCRIPTION
## Summary
- Replace remaining provider and PPQ transient inline handlers with provider panel delegated actions.
- Add delegated copy/recover/top-up wrappers for PPQ and Routstr recovery snippets.
- Add static and browser coverage for delegated provider panel actions.
- Lower inline event baseline from 176 to 159 and bump version to 1.8.508.

## Validation
- npm run quality
- npm run typecheck
- node tests/test-provider-panel-delegated-actions.js
- node tests/test-ppq-provider.js
- npx playwright test tests/playwright/provider-coverage-batch.spec.js tests/playwright/routstr-wallet-dom.spec.js
- npm test
- git diff --check
- ./run-tests.sh