### PR TITLE
[codex] Remove room AI window facade

### DIFF
--- a/js/light-env-ai-analysis.js
+++ b/js/light-env-ai-analysis.js
@@ -254,9 +254,3 @@ export function renderRoomAIBlock(r) {
     <span class="light-env-room-ai-tip">Circadian-friendliness check for this room.</span>
     <button class="sun-session-ai-refresh light-env-room-ai-refresh" ${aiActionAttrs('refresh-room', r.id)}>Analyze</button>`);
 }
-
-Object.assign(window, {
-  refreshRoomAIAnalysis,
-  analyzeRoomAI,
-  renderRoomAIBlock,
-});

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -606,6 +606,7 @@ const {
   const lightEnvShellHooksSrc = await fs.readFile(new URL('../js/light-env-shell-hooks.js', import.meta.url), 'utf8');
   const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const screenUiSrc = await fs.readFile(new URL('../js/light-env-screen-ui.js', import.meta.url), 'utf8');
+  const roomAiSrc = await fs.readFile(new URL('../js/light-env-ai-analysis.js', import.meta.url), 'utf8');
   assert('Light audit renderer emits no inline event attributes',
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light environment render/data helpers stay module exports, not window facade',
@@ -677,6 +678,11 @@ const {
     aiSaveHooksSrc.includes("import { renderRoomAIBlock } from './light-env-ai-analysis.js';") &&
     aiSaveHooksSrc.includes("import { renderScreenAIBlock } from './light-screen-ai-analysis.js';") &&
     aiSaveHooksSrc.includes('configureLightEnv({ getMeasurementsForRoom, renderMeasurementAIInline, renderRoomAIBlock, renderScreenAIBlock })') &&
+    !roomAiSrc.includes('Object.assign(window, {') &&
+    !roomAiSrc.includes('window.refreshRoomAIAnalysis') &&
+    !roomAiSrc.includes('window.analyzeRoomAI') &&
+    !roomAiSrc.includes('window.renderRoomAIBlock') &&
+    !globalsSrc.includes('renderRoomAIBlock') &&
     !envSrc.includes('globalThis.getMeasurementsForRoom') &&
     !envSrc.includes('globalThis.renderMeasurementAIInline') &&
     !envSrc.includes('globalThis.renderRoomAIBlock') &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -295,7 +295,6 @@ interface Window {
   renderAuditAIDot?: AnyFunction;
   renderBurdenInterp?: AnyFunction;
   renderMeasurementAIInline?: AnyFunction;
-  renderRoomAIBlock?: AnyFunction;
   renderScreenAIBlock?: AnyFunction;
   saveMeasurement?: AnyFunction;
   openChatPanel: AnyFunction;
@@ -329,6 +328,5 @@ declare var openLuxMeter: AnyFunction | undefined;
 declare var openSpectrumClassifier: AnyFunction | undefined;
 declare var renderBurdenInterp: AnyFunction | undefined;
 declare var renderMeasurementAIInline: AnyFunction | undefined;
-declare var renderRoomAIBlock: AnyFunction | undefined;
 declare var renderScreenAIBlock: AnyFunction | undefined;
 declare var ingredientDailyTotal: AnyFunction | undefined;


### PR DESCRIPTION
## Summary

- Remove the redundant `Object.assign(window, ...)` facade from `light-env-ai-analysis.js`.
- Keep room AI access through module exports, `configureLightEnv` injection, and the AI action registry.
- Add source-level regression coverage so the room AI functions are not reintroduced as window globals.

## Impact

This reduces the Light Environment public window surface without changing room AI rendering or refresh behavior.

## Validation

- `node tests/test-light-env.js`
- `node tests/test-light-ai-renders.js`
- `node tests/test-ai-action-delegates.js`