### PR TITLE
[codex] Delegate data protection actions

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -1,7 +1,7 @@
 // @ts-check
 // backup.js — Backup/restore, auto-backup (IndexedDB), folder backup (File System Access API)
 
-import { showNotification, showConfirmDialog, escapeHTML } from './utils.js';
+import { showNotification, showConfirmDialog, escapeAttr, escapeHTML } from './utils.js';
 import { profileStorageKey } from './profile.js';
 import { getBlob, setBlob, shouldUseBlob } from './blob-storage.js';
 
@@ -13,6 +13,43 @@ const appWindow = /** @type {Window & typeof globalThis & {
 }} */ (window);
 const getEncryptionEnabled = () => appWindow.getEncryptionEnabled?.() || false;
 const isEncryptedValue = (v) => typeof v === 'string' && v.startsWith('v1:');
+const backupActionDelegateRoots = new WeakSet();
+const BACKUP_ACTION_DELEGATE_KEY = Symbol.for('getbased.backupActionDelegatesInstalled');
+const BACKUP_ACTION_ATTR = 'data-backup-action';
+const BACKUP_ACTION_SELECTOR = `[${BACKUP_ACTION_ATTR}]`;
+
+function backupActionAttrs(action) {
+  return `${BACKUP_ACTION_ATTR}="${escapeAttr(action)}"`;
+}
+
+function closestBackupAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(BACKUP_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function handleBackupActionClick(event) {
+  const actionEl = closestBackupAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(BACKUP_ACTION_ATTR);
+  if (action === 'pick-folder') pickFolderForBackup();
+  else if (action === 'reauthorize-folder') reauthorizeFolderBackup();
+  else if (action === 'remove-folder') removeFolderBackup();
+  else return;
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+export function installBackupActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || backupActionDelegateRoots.has(root) || root[BACKUP_ACTION_DELEGATE_KEY]) return;
+  backupActionDelegateRoots.add(root);
+  Object.defineProperty(root, BACKUP_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleBackupActionClick);
+}
+
+if (typeof document !== 'undefined') installBackupActionDelegates();
 
 // Read the RAW stored value (encrypted-if-encryption-on, plaintext-if-off)
 // for any key. Big-blob `-imported` keys live in IndexedDB now; everything
@@ -665,20 +702,20 @@ export function renderFolderBackupSection() {
   let html = '<div class="backup-folder-section">';
   html += '<div class="backup-folder-desc">Sync backups to a local folder (Proton Drive, Dropbox, NAS, etc.)</div>';
   if (!st.folderName) {
-    html += '<button class="import-btn import-btn-secondary" onclick="pickFolderForBackup()">Set backup folder</button>';
+    html += `<button class="import-btn import-btn-secondary" ${backupActionAttrs('pick-folder')}>Set backup folder</button>`;
   } else if (st.permissionLost) {
     html += `<div class="backup-folder-status backup-folder-status-warn">Folder: ${escapeHTML(st.folderName)} — access lost</div>`;
     html += '<div style="display:flex;gap:8px;flex-wrap:wrap">';
-    html += '<button class="import-btn import-btn-primary" onclick="reauthorizeFolderBackup()">Restore access</button>';
-    html += '<button class="import-btn import-btn-secondary" onclick="removeFolderBackup()">Remove</button>';
+    html += `<button class="import-btn import-btn-primary" ${backupActionAttrs('reauthorize-folder')}>Restore access</button>`;
+    html += `<button class="import-btn import-btn-secondary" ${backupActionAttrs('remove-folder')}>Remove</button>`;
     html += '</div>';
   } else {
     const lastLabel = st.lastBackup ? new Date(st.lastBackup).toLocaleString() : 'never';
     html += `<div class="backup-folder-status backup-folder-status-ok">Folder: ${escapeHTML(st.folderName)}</div>`;
     html += `<div class="backup-folder-meta">Last folder backup: ${escapeHTML(lastLabel)}</div>`;
     html += '<div style="display:flex;gap:8px;flex-wrap:wrap">';
-    html += '<button class="import-btn import-btn-secondary" onclick="pickFolderForBackup()">Change folder</button>';
-    html += '<button class="import-btn import-btn-secondary" onclick="removeFolderBackup()">Remove</button>';
+    html += `<button class="import-btn import-btn-secondary" ${backupActionAttrs('pick-folder')}>Change folder</button>`;
+    html += `<button class="import-btn import-btn-secondary" ${backupActionAttrs('remove-folder')}>Remove</button>`;
     html += '</div>';
   }
   html += '</div>';

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -2,7 +2,7 @@
 // crypto.js — Encryption at rest, backup/restore, cross-tab sync
 
 import { state } from './state.js';
-import { showNotification, showConfirmDialog, escapeHTML } from './utils.js';
+import { showNotification, showConfirmDialog, escapeAttr, escapeHTML } from './utils.js';
 import { profileStorageKey } from './profile.js';
 import { getBlob, setBlob, deleteBlob, shouldUseBlob } from './blob-storage.js';
 import { ensureImportedArray } from './data-merge.js';
@@ -14,6 +14,89 @@ const appWindow = /** @type {Window & typeof globalThis & {
   migrateProfileData: (data: any) => void,
   navigate: (view: string) => void,
 }} */ (window);
+const cryptoActionDelegateRoots = new WeakSet();
+const CRYPTO_ACTION_DELEGATE_KEY = Symbol.for('getbased.cryptoActionDelegatesInstalled');
+const CRYPTO_ACTION_ATTR = 'data-crypto-action';
+const CRYPTO_ACTION_SELECTOR = `[${CRYPTO_ACTION_ATTR}]`;
+
+function cryptoActionAttrs(action, attrs = {}) {
+  let html = `${CRYPTO_ACTION_ATTR}="${escapeAttr(action)}"`;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null) continue;
+    const attr = key.replace(/[A-Z]/g, c => '-' + c.toLowerCase());
+    html += ` data-crypto-${attr}="${escapeAttr(String(value))}"`;
+  }
+  return html;
+}
+
+function closestCryptoAction(target) {
+  return /** @type {HTMLElement | null} */ (
+    target && typeof target.closest === 'function'
+      ? target.closest(CRYPTO_ACTION_SELECTOR)
+      : null
+  );
+}
+
+function readSnapshotActionId(actionEl) {
+  const raw = actionEl.dataset.cryptoSnapshotId;
+  if (raw == null) return null;
+  if (actionEl.dataset.cryptoSnapshotIdType === 'number') {
+    const id = Number(raw);
+    return Number.isFinite(id) ? id : null;
+  }
+  return raw;
+}
+
+function handleCryptoActionClick(event) {
+  const actionEl = closestCryptoAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(CRYPTO_ACTION_ATTR);
+  if (action === 'change-passphrase') changePassphrase();
+  else if (action === 'disable-encryption') disableEncryption();
+  else if (action === 'enable-encryption') showEnableEncryptionModal();
+  else if (action === 'export-backup') exportEncryptedBackup();
+  else if (action === 'toggle-backup-snapshots') toggleBackupSnapshots();
+  else if (action === 'restore-auto-backup') {
+    const id = readSnapshotActionId(actionEl);
+    if (id == null) return;
+    restoreAutoBackup(id);
+  } else {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handleCryptoActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestCryptoAction(event.target);
+  if (!actionEl || actionEl.getAttribute('role') !== 'button') return;
+  if (event.target?.closest?.('button, a, input, textarea, select')) return;
+  handleCryptoActionClick(event);
+}
+
+function handleCryptoActionChange(event) {
+  const actionEl = closestCryptoAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (actionEl.getAttribute(CRYPTO_ACTION_ATTR) !== 'import-backup') return;
+  const fileInput = /** @type {HTMLInputElement} */ (actionEl);
+  const file = fileInput.files && fileInput.files[0];
+  if (!file) return;
+  importEncryptedBackup(file);
+  fileInput.value = '';
+  event.stopPropagation();
+}
+
+export function installCryptoActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || cryptoActionDelegateRoots.has(root) || root[CRYPTO_ACTION_DELEGATE_KEY]) return;
+  cryptoActionDelegateRoots.add(root);
+  Object.defineProperty(root, CRYPTO_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleCryptoActionClick);
+  root.addEventListener('keydown', handleCryptoActionKeydown);
+  root.addEventListener('change', handleCryptoActionChange);
+}
+
+if (typeof document !== 'undefined') installCryptoActionDelegates();
 
 // ═══════════════════════════════════════════════
 // SENSITIVE KEY PATTERNS
@@ -885,8 +968,8 @@ export function renderEncryptionSection() {
       </div>
     </div>
     <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
-      <button class="import-btn import-btn-secondary" onclick="changePassphrase()">Change Passphrase</button>
-      <button class="import-btn import-btn-secondary" onclick="disableEncryption()">Disable Encryption</button>
+      <button class="import-btn import-btn-secondary" ${cryptoActionAttrs('change-passphrase')}>Change Passphrase</button>
+      <button class="import-btn import-btn-secondary" ${cryptoActionAttrs('disable-encryption')}>Disable Encryption</button>
     </div>`;
   }
   return `<div class="encryption-status-card encryption-status-off">
@@ -896,7 +979,7 @@ export function renderEncryptionSection() {
       <div class="encryption-status-detail">Your data is stored as plaintext in localStorage. Browser extensions and anyone with filesystem access can read it.</div>
     </div>
   </div>
-  <button class="import-btn import-btn-primary" style="margin-top:12px" onclick="showEnableEncryptionModal()">Enable Encryption</button>`;
+  <button class="import-btn import-btn-primary" style="margin-top:12px" ${cryptoActionAttrs('enable-encryption')}>Enable Encryption</button>`;
 }
 
 export function renderBackupSection() {
@@ -906,14 +989,14 @@ export function renderBackupSection() {
     : 'No auto-backups yet';
   return `<div class="ai-provider-desc" style="margin-bottom:10px">Create a full backup of all profiles, data, and chat history. ${getEncryptionEnabled() ? 'Backups inherit encryption \u2014 same passphrase required to restore.' : 'Backups are unencrypted unless encryption is enabled.'}</div>
   <div style="display:flex;gap:8px;flex-wrap:wrap">
-    <button class="import-btn import-btn-primary" onclick="exportEncryptedBackup()">Download Backup</button>
+    <button class="import-btn import-btn-primary" ${cryptoActionAttrs('export-backup')}>Download Backup</button>
     <label class="import-btn import-btn-secondary" style="cursor:pointer;display:inline-flex;align-items:center">
       Restore Backup
-      <input type="file" accept=".json" style="display:none" onchange="if(this.files[0])importEncryptedBackup(this.files[0])">
+      <input type="file" accept=".json" style="display:none" ${cryptoActionAttrs('import-backup')}>
     </label>
   </div>
   <div class="backup-auto-status">${escapeHTML(autoStatus)}</div>
-  <div class="backup-snapshots-toggle" onclick="toggleBackupSnapshots()" id="backup-snapshots-toggle" style="display:none">
+  <div class="backup-snapshots-toggle" ${cryptoActionAttrs('toggle-backup-snapshots')} id="backup-snapshots-toggle" role="button" tabindex="0" style="display:none">
     <span class="privacy-configure-arrow" id="backup-snapshots-arrow">&#9654;</span>
     Recent snapshots
   </div>
@@ -936,12 +1019,16 @@ export async function loadBackupSnapshots() {
   list.innerHTML = shown.map(s => {
     const date = new Date(s.createdAt).toLocaleString();
     const profileCount = (s.snapshot && s.snapshot.profiles) ? s.snapshot.profiles.length : '?';
+    const actionAttrs = cryptoActionAttrs('restore-auto-backup', {
+      snapshotId: s.id,
+      snapshotIdType: typeof s.id === 'number' ? 'number' : 'string',
+    });
     return `<div class="backup-snapshot-item">
       <div class="backup-snapshot-info">
         <span class="backup-snapshot-date">${escapeHTML(date)}</span>
         <span class="backup-snapshot-meta">${profileCount} profile(s)${s.encrypted ? ' \u2022 encrypted' : ''}</span>
       </div>
-      <button class="import-btn import-btn-secondary" style="padding:4px 10px;font-size:12px" onclick="restoreAutoBackup(${s.id})">Restore</button>
+      <button class="import-btn import-btn-secondary" style="padding:4px 10px;font-size:12px" ${actionAttrs}>Restore</button>
     </div>`;
   }).join('');
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 47,
+  "inlineEventAttributes": 35,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/backup-browser-coverage.spec.js
+++ b/tests/playwright/backup-browser-coverage.spec.js
@@ -242,13 +242,20 @@ test('backup browser coverage exercises export import auto backup and folder sta
         }),
       });
       const folderHtml = backup.renderFolderBackupSection();
-      await backup.pickFolderForBackup();
+      const folderHost = document.createElement('section');
+      folderHost.innerHTML = folderHtml;
+      document.body.appendChild(folderHost);
+      backup.installBackupActionDelegates(folderHost);
+      folderHost.querySelector('[data-backup-action="pick-folder"]')?.click();
       await waitFor(() => toasts().some(text => text.includes('Could not set backup folder')));
       outcomes.folderBackupSupportedPickerAndCloneFailurePath =
         backup.getFolderBackupState().supported === true
         && folderHtml.includes('Set backup folder')
+        && folderHtml.includes('data-backup-action="pick-folder"')
+        && !folderHtml.includes('onclick=')
         && folderWrites.some(entry => entry.name === 'getbased-backup-latest.json' && String(entry.content || '').includes('labcharts-backup'))
         && toasts().some(text => text.includes('Could not set backup folder'));
+      folderHost.remove();
       clearToasts();
 
       localStorage.setItem('labcharts-folder-backup-last', '2026-06-10T09:00:00.000Z');

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -52,6 +52,7 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
       for (const key of keys) localStorage.removeItem(key);
       document.getElementById('passphrase-overlay')?.remove();
       document.body.insertAdjacentHTML('beforeend', '<section id="encryption-section"></section>');
+      cryptoStore.installCryptoActionDelegates(document.getElementById('encryption-section'));
       window.__WEARABLES_TEST = true;
 
       outcomes.startsLocked = cryptoStore.isUnlocked() === false
@@ -101,7 +102,10 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
       localStorage.removeItem('labcharts-encryption-salt');
       localStorage.setItem('labcharts-venice-key', 'plain-venice-key');
       document.getElementById('encryption-section').innerHTML = cryptoStore.renderEncryptionSection();
-      cryptoStore.showEnableEncryptionModal();
+      outcomes.renderEncryptionSectionUsesDelegatedActions =
+        !!document.querySelector('[data-crypto-action="enable-encryption"]')
+        && !document.getElementById('encryption-section').innerHTML.includes('onclick=');
+      click('[data-crypto-action="enable-encryption"]');
       await waitFor(() => !!document.getElementById('passphrase-set-btn'), 'enable modal');
 
       click('#passphrase-set-btn');
@@ -474,6 +478,12 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       backupHost.id = 'crypto-backup-coverage-host';
       backupHost.innerHTML = cryptoStore.renderBackupSection();
       document.body.appendChild(backupHost);
+      cryptoStore.installCryptoActionDelegates(backupHost);
+      outcomes.renderBackupSectionUsesDelegatedActions =
+        !!backupHost.querySelector('[data-crypto-action="export-backup"]')
+        && !!backupHost.querySelector('[data-crypto-action="import-backup"]')
+        && !!backupHost.querySelector('[data-crypto-action="toggle-backup-snapshots"]')
+        && !/on(click|change)=/.test(backupHost.innerHTML);
       await cryptoStore.loadBackupSnapshots();
       outcomes.emptySnapshotsHideList =
         document.getElementById('backup-snapshot-list')?.style.display === 'none';
@@ -490,17 +500,22 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
         tx.onerror = () => reject(tx.error);
       });
       await cryptoStore.loadBackupSnapshots();
-      cryptoStore.toggleBackupSnapshots();
+      document.getElementById('backup-snapshots-toggle')?.click();
       const openedDisplay = document.getElementById('backup-snapshot-list')?.style.display;
       const openedArrow = document.getElementById('backup-snapshots-arrow')?.innerHTML;
-      cryptoStore.toggleBackupSnapshots();
-      outcomes.snapshotsRenderAndToggle =
+      document.getElementById('backup-snapshots-toggle')?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      const restoreBtn = document.querySelector('[data-crypto-action="restore-auto-backup"]');
+      outcomes.snapshotsRenderDelegatedRestoreButton =
         document.querySelectorAll('.backup-snapshot-item').length === 1
+        && !!restoreBtn?.dataset.cryptoSnapshotId
+        && ['number', 'string'].includes(restoreBtn?.dataset.cryptoSnapshotIdType || '')
         && document.querySelector('.backup-snapshot-meta')?.textContent.includes('1 profile(s)') === true
-        && document.querySelector('.backup-snapshot-meta')?.textContent.includes('encrypted') === true
-        && openedDisplay === 'flex'
-        && openedArrow === '\u25bc'
-        && document.getElementById('backup-snapshot-list')?.style.display === 'none'
+        && document.querySelector('.backup-snapshot-meta')?.textContent.includes('encrypted') === true;
+      outcomes.snapshotsDelegatedClickToggleOpens =
+        openedDisplay === 'flex'
+        && openedArrow === '\u25bc';
+      outcomes.snapshotsDelegatedKeyboardToggleCloses =
+        document.getElementById('backup-snapshot-list')?.style.display === 'none'
         && document.getElementById('backup-snapshots-arrow')?.innerHTML === '\u25b6';
     } finally {
       state.currentProfile = saved.profile;

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -251,10 +251,12 @@ try {
   const html = window.renderEncryptionSection();
   assert('renderEncryptionSection returns HTML', typeof html === 'string' && html.length > 50);
   assert('Encryption section has status card', html.includes('encryption-status-card'));
+  assert('Encryption section uses delegated actions', html.includes('data-crypto-action=') && !html.includes('onclick='));
   const backupHtml = window.renderBackupSection();
   assert('renderBackupSection returns HTML', typeof backupHtml === 'string' && backupHtml.length > 50);
   assert('Backup section has download button', backupHtml.includes('Download Backup'));
   assert('Backup section has restore button', backupHtml.includes('Restore Backup'));
+  assert('Backup section uses delegated actions', backupHtml.includes('data-crypto-action=') && !/on(click|change)=/.test(backupHtml));
 } catch (e) {
   assert('Settings section rendering', false, e.message);
 }
@@ -283,6 +285,7 @@ console.log('11. Encryption section reflects state');
   const offHtml = window.renderEncryptionSection();
   assert('OFF state shows Enable button', offHtml.includes('Enable Encryption'));
   assert('OFF state shows encryption-status-off', offHtml.includes('encryption-status-off'));
+  assert('OFF state enable button is delegated', offHtml.includes('data-crypto-action="enable-encryption"'));
 
   localStorage.setItem('labcharts-encryption-enabled', 'true');
   const onHtml = window.renderEncryptionSection();
@@ -290,6 +293,10 @@ console.log('11. Encryption section reflects state');
   assert('ON state shows Disable Encryption', onHtml.includes('Disable Encryption'));
   assert('ON state shows encryption-status-on', onHtml.includes('encryption-status-on'));
   assert('ON state mentions API keys encrypted', onHtml.includes('API keys are encrypted'));
+  assert('ON state action buttons are delegated',
+    onHtml.includes('data-crypto-action="change-passphrase"') &&
+    onHtml.includes('data-crypto-action="disable-encryption"') &&
+    !onHtml.includes('onclick='));
 
   if (wasEnabled) localStorage.setItem('labcharts-encryption-enabled', wasEnabled);
   else localStorage.removeItem('labcharts-encryption-enabled');
@@ -542,6 +549,10 @@ try {
   const html = window.renderBackupSection();
   assert('Backup section has auto-backup status', html.includes('backup-auto-status'));
   assert('Backup section has snapshot list container', html.includes('backup-snapshot-list'));
+  assert('Backup section has delegated snapshot toggle and import',
+    html.includes('data-crypto-action="toggle-backup-snapshots"') &&
+    html.includes('data-crypto-action="import-backup"') &&
+    !/on(click|change)=/.test(html));
 } catch (e) {
   assert('Backup section auto-backup UI', false, e.message);
 }

--- a/tests/test-folder-backup.js
+++ b/tests/test-folder-backup.js
@@ -78,7 +78,8 @@ await import('../js/export.js'); // exposes window.buildAllDataBundle
     const st = window.getFolderBackupState();
     if (st.supported) {
       assert('Folder section has description text', html.includes('backup-folder-desc'));
-      assert('Folder section has set/change button', html.includes('pickFolderForBackup'));
+      assert('Folder section has delegated set/change button', html.includes('data-backup-action="pick-folder"'));
+      assert('Folder section has no inline click handlers', !html.includes('onclick='));
     } else {
       assert('Folder section hidden on unsupported browser', !html.includes('backup-folder-desc'));
     }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.518';
+self.APP_VERSION = '1.8.519';


### PR DESCRIPTION
## Summary
- Replace backup folder controls with delegated `data-backup-action` handlers.
- Replace encryption, backup import/export, snapshot toggle, and auto-backup restore inline handlers with delegated `data-crypto-action` controls.
- Lower inline event baseline from 47 to 35 and bump `version.js` to 1.8.519.

## Validation
- `node --check js/backup.js`
- `node --check js/crypto.js`
- `node scripts/quality-guardrails.mjs`
- `node tests/test-folder-backup.js`
- `node tests/test-crypto.js`
- `npm run typecheck`
- `npx playwright test tests/playwright/backup-browser-coverage.spec.js tests/playwright/crypto-browser-coverage.spec.js`
- `npm test`
- `./run-tests.sh` (Vitest 178 passed; Playwright 325 passed; Theme Responsive E2E 472 passed, 0 failed)