### PR TITLE
Copy Agent Access bootstrap setup command

### DIFF
--- a/js/settings-agent-access-panel.js
+++ b/js/settings-agent-access-panel.js
@@ -17,6 +17,7 @@ import {
   migrateLocalAgentAccessToProfile,
   generateMessengerToken,
   generateMessengerContextKey,
+  getSyncRelay,
   revokeMessengerTokenRemote,
   pushContextToGateway,
 } from './sync.js';
@@ -32,6 +33,39 @@ function snapshotImportedData() {
 function restoreImportedDataSnapshot(snapshot) {
   if (!snapshot) return;
   try { state.importedData = JSON.parse(snapshot); } catch {}
+}
+
+function syncRelayHttpUrl() {
+  let relay = 'https://sync.getbased.health';
+  try { relay = getSyncRelay?.() || relay; } catch {}
+  return String(relay).replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://');
+}
+
+export function buildAgentAccessSetupCommand(client = 'hermes') {
+  const token = getMessengerToken();
+  const contextKey = getMessengerContextKey();
+  if (!token || !contextKey) return null;
+  const payload = {
+    version: 1,
+    token: token,
+    contextKey: contextKey,
+    gateway: syncRelayHttpUrl(),
+    client: client,
+    createdAt: new Date().toISOString(),
+  };
+  const setup = 'gbsetup_v1_' + btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  // Private bootstrap command shape: install/upgrade the stack, then connect Hermes with this setup payload.
+  return `curl -fsSL https://getbased.health/install.sh | bash -s -- connect ${client} --setup '${setup}'`;
+}
+
+async function writePrivateClipboard(text, onSuccess) {
+  await navigator.clipboard.writeText(text);
+  onSuccess?.();
+}
+
+function clearClipboardLater(timer, delay = 60000) {
+  clearTimeout(timer);
+  return setTimeout(() => { navigator.clipboard.writeText('').catch(() => {}); }, delay);
 }
 
 async function persistMigratedAgentAccessIfNeeded() {

--- a/js/settings-agent-access-panel.js
+++ b/js/settings-agent-access-panel.js
@@ -8,6 +8,7 @@ import {
   clearLegacyAgentAccessSecrets,
   disableMessengerTokenLocal,
   getAgentAccessState,
+  getSyncRelay,
   isSyncEnabled,
   isMessengerEnabled,
   getMessengerToken,
@@ -17,7 +18,6 @@ import {
   migrateLocalAgentAccessToProfile,
   generateMessengerToken,
   generateMessengerContextKey,
-  getSyncRelay,
   revokeMessengerTokenRemote,
   pushContextToGateway,
 } from './sync.js';
@@ -25,6 +25,7 @@ import { saveImportedData } from './data.js';
 
 let _tokenClipboardClearTimer = null;
 let _contextKeyClipboardClearTimer = null;
+let _setupCommandClipboardClearTimer = null;
 
 function snapshotImportedData() {
   try { return JSON.stringify(state.importedData || {}); } catch { return null; }
@@ -102,6 +103,13 @@ export function renderMessengerSection() {
       </label>
     </div>
     ${enabled && token ? `
+      <div class="settings-action-row" style="align-items:flex-start;margin-bottom:16px;padding:12px;border:1px solid var(--border-color);border-radius:12px;background:var(--bg-secondary)">
+        <div class="settings-copy">
+          <div class="settings-copy-title">Connect Hermes</div>
+          <div class="settings-copy-desc">Copy one private setup command, paste it into the terminal where Hermes runs, and it will store the key locally, register getbased-mcp, restart Hermes, and test the connection.</div>
+        </div>
+        <button class="import-btn import-btn-primary settings-mini-btn" data-sync-action="copy-agent-access-setup-command" aria-label="Copy Hermes setup command">Copy setup command</button>
+      </div>
       <div style="margin-bottom:16px">
         <div class="settings-token-head">
           <label style="font-size:12px;font-weight:600;color:var(--text-secondary)">Read-only token</label>
@@ -247,8 +255,19 @@ export function copyMessengerContextKey() {
   if (!contextKey) return;
   navigator.clipboard.writeText(contextKey).then(() => {
     showNotification('Context encryption key copied — clipboard will clear in 60s', 'success');
-    clearTimeout(_contextKeyClipboardClearTimer);
-    _contextKeyClipboardClearTimer = setTimeout(() => { navigator.clipboard.writeText('').catch(() => {}); }, 60000);
+    _contextKeyClipboardClearTimer = clearClipboardLater(_contextKeyClipboardClearTimer);
+  }).catch(() => { showNotification('Could not access clipboard', 'error'); });
+}
+
+export function copyAgentAccessSetupCommand() {
+  const command = buildAgentAccessSetupCommand('hermes');
+  if (!command) {
+    showNotification('Agent Access credentials are not ready yet — enable Agent Access first.', 'error');
+    return;
+  }
+  writePrivateClipboard(command, () => {
+    showNotification('Hermes setup command copied — paste it into the terminal where Hermes runs', 'success');
+    _setupCommandClipboardClearTimer = clearClipboardLater(_setupCommandClipboardClearTimer);
   }).catch(() => { showNotification('Could not access clipboard', 'error'); });
 }
 

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -19,6 +19,7 @@ import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { state } from './state.js';
 import {
+  copyAgentAccessSetupCommand,
   copyMessengerContextKey,
   copyMessengerToken,
   regenerateMessengerContextKey,
@@ -39,8 +40,8 @@ export { renderMessengerSection };
 // <option value="off" · <option value="7" · <option value="30" · <option value="90"
 // Extracted action contract: data-sync-action="toggle-messenger" data-sync-action="toggle-messenger-token"
 // data-sync-action="toggle-messenger-context-key" data-sync-action="copy-messenger-token"
-// data-sync-action="copy-messenger-context-key" data-sync-action="regenerate-messenger-token"
-// data-sync-action="regenerate-messenger-context-key"
+// data-sync-action="copy-messenger-context-key" data-sync-action="copy-agent-access-setup-command"
+// data-sync-action="regenerate-messenger-token" data-sync-action="regenerate-messenger-context-key"
 // Copy contract: Let AI agents query your labs and context · ~100 / 400 / 1200 extra tokens for 7 / 30 / 90 days
 
 function snapshotImportedData() {
@@ -144,6 +145,8 @@ async function handleSettingsSyncClick(event) {
     copyMessengerToken();
   } else if (action === 'copy-messenger-context-key') {
     copyMessengerContextKey();
+  } else if (action === 'copy-agent-access-setup-command') {
+    copyAgentAccessSetupCommand();
   } else if (action === 'regenerate-messenger-token') {
     void regenerateMessengerToken();
   } else if (action === 'regenerate-messenger-context-key') {

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -56,6 +56,8 @@ import {
   getAgentWearableSeriesDays,
   setAgentWearableSeriesDays,
 } from '../js/lab-context.js';
+import { setSyncRelay } from '../js/sync-environment.js';
+import { buildAgentAccessSetupCommand } from '../js/settings-agent-access-panel.js';
 
 const PROFILE_ID = 'profile-runtime';
 const PROFILE_QUERY = Symbol('profile-query');

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -642,6 +642,36 @@ describe('synced Agent Access state', () => {
     expect(localStorage.getItem(`labcharts-${PROFILE_ID}-agent-wearable-series`)).toBe('90');
   });
 
+  it('builds a one-paste Hermes setup command carrying token, context key, and gateway', () => {
+    const token = 't'.repeat(64);
+    const contextKey = 'gbctx_v1_' + 'C'.repeat(43);
+    state.importedData.agentAccess = {
+      version: 1,
+      enabled: true,
+      token,
+      contextKey,
+      updatedAt: 123,
+    };
+    setSyncRelay('wss://sync.getbased.health/app');
+    vi.stubGlobal('location', { hostname: 'localhost' });
+
+    const command = buildAgentAccessSetupCommand('hermes');
+
+    expect(command).toMatch(/^curl -fsSL https:\/\/getbased\.health\/install\.sh \| bash -s -- connect hermes --setup 'gbsetup_v1_[A-Za-z0-9_-]+'$/);
+    const setup = command.match(/--setup '([^']+)'/)?.[1];
+    expect(setup).toBeTruthy();
+    const raw = setup.slice('gbsetup_v1_'.length).replace(/-/g, '+').replace(/_/g, '/');
+    const payload = JSON.parse(atob(raw.padEnd(Math.ceil(raw.length / 4) * 4, '=')));
+    expect(payload).toMatchObject({
+      version: 1,
+      token,
+      contextKey,
+      gateway: 'https://sync.getbased.health/app',
+      client: 'hermes',
+    });
+    expect(typeof payload.createdAt).toBe('string');
+  });
+
   it('migrates legacy local Agent Access into synced profile state and delta rows', async () => {
     localStorage.setItem('labcharts-messenger-enabled', 'true');
     localStorage.setItem('labcharts-messenger-token', 'b'.repeat(64));

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -97,6 +97,15 @@ assert('Agent Access token regeneration checks saveImportedData result before pu
   /const saved = await saveImportedData\(\{ reason: 'agent-access-regenerate-token' \}\);[\s\S]*if \(saved === false\) throw new Error\('saveImportedData returned false while regenerating Agent Access token'\);[\s\S]*pushContextToGateway\(\);[\s\S]*showNotification\('Token regenerated/.test(agentSrc));
 assert('Agent Access context-key regeneration checks saveImportedData result before pushing context or success',
   /const saved = await saveImportedData\(\{ reason: 'agent-access-regenerate-context-key' \}\);[\s\S]*if \(saved === false\) throw new Error\('saveImportedData returned false while regenerating Agent Access context key'\);[\s\S]*pushContextToGateway\(\);[\s\S]*showNotification\('Context key regenerated/.test(agentSrc));
+assert('Agent Access renders one-click private bootstrap command instead of making users assemble env vars',
+  /data-sync-action="copy-agent-access-setup-command"/.test(agentSrc)
+    && /buildAgentAccessSetupCommand\('hermes'\)/.test(agentSrc)
+    && /gbsetup_v1_/.test(agentSrc)
+    && /curl -fsSL https:\/\/getbased\.health\/install\.sh \| bash -s -- connect/.test(agentSrc));
+assert('Agent Access setup command carries token and context key through setup payload builder',
+  /token:\s*token/.test(agentSrc)
+    && /contextKey:\s*contextKey/.test(agentSrc)
+    && /btoa\(JSON\.stringify\(payload\)\)/.test(agentSrc));
 assert('Delegated wearable-series select writes split Agent Access scalar and pushes context only after persisted save',
   /action === 'set-agent-wearable-series-days'[\s\S]*setAgentAccessWearableSeriesDays\(days\)[\s\S]*const saved = await saveImportedData\(\{ reason: 'agent-access-series' \}\)[\s\S]*if \(saved === false\) throw new Error\('saveImportedData returned false while saving Agent Access wearable-series preference'\)[\s\S]*pushContextToGateway/.test(src)
     && !/set-agent-wearable-series-days'[\s\S]*appWindow\.setAgentWearableSeriesDays/.test(src));

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -64,6 +64,7 @@ assert('Click delegate lets state controls reach change/input events',
   'toggle-messenger-context-key',
   'copy-messenger-token',
   'copy-messenger-context-key',
+  'copy-agent-access-setup-command',
   'regenerate-messenger-token',
   'regenerate-messenger-context-key',
   'set-agent-wearable-series-days',
@@ -101,7 +102,7 @@ assert('Agent Access renders one-click private bootstrap command instead of maki
   /data-sync-action="copy-agent-access-setup-command"/.test(agentSrc)
     && /buildAgentAccessSetupCommand\('hermes'\)/.test(agentSrc)
     && /gbsetup_v1_/.test(agentSrc)
-    && /curl -fsSL https:\/\/getbased\.health\/install\.sh \| bash -s -- connect/.test(agentSrc));
+    && agentSrc.includes('curl -fsSL https://getbased.health/install.sh | bash -s -- connect'));
 assert('Agent Access setup command carries token and context key through setup payload builder',
   /token:\s*token/.test(agentSrc)
     && /contextKey:\s*contextKey/.test(agentSrc)


### PR DESCRIPTION
Adds the Settings → Agent Access one-paste setup command and changes it to bootstrap through getbased.health/install.sh before running getbased-stack connect.\n\nVerified locally: focused sync runtime tests, delegated action source test, typecheck, quality.