### PR TITLE
[codex] Extract settings provider bridge

### DIFF
--- a/js/settings-provider-bridge.js
+++ b/js/settings-provider-bridge.js
@@ -1,0 +1,148 @@
+// @ts-check
+// settings-provider-bridge.js - lazy bridge from Settings to provider panel modules.
+
+import {
+  clearOpenRouterOAuthSession,
+  getAIProvider,
+  getOpenRouterKey,
+  rememberOpenRouterOAuthPreviousProvider,
+  setAIProvider,
+} from './api.js';
+
+/** @typedef {Window & typeof globalThis & Record<string, any>} SettingsProviderBridgeWindow */
+
+const settingsWindow = /** @type {SettingsProviderBridgeWindow} */ (window);
+
+let _providerPanelsLoad = null;
+
+function loadProviderPanels() {
+  if (!_providerPanelsLoad) _providerPanelsLoad = import('./provider-panels.js');
+  return _providerPanelsLoad;
+}
+
+export function renderAIProviderPanelBridge(provider) {
+  loadProviderPanels().then(() => {
+    const panel = document.getElementById('ai-provider-panel');
+    if (panel && typeof settingsWindow.renderAIProviderPanel === 'function' && settingsWindow.renderAIProviderPanel !== renderAIProviderPanelBridge) {
+      panel.innerHTML = settingsWindow.renderAIProviderPanel(provider || getAIProvider());
+    }
+  }).catch(() => {});
+  return '<div class="ai-provider-panel"><div class="ai-provider-desc">Loading provider settings...</div></div>';
+}
+
+/** @param {string} name */
+function installProviderPanelBridge(name) {
+  const registry = /** @type {Record<string, any>} */ (settingsWindow);
+  if (typeof registry[name] === 'function') return;
+  const bridge = async function(...args) {
+    await loadProviderPanels();
+    const fn = registry[name];
+    if (typeof fn !== 'function' || fn === bridge) return undefined;
+    return fn(...args);
+  };
+  registry[name] = bridge;
+}
+
+function setProviderButtonState(provider) {
+  const buttons = /** @type {HTMLElement[]} */ (Array.from(document.querySelectorAll('.ai-provider-btn')));
+  buttons.forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.provider === provider);
+  });
+}
+
+export function switchAIProviderBridge(provider) {
+  const previousProvider = getAIProvider();
+  if (provider === 'openrouter' && previousProvider !== 'openrouter' && !getOpenRouterKey()) {
+    rememberOpenRouterOAuthPreviousProvider(previousProvider);
+  } else if (provider !== 'openrouter') {
+    clearOpenRouterOAuthSession();
+  }
+  setAIProvider(provider);
+  setProviderButtonState(provider);
+  const panel = document.getElementById('ai-provider-panel');
+  if (panel) panel.innerHTML = '<div class="ai-provider-panel"><div class="ai-provider-desc">Loading provider settings...</div></div>';
+  loadProviderPanels().then(() => {
+    const fn = settingsWindow.switchAIProvider;
+    if (typeof fn === 'function' && fn !== switchAIProviderBridge) return fn(provider);
+    if (panel && typeof settingsWindow.renderAIProviderPanel === 'function') panel.innerHTML = settingsWindow.renderAIProviderPanel(provider);
+  }).catch(() => {});
+}
+
+const PROVIDER_PANEL_BRIDGE_NAMES = [
+  'toggleAIPause',
+  'initSettingsModelFetch',
+  'initSettingsOllamaCheck',
+  'testOllamaConnection',
+  'testPIIOllamaConnection',
+  'refreshVeniceBalance',
+  'updateVeniceModelPricing',
+  'onVeniceModelDropdownChange',
+  'toggleVeniceE2EE',
+  'updateOpenRouterModelPricing',
+  'updateRoutstrModelPricing',
+  'handleSaveVeniceKey',
+  'handleRemoveVeniceKey',
+  'renderVeniceModelDropdown',
+  'handleSaveOpenRouterKey',
+  'handleRemoveOpenRouterKey',
+  'renderOpenRouterModelDropdown',
+  'applyCustomOpenRouterModel',
+  'onOpenRouterDropdownChange',
+  'handleSaveRoutstrKey',
+  'handleRemoveRoutstrKey',
+  'renderRoutstrModelDropdown',
+  'refreshCashuWalletBalance',
+  'refreshRoutstrBalance',
+  'showRoutstrWalletFund',
+  'rsWalletFundCustomInput',
+  'doRoutstrWalletFundCustom',
+  'doRoutstrWalletFund',
+  'doRoutstrWalletReceiveCashu',
+  'showRoutstrMintEdit',
+  'doRoutstrMintChange',
+  'showRoutstrWalletBackup',
+  'showRoutstrNodePicker',
+  'connectRoutstrNode',
+  'doRoutstrNodeDeposit',
+  'doRoutstrNodeWithdraw',
+  '_setActiveNodeAction',
+  'walletSeedAcknowledged',
+  'showWalletSeedPhrase',
+  'showRoutstrWithdraw',
+  'showRoutstrWithdrawLightning',
+  'showRoutstrWithdrawToken',
+  'doRoutstrSendToken',
+  'doRoutstrWithdrawQuote',
+  'doRoutstrWithdrawExecute',
+  'doRoutstrWalletRestore',
+  'handleCreatePpqAccount',
+  'dismissPpqKeyReveal',
+  'handleSavePpqKey',
+  'handleRemovePpqKey',
+  'renderPpqModelDropdown',
+  'updatePpqModelPricing',
+  'refreshPpqBalance',
+  'showPpqTopup',
+  'selectPpqMethod',
+  'doPpqTopup',
+  'ppqShowCustomInput',
+  'doPpqTopupCustom',
+  'cancelPpqTopup',
+  'refreshOpenRouterBalance',
+  'showInsufficientBalanceDialog',
+  'handleSaveCustomApi',
+  'handleRemoveCustomApi',
+  'renderCustomApiModelDropdown',
+  'applyCustomApiManualModel',
+  'updateCustomModelPricing',
+  'copyOllamaPullCmd',
+  'refreshModelAdvisor',
+  'applyHardwareOverride',
+  'clearHardwareOverride',
+];
+
+export function installSettingsProviderBridge() {
+  settingsWindow.renderAIProviderPanel = renderAIProviderPanelBridge;
+  settingsWindow.switchAIProvider = switchAIProviderBridge;
+  PROVIDER_PANEL_BRIDGE_NAMES.forEach(installProviderPanelBridge);
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -6,7 +6,7 @@ import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isDebugMod
 import { getTheme, setTheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, getTimeFormat, setTimeFormat, THEMES } from './theme.js';
 import { switchUnitSystem, toggleAltUnits, switchRangeMode } from './data.js';
 import { formatCost, getProfileUsage, getGlobalUsage, resetProfileUsage } from './schema.js';
-import { getAIProvider, setAIProvider, isAIPaused, getOllamaPIIUrl, getOllamaPIIModel, setOllamaPIIModel, getOpenRouterKey, rememberOpenRouterOAuthPreviousProvider, clearOpenRouterOAuthSession } from './api.js';
+import { getAIProvider, isAIPaused, getOllamaPIIUrl, getOllamaPIIModel, setOllamaPIIModel } from './api.js';
 import { isOllamaPIIEnabled, setOllamaPIIEnabled, getOllamaConfig, checkOpenAICompatible } from './pii.js';
 import { renderEncryptionSection, renderBackupSection, loadBackupSnapshots } from './crypto.js';
 import { renderSyncSection, renderMessengerSection, hydrateSettingsSyncPanel } from './settings-sync-panel.js';
@@ -14,140 +14,13 @@ import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
 import { loadPdfImport } from './import-loader.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
 import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import { installSettingsProviderBridge, switchAIProviderBridge } from './settings-provider-bridge.js';
 
 /** @typedef {Window & typeof globalThis & Record<string, any>} SettingsWindow */
 
 const settingsWindow = /** @type {SettingsWindow} */ (window);
 
-let _providerPanelsLoad = null;
-
-function loadProviderPanels() {
-  if (!_providerPanelsLoad) _providerPanelsLoad = import('./provider-panels.js');
-  return _providerPanelsLoad;
-}
-
-function renderAIProviderPanelBridge(provider) {
-  loadProviderPanels().then(() => {
-    const panel = document.getElementById('ai-provider-panel');
-    if (panel && typeof settingsWindow.renderAIProviderPanel === 'function' && settingsWindow.renderAIProviderPanel !== renderAIProviderPanelBridge) {
-      panel.innerHTML = settingsWindow.renderAIProviderPanel(provider || getAIProvider());
-    }
-  }).catch(() => {});
-  return '<div class="ai-provider-panel"><div class="ai-provider-desc">Loading provider settings...</div></div>';
-}
-
-/** @param {string} name */
-function installProviderPanelBridge(name) {
-  const registry = /** @type {Record<string, any>} */ (settingsWindow);
-  if (typeof registry[name] === 'function') return;
-  const bridge = async function(...args) {
-    await loadProviderPanels();
-    const fn = registry[name];
-    if (typeof fn !== 'function' || fn === bridge) return undefined;
-    return fn(...args);
-  };
-  registry[name] = bridge;
-}
-
-function setProviderButtonState(provider) {
-  const buttons = /** @type {HTMLElement[]} */ (Array.from(document.querySelectorAll('.ai-provider-btn')));
-  buttons.forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.provider === provider);
-  });
-}
-
-function switchAIProviderBridge(provider) {
-  const previousProvider = getAIProvider();
-  if (provider === 'openrouter' && previousProvider !== 'openrouter' && !getOpenRouterKey()) {
-    rememberOpenRouterOAuthPreviousProvider(previousProvider);
-  } else if (provider !== 'openrouter') {
-    clearOpenRouterOAuthSession();
-  }
-  setAIProvider(provider);
-  setProviderButtonState(provider);
-  const panel = document.getElementById('ai-provider-panel');
-  if (panel) panel.innerHTML = '<div class="ai-provider-panel"><div class="ai-provider-desc">Loading provider settings...</div></div>';
-  loadProviderPanels().then(() => {
-    const fn = settingsWindow.switchAIProvider;
-    if (typeof fn === 'function' && fn !== switchAIProviderBridge) return fn(provider);
-    if (panel && typeof settingsWindow.renderAIProviderPanel === 'function') panel.innerHTML = settingsWindow.renderAIProviderPanel(provider);
-  }).catch(() => {});
-}
-
-settingsWindow.renderAIProviderPanel = renderAIProviderPanelBridge;
-settingsWindow.switchAIProvider = switchAIProviderBridge;
-[
-  'toggleAIPause',
-  'initSettingsModelFetch',
-  'initSettingsOllamaCheck',
-  'testOllamaConnection',
-  'testPIIOllamaConnection',
-  'refreshVeniceBalance',
-  'updateVeniceModelPricing',
-  'onVeniceModelDropdownChange',
-  'toggleVeniceE2EE',
-  'updateOpenRouterModelPricing',
-  'updateRoutstrModelPricing',
-  'handleSaveVeniceKey',
-  'handleRemoveVeniceKey',
-  'renderVeniceModelDropdown',
-  'handleSaveOpenRouterKey',
-  'handleRemoveOpenRouterKey',
-  'renderOpenRouterModelDropdown',
-  'applyCustomOpenRouterModel',
-  'onOpenRouterDropdownChange',
-  'handleSaveRoutstrKey',
-  'handleRemoveRoutstrKey',
-  'renderRoutstrModelDropdown',
-  'refreshCashuWalletBalance',
-  'refreshRoutstrBalance',
-  'showRoutstrWalletFund',
-  'rsWalletFundCustomInput',
-  'doRoutstrWalletFundCustom',
-  'doRoutstrWalletFund',
-  'doRoutstrWalletReceiveCashu',
-  'showRoutstrMintEdit',
-  'doRoutstrMintChange',
-  'showRoutstrWalletBackup',
-  'showRoutstrNodePicker',
-  'connectRoutstrNode',
-  'doRoutstrNodeDeposit',
-  'doRoutstrNodeWithdraw',
-  '_setActiveNodeAction',
-  'walletSeedAcknowledged',
-  'showWalletSeedPhrase',
-  'showRoutstrWithdraw',
-  'showRoutstrWithdrawLightning',
-  'showRoutstrWithdrawToken',
-  'doRoutstrSendToken',
-  'doRoutstrWithdrawQuote',
-  'doRoutstrWithdrawExecute',
-  'doRoutstrWalletRestore',
-  'handleCreatePpqAccount',
-  'dismissPpqKeyReveal',
-  'handleSavePpqKey',
-  'handleRemovePpqKey',
-  'renderPpqModelDropdown',
-  'updatePpqModelPricing',
-  'refreshPpqBalance',
-  'showPpqTopup',
-  'selectPpqMethod',
-  'doPpqTopup',
-  'ppqShowCustomInput',
-  'doPpqTopupCustom',
-  'cancelPpqTopup',
-  'refreshOpenRouterBalance',
-  'showInsufficientBalanceDialog',
-  'handleSaveCustomApi',
-  'handleRemoveCustomApi',
-  'renderCustomApiModelDropdown',
-  'applyCustomApiManualModel',
-  'updateCustomModelPricing',
-  'copyOllamaPullCmd',
-  'refreshModelAdvisor',
-  'applyHardwareOverride',
-  'clearHardwareOverride',
-].forEach(installProviderPanelBridge);
+installSettingsProviderBridge();
 
 // ═══════════════════════════════════════════════
 // SETTINGS MODAL

--- a/service-worker.js
+++ b/service-worker.js
@@ -162,6 +162,7 @@ const APP_SHELL = [
   '/js/chat-prompt-context.js',
   '/js/chat-summaries.js',
   '/js/settings.js',
+  '/js/settings-provider-bridge.js',
   '/js/settings-sync-panel.js',
   '/js/feedback.js',
   '/js/tour.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -69,6 +69,7 @@ assert('SW APP_SHELL includes provider model controls module', swAuditSrc.includ
 assert('SW APP_SHELL includes provider local AI controls module', swAuditSrc.includes("'/js/provider-local-ai-controls.js'"));
 assert('SW APP_SHELL includes provider PPQ panels module', swAuditSrc.includes("'/js/provider-ppq-panels.js'"));
 assert('SW APP_SHELL includes API transport module', swAuditSrc.includes("'/js/api-transport.js'"));
+assert('SW APP_SHELL includes settings provider bridge module', swAuditSrc.includes("'/js/settings-provider-bridge.js'"));
 assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/js/pdf-import-review.js'"));
 assert('SW APP_SHELL includes modal lifecycle module', swAuditSrc.includes("'/js/modal-lifecycle.js'"));
 assert('SW APP_SHELL includes marker analysis module', swAuditSrc.includes("'/js/marker-analysis.js'"));

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -95,6 +95,7 @@ const pwaAppShellAssets = [
   '/js/startup-maintenance.js',
   '/js/startup-ui.js',
   '/js/ai-verdict-engine.js',
+  '/js/settings-provider-bridge.js',
   '/js/import-loader.js',
   '/js/import-file-input.js',
   '/js/import-drop-zone.js',

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -99,6 +99,7 @@ console.log('\n3. provider panel source inspection');
 const ppSrc = read('js/provider-panels.js');
 const providerRenderSrc = read('js/provider-panel-renderers.js');
 const providerModelControlsSrc = read('js/provider-model-controls.js');
+const settingsBridgeSrc = read('js/settings-provider-bridge.js');
 const providerUiSrc = ppSrc + providerRenderSrc + providerModelControlsSrc;
 assert('imports getOpenRouterKey', providerUiSrc.includes('getOpenRouterKey'));
 assert('imports saveOpenRouterKey', ppSrc.includes('saveOpenRouterKey'));
@@ -111,8 +112,9 @@ const settingsSrc = read('js/settings.js');
 assert('provider button with data-provider="openrouter"', settingsSrc.includes('data-provider="openrouter"'));
 assert('OpenRouter provider button uses delegated settings action',
   /<button[^>]*data-provider="openrouter"[^>]*data-settings-action="switch-ai-provider"/.test(settingsSrc));
-assert('settings has eager provider switch bridge', settingsSrc.includes('function switchAIProviderBridge(provider)'));
-assert('eager provider bridge persists selection synchronously', settingsSrc.includes('setAIProvider(provider);'));
+assert('settings installs provider bridge module', settingsSrc.includes('installSettingsProviderBridge();'));
+assert('settings provider bridge has eager provider switch', settingsBridgeSrc.includes('function switchAIProviderBridge(provider)'));
+assert('eager provider bridge persists selection synchronously', settingsBridgeSrc.includes('setAIProvider(provider);'));
 assert('settings records existing provider before provider-key onboarding return',
   settingsSrc.includes('settingsWindow._settingsHadProvider = !!settingsWindow.hasAIProvider?.();')
     && ppSrc.includes('if (window._settingsHadProvider) return'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.9.6';
+self.APP_VERSION = '1.9.7';


### PR DESCRIPTION
## Summary
- move the Settings provider-panel lazy bridge into `js/settings-provider-bridge.js`
- keep delegated provider switching wired through the new bridge module
- precache the new module and update audit/PWA/OpenRouter source guards
- bump app version to `1.9.7`

## Quality impact
- `js/settings.js`: 1465 -> 1338 lines
- largest JS file is now `js/lens.js` at 1463 lines
- `npm run quality` guard: `large JS files 28/28`, `largest JS file 1464/1513: js/lens.js`

## Validation
- `npm run typecheck`
- `node tests/test-openrouter.js`
- `node tests/test-settings-delegated-actions.js`
- `node tests/test-audit.js`
- `node tests/test-correctness-phase2.js`
- `npm run quality`
- `npx playwright test tests/playwright/settings-browser-coverage.spec.js tests/playwright/settings-provider-browser-coverage.spec.js tests/playwright/openrouter-settings.spec.js tests/playwright/provider-coverage-batch.spec.js --project=chromium`
- `./run-tests.sh`