### PR TITLE
[codex] Extract lens URL validation helper

### DIFF
--- a/js/lens-url.js
+++ b/js/lens-url.js
@@ -1,0 +1,32 @@
+// @ts-check
+// lens-url.js - URL validation for external Knowledge Base backends.
+
+// http:// is accepted for hosts that can't leak the Bearer token across the
+// public internet: loopback, RFC1918 LAN, link-local, Tailscale CGNAT, mDNS.
+// Everything else must be https://.
+function isPrivateHost(host) {
+  if (!host) return false;
+  if (host === 'localhost') return true;
+  if (host === '::1' || host === '[::1]') return true;
+  if (host.endsWith('.local') || host.endsWith('.local.')) return true;
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!m) return false;
+  const a = +m[1], b = +m[2], c = +m[3], d = +m[4];
+  if (a > 255 || b > 255 || c > 255 || d > 255) return false;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
+export function isValidLensUrl(url) {
+  if (typeof url !== 'string' || !url) return false;
+  let u;
+  try { u = new URL(url); } catch { return false; }
+  if (u.protocol === 'https:') return true;
+  if (u.protocol === 'http:') return isPrivateHost(u.hostname);
+  return false;
+}

--- a/js/lens.js
+++ b/js/lens.js
@@ -7,6 +7,7 @@ import { hashString, showNotification, showConfirmDialog, showPromptDialog, isDe
 import { hasAIProvider, callClaudeAPI } from './api.js';
 import { closeModalOverlay, openModalOverlay, wireBackdropClose } from './modal-lifecycle.js';
 import { initLensActionDelegates, lensActionAttrs } from './lens-actions.js';
+import { isValidLensUrl as isValidLensUrlImpl } from './lens-url.js';
 const CONFIG_KEY = 'labcharts-lens-config';
 const SECRET_KEY = 'labcharts-lens-key';
 /** @typedef {Window & typeof globalThis & { _lensIngestRunning?: boolean }} LensWindow */
@@ -130,35 +131,7 @@ export function hasLens() {
   return !!(cfg.url && getLensKey());
 }
 // ─── URL validation ───────────────────────────────────────────
-// http:// is accepted for hosts that can't leak the Bearer token across the
-// public internet: loopback, RFC1918 LAN, link-local, Tailscale CGNAT, mDNS.
-// Everything else must be https://.
-function _isPrivateHost(host) {
-  if (!host) return false;
-  if (host === 'localhost') return true;
-  if (host === '::1' || host === '[::1]') return true;
-  if (host.endsWith('.local') || host.endsWith('.local.')) return true;
-  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (!m) return false;
-  const a = +m[1], b = +m[2], c = +m[3], d = +m[4];
-  if (a > 255 || b > 255 || c > 255 || d > 255) return false;
-  if (a === 10) return true;                           // 10.0.0.0/8
-  if (a === 127) return true;                          // loopback
-  if (a === 169 && b === 254) return true;             // link-local 169.254.0.0/16
-  if (a === 172 && b >= 16 && b <= 31) return true;    // 172.16.0.0/12
-  if (a === 192 && b === 168) return true;             // 192.168.0.0/16
-  if (a === 100 && b >= 64 && b <= 127) return true;   // Tailscale CGNAT 100.64.0.0/10
-  return false;
-}
-
-export function isValidLensUrl(url) {
-  if (typeof url !== 'string' || !url) return false;
-  let u;
-  try { u = new URL(url); } catch { return false; }
-  if (u.protocol === 'https:') return true;
-  if (u.protocol === 'http:') return _isPrivateHost(u.hostname);
-  return false;
-}
+export function isValidLensUrl(url) { return isValidLensUrlImpl(url); }
 
 // ─── Query cache ──────────────────────────────────────────────
 const _cache = new Map(); // key → { value, at }

--- a/service-worker.js
+++ b/service-worker.js
@@ -387,6 +387,7 @@ const APP_SHELL = [
   '/js/chat-threads.js',
   '/js/chat-thread-search.js',
   '/js/lens-actions.js',
+  '/js/lens-url.js',
   '/js/lens.js',
   '/js/lens-local.js',
   '/js/lens-local-worker.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -81,6 +81,7 @@ assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes(
 assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.includes("'/js/context-card-editor-ui.js'"));
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));
 assert('SW APP_SHELL includes lens action delegates module', swAuditSrc.includes("'/js/lens-actions.js'"));
+assert('SW APP_SHELL includes lens URL helper module', swAuditSrc.includes("'/js/lens-url.js'"));
 assert('SW APP_SHELL includes DNA action delegates module', swAuditSrc.includes("'/js/dna-actions.js'"));
 assert('SW APP_SHELL includes service worker update module', swAuditSrc.includes("'/js/service-worker-update.js'"));
 assert('index loads app shell CSS bundle', indexSrc.includes('href="css/app-shell.css"'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.9.2';
+self.APP_VERSION = '1.9.3';


### PR DESCRIPTION
## Summary
- Move external lens URL validation into `js/lens-url.js` while preserving the existing `isValidLensUrl` export from `js/lens.js`.
- Precache the new helper in the service worker app shell and add an audit guard for it.
- Bump `version.js` for app-shell cache invalidation.

## Quality Impact
- `js/lens.js` drops from roughly 1,512 lines to 1,485 lines.
- The quality gate now reports `js/dna.js` as the largest JS file, so lens is no longer the top large-file target.

## Validation
- `npm run typecheck`
- `node tests/test-custom-lens.js`
- `node tests/test-audit.js`
- `npm run quality`
- `./run-tests.sh`