### PR TITLE
[codex] expand checkjs provider panel coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -12,6 +12,8 @@
     "js/api-transport.js",
     "js/api-provider-storage.js",
     "js/api-models.js",
+    "js/provider-model-controls.js",
+    "js/provider-panel-renderers.js",
     "js/marker-detail-store.js",
     "js/health-goals-utils.js",
     "js/secondary-unit-conversions.js",


### PR DESCRIPTION
## Summary
- add `js/provider-model-controls.js` and `js/provider-panel-renderers.js` to the checkJs pilot include list
- ratchet provider model controls and panel rendering helpers under the existing JavaScript type-checking gate

## Validation
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`