### PR TITLE
[codex] Wire Light channel view runtime deps

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -24,4 +24,5 @@ import './sun-onboarding-ai.js';
 import './light-ai-save-hooks.js';
 import './sun-correlations.js';
 import './light-today-ai.js';
+import './light-channel-view-hooks.js';
 import './light-page-view-hooks.js';

--- a/js/app-ui-shell-modules.js
+++ b/js/app-ui-shell-modules.js
@@ -6,6 +6,7 @@ import './tour.js';
 import './touch-tooltip.js';
 import './client-list.js';
 import './views.js';
+import './light-channel-view-ui-hooks.js';
 import './light-page-view-ui-hooks.js';
 import './light-tools-ui-hooks.js';
 import './sun-session-ui-hooks.js';

--- a/js/light-channel-view-hooks.js
+++ b/js/light-channel-view-hooks.js
@@ -1,0 +1,32 @@
+// @ts-check
+// light-channel-view-hooks.js - wire Light channel feature dependencies at startup.
+
+import {
+  CHANNEL_DISPLAY,
+  dailyChannelBreakdown,
+  dailyVitaminDIUBreakdown,
+  quickLogSunSession,
+  rollingChannelTotals,
+  rollingVitaminDIU,
+  tierLabel,
+  weeklyChannelTier,
+} from './sun.js';
+import { pbmJoulesPerCm2 } from './sun-spectrum.js';
+import { quickLogDeviceSession } from './light-devices.js';
+import { getDevices, rollingDeviceTotals } from './light-devices-store.js';
+import { configureLightChannelView } from './light-channel-view.js';
+
+configureLightChannelView({
+  channelDisplay: CHANNEL_DISPLAY,
+  dailyChannelBreakdown,
+  dailyVitaminDIUBreakdown,
+  getDevices,
+  pbmJoulesPerCm2,
+  quickLogDeviceSession,
+  quickLogSunSession,
+  rollingChannelTotals,
+  rollingDeviceTotals,
+  rollingVitaminDIU,
+  tierLabel,
+  weeklyChannelTier,
+});

--- a/js/light-channel-view-ui-hooks.js
+++ b/js/light-channel-view-ui-hooks.js
@@ -1,0 +1,7 @@
+// @ts-check
+// light-channel-view-ui-hooks.js - wire Light channel shell dependencies after UI modules load.
+
+import { navigate } from './views.js';
+import { configureLightChannelView } from './light-channel-view.js';
+
+configureLightChannelView({ navigate });

--- a/js/light-channel-view.js
+++ b/js/light-channel-view.js
@@ -11,7 +11,7 @@ const lightChannelDeps = {
   tierLabel: () => 'none', rollingChannelTotals: () => ({}), rollingDeviceTotals: () => ({}), rollingVitaminDIU: () => 0,
   pbmJoulesPerCm2: null, getDevices: () => [], navigate: () => {}, quickLogSunSession: () => {}, quickLogDeviceSession: () => {},
 };
-export function configureLightChannelView(deps = {}) { Object.assign(lightChannelDeps, deps); }
+export function configureLightChannelView(deps = {}) { const previous = { ...lightChannelDeps }; Object.assign(lightChannelDeps, deps); return previous; }
 const getChannelDisplay = () => lightChannelDeps.channelDisplay || {};
 
 const LIGHT_CHANNEL_ACTION_ATTR = 'data-light-channel-action';
@@ -657,8 +657,8 @@ function _renderChannelDetailPanel(channelKey) {
   // Drill-down hero stat is a 7-day total — classify against the weekly
   // target so the badge agrees with the pill (and the AI rollup).
   const tier = lightChannelDeps.weeklyChannelTier;
-  const sunTot7 = lightChannelDeps.rollingChannelTotals(7) || {};
-  const devTot7 = lightChannelDeps.rollingDeviceTotals(7) || {};
+  const sunTot7 = (typeof lightChannelDeps.rollingChannelTotals === 'function' ? lightChannelDeps.rollingChannelTotals(7) : null) || {};
+  const devTot7 = (typeof lightChannelDeps.rollingDeviceTotals === 'function' ? lightChannelDeps.rollingDeviceTotals(7) : null) || {};
   const sun7 = sunTot7[channelKey] || 0;
   const dev7 = devTot7[channelKey] || 0;
   const totalCurrent = sun7 + dev7;

--- a/js/light-channel-view.js
+++ b/js/light-channel-view.js
@@ -5,6 +5,15 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
 import { getCachedConditionsAtmosphere } from './light-conditions-now.js';
 
+/** @type {Record<string, any>} */
+const lightChannelDeps = {
+  channelDisplay: {}, dailyChannelBreakdown: null, dailyVitaminDIUBreakdown: null, weeklyChannelTier: () => 0,
+  tierLabel: () => 'none', rollingChannelTotals: () => ({}), rollingDeviceTotals: () => ({}), rollingVitaminDIU: () => 0,
+  pbmJoulesPerCm2: null, getDevices: () => [], navigate: () => {}, quickLogSunSession: () => {}, quickLogDeviceSession: () => {},
+};
+export function configureLightChannelView(deps = {}) { Object.assign(lightChannelDeps, deps); }
+const getChannelDisplay = () => lightChannelDeps.channelDisplay || {};
+
 const LIGHT_CHANNEL_ACTION_ATTR = 'data-light-channel-action';
 const LIGHT_CHANNEL_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightChannelActionDelegatesInstalled'), lightChannelActionDelegateRoots = new WeakSet();
 function closestLightChannelAction(target) { return target?.closest?.(`[${LIGHT_CHANNEL_ACTION_ATTR}]`) || null; }
@@ -15,8 +24,8 @@ function handleLightChannelActionClick(event) {
   const channelKey = /** @type {HTMLElement} */ (actionEl).dataset.channel || '';
   let handled = true;
   if (action === 'toggle-detail' && channelKey) _toggleChannelDetail(channelKey);
-  else if (action === 'quick-log-sun') window.quickLogSunSession?.();
-  else if (action === 'quick-log-device') window.quickLogDeviceSession?.();
+  else if (action === 'quick-log-sun') lightChannelDeps.quickLogSunSession();
+  else if (action === 'quick-log-device') lightChannelDeps.quickLogDeviceSession();
   else handled = false;
   if (handled) event.stopPropagation();
 }
@@ -33,20 +42,12 @@ export function mergeTotals(a, b) {
   return out;
 }
 
-// Mini 7-day sparkline rendered as inline SVG. Bars are heightless when a
-// day's combined dose is sub-meaningful (~5% of daily target) — a faint
-// stub so the day position stays readable without inflating an empty
-// week. Replaces the prior ●○○○ dots metaphor which (a) implied a
-// "fillable container" mental model that contradicts the daily-beats-
-// banking framing and (b) had ~4 bits of resolution loss vs the
-// continuous channel-au value.
-//
-// Width: 7 bars × 5px + 6 gaps × 2px = 47px in viewBox. Renders crisply
-// at any pill height because we use viewBox + width 100%.
+// Mini 7-day sparkline rendered as inline SVG; sub-meaningful days get a faint stub.
 export function _channelSparkline(channelKey, totals = null) {
-  if (!window.dailyChannelBreakdown) return '';
-  const days = window.dailyChannelBreakdown(channelKey, 7);
-  const meta = (window.CHANNEL_DISPLAY || {})[channelKey] || {};
+  const breakdown = lightChannelDeps.dailyChannelBreakdown;
+  if (!breakdown) return '';
+  const days = breakdown(channelKey, 7);
+  const meta = getChannelDisplay()[channelKey] || {};
   const dailyTarget = meta.dailyTarget || 0;
   const observedMax = Math.max(0, ...days.map(d => d.sun + d.device));
   const max = Math.max(observedMax, dailyTarget * 1.05, 0.001);
@@ -75,12 +76,12 @@ export function _channelSparkline(channelKey, totals = null) {
   return `<svg class="light-pill-sparkline" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" aria-hidden="true">${bars}</svg>`;
 }
 
-// "X days" label for the pill — count of days that hit the channel's
-// meaningful-dose threshold. Returns "—" when no day qualified.
+// "X days" label for the pill — count of days that hit the meaningful-dose threshold.
 export function _channelDayCount(channelKey) {
-  if (!window.dailyChannelBreakdown) return { txt: '—', n: 0 };
-  const days = window.dailyChannelBreakdown(channelKey, 7);
-  const meta = (window.CHANNEL_DISPLAY || {})[channelKey] || {};
+  const breakdown = lightChannelDeps.dailyChannelBreakdown;
+  if (!breakdown) return { txt: '—', n: 0 };
+  const days = breakdown(channelKey, 7);
+  const meta = getChannelDisplay()[channelKey] || {};
   const target = meta.dailyTarget || 0;
   const threshold = (typeof _CHANNEL_DAY_THRESHOLD !== 'undefined' && _CHANNEL_DAY_THRESHOLD[channelKey]) || 0.30;
   const floor = target * threshold;
@@ -102,15 +103,13 @@ export function _channelDayCount(channelKey) {
 // sparklines; bars fill in as data accumulates. One renderer for both
 // states.
 export function renderChannelPills(totals7d, totals30d) {
-  const ch = window.CHANNEL_DISPLAY || {};
-  // Tier classifiers: weekly for v7 (the canonical "this week" headline),
-  // and a 30-day equivalent for v30 by scaling the threshold band to the
-  // longer window. Mixing daily-target classification on a multi-day total
+  const ch = getChannelDisplay();
+  // Tier classifiers: weekly for v7 and 30-day equivalent for v30 by scaling the threshold band to the longer span. Mixing daily-target classification on a multi-day total
   // double-counts and wrecks the trend arrow (t30 ALWAYS scored higher
   // than t7 because totals scale with window even when the daily rate is
   // identical, so the trend read "down" on every flat pattern).
-  const tlabel = window.tierLabel || (() => 'none');
-  const tier7 = window.weeklyChannelTier || ((v, k) => 0);
+  const tlabel = lightChannelDeps.tierLabel;
+  const tier7 = lightChannelDeps.weeklyChannelTier;
   const tier30 = (v, k) => {
     const target = ((ch[k] && ch[k].dailyTarget) || 1000) * 30;
     if (!Number.isFinite(v) || v <= 0) return 0;
@@ -246,7 +245,7 @@ const CHANNEL_CITATIONS = {
 function _renderChannelCitations(channelKey) {
   const cit = CHANNEL_CITATIONS[channelKey];
   if (!cit) return '';
-  const meta = (window.CHANNEL_DISPLAY || {})[channelKey] || {};
+  const meta = getChannelDisplay()[channelKey] || {};
   const channelName = meta.label || channelKey;
   const refs = cit.refs.map(({ cite, href, why }) => `<li>
     <a href="${escapeAttr(href)}" target="_blank" rel="noopener">${escapeHTML(cite)}</a>
@@ -282,17 +281,18 @@ function _renderChannelCitations(channelKey) {
 // like. Numeric labels above each bar surface the actual numbers when
 // non-zero.
 function _renderChannelWeekChart(channelKey) {
-  if (!window.dailyChannelBreakdown) return '';
-  const days = window.dailyChannelBreakdown(channelKey, 7);
+  const breakdown = lightChannelDeps.dailyChannelBreakdown;
+  if (!breakdown) return '';
+  const days = breakdown(channelKey, 7);
   // For vit-D, pull a per-day IU breakdown that uses the same per-session
   // math as rollingVitaminDIU (real Fitz/UVI/rotation/genetics/body-frac
   // cap). Bar height + tier color still use channel-au from `days` for
   // continuity with the sparkline; only the numeric label switches to
   // per-session-accurate IU so it agrees with the session-row IU readout.
-  const iuDays = (channelKey === 'vitamin_d' && window.dailyVitaminDIUBreakdown)
-    ? window.dailyVitaminDIUBreakdown(7)
+  const iuDays = (channelKey === 'vitamin_d' && lightChannelDeps.dailyVitaminDIUBreakdown)
+    ? lightChannelDeps.dailyVitaminDIUBreakdown(7)
     : null;
-  const ch = window.CHANNEL_DISPLAY || {};
+  const ch = getChannelDisplay();
   const meta = ch[channelKey] || {};
   const dailyTarget = meta.dailyTarget || 0;
   const dailyTargetSlice = dailyTarget; // chart is per-day, so target IS the daily target
@@ -331,8 +331,8 @@ function _renderChannelWeekChart(channelKey) {
       if (iu >= 100) return String(Math.round(iu / 10) * 10);
       return String(Math.round(iu));
     }
-    if (channelKey === 'nir_solar' && window.pbmJoulesPerCm2) {
-      const j = window.pbmJoulesPerCm2(n);
+    if (channelKey === 'nir_solar' && lightChannelDeps.pbmJoulesPerCm2) {
+      const j = lightChannelDeps.pbmJoulesPerCm2(n);
       if (j < 0.05) return '';
       if (j >= 10) return String(Math.round(j));
       if (j >= 1) return j.toFixed(1);
@@ -450,10 +450,10 @@ function _meaningfulDayCount(days, dailyTarget, threshold) {
 // the cumulative real-unit (IU / J/cm²) when defensible is shown as
 // a sub-line for completeness.
 function _channelHero(channelKey, totalCurrent, totalPrev, days7, daysPrev7, weeklyTier = 0) {
-  const meta = (window.CHANNEL_DISPLAY || {})[channelKey] || {};
+  const meta = getChannelDisplay()[channelKey] || {};
   const target = meta.dailyTarget || 0;
   const threshold = _CHANNEL_DAY_THRESHOLD[channelKey] ?? 0.30;
-  const tierLabelFor = window.tierLabel || (() => 'none');
+  const tierLabelFor = lightChannelDeps.tierLabel;
   const tierColors = ['muted', 'tier1', 'tier2', 'tier3', 'tier4'];
   const tierPill = `<span class="light-channel-detail-tierpill ${tierColors[weeklyTier] || 'muted'}">${escapeHTML(tierLabelFor(weeklyTier))} this week</span>`;
   const fmtIntK = (n) => {
@@ -468,11 +468,11 @@ function _channelHero(channelKey, totalCurrent, totalPrev, days7, daysPrev7, wee
 
   // Cumulative real-unit summary (always computed; only shown if defensible).
   let cumulative = '';
-  if (channelKey === 'vitamin_d' && window.rollingVitaminDIU) {
-    const iu = window.rollingVitaminDIU(7);
+  if (channelKey === 'vitamin_d' && lightChannelDeps.rollingVitaminDIU) {
+    const iu = lightChannelDeps.rollingVitaminDIU(7);
     if (iu >= 30) cumulative = `· ~${fmtIntK(iu)} IU total`;
-  } else if (channelKey === 'nir_solar' && window.pbmJoulesPerCm2) {
-    const j = window.pbmJoulesPerCm2(totalCurrent);
+  } else if (channelKey === 'nir_solar' && lightChannelDeps.pbmJoulesPerCm2) {
+    const j = lightChannelDeps.pbmJoulesPerCm2(totalCurrent);
     if (j >= 0.1) cumulative = `· ${j >= 10 ? Math.round(j) : j.toFixed(1)} J/cm² total`;
   }
 
@@ -652,14 +652,13 @@ function _channelNextMove(channelKey, t7, totalCurrent, devices, atm) {
 //   6. Next move: channel-specific concrete recipe + action button
 //   7. Action spectrum + paper citations (expandable)
 function _renderChannelDetailPanel(channelKey) {
-  const ch = window.CHANNEL_DISPLAY || {};
+  const ch = getChannelDisplay();
   const meta = ch[channelKey] || {};
   // Drill-down hero stat is a 7-day total — classify against the weekly
   // target so the badge agrees with the pill (and the AI rollup).
-  const tier = window.weeklyChannelTier || (() => 0);
-  const tlabel = window.tierLabel || (() => 'none');
-  const sunTot7 = (window.rollingChannelTotals && window.rollingChannelTotals(7)) || {};
-  const devTot7 = (window.rollingDeviceTotals && window.rollingDeviceTotals(7)) || {};
+  const tier = lightChannelDeps.weeklyChannelTier;
+  const sunTot7 = lightChannelDeps.rollingChannelTotals(7) || {};
+  const devTot7 = lightChannelDeps.rollingDeviceTotals(7) || {};
   const sun7 = sunTot7[channelKey] || 0;
   const dev7 = devTot7[channelKey] || 0;
   const totalCurrent = sun7 + dev7;
@@ -672,15 +671,16 @@ function _renderChannelDetailPanel(channelKey) {
   let days7 = [];
   let daysPrev7 = [];
   try {
-    if (window.dailyChannelBreakdown) {
-      const days14 = window.dailyChannelBreakdown(channelKey, 14);
+    const breakdown = lightChannelDeps.dailyChannelBreakdown;
+    if (breakdown) {
+      const days14 = breakdown(channelKey, 14);
       daysPrev7 = days14.slice(0, 7);
       days7 = days14.slice(7);
       totalPrev = daysPrev7.reduce((s, d) => s + d.sun + d.device, 0);
     }
   } catch (e) {}
 
-  const devices = (window.getDevices && window.getDevices()) || [];
+  const devices = lightChannelDeps.getDevices() || [];
 
   // Pull the Conditions Now atm if in cache so the next-move can quote
   // today's UV-peak time — way more actionable than "spend time outdoors."
@@ -731,7 +731,7 @@ export function _openChannelOnLightPage(channelKey) {
     requestAnimationFrame(() => requestAnimationFrame(flashPanel));
     return;
   }
-  if (window.navigate) window.navigate('light');
+  lightChannelDeps.navigate('light');
   // Light page renders synchronously; the pill row is in the DOM by
   // the next animation frame. Defer the toggle so the section exists.
   // Two rAFs to make sure the async devices/env/tools slot doesn't
@@ -778,7 +778,7 @@ export function renderSuggestion(totals7d) {
   // Suggestion picks the lowest-tier channel from a 7-day total, so use
   // the weekly classifier — otherwise it nudges every channel as "low"
   // because each one is being compared to a daily target.
-  const tier = window.weeklyChannelTier || (() => 0);
+  const tier = lightChannelDeps.weeklyChannelTier;
   const order = ['vitamin_d', 'circadian', 'nir_solar', 'no_cv', 'pomc', 'violet_eye'];
   const SUGGESTIONS = {
     vitamin_d:  'Get 10–15 minutes of midday sun on bare skin if your latitude allows — UVB drops sharply after 2 pm.',

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1204,
+  "windowReferences": 1164,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -188,6 +188,8 @@ const APP_SHELL = [
   '/js/light-page-view-hooks.js',
   '/js/light-page-view-ui-hooks.js',
   '/js/light-channel-view.js',
+  '/js/light-channel-view-hooks.js',
+  '/js/light-channel-view-ui-hooks.js',
   '/js/light-sessions-view.js',
   '/js/light-sessions-view-hooks.js',
   '/js/compare-correlations.js',

--- a/tests/playwright/light-coverage-batch-2.spec.js
+++ b/tests/playwright/light-coverage-batch-2.spec.js
@@ -277,8 +277,6 @@ test('light channel view covers pills detail panels suggestions and light-page r
       quickLogSunSession: window.quickLogSunSession,
       quickLogDeviceSession: window.quickLogDeviceSession,
       navigate: window.navigate,
-      _toggleChannelDetail: window._toggleChannelDetail,
-      _openChannelOnLightPage: window._openChannelOnLightPage,
     };
     const order = ['vitamin_d', 'circadian', 'nir_solar', 'no_cv', 'pomc', 'violet_eye'];
 
@@ -297,7 +295,7 @@ test('light channel view covers pills detail panels suggestions and light-page r
     });
 
     try {
-      window.CHANNEL_DISPLAY = {
+      const channelDisplay = {
         vitamin_d: { label: 'Vitamin D', icon: 'D', what: 'UVB synthesis', dailyTarget: 100 },
         circadian: { label: 'Circadian', icon: 'C', what: 'Melanopic entrainment', dailyTarget: 100 },
         nir_solar: { label: 'NIR', icon: 'N', what: 'Mitochondrial red/NIR signal', dailyTarget: 100 },
@@ -305,15 +303,12 @@ test('light channel view covers pills detail panels suggestions and light-page r
         pomc: { label: 'POMC', icon: 'P', what: 'Skin POMC pathway', dailyTarget: 100 },
         violet_eye: { label: 'Violet eye', icon: 'V', what: 'Outdoor violet at the eye', dailyTarget: 100 },
       };
-      window.dailyChannelBreakdown = makeDays;
-      window.dailyVitaminDIUBreakdown = count => makeDays('vitamin_d', count).map(day => ({
+      const dailyVitaminDIUBreakdown = count => makeDays('vitamin_d', count).map(day => ({
         date: day.date,
         sun: day.sun * 12,
         device: day.device * 3,
       }));
-      window.rollingVitaminDIU = () => 2480;
-      window.pbmJoulesPerCm2 = value => value / 40;
-      window.rollingChannelTotals = () => ({
+      const rollingChannelTotals = () => ({
         vitamin_d: 260,
         circadian: 180,
         nir_solar: 240,
@@ -321,7 +316,7 @@ test('light channel view covers pills detail panels suggestions and light-page r
         pomc: 190,
         violet_eye: 120,
       });
-      window.rollingDeviceTotals = () => ({
+      const rollingDeviceTotals = () => ({
         vitamin_d: 80,
         circadian: 15,
         nir_solar: 70,
@@ -329,23 +324,32 @@ test('light channel view covers pills detail panels suggestions and light-page r
         pomc: 10,
         violet_eye: 8,
       });
-      window.weeklyChannelTier = value => {
+      const weeklyChannelTier = value => {
         if (value >= 300) return 4;
         if (value >= 200) return 3;
         if (value >= 100) return 2;
         if (value > 0) return 1;
         return 0;
       };
-      window.tierLabel = tier => ['none', 'low', 'moderate', 'good', 'strong'][tier] || 'none';
-      window.getDevices = () => [{ brand: 'TestLight', model: 'Panel', channels: ['vitamin_d', 'nir_solar'] }];
-      window.quickLogSunSession = () => calls.push(['quick-sun']);
-      window.quickLogDeviceSession = () => calls.push(['quick-device']);
-      window.navigate = route => {
+      const navigate = route => {
         calls.push(['navigate', route]);
         state.currentView = route;
       };
-      window._toggleChannelDetail = channel._toggleChannelDetail;
-      window._openChannelOnLightPage = channel._openChannelOnLightPage;
+      channel.configureLightChannelView({
+        channelDisplay,
+        dailyChannelBreakdown: makeDays,
+        dailyVitaminDIUBreakdown,
+        getDevices: () => [{ brand: 'TestLight', model: 'Panel', channels: ['vitamin_d', 'nir_solar'] }],
+        navigate,
+        pbmJoulesPerCm2: value => value / 40,
+        quickLogDeviceSession: () => calls.push(['quick-device']),
+        quickLogSunSession: () => calls.push(['quick-sun']),
+        rollingChannelTotals,
+        rollingDeviceTotals,
+        rollingVitaminDIU: () => 2480,
+        tierLabel: tier => ['none', 'low', 'moderate', 'good', 'strong'][tier] || 'none',
+        weeklyChannelTier,
+      });
 
       document.body.appendChild(host);
       const merged = channel.mergeTotals({ vitamin_d: 10, circadian: 5 }, { vitamin_d: 7, nir_solar: 3 });
@@ -406,22 +410,20 @@ test('light channel view covers pills detail panels suggestions and light-page r
         && !!routedDetail
         && host.querySelector('.light-pill[data-channel="circadian"]')?.getAttribute('aria-expanded') === 'true';
     } finally {
-      Object.assign(window, {
-        CHANNEL_DISPLAY: saved.CHANNEL_DISPLAY,
-        dailyChannelBreakdown: saved.dailyChannelBreakdown,
-        dailyVitaminDIUBreakdown: saved.dailyVitaminDIUBreakdown,
-        rollingVitaminDIU: saved.rollingVitaminDIU,
-        pbmJoulesPerCm2: saved.pbmJoulesPerCm2,
-        rollingChannelTotals: saved.rollingChannelTotals,
-        rollingDeviceTotals: saved.rollingDeviceTotals,
-        weeklyChannelTier: saved.weeklyChannelTier,
-        tierLabel: saved.tierLabel,
-        getDevices: saved.getDevices,
-        quickLogSunSession: saved.quickLogSunSession,
-        quickLogDeviceSession: saved.quickLogDeviceSession,
-        navigate: saved.navigate,
-        _toggleChannelDetail: saved._toggleChannelDetail,
-        _openChannelOnLightPage: saved._openChannelOnLightPage,
+      channel.configureLightChannelView({
+        channelDisplay: saved.CHANNEL_DISPLAY || {},
+        dailyChannelBreakdown: saved.dailyChannelBreakdown || null,
+        dailyVitaminDIUBreakdown: saved.dailyVitaminDIUBreakdown || null,
+        getDevices: saved.getDevices || (() => []),
+        navigate: saved.navigate || (() => {}),
+        pbmJoulesPerCm2: saved.pbmJoulesPerCm2 || null,
+        quickLogDeviceSession: saved.quickLogDeviceSession || (() => {}),
+        quickLogSunSession: saved.quickLogSunSession || (() => {}),
+        rollingChannelTotals: saved.rollingChannelTotals || (() => ({})),
+        rollingDeviceTotals: saved.rollingDeviceTotals || (() => ({})),
+        rollingVitaminDIU: saved.rollingVitaminDIU || (() => 0),
+        tierLabel: saved.tierLabel || (() => 'none'),
+        weeklyChannelTier: saved.weeklyChannelTier || (() => 0),
       });
       state.currentView = saved.currentView;
       host.remove();

--- a/tests/playwright/light-coverage-batch-2.spec.js
+++ b/tests/playwright/light-coverage-batch-2.spec.js
@@ -262,22 +262,8 @@ test('light channel view covers pills detail panels suggestions and light-page r
     const outcomes = {};
     const calls = [];
     const host = document.createElement('section');
-    const saved = {
-      currentView: state.currentView,
-      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
-      dailyChannelBreakdown: window.dailyChannelBreakdown,
-      dailyVitaminDIUBreakdown: window.dailyVitaminDIUBreakdown,
-      rollingVitaminDIU: window.rollingVitaminDIU,
-      pbmJoulesPerCm2: window.pbmJoulesPerCm2,
-      rollingChannelTotals: window.rollingChannelTotals,
-      rollingDeviceTotals: window.rollingDeviceTotals,
-      weeklyChannelTier: window.weeklyChannelTier,
-      tierLabel: window.tierLabel,
-      getDevices: window.getDevices,
-      quickLogSunSession: window.quickLogSunSession,
-      quickLogDeviceSession: window.quickLogDeviceSession,
-      navigate: window.navigate,
-    };
+    const saved = { currentView: state.currentView };
+    let restoreDeps = null;
     const order = ['vitamin_d', 'circadian', 'nir_solar', 'no_cv', 'pomc', 'violet_eye'];
 
     const makeDays = (channelKey, count) => Array.from({ length: count }, (_, i) => {
@@ -335,7 +321,7 @@ test('light channel view covers pills detail panels suggestions and light-page r
         calls.push(['navigate', route]);
         state.currentView = route;
       };
-      channel.configureLightChannelView({
+      restoreDeps = channel.configureLightChannelView({
         channelDisplay,
         dailyChannelBreakdown: makeDays,
         dailyVitaminDIUBreakdown,
@@ -410,21 +396,7 @@ test('light channel view covers pills detail panels suggestions and light-page r
         && !!routedDetail
         && host.querySelector('.light-pill[data-channel="circadian"]')?.getAttribute('aria-expanded') === 'true';
     } finally {
-      channel.configureLightChannelView({
-        channelDisplay: saved.CHANNEL_DISPLAY || {},
-        dailyChannelBreakdown: saved.dailyChannelBreakdown || null,
-        dailyVitaminDIUBreakdown: saved.dailyVitaminDIUBreakdown || null,
-        getDevices: saved.getDevices || (() => []),
-        navigate: saved.navigate || (() => {}),
-        pbmJoulesPerCm2: saved.pbmJoulesPerCm2 || null,
-        quickLogDeviceSession: saved.quickLogDeviceSession || (() => {}),
-        quickLogSunSession: saved.quickLogSunSession || (() => {}),
-        rollingChannelTotals: saved.rollingChannelTotals || (() => ({})),
-        rollingDeviceTotals: saved.rollingDeviceTotals || (() => ({})),
-        rollingVitaminDIU: saved.rollingVitaminDIU || (() => 0),
-        tierLabel: saved.tierLabel || (() => 'none'),
-        weeklyChannelTier: saved.weeklyChannelTier || (() => 0),
-      });
+      if (restoreDeps) channel.configureLightChannelView(restoreDeps);
       state.currentView = saved.currentView;
       host.remove();
     }

--- a/tests/test-light-channel-view-delegated-actions.js
+++ b/tests/test-light-channel-view-delegated-actions.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Light channel view delegated-action and dependency wiring guards.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const src = fs.readFileSync(path.join(root, 'js/light-channel-view.js'), 'utf8');
+const hooksSrc = fs.readFileSync(path.join(root, 'js/light-channel-view-hooks.js'), 'utf8');
+const uiHooksSrc = fs.readFileSync(path.join(root, 'js/light-channel-view-ui-hooks.js'), 'utf8');
+const lightSunModulesSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
+const uiShellModulesSrc = fs.readFileSync(path.join(root, 'js/app-ui-shell-modules.js'), 'utf8');
+const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Light Channel View Delegated Actions ===');
+
+const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
+const directAssignmentRe = /\.(?:onclick|onchange|oninput)\s*=/;
+
+assert('light-channel-view.js has no inline event attributes',
+  !inlineHandlerRe.test(src));
+assert('light-channel-view.js avoids direct event property assignment',
+  !directAssignmentRe.test(src));
+assert('Light channel view exposes dependency configurator',
+  /export function configureLightChannelView\(deps = \{\}\)/.test(src)
+    && /Object\.assign\(lightChannelDeps, deps\)/.test(src));
+assert('Light channel view avoids direct window globals',
+  !/window\./.test(src));
+assert('Light channel actions stay delegated through data attributes',
+  /lightChannelActionDelegateRoots = new WeakSet\(\);/.test(src)
+    && /root\.addEventListener\('click', handleLightChannelActionClick\)/.test(src)
+    && /data-light-channel-action="toggle-detail"/.test(src)
+    && /data-light-channel-action="quick-log-sun"/.test(src)
+    && /data-light-channel-action="quick-log-device"/.test(src));
+assert('Light channel feature hook wires runtime dependencies',
+  /configureLightChannelView\(\{/.test(hooksSrc)
+    && /channelDisplay: CHANNEL_DISPLAY/.test(hooksSrc)
+    && /dailyChannelBreakdown/.test(hooksSrc)
+    && /dailyVitaminDIUBreakdown/.test(hooksSrc)
+    && /pbmJoulesPerCm2/.test(hooksSrc)
+    && /rollingDeviceTotals/.test(hooksSrc)
+    && /quickLogDeviceSession/.test(hooksSrc)
+    && /quickLogSunSession/.test(hooksSrc));
+assert('Light channel UI hook wires router dependency',
+  /import \{ navigate \} from '\.\/views\.js';/.test(uiHooksSrc)
+    && /configureLightChannelView\(\{ navigate \}\);/.test(uiHooksSrc));
+assert('Light channel hooks are loaded during startup',
+  lightSunModulesSrc.includes("import './light-channel-view-hooks.js';")
+    && uiShellModulesSrc.includes("import './light-channel-view-ui-hooks.js';"));
+assert('Service worker caches Light channel hooks',
+  swSrc.includes("'/js/light-channel-view-hooks.js'")
+    && swSrc.includes("'/js/light-channel-view-ui-hooks.js'"));
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -686,6 +686,12 @@
     const hasLightChannelViewJs = sw.includes('/js/light-channel-view.js');
     assert('Service worker caches js/light-channel-view.js', hasLightChannelViewJs);
 
+    const hasLightChannelViewHooksJs = sw.includes('/js/light-channel-view-hooks.js');
+    assert('Service worker caches js/light-channel-view-hooks.js', hasLightChannelViewHooksJs);
+
+    const hasLightChannelViewUiHooksJs = sw.includes('/js/light-channel-view-ui-hooks.js');
+    assert('Service worker caches js/light-channel-view-ui-hooks.js', hasLightChannelViewUiHooksJs);
+
     const hasLightSessionsViewJs = sw.includes('/js/light-sessions-view.js');
     assert('Service worker caches js/light-sessions-view.js', hasLightSessionsViewJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.535';
+self.APP_VERSION = '1.8.536';


### PR DESCRIPTION
## Summary
- Add `configureLightChannelView` and startup hook modules so the Light channel renderer receives Sun/device/router helpers through explicit runtime wiring instead of direct `window.*` reads.
- Cache the new hook modules in the service worker and load them from the Light/Sun and UI shell startup bundles.
- Update browser/static coverage and ratchet `windowReferences` from 1204 to 1164 while keeping the large-file count stable.

## Validation
- `npm run typecheck`
- `npm run quality`
- `node tests/test-light-channel-view-delegated-actions.js`
- `node tests/test-light-page-view-delegated-actions.js`
- `npm run test:playwright -- tests/playwright/light-coverage-batch-2.spec.js`
- `./run-tests.sh`