### PR TITLE
[codex] Remove inline stylesheet preload handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,7 @@
     })();
   </script>
   <style>#main-content{min-height:calc(100vh - 64px + 180px)}</style>
-  <link rel="preload" href="vendor/fonts/fonts.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="vendor/fonts/fonts.css"></noscript>
+  <link rel="stylesheet" href="vendor/fonts/fonts.css">
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="css/app-shell.css">
   <link rel="stylesheet" href="css/import.css">
@@ -88,8 +87,7 @@
   <link rel="stylesheet" href="css/chat-mobile.css">
   <link rel="stylesheet" href="css/redesign-shell.css">
   <link rel="stylesheet" href="css/chat-redesign.css">
-  <link rel="preload" href="themes-extra.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="themes-extra.css"></noscript>
+  <link rel="stylesheet" href="themes-extra.css">
 </head>
 <body>
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.521';
+self.APP_VERSION = '1.8.522';


### PR DESCRIPTION
## Summary
- Replace the two remaining `index.html` stylesheet preload `onload` handlers with ordinary stylesheet links.
- Remove the now-redundant no-script stylesheet fallbacks for those links.
- Bump `version.js` to 1.8.522.

## Validation
- `rg -n -P "<[^>]*\\son[a-z]+\\s*=" index.html js` (no matches)
- `node scripts/quality-guardrails.mjs`
- `npm run typecheck`
- `node tests/test-changelog.js`
- `npx playwright test tests/playwright/shell-actions-browser-coverage.spec.js tests/playwright/theme-responsive-e2e.spec.js` (2 passed; Theme Responsive E2E 472 passed, 0 failed)