### PR TITLE
[codex] Inject light environment render deps

### DIFF
--- a/js/light-ai-save-hooks.js
+++ b/js/light-ai-save-hooks.js
@@ -2,17 +2,20 @@
 // light-ai-save-hooks.js - wire saved Light/onboarding records to AI analyzers.
 
 import { configureLightEnvAudits } from './light-env-audits.js';
-import { configureLightTools } from './light-tools.js';
+import { configureLightTools, getMeasurementsForRoom } from './light-tools.js';
 import { configureSunDefaults } from './sun-defaults.js';
 import { hasAIProvider } from './api.js';
-import { addRoom, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';
+import { addRoom, configureLightEnv, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';
 import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';
-import { maybeAnalyzeMeasurementAfterSave } from './light-tools-ai-analysis.js';
+import { maybeAnalyzeMeasurementAfterSave, renderMeasurementAIInline } from './light-tools-ai-analysis.js';
+import { renderRoomAIBlock } from './light-env-ai-analysis.js';
+import { renderScreenAIBlock } from './light-screen-ai-analysis.js';
 import { getSunCoords } from './sun.js';
 import { getSessions, hydrateSession, logCompletedSession } from './sun-sessions-store.js';
 import { maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock } from './sun-onboarding-ai.js';
 import { solarZenithAngle } from './sun-uvdata.js';
 
+configureLightEnv({ getMeasurementsForRoom, renderMeasurementAIInline, renderRoomAIBlock, renderScreenAIBlock });
 configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot });
 configureLightTools({
   maybeAnalyzeMeasurementAfterSave,

--- a/js/light-env-screen-ui.js
+++ b/js/light-env-screen-ui.js
@@ -72,14 +72,15 @@ export function renderScreenCard(s, opts = {}) {
       <span class="light-env-room-disclosure-chevron" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
     </div>`;
 
-  if (expanded) html += renderScreenExpandedBody(s, rooms);
+  if (expanded) html += renderScreenExpandedBody(s, rooms, opts);
   html += `</div>`;
   return html;
 }
 
-function renderScreenExpandedBody(s, rooms) {
+function renderScreenExpandedBody(s, rooms, opts = {}) {
   const hoursActive = activeScreenHoursBucket(s.hoursPerDay);
   const eveActive = activeScreenEveningBucket(s.eveningUseAfterSunset);
+  const renderScreenAIBlock = opts.renderScreenAIBlock;
 
   const hoursChips = SCREEN_HOURS_BUCKETS.map(b =>
     `<button type="button" class="light-env-chip${hoursActive === b.key ? ' light-env-chip-active' : ''}" aria-pressed="${hoursActive === b.key ? 'true' : 'false'}" ${lightEnvActionAttrs('set-screen-hours-bucket', { id: s.id, key: b.key })}>${escapeHTML(b.label)}</button>`
@@ -130,6 +131,6 @@ function renderScreenExpandedBody(s, rooms) {
         <span class="toggle-slider"></span>
       </label>
     </div>
-    ${typeof globalThis.renderScreenAIBlock === 'function' ? globalThis.renderScreenAIBlock(s) : ''}
+    ${typeof renderScreenAIBlock === 'function' ? renderScreenAIBlock(s) : ''}
   </div>`;
 }

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -87,9 +87,13 @@ export {
 // before falling back to "Room N" so a fresh user lands on familiar labels.
 const DEFAULT_ROOM_NAMES = ['Bedroom', 'Living room', 'Kitchen', 'Office', 'Bathroom'];
 
-/** @type {{ renderBurdenInterp: AnyFunction | null }} */
+/** @type {{ getMeasurementsForRoom: AnyFunction | null, renderBurdenInterp: AnyFunction | null, renderMeasurementAIInline: AnyFunction | null, renderRoomAIBlock: AnyFunction | null, renderScreenAIBlock: AnyFunction | null }} */
 const lightEnvDeps = {
+  getMeasurementsForRoom: null,
   renderBurdenInterp: null,
+  renderMeasurementAIInline: null,
+  renderRoomAIBlock: null,
+  renderScreenAIBlock: null,
 };
 
 export function configureLightEnv(deps = {}) {
@@ -228,8 +232,13 @@ function resolveActiveRoomId(rooms) {
 }
 
 function getMeasurementsFor(roomId) {
-  if (typeof globalThis.getMeasurementsForRoom !== 'function') return [];
-  return globalThis.getMeasurementsForRoom(roomId);
+  if (typeof lightEnvDeps.getMeasurementsForRoom !== 'function') return [];
+  try {
+    const measurements = lightEnvDeps.getMeasurementsForRoom(roomId);
+    return Array.isArray(measurements) ? measurements : [];
+  } catch (_) {
+    return [];
+  }
 }
 
 function fmtMeasureValue(m) {
@@ -291,6 +300,7 @@ function renderLightEnvScreenCard(s, rooms) {
   return renderScreenCard(s, {
     expanded: _expandedScreenId === s.id,
     renderTodayToggle: _renderTodayToggle,
+    renderScreenAIBlock: lightEnvDeps.renderScreenAIBlock,
     rooms,
   });
 }
@@ -635,7 +645,7 @@ function renderRoomExpandedBody(r, measurements, sev) {
         <span class="light-env-reading-icon">${icon}</span>
         <span class="light-env-reading-value">${escapeHTML(fmtMeasureValue(m))}</span>
         <span class="light-env-reading-time">${escapeHTML(fmtMeasureTime(m.capturedAt))}</span>
-      </div>${typeof globalThis.renderMeasurementAIInline === 'function' ? globalThis.renderMeasurementAIInline(m) : ''}`;
+      </div>${typeof lightEnvDeps.renderMeasurementAIInline === 'function' ? lightEnvDeps.renderMeasurementAIInline(m) : ''}`;
     }
     html += `</div>`;
   }
@@ -643,8 +653,8 @@ function renderRoomExpandedBody(r, measurements, sev) {
 
   // AI verdict block (between Measure and Screens) — synthesizes the room
   // signals into a single circadian-friendliness verdict.
-  if (typeof globalThis.renderRoomAIBlock === 'function') {
-    html += globalThis.renderRoomAIBlock(r);
+  if (typeof lightEnvDeps.renderRoomAIBlock === 'function') {
+    html += lightEnvDeps.renderRoomAIBlock(r);
   }
 
   // Step 3: screens used here. Step head + empty-state copy customize

--- a/js/sun-ai-analysis.js
+++ b/js/sun-ai-analysis.js
@@ -355,9 +355,7 @@ Object.assign(window, {
   refreshSessionAIAnalysis,
   analyzeSunSessionAI,
   // Exposed so sun.js can call into the AI module without importing it
-  // — the reciprocal import would create a TDZ-risky cycle. Same
-  // window-lookup pattern other AI modules use (renderRoomAIBlock,
-  // renderScreenAIBlock, etc.).
+  // — the reciprocal import would create a TDZ-risky cycle.
   maybeAnalyzeSessionAfterFinish,
   renderSessionAIInline,
   renderSessionAIDetail,

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -92,6 +92,10 @@ assert('light-env internal action handlers are registered through module object,
     !lightEnvWindowFacadeSrc.includes('addLightEnvRoom') &&
     !lightEnvWindowFacadeSrc.includes('deleteLightEnvScreenConfirm') &&
     !lightEnvWindowFacadeSrc.includes('computeLightDeficitAxes'));
+assert('light-env screen renderer takes AI renderer from options instead of global lookup',
+  screenSrc.includes('opts.renderScreenAIBlock') &&
+    screenSrc.includes('renderScreenAIBlock(s)') &&
+    !screenSrc.includes('globalThis.renderScreenAIBlock'));
 assert('light-env form delegates separate live input from change-only controls',
   actionSrc.includes("'update-room-hours', 'update-room-name'") &&
     actionSrc.includes("'update-screen-blue-blocker'") &&

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -347,7 +347,44 @@ const {
     injectedLoadHtml.toLowerCase().includes('add a room'));
   configureLightEnv(restoredBurdenRenderer);
 
+  reset();
+  await addRoom('Bedroom');
+  const injectedRoom = getEnvironment().rooms[0];
+  await updateRoom(injectedRoom.id, {
+    primarySource: 'led-warm',
+    hoursOccupiedPerDay: 8,
+    eveningHoursAfterSunset: 1,
+  });
+  await addScreen('phone', injectedRoom.id);
+  const injectedScreen = getEnvironment().screens[0];
+  lightEnvActionHandlers.toggleLightEnvScreenExpanded(injectedScreen.id);
+  const injectedMeasurement = {
+    id: 'm-injected',
+    roomId: injectedRoom.id,
+    tool: 'lux',
+    value: 120,
+    capturedAt: Date.now(),
+    confidence: 0.9,
+  };
+  const restoredRenderDeps = configureLightEnv({
+    getMeasurementsForRoom: roomId => roomId === injectedRoom.id ? [injectedMeasurement] : [],
+    renderMeasurementAIInline: m => `<div class="injected-measurement-ai">${m.id}</div>`,
+    renderRoomAIBlock: r => `<div class="injected-room-ai">${r.id}</div>`,
+    renderScreenAIBlock: s => `<div class="injected-screen-ai">${s.id}</div>`,
+  });
+  const injectedRenderHtml = renderEnvironmentSection({ embedded: true });
+  assert('Room measurement and AI renderers use injected Light environment deps',
+    injectedRenderHtml.includes('120 lux') &&
+    injectedRenderHtml.includes('injected-measurement-ai') &&
+    injectedRenderHtml.includes('m-injected') &&
+    injectedRenderHtml.includes('injected-room-ai') &&
+    injectedRenderHtml.includes(injectedRoom.id) &&
+    injectedRenderHtml.includes('injected-screen-ai') &&
+    injectedRenderHtml.includes(injectedScreen.id));
+  configureLightEnv(restoredRenderDeps);
+
   // Heavy indoor + heavy evening → tier 2
+  reset();
   await addRoom('Office');
   await updateRoom(getEnvironment().rooms[0].id, {
     primarySource: 'led-cool',
@@ -557,6 +594,7 @@ const {
   const burdenSrc = await fs.readFile(new URL('../js/light-burden-ai-analysis.js', import.meta.url), 'utf8');
   const appLightSunSrc = await fs.readFile(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
   const aiSaveHooksSrc = await fs.readFile(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
+  const screenUiSrc = await fs.readFile(new URL('../js/light-env-screen-ui.js', import.meta.url), 'utf8');
   assert('Light audit renderer emits no inline event attributes',
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light audit storage/rendering lives in its own module',
@@ -588,6 +626,26 @@ const {
     !envSrc.includes('globalThis.renderBurdenInterp') &&
     burdenSrc.includes("import { computeDeficitAxes, computeIndoorBurden, configureLightEnv, isActiveToday } from './light-env.js';") &&
     burdenSrc.includes('configureLightEnv({ renderBurdenInterp });'));
+  assert('Room, measurement, and screen AI renderers route through Light environment configuration',
+    envSrc.includes('getMeasurementsForRoom: null') &&
+    envSrc.includes('renderMeasurementAIInline: null') &&
+    envSrc.includes('renderRoomAIBlock: null') &&
+    envSrc.includes('renderScreenAIBlock: null') &&
+    envSrc.includes('lightEnvDeps.getMeasurementsForRoom') &&
+    envSrc.includes('lightEnvDeps.renderMeasurementAIInline') &&
+    envSrc.includes('lightEnvDeps.renderRoomAIBlock') &&
+    screenUiSrc.includes('opts.renderScreenAIBlock') &&
+    screenUiSrc.includes('renderScreenAIBlock(s)') &&
+    aiSaveHooksSrc.includes("import { addRoom, configureLightEnv, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';") &&
+    aiSaveHooksSrc.includes("import { configureLightTools, getMeasurementsForRoom } from './light-tools.js';") &&
+    aiSaveHooksSrc.includes("import { maybeAnalyzeMeasurementAfterSave, renderMeasurementAIInline } from './light-tools-ai-analysis.js';") &&
+    aiSaveHooksSrc.includes("import { renderRoomAIBlock } from './light-env-ai-analysis.js';") &&
+    aiSaveHooksSrc.includes("import { renderScreenAIBlock } from './light-screen-ai-analysis.js';") &&
+    aiSaveHooksSrc.includes('configureLightEnv({ getMeasurementsForRoom, renderMeasurementAIInline, renderRoomAIBlock, renderScreenAIBlock })') &&
+    !envSrc.includes('globalThis.getMeasurementsForRoom') &&
+    !envSrc.includes('globalThis.renderMeasurementAIInline') &&
+    !envSrc.includes('globalThis.renderRoomAIBlock') &&
+    !screenUiSrc.includes('globalThis.renderScreenAIBlock'));
   const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
   const cssSrc = [

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -239,8 +239,8 @@ const tools = await import('../js/light-tools.js');
       lightToolsSrc.includes('export function configureLightTools') &&
       lightToolsSrc.includes('maybeAnalyzeMeasurementAfterSave: () => {}') &&
       !lightToolsSrc.includes('window.maybeAnalyzeMeasurementAfterSave') &&
-      lightAiSaveHooksSrc.includes("import { configureLightTools } from './light-tools.js';") &&
-      lightAiSaveHooksSrc.includes("import { maybeAnalyzeMeasurementAfterSave } from './light-tools-ai-analysis.js';") &&
+      lightAiSaveHooksSrc.includes("import { configureLightTools, getMeasurementsForRoom } from './light-tools.js';") &&
+      lightAiSaveHooksSrc.includes("import { maybeAnalyzeMeasurementAfterSave, renderMeasurementAIInline } from './light-tools-ai-analysis.js';") &&
       lightAiSaveHooksSrc.includes('configureLightTools({') &&
       lightAiSaveHooksSrc.includes('maybeAnalyzeMeasurementAfterSave') &&
       appLightSunSrc.includes("import './light-ai-save-hooks.js';"));
@@ -257,7 +257,7 @@ const tools = await import('../js/light-tools.js');
       !lightToolsSrc.includes('window.navigate') &&
       lightEnvSrc.includes('export async function suggestRoomSourceFromSpectrum') &&
       lightEnvSrc.includes('export function getRooms') &&
-      lightAiSaveHooksSrc.includes("import { addRoom, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';") &&
+      lightAiSaveHooksSrc.includes("import { addRoom, configureLightEnv, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';") &&
       lightAiSaveHooksSrc.includes("import { getSunCoords } from './sun.js';") &&
       lightAiSaveHooksSrc.includes("import { getSessions, hydrateSession, logCompletedSession } from './sun-sessions-store.js';") &&
       lightAiSaveHooksSrc.includes("import { solarZenithAngle } from './sun-uvdata.js';") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.18';
+self.APP_VERSION = '1.10.19';


### PR DESCRIPTION
## Summary
- extend `configureLightEnv` so room measurements and AI renderers are injected instead of read through `globalThis`
- pass the screen AI renderer through `renderScreenCard` options and wire all Light Env render/data deps from `light-ai-save-hooks.js`
- add runtime and source-guard coverage for the injected render path and bump `version.js`

## Validation
- `node tests/test-light-env.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-light-tools.js`
- `npx playwright test tests/playwright/light-env-browser-coverage.spec.js tests/playwright/light-ai-analysis-coverage-batch.spec.js tests/playwright/light-coverage-batch-2.spec.js tests/playwright/light-screen-ai-browser-coverage.spec.js`
- `npm test`
- `git diff --check`
- `./run-tests.sh`