### PR TITLE
[codex] Reduce startup UI window globals

### DIFF
--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -27,6 +27,15 @@ function callStartupRuntime(name, ...args) {
   return fn.apply(runtime, args);
 }
 
+function requireStartupRuntime(name, ...args) {
+  const runtime = startupRuntime();
+  const fn = runtime[name];
+  if (typeof fn !== 'function') {
+    throw new TypeError(`Startup runtime function ${name} is not available`);
+  }
+  return fn.apply(runtime, args);
+}
+
 export function renderStartupUI() {
   // Prime sync state for UI, but let Evolu boot after first paint. Its
   // worker/OPFS startup is expensive and should not block dashboard LCP.
@@ -36,7 +45,7 @@ export function renderStartupUI() {
   populateFooterVersion();
   buildSidebar();
   renderSyncIndicator();
-  callStartupRuntime('navigate', callStartupRuntime('getInitialView') || 'dashboard');
+  requireStartupRuntime('navigate', callStartupRuntime('getInitialView') || 'dashboard');
   scheduleDeferredSyncAndCatalogWarmup();
   const legalGateShown = scheduleStartupNudges();
   if (legalGateShown) {
@@ -101,12 +110,12 @@ function scheduleStartupNudges() {
 function openDeferredStartupDestinations() {
   const openSettingsAfterInit = getStartupRuntimeValue('_openSettingsAfterInit');
   if (openSettingsAfterInit) {
-    callStartupRuntime('openSettingsModal', openSettingsAfterInit);
+    requireStartupRuntime('openSettingsModal', openSettingsAfterInit);
     delete startupRuntime()._openSettingsAfterInit;
   }
   if (getStartupRuntimeValue('_openChatAfterInit')) {
     delete startupRuntime()._openChatAfterInit;
-    setTimeout(() => callStartupRuntime('openChatPanel'), 500);
+    setTimeout(() => requireStartupRuntime('openChatPanel'), 500);
   }
 }
 
@@ -118,7 +127,7 @@ function refreshStartupChrome() {
 
 function initializeChatAttachments() {
   // Init chat image attachment handlers (paste, drag-drop, file input).
-  callStartupRuntime('initChatImageHandlers');
-  callStartupRuntime('updateAttachButtonVisibility');
-  callStartupRuntime('updateChatNudge');
+  requireStartupRuntime('initChatImageHandlers');
+  requireStartupRuntime('updateAttachButtonVisibility');
+  requireStartupRuntime('updateChatNudge');
 }

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -12,6 +12,21 @@ import { maybeShowBackupNudge } from './crypto.js';
 import { maybeShowLegalConsentGate } from './legal-consent.js';
 import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 
+function startupRuntime() {
+  return /** @type {any} */ (globalThis);
+}
+
+function getStartupRuntimeValue(name) {
+  return startupRuntime()[name];
+}
+
+function callStartupRuntime(name, ...args) {
+  const runtime = startupRuntime();
+  const fn = runtime[name];
+  if (typeof fn !== 'function') return undefined;
+  return fn.apply(runtime, args);
+}
+
 export function renderStartupUI() {
   // Prime sync state for UI, but let Evolu boot after first paint. Its
   // worker/OPFS startup is expensive and should not block dashboard LCP.
@@ -21,11 +36,11 @@ export function renderStartupUI() {
   populateFooterVersion();
   buildSidebar();
   renderSyncIndicator();
-  window.navigate(window.getInitialView?.() || 'dashboard');
+  callStartupRuntime('navigate', callStartupRuntime('getInitialView') || 'dashboard');
   scheduleDeferredSyncAndCatalogWarmup();
   const legalGateShown = scheduleStartupNudges();
   if (legalGateShown) {
-    window.addEventListener('legal-consent-accepted', openDeferredStartupDestinations, { once: true });
+    startupRuntime().addEventListener('legal-consent-accepted', openDeferredStartupDestinations, { once: true });
   } else {
     openDeferredStartupDestinations();
   }
@@ -37,7 +52,7 @@ export function renderStartupUI() {
 function populateFooterVersion() {
   // Populate footer version early (doesn't depend on dashboard render).
   const vTextEl = document.getElementById('app-version-text');
-  if (vTextEl) vTextEl.textContent = window.APP_VERSION || '';
+  if (vTextEl) vTextEl.textContent = getStartupRuntimeValue('APP_VERSION') || '';
 }
 
 function scheduleDeferredSyncAndCatalogWarmup() {
@@ -56,17 +71,17 @@ function scheduleStartupNudges() {
   // local-first, so this is stored per browser/device rather than emailed.
   const legalGateShown = maybeShowLegalConsentGate();
   if (!legalGateShown) maybeShowChangelog();
-  else window.addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true });
+  else startupRuntime().addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true });
   // First-launch transparency banner about anonymous analytics appears once,
   // never again after the user clicks either "Got it" or "Turn off". Keep it
   // behind the legal gate so the user does not get competing prompts. What's
   // New and tours also stay behind the gate; legal must be the topmost first
   // interaction for new users and stale-version re-consent.
   const showAnalyticsConsent = () => {
-    window.maybeShowAnalyticsConsent?.();
+    callStartupRuntime('maybeShowAnalyticsConsent');
   };
   if (legalGateShown) {
-    window.addEventListener('legal-consent-accepted', () => setTimeout(showAnalyticsConsent, 800), { once: true });
+    startupRuntime().addEventListener('legal-consent-accepted', () => setTimeout(showAnalyticsConsent, 800), { once: true });
   } else {
     setTimeout(showAnalyticsConsent, 800);
   }
@@ -76,7 +91,7 @@ function scheduleStartupNudges() {
     maybeShowBackupNudge();
   };
   if (legalGateShown) {
-    window.addEventListener('legal-consent-accepted', () => setTimeout(showBackupNudge, 1500), { once: true });
+    startupRuntime().addEventListener('legal-consent-accepted', () => setTimeout(showBackupNudge, 1500), { once: true });
   } else {
     setTimeout(showBackupNudge, 1500);
   }
@@ -84,13 +99,14 @@ function scheduleStartupNudges() {
 }
 
 function openDeferredStartupDestinations() {
-  if (window._openSettingsAfterInit) {
-    window.openSettingsModal(window._openSettingsAfterInit);
-    delete window._openSettingsAfterInit;
+  const openSettingsAfterInit = getStartupRuntimeValue('_openSettingsAfterInit');
+  if (openSettingsAfterInit) {
+    callStartupRuntime('openSettingsModal', openSettingsAfterInit);
+    delete startupRuntime()._openSettingsAfterInit;
   }
-  if (window._openChatAfterInit) {
-    delete window._openChatAfterInit;
-    setTimeout(() => window.openChatPanel(), 500);
+  if (getStartupRuntimeValue('_openChatAfterInit')) {
+    delete startupRuntime()._openChatAfterInit;
+    setTimeout(() => callStartupRuntime('openChatPanel'), 500);
   }
 }
 
@@ -102,7 +118,7 @@ function refreshStartupChrome() {
 
 function initializeChatAttachments() {
   // Init chat image attachment handlers (paste, drag-drop, file input).
-  window.initChatImageHandlers();
-  window.updateAttachButtonVisibility();
-  window.updateChatNudge();
+  callStartupRuntime('initChatImageHandlers');
+  callStartupRuntime('updateAttachButtonVisibility');
+  callStartupRuntime('updateChatNudge');
 }

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -244,15 +244,15 @@ assert('PDF lazy import failure notifies from drop zone',
   /try\s*{\s*importMod\s*=\s*await loadPdfImport\(\);[\s\S]{0,220}catch\s*\(err\)\s*{[\s\S]{0,220}Could not load import module - check your connection and try again\./.test(importDropZoneSrc),
   'drop-zone import path should fail loudly');
 assert('analytics consent remains deferred after first paint and behind legal gate',
-  /const showAnalyticsConsent = \(\) => \{\s*window\.maybeShowAnalyticsConsent\?\.\(\);\s*\};/.test(startupUiSrc)
-  && /if \(legalGateShown\) \{\s*window\.addEventListener\('legal-consent-accepted', \(\) => setTimeout\(showAnalyticsConsent, 800\), \{ once: true \}\);\s*\} else \{\s*setTimeout\(showAnalyticsConsent, 800\);\s*\}/.test(startupUiSrc),
+  /const showAnalyticsConsent = \(\) => \{\s*callStartupRuntime\('maybeShowAnalyticsConsent'\);\s*\};/.test(startupUiSrc)
+  && /if \(legalGateShown\) \{\s*startupRuntime\(\)\.addEventListener\('legal-consent-accepted', \(\) => setTimeout\(showAnalyticsConsent, 800\), \{ once: true \}\);\s*\} else \{\s*setTimeout\(showAnalyticsConsent, 800\);\s*\}/.test(startupUiSrc),
   'first-run banner should stay deferred and must resume after Terms/Privacy acceptance');
 assert('legal gate runs before changelog and resumes changelog only after accept',
   startupUiSrc.indexOf('const legalGateShown = maybeShowLegalConsentGate()') >= 0
   && startupUiSrc.indexOf('const legalGateShown = maybeShowLegalConsentGate()') < startupUiSrc.indexOf('maybeShowChangelog()')
-  && startupUiSrc.includes("window.addEventListener('legal-consent-accepted'")
+  && startupUiSrc.includes("startupRuntime().addEventListener('legal-consent-accepted'")
   && startupUiSrc.includes('return legalGateShown')
-  && startupUiSrc.includes("window.addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true })")
+  && startupUiSrc.includes("startupRuntime().addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true })")
   && legalConsentSrc.includes("window.dispatchEvent(new CustomEvent('legal-consent-accepted'))"));
 assert('legal accept does not deadlock when localStorage persistence throws',
   /try\s*\{\s*storeLegalAcceptance\(\);\s*\}\s*catch\s*\(err\)\s*\{[\s\S]{0,220}\[legal-consent\] Failed to persist acceptance/.test(legalConsentSrc)

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -533,7 +533,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /export function getInitialView\(\)/.test(viewsSrc)
       && /return getRouterInitialView\(\)/.test(viewsSrc));
     assert('startup-ui.js: boot navigates to stored route instead of hard Dashboard',
-      /window\.navigate\(window\.getInitialView\?\.\(\) \|\| 'dashboard'\)/.test(startupUiSrc)
+      /callStartupRuntime\('navigate',\s*callStartupRuntime\('getInitialView'\)\s*\|\|\s*'dashboard'\)/.test(startupUiSrc)
       && !/window\.showDashboard\(\);/.test(startupUiSrc));
     assert('profile.js: profile switch restores that profile route',
       /window\.navigate\(window\.getInitialView\?\.\(\) \|\| 'dashboard'\)/.test(profileSrc));

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -533,7 +533,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /export function getInitialView\(\)/.test(viewsSrc)
       && /return getRouterInitialView\(\)/.test(viewsSrc));
     assert('startup-ui.js: boot navigates to stored route instead of hard Dashboard',
-      /callStartupRuntime\('navigate',\s*callStartupRuntime\('getInitialView'\)\s*\|\|\s*'dashboard'\)/.test(startupUiSrc)
+      /requireStartupRuntime\('navigate',\s*callStartupRuntime\('getInitialView'\)\s*\|\|\s*'dashboard'\)/.test(startupUiSrc)
       && !/window\.showDashboard\(\);/.test(startupUiSrc));
     assert('profile.js: profile switch restores that profile route',
       /window\.navigate\(window\.getInitialView\?\.\(\) \|\| 'dashboard'\)/.test(profileSrc));


### PR DESCRIPTION
## Summary
- add small startup runtime helpers around globalThis access
- route startup navigation/version/legal event/analytics/deferred destination/chat attachment globals through the helpers
- update correctness source guards for legal-gated analytics and changelog ordering

## Validation
- node tests/test-correctness-phase2.js
- node tests/test-sync.js
- node tests/test-folder-backup.js
- node tests/test-changelog.js
- npm run typecheck
- npm run typecheck:checkjs
- npm run quality
- npx playwright test tests/playwright/startup-helpers-browser-coverage.spec.js

Quality: window global references in js/ = 842/1088