### PR TITLE
Add Agent Access client picker

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -10,6 +10,15 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.27', date: '2026-06-25', title: 'Agent Access connects more agents',
+    forceShow: true,
+    items: [
+      '<b>Agent Access is no longer Hermes-only.</b> Settings now lets you choose Hermes, OpenClaw, Claude Code, Claude Desktop, Cursor, Cline, or Codex before copying the private setup command.',
+      '<b>The one-paste command follows your selected agent.</b> getbased now generates <code>getbased-stack connect &lt;client&gt; --setup …</code> for the chosen target, carrying the token and Agent Context key in the same private setup payload.',
+      '<b>Manual-config clients are clearer.</b> When a client cannot be auto-registered, the stack stores your credentials locally and points you to the exact <code>getbased-stack mcp-config &lt;client&gt;</code> snippet to paste next.',
+    ]
+  },
+  {
     version: '1.10.26', date: '2026-06-24', title: 'Agent Access follows your synced profile',
     forceShow: true,
     items: [

--- a/js/settings-agent-access-panel.js
+++ b/js/settings-agent-access-panel.js
@@ -27,6 +27,26 @@ let _tokenClipboardClearTimer = null;
 let _contextKeyClipboardClearTimer = null;
 let _setupCommandClipboardClearTimer = null;
 
+const AGENT_ACCESS_CLIENTS = [
+  { id: 'hermes', label: 'Hermes Agent', terminal: 'Hermes' },
+  { id: 'openclaw', label: 'OpenClaw', terminal: 'OpenClaw' },
+  { id: 'claude-code', label: 'Claude Code', terminal: 'Claude Code' },
+  { id: 'claude-desktop', label: 'Claude Desktop', terminal: 'Claude Desktop' },
+  { id: 'cursor', label: 'Cursor', terminal: 'Cursor' },
+  { id: 'cline', label: 'Cline', terminal: 'Cline' },
+  { id: 'codex', label: 'Codex CLI', terminal: 'Codex' },
+];
+
+function normalizeAgentAccessClient(client) {
+  const id = String(client || 'hermes').trim();
+  return AGENT_ACCESS_CLIENTS.some(c => c.id === id) ? id : 'hermes';
+}
+
+function agentAccessClientMeta(client) {
+  const id = normalizeAgentAccessClient(client);
+  return AGENT_ACCESS_CLIENTS.find(c => c.id === id) || AGENT_ACCESS_CLIENTS[0];
+}
+
 function snapshotImportedData() {
   try { return JSON.stringify(state.importedData || {}); } catch { return null; }
 }
@@ -46,17 +66,18 @@ export function buildAgentAccessSetupCommand(client = 'hermes') {
   const token = getMessengerToken();
   const contextKey = getMessengerContextKey();
   if (!token || !contextKey) return null;
+  const targetClient = normalizeAgentAccessClient(client);
   const payload = {
     version: 1,
     token: token,
     contextKey: contextKey,
     gateway: syncRelayHttpUrl(),
-    client: client,
+    client: targetClient,
     createdAt: new Date().toISOString(),
   };
   const setup = 'gbsetup_v1_' + btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-  // Private bootstrap command shape: install/upgrade the stack, then connect Hermes with this setup payload.
-  return `curl -fsSL https://getbased.health/install.sh | bash -s -- connect ${client} --setup '${setup}'`;
+  // Private bootstrap command shape: install/upgrade the stack, then connect the selected MCP client with this setup payload.
+  return `curl -fsSL https://getbased.health/install.sh | bash -s -- connect ${targetClient} --setup '${setup}'`;
 }
 
 async function writePrivateClipboard(text, onSuccess) {
@@ -105,10 +126,14 @@ export function renderMessengerSection() {
     ${enabled && token ? `
       <div class="settings-action-row" style="align-items:flex-start;margin-bottom:16px;padding:12px;border:1px solid var(--border-color);border-radius:12px;background:var(--bg-secondary)">
         <div class="settings-copy">
-          <div class="settings-copy-title">Connect Hermes</div>
-          <div class="settings-copy-desc">Copy one private setup command, paste it into the terminal where Hermes runs, and it will store the key locally, register getbased-mcp, restart Hermes, and test the connection.</div>
+          <div class="settings-copy-title">Connect an agent</div>
+          <div class="settings-copy-desc">Choose the target MCP client, copy one private setup command, and paste it into the terminal where that agent runs. The command stores the key locally, registers getbased-mcp when the client supports automation, and prints the manual config step otherwise.</div>
+          <label for="agent-access-client-select" style="display:block;font-size:12px;font-weight:600;color:var(--text-secondary);margin-top:10px;margin-bottom:4px">Target agent</label>
+          <select id="agent-access-client-select" class="settings-select" aria-label="Agent Access setup target">
+            ${AGENT_ACCESS_CLIENTS.map(client => `<option value="${client.id}"${client.id === 'hermes' ? ' selected' : ''}>${client.label}</option>`).join('')}
+          </select>
         </div>
-        <button class="import-btn import-btn-primary settings-mini-btn" data-sync-action="copy-agent-access-setup-command" aria-label="Copy Hermes setup command">Copy setup command</button>
+        <button class="import-btn import-btn-primary settings-mini-btn" data-sync-action="copy-agent-access-setup-command" aria-label="Copy selected agent setup command">Copy setup command</button>
       </div>
       <div style="margin-bottom:16px">
         <div class="settings-token-head">
@@ -259,14 +284,21 @@ export function copyMessengerContextKey() {
   }).catch(() => { showNotification('Could not access clipboard', 'error'); });
 }
 
+function selectedAgentAccessClient() {
+  const select = document.getElementById('agent-access-client-select');
+  return normalizeAgentAccessClient(select && 'value' in select ? select.value : 'hermes');
+}
+
 export function copyAgentAccessSetupCommand() {
-  const command = buildAgentAccessSetupCommand('hermes');
+  const client = selectedAgentAccessClient();
+  const meta = agentAccessClientMeta(client);
+  const command = buildAgentAccessSetupCommand(client);
   if (!command) {
     showNotification('Agent Access credentials are not ready yet — enable Agent Access first.', 'error');
     return;
   }
   writePrivateClipboard(command, () => {
-    showNotification('Hermes setup command copied — paste it into the terminal where Hermes runs', 'success');
+    showNotification(`${meta.label} setup command copied — paste it into the terminal where ${meta.terminal} runs`, 'success');
     _setupCommandClipboardClearTimer = clearClipboardLater(_setupCommandClipboardClearTimer);
   }).catch(() => { showNotification('Could not access clipboard', 'error'); });
 }

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -644,7 +644,7 @@ describe('synced Agent Access state', () => {
     expect(localStorage.getItem(`labcharts-${PROFILE_ID}-agent-wearable-series`)).toBe('90');
   });
 
-  it('builds a one-paste Hermes setup command carrying token, context key, and gateway', () => {
+  it('builds one-paste setup commands carrying token, context key, gateway, and selected client', () => {
     const token = 't'.repeat(64);
     const contextKey = 'gbctx_v1_' + 'C'.repeat(43);
     state.importedData.agentAccess = {
@@ -657,21 +657,23 @@ describe('synced Agent Access state', () => {
     setSyncRelay('wss://sync.getbased.health/app');
     vi.stubGlobal('location', { hostname: 'localhost' });
 
-    const command = buildAgentAccessSetupCommand('hermes');
+    for (const client of ['hermes', 'openclaw', 'claude-code', 'codex']) {
+      const command = buildAgentAccessSetupCommand(client);
 
-    expect(command).toMatch(/^curl -fsSL https:\/\/getbased\.health\/install\.sh \| bash -s -- connect hermes --setup 'gbsetup_v1_[A-Za-z0-9_-]+'$/);
-    const setup = command.match(/--setup '([^']+)'/)?.[1];
-    expect(setup).toBeTruthy();
-    const raw = setup.slice('gbsetup_v1_'.length).replace(/-/g, '+').replace(/_/g, '/');
-    const payload = JSON.parse(atob(raw.padEnd(Math.ceil(raw.length / 4) * 4, '=')));
-    expect(payload).toMatchObject({
-      version: 1,
-      token,
-      contextKey,
-      gateway: 'https://sync.getbased.health/app',
-      client: 'hermes',
-    });
-    expect(typeof payload.createdAt).toBe('string');
+      expect(command).toMatch(new RegExp(`^curl -fsSL https:\\/\\/getbased\\.health\\/install\\.sh \\| bash -s -- connect ${client} --setup 'gbsetup_v1_[A-Za-z0-9_-]+'$`));
+      const setup = command.match(/--setup '([^']+)'/)?.[1];
+      expect(setup).toBeTruthy();
+      const raw = setup.slice('gbsetup_v1_'.length).replace(/-/g, '+').replace(/_/g, '/');
+      const payload = JSON.parse(atob(raw.padEnd(Math.ceil(raw.length / 4) * 4, '=')));
+      expect(payload).toMatchObject({
+        version: 1,
+        token,
+        contextKey,
+        gateway: 'https://sync.getbased.health/app',
+        client,
+      });
+      expect(typeof payload.createdAt).toBe('string');
+    }
   });
 
   it('migrates legacy local Agent Access into synced profile state and delta rows', async () => {

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -98,11 +98,12 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
-assert('latest changelog documents synced Agent Access in user-readable terms',
-  /version:\s*'1\.10\.26'[\s\S]{0,1200}Agent Access now follows your profile across browsers/.test(changelogSrc)
-    && /version:\s*'1\.10\.26'[\s\S]{0,1200}Agent Context key still stays private/.test(changelogSrc)
-    && /version:\s*'1\.10\.26'[\s\S]{0,1200}Wearable-series preferences sync too/.test(changelogSrc)
-    && /version:\s*'1\.10\.26'[\s\S]{0,400}forceShow:\s*true/.test(changelogSrc));
+assert('latest changelog documents multi-agent Agent Access in user-readable terms',
+  /version:\s*'1\.10\.27'[\s\S]{0,1200}Agent Access is no longer Hermes-only/.test(changelogSrc)
+    && /version:\s*'1\.10\.27'[\s\S]{0,1200}OpenClaw/.test(changelogSrc)
+    && /version:\s*'1\.10\.27'[\s\S]{0,1200}Codex/.test(changelogSrc)
+    && /version:\s*'1\.10\.27'[\s\S]{0,1200}getbased-stack connect/.test(changelogSrc)
+    && /version:\s*'1\.10\.27'[\s\S]{0,400}forceShow:\s*true/.test(changelogSrc));
 assert('context/BP changelog documents merged AI context, KB-empty, and BP fixes in user-readable terms',
   /version:\s*'1\.10\.24'[\s\S]{0,1800}AI Context is easier to find/.test(changelogSrc)
     && /version:\s*'1\.10\.24'[\s\S]{0,1800}clickable green context chip/.test(changelogSrc)

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -100,12 +100,17 @@ assert('Agent Access context-key regeneration checks saveImportedData result bef
   /const saved = await saveImportedData\(\{ reason: 'agent-access-regenerate-context-key' \}\);[\s\S]*if \(saved === false\) throw new Error\('saveImportedData returned false while regenerating Agent Access context key'\);[\s\S]*pushContextToGateway\(\);[\s\S]*showNotification\('Context key regenerated/.test(agentSrc));
 assert('Agent Access renders one-click private bootstrap command instead of making users assemble env vars',
   /data-sync-action="copy-agent-access-setup-command"/.test(agentSrc)
-    && /buildAgentAccessSetupCommand\('hermes'\)/.test(agentSrc)
+    && /id="agent-access-client-select"/.test(agentSrc)
+    && /id: 'openclaw'/.test(agentSrc)
+    && /id: 'codex'/.test(agentSrc)
+    && /buildAgentAccessSetupCommand\(client\)/.test(agentSrc)
     && /gbsetup_v1_/.test(agentSrc)
     && agentSrc.includes('curl -fsSL https://getbased.health/install.sh | bash -s -- connect'));
-assert('Agent Access setup command carries token and context key through setup payload builder',
+assert('Agent Access setup command carries token, context key, and selected client through setup payload builder',
   /token:\s*token/.test(agentSrc)
     && /contextKey:\s*contextKey/.test(agentSrc)
+    && /client:\s*targetClient/.test(agentSrc)
+    && /normalizeAgentAccessClient\(client\)/.test(agentSrc)
     && /btoa\(JSON\.stringify\(payload\)\)/.test(agentSrc));
 assert('Delegated wearable-series select writes split Agent Access scalar and pushes context only after persisted save',
   /action === 'set-agent-wearable-series-days'[\s\S]*setAgentAccessWearableSeriesDays\(days\)[\s\S]*const saved = await saveImportedData\(\{ reason: 'agent-access-series' \}\)[\s\S]*if \(saved === false\) throw new Error\('saveImportedData returned false while saving Agent Access wearable-series preference'\)[\s\S]*pushContextToGateway/.test(src)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.26';
+self.APP_VERSION = '1.10.27';


### PR DESCRIPTION
## Summary\n- replaces Hermes-only Agent Access setup UI with a target-agent selector\n- supports Hermes, OpenClaw, Claude Code, Claude Desktop, Cursor, Cline, and Codex setup commands\n- carries the selected client in the private gbsetup payload and changelog/version bump\n\n## Verification\n- npm test -- tests/sync-runtime.test.js tests/_vitest-legacy.test.js --run\n- node tests/test-settings-sync-delegated-actions.js\n- npm run quality\n- browser smoke on local app: rendered selector included Hermes/OpenClaw/Claude Code/Claude Desktop/Cursor/Cline/Codex; Codex command decoded to client=codex with token/contextKey present\n