### PR TITLE
[codex] Wire Light conditions runtime deps

### DIFF
--- a/js/app-light-sun-modules.js
+++ b/js/app-light-sun-modules.js
@@ -15,6 +15,7 @@ import './light-tools.js';
 import './light-tools-ai-analysis.js';
 import './light-env.js';
 import './sun-context-hooks.js';
+import './light-conditions-now-hooks.js';
 import './light-env-ai-analysis.js';
 import './light-screen-ai-analysis.js';
 import './light-audit-ai-analysis.js';

--- a/js/light-conditions-now-hooks.js
+++ b/js/light-conditions-now-hooks.js
@@ -1,0 +1,25 @@
+// @ts-check
+// light-conditions-now-hooks.js - wire Conditions Now runtime dependencies at startup.
+
+import { saveImportedData } from './data.js';
+import {
+  computeUVConfidence,
+  fetchAtmosphere,
+  purgeMeteoCache,
+  solarZenithAngle,
+} from './sun-uvdata.js';
+import { _applyAtmOverrides, getSunCoords } from './sun.js';
+import { isDebugMode, showNotification } from './utils.js';
+import { configureLightConditionsNow } from './light-conditions-now.js';
+
+configureLightConditionsNow({
+  applyAtmOverrides: _applyAtmOverrides,
+  computeUVConfidence,
+  fetchAtmosphere,
+  getSunCoords,
+  isDebugMode,
+  purgeMeteoCache,
+  saveImportedData,
+  showNotification,
+  solarZenithAngle,
+});

--- a/js/light-conditions-now.js
+++ b/js/light-conditions-now.js
@@ -8,6 +8,59 @@ import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.
 const LIGHT_CONDITIONS_ACTION_ATTR = 'data-light-conditions-action';
 const LIGHT_CONDITIONS_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightConditionsActionDelegatesInstalled');
 const lightConditionsActionDelegateRoots = new WeakSet();
+/** @type {Record<string, any>} */
+const lightConditionsDeps = {
+  applyAtmOverrides: atm => atm,
+  computeUVConfidence: null,
+  fetchAtmosphere: null,
+  getSunCoords: () => null,
+  isDebugMode: () => false,
+  purgeMeteoCache: () => {},
+  saveImportedData: null,
+  showNotification: null,
+  solarZenithAngle: null,
+};
+
+export function configureLightConditionsNow(deps = {}) {
+  const previous = { ...lightConditionsDeps };
+  for (const [key, value] of Object.entries(deps || {})) {
+    if (Object.prototype.hasOwnProperty.call(lightConditionsDeps, key)) {
+      lightConditionsDeps[key] = value;
+    } else {
+      _debugWarn('[light-conditions-now] ignoring unknown dependency key', key);
+    }
+  }
+  return previous;
+}
+
+function _debugWarn(...args) {
+  if (typeof lightConditionsDeps.isDebugMode === 'function' && lightConditionsDeps.isDebugMode()) {
+    console.warn(...args);
+  }
+}
+
+function _getSunCoords() {
+  try {
+    return lightConditionsDeps.getSunCoords() || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function _solarZenithAngle(date, coords) {
+  if (!coords || typeof lightConditionsDeps.solarZenithAngle !== 'function') return null;
+  try {
+    return lightConditionsDeps.solarZenithAngle(date, coords.lat, coords.lon);
+  } catch (_) {
+    return null;
+  }
+}
+
+function _notify(...args) {
+  if (typeof lightConditionsDeps.showNotification === 'function') {
+    lightConditionsDeps.showNotification(...args);
+  }
+}
 
 function closestLightConditionsAction(target) {
   if (!target || !target.closest) return null;
@@ -64,8 +117,8 @@ export function renderLightConditionsWidgetBody({ variant = 'full', slotId = '' 
 }
 
 // "Conditions now" strip — renders current UVI / ozone / AQI / sun-angle
-// for the user's resolved coords. Lazy-fetches via window.fetchAtmosphere
-// (which has its own 1hr cache layer). On fetch failure, falls back to
+// for the user's resolved coords. Lazy-fetches via the injected atmosphere
+// provider, which has its own 1hr cache layer. On fetch failure, falls back to
 // cached or zenith-only estimate and shows a "stale" indicator. Designed
 // to work fully offline once any earlier fetch has populated the cache.
 //
@@ -96,7 +149,7 @@ function _coordKey(coords) {
 }
 
 export function getCachedConditionsAtmosphere() {
-  const coords = (typeof window !== 'undefined' && window.getSunCoords && window.getSunCoords()) || null;
+  const coords = _getSunCoords();
   const key = _coordKey(coords);
   return (_conditionsCache && _conditionsCache.coordKey === key) ? _conditionsCache.atm : null;
 }
@@ -145,7 +198,7 @@ export function renderConditionsNow(opts = {}) {
   // "Loading current conditions…" spinner before the cache resolved
   // ~50ms later, which the user perceived as "conditions not persistent."
   try {
-    const coords = (typeof window !== 'undefined' && window.getSunCoords && window.getSunCoords()) || null;
+    const coords = _getSunCoords();
     if (coords && _conditionsCache && _conditionsCache.coordKey === _coordKey(coords)
         && (Date.now() - _conditionsCache.fetchedAt) < 5 * 60 * 1000) {
       setTimeout(() => _centerConditionsNowMarker(slotId), 0);
@@ -170,7 +223,7 @@ async function _refreshConditions(slotId, variant, opts = {}) {
   // aria-busy="true" so screen readers don't announce intermediate
   // values. Whatever path resolves first must clear it.
   const _resolveBusy = () => slot.setAttribute('aria-busy', 'false');
-  const coords = (window.getSunCoords && window.getSunCoords()) || null;
+  const coords = _getSunCoords();
   if (!coords) {
     _resolveBusy();
     slot.innerHTML = `<div class="conditions-now-msg">Set a country in your profile to see current sun conditions.</div>`;
@@ -212,14 +265,19 @@ async function _refreshConditions(slotId, variant, opts = {}) {
     if (opts.force) _bustMeteoCacheForCoords(coords);
     let atm = null, online = true, fetchError = null;
     try {
-      atm = await window.fetchAtmosphere({
+      if (typeof lightConditionsDeps.fetchAtmosphere !== 'function') {
+        throw new Error('fetchAtmosphere unavailable');
+      }
+      atm = await lightConditionsDeps.fetchAtmosphere({
         lat: coords.lat,
         lon: coords.lon,
         isoTime: new Date().toISOString(),
         noCache: !!opts.force, // user-triggered refresh skips both fresh + stale cache
       });
       if (atm?._stale) online = false;
-      if (atm && window._applyAtmOverrides) atm = window._applyAtmOverrides(atm);
+      if (atm && typeof lightConditionsDeps.applyAtmOverrides === 'function') {
+        atm = lightConditionsDeps.applyAtmOverrides(atm);
+      }
     } catch (e) {
       online = false;
       fetchError = String(e?.message || e);
@@ -249,9 +307,7 @@ async function _refreshConditions(slotId, variant, opts = {}) {
         src.classList.add('just-refreshed');
         setTimeout(() => src.classList.remove('just-refreshed'), 1500);
       }
-      if (typeof window.showNotification === 'function') {
-        window.showNotification(online ? '✓ Conditions refreshed' : '✓ Cached values reloaded (offline)');
-      }
+      _notify(online ? '✓ Conditions refreshed' : '✓ Cached values reloaded (offline)');
     }
   } finally {
     _conditionsFetchInFlight = false;
@@ -266,8 +322,8 @@ async function _refreshConditions(slotId, variant, opts = {}) {
 // during a relay-side outage) can recover without tab-killing — the
 // next fetch hits the provider chain fresh.
 export function _refreshConditionsNow() {
-  if (typeof window.purgeMeteoCache === 'function') {
-    try { window.purgeMeteoCache(); } catch {}
+  if (typeof lightConditionsDeps.purgeMeteoCache === 'function') {
+    try { lightConditionsDeps.purgeMeteoCache(); } catch {}
   }
   document.querySelectorAll('.conditions-now').forEach(el => {
     const slot = /** @type {HTMLElement} */ (el);
@@ -282,7 +338,7 @@ export async function _setManualUvi() {
   if (!input) return;
   const v = parseFloat(input.value);
   if (!Number.isFinite(v) || v < 0 || v > 20) {
-    if (window.showNotification) window.showNotification('UVI must be between 0 and 20', 'error');
+    _notify('UVI must be between 0 and 20', 'error');
     return;
   }
   const data = state.importedData;
@@ -290,12 +346,12 @@ export async function _setManualUvi() {
   if (!data.sunDefaults) data.sunDefaults = {};
   if (!data.sunDefaults.overrides) data.sunDefaults.overrides = {};
   data.sunDefaults.overrides.uvIndex = v;
-  if (window.saveImportedData) await window.saveImportedData();
+  if (typeof lightConditionsDeps.saveImportedData === 'function') await lightConditionsDeps.saveImportedData();
   // Bust the in-memory conditions cache so the next render re-renders with
   // the override applied. Fetch isn't re-issued — the override is applied
   // to whatever atm we have cached.
   _conditionsCache = null;
-  if (window.showNotification) window.showNotification(`Manual UVI ${v.toFixed(1)} applied — used for burn-time + vit-D-threshold math until cleared. (Spectrum stays driven by ozone + zenith + cloud cover.)`, 'success', 5000);
+  _notify(`Manual UVI ${v.toFixed(1)} applied — used for burn-time + vit-D-threshold math until cleared. (Spectrum stays driven by ozone + zenith + cloud cover.)`, 'success', 5000);
   _refreshConditionsNow();
 }
 
@@ -303,9 +359,9 @@ export async function _clearManualUvi() {
   const data = state.importedData;
   if (!data?.sunDefaults?.overrides) return;
   delete data.sunDefaults.overrides.uvIndex;
-  if (window.saveImportedData) await window.saveImportedData();
+  if (typeof lightConditionsDeps.saveImportedData === 'function') await lightConditionsDeps.saveImportedData();
   _conditionsCache = null;
-  if (window.showNotification) window.showNotification('Manual UVI cleared — back to live atmosphere data.');
+  _notify('Manual UVI cleared — back to live atmosphere data.');
   _refreshConditionsNow();
 }
 
@@ -313,7 +369,7 @@ export async function _clearManualUvi() {
 // user can verify what the provider returned, what we parsed, and what the
 // engine will use. Pure inspection — no side effects.
 export function _inspectConditionsNow() {
-  const coords = (window.getSunCoords && window.getSunCoords()) || null;
+  const coords = _getSunCoords();
   const key = _coordKey(coords);
   const atm = (_conditionsCache && _conditionsCache.coordKey === key) ? _conditionsCache.atm : null;
   const warnings = atm ? _sanityCheckAtmosphere(atm, coords) : [];
@@ -353,13 +409,11 @@ export function _inspectConditionsNow() {
           // Computed real-time confidence — weights snapshot age, cloud
           // cover, solar elevation, and UVI band so a low-sun heavy-cloud
           // CAMS reading isn't dishonestly reported as 95%.
-          const computed = window.computeUVConfidence ? window.computeUVConfidence({
+          const computed = typeof lightConditionsDeps.computeUVConfidence === 'function' ? lightConditionsDeps.computeUVConfidence({
             source: atm?.source,
             snapshotAgeSec: atm?._camsMeta?.ageSec ?? null,
             cloudCover: atm?.cloudCover ?? null,
-            zenithDeg: coords && atm?.fetchedAt && window.solarZenithAngle
-              ? window.solarZenithAngle(new Date(atm.fetchedAt), coords.lat, coords.lon)
-              : null,
+            zenithDeg: coords && atm?.fetchedAt ? _solarZenithAngle(new Date(atm.fetchedAt), coords) : null,
             uvIndex: atm?.uvIndex ?? null,
             isStale: !!atm?._stale,
             manualOverridden: !!atm?._uvOverridden,
@@ -418,7 +472,7 @@ export function _inspectConditionsNow() {
   });
   overlay.querySelector('#conditions-inspect-refresh')?.addEventListener('click', () => {
     closeDialog();
-    /** @type {any} */ (window)._refreshConditionsNow?.();
+    _refreshConditionsNow();
   });
   // Manually drive scroll + halt propagation on the Raw payload <pre>.
   // CSS-only `overflow:auto`/`overscroll-behavior:contain` couldn't beat
@@ -481,7 +535,7 @@ function _renderConditionsHTML(atm, coords, variant, offline = false) {
   // Solar zenith angle — degrees from vertical. 0 = sun directly overhead.
   let zenith = null;
   try {
-    if (window.solarZenithAngle) zenith = window.solarZenithAngle(new Date(), coords.lat, coords.lon);
+    zenith = _solarZenithAngle(new Date(), coords);
   } catch (e) {}
   const sunAngle = zenith != null ? Math.round(90 - zenith) : null; // elevation above horizon
 
@@ -869,7 +923,7 @@ function _sunPositionSub(elevDeg) {
 // Threshold: 5° elevation. Reference: Hattar / Lambert eye-skin axis
 // literature; OZONE-corrected UV-A penetration models (Madronich 1998).
 function _computeUvaWindow(coords, dateLike) {
-  if (!coords || !window.solarZenithAngle) return { firstUVA: null, lastUVA: null };
+  if (!coords || typeof lightConditionsDeps.solarZenithAngle !== 'function') return { firstUVA: null, lastUVA: null };
   const baseDate = dateLike ? new Date(dateLike) : new Date();
   const day = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate());
   const SAMPLE_STEP_MIN = 1;
@@ -881,7 +935,8 @@ function _computeUvaWindow(coords, dateLike) {
   // conditions cache, so amortized cost is trivial.
   for (let m = 0; m < 24 * 60; m += SAMPLE_STEP_MIN) {
     const t = new Date(day.getTime() + m * 60_000);
-    const zenith = window.solarZenithAngle(t, coords.lat, coords.lon);
+    const zenith = _solarZenithAngle(t, coords);
+    if (zenith == null) continue;
     const elevation = 90 - zenith;
     if (elevation >= ELEVATION_THRESHOLD_DEG) {
       if (!firstUVA) firstUVA = t;
@@ -1042,8 +1097,8 @@ function _sanityCheckAtmosphere(atm, coords) {
     }
     // UVI should be near zero when sun is below horizon
     try {
-      if (window.solarZenithAngle && coords) {
-        const z = window.solarZenithAngle(new Date(), coords.lat, coords.lon);
+      if (coords) {
+        const z = _solarZenithAngle(new Date(), coords);
         if (z > 95 && atm.uvIndex > 0.3) {
           warnings.push(`UVI ${atm.uvIndex} reported but sun is ${Math.round(z - 90)}° below horizon`);
         }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1119,
+  "windowReferences": 1083,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -184,6 +184,7 @@ const APP_SHELL = [
   '/js/marker-detail-editing.js',
   '/js/marker-detail-store.js',
   '/js/light-conditions-now.js',
+  '/js/light-conditions-now-hooks.js',
   '/js/light-page-view.js',
   '/js/light-page-view-hooks.js',
   '/js/light-page-view-ui-hooks.js',

--- a/tests/playwright/light-conditions-now-browser-coverage.spec.js
+++ b/tests/playwright/light-conditions-now-browser-coverage.spec.js
@@ -22,15 +22,8 @@ test('conditions now browser coverage covers refresh cache manual override and i
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const saved = {
       importedData: clone(state.importedData),
-      getSunCoords: window.getSunCoords,
-      fetchAtmosphere: window.fetchAtmosphere,
-      applyAtmOverrides: window._applyAtmOverrides,
-      solarZenithAngle: window.solarZenithAngle,
-      computeUVConfidence: window.computeUVConfidence,
-      purgeMeteoCache: window.purgeMeteoCache,
-      showNotification: window.showNotification,
-      saveImportedData: window.saveImportedData,
     };
+    let restoreDeps = null;
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
       const key = localStorage.key(i);
       return [key, localStorage.getItem(key)];
@@ -82,26 +75,28 @@ test('conditions now browser coverage covers refresh cache manual override and i
     }, label);
 
     try {
+      restoreDeps = conditions.configureLightConditionsNow({
+        getSunCoords: () => coords,
+        solarZenithAngle: () => 38,
+        computeUVConfidence: opts => {
+          calls.push(['confidence', opts]);
+          return 0.73;
+        },
+        purgeMeteoCache: () => calls.push(['purge']),
+        showNotification: (message, tone) => calls.push(['notification', message, tone]),
+        saveImportedData: async () => calls.push(['save']),
+        applyAtmOverrides: atm => ({ ...atm, _appliedByTest: true }),
+        fetchAtmosphere: async opts => {
+          calls.push(['fetch', opts]);
+          await wait(0);
+          return makeAtmosphere();
+        },
+      });
       document.body.append(host);
       state.importedData = {
         ...(state.importedData || {}),
         sunDefaults: { fitzpatrick: 'II' },
         lightCircadian: { skinType: 'II - fair' },
-      };
-      window.getSunCoords = () => coords;
-      window.solarZenithAngle = () => 38;
-      window.computeUVConfidence = opts => {
-        calls.push(['confidence', opts]);
-        return 0.73;
-      };
-      window.purgeMeteoCache = () => calls.push(['purge']);
-      window.showNotification = (message, tone) => calls.push(['notification', message, tone]);
-      window.saveImportedData = async () => calls.push(['save']);
-      window._applyAtmOverrides = atm => ({ ...atm, _appliedByTest: true });
-      window.fetchAtmosphere = async opts => {
-        calls.push(['fetch', opts]);
-        await wait(0);
-        return makeAtmosphere();
       };
 
       host.innerHTML = conditions.renderLightConditionsWidgetBody({ variant: 'full', slotId: 'cond-now-coverage-full' });
@@ -160,31 +155,33 @@ test('conditions now browser coverage covers refresh cache manual override and i
 
       await waitForFullSlotIdle('forced refresh settle');
       calls.length = 0;
-      window.fetchAtmosphere = async opts => {
+      conditions.configureLightConditionsNow({ fetchAtmosphere: async opts => {
         calls.push(['fetch-error', opts]);
         throw new Error('offline now');
-      };
+      } });
       conditions._refreshConditionsNow();
       await waitUntil(() => slotText('cond-now-coverage-full').includes('offline') || slotText('cond-now-coverage-full').includes('cached'), 'offline cached render');
       outcomes.offlineRefreshFallsBackToCache = slotText('cond-now-coverage-full').includes('cached');
       outcomes.offlineRefreshCallsFetch = calls.some(call => call[0] === 'fetch-error');
 
       const warningCoords = { lat: 51.08, lon: 15.43, source: 'profile-precise' };
-      window.getSunCoords = () => warningCoords;
-      window.solarZenithAngle = () => 100;
-      window.fetchAtmosphere = async () => makeAtmosphere({
-        uvIndex: 17,
-        cloudCover: 130,
-        ozoneDU: 50,
-        source: 'manual_override',
-        daily: { sunrise: isoAt(-240), sunset: isoAt(240), peakAt: isoAt(20), uvIndexMax: 10 },
-        airQuality: {
-          pm25: -2,
-          pm10: -1,
-          no2: -1,
-          surfaceOzoneUgM3: 1200,
-          european_aqi: 600,
-        },
+      conditions.configureLightConditionsNow({
+        getSunCoords: () => warningCoords,
+        solarZenithAngle: () => 100,
+        fetchAtmosphere: async () => makeAtmosphere({
+          uvIndex: 17,
+          cloudCover: 130,
+          ozoneDU: 50,
+          source: 'manual_override',
+          daily: { sunrise: isoAt(-240), sunset: isoAt(240), peakAt: isoAt(20), uvIndexMax: 10 },
+          airQuality: {
+            pm25: -2,
+            pm10: -1,
+            no2: -1,
+            surfaceOzoneUgM3: 1200,
+            european_aqi: 600,
+          },
+        }),
       });
       host.innerHTML = conditions.renderConditionsNow({ variant: 'full', slotId: 'cond-now-coverage-warning' });
       await waitUntil(() => document.getElementById('cond-now-coverage-warning')?.getAttribute('aria-busy') === 'false', 'warning render');
@@ -192,39 +189,32 @@ test('conditions now browser coverage covers refresh cache manual override and i
       outcomes.warningRenderUsesManualProviderLabel = slotText('cond-now-coverage-warning').includes('manual entry');
 
       const surfaceOzoneCoords = { lat: 52.08, lon: 16.43, source: 'profile-precise' };
-      window.getSunCoords = () => surfaceOzoneCoords;
-      window.solarZenithAngle = () => 38;
-      window.fetchAtmosphere = async () => makeAtmosphere({
-        ozoneDU: null,
-        airQuality: {
-          pm25: 8,
-          pm10: 20,
-          no2: 20,
-          surfaceOzoneUgM3: 245,
-          european_aqi: 18,
-        },
+      conditions.configureLightConditionsNow({
+        getSunCoords: () => surfaceOzoneCoords,
+        solarZenithAngle: () => 38,
+        fetchAtmosphere: async () => makeAtmosphere({
+          ozoneDU: null,
+          airQuality: {
+            pm25: 8,
+            pm10: 20,
+            no2: 20,
+            surfaceOzoneUgM3: 245,
+            european_aqi: 18,
+          },
+        }),
       });
       host.innerHTML = conditions.renderConditionsNow({ variant: 'full', slotId: 'cond-now-coverage-surface-ozone' });
       await waitUntil(() => document.getElementById('cond-now-coverage-surface-ozone')?.getAttribute('aria-busy') === 'false', 'surface ozone render');
       outcomes.surfaceOzoneFallbackShowsHazardLabel = slotText('cond-now-coverage-surface-ozone').includes('Hazardous');
       outcomes.surfaceOzoneFallbackShowsAction = slotText('cond-now-coverage-surface-ozone').includes('avoid outdoor exercise');
 
-      window.getSunCoords = () => null;
+      conditions.configureLightConditionsNow({ getSunCoords: () => null });
       host.innerHTML = conditions.renderConditionsNow({ variant: 'full', slotId: 'cond-now-coverage-no-coords' });
       await waitUntil(() => slotText('cond-now-coverage-no-coords').includes('Set a country'), 'no coords render');
       outcomes.noCoordsRenderShowsProfilePrompt = slotText('cond-now-coverage-no-coords').includes('Set a country');
     } finally {
+      if (restoreDeps) conditions.configureLightConditionsNow(restoreDeps);
       state.importedData = saved.importedData;
-      Object.assign(window, {
-        getSunCoords: saved.getSunCoords,
-        fetchAtmosphere: saved.fetchAtmosphere,
-        _applyAtmOverrides: saved.applyAtmOverrides,
-        solarZenithAngle: saved.solarZenithAngle,
-        computeUVConfidence: saved.computeUVConfidence,
-        purgeMeteoCache: saved.purgeMeteoCache,
-        showNotification: saved.showNotification,
-        saveImportedData: saved.saveImportedData,
-      });
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -78,7 +78,7 @@ async function seedDemoData(page) {
     localStorage.setItem(`labcharts-onboard-provider-skipped-${profileId}`, '1');
     localStorage.setItem('labcharts-analytics-consent-seen', '1');
     localStorage.setItem('labcharts-changelog-seen', window.APP_VERSION || 'test');
-    window.fetchAtmosphere = async () => {
+    const fetchAtmosphereStub = async () => {
       const now = Date.now();
       return {
         uvIndex: 6,
@@ -98,6 +98,9 @@ async function seedDemoData(page) {
         fetchedAt: now,
       };
     };
+    window.fetchAtmosphere = fetchAtmosphereStub;
+    const conditionsNow = await import('/js/light-conditions-now.js');
+    conditionsNow.configureLightConditionsNow?.({ fetchAtmosphere: fetchAtmosphereStub });
     window._labState.importedData = demo;
     window._labState.profileSex = 'male';
     window._labState.profileDob = '1987-11-22';

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -674,6 +674,9 @@
     const hasLightConditionsNowJs = sw.includes('/js/light-conditions-now.js');
     assert('Service worker caches js/light-conditions-now.js', hasLightConditionsNowJs);
 
+    const hasLightConditionsNowHooksJs = sw.includes('/js/light-conditions-now-hooks.js');
+    assert('Service worker caches js/light-conditions-now-hooks.js', hasLightConditionsNowHooksJs);
+
     const hasLightPageViewJs = sw.includes('/js/light-page-view.js');
     assert('Service worker caches js/light-page-view.js', hasLightPageViewJs);
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.537';
+self.APP_VERSION = '1.8.538';


### PR DESCRIPTION
## Summary
- Add `configureLightConditionsNow` and a startup hook so Conditions Now reads Light/Sun runtime dependencies through module injection instead of direct `window.*` lookups.
- Cache/register the new hook module and update browser coverage to stub and restore dependencies via the configure snapshot.
- Ratchet the `windowReferences` guardrail from 1119 to 1083 and bump `version.js` for cache invalidation.
- Update the responsive E2E fixture to seed the injected Conditions Now atmosphere provider, preserving deterministic CI behavior after the dependency refactor.

## Validation
- `npm run typecheck`
- `npm run quality`
- `npm run test:playwright -- tests/playwright/light-conditions-now-browser-coverage.spec.js`
- `npm run test:playwright -- tests/playwright/theme-responsive-e2e.spec.js`
- `./run-tests.sh`