### PR TITLE
[codex] Wire Sun Session UI runtime deps through startup

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -5,6 +5,7 @@ import './sun-uvdata.js';
 import './sun-spectrum.js';
 import './sun.js';
 import './sun-ai-analysis.js';
+import './sun-session-ai-render-hooks.js';
 import './sun-context.js';
 import './light-devices.js';
 import './light-device-ai-analysis.js';

--- a/js/app-ui-shell-modules.js
+++ b/js/app-ui-shell-modules.js
@@ -7,3 +7,4 @@ import './touch-tooltip.js';
 import './client-list.js';
 import './views.js';
 import './light-tools-ui-hooks.js';
+import './sun-session-ui-hooks.js';

--- a/js/sun-session-ai-render-hooks.js
+++ b/js/sun-session-ai-render-hooks.js
@@ -1,0 +1,7 @@
+// @ts-check
+// sun-session-ai-render-hooks.js - wire Sun Session UI AI render callbacks.
+
+import { renderSessionAIDetail, renderSessionAIInline } from './sun-ai-analysis.js';
+import { configureSunSessionUI } from './sun-session-ui.js';
+
+configureSunSessionUI({ renderSessionAIDetail, renderSessionAIInline });

--- a/js/sun-session-ui-hooks.js
+++ b/js/sun-session-ui-hooks.js
@@ -1,0 +1,7 @@
+// @ts-check
+// sun-session-ui-hooks.js - wire Sun Session UI callbacks after views startup.
+
+import { configureSunSessionUI } from './sun-session-ui.js';
+import { navigate } from './views.js';
+
+configureSunSessionUI({ navigate });

--- a/js/sun-session-ui.js
+++ b/js/sun-session-ui.js
@@ -40,6 +40,9 @@ import { installSunSessionActionDelegates, sunSessionActionAttrs } from './sun-s
  * @property {() => Promise<any> | any} setOzoneOverrideMidSession
  * @property {(id: any) => Promise<any> | any} forgotStopPrompt
  * @property {(channel: string) => void} openChannelOnLightPage
+ * @property {(sess: any) => string} renderSessionAIInline
+ * @property {(sess: any) => string} renderSessionAIDetail
+ * @property {(route: string, data?: any) => void} navigate
  */
 
 /** @type {SunSessionUIDeps} */
@@ -72,6 +75,9 @@ const uiDeps = {
   setOzoneOverrideMidSession: () => {},
   forgotStopPrompt: () => {},
   openChannelOnLightPage: () => {},
+  renderSessionAIInline: () => '',
+  renderSessionAIDetail: () => '',
+  navigate: () => {},
 };
 
 const sunSessionDelegateActions = {
@@ -96,6 +102,10 @@ if (typeof document !== 'undefined') {
 /** @param {Partial<SunSessionUIDeps>} [deps] */
 export function configureSunSessionUI(deps = {}) {
   Object.assign(uiDeps, deps);
+}
+
+function refreshLightView() {
+  if (state.currentView === 'light') uiDeps.navigate('light');
 }
 
 // ─── UI: Sessions list (used by the dedicated Light & Sun page) ────────
@@ -167,7 +177,7 @@ export function renderSunSessionRow(sess) {
     ${forgotBanner}
     ${activeControls}
     ${channelChips}
-    ${typeof window !== 'undefined' && window.renderSessionAIInline ? window.renderSessionAIInline(sess) : ''}
+    ${uiDeps.renderSessionAIInline(sess)}
   </div>`;
 }
 
@@ -375,7 +385,7 @@ export function openSunSessionDetail(id) {
       <button type="button" class="modal-close" ${sunSessionActionAttrs('close-modal')} aria-label="Close">×</button>
     </div>
     <div class="modal-body">
-      ${typeof window !== 'undefined' && window.renderSessionAIDetail ? window.renderSessionAIDetail(sess) : ''}
+      ${uiDeps.renderSessionAIDetail(sess)}
       <div class="sun-detail-grid">
         <div title="Session start–end and duration"><span>When</span><strong>${escapeHTML(whenStr)}</strong></div>
         <div title="Cumulative erythemal dose as a fraction of your personal MED (Fitzpatrick-scaled). 70%+ recommends shade; 100% is sunburn threshold."><span>Burn dose</span><strong>${escapeHTML(medStr)}</strong></div>
@@ -739,7 +749,7 @@ export function openDetailedSessionDialog() {
     if (sessId) await uiDeps.hydrateSession(sessId);
     closeDialog();
     showNotification(`Detailed session saved: ${durationMin} min, ${regions.length} regions.`);
-    if (window.navigate && state.currentView === 'light') window.navigate('light');
+    refreshLightView();
   });
 }
 
@@ -778,5 +788,5 @@ export async function editSunSessionDuration(id) {
   if (next === current) return; // nothing to do
   await uiDeps.updateSession(id, { durationMin: next });
   showNotification(`Session duration set to ${next} min. Other devices will pull this on next sync.`, 'success');
-  if (window.navigate && state.currentView === 'light') window.navigate('light');
+  refreshLightView();
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1328,
+  "windowReferences": 1320,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -313,6 +313,8 @@ const APP_SHELL = [
   '/js/sun-session-model.js',
   '/js/sun-sessions-store.js',
   '/js/sun-session-ui.js',
+  '/js/sun-session-ui-hooks.js',
+  '/js/sun-session-ai-render-hooks.js',
   '/js/sun-session-actions.js',
   '/js/sun-body-silhouette.js',
   '/js/sun-ai-analysis.js',

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -20,9 +20,6 @@ test('sun session UI covers list detail edit delete and past-session save paths'
       pbmJoulesPerCm2: window.pbmJoulesPerCm2,
       circadianMelanopicLux: window.circadianMelanopicLux,
       geneticVitaminDMultiplier: window.geneticVitaminDMultiplier,
-      renderSessionAIInline: window.renderSessionAIInline,
-      renderSessionAIDetail: window.renderSessionAIDetail,
-      navigate: window.navigate,
     };
     let sessions = [
       {
@@ -87,10 +84,6 @@ test('sun session UI covers list detail edit delete and past-session save paths'
         mult: 0.82,
         contributors: [{ gene: 'GC', genotype: 'TT', multiplier: 0.82 }],
       });
-      window.renderSessionAIInline = () => '<span class="ai-inline-test">AI inline</span>';
-      window.renderSessionAIDetail = () => '<section class="ai-detail-test">AI detail</section>';
-      window.navigate = route => calls.push(['navigate', route]);
-
       sunUI.configureSunSessionUI({
         getSessions: () => sessions,
         deleteSession: async id => {
@@ -136,6 +129,9 @@ test('sun session UI covers list detail edit delete and past-session save paths'
         tierLabel: tier => ['none', 'low', 'moderate', 'high'][tier] || 'none',
         formatChannelUnit: (key, value) => `${Math.round(value)} ${key}`,
         tooShortForChannelVerdictMin: 2,
+        renderSessionAIInline: () => '<span class="ai-inline-test">AI inline</span>',
+        renderSessionAIDetail: () => '<section class="ai-detail-test">AI detail</section>',
+        navigate: route => calls.push(['navigate', route]),
       });
 
       const listHost = document.createElement('div');
@@ -231,6 +227,9 @@ test('sun session UI covers list detail edit delete and past-session save paths'
         tierLabel: () => 'none',
         formatChannelUnit: () => '',
         tooShortForChannelVerdictMin: 2,
+        renderSessionAIInline: () => '',
+        renderSessionAIDetail: () => '',
+        navigate: () => {},
       });
       document.querySelectorAll('.modal-overlay,.confirm-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/playwright/sun-session-ui-browser-coverage.spec.js
+++ b/tests/playwright/sun-session-ui-browser-coverage.spec.js
@@ -28,8 +28,6 @@ test('sun session UI covers alternate list detail and chip rendering paths', asy
       pbmJoulesPerCm2: window.pbmJoulesPerCm2,
       circadianMelanopicLux: window.circadianMelanopicLux,
       geneticVitaminDMultiplier: window.geneticVitaminDMultiplier,
-      renderSessionAIInline: window.renderSessionAIInline,
-      renderSessionAIDetail: window.renderSessionAIDetail,
     };
     const now = Date.now();
     const sessions = [
@@ -113,6 +111,8 @@ test('sun session UI covers alternate list detail and chip rendering paths', asy
       tierLabel: tier => ['none', 'low', 'moderate', 'high'][tier] || 'none',
       formatChannelUnit: (key, value) => `${Math.round(value)} ${key}`,
       tooShortForChannelVerdictMin: 2,
+      renderSessionAIInline: () => '<span class="ai-inline-test">AI inline</span>',
+      renderSessionAIDetail: () => '<section class="ai-detail-test">AI detail</section>',
     };
 
     try {
@@ -126,8 +126,6 @@ test('sun session UI covers alternate list detail and chip rendering paths', asy
       window.pbmJoulesPerCm2 = () => 8.4;
       window.circadianMelanopicLux = () => 5200;
       window.geneticVitaminDMultiplier = () => ({ mult: 1, contributors: [] });
-      window.renderSessionAIInline = () => '<span class="ai-inline-test">AI inline</span>';
-      window.renderSessionAIDetail = () => '<section class="ai-detail-test">AI detail</section>';
 
       sunUI.configureSunSessionUI({ ...baseDeps, getSessions: () => [] });
       const emptyHost = document.createElement('div');
@@ -218,8 +216,6 @@ test('sun session UI covers alternate list detail and chip rendering paths', asy
       window.pbmJoulesPerCm2 = saved.pbmJoulesPerCm2;
       window.circadianMelanopicLux = saved.circadianMelanopicLux;
       window.geneticVitaminDMultiplier = saved.geneticVitaminDMultiplier;
-      window.renderSessionAIInline = saved.renderSessionAIInline;
-      window.renderSessionAIDetail = saved.renderSessionAIDetail;
       sunUI.configureSunSessionUI({
         getSessions: () => [],
         deleteSession: async () => false,
@@ -242,6 +238,8 @@ test('sun session UI covers alternate list detail and chip rendering paths', asy
         tierLabel: () => 'none',
         formatChannelUnit: () => '',
         tooShortForChannelVerdictMin: 2,
+        renderSessionAIInline: () => '',
+        renderSessionAIDetail: () => '',
       });
       document.querySelectorAll('.modal-overlay,.notification-container,.notification-toast').forEach(el => el.remove());
     }
@@ -264,7 +262,6 @@ test('sun session UI covers detailed dialog and edit delete guard rails', async 
     const calls = [];
     const saved = {
       currentView: state.currentView,
-      navigate: window.navigate,
     };
     const sessions = [{
       id: 'editable-session',
@@ -320,6 +317,7 @@ test('sun session UI covers detailed dialog and edit delete guard rails', async 
       tierLabel: () => 'none',
       formatChannelUnit: () => '',
       tooShortForChannelVerdictMin: 2,
+      navigate: route => calls.push(['navigate', route]),
       ...overrides,
     });
 
@@ -342,7 +340,6 @@ test('sun session UI covers detailed dialog and edit delete guard rails', async 
 
     try {
       state.currentView = 'dashboard';
-      window.navigate = route => calls.push(['navigate', route]);
       configure({ getSessions: () => [] });
 
       sunUI.openDetailedSessionDialog();
@@ -494,8 +491,6 @@ test('sun session UI covers detailed dialog and edit delete guard rails', async 
         && !successCalls.some(call => call[0] === 'navigate');
     } finally {
       state.currentView = saved.currentView;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
       sunUI.configureSunSessionUI({
         getSessions: () => [],
         deleteSession: async () => false,
@@ -518,6 +513,7 @@ test('sun session UI covers detailed dialog and edit delete guard rails', async 
         tierLabel: () => 'none',
         formatChannelUnit: () => '',
         tooShortForChannelVerdictMin: 2,
+        navigate: () => {},
       });
       document.querySelectorAll('.modal-overlay,.confirm-overlay,.notification-container,.notification-toast').forEach(el => el.remove());
     }

--- a/tests/test-sun-session-ui-delegated-actions.js
+++ b/tests/test-sun-session-ui-delegated-actions.js
@@ -10,6 +10,11 @@ const root = path.resolve(__dirname, '..');
 const uiSrc = fs.readFileSync(path.join(root, 'js/sun-session-ui.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/sun-session-actions.js'), 'utf8');
 const sunSrc = fs.readFileSync(path.join(root, 'js/sun.js'), 'utf8');
+const aiHookSrc = fs.readFileSync(path.join(root, 'js/sun-session-ai-render-hooks.js'), 'utf8');
+const uiHookSrc = fs.readFileSync(path.join(root, 'js/sun-session-ui-hooks.js'), 'utf8');
+const appLightSunSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
+const appUiShellSrc = fs.readFileSync(path.join(root, 'js/app-ui-shell-modules.js'), 'utf8');
+const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -72,7 +77,25 @@ assert('sun-session-actions routes active controls through injected actions',
 assert('sun-session-ui direct module actions no longer route through window globals',
   !uiSrc.includes('window.openSunSessionDetail') &&
     !uiSrc.includes('window.deleteSunSession') &&
-    !uiSrc.includes('window.editSunSessionDuration'));
+    !uiSrc.includes('window.editSunSessionDuration') &&
+    !uiSrc.includes('window.renderSessionAIInline') &&
+    !uiSrc.includes('window.renderSessionAIDetail') &&
+    !uiSrc.includes('window.navigate'));
+assert('sun-session-ui runtime render and navigate callbacks are startup-wired',
+  uiSrc.includes('renderSessionAIInline: () =>') &&
+    uiSrc.includes('renderSessionAIDetail: () =>') &&
+    uiSrc.includes('navigate: () =>') &&
+    uiSrc.includes('uiDeps.renderSessionAIInline(sess)') &&
+    uiSrc.includes('uiDeps.renderSessionAIDetail(sess)') &&
+    uiSrc.includes('function refreshLightView()') &&
+    aiHookSrc.includes("import { renderSessionAIDetail, renderSessionAIInline } from './sun-ai-analysis.js';") &&
+    aiHookSrc.includes('configureSunSessionUI({ renderSessionAIDetail, renderSessionAIInline })') &&
+    uiHookSrc.includes("import { navigate } from './views.js';") &&
+    uiHookSrc.includes('configureSunSessionUI({ navigate })') &&
+    appLightSunSrc.includes("import './sun-session-ai-render-hooks.js';") &&
+    appUiShellSrc.includes("import './sun-session-ui-hooks.js';") &&
+    swSrc.includes("'/js/sun-session-ai-render-hooks.js'") &&
+    swSrc.includes("'/js/sun-session-ui-hooks.js'"));
 assert('sun.js configures active sun-session delegated actions',
   sunSrc.includes('quickLogSunSession,') &&
     sunSrc.includes('pauseSunSession,') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.532';
+self.APP_VERSION = '1.8.533';


### PR DESCRIPTION
## Summary
- Inject Sun Session UI AI render callbacks and light-page navigation through `configureSunSessionUI`
- Add startup hook modules for AI rendering and view navigation wiring, including service-worker cache registration
- Ratchet the window-reference quality baseline from 1328 to 1320 and update focused coverage

## Validation
- `npm run typecheck`
- `npm run quality`
- `node tests/test-sun-session-ui-delegated-actions.js`
- `npm run test:playwright -- tests/playwright/sun-session-ui-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/light-sun-coverage-batch.spec.js`
- `./run-tests.sh`