### PR TITLE
[codex] Remove audit AI window facade

### DIFF
--- a/js/light-audit-ai-analysis.js
+++ b/js/light-audit-ai-analysis.js
@@ -283,11 +283,3 @@ export function renderAuditAIDot(a) {
   const dot = a.aiAnalysis.dot;
   return `<span class="sun-session-ai-dot sun-session-ai-dot-${escapeAttr(dot)} light-audit-ai-dot" title="AI verdict: ${escapeAttr(a.aiAnalysis.tip || '')}" aria-hidden="true"></span>`;
 }
-
-Object.assign(window, {
-  refreshAuditAIAnalysis,
-  analyzeAuditAI,
-  maybeAnalyzeAuditAfterSave,
-  renderAuditAIBlock,
-  renderAuditAIDot,
-});

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -597,6 +597,7 @@ const {
     !envSrc.includes('function _hasAnyRoomSignal'));
   const fs = await import('node:fs/promises');
   const auditSrc = await fs.readFile(new URL('../js/light-env-audits.js', import.meta.url), 'utf8');
+  const auditAiSrc = await fs.readFile(new URL('../js/light-audit-ai-analysis.js', import.meta.url), 'utf8');
   const burdenSrc = await fs.readFile(new URL('../js/light-burden-ai-analysis.js', import.meta.url), 'utf8');
   const appLightSunSrc = await fs.readFile(new URL('../js/app-light-sun-modules.js', import.meta.url), 'utf8');
   const appUiShellSrc = await fs.readFile(new URL('../js/app-ui-shell-modules.js', import.meta.url), 'utf8');
@@ -643,10 +644,19 @@ const {
     !globalsSrc.includes('saveLightAuditFromUI') &&
     !envSrc.includes('function renderLightAuditCompare'));
   assert('Light audit AI hooks route through startup wiring',
+    !auditAiSrc.includes('Object.assign(window, {') &&
+    !auditAiSrc.includes('window.refreshAuditAIAnalysis') &&
+    !auditAiSrc.includes('window.analyzeAuditAI') &&
+    !auditAiSrc.includes('window.maybeAnalyzeAuditAfterSave') &&
+    !auditAiSrc.includes('window.renderAuditAIBlock') &&
+    !auditAiSrc.includes('window.renderAuditAIDot') &&
     !auditSrc.includes('window.maybeAnalyzeAuditAfterSave') &&
     !auditSrc.includes('window.renderAuditAIBlock') &&
     !auditSrc.includes('window.renderAuditAIDot') &&
     !auditSrc.includes('window.hasAIProvider') &&
+    !globalsSrc.includes('maybeAnalyzeAuditAfterSave') &&
+    !globalsSrc.includes('renderAuditAIBlock') &&
+    !globalsSrc.includes('renderAuditAIDot') &&
     aiSaveHooksSrc.includes("import { configureLightEnvAudits } from './light-env-audits.js';") &&
     aiSaveHooksSrc.includes("import { hasAIProvider } from './api.js';") &&
     aiSaveHooksSrc.includes("import { openChatPanel } from './chat-panel.js';") &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -289,9 +289,6 @@ interface Window {
   hydrateSession?: AnyFunction;
   logCompletedSession?: AnyFunction;
   getMeasurementsForRoom?: AnyFunction;
-  maybeAnalyzeAuditAfterSave?: AnyFunction;
-  renderAuditAIBlock?: AnyFunction;
-  renderAuditAIDot?: AnyFunction;
   renderBurdenInterp?: AnyFunction;
   saveMeasurement?: AnyFunction;
   openChatPanel: AnyFunction;


### PR DESCRIPTION
## Summary
- Remove the redundant `Object.assign(window, ...)` audit AI facade from `light-audit-ai-analysis.js`
- Keep audit AI access through module exports, startup wiring, and the AI action registry
- Drop stale audit AI global declarations and add regression guards

## Validation
- `node tests/test-light-env.js`
- `node tests/test-light-ai-renders.js`
- `npm run typecheck:checkjs`