### PR TITLE
[codex] Remove light env modal globals

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -7,6 +7,19 @@ import { buildSidebar } from './nav.js';
 
 let globalEventsBound = false;
 let mouseDownInsideModal = false;
+const appEventListenerDeps = {
+  closeLightEnvironmentAssessment: () => {},
+};
+
+export function configureAppEventListeners(deps = {}) {
+  const previous = { ...appEventListenerDeps };
+  for (const [name, value] of Object.entries(deps || {})) {
+    if (Object.prototype.hasOwnProperty.call(appEventListenerDeps, name) && typeof value === 'function') {
+      appEventListenerDeps[name] = value;
+    }
+  }
+  return previous;
+}
 
 function nudgeModal(overlay) {
   const modal = overlay.firstElementChild;
@@ -40,7 +53,7 @@ function handleDocumentClick(e) {
   }
   // Read-only modals close on backdrop click.
   if (e.target.id === "modal-overlay") { window.closeModal(); return; }
-  if (e.target.id === "light-env-assessment-overlay") { window.closeLightEnvironmentAssessment?.(); return; }
+  if (e.target.id === "light-env-assessment-overlay") { appEventListenerDeps.closeLightEnvironmentAssessment(); return; }
   if (e.target.id === "changelog-modal-overlay") { window.closeChangelog(); return; }
   if (e.target.id === "report-builder-overlay") { window.closeReportBuilder?.(); return; }
   // Auto-save modals close on backdrop click.
@@ -133,7 +146,7 @@ function handleAppKeydown(e) {
       return;
     }
     const lightEnvOverlay = document.getElementById("light-env-assessment-overlay");
-    if (lightEnvOverlay && lightEnvOverlay.classList.contains("show")) { window.closeLightEnvironmentAssessment?.(); return; }
+    if (lightEnvOverlay && lightEnvOverlay.classList.contains("show")) { appEventListenerDeps.closeLightEnvironmentAssessment(); return; }
     const modalOverlay = document.getElementById("modal-overlay");
     if (modalOverlay && modalOverlay.classList.contains("show")) { window.closeModal(); return; }
     // Generic fallback: anonymous dynamically-injected overlays.

--- a/js/app-ui-shell-modules.js
+++ b/js/app-ui-shell-modules.js
@@ -6,6 +6,7 @@ import './tour.js';
 import './touch-tooltip.js';
 import './client-list.js';
 import './views.js';
+import './light-env-shell-hooks.js';
 import './light-channel-view-ui-hooks.js';
 import './light-page-view-ui-hooks.js';
 import './light-tools-ui-hooks.js';

--- a/js/light-env-shell-hooks.js
+++ b/js/light-env-shell-hooks.js
@@ -1,0 +1,14 @@
+// @ts-check
+// light-env-shell-hooks.js - wire Light Environment shell actions without window lookups.
+
+import { configureAppEventListeners } from './app-event-listeners.js';
+import { openLightEnvironmentAssessment, closeLightEnvironmentAssessment } from './light-env.js';
+import { configureNavActions } from './nav.js';
+
+configureNavActions({
+  openLightEnvironmentAssessment,
+});
+
+configureAppEventListeners({
+  closeLightEnvironmentAssessment,
+});

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -1152,8 +1152,5 @@ if (typeof window !== 'undefined') {
     isLightEnvActiveToday: isActiveToday,
     renderEnvironmentSection,
     renderEnvironmentAssessmentSummary,
-    openLightEnvironmentAssessment,
-    closeLightEnvironmentAssessment,
-    refreshLightEnvironmentAssessment,
   });
 }

--- a/js/nav.js
+++ b/js/nav.js
@@ -31,6 +31,19 @@ function _iconSvg(name) {
 }
 
 let navDelegatesInstalled = false;
+const navActionDeps = {
+  openLightEnvironmentAssessment: () => {},
+};
+
+export function configureNavActions(deps = {}) {
+  const previous = { ...navActionDeps };
+  for (const [name, value] of Object.entries(deps || {})) {
+    if (Object.prototype.hasOwnProperty.call(navActionDeps, name) && typeof value === 'function') {
+      navActionDeps[name] = value;
+    }
+  }
+  return previous;
+}
 
 function _navActionAttrs(action, attrs = {}) {
   const extraAttrs = Object.entries(attrs)
@@ -71,7 +84,7 @@ function handleNavActionClick(event) {
   } else if (action === 'open-emf-assessment') {
     window.openEMFAssessmentEditor?.();
   } else if (action === 'open-light-assessment') {
-    window.openLightEnvironmentAssessment?.();
+    navActionDeps.openLightEnvironmentAssessment();
   } else if (action === 'open-knowledge-base') {
     appWindow.openKnowledgeBaseModal?.();
   } else if (action === 'open-report-builder') {

--- a/service-worker.js
+++ b/service-worker.js
@@ -380,6 +380,7 @@ const APP_SHELL = [
   '/js/light-device-session-modal.js',
   '/js/light-env.js',
   '/js/light-env-actions.js',
+  '/js/light-env-shell-hooks.js',
   '/js/light-env-store.js',
   '/js/light-env-screen-ui.js',
   '/js/light-env-audits.js',

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -85,18 +85,20 @@ test('light environment browser coverage handles summary modal prompt and source
         && window.addLightEnvRoom === undefined
         && typeof actions.addLightEnvRoom === 'function'
         && window.renderEnvironmentSection === lightEnv.renderEnvironmentSection
-        && window.openLightEnvironmentAssessment === lightEnv.openLightEnvironmentAssessment
+        && window.openLightEnvironmentAssessment === undefined
+        && window.closeLightEnvironmentAssessment === undefined
+        && window.refreshLightEnvironmentAssessment === undefined
         && emptyFull.includes('Light environment')
         && emptyFull.includes('Map your bedroom first')
         && !emptyEmbedded.includes('light-env-head')
         && emptySummary.includes('Start assessment');
 
-      window.openLightEnvironmentAssessment();
+      lightEnv.openLightEnvironmentAssessment();
       await waitUntil(() => !!document.querySelector('#light-env-assessment-overlay .light-env-assessment-modal'), 'assessment modal open');
       const openTitle = document.getElementById('light-env-assessment-title')?.textContent || '';
-      window.refreshLightEnvironmentAssessment();
+      lightEnv.refreshLightEnvironmentAssessment();
       await waitUntil(() => !!document.querySelector('#light-env-assessment-overlay .light-env-assessment-modal'), 'assessment modal refresh');
-      window.closeLightEnvironmentAssessment();
+      lightEnv.closeLightEnvironmentAssessment();
       await waitUntil(() => !document.getElementById('light-env-assessment-overlay'), 'assessment modal close');
       outcomes.modalOpenRefreshAndClose =
         openTitle.trim() === 'Indoor Light Assessment'
@@ -156,7 +158,7 @@ test('light environment browser coverage handles summary modal prompt and source
         env().rooms.find(r => r.id === bedroom.id)?.name === 'Bedroom Prime'
         && calls.some(call => call[0] === 'navigate' && call[1] === 'light');
 
-      window.openLightEnvironmentAssessment();
+      lightEnv.openLightEnvironmentAssessment();
       await waitUntil(() => !!document.querySelector('#light-env-assessment-overlay.show .light-env-assessment-modal'), 'assessment modal reopened');
       await wait(70);
       const focusedRoomName = document.querySelector('#light-env-assessment-overlay .light-env-room-name-input');

--- a/tests/playwright/light-env-coverage-batch.spec.js
+++ b/tests/playwright/light-env-coverage-batch.spec.js
@@ -7,7 +7,7 @@ test('Light environment assessment drives delegated room and screen controls', a
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openLightEnvironmentAssessment === 'function');
+  await page.waitForFunction(() => typeof window.renderEnvironmentAssessmentSummary === 'function');
 
   const results = await page.evaluate(async () => {
     const [{ state }, data] = await Promise.all([

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -31,7 +31,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     const origProfiles = state.profiles;
     const origNavigate = window.navigate;
     const origOpenEMF = window.openEMFAssessmentEditor;
-    const origOpenLightEnv = window.openLightEnvironmentAssessment;
     const origOpenReportBuilder = window.openReportBuilder;
     const origOpenKB = window.openKnowledgeBaseModal;
     const origOpenCreateMarker = window.openCreateMarkerModal;
@@ -39,6 +38,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     const origIsGroupInAI = window.isGroupInAIContext;
     const origSetGroupInAI = window.setGroupInAIContext;
     const origGroupStorage = localStorage.getItem('labcharts-navgroup-Hormones');
+    let restoreNavActions = null;
 
     try {
       const fixtureData = {
@@ -74,7 +74,9 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
         window.syncSidebarActive?.(route);
       };
       window.openEMFAssessmentEditor = () => calls.push(['open-emf']);
-      window.openLightEnvironmentAssessment = () => calls.push(['open-light-env']);
+      restoreNavActions = nav.configureNavActions({
+        openLightEnvironmentAssessment: () => calls.push(['open-light-env']),
+      });
       window.openReportBuilder = () => calls.push(['open-report-builder']);
       window.openKnowledgeBaseModal = () => calls.push(['open-kb']);
       window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
@@ -146,7 +148,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       state.profiles = origProfiles;
       window.navigate = origNavigate;
       window.openEMFAssessmentEditor = origOpenEMF;
-      window.openLightEnvironmentAssessment = origOpenLightEnv;
+      if (restoreNavActions) nav.configureNavActions(restoreNavActions);
       window.openReportBuilder = origOpenReportBuilder;
       window.openKnowledgeBaseModal = origOpenKB;
       window.openCreateMarkerModal = origOpenCreateMarker;

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -11,6 +11,10 @@ const envSrc = fs.readFileSync(path.join(root, 'js/light-env.js'), 'utf8');
 const screenSrc = fs.readFileSync(path.join(root, 'js/light-env-screen-ui.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/light-env-actions.js'), 'utf8');
 const auditSrc = fs.readFileSync(path.join(root, 'js/light-env-audits.js'), 'utf8');
+const appEventSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
+const appUiShellSrc = fs.readFileSync(path.join(root, 'js/app-ui-shell-modules.js'), 'utf8');
+const envShellHooksSrc = fs.readFileSync(path.join(root, 'js/light-env-shell-hooks.js'), 'utf8');
+const navSrc = fs.readFileSync(path.join(root, 'js/nav.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const envUiSrc = `${envSrc}\n${screenSrc}`;
 const windowAssignStart = envSrc.indexOf('Object.assign(window, {');
@@ -91,7 +95,23 @@ assert('light-env internal action handlers are registered through module object,
     lightEnvWindowFacadeSrc.includes('renderEnvironmentSection') &&
     !lightEnvWindowFacadeSrc.includes('addLightEnvRoom') &&
     !lightEnvWindowFacadeSrc.includes('deleteLightEnvScreenConfirm') &&
-    !lightEnvWindowFacadeSrc.includes('computeLightDeficitAxes'));
+    !lightEnvWindowFacadeSrc.includes('computeLightDeficitAxes') &&
+    !lightEnvWindowFacadeSrc.includes('openLightEnvironmentAssessment') &&
+    !lightEnvWindowFacadeSrc.includes('closeLightEnvironmentAssessment') &&
+    !lightEnvWindowFacadeSrc.includes('refreshLightEnvironmentAssessment'));
+assert('Light environment modal shell actions are wired through startup hooks',
+  navSrc.includes('export function configureNavActions') &&
+    navSrc.includes('navActionDeps.openLightEnvironmentAssessment()') &&
+    navSrc.includes("typeof value === 'function'") &&
+    !navSrc.includes('window.openLightEnvironmentAssessment') &&
+    appEventSrc.includes('export function configureAppEventListeners') &&
+    appEventSrc.includes('appEventListenerDeps.closeLightEnvironmentAssessment()') &&
+    appEventSrc.includes("typeof value === 'function'") &&
+    !appEventSrc.includes('window.closeLightEnvironmentAssessment') &&
+    envShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
+    envShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
+    envShellHooksSrc.includes("import { openLightEnvironmentAssessment, closeLightEnvironmentAssessment } from './light-env.js';") &&
+    appUiShellSrc.includes("import './light-env-shell-hooks.js';"));
 assert('light-env screen renderer takes AI renderer from options instead of global lookup',
   screenSrc.includes('opts.renderScreenAIBlock') &&
     screenSrc.includes('renderScreenAIBlock(s)') &&
@@ -113,6 +133,7 @@ assert('light-env.js captures light audit callbacks when installing delegates',
     envSrc.includes('interpretLightAuditCompare,'));
 assert('service worker precaches light environment action/render modules',
   swSrc.includes("'/js/light-env-actions.js'") &&
+    swSrc.includes("'/js/light-env-shell-hooks.js'") &&
     swSrc.includes("'/js/light-env-screen-ui.js'"));
 
 [

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -33,6 +33,8 @@ const {
   computeIndoorBurden, computeDeficitAxes,
   getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit,
   renderEnvironmentAssessmentSummary, renderEnvironmentSection,
+  openLightEnvironmentAssessment, closeLightEnvironmentAssessment,
+  refreshLightEnvironmentAssessment,
   configureLightEnv, lightEnvActionHandlers,
 } = env;
 const {
@@ -499,9 +501,13 @@ const {
   assert('Embedded assessment section suppresses duplicate page header',
     embeddedHtml.includes('light-env-section-embedded') &&
     !embeddedHtml.includes('class="light-env-head"'));
-  assert('Assessment modal functions are exported on window',
-    typeof window.openLightEnvironmentAssessment === 'function' &&
-    typeof window.closeLightEnvironmentAssessment === 'function');
+  assert('Assessment modal functions stay module exports instead of window facade',
+    typeof openLightEnvironmentAssessment === 'function' &&
+    typeof closeLightEnvironmentAssessment === 'function' &&
+    typeof refreshLightEnvironmentAssessment === 'function' &&
+    window.openLightEnvironmentAssessment === undefined &&
+    window.closeLightEnvironmentAssessment === undefined &&
+    window.refreshLightEnvironmentAssessment === undefined);
   assert('Internal Light environment action handlers are module-scoped instead of public window API',
     typeof lightEnvActionHandlers.addLightEnvRoom === 'function' &&
     typeof lightEnvActionHandlers.deleteLightEnvScreenConfirm === 'function' &&
@@ -550,7 +556,7 @@ const {
       lightEnvironment: { rooms: [{ id: 'sync-room', name: 'Office', hoursOccupiedPerDay: 8 }], screens: [] },
       lightMeasurements: [],
     };
-    window.openLightEnvironmentAssessment();
+    openLightEnvironmentAssessment();
     const initialModalHtml = storedOverlay?.innerHTML || '';
     window._labState.importedData.lightEnvironment.rooms[0].name = 'Bedroom';
     window.dispatchEvent({ type: 'labcharts-sync-applied' });
@@ -566,7 +572,7 @@ const {
     assert('Open Light Environment modal skips sync refresh while form is dirty',
       storedOverlay?.innerHTML === cleanSyncedHtml &&
       !storedOverlay?.innerHTML.includes('light-env-room-disclosure-name">Kitchen'));
-    window.closeLightEnvironmentAssessment();
+    closeLightEnvironmentAssessment();
   } finally {
     document.createElement = originalCreateElement;
     document.getElementById = originalGetElementById;
@@ -593,8 +599,18 @@ const {
   const auditSrc = await fs.readFile(new URL('../js/light-env-audits.js', import.meta.url), 'utf8');
   const burdenSrc = await fs.readFile(new URL('../js/light-burden-ai-analysis.js', import.meta.url), 'utf8');
   const appLightSunSrc = await fs.readFile(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
+  const appUiShellSrc = await fs.readFile(new URL('../js/app-ui-shell-modules.js', import.meta.url), 'utf8');
+  const appEventSrc = await fs.readFile(new URL('../js/app-event-listeners.js', import.meta.url), 'utf8');
   const aiSaveHooksSrc = await fs.readFile(new URL('../js/light-ai-save-hooks.js', import.meta.url), 'utf8');
+  const globalsSrc = await fs.readFile(new URL('../types/globals.d.ts', import.meta.url), 'utf8');
+  const lightEnvShellHooksSrc = await fs.readFile(new URL('../js/light-env-shell-hooks.js', import.meta.url), 'utf8');
+  const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const screenUiSrc = await fs.readFile(new URL('../js/light-env-screen-ui.js', import.meta.url), 'utf8');
+  const lightEnvWindowAssignStart = envSrc.indexOf('Object.assign(window, {');
+  const lightEnvWindowAssignEnd = lightEnvWindowAssignStart >= 0 ? envSrc.indexOf('  });', lightEnvWindowAssignStart) : -1;
+  const lightEnvWindowFacadeSrc = lightEnvWindowAssignStart >= 0 && lightEnvWindowAssignEnd >= 0
+    ? envSrc.slice(lightEnvWindowAssignStart, lightEnvWindowAssignEnd)
+    : '';
   assert('Light audit renderer emits no inline event attributes',
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light audit storage/rendering lives in its own module',
@@ -646,7 +662,20 @@ const {
     !envSrc.includes('globalThis.renderMeasurementAIInline') &&
     !envSrc.includes('globalThis.renderRoomAIBlock') &&
     !screenUiSrc.includes('globalThis.renderScreenAIBlock'));
-  const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
+  assert('Light assessment modal shell actions route through startup wiring instead of window lookup',
+    appUiShellSrc.includes("import './light-env-shell-hooks.js';") &&
+    lightEnvShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
+    lightEnvShellHooksSrc.includes("import { openLightEnvironmentAssessment, closeLightEnvironmentAssessment } from './light-env.js';") &&
+    lightEnvShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
+    navSrc.includes("typeof value === 'function'") &&
+    appEventSrc.includes("typeof value === 'function'") &&
+    !appEventSrc.includes('window.closeLightEnvironmentAssessment') &&
+    !globalsSrc.includes('openLightEnvironmentAssessment') &&
+    !globalsSrc.includes('closeLightEnvironmentAssessment') &&
+    !globalsSrc.includes('refreshLightEnvironmentAssessment') &&
+    !lightEnvWindowFacadeSrc.includes('openLightEnvironmentAssessment') &&
+    !lightEnvWindowFacadeSrc.includes('closeLightEnvironmentAssessment') &&
+    !lightEnvWindowFacadeSrc.includes('refreshLightEnvironmentAssessment'));
   const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
   const cssSrc = [
     await fs.readFile(new URL('../css/light-sun.css', import.meta.url), 'utf8'),
@@ -659,7 +688,8 @@ const {
   assert('Light assessment is linked from sidebar Analysis tools',
     navSrc.includes("label: 'Light assessment'") &&
     navSrc.includes("key: 'light-env-assessment'") &&
-    navSrc.indexOf('Analysis tools') < navSrc.indexOf("label: 'Light assessment'"));
+    navSrc.indexOf('Analysis tools') < navSrc.indexOf("label: 'Light assessment'") &&
+    !navSrc.includes('window.openLightEnvironmentAssessment'));
   assert('Light assessment sidebar badge reflects saved audit snapshots',
     navSrc.includes('lightAuditCount') &&
     navSrc.includes('lightRoomCount') &&

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -204,6 +204,7 @@ const lightWorkflowCheckJsModules = [
   'js/light-env-evening.js',
   'js/light-env-model.js',
   'js/light-env-screen-ui.js',
+  'js/light-env-shell-hooks.js',
   'js/light-env-store.js',
   'js/light-page-view-hooks.js',
   'js/light-page-view-ui-hooks.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -128,6 +128,7 @@
     "js/light-env-evening.js",
     "js/light-env-model.js",
     "js/light-env-screen-ui.js",
+    "js/light-env-shell-hooks.js",
     "js/light-env-store.js",
     "js/light-page-view-hooks.js",
     "js/light-page-view-ui-hooks.js",

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -61,7 +61,6 @@ interface Window {
   closeChatPanel: () => void;
   closeFeedbackModal: () => void;
   closeImportModal: () => void;
-  closeLightEnvironmentAssessment?: () => void;
   closeMobileSidebar: () => void;
   closeReportBuilder?: () => void;
   closeRestoreMnemonicDialog?: () => void;
@@ -287,7 +286,6 @@ interface Window {
   ingredientDailyTotal?: AnyFunction;
   maybeAnalyzeOnboardingAfterSave?: AnyFunction;
   maybeShowAnalyticsConsent?: () => void;
-  openLightEnvironmentAssessment?: AnyFunction;
   purgeMeteoCache?: AnyFunction;
   rehydrateStaleSessions?: () => Promise<{ rehydrated?: number }>;
   SUN_ENGINE_VERSION?: number;
@@ -314,7 +312,6 @@ interface Window {
   renderMeasurementAIInline?: AnyFunction;
   renderRoomAIBlock?: AnyFunction;
   renderScreenAIBlock?: AnyFunction;
-  refreshLightEnvironmentAssessment?: AnyFunction;
   saveLightAuditFromUI?: AnyFunction;
   saveMeasurement?: AnyFunction;
   suggestRoomSourceFromSpectrum?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.19';
+self.APP_VERSION = '1.10.20';


### PR DESCRIPTION
## Summary
- Wire Light Environment modal open/close through startup hook dependencies instead of window lookups in nav/global listeners.
- Remove assessment modal open/close/refresh from the Light Env window facade while keeping named module exports/action handlers.
- Add source/browser coverage guards, CheckJS registration, service worker cache entry, and bump version.js to 1.10.20.

## Tests
- node tests/test-light-env.js
- node tests/test-light-env-delegated-actions.js
- node tests/test-light-tools.js
- npx playwright test tests/playwright/light-env-browser-coverage.spec.js tests/playwright/light-env-coverage-batch.spec.js tests/playwright/nav-delegated-actions.spec.js
- node tests/test-quality-guardrails.js
- npm test
- git diff --check
- ./run-tests.sh