### PR TITLE
[codex] Extract lens query cache helper

### DIFF
--- a/js/lens-cache.js
+++ b/js/lens-cache.js
@@ -1,0 +1,40 @@
+// @ts-check
+// lens-cache.js - in-memory LRU cache for Knowledge Base query envelopes.
+import { hashString } from './utils.js';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX = 20;
+const _cache = new Map(); // key -> { value, at }
+
+function cacheKey(backendKey, topK, profileId, hint) {
+  return `${hashString(backendKey)}|${topK}|${profileId}|${hint}`;
+}
+
+export function cacheGet(k) {
+  const row = _cache.get(k);
+  if (!row) return null;
+  if (Date.now() - row.at > CACHE_TTL_MS) { _cache.delete(k); return null; }
+  _cache.delete(k);
+  _cache.set(k, row);
+  return row.value;
+}
+
+export function cacheSet(k, v) {
+  if (_cache.size >= CACHE_MAX) {
+    const oldest = _cache.keys().next().value;
+    _cache.delete(oldest);
+  }
+  _cache.set(k, { value: v, at: Date.now() });
+}
+
+export function getLensCacheEntry(backendKey, topK, profileId, hint) {
+  return cacheGet(cacheKey(backendKey, topK, profileId, hint));
+}
+
+export function setLensCacheEntry(backendKey, topK, profileId, hint, value) {
+  cacheSet(cacheKey(backendKey, topK, profileId, hint), value);
+}
+
+export function clearLensCache() {
+  _cache.clear();
+}

--- a/js/lens.js
+++ b/js/lens.js
@@ -8,6 +8,7 @@ import { hasAIProvider, callClaudeAPI } from './api.js';
 import { closeModalOverlay, openModalOverlay, wireBackdropClose } from './modal-lifecycle.js';
 import { initLensActionDelegates, lensActionAttrs } from './lens-actions.js';
 import { isValidLensUrl as isValidLensUrlImpl } from './lens-url.js';
+import { clearLensCache as clearLensCacheImpl, getLensCacheEntry, setLensCacheEntry } from './lens-cache.js';
 const CONFIG_KEY = 'labcharts-lens-config';
 const SECRET_KEY = 'labcharts-lens-key';
 /** @typedef {Window & typeof globalThis & { _lensIngestRunning?: boolean }} LensWindow */
@@ -47,8 +48,6 @@ const DEFAULT_CONFIG = {
 // flow (user thinks the app is hung); 10s is enough headroom for slow
 // HuggingFace-style local backends and surfaces offline state quickly.
 const TIMEOUT_MS = 10000;
-const CACHE_TTL_MS = 5 * 60 * 1000;
-const CACHE_MAX = 20;
 const MAX_CHUNKS = 10;
 const MAX_RESPONSE_BYTES = 32 * 1024;
 // ─── Config storage ───────────────────────────────────────────
@@ -134,27 +133,7 @@ export function hasLens() {
 export function isValidLensUrl(url) { return isValidLensUrlImpl(url); }
 
 // ─── Query cache ──────────────────────────────────────────────
-const _cache = new Map(); // key → { value, at }
-function cacheKey(url, topK, profileId, hint) { return `${hashString(url)}|${topK}|${profileId}|${hint}`; }
-function cacheGet(k) {
-  const row = _cache.get(k);
-  if (!row) return null;
-  if (Date.now() - row.at > CACHE_TTL_MS) { _cache.delete(k); return null; }
-  // Bump to end of insertion order so true LRU eviction works — Map iterates
-  // in insertion order, so without re-inserting, hot entries get evicted by
-  // CACHE_MAX before cold ones.
-  _cache.delete(k);
-  _cache.set(k, row);
-  return row.value;
-}
-function cacheSet(k, v) {
-  if (_cache.size >= CACHE_MAX) {
-    const oldest = _cache.keys().next().value;
-    _cache.delete(oldest);
-  }
-  _cache.set(k, { value: v, at: Date.now() });
-}
-export function clearLensCache() { _cache.clear(); }
+export function clearLensCache() { clearLensCacheImpl(); }
 
 // ─── Status tracking ─────────────────────────────────────────
 let _status = { state: 'idle', lastChunkCount: 0, lastError: null, sourceName: '' };
@@ -350,8 +329,7 @@ export function _dedupeQueriesForTest(queries) { return _dedupeQueries(queries);
 /// just a third fetchFn — no re-plumbing of observability per call.
 async function queryWithCache(backendKey, sourceName, hint, topK, fetchFn) {
   const profileId = state.currentProfile || 'default';
-  const ck = cacheKey(backendKey, topK, profileId, hint);
-  const cached = cacheGet(ck);
+  const cached = getLensCacheEntry(backendKey, topK, profileId, hint);
   if (cached) {
     if (isDebugMode()) console.log('[Lens] cache hit', backendKey);
     updateLensStatus({ state: 'active', lastChunkCount: cached.chunks.length, lastError: null, sourceName });
@@ -361,7 +339,7 @@ async function queryWithCache(backendKey, sourceName, hint, topK, fetchFn) {
     const rawChunks = await fetchFn();
     const chunks = Array.isArray(rawChunks) ? rawChunks : [];
     const result = { chunks, sourceName };
-    cacheSet(ck, result);
+    setLensCacheEntry(backendKey, topK, profileId, hint, result);
     updateLensStatus({ state: 'active', lastChunkCount: chunks.length, lastError: null, sourceName });
     return result;
   } catch (e) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -388,6 +388,7 @@ const APP_SHELL = [
   '/js/chat-threads.js',
   '/js/chat-thread-search.js',
   '/js/lens-actions.js',
+  '/js/lens-cache.js',
   '/js/lens-url.js',
   '/js/lens.js',
   '/js/lens-local.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -81,6 +81,7 @@ assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes(
 assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.includes("'/js/context-card-editor-ui.js'"));
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));
 assert('SW APP_SHELL includes lens action delegates module', swAuditSrc.includes("'/js/lens-actions.js'"));
+assert('SW APP_SHELL includes lens cache helper module', swAuditSrc.includes("'/js/lens-cache.js'"));
 assert('SW APP_SHELL includes lens URL helper module', swAuditSrc.includes("'/js/lens-url.js'"));
 assert('SW APP_SHELL includes DNA action delegates module', swAuditSrc.includes("'/js/dna-actions.js'"));
 assert('SW APP_SHELL includes DNA genotype helper module', swAuditSrc.includes("'/js/dna-genotype.js'"));

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -51,8 +51,8 @@ assert('lab-context fingerprint covers wearableSummary',
 
 // ─── 3. Lens LRU cache bumps on hit ───
 console.log('\n3. Lens LRU cache');
-const lensSrc = read('js/lens.js');
-const cacheGetMatch = lensSrc.match(/function cacheGet\(k\) \{([\s\S]*?)\n\}/);
+const lensCacheSrc = read('js/lens-cache.js');
+const cacheGetMatch = lensCacheSrc.match(/function cacheGet\(k\) \{([\s\S]*?)\n\}/);
 assert('cacheGet re-inserts on hit',
   cacheGetMatch && cacheGetMatch[1].includes('_cache.delete(k)') && cacheGetMatch[1].includes('_cache.set(k, row)'),
   'Map iterates in insertion order — without re-insert, hot entries are evicted by FIFO');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.9.4';
+self.APP_VERSION = '1.9.5';


### PR DESCRIPTION
## Summary
- Move the in-memory Lens query LRU cache into `js/lens-cache.js`
- Keep `clearLensCache()` exported from `js/lens.js` while delegating cache internals
- Precache the new helper and update audit/source guards
- Bump `version.js` to `1.9.5`

## Quality impact
- `js/lens.js` is down to 1463 lines
- Largest JS file is now `js/pdf-import.js` at 1475 lines, under the 1513 hard cap

## Validation
- `npm run typecheck`
- `node tests/test-custom-lens.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-audit.js`
- `npm run quality`
- `./run-tests.sh`