### PR TITLE
[codex] Delegate mobile dashboard and tour actions

### DIFF
--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -403,13 +403,17 @@ export function getMobileWearableTiles() {
   return tiles;
 }
 
-function renderMobileSectionHead(title, count, actionLabel = '', action = '') {
+/**
+ * @param {string} actionKey Delegated mobile dashboard action key; raw JavaScript expressions are not supported.
+ * @param {Record<string, string | number | boolean>} actionAttrs Additional action payload attributes.
+ */
+function renderMobileSectionHead(title, count, actionLabel = '', actionKey = '', actionAttrs = {}) {
   return `<div class="m-section-head">
     <div class="m-section-labels">
       <span class="m-section-title">${escapeHTML(title)}</span>
       ${count ? `<span class="m-section-count">${escapeHTML(count)}</span>` : ''}
     </div>
-    ${actionLabel && action ? `<button type="button" ${mobileDashboardActionAttrs(action)}>${escapeHTML(actionLabel)}</button>` : ''}
+    ${actionLabel && actionKey ? `<button type="button" ${mobileDashboardActionAttrs(actionKey, actionAttrs)}>${escapeHTML(actionLabel)}</button>` : ''}
   </div>`;
 }
 

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -23,6 +23,10 @@ const MOBILE_WEARABLE_PRIORITY = [
 
 let _mobileDashboardManualTabLockUntil = 0;
 let _mobileChromeStateObserver = null;
+let _mobileDashboardActionsInstalled = false;
+
+const MOBILE_DASHBOARD_ACTION_ATTR = 'data-mobile-dashboard-action';
+const MOBILE_DASHBOARD_ACTION_SELECTOR = `[${MOBILE_DASHBOARD_ACTION_ATTR}]`;
 
 /**
  * @typedef {{ data: any, filteredData: any, keyMarkers?: any[], trendAlerts?: any[], criticalFlags?: any[] }} MobileDashboardWidgetContext
@@ -60,6 +64,51 @@ export function configureMobileDashboardView(deps = {}) {
 function markerHasData(m) {
   return m.values?.some(v => v !== null) ?? false;
 }
+
+function mobileDashboardActionAttrs(action, attrs = {}) {
+  let html = `${MOBILE_DASHBOARD_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null) continue;
+    const attr = key.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
+    html += ` data-mobile-dashboard-${attr}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+function closestMobileDashboardAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(MOBILE_DASHBOARD_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function handleMobileDashboardActionClick(event) {
+  const actionEl = closestMobileDashboardAction(event.target);
+  if (!actionEl) return;
+  const action = actionEl.getAttribute(MOBILE_DASHBOARD_ACTION_ATTR);
+  if (action === 'navigate-tab') {
+    const tab = actionEl.dataset.mobileDashboardTab || 'dashboard';
+    const route = actionEl.dataset.mobileDashboardRoute || tab;
+    mobileDashboardSetTab(tab);
+    window.navigate?.(route);
+  } else if (action === 'open-chat') {
+    window.openChatPanel?.();
+  } else if (action === 'open-search') {
+    openMobileDashboardSearch();
+  } else {
+    return;
+  }
+  event.preventDefault();
+}
+
+export function installMobileDashboardActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || _mobileDashboardActionsInstalled) return;
+  _mobileDashboardActionsInstalled = true;
+  root.addEventListener('click', handleMobileDashboardActionClick);
+}
+
+installMobileDashboardActionDelegates();
 
 export function isMobileDashboardViewport() {
   return typeof window !== 'undefined'
@@ -360,7 +409,7 @@ function renderMobileSectionHead(title, count, actionLabel = '', action = '') {
       <span class="m-section-title">${escapeHTML(title)}</span>
       ${count ? `<span class="m-section-count">${escapeHTML(count)}</span>` : ''}
     </div>
-    ${actionLabel && action ? `<button type="button" onclick="${escapeAttr(action)}">${escapeHTML(actionLabel)}</button>` : ''}
+    ${actionLabel && action ? `<button type="button" ${mobileDashboardActionAttrs(action)}>${escapeHTML(actionLabel)}</button>` : ''}
   </div>`;
 }
 
@@ -394,11 +443,11 @@ function renderMobileBottomTabs(activeTab = 'dashboard', { id = '' } = {}) {
   const navId = id ? ` id="${id}"` : '';
   const tabAttrs = tab => `class="m-tab${activeTab === tab ? ' active' : ''}" data-tab="${tab}" aria-current="${activeTab === tab ? 'page' : 'false'}"`;
   return `<nav${navId} class="m-tabbar" aria-label="Mobile primary navigation">
-    <button type="button" ${tabAttrs('dashboard')} onclick="window.mobileDashboardSetTab('dashboard');window.navigate('dashboard')" aria-label="Dashboard"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Home</small></button>
-    <button type="button" ${tabAttrs('labs')} onclick="window.mobileDashboardSetTab('labs');window.navigate('labs')" aria-label="Labs"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Labs</small></button>
-    <button type="button" ${tabAttrs('body')} onclick="window.mobileDashboardSetTab('body');window.navigate('body')" aria-label="Body"><span class="m-tab-icon">${renderMobileIcon('body')}</span><small>Body</small></button>
-    <button type="button" ${tabAttrs('light')} onclick="window.mobileDashboardSetTab('light');window.navigate('light')" aria-label="Light"><span class="m-tab-icon">${renderMobileIcon('light')}</span><small>Light</small></button>
-    <button type="button" ${tabAttrs('insight')} onclick="window.mobileDashboardSetTab('insight');window.navigate('insight')" aria-label="Insight"><span class="m-tab-icon">${renderMobileIcon('insight')}</span><small>Insight</small></button>
+    <button type="button" ${tabAttrs('dashboard')} ${mobileDashboardActionAttrs('navigate-tab', { tab: 'dashboard', route: 'dashboard' })} aria-label="Dashboard"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Home</small></button>
+    <button type="button" ${tabAttrs('labs')} ${mobileDashboardActionAttrs('navigate-tab', { tab: 'labs', route: 'labs' })} aria-label="Labs"><span class="m-tab-icon">${renderMobileIcon('labs')}</span><small>Labs</small></button>
+    <button type="button" ${tabAttrs('body')} ${mobileDashboardActionAttrs('navigate-tab', { tab: 'body', route: 'body' })} aria-label="Body"><span class="m-tab-icon">${renderMobileIcon('body')}</span><small>Body</small></button>
+    <button type="button" ${tabAttrs('light')} ${mobileDashboardActionAttrs('navigate-tab', { tab: 'light', route: 'light' })} aria-label="Light"><span class="m-tab-icon">${renderMobileIcon('light')}</span><small>Light</small></button>
+    <button type="button" ${tabAttrs('insight')} ${mobileDashboardActionAttrs('navigate-tab', { tab: 'insight', route: 'insight' })} aria-label="Insight"><span class="m-tab-icon">${renderMobileIcon('insight')}</span><small>Insight</small></button>
   </nav>`;
 }
 
@@ -456,7 +505,7 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
         ${mobileWidgetStack}
       </div>
     </div>
-    <button type="button" class="m-chat-fab" onclick="window.openChatPanel && window.openChatPanel()" aria-label="Ask AI">${renderMobileIcon('chat')}</button>
+    <button type="button" class="m-chat-fab" ${mobileDashboardActionAttrs('open-chat')} aria-label="Ask AI">${renderMobileIcon('chat')}</button>
     ${renderMobileBottomTabs('dashboard')}`;
 
   if (resetScroll && typeof window.scrollTo === 'function') {

--- a/js/tour.js
+++ b/js/tour.js
@@ -3,6 +3,7 @@
 
 import { state } from './state.js';
 import { profileStorageKey } from './profile.js';
+import { escapeAttr } from './utils.js';
 
 const EMPTY_TOUR_STEPS = [
   { target: null, title: 'Welcome to getbased', text: 'This quick tour is for a fresh profile. After the tour, guided chat will help you decide what to add first.', position: 'center' },
@@ -37,6 +38,43 @@ const CYCLE_TOUR_STEPS = [
 
 // Active tour state
 let activeTour = null;
+
+const TOUR_ACTION_ATTR = 'data-tour-action';
+const TOUR_ACTION_SELECTOR = `[${TOUR_ACTION_ATTR}]`;
+
+function tourActionAttrs(action, attrs = {}) {
+  let html = `${TOUR_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null) continue;
+    const attr = key.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
+    html += ` data-tour-${attr}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+function closestTourAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(TOUR_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function handleTourActionClick(event) {
+  const actionEl = closestTourAction(event.target);
+  if (!actionEl) return;
+  const action = actionEl.getAttribute(TOUR_ACTION_ATTR);
+  if (action === 'end') {
+    endTour();
+  } else if (action === 'go') {
+    const index = Number(actionEl.dataset.tourIndex);
+    if (!Number.isInteger(index)) return;
+    goToStep(index);
+  } else {
+    return;
+  }
+  event.preventDefault();
+}
 
 function profileKey(suffix) {
   return profileStorageKey(state.currentProfile, suffix);
@@ -118,6 +156,7 @@ function runTour(steps, storageKey, auto) {
     tooltip.setAttribute('role', 'dialog');
     tooltip.setAttribute('aria-modal', 'true');
     tooltip.setAttribute('aria-labelledby', 'tour-tooltip-heading');
+    tooltip.addEventListener('click', handleTourActionClick);
     document.body.appendChild(tooltip);
   }
 
@@ -149,11 +188,11 @@ function goToStep(index) {
   dotsHtml += '</div>';
 
   const backBtn = isFirst
-    ? `<button class="tour-btn tour-btn-secondary" onclick="endTour()">Skip</button>`
-    : `<button class="tour-btn tour-btn-secondary" onclick="window._tourGoToStep(${index - 1})">Back</button>`;
+    ? `<button type="button" class="tour-btn tour-btn-secondary" ${tourActionAttrs('end')}>Skip</button>`
+    : `<button type="button" class="tour-btn tour-btn-secondary" ${tourActionAttrs('go', { index: index - 1 })}>Back</button>`;
   const nextBtn = isLast
-    ? `<button class="tour-btn tour-btn-primary" onclick="endTour()">Done</button>`
-    : `<button class="tour-btn tour-btn-primary" onclick="window._tourGoToStep(${index + 1})">Next</button>`;
+    ? `<button type="button" class="tour-btn tour-btn-primary" ${tourActionAttrs('end')}>Done</button>`
+    : `<button type="button" class="tour-btn tour-btn-primary" ${tourActionAttrs('go', { index: index + 1 })}>Next</button>`;
 
   tooltip.innerHTML = `<h4 id="tour-tooltip-heading">${step.title}</h4><p>${step.text}</p>
     <div class="tour-nav">${dotsHtml}<div class="tour-btns">${backBtn}${nextBtn}</div></div>`;
@@ -287,8 +326,8 @@ export function endTour() {
   }
 }
 
-// Internal navigation helper exposed for onclick
-// @ts-expect-error - custom window export for inline tour navigation handlers.
+// Internal navigation helper remains exposed for tests and legacy callers.
+// @ts-expect-error - custom window export for tour navigation.
 window._tourGoToStep = goToStep;
 
 Object.assign(window, { startEmptyTour, startTour, startGuidedTour, startCycleTour, endTour });

--- a/js/tour.js
+++ b/js/tour.js
@@ -170,8 +170,9 @@ function runTour(steps, storageKey, auto) {
 
 function goToStep(index) {
   if (!activeTour) return;
-  activeTour.currentStep = index;
   const steps = activeTour.steps;
+  if (!Number.isInteger(index) || index < 0 || index >= steps.length) return;
+  activeTour.currentStep = index;
   const step = steps[index];
   const spotlight = document.getElementById('tour-spotlight');
   const tooltip = document.getElementById('tour-tooltip');

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 103,
+  "inlineEventAttributes": 92,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/mobile-dashboard-browser-coverage.spec.js
+++ b/tests/playwright/mobile-dashboard-browser-coverage.spec.js
@@ -20,6 +20,7 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
       matchMedia: window.matchMedia,
       navigate: window.navigate,
       toggleMobileSidebar: window.toggleMobileSidebar,
+      openChatPanel: window.openChatPanel,
       loadContextCardTips: window.loadContextCardTips,
       loadCatalog: window.loadCatalog,
       scrollTo: window.scrollTo,
@@ -39,6 +40,7 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
     });
     window.navigate = route => calls.push(['navigate', route]);
     window.toggleMobileSidebar = () => calls.push(['toggleMobileSidebar']);
+    window.openChatPanel = () => calls.push(['openChatPanel']);
     window.scrollTo = (...args) => calls.push(['scrollTo', ...args]);
 
     const mobileDashboard = await import(mobileDashboardUrl);
@@ -149,6 +151,20 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
         && activeLabs?.getAttribute('aria-current') === 'page'
         && activeDashboard?.getAttribute('aria-current') === 'false';
 
+      document.querySelector('.m-tab[data-tab="light"]')?.click();
+      const activeLight = document.querySelector('.m-tab[data-tab="light"]');
+      outcomes.mobileDashboardTabsUseDelegatedActions = activeLight?.classList.contains('active') === true
+        && activeLight?.getAttribute('data-mobile-dashboard-action') === 'navigate-tab'
+        && activeLight?.getAttribute('data-mobile-dashboard-route') === 'light'
+        && calls.some(call => call[0] === 'navigate' && call[1] === 'light')
+        && !document.querySelector('.m-tab[data-tab="light"]')?.hasAttribute('onclick')
+        && !firstRenderHtml.includes('onclick=');
+
+      document.querySelector('.m-chat-fab')?.click();
+      outcomes.mobileChatFabUsesDelegatedAction = calls.some(call => call[0] === 'openChatPanel')
+        && document.querySelector('.m-chat-fab')?.getAttribute('data-mobile-dashboard-action') === 'open-chat'
+        && !document.querySelector('.m-chat-fab')?.hasAttribute('onclick');
+
       mobileDashboard.openMobileDashboardSearch();
       await wait(100);
       outcomes.openMobileDashboardSearchTogglesSidebarAndFocusesSearch = calls.some(call => call[0] === 'toggleMobileSidebar')
@@ -175,6 +191,8 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
       else delete window.navigate;
       if (saved.toggleMobileSidebar) window.toggleMobileSidebar = saved.toggleMobileSidebar;
       else delete window.toggleMobileSidebar;
+      if (saved.openChatPanel) window.openChatPanel = saved.openChatPanel;
+      else delete window.openChatPanel;
       if (saved.loadContextCardTips) window.loadContextCardTips = saved.loadContextCardTips;
       else delete window.loadContextCardTips;
       if (saved.loadCatalog) window.loadCatalog = saved.loadCatalog;

--- a/tests/playwright/tour-dom.spec.js
+++ b/tests/playwright/tour-dom.spec.js
@@ -90,16 +90,18 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
       const welcomeDots = tooltip?.querySelectorAll('.tour-dot').length === 5
         && tooltip?.querySelectorAll('.tour-dot')[0]?.classList.contains('active') === true
         && tooltip?.querySelectorAll('.tour-dot')[1]?.classList.contains('active') === false;
-      // Tour buttons are rendered by tour.js as HTML strings with inline onclick handlers.
       const welcomeButtons = tooltip?.querySelectorAll('.tour-btn').length === 2
         && tooltip?.querySelectorAll('.tour-btn')[0]?.textContent.trim() === 'Skip'
         && tooltip?.querySelectorAll('.tour-btn')[0]?.classList.contains('tour-btn-secondary') === true
         && tooltip?.querySelectorAll('.tour-btn')[1]?.textContent.trim() === 'Next'
         && tooltip?.querySelectorAll('.tour-btn')[1]?.classList.contains('tour-btn-primary') === true
-        && tooltip?.querySelectorAll('.tour-btn')[0]?.getAttribute('onclick')?.includes('endTour') === true
-        && tooltip?.querySelectorAll('.tour-btn')[1]?.getAttribute('onclick')?.includes('_tourGoToStep(1)') === true;
+        && tooltip?.querySelectorAll('.tour-btn')[0]?.getAttribute('data-tour-action') === 'end'
+        && tooltip?.querySelectorAll('.tour-btn')[1]?.getAttribute('data-tour-action') === 'go'
+        && tooltip?.querySelectorAll('.tour-btn')[1]?.getAttribute('data-tour-index') === '1'
+        && !tooltip?.querySelectorAll('.tour-btn')[0]?.hasAttribute('onclick')
+        && !tooltip?.querySelectorAll('.tour-btn')[1]?.hasAttribute('onclick');
 
-      window._tourGoToStep(1);
+      tooltip?.querySelectorAll('.tour-btn')[1]?.click();
       const stepOneNavigation = await waitFor(() => {
         const tooltip2 = document.getElementById('tour-tooltip');
         const dots2 = tooltip2?.querySelectorAll('.tour-dot') || [];
@@ -109,8 +111,12 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
           && dots2[0]?.classList.contains('active') === false
           && btns2[0]?.textContent.trim() === 'Back'
           && btns2[1]?.textContent.trim() === 'Next'
-          && btns2[0]?.getAttribute('onclick')?.includes('_tourGoToStep(0)') === true
-          && btns2[1]?.getAttribute('onclick')?.includes('_tourGoToStep(2)') === true
+          && btns2[0]?.getAttribute('data-tour-action') === 'go'
+          && btns2[0]?.getAttribute('data-tour-index') === '0'
+          && btns2[1]?.getAttribute('data-tour-action') === 'go'
+          && btns2[1]?.getAttribute('data-tour-index') === '2'
+          && !btns2[0]?.hasAttribute('onclick')
+          && !btns2[1]?.hasAttribute('onclick')
           && document.getElementById('tour-spotlight')?.style.display === 'block';
       });
 
@@ -130,7 +136,7 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
           && Math.abs(parseFloat(sl2.style.height) - (targetRect.height + 16)) < 2;
       }
 
-      window._tourGoToStep(0);
+      document.getElementById('tour-tooltip')?.querySelectorAll('.tour-btn')[0]?.click();
       await wait(50);
       const tooltip3 = document.getElementById('tour-tooltip');
       const backReturnsToWelcome = tooltip3?.querySelector('h4')?.textContent === 'Welcome to getbased'
@@ -145,8 +151,11 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
       const lastStepDoneState = tooltip4?.querySelector('h4')?.textContent === 'Settings & Connections'
         && btns4[0]?.textContent.trim() === 'Back'
         && btns4[1]?.textContent.trim() === 'Done'
-        && btns4[1]?.getAttribute('onclick')?.includes('endTour') === true
-        && btns4[0]?.getAttribute('onclick')?.includes('_tourGoToStep(3)') === true
+        && btns4[1]?.getAttribute('data-tour-action') === 'end'
+        && btns4[0]?.getAttribute('data-tour-action') === 'go'
+        && btns4[0]?.getAttribute('data-tour-index') === '3'
+        && !btns4[0]?.hasAttribute('onclick')
+        && !btns4[1]?.hasAttribute('onclick')
         && dots4[4]?.classList.contains('active') === true;
 
       window.endTour();

--- a/tests/playwright/tour-dom.spec.js
+++ b/tests/playwright/tour-dom.spec.js
@@ -120,6 +120,13 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
           && document.getElementById('tour-spotlight')?.style.display === 'block';
       });
 
+      const beforeInvalidIndexTitle = document.getElementById('tour-tooltip')?.querySelector('h4')?.textContent;
+      window._tourGoToStep(99);
+      window._tourGoToStep(-1);
+      await wait(50);
+      const invalidTourIndexNoops = document.getElementById('tour-tooltip')?.querySelector('h4')?.textContent === beforeInvalidIndexTitle
+        && document.getElementById('tour-tooltip')?.querySelectorAll('.tour-dot')[1]?.classList.contains('active') === true;
+
       const startTarget = firstVisible('.welcome-primary-panel');
       let stepOneSpotlightTargetsPanel = false;
       if (startTarget) {
@@ -269,6 +276,7 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
         welcomeDots,
         welcomeButtons,
         stepOneNavigation,
+        invalidTourIndexNoops,
         stepOneSpotlightTargetsPanel,
         backReturnsToWelcome,
         lastStepDoneState,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.513';
+self.APP_VERSION = '1.8.514';


### PR DESCRIPTION
## Summary
- Replace mobile dashboard bottom-tab and chat FAB inline handlers with delegated `data-mobile-dashboard-action` clicks
- Replace guided tour inline button handlers with delegated `data-tour-action` clicks
- Add a tour index bounds guard and document the private mobile section-head delegated action contract
- Lower the inline event attribute quality baseline from 103 to 92 and bump `version.js`

## Validation
- `node --check js/mobile-dashboard.js`
- `node --check js/tour.js`
- `node scripts/quality-guardrails.mjs`
- `npx playwright test tests/playwright/mobile-dashboard-browser-coverage.spec.js tests/playwright/tour-dom.spec.js`
- `npm run typecheck`
- `npm test`
- `./run-tests.sh` before Greptile follow-up; focused checks rerun after follow-up