### PR TITLE
[codex] Wire Light save AI hooks through startup

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -19,5 +19,6 @@ import './light-burden-ai-analysis.js';
 import './light-channels-ai-analysis.js';
 import './sun-defaults.js';
 import './sun-onboarding-ai.js';
+import './light-ai-save-hooks.js';
 import './sun-correlations.js';
 import './light-today-ai.js';

--- a/js/light-ai-save-hooks.js
+++ b/js/light-ai-save-hooks.js
@@ -1,0 +1,14 @@
+// @ts-check
+// light-ai-save-hooks.js - wire saved Light/onboarding records to AI analyzers.
+
+import { configureLightEnvAudits } from './light-env-audits.js';
+import { configureLightTools } from './light-tools.js';
+import { configureSunDefaults } from './sun-defaults.js';
+import { hasAIProvider } from './api.js';
+import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';
+import { maybeAnalyzeMeasurementAfterSave } from './light-tools-ai-analysis.js';
+import { maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock } from './sun-onboarding-ai.js';
+
+configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot });
+configureLightTools({ maybeAnalyzeMeasurementAfterSave });
+configureSunDefaults({ maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock });

--- a/js/light-env-audits.js
+++ b/js/light-env-audits.js
@@ -23,7 +23,7 @@ import { lightEnvActionAttrs } from './light-env-actions.js';
 //     screens: [...deep-copy], measurements: [...last 30d, deep-copy],
 //     createdAt, updatedAt? }
 
-/** @type {{ getEnvironment: AnyFunction, computeRoomSeverity: AnyFunction, refreshLightEnvironmentUI: AnyFunction }} */
+/** @type {{ getEnvironment: AnyFunction, computeRoomSeverity: AnyFunction, refreshLightEnvironmentUI: AnyFunction, hasAIProvider: AnyFunction, maybeAnalyzeAuditAfterSave: AnyFunction, renderAuditAIBlock: AnyFunction, renderAuditAIDot: AnyFunction }} */
 const auditDeps = {
   getEnvironment: () => state.importedData?.lightEnvironment || null,
   computeRoomSeverity: () => ({
@@ -33,6 +33,10 @@ const auditDeps = {
     reason: 'Light environment unavailable',
   }),
   refreshLightEnvironmentUI: () => {},
+  hasAIProvider: () => false,
+  maybeAnalyzeAuditAfterSave: () => {},
+  renderAuditAIBlock: () => '',
+  renderAuditAIDot: () => '',
 };
 
 const LIGHT_AUDITS_ANCHOR = '.light-audits-block';
@@ -58,6 +62,22 @@ function computeRoomSeverity(room, measurements) {
 
 function refreshLightEnvironmentUI(options = {}) {
   auditDeps.refreshLightEnvironmentUI(options);
+}
+
+function maybeAnalyzeAuditAfterSave(audit) {
+  try { auditDeps.maybeAnalyzeAuditAfterSave(audit); } catch (_) {}
+}
+
+function renderAuditAIBlock(audit) {
+  try { return auditDeps.renderAuditAIBlock(audit) || ''; } catch (_) { return ''; }
+}
+
+function renderAuditAIDot(audit) {
+  try { return auditDeps.renderAuditAIDot(audit) || ''; } catch (_) { return ''; }
+}
+
+function hasAuditAIProvider() {
+  try { return !!auditDeps.hasAIProvider(); } catch (_) { return false; }
 }
 
 function refreshAuditsUI() {
@@ -116,9 +136,7 @@ export async function saveLightAudit(label = '') {
   // verdict so the snapshot is interpretable from the moment it lands,
   // same way session-stop and onboarding-save do. Manual refresh on the
   // card re-rolls. Best-effort, no-throw — sync push handles propagation.
-  if (typeof window !== 'undefined' && window.maybeAnalyzeAuditAfterSave) {
-    try { window.maybeAnalyzeAuditAfterSave(audit); } catch (_) {}
-  }
+  maybeAnalyzeAuditAfterSave(audit);
   return audit;
 }
 
@@ -188,7 +206,7 @@ function renderLightAuditCard(a, expanded) {
     <div class="light-audit-header" role="button" tabindex="0" aria-expanded="${expanded ? 'true' : 'false'}" aria-label="${escapeAttr(cardAriaLabel)}" ${lightEnvActionAttrs('toggle-audit', { id: a.id })}>
       <div class="light-audit-info">
         <div class="light-audit-info-top">
-          ${typeof window !== 'undefined' && window.renderAuditAIDot ? window.renderAuditAIDot(a) : ''}
+          ${renderAuditAIDot(a)}
           <span class="light-audit-date">${escapeHTML(fmtAuditDate(a.date))}</span>
           ${a.label ? `<span class="light-audit-label">${escapeHTML(a.label)}</span>` : ''}
         </div>
@@ -233,7 +251,7 @@ function renderLightAuditDetail(a) {
         <input type="text" class="ctx-input" value="${escapeHTML(a.label || '')}" placeholder="e.g. Pre-mitigation" aria-label="Audit label" ${lightEnvActionAttrs('update-audit-field', { id: a.id, field: 'label' })}>
       </label>
     </div>
-    ${typeof window !== 'undefined' && window.renderAuditAIBlock ? window.renderAuditAIBlock(a) : ''}`;
+    ${renderAuditAIBlock(a)}`;
 
   if (!(a.rooms || []).length) {
     html += `<p class="light-audit-empty">No rooms in this audit's snapshot.</p>`;
@@ -369,9 +387,7 @@ function renderLightAuditCompare(audits) {
   // user can ask the AI what shifted + what to try next. Mirrors EMF
   // assessment's Interpret Comparison flow without the heavyweight
   // streaming overlay (the chat panel already serves the same purpose).
-  const hasAI = (typeof window !== 'undefined' && typeof window.hasAIProvider === 'function')
-    ? window.hasAIProvider()
-    : false;
+  const hasAI = hasAuditAIProvider();
   let html = `<div class="light-audit-compare-head">
     <span class="light-audit-compare-label">Before: ${escapeHTML(fmtAuditDate(a1.date))}${a1.label ? ' — ' + escapeHTML(a1.label) : ''}</span>
     <span class="light-audit-compare-arrow">→</span>

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -43,6 +43,19 @@ const LIGHT_TOOL_ID_ATTR = 'data-light-tool-id';
 const LIGHT_TOOLS_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightToolsActionDelegatesInstalled');
 const lightToolsActionDelegateRoots = new WeakSet();
 
+/** @type {{ maybeAnalyzeMeasurementAfterSave: AnyFunction }} */
+const lightToolsDeps = {
+  maybeAnalyzeMeasurementAfterSave: () => {},
+};
+
+export function configureLightTools(deps = {}) {
+  Object.assign(lightToolsDeps, deps);
+}
+
+function maybeAnalyzeMeasurementAfterSave(entry) {
+  try { lightToolsDeps.maybeAnalyzeMeasurementAfterSave(entry); } catch (_) {}
+}
+
 function closestLightToolsAction(target) {
   if (!target || !target.closest) return null;
   return target.closest(`[${LIGHT_TOOLS_ACTION_ATTR}]`);
@@ -214,9 +227,7 @@ export async function saveMeasurement(tool, value, opts = {}) {
   }
   getMeasurements().push(entry);
   await saveImportedData();
-  if (typeof window !== 'undefined' && window.maybeAnalyzeMeasurementAfterSave) {
-    try { window.maybeAnalyzeMeasurementAfterSave(entry); } catch (_) {}
-  }
+  maybeAnalyzeMeasurementAfterSave(entry);
   // Spectrum tool result auto-fills the room's primarySource when the
   // user hasn't picked one yet — saves a redundant question, since
   // the classifier knows warm vs cool vs fluorescent. Only fires when

--- a/js/sun-defaults.js
+++ b/js/sun-defaults.js
@@ -20,6 +20,24 @@ import { SKIN_TYPE } from './constants.js';
 //   lightCircadian.skinType : 'I — very fair' | ...         (used by context card)
 const ROMAN = ['I', 'II', 'III', 'IV', 'V', 'VI'];
 
+/** @type {{ maybeAnalyzeOnboardingAfterSave: AnyFunction, renderOnboardingAIBlock: AnyFunction }} */
+const sunDefaultsDeps = {
+  maybeAnalyzeOnboardingAfterSave: () => {},
+  renderOnboardingAIBlock: () => '',
+};
+
+export function configureSunDefaults(deps = {}) {
+  Object.assign(sunDefaultsDeps, deps);
+}
+
+function maybeAnalyzeOnboardingAfterSave() {
+  try { sunDefaultsDeps.maybeAnalyzeOnboardingAfterSave(); } catch (_) {}
+}
+
+function renderOnboardingAIBlock() {
+  try { return sunDefaultsDeps.renderOnboardingAIBlock() || ''; } catch (_) { return ''; }
+}
+
 // Map legacy boolean photosensitiveMeds storage to tier key for the
 // rendered select. true → 'moderate' (matches the previous fixed ×2.5
 // MED reduction), false / null → 'none'. New string-tier storage passes
@@ -418,7 +436,7 @@ function renderSavedSummary() {
       </div>
       ${ottChip}
     </div>
-    ${typeof window !== 'undefined' && window.renderOnboardingAIBlock ? window.renderOnboardingAIBlock() : ''}
+    ${renderOnboardingAIBlock()}
   </div>`;
 }
 
@@ -820,9 +838,7 @@ async function saveSunSetup() {
   await saveImportedData();
   closeSunSetupOverlay();
   showNotification(`Setup saved · light burden ${ottScore}/10`);
-  if (typeof window !== 'undefined' && window.maybeAnalyzeOnboardingAfterSave) {
-    try { window.maybeAnalyzeOnboardingAfterSave(); } catch (_) {}
-  }
+  maybeAnalyzeOnboardingAfterSave();
   if (window.navigate) window.navigate('light');
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1363,
+    "windowReferences": 1349,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-    "windowReferences": 1349,
+  "windowReferences": 1349,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -323,6 +323,7 @@ const APP_SHELL = [
   '/js/sun-spectrum.js',
   '/js/sun-uvdata.js',
   '/js/light-audit-ai-analysis.js',
+  '/js/light-ai-save-hooks.js',
   '/js/light-burden-ai-analysis.js',
   '/js/light-channels-ai-analysis.js',
   '/js/light-device-ai-analysis.js',

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -253,7 +253,6 @@ test('Light audit defaults cover fallback dependency accessors', async ({ page }
     const saved = {
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
-      maybeAnalyzeAuditAfterSave: window.maybeAnalyzeAuditAfterSave,
     };
     const calls = [];
     const outcomes = {};
@@ -287,9 +286,10 @@ test('Light audit defaults cover fallback dependency accessors', async ({ page }
         }],
       };
       data.invalidateActiveDataCache();
-      window.maybeAnalyzeAuditAfterSave = audit => calls.push(['default-auto-audit', audit.id]);
 
-      audits.configureLightEnvAudits({});
+      audits.configureLightEnvAudits({
+        maybeAnalyzeAuditAfterSave: audit => calls.push(['default-auto-audit', audit.id]),
+      });
       const defaultSavedAudit = await audits.saveLightAudit('Default deps snapshot');
       const host = document.createElement('div');
       host.innerHTML = audits.renderLightAuditsBlock();
@@ -313,7 +313,7 @@ test('Light audit defaults cover fallback dependency accessors', async ({ page }
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       data.invalidateActiveDataCache();
-      window.maybeAnalyzeAuditAfterSave = saved.maybeAnalyzeAuditAfterSave;
+      audits.configureLightEnvAudits({ maybeAnalyzeAuditAfterSave: () => {} });
     }
 
     return outcomes;
@@ -371,11 +371,7 @@ test('Light audit history covers save expand update compare interpret and delete
     const saved = {
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
-      renderAuditAIDot: window.renderAuditAIDot,
-      renderAuditAIBlock: window.renderAuditAIBlock,
-      hasAIProvider: window.hasAIProvider,
       openChatPanel: window.openChatPanel,
-      maybeAnalyzeAuditAfterSave: window.maybeAnalyzeAuditAfterSave,
     };
     const outcomes = {};
     const calls = [];
@@ -456,11 +452,7 @@ test('Light audit history covers save expand update compare interpret and delete
         lightAudits: [oldAudit, midAudit, newAudit],
       };
       data.invalidateActiveDataCache();
-      window.renderAuditAIDot = audit => `<span class="light-audit-ai-dot" data-audit="${audit.id}"></span>`;
-      window.renderAuditAIBlock = audit => `<div class="light-audit-ai-block">AI note for ${audit.label}</div>`;
-      window.hasAIProvider = () => true;
       window.openChatPanel = prompt => calls.push(['chat', prompt]);
-      window.maybeAnalyzeAuditAfterSave = audit => calls.push(['auto-audit', audit.id]);
       document.getElementById('confirm-dialog-overlay')?.remove();
       document.getElementById('prompt-dialog-overlay')?.remove();
 
@@ -480,6 +472,10 @@ test('Light audit history covers save expand update compare interpret and delete
           calls.push(['refresh', options?.scrollAnchor || null, options?.fallbackScrollAnchor || null]);
           renderHost();
         },
+        hasAIProvider: () => true,
+        maybeAnalyzeAuditAfterSave: audit => calls.push(['auto-audit', audit.id]),
+        renderAuditAIDot: audit => `<span class="light-audit-ai-dot" data-audit="${audit.id}"></span>`,
+        renderAuditAIBlock: audit => `<div class="light-audit-ai-block">AI note for ${audit.label}</div>`,
       });
 
       const host = renderHost();
@@ -535,7 +531,7 @@ test('Light audit history covers save expand update compare interpret and delete
       document.querySelector('.light-audit-interpret-btn')?.click();
       await waitUntil(() => calls.some(call => call[0] === 'chat'), 'audit compare chat handoff');
       outcomes.interpretComparePrefillsChat =
-        calls.some(call => call[0] === 'chat' && call[1].includes('Light Environment audit comparison'));
+        calls.some(call => call[0] === 'chat' && String(call[1] || '').includes('Light Environment audit comparison'));
 
       const deletePromise = window.deleteLightAuditConfirm('audit_mid');
       await waitFor('#confirm-ok', 'delete audit confirm');
@@ -552,11 +548,13 @@ test('Light audit history covers save expand update compare interpret and delete
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       data.invalidateActiveDataCache();
-      window.renderAuditAIDot = saved.renderAuditAIDot;
-      window.renderAuditAIBlock = saved.renderAuditAIBlock;
-      window.hasAIProvider = saved.hasAIProvider;
+      audits.configureLightEnvAudits({
+        hasAIProvider: () => false,
+        maybeAnalyzeAuditAfterSave: () => {},
+        renderAuditAIDot: () => '',
+        renderAuditAIBlock: () => '',
+      });
       window.openChatPanel = saved.openChatPanel;
-      window.maybeAnalyzeAuditAfterSave = saved.maybeAnalyzeAuditAfterSave;
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/playwright/light-tools-browser-coverage.spec.js
+++ b/tests/playwright/light-tools-browser-coverage.spec.js
@@ -23,7 +23,6 @@ test('light tools browser coverage exercises storage render and modal flows', as
     const saved = {
       importedData: clone(state.importedData),
       currentView: state.currentView,
-      maybeAnalyzeMeasurementAfterSave: window.maybeAnalyzeMeasurementAfterSave,
       suggestRoomSourceFromSpectrum: window.suggestRoomSourceFromSpectrum,
       refreshLightEnvironmentAssessment: window.refreshLightEnvironmentAssessment,
       navigate: window.navigate,
@@ -87,7 +86,9 @@ test('light tools browser coverage exercises storage render and modal flows', as
           screens: [],
         },
       };
-      window.maybeAnalyzeMeasurementAfterSave = entry => analyzeCalls.push(entry.tool);
+      lightTools.configureLightTools({
+        maybeAnalyzeMeasurementAfterSave: entry => analyzeCalls.push(entry.tool),
+      });
       window.suggestRoomSourceFromSpectrum = async (roomId, value) => {
         spectrumCalls.push({ roomId, value });
       };
@@ -336,8 +337,8 @@ test('light tools browser coverage exercises storage render and modal flows', as
     } finally {
       state.importedData = saved.importedData;
       state.currentView = saved.currentView;
+      lightTools.configureLightTools({ maybeAnalyzeMeasurementAfterSave: () => {} });
       Object.assign(window, {
-        maybeAnalyzeMeasurementAfterSave: saved.maybeAnalyzeMeasurementAfterSave,
         suggestRoomSourceFromSpectrum: saved.suggestRoomSourceFromSpectrum,
         refreshLightEnvironmentAssessment: saved.refreshLightEnvironmentAssessment,
         navigate: saved.navigate,

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -50,8 +50,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       openProfileLocationEditor: window.openProfileLocationEditor,
       openClientList: window.openClientList,
       requestPreciseLocation: window.requestPreciseLocation,
-      maybeAnalyzeOnboardingAfterSave: window.maybeAnalyzeOnboardingAfterSave,
-      renderOnboardingAIBlock: window.renderOnboardingAIBlock,
     };
     const calls = [];
     const outcomes = {};
@@ -83,8 +81,10 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
         precise = true;
         return { lat: 50.087, lon: 14.421 };
       };
-      window.maybeAnalyzeOnboardingAfterSave = () => calls.push(['onboarding-ai']);
-      window.renderOnboardingAIBlock = () => '<div id="setup-ai-block">AI setup block</div>';
+      sunDefaults.configureSunDefaults({
+        maybeAnalyzeOnboardingAfterSave: () => calls.push(['onboarding-ai']),
+        renderOnboardingAIBlock: () => '<div id="setup-ai-block">AI setup block</div>',
+      });
 
       const promptHost = document.createElement('div');
       promptHost.id = 'setup-prompt-render-host';
@@ -211,8 +211,10 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
         openProfileLocationEditor: saved.openProfileLocationEditor,
         openClientList: saved.openClientList,
         requestPreciseLocation: saved.requestPreciseLocation,
-        maybeAnalyzeOnboardingAfterSave: saved.maybeAnalyzeOnboardingAfterSave,
-        renderOnboardingAIBlock: saved.renderOnboardingAIBlock,
+      });
+      sunDefaults.configureSunDefaults({
+        maybeAnalyzeOnboardingAfterSave: () => {},
+        renderOnboardingAIBlock: () => '',
       });
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -565,7 +565,7 @@ const {
     aiSaveHooksSrc.includes("import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';") &&
     aiSaveHooksSrc.includes('configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot })') &&
     appLightSunSrc.includes("import './light-ai-save-hooks.js';"));
-  const navSrc = await (await import('node:fs/promises')).readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
+  const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
   const cssSrc = [
     await fs.readFile(new URL('../css/light-sun.css', import.meta.url), 'utf8'),

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -537,7 +537,10 @@ const {
     !modelSrc.includes('saveImportedData') &&
     !modelSrc.includes('renderEnvironmentSection') &&
     !envSrc.includes('function _hasAnyRoomSignal'));
-  const auditSrc = await (await import('node:fs/promises')).readFile(new URL('../js/light-env-audits.js', import.meta.url), 'utf8');
+  const fs = await import('node:fs/promises');
+  const auditSrc = await fs.readFile(new URL('../js/light-env-audits.js', import.meta.url), 'utf8');
+  const appLightSunSrc = await fs.readFile(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
+  const aiSaveHooksSrc = await fs.readFile(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
   assert('Light audit renderer emits no inline event attributes',
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light audit storage/rendering lives in its own module',
@@ -552,15 +555,25 @@ const {
     auditSrc.includes('sortAuditsNewestFirst(getLightAudits())[0]?.id') &&
     envSrc.includes('modal.scrollTop') &&
     !envSrc.includes('function renderLightAuditCompare'));
+  assert('Light audit AI hooks route through startup wiring',
+    !auditSrc.includes('window.maybeAnalyzeAuditAfterSave') &&
+    !auditSrc.includes('window.renderAuditAIBlock') &&
+    !auditSrc.includes('window.renderAuditAIDot') &&
+    !auditSrc.includes('window.hasAIProvider') &&
+    aiSaveHooksSrc.includes("import { configureLightEnvAudits } from './light-env-audits.js';") &&
+    aiSaveHooksSrc.includes("import { hasAIProvider } from './api.js';") &&
+    aiSaveHooksSrc.includes("import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';") &&
+    aiSaveHooksSrc.includes('configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot })') &&
+    appLightSunSrc.includes("import './light-ai-save-hooks.js';"));
   const navSrc = await (await import('node:fs/promises')).readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
-  const fs = await import('node:fs/promises');
   const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
   const cssSrc = [
     await fs.readFile(new URL('../css/light-sun.css', import.meta.url), 'utf8'),
     await fs.readFile(new URL('../css/light-env.css', import.meta.url), 'utf8'),
   ].join('\n');
   assert('Service worker precaches the light environment model module',
-    swSrc.includes("'/js/light-env-model.js'"));
+    swSrc.includes("'/js/light-env-model.js'") &&
+    swSrc.includes("'/js/light-ai-save-hooks.js'"));
   assert('Light assessment is linked from sidebar Analysis tools',
     navSrc.includes("label: 'Light assessment'") &&
     navSrc.includes("key: 'light-env-assessment'") &&

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -25,6 +25,8 @@ const tools = await import('../js/light-tools.js');
     normalizeGoldenHourMinutes,
     } = tools;
     const lightToolsSrc = fs.readFileSync(new URL('../js/light-tools.js', import.meta.url), 'utf8');
+    const lightAiSaveHooksSrc = fs.readFileSync(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
+    const appLightSunSrc = fs.readFileSync(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
     const lightToolCameraSrc = fs.readFileSync(new URL('../js/light-tool-camera.js', import.meta.url), 'utf8');
     const lightToolCameraModalsSrc = fs.readFileSync(new URL('../js/light-tool-camera-modals.js', import.meta.url), 'utf8');
     const lightSunCss = fs.readFileSync(new URL('../css/light-sun.css', import.meta.url), 'utf8');
@@ -226,6 +228,14 @@ const tools = await import('../js/light-tools.js');
     assert('light-tools.js delegates camera-backed tools to extracted module',
       lightToolsSrc.includes("from './light-tool-camera-modals.js'") &&
       lightToolsSrc.includes('return openLuxMeterModal(opts, { saveMeasurement });'));
+    assert('light-tools AI save hook routes through startup wiring',
+      lightToolsSrc.includes('export function configureLightTools') &&
+      lightToolsSrc.includes('maybeAnalyzeMeasurementAfterSave: () => {}') &&
+      !lightToolsSrc.includes('window.maybeAnalyzeMeasurementAfterSave') &&
+      lightAiSaveHooksSrc.includes("import { configureLightTools } from './light-tools.js';") &&
+      lightAiSaveHooksSrc.includes("import { maybeAnalyzeMeasurementAfterSave } from './light-tools-ai-analysis.js';") &&
+      lightAiSaveHooksSrc.includes('configureLightTools({ maybeAnalyzeMeasurementAfterSave })') &&
+      appLightSunSrc.includes("import './light-ai-save-hooks.js';"));
     assert('light-tool-camera.js owns shared camera lock and row-banding helpers',
       lightToolCameraSrc.includes('export async function lockCameraForMeasurement') &&
       lightToolCameraSrc.includes('export function computeRowBanding'));

--- a/tests/test-sun-defaults.js
+++ b/tests/test-sun-defaults.js
@@ -22,6 +22,9 @@ console.log('=== Sun Defaults Tests ===\n');
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const sunDefaultsSrc = fs.readFileSync(path.join(root, 'js/sun-defaults.js'), 'utf8');
+const appLightSunSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
+const aiSaveHooksSrc = fs.readFileSync(path.join(root, 'js/light-ai-save-hooks.js'), 'utf8');
+const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const originalDelegateDomGlobals = {
   document: globalThis.document,
   HTMLElement: globalThis.HTMLElement,
@@ -60,6 +63,7 @@ const {
   EYEWEAR_OPTIONS,
   OTT_QUESTIONS,
   getSunDefaults,
+  configureSunDefaults,
   saveSunDefaults,
   isOnboardingComplete,
   ottScoreToLabel,
@@ -78,6 +82,16 @@ const {
     sunDefaultsSrc.includes('installLightSetupDelegates();') &&
     sunDefaultsSrc.includes("data-light-setup-action=") &&
     sunDefaultsSrc.includes("data-light-setup-input="));
+  assert('sun-defaults AI hooks route through startup wiring',
+    typeof configureSunDefaults === 'function' &&
+    sunDefaultsSrc.includes('maybeAnalyzeOnboardingAfterSave: () => {}') &&
+    !sunDefaultsSrc.includes('window.maybeAnalyzeOnboardingAfterSave') &&
+    !sunDefaultsSrc.includes('window.renderOnboardingAIBlock') &&
+    aiSaveHooksSrc.includes("import { configureSunDefaults } from './sun-defaults.js';") &&
+    aiSaveHooksSrc.includes("import { maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock } from './sun-onboarding-ai.js';") &&
+    aiSaveHooksSrc.includes('configureSunDefaults({ maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock })') &&
+    appLightSunSrc.includes("import './light-ai-save-hooks.js';") &&
+    swSrc.includes("'/js/light-ai-save-hooks.js'"));
 
   document.body.innerHTML = `<div class="light-setup-focus-modal" data-setup-step="core">
     <button type="button" data-setup-tab="core" aria-selected="true"></button>

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.530';
+self.APP_VERSION = '1.8.531';


### PR DESCRIPTION
## Summary
- Add a startup wiring module for Light/Sun save-time AI hooks.
- Replace direct window lookups in light audits, light tools, and Sun defaults with configurable module dependencies.
- Extend source/browser coverage and ratchet the window-reference quality baseline from 1363 to 1349 across the recent batches.

## Validation
- `npm run typecheck`
- `npm run quality`
- `node tests/test-light-env.js`
- `node tests/test-light-tools.js`
- `node tests/test-sun-defaults.js`
- `npm run test:playwright -- tests/playwright/light-tools-browser-coverage.spec.js tests/playwright/environment-coverage-batch.spec.js tests/playwright/setup-onboarding-coverage-batch.spec.js`
- `./run-tests.sh`