### PR TITLE
[codex] Delegate context dashboard actions

### DIFF
--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -6,8 +6,70 @@ import { getEncryptionEnabled } from './crypto.js';
 import { getLensSummary } from './lens.js';
 import { state } from './state.js';
 import { isSyncEnabled } from './sync.js';
-import { escapeHTML } from './utils.js';
+import { escapeAttr, escapeHTML } from './utils.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+
+const dashboardAIActionDelegateRoots = new WeakSet();
+const DASHBOARD_AI_ACTION_ATTR = 'data-dashboard-ai-action';
+const DASHBOARD_AI_ACTION_SELECTOR = `[${DASHBOARD_AI_ACTION_ATTR}]`;
+const appWindow = /** @type {Window & typeof globalThis & {
+  openInterpretiveLensEditor?: () => void,
+  openKnowledgeBaseModal?: () => void,
+  showEnableEncryptionModal?: () => void,
+  showSyncSetupModal?: () => void,
+  pickFolderForBackup?: () => void,
+  handleDNAFile?: (file: File) => void,
+}} */ (typeof window !== 'undefined' ? window : {});
+
+function dashboardAIActionAttrs(action) {
+  return `${DASHBOARD_AI_ACTION_ATTR}="${escapeAttr(action)}"`;
+}
+
+function closestDashboardAIAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(DASHBOARD_AI_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function runDashboardAIAction(action) {
+  if (action === 'open-interpretive-lens') appWindow.openInterpretiveLensEditor?.();
+  else if (action === 'open-knowledge-base') appWindow.openKnowledgeBaseModal?.();
+  else if (action === 'open-personalize-ai-picker') openPersonalizeAIPicker();
+  else if (action === 'enable-encryption') appWindow.showEnableEncryptionModal?.();
+  else if (action === 'setup-sync') appWindow.showSyncSetupModal?.();
+  else if (action === 'setup-backup') appWindow.pickFolderForBackup?.();
+  else if (action === 'open-data-protection-picker') openDataProtectionPicker();
+  else return false;
+  return true;
+}
+
+function handleDashboardAIActionClick(event) {
+  const actionEl = closestDashboardAIAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(DASHBOARD_AI_ACTION_ATTR);
+  if (!runDashboardAIAction(action)) return;
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handleDashboardAIActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestDashboardAIAction(event.target);
+  if (!actionEl || actionEl.getAttribute('role') !== 'button') return;
+  if (event.target?.closest?.('button, a, input, textarea, select')) return;
+  handleDashboardAIActionClick(event);
+}
+
+export function installDashboardAIActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || dashboardAIActionDelegateRoots.has(root)) return;
+  dashboardAIActionDelegateRoots.add(root);
+  root.addEventListener('click', handleDashboardAIActionClick);
+  root.addEventListener('keydown', handleDashboardAIActionKeydown);
+}
+
+if (typeof document !== 'undefined') installDashboardAIActionDelegates();
 
 // Dashboard "AI personalization" zone:
 //   - Full-width row for the Interpretive Lens, only if it is set.
@@ -24,7 +86,7 @@ export function renderInterpretiveLensSection() {
   const kbConfigured = !!(summary && summary.configured);
 
   const lensRow = lens
-    ? `<div class="lens-section" role="button" tabindex="0" aria-label="Edit Interpretive Lens" onclick="openInterpretiveLensEditor()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}" title="Interpretive Lens - click to edit"><span class="lens-section-icon">&#129694;</span><span class="lens-section-body"><span class="lens-section-label">Interpretive Lens</span><span class="lens-section-text">${escapeHTML(lens)}</span></span><span class="lens-section-edit">&#9998;</span></div>`
+    ? `<div class="lens-section" role="button" tabindex="0" aria-label="Edit Interpretive Lens" ${dashboardAIActionAttrs('open-interpretive-lens')} title="Interpretive Lens - click to edit"><span class="lens-section-icon">&#129694;</span><span class="lens-section-body"><span class="lens-section-label">Interpretive Lens</span><span class="lens-section-text">${escapeHTML(lens)}</span></span><span class="lens-section-edit">&#9998;</span></div>`
     : '';
   const kbRow = kbConfigured ? renderKnowledgeBaseRow(summary) : '';
   const aiCta = renderPersonalizeAICta(!!lens, kbConfigured);
@@ -44,8 +106,8 @@ export function triggerDNAFilePicker() {
     newInput.style.display = 'none';
     newInput.addEventListener('change', () => {
       const f = newInput.files && newInput.files[0];
-      if (f && typeof window.handleDNAFile === 'function') {
-        window.handleDNAFile(f);
+      if (f && typeof appWindow.handleDNAFile === 'function') {
+        appWindow.handleDNAFile(f);
       }
       newInput.value = '';
     });
@@ -72,7 +134,7 @@ function renderKnowledgeBaseRow(s) {
     ? ` &middot; query rewriting ${s.multiQueryOn ? 'on' : 'off'}`
     : '';
   const detail = `${escapeHTML(s.displayName)}${docFragment}${rewriteFragment}`;
-  return `<div class="lens-section" role="button" tabindex="0" aria-label="Manage Knowledge Base" onclick="openKnowledgeBaseModal()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}" title="Knowledge Base - click to manage"><span class="lens-section-icon">&#128218;</span><span class="lens-section-body"><span class="lens-section-label">Knowledge Base</span><span class="lens-section-text">${detail}</span></span><span class="lens-section-edit">&#9998;</span></div>`;
+  return `<div class="lens-section" role="button" tabindex="0" aria-label="Manage Knowledge Base" ${dashboardAIActionAttrs('open-knowledge-base')} title="Knowledge Base - click to manage"><span class="lens-section-icon">&#128218;</span><span class="lens-section-body"><span class="lens-section-label">Knowledge Base</span><span class="lens-section-text">${detail}</span></span><span class="lens-section-edit">&#9998;</span></div>`;
 }
 
 // Inline CTA pill that adapts to which feature is missing. Both missing opens
@@ -84,17 +146,17 @@ function renderPersonalizeAICta(lensSet, kbSet) {
   if (!lensSet && !kbSet) {
     icon = '&#10024;';
     label = 'Personalize how AI answers';
-    action = 'openPersonalizeAIPicker()';
+    action = 'open-personalize-ai-picker';
   } else if (!kbSet) {
     icon = '&#128218;';
     label = 'Connect a knowledge base';
-    action = 'openKnowledgeBaseModal()';
+    action = 'open-knowledge-base';
   } else {
     icon = '&#129694;';
     label = 'Set an interpretive lens';
-    action = 'openInterpretiveLensEditor()';
+    action = 'open-interpretive-lens';
   }
-  return `<button type="button" class="dashboard-cta" onclick="${action}" aria-label="${escapeHTML(label)}">
+  return `<button type="button" class="dashboard-cta" ${dashboardAIActionAttrs(action)} aria-label="${escapeHTML(label)}">
     <span class="dashboard-cta-icon" aria-hidden="true">${icon}</span>
     <span class="dashboard-cta-plus" aria-hidden="true">+</span>
     <span>${escapeHTML(label)}</span>
@@ -132,27 +194,27 @@ export function renderDataProtectionCta(stateOverride) {
   if (missing.length === 1) {
     const only = missing[0];
     if (only === 'encryption') {
-      return `<button type="button" class="dashboard-cta" onclick="showEnableEncryptionModal()" aria-label="Enable encryption">
+      return `<button type="button" class="dashboard-cta" ${dashboardAIActionAttrs('enable-encryption')} aria-label="Enable encryption">
         <span class="dashboard-cta-icon" aria-hidden="true">&#128274;</span>
         <span class="dashboard-cta-plus" aria-hidden="true">+</span>
         <span>Enable encryption</span>
       </button>`;
     }
     if (only === 'sync') {
-      return `<button type="button" class="dashboard-cta" onclick="showSyncSetupModal()" aria-label="Set up cross-device sync">
+      return `<button type="button" class="dashboard-cta" ${dashboardAIActionAttrs('setup-sync')} aria-label="Set up cross-device sync">
         <span class="dashboard-cta-icon" aria-hidden="true">&#128225;</span>
         <span class="dashboard-cta-plus" aria-hidden="true">+</span>
         <span>Sync to other devices</span>
       </button>`;
     }
-    return `<button type="button" class="dashboard-cta" onclick="pickFolderForBackup()" aria-label="Set up auto-backup">
+    return `<button type="button" class="dashboard-cta" ${dashboardAIActionAttrs('setup-backup')} aria-label="Set up auto-backup">
       <span class="dashboard-cta-icon" aria-hidden="true">&#128190;</span>
       <span class="dashboard-cta-plus" aria-hidden="true">+</span>
       <span>Set up auto-backup</span>
     </button>`;
   }
 
-  return `<button type="button" class="dashboard-cta" onclick="openDataProtectionPicker()" aria-label="Protect your data">
+  return `<button type="button" class="dashboard-cta" ${dashboardAIActionAttrs('open-data-protection-picker')} aria-label="Protect your data">
     <span class="dashboard-cta-icon" aria-hidden="true">&#128737;</span>
     <span class="dashboard-cta-plus" aria-hidden="true">+</span>
     <span>Protect your data</span>

--- a/js/context-card-summaries.js
+++ b/js/context-card-summaries.js
@@ -53,9 +53,6 @@ function getEMFSummary() {
 export function renderEMFAssessmentLauncher({ inModal = false, surface = 'environment-editor' } = {}) {
   const assessments = getEMFAssessments();
   const hasAssessments = assessments.length > 0;
-  const action = inModal
-    ? 'window.closeModal&&window.closeModal();setTimeout(()=>window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor(),100)'
-    : 'window.openEMFAssessmentEditor&&window.openEMFAssessmentEditor()';
   const summary = hasAssessments
     ? getEMFSummary()
     : 'Room-by-room Baubiologie workflow with readings, photos, comparison, and AI interpretation.';
@@ -64,7 +61,7 @@ export function renderEMFAssessmentLauncher({ inModal = false, surface = 'enviro
     : 'Environment tool';
   const title = hasAssessments ? 'Open EMF assessment' : 'Start EMF assessment';
   const cta = hasAssessments ? 'Open' : 'Start';
-  return `<button type="button" class="ctx-emf-launcher${hasAssessments ? ' has-data' : ''}" onclick="${escapeAttr(action)}" data-umami-event="${escapeAttr('emf-launcher-' + surface)}">
+  return `<button type="button" class="ctx-emf-launcher${hasAssessments ? ' has-data' : ''}" data-context-card-action="open-emf-assessment" data-context-card-close-modal="${inModal ? 'true' : 'false'}" data-umami-event="${escapeAttr('emf-launcher-' + surface)}">
     <span class="ctx-emf-launcher-mark" aria-hidden="true">EMF</span>
     <span class="ctx-emf-launcher-copy">
       <span class="ctx-emf-launcher-kicker">${escapeHTML(kicker)}</span>

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -2,7 +2,7 @@
 // context-cards.js - dashboard context card facade and shared lifecycle
 
 import { state } from './state.js';
-import { escapeHTML, showNotification } from './utils.js';
+import { escapeAttr, escapeHTML, showNotification } from './utils.js';
 import { saveImportedData, getActiveData } from './data.js';
 import { hasAIProvider } from './api.js';
 import { openModalOverlay } from './modal-lifecycle.js';
@@ -109,6 +109,86 @@ import {
   showDietContaminantsModal,
 } from './context-card-lifestyle-editors.js';
 
+const contextCardActionDelegateRoots = new WeakSet();
+const CONTEXT_CARD_ACTION_ATTR = 'data-context-card-action';
+const CONTEXT_CARD_ACTION_SELECTOR = `[${CONTEXT_CARD_ACTION_ATTR}]`;
+const contextCardEditorActions = /** @type {Record<string, () => void>} */ ({
+  openHealthGoalsEditor,
+  openDiagnosesEditor,
+  openDietEditor,
+  openExerciseEditor,
+  openSleepRestEditor,
+  openLightCircadianEditor,
+  openStressEditor,
+  openLoveLifeEditor,
+  openEnvironmentEditor,
+});
+const contextCardWindow = /** @type {Window & typeof globalThis & {
+  closeModal?: () => void,
+  openEMFAssessmentEditor?: () => void,
+}} */ (typeof window !== 'undefined' ? window : {});
+
+function contextCardActionAttrs(action, attrs = {}) {
+  let html = `${CONTEXT_CARD_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null) continue;
+    const attr = key.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
+    html += ` data-context-card-${attr}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+function closestContextCardAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(CONTEXT_CARD_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function handleContextCardClick(event) {
+  const actionEl = closestContextCardAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(CONTEXT_CARD_ACTION_ATTR);
+  if (action === 'refresh-all-health-dots') {
+    refreshAllHealthDots();
+  } else if (action === 'open-editor') {
+    const editor = actionEl.dataset.contextCardEditor || '';
+    const runEditor = contextCardEditorActions[editor];
+    if (!runEditor) return;
+    runEditor();
+  } else if (action === 'open-emf-assessment') {
+    const openAssessment = () => contextCardWindow.openEMFAssessmentEditor?.();
+    if (actionEl.dataset.contextCardCloseModal === 'true') {
+      contextCardWindow.closeModal?.();
+      setTimeout(openAssessment, 100);
+    } else {
+      openAssessment();
+    }
+  } else {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handleContextCardInput(event) {
+  const actionEl = closestContextCardAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (actionEl.getAttribute(CONTEXT_CARD_ACTION_ATTR) === 'context-notes-input') {
+    debounceContextNotes();
+  }
+}
+
+export function installContextCardActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || contextCardActionDelegateRoots.has(root)) return;
+  contextCardActionDelegateRoots.add(root);
+  root.addEventListener('click', handleContextCardClick);
+  root.addEventListener('input', handleContextCardInput);
+}
+
+if (typeof document !== 'undefined') installContextCardActionDelegates();
+
 export {
   getConditionsSummary,
   getDietSummary,
@@ -210,7 +290,7 @@ export function renderProfileContextCards() {
   } else if (!_ccHasLabs) {
     _ccSubtitle = `<div class="context-section-subtitle">${_ccMissingDemo ? 'Set your sex and date of birth in Settings, then open' : 'All filled \u2014 open'} the chat to get personalized test recommendations based on your profile.</div>`;
   }
-  const _refreshBtn = hasAIProvider() ? `<button class="ctx-refresh-all-btn" onclick="event.stopPropagation();refreshAllHealthDots()" title="Refresh all AI insights">&#x21bb;</button>` : '';
+  const _refreshBtn = hasAIProvider() ? `<button class="ctx-refresh-all-btn" ${contextCardActionAttrs('refresh-all-health-dots')} title="Refresh all AI insights">&#x21bb;</button>` : '';
   let html = `<div style="margin-top:16px"><span class="context-section-title">What your GP won't ask you (${filledCount}/${cardDefs.length} filled)</span>${_refreshBtn}${_ccSubtitle}</div>`;
   html += `<div class="profile-context-cards">`;
   for (const c of cardDefs) {
@@ -220,12 +300,12 @@ export function renderProfileContextCards() {
     // KEYBOARD interactivity now lives only on the Edit button below.
     // Both fire the same editor — keyboard users tab to Edit, mouse
     // users still get the whole-card click affordance.
-    html += `<div class="context-card" onclick="${c.editor}()" style="cursor:pointer">
+    html += `<div class="context-card" ${contextCardActionAttrs('open-editor', { editor: c.editor })} style="cursor:pointer">
       <div class="context-card-header">
         <span class="ctx-health-dot ctx-health-dot-gray" id="ctx-dot-${c.key}"></span>
         <span class="context-card-label">${c.emoji} ${c.label}</span>
         <span class="context-info-icon">i<span class="context-tooltip">${c.tooltip}</span></span>
-        <span id="ctx-tips-${c.key}"></span><button class="diagnoses-edit-btn" aria-label="${filled ? 'Edit' : 'Add'} ${escapeHTML(c.label)}" onclick="event.stopPropagation();${c.editor}()">${filled ? 'Edit' : '+ Add'}</button>
+        <span id="ctx-tips-${c.key}"></span><button class="diagnoses-edit-btn" aria-label="${filled ? 'Edit' : 'Add'} ${escapeHTML(c.label)}" ${contextCardActionAttrs('open-editor', { editor: c.editor })}>${filled ? 'Edit' : '+ Add'}</button>
       </div>
       ${summary
         ? `<div class="context-card-body">${escapeHTML(summary)}</div>`
@@ -238,7 +318,7 @@ export function renderProfileContextCards() {
   // Additional Notes textarea
   const notes = state.importedData.contextNotes || '';
   html += `<div class="ctx-notes-section">
-    <textarea class="ctx-notes-textarea" id="ctx-notes-textarea" placeholder="Additional notes for AI context (anything else that might affect your labs...)" oninput="debounceContextNotes()">${escapeHTML(notes)}</textarea>
+    <textarea class="ctx-notes-textarea" id="ctx-notes-textarea" placeholder="Additional notes for AI context (anything else that might affect your labs...)" ${contextCardActionAttrs('context-notes-input')}>${escapeHTML(notes)}</textarea>
   </div>`;
   return html;
 }

--- a/js/focus-card.js
+++ b/js/focus-card.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { trackUsage } from './schema.js';
-import { hasCardContent, getStatus } from './utils.js';
+import { escapeAttr, hasCardContent, getStatus } from './utils.js';
 import { getActiveData, getFocusCardFingerprint } from './data.js';
 import { getAllFlaggedMarkers } from './marker-analysis.js';
 import { profileStorageKey } from './profile.js';
@@ -12,6 +12,38 @@ import { injectLensChunks } from './lab-context.js';
 import { hasLens, queryLens } from './lens.js';
 import { applyInlineMarkdown } from './markdown.js';
 import { computeAllImpacts } from './supplement-impact.js';
+
+const focusCardActionDelegateRoots = new WeakSet();
+const FOCUS_CARD_ACTION_ATTR = 'data-focus-card-action';
+
+function focusCardActionAttrs(action) {
+  return `${FOCUS_CARD_ACTION_ATTR}="${escapeAttr(action)}"`;
+}
+
+function closestFocusCardAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(`[${FOCUS_CARD_ACTION_ATTR}]`)
+      : null
+  );
+}
+
+function handleFocusCardActionClick(event) {
+  const actionEl = closestFocusCardAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (actionEl.getAttribute(FOCUS_CARD_ACTION_ATTR) !== 'refresh') return;
+  refreshFocusCard();
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+export function installFocusCardActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || focusCardActionDelegateRoots.has(root)) return;
+  focusCardActionDelegateRoots.add(root);
+  root.addEventListener('click', handleFocusCardActionClick);
+}
+
+if (typeof document !== 'undefined') installFocusCardActionDelegates();
 
 export function renderFocusCard() {
   const cacheKey = profileStorageKey(state.currentProfile, 'focusCard');
@@ -23,7 +55,7 @@ export function renderFocusCard() {
     <div class="focus-card-body" id="focus-card-body">${text
       ? `<span class="focus-card-text">${applyInlineMarkdown(text)}</span>`
       : `<span class="focus-card-shimmer"></span>`}</div>
-    <button class="focus-card-refresh" onclick="refreshFocusCard()" aria-label="Regenerate insight" title="Regenerate insight">\u21BB</button>
+    <button class="focus-card-refresh" ${focusCardActionAttrs('refresh')} aria-label="Regenerate insight" title="Regenerate insight">\u21BB</button>
   </div>`;
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 62,
+  "inlineEventAttributes": 47,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/context-cards-browser-coverage.spec.js
+++ b/tests/playwright/context-cards-browser-coverage.spec.js
@@ -89,12 +89,17 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
 
       host.innerHTML = cards.renderProfileContextCards();
+      outcomes.profileContextCardsUseDelegatedActions =
+        !!host.querySelector('[data-context-card-action="refresh-all-health-dots"], [data-context-card-action="open-editor"]')
+        && !!host.querySelector('#ctx-notes-textarea[data-context-card-action="context-notes-input"]')
+        && !host.innerHTML.includes('onclick=')
+        && !host.innerHTML.includes('oninput=');
       const notes = document.getElementById('ctx-notes-textarea');
       notes.value = 'Extra context for AI';
-      cards.debounceContextNotes();
+      notes.dispatchEvent(new InputEvent('input', { bubbles: true }));
       await waitFor(() => state.importedData.contextNotes === 'Extra context for AI'
         && (state.importedData.changeHistory || []).some(entry => entry.field === 'contextNotes'));
-      outcomes.debounceContextNotesPersistsAndRecordsChange = state.importedData.contextNotes === 'Extra context for AI'
+      outcomes.delegatedContextNotesPersistsAndRecordsChange = state.importedData.contextNotes === 'Extra context for AI'
         && (state.importedData.changeHistory || []).some(entry => entry.field === 'contextNotes');
 
       details = document.createElement('details');

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -600,6 +600,9 @@ test('context health dots and focus card cover cache fallback and empty states',
       const focusFp = data.getFocusCardFingerprint();
       localStorage.setItem(focusCacheKey, JSON.stringify({ fingerprint: focusFp, text: '**ApoB** is the priority.' }));
       outcomes.renderFocusCardUsesCachedMarkdown = focus.renderFocusCard().includes('<strong>ApoB</strong>');
+      outcomes.renderFocusCardUsesDelegatedRefresh =
+        focus.renderFocusCard().includes('data-focus-card-action="refresh"')
+        && !focus.renderFocusCard().includes('onclick=');
       const focusShell = document.createElement('div');
       focusShell.innerHTML = focus.renderFocusCard();
       const renderedFocusBody = focusShell.querySelector('#focus-card-body');
@@ -658,10 +661,14 @@ test('context health dots and focus card cover cache fallback and empty states',
       outcomes.loadFocusCardShowsEnableAIWithoutConnectedProvider = document.getElementById('focus-card-body')?.textContent.includes('Enable AI') === true;
       localStorage.setItem(focusCacheKey, JSON.stringify({ fingerprint: focusFp, text: 'Temporary focus cache' }));
       document.getElementById('focus-card-body').innerHTML = '<span>Temporary focus cache</span>';
-      focus.refreshFocusCard();
+      const focusRefreshBtn = document.createElement('button');
+      focusRefreshBtn.setAttribute('data-focus-card-action', 'refresh');
+      document.body.appendChild(focusRefreshBtn);
+      focusRefreshBtn.click();
       await delay(0);
       outcomes.refreshFocusCardClearsCacheAndReloadsProviderGate = localStorage.getItem(focusCacheKey) === null
         && document.getElementById('focus-card-body')?.textContent.includes('Enable AI') === true;
+      focusRefreshBtn.remove();
 
       state.importedData = { entries: [] };
       data.invalidateActiveDataCache();

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -100,7 +100,11 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
         && host.textContent.includes('query rewriting on')
         && !lensHtml.includes('Dr <Lens>')
         && !lensHtml.includes('Research <Vault>')
-        && host.querySelectorAll('.lens-section').length === 2;
+        && host.querySelectorAll('.lens-section').length === 2
+        && host.querySelector('[data-dashboard-ai-action="open-interpretive-lens"]')
+        && host.querySelector('[data-dashboard-ai-action="open-knowledge-base"]')
+        && !host.innerHTML.includes('onclick=')
+        && !host.innerHTML.includes('onkeydown=');
       outcomes.renderInterpretiveLensHidesPersonalizeCtaWhenConfigured =
         !host.textContent.includes('Personalize how AI answers');
       outcomes.renderInterpretiveLensIncludesDataProtectionCta =
@@ -154,10 +158,28 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       };
       outcomes.renderDataProtectionCtaCoversStatusMatrix = ctaCases.allProtected === ''
         && ctaCases.encryptionOnly.includes('Enable encryption')
+        && ctaCases.encryptionOnly.includes('data-dashboard-ai-action="enable-encryption"')
         && ctaCases.syncOnly.includes('Sync to other devices')
+        && ctaCases.syncOnly.includes('data-dashboard-ai-action="setup-sync"')
         && ctaCases.backupOnly.includes('Set up auto-backup')
+        && ctaCases.backupOnly.includes('data-dashboard-ai-action="setup-backup"')
         && ctaCases.backupUnsupported === ''
-        && ctaCases.multipleMissing.includes('Protect your data');
+        && ctaCases.multipleMissing.includes('Protect your data')
+        && ctaCases.multipleMissing.includes('data-dashboard-ai-action="open-data-protection-picker"')
+        && !Object.values(ctaCases).some(html => html.includes('onclick='));
+
+      host.innerHTML = ctaCases.encryptionOnly + ctaCases.syncOnly + ctaCases.backupOnly + ctaCases.multipleMissing;
+      host.querySelector('[data-dashboard-ai-action="enable-encryption"]')?.click();
+      host.querySelector('[data-dashboard-ai-action="setup-sync"]')?.click();
+      host.querySelector('[data-dashboard-ai-action="setup-backup"]')?.click();
+      host.querySelector('[data-dashboard-ai-action="open-data-protection-picker"]')?.click();
+      await Promise.resolve();
+      outcomes.dashboardAiDelegatedCtasRouteClicks =
+        calls.includes('encryption')
+        && calls.includes('sync')
+        && calls.includes('backup')
+        && !!document.querySelector('#data-protection-picker-overlay.show');
+      document.querySelector('#data-protection-picker-overlay')?.remove();
 
       const clickPickerCard = async (openPicker, selector) => {
         openPicker();

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -57,8 +57,10 @@ console.log('=== Phase 3 A11y Tests ===\n');
     categoryViewRenderersSrc.includes('class="fa-card" role="button" tabindex="0"'));
   assert('ref-editable span has role+tabindex',
     markerDetailSrc.includes('class="ref-editable" role="button" tabindex="0"'));
-  assert('focus-card refresh has aria-label',
-    focusCardSrc.includes('class="focus-card-refresh" onclick="refreshFocusCard()" aria-label="Regenerate insight"'));
+  assert('focus-card refresh has aria-label and delegated action',
+    focusCardSrc.includes('class="focus-card-refresh"') &&
+    focusCardSrc.includes('aria-label="Regenerate insight"') &&
+    focusCardSrc.includes('data-focus-card-action'));
 
   const cycleSrc = read('/js/cycle.js');
   assert('cycle-prompt is a semantic button',

--- a/tests/test-dashboard-data-protection.js
+++ b/tests/test-dashboard-data-protection.js
@@ -59,35 +59,36 @@ const make = (overrides) => ({
 {
   const html = cards.renderDataProtectionCta(make({ encryption: false, sync: true, backup: true }));
   assert('only encryption missing: direct CTA',
-    /Enable encryption/.test(html) && /showEnableEncryptionModal/.test(html));
+    /Enable encryption/.test(html) && /data-dashboard-ai-action="enable-encryption"/.test(html));
   assert('direct CTA does NOT open picker',
-    !/openDataProtectionPicker/.test(html));
+    !/data-dashboard-ai-action="open-data-protection-picker"/.test(html));
 }
 {
   const html = cards.renderDataProtectionCta(make({ encryption: true, sync: false, backup: true }));
   assert('only sync missing: direct Sync to other devices CTA',
-    /Sync to other devices/.test(html) && /showSyncSetupModal/.test(html));
+    /Sync to other devices/.test(html) && /data-dashboard-ai-action="setup-sync"/.test(html));
 }
 {
   const html = cards.renderDataProtectionCta(make({ encryption: true, sync: true, backup: false }));
   assert('only backup missing: direct Set up auto-backup CTA',
-    /Set up auto-backup/.test(html) && /pickFolderForBackup/.test(html));
+    /Set up auto-backup/.test(html) && /data-dashboard-ai-action="setup-backup"/.test(html));
 }
 
 // ─── 4. Two missing → generic picker CTA ─────────────────
 {
   const html = cards.renderDataProtectionCta(make({ encryption: false, sync: false, backup: true }));
   assert('two missing: generic Protect your data CTA',
-    /Protect your data/.test(html) && /openDataProtectionPicker/.test(html));
+    /Protect your data/.test(html) && /data-dashboard-ai-action="open-data-protection-picker"/.test(html));
   assert('two missing: NOT a feature-specific direct CTA',
-    !/onclick="showEnableEncryptionModal\(\)"/.test(html) && !/onclick="showSyncSetupModal\(\)"/.test(html));
+    !/data-dashboard-ai-action="enable-encryption"/.test(html) && !/data-dashboard-ai-action="setup-sync"/.test(html));
 }
 
 // ─── 5. All missing → picker CTA ─────────────────────────
 {
   const html = cards.renderDataProtectionCta(make({ encryption: false, sync: false, backup: false }));
   assert('all missing: picker CTA renders',
-    /Protect your data/.test(html) && /openDataProtectionPicker/.test(html));
+    /Protect your data/.test(html) && /data-dashboard-ai-action="open-data-protection-picker"/.test(html));
+  assert('data protection CTA renders without inline handlers', !/on(click|keydown)=/.test(html));
 }
 
 // Section 6 (picker open/dismiss — live DOM) lives in

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -86,7 +86,7 @@ try {
       !/lens-section-label[^>]*>Knowledge Base/.test(html));
     assert('both unset: CTA pill present', html.includes('dashboard-cta'));
     assert('both unset: picker opener wired',
-      html.includes('openPersonalizeAIPicker()'));
+      html.includes('data-dashboard-ai-action="open-personalize-ai-picker"'));
     assert('both unset: generic copy used',
       /Personalize how AI answers/i.test(html));
   }
@@ -102,11 +102,11 @@ try {
     assert('only lens: KB row absent',
       !/lens-section-label[^>]*>Knowledge Base/.test(html));
     assert('only lens: CTA opens KB modal directly',
-      html.includes('dashboard-cta') && html.includes('openKnowledgeBaseModal()'));
+      html.includes('dashboard-cta') && html.includes('data-dashboard-ai-action="open-knowledge-base"'));
     assert('only lens: CTA copy is KB-specific',
       /Connect a knowledge base/i.test(html));
     assert('only lens: CTA does NOT open picker',
-      !html.includes('openPersonalizeAIPicker()'));
+      !html.includes('data-dashboard-ai-action="open-personalize-ai-picker"'));
   }
 
   // ─── 3. Only KB set → Lens-direct CTA ───
@@ -122,7 +122,7 @@ try {
     assert('only KB: KB row present', /lens-section-label[^>]*>Knowledge Base/.test(html));
     assert('only KB: KB row shows library name', html.includes('Research Notes'));
     assert('only KB: CTA opens lens editor directly',
-      html.includes('dashboard-cta') && html.includes('openInterpretiveLensEditor()'));
+      html.includes('dashboard-cta') && html.includes('data-dashboard-ai-action="open-interpretive-lens"'));
     assert('only KB: CTA copy is lens-specific',
       /Set an interpretive lens/i.test(html));
   }
@@ -140,8 +140,12 @@ try {
     assert('both set: KB row present',
       /lens-section-label[^>]*>Knowledge Base/.test(html));
     assert('both set: AI-personalize CTA absent',
-      !html.includes('openPersonalizeAIPicker') &&
-      !/dashboard-cta[^>]*onclick="openKnowledgeBaseModal/.test(html));
+      !html.includes('data-dashboard-ai-action="open-personalize-ai-picker"') &&
+      !/dashboard-cta[^>]*data-dashboard-ai-action="open-knowledge-base"/.test(html));
+    assert('both set: lens and KB rows use delegated actions',
+      !/on(click|keydown)=/.test(html) &&
+      html.includes('data-dashboard-ai-action="open-interpretive-lens"') &&
+      html.includes('data-dashboard-ai-action="open-knowledge-base"'));
   }
 
   // Section 5 (picker open/dismiss — live DOM) lives in

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -160,6 +160,9 @@ assert('45h. Environment context card counts saved EMF assessments',
   contextCardSummariesSrc.includes("key === 'environment'") && contextCardSummariesSrc.includes('getEMFAssessments().length > 0'));
 assert('45i. Environment editor uses the EMF assessment launcher',
   contextCardLifestyleEditorsSrc.includes('renderEMFAssessmentLauncher({ inModal: true') && contextCardSummariesSrc.includes('ctx-emf-launcher'));
+assert('45i2. EMF assessment launcher uses delegated context-card action',
+  contextCardSummariesSrc.includes('data-context-card-action="open-emf-assessment"') &&
+  !contextCardSummariesSrc.includes('onclick="${escapeAttr(action)}"'));
 assert('45j. EMF launcher has dedicated context CSS',
   contextProfileCss.includes('.ctx-emf-launcher') &&
   contextProfileCss.includes('.ctx-emf-launcher-action') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.517';
+self.APP_VERSION = '1.8.518';


### PR DESCRIPTION
## Summary
- Replace dashboard AI/data-protection CTA inline handlers with delegated `data-dashboard-ai-action` controls.
- Replace profile context card, notes, refresh-all, EMF launcher, and focus-card refresh inline handlers with delegated data actions.
- Lower inline event baseline from 62 to 47 and bump `version.js` to 1.8.518.

## Validation
- `node --check js/context-card-dashboard-ai.js`
- `node --check js/context-cards.js`
- `node --check js/context-card-summaries.js`
- `node --check js/focus-card.js`
- `node scripts/quality-guardrails.mjs`
- `node tests/test-dashboard-data-protection.js`
- `node tests/test-dashboard-knowledge-base.js`
- `node tests/test-emf.js`
- `node tests/test-a11y-phase3.js`
- `npm run typecheck`
- `npx playwright test tests/playwright/dashboard-ai-browser-coverage.spec.js tests/playwright/context-cards-browser-coverage.spec.js tests/playwright/context-coverage-batch.spec.js`
- `npm test`
- `./run-tests.sh` (325 Playwright passed; Theme Responsive E2E 472 passed, 0 failed)