### PR TITLE
[codex] Reduce chat thread window coupling

### DIFF
--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -3,26 +3,9 @@
 //
 // Extracted from chat.js (v1.21.9) as the second Phase 2e refactor split.
 // Owns: thread index CRUD (localStorage layout) and thread-rail UI.
-//
-// Back-references into chat.js use `window.fn()` to avoid circular
-// deps — same pattern the rest of the codebase uses for cross-module
-// calls from modules exposed on `window`. The functions we call on
-// chat.js's window:
-//
-//   window.renderChatMessages       — redraw the message list
-//   window.updateChatHeaderTitle    — header title + personality
-//   window.updatePersonalityBar     — personality strip at top
-//   window.loadChatHistory          — hydrate state.chatHistory
-//   window.saveChatHistory          — persist state.chatHistory
-//   window.showDiscussContinuePrompt — resume an in-flight discussion
-//   window.restoreDiscussionContinuePrompt — rebuild discussion prompt from active thread/history
-//   window.renderSavedSummaries     — summaries panel refresh
-//   window.cleanupDiscussionState   — remove transient discussion UI state
-//   window.getActivePersonality     — personality lookup (chat.js)
-//   window.showPromptDialog         — shared dialog helper
 
 import { state } from './state.js';
-import { escapeHTML, showNotification, showConfirmDialog } from './utils.js';
+import { escapeHTML, showNotification, showConfirmDialog, showPromptDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import { deleteImportedArrayItems } from './data-merge.js';
 import { onChatSaved } from './sync.js';
@@ -40,6 +23,26 @@ const THREAD_ICON_EDIT = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M
 const THREAD_ICON_DELETE = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>';
 const CHAT_DELETED_PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 let chatThreadDelegatesInstalled = false;
+const noop = () => {};
+const asyncNoop = async () => {};
+const defaultPersonality = () => ({ name: 'Default', icon: '' });
+
+const chatThreadDeps = {
+  cleanupDiscussionState: noop,
+  getActivePersonality: defaultPersonality,
+  loadChatHistory: asyncNoop,
+  renderChatMessages: noop,
+  renderSavedSummaries: noop,
+  restoreDiscussionContinuePrompt: noop,
+  saveChatHistory: asyncNoop,
+  showPromptDialog,
+  updateChatHeaderTitle: noop,
+  updatePersonalityBar: noop,
+};
+
+export function configureChatThreadDeps(deps = {}) {
+  Object.assign(chatThreadDeps, deps);
+}
 
 export function getChatThreadsKey() {
   return `labcharts-${state.currentProfile}-chat-threads`;
@@ -132,7 +135,7 @@ export function ensureActiveThread() {
 export function createNewThread({ sync = true } = {}) {
   const id = generateThreadId();
   const now = new Date().toISOString();
-  const p = window.getActivePersonality?.() || { name: 'Default', icon: '' };
+  const p = chatThreadDeps.getActivePersonality() || defaultPersonality();
   const thread = {
     id,
     name: 'New Conversation',
@@ -146,15 +149,15 @@ export function createNewThread({ sync = true } = {}) {
   state.chatThreads.unshift(thread);
   pruneOldThreads();
   saveChatThreadIndex({ sync });
-  window.cleanupDiscussionState?.();
+  chatThreadDeps.cleanupDiscussionState();
   // Reset to default personality for new thread
   state.currentChatPersonality = 'default';
   localStorage.setItem(`labcharts-${state.currentProfile}-chatPersonality`, 'default');
   state.currentThreadId = id;
   state.chatHistory = [];
-  window.renderChatMessages?.();
-  window.updateChatHeaderTitle?.();
-  window.updatePersonalityBar?.();
+  chatThreadDeps.renderChatMessages();
+  chatThreadDeps.updateChatHeaderTitle();
+  chatThreadDeps.updatePersonalityBar();
   renderThreadList();
   // Focus input
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('chat-input'));
@@ -164,20 +167,20 @@ export function createNewThread({ sync = true } = {}) {
 export async function switchToThread(threadId) {
   if (threadId === state.currentThreadId) return;
   // Save current thread messages
-  await window.saveChatHistory?.();
-  window.cleanupDiscussionState?.();
+  await chatThreadDeps.saveChatHistory();
+  chatThreadDeps.cleanupDiscussionState();
   // Switch
   state.currentThreadId = threadId;
-  await window.loadChatHistory?.();
+  await chatThreadDeps.loadChatHistory();
   // Update thread personality
   const thread = state.chatThreads.find(t => t.id === threadId);
   if (thread && thread.personality) {
     state.currentChatPersonality = thread.personality;
     localStorage.setItem(`labcharts-${state.currentProfile}-chatPersonality`, thread.personality);
-    window.updateChatHeaderTitle?.();
-    window.updatePersonalityBar?.();
+    chatThreadDeps.updateChatHeaderTitle();
+    chatThreadDeps.updatePersonalityBar();
   }
-  window.restoreDiscussionContinuePrompt?.();
+  chatThreadDeps.restoreDiscussionContinuePrompt();
   renderThreadList();
 }
 
@@ -195,12 +198,12 @@ export async function deleteThread(threadId) {
       deleteImportedArrayItems(state.importedData, 'chatSummaries', s => s.threadId === threadId);
       saveImportedData();
     }
-    window.renderSavedSummaries?.();
+    chatThreadDeps.renderSavedSummaries();
     // If we deleted the active thread, switch
     if (state.currentThreadId === threadId) {
       if (state.chatThreads.length > 0) {
         state.currentThreadId = state.chatThreads[0].id;
-        window.loadChatHistory?.();
+        chatThreadDeps.loadChatHistory();
       } else {
         createNewThread();
       }
@@ -222,7 +225,7 @@ export function renameThread(threadId, newName) {
 export async function renameThreadPrompt(threadId) {
   const thread = state.chatThreads.find(t => t.id === threadId);
   if (!thread) return;
-  const name = await window.showPromptDialog('Rename conversation:', {
+  const name = await chatThreadDeps.showPromptDialog('Rename conversation:', {
     defaultValue: thread.name,
     okLabel: 'Rename',
   });

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -2,7 +2,7 @@
 // chat-window-bindings.js — chat callback wiring and legacy window exports
 
 import { setAIPaused } from './api.js';
-import { getChatThreadKey, getChatThreadsKey } from './chat-threads.js';
+import { configureChatThreadDeps, getChatThreadKey, getChatThreadsKey } from './chat-threads.js';
 import { applyInlineMarkdown, renderMarkdown } from './markdown.js';
 import { renderChatMessages } from './chat-render.js';
 import { askAIAboutCorrelations, askAIAboutMarker } from './chat-marker-prompts.js';
@@ -74,6 +74,17 @@ configureChatOnboarding({
   updateChatNudge,
 });
 configureChatPanel({ restoreDiscussionContinuePrompt });
+configureChatThreadDeps({
+  cleanupDiscussionState,
+  getActivePersonality,
+  loadChatHistory,
+  renderChatMessages,
+  renderSavedSummaries,
+  restoreDiscussionContinuePrompt,
+  saveChatHistory,
+  updateChatHeaderTitle,
+  updatePersonalityBar,
+});
 
 Object.assign(window, {
   _resumeAI,

--- a/tests/playwright/chat-threads-dom.spec.js
+++ b/tests/playwright/chat-threads-dom.spec.js
@@ -11,6 +11,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
   );
 
   const results = await page.evaluate(async () => {
+    const chatThreads = await import('/js/chat-threads.js');
     const { state } = await import('/js/state.js');
     const profileId = state.currentProfile;
     const railKey = `labcharts-${profileId}-chatRailOpen`;
@@ -18,11 +19,16 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
     const originalThreads = state.chatThreads.slice();
     const originalThreadId = state.currentThreadId;
     const originalRailState = localStorage.getItem(railKey);
-    const savedFns = {
+    const savedThreadDeps = {
       saveChatHistory: window.saveChatHistory,
       loadChatHistory: window.loadChatHistory,
       cleanupDiscussionState: window.cleanupDiscussionState,
       restoreDiscussionContinuePrompt: window.restoreDiscussionContinuePrompt,
+      renderChatMessages: window.renderChatMessages,
+      renderSavedSummaries: window.renderSavedSummaries,
+      updateChatHeaderTitle: window.updateChatHeaderTitle,
+      updatePersonalityBar: window.updatePersonalityBar,
+      getActivePersonality: window.getActivePersonality,
       showPromptDialog: window.showPromptDialog,
     };
     const waitFor = async (fn, timeoutMs = 500) => {
@@ -75,15 +81,22 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
       outcomes.deleteButtonUsesDelegatedAction = deleteBtn?.getAttribute('data-chat-thread-action') === 'delete'
         && !deleteBtn.hasAttribute('onclick');
 
-      window.saveChatHistory = async () => {};
-      window.loadChatHistory = async () => {};
-      window.cleanupDiscussionState = () => {};
-      window.restoreDiscussionContinuePrompt = () => {};
+      chatThreads.configureChatThreadDeps({
+        saveChatHistory: async () => {},
+        loadChatHistory: async () => {},
+        cleanupDiscussionState: () => {},
+        restoreDiscussionContinuePrompt: () => {},
+        renderChatMessages: () => {},
+        renderSavedSummaries: () => {},
+        updateChatHeaderTitle: () => {},
+        updatePersonalityBar: () => {},
+        getActivePersonality: savedThreadDeps.getActivePersonality || (() => ({ name: 'Default', icon: '' })),
+        showPromptDialog: async () => 'Renamed Thread',
+      });
       state.currentThreadId = 't_b';
       threadItem?.click();
       outcomes.threadItemClickSwitchesThread = await waitFor(() => state.currentThreadId === 't_a');
 
-      window.showPromptDialog = async () => 'Renamed Thread';
       document.querySelector('.chat-thread-item[data-thread-id="t_a"] .chat-thread-item-action')?.click();
       outcomes.renameButtonRenamesThread = await waitFor(() =>
         state.chatThreads.find(thread => thread.id === 't_a')?.name === 'Renamed Thread'
@@ -127,7 +140,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
     } finally {
       state.chatThreads = originalThreads;
       state.currentThreadId = originalThreadId;
-      Object.assign(window, savedFns);
+      chatThreads.configureChatThreadDeps(savedThreadDeps);
       if (originalRailState == null) localStorage.removeItem(railKey);
       else localStorage.setItem(railKey, originalRailState);
       if (originalThreads.length > 0) window.saveChatThreadIndex();

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -292,8 +292,24 @@ assert('loadProfile rerenders chat rail after profile switch', profileSrc.includ
 // ═══════════════════════════════════════════════
 console.log('16. Thread Search Extraction (source inspection)');
 const chatThreadsSrc = read('js/chat-threads.js');
+const chatWindowBindingsSrc = read('js/chat-window-bindings.js');
 const chatThreadSearchSrc = read('js/chat-thread-search.js');
 const inlineHandlerRe = /\bon(?:click|change|input|search|keydown|keyup|submit)=/;
+const windowGlobalLookupRe = /\bwindow\s*(?:\.|\[\s*['"])/;
+assert('chat-threads exposes dependency configuration',
+  chatThreadsSrc.includes('export function configureChatThreadDeps')
+    && chatThreadsSrc.includes('const chatThreadDeps = {')
+    && chatThreadsSrc.includes('showPromptDialog,'));
+assert('chat-window-bindings wires chat-thread dependencies',
+  chatWindowBindingsSrc.includes('configureChatThreadDeps({')
+    && chatWindowBindingsSrc.includes('renderChatMessages,')
+    && chatWindowBindingsSrc.includes('saveChatHistory,')
+    && chatWindowBindingsSrc.includes('loadChatHistory,')
+    && chatWindowBindingsSrc.includes('getActivePersonality,')
+    && chatWindowBindingsSrc.includes('cleanupDiscussionState,'));
+assert('chat-threads uses configured deps instead of direct window callback lookups',
+  !windowGlobalLookupRe.test(chatThreadsSrc),
+  (chatThreadsSrc.match(windowGlobalLookupRe) || [''])[0]);
 assert('chat-threads imports search module',
   chatThreadsSrc.includes("from './chat-thread-search.js'"));
 assert('chat-threads configures search callbacks',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.32';
+self.APP_VERSION = '1.10.33';


### PR DESCRIPTION
## Summary
- Add explicit dependency wiring for chat thread callbacks instead of direct `window.*` callback lookups.
- Wire chat thread dependencies from `chat-window-bindings.js` while preserving legacy window exports.
- Update chat thread source/DOM tests and bump `version.js` for cache invalidation.

## Validation
- `node tests/test-chat-threads.js`
- `npx tsc -p tsconfig.checkjs.json --noEmit`
- `npx playwright test tests/playwright/chat-threads-dom.spec.js`
- `npx vitest run tests/chat-runtime.test.js`
- `npx playwright test tests/playwright/shell-actions-browser-coverage.spec.js tests/playwright/chat-history-diagnose-browser-coverage.spec.js`
- `npm run quality`
- `./run-tests.sh`