### PR TITLE
[codex] Remove light today AI window facade

### DIFF
--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -15,6 +15,7 @@ import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js'
 import { configureMarkerDetailModal } from './marker-detail-modal.js';
 import { renderLightConditionsWidgetBody } from './light-conditions-now.js';
 import { renderDashboardLightChannelPills, renderLightSessionLogActions } from './light-page-view.js';
+import { renderLightTodayHero } from './light-today-ai.js';
 import {
   configureMobileDashboardView,
   getMobileDashboardMarkers,
@@ -56,6 +57,7 @@ export function createDashboardViewComposition({
     formatMobileWearableDelta,
     getMobileWearablePriority,
     rerenderDashboardFromWidgetChange,
+    renderLightTodayHero,
     showRecommendations,
   });
 

--- a/js/dashboard-widget-renderers.js
+++ b/js/dashboard-widget-renderers.js
@@ -39,6 +39,7 @@ export function createDashboardWidgetRenderers(deps) {
     formatMobileWearableDelta,
     getMobileWearablePriority = () => [],
     rerenderDashboardFromWidgetChange,
+    renderLightTodayHero = () => '',
     showRecommendations,
   } = deps;
 
@@ -74,9 +75,7 @@ export function createDashboardWidgetRenderers(deps) {
   } = recommendationWidget;
 
   function renderDashboardLightTodayWidget() {
-    const hero = (typeof window !== 'undefined' && typeof window.renderLightTodayHero === 'function')
-      ? window.renderLightTodayHero()
-      : '';
+    const hero = renderLightTodayHero();
     const heroHtml = hero || `<div class="light-today-hero light-today-hero-dashboard-fallback">
       <div class="light-today-hero-head"><span class="light-today-hero-label">Today's light</span></div>
       <div class="sun-detail-ai sun-detail-ai-idle">

--- a/js/light-today-ai.js
+++ b/js/light-today-ai.js
@@ -526,14 +526,6 @@ export function renderLightTodayDashboardChip() {
   </button>`;
 }
 
-Object.assign(globalThis, {
-  refreshDayAIAnalysis,
-  analyzeDayAI,
-  renderLightTodayHero,
-  renderLightTodayDashboardChip,
-  computeLightTrends,
-});
-
 // Cross-page live-update — when a verdict completes elsewhere (e.g. an
 // auto-fire on the Light & Sun page while the user is reading the
 // dashboard), re-render the dashboard chip in place without rebuilding

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -151,18 +151,18 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       rollingVitaminDIU: window.rollingVitaminDIU,
       vitaminDBudgetStatus: window.vitaminDBudgetStatus,
       getSunCoords: window.getSunCoords,
-      renderLightTodayDashboardChip: window.renderLightTodayDashboardChip,
       CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
       weeklyChannelTier: window.weeklyChannelTier,
       channelTier: window.channelTier,
       dailyChannelBreakdown: window.dailyChannelBreakdown,
       rollingChannelTotals: window.rollingChannelTotals,
       rollingDeviceTotals: window.rollingDeviceTotals,
-      renderLightTodayHero: window.renderLightTodayHero,
       renderSunSetupCard: window.renderSunSetupCard,
       renderDevicesSection: window.renderDevicesSection,
       renderLightTools: window.renderLightTools,
     };
+    let renderLightTodayDashboardChip = () => '';
+    let renderLightTodayHero = () => '';
     const syncLightPageDeps = () => lightPage.configureLightPageView({
       channelDisplay: window.CHANNEL_DISPLAY || {},
       weeklyChannelTier: typeof window.weeklyChannelTier === 'function' ? window.weeklyChannelTier : () => 0,
@@ -178,8 +178,8 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       rollingVitaminDIU: typeof window.rollingVitaminDIU === 'function' ? window.rollingVitaminDIU : () => 0,
       vitaminDBudgetStatus: typeof window.vitaminDBudgetStatus === 'function' ? window.vitaminDBudgetStatus : () => null,
       getSunCoords: typeof window.getSunCoords === 'function' ? window.getSunCoords : () => null,
-      renderLightTodayDashboardChip: typeof window.renderLightTodayDashboardChip === 'function' ? window.renderLightTodayDashboardChip : () => '',
-      renderLightTodayHero: typeof window.renderLightTodayHero === 'function' ? window.renderLightTodayHero : () => '',
+      renderLightTodayDashboardChip,
+      renderLightTodayHero,
       renderSunSetupCard: typeof window.renderSunSetupCard === 'function' ? window.renderSunSetupCard : () => '',
       renderDevicesSection: typeof window.renderDevicesSection === 'function' ? window.renderDevicesSection : () => '',
       renderEnvironmentAssessmentSummary,
@@ -237,7 +237,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
         exceedsSupplementUL: true,
       });
       window.getSunCoords = () => ({ lat: 50, lon: 14, altitudeM: 1700, source: 'profile-precise' });
-      window.renderLightTodayDashboardChip = () => '<div class="light-dashboard-chip-test">chip</div>';
+      renderLightTodayDashboardChip = () => '<div class="light-dashboard-chip-test">chip</div>';
       syncLightPageDeps();
 
       setHour(6);
@@ -285,7 +285,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
         activeStrip.includes('Stop session')
         && activeStrip.includes('data-live-elapsed-for="active-sun"');
 
-      window.renderLightTodayHero = () => '';
+      renderLightTodayHero = () => '';
       window.renderSunSetupCard = () => '<div class="setup-card-test">setup</div>';
       window.renderDevicesSection = () => '<div class="devices-section-test">devices</div>';
       renderEnvironmentAssessmentSummary = () => '';
@@ -319,18 +319,18 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.rollingVitaminDIU = saved.rollingVitaminDIU;
       window.vitaminDBudgetStatus = saved.vitaminDBudgetStatus;
       window.getSunCoords = saved.getSunCoords;
-      window.renderLightTodayDashboardChip = saved.renderLightTodayDashboardChip;
       window.CHANNEL_DISPLAY = saved.CHANNEL_DISPLAY;
       window.weeklyChannelTier = saved.weeklyChannelTier;
       window.channelTier = saved.channelTier;
       window.dailyChannelBreakdown = saved.dailyChannelBreakdown;
       window.rollingChannelTotals = saved.rollingChannelTotals;
       window.rollingDeviceTotals = saved.rollingDeviceTotals;
-      window.renderLightTodayHero = saved.renderLightTodayHero;
       window.renderSunSetupCard = saved.renderSunSetupCard;
       window.renderDevicesSection = saved.renderDevicesSection;
       renderEnvironmentAssessmentSummary = lightEnv.renderEnvironmentAssessmentSummary;
       window.renderLightTools = saved.renderLightTools;
+      renderLightTodayDashboardChip = () => '';
+      renderLightTodayHero = () => '';
       syncLightPageDeps();
     }
 

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -229,6 +229,7 @@ const lightPageViewSrc = read('js/light-page-view.js');
 const lightChannelViewSrc = read('js/light-channel-view.js');
 const dashboardWidgetsSrc = read('js/dashboard-widgets.js');
 const dashboardRenderersSrc = read('js/dashboard-widget-renderers.js');
+const dashboardViewCompositionSrc = read('js/dashboard-view-composition.js');
 const geneticsCssAuditSrc = read('css/genetics.css');
 const markerDetailCssAuditSrc = read('css/marker-detail-modal.css');
 const dnaSrc = read('js/dna.js');
@@ -496,7 +497,9 @@ assert('Light dashboard registry exposes only dashboard-safe Light widgets',
   !dashboardWidgetsBlock.includes("id: 'light-methods'"));
 assert('Dashboard Light Today uses the same hero surface as the Light page',
   dashboardRenderersSrc.includes('function renderDashboardLightTodayWidget()') &&
-  dashboardRenderersSrc.includes('window.renderLightTodayHero()') &&
+  dashboardRenderersSrc.includes('const hero = renderLightTodayHero();') &&
+  dashboardViewCompositionSrc.includes("import { renderLightTodayHero } from './light-today-ai.js';") &&
+  dashboardViewCompositionSrc.includes('renderLightTodayHero,') &&
   /id: 'light-today'[\s\S]*?render: renderers\.renderDashboardLightTodayWidget/.test(dashboardWidgetsBlock) &&
   !/id: 'light-today'[\s\S]*?render:\s*\(\)\s*=>\s*renderLightTodayStrip\(\)/.test(dashboardWidgetsBlock));
 assert('Dashboard Light Today stays separate from Conditions Now',

--- a/tests/test-light-page-view-delegated-actions.js
+++ b/tests/test-light-page-view-delegated-actions.js
@@ -9,6 +9,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const src = fs.readFileSync(path.join(root, 'js/light-page-view.js'), 'utf8');
 const hooksSrc = fs.readFileSync(path.join(root, 'js/light-page-view-hooks.js'), 'utf8');
+const todayAiSrc = fs.readFileSync(path.join(root, 'js/light-today-ai.js'), 'utf8');
+const dashboardRenderersSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-renderers.js'), 'utf8');
+const dashboardCompositionSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
+const globalsSrc = fs.readFileSync(path.join(root, 'types/globals.d.ts'), 'utf8');
 const uiHooksSrc = fs.readFileSync(path.join(root, 'js/light-page-view-ui-hooks.js'), 'utf8');
 const lightSunModulesSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
 const uiShellModulesSrc = fs.readFileSync(path.join(root, 'js/app-ui-shell-modules.js'), 'utf8');
@@ -56,6 +60,17 @@ assert('Light page feature hook wires runtime dependencies',
     && /renderDevicesSection/.test(hooksSrc)
     && /renderLightTools/.test(hooksSrc)
     && /renderChannelDeficitDeviceRecs/.test(hooksSrc));
+assert('Light Today AI renderers are wired without a window facade',
+  todayAiSrc.includes('registerAIActionHandler')
+    && !todayAiSrc.includes('Object.assign(globalThis')
+    && !todayAiSrc.includes('window.renderLightTodayHero')
+    && !todayAiSrc.includes('window.renderLightTodayDashboardChip')
+    && !globalsSrc.includes('renderLightTodayHero')
+    && !globalsSrc.includes('renderLightTodayDashboardChip')
+    && dashboardRenderersSrc.includes('renderLightTodayHero = () =>')
+    && dashboardRenderersSrc.includes('const hero = renderLightTodayHero();')
+    && dashboardCompositionSrc.includes("import { renderLightTodayHero } from './light-today-ai.js';")
+    && dashboardCompositionSrc.includes('renderLightTodayHero,'));
 assert('Light page UI hook wires router and settings dependencies',
   /import \{ navigate \} from '\.\/views\.js';/.test(uiHooksSrc)
     && /import \{ renderSunDataSourceSettings \} from '\.\/settings\.js';/.test(uiHooksSrc)

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -117,8 +117,6 @@ interface Window {
   _skinTypeToFitzpatrick?: AnyFunction;
   geneticVitaminDMultiplier?: AnyFunction;
   renderLightChannelsLive?: AnyFunction;
-  renderLightTodayDashboardChip?: AnyFunction;
-  renderLightTodayHero?: AnyFunction;
   renderLightTodayStrip?: AnyFunction;
   renderSunSessionRow?: AnyFunction;
   renderSunSetupCard?: AnyFunction;


### PR DESCRIPTION
## Summary
- remove the `light-today-ai` global facade for day AI helpers/renderers
- inject `renderLightTodayHero` into dashboard widget renderers through dashboard composition
- update source guards and browser coverage stubs so they no longer depend on `window.renderLightToday*`

## Validation
- `node tests/test-light-page-view-delegated-actions.js`
- `node tests/test-audit.js`
- `node tests/test-light-ai-renders.js`
- `npm run typecheck:checkjs`
- `npx playwright test tests/playwright/light-page-view.spec.js --grep "Light page today strip"`
- `npx playwright test tests/playwright/dashboard-widgets-browser-coverage.spec.js --grep "renderers browser coverage"`