### PR TITLE
[codex] Remove Biology Score ts-nocheck suppressions

### DIFF
--- a/js/biology-score-ai-context.js
+++ b/js/biology-score-ai-context.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // biology-score-ai-context.js — compact Biology Scores context for AI chat.
 
 import { computeBiologyScores } from './biology-scores.js';

--- a/js/biology-score-copy.js
+++ b/js/biology-score-copy.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // biology-score-copy.js — user-facing questions and panel expectations for Biology Scores.
 
 export const BIOLOGY_SCORE_COPY = {

--- a/js/biology-score-coverage-planner.js
+++ b/js/biology-score-coverage-planner.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // biology-score-coverage-planner.js — shared Coverage Planner data model for UI and chat prompts.
 
 import { contextOnlyNeedsMoreData } from './biology-score-engine.js';

--- a/js/biology-score-mappings.js
+++ b/js/biology-score-mappings.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // biology-score-mappings.js — audit metadata for non-generic Biology Scores.
 
 export const CUSTOM_BIOLOGY_SCORE_MAPPINGS = {

--- a/js/biology-score-sections.js
+++ b/js/biology-score-sections.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // biology-score-sections.js — question and embedded AI answer sections for Biology Scores.
 
 import { saveImportedData } from './data.js';

--- a/js/biology-score-tier1-definitions.js
+++ b/js/biology-score-tier1-definitions.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // biology-score-tier1-definitions.js — additional getbased-native Biology Score definitions.
 
 export const TIER1_BIOLOGY_SCORE_DEFINITIONS = [

--- a/js/biology-score-tier2-definitions.js
+++ b/js/biology-score-tier2-definitions.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // biology-score-tier2-definitions.js — contextual Biology Score definitions for recovery and immune patterning.
 
 export const TIER2_BIOLOGY_SCORE_DEFINITIONS = [


### PR DESCRIPTION
## What changed

- Removed `// @ts-nocheck` from the remaining Biology Score modules.
- Left the files under normal `checkJs` coverage without introducing narrower suppressions.

## Why

These modules now pass the app-wide JavaScript typecheck without blanket suppression, reducing hidden type debt in the Biology Scores surface.

## Validation

- `npm run typecheck:checkjs`
- `npm run typecheck`
- `npm run quality`
- `npm test`