### PR TITLE
[codex] Wire Light Tools runtime deps through startup

### DIFF
--- a/js/app-ui-shell-modules.js
+++ b/js/app-ui-shell-modules.js
@@ -6,3 +6,4 @@ import './tour.js';
 import './touch-tooltip.js';
 import './client-list.js';
 import './views.js';
+import './light-tools-ui-hooks.js';

--- a/js/light-ai-save-hooks.js
+++ b/js/light-ai-save-hooks.js
@@ -5,10 +5,25 @@ import { configureLightEnvAudits } from './light-env-audits.js';
 import { configureLightTools } from './light-tools.js';
 import { configureSunDefaults } from './sun-defaults.js';
 import { hasAIProvider } from './api.js';
+import { addRoom, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';
 import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';
 import { maybeAnalyzeMeasurementAfterSave } from './light-tools-ai-analysis.js';
+import { getSunCoords } from './sun.js';
+import { getSessions, hydrateSession, logCompletedSession } from './sun-sessions-store.js';
 import { maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock } from './sun-onboarding-ai.js';
+import { solarZenithAngle } from './sun-uvdata.js';
 
 configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot });
-configureLightTools({ maybeAnalyzeMeasurementAfterSave });
+configureLightTools({
+  maybeAnalyzeMeasurementAfterSave,
+  suggestRoomSourceFromSpectrum,
+  refreshLightEnvironmentAssessment,
+  getSunCoords,
+  solarZenithAngle,
+  logCompletedSession,
+  getSessions,
+  hydrateSession,
+  getRooms,
+  addRoom,
+});
 configureSunDefaults({ maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock });

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -979,7 +979,7 @@ async function setLightEnvRoomHoursBucket(id, bucketKey) {
 // classification — only when the user hasn't picked one yet, so
 // we don't silently overwrite a manual answer. Mapping mirrors
 // light-tools.js classifyLight() label values.
-async function suggestRoomSourceFromSpectrum(roomId, spectrumLabel) {
+export async function suggestRoomSourceFromSpectrum(roomId, spectrumLabel) {
   const env = getEnvironment();
   const room = (env?.rooms || []).find(r => r.id === roomId);
   if (!room) return;
@@ -1135,7 +1135,7 @@ async function setLightEnvTodayActive(kind, id, active) {
   refreshLightEnvironmentUI();
 }
 
-function getRooms() {
+export function getRooms() {
   return (getEnvironment()?.rooms) || [];
 }
 

--- a/js/light-tools-ui-hooks.js
+++ b/js/light-tools-ui-hooks.js
@@ -1,0 +1,7 @@
+// @ts-check
+// light-tools-ui-hooks.js - wire Light Tools UI callbacks after views startup.
+
+import { configureLightTools } from './light-tools.js';
+import { navigate } from './views.js';
+
+configureLightTools({ navigate });

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -43,17 +43,37 @@ const LIGHT_TOOL_ID_ATTR = 'data-light-tool-id';
 const LIGHT_TOOLS_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightToolsActionDelegatesInstalled');
 const lightToolsActionDelegateRoots = new WeakSet();
 
-/** @type {{ maybeAnalyzeMeasurementAfterSave: AnyFunction }} */
+/** @type {{ maybeAnalyzeMeasurementAfterSave: AnyFunction, suggestRoomSourceFromSpectrum: AnyFunction, refreshLightEnvironmentAssessment: AnyFunction, navigate: AnyFunction, getSunCoords: AnyFunction, solarZenithAngle: AnyFunction | null, logCompletedSession: AnyFunction | null, getSessions: AnyFunction, hydrateSession: AnyFunction, getRooms: AnyFunction, addRoom: AnyFunction }} */
 const lightToolsDeps = {
   maybeAnalyzeMeasurementAfterSave: () => {},
+  suggestRoomSourceFromSpectrum: async () => {},
+  refreshLightEnvironmentAssessment: () => {},
+  navigate: () => {},
+  getSunCoords: () => null,
+  solarZenithAngle: null,
+  logCompletedSession: null,
+  getSessions: () => [],
+  hydrateSession: async () => {},
+  getRooms: () => [],
+  addRoom: async () => null,
 };
 
-export function configureLightTools(deps = {}) {
-  Object.assign(lightToolsDeps, deps);
+export function configureLightTools(deps = {}) { Object.assign(lightToolsDeps, deps); }
+
+function maybeAnalyzeMeasurementAfterSave(entry) { try { lightToolsDeps.maybeAnalyzeMeasurementAfterSave(entry); } catch (_) {} }
+
+function refreshLightEnvironmentAssessment() { try { lightToolsDeps.refreshLightEnvironmentAssessment(); } catch (_) {} }
+
+function navigateLight(options) { try { lightToolsDeps.navigate('light', options); } catch (_) {} }
+
+function getSunCoords() { try { return lightToolsDeps.getSunCoords() || null; } catch (_) { return null; } }
+
+function getSunSessions() {
+  try { const sessions = lightToolsDeps.getSessions(); return Array.isArray(sessions) ? sessions : []; } catch (_) { return []; }
 }
 
-function maybeAnalyzeMeasurementAfterSave(entry) {
-  try { lightToolsDeps.maybeAnalyzeMeasurementAfterSave(entry); } catch (_) {}
+function getLightRooms() {
+  try { const rooms = lightToolsDeps.getRooms(); return Array.isArray(rooms) ? rooms : []; } catch (_) { return []; }
 }
 
 function closestLightToolsAction(target) {
@@ -232,12 +252,10 @@ export async function saveMeasurement(tool, value, opts = {}) {
   // user hasn't picked one yet — saves a redundant question, since
   // the classifier knows warm vs cool vs fluorescent. Only fires when
   // a roomId is bound; only updates when source is unset/unknown.
-  if (tool === 'spectrum' && opts.roomId && typeof window !== 'undefined' && typeof window.suggestRoomSourceFromSpectrum === 'function') {
-    try { await window.suggestRoomSourceFromSpectrum(opts.roomId, value); } catch (e) {}
+  if (tool === 'spectrum' && opts.roomId) {
+    try { await lightToolsDeps.suggestRoomSourceFromSpectrum(opts.roomId, value); } catch (e) {}
   }
-  if (typeof window !== 'undefined' && typeof window.refreshLightEnvironmentAssessment === 'function') {
-    try { window.refreshLightEnvironmentAssessment(); } catch (e) {}
-  }
+  refreshLightEnvironmentAssessment();
   // Re-render the Light & Sun page if the user is on it so per-room
   // detail panels pick up the new reading + recompute severity dots.
   // Skip when any modal is still open — the tool may not have torn down
@@ -247,13 +265,13 @@ export async function saveMeasurement(tool, value, opts = {}) {
   // Pass scrollAnchor so the rebuild keeps the room the user was looking
   // at pinned to the viewport — without it, navigate's auto-pick can
   // grab a session card visible above the room and the page jumps up.
-  if (typeof window !== 'undefined' && window.navigate && state.currentView === 'light') {
+  if (state.currentView === 'light') {
     setTimeout(() => {
       if (document.querySelector('.modal-overlay.show')) return;
       const anchor = opts.roomId
         ? `[data-id="${CSS.escape(opts.roomId)}"]`
         : null;
-      window.navigate('light', anchor ? { scrollAnchor: anchor } : undefined);
+      navigateLight(anchor ? { scrollAnchor: anchor } : undefined);
     }, 50);
   }
   return entry;
@@ -309,7 +327,8 @@ export async function openGlassTransmission(opts = {}) {
 // midnight; returns null when the sun never rises or never sets at the
 // given latitude on the given date (high-latitude polar day/night).
 function _computeSunriseSunset(coords, date) {
-  if (!coords || !window.solarZenithAngle) return { sunrise: null, sunset: null };
+  const solarZenithAngle = lightToolsDeps.solarZenithAngle;
+  if (!coords || typeof solarZenithAngle !== 'function') return { sunrise: null, sunset: null };
   const baseDate = date ? new Date(date) : new Date();
   const day = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate());
   const STEP_MIN = 5;
@@ -317,7 +336,8 @@ function _computeSunriseSunset(coords, date) {
   let prevAbove = null;
   for (let m = 0; m < 24 * 60; m += STEP_MIN) {
     const t = new Date(day.getTime() + m * 60_000);
-    const zenith = window.solarZenithAngle(t, coords.lat, coords.lon);
+    const zenith = solarZenithAngle(t, coords.lat, coords.lon);
+    if (!Number.isFinite(zenith)) continue;
     const above = zenith < 90.83; // sun above horizon (refraction-corrected)
     if (prevAbove != null && above !== prevAbove) {
       if (above && !sunrise) sunrise = t;
@@ -373,7 +393,7 @@ export function normalizeGoldenHourMinutes(value) {
 export function openSunriseLogger() {
   const overlay = document.createElement('div');
   overlay.className = 'modal-overlay light-tool-overlay';
-  const coords = (window.getSunCoords && window.getSunCoords()) || null;
+  const coords = getSunCoords();
   const cls = _classifyDayWindow(coords, new Date());
   const subtitleHtml = cls.kind === 'unknown'
     ? `<span style="color:var(--orange);font-size:11px">No location coords — set country in profile for accurate sunrise/sunset windows.</span>`
@@ -411,21 +431,23 @@ export function openSunriseLogger() {
   queryRequired(overlay, '#sunrise-save').addEventListener('click', async () => {
     const durationInput = /** @type {HTMLInputElement} */ (queryRequired(overlay, '#sunrise-duration'));
     const minutes = normalizeGoldenHourMinutes(durationInput.value);
-    if (window.logCompletedSession) {
+    if (typeof lightToolsDeps.logCompletedSession === 'function') {
       const start = Date.now() - minutes * 60 * 1000;
-      await window.logCompletedSession({
+      const loggedId = await lightToolsDeps.logCompletedSession({
         startedAt: start,
         endedAt: Date.now(),
         bodyExposure: { preset: 'face_hands', fraction: 0.05, regions: [], glassBetween: false },
         eyeExposure: { mode: 'direct', lensTint: 'clear', durationSec: minutes * 60 },
         notes: cls.label,
       });
-      const id = window.getSessions().slice(-1)[0]?.id;
-      if (id && window.hydrateSession) await window.hydrateSession(id);
+      const id = loggedId || getSunSessions().slice(-1)[0]?.id;
+      if (id) {
+        try { await lightToolsDeps.hydrateSession(id); } catch (e) {}
+      }
     }
     showNotification(`${cls.label} logged: ${minutes} min`);
     closeSunriseLogger();
-    if (window.navigate && state.currentView === 'light') window.navigate('light');
+    if (state.currentView === 'light') navigateLight();
   });
 }
 
@@ -574,8 +596,7 @@ export async function openEyeLevelAudit() {
         // one if no match. Both `getRooms` and `addRoom` are exposed
         // on window via light-env.js's bottom-of-file Object.assign.
         let bound = 0;
-        const existingRooms = (typeof window.getRooms === 'function')
-          ? (window.getRooms() || []) : [];
+        const existingRooms = getLightRooms();
         const byLabel = new Map();
         for (const r of existingRooms) {
           if (r && typeof r.name === 'string') byLabel.set(r.name.toLowerCase().trim(), r.id);
@@ -585,9 +606,9 @@ export async function openEyeLevelAudit() {
           const label = (p.label || '').trim();
           if (!label) continue; // unlabeled pauses stay in the bulk record only
           let roomId = byLabel.get(label.toLowerCase());
-          if (!roomId && typeof window.addRoom === 'function') {
+          if (!roomId) {
             try {
-              roomId = await window.addRoom(label);
+              roomId = await lightToolsDeps.addRoom(label);
               if (roomId) byLabel.set(label.toLowerCase(), roomId);
             } catch (e) {}
           }

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -58,15 +58,25 @@ const lightToolsDeps = {
   addRoom: async () => null,
 };
 
-export function configureLightTools(deps = {}) { Object.assign(lightToolsDeps, deps); }
+export function configureLightTools(deps = {}) {
+  Object.assign(lightToolsDeps, deps);
+}
 
-function maybeAnalyzeMeasurementAfterSave(entry) { try { lightToolsDeps.maybeAnalyzeMeasurementAfterSave(entry); } catch (_) {} }
+function maybeAnalyzeMeasurementAfterSave(entry) {
+  try { lightToolsDeps.maybeAnalyzeMeasurementAfterSave(entry); } catch (_) {}
+}
 
-function refreshLightEnvironmentAssessment() { try { lightToolsDeps.refreshLightEnvironmentAssessment(); } catch (_) {} }
+function refreshLightEnvironmentAssessment() {
+  try { lightToolsDeps.refreshLightEnvironmentAssessment(); } catch (_) {}
+}
 
-function navigateLight(options) { try { lightToolsDeps.navigate('light', options); } catch (_) {} }
+function navigateLight(options) {
+  try { lightToolsDeps.navigate('light', options); } catch (_) {}
+}
 
-function getSunCoords() { try { return lightToolsDeps.getSunCoords() || null; } catch (_) { return null; } }
+function getSunCoords() {
+  try { return lightToolsDeps.getSunCoords() || null; } catch (_) { return null; }
+}
 
 function getSunSessions() {
   try { const sessions = lightToolsDeps.getSessions(); return Array.isArray(sessions) ? sessions : []; } catch (_) { return []; }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1349,
+  "windowReferences": 1328,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -345,6 +345,7 @@ const APP_SHELL = [
   '/js/light-tool-camera.js',
   '/js/light-tool-camera-modals.js',
   '/js/light-tools.js',
+  '/js/light-tools-ui-hooks.js',
   '/js/light-tools-ai-analysis.js',
   '/js/lighting-hardware-caveats.js',
   '/js/silhouette-paths.js',

--- a/tests/playwright/light-tools-browser-coverage.spec.js
+++ b/tests/playwright/light-tools-browser-coverage.spec.js
@@ -23,14 +23,6 @@ test('light tools browser coverage exercises storage render and modal flows', as
     const saved = {
       importedData: clone(state.importedData),
       currentView: state.currentView,
-      suggestRoomSourceFromSpectrum: window.suggestRoomSourceFromSpectrum,
-      refreshLightEnvironmentAssessment: window.refreshLightEnvironmentAssessment,
-      navigate: window.navigate,
-      getSunCoords: window.getSunCoords,
-      solarZenithAngle: window.solarZenithAngle,
-      logCompletedSession: window.logCompletedSession,
-      getSessions: window.getSessions,
-      hydrateSession: window.hydrateSession,
       mediaDevices: navigator.mediaDevices,
       play: HTMLMediaElement.prototype.play,
       getContext: HTMLCanvasElement.prototype.getContext,
@@ -56,6 +48,9 @@ test('light tools browser coverage exercises storage render and modal flows', as
     const navigateCalls = [];
     const loggedSessions = [];
     const hydrateCalls = [];
+    let testSunCoords = null;
+    let testSolarZenithAngle = null;
+    let testSessions = [];
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitUntil = async (predicate, timeoutMs = 1000) => {
       const started = Date.now();
@@ -88,12 +83,27 @@ test('light tools browser coverage exercises storage render and modal flows', as
       };
       lightTools.configureLightTools({
         maybeAnalyzeMeasurementAfterSave: entry => analyzeCalls.push(entry.tool),
+        suggestRoomSourceFromSpectrum: async (roomId, value) => {
+          spectrumCalls.push({ roomId, value });
+        },
+        refreshLightEnvironmentAssessment: () => refreshCalls.push('refresh'),
+        navigate: (...args) => navigateCalls.push(args),
+        getSunCoords: () => testSunCoords,
+        solarZenithAngle: (...args) => testSolarZenithAngle ? testSolarZenithAngle(...args) : null,
+        logCompletedSession: async payload => {
+          loggedSessions.push(payload);
+          return null;
+        },
+        getSessions: () => testSessions,
+        hydrateSession: async id => hydrateCalls.push(id),
+        getRooms: () => state.importedData?.lightEnvironment?.rooms || [],
+        addRoom: async label => {
+          const id = `test-room-${label.toLowerCase().replace(/\s+/g, '-')}`;
+          if (!state.importedData.lightEnvironment) state.importedData.lightEnvironment = { rooms: [], screens: [] };
+          state.importedData.lightEnvironment.rooms.push({ id, name: label });
+          return id;
+        },
       });
-      window.suggestRoomSourceFromSpectrum = async (roomId, value) => {
-        spectrumCalls.push({ roomId, value });
-      };
-      window.refreshLightEnvironmentAssessment = () => refreshCalls.push('refresh');
-      window.navigate = (...args) => navigateCalls.push(args);
 
       const migrated = lightTools.getMeasurements();
       results.migrationKeepsLatestRoomTool = migrated.some(item => item.id === 'new-lux')
@@ -170,11 +180,9 @@ test('light tools browser coverage exercises storage render and modal flows', as
         && lightTools.normalizeGoldenHourMinutes('500') === 120
         && lightTools.normalizeGoldenHourMinutes('45') === 45;
 
-      window.getSunCoords = () => null;
-      window.solarZenithAngle = undefined;
-      window.logCompletedSession = async payload => loggedSessions.push(payload);
-      window.getSessions = () => [{ id: 'session-one' }];
-      window.hydrateSession = async id => hydrateCalls.push(id);
+      testSunCoords = null;
+      testSolarZenithAngle = null;
+      testSessions = [{ id: 'session-one' }];
       const sunriseNavigateStart = navigateCalls.length;
       lightTools.openSunriseLogger();
       const sunriseOverlay = document.querySelector('[aria-label="Golden hour log"]')?.closest('.modal-overlay');
@@ -190,8 +198,8 @@ test('light tools browser coverage exercises storage render and modal flows', as
         .some(call => call[0] === 'light' && !call[1]);
       sunriseOverlay?.remove();
 
-      window.getSunCoords = () => ({ lat: 50.08, lon: 14.43 });
-      window.solarZenithAngle = date => {
+      testSunCoords = { lat: 50.08, lon: 14.43 };
+      testSolarZenithAngle = date => {
         const hour = date.getHours() + date.getMinutes() / 60;
         return hour >= 6 && hour < 18 ? 80 : 100;
       };
@@ -337,16 +345,18 @@ test('light tools browser coverage exercises storage render and modal flows', as
     } finally {
       state.importedData = saved.importedData;
       state.currentView = saved.currentView;
-      lightTools.configureLightTools({ maybeAnalyzeMeasurementAfterSave: () => {} });
-      Object.assign(window, {
-        suggestRoomSourceFromSpectrum: saved.suggestRoomSourceFromSpectrum,
-        refreshLightEnvironmentAssessment: saved.refreshLightEnvironmentAssessment,
-        navigate: saved.navigate,
-        getSunCoords: saved.getSunCoords,
-        solarZenithAngle: saved.solarZenithAngle,
-        logCompletedSession: saved.logCompletedSession,
-        getSessions: saved.getSessions,
-        hydrateSession: saved.hydrateSession,
+      lightTools.configureLightTools({
+        maybeAnalyzeMeasurementAfterSave: () => {},
+        suggestRoomSourceFromSpectrum: async () => {},
+        refreshLightEnvironmentAssessment: () => {},
+        navigate: () => {},
+        getSunCoords: () => null,
+        solarZenithAngle: null,
+        logCompletedSession: null,
+        getSessions: () => [],
+        hydrateSession: async () => {},
+        getRooms: () => [],
+        addRoom: async () => null,
       });
       HTMLMediaElement.prototype.play = saved.play;
       HTMLCanvasElement.prototype.getContext = saved.getContext;

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -21,12 +21,17 @@ const tools = await import('../js/light-tools.js');
   const {
     computeRowBanding,
     cameraLockStatusLine,
+    configureLightTools,
     getMeasurements, getMeasurementsForRoom, saveMeasurement, deleteMeasurement,
     normalizeGoldenHourMinutes,
     } = tools;
     const lightToolsSrc = fs.readFileSync(new URL('../js/light-tools.js', import.meta.url), 'utf8');
     const lightAiSaveHooksSrc = fs.readFileSync(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
+    const lightToolsUiHooksSrc = fs.readFileSync(new URL('../js/light-tools-ui-hooks.js', import.meta.url), 'utf8');
     const appLightSunSrc = fs.readFileSync(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
+    const appUiShellSrc = fs.readFileSync(new URL('../js/app-ui-shell-modules.js', import.meta.url), 'utf8');
+    const lightEnvSrc = fs.readFileSync(new URL('../js/light-env.js', import.meta.url), 'utf8');
+    const swSrc = fs.readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
     const lightToolCameraSrc = fs.readFileSync(new URL('../js/light-tool-camera.js', import.meta.url), 'utf8');
     const lightToolCameraModalsSrc = fs.readFileSync(new URL('../js/light-tool-camera-modals.js', import.meta.url), 'utf8');
     const lightSunCss = fs.readFileSync(new URL('../css/light-sun.css', import.meta.url), 'utf8');
@@ -182,15 +187,16 @@ const tools = await import('../js/light-tools.js');
   // ─── 8. Spectrum tool auto-fill suggestion fires ─────────────────────
   console.log('%c 8. Spectrum tool fires suggestRoomSourceFromSpectrum ', 'font-weight:bold;color:#f59e0b');
 
-  // Stub the suggestion so we can confirm the call without touching real
-  // light-env state.
+  // Stub the suggestion through the module dependency seam so we can
+  // confirm the call without touching real light-env state.
   let suggestionCalls = 0;
   let lastArgs = null;
-  const origSuggest = window.suggestRoomSourceFromSpectrum;
-  window.suggestRoomSourceFromSpectrum = async (roomId, value) => {
-    suggestionCalls++;
-    lastArgs = { roomId, value };
-  };
+  configureLightTools({
+    suggestRoomSourceFromSpectrum: async (roomId, value) => {
+      suggestionCalls++;
+      lastArgs = { roomId, value };
+    },
+  });
 
   await saveMeasurement('spectrum', 'fluorescent', { roomId: 'r99' });
   assert('Spectrum + roomId fires the auto-fill hook exactly once',
@@ -209,6 +215,7 @@ const tools = await import('../js/light-tools.js');
   await saveMeasurement('lux', 500, { roomId: 'r99' });
     assert('Non-spectrum tool does not fire the hook',
       suggestionCalls === 0);
+    configureLightTools({ suggestRoomSourceFromSpectrum: async () => {} });
 
     // ─── 9. Golden-hour duration guard ──────────────────────────────────
     console.log('%c 9. Golden-hour duration clamp ', 'font-weight:bold;color:#f59e0b');
@@ -234,8 +241,33 @@ const tools = await import('../js/light-tools.js');
       !lightToolsSrc.includes('window.maybeAnalyzeMeasurementAfterSave') &&
       lightAiSaveHooksSrc.includes("import { configureLightTools } from './light-tools.js';") &&
       lightAiSaveHooksSrc.includes("import { maybeAnalyzeMeasurementAfterSave } from './light-tools-ai-analysis.js';") &&
-      lightAiSaveHooksSrc.includes('configureLightTools({ maybeAnalyzeMeasurementAfterSave })') &&
+      lightAiSaveHooksSrc.includes('configureLightTools({') &&
+      lightAiSaveHooksSrc.includes('maybeAnalyzeMeasurementAfterSave') &&
       appLightSunSrc.includes("import './light-ai-save-hooks.js';"));
+    assert('light-tools runtime callbacks route through startup wiring',
+      !lightToolsSrc.includes('window.suggestRoomSourceFromSpectrum') &&
+      !lightToolsSrc.includes('window.refreshLightEnvironmentAssessment') &&
+      !lightToolsSrc.includes('window.getSunCoords') &&
+      !lightToolsSrc.includes('window.solarZenithAngle') &&
+      !lightToolsSrc.includes('window.logCompletedSession') &&
+      !lightToolsSrc.includes('window.getSessions') &&
+      !lightToolsSrc.includes('window.hydrateSession') &&
+      !lightToolsSrc.includes('window.getRooms') &&
+      !lightToolsSrc.includes('window.addRoom') &&
+      !lightToolsSrc.includes('window.navigate') &&
+      lightEnvSrc.includes('export async function suggestRoomSourceFromSpectrum') &&
+      lightEnvSrc.includes('export function getRooms') &&
+      lightAiSaveHooksSrc.includes("import { addRoom, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';") &&
+      lightAiSaveHooksSrc.includes("import { getSunCoords } from './sun.js';") &&
+      lightAiSaveHooksSrc.includes("import { getSessions, hydrateSession, logCompletedSession } from './sun-sessions-store.js';") &&
+      lightAiSaveHooksSrc.includes("import { solarZenithAngle } from './sun-uvdata.js';") &&
+      lightAiSaveHooksSrc.includes('suggestRoomSourceFromSpectrum') &&
+      lightAiSaveHooksSrc.includes('refreshLightEnvironmentAssessment') &&
+      lightAiSaveHooksSrc.includes('solarZenithAngle') &&
+      lightToolsUiHooksSrc.includes("import { navigate } from './views.js';") &&
+      lightToolsUiHooksSrc.includes('configureLightTools({ navigate })') &&
+      appUiShellSrc.includes("import './light-tools-ui-hooks.js';") &&
+      swSrc.includes("'/js/light-tools-ui-hooks.js'"));
     assert('light-tool-camera.js owns shared camera lock and row-banding helpers',
       lightToolCameraSrc.includes('export async function lockCameraForMeasurement') &&
       lightToolCameraSrc.includes('export function computeRowBanding'));
@@ -282,9 +314,7 @@ const tools = await import('../js/light-tools.js');
       !lightSunCss.includes('.lux-dial-value') &&
       !lightSunCss.includes('.tool-aiming-guide'));
 
-  // restore
-  if (origSuggest) window.suggestRoomSourceFromSpectrum = origSuggest;
-  else delete window.suggestRoomSourceFromSpectrum;
+  configureLightTools({ suggestRoomSourceFromSpectrum: async () => {} });
 
   // Restore
   window._labState.importedData = orig;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.531';
+self.APP_VERSION = '1.8.532';


### PR DESCRIPTION
## Summary
- Move Light Tools save/session/sun/room callbacks behind `configureLightTools` instead of direct `window.*` reads.
- Add startup wiring for Light Tools runtime dependencies plus a UI-shell hook for `navigate` after `views.js` loads.
- Export Light Environment room helpers for module-level wiring, update focused coverage, and ratchet the window-reference baseline from 1349 to 1328.

## Validation
- `npm run typecheck`
- `npm run quality`
- `node tests/test-light-tools.js`
- `node tests/test-light-env.js`
- `npm run test:playwright -- tests/playwright/light-tools-browser-coverage.spec.js`
- `./run-tests.sh`