### PR TITLE
[codex] Delegate final inline handlers

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -5,6 +5,9 @@
 import { escapeHTML } from './utils.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
+const CHANGELOG_ACTION_ATTR = 'data-changelog-action';
+const changelogDelegateRoots = new WeakSet();
+
 const CHANGELOG = [
   {
     version: '1.8.455', date: '2026-06-13', title: 'XLSX lab imports and improvements',
@@ -280,7 +283,7 @@ export function openChangelog(showAll) {
       <div class="gb-modal-kicker">Release notes</div>
       <div class="gb-modal-title">What's New</div>
     </div>
-    <button class="modal-close" aria-label="Close" onclick="closeChangelog()">&times;</button>
+    <button type="button" class="modal-close" aria-label="Close" ${CHANGELOG_ACTION_ATTR}="close">&times;</button>
   </div>
   <div class="gb-form-body">`;
 
@@ -296,7 +299,26 @@ export function openChangelog(showAll) {
 
   html += `</div>`;
   modal.innerHTML = html;
+  installChangelogDelegates(modal);
   openModalOverlay(overlay);
+}
+
+function handleChangelogActionClick(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const actionEl = target.closest(`[${CHANGELOG_ACTION_ATTR}]`);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (actionEl.getAttribute(CHANGELOG_ACTION_ATTR) === 'close') {
+    event.preventDefault();
+    event.stopPropagation();
+    closeChangelog();
+  }
+}
+
+function installChangelogDelegates(root) {
+  if (!root || changelogDelegateRoots.has(root)) return;
+  changelogDelegateRoots.add(root);
+  root.addEventListener('click', handleChangelogActionClick);
 }
 
 export function closeChangelog() {

--- a/js/marker-detail-actions.js
+++ b/js/marker-detail-actions.js
@@ -49,6 +49,15 @@ function handleMarkerDetailAction(actionEl, event, actions) {
 
   if (action === 'close-modal') {
     actions.closeModal?.();
+  } else if (action === 'clear-ref-edit-field') {
+    const field = actionEl.dataset.markerDetailField === 'max' ? 'max' : 'min';
+    const input = document.getElementById(`ref-edit-${field}`);
+    if (input instanceof HTMLInputElement) {
+      input.value = '';
+      input.focus();
+    }
+  } else if (action === 'save-ref-range') {
+    void actions.saveRefRange?.(id, type);
   } else if (action === 'quick-pin') {
     actions.toggleDashboardQuickMarkerPin?.(id);
   } else if (action === 'edit-ref-range') {
@@ -90,6 +99,15 @@ function handleMarkerDetailAction(actionEl, event, actions) {
     void actions.saveManualEntry?.(id);
   } else if (action === 'save-and-add-manual-entry') {
     void actions.saveAndAddAnotherManualEntry?.(id);
+  } else if (action === 'toggle-custom-marker-category') {
+    const row = document.getElementById('cm-new-cat-row');
+    if (row instanceof HTMLElement && actionEl instanceof HTMLSelectElement) {
+      row.style.display = actionEl.value === '__new__' ? 'flex' : 'none';
+    }
+  } else if (action === 'pick-new-cat-icon') {
+    actions.pickNewCatIcon?.(actionEl);
+  } else if (action === 'save-custom-marker') {
+    actions.saveCustomMarker?.();
   }
 }
 
@@ -112,9 +130,17 @@ function handleMarkerDetailKeydown(event, actions) {
   handleMarkerDetailAction(actionEl, event, actions);
 }
 
+function handleMarkerDetailChange(event, actions) {
+  const actionEl = closestMarkerDetailAction(event);
+  if (!actionEl || actionEl.dataset.markerDetailAction !== 'toggle-custom-marker-category') return;
+  event.stopPropagation();
+  handleMarkerDetailAction(actionEl, event, actions);
+}
+
 export function installMarkerDetailActionDelegates(actions = {}, root = (typeof document !== 'undefined' ? document : null)) {
   if (!root || markerDetailActionDelegateRoots.has(root)) return;
   markerDetailActionDelegateRoots.add(root);
   root.addEventListener('click', event => handleMarkerDetailClick(event, actions));
   root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions));
+  root.addEventListener('change', event => handleMarkerDetailChange(event, actions));
 }

--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { getAlternateUnit, convertUserInputToSI } from './schema.js';
 import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, showPromptDialog } from './utils.js';
 import { getActiveData, updateHeaderDates, convertDisplayToSI } from './data.js';
+import { markerDetailActionAttrs } from './marker-detail-actions.js';
 import {
   deleteManualMarkerValue,
   editManualMarkerValue,
@@ -252,7 +253,7 @@ export function editRefRange(id, type, evt) {
   // Replace span with inline inputs
   const form = document.createElement('span');
   form.className = 'ref-edit-form';
-  form.innerHTML = `${escapeHTML(label)}: <span class="ref-edit-field"><input type="text" inputmode="decimal" value="${escapeAttr(curMin ?? '')}" placeholder="none" class="ref-edit-input" id="ref-edit-min"><button type="button" class="ref-edit-clear" onclick="document.getElementById('ref-edit-min').value='';document.getElementById('ref-edit-min').focus()" title="Clear (open-ended)">\u00d7</button></span> \u2013 <span class="ref-edit-field"><input type="text" inputmode="decimal" value="${escapeAttr(curMax ?? '')}" placeholder="none" class="ref-edit-input" id="ref-edit-max"><button type="button" class="ref-edit-clear" onclick="document.getElementById('ref-edit-max').value='';document.getElementById('ref-edit-max').focus()" title="Clear (open-ended)">\u00d7</button></span> <button class="ref-edit-save" onclick="saveRefRange('${id}','${type}')">Save</button>`;
+  form.innerHTML = `${escapeHTML(label)}: <span class="ref-edit-field"><input type="text" inputmode="decimal" value="${escapeAttr(curMin ?? '')}" placeholder="none" class="ref-edit-input" id="ref-edit-min"><button type="button" class="ref-edit-clear" ${markerDetailActionAttrs('clear-ref-edit-field', { field: 'min' })} title="Clear (open-ended)">\u00d7</button></span> \u2013 <span class="ref-edit-field"><input type="text" inputmode="decimal" value="${escapeAttr(curMax ?? '')}" placeholder="none" class="ref-edit-input" id="ref-edit-max"><button type="button" class="ref-edit-clear" ${markerDetailActionAttrs('clear-ref-edit-field', { field: 'max' })} title="Clear (open-ended)">\u00d7</button></span> <button type="button" class="ref-edit-save" ${markerDetailActionAttrs('save-ref-range', { id, type })}>Save</button>`;
   span.replaceWith(form);
   /** @type {HTMLElement | null} */ (form.querySelector('#ref-edit-min'))?.focus();
 

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -100,6 +100,8 @@ if (typeof document !== 'undefined') {
     deleteCustomMarker,
     saveManualEntry,
     saveAndAddAnotherManualEntry,
+    pickNewCatIcon,
+    saveCustomMarker,
   });
 }
 
@@ -443,7 +445,7 @@ export function showDetailModal(id, opts = {}) {
         <button type="button" class="gb-detail-pin-btn${quickMarkerPinned ? ' is-pinned' : ''}" aria-pressed="${quickMarkerPinned ? 'true' : 'false'}" title="${escapeAttr(quickMarkerPinTitle)}" ${markerDetailActionAttrs('quick-pin', { id })}>${escapeHTML(quickMarkerPinText)}</button>
         <span class="gb-detail-status gb-detail-status-${escapeAttr(latestStatus)}">${escapeHTML(statusText)}</span>
       </div>
-      <button class="modal-close" aria-label="Close" ${markerDetailActionAttrs('close-modal')}>&times;</button>
+      <button type="button" class="modal-close" aria-label="Close" ${markerDetailActionAttrs('close-modal')}>&times;</button>
     </div>
     <div class="marker-description" id="marker-desc"></div>
     <div class="gb-detail-summary">
@@ -897,12 +899,12 @@ export function openCreateMarkerModal() {
       <div class="me-field">
         <label>Category</label>
         <div class="cm-cat-row">
-          <select id="cm-category" onchange="document.getElementById('cm-new-cat-row').style.display=this.value==='__new__'?'flex':'none'">
+          <select id="cm-category" ${markerDetailActionAttrs('toggle-custom-marker-category')}>
             ${catOptions}
             <option value="__new__">+ New category...</option>
           </select>
           <div id="cm-new-cat-row" style="display:none;margin-top:6px;gap:8px;align-items:center">
-            <span id="cm-new-cat-icon" title="Pick icon" style="cursor:pointer;font-size:20px;min-width:28px;text-align:center" data-custom="" onclick="pickNewCatIcon(this)">\uD83D\uDD16</span>
+            <span id="cm-new-cat-icon" title="Pick icon" style="cursor:pointer;font-size:20px;min-width:28px;text-align:center" role="button" tabindex="0" data-custom="" ${markerDetailActionAttrs('pick-new-cat-icon')}>\uD83D\uDD16</span>
             <input type="text" id="cm-new-cat" placeholder="Category name" style="flex:1">
           </div>
         </div>
@@ -932,8 +934,8 @@ export function openCreateMarkerModal() {
         </div>
       </div>
       <div class="gb-form-actions">
-        <button class="import-btn import-btn-primary" onclick="saveCustomMarker()">Create</button>
-        <button class="import-btn import-btn-secondary" ${markerDetailActionAttrs('close-modal')}>Cancel</button>
+        <button type="button" class="import-btn import-btn-primary" ${markerDetailActionAttrs('save-custom-marker')}>Create</button>
+        <button type="button" class="import-btn import-btn-secondary" ${markerDetailActionAttrs('close-modal')}>Cancel</button>
       </div>
     </div>
     </div>`;

--- a/js/provider-local-ai-controls.js
+++ b/js/provider-local-ai-controls.js
@@ -15,6 +15,9 @@ import { detectHardware, assessModel, assessFitness, getBestModel, getUpgradeSug
 
 let returnToChatIfOnboarding = function() {};
 const LOCAL_AI_NOT_CONNECTED_TEXT = 'Not connected \u2014 check URL and ensure your server is running';
+const LOCAL_AI_ACTION_ATTR = 'data-local-ai-action';
+const LOCAL_AI_COMMAND_ATTR = 'data-local-ai-command';
+const localAiControlDelegateRoots = new WeakSet();
 
 export function configureLocalAiControls(options = {}) {
   if (typeof options.returnToChatIfOnboarding === 'function') {
@@ -86,6 +89,68 @@ function isLocalUrl(url) {
   } catch { return true; }
 }
 
+function closestLocalAiAction(target) {
+  if (!target || typeof target.closest !== 'function') return null;
+  return target.closest(`[${LOCAL_AI_ACTION_ATTR}]`);
+}
+
+function toggleHardwareOverride(actionEl) {
+  const body = actionEl.nextElementSibling;
+  if (!(body instanceof HTMLElement)) return;
+  const shouldOpen = body.style.display === 'none';
+  body.style.display = shouldOpen ? 'flex' : 'none';
+  actionEl.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+}
+
+function handleLocalAiAction(actionEl) {
+  const action = actionEl.getAttribute(LOCAL_AI_ACTION_ATTR) || '';
+  if (action === 'copy-pull') {
+    const command = actionEl.getAttribute(LOCAL_AI_COMMAND_ATTR) || '';
+    if (command) copyOllamaPullCmd(command);
+    return true;
+  }
+  if (action === 'toggle-override') {
+    toggleHardwareOverride(actionEl);
+    return true;
+  }
+  if (action === 'apply-hardware-override') {
+    const input = document.getElementById('hw-vram-override-input');
+    applyHardwareOverride(input instanceof HTMLInputElement ? input.value : '');
+    return true;
+  }
+  if (action === 'clear-hardware-override') {
+    clearHardwareOverride();
+    return true;
+  }
+  return false;
+}
+
+function handleLocalAiActionClick(event) {
+  const actionEl = closestLocalAiAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (!handleLocalAiAction(actionEl)) return;
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handleLocalAiActionKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  const actionEl = closestLocalAiAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (event.target?.closest?.('button, input, select, textarea')) return;
+  if (actionEl.getAttribute('role') !== 'button') return;
+  if (!handleLocalAiAction(actionEl)) return;
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function installLocalAiControlDelegates(root) {
+  if (!root || localAiControlDelegateRoots.has(root)) return;
+  localAiControlDelegateRoots.add(root);
+  root.addEventListener('click', handleLocalAiActionClick);
+  root.addEventListener('keydown', handleLocalAiActionKeydown);
+}
+
 /**
  * @param {any[]} modelDetails
  * @param {HTMLSelectElement | null} modelSelect
@@ -94,6 +159,7 @@ function isLocalUrl(url) {
 export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = false) {
   const advisorEl = document.getElementById('local-ai-advisor');
   if (!advisorEl) return;
+  installLocalAiControlDelegates(advisorEl);
   const serverUrl = getOllamaConfig().url;
   const isLocal = isLocalUrl(serverUrl);
   const hw = isLocal
@@ -156,7 +222,7 @@ export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = f
       <div class="model-advisor-suggest-title">Upgrade recommendation</div>
       ${isOllama ? `<div class="model-advisor-pull-row">
         <code class="model-advisor-pull-cmd">ollama pull ${escapeHTML(upgrade.model)}</code>
-        <button class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 8px" onclick="copyOllamaPullCmd('ollama pull ${escapeAttr(upgrade.model)}')">Copy</button>
+        <button type="button" class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 8px" ${LOCAL_AI_ACTION_ATTR}="copy-pull" ${LOCAL_AI_COMMAND_ATTR}="${escapeAttr(`ollama pull ${upgrade.model}`)}">Copy</button>
       </div>` : `<div class="model-advisor-pull-row">
         <code class="model-advisor-pull-cmd">${escapeHTML(upgrade.model)}</code>
       </div>`}
@@ -168,14 +234,14 @@ export async function renderModelAdvisor(modelDetails, modelSelect, isOllama = f
   const overrideLabel = isLocal ? 'Override VRAM' : 'Server VRAM';
   const overrideHtml = `
     <div class="model-advisor-override">
-      <div class="model-advisor-override-toggle" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'flex' : 'none'">
+      <div class="model-advisor-override-toggle" role="button" tabindex="0" aria-expanded="${overrideOpen === 'flex' ? 'true' : 'false'}" ${LOCAL_AI_ACTION_ATTR}="toggle-override">
         \u25B8 ${overrideLabel}${overrideVal ? ` (${overrideVal} GB)` : ''}
       </div>
       <div class="model-advisor-override-body" style="display:${overrideOpen}">
         <input type="number" id="hw-vram-override-input" placeholder="${hw.gpu.vram || 'GB'}" value="${overrideVal || ''}" min="1" max="256" step="1">
         <span style="font-size:12px;color:var(--text-muted)">GB</span>
-        <button class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 8px" onclick="applyHardwareOverride(document.getElementById('hw-vram-override-input').value)">Apply</button>
-        ${overrideVal ? '<button class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 8px" onclick="clearHardwareOverride()">Reset</button>' : ''}
+        <button type="button" class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 8px" ${LOCAL_AI_ACTION_ATTR}="apply-hardware-override">Apply</button>
+        ${overrideVal ? `<button type="button" class="import-btn import-btn-secondary" style="font-size:11px;padding:3px 8px" ${LOCAL_AI_ACTION_ATTR}="clear-hardware-override">Reset</button>` : ''}
       </div>
     </div>`;
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -70,7 +70,7 @@ export function queryRequired(root, selector) {
 }
 
 // Marker keys are interpolated into inline-onclick JS string literals
-// (e.g. `onclick="showDetailModal('${id}')"`), where escapeHTML is not
+// (for example, old inline click attribute strings), where escapeHTML is not
 // enough — a key containing `'` or `\` would close the JS string and
 // inject. Custom marker keys come from PDF AI extraction, so the only
 // way to be sure is an allowlist + proto-pollution guard. Returns the
@@ -364,10 +364,31 @@ export function isPIIReviewEnabled() { return localStorage.getItem('labcharts-pi
 export function setPIIReviewEnabled(on) { localStorage.setItem('labcharts-pii-review', on ? 'true' : 'false'); }
 // Analytics: opt-out, default ON. Setting `analytics-disabled=true` suppresses
 // the Umami snippet on next page load. Cookieless, no personal data, no IP.
+const ANALYTICS_CONSENT_ACTION_ATTR = 'data-analytics-consent-action';
+
 export function isAnalyticsEnabled() { return localStorage.getItem('labcharts-analytics-disabled') !== 'true'; }
 export function setAnalyticsEnabled(on) { localStorage.setItem('labcharts-analytics-disabled', on ? 'false' : 'true'); }
 function hasSeenAnalyticsConsent() { return localStorage.getItem('labcharts-analytics-consent-seen') === '1'; }
 function markAnalyticsConsentSeen() { localStorage.setItem('labcharts-analytics-consent-seen', '1'); }
+
+function handleAnalyticsConsentActionClick(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const actionEl = target.closest(`[${ANALYTICS_CONSENT_ACTION_ATTR}]`);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(ANALYTICS_CONSENT_ACTION_ATTR);
+  if (action === 'dismiss') {
+    event.preventDefault();
+    event.stopPropagation();
+    dismissAnalyticsConsent();
+    return;
+  }
+  if (action === 'disable') {
+    event.preventDefault();
+    event.stopPropagation();
+    dismissAnalyticsConsentAndDisable();
+  }
+}
 
 // One-time transparency banner shown to first-time users. Default state is
 // analytics-on (preserves the maintainer's product signal) but the user is
@@ -394,9 +415,10 @@ export function maybeShowAnalyticsConsent() {
       <span class="analytics-consent-copy analytics-consent-copy-short">Anonymous, cookieless stats are <strong>on</strong>. No health data.</span>
     </div>
     <div class="analytics-consent-actions">
-      <button type="button" class="analytics-consent-btn analytics-consent-btn-primary" onclick="dismissAnalyticsConsent()">Got it</button>
-      <button type="button" class="analytics-consent-btn" onclick="dismissAnalyticsConsentAndDisable()">Turn off</button>
+      <button type="button" class="analytics-consent-btn analytics-consent-btn-primary" ${ANALYTICS_CONSENT_ACTION_ATTR}="dismiss">Got it</button>
+      <button type="button" class="analytics-consent-btn" ${ANALYTICS_CONSENT_ACTION_ATTR}="disable">Turn off</button>
     </div>`;
+  banner.addEventListener('click', handleAnalyticsConsentActionClick);
   document.body.appendChild(banner);
   document.body.classList.add('analytics-consent-visible');
 }

--- a/js/wearables-manual-form-ui.js
+++ b/js/wearables-manual-form-ui.js
@@ -1,6 +1,9 @@
 // @ts-check
 
-import { escapeHTML } from './utils.js';
+import { escapeAttr, escapeHTML } from './utils.js';
+
+const WEARABLE_LOG_ACTION_ATTR = 'data-wearable-log-action';
+const wearableManualFormDelegateRoots = new WeakSet();
 
 // Chip row for optional context tags. Tags are informational; sensors cannot
 // infer whether a manual BP/RHR reading was resting, post-workout, etc.
@@ -13,13 +16,36 @@ export function _renderTagChips(metricId) {
   const tags = TAG_CHIPS[metricId];
   if (!tags) return '';
   return `<div class="wearable-log-tags" role="group" aria-label="Optional context">
-    ${tags.map(t => `<button type="button" class="wearable-log-chip" data-tag="${escapeHTML(t)}" onclick="toggleManualLogChip(this,event)">${escapeHTML(t)}</button>`).join('')}
+    ${tags.map(t => `<button type="button" class="wearable-log-chip" ${WEARABLE_LOG_ACTION_ATTR}="toggle-chip" data-tag="${escapeAttr(t)}">${escapeHTML(t)}</button>`).join('')}
   </div>`;
 }
 
 export function toggleManualLogChip(btn, event) {
   if (event) event.stopPropagation();
   btn.classList.toggle('active');
+}
+
+function closestWearableLogAction(target) {
+  if (!target || typeof target.closest !== 'function') return null;
+  return target.closest(`[${WEARABLE_LOG_ACTION_ATTR}]`);
+}
+
+function handleWearableLogActionClick(event) {
+  const actionEl = closestWearableLogAction(event.target);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  if (actionEl.getAttribute(WEARABLE_LOG_ACTION_ATTR) === 'toggle-chip') {
+    toggleManualLogChip(actionEl, event);
+  }
+}
+
+export function installWearablesManualFormDelegates(root = (typeof document !== 'undefined' ? document : null)) {
+  if (!root || wearableManualFormDelegateRoots.has(root)) return;
+  wearableManualFormDelegateRoots.add(root);
+  root.addEventListener('click', handleWearableLogActionClick);
+}
+
+if (typeof document !== 'undefined') {
+  installWearablesManualFormDelegates(document);
 }
 
 export function _collectActiveChips(card) {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,5 +1,5 @@
 {
-  "inlineEventAttributes": 15,
+  "inlineEventAttributes": 0,
   "windowReferences": 1847,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513

--- a/tests/playwright/browser-helper-modules-coverage.spec.js
+++ b/tests/playwright/browser-helper-modules-coverage.spec.js
@@ -127,8 +127,10 @@ test('browser helper coverage exercises url safety marker keys markdown brand as
       const banner = document.getElementById('analytics-consent-banner');
       const analyticsBannerRendersOnce = document.querySelectorAll('#analytics-consent-banner').length === 1
         && banner?.getAttribute('role') === 'region'
+        && !!banner?.querySelector('[data-analytics-consent-action="dismiss"]')
+        && !!banner?.querySelector('[data-analytics-consent-action="disable"]')
         && document.body.classList.contains('analytics-consent-visible');
-      utils.dismissAnalyticsConsent();
+      banner?.querySelector('[data-analytics-consent-action="dismiss"]')?.click();
       const analyticsDismissMarksSeenAndRemovesBanner =
         localStorage.getItem('labcharts-analytics-consent-seen') === '1'
         && !document.getElementById('analytics-consent-banner')
@@ -141,7 +143,7 @@ test('browser helper coverage exercises url safety marker keys markdown brand as
 
       for (const key of analyticsKeys) localStorage.removeItem(key);
       utils.maybeShowAnalyticsConsent();
-      utils.dismissAnalyticsConsentAndDisable();
+      document.querySelector('#analytics-consent-banner [data-analytics-consent-action="disable"]')?.click();
       outcomes.analyticsConsentHelpersCoverStorageBannerAndDisable =
         analyticsCanEnable
         && analyticsCanDisable

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -405,6 +405,10 @@ test('marker detail editing covers range overrides and marker note editor paths'
       outcomes.editRefRangeSwapsInlineInputs =
         document.getElementById('ref-edit-min')?.value === '35'
         && document.getElementById('ref-edit-max')?.value === '52';
+      outcomes.editRefRangeRendersDelegatedControls =
+        document.querySelectorAll('[data-marker-detail-action="clear-ref-edit-field"]').length === 2
+        && !!document.querySelector('[data-marker-detail-action="save-ref-range"]')
+        && !document.querySelector('.ref-edit-form')?.innerHTML.includes('onclick=');
       document.getElementById('ref-edit-min').value = '36';
       document.getElementById('ref-edit-max').value = '';
       await editing.saveRefRange(id, 'ref');

--- a/tests/playwright/settings-provider-browser-coverage.spec.js
+++ b/tests/playwright/settings-provider-browser-coverage.spec.js
@@ -171,16 +171,25 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
       await wait(0);
       const copyPullCommand = writes.includes('ollama pull qwen2.5:14b');
 
-      controls.applyHardwareOverride('16');
-      await wait(0);
+      const overrideToggle = document.querySelector('[data-local-ai-action="toggle-override"]');
+      overrideToggle?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      const hardwareOverrideKeyboardToggle = document.querySelector('.model-advisor-override-body')?.style.display === 'flex'
+        && overrideToggle?.getAttribute('aria-expanded') === 'true';
+      document.getElementById('hw-vram-override-input').value = '16';
+      document.querySelector('[data-local-ai-action="apply-hardware-override"]')?.click();
+      for (let i = 0; i < 20 && !document.getElementById('local-ai-advisor')?.textContent.includes('16 GB'); i += 1) {
+        await wait(10);
+      }
       const hardwareOverrideApplied = localStorage.getItem('labcharts-hw-vram-override') === '16'
         && document.getElementById('local-ai-advisor')?.textContent.includes('16 GB');
       controls.applyHardwareOverride('0');
       await wait(0);
       const invalidHardwareOverride = [...document.querySelectorAll('.notification-toast')]
         .some(el => el.textContent.includes('valid VRAM'));
-      controls.clearHardwareOverride();
-      await wait(0);
+      document.querySelector('[data-local-ai-action="clear-hardware-override"]')?.click();
+      for (let i = 0; i < 20 && localStorage.getItem('labcharts-hw-vram-override'); i += 1) {
+        await wait(10);
+      }
       const hardwareOverrideCleared = !localStorage.getItem('labcharts-hw-vram-override');
 
       document.getElementById('pii-local-url-input').value = 'http://localhost:11434';
@@ -208,6 +217,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
         localConnectSuccess,
         refreshModelAdvisorRerendersCachedDetails,
         copyPullCommand,
+        hardwareOverrideKeyboardToggle,
         hardwareOverrideApplied,
         invalidHardwareOverride,
         hardwareOverrideCleared,

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -56,6 +56,10 @@ assert('changelog.js uses shared modal overlay lifecycle helpers',
   changelogSrc.includes("from './modal-lifecycle.js'")
     && changelogSrc.includes('openModalOverlay(')
     && changelogSrc.includes('closeModalOverlay('));
+assert('changelog.js delegates modal close button without inline handlers',
+  changelogSrc.includes('data-changelog-action') &&
+    changelogSrc.includes('installChangelogDelegates(modal)') &&
+    !/\bon(?:click|change|input|submit|keydown|keyup)=/.test(changelogSrc));
 assert('changelog.js has getMajorMinor helper', changelogSrc.includes('function getMajorMinor'));
 assert('maybeShowChangelog compares major.minor only', changelogSrc.includes('getMajorMinor(seen) !== getMajorMinor('));
 // forceShow patch-bump escape hatch — when a maintainer flags an entry as

--- a/tests/test-hardware.js
+++ b/tests/test-hardware.js
@@ -184,6 +184,10 @@ console.log('=== Hardware & Model Advisor Tests ===\n');
   assert('Provider local AI controls calls renderModelAdvisor', localAiControlsSrc.includes('renderModelAdvisor'));
   assert('Provider panels exports copyOllamaPullCmd', ppSrc.includes('copyOllamaPullCmd'));
   assert('Provider local AI controls validates base URL before fetch', localAiControlsSrc.includes('normalizeLocalAiBaseUrl'));
+  assert('Provider local AI advisor delegates rendered controls without inline handlers',
+    localAiControlsSrc.includes('data-local-ai-action') &&
+      localAiControlsSrc.includes('installLocalAiControlDelegates') &&
+      !/\bon(?:click|change|input|submit|keydown|keyup)=/.test(localAiControlsSrc));
 
   // ═══════════════════════════════════════
   // 9. Local AI URL validation

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const modalSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
+const editingSrc = fs.readFileSync(path.join(root, 'js/marker-detail-editing.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/marker-detail-actions.js'), 'utf8');
 const dashboardSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
@@ -29,13 +30,14 @@ console.log('=== Marker Detail Delegated Actions ===');
 
 const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/g;
 const inlineHandlers = modalSrc.match(inlineHandlerRe) || [];
+const editingInlineHandlers = editingSrc.match(inlineHandlerRe) || [];
 
-assert('marker-detail-modal only keeps the custom marker creation form inline handlers',
-  inlineHandlers.length === 3 &&
-    modalSrc.includes('onchange="document.getElementById') &&
-    modalSrc.includes('onclick="pickNewCatIcon(this)"') &&
-    modalSrc.includes('onclick="saveCustomMarker()"'),
+assert('marker-detail-modal renders no inline event attributes',
+  inlineHandlers.length === 0,
   `found ${inlineHandlers.length}`);
+assert('marker-detail-editing renders no inline event attributes',
+  editingInlineHandlers.length === 0,
+  `found ${editingInlineHandlers.length}`);
 assert('marker-detail-modal imports and installs the delegated action helper',
   modalSrc.includes("from './marker-detail-actions.js'") &&
     modalSrc.includes('installMarkerDetailActionDelegates({') &&
@@ -49,7 +51,8 @@ assert('marker-detail-actions defines one shared action attribute helper',
 assert('marker-detail-actions installs idempotent click and keyboard delegates',
   actionSrc.includes('const markerDetailActionDelegateRoots = new WeakSet();') &&
     actionSrc.includes("root.addEventListener('click', event => handleMarkerDetailClick(event, actions))") &&
-    actionSrc.includes("root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions))"));
+    actionSrc.includes("root.addEventListener('keydown', event => handleMarkerDetailKeydown(event, actions))") &&
+    actionSrc.includes("root.addEventListener('change', event => handleMarkerDetailChange(event, actions))"));
 assert('marker-detail delegated actions are scoped to the installed root',
   actionSrc.includes("event.currentTarget.contains(actionEl)"));
 assert('marker-detail open manual entry action preserves optional prefill date',
@@ -68,6 +71,8 @@ assert('service worker precaches marker-detail-actions.js',
 
 [
   'close-modal',
+  'clear-ref-edit-field',
+  'save-ref-range',
   'quick-pin',
   'edit-ref-range',
   'revert-ref-range',
@@ -88,6 +93,9 @@ assert('service worker precaches marker-detail-actions.js',
   'delete-custom-marker',
   'save-manual-entry',
   'save-and-add-manual-entry',
+  'toggle-custom-marker-category',
+  'pick-new-cat-icon',
+  'save-custom-marker',
 ].forEach(action => {
   assert(`marker detail action ${action} is handled`,
     actionSrc.includes(`action === '${action}'`));
@@ -96,6 +104,9 @@ assert('service worker precaches marker-detail-actions.js',
 [
   "markerDetailActionAttrs('revert-ref-range', { id, type })",
   "markerDetailActionAttrs('edit-ref-range', { id, type })",
+  "markerDetailActionAttrs('clear-ref-edit-field', { field: 'min' })",
+  "markerDetailActionAttrs('clear-ref-edit-field', { field: 'max' })",
+  "markerDetailActionAttrs('save-ref-range', { id, type })",
   "markerDetailActionAttrs('revert-marker-name', { id })",
   "markerDetailActionAttrs('rename-marker', { id })",
   "markerDetailActionAttrs('quick-pin', { id })",
@@ -114,9 +125,12 @@ assert('service worker precaches marker-detail-actions.js',
   "markerDetailActionAttrs('delete-custom-marker', { id })",
   "markerDetailActionAttrs('save-manual-entry', { id })",
   "markerDetailActionAttrs('save-and-add-manual-entry', { id })",
+  "markerDetailActionAttrs('toggle-custom-marker-category')",
+  "markerDetailActionAttrs('pick-new-cat-icon')",
+  "markerDetailActionAttrs('save-custom-marker')",
 ].forEach(renderedAction => {
-  assert(`marker-detail-modal renders ${renderedAction}`,
-    modalSrc.includes(renderedAction));
+  assert(`marker detail renders ${renderedAction}`,
+    modalSrc.includes(renderedAction) || editingSrc.includes(renderedAction));
 });
 
 [

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -85,10 +85,15 @@ const wearablesSrc = await fetch('js/wearables.js').then(r => r.text());
 const wearablesDetailSrc = await fetch('js/wearables-detail-modal.js').then(r => r.text());
 const manualFormUiSrc = await fetch('js/wearables-manual-form-ui.js').then(r => r.text());
 const wearablesSettingsSrc = await fetch('js/wearables-settings-panel.js').then(r => r.text());
+const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
 assert('wearables.js renders empty manual cards',
   wearablesSrc.includes('renderEmptyManualCard') && wearablesSrc.includes('wearable-card-empty'));
 assert('wearables.js MANUAL_EMPTY_METRICS covers weight/bp/rhr',
   /MANUAL_EMPTY_METRICS\s*=\s*\[[^\]]*weight[^\]]*bp_systolic[^\]]*rhr/.test(wearablesSrc));
+assert('wearables manual form UI delegates tag chip actions',
+  manualFormUiSrc.includes('data-wearable-log-action') &&
+    manualFormUiSrc.includes('installWearablesManualFormDelegates') &&
+    !inlineHandlerRe.test(manualFormUiSrc));
 
 const clSrc = await fetch('js/client-list.js').then(r => r.text());
 assert('Edit Client modal no longer renders the cl-bio-weight container',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.520';
+self.APP_VERSION = '1.8.521';


### PR DESCRIPTION
## Summary
- Replace the remaining JS-rendered inline event attributes with delegated `data-*` actions for marker detail/custom marker controls, wearable manual chips, local-AI advisor controls, analytics consent, and changelog close.
- Extend marker-detail action delegation to cover ref-edit save/clear controls and custom marker select/icon/create actions.
- Lower the JS inline event guardrail baseline from 15 to 0 and bump `version.js` to 1.8.521.

## Validation
- `node scripts/quality-guardrails.mjs`
- `npm run typecheck`
- `node tests/test-marker-detail-delegated-actions.js`
- `node tests/test-wearables-manual.js`
- `node tests/test-hardware.js`
- `node tests/test-changelog.js`
- `node tests/test-quality-guardrails.js`
- `npx playwright test tests/playwright/marker-detail-browser-coverage.spec.js tests/playwright/modal-session-coverage-batch.spec.js tests/playwright/wearables-manual-form-ui-browser-coverage.spec.js tests/playwright/browser-helper-modules-coverage.spec.js tests/playwright/settings-provider-browser-coverage.spec.js tests/playwright/changelog.spec.js` (17 passed)
- `npm test` (11 files, 178 tests passed)
- `./run-tests.sh` (Vitest 178 passed; dev-server origin guard 18 passed; Playwright 325 passed; Theme Responsive E2E 472 passed, 0 failed)

Note: the focused Playwright run required local-server sandbox escalation for `127.0.0.1:8000`; the full `./run-tests.sh` completed successfully afterwards.