### PR TITLE
[codex] expand checkjs wallet core coverage

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -18,6 +18,8 @@
     "js/provider-wallet-delegates.js",
     "js/provider-wallet-panels.js",
     "js/provider-wallet-runtime.js",
+    "js/cashu-wallet.js",
+    "js/nostr-discovery.js",
     "js/marker-detail-store.js",
     "js/health-goals-utils.js",
     "js/secondary-unit-conversions.js",


### PR DESCRIPTION
## Summary
- add `js/cashu-wallet.js` and `js/nostr-discovery.js` to the checkJs pilot include list
- keep this wallet safety slice config-only: no Cashu proof, seed, balance, mint, send, withdraw, deposit, restore, or Nostr discovery runtime logic changed

## Validation
- `npx tsc --ignoreConfig --allowJs --checkJs --strict false --noEmit --target ES2022 --module Node16 --moduleResolution Node16 --lib ES2022,DOM,DOM.Iterable --skipLibCheck true types/globals.d.ts js/cashu-wallet.js js/nostr-discovery.js`
- `npm run typecheck:checkjs`
- `npm run typecheck`
- `node scripts/quality-guardrails.mjs`
- `npm test`