### PR TITLE
[codex] Remove light env audit action globals

### DIFF
--- a/js/light-ai-save-hooks.js
+++ b/js/light-ai-save-hooks.js
@@ -7,6 +7,7 @@ import { configureSunDefaults } from './sun-defaults.js';
 import { hasAIProvider } from './api.js';
 import { addRoom, configureLightEnv, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';
 import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';
+import { openChatPanel } from './chat-panel.js';
 import { maybeAnalyzeMeasurementAfterSave, renderMeasurementAIInline } from './light-tools-ai-analysis.js';
 import { renderRoomAIBlock } from './light-env-ai-analysis.js';
 import { renderScreenAIBlock } from './light-screen-ai-analysis.js';
@@ -16,7 +17,7 @@ import { maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock } from './sun-
 import { solarZenithAngle } from './sun-uvdata.js';
 
 configureLightEnv({ getMeasurementsForRoom, renderMeasurementAIInline, renderRoomAIBlock, renderScreenAIBlock });
-configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot });
+configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot, openChatPanel });
 configureLightTools({
   maybeAnalyzeMeasurementAfterSave,
   suggestRoomSourceFromSpectrum,

--- a/js/light-env-audits.js
+++ b/js/light-env-audits.js
@@ -23,7 +23,7 @@ import { lightEnvActionAttrs } from './light-env-actions.js';
 //     screens: [...deep-copy], measurements: [...last 30d, deep-copy],
 //     createdAt, updatedAt? }
 
-/** @type {{ getEnvironment: AnyFunction, computeRoomSeverity: AnyFunction, refreshLightEnvironmentUI: AnyFunction, hasAIProvider: AnyFunction, maybeAnalyzeAuditAfterSave: AnyFunction, renderAuditAIBlock: AnyFunction, renderAuditAIDot: AnyFunction }} */
+/** @type {{ getEnvironment: AnyFunction, computeRoomSeverity: AnyFunction, refreshLightEnvironmentUI: AnyFunction, hasAIProvider: AnyFunction, maybeAnalyzeAuditAfterSave: AnyFunction, renderAuditAIBlock: AnyFunction, renderAuditAIDot: AnyFunction, openChatPanel: AnyFunction | null }} */
 const auditDeps = {
   getEnvironment: () => state.importedData?.lightEnvironment || null,
   computeRoomSeverity: () => ({
@@ -37,6 +37,7 @@ const auditDeps = {
   maybeAnalyzeAuditAfterSave: () => {},
   renderAuditAIBlock: () => '',
   renderAuditAIDot: () => '',
+  openChatPanel: null,
 };
 
 const LIGHT_AUDITS_ANCHOR = '.light-audits-block';
@@ -48,8 +49,13 @@ let _showAllAudits = false;
 let _auditsBlockOpen = false;
 
 export function configureLightEnvAudits(deps = {}) {
-  Object.assign(auditDeps, deps);
-  installWindowHandlers();
+  const previous = { ...auditDeps };
+  for (const [name, value] of Object.entries(deps || {})) {
+    if (Object.prototype.hasOwnProperty.call(auditDeps, name) && typeof value === 'function') {
+      auditDeps[name] = value;
+    }
+  }
+  return previous;
 }
 
 function getEnvironmentSnapshot() {
@@ -78,6 +84,14 @@ function renderAuditAIDot(audit) {
 
 function hasAuditAIProvider() {
   try { return !!auditDeps.hasAIProvider(); } catch (_) { return false; }
+}
+
+function openAuditCompareChat(prompt) {
+  if (typeof auditDeps.openChatPanel !== 'function') {
+    showNotification('Chat panel unavailable on this build.', 'error');
+    return;
+  }
+  try { auditDeps.openChatPanel(prompt); } catch (_) { showNotification('Chat panel unavailable on this build.', 'error'); }
 }
 
 function refreshAuditsUI() {
@@ -549,93 +563,105 @@ export function renderLightAuditsBlock() {
   return html;
 }
 
-function installWindowHandlers() {
+export async function saveLightAuditFromUI() {
+  const defaultLabel = `Audit ${getLightAudits().length + 1}`;
+  const label = await showPromptDialog('Audit label (e.g. "Pre-mitigation", "After LED swap")', {
+    defaultValue: defaultLabel,
+    okLabel: 'Save audit',
+    placeholder: 'Audit label',
+  });
+  // showPromptDialog resolves to null on Cancel/Esc/backdrop-click.
+  if (label === null) return;
+  const trimmed = label.trim() || defaultLabel;
+  const audit = await saveLightAudit(trimmed);
+  if (audit) {
+    showNotification(`Saved audit: ${audit.label}`);
+    _expandedAuditId = audit.id;
+    _showAllAudits = false;
+    refreshAuditCardUI(audit.id);
+  }
+}
+
+export function toggleLightAudit(id) {
+  _expandedAuditId = (_expandedAuditId === id) ? null : id;
+  refreshAuditCardUI(id);
+}
+
+export function toggleLightAuditCompare() {
+  _auditCompareMode = !_auditCompareMode;
+  _expandedAuditId = null;
+  refreshAuditsUI();
+}
+
+export function toggleLightAuditHistory() {
+  _showAllAudits = !_showAllAudits;
+  if (!_showAllAudits && _expandedAuditId) {
+    const visibleIds = new Set(sortAuditsNewestFirst(getLightAudits()).slice(0, AUDITS_DEFAULT_CAP).map(a => a.id));
+    if (!visibleIds.has(_expandedAuditId)) _expandedAuditId = null;
+  }
+  refreshAuditsUI();
+}
+
+export function setLightAuditsBlockOpen(open) {
+  _auditsBlockOpen = !!open;
+}
+
+export async function updateLightAuditField(id, field, value) {
+  await updateLightAudit(id, { [field]: value });
+  _expandedAuditId = id;
+  keepAuditVisible(id);
+  refreshAuditCardUI(id);
+}
+
+export async function deleteLightAuditConfirm(id) {
+  if (await showConfirmDialog('Delete this audit? This cannot be undone.')) {
+    const deletingExpandedAudit = _expandedAuditId === id;
+    await deleteLightAudit(id);
+    _auditsBlockOpen = true;
+    if (getLightAudits().length < 2) _auditCompareMode = false;
+    if (deletingExpandedAudit) {
+      _expandedAuditId = sortAuditsNewestFirst(getLightAudits())[0]?.id || null;
+    }
+    if (_expandedAuditId) {
+      keepAuditVisible(_expandedAuditId);
+      refreshAuditCardUI(_expandedAuditId);
+    } else {
+      refreshAuditsUI();
+    }
+  }
+}
+
+export function interpretLightAuditCompare(oldId, newId) {
+  const audits = getLightAudits();
+  const a1 = audits.find(a => a.id === oldId);
+  const a2 = audits.find(a => a.id === newId);
+  if (!a1 || !a2) {
+    showNotification('Could not find one of the audits to compare.', 'error');
+    return;
+  }
+  const summary = serializeAuditComparison(a1, a2);
+  const prompt = `Here is a Light Environment audit comparison from my home. ` +
+    `Walk me through what improved, what regressed, and what one or two changes ` +
+    `would have the biggest circadian impact next.\n\n${summary}`;
+  openAuditCompareChat(prompt);
+}
+
+export const lightEnvAuditActionHandlers = Object.freeze({
+  saveLightAuditFromUI,
+  toggleLightAudit,
+  toggleLightAuditCompare,
+  toggleLightAuditHistory,
+  setLightAuditsBlockOpen,
+  updateLightAuditField,
+  deleteLightAuditConfirm,
+  interpretLightAuditCompare,
+});
+
+function installWindowFacade() {
   if (typeof window === 'undefined') return;
   Object.assign(window, {
     getLightAudits,
-    saveLightAuditFromUI: async () => {
-      const defaultLabel = `Audit ${getLightAudits().length + 1}`;
-      const label = await showPromptDialog('Audit label (e.g. "Pre-mitigation", "After LED swap")', {
-        defaultValue: defaultLabel,
-        okLabel: 'Save audit',
-        placeholder: 'Audit label',
-      });
-      // showPromptDialog resolves to null on Cancel/Esc/backdrop-click.
-      if (label === null) return;
-      const trimmed = label.trim() || defaultLabel;
-      const audit = await saveLightAudit(trimmed);
-      if (audit) {
-        showNotification(`Saved audit: ${audit.label}`);
-        _expandedAuditId = audit.id;
-        _showAllAudits = false;
-        refreshAuditCardUI(audit.id);
-      }
-    },
-    toggleLightAudit: (id) => {
-      _expandedAuditId = (_expandedAuditId === id) ? null : id;
-      refreshAuditCardUI(id);
-    },
-    toggleLightAuditCompare: () => {
-      _auditCompareMode = !_auditCompareMode;
-      _expandedAuditId = null;
-      refreshAuditsUI();
-    },
-    toggleLightAuditHistory: () => {
-      _showAllAudits = !_showAllAudits;
-      if (!_showAllAudits && _expandedAuditId) {
-        const visibleIds = new Set(sortAuditsNewestFirst(getLightAudits()).slice(0, AUDITS_DEFAULT_CAP).map(a => a.id));
-        if (!visibleIds.has(_expandedAuditId)) _expandedAuditId = null;
-      }
-      refreshAuditsUI();
-    },
-    setLightAuditsBlockOpen: (open) => {
-      _auditsBlockOpen = !!open;
-    },
-    updateLightAuditField: async (id, field, value) => {
-      await updateLightAudit(id, { [field]: value });
-      _expandedAuditId = id;
-      keepAuditVisible(id);
-      refreshAuditCardUI(id);
-    },
-    deleteLightAuditConfirm: async (id) => {
-      if (await showConfirmDialog('Delete this audit? This cannot be undone.')) {
-        const deletingExpandedAudit = _expandedAuditId === id;
-        await deleteLightAudit(id);
-        _auditsBlockOpen = true;
-        if (getLightAudits().length < 2) _auditCompareMode = false;
-        if (deletingExpandedAudit) {
-          _expandedAuditId = sortAuditsNewestFirst(getLightAudits())[0]?.id || null;
-        }
-        if (_expandedAuditId) {
-          keepAuditVisible(_expandedAuditId);
-          refreshAuditCardUI(_expandedAuditId);
-        } else {
-          refreshAuditsUI();
-        }
-      }
-    },
-    // "Interpret changes" — pre-fills the chat panel with a comparison
-    // summary so the AI can reason about what shifted and what to try
-    // next. Lighter-weight than EMF's dedicated streaming overlay; the
-    // chat panel already covers the same use case (and lets the user
-    // follow up with questions inline).
-    interpretLightAuditCompare: (oldId, newId) => {
-      const audits = getLightAudits();
-      const a1 = audits.find(a => a.id === oldId);
-      const a2 = audits.find(a => a.id === newId);
-      if (!a1 || !a2) {
-        showNotification('Could not find one of the audits to compare.', 'error');
-        return;
-      }
-      const summary = serializeAuditComparison(a1, a2);
-      const prompt = `Here is a Light Environment audit comparison from my home. ` +
-        `Walk me through what improved, what regressed, and what one or two changes ` +
-        `would have the biggest circadian impact next.\n\n${summary}`;
-      if (typeof window.openChatPanel === 'function') {
-        window.openChatPanel(prompt);
-      } else {
-        showNotification('Chat panel unavailable on this build.', 'error');
-      }
-    },
   });
 }
+
+installWindowFacade();

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -46,6 +46,7 @@ import {
 import {
   configureLightEnvAudits,
   getLightAudits,
+  lightEnvAuditActionHandlers,
   renderLightAuditsBlock,
 } from './light-env-audits.js';
 import { installLightEnvActionDelegates, lightEnvActionAttrs } from './light-env-actions.js';
@@ -1094,40 +1095,9 @@ configureLightEnvAudits({
 });
 
 if (typeof document !== 'undefined') {
-  const saveLightAuditFromUI = typeof globalThis.saveLightAuditFromUI === 'function'
-    ? globalThis.saveLightAuditFromUI
-    : undefined;
-  const toggleLightAudit = typeof globalThis.toggleLightAudit === 'function'
-    ? globalThis.toggleLightAudit
-    : undefined;
-  const toggleLightAuditCompare = typeof globalThis.toggleLightAuditCompare === 'function'
-    ? globalThis.toggleLightAuditCompare
-    : undefined;
-  const toggleLightAuditHistory = typeof globalThis.toggleLightAuditHistory === 'function'
-    ? globalThis.toggleLightAuditHistory
-    : undefined;
-  const setLightAuditsBlockOpen = typeof globalThis.setLightAuditsBlockOpen === 'function'
-    ? globalThis.setLightAuditsBlockOpen
-    : undefined;
-  const updateLightAuditField = typeof globalThis.updateLightAuditField === 'function'
-    ? globalThis.updateLightAuditField
-    : undefined;
-  const deleteLightAuditConfirm = typeof globalThis.deleteLightAuditConfirm === 'function'
-    ? globalThis.deleteLightAuditConfirm
-    : undefined;
-  const interpretLightAuditCompare = typeof globalThis.interpretLightAuditCompare === 'function'
-    ? globalThis.interpretLightAuditCompare
-    : undefined;
   installLightEnvActionDelegates({
     ...lightEnvActionHandlers,
-    saveLightAuditFromUI,
-    toggleLightAudit,
-    toggleLightAuditCompare,
-    toggleLightAuditHistory,
-    setLightAuditsBlockOpen,
-    updateLightAuditField,
-    deleteLightAuditConfirm,
-    interpretLightAuditCompare,
+    ...lightEnvAuditActionHandlers,
   });
 }
 

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -295,8 +295,8 @@ test('Light audit defaults cover fallback dependency accessors', async ({ page }
       host.innerHTML = audits.renderLightAuditsBlock();
       document.body.appendChild(host);
       try {
-        window.toggleLightAudit('default_dep_audit');
-        window.toggleLightAudit('default_dep_audit');
+        audits.lightEnvAuditActionHandlers.toggleLightAudit('default_dep_audit');
+        audits.lightEnvAuditActionHandlers.toggleLightAudit('default_dep_audit');
 
         outcomes.defaultAuditDepsRenderFallbackSeverity =
           host.querySelector('.light-env-sev-green') !== null;
@@ -476,6 +476,7 @@ test('Light audit history covers save expand update compare interpret and delete
         maybeAnalyzeAuditAfterSave: audit => calls.push(['auto-audit', audit.id]),
         renderAuditAIDot: audit => `<span class="light-audit-ai-dot" data-audit="${audit.id}"></span>`,
         renderAuditAIBlock: audit => `<div class="light-audit-ai-block">AI note for ${audit.label}</div>`,
+        openChatPanel: prompt => calls.push(['chat', prompt]),
       });
 
       const host = renderHost();
@@ -492,7 +493,7 @@ test('Light audit history covers save expand update compare interpret and delete
       outcomes.showAllHistoryRevealsOlderAudit =
         document.querySelector('#light-audit-test-host')?.textContent.includes('Baseline') === true;
 
-      window.toggleLightAudit('audit_old');
+      audits.lightEnvAuditActionHandlers.toggleLightAudit('audit_old');
       await waitFor('.light-audit-card[data-id="audit_old"].expanded', 'expanded older audit');
       outcomes.expandedAuditRendersChannelsAndAI =
         document.querySelector('.light-audit-card[data-id="audit_old"]')?.textContent.includes('Melanopic') === true
@@ -521,7 +522,7 @@ test('Light audit history covers save expand update compare interpret and delete
         && savedAudit?.measurements?.length === 3
         && document.querySelector('.notification-toast')?.textContent.includes('Saved audit: Post cleanup') === true;
 
-      window.toggleLightAuditCompare();
+      audits.lightEnvAuditActionHandlers.toggleLightAuditCompare();
       await waitFor('.light-audit-compare-rooms', 'audit compare rooms');
       outcomes.compareModeShowsDeltasAndInterpretAction =
         document.querySelector('.light-audit-compare-head')?.textContent.includes('After:') === true
@@ -533,7 +534,7 @@ test('Light audit history covers save expand update compare interpret and delete
       outcomes.interpretComparePrefillsChat =
         calls.some(call => call[0] === 'chat' && String(call[1] || '').includes('Light Environment audit comparison'));
 
-      const deletePromise = window.deleteLightAuditConfirm('audit_mid');
+      const deletePromise = audits.lightEnvAuditActionHandlers.deleteLightAuditConfirm('audit_mid');
       await waitFor('#confirm-ok', 'delete audit confirm');
       document.getElementById('confirm-ok').click();
       await deletePromise;

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -92,6 +92,8 @@ assert('light-env click delegate ignores toggle-only details actions',
 assert('light-env internal action handlers are registered through module object, not window facade',
   envSrc.includes('export const lightEnvActionHandlers = Object.freeze({') &&
     envSrc.includes('...lightEnvActionHandlers,') &&
+    envSrc.includes('...lightEnvAuditActionHandlers') &&
+    actionSrc.includes('actions.saveLightAuditFromUI?.()') &&
     lightEnvWindowFacadeSrc.includes('renderEnvironmentSection') &&
     !lightEnvWindowFacadeSrc.includes('addLightEnvRoom') &&
     !lightEnvWindowFacadeSrc.includes('deleteLightEnvScreenConfirm') &&
@@ -120,17 +122,15 @@ assert('light-env form delegates separate live input from change-only controls',
   actionSrc.includes("'update-room-hours', 'update-room-name'") &&
     actionSrc.includes("'update-screen-blue-blocker'") &&
     actionSrc.includes("'update-audit-field'"));
-assert('light-env.js captures saveLightAuditFromUI when installing delegates',
-  envSrc.includes("const saveLightAuditFromUI = typeof globalThis.saveLightAuditFromUI === 'function'") &&
-    envSrc.includes('saveLightAuditFromUI,') &&
-    !envSrc.includes('saveLightAuditFromUI: () => globalThis.saveLightAuditFromUI?.()'));
-assert('light-env.js captures light audit callbacks when installing delegates',
-  envSrc.includes("const toggleLightAudit = typeof globalThis.toggleLightAudit === 'function'") &&
-    envSrc.includes("const updateLightAuditField = typeof globalThis.updateLightAuditField === 'function'") &&
-    envSrc.includes('toggleLightAudit,') &&
-    envSrc.includes('updateLightAuditField,') &&
-    envSrc.includes('deleteLightAuditConfirm,') &&
-    envSrc.includes('interpretLightAuditCompare,'));
+assert('light-env audit callbacks install from module handlers instead of global capture',
+  auditSrc.includes('export const lightEnvAuditActionHandlers = Object.freeze({') &&
+    envSrc.includes("import {") &&
+    envSrc.includes('lightEnvAuditActionHandlers') &&
+    envSrc.includes('...lightEnvAuditActionHandlers') &&
+    !envSrc.includes('globalThis.saveLightAuditFromUI') &&
+    !envSrc.includes('globalThis.toggleLightAudit') &&
+    !envSrc.includes('globalThis.updateLightAuditField') &&
+    !auditSrc.includes('window.openChatPanel'));
 assert('service worker precaches light environment action/render modules',
   swSrc.includes("'/js/light-env-actions.js'") &&
     swSrc.includes("'/js/light-env-shell-hooks.js'") &&

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -465,21 +465,21 @@ const {
     !compactAudits.includes('Older hidden') &&
     !compactAudits.includes('Oldest hidden') &&
     compactAudits.includes('Show 2 older audits'));
-  window.toggleLightAuditHistory();
+  auditModule.lightEnvAuditActionHandlers.toggleLightAuditHistory();
   const expandedAudits = auditModule.renderLightAuditsBlock();
   assert('Audit history can expand older snapshots inline',
     expandedAudits.includes('Latest visible') &&
     expandedAudits.includes('Older hidden') &&
     expandedAudits.includes('Oldest hidden') &&
     expandedAudits.includes('Show only latest 2 audits'));
-  window.toggleLightAuditHistory();
-  window.setLightAuditsBlockOpen(true);
+  auditModule.lightEnvAuditActionHandlers.toggleLightAuditHistory();
+  auditModule.lightEnvAuditActionHandlers.setLightAuditsBlockOpen(true);
   const manuallyOpenAudits = auditModule.renderLightAuditsBlock();
   assert('Audit block can stay open without an expanded audit card',
     manuallyOpenAudits.includes('class="light-env-block light-audits-block" open') &&
     manuallyOpenAudits.includes('data-light-env-action="set-audits-block-open"') &&
     !manuallyOpenAudits.includes('ontoggle='));
-  window.setLightAuditsBlockOpen(false);
+  auditModule.lightEnvAuditActionHandlers.setLightAuditsBlockOpen(false);
   const manuallyClosedAudits = auditModule.renderLightAuditsBlock();
   assert('Audit block open state can be manually collapsed',
     manuallyClosedAudits.includes('class="light-env-block light-audits-block"') &&
@@ -615,6 +615,7 @@ const {
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light audit storage/rendering lives in its own module',
     auditSrc.includes('configureLightEnvAudits') &&
+    auditSrc.includes('export const lightEnvAuditActionHandlers = Object.freeze({') &&
     auditSrc.includes('renderLightAuditsBlock') &&
     auditSrc.includes('saveLightAuditFromUI') &&
     auditSrc.includes('scrollAnchor: LIGHT_AUDITS_ANCHOR') &&
@@ -624,6 +625,12 @@ const {
     auditSrc.includes('deletingExpandedAudit') &&
     auditSrc.includes('sortAuditsNewestFirst(getLightAudits())[0]?.id') &&
     envSrc.includes('modal.scrollTop') &&
+    envSrc.includes('...lightEnvAuditActionHandlers') &&
+    !envSrc.includes('globalThis.saveLightAuditFromUI') &&
+    !envSrc.includes('globalThis.toggleLightAudit') &&
+    !envSrc.includes('globalThis.updateLightAuditField') &&
+    !auditSrc.includes('window.openChatPanel') &&
+    !globalsSrc.includes('saveLightAuditFromUI') &&
     !envSrc.includes('function renderLightAuditCompare'));
   assert('Light audit AI hooks route through startup wiring',
     !auditSrc.includes('window.maybeAnalyzeAuditAfterSave') &&
@@ -632,8 +639,9 @@ const {
     !auditSrc.includes('window.hasAIProvider') &&
     aiSaveHooksSrc.includes("import { configureLightEnvAudits } from './light-env-audits.js';") &&
     aiSaveHooksSrc.includes("import { hasAIProvider } from './api.js';") &&
+    aiSaveHooksSrc.includes("import { openChatPanel } from './chat-panel.js';") &&
     aiSaveHooksSrc.includes("import { maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot } from './light-audit-ai-analysis.js';") &&
-    aiSaveHooksSrc.includes('configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot })') &&
+    aiSaveHooksSrc.includes('configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot, openChatPanel })') &&
     appLightSunSrc.includes("import './light-ai-save-hooks.js';"));
   assert('Burden AI renderer routes through light-env configuration instead of window lookup',
     envSrc.includes('export function configureLightEnv') &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -312,7 +312,6 @@ interface Window {
   renderMeasurementAIInline?: AnyFunction;
   renderRoomAIBlock?: AnyFunction;
   renderScreenAIBlock?: AnyFunction;
-  saveLightAuditFromUI?: AnyFunction;
   saveMeasurement?: AnyFunction;
   suggestRoomSourceFromSpectrum?: AnyFunction;
   openChatPanel: AnyFunction;
@@ -348,5 +347,4 @@ declare var renderBurdenInterp: AnyFunction | undefined;
 declare var renderMeasurementAIInline: AnyFunction | undefined;
 declare var renderRoomAIBlock: AnyFunction | undefined;
 declare var renderScreenAIBlock: AnyFunction | undefined;
-declare var saveLightAuditFromUI: AnyFunction | undefined;
 declare var ingredientDailyTotal: AnyFunction | undefined;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.20';
+self.APP_VERSION = '1.10.21';


### PR DESCRIPTION
## Summary

- export Light Environment audit UI actions as `lightEnvAuditActionHandlers`
- install those handlers directly from `light-env.js` instead of rediscovering them on `globalThis`
- inject the audit compare chat handoff through `configureLightEnvAudits({ openChatPanel })`
- remove `saveLightAuditFromUI` from ambient globals and bump `APP_VERSION` to `1.10.21`

## Validation

- `node tests/test-light-env.js`
- `node tests/test-light-env-delegated-actions.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npx playwright test tests/playwright/environment-coverage-batch.spec.js tests/playwright/light-env-actions-browser-coverage.spec.js --project=chromium`
- `npm test`
- `npm run quality`
- `./run-tests.sh`
