### PR TITLE
Add Terms and Privacy acceptance gate

### DIFF
--- a/css/app-shell.css
+++ b/css/app-shell.css
@@ -160,6 +160,102 @@
 .version-update-btn-primary:hover { filter: brightness(1.08); background: var(--accent); color: var(--on-accent); }
 body.analytics-consent-visible .version-update-banner { bottom: 78px; }
 
+/* Terms/Privacy acceptance gate */
+.modal-overlay.legal-consent-overlay {
+  z-index: 4200;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+}
+.legal-consent-modal {
+  width: min(620px, 100%);
+  background: var(--bg-secondary, #171a22);
+  border: 1px solid var(--border, #2d3138);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  color: var(--text-primary);
+}
+.legal-consent-kicker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.legal-consent-modal h2 { margin: 0 0 10px; font-size: 24px; }
+.legal-consent-copy { color: var(--text-secondary); line-height: 1.55; margin: 0 0 16px; }
+.legal-consent-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0 0 14px;
+}
+.legal-consent-summary > div {
+  padding: 10px 12px;
+  background: var(--bg-card, rgba(255,255,255,.04));
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.legal-consent-summary strong { color: var(--text-primary); }
+.legal-consent-points {
+  margin: 0 0 16px 18px;
+  padding: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.55;
+}
+.legal-consent-check {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 13px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-primary, rgba(0,0,0,.18));
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+.legal-consent-check input { margin-top: 3px; accent-color: var(--accent); }
+.legal-consent-check a { color: var(--accent); text-decoration: none; }
+.legal-consent-check a:hover { text-decoration: underline; }
+.legal-consent-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+.legal-consent-link { font-size: 13px; margin-right: auto; }
+.legal-consent-link + .legal-consent-link { margin-right: 0; }
+.legal-consent-accept {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--on-accent);
+  border-radius: 9px;
+  padding: 9px 16px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.legal-consent-accept:disabled {
+  opacity: .45;
+  cursor: not-allowed;
+  filter: grayscale(.35);
+}
+@media (max-width: 640px) {
+  .legal-consent-modal { padding: 18px; border-radius: 14px; }
+  .legal-consent-summary { grid-template-columns: 1fr; }
+  .legal-consent-actions { justify-content: stretch; }
+  .legal-consent-link { margin-right: 0; }
+  .legal-consent-accept { width: 100%; }
+}
+
 .layout { display: flex; min-height: calc(100vh - 57px); }
 .sidebar {
   width: 260px;

--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -147,7 +147,7 @@ function handleAppKeydown(e) {
 
   // Focus trap for open modals. Sync overlays use `.confirm-overlay` too.
   if (e.key === "Tab") {
-    const overlayIds = ["client-list-overlay", "changelog-modal-overlay", "report-builder-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "summary-modal-overlay", "light-env-assessment-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "data-protection-picker-overlay"];
+    const overlayIds = ["legal-consent-overlay", "client-list-overlay", "changelog-modal-overlay", "report-builder-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "summary-modal-overlay", "light-env-assessment-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "data-protection-picker-overlay"];
     for (const oid of overlayIds) {
       const ov = document.getElementById(oid);
       if (ov && ov.classList.contains("show")) {

--- a/js/app-foundation-modules.js
+++ b/js/app-foundation-modules.js
@@ -4,4 +4,5 @@
 import './schema.js';
 import './constants.js';
 import './utils.js';
+import './legal-consent.js';
 import './pii.js';

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -10,6 +10,14 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.9', date: '2026-06-23', title: 'Terms and Privacy gate priority',
+    forceShow: true,
+    items: [
+      '<b>Terms and Privacy now come first.</b> New browsers and stale-version re-consent see the legal gate before What\'s New, guided tours, backup nudges, analytics prompts, or deferred startup destinations.',
+      '<b>No competing overlays.</b> The changelog and guided tour refuse to open while the Terms/Privacy gate is visible, then resume only after acceptance.',
+    ]
+  },
+  {
     version: '1.10.8', date: '2026-06-22', title: 'Private PPQ chat with verified end-to-end encryption',
     forceShow: true,
     items: [
@@ -386,6 +394,7 @@ function _semverGt(a, b) {
 }
 
 export function maybeShowChangelog() {
+  if (document.getElementById('legal-consent-overlay')) return;
   const seen = getSeenVersion();
   // First visit — no changelog, just mark as seen
   if (!seen) { markChangelogSeen(); return; }

--- a/js/legal-consent.js
+++ b/js/legal-consent.js
@@ -1,0 +1,138 @@
+// @ts-check
+// legal-consent.js — first-launch Terms/Privacy gate and re-consent on document updates.
+
+const LEGAL_ACCEPTANCE_KEY = 'labcharts-legal-acceptance';
+export const TERMS_VERSION = '2026-06-22';
+export const PRIVACY_VERSION = '2026-06-22';
+
+const LEGAL_ACTION_ATTR = 'data-legal-consent-action';
+
+function nowIso() {
+  try { return new Date().toISOString(); } catch { return ''; }
+}
+
+export function getLegalAcceptance() {
+  try {
+    const raw = localStorage.getItem(LEGAL_ACCEPTANCE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasAcceptedCurrentLegal() {
+  const accepted = getLegalAcceptance();
+  return accepted?.termsVersion === TERMS_VERSION
+    && accepted?.privacyVersion === PRIVACY_VERSION
+    && accepted?.accepted === true;
+}
+
+export function isLegalConsentGateVisible() {
+  return !!document.getElementById('legal-consent-overlay');
+}
+
+function storeLegalAcceptance() {
+  const payload = {
+    accepted: true,
+    termsVersion: TERMS_VERSION,
+    privacyVersion: PRIVACY_VERSION,
+    acceptedAt: nowIso(),
+    appVersion: globalThis.APP_VERSION || null,
+    location: typeof location !== 'undefined' ? location.origin + location.pathname : null,
+  };
+  localStorage.setItem(LEGAL_ACCEPTANCE_KEY, JSON.stringify(payload));
+  return payload;
+}
+
+function shouldUseLocalLegalLinks() {
+  return location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+}
+
+function legalHref(path) {
+  return shouldUseLocalLegalLinks() ? path : `https://getbased.health${path}`;
+}
+
+function renderLegalConsentModal({ update = false } = {}) {
+  const intro = update
+    ? 'The Terms or Privacy Policy changed since this browser last accepted them. Please review and accept the current versions before continuing.'
+    : 'Before using getbased, please review and accept the Terms and Privacy Policy.';
+  const title = update ? 'Review updated Terms & Privacy' : 'Accept Terms & Privacy';
+  return `
+    <div class="legal-consent-modal" role="dialog" aria-modal="true" aria-labelledby="legal-consent-title" aria-describedby="legal-consent-desc">
+      <div class="legal-consent-kicker">getbased legal</div>
+      <h2 id="legal-consent-title">${title}</h2>
+      <p id="legal-consent-desc" class="legal-consent-copy">${intro}</p>
+      <div class="legal-consent-summary">
+        <div><strong>Terms:</strong> ${TERMS_VERSION}</div>
+        <div><strong>Privacy:</strong> ${PRIVACY_VERSION}</div>
+      </div>
+      <ul class="legal-consent-points">
+        <li>getbased is a wellness, self-tracking, and educational tool — not medical advice or a medical device.</li>
+        <li>Your health data is stored locally by default; optional network features are described in the Privacy Policy.</li>
+        <li>Anonymous, cookieless usage analytics may run on the hosted app and can be turned off in Settings → Privacy.</li>
+      </ul>
+      <label class="legal-consent-check">
+        <input type="checkbox" id="legal-consent-checkbox">
+        <span>I have read and agree to the <a href="${legalHref('/terms')}" target="_blank" rel="noopener">Terms of Service</a> and <a href="${legalHref('/privacy')}" target="_blank" rel="noopener">Privacy Policy</a>.</span>
+      </label>
+      <div class="legal-consent-actions">
+        <button type="button" class="legal-consent-accept" ${LEGAL_ACTION_ATTR}="accept" disabled>Accept & continue</button>
+      </div>
+    </div>`;
+}
+
+function closeLegalConsentGate() {
+  document.getElementById('legal-consent-overlay')?.remove();
+  document.body.classList.remove('legal-consent-visible');
+}
+
+function handleLegalConsentClick(event) {
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return;
+  const actionEl = target.closest(`[${LEGAL_ACTION_ATTR}]`);
+  if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
+  const action = actionEl.getAttribute(LEGAL_ACTION_ATTR);
+  if (action !== 'accept') return;
+  event.preventDefault();
+  const checkbox = /** @type {HTMLInputElement | null} */ (document.getElementById('legal-consent-checkbox'));
+  if (!checkbox?.checked) return;
+  let persisted = true;
+  try {
+    storeLegalAcceptance();
+  } catch (err) {
+    persisted = false;
+    console.warn('[legal-consent] Failed to persist acceptance:', err);
+  }
+  closeLegalConsentGate();
+  window.dispatchEvent(new CustomEvent('legal-consent-accepted'));
+  if (persisted) {
+    globalThis.showNotification?.('Terms and Privacy accepted.', 'success', 3000);
+  } else {
+    globalThis.showNotification?.('Terms accepted for this session. Your browser blocked saving the acceptance record, so you may be asked again next visit.', 'warning', 6000);
+  }
+}
+
+function handleLegalConsentChange(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement) || target.id !== 'legal-consent-checkbox') return;
+  const acceptBtn = /** @type {HTMLButtonElement | null} */ (document.querySelector('#legal-consent-overlay [data-legal-consent-action="accept"]'));
+  if (acceptBtn) acceptBtn.disabled = !target.checked;
+}
+
+export function maybeShowLegalConsentGate() {
+  if (hasAcceptedCurrentLegal()) return false;
+  if (document.getElementById('legal-consent-overlay')) return true;
+  const previous = getLegalAcceptance();
+  const overlay = document.createElement('div');
+  overlay.id = 'legal-consent-overlay';
+  overlay.className = 'modal-overlay legal-consent-overlay show';
+  overlay.innerHTML = renderLegalConsentModal({ update: !!previous });
+  overlay.addEventListener('click', handleLegalConsentClick);
+  overlay.addEventListener('change', handleLegalConsentChange);
+  document.body.appendChild(overlay);
+  document.body.classList.add('legal-consent-visible');
+  setTimeout(() => document.getElementById('legal-consent-checkbox')?.focus(), 30);
+  return true;
+}

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -9,6 +9,7 @@ import { ensureSNPTable, ensureHaplogroupTable } from './dna.js';
 import { maybeShowChangelog } from './changelog.js';
 import { buildSidebar, renderProfileDropdown } from './nav.js';
 import { maybeShowBackupNudge } from './crypto.js';
+import { maybeShowLegalConsentGate } from './legal-consent.js';
 import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 
 export function renderStartupUI() {
@@ -22,9 +23,12 @@ export function renderStartupUI() {
   renderSyncIndicator();
   window.navigate(window.getInitialView?.() || 'dashboard');
   scheduleDeferredSyncAndCatalogWarmup();
-  maybeShowChangelog();
-  scheduleStartupNudges();
-  openDeferredStartupDestinations();
+  const legalGateShown = scheduleStartupNudges();
+  if (legalGateShown) {
+    window.addEventListener('legal-consent-accepted', openDeferredStartupDestinations, { once: true });
+  } else {
+    openDeferredStartupDestinations();
+  }
   refreshStartupChrome();
   initializeChatAttachments();
   bindImportFileInput();
@@ -47,14 +51,36 @@ function scheduleDeferredSyncAndCatalogWarmup() {
 }
 
 function scheduleStartupNudges() {
+  // Legal acceptance is a gate: first-time users and users with stale
+  // Terms/Privacy acceptance must explicitly accept before continuing. It is
+  // local-first, so this is stored per browser/device rather than emailed.
+  const legalGateShown = maybeShowLegalConsentGate();
+  if (!legalGateShown) maybeShowChangelog();
+  else window.addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true });
   // First-launch transparency banner about anonymous analytics appears once,
-  // never again after the user clicks either "Got it" or "Turn off".
-  setTimeout(() => window.maybeShowAnalyticsConsent?.(), 800);
-  setTimeout(() => {
+  // never again after the user clicks either "Got it" or "Turn off". Keep it
+  // behind the legal gate so the user does not get competing prompts. What's
+  // New and tours also stay behind the gate; legal must be the topmost first
+  // interaction for new users and stale-version re-consent.
+  const showAnalyticsConsent = () => {
+    window.maybeShowAnalyticsConsent?.();
+  };
+  if (legalGateShown) {
+    window.addEventListener('legal-consent-accepted', () => setTimeout(showAnalyticsConsent, 800), { once: true });
+  } else {
+    setTimeout(showAnalyticsConsent, 800);
+  }
+  const showBackupNudge = () => {
     const overlay = document.getElementById('passphrase-overlay');
     if (overlay && overlay.style.display === 'flex') return;
     maybeShowBackupNudge();
-  }, 1500);
+  };
+  if (legalGateShown) {
+    window.addEventListener('legal-consent-accepted', () => setTimeout(showBackupNudge, 1500), { once: true });
+  } else {
+    setTimeout(showBackupNudge, 1500);
+  }
+  return legalGateShown;
 }
 
 function openDeferredStartupDestinations() {

--- a/js/tour.js
+++ b/js/tour.js
@@ -126,6 +126,7 @@ function getTourTargetElement(target) {
 }
 
 function runTour(steps, storageKey, auto) {
+  if (document.getElementById('legal-consent-overlay')) return false;
   if (auto && isTourCompleted(storageKey)) return false;
   // Demo profiles are exploration sandboxes — re-firing the welcome
   // tour every time the user picks a different demo is noise. Manual

--- a/tests/playwright/coverage-fixture.js
+++ b/tests/playwright/coverage-fixture.js
@@ -8,6 +8,28 @@ const coverageDir = process.env.PLAYWRIGHT_COVERAGE_DIR ||
   path.join(repoRoot, 'tests', '.playwright-coverage');
 const startedPages = new WeakSet();
 const coverageStates = new WeakMap();
+const LEGAL_ACCEPTANCE_KEY = 'labcharts-legal-acceptance';
+const TEST_LEGAL_ACCEPTANCE = {
+  accepted: true,
+  termsVersion: '2026-06-22',
+  privacyVersion: '2026-06-22',
+  acceptedAt: '2026-06-23T00:00:00.000Z',
+  appVersion: 'playwright-fixture',
+  location: 'playwright-fixture',
+};
+
+async function seedCurrentLegalAcceptance(page) {
+  await page.addInitScript(({ key, payload }) => {
+    try {
+      localStorage.setItem(key, JSON.stringify(payload));
+    } catch {
+      // Individual tests that deliberately exercise blocked storage can still
+      // remove/override this after navigation. The default browser-suite
+      // contract is an already-accepted returning user so feature tests are
+      // not hidden behind the mandatory legal gate.
+    }
+  }, { key: LEGAL_ACCEPTANCE_KEY, payload: TEST_LEGAL_ACCEPTANCE });
+}
 
 function isCoverageEnabled() {
   return process.env.PLAYWRIGHT_SUITE_COVERAGE === '1' ||
@@ -212,6 +234,8 @@ export async function stopPageCoverage(page, testInfo, label = 'page') {
 
 export const test = base.extend({
   page: async ({ page }, use, testInfo) => {
+    await seedCurrentLegalAcceptance(page);
+
     if (!isCoverageEnabled()) {
       await use(page);
       return;

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -61,6 +61,11 @@ assert('cacheGet re-inserts on hit',
 console.log('\n4. SW precache');
 const swSrc = read('service-worker.js');
 const startupUiSrc = read('js/startup-ui.js');
+const legalConsentSrc = read('js/legal-consent.js');
+const changelogSrc = read('js/changelog.js');
+const tourSrc = read('js/tour.js');
+const appShellCss = read('css/app-shell.css');
+const playwrightFixtureSrc = read('tests/playwright/coverage-fixture.js');
 const viewsSrc = read('js/views.js');
 const dashboardCompositionSrc = read('js/dashboard-view-composition.js');
 const importLoaderSrc = read('js/import-loader.js');
@@ -238,9 +243,37 @@ assert('PDF lazy import failure notifies from file input and clears selection',
 assert('PDF lazy import failure notifies from drop zone',
   /try\s*{\s*importMod\s*=\s*await loadPdfImport\(\);[\s\S]{0,220}catch\s*\(err\)\s*{[\s\S]{0,220}Could not load import module - check your connection and try again\./.test(importDropZoneSrc),
   'drop-zone import path should fail loudly');
-assert('analytics consent remains deferred after first paint',
-  /setTimeout\(\(\)\s*=>\s*window\.maybeShowAnalyticsConsent\?\.\(\),\s*800\)/.test(startupUiSrc),
-  'first-run banner should not stack into the same tick as tour/startup work');
+assert('analytics consent remains deferred after first paint and behind legal gate',
+  /const showAnalyticsConsent = \(\) => \{\s*window\.maybeShowAnalyticsConsent\?\.\(\);\s*\};/.test(startupUiSrc)
+  && /if \(legalGateShown\) \{\s*window\.addEventListener\('legal-consent-accepted', \(\) => setTimeout\(showAnalyticsConsent, 800\), \{ once: true \}\);\s*\} else \{\s*setTimeout\(showAnalyticsConsent, 800\);\s*\}/.test(startupUiSrc),
+  'first-run banner should stay deferred and must resume after Terms/Privacy acceptance');
+assert('legal gate runs before changelog and resumes changelog only after accept',
+  startupUiSrc.indexOf('const legalGateShown = maybeShowLegalConsentGate()') >= 0
+  && startupUiSrc.indexOf('const legalGateShown = maybeShowLegalConsentGate()') < startupUiSrc.indexOf('maybeShowChangelog()')
+  && startupUiSrc.includes("window.addEventListener('legal-consent-accepted'")
+  && startupUiSrc.includes('return legalGateShown')
+  && startupUiSrc.includes("window.addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true })")
+  && legalConsentSrc.includes("window.dispatchEvent(new CustomEvent('legal-consent-accepted'))"));
+assert('legal accept does not deadlock when localStorage persistence throws',
+  /try\s*\{\s*storeLegalAcceptance\(\);\s*\}\s*catch\s*\(err\)\s*\{[\s\S]{0,220}\[legal-consent\] Failed to persist acceptance/.test(legalConsentSrc)
+  && /catch\s*\(err\)[\s\S]{0,260}\}\s*closeLegalConsentGate\(\);\s*window\.dispatchEvent\(new CustomEvent\('legal-consent-accepted'\)\)/.test(legalConsentSrc));
+assert('deferred startup destinations wait behind legal gate',
+  /const legalGateShown = scheduleStartupNudges\(\);[\s\S]{0,240}addEventListener\('legal-consent-accepted', openDeferredStartupDestinations[\s\S]{0,120}else \{\s*openDeferredStartupDestinations\(\);\s*\}/.test(startupUiSrc));
+assert('analytics consent and backup nudge resume after legal gate acceptance',
+  /addEventListener\('legal-consent-accepted', \(\) => setTimeout\(showAnalyticsConsent, 800\), \{ once: true \}\)/.test(startupUiSrc)
+  && /addEventListener\('legal-consent-accepted', \(\) => setTimeout\(showBackupNudge, 1500\), \{ once: true \}\)/.test(startupUiSrc)
+  && /const showBackupNudge = \(\) => \{[\s\S]{0,180}maybeShowBackupNudge\(\);\s*\};/.test(startupUiSrc));
+assert('changelog and tour refuse to open over legal consent',
+  /export function maybeShowChangelog\(\) \{\s*if \(document\.getElementById\('legal-consent-overlay'\)\) return;/.test(changelogSrc)
+  && /function runTour\(steps, storageKey, auto\) \{\s*if \(document\.getElementById\('legal-consent-overlay'\)\) return false;/.test(tourSrc));
+assert('legal gate z-index selector beats generic modal overlay',
+  /\.modal-overlay\.legal-consent-overlay\s*\{[\s\S]{0,80}z-index:\s*4200;/.test(appShellCss)
+  && /\.modal-overlay\.legal-consent-overlay\s*\{[\s\S]{0,180}-webkit-backdrop-filter:\s*blur\(8px\);[\s\S]{0,60}backdrop-filter:\s*blur\(8px\);/.test(appShellCss));
+assert('Playwright feature tests seed the current legal acceptance version',
+  /TEST_LEGAL_ACCEPTANCE\s*=\s*\{[\s\S]{0,120}termsVersion:\s*'2026-06-22',[\s\S]{0,80}privacyVersion:\s*'2026-06-22'/.test(playwrightFixtureSrc)
+  && /const TERMS_VERSION = '2026-06-22';/.test(legalConsentSrc)
+  && /const PRIVACY_VERSION = '2026-06-22';/.test(legalConsentSrc)
+  && /await seedCurrentLegalAcceptance\(page\);/.test(playwrightFixtureSrc));
 assert('footer commit hash loader lives in its own module and remains wired',
   /export function loadCommitHash\(\)/.test(commitHashSrc)
   && /_cachedCommitHash/.test(commitHashSrc)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.8';
+self.APP_VERSION = '1.10.9';


### PR DESCRIPTION
## Summary
- add a first-launch Terms & Privacy acceptance gate before users continue into the app
- store versioned local acceptance for the current Terms/Privacy versions
- re-prompt with updated-copy when the stored legal versions are stale
- keep analytics transparency behind the legal gate so prompts do not stack

## Legal/product context
- Current product is free, no-account, and local-first, so acceptance is stored locally per browser/device.
- The public Terms and Privacy pages were already updated and deployed first.
- The gate uses a single checkbox sentence with linked Terms of Service and Privacy Policy, avoiding duplicate legal links.

## Verification
- `npm run typecheck`
- `npm run quality`
- `npm test`
- `git diff --check`
- local served route checks on `8174` for `/app`, `/js/legal-consent.js`, and `/css/app-shell.css`
