### PR TITLE
[codex] Extract API model helpers

### DIFF
--- a/js/api-models.js
+++ b/js/api-models.js
@@ -1,0 +1,296 @@
+// @ts-check
+// api-models.js - Provider model catalogs, pricing, and capability helpers.
+
+import { getModelPricing } from './schema.js';
+import {
+  getAIProvider,
+  getOllamaMainModel,
+  getVeniceKey,
+  getVeniceModel,
+  getVeniceModelDisplay,
+  modelSupportsVeniceE2EE,
+  syncVeniceModelSelection,
+  isVeniceE2EEActive,
+  getOpenRouterKey,
+  getOpenRouterModel,
+  getOpenRouterModelDisplay,
+  getOpenRouterPricing,
+  setOpenRouterModel,
+  getRoutstrModel,
+  getRoutstrModelDisplay,
+  getPpqModel,
+  getPpqModelDisplay,
+  getCustomApiModel,
+  getCustomApiModelDisplay,
+} from './api-provider-storage.js';
+
+export function deduplicateModels(models, familyFn) {
+  const seen = {};
+  return models.filter(function(m) {
+    const fam = familyFn(m.id);
+    if (seen[fam]) return false;
+    seen[fam] = true;
+    return true;
+  });
+}
+
+// Curated: latest-gen medically capable models only (prefixes matched against IDs)
+const OPENROUTER_CURATED = [
+  'anthropic/claude-sonnet-4', 'anthropic/claude-opus-4',
+  'openai/gpt-5',
+  'google/gemini-3', 'google/gemini-2',
+  'deepseek/deepseek',
+  'qwen/qwen', 'qwen/qwq',
+  'x-ai/grok',
+];
+
+// Recommended models for medical analysis.
+// Update when a new generation launches. Each provider uses different ID formats:
+// OpenRouter: "provider/model-version" (dots: 4.6)
+// Anthropic: "claude-model-version" (hyphens: 4-6, with date suffix)
+// Venice: "model-version" (hyphens: 4-6, no provider prefix)
+const OPENROUTER_RECOMMENDED = [
+  'anthropic/claude-sonnet-4.6', 'anthropic/claude-opus-4.7',
+  'openai/gpt-5.5', 'openai/gpt-5.4',
+  'google/gemini-3.1-pro',
+  'x-ai/grok-4',
+];
+
+// Routstr uses bare model IDs (no provider prefix, dots: claude-sonnet-4.6)
+const ROUTSTR_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.1-pro', 'grok-4'];
+
+// PPQ uses bare model IDs (same as Routstr).
+// private/ models are listed in API but require EHBP protocol, not standard completions.
+const PPQ_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3-flash-preview', 'grok-4'];
+
+export function isRecommendedModel(provider, modelId) {
+  if (provider === 'openrouter') return OPENROUTER_RECOMMENDED.some(function(prefix) { return modelId.startsWith(prefix); });
+  if (provider === 'venice') {
+    if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5/.test(modelId);
+    // claude-(sonnet-4-6|opus-4-7) is intentionally narrow. When newer
+    // versions land, broaden the alternation rather than matching all 4.x.
+    return /^(claude-(sonnet-4-6|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3(-1)?-pro|grok-4[1-9]?)(-|$)/.test(modelId);
+  }
+  if (provider === 'routstr') return ROUTSTR_RECOMMENDED.some(function(r) { return modelId === r || modelId.startsWith(r); });
+  if (provider === 'ppq') return PPQ_RECOMMENDED.some(function(r) { return modelId === r || modelId.startsWith(r); });
+  return false;
+}
+
+export function getActiveModelId(provider = getAIProvider()) {
+  if (provider === 'venice') return getVeniceModel();
+  if (provider === 'openrouter') return getOpenRouterModel();
+  if (provider === 'routstr') return getRoutstrModel();
+  if (provider === 'ppq') return getPpqModel();
+  if (provider === 'custom') return getCustomApiModel();
+  return getOllamaMainModel();
+}
+
+export function getActiveModelDisplay(provider = getAIProvider()) {
+  if (provider === 'venice') return getVeniceModelDisplay();
+  if (provider === 'openrouter') return getOpenRouterModelDisplay();
+  if (provider === 'routstr') return getRoutstrModelDisplay();
+  if (provider === 'ppq') return getPpqModelDisplay();
+  if (provider === 'custom') return getCustomApiModelDisplay();
+  return getOllamaMainModel();
+}
+
+// Exclude specialized variants not suited for medical analysis.
+const OPENROUTER_EXCLUDE = ['codex', 'audio', 'image', 'oss', 'safeguard', 'coder'];
+
+export async function fetchOpenRouterModels(key) {
+  try {
+    const res = await fetch('https://openrouter.ai/api/v1/models', {
+      headers: { 'Authorization': 'Bearer ' + (key || getOpenRouterKey()) }
+    });
+    if (!res.ok) return [];
+    const json = await res.json();
+    const all = (json.data || []).filter(function(m) {
+      if (!m.id) return false;
+      if (OPENROUTER_EXCLUDE.some(function(ex) { return m.id.includes(ex); })) return false;
+      return OPENROUTER_CURATED.some(function(prefix) { return m.id.startsWith(prefix); });
+    }).sort(function(a, b) { return (a.name || a.id).localeCompare(b.name || b.id); });
+    const models = deduplicateModels(all, function(id) {
+      return id.replace(/:\d{4}-\d{2}-\d{2}$/, '').replace(/-\d{8}$/, '');
+    });
+    models.sort(function(a, b) {
+      const aRec = OPENROUTER_RECOMMENDED.some(function(p) { return a.id.startsWith(p); });
+      const bRec = OPENROUTER_RECOMMENDED.some(function(p) { return b.id.startsWith(p); });
+      if (aRec !== bRec) return aRec ? -1 : 1;
+      return (a.name || a.id).localeCompare(b.name || b.id);
+    });
+    const pricingCache = {};
+    for (const m of models) {
+      if (m.pricing && m.pricing.prompt && m.pricing.completion) {
+        pricingCache[m.id] = {
+          input: parseFloat(m.pricing.prompt) * 1_000_000,
+          output: parseFloat(m.pricing.completion) * 1_000_000
+        };
+      }
+    }
+    localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify(pricingCache));
+    const visionIds = (json.data || []).filter(function(m) {
+      if (!m.id || !m.architecture) return false;
+      const modality = m.architecture.modality || '';
+      return modality.includes('image');
+    }).map(function(m) { return m.id; });
+    localStorage.setItem('labcharts-openrouter-vision-models', JSON.stringify(visionIds));
+    localStorage.setItem('labcharts-openrouter-models', JSON.stringify(models));
+    if (!localStorage.getItem('labcharts-openrouter-model') && models.length) {
+      const claude = models.find(function(m) { return m.id === 'anthropic/claude-sonnet-4.6'; });
+      if (claude) setOpenRouterModel(claude.id);
+    }
+    return models;
+  } catch (e) { return []; }
+}
+
+export async function fetchOpenRouterModelPricing(modelId) {
+  if (!modelId) return null;
+  const existing = getOpenRouterPricing(modelId);
+  if (existing) return existing;
+  try {
+    const res = await fetch('https://openrouter.ai/api/v1/models', {
+      headers: { 'Authorization': 'Bearer ' + getOpenRouterKey() }
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const norm = s => s.replace(/\./g, '-').replace(/-\d{8}$/, '');
+    const model = (json.data || []).find(m => m.id === modelId)
+      || (json.data || []).find(m => norm(m.id) === norm(modelId));
+    if (!model?.pricing) return null;
+    const pricing = {
+      input: parseFloat(model.pricing.prompt || '0') * 1_000_000,
+      output: parseFloat(model.pricing.completion || '0') * 1_000_000
+    };
+    const cached = JSON.parse(localStorage.getItem('labcharts-openrouter-pricing') || '{}');
+    cached[model.id] = pricing;
+    cached[modelId] = pricing;
+    localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify(cached));
+    return pricing;
+  } catch (e) {}
+  return null;
+}
+
+export async function validateOpenRouterKey(key) {
+  try {
+    const res = await fetch('https://openrouter.ai/api/v1/models', {
+      headers: { 'Authorization': 'Bearer ' + key }
+    });
+    if (res.ok) return { valid: true };
+    if (res.status === 401) return { valid: false, error: 'Invalid API key' };
+    if (res.status === 429) return { valid: true };
+    const errBody = await res.json().catch(() => null);
+    const errMsg = errBody?.error?.message || `status ${res.status}`;
+    return { valid: false, error: `API error: ${errMsg}` };
+  } catch (e) {
+    return { valid: false, error: 'Cannot reach OpenRouter API: ' + e.message };
+  }
+}
+
+export function renderModelPricingHint(provider, modelId) {
+  if (provider === 'ollama') return '<span style="font-size:11px;color:var(--green)">Free (local)</span>';
+  if (provider === 'custom') return '';
+  const p = getModelPricing(provider, modelId);
+  if (p.input === 0 && p.output === 0) return '<span style="font-size:11px;color:var(--green)">Free</span>';
+  const pre = p.approx ? '~' : '';
+  return `<span style="font-size:11px;color:var(--text-muted)">${pre}$${p.input.toFixed(2)}/M in \u00b7 ${pre}$${p.output.toFixed(2)}/M out</span>`;
+}
+
+export async function fetchVeniceModels(key) {
+  try {
+    const res = await fetch('https://api.venice.ai/api/v1/models', {
+      headers: { 'Authorization': 'Bearer ' + (key || getVeniceKey()) }
+    });
+    if (!res.ok) return [];
+    const json = await res.json();
+    const allText = (json.data || []).filter(function(m) { return m.id && m.type === 'text'; }).sort(function(a, b) { return b.id.localeCompare(a.id); });
+    const e2eeList = allText.filter(modelSupportsVeniceE2EE);
+    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify(e2eeList));
+    const e2eeIds = new Set(e2eeList.map(function(m) { return m.id; }));
+    const all = allText.filter(function(m) { return !e2eeIds.has(m.id) && !m.id.startsWith('e2ee-'); });
+    const models = deduplicateModels(all, function(id) {
+      if (id.startsWith('claude-')) return id;
+      return id.replace(/-\d{8}$/, '').replace(/-\d+[bB]$/, '');
+    });
+    models.sort(function(a, b) { return (a.name || a.id).localeCompare(b.name || b.id); });
+    const pricingCache = {};
+    for (const m of allText) {
+      const p = m.model_spec && m.model_spec.pricing;
+      if (p && p.input && p.output) {
+        pricingCache[m.id] = { input: parseFloat(p.input.usd || 0), output: parseFloat(p.output.usd || 0) };
+      }
+    }
+    localStorage.setItem('labcharts-venice-pricing', JSON.stringify(pricingCache));
+    const visionIds = allText.filter(m => m.model_spec?.capabilities?.supportsVision).map(m => m.id);
+    localStorage.setItem('labcharts-venice-vision-models', JSON.stringify(visionIds));
+    localStorage.setItem('labcharts-venice-models', JSON.stringify(models));
+    localStorage.setItem('labcharts-venice-models-fetched-at', String(Date.now()));
+    syncVeniceModelSelection(models, e2eeList);
+    return models;
+  } catch (e) { return []; }
+}
+
+export async function validateVeniceKey(key) {
+  try {
+    const res = await fetch('https://api.venice.ai/api/v1/models', {
+      headers: { 'Authorization': 'Bearer ' + key }
+    });
+    if (res.ok) return { valid: true };
+    if (res.status === 401) return { valid: false, error: 'Invalid API key' };
+    if (res.status === 429) return { valid: true };
+    const errBody = await res.json().catch(() => null);
+    const errMsg = errBody?.error?.message || `status ${res.status}`;
+    return { valid: false, error: `API error: ${errMsg}` };
+  } catch (e) {
+    return { valid: false, error: 'Cannot reach Venice API: ' + e.message };
+  }
+}
+
+export function supportsWebSearch(provider = getAIProvider()) {
+  if (provider === 'venice') return !isVeniceE2EEActive();
+  if (provider === 'routstr') return false;
+  if (provider === 'ppq') return true;
+  if (provider === 'custom') return false;
+  return provider === 'openrouter';
+}
+
+export function supportsVision() {
+  const provider = getAIProvider();
+  if (provider === 'openrouter') {
+    const modelId = getOpenRouterModel();
+    try {
+      const visionIds = JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models') || '[]');
+      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/:\d{4}-\d{2}-\d{2}$/, '')); });
+    } catch { return false; }
+  }
+  if (provider === 'venice') {
+    if (isVeniceE2EEActive()) return false;
+    const modelId = getVeniceModel();
+    try {
+      const visionIds = JSON.parse(localStorage.getItem('labcharts-venice-vision-models') || '[]');
+      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/-\d{8}$/, '')); });
+    } catch { return false; }
+  }
+  if (provider === 'routstr') {
+    const modelId = getRoutstrModel();
+    try {
+      const visionIds = JSON.parse(localStorage.getItem('labcharts-routstr-vision-models') || '[]');
+      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/-\d{8}$/, '')); });
+    } catch { return false; }
+  }
+  if (provider === 'ppq') {
+    const modelId = getPpqModel();
+    try {
+      const visionIds = JSON.parse(localStorage.getItem('labcharts-ppq-vision-models') || '[]');
+      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/-\d{8}$/, '')); });
+    } catch { return false; }
+  }
+  if (provider === 'custom') return true;
+  return true;
+}
+
+export function needsMaxCompletionTokens(modelId) {
+  if (!modelId) return false;
+  const id = String(modelId).toLowerCase();
+  const bare = id.includes('/') ? id.split('/').pop() : id;
+  return /^(gpt-5|o[1-9])([-.]|$)/.test(bare);
+}

--- a/js/api.js
+++ b/js/api.js
@@ -1,7 +1,6 @@
 // @ts-check
-// api.js — AI provider management, API calls (OpenRouter, Venice, Routstr, PPQ, Local, Custom)
+// api.js - AI provider management, API calls (OpenRouter, Venice, Routstr, PPQ, Local, Custom)
 
-import { getModelPricing } from './schema.js';
 import { isDebugMode } from './utils.js';
 import {
   FETCH_REQUEST_TIMEOUT_MS,
@@ -28,7 +27,6 @@ import {
   getVeniceModelDisplay,
   getVeniceE2EE,
   setVeniceE2EE,
-  modelSupportsVeniceE2EE,
   readStoredArray,
   syncVeniceModelSelection,
   veniceModelsCacheStale,
@@ -64,6 +62,21 @@ import {
   setCustomApiModel,
   getCustomApiModelDisplay,
 } from './api-provider-storage.js';
+import {
+  deduplicateModels,
+  fetchOpenRouterModelPricing,
+  fetchOpenRouterModels,
+  fetchVeniceModels,
+  getActiveModelDisplay,
+  getActiveModelId,
+  isRecommendedModel,
+  needsMaxCompletionTokens,
+  renderModelPricingHint,
+  supportsVision,
+  supportsWebSearch,
+  validateOpenRouterKey,
+  validateVeniceKey,
+} from './api-models.js';
 
 /** @typedef {Window & typeof globalThis & {
  *   _veniceE2EE?: any,
@@ -79,6 +92,21 @@ export {
   FETCH_REQUEST_TIMEOUT_MS,
   STREAM_STALL_TIMEOUT_MS,
 } from './api-transport.js';
+export {
+  deduplicateModels,
+  fetchOpenRouterModelPricing,
+  fetchOpenRouterModels,
+  fetchVeniceModels,
+  getActiveModelDisplay,
+  getActiveModelId,
+  isRecommendedModel,
+  needsMaxCompletionTokens,
+  renderModelPricingHint,
+  supportsVision,
+  supportsWebSearch,
+  validateOpenRouterKey,
+  validateVeniceKey,
+} from './api-models.js';
 export {
   getAIProvider,
   setAIProvider,
@@ -140,16 +168,6 @@ function isTokenLimitFinish(reason) {
     || r === 'max_completion_tokens'
     || r.includes('token_limit')
     || r.includes('max token');
-}
-
-export function deduplicateModels(models, familyFn) {
-  const seen = {};
-  return models.filter(function(m) {
-    const fam = familyFn(m.id);
-    if (seen[fam]) return false;
-    seen[fam] = true;
-    return true;
-  });
 }
 
 const OPENROUTER_OAUTH_PREVIOUS_PROVIDER_KEY = 'or_previous_ai_provider';
@@ -283,213 +301,11 @@ export async function exchangeOpenRouterCode(code, returnedState) {
   sessionStorage.removeItem('or_oauth_state');
   return data.key;
 }
-// Curated: latest-gen medically capable models only (prefixes matched against IDs)
-const OPENROUTER_CURATED = [
-  'anthropic/claude-sonnet-4', 'anthropic/claude-opus-4',
-  'openai/gpt-5',
-  'google/gemini-3', 'google/gemini-2',
-  'deepseek/deepseek',
-  'qwen/qwen', 'qwen/qwq',
-  'x-ai/grok',
-];
-// ─── Recommended models for medical analysis ───
-// Update when a new generation launches. Each provider uses different ID formats:
-//   OpenRouter: "provider/model-version"  (dots: 4.6)
-//   Anthropic:  "claude-model-version"    (hyphens: 4-6, with date suffix)
-//   Venice:     "model-version"           (hyphens: 4-6, no provider prefix)
-// To check current IDs, run in console:
-//   JSON.parse(localStorage.getItem('labcharts-openrouter-models')||'[]').map(m=>m.id)
-const OPENROUTER_RECOMMENDED = [
-  'anthropic/claude-sonnet-4.6', 'anthropic/claude-opus-4.7',
-  'openai/gpt-5.5', 'openai/gpt-5.4',
-  'google/gemini-3.1-pro',
-  'x-ai/grok-4',
-];
-// Routstr uses bare model IDs (no provider prefix, dots: claude-sonnet-4.6)
 const ROUTSTR_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gemini-3', 'gemini-2', 'grok-4', 'grok-3', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'mimo-'];
 const ROUTSTR_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.1-pro', 'grok-4'];
-// PPQ uses bare model IDs (same as Routstr)
-// private/ models (Tinfoil TEE) listed in API but require EHBP protocol, not standard completions
 const PPQ_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'grok-', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
 const PPQ_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3-flash-preview', 'grok-4'];
 const PPQ_EXCLUDE = ['codex', 'audio', 'image', 'embed', 'tts', 'whisper', 'video', 'nano-banana'];
-export function isRecommendedModel(provider, modelId) {
-  if (provider === 'openrouter') return OPENROUTER_RECOMMENDED.some(function(prefix) { return modelId.startsWith(prefix); });
-  if (provider === 'venice') {
-    if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5/.test(modelId);
-    // claude-(sonnet-4-6|opus-4-7) is intentionally narrow — Anthropic ships
-    // each model as its own version. When sonnet-4-7 / opus-4-8 land, broaden
-    // the alternation rather than back to (sonnet|opus)-4-X (would over-match
-    // older versions). gpt-5[2345] tracks 5.2/5.3/5.4/5.5 — extend digits as
-    // OpenAI ships new minor versions.
-    return /^(claude-(sonnet-4-6|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3(-1)?-pro|grok-4[1-9]?)(-|$)/.test(modelId);
-  }
-  if (provider === 'routstr') return ROUTSTR_RECOMMENDED.some(function(r) { return modelId === r || modelId.startsWith(r); });
-  if (provider === 'ppq') return PPQ_RECOMMENDED.some(function(r) { return modelId === r || modelId.startsWith(r); });
-  return false; // Ollama — local models, can't tier
-}
-export function getActiveModelId(provider = getAIProvider()) {
-  if (provider === 'venice') return getVeniceModel();
-  if (provider === 'openrouter') return getOpenRouterModel();
-  if (provider === 'routstr') return getRoutstrModel();
-  if (provider === 'ppq') return getPpqModel();
-  if (provider === 'custom') return getCustomApiModel();
-  return getOllamaMainModel();
-}
-export function getActiveModelDisplay(provider = getAIProvider()) {
-  if (provider === 'venice') return getVeniceModelDisplay();
-  if (provider === 'openrouter') return getOpenRouterModelDisplay();
-  if (provider === 'routstr') return getRoutstrModelDisplay();
-  if (provider === 'ppq') return getPpqModelDisplay();
-  if (provider === 'custom') return getCustomApiModelDisplay();
-  return getOllamaMainModel();
-}
-// Exclude specialized variants not suited for medical analysis
-const OPENROUTER_EXCLUDE = ['codex', 'audio', 'image', 'oss', 'safeguard', 'coder'];
-export async function fetchOpenRouterModels(key) {
-  try {
-    const res = await fetch('https://openrouter.ai/api/v1/models', {
-      headers: { 'Authorization': 'Bearer ' + (key || getOpenRouterKey()) }
-    });
-    if (!res.ok) return [];
-    const json = await res.json();
-    // Filter to curated medically capable models, exclude specialized variants
-    const all = (json.data || []).filter(function(m) {
-      if (!m.id) return false;
-      if (OPENROUTER_EXCLUDE.some(function(ex) { return m.id.includes(ex); })) return false;
-      return OPENROUTER_CURATED.some(function(prefix) { return m.id.startsWith(prefix); });
-    }).sort(function(a, b) { return (a.name || a.id).localeCompare(b.name || b.id); });
-    // Deduplicate: strip date/size suffixes after provider/ prefix
-    const models = deduplicateModels(all, function(id) {
-      return id.replace(/:\d{4}-\d{2}-\d{2}$/, '').replace(/-\d{8}$/, '');
-    });
-    // Sort recommended models first, then alphabetical within each group
-    models.sort(function(a, b) {
-      const aRec = OPENROUTER_RECOMMENDED.some(function(p) { return a.id.startsWith(p); });
-      const bRec = OPENROUTER_RECOMMENDED.some(function(p) { return b.id.startsWith(p); });
-      if (aRec !== bRec) return aRec ? -1 : 1;
-      return (a.name || a.id).localeCompare(b.name || b.id);
-    });
-    // Extract per-million-token pricing from API response
-    const pricingCache = {};
-    for (const m of models) {
-      if (m.pricing && m.pricing.prompt && m.pricing.completion) {
-        pricingCache[m.id] = {
-          input: parseFloat(m.pricing.prompt) * 1_000_000,
-          output: parseFloat(m.pricing.completion) * 1_000_000
-        };
-      }
-    }
-    localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify(pricingCache));
-    // Cache vision-capable model IDs (architecture.modality contains "image->text" or similar)
-    const visionIds = (json.data || []).filter(function(m) {
-      if (!m.id || !m.architecture) return false;
-      const modality = m.architecture.modality || '';
-      return modality.includes('image');
-    }).map(function(m) { return m.id; });
-    localStorage.setItem('labcharts-openrouter-vision-models', JSON.stringify(visionIds));
-    localStorage.setItem('labcharts-openrouter-models', JSON.stringify(models));
-    if (!localStorage.getItem('labcharts-openrouter-model') && models.length) {
-      const claude = models.find(function(m) { return m.id === 'anthropic/claude-sonnet-4.6'; });
-      if (claude) setOpenRouterModel(claude.id);
-    }
-    return models;
-  } catch (e) { return []; }
-}
-/** Fetch and cache pricing for a custom OpenRouter model not in the curated list */
-export async function fetchOpenRouterModelPricing(modelId) {
-  if (!modelId) return null;
-  const existing = getOpenRouterPricing(modelId);
-  if (existing) return existing;
-  try {
-    const res = await fetch('https://openrouter.ai/api/v1/models', {
-      headers: { 'Authorization': 'Bearer ' + getOpenRouterKey() }
-    });
-    if (!res.ok) return null;
-    const json = await res.json();
-    // Exact match first, then fuzzy (dots vs dashes, date suffixes)
-    const norm = s => s.replace(/\./g, '-').replace(/-\d{8}$/, '');
-    const model = (json.data || []).find(m => m.id === modelId)
-      || (json.data || []).find(m => norm(m.id) === norm(modelId));
-    if (!model?.pricing) return null;
-    const pricing = {
-      input: parseFloat(model.pricing.prompt || '0') * 1_000_000,
-      output: parseFloat(model.pricing.completion || '0') * 1_000_000
-    };
-    const cached = JSON.parse(localStorage.getItem('labcharts-openrouter-pricing') || '{}');
-    // Cache under both the API ID and the user-typed ID
-    cached[model.id] = pricing;
-    cached[modelId] = pricing;
-    localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify(cached));
-    return pricing;
-  } catch (e) { /* fail silently */ }
-  return null;
-}
-
-export async function validateOpenRouterKey(key) {
-  try {
-    const res = await fetch('https://openrouter.ai/api/v1/models', {
-      headers: { 'Authorization': 'Bearer ' + key }
-    });
-    if (res.ok) return { valid: true };
-    if (res.status === 401) return { valid: false, error: 'Invalid API key' };
-    if (res.status === 429) return { valid: true };
-    const errBody = await res.json().catch(() => null);
-    const errMsg = errBody?.error?.message || `status ${res.status}`;
-    return { valid: false, error: `API error: ${errMsg}` };
-  } catch (e) {
-    return { valid: false, error: 'Cannot reach OpenRouter API: ' + e.message };
-  }
-}
-
-export function renderModelPricingHint(provider, modelId) {
-  if (provider === 'ollama') return '<span style="font-size:11px;color:var(--green)">Free (local)</span>';
-  if (provider === 'custom') return '';
-  const p = getModelPricing(provider, modelId);
-  if (p.input === 0 && p.output === 0) return '<span style="font-size:11px;color:var(--green)">Free</span>';
-  const pre = p.approx ? '~' : '';
-  return `<span style="font-size:11px;color:var(--text-muted)">${pre}$${p.input.toFixed(2)}/M in \u00b7 ${pre}$${p.output.toFixed(2)}/M out</span>`;
-}
-export async function fetchVeniceModels(key) {
-  try {
-    const res = await fetch('https://api.venice.ai/api/v1/models', {
-      headers: { 'Authorization': 'Bearer ' + (key || getVeniceKey()) }
-    });
-    if (!res.ok) return [];
-    const json = await res.json();
-    // Sort descending so latest version comes first per family
-    const allText = (json.data || []).filter(function(m) { return m.id && m.type === 'text'; }).sort(function(a, b) { return b.id.localeCompare(a.id); });
-    // Cache E2EE models separately. The capability flag is authoritative;
-    // keep a prefix fallback for older Venice responses that did not include it.
-    const e2eeList = allText.filter(modelSupportsVeniceE2EE);
-    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify(e2eeList));
-    const e2eeIds = new Set(e2eeList.map(function(m) { return m.id; }));
-    const all = allText.filter(function(m) { return !e2eeIds.has(m.id) && !m.id.startsWith('e2ee-'); });
-    // Deduplicate: Venice curates Claude models (no date-stamped variants), so keep all.
-    // For others, strip size/date suffixes to collapse duplicates.
-    const models = deduplicateModels(all, function(id) {
-      if (id.startsWith('claude-')) return id;
-      return id.replace(/-\d{8}$/, '').replace(/-\d+[bB]$/, '');
-    });
-    // Re-sort alphabetically by display name
-    models.sort(function(a, b) { return (a.name || a.id).localeCompare(b.name || b.id); });
-    // Extract per-million-token pricing from model_spec
-    const pricingCache = {};
-    for (const m of allText) {
-      const p = m.model_spec && m.model_spec.pricing;
-      if (p && p.input && p.output) {
-        pricingCache[m.id] = { input: parseFloat(p.input.usd || 0), output: parseFloat(p.output.usd || 0) };
-      }
-    }
-    localStorage.setItem('labcharts-venice-pricing', JSON.stringify(pricingCache));
-    const visionIds = allText.filter(m => m.model_spec?.capabilities?.supportsVision).map(m => m.id);
-    localStorage.setItem('labcharts-venice-vision-models', JSON.stringify(visionIds));
-    localStorage.setItem('labcharts-venice-models', JSON.stringify(models));
-    localStorage.setItem('labcharts-venice-models-fetched-at', String(Date.now()));
-    syncVeniceModelSelection(models, e2eeList);
-    return models;
-  } catch (e) { return []; }
-}
 
 // ─── Proxy support ───
 // Only Custom API needs the proxy (arbitrary endpoints may lack CORS headers).
@@ -512,57 +328,6 @@ async function _fetchWithRetry(url, options, retries = 2, useProxy = true, reque
     directFetch: fetch,
     debug: isDebugMode,
   });
-}
-
-// ═══════════════════════════════════════════════
-// WEB SEARCH SUPPORT
-// ═══════════════════════════════════════════════
-export function supportsWebSearch(provider = getAIProvider()) {
-  if (provider === 'venice') return !isVeniceE2EEActive();
-  if (provider === 'routstr') return false;
-  if (provider === 'ppq') return true;
-  if (provider === 'custom') return false;
-  return provider === 'openrouter';
-}
-
-// ═══════════════════════════════════════════════
-// VISION SUPPORT
-// ═══════════════════════════════════════════════
-export function supportsVision() {
-  const provider = getAIProvider();
-  if (provider === 'openrouter') {
-    const modelId = getOpenRouterModel();
-    try {
-      const visionIds = JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models') || '[]');
-      // Check exact match or prefix match (model IDs may have date suffixes)
-      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/:\d{4}-\d{2}-\d{2}$/, '')); });
-    } catch { return false; }
-  }
-  if (provider === 'venice') {
-    if (isVeniceE2EEActive()) return false;
-    const modelId = getVeniceModel();
-    try {
-      const visionIds = JSON.parse(localStorage.getItem('labcharts-venice-vision-models') || '[]');
-      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/-\d{8}$/, '')); });
-    } catch { return false; }
-  }
-  if (provider === 'routstr') {
-    const modelId = getRoutstrModel();
-    try {
-      const visionIds = JSON.parse(localStorage.getItem('labcharts-routstr-vision-models') || '[]');
-      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/-\d{8}$/, '')); });
-    } catch { return false; }
-  }
-  if (provider === 'ppq') {
-    const modelId = getPpqModel();
-    try {
-      const visionIds = JSON.parse(localStorage.getItem('labcharts-ppq-vision-models') || '[]');
-      return visionIds.some(function(vid) { return modelId === vid || modelId.startsWith(vid.replace(/-\d{8}$/, '')); });
-    } catch { return false; }
-  }
-  // Custom API / Local AI — optimistic (user's responsibility)
-  if (provider === 'custom') return true;
-  return true;
 }
 
 export async function callOllamaChat({ system, messages, maxTokens, onStream, signal }) {
@@ -658,18 +423,6 @@ export async function callOllamaChat({ system, messages, maxTokens, onStream, si
     const data = await res.json();
     return { text: data.message?.content || '', usage: { inputTokens: data.prompt_eval_count || 0, outputTokens: data.eval_count || 0 } };
   }
-}
-
-// ═══════════════════════════════════════════════
-// SHARED OPENAI-COMPATIBLE API HELPER
-// ═══════════════════════════════════════════════
-// GPT-5 family + o-series reasoning models reject `max_tokens` and require `max_completion_tokens`.
-// Matches bare ids (gpt-5.4, o1-mini) and provider-prefixed (openai/gpt-5, openai/o3).
-export function needsMaxCompletionTokens(modelId) {
-  if (!modelId) return false;
-  const id = String(modelId).toLowerCase();
-  const bare = id.includes('/') ? id.split('/').pop() : id;
-  return /^(gpt-5|o[1-9])([-.]|$)/.test(bare);
 }
 
 async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { system, messages, maxTokens, onStream, signal, requestTimeoutMs, jsonMode }, extraHeaders = {}, { useProxy = true, extraBody = {} } = {}) {
@@ -963,22 +716,6 @@ export async function callOpenRouterAPI(opts) {
     { 'HTTP-Referer': window.location.origin, 'X-Title': 'getbased' },
     { extraBody }
   );
-}
-
-export async function validateVeniceKey(key) {
-  try {
-    const res = await fetch('https://api.venice.ai/api/v1/models', {
-      headers: { 'Authorization': 'Bearer ' + key }
-    });
-    if (res.ok) return { valid: true };
-    if (res.status === 401) return { valid: false, error: 'Invalid API key' };
-    if (res.status === 429) return { valid: true };
-    const errBody = await res.json().catch(() => null);
-    const errMsg = errBody?.error?.message || `status ${res.status}`;
-    return { valid: false, error: `API error: ${errMsg}` };
-  } catch (e) {
-    return { valid: false, error: 'Cannot reach Venice API: ' + e.message };
-  }
 }
 
 // ═══════════════════════════════════════════════

--- a/service-worker.js
+++ b/service-worker.js
@@ -82,6 +82,7 @@ const APP_SHELL = [
   '/js/utils.js',
   '/js/theme.js',
   '/js/api.js',
+  '/js/api-models.js',
   '/js/api-provider-storage.js',
   '/js/api-transport.js',
   '/js/startup-foundation.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -64,6 +64,7 @@ const swAuditSrc = read('service-worker.js');
 assert('SW uses importScripts for version', swAuditSrc.includes("importScripts('/version.js')"));
 assert('SW CACHE_NAME uses semver', swAuditSrc.includes('`labcharts-v${self.APP_VERSION}`'));
 assert('SW treats app.getbased.health as production host', swAuditSrc.includes("'app.getbased.health'"));
+assert('SW APP_SHELL includes API models module', swAuditSrc.includes("'/js/api-models.js'"));
 assert('SW APP_SHELL includes API provider storage module', swAuditSrc.includes("'/js/api-provider-storage.js'"));
 assert('SW APP_SHELL includes provider model controls module', swAuditSrc.includes("'/js/provider-model-controls.js'"));
 assert('SW APP_SHELL includes provider local AI controls module', swAuditSrc.includes("'/js/provider-local-ai-controls.js'"));

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -37,6 +37,7 @@ await import('../js/provider-panels.js');
 // ─── 1. api.js source inspection ───
 console.log('1. api.js source inspection');
 const apiSrc = read('js/api.js');
+const apiModelsSrc = read('js/api-models.js');
 const apiProviderStorageSrc = read('js/api-provider-storage.js');
 assert('getCustomApiUrl exists', apiProviderStorageSrc.includes('function getCustomApiUrl()'));
 assert('setCustomApiUrl exists', apiProviderStorageSrc.includes('function setCustomApiUrl('));
@@ -51,11 +52,11 @@ assert('validateCustomApiKey exists', apiSrc.includes('function validateCustomAp
 assert('callCustomAPI exists', apiSrc.includes('function callCustomAPI('));
 assert('hasAIProvider handles custom', apiProviderStorageSrc.includes("provider === 'custom') return hasCustomApiKey()"));
 assert('hasAIProvider custom requires URL', apiProviderStorageSrc.includes("hasCustomApiKey() && !!getCustomApiUrl()"));
-assert('getActiveModelId handles custom', apiSrc.includes("provider === 'custom') return getCustomApiModel()"));
-assert('getActiveModelDisplay handles custom', apiSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
+assert('getActiveModelId handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModel()"));
+assert('getActiveModelDisplay handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
 assert('callClaudeAPI handles custom', apiSrc.includes("provider === 'custom') return callCustomAPI("));
-assert('supportsWebSearch false for custom', apiSrc.includes("provider === 'custom') return false"));
-assert('supportsVision true for custom', apiSrc.includes("provider === 'custom') return true"));
+assert('supportsWebSearch false for custom', apiModelsSrc.includes("provider === 'custom') return false"));
+assert('supportsVision true for custom', apiModelsSrc.includes("provider === 'custom') return true"));
 assert('callCustomAPI routes through proxy', apiSrc.includes("'Custom', opts,\n    {}"));
 assert('saveCustomApiKey uses encryptedSetItem', apiProviderStorageSrc.includes("encryptedSetItem('labcharts-custom-key'"));
 assert('getCustomApiKey uses getCachedKey', apiProviderStorageSrc.includes("getCachedKey('labcharts-custom-key')"));

--- a/tests/test-image-utils.js
+++ b/tests/test-image-utils.js
@@ -121,8 +121,9 @@ assert('parseLabPDFWithAIImages exported', typeof window.parseLabPDFWithAIImages
 console.log('9. Source Code');
 
 const apiSrc = await fetchWithRetry('js/api.js');
-assert('supportsVision function in api.js', apiSrc.includes('export function supportsVision'));
-assert('Vision models cached in fetchOpenRouterModels', apiSrc.includes('labcharts-openrouter-vision-models'));
+const apiModelsSrc = await fetchWithRetry('js/api-models.js');
+assert('supportsVision function in api-models.js', apiModelsSrc.includes('export function supportsVision'));
+assert('Vision models cached in fetchOpenRouterModels', apiModelsSrc.includes('labcharts-openrouter-vision-models'));
 assert('Ollama image normalization', apiSrc.includes('ollamaMsg.images = images'));
 
 const chatRenderSrc = await fetchWithRetry('js/chat-render.js');

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -34,6 +34,7 @@ await import('../js/provider-panels.js');
 // ─── 1. api.js source inspection ───
 console.log('1. api.js source inspection');
 const apiSrc = read('js/api.js');
+const apiModelsSrc = read('js/api-models.js');
 const apiProviderStorageSrc = read('js/api-provider-storage.js');
 assert('getOpenRouterKey exists', apiProviderStorageSrc.includes('function getOpenRouterKey()'));
 assert('saveOpenRouterKey exists', apiProviderStorageSrc.includes('function saveOpenRouterKey('));
@@ -41,8 +42,9 @@ assert('hasOpenRouterKey exists', apiProviderStorageSrc.includes('function hasOp
 assert('getOpenRouterModel exists', apiProviderStorageSrc.includes('function getOpenRouterModel()'));
 assert('setOpenRouterModel exists', apiProviderStorageSrc.includes('function setOpenRouterModel('));
 assert('getOpenRouterModelDisplay exists', apiProviderStorageSrc.includes('function getOpenRouterModelDisplay()'));
-assert('fetchOpenRouterModels exists', apiSrc.includes('function fetchOpenRouterModels('));
-assert('validateOpenRouterKey exists', apiSrc.includes('function validateOpenRouterKey('));
+assert('api.js re-exports OpenRouter model helpers', apiSrc.includes("from './api-models.js'"));
+assert('fetchOpenRouterModels exists', apiModelsSrc.includes('function fetchOpenRouterModels('));
+assert('validateOpenRouterKey exists', apiModelsSrc.includes('function validateOpenRouterKey('));
 assert('callOpenRouterAPI exists', apiSrc.includes('function callOpenRouterAPI('));
 assert('extraHeaders in helper signature', apiSrc.includes('extraHeaders = {}'));
 assert('extraHeaders spread in fetch headers', apiSrc.includes('...extraHeaders'));
@@ -56,7 +58,7 @@ assert('callOpenRouterAPI sends X-Title', apiSrc.includes("'X-Title': 'getbased'
 // assertion). This checks the legacy-migration source string is still present.
 assert('provider storage still references legacy hyphenated ID for migration', apiProviderStorageSrc.includes("'anthropic/claude-sonnet-4-6'"));
 assert('OpenRouter API endpoint', apiSrc.includes('openrouter.ai/api/v1/chat/completions'));
-assert('OpenRouter models endpoint', apiSrc.includes('openrouter.ai/api/v1/models'));
+assert('OpenRouter models endpoint', apiModelsSrc.includes('openrouter.ai/api/v1/models'));
 
 // ─── 2. schema.js + api.js: curated models + dynamic pricing ───
 console.log('\n2. Curated models + dynamic pricing');
@@ -64,23 +66,23 @@ const schemaSrc = read('js/schema.js');
 assert('MODEL_PRICING has openrouter block', schemaSrc.includes('openrouter:'));
 assert('Has openrouter _default fallback', schemaSrc.includes("'_default':") && schemaSrc.includes('approx: true'));
 assert('getModelPricing checks openrouter-pricing cache', schemaSrc.includes('labcharts-openrouter-pricing'));
-assert('OPENROUTER_CURATED whitelist exists', apiSrc.includes('OPENROUTER_CURATED'));
-assert('Curated: anthropic/claude-sonnet prefix', apiSrc.includes("'anthropic/claude-sonnet-4'"));
-assert('Curated: anthropic/claude-opus prefix', apiSrc.includes("'anthropic/claude-opus-4'"));
-assert('Curated: openai/gpt prefix', apiSrc.includes("'openai/gpt-5'"));
-assert('Curated: google/gemini-3 prefix', apiSrc.includes("'google/gemini-3'"));
-assert('Curated: google/gemini-2 prefix', apiSrc.includes("'google/gemini-2'"));
-assert('Curated: deepseek prefix', apiSrc.includes("'deepseek/deepseek'"));
-assert('Curated: qwen prefix', apiSrc.includes("'qwen/qwen'"));
-assert('Curated: x-ai/grok prefix', apiSrc.includes("'x-ai/grok'"));
-assert('OPENROUTER_EXCLUDE exists', apiSrc.includes('OPENROUTER_EXCLUDE'));
-assert('Excludes codex variants', apiSrc.includes("'codex'"));
-assert('Excludes audio variants', apiSrc.includes("'audio'"));
-assert('Excludes image variants', apiSrc.includes("'image'"));
-assert('Exclude filter applied in fetch', apiSrc.includes('OPENROUTER_EXCLUDE.some'));
-assert('fetchOpenRouterModels extracts pricing.prompt', apiSrc.includes('m.pricing.prompt'));
-assert('fetchOpenRouterModels converts to per-million', apiSrc.includes('* 1_000_000'));
-assert('fetchOpenRouterModels caches pricing', apiSrc.includes("'labcharts-openrouter-pricing'"));
+assert('OPENROUTER_CURATED whitelist exists', apiModelsSrc.includes('OPENROUTER_CURATED'));
+assert('Curated: anthropic/claude-sonnet prefix', apiModelsSrc.includes("'anthropic/claude-sonnet-4'"));
+assert('Curated: anthropic/claude-opus prefix', apiModelsSrc.includes("'anthropic/claude-opus-4'"));
+assert('Curated: openai/gpt prefix', apiModelsSrc.includes("'openai/gpt-5'"));
+assert('Curated: google/gemini-3 prefix', apiModelsSrc.includes("'google/gemini-3'"));
+assert('Curated: google/gemini-2 prefix', apiModelsSrc.includes("'google/gemini-2'"));
+assert('Curated: deepseek prefix', apiModelsSrc.includes("'deepseek/deepseek'"));
+assert('Curated: qwen prefix', apiModelsSrc.includes("'qwen/qwen'"));
+assert('Curated: x-ai/grok prefix', apiModelsSrc.includes("'x-ai/grok'"));
+assert('OPENROUTER_EXCLUDE exists', apiModelsSrc.includes('OPENROUTER_EXCLUDE'));
+assert('Excludes codex variants', apiModelsSrc.includes("'codex'"));
+assert('Excludes audio variants', apiModelsSrc.includes("'audio'"));
+assert('Excludes image variants', apiModelsSrc.includes("'image'"));
+assert('Exclude filter applied in fetch', apiModelsSrc.includes('OPENROUTER_EXCLUDE.some'));
+assert('fetchOpenRouterModels extracts pricing.prompt', apiModelsSrc.includes('m.pricing.prompt'));
+assert('fetchOpenRouterModels converts to per-million', apiModelsSrc.includes('* 1_000_000'));
+assert('fetchOpenRouterModels caches pricing', apiModelsSrc.includes("'labcharts-openrouter-pricing'"));
 assert('getOpenRouterPricing function exists', apiProviderStorageSrc.includes('function getOpenRouterPricing('));
 assert('window.getOpenRouterPricing is function', typeof window.getOpenRouterPricing === 'function');
 

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -28,13 +28,14 @@ const cryptoMod = await import('../js/crypto.js');
 
 // 1. Source: api.js has isE2EEModel and E2EE branch
 const apiSrc = read('js/api.js');
+const apiModelsSrc = read('js/api-models.js');
 const apiProviderStorageSrc = read('js/api-provider-storage.js');
 assert('isE2EEModel exported through api.js', apiSrc.includes('isE2EEModel,'));
 assert('e2ee prefix detection', apiProviderStorageSrc.includes("modelId.startsWith('e2ee-')"));
 assert('callVeniceAPI has E2EE import', apiSrc.includes("import('../vendor/venice-e2ee.js')"));
-assert('supportsWebSearch excludes E2EE', apiSrc.includes('isVeniceE2EEActive()'));
-assert('supportsVision excludes E2EE', apiSrc.includes('isVeniceE2EEActive()') && apiSrc.includes('return false'));
-assert('fetchVeniceModels excludes unsupported e2ee-prefixed regular models', apiSrc.includes("!m.id.startsWith('e2ee-')"));
+assert('supportsWebSearch excludes E2EE', apiModelsSrc.includes('isVeniceE2EEActive()'));
+assert('supportsVision excludes E2EE', apiModelsSrc.includes('isVeniceE2EEActive()') && apiModelsSrc.includes('return false'));
+assert('fetchVeniceModels excludes unsupported e2ee-prefixed regular models', apiModelsSrc.includes("!m.id.startsWith('e2ee-')"));
 assert('Venice E2EE supports forced non-stream retry path',
   /forceNonStream/.test(apiSrc)
   && /requestTimeoutMs/.test(apiSrc)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.1';
+self.APP_VERSION = '1.10.2';


### PR DESCRIPTION
## Summary
- Move provider model catalog, pricing, validation, vision/web-search capability, active-model, and token-limit helpers into `js/api-models.js`.
- Keep `js/api.js` as the public facade by importing/re-exporting the moved helpers so existing callers continue to import from `./api.js`.
- Precache the new module, update source guards for the new boundary, and bump the app version to `1.10.2`.

## Quality impact
- `js/api.js`: 1324 -> 1061 lines.
- New helper: `js/api-models.js` at 296 lines.
- Largest module is now `js/light-env.js` at 1269 lines, followed by `js/recommendations.js` at 1267 and `js/pdf-import.js` at 1255.
- `npm run quality`: largest `1270/1513: js/light-env.js`; all JS/MJS parsed (`355 files`).

## Validation
- `npm run typecheck`
- `node tests/test-openrouter.js` (149 passed)
- `node tests/test-custom-api.js` (130 passed)
- `node tests/test-image-utils.js` (59 passed)
- `node tests/test-venice-e2ee.js` (83 passed)
- `node tests/test-audit.js` (299 passed)
- `npx vitest run tests/api-provider-runtime.test.js` (6 passed)
- `npm run quality`
- `node tests/test-cashu-wallet.js` (178 passed)
- `node tests/test-correctness-phase2.js` (167 passed)
- `npx playwright test tests/playwright/api-provider-calls-browser-coverage.spec.js tests/playwright/api-provider-storage-browser-coverage.spec.js tests/playwright/provider-coverage-batch.spec.js tests/playwright/provider-model-controls-edge-browser-coverage.spec.js tests/playwright/settings-provider-browser-coverage.spec.js tests/playwright/custom-api-settings.spec.js tests/playwright/openrouter-settings.spec.js --project=chromium` (13 passed)
- `./run-tests.sh` (Vitest 191 passed, dev-server origin guards 18 passed, Playwright 332 passed)