### PR TITLE
[codex] expand checkjs api models coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -11,6 +11,7 @@
     "js/data-merge.js",
     "js/api-transport.js",
     "js/api-provider-storage.js",
+    "js/api-models.js",
     "js/marker-detail-store.js",
     "js/health-goals-utils.js",
     "js/secondary-unit-conversions.js",


### PR DESCRIPTION
## Summary
- add `js/api-models.js` to the checkJs pilot include list
- ratchet provider model catalog, pricing, and capability helpers under the existing JavaScript type-checking gate

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`