### PR TITLE
[codex] Delegate compare correlation actions

### DIFF
--- a/js/compare-correlations.js
+++ b/js/compare-correlations.js
@@ -91,6 +91,15 @@ function handleCompareClick(event) {
   }
 }
 
+function handleCompareKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestCompareTarget(event, '[data-compare-action]');
+  if (!actionEl) return;
+  if (['BUTTON', 'A', 'INPUT', 'SELECT', 'TEXTAREA'].includes(actionEl.tagName)) return;
+  event.preventDefault();
+  actionEl.click();
+}
+
 function handleCompareChange(event) {
   const actionEl = closestCompareTarget(event, '[data-compare-change-action]');
   if (!actionEl || actionEl.dataset.compareChangeAction !== 'set-date') return;
@@ -117,6 +126,7 @@ export function installCompareCorrelationDelegates(root = (typeof document !== '
   if (!root || typeof root.addEventListener !== 'function' || compareDelegateRoots.has(root)) return;
   compareDelegateRoots.add(root);
   root.addEventListener('click', handleCompareClick);
+  root.addEventListener('keydown', handleCompareKeydown);
   root.addEventListener('change', handleCompareChange);
   root.addEventListener('input', handleCompareInput);
   root.addEventListener('focusin', handleCompareFocus);

--- a/js/compare-correlations.js
+++ b/js/compare-correlations.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { CORRELATION_PRESETS, CHIP_COLORS } from './schema.js';
-import { escapeHTML, getStatus, formatValue } from './utils.js';
+import { escapeHTML, escapeAttr, getStatus, formatValue } from './utils.js';
 import { getChartColors } from './theme.js';
 import { getActiveData } from './data.js';
 import { getEffectiveRange, getEffectiveRangeForDate } from './marker-analysis.js';
@@ -32,6 +32,95 @@ function renderScrollableTableShell(...args) {
 function renderCategoryGlyph(...args) {
   return compareCorrelationDeps.renderCategoryGlyph(...args);
 }
+
+function dataAttrName(name) {
+  return String(name).replace(/[A-Z]/g, c => `-${c.toLowerCase()}`);
+}
+
+function compareAttrs(actionAttr, action, attrs = {}) {
+  return [
+    `${actionAttr}="${escapeAttr(action)}"`,
+    ...Object.entries(attrs)
+      .filter(([, value]) => value !== null && value !== undefined)
+      .map(([name, value]) => `data-compare-${escapeAttr(dataAttrName(name))}="${escapeAttr(String(value))}"`),
+  ].join(' ');
+}
+
+export function compareActionAttrs(action, attrs = {}) {
+  return compareAttrs('data-compare-action', action, attrs);
+}
+
+function compareChangeAttrs(action, attrs = {}) {
+  return compareAttrs('data-compare-change-action', action, attrs);
+}
+
+function compareInputAttrs(action, attrs = {}) {
+  return compareAttrs('data-compare-input-action', action, attrs);
+}
+
+function compareFocusAttrs(action, attrs = {}) {
+  return compareAttrs('data-compare-focus-action', action, attrs);
+}
+
+function closestCompareTarget(event, selector) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return null;
+  return /** @type {HTMLElement | null} */ (target.closest(selector));
+}
+
+function handleCompareClick(event) {
+  const actionEl = closestCompareTarget(event, '[data-compare-action]');
+  if (!actionEl) return;
+  const action = actionEl.dataset.compareAction || '';
+  if (action === 'swap-dates') {
+    event.preventDefault();
+    swapCompareDates();
+  } else if (action === 'apply-preset') {
+    event.preventDefault();
+    const index = Number.parseInt(actionEl.dataset.compareIndex || '', 10);
+    if (Number.isInteger(index)) applyCorrelationPreset(index);
+  } else if (action === 'toggle-marker') {
+    event.preventDefault();
+    if (actionEl.dataset.compareKey) toggleCorrelationMarker(actionEl.dataset.compareKey);
+  } else if (action === 'ask-ai-correlations') {
+    event.preventDefault();
+    const askAIAboutCorrelations = typeof window !== 'undefined'
+      ? /** @type {any} */ (window).askAIAboutCorrelations
+      : null;
+    if (typeof askAIAboutCorrelations === 'function') askAIAboutCorrelations();
+  }
+}
+
+function handleCompareChange(event) {
+  const actionEl = closestCompareTarget(event, '[data-compare-change-action]');
+  if (!actionEl || actionEl.dataset.compareChangeAction !== 'set-date') return;
+  const value = 'value' in actionEl ? String(actionEl.value) : '';
+  if (actionEl.dataset.compareIndex === '1') setCompareDate1(value);
+  else if (actionEl.dataset.compareIndex === '2') setCompareDate2(value);
+}
+
+function handleCompareInput(event) {
+  const actionEl = closestCompareTarget(event, '[data-compare-input-action]');
+  if (!actionEl || actionEl.dataset.compareInputAction !== 'filter-options') return;
+  filterCorrelationOptions();
+}
+
+function handleCompareFocus(event) {
+  const actionEl = closestCompareTarget(event, '[data-compare-focus-action]');
+  if (!actionEl || actionEl.dataset.compareFocusAction !== 'show-dropdown') return;
+  showCorrelationDropdown();
+}
+
+const compareDelegateRoots = new WeakSet();
+
+export function installCompareCorrelationDelegates(root = (typeof document !== 'undefined' ? document : null)) {
+  if (!root || typeof root.addEventListener !== 'function' || compareDelegateRoots.has(root)) return;
+  compareDelegateRoots.add(root);
+  root.addEventListener('click', handleCompareClick);
+  root.addEventListener('change', handleCompareChange);
+  root.addEventListener('input', handleCompareInput);
+  root.addEventListener('focusin', handleCompareFocus);
+}
 // Compare Dates
 
 export function showCompare(data) {
@@ -53,11 +142,11 @@ export function showCompare(data) {
   };
   html += `<div class="compare-controls">
     <label class="compare-date-field" for="compare-select-1"><span>Date 1:</span>
-      <select id="compare-select-1" onchange="setCompareDate1(this.value)">${data.dates.map(d => fmtOpt(d)).join('')}</select>
+      <select id="compare-select-1" ${compareChangeAttrs('set-date', { index: '1' })}>${data.dates.map(d => fmtOpt(d)).join('')}</select>
     </label>
-    <button class="compare-swap-btn" onclick="swapCompareDates()" title="Swap dates" aria-label="Swap dates">\u21C4</button>
+    <button class="compare-swap-btn" ${compareActionAttrs('swap-dates')} title="Swap dates" aria-label="Swap dates">\u21C4</button>
     <label class="compare-date-field" for="compare-select-2"><span>Date 2:</span>
-      <select id="compare-select-2" onchange="setCompareDate2(this.value)">${data.dates.map(d => fmtOpt(d)).join('')}</select>
+      <select id="compare-select-2" ${compareChangeAttrs('set-date', { index: '2' })}>${data.dates.map(d => fmtOpt(d)).join('')}</select>
     </label>
   </div>`;
   html += `<div id="compare-results"></div>`;
@@ -164,7 +253,7 @@ export function showCorrelations(data) {
     <div class="corr-select-row">
       <div class="corr-dropdown">
         <input type="text" class="corr-search" id="corr-search" placeholder="Search biomarkers..."
-          oninput="filterCorrelationOptions()" onfocus="showCorrelationDropdown()">
+          ${compareInputAttrs('filter-options')} ${compareFocusAttrs('show-dropdown')}>
         <div class="corr-options" id="corr-options"></div>
       </div>
     </div>
@@ -172,12 +261,12 @@ export function showCorrelations(data) {
     <div class="corr-presets">
       <div class="corr-presets-label">Quick Presets:</div>`;
   for (let i = 0; i < CORRELATION_PRESETS.length; i++) {
-    html += `<button class="corr-preset-btn" onclick="applyCorrelationPreset(${i})">${CORRELATION_PRESETS[i].label}</button>`;
+    html += `<button class="corr-preset-btn" ${compareActionAttrs('apply-preset', { index: i })}>${CORRELATION_PRESETS[i].label}</button>`;
   }
   html += `</div></div>`;
   html += `<div class="corr-chart-container" id="corr-chart-container" style="display:none">
     <h3>Normalized Comparison (% of Reference Range)
-      <button class="corr-ask-ai-btn" onclick="askAIAboutCorrelations()" title="Ask AI about these correlations">Ask AI</button>
+      <button class="corr-ask-ai-btn" ${compareActionAttrs('ask-ai-correlations')} title="Ask AI about these correlations">Ask AI</button>
     </h3>
     <div class="corr-chart"><canvas id="chart-correlation"></canvas></div></div>`;
   main.innerHTML = html;
@@ -197,8 +286,8 @@ export function populateCorrelationOptions(data) {
       const fullKey = `${catKey}.${markerKey}`;
       const selected = state.selectedCorrelationMarkers.includes(fullKey);
       html += `<div class="corr-option ${selected ? 'selected' : ''}"
-        data-key="${fullKey}" data-name="${escapeHTML(marker.name)}" data-cat="${escapeHTML(cat.label)}"
-        onclick="toggleCorrelationMarker('${fullKey}')">
+        data-key="${escapeAttr(fullKey)}" data-name="${escapeHTML(marker.name)}" data-cat="${escapeHTML(cat.label)}"
+        role="button" tabindex="0" ${compareActionAttrs('toggle-marker', { key: fullKey })}>
         ${escapeHTML(marker.name)} <span class="opt-cat">${escapeHTML(cat.label)}</span></div>`;
     }
   }
@@ -253,7 +342,7 @@ export function renderCorrelationChips() {
     if (!marker) return;
     const color = CHIP_COLORS[i % CHIP_COLORS.length];
     html += `<span class="corr-chip" style="background:${color}20;border-color:${color};color:${color}">
-      ${escapeHTML(marker.name)} <span class="chip-remove" onclick="toggleCorrelationMarker('${key}')">&times;</span></span>`;
+      ${escapeHTML(marker.name)} <span class="chip-remove" ${compareActionAttrs('toggle-marker', { key })}>&times;</span></span>`;
   });
   container.innerHTML = html;
 }
@@ -328,3 +417,5 @@ export function renderCorrelationChart() {
     plugins: [refBandPlugin, noteAnnotationPlugin, supplementBarPlugin]
   });
 }
+
+installCompareCorrelationDelegates();

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 149,
+  "inlineEventAttributes": 141,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -170,6 +170,7 @@ const LEGACY_TESTS = [
   './test-lens-page-shell-delegated-actions.js',
   './test-light-page-view-delegated-actions.js',
   './test-light-env-delegated-actions.js',
+  './test-compare-correlations-delegated-actions.js',
   './test-sun-session-ui-delegated-actions.js',
   './test-marker-detail-delegated-actions.js',
   './test-wearables-delegated-actions.js',

--- a/tests/playwright/compare-correlations-browser-coverage.spec.js
+++ b/tests/playwright/compare-correlations-browser-coverage.spec.js
@@ -299,8 +299,9 @@ test('correlations browser contract filters markers toggles chips and builds cha
       search.value = '';
       search.dispatchEvent(new Event('input', { bubbles: true }));
 
-      document.querySelector('[data-compare-key="lipids.ldl"]')?.click();
-      outcomes.singleMarkerRendersChipWithoutChart =
+      const ldlOption = document.querySelector('[data-compare-key="lipids.ldl"]');
+      ldlOption?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      outcomes.delegatedKeyboardOptionRendersChipWithoutChart =
         state.selectedCorrelationMarkers.join(',') === 'lipids.ldl'
         && document.querySelectorAll('.corr-chip').length === 1
         && document.getElementById('corr-chart-container')?.style.display === 'none'
@@ -384,7 +385,7 @@ test('correlations browser contract filters markers toggles chips and builds cha
     'correlationControlsEmitDelegatedAttributesOnly',
     'showCorrelationDropdownOpensOptions',
     'searchDropdownFiltersByMarkerOrCategory',
-    'singleMarkerRendersChipWithoutChart',
+    'delegatedKeyboardOptionRendersChipWithoutChart',
     'secondMarkerBuildsNormalizedChart',
     'presetRendersFourChipsAndRefreshesChart',
     'removingBelowTwoHidesChartAndDestroysInstance',

--- a/tests/playwright/compare-correlations-browser-coverage.spec.js
+++ b/tests/playwright/compare-correlations-browser-coverage.spec.js
@@ -105,6 +105,10 @@ test('compare dates browser contract renders date controls table and updates sta
         && select2?.value === '2026-03-01'
         && document.querySelectorAll('#compare-select-1 option').length === 3
         && document.querySelector('.compare-swap-btn')?.getAttribute('aria-label') === 'Swap dates';
+      outcomes.compareControlsEmitDelegatedAttributesOnly =
+        document.querySelectorAll('#main-content [onclick], #main-content [onchange], #main-content [oninput], #main-content [onfocus]').length === 0
+        && select1?.getAttribute('data-compare-change-action') === 'set-date'
+        && document.querySelector('.compare-swap-btn')?.getAttribute('data-compare-action') === 'swap-dates';
       outcomes.compareTableUsesInjectedShellAndRendersMarkers =
         document.querySelector('[data-kind="compare"] .compare-table')
         && document.querySelector('colgroup')?.getAttribute('data-cols')?.includes('gb-col-marker')
@@ -112,6 +116,18 @@ test('compare dates browser contract renders date controls table and updates sta
         && rows.some(row => row.textContent.includes('LDL Cholesterol'))
         && !!document.querySelector('[data-glyph="biochemistry"]')
         && !!document.querySelector('.compare-improved');
+
+      select1.value = '2026-02-01';
+      select1.dispatchEvent(new Event('change', { bubbles: true }));
+      select2.value = '2026-01-01';
+      select2.dispatchEvent(new Event('change', { bubbles: true }));
+      document.querySelector('.compare-swap-btn')?.click();
+      outcomes.delegatedCompareControlsUpdateStateSelectsAndTable =
+        state.compareDate1 === '2026-01-01'
+        && state.compareDate2 === '2026-02-01'
+        && select1.value === '2026-01-01'
+        && select2.value === '2026-02-01'
+        && document.getElementById('compare-results')?.textContent.includes('+1.7');
 
       compare.setCompareDate1('2026-02-01');
       outcomes.setCompareDate1RebuildsTable =
@@ -152,7 +168,9 @@ test('compare dates browser contract renders date controls table and updates sta
 
   const expectedOutcomeKeys = [
     'initialCompareControlsAndDefaults',
+    'compareControlsEmitDelegatedAttributesOnly',
     'compareTableUsesInjectedShellAndRendersMarkers',
+    'delegatedCompareControlsUpdateStateSelectsAndTable',
     'setCompareDate1RebuildsTable',
     'setCompareDate2RebuildsTable',
     'swapUpdatesStateSelectsAndTable',
@@ -253,12 +271,22 @@ test('correlations browser contract filters markers toggles chips and builds cha
       const expectedLdlPct = ((2.3 - ldlMarker.refMin) / (ldlMarker.refMax - ldlMarker.refMin)) * 100;
       const optionCount = document.querySelectorAll('.corr-option').length;
       const dropdown = document.getElementById('corr-options');
+      const search = document.getElementById('corr-search');
+      let askCount = 0;
+      window.askAIAboutCorrelations = () => { askCount += 1; };
+      outcomes.correlationControlsEmitDelegatedAttributesOnly =
+        document.querySelectorAll('#main-content [onclick], #main-content [onchange], #main-content [oninput], #main-content [onfocus]').length === 0
+        && search?.getAttribute('data-compare-input-action') === 'filter-options'
+        && search?.getAttribute('data-compare-focus-action') === 'show-dropdown'
+        && document.querySelector('.corr-preset-btn')?.getAttribute('data-compare-action') === 'apply-preset'
+        && document.querySelector('.corr-ask-ai-btn')?.getAttribute('data-compare-action') === 'ask-ai-correlations'
+        && document.querySelector('.corr-option')?.getAttribute('data-compare-action') === 'toggle-marker';
       dropdown?.classList.remove('show');
-      compare.showCorrelationDropdown();
+      search?.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
       outcomes.showCorrelationDropdownOpensOptions = dropdown?.classList.contains('show') === true;
       dropdown?.classList.remove('show');
-      document.getElementById('corr-search').value = 'vitamin';
-      compare.filterCorrelationOptions();
+      search.value = 'vitamin';
+      search.dispatchEvent(new Event('input', { bubbles: true }));
       const vitaminOption = Array.from(document.querySelectorAll('.corr-option'))
         .find(option => option.dataset.key === 'vitamins.vitaminD');
       const glucoseOption = Array.from(document.querySelectorAll('.corr-option'))
@@ -268,15 +296,17 @@ test('correlations browser contract filters markers toggles chips and builds cha
         && document.getElementById('corr-options')?.classList.contains('show') === true
         && vitaminOption?.style.display === ''
         && glucoseOption?.style.display === 'none';
+      search.value = '';
+      search.dispatchEvent(new Event('input', { bubbles: true }));
 
-      compare.toggleCorrelationMarker('lipids.ldl');
+      document.querySelector('[data-compare-key="lipids.ldl"]')?.click();
       outcomes.singleMarkerRendersChipWithoutChart =
         state.selectedCorrelationMarkers.join(',') === 'lipids.ldl'
         && document.querySelectorAll('.corr-chip').length === 1
         && document.getElementById('corr-chart-container')?.style.display === 'none'
         && chartCaptures.length === 0;
 
-      compare.toggleCorrelationMarker('proteins.hsCRP');
+      document.querySelector('[data-compare-key="proteins.hsCRP"]')?.click();
       const firstChart = chartCaptures.at(-1);
       const firstDataset = firstChart?.config?.data?.datasets?.[0];
       const tooltipLabel = firstChart?.config?.options?.plugins?.tooltip?.callbacks?.label({
@@ -300,7 +330,7 @@ test('correlations browser contract filters markers toggles chips and builds cha
         && firstChart.config.plugins.length === 3;
 
       const lipidPresetIndex = schemaModule.CORRELATION_PRESETS.findIndex(p => p.label === 'Lipid Panel');
-      compare.applyCorrelationPreset(lipidPresetIndex);
+      Array.from(document.querySelectorAll('.corr-preset-btn'))[lipidPresetIndex]?.click();
       const presetChart = chartCaptures.at(-1);
       outcomes.presetRendersFourChipsAndRefreshesChart =
         lipidPresetIndex !== -1
@@ -309,14 +339,17 @@ test('correlations browser contract filters markers toggles chips and builds cha
         && presetChart?.config?.data?.datasets?.length === 4
         && presetChart.config.data.datasets.some(dataset => dataset.label === 'Triglycerides');
 
-      compare.toggleCorrelationMarker('lipids.hdl');
-      compare.toggleCorrelationMarker('lipids.ldl');
-      compare.toggleCorrelationMarker('lipids.triglycerides');
+      document.querySelector('[data-compare-key="lipids.hdl"].chip-remove')?.click();
+      document.querySelector('[data-compare-key="lipids.ldl"].chip-remove')?.click();
+      document.querySelector('[data-compare-key="lipids.triglycerides"].chip-remove')?.click();
       outcomes.removingBelowTwoHidesChartAndDestroysInstance =
         state.selectedCorrelationMarkers.join('|') === 'lipids.cholesterol'
         && document.getElementById('corr-chart-container')?.style.display === 'none'
         && destroyCount >= 1
         && state.chartInstances.correlation === undefined;
+
+      document.querySelector('.corr-ask-ai-btn')?.click();
+      outcomes.askAiButtonUsesDelegatedAction = askCount === 1;
 
       state.selectedCorrelationMarkers = [
         'lipids.cholesterol',
@@ -348,12 +381,14 @@ test('correlations browser contract filters markers toggles chips and builds cha
   });
 
   const expectedOutcomeKeys = [
+    'correlationControlsEmitDelegatedAttributesOnly',
     'showCorrelationDropdownOpensOptions',
     'searchDropdownFiltersByMarkerOrCategory',
     'singleMarkerRendersChipWithoutChart',
     'secondMarkerBuildsNormalizedChart',
     'presetRendersFourChipsAndRefreshesChart',
     'removingBelowTwoHidesChartAndDestroysInstance',
+    'askAiButtonUsesDelegatedAction',
     'selectionLimitStopsNinthMarker',
   ];
   expect(Object.keys(results)).toEqual(expectedOutcomeKeys);

--- a/tests/test-compare-correlations-delegated-actions.js
+++ b/tests/test-compare-correlations-delegated-actions.js
@@ -37,8 +37,9 @@ assert('compare action attribute helper is exported',
   /export function compareActionAttrs\(action, attrs = \{\}\)/.test(compareSrc)
   && compareSrc.includes('data-compare-action'));
 
-assert('compare delegates install click change input and focusin listeners',
+assert('compare delegates install click keydown change input and focusin listeners',
   compareSrc.includes("root.addEventListener('click', handleCompareClick)")
+  && compareSrc.includes("root.addEventListener('keydown', handleCompareKeydown)")
   && compareSrc.includes("root.addEventListener('change', handleCompareChange)")
   && compareSrc.includes("root.addEventListener('input', handleCompareInput)")
   && compareSrc.includes("root.addEventListener('focusin', handleCompareFocus)")
@@ -64,6 +65,10 @@ assert('compare click delegate routes all rendered actions',
   && compareSrc.includes("action === 'apply-preset'")
   && compareSrc.includes("action === 'toggle-marker'")
   && compareSrc.includes("action === 'ask-ai-correlations'"));
+
+assert('compare keydown delegate activates non-native action elements',
+  /function handleCompareKeydown\(event\)[\s\S]{0,400}event\.preventDefault\(\);[\s\S]{0,80}actionEl\.click\(\);/.test(compareSrc)
+  && compareSrc.includes("['BUTTON', 'A', 'INPUT', 'SELECT', 'TEXTAREA'].includes(actionEl.tagName)"));
 
 console.log(`\nCompare correlations delegated actions tests: ${pass} passed, ${fail} failed`);
 if (fail) process.exit(1);

--- a/tests/test-compare-correlations-delegated-actions.js
+++ b/tests/test-compare-correlations-delegated-actions.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Source-inspection coverage for compare/correlation delegated actions.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+let pass = 0;
+let fail = 0;
+
+function assert(name, condition) {
+  if (condition) {
+    pass += 1;
+    console.log(`  PASS: ${name}`);
+  } else {
+    fail += 1;
+    console.log(`  FAIL: ${name}`);
+  }
+}
+
+const compareSrc = read('js/compare-correlations.js');
+const eventNames = ['click', 'keydown', 'change', 'input', 'submit', 'blur', 'toggle'];
+const inlineEventPattern = new RegExp(`\\bon(?:${eventNames.join('|')})=["']`);
+
+console.log('=== Compare Correlations Delegated Actions Tests ===');
+
+assert('compare-correlations renderer emits no inline event attributes',
+  !inlineEventPattern.test(compareSrc));
+
+assert('compare-correlations imports escapeAttr for delegated data attributes',
+  /import\s*\{[^}]*\bescapeAttr\b[^}]*\}\s*from\s*['"]\.\/utils\.js['"]/.test(compareSrc));
+
+assert('compare action attribute helper is exported',
+  /export function compareActionAttrs\(action, attrs = \{\}\)/.test(compareSrc)
+  && compareSrc.includes('data-compare-action'));
+
+assert('compare delegates install click change input and focusin listeners',
+  compareSrc.includes("root.addEventListener('click', handleCompareClick)")
+  && compareSrc.includes("root.addEventListener('change', handleCompareChange)")
+  && compareSrc.includes("root.addEventListener('input', handleCompareInput)")
+  && compareSrc.includes("root.addEventListener('focusin', handleCompareFocus)")
+  && compareSrc.includes('installCompareCorrelationDelegates();'));
+
+assert('compare date controls use delegated change actions',
+  compareSrc.includes("compareChangeAttrs('set-date', { index: '1' })")
+  && compareSrc.includes("compareChangeAttrs('set-date', { index: '2' })")
+  && compareSrc.includes("compareActionAttrs('swap-dates')"));
+
+assert('correlation search uses delegated input and focus actions',
+  compareSrc.includes("compareInputAttrs('filter-options')")
+  && compareSrc.includes("compareFocusAttrs('show-dropdown')"));
+
+assert('correlation preset AI option and chip controls use delegated click actions',
+  compareSrc.includes("compareActionAttrs('apply-preset', { index: i })")
+  && compareSrc.includes("compareActionAttrs('ask-ai-correlations')")
+  && compareSrc.includes("compareActionAttrs('toggle-marker', { key: fullKey })")
+  && compareSrc.includes("compareActionAttrs('toggle-marker', { key })"));
+
+assert('compare click delegate routes all rendered actions',
+  compareSrc.includes("action === 'swap-dates'")
+  && compareSrc.includes("action === 'apply-preset'")
+  && compareSrc.includes("action === 'toggle-marker'")
+  && compareSrc.includes("action === 'ask-ai-correlations'"));
+
+console.log(`\nCompare correlations delegated actions tests: ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.509';
+self.APP_VERSION = '1.8.510';


### PR DESCRIPTION
## Summary
- Replace compare/correlation inline handlers with delegated data-compare actions.
- Add delegated click/change/input/focus routing for compare date selects, swap, correlation search, presets, marker toggles, chip removal, and Ask AI.
- Add static source coverage and browser event-path coverage for the delegated controls.
- Lower inline event baseline from 149 to 141 and bump version to 1.8.510.

## Validation
- node --check js/compare-correlations.js
- npm run quality
- npm run typecheck
- node tests/test-compare-correlations-delegated-actions.js
- npx playwright test tests/playwright/compare-correlations-browser-coverage.spec.js
- npm test
- git diff --check
- ./run-tests.sh
