### PR TITLE
[codex] Remove chat send button window facade

### DIFF
--- a/js/chat-images.js
+++ b/js/chat-images.js
@@ -6,10 +6,8 @@
 // toggle, and thumbnail generation. Exposes a small interface so
 // chat.js can read the queue when sending and clear it afterwards.
 //
-// The only back-reference into chat.js is `window.updateSendButtonState?.()`
-// invoked when the queue changes — same window.fn() pattern that
-// cross-module calls use elsewhere in the codebase to avoid circular
-// deps (see CLAUDE.md's module-roster note).
+// The only back-reference into chat-send.js is the configured
+// updateSendButtonState callback invoked when the queue changes.
 
 import { escapeHTML, showNotification } from './utils.js';
 import { resizeImage, isValidImageType } from './image-utils.js';
@@ -22,6 +20,15 @@ const THUMB_SIZE = 80;
 /** @type {Array<{ base64: string, mediaType: string, name: string, previewUrl: string, thumbUrl: string | null }>} */
 let _pendingAttachments = []; // { base64, mediaType, name, previewUrl, thumbUrl }
 let _hdMode = localStorage.getItem('labcharts-hd-images') === 'true';
+const chatImageDeps = {
+  updateSendButtonState: () => {},
+};
+
+export function configureChatImages(deps = {}) {
+  if (typeof deps.updateSendButtonState === 'function') {
+    chatImageDeps.updateSendButtonState = deps.updateSendButtonState;
+  }
+}
 
 /// Queue inspection for chat.js's sendChatMessage + send-button state.
 export function getPendingAttachments() { return _pendingAttachments; }
@@ -75,7 +82,7 @@ export async function addImageAttachment(file) {
     const thumbUrl = await makeThumbnail(previewUrl, width, height);
     _pendingAttachments.push({ base64, mediaType, name: file.name, previewUrl, thumbUrl });
     renderAttachmentPreview();
-    window.updateSendButtonState?.();
+    chatImageDeps.updateSendButtonState();
     // Warn about image quality issues
     const longSide = Math.max(origWidth, origHeight);
     if (longSide < 512) {
@@ -95,7 +102,7 @@ export async function addImageAttachment(file) {
 export function removeImageAttachment(index) {
   _pendingAttachments.splice(index, 1);
   renderAttachmentPreview();
-  window.updateSendButtonState?.();
+  chatImageDeps.updateSendButtonState();
 }
 
 export function renderAttachmentPreview() {

--- a/js/chat-send.js
+++ b/js/chat-send.js
@@ -10,7 +10,9 @@ import {
   isPpqPrivateModeActive, isVeniceE2EEActive, supportsWebSearch,
 } from './api.js';
 import { buildVisionContent, formatImageBlock } from './image-utils.js';
-import { clearAttachments, getPendingAttachments, hasPendingAttachments } from './chat-images.js';
+import {
+  clearAttachments, configureChatImages, getPendingAttachments, hasPendingAttachments,
+} from './chat-images.js';
 import { autoNameThread, createNewThread } from './chat-threads.js';
 import { buildLabContext, getContextSummary, injectLensChunks } from './lab-context.js';
 import { hasLens, queryLensMulti } from './lens.js';
@@ -112,8 +114,7 @@ export function createTypewriter(el, typingEl, container) {
 }
 
 // Image-attachment flow (paste/drop/picker handlers, HD-mode toggle,
-// pending-queue, thumbnail generation) lives in chat-images.js. The only
-// back-reference into this module is `window.updateSendButtonState?.()`.
+// pending-queue, thumbnail generation) lives in chat-images.js.
 export function updateSendButtonState() {
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('chat-input'));
   const sendBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('chat-send-btn'));
@@ -121,7 +122,7 @@ export function updateSendButtonState() {
   const hasContent = (input && input.value.trim()) || hasPendingAttachments();
   sendBtn.disabled = !hasContent && !_chatAbortController;
 }
-Object.assign(window, { updateSendButtonState });
+configureChatImages({ updateSendButtonState });
 
 // ═══════════════════════════════════════════════
 // SEND BUTTON STATE

--- a/tests/playwright/chat-ui-browser-coverage.spec.js
+++ b/tests/playwright/chat-ui-browser-coverage.spec.js
@@ -27,6 +27,7 @@ test('chat image attachments cover previews handlers and lightbox controls', asy
     const originalHdClass = hdBtn?.className;
     const originalAttachDisplay = attachBtn?.style.display;
     const originalInputFiles = input ? Object.getOwnPropertyDescriptor(input, 'files') : null;
+    let sendButtonRefreshes = 0;
 
     const pngBytes = Uint8Array.from(atob(
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
@@ -37,6 +38,9 @@ test('chat image attachments cover previews handlers and lightbox controls', asy
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ai-paused', 'false');
       localStorage.setItem('labcharts-hd-images', 'false');
+      chatImages.configureChatImages({
+        updateSendButtonState: () => { sendButtonRefreshes += 1; },
+      });
       chatImages.clearAttachments();
       chatImages.updateAttachButtonVisibility();
 
@@ -59,6 +63,17 @@ test('chat image attachments cover previews handlers and lightbox controls', asy
       chatImages.removeImageAttachment(0);
       outcomes.removeImageClearsPreview = chatImages.getPendingAttachments().length === 0
         && preview?.style.display === 'none';
+      outcomes.attachmentChangesRefreshSendButtonThroughConfiguredCallback = sendButtonRefreshes >= 2
+        && typeof window.updateSendButtonState === 'undefined';
+      chatImages.configureChatImages({ updateSendButtonState: undefined });
+      let invalidCallbackConfigThrew = false;
+      try {
+        chatImages.removeImageAttachment(99);
+      } catch (_) {
+        invalidCallbackConfigThrew = true;
+      }
+      outcomes.invalidCallbackConfigKeepsSafeCallback = invalidCallbackConfigThrew === false
+        && sendButtonRefreshes >= 3;
 
       await chatImages.addImageAttachment(new File(['not an image'], 'note.txt', { type: 'text/plain' }));
       outcomes.invalidImageIsRejected = chatImages.getPendingAttachments().length === 0;
@@ -118,6 +133,7 @@ test('chat image attachments cover previews handlers and lightbox controls', asy
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
       outcomes.lightboxEscapeCloses = !document.querySelector('.chat-lightbox');
     } finally {
+      chatImages.configureChatImages({ updateSendButtonState: () => {} });
       chatImages.clearAttachments();
       if (preview) {
         preview.innerHTML = originalPreview || '';

--- a/tests/test-image-utils.js
+++ b/tests/test-image-utils.js
@@ -141,6 +141,13 @@ assert('chat-images imports supportsVision', chatImagesSrc.includes('supportsVis
 assert('chat-send.js imports image-utils for send-time helpers', chatSendSrc.includes("from './image-utils.js'"));
 assert('chat-send.js imports from chat-images for pending-queue access',
   chatSendSrc.includes("from './chat-images.js'") && chatSendSrc.includes('getPendingAttachments'));
+assert('chat-send.js wires send-button refresh into chat-images without a window facade',
+  chatImagesSrc.includes('export function configureChatImages')
+    && chatImagesSrc.includes("typeof deps.updateSendButtonState === 'function'")
+    && chatImagesSrc.includes('chatImageDeps.updateSendButtonState()')
+    && chatSendSrc.includes('configureChatImages({ updateSendButtonState })')
+    && !chatSendSrc.includes('Object.assign(window, { updateSendButtonState')
+    && !chatImagesSrc.includes('window.updateSendButtonState'));
 assert('Pending attachments variable lives in chat-images.js',
   chatImagesSrc.includes('_pendingAttachments'));
 assert('chat-images.js imports isValidImageType + resizeImage',

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -236,7 +236,6 @@ interface Window {
   togglePersonalityBar?: AnyFunction;
   updateChatHeaderModel?: AnyFunction;
   updateAttachButtonVisibility: () => void;
-  updateSendButtonState?: AnyFunction;
   updateChatNudge: () => void;
   updatePrivacyStatusCard?: AnyFunction;
   refreshWebSearchToggle?: AnyFunction;


### PR DESCRIPTION
## Summary
- remove the `updateSendButtonState` browser-global facade from `chat-send.js`
- configure `chat-images.js` with the send-button refresh callback instead of calling `window.updateSendButtonState`
- remove the stale global type and add source/browser regression coverage for the configured callback path

## Validation
- `node tests/test-image-utils.js`
- `npm run typecheck:checkjs`
- `npx playwright test tests/playwright/chat-ui-browser-coverage.spec.js --grep "chat image attachments"`