### PR TITLE
Collapse June 24 changelog under 1.10.26

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -10,23 +10,14 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
-    version: '1.10.25', date: '2026-06-24', title: 'Agent Access security hardening',
+    version: '1.10.26', date: '2026-06-24', title: 'Clearer AI context, safer Agent Access, and better BP details',
     forceShow: true,
     items: [
-      '<b>Agent Access now separates relay authorization from context decryption.</b> The token authorizes fetching from the relay, while a separate Agent Context key decrypts the context locally inside your self-hosted MCP.',
-      '<b>The hosted relay still only carries ciphertext.</b> Agent context is encrypted in the browser before upload and remains unreadable to the relay.',
+      '<b>AI grounding has one clear home.</b> Interpretive Lens and Knowledge Base now live together under Manage → Context, while Profile Context stays focused on biological facts about you.',
+      '<b>Chat now shows what context is active.</b> Enabled lenses and knowledge bases appear as clickable AI Context chips in chat, including an amber KB empty state when Knowledge Base is switched on but has no indexed documents yet.',
+      '<b>Blood pressure details are safer and easier to read.</b> Systolic and diastolic now open as one paired BP detail view, with clearer charting and guardrails that avoid inventing mixed-date or mixed-source readings.',
+      '<b>Agent Access is harder to misconfigure.</b> Relay authorization and local context decryption are separated, so the hosted relay only carries ciphertext while your self-hosted MCP uses the separate Agent Context key to decrypt locally.',
       '<b>Setup copy is clearer.</b> Settings → Agent Access now shows the exact <code>GETBASED_TOKEN</code> and <code>GETBASED_AGENT_CONTEXT_KEY</code> values your MCP config needs.',
-    ]
-  },
-  {
-    version: '1.10.24', date: '2026-06-24', title: 'Clearer AI context and blood pressure details',
-    forceShow: true,
-    items: [
-      '<b>AI Context is easier to find.</b> Personalize how AI answers and Knowledge Base now live together under Manage → Context, so AI grounding has one clear home instead of being mixed into Profile Context.',
-      '<b>AI Context status is visible in chat.</b> When an Interpretive Lens or Knowledge Base is enabled, chat shows a clickable green context chip that jumps back to Manage → Context.',
-      '<b>Empty Knowledge Base state is visible.</b> If Knowledge Base is enabled but no documents are indexed yet, chat shows an amber KB empty context chip instead of staying silent or pretending answers are grounded.',
-      '<b>Blood pressure details now stay paired.</b> Systolic and diastolic readings open as one BP detail view, even if you enter through the diastolic metric, and the chart keeps the two lines and manual readings visually distinct.',
-      '<b>Mixed-source BP data is safer.</b> When systolic and diastolic come from different sources, getbased fetches each source separately and only shows a Latest BP pair when both halves were recorded on the same date.',
     ]
   },
   {

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -98,13 +98,15 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
-assert('context/BP changelog documents merged AI context, KB-empty, and BP fixes in user-readable terms',
-  /version:\s*'1\.10\.24'[\s\S]{0,1800}AI Context is easier to find/.test(changelogSrc)
-    && /version:\s*'1\.10\.24'[\s\S]{0,1800}clickable green context chip/.test(changelogSrc)
-    && /version:\s*'1\.10\.24'[\s\S]{0,1800}KB empty context chip/.test(changelogSrc)
-    && /version:\s*'1\.10\.24'[\s\S]{0,1800}Blood pressure details now stay paired/.test(changelogSrc)
-    && /version:\s*'1\.10\.24'[\s\S]{0,1800}Mixed-source BP data is safer/.test(changelogSrc)
-    && /version:\s*'1\.10\.24'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
+assert('current changelog collapses today into one user-readable patch entry',
+  /version:\s*'1\.10\.26'[\s\S]{0,2200}AI grounding has one clear home/.test(changelogSrc)
+    && /version:\s*'1\.10\.26'[\s\S]{0,2200}clickable AI Context chips/.test(changelogSrc)
+    && /version:\s*'1\.10\.26'[\s\S]{0,2200}KB empty state/.test(changelogSrc)
+    && /version:\s*'1\.10\.26'[\s\S]{0,2200}Blood pressure details are safer/.test(changelogSrc)
+    && /version:\s*'1\.10\.26'[\s\S]{0,2200}Agent Access is harder to misconfigure/.test(changelogSrc)
+    && /version:\s*'1\.10\.26'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc)
+    && !/version:\s*'1\.10\.24'/.test(changelogSrc)
+    && !/version:\s*'1\.10\.25'/.test(changelogSrc));
 assert('previous changelog documents PPQ Private TEE in user-readable terms',
   /version:\s*'1\.10\.8'[\s\S]{0,900}PPQ Private TEE Mode/.test(changelogSrc)
     && /version:\s*'1\.10\.8'[\s\S]{0,900}encrypts prompts in your browser/.test(changelogSrc)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.25';
+self.APP_VERSION = '1.10.26';


### PR DESCRIPTION
## Summary
- bump the app shell version to `1.10.26`
- collapse today’s Agent Access, AI Context, Knowledge Base, and BP-detail notes into one high-level top changelog entry
- add a changelog regression so the June 24 work stays a single user-readable patch entry instead of split under buried patch versions

## Verification
- `node tests/test-changelog.js`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test`

Follow-up to #991 after it merged before the changelog cleanup landed.