### PR TITLE
[codex] Route AI actions through registry

### DIFF
--- a/js/ai-action-delegates.js
+++ b/js/ai-action-delegates.js
@@ -5,25 +5,33 @@ import { escapeAttr } from './utils.js';
 
 let aiActionDelegatesInstalled = false;
 
-function callWindowAction(name, targetId) {
-  const fn = /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (window))[name];
-  if (typeof fn !== 'function') return undefined;
-  if (targetId === undefined) return fn();
-  return fn(targetId);
+export const KNOWN_AI_ACTIONS = [
+  'refresh-sun-session',
+  'refresh-device-session',
+  'refresh-measurement',
+  'refresh-audit',
+  'refresh-room',
+  'refresh-screen',
+  'refresh-day',
+  'refresh-channel-mix',
+  'refresh-burden',
+  'refresh-onboarding',
+];
+
+const AI_ACTION_HANDLERS = new Map();
+
+export function registerAIActionHandler(action, handler) {
+  if (!KNOWN_AI_ACTIONS.includes(action)) throw new Error(`Unknown AI action: ${action}`);
+  if (typeof handler !== 'function') throw new Error(`AI action handler must be a function: ${action}`);
+  AI_ACTION_HANDLERS.set(action, handler);
+  return () => {
+    if (AI_ACTION_HANDLERS.get(action) === handler) AI_ACTION_HANDLERS.delete(action);
+  };
 }
 
-const AI_ACTIONS = {
-  'refresh-sun-session': (targetId) => callWindowAction('refreshSessionAIAnalysis', targetId),
-  'refresh-device-session': (targetId) => callWindowAction('refreshDeviceSessionAIAnalysis', targetId),
-  'refresh-measurement': (targetId) => callWindowAction('refreshMeasurementAIAnalysis', targetId),
-  'refresh-audit': (targetId) => callWindowAction('refreshAuditAIAnalysis', targetId),
-  'refresh-room': (targetId) => callWindowAction('refreshRoomAIAnalysis', targetId),
-  'refresh-screen': (targetId) => callWindowAction('refreshScreenAIAnalysis', targetId),
-  'refresh-day': (targetId) => callWindowAction('refreshDayAIAnalysis', targetId),
-  'refresh-channel-mix': () => callWindowAction('refreshChannelMixAI', undefined),
-  'refresh-burden': () => callWindowAction('refreshBurdenAIAnalysis', undefined),
-  'refresh-onboarding': () => callWindowAction('refreshOnboardingAIAnalysis', undefined),
-};
+export function getRegisteredAIActionHandler(action) {
+  return AI_ACTION_HANDLERS.get(action) || null;
+}
 
 export function aiActionAttrs(action, targetId = '', opts = {}) {
   const attrs = [`data-ai-action="${escapeAttr(action)}"`];
@@ -47,10 +55,11 @@ function _handleAIActionClick(event) {
   }
   if (action === 'stop-propagation') return;
 
-  const handler = AI_ACTIONS[action];
+  const handler = getRegisteredAIActionHandler(action);
   if (!handler) return;
   event.preventDefault();
-  handler(actionEl.dataset.aiTarget);
+  if (actionEl.dataset.aiTarget === undefined) handler();
+  else handler(actionEl.dataset.aiTarget);
 }
 
 export function installAIActionDelegates(root = typeof document !== 'undefined' ? document : null) {

--- a/js/light-audit-ai-analysis.js
+++ b/js/light-audit-ai-analysis.js
@@ -19,7 +19,7 @@ import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { getRoomEveningHoursAfterSunset } from './light-env-evening.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 function _getAudits() {
   if (!state.importedData) return [];
@@ -217,6 +217,7 @@ const engine = createAIVerdict({
 
 export const analyzeAuditAI = engine.analyze;
 export const refreshAuditAIAnalysis = engine.refresh;
+registerAIActionHandler('refresh-audit', refreshAuditAIAnalysis);
 export const maybeAnalyzeAuditAfterSave = engine.maybeAfterFinish;
 
 // ─── Render ────────────────────────────────────────────────────────────

--- a/js/light-burden-ai-analysis.js
+++ b/js/light-burden-ai-analysis.js
@@ -23,7 +23,7 @@ import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { computeDeficitAxes, computeIndoorBurden, isActiveToday } from './light-env.js';
 import { getRoomEveningHoursAfterSunset } from './light-env-evening.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 function _getEnv() {
   if (!state.importedData) return null;
@@ -165,6 +165,7 @@ const engine = createAIVerdict({
 
 export const analyzeBurdenAI = (opts) => engine.analyze(SINGLETON, opts);
 export const refreshBurdenAIAnalysis = () => engine.refresh('default');
+registerAIActionHandler('refresh-burden', refreshBurdenAIAnalysis);
 
 // ─── Render ────────────────────────────────────────────────────────────
 

--- a/js/light-channels-ai-analysis.js
+++ b/js/light-channels-ai-analysis.js
@@ -19,7 +19,7 @@ import { escapeHTML, escapeAttr } from './utils.js';
 import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 function _getMix() {
   return state.importedData?.channelMixAI || null;
@@ -201,6 +201,7 @@ const engine = createAIVerdict({
 
 export const analyzeChannelMixAI = (opts) => engine.analyze(SINGLETON, opts);
 export const refreshChannelMixAI = () => engine.refresh('default');
+registerAIActionHandler('refresh-channel-mix', refreshChannelMixAI);
 
 // ─── Render ────────────────────────────────────────────────────────────
 

--- a/js/light-device-ai-analysis.js
+++ b/js/light-device-ai-analysis.js
@@ -14,7 +14,7 @@ import { getDevices, getDeviceSessions } from './light-devices.js';
 import { CHANNEL_DISPLAY, channelTier, tierLabel, formatChannelUnit, BODY_REGIONS } from './sun.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 // ─── Fingerprint ───────────────────────────────────────────────────────
 
@@ -243,6 +243,7 @@ const engine = createAIVerdict({
 
 export const analyzeDeviceSessionAI = engine.analyze;
 export const refreshDeviceSessionAIAnalysis = engine.refresh;
+registerAIActionHandler('refresh-device-session', refreshDeviceSessionAIAnalysis);
 export const maybeAnalyzeDeviceSessionAfterFinish = engine.maybeAfterFinish;
 
 // ─── Render ────────────────────────────────────────────────────────────

--- a/js/light-env-ai-analysis.js
+++ b/js/light-env-ai-analysis.js
@@ -13,7 +13,7 @@ import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { getRoomEveningHoursAfterSunset } from './light-env-evening.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 function _getRooms() { return state.importedData?.lightEnvironment?.rooms || []; }
 function _getMeasurementsForRoom(roomId) {
@@ -190,6 +190,7 @@ const engine = createAIVerdict({
 
 export const analyzeRoomAI = engine.analyze;
 export const refreshRoomAIAnalysis = engine.refresh;
+registerAIActionHandler('refresh-room', refreshRoomAIAnalysis);
 
 // ─── Render ────────────────────────────────────────────────────────────
 

--- a/js/light-screen-ai-analysis.js
+++ b/js/light-screen-ai-analysis.js
@@ -14,7 +14,7 @@ import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 function _getScreens() { return state.importedData?.lightEnvironment?.screens || []; }
 function _getRooms() { return state.importedData?.lightEnvironment?.rooms || []; }
@@ -118,6 +118,7 @@ const engine = createAIVerdict({
 
 export const analyzeScreenAI = engine.analyze;
 export const refreshScreenAIAnalysis = engine.refresh;
+registerAIActionHandler('refresh-screen', refreshScreenAIAnalysis);
 
 // ─── Render ────────────────────────────────────────────────────────────
 

--- a/js/light-today-ai.js
+++ b/js/light-today-ai.js
@@ -15,7 +15,7 @@ import { solarZenithAngle } from './sun-uvdata.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 const defaultLightTodayDeps = {
   solarZenithAngle,
@@ -319,6 +319,7 @@ export async function refreshDayAIAnalysis(dateKey) {
   if (!dateKey) dateKey = _localDateString(new Date());
   return engine.refresh(dateKey);
 }
+registerAIActionHandler('refresh-day', refreshDayAIAnalysis);
 
 // ─── Render ────────────────────────────────────────────────────────────
 

--- a/js/light-tools-ai-analysis.js
+++ b/js/light-tools-ai-analysis.js
@@ -13,7 +13,7 @@ import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 function _formatNumber(n, digits = 1) {
   if (n == null || !Number.isFinite(n)) return '—';
@@ -212,6 +212,7 @@ const engine = createAIVerdict({
 
 export const analyzeMeasurementAI = engine.analyze;
 export const refreshMeasurementAIAnalysis = engine.refresh;
+registerAIActionHandler('refresh-measurement', refreshMeasurementAIAnalysis);
 export const maybeAnalyzeMeasurementAfterSave = engine.maybeAfterFinish;
 
 // ─── Render ────────────────────────────────────────────────────────────

--- a/js/sun-ai-analysis.js
+++ b/js/sun-ai-analysis.js
@@ -19,7 +19,7 @@ import { vitaminDIU } from './sun-spectrum.js';
 import { solarZenithAngle } from './sun-uvdata.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 // ─── Fingerprint ───────────────────────────────────────────────────────
 //
@@ -265,6 +265,7 @@ const engine = createAIVerdict({
 
 export const analyzeSunSessionAI = engine.analyze;
 export const refreshSessionAIAnalysis = engine.refresh;
+registerAIActionHandler('refresh-sun-session', refreshSessionAIAnalysis);
 export const maybeAnalyzeSessionAfterFinish = engine.maybeAfterFinish;
 
 // ─── Render helpers ────────────────────────────────────────────────────

--- a/js/sun-onboarding-ai.js
+++ b/js/sun-onboarding-ai.js
@@ -13,7 +13,7 @@ import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
-import { aiActionAttrs } from './ai-action-delegates.js';
+import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 
 function _getDefaults() { return state.importedData?.sunDefaults || null; }
 
@@ -176,6 +176,7 @@ const engine = createAIVerdict({
 
 export const analyzeOnboardingAI = (opts) => engine.analyze(SINGLETON_TARGET, opts);
 export const refreshOnboardingAIAnalysis = () => engine.refresh('default');
+registerAIActionHandler('refresh-onboarding', refreshOnboardingAIAnalysis);
 export function maybeAnalyzeOnboardingAfterSave() {
   engine.maybeAfterFinish(SINGLETON_TARGET);
 }

--- a/tests/test-ai-action-delegates.js
+++ b/tests/test-ai-action-delegates.js
@@ -35,6 +35,19 @@ const actions = [
   'refresh-onboarding',
 ];
 
+const actionOwners = {
+  'refresh-sun-session': 'js/sun-ai-analysis.js',
+  'refresh-device-session': 'js/light-device-ai-analysis.js',
+  'refresh-measurement': 'js/light-tools-ai-analysis.js',
+  'refresh-audit': 'js/light-audit-ai-analysis.js',
+  'refresh-room': 'js/light-env-ai-analysis.js',
+  'refresh-screen': 'js/light-screen-ai-analysis.js',
+  'refresh-day': 'js/light-today-ai.js',
+  'refresh-channel-mix': 'js/light-channels-ai-analysis.js',
+  'refresh-burden': 'js/light-burden-ai-analysis.js',
+  'refresh-onboarding': 'js/sun-onboarding-ai.js',
+};
+
 const helperSrc = fs.readFileSync(path.join(root, 'js/ai-action-delegates.js'), 'utf8');
 const sources = Object.fromEntries(targetFiles.map(file => [
   file,
@@ -75,28 +88,35 @@ assert('AI action helper handles row-level stop propagation',
   helperSrc.includes("action === 'stop-propagation'") &&
     combined.includes("aiActionAttrs('stop-propagation')") &&
     combined.includes('{ stopPropagation: true }'));
+assert('AI action helper dispatches through registry instead of window globals',
+  helperSrc.includes('registerAIActionHandler') &&
+    helperSrc.includes('getRegisteredAIActionHandler') &&
+    !helperSrc.includes('callWindowAction') &&
+    !helperSrc.includes('window.refresh'));
 
 for (const action of actions) {
-  assert(`AI action ${action} is mapped in helper`,
+  assert(`AI action ${action} is declared in helper`,
     helperSrc.includes(`'${action}'`));
   assert(`AI action ${action} is rendered by target modules`,
     combined.includes(`aiActionAttrs('${action}'`));
+  assert(`AI action ${action} is registered by its owner module`,
+    sources[actionOwners[action]].includes(`registerAIActionHandler('${action}'`));
 }
 
 const dom = new JSDOM('<!doctype html><body></body>');
 globalThis.window = dom.window;
 globalThis.document = dom.window.document;
-const { aiActionAttrs } = await import('../js/ai-action-delegates.js');
+const { aiActionAttrs, getRegisteredAIActionHandler, registerAIActionHandler } = await import('../js/ai-action-delegates.js');
 
 let dayArgs = null;
-window.refreshDayAIAnalysis = (...args) => { dayArgs = args; };
+registerAIActionHandler('refresh-day', (...args) => { dayArgs = args; });
 document.body.innerHTML = `<button id="day" ${aiActionAttrs('refresh-day')}>Run</button>`;
 document.getElementById('day')?.click();
 assert('delegated click routes action without a target id',
   Array.isArray(dayArgs) && dayArgs.length === 0);
 
 let channelArgs = null;
-window.refreshChannelMixAI = (...args) => { channelArgs = args; };
+registerAIActionHandler('refresh-channel-mix', (...args) => { channelArgs = args; });
 document.body.innerHTML = `<button id="channel" ${aiActionAttrs('refresh-channel-mix')}>Run</button>`;
 document.getElementById('channel')?.click();
 assert('delegated singleton action calls without an empty string argument',
@@ -104,7 +124,7 @@ assert('delegated singleton action calls without an empty string argument',
 
 let routedSessionId = '';
 let rowOpened = false;
-window.refreshSessionAIAnalysis = id => { routedSessionId = id; };
+registerAIActionHandler('refresh-sun-session', id => { routedSessionId = id; });
 const row = document.createElement('div');
 row.addEventListener('click', () => { rowOpened = true; });
 row.innerHTML = `<button id="sun" ${aiActionAttrs('refresh-sun-session', 'sun-1', { stopPropagation: true })}>Refresh</button>`;
@@ -114,6 +134,12 @@ assert('delegated row action routes target id',
   routedSessionId === 'sun-1');
 assert('delegated row action stops parent row click before bubble phase',
   rowOpened === false);
+const unregisterDay = registerAIActionHandler('refresh-day', () => {});
+assert('registered action handler can be unregistered',
+  typeof getRegisteredAIActionHandler('refresh-day') === 'function');
+unregisterDay();
+assert('unregister only removes the matching registered handler',
+  getRegisteredAIActionHandler('refresh-day') === null);
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.15';
+self.APP_VERSION = '1.10.16';


### PR DESCRIPTION
## Summary

- Replace AI verdict click dispatch through `window.*` lookups with an explicit registered action-handler map.
- Register each Light & Sun AI verdict refresh action from its owning module while preserving existing exported functions.
- Strengthen the AI action delegate guard test and bump `version.js` for cache invalidation.

## Validation

- `node tests/test-ai-action-delegates.js`
- `npm test`
- `./run-tests.sh`
- `node tests/test-changelog.js`
- `node tests/test-v1-6-shipped.js`