### PR TITLE
[codex] Add typecheck to full test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: node scripts/fetch-catalog.mjs
 
       - name: Run test suite
-        run: ./run-tests.sh
+        run: SKIP_TYPECHECK=1 ./run-tests.sh
 
       - name: Upload test logs on failure
         if: failure()

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,6 +11,10 @@ if [ "$COVERAGE" = "1" ] || [ "$COVERAGE" = "true" ]; then
   COVERAGE_ENABLED=1
 fi
 
+if [ "$SKIP_TYPECHECK" != "1" ] && [ "$SKIP_TYPECHECK" != "true" ]; then
+  npm run typecheck || exit 1
+fi
+
 # Start server if not already running. nohup + disown fully detaches it
 # from the shell — signals sent to the shell's process group won't
 # propagate. Log to /tmp so we can inspect if it ever dies unexpectedly.

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -26,6 +26,8 @@ console.log('=== Quality Guardrails Tests ===\n');
 const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
 const guardrailSrc = fs.readFileSync(path.join(ROOT, 'scripts', 'quality-guardrails.mjs'), 'utf8');
 const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'quality-baseline.json'), 'utf8'));
+const runTestsSrc = fs.readFileSync(path.join(ROOT, 'run-tests.sh'), 'utf8');
+const testWorkflowSrc = fs.readFileSync(path.join(ROOT, '.github/workflows/test.yml'), 'utf8');
 
 assert('package.json exposes npm run quality',
   pkg.scripts?.quality === 'node scripts/quality-guardrails.mjs');
@@ -43,6 +45,13 @@ assert('quality guardrail tracks large-module budget',
     Object.hasOwn(baseline, 'maxJsFileLines'));
 assert('quality guardrail exits non-zero on failures',
   guardrailSrc.includes('process.exit(failed > 0 ? 1 : 0)'));
+assert('full local test suite runs typecheck',
+  runTestsSrc.includes('npm run typecheck || exit 1') &&
+    runTestsSrc.includes('SKIP_TYPECHECK'));
+assert('CI keeps a dedicated typecheck step and skips duplicate script typecheck',
+  testWorkflowSrc.includes('name: Run typecheck') &&
+    testWorkflowSrc.includes('run: npm run typecheck') &&
+    testWorkflowSrc.includes('SKIP_TYPECHECK=1 ./run-tests.sh'));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Run `npm run typecheck` at the start of the default local `./run-tests.sh` flow.
- Keep CI's dedicated typecheck step for fast failure output, while setting `SKIP_TYPECHECK=1` when CI invokes `./run-tests.sh` to avoid duplicate work.
- Add guardrail assertions so the local full-suite/typecheck parity does not regress.

## Validation

- `npm run typecheck` passed.
- `node tests/test-quality-guardrails.js` passed.
- `npm run quality` passed.
- `./run-tests.sh` passed: typecheck, Vitest, dev-server origin guard, and 332 Playwright tests.