### PR TITLE
Fix Biology Scores context unlock sync

### DIFF
--- a/js/biology-score-context-ai.js
+++ b/js/biology-score-context-ai.js
@@ -13,7 +13,7 @@ const FLAG_LABELS = {
   acuteIllnessNearDraw: 'Acute illness / infection / injury near blood draw',
 };
 const FLAG_KEYS = Object.keys(FLAG_LABELS);
-const CONTEXT_REVIEW_RANGES = ['all', '1y', '6m', '3m'];
+export const CONTEXT_REVIEW_RANGES = ['all', '1y', '6m', '3m'];
 let installed = false;
 
 function safeContextText(value, max = 500) {

--- a/js/sync-pull-merge.js
+++ b/js/sync-pull-merge.js
@@ -8,6 +8,7 @@ import { mergeImportedData, localHasRowsRemoteLacks, preserveFreshLocalLabEntrie
 import { parseSyncPayload } from './sync-payload.js';
 import { _mergeItemRowsIntoImported } from './sync-delta.js';
 import { isRestoreJoinPending } from './sync-identity.js';
+import { CONTEXT_REVIEW_RANGES } from './biology-score-context-ai.js';
 
 export const PROFILE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 
@@ -112,16 +113,14 @@ function getUpdatedAt(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
-const BIOLOGY_CONTEXT_REVIEW_RANGES = ['all', '1y', '6m', '3m'];
-
 function biologyContextReviewCoverageScore(review) {
   if (!review || typeof review !== 'object') return 0;
   const fps = review.fingerprintsByRange && typeof review.fingerprintsByRange === 'object'
     ? review.fingerprintsByRange
     : null;
   const unlocked = Array.isArray(review.unlockedRanges) ? review.unlockedRanges : [];
-  const hasAllRangeFingerprints = !!fps && BIOLOGY_CONTEXT_REVIEW_RANGES.every(range => typeof fps[range] === 'string' && fps[range]);
-  const unlocksAllRanges = BIOLOGY_CONTEXT_REVIEW_RANGES.every(range => unlocked.includes(range));
+  const hasAllRangeFingerprints = !!fps && CONTEXT_REVIEW_RANGES.every(range => typeof fps[range] === 'string' && fps[range]);
+  const unlocksAllRanges = CONTEXT_REVIEW_RANGES.every(range => unlocked.includes(range));
   if (hasAllRangeFingerprints && unlocksAllRanges) return 3;
   if (hasAllRangeFingerprints) return 2;
   if (review.fingerprint && review.range) return 1;

--- a/js/sync-pull-merge.js
+++ b/js/sync-pull-merge.js
@@ -112,13 +112,37 @@ function getUpdatedAt(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
+const BIOLOGY_CONTEXT_REVIEW_RANGES = ['all', '1y', '6m', '3m'];
+
+function biologyContextReviewCoverageScore(review) {
+  if (!review || typeof review !== 'object') return 0;
+  const fps = review.fingerprintsByRange && typeof review.fingerprintsByRange === 'object'
+    ? review.fingerprintsByRange
+    : null;
+  const unlocked = Array.isArray(review.unlockedRanges) ? review.unlockedRanges : [];
+  const hasAllRangeFingerprints = !!fps && BIOLOGY_CONTEXT_REVIEW_RANGES.every(range => typeof fps[range] === 'string' && fps[range]);
+  const unlocksAllRanges = BIOLOGY_CONTEXT_REVIEW_RANGES.every(range => unlocked.includes(range));
+  if (hasAllRangeFingerprints && unlocksAllRanges) return 3;
+  if (hasAllRangeFingerprints) return 2;
+  if (review.fingerprint && review.range) return 1;
+  return 0;
+}
+
+function compareBiologyContextReviews(a, b) {
+  const coverageDelta = biologyContextReviewCoverageScore(a) - biologyContextReviewCoverageScore(b);
+  if (coverageDelta !== 0) return coverageDelta;
+  const timeDelta = getUpdatedAt(a) - getUpdatedAt(b);
+  if (timeDelta !== 0) return timeDelta;
+  return 0;
+}
+
 function preserveFreshLocalBiologyScoreContextAI(merged, localImported, remoteImported) {
   const candidates = [merged?.biologyScoreContextAI, localImported?.biologyScoreContextAI, remoteImported?.biologyScoreContextAI]
     .filter(item => item && typeof item === 'object');
   if (!candidates.length) return false;
-  const best = candidates.reduce((winner, item) => getUpdatedAt(item) > getUpdatedAt(winner) ? item : winner, candidates[0]);
+  const best = candidates.reduce((winner, item) => compareBiologyContextReviews(item, winner) > 0 ? item : winner, candidates[0]);
   if (merged.biologyScoreContextAI === best) return false;
-  if (getUpdatedAt(best) <= getUpdatedAt(merged?.biologyScoreContextAI)) return false;
+  if (compareBiologyContextReviews(best, merged?.biologyScoreContextAI) <= 0) return false;
   merged.biologyScoreContextAI = best;
   return true;
 }

--- a/tests/sync-biology-context.test.js
+++ b/tests/sync-biology-context.test.js
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { state } from '../js/state.js';
+import { createDefaultProfileData } from '../js/profile.js';
+import { mergePulledImportedData } from '../js/sync-pull-merge.js';
+
+const ALL_RANGE_REVIEW = {
+  summary: 'Context checked locally',
+  suggestions: [],
+  updatedAt: 1000,
+  range: 'all',
+  fingerprint: 'biology-context:all-current',
+  fingerprintsByRange: {
+    all: 'biology-context:all-current',
+    '1y': 'biology-context:1y-current',
+    '6m': 'biology-context:6m-current',
+    '3m': 'biology-context:3m-current',
+  },
+  unlockedRanges: ['all', '1y', '6m', '3m'],
+};
+
+describe('Biology Score context sync merge', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    state.currentProfile = 'bio-context-profile';
+    state.importedData = null;
+  });
+
+  it('preserves an all-range unlocked context review over a newer legacy single-range sync row', async () => {
+    const local = {
+      ...createDefaultProfileData(),
+      biologyScoreContextAI: { ...ALL_RANGE_REVIEW },
+    };
+    const remoteLegacy = {
+      ...createDefaultProfileData(),
+      biologyScoreContextAI: {
+        summary: 'Older-device single-range context check',
+        suggestions: [],
+        updatedAt: 2000,
+        range: 'all',
+        fingerprint: 'biology-context:legacy-only',
+      },
+    };
+
+    state.importedData = local;
+    const result = await mergePulledImportedData(state.currentProfile, remoteLegacy);
+
+    expect(result.merged.biologyScoreContextAI.summary).toBe('Context checked locally');
+    expect(result.merged.biologyScoreContextAI.fingerprintsByRange).toEqual(ALL_RANGE_REVIEW.fingerprintsByRange);
+    expect(result.merged.biologyScoreContextAI.unlockedRanges).toEqual(['all', '1y', '6m', '3m']);
+    expect(result.localDataChanged).toBe(false);
+  });
+
+  it('accepts a newer all-range context review from sync', async () => {
+    const local = {
+      ...createDefaultProfileData(),
+      biologyScoreContextAI: { ...ALL_RANGE_REVIEW },
+    };
+    const remoteCurrent = {
+      ...createDefaultProfileData(),
+      biologyScoreContextAI: {
+        ...ALL_RANGE_REVIEW,
+        summary: 'Fresh context checked on another device',
+        updatedAt: 3000,
+        fingerprintsByRange: {
+          all: 'biology-context:all-fresh',
+          '1y': 'biology-context:1y-fresh',
+          '6m': 'biology-context:6m-fresh',
+          '3m': 'biology-context:3m-fresh',
+        },
+      },
+    };
+
+    state.importedData = local;
+    const result = await mergePulledImportedData(state.currentProfile, remoteCurrent);
+
+    expect(result.merged.biologyScoreContextAI.summary).toBe('Fresh context checked on another device');
+    expect(result.merged.biologyScoreContextAI.updatedAt).toBe(3000);
+    expect(result.localDataChanged).toBe(true);
+  });
+});

--- a/tests/sync-biology-context.test.js
+++ b/tests/sync-biology-context.test.js
@@ -79,4 +79,33 @@ describe('Biology Score context sync merge', () => {
     expect(result.merged.biologyScoreContextAI.updatedAt).toBe(3000);
     expect(result.localDataChanged).toBe(true);
   });
+
+  it('accepts an older all-range context review from sync over a newer local legacy row', async () => {
+    const localLegacy = {
+      ...createDefaultProfileData(),
+      biologyScoreContextAI: {
+        summary: 'Newer local legacy context check',
+        suggestions: [],
+        updatedAt: 3000,
+        range: 'all',
+        fingerprint: 'biology-context:legacy-local',
+      },
+    };
+    const remoteComplete = {
+      ...createDefaultProfileData(),
+      biologyScoreContextAI: {
+        ...ALL_RANGE_REVIEW,
+        summary: 'Older complete context checked on another device',
+        updatedAt: 2000,
+      },
+    };
+
+    state.importedData = localLegacy;
+    const result = await mergePulledImportedData(state.currentProfile, remoteComplete);
+
+    expect(result.merged.biologyScoreContextAI.summary).toBe('Older complete context checked on another device');
+    expect(result.merged.biologyScoreContextAI.fingerprintsByRange).toEqual(ALL_RANGE_REVIEW.fingerprintsByRange);
+    expect(result.merged.biologyScoreContextAI.unlockedRanges).toEqual(['all', '1y', '6m', '3m']);
+    expect(result.localDataChanged).toBe(true);
+  });
 });

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -211,8 +211,10 @@ assert('CHANGELOG records Biology Scores main release',
     && changelogSrc.includes('Know what to test next'));
 assert('Biology Scores changelog is announcement-style, not a technical fix log',
   !/Greptile|bugfix|bugfixes|production hardening|UI polish|stale explanation|sync|CRP\/hs-CRP|fixed|tightened before release/i.test(changelogSrc.slice(changelogSrc.indexOf("version: '1.9.0'"), changelogSrc.indexOf("version: '1.8.550'"))));
+const appVersionMatch = versionSrc.match(/APP_VERSION\s*=\s*'([^']+)'/);
+const appVersionParts = appVersionMatch?.[1]?.split('.').map(Number) || [];
 assert('APP_VERSION is bumped for Biology Scores main release',
-  versionSrc.includes("APP_VERSION = '1.9.0'"));
+  appVersionParts.length === 3 && (appVersionParts[0] > 1 || (appVersionParts[0] === 1 && appVersionParts[1] >= 9)));
 
 // ═══════════════════════════════════════
 // 11. Window exports


### PR DESCRIPTION
## Summary
- preserve all-timeframe Biology Scores context unlocks during cross-device sync
- prefer complete all-range `biologyScoreContextAI` reviews over newer legacy/single-range rows
- add regression coverage for unlocked local context vs stale remote sync and newer complete remote sync
- relax the stale changelog version assertion so current 1.9.x patch releases satisfy the Biology Scores release gate

## Verification
- `npm run typecheck` ✅
- `npm run quality` ✅
- `npm test` ✅ 13 files / 190 tests
