### PR TITLE
[codex] Wire Light Sessions View runtime deps through startup

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -9,6 +9,7 @@ import './sun-session-ai-render-hooks.js';
 import './sun-context.js';
 import './light-devices.js';
 import './light-device-ai-analysis.js';
+import './light-sessions-view-hooks.js';
 import './light-sun-ai-hooks.js';
 import './light-tools.js';
 import './light-tools-ai-analysis.js';

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -748,6 +748,12 @@ function _openDevicePicker(devices) {
   }
 }
 
+export async function deleteDeviceSessionWithConfirm(id) {
+  if (!await showConfirmDialog("Delete this device session? This can't be undone.")) return;
+  await deleteDeviceSession(id);
+  if (window.navigate && state.currentView === 'light') window.navigate('light');
+}
+
 // ─── Window export ─────────────────────────────────────────────────────
 
 if (typeof window !== 'undefined') {
@@ -779,12 +785,7 @@ if (typeof window !== 'undefined') {
       }
       if (window.navigate && state.currentView === 'light') window.navigate('light');
     },
-    deleteDeviceSession: async (id) => {
-      if (await showConfirmDialog("Delete this device session? This can't be undone.")) {
-        await deleteDeviceSession(id);
-        if (window.navigate && state.currentView === 'light') window.navigate('light');
-      }
-    },
+    deleteDeviceSession: deleteDeviceSessionWithConfirm,
     rollingDeviceTotals,
     renderDevicesSection,
     openDeviceSessionDetail,

--- a/js/light-sessions-view-hooks.js
+++ b/js/light-sessions-view-hooks.js
@@ -1,0 +1,22 @@
+// @ts-check
+// light-sessions-view-hooks.js - wire Light Sessions View callbacks at startup.
+
+import { CHANNEL_DISPLAY, channelTier, formatChannelUnit, getSessions } from './sun.js';
+import { renderSunSessionRow } from './sun-session-ui.js';
+import { deleteDeviceSessionWithConfirm, openDeviceSessionDetail } from './light-devices.js';
+import { getDeviceSessions, getDevices } from './light-devices-store.js';
+import { renderDeviceSessionAIInline } from './light-device-ai-analysis.js';
+import { configureLightSessionsView } from './light-sessions-view.js';
+
+configureLightSessionsView({
+  channelDisplay: CHANNEL_DISPLAY,
+  channelTier,
+  deleteDeviceSession: deleteDeviceSessionWithConfirm,
+  formatChannelUnit,
+  getDeviceSessions,
+  getDevices,
+  getSessions,
+  openDeviceSessionDetail,
+  renderDeviceSessionAIInline,
+  renderSunSessionRow,
+});

--- a/js/light-sessions-view.js
+++ b/js/light-sessions-view.js
@@ -9,6 +9,51 @@ const LIGHT_SESSION_ID_ATTR = 'data-light-session-id';
 const LIGHT_SESSIONS_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightSessionsActionDelegatesInstalled');
 const lightSessionsActionDelegateRoots = new WeakSet();
 
+/**
+ * @typedef {object} LightSessionsViewDeps
+ * @property {() => any[]} getSessions
+ * @property {() => any[]} getDeviceSessions
+ * @property {() => any[]} getDevices
+ * @property {(sess: any) => string} renderSunSessionRow
+ * @property {(sess: any) => string} renderDeviceSessionAIInline
+ * @property {(id: string) => void | Promise<any>} openDeviceSessionDetail
+ * @property {(id: string) => void | Promise<any>} deleteDeviceSession
+ * @property {Record<string, any>} channelDisplay
+ * @property {(value: number, key: string) => number} channelTier
+ * @property {(key: string, value: number, durationMin?: number, fitzpatrick?: string, uvi?: any, zenith?: any, rotatedSides?: boolean, bodyFraction?: any) => string} formatChannelUnit
+ * @property {(type: string, listener: EventListener) => void} addEventListener
+ * @property {(type: string, listener: EventListener) => void} removeEventListener
+ */
+
+/** @type {LightSessionsViewDeps} */
+const viewDeps = {
+  getSessions: () => [],
+  getDeviceSessions: () => [],
+  getDevices: () => [],
+  renderSunSessionRow: () => '',
+  renderDeviceSessionAIInline: () => '',
+  openDeviceSessionDetail: () => {},
+  deleteDeviceSession: () => {},
+  channelDisplay: {},
+  channelTier: () => 0,
+  formatChannelUnit: () => '',
+  addEventListener: (type, listener) => {
+    if (typeof globalThis !== 'undefined' && typeof globalThis.addEventListener === 'function') {
+      globalThis.addEventListener(type, listener);
+    }
+  },
+  removeEventListener: (type, listener) => {
+    if (typeof globalThis !== 'undefined' && typeof globalThis.removeEventListener === 'function') {
+      globalThis.removeEventListener(type, listener);
+    }
+  },
+};
+
+/** @param {Partial<LightSessionsViewDeps>} [deps] */
+export function configureLightSessionsView(deps = {}) {
+  Object.assign(viewDeps, deps);
+}
+
 function closestLightSessionsAction(target) {
   if (!target || !target.closest) return null;
   return target.closest(`[${LIGHT_SESSIONS_ACTION_ATTR}]`);
@@ -19,15 +64,14 @@ function handleLightSessionsActionClick(event) {
   if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
   const action = actionEl.getAttribute(LIGHT_SESSIONS_ACTION_ATTR);
   const sessionId = actionEl.getAttribute(LIGHT_SESSION_ID_ATTR) || '';
-  const appWindow = /** @type {any} */ (window);
   if (action === 'open-device-session') {
-    if (sessionId) appWindow.openDeviceSessionDetail?.(sessionId);
+    if (sessionId) viewDeps.openDeviceSessionDetail(sessionId);
     event.stopPropagation();
     return;
   }
   if (action === 'delete-device-session') {
     event.stopPropagation();
-    if (sessionId) appWindow.deleteDeviceSession?.(sessionId);
+    if (sessionId) viewDeps.deleteDeviceSession(sessionId);
     return;
   }
   if (action === 'show-all') {
@@ -71,10 +115,10 @@ function _collectUnifiedSessionRows() {
   // Active sun session is pinned at the top of the page (showLight
   // renders it before the quicklog row), so filter it out of the
   // historical-sessions list to avoid the same row appearing twice.
-  const sunSessions = ((window.getSessions && window.getSessions()) || []).filter(s => !!s.endedAt);
+  const sunSessions = viewDeps.getSessions().filter(s => !!s.endedAt);
   // Active device sessions are pinned above (renderActiveDeviceSessionCard);
   // filter them out here so the same row doesn't render twice.
-  const devSessions = ((window.getDeviceSessions && window.getDeviceSessions()) || []).filter(s => !!s.endedAt);
+  const devSessions = viewDeps.getDeviceSessions().filter(s => !!s.endedAt);
   const rows = [];
   for (const s of sunSessions) rows.push({ kind: 'sun', startedAt: s.startedAt || 0, sess: s });
   for (const s of devSessions) rows.push({ kind: 'device', startedAt: s.startedAt || 0, sess: s });
@@ -84,9 +128,9 @@ function _collectUnifiedSessionRows() {
 
 function _renderLightSessionChannelChips(doses, durationMin = 0) {
   if (!doses) return '';
-  const ch = window.CHANNEL_DISPLAY || {};
-  const tier = window.channelTier || (() => 0);
-  const formatUnit = window.formatChannelUnit || (() => '');
+  const ch = viewDeps.channelDisplay || {};
+  const tier = viewDeps.channelTier;
+  const formatUnit = viewDeps.formatChannelUnit;
   const order = ['vitamin_d', 'pomc', 'no_cv', 'violet_eye', 'circadian', 'nir_solar', 'pbm_red', 'pbm_nir'];
   const ranked = order
     .map(key => ({ key, v: doses[key] || 0, tier: tier(doses[key] || 0, key) }))
@@ -109,9 +153,9 @@ function _renderLightSessionChannelChips(doses, durationMin = 0) {
 }
 
 function _renderSessionRowsHTML(rows) {
-  const devices = (window.getDevices && window.getDevices()) || [];
+  const devices = viewDeps.getDevices();
   const deviceById = Object.fromEntries(devices.map(d => [d.id, d]));
-  const renderSunRow = window.renderSunSessionRow;
+  const renderSunRow = viewDeps.renderSunSessionRow;
   let html = '';
   for (const row of rows) {
     if (row.kind === 'sun' && renderSunRow) {
@@ -152,7 +196,7 @@ function _renderSessionRowsHTML(rows) {
         </div>
         <div class="sun-session-meta">${escapeHTML(meta)}</div>
         ${_renderLightSessionChannelChips(sess.doses, sess.durationMin || 0)}
-        ${window.renderDeviceSessionAIInline ? window.renderDeviceSessionAIInline(sess) : ''}
+        ${viewDeps.renderDeviceSessionAIInline(sess)}
       </div>`;
     }
   }
@@ -242,9 +286,9 @@ export function _openAllSessionsModal() {
   };
   _detach = () => {
     detachSyncRefresh();
-    window.removeEventListener('labcharts-ai-verdict-updated', onVerdictRefresh);
+    viewDeps.removeEventListener('labcharts-ai-verdict-updated', onVerdictRefresh);
   };
-  window.addEventListener('labcharts-ai-verdict-updated', onVerdictRefresh);
+  viewDeps.addEventListener('labcharts-ai-verdict-updated', onVerdictRefresh);
   const eventElement = (target) => {
     if (!target) return null;
     if (target.closest) return target;

--- a/js/light-sessions-view.js
+++ b/js/light-sessions-view.js
@@ -158,7 +158,7 @@ function _renderSessionRowsHTML(rows) {
   const renderSunRow = viewDeps.renderSunSessionRow;
   let html = '';
   for (const row of rows) {
-    if (row.kind === 'sun' && renderSunRow) {
+    if (row.kind === 'sun') {
       html += renderSunRow(row.sess);
     } else if (row.kind === 'device') {
       const sess = row.sess;

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1320,
+  "windowReferences": 1306,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -187,6 +187,7 @@ const APP_SHELL = [
   '/js/light-page-view.js',
   '/js/light-channel-view.js',
   '/js/light-sessions-view.js',
+  '/js/light-sessions-view-hooks.js',
   '/js/compare-correlations.js',
   '/js/mobile-dashboard.js',
   '/js/views.js',

--- a/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
+++ b/tests/playwright/light-sessions-view-edge-browser-coverage.spec.js
@@ -13,34 +13,36 @@ test('light sessions view edge coverage handles empty and compact device history
     const outcomes = {};
     const calls = [];
     const base = Date.UTC(2026, 5, 10, 10, 0);
-    const saved = {
-      getSessions: window.getSessions,
-      getDeviceSessions: window.getDeviceSessions,
-      getDevices: window.getDevices,
-      renderSunSessionRow: window.renderSunSessionRow,
-      openDeviceSessionDetail: window.openDeviceSessionDetail,
-      deleteDeviceSession: window.deleteDeviceSession,
-      renderDeviceSessionAIInline: window.renderDeviceSessionAIInline,
-      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
-      channelTier: window.channelTier,
-      formatChannelUnit: window.formatChannelUnit,
-    };
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const resetDeps = () => sessionsView.configureLightSessionsView({
+      getSessions: () => [],
+      getDeviceSessions: () => [],
+      getDevices: () => [],
+      renderSunSessionRow: () => '',
+      openDeviceSessionDetail: () => {},
+      deleteDeviceSession: () => {},
+      renderDeviceSessionAIInline: () => '',
+      channelDisplay: {},
+      channelTier: () => 0,
+      formatChannelUnit: () => '',
+    });
 
     try {
-      window.getSessions = () => [];
-      window.getDeviceSessions = () => [];
-      window.getDevices = () => [];
-      window.renderSunSessionRow = sess => `<div class="sun-session light-session-row light-session-sun" data-id="${sess.id}" role="button">${sess.id}</div>`;
-      window.openDeviceSessionDetail = id => calls.push(['detail', id]);
-      window.deleteDeviceSession = id => calls.push(['delete', id]);
-      window.renderDeviceSessionAIInline = sess => `<span class="ai-inline">AI ${sess.id}</span>`;
-      window.CHANNEL_DISPLAY = {
-        pbm_red: { icon: 'R', label: 'Red <unsafe>', what: 'Red channel' },
-        pbm_nir: { icon: 'N', label: 'NIR', what: 'Near infrared' },
-      };
-      window.channelTier = (value, key) => key === 'pbm_nir' && value > 0 ? 3 : 0;
-      window.formatChannelUnit = (key, value) => `${Math.round(value)} ${key}`;
+      sessionsView.configureLightSessionsView({
+        getSessions: () => [],
+        getDeviceSessions: () => [],
+        getDevices: () => [],
+        renderSunSessionRow: sess => `<div class="sun-session light-session-row light-session-sun" data-id="${sess.id}" role="button">${sess.id}</div>`,
+        openDeviceSessionDetail: id => calls.push(['detail', id]),
+        deleteDeviceSession: id => calls.push(['delete', id]),
+        renderDeviceSessionAIInline: sess => `<span class="ai-inline">AI ${sess.id}</span>`,
+        channelDisplay: {
+          pbm_red: { icon: 'R', label: 'Red <unsafe>', what: 'Red channel' },
+          pbm_nir: { icon: 'N', label: 'NIR', what: 'Near infrared' },
+        },
+        channelTier: (value, key) => key === 'pbm_nir' && value > 0 ? 3 : 0,
+        formatChannelUnit: (key, value) => `${Math.round(value)} ${key}`,
+      });
 
       outcomes.emptyInlineReturnsBlank = sessionsView.renderUnifiedSessionsList() === '';
       sessionsView._openAllSessionsModal();
@@ -50,53 +52,57 @@ test('light sessions view edge coverage handles empty and compact device history
         && overlay?.querySelectorAll('.sun-session').length === 0;
       overlay?.remove();
 
-      window.getSessions = () => [
-        { id: 'sun-only-a', startedAt: base - 60000, endedAt: base, durationMin: 10 },
-        { id: 'sun-active', startedAt: base + 1000, endedAt: null, durationMin: 0 },
-      ];
-      window.getDeviceSessions = () => [];
+      sessionsView.configureLightSessionsView({
+        getSessions: () => [
+          { id: 'sun-only-a', startedAt: base - 60000, endedAt: base, durationMin: 10 },
+          { id: 'sun-active', startedAt: base + 1000, endedAt: null, durationMin: 0 },
+        ],
+        getDeviceSessions: () => [],
+      });
       const sunOnlyHost = document.createElement('div');
       sunOnlyHost.innerHTML = sessionsView.renderUnifiedSessionsList();
       outcomes.sunOnlyInlineHasNoUnifiedClassOrShowMore = sunOnlyHost.querySelectorAll('.sun-session').length === 1
         && !sunOnlyHost.querySelector('.light-sessions-list-unified')
         && !sunOnlyHost.querySelector('.light-sessions-show-more');
 
-      window.getSessions = () => [];
-      window.getDevices = () => [{
-        id: 'panel-a',
-        brand: 'Panel <Co>',
-        model: 'Red & NIR',
-        modes: [
-          { id: 'red', label: 'Red only', default: true },
-          { id: 'nir', label: 'NIR boost' },
+      sessionsView.configureLightSessionsView({
+        getSessions: () => [],
+        getDevices: () => [{
+          id: 'panel-a',
+          brand: 'Panel <Co>',
+          model: 'Red & NIR',
+          modes: [
+            { id: 'red', label: 'Red only', default: true },
+            { id: 'nir', label: 'NIR boost' },
+          ],
+        }],
+        getDeviceSessions: () => [
+          {
+            id: 'dev-nir',
+            deviceId: 'panel-a',
+            startedAt: base,
+            endedAt: base + 60000,
+            durationMin: 9.6,
+            distanceCm: 18,
+            bodyArea: 'hands',
+            eyesProtected: true,
+            doses: { pbm_red: 0, pbm_nir: 4.2 },
+            mode: 'nir',
+          },
+          {
+            id: 'dev-removed',
+            deviceId: 'missing-panel',
+            startedAt: base - 60000,
+            endedAt: base,
+            durationMin: 0,
+            distanceCm: 30,
+            bodyArea: '',
+            eyesProtected: false,
+            doses: {},
+          },
+          { id: 'dev-active', deviceId: 'panel-a', startedAt: base + 1000, endedAt: null },
         ],
-      }];
-      window.getDeviceSessions = () => [
-        {
-          id: 'dev-nir',
-          deviceId: 'panel-a',
-          startedAt: base,
-          endedAt: base + 60000,
-          durationMin: 9.6,
-          distanceCm: 18,
-          bodyArea: 'hands',
-          eyesProtected: true,
-          doses: { pbm_red: 0, pbm_nir: 4.2 },
-          mode: 'nir',
-        },
-        {
-          id: 'dev-removed',
-          deviceId: 'missing-panel',
-          startedAt: base - 60000,
-          endedAt: base,
-          durationMin: 0,
-          distanceCm: 30,
-          bodyArea: '',
-          eyesProtected: false,
-          doses: {},
-        },
-        { id: 'dev-active', deviceId: 'panel-a', startedAt: base + 1000, endedAt: null },
-      ];
+      });
       const mixedHost = document.createElement('div');
       mixedHost.innerHTML = sessionsView.renderUnifiedSessionsList();
       sessionsView.installLightSessionsActionDelegates(mixedHost);
@@ -132,7 +138,7 @@ test('light sessions view edge coverage handles empty and compact device history
       outcomes.modalEnterClosesAfterOpeningDetail = !document.body.contains(overlay)
         && calls.filter(call => call[0] === 'detail' && call[1] === 'dev-nir').length === detailCallsBeforeModalEnter + 1;
     } finally {
-      Object.assign(window, saved);
+      resetDeps();
       document.querySelectorAll('.light-sessions-modal-overlay').forEach(el => el.remove());
     }
 

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -497,18 +497,18 @@ test('light sessions view covers all-sessions modal refresh scroll and row event
     const calls = [];
     const base = Date.UTC(2026, 5, 7, 12, 0);
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-    const saved = {
-      getSessions: window.getSessions,
-      getDeviceSessions: window.getDeviceSessions,
-      getDevices: window.getDevices,
-      renderSunSessionRow: window.renderSunSessionRow,
-      openDeviceSessionDetail: window.openDeviceSessionDetail,
-      deleteDeviceSession: window.deleteDeviceSession,
-      renderDeviceSessionAIInline: window.renderDeviceSessionAIInline,
-      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
-      channelTier: window.channelTier,
-      formatChannelUnit: window.formatChannelUnit,
-    };
+    const resetDeps = () => sessionsView.configureLightSessionsView({
+      getSessions: () => [],
+      getDeviceSessions: () => [],
+      getDevices: () => [],
+      renderSunSessionRow: () => '',
+      openDeviceSessionDetail: () => {},
+      deleteDeviceSession: () => {},
+      renderDeviceSessionAIInline: () => '',
+      channelDisplay: {},
+      channelTier: () => 0,
+      formatChannelUnit: () => '',
+    });
 
     let sunSessions = [
       { id: 'sun-a', startedAt: base - 60000, endedAt: base, durationMin: 15, doses: { vitamin_d: 2 } },
@@ -522,26 +522,28 @@ test('light sessions view covers all-sessions modal refresh scroll and row event
     ];
 
     try {
-      window.getSessions = () => sunSessions;
-      window.getDeviceSessions = () => deviceSessions;
-      window.getDevices = () => [{
-        id: 'panel-a',
-        brand: 'PanelCo',
-        model: 'Red 900',
-        modes: [{ id: 'red', label: 'Red only', default: true }, { id: 'nir', label: 'NIR' }],
-      }];
-      window.CHANNEL_DISPLAY = {
-        pbm_red: { icon: 'R', label: 'Red', what: 'Red light' },
-        pbm_nir: { icon: 'N', label: 'NIR', what: 'Near infrared' },
-      };
-      window.channelTier = value => value > 0 ? 2 : 0;
-      window.formatChannelUnit = (key, value) => `${Math.round(value)} ${key}`;
-      window.renderSunSessionRow = sess => `<div class="sun-session light-session-row light-session-sun" data-id="${sess.id}" role="button" tabindex="0" aria-label="Sun ${sess.id}">
-        <div class="sun-session-head"><span class="sun-session-date">${sess.id}</span></div>
-      </div>`;
-      window.openDeviceSessionDetail = id => calls.push(['detail', id]);
-      window.deleteDeviceSession = id => calls.push(['delete', id]);
-      window.renderDeviceSessionAIInline = sess => `<span class="ai-inline">AI ${sess.id}</span>`;
+      sessionsView.configureLightSessionsView({
+        getSessions: () => sunSessions,
+        getDeviceSessions: () => deviceSessions,
+        getDevices: () => [{
+          id: 'panel-a',
+          brand: 'PanelCo',
+          model: 'Red 900',
+          modes: [{ id: 'red', label: 'Red only', default: true }, { id: 'nir', label: 'NIR' }],
+        }],
+        channelDisplay: {
+          pbm_red: { icon: 'R', label: 'Red', what: 'Red light' },
+          pbm_nir: { icon: 'N', label: 'NIR', what: 'Near infrared' },
+        },
+        channelTier: value => value > 0 ? 2 : 0,
+        formatChannelUnit: (key, value) => `${Math.round(value)} ${key}`,
+        renderSunSessionRow: sess => `<div class="sun-session light-session-row light-session-sun" data-id="${sess.id}" role="button" tabindex="0" aria-label="Sun ${sess.id}">
+          <div class="sun-session-head"><span class="sun-session-date">${sess.id}</span></div>
+        </div>`,
+        openDeviceSessionDetail: id => calls.push(['detail', id]),
+        deleteDeviceSession: id => calls.push(['delete', id]),
+        renderDeviceSessionAIInline: sess => `<span class="ai-inline">AI ${sess.id}</span>`,
+      });
 
       const inlineHost = document.createElement('div');
       inlineHost.innerHTML = sessionsView.renderUnifiedSessionsList();
@@ -604,7 +606,7 @@ test('light sessions view covers all-sessions modal refresh scroll and row event
       await delay(0);
       outcomes.deviceRowKeyboardClosesModal = !document.body.contains(overlay);
     } finally {
-      Object.assign(window, saved);
+      resetDeps();
       document.querySelectorAll('.light-sessions-modal-overlay').forEach(el => el.remove());
     }
 

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
+const appLightSunModulesSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
 const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
 const chatImagesSrc = fs.readFileSync(path.join(root, 'js/chat-images.js'), 'utf8');
 const chatSummariesSrc = fs.readFileSync(path.join(root, 'js/chat-summaries.js'), 'utf8');
@@ -24,6 +25,7 @@ const lightDeviceSessionModalSrc = fs.readFileSync(path.join(root, 'js/light-dev
 const lightDeviceSetupModalSrc = fs.readFileSync(path.join(root, 'js/light-device-setup-modal.js'), 'utf8');
 const lightDevicesSrc = fs.readFileSync(path.join(root, 'js/light-devices.js'), 'utf8');
 const lightEnvSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
+const lightSessionsViewHooksSrc = fs.readFileSync(path.join(root, 'js/light-sessions-view-hooks.js'), 'utf8');
 const lightSessionsViewSrc = fs.readFileSync(path.join(root, 'js/light-sessions-view.js'), 'utf8');
 const lightToolCameraModalsSrc = fs.readFileSync(path.join(root, 'js/light-tool-camera-modals.js'), 'utf8');
 const lightToolsSrc = fs.readFileSync(path.join(root, 'js/light-tools.js'), 'utf8');
@@ -40,6 +42,7 @@ const recommendationActionsSrc = fs.readFileSync(path.join(root, 'js/recommendat
 const recommendationsSrc = fs.readFileSync(path.join(root, 'js/recommendations.js'), 'utf8');
 const settingsSrc = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const settingsSyncPanelSrc = fs.readFileSync(path.join(root, 'js/settings-sync-panel.js'), 'utf8');
+const serviceWorkerSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const supplementsSrc = fs.readFileSync(path.join(root, 'js/supplements.js'), 'utf8');
 const sunSrc = fs.readFileSync(path.join(root, 'js/sun.js'), 'utf8');
 const sunActiveSessionSrc = fs.readFileSync(path.join(root, 'js/sun-active-session.js'), 'utf8');
@@ -291,6 +294,16 @@ assert('light device and session modals use shared overlay lifecycle helpers',
         !src.includes('overlay.remove()') &&
         !src.includes('wireBackdropClose') &&
         !src.includes('trapModalFocus')));
+
+assert('light sessions view runtime dependencies are startup-wired',
+  lightSessionsViewSrc.includes('export function configureLightSessionsView') &&
+    !lightSessionsViewSrc.includes('window.') &&
+    lightDevicesSrc.includes('export async function deleteDeviceSessionWithConfirm') &&
+    lightSessionsViewHooksSrc.includes("import { CHANNEL_DISPLAY, channelTier, formatChannelUnit, getSessions } from './sun.js';") &&
+    lightSessionsViewHooksSrc.includes("import { deleteDeviceSessionWithConfirm, openDeviceSessionDetail } from './light-devices.js';") &&
+    lightSessionsViewHooksSrc.includes('configureLightSessionsView({') &&
+    appLightSunModulesSrc.includes("import './light-sessions-view-hooks.js';") &&
+    serviceWorkerSrc.includes("'/js/light-sessions-view-hooks.js'"));
 
 assert('sun session and setup modals use shared overlay lifecycle helpers',
   sunSrc.includes('openAppendedModalOverlay') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.533';
+self.APP_VERSION = '1.8.534';


### PR DESCRIPTION
## Summary
- Move Light Sessions View session getters, render callbacks, channel helpers, and device actions behind `configureLightSessionsView`
- Add a startup hook that wires the real Sun/device/session dependencies and cache it in the service worker
- Export the existing confirmed device-session delete wrapper so injected delete behavior matches the former window facade
- Ratchet the window-reference baseline from 1320 to 1306 and bump the app version

## Validation
- `npm run typecheck`
- `npm run quality`
- `node tests/test-modal-lifecycle-integrations.js`
- `npm run test:playwright -- tests/playwright/light-sessions-view-edge-browser-coverage.spec.js tests/playwright/modal-session-coverage-batch.spec.js`
- `./run-tests.sh`

Note: `node tests/verify-modules.js` is not a valid direct Node invocation; it expects the browser/document harness.