### PR TITLE
fix: prevent demo data from silently contaminating real profiles

### DIFF
--- a/data/demo-female.json
+++ b/data/demo-female.json
@@ -1,4 +1,5 @@
 {
+  "_source": "demo",
   "version": 3,
   "exportedAt": "2026-05-09T08:30:00.000Z",
   "entries": [

--- a/data/demo-male.json
+++ b/data/demo-male.json
@@ -1,4 +1,5 @@
 {
+  "_source": "demo",
   "version": 3,
   "exportedAt": "2026-05-09T08:30:00.000Z",
   "entries": [

--- a/js/export.js
+++ b/js/export.js
@@ -340,7 +340,16 @@ export function importDataJSON(file) {
     reader.onload = async (e) => {
       try {
         const json = JSON.parse(/** @type {string} */ (reader.result));
-      // Database bundle — multi-profile import
+        // Guard: demo data should never be silently imported into a non-demo profile
+        if (json._source === 'demo') {
+          const profiles = getProfiles();
+          const current = profiles.find(p => p.id === state.currentProfile);
+          if (!current?.tags?.includes('demo')) {
+            showNotification('Demo data detected. Use the dashboard "Load demo" button to create a demo profile, or switch to a demo profile before importing.', 'error');
+            return;
+          }
+        }
+        // Database bundle — multi-profile import
       if (json.type === 'database' && Array.isArray(json.profiles)) {
         await _importDatabaseBundle(json);
         return;

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -10,6 +10,13 @@ return (async function() {
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const S = window._labState;
 
+  // ── Profile safety guard: run tests in a throwaway profile ──
+  const origProfileId = S.currentProfile;
+  const testProfileId = window.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
+  await window.switchProfile(testProfileId);
+
+  try {
+
   console.log('%c Export/Import Roundtrip Tests ', 'background:#6366f1;color:#fff;padding:4px 12px;border-radius:4px;font-weight:bold');
 
   // ═══════════════════════════════════════
@@ -1125,4 +1132,15 @@ return (async function() {
       : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
   console.log(`Results: ${pass} passed, ${fail} failed`);
   window.__testResults = { pass, fail };
+
+  } finally {
+    // Restore original profile and delete the throwaway
+    try {
+      const profiles = window.getProfiles();
+      await window.switchProfile(origProfileId);
+      window.saveProfiles(profiles.filter(p => p.id !== testProfileId));
+    } catch (e) {
+      console.error('Test cleanup failed:', e);
+    }
+  }
 })();

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -14,6 +14,13 @@ return (async function() {
   const main = document.getElementById('main-content');
   const S = window._labState;
 
+  // ── Profile safety guard: run tests in a throwaway profile ──
+  const origProfileId = S.currentProfile;
+  const testProfileId = window.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
+  await window.switchProfile(testProfileId);
+
+  try {
+
   console.log('%c Sun UI Flow Tests ', 'background:#f59e0b;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
   // Stash + reset state so we don't pollute the host page
@@ -478,4 +485,15 @@ return (async function() {
   await window.saveImportedData?.();
 
   console.log(`Light & Sun UI: ${pass} passed, ${fail} failed`);
+
+  } finally {
+    // Restore original profile and delete the throwaway
+    try {
+      const profiles = window.getProfiles();
+      await window.switchProfile(origProfileId);
+      window.saveProfiles(profiles.filter(p => p.id !== testProfileId));
+    } catch (e) {
+      console.error('Test cleanup failed:', e);
+    }
+  }
 })();

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -26,6 +26,12 @@ return (async function() {
   const main = document.getElementById('main-content');
   const S = window._labState;
 
+  // ── Profile safety guard: run tests in a throwaway profile ──
+  const origProfileId = S.currentProfile;
+  const testProfileId = window.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
+  await window.switchProfile(testProfileId);
+
+  try {
 
   // Dismiss any open dialogs/modals from prior tests
   document.getElementById('confirm-dialog-overlay')?.classList.remove('show');
@@ -853,4 +859,15 @@ return (async function() {
       ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px'
       : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
   console.log(`Results: ${pass} passed, ${fail} failed`);
+
+  } finally {
+    // Restore original profile and delete the throwaway
+    try {
+      const profiles = window.getProfiles();
+      await window.switchProfile(origProfileId);
+      window.saveProfiles(profiles.filter(p => p.id !== testProfileId));
+    } catch (e) {
+      console.error('Test cleanup failed:', e);
+    }
+  }
 })();

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.9.0';
+self.APP_VERSION = '1.9.1';


### PR DESCRIPTION
## Bug

Demo data could silently leak into real profiles through:
1. Accidentally importing a demo JSON file via the file picker (lands in current active profile)
2. Browser console one-liners that load demo data and call saveImportedData() on whatever profile is active

## Fix

### Import boundary guard (js/export.js)
- Demo JSONs now carry _source: demo
- importDataJSON() blocks any import with _source: demo into a non-demo profile

### Browser-run tests run in throwaway profiles
- test-ui-flows.js, test-export-import.js, test-sun-ui-flow.js now create a temp __test_* profile, switch to it, run assertions, then clean up

### Service worker cache bump
- 1.9.0 -> 1.9.1

## Files changed
- data/demo-male.json
- data/demo-female.json
- js/export.js
- tests/test-ui-flows.js
- tests/test-export-import.js
- tests/test-sun-ui-flow.js
- version.js