### PR TITLE
Extract light environment screen UI

### DIFF
--- a/js/light-env-screen-ui.js
+++ b/js/light-env-screen-ui.js
@@ -1,0 +1,135 @@
+// @ts-check
+// light-env-screen-ui.js — screen-card rendering helpers for Light Environment.
+
+import { escapeHTML, escapeAttr } from './utils.js';
+import { lightEnvActionAttrs } from './light-env-actions.js';
+import { SCREEN_DEVICES, computeScreenStatus } from './light-env-model.js';
+import { isActiveToday } from './light-env-store.js';
+
+const SCREEN_DEVICE_ICONS = {
+  phone: '📱', laptop: '💻', monitor: '🖥', tablet: '📲', tv: '📺',
+};
+
+function screenSummary(s, status) {
+  const parts = [];
+  const hours = s.hoursPerDay;
+  if (hours != null && hours > 0) parts.push(`${hours} hr/day`);
+  const eve = s.eveningUseAfterSunset;
+  if (eve != null && eve > 0) parts.push(`${eve} hr evening`);
+  else if (hours > 0) parts.push('daytime only');
+  if (s.blueBlockerEnabled) parts.push('✓ blocker');
+  return parts.join(' · ');
+}
+
+// Hours-per-day chip buckets — separate set from room HOURS_BUCKETS
+// because screen total-day usage often skews lower (a phone is 3 hr,
+// not 8). Stored as numeric midpoint, same as rooms.
+export const SCREEN_HOURS_BUCKETS = [
+  { key: 'short',  label: '< 1 hr',  midpoint: 0.5, min: 0, max: 1 },
+  { key: 'some',   label: '1–3 hr',  midpoint: 2,   min: 1, max: 3 },
+  { key: 'lots',   label: '3–6 hr',  midpoint: 4.5, min: 3, max: 6 },
+  { key: 'most',   label: '6+ hr',   midpoint: 8,   min: 6, max: 24 },
+];
+
+export function activeScreenHoursBucket(hours) {
+  if (hours == null || isNaN(+hours)) return null;
+  const h = +hours;
+  for (const b of SCREEN_HOURS_BUCKETS) if (h >= b.min && h < b.max) return b.key;
+  return 'most';
+}
+
+export function activeScreenEveningBucket(eve) {
+  if (eve == null) return null;
+  const h = +eve;
+  if (h <= 0) return 'none';
+  if (h < 1) return 'lt1';
+  if (h < 3) return 'mid';
+  return 'gt3';
+}
+
+// Single screen card markup — used both at top level (portable) and
+// nested inside a room card (compact mode). Expansion state stays in
+// light-env.js; this module renders from the supplied context.
+export function renderScreenCard(s, opts = {}) {
+  const status = computeScreenStatus(s);
+  const activeToday = isActiveToday(s);
+  const expanded = !!opts.expanded;
+  const rooms = Array.isArray(opts.rooms) ? opts.rooms : [];
+  const renderTodayToggle = opts.renderTodayToggle;
+  const deviceIcon = SCREEN_DEVICE_ICONS[s.device] || '📱';
+  const deviceLabel = (SCREEN_DEVICES.find(d => d.key === s.device)?.label) || 'Device';
+  const summary = screenSummary(s, status);
+
+  let html = `<div class="light-env-screen-card light-env-card-sev-${status.color}${activeToday ? '' : ' light-env-card-skipped'}${expanded ? ' expanded' : ''}" data-id="${escapeAttr(s.id)}">
+    <div class="light-env-screen-card-head" role="button" tabindex="0" aria-expanded="${expanded ? 'true' : 'false'}" aria-label="${escapeAttr(deviceLabel + ' — ' + status.label + (summary ? ', ' + summary : '') + (expanded ? ', expanded' : ', collapsed'))}" ${lightEnvActionAttrs('toggle-screen-expanded', { id: s.id })}>
+      <span class="light-env-sev-dot light-env-sev-${status.color}" title="${escapeAttr(status.label + ' — ' + status.reason)}"><span class="sr-only">${escapeHTML(status.label)}</span></span>
+      <span class="light-env-screen-card-icon" aria-hidden="true">${deviceIcon}</span>
+      <span class="light-env-screen-card-name">${escapeHTML(deviceLabel)}</span>
+      ${expanded ? '' : `<span class="light-env-screen-card-summary">${escapeHTML(summary || 'Tap to set up')}</span>`}
+      <span class="light-env-room-disclosure-spacer"></span>
+      ${typeof renderTodayToggle === 'function' ? renderTodayToggle('screen', s.id, activeToday) : ''}
+      ${expanded ? `<button class="light-env-overflow" ${lightEnvActionAttrs('delete-screen-confirm', { id: s.id })} title="Delete screen" aria-label="Delete screen">⋯</button>` : ''}
+      <span class="light-env-room-disclosure-chevron" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
+    </div>`;
+
+  if (expanded) html += renderScreenExpandedBody(s, rooms);
+  html += `</div>`;
+  return html;
+}
+
+function renderScreenExpandedBody(s, rooms) {
+  const hoursActive = activeScreenHoursBucket(s.hoursPerDay);
+  const eveActive = activeScreenEveningBucket(s.eveningUseAfterSunset);
+
+  const hoursChips = SCREEN_HOURS_BUCKETS.map(b =>
+    `<button type="button" class="light-env-chip${hoursActive === b.key ? ' light-env-chip-active' : ''}" aria-pressed="${hoursActive === b.key ? 'true' : 'false'}" ${lightEnvActionAttrs('set-screen-hours-bucket', { id: s.id, key: b.key })}>${escapeHTML(b.label)}</button>`
+  ).join('');
+
+  const eveBuckets = [
+    { key: 'none', label: 'None',     midpoint: 0 },
+    { key: 'lt1',  label: '< 1 hr',   midpoint: 0.5 },
+    { key: 'mid',  label: '1–3 hr',   midpoint: 2 },
+    { key: 'gt3',  label: '3+ hr',    midpoint: 4 },
+  ];
+  const eveChips = eveBuckets.map(b =>
+    `<button type="button" class="light-env-chip${eveActive === b.key ? ' light-env-chip-active' : ''}" aria-pressed="${eveActive === b.key ? 'true' : 'false'}" ${lightEnvActionAttrs('set-screen-evening-bucket', { id: s.id, key: b.key })}>${escapeHTML(b.label)}</button>`
+  ).join('');
+
+  const roomOptions = rooms.length > 0
+    ? `<select class="ctx-select light-env-screen-room" ${lightEnvActionAttrs('update-screen-room', { id: s.id })} aria-label="Used in room">
+        <option value=""${!s.roomId ? ' selected' : ''}>Portable / multiple rooms</option>
+        ${rooms.map(r => `<option value="${escapeAttr(r.id)}"${s.roomId === r.id ? ' selected' : ''}>${escapeHTML(r.name || 'Room')}</option>`).join('')}
+      </select>`
+    : '';
+
+  return `<div class="light-env-screen-card-body">
+    <div class="light-env-screen-meta-row">
+      <label class="ctx-label">Device
+        <select class="ctx-select" ${lightEnvActionAttrs('update-screen-device', { id: s.id })} aria-label="Device type">
+          ${SCREEN_DEVICES.map(d => `<option value="${escapeAttr(d.key)}"${s.device === d.key ? ' selected' : ''}>${escapeHTML(d.label)}</option>`).join('')}
+        </select>
+      </label>
+      ${roomOptions ? `<label class="ctx-label">Used in
+        ${roomOptions}
+      </label>` : ''}
+    </div>
+    <div class="light-env-picker">
+      <span class="light-env-picker-label">Hours per day</span>
+      <div class="light-env-chip-row">${hoursChips}</div>
+    </div>
+    <div class="light-env-picker">
+      <span class="light-env-picker-label">Time after sunset</span>
+      <div class="light-env-chip-row">${eveChips}</div>
+    </div>
+    <div class="light-env-screen-blocker" style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:8px">
+      <span style="flex:1;min-width:0;font-size:13px;color:var(--text-secondary)">Blue blocker active
+        <span style="display:block;font-size:11px;color:var(--text-muted);margin-top:2px">Glasses, f.lux, Night Shift, amber tint — zeroes the circadian penalty.</span>
+      </span>
+      <label class="toggle-switch">
+        <input type="checkbox"${s.blueBlockerEnabled ? ' checked' : ''} ${lightEnvActionAttrs('update-screen-blue-blocker', { id: s.id })} />
+        <span class="toggle-slider"></span>
+      </label>
+    </div>
+    ${typeof globalThis.renderScreenAIBlock === 'function' ? globalThis.renderScreenAIBlock(s) : ''}
+  </div>`;
+}

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -49,6 +49,7 @@ import {
   renderLightAuditsBlock,
 } from './light-env-audits.js';
 import { installLightEnvActionDelegates, lightEnvActionAttrs } from './light-env-actions.js';
+import { SCREEN_HOURS_BUCKETS, renderScreenCard } from './light-env-screen-ui.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 export { getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit } from './light-env-audits.js';
@@ -263,140 +264,20 @@ function _renderTodayToggle(kind, id, activeToday, opts = {}) {
   return `<button type="button" class="${cls}" ${lightEnvActionAttrs('set-today-active', { kind, id, active: flipTo })} title="${escapeAttr(tip)}" aria-label="${escapeAttr(label)} — click to flip" aria-pressed="${activeToday}">${inner}</button>`;
 }
 
-// Single screen card markup — used both at top level (portable) and
-// nested inside a room card (compact mode). When compact, density
-// ratchets down; the "Used in" dropdown lets the user reassign
-// without leaving the page.
 // Screen card — disclosure pattern matching rooms + audits + EMF.
 // Collapsed header shows: status dot + device-icon + device-label +
 // one-line summary (hours, evening, blocker) + today-toggle + chevron.
-// Expanded body holds the full controls. Single global `_expandedScreenId`
-// — tracking expansion isn't worth localStorage persistence here.
-const SCREEN_DEVICE_ICONS = {
-  phone: '📱', laptop: '💻', monitor: '🖥', tablet: '📲', tv: '📺',
-};
-
+// Expanded body holds the full controls. Tracking expansion isn't worth
+// localStorage persistence, so light-env.js owns the single active id and
+// passes render context into light-env-screen-ui.js.
 let _expandedScreenId = null;
 
-function _screenSummary(s, status) {
-  const parts = [];
-  const hours = s.hoursPerDay;
-  if (hours != null && hours > 0) parts.push(`${hours} hr/day`);
-  const eve = s.eveningUseAfterSunset;
-  if (eve != null && eve > 0) parts.push(`${eve} hr evening`);
-  else if (hours > 0) parts.push('daytime only');
-  if (s.blueBlockerEnabled) parts.push('✓ blocker');
-  return parts.join(' · ');
-}
-
-// Hours-per-day chip buckets — separate set from room HOURS_BUCKETS
-// because screen total-day usage often skews lower (a phone is 3 hr,
-// not 8). Stored as numeric midpoint, same as rooms.
-const SCREEN_HOURS_BUCKETS = [
-  { key: 'short',  label: '< 1 hr',  midpoint: 0.5, min: 0, max: 1 },
-  { key: 'some',   label: '1–3 hr',  midpoint: 2,   min: 1, max: 3 },
-  { key: 'lots',   label: '3–6 hr',  midpoint: 4.5, min: 3, max: 6 },
-  { key: 'most',   label: '6+ hr',   midpoint: 8,   min: 6, max: 24 },
-];
-
-function activeScreenHoursBucket(hours) {
-  if (hours == null || isNaN(+hours)) return null;
-  const h = +hours;
-  for (const b of SCREEN_HOURS_BUCKETS) if (h >= b.min && h < b.max) return b.key;
-  return 'most';
-}
-
-function activeScreenEveningBucket(eve) {
-  if (eve == null) return null;
-  const h = +eve;
-  if (h <= 0) return 'none';
-  if (h < 1) return 'lt1';
-  if (h < 3) return 'mid';
-  return 'gt3';
-}
-
-function renderScreenCard(s, opts = {}) {
-  const status = computeScreenStatus(s);
-  const activeToday = isActiveToday(s);
-  const expanded = _expandedScreenId === s.id;
-  const env = getEnvironment();
-  const rooms = env?.rooms || [];
-  const deviceIcon = SCREEN_DEVICE_ICONS[s.device] || '📱';
-  const deviceLabel = (SCREEN_DEVICES.find(d => d.key === s.device)?.label) || 'Device';
-  const summary = _screenSummary(s, status);
-
-  let html = `<div class="light-env-screen-card light-env-card-sev-${status.color}${activeToday ? '' : ' light-env-card-skipped'}${expanded ? ' expanded' : ''}" data-id="${escapeAttr(s.id)}">
-    <div class="light-env-screen-card-head" role="button" tabindex="0" aria-expanded="${expanded ? 'true' : 'false'}" aria-label="${escapeAttr(deviceLabel + ' — ' + status.label + (summary ? ', ' + summary : '') + (expanded ? ', expanded' : ', collapsed'))}" ${lightEnvActionAttrs('toggle-screen-expanded', { id: s.id })}>
-      <span class="light-env-sev-dot light-env-sev-${status.color}" title="${escapeAttr(status.label + ' — ' + status.reason)}"><span class="sr-only">${escapeHTML(status.label)}</span></span>
-      <span class="light-env-screen-card-icon" aria-hidden="true">${deviceIcon}</span>
-      <span class="light-env-screen-card-name">${escapeHTML(deviceLabel)}</span>
-      ${expanded ? '' : `<span class="light-env-screen-card-summary">${escapeHTML(summary || 'Tap to set up')}</span>`}
-      <span class="light-env-room-disclosure-spacer"></span>
-      ${_renderTodayToggle('screen', s.id, activeToday)}
-      ${expanded ? `<button class="light-env-overflow" ${lightEnvActionAttrs('delete-screen-confirm', { id: s.id })} title="Delete screen" aria-label="Delete screen">⋯</button>` : ''}
-      <span class="light-env-room-disclosure-chevron" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
-    </div>`;
-
-  if (expanded) html += renderScreenExpandedBody(s, rooms);
-  html += `</div>`;
-  return html;
-}
-
-function renderScreenExpandedBody(s, rooms) {
-  const hoursActive = activeScreenHoursBucket(s.hoursPerDay);
-  const eveActive = activeScreenEveningBucket(s.eveningUseAfterSunset);
-
-  const hoursChips = SCREEN_HOURS_BUCKETS.map(b =>
-    `<button type="button" class="light-env-chip${hoursActive === b.key ? ' light-env-chip-active' : ''}" aria-pressed="${hoursActive === b.key ? 'true' : 'false'}" ${lightEnvActionAttrs('set-screen-hours-bucket', { id: s.id, key: b.key })}>${escapeHTML(b.label)}</button>`
-  ).join('');
-
-  const eveBuckets = [
-    { key: 'none', label: 'None',     midpoint: 0 },
-    { key: 'lt1',  label: '< 1 hr',   midpoint: 0.5 },
-    { key: 'mid',  label: '1–3 hr',   midpoint: 2 },
-    { key: 'gt3',  label: '3+ hr',    midpoint: 4 },
-  ];
-  const eveChips = eveBuckets.map(b =>
-    `<button type="button" class="light-env-chip${eveActive === b.key ? ' light-env-chip-active' : ''}" aria-pressed="${eveActive === b.key ? 'true' : 'false'}" ${lightEnvActionAttrs('set-screen-evening-bucket', { id: s.id, key: b.key })}>${escapeHTML(b.label)}</button>`
-  ).join('');
-
-  const roomOptions = rooms.length > 0
-    ? `<select class="ctx-select light-env-screen-room" ${lightEnvActionAttrs('update-screen-room', { id: s.id })} aria-label="Used in room">
-        <option value=""${!s.roomId ? ' selected' : ''}>Portable / multiple rooms</option>
-        ${rooms.map(r => `<option value="${escapeAttr(r.id)}"${s.roomId === r.id ? ' selected' : ''}>${escapeHTML(r.name || 'Room')}</option>`).join('')}
-      </select>`
-    : '';
-
-  return `<div class="light-env-screen-card-body">
-    <div class="light-env-screen-meta-row">
-      <label class="ctx-label">Device
-        <select class="ctx-select" ${lightEnvActionAttrs('update-screen-device', { id: s.id })} aria-label="Device type">
-          ${SCREEN_DEVICES.map(d => `<option value="${escapeAttr(d.key)}"${s.device === d.key ? ' selected' : ''}>${escapeHTML(d.label)}</option>`).join('')}
-        </select>
-      </label>
-      ${roomOptions ? `<label class="ctx-label">Used in
-        ${roomOptions}
-      </label>` : ''}
-    </div>
-    <div class="light-env-picker">
-      <span class="light-env-picker-label">Hours per day</span>
-      <div class="light-env-chip-row">${hoursChips}</div>
-    </div>
-    <div class="light-env-picker">
-      <span class="light-env-picker-label">Time after sunset</span>
-      <div class="light-env-chip-row">${eveChips}</div>
-    </div>
-    <div class="light-env-screen-blocker" style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:8px">
-      <span style="flex:1;min-width:0;font-size:13px;color:var(--text-secondary)">Blue blocker active
-        <span style="display:block;font-size:11px;color:var(--text-muted);margin-top:2px">Glasses, f.lux, Night Shift, amber tint — zeroes the circadian penalty.</span>
-      </span>
-      <label class="toggle-switch">
-        <input type="checkbox"${s.blueBlockerEnabled ? ' checked' : ''} ${lightEnvActionAttrs('update-screen-blue-blocker', { id: s.id })} />
-        <span class="toggle-slider"></span>
-      </label>
-    </div>
-    ${typeof globalThis.renderScreenAIBlock === 'function' ? globalThis.renderScreenAIBlock(s) : ''}
-  </div>`;
+function renderLightEnvScreenCard(s, rooms) {
+  return renderScreenCard(s, {
+    expanded: _expandedScreenId === s.id,
+    renderTodayToggle: _renderTodayToggle,
+    rooms,
+  });
 }
 
 // Quick-pick chip row for adding common rooms — eliminates the
@@ -785,7 +666,8 @@ function renderRoomExpandedBody(r, measurements, sev) {
     html += `<p class="light-env-room-empty">${escapeHTML(emptyCopy)}</p>`;
   } else {
     html += `<div class="light-env-room-screens-list">`;
-    for (const s of screensHere) html += renderScreenCard(s, { compact: true });
+    const rooms = getEnvironment()?.rooms || [];
+    for (const s of screensHere) html += renderLightEnvScreenCard(s, rooms);
     html += `</div>`;
   }
   // Quick-pick chip row — one-click adds a screen with the right device
@@ -865,7 +747,7 @@ export function renderEnvironmentSection(options = {}) {
     </div>`;
   } else {
     html += `<div class="light-env-screen-cards">`;
-    for (const s of portableScreens) html += renderScreenCard(s);
+    for (const s of portableScreens) html += renderLightEnvScreenCard(s, rooms);
     html += `</div>`;
   }
   html += `</div>`;

--- a/service-worker.js
+++ b/service-worker.js
@@ -376,6 +376,7 @@ const APP_SHELL = [
   '/js/light-env.js',
   '/js/light-env-actions.js',
   '/js/light-env-store.js',
+  '/js/light-env-screen-ui.js',
   '/js/light-env-audits.js',
   '/js/light-env-ai-analysis.js',
   '/js/light-env-evening.js',

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -144,6 +144,7 @@ const pwaAppShellAssets = [
   '/js/light-device-session-engine.js',
   '/js/light-device-setup-modal.js',
   '/js/light-env.js',
+  '/js/light-env-screen-ui.js',
   '/js/light-env-audits.js',
   '/js/light-env-evening.js',
   '/js/light-env-model.js',

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -8,9 +8,11 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const envSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
+const screenSrc = fs.readFileSync(path.join(root, 'js/light-env-screen-ui.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/light-env-actions.js'), 'utf8');
 const auditSrc = fs.readFileSync(path.join(root, 'js/light-env-audits.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+const envUiSrc = `${envSrc}\n${screenSrc}`;
 
 let passed = 0;
 let failed = 0;
@@ -30,12 +32,12 @@ console.log('=== Light Environment Delegated Actions ===');
 const inlineHandlerRe = /\bon(?:click|keydown|change|input|submit|blur|toggle)=/g;
 const directAssignmentRe = /\.(?:onclick|onchange|oninput|onkeydown)\s*=/;
 
-assert('light-env.js has no inline event attributes',
-  !inlineHandlerRe.test(envSrc));
+assert('light environment UI has no inline event attributes',
+  !inlineHandlerRe.test(envUiSrc));
 assert('light-env-audits.js has no inline event attributes',
   !inlineHandlerRe.test(auditSrc));
-assert('light-env.js avoids direct event property assignment',
-  !directAssignmentRe.test(envSrc));
+assert('light environment UI avoids direct event property assignment',
+  !directAssignmentRe.test(envUiSrc));
 assert('light-env.js imports and installs the delegated action helper',
   envSrc.includes("from './light-env-actions.js'") &&
     envSrc.includes('installLightEnvActionDelegates({') &&
@@ -93,8 +95,9 @@ assert('light-env.js captures light audit callbacks when installing delegates',
     envSrc.includes('updateLightAuditField,') &&
     envSrc.includes('deleteLightAuditConfirm,') &&
     envSrc.includes('interpretLightAuditCompare,'));
-assert('service worker precaches light-env-actions.js',
-  swSrc.includes("'/js/light-env-actions.js'"));
+assert('service worker precaches light environment action/render modules',
+  swSrc.includes("'/js/light-env-actions.js'") &&
+    swSrc.includes("'/js/light-env-screen-ui.js'"));
 
 [
   'set-room-source-archetype',
@@ -161,8 +164,8 @@ assert('service worker precaches light-env-actions.js',
   "lightEnvActionAttrs('open-tool', { id: r.id, tool: 'spectrum' })",
   "lightEnvActionAttrs('add-room')",
 ].forEach(renderedAction => {
-  assert(`light-env.js renders ${renderedAction}`,
-    envSrc.includes(renderedAction));
+  assert(`light environment UI renders ${renderedAction}`,
+    envUiSrc.includes(renderedAction));
 });
 
 [
@@ -195,11 +198,11 @@ assert('service worker precaches light-env-actions.js',
   'closeLightEnvironmentAssessment',
   'openLightEnvTool',
 ].forEach(fnName => {
-  assert(`light-env.js has no inline handler ${fnName} call`,
-    !envSrc.includes(`onclick="${fnName}`) &&
-      !envSrc.includes(`onclick="window.${fnName}`) &&
-      !envSrc.includes(`onchange="window.${fnName}`) &&
-      !envSrc.includes(`oninput="window.${fnName}`));
+  assert(`light environment UI has no inline handler ${fnName} call`,
+    !envUiSrc.includes(`onclick="${fnName}`) &&
+      !envUiSrc.includes(`onclick="window.${fnName}`) &&
+      !envUiSrc.includes(`onchange="window.${fnName}`) &&
+      !envUiSrc.includes(`oninput="window.${fnName}`));
 });
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -573,6 +573,7 @@ const {
   ].join('\n');
   assert('Service worker precaches the light environment model module',
     swSrc.includes("'/js/light-env-model.js'") &&
+    swSrc.includes("'/js/light-env-screen-ui.js'") &&
     swSrc.includes("'/js/light-ai-save-hooks.js'"));
   assert('Light assessment is linked from sidebar Analysis tools',
     navSrc.includes("label: 'Light assessment'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.2';
+self.APP_VERSION = '1.10.3';


### PR DESCRIPTION
## Summary
- Move light environment screen-card rendering and screen hour buckets into `js/light-env-screen-ui.js`
- Keep screen expansion state and mutations owned by `js/light-env.js`
- Add the new module to the service worker app shell and source guards
- Bump `APP_VERSION` to `1.10.3`

## Tests
- `node tests/test-light-env.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-light-env-store.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `npm run typecheck`
- `npm run quality`
- `node tests/test-correctness-phase2.js`
- `node tests/test-audit.js`
- `npx playwright test tests/playwright/light-env-browser-coverage.spec.js tests/playwright/light-env-coverage-batch.spec.js`
- `npx playwright test tests/playwright/light-env-actions-browser-coverage.spec.js`
- `./run-tests.sh`