### PR TITLE
[codex] Delegate chat message actions

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -70,7 +70,7 @@ function handleRoleButtonKeydown(e) {
   const tag = t.tagName;
   if (tag === 'BUTTON' || tag === 'A' || tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
   // Don't fire twice if the element already has its own keydown wiring.
-  if (t.hasAttribute('onkeydown') || t.hasAttribute('data-chat-key-action')) return;
+  if (t.hasAttribute('onkeydown') || t.hasAttribute('data-chat-key-action') || t.hasAttribute('data-chat-message-action')) return;
   e.preventDefault();
   t.click();
 }

--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -34,15 +34,13 @@ function containChatMessageEvent(event) {
   if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
 }
 
-function handleChatMessageClick(event) {
-  const actionEl = closestChatMessageAction(event.target);
-  if (!actionEl) return;
+function runChatMessageAction(actionEl, event) {
   const action = actionEl.getAttribute(CHAT_MESSAGE_ACTION_ATTR);
   const appWindow = /** @type {any} */ (window);
 
   if (action === 'contain-click') {
     containChatMessageEvent(event);
-    return;
+    return true;
   }
 
   if (action === 'regenerate-last-message') {
@@ -93,19 +91,32 @@ function handleChatMessageClick(event) {
   } else if (action === 'end-discussion') {
     appWindow.endDiscussion?.();
   } else {
-    return;
+    return false;
   }
 
   event.preventDefault();
+  return true;
+}
+
+function handleChatMessageClick(event) {
+  const actionEl = closestChatMessageAction(event.target);
+  if (!actionEl) return;
+  runChatMessageAction(actionEl, event);
 }
 
 function handleChatMessageKeydown(event) {
-  if (event.key !== 'Enter') return;
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
-  if (target.dataset.chatMessageKeyAction !== 'continue-discussion') return;
-  event.preventDefault();
-  void /** @type {any} */ (window).continueDiscussion?.();
+  if (event.key === 'Enter' && target.dataset.chatMessageKeyAction === 'continue-discussion') {
+    event.preventDefault();
+    void /** @type {any} */ (window).continueDiscussion?.();
+    return;
+  }
+
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestChatMessageAction(target);
+  if (!actionEl || actionEl.getAttribute('role') !== 'button') return;
+  runChatMessageAction(actionEl, event);
 }
 
 export function installChatMessageActionDelegates(root = typeof document !== 'undefined' ? document : null) {

--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -5,6 +5,117 @@ import { state } from './state.js';
 import { escapeHTML } from './utils.js';
 import { CHAT_ICON_COPY, CHAT_ICON_REFRESH, setIconButtonContent } from './chat-icons.js';
 import { saveChatHistory } from './chat-history.js';
+import {
+  CHAT_MESSAGE_ACTION_ATTR,
+  CHAT_MESSAGE_ACTION_SELECTOR,
+  CHAT_MESSAGE_INDEX_ATTR,
+  chatMessageActionAttrs,
+} from './chat-message-action-attrs.js';
+
+let chatMessageDelegatesInstalled = false;
+export { chatMessageActionAttrs } from './chat-message-action-attrs.js';
+
+function closestChatMessageAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(CHAT_MESSAGE_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function readMessageIndex(actionEl) {
+  const raw = actionEl.getAttribute(CHAT_MESSAGE_INDEX_ATTR);
+  const index = raw == null ? NaN : Number(raw);
+  return Number.isInteger(index) ? index : null;
+}
+
+function containChatMessageEvent(event) {
+  event.stopPropagation();
+  if (typeof event.stopImmediatePropagation === 'function') event.stopImmediatePropagation();
+}
+
+function handleChatMessageClick(event) {
+  const actionEl = closestChatMessageAction(event.target);
+  if (!actionEl) return;
+  const action = actionEl.getAttribute(CHAT_MESSAGE_ACTION_ATTR);
+  const appWindow = /** @type {any} */ (window);
+
+  if (action === 'contain-click') {
+    containChatMessageEvent(event);
+    return;
+  }
+
+  if (action === 'regenerate-last-message') {
+    regenerateLastMessage();
+  } else if (action === 'copy-message') {
+    const index = readMessageIndex(actionEl);
+    if (index == null) return;
+    copyMessage(index);
+  } else if (action === 'toggle-context-details') {
+    const index = readMessageIndex(actionEl);
+    if (index == null) return;
+    toggleContextDetails(index);
+  } else if (action === 'remove-image-attachment') {
+    const index = readMessageIndex(actionEl);
+    if (index == null) return;
+    appWindow.removeImageAttachment?.(index);
+  } else if (action === 'open-image-lightbox') {
+    const src = actionEl instanceof HTMLImageElement ? actionEl.src : actionEl.dataset.chatMessageSrc;
+    if (!src) return;
+    appWindow.openImageLightbox?.(src);
+  } else if (action === 'open-emf-assessment') {
+    appWindow.openEMFAssessmentEditor?.();
+  } else if (action === 'jump-search-result') {
+    const index = readMessageIndex(actionEl);
+    const threadId = actionEl.dataset.chatMessageThreadId || '';
+    if (!threadId || index == null) return;
+    void appWindow.jumpToSearchResult?.(threadId, index, actionEl.dataset.chatMessagePrefix || '');
+  } else if (action === 'view-summary') {
+    const id = actionEl.dataset.chatMessageSummaryId || '';
+    if (!id) return;
+    appWindow.viewSavedSummary?.(id);
+  } else if (action === 'close-summary') {
+    appWindow.closeSummaryModal?.();
+  } else if (action === 'copy-summary') {
+    appWindow.copySummary?.();
+  } else if (action === 'download-summary') {
+    appWindow.downloadSummary?.();
+  } else if (action === 'print-summary') {
+    appWindow.printSummary?.();
+  } else if (action === 'delete-summary') {
+    const id = actionEl.dataset.chatMessageSummaryId || '';
+    if (!id) return;
+    void appWindow.deleteSavedSummary?.(id);
+  } else if (action === 'start-discussion-from-picker') {
+    void appWindow.startDiscussionFromPicker?.();
+  } else if (action === 'continue-discussion') {
+    void appWindow.continueDiscussion?.();
+  } else if (action === 'end-discussion') {
+    appWindow.endDiscussion?.();
+  } else {
+    return;
+  }
+
+  event.preventDefault();
+}
+
+function handleChatMessageKeydown(event) {
+  if (event.key !== 'Enter') return;
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  if (target.dataset.chatMessageKeyAction !== 'continue-discussion') return;
+  event.preventDefault();
+  void /** @type {any} */ (window).continueDiscussion?.();
+}
+
+export function installChatMessageActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || chatMessageDelegatesInstalled) return;
+  chatMessageDelegatesInstalled = true;
+  root.addEventListener('click', handleChatMessageClick);
+  root.addEventListener('keydown', handleChatMessageKeydown);
+}
+
+installChatMessageActionDelegates();
 
 export function buildActionBar(msgIndex) {
   const msg = state.chatHistory[msgIndex];
@@ -13,13 +124,13 @@ export function buildActionBar(msgIndex) {
 
   let html = '<div class="chat-action-bar">';
   if (isLast) {
-    html += `<button class="chat-action-btn" onclick="regenerateLastMessage()" title="Regenerate response">${CHAT_ICON_REFRESH}<span>Regenerate</span></button>`;
+    html += `<button class="chat-action-btn" type="button" ${chatMessageActionAttrs('regenerate-last-message')} title="Regenerate response">${CHAT_ICON_REFRESH}<span>Regenerate</span></button>`;
   }
-  html += `<button class="chat-action-btn" onclick="copyMessage(${msgIndex})" id="chat-copy-btn-${msgIndex}" title="Copy to clipboard">${CHAT_ICON_COPY}<span>Copy</span></button>`;
+  html += `<button class="chat-action-btn" type="button" ${chatMessageActionAttrs('copy-message', { index: msgIndex })} id="chat-copy-btn-${msgIndex}" title="Copy to clipboard">${CHAT_ICON_COPY}<span>Copy</span></button>`;
   html += '</div>';
 
   if (msg.context && msg.context.length > 0) {
-    html += `<div class="chat-context-toggle" onclick="toggleContextDetails(${msgIndex})">`;
+    html += `<div class="chat-context-toggle" role="button" tabindex="0" ${chatMessageActionAttrs('toggle-context-details', { index: msgIndex })}>`;
     html += `<span class="chat-toggle-arrow" id="chat-ctx-arrow-${msgIndex}">\u25B8</span> Context used (${msg.context.length} area${msg.context.length !== 1 ? 's' : ''})`;
     html += '</div>';
     html += `<div class="chat-context-details" id="chat-ctx-details-${msgIndex}" style="display:none">`;

--- a/js/chat-discussion-picker.js
+++ b/js/chat-discussion-picker.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { CHAT_PERSONALITIES } from './constants.js';
 import { escapeHTML } from './utils.js';
 import { getCustomPersonalities } from './chat-personalities.js';
+import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
 
 export function removeDiscussPersonaPicker() {
   const picker = document.querySelector('.discuss-persona-picker');
@@ -75,7 +76,7 @@ export function showDiscussPersonaPicker() {
       </label>`;
       }).join('')}
     </div>
-    <button class="discuss-picker-start" disabled onclick="startDiscussionFromPicker()">${addingToExisting ? 'Add to Discussion' : 'Start Debate'}</button>`;
+    <button class="discuss-picker-start" type="button" disabled ${chatMessageActionAttrs('start-discussion-from-picker')}>${addingToExisting ? 'Add to Discussion' : 'Start Debate'}</button>`;
 
   function updatePickerState() {
     const checkedCount = picker.querySelectorAll('input:checked:not([data-locked="1"])').length;

--- a/js/chat-discussion-ui.js
+++ b/js/chat-discussion-ui.js
@@ -3,6 +3,7 @@
 
 import { state } from './state.js';
 import { getThreadPersonaCount } from './chat-discussion-state.js';
+import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
 
 export {
   readDiscussPersonaPickerSelection,
@@ -36,10 +37,10 @@ export function showDiscussContinuePrompt(personas, originalPersonality, { onPer
 
   const prompt = document.createElement('div');
   prompt.className = 'chat-discuss-continue';
-  prompt.innerHTML = '<input type="text" class="chat-discuss-steer" id="chat-discuss-steer" autocomplete="off" placeholder="Steer the debate (optional)..." onkeydown="if(event.key===\'Enter\'){event.preventDefault();continueDiscussion()}">' +
+  prompt.innerHTML = '<input type="text" class="chat-discuss-steer" id="chat-discuss-steer" autocomplete="off" placeholder="Steer the debate (optional)..." data-chat-message-key-action="continue-discussion">' +
     '<div class="chat-discuss-continue-actions">' +
-    '<button class="chat-discuss-continue-btn" onclick="continueDiscussion()">Continue</button>' +
-    '<button class="chat-discuss-done-btn" onclick="endDiscussion()">Done</button>' +
+    `<button class="chat-discuss-continue-btn" type="button" ${chatMessageActionAttrs('continue-discussion')}>Continue</button>` +
+    `<button class="chat-discuss-done-btn" type="button" ${chatMessageActionAttrs('end-discussion')}>Done</button>` +
     '</div>';
   container.appendChild(prompt);
   container.scrollTop = container.scrollHeight;

--- a/js/chat-images.js
+++ b/js/chat-images.js
@@ -15,6 +15,7 @@ import { escapeHTML, showNotification } from './utils.js';
 import { resizeImage, isValidImageType } from './image-utils.js';
 import { hasAIProvider, supportsVision } from './api.js';
 import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
 
 const MAX_ATTACHMENTS = 5;
 const THUMB_SIZE = 80;
@@ -109,7 +110,7 @@ export function renderAttachmentPreview() {
   container.innerHTML = _pendingAttachments.map((att, i) =>
     `<div class="chat-attach-thumb" title="${escapeHTML(att.name)}">` +
     `<img src="${att.previewUrl}" alt="${escapeHTML(att.name)}">` +
-    `<button class="chat-attach-remove" onclick="removeImageAttachment(${i})" aria-label="Remove">&times;</button>` +
+    `<button class="chat-attach-remove" type="button" ${chatMessageActionAttrs('remove-image-attachment', { index: i })} aria-label="Remove">&times;</button>` +
     `</div>`
   ).join('') +
   `<span class="chat-attach-count">${_pendingAttachments.length}/${MAX_ATTACHMENTS}</span>`;
@@ -217,8 +218,8 @@ export function initChatImageHandlers() {
   }
 }
 
-// HTML onclicks call these names directly; main.js / chat.js init also
-// wires initChatImageHandlers() on DOMContentLoaded.
+// Keep legacy window exports; main.js / chat.js init also wires
+// initChatImageHandlers() on DOMContentLoaded.
 Object.assign(window, {
   toggleHDMode,
   addImageAttachment,

--- a/js/chat-message-action-attrs.js
+++ b/js/chat-message-action-attrs.js
@@ -1,0 +1,21 @@
+// @ts-check
+// chat-message-action-attrs.js - no-dependency delegated chat action attributes
+
+import { escapeAttr } from './utils.js';
+
+export const CHAT_MESSAGE_ACTION_ATTR = 'data-chat-message-action';
+export const CHAT_MESSAGE_INDEX_ATTR = 'data-chat-message-index';
+export const CHAT_MESSAGE_ACTION_SELECTOR = `[${CHAT_MESSAGE_ACTION_ATTR}]`;
+
+function chatMessageAttrName(name) {
+  return String(name).replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+}
+
+export function chatMessageActionAttrs(action, attrs = {}) {
+  let html = `${CHAT_MESSAGE_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null || value === false) continue;
+    html += ` data-chat-message-${escapeAttr(chatMessageAttrName(name))}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}

--- a/js/chat-render.js
+++ b/js/chat-render.js
@@ -8,7 +8,7 @@ import {
   getAIProvider, getActiveModelDisplay, getActiveModelId,
 } from './api.js';
 import { renderMarkdown } from './markdown.js';
-import { buildActionBar } from './chat-actions.js';
+import { buildActionBar, chatMessageActionAttrs } from './chat-actions.js';
 import { responseLimitNote } from './chat-continuation.js';
 import { e2eeLockFootnote } from './chat-attestation.js';
 import { updateChatHeaderTitle } from './chat-personalities.js';
@@ -34,7 +34,7 @@ export function _renderLensSources(chunks, sourceName) {
       ? `<span class="chat-lens-source-score" title="Cosine similarity">${c.score.toFixed(2)}</span>`
       : '';
     const text = c.text ? escapeHTML(c.text).replace(/\n/g, '<br>') : '';
-    return `<details class="chat-lens-source" onclick="event.stopPropagation()">
+    return `<details class="chat-lens-source" ${chatMessageActionAttrs('contain-click')}>
       <summary class="chat-lens-source-summary">
         <span class="chat-lens-source-name">${escapeHTML(src)}</span>
         ${score}
@@ -42,7 +42,7 @@ export function _renderLensSources(chunks, sourceName) {
       <div class="chat-lens-source-text">${text}</div>
     </details>`;
   }).join('');
-  return `<details class="chat-lens-sources" onclick="event.stopPropagation()">
+  return `<details class="chat-lens-sources" ${chatMessageActionAttrs('contain-click')}>
     <summary class="chat-lens-sources-summary">📎 ${chunks.length} excerpt${chunks.length !== 1 ? 's' : ''} from ${sourceLabel}</summary>
     <div class="chat-lens-sources-body">${items}</div>
   </details>`;
@@ -82,7 +82,7 @@ export function renderChatMessages() {
     if (msg.hasImages) {
       if (msg.thumbnails && msg.thumbnails.length > 0) {
         imageBadge = '<div class="chat-image-thumbs">' + msg.thumbnails.map(t =>
-          `<img src="${t}" class="chat-image-thumb" alt="attached image" onclick="openImageLightbox(this.src)">`
+          `<img src="${t}" class="chat-image-thumb" alt="attached image" ${chatMessageActionAttrs('open-image-lightbox')}>`
         ).join('') + '</div>';
       } else {
         imageBadge = `<div class="chat-image-badge">\uD83D\uDDBC ${msg.imageCount} image${msg.imageCount !== 1 ? 's' : ''} attached</div>`;
@@ -111,8 +111,7 @@ export function renderChatMessages() {
       }
       // EMF hint (persisted, single-line link to assessment editor)
       if (msg.emfHint && window.isProductRecsEnabled?.()) {
-        const openHandler = `event.preventDefault();window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor();`;
-        html += `<div class="chat-emf-hint"><span aria-hidden="true">💡</span> Curious about your EMF environment? <a href="#" onclick="${openHandler}" data-umami-event="emf-nudge-chat">Open the assessment →</a></div>`;
+        html += `<div class="chat-emf-hint"><span aria-hidden="true">💡</span> Curious about your EMF environment? <a href="#" ${chatMessageActionAttrs('open-emf-assessment')} data-umami-event="emf-nudge-chat">Open the assessment →</a></div>`;
       }
       // Rec slots (persisted on message, rendered from catalog)
       if (msg.recSlots?.length && window.isProductRecsEnabled?.() && window.renderRecommendationSectionSync && window._cachedCatalog?.slots) {
@@ -121,7 +120,7 @@ export function renderChatMessages() {
           return window.renderRecommendationSectionSync(slot, { label: slotLabel, maxProducts: 2 });
         }).filter(Boolean);
         if (recSections.length) {
-          html += `<details class="rec-chat-wrapper" onclick="event.stopPropagation()"><summary class="rec-chat-summary">What can help</summary>`;
+          html += `<details class="rec-chat-wrapper" ${chatMessageActionAttrs('contain-click')}><summary class="rec-chat-summary">What can help</summary>`;
           let recBody = recSections.map(s => s.replace('rec-section-header', 'rec-chat-subheading')).join('');
           // Deduplicate disclosure banners (each renderRecommendationSectionSync prepends one)
           let bannerCount = 0;

--- a/js/chat-render.js
+++ b/js/chat-render.js
@@ -18,6 +18,12 @@ import { renderEmptyChatState } from './chat-empty-state.js';
 
 export { _getNoDataPrompts } from './chat-empty-state.js';
 
+function bindRenderedChatContainClicks(container) {
+  container.querySelectorAll('[data-chat-message-action="contain-click"]').forEach(el => {
+    el.addEventListener('click', event => event.stopPropagation());
+  });
+}
+
 /**
  * Render the collapsible "Sources" block under an assistant message.
  * Shows the excerpts the lens returned for this question — filename, score,
@@ -133,6 +139,7 @@ export function renderChatMessages() {
     html += '</div>';
   }
   container.innerHTML = html;
+  bindRenderedChatContainClicks(container);
   container.scrollTop = container.scrollHeight;
   updateDiscussButton();
   updateChatHeaderTitle();

--- a/js/chat-send.js
+++ b/js/chat-send.js
@@ -387,7 +387,6 @@ export async function sendChatMessage() {
         const wrapper = document.createElement('details');
         wrapper.className = 'rec-chat-wrapper';
         wrapper.open = true;
-        wrapper.setAttribute('data-chat-message-action', 'contain-click');
         wrapper.addEventListener('click', e => e.stopPropagation());
         const summary = document.createElement('summary');
         summary.className = 'rec-chat-summary';

--- a/js/chat-send.js
+++ b/js/chat-send.js
@@ -30,7 +30,7 @@ import {
   getActivePersonality, getCustomPersonality, updateChatHeaderTitle,
 } from './chat-personalities.js';
 import { saveChatHistory } from './chat-history.js';
-import { buildActionBar } from './chat-actions.js';
+import { buildActionBar, chatMessageActionAttrs } from './chat-actions.js';
 import { getChatWebSearchEnabled } from './chat-panel.js';
 import {
   getCurrentDiscussionState, sendDiscussionUserTurn, updateDiscussButton,
@@ -355,7 +355,7 @@ export async function sendChatMessage() {
         if (!aiMsgEl?.isConnected) return;
         const hintEl = document.createElement('div');
         hintEl.className = 'chat-emf-hint';
-        hintEl.innerHTML = `<span aria-hidden="true">💡</span> Curious about your EMF environment? <a href="#" onclick="event.preventDefault();window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor();" data-umami-event="emf-nudge-chat">Open the assessment →</a>`;
+        hintEl.innerHTML = `<span aria-hidden="true">💡</span> Curious about your EMF environment? <a href="#" ${chatMessageActionAttrs('open-emf-assessment')} data-umami-event="emf-nudge-chat">Open the assessment →</a>`;
         const actionBar = aiMsgEl.querySelector('.chat-action-bar');
         if (actionBar) aiMsgEl.insertBefore(hintEl, actionBar);
         else aiMsgEl.appendChild(hintEl);
@@ -387,7 +387,8 @@ export async function sendChatMessage() {
         const wrapper = document.createElement('details');
         wrapper.className = 'rec-chat-wrapper';
         wrapper.open = true;
-        wrapper.onclick = (e) => e.stopPropagation();
+        wrapper.setAttribute('data-chat-message-action', 'contain-click');
+        wrapper.addEventListener('click', e => e.stopPropagation());
         const summary = document.createElement('summary');
         summary.className = 'rec-chat-summary';
         summary.textContent = 'What can help';

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -9,6 +9,7 @@ import { callClaudeAPI, getActiveModelDisplay, getActiveModelId, getAIProvider, 
 import { renderThreadList, saveChatThreadIndex } from './chat-threads.js';
 import { renderMarkdown } from './markdown.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
 import {
   appendImportedArrayItem,
   deleteImportedArrayItems,
@@ -237,7 +238,7 @@ export function renderSavedSummaries() {
     summaries.map(s => {
       const date = new Date(s.createdAt);
       const dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-      return `<div class="chat-saved-summary-item" onclick="viewSavedSummary('${escapeHTML(s.id)}')">
+      return `<div class="chat-saved-summary-item" role="button" tabindex="0" ${chatMessageActionAttrs('view-summary', { summaryId: s.id })}>
         <div class="chat-saved-summary-name">${escapeHTML(s.threadName)}</div>
         <div class="chat-saved-summary-meta">${dateStr}${s.model ? ' \u00b7 ' + escapeHTML(s.model) : ''}</div>
       </div>`;
@@ -253,7 +254,10 @@ function _showSummaryModal(summaryText, thread, loading = false, usageInfo = nul
     overlay.className = 'modal-overlay';
     let mdInside = false;
     overlay.addEventListener('mousedown', (e) => { mdInside = e.target !== overlay; });
-    overlay.onclick = (e) => { if (e.target === overlay && !mdInside) _closeSummaryModal(); mdInside = false; };
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay && !mdInside) _closeSummaryModal();
+      mdInside = false;
+    });
     document.body.appendChild(overlay);
   } else if (!overlay.classList.contains('show')) {
     overlay.className = 'modal-overlay';
@@ -283,15 +287,15 @@ function _showSummaryModal(summaryText, thread, loading = false, usageInfo = nul
   }
 
   overlay.innerHTML = `<div class="modal">
-    <button class="modal-close" onclick="closeSummaryModal()" aria-label="Close">&times;</button>
+    <button class="modal-close" type="button" ${chatMessageActionAttrs('close-summary')} aria-label="Close">&times;</button>
     <h3>Summary</h3>
     <div class="summary-modal-meta">${threadName}${dateStr ? ' \u00b7 ' + dateStr : ''}${modelStr}${costLine}</div>
     <div id="summary-modal-body" class="summary-modal-body">${bodyContent}</div>
     <div class="summary-modal-actions"${loading ? ' style="display:none"' : ''}>
-      <button class="summary-action-btn" onclick="copySummary()" title="Copy as markdown">Copy</button>
-      <button class="summary-action-btn" onclick="downloadSummary()" title="Download as .md file">Download</button>
-      <button class="summary-action-btn" onclick="printSummary()" title="Print">Print</button>
-      ${thread?._savedId ? `<button class="summary-action-btn secondary delete" onclick="deleteSavedSummary('${escapeHTML(thread._savedId)}')" title="Delete summary">Delete</button>` : ''}
+      <button class="summary-action-btn" type="button" ${chatMessageActionAttrs('copy-summary')} title="Copy as markdown">Copy</button>
+      <button class="summary-action-btn" type="button" ${chatMessageActionAttrs('download-summary')} title="Download as .md file">Download</button>
+      <button class="summary-action-btn" type="button" ${chatMessageActionAttrs('print-summary')} title="Print">Print</button>
+      ${thread?._savedId ? `<button class="summary-action-btn secondary delete" type="button" ${chatMessageActionAttrs('delete-summary', { summaryId: thread._savedId })} title="Delete summary">Delete</button>` : ''}
     </div>
   </div>`;
   openModalOverlay(overlay);

--- a/js/chat-thread-search.js
+++ b/js/chat-thread-search.js
@@ -4,6 +4,7 @@
 import { state } from './state.js';
 import { encryptedGetItem, getEncryptionEnabled } from './crypto.js';
 import { escapeHTML } from './utils.js';
+import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
 
 /** @type {{
  *   getChatThreadKey: (threadId: string) => string,
@@ -104,7 +105,7 @@ function showSearchResults(query, results) {
   list.innerHTML = `<div class="chat-search-results-label">Messages</div>` +
     visibleResults.map(r => {
       const icon = r.role === 'user' ? '\uD83D\uDCDD' : '\uD83E\uDD16';
-      return `<div class="chat-search-result" data-prefix="${escapeHTML(r.contentPrefix)}" onclick="jumpToSearchResult('${escapeHTML(r.threadId)}',${r.msgIndex},this.dataset.prefix)">
+      return `<div class="chat-search-result" ${chatMessageActionAttrs('jump-search-result', { threadId: r.threadId, index: r.msgIndex, prefix: r.contentPrefix })}>
         <div class="chat-search-result-thread">${escapeHTML(r.threadName)}</div>
         <div class="chat-search-result-snippet">${icon} ${escapeHTML(r.pre)}<mark>${escapeHTML(r.match)}</mark>${escapeHTML(r.post)}</div>
       </div>`;

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 124,
+  "inlineEventAttributes": 103,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -173,6 +173,7 @@ const LEGACY_TESTS = [
   './test-compare-correlations-delegated-actions.js',
   './test-data-delegated-actions.js',
   './test-chat-personality-delegated-actions.js',
+  './test-chat-message-delegated-actions.js',
   './test-sun-session-ui-delegated-actions.js',
   './test-marker-detail-delegated-actions.js',
   './test-wearables-delegated-actions.js',

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -131,7 +131,9 @@ test('chat action browser coverage handles copy and regenerate branches', async 
       outcomes.buildActionBarEscapesContextAndAddsLastRegenerate = (() => {
         const html = chatActions.buildActionBar(1);
         return html.includes('Regenerate')
-          && html.includes('copyMessage(1)')
+          && html.includes('data-chat-message-action="copy-message"')
+          && html.includes('data-chat-message-index="1"')
+          && !html.includes('onclick=')
           && html.includes('&lt;Labs&gt;')
           && html.includes('5 &gt; 3')
           && chatActions.buildActionBar(0) === ''

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -62,6 +62,69 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
       } finally {
         testDiv.remove();
       }
+
+      const keyDiv = document.createElement('div');
+      keyDiv.innerHTML = '<div id="chat-ctx-details-42" style="display:none">content</div>' +
+        '<span id="chat-ctx-arrow-42">▸</span>' +
+        '<div id="chat-ctx-key-42" role="button" tabindex="0" data-chat-message-action="toggle-context-details" data-chat-message-index="42">Context</div>';
+      document.body.appendChild(keyDiv);
+      try {
+        const keyToggle = document.getElementById('chat-ctx-key-42');
+        const details = document.getElementById('chat-ctx-details-42');
+        const enterPrevented = keyToggle
+          ? !keyToggle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+          : false;
+        const opens = details?.style.display === 'flex';
+        const spacePrevented = keyToggle
+          ? !keyToggle.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }))
+          : false;
+        outcomes.roleButtonContextKeyboardDelegates = enterPrevented
+          && opens
+          && spacePrevented
+          && details?.style.display === 'none';
+      } finally {
+        keyDiv.remove();
+      }
+
+      const savedViewSavedSummary = window.viewSavedSummary;
+      const summaryButton = document.createElement('div');
+      let viewedSummaryId = null;
+      summaryButton.setAttribute('role', 'button');
+      summaryButton.setAttribute('tabindex', '0');
+      summaryButton.setAttribute('data-chat-message-action', 'view-summary');
+      summaryButton.setAttribute('data-chat-message-summary-id', 'summary-keyboard');
+      document.body.appendChild(summaryButton);
+      try {
+        window.viewSavedSummary = id => { viewedSummaryId = id; };
+        const summaryPrevented = !summaryButton.dispatchEvent(
+          new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
+        );
+        outcomes.roleButtonSummaryKeyboardDelegates = summaryPrevented
+          && viewedSummaryId === 'summary-keyboard';
+      } finally {
+        window.viewSavedSummary = savedViewSavedSummary;
+        summaryButton.remove();
+      }
+
+      if (realContainer) {
+        let bubbled = 0;
+        const onBubble = () => { bubbled += 1; };
+        realContainer.addEventListener('click', onBubble);
+        try {
+          state.chatHistory = [{
+            role: 'assistant',
+            content: 'Answer',
+            lensSources: [{ source: 'notes.md', score: 0.75, text: 'Relevant excerpt' }],
+            lensSourceName: 'notes',
+          }];
+          window.renderChatMessages();
+          const lensSummary = realContainer.querySelector('.chat-lens-source-summary');
+          lensSummary?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+          outcomes.renderedContainClickStopsAtElement = !!lensSummary && bubbled === 0;
+        } finally {
+          realContainer.removeEventListener('click', onBubble);
+        }
+      }
     } finally {
       state.chatHistory = originalHistory;
     }

--- a/tests/playwright/chat-ui-browser-coverage.spec.js
+++ b/tests/playwright/chat-ui-browser-coverage.spec.js
@@ -228,6 +228,9 @@ test('chat thread search covers message results clearing and jump highlighting',
       outcomes.searchShowsEscapedMessageResult = !!result
         && result.querySelector('.chat-search-result-thread')?.textContent === 'Ferritin <Plan>'
         && result.querySelector('mark')?.textContent.toLowerCase() === 'ferritin'
+        && result.getAttribute('data-chat-message-action') === 'jump-search-result'
+        && result.getAttribute('data-chat-message-thread-id') === 'thread_a'
+        && !result.hasAttribute('onclick')
         && renderCalls.includes('ferritin');
 
       await threadSearch.jumpToSearchResult('thread_a', 0, messagesByThread.thread_a[0].content.slice(0, 50));
@@ -464,7 +467,9 @@ test('chat summaries cover saved summary modal actions without network calls', a
       const savedItems = [...document.querySelectorAll('.chat-saved-summary-item')];
       outcomes.savedSummariesRenderNewestFirstEscaped = savedItems.length === 2
         && savedItems[0].querySelector('.chat-saved-summary-name')?.textContent === 'Wellness <Plan>'
-        && savedItems[0].getAttribute('onclick')?.includes('s_new');
+        && savedItems[0].getAttribute('data-chat-message-action') === 'view-summary'
+        && savedItems[0].getAttribute('data-chat-message-summary-id') === 's_new'
+        && !savedItems[0].hasAttribute('onclick');
 
       await summaries.summarizeThread();
       outcomes.existingThreadSummaryOpensModal = document.getElementById('summary-modal-overlay')?.classList.contains('show') === true
@@ -585,6 +590,8 @@ test('chat discussion picker lifecycle and resume binding cover browser state pa
       firstInputs[1].click();
       outcomes.newDiscussionPickerRequiresTwoSelections =
         firstPicker.querySelector('.discuss-picker-start')?.disabled === false
+        && firstPicker.querySelector('.discuss-picker-start')?.getAttribute('data-chat-message-action') === 'start-discussion-from-picker'
+        && !firstPicker.querySelector('.discuss-picker-start')?.hasAttribute('onclick')
         && picker.readDiscussPersonaPickerSelection()?.allPersonas.length === 2
         && firstInputs.slice(2).every(input => input.disabled);
 
@@ -603,6 +610,9 @@ test('chat discussion picker lifecycle and resume binding cover browser state pa
 
       lifecycle.showDiscussContinuePrompt(personas, 'default');
       outcomes.continuePromptPersistsThreadState = !!document.querySelector('.chat-discuss-continue')
+        && document.querySelector('.chat-discuss-steer')?.getAttribute('data-chat-message-key-action') === 'continue-discussion'
+        && document.querySelector('.chat-discuss-continue-btn')?.getAttribute('data-chat-message-action') === 'continue-discussion'
+        && document.querySelector('.chat-discuss-done-btn')?.getAttribute('data-chat-message-action') === 'end-discussion'
         && state.chatThreads[0].discussionPersonas?.length === 2
         && state._discussionPersonas?.length === 2;
 

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -227,13 +227,26 @@ if (hasState) {
   assert('Non-last AI msg has NO Regenerate', !bar1.includes('Regenerate'), 'no Regenerate for non-last');
   assert('AI msg has NO Read button (removed)', !bar1.includes('Read'), 'no Read button');
   assert('AI msg has Copy button', bar1.includes('Copy'), 'contains Copy');
+  assert('AI msg copy button uses delegated action',
+    bar1.includes('data-chat-message-action="copy-message"')
+      && bar1.includes('data-chat-message-index="1"')
+      && !bar1.includes('onclick='),
+    'delegated copy');
 
   const bar3 = buildActionBar(3);
   assert('Last AI msg has Regenerate', bar3.includes('Regenerate'), 'contains Regenerate');
   assert('Last AI msg has Copy', bar3.includes('Copy'), 'contains Copy');
   assert('Last AI msg has NO Read', !bar3.includes('Read'), 'no Read');
+  assert('Last AI msg regenerate button uses delegated action',
+    bar3.includes('data-chat-message-action="regenerate-last-message"'),
+    'delegated regenerate');
 
   assert('AI msg with context has context toggle', bar1.includes('chat-context-toggle'), 'contains toggle');
+  assert('AI msg context toggle uses delegated action',
+    bar1.includes('data-chat-message-action="toggle-context-details"')
+      && bar1.includes('role="button"')
+      && bar1.includes('tabindex="0"'),
+    'delegated context');
   assert('Context shows area count', bar1.includes('1 area'), 'shows 1 area');
   assert('Context details are hidden by default', bar1.includes('display:none'), 'hidden');
   assert('Context item has checkmark', bar1.includes('✓'), 'has checkmark');
@@ -334,6 +347,7 @@ console.log('Section 17: Source inspection');
 const chatSrc = read('js/chat.js');
 const chatWindowBindingsSrc = read('js/chat-window-bindings.js');
 const chatActionsSrc = read('js/chat-actions.js');
+const chatMessageActionAttrsSrc = read('js/chat-message-action-attrs.js');
 const chatAttestationSrc = read('js/chat-attestation.js');
 const chatIconsSrc = read('js/chat-icons.js');
 const chatSummariesSrc = read('js/chat-summaries.js');
@@ -366,6 +380,18 @@ assert('chat.js loads window bindings entry', chatSrc.includes("import './chat-w
 assert('chat.js imports action helpers', chatSrc.includes("from './chat-actions.js'"), 'found');
 assert('chat-actions.js exports buildActionBar', chatActionsSrc.includes('export function buildActionBar'), 'found');
 assert('chat-actions.js keeps buildActionBar off window', !chatActionsSrc.includes('  buildActionBar,'), 'not a window handler');
+assert('chat-actions.js installs delegated chat message actions',
+  chatActionsSrc.includes("from './chat-message-action-attrs.js'")
+    && chatActionsSrc.includes("export { chatMessageActionAttrs } from './chat-message-action-attrs.js'")
+    && chatActionsSrc.includes('installChatMessageActionDelegates();')
+    && chatActionsSrc.includes("root.addEventListener('click', handleChatMessageClick)")
+    && chatActionsSrc.includes("root.addEventListener('keydown', handleChatMessageKeydown)"),
+  'found');
+assert('chat message action attrs helper stays dependency-light',
+  chatMessageActionAttrsSrc.includes('export function chatMessageActionAttrs(action, attrs = {})')
+    && chatMessageActionAttrsSrc.includes("import { escapeAttr } from './utils.js'")
+    && !chatMessageActionAttrsSrc.includes("from './chat-actions.js'"),
+  'found');
 assert('chat-actions.js exports regenerateLastMessage', chatActionsSrc.includes('export function regenerateLastMessage'), 'found');
 assert('chat.js does NOT have readAloud', !chatSrc.includes('function readAloud'), 'removed');
 assert('chat-actions.js exports copyMessage', chatActionsSrc.includes('export function copyMessage'), 'found');
@@ -617,8 +643,8 @@ if (hasState) {
 
   const bar0 = buildActionBar(1); // first AI msg
   const barLast = buildActionBar(3); // last AI msg
-  assert('First AI msg (non-last) has no Regenerate', !bar0.includes('regenerateLastMessage'), 'no regenerate');
-  assert('Last AI msg has Regenerate', barLast.includes('regenerateLastMessage'), 'has regenerate');
+  assert('First AI msg (non-last) has no Regenerate', !bar0.includes('regenerate-last-message'), 'no regenerate');
+  assert('Last AI msg has Regenerate', barLast.includes('regenerate-last-message'), 'has regenerate');
 } else {
   console.warn('Skipping regenerate placement tests — _labState not available');
 }

--- a/tests/test-chat-message-delegated-actions.js
+++ b/tests/test-chat-message-delegated-actions.js
@@ -73,12 +73,22 @@ assert('chat-actions delegates dynamic chat controls',
   ].every(action => actionsSrc.includes(`action === '${action}'`)));
 
 const renderSrc = read('js/chat-render.js');
+const sendSrc = read('js/chat-send.js');
 const summariesSrc = read('js/chat-summaries.js');
 const discussionUiSrc = read('js/chat-discussion-ui.js');
+assert('chat-actions keyboard activates delegated role button actions',
+  actionsSrc.includes("event.key !== 'Enter' && event.key !== ' '")
+    && actionsSrc.includes("actionEl.getAttribute('role') !== 'button'")
+    && actionsSrc.includes('runChatMessageAction(actionEl, event)'));
 assert('chat render uses delegated image emf lens and recommendation actions',
   renderSrc.includes("chatMessageActionAttrs('open-image-lightbox')")
     && renderSrc.includes("chatMessageActionAttrs('open-emf-assessment')")
-    && renderSrc.includes("chatMessageActionAttrs('contain-click')"));
+    && renderSrc.includes("chatMessageActionAttrs('contain-click')")
+    && renderSrc.includes("el.addEventListener('click', event => event.stopPropagation())")
+    && renderSrc.includes('bindRenderedChatContainClicks(container)'));
+assert('dynamic recommendation wrapper keeps direct containment without dead delegated attr',
+  sendSrc.includes("wrapper.addEventListener('click', e => e.stopPropagation())")
+    && !sendSrc.includes("wrapper.setAttribute('data-chat-message-action', 'contain-click')"));
 assert('summary list and modal use delegated summary actions',
   summariesSrc.includes("chatMessageActionAttrs('view-summary', { summaryId: s.id })")
     && summariesSrc.includes("chatMessageActionAttrs('close-summary')")

--- a/tests/test-chat-message-delegated-actions.js
+++ b/tests/test-chat-message-delegated-actions.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Source-inspection coverage for delegated chat message controls.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+let pass = 0;
+let fail = 0;
+
+function assert(name, condition) {
+  if (condition) {
+    pass += 1;
+    console.log(`  PASS: ${name}`);
+  } else {
+    fail += 1;
+    console.log(`  FAIL: ${name}`);
+  }
+}
+
+console.log('=== Chat Message Delegated Actions Tests ===');
+
+const files = [
+  'js/chat-message-action-attrs.js',
+  'js/chat-actions.js',
+  'js/chat-render.js',
+  'js/chat-images.js',
+  'js/chat-send.js',
+  'js/chat-thread-search.js',
+  'js/chat-summaries.js',
+  'js/chat-discussion-picker.js',
+  'js/chat-discussion-ui.js',
+];
+const inlineEventPattern = /\bon(?:click|keydown|change|input|submit)=["']/;
+
+for (const file of files) {
+  assert(`${file} has no inline event attributes`, !inlineEventPattern.test(read(file)));
+}
+
+const actionsSrc = read('js/chat-actions.js');
+const attrsSrc = read('js/chat-message-action-attrs.js');
+assert('chat-actions exports delegated action attributes helper',
+  actionsSrc.includes("export { chatMessageActionAttrs } from './chat-message-action-attrs.js'")
+    && attrsSrc.includes('export function chatMessageActionAttrs(action, attrs = {})')
+    && attrsSrc.includes('data-chat-message-action')
+    && attrsSrc.includes('data-chat-message-index'));
+assert('chat-actions installs idempotent click and keydown delegates',
+  actionsSrc.includes('let chatMessageDelegatesInstalled = false;')
+    && actionsSrc.includes("root.addEventListener('click', handleChatMessageClick)")
+    && actionsSrc.includes("root.addEventListener('keydown', handleChatMessageKeydown)")
+    && actionsSrc.includes('installChatMessageActionDelegates();'));
+assert('chat-actions delegates message action bar controls',
+  actionsSrc.includes("chatMessageActionAttrs('regenerate-last-message')")
+    && actionsSrc.includes("chatMessageActionAttrs('copy-message', { index: msgIndex })")
+    && actionsSrc.includes("chatMessageActionAttrs('toggle-context-details', { index: msgIndex })")
+    && actionsSrc.includes("action === 'regenerate-last-message'")
+    && actionsSrc.includes("action === 'copy-message'")
+    && actionsSrc.includes("action === 'toggle-context-details'"));
+assert('chat-actions delegates dynamic chat controls',
+  [
+    'remove-image-attachment',
+    'open-image-lightbox',
+    'open-emf-assessment',
+    'jump-search-result',
+    'view-summary',
+    'delete-summary',
+    'start-discussion-from-picker',
+    'continue-discussion',
+    'end-discussion',
+  ].every(action => actionsSrc.includes(`action === '${action}'`)));
+
+const renderSrc = read('js/chat-render.js');
+const summariesSrc = read('js/chat-summaries.js');
+const discussionUiSrc = read('js/chat-discussion-ui.js');
+assert('chat render uses delegated image emf lens and recommendation actions',
+  renderSrc.includes("chatMessageActionAttrs('open-image-lightbox')")
+    && renderSrc.includes("chatMessageActionAttrs('open-emf-assessment')")
+    && renderSrc.includes("chatMessageActionAttrs('contain-click')"));
+assert('summary list and modal use delegated summary actions',
+  summariesSrc.includes("chatMessageActionAttrs('view-summary', { summaryId: s.id })")
+    && summariesSrc.includes("chatMessageActionAttrs('close-summary')")
+    && summariesSrc.includes("chatMessageActionAttrs('copy-summary')")
+    && summariesSrc.includes("chatMessageActionAttrs('download-summary')")
+    && summariesSrc.includes("chatMessageActionAttrs('print-summary')")
+    && summariesSrc.includes("chatMessageActionAttrs('delete-summary', { summaryId: thread._savedId })"));
+assert('discussion prompt uses delegated buttons and enter key action',
+  discussionUiSrc.includes('data-chat-message-key-action="continue-discussion"')
+    && discussionUiSrc.includes("chatMessageActionAttrs('continue-discussion')")
+    && discussionUiSrc.includes("chatMessageActionAttrs('end-discussion')"));
+
+console.log(`\nChat message delegated actions tests: ${pass} passed, ${fail} failed`);
+if (fail) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.512';
+self.APP_VERSION = '1.8.513';


### PR DESCRIPTION
## Summary
- Move chat message, summary, image, search, and discussion-picker inline handlers onto delegated chat message actions.
- Add a small helper for `data-chat-message-action` attributes so helper-only modules do not pull in broader chat action imports.
- Update the inline-handler quality baseline from 124 to 103 and bump `version.js` for cache invalidation.

## Tests
- `node tests/test-chat-message-delegated-actions.js`
- `node tests/test-chat-actions.js`
- `npx playwright test tests/playwright/chat-summary-browser-coverage.spec.js`
- `npx playwright test tests/playwright/chat-actions-dom.spec.js tests/playwright/chat-ui-browser-coverage.spec.js tests/playwright/chat-render-browser-coverage.spec.js`
- `npm run quality`
- `npm run typecheck`
- `npm test`
- `./run-tests.sh`