### PR TITLE
Fix Interpretive Lens visibility and BP detail pairing

### DIFF
--- a/css/chat-panel.css
+++ b/css/chat-panel.css
@@ -255,6 +255,22 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .chat-header-title { font-family: var(--font-display); font-size: 15px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .chat-header-model { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .chat-header-model:empty { display: none; }
+.chat-context-status {
+  display: inline-flex; align-items: center; gap: 6px;
+  width: fit-content; max-width: 100%; margin-top: 4px; padding: 3px 8px;
+  border: 1px solid color-mix(in srgb, var(--green) 45%, var(--border));
+  border-radius: 999px; background: color-mix(in srgb, var(--green) 12%, transparent);
+  color: color-mix(in srgb, var(--green) 78%, var(--text-primary));
+  font-size: 11px; line-height: 1.2; cursor: pointer;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.chat-context-status[hidden] { display: none; }
+.chat-context-status:hover { border-color: var(--green); background: color-mix(in srgb, var(--green) 18%, transparent); }
+.chat-context-status:focus-visible { outline: 2px solid var(--green); outline-offset: 2px; }
+.chat-context-dot {
+  width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto;
+  background: var(--green); box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 18%, transparent);
+}
 .chat-header-actions { display: flex; gap: 8px; align-items: center; }
 .chat-summary-btn, .chat-clear-btn {
   background: none; border: 1px solid var(--border); color: var(--text-muted);

--- a/css/chat-panel.css
+++ b/css/chat-panel.css
@@ -267,6 +267,16 @@ body.chat-autostart-reserved:has(#chat-thread-rail.open):not(.chat-fullscreen) .
 .chat-context-status[hidden] { display: none; }
 .chat-context-status:hover { border-color: var(--green); background: color-mix(in srgb, var(--green) 18%, transparent); }
 .chat-context-status:focus-visible { outline: 2px solid var(--green); outline-offset: 2px; }
+.chat-context-status-pending {
+  border-color: color-mix(in srgb, var(--yellow) 55%, var(--border));
+  background: color-mix(in srgb, var(--yellow) 14%, transparent);
+  color: color-mix(in srgb, var(--yellow) 76%, var(--text-primary));
+}
+.chat-context-status-pending:hover { border-color: var(--yellow); background: color-mix(in srgb, var(--yellow) 20%, transparent); }
+.chat-context-status-pending:focus-visible { outline-color: var(--yellow); }
+.chat-context-status-pending .chat-context-dot {
+  background: var(--yellow); box-shadow: 0 0 0 3px color-mix(in srgb, var(--yellow) 20%, transparent);
+}
 .chat-context-dot {
   width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto;
   background: var(--green); box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 18%, transparent);

--- a/css/dashboard-widgets.css
+++ b/css/dashboard-widgets.css
@@ -219,9 +219,28 @@
   transition: border-color 0.15s, background 0.15s;
   width: 100%;
 }
-.ai-picker-card:hover, .dashboard-picker-card:hover { border-color: var(--purple); background: var(--bg-hover); }
-.ai-picker-card:focus-visible, .dashboard-picker-card:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
-.ai-picker-icon, .dashboard-picker-icon { font-size: 22px; line-height: 1; }
+.dashboard-picker-card:hover { border-color: var(--purple); background: var(--bg-hover); }
+.dashboard-picker-card:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
+.ai-picker-card {
+  position: relative; min-height: 150px; padding: 16px 16px 14px 18px;
+  border-color: color-mix(in srgb, var(--border) 86%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--bg-card) 96%, var(--accent)), var(--bg-card));
+}
+.ai-picker-card::before {
+  content: ''; position: absolute; inset: 14px auto 14px 0; width: 3px; border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 78%, var(--text-primary));
+}
+.ai-picker-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--bg-hover) 88%, var(--accent));
+}
+.ai-picker-card:focus-visible { outline: 2px solid color-mix(in srgb, var(--accent) 78%, transparent); outline-offset: 2px; }
+.ai-picker-kicker {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  color: color-mix(in srgb, var(--accent) 78%, var(--text-muted));
+}
+.ai-picker-action { font-size: 12px; color: var(--accent); font-weight: 600; margin-top: auto; }
+.dashboard-picker-icon { font-size: 22px; line-height: 1; }
 .ai-picker-title, .dashboard-picker-title { font-weight: 600; font-size: 14px; display: inline-flex; align-items: center; gap: 6px; }
 .ai-picker-sub, .dashboard-picker-sub { font-size: 12px; color: var(--text-muted); line-height: 1.4; }
 .dashboard-picker-action { font-size: 12px; color: var(--purple); font-weight: 500; margin-top: 4px; }
@@ -238,6 +257,7 @@
   .db-quick-marker-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 @media (max-width: 640px) {
+  .ai-picker-grid { grid-template-columns: 1fr; }
   .dashboard-widget,
   .dashboard-widget-quarter,
   .dashboard-widget-third { grid-column: span 12; }

--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -161,7 +161,7 @@ function handleAppKeydown(e) {
 
   // Focus trap for open modals. Sync overlays use `.confirm-overlay` too.
   if (e.key === "Tab") {
-    const overlayIds = ["legal-consent-overlay", "client-list-overlay", "changelog-modal-overlay", "report-builder-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "summary-modal-overlay", "light-env-assessment-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "data-protection-picker-overlay"];
+    const overlayIds = ["legal-consent-overlay", "client-list-overlay", "changelog-modal-overlay", "report-builder-overlay", "settings-modal-overlay", "tweaks-panel-overlay", "import-modal-overlay", "feedback-modal-overlay", "sync-restore-overlay", "sync-setup-overlay", "summary-modal-overlay", "light-env-assessment-overlay", "modal-overlay", "kb-modal-overlay", "ai-personalize-picker-overlay", "context-hub-overlay", "data-protection-picker-overlay"];
     for (const oid of overlayIds) {
       const ov = document.getElementById(oid);
       if (ov && ov.classList.contains("show")) {

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -19,6 +19,15 @@ const CHANGELOG = [
     ]
   },
   {
+    version: '1.10.24', date: '2026-06-24', title: 'Clearer AI context and blood pressure details',
+    forceShow: true,
+    items: [
+      '<b>AI Context is easier to find.</b> The Interpretive Lens and Knowledge Base controls are restored where profile context renders, so personalization is visible again instead of disappearing from the dashboard/profile-context path.',
+      '<b>Blood pressure details now stay paired.</b> Systolic and diastolic readings open as one BP detail view, even if you enter through the diastolic metric, and the chart keeps the two lines and manual readings visually distinct.',
+      '<b>Mixed-source BP data is safer.</b> When systolic and diastolic come from different sources, getbased fetches each source separately and only shows a Latest BP pair when both halves were recorded on the same date.',
+    ]
+  },
+  {
     version: '1.10.15', date: '2026-06-23', title: 'Safer Routstr wallet upgrade',
     forceShow: true,
     items: [

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -23,6 +23,7 @@ const CHANGELOG = [
     forceShow: true,
     items: [
       '<b>AI Context is easier to find.</b> Personalize how AI answers and Knowledge Base now live together under Manage → Context, so AI grounding has one clear home instead of being mixed into Profile Context.',
+      '<b>AI Context status is visible in chat.</b> When an Interpretive Lens or Knowledge Base is enabled, chat shows a clickable green context chip that jumps back to Manage → Context.',
       '<b>Blood pressure details now stay paired.</b> Systolic and diastolic readings open as one BP detail view, even if you enter through the diastolic metric, and the chart keeps the two lines and manual readings visually distinct.',
       '<b>Mixed-source BP data is safer.</b> When systolic and diastolic come from different sources, getbased fetches each source separately and only shows a Latest BP pair when both halves were recorded on the same date.',
     ]

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -24,6 +24,7 @@ const CHANGELOG = [
     items: [
       '<b>AI Context is easier to find.</b> Personalize how AI answers and Knowledge Base now live together under Manage → Context, so AI grounding has one clear home instead of being mixed into Profile Context.',
       '<b>AI Context status is visible in chat.</b> When an Interpretive Lens or Knowledge Base is enabled, chat shows a clickable green context chip that jumps back to Manage → Context.',
+      '<b>Empty Knowledge Base state is visible.</b> If Knowledge Base is enabled but no documents are indexed yet, chat shows an amber KB empty context chip instead of staying silent or pretending answers are grounded.',
       '<b>Blood pressure details now stay paired.</b> Systolic and diastolic readings open as one BP detail view, even if you enter through the diastolic metric, and the chart keeps the two lines and manual readings visually distinct.',
       '<b>Mixed-source BP data is safer.</b> When systolic and diastolic come from different sources, getbased fetches each source separately and only shows a Latest BP pair when both halves were recorded on the same date.',
     ]

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -22,7 +22,7 @@ const CHANGELOG = [
     version: '1.10.24', date: '2026-06-24', title: 'Clearer AI context and blood pressure details',
     forceShow: true,
     items: [
-      '<b>AI Context is easier to find.</b> The Interpretive Lens and Knowledge Base controls are restored where profile context renders, so personalization is visible again instead of disappearing from the dashboard/profile-context path.',
+      '<b>AI Context is easier to find.</b> Personalize how AI answers and Knowledge Base now live together under Manage → Context, so AI grounding has one clear home instead of being mixed into Profile Context.',
       '<b>Blood pressure details now stay paired.</b> Systolic and diastolic readings open as one BP detail view, even if you enter through the diastolic metric, and the chart keeps the two lines and manual readings visually distinct.',
       '<b>Mixed-source BP data is safer.</b> When systolic and diastolic come from different sources, getbased fetches each source separately and only shows a Latest BP pair when both halves were recorded on the same date.',
     ]

--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -260,14 +260,16 @@ export function updateSummaryButton() {
 }
 
 let _headerListenerAdded = false;
-function getAIContextHeaderParts() {
-  const parts = [];
-  if ((state.importedData?.interpretiveLens || '').trim()) parts.push('Lens');
+function getAIContextHeaderState() {
+  const active = [];
+  const pending = [];
+  if ((state.importedData?.interpretiveLens || '').trim()) active.push('Lens');
   try {
     const kb = getLensSummary();
-    if (kb?.configured) parts.push(kb.displayName || 'Knowledge Base');
+    if (kb?.configured) active.push(kb.displayName || 'Knowledge Base');
+    else if (kb?.enabled) pending.push('KB empty');
   } catch { /* Knowledge Base not initialised yet. */ }
-  return parts;
+  return { active, pending };
 }
 
 function ensureChatContextStatus(el) {
@@ -292,16 +294,23 @@ export function updateChatContextStatus() {
   if (!modelEl) return;
   const status = ensureChatContextStatus(modelEl);
   if (!status) return;
-  const parts = getAIContextHeaderParts();
+  const contextState = getAIContextHeaderState();
+  const parts = [...contextState.active, ...contextState.pending];
   if (parts.length === 0) {
     status.textContent = '';
     status.hidden = true;
     status.removeAttribute('aria-label');
+    status.classList.remove('chat-context-status-pending');
     return;
   }
+  const pendingOnly = contextState.active.length === 0 && contextState.pending.length > 0;
   const label = `AI Context: ${parts.join(' + ')}`;
+  const ariaSuffix = pendingOnly
+    ? 'Knowledge Base is enabled but no library is indexed yet. Click to manage Context.'
+    : 'Click to manage Context.';
   status.hidden = false;
-  status.setAttribute('aria-label', `${label}. Click to manage Context.`);
+  status.classList.toggle('chat-context-status-pending', pendingOnly);
+  status.setAttribute('aria-label', `${label}. ${ariaSuffix}`);
   status.innerHTML = `<span class="chat-context-dot" aria-hidden="true"></span><span>${escapeHTML(label)}</span>`;
 }
 

--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -260,14 +260,49 @@ export function updateSummaryButton() {
 }
 
 let _headerListenerAdded = false;
-function getAIContextHeaderSuffix() {
+function getAIContextHeaderParts() {
   const parts = [];
   if ((state.importedData?.interpretiveLens || '').trim()) parts.push('Lens');
   try {
     const kb = getLensSummary();
     if (kb?.configured) parts.push(kb.displayName || 'Knowledge Base');
   } catch { /* Knowledge Base not initialised yet. */ }
-  return parts.length ? ` · ${parts.join(' · ')}` : '';
+  return parts;
+}
+
+function ensureChatContextStatus(el) {
+  const parent = el.parentElement;
+  if (!parent) return null;
+  let status = parent.querySelector('.chat-context-status');
+  if (!status) {
+    status = document.createElement('button');
+    status.type = 'button';
+    status.className = 'chat-context-status';
+    status.addEventListener('click', () => {
+      const opener = /** @type {any} */ (window).openContextModal;
+      if (typeof opener === 'function') opener();
+    });
+    parent.appendChild(status);
+  }
+  return status;
+}
+
+export function updateChatContextStatus() {
+  const modelEl = document.querySelector('.chat-header-model');
+  if (!modelEl) return;
+  const status = ensureChatContextStatus(modelEl);
+  if (!status) return;
+  const parts = getAIContextHeaderParts();
+  if (parts.length === 0) {
+    status.textContent = '';
+    status.hidden = true;
+    status.removeAttribute('aria-label');
+    return;
+  }
+  const label = `AI Context: ${parts.join(' + ')}`;
+  status.hidden = false;
+  status.setAttribute('aria-label', `${label}. Click to manage Context.`);
+  status.innerHTML = `<span class="chat-context-dot" aria-hidden="true"></span><span>${escapeHTML(label)}</span>`;
 }
 
 export function updateChatHeaderModel() {
@@ -277,16 +312,16 @@ export function updateChatHeaderModel() {
     el.addEventListener('e2ee-attestation', () => updateChatHeaderModel());
     _headerListenerAdded = true;
   }
+  updateChatContextStatus();
   if (!hasAIProvider()) { el.textContent = ''; return; }
   const display = getActiveModelDisplay();
-  const contextSuffix = getAIContextHeaderSuffix();
   const provider = getAIProvider();
   const e2ee = provider === 'venice' && isVeniceE2EEActive();
   const ppqPrivate = provider === 'ppq' && isPpqPrivateModeActive();
   if (e2ee || ppqPrivate) {
-    el.innerHTML = escapeHTML(display + contextSuffix) + e2eeLockHTML(ppqPrivate ? window._ppqAttestation : window._veniceAttestation);
+    el.innerHTML = escapeHTML(display) + e2eeLockHTML(ppqPrivate ? window._ppqAttestation : window._veniceAttestation);
   } else {
-    el.textContent = display + contextSuffix;
+    el.textContent = display;
   }
 }
 

--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -294,6 +294,13 @@ export function updateChatContextStatus() {
   if (!modelEl) return;
   const status = ensureChatContextStatus(modelEl);
   if (!status) return;
+  if (!hasAIProvider()) {
+    status.textContent = '';
+    status.hidden = true;
+    status.removeAttribute('aria-label');
+    status.classList.remove('chat-context-status-pending');
+    return;
+  }
   const contextState = getAIContextHeaderState();
   const parts = [...contextState.active, ...contextState.pending];
   if (parts.length === 0) {
@@ -321,8 +328,8 @@ export function updateChatHeaderModel() {
     el.addEventListener('e2ee-attestation', () => updateChatHeaderModel());
     _headerListenerAdded = true;
   }
+  if (!hasAIProvider()) { el.textContent = ''; updateChatContextStatus(); return; }
   updateChatContextStatus();
-  if (!hasAIProvider()) { el.textContent = ''; return; }
   const display = getActiveModelDisplay();
   const provider = getAIProvider();
   const e2ee = provider === 'venice' && isVeniceE2EEActive();

--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -8,6 +8,7 @@ import { callClaudeAPI, hasAIProvider, getAIProvider, getActiveModelDisplay, isV
 import { saveChatThreadIndex, renderThreadList } from './chat-threads.js';
 import { CHAT_ICON_EDIT, CHAT_ICON_X } from './chat-icons.js';
 import { e2eeLockHTML } from './chat-attestation.js';
+import { getLensSummary } from './lens.js';
 
 const PERSONA_ICONS = ['🧠', '🎭', '🔮', '🌿', '⚡', '🦊', '🧬', '🌊', '🔥', '🏛️'];
 
@@ -259,6 +260,16 @@ export function updateSummaryButton() {
 }
 
 let _headerListenerAdded = false;
+function getAIContextHeaderSuffix() {
+  const parts = [];
+  if ((state.importedData?.interpretiveLens || '').trim()) parts.push('Lens');
+  try {
+    const kb = getLensSummary();
+    if (kb?.configured) parts.push(kb.displayName || 'Knowledge Base');
+  } catch { /* Knowledge Base not initialised yet. */ }
+  return parts.length ? ` · ${parts.join(' · ')}` : '';
+}
+
 export function updateChatHeaderModel() {
   const el = document.querySelector('.chat-header-model');
   if (!el) return;
@@ -268,13 +279,14 @@ export function updateChatHeaderModel() {
   }
   if (!hasAIProvider()) { el.textContent = ''; return; }
   const display = getActiveModelDisplay();
+  const contextSuffix = getAIContextHeaderSuffix();
   const provider = getAIProvider();
   const e2ee = provider === 'venice' && isVeniceE2EEActive();
   const ppqPrivate = provider === 'ppq' && isPpqPrivateModeActive();
   if (e2ee || ppqPrivate) {
-    el.innerHTML = escapeHTML(display) + e2eeLockHTML(ppqPrivate ? window._ppqAttestation : window._veniceAttestation);
+    el.innerHTML = escapeHTML(display + contextSuffix) + e2eeLockHTML(ppqPrivate ? window._ppqAttestation : window._veniceAttestation);
   } else {
-    el.textContent = display;
+    el.textContent = display + contextSuffix;
   }
 }
 

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -1,5 +1,5 @@
 // @ts-check
-// context-card-dashboard-ai.js - dashboard AI personalization and data protection CTAs
+// context-card-dashboard-ai.js - AI context and data protection CTAs
 
 import { getFolderBackupState } from './backup.js';
 import { getEncryptionEnabled } from './crypto.js';
@@ -36,7 +36,7 @@ function closestDashboardAIAction(target) {
 function runDashboardAIAction(action) {
   if (action === 'open-interpretive-lens') appWindow.openInterpretiveLensEditor?.();
   else if (action === 'open-knowledge-base') appWindow.openKnowledgeBaseModal?.();
-  else if (action === 'open-personalize-ai-picker') openPersonalizeAIPicker();
+  else if (action === 'open-personalize-ai-picker') openContextModal();
   else if (action === 'enable-encryption') appWindow.showEnableEncryptionModal?.();
   else if (action === 'setup-sync') appWindow.showSyncSetupModal?.();
   else if (action === 'setup-backup') appWindow.pickFolderForBackup?.();
@@ -90,8 +90,7 @@ export function renderInterpretiveLensSection() {
     : '';
   const kbRow = kbConfigured ? renderKnowledgeBaseRow(summary) : '';
   const aiCta = renderPersonalizeAICta(!!lens, kbConfigured);
-  const dataCta = renderDataProtectionCta();
-  return lensRow + kbRow + aiCta + dataCta;
+  return lensRow + kbRow + aiCta;
 }
 
 // Programmatic DNA file picker. Mirrors the chat onboarding hidden-file-input
@@ -278,12 +277,12 @@ export function openDataProtectionPicker() {
   });
 }
 
-export function openPersonalizeAIPicker() {
+export function openContextModal() {
   const appWindow = /** @type {any} */ (window);
-  let overlay = document.getElementById('ai-personalize-picker-overlay');
+  let overlay = document.getElementById('context-hub-overlay');
   if (!overlay) {
     overlay = document.createElement('div');
-    overlay.id = 'ai-personalize-picker-overlay';
+    overlay.id = 'context-hub-overlay';
     overlay.className = 'confirm-overlay';
     document.body.appendChild(overlay);
   }
@@ -292,31 +291,32 @@ export function openPersonalizeAIPicker() {
     document.removeEventListener('keydown', onKey);
   };
   const onKey = (e) => { if (e.key === 'Escape') close(); };
-  overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-label="Personalize how AI answers" style="max-width:520px">
-    <p class="confirm-message" style="margin-bottom:14px">Personalize how AI answers</p>
+  overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-label="Context" style="max-width:520px">
+    <p class="confirm-message" style="margin-bottom:6px">Context</p>
+    <p class="confirm-subtext" style="margin:0 0 14px;color:var(--muted);font-size:0.92rem">Control how AI interprets and grounds answers. Profile facts stay in Profile Context.</p>
     <div class="ai-picker-grid">
       <button type="button" class="ai-picker-card" data-pick="lens">
         <span class="ai-picker-icon" aria-hidden="true">&#129694;</span>
-        <span class="ai-picker-title">Interpretive Lens</span>
-        <span class="ai-picker-sub">Frame answers around researchers, paradigms, or schools of thought.</span>
+        <span class="ai-picker-title">Personalize how AI answers</span>
+        <span class="ai-picker-sub">Set the interpretive lens: researchers, paradigms, or schools of thought.</span>
       </button>
       <button type="button" class="ai-picker-card" data-pick="kb">
         <span class="ai-picker-icon" aria-hidden="true">&#128218;</span>
         <span class="ai-picker-title">Knowledge Base</span>
-        <span class="ai-picker-sub">Ground answers in your own documents - research papers, notes, references.</span>
+        <span class="ai-picker-sub">Ground answers in your own documents, research papers, notes, and references.</span>
       </button>
     </div>
     <div class="confirm-actions" style="margin-top:6px">
-      <button class="confirm-btn confirm-btn-cancel" id="ai-personalize-picker-cancel">Cancel</button>
+      <button class="confirm-btn confirm-btn-cancel" id="context-hub-cancel">Close</button>
     </div>
   </div>`;
   openModalOverlay(overlay, {
-    initialFocus: '.ai-picker-card,#ai-personalize-picker-cancel',
+    initialFocus: '.ai-picker-card,#context-hub-cancel',
     focusDelay: 50,
   });
   document.addEventListener('keydown', onKey);
   overlay.onclick = (e) => { if (e.target === overlay) close(); };
-  const cancelButton = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#ai-personalize-picker-cancel'));
+  const cancelButton = /** @type {HTMLButtonElement | null} */ (overlay.querySelector('#context-hub-cancel'));
   if (cancelButton) cancelButton.onclick = close;
   overlay.querySelectorAll('.ai-picker-card').forEach(btn => {
     const button = /** @type {HTMLButtonElement} */ (btn);
@@ -330,4 +330,8 @@ export function openPersonalizeAIPicker() {
       }
     };
   });
+}
+
+export function openPersonalizeAIPicker() {
+  openContextModal();
 }

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -84,11 +84,12 @@ export function renderInterpretiveLensSection() {
   const lens = (state.importedData.interpretiveLens || '').trim();
   let summary; try { summary = getLensSummary(); } catch { summary = null; }
   const kbConfigured = !!(summary && summary.configured);
+  const kbEnabled = !!(summary && summary.enabled);
 
   const lensRow = lens
     ? `<div class="lens-section" role="button" tabindex="0" aria-label="Edit Interpretive Lens" ${dashboardAIActionAttrs('open-interpretive-lens')} title="Interpretive Lens - click to edit"><span class="lens-section-icon">&#129694;</span><span class="lens-section-body"><span class="lens-section-label">Interpretive Lens</span><span class="lens-section-text">${escapeHTML(lens)}</span></span><span class="lens-section-edit">&#9998;</span></div>`
     : '';
-  const kbRow = kbConfigured ? renderKnowledgeBaseRow(summary) : '';
+  const kbRow = (kbConfigured || kbEnabled) ? renderKnowledgeBaseRow(summary) : '';
   const aiCta = renderPersonalizeAICta(!!lens, kbConfigured);
   return lensRow + kbRow + aiCta;
 }
@@ -121,7 +122,7 @@ export function triggerDNAFilePicker() {
 // query-rewriting status.
 export function renderKnowledgeBaseSection() {
   let s; try { s = getLensSummary(); } catch { return ''; }
-  if (!s || !s.configured) return '';
+  if (!s || (!s.configured && !s.enabled)) return '';
   return renderKnowledgeBaseRow(s);
 }
 
@@ -132,7 +133,8 @@ function renderKnowledgeBaseRow(s) {
   const rewriteFragment = s.aiAvailable
     ? ` &middot; query rewriting ${s.multiQueryOn ? 'on' : 'off'}`
     : '';
-  const detail = `${escapeHTML(s.displayName)}${docFragment}${rewriteFragment}`;
+  const emptyEnabledFragment = (!s.configured && s.enabled) ? ' &middot; enabled, no documents indexed yet' : '';
+  const detail = `${escapeHTML(s.displayName)}${emptyEnabledFragment}${docFragment}${rewriteFragment}`;
   return `<div class="lens-section" role="button" tabindex="0" aria-label="Manage Knowledge Base" ${dashboardAIActionAttrs('open-knowledge-base')} title="Knowledge Base - click to manage"><span class="lens-section-icon">&#128218;</span><span class="lens-section-body"><span class="lens-section-label">Knowledge Base</span><span class="lens-section-text">${detail}</span></span><span class="lens-section-edit">&#9998;</span></div>`;
 }
 
@@ -294,7 +296,13 @@ export function openContextModal() {
   const lensSet = !!(state.importedData.interpretiveLens || '').trim();
   let kbSummary; try { kbSummary = getLensSummary(); } catch { kbSummary = null; }
   const kbSet = !!kbSummary?.configured;
+  const kbEnabled = !!kbSummary?.enabled;
   const check = '<span class="dashboard-picker-check" aria-hidden="true">&#10003;</span>';
+  const kbStatus = kbSet
+    ? `${escapeHTML(kbSummary.displayName || 'Knowledge Base')} is enabled. Click to manage documents and retrieval.`
+    : (kbEnabled
+      ? 'Knowledge Base is enabled, but no documents are indexed yet. Add a library before it can ground answers.'
+      : 'Ground answers in your own documents, research papers, notes, and references.');
   overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-label="Context" style="max-width:520px">
     <p class="confirm-message" style="margin-bottom:6px">Context</p>
     <p class="confirm-subtext" style="margin:0 0 14px;color:var(--muted);font-size:0.92rem">Control how AI interprets and grounds answers. Profile facts stay in Profile Context.</p>
@@ -308,8 +316,8 @@ export function openContextModal() {
       <button type="button" class="ai-picker-card" data-pick="kb" data-context-kind="knowledge">
         <span class="ai-picker-kicker">Retrieval</span>
         <span class="ai-picker-title">Knowledge Base ${kbSet ? check : ''}</span>
-        <span class="ai-picker-sub">${kbSet ? `${escapeHTML(kbSummary.displayName || 'Knowledge Base')} is enabled. Click to manage documents and retrieval.` : 'Ground answers in your own documents, research papers, notes, and references.'}</span>
-        <span class="ai-picker-action">${kbSet ? 'Manage source' : 'Connect source'} &rarr;</span>
+        <span class="ai-picker-sub">${kbStatus}</span>
+        <span class="ai-picker-action">${kbSet ? 'Manage source' : (kbEnabled ? 'Add documents' : 'Connect source')} &rarr;</span>
       </button>
     </div>
     <div class="confirm-actions" style="margin-top:6px">

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -299,15 +299,17 @@ export function openContextModal() {
     <p class="confirm-message" style="margin-bottom:6px">Context</p>
     <p class="confirm-subtext" style="margin:0 0 14px;color:var(--muted);font-size:0.92rem">Control how AI interprets and grounds answers. Profile facts stay in Profile Context.</p>
     <div class="ai-picker-grid">
-      <button type="button" class="ai-picker-card" data-pick="lens">
-        <span class="ai-picker-icon" aria-hidden="true">&#129694;</span>
+      <button type="button" class="ai-picker-card" data-pick="lens" data-context-kind="lens">
+        <span class="ai-picker-kicker">Interpretive Lens</span>
         <span class="ai-picker-title">Personalize how AI answers ${lensSet ? check : ''}</span>
         <span class="ai-picker-sub">${lensSet ? 'Interpretive Lens is enabled. Click to review or edit it.' : 'Set the interpretive lens: researchers, paradigms, or schools of thought.'}</span>
+        <span class="ai-picker-action">${lensSet ? 'Review lens' : 'Set lens'} &rarr;</span>
       </button>
-      <button type="button" class="ai-picker-card" data-pick="kb">
-        <span class="ai-picker-icon" aria-hidden="true">&#128218;</span>
+      <button type="button" class="ai-picker-card" data-pick="kb" data-context-kind="knowledge">
+        <span class="ai-picker-kicker">Retrieval</span>
         <span class="ai-picker-title">Knowledge Base ${kbSet ? check : ''}</span>
         <span class="ai-picker-sub">${kbSet ? `${escapeHTML(kbSummary.displayName || 'Knowledge Base')} is enabled. Click to manage documents and retrieval.` : 'Ground answers in your own documents, research papers, notes, and references.'}</span>
+        <span class="ai-picker-action">${kbSet ? 'Manage source' : 'Connect source'} &rarr;</span>
       </button>
     </div>
     <div class="confirm-actions" style="margin-top:6px">

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -91,7 +91,7 @@ export function renderInterpretiveLensSection() {
     : '';
   const kbRow = (kbConfigured || kbEnabled) ? renderKnowledgeBaseRow(summary) : '';
   const aiCta = renderPersonalizeAICta(!!lens, kbConfigured);
-  return lensRow + kbRow + aiCta;
+  return lensRow + kbRow + aiCta + renderDataProtectionCta();
 }
 
 // Programmatic DNA file picker. Mirrors the chat onboarding hidden-file-input

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -291,19 +291,23 @@ export function openContextModal() {
     document.removeEventListener('keydown', onKey);
   };
   const onKey = (e) => { if (e.key === 'Escape') close(); };
+  const lensSet = !!(state.importedData.interpretiveLens || '').trim();
+  let kbSummary; try { kbSummary = getLensSummary(); } catch { kbSummary = null; }
+  const kbSet = !!kbSummary?.configured;
+  const check = '<span class="dashboard-picker-check" aria-hidden="true">&#10003;</span>';
   overlay.innerHTML = `<div class="confirm-dialog" role="dialog" aria-modal="true" aria-label="Context" style="max-width:520px">
     <p class="confirm-message" style="margin-bottom:6px">Context</p>
     <p class="confirm-subtext" style="margin:0 0 14px;color:var(--muted);font-size:0.92rem">Control how AI interprets and grounds answers. Profile facts stay in Profile Context.</p>
     <div class="ai-picker-grid">
       <button type="button" class="ai-picker-card" data-pick="lens">
         <span class="ai-picker-icon" aria-hidden="true">&#129694;</span>
-        <span class="ai-picker-title">Personalize how AI answers</span>
-        <span class="ai-picker-sub">Set the interpretive lens: researchers, paradigms, or schools of thought.</span>
+        <span class="ai-picker-title">Personalize how AI answers ${lensSet ? check : ''}</span>
+        <span class="ai-picker-sub">${lensSet ? 'Interpretive Lens is enabled. Click to review or edit it.' : 'Set the interpretive lens: researchers, paradigms, or schools of thought.'}</span>
       </button>
       <button type="button" class="ai-picker-card" data-pick="kb">
         <span class="ai-picker-icon" aria-hidden="true">&#128218;</span>
-        <span class="ai-picker-title">Knowledge Base</span>
-        <span class="ai-picker-sub">Ground answers in your own documents, research papers, notes, and references.</span>
+        <span class="ai-picker-title">Knowledge Base ${kbSet ? check : ''}</span>
+        <span class="ai-picker-sub">${kbSet ? `${escapeHTML(kbSummary.displayName || 'Knowledge Base')} is enabled. Click to manage documents and retrieval.` : 'Ground answers in your own documents, research papers, notes, and references.'}</span>
       </button>
     </div>
     <div class="confirm-actions" style="margin-top:6px">

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -731,6 +731,7 @@ export function saveInterpretiveLens() {
   const ta = getTextInput('interpretive-lens-textarea');
   const text = ta ? ta.value.trim() : '';
   state.importedData.interpretiveLens = text || '';
+  window.updateChatHeaderModel?.();
   recordContextChange('interpretiveLens');
   saveImportedData();
   window.closeModal();
@@ -740,6 +741,7 @@ export function saveInterpretiveLens() {
 
 export function clearInterpretiveLens() {
   state.importedData.interpretiveLens = '';
+  window.updateChatHeaderModel?.();
   recordContextChange('interpretiveLens');
   saveImportedData();
   window.closeModal();

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -34,6 +34,7 @@ import {
 } from './context-card-health-dots.js';
 import {
   openDataProtectionPicker,
+  openContextModal,
   openPersonalizeAIPicker,
   renderDataProtectionCta,
   renderInterpretiveLensSection,
@@ -235,6 +236,7 @@ export {
 } from './context-card-medical-history-editor.js';
 export {
   openDataProtectionPicker,
+  openContextModal,
   openPersonalizeAIPicker,
   renderDataProtectionCta,
   renderInterpretiveLensSection,
@@ -291,11 +293,7 @@ export function renderProfileContextCards() {
     _ccSubtitle = `<div class="context-section-subtitle">${_ccMissingDemo ? 'Set your sex and date of birth in Settings, then open' : 'All filled \u2014 open'} the chat to get personalized test recommendations based on your profile.</div>`;
   }
   const _refreshBtn = hasAIProvider() ? `<button class="ctx-refresh-all-btn" ${contextCardActionAttrs('refresh-all-health-dots')} title="Refresh all AI insights">&#x21bb;</button>` : '';
-  // Personalize-AI section (Interpretive Lens row, Knowledge Base row, and CTA pills).
-  // The dashboard redesign dropped the standalone call site, leaving Interpretive Lens
-  // with working storage/prompt wiring but no rendered UI entry point.
-  let html = renderInterpretiveLensSection();
-  html += `<div style="margin-top:16px"><span class="context-section-title">What your GP won't ask you (${filledCount}/${cardDefs.length} filled)</span>${_refreshBtn}${_ccSubtitle}</div>`;
+  let html = `<div><span class="context-section-title">What your GP won't ask you (${filledCount}/${cardDefs.length} filled)</span>${_refreshBtn}${_ccSubtitle}</div>`;
   html += `<div class="profile-context-cards">`;
   for (const c of cardDefs) {
     const filled = isContextFilled(c.key);
@@ -536,6 +534,7 @@ Object.assign(window, {
   clearInterpretiveLens,
   renderInterpretiveLensSection,
   renderKnowledgeBaseSection,
+  openContextModal,
   openPersonalizeAIPicker,
   openDataProtectionPicker,
   triggerDNAFilePicker,

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -293,7 +293,8 @@ export function renderProfileContextCards() {
     _ccSubtitle = `<div class="context-section-subtitle">${_ccMissingDemo ? 'Set your sex and date of birth in Settings, then open' : 'All filled \u2014 open'} the chat to get personalized test recommendations based on your profile.</div>`;
   }
   const _refreshBtn = hasAIProvider() ? `<button class="ctx-refresh-all-btn" ${contextCardActionAttrs('refresh-all-health-dots')} title="Refresh all AI insights">&#x21bb;</button>` : '';
-  let html = `<div><span class="context-section-title">What your GP won't ask you (${filledCount}/${cardDefs.length} filled)</span>${_refreshBtn}${_ccSubtitle}</div>`;
+  let html = renderInterpretiveLensSection();
+  html += `<div><span class="context-section-title">What your GP won't ask you (${filledCount}/${cardDefs.length} filled)</span>${_refreshBtn}${_ccSubtitle}</div>`;
   html += `<div class="profile-context-cards">`;
   for (const c of cardDefs) {
     const filled = isContextFilled(c.key);

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -291,7 +291,11 @@ export function renderProfileContextCards() {
     _ccSubtitle = `<div class="context-section-subtitle">${_ccMissingDemo ? 'Set your sex and date of birth in Settings, then open' : 'All filled \u2014 open'} the chat to get personalized test recommendations based on your profile.</div>`;
   }
   const _refreshBtn = hasAIProvider() ? `<button class="ctx-refresh-all-btn" ${contextCardActionAttrs('refresh-all-health-dots')} title="Refresh all AI insights">&#x21bb;</button>` : '';
-  let html = `<div style="margin-top:16px"><span class="context-section-title">What your GP won't ask you (${filledCount}/${cardDefs.length} filled)</span>${_refreshBtn}${_ccSubtitle}</div>`;
+  // Personalize-AI section (Interpretive Lens row, Knowledge Base row, and CTA pills).
+  // The dashboard redesign dropped the standalone call site, leaving Interpretive Lens
+  // with working storage/prompt wiring but no rendered UI entry point.
+  let html = renderInterpretiveLensSection();
+  html += `<div style="margin-top:16px"><span class="context-section-title">What your GP won't ask you (${filledCount}/${cardDefs.length} filled)</span>${_refreshBtn}${_ccSubtitle}</div>`;
   html += `<div class="profile-context-cards">`;
   for (const c of cardDefs) {
     const filled = isContextFilled(c.key);

--- a/js/lens.js
+++ b/js/lens.js
@@ -103,6 +103,10 @@ export async function saveLensKey(key) {
   await encryptedSetItem(SECRET_KEY, key);
   updateKeyCache(SECRET_KEY, key);
   clearLensCache();
+  // External-server hasLens() gates on getLensKey(); refresh the chat header
+  // immediately so first-time KB key saves surface the AI Context chip without
+  // waiting for an unrelated model/config refresh.
+  /** @type {any} */ (globalThis).updateChatHeaderModel?.();
 }
 export async function removeLens() {
   localStorage.removeItem(CONFIG_KEY);

--- a/js/lens.js
+++ b/js/lens.js
@@ -95,6 +95,7 @@ export function saveLensConfig(partial) {
   if (urlChanged || topKChanged) clearLensCache();
   // Ping listeners so the indicator re-evaluates visibility (without clobbering state)
   updateLensStatus({});
+  /** @type {any} */ (globalThis).updateChatHeaderModel?.();
   return next;
 }
 export function getLensKey() { return getCachedKey(SECRET_KEY) || ''; }
@@ -109,6 +110,7 @@ export async function removeLens() {
   updateKeyCache(SECRET_KEY, '');
   clearLensCache();
   updateLensStatus({ state: 'idle', lastChunkCount: 0, lastError: null, sourceName: '' });
+  /** @type {any} */ (globalThis).updateChatHeaderModel?.();
 }
 export function hasLens() {
   const cfg = getLensConfig();

--- a/js/nav.js
+++ b/js/nav.js
@@ -89,6 +89,8 @@ function handleNavActionClick(event) {
     appWindow.openKnowledgeBaseModal?.();
   } else if (action === 'open-report-builder') {
     appWindow.openReportBuilder?.();
+  } else if (action === 'open-context') {
+    appWindow.openContextModal?.();
   } else if (action === 'open-custom-marker') {
     appWindow.openCreateMarkerModal?.();
   } else if (action === 'toggle-group') {
@@ -268,8 +270,8 @@ export function buildSidebar(data) {
   html += `<div class="nav-section">Manage</div>`;
   html += `<div class="nav-item" data-category="reports" tabindex="0" role="button" ${_navActionAttrs('open-report-builder')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('report')}</span><span class="nav-item-label">Reports</span><span class="nav-item-dot"></span></div>`;
-  html += `<div class="nav-item" data-category="knowledge" tabindex="0" role="button" ${_navActionAttrs('open-knowledge-base')}>
-    <span class="nav-item-icon" aria-hidden="true">${_iconSvg('knowledge')}</span><span class="nav-item-label">Knowledge Base</span><span class="nav-item-dot"></span></div>`;
+  html += `<div class="nav-item" data-category="context" tabindex="0" role="button" ${_navActionAttrs('open-context')}>
+    <span class="nav-item-icon" aria-hidden="true">${_iconSvg('knowledge')}</span><span class="nav-item-label">Context</span><span class="nav-item-dot"></span></div>`;
   html += `<div class="nav-item" data-category="custom-markers" tabindex="0" role="button" ${_navActionAttrs('open-custom-marker')}>
     <span class="nav-item-icon" aria-hidden="true">${_iconSvg('plus')}</span><span class="nav-item-label">Custom markers</span><span class="nav-item-dot"></span></div>`;
 
@@ -381,7 +383,7 @@ export function filterSidebar() {
   // When searching: show matching items, expand groups with matches, hide empty groups
   items.forEach(el => {
     const cat = el.dataset.category;
-    if (cat === 'dashboard' || cat === 'labs' || cat === 'correlations' || cat === 'compare' || cat === 'recommendations' || cat === 'reports' || cat === 'knowledge' || cat === 'custom-markers' || cat === 'light' || cat === 'body' || cat === 'wearables' || cat === 'emf' || cat === 'light-env-assessment' || cat === 'genome' || cat === 'genetics' || cat === 'insight') { el.style.display = ''; return; }
+    if (cat === 'dashboard' || cat === 'labs' || cat === 'correlations' || cat === 'compare' || cat === 'recommendations' || cat === 'reports' || cat === 'context' || cat === 'custom-markers' || cat === 'light' || cat === 'body' || cat === 'wearables' || cat === 'emf' || cat === 'light-env-assessment' || cat === 'genome' || cat === 'genetics' || cat === 'insight') { el.style.display = ''; return; }
     const label = el.textContent.toLowerCase();
     const markers = (el.dataset.markers || '').toLowerCase();
     el.style.display = (label.includes(query) || markers.includes(query)) ? '' : 'none';

--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -39,7 +39,8 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
   const sysColor = tc.lineColor || '#60a5fa';
   const diaColor = '#a78bfa';
   const manualColor = '#f59e0b';
-  const manualDiaColor = '#fb7185';
+  // Keep manual diastolic visually distinct from the primary diastolic line.
+  const manualDiaColor = '#f43f5e';
 
   const baselineDatasets = [];
   if (xDates.length && typeof m.baseline === 'number' && isFinite(m.baseline)) {

--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -8,9 +8,13 @@ import { formatValue, shortDate } from './wearables-formatters.js';
 
 export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diastolicSeries = [], manualSeries = [], pairedMetric = null) {
   if (!window.Chart || !isChartDateAdapterReady()) {
+    const retryToken = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    canvas.dataset.bpRenderToken = retryToken;
     ensureChartJs().then(() => {
       const currentCanvas = document.getElementById(canvas.id);
-      if (currentCanvas) renderBloodPressureChart(currentCanvas, canon, m, systolicSeries, diastolicSeries, manualSeries, pairedMetric);
+      if (currentCanvas === canvas && canvas.isConnected && canvas.dataset.bpRenderToken === retryToken) {
+        renderBloodPressureChart(canvas, canon, m, systolicSeries, diastolicSeries, manualSeries, pairedMetric);
+      }
     }).catch(() => {});
     return;
   }

--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -34,6 +34,8 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
   const formatV = v => formatValue(v, unit);
   const primaryAdapter = adapterById(m.primarySource);
   const primaryLabel = primaryAdapter?.displayName || 'Primary source';
+  const pairedAdapter = adapterById(pairedMetric?.primarySource);
+  const pairedLabel = pairedAdapter?.displayName || primaryLabel;
   const sysColor = tc.lineColor || '#60a5fa';
   const diaColor = '#a78bfa';
   const manualColor = '#f59e0b';
@@ -83,7 +85,7 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
     spanGaps: true,
   });
   if (diaData.length) datasets.push({
-    label: `Diastolic (${primaryLabel})`,
+    label: `Diastolic (${pairedLabel})`,
     data: diaData,
     _kind: 'primary',
     borderColor: diaColor,

--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -1,0 +1,165 @@
+// @ts-check
+
+import { state } from './state.js';
+import { adapterById, isMetricValueMeaningful } from './wearable-adapters.js';
+import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
+import { getChartColors } from './theme.js';
+import { formatValue, shortDate } from './wearables-formatters.js';
+
+export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diastolicSeries = [], manualSeries = [], pairedMetric = null) {
+  if (!window.Chart || !isChartDateAdapterReady()) {
+    ensureChartJs().then(() => {
+      const currentCanvas = document.getElementById(canvas.id);
+      if (currentCanvas) renderBloodPressureChart(currentCanvas, canon, m, systolicSeries, diastolicSeries, manualSeries, pairedMetric);
+    }).catch(() => {});
+    return;
+  }
+
+  const tc = getChartColors();
+  const sysData = systolicSeries.map(p => ({ x: p.date, y: p.v }));
+  const diaData = diastolicSeries.map(p => ({ x: p.date, y: p.v }));
+  const manualSysData = manualSeries
+    .filter(p => isMetricValueMeaningful('bp_systolic', p.v))
+    .map(p => ({ x: p.date, y: p.v }));
+  const manualDiaData = manualSeries
+    .filter(p => isMetricValueMeaningful('bp_diastolic', p.pairedV))
+    .map(p => ({ x: p.date, y: p.pairedV }));
+  const xDates = [...systolicSeries, ...diastolicSeries, ...manualSeries].map(p => p.date).filter(Boolean).sort();
+  const values = [...sysData, ...diaData, ...manualSysData, ...manualDiaData]
+    .map(p => p.y)
+    .filter(v => typeof v === 'number' && isFinite(v));
+  if (values.length === 0) return;
+
+  const unit = canon.unit || '';
+  const formatV = v => formatValue(v, unit);
+  const primaryAdapter = adapterById(m.primarySource);
+  const primaryLabel = primaryAdapter?.displayName || 'Primary source';
+  const sysColor = tc.lineColor || '#60a5fa';
+  const diaColor = '#a78bfa';
+  const manualColor = '#f59e0b';
+
+  const baselineDatasets = [];
+  if (xDates.length && typeof m.baseline === 'number' && isFinite(m.baseline)) {
+    baselineDatasets.push({
+      label: 'Systolic baseline',
+      data: [{ x: xDates[0], y: m.baseline }, { x: xDates[xDates.length - 1], y: m.baseline }],
+      _kind: 'baseline',
+      borderColor: sysColor,
+      backgroundColor: 'transparent',
+      borderWidth: 1,
+      borderDash: [4, 4],
+      pointRadius: 0,
+      pointHoverRadius: 0,
+      tension: 0,
+    });
+  }
+  if (xDates.length && typeof pairedMetric?.baseline === 'number' && isFinite(pairedMetric.baseline)) {
+    baselineDatasets.push({
+      label: 'Diastolic baseline',
+      data: [{ x: xDates[0], y: pairedMetric.baseline }, { x: xDates[xDates.length - 1], y: pairedMetric.baseline }],
+      _kind: 'baseline',
+      borderColor: diaColor,
+      backgroundColor: 'transparent',
+      borderWidth: 1,
+      borderDash: [4, 4],
+      pointRadius: 0,
+      pointHoverRadius: 0,
+      tension: 0,
+    });
+  }
+
+  const datasets = [];
+  if (sysData.length) datasets.push({
+    label: `Systolic (${primaryLabel})`,
+    data: sysData,
+    _kind: 'primary',
+    borderColor: sysColor,
+    backgroundColor: 'transparent',
+    borderWidth: 2,
+    pointRadius: 3,
+    pointHoverRadius: 5,
+    tension: 0.3,
+    spanGaps: true,
+  });
+  if (diaData.length) datasets.push({
+    label: `Diastolic (${primaryLabel})`,
+    data: diaData,
+    _kind: 'primary',
+    borderColor: diaColor,
+    backgroundColor: 'transparent',
+    borderWidth: 2,
+    pointRadius: 3,
+    pointHoverRadius: 5,
+    tension: 0.3,
+    spanGaps: true,
+  });
+  datasets.push(...baselineDatasets);
+  if (manualSysData.length) datasets.push({
+    type: 'scatter',
+    label: 'Manual systolic',
+    data: manualSysData,
+    _kind: 'manual',
+    borderColor: manualColor,
+    backgroundColor: manualColor,
+    pointRadius: 5,
+    pointHoverRadius: 7,
+    showLine: false,
+  });
+  if (manualDiaData.length) datasets.push({
+    type: 'scatter',
+    label: 'Manual diastolic',
+    data: manualDiaData,
+    _kind: 'manual',
+    borderColor: diaColor,
+    backgroundColor: diaColor,
+    pointRadius: 5,
+    pointHoverRadius: 7,
+    showLine: false,
+  });
+
+  const yValues = [...values];
+  if (typeof m.baseline === 'number' && isFinite(m.baseline)) yValues.push(m.baseline);
+  if (typeof pairedMetric?.baseline === 'number' && isFinite(pairedMetric.baseline)) yValues.push(pairedMetric.baseline);
+  const ymin = Math.min(...yValues);
+  const ymax = Math.max(...yValues);
+  const pad = Math.max((ymax - ymin) * 0.08, 2);
+  const titleForPoint = (items) => {
+    const rawX = items?.[0]?.raw?.x;
+    if (typeof rawX === 'string') return shortDate(rawX);
+    return items?.[0]?.label || '';
+  };
+
+  state.chartInstances['modal'] = new window.Chart(canvas, {
+    type: 'line',
+    data: { datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: datasets.some(d => d._kind === 'manual') ? 'nearest' : 'index', intersect: false, axis: 'x' },
+      plugins: {
+        legend: { display: true },
+        tooltip: {
+          backgroundColor: tc.tooltipBg, titleColor: tc.tooltipTitle,
+          bodyColor: tc.tooltipBody, borderColor: tc.tooltipBorder, borderWidth: 1,
+          callbacks: {
+            title: titleForPoint,
+            label: (c) => `${c.dataset.label}: ${formatV(c.parsed.y)}${unit ? ' ' + unit : ''}${c.dataset._kind === 'manual' ? '  (manual entry)' : ''}`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          type: 'time',
+          time: { tooltipFormat: 'MMM d, yyyy', displayFormats: { day: 'MMM d', month: 'MMM yyyy' } },
+          ticks: { source: 'auto', color: tc.tickColor, font: { size: 10 }, maxTicksLimit: 8 },
+          grid: { display: false },
+        },
+        y: {
+          min: ymin - pad, max: ymax + pad,
+          ticks: { color: tc.tickColor, font: { size: 10 } },
+          grid: { color: tc.gridColor },
+        },
+      },
+    },
+  });
+}

--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -37,6 +37,7 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
   const sysColor = tc.lineColor || '#60a5fa';
   const diaColor = '#a78bfa';
   const manualColor = '#f59e0b';
+  const manualDiaColor = '#fb7185';
 
   const baselineDatasets = [];
   if (xDates.length && typeof m.baseline === 'number' && isFinite(m.baseline)) {
@@ -110,8 +111,8 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
     label: 'Manual diastolic',
     data: manualDiaData,
     _kind: 'manual',
-    borderColor: diaColor,
-    backgroundColor: diaColor,
+    borderColor: manualDiaColor,
+    backgroundColor: manualDiaColor,
     pointRadius: 5,
     pointHoverRadius: 7,
     showLine: false,

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -316,17 +316,17 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
   const pairedMetric = metricId === 'bp_systolic' ? opts.pairedMetric : null;
   const pairedSeries = Array.isArray(opts.pairedSeries) ? opts.pairedSeries : [];
   const pairedUnitSpaced = unitSpaced;
-  const formatPaired = (sys, dia) => {
+  const formatPaired = (sys, dia, includeUnit = true) => {
     const sysText = isMetricValueMeaningful('bp_systolic', sys) ? formatV(sys) : '—';
     const diaText = isMetricValueMeaningful('bp_diastolic', dia) ? formatV(dia) : '—';
-    return `${sysText}/${diaText}${pairedUnitSpaced}`;
+    return `${sysText}/${diaText}${includeUnit ? pairedUnitSpaced : ''}`;
   };
   const baseStats = pairedMetric ? [
     ['Latest',   formatPaired(m.latest, pairedMetric.latest), m.latestDate || pairedMetric.latestDate ? shortDate(m.latestDate || pairedMetric.latestDate) : ''],
     ['Baseline (90d)', formatPaired(m.baseline, pairedMetric.baseline), 'median'],
     ['7-day avg', formatPaired(m.rolling?.d7, pairedMetric.rolling?.d7), ''],
     ['30-day avg', formatPaired(m.rolling?.d30, pairedMetric.rolling?.d30), ''],
-    ['Typical range', `${formatPaired(m.baselineP25, pairedMetric.baselineP25)} – ${formatPaired(m.baselineP75, pairedMetric.baselineP75)}`, '25th–75th percentile'],
+    ['Typical range', `${formatPaired(m.baselineP25, pairedMetric.baselineP25, false)} – ${formatPaired(m.baselineP75, pairedMetric.baselineP75, false)}${pairedUnitSpaced}`, '25th–75th percentile'],
     ['Chart samples', `${Math.max(series.length, pairedSeries.length)}d`, rangeDef.coverageSuffix],
   ] : [
     ['Latest',   `${formatV(m.latest)}${unitSpaced}`, m.latestDate ? shortDate(m.latestDate) : ''],

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -141,11 +141,15 @@ export async function openWearableDetail(metricId, opts = {}) {
     }))
     .filter(p => isMetricValueMeaningful(normalizedMetricId, p.v) || (pairedMetricId && isMetricValueMeaningful(pairedMetricId, p.pairedV)))
     .sort((a, b) => b.date.localeCompare(a.date));
-  const manualChartEntries = m.primarySource === 'manual'
-    ? []
-    : manualEntries
-        .filter(p => rangeDef.days == null || p.date >= startDate)
-        .sort((a, b) => a.date.localeCompare(b.date));
+  const manualChartEntries = manualEntries
+    .map(p => ({
+      ...p,
+      v: m.primarySource === 'manual' ? undefined : p.v,
+      pairedV: pairedMetric?.primarySource === 'manual' ? undefined : p.pairedV,
+    }))
+    .filter(p => isMetricValueMeaningful(normalizedMetricId, p.v) || (pairedMetricId && isMetricValueMeaningful(pairedMetricId, p.pairedV)))
+    .filter(p => rangeDef.days == null || p.date >= startDate)
+    .sort((a, b) => a.date.localeCompare(b.date));
 
   const modal = document.getElementById('detail-modal');
   const overlay = document.getElementById('modal-overlay');

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -16,6 +16,7 @@ import { getChartColors } from './theme.js';
 import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
 import { _collectActiveChips, _renderNoteField, _renderTagChips, inputValueById, inputValueFromElement } from './wearables-manual-form-ui.js';
+import { renderBloodPressureChart } from './wearables-bp-detail-chart.js';
 import { openModalOverlay } from './modal-lifecycle.js';
 
 const WEARABLE_DETAIL_RANGES = [
@@ -95,10 +96,17 @@ export async function openWearableDetail(metricId, opts = {}) {
   }
   if (op !== _detailOp) return;
 
+  const isBloodPressureDetail = metricId === 'bp_systolic';
+  const pairedMetricId = isBloodPressureDetail ? 'bp_diastolic' : null;
+  const pairedMetric = pairedMetricId ? summary?.metrics?.[pairedMetricId] : null;
   const series = rows
     .map(r => ({ date: r.date, v: r[metricId] }))
     .filter(p => isMetricValueMeaningful(metricId, p.v))
     .sort((a, b) => a.date.localeCompare(b.date));
+  const pairedSeries = pairedMetricId ? rows
+    .map(r => ({ date: r.date, v: r[pairedMetricId] }))
+    .filter(p => isMetricValueMeaningful(pairedMetricId, p.v))
+    .sort((a, b) => a.date.localeCompare(b.date)) : [];
 
   const allZeroActivity = metricId === 'activity_score'
     && series.length > 0
@@ -115,8 +123,14 @@ export async function openWearableDetail(metricId, opts = {}) {
   }
 
   const manualEntries = manualRows
-    .map(r => ({ date: r.date, v: r[metricId], tags: r.tags, note: r.note }))
-    .filter(p => isMetricValueMeaningful(metricId, p.v))
+    .map(r => ({
+      date: r.date,
+      v: r[metricId],
+      pairedV: pairedMetricId ? r[pairedMetricId] : undefined,
+      tags: r.tags,
+      note: r.note,
+    }))
+    .filter(p => isMetricValueMeaningful(metricId, p.v) || (pairedMetricId && isMetricValueMeaningful(pairedMetricId, p.pairedV)))
     .sort((a, b) => b.date.localeCompare(a.date));
   const manualChartEntries = m.primarySource === 'manual'
     ? []
@@ -133,7 +147,13 @@ export async function openWearableDetail(metricId, opts = {}) {
     delete state.chartInstances['modal'];
   }
 
-  modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries, { allZeroActivity, rangeKey });
+  modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries, {
+    allZeroActivity,
+    rangeKey,
+    pairedMetric,
+    pairedSeries,
+    pairedMetricId,
+  });
   openModalOverlay(overlay);
 
   const focusTarget = opts.fromRangeToggle
@@ -143,8 +163,11 @@ export async function openWearableDetail(metricId, opts = {}) {
   _installWearableModalFocusTrap(modal);
 
   const canvas = document.getElementById('chart-modal');
-  if (canvas && (series.length > 0 || manualChartEntries.length > 0)) {
-    if (canvas instanceof HTMLCanvasElement) renderWearableChart(canvas, canon, m, series, manualChartEntries);
+  if (canvas && (series.length > 0 || pairedSeries.length > 0 || manualChartEntries.length > 0)) {
+    if (canvas instanceof HTMLCanvasElement) {
+      if (isBloodPressureDetail) renderBloodPressureChart(canvas, canon, m, series, pairedSeries, manualChartEntries, pairedMetric);
+      else renderWearableChart(canvas, canon, m, series, manualChartEntries);
+    }
   }
 }
 
@@ -207,6 +230,15 @@ function buildManualEntriesSection(metricId, manualEntries, primarySource) {
   const canon = canonicalMetric(metricId);
   const unit = canon?.unit || '';
   const metricLabel = canon?.label || metricId;
+  const isBloodPressure = metricId === 'bp_systolic';
+  const formatEntryValue = (e) => {
+    if (isBloodPressure) {
+      const sys = isMetricValueMeaningful('bp_systolic', e.v) ? formatValue(e.v, unit) : '—';
+      const dia = isMetricValueMeaningful('bp_diastolic', e.pairedV) ? formatValue(e.pairedV, unit) : '—';
+      return `${sys}/${dia}`;
+    }
+    return formatValue(e.v, unit);
+  };
   const formatSpokenDate = (iso) => {
     try {
       const d = new Date(iso + 'T00:00:00');
@@ -222,8 +254,8 @@ function buildManualEntriesSection(metricId, manualEntries, primarySource) {
     const noteRow = (typeof e.note === 'string' && e.note.trim())
       ? `<div class="wearable-manual-entry-note">${escapeHTML(e.note)}</div>`
       : '';
-    const valueRead = formatValue(e.v, unit);
-    const ariaText = `Delete ${metricLabel.toLowerCase()} reading from ${formatSpokenDate(e.date)}, ${valueRead}${unit ? ' ' + unit : ''}`;
+    const valueRead = formatEntryValue(e);
+    const ariaText = `Delete ${isBloodPressure ? 'blood pressure' : metricLabel.toLowerCase()} reading from ${formatSpokenDate(e.date)}, ${valueRead}${unit ? ' ' + unit : ''}`;
     return `<li class="wearable-manual-entry${noteRow ? ' has-note' : ''}" data-entry-date="${escapeHTML(e.date)}">
       <span class="wearable-manual-entry-date">${escapeHTML(shortDate(e.date))}</span>
       <span class="wearable-manual-entry-val">${valueRead}${unit ? ` <span class="wearable-manual-entry-unit">${escapeHTML(unit)}</span>` : ''}</span>
@@ -281,7 +313,22 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
 
   const rangeKey = opts.rangeKey || '90d';
   const rangeDef = WEARABLE_DETAIL_RANGES.find(r => r.key === rangeKey) || WEARABLE_DETAIL_RANGES[0];
-  const baseStats = [
+  const pairedMetric = metricId === 'bp_systolic' ? opts.pairedMetric : null;
+  const pairedSeries = Array.isArray(opts.pairedSeries) ? opts.pairedSeries : [];
+  const pairedUnitSpaced = unitSpaced;
+  const formatPaired = (sys, dia) => {
+    const sysText = isMetricValueMeaningful('bp_systolic', sys) ? formatV(sys) : '—';
+    const diaText = isMetricValueMeaningful('bp_diastolic', dia) ? formatV(dia) : '—';
+    return `${sysText}/${diaText}${pairedUnitSpaced}`;
+  };
+  const baseStats = pairedMetric ? [
+    ['Latest',   formatPaired(m.latest, pairedMetric.latest), m.latestDate || pairedMetric.latestDate ? shortDate(m.latestDate || pairedMetric.latestDate) : ''],
+    ['Baseline (90d)', formatPaired(m.baseline, pairedMetric.baseline), 'median'],
+    ['7-day avg', formatPaired(m.rolling?.d7, pairedMetric.rolling?.d7), ''],
+    ['30-day avg', formatPaired(m.rolling?.d30, pairedMetric.rolling?.d30), ''],
+    ['Typical range', `${formatPaired(m.baselineP25, pairedMetric.baselineP25)} – ${formatPaired(m.baselineP75, pairedMetric.baselineP75)}`, '25th–75th percentile'],
+    ['Chart samples', `${Math.max(series.length, pairedSeries.length)}d`, rangeDef.coverageSuffix],
+  ] : [
     ['Latest',   `${formatV(m.latest)}${unitSpaced}`, m.latestDate ? shortDate(m.latestDate) : ''],
     ['Baseline (90d)', `${formatV(m.baseline)}${unitSpaced}`, 'median'],
     ['7-day avg', `${formatV(m.rolling?.d7)}${unitSpaced}`, ''],
@@ -341,7 +388,7 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
 
   const emptyHint = opts.allZeroActivity
     ? `<div class="wearable-detail-empty">Every day shows 0 — Oura suppresses the Activity composite score while Rest Mode is on. Check the <b>Steps</b> card for raw movement data, or disable Rest Mode in the Oura app.</div>`
-    : series.length === 0
+    : series.length === 0 && pairedSeries.length === 0
       ? manualEntries.length > 0
         ? `<div class="wearable-detail-empty">No chart samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Manual readings are listed below${m.primarySource === 'manual' && rangeDef.days != null ? '; switch to All to chart older manual readings' : ''}.</div>`
         : `<div class="wearable-detail-empty">No daily samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -150,6 +150,11 @@ export async function openWearableDetail(metricId, opts = {}) {
     .filter(p => isMetricValueMeaningful(normalizedMetricId, p.v) || (pairedMetricId && isMetricValueMeaningful(pairedMetricId, p.pairedV)))
     .filter(p => rangeDef.days == null || p.date >= startDate)
     .sort((a, b) => a.date.localeCompare(b.date));
+  const chartSampleCount = new Set([
+    ...series.map(p => p.date),
+    ...pairedSeries.map(p => p.date),
+    ...manualChartEntries.map(p => p.date),
+  ].filter(Boolean)).size;
 
   const modal = document.getElementById('detail-modal');
   const overlay = document.getElementById('modal-overlay');
@@ -166,6 +171,7 @@ export async function openWearableDetail(metricId, opts = {}) {
     pairedMetric,
     pairedSeries,
     pairedMetricId,
+    chartSampleCount,
   });
   openModalOverlay(overlay);
 
@@ -328,6 +334,9 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
   const rangeDef = WEARABLE_DETAIL_RANGES.find(r => r.key === rangeKey) || WEARABLE_DETAIL_RANGES[0];
   const pairedMetric = metricId === 'bp_systolic' ? opts.pairedMetric : null;
   const pairedSeries = Array.isArray(opts.pairedSeries) ? opts.pairedSeries : [];
+  const chartSampleCount = Number.isFinite(opts.chartSampleCount)
+    ? opts.chartSampleCount
+    : Math.max(series.length, pairedSeries.length);
   const pairedUnitSpaced = unitSpaced;
   const formatPaired = (sys, dia, includeUnit = true) => {
     const sysText = isMetricValueMeaningful('bp_systolic', sys) ? formatV(sys) : '—';
@@ -359,7 +368,7 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
     ['7-day avg', formatPaired(m.rolling?.d7, pairedMetric.rolling?.d7), ''],
     ['30-day avg', formatPaired(m.rolling?.d30, pairedMetric.rolling?.d30), ''],
     ['Typical range', `${formatPaired(m.baselineP25, pairedMetric.baselineP25, false)} – ${formatPaired(m.baselineP75, pairedMetric.baselineP75, false)}${pairedUnitSpaced}`, '25th–75th percentile'],
-    ['Chart samples', `${Math.max(series.length, pairedSeries.length)}d`, rangeDef.coverageSuffix],
+    ['Chart samples', `${chartSampleCount}d`, rangeDef.coverageSuffix],
   ] : [
     ['Latest',   `${formatV(m.latest)}${unitSpaced}`, m.latestDate ? shortDate(m.latestDate) : ''],
     ['Baseline (90d)', `${formatV(m.baseline)}${unitSpaced}`, 'median'],

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -64,9 +64,12 @@ let _detailOp = 0;
 
 export async function openWearableDetail(metricId, opts = {}) {
   const op = ++_detailOp;
-  const canon = canonicalMetric(metricId);
   const summary = state.importedData?.wearableSummary;
-  const m = summary?.metrics?.[metricId];
+  const normalizedMetricId = metricId === 'bp_diastolic' && summary?.metrics?.bp_systolic
+    ? 'bp_systolic'
+    : metricId;
+  const canon = canonicalMetric(normalizedMetricId);
+  const m = summary?.metrics?.[normalizedMetricId];
   if (!canon || !m) {
     showNotification?.('No data for this metric yet — run a sync first', 'info');
     return;
@@ -88,32 +91,38 @@ export async function openWearableDetail(metricId, opts = {}) {
   }
 
   let rows = [];
+  let pairedRows = [];
+  const isBloodPressureDetail = normalizedMetricId === 'bp_systolic';
+  const pairedMetricId = isBloodPressureDetail ? 'bp_diastolic' : null;
+  const pairedMetric = pairedMetricId ? summary?.metrics?.[pairedMetricId] : null;
   try {
     rows = await getDailyRange(profileId, m.primarySource, startDate, endDate);
+    if (pairedMetricId && pairedMetric?.primarySource && pairedMetric.primarySource !== m.primarySource) {
+      pairedRows = await getDailyRange(profileId, pairedMetric.primarySource, startDate, endDate);
+    } else {
+      pairedRows = rows;
+    }
   } catch (e) {
     showNotification?.(`Couldn't read local history: ${e.message}`, 'error', 4000);
     return;
   }
   if (op !== _detailOp) return;
 
-  const isBloodPressureDetail = metricId === 'bp_systolic';
-  const pairedMetricId = isBloodPressureDetail ? 'bp_diastolic' : null;
-  const pairedMetric = pairedMetricId ? summary?.metrics?.[pairedMetricId] : null;
   const series = rows
-    .map(r => ({ date: r.date, v: r[metricId] }))
-    .filter(p => isMetricValueMeaningful(metricId, p.v))
+    .map(r => ({ date: r.date, v: r[normalizedMetricId] }))
+    .filter(p => isMetricValueMeaningful(normalizedMetricId, p.v))
     .sort((a, b) => a.date.localeCompare(b.date));
-  const pairedSeries = pairedMetricId ? rows
+  const pairedSeries = pairedMetricId ? pairedRows
     .map(r => ({ date: r.date, v: r[pairedMetricId] }))
     .filter(p => isMetricValueMeaningful(pairedMetricId, p.v))
     .sort((a, b) => a.date.localeCompare(b.date)) : [];
 
-  const allZeroActivity = metricId === 'activity_score'
+  const allZeroActivity = normalizedMetricId === 'activity_score'
     && series.length > 0
     && series.every(p => p.v === 0);
 
   let manualRows = [];
-  if (MANUAL_METRICS.includes(metricId)) {
+  if (MANUAL_METRICS.includes(normalizedMetricId)) {
     try {
       manualRows = await getDailyRange(profileId, 'manual', WEARABLE_ALL_HISTORY_START_DATE, endDate);
     } catch {
@@ -125,12 +134,12 @@ export async function openWearableDetail(metricId, opts = {}) {
   const manualEntries = manualRows
     .map(r => ({
       date: r.date,
-      v: r[metricId],
+      v: r[normalizedMetricId],
       pairedV: pairedMetricId ? r[pairedMetricId] : undefined,
       tags: r.tags,
       note: r.note,
     }))
-    .filter(p => isMetricValueMeaningful(metricId, p.v) || (pairedMetricId && isMetricValueMeaningful(pairedMetricId, p.pairedV)))
+    .filter(p => isMetricValueMeaningful(normalizedMetricId, p.v) || (pairedMetricId && isMetricValueMeaningful(pairedMetricId, p.pairedV)))
     .sort((a, b) => b.date.localeCompare(a.date));
   const manualChartEntries = m.primarySource === 'manual'
     ? []
@@ -147,7 +156,7 @@ export async function openWearableDetail(metricId, opts = {}) {
     delete state.chartInstances['modal'];
   }
 
-  modal.innerHTML = buildWearableDetailHtml(canon, m, series, metricId, manualEntries, {
+  modal.innerHTML = buildWearableDetailHtml(canon, m, series, normalizedMetricId, manualEntries, {
     allZeroActivity,
     rangeKey,
     pairedMetric,
@@ -321,8 +330,27 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
     const diaText = isMetricValueMeaningful('bp_diastolic', dia) ? formatV(dia) : '—';
     return `${sysText}/${diaText}${includeUnit ? pairedUnitSpaced : ''}`;
   };
+  const latestPairedReading = (() => {
+    if (!pairedMetric) return null;
+    const diastolicByDate = new Map(pairedSeries.map(p => [p.date, p.v]));
+    for (const point of [...series].sort((a, b) => b.date.localeCompare(a.date))) {
+      const dia = diastolicByDate.get(point.date);
+      if (isMetricValueMeaningful('bp_systolic', point.v) && isMetricValueMeaningful('bp_diastolic', dia)) {
+        return { date: point.date, sys: point.v, dia };
+      }
+    }
+    return null;
+  })();
+  const latestBpValue = latestPairedReading
+    ? formatPaired(latestPairedReading.sys, latestPairedReading.dia)
+    : `${formatPaired(m.latest, pairedMetric?.latest)}${m.latestDate && pairedMetric?.latestDate && m.latestDate !== pairedMetric.latestDate ? ' split dates' : ''}`;
+  const latestBpDate = latestPairedReading
+    ? shortDate(latestPairedReading.date)
+    : (m.latestDate && pairedMetric?.latestDate && m.latestDate !== pairedMetric.latestDate
+        ? `sys ${shortDate(m.latestDate)} · dia ${shortDate(pairedMetric.latestDate)}`
+        : (m.latestDate || pairedMetric?.latestDate ? shortDate(m.latestDate || pairedMetric?.latestDate) : ''));
   const baseStats = pairedMetric ? [
-    ['Latest',   formatPaired(m.latest, pairedMetric.latest), m.latestDate || pairedMetric.latestDate ? shortDate(m.latestDate || pairedMetric.latestDate) : ''],
+    ['Latest',   latestBpValue, latestBpDate],
     ['Baseline (90d)', formatPaired(m.baseline, pairedMetric.baseline), 'median'],
     ['7-day avg', formatPaired(m.rolling?.d7, pairedMetric.rolling?.d7), ''],
     ['30-day avg', formatPaired(m.rolling?.d30, pairedMetric.rolling?.d30), ''],

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -172,6 +172,7 @@ export async function openWearableDetail(metricId, opts = {}) {
     pairedSeries,
     pairedMetricId,
     chartSampleCount,
+    manualChartSampleCount: manualChartEntries.length,
   });
   openModalOverlay(overlay);
 
@@ -427,9 +428,10 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
       ${sub ? `<div class="wearable-detail-stat-sub">${escapeHTML(sub)}</div>` : ''}
     </div>`).join('');
 
+  const hasManualChartSamples = Number(opts.manualChartSampleCount || 0) > 0;
   const emptyHint = opts.allZeroActivity
     ? `<div class="wearable-detail-empty">Every day shows 0 — Oura suppresses the Activity composite score while Rest Mode is on. Check the <b>Steps</b> card for raw movement data, or disable Rest Mode in the Oura app.</div>`
-    : series.length === 0 && pairedSeries.length === 0
+    : series.length === 0 && pairedSeries.length === 0 && !hasManualChartSamples
       ? manualEntries.length > 0
         ? `<div class="wearable-detail-empty">No chart samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Manual readings are listed below${m.primarySource === 'manual' && rangeDef.days != null ? '; switch to All to chart older manual readings' : ''}.</div>`
         : `<div class="wearable-detail-empty">No daily samples for this metric in ${escapeHTML(rangeDef.emptyWindow)}. Either your wearable doesn't share this metric, the feature is off on your device, or you didn't wear it. Try Sync now, or reconnect to refresh permissions.</div>`
@@ -438,7 +440,14 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
   const connectedSources = state.importedData?.wearableSummary?.sources || {};
   const showSwapButton = Object.keys(connectedSources).length > 1 && !!adapter;
   const swapButton = showSwapButton
-    ? `<button type="button" class="wearable-source-badge wearable-source-badge-btn wearable-modal-source-swap" ${wearableActionAttrs('choose-source', { metric: metricId })} title="Switch source for this metric">via ${escapeHTML(adapter.displayName)} · swap</button>`
+    ? pairedMetric
+      ? (() => {
+          const pairedAdapter = adapterById(pairedMetric.primarySource);
+          const pairedSourceName = pairedAdapter?.displayName || pairedMetric.primarySource || 'Diastolic source';
+          return `<button type="button" class="wearable-source-badge wearable-source-badge-btn wearable-modal-source-swap" ${wearableActionAttrs('choose-source', { metric: 'bp_systolic' })} title="Switch systolic source">sys via ${escapeHTML(sourceName)} · swap</button>
+            <button type="button" class="wearable-source-badge wearable-source-badge-btn wearable-modal-source-swap" ${wearableActionAttrs('choose-source', { metric: 'bp_diastolic' })} title="Switch diastolic source">dia via ${escapeHTML(pairedSourceName)} · swap</button>`;
+        })()
+      : `<button type="button" class="wearable-source-badge wearable-source-badge-btn wearable-modal-source-swap" ${wearableActionAttrs('choose-source', { metric: metricId })} title="Switch source for this metric">via ${escapeHTML(adapter.displayName)} · swap</button>`
     : '';
 
   const emfSleepHint = _buildEMFSleepHint(metricId, m);

--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -343,7 +343,7 @@ function buildWearableDetailHtml(canon, m, series, metricId, manualEntries = [],
   })();
   const latestBpValue = latestPairedReading
     ? formatPaired(latestPairedReading.sys, latestPairedReading.dia)
-    : `${formatPaired(m.latest, pairedMetric?.latest)}${m.latestDate && pairedMetric?.latestDate && m.latestDate !== pairedMetric.latestDate ? ' split dates' : ''}`;
+    : formatPaired(m.latest, pairedMetric?.latest);
   const latestBpDate = latestPairedReading
     ? shortDate(latestPairedReading.date)
     : (m.latestDate && pairedMetric?.latestDate && m.latestDate !== pairedMetric.latestDate

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 1088,
-  "largeJsFilesOver800Lines": 28,
+  "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -326,6 +326,7 @@ const APP_SHELL = [
   // Wearables (added v1.22.0)
   '/js/wearable-adapters.js',
   '/js/wearables.js',
+  '/js/wearables-bp-detail-chart.js',
   '/js/wearables-detail-modal.js',
   '/js/wearables-formatters.js',
   '/js/wearables-manual-form-ui.js',

--- a/tests/playwright/custom-personality-dom.spec.js
+++ b/tests/playwright/custom-personality-dom.spec.js
@@ -188,6 +188,9 @@ test('custom personality generator fills prompt and preserves selected custom te
       export const CHAT_PERSONALITIES = [
         { id: 'default', name: 'AI Lab Analyst', icon: 'A', promptAddition: null },
       ];
+      export const COUNTRY_LATITUDES = {};
+      export const LATITUDE_BANDS = {};
+      export const COUNTRY_CENTROIDS = {};
     `,
   }));
   await page.route('**/js/utils.js*', route => route.fulfill({
@@ -203,8 +206,30 @@ test('custom personality generator fills prompt and preserves selected custom te
         })[ch]);
       }
       export const escapeAttr = escapeHTML;
+      export function hashString(value) {
+        let hash = 0;
+        for (const ch of String(value ?? '')) hash = ((hash << 5) - hash + ch.charCodeAt(0)) | 0;
+        return String(Math.abs(hash));
+      }
+      export function formatValue(value) { return String(value ?? ''); }
+      export function formatDate(value) { return String(value ?? ''); }
+      export function queryRequired(root, selector) { const el = root.querySelector(selector); if (!el) throw new Error(selector); return el; }
+      export function safeMarkerId(value) { return String(value ?? '').replace(/[^a-zA-Z0-9_.-]/g, '_'); }
+      export function sanitizeMarkerKey(value) { return String(value ?? '').replace(/[^a-zA-Z0-9_.-]/g, ''); }
+      export function hasDirtyFormFields() { return false; }
+      export function bindDetachedModalSyncRefresh() {}
+      export function bindModalSyncRefresh() {}
+      export function getStatus() { return 'normal'; }
+      export function getRangePosition() { return 0.5; }
+      export function getTrend() { return 'flat'; }
       export function showNotification() {}
       export async function showConfirmDialog() { return true; }
+      export async function showPromptDialog() { return ''; }
+      export async function showChoiceDialog() { return null; }
+      export function isPIIReviewEnabled() { return false; }
+      export function bindDetailModalSyncRefresh() {}
+      export function linearRegression() { return { slope: 0, intercept: 0, r2: 0 }; }
+      export function isDebugMode() { return false; }
     `,
   }));
 

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -15,6 +15,9 @@ test('Context hub opens from Personalize AI alias and dismisses', async ({ page 
   await expect(overlay.locator('.ai-picker-card')).toHaveCount(2);
   await expect(overlay).toContainText('Context');
   await expect(overlay).toContainText('Personalize how AI answers');
+  await expect(overlay).toContainText('Interpretive Lens');
+  await expect(overlay.locator('.ai-picker-kicker')).toHaveCount(2);
+  await expect(overlay.locator('.ai-picker-icon')).toHaveCount(0);
   await expect(overlay).toContainText('Knowledge Base');
   await expect(overlay).not.toContainText('DNA Data');
   await expect(overlay).not.toContainText('Protect your data');

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -34,6 +34,8 @@ test('chat header shows clickable green AI Context status chip', async ({ page }
     const { state } = await import('/js/state.js');
     const { openChatPanel } = await import('/js/chat-panel.js');
     const chat = await import('/js/chat-personalities.js');
+    localStorage.removeItem('labcharts-ai-paused');
+    localStorage.setItem('labcharts-ai-provider', 'ollama');
     localStorage.removeItem('labcharts-lens-config');
     localStorage.removeItem('labcharts-lens-local-count');
     state.importedData.interpretiveLens = 'Functional endocrinology';
@@ -62,6 +64,8 @@ test('chat header shows pending KB state when Knowledge Base is enabled but empt
     const { saveLensConfig } = await import('/js/lens.js');
     const { openChatPanel } = await import('/js/chat-panel.js');
     const chat = await import('/js/chat-personalities.js');
+    localStorage.removeItem('labcharts-ai-paused');
+    localStorage.setItem('labcharts-ai-provider', 'ollama');
     localStorage.removeItem('labcharts-lens-local-count');
     state.importedData.interpretiveLens = '';
     saveLensConfig({ backend: 'in-browser', enabled: true, name: 'Research Notes', topK: 5, multiQuery: true });
@@ -89,6 +93,8 @@ test('clearing Interpretive Lens immediately clears chat header context chip', a
     const { state } = await import('/js/state.js');
     const { openChatPanel } = await import('/js/chat-panel.js');
     const chat = await import('/js/chat-personalities.js');
+    localStorage.removeItem('labcharts-ai-paused');
+    localStorage.setItem('labcharts-ai-provider', 'ollama');
     localStorage.removeItem('labcharts-lens-config');
     localStorage.removeItem('labcharts-lens-local-count');
     state.importedData.interpretiveLens = 'Functional endocrinology';
@@ -114,4 +120,23 @@ test('clearing Interpretive Lens immediately clears chat header context chip', a
   await page.evaluate(() => {
     if (document.querySelector('.chat-context-status:not([hidden])')) throw new Error('Context chip stayed visible after clearing Lens');
   });
+});
+
+test('chat header hides AI Context status chip when no AI provider is configured', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const { openChatPanel } = await import('/js/chat-panel.js');
+    const chat = await import('/js/chat-personalities.js');
+    localStorage.removeItem('labcharts-ai-provider');
+    localStorage.removeItem('labcharts-ai-paused');
+    localStorage.removeItem('labcharts-lens-config');
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = 'Functional endocrinology';
+    await openChatPanel();
+    chat.updateChatHeaderModel();
+  });
+
+  await expect(page.locator('.chat-context-status')).toBeHidden();
 });

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -23,3 +23,30 @@ test('Context hub opens from Personalize AI alias and dismisses', async ({ page 
   await overlay.locator('#context-hub-cancel').click();
   await expect(overlay).not.toHaveClass(/show/);
 });
+
+test('chat header shows clickable green AI Context status chip', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const { openChatPanel } = await import('/js/chat-panel.js');
+    const chat = await import('/js/chat-personalities.js');
+    localStorage.removeItem('labcharts-lens-config');
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = 'Functional endocrinology';
+    await openChatPanel();
+    chat.updateChatHeaderModel();
+  });
+
+  const chip = page.locator('.chat-context-status');
+  await expect(chip).toBeVisible();
+  await expect(chip).toContainText('AI Context: Lens');
+  await expect(chip.locator('.chat-context-dot')).toBeVisible();
+  await expect(chip).toHaveAttribute('aria-label', /Click to manage Context/);
+
+  await chip.evaluate(el => el.click());
+  const overlay = page.locator('#context-hub-overlay');
+  await expect(overlay).toHaveClass(/show/);
+  await expect(overlay).toContainText('Personalize how AI answers');
+  await expect(overlay).toContainText('Interpretive Lens is enabled');
+});

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -54,6 +54,34 @@ test('chat header shows clickable green AI Context status chip', async ({ page }
   await expect(overlay).toContainText('Interpretive Lens is enabled');
 });
 
+test('chat header shows pending KB state when Knowledge Base is enabled but empty', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const { saveLensConfig } = await import('/js/lens.js');
+    const { openChatPanel } = await import('/js/chat-panel.js');
+    const chat = await import('/js/chat-personalities.js');
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = '';
+    saveLensConfig({ backend: 'in-browser', enabled: true, name: 'Research Notes', topK: 5, multiQuery: true });
+    await openChatPanel();
+    chat.updateChatHeaderModel();
+  });
+
+  const chip = page.locator('.chat-context-status');
+  await expect(chip).toBeVisible();
+  await expect(chip).toContainText('AI Context: KB empty');
+  await expect(chip).toHaveClass(/chat-context-status-pending/);
+  await expect(chip).toHaveAttribute('aria-label', /no library is indexed yet/);
+
+  await chip.evaluate(el => el.click());
+  const overlay = page.locator('#context-hub-overlay');
+  await expect(overlay).toHaveClass(/show/);
+  await expect(overlay).toContainText('Knowledge Base is enabled, but no documents are indexed yet');
+  await expect(overlay).toContainText('Add documents');
+});
+
 test('clearing Interpretive Lens immediately clears chat header context chip', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -1,23 +1,25 @@
 import { expect, test } from './coverage-fixture.js';
 
-test('personalize AI picker opens and dismisses', async ({ page }) => {
+test('Context hub opens from Personalize AI alias and dismisses', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  await expect(page.locator('#ai-personalize-picker-overlay.show')).toHaveCount(0);
+  await expect(page.locator('#context-hub-overlay.show')).toHaveCount(0);
 
   await page.evaluate(async () => {
     const cards = await import('/js/context-cards.js');
     cards.openPersonalizeAIPicker();
   });
 
-  const overlay = page.locator('#ai-personalize-picker-overlay');
+  const overlay = page.locator('#context-hub-overlay');
   await expect(overlay).toHaveClass(/show/);
   await expect(overlay.locator('.ai-picker-card')).toHaveCount(2);
-  await expect(overlay).toContainText('Interpretive Lens');
+  await expect(overlay).toContainText('Context');
+  await expect(overlay).toContainText('Personalize how AI answers');
   await expect(overlay).toContainText('Knowledge Base');
   await expect(overlay).not.toContainText('DNA Data');
+  await expect(overlay).not.toContainText('Protect your data');
 
-  await expect(overlay.locator('#ai-personalize-picker-cancel')).toBeVisible();
-  await overlay.locator('#ai-personalize-picker-cancel').click();
+  await expect(overlay.locator('#context-hub-cancel')).toBeVisible();
+  await overlay.locator('#context-hub-cancel').click();
   await expect(overlay).not.toHaveClass(/show/);
 });

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -53,3 +53,37 @@ test('chat header shows clickable green AI Context status chip', async ({ page }
   await expect(overlay).toContainText('Personalize how AI answers');
   await expect(overlay).toContainText('Interpretive Lens is enabled');
 });
+
+test('clearing Interpretive Lens immediately clears chat header context chip', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  await page.evaluate(async () => {
+    const { state } = await import('/js/state.js');
+    const { openChatPanel } = await import('/js/chat-panel.js');
+    const chat = await import('/js/chat-personalities.js');
+    localStorage.removeItem('labcharts-lens-config');
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = 'Functional endocrinology';
+    await openChatPanel();
+    chat.updateChatHeaderModel();
+  });
+
+  const chip = page.locator('.chat-context-status');
+  await expect(chip).toBeVisible();
+  await expect(chip).toContainText('AI Context: Lens');
+
+  await chip.evaluate(el => el.click());
+  const contextOverlay = page.locator('#context-hub-overlay');
+  await expect(contextOverlay).toHaveClass(/show/);
+  await contextOverlay.locator('.ai-picker-card[data-pick="lens"]').click();
+
+  const editorOverlay = page.locator('#modal-overlay');
+  await expect(editorOverlay).toHaveClass(/show/);
+  await page.locator('[data-lifestyle-action="clear-interpretive-lens"]').evaluate(el => el.click());
+
+  await expect(editorOverlay).not.toHaveClass(/show/);
+  await expect(chip).toBeHidden();
+  await page.evaluate(() => {
+    if (document.querySelector('.chat-context-status:not([hidden])')) throw new Error('Context chip stayed visible after clearing Lens');
+  });
+});

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -33,6 +33,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     const origOpenEMF = window.openEMFAssessmentEditor;
     const origOpenReportBuilder = window.openReportBuilder;
     const origOpenKB = window.openKnowledgeBaseModal;
+    const origOpenContext = window.openContextModal;
     const origOpenCreateMarker = window.openCreateMarkerModal;
     const origOpenClientList = window.openClientList;
     const origIsGroupInAI = window.isGroupInAIContext;
@@ -79,6 +80,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       });
       window.openReportBuilder = () => calls.push(['open-report-builder']);
       window.openKnowledgeBaseModal = () => calls.push(['open-kb']);
+      window.openContextModal = () => calls.push(['open-context']);
       window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
       window.openClientList = () => calls.push(['open-client-list']);
       window.isGroupInAIContext = group => aiGroups.has(group);
@@ -119,7 +121,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       document.querySelector('#sidebar-nav .nav-item[data-category="emf"]')?.click();
       document.querySelector('#sidebar-nav .nav-item[data-category="light-env-assessment"]')?.click();
       document.querySelector('#sidebar-nav .nav-item[data-category="reports"]')?.click();
-      document.querySelector('#sidebar-nav .nav-item[data-category="knowledge"]')?.click();
+      document.querySelector('#sidebar-nav .nav-item[data-category="context"]')?.click();
       document.querySelector('#sidebar-nav .nav-item[data-category="custom-markers"]')?.click();
       document.querySelector('#sidebar-nav .sidebar-add-marker')?.click();
       document.querySelector('#profile-selector .profile-compact-btn')?.click();
@@ -138,7 +140,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
         utilitiesCallHandlers: calls.some(c => c[0] === 'open-emf')
           && calls.some(c => c[0] === 'open-light-env')
           && calls.some(c => c[0] === 'open-report-builder')
-          && calls.some(c => c[0] === 'open-kb')
+          && calls.some(c => c[0] === 'open-context')
           && calls.filter(c => c[0] === 'open-custom-marker').length >= 2
           && calls.some(c => c[0] === 'open-client-list'),
       };
@@ -151,6 +153,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       if (restoreNavActions) nav.configureNavActions(restoreNavActions);
       window.openReportBuilder = origOpenReportBuilder;
       window.openKnowledgeBaseModal = origOpenKB;
+      window.openContextModal = origOpenContext;
       window.openCreateMarkerModal = origOpenCreateMarker;
       window.openClientList = origOpenClientList;
       window.isGroupInAIContext = origIsGroupInAI;

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -98,7 +98,11 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
-assert('latest changelog documents AI context and BP detail fixes in user-readable terms',
+assert('latest changelog documents visible AI context status in user-readable terms',
+  /version:\s*'1\.10\.17'[\s\S]{0,900}AI Context is now hard to miss/.test(changelogSrc)
+    && /version:\s*'1\.10\.17'[\s\S]{0,900}green context chip/.test(changelogSrc)
+    && /version:\s*'1\.10\.17'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
+assert('previous changelog documents AI context and BP detail fixes in user-readable terms',
   /version:\s*'1\.10\.16'[\s\S]{0,1400}AI Context is easier to find/.test(changelogSrc)
     && /version:\s*'1\.10\.16'[\s\S]{0,1400}Blood pressure details now stay paired/.test(changelogSrc)
     && /version:\s*'1\.10\.16'[\s\S]{0,1400}Mixed-source BP data is safer/.test(changelogSrc)

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -98,7 +98,11 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
-assert('latest changelog documents visible AI context status in user-readable terms',
+assert('latest changelog documents empty Knowledge Base status in user-readable terms',
+  /version:\s*'1\.10\.23'[\s\S]{0,900}Empty Knowledge Base state is now visible/.test(changelogSrc)
+    && /version:\s*'1\.10\.23'[\s\S]{0,900}KB empty/.test(changelogSrc)
+    && /version:\s*'1\.10\.23'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
+assert('previous changelog documents visible AI context status in user-readable terms',
   /version:\s*'1\.10\.17'[\s\S]{0,900}AI Context is now hard to miss/.test(changelogSrc)
     && /version:\s*'1\.10\.17'[\s\S]{0,900}green context chip/.test(changelogSrc)
     && /version:\s*'1\.10\.17'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -98,19 +98,13 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
-assert('latest changelog documents empty Knowledge Base status in user-readable terms',
-  /version:\s*'1\.10\.23'[\s\S]{0,900}Empty Knowledge Base state is now visible/.test(changelogSrc)
-    && /version:\s*'1\.10\.23'[\s\S]{0,900}KB empty/.test(changelogSrc)
-    && /version:\s*'1\.10\.23'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
-assert('previous changelog documents visible AI context status in user-readable terms',
-  /version:\s*'1\.10\.17'[\s\S]{0,900}AI Context is now hard to miss/.test(changelogSrc)
-    && /version:\s*'1\.10\.17'[\s\S]{0,900}green context chip/.test(changelogSrc)
-    && /version:\s*'1\.10\.17'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
-assert('previous changelog documents AI context and BP detail fixes in user-readable terms',
-  /version:\s*'1\.10\.16'[\s\S]{0,1400}AI Context is easier to find/.test(changelogSrc)
-    && /version:\s*'1\.10\.16'[\s\S]{0,1400}Blood pressure details now stay paired/.test(changelogSrc)
-    && /version:\s*'1\.10\.16'[\s\S]{0,1400}Mixed-source BP data is safer/.test(changelogSrc)
-    && /version:\s*'1\.10\.16'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
+assert('context/BP changelog documents merged AI context, KB-empty, and BP fixes in user-readable terms',
+  /version:\s*'1\.10\.24'[\s\S]{0,1800}AI Context is easier to find/.test(changelogSrc)
+    && /version:\s*'1\.10\.24'[\s\S]{0,1800}clickable green context chip/.test(changelogSrc)
+    && /version:\s*'1\.10\.24'[\s\S]{0,1800}KB empty context chip/.test(changelogSrc)
+    && /version:\s*'1\.10\.24'[\s\S]{0,1800}Blood pressure details now stay paired/.test(changelogSrc)
+    && /version:\s*'1\.10\.24'[\s\S]{0,1800}Mixed-source BP data is safer/.test(changelogSrc)
+    && /version:\s*'1\.10\.24'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
 assert('previous changelog documents PPQ Private TEE in user-readable terms',
   /version:\s*'1\.10\.8'[\s\S]{0,900}PPQ Private TEE Mode/.test(changelogSrc)
     && /version:\s*'1\.10\.8'[\s\S]{0,900}encrypts prompts in your browser/.test(changelogSrc)

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -98,11 +98,11 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
-assert('latest changelog documents Routstr wallet upgrade in user-readable terms',
-  /version:\s*'1\.10\.15'[\s\S]{0,1200}Routstr wallet upgrades are safer/.test(changelogSrc)
-    && /version:\s*'1\.10\.15'[\s\S]{0,1200}Funding and refund recovery is better protected/.test(changelogSrc)
-    && /version:\s*'1\.10\.15'[\s\S]{0,1200}wallet engine was refreshed/.test(changelogSrc)
-    && /version:\s*'1\.10\.15'[\s\S]{0,400}forceShow:\s*true/.test(changelogSrc));
+assert('latest changelog documents AI context and BP detail fixes in user-readable terms',
+  /version:\s*'1\.10\.16'[\s\S]{0,1400}AI Context is easier to find/.test(changelogSrc)
+    && /version:\s*'1\.10\.16'[\s\S]{0,1400}Blood pressure details now stay paired/.test(changelogSrc)
+    && /version:\s*'1\.10\.16'[\s\S]{0,1400}Mixed-source BP data is safer/.test(changelogSrc)
+    && /version:\s*'1\.10\.16'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
 assert('previous changelog documents PPQ Private TEE in user-readable terms',
   /version:\s*'1\.10\.8'[\s\S]{0,900}PPQ Private TEE Mode/.test(changelogSrc)
     && /version:\s*'1\.10\.8'[\s\S]{0,900}encrypts prompts in your browser/.test(changelogSrc)

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -148,7 +148,25 @@ try {
       html.includes('data-dashboard-ai-action="open-knowledge-base"'));
   }
 
-  // Section 5 (picker open/dismiss — live DOM) lives in
+  // ─── 5. Profile Context surface actually mounts the section ───
+  // The isolated renderer can pass while production UI drops the call site.
+  {
+    localStorage.removeItem('labcharts-lens-config');
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = 'Functional endocrinology';
+    const html = cards.renderProfileContextCards();
+    assert('Profile Context mounts set Interpretive Lens row',
+      /lens-section-label[^>]*>Interpretive Lens/.test(html));
+    assert('Profile Context row opens the lens editor',
+      html.includes('data-dashboard-ai-action="open-interpretive-lens"'));
+
+    state.importedData.interpretiveLens = '';
+    const htmlEmpty = cards.renderProfileContextCards();
+    assert('Profile Context mounts Personalize-AI CTA when lens is unset',
+      htmlEmpty.includes('data-dashboard-ai-action="open-personalize-ai-picker"'));
+  }
+
+  // Section 5b (picker open/dismiss — live DOM) lives in
   // tests/playwright/dashboard-knowledge-base.spec.js.
 
   // ─── 6. Window exports ───

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -127,6 +127,22 @@ try {
       /Set an interpretive lens/i.test(html));
   }
 
+  // ─── 3b. KB toggle enabled but no indexed library → honest setup state ───
+  {
+    lens.saveLensConfig({
+      backend: 'in-browser', enabled: true, name: 'Research Notes', topK: 5, multiQuery: true,
+    });
+    localStorage.removeItem('labcharts-lens-local-count');
+    state.importedData.interpretiveLens = '';
+    const html = cards.renderInterpretiveLensSection();
+    assert('KB enabled-empty: KB row present as setup state',
+      /lens-section-label[^>]*>Knowledge Base/.test(html));
+    assert('KB enabled-empty: row says no documents indexed yet',
+      /enabled, no documents indexed yet/.test(html));
+    assert('KB enabled-empty: CTA still opens KB modal to finish setup',
+      html.includes('dashboard-cta') && html.includes('data-dashboard-ai-action="open-knowledge-base"'));
+  }
+
   // ─── 4. Both Lens + KB set → no AI-personalize CTA ───
   {
     lens.saveLensConfig({

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -215,9 +215,12 @@ try {
     const appEventsSrc = fs.readFileSync('js/app-event-listeners.js', 'utf8');
     assert('global modal focus trap includes Context hub overlay id',
       appEventsSrc.includes('"context-hub-overlay"') && appEventsSrc.includes('"ai-personalize-picker-overlay"'));
+    const lensSrc = fs.readFileSync('js/lens.js', 'utf8');
+    assert('saveLensKey refreshes chat header after external KB key cache updates',
+      /export\s+async\s+function\s+saveLensKey[\s\S]*updateKeyCache\(SECRET_KEY, key\)[\s\S]*updateChatHeaderModel\?\.\(\)/.test(lensSrc));
   }
 
-  // ─── 9. renderKnowledgeBaseSection still empty when not configured ───
+  // ─── 7. renderKnowledgeBaseSection still empty when not configured ───
   {
     localStorage.removeItem('labcharts-lens-config');
     localStorage.removeItem('labcharts-lens-local-count');

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -16,6 +16,7 @@
 // lives in tests/playwright/dashboard-knowledge-base.spec.js.
 
 import './_node-shim.js';
+import fs from 'fs';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -203,7 +204,20 @@ try {
       typeof window.triggerDNAFilePicker === 'function');
   }
 
-  // ─── 7. renderKnowledgeBaseSection still empty when not configured ───
+  // ─── 8. Current-head Greptile regressions ───
+  {
+    const chatSrc = fs.readFileSync('js/chat-personalities.js', 'utf8');
+    assert('chat header hides AI Context chip when no provider is configured',
+      /function updateChatContextStatus\(\)[\s\S]*?if \(!hasAIProvider\(\)\) \{[\s\S]*?status\.hidden = true;[\s\S]*?return;[\s\S]*?const contextState/.test(chatSrc));
+    assert('chat header clears model before refreshing hidden context state in no-provider path',
+      /if \(!hasAIProvider\(\)\) \{ el\.textContent = ''; updateChatContextStatus\(\); return; \}/.test(chatSrc));
+
+    const appEventsSrc = fs.readFileSync('js/app-event-listeners.js', 'utf8');
+    assert('global modal focus trap includes Context hub overlay id',
+      appEventsSrc.includes('"context-hub-overlay"') && appEventsSrc.includes('"ai-personalize-picker-overlay"'));
+  }
+
+  // ─── 9. renderKnowledgeBaseSection still empty when not configured ───
   {
     localStorage.removeItem('labcharts-lens-config');
     localStorage.removeItem('labcharts-lens-local-count');

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// test-dashboard-knowledge-base.js — KB row + Personalize-AI CTA on the dashboard
+// test-dashboard-knowledge-base.js — Context hub rows and Personalize-AI CTA
 //
 // UX contract (v1.3.23):
 //   - Interpretive Lens row → ONLY when set
@@ -12,7 +12,7 @@
 //
 // Run: node tests/test-dashboard-knowledge-base.js  (or via npm test)
 //
-// Section 5 (picker open/dismiss — needs a live DOM overlay + click events)
+// Section 5 (Context hub open/dismiss — needs a live DOM overlay + click events)
 // lives in tests/playwright/dashboard-knowledge-base.spec.js.
 
 import './_node-shim.js';
@@ -148,22 +148,27 @@ try {
       html.includes('data-dashboard-ai-action="open-knowledge-base"'));
   }
 
-  // ─── 5. Profile Context surface actually mounts the section ───
-  // The isolated renderer can pass while production UI drops the call site.
+  // ─── 5. Profile Context stays separate from AI grounding controls ───
   {
     localStorage.removeItem('labcharts-lens-config');
     localStorage.removeItem('labcharts-lens-local-count');
     state.importedData.interpretiveLens = 'Functional endocrinology';
     const html = cards.renderProfileContextCards();
-    assert('Profile Context mounts set Interpretive Lens row',
-      /lens-section-label[^>]*>Interpretive Lens/.test(html));
-    assert('Profile Context row opens the lens editor',
-      html.includes('data-dashboard-ai-action="open-interpretive-lens"'));
+    assert('Profile Context does not mount Interpretive Lens row',
+      !/lens-section-label[^>]*>Interpretive Lens/.test(html));
+    assert('Profile Context does not mount Knowledge Base row',
+      !/lens-section-label[^>]*>Knowledge Base/.test(html));
+    assert('Profile Context does not mount AI grounding actions',
+      !html.includes('data-dashboard-ai-action="open-interpretive-lens"') &&
+      !html.includes('data-dashboard-ai-action="open-knowledge-base"'));
 
     state.importedData.interpretiveLens = '';
     const htmlEmpty = cards.renderProfileContextCards();
-    assert('Profile Context mounts Personalize-AI CTA when lens is unset',
-      htmlEmpty.includes('data-dashboard-ai-action="open-personalize-ai-picker"'));
+    assert('Profile Context does not mount Personalize-AI CTA when lens is unset',
+      !htmlEmpty.includes('data-dashboard-ai-action="open-personalize-ai-picker"'));
+    assert('Profile Context does not mount Protect Data CTA',
+      !/Protect your data/.test(htmlEmpty) &&
+      !htmlEmpty.includes('data-dashboard-ai-action="open-data-protection-picker"'));
   }
 
   // Section 5b (picker open/dismiss — live DOM) lives in
@@ -171,6 +176,8 @@ try {
 
   // ─── 6. Window exports ───
   {
+    assert('window.openContextModal exists',
+      typeof window.openContextModal === 'function');
     assert('window.openPersonalizeAIPicker exists',
       typeof window.openPersonalizeAIPicker === 'function');
     assert('window.openKnowledgeBaseModal exists',

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -164,27 +164,24 @@ try {
       html.includes('data-dashboard-ai-action="open-knowledge-base"'));
   }
 
-  // ─── 5. Profile Context stays separate from AI grounding controls ───
+  // ─── 5. Profile Context includes the Context entry surface without duplicating rows ───
   {
     localStorage.removeItem('labcharts-lens-config');
     localStorage.removeItem('labcharts-lens-local-count');
     state.importedData.interpretiveLens = 'Functional endocrinology';
     const html = cards.renderProfileContextCards();
-    assert('Profile Context does not mount Interpretive Lens row',
-      !/lens-section-label[^>]*>Interpretive Lens/.test(html));
-    assert('Profile Context does not mount Knowledge Base row',
-      !/lens-section-label[^>]*>Knowledge Base/.test(html));
-    assert('Profile Context does not mount AI grounding actions',
-      !html.includes('data-dashboard-ai-action="open-interpretive-lens"') &&
-      !html.includes('data-dashboard-ai-action="open-knowledge-base"'));
+    assert('Profile Context mounts Interpretive Lens row via production renderer',
+      /lens-section-label[^>]*>Interpretive Lens/.test(html));
+    assert('Profile Context mounts AI grounding action surface',
+      html.includes('data-dashboard-ai-action="open-interpretive-lens"'));
+    assert('Profile Context keeps Data Protection CTA available',
+      /Protect your data|Enable encryption|Sync to other devices|Set up auto-backup/.test(html) &&
+      /data-dashboard-ai-action="(open-data-protection-picker|enable-encryption|setup-sync|setup-backup)"/.test(html));
 
     state.importedData.interpretiveLens = '';
     const htmlEmpty = cards.renderProfileContextCards();
-    assert('Profile Context does not mount Personalize-AI CTA when lens is unset',
-      !htmlEmpty.includes('data-dashboard-ai-action="open-personalize-ai-picker"'));
-    assert('Profile Context does not mount Protect Data CTA',
-      !/Protect your data/.test(htmlEmpty) &&
-      !htmlEmpty.includes('data-dashboard-ai-action="open-data-protection-picker"'));
+    assert('Profile Context mounts Personalize-AI CTA when lens is unset',
+      htmlEmpty.includes('data-dashboard-ai-action="open-personalize-ai-picker"'));
   }
 
   // Section 5b (picker open/dismiss — live DOM) lives in

--- a/tests/test-nav-delegated-actions.js
+++ b/tests/test-nav-delegated-actions.js
@@ -43,6 +43,7 @@ assert('nav.js installs idempotent click and input delegates',
   'open-emf-assessment',
   'open-light-assessment',
   'open-report-builder',
+  'open-context',
   'open-knowledge-base',
   'open-custom-marker',
   'toggle-group',
@@ -51,6 +52,12 @@ assert('nav.js installs idempotent click and input delegates',
 ].forEach(action => {
   assert(`nav action ${action} is handled`, navSrc.includes(`action === '${action}'`));
 });
+
+assert('Manage section exposes Context instead of standalone Knowledge Base',
+  navSrc.includes('data-category="context"') &&
+    navSrc.includes("_navActionAttrs('open-context')") &&
+    navSrc.includes('<span class="nav-item-label">Context</span>') &&
+    !navSrc.includes('data-category="knowledge"'));
 
 assert('nav delegates are scoped to sidebar/profile surfaces',
   navSrc.includes("el.closest('#sidebar-nav, #profile-selector')"));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -148,7 +148,7 @@ return (async function() {
   assert('Sidebar does not duplicate Labs with an All biomarkers category shortcut',
     !sidebar.querySelector('.nav-item[data-category="all"]') && !sidebarText.includes('All biomarkers'));
   assert('Sidebar separates analysis tools from management modals',
-    sidebarText.includes('Analysis tools') && sidebarText.includes('Manage') && sidebarText.includes('Reports') && sidebarText.includes('Knowledge Base'));
+    sidebarText.includes('Analysis tools') && sidebarText.includes('Manage') && sidebarText.includes('Reports') && sidebarText.includes('Context'));
   const analysisIndex = sidebarText.indexOf('Analysis tools');
   const manageIndex = sidebarText.indexOf('Manage');
   const labCategoriesIndex = sidebarText.indexOf('Lab categories');
@@ -160,6 +160,12 @@ return (async function() {
     !!sidebar.querySelector('.nav-item[data-category="reports"]') &&
       manageIndex > -1 && reportIndex > -1 && labCategoriesIndex > -1 &&
       manageIndex < reportIndex && reportIndex < labCategoriesIndex);
+  const contextIndex = sidebarText.indexOf('Context');
+  assert('Sidebar exposes Context as the AI grounding management action',
+    !!sidebar.querySelector('.nav-item[data-category="context"]') &&
+      !sidebar.querySelector('.nav-item[data-category="knowledge"]') &&
+      manageIndex > -1 && contextIndex > -1 && labCategoriesIndex > -1 &&
+      manageIndex < contextIndex && contextIndex < labCategoriesIndex);
   const emfIndex = sidebarText.indexOf('EMF assessment');
   assert('Sidebar exposes EMF assessment as an analysis tool',
     !!sidebar.querySelector('.nav-item[data-category="emf"]') &&

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -190,12 +190,42 @@ return (async function() {
     !/split dates/.test(mixedModalText), mixedModalText);
   assert('BP chart sample count uses unique rendered dates across paired sources',
     /Chart samples\s+3d/.test(mixedModalText), mixedModalText);
+  const bpSwapTargets = Array.from(document.querySelectorAll('#detail-modal .wearable-modal-source-swap'))
+    .map(btn => btn.getAttribute('data-wearable-metric'));
+  assert('BP modal exposes separate systolic and diastolic source swap targets',
+    bpSwapTargets.includes('bp_systolic') && bpSwapTargets.includes('bp_diastolic'), bpSwapTargets.join('|'));
   window.closeModal();
+
   await window.openWearableDetail('bp_diastolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Systolic/.test(d?.label || '')));
   assert('Opening bp_diastolic normalizes to the paired BP detail view',
     (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /^Systolic/.test(l)) &&
     /124\/80/.test(document.getElementById('detail-modal')?.textContent || ''));
+  window.closeModal();
+
+  await store.clearSource(TEST_PROFILE, 'manual');
+  await store.clearSource(TEST_PROFILE, 'withings');
+  window._labState.importedData.wearableSummary = {
+    sources: {
+      withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 0 },
+      manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
+    },
+    metrics: {
+      bp_systolic: { primarySource: 'withings', latest: 121, latestDate: '2026-06-22', baseline: 121, baselineP25: 119, baselineP75: 123, rolling: { d7: 121, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [] },
+      bp_diastolic: { primarySource: 'withings', latest: 79, latestDate: '2026-06-22', baseline: 79, baselineP25: 77, baselineP75: 81, rolling: { d7: 79, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [] },
+    },
+  };
+  await store.upsertDailyBatch(TEST_PROFILE, [
+    { source: 'manual', date: '2026-06-21', bp_systolic: 122, bp_diastolic: 80 },
+    { source: 'manual', date: '2026-06-22', bp_systolic: 121, bp_diastolic: 79 },
+  ]);
+  await window.openWearableDetail('bp_systolic');
+  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Manual systolic$/.test(d?.label || '')));
+  const manualOnlyText = document.getElementById('detail-modal')?.textContent || '';
+  assert('BP modal hides empty chart hint when manual readings are charted',
+    !/No chart samples for this metric/.test(manualOnlyText), manualOnlyText);
+  assert('BP manual-only fallback chart renders manual sys/dia points',
+    (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /^Manual diastolic$/.test(l)));
   window.closeModal();
   delete window._labState.importedData.wearableSummary;
 

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -159,6 +159,8 @@ return (async function() {
     !!document.querySelector('#detail-modal .wearable-manual-entry-val')?.textContent?.includes('120/80'));
   window.closeModal();
 
+  await store.clearSource(TEST_PROFILE, 'manual');
+  await store.clearSource(TEST_PROFILE, 'withings');
   window._labState.importedData.wearableSummary = {
     sources: {
       withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
@@ -173,6 +175,7 @@ return (async function() {
     { source: 'withings', date: '2026-06-20', bp_systolic: 124 },
     { source: 'withings', date: '2026-06-24', bp_systolic: 130 },
     { source: 'manual', date: '2026-06-20', bp_diastolic: 80 },
+    { source: 'manual', date: '2026-06-22', bp_diastolic: 78 },
   ]);
   await window.openWearableDetail('bp_systolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic/.test(d?.label || '')));
@@ -186,6 +189,8 @@ return (async function() {
     /Latest\s+124\/80 mmHg/.test(mixedModalText) && !/Latest\s+130\/80 mmHg/.test(mixedModalText), mixedModalText);
   assert('BP latest row never leaks split-date debug text into visible value',
     !/split dates/.test(mixedModalText), mixedModalText);
+  assert('BP chart sample count uses unique rendered dates across paired sources',
+    /Chart samples\s+3d/.test(mixedModalText), mixedModalText);
   window.closeModal();
   await window.openWearableDetail('bp_diastolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Systolic/.test(d?.label || '')));

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -180,6 +180,8 @@ return (async function() {
   const mixedChartLabels = window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || [];
   assert('BP modal fetches diastolic rows from paired metric primary source',
     mixedChartLabels.some(l => /^Diastolic \(Manual/.test(l)), mixedChartLabels.join('|'));
+  assert('BP mixed-source chart does not duplicate manual-primary diastolic as manual scatter',
+    !mixedChartLabels.some(l => /^Manual diastolic$/.test(l)), mixedChartLabels.join('|'));
   assert('BP latest row uses an actual same-date pair instead of mismatched latest halves',
     /Latest\s+124\/80 mmHg/.test(mixedModalText) && !/Latest\s+130\/80 mmHg/.test(mixedModalText), mixedModalText);
   assert('BP latest row never leaks split-date debug text into visible value',

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -182,6 +182,8 @@ return (async function() {
     mixedChartLabels.some(l => /^Diastolic \(Manual/.test(l)), mixedChartLabels.join('|'));
   assert('BP latest row uses an actual same-date pair instead of mismatched latest halves',
     /Latest\s+124\/80 mmHg/.test(mixedModalText) && !/Latest\s+130\/80 mmHg/.test(mixedModalText), mixedModalText);
+  assert('BP latest row never leaks split-date debug text into visible value',
+    !/split dates/.test(mixedModalText), mixedModalText);
   window.closeModal();
   await window.openWearableDetail('bp_diastolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Systolic/.test(d?.label || '')));

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -123,6 +123,38 @@ return (async function() {
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
+  // A2. Blood Pressure detail modal pairs systolic + diastolic
+  // ═══════════════════════════════════════
+  console.log('%c A2. Blood Pressure Modal Pairing ', 'font-weight:bold;color:#f59e0b');
+  localStorage.setItem('wearable-detail-range', '90d');
+  window._labState.importedData.wearableSummary = {
+    sources: { manual: { connectedSince: '2026-04-20', lastSyncAt: Date.now(), coverageDays: 3 } },
+    metrics: {
+      bp_systolic: { primarySource: 'manual', latest: 120, latestDate: '2026-04-22', baseline: 121, baselineP25: 118, baselineP75: 123, rolling: { d7: 120, d30: 121, d90: 121 }, trend30d: 'flat', weekly: [121, 120] },
+      bp_diastolic: { primarySource: 'manual', latest: 80, latestDate: '2026-04-22', baseline: 79, baselineP25: 76, baselineP75: 82, rolling: { d7: 80, d30: 79, d90: 79 }, trend30d: 'flat', weekly: [79, 80] },
+    },
+  };
+  await store.upsertDailyBatch(TEST_PROFILE, [
+    { source: 'manual', date: '2026-04-20', bp_systolic: 122, bp_diastolic: 81 },
+    { source: 'manual', date: '2026-04-21', bp_systolic: 121, bp_diastolic: 79 },
+    { source: 'manual', date: '2026-04-22', bp_systolic: 120, bp_diastolic: 80, note: 'after walk', tags: ['rested'] },
+  ]);
+  await window.openWearableDetail('bp_systolic');
+  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /Diastolic/.test(d?.label || '')));
+  const bpModalText = document.getElementById('detail-modal')?.textContent || '';
+  const bpChart = window._labState.chartInstances?.modal;
+  const bpLabels = bpChart?.data?.datasets?.map(d => d.label) || [];
+  assert('BP modal latest/stat/manual list shows paired 120/80 value', /120\/80/.test(bpModalText), bpModalText);
+  assert('BP chart renders Systolic and Diastolic datasets',
+    bpLabels.some(l => /^Systolic/.test(l)) && bpLabels.some(l => /^Diastolic/.test(l)), bpLabels.join('|'));
+  assert('BP diastolic dataset has 3 dated points',
+    bpChart?.data?.datasets?.find(d => /^Diastolic/.test(d.label))?.data?.length === 3);
+  assert('BP manual entries preserve paired sys/dia row value',
+    !!document.querySelector('#detail-modal .wearable-manual-entry-val')?.textContent?.includes('120/80'));
+  window.closeModal();
+  delete window._labState.importedData.wearableSummary;
+
+  // ═══════════════════════════════════════
   // B. JSZip lazy-loader functional smoke
   // ═══════════════════════════════════════
   // Clear window.JSZip, route through importAppleHealthFile (the public entry

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -158,6 +158,37 @@ return (async function() {
   assert('BP manual entries preserve paired sys/dia row value',
     !!document.querySelector('#detail-modal .wearable-manual-entry-val')?.textContent?.includes('120/80'));
   window.closeModal();
+
+  window._labState.importedData.wearableSummary = {
+    sources: {
+      withings: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 2 },
+      manual: { connectedSince: '2026-06-20', lastSyncAt: Date.now(), coverageDays: 1 },
+    },
+    metrics: {
+      bp_systolic: { primarySource: 'withings', latest: 130, latestDate: '2026-06-24', baseline: 126, baselineP25: 124, baselineP75: 130, rolling: { d7: 127, d30: 126, d90: 126 }, trend30d: 'flat', weekly: [126, 127] },
+      bp_diastolic: { primarySource: 'manual', latest: 80, latestDate: '2026-06-20', baseline: 80, baselineP25: 78, baselineP75: 82, rolling: { d7: 80, d30: 80, d90: 80 }, trend30d: 'flat', weekly: [80] },
+    },
+  };
+  await store.upsertDailyBatch(TEST_PROFILE, [
+    { source: 'withings', date: '2026-06-20', bp_systolic: 124 },
+    { source: 'withings', date: '2026-06-24', bp_systolic: 130 },
+    { source: 'manual', date: '2026-06-20', bp_diastolic: 80 },
+  ]);
+  await window.openWearableDetail('bp_systolic');
+  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic/.test(d?.label || '')));
+  const mixedModalText = document.getElementById('detail-modal')?.textContent || '';
+  const mixedChartLabels = window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || [];
+  assert('BP modal fetches diastolic rows from paired metric primary source',
+    mixedChartLabels.some(l => /^Diastolic \(Manual/.test(l)), mixedChartLabels.join('|'));
+  assert('BP latest row uses an actual same-date pair instead of mismatched latest halves',
+    /Latest\s+124\/80 mmHg/.test(mixedModalText) && !/Latest\s+130\/80 mmHg/.test(mixedModalText), mixedModalText);
+  window.closeModal();
+  await window.openWearableDetail('bp_diastolic');
+  await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Systolic/.test(d?.label || '')));
+  assert('Opening bp_diastolic normalizes to the paired BP detail view',
+    (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /^Systolic/.test(l)) &&
+    /124\/80/.test(document.getElementById('detail-modal')?.textContent || ''));
+  window.closeModal();
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -150,9 +150,8 @@ return (async function() {
     !/Typical range\s+118\/76 mmHg\s+–\s+123\/82 mmHg/.test(bpModalText), bpModalText);
   assert('BP chart renders Systolic and Diastolic datasets',
     bpLabels.some(l => /^Systolic/.test(l)) && bpLabels.some(l => /^Diastolic/.test(l)), bpLabels.join('|'));
-  assert('BP manual diastolic scatter has a distinct color from primary diastolic line',
-    bpChart?.data?.datasets?.find(d => d.label === 'Manual diastolic')?.borderColor !==
-    bpChart?.data?.datasets?.find(d => /^Diastolic/.test(d.label))?.borderColor);
+  assert('BP manual-primary chart suppresses duplicate manual diastolic scatter',
+    !bpLabels.some(l => /^Manual diastolic$/.test(l)), bpLabels.join('|'));
   assert('BP diastolic dataset has 3 dated points',
     bpChart?.data?.datasets?.find(d => /^Diastolic/.test(d.label))?.data?.length === 3);
   assert('BP manual entries preserve paired sys/dia row value',

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -145,8 +145,14 @@ return (async function() {
   const bpChart = window._labState.chartInstances?.modal;
   const bpLabels = bpChart?.data?.datasets?.map(d => d.label) || [];
   assert('BP modal latest/stat/manual list shows paired 120/80 value', /120\/80/.test(bpModalText), bpModalText);
+  assert('BP modal Typical range shows unit once at the end',
+    /Typical range\s+118\/76\s+–\s+123\/82 mmHg/.test(bpModalText) &&
+    !/Typical range\s+118\/76 mmHg\s+–\s+123\/82 mmHg/.test(bpModalText), bpModalText);
   assert('BP chart renders Systolic and Diastolic datasets',
     bpLabels.some(l => /^Systolic/.test(l)) && bpLabels.some(l => /^Diastolic/.test(l)), bpLabels.join('|'));
+  assert('BP manual diastolic scatter has a distinct color from primary diastolic line',
+    bpChart?.data?.datasets?.find(d => d.label === 'Manual diastolic')?.borderColor !==
+    bpChart?.data?.datasets?.find(d => /^Diastolic/.test(d.label))?.borderColor);
   assert('BP diastolic dataset has 3 dated points',
     bpChart?.data?.datasets?.find(d => /^Diastolic/.test(d.label))?.data?.length === 3);
   assert('BP manual entries preserve paired sys/dia row value',

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -417,7 +417,7 @@ try {
 
   const entriesSectionFn = wearablesDetailSrc.match(/function buildManualEntriesSection[\s\S]*?\n\}\s*\n/)?.[0] || '';
   assert('manualEntries map pulls note: r.note from the IDB row',
-    /\.map\(r => \(\{ date: r\.date, v: r\[metricId\], tags: r\.tags, note: r\.note \}\)\)/.test(wearablesDetailSrc));
+    /note:\s*r\.note/.test(wearablesDetailSrc));
   assert('Entries-list row renders the note (.wearable-manual-entry-note) when present',
     /typeof e\.note === 'string' && e\.note\.trim\(\)[\s\S]{0,200}wearable-manual-entry-note/.test(entriesSectionFn));
   assert("Row gains 'has-note' modifier class for layout when note is present",

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1815,6 +1815,11 @@ assert('Service-worker static cache lists extracted wearable detail modules',
   /\/js\/wearables-bp-detail-chart\.js/.test(swSrc) &&
   /\/js\/wearables-formatters\.js/.test(swSrc) &&
   /\/js\/wearables-manual-form-ui\.js/.test(swSrc));
+const bpChartSrc = await fetch('/js/wearables-bp-detail-chart.js').then(r => r.text());
+assert('Manual diastolic scatter color is distinct from primary diastolic line',
+  /const\s+diaColor\s*=\s*['"]#a78bfa['"]/.test(bpChartSrc) &&
+  /const\s+manualDiaColor\s*=\s*['"]#f43f5e['"]/.test(bpChartSrc) &&
+  !/const\s+manualDiaColor\s*=\s*diaColor\b/.test(bpChartSrc));
 
 // disconnectWearable now clears last-sync meta so reconnect doesn't pick
 // up a stale endDate.

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1820,6 +1820,11 @@ assert('Manual diastolic scatter color is distinct from primary diastolic line',
   /const\s+diaColor\s*=\s*['"]#a78bfa['"]/.test(bpChartSrc) &&
   /const\s+manualDiaColor\s*=\s*['"]#f43f5e['"]/.test(bpChartSrc) &&
   !/const\s+manualDiaColor\s*=\s*diaColor\b/.test(bpChartSrc));
+assert('Deferred BP chart render is guarded against stale modal canvas reuse',
+  bpChartSrc.includes('canvas.dataset.bpRenderToken = retryToken') &&
+  bpChartSrc.includes('currentCanvas === canvas') &&
+  bpChartSrc.includes('canvas.isConnected') &&
+  bpChartSrc.includes('canvas.dataset.bpRenderToken === retryToken'));
 
 // disconnectWearable now clears last-sync meta so reconnect doesn't pick
 // up a stale endDate.

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1673,7 +1673,7 @@ assert('Backfill + sync error toasts run their messages through _scrubError',
 // P2 a11y: friendlier aria on manual delete button + collapse-arrow header.
 assert('Manual-entry delete aria reads as a sentence (long date + value + unit)',
   /aria-label="\$\{escapeHTML\(ariaText\)\}"/.test(wearablesDetailSrcP2) &&
-  /Delete\s+\$\{metricLabel\.toLowerCase\(\)\}\s+reading\s+from/.test(wearablesDetailSrcP2));
+  /Delete\s+\$\{isBloodPressure\s*\?\s*'blood pressure'\s*:\s*metricLabel\.toLowerCase\(\)\}\s+reading\s+from/.test(wearablesDetailSrcP2));
 assert('Strip-header role="button" carries an aria-label distinct from the live source list',
   /'(Expand|Collapse) wearables strip'/.test(wearablesSrcP2)
   && /aria-label="\$\{ariaLabel\}"/.test(wearablesSrcP2));
@@ -1812,6 +1812,7 @@ assert('Service-worker static cache lists wearables-manual.js',
   /\/js\/wearables-manual\.js/.test(swSrc));
 assert('Service-worker static cache lists extracted wearable detail modules',
   /\/js\/wearables-detail-modal\.js/.test(swSrc) &&
+  /\/js\/wearables-bp-detail-chart\.js/.test(swSrc) &&
   /\/js\/wearables-formatters\.js/.test(swSrc) &&
   /\/js\/wearables-manual-form-ui\.js/.test(swSrc));
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -629,6 +629,9 @@
     const hasWearablesDetailModalJs = sw.includes('/js/wearables-detail-modal.js');
     assert('Service worker caches js/wearables-detail-modal.js', hasWearablesDetailModalJs);
 
+    const hasWearablesBpDetailChartJs = sw.includes('/js/wearables-bp-detail-chart.js');
+    assert('Service worker caches js/wearables-bp-detail-chart.js', hasWearablesBpDetailChartJs);
+
     const hasWearablesFormattersJs = sw.includes('/js/wearables-formatters.js');
     assert('Service worker caches js/wearables-formatters.js', hasWearablesFormattersJs);
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -100,7 +100,7 @@
     'openHealthGoalsEditor','renderHealthGoalsModal',
     'addHealthGoal','deleteHealthGoal','clearHealthGoals',
     'openInterpretiveLensEditor','saveInterpretiveLens','clearInterpretiveLens',
-    'renderInterpretiveLensSection'
+    'renderInterpretiveLensSection','openContextModal'
   ];
 
   // client-list.js (3)

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -199,6 +199,7 @@
     "js/wearable-adapters.js",
     "js/wearables-apple-health.js",
     "js/wearables-connect.js",
+    "js/wearables-bp-detail-chart.js",
     "js/wearables-detail-modal.js",
     "js/wearables-fitbit-auth.js",
     "js/wearables-fitbit.js",


### PR DESCRIPTION
## Summary
- restore the Interpretive Lens / Knowledge Base personalization entry point above Profile Context cards for issue #965
- pair systolic and diastolic BP readings in the wearable detail modal and extract the BP chart renderer
- register the new BP chart module with service worker, typecheck config, and regression tests

## Verification
- npm run typecheck:checkjs
- npm run quality
- npm test
- node tests/test-wearables-manual.js
- PORT=8178 npx playwright test tests/playwright/wearables-browser-flows.spec.js