### PR TITLE
test: add Routstr wallet safety baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:playwright": "playwright test",
     "typecheck": "tsc -p tsconfig.json",
     "typecheck:checkjs": "tsc -p tsconfig.checkjs.json",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:routstr-wallet": "PORT=${PORT:-8180} playwright test tests/playwright/routstr-wallet-dom.spec.js",
+    "canary:routstr-real": "node scripts/routstr-real-funds-canary.mjs"
   },
   "devDependencies": {
     "@cashu/cashu-ts": "4.6.0",

--- a/scripts/routstr-real-funds-canary.mjs
+++ b/scripts/routstr-real-funds-canary.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * Routstr/Cashu real-funds browser canary.
+ *
+ * This is intentionally NOT part of the normal automated suite. It moves bearer
+ * money and must be run manually with tiny sats after Cashu/Routstr refactors.
+ * It redacts seeds, Cashu tokens, and Routstr keys. The only bearer-like value it
+ * prints is the Lightning invoice in setup phase, because an operator must pay it.
+ *
+ * Usage:
+ *   GETBASED_URL=http://127.0.0.1:8180/app \
+ *   ROUTSTR_CANARY_ALLOW_REAL_FUNDS=1 \
+ *   node scripts/routstr-real-funds-canary.mjs setup
+ *
+ *   # pay printed PAY_THIS_LIGHTNING_INVOICE, then:
+ *   GETBASED_URL=http://127.0.0.1:8180/app \
+ *   ROUTSTR_CANARY_ALLOW_REAL_FUNDS=1 \
+ *   node scripts/routstr-real-funds-canary.mjs resume
+ */
+import { chromium } from 'playwright';
+import { rmSync } from 'node:fs';
+
+const APP_URL = process.env.GETBASED_URL || 'http://127.0.0.1:8180/app';
+const USER_DATA_DIR = process.env.CANARY_PROFILE || '/tmp/getbased-routstr-real-canary-profile';
+const TOKEN_IMPORT_DIR = process.env.CANARY_TOKEN_PROFILE || '/tmp/getbased-routstr-token-import-profile';
+const SEED_RESTORE_DIR = process.env.CANARY_RESTORE_PROFILE || '/tmp/getbased-routstr-seed-restore-profile';
+const MINT_URL = process.env.CANARY_MINT || 'https://mint.cubabitcoin.org';
+const AMOUNT_SATS = Number(process.env.CANARY_SATS || '1000');
+const phase = process.argv[2] || 'help';
+
+function requireRealFundsAllowed() {
+  if (process.env.ROUTSTR_CANARY_ALLOW_REAL_FUNDS !== '1') {
+    throw new Error('Refusing real-funds canary without ROUTSTR_CANARY_ALLOW_REAL_FUNDS=1');
+  }
+  if (!Number.isFinite(AMOUNT_SATS) || AMOUNT_SATS < 100 || AMOUNT_SATS > 5000) {
+    throw new Error(`Unsafe CANARY_SATS=${AMOUNT_SATS}; expected 100..5000`);
+  }
+}
+function log(msg, obj) {
+  if (obj === undefined) console.log(msg);
+  else console.log(msg, JSON.stringify(obj));
+}
+function redactText(text) {
+  if (!text) return text;
+  return String(text)
+    .replace(/cashu[A-Za-z0-9_-]{20,}/g, '[cashu-token-redacted]')
+    .replace(/sk-[A-Za-z0-9_-]{10,}/g, '[routstr-key-redacted]')
+    .replace(/\b(?:[a-z]+\s+){11}[a-z]+\b/g, '[possible-seed-redacted]');
+}
+async function openApp(dir = USER_DATA_DIR) {
+  const context = await chromium.launchPersistentContext(dir, {
+    headless: true,
+    viewport: { width: 1280, height: 900 },
+  });
+  const page = context.pages()[0] || await context.newPage();
+  const errors = [];
+  const requests = [];
+  page.on('pageerror', e => errors.push(e.message));
+  page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()); });
+  page.on('request', req => {
+    const url = req.url();
+    if (/routstr|balance|wallet|mint|cashu/i.test(url)) {
+      requests.push({ method: req.method(), url: url.replace(/initial_balance_token=[^&]+/, 'initial_balance_token=[redacted]') });
+    }
+  });
+  await page.goto(APP_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(1500);
+  await page.evaluate(() => {
+    document.querySelector('.chat-close-btn')?.click();
+    document.querySelectorAll('.tour-btn, .analytics-consent-btn').forEach(btn => {
+      if (/^(Skip|Turn off|Got it)$/.test((btn.textContent || '').trim())) btn.click();
+    });
+  });
+  return { context, page, errors, requests };
+}
+async function ensureAppWallet(page) {
+  await page.evaluate(async (mint) => {
+    if (typeof window.cashuHasWalletSeed === 'function' && !(await window.cashuHasWalletSeed())) {
+      await window.cashuGenerateWalletSeed();
+    }
+    await window.cashuSetMintUrl(mint);
+  }, MINT_URL);
+  log('PASS app wallet seed exists and mint selected', { mintHost: new URL(MINT_URL).host });
+}
+async function setup() {
+  requireRealFundsAllowed();
+  rmSync(USER_DATA_DIR, { recursive: true, force: true });
+  const { context, page, errors } = await openApp(USER_DATA_DIR);
+  try {
+    await ensureAppWallet(page);
+    const quote = await page.evaluate(async (sats) => window.cashuCreateFundingInvoice(sats), AMOUNT_SATS);
+    const invoice = quote?.request || quote?.invoice || quote?.bolt11 || quote?.payment_request || '';
+    if (!invoice) throw new Error('No Lightning invoice found after funding request');
+    log('PASS app Lightning invoice created', { sats: AMOUNT_SATS, mintHost: new URL(MINT_URL).host });
+    console.log('PAY_THIS_LIGHTNING_INVOICE=' + invoice);
+    log('NEXT', { command: 'ROUTSTR_CANARY_ALLOW_REAL_FUNDS=1 node scripts/routstr-real-funds-canary.mjs resume' });
+    if (errors.length) log('WARN browser_errors_redacted', errors.map(redactText).slice(-5));
+  } finally {
+    await context.close();
+  }
+}
+async function resume() {
+  requireRealFundsAllowed();
+  const { context, page, errors, requests } = await openApp(USER_DATA_DIR);
+  try {
+    await ensureAppWallet(page);
+    await page.evaluate(async () => window.cashuRecoverPendingFunding());
+    const initialWallet = await page.evaluate(async () => Number(await window.cashuGetBalance()) || 0);
+    if (initialWallet <= 0) {
+      log('WAIT pending funding not paid or not minted yet', { walletSats: initialWallet });
+      return;
+    }
+    log('PASS wallet funding recovered/confirmed', { walletSats: initialWallet });
+
+    const firstDeposit = Math.min(500, Math.max(100, Math.floor(initialWallet / 2)));
+    await page.evaluate(async (amount) => {
+      const node = localStorage.getItem('labcharts-routstr-node') || 'https://api.routstr.com/';
+      const result = await window.cashuDepositToNode(node, amount, null);
+      if (result?.api_key) localStorage.setItem('labcharts-routstr-key', result.api_key);
+      localStorage.setItem('labcharts-routstr-node', node);
+    }, firstDeposit);
+    const createCalls = requests.filter(r => /\/v1\/balance\/create/.test(r.url)).length;
+    if (createCalls !== 1) throw new Error(`Expected exactly one create call for first deposit, saw ${createCalls}`);
+    log('PASS first node deposit used /v1/balance/create', { sats: firstDeposit });
+
+    await page.evaluate(async () => {
+      const node = localStorage.getItem('labcharts-routstr-node') || 'https://api.routstr.com/';
+      const key = localStorage.getItem('labcharts-routstr-key');
+      if (!key) throw new Error('No Routstr key after first deposit');
+      await window.cashuDepositToNode(node, 100, key);
+    });
+    const topupCalls = requests.filter(r => /\/v1\/balance\/topup/.test(r.url)).length;
+    if (topupCalls !== 1) throw new Error(`Expected existing key topup call, saw ${topupCalls}`);
+    log('PASS second node deposit used /v1/balance/topup');
+
+    const nodeResult = await page.evaluate(async () => {
+      const node = (localStorage.getItem('labcharts-routstr-node') || 'https://api.routstr.com/').replace(/\/$/, '');
+      const key = localStorage.getItem('labcharts-routstr-key');
+      const balanceInfo = async () => {
+        const res = await fetch(node + '/v1/balance/info', { headers: { Authorization: 'Bearer ' + key } });
+        const json = await res.json().catch(() => ({}));
+        return { ok: res.ok, sats: json.balance != null ? Math.floor(json.balance / 1000) : null, total_requests: json.total_requests || 0, total_spent: json.total_spent || 0 };
+      };
+      const before = await balanceInfo();
+      let modelCall = { ok: false };
+      try {
+        const model = localStorage.getItem('labcharts-routstr-model') || 'claude-sonnet-4.6';
+        const res = await fetch(node + '/v1/chat/completions', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer ' + key, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model, messages: [{ role: 'user', content: 'Reply with exactly: ok' }], max_tokens: 3, temperature: 0 }),
+        });
+        const json = await res.json().catch(() => ({}));
+        modelCall = { ok: res.ok, status: res.status, hasChoice: Array.isArray(json.choices) && json.choices.length > 0 };
+      } catch (e) { modelCall = { ok: false, error: e.message }; }
+      const afterModel = await balanceInfo();
+      const refundRes = await fetch(node + '/v1/wallet/refund', { method: 'POST', headers: { Authorization: 'Bearer ' + key } });
+      const refundJson = await refundRes.json().catch(() => null);
+      const token = refundJson?.token || refundJson?.cashu_token || (typeof refundJson === 'string' && refundJson.startsWith('cashu') ? refundJson : null);
+      if (!refundRes.ok || !token) return { before, afterModel, modelCall, refund: { ok: refundRes.ok, hasToken: !!token } };
+      const pendingSaved = await window.cashuSavePendingWithdrawToken(token, 'routstr-real-canary-refund');
+      const recv = await window.cashuReceiveToken(token);
+      await window.cashuClearPendingWithdraw();
+      localStorage.removeItem('labcharts-routstr-key');
+      return { before, afterModel, modelCall, refund: { ok: true, hasToken: true, pendingSaved, received: Number(recv?.received ?? recv) || 0 } };
+    });
+    if (!nodeResult.modelCall.ok) throw new Error('Routstr model call failed: ' + redactText(JSON.stringify(nodeResult.modelCall)));
+    if (!nodeResult.refund.ok || !nodeResult.refund.pendingSaved || !nodeResult.refund.received) {
+      throw new Error('Node refund recovery failed: ' + redactText(JSON.stringify(nodeResult.refund)));
+    }
+    log('PASS model call and refund recovered', nodeResult);
+
+    const tokenRoundtrip = await tokenRoundtripAndSeedRestore();
+    log('PASS token export/import and seed restore', tokenRoundtrip);
+
+    const finalState = await page.evaluate(async () => ({
+      mintHost: new URL(await window.cashuGetMintUrl()).host,
+      walletBalance: Number(await window.cashuGetBalance()) || 0,
+      hasRoutstrKey: !!localStorage.getItem('labcharts-routstr-key'),
+      pendingDeposit: !!(await window.cashuRecoverPendingDeposit()),
+      pendingWithdraw: !!(await window.cashuRecoverPendingWithdraw()),
+    }));
+    log('PASS final state', finalState);
+    if (errors.length) log('WARN browser_errors_redacted', errors.map(redactText).slice(-10));
+  } finally {
+    await context.close();
+  }
+}
+async function tokenRoundtripAndSeedRestore() {
+  const main = await openApp(USER_DATA_DIR);
+  let tokenToSecond;
+  try {
+    const sent = await main.page.evaluate(async () => {
+      const before = Number(await window.cashuGetBalance());
+      const amount = Math.min(100, Math.max(10, before - 10));
+      const result = await window.cashuSendAsToken(amount);
+      return { before, after: Number(await window.cashuGetBalance()), amount: result.amount, token: result.token };
+    });
+    tokenToSecond = sent.token;
+  } finally { await main.context.close(); }
+
+  rmSync(TOKEN_IMPORT_DIR, { recursive: true, force: true });
+  const second = await openApp(TOKEN_IMPORT_DIR);
+  let returnToken;
+  try {
+    const received = await second.page.evaluate(async ({ token, mint }) => {
+      await window.cashuGenerateWalletSeed();
+      await window.cashuSetMintUrl(mint);
+      const recv = await window.cashuReceiveToken(token);
+      const backup = await window.cashuExportWallet();
+      const balance = Number(await window.cashuGetBalance());
+      let sendBack = null;
+      for (const amount of [Math.max(1, balance - 1), Math.max(1, balance - 2), Math.max(1, balance - 5), 1]) {
+        try { sendBack = await window.cashuSendAsToken(amount); break; } catch {}
+      }
+      return { received: Number(recv?.received ?? recv) || 0, backupCreated: !!backup, sendBack };
+    }, { token: tokenToSecond, mint: MINT_URL });
+    if (!received.received || !received.backupCreated || !received.sendBack?.token) throw new Error('Token import/export failed');
+    returnToken = received.sendBack.token;
+  } finally { await second.context.close(); }
+
+  const recover = await openApp(USER_DATA_DIR);
+  try {
+    const recovered = await recover.page.evaluate(async (token) => {
+      const recv = await window.cashuReceiveToken(token);
+      return { received: Number(recv?.received ?? recv) || 0, balance: Number(await window.cashuGetBalance()) || 0, seedPresent: !!(await window.cashuGetWalletMnemonic()) };
+    }, returnToken);
+    if (!recovered.received) throw new Error('Return token receive failed');
+    const seedRestore = await seedRestoreSmoke();
+    return { recovered: recovered.received, walletBalance: recovered.balance, seedRestoreBalance: seedRestore.balance };
+  } finally { await recover.context.close(); }
+}
+async function seedRestoreSmoke() {
+  const main = await openApp(USER_DATA_DIR);
+  let seed;
+  try { seed = await main.page.evaluate(async () => window.cashuGetWalletMnemonic()); }
+  finally { await main.context.close(); }
+  rmSync(SEED_RESTORE_DIR, { recursive: true, force: true });
+  const restored = await openApp(SEED_RESTORE_DIR);
+  try {
+    const result = await restored.page.evaluate(async ({ seed, mint }) => {
+      await window.cashuSetMintUrl(mint);
+      await window.cashuRestoreWalletFromSeed(seed);
+      return { balance: Number(await window.cashuGetBalance()) || 0 };
+    }, { seed, mint: MINT_URL });
+    return result;
+  } finally {
+    await restored.context.close();
+    rmSync(SEED_RESTORE_DIR, { recursive: true, force: true });
+  }
+}
+
+if (phase === 'setup') await setup();
+else if (phase === 'resume') await resume();
+else {
+  console.log('Usage: ROUTSTR_CANARY_ALLOW_REAL_FUNDS=1 node scripts/routstr-real-funds-canary.mjs <setup|resume>');
+}

--- a/scripts/routstr-real-funds-canary.mjs
+++ b/scripts/routstr-real-funds-canary.mjs
@@ -116,7 +116,8 @@ async function resume() {
     await page.evaluate(async (amount) => {
       const node = localStorage.getItem('labcharts-routstr-node') || 'https://api.routstr.com/';
       const result = await window.cashuDepositToNode(node, amount, null);
-      if (result?.api_key) localStorage.setItem('labcharts-routstr-key', result.api_key);
+      if (!result?.api_key) throw new Error('Node deposit did not return a Routstr key');
+      window.__routstrCanaryKey = result.api_key;
       localStorage.setItem('labcharts-routstr-node', node);
     }, firstDeposit);
     const createCalls = requests.filter(r => /\/v1\/balance\/create/.test(r.url)).length;
@@ -125,7 +126,7 @@ async function resume() {
 
     await page.evaluate(async () => {
       const node = localStorage.getItem('labcharts-routstr-node') || 'https://api.routstr.com/';
-      const key = localStorage.getItem('labcharts-routstr-key');
+      const key = window.__routstrCanaryKey;
       if (!key) throw new Error('No Routstr key after first deposit');
       await window.cashuDepositToNode(node, 100, key);
     });
@@ -135,7 +136,8 @@ async function resume() {
 
     const nodeResult = await page.evaluate(async () => {
       const node = (localStorage.getItem('labcharts-routstr-node') || 'https://api.routstr.com/').replace(/\/$/, '');
-      const key = localStorage.getItem('labcharts-routstr-key');
+      const key = window.__routstrCanaryKey;
+      if (!key) throw new Error('No Routstr key available for canary node checks');
       const balanceInfo = async () => {
         const res = await fetch(node + '/v1/balance/info', { headers: { Authorization: 'Bearer ' + key } });
         const json = await res.json().catch(() => ({}));
@@ -161,6 +163,7 @@ async function resume() {
       const pendingSaved = await window.cashuSavePendingWithdrawToken(token, 'routstr-real-canary-refund');
       const recv = await window.cashuReceiveToken(token);
       await window.cashuClearPendingWithdraw();
+      delete window.__routstrCanaryKey;
       localStorage.removeItem('labcharts-routstr-key');
       return { before, afterModel, modelCall, refund: { ok: true, hasToken: true, pendingSaved, received: Number(recv?.received ?? recv) || 0 } };
     });
@@ -176,7 +179,7 @@ async function resume() {
     const finalState = await page.evaluate(async () => ({
       mintHost: new URL(await window.cashuGetMintUrl()).host,
       walletBalance: Number(await window.cashuGetBalance()) || 0,
-      hasRoutstrKey: !!localStorage.getItem('labcharts-routstr-key'),
+      hasRoutstrKey: !!localStorage.getItem('labcharts-routstr-key') || !!window.__routstrCanaryKey,
       pendingDeposit: !!(await window.cashuRecoverPendingDeposit()),
       pendingWithdraw: !!(await window.cashuRecoverPendingWithdraw()),
     }));
@@ -227,6 +230,7 @@ async function tokenRoundtripAndSeedRestore() {
     }, returnToken);
     if (!recovered.received) throw new Error('Return token receive failed');
     const seedRestore = await seedRestoreSmoke();
+    if (!seedRestore.balance) throw new Error('Seed restore smoke did not recover a positive balance');
     return { recovered: recovered.received, walletBalance: recovered.balance, seedRestoreBalance: seedRestore.balance };
   } finally { await recover.context.close(); }
 }
@@ -235,13 +239,16 @@ async function seedRestoreSmoke() {
   let seed;
   try { seed = await main.page.evaluate(async () => window.cashuGetWalletMnemonic()); }
   finally { await main.context.close(); }
+  if (!seed) throw new Error('Cannot run seed restore smoke without a wallet mnemonic');
   rmSync(SEED_RESTORE_DIR, { recursive: true, force: true });
   const restored = await openApp(SEED_RESTORE_DIR);
   try {
     const result = await restored.page.evaluate(async ({ seed, mint }) => {
       await window.cashuSetMintUrl(mint);
       await window.cashuRestoreWalletFromSeed(seed);
-      return { balance: Number(await window.cashuGetBalance()) || 0 };
+      const balance = Number(await window.cashuGetBalance()) || 0;
+      if (balance <= 0) throw new Error('Seed restore completed without recoverable balance');
+      return { balance };
     }, { seed, mint: MINT_URL });
     return result;
   } finally {

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -27,10 +27,14 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       'cashuGetBalance',
       'cashuGetMintUrl',
       'cashuSetMintUrl',
+      'cashuCreateFundingInvoice',
+      'cashuCheckFundingStatus',
+      'cashuRecoverPendingFunding',
       'cashuDepositToNode',
       'cashuRecoverPendingDeposit',
       'cashuImportWallet',
       'cashuReceiveToken',
+      'cashuExportWallet',
       'cashuSavePendingWithdrawToken',
       'cashuClearPendingWithdraw',
       'cashuClearPendingDeposit',
@@ -38,6 +42,10 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       'cashuRestoreWalletFromSeed',
       'cashuHasWalletSeed',
       'cashuGenerateWalletSeed',
+      'cashuSendAsToken',
+      'cashuCreateWithdrawQuote',
+      'cashuExecuteWithdraw',
+      'cashuWithdrawToAddress',
     ];
     const oldGlobals = {};
     for (const name of globalNames) oldGlobals[name] = window[name];
@@ -62,6 +70,14 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
     let refundCalled = false;
     let importedToken = null;
     let receivedToken = null;
+    let fundingInvoiceAmount = null;
+    let fundingStatusQuote = null;
+    let pendingFundingChecked = false;
+    let exportedWallet = false;
+    let sentTokenAmount = null;
+    let withdrawAddressArgs = null;
+    let withdrawQuoteInvoice = null;
+    let executeWithdrawQuote = null;
     let savedPendingWithdraw = null;
     let clearPendingWithdrawCalled = false;
     let restoredMnemonic = null;
@@ -98,6 +114,18 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
         currentMint = url;
         localStorage.setItem('labcharts-cashu-wallet-mint', url);
       };
+      window.cashuCreateFundingInvoice = async amount => {
+        fundingInvoiceAmount = amount;
+        return { quote: 'funding-quote-1000', invoice: 'lnbc1000getbasedtestinvoice' };
+      };
+      window.cashuCheckFundingStatus = async quote => {
+        fundingStatusQuote = quote;
+        return { paid: true, minted: 1000, fee: 2 };
+      };
+      window.cashuRecoverPendingFunding = async () => {
+        pendingFundingChecked = true;
+        return { checked: 1, recovered: 998, pending: 0, failed: 0, cleared: 0 };
+      };
       window.cashuDepositToNode = async (url, amount, existingKey) => {
         depositArgs = { url, amount, existingKey };
         throw new Error('mock node rejected deposit');
@@ -113,6 +141,26 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       window.cashuReceiveToken = async token => {
         receivedToken = token;
         return { received: 888, balance: 2388 };
+      };
+      window.cashuExportWallet = async () => {
+        exportedWallet = true;
+        return 'cashuAbackupwallet';
+      };
+      window.cashuSendAsToken = async amount => {
+        sentTokenAmount = amount;
+        return { token: 'cashuAsendtoken', amount, remaining: 1400 - amount };
+      };
+      window.cashuCreateWithdrawQuote = async invoice => {
+        withdrawQuoteInvoice = invoice;
+        return { quote: 'withdraw-quote-1', amount: 123, fee_reserve: 4 };
+      };
+      window.cashuExecuteWithdraw = async quote => {
+        executeWithdrawQuote = quote;
+        return { paid: true };
+      };
+      window.cashuWithdrawToAddress = async (address, amount) => {
+        withdrawAddressArgs = { address, amount };
+        return { paid: true, amount, balance: 1234 };
       };
       window.cashuSavePendingWithdrawToken = async (token, source) => {
         savedPendingWithdraw = { token, source };
@@ -135,16 +183,24 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
         cashuGetBalance: window.cashuGetBalance,
         cashuGetMintUrl: window.cashuGetMintUrl,
         cashuSetMintUrl: window.cashuSetMintUrl,
+        cashuCreateFundingInvoice: window.cashuCreateFundingInvoice,
+        cashuCheckFundingStatus: window.cashuCheckFundingStatus,
+        cashuRecoverPendingFunding: window.cashuRecoverPendingFunding,
         cashuDepositToNode: window.cashuDepositToNode,
         cashuRecoverPendingDeposit: window.cashuRecoverPendingDeposit,
         cashuImportWallet: window.cashuImportWallet,
         cashuReceiveToken: window.cashuReceiveToken,
+        cashuExportWallet: window.cashuExportWallet,
         cashuSavePendingWithdrawToken: window.cashuSavePendingWithdrawToken,
         cashuClearPendingWithdraw: window.cashuClearPendingWithdraw,
         cashuGetWalletMnemonic: window.cashuGetWalletMnemonic,
         cashuRestoreWalletFromSeed: window.cashuRestoreWalletFromSeed,
         cashuHasWalletSeed: window.cashuHasWalletSeed,
         cashuGenerateWalletSeed: window.cashuGenerateWalletSeed,
+        cashuSendAsToken: window.cashuSendAsToken,
+        cashuCreateWithdrawQuote: window.cashuCreateWithdrawQuote,
+        cashuExecuteWithdraw: window.cashuExecuteWithdraw,
+        cashuWithdrawToAddress: window.cashuWithdrawToAddress,
       });
 
       localStorage.setItem('labcharts-ai-provider', 'routstr');
@@ -219,6 +275,55 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
         seedAckProceedsToFunding = !!document.getElementById('routstr-wcashu-input');
       }
 
+      await panels.doRoutstrWalletFund(1000);
+      await wait(50);
+      const lightningFundingCreatesInvoice = fundingInvoiceAmount === 1000
+        && (document.getElementById('routstr-wfund-status')?.textContent || '').includes('Waiting for payment');
+      await panels.recoverPendingWalletFunding();
+      await wait(50);
+      const pendingFundingRecoveryReportsRecovered = pendingFundingChecked
+        && (document.getElementById('routstr-wfund-status')?.textContent || '').includes('+998 sats recovered');
+      const fundingPollUsesQuote = fundingStatusQuote === null || fundingStatusQuote === 'funding-quote-1000';
+
+      await panels.showRoutstrWalletBackup();
+      await wait(50);
+      const walletBackupExportCalled = exportedWallet === true;
+
+      await panels.showRoutstrWithdraw();
+      await wait(50);
+      await panels.showRoutstrWithdrawToken();
+      await wait(50);
+      await panels.doRoutstrSendToken(250);
+      await wait(50);
+      const sendTokenUsesWalletRuntime = sentTokenAmount === 250
+        && (document.getElementById('routstr-token-result')?.textContent || '').includes('Token created');
+
+      await panels.showRoutstrWithdrawLightning();
+      await wait(50);
+      const lightningInput = document.getElementById('routstr-withdraw-input');
+      if (lightningInput) lightningInput.value = 'lnbc123getbasedtestinvoice';
+      await panels.doRoutstrWithdrawQuote();
+      await wait(50);
+      const lightningWithdrawQuotesInvoice = withdrawQuoteInvoice === 'lnbc123getbasedtestinvoice'
+        && (document.getElementById('routstr-withdraw-status')?.textContent || '').includes('Fee reserve');
+      await panels.doRoutstrWithdrawExecute('withdraw-quote-1');
+      await wait(50);
+      const lightningWithdrawExecutesQuote = executeWithdrawQuote === 'withdraw-quote-1'
+        && (document.getElementById('routstr-withdraw-status')?.textContent || '').includes('Withdrawn');
+      panels.showRoutstrWithdrawLightning();
+      await wait(50);
+      const addressInput = document.getElementById('routstr-withdraw-input');
+      if (addressInput) {
+        addressInput.value = 'alice@getbased.test';
+        addressInput.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      const amountInput = document.getElementById('routstr-withdraw-amount');
+      if (amountInput) amountInput.value = '42';
+      await panels.doRoutstrWithdrawQuote();
+      await wait(50);
+      const lightningAddressWithdrawUsesAmount = withdrawAddressArgs?.address === 'alice@getbased.test'
+        && withdrawAddressArgs.amount === 42;
+
       return {
         walletRenders,
         nodeBalanceRenders,
@@ -242,6 +347,14 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
         seedContinueStartsDisabled,
         seedAckEnablesContinue,
         seedAckProceedsToFunding,
+        lightningFundingCreatesInvoice,
+        pendingFundingRecoveryReportsRecovered,
+        fundingPollUsesQuote,
+        walletBackupExportCalled,
+        sendTokenUsesWalletRuntime,
+        lightningWithdrawQuotesInvoice,
+        lightningWithdrawExecutesQuote,
+        lightningAddressWithdrawUsesAmount,
       };
     } finally {
       const panels = await import('/js/provider-wallet-panels.js');

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -310,7 +310,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       await wait(50);
       const lightningWithdrawExecutesQuote = executeWithdrawQuote === 'withdraw-quote-1'
         && (document.getElementById('routstr-withdraw-status')?.textContent || '').includes('Withdrawn');
-      panels.showRoutstrWithdrawLightning();
+      await panels.showRoutstrWithdrawLightning();
       await wait(50);
       const addressInput = document.getElementById('routstr-withdraw-input');
       if (addressInput) {
@@ -318,7 +318,10 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
         addressInput.dispatchEvent(new Event('input', { bubbles: true }));
       }
       const amountInput = document.getElementById('routstr-withdraw-amount');
-      if (amountInput) amountInput.value = '42';
+      if (amountInput) {
+        amountInput.value = '42';
+        amountInput.dispatchEvent(new Event('input', { bubbles: true }));
+      }
       await panels.doRoutstrWithdrawQuote();
       await wait(50);
       const lightningAddressWithdrawUsesAmount = withdrawAddressArgs?.address === 'alice@getbased.test'


### PR DESCRIPTION
## Summary
- expands the Routstr wallet Playwright DOM regression to cover funding invoices, pending funding recovery, wallet backup/export, send-as-token, Lightning invoice withdrawals, and Lightning-address withdrawals
- adds focused npm scripts for the Routstr wallet regression and the manual real-funds canary
- adds a guarded tiny-sats Routstr/Cashu canary script for pre-release money-path verification; it refuses to run unless `ROUTSTR_CANARY_ALLOW_REAL_FUNDS=1` is set

## Verification
- `npx vitest run tests/cashu-wallet-runtime.test.js --reporter=dot` → 11 passed
- `PORT=8181 npm run test:routstr-wallet -- --reporter=line` → 1 passed
- `node --check scripts/routstr-real-funds-canary.mjs`
- `npm run canary:routstr-real -- help`
- `npm run canary:routstr-real -- setup` without guard → exits with refusal, as intended

## Manual baseline already run before this PR
A 1000 sat current-state Routstr/Cashu canary was run before opening this PR:
- wallet funding recovered
- first node deposit used `/v1/balance/create`
- second existing-key deposit used `/v1/balance/topup`
- tiny Routstr model call succeeded
- node refund recovered to wallet
- Cashu token export/import round-tripped through an isolated profile
- seed restore worked in a throwaway profile
- final wallet recovered 993 sats, with no pending deposit, no pending withdraw, and no Routstr key left behind

## Notes
This PR intentionally does **not** migrate Cashu internals. It establishes the current safe baseline before the Cashu TS migration PR.
