### PR TITLE
[codex] Reduce sun AI analysis window globals

### DIFF
--- a/js/sun-ai-analysis.js
+++ b/js/sun-ai-analysis.js
@@ -15,6 +15,8 @@ import { escapeHTML, escapeAttr } from './utils.js';
 import { hasAIProvider } from './api.js';
 import { getSunDefaults } from './sun-defaults.js';
 import { getSessions, formatChannelUnit, CHANNEL_DISPLAY, channelTier, tierLabel } from './sun.js';
+import { vitaminDIU } from './sun-spectrum.js';
+import { solarZenithAngle } from './sun-uvdata.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
 import { aiActionAttrs } from './ai-action-delegates.js';
@@ -98,8 +100,8 @@ function _sevenDayRollup(currentSess) {
   for (const s of recent) {
     totalMin += s.durationMin || 0;
     const rawVitD = s.doses?.vitamin_d || 0;
-    if (rawVitD > 0 && typeof window.vitaminDIU === 'function') {
-      const iu = window.vitaminDIU(
+    if (rawVitD > 0) {
+      const iu = vitaminDIU(
         rawVitD,
         s.safety?.fitzpatrick || 'III',
         s.atmosphere?.uvIndex ?? null,
@@ -145,10 +147,10 @@ export function buildSingleSessionContext(sess) {
   }
 
   // Solar geometry
-  if (end && sess.location && typeof window.solarZenithAngle === 'function') {
+  if (end && sess.location) {
     try {
-      const zStart = window.solarZenithAngle(start, sess.location.lat, sess.location.lon);
-      const zEnd = window.solarZenithAngle(end, sess.location.lat, sess.location.lon);
+      const zStart = solarZenithAngle(start, sess.location.lat, sess.location.lon);
+      const zEnd = solarZenithAngle(end, sess.location.lat, sess.location.lon);
       const elevStart = 90 - zStart;
       const elevEnd = 90 - zEnd;
       lines.push(`Solar elevation: ${elevStart.toFixed(1)}° at start → ${elevEnd.toFixed(1)}° at end`);
@@ -160,9 +162,9 @@ export function buildSingleSessionContext(sess) {
   if (sess.doses) {
     let zenith = null;
     try {
-      if (sess.startedAt && sess.endedAt && sess.location && typeof window.solarZenithAngle === 'function') {
+      if (sess.startedAt && sess.endedAt && sess.location) {
         const mid = new Date((sess.startedAt + sess.endedAt) / 2);
-        zenith = window.solarZenithAngle(mid, sess.location.lat, sess.location.lon);
+        zenith = solarZenithAngle(mid, sess.location.lat, sess.location.lon);
       }
     } catch (_) {}
     const fitz = sess.safety?.fitzpatrick || sd.fitzpatrick || 'III';

--- a/tests/playwright/light-ai-analysis-coverage-batch.spec.js
+++ b/tests/playwright/light-ai-analysis-coverage-batch.spec.js
@@ -39,10 +39,8 @@ test('sun and device session AI analysis covers contexts fingerprints and render
     };
 
     try {
-      const baseDay = new Date();
-      baseDay.setHours(6, 20, 0, 0);
-      const startedAt = baseDay.getTime();
-      const endedAt = startedAt + 25 * 60000;
+      const startedAt = Date.parse('2026-04-15T04:25:00Z');
+      const endedAt = Date.parse('2026-04-15T05:10:00Z');
       const priorStart = startedAt - 2 * 86400000;
       const deviceStart = startedAt + 4 * 3600000;
       const lightDevice = {
@@ -68,8 +66,8 @@ test('sun and device session AI analysis covers contexts fingerprints and render
         id: 'sun-session-ai',
         startedAt,
         endedAt,
-        durationMin: 25,
-        location: { lat: 50.1, lon: 14.4 },
+        durationMin: 45,
+        location: { lat: 50.08, lon: 14.42 },
         bodyExposure: { preset: 'arms-face', fraction: 0.22, glassBetween: true, sunscreenSPF: 15, rotatedSides: true },
         eyeExposure: { mode: 'direct', lensTint: 'amber', durationSec: 120 },
         atmosphere: { uvIndex: 3.8, cloudCover: 35, ozoneDU: 312 },
@@ -140,20 +138,14 @@ test('sun and device session AI analysis covers contexts fingerprints and render
         deviceSessions: [deviceSession, priorDeviceSession],
       };
       window._refreshSunSurfaces = () => {};
-      window.solarZenithAngle = date => {
-        const hour = date.getHours() + date.getMinutes() / 60;
-        return hour < 6.6 ? 91 : 84;
-      };
-      window.vitaminDIU = raw => raw * 9;
-
       const sunContext = sun.buildSingleSessionContext(sunSession);
       outcomes.sunContextIncludesSolarPhase = sunContext.includes('Solar phase:')
-        && sunContext.includes('sun crossed horizon');
+        && sunContext.includes('sunrise window');
       outcomes.sunContextIncludesExposureSafetyAndRollup = sunContext.includes('Through glass: yes')
         && sunContext.includes('Sunscreen: SPF 15')
         && sunContext.includes('Burn dose: 32% of MED')
         && sunContext.includes('Last 7 days')
-        && sunContext.includes('Vit-D total: ~450 IU');
+        && /Vit-D total: ~\d+ IU/.test(sunContext);
       outcomes.sunContextIncludesProfileGoalsAndLab = sunContext.includes('Skin type: Fitzpatrick II')
         && sunContext.includes('Photosensitizing meds: mild')
         && sunContext.includes('Health goals: Restore vitamin D; Improve sleep timing')

--- a/tests/test-sun-ai-analysis.js
+++ b/tests/test-sun-ai-analysis.js
@@ -5,6 +5,7 @@
 // Run: node tests/test-sun-ai-analysis.js  (or via npm test)
 
 import './_node-shim.js';
+import fs from 'fs';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -16,7 +17,6 @@ console.log('=== Sun AI Analysis Tests ===\n');
 
 await import('../js/state.js');
 await import('../js/sun.js');
-// sun-uvdata.js exposes solarZenithAngle on window for solar-phase lines.
 await import('../js/sun-uvdata.js');
 const mod = await import('../js/sun-ai-analysis.js');
 const {
@@ -65,6 +65,14 @@ const {
     localStorage.setItem('labcharts-ai-provider', 'ollama'); // optimistic-true
   }
 
+  const sunAiSource = fs.readFileSync(new URL('../js/sun-ai-analysis.js', import.meta.url), 'utf8');
+  assert('sun AI imports vitamin-D and solar geometry helpers directly',
+    sunAiSource.includes("import { vitaminDIU } from './sun-spectrum.js';") &&
+      sunAiSource.includes("import { solarZenithAngle } from './sun-uvdata.js';"));
+  assert('sun AI context builder avoids direct window helper reads',
+    !sunAiSource.includes('window.vitaminDIU') &&
+      !sunAiSource.includes('window.solarZenithAngle'));
+
   // ─── 1. Fingerprint ─────────────────────────────────────────────────
   console.log('%c 1. Fingerprint stability ', 'font-weight:bold;color:#f59e0b');
 
@@ -102,8 +110,7 @@ const {
   console.log('%c 1b. Solar phase context ', 'font-weight:bold;color:#f59e0b');
 
   // Build a sunrise-session fixture: startedAt below horizon, endedAt above.
-  // Need a real location so window.solarZenithAngle resolves; the test harness
-  // loads sun-spectrum.js which exports it on window.
+  // Need a real location so the imported solar geometry helper can classify phase.
   reset({ sunDefaults: { fitzpatrick: 'III' } });
   // 2026-04-15 06:30 UTC at lat=50, lon=14 — elevation around -3° at 06:30,
   // climbing past 0° by 07:00 (sunrise crossing). Numbers are illustrative;
@@ -190,7 +197,7 @@ const {
   });
   const ctx2 = buildSingleSessionContext(makeSess({ id: 'current' }));
   assert('rollup section appears with prior sessions', ctx2.includes('### Last 7 days'));
-  // Cumulative IU is now computed via window.vitaminDIU on each session,
+  // Cumulative IU is now computed via vitaminDIU on each session,
   // not by summing raw channelAu values. Just assert the line exists with
   // a non-zero IU number — the exact value depends on the spectrum model.
   assert('rollup line includes a numeric Vit-D total in IU',


### PR DESCRIPTION
## Summary
- import vitaminDIU and solarZenithAngle directly in sun-ai-analysis instead of reading them from window
- add source guards for the direct imports and absence of window helper reads
- update browser coverage to exercise real solar geometry rather than window stubs

## Validation
- node tests/test-sun-ai-analysis.js
- node tests/test-ai-action-delegates.js
- node tests/test-sun-spectrum.js
- npm run typecheck
- npm run typecheck:checkjs
- npm run quality
- npx playwright test tests/playwright/light-ai-analysis-coverage-batch.spec.js

Quality: window global references in js/ = 927/1088