### PR TITLE
[codex] Remove device AI window facade

### DIFF
--- a/js/light-device-ai-analysis.js
+++ b/js/light-device-ai-analysis.js
@@ -320,11 +320,3 @@ export function renderDeviceSessionAIDetail(sess) {
     ${detail ? `<div class="sun-detail-ai-body">${escapeHTML(detail)}</div>` : ''}
   </div>`;
 }
-
-Object.assign(window, {
-  refreshDeviceSessionAIAnalysis,
-  analyzeDeviceSessionAI,
-  renderDeviceSessionAIInline,
-  renderDeviceSessionAIDetail,
-  maybeAnalyzeDeviceSessionAfterFinish,
-});

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -47,6 +47,15 @@ const LIGHT_DEVICE_ID_ATTR = 'data-light-device-id';
 const LIGHT_DEVICE_SESSION_ID_ATTR = 'data-light-device-session-id';
 const LIGHT_DEVICES_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightDevicesActionDelegatesInstalled'), lightDevicesActionDelegateRoots = new WeakSet();
 
+/** @type {{ renderDeviceSessionAIDetail: (sess: any) => string }} */
+const lightDevicesDeps = {
+  renderDeviceSessionAIDetail: () => '',
+};
+
+export function configureLightDevices(deps = {}) {
+  Object.assign(lightDevicesDeps, deps);
+}
+
 function closestLightDevicesAction(target) { return target?.closest?.(`[${LIGHT_DEVICES_ACTION_ATTR}]`) || null; }
 
 function handleLightDevicesActionClick(event) {
@@ -347,7 +356,7 @@ export function openDeviceSessionDetail(id) {
       <button class="modal-close" data-device-session-detail-close aria-label="Close">×</button>
     </div>
     <div class="modal-body">
-      ${window.renderDeviceSessionAIDetail ? window.renderDeviceSessionAIDetail(sess) : ''}
+      ${typeof lightDevicesDeps.renderDeviceSessionAIDetail === 'function' ? lightDevicesDeps.renderDeviceSessionAIDetail(sess) : ''}
       <div class="sun-detail-grid">
         <div title="Total session duration. Edit via the action row below if the timer ran past the actual session."><span>Duration</span><strong>${escapeHTML(dur)}</strong></div>
         <div title="Distance from the panel's emitting surface to your skin. Inverse-square law applies — the model corrects irradiance by (recommendedDistanceCm / actualDistance)²."><span>Distance</span><strong>${escapeHTML(distanceStr)}</strong></div>

--- a/js/light-sessions-view-hooks.js
+++ b/js/light-sessions-view-hooks.js
@@ -3,10 +3,12 @@
 
 import { CHANNEL_DISPLAY, channelTier, formatChannelUnit, getSessions } from './sun.js';
 import { renderSunSessionRow } from './sun-session-ui.js';
-import { deleteDeviceSessionWithConfirm, openDeviceSessionDetail } from './light-devices.js';
+import { configureLightDevices, deleteDeviceSessionWithConfirm, openDeviceSessionDetail } from './light-devices.js';
 import { getDeviceSessions, getDevices } from './light-devices-store.js';
-import { renderDeviceSessionAIInline } from './light-device-ai-analysis.js';
+import { renderDeviceSessionAIDetail, renderDeviceSessionAIInline } from './light-device-ai-analysis.js';
 import { configureLightSessionsView } from './light-sessions-view.js';
+
+configureLightDevices({ renderDeviceSessionAIDetail });
 
 configureLightSessionsView({
   channelDisplay: CHANNEL_DISPLAY,

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -829,7 +829,6 @@ test('light devices cover session detail edit log active card and rendered list 
       formatChannelUnit: window.formatChannelUnit,
       CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
       _openChannelOnLightPage: window._openChannelOnLightPage,
-      renderDeviceSessionAIDetail: window.renderDeviceSessionAIDetail,
       loadCatalog: window.loadCatalog,
       renderLightDeviceAffiliateRow: window.renderLightDeviceAffiliateRow,
       showPromptDialog: window.showPromptDialog,
@@ -896,7 +895,9 @@ test('light devices cover session detail edit log active card and rendered list 
         pbm_nir: { icon: 'N', label: 'NIR', what: 'NIR' },
       };
       window._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
-      window.renderDeviceSessionAIDetail = () => '<section class="device-ai-detail-test">Device AI</section>';
+      lightDevices.configureLightDevices({
+        renderDeviceSessionAIDetail: () => '<section class="device-ai-detail-test">Device AI</section>',
+      });
       window.loadCatalog = async () => ({ items: [] });
       window.renderLightDeviceAffiliateRow = (_catalog, slug) => `<a class="affiliate-test">${slug}</a>`;
       window.showPromptDialog = async () => '17';
@@ -986,6 +987,7 @@ test('light devices cover session detail edit log active card and rendered list 
       else await blobStorage.setBlob(importedStorageKey, originalImportedBlobValue);
       if (originalImportedLocalValue == null) localStorage.removeItem(importedStorageKey);
       else localStorage.setItem(importedStorageKey, originalImportedLocalValue);
+      lightDevices.configureLightDevices({ renderDeviceSessionAIDetail: () => '' });
       Object.assign(window, savedWindow);
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -23,6 +23,7 @@ const exportReportBuilderSrc = fs.readFileSync(path.join(root, 'js/export-report
 const lensSrc = fs.readFileSync(path.join(root, 'js/lens.js'), 'utf8');
 const lensLibrarySrc = fs.readFileSync(path.join(root, 'js/lens-library.js'), 'utf8');
 const lightConditionsNowSrc = fs.readFileSync(path.join(root, 'js/light-conditions-now.js'), 'utf8');
+const lightDeviceAiSrc = fs.readFileSync(path.join(root, 'js/light-device-ai-analysis.js'), 'utf8');
 const lightDeviceSessionModalSrc = fs.readFileSync(path.join(root, 'js/light-device-session-modal.js'), 'utf8');
 const lightDeviceSetupModalSrc = fs.readFileSync(path.join(root, 'js/light-device-setup-modal.js'), 'utf8');
 const lightDevicesSrc = fs.readFileSync(path.join(root, 'js/light-devices.js'), 'utf8');
@@ -304,9 +305,17 @@ assert('light device and session modals use shared overlay lifecycle helpers',
 assert('light sessions view runtime dependencies are startup-wired',
   lightSessionsViewSrc.includes('export function configureLightSessionsView') &&
     !lightSessionsViewSrc.includes('window.') &&
+    lightDevicesSrc.includes('export function configureLightDevices') &&
+    !lightDevicesSrc.includes('window.renderDeviceSessionAIDetail') &&
+    lightDeviceAiSrc.includes('registerAIActionHandler') &&
+    !lightDeviceAiSrc.includes('Object.assign(window, {') &&
+    !lightDeviceAiSrc.includes('window.renderDeviceSessionAIDetail') &&
+    !lightDeviceAiSrc.includes('window.renderDeviceSessionAIInline') &&
     lightDevicesSrc.includes('export async function deleteDeviceSessionWithConfirm') &&
     lightSessionsViewHooksSrc.includes("import { CHANNEL_DISPLAY, channelTier, formatChannelUnit, getSessions } from './sun.js';") &&
-    lightSessionsViewHooksSrc.includes("import { deleteDeviceSessionWithConfirm, openDeviceSessionDetail } from './light-devices.js';") &&
+    lightSessionsViewHooksSrc.includes("import { configureLightDevices, deleteDeviceSessionWithConfirm, openDeviceSessionDetail } from './light-devices.js';") &&
+    lightSessionsViewHooksSrc.includes("import { renderDeviceSessionAIDetail, renderDeviceSessionAIInline } from './light-device-ai-analysis.js';") &&
+    lightSessionsViewHooksSrc.includes('configureLightDevices({ renderDeviceSessionAIDetail });') &&
     lightSessionsViewHooksSrc.includes('configureLightSessionsView({') &&
     appLightSunModulesSrc.includes("import './light-sessions-view-hooks.js';") &&
     serviceWorkerSrc.includes("'/js/light-sessions-view-hooks.js'"));

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -118,8 +118,6 @@ interface Window {
   geneticVitaminDMultiplier?: AnyFunction;
   renderSessionAIInline?: AnyFunction;
   renderSessionAIDetail?: AnyFunction;
-  renderDeviceSessionAIDetail?: AnyFunction;
-  renderDeviceSessionAIInline?: AnyFunction;
   renderLightChannelsLive?: AnyFunction;
   renderLightTodayDashboardChip?: AnyFunction;
   renderLightTodayHero?: AnyFunction;


### PR DESCRIPTION
## Summary
- Remove the redundant `Object.assign(window, ...)` device session AI facade from `light-device-ai-analysis.js`
- Wire device detail AI rendering through `configureLightDevices` from startup hooks instead of `window.renderDeviceSessionAIDetail`
- Drop stale device AI global declarations and update regression/browser coverage

## Validation
- `node tests/test-light-device-ai-analysis.js`
- `node tests/test-light-ai-renders.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-ai-action-delegates.js`
- `npm run typecheck:checkjs`
- `npx playwright test tests/playwright/light-sun-coverage-batch.spec.js --grep "light devices cover session detail"`