### PR TITLE
Extract recommendation region helpers

### DIFF
--- a/js/recommendations-region.js
+++ b/js/recommendations-region.js
@@ -1,0 +1,84 @@
+// @ts-check
+// recommendations-region.js — region hierarchy and labels for recommendation filtering.
+
+// SINGLE SOURCE OF TRUTH for region semantics. Used by both the product
+// visibility filter (getProductsForSlot) AND the per-region map resolver
+// (_pickRegional, used by vendor.homepage / vendor.coupon / product.url
+// when those are Record<RegionCode, …> shape).
+//
+// The chain represents the lookup order from most-specific (the user's
+// market) to most-generic (worldwide). Both consumers walk the same chain:
+//   - getProductsForSlot: a product matches if any of its regions[] tags
+//     appear anywhere in the chain (visibility = "covers this user")
+//   - _pickRegional: pick the FIRST chain entry that has a key in the map
+//     (specificity = "show me the most-targeted variant available")
+//
+// Hierarchy: country → continent/region → INTL.
+//   CZSK is the multi-country marker for catalogs that serve both CZ + SK
+//   together; it expands to the union of the CZ and SK chains.
+const REGION_HIERARCHY = {
+  CZ:   ['CZ', 'EU', 'INTL'],
+  SK:   ['SK', 'EU', 'INTL'],
+  DE:   ['DE', 'EU', 'INTL'],
+  AT:   ['AT', 'EU', 'INTL'],
+  CZSK: ['CZ', 'SK', 'EU', 'INTL'],
+  EU:   ['EU', 'INTL'],
+  US:   ['US', 'INTL'],
+  INTL: ['INTL'],
+};
+
+// Country name / ISO code → granular region. Names are lowercased before
+// lookup. Anything not in the table falls through to the caller's default.
+// Granular regions matter because the region hierarchy chain treats CZ and
+// SK as siblings under EU — a Slovak user who falls into "CZSK" always gets
+// the CZ URL via the chain walk, never the SK one.
+export const COUNTRY_TO_REGION = {
+  // Czech Republic
+  'cz': 'CZ', 'cze': 'CZ', 'czechia': 'CZ', 'czech republic': 'CZ',
+  'česko': 'CZ', 'cesko': 'CZ', 'česká republika': 'CZ', 'ceska republika': 'CZ',
+  // Slovakia
+  'sk': 'SK', 'svk': 'SK', 'slovakia': 'SK',
+  'slovensko': 'SK', 'slovenská republika': 'SK', 'slovenska republika': 'SK',
+  // German-speaking
+  'de': 'DE', 'deu': 'DE', 'germany': 'DE', 'deutschland': 'DE',
+  'at': 'AT', 'aut': 'AT', 'austria': 'AT',
+  'österreich': 'AT', 'oesterreich': 'AT', 'osterreich': 'AT',
+  // United States
+  'us': 'US', 'usa': 'US', 'u.s.': 'US',
+  'united states': 'US', 'united states of america': 'US',
+  // Other EU member states route to EU (no country-specific affiliate yet)
+  'fr': 'EU', 'france': 'EU',
+  'it': 'EU', 'italy': 'EU', 'italia': 'EU',
+  'es': 'EU', 'spain': 'EU', 'españa': 'EU', 'espana': 'EU',
+  'nl': 'EU', 'netherlands': 'EU', 'nederland': 'EU',
+  'be': 'EU', 'belgium': 'EU',
+  'pl': 'EU', 'poland': 'EU', 'polska': 'EU',
+  'hu': 'EU', 'hungary': 'EU', 'magyarország': 'EU',
+  'pt': 'EU', 'portugal': 'EU',
+  'ie': 'EU', 'ireland': 'EU',
+  'dk': 'EU', 'denmark': 'EU', 'danmark': 'EU',
+  'se': 'EU', 'sweden': 'EU', 'sverige': 'EU',
+  'fi': 'EU', 'finland': 'EU', 'suomi': 'EU',
+};
+
+// Returns the lookup chain for a given region — most-specific first.
+// Unknown regions get [region, INTL] as a graceful fallback.
+export function regionLookupChain(region) {
+  if (!region) return ['INTL'];
+  return REGION_HIERARCHY[region] || [region, 'INTL'];
+}
+
+// Human-readable label for the active region. Shown in the rec-disclosure
+// footer so users know which market's products + URLs they're seeing,
+// since the recs are silently filtered by their profile country.
+const REGION_LABELS = {
+  CZ: 'Czech Republic', SK: 'Slovakia', DE: 'Germany', AT: 'Austria',
+  US: 'United States', EU: 'European Union', INTL: 'worldwide',
+  CZSK: 'Czech Republic + Slovakia',
+};
+
+export function regionLabel(region) {
+  // Unknown ISO codes (UK, AU, BG…) fall back to "worldwide" — better than
+  // showing a raw 2-letter code that looks like a bug to users.
+  return REGION_LABELS[region] || 'worldwide';
+}

--- a/js/recommendations.js
+++ b/js/recommendations.js
@@ -5,6 +5,11 @@ import { escapeAttr, escapeHTML } from './utils.js';
 import { getProfileLocation } from './profile.js';
 import { state } from './state.js';
 import { findGenotypeInfo, findSnpHint } from './dna.js';
+import {
+  COUNTRY_TO_REGION,
+  regionLabel as formatRegionLabel,
+  regionLookupChain as lookupRegionChain,
+} from './recommendations-region.js';
 
 // ═══════════════════════════════════════════════
 // CATALOG CACHE
@@ -108,76 +113,9 @@ export function markDisclosureSeen() {
   localStorage.setItem('labcharts-rec-disclosure', 'seen');
 }
 
-// ═══════════════════════════════════════════════
-// REGION
-// ═══════════════════════════════════════════════
-//
-// SINGLE SOURCE OF TRUTH for region semantics. Used by both the product
-// visibility filter (getProductsForSlot) AND the per-region map resolver
-// (_pickRegional, used by vendor.homepage / vendor.coupon / product.url
-// when those are Record<RegionCode, …> shape).
-//
-// The chain represents the lookup order from most-specific (the user's
-// market) to most-generic (worldwide). Both consumers walk the same chain:
-//   - getProductsForSlot: a product matches if any of its regions[] tags
-//     appear anywhere in the chain (visibility = "covers this user")
-//   - _pickRegional: pick the FIRST chain entry that has a key in the map
-//     (specificity = "show me the most-targeted variant available")
-//
-// Hierarchy: country → continent/region → INTL.
-//   CZSK is the multi-country marker for catalogs that serve both CZ + SK
-//   together; it expands to the union of the CZ and SK chains.
-const REGION_HIERARCHY = {
-  CZ:   ['CZ', 'EU', 'INTL'],
-  SK:   ['SK', 'EU', 'INTL'],
-  DE:   ['DE', 'EU', 'INTL'],
-  AT:   ['AT', 'EU', 'INTL'],
-  CZSK: ['CZ', 'SK', 'EU', 'INTL'],
-  EU:   ['EU', 'INTL'],
-  US:   ['US', 'INTL'],
-  INTL: ['INTL'],
-};
-
-// Returns the lookup chain for a given region — most-specific first.
-// Unknown regions get [region, INTL] as a graceful fallback.
 export function regionLookupChain(region) {
-  if (!region) return ['INTL'];
-  return REGION_HIERARCHY[region] || [region, 'INTL'];
+  return lookupRegionChain(region);
 }
-
-// Country name / ISO code → granular region. Names are lowercased before
-// lookup. Anything not in the table falls through to the heuristic below.
-// Granular regions matter because the new region hierarchy chain treats
-// CZ and SK as siblings under EU — a Slovak user who falls into "CZSK"
-// always gets the CZ URL via the chain walk, never the SK one.
-const COUNTRY_TO_REGION = {
-  // Czech Republic
-  'cz': 'CZ', 'cze': 'CZ', 'czechia': 'CZ', 'czech republic': 'CZ',
-  'česko': 'CZ', 'cesko': 'CZ', 'česká republika': 'CZ', 'ceska republika': 'CZ',
-  // Slovakia
-  'sk': 'SK', 'svk': 'SK', 'slovakia': 'SK',
-  'slovensko': 'SK', 'slovenská republika': 'SK', 'slovenska republika': 'SK',
-  // German-speaking
-  'de': 'DE', 'deu': 'DE', 'germany': 'DE', 'deutschland': 'DE',
-  'at': 'AT', 'aut': 'AT', 'austria': 'AT',
-  'österreich': 'AT', 'oesterreich': 'AT', 'osterreich': 'AT',
-  // United States
-  'us': 'US', 'usa': 'US', 'u.s.': 'US',
-  'united states': 'US', 'united states of america': 'US',
-  // Other EU member states route to EU (no country-specific affiliate yet)
-  'fr': 'EU', 'france': 'EU',
-  'it': 'EU', 'italy': 'EU', 'italia': 'EU',
-  'es': 'EU', 'spain': 'EU', 'españa': 'EU', 'espana': 'EU',
-  'nl': 'EU', 'netherlands': 'EU', 'nederland': 'EU',
-  'be': 'EU', 'belgium': 'EU',
-  'pl': 'EU', 'poland': 'EU', 'polska': 'EU',
-  'hu': 'EU', 'hungary': 'EU', 'magyarország': 'EU',
-  'pt': 'EU', 'portugal': 'EU',
-  'ie': 'EU', 'ireland': 'EU',
-  'dk': 'EU', 'denmark': 'EU', 'danmark': 'EU',
-  'se': 'EU', 'sweden': 'EU', 'sverige': 'EU',
-  'fi': 'EU', 'finland': 'EU', 'suomi': 'EU',
-};
 
 export function getUserRegion() {
   const loc = getProfileLocation();
@@ -787,18 +725,8 @@ function buildProductRow(product, region, slotKey) {
   </div>`;
 }
 
-// Human-readable label for the active region. Shown in the rec-disclosure
-// footer so users know which market's products + URLs they're seeing,
-// since the recs are silently filtered by their profile country.
-const REGION_LABELS = {
-  CZ: 'Czech Republic', SK: 'Slovakia', DE: 'Germany', AT: 'Austria',
-  US: 'United States', EU: 'European Union', INTL: 'worldwide',
-  CZSK: 'Czech Republic + Slovakia',
-};
 export function regionLabel(region) {
-  // Unknown ISO codes (UK, AU, BG…) fall back to "worldwide" — better than
-  // showing a raw 2-letter code that looks like a bug to users.
-  return REGION_LABELS[region] || 'worldwide';
+  return formatRegionLabel(region);
 }
 
 function buildDisclosureFooter() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -225,6 +225,7 @@ const APP_SHELL = [
   '/js/mobile-dashboard.js',
   '/js/views.js',
   '/js/recommendations.js',
+  '/js/recommendations-region.js',
   '/js/crypto.js',
   '/js/backup.js',
   '/js/lab-context.js',

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -37,6 +37,7 @@ globalThis.fetch = async (url, opts) => {
   return _realFetch(url, opts);
 };
   const recSrc = await fetchWithRetry('js/recommendations.js');
+  const recRegionSrc = await fetchWithRetry('js/recommendations-region.js');
   const mainSrc = await fetchWithRetry('js/main.js');
   const chatRenderSrc = await fetchWithRetry('js/chat-render.js');
   const chatSendSrc = await fetchWithRetry('js/chat-send.js');
@@ -72,6 +73,10 @@ globalThis.fetch = async (url, opts) => {
   assert('recommendations.js exports renderRecommendationSection', recSrc.includes('export async function renderRecommendationSection'));
   assert('recommendations.js exports renderRecommendationSectionSync', recSrc.includes('export function renderRecommendationSectionSync'));
   assert('recommendations.js exports detectSupplementSlots', recSrc.includes('export function detectSupplementSlots'));
+  assert('recommendations-region.js owns region hierarchy data',
+    recRegionSrc.includes('REGION_HIERARCHY') &&
+    recRegionSrc.includes('COUNTRY_TO_REGION') &&
+    recSrc.includes("from './recommendations-region.js'"));
 
   // ═══════════════════════════════════════
   // 2. Window exports
@@ -279,6 +284,7 @@ globalThis.fetch = async (url, opts) => {
   console.log('%c 12. Infrastructure ', 'font-weight:bold;color:#f59e0b');
 
   assert('SW includes recommendations.js', swSrc.includes('/js/recommendations.js'));
+  assert('SW includes recommendations-region.js', swSrc.includes('/js/recommendations-region.js'));
   assert('SW includes recommendation-actions.js', swSrc.includes('/js/recommendation-actions.js'));
   assert('SW includes dashboard-recommendation-widget.js', swSrc.includes('/js/dashboard-recommendation-widget.js'));
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.3';
+self.APP_VERSION = '1.10.4';


### PR DESCRIPTION
## Summary
- Move recommendation region hierarchy, country mapping, and labels into `js/recommendations-region.js`
- Keep the existing `recommendations.js` public exports as compatibility wrappers
- Add the new module to the service worker app shell and source-level recommendation coverage
- Bump `version.js` to `1.10.4`

## Tests
- `node tests/test-recommendations.js`
- `node tests/test-emf.js`
- `node tests/test-dna-recommendations.js`
- `npm run typecheck`
- `npm run quality`
- `node tests/test-correctness-phase2.js`
- `node tests/test-audit.js`
- `npx playwright test tests/playwright/recommendations-browser-coverage.spec.js`
- `./run-tests.sh`