### PR TITLE
Update Agent Access discovery metadata

### DIFF
--- a/.well-known/agent-skills/getbased-health-data/SKILL.md
+++ b/.well-known/agent-skills/getbased-health-data/SKILL.md
@@ -7,7 +7,7 @@ description: Connect to a user's getbased health data and query their blood work
 
 [getbased](https://getbased.health) is a free, open-source Personal Health Intelligence app that runs in the user's browser. It connects five lenses on a person's biology — labs, genome, body, lifestyle, and environment — and exposes a read-only summary to AI agents through the [`getbased-mcp`](https://github.com/elkimek/getbased-agents/tree/main/packages/mcp) server.
 
-The user's raw data and encryption keys never leave their device. The MCP server reads the same pre-built context text the in-app AI chat uses — not the underlying database.
+The user's raw data and sync mnemonic never leave their device. The browser encrypts a pre-built context summary, pushes only ciphertext to the relay, and the local MCP process decrypts it with the separate Agent Context key. The relay token is not the encryption key.
 
 ## When to use this skill
 
@@ -17,10 +17,14 @@ Use this skill when the user wants you to reason about *their own* health data: 
 
 The MCP server is installed and run locally by the user — there is no hosted endpoint.
 
-1. Install: `pip install getbased-mcp` (or the `getbased-agent-stack` bundle).
-2. The user enables **Settings > Data > Agent Access** in the getbased app and copies the read-only token.
-3. The token is provided to the MCP server via the `GETBASED_TOKEN` environment variable. It grants access to lab-context text only, no raw data, and is revocable.
+1. Install the bundled stack: `curl -sSL https://getbased.health/install.sh | bash` (recommended) or install only the adapter with `pipx install "getbased-mcp>=0.2.6"`.
+2. The user enables **Settings > Agent Access** in the getbased app and copies both generated values.
+3. Provide both env vars to the MCP server:
+   - `GETBASED_TOKEN` — authorizes the relay fetch.
+   - `GETBASED_AGENT_CONTEXT_KEY` — decrypts the encrypted context locally. The relay never receives it.
 4. Add `getbased` to the MCP client config pointing at the `getbased-mcp` command.
+
+If the token works but tools return ciphertext, empty sections, or a decryption error, the context key is missing, stale, or copied incorrectly. Update both env vars and restart the MCP client; token-only access must fail closed for current encrypted v2 contexts.
 
 Full configuration details: https://docs.getbased.health/guides/agent-access
 

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Connect to a user's getbased health data and query their blood work, biomarkers, genome, wearables, and personal research library via the getbased MCP server. Use when a user asks about their lab results, health trends, or wants AI reasoning grounded in their own health data.",
       "url": "/.well-known/agent-skills/getbased-health-data/SKILL.md",
-      "digest": "sha256:2f8bfd0828ec04d6f393dbf9027c67867a8b16410197c9c9b64ff6cdb56a72ef"
+      "digest": "sha256:07a0fb7d4c26d2f6607238eaae15394dd34407a3df98bef02834ba555e3928e6"
     }
   ]
 }

--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -1,7 +1,7 @@
 {
   "name": "getbased",
   "description": "MCP server that exposes your getbased health data — blood work context, biomarker sections, and an optional RAG knowledge base — as tools for any MCP-compatible agent. Your data stays on your device; the server reads a read-only context summary, not raw records.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "transport": "stdio",
   "hosting": "local",
   "homepage": "https://getbased.health",
@@ -18,9 +18,10 @@
     }
   },
   "authentication": {
-    "type": "token",
+    "type": "token-plus-local-decryption-key",
     "env": "GETBASED_TOKEN",
-    "description": "Read-only token generated in the getbased app under Settings > Data > Agent Access. Grants access to lab-context text only — no raw data, no write access. Revocable at any time by regenerating the token."
+    "requiredEnv": ["GETBASED_TOKEN", "GETBASED_AGENT_CONTEXT_KEY"],
+    "description": "Agent Access uses two generated values from getbased Settings > Agent Access. GETBASED_TOKEN authorizes the relay fetch. GETBASED_AGENT_CONTEXT_KEY decrypts the encrypted context locally in the MCP process. The gateway never receives the context key. Both values are required for current encrypted v2 contexts; a token alone must fail closed."
   },
   "syncBackend": "https://sync.getbased.health",
   "tools": [


### PR DESCRIPTION
## Summary
- mirror the site `.well-known` Agent Access metadata updates into the app repo
- update MCP card to `getbased-mcp` 0.2.6 and two-secret auth
- update static agent skill setup/troubleshooting and digest

## Why
The site metadata is mirrored in the app repo. Keeping both copies aligned avoids stale agent-discovery surfaces that tell agents to configure only `GETBASED_TOKEN`.

## Verification
- `python3 -m json.tool .well-known/mcp.json`
- `python3 -m json.tool .well-known/agent-skills/index.json`
- digest recomputed and asserted against `SKILL.md`
- `npm run typecheck`
- `npm test` → 13 files / 199 Vitest tests passed, legacy suite also passed in output
