### PR TITLE
[codex] Type tour window helper export

### DIFF
--- a/js/tour.js
+++ b/js/tour.js
@@ -329,7 +329,6 @@ export function endTour() {
 }
 
 // Internal navigation helper remains exposed for tests and legacy callers.
-// @ts-expect-error - custom window export for tour navigation.
 window._tourGoToStep = goToStep;
 
 Object.assign(window, { startEmptyTour, startTour, startGuidedTour, startCycleTour, endTour });

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -265,6 +265,7 @@ interface Window {
   showDetailModal?: AnyFunction;
   startEmptyTour?: AnyFunction;
   startTour?: AnyFunction;
+  _tourGoToStep?: (index: number) => void;
   syncWearableNow?: AnyFunction;
   triggerDNAFilePicker?: AnyFunction;
   loadLightDevicePresets?: AnyFunction;


### PR DESCRIPTION
## What changed

- Added `_tourGoToStep` to the ambient `Window` interface.
- Removed the local `@ts-expect-error` suppression from the tour helper window export.

## Why

The helper is intentionally exposed for tests and legacy callers. Typing that export directly removes the last app-owned TypeScript suppression without changing runtime behavior.

## Validation

- `npm run typecheck:checkjs`
- `npm run typecheck`
- `npm run quality`