### PR TITLE
[codex] Expand checkJs sync helper coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -47,6 +47,19 @@
     "js/sync-diagnose-actions.js",
     "js/sync-diagnose-render.js",
     "js/sync-diagnose-ui.js",
-    "js/sync-diagnostics.js"
+    "js/sync-diagnostics.js",
+    "js/sync-schema.js",
+    "js/sync-settings-state.js",
+    "js/sync-state.js",
+    "js/sync-environment.js",
+    "js/sync-tombstones.js",
+    "js/sync-relay-health.js",
+    "js/sync-disable-cleanup.js",
+    "js/sync-storage-cleanup.js",
+    "js/sync-recovery.js",
+    "js/sync-payload-collectors.js",
+    "js/sync-payload.js",
+    "js/sync-apply.js",
+    "js/sync-reconcile.js"
   ]
 }


### PR DESCRIPTION
## Summary
- Extend the checkJs pilot include list to cover low-level sync helper modules for schema, state, environment, cleanup, payload, apply, and reconcile behavior.
- Keep the existing `noResolve` pilot boundary unchanged.

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`

Note: Vercel preview checks may fail while the account is over the preview deployment quota; local Vercel build was validated during the previous PR investigation.