### PR TITLE
[codex] Wire Sun context runtime deps

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -14,6 +14,7 @@ import './light-sun-ai-hooks.js';
 import './light-tools.js';
 import './light-tools-ai-analysis.js';
 import './light-env.js';
+import './sun-context-hooks.js';
 import './light-env-ai-analysis.js';
 import './light-screen-ai-analysis.js';
 import './light-audit-ai-analysis.js';

--- a/js/sun-context-hooks.js
+++ b/js/sun-context-hooks.js
@@ -1,0 +1,40 @@
+// @ts-check
+// sun-context-hooks.js - wire Sun AI context dependencies at startup.
+
+import {
+  BODY_REGIONS,
+  CHANNEL_DISPLAY,
+  cumulativeMEDToday,
+  rollingChannelTotals,
+  tierLabel,
+  weeklyChannelTier,
+} from './sun.js';
+import {
+  VITD_DAILY_SATURATION_IU,
+  circadianMelanopicLux,
+  pbmJoulesPerCm2,
+  vitaminDIUPerSession,
+} from './sun-spectrum.js';
+import { getMeteoConfig } from './sun-uvdata.js';
+import { rollingDeviceTotals } from './light-devices-store.js';
+import { computeDeficitAxes, computeIndoorBurden } from './light-env.js';
+import { isDebugMode } from './utils.js';
+import { configureSunContext } from './sun-context.js';
+
+configureSunContext({
+  bodyRegions: BODY_REGIONS,
+  channelDisplay: CHANNEL_DISPLAY,
+  circadianMelanopicLux,
+  computeDeficitAxes,
+  computeIndoorBurden,
+  cumulativeMEDToday,
+  getMeteoConfig,
+  isDebugMode,
+  pbmJoulesPerCm2,
+  rollingChannelTotals,
+  rollingDeviceTotals,
+  tierLabel,
+  vitaminDDailySaturationIU: VITD_DAILY_SATURATION_IU,
+  vitaminDIUPerSession,
+  weeklyChannelTier,
+});

--- a/js/sun-context.js
+++ b/js/sun-context.js
@@ -19,6 +19,50 @@ import {
   roomUsesEveningAfterSunset,
 } from './light-env-evening.js';
 
+const DEFAULT_TIER_LABELS = ['none', 'low', 'moderate', 'good', 'strong'];
+
+/** @type {Record<string, any>} */
+const sunContextDeps = {
+  bodyRegions: [],
+  channelDisplay: {},
+  circadianMelanopicLux: null,
+  computeDeficitAxes: null,
+  computeIndoorBurden: null,
+  cumulativeMEDToday: () => 0,
+  getMeteoConfig: () => ({ privacyRounding: 0.01 }),
+  isDebugMode: () => false,
+  pbmJoulesPerCm2: null,
+  rollingChannelTotals: () => ({}),
+  rollingDeviceTotals: () => ({}),
+  tierLabel: tier => DEFAULT_TIER_LABELS[tier] || 'none',
+  vitaminDDailySaturationIU: 20000,
+  vitaminDIUPerSession: null,
+  weeklyChannelTier: null,
+};
+
+export function configureSunContext(deps = {}) {
+  const previous = { ...sunContextDeps };
+  for (const [key, value] of Object.entries(deps || {})) {
+    if (Object.prototype.hasOwnProperty.call(sunContextDeps, key)) {
+      sunContextDeps[key] = value;
+    } else {
+      _debugWarn('[sun-context] ignoring unknown dependency key', key);
+    }
+  }
+  return previous;
+}
+
+function _debugWarn(...args) {
+  if (typeof sunContextDeps.isDebugMode === 'function' && sunContextDeps.isDebugMode()) {
+    console.warn(...args);
+  }
+}
+
+function _bodyRegionFractionByKey() {
+  const regions = Array.isArray(sunContextDeps.bodyRegions) ? sunContextDeps.bodyRegions : [];
+  return Object.fromEntries(regions.map(r => [r.key, r.fraction]));
+}
+
 // Sanitize user-supplied strings before interpolating into AI prompts.
 // Mirrors the helper in light-env-ai-analysis.js / light-today-ai.js.
 // User-typed device.brand / device.model / room.name reach the always-
@@ -190,13 +234,13 @@ function _trimToBudget(ctx, budget, aggressive = false) {
 function alwaysTierBlock(sessions) {
   // Combine outdoor sun + indoor device contributions — channels reflect the
   // full biological state, not just one source class.
-  const sunTot7 = window.rollingChannelTotals ? window.rollingChannelTotals(7) : {};
-  const sunTot30 = window.rollingChannelTotals ? window.rollingChannelTotals(30) : {};
-  const devTot7 = window.rollingDeviceTotals ? window.rollingDeviceTotals(7) : {};
-  const devTot30 = window.rollingDeviceTotals ? window.rollingDeviceTotals(30) : {};
+  const sunTot7 = (typeof sunContextDeps.rollingChannelTotals === 'function' ? sunContextDeps.rollingChannelTotals(7) : null) || {};
+  const sunTot30 = (typeof sunContextDeps.rollingChannelTotals === 'function' ? sunContextDeps.rollingChannelTotals(30) : null) || {};
+  const devTot7 = (typeof sunContextDeps.rollingDeviceTotals === 'function' ? sunContextDeps.rollingDeviceTotals(7) : null) || {};
+  const devTot30 = (typeof sunContextDeps.rollingDeviceTotals === 'function' ? sunContextDeps.rollingDeviceTotals(30) : null) || {};
   const totals7d = mergeTotalsCtx(sunTot7, devTot7);
   const totals30d = mergeTotalsCtx(sunTot30, devTot30);
-  const medToday = window.cumulativeMEDToday ? window.cumulativeMEDToday() : 0;
+  const medToday = typeof sunContextDeps.cumulativeMEDToday === 'function' ? sunContextDeps.cumulativeMEDToday() : 0;
   const lastSession = sessions.filter(s => s.endedAt).slice(-1)[0];
   const activeSession = sessions.find(s => !s.endedAt);
 
@@ -491,9 +535,9 @@ function lightEnvironmentBlock() {
   }
   // Indoor burden tier + deficit axes — collapsed onto one line. Burden is
   // the qualitative summary, d2/d3 are the components that drove it.
-  if (typeof window.computeIndoorBurden === 'function') {
+  if (typeof sunContextDeps.computeIndoorBurden === 'function') {
     try {
-      const burden = window.computeIndoorBurden();
+      const burden = sunContextDeps.computeIndoorBurden();
       if (burden && typeof burden === 'object') {
         // Use the helper's own label so the AI surface matches the
         // page UI verbatim. The helper returns 3 tiers (0/1/2 →
@@ -501,20 +545,20 @@ function lightEnvironmentBlock() {
         // map that didn't exist anywhere else.
         const burdenLabel = burden.label || ['Light load', 'Moderate load', 'Heavy load'][burden.tier] || 'unknown';
         let line = `- Indoor light burden: ${burdenLabel} (tier ${burden.tier}/2 · 0=light, 2=heavy across screens/sleep/daylight)`;
-        if (typeof window.computeDeficitAxes === 'function') {
+        if (typeof sunContextDeps.computeDeficitAxes === 'function') {
           try {
-            const axes = window.computeDeficitAxes();
+            const axes = sunContextDeps.computeDeficitAxes();
             if (axes && (axes.d2 != null || axes.d3 != null)) {
               line += ` · d2=${(axes.d2 ?? 0).toFixed(2)} (intensity gap, 0=no gap, 5+=severe) · d3=${(axes.d3 ?? 0).toFixed(2)} (after-sunset blue, 0=clean, 3+=heavy)`;
             }
           } catch (e) {
-            if (window.isDebugMode && window.isDebugMode()) console.warn('[sun-context] computeDeficitAxes failed', e);
+            _debugWarn('[sun-context] computeDeficitAxes failed', e);
           }
         }
         s += line + '\n';
       }
     } catch (e) {
-      if (window.isDebugMode && window.isDebugMode()) console.warn('[sun-context] indoor-burden line build failed', e);
+      _debugWarn('[sun-context] indoor-burden line build failed', e);
     }
   }
   // Concrete tool measurements that warrant the AI's attention. We
@@ -629,10 +673,8 @@ function standardTierBlock(sessions) {
   // (without this, raw channel-au sums to nonsense for vit-D).
   const _genetics = state.importedData?.genetics || null;
   const _fitzForDevice = state.importedData?.sunDefaults?.fitzpatrick || 'III';
-  const _perSession = (typeof window !== 'undefined' && typeof window.vitaminDIUPerSession === 'function') ? window.vitaminDIUPerSession : null;
-  const _fracByKey = (typeof window !== 'undefined' && window.BODY_REGIONS)
-    ? Object.fromEntries(window.BODY_REGIONS.map(r => [r.key, r.fraction]))
-    : {};
+  const _perSession = typeof sunContextDeps.vitaminDIUPerSession === 'function' ? sunContextDeps.vitaminDIUPerSession : null;
+  const _fracByKey = _bodyRegionFractionByKey();
   const _broadFracs = { face: 0.04, arms: 0.10, torso: 0.13, legs: 0.30, 'whole-body': 0.92, targeted: 0.05 };
   const _devBodyFrac = (s) => {
     if (Array.isArray(s.bodyAreas) && s.bodyAreas.length > 0) {
@@ -678,8 +720,8 @@ function standardTierBlock(sessions) {
     // pattern but on a representative 1-hour basis. The AI cares about
     // shape week-to-week, not absolute lux-h here (always-tier already
     // shows the absolute 7d total).
-    if (typeof window.circadianMelanopicLux === 'function') {
-      return Math.round(window.circadianMelanopicLux(weeklyAu, 60) * 1); // 60-min basis
+    if (typeof sunContextDeps.circadianMelanopicLux === 'function') {
+      return Math.round(sunContextDeps.circadianMelanopicLux(weeklyAu, 60) * 1); // 60-min basis
     }
     return Math.round(weeklyAu);
   };
@@ -704,7 +746,7 @@ function standardTierBlock(sessions) {
     } else if (k === 'nir_solar' || k === 'pbm_red' || k === 'pbm_nir') {
       formatted = b.map(v => {
         if (v <= 0) return '0';
-        const j = typeof window.pbmJoulesPerCm2 === 'function' ? window.pbmJoulesPerCm2(v) : v / 10000;
+        const j = typeof sunContextDeps.pbmJoulesPerCm2 === 'function' ? sunContextDeps.pbmJoulesPerCm2(v) : v / 10000;
         return fmtJ(j);
       }).join('→');
     } else {
@@ -748,7 +790,7 @@ function _correlationsBlock() {
   let corr = state.importedData?.sunCorrelations;
   if (!corr || !corr.pairs) {
     try { corr = getSunCorrelations(); } catch (e) {
-      if (window.isDebugMode && window.isDebugMode()) console.warn('[sun-context] getSunCorrelations failed', e);
+      _debugWarn('[sun-context] getSunCorrelations failed', e);
     }
   }
   if (corr && corr.pairs) {
@@ -842,8 +884,11 @@ function _projectSession(sess, fields) {
   if (fields.includes('location') && sess.location) {
     // Honor the user's network privacyRounding setting; default to 0.01°.
     let p = 0.01;
-    try { p = (window.getMeteoConfig && window.getMeteoConfig().privacyRounding) || 0.01; } catch (e) {
-      if (window.isDebugMode && window.isDebugMode()) console.warn('[sun-context] getMeteoConfig failed', e);
+    try {
+      const cfg = typeof sunContextDeps.getMeteoConfig === 'function' ? sunContextDeps.getMeteoConfig() : null;
+      p = cfg?.privacyRounding || 0.01;
+    } catch (e) {
+      _debugWarn('[sun-context] getMeteoConfig failed', e);
     }
     const f = 1 / p;
     out.location = {
@@ -932,20 +977,24 @@ function formatChannelTotals(totals) {
   // Targets are daily; rolling window is 7d, so weekly target is ×7. Use
   // the canonical weeklyChannelTier so the AI rollup, the dashboard
   // strip, and the per-channel drill-down all agree.
-  const tierLabel = window.tierLabel || ((t) => ['none','low','moderate','good','strong'][t] || 'none');
-  const channelTier = window.weeklyChannelTier || ((v, k) => {
-    const meta = (window.CHANNEL_DISPLAY || {})[k];
-    if (!meta || !meta.dailyTarget) return 0;
-    const target = meta.dailyTarget * 7;
-    if (!Number.isFinite(v) || v <= 0) return 0;
-    const r = v / target;
-    if (r < 0.20) return 1;
-    if (r < 0.55) return 2;
-    if (r < 1.00) return 3;
-    return 4;
-  });
+  const tierLabel = typeof sunContextDeps.tierLabel === 'function'
+    ? sunContextDeps.tierLabel
+    : (t) => DEFAULT_TIER_LABELS[t] || 'none';
+  const channelTier = typeof sunContextDeps.weeklyChannelTier === 'function'
+    ? sunContextDeps.weeklyChannelTier
+    : ((v, k) => {
+      const meta = (sunContextDeps.channelDisplay || {})[k];
+      if (!meta || !meta.dailyTarget) return 0;
+      const target = meta.dailyTarget * 7;
+      if (!Number.isFinite(v) || v <= 0) return 0;
+      const r = v / target;
+      if (r < 0.20) return 1;
+      if (r < 0.55) return 2;
+      if (r < 1.00) return 3;
+      return 4;
+    });
 
-  // Per-unit rollup helpers. Walk recent sessions/devices in window so
+  // Per-unit rollup helpers. Walk recent sessions/devices so
   // per-session conversions (UVI gate, Fitzpatrick, IU saturation) apply
   // correctly. Sum afterwards rather than scaling the channel-au total.
   const cutoff = Date.now() - 7 * 86400 * 1000;
@@ -956,8 +1005,8 @@ function formatChannelTotals(totals) {
   // body-fraction cap → per-day saturation cap → sum capped days. Both
   // functions are user-visible 7-day totals and must agree.
   const _gx = state.importedData?.genetics || null;
-  const _perSession = (typeof window !== 'undefined' && typeof window.vitaminDIUPerSession === 'function') ? window.vitaminDIUPerSession : null;
-  const _cap = (typeof window !== 'undefined' && Number.isFinite(window.VITD_DAILY_SATURATION_IU)) ? window.VITD_DAILY_SATURATION_IU : 20000;
+  const _perSession = typeof sunContextDeps.vitaminDIUPerSession === 'function' ? sunContextDeps.vitaminDIUPerSession : null;
+  const _cap = Number.isFinite(sunContextDeps.vitaminDDailySaturationIU) ? sunContextDeps.vitaminDDailySaturationIU : 20000;
   const _localDayKey = (ts) => {
     const d = new Date(ts);
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
@@ -977,9 +1026,7 @@ function formatChannelTotals(totals) {
   // UVB device sessions. uvi=null (device IS the UVB source);
   // rotatedSides=false (devices track skin% on bodyAreas, not anatomical sides).
   const _fitzForDevice = state.importedData?.sunDefaults?.fitzpatrick || 'III';
-  const _fracByKey = (typeof window !== 'undefined' && window.BODY_REGIONS)
-    ? Object.fromEntries(window.BODY_REGIONS.map(r => [r.key, r.fraction]))
-    : {};
+  const _fracByKey = _bodyRegionFractionByKey();
   const _broadFracs = { face: 0.04, arms: 0.10, torso: 0.13, legs: 0.30, 'whole-body': 0.92, targeted: 0.05 };
   for (const s of deviceSessions) {
     const au = s.doses?.vitamin_d;
@@ -1004,8 +1051,8 @@ function formatChannelTotals(totals) {
     const au = s.doses?.circadian;
     const dur = s.durationMin || 0;
     if (!Number.isFinite(au) || au <= 0 || dur <= 0) continue;
-    if (typeof window.circadianMelanopicLux === 'function') {
-      const lux = window.circadianMelanopicLux(au, dur);
+    if (typeof sunContextDeps.circadianMelanopicLux === 'function') {
+      const lux = sunContextDeps.circadianMelanopicLux(au, dur);
       totalLuxHours += lux * (dur / 60);
     }
   }
@@ -1015,7 +1062,7 @@ function formatChannelTotals(totals) {
     for (const s of [...sunSessions, ...deviceSessions]) {
       const au = s.doses?.[k];
       if (!Number.isFinite(au) || au <= 0) continue;
-      j += typeof window.pbmJoulesPerCm2 === 'function' ? window.pbmJoulesPerCm2(au) : au / 10000;
+      j += typeof sunContextDeps.pbmJoulesPerCm2 === 'function' ? sunContextDeps.pbmJoulesPerCm2(au) : au / 10000;
     }
     return j;
   };

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1164,
+  "windowReferences": 1119,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -324,6 +324,7 @@ const APP_SHELL = [
   '/js/sun-body-silhouette.js',
   '/js/sun-ai-analysis.js',
   '/js/sun-context.js',
+  '/js/sun-context-hooks.js',
   '/js/sun-correlations.js',
   '/js/sun-defaults.js',
   '/js/sun-onboarding-ai.js',

--- a/tests/playwright/sun-context-browser-coverage.spec.js
+++ b/tests/playwright/sun-context-browser-coverage.spec.js
@@ -23,18 +23,6 @@ test('sun context browser coverage handles consent slices deficits and trimming'
     const saved = {
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
-      BODY_REGIONS: window.BODY_REGIONS,
-      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
-      rollingChannelTotals: window.rollingChannelTotals,
-      rollingDeviceTotals: window.rollingDeviceTotals,
-      cumulativeMEDToday: window.cumulativeMEDToday,
-      vitaminDIUPerSession: window.vitaminDIUPerSession,
-      VITD_DAILY_SATURATION_IU: window.VITD_DAILY_SATURATION_IU,
-      circadianMelanopicLux: window.circadianMelanopicLux,
-      pbmJoulesPerCm2: window.pbmJoulesPerCm2,
-      computeIndoorBurden: window.computeIndoorBurden,
-      computeDeficitAxes: window.computeDeficitAxes,
-      getMeteoConfig: window.getMeteoConfig,
     };
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
       const key = localStorage.key(i);
@@ -46,6 +34,12 @@ test('sun context browser coverage handles consent slices deficits and trimming'
     const profileId = `sun-context-${Date.now()}`;
     const channels = ['vitamin_d', 'circadian', 'nir_solar', 'pbm_red', 'pbm_nir', 'no_cv', 'pomc', 'violet_eye'];
     const zeroTotals = Object.fromEntries(channels.map(key => [key, 0]));
+    const bodyRegions = [
+      { key: 'face', fraction: 0.04 },
+      { key: 'chest', fraction: 0.13 },
+      { key: 'arms', fraction: 0.10 },
+    ];
+    let restoreDeps = null;
     const makeSession = (index, overrides = {}) => ({
       id: `sun-session-${index}`,
       startedAt: now - (index + 1) * day + 9 * 3600000,
@@ -69,25 +63,23 @@ test('sun context browser coverage handles consent slices deficits and trimming'
     });
 
     try {
+      restoreDeps = sunContext.configureSunContext({
+        bodyRegions,
+        channelDisplay: Object.fromEntries(channels.map(key => [key, { dailyTarget: 1000 }])),
+        rollingChannelTotals: days => days >= 30 ? zeroTotals : { ...zeroTotals, vitamin_d: 300, circadian: 500 },
+        rollingDeviceTotals: () => ({}),
+        cumulativeMEDToday: () => 1.15,
+        vitaminDIUPerSession: au => au * 40,
+        vitaminDDailySaturationIU: 20000,
+        circadianMelanopicLux: (au, min) => au / Math.max(1, min),
+        pbmJoulesPerCm2: au => au / 1000,
+        computeIndoorBurden: () => ({ tier: 2, label: 'Heavy load' }),
+        computeDeficitAxes: () => ({ d2: 6.25, d3: 3.5 }),
+        getMeteoConfig: () => ({ privacyRounding: 0.1 }),
+      });
       localStorage.setItem('labcharts-active-profile', profileId);
       localStorage.removeItem(`labcharts-${profileId}-ai-include-body-regions`);
       state.currentProfile = profileId;
-      window.BODY_REGIONS = [
-        { key: 'face', fraction: 0.04 },
-        { key: 'chest', fraction: 0.13 },
-        { key: 'arms', fraction: 0.10 },
-      ];
-      window.CHANNEL_DISPLAY = Object.fromEntries(channels.map(key => [key, { dailyTarget: 1000 }]));
-      window.rollingChannelTotals = days => days >= 30 ? zeroTotals : { ...zeroTotals, vitamin_d: 300, circadian: 500 };
-      window.rollingDeviceTotals = () => ({});
-      window.cumulativeMEDToday = () => 1.15;
-      window.vitaminDIUPerSession = au => au * 40;
-      window.VITD_DAILY_SATURATION_IU = 20000;
-      window.circadianMelanopicLux = (au, min) => au / Math.max(1, min);
-      window.pbmJoulesPerCm2 = au => au / 1000;
-      window.computeIndoorBurden = () => ({ tier: 2, label: 'Heavy load' });
-      window.computeDeficitAxes = () => ({ d2: 6.25, d3: 3.5 });
-      window.getMeteoConfig = () => ({ privacyRounding: 0.1 });
 
       const rooms = Array.from({ length: 7 }, (_, i) => ({
         id: `room-${i}`,
@@ -203,20 +195,7 @@ test('sun context browser coverage handles consent slices deficits and trimming'
     } finally {
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
-      Object.assign(window, {
-        BODY_REGIONS: saved.BODY_REGIONS,
-        CHANNEL_DISPLAY: saved.CHANNEL_DISPLAY,
-        rollingChannelTotals: saved.rollingChannelTotals,
-        rollingDeviceTotals: saved.rollingDeviceTotals,
-        cumulativeMEDToday: saved.cumulativeMEDToday,
-        vitaminDIUPerSession: saved.vitaminDIUPerSession,
-        VITD_DAILY_SATURATION_IU: saved.VITD_DAILY_SATURATION_IU,
-        circadianMelanopicLux: saved.circadianMelanopicLux,
-        pbmJoulesPerCm2: saved.pbmJoulesPerCm2,
-        computeIndoorBurden: saved.computeIndoorBurden,
-        computeDeficitAxes: saved.computeDeficitAxes,
-        getMeteoConfig: saved.getMeteoConfig,
-      });
+      if (restoreDeps) sunContext.configureSunContext(restoreDeps);
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/test-sun-context.js
+++ b/tests/test-sun-context.js
@@ -20,7 +20,8 @@ await import('../js/state.js');
 // gates on its presence. Importing it makes the gate fire.
 await import('../js/lab-context.js');
 const ctxMod = await import('../js/sun-context.js');
-const { buildSunContext } = ctxMod;
+await import('../js/sun-context-hooks.js');
+const { buildSunContext, configureSunContext } = ctxMod;
 
   const orig = window._labState.importedData;
   function reset(seed = {}) {
@@ -193,6 +194,17 @@ const { buildSunContext } = ctxMod;
   const { getSunSessionsSlice, getSunSessionDetail } = ctxMod;
   assert('getSunSessionsSlice exported', typeof getSunSessionsSlice === 'function');
   assert('getSunSessionDetail exported', typeof getSunSessionDetail === 'function');
+  let unknownDepWarned = false;
+  const restoreUnknownDeps = configureSunContext({ isDebugMode: () => true });
+  const origConsoleWarn = console.warn;
+  try {
+    console.warn = (...args) => { unknownDepWarned ||= String(args[0] || '').includes('unknown dependency key'); };
+    configureSunContext({ notARealSunContextDep: true });
+  } finally {
+    console.warn = origConsoleWarn;
+    configureSunContext(restoreUnknownDeps);
+  }
+  assert('configureSunContext warns on unknown dependency keys in debug mode', unknownDepWarned);
 
   // Default slice — last 30 days, default field set
   const slice = getSunSessionsSlice();
@@ -257,20 +269,17 @@ const { buildSunContext } = ctxMod;
   // ─── 6. Privacy: location rounding (slice + detail honor config) ────
   console.log('%c 6. Privacy-aware location rounding ', 'font-weight:bold;color:#f59e0b');
 
-  const origGetMeteoConfig = window.getMeteoConfig;
-  window.getMeteoConfig = () => ({ privacyRounding: 0.1 });
+  const restoreMeteoDeps = configureSunContext({ getMeteoConfig: () => ({ privacyRounding: 0.1 }) });
   const detailCoarse = getSunSessionDetail('locked');
   assert('Detail rounds lat to 0.1° privacy',
     detailCoarse.location.lat === 50.1 && detailCoarse.location.lon === 14.4);
 
-  window.getMeteoConfig = () => ({ privacyRounding: 0.01 });
+  configureSunContext({ getMeteoConfig: () => ({ privacyRounding: 0.01 }) });
   const detailSharp = getSunSessionDetail('locked');
   assert('Detail rounds lat to 0.01° privacy',
     detailSharp.location.lat === 50.07 && detailSharp.location.lon === 14.44);
 
-  // restore
-  if (origGetMeteoConfig) window.getMeteoConfig = origGetMeteoConfig;
-  else delete window.getMeteoConfig;
+  configureSunContext(restoreMeteoDeps);
 
   // ─── 7. Section markers always present ───────────────────────────────
   console.log('%c 7. Section marker discipline ', 'font-weight:bold;color:#f59e0b');
@@ -384,13 +393,15 @@ const { buildSunContext } = ctxMod;
   // Stub the burden helper. Helper returns 3 tiers (0=Light/1=Moderate/
   // 2=Heavy load); the AI line surfaces the helper's label verbatim so
   // it matches the page UI rather than inventing a parallel scale.
-  window.computeIndoorBurden = () => ({ tier: 2, label: 'Heavy load', note: 'high' });
+  const restoreBurdenDeps = configureSunContext({
+    computeIndoorBurden: () => ({ tier: 2, label: 'Heavy load', note: 'high' }),
+  });
   const withRubric = buildSunContext({ tier: 'always' });
   assert('Burden line names the qualitative tier',
     /tier 2\/2/.test(withRubric) && /Heavy load/.test(withRubric));
   assert('Burden line carries inline 0=light … 2=heavy rubric',
     /0=light, 2=heavy/.test(withRubric));
-  delete window.computeIndoorBurden;
+  configureSunContext(restoreBurdenDeps);
 
   // ─── 10. Room-name resolution in tool warnings ───────────────────────
   console.log('%c 10. Tool warning roomId → name ', 'font-weight:bold;color:#f59e0b');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -692,6 +692,9 @@
     const hasLightChannelViewUiHooksJs = sw.includes('/js/light-channel-view-ui-hooks.js');
     assert('Service worker caches js/light-channel-view-ui-hooks.js', hasLightChannelViewUiHooksJs);
 
+    const hasSunContextHooksJs = sw.includes('/js/sun-context-hooks.js');
+    assert('Service worker caches js/sun-context-hooks.js', hasSunContextHooksJs);
+
     const hasLightSessionsViewJs = sw.includes('/js/light-sessions-view.js');
     assert('Service worker caches js/light-sessions-view.js', hasLightSessionsViewJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.536';
+self.APP_VERSION = '1.8.537';


### PR DESCRIPTION
## Summary
- Add `configureSunContext` and a startup hook so Sun AI context helpers are wired from canonical modules instead of direct `window.*` reads.
- Cache and load the new hook module from the Light/Sun startup bundle, with service-worker coverage guarded in `verify-modules`.
- Update focused node/browser tests to configure and restore Sun context deps directly, and ratchet `windowReferences` from 1164 to 1119.

## Validation
- `npm run typecheck`
- `npm run quality`
- `node tests/test-sun-context.js`
- `npm run test:playwright -- tests/playwright/sun-context-browser-coverage.spec.js`
- `./run-tests.sh`