### PR TITLE
[codex] Remove light env render window facade

### DIFF
--- a/js/light-env.js
+++ b/js/light-env.js
@@ -1107,20 +1107,4 @@ if (typeof window !== 'undefined') {
     modalSelector: '.light-env-assessment-modal',
     refresh: refreshOpenLightEnvironmentAssessmentOnSync,
   });
-
-  Object.assign(window, {
-    getLightEnvironment: getEnvironment,
-    suggestRoomSourceFromSpectrum,
-    computeDeficitAxes,
-    computeRoomSeverity,
-    computeScreenStatus,
-    computeIndoorBurden,
-    getScreensForRoom,
-    // Rooms accessor for legacy debug/coverage surfaces. Cross-module app
-    // callers should import getRooms/addRoom through light-ai-save-hooks.
-    getRooms,
-    isLightEnvActiveToday: isActiveToday,
-    renderEnvironmentSection,
-    renderEnvironmentAssessmentSummary,
-  });
 }

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -327,7 +327,6 @@ test('Light audit defaults cover fallback dependency accessors', async ({ page }
 test('Light audit history covers save expand update compare interpret and delete controls', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.renderEnvironmentAssessmentSummary === 'function');
 
   const results = await page.evaluate(async () => {
     const [{ state }, data, audits] = await Promise.all([

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -16,7 +16,6 @@ function expectAll(outcomes) {
 test('light environment browser coverage handles summary modal prompt and source helpers', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.renderEnvironmentSection === 'function');
 
   const outcomes = await page.evaluate(async () => {
     const [{ state }, data, lightEnv] = await Promise.all([
@@ -75,16 +74,17 @@ test('light environment browser coverage handles summary modal prompt and source
       window.navigate = (route, meta) => calls.push(['navigate', route, meta || null]);
       document.getElementById('light-env-assessment-overlay')?.remove();
 
-      const emptyFull = window.renderEnvironmentSection();
-      const emptyEmbedded = window.renderEnvironmentSection({ embedded: true });
-      const emptySummary = window.renderEnvironmentAssessmentSummary();
-      outcomes.windowExportsAndEmptyRenderStates =
-        window.computeIndoorBurden === lightEnv.computeIndoorBurden
-        && window.computeDeficitAxes === lightEnv.computeDeficitAxes
+      const emptyFull = lightEnv.renderEnvironmentSection();
+      const emptyEmbedded = lightEnv.renderEnvironmentSection({ embedded: true });
+      const emptySummary = lightEnv.renderEnvironmentAssessmentSummary();
+      outcomes.moduleExportsAndEmptyRenderStates =
+        window.computeIndoorBurden === undefined
+        && window.computeDeficitAxes === undefined
         && window.computeLightDeficitAxes === undefined
         && window.addLightEnvRoom === undefined
         && typeof actions.addLightEnvRoom === 'function'
-        && window.renderEnvironmentSection === lightEnv.renderEnvironmentSection
+        && window.renderEnvironmentSection === undefined
+        && window.renderEnvironmentAssessmentSummary === undefined
         && window.openLightEnvironmentAssessment === undefined
         && window.closeLightEnvironmentAssessment === undefined
         && window.refreshLightEnvironmentAssessment === undefined
@@ -138,8 +138,8 @@ test('light environment browser coverage handles summary modal prompt and source
           .some(el => (el.textContent || '').includes('Auto-set Bedroom'));
 
       env().burdenAI = { status: 'ok', dot: 'yellow', text: 'AI says moderate' };
-      const mappedSummary = window.renderEnvironmentAssessmentSummary();
-      const mappedSection = window.renderEnvironmentSection({ embedded: true });
+      const mappedSummary = lightEnv.renderEnvironmentAssessmentSummary();
+      const mappedSection = lightEnv.renderEnvironmentSection({ embedded: true });
       outcomes.summaryUsesAIVerdictWhenMapped =
         mappedSection.includes('Moderate load')
         && mappedSummary.includes('Open assessment')
@@ -149,7 +149,7 @@ test('light environment browser coverage handles summary modal prompt and source
       env().rooms[0].updatedAt = 100;
       bedroom.updatedAt = 200;
       const defaultHost = document.createElement('div');
-      defaultHost.innerHTML = window.renderEnvironmentSection({ embedded: true });
+      defaultHost.innerHTML = lightEnv.renderEnvironmentSection({ embedded: true });
       outcomes.defaultActiveRoomUsesMostRecentlyUpdatedRoom =
         defaultHost.querySelector(`.light-env-room-disclosure[data-id="${bedroom.id}"]`)?.classList.contains('expanded') === true;
 
@@ -202,7 +202,6 @@ test('light environment browser coverage handles summary modal prompt and source
 test('light environment browser coverage handles screens tools and confirm deletes', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.renderEnvironmentSection === 'function');
 
   const outcomes = await page.evaluate(async () => {
     const [{ state }, data, lightEnv] = await Promise.all([
@@ -310,7 +309,7 @@ test('light environment browser coverage handles screens tools and confirm delet
       ];
       const host = document.createElement('div');
       host.id = 'light-env-browser-host';
-      host.innerHTML = window.renderEnvironmentSection({ embedded: true });
+      host.innerHTML = lightEnv.renderEnvironmentSection({ embedded: true });
       document.body.appendChild(host);
       const fallbackCard = host.querySelector(`.light-env-screen-card[data-id="${fallbackScreen.id}"]`);
       outcomes.screenMutationHandlersUpdateAndRender =
@@ -332,7 +331,7 @@ test('light environment browser coverage handles screens tools and confirm delet
       const wasScreenExpanded = fallbackCard?.classList.contains('expanded') === true;
       actions.toggleLightEnvScreenExpanded(fallbackScreen.id);
       const expandedHost = document.createElement('div');
-      expandedHost.innerHTML = window.renderEnvironmentSection({ embedded: true });
+      expandedHost.innerHTML = lightEnv.renderEnvironmentSection({ embedded: true });
       outcomes.screenExpandToggleChangesPortableCardState =
         expandedHost.querySelector(`.light-env-screen-card[data-id="${fallbackScreen.id}"]`)?.classList.contains('expanded') !== wasScreenExpanded;
       for (const tool of ['spectrum', 'lux', 'flicker', 'cct', 'darkness']) {
@@ -372,29 +371,32 @@ test('light environment browser coverage handles screens tools and confirm delet
         && env().screens.some(s => s.id === officeScreen.id && s.roomId === null);
 
       actions.setActiveLightEnvRoom(livingId);
-      outcomes.setActiveRoomAndBurdenGlobalsRemainUsable =
+      outcomes.setActiveRoomAndBurdenModuleHelpersRemainUsable =
         localStorage.getItem('labcharts-light-env-active-room') === livingId
-        && window.isLightEnvActiveToday(env().rooms.find(r => r.id === livingId)) === true
-        && typeof window.computeRoomSeverity(env().rooms.find(r => r.id === livingId)).tier === 'number'
-        && typeof window.computeIndoorBurden().d2 === 'number'
-        && typeof window.computeDeficitAxes().d3 === 'number'
-        && window.getScreensForRoom(null).some(s => s.id === officeScreen.id)
-        && window.getRooms().some(r => r.id === livingId);
+        && lightEnv.isActiveToday(env().rooms.find(r => r.id === livingId)) === true
+        && typeof lightEnv.computeRoomSeverity(env().rooms.find(r => r.id === livingId)).tier === 'number'
+        && typeof lightEnv.computeIndoorBurden().d2 === 'number'
+        && typeof lightEnv.computeDeficitAxes().d3 === 'number'
+        && lightEnv.getScreensForRoom(null).some(s => s.id === officeScreen.id)
+        && lightEnv.getRooms().some(r => r.id === livingId)
+        && window.isLightEnvActiveToday === undefined
+        && window.getScreensForRoom === undefined
+        && window.getRooms === undefined;
 
       const directRoomId = await lightEnv.addRoom('Garage');
       await actions.addLightEnvScreenWithDevice(null, 'tablet');
       await waitUntil(() => env().screens.some(s => s.device === 'tablet'), 'tablet screen added');
       const directScreenId = latestScreen().id;
       const directScreenBeforeDelete = document.createElement('div');
-      directScreenBeforeDelete.innerHTML = window.renderEnvironmentSection({ embedded: true });
+      directScreenBeforeDelete.innerHTML = lightEnv.renderEnvironmentSection({ embedded: true });
       await actions.deleteLightEnvScreen(directScreenId);
       const directScreenAfterDelete = document.createElement('div');
-      directScreenAfterDelete.innerHTML = window.renderEnvironmentSection({ embedded: true });
+      directScreenAfterDelete.innerHTML = lightEnv.renderEnvironmentSection({ embedded: true });
       await actions.addLightEnvScreenWithDevice(null, 'monitor');
       await waitUntil(() => env().screens.some(s => s.device === 'monitor'), 'monitor screen added');
       const replacementScreenId = latestScreen().id;
       const directScreenAfterReplacement = document.createElement('div');
-      directScreenAfterReplacement.innerHTML = window.renderEnvironmentSection({ embedded: true });
+      directScreenAfterReplacement.innerHTML = lightEnv.renderEnvironmentSection({ embedded: true });
       await actions.deleteLightEnvRoom(directRoomId);
       outcomes.directDeleteHelpersRemoveRecords =
         directScreenBeforeDelete.querySelector(`.light-env-screen-card[data-id="${directScreenId}"]`)?.classList.contains('expanded') === true

--- a/tests/playwright/light-env-coverage-batch.spec.js
+++ b/tests/playwright/light-env-coverage-batch.spec.js
@@ -7,12 +7,12 @@ test('Light environment assessment drives delegated room and screen controls', a
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.renderEnvironmentAssessmentSummary === 'function');
 
   const results = await page.evaluate(async () => {
-    const [{ state }, data] = await Promise.all([
+    const [{ state }, data, lightEnv] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
+      import('/js/light-env.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
@@ -92,7 +92,7 @@ test('Light environment assessment drives delegated room and screen controls', a
 
       const summaryHost = document.createElement('div');
       summaryHost.id = 'light-env-summary-host';
-      summaryHost.innerHTML = window.renderEnvironmentAssessmentSummary();
+      summaryHost.innerHTML = lightEnv.renderEnvironmentAssessmentSummary();
       document.body.appendChild(summaryHost);
       summaryHost.querySelector(selectorFor('open-assessment'))?.click();
       await waitFor('#light-env-assessment-overlay .light-env-assessment-modal', 'assessment modal');

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -129,13 +129,15 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
   await page.waitForSelector('#main-content');
 
   const results = await page.evaluate(async ({ lightPageUrl }) => {
-    const [{ state }, lightPage] = await Promise.all([
+    const [{ state }, lightPage, lightEnv] = await Promise.all([
       import('/js/state.js'),
       import(lightPageUrl),
+      import('/js/light-env.js'),
     ]);
     const outcomes = {};
     const RealDate = Date;
     const main = document.getElementById('main-content');
+    let renderEnvironmentAssessmentSummary = lightEnv.renderEnvironmentAssessmentSummary;
     const saved = {
       importedData: state.importedData,
       mainHTML: main?.innerHTML,
@@ -159,7 +161,6 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       renderLightTodayHero: window.renderLightTodayHero,
       renderSunSetupCard: window.renderSunSetupCard,
       renderDevicesSection: window.renderDevicesSection,
-      renderEnvironmentAssessmentSummary: window.renderEnvironmentAssessmentSummary,
       renderLightTools: window.renderLightTools,
     };
     const syncLightPageDeps = () => lightPage.configureLightPageView({
@@ -181,7 +182,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       renderLightTodayHero: typeof window.renderLightTodayHero === 'function' ? window.renderLightTodayHero : () => '',
       renderSunSetupCard: typeof window.renderSunSetupCard === 'function' ? window.renderSunSetupCard : () => '',
       renderDevicesSection: typeof window.renderDevicesSection === 'function' ? window.renderDevicesSection : () => '',
-      renderEnvironmentAssessmentSummary: typeof window.renderEnvironmentAssessmentSummary === 'function' ? window.renderEnvironmentAssessmentSummary : () => '',
+      renderEnvironmentAssessmentSummary,
       renderLightTools: typeof window.renderLightTools === 'function' ? window.renderLightTools : () => '',
     });
     const setHour = (hour) => {
@@ -287,7 +288,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.renderLightTodayHero = () => '';
       window.renderSunSetupCard = () => '<div class="setup-card-test">setup</div>';
       window.renderDevicesSection = () => '<div class="devices-section-test">devices</div>';
-      window.renderEnvironmentAssessmentSummary = () => '';
+      renderEnvironmentAssessmentSummary = () => '';
       window.renderLightTools = () => '';
       window.getActiveSession = () => null;
       window.getDevices = () => [];
@@ -328,7 +329,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.renderLightTodayHero = saved.renderLightTodayHero;
       window.renderSunSetupCard = saved.renderSunSetupCard;
       window.renderDevicesSection = saved.renderDevicesSection;
-      window.renderEnvironmentAssessmentSummary = saved.renderEnvironmentAssessmentSummary;
+      renderEnvironmentAssessmentSummary = lightEnv.renderEnvironmentAssessmentSummary;
       window.renderLightTools = saved.renderLightTools;
       syncLightPageDeps();
     }

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -17,11 +17,6 @@ const envShellHooksSrc = fs.readFileSync(path.join(root, 'js/light-env-shell-hoo
 const navSrc = fs.readFileSync(path.join(root, 'js/nav.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const envUiSrc = `${envSrc}\n${screenSrc}`;
-const windowAssignStart = envSrc.indexOf('Object.assign(window, {');
-const windowAssignEnd = windowAssignStart >= 0 ? envSrc.indexOf('  });', windowAssignStart) : -1;
-const lightEnvWindowFacadeSrc = windowAssignStart >= 0 && windowAssignEnd >= 0
-  ? envSrc.slice(windowAssignStart, windowAssignEnd)
-  : '';
 
 let passed = 0;
 let failed = 0;
@@ -94,13 +89,11 @@ assert('light-env internal action handlers are registered through module object,
     envSrc.includes('...lightEnvActionHandlers,') &&
     envSrc.includes('...lightEnvAuditActionHandlers') &&
     actionSrc.includes('actions.saveLightAuditFromUI?.()') &&
-    lightEnvWindowFacadeSrc.includes('renderEnvironmentSection') &&
-    !lightEnvWindowFacadeSrc.includes('addLightEnvRoom') &&
-    !lightEnvWindowFacadeSrc.includes('deleteLightEnvScreenConfirm') &&
-    !lightEnvWindowFacadeSrc.includes('computeLightDeficitAxes') &&
-    !lightEnvWindowFacadeSrc.includes('openLightEnvironmentAssessment') &&
-    !lightEnvWindowFacadeSrc.includes('closeLightEnvironmentAssessment') &&
-    !lightEnvWindowFacadeSrc.includes('refreshLightEnvironmentAssessment'));
+    !envSrc.includes('Object.assign(window, {') &&
+    !envSrc.includes('getLightEnvironment: getEnvironment') &&
+    !envSrc.includes('renderEnvironmentSection,') &&
+    !envSrc.includes('renderEnvironmentAssessmentSummary,') &&
+    !envSrc.includes('isLightEnvActiveToday: isActiveToday'));
 assert('Light environment modal shell actions are wired through startup hooks',
   navSrc.includes('export function configureNavActions') &&
     navSrc.includes('navActionDeps.openLightEnvironmentAssessment()') &&

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -606,13 +606,18 @@ const {
   const lightEnvShellHooksSrc = await fs.readFile(new URL('../js/light-env-shell-hooks.js', import.meta.url), 'utf8');
   const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const screenUiSrc = await fs.readFile(new URL('../js/light-env-screen-ui.js', import.meta.url), 'utf8');
-  const lightEnvWindowAssignStart = envSrc.indexOf('Object.assign(window, {');
-  const lightEnvWindowAssignEnd = lightEnvWindowAssignStart >= 0 ? envSrc.indexOf('  });', lightEnvWindowAssignStart) : -1;
-  const lightEnvWindowFacadeSrc = lightEnvWindowAssignStart >= 0 && lightEnvWindowAssignEnd >= 0
-    ? envSrc.slice(lightEnvWindowAssignStart, lightEnvWindowAssignEnd)
-    : '';
   assert('Light audit renderer emits no inline event attributes',
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
+  assert('Light environment render/data helpers stay module exports, not window facade',
+    !envSrc.includes('Object.assign(window, {') &&
+    !envSrc.includes('getLightEnvironment: getEnvironment') &&
+    !envSrc.includes('renderEnvironmentSection,') &&
+    !envSrc.includes('renderEnvironmentAssessmentSummary,') &&
+    !envSrc.includes('isLightEnvActiveToday: isActiveToday') &&
+    !globalsSrc.includes('renderEnvironmentAssessmentSummary') &&
+    !globalsSrc.includes('computeDeficitAxes') &&
+    !globalsSrc.includes('computeIndoorBurden') &&
+    !globalsSrc.includes('suggestRoomSourceFromSpectrum'));
   assert('Light audit storage/rendering lives in its own module',
     auditSrc.includes('configureLightEnvAudits') &&
     auditSrc.includes('export const lightEnvAuditActionHandlers = Object.freeze({') &&
@@ -680,10 +685,7 @@ const {
     !appEventSrc.includes('window.closeLightEnvironmentAssessment') &&
     !globalsSrc.includes('openLightEnvironmentAssessment') &&
     !globalsSrc.includes('closeLightEnvironmentAssessment') &&
-    !globalsSrc.includes('refreshLightEnvironmentAssessment') &&
-    !lightEnvWindowFacadeSrc.includes('openLightEnvironmentAssessment') &&
-    !lightEnvWindowFacadeSrc.includes('closeLightEnvironmentAssessment') &&
-    !lightEnvWindowFacadeSrc.includes('refreshLightEnvironmentAssessment'));
+    !globalsSrc.includes('refreshLightEnvironmentAssessment'));
   const swSrc = await fs.readFile(new URL('../service-worker.js', import.meta.url), 'utf8');
   const cssSrc = [
     await fs.readFile(new URL('../css/light-sun.css', import.meta.url), 'utf8'),

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -275,11 +275,8 @@ interface Window {
   renderChannelDeficitDeviceRecs?: AnyFunction;
   renderChannelMixVerdict?: AnyFunction;
   renderDevicesSection?: AnyFunction;
-  renderEnvironmentAssessmentSummary?: AnyFunction;
   renderOnboardingAIBlock?: AnyFunction;
   renderSunDataSourceSettings?: AnyFunction;
-  computeDeficitAxes?: AnyFunction;
-  computeIndoorBurden?: AnyFunction;
   computeUVConfidence?: AnyFunction;
   ensureActiveDeviceTicker?: AnyFunction;
   getMeteoConfig?: AnyFunction;
@@ -299,7 +296,6 @@ interface Window {
   _closeSpec?: AnyFunction;
   _dismissAimingGuide?: AnyFunction;
   addRoom?: AnyFunction;
-  getRooms?: AnyFunction;
   getSunCoords?: AnyFunction;
   hydrateSession?: AnyFunction;
   logCompletedSession?: AnyFunction;
@@ -313,7 +309,6 @@ interface Window {
   renderRoomAIBlock?: AnyFunction;
   renderScreenAIBlock?: AnyFunction;
   saveMeasurement?: AnyFunction;
-  suggestRoomSourceFromSpectrum?: AnyFunction;
   openChatPanel: AnyFunction;
   openCCTMeter?: AnyFunction;
   openDarknessMeter?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.21';
+self.APP_VERSION = '1.10.22';


### PR DESCRIPTION
## Summary

- remove the remaining Light Environment render/data `Object.assign(window, ...)` facade
- keep modal sync refresh wiring intact while requiring render/data helpers to be imported from `light-env.js`
- update browser coverage and source guards to use module exports and assert the old globals are absent
- remove obsolete ambient globals and bump `APP_VERSION` to `1.10.22`

## Validation

- `node tests/test-light-env.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-light-tools.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npx playwright test tests/playwright/light-env-browser-coverage.spec.js tests/playwright/light-env-coverage-batch.spec.js tests/playwright/environment-coverage-batch.spec.js tests/playwright/light-page-view.spec.js --project=chromium`
- `npm test`
- `npm run quality`
- `git diff --check`
- `./run-tests.sh`
