### PR TITLE
[codex] Delegate notes and feedback actions

### DIFF
--- a/js/feedback.js
+++ b/js/feedback.js
@@ -1,7 +1,7 @@
 // @ts-check
 // feedback.js — Bug report / feedback modal (opens GitHub issue)
 
-import { escapeHTML, showNotification } from './utils.js';
+import { escapeAttr, escapeHTML, showNotification } from './utils.js';
 import { getTheme } from './theme.js';
 import { getAIProvider } from './api.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
@@ -12,6 +12,60 @@ const FEEDBACK_TYPES = [
   { value: 'idea', label: 'Idea / Suggestion', prefix: '[Idea]', ghLabel: 'idea', placeholder: 'Describe your idea' },
   { value: 'other', label: 'Other', prefix: '', ghLabel: '', placeholder: 'What\'s on your mind?' },
 ];
+
+let _feedbackActionDelegatesInstalled = false;
+
+const FEEDBACK_ACTION_ATTR = 'data-feedback-action';
+const FEEDBACK_ACTION_SELECTOR = `[${FEEDBACK_ACTION_ATTR}]`;
+const appWindow = /** @type {Window & typeof globalThis & {
+  closeFeedbackModal?: () => void,
+  submitFeedback?: () => void,
+  _updateFeedbackPlaceholder?: () => void,
+  __feedbackActionDelegatesBound?: boolean,
+}} */ (typeof window !== 'undefined' ? window : {});
+
+function feedbackActionAttrs(action) {
+  return `${FEEDBACK_ACTION_ATTR}="${escapeAttr(action)}"`;
+}
+
+function closestFeedbackAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(FEEDBACK_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function handleFeedbackActionClick(event) {
+  const actionEl = closestFeedbackAction(event.target);
+  if (!actionEl || actionEl.getAttribute(FEEDBACK_ACTION_ATTR) !== 'close') return;
+  appWindow.closeFeedbackModal?.();
+  event.preventDefault();
+}
+
+function handleFeedbackActionSubmit(event) {
+  const actionEl = closestFeedbackAction(event.target);
+  if (!actionEl || actionEl.getAttribute(FEEDBACK_ACTION_ATTR) !== 'submit') return;
+  event.preventDefault();
+  appWindow.submitFeedback?.();
+}
+
+function handleFeedbackActionChange(event) {
+  const actionEl = closestFeedbackAction(event.target);
+  if (!actionEl || actionEl.getAttribute(FEEDBACK_ACTION_ATTR) !== 'placeholder') return;
+  appWindow._updateFeedbackPlaceholder?.();
+}
+
+export function installFeedbackActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || _feedbackActionDelegatesInstalled || appWindow.__feedbackActionDelegatesBound) return;
+  _feedbackActionDelegatesInstalled = true;
+  appWindow.__feedbackActionDelegatesBound = true;
+  root.addEventListener('click', handleFeedbackActionClick);
+  root.addEventListener('submit', handleFeedbackActionSubmit);
+  root.addEventListener('change', handleFeedbackActionChange);
+}
+
+if (typeof window !== 'undefined') installFeedbackActionDelegates();
 
 export function openFeedbackModal() {
   const modal = document.getElementById('feedback-modal');
@@ -25,13 +79,13 @@ export function openFeedbackModal() {
         <div class="gb-modal-kicker">GitHub issue</div>
         <div class="gb-modal-title">Send Feedback</div>
       </div>
-      <button type="button" class="modal-close" aria-label="Close" onclick="closeFeedbackModal()">&times;</button>
+      <button type="button" class="modal-close" aria-label="Close" ${feedbackActionAttrs('close')}>&times;</button>
     </div>
     <div class="gb-form-body feedback-form-body">
-    <form class="feedback-form" onsubmit="event.preventDefault();submitFeedback()">
+    <form class="feedback-form" ${feedbackActionAttrs('submit')}>
       <div class="feedback-field">
         <label class="feedback-label" for="feedback-type">Type</label>
-        <select class="feedback-select" id="feedback-type" onchange="window._updateFeedbackPlaceholder()">
+        <select class="feedback-select" id="feedback-type" ${feedbackActionAttrs('placeholder')}>
           ${typeOptions}
         </select>
       </div>
@@ -45,7 +99,7 @@ export function openFeedbackModal() {
       </div>
       <p class="feedback-notice">Opens a GitHub issue in a new tab. Requires a GitHub account.</p>
       <div class="feedback-actions">
-        <button type="button" class="feedback-action-btn feedback-action-secondary" onclick="closeFeedbackModal()">Cancel</button>
+        <button type="button" class="feedback-action-btn feedback-action-secondary" ${feedbackActionAttrs('close')}>Cancel</button>
         <button type="submit" class="feedback-action-btn feedback-action-primary">Submit</button>
       </div>
     </form>

--- a/js/notes.js
+++ b/js/notes.js
@@ -1,7 +1,7 @@
 // @ts-check
 // notes.js — Standalone note editor
 import { state } from './state.js';
-import { bindDetailModalSyncRefresh, escapeHTML, showNotification, showConfirmDialog } from './utils.js';
+import { bindDetailModalSyncRefresh, escapeAttr, escapeHTML, showNotification, showConfirmDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import {
   appendImportedArrayItem,
@@ -10,6 +10,66 @@ import {
   replaceImportedArrayItem,
 } from './data-merge.js';
 import { openModalOverlay } from './modal-lifecycle.js';
+
+let _noteActionDelegatesInstalled = false;
+
+const NOTE_ACTION_ATTR = 'data-note-action';
+const NOTE_ACTION_SELECTOR = `[${NOTE_ACTION_ATTR}]`;
+const appWindow = /** @type {Window & typeof globalThis & {
+  closeModal?: () => void,
+  saveNote?: (idx?: number | null) => void,
+  deleteNote?: (idx: number) => Promise<void>,
+  __noteActionDelegatesBound?: boolean,
+}} */ (typeof window !== 'undefined' ? window : {});
+
+function noteActionAttrs(action, attrs = {}) {
+  let html = `${NOTE_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null) continue;
+    const attr = key.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
+    html += ` data-note-${attr}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+function closestNoteAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(NOTE_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function parseNoteIndex(actionEl) {
+  if (!actionEl.dataset.noteIndex) return null;
+  const idx = Number.parseInt(actionEl.dataset.noteIndex, 10);
+  return Number.isInteger(idx) ? idx : null;
+}
+
+function handleNoteActionClick(event) {
+  const actionEl = closestNoteAction(event.target);
+  if (!actionEl) return;
+  const action = actionEl.getAttribute(NOTE_ACTION_ATTR);
+  if (action === 'close') {
+    appWindow.closeModal?.();
+  } else if (action === 'save') {
+    appWindow.saveNote?.(parseNoteIndex(actionEl));
+  } else if (action === 'delete') {
+    const idx = parseNoteIndex(actionEl);
+    if (idx === null) return;
+    appWindow.deleteNote?.(idx);
+  } else {
+    return;
+  }
+  event.preventDefault();
+}
+
+export function installNoteActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || _noteActionDelegatesInstalled || appWindow.__noteActionDelegatesBound) return;
+  _noteActionDelegatesInstalled = true;
+  appWindow.__noteActionDelegatesBound = true;
+  root.addEventListener('click', handleNoteActionClick);
+}
 
 /** @param {{ modal: HTMLElement }} context */
 function refreshOpenNoteEditorOnSync({ modal }) {
@@ -34,6 +94,7 @@ function refreshOpenNoteEditorOnSync({ modal }) {
 
 if (typeof window !== 'undefined') {
   bindDetailModalSyncRefresh('note', refreshOpenNoteEditorOnSync);
+  installNoteActionDelegates();
 }
 
 /**
@@ -50,18 +111,18 @@ export function openNoteEditor(date, existingIdx) {
   const defaultDate = existing ? existing.date : (date || new Date().toISOString().slice(0, 10));
   const currentText = existing ? existing.text : '';
   const title = isEditing ? 'Edit Note' : 'Add Note';
-  modal.innerHTML = `<button class="modal-close" onclick="closeModal()">&times;</button>
+  modal.innerHTML = `<button type="button" class="modal-close" ${noteActionAttrs('close')}>&times;</button>
     <h3>${title}</h3>
     <div class="modal-unit">Add context: medication changes, supplements, symptoms, lifestyle changes</div>
     <div style="margin:16px 0">
       <label style="font-size:13px;color:var(--text-secondary);display:block;margin-bottom:4px">Date</label>
-      <input type="date" id="note-date-input" value="${defaultDate}" style="padding:8px 12px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-size:13px;font-family:inherit">
+      <input type="date" id="note-date-input" value="${escapeAttr(defaultDate)}" style="padding:8px 12px;border-radius:6px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-primary);font-size:13px;font-family:inherit">
     </div>
     <textarea class="note-editor" id="note-textarea" placeholder="e.g. Started creatine supplement, switched to low-carb diet...">${escapeHTML(currentText)}</textarea>
     <div class="note-editor-actions">
-      <button class="import-btn import-btn-primary" onclick="saveNote(${isEditing ? existingIdx : 'null'})">Save</button>
-      <button class="import-btn import-btn-secondary" onclick="closeModal()">Cancel</button>
-      ${isEditing ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" onclick="deleteNote(${existingIdx})">Delete</button>` : ''}
+      <button type="button" class="import-btn import-btn-primary" ${noteActionAttrs('save', { index: isEditing ? existingIdx : null })}>Save</button>
+      <button type="button" class="import-btn import-btn-secondary" ${noteActionAttrs('close')}>Cancel</button>
+      ${isEditing ? `<button type="button" class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${noteActionAttrs('delete', { index: existingIdx })}>Delete</button>` : ''}
     </div>`;
   modal.dataset.syncRefreshKind = 'note';
   modal.dataset.syncRefreshMode = isEditing ? 'edit' : 'add';

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 81,
+  "inlineEventAttributes": 73,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -22,25 +22,34 @@ test('feedback modal browser contract builds and submits GitHub issue URLs', asy
 
       feedback.openFeedbackModal();
       const overlay = document.getElementById('feedback-modal-overlay');
+      const modal = document.getElementById('feedback-modal');
+      const form = document.querySelector('.feedback-form');
       const typeSelect = document.getElementById('feedback-type');
       const titleInput = document.getElementById('feedback-title');
       const descInput = document.getElementById('feedback-desc');
 
       outcomes.opensOverlay = overlay?.classList.contains('show') === true;
+      outcomes.usesDelegatedFeedbackActions =
+        modal?.querySelector('[data-feedback-action="close"]')
+        && form?.getAttribute('data-feedback-action') === 'submit'
+        && typeSelect?.getAttribute('data-feedback-action') === 'placeholder'
+        && !modal.innerHTML.includes('onclick=')
+        && !modal.innerHTML.includes('onsubmit=')
+        && !modal.innerHTML.includes('onchange=');
       outcomes.rendersTypeChoices = typeSelect?.querySelectorAll('option').length === 4;
       outcomes.defaultPlaceholder = titleInput?.getAttribute('placeholder') === 'Brief description of the bug';
 
       typeSelect.value = 'feature';
-      window._updateFeedbackPlaceholder();
+      typeSelect.dispatchEvent(new Event('change', { bubbles: true }));
       outcomes.placeholderFollowsType = titleInput.getAttribute('placeholder') === 'What feature would you like?';
 
-      feedback.submitFeedback();
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
       outcomes.emptyTitleKeepsModalOpen = overlay?.classList.contains('show') === true
         && document.activeElement === titleInput;
 
       titleInput.value = 'Batch coverage affordance';
       descInput.value = 'Please group browser coverage improvements.';
-      feedback.submitFeedback();
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
       const issueUrl = new URL(openedUrl);
       outcomes.issueUrlTargetsGitHub = issueUrl.origin === 'https://github.com'
         && issueUrl.pathname === '/elkimek/get-based/issues/new';
@@ -50,7 +59,7 @@ test('feedback modal browser contract builds and submits GitHub issue URLs', asy
       outcomes.submitClosesOverlay = overlay?.classList.contains('show') === false;
 
       feedback.openFeedbackModal();
-      feedback.closeFeedbackModal();
+      document.querySelector('[data-feedback-action="close"]')?.click();
       outcomes.closeHidesOverlay = overlay?.classList.contains('show') === false;
     } finally {
       window.open = originalOpen;
@@ -98,12 +107,17 @@ test('notes editor browser contract adds edits and deletes notes', async ({ page
       window.navigate = (category) => { navCalls.push(category); };
 
       notes.openNoteEditor('2026-06-07');
+      const addModal = document.getElementById('detail-modal');
       outcomes.addEditorOpens = document.getElementById('modal-overlay')?.classList.contains('show') === true
         && document.getElementById('note-date-input')?.value === '2026-06-07'
         && document.getElementById('note-textarea')?.value === '';
+      outcomes.usesDelegatedNoteActions =
+        addModal?.querySelector('[data-note-action="close"]')
+        && addModal?.querySelector('[data-note-action="save"]')
+        && !addModal.innerHTML.includes('onclick=');
 
       document.getElementById('note-textarea').value = 'Started coverage batching';
-      notes.saveNote(null);
+      document.querySelector('[data-note-action="save"]')?.click();
       outcomes.saveAddsNote = state.importedData.notes.length === 1
         && state.importedData.notes[0].date === '2026-06-07'
         && state.importedData.notes[0].text === 'Started coverage batching'
@@ -115,7 +129,7 @@ test('notes editor browser contract adds edits and deletes notes', async ({ page
         && document.getElementById('detail-modal')?.dataset.syncRefreshKind === 'note';
 
       document.getElementById('note-textarea').value = 'Edited coverage batch note';
-      notes.saveNote(0);
+      document.querySelector('[data-note-action="save"]')?.click();
       outcomes.saveEditsInPlace = state.importedData.notes.length === 1
         && state.importedData.notes[0].text === 'Edited coverage batch note';
 
@@ -149,10 +163,10 @@ test('notes editor browser contract adds edits and deletes notes', async ({ page
 
       state.importedData.notes = [{ date: '2026-06-09', text: 'Delete coverage note' }];
       notes.openNoteEditor(null, 0);
-      const deletePromise = notes.deleteNote(0);
+      document.querySelector('[data-note-action="delete"]')?.click();
       await Promise.resolve();
       document.getElementById('confirm-ok')?.click();
-      await deletePromise;
+      await waitFor(() => state.importedData.notes.length === 0);
       outcomes.deleteRemovesNote = state.importedData.notes.length === 0;
     } finally {
       if (originalNotes === undefined) delete state.importedData.notes;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.515';
+self.APP_VERSION = '1.8.516';


### PR DESCRIPTION
## Summary
- Replace notes editor inline `onclick` handlers with delegated `data-note-action` controls.
- Replace feedback modal inline click, submit, and change handlers with delegated `data-feedback-action` controls.
- Exercise notes and feedback through rendered DOM events in browser coverage.
- Lower the inline event baseline from 81 to 73 and bump `version.js` to 1.8.516.

## Validation
- `node --check js/notes.js`
- `node --check js/feedback.js`
- `node --check tests/playwright/browser-coverage-batch.spec.js`
- `node scripts/quality-guardrails.mjs`
- `npx playwright test tests/playwright/browser-coverage-batch.spec.js` (9 passed)
- `npm run typecheck`
- `npm test`
- `./run-tests.sh` (325 Playwright passed; Theme Responsive E2E 472 passed, 0 failed)