### PR TITLE
[codex] Harden light device session boundary

### DIFF
--- a/js/light-device-session-modal.js
+++ b/js/light-device-session-modal.js
@@ -7,6 +7,31 @@ import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.
 import { BODY_REGIONS } from './sun.js';
 
 /**
+ * @param {string} name
+ * @param {any} [fallback]
+ * @returns {any}
+ */
+function _windowDep(name, fallback = null) {
+  if (typeof window === 'undefined') return fallback;
+  const value = window[name];
+  return typeof value === 'function' ? value : fallback;
+}
+
+/**
+ * @param {Record<string, any>} [deps]
+ * @returns {Record<string, any>}
+ */
+function _resolveSessionDialogDeps(deps = {}) {
+  return {
+    ...deps,
+    validateModeCoupling: deps.validateModeCoupling || _windowDep('validateModeCoupling', () => ({ ok: true })),
+    renderBodySilhouette: deps.renderBodySilhouette || _windowDep('renderBodySilhouette'),
+    bindBodySilhouette: deps.bindBodySilhouette || _windowDep('bindBodySilhouette'),
+    navigate: deps.navigate || _windowDep('navigate'),
+  };
+}
+
+/**
  * @param {ParentNode} root
  * @param {string} selector
  * @returns {HTMLInputElement|null}
@@ -67,6 +92,7 @@ function _showEmptyRegionError(updateAreaHint, selectedRegions, hintEl) {
 }
 
 export async function openDeviceSessionDialog(deviceId, deps = {}) {
+  const resolvedDeps = _resolveSessionDialogDeps(deps);
   const {
     hydrateDevicesFromPresets,
     getDevices,
@@ -74,7 +100,11 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     getActiveDeviceSession,
     startDeviceSession,
     ensureActiveDeviceTicker,
-  } = deps;
+    validateModeCoupling,
+    renderBodySilhouette,
+    bindBodySilhouette,
+    navigate,
+  } = resolvedDeps;
 
   // Lazy hydrate covers page-opened-mid-init / cold preset cache cases so
   // the dialog renders with the latest mode/coupling schema.
@@ -93,9 +123,8 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
   const defaultRegions = _defaultRegionsForLastSession(last);
 
   // Mode picker renders only for devices with multiple valid modes.
-  const validateMode = window.validateModeCoupling || (() => ({ ok: true }));
   const validModes = Array.isArray(device.modes)
-    ? device.modes.filter(m => validateMode(device, m.id).ok)
+    ? device.modes.filter(m => validateModeCoupling(device, m.id).ok)
     : [];
   const showModePicker = validModes.length > 1;
   let defaultMode = null;
@@ -147,7 +176,7 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
       })()}
       <div class="ctx-label" style="display:block">
         <span>Body area treated</span>
-        <div class="sun-silhouette-wrap" id="dev-session-silhouette-slot">${(typeof window !== 'undefined' && window.renderBodySilhouette) ? window.renderBodySilhouette(new Set(defaultRegions)) : ''}</div>
+        <div class="sun-silhouette-wrap" id="dev-session-silhouette-slot">${renderBodySilhouette ? renderBodySilhouette(new Set(defaultRegions)) : ''}</div>
         <div class="sun-silhouette-hint-row" style="display:flex;align-items:center;justify-content:space-between;gap:8px">
           <div class="sun-silhouette-hint" id="dev-session-area-hint">Tap regions the panel reaches.</div>
           <button type="button" class="ctx-btn-option" id="dev-session-clear" style="padding:2px 10px;font-size:11px">Clear</button>
@@ -226,8 +255,8 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     const more = set.size > 4 ? ` +${set.size - 4} more` : '';
     hint.textContent = `${set.size} region${set.size === 1 ? '' : 's'} (~${Math.round(frac * 100)}% of skin) — ${labels}${more}`;
   };
-  if (silhouetteSlot && typeof window !== 'undefined' && window.bindBodySilhouette) {
-    window.bindBodySilhouette(silhouetteSlot, selectedRegions, (set) => {
+  if (silhouetteSlot && bindBodySilhouette) {
+    bindBodySilhouette(silhouetteSlot, selectedRegions, (set) => {
       updateAreaHint(set);
     });
   }
@@ -235,8 +264,8 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
 
   overlay.querySelector('#dev-session-clear')?.addEventListener('click', () => {
     selectedRegions.clear();
-    if (silhouetteSlot && typeof window !== 'undefined' && window.renderBodySilhouette) {
-      silhouetteSlot.innerHTML = window.renderBodySilhouette(selectedRegions);
+    if (silhouetteSlot && renderBodySilhouette) {
+      silhouetteSlot.innerHTML = renderBodySilhouette(selectedRegions);
     }
     updateAreaHint(selectedRegions);
   });
@@ -277,7 +306,7 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     await logDeviceSession({ deviceId, durationMin, distanceCm, bodyArea, bodyAreas, eyesProtected, mode });
     closeDialog();
     showNotification(`${durationMin} min ${escapeHTML(device.brand)} session saved.`);
-    if (window.navigate) window.navigate('light');
+    navigate?.('light');
   });
 
   overlay.querySelector('#dev-session-start').addEventListener('click', async () => {
@@ -298,7 +327,7 @@ export async function openDeviceSessionDialog(deviceId, deps = {}) {
     closeDialog();
     showNotification(`Live ${escapeHTML(device.brand)} session started — tap Stop & save when finished.`);
     ensureActiveDeviceTicker();
-    if (window.navigate) window.navigate('light');
+    navigate?.('light');
   });
 }
 

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -22,7 +22,8 @@ import { state } from './state.js';
 import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showConfirmDialog } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { CHANNEL_DISPLAY } from './sun.js';
-import { BODY_REGIONS } from './sun-body-silhouette.js';
+import { BODY_REGIONS, bindBodySilhouette, renderBodySilhouette } from './sun-body-silhouette.js';
+import { validateModeCoupling } from './sun-spectrum.js';
 import {
   addCustomDevice,
   addDeviceFromPresetRecord,
@@ -39,11 +40,7 @@ import {
   updateDeviceSession,
 } from './light-devices-store.js';
 import { openDeviceSessionDialog as openDeviceSessionDialogModal } from './light-device-session-modal.js';
-import {
-  configureLightDeviceSetup,
-  openAddDeviceDialog,
-  openCustomDeviceDialog,
-} from './light-device-setup-modal.js';
+import { configureLightDeviceSetup, openAddDeviceDialog, openCustomDeviceDialog } from './light-device-setup-modal.js';
 
 const LIGHT_DEVICES_ACTION_ATTR = 'data-light-devices-action';
 const LIGHT_DEVICE_ID_ATTR = 'data-light-device-id';
@@ -170,8 +167,7 @@ export async function editDeviceSessionMode(id) {
     showNotification('This device has no selectable modes.', 'info');
     return;
   }
-  const validateMode = window.validateModeCoupling || (() => ({ ok: true }));
-  const validModes = device.modes.filter(m => validateMode(device, m.id).ok);
+  const validModes = device.modes.filter(m => validateModeCoupling(device, m.id).ok);
   if (validModes.length < 2) {
     showNotification('Only one mode is available for this device.', 'info');
     return;
@@ -312,8 +308,7 @@ export function openDeviceSessionDetail(id) {
       || device.modes.find(m => m.default)
       || device.modes[0];
     modeLabel = resolved ? (resolved.label || resolved.id) : null;
-    const validateMode = window.validateModeCoupling || (() => ({ ok: true }));
-    canEditMode = device.modes.filter(m => validateMode(device, m.id).ok).length > 1;
+    canEditMode = device.modes.filter(m => validateModeCoupling(device, m.id).ok).length > 1;
   }
 
   // Body-fraction for the per-session vit-D cap (Audit P1 #8). Computed
@@ -692,6 +687,10 @@ export async function openDeviceSessionDialog(deviceId) {
     getActiveDeviceSession,
     startDeviceSession,
     ensureActiveDeviceTicker,
+    validateModeCoupling,
+    renderBodySilhouette,
+    bindBodySilhouette,
+    navigate: route => window.navigate?.(route),
   });
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1847,
+  "windowReferences": 1374,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1374,
+  "windowReferences": 1377,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/scripts/quality-guardrails.mjs
+++ b/scripts/quality-guardrails.mjs
@@ -11,7 +11,7 @@ const BASELINE_PATH = path.join(ROOT, 'scripts', 'quality-baseline.json');
 const SYNTAX_DIRS = ['js', 'api', 'scripts'];
 const APP_JS_DIR = path.join(ROOT, 'js');
 const INLINE_EVENT_RE = /\bon(?:click|keydown|change|input|submit)=["']/g;
-const WINDOW_REF_RE = /\bwindow\./g;
+const WINDOW_REF_RE = /\bwindow(?:\.|\s*\[)/g;
 // Keep this value in sync with the baseline key name largeJsFilesOver800Lines.
 const LARGE_FILE_LINE_LIMIT = 800;
 
@@ -117,7 +117,7 @@ function main() {
   const metrics = collectAppMetrics();
 
   compareBudget('inline event attributes in js/', metrics.inlineEventAttributes, baseline.inlineEventAttributes);
-  compareBudget('window.* references in js/', metrics.windowReferences, baseline.windowReferences);
+  compareBudget('window global references in js/', metrics.windowReferences, baseline.windowReferences);
   compareBudget('large JS files (>=800 lines)', metrics.largeJsFilesOver800Lines, baseline.largeJsFilesOver800Lines);
 
   if (metrics.largestFile.lines <= baseline.maxJsFileLines) {

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -775,7 +775,6 @@ test('light devices cover session detail edit log active card and rendered list 
     const originalImportedLocalValue = localStorage.getItem(importedStorageKey);
     const originalImportedBlobValue = await blobStorage.getBlob(importedStorageKey);
     const savedWindow = {
-      validateModeCoupling: window.validateModeCoupling,
       channelTier: window.channelTier,
       tierLabel: window.tierLabel,
       formatChannelUnit: window.formatChannelUnit,
@@ -804,10 +803,11 @@ test('light devices cover session detail edit log active card and rendered list 
         recommendedDistanceCm: 20,
         channels: ['vitamin_d', 'circadian', 'pbm_red', 'pbm_nir'],
         modes: [
-          { id: 'combo', label: 'Combo', default: true },
-          { id: 'red', label: 'Red only' },
-          { id: 'blocked', label: 'Blocked' },
+          { id: 'combo', label: 'Combo', groups: ['red', 'nir'], default: true },
+          { id: 'red', label: 'Red only', groups: ['red'] },
+          { id: 'blocked', label: 'Blocked', groups: ['blocked'] },
         ],
+        coupling: [{ if: 'blocked', requires: ['missing'], reason: 'blocked test mode' }],
         catalogSlug: 'testlight-panel-900',
         addedAt: Date.now() - 9 * 86400000,
         lastSession: {
@@ -837,7 +837,6 @@ test('light devices cover session detail edit log active card and rendered list 
         lightDevices: [device],
         deviceSessions: [session],
       };
-      window.validateModeCoupling = (_device, mode) => ({ ok: mode !== 'blocked' });
       window.channelTier = value => value > 30 ? 3 : value > 10 ? 2 : value > 0 ? 1 : 0;
       window.tierLabel = tier => ['none', 'low', 'moderate', 'high'][tier] || 'none';
       window.formatChannelUnit = (key, value) => `${Math.round(value)} ${key}`;

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -334,10 +334,6 @@ test('device session dialog covers validation unit mode start and save paths', a
     const calls = [];
     const saved = {
       unitSystem: state.unitSystem,
-      navigate: window.navigate,
-      validateModeCoupling: window.validateModeCoupling,
-      renderBodySilhouette: window.renderBodySilhouette,
-      bindBodySilhouette: window.bindBodySilhouette,
     };
     let activeSession = null;
     const devices = [{
@@ -374,13 +370,12 @@ test('device session dialog covers validation unit mode start and save paths', a
 
     try {
       state.unitSystem = 'US';
-      window.navigate = route => calls.push(['navigate', route]);
-      window.validateModeCoupling = (_device, mode) => ({ ok: mode !== 'blocked' });
-      window.renderBodySilhouette = selected => `
+      const validateModeCoupling = (_device, mode) => ({ ok: mode !== 'blocked' });
+      const renderBodySilhouette = selected => `
         <button type="button" class="body-region-test" data-region="legs-front" aria-pressed="${selected.has('legs-front')}">Legs front</button>
         <button type="button" class="body-region-test" data-region="arms-front" aria-pressed="${selected.has('arms-front')}">Arms front</button>
       `;
-      window.bindBodySilhouette = (slot, selected, callback) => {
+      const bindBodySilhouette = (slot, selected, callback) => {
         slot.querySelectorAll('[data-region]').forEach(btn => {
           btn.addEventListener('click', () => {
             const region = btn.dataset.region;
@@ -406,6 +401,10 @@ test('device session dialog covers validation unit mode start and save paths', a
           activeSession = { id: 'active-device' };
         },
         ensureActiveDeviceTicker: () => calls.push(['ticker']),
+        validateModeCoupling,
+        renderBodySilhouette,
+        bindBodySilhouette,
+        navigate: route => calls.push(['navigate', route]),
       };
 
       await deviceSessionModal.openDeviceSessionDialog('panel-coverage', deps);
@@ -417,6 +416,7 @@ test('device session dialog covers validation unit mode start and save paths', a
         && overlay.querySelector('#dev-session-mode')?.value === 'red'
         && modeButtons.length === 3
         && !overlay.textContent.includes('Blocked')
+        && !!overlay.querySelector('.body-region-test')
         && overlay.querySelector('#dev-session-eyes')?.checked === false
         && overlay.querySelector('#dev-session-area-hint')?.textContent.includes('Legs');
 
@@ -477,14 +477,6 @@ test('device session dialog covers validation unit mode start and save paths', a
       outcomes.hydratesDevicesOnEachOpen = calls.filter(call => call[0] === 'hydrate-devices').length === 3;
     } finally {
       state.unitSystem = saved.unitSystem;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
-      if (saved.validateModeCoupling) window.validateModeCoupling = saved.validateModeCoupling;
-      else delete window.validateModeCoupling;
-      if (saved.renderBodySilhouette) window.renderBodySilhouette = saved.renderBodySilhouette;
-      else delete window.renderBodySilhouette;
-      if (saved.bindBodySilhouette) window.bindBodySilhouette = saved.bindBodySilhouette;
-      else delete window.bindBodySilhouette;
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }
 

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -33,8 +33,10 @@ assert('quality guardrail syntax-checks JS/MJS files',
   guardrailSrc.includes("execFileSync(process.execPath, ['--check', file]"));
 assert('quality guardrail tracks inline event attribute budget',
   guardrailSrc.includes('INLINE_EVENT_RE') && Object.hasOwn(baseline, 'inlineEventAttributes'));
-assert('quality guardrail tracks window.* coupling budget',
-  guardrailSrc.includes('WINDOW_REF_RE') && Object.hasOwn(baseline, 'windowReferences'));
+assert('quality guardrail tracks window global coupling budget',
+  guardrailSrc.includes('WINDOW_REF_RE') &&
+    guardrailSrc.includes('window(?:\\.|\\s*\\[)') &&
+    Object.hasOwn(baseline, 'windowReferences'));
 assert('quality guardrail tracks large-module budget',
   guardrailSrc.includes('LARGE_FILE_LINE_LIMIT') &&
     Object.hasOwn(baseline, 'largeJsFilesOver800Lines') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.527';
+self.APP_VERSION = '1.8.528';


### PR DESCRIPTION
## Summary

- Move light device session dialog UI dependencies into an explicit dependency seam for mode validation, silhouette rendering/binding, and post-save navigation.
- Import the real mode validator and silhouette helpers in `light-devices.js`, keeping the public `window.openDeviceSessionDialog` facade intact while reducing hidden app-global contracts.
- Update browser HVTs to exercise injected dialog dependencies and real coupling metadata instead of patched mode-validation globals.
- Expand the `window` coupling guardrail to count bracketed `window[...]` access, then ratchet the measured app JS budget to `1377`.
- Bump `version.js` for app cache invalidation.

## Validation

- `npm run quality`
- `npm run typecheck`
- `npm test -- -t "test-a11y-phase3"`
- `npm test -- -t "test-quality-guardrails"`
- `node tests/test-quality-guardrails.js`
- `npm run test:playwright -- tests/playwright/modal-session-coverage-batch.spec.js tests/playwright/light-sun-coverage-batch.spec.js`
- `./run-tests.sh`