### PR TITLE
[codex] Add user-controlled service worker update prompt

### DIFF
--- a/css/app-shell.css
+++ b/css/app-shell.css
@@ -141,6 +141,26 @@
 .analytics-consent-btn-primary { background: var(--accent); border-color: var(--accent); color: var(--on-accent); }
 .analytics-consent-btn-primary:hover { filter: brightness(1.08); background: var(--accent); color: var(--on-accent); }
 
+/* Version update prompt - user-controlled service-worker activation */
+.version-update-banner {
+  position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%);
+  z-index: 1001; max-width: min(560px, calc(100vw - 24px));
+  display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+  background: var(--bg-secondary, #1a1d24); border: 1px solid var(--border, #2d3138);
+  border-radius: 10px; padding: 10px 14px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.32);
+  animation: analytics-consent-in 0.25s ease-out;
+}
+.version-update-body { display: flex; gap: 8px; align-items: center; font-size: 12px; color: var(--text-secondary); line-height: 1.45; flex: 1 1 240px; min-width: 0; }
+.version-update-body strong { color: var(--text-primary); }
+.version-update-copy-short { display: none; }
+.version-update-actions { display: flex; gap: 6px; flex: 0 0 auto; }
+.version-update-btn { font-size: 12px; padding: 4px 12px; border-radius: 6px; border: 1px solid var(--border); background: transparent; color: var(--text-secondary); cursor: pointer; transition: background 0.15s, border-color 0.15s, color 0.15s; }
+.version-update-btn:hover { background: var(--bg-elevated, rgba(255,255,255,0.04)); color: var(--text-primary); border-color: var(--text-muted); }
+.version-update-btn-primary { background: var(--accent); border-color: var(--accent); color: var(--on-accent); }
+.version-update-btn-primary:hover { filter: brightness(1.08); background: var(--accent); color: var(--on-accent); }
+body.analytics-consent-visible .version-update-banner { bottom: 78px; }
+
 .layout { display: flex; min-height: calc(100vh - 57px); }
 .sidebar {
   width: 260px;
@@ -462,6 +482,33 @@
     min-height: 32px;
     padding: 4px 8px;
   }
+  .version-update-banner {
+    left: 12px;
+    right: 12px;
+    transform: none;
+    max-width: none;
+    bottom: 12px;
+    gap: 8px;
+    padding: 8px 10px;
+    flex-wrap: nowrap;
+  }
+  .version-update-body {
+    flex: 1 1 auto;
+    font-size: 11px;
+    line-height: 1.35;
+  }
+  .version-update-copy-long { display: none; }
+  .version-update-copy-short { display: inline; }
+  .version-update-actions {
+    width: auto;
+    display: flex;
+    flex: 0 0 auto;
+  }
+  .version-update-btn {
+    min-height: 32px;
+    padding: 4px 8px;
+  }
+  body.analytics-consent-visible .version-update-banner { bottom: 74px; }
   @keyframes analytics-consent-in { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
 }
 @media (max-width: 480px) {
@@ -478,18 +525,32 @@
 }
 @media (max-width: 799px) {
   body.mobile-dashboard-active .analytics-consent-banner,
-  body.mobile-tabs-active .analytics-consent-banner {
+  body.mobile-tabs-active .analytics-consent-banner,
+  body.mobile-dashboard-active .version-update-banner,
+  body.mobile-tabs-active .version-update-banner {
     bottom: calc(96px + env(safe-area-inset-bottom));
     z-index: 205;
+  }
+  body.analytics-consent-visible.mobile-dashboard-active .version-update-banner,
+  body.analytics-consent-visible.mobile-tabs-active .version-update-banner {
+    bottom: calc(160px + env(safe-area-inset-bottom));
   }
   body.empty-dashboard-active.mobile-tabs-active #chat-fab {
     display: none;
   }
-  body.analytics-consent-visible.mobile-tabs-active #chat-fab {
+  body.analytics-consent-visible.mobile-tabs-active #chat-fab,
+  body.version-update-visible.mobile-tabs-active #chat-fab {
     bottom: calc(186px + env(safe-area-inset-bottom));
   }
-  body.analytics-consent-visible.mobile-tabs-active .main {
+  body.analytics-consent-visible.version-update-visible.mobile-tabs-active #chat-fab {
+    bottom: calc(250px + env(safe-area-inset-bottom));
+  }
+  body.analytics-consent-visible.mobile-tabs-active .main,
+  body.version-update-visible.mobile-tabs-active .main {
     padding-bottom: calc(220px + env(safe-area-inset-bottom));
+  }
+  body.analytics-consent-visible.version-update-visible.mobile-tabs-active .main {
+    padding-bottom: calc(284px + env(safe-area-inset-bottom));
   }
 }
 @media (max-width: 480px), (pointer: coarse) {

--- a/index.html
+++ b/index.html
@@ -276,6 +276,7 @@
   <div class="notification-container" id="notification-container" aria-live="polite" role="status"></div>
 
   <script src="version.js" defer></script>
+  <script type="module" src="js/service-worker-update.js"></script>
   <script type="module" src="js/main.js"></script>
   <script>
     // Cookieless Umami analytics — opt-out via Settings → Privacy. Skips on
@@ -296,46 +297,6 @@
       s.dataset.websiteId = '6272072c-97a9-47b0-99e7-c52e7a4ca481';
       document.head.appendChild(s);
     }
-  </script>
-  <script>
-  // Skip SW registration on dev hosts by default — even though the SW's fetch
-  // handler can handle same-origin localhost, WebKit's HTTP cache layer still
-  // serves stale module bytes after a normal F5 reload (no "hard reload" bypass
-  // exists in Tauri's webkit2gtk webview). Net effect: developer edits a JS
-  // file, dev-server returns the new bytes, but the Tauri window keeps running
-  // the old version forever until manual cache purge. Skipping registration
-  // here means normal dev mode is never SW-controlled. Use ?dev-sw=1 for an
-  // explicit local offline smoke test.
-  // Production hosts (anything not localhost / 127.0.0.1 / .local — Tauri
-  // bundled apps use https://tauri.localhost) get the normal registration.
-  var _isDevHost = location.hostname === 'localhost'
-                || location.hostname === '127.0.0.1'
-                || location.hostname.endsWith('.local');
-  var _allowDevSW = /(?:^|[?&])dev-sw=1(?:&|$)/.test(location.search);
-  if ('serviceWorker' in navigator && (!_isDevHost || _allowDevSW)) {
-    navigator.serviceWorker.register('/service-worker.js').then(function(reg) {
-      // When a new SW takes over, reload to get fresh assets
-      var refreshing = false;
-      navigator.serviceWorker.addEventListener('controllerchange', function() {
-        if (!refreshing) { refreshing = true; location.reload(); }
-      });
-    }).catch(function() {});
-  } else if ('serviceWorker' in navigator && _isDevHost) {
-    // Tauri dev windows that previously registered the SW (before this skip
-    // landed) have a controlling SW that intercepts our requests. Unregister
-    // it so future F5s actually fetch fresh JS from the dev server.
-    navigator.serviceWorker.getRegistrations().then(function(regs) {
-      var changed = false;
-      regs.forEach(function(r) { r.unregister(); changed = true; });
-      if (changed) {
-        // Also nuke whatever the SW already cached. CacheStorage isn't
-        // governed by the SW lifecycle so it survives unregister.
-        if (window.caches && caches.keys) {
-          caches.keys().then(function(keys) { keys.forEach(function(k) { caches.delete(k); }); });
-        }
-      }
-    }).catch(function() {});
-  }
   </script>
 </body>
 </html>

--- a/js/service-worker-update.js
+++ b/js/service-worker-update.js
@@ -1,0 +1,216 @@
+// @ts-check
+// service-worker-update.js - explicit PWA update prompt and SW registration
+
+const UPDATE_BANNER_ID = 'version-update-banner';
+const UPDATE_ACTION_ATTR = 'data-version-update-action';
+const DEV_SW_QUERY_RE = /(?:^|[?&])dev-sw=1(?:&|$)/;
+
+let pendingRegistration = null;
+let dismissedWaitingWorker = null;
+let updateRequested = false;
+let reloadAvailable = false;
+let reloadPage = () => {
+  if (typeof window !== 'undefined') window.location.reload();
+};
+
+export function isDevServiceWorkerHost(hostname) {
+  if (!hostname) return false;
+  return hostname === 'localhost'
+    || hostname === '127.0.0.1'
+    || hostname.endsWith('.local');
+}
+
+export function shouldRegisterServiceWorker(
+  locationLike = typeof window !== 'undefined' ? window.location : null
+) {
+  if (!locationLike) return false;
+  return !isDevServiceWorkerHost(locationLike.hostname)
+    || DEV_SW_QUERY_RE.test(locationLike.search || '');
+}
+
+function getServiceWorker(registration) {
+  if (registration?.waiting) return registration.waiting;
+  const installingWorker = registration?.installing;
+  return installingWorker?.state === 'installed' ? installingWorker : null;
+}
+
+function canPromptForUpdate(registration, serviceWorkerContainer) {
+  return !!getServiceWorker(registration) && !!serviceWorkerContainer?.controller;
+}
+
+function removeBanner() {
+  document.getElementById(UPDATE_BANNER_ID)?.remove();
+  document.body?.classList.remove('version-update-visible');
+}
+
+export function hideVersionUpdateBanner() {
+  reloadAvailable = false;
+  removeBanner();
+}
+
+export function showVersionUpdateBanner(registration) {
+  const waitingWorker = getServiceWorker(registration);
+  if (!reloadAvailable && (!waitingWorker || waitingWorker === dismissedWaitingWorker)) return false;
+
+  pendingRegistration = registration || pendingRegistration;
+
+  let banner = document.getElementById(UPDATE_BANNER_ID);
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = UPDATE_BANNER_ID;
+    banner.className = 'version-update-banner';
+    banner.setAttribute('role', 'region');
+    banner.setAttribute('aria-label', 'App update available');
+    banner.setAttribute('aria-live', 'polite');
+    banner.innerHTML = `
+      <div class="version-update-body">
+        <span class="version-update-copy version-update-copy-long"><strong>New version available.</strong> Update when you are ready.</span>
+        <span class="version-update-copy version-update-copy-short"><strong>Update available.</strong></span>
+      </div>
+      <div class="version-update-actions">
+        <button type="button" class="version-update-btn version-update-btn-primary" ${UPDATE_ACTION_ATTR}="apply">Update</button>
+        <button type="button" class="version-update-btn" ${UPDATE_ACTION_ATTR}="dismiss">Later</button>
+      </div>
+    `;
+    banner.addEventListener('click', handleVersionUpdateActionClick);
+    document.body.appendChild(banner);
+  }
+
+  renderVersionUpdateBanner(banner);
+  document.body.classList.add('version-update-visible');
+  return true;
+}
+
+function renderVersionUpdateBanner(banner) {
+  const longCopy = banner.querySelector('.version-update-copy-long');
+  const shortCopy = banner.querySelector('.version-update-copy-short');
+  const primaryButton = banner.querySelector(`[${UPDATE_ACTION_ATTR}="apply"]`);
+  if (reloadAvailable) {
+    if (longCopy) longCopy.innerHTML = '<strong>New version installed.</strong> Reload when you are ready.';
+    if (shortCopy) shortCopy.innerHTML = '<strong>Reload available.</strong>';
+    if (primaryButton) primaryButton.textContent = 'Reload';
+    banner.setAttribute('aria-label', 'App update ready to reload');
+    return;
+  }
+
+  if (longCopy) longCopy.innerHTML = '<strong>New version available.</strong> Update when you are ready.';
+  if (shortCopy) shortCopy.innerHTML = '<strong>Update available.</strong>';
+  if (primaryButton) primaryButton.textContent = 'Update';
+  banner.setAttribute('aria-label', 'App update available');
+}
+
+function handleVersionUpdateActionClick(event) {
+  const target = event.target instanceof Element
+    ? event.target.closest(`[${UPDATE_ACTION_ATTR}]`)
+    : null;
+  if (!target) return;
+  event.preventDefault();
+
+  const action = target.getAttribute(UPDATE_ACTION_ATTR);
+  if (action === 'apply') {
+    applyPendingServiceWorkerUpdate();
+    return;
+  }
+
+  if (action === 'dismiss') {
+    if (!reloadAvailable) dismissedWaitingWorker = getServiceWorker(pendingRegistration);
+    hideVersionUpdateBanner();
+  }
+}
+
+export function applyPendingServiceWorkerUpdate(registration = pendingRegistration) {
+  if (reloadAvailable) {
+    hideVersionUpdateBanner();
+    reloadPage();
+    return true;
+  }
+
+  const waitingWorker = getServiceWorker(registration);
+  if (!waitingWorker) return false;
+
+  updateRequested = true;
+  waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+  hideVersionUpdateBanner();
+  return true;
+}
+
+export function watchServiceWorkerRegistration(
+  registration,
+  serviceWorkerContainer = typeof navigator !== 'undefined' ? navigator.serviceWorker : null
+) {
+  if (!registration || !serviceWorkerContainer) return;
+
+  if (canPromptForUpdate(registration, serviceWorkerContainer)) {
+    showVersionUpdateBanner(registration);
+  }
+
+  registration.addEventListener('updatefound', () => {
+    const installingWorker = registration.installing;
+    if (!installingWorker) return;
+
+    installingWorker.addEventListener('statechange', () => {
+      if (installingWorker.state === 'installed'
+          && canPromptForUpdate(registration, serviceWorkerContainer)) {
+        dismissedWaitingWorker = null;
+        reloadAvailable = false;
+        showVersionUpdateBanner(registration);
+      }
+    });
+  });
+}
+
+async function unregisterDevServiceWorkers(serviceWorkerContainer, cacheStorage) {
+  const registrations = await serviceWorkerContainer.getRegistrations();
+  let changed = false;
+  await Promise.all(registrations.map(async (registration) => {
+    changed = true;
+    await registration.unregister();
+  }));
+
+  if (changed && cacheStorage?.keys) {
+    const keys = await cacheStorage.keys();
+    await Promise.all(keys.map((key) => cacheStorage.delete(key)));
+  }
+}
+
+export async function registerServiceWorkerUpdates({
+  win = typeof window !== 'undefined' ? window : null,
+  serviceWorkerContainer = typeof navigator !== 'undefined' ? navigator.serviceWorker : null,
+  cacheStorage = typeof window !== 'undefined' ? window.caches : null,
+} = {}) {
+  if (!win || !serviceWorkerContainer) return null;
+
+  if (!shouldRegisterServiceWorker(win.location)) {
+    if (isDevServiceWorkerHost(win.location.hostname)) {
+      unregisterDevServiceWorkers(serviceWorkerContainer, cacheStorage).catch(() => {});
+    }
+    return null;
+  }
+
+  try {
+    const registration = await serviceWorkerContainer.register('/service-worker.js');
+    reloadPage = () => win.location.reload();
+    let refreshing = false;
+    serviceWorkerContainer.addEventListener('controllerchange', () => {
+      if (refreshing) return;
+      if (!updateRequested) {
+        reloadAvailable = true;
+        showVersionUpdateBanner(registration);
+        return;
+      }
+      refreshing = true;
+      win.location.reload();
+    });
+    watchServiceWorkerRegistration(registration, serviceWorkerContainer);
+    return registration;
+  } catch {
+    return null;
+  }
+}
+
+// Skip SW registration on dev hosts by default. WebKit's HTTP cache layer can
+// otherwise keep serving stale module bytes in Tauri/webkit2gtk dev windows.
+// Use ?dev-sw=1 for explicit local offline smoke testing.
+if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
+  registerServiceWorkerUpdates();
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -64,6 +64,7 @@ const APP_SHELL = [
   '/css/redesign-shell.css',
   '/css/chat-redesign.css',
   '/themes-extra.css',
+  '/js/service-worker-update.js',
   '/js/main.js',
   '/js/shell-actions.js',
   '/js/app-feature-modules.js',
@@ -437,7 +438,21 @@ self.addEventListener('install', (event) => {
       caches.open(name).then((cache) => cache.addAll(APP_SHELL))
     )
   );
-  self.skipWaiting();
+});
+
+function isSameOriginMessage(event) {
+  try {
+    const origin = event.origin || (event.source?.url ? new URL(event.source.url).origin : '');
+    return origin === self.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'SKIP_WAITING' && isSameOriginMessage(event)) {
+    self.skipWaiting();
+  }
 });
 
 // Activate: delete old caches (any key that isn't this build's)

--- a/tests/service-worker-runtime.test.js
+++ b/tests/service-worker-runtime.test.js
@@ -119,7 +119,8 @@ describe('service worker runtime cache behavior', () => {
     expect(cache.addAll).toHaveBeenCalled();
     expect(cache.addAll.mock.calls[0][0]).toContain('/app');
     expect(cache.addAll.mock.calls[0][0]).toContain('/js/main.js');
-    expect(self.skipWaiting).toHaveBeenCalled();
+    expect(cache.addAll.mock.calls[0][0]).toContain('/js/service-worker-update.js');
+    expect(self.skipWaiting).not.toHaveBeenCalled();
 
     const activate = makeWaitEvent();
     listeners.get('activate')(activate);
@@ -180,5 +181,19 @@ describe('service worker runtime cache behavior', () => {
 
     expect(caches.open).toHaveBeenCalledWith('labcharts-v9.9.9');
     expect(globalThis.fetch).not.toHaveBeenCalledWith('/api/commit', { cache: 'no-store' });
+  });
+
+  it('only skips waiting after an explicit update message', async () => {
+    const { listeners, self } = await loadServiceWorker();
+
+    expect(listeners.has('message')).toBe(true);
+    listeners.get('message')({ data: { type: 'NOOP' }, origin: 'https://preview.getbased.health' });
+    expect(self.skipWaiting).not.toHaveBeenCalled();
+
+    listeners.get('message')({ data: { type: 'SKIP_WAITING' }, origin: 'https://evil.example' });
+    expect(self.skipWaiting).not.toHaveBeenCalled();
+
+    listeners.get('message')({ data: { type: 'SKIP_WAITING' }, origin: 'https://preview.getbased.health' });
+    expect(self.skipWaiting).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/service-worker-update.test.js
+++ b/tests/service-worker-update.test.js
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let serviceWorkerUpdate;
+
+beforeEach(async () => {
+  vi.resetModules();
+  serviceWorkerUpdate = await import('../js/service-worker-update.js');
+});
+
+afterEach(() => {
+  serviceWorkerUpdate?.hideVersionUpdateBanner();
+  serviceWorkerUpdate = null;
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('service worker update prompt', () => {
+  it('keeps development service workers opt-in only', () => {
+    const { shouldRegisterServiceWorker } = serviceWorkerUpdate;
+
+    expect(shouldRegisterServiceWorker({ hostname: 'localhost', search: '' })).toBe(false);
+    expect(shouldRegisterServiceWorker({ hostname: '127.0.0.1', search: '' })).toBe(false);
+    expect(shouldRegisterServiceWorker({ hostname: 'preview.local', search: '' })).toBe(false);
+    expect(shouldRegisterServiceWorker({ hostname: 'localhost', search: '?dev-sw=1' })).toBe(true);
+    expect(shouldRegisterServiceWorker({ hostname: 'getbased.health', search: '' })).toBe(true);
+    expect(shouldRegisterServiceWorker({ hostname: 'tauri.localhost', search: '' })).toBe(true);
+  });
+
+  it('turns a secondary-tab controllerchange into a reload prompt', async () => {
+    const { registerServiceWorkerUpdates } = serviceWorkerUpdate;
+    let onControllerChange = null;
+    const reload = vi.fn();
+    const registration = {
+      waiting: null,
+      addEventListener: vi.fn(),
+    };
+    const serviceWorkerContainer = {
+      controller: {},
+      register: vi.fn(async () => registration),
+      addEventListener: vi.fn((type, listener) => {
+        if (type === 'controllerchange') onControllerChange = listener;
+      }),
+    };
+
+    await registerServiceWorkerUpdates({
+      win: { location: { hostname: 'getbased.health', search: '', reload } },
+      serviceWorkerContainer,
+      cacheStorage: null,
+    });
+
+    onControllerChange();
+    const banner = document.getElementById('version-update-banner');
+    expect(reload).not.toHaveBeenCalled();
+    expect(banner.textContent).toContain('Reload');
+
+    banner.querySelector('[data-version-update-action="apply"]').click();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a banner and activates only from the update action', () => {
+    const { showVersionUpdateBanner } = serviceWorkerUpdate;
+    const waiting = { postMessage: vi.fn() };
+    const registration = { waiting };
+
+    expect(showVersionUpdateBanner(registration)).toBe(true);
+    const banner = document.getElementById('version-update-banner');
+    expect(banner).not.toBeNull();
+    expect(document.body.classList.contains('version-update-visible')).toBe(true);
+    expect(waiting.postMessage).not.toHaveBeenCalled();
+
+    banner.querySelector('[data-version-update-action="apply"]').click();
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    expect(document.getElementById('version-update-banner')).toBeNull();
+    expect(document.body.classList.contains('version-update-visible')).toBe(false);
+  });
+
+  it('dismisses the current waiting worker without activating it', () => {
+    const { showVersionUpdateBanner } = serviceWorkerUpdate;
+    const waiting = { postMessage: vi.fn() };
+    const registration = { waiting };
+
+    showVersionUpdateBanner(registration);
+    document.querySelector('[data-version-update-action="dismiss"]').click();
+
+    expect(waiting.postMessage).not.toHaveBeenCalled();
+    expect(document.getElementById('version-update-banner')).toBeNull();
+    expect(showVersionUpdateBanner(registration)).toBe(false);
+  });
+
+  it('returns false when no waiting worker is available', () => {
+    const { applyPendingServiceWorkerUpdate } = serviceWorkerUpdate;
+
+    expect(applyPendingServiceWorkerUpdate({ waiting: null })).toBe(false);
+  });
+});

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -50,10 +50,14 @@ console.log('2. Service Worker Registration');
 
 // Original test fetched '/app' (dev-server alias for index.html).
 const indexSrc = read('index.html');
-assert('SW registration uses absolute path', indexSrc.includes("'/service-worker.js'") || indexSrc.includes('"/service-worker.js"'));
-assert('SW registration has catch handler', indexSrc.includes('.catch('));
+const serviceWorkerUpdateSrc = read('js/service-worker-update.js');
+assert('index loads service worker update module', indexSrc.includes('src="js/service-worker-update.js"'));
+assert('SW registration uses absolute path', serviceWorkerUpdateSrc.includes("'/service-worker.js'") || serviceWorkerUpdateSrc.includes('"/service-worker.js"'));
+assert('SW registration failures are handled',
+  serviceWorkerUpdateSrc.includes("serviceWorkerContainer.register('/service-worker.js')")
+    && serviceWorkerUpdateSrc.includes('} catch {'));
 assert('SW has explicit dev-host offline test opt-in',
-  indexSrc.includes('dev-sw=1') && indexSrc.includes("(!_isDevHost || _allowDevSW)"));
+  serviceWorkerUpdateSrc.includes('dev-sw=1') && serviceWorkerUpdateSrc.includes('shouldRegisterServiceWorker'));
 const swAuditSrc = read('service-worker.js');
 assert('SW uses importScripts for version', swAuditSrc.includes("importScripts('/version.js')"));
 assert('SW CACHE_NAME uses semver', swAuditSrc.includes('`labcharts-v${self.APP_VERSION}`'));
@@ -75,6 +79,7 @@ assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.include
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));
 assert('SW APP_SHELL includes lens action delegates module', swAuditSrc.includes("'/js/lens-actions.js'"));
 assert('SW APP_SHELL includes DNA action delegates module', swAuditSrc.includes("'/js/dna-actions.js'"));
+assert('SW APP_SHELL includes service worker update module', swAuditSrc.includes("'/js/service-worker-update.js'"));
 assert('index loads app shell CSS bundle', indexSrc.includes('href="css/app-shell.css"'));
 assert('SW APP_SHELL includes app shell CSS bundle', swAuditSrc.includes("'/css/app-shell.css'"));
 assert('app shell CSS loads after core CSS and before feature CSS',

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -89,6 +89,7 @@ assert('SW imports version.js', swSrc.includes("importScripts('/version.js')"));
 assert('SW CACHE_NAME uses template literal', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
 assert('SW APP_SHELL includes version.js', swSrc.includes("'/version.js'"));
 assert('index.html loads version.js', indexSrc.includes('src="version.js"'));
+assert('index.html loads service worker update module', indexSrc.includes('src="js/service-worker-update.js"'));
 assert('modal-lifecycle.js exports overlay show/hide helpers',
   modalLifecycleSrc.includes('export function openModalOverlay')
     && modalLifecycleSrc.includes('export function closeModalOverlay'));
@@ -186,6 +187,7 @@ assert('No hasCardContent(lc)', !labCtxSrc.includes('hasCardContent(lc)'));
 console.log('9. Service Worker');
 
 assert('APP_SHELL includes /js/changelog.js', swSrc.includes('/js/changelog.js'));
+assert('APP_SHELL includes /js/service-worker-update.js', swSrc.includes('/js/service-worker-update.js'));
 
 // ═══════════════════════════════════════
 // 10. Changelog data integrity

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -79,6 +79,7 @@ const pwaAppShellAssets = [
   '/vendor/evolu/sqlite3-opfs-async-proxy.js',
   '/vendor/evolu/sqlite3-worker1-bundler-friendly.mjs',
   '/vendor/evolu/sqlite3.wasm',
+  '/js/service-worker-update.js',
   '/js/app-feature-modules.js',
   '/js/app-foundation-modules.js',
   '/js/app-health-data-modules.js',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.522';
+self.APP_VERSION = '1.8.523';


### PR DESCRIPTION
## Summary
- Move service worker registration/update handling into `js/service-worker-update.js`.
- Stop automatic `skipWaiting()` on install; activate a waiting worker only after the user clicks the update banner.
- Add desktop/mobile banner styling aligned with the existing app shell and keep it above the mobile tab bar.
- Precache the new module and bump `APP_VERSION` to `1.8.523`.

## Validation
- `npm test -- tests/service-worker-update.test.js tests/service-worker-runtime.test.js`
- `node tests/test-audit.js`
- `node tests/test-changelog.js`
- `node tests/test-correctness-phase2.js`
- `./run-tests.sh`
- `node scripts/quality-guardrails.mjs`
- focused Playwright smoke against `http://127.0.0.1:8000/app` for desktop and mobile banner bounds/screenshots