### PR TITLE
Import lab reports as per-file snapshots

### DIFF
--- a/css/import.css
+++ b/css/import.css
@@ -981,8 +981,12 @@ select.import-unit-input {
     padding: 12px;
   }
   .import-review-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 3;
     padding: 12px;
     flex-wrap: wrap;
+    box-shadow: 0 -8px 18px color-mix(in srgb, var(--bg-primary) 14%, transparent);
   }
   .import-review-actions .import-btn {
     flex: 1 1 calc(50% - 5px);

--- a/css/settings.css
+++ b/css/settings.css
@@ -359,14 +359,21 @@
 
 /* Imported data entries */
 .imported-entry {
-  display: flex; align-items: center; justify-content: space-between;
+  display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px; align-items: center;
   padding: 10px 16px; background: var(--bg-card); border: 1px solid var(--border);
   border-radius: var(--radius-sm); margin-bottom: 6px; font-size: 13px;
 }
-.imported-entry .ie-info { color: var(--text-secondary); }
+.imported-entry .ie-info { min-width: 0; color: var(--text-secondary); }
+.imported-entry .ie-mainline { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+.imported-entry .ie-meta { display: flex; align-items: center; gap: 8px; min-width: 0; margin-top: 3px; color: var(--text-muted); font-size: 11px; line-height: 1.35; }
+.imported-entry .ie-file,
+.imported-entry .ie-model { min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.imported-entry .ie-file { max-width: min(320px, 45vw); }
+.imported-entry .ie-model { max-width: min(260px, 35vw); }
+.imported-entry .ie-type { flex: 0 0 auto; font-size: 10px; letter-spacing: 0.04em; text-transform: uppercase; }
 .imported-entry .ie-date { color: var(--text-primary); font-weight: 500; }
-.imported-entry .ie-count { color: var(--text-muted); margin-left: 8px; }
-.imported-entry .ie-actions { display: flex; align-items: center; gap: 4px; }
+.imported-entry .ie-count { flex: 0 0 auto; color: var(--text-muted); }
+.imported-entry .ie-actions { display: flex; align-items: center; gap: 4px; justify-content: flex-end; }
 .imported-entry .ie-remove,
 .imported-entry .ie-edit {
   background: none; border: none; color: var(--text-muted); cursor: pointer;
@@ -374,6 +381,13 @@
 }
 .imported-entry .ie-remove:hover { color: var(--red); background: var(--red-bg); }
 .imported-entry .ie-edit:hover { color: var(--text-primary); background: var(--bg-hover); }
+@media (max-width: 640px) {
+  .imported-entry { grid-template-columns: 1fr; align-items: stretch; padding: 12px; }
+  .imported-entry .ie-meta { flex-wrap: wrap; }
+  .imported-entry .ie-file,
+  .imported-entry .ie-model { max-width: 100%; }
+  .imported-entry .ie-actions { justify-content: flex-start; flex-wrap: wrap; }
+}
 
 /* Settings sections */
 .settings-section { margin-top: 16px; }

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -10,6 +10,15 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.6', date: '2026-06-21', title: 'Per-file lab import storage',
+    forceShow: true,
+    items: [
+      '<b>Lab imports are now stored per file.</b> Each imported report gets its own saved import record, so you can review, edit, or delete one report without disturbing another report from the same lab date.',
+      '<b>Same-day reports are easier to manage.</b> If two PDFs share a date or overlap on a marker, getbased keeps the report history visible in Settings → Data and preserves the latest live values safely.',
+      '<b>Upgrade note for existing imports.</b> Reports imported before this release were saved in the older date-based storage. To move an old report into the new per-file storage, import that report again.',
+    ]
+  },
+  {
     version: '1.9.0', date: '2026-06-19', title: 'Biology Scores and Biological Coherence',
     items: [
       '<b>A new lens on your biology.</b> Biology Scores turn your labs into plain-English system patterns across metabolism, thyroid, cardiovascular health, inflammation, methylation, kidney and hydration, liver and bile flow, iron and blood health, hormones, stress resilience, cellular energy, gut-immune terrain, and more.',

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -105,6 +105,7 @@ const TIMESTAMP_FIELDS = [
   'savedAt',
   'loggedAt',
   'createdAt',
+  'importedAt',
   'addedAt',
   'at',
 ];

--- a/js/export.js
+++ b/js/export.js
@@ -8,6 +8,7 @@ import { getProfiles, profileStorageKey, createProfile, updateProfileMeta, loadP
 import { encryptedGetItem, encryptedSetItem, getEncryptionEnabled, encryptedRemoveItem } from './crypto.js';
 import {
   appendImportedArrayItem,
+  clearTombstone,
   ensureImportedArray,
   replaceImportedArrayItem,
   sortImportedArray,
@@ -239,7 +240,8 @@ export async function buildClientExportObject(profileId, includeChat = false) {
     lifelightProfile: data.lifelightProfile || null,
     lightDailyVerdicts: data.lightDailyVerdicts || null,
     channelMixAI: data.channelMixAI || null,
-    biologyScoreContextAI: data.biologyScoreContextAI || null
+    biologyScoreContextAI: data.biologyScoreContextAI || null,
+    importSnapshots: data.importSnapshots || []
   };
   if (includeChat) {
     const chat = await _exportChatData(profileId);
@@ -725,6 +727,26 @@ export function importDataJSON(file) {
           if (!exists) appendImportedArrayItem(state.importedData, 'notes', { date: note.date, text: note.text });
         }
       }
+      // Import import snapshots (issue #39)
+      if (Array.isArray(json.importSnapshots)) {
+        if (!state.importedData.importSnapshots) state.importedData.importSnapshots = [];
+        for (const snap of json.importSnapshots) {
+          if (snap && snap.id) {
+            clearTombstone(state.importedData, 'importSnapshots', snap.id);
+            const idx = state.importedData.importSnapshots.findIndex(s => s.id === snap.id);
+            if (idx >= 0) {
+              const existingAt = Number(state.importedData.importSnapshots[idx]?.importedAt) || 0;
+              const incomingAt = Number(snap.importedAt) || 0;
+              if (incomingAt >= existingAt) state.importedData.importSnapshots[idx] = snap;
+            } else {
+              state.importedData.importSnapshots.push(snap);
+            }
+          }
+        }
+        // Sort by importedAt descending (newest first)
+        state.importedData.importSnapshots.sort((a, b) => (b.importedAt || 0) - (a.importedAt || 0));
+      }
+
       migrateProfileData(state.importedData);
       saveImportedData((/** @type {any} */ (globalThis))._demoLoadingProfileId === state.currentProfile
         ? { skipSync: true, reason: 'demo-import' }
@@ -858,6 +880,24 @@ async function _importDatabaseBundle(json) {
           else { appendImportedArrayItem(current, 'chatSummaries', s); }
         }
       }
+      // Import snapshots: merge by stable snapshot id
+      if (Array.isArray(importData.importSnapshots)) {
+        const importSnapshots = ensureImportedArray(current, 'importSnapshots');
+        for (const snap of importData.importSnapshots) {
+          if (snap?.id) {
+            clearTombstone(current, 'importSnapshots', snap.id);
+            const idx = importSnapshots.findIndex(s => s.id === snap.id);
+            if (idx >= 0) {
+              const existingAt = Number(importSnapshots[idx]?.importedAt) || 0;
+              const incomingAt = Number(snap.importedAt) || 0;
+              if (incomingAt >= existingAt) replaceImportedArrayItem(current, 'importSnapshots', idx, snap);
+            } else {
+              appendImportedArrayItem(current, 'importSnapshots', snap);
+            }
+          }
+        }
+        sortImportedArray(current, 'importSnapshots', (a, b) => (b.importedAt || 0) - (a.importedAt || 0));
+      }
       // Display overrides: merge labels/icons/manualValues (don't overwrite existing)
       for (const field of ['categoryLabels', 'categoryIcons', 'markerLabels', 'manualValues']) {
         if (importData[field] && typeof importData[field] === 'object') {
@@ -956,7 +996,7 @@ export async function clearAllData() {
     const defaultId = profiles[0]?.id || 'default';
     const defaultName = profiles[0]?.name || 'Profile 1';
     saveProfiles([{ id: defaultId, name: defaultName, sex: null, dob: null, location: { country: '', zip: '' }, tags: [], notes: '', status: 'active', avatar: null, height: null, heightUnit: 'cm', createdAt: Date.now(), lastUpdated: Date.now(), pinned: false }]);
-    state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, diet: null, exercise: null, sleepRest: null, lightCircadian: null, stress: null, loveLife: null, environment: null, interpretiveLens: '', contextNotes: '', customMarkers: {}, refOverrides: {}, menstrualCycle: null, emfAssessment: null, genetics: null, biometrics: null, markerNotes: {}, markerValueNotes: {}, biologyScoreAI: {}, changeHistory: [] };
+    state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, diet: null, exercise: null, sleepRest: null, lightCircadian: null, stress: null, loveLife: null, environment: null, interpretiveLens: '', contextNotes: '', customMarkers: {}, refOverrides: {}, menstrualCycle: null, emfAssessment: null, genetics: null, biometrics: null, markerNotes: {}, markerValueNotes: {}, biologyScoreAI: {}, changeHistory: [], importSnapshots: [] };
     state.currentProfile = defaultId;
     localStorage.setItem('labcharts-active-profile', defaultId);
     // Clear Cashu wallet database

--- a/js/lab-entry.js
+++ b/js/lab-entry.js
@@ -52,6 +52,21 @@ export function recalculateLabEntryHOMAIR(entry) {
   const insulin = entry.markers['hormones.insulin'] ?? entry.markers['diabetes.insulin_d'];
   if (glucose !== undefined && insulin !== undefined) {
     entry.markers['diabetes.homaIR'] = Math.round((glucose * insulin) / 22.5 * 100) / 100;
+    const glucoseSource = entry.markerSources?.['biochemistry.glucose'];
+    const insulinSource = entry.markerSources?.['hormones.insulin'] ?? entry.markerSources?.['diabetes.insulin_d'];
+    const sharedSnapshotId = glucoseSource?.snapshotId && glucoseSource.snapshotId === insulinSource?.snapshotId
+      ? glucoseSource.snapshotId
+      : null;
+    if (sharedSnapshotId) {
+      ensureMarkerSources(entry)['diabetes.homaIR'] = {
+        file: glucoseSource.file || insulinSource.file || null,
+        at: Math.max(normalizeTimestamp(glucoseSource.at) || 0, normalizeTimestamp(insulinSource.at) || 0) || Date.now(),
+        snapshotId: sharedSnapshotId,
+        derivedFrom: ['biochemistry.glucose', insulinSource === entry.markerSources?.['hormones.insulin'] ? 'hormones.insulin' : 'diabetes.insulin_d'],
+      };
+    } else if (entry.markerSources) {
+      delete entry.markerSources['diabetes.homaIR'];
+    }
   } else {
     delete entry.markers['diabetes.homaIR'];
     if (entry.markerSources) delete entry.markerSources['diabetes.homaIR'];
@@ -62,6 +77,13 @@ export function labEntryMarkerAffectsHOMAIR(dotKey) {
   return dotKey === 'biochemistry.glucose'
     || dotKey === 'hormones.insulin'
     || dotKey === 'diabetes.insulin_d';
+}
+
+export function isSnapshotDerivedHOMAIR(entry, dotKey) {
+  if (dotKey !== 'diabetes.homaIR') return false;
+  const glucoseSource = entry?.markerSources?.['biochemistry.glucose'];
+  const insulinSource = entry?.markerSources?.['hormones.insulin'] ?? entry?.markerSources?.['diabetes.insulin_d'];
+  return !!(glucoseSource?.snapshotId && glucoseSource.snapshotId === insulinSource?.snapshotId);
 }
 
 function affectsHOMAIR(dotKey, keys = []) {

--- a/js/pdf-import-persistence.js
+++ b/js/pdf-import-persistence.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { showNotification, showPromptDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import { clearTombstone, deleteImportedArrayItems, recordTombstone } from './data-merge.js';
+import { deleteLabEntryMarker, isSnapshotDerivedHOMAIR } from './lab-entry.js';
 
 export function snapshotImportedData() {
   try { return JSON.stringify(state.importedData || {}); } catch { return null; }
@@ -31,18 +32,49 @@ function isValidISOCalendarDate(date) {
     && parsed.getUTCDate() === day;
 }
 
+
 export async function removeImportedEntry(date) {
   if (!date) return false;
+  const entries = state.importedData?.entries || [];
+  const entry = entries.find(e => e.date === date);
+  if (!entry) return false;
   const rollback = snapshotImportedData();
-  recordTombstone(state.importedData, 'entries', date);
-  deleteImportedArrayItems(state.importedData, 'entries', e => e.date === date);
+  const now = Date.now();
+  const markerKeys = Object.keys(entry.markers || {});
+  let removedCount = 0;
+  const removedKeys = markerKeys.filter(k => {
+    if (isSnapshotDerivedHOMAIR(entry, k)) return false;
+    const src = entry.markerSources?.[k];
+    return !src || !src.snapshotId;
+  });
+  // Only delete markers NOT tagged with a snapshotId (legacy/manual markers)
+  if (removedKeys.length > 0) {
+    for (const k of removedKeys) {
+      const result = deleteLabEntryMarker(entry, k, { now, mirrorInsulin: true });
+      if (result.changed) removedCount++;
+    }
+  }
+  // Delete manual values only for markers that were actually removed
+  const manualValues = state.importedData.manualValues || {};
+  for (const k of Object.keys(manualValues)) {
+    if (k.endsWith(':' + date) && removedKeys.includes(k.split(':')[0])) {
+      delete manualValues[k];
+    }
+  }
+  // If no markers remain, delete the whole entry; otherwise keep it for remaining snapshots
+  if (Object.keys(entry.markers).length === 0) {
+    recordTombstone(state.importedData, 'entries', date);
+    deleteImportedArrayItems(state.importedData, 'entries', e => e.date === date);
+  } else {
+    entry.updatedAt = now;
+  }
   const saved = await saveImportedData({ immediate: true });
   if (!saved) {
     restoreImportedDataSnapshot(rollback);
     return false;
   }
   refreshImportedDataViews();
-  showNotification(`Removed imported data from ${date}`, 'info');
+  showNotification(`Removed ${removedCount} marker${removedCount !== 1 ? 's' : ''} from ${date}`, 'info');
   return true;
 }
 
@@ -50,6 +82,15 @@ export async function renameImportedEntryDate(oldDate) {
   const entries = state.importedData?.entries;
   const entry = entries?.find(e => e.date === oldDate);
   if (!entry) return false;
+  // Prevent renaming entries that contain snapshot-tagged markers — use Review & Edit on the snapshot instead
+  const hasSnapshotMarkers = Object.keys(entry.markers || {}).some(k => {
+    const src = entry.markerSources?.[k];
+    return !!src?.snapshotId;
+  });
+  if (hasSnapshotMarkers) {
+    showNotification('Entries with AI-imported markers cannot be renamed from here. Use Review & Edit on the import snapshot.', 'error', 5000);
+    return false;
+  }
   const newDate = await showPromptDialog(
     `Edit collection date (was ${oldDate})`,
     { defaultValue: oldDate, inputType: 'date', okLabel: 'Save' }

--- a/js/pdf-import-review.js
+++ b/js/pdf-import-review.js
@@ -558,7 +558,7 @@ export function showImportPreview(parseResult) {
     html += `<div class="privacy-notice privacy-notice-warning">&#128274; ${parseResult.privacyReplacements} personal detail${parseResult.privacyReplacements !== 1 ? 's' : ''} replaced with fake data`;
     html += '<span class="privacy-notice-detail">Set up Local AI in Settings for comprehensive language-aware protection</span></div>';
   }
-  if (parseResult.costInfo) {
+  if (parseResult.costInfo && typeof parseResult.costInfo.cost === 'number') {
     const ci = parseResult.costInfo;
     const totalTokens = (ci.inputTokens || 0) + (ci.outputTokens || 0);
     const modelLabel = ci.provider === 'ollama' ? getOllamaMainModel() : ci.provider === 'venice' ? getVeniceModelDisplay() : ci.provider === 'openrouter' ? getOpenRouterModelDisplay() : getActiveModelDisplay();
@@ -579,10 +579,13 @@ export function showImportPreview(parseResult) {
 
   const cancelLabel = batchCtx ? 'Skip' : 'Cancel';
   const importDisabled = !date ? ' disabled' : '';
+  const confirmLabel = parseResult._reReviewSnapshotId
+    ? `Update Import (${importCount} Marker${importCount !== 1 ? 's' : ''})`
+    : `Import ${importCount} Marker${importCount !== 1 ? 's' : ''}`;
   html += `</div>
     <div class="import-review-actions">
       <button type="button" class="import-btn import-btn-secondary" ${importReviewActionAttrs('close')}>${cancelLabel}</button>
-      <button type="button" class="import-btn import-btn-primary" id="import-confirm-btn" ${importReviewActionAttrs('confirm')}${importDisabled}>Import ${importCount} Marker${importCount !== 1 ? 's' : ''}</button>
+      <button type="button" class="import-btn import-btn-primary" id="import-confirm-btn" ${importReviewActionAttrs('confirm')}${importDisabled}>${confirmLabel}</button>
     </div>`;
   if (!parseResult._importProfileId) parseResult._importProfileId = state.currentProfile;
   window._pendingImport = parseResult;
@@ -696,7 +699,9 @@ function updateImportConfirmCount() {
   const excludedIdxs = getExcludedImportIndices();
   const importCount = result.markers.filter((m, i) => (m.matched || (!m.matched && m.suggestedKey)) && !excludedIdxs.has(i)).length;
   const btn = document.getElementById('import-confirm-btn');
-  if (btn) btn.textContent = `Import ${importCount} Marker${importCount !== 1 ? 's' : ''}`;
+  if (btn) btn.textContent = result._reReviewSnapshotId
+    ? `Update Import (${importCount} Marker${importCount !== 1 ? 's' : ''})`
+    : `Import ${importCount} Marker${importCount !== 1 ? 's' : ''}`;
 }
 
 /** @param {HTMLElement} btn */

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -10,7 +10,7 @@ import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, chec
 import { getPdfDocument } from './pdfjs-loader.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
-import { setLabEntryMarker, syncLabEntryInsulinMirror } from './lab-entry.js';
+import { deleteLabEntryMarker, setLabEntryMarker, syncLabEntryInsulinMirror } from './lab-entry.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   callImportAIWithStreamFallback,
@@ -25,9 +25,10 @@ import {
   refreshImportedDataViews,
   removeImportedEntry,
   renameImportedEntryDate,
-  restoreImportedDataSnapshot,
   snapshotImportedData,
+  restoreImportedDataSnapshot,
 } from './pdf-import-persistence.js';
+import { clearTombstone, deleteImportedArrayItems, recordTombstone } from './data-merge.js';
 import {
   handleImportStatusClick,
   hideImportProgress,
@@ -389,6 +390,50 @@ export async function confirmImport() {
     return;
   }
   const importTs = Date.now();
+  const isReReview = !!result._reReviewSnapshotId;
+  const snapshotId = isReReview ? result._reReviewSnapshotId : ('snap_' + importTs + '_' + Math.random().toString(36).slice(2, 6));
+
+  // Re-review: remove old snapshot markers before re-applying
+  if (isReReview) {
+    const oldSnapshot = state.importedData.importSnapshots?.find(s => s.id === snapshotId);
+    if (oldSnapshot) {
+      const oldEntry = state.importedData.entries?.find(e => e.date === oldSnapshot.date);
+      if (oldEntry?.markers) {
+        const removedKeys = [];
+        for (const key of Object.keys(oldEntry.markers)) {
+          const src = oldEntry.markerSources?.[key];
+          if (src?.snapshotId === snapshotId) {
+            deleteLabEntryMarker(oldEntry, key, { now: importTs, mirrorInsulin: true });
+            removedKeys.push(key);
+          }
+        }
+        const manualValues = state.importedData.manualValues || {};
+        for (const k of Object.keys(manualValues)) {
+          if (k.endsWith(':' + oldSnapshot.date) && removedKeys.includes(k.split(':')[0])) {
+            delete manualValues[k];
+          }
+        }
+        for (const key of removedKeys) restoreLatestSnapshotMarkerForKey(oldEntry, oldSnapshot, key, importTs);
+        if (!oldEntry.markers || Object.keys(oldEntry.markers).length === 0) {
+          recordTombstone(state.importedData, 'entries', oldEntry.date);
+          deleteImportedArrayItems(state.importedData, 'entries', e => e === oldEntry);
+        }
+      }
+    }
+  }
+
+  // Derive import type from file extension for the snapshot record
+  function _deriveImportType(fileName) {
+    if (!fileName) return 'import';
+    const ext = fileName.split('.').pop()?.toLowerCase() || '';
+    if (ext === 'pdf') return 'pdf';
+    if (ext === 'csv') return 'csv';
+    if (ext === 'xlsx' || ext === 'xls') return 'xlsx';
+    if (ext === 'txt') return 'text';
+    if (['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp'].includes(ext)) return 'image';
+    return 'import';
+  }
+
   const entry = findOrCreateLabEntry(state.importedData, result.date, { now: importTs });
   entry.importedWith = {
     provider: result.costInfo?.provider || null,
@@ -404,7 +449,7 @@ export async function confirmImport() {
   for (const m of matched) {
     setLabEntryMarker(entry, m.mappedKey, normalizeToSI(m.mappedKey, m.value, m.unit), {
       now: importTs,
-      source: { file: result.fileName || null, at: importTs },
+      source: { file: result.fileName || null, at: importTs, snapshotId },
     });
   }
   // For non-blood imports, testType is the authoritative sidebar group for all markers
@@ -434,7 +479,7 @@ export async function confirmImport() {
   for (const m of newMarkers) {
     setLabEntryMarker(entry, m.suggestedKey, normalizeToSI(m.suggestedKey, m.value, m.unit), {
       now: importTs,
-      source: { file: result.fileName || null, at: importTs },
+      source: { file: result.fileName || null, at: importTs, snapshotId },
     });
     const [catKey] = m.suggestedKey.split('.');
     const schemaCategory = MARKER_SCHEMA[catKey];
@@ -479,6 +524,58 @@ export async function confirmImport() {
       state.importedData.refOverrides[m.mappedKey] = ovr;
     }
   }
+  // Persist import snapshot for later re-review without AI
+  const snapshotPayload = (m) => ({
+    rawName: m.rawName,
+    value: m.value,
+    unit: m.unit || null,
+    refMin: m.refMin != null ? m.refMin : null,
+    refMax: m.refMax != null ? m.refMax : null,
+    mappedKey: m.mappedKey || null,
+    suggestedKey: m.suggestedKey || null,
+    suggestedName: m.suggestedName || null,
+    suggestedCategoryLabel: m.suggestedCategoryLabel || null,
+    suggestedGroup: m.suggestedGroup || null,
+    matched: !!m.matched,
+  });
+  const snapBase = {
+    fileName: result.fileName || '',
+    date: result.date || '',
+    testType: result.testType || null,
+    type: _deriveImportType(result.fileName),
+    markerCount: importCount,
+    excludedIndices: Array.from(excludedIdxs),
+    costInfo: result.costInfo ? { provider: result.costInfo.provider, modelId: result.costInfo.modelId } : null,
+  };
+  if (isReReview) {
+    if (!state.importedData.importSnapshots) state.importedData.importSnapshots = [];
+    clearTombstone(state.importedData, 'importSnapshots', snapshotId);
+    const snapIdx = state.importedData.importSnapshots?.findIndex(s => s.id === snapshotId);
+    if (snapIdx >= 0) {
+      state.importedData.importSnapshots[snapIdx] = {
+        ...state.importedData.importSnapshots[snapIdx],
+        ...snapBase,
+        markers: result.markers.map(m => snapshotPayload(m)),
+        importedAt: importTs,
+      };
+    } else {
+      state.importedData.importSnapshots.push({
+        id: snapshotId,
+        ...snapBase,
+        markers: result.markers.map(m => snapshotPayload(m)),
+        importedAt: importTs,
+      });
+    }
+  } else {
+    if (!state.importedData.importSnapshots) state.importedData.importSnapshots = [];
+    state.importedData.importSnapshots.push({
+      id: snapshotId,
+      ...snapBase,
+      markers: result.markers.map(m => snapshotPayload(m)),
+      importedAt: importTs,
+    });
+  }
+
   const saved = await saveImportedData({ immediate: true });
   if (!saved) {
     restoreImportedDataSnapshot(rollback);
@@ -493,6 +590,109 @@ export async function confirmImport() {
   }
   showNotification(`Imported ${importCount} markers from ${result.date}`, "success");
   if (!_batchMode && typeof pdfImportWindow.maybeShowEncryptionNudge === 'function') pdfImportWindow.maybeShowEncryptionNudge();
+}
+
+// ═══════════════════════════════════════════════
+// IMPORT SNAPSHOT ACTIONS (issue #39)
+// ═══════════════════════════════════════════════
+function snapshotMarkerDotKey(marker) {
+  return marker?.mappedKey || marker?.suggestedKey || null;
+}
+
+function findLatestRestorableSnapshotMarker(date, excludedSnapshotId, dotKey) {
+  const snaps = Array.isArray(state.importedData?.importSnapshots) ? state.importedData.importSnapshots : [];
+  const candidates = snaps
+    .filter(s => s?.id && s.id !== excludedSnapshotId && s.date === date && Array.isArray(s.markers))
+    .sort((a, b) => (b.importedAt || 0) - (a.importedAt || 0));
+  for (const snap of candidates) {
+    const excluded = new Set(Array.isArray(snap.excludedIndices) ? snap.excludedIndices : []);
+    for (let i = 0; i < snap.markers.length; i++) {
+      if (excluded.has(i)) continue;
+      const marker = snap.markers[i];
+      if (snapshotMarkerDotKey(marker) !== dotKey) continue;
+      return { snap, marker };
+    }
+  }
+  return null;
+}
+
+function restoreLatestSnapshotMarkerForKey(entry, removedSnapshot, dotKey, now = Date.now()) {
+  if (!entry || !removedSnapshot || !dotKey) return false;
+  const replacement = findLatestRestorableSnapshotMarker(removedSnapshot.date, removedSnapshot.id, dotKey);
+  if (!replacement) return false;
+  const { snap, marker } = replacement;
+  setLabEntryMarker(entry, dotKey, normalizeToSI(dotKey, marker.value, marker.unit), {
+    now,
+    source: { file: snap.fileName || null, at: snap.importedAt || now, snapshotId: snap.id },
+  });
+  return true;
+}
+
+export async function deleteImportSnapshot(snapId) {
+  const snaps = state.importedData?.importSnapshots;
+  const idx = snaps ? snaps.findIndex(s => s.id === snapId) : -1;
+  if (idx < 0) {
+    showNotification('Import snapshot not found', 'error');
+    return false;
+  }
+  const snapshot = snaps[idx];
+  const rollback = snapshotImportedData();
+  // Remove markers tagged with this snapshotId from the entry
+  const entry = state.importedData.entries?.find(e => e.date === snapshot.date);
+  if (entry?.markers) {
+    const removedKeys = [];
+    for (const key of Object.keys(entry.markers)) {
+      const src = entry.markerSources?.[key];
+      if (src?.snapshotId === snapshot.id) {
+        deleteLabEntryMarker(entry, key, { mirrorInsulin: true });
+        removedKeys.push(key);
+      }
+    }
+    const manualValues = state.importedData.manualValues || {};
+    for (const k of Object.keys(manualValues)) {
+      if (k.endsWith(':' + snapshot.date) && removedKeys.includes(k.split(':')[0])) {
+        delete manualValues[k];
+      }
+    }
+    for (const key of removedKeys) restoreLatestSnapshotMarkerForKey(entry, snapshot, key);
+    if (!entry.markers || Object.keys(entry.markers).length === 0) {
+      recordTombstone(state.importedData, 'entries', snapshot.date);
+      deleteImportedArrayItems(state.importedData, 'entries', e => e === entry);
+    }
+  }
+  recordTombstone(state.importedData, 'importSnapshots', snapId);
+  deleteImportedArrayItems(state.importedData, 'importSnapshots', s => s.id === snapId);
+  const saved = await saveImportedData({ immediate: true });
+  if (!saved) {
+    restoreImportedDataSnapshot(rollback);
+    return false;
+  }
+  refreshImportedDataViews();
+  showNotification(`Deleted import from ${snapshot.fileName || 'unknown'}`, 'info');
+  return true;
+}
+
+export function openImportReviewFromSnapshot(snapId) {
+  const snapshot = state.importedData?.importSnapshots?.find(s => s.id === snapId);
+  if (!snapshot) {
+    showNotification('Import snapshot not found', 'error');
+    return;
+  }
+  if (!Array.isArray(snapshot.markers) || snapshot.markers.length === 0) {
+    showNotification('This import has no saved marker review data', 'error');
+    return;
+  }
+  const result = {
+    date: snapshot.date,
+    fileName: snapshot.fileName,
+    testType: snapshot.testType,
+    markers: snapshot.markers.map(m => ({ ...m })),
+    costInfo: snapshot.costInfo,
+    importHash: snapshot.importHash,
+    _reReviewSnapshotId: snapshot.id,
+    _excludedImportIndices: snapshot.excludedIndices || [],
+  };
+  showImportPreview(result);
 }
 
 // ═══════════════════════════════════════════════
@@ -1146,6 +1346,8 @@ export async function handleTextFile(file) {
 // WINDOW EXPORTS
 // ═══════════════════════════════════════════════
 Object.assign(window, {
+  deleteImportSnapshot,
+  openImportReviewFromSnapshot,
   buildMarkerReference,
   reconcileImportMarkerMappings,
   extractPDFText,

--- a/js/profile.js
+++ b/js/profile.js
@@ -79,6 +79,7 @@ import {
  *   markerNotes: Record<string, any>,
  *   markerValueNotes: Record<string, any>,
  *   biologyScoreAI: Record<string, any>,
+ *   importSnapshots: any[],
  *   markerLabels?: Record<string, any>,
  *   refOverrides?: Record<string, any>,
  *   changeHistory: any[],
@@ -207,12 +208,13 @@ export function createDefaultProfileData() {
     contextNotes: '',
     menstrualCycle: null,
     emfAssessment: null,
+    genetics: null,
     customMarkers: {},
     markerNotes: {},
     markerValueNotes: {},
     biologyScoreAI: {},
     changeHistory: [],
-    genetics: null,
+    importSnapshots: [],
     biometrics: null,
     manualValues: {},
     sunSessions: [],
@@ -658,6 +660,7 @@ export function migrateProfileData(data) {
   if (data.markerValueNotes === undefined) data.markerValueNotes = {};
   if (data.biologyScoreAI === undefined) data.biologyScoreAI = {};
   if (data.changeHistory === undefined) data.changeHistory = [];
+  if (data.importSnapshots === undefined) data.importSnapshots = [];
   if (data.biometrics === undefined) data.biometrics = null;
   // Light lens (v1.7+): sun sessions, light devices, light environment, on-device measurements
   if (data.sunSessions === undefined) data.sunSessions = [];

--- a/js/settings-data.js
+++ b/js/settings-data.js
@@ -5,45 +5,101 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isDebugMode, setPIIReviewEnabled } from './utils.js';
 import { formatCost, getProfileUsage, getGlobalUsage, resetProfileUsage } from './schema.js';
 import { loadPdfImport } from './import-loader.js';
+import { isSnapshotDerivedHOMAIR } from './lab-entry.js';
 
 export function renderDataEntriesSection() {
+  const snapshots = state.importedData?.importSnapshots || [];
   const rawEntries = state.importedData?.entries || [];
   const entries = [];
   for (const entry of rawEntries) {
     if (Object.keys(entry?.markers || {}).length > 0) entries.push(entry);
   }
-  if (entries.length === 0) {
+  const hasSnapshots = snapshots.length > 0;
+  const hasEntries = entries.length > 0;
+  if (!hasSnapshots && !hasEntries) {
     return '<div style="color:var(--text-muted);font-size:13px;padding:8px 0">No data yet. Drop a PDF or JSON file on the dashboard, or add values manually.</div>';
   }
-  const sorted = [...entries].sort((a, b) => a.date.localeCompare(b.date));
-  const manualValues = state.importedData.manualValues || {};
+
   let html = '';
-  for (const entry of sorted) {
-    const d = new Date(entry.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    const cnt = Object.keys(entry.markers).length;
-    const entryMarkerKeys = Object.keys(entry.markers);
-    const manualCount = entryMarkerKeys.filter(k => manualValues[k + ':' + entry.date]).length;
-    const isFullyManual = !entry.importedWith && manualCount === cnt;
-    const files = entry.sourceFiles || (entry.sourceFile ? [entry.sourceFile] : []);
-    const fileLabel = files.length > 0
-      ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px;border-bottom:1px dashed var(--text-muted);cursor:help" title="${escapeAttr(files.join('\n'))}">${files.length === 1 ? escapeHTML(files[0].length > 30 ? files[0].slice(0, 27) + '...' : files[0]) : files.length + ' files'}</span>`
-      : '';
-    const sourceLabel = isFullyManual
-      ? '<span style="color:var(--accent);margin-left:8px;font-size:11px">manual entry</span>'
-      : entry.importedWith?.modelId
-        ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${escapeHTML(entry.importedWith.modelId)}</span>`
-        : manualCount > 0
-          ? `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">${manualCount} manual</span>`
-          : '';
-    const dateAttr = escapeAttr(entry.date);
-    html += `<div class="imported-entry">
-      <span class="ie-info"><span class="ie-date">${d}</span><span class="ie-count">${cnt} markers</span>${fileLabel}${sourceLabel}</span>
-      <div class="ie-actions">
-        <button class="ie-edit" data-settings-action="rename-imported-entry" data-entry-date="${dateAttr}" title="Edit collection date">Edit date</button>
-        <button class="ie-remove" data-settings-action="remove-imported-entry" data-entry-date="${dateAttr}">Remove</button>
-      </div>
-    </div>`;
+
+  if (hasSnapshots) {
+    const sortedSnapshots = [...snapshots].sort((a, b) => (b.importedAt || 0) - (a.importedAt || 0));
+    html += '<div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin:8px 0 4px">Imports</div>';
+    for (const snap of sortedSnapshots) {
+      const d = new Date((snap.date || '') + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      const cnt = snap.markerCount || (snap.markers || []).length;
+      const fileName = snap.fileName || 'Unknown file';
+      const typeLabel = snap.type || 'import';
+      const modelLabel = snap.costInfo?.modelId ? `${snap.costInfo.modelId}` : '';
+      const importedLabel = Number.isFinite(snap.importedAt)
+        ? new Date(snap.importedAt).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+        : '';
+      const snapId = snap.id;
+      html += `<div class="imported-entry imported-entry-snapshot">
+        <div class="ie-info">
+          <div class="ie-mainline">
+            <span class="ie-date">${d}</span>
+            <span class="ie-count">${cnt} marker${cnt === 1 ? '' : 's'}</span>
+          </div>
+          <div class="ie-meta">
+            <span class="ie-file" title="${escapeAttr(fileName)}">${escapeHTML(fileName)}</span>
+            ${modelLabel ? `<span class="ie-model" title="${escapeAttr(modelLabel)}">${escapeHTML(modelLabel)}</span>` : ''}
+            <span class="ie-type">${escapeHTML(typeLabel)}</span>
+            ${importedLabel ? `<span class="ie-type" title="Imported time">${escapeHTML(importedLabel)}</span>` : ''}
+          </div>
+        </div>
+        <div class="ie-actions">
+          <button class="ie-edit" data-settings-action="review-import" data-snap-id="${escapeAttr(snapId)}" title="Review, edit values/units, and re-import without AI cost">Review & Edit</button>
+          <button class="ie-remove" data-settings-action="remove-import-snapshot" data-snap-id="${escapeAttr(snapId)}">Delete</button>
+        </div>
+      </div>`;
+    }
   }
+
+  const manualValues = state.importedData.manualValues || {};
+  const legacyEntries = [];
+  for (const entry of entries) {
+    const entryMarkerKeys = Object.keys(entry.markers || {});
+    const manualKeys = entryMarkerKeys.filter(k => manualValues[k + ':' + entry.date]);
+    const manualNonSnapshotKeys = manualKeys.filter(k => {
+      if (isSnapshotDerivedHOMAIR(entry, k)) return false;
+      return !entry.markerSources?.[k]?.snapshotId;
+    });
+    const legacyKeys = entryMarkerKeys.filter(k => {
+      if (isSnapshotDerivedHOMAIR(entry, k)) return false;
+      const src = entry.markerSources?.[k];
+      return !src || !src.snapshotId;
+    });
+    const otherKeys = legacyKeys.length ? legacyKeys : manualNonSnapshotKeys;
+    const hasSnapshotMarkers = entryMarkerKeys.some(k => !!entry.markerSources?.[k]?.snapshotId);
+    if (otherKeys.length > 0) legacyEntries.push({ entry, otherKeys, manualKeys, hasSnapshotMarkers });
+  }
+
+  if (legacyEntries.length > 0) {
+    const sortedLegacy = [...legacyEntries].sort((a, b) => a.entry.date.localeCompare(b.entry.date));
+    html += '<div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin:16px 0 4px">Manual / legacy markers</div>';
+    for (const legacy of sortedLegacy) {
+      const { entry, otherKeys, manualKeys, hasSnapshotMarkers } = legacy;
+      const d = new Date(entry.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      const cnt = otherKeys.length;
+      const isManual = cnt > 0 && cnt === manualKeys.length;
+      const sourceLabel = isManual
+        ? '<span style="color:var(--accent);margin-left:8px;font-size:11px">manual markers not tied to an import file</span>'
+        : `<span style="color:var(--text-muted);margin-left:8px;font-size:11px">legacy markers not tied to an import file${entry.sourceFile ? ` · ${escapeHTML(entry.sourceFile)}` : ''}</span>`;
+      const dateAttr = escapeAttr(entry.date);
+      const editDateControl = hasSnapshotMarkers
+        ? '<span class="ie-count" title="Date is locked because this date also has AI-imported snapshots">Date locked</span>'
+        : `<button class="ie-edit" data-settings-action="rename-imported-entry" data-entry-date="${dateAttr}">Edit date</button>`;
+      html += `<div class="imported-entry">
+        <div class="ie-info"><div class="ie-mainline"><span class="ie-date">${d}</span><span class="ie-count">${cnt} marker${cnt === 1 ? '' : 's'}</span></div><div class="ie-meta">${sourceLabel}</div></div>
+        <div class="ie-actions">
+          ${editDateControl}
+          <button class="ie-remove" data-settings-action="remove-imported-entry" data-entry-date="${dateAttr}">Remove</button>
+        </div>
+      </div>`;
+    }
+  }
+
   html += `<div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
     <button class="import-btn import-btn-primary" data-settings-action="share-profile">Share Profile</button>
     <button class="import-btn import-btn-secondary" data-settings-action="export-client">Export Client</button>

--- a/js/settings.js
+++ b/js/settings.js
@@ -2,7 +2,7 @@
 // settings.js — Settings modal (profile, display, AI provider, privacy)
 
 import { state } from './state.js';
-import { escapeHTML, escapeAttr, isDebugMode, setDebugMode, isPIIReviewEnabled, isAnalyticsEnabled, setAnalyticsEnabled } from './utils.js';
+import { escapeHTML, escapeAttr, isDebugMode, setDebugMode, isPIIReviewEnabled, isAnalyticsEnabled, setAnalyticsEnabled, showNotification, showConfirmDialog } from './utils.js';
 import { getTheme, setTheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, getTimeFormat, setTimeFormat, THEMES } from './theme.js';
 import { switchUnitSystem, toggleAltUnits, switchRangeMode } from './data.js';
 import { getAIProvider, isAIPaused, getOllamaPIIUrl, getOllamaPIIModel, setOllamaPIIModel } from './api.js';
@@ -13,6 +13,7 @@ import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
 import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { installSettingsProviderBridge, switchAIProviderBridge } from './settings-provider-bridge.js';
+import { loadPdfImport } from './import-loader.js';
 import {
   confirmDisablePIIReview,
   refreshDataEntriesSection,
@@ -287,7 +288,7 @@ function isTweaksToggleAction(actionEl) {
     || actionEl.dataset.tweaksAction === 'toggle-crt';
 }
 
-function handleSettingsClick(event) {
+async function handleSettingsClick(event) {
   const modal = document.getElementById('settings-modal');
   if (!modal) return;
 
@@ -361,6 +362,28 @@ function handleSettingsClick(event) {
   } else if (action === 'remove-imported-entry') {
     event.preventDefault();
     void removeImportedEntryFromSettings(actionEl.dataset.entryDate || '');
+  } else if (action === 'review-import') {
+    event.preventDefault();
+    try {
+      const { openImportReviewFromSnapshot } = await loadPdfImport();
+      closeSettingsModal();
+      openImportReviewFromSnapshot(actionEl.dataset.snapId || '');
+    } catch (err) {
+      if (isDebugMode()) console.error('Review import snapshot failed:', err);
+      showNotification('Could not open import review. Reload and try again.', 'error');
+    }
+  } else if (action === 'remove-import-snapshot') {
+    event.preventDefault();
+    const confirmed = await showConfirmDialog('Delete this import? This will remove all markers from this file and cannot be undone.');
+    if (!confirmed) return;
+    try {
+      const { deleteImportSnapshot } = await loadPdfImport();
+      const ok = await deleteImportSnapshot(actionEl.dataset.snapId || '');
+      if (ok) refreshDataEntriesSection();
+    } catch (err) {
+      if (isDebugMode()) console.error('Delete import snapshot failed:', err);
+      showNotification('Could not delete import. Reload and try again.', 'error');
+    }
   } else if (action === 'export-client') {
     event.preventDefault();
     settingsWindow.exportClientJSON?.(settingsWindow.getActiveProfileId?.());

--- a/js/state.js
+++ b/js/state.js
@@ -4,7 +4,7 @@
 export const state = {
   chartInstances: {},
   markerRegistry: {},
-  importedData: { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, diet: null, exercise: null, sleepRest: null, lightCircadian: null, stress: null, loveLife: null, environment: null, interpretiveLens: '', contextNotes: '', menstrualCycle: null, emfAssessment: null, genetics: null, customMarkers: {}, markerNotes: {}, markerValueNotes: {}, biologyScoreAI: {}, changeHistory: [] },
+  importedData: { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, diet: null, exercise: null, sleepRest: null, lightCircadian: null, stress: null, loveLife: null, environment: null, interpretiveLens: '', contextNotes: '', menstrualCycle: null, emfAssessment: null, genetics: null, customMarkers: {}, markerNotes: {}, markerValueNotes: {}, biologyScoreAI: {}, changeHistory: [], importSnapshots: [] },
   unitSystem: 'EU',
   showAltUnits: false,
   selectedCorrelationMarkers: [],

--- a/js/sync-delta-surface-config.js
+++ b/js/sync-delta-surface-config.js
@@ -24,6 +24,12 @@ export const DELTA_ARRAY_CONFIG = {
   entries: {
     itemIdFn: (it) => (it && typeof it.date === 'string' && _isAllowlistSafeId(it.date)) ? it.date : null,
   },
+  // Import snapshots are user-visible per-file records with stable `id`s.
+  // Keep them in the configured set so blob merge and row overlay share the
+  // same tombstone-aware identity semantics.
+  importSnapshots: {
+    itemIdFn: (it) => (it && typeof it.id === 'string' && _isAllowlistSafeId(it.id)) ? it.id : null,
+  },
   // Supplements have no `.id`; hash stable identity fields so identical
   // pre-existing data derives the same itemId on each device.
   supplements: {

--- a/js/sync-delta-surfaces.js
+++ b/js/sync-delta-surfaces.js
@@ -34,6 +34,7 @@ export const DELTA_ARRAYS = [
   'healthGoals',
   'changeHistory',
   'chatSummaries',
+  'importSnapshots',
 ];
 
 // Keyed-object shapes subject to delta sync.

--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -747,7 +747,7 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
         && viewCalls.includes('updateHeaderDates')
         && viewCalls.includes('navigate:labs')
         && Array.from(document.querySelectorAll('.notification-toast.info'))
-          .some(toast => toast.textContent.includes('Removed imported data from 2026-01-03'));
+          .some(toast => toast.textContent.includes('Removed 1 marker from 2026-01-03'));
 
       outcomes.missingDateReturnsFalse = await persistence.removeImportedEntry('') === false
         && await persistence.renameImportedEntryDate('missing-date') === false;

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -220,8 +220,19 @@ assert('CHANGELOG records Biology Scores main release',
     && changelogSrc.includes('A new lens on your biology')
     && changelogSrc.includes('Biological Coherence shows the whole-body picture')
     && changelogSrc.includes('Know what to test next'));
+assert('CHANGELOG records per-file lab import storage release',
+  changelogSrc.includes("version: '1.10.6'")
+    && changelogSrc.includes('Per-file lab import storage')
+    && changelogSrc.includes('Lab imports are now stored per file')
+    && changelogSrc.includes('Same-day reports are easier to manage')
+    && changelogSrc.includes('import that report again')
+    && /version:\s*'1\.10\.6'[\s\S]{0,180}forceShow:\s*true/.test(changelogSrc));
+assert('Per-file import storage changelog is user-facing, not a technical fix log',
+  !/Greptile|bugfix|bugfixes|production hardening|UI polish|tombstone|CRDT|manualValues|fixed|tightened before release/i.test(changelogSrc.slice(changelogSrc.indexOf("version: '1.10.6'"), changelogSrc.indexOf("version: '1.9.0'"))));
 assert('Biology Scores changelog is announcement-style, not a technical fix log',
   !/Greptile|bugfix|bugfixes|production hardening|UI polish|stale explanation|sync|CRP\/hs-CRP|fixed|tightened before release/i.test(changelogSrc.slice(changelogSrc.indexOf("version: '1.9.0'"), changelogSrc.indexOf("version: '1.8.550'"))));
+assert('APP_VERSION is bumped for per-file lab import storage',
+  appVersion === '1.10.6', appVersion);
 assert('APP_VERSION is at least the Biology Scores main release',
   versionMatch && semverGte(appVersion, '1.9.0'), appVersion);
 

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -62,8 +62,10 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
     pickTimestamp({ at: 10 }) === 10);
   assert('createdAt ISO strings are parsed for chat-summary freshness',
     pickTimestamp({ createdAt: '2026-05-31T04:00:00.000Z' }) === Date.parse('2026-05-31T04:00:00.000Z'));
-  assert('takenAt and addedAt are recognized for light tools/devices',
-    pickTimestamp({ takenAt: 70 }) === 70 && pickTimestamp({ addedAt: 80 }) === 80);
+  assert('takenAt, importedAt and addedAt are recognized for synced records',
+    pickTimestamp({ takenAt: 70 }) === 70
+      && pickTimestamp({ importedAt: 75 }) === 75
+      && pickTimestamp({ addedAt: 80 }) === 80);
   assert('falls back to Date.parse(date) when no numeric field',
     pickTimestamp({ date: '2026-04-15' }) === Date.parse('2026-04-15'));
   assert('returns 0 on totally bare record', pickTimestamp({}) === 0);

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -27,6 +27,11 @@ const mappingSrc = read('js/pdf-import-marker-mapping.js');
 const normalizationSrc = read('js/pdf-import-marker-normalization.js');
 const persistenceSrc = read('js/pdf-import-persistence.js');
 const settingsDataSrc = read('js/settings-data.js');
+const settingsSrc = read('js/settings.js');
+const reviewSrc = read('js/pdf-import-review.js');
+const labEntrySrc = read('js/lab-entry.js');
+const profileSrc = read('js/profile.js');
+const importCssSrc = read('css/import.css');
   // ═══════════════════════════════════════
   // 1. normalizeToSI function exists
   // ═══════════════════════════════════════
@@ -75,7 +80,7 @@ const settingsDataSrc = read('js/settings-data.js');
   assert('import delete uses immediate sync push',
     /await\s+saveImportedData\(\{\s*immediate:\s*true\s*\}\)/.test(removeBlock));
   assert('import delete restores state and returns false when save fails',
-    /const rollback = snapshotImportedData\(\)[\s\S]{0,400}if \(!saved\) \{[\s\S]{0,160}restoreImportedDataSnapshot\(rollback\)[\s\S]{0,120}return false/.test(removeBlock));
+    /const rollback = snapshotImportedData\(\)[\s\S]{0,1600}if \(!saved\) \{[\s\S]{0,160}restoreImportedDataSnapshot\(rollback\)[\s\S]{0,120}return false/.test(removeBlock));
   const renameStart = persistenceSrc.indexOf('export async function renameImportedEntryDate');
   const renameBlock = persistenceSrc.substring(renameStart);
   assert('import date rename tombstones old date',
@@ -92,6 +97,79 @@ const settingsDataSrc = read('js/settings-data.js');
     /removeImportedEntryFromSettings[\s\S]{0,240}const ok = await removeImportedEntry\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsDataSrc));
   assert('Settings Data rename refreshes only after successful save',
     /renameImportedEntryDateFromSettings[\s\S]{0,260}const ok = await renameImportedEntryDate\(date\)[\s\S]{0,80}if \(ok\) refreshDataEntriesSection\(\)/.test(settingsDataSrc));
+  assert('Settings Data Review & Edit lazy-loads pdf-import module before opening snapshot review',
+    /loadPdfImport\(\)[\s\S]{0,160}closeSettingsModal\(\)[\s\S]{0,120}openImportReviewFromSnapshot\(actionEl\.dataset\.snapId/.test(settingsSrc)
+      && /data-settings-action=\"review-import\"/.test(settingsDataSrc));
+  assert('Settings Data import rows use wrapping metadata layout classes',
+    settingsDataSrc.includes('imported-entry-snapshot')
+      && settingsDataSrc.includes('class=\"ie-mainline\"')
+      && settingsDataSrc.includes('class=\"ie-meta\"')
+      && settingsDataSrc.includes('class=\"ie-file\"')
+      && settingsDataSrc.includes('Imported time'));
+  assert('Settings Data Other data counts only markers not owned by import snapshots',
+    settingsDataSrc.includes('const legacyKeys = entryMarkerKeys.filter')
+      && settingsDataSrc.includes('const manualNonSnapshotKeys = manualKeys.filter')
+      && settingsDataSrc.includes('const otherKeys = legacyKeys.length ? legacyKeys : manualNonSnapshotKeys')
+      && settingsDataSrc.includes('legacyEntries.push({ entry, otherKeys, manualKeys, hasSnapshotMarkers })')
+      && /const cnt = otherKeys\.length/.test(settingsDataSrc));
+  assert('Settings Data treats snapshot-derived HOMA-IR as snapshot-owned even for existing rows without marker source',
+    settingsDataSrc.includes('isSnapshotDerivedHOMAIR')
+      && settingsDataSrc.includes('isSnapshotDerivedHOMAIR(entry, k)')
+      && /import \{ deleteLabEntryMarker, isSnapshotDerivedHOMAIR \} from ['"]\.\/lab-entry\.js['"]/.test(persistenceSrc)
+      && /glucoseSource\.snapshotId === insulinSource\?\.snapshotId/.test(labEntrySrc)
+      && persistenceSrc.includes('isSnapshotDerivedHOMAIR(entry, k)'));
+  assert('HOMA-IR recalculation preserves snapshot ownership when glucose and insulin come from the same import snapshot',
+    /ensureMarkerSources\(entry\)\['diabetes\.homaIR'\][\s\S]{0,260}snapshotId:\s*sharedSnapshotId/.test(read('js/lab-entry.js')));
+  assert('Settings Data does not classify a date row as legacy only because importedWith is missing',
+    !/if \(isFullyManual \|\| !entry\.importedWith\)/.test(settingsDataSrc));
+  assert('Re-review tombstones an emptied old snapshot entry before deleting it',
+    /if \(isReReview\)[\s\S]{0,1200}recordTombstone\(state\.importedData,\s*['"]entries['"],\s*oldEntry\.date\)[\s\S]{0,160}deleteImportedArrayItems\(state\.importedData,\s*['"]entries['"],\s*e => e === oldEntry\)/.test(confirmBlock));
+  assert('Re-review purges manual value overrides for removed old snapshot markers',
+    /if \(isReReview\)[\s\S]{0,700}const manualValues = state\.importedData\.manualValues \|\| \{\}/.test(confirmBlock)
+      && /k\.endsWith\(':' \+ oldSnapshot\.date\)[\s\S]{0,120}removedKeys\.includes\(k\.split\(':'\)\[0\]\)[\s\S]{0,80}delete manualValues\[k\]/.test(confirmBlock));
+  assert('Re-review upserts a snapshot row when the original snapshot was concurrently deleted',
+    /if \(isReReview\)[\s\S]{0,260}clearTombstone\(state\.importedData,\s*['"]importSnapshots['"],\s*snapshotId\)/.test(confirmBlock)
+      && /if \(snapIdx >= 0\)[\s\S]{0,420}else \{[\s\S]{0,120}state\.importedData\.importSnapshots\.push\(\{[\s\S]{0,80}id:\s*snapshotId/.test(confirmBlock));
+  assert('Database bundle import merges importSnapshots into existing profiles',
+    /Array\.isArray\(importData\.importSnapshots\)[\s\S]{0,260}ensureImportedArray\(current,\s*['"]importSnapshots['"]\)[\s\S]{0,700}appendImportedArrayItem\(current,\s*['"]importSnapshots['"],\s*snap\)/.test(exportSrc));
+  assert('Import restore clears snapshot tombstones and updates newer duplicate snapshot ids',
+    /clearTombstone\(state\.importedData,\s*['"]importSnapshots['"],\s*snap\.id\)/.test(exportSrc)
+      && /clearTombstone\(current,\s*['"]importSnapshots['"],\s*snap\.id\)/.test(exportSrc)
+      && /incomingAt >= existingAt/.test(exportSrc));
+  assert('Existing profile migration backfills importSnapshots array',
+    /if \(data\.importSnapshots === undefined\) data\.importSnapshots = \[\]/.test(profileSrc));
+  assert('Import snapshots are tombstone-aware delta array records',
+    /importSnapshots:\s*\{[\s\S]{0,180}itemIdFn/.test(read('js/sync-delta-surface-config.js'))
+      && /recordTombstone\(state\.importedData,\s*['"]importSnapshots['"],\s*snapId\)/.test(confirmBlock)
+      && /deleteImportedArrayItems\(state\.importedData,\s*['"]importSnapshots['"]/.test(confirmBlock));
+  assert('Snapshot marker deletes use lab-entry tombstones and HOMA-IR recalculation',
+    /import \{ deleteLabEntryMarker,/.test(src)
+      && /deleteLabEntryMarker\(oldEntry, key,[\s\S]{0,80}mirrorInsulin:\s*true/.test(confirmBlock)
+      && /deleteLabEntryMarker\(entry, key,[\s\S]{0,80}mirrorInsulin:\s*true/.test(confirmBlock)
+      && !/delete\s+(?:oldEntry|entry)\.markers\[key\]/.test(confirmBlock));
+  assert('Snapshot delete/re-review restores latest remaining same-date snapshot marker value',
+    /function findLatestRestorableSnapshotMarker/.test(confirmBlock)
+      && /s\.id !== excludedSnapshotId/.test(confirmBlock)
+      && /snapshotMarkerDotKey\(marker\) !== dotKey/.test(confirmBlock)
+      && /restoreLatestSnapshotMarkerForKey\(entry, snapshot, key\)/.test(confirmBlock)
+      && /restoreLatestSnapshotMarkerForKey\(oldEntry, oldSnapshot, key, importTs\)/.test(confirmBlock));
+  assert('Snapshot delete purges manual value overrides for removed snapshot markers',
+    /const manualValues = state\.importedData\.manualValues \|\| \{\}/.test(confirmBlock)
+      && /k\.endsWith\(':' \+ snapshot\.date\)[\s\S]{0,120}removedKeys\.includes\(k\.split\(':'\)\[0\]\)[\s\S]{0,80}delete manualValues\[k\]/.test(confirmBlock));
+  assert('Legacy mixed-entry delete uses lab-entry tombstones and HOMA-IR recalculation',
+    /import \{ deleteLabEntryMarker, isSnapshotDerivedHOMAIR \} from ['"]\.\/lab-entry\.js['"]/.test(persistenceSrc)
+      && /deleteLabEntryMarker\(entry, k,[\s\S]{0,80}mirrorInsulin:\s*true/.test(removeBlock)
+      && !/delete\s+entry\.markers\[k\]/.test(removeBlock));
+
+  assert('Review snapshot modal tolerates stored costInfo without a cost field',
+    /parseResult\.costInfo && typeof parseResult\.costInfo\.cost === ['"]number['"]/.test(reviewSrc));
+  assert('Re-review modal uses update wording instead of import wording',
+    /parseResult\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc)
+      && /result\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc));
+  assert('Import review mobile footer actions are sticky',
+    /\.import-review-actions \{[\s\S]{0,160}position:\s*sticky[\s\S]{0,80}bottom:\s*0/.test(importCssSrc));
+  assert('Review snapshot opener tolerates corrupt snapshot rows without marker arrays',
+    /openImportReviewFromSnapshot[\s\S]{0,320}Array\.isArray\(snapshot\.markers\)[\s\S]{0,120}no saved marker review data/.test(confirmBlock));
 
   // ═══════════════════════════════════════
   // 4. normalizeToSI handles multiply type (inverse)

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -147,6 +147,7 @@ interface Window {
   handleChatKeydown?: AnyFunction;
   handleMtDNAFile?: (file: File) => Promise<void> | void;
   importDataJSON: (file: File) => Promise<void> | void;
+  deleteImportSnapshot?: (snapshotId: string) => Promise<boolean> | boolean;
   isDebugMode?: () => boolean;
   isImportRunning?: () => boolean;
   initChatImageHandlers: () => void;
@@ -190,6 +191,7 @@ interface Window {
   openEMFAssessmentEditor?: () => void;
   openSettingsModal: (tab?: string) => void;
   openChatProviderQuiz?: AnyFunction;
+  openImportReviewFromSnapshot?: (snapshotId: string) => void;
   pdfjsLib?: unknown;
   openProfileShareModal?: (profileId?: string) => void;
   openProfileLocationEditor?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.5';
+self.APP_VERSION = '1.10.6';


### PR DESCRIPTION
## Summary
- Adds per-file lab import snapshots for AI/PDF lab reports so each file can be reviewed, edited, deleted, and re-applied without re-paying AI costs.
- Preserves snapshot marker ownership through delete/re-review, same-date duplicate fallback, HOMA-IR provenance, export/import restore, and tombstone-aware sync.
- Updates Settings → Data with dedicated import snapshot rows plus manual/legacy marker handling.

## Verification
- `node tests/test-unit-import.js` — 110 passed
- `npm run typecheck` — passed
- `npm run quality` — 5 passed
- focused Playwright import persistence spec — passed
- `npm test` — 13 files passed, 191 tests passed

## Review reset
This is the clean one-commit replacement for PR #926 after the Greptile review thread/dashboard got stuck across repeated incremental fix commits. The tree is identical to the fixed head of #926 (`b775a0f`) but squashed into one commit from current `origin/main`.
