### PR TITLE
[codex] Remove onboarding AI window facade

### DIFF
--- a/js/sun-onboarding-ai.js
+++ b/js/sun-onboarding-ai.js
@@ -238,10 +238,3 @@ export function renderOnboardingAIBlock() {
     </div>
   </div>`;
 }
-
-Object.assign(window, {
-  refreshOnboardingAIAnalysis,
-  analyzeOnboardingAI,
-  maybeAnalyzeOnboardingAfterSave,
-  renderOnboardingAIBlock,
-});

--- a/tests/test-sun-defaults.js
+++ b/tests/test-sun-defaults.js
@@ -24,6 +24,8 @@ const root = path.resolve(__dirname, '..');
 const sunDefaultsSrc = fs.readFileSync(path.join(root, 'js/sun-defaults.js'), 'utf8');
 const appLightSunSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
 const aiSaveHooksSrc = fs.readFileSync(path.join(root, 'js/light-ai-save-hooks.js'), 'utf8');
+const onboardingAiSrc = fs.readFileSync(path.join(root, 'js/sun-onboarding-ai.js'), 'utf8');
+const globalsSrc = fs.readFileSync(path.join(root, 'types/globals.d.ts'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 const originalDelegateDomGlobals = {
   document: globalThis.document,
@@ -85,8 +87,16 @@ const {
   assert('sun-defaults AI hooks route through startup wiring',
     typeof configureSunDefaults === 'function' &&
     sunDefaultsSrc.includes('maybeAnalyzeOnboardingAfterSave: () => {}') &&
+    onboardingAiSrc.includes('registerAIActionHandler') &&
+    !onboardingAiSrc.includes('Object.assign(window, {') &&
+    !onboardingAiSrc.includes('window.refreshOnboardingAIAnalysis') &&
+    !onboardingAiSrc.includes('window.analyzeOnboardingAI') &&
+    !onboardingAiSrc.includes('window.maybeAnalyzeOnboardingAfterSave') &&
+    !onboardingAiSrc.includes('window.renderOnboardingAIBlock') &&
     !sunDefaultsSrc.includes('window.maybeAnalyzeOnboardingAfterSave') &&
     !sunDefaultsSrc.includes('window.renderOnboardingAIBlock') &&
+    !globalsSrc.includes('maybeAnalyzeOnboardingAfterSave') &&
+    !globalsSrc.includes('renderOnboardingAIBlock') &&
     aiSaveHooksSrc.includes("import { configureSunDefaults } from './sun-defaults.js';") &&
     aiSaveHooksSrc.includes("import { maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock } from './sun-onboarding-ai.js';") &&
     aiSaveHooksSrc.includes('configureSunDefaults({ maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock })') &&

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -265,13 +265,11 @@ interface Window {
   renderActiveDeviceSessionCard?: AnyFunction;
   renderChannelDeficitDeviceRecs?: AnyFunction;
   renderDevicesSection?: AnyFunction;
-  renderOnboardingAIBlock?: AnyFunction;
   renderSunDataSourceSettings?: AnyFunction;
   computeUVConfidence?: AnyFunction;
   ensureActiveDeviceTicker?: AnyFunction;
   getMeteoConfig?: AnyFunction;
   ingredientDailyTotal?: AnyFunction;
-  maybeAnalyzeOnboardingAfterSave?: AnyFunction;
   maybeShowAnalyticsConsent?: () => void;
   purgeMeteoCache?: AnyFunction;
   rehydrateStaleSessions?: () => Promise<{ rehydrated?: number }>;


### PR DESCRIPTION
## Summary
- Remove the redundant `Object.assign(window, ...)` onboarding AI facade from `sun-onboarding-ai.js`
- Keep onboarding AI access through module exports, startup hooks, and the AI action registry
- Drop stale onboarding AI global declarations and add regression guards

## Validation
- `node tests/test-sun-defaults.js`
- `node tests/test-light-ai-renders.js`
- `node tests/test-ai-action-delegates.js`
- `npm run typecheck:checkjs`