### PR TITLE
[codex] Remove tour window facade

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -4,6 +4,7 @@
 import { state } from './state.js';
 import { registerRefreshCallback } from './data.js';
 import { buildSidebar } from './nav.js';
+import { endTour } from './tour.js';
 
 let globalEventsBound = false;
 let mouseDownInsideModal = false;
@@ -94,7 +95,7 @@ function handleAppKeydown(e) {
     const passphraseOverlay = document.getElementById("passphrase-overlay");
     if (passphraseOverlay && passphraseOverlay.style.display === 'flex') return;
     const tourOverlay = document.getElementById("tour-overlay");
-    if (tourOverlay) { window.endTour(); return; }
+    if (tourOverlay) { endTour(); return; }
     const sidebarNav = document.getElementById("sidebar-nav");
     if (sidebarNav && sidebarNav.classList.contains("mobile-open")) { window.closeMobileSidebar(); return; }
     const emfInterpOverlay = document.getElementById("emf-interp-overlay");

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -5,6 +5,7 @@ import { PERIOD_SYMPTOMS } from './constants.js';
 import { escapeHTML, showNotification, showConfirmDialog, linearRegression } from './utils.js';
 import { saveImportedData } from './data.js';
 import { openModalOverlay } from './modal-lifecycle.js';
+import { startCycleTour } from './tour.js';
 
 const CYCLE_ACTIVE_STATUSES = new Set(['regular', 'perimenopause']);
 const CYCLE_ICONS = {
@@ -23,7 +24,6 @@ const appWindow = /** @type {Window & typeof globalThis & {
   closeModal: () => void,
   navigate: (category: string) => void,
   recordChange: (field: string) => void,
-  startCycleTour?: (fromSave?: boolean) => void,
   __cycleDelegatesBound?: boolean
 }} */ (window);
 
@@ -66,7 +66,7 @@ function handleCycleClick(event) {
       saveMenstrualCycle();
       break;
     case 'start-tour':
-      if (appWindow.startCycleTour) appWindow.startCycleTour(false);
+      startCycleTour(false);
       break;
     case 'open-editor':
       openMenstrualCycleEditor();
@@ -585,7 +585,7 @@ export function saveMenstrualCycle() {
   appWindow.navigate(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
   showNotification('Menstrual cycle profile saved', 'success');
   // Auto-trigger cycle tour after dashboard re-renders
-  setTimeout(() => { if (appWindow.startCycleTour) appWindow.startCycleTour(true); }, 600);
+  setTimeout(() => { startCycleTour(true); }, 600);
 }
 
 export async function clearMenstrualCycle() {

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -15,6 +15,7 @@ import {
   getMobileGreetingName,
   getMobileDashboardCounts,
 } from './mobile-dashboard.js';
+import { startEmptyTour as defaultStartEmptyTour, startTour as defaultStartTour } from './tour.js';
 
 let _dashboardWelcomeActionsInstalled = false;
 
@@ -119,6 +120,8 @@ export function createDashboardPageView(deps) {
     renderDashboardWidget,
     isDashboardOrganizeMode,
     loadFocusCard,
+    startEmptyTour = defaultStartEmptyTour,
+    startTour = defaultStartTour,
   } = deps;
 
   function renderDashboardGreeting(ctx, title, visibleCount) {
@@ -251,8 +254,8 @@ export function createDashboardPageView(deps) {
       // First visit starts the empty-state tour from the welcome screen.
       // Delay one tick so header/profile controls are rendered before targets
       // are filtered. If the user already completed it, fall through to chat onboarding.
-      const shouldAutoStartEmptyTour = typeof getDashboardPageRuntimeValue('startEmptyTour') === 'function' && !localStorage.getItem(profileStorageKey(state.currentProfile, 'emptyTour'));
-      if (shouldAutoStartEmptyTour) setTimeout(() => callDashboardPageRuntime('startEmptyTour', true), 100);
+      const shouldAutoStartEmptyTour = !localStorage.getItem(profileStorageKey(state.currentProfile, 'emptyTour'));
+      if (shouldAutoStartEmptyTour) setTimeout(() => startEmptyTour(true), 100);
       // Returning desktop visitors get the guided chat setup beside the
       // welcome hero. Mobile keeps the welcome/import controls unobscured.
       const isDesktopChatOnboardingViewport = getDashboardPageRuntimeValue('innerWidth') > 768;
@@ -305,7 +308,7 @@ export function createDashboardPageView(deps) {
     const _p = callDashboardPageRuntime('getProfiles')?.find(p => p.id === state.currentProfile);
     const _hasProfile = _p?.name && _p.name !== 'Default' && state.profileSex;
     if (_hasProfile && hasData) {
-      callDashboardPageRuntime('startTour', true);
+      startTour(true);
     }
   }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,6 +14,7 @@ import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.j
 import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { installSettingsProviderBridge, switchAIProviderBridge } from './settings-provider-bridge.js';
 import { loadPdfImport } from './import-loader.js';
+import { startGuidedTour } from './tour.js';
 import {
   confirmDisablePIIReview,
   refreshDataEntriesSection,
@@ -342,7 +343,7 @@ async function handleSettingsClick(event) {
   } else if (action === 'start-guided-tour') {
     event.preventDefault();
     closeSettingsModal();
-    setTimeout(() => settingsWindow.startGuidedTour?.(false), 300);
+    setTimeout(() => startGuidedTour(false), 300);
   } else if (action === 'open-changelog') {
     event.preventDefault();
     closeSettingsModal();

--- a/js/tour.js
+++ b/js/tour.js
@@ -306,6 +306,10 @@ export function startCycleTour(auto) {
   return runTour(CYCLE_TOUR_STEPS, profileKey('cycleTour'), auto);
 }
 
+export function goToTourStep(index) {
+  goToStep(index);
+}
+
 export function endTour() {
   const shouldOpenEmptyChat = activeTour?.storageKey === profileKey('emptyTour') &&
     !state.importedData?.entries?.length &&
@@ -327,8 +331,3 @@ export function endTour() {
     }, 250);
   }
 }
-
-// Internal navigation helper remains exposed for tests and legacy callers.
-window._tourGoToStep = goToStep;
-
-Object.assign(window, { startEmptyTour, startTour, startGuidedTour, startCycleTour, endTour });

--- a/tests/playwright/cycle-browser-coverage.spec.js
+++ b/tests/playwright/cycle-browser-coverage.spec.js
@@ -14,9 +14,10 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ cycleUrl }) => {
-    const [{ state }, cycle] = await Promise.all([
+    const [{ state }, cycle, tour] = await Promise.all([
       import('/js/state.js'),
       import(cycleUrl),
+      import('/js/tour.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const outcomes = {};
@@ -28,8 +29,9 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       closeModal: window.closeModal,
       navigate: window.navigate,
       recordChange: window.recordChange,
-      startCycleTour: window.startCycleTour,
     };
+    const cycleTourKey = `labcharts-${state.currentProfile}-cycleTour`;
+    const savedCycleTourState = localStorage.getItem(cycleTourKey);
     const waitFor = async (predicate, attempts = 25, delayMs = 0) => {
       for (let i = 0; i < attempts; i += 1) {
         if (predicate()) return true;
@@ -67,7 +69,7 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       };
       window.navigate = category => calls.push(['navigate', category]);
       window.recordChange = field => calls.push(['record', field]);
-      window.startCycleTour = fromSave => calls.push(['tour', fromSave]);
+      localStorage.removeItem(cycleTourKey);
 
       state.profileDob = '1974-01-01';
       state.importedData = {
@@ -177,7 +179,11 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       document.getElementById('mc-period-notes').value = 'pending save';
       const saveBefore = calls.length;
       cycle.saveMenstrualCycle();
-      await waitFor(() => calls.slice(saveBefore).some(call => call[0] === 'tour' && call[1] === true), 80, 25);
+      const tourStartedAfterSave = await waitFor(
+        () => document.getElementById('tour-tooltip')?.textContent?.includes('Cycle-Aware Lab Interpretation'),
+        80,
+        25
+      );
       const saveCalls = calls.slice(saveBefore);
       const savedPeriod = state.importedData.menstrualCycle.periods.find(p => p.startDate === '2026-07-01');
       outcomes.saveSyncsFormPendingPeriodNavigatesAndTours = state.importedData.menstrualCycle.contraceptive === 'Copper IUD'
@@ -187,9 +193,10 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
         && saveCalls.some(call => call[0] === 'record' && call[1] === 'menstrualCycle')
         && saveCalls.some(call => call[0] === 'close')
         && saveCalls.some(call => call[0] === 'navigate' && call[1] === 'cycle')
-        && saveCalls.some(call => call[0] === 'tour' && call[1] === true)
+        && tourStartedAfterSave
         && toasts().some(text => text.includes('Menstrual cycle profile saved'));
       clearToasts();
+      tour.endTour();
 
       cycle.openMenstrualCycleEditor();
       const clearCancel = cycle.clearMenstrualCycle();
@@ -218,8 +225,9 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       else delete window.navigate;
       if (saved.recordChange) window.recordChange = saved.recordChange;
       else delete window.recordChange;
-      if (saved.startCycleTour) window.startCycleTour = saved.startCycleTour;
-      else delete window.startCycleTour;
+      tour.endTour();
+      if (savedCycleTourState) localStorage.setItem(cycleTourKey, savedCycleTourState);
+      else localStorage.removeItem(cycleTourKey);
       document.querySelectorAll('.notification-container,.notification-toast,.confirm-overlay').forEach(el => el.remove());
       injectedNav?.remove();
       document.querySelectorAll('.nav-item.active').forEach(el => el.classList.remove('active'));

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -474,7 +474,6 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       closeChatPanel: window.closeChatPanel,
       openSettingsModal: window.openSettingsModal,
       loadDemoData: window.loadDemoData,
-      startEmptyTour: window.startEmptyTour,
       mainHtml: document.getElementById('main-content')?.innerHTML || '',
     };
     const calls = [];
@@ -496,7 +495,6 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       window.closeChatPanel = () => calls.push(['close-chat']);
       window.openSettingsModal = tab => calls.push(['settings', tab]);
       window.loadDemoData = sex => calls.push(['demo', sex]);
-      window.startEmptyTour = () => calls.push(['tour']);
 
       let pdfInput = document.getElementById('pdf-input');
       hadPdfInput = !!pdfInput;
@@ -522,6 +520,7 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
         renderDashboardWidget: () => '',
         isDashboardOrganizeMode: () => false,
         loadFocusCard: () => calls.push(['focus-card']),
+        startEmptyTour: () => calls.push(['tour']),
       });
 
       view.showDashboard({ dates: [], categories: {} });
@@ -575,7 +574,6 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
         closeChatPanel: saved.closeChatPanel,
         openSettingsModal: saved.openSettingsModal,
         loadDemoData: saved.loadDemoData,
-        startEmptyTour: saved.startEmptyTour,
       });
       document.body.classList.remove('empty-dashboard-active', 'chat-autostart-reserved');
       localStorage.clear();

--- a/tests/playwright/tour-dom.spec.js
+++ b/tests/playwright/tour-dom.spec.js
@@ -2,14 +2,6 @@ import { expect, test } from './coverage-fixture.js';
 
 test('guided and cycle tour DOM creates navigates layers and restores overlays', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.startEmptyTour === 'function'
-      && typeof window.startTour === 'function'
-      && typeof window.startGuidedTour === 'function'
-      && typeof window.startCycleTour === 'function'
-      && typeof window.endTour === 'function'
-      && typeof window._tourGoToStep === 'function'
-  );
   await page.waitForFunction(() => {
     const isVisible = selector => Array.from(document.querySelectorAll(selector)).some(el => {
       const rect = el.getBoundingClientRect();
@@ -32,6 +24,7 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
   });
 
   const results = await page.evaluate(async () => {
+    const tour = await import('/js/tour.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, timeoutMs = 1000) => {
       const startedAt = performance.now();
@@ -67,14 +60,16 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
       localStorage.removeItem(cycleTourKey);
       ['tour-overlay', 'tour-spotlight', 'tour-tooltip'].forEach(id => document.getElementById(id)?.remove());
 
-      const exportsCallable = typeof window.startEmptyTour === 'function'
-        && typeof window.startTour === 'function'
-        && typeof window.startGuidedTour === 'function'
-        && typeof window.startCycleTour === 'function'
-        && typeof window.endTour === 'function'
-        && typeof window._tourGoToStep === 'function';
+      const exportsCallable = typeof tour.startEmptyTour === 'function'
+        && typeof tour.startTour === 'function'
+        && typeof tour.startGuidedTour === 'function'
+        && typeof tour.startCycleTour === 'function'
+        && typeof tour.endTour === 'function'
+        && typeof tour.goToTourStep === 'function'
+        && typeof window.startTour !== 'function'
+        && typeof window._tourGoToStep !== 'function';
 
-      window.startEmptyTour(false);
+      tour.startEmptyTour(false);
       await wait(50);
 
       const overlay = document.getElementById('tour-overlay');
@@ -121,8 +116,8 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
       });
 
       const beforeInvalidIndexTitle = document.getElementById('tour-tooltip')?.querySelector('h4')?.textContent;
-      window._tourGoToStep(99);
-      window._tourGoToStep(-1);
+      tour.goToTourStep(99);
+      tour.goToTourStep(-1);
       await wait(50);
       const invalidTourIndexNoops = document.getElementById('tour-tooltip')?.querySelector('h4')?.textContent === beforeInvalidIndexTitle
         && document.getElementById('tour-tooltip')?.querySelectorAll('.tour-dot')[1]?.classList.contains('active') === true;
@@ -131,7 +126,7 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
       let stepOneSpotlightTargetsPanel = false;
       if (startTarget) {
         startTarget.scrollIntoView({ behavior: 'instant', block: 'nearest' });
-        window._tourGoToStep(1);
+        tour.goToTourStep(1);
         await wait(150);
         const targetRect = startTarget.getBoundingClientRect();
         const sl2 = document.getElementById('tour-spotlight');
@@ -150,7 +145,7 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
         && tooltip3?.querySelectorAll('.tour-dot')[0]?.classList.contains('active') === true
         && document.getElementById('tour-spotlight')?.style.display === 'none';
 
-      window._tourGoToStep(4);
+      tour.goToTourStep(4);
       await wait(100);
       const tooltip4 = document.getElementById('tour-tooltip');
       const btns4 = tooltip4?.querySelectorAll('.tour-btn') || [];
@@ -165,55 +160,55 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
         && !btns4[1]?.hasAttribute('onclick')
         && dots4[4]?.classList.contains('active') === true;
 
-      window.endTour();
+      tour.endTour();
       await wait(50);
       const endTourCleansUp = !document.getElementById('tour-overlay')
         && !document.getElementById('tour-spotlight')
         && !document.getElementById('tour-tooltip')
         && localStorage.getItem(emptyTourKey) === 'completed';
 
-      window.startEmptyTour(true);
+      tour.startEmptyTour(true);
       await wait(50);
       const autoTriggerCompletedNoops = !document.getElementById('tour-overlay')
         && !document.getElementById('tour-spotlight')
         && !document.getElementById('tour-tooltip');
 
       localStorage.setItem(emptyTourKey, 'v1:legacy-ciphertext:completed');
-      window.startEmptyTour(true);
+      tour.startEmptyTour(true);
       await wait(50);
       const legacyEncryptedFlagNoops = !document.getElementById('tour-overlay')
         && localStorage.getItem(emptyTourKey) === 'completed';
 
-      window.startEmptyTour(false);
+      tour.startEmptyTour(false);
       await wait(50);
       const manualRetriggerIgnoresCompletion = !!document.getElementById('tour-overlay')
         && !!document.getElementById('tour-tooltip');
-      window.endTour();
+      tour.endTour();
       await wait(50);
 
       localStorage.removeItem(emptyTourKey);
-      window.startGuidedTour(false);
+      tour.startGuidedTour(false);
       await wait(50);
       const guidedTourChoosesEmptyWelcomeText =
         document.getElementById('tour-tooltip')?.querySelector('p')?.textContent.includes('fresh profile') === true;
       const guidedTourChoosesEmptyStepCount =
         document.getElementById('tour-tooltip')?.querySelectorAll('.tour-dot').length === 5;
-      window.endTour();
+      tour.endTour();
       await wait(50);
 
       localStorage.removeItem(cycleTourKey);
-      window.startCycleTour(false);
+      tour.startCycleTour(false);
       await wait(50);
       const cycleTourStartsAtCycleWelcomeTitle =
         document.getElementById('tour-tooltip')?.querySelector('h4')?.textContent === 'Cycle-Aware Lab Interpretation';
       const cycleTourStartsCentered =
         document.getElementById('tour-spotlight')?.style.display === 'none';
-      window.endTour();
+      tour.endTour();
       await wait(50);
       const cycleTourCompletesKey = localStorage.getItem(cycleTourKey) === 'completed';
 
       localStorage.removeItem(emptyTourKey);
-      window.startEmptyTour(false);
+      tour.startEmptyTour(false);
       await wait(50);
       const overlayStyles = getComputedStyle(document.getElementById('tour-overlay'));
       const spotlightStyles = getComputedStyle(document.getElementById('tour-spotlight'));
@@ -226,18 +221,18 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
         && tooltipStyles.position === 'fixed'
         && spotlightStyles.pointerEvents === 'none'
         && overlayStyles.pointerEvents === 'auto';
-      window.endTour();
+      tour.endTour();
       await wait(50);
 
-      window.startEmptyTour(false);
-      window._tourGoToStep(1);
+      tour.startEmptyTour(false);
+      tour.goToTourStep(1);
       await wait(100);
       const tooltipRect = document.getElementById('tour-tooltip').getBoundingClientRect();
       const tooltipStaysInViewport = tooltipRect.left >= 0
         && tooltipRect.top >= 0
         && tooltipRect.right <= window.innerWidth + 1
         && tooltipRect.bottom <= window.innerHeight + 1;
-      window.endTour();
+      tour.endTour();
       await wait(50);
 
       const stepTargetsExist = !!document.querySelector('.welcome-primary-panel, #drop-zone')
@@ -254,18 +249,18 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
         'Settings & Connections',
       ];
       localStorage.removeItem(emptyTourKey);
-      window.startEmptyTour(false);
+      tour.startEmptyTour(false);
       await wait(50);
       const walkthroughSteps = [];
       for (let i = 0; i < expectedTitles.length; i++) {
-        window._tourGoToStep(i);
+        tour.goToTourStep(i);
         await wait(100);
         const tt = document.getElementById('tour-tooltip');
         walkthroughSteps.push(tt?.querySelector('h4')?.textContent === expectedTitles[i]
           && tt?.querySelectorAll('.tour-dot.active').length === 1);
       }
       const fullWalkthroughTitlesAndDots = walkthroughSteps.every(Boolean);
-      window.endTour();
+      tour.endTour();
       await wait(50);
 
       return {
@@ -295,7 +290,7 @@ test('guided and cycle tour DOM creates navigates layers and restores overlays',
         fullWalkthroughTitlesAndDots,
       };
     } finally {
-      window.endTour?.();
+      tour.endTour?.();
       ['tour-overlay', 'tour-spotlight', 'tour-tooltip'].forEach(id => document.getElementById(id)?.remove());
       if (savedEmptyTourState) localStorage.setItem(emptyTourKey, savedEmptyTourState);
       else localStorage.removeItem(emptyTourKey);

--- a/tests/test-cycle-tour.js
+++ b/tests/test-cycle-tour.js
@@ -22,10 +22,8 @@ function assert(name, condition, detail) {
 
 console.log('=== Cycle Tour Tests ===\n');
 
-// tour.js exposes window.startTour / startCycleTour / endTour / _tourGoToStep
-// via Object.assign(window, ...) at module load.
 await import('../js/state.js');
-await import('../js/tour.js');
+const tour = await import('../js/tour.js');
 
   // --- 1. TOUR_STEPS structure ---
   console.log('%c[1] App tour steps', 'font-weight:bold');
@@ -76,14 +74,15 @@ await import('../js/tour.js');
   assert('startCycleTour calls runTour with CYCLE_TOUR_STEPS', /startCycleTour.*\{[\s\S]*?runTour\(\s*CYCLE_TOUR_STEPS/.test(tourSrc));
   assert('startCycleTour uses cycleTour storage key', tourSrc.includes("profileKey('cycleTour')"));
 
-  // --- 8. Window exports ---
-  console.log('%c[8] Window exports', 'font-weight:bold');
-  assert('window.startEmptyTour exists', typeof window.startEmptyTour === 'function');
-  assert('window.startTour exists', typeof window.startTour === 'function');
-  assert('window.startGuidedTour exists', typeof window.startGuidedTour === 'function');
-  assert('window.startCycleTour exists', typeof window.startCycleTour === 'function');
-  assert('window.endTour exists', typeof window.endTour === 'function');
-  assert('window._tourGoToStep exists', typeof window._tourGoToStep === 'function');
+  // --- 8. Module exports ---
+  console.log('%c[8] Module exports', 'font-weight:bold');
+  assert('tour.startEmptyTour exists', typeof tour.startEmptyTour === 'function');
+  assert('tour.startTour exists', typeof tour.startTour === 'function');
+  assert('tour.startGuidedTour exists', typeof tour.startGuidedTour === 'function');
+  assert('tour.startCycleTour exists', typeof tour.startCycleTour === 'function');
+  assert('tour.endTour exists', typeof tour.endTour === 'function');
+  assert('tour.goToTourStep exists', typeof tour.goToTourStep === 'function');
+  assert('tour API is not published on window', typeof window.startTour !== 'function' && typeof window._tourGoToStep !== 'function');
 
   // --- 9. runTour filters missing targets ---
   console.log('%c[9] Step filtering', 'font-weight:bold');
@@ -98,6 +97,7 @@ await import('../js/tour.js');
   // --- 11. Auto-trigger in saveMenstrualCycle ---
   console.log('%c[11] Auto-trigger in saveMenstrualCycle', 'font-weight:bold');
   const cycleSrc = read('/js/cycle.js');
+  assert('cycle.js imports startCycleTour', cycleSrc.includes("import { startCycleTour } from './tour.js'"));
   assert('saveMenstrualCycle calls startCycleTour(true)', cycleSrc.includes('startCycleTour(true)'));
   assert('setTimeout delay for DOM readiness', /setTimeout\s*\(\s*\(\)\s*=>\s*\{[^}]*startCycleTour\(true\)[^}]*\}\s*,\s*600\s*\)/.test(cycleSrc));
 

--- a/tests/test-tour.js
+++ b/tests/test-tour.js
@@ -6,7 +6,7 @@
 //
 // Run: node tests/test-tour.js  (or via npm test)
 //
-// DOM-runtime sections (3 window-export checks + 4-12/15-17 — live tour
+// DOM-runtime sections (module-export checks + 4-12/15-17 — live tour
 // overlay/spotlight/tooltip creation, step navigation, z-index computed
 // styles, walkthrough) live in tests/playwright/tour-dom.spec.js on the Playwright
 // runner. This file is pure source-inspection — no module import.
@@ -45,8 +45,8 @@ assert('tour.js has EMPTY_TOUR_STEPS array', tourSrc.includes('const EMPTY_TOUR_
 assert('tour.js has TOUR_STEPS array', tourSrc.includes('const TOUR_STEPS'));
 assert('tour.js imports state', tourSrc.includes("import { state } from './state.js'"));
 assert('tour.js imports profileStorageKey', tourSrc.includes("import { profileStorageKey } from './profile.js'"));
-assert('tour.js has window exports', tourSrc.includes('Object.assign(window,') && tourSrc.includes('startEmptyTour') && tourSrc.includes('startTour') && tourSrc.includes('startGuidedTour') && tourSrc.includes('endTour'));
-assert('tour.js exposes _tourGoToStep on window', tourSrc.includes('window._tourGoToStep = goToStep'));
+assert('tour.js exports testable step navigation', tourSrc.includes('export function goToTourStep'));
+assert('tour.js does not publish tour API on window', !tourSrc.includes('Object.assign(window,') && !tourSrc.includes('window._tourGoToStep'));
 assert('startTour respects auto flag', tourSrc.includes('if (auto && isTourCompleted(') && tourSrc.includes(') return'));
 assert('startTour returns whether tour opened', tourSrc.includes('return runTour(TOUR_STEPS') && tourSrc.includes('return true'));
 assert('startEmptyTour returns whether empty tour opened', tourSrc.includes('return runTour(EMPTY_TOUR_STEPS') && tourSrc.includes("profileKey('emptyTour')"));
@@ -97,7 +97,7 @@ const tourStepsSection = tourStepsStart >= 0 && cycleStepsStart > tourStepsStart
 const stepMatches = tourStepsSection.match(/\{ target:/g);
 assert('Exactly 9 steps in TOUR_STEPS', stepMatches && stepMatches.length === 9, `found ${stepMatches ? stepMatches.length : 0}`);
 
-// Section 3 (window-export checks) + sections 4-12, 15-17 (live DOM tour
+// Section 3 (module-export checks) + sections 4-12, 15-17 (live DOM tour
 // overlay/spotlight/tooltip creation, step navigation, z-index computed
 // styles, viewport clamping, walkthrough) live in tests/playwright/tour-dom.spec.js.
 
@@ -170,7 +170,8 @@ assert('main.js imports app-feature-modules.js', mainSrc.includes("import './app
 assert('app-feature-modules.js delegates UI shell modules', appFeatureModulesSrc.includes("import './app-ui-shell-modules.js'"));
 assert('app-ui-shell-modules.js imports tour.js', appUiShellModulesSrc.includes("import './tour.js'"));
 assert('app-event-listeners.js Escape checks #tour-overlay', appEventsSrc.includes('tour-overlay'));
-assert('app-event-listeners.js Escape calls window.endTour()', appEventsSrc.includes('window.endTour()'));
+assert('app-event-listeners.js imports endTour()', appEventsSrc.includes("import { endTour } from './tour.js'"));
+assert('app-event-listeners.js Escape calls imported endTour()', appEventsSrc.includes('if (tourOverlay) { endTour(); return; }'));
 const tourEscIdx = appEventsSrc.indexOf('tour-overlay');
 const confirmEscIdx = appEventsSrc.indexOf('confirm-dialog-overlay');
 assert('Tour Escape check before confirm dialog', tourEscIdx > 0 && tourEscIdx < confirmEscIdx);
@@ -182,17 +183,19 @@ console.log('20. dashboard-page-view.js Auto-Trigger');
 
 const dashboardPageViewSrc = read('js/dashboard-page-view.js');
 
-assert('dashboard-page-view.js calls startTour through runtime helper',
-  dashboardPageViewSrc.includes("callDashboardPageRuntime('startTour', true)"));
-assert('dashboard-page-view.js calls startEmptyTour through runtime helper',
-  dashboardPageViewSrc.includes("callDashboardPageRuntime('startEmptyTour', true)"));
+assert('dashboard-page-view.js imports tour starters',
+  dashboardPageViewSrc.includes("import { startEmptyTour as defaultStartEmptyTour, startTour as defaultStartTour } from './tour.js'"));
+assert('dashboard-page-view.js calls injected startTour dependency',
+  dashboardPageViewSrc.includes('startTour(true)'));
+assert('dashboard-page-view.js calls injected startEmptyTour dependency',
+  dashboardPageViewSrc.includes('startEmptyTour(true)'));
 assert('Empty first visit starts empty tour before chat onboarding',
-  dashboardPageViewSrc.includes("const shouldAutoStartEmptyTour = typeof getDashboardPageRuntimeValue('startEmptyTour') === 'function' && !localStorage.getItem(profileStorageKey(state.currentProfile, 'emptyTour'))") &&
-  dashboardPageViewSrc.includes("setTimeout(() => callDashboardPageRuntime('startEmptyTour', true), 100)") &&
+  dashboardPageViewSrc.includes("const shouldAutoStartEmptyTour = !localStorage.getItem(profileStorageKey(state.currentProfile, 'emptyTour'))") &&
+  dashboardPageViewSrc.includes('setTimeout(() => startEmptyTour(true), 100)') &&
   dashboardPageViewSrc.includes('if (!shouldAutoStartEmptyTour && state.chatHistory.length === 0)'));
 const setupIdx = dashboardPageViewSrc.indexOf('setupDropZone()');
-const emptyTourIdx = dashboardPageViewSrc.indexOf('startEmptyTour');
-const tourIdx = dashboardPageViewSrc.indexOf("callDashboardPageRuntime('startTour', true)");
+const emptyTourIdx = dashboardPageViewSrc.indexOf('setTimeout(() => startEmptyTour(true), 100)');
+const tourIdx = dashboardPageViewSrc.indexOf('startTour(true)');
 assert('startEmptyTour called after setupDropZone', setupIdx > 0 && emptyTourIdx > setupIdx);
 assert('startTour called after setupDropZone', setupIdx > 0 && tourIdx > setupIdx);
 
@@ -207,10 +210,10 @@ assert('settings.js has "Guided Tour" button', settingsSrc.includes('Guided Tour
 assert('settings.js routes Guided Tour through delegated action',
   settingsSrc.includes('data-settings-action="start-guided-tour"'));
 assert('settings.js delegated handler calls startGuidedTour(false)',
-  /start-guided-tour[\s\S]{0,160}startGuidedTour\?\.\(false\)/.test(settingsSrc));
+  /start-guided-tour[\s\S]{0,160}startGuidedTour\(false\)/.test(settingsSrc));
 assert('settings.js closes modal before tour', settingsSrc.includes('closeSettingsModal()'));
 assert('settings.js uses setTimeout for tour delay',
-  /setTimeout\(\(\) => settingsWindow\.startGuidedTour\?\.\(false\), 300\)/.test(settingsSrc));
+  /setTimeout\(\(\) => startGuidedTour\(false\), 300\)/.test(settingsSrc));
 assert('Tour button in Display tab panel', /tab-panel="display"[\s\S]*?Guided Tour/s.test(settingsSrc));
 
 // ═══════════════════════════════════════

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -78,7 +78,6 @@ interface Window {
   ensureActiveThread?: () => void;
   exportAllDataJSON?: () => Promise<void> | void;
   exportClientJSON?: (profileId: string, includeChat?: boolean) => Promise<void> | void;
-  endTour: () => void;
   getInitialView?: () => string;
   getActiveData?: AnyFunction;
   getActivePersonality?: AnyFunction;
@@ -262,9 +261,6 @@ interface Window {
   openNoteEditor?: AnyFunction;
   openWearableDetail?: AnyFunction;
   showDetailModal?: AnyFunction;
-  startEmptyTour?: AnyFunction;
-  startTour?: AnyFunction;
-  _tourGoToStep?: (index: number) => void;
   syncWearableNow?: AnyFunction;
   triggerDNAFilePicker?: AnyFunction;
   loadLightDevicePresets?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.23';
+self.APP_VERSION = '1.10.24';


### PR DESCRIPTION
## Summary
- Remove tour start/end/step controls from the global `window` surface.
- Route dashboard, settings, cycle, and Escape-key tour interactions through direct ES module imports.
- Keep tour DOM coverage on module exports and bump `version.js` for app cache invalidation.

## Validation
- `node tests/test-tour.js`
- `node tests/test-cycle-tour.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`
- `npx playwright test tests/playwright/tour-dom.spec.js tests/playwright/cycle-browser-coverage.spec.js tests/playwright/setup-onboarding-coverage-batch.spec.js --project=chromium`
- `./run-tests.sh`
