### PR TITLE
[codex] Expand checkJs sync diagnostics coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -30,6 +30,15 @@
     "js/sync-delta-snapshot.js",
     "js/sync-delta-pull-snapshot.js",
     "js/sync-delta-telemetry.js",
-    "js/sync-delta-observability-context.js"
+    "js/sync-delta-observability-context.js",
+    "js/sync-delta-surfaces.js",
+    "js/sync-delta-registry.js",
+    "js/sync-delta-merge.js",
+    "js/sync-delta.js",
+    "js/sync-delta-observability.js",
+    "js/sync-diagnostics-context.js",
+    "js/sync-diagnostics-text.js",
+    "js/sync-diagnostics-snapshot.js",
+    "js/sync-diagnose-actions-context.js"
   ]
 }


### PR DESCRIPTION
## Summary
- expand the checkJs pilot to the remaining sync-delta modules
- add the sync diagnostics context, text, snapshot, and action-context modules that pass isolated `checkJs`
- leave `sync-diagnose-identity-actions.js` out because it still needs typing for `window.showConfirmDialog`

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`