### PR TITLE
[codex] Expand checkJs pilot coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -10,6 +10,16 @@
     "js/url-safety.js",
     "js/data-merge.js",
     "js/api-transport.js",
-    "js/marker-detail-store.js"
+    "js/marker-detail-store.js",
+    "js/health-goals-utils.js",
+    "js/secondary-unit-conversions.js",
+    "js/markdown.js",
+    "js/sync-delta-id.js",
+    "js/sync-delta-row-codec.js",
+    "js/sync-delta-merge-shapes.js",
+    "js/sync-delta-surface-config.js",
+    "js/sync-delta-scalar-merge.js",
+    "js/sync-delta-array-merge.js",
+    "js/sync-delta-map-merge.js"
   ]
 }


### PR DESCRIPTION
## Summary

- Expand `tsconfig.checkjs.json` from 5 to 15 checked JavaScript modules.
- Add focused helper and sync-delta modules that pass under the existing pilot settings.

## Why

This continues the incremental `checkJs` rollout without broadening the gate to the whole app at once. The added files are low-level helpers or bounded sync-delta modules, keeping the CI signal green and actionable.

## Validation

- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`