### PR TITLE
[codex] Remove screen AI window facade

### DIFF
--- a/js/light-screen-ai-analysis.js
+++ b/js/light-screen-ai-analysis.js
@@ -191,9 +191,3 @@ export function renderScreenAIBlock(s) {
     </div>
   </div>`;
 }
-
-Object.assign(window, {
-  refreshScreenAIAnalysis,
-  analyzeScreenAI,
-  renderScreenAIBlock,
-});

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -607,6 +607,7 @@ const {
   const navSrc = await fs.readFile(new URL('../js/nav.js', import.meta.url), 'utf8');
   const screenUiSrc = await fs.readFile(new URL('../js/light-env-screen-ui.js', import.meta.url), 'utf8');
   const roomAiSrc = await fs.readFile(new URL('../js/light-env-ai-analysis.js', import.meta.url), 'utf8');
+  const screenAiSrc = await fs.readFile(new URL('../js/light-screen-ai-analysis.js', import.meta.url), 'utf8');
   assert('Light audit renderer emits no inline event attributes',
     !/\bon(?:click|keydown|change|input|submit|blur|toggle)=/.test(auditSrc));
   assert('Light environment render/data helpers stay module exports, not window facade',
@@ -683,6 +684,11 @@ const {
     !roomAiSrc.includes('window.analyzeRoomAI') &&
     !roomAiSrc.includes('window.renderRoomAIBlock') &&
     !globalsSrc.includes('renderRoomAIBlock') &&
+    !screenAiSrc.includes('Object.assign(window, {') &&
+    !screenAiSrc.includes('window.refreshScreenAIAnalysis') &&
+    !screenAiSrc.includes('window.analyzeScreenAI') &&
+    !screenAiSrc.includes('window.renderScreenAIBlock') &&
+    !globalsSrc.includes('renderScreenAIBlock') &&
     !envSrc.includes('globalThis.getMeasurementsForRoom') &&
     !envSrc.includes('globalThis.renderMeasurementAIInline') &&
     !envSrc.includes('globalThis.renderRoomAIBlock') &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -295,7 +295,6 @@ interface Window {
   renderAuditAIDot?: AnyFunction;
   renderBurdenInterp?: AnyFunction;
   renderMeasurementAIInline?: AnyFunction;
-  renderScreenAIBlock?: AnyFunction;
   saveMeasurement?: AnyFunction;
   openChatPanel: AnyFunction;
   openCCTMeter?: AnyFunction;
@@ -328,5 +327,4 @@ declare var openLuxMeter: AnyFunction | undefined;
 declare var openSpectrumClassifier: AnyFunction | undefined;
 declare var renderBurdenInterp: AnyFunction | undefined;
 declare var renderMeasurementAIInline: AnyFunction | undefined;
-declare var renderScreenAIBlock: AnyFunction | undefined;
 declare var ingredientDailyTotal: AnyFunction | undefined;


### PR DESCRIPTION
## Summary
- Remove the redundant `Object.assign(window, ...)` screen AI facade from `light-screen-ai-analysis.js`
- Keep screen AI access through module exports, configured environment injection, and the AI action registry
- Drop stale `renderScreenAIBlock` globals and add regression guards

## Validation
- `node tests/test-light-env.js`
- `node tests/test-light-ai-renders.js`
- `npm run typecheck:checkjs`