### PR TITLE
[codex] Harden sun session action boundary

### DIFF
--- a/js/sun-session-actions.js
+++ b/js/sun-session-actions.js
@@ -50,24 +50,24 @@ function handleSunSessionAction(actionEl, actions) {
     if (actionEl.dataset.sunSessionCloseModal === 'true') closeContainingOverlay(actionEl);
     void actions.deleteSunSession?.(id);
   } else if (action === 'quick-log-sun') {
-    window.quickLogSunSession?.();
+    void actions.quickLogSunSession?.();
   } else if (action === 'pause-session') {
-    window.pauseSunSession?.(id);
+    void actions.pauseSunSession?.(id);
   } else if (action === 'resume-session') {
-    window.resumeSunSession?.(id);
+    void actions.resumeSunSession?.(id);
   } else if (action === 'flip-sides') {
-    window.flipSidesMidSession?.(id);
+    void actions.flipSidesMidSession?.(id);
   } else if (action === 'change-coverage') {
-    window.changeCoverageMidSession?.(id);
+    void actions.changeCoverageMidSession?.(id);
   } else if (action === 'apply-sunscreen') {
-    window.applySunscreenMidSession?.(id);
+    void actions.applySunscreenMidSession?.(id);
   } else if (action === 'override-ozone') {
-    window.setOzoneOverrideMidSession?.();
+    void actions.setOzoneOverrideMidSession?.();
   } else if (action === 'forgot-stop') {
-    window._forgotStopPrompt?.(id);
+    void actions.forgotStopPrompt?.(id);
   } else if (action === 'open-channel') {
     closeContainingOverlay(actionEl);
-    window._openChannelOnLightPage?.(channel);
+    actions.openChannelOnLightPage?.(channel);
   } else if (action === 'close-modal') {
     closeContainingOverlay(actionEl);
   } else if (action === 'edit-duration') {

--- a/js/sun-session-ui.js
+++ b/js/sun-session-ui.js
@@ -31,6 +31,15 @@ import { installSunSessionActionDelegates, sunSessionActionAttrs } from './sun-s
  * @property {(tier: any) => string} tierLabel
  * @property {(...args: any[]) => string} formatChannelUnit
  * @property {number} tooShortForChannelVerdictMin
+ * @property {() => Promise<any> | any} quickLogSunSession
+ * @property {(id: any) => Promise<any> | any} pauseSunSession
+ * @property {(id: any) => Promise<any> | any} resumeSunSession
+ * @property {(id: any) => Promise<any> | any} flipSidesMidSession
+ * @property {(id: any) => Promise<any> | any} changeCoverageMidSession
+ * @property {(id: any) => Promise<any> | any} applySunscreenMidSession
+ * @property {() => Promise<any> | any} setOzoneOverrideMidSession
+ * @property {(id: any) => Promise<any> | any} forgotStopPrompt
+ * @property {(channel: string) => void} openChannelOnLightPage
  */
 
 /** @type {SunSessionUIDeps} */
@@ -54,14 +63,34 @@ const uiDeps = {
   tierLabel: () => 'none',
   formatChannelUnit: () => '',
   tooShortForChannelVerdictMin: 2,
+  quickLogSunSession: () => {},
+  pauseSunSession: () => {},
+  resumeSunSession: () => {},
+  flipSidesMidSession: () => {},
+  changeCoverageMidSession: () => {},
+  applySunscreenMidSession: () => {},
+  setOzoneOverrideMidSession: () => {},
+  forgotStopPrompt: () => {},
+  openChannelOnLightPage: () => {},
+};
+
+const sunSessionDelegateActions = {
+  openSunSessionDetail,
+  deleteSunSession,
+  editSunSessionDuration,
+  quickLogSunSession: () => uiDeps.quickLogSunSession(),
+  pauseSunSession: id => uiDeps.pauseSunSession(id),
+  resumeSunSession: id => uiDeps.resumeSunSession(id),
+  flipSidesMidSession: id => uiDeps.flipSidesMidSession(id),
+  changeCoverageMidSession: id => uiDeps.changeCoverageMidSession(id),
+  applySunscreenMidSession: id => uiDeps.applySunscreenMidSession(id),
+  setOzoneOverrideMidSession: () => uiDeps.setOzoneOverrideMidSession(),
+  forgotStopPrompt: id => uiDeps.forgotStopPrompt(id),
+  openChannelOnLightPage: channel => uiDeps.openChannelOnLightPage(channel),
 };
 
 if (typeof document !== 'undefined') {
-  installSunSessionActionDelegates({
-    openSunSessionDetail,
-    deleteSunSession,
-    editSunSessionDuration,
-  });
+  installSunSessionActionDelegates(sunSessionDelegateActions);
 }
 
 /** @param {Partial<SunSessionUIDeps>} [deps] */

--- a/js/sun.js
+++ b/js/sun.js
@@ -1070,6 +1070,17 @@ configureSunSessionUI({
   tierLabel,
   formatChannelUnit,
   tooShortForChannelVerdictMin: TOO_SHORT_FOR_CHANNEL_VERDICT_MIN,
+  quickLogSunSession,
+  pauseSunSession,
+  resumeSunSession,
+  flipSidesMidSession,
+  changeCoverageMidSession,
+  applySunscreenMidSession,
+  setOzoneOverrideMidSession,
+  forgotStopPrompt: _forgotStopPrompt,
+  openChannelOnLightPage: channel => {
+    if (typeof window !== 'undefined') window._openChannelOnLightPage?.(channel);
+  },
 });
 
 // Reset all sun.js module-singleton state. Called on profile switch so

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1377,
+  "windowReferences": 1369,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/tests/playwright/sun-session-actions-browser-coverage.spec.js
+++ b/tests/playwright/sun-session-actions-browser-coverage.spec.js
@@ -88,20 +88,19 @@ test('sun session action delegates route clicks keyboard and modal actions in br
 
     document.addEventListener('click', () => push('document-click'));
     document.addEventListener('keydown', () => push('document-keydown'));
-    window.quickLogSunSession = () => push('quickLogSunSession');
-    window.pauseSunSession = id => push('pauseSunSession', id);
-    window.resumeSunSession = id => push('resumeSunSession', id);
-    window.flipSidesMidSession = id => push('flipSidesMidSession', id);
-    window.changeCoverageMidSession = id => push('changeCoverageMidSession', id);
-    window.applySunscreenMidSession = id => push('applySunscreenMidSession', id);
-    window.setOzoneOverrideMidSession = () => push('setOzoneOverrideMidSession');
-    window._forgotStopPrompt = id => push('_forgotStopPrompt', id);
-    window._openChannelOnLightPage = channel => push('_openChannelOnLightPage', channel);
-
     const delegateActions = {
       openSunSessionDetail: id => push('openSunSessionDetail', id),
       deleteSunSession: id => push('deleteSunSession', id),
       editSunSessionDuration: id => push('editSunSessionDuration', id),
+      quickLogSunSession: () => push('quickLogSunSession'),
+      pauseSunSession: id => push('pauseSunSession', id),
+      resumeSunSession: id => push('resumeSunSession', id),
+      flipSidesMidSession: id => push('flipSidesMidSession', id),
+      changeCoverageMidSession: id => push('changeCoverageMidSession', id),
+      applySunscreenMidSession: id => push('applySunscreenMidSession', id),
+      setOzoneOverrideMidSession: () => push('setOzoneOverrideMidSession'),
+      forgotStopPrompt: id => push('_forgotStopPrompt', id),
+      openChannelOnLightPage: channel => push('_openChannelOnLightPage', channel),
     };
     actionsModule.installSunSessionActionDelegates(delegateActions, root);
     actionsModule.installSunSessionActionDelegates(delegateActions, root);
@@ -128,7 +127,7 @@ test('sun session action delegates route clicks keyboard and modal actions in br
     click('sunscreen');
     click('ozone');
     click('forgot-stop');
-    outcomes.clickRoutesWindowBackedActions =
+    outcomes.clickRoutesInjectedActions =
       called('quickLogSunSession')
       && called('pauseSunSession', call => call[1] === 'sun-1')
       && called('resumeSunSession', call => call[1] === 'sun-1')

--- a/tests/test-sun-session-ui-delegated-actions.js
+++ b/tests/test-sun-session-ui-delegated-actions.js
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const uiSrc = fs.readFileSync(path.join(root, 'js/sun-session-ui.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/sun-session-actions.js'), 'utf8');
+const sunSrc = fs.readFileSync(path.join(root, 'js/sun.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -37,7 +38,8 @@ assert('sun-session-actions defines one shared action attribute helper',
     actionSrc.includes("value !== false"));
 assert('sun-session-ui imports and installs idempotent action delegates',
   uiSrc.includes("from './sun-session-actions.js'") &&
-    uiSrc.includes('installSunSessionActionDelegates({') &&
+    uiSrc.includes('const sunSessionDelegateActions = {') &&
+    uiSrc.includes('installSunSessionActionDelegates(sunSessionDelegateActions)') &&
     actionSrc.includes('const sunSessionActionDelegateRoots = new WeakSet();') &&
     actionSrc.includes("root.addEventListener('click', event => handleSunSessionClick(event, actions))") &&
     actionSrc.includes("root.addEventListener('keydown', event => handleSunSessionKeydown(event, actions))"));
@@ -56,10 +58,31 @@ assert('sun-session-actions closes overlays through the shared lifecycle removal
   actionSrc.includes("import { removeModalOverlay } from './modal-lifecycle.js';") &&
     actionSrc.includes('removeModalOverlay(overlay)') &&
     !actionSrc.includes("closest('.modal-overlay')?.remove()"));
+assert('sun-session-actions routes active controls through injected actions',
+  !actionSrc.includes('window.') &&
+    actionSrc.includes('actions.quickLogSunSession') &&
+    actionSrc.includes('actions.pauseSunSession') &&
+    actionSrc.includes('actions.resumeSunSession') &&
+    actionSrc.includes('actions.flipSidesMidSession') &&
+    actionSrc.includes('actions.changeCoverageMidSession') &&
+    actionSrc.includes('actions.applySunscreenMidSession') &&
+    actionSrc.includes('actions.setOzoneOverrideMidSession') &&
+    actionSrc.includes('actions.forgotStopPrompt') &&
+    actionSrc.includes('actions.openChannelOnLightPage'));
 assert('sun-session-ui direct module actions no longer route through window globals',
   !uiSrc.includes('window.openSunSessionDetail') &&
     !uiSrc.includes('window.deleteSunSession') &&
     !uiSrc.includes('window.editSunSessionDuration'));
+assert('sun.js configures active sun-session delegated actions',
+  sunSrc.includes('quickLogSunSession,') &&
+    sunSrc.includes('pauseSunSession,') &&
+    sunSrc.includes('resumeSunSession,') &&
+    sunSrc.includes('flipSidesMidSession,') &&
+    sunSrc.includes('changeCoverageMidSession,') &&
+    sunSrc.includes('applySunscreenMidSession,') &&
+    sunSrc.includes('setOzoneOverrideMidSession,') &&
+    sunSrc.includes('forgotStopPrompt: _forgotStopPrompt') &&
+    sunSrc.includes('openChannelOnLightPage: channel =>'));
 
 [
   'ignore',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.528';
+self.APP_VERSION = '1.8.529';


### PR DESCRIPTION
## Summary

- Route Sun session delegated active controls through injected action callbacks instead of direct `window.*` calls in `sun-session-actions.js`.
- Add stable UI delegate wrappers in `sun-session-ui.js` and wire the real Sun session operations from `sun.js`, keeping Light channel navigation as a late-bound callback to avoid a Sun-to-Light import cycle.
- Update browser and source-guard tests to verify injected action routing and prevent reintroducing `window.*` calls in the action module.
- Ratchet the `window` coupling guardrail from `1377` to `1369` and bump `version.js` for cache invalidation.

## Validation

- `npm run quality`
- `npm run typecheck`
- `npm test -- -t "test-sun-session-ui-delegated-actions"`
- `npm run test:playwright -- tests/playwright/sun-session-actions-browser-coverage.spec.js`
- `./run-tests.sh`