### PR TITLE
[codex] Remove sun session AI window facade

### DIFF
--- a/js/sun-ai-analysis.js
+++ b/js/sun-ai-analysis.js
@@ -350,13 +350,3 @@ export function renderSessionAIDetail(sess) {
     ${detail ? `<div class="sun-detail-ai-body">${escapeHTML(detail)}</div>` : ''}
   </div>`;
 }
-
-Object.assign(window, {
-  refreshSessionAIAnalysis,
-  analyzeSunSessionAI,
-  // Exposed so sun.js can call into the AI module without importing it
-  // — the reciprocal import would create a TDZ-risky cycle.
-  maybeAnalyzeSessionAfterFinish,
-  renderSessionAIInline,
-  renderSessionAIDetail,
-});

--- a/tests/test-sun-session-ui-delegated-actions.js
+++ b/tests/test-sun-session-ui-delegated-actions.js
@@ -10,8 +10,10 @@ const root = path.resolve(__dirname, '..');
 const uiSrc = fs.readFileSync(path.join(root, 'js/sun-session-ui.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/sun-session-actions.js'), 'utf8');
 const sunSrc = fs.readFileSync(path.join(root, 'js/sun.js'), 'utf8');
+const sunAiSrc = fs.readFileSync(path.join(root, 'js/sun-ai-analysis.js'), 'utf8');
 const aiHookSrc = fs.readFileSync(path.join(root, 'js/sun-session-ai-render-hooks.js'), 'utf8');
 const uiHookSrc = fs.readFileSync(path.join(root, 'js/sun-session-ui-hooks.js'), 'utf8');
+const lightSunAiHooksSrc = fs.readFileSync(path.join(root, 'js/light-sun-ai-hooks.js'), 'utf8');
 const appLightSunSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
 const appUiShellSrc = fs.readFileSync(path.join(root, 'js/app-ui-shell-modules.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
@@ -88,8 +90,17 @@ assert('sun-session-ui runtime render and navigate callbacks are startup-wired',
     uiSrc.includes('uiDeps.renderSessionAIInline(sess)') &&
     uiSrc.includes('uiDeps.renderSessionAIDetail(sess)') &&
     uiSrc.includes('function refreshLightView()') &&
+    sunAiSrc.includes('registerAIActionHandler') &&
+    !sunAiSrc.includes('Object.assign(window, {') &&
+    !sunAiSrc.includes('window.refreshSessionAIAnalysis') &&
+    !sunAiSrc.includes('window.analyzeSunSessionAI') &&
+    !sunAiSrc.includes('window.maybeAnalyzeSessionAfterFinish') &&
+    !sunAiSrc.includes('window.renderSessionAIInline') &&
+    !sunAiSrc.includes('window.renderSessionAIDetail') &&
     aiHookSrc.includes("import { renderSessionAIDetail, renderSessionAIInline } from './sun-ai-analysis.js';") &&
     aiHookSrc.includes('configureSunSessionUI({ renderSessionAIDetail, renderSessionAIInline })') &&
+    lightSunAiHooksSrc.includes("import { maybeAnalyzeSessionAfterFinish } from './sun-ai-analysis.js';") &&
+    lightSunAiHooksSrc.includes('configureSunSessionsStore({ maybeAnalyzeSessionAfterFinish })') &&
     uiHookSrc.includes("import { navigate } from './views.js';") &&
     uiHookSrc.includes('configureSunSessionUI({ navigate })') &&
     appLightSunSrc.includes("import './sun-session-ai-render-hooks.js';") &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -116,8 +116,6 @@ interface Window {
   circadianMelanopicLux?: AnyFunction;
   _skinTypeToFitzpatrick?: AnyFunction;
   geneticVitaminDMultiplier?: AnyFunction;
-  renderSessionAIInline?: AnyFunction;
-  renderSessionAIDetail?: AnyFunction;
   renderLightChannelsLive?: AnyFunction;
   renderLightTodayDashboardChip?: AnyFunction;
   renderLightTodayHero?: AnyFunction;
@@ -137,7 +135,6 @@ interface Window {
   cumulativeMEDYesterday?: AnyFunction;
   vitaminDBudgetStatus?: AnyFunction;
   maybeAnalyzeDeviceSessionAfterFinish?: AnyFunction;
-  maybeAnalyzeSessionAfterFinish?: AnyFunction;
   _labState?: { currentProfile?: string | null };
   handleDNAFile: (file: File) => Promise<void> | void;
   handleChatKeydown?: AnyFunction;


### PR DESCRIPTION
## Summary
- Remove the redundant `Object.assign(window, ...)` Sun session AI facade from `sun-ai-analysis.js`
- Keep Sun session AI access through module exports, startup hooks, and the AI action registry
- Drop stale Sun session AI global declarations and add regression guards

## Validation
- `node tests/test-sun-ai-analysis.js`
- `node tests/test-sun-session-ui-delegated-actions.js`
- `node tests/test-ai-action-delegates.js`
- `node tests/test-light-ai-renders.js`
- `npm run typecheck:checkjs`