### PR TITLE
[codex] Reduce shell window coupling

### DIFF
--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -46,6 +46,27 @@ function nudgeModal(overlay) {
   modal.addEventListener("animationend", () => modal.classList.remove("modal-nudge"), { once: true });
 }
 
+function reportAppEventListenerError(label, err) {
+  console.error(`[app-event-listeners] ${label} failed:`, err);
+}
+
+/**
+ * @param {string} label
+ * @param {() => unknown} action
+ */
+function runAppEventListener(label, action) {
+  try {
+    const result = action();
+    if (!result) return;
+    const maybePromise = /** @type {{ catch?: (onRejected: (err: unknown) => unknown) => unknown }} */ (result);
+    if (typeof maybePromise.catch === 'function') {
+      maybePromise.catch((err) => reportAppEventListenerError(label, err));
+    }
+  } catch (err) {
+    reportAppEventListenerError(label, err);
+  }
+}
+
 function handleModalWheel(e) {
   const overlay = e.target.closest(".modal-overlay.show, .chat-backdrop.open");
   if (!overlay) return;
@@ -126,13 +147,13 @@ function handleAppKeydown(e) {
     // Sync restore dialog — single-step "paste your 24 words" modal.
     const syncRestoreOverlay = document.getElementById("sync-restore-overlay");
     if (syncRestoreOverlay && syncRestoreOverlay.classList.contains("show")) {
-      appEventListenerDeps.closeRestoreMnemonicDialog();
+      runAppEventListener('closeRestoreMnemonicDialog', appEventListenerDeps.closeRestoreMnemonicDialog);
       return;
     }
     // Sync setup wizard — "New setup / Join existing" choice + generated seed.
     const syncSetupOverlay = document.getElementById("sync-setup-overlay");
     if (syncSetupOverlay && syncSetupOverlay.classList.contains("show")) {
-      appEventListenerDeps.closeSyncSetup();
+      runAppEventListener('closeSyncSetup', appEventListenerDeps.closeSyncSetup);
       return;
     }
     const summaryOverlay = document.getElementById("summary-modal-overlay");

--- a/js/app-event-listeners.js
+++ b/js/app-event-listeners.js
@@ -9,7 +9,24 @@ import { endTour } from './tour.js';
 let globalEventsBound = false;
 let mouseDownInsideModal = false;
 const appEventListenerDeps = {
+  closeChangelog: () => {},
+  closeChatPanel: () => {},
+  closeClientList: () => {},
+  closeEMFInterpretation: () => {},
+  closeFeedbackModal: () => {},
+  closeImportModal: () => {},
   closeLightEnvironmentAssessment: () => {},
+  closeMobileSidebar: () => {},
+  closeModal: () => {},
+  closeReportBuilder: () => {},
+  closeRestoreMnemonicDialog: () => {},
+  closeSettingsModal: () => {},
+  closeSummaryModal: () => {},
+  closeSyncSetup: () => {},
+  closeTweaksPanel: () => {},
+  navigate: (..._args) => {},
+  toggleChatPanel: () => {},
+  updateChatNudge: () => {},
 };
 
 export function configureAppEventListeners(deps = {}) {
@@ -53,19 +70,19 @@ function handleDocumentClick(e) {
     return;
   }
   // Read-only modals close on backdrop click.
-  if (e.target.id === "modal-overlay") { window.closeModal(); return; }
+  if (e.target.id === "modal-overlay") { appEventListenerDeps.closeModal(); return; }
   if (e.target.id === "light-env-assessment-overlay") { appEventListenerDeps.closeLightEnvironmentAssessment(); return; }
-  if (e.target.id === "changelog-modal-overlay") { window.closeChangelog(); return; }
-  if (e.target.id === "report-builder-overlay") { window.closeReportBuilder?.(); return; }
+  if (e.target.id === "changelog-modal-overlay") { appEventListenerDeps.closeChangelog(); return; }
+  if (e.target.id === "report-builder-overlay") { appEventListenerDeps.closeReportBuilder(); return; }
   // Auto-save modals close on backdrop click.
-  if (e.target.id === "settings-modal-overlay") { window.closeSettingsModal(); return; }
+  if (e.target.id === "settings-modal-overlay") { appEventListenerDeps.closeSettingsModal(); return; }
   // Work-in-progress modals nudge instead of closing.
   const nudgeIds = ["import-modal-overlay", "feedback-modal-overlay"];
   if (nudgeIds.includes(e.target.id)) { nudgeModal(e.target); return; }
   // Client List nudges if editing form, closes if browsing list.
   if (e.target.id === "client-list-overlay") {
     if (document.querySelector('.cl-form')) nudgeModal(e.target);
-    else window.closeClientList();
+    else appEventListenerDeps.closeClientList();
     return;
   }
   // Chat backdrop is pointer-events: none; clicks never reach it.
@@ -97,9 +114,9 @@ function handleAppKeydown(e) {
     const tourOverlay = document.getElementById("tour-overlay");
     if (tourOverlay) { endTour(); return; }
     const sidebarNav = document.getElementById("sidebar-nav");
-    if (sidebarNav && sidebarNav.classList.contains("mobile-open")) { window.closeMobileSidebar(); return; }
+    if (sidebarNav && sidebarNav.classList.contains("mobile-open")) { appEventListenerDeps.closeMobileSidebar(); return; }
     const emfInterpOverlay = document.getElementById("emf-interp-overlay");
-    if (emfInterpOverlay && emfInterpOverlay.classList.contains("show")) { window.closeEMFInterpretation(); return; }
+    if (emfInterpOverlay && emfInterpOverlay.classList.contains("show")) { appEventListenerDeps.closeEMFInterpretation(); return; }
     const confirmOverlay = document.getElementById("confirm-dialog-overlay");
     if (confirmOverlay && confirmOverlay.classList.contains("show")) {
       if (confirmOverlay.dataset.escapeOwner) return;
@@ -109,38 +126,36 @@ function handleAppKeydown(e) {
     // Sync restore dialog — single-step "paste your 24 words" modal.
     const syncRestoreOverlay = document.getElementById("sync-restore-overlay");
     if (syncRestoreOverlay && syncRestoreOverlay.classList.contains("show")) {
-      if (window.closeRestoreMnemonicDialog) window.closeRestoreMnemonicDialog();
-      else syncRestoreOverlay.classList.remove("show");
+      appEventListenerDeps.closeRestoreMnemonicDialog();
       return;
     }
     // Sync setup wizard — "New setup / Join existing" choice + generated seed.
     const syncSetupOverlay = document.getElementById("sync-setup-overlay");
     if (syncSetupOverlay && syncSetupOverlay.classList.contains("show")) {
-      if (window.closeSyncSetup) window.closeSyncSetup();
-      else syncSetupOverlay.classList.remove("show");
+      appEventListenerDeps.closeSyncSetup();
       return;
     }
     const summaryOverlay = document.getElementById("summary-modal-overlay");
-    if (summaryOverlay && summaryOverlay.classList.contains("show")) { window.closeSummaryModal?.(); return; }
+    if (summaryOverlay && summaryOverlay.classList.contains("show")) { appEventListenerDeps.closeSummaryModal(); return; }
     const chatPanel = document.getElementById("chat-panel");
-    if (chatPanel && chatPanel.classList.contains("open")) { window.closeChatPanel(); return; }
+    if (chatPanel && chatPanel.classList.contains("open")) { appEventListenerDeps.closeChatPanel(); return; }
     const importOverlay = document.getElementById("import-modal-overlay");
     if (importOverlay && importOverlay.classList.contains("show")) {
-      if (!document.getElementById("import-modal").innerHTML.trim()) window.closeImportModal();
+      if (!document.getElementById("import-modal").innerHTML.trim()) appEventListenerDeps.closeImportModal();
       return;
     }
     const changelogOverlay = document.getElementById("changelog-modal-overlay");
-    if (changelogOverlay && changelogOverlay.classList.contains("show")) { window.closeChangelog(); return; }
+    if (changelogOverlay && changelogOverlay.classList.contains("show")) { appEventListenerDeps.closeChangelog(); return; }
     const reportBuilderOverlay = document.getElementById("report-builder-overlay");
-    if (reportBuilderOverlay && reportBuilderOverlay.classList.contains("show")) { window.closeReportBuilder?.(); return; }
+    if (reportBuilderOverlay && reportBuilderOverlay.classList.contains("show")) { appEventListenerDeps.closeReportBuilder(); return; }
     const clientListOverlay = document.getElementById("client-list-overlay");
-    if (clientListOverlay && clientListOverlay.classList.contains("show")) { window.closeClientList(); return; }
+    if (clientListOverlay && clientListOverlay.classList.contains("show")) { appEventListenerDeps.closeClientList(); return; }
     const feedbackOverlay = document.getElementById("feedback-modal-overlay");
-    if (feedbackOverlay && feedbackOverlay.classList.contains("show")) { window.closeFeedbackModal(); return; }
+    if (feedbackOverlay && feedbackOverlay.classList.contains("show")) { appEventListenerDeps.closeFeedbackModal(); return; }
     const settingsOverlay = document.getElementById("settings-modal-overlay");
-    if (settingsOverlay && settingsOverlay.classList.contains("show")) { window.closeSettingsModal(); return; }
+    if (settingsOverlay && settingsOverlay.classList.contains("show")) { appEventListenerDeps.closeSettingsModal(); return; }
     const tweaksOverlay = document.getElementById("tweaks-panel-overlay");
-    if (tweaksOverlay && tweaksOverlay.classList.contains("show")) { window.closeTweaksPanel(); return; }
+    if (tweaksOverlay && tweaksOverlay.classList.contains("show")) { appEventListenerDeps.closeTweaksPanel(); return; }
     const anonymousOverlays = document.querySelectorAll('.modal-overlay.show:not([id])');
     if (anonymousOverlays.length > 0) {
       anonymousOverlays[anonymousOverlays.length - 1].remove();
@@ -149,7 +164,7 @@ function handleAppKeydown(e) {
     const lightEnvOverlay = document.getElementById("light-env-assessment-overlay");
     if (lightEnvOverlay && lightEnvOverlay.classList.contains("show")) { appEventListenerDeps.closeLightEnvironmentAssessment(); return; }
     const modalOverlay = document.getElementById("modal-overlay");
-    if (modalOverlay && modalOverlay.classList.contains("show")) { window.closeModal(); return; }
+    if (modalOverlay && modalOverlay.classList.contains("show")) { appEventListenerDeps.closeModal(); return; }
     // Generic fallback: anonymous dynamically-injected overlays.
     const dynamicOverlays = document.querySelectorAll('.modal-overlay.show');
     if (dynamicOverlays.length > 0) {
@@ -182,7 +197,7 @@ function handleAppKeydown(e) {
   if (e.ctrlKey || e.metaKey || e.altKey) return;
   const tag = document.activeElement?.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
-  if (e.key === "c" || e.key === "C") { e.preventDefault(); window.toggleChatPanel(); }
+  if (e.key === "c" || e.key === "C") { e.preventDefault(); appEventListenerDeps.toggleChatPanel(); }
   if (e.key === "/") {
     e.preventDefault();
     const sb = /** @type {HTMLInputElement | null} */ (document.getElementById("sidebar-search"));
@@ -205,7 +220,7 @@ export function registerAppRefreshCallback() {
     buildSidebar();
     // buildSidebar resets the sidebar's .active class to Dashboard by default.
     // Source the target view from state.currentView so refresh preserves place.
-    window.navigate(state.currentView || 'dashboard');
-    window.updateChatNudge();
+    appEventListenerDeps.navigate(state.currentView || 'dashboard');
+    appEventListenerDeps.updateChatNudge();
   });
 }

--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -1,0 +1,38 @@
+// @ts-check
+// app-shell-hooks.js - wire app shell actions without window lookups.
+
+import { configureAppEventListeners } from './app-event-listeners.js';
+import { closeChangelog } from './changelog.js';
+import { closeChatPanel, toggleChatPanel } from './chat-panel.js';
+import { updateChatNudge } from './chat-nudge.js';
+import { closeSummaryModal } from './chat-summaries.js';
+import { closeClientList } from './client-list.js';
+import { closeEMFInterpretation } from './emf-interpretation.js';
+import { closeReportBuilder } from './export.js';
+import { closeFeedbackModal } from './feedback.js';
+import { closeImportModal } from './pdf-import-review.js';
+import { closeModal } from './marker-detail-modal.js';
+import { closeMobileSidebar } from './nav.js';
+import { closeSettingsModal, closeTweaksPanel } from './settings.js';
+import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
+import { navigate } from './views.js';
+
+configureAppEventListeners({
+  closeChangelog,
+  closeChatPanel,
+  closeClientList,
+  closeEMFInterpretation,
+  closeFeedbackModal,
+  closeImportModal,
+  closeMobileSidebar,
+  closeModal,
+  closeReportBuilder,
+  closeRestoreMnemonicDialog,
+  closeSettingsModal,
+  closeSummaryModal,
+  closeSyncSetup,
+  closeTweaksPanel,
+  navigate,
+  toggleChatPanel,
+  updateChatNudge,
+});

--- a/js/app-ui-shell-modules.js
+++ b/js/app-ui-shell-modules.js
@@ -6,6 +6,7 @@ import './tour.js';
 import './touch-tooltip.js';
 import './client-list.js';
 import './views.js';
+import './app-shell-hooks.js';
 import './light-env-shell-hooks.js';
 import './light-channel-view-ui-hooks.js';
 import './light-page-view-ui-hooks.js';

--- a/js/data.js
+++ b/js/data.js
@@ -170,6 +170,9 @@ function _getCyclePhase(dateStr, mc) {
 // ═══════════════════════════════════════════════
 let _refreshCallback = null;
 export function registerRefreshCallback(fn) { _refreshCallback = fn; }
+export function _runRegisteredRefreshCallback() {
+  if (typeof _refreshCallback === 'function') _refreshCallback();
+}
 
 let _activeDataCache = null;
 let _activeDataCacheMeta = null;

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -370,17 +370,23 @@ export function showSyncSetupModal() {
 }
 
 export async function closeSyncSetup() {
-  closeModalOverlay('sync-setup-overlay');
-  // If sync was started during setup but user cancelled, clean up
-  if (isSyncEnabled()) {
-    _mnemonicCache = null;
-    _mnemonicRetries = 0;
-    clearTimeout(_mnemonicRetryTimer);
-    await disableSync();
+  try {
+    closeModalOverlay('sync-setup-overlay');
+    // If sync was started during setup but user cancelled, clean up
+    if (isSyncEnabled()) {
+      _mnemonicCache = null;
+      _mnemonicRetries = 0;
+      clearTimeout(_mnemonicRetryTimer);
+      await disableSync();
+    }
+  } catch (e) {
+    console.error('[sync] setup close cleanup failed:', e);
+    showNotification(`Sync cleanup failed: ${e?.message || e}`, 'error');
+  } finally {
+    const el = document.getElementById('sync-section');
+    if (el) el.innerHTML = renderSyncSection();
+    _releaseSyncToggle();
   }
-  const el = document.getElementById('sync-section');
-  if (el) el.innerHTML = renderSyncSection();
-  _releaseSyncToggle();
 }
 
 let _syncSetupInProgress = false;

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -369,7 +369,7 @@ export function showSyncSetupModal() {
   openModalOverlay(overlay, { initialFocus: '[data-sync-setup-action="setup-new"]', focusDelay: 50 });
 }
 
-async function closeSyncSetup() {
+export async function closeSyncSetup() {
   closeModalOverlay('sync-setup-overlay');
   // If sync was started during setup but user cancelled, clean up
   if (isSyncEnabled()) {
@@ -634,7 +634,7 @@ function updateRestoreMnemonicDialogState(input = /** @type {HTMLTextAreaElement
   }
 }
 
-function closeRestoreMnemonicDialog() {
+export function closeRestoreMnemonicDialog() {
   closeModalOverlay('sync-restore-overlay');
 }
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,6 +15,7 @@ if [ "$SKIP_TYPECHECK" != "1" ] && [ "$SKIP_TYPECHECK" != "true" ]; then
   npm run typecheck || exit 1
   npm run typecheck:checkjs || exit 1
 fi
+node "$DIR/tests/verify-modules.js" || exit 1
 
 # Start server if not already running. nohup + disown fully detaches it
 # from the shell — signals sent to the shell's process group won't

--- a/service-worker.js
+++ b/service-worker.js
@@ -74,6 +74,7 @@ const APP_SHELL = [
   '/js/app-data-io-modules.js',
   '/js/app-ai-interaction-modules.js',
   '/js/app-ui-shell-modules.js',
+  '/js/app-shell-hooks.js',
   '/js/app-event-listeners.js',
   '/js/startup-orchestrator.js',
   '/js/schema.js',

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -212,3 +212,51 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     expect(passed, name).toBe(true);
   }
 });
+
+test('app refresh callback uses configured shell dependencies', async ({ page }) => {
+  await openBlankPage(page);
+
+  const results = await page.evaluate(async () => {
+    const [{ state }, data, appEvents] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+      import('/js/app-event-listeners.js'),
+      import('/js/app-shell-hooks.js'),
+    ]);
+    const calls = [];
+    const saved = {
+      currentView: state.currentView,
+      importedData: state.importedData,
+    };
+    const previous = appEvents.configureAppEventListeners({
+      navigate: route => calls.push(['navigate', route]),
+      updateChatNudge: () => calls.push(['updateChatNudge']),
+    });
+
+    try {
+      document.body.innerHTML = '<nav id="sidebar-nav"></nav>';
+      state.currentView = 'labs';
+      state.importedData = { entries: [], customMarkers: {} };
+      data.invalidateActiveDataCache();
+      appEvents.registerAppRefreshCallback();
+      data._runRegisteredRefreshCallback();
+      return {
+        navigatesCurrentView: calls.some(call => call[0] === 'navigate' && call[1] === 'labs'),
+        updatesChatNudge: calls.some(call => call[0] === 'updateChatNudge'),
+        buildsSidebarAgainstSameDataModule: document.querySelectorAll('#sidebar-nav .nav-item').length > 0,
+      };
+    } finally {
+      appEvents.configureAppEventListeners(previous);
+      state.currentView = saved.currentView;
+      state.importedData = saved.importedData;
+      data.invalidateActiveDataCache();
+      document.body.innerHTML = '';
+    }
+  });
+
+  expect(results).toEqual({
+    navigatesCurrentView: true,
+    updatesChatNudge: true,
+    buildsSidebarAgainstSameDataModule: true,
+  });
+});

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -117,7 +117,7 @@ assert('chat summary modal uses shared overlay lifecycle helpers',
 
 assert('chat summary modal participates in global keyboard modal handling',
   appEventsSrc.includes('"summary-modal-overlay"') &&
-    appEventsSrc.includes('window.closeSummaryModal?.()'));
+    appEventsSrc.includes('appEventListenerDeps.closeSummaryModal()'));
 
 assert('chat image lightbox uses shared overlay lifecycle helpers',
   chatImagesSrc.includes("import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';") &&

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -29,6 +29,7 @@ const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, 'scripts', 'quality-
 const runTestsSrc = fs.readFileSync(path.join(ROOT, 'run-tests.sh'), 'utf8');
 const testWorkflowSrc = fs.readFileSync(path.join(ROOT, '.github/workflows/test.yml'), 'utf8');
 const checkJsConfig = JSON.parse(fs.readFileSync(path.join(ROOT, 'tsconfig.checkjs.json'), 'utf8'));
+const appEventListenersSrc = fs.readFileSync(path.join(ROOT, 'js', 'app-event-listeners.js'), 'utf8');
 
 assert('package.json exposes npm run quality',
   pkg.scripts?.quality === 'node scripts/quality-guardrails.mjs');
@@ -40,6 +41,24 @@ assert('quality guardrail tracks window global coupling budget',
   guardrailSrc.includes('WINDOW_REF_RE') &&
     guardrailSrc.includes('window(?:\\.|\\s*\\[)') &&
     Object.hasOwn(baseline, 'windowReferences'));
+const forbiddenAppEventWindowGlobals = [
+  'closeModal',
+  'toggleChatPanel',
+  'closeChatPanel',
+  'closeSettingsModal',
+  'closeSummaryModal',
+  'closeSyncSetup',
+  'closeRestoreMnemonicDialog',
+  'navigate',
+  'updateChatNudge',
+];
+const appEventWindowGlobalHits = forbiddenAppEventWindowGlobals.filter(name => {
+  const pattern = new RegExp(`\\bwindow\\s*(?:\\.\\s*${name}\\b|\\[\\s*['"]${name}['"]\\s*\\])`);
+  return pattern.test(appEventListenersSrc);
+});
+assert('app-event-listeners uses configured deps instead of delegated shell window globals',
+  appEventWindowGlobalHits.length === 0,
+  appEventWindowGlobalHits.length ? `found: ${appEventWindowGlobalHits.join(', ')}` : '');
 assert('quality guardrail tracks large-module budget',
   guardrailSrc.includes('LARGE_FILE_LINE_LIMIT') &&
     Object.hasOwn(baseline, 'largeJsFilesOver800Lines') &&

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -294,6 +294,7 @@ const startupAppShellCheckJsModules = [
   'js/app-feature-modules.js',
   'js/app-foundation-modules.js',
   'js/app-health-data-modules.js',
+  'js/app-shell-hooks.js',
   'js/app-ui-shell-modules.js',
   'js/main.js',
   'js/modal-lifecycle.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -68,6 +68,8 @@ assert('quality guardrail exits non-zero on failures',
 assert('full local test suite runs typecheck',
   runTestsSrc.includes('npm run typecheck || exit 1') &&
     runTestsSrc.includes('SKIP_TYPECHECK'));
+assert('full local test suite runs static module verification',
+  runTestsSrc.includes('node "$DIR/tests/verify-modules.js" || exit 1'));
 assert('CI keeps a dedicated typecheck step and skips duplicate script typecheck',
   testWorkflowSrc.includes('name: Run typecheck') &&
     testWorkflowSrc.includes('run: npm run typecheck') &&

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -105,6 +105,10 @@ assert('App event listeners use configured shell deps instead of window globals'
     && appEventsSrc.includes('appEventListenerDeps.toggleChatPanel()')
     && appEventsSrc.includes('appEventListenerDeps.closeModal()')
     && !appEventsSrc.includes('window.'));
+assert('Sync setup Escape close catches async cleanup failures',
+  appEventsSrc.includes('function runAppEventListener(label, action)')
+    && appEventsSrc.includes(".catch((err) => reportAppEventListenerError(label, err))")
+    && appEventsSrc.includes("runAppEventListener('closeSyncSetup', appEventListenerDeps.closeSyncSetup)"));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
+const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
 const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
 
@@ -95,6 +96,15 @@ assert('Click delegate only prevents default for handled actions',
     && !shellSrc.includes('event.preventDefault();\n  if (shellAction)'));
 assert('Generic role-button key shim skips delegated chat key actions',
   appEventsSrc.includes("t.hasAttribute('data-chat-key-action')"));
+assert('App shell hooks configure app-event-listeners without window lookups',
+  appShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';")
+    && appShellHooksSrc.includes('configureAppEventListeners({')
+    && !appShellHooksSrc.includes('window.'));
+assert('App event listeners use configured shell deps instead of window globals',
+  appEventsSrc.includes('appEventListenerDeps.navigate(state.currentView ||')
+    && appEventsSrc.includes('appEventListenerDeps.toggleChatPanel()')
+    && appEventsSrc.includes('appEventListenerDeps.closeModal()')
+    && !appEventsSrc.includes('window.'));
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1407,6 +1407,8 @@ await import('../js/settings.js');
   assert('syncSetupBack returns to choices', settingsSyncPanelSrc.includes('function syncSetupBack'));
   assert('closeSyncSetup disables sync if started', settingsSyncPanelSrc.includes('async function closeSyncSetup') && settingsSyncPanelSrc.includes('disableSync'));
   assert('closeSyncSetup releases _syncToggling', settingsSyncPanelSrc.includes('_syncToggling = false'));
+  assert('closeSyncSetup handles cleanup failure before releasing toggle',
+    /export async function closeSyncSetup\(\)[\s\S]{0,500}await disableSync\(\);[\s\S]{0,260}catch \(e\)[\s\S]{0,220}setup close cleanup failed[\s\S]{0,260}finally[\s\S]{0,260}_releaseSyncToggle\(\)/.test(settingsSyncPanelSrc));
   assert('Clipboard auto-clear after 60s', settingsSyncPanelSrc.includes('60000') && settingsSyncPanelSrc.includes("writeText('')"));
   assert('loadMnemonic retry timer is cancellable', settingsSyncPanelSrc.includes('_mnemonicRetryTimer') && settingsSyncPanelSrc.includes('clearTimeout(_mnemonicRetryTimer)'));
   assert('Dynamic relay status indicator', settingsSyncPanelSrc.includes('updateRelayStatus') && settingsSyncPanelSrc.includes('sync-status-dot'));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -1,6 +1,7 @@
-// verify-modules.js — Browser-based verification for modularized app
-// Run in console: fetch('tests/verify-modules.js').then(r=>r.text()).then(s=>Function(s)())
-(function() {
+// verify-modules.js — Browser/static verification for modularized app
+// Browser console: fetch('tests/verify-modules.js').then(r=>r.text()).then(s=>Function(s)())
+// Static Node check: node tests/verify-modules.js
+(async function() {
   'use strict';
   let passed = 0, failed = 0, errors = [];
 
@@ -12,6 +13,102 @@
       errors.push({ name, detail: detail || '' });
       console.error(`FAIL: ${name}${detail ? ' — ' + detail : ''}`);
     }
+  }
+
+  const serviceWorkerCacheModules = [
+    '/js/main.js',
+    '/js/app-feature-modules.js',
+    '/js/app-foundation-modules.js',
+    '/js/app-health-data-modules.js',
+    '/js/app-light-sun-modules.js',
+    '/js/app-data-io-modules.js',
+    '/js/app-ai-interaction-modules.js',
+    '/js/app-ui-shell-modules.js',
+    '/js/app-shell-hooks.js',
+    '/js/app-event-listeners.js',
+    '/js/startup-orchestrator.js',
+    '/js/startup-foundation.js',
+    '/js/startup-profile.js',
+    '/js/startup-oauth-callbacks.js',
+    '/js/startup-maintenance.js',
+    '/js/startup-ui.js',
+    '/js/emf-facade.js',
+    '/js/views.js',
+    '/js/import-file-input.js',
+    '/js/import-drop-zone.js',
+    '/js/recommendation-actions.js',
+    '/js/dashboard-recommendation-widget.js',
+    '/js/supplement-impact.js',
+    '/js/context-card-lifestyle-editors.js',
+    '/js/wearables-detail-modal.js',
+    '/js/wearables-bp-detail-chart.js',
+    '/js/wearables-formatters.js',
+    '/js/wearables-manual-form-ui.js',
+    '/js/dashboard-view-composition.js',
+    '/js/dashboard-page-view.js',
+    '/js/lens-page-shell.js',
+    '/js/chart-card-recs.js',
+    '/js/category-glyphs.js',
+    '/js/category-page-view.js',
+    '/js/category-customization.js',
+    '/js/commit-hash.js',
+    '/js/focus-card.js',
+    '/js/onboarding-view.js',
+    '/js/marker-detail-modal.js',
+    '/js/marker-detail-editing.js',
+    '/js/light-conditions-now.js',
+    '/js/light-conditions-now-hooks.js',
+    '/js/light-page-view.js',
+    '/js/light-page-view-hooks.js',
+    '/js/light-page-view-ui-hooks.js',
+    '/js/light-channel-view.js',
+    '/js/light-channel-view-hooks.js',
+    '/js/light-channel-view-ui-hooks.js',
+    '/js/sun-context-hooks.js',
+    '/js/light-sessions-view.js',
+    '/js/compare-correlations.js',
+    '/js/mobile-dashboard.js',
+    '/js/schema.js',
+  ];
+
+  function assertServiceWorkerCache(sw) {
+    assert('SW uses importScripts for version', sw.includes("importScripts('/version.js')"));
+    assert('SW CACHE_NAME uses semver template', sw.includes('`labcharts-v${self.APP_VERSION}`'));
+    assert('SW APP_SHELL includes version.js', sw.includes("'/version.js'"));
+    for (const modulePath of serviceWorkerCacheModules) {
+      assert(`Service worker caches ${modulePath.slice(1)}`, sw.includes(modulePath));
+    }
+    assert('Service worker does NOT cache app.js', !sw.includes('/app.js'));
+  }
+
+  async function runNodeVerification() {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const scriptPath = path.resolve(process.argv[1] || 'tests/verify-modules.js');
+    const root = path.resolve(path.dirname(scriptPath), '..');
+    const [indexHtml, sw, checkJsConfigText, appUiShellModules] = await Promise.all([
+      fs.readFile(path.join(root, 'index.html'), 'utf8'),
+      fs.readFile(path.join(root, 'service-worker.js'), 'utf8'),
+      fs.readFile(path.join(root, 'tsconfig.checkjs.json'), 'utf8'),
+      fs.readFile(path.join(root, 'js', 'app-ui-shell-modules.js'), 'utf8'),
+    ]);
+    const checkJsConfig = JSON.parse(checkJsConfigText);
+
+    assert('Module script tag exists', indexHtml.includes('<script type="module" src="js/main.js"></script>'));
+    assert('Old app.js script tag removed', !/<script[^>]+src=["']app\.js["']/.test(indexHtml));
+    assert('checkJs includes js/app-shell-hooks.js',
+      Array.isArray(checkJsConfig.include) && checkJsConfig.include.includes('js/app-shell-hooks.js'));
+    assert('app-ui shell module imports app-shell-hooks.js',
+      appUiShellModules.includes("./app-shell-hooks.js") || appUiShellModules.includes("'./app-shell-hooks.js'"));
+    assertServiceWorkerCache(sw);
+    printResults();
+  }
+
+  if (typeof document === 'undefined' &&
+      typeof process !== 'undefined' &&
+      process.versions?.node) {
+    await runNodeVerification();
+    return;
   }
 
   // ═══════════════════════════════════════════════
@@ -553,172 +650,7 @@
   // 20. SERVICE WORKER — cache version check
   // ═══════════════════════════════════════════════
   fetch('service-worker.js').then(r => r.text()).then(sw => {
-    assert('SW uses importScripts for version', sw.includes("importScripts('/version.js')"));
-    assert('SW CACHE_NAME uses semver template', sw.includes('`labcharts-v${self.APP_VERSION}`'));
-    assert('SW APP_SHELL includes version.js', sw.includes("'/version.js'"));
-
-    const hasMainJs = sw.includes('/js/main.js');
-    assert('Service worker caches js/main.js', hasMainJs);
-
-    const hasAppFeatureModulesJs = sw.includes('/js/app-feature-modules.js');
-    assert('Service worker caches js/app-feature-modules.js', hasAppFeatureModulesJs);
-
-    const hasAppFoundationModulesJs = sw.includes('/js/app-foundation-modules.js');
-    assert('Service worker caches js/app-foundation-modules.js', hasAppFoundationModulesJs);
-
-    const hasAppHealthDataModulesJs = sw.includes('/js/app-health-data-modules.js');
-    assert('Service worker caches js/app-health-data-modules.js', hasAppHealthDataModulesJs);
-
-    const hasAppLightSunModulesJs = sw.includes('/js/app-light-sun-modules.js');
-    assert('Service worker caches js/app-light-sun-modules.js', hasAppLightSunModulesJs);
-
-    const hasAppDataIoModulesJs = sw.includes('/js/app-data-io-modules.js');
-    assert('Service worker caches js/app-data-io-modules.js', hasAppDataIoModulesJs);
-
-    const hasAppAiInteractionModulesJs = sw.includes('/js/app-ai-interaction-modules.js');
-    assert('Service worker caches js/app-ai-interaction-modules.js', hasAppAiInteractionModulesJs);
-
-    const hasAppUiShellModulesJs = sw.includes('/js/app-ui-shell-modules.js');
-    assert('Service worker caches js/app-ui-shell-modules.js', hasAppUiShellModulesJs);
-
-    const hasAppShellHooksJs = sw.includes('/js/app-shell-hooks.js');
-    assert('Service worker caches js/app-shell-hooks.js', hasAppShellHooksJs);
-
-    const hasAppEventListenersJs = sw.includes('/js/app-event-listeners.js');
-    assert('Service worker caches js/app-event-listeners.js', hasAppEventListenersJs);
-
-    const hasStartupOrchestratorJs = sw.includes('/js/startup-orchestrator.js');
-    assert('Service worker caches js/startup-orchestrator.js', hasStartupOrchestratorJs);
-
-    const hasStartupFoundationJs = sw.includes('/js/startup-foundation.js');
-    assert('Service worker caches js/startup-foundation.js', hasStartupFoundationJs);
-
-    const hasStartupProfileJs = sw.includes('/js/startup-profile.js');
-    assert('Service worker caches js/startup-profile.js', hasStartupProfileJs);
-
-    const hasStartupOAuthCallbacksJs = sw.includes('/js/startup-oauth-callbacks.js');
-    assert('Service worker caches js/startup-oauth-callbacks.js', hasStartupOAuthCallbacksJs);
-
-    const hasStartupMaintenanceJs = sw.includes('/js/startup-maintenance.js');
-    assert('Service worker caches js/startup-maintenance.js', hasStartupMaintenanceJs);
-
-    const hasStartupUiJs = sw.includes('/js/startup-ui.js');
-    assert('Service worker caches js/startup-ui.js', hasStartupUiJs);
-
-    const hasEmfFacadeJs = sw.includes('/js/emf-facade.js');
-    assert('Service worker caches js/emf-facade.js', hasEmfFacadeJs);
-
-    const hasViewsJs = sw.includes('/js/views.js');
-    assert('Service worker caches js/views.js', hasViewsJs);
-
-    const hasImportFileInputJs = sw.includes('/js/import-file-input.js');
-    assert('Service worker caches js/import-file-input.js', hasImportFileInputJs);
-
-    const hasImportDropZoneJs = sw.includes('/js/import-drop-zone.js');
-    assert('Service worker caches js/import-drop-zone.js', hasImportDropZoneJs);
-
-    const hasRecommendationActionsJs = sw.includes('/js/recommendation-actions.js');
-    assert('Service worker caches js/recommendation-actions.js', hasRecommendationActionsJs);
-
-    const hasDashboardRecommendationWidgetJs = sw.includes('/js/dashboard-recommendation-widget.js');
-    assert('Service worker caches js/dashboard-recommendation-widget.js', hasDashboardRecommendationWidgetJs);
-
-    const hasSupplementImpactJs = sw.includes('/js/supplement-impact.js');
-    assert('Service worker caches js/supplement-impact.js', hasSupplementImpactJs);
-
-    const hasContextCardLifestyleEditorsJs = sw.includes('/js/context-card-lifestyle-editors.js');
-    assert('Service worker caches js/context-card-lifestyle-editors.js', hasContextCardLifestyleEditorsJs);
-
-    const hasWearablesDetailModalJs = sw.includes('/js/wearables-detail-modal.js');
-    assert('Service worker caches js/wearables-detail-modal.js', hasWearablesDetailModalJs);
-
-    const hasWearablesBpDetailChartJs = sw.includes('/js/wearables-bp-detail-chart.js');
-    assert('Service worker caches js/wearables-bp-detail-chart.js', hasWearablesBpDetailChartJs);
-
-    const hasWearablesFormattersJs = sw.includes('/js/wearables-formatters.js');
-    assert('Service worker caches js/wearables-formatters.js', hasWearablesFormattersJs);
-
-    const hasWearablesManualFormUiJs = sw.includes('/js/wearables-manual-form-ui.js');
-    assert('Service worker caches js/wearables-manual-form-ui.js', hasWearablesManualFormUiJs);
-
-    const hasDashboardCompositionJs = sw.includes('/js/dashboard-view-composition.js');
-    assert('Service worker caches js/dashboard-view-composition.js', hasDashboardCompositionJs);
-
-    const hasDashboardPageViewJs = sw.includes('/js/dashboard-page-view.js');
-    assert('Service worker caches js/dashboard-page-view.js', hasDashboardPageViewJs);
-
-    const hasLensPageShellJs = sw.includes('/js/lens-page-shell.js');
-    assert('Service worker caches js/lens-page-shell.js', hasLensPageShellJs);
-
-    const hasChartCardRecsJs = sw.includes('/js/chart-card-recs.js');
-    assert('Service worker caches js/chart-card-recs.js', hasChartCardRecsJs);
-
-    const hasCategoryGlyphsJs = sw.includes('/js/category-glyphs.js');
-    assert('Service worker caches js/category-glyphs.js', hasCategoryGlyphsJs);
-
-    const hasCategoryPageViewJs = sw.includes('/js/category-page-view.js');
-    assert('Service worker caches js/category-page-view.js', hasCategoryPageViewJs);
-
-    const hasCategoryCustomizationJs = sw.includes('/js/category-customization.js');
-    assert('Service worker caches js/category-customization.js', hasCategoryCustomizationJs);
-
-    const hasCommitHashJs = sw.includes('/js/commit-hash.js');
-    assert('Service worker caches js/commit-hash.js', hasCommitHashJs);
-
-    const hasFocusCardJs = sw.includes('/js/focus-card.js');
-    assert('Service worker caches js/focus-card.js', hasFocusCardJs);
-
-    const hasOnboardingViewJs = sw.includes('/js/onboarding-view.js');
-    assert('Service worker caches js/onboarding-view.js', hasOnboardingViewJs);
-
-    const hasMarkerDetailModalJs = sw.includes('/js/marker-detail-modal.js');
-    assert('Service worker caches js/marker-detail-modal.js', hasMarkerDetailModalJs);
-
-    const hasMarkerDetailEditingJs = sw.includes('/js/marker-detail-editing.js');
-    assert('Service worker caches js/marker-detail-editing.js', hasMarkerDetailEditingJs);
-
-    const hasLightConditionsNowJs = sw.includes('/js/light-conditions-now.js');
-    assert('Service worker caches js/light-conditions-now.js', hasLightConditionsNowJs);
-
-    const hasLightConditionsNowHooksJs = sw.includes('/js/light-conditions-now-hooks.js');
-    assert('Service worker caches js/light-conditions-now-hooks.js', hasLightConditionsNowHooksJs);
-
-    const hasLightPageViewJs = sw.includes('/js/light-page-view.js');
-    assert('Service worker caches js/light-page-view.js', hasLightPageViewJs);
-
-    const hasLightPageViewHooksJs = sw.includes('/js/light-page-view-hooks.js');
-    assert('Service worker caches js/light-page-view-hooks.js', hasLightPageViewHooksJs);
-
-    const hasLightPageViewUiHooksJs = sw.includes('/js/light-page-view-ui-hooks.js');
-    assert('Service worker caches js/light-page-view-ui-hooks.js', hasLightPageViewUiHooksJs);
-
-    const hasLightChannelViewJs = sw.includes('/js/light-channel-view.js');
-    assert('Service worker caches js/light-channel-view.js', hasLightChannelViewJs);
-
-    const hasLightChannelViewHooksJs = sw.includes('/js/light-channel-view-hooks.js');
-    assert('Service worker caches js/light-channel-view-hooks.js', hasLightChannelViewHooksJs);
-
-    const hasLightChannelViewUiHooksJs = sw.includes('/js/light-channel-view-ui-hooks.js');
-    assert('Service worker caches js/light-channel-view-ui-hooks.js', hasLightChannelViewUiHooksJs);
-
-    const hasSunContextHooksJs = sw.includes('/js/sun-context-hooks.js');
-    assert('Service worker caches js/sun-context-hooks.js', hasSunContextHooksJs);
-
-    const hasLightSessionsViewJs = sw.includes('/js/light-sessions-view.js');
-    assert('Service worker caches js/light-sessions-view.js', hasLightSessionsViewJs);
-
-    const hasCompareCorrelationsJs = sw.includes('/js/compare-correlations.js');
-    assert('Service worker caches js/compare-correlations.js', hasCompareCorrelationsJs);
-
-    const hasMobileDashboardJs = sw.includes('/js/mobile-dashboard.js');
-    assert('Service worker caches js/mobile-dashboard.js', hasMobileDashboardJs);
-
-    const hasSchemaJs = sw.includes('/js/schema.js');
-    assert('Service worker caches js/schema.js', hasSchemaJs);
-
-    const hasNoAppJs = !sw.includes('/app.js');
-    assert('Service worker does NOT cache app.js', hasNoAppJs);
-
+    assertServiceWorkerCache(sw);
     printResults();
   });
 
@@ -736,5 +668,16 @@
       console.log('\n✓ All tests passed!');
     }
     console.log('═'.repeat(50) + '\n');
+    if (failed > 0 &&
+        typeof process !== 'undefined' &&
+        process.versions?.node) {
+      process.exitCode = 1;
+    }
   }
-})();
+})().catch(error => {
+  console.error(error);
+  if (typeof process !== 'undefined' &&
+      process.versions?.node) {
+    process.exitCode = 1;
+  }
+});

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -130,7 +130,7 @@
     'detectTrendAlerts','getKeyTrendMarkers',
     'switchUnitSystem','getEffectiveRange','switchRangeMode',
     'updateHeaderDates','updateHeaderRangeToggle',
-    'registerRefreshCallback'
+    'registerRefreshCallback','_runRegisteredRefreshCallback'
   ];
 
   // export.js (8)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -581,6 +581,9 @@
     const hasAppUiShellModulesJs = sw.includes('/js/app-ui-shell-modules.js');
     assert('Service worker caches js/app-ui-shell-modules.js', hasAppUiShellModulesJs);
 
+    const hasAppShellHooksJs = sw.includes('/js/app-shell-hooks.js');
+    assert('Service worker caches js/app-shell-hooks.js', hasAppShellHooksJs);
+
     const hasAppEventListenersJs = sw.includes('/js/app-event-listeners.js');
     assert('Service worker caches js/app-event-listeners.js', hasAppEventListenersJs);
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -13,6 +13,7 @@
     "js/app-feature-modules.js",
     "js/app-foundation-modules.js",
     "js/app-health-data-modules.js",
+    "js/app-shell-hooks.js",
     "js/app-light-sun-modules.js",
     "js/app-ui-shell-modules.js",
     "js/biology-score-ai-context.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.30';
+self.APP_VERSION = '1.10.31';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.29';
+self.APP_VERSION = '1.10.30';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.31';
+self.APP_VERSION = '1.10.32';


### PR DESCRIPTION
## Summary

- Adds `app-shell-hooks.js` to wire app shell callbacks into `app-event-listeners` through named imports instead of `window.*` lookups.
- Converts `app-event-listeners.js` modal, keyboard, refresh, and chat shortcut behavior to configured dependencies.
- Exports sync dialog close helpers for shell wiring, precaches the new shell hook module, and bumps `version.js` for cache invalidation.
- Adds source guards so shell listeners do not regress to direct `window.*` dependencies.

## Why

The shell listener module was one of the highest-value window-coupling targets: it owned global Escape/backdrop/refresh behavior but reached back into feature modules through browser globals. This change keeps behavior centralized while making those dependencies explicit and testable.

## Validation

- `node tests/test-shell-delegated-actions.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-quality-guardrails.js`
- `node tests/test-sync.js`
- `node tests/test-changelog.js`
- `npx tsc -p tsconfig.checkjs.json --noEmit`
- `./run-tests.sh`