### PR TITLE
[codex] Extract settings data helpers

### DIFF
--- a/js/settings-data.js
+++ b/js/settings-data.js
@@ -1,0 +1,131 @@
+// @ts-check
+// settings-data.js - Settings data-entry management and AI usage helpers.
+
+import { state } from './state.js';
+import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isDebugMode, setPIIReviewEnabled } from './utils.js';
+import { formatCost, getProfileUsage, getGlobalUsage, resetProfileUsage } from './schema.js';
+import { loadPdfImport } from './import-loader.js';
+
+export function renderDataEntriesSection() {
+  const rawEntries = state.importedData?.entries || [];
+  const entries = [];
+  for (const entry of rawEntries) {
+    if (Object.keys(entry?.markers || {}).length > 0) entries.push(entry);
+  }
+  if (entries.length === 0) {
+    return '<div style="color:var(--text-muted);font-size:13px;padding:8px 0">No data yet. Drop a PDF or JSON file on the dashboard, or add values manually.</div>';
+  }
+  const sorted = [...entries].sort((a, b) => a.date.localeCompare(b.date));
+  const manualValues = state.importedData.manualValues || {};
+  let html = '';
+  for (const entry of sorted) {
+    const d = new Date(entry.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const cnt = Object.keys(entry.markers).length;
+    const entryMarkerKeys = Object.keys(entry.markers);
+    const manualCount = entryMarkerKeys.filter(k => manualValues[k + ':' + entry.date]).length;
+    const isFullyManual = !entry.importedWith && manualCount === cnt;
+    const files = entry.sourceFiles || (entry.sourceFile ? [entry.sourceFile] : []);
+    const fileLabel = files.length > 0
+      ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px;border-bottom:1px dashed var(--text-muted);cursor:help" title="${escapeAttr(files.join('\n'))}">${files.length === 1 ? escapeHTML(files[0].length > 30 ? files[0].slice(0, 27) + '...' : files[0]) : files.length + ' files'}</span>`
+      : '';
+    const sourceLabel = isFullyManual
+      ? '<span style="color:var(--accent);margin-left:8px;font-size:11px">manual entry</span>'
+      : entry.importedWith?.modelId
+        ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${escapeHTML(entry.importedWith.modelId)}</span>`
+        : manualCount > 0
+          ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${manualCount} manual</span>`
+          : '';
+    const dateAttr = escapeAttr(entry.date);
+    html += `<div class="imported-entry">
+      <span class="ie-info"><span class="ie-date">${d}</span><span class="ie-count">${cnt} markers</span>${fileLabel}${sourceLabel}</span>
+      <div class="ie-actions">
+        <button class="ie-edit" data-settings-action="rename-imported-entry" data-entry-date="${dateAttr}" title="Edit collection date">Edit date</button>
+        <button class="ie-remove" data-settings-action="remove-imported-entry" data-entry-date="${dateAttr}">Remove</button>
+      </div>
+    </div>`;
+  }
+  html += `<div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
+    <button class="import-btn import-btn-primary" data-settings-action="share-profile">Share Profile</button>
+    <button class="import-btn import-btn-secondary" data-settings-action="export-client">Export Client</button>
+    <button class="import-btn import-btn-secondary" data-settings-action="export-all-clients" title="Full backup \u2014 all profiles, data, and chat history">Export All Clients</button>
+    <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" data-settings-action="clear-all-data">Clear All Data</button></div>`;
+  return html;
+}
+
+export function refreshDataEntriesSection() {
+  const el = document.getElementById('data-entries-section');
+  if (el) el.innerHTML = renderDataEntriesSection();
+}
+
+export async function removeImportedEntryFromSettings(date) {
+  try {
+    const { removeImportedEntry } = await loadPdfImport();
+    const ok = await removeImportedEntry(date);
+    if (ok) refreshDataEntriesSection();
+  } catch (err) {
+    if (isDebugMode()) console.error('Remove imported entry failed:', err);
+    showNotification('Could not remove imported data. Reload and try again.', 'error');
+  }
+}
+
+export async function renameImportedEntryDateFromSettings(date) {
+  try {
+    const { renameImportedEntryDate } = await loadPdfImport();
+    const ok = await renameImportedEntryDate(date);
+    if (ok) refreshDataEntriesSection();
+  } catch (err) {
+    if (isDebugMode()) console.error('Rename imported entry failed:', err);
+    showNotification('Could not edit the import date. Reload and try again.', 'error');
+  }
+}
+
+function formatTokens(n) {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+  return String(n);
+}
+
+export function renderAIUsageSection() {
+  const pu = getProfileUsage(state.currentProfile);
+  const gu = getGlobalUsage();
+  const profileName = state.profiles?.[state.currentProfile]?.name || 'Current profile';
+  const separator = ' \u00b7 ';
+  let html = '<div style="font-size:13px;color:var(--text-secondary);line-height:2">';
+  html += `<div><strong>${escapeHTML(profileName)}</strong>: ${formatCost(pu.totalCost)}${separator}${pu.requestCount} request${pu.requestCount !== 1 ? 's' : ''}${separator}${formatTokens(pu.totalInputTokens + pu.totalOutputTokens)} tokens</div>`;
+  html += `<div><strong>All profiles</strong>: ${formatCost(gu.totalCost)}${separator}${gu.requestCount} request${gu.requestCount !== 1 ? 's' : ''}${separator}${formatTokens(gu.totalInputTokens + gu.totalOutputTokens)} tokens</div>`;
+  html += '</div>';
+  if (pu.requestCount > 0) {
+    html += `<button class="import-btn import-btn-secondary" style="margin-top:8px;font-size:11px" data-settings-action="reset-profile-usage">Reset profile usage</button>`;
+  }
+  return html;
+}
+
+export function resetCurrentProfileUsage() {
+  resetProfileUsage(state.currentProfile);
+  const el = document.getElementById('ai-usage-section');
+  if (el) el.innerHTML = renderAIUsageSection();
+}
+
+// Disable confirmation for the PII review toggle. On->off shows a one-time
+// warning so users do not silently lose visibility into what is leaving their
+// device. Re-enabling and the initial setup are silent.
+export async function confirmDisablePIIReview(checkbox) {
+  if (checkbox.checked) {
+    setPIIReviewEnabled(true);
+    return;
+  }
+  const acknowledged = localStorage.getItem('labcharts-pii-review-disable-ack') === '1';
+  if (acknowledged) {
+    setPIIReviewEnabled(false);
+    return;
+  }
+  // Restore the toggle while the dialog is open; commit only on confirm.
+  checkbox.checked = true;
+  if (await showConfirmDialog(
+    "Turn off the obfuscation review?\n\nWith this off, getbased's PII detector runs but you won't see the result before it's sent to the AI provider. Recommended only after you've verified the obfuscation works on your data."
+  )) {
+    localStorage.setItem('labcharts-pii-review-disable-ack', '1');
+    setPIIReviewEnabled(false);
+    checkbox.checked = false;
+  }
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -2,25 +2,41 @@
 // settings.js — Settings modal (profile, display, AI provider, privacy)
 
 import { state } from './state.js';
-import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isDebugMode, setDebugMode, isPIIReviewEnabled, setPIIReviewEnabled, isAnalyticsEnabled, setAnalyticsEnabled } from './utils.js';
+import { escapeHTML, escapeAttr, isDebugMode, setDebugMode, isPIIReviewEnabled, isAnalyticsEnabled, setAnalyticsEnabled } from './utils.js';
 import { getTheme, setTheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, getTimeFormat, setTimeFormat, THEMES } from './theme.js';
 import { switchUnitSystem, toggleAltUnits, switchRangeMode } from './data.js';
-import { formatCost, getProfileUsage, getGlobalUsage, resetProfileUsage } from './schema.js';
 import { getAIProvider, isAIPaused, getOllamaPIIUrl, getOllamaPIIModel, setOllamaPIIModel } from './api.js';
 import { isOllamaPIIEnabled, setOllamaPIIEnabled, getOllamaConfig, checkOpenAICompatible } from './pii.js';
 import { renderEncryptionSection, renderBackupSection, loadBackupSnapshots } from './crypto.js';
 import { renderSyncSection, renderMessengerSection, hydrateSettingsSyncPanel } from './settings-sync-panel.js';
 import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
-import { loadPdfImport } from './import-loader.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
 import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { installSettingsProviderBridge, switchAIProviderBridge } from './settings-provider-bridge.js';
+import {
+  confirmDisablePIIReview,
+  refreshDataEntriesSection,
+  removeImportedEntryFromSettings,
+  renameImportedEntryDateFromSettings,
+  renderAIUsageSection,
+  renderDataEntriesSection,
+  resetCurrentProfileUsage,
+} from './settings-data.js';
 
 /** @typedef {Window & typeof globalThis & Record<string, any>} SettingsWindow */
 
 const settingsWindow = /** @type {SettingsWindow} */ (window);
 
 installSettingsProviderBridge();
+
+export {
+  confirmDisablePIIReview,
+  refreshDataEntriesSection,
+  removeImportedEntryFromSettings,
+  renameImportedEntryDateFromSettings,
+  renderDataEntriesSection,
+  resetCurrentProfileUsage,
+};
 
 // ═══════════════════════════════════════════════
 // SETTINGS MODAL
@@ -1183,130 +1199,6 @@ export function closeSettingsModal() {
   closeModalOverlay('settings-modal-overlay');
   if (settingsWindow.updateChatNudge) settingsWindow.updateChatNudge();
   settingsWindow.refreshMobileDashboardActiveTab?.();
-}
-
-export function renderDataEntriesSection() {
-  const rawEntries = state.importedData?.entries || [];
-  const entries = [];
-  for (const entry of rawEntries) {
-    if (Object.keys(entry?.markers || {}).length > 0) entries.push(entry);
-  }
-  if (entries.length === 0) {
-    return '<div style="color:var(--text-muted);font-size:13px;padding:8px 0">No data yet. Drop a PDF or JSON file on the dashboard, or add values manually.</div>';
-  }
-  const sorted = [...entries].sort((a, b) => a.date.localeCompare(b.date));
-  const manualValues = state.importedData.manualValues || {};
-  let html = '';
-  for (const entry of sorted) {
-    const d = new Date(entry.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    const cnt = Object.keys(entry.markers).length;
-    const entryMarkerKeys = Object.keys(entry.markers);
-    const manualCount = entryMarkerKeys.filter(k => manualValues[k + ':' + entry.date]).length;
-    const isFullyManual = !entry.importedWith && manualCount === cnt;
-    const files = entry.sourceFiles || (entry.sourceFile ? [entry.sourceFile] : []);
-    const fileLabel = files.length > 0
-      ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px;border-bottom:1px dashed var(--text-muted);cursor:help" title="${escapeAttr(files.join('\n'))}">${files.length === 1 ? escapeHTML(files[0].length > 30 ? files[0].slice(0, 27) + '...' : files[0]) : files.length + ' files'}</span>`
-      : '';
-    const sourceLabel = isFullyManual
-      ? '<span style="color:var(--accent);margin-left:8px;font-size:11px">manual entry</span>'
-      : entry.importedWith?.modelId
-        ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${escapeHTML(entry.importedWith.modelId)}</span>`
-        : manualCount > 0
-          ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${manualCount} manual</span>`
-          : '';
-    const dateAttr = escapeAttr(entry.date);
-    html += `<div class="imported-entry">
-      <span class="ie-info"><span class="ie-date">${d}</span><span class="ie-count">${cnt} markers</span>${fileLabel}${sourceLabel}</span>
-      <div class="ie-actions">
-        <button class="ie-edit" data-settings-action="rename-imported-entry" data-entry-date="${dateAttr}" title="Edit collection date">Edit date</button>
-        <button class="ie-remove" data-settings-action="remove-imported-entry" data-entry-date="${dateAttr}">Remove</button>
-      </div>
-    </div>`;
-  }
-  html += `<div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
-    <button class="import-btn import-btn-primary" data-settings-action="share-profile">Share Profile</button>
-    <button class="import-btn import-btn-secondary" data-settings-action="export-client">Export Client</button>
-    <button class="import-btn import-btn-secondary" data-settings-action="export-all-clients" title="Full backup — all profiles, data, and chat history">Export All Clients</button>
-    <button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red)" data-settings-action="clear-all-data">Clear All Data</button></div>`;
-  return html;
-}
-
-export function refreshDataEntriesSection() {
-  const el = document.getElementById('data-entries-section');
-  if (el) el.innerHTML = renderDataEntriesSection();
-}
-
-export async function removeImportedEntryFromSettings(date) {
-  try {
-    const { removeImportedEntry } = await loadPdfImport();
-    const ok = await removeImportedEntry(date);
-    if (ok) refreshDataEntriesSection();
-  } catch (err) {
-    if (isDebugMode()) console.error('Remove imported entry failed:', err);
-    showNotification('Could not remove imported data. Reload and try again.', 'error');
-  }
-}
-
-export async function renameImportedEntryDateFromSettings(date) {
-  try {
-    const { renameImportedEntryDate } = await loadPdfImport();
-    const ok = await renameImportedEntryDate(date);
-    if (ok) refreshDataEntriesSection();
-  } catch (err) {
-    if (isDebugMode()) console.error('Rename imported entry failed:', err);
-    showNotification('Could not edit the import date. Reload and try again.', 'error');
-  }
-}
-
-function formatTokens(n) {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
-  return String(n);
-}
-
-function renderAIUsageSection() {
-  const pu = getProfileUsage(state.currentProfile);
-  const gu = getGlobalUsage();
-  const profileName = state.profiles?.[state.currentProfile]?.name || 'Current profile';
-  let html = '<div style="font-size:13px;color:var(--text-secondary);line-height:2">';
-  html += `<div><strong>${escapeHTML(profileName)}</strong>: ${formatCost(pu.totalCost)} · ${pu.requestCount} request${pu.requestCount !== 1 ? 's' : ''} · ${formatTokens(pu.totalInputTokens + pu.totalOutputTokens)} tokens</div>`;
-  html += `<div><strong>All profiles</strong>: ${formatCost(gu.totalCost)} · ${gu.requestCount} request${gu.requestCount !== 1 ? 's' : ''} · ${formatTokens(gu.totalInputTokens + gu.totalOutputTokens)} tokens</div>`;
-  html += '</div>';
-  if (pu.requestCount > 0) {
-    html += `<button class="import-btn import-btn-secondary" style="margin-top:8px;font-size:11px" data-settings-action="reset-profile-usage">Reset profile usage</button>`;
-  }
-  return html;
-}
-
-function resetCurrentProfileUsage() {
-  resetProfileUsage(state.currentProfile);
-  const el = document.getElementById('ai-usage-section');
-  if (el) el.innerHTML = renderAIUsageSection();
-}
-
-// Disable confirmation for the PII review toggle. On→off shows a one-time
-// warning so users don't silently lose visibility into what's leaving their
-// device. On→on (re-enabling) and the initial setup are silent.
-export async function confirmDisablePIIReview(checkbox) {
-  if (checkbox.checked) {
-    setPIIReviewEnabled(true);
-    return;
-  }
-  // Going from on → off: warn unless they've explicitly dismissed before
-  const acknowledged = localStorage.getItem('labcharts-pii-review-disable-ack') === '1';
-  if (acknowledged) {
-    setPIIReviewEnabled(false);
-    return;
-  }
-  // Restore the toggle while the dialog is open; commit only on confirm
-  checkbox.checked = true;
-  if (await showConfirmDialog(
-    "Turn off the obfuscation review?\n\nWith this off, getbased's PII detector runs but you won't see the result before it's sent to the AI provider. Recommended only after you've verified the obfuscation works on your data."
-  )) {
-    localStorage.setItem('labcharts-pii-review-disable-ack', '1');
-    setPIIReviewEnabled(false);
-    checkbox.checked = false;
-  }
 }
 
 Object.assign(window, {

--- a/service-worker.js
+++ b/service-worker.js
@@ -163,6 +163,7 @@ const APP_SHELL = [
   '/js/chat-prompt-context.js',
   '/js/chat-summaries.js',
   '/js/settings.js',
+  '/js/settings-data.js',
   '/js/settings-provider-bridge.js',
   '/js/settings-sync-panel.js',
   '/js/feedback.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -69,6 +69,7 @@ assert('SW APP_SHELL includes provider model controls module', swAuditSrc.includ
 assert('SW APP_SHELL includes provider local AI controls module', swAuditSrc.includes("'/js/provider-local-ai-controls.js'"));
 assert('SW APP_SHELL includes provider PPQ panels module', swAuditSrc.includes("'/js/provider-ppq-panels.js'"));
 assert('SW APP_SHELL includes API transport module', swAuditSrc.includes("'/js/api-transport.js'"));
+assert('SW APP_SHELL includes settings data module', swAuditSrc.includes("'/js/settings-data.js'"));
 assert('SW APP_SHELL includes settings provider bridge module', swAuditSrc.includes("'/js/settings-provider-bridge.js'"));
 assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/js/pdf-import-review.js'"));
 assert('SW APP_SHELL includes modal lifecycle module', swAuditSrc.includes("'/js/modal-lifecycle.js'"));

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -256,9 +256,9 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   const importSrc = read('/js/pdf-import.js');
   assert('confirmImport stores sourceFile', importSrc.includes('entry.sourceFile = result.fileName'));
 
-  const settingsSrc = read('/js/settings.js');
-  assert('Settings shows sourceFile', settingsSrc.includes('entry.sourceFile'));
-  assert('Settings imports escapeAttr', settingsSrc.includes('escapeAttr'));
+  const settingsDataSrc = read('/js/settings-data.js');
+  assert('Settings Data shows sourceFile', settingsDataSrc.includes('entry.sourceFile'));
+  assert('Settings Data imports escapeAttr', settingsDataSrc.includes('escapeAttr'));
 
   // ═══════════════════════════════════════
   // 13. Both-range mode on cards

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -22,6 +22,7 @@ const mod = await import('../js/profile-share.js');
 const profileShareSrc = read('js/profile-share.js');
 const exportSrc = read('js/export.js');
 const settingsSrc = read('js/settings.js');
+const settingsDataSrc = read('js/settings-data.js');
 const appDataIoSrc = read('js/app-data-io-modules.js');
 const apiShareSrc = read('api/share.js');
 const devServerSrc = read('dev-server.js');
@@ -93,7 +94,7 @@ assert('profile-share module imports reusable export builder',
 assert('Profile share module is startup-loaded',
   appDataIoSrc.includes("import './profile-share.js';"));
 assert('Settings Data tab exposes Share Profile action',
-  settingsSrc.includes("data-settings-action=\"share-profile\"") &&
+  settingsDataSrc.includes("data-settings-action=\"share-profile\"") &&
   settingsSrc.includes('settingsWindow.openProfileShareModal?.()'));
 assert('Share modal has dedicated shared-modal styling',
   modalCss.includes('#profile-share-overlay.modal-overlay') &&

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const src = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
+const settingsDataSrc = fs.readFileSync(path.join(root, 'js/settings-data.js'), 'utf8');
+const settingsSurfaceSrc = `${src}\n${settingsDataSrc}`;
 
 let passed = 0;
 let failed = 0;
@@ -94,7 +96,7 @@ assert('Tweaks panel uses shared overlay lifecycle helpers',
   'clear-all-data',
   'reset-profile-usage',
 ].forEach(action => {
-  assert(`Settings action ${action} is rendered`, src.includes(`data-settings-action="${action}"`));
+  assert(`Settings action ${action} is rendered`, settingsSurfaceSrc.includes(`data-settings-action="${action}"`));
 });
 
 [

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -25,7 +25,7 @@ const exportSrc = read('js/export.js');
 const mappingSrc = read('js/pdf-import-marker-mapping.js');
 const normalizationSrc = read('js/pdf-import-marker-normalization.js');
 const persistenceSrc = read('js/pdf-import-persistence.js');
-const settingsSrc = read('js/settings.js');
+const settingsDataSrc = read('js/settings-data.js');
   // ═══════════════════════════════════════
   // 1. normalizeToSI function exists
   // ═══════════════════════════════════════
@@ -88,9 +88,9 @@ const settingsSrc = read('js/settings.js');
       && /Date\.UTC\(year,\s*month - 1,\s*day\)/.test(persistenceSrc)
       && /getUTCFullYear\(\)\s*===\s*year[\s\S]{0,120}getUTCMonth\(\)\s*===\s*month - 1[\s\S]{0,120}getUTCDate\(\)\s*===\s*day/.test(persistenceSrc));
   assert('Settings Data remove refreshes only after successful delete',
-    /removeImportedEntryFromSettings[\s\S]{0,240}const ok = await removeImportedEntry\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsSrc));
+    /removeImportedEntryFromSettings[\s\S]{0,240}const ok = await removeImportedEntry\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsDataSrc));
   assert('Settings Data rename refreshes only after successful save',
-    /renameImportedEntryDateFromSettings[\s\S]{0,260}const ok = await renameImportedEntryDate\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsSrc));
+    /renameImportedEntryDateFromSettings[\s\S]{0,260}const ok = await renameImportedEntryDate\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsDataSrc));
 
   // ═══════════════════════════════════════
   // 4. normalizeToSI handles multiply type (inverse)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.0';
+self.APP_VERSION = '1.10.1';


### PR DESCRIPTION
## Summary
- Move Settings Data imported-entry rendering, remove/rename wrappers, AI usage rendering/reset, and the PII review disable confirmation into `js/settings-data.js`.
- Re-export existing public helper names from `settings.js` so window/delegate wiring remains compatible.
- Precache the new module, update source-inspection guards for the new boundary, and bump the app version to `1.10.1`.

## Quality impact
- `js/settings.js`: 1338 -> 1230 lines.
- New helper: `js/settings-data.js` at 131 lines.
- Largest module is now `js/api.js` at 1324 lines; next HVTs are `js/light-env.js`, `js/recommendations.js`, and `js/pdf-import.js`.
- `npm run quality` remained green before the final test-only guard updates: largest `1325/1513: js/api.js`, all JS/MJS parsed (`354 files`).

## Validation
- `npm run typecheck`
- `node tests/test-unit-import.js` (88 passed)
- `node tests/test-audit.js` (302 passed)
- `node tests/test-integration-batch2.js` (80 passed)
- `node tests/test-settings-delegated-actions.js` (57 passed)
- `node tests/test-profile-share.js` (35 passed)
- `npm run quality`
- `npx playwright test tests/playwright/core-browser-flows.spec.js tests/playwright/settings-browser-coverage.spec.js tests/playwright/settings-provider-browser-coverage.spec.js --project=chromium` (6 passed)
- `./run-tests.sh` (Vitest 191 passed, dev-server origin guards 18 passed, Playwright 332 passed)