### PR TITLE
[codex] Remove sun correlations window facade

### DIFF
--- a/js/sun-correlations.js
+++ b/js/sun-correlations.js
@@ -154,10 +154,3 @@ export function getSunCorrelations() {
   // demand and the cache covers cross-page reads within a session.
   return value;
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    computeSunCorrelations,
-    getSunCorrelations,
-  });
-}

--- a/tests/test-sun-correlations.js
+++ b/tests/test-sun-correlations.js
@@ -18,6 +18,9 @@ console.log('=== Sun Correlations Tests ===\n');
 await import('../js/state.js');
 const mod = await import('../js/sun-correlations.js');
 const { computeSunCorrelations, getSunCorrelations } = mod;
+assert('sun correlations exports stay module-scoped',
+  typeof window.computeSunCorrelations === 'undefined'
+  && typeof window.getSunCorrelations === 'undefined');
 
   // Stash and restore importedData around the run so we don't pollute the
   // host page's profile state.


### PR DESCRIPTION
## Summary
- remove the `sun-correlations` window facade for `computeSunCorrelations` and `getSunCorrelations`
- keep callers on module imports and add a regression guard that the exports remain module-scoped

## Validation
- `node tests/test-sun-correlations.js`
- `npm run typecheck:checkjs`
- `npx playwright test tests/playwright/sun-correlations-browser-coverage.spec.js`