### PR TITLE
[codex] expand checkjs lens local coverage

### DIFF
--- a/js/lens-local-parsers.js
+++ b/js/lens-local-parsers.js
@@ -138,7 +138,8 @@ const _scriptLoads = new Map(); // src → Promise
  * @returns {Promise<void>}
  */
 function loadScript(src) {
-  if (_scriptLoads.has(src)) return _scriptLoads.get(src);
+  const cached = _scriptLoads.get(src);
+  if (cached) return cached;
   // Already on the page? (Main app preloads pdf.js for the PDF-import
   // pipeline, so the <script> tag is there before we need it.)
   if ([...document.scripts].some((s) => s.src.endsWith(src))) {
@@ -148,7 +149,7 @@ function loadScript(src) {
   const p = new Promise((resolve, reject) => {
     const s = document.createElement('script');
     s.src = src;
-    s.onload = () => resolve();
+    s.onload = () => resolve(undefined);
     s.onerror = () => reject(new Error(`Failed to load ${src}`));
     document.head.appendChild(s);
   });

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -14,6 +14,8 @@
     "js/health-goals-utils.js",
     "js/secondary-unit-conversions.js",
     "js/markdown.js",
+    "js/lens-local-utils.js",
+    "js/lens-local-parsers.js",
     "js/sync-delta-id.js",
     "js/sync-delta-row-codec.js",
     "js/sync-delta-merge-shapes.js",


### PR DESCRIPTION
## Summary
- add the lens-local utility and parser modules to the checkJs pilot coverage
- tighten the lazy script loader Promise cache so it always returns a concrete `Promise<void>`
- resolve the script-load Promise with an explicit `undefined` for checkJs compatibility

## Validation
- `npm run typecheck:checkjs`
- `npm test -- tests/lens-local-runtime.test.js`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`