### PR TITLE
[codex] Wire Light/Sun AI analyzers through store deps

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -8,6 +8,7 @@ import './sun-ai-analysis.js';
 import './sun-context.js';
 import './light-devices.js';
 import './light-device-ai-analysis.js';
+import './light-sun-ai-hooks.js';
 import './light-tools.js';
 import './light-tools-ai-analysis.js';
 import './light-env.js';

--- a/js/light-devices-store.js
+++ b/js/light-devices-store.js
@@ -14,6 +14,21 @@ import {
   resolveDeviceMode,
 } from './light-device-session-engine.js';
 
+/**
+ * @typedef {object} LightDevicesStoreDeps
+ * @property {(session: any) => void} maybeAnalyzeDeviceSessionAfterFinish
+ */
+
+/** @type {LightDevicesStoreDeps} */
+const storeDeps = {
+  maybeAnalyzeDeviceSessionAfterFinish: () => {},
+};
+
+/** @param {Partial<LightDevicesStoreDeps>} [deps] */
+export function configureLightDevicesStore(deps = {}) {
+  Object.assign(storeDeps, deps);
+}
+
 function randomSuffix(chars = 4) {
   if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
     const bytes = new Uint8Array(Math.ceil(chars * 0.75) + 1);
@@ -28,9 +43,7 @@ function makeId(prefix, now = Date.now()) {
 }
 
 function runDeviceSessionAnalysis(session) {
-  if (typeof window !== 'undefined' && window.maybeAnalyzeDeviceSessionAfterFinish) {
-    try { window.maybeAnalyzeDeviceSessionAfterFinish(session); } catch (_) {}
-  }
+  try { storeDeps.maybeAnalyzeDeviceSessionAfterFinish(session); } catch (_) {}
 }
 
 export function getDevices() {

--- a/js/light-sun-ai-hooks.js
+++ b/js/light-sun-ai-hooks.js
@@ -1,0 +1,10 @@
+// @ts-check
+// light-sun-ai-hooks.js - wire session-store completion hooks to AI analyzers.
+
+import { configureLightDevicesStore } from './light-devices-store.js';
+import { configureSunSessionsStore } from './sun-sessions-store.js';
+import { maybeAnalyzeDeviceSessionAfterFinish } from './light-device-ai-analysis.js';
+import { maybeAnalyzeSessionAfterFinish } from './sun-ai-analysis.js';
+
+configureLightDevicesStore({ maybeAnalyzeDeviceSessionAfterFinish });
+configureSunSessionsStore({ maybeAnalyzeSessionAfterFinish });

--- a/js/sun-sessions-store.js
+++ b/js/sun-sessions-store.js
@@ -22,6 +22,7 @@ import {
  * @property {(id: any, state: any) => void} setLiveState
  * @property {(id: any) => void} clearLiveState
  * @property {(ms: number) => string} formatElapsed
+ * @property {(session: any) => void} maybeAnalyzeSessionAfterFinish
  */
 
 /** @type {SunSessionsStoreDeps} */
@@ -30,11 +31,16 @@ const storeDeps = {
   setLiveState: () => {},
   clearLiveState: () => {},
   formatElapsed: (ms) => `${Math.max(0, Math.floor((ms || 0) / 60000))}m`,
+  maybeAnalyzeSessionAfterFinish: () => {},
 };
 
 /** @param {Partial<SunSessionsStoreDeps>} [deps] */
 export function configureSunSessionsStore(deps = {}) {
   Object.assign(storeDeps, deps);
+}
+
+function runSessionAnalysis(session) {
+  try { storeDeps.maybeAnalyzeSessionAfterFinish(session); } catch (_) {}
 }
 
 export function getSessions() {
@@ -141,9 +147,7 @@ export async function stopSession(id) {
     });
   }
   await saveImportedData();
-  if (typeof window !== 'undefined' && window.maybeAnalyzeSessionAfterFinish) {
-    try { window.maybeAnalyzeSessionAfterFinish(sess); } catch (_) {}
-  }
+  runSessionAnalysis(sess);
   return sess;
 }
 
@@ -165,9 +169,7 @@ export async function logCompletedSession(payload) {
   if (!session.durationMin) session.durationMin = Math.max(0, (session.endedAt - session.startedAt) / 60000);
   getSessions().push(session);
   await saveImportedData();
-  if (typeof window !== 'undefined' && window.maybeAnalyzeSessionAfterFinish) {
-    try { window.maybeAnalyzeSessionAfterFinish(session); } catch (_) {}
-  }
+  runSessionAnalysis(session);
   return id;
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1369,
+  "windowReferences": 1363,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -326,6 +326,7 @@ const APP_SHELL = [
   '/js/light-burden-ai-analysis.js',
   '/js/light-channels-ai-analysis.js',
   '/js/light-device-ai-analysis.js',
+  '/js/light-sun-ai-hooks.js',
   '/js/light-devices.js',
   '/js/light-devices-store.js',
   '/js/light-device-session-engine.js',

--- a/tests/playwright/light-devices-browser-coverage.spec.js
+++ b/tests/playwright/light-devices-browser-coverage.spec.js
@@ -63,7 +63,6 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       getOllamaConfig: window.getOllamaConfig,
       navigate: window.navigate,
       showConfirmDialog: window.showConfirmDialog,
-      maybeAnalyzeDeviceSessionAfterFinish: window.maybeAnalyzeDeviceSessionAfterFinish,
       loadCatalog: window.loadCatalog,
       renderLightDeviceAffiliateRow: window.renderLightDeviceAffiliateRow,
       scrollIntoView: Element.prototype.scrollIntoView,
@@ -119,7 +118,9 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
         calls.push(['confirm', message]);
         return true;
       };
-      window.maybeAnalyzeDeviceSessionAfterFinish = session => calls.push(['analyze', session.id]);
+      store.configureLightDevicesStore({
+        maybeAnalyzeDeviceSessionAfterFinish: session => calls.push(['analyze', session.id]),
+      });
       window.loadCatalog = async () => ({ products: [] });
       window.renderLightDeviceAffiliateRow = (_catalog, slug) => `<a class="affiliate-test">${slug}</a>`;
 
@@ -291,8 +292,9 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       else delete window.navigate;
       if (saved.showConfirmDialog) window.showConfirmDialog = saved.showConfirmDialog;
       else delete window.showConfirmDialog;
-      if (saved.maybeAnalyzeDeviceSessionAfterFinish) window.maybeAnalyzeDeviceSessionAfterFinish = saved.maybeAnalyzeDeviceSessionAfterFinish;
-      else delete window.maybeAnalyzeDeviceSessionAfterFinish;
+      store.configureLightDevicesStore({
+        maybeAnalyzeDeviceSessionAfterFinish: window.maybeAnalyzeDeviceSessionAfterFinish || (() => {}),
+      });
       if (saved.loadCatalog) window.loadCatalog = saved.loadCatalog;
       else delete window.loadCatalog;
       if (saved.renderLightDeviceAffiliateRow) window.renderLightDeviceAffiliateRow = saved.renderLightDeviceAffiliateRow;

--- a/tests/playwright/light-devices-browser-coverage.spec.js
+++ b/tests/playwright/light-devices-browser-coverage.spec.js
@@ -32,10 +32,11 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
   });
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data, store] = await Promise.all([
+    const [{ state }, data, store, ai] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/light-devices-store.js'),
+      import('/js/light-device-ai-analysis.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -63,6 +64,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       getOllamaConfig: window.getOllamaConfig,
       navigate: window.navigate,
       showConfirmDialog: window.showConfirmDialog,
+      maybeAnalyzeDeviceSessionAfterFinish: ai.maybeAnalyzeDeviceSessionAfterFinish,
       loadCatalog: window.loadCatalog,
       renderLightDeviceAffiliateRow: window.renderLightDeviceAffiliateRow,
       scrollIntoView: Element.prototype.scrollIntoView,
@@ -293,7 +295,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       if (saved.showConfirmDialog) window.showConfirmDialog = saved.showConfirmDialog;
       else delete window.showConfirmDialog;
       store.configureLightDevicesStore({
-        maybeAnalyzeDeviceSessionAfterFinish: window.maybeAnalyzeDeviceSessionAfterFinish || (() => {}),
+        maybeAnalyzeDeviceSessionAfterFinish: saved.maybeAnalyzeDeviceSessionAfterFinish || (() => {}),
       });
       if (saved.loadCatalog) window.loadCatalog = saved.loadCatalog;
       else delete window.loadCatalog;

--- a/tests/playwright/sun-sessions-store-browser-coverage.spec.js
+++ b/tests/playwright/sun-sessions-store-browser-coverage.spec.js
@@ -91,8 +91,8 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
         ]),
         clearLiveState: id => depCalls.push(['clear', id]),
         formatElapsed: ms => `elapsed:${Math.round(ms / 1000)}s`,
+        maybeAnalyzeSessionAfterFinish: sess => aiCalls.push(sess.id),
       });
-      window.maybeAnalyzeSessionAfterFinish = sess => aiCalls.push(sess.id);
       console.warn = (...args) => warnings.push(args.map(String).join(' '));
 
       window.fetchAtmosphere = async () => {
@@ -240,12 +240,14 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
         setLiveState: () => {},
         clearLiveState: () => {},
         formatElapsed: ms => `${Math.max(0, Math.floor((ms || 0) / 60000))}m`,
+        maybeAnalyzeSessionAfterFinish: saved.maybeAnalyzeSessionAfterFinish || (() => {}),
       });
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       data.invalidateActiveDataCache();
-      window.maybeAnalyzeSessionAfterFinish = saved.maybeAnalyzeSessionAfterFinish;
+      if (saved.maybeAnalyzeSessionAfterFinish === undefined) delete window.maybeAnalyzeSessionAfterFinish;
+      else window.maybeAnalyzeSessionAfterFinish = saved.maybeAnalyzeSessionAfterFinish;
       window.fetchAtmosphere = saved.fetchAtmosphere;
       window.reconstructSpectrum = saved.reconstructSpectrum;
       window.computeChannelDoses = saved.computeChannelDoses;
@@ -311,6 +313,13 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
       };
       data.invalidateActiveDataCache();
       delete window.maybeAnalyzeSessionAfterFinish;
+      store.configureSunSessionsStore({
+        commitCurrentSlice: () => {},
+        setLiveState: () => {},
+        clearLiveState: () => {},
+        formatElapsed: ms => `${Math.max(0, Math.floor((ms || 0) / 60000))}m`,
+        maybeAnalyzeSessionAfterFinish: () => {},
+      });
 
       const id = await store.startSession({ exposurePreset: 'face_hands' });
       const active = store.getActiveSession();
@@ -326,7 +335,7 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
       document.body.appendChild(elapsed);
       const stopped = await store.stopSession(id);
       const expectedElapsed = `${Math.max(0, Math.floor((stopped.endedAt - stopped.startedAt) / 60000))}m`;
-      results.defaultStopDepsFreezeElapsedAndSkipAiHook =
+      results.noopStopDepsFreezeElapsedAndSkipAiHook =
         stopped?.endedAt
         && stopped.durationMin >= 2
         && stopped.eyeExposure?.durationSec >= 120
@@ -336,6 +345,9 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
       elapsed.remove();
     } finally {
       document.querySelectorAll('[data-live-elapsed-for]').forEach(el => el.remove());
+      store.configureSunSessionsStore({
+        maybeAnalyzeSessionAfterFinish: saved.maybeAnalyzeSessionAfterFinish || (() => {}),
+      });
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
@@ -353,7 +365,7 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
 
   const expectedOutcomes = [
     'defaultPauseDepsAreNoopsButStatePersists',
-    'defaultStopDepsFreezeElapsedAndSkipAiHook',
+    'noopStopDepsFreezeElapsedAndSkipAiHook',
   ];
   for (const key of expectedOutcomes) {
     expect(outcomes, `outcome key '${key}' was never set`).toHaveProperty(key);

--- a/tests/playwright/sun-sessions-store-browser-coverage.spec.js
+++ b/tests/playwright/sun-sessions-store-browser-coverage.spec.js
@@ -31,7 +31,6 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
       profiles: clone(state.profiles),
-      maybeAnalyzeSessionAfterFinish: window.maybeAnalyzeSessionAfterFinish,
       fetchAtmosphere: window.fetchAtmosphere,
       reconstructSpectrum: window.reconstructSpectrum,
       computeChannelDoses: window.computeChannelDoses,
@@ -240,14 +239,12 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
         setLiveState: () => {},
         clearLiveState: () => {},
         formatElapsed: ms => `${Math.max(0, Math.floor((ms || 0) / 60000))}m`,
-        maybeAnalyzeSessionAfterFinish: saved.maybeAnalyzeSessionAfterFinish || (() => {}),
+        maybeAnalyzeSessionAfterFinish: () => {},
       });
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       data.invalidateActiveDataCache();
-      if (saved.maybeAnalyzeSessionAfterFinish === undefined) delete window.maybeAnalyzeSessionAfterFinish;
-      else window.maybeAnalyzeSessionAfterFinish = saved.maybeAnalyzeSessionAfterFinish;
       window.fetchAtmosphere = saved.fetchAtmosphere;
       window.reconstructSpectrum = saved.reconstructSpectrum;
       window.computeChannelDoses = saved.computeChannelDoses;
@@ -288,7 +285,6 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
       profiles: clone(state.profiles),
-      maybeAnalyzeSessionAfterFinish: window.maybeAnalyzeSessionAfterFinish,
     };
     const results = {};
 
@@ -312,7 +308,6 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
         sunSessions: [],
       };
       data.invalidateActiveDataCache();
-      delete window.maybeAnalyzeSessionAfterFinish;
       store.configureSunSessionsStore({
         commitCurrentSlice: () => {},
         setLiveState: () => {},
@@ -335,25 +330,22 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
       document.body.appendChild(elapsed);
       const stopped = await store.stopSession(id);
       const expectedElapsed = `${Math.max(0, Math.floor((stopped.endedAt - stopped.startedAt) / 60000))}m`;
-      results.noopStopDepsFreezeElapsedAndSkipAiHook =
+      results.noopStopDepsFreezeElapsed =
         stopped?.endedAt
         && stopped.durationMin >= 2
         && stopped.eyeExposure?.durationSec >= 120
         && !elapsed.hasAttribute('data-live-elapsed-for')
-        && elapsed.textContent === expectedElapsed
-        && window.maybeAnalyzeSessionAfterFinish === undefined;
+        && elapsed.textContent === expectedElapsed;
       elapsed.remove();
     } finally {
       document.querySelectorAll('[data-live-elapsed-for]').forEach(el => el.remove());
       store.configureSunSessionsStore({
-        maybeAnalyzeSessionAfterFinish: saved.maybeAnalyzeSessionAfterFinish || (() => {}),
+        maybeAnalyzeSessionAfterFinish: () => {},
       });
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       data.invalidateActiveDataCache();
-      if (saved.maybeAnalyzeSessionAfterFinish === undefined) delete window.maybeAnalyzeSessionAfterFinish;
-      else window.maybeAnalyzeSessionAfterFinish = saved.maybeAnalyzeSessionAfterFinish;
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);
@@ -365,7 +357,7 @@ test('sun sessions store default dependency callbacks preserve lifecycle behavio
 
   const expectedOutcomes = [
     'defaultPauseDepsAreNoopsButStatePersists',
-    'noopStopDepsFreezeElapsedAndSkipAiHook',
+    'noopStopDepsFreezeElapsed',
   ];
   for (const key of expectedOutcomes) {
     expect(outcomes, `outcome key '${key}' was never set`).toHaveProperty(key);

--- a/tests/test-light-devices-store.js
+++ b/tests/test-light-devices-store.js
@@ -22,6 +22,7 @@ const { state } = await import('../js/state.js');
 const {
   addCustomDevice,
   addDeviceFromPresetRecord,
+  configureLightDevicesStore,
   deleteDevice,
   deleteDeviceSession,
   getActiveDeviceSession,
@@ -37,8 +38,9 @@ const {
 
 state.currentProfile = 'light-devices-store-test';
 let analysisCalls = 0;
-const originalAnalyzer = window.maybeAnalyzeDeviceSessionAfterFinish;
-window.maybeAnalyzeDeviceSessionAfterFinish = () => { analysisCalls++; };
+configureLightDevicesStore({
+  maybeAnalyzeDeviceSessionAfterFinish: () => { analysisCalls++; },
+});
 
 function reset(seed = {}) {
   analysisCalls = 0;
@@ -187,6 +189,8 @@ assert('rollingDeviceTotals sums only in-window finite doses',
 console.log('%c 3. Boundary ownership ', 'font-weight:bold;color:#f59e0b');
 const uiSrc = read('js/light-devices.js');
 const storeSrc = read('js/light-devices-store.js');
+const appLightSunSrc = read('js/app-light-sun-modules.js');
+const aiHooksSrc = read('js/light-sun-ai-hooks.js');
 assert('light-devices imports the store boundary',
   uiSrc.includes("from './light-devices-store.js'"));
 assert('light-devices no longer persists device/session mutations directly',
@@ -198,9 +202,17 @@ assert('light-devices-store owns synced persistence for devices and sessions',
     && /deleteImportedArrayItem\(state\.importedData, 'lightDevices'/.test(storeSrc)
     && /deleteImportedArrayItem\(state\.importedData, 'deviceSessions'/.test(storeSrc)
     && /computeDeviceSessionDoses/.test(storeSrc));
+assert('light-devices-store routes analyzer hook through injected deps',
+  storeSrc.includes('configureLightDevicesStore')
+    && storeSrc.includes('maybeAnalyzeDeviceSessionAfterFinish: () => {}')
+    && !storeSrc.includes('window.maybeAnalyzeDeviceSessionAfterFinish'));
+assert('light-sun AI hooks wire device analyzer into store deps',
+  aiHooksSrc.includes("import { configureLightDevicesStore } from './light-devices-store.js';")
+    && aiHooksSrc.includes("import { maybeAnalyzeDeviceSessionAfterFinish } from './light-device-ai-analysis.js';")
+    && aiHooksSrc.includes('configureLightDevicesStore({ maybeAnalyzeDeviceSessionAfterFinish })')
+    && appLightSunSrc.includes("import './light-sun-ai-hooks.js';"));
 
-if (originalAnalyzer) window.maybeAnalyzeDeviceSessionAfterFinish = originalAnalyzer;
-else delete window.maybeAnalyzeDeviceSessionAfterFinish;
+configureLightDevicesStore({ maybeAnalyzeDeviceSessionAfterFinish: () => {} });
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -501,6 +501,8 @@ const {
   const sunSrc = await fs.readFile(new URL('../js/sun.js', import.meta.url), 'utf8');
   const modelSrc = await fs.readFile(new URL('../js/sun-session-model.js', import.meta.url), 'utf8');
   const storeSrc = await fs.readFile(new URL('../js/sun-sessions-store.js', import.meta.url), 'utf8');
+  const appLightSunSrc = await fs.readFile(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
+  const aiHooksSrc = await fs.readFile(new URL('../js/light-sun-ai-hooks.js', import.meta.url), 'utf8');
   const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
   assert('Sun session model owns shared option/safety constants',
     sunSrc.includes("from './sun-session-model.js'") &&
@@ -514,9 +516,16 @@ const {
     storeSrc.includes('export function getSessions') &&
     !storeSrc.includes('showPromptDialog') &&
     !storeSrc.includes('renderBodySilhouette'));
+  assert('Sun sessions store routes analyzer hook through startup wiring',
+    !storeSrc.includes('window.maybeAnalyzeSessionAfterFinish') &&
+    aiHooksSrc.includes("import { configureSunSessionsStore } from './sun-sessions-store.js';") &&
+    aiHooksSrc.includes("import { maybeAnalyzeSessionAfterFinish } from './sun-ai-analysis.js';") &&
+    aiHooksSrc.includes('configureSunSessionsStore({ maybeAnalyzeSessionAfterFinish })') &&
+    appLightSunSrc.includes("import './light-sun-ai-hooks.js';"));
   assert('Service worker precaches extracted sun session modules',
     swSrc.includes("'/js/sun-session-model.js'") &&
-    swSrc.includes("'/js/sun-sessions-store.js'"));
+    swSrc.includes("'/js/sun-sessions-store.js'") &&
+    swSrc.includes("'/js/light-sun-ai-hooks.js'"));
 
   // Restore
   window._labState.importedData = orig;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.529';
+self.APP_VERSION = '1.8.530';


### PR DESCRIPTION
## What changed

- Added `light-sun-ai-hooks.js` startup wiring for Sun and Light device session analyzer callbacks.
- Moved Sun and Light device store completion analysis from direct `window.*` lookups to injected store dependencies with no-op defaults.
- Updated store and browser coverage tests to exercise the injected analyzer hooks.
- Precaches the new startup hook in the service worker and bumps `version.js` to `1.8.530`.
- Ratchets `windowReferences` quality baseline from `1369` to `1363`.

## Why

The session stores should own persistence and lifecycle behavior without reaching through global browser state for optional AI side effects. This keeps the store boundary easier to test, reduces global coupling, and preserves the existing analyzer behavior through explicit startup wiring.

## Validation

- `npm run quality`
- `npm run typecheck`
- `node tests/test-light-devices-store.js`
- `npm test -- -t test-sun.js`
- `npm run test:playwright -- tests/playwright/light-devices-browser-coverage.spec.js tests/playwright/sun-sessions-store-browser-coverage.spec.js`
- `./run-tests.sh`