### PR TITLE
[codex] Delegate light surface actions

### DIFF
--- a/js/light-channel-view.js
+++ b/js/light-channel-view.js
@@ -5,6 +5,28 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
 import { getCachedConditionsAtmosphere } from './light-conditions-now.js';
 
+const LIGHT_CHANNEL_ACTION_ATTR = 'data-light-channel-action';
+const LIGHT_CHANNEL_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightChannelActionDelegatesInstalled'), lightChannelActionDelegateRoots = new WeakSet();
+function closestLightChannelAction(target) { return target?.closest?.(`[${LIGHT_CHANNEL_ACTION_ATTR}]`) || null; }
+function handleLightChannelActionClick(event) {
+  const actionEl = closestLightChannelAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(LIGHT_CHANNEL_ACTION_ATTR);
+  const channelKey = /** @type {HTMLElement} */ (actionEl).dataset.channel || '';
+  let handled = true;
+  if (action === 'toggle-detail' && channelKey) _toggleChannelDetail(channelKey);
+  else if (action === 'quick-log-sun') window.quickLogSunSession?.();
+  else if (action === 'quick-log-device') window.quickLogDeviceSession?.();
+  else handled = false;
+  if (handled) event.stopPropagation();
+}
+export function installLightChannelActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || lightChannelActionDelegateRoots.has(root) || root[LIGHT_CHANNEL_ACTION_DELEGATE_KEY]) return;
+  lightChannelActionDelegateRoots.add(root);
+  Object.defineProperty(root, LIGHT_CHANNEL_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleLightChannelActionClick);
+}
+if (typeof document !== 'undefined') installLightChannelActionDelegates();
 export function mergeTotals(a, b) {
   const out = { ...a };
   for (const [k, v] of Object.entries(b || {})) out[k] = (out[k] || 0) + v;
@@ -110,7 +132,7 @@ export function renderChannelPills(totals7d, totals30d) {
     const dc = _channelDayCount(k);
     const tip = `${meta.what || ''} — ${dc.n} of 7 days hit target this week.`;
     const detailId = `light-pill-detail-${k}`;
-    html += `<button type="button" class="light-pill light-pill-tier-${t7} light-pill-interactive" data-channel="${escapeAttr(k)}" data-trend="${trendDir}" aria-expanded="false" aria-controls="${detailId}" title="${escapeHTML(tip)}" onclick="window._toggleChannelDetail && window._toggleChannelDetail('${escapeAttr(k)}')">
+    html += `<button type="button" class="light-pill light-pill-tier-${t7} light-pill-interactive" data-light-channel-action="toggle-detail" data-channel="${escapeAttr(k)}" data-trend="${trendDir}" aria-expanded="false" aria-controls="${detailId}" title="${escapeHTML(tip)}">
       <span class="light-pill-icon" aria-hidden="true">${meta.icon || '·'}</span>
       <span class="light-pill-label">${escapeHTML(meta.label || k)}</span>
       ${_channelSparkline(k)}
@@ -609,8 +631,8 @@ function _channelNextMove(channelKey, t7, totalCurrent, devices, atm) {
   const showSun = true; // every channel can be filled with sun
   const showDev = !!matchingDevice;
   const buttons = `
-    ${showSun ? `<button type="button" class="import-btn import-btn-primary light-channel-cta-btn" onclick="window.quickLogSunSession && window.quickLogSunSession()">☀ Log a sun session</button>` : ''}
-    ${showDev ? `<button type="button" class="import-btn import-btn-secondary light-channel-cta-btn" onclick="window.quickLogDeviceSession && window.quickLogDeviceSession()">🔴 Log device session</button>` : ''}`;
+    ${showSun ? `<button type="button" class="import-btn import-btn-primary light-channel-cta-btn" data-light-channel-action="quick-log-sun">☀ Log a sun session</button>` : ''}
+    ${showDev ? `<button type="button" class="import-btn import-btn-secondary light-channel-cta-btn" data-light-channel-action="quick-log-device">🔴 Log device session</button>` : ''}`;
   return `<section class="light-channel-nextmove">
     <div class="light-channel-nextmove-label">Next move</div>
     <p class="light-channel-nextmove-text">${txt}</p>
@@ -668,7 +690,7 @@ function _renderChannelDetailPanel(channelKey) {
     <header class="light-channel-detail-head">
       <span class="light-channel-detail-icon" aria-hidden="true">${meta.icon || '·'}</span>
       <h4 class="light-channel-detail-title">${escapeHTML(meta.label || channelKey)}</h4>
-      <button type="button" class="light-channel-detail-close" aria-label="Close ${escapeAttr(meta.label || channelKey)} detail" onclick="window._toggleChannelDetail && window._toggleChannelDetail('${escapeAttr(channelKey)}')">×</button>
+      <button type="button" class="light-channel-detail-close" aria-label="Close ${escapeAttr(meta.label || channelKey)} detail" data-light-channel-action="toggle-detail" data-channel="${escapeAttr(channelKey)}">×</button>
     </header>
 
     ${_channelHero(channelKey, totalCurrent, totalPrev, days7, daysPrev7, t7)}

--- a/js/light-conditions-now.js
+++ b/js/light-conditions-now.js
@@ -5,6 +5,49 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
+const LIGHT_CONDITIONS_ACTION_ATTR = 'data-light-conditions-action';
+const LIGHT_CONDITIONS_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightConditionsActionDelegatesInstalled');
+const lightConditionsActionDelegateRoots = new WeakSet();
+
+function closestLightConditionsAction(target) {
+  if (!target || !target.closest) return null;
+  return target.closest(`[${LIGHT_CONDITIONS_ACTION_ATTR}]`);
+}
+
+function handleLightConditionsActionClick(event) {
+  const actionEl = closestLightConditionsAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(LIGHT_CONDITIONS_ACTION_ATTR);
+  if (action === 'refresh') {
+    _refreshConditionsNow();
+    event.stopPropagation();
+    return;
+  }
+  if (action === 'inspect') {
+    _inspectConditionsNow();
+    event.stopPropagation();
+    return;
+  }
+  if (action === 'set-manual-uvi') {
+    _setManualUvi();
+    event.stopPropagation();
+    return;
+  }
+  if (action === 'clear-manual-uvi') {
+    _clearManualUvi();
+    event.stopPropagation();
+  }
+}
+
+export function installLightConditionsActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || lightConditionsActionDelegateRoots.has(root) || root[LIGHT_CONDITIONS_ACTION_DELEGATE_KEY]) return;
+  lightConditionsActionDelegateRoots.add(root);
+  Object.defineProperty(root, LIGHT_CONDITIONS_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleLightConditionsActionClick);
+}
+
+if (typeof document !== 'undefined') installLightConditionsActionDelegates();
+
 export function renderLightConditionsWidgetBody({ variant = 'full', slotId = '' } = {}) {
   const conditionsOpts = { variant };
   if (slotId) conditionsOpts.slotId = slotId;
@@ -12,8 +55,8 @@ export function renderLightConditionsWidgetBody({ variant = 'full', slotId = '' 
       <div class="light-conditions-now-head">
         <span class="light-conditions-now-title">Conditions now</span>
         <span class="light-conditions-now-actions">
-          <button type="button" class="conditions-now-refresh light-widget-mini-btn" aria-label="Refresh conditions data — bypasses cache" onclick="window._refreshConditionsNow && window._refreshConditionsNow()"${_conditionsTooltipAttr('Force a fresh fetch, bypassing the short cache')}>Refresh</button>
-          <button type="button" class="conditions-now-inspect light-widget-mini-btn" aria-label="Show raw conditions response, source, cache, and sanity check" onclick="window._inspectConditionsNow && window._inspectConditionsNow()"${_conditionsTooltipAttr('See raw response, source, cache age, and sanity checks')}>Details</button>
+          <button type="button" class="conditions-now-refresh light-widget-mini-btn" data-light-conditions-action="refresh" aria-label="Refresh conditions data — bypasses cache"${_conditionsTooltipAttr('Force a fresh fetch, bypassing the short cache')}>Refresh</button>
+          <button type="button" class="conditions-now-inspect light-widget-mini-btn" data-light-conditions-action="inspect" aria-label="Show raw conditions response, source, cache, and sanity check"${_conditionsTooltipAttr('See raw response, source, cache age, and sanity checks')}>Details</button>
         </span>
       </div>
       ${renderConditionsNow(conditionsOpts)}
@@ -614,8 +657,8 @@ function _renderConditionsHTML(atm, coords, variant, offline = false) {
     <span class="conditions-now-override"${_conditionsTooltipAttr('Manual UVI override — feeds your own UV-meter reading into the spectrum reconstruction. Leave blank to use the live atmosphere fetch.')}>
       <label for="manual-uvi-input">Manual UVI:</label>
       <input type="number" min="0" max="20" step="0.1" inputmode="decimal" id="manual-uvi-input" value="${Number.isFinite(ovStored) ? ovStored : ''}" placeholder="${atm.uvIndex != null && !atm._uvOverridden ? atm.uvIndex.toFixed(1) : '—'}">
-      <button type="button" onclick="window._setManualUvi && window._setManualUvi()">Apply</button>
-      ${Number.isFinite(ovStored) ? `<button type="button" onclick="window._clearManualUvi && window._clearManualUvi()"${_conditionsTooltipAttr('Clear the manual override')} aria-label="Clear manual UVI override">×</button>` : ''}
+      <button type="button" data-light-conditions-action="set-manual-uvi">Apply</button>
+      ${Number.isFinite(ovStored) ? `<button type="button" data-light-conditions-action="clear-manual-uvi"${_conditionsTooltipAttr('Clear the manual override')} aria-label="Clear manual UVI override">×</button>` : ''}
     </span>
   </div>`;
 

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -45,6 +45,48 @@ import {
   openCustomDeviceDialog,
 } from './light-device-setup-modal.js';
 
+const LIGHT_DEVICES_ACTION_ATTR = 'data-light-devices-action';
+const LIGHT_DEVICE_ID_ATTR = 'data-light-device-id';
+const LIGHT_DEVICE_SESSION_ID_ATTR = 'data-light-device-session-id';
+const LIGHT_DEVICES_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightDevicesActionDelegatesInstalled'), lightDevicesActionDelegateRoots = new WeakSet();
+
+function closestLightDevicesAction(target) { return target?.closest?.(`[${LIGHT_DEVICES_ACTION_ATTR}]`) || null; }
+
+function handleLightDevicesActionClick(event) {
+  const actionEl = closestLightDevicesAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(LIGHT_DEVICES_ACTION_ATTR);
+  const appWindow = /** @type {any} */ (window);
+  if (action === 'suppress') {
+    event.stopPropagation();
+    return;
+  }
+  if (action === 'stop-device-session') {
+    event.stopPropagation();
+    const sessionId = actionEl.getAttribute(LIGHT_DEVICE_SESSION_ID_ATTR) || '';
+    if (sessionId) appWindow.stopDeviceSessionAndNotify?.(sessionId);
+    return;
+  }
+  if (action === 'add-device') { appWindow.openAddDeviceDialog?.(); return; }
+  if (action === 'delete-device') {
+    const deviceId = actionEl.getAttribute(LIGHT_DEVICE_ID_ATTR) || '';
+    if (deviceId) appWindow.deleteLightDevice?.(deviceId);
+    return;
+  }
+  if (action === 'log-device-session') {
+    const deviceId = actionEl.getAttribute(LIGHT_DEVICE_ID_ATTR) || '';
+    if (deviceId) appWindow.openDeviceSessionDialog?.(deviceId);
+  }
+}
+
+export function installLightDevicesActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || lightDevicesActionDelegateRoots.has(root) || root[LIGHT_DEVICES_ACTION_DELEGATE_KEY]) return;
+  lightDevicesActionDelegateRoots.add(root);
+  Object.defineProperty(root, LIGHT_DEVICES_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleLightDevicesActionClick);
+}
+if (typeof document !== 'undefined') installLightDevicesActionDelegates();
+
 export { openAddDeviceDialog, openCustomDeviceDialog };
 export {
   addCustomDevice,
@@ -455,9 +497,9 @@ export function renderActiveDeviceSessionCard() {
       <span class="sun-session-paused" title="Live device-therapy session">LIVE</span>
     </div>
     <div class="sun-session-meta">${escapeHTML(distLine)}${distLine && areaLine ? ' · ' : ''}${escapeHTML(areaLine)}${areaLine ? ' · ' : ''}${escapeHTML(eyesLine)}</div>
-    <div class="sun-session-active-controls" onclick="event.stopPropagation()">
+    <div class="sun-session-active-controls" data-light-devices-action="suppress">
       <div class="sun-session-ctl-primary">
-        <button class="sun-session-ctl sun-session-ctl-stop" onclick="event.stopPropagation();window.stopDeviceSessionAndNotify('${escapeAttr(sess.id)}')" title="Stop and save the session"><span aria-hidden="true">⏹</span> <span class="sun-session-ctl-label">Stop &amp; save</span></button>
+        <button type="button" class="sun-session-ctl sun-session-ctl-stop" data-light-devices-action="stop-device-session" data-light-device-session-id="${escapeAttr(sess.id)}" title="Stop and save the session"><span aria-hidden="true">⏹</span> <span class="sun-session-ctl-label">Stop &amp; save</span></button>
       </div>
     </div>
   </section>`;
@@ -519,7 +561,7 @@ export async function renderDevicesSection() {
   let html = `<div class="light-devices-section">
     <div class="light-devices-head">
       <h3 class="light-section-title">Light devices</h3>
-      <button class="import-btn import-btn-secondary" onclick="window.openAddDeviceDialog()">+ Add device</button>
+      <button type="button" class="import-btn import-btn-secondary" data-light-devices-action="add-device">+ Add device</button>
     </div>`;
 
   if (devices.length === 0) {
@@ -554,7 +596,7 @@ export async function renderDevicesSection() {
           <span class="light-device-name">${escapeHTML(dev.brand)} ${escapeHTML(dev.model)}</span>
           <span class="light-device-typeline">${escapeHTML(typeLabel)}${wavelengthStr ? ` · ${escapeHTML(wavelengthStr)}` : ''}${intensityStr ? ` · ${escapeHTML(intensityStr)}` : ''}</span>
         </div>
-        <button class="light-device-delete" onclick="window.deleteLightDevice('${escapeAttr(dev.id)}')" title="Remove device" aria-label="Remove device">×</button>
+        <button type="button" class="light-device-delete" data-light-devices-action="delete-device" data-light-device-id="${escapeAttr(dev.id)}" title="Remove device" aria-label="Remove device">×</button>
       </div>
       ${channelChips ? `<div class="light-device-feeds">
         <span class="light-device-feeds-label">Feeds</span>
@@ -562,7 +604,7 @@ export async function renderDevicesSection() {
       </div>` : ''}
       <div class="light-device-stats">${escapeHTML(statsLine)}</div>
       <div class="light-device-actions">
-        <button class="import-btn import-btn-secondary light-device-log" onclick="window.openDeviceSessionDialog('${escapeAttr(dev.id)}')">▶ Log session</button>
+        <button type="button" class="import-btn import-btn-secondary light-device-log" data-light-devices-action="log-device-session" data-light-device-id="${escapeAttr(dev.id)}">▶ Log session</button>
         ${affRow}
       </div>
     </div>`;

--- a/js/light-sessions-view.js
+++ b/js/light-sessions-view.js
@@ -4,6 +4,58 @@
 import { bindModalSyncRefresh, escapeHTML, escapeAttr, formatDate } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 
+const LIGHT_SESSIONS_ACTION_ATTR = 'data-light-sessions-action';
+const LIGHT_SESSION_ID_ATTR = 'data-light-session-id';
+const LIGHT_SESSIONS_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightSessionsActionDelegatesInstalled');
+const lightSessionsActionDelegateRoots = new WeakSet();
+
+function closestLightSessionsAction(target) {
+  if (!target || !target.closest) return null;
+  return target.closest(`[${LIGHT_SESSIONS_ACTION_ATTR}]`);
+}
+
+function handleLightSessionsActionClick(event) {
+  const actionEl = closestLightSessionsAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(LIGHT_SESSIONS_ACTION_ATTR);
+  const sessionId = actionEl.getAttribute(LIGHT_SESSION_ID_ATTR) || '';
+  const appWindow = /** @type {any} */ (window);
+  if (action === 'open-device-session') {
+    if (sessionId) appWindow.openDeviceSessionDetail?.(sessionId);
+    event.stopPropagation();
+    return;
+  }
+  if (action === 'delete-device-session') {
+    event.stopPropagation();
+    if (sessionId) appWindow.deleteDeviceSession?.(sessionId);
+    return;
+  }
+  if (action === 'show-all') {
+    event.stopPropagation();
+    _openAllSessionsModal();
+  }
+}
+
+function handleLightSessionsActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestLightSessionsAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (actionEl.getAttribute('role') !== 'button') return;
+  if (event.target?.closest?.('button, a, input, textarea, select')) return;
+  event.preventDefault();
+  handleLightSessionsActionClick(event);
+}
+
+export function installLightSessionsActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || lightSessionsActionDelegateRoots.has(root) || root[LIGHT_SESSIONS_ACTION_DELEGATE_KEY]) return;
+  lightSessionsActionDelegateRoots.add(root);
+  Object.defineProperty(root, LIGHT_SESSIONS_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleLightSessionsActionClick);
+  root.addEventListener('keydown', handleLightSessionsActionKeydown);
+}
+
+if (typeof document !== 'undefined') installLightSessionsActionDelegates();
+
 // Inline cap on the historical sessions list. 3 is enough for
 // at-a-glance context ("what did I do recently"); the full history
 // opens in a modal so the rest of the Light & Sun page (Devices,
@@ -89,14 +141,14 @@ function _renderSessionRowsHTML(rows) {
         }
       }
       const devAriaLabel = `Open ${date} device session details — ${devName}${modeAria}`;
-      html += `<div class="sun-session light-session-row light-session-device" data-id="${escapeAttr(sess.id)}" role="button" tabindex="0" aria-label="${escapeAttr(devAriaLabel)}" onclick="window.openDeviceSessionDetail && window.openDeviceSessionDetail('${escapeAttr(sess.id)}')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.openDeviceSessionDetail && window.openDeviceSessionDetail('${escapeAttr(sess.id)}')}">
+      html += `<div class="sun-session light-session-row light-session-device" data-id="${escapeAttr(sess.id)}" data-light-sessions-action="open-device-session" data-light-session-id="${escapeAttr(sess.id)}" role="button" tabindex="0" aria-label="${escapeAttr(devAriaLabel)}">
         <div class="sun-session-head">
           <span class="light-session-icon" aria-hidden="true">🔴</span>
           <span class="sun-session-date">${escapeHTML(date)}</span>
           <span class="sun-session-duration">${escapeHTML(dur)}</span>
           <span class="light-session-kind">${escapeHTML(devName)}</span>
           ${modeBadge}
-          <button class="sun-session-delete" onclick="event.stopPropagation();window.deleteDeviceSession && window.deleteDeviceSession('${escapeAttr(sess.id)}')" title="Delete session" aria-label="Delete session">×</button>
+          <button type="button" class="sun-session-delete" data-light-sessions-action="delete-device-session" data-light-session-id="${escapeAttr(sess.id)}" title="Delete session" aria-label="Delete session">×</button>
         </div>
         <div class="sun-session-meta">${escapeHTML(meta)}</div>
         ${_renderLightSessionChannelChips(sess.doses, sess.durationMin || 0)}
@@ -119,7 +171,7 @@ export function renderUnifiedSessionsList() {
   html += _renderSessionRowsHTML(visibleRows);
   html += `</div>`;
   if (hiddenCount > 0) {
-    html += `<button class="light-sessions-show-more" onclick="window._openAllSessionsModal()">View all ${totalCount} sessions</button>`;
+    html += `<button type="button" class="light-sessions-show-more" data-light-sessions-action="show-all">View all ${totalCount} sessions</button>`;
   }
   return html;
 }

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -38,6 +38,56 @@ import {
   openGlassTransmission as openGlassTransmissionModal,
 } from './light-tool-camera-modals.js';
 
+const LIGHT_TOOLS_ACTION_ATTR = 'data-light-tools-action';
+const LIGHT_TOOL_ID_ATTR = 'data-light-tool-id';
+const LIGHT_TOOLS_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightToolsActionDelegatesInstalled');
+const lightToolsActionDelegateRoots = new WeakSet();
+
+function closestLightToolsAction(target) {
+  if (!target || !target.closest) return null;
+  return target.closest(`[${LIGHT_TOOLS_ACTION_ATTR}]`);
+}
+
+function openLightToolById(toolId) {
+  const openers = {
+    spectrum: openSpectrumClassifier,
+    lux: openLuxMeter,
+    cct: openCCTMeter,
+    flicker: openFlickerDetector,
+    darkness: openDarknessMeter,
+    glass: openGlassTransmission,
+    audit: openEyeLevelAudit,
+    golden: openSunriseLogger,
+  };
+  const opener = openers[toolId];
+  if (opener) opener();
+}
+
+function handleLightToolsActionClick(event) {
+  const actionEl = closestLightToolsAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(LIGHT_TOOLS_ACTION_ATTR);
+  if (action === 'close-audit') {
+    window._closeAudit?.();
+    event.stopPropagation();
+    return;
+  }
+  if (action === 'open-tool') {
+    const toolId = actionEl.getAttribute(LIGHT_TOOL_ID_ATTR) || '';
+    openLightToolById(toolId);
+    event.stopPropagation();
+  }
+}
+
+export function installLightToolsActionDelegates(root = typeof document !== 'undefined' ? document : null) {
+  if (!root || lightToolsActionDelegateRoots.has(root) || root[LIGHT_TOOLS_ACTION_DELEGATE_KEY]) return;
+  lightToolsActionDelegateRoots.add(root);
+  Object.defineProperty(root, LIGHT_TOOLS_ACTION_DELEGATE_KEY, { value: true, configurable: true });
+  root.addEventListener('click', handleLightToolsActionClick);
+}
+
+if (typeof document !== 'undefined') installLightToolsActionDelegates();
+
 export {
   aimingGuideHTML,
   lockCameraForMeasurement,
@@ -378,7 +428,7 @@ export async function openEyeLevelAudit() {
   overlay.innerHTML = `<div class="modal light-tool-modal" role="dialog" aria-label="Home audit">
     <div class="modal-header">
       <h3>Home audit <span style="font-weight:400;color:var(--text-muted);font-size:13px">— 10 min walkthrough</span></h3>
-      <button class="modal-close" onclick="window._closeAudit()" aria-label="Close">×</button>
+      <button type="button" class="modal-close" data-light-tools-action="close-audit" aria-label="Close">×</button>
     </div>
     <div class="modal-body">
       ${aimingGuideHTML('audit')}
@@ -386,8 +436,8 @@ export async function openEyeLevelAudit() {
       <div class="audit-status" id="audit-status" aria-live="polite" aria-atomic="true">Press Start when ready.</div>
       <ol class="audit-room-list" id="audit-room-list" style="margin-top:12px;list-style:decimal inside;color:var(--text-secondary)"></ol>
       <div class="modal-actions" style="margin-top:18px">
-        <button class="import-btn import-btn-secondary" onclick="window._closeAudit()">Cancel</button>
-        <button class="import-btn import-btn-primary" id="audit-toggle">Start audit</button>
+        <button type="button" class="import-btn import-btn-secondary" data-light-tools-action="close-audit">Cancel</button>
+        <button type="button" class="import-btn import-btn-primary" id="audit-toggle">Start audit</button>
       </div>
     </div>
   </div>`;
@@ -571,56 +621,48 @@ export function renderLightTools() {
 
   const tools = {
     spectrum: {
-      handler: 'window.openSpectrumClassifier()',
       icon: '🔬',
       name: 'What is this light?',
       desc: 'Classify LED, fluorescent, daylight, or incandescent and estimate melanopic load.',
       short: 'Bulb type + spectrum',
     },
     lux: {
-      handler: 'window.openLuxMeter()',
       icon: '📏',
       name: 'Lux meter',
       desc: 'Measure room brightness with daylight comparison and per-device calibration.',
       short: 'Brightness baseline',
     },
     cct: {
-      handler: 'window.openCCTMeter()',
       icon: '🎨',
       name: 'Color temp',
       desc: 'Check warm/cool kelvin, solar-time match, and dimming warning signs.',
       short: 'Warm vs cool',
     },
     flicker: {
-      handler: 'window.openFlickerDetector()',
       icon: '⚡',
       name: 'Flicker detector',
       desc: 'Find PWM and rolling-shutter banding up to 25 kHz.',
       short: 'PWM risk',
     },
     darkness: {
-      handler: 'window.openDarknessMeter()',
       icon: '🌙',
       name: 'Sleep darkness',
       desc: 'Measure mean and peak lux at the pillow.',
       short: 'Bedroom night check',
     },
     glass: {
-      handler: 'window.openGlassTransmission()',
       icon: '🪟',
       name: 'Window check',
       desc: 'Compare two readings with and without glass for a better behind-glass estimate.',
       short: 'Glass transmission',
     },
     audit: {
-      handler: 'window.openEyeLevelAudit()',
       icon: '🚶',
       name: 'Home audit',
       desc: 'Walk through rooms and capture a per-room snapshot in about 10 minutes.',
       short: 'Room sweep',
     },
     golden: {
-      handler: 'window.openSunriseLogger()',
       icon: '🌅',
       name: 'Golden hour log',
       desc: 'After-the-fact log for sunrise or sunset sessions.',
@@ -632,7 +674,7 @@ export function renderLightTools() {
     const t = tools[id];
     if (!t) return '';
     const reason = opts.reason || t.short;
-    return `<button class="light-tool-action${opts.primary ? ' light-tool-action-primary' : ''}" onclick="${t.handler}" title="${escapeAttr(t.desc)}">
+    return `<button type="button" class="light-tool-action${opts.primary ? ' light-tool-action-primary' : ''}" data-light-tools-action="open-tool" data-light-tool-id="${escapeAttr(id)}" title="${escapeAttr(t.desc)}">
       <span class="light-tool-action-icon" aria-hidden="true">${t.icon}</span>
       <span class="light-tool-action-copy">
         <span class="light-tool-action-name">${escapeHTML(t.name)}</span>

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 35,
+  "inlineEventAttributes": 15,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/light-conditions-now-browser-coverage.spec.js
+++ b/tests/playwright/light-conditions-now-browser-coverage.spec.js
@@ -105,8 +105,12 @@ test('conditions now browser coverage covers refresh cache manual override and i
       };
 
       host.innerHTML = conditions.renderLightConditionsWidgetBody({ variant: 'full', slotId: 'cond-now-coverage-full' });
+      conditions.installLightConditionsActionDelegates(host);
       outcomes.widgetBodyRendersRefreshButton = !!host.querySelector('.conditions-now-refresh');
       outcomes.widgetBodyRendersInspectButton = !!host.querySelector('.conditions-now-inspect');
+      outcomes.widgetBodyUsesDelegatedActions = !!host.querySelector('[data-light-conditions-action="refresh"]')
+        && !!host.querySelector('[data-light-conditions-action="inspect"]')
+        && !host.innerHTML.includes('onclick=');
       await waitUntil(() => document.getElementById('cond-now-coverage-full')?.getAttribute('aria-busy') === 'false', 'initial conditions render');
       outcomes.initialRefreshFetchesCoords = calls.some(call => call[0] === 'fetch' && call[1].lat === coords.lat && call[1].lon === coords.lon);
       outcomes.fullRenderShowsUvIndex = slotText('cond-now-coverage-full').includes('UV index');

--- a/tests/playwright/light-coverage-batch-2.spec.js
+++ b/tests/playwright/light-coverage-batch-2.spec.js
@@ -356,11 +356,14 @@ test('light channel view covers pills detail panels suggestions and light-page r
       const totals7d = { vitamin_d: 260, circadian: 25, nir_solar: 140, no_cv: 120, pomc: 110, violet_eye: 0 };
       const totals30d = { vitamin_d: 500, circadian: 900, nir_solar: 300, no_cv: 100, pomc: 100, violet_eye: 10 };
       host.innerHTML = channel.renderChannelPills(totals7d, totals30d);
+      channel.installLightChannelActionDelegates(host);
       const pills = Array.from(host.querySelectorAll('.light-pill'));
       outcomes.pillsRenderSixSparklinesAndTrendData = pills.length === 6
         && !!host.querySelector('.light-pill-sparkline')
         && pills.some(pill => pill.dataset.channel === 'vitamin_d' && pill.dataset.trend === 'up')
         && pills.some(pill => pill.querySelector('.light-pill-daycount')?.textContent.includes('/7'));
+      outcomes.channelPillsUseDelegatedActions = pills.every(pill => pill.getAttribute('data-light-channel-action') === 'toggle-detail')
+        && !host.innerHTML.includes('onclick=');
 
       const dayCount = channel._channelDayCount('circadian');
       outcomes.dayCountUsesThresholdAndConsistentLabel = /^\d\/7$/.test(dayCount.txt)
@@ -382,6 +385,10 @@ test('light channel view covers pills detail panels suggestions and light-page r
         && !!detail.querySelector('.light-channel-mix')
         && !!detail.querySelector('.light-channel-weekchart svg')
         && host.querySelector('.light-pill[data-channel="vitamin_d"]')?.getAttribute('aria-expanded') === 'true';
+      outcomes.detailActionsUseDelegatedActions = !!detail?.querySelector('[data-light-channel-action="quick-log-sun"]')
+        && !!detail?.querySelector('[data-light-channel-action="quick-log-device"]')
+        && !!detail?.querySelector('.light-channel-detail-close[data-light-channel-action="toggle-detail"]')
+        && !detail.innerHTML.includes('onclick=');
       detail?.querySelector('.light-channel-cta-btn.import-btn-primary')?.click();
       detail?.querySelector('.light-channel-cta-btn.import-btn-secondary')?.click();
       outcomes.detailActionButtonsCallSunAndDeviceLoggers = calls.some(call => call[0] === 'quick-sun')

--- a/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
+++ b/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
@@ -99,6 +99,7 @@ test('light sessions view edge coverage handles empty and compact device history
       ];
       const mixedHost = document.createElement('div');
       mixedHost.innerHTML = sessionsView.renderUnifiedSessionsList();
+      sessionsView.installLightSessionsActionDelegates(mixedHost);
       const nirRow = mixedHost.querySelector('.light-session-device[data-id="dev-nir"]');
       const removedRow = mixedHost.querySelector('.light-session-device[data-id="dev-removed"]');
       outcomes.deviceInlineRendersEscapedModeChipsAndFallbacks =
@@ -111,6 +112,11 @@ test('light sessions view edge coverage handles empty and compact device history
         && nirRow?.querySelectorAll('.sun-chip').length === 1
         && removedRow?.textContent.includes('Removed device') === true
         && removedRow?.textContent.includes('— @ 30cm') === true;
+      outcomes.deviceInlineRowsUseDelegatedActions =
+        nirRow?.getAttribute('data-light-sessions-action') === 'open-device-session'
+        && nirRow?.querySelector('.sun-session-delete')?.getAttribute('data-light-sessions-action') === 'delete-device-session'
+        && !mixedHost.innerHTML.includes('onclick=')
+        && !mixedHost.innerHTML.includes('onkeydown=');
 
       nirRow?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       nirRow?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
@@ -118,6 +124,7 @@ test('light sessions view edge coverage handles empty and compact device history
 
       sessionsView._openAllSessionsModal();
       overlay = document.querySelector('.light-sessions-modal-overlay');
+      if (overlay) sessionsView.installLightSessionsActionDelegates(overlay);
       const modalRow = overlay?.querySelector('.light-session-device[data-id="dev-nir"]');
       const detailCallsBeforeModalEnter = calls.filter(call => call[0] === 'detail' && call[1] === 'dev-nir').length;
       modalRow?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -859,12 +859,17 @@ test('light devices cover session detail edit log active card and rendered list 
       const devicesHtml = await lightDevices.renderDevicesSection();
       const devicesHost = document.createElement('div');
       devicesHost.innerHTML = devicesHtml;
+      lightDevices.installLightDevicesActionDelegates(devicesHost);
       outcomes.renderDevicesSectionShowsStatsAndAffiliate = devicesHost.textContent.includes('TestLight Panel 900')
         && devicesHost.textContent.includes('1 session')
         && !!devicesHost.querySelector('.affiliate-test')
         && devicesHost.textContent.includes('630')
         && devicesHost.textContent.includes('850')
         && !!devicesHost.querySelector('.light-device-feed-chip');
+      outcomes.renderDevicesSectionUsesDelegatedActions = !!devicesHost.querySelector('[data-light-devices-action="add-device"]')
+        && !!devicesHost.querySelector('[data-light-devices-action="delete-device"][data-light-device-id="dev-panel"]')
+        && !!devicesHost.querySelector('[data-light-devices-action="log-device-session"][data-light-device-id="dev-panel"]')
+        && !devicesHost.innerHTML.includes('onclick=');
 
       lightDevices.openDeviceSessionDetail('devsess-one');
       let detailOverlay = document.querySelector('[data-session-kind="device"]')?.closest('.modal-overlay');

--- a/tests/playwright/light-tools-browser-coverage.spec.js
+++ b/tests/playwright/light-tools-browser-coverage.spec.js
@@ -144,6 +144,9 @@ test('light tools browser coverage exercises storage render and modal flows', as
       results.renderShowsMeasuredStatus = populatedHtml.includes('measurements')
         && populatedHtml.includes('2 rooms mapped')
         && populatedHtml.includes('Recommended next');
+      results.renderUsesDelegatedToolActions = populatedHtml.includes('data-light-tools-action="open-tool"')
+        && populatedHtml.includes('data-light-tool-id="lux"')
+        && !populatedHtml.includes('onclick=');
       const guideHost = document.createElement('div');
       guideHost.innerHTML = lightTools.aimingGuideHTML('lux');
       document.body.append(guideHost);

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -553,15 +553,20 @@ test('light sessions view covers all-sessions modal refresh scroll and row event
 
       const inlineHost = document.createElement('div');
       inlineHost.innerHTML = sessionsView.renderUnifiedSessionsList();
+      sessionsView.installLightSessionsActionDelegates(inlineHost);
       // Active sessions are pinned elsewhere, so history sees four completed
       // rows (2 sun + 2 device) and caps the inline list to the first three.
       const inlineRows = inlineHost.querySelectorAll('.sun-session');
       outcomes.inlineListCapsAndShowsMore = inlineRows.length === 3
         && inlineHost.textContent.includes('View all 4 sessions')
         && !!inlineHost.querySelector('.light-sessions-list-unified');
+      outcomes.inlineListUsesDelegatedActions = !!inlineHost.querySelector('[data-light-sessions-action="show-all"]')
+        && !inlineHost.innerHTML.includes('onclick=')
+        && !inlineHost.innerHTML.includes('onkeydown=');
 
       sessionsView._openAllSessionsModal();
       let overlay = document.querySelector('.light-sessions-modal-overlay');
+      if (overlay) sessionsView.installLightSessionsActionDelegates(overlay);
       outcomes.modalSummaryCountsBothKinds = overlay?.textContent.includes('All sessions (4)') === true
         && overlay?.textContent.includes('Sun') === true
         && overlay?.textContent.includes('Device') === true
@@ -601,6 +606,7 @@ test('light sessions view covers all-sessions modal refresh scroll and row event
 
       sessionsView._openAllSessionsModal();
       overlay = document.querySelector('.light-sessions-modal-overlay');
+      if (overlay) sessionsView.installLightSessionsActionDelegates(overlay);
       const keyRow = overlay?.querySelector('.light-session-device[role="button"]');
       keyRow?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }));
       await delay(0);

--- a/tests/test-light-tools-flow.js
+++ b/tests/test-light-tools-flow.js
@@ -90,6 +90,10 @@ await import('../js/light-tools.js');
   }
   assert('renderLightTools drawers contain only secondary tools',
     html.includes('Specialized checks') && html.includes('Color temp') && html.includes('Sleep darkness') && html.includes('Window check'));
+  assert('renderLightTools uses delegated tool actions',
+    html.includes('data-light-tools-action="open-tool"') && html.includes('data-light-tool-id="lux"'));
+  assert('renderLightTools has no inline onclick handlers',
+    !html.includes('onclick='));
 
   // ── 5. Camera-dependent openers (all 8) ──────────────────────────────
   // These need getUserMedia which isn't available in the test page. They

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.519';
+self.APP_VERSION = '1.8.520';


### PR DESCRIPTION
## Summary
- Replace inline light-session, light-device, channel, conditions, and tools handlers with module-local delegated `data-*` actions.
- Preserve modal row close behavior while avoiding duplicate cache-busted delegate dispatch in browser tests.
- Lower inline event baseline from 35 to 15 and bump `version.js` to 1.8.520.

## Validation
- `node scripts/quality-guardrails.mjs`
- `npm run typecheck`
- `node tests/test-light-tools-flow.js`
- `node tests/test-light-tools.js`
- `node tests/test-light-devices.js`
- `node tests/test-a11y-phase3.js`
- `npx playwright test tests/playwright/light-coverage-batch-2.spec.js tests/playwright/light-sessions-view-edge-browser-coverage.spec.js tests/playwright/modal-session-coverage-batch.spec.js tests/playwright/light-sun-coverage-batch.spec.js tests/playwright/light-conditions-now-browser-coverage.spec.js tests/playwright/light-tools-browser-coverage.spec.js` (16 passed)
- `npm test` (11 files, 178 tests passed)
- `./run-tests.sh` (Vitest 178 passed; dev-server origin guard 18 passed; Playwright 325 passed; Theme Responsive E2E 472 passed, 0 failed)