### PR TITLE
[codex] Inject burden AI renderer

### DIFF
--- a/js/light-burden-ai-analysis.js
+++ b/js/light-burden-ai-analysis.js
@@ -20,7 +20,7 @@ import { escapeHTML, escapeAttr } from './utils.js';
 import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { LIGHTING_HARDWARE_CAVEATS } from './lighting-hardware-caveats.js';
-import { computeDeficitAxes, computeIndoorBurden, isActiveToday } from './light-env.js';
+import { computeDeficitAxes, computeIndoorBurden, configureLightEnv, isActiveToday } from './light-env.js';
 import { getRoomEveningHoursAfterSunset } from './light-env-evening.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
 import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
@@ -264,3 +264,5 @@ Object.assign(window, {
   analyzeBurdenAI,
   renderBurdenInterp,
 });
+
+configureLightEnv({ renderBurdenInterp });

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -87,6 +87,21 @@ export {
 // before falling back to "Room N" so a fresh user lands on familiar labels.
 const DEFAULT_ROOM_NAMES = ['Bedroom', 'Living room', 'Kitchen', 'Office', 'Bathroom'];
 
+/** @type {{ renderBurdenInterp: AnyFunction | null }} */
+const lightEnvDeps = {
+  renderBurdenInterp: null,
+};
+
+export function configureLightEnv(deps = {}) {
+  const previous = { ...lightEnvDeps };
+  for (const [key, value] of Object.entries(deps || {})) {
+    if (Object.prototype.hasOwnProperty.call(lightEnvDeps, key)) {
+      lightEnvDeps[key] = value;
+    }
+  }
+  return previous;
+}
+
 // Pick the next default room name based on which common names haven't been
 // used yet. Names are matched case-insensitively so "bedroom" and "Bedroom"
 // don't collide. Falls back to "Room N" once the curated list is exhausted.
@@ -337,8 +352,8 @@ function renderEnvironmentLoadSummary() {
   const env = getEnvironment();
   const hasMappedExposure = ((env?.rooms || []).length + (env?.screens || []).length) > 0;
   const burden = computeIndoorBurden();
-  const interpHTML = (typeof globalThis.renderBurdenInterp === 'function')
-    ? globalThis.renderBurdenInterp(burden)
+  const interpHTML = (typeof lightEnvDeps.renderBurdenInterp === 'function')
+    ? lightEnvDeps.renderBurdenInterp(burden)
     : `<p class="light-env-summary-interp">${escapeHTML(burden.interp)}</p>`;
   // Reconcile the banner label with the AI verdict's dot when one exists.
   // The deterministic computeIndoorBurden() tier crosses to "Heavy" at

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -33,6 +33,7 @@ const {
   computeIndoorBurden, computeDeficitAxes,
   getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit,
   renderEnvironmentAssessmentSummary, renderEnvironmentSection,
+  configureLightEnv,
 } = env;
 const {
   computeRoomSeverityForRoom,
@@ -337,6 +338,14 @@ const {
     emptyLoadHtml.includes('Light load') &&
     !emptyLoadHtml.includes('Moderate load') &&
     !emptyLoadHtml.includes('stale moderate verdict'));
+  const restoredBurdenRenderer = configureLightEnv({
+    renderBurdenInterp: b => `<p class="light-env-summary-interp injected-burden">${b.interp}</p>`,
+  });
+  const injectedLoadHtml = renderEnvironmentSection({ embedded: true });
+  assert('Burden summary uses injected renderer instead of window lookup',
+    injectedLoadHtml.includes('injected-burden') &&
+    injectedLoadHtml.toLowerCase().includes('add a room'));
+  configureLightEnv(restoredBurdenRenderer);
 
   // Heavy indoor + heavy evening → tier 2
   await addRoom('Office');
@@ -539,6 +548,7 @@ const {
     !envSrc.includes('function _hasAnyRoomSignal'));
   const fs = await import('node:fs/promises');
   const auditSrc = await fs.readFile(new URL('../js/light-env-audits.js', import.meta.url), 'utf8');
+  const burdenSrc = await fs.readFile(new URL('../js/light-burden-ai-analysis.js', import.meta.url), 'utf8');
   const appLightSunSrc = await fs.readFile(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
   const aiSaveHooksSrc = await fs.readFile(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
   assert('Light audit renderer emits no inline event attributes',
@@ -565,6 +575,13 @@ const {
     aiSaveHooksSrc.includes("import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';") &&
     aiSaveHooksSrc.includes('configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot })') &&
     appLightSunSrc.includes("import './light-ai-save-hooks.js';"));
+  assert('Burden AI renderer routes through light-env configuration instead of window lookup',
+    envSrc.includes('export function configureLightEnv') &&
+    envSrc.includes('renderBurdenInterp: null') &&
+    envSrc.includes('lightEnvDeps.renderBurdenInterp') &&
+    !envSrc.includes('globalThis.renderBurdenInterp') &&
+    burdenSrc.includes("import { computeDeficitAxes, computeIndoorBurden, configureLightEnv, isActiveToday } from './light-env.js';") &&
+    burdenSrc.includes('configureLightEnv({ renderBurdenInterp });'));
   const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
   const cssSrc = [

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.16';
+self.APP_VERSION = '1.10.17';


### PR DESCRIPTION
## Summary
- add an explicit `configureLightEnv` dependency hook for the burden AI interpreter renderer
- wire `light-burden-ai-analysis` into that hook while preserving existing window exports
- cover the injected renderer path and bump `version.js` for app cache invalidation

## Validation
- `node tests/test-light-env.js`
- `node tests/test-light-ai-renders.js`
- `node tests/test-changelog.js`
- `npm test`
- `git diff --check`
- `./run-tests.sh`