### PR TITLE
Unlock Biology Scores in demo profiles

### DIFF
--- a/data/demo-female.json
+++ b/data/demo-female.json
@@ -1584,16 +1584,16 @@
     {
       "date": "2026-01-25",
       "markers": {
-        "biochemistry.glucose": 4.5,
+        "biochemistry.glucose": 5.15,
         "biochemistry.urea": 4.6,
         "biochemistry.creatinine": 54,
         "biochemistry.egfr": 1.95,
         "biochemistry.uricAcid": 210,
         "biochemistry.bilirubinTotal": 7,
-        "biochemistry.ast": 0.23,
-        "biochemistry.alt": 0.26,
+        "biochemistry.ast": 0.48,
+        "biochemistry.alt": 0.38,
         "biochemistry.alp": 0.9,
-        "biochemistry.ggt": 0.24,
+        "biochemistry.ggt": 0.34,
         "biochemistry.ldh": 2.52,
         "biochemistry.creatineKinase": 1.1,
         "biochemistry.cystatinC": 0.65,
@@ -1604,7 +1604,7 @@
         "hormones.dheaS": 6.1,
         "hormones.estradiol": 425,
         "hormones.progesterone": 0.42,
-        "hormones.insulin": 5.8,
+        "hormones.insulin": 7.5,
         "hormones.lh": 8.2,
         "hormones.fsh": 9.5,
         "hormones.prolactin": 13,
@@ -1620,9 +1620,9 @@
         "electrolytes.copper": 17.2,
         "electrolytes.zinc": 12.5,
         "lipids.cholesterol": 4.58,
-        "lipids.triglycerides": 0.7,
+        "lipids.triglycerides": 0.92,
         "lipids.hdl": 1.85,
-        "lipids.ldl": 2.41,
+        "lipids.ldl": 2.65,
         "lipids.nonHdl": 2.73,
         "lipids.cholHdlRatio": 2.5,
         "lipids.apoAI": 1.58,
@@ -1632,7 +1632,7 @@
         "iron.transferrin": 3.3,
         "iron.tibc": 56.8,
         "iron.transferrinSat": 28,
-        "proteins.hsCRP": 0.38,
+        "proteins.hsCRP": 0.9,
         "proteins.totalProtein": 71.5,
         "proteins.albumin": 44.5,
         "proteins.ceruloplasmin": 0.23,
@@ -1644,8 +1644,8 @@
         "vitamins.vitaminD": 88,
         "vitamins.vitaminD3": 78,
         "vitamins.vitaminA": 1.75,
-        "diabetes.hba1c": 28,
-        "diabetes.insulin_d": 5.8,
+        "diabetes.hba1c": 35,
+        "diabetes.insulin_d": 7.5,
         "diabetes.homaIR": 1.16,
         "coagulation.homocysteine": 6.5,
         "hematology.wbc": 5.35,
@@ -1660,7 +1660,7 @@
         "hematology.mpv": 9.9,
         "hematology.pdw": 12.5,
         "differential.neutrophils": 3.05,
-        "differential.lymphocytes": 1.75,
+        "differential.lymphocytes": 1.85,
         "differential.monocytes": 0.35,
         "differential.eosinophils": 0.14,
         "differential.basophils": 0.06,
@@ -1669,7 +1669,33 @@
         "differential.monocytesPct": 0.065,
         "boneMetabolism.osteocalcin": 26.5,
         "specialty.glycanAge": 36,
-        "specialty.urinaryIodine": 175
+        "specialty.urinaryIodine": 175,
+        "vitamins.vitaminB12": 365,
+        "vitamins.activeB12": 92,
+        "vitamins.folate": 20.5,
+        "vitamins.methylmalonicAcid": 245,
+        "oatMetabolic.lactic": 26,
+        "oatMetabolic.pyruvic": 9.8,
+        "oatMetabolic.succinic": 5.2,
+        "oatMetabolic.fumaric": 0.42,
+        "oatMetabolic.malic": 1.55,
+        "oatMetabolic.oxoglutaric2": 15.5,
+        "oatMetabolic.aconitic": 34,
+        "oatMetabolic.methylglutaconic3": 2.4,
+        "oatAminoFatty.ethylmalonic": 3.4,
+        "oatAminoFatty.methylsuccinic": 1.35,
+        "oatAminoFatty.adipic": 2.1,
+        "oatAminoFatty.suberic": 1.05,
+        "oatAminoFatty.sebacic": 0.42,
+        "oatNutritional.hmg": 1.7,
+        "stool.calprotectin": 42,
+        "stool.zonulin": 34,
+        "stool.secretoryIgA": 760,
+        "oatMicrobial.arabinose": 12,
+        "oatMicrobial.hphpa": 45,
+        "oatMicrobial.cresol4": 26,
+        "oatMicrobial.dArabinitol": 22,
+        "calculatedRatios.nlr": 1.65
       },
       "markerSources": {
         "biochemistry.glucose": {
@@ -2015,6 +2041,90 @@
         "specialty.urinaryIodine": {
           "file": "Urinary iodine spot test.pdf",
           "at": 1769328000000
+        },
+        "oatMetabolic.lactic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.pyruvic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.succinic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.fumaric": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.malic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.oxoglutaric2": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.aconitic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.methylglutaconic3": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.ethylmalonic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.methylsuccinic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.adipic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.suberic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.sebacic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatNutritional.hmg": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "stool.calprotectin": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "stool.zonulin": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "stool.secretoryIgA": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.arabinose": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.hphpa": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.cresol4": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.dArabinitol": {
+          "file": "Demo advanced functional panel",
+          "page": 1
         }
       }
     },
@@ -4331,5 +4441,24 @@
       "loveLife": "Hormonal shifts affecting libido — track with cycle",
       "environment": "Urban EMF + WiFi load partially mitigated"
     }
+  },
+  "biologyScoreContextAI": {
+    "summary": "Demo context checked locally. Biology Scores are unlocked for this sample profile without using an AI provider.",
+    "suggestions": [],
+    "fingerprint": "biology-context:1rgpz9i",
+    "fingerprintsByRange": {
+      "all": "biology-context:1rgpz9i",
+      "1y": "biology-context:7ffmh2",
+      "6m": "biology-context:tc1fgj",
+      "3m": "biology-context:1s3oyl2"
+    },
+    "unlockedRanges": [
+      "all",
+      "1y",
+      "6m",
+      "3m"
+    ],
+    "range": "all",
+    "updatedAt": 1781913600000
   }
 }

--- a/data/demo-male.json
+++ b/data/demo-male.json
@@ -1627,8 +1627,8 @@
         "electrolytes.sodium": 138,
         "electrolytes.potassium": 4.7,
         "electrolytes.chloride": 100,
-        "electrolytes.calciumTotal": 2.32,
-        "electrolytes.phosphorus": 1.2,
+        "electrolytes.calciumTotal": 2.43,
+        "electrolytes.phosphorus": 1.17,
         "electrolytes.magnesium": 0.92,
         "electrolytes.magnesiumRBC": 2.28,
         "electrolytes.copper": 15.8,
@@ -1641,10 +1641,10 @@
         "lipids.cholHdlRatio": 4.5,
         "lipids.apoAI": 1.12,
         "lipids.apoB": 1.02,
-        "iron.iron": 17.8,
-        "iron.ferritin": 145,
+        "iron.iron": 27,
+        "iron.ferritin": 190,
         "iron.transferrin": 2.7,
-        "iron.transferrinSat": 30.5,
+        "iron.transferrinSat": 48,
         "proteins.hsCRP": 1.5,
         "proteins.totalProtein": 73,
         "proteins.albumin": 43.5,
@@ -1654,7 +1654,7 @@
         "thyroid.ft3": 4.2,
         "thyroid.t4total": 98,
         "thyroid.t3total": 1.65,
-        "vitamins.vitaminD": 118,
+        "vitamins.vitaminD": 102,
         "vitamins.vitaminD3": 105,
         "vitamins.vitaminA": 2.1,
         "diabetes.hba1c": 29,
@@ -1683,7 +1683,52 @@
         "differential.monocytesPct": 0.08,
         "boneMetabolism.osteocalcin": 21,
         "specialty.glycanAge": 40,
-        "specialty.urinaryIodine": 195
+        "specialty.urinaryIodine": 195,
+        "fattyAcids.palmiticC16": 27.5,
+        "fattyAcids.stearicC18": 12.8,
+        "fattyAcids.oleicC18_1": 23.2,
+        "fattyAcids.linoleicC18_2": 18.5,
+        "fattyAcids.glaC18_3": 0.18,
+        "fattyAcids.arachidonicC20_4": 5.9,
+        "fattyAcids.dglaC20_3": 1.15,
+        "fattyAcids.alaC18_3": 0.85,
+        "fattyAcids.epaC20_5": 3.2,
+        "fattyAcids.dpaC22_5": 1.95,
+        "fattyAcids.dhaC22_6": 4.5,
+        "fattyAcids.omega3Index": 7.8,
+        "fattyAcids.omega6to3Ratio": 2.1,
+        "fattyAcids.membraneFluidity": 5.8,
+        "fattyAcids.mentalResilience": 0.78,
+        "vitamins.vitaminB12": 315,
+        "vitamins.activeB12": 74,
+        "vitamins.folate": 15.5,
+        "vitamins.methylmalonicAcid": 285,
+        "hormones.lh": 3.4,
+        "hormones.fsh": 4.7,
+        "hormones.prolactin": 13.6,
+        "oatMetabolic.lactic": 31,
+        "oatMetabolic.pyruvic": 12.4,
+        "oatMetabolic.succinic": 6.8,
+        "oatMetabolic.fumaric": 0.55,
+        "oatMetabolic.malic": 2.05,
+        "oatMetabolic.oxoglutaric2": 18.5,
+        "oatMetabolic.aconitic": 41,
+        "oatMetabolic.methylglutaconic3": 3.15,
+        "oatAminoFatty.ethylmalonic": 4.5,
+        "oatAminoFatty.methylsuccinic": 1.85,
+        "oatAminoFatty.adipic": 2.7,
+        "oatAminoFatty.suberic": 1.55,
+        "oatAminoFatty.sebacic": 0.62,
+        "oatNutritional.hmg": 2.2,
+        "biostarksAmino.carnitine": 38,
+        "stool.calprotectin": 68,
+        "stool.zonulin": 42,
+        "stool.secretoryIgA": 620,
+        "oatMicrobial.arabinose": 18,
+        "oatMicrobial.hphpa": 75,
+        "oatMicrobial.cresol4": 42,
+        "oatMicrobial.dArabinitol": 31,
+        "iron.transferrinSaturation": 0.34
       },
       "markerSources": {
         "biochemistry.glucose": {
@@ -2017,6 +2062,154 @@
         "specialty.urinaryIodine": {
           "file": "Urinary iodine spot test.pdf",
           "at": 1769932800000
+        },
+        "fattyAcids.palmiticC16": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.stearicC18": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.oleicC18_1": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.linoleicC18_2": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.glaC18_3": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.arachidonicC20_4": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.dglaC20_3": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.alaC18_3": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.epaC20_5": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.dpaC22_5": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.dhaC22_6": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.omega3Index": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.omega6to3Ratio": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.membraneFluidity": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "fattyAcids.mentalResilience": {
+          "file": "2026-Q1 fatty-acid add-on panel.pdf",
+          "at": 1769932800000
+        },
+        "oatMetabolic.lactic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.pyruvic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.succinic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.fumaric": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.malic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.oxoglutaric2": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.aconitic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMetabolic.methylglutaconic3": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.ethylmalonic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.methylsuccinic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.adipic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.suberic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatAminoFatty.sebacic": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatNutritional.hmg": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "biostarksAmino.carnitine": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "stool.calprotectin": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "stool.zonulin": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "stool.secretoryIgA": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.arabinose": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.hphpa": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.cresol4": {
+          "file": "Demo advanced functional panel",
+          "page": 1
+        },
+        "oatMicrobial.dArabinitol": {
+          "file": "Demo advanced functional panel",
+          "page": 1
         }
       }
     }
@@ -4271,7 +4464,7 @@
     "hrv",
     "activity"
   ],
-  "demoUpgradedAt": "2026-05-09-v12",
+  "demoUpgradedAt": "2026-06-20-v13",
   "channelMixAI": {
     "status": "ok",
     "dot": "yellow",
@@ -4305,5 +4498,24 @@
       "loveLife": "Mismatched libido worth open conversation",
       "environment": "Smart meter + WiFi + RF density elevated"
     }
+  },
+  "biologyScoreContextAI": {
+    "summary": "Demo context checked locally. Biology Scores are unlocked for this sample profile without using an AI provider.",
+    "suggestions": [],
+    "fingerprint": "biology-context:ukzggm",
+    "fingerprintsByRange": {
+      "all": "biology-context:ukzggm",
+      "1y": "biology-context:1jwmvxu",
+      "6m": "biology-context:2h1789",
+      "3m": "biology-context:1hyo7qp"
+    },
+    "unlockedRanges": [
+      "all",
+      "1y",
+      "6m",
+      "3m"
+    ],
+    "range": "all",
+    "updatedAt": 1781913600000
   }
 }

--- a/js/export.js
+++ b/js/export.js
@@ -169,6 +169,7 @@ async function _importChatData(profileId, chat) {
  * @property {unknown} lifelightProfile
  * @property {unknown} lightDailyVerdicts
  * @property {unknown} channelMixAI
+ * @property {unknown} biologyScoreContextAI
  * @property {unknown} [chat]
  */
 
@@ -237,7 +238,8 @@ export async function buildClientExportObject(profileId, includeChat = false) {
     sunCorrelations: data.sunCorrelations || null,
     lifelightProfile: data.lifelightProfile || null,
     lightDailyVerdicts: data.lightDailyVerdicts || null,
-    channelMixAI: data.channelMixAI || null
+    channelMixAI: data.channelMixAI || null,
+    biologyScoreContextAI: data.biologyScoreContextAI || null
   };
   if (includeChat) {
     const chat = await _exportChatData(profileId);
@@ -629,6 +631,13 @@ export function importDataJSON(file) {
       if (json.channelMixAI && typeof json.channelMixAI === 'object') {
         state.importedData.channelMixAI = json.channelMixAI;
       }
+      // Biology Scores are gated behind a context review because the review can
+      // send profile/lab context to the configured AI provider. Demo profiles
+      // ship a locally-generated review from loadDemoData() so the feature is
+      // visible immediately without spending a real LLM call.
+      if (json.biologyScoreContextAI && typeof json.biologyScoreContextAI === 'object') {
+        state.importedData.biologyScoreContextAI = json.biologyScoreContextAI;
+      }
       // Import change history (merge by field+date, imported snapshot wins on conflict)
       if (Array.isArray(json.changeHistory)) {
         const changeHistory = ensureImportedArray(state.importedData, 'changeHistory');
@@ -708,7 +717,9 @@ export function importDataJSON(file) {
         }
       }
       migrateProfileData(state.importedData);
-      saveImportedData();
+      saveImportedData((/** @type {any} */ (globalThis))._demoLoadingProfileId === state.currentProfile
+        ? { skipSync: true, reason: 'demo-import' }
+        : {});
       if (json.chat) {
         await _importChatData(state.currentProfile, json.chat);
         if (window.loadChatThreads) window.loadChatThreads();
@@ -973,7 +984,7 @@ export async function loadDemoData(sex = 'male') {
       ? 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc4MCcgaGVpZ2h0PSc4MCcgdmlld0JveD0nMCAwIDgwIDgwJz4KPGNpcmNsZSBjeD0nNDAnIGN5PSc0MCcgcj0nNDAnIGZpbGw9JyNmMGM4YTAnLz4KPGVsbGlwc2UgY3g9JzQwJyBjeT0nMjgnIHJ4PScyMicgcnk9JzIwJyBmaWxsPScjNmIzYTJhJy8+CjxlbGxpcHNlIGN4PSc0MCcgY3k9JzQ4JyByeD0nMTYnIHJ5PScxOCcgZmlsbD0nI2Y1ZDViOCcvPgo8Y2lyY2xlIGN4PSczMycgY3k9JzQ0JyByPScyJyBmaWxsPScjNGEzNzI4Jy8+CjxjaXJjbGUgY3g9JzQ3JyBjeT0nNDQnIHI9JzInIGZpbGw9JyM0YTM3MjgnLz4KPHBhdGggZD0nTTM2IDUyIFE0MCA1NiA0NCA1Micgc3Ryb2tlPScjYzQ3YTZhJyBzdHJva2Utd2lkdGg9JzEuNScgZmlsbD0nbm9uZScgc3Ryb2tlLWxpbmVjYXA9J3JvdW5kJy8+CjxwYXRoIGQ9J00xOCAzMCBRMjAgMTIgNDAgMTAgUTYwIDEyIDYyIDMwIFE1OCAyMiA0MCAyMCBRMjIgMjIgMTggMzBaJyBmaWxsPScjNmIzYTJhJy8+CjxwYXRoIGQ9J00xNiAzNSBRMTQgMjAgMjUgMTUnIHN0cm9rZT0nIzZiM2EyYScgc3Ryb2tlLXdpZHRoPSc2JyBmaWxsPSdub25lJyBzdHJva2UtbGluZWNhcD0ncm91bmQnLz4KPHBhdGggZD0nTTY0IDM1IFE2NiAyMCA1NSAxNScgc3Ryb2tlPScjNmIzYTJhJyBzdHJva2Utd2lkdGg9JzYnIGZpbGw9J25vbmUnIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcvPgo8L3N2Zz4='
       : 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc4MCcgaGVpZ2h0PSc4MCcgdmlld0JveD0nMCAwIDgwIDgwJz4KPGNpcmNsZSBjeD0nNDAnIGN5PSc0MCcgcj0nNDAnIGZpbGw9JyNkNGE4N2MnLz4KPGVsbGlwc2UgY3g9JzQwJyBjeT0nNDgnIHJ4PScxNycgcnk9JzE4JyBmaWxsPScjZThjNGEwJy8+CjxyZWN0IHg9JzIwJyB5PScxNCcgd2lkdGg9JzQwJyBoZWlnaHQ9JzIyJyByeD0nOCcgZmlsbD0nIzNhMmExYScvPgo8Y2lyY2xlIGN4PSczMycgY3k9JzQ0JyByPScyJyBmaWxsPScjM2EyYTFhJy8+CjxjaXJjbGUgY3g9JzQ3JyBjeT0nNDQnIHI9JzInIGZpbGw9JyMzYTJhMWEnLz4KPHBhdGggZD0nTTM2IDUzIFE0MCA1NiA0NCA1Mycgc3Ryb2tlPScjYjA3MDYwJyBzdHJva2Utd2lkdGg9JzEuNScgZmlsbD0nbm9uZScgc3Ryb2tlLWxpbmVjYXA9J3JvdW5kJy8+CjxyZWN0IHg9JzMwJyBjeT0nNTgnIHk9JzU5JyB3aWR0aD0nMjAnIGhlaWdodD0nMycgcng9JzEnIGZpbGw9JyM4YjZiNTAnIG9wYWNpdHk9JzAuNCcvPgo8L3N2Zz4=';
     const height = sex === 'female' ? 168 : 182;
-    const profileId = createProfile(name, { sex, dob, location, avatar, tags: ['demo'], height, heightUnit: 'cm' });
+    const profileId = createProfile(name, { sex, dob, location, avatar, tags: ['demo'], height, heightUnit: 'cm', skipInitialSync: true });
     // Remove empty Default profile when loading demo data
     const { getProfiles, saveProfiles: saveProfileList } = await import('./profile.js');
     const allProfiles = getProfiles();
@@ -1009,6 +1020,7 @@ export async function loadDemoData(sex = 'male') {
     // demo-only by code path (regular importDataJSON does not touch
     // either localStorage cache).
     let demoJson = null;
+    let demoImportFile = new File([blob], file, { type: 'application/json' });
     try { demoJson = JSON.parse(await blob.text()); } catch (_) {}
     if (demoJson?.focusCard?.text) {
       // Focus card cache ships without a fingerprint — loadFocusCard
@@ -1017,7 +1029,7 @@ export async function loadDemoData(sex = 'male') {
       localStorage.setItem(profileStorageKey(profileId, 'focusCard'),
         JSON.stringify({ text: demoJson.focusCard.text }));
     }
-    if (demoJson?.contextHealth?.dots) {
+    if (demoJson?.contextHealth?.dots || demoJson?.entries?.length) {
       try {
         const { getCardFingerprint } = await import('./context-cards.js');
         // Compute fingerprints against the demo JSON directly — passing
@@ -1051,24 +1063,92 @@ export async function loadDemoData(sex = 'male') {
           }
         }
         try { migrateProfileData(_ctxData); } catch (_) {}
-        const ctx = {
-          importedData: _ctxData,
-          profileSex: sex,
-          profileDob: dob,
-        };
-        const cacheKey = profileStorageKey(profileId, 'contextHealth');
-        const dots = {};
-        const summaries = {};
-        const fingerprints = {};
-        for (const k of Object.keys(demoJson.contextHealth.dots)) {
-          dots[k] = demoJson.contextHealth.dots[k];
-          summaries[k] = demoJson.contextHealth.summaries?.[k] || '';
-          try { fingerprints[k] = getCardFingerprint(k, ctx); } catch (_) {}
+        if (demoJson?.contextHealth?.dots) {
+          const ctx = {
+            importedData: _ctxData,
+            profileSex: sex,
+            profileDob: dob,
+          };
+          const cacheKey = profileStorageKey(profileId, 'contextHealth');
+          const dots = {};
+          const summaries = {};
+          const fingerprints = {};
+          for (const k of Object.keys(demoJson.contextHealth.dots)) {
+            dots[k] = demoJson.contextHealth.dots[k];
+            summaries[k] = demoJson.contextHealth.summaries?.[k] || '';
+            try { fingerprints[k] = getCardFingerprint(k, ctx); } catch (_) {}
+          }
+          localStorage.setItem(cacheKey, JSON.stringify({ dots, summaries, fingerprints }));
         }
-        localStorage.setItem(cacheKey, JSON.stringify({ dots, summaries, fingerprints }));
+
+        // Biology Scores use a manual AI context gate in normal profiles. For
+        // demos, generate the same fingerprint shape locally against the exact
+        // post-import data shape so Alex/Sarah land directly on unlocked scores
+        // without calling the user's provider.
+        try {
+          const previousImportedData = state.importedData;
+          const previousSex = state.profileSex;
+          const previousDob = state.profileDob;
+          const { getActiveData, invalidateActiveDataCache } = await import('./data.js');
+          const { buildBiologyScoreContextFingerprint, buildBiologyScoreContextFingerprintsByRange } = await import('./biology-score-context-ai.js');
+          try {
+            state.importedData = structuredClone(_ctxData);
+            state.profileSex = sex;
+            state.profileDob = dob;
+            invalidateActiveDataCache?.();
+            const activeData = getActiveData();
+            demoJson.biologyScoreContextAI = {
+              summary: 'Demo context checked locally. Biology Scores are unlocked for this sample profile without using an AI provider.',
+              suggestions: [],
+              fingerprint: buildBiologyScoreContextFingerprint(activeData, 'all'),
+              fingerprintsByRange: buildBiologyScoreContextFingerprintsByRange(activeData),
+              unlockedRanges: ['all', '1y', '6m', '3m'],
+              range: 'all',
+              updatedAt: _ctxImportTs,
+            };
+          } finally {
+            state.importedData = previousImportedData;
+            state.profileSex = previousSex;
+            state.profileDob = previousDob;
+            invalidateActiveDataCache?.();
+          }
+          demoImportFile = new File([JSON.stringify(demoJson)], file, { type: 'application/json' });
+        } catch (_) {
+          // Best-effort: if Biology Scores modules fail to load, the demo still
+          // imports normally and the standard locked state remains honest.
+        }
       } catch (_) { /* prefill is best-effort */ }
     }
-    importDataJSON(new File([blob], file, { type: 'application/json' }));
+    await importDataJSON(demoImportFile);
+
+    // Post-import safety net: the seeded Biology Scores review must match the
+    // exact state that survived importDataJSON + migrateProfileData + storage
+    // persistence. If any future import transform changes the fingerprint
+    // basis, recompute locally here instead of letting the demo briefly unlock
+    // and then fall back to the normal AI gate.
+    try {
+      const { getActiveData, invalidateActiveDataCache, filterDatesByRange } = await import('./data.js');
+      const { buildBiologyScoreContextFingerprint, buildBiologyScoreContextFingerprintsByRange, hasCurrentBiologyScoreContextReview } = await import('./biology-score-context-ai.js');
+      invalidateActiveDataCache?.();
+      const activeData = getActiveData();
+      const scoreData = filterDatesByRange(activeData, { fallbackToAll: false });
+      if (!hasCurrentBiologyScoreContextReview(scoreData)) {
+        state.importedData.biologyScoreContextAI = {
+          summary: 'Demo context checked locally. Biology Scores are unlocked for this sample profile without using an AI provider.',
+          suggestions: [],
+          fingerprint: buildBiologyScoreContextFingerprint(activeData, 'all'),
+          fingerprintsByRange: buildBiologyScoreContextFingerprintsByRange(activeData),
+          unlockedRanges: ['all', '1y', '6m', '3m'],
+          range: 'all',
+          updatedAt: Date.now(),
+        };
+        await saveImportedData({ skipSync: true, reason: 'demo-biology-score-context' });
+        const w = /** @type {any} */ (window);
+        if (w.buildSidebar) w.buildSidebar();
+        if (w.updateHeaderDates) w.updateHeaderDates();
+        if (w.navigate && state.currentView === 'biology-scores') w.navigate('biology-scores');
+      }
+    } catch (_) { /* demo Biology Scores post-import unlock is best-effort */ }
   } catch (err) {
     delete window._demoLoadingProfileId;
     showNotification('Could not load demo data: ' + err.message, 'error');

--- a/js/profile.js
+++ b/js/profile.js
@@ -42,7 +42,8 @@ import {
  *   status?: string,
  *   avatar?: string | null,
  *   height?: number | string | null,
- *   heightUnit?: string
+ *   heightUnit?: string,
+ *   skipInitialSync?: boolean
  * }} CreateProfileOptions
  * @typedef {{
  *   name?: string,
@@ -812,7 +813,7 @@ export function createProfile(name, opts = {}) {
     pinned: false
   });
   saveProfiles(profiles);
-  queueProfileSync(id, createDefaultProfileData());
+  if (!opts.skipInitialSync) queueProfileSync(id, createDefaultProfileData());
   return id;
 }
 

--- a/js/sync-save-hooks.js
+++ b/js/sync-save-hooks.js
@@ -136,9 +136,9 @@ export function onProfileSaved(profileId, importedData = null) {
   _profileSyncTimers.set(profileId, timer);
 }
 
-/** @param {{ immediate?: boolean }} [options] */
+/** @param {{ immediate?: boolean, skipSync?: boolean }} [options] */
 export function onDataSaved(options = {}) {
-  if (_isSyncEnabled() && _isEvoluReady()) {
+  if (!options?.skipSync && _isSyncEnabled() && _isEvoluReady()) {
     const profileId = state.currentProfile;
     const data = state.importedData;
     if (profileId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getbased",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getbased",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "dependencies": {
         "@vercel/blob": "^2.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getbased",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "private": true,
   "description": "getbased — open-source health dashboard (PWA)",
   "type": "module",

--- a/tests/playwright/biology-scores-dashboard-lens.spec.js
+++ b/tests/playwright/biology-scores-dashboard-lens.spec.js
@@ -111,10 +111,10 @@ test('Biology Scores lens renders coherence hero with dashboard toggle and score
   await expect(hero).toBeVisible();
   await expect(hero.locator('[data-lens-page-action]')).toBeVisible();
 
-  // The demo-male dataset only drives Biological Coherence; most individual scores
-  // land in the unavailable group. Verify both the hero and the unavailable disclosure.
-  const unavailableGroup = page.locator('.biology-score-unavailable-group');
-  await expect(unavailableGroup).toBeVisible();
+  // Demo profiles should now be fully unlocked and complete: every individual
+  // Biology Score detail card is live, with no "needs more data" disclosure.
+  await expect(page.locator('.biology-score-detail')).toHaveCount(18);
+  await expect(page.locator('.biology-score-unavailable-group')).toHaveCount(0);
 });
 
 test('dashboard domain rows without primaryScoreId get no-jump visual cue', async ({ page }) => {

--- a/tests/test-demo.js
+++ b/tests/test-demo.js
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
+const readJson = (rel) => JSON.parse(read(rel));
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -21,8 +22,14 @@ function assert(name, condition, detail) {
 console.log('=== Demo Data Onboarding Tests ===\n');
 
 // export.js exposes window.loadDemoData via Object.assign(window, ...).
-await import('../js/state.js');
+const { state } = await import('../js/state.js');
 await import('../js/export.js');
+const { findOrCreateLabEntry } = await import('../js/lab-entry-mutations.js');
+const { setLabEntryMarker } = await import('../js/lab-entry.js');
+const { migrateProfileData } = await import('../js/profile.js');
+const { getActiveData, invalidateActiveDataCache, filterDatesByRange } = await import('../js/data.js');
+const { computeBiologyScores, getBiologyScoreMapping } = await import('../js/biology-scores.js');
+const { buildBiologyScoreContextFingerprint, buildBiologyScoreContextFingerprintsByRange, hasCurrentBiologyScoreContextReview } = await import('../js/biology-score-context-ai.js');
 
   // ── 1. Source: dashboard-page-view.js ──
   console.log('\n1. dashboard-page-view.js — Onboarding HTML');
@@ -111,6 +118,97 @@ await import('../js/export.js');
   const swSrc = read('service-worker.js');
   assert('SW uses importScripts for version', swSrc.includes("importScripts('/version.js')"));
   assert('SW CACHE_NAME uses semver', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
+
+  // ── 7. Demo profile feature coverage ──
+  console.log('\n7. Demo JSONs — feature coverage + Biology Scores unlock');
+  function importShapeFromDemo(demoJson) {
+    const data = structuredClone(demoJson);
+    const sourceEntries = Array.isArray(data.entries) ? data.entries : [];
+    data.entries = [];
+    const now = Date.parse('2026-06-20T00:00:00.000Z');
+    for (const entry of sourceEntries) {
+      if (!entry.date || !entry.markers) continue;
+      const existing = findOrCreateLabEntry(data, entry.date, { now });
+      for (const [key, value] of Object.entries(entry.markers)) {
+        setLabEntryMarker(existing, key, value, { now, mirrorInsulin: true });
+      }
+    }
+    migrateProfileData(data);
+    return data;
+  }
+  const snapshot = structuredClone(state.importedData || {});
+  const origSex = state.profileSex;
+  const origDob = state.profileDob;
+  const origRange = state.dateRangeFilter;
+  try {
+    for (const demo of [
+      { file: 'data/demo-female.json', sex: 'female', dob: '1991-08-15', label: 'Demo Sarah' },
+      { file: 'data/demo-male.json', sex: 'male', dob: '1987-11-22', label: 'Demo Alex' },
+    ]) {
+      const demoJson = readJson(demo.file);
+      assert(`${demo.label} has manual/body/light/genetics/context demo surfaces`,
+        Object.keys(demoJson.manualValues || {}).length >= 16
+          && (demoJson.sunSessions || []).length >= 7
+          && (demoJson.deviceSessions || []).length >= 6
+          && (demoJson.lightDevices || []).length >= 2
+          && (demoJson.lightMeasurements || []).length >= 8
+          && Object.keys(demoJson.genetics?.snps || {}).length >= 7
+          && Object.keys(demoJson.contextHealth?.dots || {}).length === 9
+          && !!demoJson.channelMixAI
+          && typeof demoJson.focusCard?.text === 'string',
+        'demo JSON must exercise current app feature surfaces');
+      const imported = importShapeFromDemo(demoJson);
+      state.importedData = imported;
+      state.profileSex = demo.sex;
+      state.profileDob = demo.dob;
+      state.dateRangeFilter = 'all';
+      invalidateActiveDataCache();
+      const activeData = getActiveData();
+      const scores = computeBiologyScores(activeData).filter(score => score.id !== 'biologicalCoherence');
+      const liveScores = scores.filter(score => score.score != null);
+      assert(`${demo.label} computes every Biology Score detail card`,
+        liveScores.length === scores.length && scores.length === getBiologyScoreMapping().length - 1,
+        `live=${liveScores.length}/${scores.length}, waiting=${scores.filter(score => score.score == null).map(score => score.id).join(', ')}`);
+      const directionalOnly = scores.filter(score => score.evidence === 'experimental' && (score.coverage || 0) < 0.25).map(score => score.id);
+      assert(`${demo.label} has no Biology Score stuck at directional-only coverage`,
+        directionalOnly.length === 0,
+        `directional-only: ${directionalOnly.join(', ')}`);
+      const missingCore = scores.flatMap(score => (score.missing || []).filter(item => item.core).map(item => `${score.id}:${item.label || item.path || item.key}`));
+      assert(`${demo.label} has no missing core Biology Score markers`,
+        missingCore.length === 0,
+        `missing core: ${missingCore.join(', ')}`);
+      const perfectScores = scores.filter(score => score.score === 100).map(score => score.id);
+      assert(`${demo.label} avoids implausible clusters of perfect Biology Scores`,
+        perfectScores.length <= 1,
+        `perfect scores: ${perfectScores.join(', ')}`);
+      imported.biologyScoreContextAI = {
+        summary: 'Demo context checked locally. Biology Scores are unlocked for this sample profile without using an AI provider.',
+        suggestions: [],
+        fingerprint: buildBiologyScoreContextFingerprint(activeData, 'all'),
+        fingerprintsByRange: buildBiologyScoreContextFingerprintsByRange(activeData),
+        unlockedRanges: ['all', '1y', '6m', '3m'],
+        range: 'all',
+        updatedAt: Date.parse('2026-06-20T00:00:00.000Z'),
+      };
+      const badRanges = [];
+      for (const range of ['all', '1y', '6m', '3m']) {
+        state.dateRangeFilter = range;
+        invalidateActiveDataCache();
+        const rawRangeData = getActiveData();
+        const scoreData = range === 'all' ? rawRangeData : filterDatesByRange(rawRangeData, { fallbackToAll: false });
+        if (!hasCurrentBiologyScoreContextReview(scoreData)) badRanges.push(range);
+      }
+      assert(`${demo.label} Biology Scores unlock is current for every timeframe without AI`,
+        badRanges.length === 0,
+        `stale ranges: ${badRanges.join(', ')}`);
+    }
+  } finally {
+    state.importedData = snapshot;
+    state.profileSex = origSex;
+    state.profileDob = origDob;
+    state.dateRangeFilter = origRange;
+    invalidateActiveDataCache();
+  }
 
   // ── Summary ──
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -939,6 +939,24 @@ return (async function() {
       assert('contextHealth prefill is inside loadDemoData (demo-only by code path)',
         _loadDemoSection.includes("profileStorageKey(profileId, 'contextHealth')"),
         'prefill must live in loadDemoData, not in importDataJSON');
+      assert('loadDemoData pre-unlocks Biology Scores without AI provider call',
+        _loadDemoSection.includes('buildBiologyScoreContextFingerprintsByRange')
+          && _loadDemoSection.includes('biologyScoreContextAI')
+          && _loadDemoSection.includes('Demo context checked locally'),
+        'demo loader must seed Biology Scores context review locally');
+      assert('loadDemoData does not depend on cross-device sync for demo Biology Scores',
+        _loadDemoSection.includes('skipInitialSync: true')
+          && _loadDemoSection.includes("skipSync: true, reason: 'demo-import'")
+          && _loadDemoSection.includes("skipSync: true, reason: 'demo-biology-score-context'"),
+        'demo loading must not sync an empty demo profile and wait for pull/rebroadcast to unlock Biology Scores');
+      assert('loadDemoData awaits demo import before post-import Biology Scores validation',
+        _loadDemoSection.includes('await importDataJSON(demoImportFile)')
+          && _loadDemoSection.includes('hasCurrentBiologyScoreContextReview(scoreData)')
+          && _loadDemoSection.includes("reason: 'demo-biology-score-context'"),
+        'demo loader must recompute the local Biology Scores unlock after the real import path settles');
+      assert('importDataJSON imports precomputed Biology Score context review',
+        _importBody.includes('json.biologyScoreContextAI') && _importBody.includes('state.importedData.biologyScoreContextAI'),
+        'JSON import must preserve the demo Biology Scores unlock');
       assert('importDataJSON does NOT touch contextHealth cache (so non-demo imports are unaffected)',
         _importBody.length > 0 && !_importBody.includes('contextHealth'),
         'context-health prefill leaks into the regular JSON-import path');
@@ -1065,6 +1083,23 @@ return (async function() {
         assert('All 9 cached fingerprints match live fingerprints (proves migration + merge applied correctly)',
           mismatched.length === 0,
           `mismatched: ${mismatched.map(x => x.k).join(', ')}`);
+      }
+
+      const bioReview = S.importedData?.biologyScoreContextAI;
+      assert('Biology Scores demo context review populated after demo load',
+        bioReview?.summary?.includes('Demo context checked locally')
+          && bioReview?.updatedAt
+          && Array.isArray(bioReview?.unlockedRanges)
+          && ['all','1y','6m','3m'].every(range => bioReview.unlockedRanges.includes(range)),
+        `got ${JSON.stringify(bioReview || {}).slice(0, 160)}`);
+      try {
+        const { hasCurrentBiologyScoreContextReview } = await import('../js/biology-score-context-ai.js');
+        const scoreData = window.filterDatesByRange?.(window.getActiveData?.() || {}, { fallbackToAll: false }) || window.getActiveData?.() || {};
+        assert('Biology Scores demo context review matches live fingerprints',
+          hasCurrentBiologyScoreContextReview(scoreData),
+          'demo Biology Scores would still show the unlock gate');
+      } catch (err) {
+        assert('Biology Scores demo context review module import failed', false, err?.message || String(err));
       }
 
       // Zero AI calls during the demo-load window


### PR DESCRIPTION
## Summary
- unlock Biology Scores for bundled demo profiles without requiring an AI/provider call
- seed current Biology Score context fingerprints for all timeframe tabs during demo import
- refresh Alex demo fatty-acid data so all 18 score detail cards are live
- update demo regression coverage, including the Playwright Biology Scores lens expectation
- bump package version to 1.3.9

## Verification
- `node tests/test-demo.js` — 45 passed
- `npm run typecheck` — passed
- `npm run quality` — passed
- `npm test` — 12 files / 188 tests passed
- `PORT=8175 npx playwright test tests/playwright/biology-scores-dashboard-lens.spec.js --project=chromium` — 5 passed
- browser smoke on port 8174: Alex demo showed 18/18 live score cards, current context review, and no AI/network provider calls

## Notes
- The first CI run correctly failed because the older Playwright assertion still expected unavailable Biology Score cards. This branch now updates that assertion to match the new fully-live demo profile state.
- Vercel preview is currently failing at deployment provisioning; local browser/server verification passed.
