### PR TITLE
[codex] Expand checkJs sync coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -20,6 +20,16 @@
     "js/sync-delta-surface-config.js",
     "js/sync-delta-scalar-merge.js",
     "js/sync-delta-array-merge.js",
-    "js/sync-delta-map-merge.js"
+    "js/sync-delta-map-merge.js",
+    "js/sync-delta-scalar-planner.js",
+    "js/sync-delta-array-planner.js",
+    "js/sync-delta-map-planner.js",
+    "js/sync-delta-planner-context.js",
+    "js/sync-delta-planners.js",
+    "js/sync-delta-readiness.js",
+    "js/sync-delta-snapshot.js",
+    "js/sync-delta-pull-snapshot.js",
+    "js/sync-delta-telemetry.js",
+    "js/sync-delta-observability-context.js"
   ]
 }


### PR DESCRIPTION
## Summary
- expand the checkJs pilot to the next batch of sync delta planner, readiness, snapshot, telemetry, and observability modules
- keep the pilot scoped to modules that already pass isolated `allowJs`/`checkJs` validation

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`