### PR TITLE
Polish Agent Access client picker

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -181,6 +181,78 @@
   font: inherit;
   font-size: 12px;
 }
+.settings-modal .agent-access-connect-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 14px;
+  margin-bottom: 16px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--accent) 8%, transparent), transparent 55%),
+    var(--bg-card);
+}
+.settings-modal .agent-access-client-kicker {
+  margin-top: 11px;
+  margin-bottom: 6px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.settings-modal .agent-access-client-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.settings-modal .agent-access-client-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+.settings-modal .agent-access-client-chip input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.settings-modal .agent-access-client-chip span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 27px;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-secondary) 86%, transparent);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+.settings-modal .agent-access-client-chip input:checked + span {
+  border-color: color-mix(in srgb, var(--accent) 62%, var(--border));
+  background: var(--accent-fill);
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+.settings-modal .agent-access-client-chip input:focus-visible + span {
+  outline: 2px solid color-mix(in srgb, var(--accent) 72%, transparent);
+  outline-offset: 2px;
+}
+.settings-modal .agent-access-copy-btn {
+  align-self: end;
+  min-height: 34px;
+  padding: 7px 13px;
+  font-size: 12px;
+  white-space: nowrap;
+}
 .settings-modal .settings-mini-btn {
   padding: 3px 10px;
   font-size: 11px;
@@ -586,6 +658,14 @@
   .settings-modal .settings-action-row {
     align-items: flex-start;
     gap: 12px;
+  }
+  .settings-modal .agent-access-connect-card {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+  .settings-modal .agent-access-copy-btn {
+    width: 100%;
+    justify-content: center;
   }
   .settings-modal .settings-action-row > .toggle-switch {
     margin-top: 2px;

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -10,6 +10,13 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.28', date: '2026-06-25', title: 'Agent Access setup target feels native',
+    items: [
+      '<b>Agent Access setup is cleaner.</b> The target-agent picker now uses compact in-card choices instead of a generic dropdown, so Hermes, OpenClaw, Claude, Cursor, Cline, and Codex feel like part of the setup flow.',
+      '<b>The one-paste command behavior is unchanged.</b> Pick a target, copy the private setup command, and paste it into that agent terminal.',
+    ]
+  },
+  {
     version: '1.10.27', date: '2026-06-25', title: 'Agent Access connects more agents',
     forceShow: true,
     items: [

--- a/js/settings-agent-access-panel.js
+++ b/js/settings-agent-access-panel.js
@@ -37,6 +37,15 @@ const AGENT_ACCESS_CLIENTS = [
   { id: 'codex', label: 'Codex CLI', terminal: 'Codex' },
 ];
 
+function renderAgentAccessClientChoices() {
+  return AGENT_ACCESS_CLIENTS.map(client => `
+    <label class="agent-access-client-chip">
+      <input type="radio" name="agent-access-client" value="${client.id}"${client.id === 'hermes' ? ' checked' : ''}>
+      <span>${client.label}</span>
+    </label>
+  `).join('');
+}
+
 function normalizeAgentAccessClient(client) {
   const id = String(client || 'hermes').trim();
   return AGENT_ACCESS_CLIENTS.some(c => c.id === id) ? id : 'hermes';
@@ -124,16 +133,16 @@ export function renderMessengerSection() {
       </label>
     </div>
     ${enabled && token ? `
-      <div class="settings-action-row" style="align-items:flex-start;margin-bottom:16px;padding:12px;border:1px solid var(--border-color);border-radius:12px;background:var(--bg-secondary)">
+      <div class="agent-access-connect-card">
         <div class="settings-copy">
           <div class="settings-copy-title">Connect an agent</div>
-          <div class="settings-copy-desc">Choose the target MCP client, copy one private setup command, and paste it into the terminal where that agent runs. The command stores the key locally, registers getbased-mcp when the client supports automation, and prints the manual config step otherwise.</div>
-          <label for="agent-access-client-select" style="display:block;font-size:12px;font-weight:600;color:var(--text-secondary);margin-top:10px;margin-bottom:4px">Target agent</label>
-          <select id="agent-access-client-select" class="settings-select" aria-label="Agent Access setup target">
-            ${AGENT_ACCESS_CLIENTS.map(client => `<option value="${client.id}"${client.id === 'hermes' ? ' selected' : ''}>${client.label}</option>`).join('')}
-          </select>
+          <div class="settings-copy-desc">Pick where this machine should connect, then paste one private setup command into that agent's terminal.</div>
+          <div class="agent-access-client-kicker">Setup target</div>
+          <div class="agent-access-client-grid" role="radiogroup" aria-label="Agent Access setup target">
+            ${renderAgentAccessClientChoices()}
+          </div>
         </div>
-        <button class="import-btn import-btn-primary settings-mini-btn" data-sync-action="copy-agent-access-setup-command" aria-label="Copy selected agent setup command">Copy setup command</button>
+        <button class="import-btn import-btn-primary agent-access-copy-btn" data-sync-action="copy-agent-access-setup-command" aria-label="Copy selected agent setup command">Copy setup command</button>
       </div>
       <div style="margin-bottom:16px">
         <div class="settings-token-head">
@@ -285,8 +294,8 @@ export function copyMessengerContextKey() {
 }
 
 function selectedAgentAccessClient() {
-  const select = document.getElementById('agent-access-client-select');
-  return normalizeAgentAccessClient(select && 'value' in select ? select.value : 'hermes');
+  const input = document.querySelector('input[name="agent-access-client"]:checked');
+  return normalizeAgentAccessClient(input && 'value' in input ? input.value : 'hermes');
 }
 
 export function copyAgentAccessSetupCommand() {

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -100,7 +100,8 @@ assert('Agent Access context-key regeneration checks saveImportedData result bef
   /const saved = await saveImportedData\(\{ reason: 'agent-access-regenerate-context-key' \}\);[\s\S]*if \(saved === false\) throw new Error\('saveImportedData returned false while regenerating Agent Access context key'\);[\s\S]*pushContextToGateway\(\);[\s\S]*showNotification\('Context key regenerated/.test(agentSrc));
 assert('Agent Access renders one-click private bootstrap command instead of making users assemble env vars',
   /data-sync-action="copy-agent-access-setup-command"/.test(agentSrc)
-    && /id="agent-access-client-select"/.test(agentSrc)
+    && /agent-access-client-grid/.test(agentSrc)
+    && /name="agent-access-client"/.test(agentSrc)
     && /id: 'openclaw'/.test(agentSrc)
     && /id: 'codex'/.test(agentSrc)
     && /buildAgentAccessSetupCommand\(client\)/.test(agentSrc)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.27';
+self.APP_VERSION = '1.10.28';


### PR DESCRIPTION
## Summary\n- replace the Agent Access target dropdown with compact in-card client chips\n- keep the one-paste setup command behavior unchanged\n- bump app version to 1.10.28 so cached JS/CSS updates cleanly\n\n## Verification\n- npm run test\n- npm run typecheck\n- npm run quality\n- node tests/test-changelog.js\n- node tests/test-settings-sync-delegated-actions.js\n- node /tmp/hermes-verify-agent-access-picker-visual.mjs (desktop + 390px mobile, no overflow, no old select)