### PR TITLE
[codex] Remove light audit window facade

### DIFF
--- a/js/light-env-audits.js
+++ b/js/light-env-audits.js
@@ -656,12 +656,3 @@ export const lightEnvAuditActionHandlers = Object.freeze({
   deleteLightAuditConfirm,
   interpretLightAuditCompare,
 });
-
-function installWindowFacade() {
-  if (typeof window === 'undefined') return;
-  Object.assign(window, {
-    getLightAudits,
-  });
-}
-
-installWindowFacade();

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -631,6 +631,8 @@ const {
     auditSrc.includes('sortAuditsNewestFirst(getLightAudits())[0]?.id') &&
     envSrc.includes('modal.scrollTop') &&
     envSrc.includes('...lightEnvAuditActionHandlers') &&
+    !auditSrc.includes('Object.assign(window, {') &&
+    !auditSrc.includes('window.getLightAudits') &&
     !envSrc.includes('globalThis.saveLightAuditFromUI') &&
     !envSrc.includes('globalThis.toggleLightAudit') &&
     !envSrc.includes('globalThis.updateLightAuditField') &&


### PR DESCRIPTION
## Summary

- Remove the redundant `getLightAudits` `Object.assign(window, ...)` facade from `light-env-audits.js`.
- Keep audit access through module exports and the `light-env.js` re-export surface.
- Add source-level regression coverage so the audit module does not reintroduce a window facade.

## Impact

This reduces the Light Environment public window surface without changing UI behavior. Existing audit actions already use delegated handlers and module wiring.

## Validation

- `node tests/test-light-env.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-ai-action-delegates.js`