### PR TITLE
[codex] Fix audit security and data cleanup issues

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -54,20 +54,32 @@ function _isBlockedHost(host) {
     // IPv4-mapped/translated: ::ffff:a.b.c.d / ::ffff:0:a.b.c.d / ::a.b.c.d
     const v4Embed = lower.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
     if (v4Embed) return _isBlockedHost(v4Embed[1]);
-    // IPv4-mapped hex form ::ffff:7f00:0001 etc — collapse and recheck via
-    // last 32 bits when it's a clear ::ffff: prefix.
+    // IPv4-mapped hex form ::ffff:7f00:0001 etc — parse each 16-bit
+    // group independently so compressed forms like ::ffff:c0a8:101 keep
+    // their byte boundaries (192.168.1.1, not 12.10.129.1).
     if (lower.startsWith('::ffff:')) {
       const tail = lower.slice(7);
-      // Hex pair → dotted quad if it looks like 0001:0002 etc.
-      const hex = tail.replace(/:/g, '');
-      if (/^[0-9a-f]{1,8}$/.test(hex)) {
-        const padded = hex.padStart(8, '0');
-        const a = parseInt(padded.slice(0, 2), 16);
-        const b = parseInt(padded.slice(2, 4), 16);
-        const c = parseInt(padded.slice(4, 6), 16);
-        const d = parseInt(padded.slice(6, 8), 16);
+      const groups = tail.split(':');
+      if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
+        const g0 = parseInt(groups[0], 16);
+        const g1 = parseInt(groups[1], 16);
+        const a = (g0 >> 8) & 0xff;
+        const b = g0 & 0xff;
+        const c = (g1 >> 8) & 0xff;
+        const d = g1 & 0xff;
         return _isBlockedHost(`${a}.${b}.${c}.${d}`);
       }
+    }
+    // 6to4 = 2002:WWXX:YYZZ::/48, with WWXX:YYZZ encoding IPv4.
+    const sixToFour = /^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4})(?::|$)/.exec(lower);
+    if (sixToFour) {
+      const g0 = parseInt(sixToFour[1], 16);
+      const g1 = parseInt(sixToFour[2], 16);
+      const a = (g0 >> 8) & 0xff;
+      const b = g0 & 0xff;
+      const c = (g1 >> 8) & 0xff;
+      const d = g1 & 0xff;
+      return _isBlockedHost(`${a}.${b}.${c}.${d}`);
     }
     // Unknown / private IPv6 ranges we haven't enumerated — be safe and
     // allow only globally routable (2000::/3) IPv6 addresses through.

--- a/dev-server.js
+++ b/dev-server.js
@@ -51,15 +51,25 @@ const ROOT = path.dirname(__filename);
 // the read-hash → writeFileSync critical section. Promise-chained queue:
 // each request's _deployCatalog body waits for the prior one to finish.
 let _deployLock = Promise.resolve();
+
+export function _isValidCatalogShape(parsed) {
+  return !!(
+    parsed
+    && typeof parsed === 'object'
+    && !Array.isArray(parsed)
+    && parsed.slots
+    && parsed.products
+  );
+}
+
 function _deployCatalog(body, req, res) {
   _deployLock = _deployLock.then(async () => {
     try {
       JSON.parse(body); // validate JSON shape
       const parsed = JSON.parse(body);
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)
-          || !parsed.slots || !parsed.shops) {
+      if (!_isValidCatalogShape(parsed)) {
         res.writeHead(400, { 'Content-Type': 'text/plain' });
-        res.end('Invalid catalog shape: missing required slots/shops keys');
+        res.end('Invalid catalog shape: missing required slots/products keys');
         return;
       }
       const filePath = path.join(ROOT, 'data', 'recommendations.json');
@@ -323,15 +333,26 @@ export function _proxyHostBlocked(host) {
     if (v4Embed) return _proxyHostBlocked(v4Embed[1]);
     if (lower.startsWith('::ffff:')) {
       const tail = lower.slice(7);
-      const hex = tail.replace(/:/g, '');
-      if (/^[0-9a-f]{1,8}$/.test(hex)) {
-        const padded = hex.padStart(8, '0');
-        const a = parseInt(padded.slice(0, 2), 16);
-        const b = parseInt(padded.slice(2, 4), 16);
-        const c = parseInt(padded.slice(4, 6), 16);
-        const d = parseInt(padded.slice(6, 8), 16);
+      const groups = tail.split(':');
+      if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
+        const g0 = parseInt(groups[0], 16);
+        const g1 = parseInt(groups[1], 16);
+        const a = (g0 >> 8) & 0xff;
+        const b = g0 & 0xff;
+        const c = (g1 >> 8) & 0xff;
+        const d = g1 & 0xff;
         return _proxyHostBlocked(`${a}.${b}.${c}.${d}`);
       }
+    }
+    const sixToFour = /^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4})(?::|$)/.exec(lower);
+    if (sixToFour) {
+      const g0 = parseInt(sixToFour[1], 16);
+      const g1 = parseInt(sixToFour[2], 16);
+      const a = (g0 >> 8) & 0xff;
+      const b = g0 & 0xff;
+      const c = (g1 >> 8) & 0xff;
+      const d = g1 & 0xff;
+      return _proxyHostBlocked(`${a}.${b}.${c}.${d}`);
     }
     return !/^[23][0-9a-f]{3}:/.test(lower);
   }

--- a/js/api.js
+++ b/js/api.js
@@ -214,27 +214,38 @@ export async function getOpenRouterBalance() {
 
 // ─── OpenRouter OAuth PKCE ───
 export async function generatePKCE() {
-  const array = new Uint8Array(32);
-  crypto.getRandomValues(array);
-  const codeVerifier = btoa(String.fromCharCode(...array)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
-  const codeChallenge = btoa(String.fromCharCode(...new Uint8Array(digest))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const codeVerifier = _randomBase64Url(32);
+  const codeChallenge = await _sha256Base64Url(codeVerifier);
   return { codeVerifier, codeChallenge };
 }
 
-function _generateOAuthState() {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
+function _base64UrlFromBytes(bytes) {
   return btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function _randomBase64Url(byteLength) {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return _base64UrlFromBytes(bytes);
+}
+
+async function _sha256Base64Url(value) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return _base64UrlFromBytes(new Uint8Array(digest));
+}
+
+function _generateOAuthState() {
+  return _randomBase64Url(16);
 }
 
 export async function startOpenRouterOAuth() {
   const { codeVerifier, codeChallenge } = await generatePKCE();
   const state = _generateOAuthState();
+  const stateDigest = await _sha256Base64Url(state);
   const previousProvider = sessionStorage.getItem(OPENROUTER_OAUTH_PREVIOUS_PROVIDER_KEY) || getAIProvider();
   if (_isValidAIProvider(previousProvider)) sessionStorage.setItem(OPENROUTER_OAUTH_PREVIOUS_PROVIDER_KEY, previousProvider);
   sessionStorage.setItem('or_pkce_verifier', codeVerifier);
-  sessionStorage.setItem('or_oauth_state', state);
+  sessionStorage.setItem('or_oauth_state', `sha256:${stateDigest}`);
   const callbackUrl = window.location.origin + window.location.pathname;
   // PKCE verifier-mismatch alone catches code-injection but not login-CSRF;
   // `state` binds the redirect to the tab that initiated it.
@@ -275,10 +286,15 @@ export async function exchangeOpenRouterCode(code, returnedState) {
   const expectedState = sessionStorage.getItem('or_oauth_state');
   if (!codeVerifier) throw new Error('Missing PKCE verifier. Please try connecting again.');
   // Some OAuth flows omit `state` on the way back; reject the exchange in
-  // that case rather than fail-open. If the user started before this state
-  // check existed, expectedState will also be null — that branch is safe to
-  // accept (the verifier still binds the request).
-  if (expectedState && returnedState !== expectedState) {
+  // that case rather than fail-open. New sessions store only a digest of the
+  // state; the raw comparison keeps older in-flight tabs from getting stranded.
+  const returnedStateDigest = typeof returnedState === 'string'
+    ? `sha256:${await _sha256Base64Url(returnedState)}`
+    : '';
+  const stateMatches = expectedState?.startsWith('sha256:')
+    ? returnedStateDigest === expectedState
+    : returnedState === expectedState;
+  if (expectedState && !stateMatches) {
     sessionStorage.removeItem('or_pkce_verifier');
     sessionStorage.removeItem('or_oauth_state');
     throw new Error('OAuth state mismatch — please try connecting again.');

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -468,13 +468,18 @@ function renderPassphraseForm(overlay, onSuccess) {
     document.getElementById('passphrase-forgot-cancel')?.addEventListener('click', () => {
       renderPassphraseForm(overlay, onSuccess);
     });
-    document.getElementById('passphrase-forgot-confirm')?.addEventListener('click', () => {
-      const keysToRemove = [];
-      for (let i = 0; i < localStorage.length; i++) {
-        const k = localStorage.key(i);
-        if (k && k.startsWith('labcharts')) keysToRemove.push(k);
+    document.getElementById('passphrase-forgot-confirm')?.addEventListener('click', async () => {
+      try {
+        const { eraseAllLocalAppData } = await import('./data-wipe.js');
+        await eraseAllLocalAppData();
+      } catch {
+        const keysToRemove = [];
+        for (let i = 0; i < localStorage.length; i++) {
+          const k = localStorage.key(i);
+          if (k && k.startsWith('labcharts')) keysToRemove.push(k);
+        }
+        keysToRemove.forEach(k => localStorage.removeItem(k));
       }
-      keysToRemove.forEach(k => localStorage.removeItem(k));
       _sessionKey = null;
       overlay.style.display = 'none';
       overlay.innerHTML = '';

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -341,34 +341,63 @@ export function preserveFreshLocalLabEntries(merged, local, now = Date.now()) {
 // Get/set helpers for the dotted path.
 // Exported so sync.js can plan deltas at nested paths (e.g.
 // `lightEnvironment.rooms`) without re-implementing the walk.
+const _hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+function _isSafePathSegment(segment) {
+  return (
+    typeof segment === 'string'
+    && segment !== ''
+    && segment !== '__proto__'
+    && segment !== 'constructor'
+    && segment !== 'prototype'
+  );
+}
+
+function _splitSafePath(path) {
+  if (typeof path !== 'string') return null;
+  const parts = path.split('.');
+  return parts.every(_isSafePathSegment) ? parts : null;
+}
+
 export function getAt(obj, path) {
   if (!obj) return undefined;
-  const parts = path.split('.');
+  const parts = _splitSafePath(path);
+  if (!parts) return undefined;
   let cur = obj;
   for (const p of parts) {
     if (cur == null || typeof cur !== 'object') return undefined;
+    if (!_hasOwn(cur, p)) return undefined;
     cur = cur[p];
   }
   return cur;
 }
-// Reject any path segment that would walk Object.prototype. setAt is only
-// called with allowlisted importedData paths, but defence-in-depth — a
-// future caller passing user input through here would otherwise enable
-// prototype pollution (the same class of bug `_isAllowlistSafeId` defends
-// against in sync.js). Mirrors that guard so both code paths agree.
-const _PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+// Reject any path segment that would walk Object.prototype. setAt currently
+// receives allowlisted importedData paths, but future caller mistakes should
+// fail closed instead of creating attacker-controlled prototype properties.
 export function setAt(obj, path, value) {
-  const parts = path.split('.');
-  for (const p of parts) {
-    if (_PROTO_KEYS.has(p)) return;
-  }
+  const parts = _splitSafePath(path);
+  if (!parts || !obj || typeof obj !== 'object') return false;
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const p = parts[i];
-    if (cur[p] == null || typeof cur[p] !== 'object') cur[p] = {};
+    const existing = _hasOwn(cur, p) ? cur[p] : undefined;
+    if (existing == null || typeof existing !== 'object') {
+      Object.defineProperty(cur, p, {
+        value: {},
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
     cur = cur[p];
   }
-  cur[parts[parts.length - 1]] = value;
+  Object.defineProperty(cur, parts[parts.length - 1], {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+  return true;
 }
 
 function naturalItemId(path, item) {

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -360,6 +360,14 @@ function _splitSafePath(path) {
 }
 
 function _defineDataProperty(obj, key, value) {
+  if (
+    typeof key !== 'string'
+    || key === '__proto__'
+    || key === 'constructor'
+    || key === 'prototype'
+  ) {
+    return false;
+  }
   try {
     Object.defineProperty(obj, key, {
       value,

--- a/js/data-merge.js
+++ b/js/data-merge.js
@@ -359,6 +359,20 @@ function _splitSafePath(path) {
   return parts.every(_isSafePathSegment) ? parts : null;
 }
 
+function _defineDataProperty(obj, key, value) {
+  try {
+    Object.defineProperty(obj, key, {
+      value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function getAt(obj, path) {
   if (!obj) return undefined;
   const parts = _splitSafePath(path);
@@ -382,22 +396,11 @@ export function setAt(obj, path, value) {
     const p = parts[i];
     const existing = _hasOwn(cur, p) ? cur[p] : undefined;
     if (existing == null || typeof existing !== 'object') {
-      Object.defineProperty(cur, p, {
-        value: {},
-        enumerable: true,
-        configurable: true,
-        writable: true,
-      });
+      if (!_defineDataProperty(cur, p, {})) return false;
     }
     cur = cur[p];
   }
-  Object.defineProperty(cur, parts[parts.length - 1], {
-    value,
-    enumerable: true,
-    configurable: true,
-    writable: true,
-  });
-  return true;
+  return _defineDataProperty(cur, parts[parts.length - 1], value);
 }
 
 function naturalItemId(path, item) {

--- a/js/data-wipe.js
+++ b/js/data-wipe.js
@@ -1,0 +1,86 @@
+// @ts-check
+// data-wipe.js — destructive local storage cleanup helpers
+
+async function deleteIndexedDBDatabase(name) {
+  if (!name || typeof indexedDB === 'undefined') return;
+  await new Promise((resolve) => {
+    try {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      // If another open connection blocks deletion, resolve so callers can
+      // continue to reload; the browser completes the delete when handles close.
+      req.onblocked = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+function collectKnownProfileIds() {
+  const ids = new Set(['default']);
+  try {
+    const active = localStorage.getItem('labcharts-active-profile');
+    if (active) ids.add(active);
+  } catch {}
+  try {
+    const raw = localStorage.getItem('labcharts-profiles');
+    if (raw && !raw.startsWith('v1:')) {
+      const profiles = JSON.parse(raw);
+      if (Array.isArray(profiles)) {
+        for (const profile of profiles) {
+          if (profile?.id && typeof profile.id === 'string') ids.add(profile.id);
+        }
+      }
+    }
+  } catch {}
+  return [...ids];
+}
+
+async function deleteIndexedDBDatabasesByPrefix(prefixes, fallbackNames = []) {
+  const names = new Set(fallbackNames);
+  try {
+    if (typeof indexedDB?.databases === 'function') {
+      const dbs = await indexedDB.databases();
+      for (const db of dbs || []) {
+        const name = db?.name || '';
+        if (prefixes.some(prefix => name.startsWith(prefix))) names.add(name);
+      }
+    }
+  } catch {}
+  await Promise.all([...names].map(deleteIndexedDBDatabase));
+}
+
+async function deleteAppCaches() {
+  try {
+    if (typeof caches === 'undefined' || typeof caches.keys !== 'function') return;
+    const keys = await caches.keys();
+    await Promise.all(keys
+      .filter(key => key.startsWith('labcharts-'))
+      .map(key => caches.delete(key)));
+  } catch {}
+}
+
+export async function eraseAllLocalAppData() {
+  const profileIds = collectKnownProfileIds();
+  const keysToRemove = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith('labcharts')) keysToRemove.push(key);
+    }
+  } catch {}
+
+  for (const key of keysToRemove) {
+    try { localStorage.removeItem(key); } catch {}
+  }
+
+  await deleteIndexedDBDatabasesByPrefix(
+    ['labcharts-wearables-'],
+    profileIds.map(id => `labcharts-wearables-${id}`),
+  );
+  await deleteIndexedDBDatabase('labcharts-blobs');
+  await deleteIndexedDBDatabase('getbased-cashu');
+  await deleteAppCaches();
+}
+

--- a/js/export.js
+++ b/js/export.js
@@ -964,6 +964,7 @@ export async function clearAllData() {
       // The `-imported` blob lives in IndexedDB now → encryptedRemoveItem
       // hits both backends so the IDB residue is also wiped.
       await encryptedRemoveItem(profileStorageKey(id, 'imported'));
+      await encryptedRemoveItem(profileStorageKey(id, 'imported-corrupt'));
       localStorage.removeItem(profileStorageKey(id, 'units'));
       localStorage.removeItem(profileStorageKey(id, 'suppOverlay'));
       localStorage.removeItem(profileStorageKey(id, 'noteOverlay'));
@@ -991,6 +992,10 @@ export async function clearAllData() {
       localStorage.removeItem(`labcharts-${id}-cycleTour`);
       localStorage.removeItem(`labcharts-${id}-phaseOverlay`);
       localStorage.removeItem(`labcharts-${id}-sync-ts`);
+      try {
+        const { deleteWearablesDB } = await import('./wearables-store.js');
+        await deleteWearablesDB(id);
+      } catch {}
     }
     // Reset to single default profile
     const defaultId = profiles[0]?.id || 'default';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,9 +1215,9 @@
       }
     },
     "node_modules/jsdom/node_modules/undici": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
-      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1951,9 +1951,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/service-worker.js
+++ b/service-worker.js
@@ -228,6 +228,7 @@ const APP_SHELL = [
   '/js/recommendations.js',
   '/js/recommendations-region.js',
   '/js/crypto.js',
+  '/js/data-wipe.js',
   '/js/backup.js',
   '/js/lab-context.js',
   '/js/markdown.js',

--- a/tests/api-network-runtime.test.js
+++ b/tests/api-network-runtime.test.js
@@ -337,6 +337,9 @@ describe('AI proxy runtime behavior', () => {
       'https://169.254.169.254/latest/meta-data/',
       'https://168.63.129.16/metadata',
       'https://[::ffff:127.0.0.1]/private',
+      'https://[::ffff:c0a8:101]/private',
+      'https://[::ffff:ac10:1]/private',
+      'https://[2002:c0a8:0101::1]/private',
       'not a url',
     ]) {
       const response = await proxyHandler(makeProxyRequest({ url }));

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
 
 import { updateKeyCache } from '../js/crypto.js';
 import {
@@ -36,6 +37,10 @@ function jsonResponse(body, init = {}) {
     status: init.status || 200,
     headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
   });
+}
+
+function sha256Base64Url(value) {
+  return createHash('sha256').update(value).digest('base64url');
 }
 
 function clearKeyCaches() {
@@ -216,6 +221,19 @@ describe('API provider runtime behavior', () => {
     expect(JSON.parse(fetch.mock.calls.at(-1)[1].body)).toEqual({
       code: 'code-b',
       code_verifier: 'verifier-b',
+      code_challenge_method: 'S256',
+    });
+    expect(sessionStorage.getItem('or_pkce_verifier')).toBeNull();
+    expect(sessionStorage.getItem('or_oauth_state')).toBeNull();
+
+    sessionStorage.setItem('or_pkce_verifier', 'verifier-c');
+    sessionStorage.setItem('or_oauth_state', `sha256:${sha256Base64Url('state-c')}`);
+    fetch.mockResolvedValueOnce(jsonResponse({ key: 'sk-hashed' }));
+
+    await expect(exchangeOpenRouterCode('code-c', 'state-c')).resolves.toBe('sk-hashed');
+    expect(JSON.parse(fetch.mock.calls.at(-1)[1].body)).toEqual({
+      code: 'code-c',
+      code_verifier: 'verifier-c',
       code_challenge_method: 'S256',
     });
     expect(sessionStorage.getItem('or_pkce_verifier')).toBeNull();

--- a/tests/playwright/data-merge-browser-coverage.spec.js
+++ b/tests/playwright/data-merge-browser-coverage.spec.js
@@ -216,8 +216,15 @@ test('data merge browser coverage covers array mutations and rebroadcast predica
     const nested = {};
     dm.setAt(nested, 'lightEnvironment.rooms', [{ id: 'room-1' }]);
     dm.setAt(nested, '__proto__.polluted', true);
+    dm.setAt(nested, 'constructor.prototype.polluted', true);
+    dm.setAt(nested, 'prototype.polluted', true);
+    const inheritedPath = Object.create({ lightEnvironment: { rooms: [{ id: 'inherited' }] } });
+    dm.setAt(inheritedPath, 'lightEnvironment.rooms', [{ id: 'own-room' }]);
     outcomes.setAtCreatesNestedPaths = dm.getAt(nested, 'lightEnvironment.rooms.0.id') === 'room-1';
     outcomes.getAtReturnsUndefinedForNullRoot = dm.getAt(null, 'anything') === undefined;
+    outcomes.getAtIgnoresInheritedPath = dm.getAt(Object.create({ lightEnvironment: { rooms: [] } }), 'lightEnvironment.rooms') === undefined;
+    outcomes.setAtWritesOwnPathOverInherited = Object.prototype.hasOwnProperty.call(inheritedPath, 'lightEnvironment')
+      && inheritedPath.lightEnvironment.rooms[0].id === 'own-room';
     outcomes.setAtRejectsPrototypePollution = !({}).polluted;
 
     const idsBlob = {};

--- a/tests/playwright/data-merge-browser-coverage.spec.js
+++ b/tests/playwright/data-merge-browser-coverage.spec.js
@@ -226,6 +226,8 @@ test('data merge browser coverage covers array mutations and rebroadcast predica
     outcomes.setAtWritesOwnPathOverInherited = Object.prototype.hasOwnProperty.call(inheritedPath, 'lightEnvironment')
       && inheritedPath.lightEnvironment.rooms[0].id === 'own-room';
     outcomes.setAtRejectsPrototypePollution = !({}).polluted;
+    outcomes.setAtReturnsFalseForFrozenTarget =
+      dm.setAt(Object.freeze({}), 'lightEnvironment.rooms', []) === false;
 
     const idsBlob = {};
     const firstNotes = dm.ensureImportedArray(idsBlob, 'notes');

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -231,8 +231,8 @@ assert('Per-file import storage changelog is user-facing, not a technical fix lo
   !/Greptile|bugfix|bugfixes|production hardening|UI polish|tombstone|CRDT|manualValues|fixed|tightened before release/i.test(changelogSrc.slice(changelogSrc.indexOf("version: '1.10.6'"), changelogSrc.indexOf("version: '1.9.0'"))));
 assert('Biology Scores changelog is announcement-style, not a technical fix log',
   !/Greptile|bugfix|bugfixes|production hardening|UI polish|stale explanation|sync|CRP\/hs-CRP|fixed|tightened before release/i.test(changelogSrc.slice(changelogSrc.indexOf("version: '1.9.0'"), changelogSrc.indexOf("version: '1.8.550'"))));
-assert('APP_VERSION is bumped for per-file lab import storage',
-  appVersion === '1.10.6', appVersion);
+assert('APP_VERSION is at least the per-file lab import storage release',
+  versionMatch && semverGte(appVersion, '1.10.6'), appVersion);
 assert('APP_VERSION is at least the Biology Scores main release',
   versionMatch && semverGte(appVersion, '1.9.0'), appVersion);
 

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -237,6 +237,7 @@ console.log('8. Service worker');
 try {
   const swText = read('service-worker.js');
   assert('Service worker contains /js/crypto.js', swText.includes('/js/crypto.js'));
+  assert('Service worker contains /js/data-wipe.js', swText.includes('/js/data-wipe.js'));
   assert('SW uses importScripts for version', swText.includes("importScripts('/version.js')"));
   assert('SW CACHE_NAME uses semver', swText.includes('`labcharts-v${self.APP_VERSION}`'));
 } catch (e) {
@@ -381,6 +382,7 @@ try {
   assert('Forgot passphrase does NOT use showConfirmDialog', !src.includes("forgotBtn.addEventListener('click', () => {\n    showConfirmDialog"));
   assert('Forgot passphrase has inline confirm UI', src.includes('passphrase-forgot-confirm'));
   assert('Forgot passphrase has Go Back button', src.includes('passphrase-forgot-cancel'));
+  assert('Forgot passphrase wipes IndexedDB-backed app data', src.includes("import('./data-wipe.js'") && src.includes('eraseAllLocalAppData'));
   const bkSrc0 = await fetchWithRetry('js/backup.js');
   assert('Backup includes encryptionSalt field', bkSrc0.includes('encryptionSalt'));
   assert('Restore sets labcharts-encryption-enabled', bkSrc0.includes("localStorage.setItem('labcharts-encryption-enabled'"));

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -105,6 +105,8 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
   setAt(inheritedPath, '__proto__.polluted', true);
   assert('setAt rejects prototype-polluting path segments',
     !({}).polluted);
+  assert('setAt returns false instead of throwing on frozen targets',
+    setAt(Object.freeze({}), 'lightEnvironment.rooms', []) === false);
 
   // ─── 2. unionById additivity ──────────────────────────────────────────
   console.log('%c 2. unionById additive merge ', 'font-weight:bold;color:#f59e0b');

--- a/tests/test-data-merge.js
+++ b/tests/test-data-merge.js
@@ -28,6 +28,8 @@ const {
   recordTombstone,
   recordArrayItemTombstone,
   clearTombstone,
+  getAt,
+  setAt,
   sortImportedArray,
   trimImportedArray,
   unionById,
@@ -90,6 +92,19 @@ const { DELTA_ARRAY_CONFIG } = await import('../js/sync-delta-surface-config.js'
     assert(`tombstone path covers ${path}`, TOMBSTONE_ARRAY_PATHS.includes(path));
   }
   assert('entries is an explicit tombstone path', TOMBSTONE_ARRAY_PATHS.includes('entries'));
+
+  const inheritedPath = Object.create({ lightEnvironment: { rooms: [{ id: 'inherited' }] } });
+  assert('getAt ignores inherited path containers',
+    getAt(inheritedPath, 'lightEnvironment.rooms') === undefined);
+  setAt(inheritedPath, 'lightEnvironment.rooms', [{ id: 'own-room' }]);
+  assert('setAt writes own path containers over inherited values',
+    Object.prototype.hasOwnProperty.call(inheritedPath, 'lightEnvironment')
+      && inheritedPath.lightEnvironment.rooms[0].id === 'own-room');
+  setAt(inheritedPath, 'constructor.prototype.polluted', true);
+  setAt(inheritedPath, 'prototype.polluted', true);
+  setAt(inheritedPath, '__proto__.polluted', true);
+  assert('setAt rejects prototype-polluting path segments',
+    !({}).polluted);
 
   // ─── 2. unionById additivity ──────────────────────────────────────────
   console.log('%c 2. unionById additive merge ', 'font-weight:bold;color:#f59e0b');

--- a/tests/test-dev-server-helpers.js
+++ b/tests/test-dev-server-helpers.js
@@ -153,7 +153,7 @@ assert('CAMS dev proxy defaults to hosted getbased-uvdata',
     'WITHINGS_CLIENT_SECRET=unquoted-value-with-dashes\n' +
     'ULTRAHUMAN_CLIENT_SECRET=\'single-quoted\'\n'
   );
-assert('real-world .env.local round-trips',
+  assert('real-world .env.local round-trips',
     p.OURA_CLIENT_SECRET === 'S3cr3tVal' &&
     p.WITHINGS_CLIENT_SECRET === 'unquoted-value-with-dashes' &&
     p.ULTRAHUMAN_CLIENT_SECRET === 'single-quoted',

--- a/tests/test-dev-server-helpers.js
+++ b/tests/test-dev-server-helpers.js
@@ -8,6 +8,7 @@
 //   - _isAllowedProxyUrl: vendor-allowlist shortcuts + HTTPS-public-host fallback
 //   - _resolveCatalogRepo: env-override path, symlink-to-other-repo path,
 //                       refusal to push the app repo when there's no symlink
+//   - _isValidCatalogShape: deploy-catalog shape parity with fetch-catalog
 //   - _runPostDeployHooks: end-to-end Deploy button hooks (git commit + push
 //                       in catalog repo, Vercel deploy hook trigger). Each
 //                       step gated on env config; downstream skipped when
@@ -28,6 +29,7 @@ import {
   WEARABLE_CLIENT_ID_VARS,
   DEFAULT_UVDATA_UPSTREAM,
   isSameOrigin,
+  _isValidCatalogShape,
   _isLoopbackSocket,
   _isHostOriginMatch,
   corsHeaders,
@@ -151,12 +153,23 @@ assert('CAMS dev proxy defaults to hosted getbased-uvdata',
     'WITHINGS_CLIENT_SECRET=unquoted-value-with-dashes\n' +
     'ULTRAHUMAN_CLIENT_SECRET=\'single-quoted\'\n'
   );
-  assert('real-world .env.local round-trips',
+assert('real-world .env.local round-trips',
     p.OURA_CLIENT_SECRET === 'S3cr3tVal' &&
     p.WITHINGS_CLIENT_SECRET === 'unquoted-value-with-dashes' &&
     p.ULTRAHUMAN_CLIENT_SECRET === 'single-quoted',
     JSON.stringify(p));
 }
+
+console.log('\n── _isValidCatalogShape ──');
+
+assert('catalog shape requires slots and products',
+  _isValidCatalogShape({ slots: {}, products: {} }));
+assert('catalog shape does not require legacy shops key',
+  _isValidCatalogShape({ slots: {}, products: {}, vendors: {} }));
+assert('catalog shape rejects missing products',
+  !_isValidCatalogShape({ slots: {}, shops: [] }));
+assert('catalog shape rejects arrays and null',
+  !_isValidCatalogShape([]) && !_isValidCatalogShape(null));
 
 console.log('\n── _proxyHostBlocked ──');
 
@@ -168,6 +181,10 @@ assert('blocks [::1]',         _proxyHostBlocked('[::1]'));
 assert('blocks .local TLD',    _proxyHostBlocked('server.local'));
 assert('blocks .localhost',    _proxyHostBlocked('foo.localhost'));
 assert('blocks 127/8 edges',   _proxyHostBlocked('127.255.255.254') && _proxyHostBlocked('127.0.0.42'));
+assert('blocks compressed IPv4-mapped private IPv6',
+  _proxyHostBlocked('::ffff:c0a8:101') && _proxyHostBlocked('::ffff:ac10:1'));
+assert('blocks 6to4 private IPv4 embeddings',
+  _proxyHostBlocked('2002:c0a8:0101::1') && _proxyHostBlocked('2002:0a00:0001::1'));
 
 // Private RFC1918
 assert('blocks 10.0.0.0/8',     _proxyHostBlocked('10.0.0.1') && _proxyHostBlocked('10.255.255.254'));
@@ -232,6 +249,8 @@ assert('allows custom HTTPS public host', _isAllowedProxyUrl('https://api.exampl
 assert('blocks HTTP (no TLS)',         !_isAllowedProxyUrl('http://api.example.com/v1/chat'));
 assert('blocks loopback',              !_isAllowedProxyUrl('https://localhost/admin'));
 assert('blocks private IP',            !_isAllowedProxyUrl('https://192.168.1.1/admin'));
+assert('blocks compressed IPv4-mapped private IP', !_isAllowedProxyUrl('https://[::ffff:c0a8:101]/admin'));
+assert('blocks 6to4 private IP',       !_isAllowedProxyUrl('https://[2002:c0a8:0101::1]/admin'));
 assert('blocks cloud metadata',        !_isAllowedProxyUrl('https://169.254.169.254/latest/meta-data/'));
 assert('blocks .local',                !_isAllowedProxyUrl('https://box.local/admin'));
 assert('blocks malformed URL',         !_isAllowedProxyUrl('not a url'));

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -420,6 +420,8 @@ return (async function() {
   // Verify it clears the expected storage keys. The `-imported` blob lives in
   // IndexedDB now → encryptedRemoveItem hits both backends.
   assert('Clears imported data key', exportSrc.includes("encryptedRemoveItem(profileStorageKey(id, 'imported'))"));
+  assert('Clears corrupt imported data key', exportSrc.includes("encryptedRemoveItem(profileStorageKey(id, 'imported-corrupt'))"));
+  assert('Clears wearable profile IDB', /clearAllData[\s\S]*?deleteWearablesDB\(id\)/.test(exportSrc));
   assert('Clears units key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'units'))"));
   assert('Clears suppOverlay key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'suppOverlay'))"));
   assert('Clears noteOverlay key', exportSrc.includes("localStorage.removeItem(profileStorageKey(id, 'noteOverlay'))"));

--- a/tests/test-security-phase1.js
+++ b/tests/test-security-phase1.js
@@ -65,10 +65,13 @@ const apiSrc = read('js/api.js');
 assert('startOpenRouterOAuth sends state param',
   apiSrc.includes("&state=' + encodeURIComponent(state)"),
   'login-CSRF needs state, PKCE alone is insufficient');
-assert('startOpenRouterOAuth stores state in sessionStorage',
-  apiSrc.includes("sessionStorage.setItem('or_oauth_state', state)"));
-assert('exchangeOpenRouterCode verifies returned state',
-  apiSrc.includes('returnedState !== expectedState'));
+assert('startOpenRouterOAuth stores only a state digest in sessionStorage',
+  apiSrc.includes('const stateDigest = await _sha256Base64Url(state)')
+    && apiSrc.includes("sessionStorage.setItem('or_oauth_state', `sha256:${stateDigest}`)")
+    && !apiSrc.includes("sessionStorage.setItem('or_oauth_state', state)"));
+assert('exchangeOpenRouterCode verifies returned state digest and legacy state',
+  apiSrc.includes('returnedStateDigest === expectedState')
+    && apiSrc.includes('returnedState === expectedState'));
 assert('exchangeOpenRouterCode clears state on success and on mismatch',
   (apiSrc.match(/sessionStorage\.removeItem\('or_oauth_state'\)/g) || []).length >= 2);
 const startupOAuthSrc = read('js/startup-oauth-callbacks.js');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.6';
+self.APP_VERSION = '1.10.7';


### PR DESCRIPTION
## Summary

- Add a shared local data wipe helper and route forgot-passphrase cleanup through it.
- Harden proxy/dev-server SSRF guards for compressed IPv4-mapped IPv6 and 6to4 private embeddings.
- Update `undici` lockfile entries to patched versions for the open Dependabot alerts.
- Harden `data-merge` path access against prototype pollution and inherited path traversal.
- Store OpenRouter OAuth state as a SHA-256 digest while keeping legacy in-flight callback compatibility.
- Align dev catalog deployment validation with production `fetch-catalog` by requiring `slots` and `products`.
- Expand regression coverage and bump `APP_VERSION` for cache invalidation.

## Why

This follows the full codebase audit and GitHub security/quality review. The branch addresses the active `undici` Dependabot alerts, the open CodeQL findings around prototype pollution and clear-text OAuth state storage, and a small catalog validation gap from PR #527.

## Validation

- `npm audit --omit=dev`
- `npm run quality`
- `npm run typecheck`
- `./run-tests.sh`
  - Vitest: 13 files, 191 tests
  - dev-server origin guard: 18/18
  - Playwright: 332/332

## Notes

The default branch still shows Dependabot alerts until this branch lands and GitHub re-evaluates the patched lockfile.