### PR TITLE
[codex] Add checkJs pilot typecheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run typecheck
         run: npm run typecheck
 
+      - name: Run checkJs pilot
+        run: npm run typecheck:checkjs
+
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         with:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:playwright": "playwright test",
     "typecheck": "tsc -p tsconfig.json",
+    "typecheck:checkjs": "tsc -p tsconfig.checkjs.json",
     "test:watch": "vitest"
   },
   "devDependencies": {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,6 +13,7 @@ fi
 
 if [ "$SKIP_TYPECHECK" != "1" ] && [ "$SKIP_TYPECHECK" != "true" ]; then
   npm run typecheck || exit 1
+  npm run typecheck:checkjs || exit 1
 fi
 
 # Start server if not already running. nohup + disown fully detaches it

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -1,0 +1,15 @@
+{
+  "description": "Pilot checkJs config. noResolve is intentional for the initial narrow scope; remove it when expanding this check across module boundaries.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "checkJs": true,
+    "noResolve": true
+  },
+  "include": [
+    "js/utils.js",
+    "js/url-safety.js",
+    "js/data-merge.js",
+    "js/api-transport.js",
+    "js/marker-detail-store.js"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a dedicated `tsconfig.checkjs.json` pilot with `checkJs` enabled for a small set of low-level modules.
- Add `npm run typecheck:checkjs` so the stricter JS check can run independently from the existing project typecheck.

## Why

This starts tightening JavaScript type contracts without turning `checkJs` on for the whole app at once. The initial scope stays deliberately small and green.

## Validation

- `npm run typecheck:checkjs`
- `npm run typecheck`
- `npm audit --omit=dev`
- `npm test`
- `node scripts/quality-guardrails.mjs`