### PR TITLE
[codex] Delegate chat personality actions

### DIFF
--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -3,13 +3,98 @@
 
 import { state } from './state.js';
 import { CHAT_PERSONALITIES } from './constants.js';
-import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
+import { escapeAttr, escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelDisplay, isVeniceE2EEActive } from './api.js';
 import { saveChatThreadIndex, renderThreadList } from './chat-threads.js';
 import { CHAT_ICON_EDIT, CHAT_ICON_X } from './chat-icons.js';
 import { e2eeLockHTML } from './chat-attestation.js';
 
 const PERSONA_ICONS = ['🧠', '🎭', '🔮', '🌿', '⚡', '🦊', '🧬', '🌊', '🔥', '🏛️'];
+
+const CHAT_PERSONALITY_ACTION_ATTR = 'data-chat-personality-action';
+const CHAT_PERSONALITY_INPUT_ATTR = 'data-chat-personality-input';
+const CHAT_PERSONALITY_ID_ATTR = 'data-chat-personality-id';
+const CHAT_PERSONALITY_ACTION_SELECTOR = `[${CHAT_PERSONALITY_ACTION_ATTR}]`;
+const CHAT_PERSONALITY_INPUT_SELECTOR = `[${CHAT_PERSONALITY_INPUT_ATTR}]`;
+const chatPersonalityDelegateRoots = new WeakSet();
+
+function chatPersonalityAttrName(name) {
+  return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+function chatPersonalityAttrs(kind, action, attrs = {}) {
+  let html = `data-chat-personality-${kind}="${escapeAttr(action)}"`;
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null || value === false) continue;
+    html += ` data-chat-personality-${escapeAttr(chatPersonalityAttrName(name))}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+export function chatPersonalityActionAttrs(action, attrs = {}) {
+  return chatPersonalityAttrs('action', action, attrs);
+}
+
+export function chatPersonalityInputAttrs(action, attrs = {}) {
+  return chatPersonalityAttrs('input', action, attrs);
+}
+
+function closestChatPersonalityElement(target, selector) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function' ? target.closest(selector) : null
+  );
+}
+
+function rootContains(root, el) {
+  return !!(root && typeof root.contains === 'function' && root.contains(el));
+}
+
+function containPersonalityClick(event) {
+  event.stopPropagation();
+  if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
+}
+
+function handleChatPersonalityClick(event) {
+  const actionEl = closestChatPersonalityElement(event.target, CHAT_PERSONALITY_ACTION_SELECTOR);
+  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
+  const action = actionEl.getAttribute(CHAT_PERSONALITY_ACTION_ATTR);
+  const id = actionEl.getAttribute(CHAT_PERSONALITY_ID_ATTR) || '';
+  event.preventDefault();
+  if (action === 'edit-custom') {
+    containPersonalityClick(event);
+    if (id) editCustomPersonality(id);
+  } else if (action === 'delete-custom') {
+    containPersonalityClick(event);
+    if (id) void deleteCustomPersonality(id);
+  } else if (action === 'start-new-custom') {
+    startNewCustomPersonality();
+  } else if (action === 'generate-custom') {
+    void generateCustomPersonality();
+  } else if (action === 'save-custom') {
+    saveCustomPersonality();
+  }
+}
+
+function handleChatPersonalityInput(event) {
+  const actionEl = closestChatPersonalityElement(event.target, CHAT_PERSONALITY_INPUT_SELECTOR);
+  if (!actionEl || !rootContains(event.currentTarget, actionEl)) return;
+  const action = actionEl.getAttribute(CHAT_PERSONALITY_INPUT_ATTR);
+  if (action === 'mark-dirty') {
+    markPersonalityDirty();
+  } else if (action === 'resize-and-mark-dirty') {
+    autoResizePersonaTextarea();
+    markPersonalityDirty();
+  }
+}
+
+export function installChatPersonalityActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || chatPersonalityDelegateRoots.has(root)) return;
+  chatPersonalityDelegateRoots.add(root);
+  root.addEventListener('click', handleChatPersonalityClick);
+  root.addEventListener('input', handleChatPersonalityInput);
+}
+
+installChatPersonalityActionDelegates();
 
 /** @param {string} selector */
 function htmlBySelector(selector) {
@@ -211,7 +296,7 @@ export function updatePersonalityBar() {
   for (const cp of customs) {
     const isActive = cp.id === state.currentChatPersonality;
     html += `<div class="chat-personality-opt-wrapper">
-      <button class="chat-personality-opt${isActive ? ' active' : ''}" data-personality="${escapeHTML(cp.id)}" onclick="setChatPersonality('${escapeHTML(cp.id)}')">
+      <button class="chat-personality-opt${isActive ? ' active' : ''}" type="button" data-personality="${escapeAttr(cp.id)}" data-chat-action="set-personality">
         <span class="chat-personality-opt-icon">${cp.icon}</span>
         <div class="chat-personality-opt-info">
           <span class="chat-personality-opt-name">${escapeHTML(cp.name)}</span>
@@ -219,20 +304,20 @@ export function updatePersonalityBar() {
         </div>
         <span class="chat-personality-opt-check">&#10003;</span>
       </button>
-      <button class="chat-personality-edit" onclick="event.stopPropagation(); editCustomPersonality('${escapeHTML(cp.id)}')" title="Edit personality" aria-label="Edit personality">${CHAT_ICON_EDIT}</button>
-      <button class="chat-personality-delete" onclick="event.stopPropagation(); deleteCustomPersonality('${escapeHTML(cp.id)}')" title="Delete personality" aria-label="Delete personality">${CHAT_ICON_X}</button>
+      <button class="chat-personality-edit" type="button" ${chatPersonalityActionAttrs('edit-custom', { id: cp.id })} title="Edit personality" aria-label="Edit personality">${CHAT_ICON_EDIT}</button>
+      <button class="chat-personality-delete" type="button" ${chatPersonalityActionAttrs('delete-custom', { id: cp.id })} title="Delete personality" aria-label="Delete personality">${CHAT_ICON_X}</button>
     </div>`;
   }
-  html += '<button class="chat-personality-add-btn" onclick="startNewCustomPersonality()">+ New Personality</button>';
+  html += `<button class="chat-personality-add-btn" type="button" ${chatPersonalityActionAttrs('start-new-custom')}>+ New Personality</button>`;
   html += `<div class="chat-personality-custom-area" style="display:${showEditor ? 'block' : 'none'}">
     <div class="chat-personality-custom-header">
-      <input type="text" id="chat-personality-custom-name" class="chat-personality-custom-name-input" placeholder="e.g. A longevity researcher" maxlength="60" oninput="markPersonalityDirty()">
-      <button id="chat-personality-generate-btn" class="chat-personality-generate-btn" onclick="generateCustomPersonality()">Generate</button>
+      <input type="text" id="chat-personality-custom-name" class="chat-personality-custom-name-input" placeholder="e.g. A longevity researcher" maxlength="60" ${chatPersonalityInputAttrs('mark-dirty')}>
+      <button id="chat-personality-generate-btn" class="chat-personality-generate-btn" type="button" ${chatPersonalityActionAttrs('generate-custom')}>Generate</button>
     </div>
-    <textarea class="chat-personality-custom-textarea" placeholder="Describe how you want the AI to communicate, or type a name above and click Generate..." oninput="autoResizePersonaTextarea(); markPersonalityDirty()"></textarea>
+    <textarea class="chat-personality-custom-textarea" placeholder="Describe how you want the AI to communicate, or type a name above and click Generate..." ${chatPersonalityInputAttrs('resize-and-mark-dirty')}></textarea>
     <div class="chat-personality-custom-footer">
       <span class="chat-personality-disclaimer">Custom personas are for personal use. Don't impersonate real individuals without their consent.</span>
-      <button class="chat-personality-custom-save" onclick="saveCustomPersonality()" disabled>Save</button>
+      <button class="chat-personality-custom-save" type="button" ${chatPersonalityActionAttrs('save-custom')} disabled>Save</button>
     </div>
   </div>`;
   section.innerHTML = html;

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 132,
+  "inlineEventAttributes": 124,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -172,6 +172,7 @@ const LEGACY_TESTS = [
   './test-light-env-delegated-actions.js',
   './test-compare-correlations-delegated-actions.js',
   './test-data-delegated-actions.js',
+  './test-chat-personality-delegated-actions.js',
   './test-sun-session-ui-delegated-actions.js',
   './test-marker-detail-delegated-actions.js',
   './test-wearables-delegated-actions.js',

--- a/tests/playwright/custom-personality-dom.spec.js
+++ b/tests/playwright/custom-personality-dom.spec.js
@@ -7,6 +7,7 @@ function moduleUrl(path) {
 test('custom personality DOM renders editor controls and delegated discuss action', async ({ page }) => {
   const expectedOutcomeKeys = [
     'customSectionRenders',
+    'customSectionHasNoInlineHandlers',
     'customButtonsRender',
     'customEditorControlsRender',
     'customEditorFieldsPopulate',
@@ -54,20 +55,29 @@ test('custom personality DOM renders editor controls and delegated discuss actio
       const saveBtn = section?.querySelector('.chat-personality-custom-save');
 
       outcomes.customSectionRenders = !!section;
+      outcomes.customSectionHasNoInlineHandlers =
+        section?.querySelectorAll('[onclick],[oninput]').length === 0;
       outcomes.customButtonsRender = customBtns.length === 2
         && customBtns[0]?.dataset.personality === 'custom_abc'
+        && customBtns[0]?.getAttribute('data-chat-action') === 'set-personality'
         && customBtns[1]?.dataset.personality === 'custom_def'
+        && customBtns[1]?.getAttribute('data-chat-action') === 'set-personality'
         && customBtns[0]?.classList.contains('active') === true
         && customBtns[1]?.classList.contains('active') === false;
       outcomes.customEditorControlsRender = !!addBtn
         && addBtn.textContent.includes('New Personality')
+        && addBtn.getAttribute('data-chat-personality-action') === 'start-new-custom'
         && deleteBtns.length === 2
+        && deleteBtns[0]?.getAttribute('data-chat-personality-action') === 'delete-custom'
         && !!customArea
         && nameInput?.type === 'text'
+        && nameInput.getAttribute('data-chat-personality-input') === 'mark-dirty'
         && nameInput.placeholder.toLowerCase().includes('longevity')
         && genBtn?.textContent.trim() === 'Generate'
+        && genBtn?.getAttribute('data-chat-personality-action') === 'generate-custom'
         && !!textarea
-        && !!saveBtn;
+        && textarea.getAttribute('data-chat-personality-input') === 'resize-and-mark-dirty'
+        && saveBtn?.getAttribute('data-chat-personality-action') === 'save-custom';
       outcomes.customEditorFieldsPopulate = nameInput?.value === 'Longevity Expert'
         && textarea?.value === 'Expert prompt';
 
@@ -191,6 +201,7 @@ test('custom personality generator fills prompt and preserves selected custom te
           "'": '&#39;',
         })[ch]);
       }
+      export const escapeAttr = escapeHTML;
       export function showNotification() {}
       export async function showConfirmDialog() { return true; }
     `,
@@ -363,16 +374,19 @@ test('custom personality save path updates picker, header, and persisted state',
 
       state.chatHistory = [];
       window.updateChatHeaderTitle();
-      window.startNewCustomPersonality();
+      window.updatePersonalityBar();
+      document.querySelector('.chat-personality-add-btn')?.click();
+      await waitFor(() => !!document.getElementById('chat-personality-custom-name'));
       const nameInput = document.getElementById('chat-personality-custom-name');
       const textarea = document.querySelector('.chat-personality-custom-textarea');
       nameInput.value = 'Methodical Reviewer';
+      nameInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
       textarea.value = 'Prefer careful concise lab review.';
-      window.markPersonalityDirty();
+      textarea.dispatchEvent(new InputEvent('input', { bubbles: true }));
       outcomes.newCustomEditorEnablesSave =
         document.querySelector('.chat-personality-custom-save')?.disabled === false;
 
-      window.saveCustomPersonality();
+      document.querySelector('.chat-personality-custom-save')?.click();
       const savedCustoms = JSON.parse(localStorage.getItem(customKey) || '[]');
       const created = savedCustoms.find(personality => personality.name === 'Methodical Reviewer');
       outcomes.saveNewCustomPersistsSelectsAndUpdatesDisplay =

--- a/tests/test-chat-personality-delegated-actions.js
+++ b/tests/test-chat-personality-delegated-actions.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Source-inspection coverage for chat personality delegated actions.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+let pass = 0;
+let fail = 0;
+
+function assert(name, condition) {
+  if (condition) {
+    pass += 1;
+    console.log(`  PASS: ${name}`);
+  } else {
+    fail += 1;
+    console.log(`  FAIL: ${name}`);
+  }
+}
+
+const personalitySrc = read('js/chat-personalities.js');
+const eventNames = ['click', 'keydown', 'change', 'input', 'submit', 'blur', 'toggle'];
+const inlineEventPattern = new RegExp(`\\bon(?:${eventNames.join('|')})=["']`);
+
+console.log('=== Chat Personality Delegated Actions Tests ===');
+
+assert('chat-personalities.js renderer emits no inline event attributes',
+  !inlineEventPattern.test(personalitySrc));
+
+assert('chat-personalities imports escapeAttr for delegated data attributes',
+  /import\s*\{[^}]*\bescapeAttr\b[^}]*\}\s*from\s*['"]\.\/utils\.js['"]/.test(personalitySrc));
+
+assert('chat personality action and input helpers are exported',
+  /export function chatPersonalityActionAttrs\(action, attrs = \{\}\)/.test(personalitySrc)
+  && /export function chatPersonalityInputAttrs\(action, attrs = \{\}\)/.test(personalitySrc)
+  && personalitySrc.includes('data-chat-personality-action')
+  && personalitySrc.includes('data-chat-personality-input'));
+
+assert('chat personality delegates install idempotent click and input listeners',
+  personalitySrc.includes('const chatPersonalityDelegateRoots = new WeakSet();')
+  && personalitySrc.includes("root.addEventListener('click', handleChatPersonalityClick)")
+  && personalitySrc.includes("root.addEventListener('input', handleChatPersonalityInput)")
+  && personalitySrc.includes('installChatPersonalityActionDelegates();'));
+
+assert('custom personality selection reuses shell delegated chat action',
+  personalitySrc.includes('data-chat-action="set-personality"')
+  && personalitySrc.includes('data-personality="${escapeAttr(cp.id)}"'));
+
+assert('custom edit and delete buttons use delegated actions with containment',
+  personalitySrc.includes("chatPersonalityActionAttrs('edit-custom', { id: cp.id })")
+  && personalitySrc.includes("chatPersonalityActionAttrs('delete-custom', { id: cp.id })")
+  && personalitySrc.includes("action === 'edit-custom'")
+  && personalitySrc.includes("action === 'delete-custom'")
+  && personalitySrc.includes('containPersonalityClick(event);'));
+
+assert('custom add generate and save buttons use delegated actions',
+  personalitySrc.includes("chatPersonalityActionAttrs('start-new-custom')")
+  && personalitySrc.includes("chatPersonalityActionAttrs('generate-custom')")
+  && personalitySrc.includes("chatPersonalityActionAttrs('save-custom')")
+  && personalitySrc.includes("action === 'start-new-custom'")
+  && personalitySrc.includes("action === 'generate-custom'")
+  && personalitySrc.includes("action === 'save-custom'"));
+
+assert('custom name and textarea inputs use delegated input actions',
+  personalitySrc.includes("chatPersonalityInputAttrs('mark-dirty')")
+  && personalitySrc.includes("chatPersonalityInputAttrs('resize-and-mark-dirty')")
+  && personalitySrc.includes("action === 'mark-dirty'")
+  && personalitySrc.includes("action === 'resize-and-mark-dirty'")
+  && personalitySrc.includes('autoResizePersonaTextarea();')
+  && personalitySrc.includes('markPersonalityDirty();'));
+
+console.log(`\nChat personality delegated actions tests: ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.511';
+self.APP_VERSION = '1.8.512';


### PR DESCRIPTION
Summary:
- Replace custom personality picker/editor inline handlers with delegated actions.
- Reuse existing shell set-personality action for custom option selection.
- Add source and browser coverage, lower inline-event baseline to 124, and bump app version to 1.8.512.

Validation:
- node --check js/chat-personalities.js
- npm run quality
- npm run typecheck
- node tests/test-chat-personality-delegated-actions.js
- node tests/test-custom-personality.js
- npx playwright test tests/playwright/custom-personality-dom.spec.js
- npm test
- ./run-tests.sh