### PR TITLE
[codex] Extract EMF interpretation helpers

### DIFF
--- a/js/emf-interpretation.js
+++ b/js/emf-interpretation.js
@@ -1,0 +1,349 @@
+// @ts-check
+// emf-interpretation.js - EMF AI interpretation modal, streaming, and chat handoff.
+
+import { state } from './state.js';
+import { SBM_2015_THRESHOLDS, getEMFSeverity, calculateCost, formatCost, trackUsage } from './schema.js';
+import { escapeHTML, escapeAttr } from './utils.js';
+import { saveImportedData } from './data.js';
+import { callClaudeAPI, getAIProvider, getActiveModelId, getActiveModelDisplay } from './api.js';
+import { renderMarkdown } from './markdown.js';
+import { loadEMFCatalog, renderEMFMitigationRecs, isProductRecsEnabled, detectMitigationsInText } from './recommendations.js';
+import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
+
+/**
+ * @typedef {{ text?: string, model?: string, provider?: string, modelId?: string, inputTokens?: number, outputTokens?: number, date?: string }} EMFInterpretation
+ * @typedef {HTMLElement & { _interpretText?: string, _onGenerate?: ((onSave: (((interp: EMFInterpretation) => void) | null)) => void), _onSave?: ((interp: EMFInterpretation) => void) | null, _mouseDownInside?: boolean, _delegatesInstalled?: boolean }} EMFInterpretationOverlay
+ * @typedef {{ collectActiveAssessmentState?: () => void, getAssessments?: () => any[] }} EMFInterpretationDeps
+ */
+
+let _aiAbortController = null;
+
+function getAssessments(deps) {
+  return deps?.getAssessments?.() || state.importedData.emfAssessment?.assessments || [];
+}
+
+function serializeAssessment(a) {
+  const fmtDate = new Date(a.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  let text = `Assessment: ${fmtDate}${a.label ? ' (' + a.label + ')' : ''}${a.consultant ? ' by ' + a.consultant : ''}\n`;
+  for (const room of a.rooms) {
+    const sleeping = room.sleeping !== false;
+    text += `  ${room.name}${room.location ? ' (' + room.location + ')' : ''} [${sleeping ? 'sleeping area' : 'daytime area'}]:\n`;
+    for (const [type, m] of Object.entries(room.measurements || {})) {
+      if (m && m.value != null) {
+        const def = SBM_2015_THRESHOLDS[type];
+        const sev = getEMFSeverity(type, m.value, sleeping);
+        text += `    ${def.name}: ${m.value} ${def.unit}${sev ? ' \u2014 ' + sev.label : ''}${m.meter ? ' (meter: ' + m.meter + ')' : ''}\n`;
+      }
+    }
+    if (room.sources?.length) text += `    Sources: ${room.sources.join(', ')}\n`;
+    if (room.mitigations?.length) text += `    Mitigations: ${room.mitigations.join(', ')}\n`;
+  }
+  if (a.note) text += `Notes: ${a.note}\n`;
+  return text;
+}
+
+/** Strip OpenRouter-style <think>...</think> blocks */
+function stripThinking(text) {
+  return text.replace(/<think>[\s\S]*?<\/think>/g, '').replace(/<think>[\s\S]*$/, '').trim();
+}
+
+const EMF_SYSTEM = `You are a Baubiologie (Building Biology) consultant interpreting EMF assessment data rated against SBM-2015 standards. Be specific about health implications, prioritize concerns by severity (sleeping areas are most critical), and suggest actionable mitigations in priority order. Keep the response concise and practical. Use markdown formatting with headers and bullet points.`;
+
+function emfInterpAttrString(attrs) {
+  return Object.entries(attrs)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([name, value]) => `${name}="${escapeAttr(String(value))}"`)
+    .join(' ');
+}
+
+function emfInterpActionAttrs(action, attrs = {}) {
+  return emfInterpAttrString({ 'data-emf-interp-action': action, ...attrs });
+}
+
+function _handleEMFInterpretationMouseDown(event) {
+  const overlay = /** @type {EMFInterpretationOverlay | null} */ (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
+  if (!overlay) return;
+  overlay._mouseDownInside = event.target !== overlay;
+}
+
+function _handleEMFInterpretationClick(event) {
+  const overlay = /** @type {EMFInterpretationOverlay | null} */ (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
+  if (!overlay) return;
+
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    overlay._mouseDownInside = false;
+    return;
+  }
+
+  const actionEl = target.closest('[data-emf-interp-action]');
+  if (actionEl instanceof HTMLElement && overlay.contains(actionEl)) {
+    const action = actionEl.dataset.emfInterpAction || '';
+    if (action === 'close') {
+      event.preventDefault();
+      overlay._mouseDownInside = false;
+      closeEMFInterpretation();
+      return;
+    }
+    if (action === 'discuss') {
+      event.preventDefault();
+      overlay._mouseDownInside = false;
+      discussEMFInterpretation();
+      return;
+    }
+    if (action === 'generate') {
+      event.preventDefault();
+      overlay._mouseDownInside = false;
+      if (!overlay._onGenerate) return;
+      const btn = actionEl instanceof HTMLButtonElement ? actionEl : null;
+      if (btn) {
+        btn.disabled = true;
+        btn.textContent = 'Interpreting\u2026';
+      }
+      overlay._onGenerate(overlay._onSave || null);
+      return;
+    }
+  }
+
+  if (target === overlay && !overlay._mouseDownInside) closeEMFInterpretation();
+  overlay._mouseDownInside = false;
+}
+
+function installEMFInterpretationDelegates(overlay) {
+  if (overlay._delegatesInstalled) return;
+  overlay._delegatesInstalled = true;
+  overlay.addEventListener('mousedown', _handleEMFInterpretationMouseDown);
+  overlay.addEventListener('click', _handleEMFInterpretationClick);
+}
+
+function openInterpretationModal(title, existingInterp, onGenerate, onSave, mitigationTags = []) {
+  // Create overlay that sits on top of the EMF editor (z-index above modal-overlay)
+  let overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
+  if (!overlay) {
+    overlay = /** @type {EMFInterpretationOverlay} */ (document.createElement('div'));
+    overlay.id = 'emf-interp-overlay';
+    overlay.className = 'emf-interp-overlay';
+  }
+
+  const hasExisting = existingInterp && existingInterp.text;
+
+  let html = `<div class="emf-interp-modal">
+    <div class="emf-interp-header">
+      <h3>${escapeHTML(title)}</h3>
+      <button class="modal-close" aria-label="Close" ${emfInterpActionAttrs('close')}>&times;</button>
+    </div>
+    <div class="emf-interp-body" id="emf-interp-body">
+      ${hasExisting ? renderMarkdown(existingInterp.text) : '<div class="emf-interp-placeholder">Click Interpret to get an AI interpretation of this assessment.</div>'}
+    </div>
+    <div id="emf-interp-recs"></div>
+    <div class="emf-interp-footer">
+      <div id="emf-interp-meta" class="emf-interp-meta">
+        ${hasExisting ? buildMetaLine(existingInterp) : ''}
+      </div>
+      <div class="emf-interp-actions">
+        <button class="import-btn import-btn-primary" id="emf-interp-generate" ${emfInterpActionAttrs('generate')}>${hasExisting ? 'Re-interpret' : 'Interpret'}</button>
+        ${hasExisting ? `<button class="import-btn import-btn-secondary" ${emfInterpActionAttrs('discuss')}>Discuss in Chat</button>` : ''}
+        <button class="import-btn import-btn-secondary" ${emfInterpActionAttrs('close')}>Close</button>
+      </div>
+    </div>
+  </div>`;
+
+  overlay.innerHTML = html;
+  const wasConnected = overlay.isConnected;
+  if (!wasConnected) document.body.appendChild(overlay);
+  openModalOverlay(overlay);
+  if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}
+
+  // Store context for discuss button
+  overlay._interpretText = hasExisting ? existingInterp.text : '';
+  overlay._onGenerate = onGenerate;
+  overlay._onSave = onSave;
+  overlay._mouseDownInside = false;
+  installEMFInterpretationDelegates(overlay);
+
+  // Populate mitigation product recs alongside the AI interpretation
+  if (mitigationTags && mitigationTags.length && isProductRecsEnabled()) {
+    const recSlot = document.getElementById('emf-interp-recs');
+    if (recSlot) {
+      loadEMFCatalog().then(cat => {
+        if (cat && document.getElementById('emf-interp-recs') === recSlot) {
+          recSlot.innerHTML = renderEMFMitigationRecs(cat, mitigationTags, { heading: 'Products to consider' });
+        }
+      });
+    }
+  }
+}
+
+function buildMetaLine(interp) {
+  if (!interp) return '';
+  const parts = [];
+  const separator = ' \u00b7 ';
+  if (interp.model) parts.push(interp.model);
+  if (interp.inputTokens || interp.outputTokens) {
+    const cost = calculateCost(interp.provider || '', interp.modelId || '', interp.inputTokens || 0, interp.outputTokens || 0);
+    const total = (interp.inputTokens || 0) + (interp.outputTokens || 0);
+    parts.push(`${formatCost(cost)}${separator}${total.toLocaleString()} tokens`);
+  }
+  if (interp.date) {
+    parts.push(new Date(interp.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }));
+  }
+  return parts.length ? escapeHTML(parts.join(separator)) : '';
+}
+
+function streamInterpretation(prompt, onComplete) {
+  if (_aiAbortController) _aiAbortController.abort();
+  _aiAbortController = new AbortController();
+
+  const body = document.getElementById('emf-interp-body');
+  const meta = document.getElementById('emf-interp-meta');
+  if (!body) return;
+
+  body.innerHTML = '<div class="emf-interp-placeholder">Thinking\u2026</div>';
+  if (meta) meta.textContent = '';
+
+  let lastRender = 0;
+  const THROTTLE_MS = 150;
+
+  const provider = getAIProvider();
+  const modelId = getActiveModelId();
+  const modelDisplay = getActiveModelDisplay();
+
+  callClaudeAPI({
+    messages: [{ role: 'user', content: prompt }],
+    system: EMF_SYSTEM,
+    signal: _aiAbortController.signal,
+    onStream(fullText) {
+      const now = Date.now();
+      if (now - lastRender < THROTTLE_MS) return;
+      lastRender = now;
+      const clean = stripThinking(fullText);
+      if (clean) body.innerHTML = renderMarkdown(clean);
+    }
+  }).then(response => {
+    _aiAbortController = null;
+    const finalText = stripThinking(response?.text || '');
+    const usage = /** @type {{ inputTokens?: number, outputTokens?: number }} */ (response?.usage || {});
+    body.innerHTML = finalText ? renderMarkdown(finalText) : '<div class="emf-interp-placeholder">No response received.</div>';
+
+    const interp = {
+      text: finalText,
+      model: modelDisplay,
+      provider,
+      modelId,
+      inputTokens: usage.inputTokens || 0,
+      outputTokens: usage.outputTokens || 0,
+      date: new Date().toISOString()
+    };
+    trackUsage(provider, modelId, usage.inputTokens || 0, usage.outputTokens || 0);
+
+    if (meta) meta.innerHTML = buildMetaLine(interp);
+
+    // Update generate button
+    const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('emf-interp-generate'));
+    if (btn) { btn.disabled = false; btn.textContent = 'Re-interpret'; }
+
+    // Add discuss button if not present
+    const overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
+    const actions = overlay?.querySelector('.emf-interp-actions');
+    if (actions && !actions.querySelector('[data-emf-interp-action="discuss"]')) {
+      const discussBtn = document.createElement('button');
+      discussBtn.type = 'button';
+      discussBtn.className = 'import-btn import-btn-secondary';
+      discussBtn.dataset.emfInterpAction = 'discuss';
+      discussBtn.textContent = 'Discuss in Chat';
+      actions.appendChild(discussBtn);
+    }
+
+    // Store for discuss
+    if (overlay) overlay._interpretText = finalText;
+
+    if (onComplete) onComplete(interp);
+  }).catch(err => {
+    _aiAbortController = null;
+    if (err.name === 'AbortError') return;
+    body.innerHTML = `<div style="color:var(--red);padding:12px">Error: ${escapeHTML(err.message)}</div>`;
+    const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('emf-interp-generate'));
+    if (btn) { btn.disabled = false; btn.textContent = 'Retry'; }
+  });
+}
+
+export function closeEMFInterpretation() {
+  if (_aiAbortController) { _aiAbortController.abort(); _aiAbortController = null; }
+  const overlay = document.getElementById('emf-interp-overlay');
+  if (overlay) removeModalOverlay(overlay);
+}
+
+export function discussEMFInterpretation() {
+  const overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
+  const text = overlay?._interpretText;
+  if (!text) return;
+  closeEMFInterpretation();
+  window.closeModal();
+  window.openChatPanel(`I'd like to discuss this EMF assessment interpretation further. Here's the interpretation:\n\n${text}\n\nWhat questions should I prioritize, and what are the most important next steps?`);
+}
+
+function _collectMitigationTags(assessment) {
+  if (!assessment?.rooms) return [];
+  const seen = new Set();
+  const out = [];
+  // 1) User-tagged mitigation chips on each room (explicit signal)
+  for (const room of assessment.rooms) {
+    for (const t of (room.mitigations || [])) {
+      if (!seen.has(t)) { seen.add(t); out.push(t); }
+    }
+  }
+  // 2) Mitigations the AI interpretation text mentions, even if no chip was set.
+  // This catches freshly-imported consultant PDFs where recommended mitigations
+  // appear in prose but the room's chip array is empty.
+  const interpText = assessment.interpretation?.text;
+  if (interpText) {
+    for (const t of detectMitigationsInText(interpText)) {
+      if (!seen.has(t)) { seen.add(t); out.push(t); }
+    }
+  }
+  return out;
+}
+
+export function interpretEMFAssessment(assessmentId, deps = {}) {
+  deps.collectActiveAssessmentState?.();
+  const assessments = getAssessments(deps);
+  const a = assessments.find(x => x.id === assessmentId);
+  if (!a) return;
+
+  const fmtDate = new Date(a.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  const title = `EMF Interpretation \u2014 ${fmtDate}${a.label ? ' (' + a.label + ')' : ''}`;
+  const data = serializeAssessment(a);
+  const tags = _collectMitigationTags(a);
+
+  openInterpretationModal(title, a.interpretation, (onSave) => {
+    const prompt = `Interpret this Baubiologie EMF assessment. Identify the most concerning readings, explain health implications (especially for sleeping areas), and recommend specific mitigations in priority order.\n\n${data}`;
+    streamInterpretation(prompt, (interp) => {
+      a.interpretation = interp;
+      saveImportedData();
+    });
+  }, null, tags);
+}
+
+export function interpretEMFComparison(deps = {}) {
+  deps.collectActiveAssessmentState?.();
+  const assessments = getAssessments(deps);
+  const sorted = [...assessments].sort((a, b) => b.date.localeCompare(a.date));
+  if (sorted.length < 2) return;
+
+  const emf = state.importedData.emfAssessment;
+  const title = 'EMF Comparison \u2014 Before vs After';
+  const before = serializeAssessment(sorted[1]);
+  const after = serializeAssessment(sorted[0]);
+  const tags = [..._collectMitigationTags(sorted[0]), ..._collectMitigationTags(sorted[1])];
+  const dedup = [];
+  const seen = new Set();
+  for (const t of tags) { if (!seen.has(t)) { seen.add(t); dedup.push(t); } }
+
+  openInterpretationModal(title, emf.comparisonInterpretation, (onSave) => {
+    const prompt = `Compare these two Baubiologie EMF assessments (before and after). Evaluate what improved, what worsened, and what still needs attention. Prioritize remaining concerns and suggest next steps.\n\nBEFORE:\n${before}\nAFTER:\n${after}`;
+    streamInterpretation(prompt, (interp) => {
+      emf.comparisonInterpretation = interp;
+      saveImportedData();
+    });
+  }, null, dedup);
+}

--- a/js/emf.js
+++ b/js/emf.js
@@ -3,7 +3,7 @@
 // Room-by-room EMF measurements with SBM-2015 severity ratings
 
 import { state } from './state.js';
-import { SBM_2015_THRESHOLDS, getEMFSeverity, calculateCost, formatCost, trackUsage } from './schema.js';
+import { SBM_2015_THRESHOLDS, getEMFSeverity } from './schema.js';
 
 const SAFE_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 function safeMediaType(t) { return SAFE_IMAGE_TYPES.includes(t) ? t : 'image/png'; }
@@ -11,18 +11,18 @@ import { EMF_ROOM_PRESETS, EMF_SOURCES, EMF_MITIGATIONS, EMF_METER_PRESETS } fro
 import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isPIIReviewEnabled } from './utils.js';
 import { saveImportedData } from './data.js';
 import { resizeImage, isValidImageType } from './image-utils.js';
-import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId, getActiveModelDisplay } from './api.js';
-import { renderMarkdown } from './markdown.js';
+import { callClaudeAPI, hasAIProvider } from './api.js';
 import { toggleCtxTag } from './context-card-editor-ui.js';
 import { extractPDFText } from './pdf-import.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
-import { loadEMFCatalog, renderEMFMeterRecs, renderEMFMitigationRecs, isProductRecsEnabled, detectMitigationsInText } from './recommendations.js';
+import { loadEMFCatalog, renderEMFMeterRecs, isProductRecsEnabled } from './recommendations.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
-
-/**
- * @typedef {{ text?: string, model?: string, provider?: string, modelId?: string, inputTokens?: number, outputTokens?: number, date?: string }} EMFInterpretation
- * @typedef {HTMLElement & { _interpretText?: string, _onGenerate?: ((onSave: (((interp: EMFInterpretation) => void) | null)) => void), _onSave?: ((interp: EMFInterpretation) => void) | null, _mouseDownInside?: boolean, _delegatesInstalled?: boolean }} EMFInterpretationOverlay
- */
+import {
+  closeEMFInterpretation,
+  discussEMFInterpretation,
+  interpretEMFAssessment as interpretEMFAssessmentImpl,
+  interpretEMFComparison as interpretEMFComparisonImpl,
+} from './emf-interpretation.js';
 
 // ═══════════════════════════════════════════════
 // MEASUREMENT TYPES (display order)
@@ -136,10 +136,6 @@ function emfActionAttrs(action, attrs = {}) {
 
 function emfChangeAttrs(action, attrs = {}) {
   return emfAttrString({ 'data-emf-change-action': action, ...attrs });
-}
-
-function emfInterpActionAttrs(action, attrs = {}) {
-  return emfAttrString({ 'data-emf-interp-action': action, ...attrs });
 }
 
 function isEMFEditorTarget(el) {
@@ -991,322 +987,23 @@ function renderComparisonView(sorted) {
 }
 
 // ═══════════════════════════════════════════════
-// AI INTERPRETATION
+// AI INTERPRETATION WRAPPERS
 // ═══════════════════════════════════════════════
-let _aiAbortController = null;
+export { closeEMFInterpretation, discussEMFInterpretation };
 
-function serializeAssessment(a) {
-  const fmtDate = new Date(a.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-  let text = `Assessment: ${fmtDate}${a.label ? ' (' + a.label + ')' : ''}${a.consultant ? ' by ' + a.consultant : ''}\n`;
-  for (const room of a.rooms) {
-    const sleeping = room.sleeping !== false;
-    text += `  ${room.name}${room.location ? ' (' + room.location + ')' : ''} [${sleeping ? 'sleeping area' : 'daytime area'}]:\n`;
-    for (const [type, m] of Object.entries(room.measurements || {})) {
-      if (m && m.value != null) {
-        const def = SBM_2015_THRESHOLDS[type];
-        const sev = getEMFSeverity(type, m.value, sleeping);
-        text += `    ${def.name}: ${m.value} ${def.unit}${sev ? ' — ' + sev.label : ''}${m.meter ? ' (meter: ' + m.meter + ')' : ''}\n`;
-      }
-    }
-    if (room.sources?.length) text += `    Sources: ${room.sources.join(', ')}\n`;
-    if (room.mitigations?.length) text += `    Mitigations: ${room.mitigations.join(', ')}\n`;
-  }
-  if (a.note) text += `Notes: ${a.note}\n`;
-  return text;
-}
-
-/** Strip OpenRouter-style <think>…</think> blocks */
-function stripThinking(text) {
-  return text.replace(/<think>[\s\S]*?<\/think>/g, '').replace(/<think>[\s\S]*$/, '').trim();
-}
-
-const EMF_SYSTEM = `You are a Baubiologie (Building Biology) consultant interpreting EMF assessment data rated against SBM-2015 standards. Be specific about health implications, prioritize concerns by severity (sleeping areas are most critical), and suggest actionable mitigations in priority order. Keep the response concise and practical. Use markdown formatting with headers and bullet points.`;
-
-function _handleEMFInterpretationMouseDown(event) {
-  const overlay = /** @type {EMFInterpretationOverlay | null} */ (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
-  if (!overlay) return;
-  overlay._mouseDownInside = event.target !== overlay;
-}
-
-function _handleEMFInterpretationClick(event) {
-  const overlay = /** @type {EMFInterpretationOverlay | null} */ (event.currentTarget instanceof HTMLElement ? event.currentTarget : null);
-  if (!overlay) return;
-
-  const target = event.target;
-  if (!(target instanceof Element)) {
-    overlay._mouseDownInside = false;
-    return;
-  }
-
-  const actionEl = target.closest('[data-emf-interp-action]');
-  if (actionEl instanceof HTMLElement && overlay.contains(actionEl)) {
-    const action = actionEl.dataset.emfInterpAction || '';
-    if (action === 'close') {
-      event.preventDefault();
-      overlay._mouseDownInside = false;
-      closeEMFInterpretation();
-      return;
-    }
-    if (action === 'discuss') {
-      event.preventDefault();
-      overlay._mouseDownInside = false;
-      discussEMFInterpretation();
-      return;
-    }
-    if (action === 'generate') {
-      event.preventDefault();
-      overlay._mouseDownInside = false;
-      if (!overlay._onGenerate) return;
-      const btn = actionEl instanceof HTMLButtonElement ? actionEl : null;
-      if (btn) {
-        btn.disabled = true;
-        btn.textContent = 'Interpreting…';
-      }
-      overlay._onGenerate(overlay._onSave || null);
-      return;
-    }
-  }
-
-  if (target === overlay && !overlay._mouseDownInside) closeEMFInterpretation();
-  overlay._mouseDownInside = false;
-}
-
-function installEMFInterpretationDelegates(overlay) {
-  if (overlay._delegatesInstalled) return;
-  overlay._delegatesInstalled = true;
-  overlay.addEventListener('mousedown', _handleEMFInterpretationMouseDown);
-  overlay.addEventListener('click', _handleEMFInterpretationClick);
-}
-
-function openInterpretationModal(title, existingInterp, onGenerate, onSave, mitigationTags = []) {
-  // Create overlay that sits on top of the EMF editor (z-index above modal-overlay)
-  let overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
-  if (!overlay) {
-    overlay = /** @type {EMFInterpretationOverlay} */ (document.createElement('div'));
-    overlay.id = 'emf-interp-overlay';
-    overlay.className = 'emf-interp-overlay';
-  }
-
-  const hasExisting = existingInterp && existingInterp.text;
-
-  let html = `<div class="emf-interp-modal">
-    <div class="emf-interp-header">
-      <h3>${escapeHTML(title)}</h3>
-      <button class="modal-close" aria-label="Close" ${emfInterpActionAttrs('close')}>&times;</button>
-    </div>
-    <div class="emf-interp-body" id="emf-interp-body">
-      ${hasExisting ? renderMarkdown(existingInterp.text) : '<div class="emf-interp-placeholder">Click Interpret to get an AI interpretation of this assessment.</div>'}
-    </div>
-    <div id="emf-interp-recs"></div>
-    <div class="emf-interp-footer">
-      <div id="emf-interp-meta" class="emf-interp-meta">
-        ${hasExisting ? buildMetaLine(existingInterp) : ''}
-      </div>
-      <div class="emf-interp-actions">
-        <button class="import-btn import-btn-primary" id="emf-interp-generate" ${emfInterpActionAttrs('generate')}>${hasExisting ? 'Re-interpret' : 'Interpret'}</button>
-        ${hasExisting ? `<button class="import-btn import-btn-secondary" ${emfInterpActionAttrs('discuss')}>Discuss in Chat</button>` : ''}
-        <button class="import-btn import-btn-secondary" ${emfInterpActionAttrs('close')}>Close</button>
-      </div>
-    </div>
-  </div>`;
-
-  overlay.innerHTML = html;
-  const wasConnected = overlay.isConnected;
-  if (!wasConnected) document.body.appendChild(overlay);
-  openModalOverlay(overlay);
-  if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}
-
-  // Store context for discuss button
-  overlay._interpretText = hasExisting ? existingInterp.text : '';
-  overlay._onGenerate = onGenerate;
-  overlay._onSave = onSave;
-  overlay._mouseDownInside = false;
-  installEMFInterpretationDelegates(overlay);
-
-  // Populate mitigation product recs alongside the AI interpretation
-  if (mitigationTags && mitigationTags.length && isProductRecsEnabled()) {
-    const recSlot = document.getElementById('emf-interp-recs');
-    if (recSlot) {
-      loadEMFCatalog().then(cat => {
-        if (cat && document.getElementById('emf-interp-recs') === recSlot) {
-          recSlot.innerHTML = renderEMFMitigationRecs(cat, mitigationTags, { heading: 'Products to consider' });
-        }
-      });
-    }
-  }
-}
-
-function buildMetaLine(interp) {
-  if (!interp) return '';
-  const parts = [];
-  if (interp.model) parts.push(interp.model);
-  if (interp.inputTokens || interp.outputTokens) {
-    const cost = calculateCost(interp.provider || '', interp.modelId || '', interp.inputTokens || 0, interp.outputTokens || 0);
-    const total = (interp.inputTokens || 0) + (interp.outputTokens || 0);
-    parts.push(`${formatCost(cost)} · ${total.toLocaleString()} tokens`);
-  }
-  if (interp.date) {
-    parts.push(new Date(interp.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }));
-  }
-  return parts.length ? escapeHTML(parts.join(' · ')) : '';
-}
-
-function streamInterpretation(prompt, onComplete) {
-  if (_aiAbortController) _aiAbortController.abort();
-  _aiAbortController = new AbortController();
-
-  const body = document.getElementById('emf-interp-body');
-  const meta = document.getElementById('emf-interp-meta');
-  if (!body) return;
-
-  body.innerHTML = '<div class="emf-interp-placeholder">Thinking…</div>';
-  if (meta) meta.textContent = '';
-
-  let lastRender = 0;
-  const THROTTLE_MS = 150;
-
-  const provider = getAIProvider();
-  const modelId = getActiveModelId();
-  const modelDisplay = getActiveModelDisplay();
-
-  callClaudeAPI({
-    messages: [{ role: 'user', content: prompt }],
-    system: EMF_SYSTEM,
-    signal: _aiAbortController.signal,
-    onStream(fullText) {
-      const now = Date.now();
-      if (now - lastRender < THROTTLE_MS) return;
-      lastRender = now;
-      const clean = stripThinking(fullText);
-      if (clean) body.innerHTML = renderMarkdown(clean);
-    }
-  }).then(response => {
-    _aiAbortController = null;
-    const finalText = stripThinking(response?.text || '');
-    const usage = /** @type {{ inputTokens?: number, outputTokens?: number }} */ (response?.usage || {});
-    body.innerHTML = finalText ? renderMarkdown(finalText) : '<div class="emf-interp-placeholder">No response received.</div>';
-
-    const interp = {
-      text: finalText,
-      model: modelDisplay,
-      provider,
-      modelId,
-      inputTokens: usage.inputTokens || 0,
-      outputTokens: usage.outputTokens || 0,
-      date: new Date().toISOString()
-    };
-    trackUsage(provider, modelId, usage.inputTokens || 0, usage.outputTokens || 0);
-
-    if (meta) meta.innerHTML = buildMetaLine(interp);
-
-    // Update generate button
-    const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('emf-interp-generate'));
-    if (btn) { btn.disabled = false; btn.textContent = 'Re-interpret'; }
-
-    // Add discuss button if not present
-    const overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
-    const actions = overlay?.querySelector('.emf-interp-actions');
-    if (actions && !actions.querySelector('[data-emf-interp-action="discuss"]')) {
-      const discussBtn = document.createElement('button');
-      discussBtn.type = 'button';
-      discussBtn.className = 'import-btn import-btn-secondary';
-      discussBtn.dataset.emfInterpAction = 'discuss';
-      discussBtn.textContent = 'Discuss in Chat';
-      actions.appendChild(discussBtn);
-    }
-
-    // Store for discuss
-    if (overlay) overlay._interpretText = finalText;
-
-    if (onComplete) onComplete(interp);
-  }).catch(err => {
-    _aiAbortController = null;
-    if (err.name === 'AbortError') return;
-    body.innerHTML = `<div style="color:var(--red);padding:12px">Error: ${escapeHTML(err.message)}</div>`;
-    const btn = /** @type {HTMLButtonElement | null} */ (document.getElementById('emf-interp-generate'));
-    if (btn) { btn.disabled = false; btn.textContent = 'Retry'; }
-  });
-}
-
-export function closeEMFInterpretation() {
-  if (_aiAbortController) { _aiAbortController.abort(); _aiAbortController = null; }
-  const overlay = document.getElementById('emf-interp-overlay');
-  if (overlay) removeModalOverlay(overlay);
-}
-
-export function discussEMFInterpretation() {
-  const overlay = /** @type {EMFInterpretationOverlay | null} */ (document.getElementById('emf-interp-overlay'));
-  const text = overlay?._interpretText;
-  if (!text) return;
-  closeEMFInterpretation();
-  window.closeModal();
-  window.openChatPanel(`I'd like to discuss this EMF assessment interpretation further. Here's the interpretation:\n\n${text}\n\nWhat questions should I prioritize, and what are the most important next steps?`);
-}
-
-function _collectMitigationTags(assessment) {
-  if (!assessment?.rooms) return [];
-  const seen = new Set();
-  const out = [];
-  // 1) User-tagged mitigation chips on each room (explicit signal)
-  for (const room of assessment.rooms) {
-    for (const t of (room.mitigations || [])) {
-      if (!seen.has(t)) { seen.add(t); out.push(t); }
-    }
-  }
-  // 2) Mitigations the AI interpretation text mentions, even if no chip was set —
-  // catches the common case where a freshly-imported consultant PDF surfaces
-  // recommended mitigations in the AI's prose but the room's chip array is empty.
-  const interpText = assessment.interpretation?.text;
-  if (interpText) {
-    for (const t of detectMitigationsInText(interpText)) {
-      if (!seen.has(t)) { seen.add(t); out.push(t); }
-    }
-  }
-  return out;
+function getEMFInterpretationDeps() {
+  return {
+    collectActiveAssessmentState,
+    getAssessments: ensureAssessments
+  };
 }
 
 export function interpretEMFAssessment(assessmentId) {
-  collectActiveAssessmentState();
-  const assessments = ensureAssessments();
-  const a = assessments.find(x => x.id === assessmentId);
-  if (!a) return;
-
-  const fmtDate = new Date(a.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-  const title = `EMF Interpretation — ${fmtDate}${a.label ? ' (' + a.label + ')' : ''}`;
-  const data = serializeAssessment(a);
-  const tags = _collectMitigationTags(a);
-
-  openInterpretationModal(title, a.interpretation, (onSave) => {
-    const prompt = `Interpret this Baubiologie EMF assessment. Identify the most concerning readings, explain health implications (especially for sleeping areas), and recommend specific mitigations in priority order.\n\n${data}`;
-    streamInterpretation(prompt, (interp) => {
-      a.interpretation = interp;
-      saveImportedData();
-    });
-  }, null, tags);
+  interpretEMFAssessmentImpl(assessmentId, getEMFInterpretationDeps());
 }
 
 export function interpretEMFComparison() {
-  collectActiveAssessmentState();
-  const assessments = ensureAssessments();
-  const sorted = [...assessments].sort((a, b) => b.date.localeCompare(a.date));
-  if (sorted.length < 2) return;
-
-  const emf = state.importedData.emfAssessment;
-  const title = 'EMF Comparison — Before vs After';
-  const before = serializeAssessment(sorted[1]);
-  const after = serializeAssessment(sorted[0]);
-  const tags = [..._collectMitigationTags(sorted[0]), ..._collectMitigationTags(sorted[1])];
-  const dedup = [];
-  const seen = new Set();
-  for (const t of tags) { if (!seen.has(t)) { seen.add(t); dedup.push(t); } }
-
-  openInterpretationModal(title, emf.comparisonInterpretation, (onSave) => {
-    const prompt = `Compare these two Baubiologie EMF assessments (before and after). Evaluate what improved, what worsened, and what still needs attention. Prioritize remaining concerns and suggest next steps.\n\nBEFORE:\n${before}\nAFTER:\n${after}`;
-    streamInterpretation(prompt, (interp) => {
-      emf.comparisonInterpretation = interp;
-      saveImportedData();
-    });
-  }, null, dedup);
+  interpretEMFComparisonImpl(getEMFInterpretationDeps());
 }
 
 // ═══════════════════════════════════════════════

--- a/service-worker.js
+++ b/service-worker.js
@@ -118,6 +118,7 @@ const APP_SHELL = [
   '/js/onboarding-view.js',
   '/js/emf-facade.js',
   '/js/emf.js',
+  '/js/emf-interpretation.js',
   '/js/image-utils.js',
   '/js/pdf-import.js',
   '/js/pdf-import-spreadsheet.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -82,6 +82,7 @@ assert('SW APP_SHELL includes PDF import support modules',
 assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes("'/js/context-card-summaries.js'"));
 assert('SW APP_SHELL includes context card editor UI module', swAuditSrc.includes("'/js/context-card-editor-ui.js'"));
 assert('SW APP_SHELL includes context card medical history module', swAuditSrc.includes("'/js/context-card-medical-history-editor.js'"));
+assert('SW APP_SHELL includes EMF interpretation module', swAuditSrc.includes("'/js/emf-interpretation.js'"));
 assert('SW APP_SHELL includes lens action delegates module', swAuditSrc.includes("'/js/lens-actions.js'"));
 assert('SW APP_SHELL includes lens library handlers module', swAuditSrc.includes("'/js/lens-library.js'"));
 assert('SW APP_SHELL includes lens cache helper module', swAuditSrc.includes("'/js/lens-cache.js'"));

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
+const emfInterpretationSrc = fs.readFileSync(path.join(root, 'js/emf-interpretation.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -31,7 +32,13 @@ function section(start, end) {
 const editorSrc = section('let _editingAssessmentId = null;', '// ═══════════════════════════════════════════════\n// CRUD OPERATIONS');
 const importPreviewSrc = section('function showEMFImportPreview(parsed)', '// ═══════════════════════════════════════════════\n// BEFORE / AFTER COMPARISON');
 const compareSrc = section('function renderComparisonView(sorted)', '// ═══════════════════════════════════════════════\n// AI INTERPRETATION');
-const interpretationSrc = section('function _handleEMFInterpretationMouseDown', 'function _collectMitigationTags');
+function interpretationSection(start, end) {
+  const startIdx = emfInterpretationSrc.indexOf(start);
+  const endIdx = emfInterpretationSrc.indexOf(end, startIdx);
+  return startIdx >= 0 && endIdx > startIdx ? emfInterpretationSrc.slice(startIdx, endIdx) : '';
+}
+
+const interpretationSrc = interpretationSection('function _handleEMFInterpretationMouseDown', 'function _collectMitigationTags');
 const closePreviewSrc = section('function closeEMFPreviewModal()', 'function closeEMFEditorModal()');
 const migratedEditorSurface = `${editorSrc}\n${importPreviewSrc}\n${compareSrc}`;
 const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
@@ -80,7 +87,7 @@ assert('EMF editor delegates can be explicitly removed',
     emfSrc.includes("document.removeEventListener('change', _handleEMFEditorChange)") &&
     emfSrc.includes("document.removeEventListener('keydown', _handleEMFEditorKeydown)"));
 assert('EMF interpretation modal installs scoped action delegates',
-  emfSrc.includes('function emfInterpActionAttrs') &&
+  emfInterpretationSrc.includes('function emfInterpActionAttrs') &&
     interpretationSrc.includes('data-emf-interp-action') &&
     interpretationSrc.includes('installEMFInterpretationDelegates(overlay);') &&
     interpretationSrc.includes("overlay.addEventListener('mousedown', _handleEMFInterpretationMouseDown)") &&

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -18,6 +18,7 @@ const dashboardAiSrc = fs.readFileSync(path.join(root, 'js/context-card-dashboar
 const dashboardWidgetControlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
 const cycleSrc = fs.readFileSync(path.join(root, 'js/cycle.js'), 'utf8');
 const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
+const emfInterpretationSrc = fs.readFileSync(path.join(root, 'js/emf-interpretation.js'), 'utf8');
 const exportReportBuilderSrc = fs.readFileSync(path.join(root, 'js/export-report-builder.js'), 'utf8');
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lensLibrarySrc = fs.readFileSync(path.join(root, 'js/lens-library.js'), 'utf8');
@@ -249,17 +250,21 @@ assert('light environment assessment uses shared overlay lifecycle before remova
 
 assert('EMF editor, interpretation, and photo overlays use shared lifecycle helpers',
   emfSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
-    (emfSrc.match(/openModalOverlay\(overlay\)/g) || []).length >= 4 &&
-    (emfSrc.match(/removeModalOverlay\(overlay\)/g) || []).length >= 2 &&
-    emfSrc.includes('const wasConnected = overlay.isConnected;') &&
-    emfSrc.includes('if (!wasConnected) document.body.appendChild(overlay);') &&
-    emfSrc.includes("if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}") &&
-    emfSrc.includes("trapModalFocus(overlay, { closeOnEscape: false })") &&
+    emfInterpretationSrc.includes("import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';") &&
+    ((emfSrc.match(/openModalOverlay\(overlay\)/g) || []).length + (emfInterpretationSrc.match(/openModalOverlay\(overlay\)/g) || []).length) >= 4 &&
+    ((emfSrc.match(/removeModalOverlay\(overlay\)/g) || []).length + (emfInterpretationSrc.match(/removeModalOverlay\(overlay\)/g) || []).length) >= 2 &&
+    emfInterpretationSrc.includes('const wasConnected = overlay.isConnected;') &&
+    emfInterpretationSrc.includes('if (!wasConnected) document.body.appendChild(overlay);') &&
+    emfInterpretationSrc.includes("if (!wasConnected) try { trapModalFocus(overlay, { closeOnEscape: false }); } catch (_) {}") &&
+    emfInterpretationSrc.includes("trapModalFocus(overlay, { closeOnEscape: false })") &&
     emfSrc.includes('trapModalFocus(overlay)') &&
     emfSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el))") &&
     !emfSrc.includes("overlay.classList.add('show')") &&
+    !emfInterpretationSrc.includes("overlay.classList.add('show')") &&
     !emfSrc.includes("overlay.classList.remove('show')") &&
-    !emfSrc.includes('overlay.onclick = () => overlay.remove()'));
+    !emfInterpretationSrc.includes("overlay.classList.remove('show')") &&
+    !emfSrc.includes('overlay.onclick = () => overlay.remove()') &&
+    !emfInterpretationSrc.includes('overlay.onclick = () => overlay.remove()'));
 
 assert('light tool modals use shared overlay lifecycle helpers',
   modalLifecycleSrc.includes('export function openAppendedModalOverlay') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.9.9';
+self.APP_VERSION = '1.10.0';


### PR DESCRIPTION
## Summary
- Move EMF AI interpretation modal, streaming, discuss handoff, and mitigation recommendation logic into `js/emf-interpretation.js`.
- Keep `js/emf.js` as the public facade with wrapper exports for the existing window/API surface.
- Precache the new module and update static source guards for delegated interpretation controls and modal lifecycle coverage.
- Bump app version to `1.10.0`.

## Quality impact
- `js/emf.js`: 1394 -> 1091 lines.
- Largest JS file is now `js/settings.js` at 1338 lines.
- `npm run quality`: passed, largest file guard reports `1339/1513: js/settings.js`, all 353 JS/MJS files parse.

## Validation
- `npm run typecheck`
- `node tests/test-emf-delegated-actions.js` (36 passed)
- `node tests/test-modal-lifecycle-integrations.js` (31 passed)
- `node tests/test-audit.js` (301 passed)
- `node tests/test-emf.js` (216 passed)
- `node tests/test-emf-flow.js` (32 passed)
- `npm run quality`
- `npx playwright test tests/playwright/emf-edge-browser-coverage.spec.js tests/playwright/environment-coverage-batch.spec.js --project=chromium` (4 passed; initial sandbox run failed to bind 127.0.0.1:8000, rerun outside sandbox passed)
- `./run-tests.sh` (full suite passed; Playwright 332 passed)