### PR TITLE
Remove category sidebar window coupling

### DIFF
--- a/js/category-customization.js
+++ b/js/category-customization.js
@@ -7,12 +7,20 @@ import { getActiveData, saveImportedData } from './data.js';
 import { showDetailModal } from './marker-detail-modal.js';
 
 let _navigate = (route, data) => window.navigate?.(route, data);
+/** @type {((data?: any) => void) | null} */
+let _buildSidebar = null;
+
+function getFallbackBuildSidebar() {
+  const runtime = typeof window !== 'undefined' ? /** @type {any} */ (window) : /** @type {any} */ (globalThis);
+  return typeof runtime.buildSidebar === 'function' ? runtime.buildSidebar : null;
+}
 
 /**
- * @param {{ navigate?: (route: string, data?: any) => void }} [deps]
+ * @param {{ navigate?: (route: string, data?: any) => void, buildSidebar?: (data?: any) => void }} [deps]
  */
 export function configureCategoryCustomization(deps = {}) {
   if (typeof deps.navigate === 'function') _navigate = deps.navigate;
+  if (typeof deps.buildSidebar === 'function') _buildSidebar = deps.buildSidebar;
 }
 
 /**
@@ -21,7 +29,8 @@ export function configureCategoryCustomization(deps = {}) {
  */
 function _refreshActiveView(fallbackRoute, opts = {}) {
   const data = getActiveData();
-  window.buildSidebar?.(data);
+  const buildSidebar = _buildSidebar || getFallbackBuildSidebar();
+  buildSidebar?.(data);
   _navigate(opts.forceRoute || state.currentView || fallbackRoute, data);
 }
 

--- a/js/nav.js
+++ b/js/nav.js
@@ -442,6 +442,10 @@ export function renderProfileDropdown() { renderProfileButton(); }
 export function toggleMobileSidebar() {
   const sidebar = document.getElementById('sidebar-nav');
   const backdrop = document.getElementById('sidebar-backdrop');
+  if (!sidebar) {
+    closeModalOverlay('sidebar-backdrop', { restoreFocus: false });
+    return;
+  }
   const isOpen = sidebar.classList.contains('mobile-open');
   if (isOpen) {
     closeMobileSidebar();
@@ -452,7 +456,7 @@ export function toggleMobileSidebar() {
 }
 
 export function closeMobileSidebar() {
-  document.getElementById('sidebar-nav').classList.remove('mobile-open');
+  document.getElementById('sidebar-nav')?.classList.remove('mobile-open');
   closeModalOverlay('sidebar-backdrop', { restoreFocus: false });
 }
 

--- a/js/views.js
+++ b/js/views.js
@@ -2,6 +2,7 @@
 // views.js — route facade and compatibility exports
 
 import { getActiveData, destroyAllCharts } from './data.js';
+import { buildSidebar } from './nav.js';
 import { setupDropZone } from './import-drop-zone.js';
 import { createRecommendationActions } from './recommendation-actions.js';
 import { createNavigate, getInitialView as getRouterInitialView } from './views-router.js';
@@ -182,7 +183,7 @@ export function navigate(category, data) {
 }
 
 configureOnboardingView({ navigate });
-configureCategoryCustomization({ navigate });
+configureCategoryCustomization({ navigate, buildSidebar });
 
 // ═══════════════════════════════════════════════
 // DASHBOARD WIDGETS

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -61,6 +61,7 @@ test('category customization covers rename icon and emoji picker browser paths',
       import('/js/state.js'),
       import(categoryUrl),
     ]);
+    const categorySrc = await fetch(categoryUrl).then(response => response.text());
     const outcomes = {};
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -90,14 +91,29 @@ test('category customization covers rename icon and emoji picker browser paths',
         },
       };
       state.currentView = 'dashboard';
-      window.buildSidebar = data => calls.push(['sidebar', !!data?.categories?.lipids]);
       window.navigate = (route, data) => calls.push(['navigate', route, !!data?.categories?.lipids]);
+      window.buildSidebar = data => calls.push(['fallbackSidebar', !!data?.categories?.lipids]);
+
+      window.showPromptDialog = async () => '  Fallback Lipids  ';
+      await category.renameCategory('lipids');
+      outcomes.renameCategoryKeepsSidebarFallback = state.importedData.categoryLabels?.lipids === 'Fallback Lipids'
+        && calls.some(call => call[0] === 'fallbackSidebar' && call[1] === true);
+
+      category.configureCategoryCustomization({
+        buildSidebar: data => calls.push(['sidebar', !!data?.categories?.lipids]),
+        navigate: window.navigate,
+      });
 
       window.showPromptDialog = async () => '  Better Lipids  ';
       await category.renameCategory('lipids');
       outcomes.renameCategoryStoresTrimmedLabel = state.importedData.categoryLabels?.lipids === 'Better Lipids';
       outcomes.renameCategoryUpdatesCustomMarkerLabel = state.importedData.customMarkers['lipids.contextCustom']?.categoryLabel === 'Better Lipids';
+      outcomes.renameCategoryRefreshesSidebarThroughConfiguredCallback = calls.some(call => call[0] === 'sidebar' && call[1] === true);
       outcomes.renameCategoryRefreshesForcedRoute = calls.some(call => call[0] === 'navigate' && call[1] === 'lipids' && call[2] === true);
+      outcomes.categoryCustomizationDoesNotUseWindowBuildSidebar = categorySrc.includes('buildSidebar?:')
+        && categorySrc.includes('getFallbackBuildSidebar')
+        && categorySrc.includes('buildSidebar?.(data)')
+        && !categorySrc.includes('window.buildSidebar');
       outcomes.renameMissingCategoryNoops = await category.renameCategory('missing-category') === undefined;
 
       window.showPromptDialog = async () => '  ApoB Better Name  ';
@@ -168,7 +184,10 @@ test('category customization covers rename icon and emoji picker browser paths',
       window.showPromptDialog = saved.prompt;
       window.buildSidebar = saved.buildSidebar;
       window.navigate = saved.navigate;
-      category.configureCategoryCustomization({ navigate: saved.navigate || (() => {}) });
+      category.configureCategoryCustomization({
+        buildSidebar: saved.buildSidebar || (() => {}),
+        navigate: saved.navigate || (() => {}),
+      });
       document.querySelector('.emoji-picker')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       document.getElementById('emoji-anchor')?.remove();

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -297,7 +297,8 @@ assert('category rename rejects whitespace-only labels after trim',
 assert('marker rename rejects whitespace-only labels after trim',
   /export async function renameMarker[^{]*\{[\s\S]{0,700}const trimmed = newName\.trim\(\);\s*if\s*\(\s*!trimmed\s*\)\s*return/.test(categoryCustomizationSrc));
 assert('category customization refreshes the active view with fresh data',
-  /function _refreshActiveView[^{]*\{[\s\S]{0,300}const data = getActiveData\(\);[\s\S]{0,200}window\.buildSidebar\?\.\(data\);[\s\S]{0,200}_navigate\(opts\.forceRoute \|\| state\.currentView \|\| fallbackRoute, data\)/.test(categoryCustomizationSrc));
+  /function _refreshActiveView[^{]*\{[\s\S]{0,300}const data = getActiveData\(\);[\s\S]{0,200}const buildSidebar = _buildSidebar \|\| getFallbackBuildSidebar\(\);[\s\S]{0,200}buildSidebar\?\.\(data\);[\s\S]{0,200}_navigate\(opts\.forceRoute \|\| state\.currentView \|\| fallbackRoute, data\)/.test(categoryCustomizationSrc) &&
+  viewsSrc.includes('configureCategoryCustomization({ navigate, buildSidebar });'));
 assert('marker rename refreshes the backing view before reopening modal',
   /export async function renameMarker[^{]*\{[\s\S]{0,900}await saveImportedData\(\);\s*_refreshActiveView\(catKey\);\s*showDetailModal\(id\)/.test(categoryCustomizationSrc));
 

--- a/tests/test-nav-delegated-actions.js
+++ b/tests/test-nav-delegated-actions.js
@@ -64,6 +64,9 @@ assert('nav delegates are scoped to sidebar/profile surfaces',
 assert('group lookup avoids selector interpolation',
   navSrc.includes('function _findGroupHeader') &&
     navSrc.includes('el.dataset.groupName === groupName'));
+assert('mobile sidebar controls tolerate missing sidebar DOM',
+  /export function toggleMobileSidebar[^{]*\{[\s\S]{0,250}if \(!sidebar\) \{[\s\S]{0,120}closeModalOverlay\('sidebar-backdrop'/.test(navSrc) &&
+    navSrc.includes("document.getElementById('sidebar-nav')?.classList.remove('mobile-open')"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- route category customization sidebar refresh through `configureCategoryCustomization`
- wire `buildSidebar` from `views.js` instead of reading `window.buildSidebar` in `category-customization.js`
- update static and browser coverage for the configured callback path

## Validation
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-audit.js`
- `npx playwright test tests/playwright/context-coverage-batch.spec.js --grep "category customization"`