### PR TITLE
Genome lens: clean up empty DNA state and affiliate placement

### DIFF
--- a/css/chat-onboarding.css
+++ b/css/chat-onboarding.css
@@ -231,6 +231,32 @@ select.chat-onboard-unit-select:hover { border-color: var(--accent); }
   border-color: var(--accent);
   color: var(--accent);
 }
+.chat-onboard-mini-btn-secondary {
+  border-color: var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+.chat-onboard-mini-btn-secondary:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+.chat-onboard-affiliate-foot {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+.chat-onboard-affiliate-link {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-weight: 600;
+}
+.chat-onboard-affiliate-link:hover {
+  color: var(--accent);
+}
 .chat-onboard-note {
   margin-top: 10px;
   color: var(--text-muted);

--- a/css/dashboard-data.css
+++ b/css/dashboard-data.css
@@ -722,8 +722,11 @@
   width: 100%; min-height: 130px; padding: 18px; border-radius: var(--radius-sm);
   border: 1px dashed var(--border); background: transparent; color: var(--text-primary);
   display: flex; flex-direction: column; align-items: flex-start; justify-content: center;
-  gap: 6px; text-align: left; font: inherit; cursor: pointer;
+  gap: 6px; text-align: left; font: inherit;
 }
+.db-genome-empty { cursor: default; }
+button.db-genome-empty,
+button.db-correlation-empty { cursor: pointer; }
 .db-genome-empty span,
 .db-correlation-empty span { color: var(--text-secondary); font-size: 13px; line-height: 1.45; }
 .db-genome-loading { cursor: default; }

--- a/css/dashboard-widgets.css
+++ b/css/dashboard-widgets.css
@@ -73,6 +73,20 @@
 .dashboard-widget-inline-controls {
   display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px;
 }
+.lens-header-affiliate {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+.lens-header-affiliate a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-weight: 600;
+}
+.lens-header-affiliate a:hover {
+  color: var(--accent);
+}
 .dashboard-widget-empty {
   padding: 12px 0; color: var(--text-muted); font-size: 13px; font-style: italic;
 }

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -283,14 +283,24 @@ function renderProviderSetupState(container, panel, { personality, name }) {
   return true;
 }
 
+function renderAffiliateDnaKitLink(hasSnps) {
+  if (hasSnps) return '';
+  return `<div class="chat-onboard-affiliate-foot">
+    No DNA file? We recommend a <a href="https://www.dpbolvw.net/q2101xdmjdl0212824AA4024989447" target="_blank" rel="noopener sponsored" class="chat-onboard-affiliate-link">LivingDNA kit</a>.
+  </div>`;
+}
+
 function renderOptionalContextState(container, panel, { personality }) {
   setOnboardingActive(panel);
   const cards = buildOptionalContextTaskCards();
+  const genetics = state.importedData.genetics || {};
+  const hasSnps = Object.keys(genetics.snps || {}).length > 0;
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
       ${_renderOnboardCrumbs(3)}
       <p>${hasAIProvider() ? 'Great, we are connected.' : 'Nice. We can collect useful context first and connect AI when recommendations or AI imports need it.'} These optional context pieces make later interpretation more useful, but you can skip them and import labs now.</p>
       <div class="chat-onboard-task-grid">${cards}</div>
+      ${renderAffiliateDnaKitLink(hasSnps)}
       <div class="chat-onboard-note">You can change all of this later from the dashboard, settings, or client profile.</div>
       <div class="chat-onboard-actions chat-onboard-actions-row">
         <button type="button" class="chat-onboard-cta" data-chat-empty-action="skip-extras">Continue to import</button>
@@ -331,7 +341,7 @@ function summarizeGenetics(genetics, hasSnps, hasMtdna) {
   return [
     hasSnps ? `${Object.keys(genetics.snps || {}).length} SNPs` : '',
     hasMtdna ? `mtDNA ${genetics.mtdna?.haplogroup || ''}`.trim() : '',
-  ].filter(Boolean).join(' · ') || 'Optional: import DNA context when you have it.';
+  ].filter(Boolean).join(' · ') || 'Import nuclear DNA (SNPs) or mitochondrial DNA (mtDNA) raw data.';
 }
 
 function renderCycleTask(hasCycle) {
@@ -364,10 +374,11 @@ function renderGeneticsTask(hasSnps, hasMtdna, dnaSummary) {
       <small>${escapeHTML(dnaSummary)}</small>
     </span>
     <span class="chat-onboard-mini-actions">
-      ${!hasSnps ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Import</button>` : ''}
-      ${!hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-mtdna">mtDNA</button>
-      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" aria-label="Import mtDNA file" data-chat-empty-action="import-mtdna-file">` : ''}
-      ${hasSnps && hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Re-import</button>` : ''}
+      ${!hasSnps ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-dna">Import DNA file</button>` : ''}
+      ${!hasMtdna ? `<button type="button" class="chat-onboard-mini-btn" data-chat-empty-action="import-mtdna">Import mtDNA</button>` : ''}
+      ${hasSnps ? `<button type="button" class="chat-onboard-mini-btn chat-onboard-mini-btn-secondary" data-chat-empty-action="import-dna">Re-import DNA</button>` : ''}
+      ${hasMtdna ? `<button type="button" class="chat-onboard-mini-btn chat-onboard-mini-btn-secondary" data-chat-empty-action="import-mtdna">Re-import mtDNA</button>` : ''}
+      <input type="file" id="mtdna-onboard-input" class="sr-only" accept=".txt,.csv" aria-label="Import mtDNA file" data-chat-empty-action="import-mtdna-file">
     </span>
   </article>`;
 }

--- a/js/dashboard-widget-renderers.js
+++ b/js/dashboard-widget-renderers.js
@@ -934,10 +934,10 @@ export function createDashboardWidgetRenderers(deps) {
       .filter(f => f.gene || f.variant || f.genotype)
       .sort((a, b) => (a.impactRank - b.impactRank) || String(a.gene || a.rsid).localeCompare(String(b.gene || b.rsid)) || String(a.variant || '').localeCompare(String(b.variant || '')));
     if (!findings.length && !apoe && !genetics?.mtdna) {
-      return `<button type="button" class="db-genome-empty" ${dashboardWidgetActionAttrs('trigger-dna-picker')}>
-        <strong>Add DNA data</strong>
-        <span>Top variants will appear here alongside labs and body signals.</span>
-      </button>`;
+      return `<div class="db-genome-empty">
+        <strong>No DNA data imported yet</strong>
+        <span>Import a raw DNA file above to see actionable variants alongside your labs and body signals.</span>
+      </div>`;
     }
     const visibleFindings = findings.filter(f => DASHBOARD_VISIBLE_SNP_TONES.has(f.impactTone));
     const secondaryFindings = findings.filter(f => !DASHBOARD_VISIBLE_SNP_TONES.has(f.impactTone));

--- a/js/dna.js
+++ b/js/dna.js
@@ -711,9 +711,8 @@ export function renderGeneticsSection() {
   const hasSnps = genetics && genetics.snps && Object.keys(genetics.snps).length > 0;
   const hasMtdna = genetics && genetics.mtdna;
   // Empty-state CTA: lives in the natural conceptual slot (where genetics
-  // *would* render) so users who skipped or never saw the chat onboarding
-  // DNA step have an in-context path back. Below the fold on first paint
-  // but appears for any user scrolling past supplements/charts.
+  // would render) so users who skipped the chat onboarding DNA step have a
+  // path back. Below the fold on first paint but appears after supplements/charts.
   if (!hasSnps && !hasMtdna) {
     return `<div class="genetics-empty-stub" ${dnaActionAttrs('import-file')} role="button" tabindex="0" aria-label="Add DNA data">
       <span class="genetics-empty-stub-icon" aria-hidden="true">&#129516;</span>

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -158,8 +158,11 @@ export function createLensPageHandlers(deps) {
     if (!main) return;
     document.body.classList.remove('mobile-dashboard-active');
     const importDetails = renderGenomeImportDetailsWidget(lensPageActionAttrs);
+    const genetics = state.importedData?.genetics || {};
+    const hasSnps = Object.keys(genetics.snps || {}).length > 0;
+    const affiliate = hasSnps ? '' : `<span class="lens-header-affiliate">No raw file? We recommend a <a href="https://www.dpbolvw.net/q2101xdmjdl0212824AA4024989447" target="_blank" rel="noopener sponsored">LivingDNA kit</a>.</span>`;
     let html = renderLensHeader('Genome', 'Dedicated DNA workspace: actionable genetic modifiers, import status, mtDNA, and lab-linked context.',
-      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('import-dna')}>Import DNA</button>`);
+      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('import-dna')}>Import DNA file</button>${affiliate}`);
     html += renderLensPageWidgets('genome', [
       { id: 'genome', title: 'Actionable Genetic Modifiers', description: 'Priority SNP context relevant to labs and goals', body: renderDashboardGenomeWidget(), size: 'full', opts: { source: 'Genome' } },
       importDetails ? { id: 'genome-import', title: 'Import Details', description: 'Source, counts, mtDNA, and file management', body: importDetails, size: 'full', opts: { source: 'Genome', dashboardId: '' } } : null,

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -72,9 +72,10 @@ assert('dashboard biometric overview renders delegated widget actions',
 assert('dashboard renderer body actions use the shared dashboard delegate contract',
   renderersSrc.includes("dashboardWidgetActionAttrs('open-marker-detail'") &&
     renderersSrc.includes("dashboardWidgetActionAttrs('navigate'") &&
-    renderersSrc.includes("dashboardWidgetActionAttrs('trigger-dna-picker'") &&
     renderersSrc.includes("dashboardWidgetActionAttrs('open-note-editor'") &&
     renderersSrc.includes("dashboardWidgetActionAttrs('delete-note'"));
+assert('dashboard renderer no longer duplicates the Genome lens DNA import CTA',
+  !renderersSrc.includes("dashboardWidgetActionAttrs('trigger-dna-picker'"));
 assert('dashboard widget click delegate lets nested wearable actions handle inline forms',
   controlsSrc.includes("target.closest('[data-wearable-action]')") &&
     controlsSrc.includes('actionEl.contains(wearableActionEl)') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.8.538';
+self.APP_VERSION = '1.8.539';


### PR DESCRIPTION
Follow-up to #897. Polishes the Genome lens page when no DNA data is imported.

Changes:
- Rename header CTA from "Import DNA" to "Import DNA file"
- Remove duplicate "Add DNA data" button in the empty widget; replace with plain info text
- Keep the LivingDNA kit affiliate link in the header action row
- Add CSS for the affiliate text in lens headers and for non-clickable genome empty state

Tested: npm run typecheck + npm run quality pass.