### PR TITLE
[codex] Delegate category view actions

### DIFF
--- a/js/category-page-view.js
+++ b/js/category-page-view.js
@@ -2,7 +2,7 @@
 // category-page-view.js — category route orchestration and view-mode switching
 
 import { state } from './state.js';
-import { escapeHTML, getStatus, safeMarkerId } from './utils.js';
+import { escapeAttr, escapeHTML, getStatus, safeMarkerId } from './utils.js';
 import {
   getActiveData,
   filterDatesByRange,
@@ -21,6 +21,69 @@ import {
   renderFattyAcidsView,
   renderFattyAcidsCharts,
 } from './category-view-renderers.js';
+import { markerDetailActionAttrs } from './marker-detail-actions.js';
+
+const categoryPageActionDelegateRoots = new WeakSet();
+
+const CATEGORY_PAGE_ACTION_ATTR = 'data-category-page-action';
+const CATEGORY_PAGE_ACTION_SELECTOR = `[${CATEGORY_PAGE_ACTION_ATTR}]`;
+const appWindow = /** @type {Window & typeof globalThis & {
+  renameCategory?: (categoryKey: string) => void,
+}} */ (typeof window !== 'undefined' ? window : {});
+
+function categoryPageActionAttrs(action, attrs = {}) {
+  let html = `${CATEGORY_PAGE_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null) continue;
+    const attr = key.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
+    html += ` data-category-page-${attr}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+function closestCategoryPageAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(CATEGORY_PAGE_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function handleCategoryPageActionClick(event) {
+  const actionEl = closestCategoryPageAction(event.target);
+  if (!actionEl) return;
+  const action = actionEl.getAttribute(CATEGORY_PAGE_ACTION_ATTR);
+  const categoryKey = actionEl.dataset.categoryPageCategory || '';
+  if (!safeMarkerId(categoryKey)) return;
+  if (action === 'rename-category') {
+    appWindow.renameCategory?.(categoryKey);
+  } else if (action === 'switch-view') {
+    const view = actionEl.dataset.categoryPageView || '';
+    if (view !== 'charts' && view !== 'table' && view !== 'heatmap') return;
+    switchView(view, categoryKey, actionEl);
+  } else {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handleCategoryPageActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestCategoryPageAction(event.target);
+  if (!actionEl || actionEl.getAttribute('role') !== 'button') return;
+  if (event.target?.closest?.('button, a, input, textarea, select')) return;
+  handleCategoryPageActionClick(event);
+}
+
+export function installCategoryPageActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || categoryPageActionDelegateRoots.has(root)) return;
+  categoryPageActionDelegateRoots.add(root);
+  root.addEventListener('click', handleCategoryPageActionClick);
+  root.addEventListener('keydown', handleCategoryPageActionKeydown);
+}
+
+if (typeof document !== 'undefined') installCategoryPageActionDelegates();
 
 function markerHasData(m) { return m.values?.some(v => v !== null) ?? false; }
 
@@ -52,10 +115,9 @@ function sortCategoryChartEntries(entries, categoryKey) {
 }
 
 export function showCategory(categoryKey, preData) {
-  // categoryKey is interpolated into inline-onclick handlers below (rename,
-  // switchView, showDetailModal). Reject anything that doesn't
-  // match the strict allowlist so a poisoned customMarker key can't break
-  // out of the JS string context.
+  // categoryKey is interpolated into delegated data attributes below. Reject
+  // anything that doesn't match the strict allowlist so a poisoned
+  // customMarker key can't break out of the HTML attribute context.
   if (!safeMarkerId(categoryKey)) return;
   // Ensure catalog is preloaded for sorting and rec links
   if (window.loadCatalog && !window._cachedCatalog) window.loadCatalog().then(c => { window._cachedCatalog = c; });
@@ -66,15 +128,15 @@ export function showCategory(categoryKey, preData) {
   const allEntries = Object.entries(cat.markers).filter(([, m]) => !m.hidden);
   const withData = allEntries.filter(([, m]) => markerHasData(m));
   const countLabel = withData.length < allEntries.length ? `${withData.length} of ${allEntries.length} biomarkers with data` : `${allEntries.length} biomarkers tracked`;
-  const renameBtn = ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Rename category" title="Rename category" onclick="event.stopPropagation();renameCategory('${categoryKey}')" style="cursor:pointer;font-size:12px">rename</span>`;
+  const renameBtn = ` <span class="ref-edited-badge" role="button" tabindex="0" aria-label="Rename category" title="Rename category" ${categoryPageActionAttrs('rename-category', { category: categoryKey })} style="cursor:pointer;font-size:12px">rename</span>`;
   let html = `<div class="category-header"><h2>${renderCategoryGlyph(categoryKey, cat.label)}<span class="category-title-text">${escapeHTML(cat.label)}</span>${renameBtn}</h2>
     <p>${countLabel}</p></div>`;
 
   html += `<div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;margin-bottom:20px">`;
   html += `<div class="view-toggle" role="tablist" aria-label="View mode" style="margin-bottom:0">
-    <button class="view-btn active" role="tab" aria-selected="true" tabindex="0" onclick="switchView('charts','${categoryKey}',this)">Charts</button>
-    <button class="view-btn" role="tab" aria-selected="false" tabindex="-1" onclick="switchView('table','${categoryKey}',this)">Table</button>
-    <button class="view-btn" role="tab" aria-selected="false" tabindex="-1" onclick="switchView('heatmap','${categoryKey}',this)">Heatmap</button></div>`;
+    <button class="view-btn active" role="tab" aria-selected="true" tabindex="0" ${categoryPageActionAttrs('switch-view', { category: categoryKey, view: 'charts' })}>Charts</button>
+    <button class="view-btn" role="tab" aria-selected="false" tabindex="-1" ${categoryPageActionAttrs('switch-view', { category: categoryKey, view: 'table' })}>Table</button>
+    <button class="view-btn" role="tab" aria-selected="false" tabindex="-1" ${categoryPageActionAttrs('switch-view', { category: categoryKey, view: 'heatmap' })}>Heatmap</button></div>`;
   html += renderDateRangeFilter();
   html += renderChartLayersDropdown();
   html += `</div>`;
@@ -102,7 +164,7 @@ export function showCategory(categoryKey, preData) {
       for (const [key, marker] of noData) {
         if (!safeMarkerId(key)) continue;
         const id = categoryKey + '_' + key;
-        html += `<div class="chart-card" role="button" tabindex="0" aria-label="Add value for ${escapeHTML(marker.name)}" onclick="showDetailModal('${id}')" style="cursor:pointer;padding:12px 16px;min-height:auto;flex:0 0 auto">
+        html += `<div class="chart-card" role="button" tabindex="0" aria-label="Add value for ${escapeHTML(marker.name)}" ${markerDetailActionAttrs('show-detail-modal', { id })} style="cursor:pointer;padding:12px 16px;min-height:auto;flex:0 0 auto">
           <span style="color:var(--text-secondary)">${escapeHTML(marker.name)}</span>
           <span style="color:var(--text-muted);font-size:11px;margin-left:6px">+ add value</span></div>`;
       }
@@ -130,7 +192,7 @@ export function showCategory(categoryKey, preData) {
 }
 
 export function switchView(view, categoryKey, btn) {
-  // categoryKey reaches inline-onclick handlers via renderChartCard /
+  // categoryKey reaches delegated data attributes via renderChartCard /
   // renderFattyAcidsView / renderTableView / renderHeatmapView. Same
   // allowlist guard as showCategory.
   if (!safeMarkerId(categoryKey)) return;
@@ -152,8 +214,8 @@ export function switchView(view, categoryKey, btn) {
   // (js/xss-through-dom) doesn't trace sanitizers across function calls, so
   // even though renderTableView/renderHeatmapView re-escape internally,
   // escaping here closes the call-site taint flow. Date arrays stay raw
-  // because they're consumed by JSON.stringify in inline-onclick attrs
-  // (escapeHTML would double-escape the JSON literal).
+  // because renderers treat them as values and escape at the attribute/text
+  // boundary where needed.
   const safeLabels = Array.isArray(data.dateLabels) ? data.dateLabels.map(escapeHTML) : data.dateLabels;
   if (view === "table") {
     container.innerHTML = renderTableView(cat, safeLabels, categoryKey, data.dates);

--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -6,10 +6,31 @@ import { escapeHTML, escapeAttr, getStatus, getRangePosition, formatValue, getTr
 import { getChartColors } from './theme.js';
 import { ensureChartJs } from './charts.js';
 import { getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, statusIcon } from './marker-analysis.js';
+import { markerDetailActionAttrs } from './marker-detail-actions.js';
+
+const categoryRendererDelegateRoots = new WeakSet();
+
+function handleTableScrollSync(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const scrollEl = /** @type {HTMLElement | null} */ (target.closest('[data-gb-table-scroll-sync]'));
+  if (!scrollEl || !event.currentTarget?.contains?.(scrollEl)) return;
+  const shell = /** @type {HTMLElement | null} */ (scrollEl.closest('.gb-table-shell'));
+  shell?.style.setProperty('--gb-table-scroll-x', `${scrollEl.scrollLeft}px`);
+}
+
+export function installCategoryRendererDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || categoryRendererDelegateRoots.has(root)) return;
+  categoryRendererDelegateRoots.add(root);
+  root.addEventListener('scroll', handleTableScrollSync, { capture: true, passive: true });
+}
+
+if (typeof document !== 'undefined') installCategoryRendererDelegates();
 
 export function renderChartCard(id, marker, dateLabels) {
-  // id is interpolated into onclick handlers and DOM ids below. Single
-  // chokepoint guard for every caller (dashboard, showCategory, switchView).
+  // id is interpolated into delegated data attributes and DOM ids below.
+  // Single chokepoint guard for every caller (dashboard, showCategory,
+  // switchView).
   if (!safeMarkerId(id)) return '';
   state.markerRegistry[id] = marker;
   const latestIdx = getLatestValueIndex(marker.values);
@@ -36,7 +57,7 @@ export function renderChartCard(id, marker, dateLabels) {
     ? `${latestDateLabel}${latestUnit ? ' · ' + latestUnit : ''}`
     : 'Add a value to start the trend';
 
-  let html = `<div class="chart-card chart-card-${status}" role="button" tabindex="0" aria-label="${escapeAttr(markerName + ' - ' + statusLabel)}" onclick="showDetailModal('${id}')">
+  let html = `<div class="chart-card chart-card-${status}" role="button" tabindex="0" aria-label="${escapeAttr(markerName + ' - ' + statusLabel)}" ${markerDetailActionAttrs('show-detail-modal', { id })}>
     <div class="chart-card-header">
       <div class="chart-card-title-block">
         <div class="chart-card-title" title="${escapeAttr(markerName)}">
@@ -99,14 +120,13 @@ export function renderTableColgroup(cols) {
 
 export function renderScrollableTableShell(kind, wrapperClass, tableClass, colgroup, headHtml, bodyHtml, minWidth) {
   const shellClass = `gb-table-shell gb-table-shell-${kind}`;
-  const syncScroll = "this.parentElement&&this.parentElement.style.setProperty('--gb-table-scroll-x',this.scrollLeft+'px')";
   return `<div class="${shellClass}" style="--gb-table-min-width:${Math.max(660, Math.round(minWidth))}px">
     <div class="gb-table-sticky-head" aria-hidden="true">
       <div class="gb-table-sticky-head-scroll">
         <table class="${tableClass}">${colgroup}<thead>${headHtml}</thead></table>
       </div>
     </div>
-    <div class="${wrapperClass}" onscroll="${syncScroll}">
+    <div class="${wrapperClass}" data-gb-table-scroll-sync>
       <table class="${tableClass}">${colgroup}<thead>${headHtml}</thead><tbody>${bodyHtml}</tbody></table>
     </div>
   </div>`;
@@ -144,7 +164,7 @@ export function renderTableView(cat, dateLabels, categoryKey, dates) {
     if (state.rangeMode === 'both') {
       if (marker.optimalMin != null || marker.optimalMax != null) refCell = `${formatValue(marker.refMin)} – ${formatValue(marker.refMax)}<br><span style="color:var(--green);font-size:11px">opt: ${formatValue(marker.optimalMin)} – ${formatValue(marker.optimalMax)}</span>`;
     }
-    const rowClick = id ? ` onclick="showDetailModal('${id}')" style="cursor:pointer"` : '';
+    const rowClick = id ? ` ${markerDetailActionAttrs('show-detail-modal', { id })} style="cursor:pointer"` : '';
     bodyHtml += `<tr${rowClick}><td class="marker-name">${escapeHTML(marker.name)}</td>
       <td class="unit-col">${escapeHTML(marker.unit)}</td>
       <td class="ref-col">${refCell}</td>`;
@@ -155,14 +175,8 @@ export function renderTableView(cat, dateLabels, categoryKey, dates) {
       // Empty cells: click → add a value for THIS column's date (not today).
       // Skip for singleDate categories where the "date" is a synthetic label.
       const colDate = (dates && !cat.singleDate) ? dates[i] : null;
-      // JSON.stringify + escapeHTML so the interpolated values survive
-      // the HTML-attribute → JS-string-literal round-trip even if they
-      // ever contain quotes or HTML meta-chars (CodeQL js/xss-through-dom).
-      // Same trick as filterConditionSuggestions for apostrophe-bearing
-      // condition names — defense in depth on top of the marker-key /
-      // ISO-date validators upstream.
       const emptyClick = (v === null && id && colDate)
-        ? ` onclick="event.stopPropagation();openManualEntryForm(${escapeHTML(JSON.stringify(id))},${escapeHTML(JSON.stringify(colDate))})" style="cursor:cell" title="Add value for ${dateLabels[i] || escapeHTML(colDate)}"`
+        ? ` ${markerDetailActionAttrs('open-manual-entry', { id, date: colDate })} style="cursor:cell" title="Add value for ${dateLabels[i] || escapeHTML(colDate)}"`
         : '';
       bodyHtml += `<td class="value-cell val-${s}"${emptyClick}>${v !== null ? formatValue(v) : "—"}</td>`;
     }
@@ -203,13 +217,13 @@ export function renderHeatmapView(cat, dateLabels, dates, categoryKey) {
   for (const [key, marker] of markerEntries) {
     const id = categoryKey + "_" + key;
     state.markerRegistry[id] = marker;
-    bodyHtml += `<tr><td role="button" tabindex="0" aria-label="${escapeHTML(marker.name)}" style="cursor:pointer" onclick="showDetailModal('${id}')">${escapeHTML(marker.name)}</td>`;
+    bodyHtml += `<tr><td role="button" tabindex="0" aria-label="${escapeHTML(marker.name)}" style="cursor:pointer" ${markerDetailActionAttrs('show-detail-modal', { id })}>${escapeHTML(marker.name)}</td>`;
     for (let i = 0; i < marker.values.length; i++) {
       const v = marker.values[i];
       const ri = getEffectiveRangeForDate(marker, i);
       const s = v !== null ? getStatus(v, ri.min, ri.max) : "missing";
       const cellLabel = `${escapeHTML(marker.name)} ${labels[i] || ''}: ${v !== null ? formatValue(v) : 'no value'}`;
-      bodyHtml += `<td class="heatmap-${s}" role="button" tabindex="0" aria-label="${cellLabel}" onclick="showDetailModal('${id}')">${v !== null ? formatValue(v) : "—"}</td>`;
+      bodyHtml += `<td class="heatmap-${s}" role="button" tabindex="0" aria-label="${cellLabel}" ${markerDetailActionAttrs('show-detail-modal', { id })}>${v !== null ? formatValue(v) : "—"}</td>`;
     }
     bodyHtml += `</tr>`;
   }
@@ -218,7 +232,7 @@ export function renderHeatmapView(cat, dateLabels, dates, categoryKey) {
 }
 
 export function renderFattyAcidsView(cat, categoryKey) {
-  // categoryKey + per-marker key flow into inline-onclick handlers below.
+  // categoryKey + per-marker key flow into delegated data attributes below.
   if (!safeMarkerId(categoryKey)) return '';
   let html = `<div style="background:var(--bg-card);border-radius:var(--radius);padding:20px;margin-bottom:20px;border:1px solid var(--border)">
     <h3 style="margin-bottom:16px;font-size:16px">Fatty Acid Profile${cat.singleDate ? ' — ' + new Date(cat.singleDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) : ''}</h3>
@@ -236,7 +250,7 @@ export function renderFattyAcidsView(cat, categoryKey) {
       const rangeLabel = state.rangeMode === 'optimal' && (marker.optimalMin != null || marker.optimalMax != null) ? 'Optimal' : 'Ref';
       faRangeText = `${rangeLabel}: ${formatValue(r.min)} – ${formatValue(r.max)}`;
     }
-    html += `<div class="fa-card" role="button" tabindex="0" aria-label="${escapeHTML(marker.name)} ${formatValue(v)}${marker.unit ? ' ' + escapeHTML(marker.unit) : ''}" onclick="showDetailModal('${categoryKey}_${key}')" style="cursor:pointer"><div class="fa-card-name">${escapeHTML(marker.name)}</div>
+    html += `<div class="fa-card" role="button" tabindex="0" aria-label="${escapeHTML(marker.name)} ${formatValue(v)}${marker.unit ? ' ' + escapeHTML(marker.unit) : ''}" ${markerDetailActionAttrs('show-detail-modal', { id: categoryKey + '_' + key })} style="cursor:pointer"><div class="fa-card-name">${escapeHTML(marker.name)}</div>
       <div class="fa-card-value val-${s}">${formatValue(v)}${marker.unit ? " " + escapeHTML(marker.unit) : ""}</div>
       <div class="fa-card-ref">${faRangeText}</div>
       <div class="range-bar" style="margin-top:8px;width:100%"><div class="range-bar-fill" style="left:0;width:100%"></div>

--- a/js/marker-detail-actions.js
+++ b/js/marker-detail-actions.js
@@ -75,7 +75,7 @@ function handleMarkerDetailAction(actionEl, event, actions) {
   } else if (action === 'show-detail-modal') {
     actions.showDetailModal?.(id, showDetailOptions(actionEl));
   } else if (action === 'open-manual-entry') {
-    actions.openManualEntryForm?.(id);
+    actions.openManualEntryForm?.(id, date || undefined);
   } else if (action === 'ask-ai') {
     actions.askAIAboutMarker?.(id);
   } else if (action === 'toggle-marker-note-editor') {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 73,
+  "inlineEventAttributes": 62,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -14,6 +14,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
     const originalSex = state.profileSex;
     const originalDob = state.profileDob;
     const originalView = state.currentView;
+    const originalRenameCategory = window.renameCategory;
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
     try {
@@ -29,6 +30,19 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
       window.showCategory('biochemistry');
       await delay(50);
       const beforeHeading = document.querySelector('.category-header h2')?.textContent || null;
+      const tableBtn = document.querySelector('[data-category-page-action="switch-view"][data-category-page-view="table"]');
+      tableBtn?.click();
+      await delay(30);
+      const categoryDelegatesSwitchViews =
+        tableBtn?.classList.contains('active') === true
+        && !!document.querySelector('.gb-table-shell-data')
+        && !document.querySelector('.view-toggle')?.innerHTML.includes('onclick=');
+
+      let renameCategoryKey = '';
+      window.renameCategory = key => { renameCategoryKey = key; };
+      document.querySelector('[data-category-page-action="rename-category"]')?.click();
+      await delay(10);
+      const categoryDelegatesRename = renameCategoryKey === 'biochemistry';
 
       let quoteInjectionNoop = false;
       let protoNoop = false;
@@ -52,6 +66,8 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
         controlCategoryRendered: !!beforeHeading,
         quoteInjectionNoop,
         protoNoop,
+        categoryDelegatesSwitchViews,
+        categoryDelegatesRename,
         detailModalInjectionNoop: !!overlay?.classList.contains('show') === openBefore,
         unsafeChartCardEmpty: window.renderChartCard("foo';evil('", { name: 'x', values: [1] }, ['2025-01-01']) === '',
         safeChartCardRenders: safeRender.includes('biochemistry_glucose') && safeRender.includes('chart-card'),
@@ -60,6 +76,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
       state.importedData = originalData;
       state.profileSex = originalSex;
       state.profileDob = originalDob;
+      window.renameCategory = originalRenameCategory;
       if (originalView) window.navigate?.(originalView);
     }
   });

--- a/tests/playwright/category-view-renderers-browser-coverage.spec.js
+++ b/tests/playwright/category-view-renderers-browser-coverage.spec.js
@@ -69,6 +69,9 @@ test('category view renderers browser coverage exercises chart table heatmap and
       outcomes.chartCardEscapesMarkerStoresRegistryAndShowsLatest =
         state.markerRegistry.lipids_apob === apoBMarker
         && card?.getAttribute('aria-label') === 'ApoB <script> - Normal'
+        && card.getAttribute('data-marker-detail-action') === 'show-detail-modal'
+        && card.getAttribute('data-marker-detail-id') === 'lipids_apob'
+        && !card.hasAttribute('onclick')
         && card.querySelector('.chart-card-title-text')?.textContent === 'ApoB <script>'
         && card.querySelector('.chart-card-latest-value')?.textContent === '90'
         && card.querySelector('#chart-rec-lipids_apob')
@@ -96,6 +99,8 @@ test('category view renderers browser coverage exercises chart table heatmap and
       const syncedScroll = tinyShell?.style.getPropertyValue('--gb-table-scroll-x');
       outcomes.scrollableTableShellClampsWidthEscapesColsAndSyncsScroll =
         tinyShell?.style.getPropertyValue('--gb-table-min-width') === '660px'
+        && tinyScroll.hasAttribute('data-gb-table-scroll-sync')
+        && !tinyScroll.hasAttribute('onscroll')
         && syncedScroll === `${tinyScroll.scrollLeft}px`
         && tinyScroll.scrollLeft > 0
         && fixture.querySelectorAll('col').length === 4
@@ -109,9 +114,10 @@ test('category view renderers browser coverage exercises chart table heatmap and
         && tableText.includes('ApoB <script>')
         && !tableText.includes('Empty Marker')
         && !fixture.querySelector('script')
-        && emptyValueCell?.getAttribute('onclick')?.includes('openManualEntryForm')
-        && emptyValueCell.getAttribute('onclick')?.includes('lipids_apob')
-        && emptyValueCell.getAttribute('onclick')?.includes('2026-02-01');
+        && !fixture.innerHTML.includes('onclick=')
+        && emptyValueCell?.getAttribute('data-marker-detail-action') === 'open-manual-entry'
+        && emptyValueCell.getAttribute('data-marker-detail-id') === 'lipids_apob'
+        && emptyValueCell.getAttribute('data-marker-detail-date') === '2026-02-01';
 
       fixture.innerHTML = renderers.renderTableView({ singleDate: false, markers: {} }, dateLabels, 'empty', dates);
       outcomes.tableViewEmptyStateExplainsNoData =
@@ -126,7 +132,9 @@ test('category view renderers browser coverage exercises chart table heatmap and
         && !!fixture.querySelector('.gb-table-shell-heatmap')
         && highHeatmapCell?.textContent === '130'
         && missingHeatmapCell?.textContent?.charCodeAt(0) === 8212
-        && highHeatmapCell.getAttribute('onclick')?.includes('lipids_apob')
+        && highHeatmapCell.getAttribute('data-marker-detail-action') === 'show-detail-modal'
+        && highHeatmapCell.getAttribute('data-marker-detail-id') === 'lipids_apob'
+        && !fixture.innerHTML.includes('onclick=')
         && highHeatmapCell.getAttribute('aria-label')?.includes('ApoB <script> Mar 1: 130');
 
       fixture.innerHTML = renderers.renderHeatmapView({ singleDate: false, markers: {} }, dateLabels, dates, 'empty');
@@ -172,7 +180,9 @@ test('category view renderers browser coverage exercises chart table heatmap and
         && fixture.textContent.includes('Optimal: 8')
         && fixture.textContent.includes('12')
         && !fixture.textContent.includes('Unsafe')
-        && fixture.querySelector('.fa-card')?.getAttribute('onclick')?.includes('fatty_omega3');
+        && fixture.querySelector('.fa-card')?.getAttribute('data-marker-detail-action') === 'show-detail-modal'
+        && fixture.querySelector('.fa-card')?.getAttribute('data-marker-detail-id') === 'fatty_omega3'
+        && !fixture.innerHTML.includes('onclick=');
       outcomes.fattyAcidsViewRejectsUnsafeCategoryKey =
         renderers.renderFattyAcidsView(fattyAcids, 'bad"cat') === '';
 

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -240,7 +240,7 @@ assert('Clipboard has navigator.clipboard guard', chatActionsSrc.includes('if (!
 // ═══════════════════════════════════════
 // PDF AI extraction is sanitized at the parse boundary by _sanitizeAIMarker,
 // but legacy data and sync pulls can still feed unsafe keys into category
-// views — five entry points interpolate keys into onclick="…('${id}')" handlers.
+// views — category marker ids flow into delegated data attributes.
 // safeMarkerId in utils.js gates each one. The *functional* proof that the
 // guards no-op on adversarial input lives in tests/playwright/audit-dom.spec.js (needs a
 // live DOM); here we pin the guard *wiring*.

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -52,6 +52,8 @@ assert('marker-detail-actions installs idempotent click and keyboard delegates',
     actionSrc.includes("root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions))"));
 assert('marker-detail delegated actions are scoped to the installed root',
   actionSrc.includes("event.currentTarget.contains(actionEl)"));
+assert('marker-detail open manual entry action preserves optional prefill date',
+  actionSrc.includes('actions.openManualEntryForm?.(id, date || undefined)'));
 assert('marker-detail keyboard delegate supports role-button spans and ignores form controls',
   actionSrc.includes("event.target?.closest?.('button, a, input, textarea, select')") &&
     actionSrc.includes("actionEl.getAttribute('role') !== 'button'"));

--- a/tests/test-marker-value-notes.js
+++ b/tests/test-marker-value-notes.js
@@ -90,6 +90,7 @@ const state = (await import('../js/state.js')).state;
 
   const viewsSrc = read('js/views.js');
   const categoryViewRenderersSrc = read('js/category-view-renderers.js');
+  const markerDetailActionsSrc = read('js/marker-detail-actions.js');
   const markerDetailSrc = read('js/marker-detail-modal.js');
   const markerDetailEditingSrc = read('js/marker-detail-editing.js');
   const markerDetailStoreSrc = read('js/marker-detail-store.js');
@@ -181,10 +182,9 @@ const state = (await import('../js/state.js')).state;
       && /saveMarkerValueNote[\s\S]{0,500}writeMarkerValueNote\(dotKey, date, noteText\)/.test(markerDetailStoreSrc)
       && /writeMarkerValueNote[\s\S]{0,900}insulinMirrorMapKey\(dotKey, date\)/.test(markerDetailStoreSrc));
 
-  // CodeQL js/xss-through-dom: empty-cell onclick must use JSON.stringify
-  // so interpolated id/date survive the HTML-attr → JS-string round-trip.
-  assert('Empty-cell onclick uses JSON.stringify(id), JSON.stringify(colDate)',
-    /openManualEntryForm\(\$\{escapeHTML\(JSON\.stringify\(id\)\)\},\$\{escapeHTML\(JSON\.stringify\(colDate\)\)\}\)/.test(categoryViewRenderersSrc));
+  assert('Empty-cell manual entry uses delegated id/date attrs',
+    categoryViewRenderersSrc.includes("markerDetailActionAttrs('open-manual-entry', { id, date: colDate })") &&
+    /open-manual-entry'[\s\S]{0,180}openManualEntryForm\?\.\(id, date \|\| undefined\)/.test(markerDetailActionsSrc));
 
   // ═══════════════════════════════════════
   // 7. Value-card rendering

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.516';
+self.APP_VERSION = '1.8.517';


### PR DESCRIPTION
## Summary
- Replace category page rename/view-tab inline handlers with delegated `data-category-page-action` controls.
- Replace category chart/table/heatmap/fatty-acid marker inline handlers with the shared marker detail delegated action contract.
- Replace table scroll `onscroll` sync with a captured delegated `data-gb-table-scroll-sync` handler.
- Pass manual-entry prefill dates through `data-marker-detail-date`.
- Lower inline event baseline from 73 to 62 and bump `version.js` to 1.8.517.

## Validation
- `node --check js/category-page-view.js`
- `node --check js/category-view-renderers.js`
- `node --check js/marker-detail-actions.js`
- `node --check tests/playwright/category-view-renderers-browser-coverage.spec.js`
- `node scripts/quality-guardrails.mjs`
- `node tests/test-marker-value-notes.js`
- `node tests/test-audit.js`
- `node tests/test-marker-detail-delegated-actions.js`
- `npm run typecheck`
- `npx playwright test tests/playwright/audit-dom.spec.js tests/playwright/category-view-renderers-browser-coverage.spec.js`
- `npm test`
- `./run-tests.sh` (325 Playwright passed; Theme Responsive E2E 472 passed, 0 failed)