### PR TITLE
[codex] Remove light burden window facade

### DIFF
--- a/js/light-burden-ai-analysis.js
+++ b/js/light-burden-ai-analysis.js
@@ -259,10 +259,4 @@ export function renderBurdenInterp(burden) {
   </div>`;
 }
 
-Object.assign(window, {
-  refreshBurdenAIAnalysis,
-  analyzeBurdenAI,
-  renderBurdenInterp,
-});
-
 configureLightEnv({ renderBurdenInterp });

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -653,6 +653,10 @@ const {
     envSrc.includes('renderBurdenInterp: null') &&
     envSrc.includes('lightEnvDeps.renderBurdenInterp') &&
     !envSrc.includes('globalThis.renderBurdenInterp') &&
+    !burdenSrc.includes('Object.assign(window, {') &&
+    !burdenSrc.includes('window.refreshBurdenAIAnalysis') &&
+    !burdenSrc.includes('window.analyzeBurdenAI') &&
+    !burdenSrc.includes('window.renderBurdenInterp') &&
     burdenSrc.includes("import { computeDeficitAxes, computeIndoorBurden, configureLightEnv, isActiveToday } from './light-env.js';") &&
     burdenSrc.includes('configureLightEnv({ renderBurdenInterp });'));
   assert('Room, measurement, and screen AI renderers route through Light environment configuration',


### PR DESCRIPTION
## Summary

- Remove the remaining `Object.assign(window, ...)` facade from `light-burden-ai-analysis.js`.
- Keep burden AI wired through module exports, the AI action registry, and `configureLightEnv({ renderBurdenInterp })`.
- Add source-level regression coverage so the burden renderer/analyzers are not reintroduced as window globals.

## Impact

This reduces the public window surface for the Light Environment burden AI path without changing runtime behavior. Existing callers use module imports or delegated AI action handlers.

## Validation

- `node tests/test-light-env.js`
- `node tests/test-light-ai-renders.js`
- `node tests/test-ai-action-delegates.js`