### PR TITLE
[codex] enable module-aware checkjs coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -1,9 +1,8 @@
 {
-  "description": "Pilot checkJs config. noResolve is intentional for the initial narrow scope; remove it when expanding this check across module boundaries.",
+  "description": "Pilot checkJs config for selected JavaScript modules and their local dependency graph.",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "checkJs": true,
-    "noResolve": true
+    "checkJs": true
   },
   "include": [
     "types/globals.d.ts",

--- a/update-vendor.sh
+++ b/update-vendor.sh
@@ -18,6 +18,11 @@ JSZIP_VERSION="3.10.1"
 # bundler pass that produces a single resolved ESM. Tracked as phase 2c
 # in memory/project_browser_local_lens.md.
 # Google Fonts: no version pin — re-run to fetch latest files
+#
+# Manually bundled vendor files not downloaded here, including
+# vendor/evolu/evolu-bundle.js and vendor/venice-e2ee.js, must preserve
+# `// @ts-nocheck` as their first line when regenerated so checkJs does not
+# type-check third-party bundle internals.
 # ───────────────────────────────────────────────────────────────────────────
 
 VENDOR_DIR="vendor"

--- a/vendor/evolu/evolu-bundle.js
+++ b/vendor/evolu/evolu-bundle.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // node_modules/@evolu/common/dist/src/Array.js
 var isNonEmptyArray = (array2) => array2.length > 0;
 var isNonEmptyReadonlyArray = (array2) => array2.length > 0;

--- a/vendor/venice-e2ee.js
+++ b/vendor/venice-e2ee.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // node_modules/@noble/secp256k1/index.js
 var secp256k1_CURVE = {
   p: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2fn,


### PR DESCRIPTION
## Summary
- remove the `noResolve` bypass from the checkJs pilot config so selected JavaScript modules are checked through their local dependency graph
- mark generated vendor bundles with `// @ts-nocheck` so TypeScript does not type-check third-party bundled output as app source

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`