### PR TITLE
Extract PDF import AI utilities

### DIFF
--- a/js/pdf-import-ai-utils.js
+++ b/js/pdf-import-ai-utils.js
@@ -1,0 +1,90 @@
+// @ts-check
+// pdf-import-ai-utils.js - AI request retry, JSON parsing, and accounting helpers.
+
+import { callClaudeAPI, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
+import { isDebugMode } from './utils.js';
+
+/**
+ * @typedef {{
+ *   inputTokens?: number,
+ *   outputTokens?: number
+ * }} ImportUsage
+ */
+
+export function isAIStreamAbortError(err) {
+  const message = String(err?.message || err || '').toLowerCase();
+  const name = String(err?.name || '').toLowerCase();
+  return message.includes('bodystreambuffer was aborted')
+    || message.includes('aborted by user')
+    || (message.includes('body') && message.includes('stream') && message.includes('abort'))
+    || name === 'aborterror';
+}
+
+export async function callImportAIWithStreamFallback(request, label) {
+  try {
+    return await callClaudeAPI(request);
+  } catch (err) {
+    if (!request.onStream || request.signal?.aborted || !isAIStreamAbortError(err)) throw err;
+    if (isDebugMode()) console.warn(`[Import] ${label} stream aborted; retrying without streaming`, err);
+    try {
+      return await callClaudeAPI({ ...request, onStream: undefined, forceNonStream: true, requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS });
+    } catch (retryErr) {
+      if (isAIStreamAbortError(retryErr)) {
+        throw new Error('AI analysis request was aborted after retrying without streaming. The PDF text extracted correctly; try another model/provider if this persists.');
+      }
+      throw retryErr;
+    }
+  }
+}
+
+export function formatImportError(err) {
+  if (isAIStreamAbortError(err)) {
+    return 'AI analysis request was interrupted after privacy review. Try again, or switch provider/model if it repeats.';
+  }
+  return err?.message || String(err);
+}
+
+export function getUsageTokens(usage) {
+  const u = /** @type {ImportUsage} */ (usage || {});
+  return {
+    inputTokens: Number(u.inputTokens) || 0,
+    outputTokens: Number(u.outputTokens) || 0,
+  };
+}
+
+export function tryParseJSON(str) {
+  try { return JSON.parse(str); } catch {}
+  // Try trimming to last complete object (handles truncated output)
+  const lastBrace = str.lastIndexOf('}');
+  if (lastBrace > 0 && lastBrace < str.length - 1) {
+    try { return JSON.parse(str.slice(0, lastBrace + 1)); } catch {}
+  }
+  // Attempt to repair truncated JSON from local models
+  let s = str;
+  // Close any unterminated string
+  const quotes = (s.match(/"/g) || []).length;
+  if (quotes % 2 !== 0) s += '"';
+  // Try closing open arrays and objects
+  const opens = { '{': 0, '[': 0 };
+  let inString = false;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '"' && (i === 0 || s[i - 1] !== '\\')) { inString = !inString; continue; }
+    if (inString) continue;
+    if (s[i] === '{') opens['{']++;
+    if (s[i] === '}') opens['{']--;
+    if (s[i] === '[') opens['[']++;
+    if (s[i] === ']') opens['[']--;
+  }
+  // Remove trailing comma before closing
+  s = s.replace(/,\s*$/, '');
+  // Close unclosed brackets/braces
+  for (let i = 0; i < opens['[']; i++) s += ']';
+  for (let i = 0; i < opens['{']; i++) s += '}';
+  try {
+    const result = JSON.parse(s);
+    if (isDebugMode()) console.log('[PDF Parse] Repaired truncated JSON from model');
+    return result;
+  } catch (e2) {
+    throw new Error(`Model returned invalid JSON that could not be repaired. Try a more capable model.`);
+  }
+}

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -5,13 +5,19 @@ import { state } from './state.js';
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS, calculateCost, trackUsage } from './schema.js';
 import { showNotification, showConfirmDialog, isDebugMode, isPIIReviewEnabled, hashString } from './utils.js';
 import { saveImportedData } from './data.js';
-import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
+import { hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEOUT_MS } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
 import { setLabEntryMarker, syncLabEntryInsulinMirror } from './lab-entry.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import {
+  callImportAIWithStreamFallback,
+  formatImportError,
+  getUsageTokens,
+  tryParseJSON,
+} from './pdf-import-ai-utils.js';
 import { extractXLSXText, isCsvTextFile, isTextImportFile, isXlsxFile } from './pdf-import-spreadsheet.js';
 import { runPreflightChecks } from './pdf-import-preflight.js';
 import { normalizeParsedImportMarkers } from './pdf-import-marker-normalization.js';
@@ -64,12 +70,12 @@ import {
  *   handleMtDNAFile?: (file: File) => void | Promise<void>,
  *   handleDNAFile: (file: File) => void | Promise<void>,
  * }} PdfImportWindowHooks
- * @typedef {{ inputTokens?: number, outputTokens?: number }} ImportUsage
  */
 
 const pdfImportWindow = /** @type {Window & typeof globalThis & PdfImportWindowHooks} */ (window);
 
 export { buildMarkerReference, reconcileImportMarkerMappings } from './pdf-import-marker-mapping.js';
+export { tryParseJSON } from './pdf-import-ai-utils.js';
 export { extractXLSXText } from './pdf-import-spreadsheet.js';
 export {
   showImportPreview,
@@ -220,84 +226,6 @@ async function readFileArrayBuffer(file) {
       reader.onabort = () => reject(firstError);
       reader.readAsArrayBuffer(file);
     });
-  }
-}
-
-function isAIStreamAbortError(err) {
-  const message = String(err?.message || err || '').toLowerCase();
-  const name = String(err?.name || '').toLowerCase();
-  return message.includes('bodystreambuffer was aborted')
-    || message.includes('aborted by user')
-    || (message.includes('body') && message.includes('stream') && message.includes('abort'))
-    || name === 'aborterror';
-}
-
-async function callImportAIWithStreamFallback(request, label) {
-  try {
-    return await callClaudeAPI(request);
-  } catch (err) {
-    if (!request.onStream || request.signal?.aborted || !isAIStreamAbortError(err)) throw err;
-    if (isDebugMode()) console.warn(`[Import] ${label} stream aborted; retrying without streaming`, err);
-    try {
-      return await callClaudeAPI({ ...request, onStream: undefined, forceNonStream: true, requestTimeoutMs: AI_IMPORT_REQUEST_TIMEOUT_MS });
-    } catch (retryErr) {
-      if (isAIStreamAbortError(retryErr)) {
-        throw new Error('AI analysis request was aborted after retrying without streaming. The PDF text extracted correctly; try another model/provider if this persists.');
-      }
-      throw retryErr;
-    }
-  }
-}
-
-function formatImportError(err) {
-  if (isAIStreamAbortError(err)) {
-    return 'AI analysis request was interrupted after privacy review. Try again, or switch provider/model if it repeats.';
-  }
-  return err?.message || String(err);
-}
-
-function getUsageTokens(usage) {
-  const u = /** @type {ImportUsage} */ (usage || {});
-  return {
-    inputTokens: Number(u.inputTokens) || 0,
-    outputTokens: Number(u.outputTokens) || 0,
-  };
-}
-
-export function tryParseJSON(str) {
-  try { return JSON.parse(str); } catch {}
-  // Try trimming to last complete object (handles truncated output)
-  const lastBrace = str.lastIndexOf('}');
-  if (lastBrace > 0 && lastBrace < str.length - 1) {
-    try { return JSON.parse(str.slice(0, lastBrace + 1)); } catch {}
-  }
-  // Attempt to repair truncated JSON from local models
-  let s = str;
-  // Close any unterminated string
-  const quotes = (s.match(/"/g) || []).length;
-  if (quotes % 2 !== 0) s += '"';
-  // Try closing open arrays and objects
-  const opens = { '{': 0, '[': 0 };
-  let inString = false;
-  for (let i = 0; i < s.length; i++) {
-    if (s[i] === '"' && (i === 0 || s[i - 1] !== '\\')) { inString = !inString; continue; }
-    if (inString) continue;
-    if (s[i] === '{') opens['{']++;
-    if (s[i] === '}') opens['{']--;
-    if (s[i] === '[') opens['[']++;
-    if (s[i] === ']') opens['[']--;
-  }
-  // Remove trailing comma before closing
-  s = s.replace(/,\s*$/, '');
-  // Close unclosed brackets/braces
-  for (let i = 0; i < opens['[']; i++) s += ']';
-  for (let i = 0; i < opens['{']; i++) s += '}';
-  try {
-    const result = JSON.parse(s);
-    if (isDebugMode()) console.log('[PDF Parse] Repaired truncated JSON from model');
-    return result;
-  } catch (e2) {
-    throw new Error(`Model returned invalid JSON that could not be repaired. Try a more capable model.`);
   }
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -125,6 +125,7 @@ const APP_SHELL = [
   '/js/pdf-import-spreadsheet.js',
   '/js/pdf-import-preflight.js',
   '/js/pdf-import-progress.js',
+  '/js/pdf-import-ai-utils.js',
   '/js/pdf-import-review.js',
   '/js/pdf-import-marker-mapping.js',
   '/js/pdf-import-marker-normalization.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -79,6 +79,7 @@ assert('SW APP_SHELL includes PDF import support modules',
   swAuditSrc.includes("'/js/pdf-import-spreadsheet.js'")
   && swAuditSrc.includes("'/js/pdf-import-preflight.js'")
   && swAuditSrc.includes("'/js/pdf-import-progress.js'")
+  && swAuditSrc.includes("'/js/pdf-import-ai-utils.js'")
   && swAuditSrc.includes("'/js/pdf-import-marker-normalization.js'")
   && swAuditSrc.includes("'/js/pdf-import-persistence.js'"));
 assert('SW APP_SHELL includes context card summary module', swAuditSrc.includes("'/js/context-card-summaries.js'"));

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -21,6 +21,7 @@ function assert(name, condition, detail) {
 console.log('=== Unit Normalization on Import Tests ===\n');
 
 const src = read('js/pdf-import.js');
+const aiUtilsSrc = read('js/pdf-import-ai-utils.js');
 const exportSrc = read('js/export.js');
 const mappingSrc = read('js/pdf-import-marker-mapping.js');
 const normalizationSrc = read('js/pdf-import-marker-normalization.js');
@@ -282,6 +283,9 @@ const settingsDataSrc = read('js/settings-data.js');
   assert('pdf-import exports reconcileImportMarkerMappings',
     /export\s*\{[^}]*reconcileImportMarkerMappings[^}]*\}\s*from\s*['"]\.\/pdf-import-marker-mapping\.js['"]/.test(src)
     && /export function reconcileImportMarkerMappings/.test(mappingSrc));
+  assert('pdf-import re-exports tryParseJSON from AI utils',
+    /export\s*\{[^}]*tryParseJSON[^}]*\}\s*from\s*['"]\.\/pdf-import-ai-utils\.js['"]/.test(src)
+    && /export function tryParseJSON/.test(aiUtilsSrc));
   assert('pdf-import imports existing marker key lookup from mapping module',
     src.includes('getExistingImportMarkerKeys') && !src.includes('_getExistingImportMarkerKeys'));
   assert('Czech/Spadia alias table includes key labels',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -426,24 +426,25 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   console.log('%c 15. PDF import inherits stream + request timeouts ', 'font-weight:bold;color:#0891b2');
   {
     const pdfSrc = await fetchSrc('js/pdf-import.js');
-    // PDF import calls callClaudeAPI (imported from api.js) which routes
+    const pdfAiUtilsSrc = await fetchSrc('js/pdf-import-ai-utils.js');
+    // PDF import calls callClaudeAPI through its AI helper, which routes
     // through _fetchWithRetry and the streaming helpers. We don't
     // duplicate the timeout logic here, just confirm the import + call
     // sites exist so a future refactor doesn't accidentally bypass them.
-    assert('pdf-import.js: imports callClaudeAPI from api.js',
-      /import\s*\{[^}]*callClaudeAPI[^}]*\}\s*from\s*['"]\.\/api\.js['"]/.test(pdfSrc));
-    assert('pdf-import.js: imports import-specific AI timeout from api.js',
-      /import\s*\{[^}]*AI_IMPORT_REQUEST_TIMEOUT_MS[^}]*\}\s*from\s*['"]\.\/api\.js['"]/.test(pdfSrc));
-    assert('pdf-import.js: import AI fallback calls callClaudeAPI',
-      /function\s+callImportAIWithStreamFallback[\s\S]+?callClaudeAPI\(/.test(pdfSrc));
-    assert('pdf-import.js: retries aborted AI import streams without streaming',
-      /function\s+isAIStreamAbortError/.test(pdfSrc)
-      && /aborted by user/.test(pdfSrc)
-      && /name\s*===\s*['"]aborterror['"]/.test(pdfSrc)
-      && /function\s+callImportAIWithStreamFallback/.test(pdfSrc)
-      && /onStream:\s*undefined/.test(pdfSrc)
-      && /forceNonStream:\s*true/.test(pdfSrc)
-      && /requestTimeoutMs:\s*AI_IMPORT_REQUEST_TIMEOUT_MS/.test(pdfSrc)
+    assert('pdf-import-ai-utils.js: imports callClaudeAPI from api.js',
+      /import\s*\{[^}]*callClaudeAPI[^}]*\}\s*from\s*['"]\.\/api\.js['"]/.test(pdfAiUtilsSrc));
+    assert('pdf-import-ai-utils.js: imports import-specific AI timeout from api.js',
+      /import\s*\{[^}]*AI_IMPORT_REQUEST_TIMEOUT_MS[^}]*\}\s*from\s*['"]\.\/api\.js['"]/.test(pdfAiUtilsSrc));
+    assert('pdf-import-ai-utils.js: import AI fallback calls callClaudeAPI',
+      /function\s+callImportAIWithStreamFallback[\s\S]+?callClaudeAPI\(/.test(pdfAiUtilsSrc));
+    assert('pdf-import-ai-utils.js: retries aborted AI import streams without streaming',
+      /function\s+isAIStreamAbortError/.test(pdfAiUtilsSrc)
+      && /aborted by user/.test(pdfAiUtilsSrc)
+      && /name\s*===\s*['"]aborterror['"]/.test(pdfAiUtilsSrc)
+      && /function\s+callImportAIWithStreamFallback/.test(pdfAiUtilsSrc)
+      && /onStream:\s*undefined/.test(pdfAiUtilsSrc)
+      && /forceNonStream:\s*true/.test(pdfAiUtilsSrc)
+      && /requestTimeoutMs:\s*AI_IMPORT_REQUEST_TIMEOUT_MS/.test(pdfAiUtilsSrc)
       && /parseLabPDFWithAI[\s\S]+?callImportAIWithStreamFallback/.test(pdfSrc));
     assert('pdf-import.js: catch path closes the import modal on error',
       /catch\s*\([^)]+\)\s*\{[\s\S]{0,500}hideImportProgress\('error'\)/.test(pdfSrc));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.4';
+self.APP_VERSION = '1.10.5';


### PR DESCRIPTION
## Summary
- Move PDF import AI stream-retry, JSON repair, error formatting, and token accounting helpers into `js/pdf-import-ai-utils.js`
- Keep `pdf-import.js` public `tryParseJSON` export stable via re-export
- Add the helper module to the service worker app shell and source-level guards
- Bump `version.js` to `1.10.5`

## Tests
- `npm run typecheck`
- `node tests/test-unit-import.js`
- `node tests/test-audit.js`
- `npm run quality`
- `git diff --check`
- `./run-tests.sh`