### PR TITLE
[codex] Open browser from dev server

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -11,7 +11,7 @@ import https from 'node:https';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import crypto from 'node:crypto';
 import zlib from 'node:zlib';
 
@@ -392,6 +392,81 @@ const MIME = {
   '.pdf': 'application/pdf', '.txt': 'text/plain', '.xml': 'application/xml', '.wasm': 'application/wasm',
   '.webmanifest': 'application/manifest+json',
 };
+
+export function _browserLaunchDisabled(env = process.env) {
+  const ci = String(env.CI || '').trim().toLowerCase();
+  const openBrowser = String(env.OPEN_BROWSER || '').trim().toLowerCase();
+  const browser = String(env.BROWSER || '').trim().toLowerCase();
+  return (ci && !['0', 'false', 'no', 'off'].includes(ci))
+    || ['0', 'false', 'no', 'off'].includes(openBrowser)
+    || ['0', 'false', 'none', 'no', 'off'].includes(browser);
+}
+
+export function _browserLaunchCandidates(env = process.env, platform = process.platform) {
+  const requestedBrowser = String(env.BROWSER || '').trim();
+  if (requestedBrowser && !['0', 'false', 'none', 'no', 'off'].includes(requestedBrowser.toLowerCase())) {
+    return [{ command: requestedBrowser, args: [] }];
+  }
+  if (platform === 'darwin') {
+    return [
+      { command: 'open', args: ['-a', 'Google Chrome'] },
+      { command: 'open', args: [] },
+    ];
+  }
+  if (platform === 'win32') {
+    return [{ command: 'cmd', args: ['/c', 'start', '', 'chrome'] }];
+  }
+  return [
+    { command: 'google-chrome', args: [] },
+    { command: 'google-chrome-stable', args: [] },
+    { command: 'chromium', args: [] },
+    { command: 'chromium-browser', args: [] },
+    { command: 'xdg-open', args: [] },
+  ];
+}
+
+export function openDevBrowser(url, opts = {}) {
+  const env = opts.env || process.env;
+  if (_browserLaunchDisabled(env)) return false;
+
+  const spawnImpl = opts.spawn || spawn;
+  const candidates = opts.candidates || _browserLaunchCandidates(env, opts.platform || process.platform);
+  let index = 0;
+
+  const tryNext = () => {
+    const candidate = candidates[index++];
+    if (!candidate) {
+      console.warn(`Could not open a browser automatically. Open ${url} manually.`);
+      return;
+    }
+    let child;
+    try {
+      child = spawnImpl(candidate.command, [...candidate.args, url], {
+        detached: true,
+        stdio: 'ignore',
+      });
+    } catch {
+      tryNext();
+      return;
+    }
+    let didFallback = false;
+    const fallback = () => {
+      if (didFallback) return;
+      didFallback = true;
+      tryNext();
+    };
+    child.once('error', fallback);
+    child.once('spawn', () => {
+      if (typeof child.unref === 'function') child.unref();
+    });
+    child.once('exit', (code) => {
+      if (code) fallback();
+    });
+  };
+
+  tryNext();
+  return true;
+}
 
 const COMPRESSIBLE_EXTENSIONS = new Set([
   '.html', '.css', '.js', '.mjs', '.json', '.svg', '.txt', '.xml', '.webmanifest',
@@ -1287,6 +1362,7 @@ const server = http.createServer((req, res) => {
 const _entryUrl = process.argv[1] ? new URL(`file://${path.resolve(process.argv[1])}`).href : '';
 const _isDirectRun = import.meta.url === _entryUrl;
 if (_isDirectRun) server.listen(PORT, HOST, () => {
+  const localUrl = `http://127.0.0.1:${PORT}`;
   console.log(`Dev server running at http://${HOST === '0.0.0.0' ? '0.0.0.0' : '127.0.0.1'}:${PORT}`);
   if (HOST === '0.0.0.0') {
     console.log(`  → reachable on your LAN at http://<your-lan-ip>:${PORT}`);
@@ -1298,4 +1374,5 @@ if (_isDirectRun) server.listen(PORT, HOST, () => {
     console.log(`  /        → index.html (no site repo found at ${SITE_DIR})`);
   }
   console.log(`  /docs/*  → 301 docs.getbased.health`);
+  openDevBrowser(localUrl);
 });

--- a/tests/test-dev-server-helpers.js
+++ b/tests/test-dev-server-helpers.js
@@ -33,6 +33,9 @@ import {
   _isLoopbackSocket,
   _isHostOriginMatch,
   corsHeaders,
+  _browserLaunchDisabled,
+  _browserLaunchCandidates,
+  openDevBrowser,
   _sendProfileShareJSON,
   _validateProfileShareEnvelope,
   _handleProfileShareDev,
@@ -271,6 +274,91 @@ assert('isSameOrigin rejects malformed Referer',
   !isSameOrigin(reqWith({ referer: 'not a url' })));
 assert('isSameOrigin rejects foreign Origin',
   !isSameOrigin(reqWith({ origin: 'https://evil.example' })));
+
+console.log('\n── browser launch helpers ──');
+
+assert('browser auto-launch is disabled in CI',
+  _browserLaunchDisabled({ CI: 'true' }));
+assert('browser auto-launch treats CI=1 as disabled',
+  _browserLaunchDisabled({ CI: '1' }));
+assert('browser auto-launch allows explicit CI=false',
+  !_browserLaunchDisabled({ CI: 'false' }));
+assert('browser auto-launch respects OPEN_BROWSER=0',
+  _browserLaunchDisabled({ OPEN_BROWSER: '0' }));
+assert('browser auto-launch respects BROWSER=none',
+  _browserLaunchDisabled({ BROWSER: 'none' }));
+assert('Linux browser candidates prefer Google Chrome',
+  _browserLaunchCandidates({}, 'linux')[0].command === 'google-chrome');
+assert('macOS browser candidates fall back to default browser opener',
+  _browserLaunchCandidates({}, 'darwin').some(c => c.command === 'open' && c.args.length === 0));
+assert('BROWSER env overrides browser command',
+  _browserLaunchCandidates({ BROWSER: 'brave-browser' }, 'linux')[0].command === 'brave-browser');
+{
+  const calls = [];
+  const launched = openDevBrowser('http://127.0.0.1:8765', {
+    env: {},
+    candidates: [{ command: 'google-chrome', args: [] }],
+    spawn: (command, args, options) => {
+      calls.push({ command, args, options });
+      return {
+        once(event, callback) {
+          if (event === 'spawn') callback();
+          return this;
+        },
+        unref() { calls.push({ unref: true }); },
+      };
+    },
+  });
+  assert('openDevBrowser launches Chrome with URL and detaches',
+    launched
+      && calls[0]?.command === 'google-chrome'
+      && calls[0]?.args?.[0] === 'http://127.0.0.1:8765'
+      && calls[0]?.options?.detached === true
+      && calls.some(c => c.unref === true),
+    JSON.stringify(calls));
+}
+{
+  const calls = [];
+  const launched = openDevBrowser('http://127.0.0.1:8765', {
+    env: {},
+    candidates: [
+      { command: 'bad-browser', args: [] },
+      { command: 'good-browser', args: ['--new-window'] },
+    ],
+    spawn: (command, args, options) => {
+      calls.push({ command, args, options });
+      return {
+        once(event, callback) {
+          if (command === 'bad-browser' && event === 'spawn') callback();
+          if (command === 'bad-browser' && event === 'exit') callback(1);
+          if (command === 'good-browser' && event === 'spawn') callback();
+          return this;
+        },
+        unref() { calls.push({ command, unref: true }); },
+      };
+    },
+  });
+  assert('openDevBrowser falls back after spawned opener exits non-zero',
+    launched
+      && calls.some(c => c.command === 'bad-browser')
+      && calls.some(c => c.command === 'good-browser')
+      && calls.some(c => c.command === 'good-browser' && c.unref === true),
+    JSON.stringify(calls));
+}
+{
+  const calls = [];
+  const launched = openDevBrowser('http://127.0.0.1:8765', {
+    env: { OPEN_BROWSER: '0' },
+    candidates: [{ command: 'google-chrome', args: [] }],
+    spawn: (command, args) => {
+      calls.push({ command, args });
+      return { once() { return this; }, unref() {} };
+    },
+  });
+  assert('openDevBrowser does nothing when disabled',
+    launched === false && calls.length === 0,
+    JSON.stringify(calls));
+}
 
 assert('loopback socket helper accepts IPv4 and IPv6 loopback',
   _isLoopbackSocket(reqWith({}, '127.0.0.1')) &&


### PR DESCRIPTION
## What changed

- Added dev-server browser launch helpers that prefer Chrome on Linux and support platform-specific fallbacks.
- Automatically opens `http://127.0.0.1:${PORT}` when `dev-server.js` is run directly.
- Added opt-outs for CI, `OPEN_BROWSER=0`, and `BROWSER=none`.
- Added helper tests for disabled states, candidate selection, custom `BROWSER`, and launch behavior.

## Why

Starting the local dev server should put the app in front of the developer without requiring a manual URL copy, while still being quiet in CI and scriptable environments.

## Validation

- `npm run typecheck:checkjs`
- `npm run quality`
- `node tests/test-dev-server-helpers.js`
- `npm test`

Note: an attempted `npm uninstall @vercel/speed-insights` hit an npm CLI exit-handler bug, so the unused package entries were removed with a targeted patch instead. No package changes remain in this PR.