### PR TITLE
[codex] Shrink light environment window surface

### DIFF
--- a/js/light-env.js
+++ b/js/light-env.js
@@ -1049,6 +1049,34 @@ function openLightEnvTool(tool, roomId) {
   if (typeof opener === 'function') opener(opts);
 }
 
+export const lightEnvActionHandlers = Object.freeze({
+  addLightEnvRoom,
+  addLightEnvRoomNamed,
+  addLightEnvRoomCustom,
+  toggleLightEnvRoomExpanded,
+  updateLightEnvRoom,
+  setLightEnvRoomSourceArchetype,
+  setLightEnvRoomHoursBucket,
+  setLightEnvRoomEveningBucket,
+  updateLightEnvRoomAndRender,
+  deleteLightEnvRoom,
+  deleteLightEnvRoomConfirm,
+  setActiveLightEnvRoom,
+  addLightEnvScreenWithDevice,
+  addLightEnvScreen,
+  updateLightEnvScreen,
+  updateLightEnvScreenAndRender,
+  deleteLightEnvScreen,
+  deleteLightEnvScreenConfirm,
+  toggleLightEnvScreenExpanded,
+  setLightEnvScreenHoursBucket,
+  setLightEnvScreenEveningBucket,
+  setLightEnvTodayActive,
+  openLightEnvironmentAssessment,
+  closeLightEnvironmentAssessment,
+  openLightEnvTool,
+});
+
 configureLightEnvAudits({
   getEnvironment,
   computeRoomSeverity,
@@ -1081,26 +1109,7 @@ if (typeof document !== 'undefined') {
     ? globalThis.interpretLightAuditCompare
     : undefined;
   installLightEnvActionDelegates({
-    addLightEnvRoom,
-    addLightEnvRoomNamed,
-    addLightEnvRoomCustom,
-    toggleLightEnvRoomExpanded,
-    updateLightEnvRoom,
-    setLightEnvRoomSourceArchetype,
-    setLightEnvRoomHoursBucket,
-    setLightEnvRoomEveningBucket,
-    updateLightEnvRoomAndRender,
-    deleteLightEnvRoomConfirm,
-    addLightEnvScreenWithDevice,
-    addLightEnvScreen,
-    updateLightEnvScreenAndRender,
-    deleteLightEnvScreenConfirm,
-    toggleLightEnvScreenExpanded,
-    setLightEnvScreenHoursBucket,
-    setLightEnvScreenEveningBucket,
-    setLightEnvTodayActive,
-    openLightEnvironmentAssessment,
-    closeLightEnvironmentAssessment,
+    ...lightEnvActionHandlers,
     saveLightAuditFromUI,
     toggleLightAudit,
     toggleLightAuditCompare,
@@ -1109,7 +1118,6 @@ if (typeof document !== 'undefined') {
     updateLightAuditField,
     deleteLightAuditConfirm,
     interpretLightAuditCompare,
-    openLightEnvTool,
   });
 }
 
@@ -1122,41 +1130,16 @@ if (typeof window !== 'undefined') {
 
   Object.assign(window, {
     getLightEnvironment: getEnvironment,
-    addLightEnvRoom,
-    addLightEnvRoomNamed,
-    addLightEnvRoomCustom,
-    toggleLightEnvRoomExpanded,
-    updateLightEnvRoom,
-    setLightEnvRoomSourceArchetype,
-    setLightEnvRoomHoursBucket,
     suggestRoomSourceFromSpectrum,
-    setLightEnvRoomEveningBucket,
-    updateLightEnvRoomAndRender,
-    deleteLightEnvRoom,
-    deleteLightEnvRoomConfirm,
-    setActiveLightEnvRoom,
-    addLightEnvScreenWithDevice,
-    addLightEnvScreen,
-    updateLightEnvScreen,
-    updateLightEnvScreenAndRender,
-    deleteLightEnvScreen,
-    deleteLightEnvScreenConfirm,
-    toggleLightEnvScreenExpanded,
-    setLightEnvScreenHoursBucket,
-    setLightEnvScreenEveningBucket,
-    computeLightDeficitAxes: computeDeficitAxes,
     computeDeficitAxes,
     computeRoomSeverity,
     computeScreenStatus,
     computeIndoorBurden,
     getScreensForRoom,
-    // Rooms accessor + adder so cross-module callers (Tool 8 Eye-Level
-    // Audit, recommendations engine, AI helpers) stay behind the
-    // light-environment store boundary.
+    // Rooms accessor for legacy debug/coverage surfaces. Cross-module app
+    // callers should import getRooms/addRoom through light-ai-save-hooks.
     getRooms,
-    addRoom,
     isLightEnvActiveToday: isActiveToday,
-    setLightEnvTodayActive,
     renderEnvironmentSection,
     renderEnvironmentAssessmentSummary,
     openLightEnvironmentAssessment,

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -50,6 +50,7 @@ test('light environment browser coverage handles summary modal prompt and source
     const outcomes = {};
     const calls = [];
     const env = () => state.importedData.lightEnvironment;
+    const actions = lightEnv.lightEnvActionHandlers;
 
     try {
       state.currentProfile = 'light-env-browser-coverage';
@@ -80,7 +81,9 @@ test('light environment browser coverage handles summary modal prompt and source
       outcomes.windowExportsAndEmptyRenderStates =
         window.computeIndoorBurden === lightEnv.computeIndoorBurden
         && window.computeDeficitAxes === lightEnv.computeDeficitAxes
-        && window.computeLightDeficitAxes === lightEnv.computeDeficitAxes
+        && window.computeLightDeficitAxes === undefined
+        && window.addLightEnvRoom === undefined
+        && typeof actions.addLightEnvRoom === 'function'
         && window.renderEnvironmentSection === lightEnv.renderEnvironmentSection
         && window.openLightEnvironmentAssessment === lightEnv.openLightEnvironmentAssessment
         && emptyFull.includes('Light environment')
@@ -102,7 +105,7 @@ test('light environment browser coverage handles summary modal prompt and source
       outcomes.nextDefaultRoomNameStartsWithBedroom =
         lightEnv.nextDefaultRoomName() === 'Bedroom';
 
-      const customPromise = window.addLightEnvRoomCustom();
+      const customPromise = actions.addLightEnvRoomCustom();
       await waitUntil(() => !!document.getElementById('prompt-dialog-input'), 'custom room prompt');
       document.getElementById('prompt-dialog-input').value = 'Studio';
       document.getElementById('prompt-dialog-input').dispatchEvent(new Event('input', { bubbles: true }));
@@ -114,7 +117,7 @@ test('light environment browser coverage handles summary modal prompt and source
         && localStorage.getItem('labcharts-light-env-active-room') === customRoomId
         && calls.some(call => call[0] === 'navigate' && call[1] === 'light');
 
-      await window.addLightEnvRoom();
+      await actions.addLightEnvRoom();
       await waitUntil(() => env().rooms.length === 2, 'default room added');
       const bedroom = env().rooms[1];
       outcomes.defaultRoomUsesNextAvailableName =
@@ -122,11 +125,11 @@ test('light environment browser coverage handles summary modal prompt and source
         && lightEnv.nextDefaultRoomName() === 'Living room'
         && localStorage.getItem('labcharts-light-env-active-room') === bedroom.id;
 
-      await window.suggestRoomSourceFromSpectrum(bedroom.id, 'Cool LED (4000K+)');
+      await lightEnv.suggestRoomSourceFromSpectrum(bedroom.id, 'Cool LED (4000K+)');
       await waitUntil(() => bedroom.primarySource === 'led-cool', 'spectrum source applied');
-      await window.suggestRoomSourceFromSpectrum(bedroom.id, 'Fluorescent / CFL');
-      await window.suggestRoomSourceFromSpectrum('missing-room', 'Warm LED (2700-3000K)');
-      await window.suggestRoomSourceFromSpectrum(bedroom.id, 'Unknown spectrum label');
+      await lightEnv.suggestRoomSourceFromSpectrum(bedroom.id, 'Fluorescent / CFL');
+      await lightEnv.suggestRoomSourceFromSpectrum('missing-room', 'Warm LED (2700-3000K)');
+      await lightEnv.suggestRoomSourceFromSpectrum(bedroom.id, 'Unknown spectrum label');
       outcomes.spectrumSuggestionMapsOnceAndDoesNotOverwrite =
         bedroom.primarySource === 'led-cool'
         && Array.from(document.querySelectorAll('.notification-toast'))
@@ -148,7 +151,7 @@ test('light environment browser coverage handles summary modal prompt and source
       outcomes.defaultActiveRoomUsesMostRecentlyUpdatedRoom =
         defaultHost.querySelector(`.light-env-room-disclosure[data-id="${bedroom.id}"]`)?.classList.contains('expanded') === true;
 
-      await window.updateLightEnvRoomAndRender(bedroom.id, { name: 'Bedroom Prime' });
+      await actions.updateLightEnvRoomAndRender(bedroom.id, { name: 'Bedroom Prime' });
       outcomes.updateRoomAndRenderRefreshesLightUI =
         env().rooms.find(r => r.id === bedroom.id)?.name === 'Bedroom Prime'
         && calls.some(call => call[0] === 'navigate' && call[1] === 'light');
@@ -197,7 +200,7 @@ test('light environment browser coverage handles summary modal prompt and source
 test('light environment browser coverage handles screens tools and confirm deletes', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.addLightEnvScreen === 'function');
+  await page.waitForFunction(() => typeof window.renderEnvironmentSection === 'function');
 
   const outcomes = await page.evaluate(async () => {
     const [{ state }, data, lightEnv] = await Promise.all([
@@ -237,6 +240,7 @@ test('light environment browser coverage handles screens tools and confirm delet
     const calls = [];
     const env = () => state.importedData.lightEnvironment;
     const latestScreen = () => env().screens[env().screens.length - 1];
+    const actions = lightEnv.lightEnvActionHandlers;
 
     try {
       state.currentProfile = 'light-env-screen-coverage';
@@ -268,16 +272,16 @@ test('light environment browser coverage handles screens tools and confirm delet
       const livingId = await lightEnv.addRoom('Living room');
       const bedroomId = await lightEnv.addRoom('Bedroom');
 
-      await window.addLightEnvScreen(officeId);
+      await actions.addLightEnvScreen(officeId);
       await waitUntil(() => env().screens.length === 1, 'office screen added');
       const officeScreen = latestScreen();
-      await window.addLightEnvScreen(livingId);
+      await actions.addLightEnvScreen(livingId);
       await waitUntil(() => env().screens.length === 2, 'living screen added');
       const livingScreen = latestScreen();
-      await window.addLightEnvScreen(bedroomId);
+      await actions.addLightEnvScreen(bedroomId);
       await waitUntil(() => env().screens.length === 3, 'bedroom screen added');
       const bedroomScreen = latestScreen();
-      await window.addLightEnvScreenWithDevice(null, 'projector');
+      await actions.addLightEnvScreenWithDevice(null, 'projector');
       await waitUntil(() => env().screens.length === 4, 'invalid-device screen added');
       const fallbackScreen = latestScreen();
       outcomes.screenDefaultsInferRoomAndInvalidDeviceFallbacks =
@@ -287,11 +291,11 @@ test('light environment browser coverage handles screens tools and confirm delet
         && fallbackScreen.device === 'phone'
         && fallbackScreen.roomId === null;
 
-      await window.updateLightEnvScreen(fallbackScreen.id, { hoursPerDay: 2 });
-      await window.updateLightEnvScreenAndRender(fallbackScreen.id, { eveningUseAfterSunset: 0.5 });
-      await window.setLightEnvScreenHoursBucket(fallbackScreen.id, 'most');
-      await window.setLightEnvScreenEveningBucket(fallbackScreen.id, 'gt3');
-      await window.setLightEnvTodayActive('screen', fallbackScreen.id, false);
+      await actions.updateLightEnvScreen(fallbackScreen.id, { hoursPerDay: 2 });
+      await actions.updateLightEnvScreenAndRender(fallbackScreen.id, { eveningUseAfterSunset: 0.5 });
+      await actions.setLightEnvScreenHoursBucket(fallbackScreen.id, 'most');
+      await actions.setLightEnvScreenEveningBucket(fallbackScreen.id, 'gt3');
+      await actions.setLightEnvTodayActive('screen', fallbackScreen.id, false);
       localStorage.setItem('labcharts-light-env-active-room', bedroomId);
       state.importedData.lightMeasurements = [
         { id: 'lux-reading', roomId: bedroomId, tool: 'lux', value: 1234, capturedAt: Date.now() },
@@ -307,7 +311,7 @@ test('light environment browser coverage handles screens tools and confirm delet
       host.innerHTML = window.renderEnvironmentSection({ embedded: true });
       document.body.appendChild(host);
       const fallbackCard = host.querySelector(`.light-env-screen-card[data-id="${fallbackScreen.id}"]`);
-      outcomes.screenMutationGlobalsUpdateAndRender =
+      outcomes.screenMutationHandlersUpdateAndRender =
         fallbackScreen.hoursPerDay === 8
         && fallbackScreen.eveningUseAfterSunset === 4
         && fallbackScreen.todayOverride?.active === false
@@ -324,7 +328,7 @@ test('light environment browser coverage handles screens tools and confirm delet
         && bedroomCardText.includes('42% transmits')
         && bedroomCardText.includes('2 room snapshots');
       const wasScreenExpanded = fallbackCard?.classList.contains('expanded') === true;
-      window.toggleLightEnvScreenExpanded(fallbackScreen.id);
+      actions.toggleLightEnvScreenExpanded(fallbackScreen.id);
       const expandedHost = document.createElement('div');
       expandedHost.innerHTML = window.renderEnvironmentSection({ embedded: true });
       outcomes.screenExpandToggleChangesPortableCardState =
@@ -336,12 +340,12 @@ test('light environment browser coverage handles screens tools and confirm delet
         ['spectrum', 'lux', 'flicker', 'cct', 'darkness']
           .every(tool => calls.some(call => call[0] === tool && call[1] === bedroomId));
 
-      const cancelScreenDelete = window.deleteLightEnvScreenConfirm(fallbackScreen.id);
+      const cancelScreenDelete = actions.deleteLightEnvScreenConfirm(fallbackScreen.id);
       await waitUntil(() => !!document.getElementById('confirm-cancel'), 'screen delete cancel dialog');
       document.getElementById('confirm-cancel').click();
       await cancelScreenDelete;
       const screenStillExists = env().screens.some(s => s.id === fallbackScreen.id);
-      const confirmScreenDelete = window.deleteLightEnvScreenConfirm(fallbackScreen.id);
+      const confirmScreenDelete = actions.deleteLightEnvScreenConfirm(fallbackScreen.id);
       await waitUntil(() => !!document.getElementById('confirm-ok'), 'screen delete confirm dialog');
       document.getElementById('confirm-ok').click();
       await confirmScreenDelete;
@@ -349,13 +353,13 @@ test('light environment browser coverage handles screens tools and confirm delet
         screenStillExists
         && !env().screens.some(s => s.id === fallbackScreen.id);
 
-      const cancelRoomDelete = window.deleteLightEnvRoomConfirm(officeId);
+      const cancelRoomDelete = actions.deleteLightEnvRoomConfirm(officeId);
       await waitUntil(() => !!document.getElementById('confirm-cancel'), 'room delete cancel dialog');
       document.getElementById('confirm-cancel').click();
       await cancelRoomDelete;
       const roomStillExists = env().rooms.some(r => r.id === officeId);
       const linkedScreenBeforeRoomDelete = env().screens.find(s => s.id === officeScreen.id);
-      const confirmRoomDelete = window.deleteLightEnvRoomConfirm(officeId);
+      const confirmRoomDelete = actions.deleteLightEnvRoomConfirm(officeId);
       await waitUntil(() => !!document.getElementById('confirm-ok'), 'room delete confirm dialog');
       document.getElementById('confirm-ok').click();
       await confirmRoomDelete;
@@ -365,7 +369,7 @@ test('light environment browser coverage handles screens tools and confirm delet
         && !env().rooms.some(r => r.id === officeId)
         && env().screens.some(s => s.id === officeScreen.id && s.roomId === null);
 
-      window.setActiveLightEnvRoom(livingId);
+      actions.setActiveLightEnvRoom(livingId);
       outcomes.setActiveRoomAndBurdenGlobalsRemainUsable =
         localStorage.getItem('labcharts-light-env-active-room') === livingId
         && window.isLightEnvActiveToday(env().rooms.find(r => r.id === livingId)) === true
@@ -376,20 +380,20 @@ test('light environment browser coverage handles screens tools and confirm delet
         && window.getRooms().some(r => r.id === livingId);
 
       const directRoomId = await lightEnv.addRoom('Garage');
-      await window.addLightEnvScreenWithDevice(null, 'tablet');
+      await actions.addLightEnvScreenWithDevice(null, 'tablet');
       await waitUntil(() => env().screens.some(s => s.device === 'tablet'), 'tablet screen added');
       const directScreenId = latestScreen().id;
       const directScreenBeforeDelete = document.createElement('div');
       directScreenBeforeDelete.innerHTML = window.renderEnvironmentSection({ embedded: true });
-      await window.deleteLightEnvScreen(directScreenId);
+      await actions.deleteLightEnvScreen(directScreenId);
       const directScreenAfterDelete = document.createElement('div');
       directScreenAfterDelete.innerHTML = window.renderEnvironmentSection({ embedded: true });
-      await window.addLightEnvScreenWithDevice(null, 'monitor');
+      await actions.addLightEnvScreenWithDevice(null, 'monitor');
       await waitUntil(() => env().screens.some(s => s.device === 'monitor'), 'monitor screen added');
       const replacementScreenId = latestScreen().id;
       const directScreenAfterReplacement = document.createElement('div');
       directScreenAfterReplacement.innerHTML = window.renderEnvironmentSection({ embedded: true });
-      await window.deleteLightEnvRoom(directRoomId);
+      await actions.deleteLightEnvRoom(directRoomId);
       outcomes.directDeleteHelpersRemoveRecords =
         directScreenBeforeDelete.querySelector(`.light-env-screen-card[data-id="${directScreenId}"]`)?.classList.contains('expanded') === true
         && directScreenAfterDelete.querySelector(`.light-env-screen-card[data-id="${directScreenId}"]`) === null

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -13,6 +13,11 @@ const actionSrc = fs.readFileSync(path.join(root, 'js/light-env-actions.js'), 'u
 const auditSrc = fs.readFileSync(path.join(root, 'js/light-env-audits.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const envUiSrc = `${envSrc}\n${screenSrc}`;
+const windowAssignStart = envSrc.indexOf('Object.assign(window, {');
+const windowAssignEnd = windowAssignStart >= 0 ? envSrc.indexOf('  });', windowAssignStart) : -1;
+const lightEnvWindowFacadeSrc = windowAssignStart >= 0 && windowAssignEnd >= 0
+  ? envSrc.slice(windowAssignStart, windowAssignEnd)
+  : '';
 
 let passed = 0;
 let failed = 0;
@@ -80,6 +85,13 @@ assert('light-env click delegate ignores toggle-only details actions',
   actionSrc.includes('const NON_CLICK_ACTIONS = new Set') &&
     actionSrc.includes("'set-audits-block-open'") &&
     actionSrc.includes('!NON_CLICK_ACTIONS.has(actionName(actionEl))'));
+assert('light-env internal action handlers are registered through module object, not window facade',
+  envSrc.includes('export const lightEnvActionHandlers = Object.freeze({') &&
+    envSrc.includes('...lightEnvActionHandlers,') &&
+    lightEnvWindowFacadeSrc.includes('renderEnvironmentSection') &&
+    !lightEnvWindowFacadeSrc.includes('addLightEnvRoom') &&
+    !lightEnvWindowFacadeSrc.includes('deleteLightEnvScreenConfirm') &&
+    !lightEnvWindowFacadeSrc.includes('computeLightDeficitAxes'));
 assert('light-env form delegates separate live input from change-only controls',
   actionSrc.includes("'update-room-hours', 'update-room-name'") &&
     actionSrc.includes("'update-screen-blue-blocker'") &&

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -33,7 +33,7 @@ const {
   computeIndoorBurden, computeDeficitAxes,
   getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit,
   renderEnvironmentAssessmentSummary, renderEnvironmentSection,
-  configureLightEnv,
+  configureLightEnv, lightEnvActionHandlers,
 } = env;
 const {
   computeRoomSeverityForRoom,
@@ -465,6 +465,12 @@ const {
   assert('Assessment modal functions are exported on window',
     typeof window.openLightEnvironmentAssessment === 'function' &&
     typeof window.closeLightEnvironmentAssessment === 'function');
+  assert('Internal Light environment action handlers are module-scoped instead of public window API',
+    typeof lightEnvActionHandlers.addLightEnvRoom === 'function' &&
+    typeof lightEnvActionHandlers.deleteLightEnvScreenConfirm === 'function' &&
+    window.addLightEnvRoom === undefined &&
+    window.deleteLightEnvScreenConfirm === undefined &&
+    window.computeLightDeficitAxes === undefined);
 
   const beforeModalSyncData = window._labState.importedData;
   const originalCreateElement = document.createElement;
@@ -657,12 +663,12 @@ const {
   assert('Single room auto-expands on first render',
     singleRoomInitial.includes('aria-expanded="true"') &&
     singleRoomInitial.includes('light-env-room-disclosure-body'));
-  window.toggleLightEnvRoomExpanded('room_single');
+  lightEnvActionHandlers.toggleLightEnvRoomExpanded('room_single');
   const singleRoomCollapsed = renderEnvironmentSection({ embedded: true });
   assert('Single room can be explicitly collapsed',
     singleRoomCollapsed.includes('aria-expanded="false"') &&
     !singleRoomCollapsed.includes('light-env-room-disclosure-body'));
-  window.toggleLightEnvRoomExpanded('room_single');
+  lightEnvActionHandlers.toggleLightEnvRoomExpanded('room_single');
   const singleRoomExpandedAgain = renderEnvironmentSection({ embedded: true });
   assert('Single room expands again after explicit collapse',
     singleRoomExpandedAgain.includes('aria-expanded="true"') &&
@@ -686,7 +692,7 @@ const {
     lightEnvironment: { rooms: [], screens: [{ id: 'screen_single', device: 'phone', roomId: null }] },
     lightMeasurements: [],
   };
-  window.toggleLightEnvScreenExpanded('screen_single', {
+  lightEnvActionHandlers.toggleLightEnvScreenExpanded('screen_single', {
     preventDefault() { screenPrevented = true; },
     stopPropagation() { screenStopped = true; },
   });

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.17';
+self.APP_VERSION = '1.10.18';


### PR DESCRIPTION
## Summary
- move internal Light Environment UI mutation handlers into an exported `lightEnvActionHandlers` module object
- keep delegated UI wiring on the module object while removing those handlers from the public `window` facade
- update node and browser coverage to assert the smaller facade and bump `version.js`

## Validation
- `node tests/test-light-env.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-light-tools.js`
- `npx playwright test tests/playwright/light-env-browser-coverage.spec.js`
- `git diff --check`
- `./run-tests.sh`