### PR TITLE
[codex] expand checkjs api provider coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -10,6 +10,7 @@
     "js/url-safety.js",
     "js/data-merge.js",
     "js/api-transport.js",
+    "js/api-provider-storage.js",
     "js/marker-detail-store.js",
     "js/health-goals-utils.js",
     "js/secondary-unit-conversions.js",


### PR DESCRIPTION
## Summary
- add `js/api-provider-storage.js` to the checkJs pilot include list
- ratchet provider settings/model-cache storage under the existing JavaScript type-checking gate

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`