### PR TITLE
Onboard: clarify DNA/mtDNA CTAs and add LivingDNA kit link

### DIFF
--- a/css/chat-onboarding.css
+++ b/css/chat-onboarding.css
@@ -231,6 +231,32 @@ select.chat-onboard-unit-select:hover { border-color: var(--accent); }
   border-color: var(--accent);
   color: var(--accent);
 }
+.chat-onboard-mini-btn-secondary {
+  border-color: var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+.chat-onboard-mini-btn-secondary:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+.chat-onboard-affiliate-foot {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+.chat-onboard-affiliate-link {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-weight: 600;
+}
+.chat-onboard-affiliate-link:hover {
+  color: var(--accent);
+}
 .chat-onboard-note {
   margin-top: 10px;
   color: var(--text-muted);

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -283,14 +283,24 @@ function renderProviderSetupState(container, panel, { personality, name }) {
   return true;
 }
 
+function renderAffiliateDnaKitLink(hasSnps) {
+  if (hasSnps) return '';
+  return `<div class="chat-onboard-affiliate-foot">
+    No DNA file? We recommend a <a href="https://www.dpbolvw.net/q2101xdmjdl0212824AA4024989447" target="_blank" rel="noopener sponsored" class="chat-onboard-affiliate-link">LivingDNA kit</a>.
+  </div>`;
+}
+
 function renderOptionalContextState(container, panel, { personality }) {
   setOnboardingActive(panel);
   const cards = buildOptionalContextTaskCards();
+  const genetics = state.importedData.genetics || {};
+  const hasSnps = Object.keys(genetics.snps || {}).length > 0;
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
       ${_renderOnboardCrumbs(3)}
       <p>${hasAIProvider() ? 'Great, we are connected.' : 'Nice. We can collect useful context first and connect AI when recommendations or AI imports need it.'} These optional context pieces make later interpretation more useful, but you can skip them and import labs now.</p>
       <div class="chat-onboard-task-grid">${cards}</div>
+      ${renderAffiliateDnaKitLink(hasSnps)}
       <div class="chat-onboard-note">You can change all of this later from the dashboard, settings, or client profile.</div>
       <div class="chat-onboard-actions chat-onboard-actions-row">
         <button type="button" class="chat-onboard-cta" data-chat-empty-action="skip-extras">Continue to import</button>
@@ -331,7 +341,7 @@ function summarizeGenetics(genetics, hasSnps, hasMtdna) {
   return [
     hasSnps ? `${Object.keys(genetics.snps || {}).length} SNPs` : '',
     hasMtdna ? `mtDNA ${genetics.mtdna?.haplogroup || ''}`.trim() : '',
-  ].filter(Boolean).join(' · ') || 'Optional: import DNA context when you have it.';
+  ].filter(Boolean).join(' · ') || 'Import nuclear DNA (SNPs) or mitochondrial DNA (mtDNA) raw data.';
 }
 
 function renderCycleTask(hasCycle) {
@@ -364,10 +374,11 @@ function renderGeneticsTask(hasSnps, hasMtdna, dnaSummary) {
       <small>${escapeHTML(dnaSummary)}</small>
     </span>
     <span class="chat-onboard-mini-actions">
-      ${!hasSnps ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Import</button>` : ''}
-      ${!hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-mtdna">mtDNA</button>
-      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" aria-label="Import mtDNA file" data-chat-empty-action="import-mtdna-file">` : ''}
-      ${hasSnps && hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Re-import</button>` : ''}
+      ${!hasSnps ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Import DNA file</button>` : ''}
+      ${!hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-mtdna">Import mtDNA</button>` : ''}
+      ${hasSnps ? `<button type="button" class="chat-onboard-mini-btn chat-onboard-mini-btn-secondary" data-chat-empty-action="import-dna">Re-import DNA</button>` : ''}
+      ${hasMtdna ? `<button type="button" class="chat-onboard-mini-btn chat-onboard-mini-btn-secondary" data-chat-empty-action="import-mtdna">Re-import mtDNA</button>` : ''}
+      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" aria-label="Import mtDNA file" data-chat-empty-action="import-mtdna-file">
     </span>
   </article>`;
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.538';
+self.APP_VERSION = '1.8.539';


### PR DESCRIPTION
Clarifies the chat onboarding genetics card and adds a LivingDNA kit recommendation for users without raw DNA data.

Changes:
- Rename Import/mtDNA buttons to Import DNA file / Import mtDNA
- Make primary import buttons visually consistent
- Move LivingDNA link below the optional context card grid
- Add CSS for secondary mini buttons and affiliate footer styling
- Bump version.js to 1.8.539 for SW cache bust

Tested: npm run typecheck + npm run quality pass.