### PR TITLE
[codex] Remove light tools close globals

### DIFF
--- a/js/light-tool-camera-modals.js
+++ b/js/light-tool-camera-modals.js
@@ -35,40 +35,38 @@ function _handleLightToolModalClick(event) {
   if (!(overlay instanceof HTMLElement) || !overlay.contains(actionEl)) return;
 
   const action = actionEl.dataset.lightToolModalAction || '';
-  if (action === 'close-lux') {
-    event.preventDefault();
-    window._closeLuxMeter?.();
-    return;
-  }
-  if (action === 'close-flicker') {
-    event.preventDefault();
-    window._closeFlicker?.();
-    return;
-  }
-  if (action === 'close-dark') {
-    event.preventDefault();
-    window._closeDark?.();
-    return;
-  }
-  if (action === 'close-cct') {
-    event.preventDefault();
-    window._closeCCT?.();
-    return;
-  }
-  if (action === 'close-spec') {
-    event.preventDefault();
-    window._closeSpec?.();
-    return;
-  }
-  if (action === 'close-glass') {
-    event.preventDefault();
-    window._closeGlass?.();
-  }
+  const close = activeCameraToolClosers.get(action);
+  if (typeof close !== 'function') return;
+  event.preventDefault();
+  close();
 }
 
 function installLightToolModalDelegates(overlay) {
   overlay.addEventListener('click', _handleLightToolModalClick);
 }
+
+/** @type {Map<string, AnyFunction>} */
+const activeCameraToolClosers = new Map();
+
+function registerCameraToolCloser(action, close) {
+  activeCameraToolClosers.set(action, close);
+}
+
+function clearCameraToolCloser(action, close) {
+  if (activeCameraToolClosers.get(action) === close) activeCameraToolClosers.delete(action);
+}
+
+function closeCameraTool(action) {
+  const close = activeCameraToolClosers.get(action);
+  if (typeof close === 'function') close();
+}
+
+export function closeLuxMeter() { closeCameraTool('close-lux'); }
+export function closeFlickerDetector() { closeCameraTool('close-flicker'); }
+export function closeDarknessMeter() { closeCameraTool('close-dark'); }
+export function closeCCTMeter() { closeCameraTool('close-cct'); }
+export function closeSpectrumClassifier() { closeCameraTool('close-spec'); }
+export function closeGlassTransmission() { closeCameraTool('close-glass'); }
 
 /** @param {{ saveMeasurement?: AnyFunction }} [deps] */
 function getSaveMeasurement(deps = {}) {
@@ -140,17 +138,20 @@ export async function openLuxMeter(opts = {}, deps = {}) {
       </div>
     </div>
   </div>`;
-  installLightToolModalDelegates(overlay);
   let closed = false;
-  window._closeLuxMeter = () => {
+  const closeLuxMeterOverlay = () => {
+    if (closed) return;
     closed = true;
     _luxState.running = false;
     if (_luxState.sensor) { try { _luxState.sensor.stop(); } catch (e) {} _luxState.sensor = null; }
     if (_luxState.stream) { try { _luxState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _luxState.stream = null; }
     _luxState.video = null;
+    clearCameraToolCloser('close-lux', closeLuxMeterOverlay);
     removeModalOverlay(overlay);
   };
-  openAppendedModalOverlay(overlay, () => window._closeLuxMeter());
+  registerCameraToolCloser('close-lux', closeLuxMeterOverlay);
+  installLightToolModalDelegates(overlay);
+  openAppendedModalOverlay(overlay, closeLuxMeterOverlay);
 
   let currentLux = null;
   // Snapshot of the LATEST raw camera luma (before calibration multiply).
@@ -353,7 +354,7 @@ export async function openLuxMeter(opts = {}, deps = {}) {
       roomId,
     });
     showNotification(`Lux reading saved: ${Math.round(currentLux)}`);
-    window._closeLuxMeter();
+    closeLuxMeterOverlay();
   });
 
 }
@@ -383,15 +384,18 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
       </div>
     </div>
     </div>`;
-  installLightToolModalDelegates(overlay);
   let closed = false;
-  window._closeFlicker = () => {
+  const closeFlickerOverlay = () => {
+    if (closed) return;
     closed = true;
     _flickerState.running = false;
     if (_flickerState.stream) { try { _flickerState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _flickerState.stream = null; }
+    clearCameraToolCloser('close-flicker', closeFlickerOverlay);
     removeModalOverlay(overlay);
   };
-  openAppendedModalOverlay(overlay, () => window._closeFlicker());
+  registerCameraToolCloser('close-flicker', closeFlickerOverlay);
+  installLightToolModalDelegates(overlay);
+  openAppendedModalOverlay(overlay, closeFlickerOverlay);
 
   let lastResult = null;
   const resultEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#flicker-result'));
@@ -511,7 +515,7 @@ export async function openFlickerDetector(opts = {}, deps = {}) {
       roomId,
     });
     showNotification(`Flicker score saved: ${lastResult.label}`);
-    window._closeFlicker();
+    closeFlickerOverlay();
   });
 
 }
@@ -540,8 +544,18 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
       </div>
     </div>
   </div>`;
+  let closed = false;
+  const closeDarknessOverlay = () => {
+    if (closed) return;
+    closed = true;
+    _darkState.running = false;
+    if (_darkState.stream) { try { _darkState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _darkState.stream = null; }
+    clearCameraToolCloser('close-dark', closeDarknessOverlay);
+    removeModalOverlay(overlay);
+  };
+  registerCameraToolCloser('close-dark', closeDarknessOverlay);
   installLightToolModalDelegates(overlay);
-  openAppendedModalOverlay(overlay, () => window._closeDark());
+  openAppendedModalOverlay(overlay, closeDarknessOverlay);
 
   let result = null;
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#dark-status'));
@@ -555,12 +569,17 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: { facingMode: 'user', width: 160, height: 120 },
       });
+      if (closed) {
+        try { stream.getTracks().forEach(t => t.stop()); } catch (e) {}
+        return;
+      }
       _darkState.stream = stream;
       const video = document.createElement('video');
       video.srcObject = stream;
       video.muted = true;
       video.playsInline = true;
       await video.play();
+      if (closed) return;
       // Lock long shutter + fixed ISO so dim pixels register at a known
       // gain. Without ISO lock, auto-gain compensates darkness and the
       // raw pixel values can't be translated to lux. Surfaces the
@@ -574,8 +593,8 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
       const t0 = performance.now();
       let cancelled = false;
       while (performance.now() - t0 < 30000 && _darkState.running) {
-        // The camera stream may have been stopped by _closeDark() while
-        // we were sleeping in setTimeout. drawImage on a closed stream
+        // The camera stream may have been stopped by closeDarknessOverlay()
+        // while we were sleeping in setTimeout. drawImage on a closed stream
         // throws InvalidStateError; catch it explicitly so the loop
         // exits cleanly instead of silently failing inside an unhandled
         // rejection (which would leave the dialog stuck at "—" forever).
@@ -659,7 +678,7 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
           roomId,
         });
         showNotification('Sleep darkness reading saved.');
-        window._closeDark();
+        closeDarknessOverlay();
       };
     } catch (e) {
       statusEl.innerHTML = 'Camera access denied — darkness meter unavailable. <br><span style="font-size:11px;color:var(--text-muted)">Open your browser\'s site settings to allow camera access. This tool runs a long-exposure capture to detect ambient light below 1 lux — there\'s no useful manual-entry fallback.</span>';
@@ -667,11 +686,6 @@ export async function openDarknessMeter(opts = {}, deps = {}) {
     }
   });
 
-  window._closeDark = () => {
-    _darkState.running = false;
-    if (_darkState.stream) { try { _darkState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _darkState.stream = null; }
-    removeModalOverlay(overlay);
-  };
 }
 
 // ─── Tool 3: CCT Meter ────────────────────────────────────────────────
@@ -703,15 +717,18 @@ export async function openCCTMeter(opts = {}, deps = {}) {
       </div>
     </div>
     </div>`;
-  installLightToolModalDelegates(overlay);
   let closed = false;
-  window._closeCCT = () => {
+  const closeCCTOverlay = () => {
+    if (closed) return;
     closed = true;
     _cctState.running = false;
     if (_cctState.stream) { try { _cctState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _cctState.stream = null; }
+    clearCameraToolCloser('close-cct', closeCCTOverlay);
     removeModalOverlay(overlay);
   };
-  openAppendedModalOverlay(overlay, () => window._closeCCT());
+  registerCameraToolCloser('close-cct', closeCCTOverlay);
+  installLightToolModalDelegates(overlay);
+  openAppendedModalOverlay(overlay, closeCCTOverlay);
 
   let currentCCT = null;
   let currentMelanopic = null;
@@ -804,7 +821,7 @@ export async function openCCTMeter(opts = {}, deps = {}) {
       roomId,
     });
     showNotification(`Color temp saved: ${currentCCT} K`);
-    window._closeCCT();
+    closeCCTOverlay();
   });
 
 }
@@ -857,15 +874,18 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
       </div>
     </div>
     </div>`;
-  installLightToolModalDelegates(overlay);
   let closed = false;
-  window._closeSpec = () => {
+  const closeSpectrumOverlay = () => {
+    if (closed) return;
     closed = true;
     _specState.running = false;
     if (_specState.stream) { try { _specState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _specState.stream = null; }
+    clearCameraToolCloser('close-spec', closeSpectrumOverlay);
     removeModalOverlay(overlay);
   };
-  openAppendedModalOverlay(overlay, () => window._closeSpec());
+  registerCameraToolCloser('close-spec', closeSpectrumOverlay);
+  installLightToolModalDelegates(overlay);
+  openAppendedModalOverlay(overlay, closeSpectrumOverlay);
 
   let result = null;
   const resultEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#spec-result'));
@@ -962,7 +982,7 @@ export async function openSpectrumClassifier(opts = {}, deps = {}) {
     }
     await saveMeasurement('spectrum', result.label, { confidence: result.confidence, extra: result, roomId });
     showNotification(`Light type saved: ${result.label}`);
-    window._closeSpec();
+    closeSpectrumOverlay();
   });
 
 }
@@ -1046,19 +1066,22 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
       </div>
     </div>
     </div>`;
-  installLightToolModalDelegates(overlay);
   let closed = false;
   /** @type {Set<MediaStream>} */
   const activeGlassStreams = new Set();
-  window._closeGlass = () => {
+  const closeGlassOverlay = () => {
+    if (closed) return;
     closed = true;
     for (const stream of activeGlassStreams) {
       try { stream.getTracks().forEach(t => t.stop()); } catch (e) {}
     }
     activeGlassStreams.clear();
+    clearCameraToolCloser('close-glass', closeGlassOverlay);
     removeModalOverlay(overlay);
   };
-  openAppendedModalOverlay(overlay, () => window._closeGlass());
+  registerCameraToolCloser('close-glass', closeGlassOverlay);
+  installLightToolModalDelegates(overlay);
+  openAppendedModalOverlay(overlay, closeGlassOverlay);
 
   _glassReadings = { inside: null, outside: null };
 
@@ -1135,7 +1158,7 @@ export async function openGlassTransmission(opts = {}, deps = {}) {
         roomId,
       });
       showNotification(`Glass transmission saved: ${(transmission * 100).toFixed(0)}%`);
-      window._closeGlass();
+      closeGlassOverlay();
     };
   }
 

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -37,6 +37,7 @@ import {
   openSpectrumClassifier as openSpectrumClassifierModal,
   openGlassTransmission as openGlassTransmissionModal,
 } from './light-tool-camera-modals.js';
+export { closeLuxMeter, closeFlickerDetector, closeDarknessMeter, closeCCTMeter, closeSpectrumClassifier, closeGlassTransmission } from './light-tool-camera-modals.js';
 
 const LIGHT_TOOLS_ACTION_ATTR = 'data-light-tools-action';
 const LIGHT_TOOL_ID_ATTR = 'data-light-tool-id';
@@ -111,7 +112,7 @@ function handleLightToolsActionClick(event) {
   if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
   const action = actionEl.getAttribute(LIGHT_TOOLS_ACTION_ATTR);
   if (action === 'close-audit') {
-    window._closeAudit?.();
+    closeEyeLevelAudit();
     event.stopPropagation();
     return;
   }
@@ -305,29 +306,12 @@ export async function deleteMeasurement(id) {
 
 // ─── Camera-backed tool modal facade ──────────────────────────────────
 
-export async function openLuxMeter(opts = {}) {
-  return openLuxMeterModal(opts, { saveMeasurement });
-}
-
-export async function openFlickerDetector(opts = {}) {
-  return openFlickerDetectorModal(opts, { saveMeasurement });
-}
-
-export async function openDarknessMeter(opts = {}) {
-  return openDarknessMeterModal(opts, { saveMeasurement });
-}
-
-export async function openCCTMeter(opts = {}) {
-  return openCCTMeterModal(opts, { saveMeasurement });
-}
-
-export async function openSpectrumClassifier(opts = {}) {
-  return openSpectrumClassifierModal(opts, { saveMeasurement });
-}
-
-export async function openGlassTransmission(opts = {}) {
-  return openGlassTransmissionModal(opts, { saveMeasurement });
-}
+export async function openLuxMeter(opts = {}) { return openLuxMeterModal(opts, { saveMeasurement }); }
+export async function openFlickerDetector(opts = {}) { return openFlickerDetectorModal(opts, { saveMeasurement }); }
+export async function openDarknessMeter(opts = {}) { return openDarknessMeterModal(opts, { saveMeasurement }); }
+export async function openCCTMeter(opts = {}) { return openCCTMeterModal(opts, { saveMeasurement }); }
+export async function openSpectrumClassifier(opts = {}) { return openSpectrumClassifierModal(opts, { saveMeasurement }); }
+export async function openGlassTransmission(opts = {}) { return openGlassTransmissionModal(opts, { saveMeasurement }); }
 
 // ─── Tool 7: Sunrise / Sunset Logger ──────────────────────────────────
 
@@ -464,6 +448,12 @@ export function openSunriseLogger() {
 // ─── Tool 8: Eye-Level Audit (10-min walkthrough) ─────────────────────
 
 let _auditState = { running: false, stream: null, samples: [] };
+/** @type {AnyFunction | null} */
+let activeEyeLevelAuditCloser = null;
+
+export function closeEyeLevelAudit() {
+  if (typeof activeEyeLevelAuditCloser === 'function') activeEyeLevelAuditCloser();
+}
 
 export async function openEyeLevelAudit() {
   const overlay = document.createElement('div');
@@ -484,7 +474,17 @@ export async function openEyeLevelAudit() {
       </div>
     </div>
   </div>`;
-  openAppendedModalOverlay(overlay, () => window._closeAudit());
+  let closed = false;
+  const closeAuditOverlay = () => {
+    if (closed) return;
+    closed = true;
+    _auditState.running = false;
+    if (_auditState.stream) { try { _auditState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _auditState.stream = null; }
+    if (activeEyeLevelAuditCloser === closeAuditOverlay) activeEyeLevelAuditCloser = null;
+    removeModalOverlay(overlay);
+  };
+  activeEyeLevelAuditCloser = closeAuditOverlay;
+  openAppendedModalOverlay(overlay, closeAuditOverlay);
 
   const statusEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-status'));
   const listEl = /** @type {HTMLElement} */ (queryRequired(overlay, '#audit-room-list'));
@@ -528,10 +528,15 @@ export async function openEyeLevelAudit() {
       statusEl.textContent = 'Recording… walk through each room you spend time in. Pause for ~5 seconds in each.';
       try {
         const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment', width: 160, height: 120 } });
+        if (closed) {
+          try { stream.getTracks().forEach(t => t.stop()); } catch (e) {}
+          return;
+        }
         _auditState.stream = stream;
         const video = document.createElement('video');
         video.srcObject = stream; video.muted = true; video.playsInline = true;
         await video.play();
+        if (closed) return;
         // Lock exposure across the whole walkthrough — without this, AE
         // re-exposes when you walk into a brighter / dimmer room, making
         // the per-room luma values incomparable. We want the absolute
@@ -603,8 +608,8 @@ export async function openEyeLevelAudit() {
           })) },
         });
         // Try to bind each pause to an existing room by name; create
-        // one if no match. Both `getRooms` and `addRoom` are exposed
-        // on window via light-env.js's bottom-of-file Object.assign.
+        // one if no match. Startup wiring injects getRooms/addRoom from
+        // light-env.js so this modal does not reach through window.
         let bound = 0;
         const existingRooms = getLightRooms();
         const byLabel = new Map();
@@ -639,15 +644,9 @@ export async function openEyeLevelAudit() {
       } else {
         showNotification('No room pauses detected — try holding still longer next time.');
       }
-      window._closeAudit();
+      closeAuditOverlay();
     }
   });
-
-  window._closeAudit = () => {
-    _auditState.running = false;
-    if (_auditState.stream) { try { _auditState.stream.getTracks().forEach(t => t.stop()); } catch (e) {} _auditState.stream = null; }
-    removeModalOverlay(overlay);
-  };
 }
 
 // ─── Tools page render ────────────────────────────────────────────────

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -540,19 +540,19 @@ test('light camera tool modals cover denied and manual fallback contracts', asyn
       outcomes.flickerDeniedExplainsCameraRequirement = document.getElementById('flicker-result')?.textContent.includes('Camera access denied');
       document.getElementById('flicker-save').click();
       await Promise.resolve();
-      window._closeFlicker();
+      modals.closeFlickerDetector();
 
       await modals.openCCTMeter({ roomId: 'office' }, deps);
       outcomes.cctDeniedSetsCameraDeniedValue = document.getElementById('cct-value')?.textContent === 'Camera denied';
       document.getElementById('cct-save').click();
       await Promise.resolve();
-      window._closeCCT();
+      modals.closeCCTMeter();
 
       await modals.openDarknessMeter({ roomId: 'bedroom' }, deps);
       document.getElementById('dark-start').click();
       await Promise.resolve();
       outcomes.darknessDeniedShowsUnavailableMessage = document.getElementById('dark-status')?.textContent.includes('Camera access denied');
-      window._closeDark();
+      modals.closeDarknessMeter();
 
       outcomes.deniedToolsDoNotSaveWithoutResult = saved.filter(item => item.kind !== 'lux' && item.kind !== 'spectrum').length === 0;
     } finally {
@@ -562,8 +562,15 @@ test('light camera tool modals cover denied and manual fallback contracts', asyn
       });
       if (hadALS) window.AmbientLightSensor = originalALS;
       else delete window.AmbientLightSensor;
-      ['_closeLuxMeter', '_closeSpec', '_closeFlicker', '_closeCCT', '_closeDark', '_closeGlass'].forEach(name => {
-        try { if (typeof window[name] === 'function') window[name](); } catch (_) {}
+      [
+        modals.closeLuxMeter,
+        modals.closeSpectrumClassifier,
+        modals.closeFlickerDetector,
+        modals.closeCCTMeter,
+        modals.closeDarknessMeter,
+        modals.closeGlassTransmission,
+      ].forEach(close => {
+        try { close(); } catch (_) {}
       });
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }
@@ -781,8 +788,13 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
       window.cancelAnimationFrame = savedCancelRaf;
       if (hadALS) window.AmbientLightSensor = originalALS;
       else delete window.AmbientLightSensor;
-      ['_closeLuxMeter', '_closeFlicker', '_closeCCT', '_closeGlass'].forEach(name => {
-        try { if (typeof window[name] === 'function') window[name](); } catch (_) {}
+      [
+        modals.closeLuxMeter,
+        modals.closeFlickerDetector,
+        modals.closeCCTMeter,
+        modals.closeGlassTransmission,
+      ].forEach(close => {
+        try { close(); } catch (_) {}
       });
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/playwright/light-tool-camera-modals-browser-coverage.spec.js
+++ b/tests/playwright/light-tool-camera-modals-browser-coverage.spec.js
@@ -205,8 +205,8 @@ test('light tool camera modals cover ambient sensor lux and darkness success pat
       if (hadAmbientLightSensor) window.AmbientLightSensor = savedAmbientLightSensor;
       else delete window.AmbientLightSensor;
       localStorage.removeItem('labcharts-lux-calibration');
-      ['_closeLuxMeter', '_closeDark'].forEach(name => {
-        try { if (typeof window[name] === 'function') window[name](); } catch (_) {}
+      [modals.closeLuxMeter, modals.closeDarknessMeter].forEach(close => {
+        try { close(); } catch (_) {}
       });
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js
+++ b/tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js
@@ -304,8 +304,14 @@ test('light tool camera modals cover camera fallback calibration flicker cct spe
       else delete window.AmbientLightSensor;
       if (savedLuxCalibration == null) localStorage.removeItem('labcharts-lux-calibration');
       else localStorage.setItem('labcharts-lux-calibration', savedLuxCalibration);
-      ['_closeLuxMeter', '_closeFlicker', '_closeCCT', '_closeSpec', '_closeGlass'].forEach(name => {
-        try { if (typeof window[name] === 'function') window[name](); } catch (_) {}
+      [
+        modals.closeLuxMeter,
+        modals.closeFlickerDetector,
+        modals.closeCCTMeter,
+        modals.closeSpectrumClassifier,
+        modals.closeGlassTransmission,
+      ].forEach(close => {
+        try { close(); } catch (_) {}
       });
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/playwright/light-tools-browser-coverage.spec.js
+++ b/tests/playwright/light-tools-browser-coverage.spec.js
@@ -277,11 +277,11 @@ test('light tools browser coverage exercises storage render and modal flows', as
       await wait(10);
       results.openLuxMeterFacadeCreatesAndClosesModal =
         !!document.querySelector('[aria-label="Lux meter"]');
-      window._closeLuxMeter?.();
+      lightTools.closeLuxMeter();
       await lightTools.openFlickerDetector({ roomId: 'room-1' });
       results.openFlickerFacadeCreatesAndClosesModal =
         !!document.querySelector('[aria-label="Flicker detector"]');
-      window._closeFlicker?.();
+      lightTools.closeFlickerDetector();
       let fakeNow = 0;
       Object.defineProperty(performance, 'now', {
         configurable: true,
@@ -296,7 +296,7 @@ test('light tools browser coverage exercises storage render and modal flows', as
       await waitUntil(() => document.getElementById('dark-start')?.textContent === 'Save reading');
       results.openDarknessFacadeCreatesAndClosesModal =
         !!document.querySelector('[aria-label="Sleep darkness meter"]');
-      window._closeDark?.();
+      lightTools.closeDarknessMeter();
       window.setTimeout = saved.setTimeout;
       window.clearTimeout = saved.clearTimeout;
       if (saved.performanceNowDescriptor) {
@@ -312,17 +312,17 @@ test('light tools browser coverage exercises storage render and modal flows', as
       await lightTools.openCCTMeter({ roomId: 'room-2' });
       results.openCCTFacadeCreatesAndClosesModal =
         !!document.querySelector('[aria-label="Color temperature meter"]');
-      window._closeCCT?.();
+      lightTools.closeCCTMeter();
       await lightTools.openSpectrumClassifier({ roomId: 'room-2' });
       results.openSpectrumFacadeCreatesAndClosesModal =
         !!document.querySelector('[aria-label="Spectrum classifier"]');
-      window._closeSpec?.();
+      lightTools.closeSpectrumClassifier();
       await lightTools.openGlassTransmission({ roomId: 'room-2' });
       document.getElementById('glass-measure-inside')?.click();
       await waitUntil(() => (document.getElementById('glass-reading-inside')?.textContent || '').includes('lux'), 2500);
       results.openGlassFacadeCreatesAndClosesModal =
         !!document.querySelector('[aria-label="Glass transmission test"]');
-      window._closeGlass?.();
+      lightTools.closeGlassTransmission();
       results.cameraFacadeStreamsStoppedOnClose = streamStops.length >= 5;
 
       Object.defineProperty(navigator, 'mediaDevices', {
@@ -339,7 +339,7 @@ test('light tools browser coverage exercises storage render and modal flows', as
       await wait(20);
       results.auditDeniedPathShowsCameraMessage = (document.getElementById('audit-status')?.textContent || '')
         .includes('Camera access denied');
-      window._closeAudit?.();
+      lightTools.closeEyeLevelAudit();
       results.auditCloseRemovesOverlay = !document.querySelector('[aria-label="Home audit"]');
       auditOverlay?.remove();
     } finally {
@@ -384,9 +384,16 @@ test('light tools browser coverage exercises storage render and modal flows', as
           value: saved.mediaDevices,
         });
       } catch (_) {}
-      ['_closeLuxMeter', '_closeFlicker', '_closeDark', '_closeCCT', '_closeSpec', '_closeGlass', '_closeAudit'].forEach(name => {
-        try { window[name]?.(); } catch (_) {}
-        try { delete window[name]; } catch (_) {}
+      [
+        lightTools.closeLuxMeter,
+        lightTools.closeFlickerDetector,
+        lightTools.closeDarknessMeter,
+        lightTools.closeCCTMeter,
+        lightTools.closeSpectrumClassifier,
+        lightTools.closeGlassTransmission,
+        lightTools.closeEyeLevelAudit,
+      ].forEach(close => {
+        try { close(); } catch (_) {}
       });
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
       localStorage.clear();

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -655,14 +655,14 @@ test('glass transmission modal covers denied measurement fallback and close clea
         && overlay?.querySelector('#glass-reading-outside')?.textContent === 'denied';
       outcomes.deniedReadingsDoNotEnableSave = overlay?.querySelector('#glass-save')?.disabled === true
         && saved.length === 0;
-      window._closeGlass?.();
+      modals.closeGlassTransmission();
       outcomes.closeGlassRemovesOverlay = !document.body.contains(overlay);
     } finally {
       Object.defineProperty(navigator, 'mediaDevices', {
         configurable: true,
         value: savedMediaDevices,
       });
-      try { window._closeGlass?.(); } catch (_) {}
+      try { modals.closeGlassTransmission(); } catch (_) {}
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }
 

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -31,6 +31,7 @@ const tools = await import('../js/light-tools.js');
     const appLightSunSrc = fs.readFileSync(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
     const appUiShellSrc = fs.readFileSync(new URL('../js/app-ui-shell-modules.js', import.meta.url), 'utf8');
     const lightEnvSrc = fs.readFileSync(new URL('../js/light-env.js', import.meta.url), 'utf8');
+    const globalsSrc = fs.readFileSync(new URL('../types/globals.d.ts', import.meta.url), 'utf8');
     const swSrc = fs.readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
     const lightToolCameraSrc = fs.readFileSync(new URL('../js/light-tool-camera.js', import.meta.url), 'utf8');
     const lightToolCameraModalsSrc = fs.readFileSync(new URL('../js/light-tool-camera-modals.js', import.meta.url), 'utf8');
@@ -271,16 +272,31 @@ const tools = await import('../js/light-tools.js');
     assert('light-tool-camera.js owns shared camera lock and row-banding helpers',
       lightToolCameraSrc.includes('export async function lockCameraForMeasurement') &&
       lightToolCameraSrc.includes('export function computeRowBanding'));
+    assert('Light tool modal close handlers are module exports instead of window globals',
+      lightToolCameraModalsSrc.includes('export function closeLuxMeter()') &&
+      lightToolCameraModalsSrc.includes('export function closeFlickerDetector()') &&
+      lightToolCameraModalsSrc.includes('export function closeDarknessMeter()') &&
+      lightToolCameraModalsSrc.includes('export function closeCCTMeter()') &&
+      lightToolCameraModalsSrc.includes('export function closeSpectrumClassifier()') &&
+      lightToolCameraModalsSrc.includes('export function closeGlassTransmission()') &&
+      lightToolsSrc.includes('export { closeLuxMeter, closeFlickerDetector') &&
+      lightToolsSrc.includes('export function closeEyeLevelAudit()') &&
+      !lightToolCameraModalsSrc.includes('window._close') &&
+      !lightToolsSrc.includes('window._close') &&
+      !globalsSrc.includes('_closeLuxMeter') &&
+      !globalsSrc.includes('_closeAudit'));
     assert('Lux assigns close handler before camera fallback can await',
-      appearsBefore(lightToolCameraModalsSrc, 'window._closeLuxMeter =', 'await startCameraFallback();'));
+      appearsBefore(lightToolCameraModalsSrc, 'const closeLuxMeterOverlay =', 'await startCameraFallback();'));
     assert('Lux AmbientLightSensor error retries the camera fallback',
       /sensor\.addEventListener\('error'[\s\S]{0,500}startCameraFallback/.test(lightToolCameraModalsSrc));
       assert('Flicker assigns close handler before getUserMedia await',
-        appearsBefore(lightToolCameraModalsSrc, 'window._closeFlicker =', 'navigator.mediaDevices.getUserMedia', lightToolCameraModalsSrc.indexOf('export async function openFlickerDetector')));
+        appearsBefore(lightToolCameraModalsSrc, 'const closeFlickerOverlay =', 'navigator.mediaDevices.getUserMedia', lightToolCameraModalsSrc.indexOf('export async function openFlickerDetector')));
+      assert('Darkness stops late camera stream if closed after getUserMedia',
+        /export async function openDarknessMeter[\s\S]*const stream = await navigator\.mediaDevices\.getUserMedia[\s\S]*if \(closed\) \{[\s\S]*stream\.getTracks\(\)\.forEach\(t => t\.stop\(\)\)/.test(lightToolCameraModalsSrc));
       assert('CCT assigns close handler before getUserMedia await',
-        appearsBefore(lightToolCameraModalsSrc, 'window._closeCCT =', 'navigator.mediaDevices.getUserMedia', lightToolCameraModalsSrc.indexOf('export async function openCCTMeter')));
+        appearsBefore(lightToolCameraModalsSrc, 'const closeCCTOverlay =', 'navigator.mediaDevices.getUserMedia', lightToolCameraModalsSrc.indexOf('export async function openCCTMeter')));
       assert('Spectrum assigns close handler before getUserMedia await',
-        appearsBefore(lightToolCameraModalsSrc, 'window._closeSpec =', 'navigator.mediaDevices.getUserMedia', lightToolCameraModalsSrc.indexOf('export async function openSpectrumClassifier')));
+        appearsBefore(lightToolCameraModalsSrc, 'const closeSpectrumOverlay =', 'navigator.mediaDevices.getUserMedia', lightToolCameraModalsSrc.indexOf('export async function openSpectrumClassifier')));
     assert('Glass transmission tracks and stops active streams on close/finally',
       /activeGlassStreams\.add\(stream\)/.test(lightToolCameraModalsSrc) &&
       /activeGlassStreams\.delete\(stream\)/.test(lightToolCameraModalsSrc) &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -287,13 +287,6 @@ interface Window {
   rehydrateStaleSessions?: () => Promise<{ rehydrated?: number }>;
   SUN_ENGINE_VERSION?: number;
   AmbientLightSensor?: AmbientLightSensorConstructor;
-  _closeAudit?: AnyFunction;
-  _closeCCT?: AnyFunction;
-  _closeDark?: AnyFunction;
-  _closeFlicker?: AnyFunction;
-  _closeGlass?: AnyFunction;
-  _closeLuxMeter?: AnyFunction;
-  _closeSpec?: AnyFunction;
   _dismissAimingGuide?: AnyFunction;
   addRoom?: AnyFunction;
   getSunCoords?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.22';
+self.APP_VERSION = '1.10.23';


### PR DESCRIPTION
## Summary
- Replace Light Tools `window._close*` modal globals with module-local close registries and exported close functions.
- Route Light Tools camera and eye-audit modal close actions through module APIs instead of ambient `window` state.
- Update browser/source tests and remove the ambient close globals from `types/globals.d.ts`; bump `version.js` to 1.10.23.

## Validation
- `node tests/test-light-tools.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`
- `npx playwright test tests/playwright/light-tools-browser-coverage.spec.js tests/playwright/light-tool-camera-modals-browser-coverage.spec.js tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js tests/playwright/light-sun-coverage-batch.spec.js tests/playwright/modal-session-coverage-batch.spec.js --project=chromium`
- `./run-tests.sh`