### PR TITLE
[codex] Wire Light page runtime deps through startup

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -24,3 +24,4 @@ import './sun-onboarding-ai.js';
 import './light-ai-save-hooks.js';
 import './sun-correlations.js';
 import './light-today-ai.js';
+import './light-page-view-hooks.js';

--- a/js/app-ui-shell-modules.js
+++ b/js/app-ui-shell-modules.js
@@ -6,5 +6,6 @@ import './tour.js';
 import './touch-tooltip.js';
 import './client-list.js';
 import './views.js';
+import './light-page-view-ui-hooks.js';
 import './light-tools-ui-hooks.js';
 import './sun-session-ui-hooks.js';

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -110,7 +110,7 @@ function _wireModal(overlay, closeFn) {
   openAppendedModalOverlay(overlay, closeFn);
 }
 
-async function loadPresets() {
+export async function loadLightDevicePresets() {
   if (_PRESETS) return { presets: _PRESETS, types: _PRESET_TYPES };
   try {
     const res = await fetch('data/light-device-presets.json');
@@ -127,7 +127,7 @@ async function loadPresets() {
 // ─── Public API ────────────────────────────────────────────────────────
 
 export async function addDeviceFromPreset(presetId, overrides = {}) {
-  const { presets } = await loadPresets();
+  const { presets } = await loadLightDevicePresets();
   const preset = presets.find(p => p.id === presetId);
   return addDeviceFromPresetRecord(preset, overrides);
 }
@@ -138,7 +138,7 @@ export async function addDeviceFromPreset(presetId, overrides = {}) {
 // once at boot so existing localStorage devices light up the mode picker
 // without requiring re-add.
 export async function hydrateDevicesFromPresets() {
-  const { presets } = await loadPresets();
+  const { presets } = await loadLightDevicePresets();
   return hydrateDevicesFromPresetRecords(presets);
 }
 
@@ -537,7 +537,7 @@ export async function renderDevicesSection() {
   } catch { /* offline / 404 — page still renders without affiliate row */ }
   let typesMeta = {};
   try {
-    const presetData = await loadPresets();
+    const presetData = await loadLightDevicePresets();
     typesMeta = presetData.types || {};
   } catch { /* presets file unreachable; fallback uses raw type strings */ }
 
@@ -668,7 +668,7 @@ function _relativeTimeShort(ts) {
 }
 
 configureLightDeviceSetup({
-  loadPresets,
+  loadPresets: loadLightDevicePresets,
   addDeviceFromPreset,
   addCustomDevice,
   wireModal: _wireModal,
@@ -758,7 +758,7 @@ export async function deleteDeviceSessionWithConfirm(id) {
 
 if (typeof window !== 'undefined') {
   Object.assign(window, {
-    loadLightDevicePresets: loadPresets,
+    loadLightDevicePresets,
     getDevices,
     getDeviceSessions,
     addDeviceFromPreset,

--- a/js/light-page-view-hooks.js
+++ b/js/light-page-view-hooks.js
@@ -1,0 +1,76 @@
+// @ts-check
+// light-page-view-hooks.js - wire Light page feature dependencies at startup.
+
+import { loadCatalog, renderChannelDeficitDeviceRecs } from './recommendations.js';
+import {
+  CHANNEL_DISPLAY,
+  channelTier,
+  cumulativeMEDToday,
+  cumulativeMEDYesterday,
+  getActiveSession,
+  getSessions,
+  getSunCoords,
+  openDetailedSessionDialog,
+  quickLogSunSession,
+  requestPreciseLocation,
+  renderSunSessionRow,
+  rollingChannelTotals,
+  rollingVitaminDIU,
+  vitaminDBudgetStatus,
+  weeklyChannelTier,
+} from './sun.js';
+import { resumeActiveTickerIfNeeded } from './sun-active-session.js';
+import { renderSetupCard as renderSunSetupCard } from './sun-defaults.js';
+import { _openChannelOnLightPage } from './light-channel-view.js';
+import {
+  ensureActiveDeviceTicker,
+  loadLightDevicePresets,
+  openAddDeviceDialog,
+  quickLogDeviceSession,
+  renderActiveDeviceSessionCard,
+  renderDevicesSection,
+} from './light-devices.js';
+import { getDeviceSessions, getDevices, rollingDeviceTotals } from './light-devices-store.js';
+import { openLightEnvironmentAssessment, renderEnvironmentAssessmentSummary } from './light-env.js';
+import { renderLightTools } from './light-tools.js';
+import { renderChannelMixVerdict } from './light-channels-ai-analysis.js';
+import { renderLightTodayDashboardChip, renderLightTodayHero } from './light-today-ai.js';
+import { configureLightPageView } from './light-page-view.js';
+
+configureLightPageView({
+  channelDisplay: CHANNEL_DISPLAY,
+  channelTier,
+  cumulativeMEDToday,
+  cumulativeMEDYesterday,
+  ensureActiveDeviceTicker,
+  getActiveSession,
+  getDeviceSessions,
+  getDevices,
+  getSessions,
+  getSunCoords,
+  loadCatalog,
+  loadLightDevicePresets,
+  openAddDeviceDialog,
+  openChannelOnLightPage: _openChannelOnLightPage,
+  openDetailedSessionDialog,
+  openLightEnvironmentAssessment,
+  quickLogDeviceSession,
+  quickLogSunSession,
+  renderActiveDeviceSessionCard,
+  renderChannelDeficitDeviceRecs,
+  renderChannelMixVerdict,
+  renderDevicesSection,
+  renderEnvironmentAssessmentSummary,
+  renderLightTodayDashboardChip,
+  renderLightTodayHero,
+  renderLightTools,
+  renderSunSessionRow,
+  renderSunSetupCard,
+  requestPreciseLocation,
+  resumeActiveTickerIfNeeded,
+  rollingChannelTotals,
+  rollingDeviceTotals,
+  rollingVitaminDIU,
+  vitaminDBudgetStatus,
+  weeklyChannelTier,
+});

--- a/js/light-page-view-ui-hooks.js
+++ b/js/light-page-view-ui-hooks.js
@@ -1,0 +1,11 @@
+// @ts-check
+// light-page-view-ui-hooks.js - wire Light page shell dependencies after UI modules load.
+
+import { renderSunDataSourceSettings } from './settings.js';
+import { navigate } from './views.js';
+import { configureLightPageView } from './light-page-view.js';
+
+configureLightPageView({
+  navigate,
+  renderSunDataSourceSettings,
+});

--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -15,6 +15,52 @@ import {
   renderSuggestion,
 } from './light-channel-view.js';
 
+/** @type {Record<string, any>} */
+const lightPageDeps = {
+  channelDisplay: {},
+  weeklyChannelTier: () => 0,
+  channelTier: () => 0,
+  getSessions: () => [],
+  getDevices: () => [],
+  getDeviceSessions: () => [],
+  getActiveSession: () => null,
+  rollingChannelTotals: () => ({}),
+  rollingDeviceTotals: () => ({}),
+  cumulativeMEDToday: () => 0,
+  cumulativeMEDYesterday: () => 0,
+  rollingVitaminDIU: () => 0,
+  vitaminDBudgetStatus: () => null,
+  getSunCoords: () => null,
+  resumeActiveTickerIfNeeded: () => {},
+  ensureActiveDeviceTicker: () => {},
+  openChannelOnLightPage: () => {},
+  quickLogDeviceSession: () => {},
+  openAddDeviceDialog: () => {},
+  quickLogSunSession: () => {},
+  openDetailedSessionDialog: () => {},
+  navigate: () => {},
+  requestPreciseLocation: () => {},
+  openLightEnvironmentAssessment: () => {},
+  renderSunDataSourceSettings: () => '',
+  renderLightTodayDashboardChip: () => '',
+  renderLightTodayHero: () => '',
+  renderSunSessionRow: () => '',
+  renderActiveDeviceSessionCard: () => '',
+  renderSunSetupCard: () => '',
+  renderChannelMixVerdict: staticFallback => staticFallback,
+  renderChannelDeficitDeviceRecs: () => '',
+  loadCatalog: async () => null,
+  loadLightDevicePresets: async () => null,
+  renderDevicesSection: async () => '',
+  renderEnvironmentAssessmentSummary: () => '',
+  renderLightTools: () => '',
+};
+
+/** @param {Partial<typeof lightPageDeps>} [deps] */
+export function configureLightPageView(deps = {}) {
+  Object.assign(lightPageDeps, deps);
+}
+
 function closestLightPageAction(event) {
   const target = event.target;
   if (!(target instanceof Element)) return null;
@@ -32,21 +78,21 @@ function handleLightPageActionClick(event) {
   if (typeof HTMLAnchorElement !== 'undefined' && actionEl instanceof HTMLAnchorElement) event.preventDefault();
 
   if (action === 'open-channel') {
-    window._openChannelOnLightPage?.(actionEl.dataset.channel || '');
+    lightPageDeps.openChannelOnLightPage(actionEl.dataset.channel || '');
   } else if (action === 'quick-log-device') {
-    window.quickLogDeviceSession?.();
+    lightPageDeps.quickLogDeviceSession();
   } else if (action === 'open-add-device') {
-    window.openAddDeviceDialog?.();
+    lightPageDeps.openAddDeviceDialog();
   } else if (action === 'quick-log-sun') {
-    window.quickLogSunSession?.();
+    lightPageDeps.quickLogSunSession();
   } else if (action === 'open-detailed-session') {
-    window.openDetailedSessionDialog?.();
+    lightPageDeps.openDetailedSessionDialog();
   } else if (action === 'navigate-light') {
-    window.navigate?.('light');
+    lightPageDeps.navigate('light');
   } else if (action === 'request-precise-location') {
-    window.requestPreciseLocation?.();
+    lightPageDeps.requestPreciseLocation();
   } else if (action === 'open-light-environment') {
-    window.openLightEnvironmentAssessment?.();
+    lightPageDeps.openLightEnvironmentAssessment();
   } else if (action === 'expand-light-tools') {
     _expandLightToolsSection();
   }
@@ -66,13 +112,13 @@ if (typeof document !== 'undefined') installLightPageActionDelegates();
 // ═══════════════════════════════════════════════
 
 export function renderDashboardLightChannelPills() {
-  const ch = window.CHANNEL_DISPLAY || {};
+  const ch = lightPageDeps.channelDisplay || {};
   // Dashboard pills represent a 7-day rolling total; classify with the
   // weekly tier so optional Light widgets agree with the Light page pills.
-  const tier = window.weeklyChannelTier || (() => 0);
+  const tier = lightPageDeps.weeklyChannelTier || (() => 0);
   const order = ['vitamin_d', 'circadian', 'nir_solar', 'no_cv', 'pomc', 'violet_eye'];
-  const totals7d = (window.rollingChannelTotals && window.rollingChannelTotals(7)) || {};
-  const devTotals7d = (window.rollingDeviceTotals && window.rollingDeviceTotals(7)) || {};
+  const totals7d = lightPageDeps.rollingChannelTotals(7) || {};
+  const devTotals7d = lightPageDeps.rollingDeviceTotals(7) || {};
   const combinedTotals7d = mergeTotals(totals7d, devTotals7d);
   return `<div class="light-pills-row">
     ${order.map(k => {
@@ -91,9 +137,9 @@ export function renderDashboardLightChannelPills() {
 }
 
 export function renderLightSessionLogActions() {
-  const sessions = (window.getSessions && window.getSessions()) || [];
-  const devices = (window.getDevices && window.getDevices()) || [];
-  const deviceSessionsAll = (window.getDeviceSessions && window.getDeviceSessions()) || [];
+  const sessions = lightPageDeps.getSessions() || [];
+  const devices = lightPageDeps.getDevices() || [];
+  const deviceSessionsAll = lightPageDeps.getDeviceSessions() || [];
   const hasDevices = devices.length > 0;
   const totalSessions = sessions.length + deviceSessionsAll.length;
   const sunCount = sessions.length;
@@ -101,7 +147,7 @@ export function renderLightSessionLogActions() {
   const tallyDetail = (sunCount > 0 || devCount > 0)
     ? `${sunCount} sun + ${devCount} device`
     : '';
-  const sunActive = !!(window.getActiveSession && window.getActiveSession());
+  const sunActive = !!lightPageDeps.getActiveSession();
   let ctaButtons = '';
   if (sunActive) {
     // Stop controls live in the pinned active-session card; this widget keeps
@@ -149,23 +195,24 @@ function renderLightMethodsWidgetBody() {
       <p><strong>Want the math?</strong> See <a href="https://github.com/elkimek/get-based/blob/main/dev-docs/sun-spectrum-model.md" target="_blank" rel="noopener">the contributor doc</a> for the Bird-Riordan reconstruction, action-spectrum table, and per-channel citations.</p>
     </div>
   </details>`;
-  if (typeof window !== 'undefined' && typeof window.renderSunDataSourceSettings === 'function') {
+  const dataSourceSettings = lightPageDeps.renderSunDataSourceSettings();
+  if (dataSourceSettings) {
     html += `<details class="light-data-source-details">
       <summary>Sun data source</summary>
-      <div class="light-data-source-body">${window.renderSunDataSourceSettings()}</div>
+      <div class="light-data-source-body">${dataSourceSettings}</div>
     </details>`;
   }
   return `<div class="light-methods-stack">${html}</div>`;
 }
 
 export function renderLightTodayStrip() {
-  const sessions = (window.getSessions && window.getSessions()) || [];
+  const sessions = lightPageDeps.getSessions() || [];
   const inSolarWindow = isSolarWindow();
   // Always render — even a fresh user outside a solar window needs to see
   // that the Light lens exists. The CTA copy adapts to the situation.
 
-  const active = (window.getActiveSession && window.getActiveSession()) || null;
-  const medToday = (window.cumulativeMEDToday && window.cumulativeMEDToday()) || 0;
+  const active = lightPageDeps.getActiveSession() || null;
+  const medToday = lightPageDeps.cumulativeMEDToday() || 0;
 
   // CTA — adaptive to whether the user has therapy devices set up. A
   // winter user with a Joovv but no recent sun should see the device
@@ -175,7 +222,7 @@ export function renderLightTodayStrip() {
   // applies once to the GROUP — without the wrapper each individual
   // CTA's margin-left:auto pushed every button to the right edge,
   // spreading them apart instead of clustering them.
-  const devicesArr = (window.getDevices && window.getDevices()) || [];
+  const devicesArr = lightPageDeps.getDevices() || [];
   const hasDevices = devicesArr.length > 0;
   // Device button copy adapts to how many devices the user owns. With
   // 1 device, name it inline so the click goes straight to that
@@ -248,14 +295,14 @@ export function renderLightTodayStrip() {
   // its window (it was actually counting all-time sun sessions).
   const weekCutoff = Date.now() - 7 * 86400 * 1000;
   const sunWeek = sessions.filter(s => (s.startedAt || 0) >= weekCutoff).length;
-  const devSessionsAll = (window.getDeviceSessions && window.getDeviceSessions()) || [];
+  const devSessionsAll = lightPageDeps.getDeviceSessions() || [];
   const devWeek = devSessionsAll.filter(s => (s.startedAt || 0) >= weekCutoff).length;
   const weekTotal = sunWeek + devWeek;
   // Rolling 7-day vitamin D total in IU — sums per-session yields with
   // each session's 20k saturation cap, so a week of three good sessions
   // doesn't get clipped to one session's maximum. Hidden when the total
   // is essentially zero (cloudy week / no UVB exposure / device-only).
-  const weeklyIU = (window.rollingVitaminDIU && window.rollingVitaminDIU(7)) || 0;
+  const weeklyIU = lightPageDeps.rollingVitaminDIU(7) || 0;
   let weeklyIUStr = '';
   if (weeklyIU >= 100) {
     // Surface the same uncertainty band as session detail. The weekly
@@ -276,8 +323,8 @@ export function renderLightTodayStrip() {
   // context — clinicians treating high serum 25(OH)D look at total daily
   // input.
   let vitDBudgetChip = '';
-  if (typeof window.vitaminDBudgetStatus === 'function') {
-    const b = window.vitaminDBudgetStatus();
+  const b = lightPageDeps.vitaminDBudgetStatus();
+  if (b) {
     const fmtIU = (n) => n >= 1000 ? `${(n/1000).toFixed(1).replace(/\.0$/, '')}k` : `${Math.round(n)}`;
     if (b.exceedsSupplementUL) {
       vitDBudgetChip = `<span class="light-today-vitd-warn" title="IOM 2010 Tolerable Upper Intake Level for vitamin D from supplements alone is 4000 IU/d. Today: ${fmtIU(b.supplementIU)} IU supplement + ~${fmtIU(b.sunIU)} IU sun = ~${fmtIU(b.total)} IU total. Supplement above UL — flag this with your clinician.">⚠ Vit D today: ${fmtIU(b.supplementIU)} IU supplement above 4000 IU UL (+${fmtIU(b.sunIU)} sun)</span>`;
@@ -289,7 +336,7 @@ export function renderLightTodayStrip() {
   // High-altitude UV chip — UV irradiance climbs ~10% per 1000m above sea
   // level (WHO/INTERSUN). At >1500m it's a meaningful safety modifier the
   // user should see before going outside.
-  const altCoords = (window.getSunCoords && window.getSunCoords()) || null;
+  const altCoords = lightPageDeps.getSunCoords() || null;
   const altM = altCoords?.altitudeM || 0;
   const altChip = altM > 1500
     ? `<span class="light-today-altitude" title="UV irradiance climbs ~10% per 1000m above sea level. At ${Math.round(altM)}m, expect ~${Math.round((altM / 1000) * 10)}% more UV than sea-level estimates.">⛰ +${Math.round((altM / 1000) * 10)}% UV (altitude ${Math.round(altM)}m)</span>`
@@ -302,7 +349,7 @@ export function renderLightTodayStrip() {
       ${altChip}
       <a href="#" class="light-today-link" data-light-page-action="navigate-light">Open Light &amp; Sun →</a>
     </div>
-    ${typeof window !== 'undefined' && window.renderLightTodayDashboardChip ? window.renderLightTodayDashboardChip() : ''}
+    ${lightPageDeps.renderLightTodayDashboardChip() || ''}
     ${renderConditionsNow({ variant: 'compact' })}
     ${renderDashboardLightChannelPills()}
     ${weeklyIUStr || vitDBudgetChip ? `<div class="light-today-vitd-row">${weeklyIUStr}${vitDBudgetChip ? ' ' + vitDBudgetChip : ''}</div>` : ''}
@@ -323,10 +370,10 @@ export function renderLightTodayStrip() {
 export function renderLightChannelsLive() {
   const section = document.querySelector('.light-channels-section');
   if (!section) return;
-  const totals7d = (window.rollingChannelTotals && window.rollingChannelTotals(7)) || {};
-  const totals30d = (window.rollingChannelTotals && window.rollingChannelTotals(30)) || {};
-  const devTotals7d = (window.rollingDeviceTotals && window.rollingDeviceTotals(7)) || {};
-  const devTotals30d = (window.rollingDeviceTotals && window.rollingDeviceTotals(30)) || {};
+  const totals7d = lightPageDeps.rollingChannelTotals(7) || {};
+  const totals30d = lightPageDeps.rollingChannelTotals(30) || {};
+  const devTotals7d = lightPageDeps.rollingDeviceTotals(7) || {};
+  const devTotals30d = lightPageDeps.rollingDeviceTotals(30) || {};
   const combined7d = mergeTotals(totals7d, devTotals7d);
   const combined30d = mergeTotals(totals30d, devTotals30d);
   const row = section.querySelector('.light-pills-row');
@@ -367,14 +414,14 @@ export function showLight(_data) {
   // Resume the live-session ticker if a session was started before this
   // page loaded — without this, hard-reload while outside leaves the card
   // static until you explicitly tap something else.
-  if (window._resumeActiveTickerIfNeeded) try { window._resumeActiveTickerIfNeeded(); } catch (e) {}
-  if (window.ensureActiveDeviceTicker) try { window.ensureActiveDeviceTicker(); } catch (e) {}
+  try { lightPageDeps.resumeActiveTickerIfNeeded(); } catch (e) {}
+  try { lightPageDeps.ensureActiveDeviceTicker(); } catch (e) {}
   const main = document.getElementById("main-content");
-  const sessions = (window.getSessions && window.getSessions()) || [];
-  const totals7d = (window.rollingChannelTotals && window.rollingChannelTotals(7)) || {};
-  const totals30d = (window.rollingChannelTotals && window.rollingChannelTotals(30)) || {};
-  const medToday = (window.cumulativeMEDToday && window.cumulativeMEDToday()) || 0;
-  const deviceSessionsAll = (window.getDeviceSessions && window.getDeviceSessions()) || [];
+  const sessions = lightPageDeps.getSessions() || [];
+  const totals7d = lightPageDeps.rollingChannelTotals(7) || {};
+  const totals30d = lightPageDeps.rollingChannelTotals(30) || {};
+  const medToday = lightPageDeps.cumulativeMEDToday() || 0;
+  const deviceSessionsAll = lightPageDeps.getDeviceSessions() || [];
   const totalSessions = sessions.length + deviceSessionsAll.length;
   const sunCount = sessions.length;
   const widgets = [];
@@ -386,9 +433,9 @@ export function showLight(_data) {
   // environment + trends) into one read. Sits above active-session and
   // conditions so the user gets the "how am I doing?" answer before the
   // raw inputs.
-  if (typeof window !== 'undefined' && window.renderLightTodayHero) {
+  if (lightPageDeps.renderLightTodayHero) {
     try {
-      const todayBody = window.renderLightTodayHero() || '';
+      const todayBody = lightPageDeps.renderLightTodayHero() || '';
       if (todayBody) {
         widgets.push({
           id: 'light-today',
@@ -407,16 +454,16 @@ export function showLight(_data) {
   // first thing the user sees when a session is running. Renders above
   // Conditions / Setup / Stop CTA. Filtered out of the historical
   // sessions list further down so the same row doesn't render twice.
-  const _activeSunSess = (window.getActiveSession && window.getActiveSession()) || null;
+  const _activeSunSess = lightPageDeps.getActiveSession() || null;
   let activeSessionBody = '';
-  if (_activeSunSess && typeof window.renderSunSessionRow === 'function') {
-    activeSessionBody += `<div class="light-active-session-pinned" aria-label="Active sun session">${window.renderSunSessionRow(_activeSunSess)}</div>`;
+  if (_activeSunSess) {
+    activeSessionBody += `<div class="light-active-session-pinned" aria-label="Active sun session">${lightPageDeps.renderSunSessionRow(_activeSunSess)}</div>`;
   }
   // Same pattern for active device-therapy sessions (PBM panels, SAD
   // lamps, dawn simulators). Pinned above the conditions panel so the
   // stop button is always one tap away.
-  if (typeof window.renderActiveDeviceSessionCard === 'function') {
-    const _activeDevHtml = window.renderActiveDeviceSessionCard();
+  if (lightPageDeps.renderActiveDeviceSessionCard) {
+    const _activeDevHtml = lightPageDeps.renderActiveDeviceSessionCard();
     if (_activeDevHtml) {
       activeSessionBody += `<div class="light-active-session-pinned" aria-label="Active device session">${_activeDevHtml}</div>`;
     }
@@ -439,9 +486,7 @@ export function showLight(_data) {
   // when onboarding is incomplete or the user has reopened to edit, and a
   // compact "Light setup saved" summary with an Edit button otherwise.
   let setupHtml = '';
-  if (typeof window.renderSunSetupCard === 'function') {
-    try { setupHtml = window.renderSunSetupCard() || ''; } catch (_) {}
-  }
+  try { setupHtml = lightPageDeps.renderSunSetupCard() || ''; } catch (_) {}
   const conditionsBody = renderLightConditionsWidgetBody({ variant: 'full' });
   widgets.push({
     id: 'light-conditions-now',
@@ -478,8 +523,8 @@ export function showLight(_data) {
   let deficitRecSlotId = null;
 
   // Combine sun + device totals so channels reflect every light source
-  const devTotals7d = (window.rollingDeviceTotals && window.rollingDeviceTotals(7)) || {};
-  const devTotals30d = (window.rollingDeviceTotals && window.rollingDeviceTotals(30)) || {};
+  const devTotals7d = lightPageDeps.rollingDeviceTotals(7) || {};
+  const devTotals30d = lightPageDeps.rollingDeviceTotals(30) || {};
   const combined7d = mergeTotals(totals7d, devTotals7d);
   const combined30d = mergeTotals(totals30d, devTotals30d);
 
@@ -498,7 +543,7 @@ export function showLight(_data) {
   //   • At least one channel has a meaningful tier → invite drill-down
   //     with realistic copy
   const channelKeysOrdered = ['vitamin_d', 'circadian', 'nir_solar', 'no_cv', 'pomc', 'violet_eye'];
-  const _wkTier = window.weeklyChannelTier || window.channelTier || (() => 0);
+  const _wkTier = lightPageDeps.weeklyChannelTier || lightPageDeps.channelTier || (() => 0);
   const litChannels = channelKeysOrdered.filter(k => _wkTier(combined7d[k] || 0, k) > 0).length;
   let lead;
   if (isEmpty) {
@@ -530,7 +575,7 @@ export function showLight(_data) {
     // is part of the routine.
     if (sunCount > 0) {
       const medPct = Math.round(medToday * 100);
-      const medY = (window.cumulativeMEDYesterday && window.cumulativeMEDYesterday()) || 0;
+      const medY = lightPageDeps.cumulativeMEDYesterday() || 0;
       const combinedMED = medToday + medY;
       let medCls = 'ok', medTitle = 'Sun exposure today: safe', medMsg = 'You\'re well under your burn threshold.';
       if (medToday >= 1) { medCls = 'over'; medTitle = 'Burn threshold reached'; medMsg = 'You\'ve crossed your burn threshold for the day. Avoid more direct sun until tomorrow.'; }
@@ -560,9 +605,7 @@ export function showLight(_data) {
     // baseline content under the "Get AI synthesis" CTA before the
     // user has clicked it.
     const _staticSuggestion = renderSuggestion(combined7d);
-    guidanceBody += (typeof window !== 'undefined' && window.renderChannelMixVerdict)
-      ? window.renderChannelMixVerdict(_staticSuggestion)
-      : _staticSuggestion;
+    guidanceBody += lightPageDeps.renderChannelMixVerdict(_staticSuggestion) || _staticSuggestion;
 
     // Channel-deficit device recommendations — async slot. Surfaces a
     // CTA card with matching catalog devices when (a) the user has a
@@ -653,9 +696,7 @@ export function showLight(_data) {
   // channels only — sun-derived deficits (vit_d, circadian, etc.) get
   // suggested actions via renderSuggestion above; we don't try to sell
   // a panel as a sun substitute.
-  if (deficitRecSlotId && totalSessions >= 7 && typeof window.renderChannelDeficitDeviceRecs === 'function'
-      && typeof window.loadCatalog === 'function'
-      && typeof window.loadLightDevicePresets === 'function') {
+  if (deficitRecSlotId && totalSessions >= 7) {
     const slot = document.getElementById(deficitRecSlotId);
     if (slot) {
       const DEVICE_CHANNELS = [
@@ -664,11 +705,11 @@ export function showLight(_data) {
       ];
       const empty = DEVICE_CHANNELS.filter(c => (combined30d[c.key] || 0) === 0);
       if (empty.length) {
-        Promise.all([window.loadCatalog(), window.loadLightDevicePresets()])
+        Promise.all([lightPageDeps.loadCatalog(), lightPageDeps.loadLightDevicePresets()])
           .then(([catalog, presetData]) => {
             if (!catalog || !presetData?.presets) return;
             const blocks = empty
-              .map(c => window.renderChannelDeficitDeviceRecs(catalog, c.key, presetData.presets, { label: escapeHTML(c.label) }))
+              .map(c => lightPageDeps.renderChannelDeficitDeviceRecs(catalog, c.key, presetData.presets, { label: escapeHTML(c.label) }))
               .filter(Boolean);
             if (blocks.length && slot.isConnected) slot.innerHTML = blocks.join('');
           })
@@ -677,11 +718,11 @@ export function showLight(_data) {
     }
   }
 
-  if (typeof window.renderDevicesSection === 'function') {
-    Promise.resolve(window.renderDevicesSection()).then((devHtml) => {
+  if (lightPageDeps.renderDevicesSection) {
+    Promise.resolve(lightPageDeps.renderDevicesSection()).then((devHtml) => {
       const slot = document.getElementById(devicesSlotId);
       if (!slot) return;
-      const devices = (window.getDevices && window.getDevices()) || [];
+      const devices = lightPageDeps.getDevices() || [];
       slot.outerHTML = devices.length > 0
         ? devHtml
         : renderLightWidgetPrompt('No devices added', 'Add device', 'open-add-device', 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
@@ -694,15 +735,15 @@ export function showLight(_data) {
   }
   const envSlot = document.getElementById(environmentSlotId);
   if (envSlot) {
-    envSlot.outerHTML = window.renderEnvironmentAssessmentSummary
-      ? (window.renderEnvironmentAssessmentSummary() || '')
-      : renderLightWidgetPrompt('No rooms mapped', 'Open assessment', 'open-light-environment', 'Map bedroom, office, screens, and evening light so Light can interpret your indoor day.', 'light-environment-prompt');
+    const envHtml = lightPageDeps.renderEnvironmentAssessmentSummary() || '';
+    envSlot.outerHTML = envHtml
+      || renderLightWidgetPrompt('No rooms mapped', 'Open assessment', 'open-light-environment', 'Map bedroom, office, screens, and evening light so Light can interpret your indoor day.', 'light-environment-prompt');
   }
   const toolsSlot = document.getElementById(toolsSlotId);
   if (toolsSlot) {
-    toolsSlot.outerHTML = window.renderLightTools
-      ? (window.renderLightTools() || '')
-      : renderLightWidgetPrompt('No measurements yet', 'Open light tools', 'expand-light-tools', 'Run lux, flicker, color temperature, glass, and sleep-darkness checks on this device. Camera frames stay local.', 'light-tools-section-collapsed');
+    const toolsHtml = lightPageDeps.renderLightTools() || '';
+    toolsSlot.outerHTML = toolsHtml
+      || renderLightWidgetPrompt('No measurements yet', 'Open light tools', 'expand-light-tools', 'Run lux, flicker, color temperature, glass, and sleep-darkness checks on this device. Camera frames stay local.', 'light-tools-section-collapsed');
   }
 }
 
@@ -710,15 +751,14 @@ export function showLight(_data) {
 // Named function so delegated Light page actions can expand the placeholder.
 export function _expandLightToolsSection() {
   const collapsed = document.querySelector('.light-tools-section-collapsed');
-  if (!collapsed || typeof window.renderLightTools !== 'function') return;
+  if (!collapsed) return;
   const wrap = document.createElement('div');
-  wrap.innerHTML = window.renderLightTools() || '';
+  wrap.innerHTML = lightPageDeps.renderLightTools() || '';
   if (wrap.firstElementChild) collapsed.replaceWith(wrap.firstElementChild);
 }
 
 function getSunCoordsHint() {
-  if (typeof window === 'undefined' || !window.getSunCoords) return '';
-  const c = window.getSunCoords();
+  const c = lightPageDeps.getSunCoords();
   if (!c) {
     return `<p class="light-intro-hint">Tip: set your country in the profile editor for accurate sun calculations, or <a href="#" data-light-page-action="request-precise-location">share your precise location</a> once.</p>`;
   }

--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -433,21 +433,19 @@ export function showLight(_data) {
   // environment + trends) into one read. Sits above active-session and
   // conditions so the user gets the "how am I doing?" answer before the
   // raw inputs.
-  if (lightPageDeps.renderLightTodayHero) {
-    try {
-      const todayBody = lightPageDeps.renderLightTodayHero() || '';
-      if (todayBody) {
-        widgets.push({
-          id: 'light-today',
-          title: 'Today',
-          description: 'Current light synthesis across sun, devices, and environment',
-          body: todayBody,
-          size: 'full',
-          opts: { source: 'Light', dashboardId: 'light-today' },
-        });
-      }
-    } catch (_) {}
-  }
+  try {
+    const todayBody = lightPageDeps.renderLightTodayHero() || '';
+    if (todayBody) {
+      widgets.push({
+        id: 'light-today',
+        title: 'Today',
+        description: 'Current light synthesis across sun, devices, and environment',
+        body: todayBody,
+        size: 'full',
+        opts: { source: 'Light', dashboardId: 'light-today' },
+      });
+    }
+  } catch (_) {}
 
   // Active sun session card — pinned at the very top of the page so the
   // live timer + channel chips + Pause/Flip/Sunscreen controls are the
@@ -462,11 +460,9 @@ export function showLight(_data) {
   // Same pattern for active device-therapy sessions (PBM panels, SAD
   // lamps, dawn simulators). Pinned above the conditions panel so the
   // stop button is always one tap away.
-  if (lightPageDeps.renderActiveDeviceSessionCard) {
-    const _activeDevHtml = lightPageDeps.renderActiveDeviceSessionCard();
-    if (_activeDevHtml) {
-      activeSessionBody += `<div class="light-active-session-pinned" aria-label="Active device session">${_activeDevHtml}</div>`;
-    }
+  const _activeDevHtml = lightPageDeps.renderActiveDeviceSessionCard();
+  if (_activeDevHtml) {
+    activeSessionBody += `<div class="light-active-session-pinned" aria-label="Active device session">${_activeDevHtml}</div>`;
   }
   if (activeSessionBody) {
     widgets.push({
@@ -718,21 +714,14 @@ export function showLight(_data) {
     }
   }
 
-  if (lightPageDeps.renderDevicesSection) {
-    Promise.resolve(lightPageDeps.renderDevicesSection()).then((devHtml) => {
-      const slot = document.getElementById(devicesSlotId);
-      if (!slot) return;
-      const devices = lightPageDeps.getDevices() || [];
-      slot.outerHTML = devices.length > 0
-        ? devHtml
-        : renderLightWidgetPrompt('No devices added', 'Add device', 'open-add-device', 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
-    }).catch(() => {});
-  } else {
+  Promise.resolve(lightPageDeps.renderDevicesSection()).then((devHtml) => {
     const slot = document.getElementById(devicesSlotId);
-    if (slot) {
-      slot.outerHTML = renderLightWidgetPrompt('No devices added', 'Add device', 'open-add-device', 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
-    }
-  }
+    if (!slot) return;
+    const devices = lightPageDeps.getDevices() || [];
+    slot.outerHTML = devices.length > 0
+      ? devHtml
+      : renderLightWidgetPrompt('No devices added', 'Add device', 'open-add-device', 'Therapy panels, SAD lamps, and dawn simulators feed the same Light channels as outdoor sun.');
+  }).catch(() => {});
   const envSlot = document.getElementById(environmentSlotId);
   if (envSlot) {
     const envHtml = lightPageDeps.renderEnvironmentAssessmentSummary() || '';

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1306,
+  "windowReferences": 1204,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -185,6 +185,8 @@ const APP_SHELL = [
   '/js/marker-detail-store.js',
   '/js/light-conditions-now.js',
   '/js/light-page-view.js',
+  '/js/light-page-view-hooks.js',
+  '/js/light-page-view-ui-hooks.js',
   '/js/light-channel-view.js',
   '/js/light-sessions-view.js',
   '/js/light-sessions-view-hooks.js',

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -9,51 +9,41 @@ test('Light page view delegates session, link, channel, and prompt actions', asy
   await page.waitForFunction(() => typeof window.navigate === 'function');
 
   const results = await page.evaluate(async () => {
-    const { renderDashboardLightChannelPills, renderLightSessionLogActions } = await import('/js/light-page-view.js');
+    const { configureLightPageView, renderDashboardLightChannelPills, renderLightSessionLogActions } = await import('/js/light-page-view.js');
     const savedFns = {
-      getSessions: window.getSessions,
-      getDevices: window.getDevices,
-      getDeviceSessions: window.getDeviceSessions,
-      getActiveSession: window.getActiveSession,
-      _openChannelOnLightPage: window._openChannelOnLightPage,
-      quickLogSunSession: window.quickLogSunSession,
-      quickLogDeviceSession: window.quickLogDeviceSession,
-      openAddDeviceDialog: window.openAddDeviceDialog,
-      openDetailedSessionDialog: window.openDetailedSessionDialog,
-      navigate: window.navigate,
-      requestPreciseLocation: window.requestPreciseLocation,
-      openLightEnvironmentAssessment: window.openLightEnvironmentAssessment,
-      renderLightTools: window.renderLightTools,
-      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
-      weeklyChannelTier: window.weeklyChannelTier,
       dailyChannelBreakdown: window.dailyChannelBreakdown,
     };
     const calls = [];
     const host = document.createElement('div');
+    const channelDisplay = {
+      vitamin_d: { label: 'Vitamin D', icon: 'D', what: 'Vitamin D', dailyTarget: 100 },
+      circadian: { label: 'Circadian', icon: 'C', what: 'Circadian', dailyTarget: 100 },
+      nir_solar: { label: 'NIR', icon: 'N', what: 'NIR', dailyTarget: 100 },
+      no_cv: { label: 'NO', icon: 'NO', what: 'Nitric oxide', dailyTarget: 100 },
+      pomc: { label: 'POMC', icon: 'P', what: 'POMC', dailyTarget: 100 },
+      violet_eye: { label: 'Violet', icon: 'V', what: 'Violet', dailyTarget: 100 },
+    };
 
     try {
-      window.getSessions = () => [];
-      window.getDevices = () => [];
-      window.getDeviceSessions = () => [];
-      window.getActiveSession = () => null;
-      window._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
-      window.quickLogSunSession = () => calls.push(['quick-log-sun']);
-      window.quickLogDeviceSession = () => calls.push(['quick-log-device']);
-      window.openAddDeviceDialog = () => calls.push(['open-add-device']);
-      window.openDetailedSessionDialog = () => calls.push(['open-detailed-session']);
-      window.navigate = route => calls.push(['navigate', route]);
-      window.requestPreciseLocation = () => calls.push(['request-precise-location']);
-      window.openLightEnvironmentAssessment = () => calls.push(['open-light-environment']);
-      window.renderLightTools = () => '<section id="light-tools-expanded-test">Expanded tools</section>';
-      window.CHANNEL_DISPLAY = {
-        vitamin_d: { label: 'Vitamin D', icon: 'D', what: 'Vitamin D', dailyTarget: 100 },
-        circadian: { label: 'Circadian', icon: 'C', what: 'Circadian', dailyTarget: 100 },
-        nir_solar: { label: 'NIR', icon: 'N', what: 'NIR', dailyTarget: 100 },
-        no_cv: { label: 'NO', icon: 'NO', what: 'Nitric oxide', dailyTarget: 100 },
-        pomc: { label: 'POMC', icon: 'P', what: 'POMC', dailyTarget: 100 },
-        violet_eye: { label: 'Violet', icon: 'V', what: 'Violet', dailyTarget: 100 },
-      };
-      window.weeklyChannelTier = () => 0;
+      configureLightPageView({
+        channelDisplay,
+        weeklyChannelTier: () => 0,
+        getSessions: () => [],
+        getDevices: () => [],
+        getDeviceSessions: () => [],
+        getActiveSession: () => null,
+        rollingChannelTotals: () => ({}),
+        rollingDeviceTotals: () => ({}),
+        openChannelOnLightPage: channel => calls.push(['open-channel', channel]),
+        quickLogSunSession: () => calls.push(['quick-log-sun']),
+        quickLogDeviceSession: () => calls.push(['quick-log-device']),
+        openAddDeviceDialog: () => calls.push(['open-add-device']),
+        openDetailedSessionDialog: () => calls.push(['open-detailed-session']),
+        navigate: route => calls.push(['navigate', route]),
+        requestPreciseLocation: () => calls.push(['request-precise-location']),
+        openLightEnvironmentAssessment: () => calls.push(['open-light-environment']),
+        renderLightTools: () => '<section id="light-tools-expanded-test">Expanded tools</section>',
+      });
       window.dailyChannelBreakdown = () => Array.from({ length: 7 }, (_, i) => ({
         sun: i === 0 ? 10 : 0,
         device: 0,
@@ -104,7 +94,26 @@ test('Light page view delegates session, link, channel, and prompt actions', asy
           && !!document.getElementById('light-tools-expanded-test'),
       };
     } finally {
-      Object.assign(window, savedFns);
+      configureLightPageView({
+        channelDisplay: {},
+        weeklyChannelTier: () => 0,
+        getSessions: () => [],
+        getDevices: () => [],
+        getDeviceSessions: () => [],
+        getActiveSession: () => null,
+        rollingChannelTotals: () => ({}),
+        rollingDeviceTotals: () => ({}),
+        openChannelOnLightPage: () => {},
+        quickLogSunSession: () => {},
+        quickLogDeviceSession: () => {},
+        openAddDeviceDialog: () => {},
+        openDetailedSessionDialog: () => {},
+        navigate: () => {},
+        requestPreciseLocation: () => {},
+        openLightEnvironmentAssessment: () => {},
+        renderLightTools: () => '',
+      });
+      window.dailyChannelBreakdown = savedFns.dailyChannelBreakdown;
       host.remove();
       document.getElementById('light-tools-expanded-test')?.remove();
     }
@@ -153,6 +162,28 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       renderEnvironmentAssessmentSummary: window.renderEnvironmentAssessmentSummary,
       renderLightTools: window.renderLightTools,
     };
+    const syncLightPageDeps = () => lightPage.configureLightPageView({
+      channelDisplay: window.CHANNEL_DISPLAY || {},
+      weeklyChannelTier: typeof window.weeklyChannelTier === 'function' ? window.weeklyChannelTier : () => 0,
+      channelTier: typeof window.channelTier === 'function' ? window.channelTier : () => 0,
+      getSessions: typeof window.getSessions === 'function' ? window.getSessions : () => [],
+      getDevices: typeof window.getDevices === 'function' ? window.getDevices : () => [],
+      getDeviceSessions: typeof window.getDeviceSessions === 'function' ? window.getDeviceSessions : () => [],
+      getActiveSession: typeof window.getActiveSession === 'function' ? window.getActiveSession : () => null,
+      rollingChannelTotals: typeof window.rollingChannelTotals === 'function' ? window.rollingChannelTotals : () => ({}),
+      rollingDeviceTotals: typeof window.rollingDeviceTotals === 'function' ? window.rollingDeviceTotals : () => ({}),
+      cumulativeMEDToday: typeof window.cumulativeMEDToday === 'function' ? window.cumulativeMEDToday : () => 0,
+      cumulativeMEDYesterday: typeof window.cumulativeMEDYesterday === 'function' ? window.cumulativeMEDYesterday : () => 0,
+      rollingVitaminDIU: typeof window.rollingVitaminDIU === 'function' ? window.rollingVitaminDIU : () => 0,
+      vitaminDBudgetStatus: typeof window.vitaminDBudgetStatus === 'function' ? window.vitaminDBudgetStatus : () => null,
+      getSunCoords: typeof window.getSunCoords === 'function' ? window.getSunCoords : () => null,
+      renderLightTodayDashboardChip: typeof window.renderLightTodayDashboardChip === 'function' ? window.renderLightTodayDashboardChip : () => '',
+      renderLightTodayHero: typeof window.renderLightTodayHero === 'function' ? window.renderLightTodayHero : () => '',
+      renderSunSetupCard: typeof window.renderSunSetupCard === 'function' ? window.renderSunSetupCard : () => '',
+      renderDevicesSection: typeof window.renderDevicesSection === 'function' ? window.renderDevicesSection : () => '',
+      renderEnvironmentAssessmentSummary: typeof window.renderEnvironmentAssessmentSummary === 'function' ? window.renderEnvironmentAssessmentSummary : () => '',
+      renderLightTools: typeof window.renderLightTools === 'function' ? window.renderLightTools : () => '',
+    });
     const setHour = (hour) => {
       const fixed = new RealDate(`2026-06-11T${String(hour).padStart(2, '0')}:15:00`);
       class FixedDate extends RealDate {
@@ -206,6 +237,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       });
       window.getSunCoords = () => ({ lat: 50, lon: 14, altitudeM: 1700, source: 'profile-precise' });
       window.renderLightTodayDashboardChip = () => '<div class="light-dashboard-chip-test">chip</div>';
+      syncLightPageDeps();
 
       setHour(6);
       const morning = lightPage.renderLightTodayStrip();
@@ -230,10 +262,13 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       };
       setHour(22);
       window.getDevices = () => [{ brand: 'Joovv', model: 'Solo' }];
+      syncLightPageDeps();
       const oneDevice = lightPage.renderLightTodayStrip();
       window.getDevices = () => [{ brand: 'Joovv', model: 'Solo' }, { brand: 'SAD', model: 'Desk' }];
+      syncLightPageDeps();
       const manyDevices = lightPage.renderLightTodayStrip();
       window.getDevices = () => [];
+      syncLightPageDeps();
       const noDevices = lightPage.renderLightTodayStrip();
       outcomes.nonSolarCtasAdaptToDeviceAndRoomState =
         oneDevice.includes('Joovv Solo')
@@ -243,6 +278,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
 
       setHour(10);
       window.getActiveSession = () => ({ id: 'active-sun', startedAt: Date.now() - 95_000 });
+      syncLightPageDeps();
       const activeStrip = lightPage.renderLightTodayStrip();
       outcomes.activeSessionStripShowsStopElapsed =
         activeStrip.includes('Stop session')
@@ -258,12 +294,14 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.getSessions = () => [];
       window.getDeviceSessions = () => [];
       window.getSunCoords = () => null;
+      syncLightPageDeps();
       lightPage.showLight(state.importedData);
       outcomes.emptyLightPagePromptsForMissingCoords =
         main?.textContent.includes('set your country in the profile editor') === true
         && main?.querySelector('[data-light-page-action="request-precise-location"]') !== null;
 
       window.getSunCoords = () => ({ source: 'country-band', lat: 49.2, lon: 16.6 });
+      syncLightPageDeps();
       lightPage.showLight(state.importedData);
       outcomes.emptyLightPageShowsCountryBandHint =
         main?.textContent.includes('Calculations use your country (~49.2° lat)') === true;
@@ -292,6 +330,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.renderDevicesSection = saved.renderDevicesSection;
       window.renderEnvironmentAssessmentSummary = saved.renderEnvironmentAssessmentSummary;
       window.renderLightTools = saved.renderLightTools;
+      syncLightPageDeps();
     }
 
     return outcomes;

--- a/tests/test-light-page-view-delegated-actions.js
+++ b/tests/test-light-page-view-delegated-actions.js
@@ -8,6 +8,11 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const src = fs.readFileSync(path.join(root, 'js/light-page-view.js'), 'utf8');
+const hooksSrc = fs.readFileSync(path.join(root, 'js/light-page-view-hooks.js'), 'utf8');
+const uiHooksSrc = fs.readFileSync(path.join(root, 'js/light-page-view-ui-hooks.js'), 'utf8');
+const lightSunModulesSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
+const uiShellModulesSrc = fs.readFileSync(path.join(root, 'js/app-ui-shell-modules.js'), 'utf8');
+const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -40,6 +45,27 @@ assert('Light page view installs one click delegate per root',
 assert('Light page actions are scoped through closest data action lookup',
   /target\.closest\('\[data-light-page-action\]'\)/.test(src)
     && /event\.currentTarget\?\.contains\(actionEl\)/.test(src));
+assert('Light page view exposes dependency configurator',
+  /export function configureLightPageView\(deps = \{\}\)/.test(src)
+    && /Object\.assign\(lightPageDeps, deps\)/.test(src));
+assert('Light page view avoids direct window globals',
+  !/window\./.test(src));
+assert('Light page feature hook wires runtime dependencies',
+  /configureLightPageView\(\{/.test(hooksSrc)
+    && /renderLightTodayHero/.test(hooksSrc)
+    && /renderDevicesSection/.test(hooksSrc)
+    && /renderLightTools/.test(hooksSrc)
+    && /renderChannelDeficitDeviceRecs/.test(hooksSrc));
+assert('Light page UI hook wires router and settings dependencies',
+  /import \{ navigate \} from '\.\/views\.js';/.test(uiHooksSrc)
+    && /import \{ renderSunDataSourceSettings \} from '\.\/settings\.js';/.test(uiHooksSrc)
+    && /configureLightPageView\(\{[\s\S]*navigate[\s\S]*renderSunDataSourceSettings[\s\S]*\}\);/.test(uiHooksSrc));
+assert('Light page hooks are loaded during startup',
+  lightSunModulesSrc.includes("import './light-page-view-hooks.js';")
+    && uiShellModulesSrc.includes("import './light-page-view-ui-hooks.js';"));
+assert('Service worker caches Light page hooks',
+  swSrc.includes("'/js/light-page-view-hooks.js'")
+    && swSrc.includes("'/js/light-page-view-ui-hooks.js'"));
 
 [
   'open-channel',
@@ -62,7 +88,7 @@ assert('Light widget prompt receives action ids instead of JavaScript snippets',
     && !/function renderLightWidgetPrompt\(status, ctaLabel, ctaJs/.test(src));
 assert('Dashboard channel pill action passes channel through data attribute',
   /data-light-page-action="open-channel" data-channel="\$\{escapeAttr\(k\)\}"/.test(src)
-    && /_openChannelOnLightPage\?\.\(actionEl\.dataset\.channel/.test(src));
+    && /lightPageDeps\.openChannelOnLightPage\(actionEl\.dataset\.channel \|\| ''\)/.test(src));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -677,6 +677,12 @@
     const hasLightPageViewJs = sw.includes('/js/light-page-view.js');
     assert('Service worker caches js/light-page-view.js', hasLightPageViewJs);
 
+    const hasLightPageViewHooksJs = sw.includes('/js/light-page-view-hooks.js');
+    assert('Service worker caches js/light-page-view-hooks.js', hasLightPageViewHooksJs);
+
+    const hasLightPageViewUiHooksJs = sw.includes('/js/light-page-view-ui-hooks.js');
+    assert('Service worker caches js/light-page-view-ui-hooks.js', hasLightPageViewUiHooksJs);
+
     const hasLightChannelViewJs = sw.includes('/js/light-channel-view.js');
     assert('Service worker caches js/light-channel-view.js', hasLightChannelViewJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.534';
+self.APP_VERSION = '1.8.535';


### PR DESCRIPTION
## Summary
- Add `configureLightPageView` and route Light page renderer/action dependencies through startup hooks.
- Wire feature deps from the Light/Sun startup group and router/settings deps from the UI shell group.
- Export the existing device preset loader, cache the new hooks, update Light page coverage, and ratchet `window` references from 1306 to 1204.

## Tests
- `npm run typecheck`
- `npm run quality`
- `node tests/test-light-page-view-delegated-actions.js`
- `npm run test:playwright -- tests/playwright/light-page-view.spec.js`
- `./run-tests.sh`