### PR TITLE
Remove aiming guide window facade

### DIFF
--- a/js/light-tool-camera.js
+++ b/js/light-tool-camera.js
@@ -62,7 +62,7 @@ function _handleAimingGuideClick(event) {
   const toolKey = actionEl.dataset.tool || '';
   if (!toolKey) return;
   event.preventDefault();
-  window._dismissAimingGuide?.(toolKey);
+  dismissAimingGuide(toolKey);
 }
 
 function installAimingGuideDelegates() {
@@ -92,15 +92,20 @@ export function aimingGuideHTML(toolKey) {
   </div>`;
 }
 
-if (typeof window !== 'undefined') {
-  installAimingGuideDelegates();
-  window._dismissAimingGuide = (toolKey) => {
-    try { localStorage.setItem(`labcharts-aim-guide-${toolKey}`, 'dismissed'); } catch (_) {}
-    // Hide the currently-rendered guide without re-rendering the whole modal.
-    const el = /** @type {HTMLElement | null} */ (document.querySelector(`.tool-aiming-guide[data-tool="${toolKey}"]`));
-    if (el) el.style.display = 'none';
-  };
+export function dismissAimingGuide(toolKey) {
+  try { localStorage.setItem(`labcharts-aim-guide-${toolKey}`, 'dismissed'); } catch (_) {}
+  // Hide the currently-rendered guide without re-rendering the whole modal.
+  let el = /** @type {HTMLElement | null} */ (null);
+  for (const candidate of document.querySelectorAll('.tool-aiming-guide')) {
+    if (candidate instanceof HTMLElement && candidate.dataset.tool === String(toolKey)) {
+      el = candidate;
+      break;
+    }
+  }
+  if (el) el.style.display = 'none';
 }
+
+if (typeof window !== 'undefined') installAimingGuideDelegates();
 
 // ─── Camera AE/AWB lock helper ────────────────────────────────────────
 //

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -137,6 +137,7 @@ export {
   lockCameraForMeasurement,
   cameraLockStatusLine,
   computeRowBanding,
+  dismissAimingGuide,
   loadLuxCalibration,
   saveLuxCalibration,
 } from './light-tool-camera.js';

--- a/tests/playwright/light-tools-browser-coverage.spec.js
+++ b/tests/playwright/light-tools-browser-coverage.spec.js
@@ -34,8 +34,6 @@ test('light tools browser coverage exercises storage render and modal flows', as
       performanceNow: performance.now,
       hadAmbientLightSensor: Object.prototype.hasOwnProperty.call(window, 'AmbientLightSensor'),
       AmbientLightSensor: window.AmbientLightSensor,
-      hadDismissAimingGuide: Object.prototype.hasOwnProperty.call(window, '_dismissAimingGuide'),
-      dismissAimingGuide: window._dismissAimingGuide,
     };
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
       const key = localStorage.key(i);
@@ -162,11 +160,20 @@ test('light tools browser coverage exercises storage render and modal flows', as
       guideHost.innerHTML = lightTools.aimingGuideHTML('lux');
       document.body.append(guideHost);
       const guide = guideHost.querySelector('.tool-aiming-guide');
-      window._dismissAimingGuide?.('lux');
+      lightTools.dismissAimingGuide('lux');
       results.aimingGuideDismissHidesRenderedCard = guide?.style.display === 'none';
       results.aimingGuideDismissPersistsFlag =
         localStorage.getItem('labcharts-aim-guide-lux') === 'dismissed';
       results.aimingGuideDismissSuppressesFutureHtml = lightTools.aimingGuideHTML('lux') === '';
+      results.aimingGuideDismissGlobalRemoved = typeof window._dismissAimingGuide === 'undefined';
+      let selectorLikeDismissThrew = false;
+      try {
+        lightTools.dismissAimingGuide('lux"], .tool-aiming-guide');
+      } catch (_) {
+        selectorLikeDismissThrew = true;
+      }
+      results.aimingGuideDismissIgnoresSelectorSyntax =
+        selectorLikeDismissThrew === false && guide?.style.display === 'none';
       guideHost.remove();
       localStorage.removeItem('labcharts-aim-guide-lux');
       state.importedData.lightMeasurements = [];
@@ -376,8 +383,6 @@ test('light tools browser coverage exercises storage render and modal flows', as
       }
       if (saved.hadAmbientLightSensor) window.AmbientLightSensor = saved.AmbientLightSensor;
       else delete window.AmbientLightSensor;
-      if (saved.hadDismissAimingGuide) window._dismissAimingGuide = saved.dismissAimingGuide;
-      else delete window._dismissAimingGuide;
       try {
         Object.defineProperty(navigator, 'mediaDevices', {
           configurable: true,

--- a/tests/test-light-tool-camera-modal-delegates.js
+++ b/tests/test-light-tool-camera-modal-delegates.js
@@ -51,13 +51,16 @@ assert('light camera aiming guide dismiss uses delegated action helper',
   cameraSrc.includes('data-aiming-guide-action="dismiss"') &&
     cameraSrc.includes('function _handleAimingGuideClick') &&
     cameraSrc.includes("document.addEventListener('click', _handleAimingGuideClick)") &&
-    cameraSrc.includes('window._dismissAimingGuide?.(toolKey);'));
+    cameraSrc.includes('dismissAimingGuide(toolKey);') &&
+    !cameraSrc.includes('window._dismissAimingGuide'));
 
 for (const action of closeActions) {
   assert(`light camera close action ${action} is rendered twice`,
     modalSrc.split(`lightToolModalActionAttrs('${action}')`).length - 1 === 2);
   assert(`light camera close action ${action} is handled`,
-    modalSrc.includes(`action === '${action}'`));
+    modalSrc.includes(`closeCameraTool('${action}')`) &&
+      modalSrc.includes(`registerCameraToolCloser('${action}'`) &&
+      modalSrc.includes(`clearCameraToolCloser('${action}'`));
 }
 
 assert('light camera close delegates are installed for each modal',

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -272,7 +272,6 @@ interface Window {
   rehydrateStaleSessions?: () => Promise<{ rehydrated?: number }>;
   SUN_ENGINE_VERSION?: number;
   AmbientLightSensor?: AmbientLightSensorConstructor;
-  _dismissAimingGuide?: AnyFunction;
   addRoom?: AnyFunction;
   getSunCoords?: AnyFunction;
   hydrateSession?: AnyFunction;


### PR DESCRIPTION
## Summary
- replace the `_dismissAimingGuide` window facade with a named `dismissAimingGuide` module export
- re-export the helper through `light-tools.js` for callers/tests
- remove the stale Window type and update focused static/browser coverage

## Validation
- `node tests/test-light-tool-camera-modal-delegates.js`
- `node tests/test-light-tools.js`
- `npm run typecheck:checkjs`
- `npx playwright test tests/playwright/light-tools-browser-coverage.spec.js`