### PR TITLE
[codex] Delegate data view actions

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -110,6 +110,7 @@ function handleDataClick(event) {
   if (action === 'switch-range-mode') {
     event.preventDefault();
     switchRangeMode(actionEl.getAttribute(DATA_RANGE_ATTR) || 'optimal');
+    return;
   }
 }
 
@@ -820,6 +821,8 @@ function _getActiveNavCategory() {
 }
 
 export function toggleChartLayersDropdown(e) {
+  // Direct callers still rely on this; delegated clicks add
+  // stopImmediatePropagation() at document level after this returns.
   e.stopPropagation();
   const dd = document.getElementById('chart-layers-dropdown');
   if (!dd) return;

--- a/js/data.js
+++ b/js/data.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { MARKER_SCHEMA, UNIT_CONVERSIONS, OPTIMAL_RANGES, PHASE_RANGES } from './schema.js';
-import { hashString, showNotification } from './utils.js';
+import { escapeAttr, hashString, showNotification } from './utils.js';
 import { profileStorageKey, touchProfileTimestamp } from './profile.js';
 import { encryptedSetItem, broadcastDataChanged, scheduleAutoBackup } from './crypto.js';
 import { onDataSaved } from './sync.js';
@@ -44,6 +44,98 @@ export {
  */
 
 const dataWindow = /** @type {Window & typeof globalThis & DataWindowHooks} */ (window);
+
+const DATA_ACTION_ATTR = 'data-lab-data-action';
+const DATA_CHANGE_ATTR = 'data-lab-data-change';
+const DATA_RANGE_ATTR = 'data-lab-data-range';
+const DATA_ACTION_SELECTOR = `[${DATA_ACTION_ATTR}]`;
+const DATA_CHANGE_SELECTOR = `[${DATA_CHANGE_ATTR}]`;
+const dataActionDelegateRoots = new WeakSet();
+
+function dataAttrName(name) {
+  return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+function dataControlAttrs(kind, action, attrs = {}) {
+  let html = `data-lab-data-${kind}="${escapeAttr(action)}"`;
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null || value === false) continue;
+    html += ` data-lab-data-${escapeAttr(dataAttrName(name))}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+export function dataActionAttrs(action, attrs = {}) {
+  return dataControlAttrs('action', action, attrs);
+}
+
+export function dataChangeAttrs(action, attrs = {}) {
+  return dataControlAttrs('change', action, attrs);
+}
+
+function closestDataElement(target, selector) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function' ? target.closest(selector) : null
+  );
+}
+
+function rootContains(root, el) {
+  return !!(root && typeof root.contains === 'function' && root.contains(el));
+}
+
+function containChartLayersClick(event) {
+  event.stopPropagation();
+  if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
+}
+
+function handleDataClick(event) {
+  const actionEl = closestDataElement(event.target, DATA_ACTION_SELECTOR);
+  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
+  const action = actionEl.getAttribute(DATA_ACTION_ATTR);
+  if (action === 'chart-layers-row') {
+    containChartLayersClick(event);
+    return;
+  }
+  if (action === 'set-date-range') {
+    event.preventDefault();
+    setDateRange(actionEl.getAttribute(DATA_RANGE_ATTR) || 'all');
+    return;
+  }
+  if (action === 'toggle-chart-layers') {
+    event.preventDefault();
+    toggleChartLayersDropdown(event);
+    if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
+    return;
+  }
+  if (action === 'switch-range-mode') {
+    event.preventDefault();
+    switchRangeMode(actionEl.getAttribute(DATA_RANGE_ATTR) || 'optimal');
+  }
+}
+
+function handleDataChange(event) {
+  const actionEl = closestDataElement(event.target, DATA_CHANGE_SELECTOR);
+  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
+  const action = actionEl.getAttribute(DATA_CHANGE_ATTR);
+  const checked = /** @type {{ checked?: boolean }} */ (event.target || {}).checked === true;
+  const mode = checked ? 'on' : 'off';
+  if (action === 'set-note-overlay') {
+    setNoteOverlay(mode);
+  } else if (action === 'set-supp-overlay') {
+    setSuppOverlay(mode);
+  } else if (action === 'set-phase-overlay') {
+    setPhaseOverlay(mode);
+  }
+}
+
+export function installDataActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || dataActionDelegateRoots.has(root)) return;
+  dataActionDelegateRoots.add(root);
+  root.addEventListener('click', handleDataClick);
+  root.addEventListener('change', handleDataChange);
+}
+
+installDataActionDelegates();
 
 // ═══════════════════════════════════════════════
 // PRIVATE CYCLE PHASE HELPER (avoids circular dep with cycle.js)
@@ -681,7 +773,7 @@ export function renderDateRangeFilter() {
     { key: 'all', label: 'All' }
   ];
   return `<div class="date-range-filter">${ranges.map(r =>
-    `<button class="range-btn${state.dateRangeFilter === r.key ? ' active' : ''}" onclick="setDateRange('${r.key}')">${r.label}</button>`
+    `<button class="range-btn${state.dateRangeFilter === r.key ? ' active' : ''}" type="button" ${dataActionAttrs('set-date-range', { range: r.key })}>${r.label}</button>`
   ).join('')}</div>`;
 }
 
@@ -704,18 +796,18 @@ export function renderChartLayersDropdown() {
   const hasCycle = state.profileSex === 'female' && state.importedData.menstrualCycle?.periods?.length > 0;
   if (!hasNotes && !hasSupps && !hasCycle) return '';
   return `<div class="chart-layers-wrapper">
-    <button class="view-btn chart-layers-trigger" aria-haspopup="true" aria-expanded="false" aria-controls="chart-layers-dropdown" onclick="toggleChartLayersDropdown(event)">Layers \u25BE</button>
+    <button class="view-btn chart-layers-trigger" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="chart-layers-dropdown" ${dataActionAttrs('toggle-chart-layers')}>Layers \u25BE</button>
     <div class="chart-layers-dropdown" id="chart-layers-dropdown" role="menu">
-      ${hasNotes ? `<label class="chart-layers-row" onclick="event.stopPropagation()">
-        <input type="checkbox" ${state.noteOverlayMode === 'on' ? 'checked' : ''} onchange="setNoteOverlay(this.checked?'on':'off')">
+      ${hasNotes ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
+        <input type="checkbox" ${state.noteOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-note-overlay')}>
         <span>\uD83D\uDCDD Notes</span>
       </label>` : ''}
-      ${hasSupps ? `<label class="chart-layers-row" onclick="event.stopPropagation()">
-        <input type="checkbox" ${state.suppOverlayMode === 'on' ? 'checked' : ''} onchange="setSuppOverlay(this.checked?'on':'off')">
+      ${hasSupps ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
+        <input type="checkbox" ${state.suppOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-supp-overlay')}>
         <span>\uD83D\uDC8A Supplements</span>
       </label>` : ''}
-      ${hasCycle ? `<label class="chart-layers-row" onclick="event.stopPropagation()">
-        <input type="checkbox" ${state.phaseOverlayMode === 'on' ? 'checked' : ''} onchange="setPhaseOverlay(this.checked?'on':'off')">
+      ${hasCycle ? `<label class="chart-layers-row" ${dataActionAttrs('chart-layers-row')}>
+        <input type="checkbox" ${state.phaseOverlayMode === 'on' ? 'checked' : ''} ${dataChangeAttrs('set-phase-overlay')}>
         <span>\uD83D\uDD34 Cycle Phases</span>
       </label>` : ''}
     </div>
@@ -909,7 +1001,7 @@ export function updateHeaderRangeToggle() {
   const canPatch = buttons.length === modes.length && modes.every(m => buttons.some(btn => btn.dataset.range === m));
   if (!canPatch) {
     el.innerHTML = modes.map(m =>
-      `<button class="range-toggle-btn${state.rangeMode === m ? ' active' : ''}" data-range="${m}" aria-pressed="${state.rangeMode === m ? 'true' : 'false'}" onclick="switchRangeMode('${m}')">${m.charAt(0).toUpperCase() + m.slice(1)}</button>`
+      `<button class="range-toggle-btn${state.rangeMode === m ? ' active' : ''}" type="button" data-range="${m}" aria-pressed="${state.rangeMode === m ? 'true' : 'false'}" ${dataActionAttrs('switch-range-mode', { range: m })}>${m.charAt(0).toUpperCase() + m.slice(1)}</button>`
     ).join('');
     return;
   }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 141,
+  "inlineEventAttributes": 132,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -171,6 +171,7 @@ const LEGACY_TESTS = [
   './test-light-page-view-delegated-actions.js',
   './test-light-env-delegated-actions.js',
   './test-compare-correlations-delegated-actions.js',
+  './test-data-delegated-actions.js',
   './test-sun-session-ui-delegated-actions.js',
   './test-marker-detail-delegated-actions.js',
   './test-wearables-delegated-actions.js',

--- a/tests/playwright/data-browser-coverage.spec.js
+++ b/tests/playwright/data-browser-coverage.spec.js
@@ -36,6 +36,7 @@ test('data browser coverage exercises display toggles range refresh and helpers'
       unitSystem: state.unitSystem,
       showAltUnits: state.showAltUnits,
       dateRangeFilter: state.dateRangeFilter,
+      profileSex: state.profileSex,
       phaseOverlayMode: state.phaseOverlayMode,
       rangeMode: state.rangeMode,
       activeDetailMarkerId: state._activeDetailMarkerId,
@@ -66,6 +67,7 @@ test('data browser coverage exercises display toggles range refresh and helpers'
       state.unitSystem = 'EU';
       state.showAltUnits = false;
       state.dateRangeFilter = 'all';
+      state.profileSex = 'female';
       state.phaseOverlayMode = 'off';
       state.rangeMode = 'optimal';
       state._activeDetailMarkerId = 'metabolic_glucose';
@@ -92,29 +94,42 @@ test('data browser coverage exercises display toggles range refresh and helpers'
         menstrualCycle: { periods: [{ startDate: '2025-12-28' }], cycleStatus: 'regular' },
       };
 
-      dataMod.setDateRange('6m');
+      const fixture = document.getElementById('fixture');
+      fixture.innerHTML = dataMod.renderDateRangeFilter();
+      const dateRangeBtn = fixture.querySelector('[data-lab-data-action="set-date-range"][data-lab-data-range="6m"]');
+      dateRangeBtn?.click();
       outcomes.setDateRangePersistsStateAndUsesCurrentView = state.dateRangeFilter === '6m'
+        && fixture.querySelectorAll('[onclick]').length === 0
         && calls.some(call => call[0] === 'buildSidebar')
         && calls.some(call => call[0] === 'navigate' && call[1] === 'metabolic');
 
-      const layersHost = document.getElementById('fixture');
+      const layersHost = fixture;
       layersHost.innerHTML = dataMod.renderChartLayersDropdown();
-      const stopCalls = [];
-      dataMod.toggleChartLayersDropdown({ stopPropagation: () => stopCalls.push('stop') });
+      const leakedLayerClicks = [];
+      document.addEventListener('click', () => leakedLayerClicks.push('click'));
+      const layerTrigger = layersHost.querySelector('[data-lab-data-action="toggle-chart-layers"]');
+      layerTrigger?.click();
       await wait(0);
       const dropdown = document.getElementById('chart-layers-dropdown');
       const trigger = document.querySelector('.chart-layers-trigger');
       const opened = dropdown?.classList.contains('open') === true && trigger?.getAttribute('aria-expanded') === 'true';
+      const phaseCheckbox = layersHost.querySelector('[data-lab-data-change="set-phase-overlay"]');
+      const phaseCallStart = calls.length;
+      phaseCheckbox?.click();
+      await wait(0);
+      const phaseChanged = state.phaseOverlayMode === 'on'
+        && localStorage.getItem(`labcharts-${profileId}-phaseOverlay`) === 'on'
+        && calls.slice(phaseCallStart).some(call => call[0] === 'navigate' && call[1] === 'metabolic');
+      const stayedOpenAfterLayerClick = dropdown?.classList.contains('open') === true
+        && trigger?.getAttribute('aria-expanded') === 'true'
+        && leakedLayerClicks.length === 0;
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
       const closed = dropdown?.classList.contains('open') === false && trigger?.getAttribute('aria-expanded') === 'false';
-      outcomes.chartLayersDropdownOpensAndClosesFromKeyboard = stopCalls.length === 1
+      outcomes.chartLayersDropdownOpensAndClosesFromKeyboard = layersHost.querySelectorAll('[onclick],[onchange]').length === 0
         && opened
+        && phaseChanged
+        && stayedOpenAfterLayerClick
         && closed;
-
-      dataMod.setPhaseOverlay('on');
-      outcomes.setPhaseOverlayPersistsAndNavigatesActiveCategory = state.phaseOverlayMode === 'on'
-        && localStorage.getItem(`labcharts-${profileId}-phaseOverlay`) === 'on'
-        && calls.some(call => call[0] === 'navigate' && call[1] === 'metabolic');
 
       const homaEntry = { markers: { 'biochemistry.glucose': 5, 'hormones.insulin': 8 } };
       dataMod.recalculateHOMAIR(homaEntry);
@@ -162,11 +177,13 @@ test('data browser coverage exercises display toggles range refresh and helpers'
       const prebuiltToggle = document.getElementById('header-range-toggle');
       const hasInitialRangeButtons = prebuiltToggle?.querySelectorAll('.range-toggle-btn').length === 3;
       calls.length = 0;
-      dataMod.switchRangeMode('both');
+      const rangeModeBtn = prebuiltToggle?.querySelector('[data-lab-data-action="switch-range-mode"][data-lab-data-range="both"]');
+      rangeModeBtn?.click();
       await wait(0);
       await wait(0);
       const activeBoth = document.querySelector('.range-toggle-btn[data-range="both"]');
       outcomes.switchRangeModeCapturesCardOrderAndRefreshesAfterPaint = hasInitialRangeButtons
+        && prebuiltToggle?.querySelectorAll('[onclick]').length === 0
         && state.rangeMode === 'both'
         && localStorage.getItem(`labcharts-${profileId}-rangeMode`) === 'both'
         && activeBoth?.classList.contains('active') === true
@@ -184,6 +201,7 @@ test('data browser coverage exercises display toggles range refresh and helpers'
       state.unitSystem = saved.unitSystem;
       state.showAltUnits = saved.showAltUnits;
       state.dateRangeFilter = saved.dateRangeFilter;
+      state.profileSex = saved.profileSex;
       state.phaseOverlayMode = saved.phaseOverlayMode;
       state.rangeMode = saved.rangeMode;
       if (saved.activeDetailMarkerId === undefined) delete state._activeDetailMarkerId;

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -123,8 +123,7 @@ console.log('=== Phase 3 A11y Tests ===\n');
   // ─── 6. Chart layers dropdown ARIA ───
   const dataSrc = read('/js/data.js');
   assert('chart-layers-trigger has aria-haspopup + aria-controls',
-    dataSrc.includes('class="view-btn chart-layers-trigger" aria-haspopup="true"') &&
-    dataSrc.includes('aria-controls="chart-layers-dropdown"'));
+    /<button class="view-btn chart-layers-trigger"[\s\S]{0,220}aria-haspopup="true"[\s\S]{0,220}aria-expanded="false"[\s\S]{0,220}aria-controls="chart-layers-dropdown"/.test(dataSrc));
   assert('chart-layers-dropdown has role=menu',
     dataSrc.includes('class="chart-layers-dropdown" id="chart-layers-dropdown" role="menu"'));
   assert('toggle handler updates aria-expanded',

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -134,7 +134,8 @@ await import('../js/charts.js');
   {
     const src = read('js/data.js');
     assert('Layers dropdown checks for cycle data', src.includes('hasCycle'));
-    assert('Layers dropdown has setPhaseOverlay', src.includes("setPhaseOverlay(this.checked"));
+    assert('Layers dropdown delegates setPhaseOverlay changes',
+      src.includes("dataChangeAttrs('set-phase-overlay')") && src.includes('setPhaseOverlay(mode)'));
     assert('Layers dropdown shows Cycle Phases label', src.includes('Cycle Phases'));
   }
 

--- a/tests/test-data-delegated-actions.js
+++ b/tests/test-data-delegated-actions.js
@@ -73,7 +73,7 @@ assert('range mode buttons keep data-range and use delegated actions',
   dataSrc.includes('data-range="${m}"')
   && dataSrc.includes("dataActionAttrs('switch-range-mode', { range: m })")
   && dataSrc.includes("action === 'switch-range-mode'")
-  && dataSrc.includes("switchRangeMode(actionEl.getAttribute(DATA_RANGE_ATTR) || 'optimal')"));
+  && /action === 'switch-range-mode'[\s\S]{0,220}switchRangeMode\(actionEl\.getAttribute\(DATA_RANGE_ATTR\) \|\| 'optimal'\);[\s\S]{0,60}return;/.test(dataSrc));
 
 console.log(`\nData delegated actions tests: ${pass} passed, ${fail} failed`);
 if (fail) process.exit(1);

--- a/tests/test-data-delegated-actions.js
+++ b/tests/test-data-delegated-actions.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Source-inspection coverage for data-view delegated actions.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+let pass = 0;
+let fail = 0;
+
+function assert(name, condition) {
+  if (condition) {
+    pass += 1;
+    console.log(`  PASS: ${name}`);
+  } else {
+    fail += 1;
+    console.log(`  FAIL: ${name}`);
+  }
+}
+
+const dataSrc = read('js/data.js');
+const eventNames = ['click', 'keydown', 'change', 'input', 'submit', 'blur', 'toggle'];
+const inlineEventPattern = new RegExp(`\\bon(?:${eventNames.join('|')})=["']`);
+
+console.log('=== Data Delegated Actions Tests ===');
+
+assert('data.js renderer emits no inline event attributes',
+  !inlineEventPattern.test(dataSrc));
+
+assert('data.js imports escapeAttr for delegated data attributes',
+  /import\s*\{[^}]*\bescapeAttr\b[^}]*\}\s*from\s*['"]\.\/utils\.js['"]/.test(dataSrc));
+
+assert('data action attribute helpers are exported',
+  /export function dataActionAttrs\(action, attrs = \{\}\)/.test(dataSrc)
+  && /export function dataChangeAttrs\(action, attrs = \{\}\)/.test(dataSrc)
+  && dataSrc.includes('data-lab-data-action')
+  && dataSrc.includes('data-lab-data-change'));
+
+assert('data delegates install idempotent click and change listeners',
+  dataSrc.includes('const dataActionDelegateRoots = new WeakSet();')
+  && dataSrc.includes("root.addEventListener('click', handleDataClick)")
+  && dataSrc.includes("root.addEventListener('change', handleDataChange)")
+  && dataSrc.includes('installDataActionDelegates();'));
+
+assert('date range buttons use delegated click actions',
+  dataSrc.includes("dataActionAttrs('set-date-range', { range: r.key })")
+  && dataSrc.includes("action === 'set-date-range'")
+  && dataSrc.includes("setDateRange(actionEl.getAttribute(DATA_RANGE_ATTR) || 'all')"));
+
+assert('chart layers trigger and rows use delegated click actions',
+  dataSrc.includes("dataActionAttrs('toggle-chart-layers')")
+  && dataSrc.includes("dataActionAttrs('chart-layers-row')")
+  && dataSrc.includes("action === 'toggle-chart-layers'")
+  && dataSrc.includes("action === 'chart-layers-row'"));
+
+assert('chart layer row delegate preserves old propagation containment',
+  dataSrc.includes('function containChartLayersClick(event)')
+  && dataSrc.includes('event.stopImmediatePropagation')
+  && dataSrc.includes('containChartLayersClick(event);'));
+
+assert('chart layer checkboxes use delegated change actions',
+  dataSrc.includes("dataChangeAttrs('set-note-overlay')")
+  && dataSrc.includes("dataChangeAttrs('set-supp-overlay')")
+  && dataSrc.includes("dataChangeAttrs('set-phase-overlay')")
+  && dataSrc.includes("setNoteOverlay(mode)")
+  && dataSrc.includes("setSuppOverlay(mode)")
+  && dataSrc.includes("setPhaseOverlay(mode)"));
+
+assert('range mode buttons keep data-range and use delegated actions',
+  dataSrc.includes('data-range="${m}"')
+  && dataSrc.includes("dataActionAttrs('switch-range-mode', { range: m })")
+  && dataSrc.includes("action === 'switch-range-mode'")
+  && dataSrc.includes("switchRangeMode(actionEl.getAttribute(DATA_RANGE_ATTR) || 'optimal')"));
+
+console.log(`\nData delegated actions tests: ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.510';
+self.APP_VERSION = '1.8.511';


### PR DESCRIPTION
## Summary
- Replaced data view inline event attributes with delegated data action/change handlers.
- Preserved chart-layer dropdown click containment while moving overlays and range controls to data attributes.
- Added source and browser coverage, lowered the inline-event baseline to 132, and bumped the app version to 1.8.511.

## Validation
- node --check js/data.js
- npm run quality
- npm run typecheck
- node tests/test-data-delegated-actions.js
- node tests/test-cycle-improvements.js
- node tests/test-a11y-phase3.js
- npx playwright test tests/playwright/data-browser-coverage.spec.js
- npm test
- git diff --check
- ./run-tests.sh