### PR TITLE
[codex] Delegate light audit actions

### DIFF
--- a/js/light-env-actions.js
+++ b/js/light-env-actions.js
@@ -10,10 +10,16 @@ const PROPAGATION_STOPPING_CLICK_ACTIONS = new Set([
   'delete-screen-confirm',
   'toggle-room-expanded',
   'delete-room-confirm',
+  'toggle-audit-compare',
+  'save-audit',
+  'toggle-audit-history',
 ]);
 const PROPAGATION_STOPPING_KEYDOWN_ACTIONS = new Set([
   'toggle-screen-expanded',
   'toggle-room-expanded',
+]);
+const NON_CLICK_ACTIONS = new Set([
+  'set-audits-block-open',
 ]);
 
 function dataAttrName(name) {
@@ -51,7 +57,7 @@ function actionName(actionEl) {
 }
 
 function shouldHandleClick(actionEl) {
-  return actionEl && !actionEl.matches?.('input, select, textarea');
+  return actionEl && !NON_CLICK_ACTIONS.has(actionName(actionEl)) && !actionEl.matches?.('input, select, textarea');
 }
 
 function shouldHandleRoleButtonKeydown(actionEl, event) {
@@ -68,6 +74,9 @@ function handleLightEnvAction(actionEl, event, actions) {
   const kind = actionEl.dataset.lightEnvKind || '';
   const device = actionEl.dataset.lightEnvDevice || '';
   const tool = actionEl.dataset.lightEnvTool || '';
+  const field = actionEl.dataset.lightEnvField || '';
+  const oldId = actionEl.dataset.lightEnvOldId || '';
+  const newId = actionEl.dataset.lightEnvNewId || '';
 
   if (action === 'set-room-source-archetype') {
     void actions.setLightEnvRoomSourceArchetype?.(id, key);
@@ -120,6 +129,20 @@ function handleLightEnvAction(actionEl, event, actions) {
     actions.openLightEnvTool?.(tool, id);
   } else if (action === 'add-room') {
     void actions.addLightEnvRoom?.();
+  } else if (action === 'toggle-audit') {
+    actions.toggleLightAudit?.(id);
+  } else if (action === 'update-audit-field') {
+    void actions.updateLightAuditField?.(id, field, actionEl.value);
+  } else if (action === 'delete-audit-confirm') {
+    void actions.deleteLightAuditConfirm?.(id);
+  } else if (action === 'interpret-audit-compare') {
+    actions.interpretLightAuditCompare?.(oldId, newId);
+  } else if (action === 'toggle-audit-compare') {
+    actions.toggleLightAuditCompare?.();
+  } else if (action === 'save-audit') {
+    void actions.saveLightAuditFromUI?.();
+  } else if (action === 'toggle-audit-history') {
+    actions.toggleLightAuditHistory?.();
   }
 }
 
@@ -165,6 +188,7 @@ function handleLightEnvChange(event, actions) {
     'update-screen-room',
     'update-screen-device',
     'update-screen-blue-blocker',
+    'update-audit-field',
   ].includes(actionEl.dataset.lightEnvAction || '')) return;
   handleLightEnvAction(actionEl, event, actions);
 }
@@ -176,6 +200,12 @@ function handleLightEnvInput(event, actions) {
   handleLightEnvAction(actionEl, event, actions);
 }
 
+function handleLightEnvToggle(event, actions) {
+  const actionEl = closestLightEnvAction(event);
+  if (!actionEl || actionName(actionEl) !== 'set-audits-block-open') return;
+  actions.setLightAuditsBlockOpen?.(!!actionEl.open);
+}
+
 export function installLightEnvActionDelegates(actions = {}, root = (typeof document !== 'undefined' ? document : null)) {
   if (!root || lightEnvActionDelegateRoots.has(root)) return;
   lightEnvActionDelegateRoots.add(root);
@@ -185,4 +215,5 @@ export function installLightEnvActionDelegates(actions = {}, root = (typeof docu
   root.addEventListener('keydown', event => handleLightEnvKeydown(event, actions));
   root.addEventListener('change', event => handleLightEnvChange(event, actions));
   root.addEventListener('input', event => handleLightEnvInput(event, actions));
+  root.addEventListener('toggle', event => handleLightEnvToggle(event, actions), true);
 }

--- a/js/light-env-audits.js
+++ b/js/light-env-audits.js
@@ -10,6 +10,7 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, showPromptDialog, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItems } from './data-merge.js';
+import { lightEnvActionAttrs } from './light-env-actions.js';
 
 // Mirrors the EMF Assessment pattern: each audit is a dated, labeled,
 // immutable snapshot of the rooms + screens + recent measurements at
@@ -184,7 +185,7 @@ function renderLightAuditCard(a, expanded) {
   const measCount = (a.measurements || []).length;
   const cardAriaLabel = `${fmtAuditDate(a.date)}${a.label ? ' — ' + a.label : ''} — ${roomsCount} room${roomsCount === 1 ? '' : 's'}, ${measCount} measurement${measCount === 1 ? '' : 's'}, ${sev.label}${expanded ? ', expanded' : ', collapsed'}`;
   let html = `<div class="light-audit-card${expanded ? ' expanded' : ''}" data-id="${escapeAttr(a.id)}">
-    <div class="light-audit-header" role="button" tabindex="0" aria-expanded="${expanded ? 'true' : 'false'}" aria-label="${escapeAttr(cardAriaLabel)}" onclick="window.toggleLightAudit('${escapeAttr(a.id)}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.toggleLightAudit('${escapeAttr(a.id)}')}">
+    <div class="light-audit-header" role="button" tabindex="0" aria-expanded="${expanded ? 'true' : 'false'}" aria-label="${escapeAttr(cardAriaLabel)}" ${lightEnvActionAttrs('toggle-audit', { id: a.id })}>
       <div class="light-audit-info">
         <div class="light-audit-info-top">
           ${typeof window !== 'undefined' && window.renderAuditAIDot ? window.renderAuditAIDot(a) : ''}
@@ -221,16 +222,15 @@ function _auditRoomChannels(audit, room) {
 }
 
 function renderLightAuditDetail(a) {
-  const auditIdAttr = escapeAttr(a.id);
   let html = `<div class="light-audit-detail">
     <div class="light-audit-meta-row">
       <label class="light-audit-meta-field light-audit-meta-field--date">
         <span class="light-audit-meta-field-text">Date</span>
-        <input type="date" class="ctx-input" value="${escapeAttr(a.date)}" aria-label="Audit date" onchange="window.updateLightAuditField('${auditIdAttr}','date',this.value)">
+        <input type="date" class="ctx-input" value="${escapeAttr(a.date)}" aria-label="Audit date" ${lightEnvActionAttrs('update-audit-field', { id: a.id, field: 'date' })}>
       </label>
       <label class="light-audit-meta-field light-audit-meta-field--label">
         <span class="light-audit-meta-field-text">Label</span>
-        <input type="text" class="ctx-input" value="${escapeHTML(a.label || '')}" placeholder="e.g. Pre-mitigation" aria-label="Audit label" onchange="window.updateLightAuditField('${auditIdAttr}','label',this.value)">
+        <input type="text" class="ctx-input" value="${escapeHTML(a.label || '')}" placeholder="e.g. Pre-mitigation" aria-label="Audit label" ${lightEnvActionAttrs('update-audit-field', { id: a.id, field: 'label' })}>
       </label>
     </div>
     ${typeof window !== 'undefined' && window.renderAuditAIBlock ? window.renderAuditAIBlock(a) : ''}`;
@@ -267,7 +267,7 @@ function renderLightAuditDetail(a) {
   }
 
   html += `<div class="light-audit-footer">
-      <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" onclick="window.deleteLightAuditConfirm('${escapeAttr(a.id)}')">Delete audit</button>
+      <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" ${lightEnvActionAttrs('delete-audit-confirm', { id: a.id })}>Delete audit</button>
     </div>
   </div>`;
   return html;
@@ -376,7 +376,7 @@ function renderLightAuditCompare(audits) {
     <span class="light-audit-compare-label">Before: ${escapeHTML(fmtAuditDate(a1.date))}${a1.label ? ' — ' + escapeHTML(a1.label) : ''}</span>
     <span class="light-audit-compare-arrow">→</span>
     <span class="light-audit-compare-label">After: ${escapeHTML(fmtAuditDate(a2.date))}${a2.label ? ' — ' + escapeHTML(a2.label) : ''}</span>
-    ${hasAI ? `<button class="import-btn import-btn-secondary light-audit-interpret-btn" onclick="window.interpretLightAuditCompare('${escapeAttr(a1.id)}','${escapeAttr(a2.id)}')" title="Open the chat panel with a pre-filled comparison summary so the AI can interpret what changed.">✨ Interpret changes</button>` : ''}
+    ${hasAI ? `<button class="import-btn import-btn-secondary light-audit-interpret-btn" ${lightEnvActionAttrs('interpret-audit-compare', { oldId: a1.id, newId: a2.id })} title="Open the chat panel with a pre-filled comparison summary so the AI can interpret what changed.">✨ Interpret changes</button>` : ''}
   </div>`;
 
   if (sorted.length > 2) {
@@ -490,15 +490,15 @@ export function renderLightAuditsBlock() {
   // Bumped to import-btn-primary so it is visually weighted ahead of
   // "Save audit".
   const compareBtn = audits.length >= 2
-    ? `<button class="import-btn ${_auditCompareMode ? 'import-btn-secondary' : 'import-btn-primary'}" onclick="event.preventDefault();event.stopPropagation();window.toggleLightAuditCompare()">${_auditCompareMode ? 'Exit compare' : '⇄ Compare'}</button>`
+    ? `<button class="import-btn ${_auditCompareMode ? 'import-btn-secondary' : 'import-btn-primary'}" ${lightEnvActionAttrs('toggle-audit-compare')}>${_auditCompareMode ? 'Exit compare' : '⇄ Compare'}</button>`
     : '';
   const openAttr = (_auditsBlockOpen || _auditCompareMode || _expandedAuditId) ? ' open' : '';
-  let html = `<details class="light-env-block light-audits-block"${openAttr} ontoggle="window.setLightAuditsBlockOpen(this.open)">
+  let html = `<details class="light-env-block light-audits-block"${openAttr} ${lightEnvActionAttrs('set-audits-block-open')}>
     <summary class="light-env-block-head light-audits-summary">
       <strong>Light audits</strong>
       <div class="light-audit-actions">
         ${compareBtn}
-        <button class="import-btn import-btn-secondary" onclick="event.preventDefault();event.stopPropagation();window.saveLightAuditFromUI()" title="Snapshot the current rooms + screens + recent measurements as a dated audit. Save another after you make changes (warmer bulbs, blackouts, blue blockers) to unlock the side-by-side compare.">+ Save audit</button>
+        <button class="import-btn import-btn-secondary" ${lightEnvActionAttrs('save-audit')} title="Snapshot the current rooms + screens + recent measurements as a dated audit. Save another after you make changes (warmer bulbs, blackouts, blue blockers) to unlock the side-by-side compare.">+ Save audit</button>
       </div>
     </summary>`;
 
@@ -519,11 +519,11 @@ export function renderLightAuditsBlock() {
       html += renderLightAuditCard(a, _expandedAuditId === a.id);
     }
     if (hiddenCount > 0) {
-      html += `<button class="light-audit-show-more" onclick="event.preventDefault();event.stopPropagation();window.toggleLightAuditHistory()">
+      html += `<button class="light-audit-show-more" ${lightEnvActionAttrs('toggle-audit-history')}>
         Show ${hiddenCount} older audit${hiddenCount === 1 ? '' : 's'}
       </button>`;
     } else if (_showAllAudits && sorted.length > AUDITS_DEFAULT_CAP) {
-      html += `<button class="light-audit-show-more" onclick="event.preventDefault();event.stopPropagation();window.toggleLightAuditHistory()">
+      html += `<button class="light-audit-show-more" ${lightEnvActionAttrs('toggle-audit-history')}>
         Show only latest ${AUDITS_DEFAULT_CAP} audits
       </button>`;
     }

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -1162,6 +1162,27 @@ if (typeof document !== 'undefined') {
   const saveLightAuditFromUI = typeof globalThis.saveLightAuditFromUI === 'function'
     ? globalThis.saveLightAuditFromUI
     : undefined;
+  const toggleLightAudit = typeof globalThis.toggleLightAudit === 'function'
+    ? globalThis.toggleLightAudit
+    : undefined;
+  const toggleLightAuditCompare = typeof globalThis.toggleLightAuditCompare === 'function'
+    ? globalThis.toggleLightAuditCompare
+    : undefined;
+  const toggleLightAuditHistory = typeof globalThis.toggleLightAuditHistory === 'function'
+    ? globalThis.toggleLightAuditHistory
+    : undefined;
+  const setLightAuditsBlockOpen = typeof globalThis.setLightAuditsBlockOpen === 'function'
+    ? globalThis.setLightAuditsBlockOpen
+    : undefined;
+  const updateLightAuditField = typeof globalThis.updateLightAuditField === 'function'
+    ? globalThis.updateLightAuditField
+    : undefined;
+  const deleteLightAuditConfirm = typeof globalThis.deleteLightAuditConfirm === 'function'
+    ? globalThis.deleteLightAuditConfirm
+    : undefined;
+  const interpretLightAuditCompare = typeof globalThis.interpretLightAuditCompare === 'function'
+    ? globalThis.interpretLightAuditCompare
+    : undefined;
   installLightEnvActionDelegates({
     addLightEnvRoom,
     addLightEnvRoomNamed,
@@ -1184,6 +1205,13 @@ if (typeof document !== 'undefined') {
     openLightEnvironmentAssessment,
     closeLightEnvironmentAssessment,
     saveLightAuditFromUI,
+    toggleLightAudit,
+    toggleLightAuditCompare,
+    toggleLightAuditHistory,
+    setLightAuditsBlockOpen,
+    updateLightAuditField,
+    deleteLightAuditConfirm,
+    interpretLightAuditCompare,
     openLightEnvTool,
   });
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 159,
+  "inlineEventAttributes": 149,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -483,6 +483,10 @@ test('Light audit history covers save expand update compare interpret and delete
       });
 
       const host = renderHost();
+      outcomes.auditRenderUsesDelegatedActions =
+        host.querySelector('[onclick],[onchange],[oninput],[onkeydown],[onblur],[onsubmit],[ontoggle]') === null
+        && host.querySelector('[data-light-env-action="save-audit"]') !== null
+        && host.querySelector('[data-light-env-action="toggle-audit-history"]') !== null;
       outcomes.initialHistoryCapsAtTwoAndShowsMore =
         host.querySelectorAll('.light-audit-card').length === 2
         && host.querySelector('.light-audit-show-more')?.textContent.includes('Show 1 older audit') === true;
@@ -506,7 +510,7 @@ test('Light audit history covers save expand update compare interpret and delete
         && document.querySelector('.light-audit-card[data-id="audit_old"].expanded') !== null
         && calls.some(call => call[0] === 'refresh' && String(call[1]).includes('audit_old'));
 
-      document.querySelector('#light-audit-test-host .light-audit-actions button[onclick*="saveLightAuditFromUI"]')?.click();
+      document.querySelector('#light-audit-test-host .light-audit-actions [data-light-env-action="save-audit"]')?.click();
       await waitFor('#prompt-dialog-input', 'audit save prompt');
       document.getElementById('prompt-dialog-input').value = 'Post cleanup';
       document.getElementById('prompt-ok').click();

--- a/tests/playwright/light-env-actions-browser-coverage.spec.js
+++ b/tests/playwright/light-env-actions-browser-coverage.spec.js
@@ -46,6 +46,11 @@ test('light environment action delegates route DOM events and attrs in browser',
       if (checked !== undefined) el.checked = checked;
       el.dispatchEvent(new Event('change', { bubbles: true }));
     };
+    const toggle = (id, open) => {
+      const el = byId(id);
+      el.open = open;
+      el.dispatchEvent(new Event('toggle', { bubbles: false }));
+    };
     const called = (name, predicate = () => true) => calls.some(call => call[0] === name && predicate(call));
     const callCount = name => calls.filter(call => call[0] === name).length;
 
@@ -80,6 +85,13 @@ test('light environment action delegates route DOM events and attrs in browser',
       <button id="open-save-audit" ${actionsModule.lightEnvActionAttrs('open-assessment-save-audit')}>Open and save</button>
       <button id="close-assessment" ${actionsModule.lightEnvActionAttrs('close-assessment')}>Close</button>
       <button id="open-tool" ${actionsModule.lightEnvActionAttrs('open-tool', { id: 'room-1', tool: 'flicker' })}>Tool</button>
+      <div id="audit-toggle" role="button" tabindex="0" ${actionsModule.lightEnvActionAttrs('toggle-audit', { id: 'audit-1' })}>Audit</div>
+      <button id="audit-delete" ${actionsModule.lightEnvActionAttrs('delete-audit-confirm', { id: 'audit-1' })}>Delete audit</button>
+      <button id="audit-interpret" ${actionsModule.lightEnvActionAttrs('interpret-audit-compare', { oldId: 'audit-1', newId: 'audit-2' })}>Interpret audit</button>
+      <button id="audit-compare" ${actionsModule.lightEnvActionAttrs('toggle-audit-compare')}>Compare</button>
+      <button id="audit-save" ${actionsModule.lightEnvActionAttrs('save-audit')}>Save audit</button>
+      <button id="audit-history" ${actionsModule.lightEnvActionAttrs('toggle-audit-history')}>History</button>
+      <details id="audit-details" ${actionsModule.lightEnvActionAttrs('set-audits-block-open')}><summary id="audit-summary">Audits</summary></details>
       <select id="room-source" ${actionsModule.lightEnvActionAttrs('update-room-primary-source', { id: 'room-1' })}>
         <option value="unknown">Unknown</option>
         <option value="led-warm">Warm LED</option>
@@ -95,6 +107,7 @@ test('light environment action delegates route DOM events and attrs in browser',
         <option value="laptop">Laptop</option>
       </select>
       <input id="blue-blocker" type="checkbox" ${actionsModule.lightEnvActionAttrs('update-screen-blue-blocker', { id: 'screen-1' })} />
+      <input id="audit-label" ${actionsModule.lightEnvActionAttrs('update-audit-field', { id: 'audit-1', field: 'label' })} />
       <input id="ignored-click-input" ${actionsModule.lightEnvActionAttrs('add-room')} />
     `;
 
@@ -124,6 +137,13 @@ test('light environment action delegates route DOM events and attrs in browser',
       deleteLightEnvRoomConfirm: id => push('deleteLightEnvRoomConfirm', id),
       openLightEnvTool: (tool, id) => push('openLightEnvTool', tool, id),
       addLightEnvRoom: () => push('addLightEnvRoom'),
+      toggleLightAudit: id => push('toggleLightAudit', id),
+      updateLightAuditField: (id, field, value) => push('updateLightAuditField', id, field, value),
+      deleteLightAuditConfirm: id => push('deleteLightAuditConfirm', id),
+      interpretLightAuditCompare: (oldId, newId) => push('interpretLightAuditCompare', oldId, newId),
+      toggleLightAuditCompare: () => push('toggleLightAuditCompare'),
+      toggleLightAuditHistory: () => push('toggleLightAuditHistory'),
+      setLightAuditsBlockOpen: open => push('setLightAuditsBlockOpen', open),
     };
 
     actionsModule.installLightEnvActionDelegates(actions, root);
@@ -164,6 +184,9 @@ test('light environment action delegates route DOM events and attrs in browser',
     await new Promise(resolve => setTimeout(resolve, 0));
     click('close-assessment');
     click('open-tool');
+    click('audit-toggle');
+    click('audit-delete');
+    click('audit-interpret');
     outcomes.clickRoutesRemainingButtonActions =
       called('setLightEnvRoomHoursBucket', call => call[1] === 'room-1' && call[2] === 'workday')
       && called('setLightEnvRoomEveningBucket', call => call[1] === 'room-1' && call[2] === 'gt3')
@@ -177,7 +200,24 @@ test('light environment action delegates route DOM events and attrs in browser',
       && callCount('openLightEnvironmentAssessment') === 2
       && called('saveLightAuditFromUI')
       && called('closeLightEnvironmentAssessment')
-      && called('openLightEnvTool', call => call[1] === 'flicker' && call[2] === 'room-1');
+      && called('openLightEnvTool', call => call[1] === 'flicker' && call[2] === 'room-1')
+      && called('toggleLightAudit', call => call[1] === 'audit-1')
+      && called('deleteLightAuditConfirm', call => call[1] === 'audit-1')
+      && called('interpretLightAuditCompare', call => call[1] === 'audit-1' && call[2] === 'audit-2');
+
+    const docClicksBeforeAuditStop = callCount('document-click');
+    const saveCallsBeforeAuditStop = callCount('saveLightAuditFromUI');
+    const compareDefaultAllowed = click('audit-compare');
+    const saveDefaultAllowed = click('audit-save');
+    const historyDefaultAllowed = click('audit-history');
+    outcomes.captureStoppingAuditActionsPreventDefaultAndStopDocumentBubble =
+      compareDefaultAllowed === false
+      && saveDefaultAllowed === false
+      && historyDefaultAllowed === false
+      && called('toggleLightAuditCompare')
+      && callCount('saveLightAuditFromUI') === saveCallsBeforeAuditStop + 1
+      && called('toggleLightAuditHistory')
+      && callCount('document-click') === docClicksBeforeAuditStop;
 
     const ignoredBefore = callCount('addLightEnvRoom');
     click('ignored-click-input');
@@ -189,13 +229,21 @@ test('light environment action delegates route DOM events and attrs in browser',
     change('screen-room', '');
     change('screen-device', 'laptop');
     change('blue-blocker', undefined, true);
+    change('audit-label', 'After blackout curtains');
+    const docClicksBeforeSummary = callCount('document-click');
+    const summaryDefaultAllowed = click('audit-summary');
+    toggle('audit-details', true);
     outcomes.inputAndChangeRouteFormActions =
       called('updateLightEnvRoomAndRender', call => call[1] === 'room-1' && call[2].primarySource === 'led-warm')
       && called('updateLightEnvRoom', call => call[1] === 'room-1' && call[2].hoursOccupiedPerDay === 7.5)
       && called('updateLightEnvRoom', call => call[1] === 'room-1' && call[2].name === 'Office')
       && called('updateLightEnvScreenAndRender', call => call[1] === 'screen-1' && call[2].roomId === null)
       && called('updateLightEnvScreenAndRender', call => call[1] === 'screen-1' && call[2].device === 'laptop')
-      && called('updateLightEnvScreenAndRender', call => call[1] === 'screen-1' && call[2].blueBlockerEnabled === true);
+      && called('updateLightEnvScreenAndRender', call => call[1] === 'screen-1' && call[2].blueBlockerEnabled === true)
+      && called('updateLightAuditField', call => call[1] === 'audit-1' && call[2] === 'label' && call[3] === 'After blackout curtains')
+      && summaryDefaultAllowed === true
+      && callCount('document-click') === docClicksBeforeSummary + 1
+      && called('setLightAuditsBlockOpen', call => call[1] === true);
 
     const docKeysBeforeStop = callCount('document-keydown');
     const screenSpaceAllowed = keydown('screen-toggle', ' ');

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const envSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/light-env-actions.js'), 'utf8');
+const auditSrc = fs.readFileSync(path.join(root, 'js/light-env-audits.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 
 let passed = 0;
@@ -26,11 +27,13 @@ function assert(name, condition, detail = '') {
 
 console.log('=== Light Environment Delegated Actions ===');
 
-const inlineHandlerRe = /\bon(?:click|keydown|change|input|submit)=/g;
+const inlineHandlerRe = /\bon(?:click|keydown|change|input|submit|blur|toggle)=/g;
 const directAssignmentRe = /\.(?:onclick|onchange|oninput|onkeydown)\s*=/;
 
 assert('light-env.js has no inline event attributes',
   !inlineHandlerRe.test(envSrc));
+assert('light-env-audits.js has no inline event attributes',
+  !inlineHandlerRe.test(auditSrc));
 assert('light-env.js avoids direct event property assignment',
   !directAssignmentRe.test(envSrc));
 assert('light-env.js imports and installs the delegated action helper',
@@ -44,19 +47,23 @@ assert('light-env-actions defines one shared action attribute helper',
     actionSrc.includes("replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)") &&
     actionSrc.includes('Boolean false means "absent but false"') &&
     actionSrc.includes("value !== false"));
-assert('light-env-actions installs idempotent click, keyboard, change, and input delegates',
+assert('light-env-actions installs idempotent click, keyboard, change, input, and toggle delegates',
   actionSrc.includes('const lightEnvActionDelegateRoots = new WeakSet();') &&
     actionSrc.includes("root.addEventListener('click', event => handleLightEnvCapturedClick(event, actions), true)") &&
     actionSrc.includes("root.addEventListener('click', event => handleLightEnvClick(event, actions))") &&
     actionSrc.includes("root.addEventListener('keydown', event => handleLightEnvCapturedKeydown(event, actions), true)") &&
     actionSrc.includes("root.addEventListener('keydown', event => handleLightEnvKeydown(event, actions))") &&
     actionSrc.includes("root.addEventListener('change', event => handleLightEnvChange(event, actions))") &&
-    actionSrc.includes("root.addEventListener('input', event => handleLightEnvInput(event, actions))"));
+    actionSrc.includes("root.addEventListener('input', event => handleLightEnvInput(event, actions))") &&
+    actionSrc.includes("root.addEventListener('toggle', event => handleLightEnvToggle(event, actions), true)"));
 assert('light-env-actions preserves old stop-propagation semantics in capture phase',
   actionSrc.includes('const PROPAGATION_STOPPING_CLICK_ACTIONS = new Set') &&
     actionSrc.includes("'set-today-active'") &&
     actionSrc.includes("'delete-screen-confirm'") &&
     actionSrc.includes("'delete-room-confirm'") &&
+    actionSrc.includes("'toggle-audit-compare'") &&
+    actionSrc.includes("'save-audit'") &&
+    actionSrc.includes("'toggle-audit-history'") &&
     actionSrc.includes('function handleLightEnvCapturedClick') &&
     actionSrc.includes('if (!PROPAGATION_STOPPING_CLICK_ACTIONS.has(actionName(actionEl))) return;') &&
     actionSrc.includes('if (PROPAGATION_STOPPING_CLICK_ACTIONS.has(actionName(actionEl))) return;') &&
@@ -67,13 +74,25 @@ assert('light-env delegated actions are scoped to the installed root',
 assert('light-env keyboard delegate supports role-button rows and ignores form controls',
   actionSrc.includes("event.target?.closest?.('button, a, input, textarea, select')") &&
     actionSrc.includes("actionEl.getAttribute('role') === 'button'"));
+assert('light-env click delegate ignores toggle-only details actions',
+  actionSrc.includes('const NON_CLICK_ACTIONS = new Set') &&
+    actionSrc.includes("'set-audits-block-open'") &&
+    actionSrc.includes('!NON_CLICK_ACTIONS.has(actionName(actionEl))'));
 assert('light-env form delegates separate live input from change-only controls',
   actionSrc.includes("'update-room-hours', 'update-room-name'") &&
-    actionSrc.includes("'update-screen-blue-blocker'"));
+    actionSrc.includes("'update-screen-blue-blocker'") &&
+    actionSrc.includes("'update-audit-field'"));
 assert('light-env.js captures saveLightAuditFromUI when installing delegates',
   envSrc.includes("const saveLightAuditFromUI = typeof globalThis.saveLightAuditFromUI === 'function'") &&
     envSrc.includes('saveLightAuditFromUI,') &&
     !envSrc.includes('saveLightAuditFromUI: () => globalThis.saveLightAuditFromUI?.()'));
+assert('light-env.js captures light audit callbacks when installing delegates',
+  envSrc.includes("const toggleLightAudit = typeof globalThis.toggleLightAudit === 'function'") &&
+    envSrc.includes("const updateLightAuditField = typeof globalThis.updateLightAuditField === 'function'") &&
+    envSrc.includes('toggleLightAudit,') &&
+    envSrc.includes('updateLightAuditField,') &&
+    envSrc.includes('deleteLightAuditConfirm,') &&
+    envSrc.includes('interpretLightAuditCompare,'));
 assert('service worker precaches light-env-actions.js',
   swSrc.includes("'/js/light-env-actions.js'"));
 
@@ -103,6 +122,13 @@ assert('service worker precaches light-env-actions.js',
   'update-room-name',
   'open-tool',
   'add-room',
+  'toggle-audit',
+  'update-audit-field',
+  'delete-audit-confirm',
+  'interpret-audit-compare',
+  'toggle-audit-compare',
+  'save-audit',
+  'toggle-audit-history',
 ].forEach(action => {
   assert(`light environment action ${action} is handled`,
     actionSrc.includes(`action === '${action}'`));
@@ -137,6 +163,21 @@ assert('service worker precaches light-env-actions.js',
 ].forEach(renderedAction => {
   assert(`light-env.js renders ${renderedAction}`,
     envSrc.includes(renderedAction));
+});
+
+[
+  "lightEnvActionAttrs('toggle-audit', { id: a.id })",
+  "lightEnvActionAttrs('update-audit-field', { id: a.id, field: 'date' })",
+  "lightEnvActionAttrs('update-audit-field', { id: a.id, field: 'label' })",
+  "lightEnvActionAttrs('delete-audit-confirm', { id: a.id })",
+  "lightEnvActionAttrs('interpret-audit-compare', { oldId: a1.id, newId: a2.id })",
+  "lightEnvActionAttrs('toggle-audit-compare')",
+  "lightEnvActionAttrs('set-audits-block-open')",
+  "lightEnvActionAttrs('save-audit')",
+  "lightEnvActionAttrs('toggle-audit-history')",
+].forEach(renderedAction => {
+  assert(`light-env-audits.js renders ${renderedAction}`,
+    auditSrc.includes(renderedAction));
 });
 
 [

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -429,7 +429,8 @@ const {
   const manuallyOpenAudits = auditModule.renderLightAuditsBlock();
   assert('Audit block can stay open without an expanded audit card',
     manuallyOpenAudits.includes('class="light-env-block light-audits-block" open') &&
-    manuallyOpenAudits.includes('ontoggle="window.setLightAuditsBlockOpen(this.open)"'));
+    manuallyOpenAudits.includes('data-light-env-action="set-audits-block-open"') &&
+    !manuallyOpenAudits.includes('ontoggle='));
   window.setLightAuditsBlockOpen(false);
   const manuallyClosedAudits = auditModule.renderLightAuditsBlock();
   assert('Audit block open state can be manually collapsed',
@@ -537,6 +538,8 @@ const {
     !modelSrc.includes('renderEnvironmentSection') &&
     !envSrc.includes('function _hasAnyRoomSignal'));
   const auditSrc = await (await import('node:fs/promises')).readFile(new URL('../js/light-env-audits.js', import.meta.url), 'utf8');
+  assert('Light audit renderer emits no inline event attributes',
+    !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light audit storage/rendering lives in its own module',
     auditSrc.includes('configureLightEnvAudits') &&
     auditSrc.includes('renderLightAuditsBlock') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.508';
+self.APP_VERSION = '1.8.509';


### PR DESCRIPTION
## Summary
- Replace light audit inline handlers with existing light environment delegated actions.
- Add audit-specific click/change/toggle routing, including a toggle-only details handler that preserves native summary clicks.
- Add static and browser coverage for delegated light audit actions.
- Lower inline event baseline from 159 to 149 and bump version to 1.8.509.

## Validation
- npm run quality
- npm run typecheck
- node tests/test-light-env-delegated-actions.js
- node tests/test-light-env.js
- npx playwright test tests/playwright/light-env-actions-browser-coverage.spec.js tests/playwright/environment-coverage-batch.spec.js
- npm test
- git diff --check
- ./run-tests.sh
