### PR TITLE
fix(cashu): harden wallet funding recovery

### DIFF
--- a/js/cashu-wallet.js
+++ b/js/cashu-wallet.js
@@ -54,6 +54,25 @@ async function _ensureBip39() {
   return _bip39Load;
 }
 
+function _amountToNumber(value) {
+  if (value == null) return 0;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'string') return Number(value) || 0;
+  if (typeof value.toNumber === 'function') return value.toNumber();
+  if (typeof value.toNumberUnsafe === 'function') return value.toNumberUnsafe();
+  if (typeof value.toBigInt === 'function') return Number(value.toBigInt());
+  return Number(value) || 0;
+}
+
+function _sumProofsAsNumber(cashuts, proofs) {
+  return _amountToNumber(cashuts.sumProofs(proofs || []));
+}
+
+function _normalizeProofForStorage(proof, mintUrl) {
+  return { ...proof, amount: _amountToNumber(proof.amount), _mint: mintUrl };
+}
+
 // ═══════════════════════════════════════════════
 // GLOBAL WALLET LOCK — prevents concurrent proof-mutating operations (C1)
 // ═══════════════════════════════════════════════
@@ -156,7 +175,7 @@ async function _saveProofs(proofs) {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_PROOFS, 'readwrite');
     const store = tx.objectStore(STORE_PROOFS);
-    for (const p of proofs) store.put({ ...p, _mint: mintUrl });
+    for (const p of proofs) store.put(_normalizeProofForStorage(p, mintUrl));
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
@@ -272,7 +291,7 @@ async function _saveFeeProofs(proofs) {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_FEES, 'readwrite');
     const store = tx.objectStore(STORE_FEES);
-    for (const p of proofs) store.put({ ...p, _mint: mintUrl });
+    for (const p of proofs) store.put(_normalizeProofForStorage(p, mintUrl));
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
@@ -446,11 +465,7 @@ export async function hasWalletSeed() {
   return !!(await _loadMnemonic());
 }
 
-/** Restore wallet from a 12-word mnemonic phrase.
- *  Queries the mint to recover previously-minted proofs.
- *  Returns { balance, restoredCount } */
-export async function restoreWalletFromSeed(mnemonic) {
-  return _withWalletLock(async () => {
+async function _restoreProofsFromSeed(mnemonic, { clearExisting = false } = {}) {
   const bip39 = await _ensureBip39();
   const cashuts = await _cashuLib();
   const valid = await bip39.validateMnemonic(mnemonic);
@@ -458,7 +473,7 @@ export async function restoreWalletFromSeed(mnemonic) {
   await _saveMnemonic(mnemonic);
   _wallet = null; _mintUrl = null; // reset
   const wallet = await _getWallet();
-  await _clearAllProofs();
+  if (clearExisting) await _clearAllProofs();
   let totalRestored = 0;
   try {
     // Loop batchRestore until no more proofs found (H5)
@@ -471,7 +486,7 @@ export async function restoreWalletFromSeed(mnemonic) {
       const { unspent } = await wallet.groupProofsByState(result.proofs);
       if (unspent.length) {
         await _saveProofs(unspent);
-        totalRestored += cashuts.sumProofs(unspent);
+        totalRestored += _sumProofsAsNumber(cashuts, unspent);
       }
       start += batchSize;
     }
@@ -481,14 +496,24 @@ export async function restoreWalletFromSeed(mnemonic) {
   }
   const balance = await getWalletBalance();
   return { balance, restoredCount: totalRestored };
-  }); // _withWalletLock
+}
+
+function _looksLikeAlreadyIssuedMintError(error) {
+  return /outputs? already signed|already signed|quote.*issued|already.*issued/i.test(error?.message || String(error || ''));
+}
+
+/** Restore wallet from a 12-word mnemonic phrase.
+ *  Queries the mint to recover previously-minted proofs.
+ *  Returns { balance, restoredCount } */
+export async function restoreWalletFromSeed(mnemonic) {
+  return _withWalletLock(async () => _restoreProofsFromSeed(mnemonic, { clearExisting: true }));
 }
 
 /** Get wallet balance in sats (prunes spent proofs on first call / after cooldown) */
 export async function getWalletBalance() {
   const proofs = await _pruneSpentProofs();
   const cashuts = await _cashuLib();
-  return cashuts.sumProofs(proofs);
+  return _sumProofsAsNumber(cashuts, proofs);
 }
 
 /** Force-check all proof states against mint and return updated balance */
@@ -496,7 +521,7 @@ export async function checkProofStates() {
   return _withWalletLock(async () => {
     const cashuts = await _cashuLib();
     const proofs = await _pruneSpentProofs(true);
-    return cashuts.sumProofs(proofs);
+    return _sumProofsAsNumber(cashuts, proofs);
   });
 }
 
@@ -527,10 +552,23 @@ export async function checkFundingStatus(quoteId) {
     if (checked.state === cashuts.MintQuoteState.PAID) {
       const pendingKey = PENDING_QUOTE_PREFIX + quoteId;
       const storedAmount = await _getMeta(pendingKey);
-      const amount = storedAmount || checked.amount || 0;
+      const amount = storedAmount || _amountToNumber(checked.amount) || 0;
       if (!amount) throw new Error('Cannot determine invoice amount — please contact support');
-      const proofs = await wallet.mintProofsBolt11(amount, quoteId);
-      const total = cashuts.sumProofs(proofs);
+      let proofs;
+      try {
+        proofs = await wallet.mintProofsBolt11(amount, quoteId);
+      } catch (e) {
+        if (!_looksLikeAlreadyIssuedMintError(e)) throw e;
+        const mnemonic = await _loadMnemonic();
+        if (!mnemonic) throw e;
+        const before = await getWalletBalance();
+        const restored = await _restoreProofsFromSeed(mnemonic, { clearExisting: false });
+        const recovered = Math.max(0, restored.balance - before);
+        if (recovered <= 0) throw e;
+        await _deleteMeta(pendingKey);
+        return { paid: true, balance: restored.balance, minted: recovered, fee: 0, recoveredFromRestore: true };
+      }
+      const total = _sumProofsAsNumber(cashuts, proofs);
       const fee = Math.ceil(total * WALLET_FEE_PCT);
 
       if (fee > 0 && total > fee) {
@@ -593,7 +631,7 @@ export async function receiveToken(tokenString) {
     if (currentBal >= MAX_WALLET_BALANCE) throw new Error('Wallet at ' + MAX_WALLET_BALANCE.toLocaleString() + ' sats safety cap. Withdraw some sats first.');
     const wallet = await _getWallet();
     const proofs = await wallet.receive(tokenString);
-    const total = cashuts.sumProofs(proofs);
+    const total = _sumProofsAsNumber(cashuts, proofs);
     const fee = Math.ceil(total * WALLET_FEE_PCT);
 
     if (fee > 0 && total > fee) {
@@ -617,7 +655,7 @@ export async function depositToNode(nodeUrl, amountSats, existingKey) {
   return _withWalletLock(async () => {
     const cashuts = await _cashuLib();
     const proofs = await _pruneSpentProofs(true);
-    const total = cashuts.sumProofs(proofs);
+    const total = _sumProofsAsNumber(cashuts, proofs);
     if (total < amountSats) throw new Error('Insufficient wallet balance: ' + total + ' sats, need ' + amountSats);
 
     const wallet = await _getWallet();
@@ -691,10 +729,12 @@ export async function clearPendingWithdraw() {
 export async function createWithdrawQuote(bolt11Invoice) {
   const wallet = await _getWallet();
   const quote = await wallet.createMeltQuoteBolt11(bolt11Invoice);
+  const quoteAmount = _amountToNumber(quote.amount);
+  const feeReserve = _amountToNumber(quote.fee_reserve);
   return {
     quote: quote.quote,
-    amount: quote.amount,
-    fee_reserve: quote.fee_reserve,
+    amount: quoteAmount,
+    fee_reserve: feeReserve,
     state: quote.state
   };
 }
@@ -706,9 +746,9 @@ export async function executeWithdraw(quoteId) {
     const cashuts = await _cashuLib();
     const wallet = await _getWallet();
     const quote = await wallet.checkMeltQuoteBolt11(quoteId);
-    const amountNeeded = (quote.amount || 0) + (quote.fee_reserve || 0);
+    const amountNeeded = _amountToNumber(quote.amount) + _amountToNumber(quote.fee_reserve);
     const proofs = await _pruneSpentProofs(true);
-    const total = cashuts.sumProofs(proofs);
+    const total = _sumProofsAsNumber(cashuts, proofs);
     if (total < amountNeeded) throw new Error('Insufficient balance: ' + total + ' sats, need ' + amountNeeded);
 
     const { keep, send } = await wallet.send(amountNeeded, proofs, { includeFees: true });
@@ -768,7 +808,7 @@ export async function retryFeeAutoMelt() {
   return _withFeeLock(async () => {
     const cashuts = await _cashuLib();
     const feeProofs = await _getAllFeeProofs();
-    const feeSats = cashuts.sumProofs(feeProofs);
+    const feeSats = _sumProofsAsNumber(cashuts, feeProofs);
     if (feeSats < 1) return { melted: 0, remaining: 0 };
     try {
       const invoice = await _lnAddressToInvoice(FEE_LN_ADDRESS, feeSats);
@@ -798,7 +838,7 @@ export async function sendAsToken(amountSats) {
   return _withWalletLock(async () => {
     const cashuts = await _cashuLib();
     const proofs = await _pruneSpentProofs(true);
-    const total = cashuts.sumProofs(proofs);
+    const total = _sumProofsAsNumber(cashuts, proofs);
     if (total < amountSats) throw new Error('Insufficient balance: ' + total + ' sats, need ' + amountSats);
     const wallet = await _getWallet();
     const { keep, send } = await wallet.send(amountSats, proofs, { includeFees: true });
@@ -807,7 +847,7 @@ export async function sendAsToken(amountSats) {
     const mintUrl = await getMintUrl();
     const token = cashuts.getEncodedToken({ mint: mintUrl, proofs: send });
     const remaining = await getWalletBalance();
-    return { token, amount: cashuts.sumProofs(send), remaining };
+    return { token, amount: _sumProofsAsNumber(cashuts, send), remaining };
   });
 }
 
@@ -842,7 +882,7 @@ async function _autoMeltFees(feeProofs) {
     const accumulated = await _getAllFeeProofs();
     const allFees = [...accumulated, ...feeProofs];
     if (!allFees.length) return;
-    const feeSats = cashuts.sumProofs(allFees);
+    const feeSats = _sumProofsAsNumber(cashuts, allFees);
     if (feeSats < 1) return;
     if (feeSats < FEE_MELT_MIN_SATS) {
       if (feeProofs.length) await _saveFeeProofs(feeProofs);
@@ -865,7 +905,7 @@ async function _autoMeltFees(feeProofs) {
       const wallet = await _getWallet();
       const quote = await wallet.createMeltQuoteBolt11(invoice);
       // Verify we have enough proofs for amount + fee_reserve
-      const needed = (quote.amount || 0) + (quote.fee_reserve || 0);
+      const needed = _amountToNumber(quote.amount) + _amountToNumber(quote.fee_reserve);
       if (feeSats < needed) {
         if (feeProofs.length) await _saveFeeProofs(feeProofs);
         if (isDebugMode()) console.log('[cashu-wallet] Fee pool ' + feeSats + ' < ' + needed + ' needed for melt, accumulating');
@@ -908,7 +948,7 @@ let _autoMeltConsecutiveFailures = 0;
 export async function getFeeBalance() {
   const cashuts = await _cashuLib();
   const proofs = await _getAllFeeProofs();
-  return cashuts.sumProofs(proofs);
+  return _sumProofsAsNumber(cashuts, proofs);
 }
 
 /** Redeem accumulated fee proofs by paying a Lightning invoice.
@@ -917,7 +957,7 @@ export async function redeemFees(bolt11Invoice) {
   return _withFeeLock(async () => {
     const cashuts = await _cashuLib();
     const proofs = await _getAllFeeProofs();
-    const total = cashuts.sumProofs(proofs);
+    const total = _sumProofsAsNumber(cashuts, proofs);
     if (total < 1) throw new Error('No fee proofs to redeem');
     const wallet = await _getWallet();
     const quote = await wallet.createMeltQuoteBolt11(bolt11Invoice);
@@ -950,7 +990,7 @@ export async function importWallet(tokenString) {
     const wallet = await _getWallet();
     const proofs = await wallet.receive(tokenString);
     await _saveProofs(proofs);
-    return cashuts.sumProofs(proofs);
+    return _sumProofsAsNumber(cashuts, proofs);
   });
 }
 

--- a/js/cashu-wallet.js
+++ b/js/cashu-wallet.js
@@ -564,7 +564,12 @@ export async function checkFundingStatus(quoteId) {
         const before = await getWalletBalance();
         const restored = await _restoreProofsFromSeed(mnemonic, { clearExisting: false });
         const recovered = Math.max(0, restored.balance - before);
-        if (recovered <= 0) throw e;
+        if (recovered <= 0) {
+          const alreadyCovered = restored.balance >= amount;
+          if (!alreadyCovered) throw e;
+          await _deleteMeta(pendingKey);
+          return { paid: true, balance: restored.balance, minted: 0, fee: 0, recoveredFromRestore: true, alreadyPresent: true };
+        }
         await _deleteMeta(pendingKey);
         return { paid: true, balance: restored.balance, minted: recovered, fee: 0, recoveredFromRestore: true };
       }

--- a/js/provider-wallet-panels.js
+++ b/js/provider-wallet-panels.js
@@ -76,6 +76,8 @@ export function refreshRoutstrBalance() {
 }
 
 let _rsFundPollTimer = null;
+const FUNDING_POLL_INTERVAL_MS = 3000;
+const FUNDING_POLL_MAX_CONSECUTIVE_FAILURES = 3;
 
 function _getWalletInput(id) {
   return /** @type {HTMLInputElement | HTMLTextAreaElement | null} */ (document.getElementById(id));
@@ -167,9 +169,12 @@ export async function doRoutstrWalletFund(amountSats) {
       <div style="margin-top:6px"><button class="import-btn import-btn-secondary" style="font-size:10px;padding:2px 8px" data-routstr-wallet-action="copy-clipboard" data-clipboard-text="${escapeAttr(result.invoice)}" data-copied-text="\u2713 Copied">${result.invoice.slice(0, 20)}\u2026 copy</button></div>
       <div style="font-size:11px;color:var(--text-muted);margin-top:4px" id="routstr-wfund-poll">Waiting for payment\u2026</div>
     </div>`;
+    if (_rsFundPollTimer) { clearInterval(_rsFundPollTimer); _rsFundPollTimer = null; }
+    let consecutivePollFailures = 0;
     _rsFundPollTimer = setInterval(async function() {
       try {
         const s = await walletRuntime.cashuCheckFundingStatus(result.quote);
+        consecutivePollFailures = 0;
         if (s && s.paid) {
           clearInterval(_rsFundPollTimer); _rsFundPollTimer = null;
           const feeText = s.fee ? ' (' + s.fee + ' fee)' : '';
@@ -181,10 +186,16 @@ export async function doRoutstrWalletFund(amountSats) {
           setTimeout(function() { const a = document.getElementById('routstr-wallet-fund-area'); if (a) a.style.display = 'none'; }, 3000);
         }
       } catch {
+        consecutivePollFailures += 1;
         const poll = document.getElementById('routstr-wfund-poll');
-        if (poll) poll.innerHTML = '<span style="color:var(--red)">Payment check failed. Use "Check pending Lightning deposits" after payment confirms.</span>';
+        if (consecutivePollFailures >= FUNDING_POLL_MAX_CONSECUTIVE_FAILURES) {
+          if (_rsFundPollTimer) { clearInterval(_rsFundPollTimer); _rsFundPollTimer = null; }
+          if (poll) poll.innerHTML = '<span style="color:var(--red)">Mint unreachable. Auto-check stopped; use "Check pending Lightning deposits" after the mint is reachable/payment confirms.</span>';
+        } else if (poll) {
+          poll.innerHTML = '<span style="color:var(--yellow, #f0a800)">Payment check failed. Retrying\u2026</span>';
+        }
       }
-    }, 3000);
+    }, FUNDING_POLL_INTERVAL_MS);
   } catch (e) {
     statusEl.innerHTML = '<div style="margin-top:8px;font-size:11px;color:var(--red)">' + escapeHTML(e.message) + '</div>';
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "getbased",
       "version": "1.3.9",
       "dependencies": {
+        "@cashu/cashu-ts": "4.6.0",
         "@vercel/blob": "^2.4.0",
         "tinfoil": "^1.1.3"
       },
@@ -187,6 +188,21 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@cashu/cashu-ts": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.6.0.tgz",
+      "integrity": "sha512-B0XG662h53ZBTKFnVdTVXyK5GwNC5QDkZqbXu6Bl0SduCc6GV90+h9f3SI/bLDxMKFVk/aFs00LeSUCj4JknKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/base": "^2.2.0",
+        "@scure/bip32": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=22.4.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -850,6 +866,29 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "getbased",
       "version": "1.3.9",
       "dependencies": {
-        "@cashu/cashu-ts": "4.6.0",
         "@vercel/blob": "^2.4.0",
         "tinfoil": "^1.1.3"
       },
       "devDependencies": {
+        "@cashu/cashu-ts": "4.6.0",
         "@playwright/test": "^1.60.0",
         "@vitest/coverage-v8": "^4.1.8",
         "fake-indexeddb": "^6.2.5",
@@ -194,6 +194,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@cashu/cashu-ts/-/cashu-ts-4.6.0.tgz",
       "integrity": "sha512-B0XG662h53ZBTKFnVdTVXyK5GwNC5QDkZqbXu6Bl0SduCc6GV90+h9f3SI/bLDxMKFVk/aFs00LeSUCj4JknKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",
@@ -871,6 +872,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
       "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -880,6 +882,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
       "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@cashu/cashu-ts": "4.6.0",
     "@playwright/test": "^1.60.0",
     "@vitest/coverage-v8": "^4.1.8",
     "fake-indexeddb": "^6.2.5",
@@ -22,7 +23,6 @@
     "vitest": "^4.1.8"
   },
   "dependencies": {
-    "@cashu/cashu-ts": "4.6.0",
     "@vercel/blob": "^2.4.0",
     "tinfoil": "^1.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "vitest": "^4.1.8"
   },
   "dependencies": {
+    "@cashu/cashu-ts": "4.6.0",
     "@vercel/blob": "^2.4.0",
     "tinfoil": "^1.1.3"
   }

--- a/tests/cashu-wallet-runtime.test.js
+++ b/tests/cashu-wallet-runtime.test.js
@@ -8,12 +8,27 @@ function proof(secret, amount) {
   return { secret, amount, C: `C-${secret}` };
 }
 
-function installCashuStub() {
+class AmountStub {
+  constructor(value) { this.value = Number(value) || 0; }
+  toNumber() { return this.value; }
+  toString() { return String(this.value); }
+  toJSON() { return String(this.value); }
+  add(other) { return new AmountStub(this.value + amountNumber(other)); }
+}
+
+function amountNumber(value) {
+  if (value && typeof value.toNumber === 'function') return value.toNumber();
+  return Number(value) || 0;
+}
+
+function installCashuStub(options = {}) {
   const state = {
     receiveProofs: [proof('rx-1', 10)],
     meltQuotes: new Map(),
     mintQuoteStates: new Map(),
     failMelt: false,
+    failMintOutputsAlreadySigned: false,
+    restoreProofs: [proof('restored-1', 7), { ...proof('restored-spent', 3), spent: true }],
     instances: [],
   };
 
@@ -39,15 +54,17 @@ function installCashuStub() {
     }
 
     async send(amount, proofs) {
-      const total = sumProofs(proofs);
+      const amountSats = amountNumber(amount);
+      const total = amountNumber(sumProofs(proofs));
       return {
-        send: [proof(`send-${amount}-${state.instances.length}`, amount)],
-        keep: total > amount ? [proof(`keep-${total - amount}-${state.instances.length}`, total - amount)] : [],
+        send: [proof(`send-${amountSats}-${state.instances.length}`, options.amountObjects ? new AmountStub(amountSats) : amountSats)],
+        keep: total > amountSats ? [proof(`keep-${total - amountSats}-${state.instances.length}`, options.amountObjects ? new AmountStub(total - amountSats) : total - amountSats)] : [],
       };
     }
 
     async createMintQuoteBolt11(amount) {
-      return { quote: `mint-${amount}`, request: `invoice-${amount}`, amount, state: 'UNPAID' };
+      const amountSats = amountNumber(typeof amount === 'object' && amount ? amount.amount : amount);
+      return { quote: `mint-${amountSats}`, request: `invoice-${amountSats}`, amount: options.amountObjects ? new AmountStub(amountSats) : amountSats, state: 'UNPAID' };
     }
 
     async checkMintQuoteBolt11(quoteId) {
@@ -56,12 +73,18 @@ function installCashuStub() {
     }
 
     async mintProofsBolt11(amount, quoteId) {
+      if (state.failMintOutputsAlreadySigned) throw new Error('outputs already signed');
       return [proof(`minted-${quoteId}`, amount)];
     }
 
     async createMeltQuoteBolt11(invoice) {
       const amount = Number(String(invoice).split(':').pop()) || 10;
-      const quote = { quote: `quote-${amount}`, amount, fee_reserve: 5, state: 'UNPAID' };
+      const quote = {
+        quote: `quote-${amount}`,
+        amount: options.amountObjects ? new AmountStub(amount) : amount,
+        fee_reserve: options.amountObjects ? new AmountStub(5) : 5,
+        state: 'UNPAID'
+      };
       state.meltQuotes.set(quote.quote, quote);
       return quote;
     }
@@ -77,12 +100,13 @@ function installCashuStub() {
 
     async batchRestore(batchSize, gap, start) {
       if (start > 0) return { proofs: [] };
-      return { proofs: [proof('restored-1', 7), { ...proof('restored-spent', 3), spent: true }] };
+      return { proofs: state.restoreProofs.map(p => ({ ...p })) };
     }
   }
 
   function sumProofs(proofs = []) {
-    return proofs.reduce((sum, p) => sum + (Number(p.amount) || 0), 0);
+    const total = proofs.reduce((sum, p) => sum + amountNumber(p.amount), 0);
+    return options.amountObjects ? new AmountStub(total) : total;
   }
 
   globalThis.cashuts = {
@@ -229,6 +253,27 @@ describe('Cashu wallet runtime behavior', () => {
     expect(paidFunding.quote).toBe('mint-12');
   });
 
+  it('recovers already-issued funding outputs from seed restore when retrying a paid quote reports outputs already signed', async () => {
+    const stub = installCashuStub();
+    stub.failMintOutputsAlreadySigned = true;
+    stub.restoreProofs = [proof('issued-after-lost-response', 200)];
+    const wallet = await loadWallet();
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+    await wallet.generateWalletSeed();
+
+    const funding = await wallet.createFundingInvoice(200);
+    await expect(wallet.recoverPendingFunding()).resolves.toMatchObject({
+      checked: 1,
+      recovered: 200,
+      pending: 0,
+      failed: 0,
+      balance: 200,
+    });
+    await expect(wallet.recoverPendingFunding()).resolves.toMatchObject({ checked: 0, recovered: 0 });
+    await expect(wallet.getWalletBalance()).resolves.toBe(200);
+    expect(funding.quote).toBe('mint-200');
+  });
+
   it('auto-reduces lightning-address withdrawals and exposes failed melt recovery', async () => {
     const wallet = await loadWallet();
     await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
@@ -264,6 +309,44 @@ describe('Cashu wallet runtime behavior', () => {
     await expect(wallet.recoverPendingWithdraw()).resolves.toBeNull();
   });
 
+  it('keeps Cashu v4 Amount objects at the library boundary and stores JSON-safe proof rows', async () => {
+    const stub = installCashuStub({ amountObjects: true });
+    stub.receiveProofs = [proof('amount-rx', new AmountStub(11))];
+    const wallet = await loadWallet();
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+
+    await expect(wallet.receiveToken('cashu-token')).resolves.toEqual({ received: 11, fee: 0, balance: 11 });
+    await expect(wallet.getWalletBalance()).resolves.toBe(11);
+    await expect(wallet.sendAsToken(4)).resolves.toMatchObject({ amount: 4, remaining: 7 });
+
+    const rows = await readIdbStore('proofs');
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row._mint).toBe('https://mint.getbased.test/Bitcoin');
+      expect(typeof row.amount === 'number' || typeof row.amount === 'string').toBe(true);
+      expect(row.amount && typeof row.amount.toNumber).toBe('undefined');
+    }
+  });
+
+  it('tops up an existing Routstr node key without creating a replacement session', async () => {
+    const wallet = await loadWallet();
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+    await wallet.receiveToken('cashu-token');
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(jsonResponse({ balance: 100000 }));
+
+    await expect(wallet.depositToNode('https://node.getbased.test/', 5, 'sk-existing')).resolves.toEqual({ balance: 100000 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toBe('https://node.getbased.test/v1/balance/topup');
+    expect(fetch.mock.calls[0][1]).toMatchObject({
+      method: 'POST',
+      headers: { Authorization: 'Bearer sk-existing', 'Content-Type': 'application/json' },
+    });
+    expect(JSON.parse(fetch.mock.calls[0][1].body).cashu_token).toContain('cashu:https://mint.getbased.test/Bitcoin:5:send-5');
+    await expect(wallet.recoverPendingDeposit()).resolves.toBeNull();
+    await expect(wallet.getWalletBalance()).resolves.toBe(5);
+  });
+
   it('handles empty fee pools without mutating the wallet', async () => {
     const wallet = await loadWallet();
 
@@ -273,6 +356,24 @@ describe('Cashu wallet runtime behavior', () => {
     await expect(wallet.redeemFees('invoice:1')).rejects.toThrow('No fee proofs to redeem');
   });
 });
+
+async function readIdbStore(storeName) {
+  const db = await new Promise((resolve, reject) => {
+    const req = indexedDB.open('getbased-cashu', 2);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  try {
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(storeName, 'readonly');
+      const req = tx.objectStore(storeName).getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error);
+    });
+  } finally {
+    db.close();
+  }
+}
 
 function jsonResponse(body, init = {}) {
   return new Response(JSON.stringify(body), {

--- a/tests/cashu-wallet-runtime.test.js
+++ b/tests/cashu-wallet-runtime.test.js
@@ -274,6 +274,29 @@ describe('Cashu wallet runtime behavior', () => {
     expect(funding.quote).toBe('mint-200');
   });
 
+  it('clears already-issued pending funding when restored proofs are already present locally', async () => {
+    const stub = installCashuStub();
+    stub.receiveProofs = [proof('already-present-issued-proof', 200)];
+    stub.restoreProofs = [];
+    stub.failMintOutputsAlreadySigned = true;
+    const wallet = await loadWallet();
+    await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');
+    await wallet.generateWalletSeed();
+    await wallet.receiveToken('cashu-token');
+
+    const funding = await wallet.createFundingInvoice(200);
+    await expect(wallet.recoverPendingFunding()).resolves.toMatchObject({
+      checked: 1,
+      recovered: 0,
+      pending: 0,
+      failed: 0,
+      balance: 200,
+    });
+    await expect(wallet.recoverPendingFunding()).resolves.toMatchObject({ checked: 0, recovered: 0 });
+    await expect(wallet.getWalletBalance()).resolves.toBe(200);
+    expect(funding.quote).toBe('mint-200');
+  });
+
   it('auto-reduces lightning-address withdrawals and exposes failed melt recovery', async () => {
     const wallet = await loadWallet();
     await wallet.setMintUrl('https://mint.getbased.test/Bitcoin');

--- a/tests/test-cashu-wallet.js
+++ b/tests/test-cashu-wallet.js
@@ -281,6 +281,12 @@ assert('Seed onboarding gate', walletPanelSrc.includes('_ensureWalletSeed'));
 assert('Seed acknowledgment checkbox', walletPanelSrc.includes('routstr-seed-ack'));
 assert('Wallet action buttons', walletPanelSrc.includes('routstrWalletActionButtons'));
 assert('Wallet panel owns fund timer cleanup', walletPanelSrc.includes('export function clearRoutstrWalletTimers()'));
+assert('Wallet funding auto-poll is bounded on mint/network failure',
+  walletPanelSrc.includes('FUNDING_POLL_MAX_CONSECUTIVE_FAILURES') &&
+  walletPanelSrc.includes('Mint unreachable. Auto-check stopped') &&
+  walletPanelSrc.includes('consecutivePollFailures >= FUNDING_POLL_MAX_CONSECUTIVE_FAILURES'));
+assert('Wallet funding starts only one active auto-poll timer',
+  walletPanelSrc.includes('if (_rsFundPollTimer) { clearInterval(_rsFundPollTimer); _rsFundPollTimer = null; }\n    let consecutivePollFailures = 0;'));
 assert('Wallet backup (export token)', walletPanelSrc.includes('showRoutstrWalletBackup'));
 assert('Lightning withdraw UI', walletPanelSrc.includes('showRoutstrWithdrawLightning'));
 assert('Cashu token withdraw UI', walletPanelSrc.includes('showRoutstrWithdrawToken'));

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -96,7 +96,8 @@ function semverGte(a, b) {
 }
 assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${versionMatch[1]}'` : 'not found');
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
-assert('latest changelog entry matches APP_VERSION', appVersion && changelogSrc.includes(`version: '${appVersion}'`));
+const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
+assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
 assert('latest changelog documents PPQ Private TEE in user-readable terms',
   /version:\s*'1\.10\.8'[\s\S]{0,900}PPQ Private TEE Mode/.test(changelogSrc)
     && /version:\s*'1\.10\.8'[\s\S]{0,900}encrypts prompts in your browser/.test(changelogSrc)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.9';
+self.APP_VERSION = '1.10.12';


### PR DESCRIPTION
## Summary
- normalize Cashu v4 Amount-like values at wallet/storage boundaries
- recover already-issued pending funding outputs from seed restore without clearing existing proofs
- bound wallet funding auto-polling when a mint/network path refuses connections
- patch-bump service worker cache without adding public Cashu/Routstr changelog copy

## Tests
- npm test -- --run
- npm run typecheck:checkjs -- --pretty false