### PR TITLE
[codex] Expand checkJs sync orchestration coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -60,6 +60,27 @@
     "js/sync-payload-collectors.js",
     "js/sync-payload.js",
     "js/sync-apply.js",
-    "js/sync-reconcile.js"
+    "js/sync-reconcile.js",
+    "js/sync-chat-apply.js",
+    "js/sync-messenger.js",
+    "js/sync-save-hooks.js",
+    "js/sync-configure.js",
+    "js/sync-cutover.js",
+    "js/sync-identity.js",
+    "js/sync-init.js",
+    "js/sync-lifecycle.js",
+    "js/sync-runtime.js",
+    "js/sync-pull-active-refresh.js",
+    "js/sync-pull-maintenance.js",
+    "js/sync-pull-merge.js",
+    "js/sync-pull-rebroadcast.js",
+    "js/sync-pull.js",
+    "js/sync-push-deltas.js",
+    "js/sync-push.js",
+    "js/sync-subscriptions.js",
+    "js/sync-actions.js",
+    "js/sync-ui.js",
+    "js/sync-window-bindings.js",
+    "js/sync.js"
   ]
 }


### PR DESCRIPTION
## Summary
- Extend the checkJs pilot include list to cover the remaining sync orchestration, pull/push, subscription, UI, and window binding modules.
- Keep the existing `noResolve` pilot boundary unchanged.

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`

Note: Vercel preview checks may fail while the account is over the preview deployment quota.