### PR TITLE
[codex] Reduce chat onboarding window coupling

### DIFF
--- a/js/app-ui-shell-modules.js
+++ b/js/app-ui-shell-modules.js
@@ -6,6 +6,7 @@ import './tour.js';
 import './touch-tooltip.js';
 import './client-list.js';
 import './views.js';
+import './chat-onboarding-host-bindings.js';
 import './app-shell-hooks.js';
 import './light-env-shell-hooks.js';
 import './light-channel-view-ui-hooks.js';

--- a/js/chat-onboarding-host-bindings.js
+++ b/js/chat-onboarding-host-bindings.js
@@ -1,0 +1,29 @@
+// @ts-check
+// chat-onboarding-host-bindings.js - host app dependencies for chat onboarding
+
+import { startOpenRouterOAuth } from './api.js';
+import { configureChatOnboarding } from './chat-onboarding.js';
+import { recordChange } from './context-cards.js';
+import { renderMenstrualCycleSection } from './cycle.js';
+import { getActiveData } from './data.js';
+import { renderProfileButton } from './nav.js';
+import { openChatProviderQuiz } from './onboarding-view.js';
+import { setProfileHeight } from './profile.js';
+import { openSettingsModal } from './settings.js';
+import { switchAIProviderBridge } from './settings-provider-bridge.js';
+import { renderSupplementsSection } from './supplements.js';
+import { navigate } from './views.js';
+
+configureChatOnboarding({
+  getActiveData,
+  navigate,
+  openChatProviderQuiz,
+  openSettingsModal,
+  recordChange,
+  renderMenstrualCycleSection,
+  renderProfileButton,
+  renderSupplementsSection,
+  setProfileHeight,
+  startOpenRouterOAuth,
+  switchAIProvider: switchAIProviderBridge,
+});

--- a/js/chat-onboarding.js
+++ b/js/chat-onboarding.js
@@ -18,16 +18,38 @@ import { hasAIProvider, isAIPaused } from './api.js';
 
 /** @type {{
  *   closeChatPanel: () => void,
+ *   getActiveData: () => any,
+ *   navigate: (route: string, data?: any) => void,
+ *   openChatProviderQuiz: null | (() => void),
+ *   openSettingsModal: (tab?: string) => void,
+ *   recordChange: (field: string) => void,
  *   renderChatMessages: () => void,
+ *   renderMenstrualCycleSection: null | ((data: any, opts?: any) => string),
+ *   renderProfileButton: () => void,
+ *   renderSupplementsSection: null | (() => string),
  *   sendChatMessage: () => void,
  *   setChatNudge: (mode?: string) => void,
+ *   setProfileHeight: null | ((profileId: string, height: number, unit: string) => void),
+ *   startOpenRouterOAuth: () => void,
+ *   switchAIProvider: (provider: string) => void,
  *   updateChatNudge: () => void,
  * }} */
 const onboardingCallbacks = {
   closeChatPanel: () => {},
+  getActiveData: () => state.importedData,
+  navigate: () => {},
+  openChatProviderQuiz: null,
+  openSettingsModal: () => {},
+  recordChange: () => {},
   renderChatMessages: () => {},
+  renderMenstrualCycleSection: null,
+  renderProfileButton: () => {},
+  renderSupplementsSection: null,
   sendChatMessage: () => {},
   setChatNudge: () => {},
+  setProfileHeight: null,
+  startOpenRouterOAuth: () => {},
+  switchAIProvider: () => {},
   updateChatNudge: () => {},
 };
 
@@ -50,15 +72,15 @@ function isChatOnboardingActionScope(actionEl) {
 function openAiSettings() {
   closeChatPanel();
   setTimeout(() => {
-    if (window.openSettingsModal) window.openSettingsModal('ai');
+    openSettingsModal('ai');
   }, 300);
 }
 
 function openAiProviderSettings(provider) {
   closeChatPanel();
   setTimeout(() => {
-    if (window.openSettingsModal) window.openSettingsModal('ai');
-    if (CHAT_ONBOARDING_SETTING_PROVIDERS.has(provider) && window.switchAIProvider) window.switchAIProvider(provider);
+    openSettingsModal('ai');
+    if (CHAT_ONBOARDING_SETTING_PROVIDERS.has(provider)) switchAIProvider(provider);
   }, 300);
 }
 
@@ -73,8 +95,7 @@ function handleChatOnboardingClick(event) {
   if (action === 'back-to-provider-quiz') {
     backToProviderQuiz();
   } else if (action === 'start-openrouter-oauth') {
-    const appWindow = /** @type {Window & typeof globalThis & { startOpenRouterOAuth?: () => void }} */ (window);
-    appWindow.startOpenRouterOAuth?.();
+    startOpenRouterOAuth();
   } else if (action === 'open-ai-settings') {
     openAiSettings();
   } else if (action === 'open-provider-settings') {
@@ -121,8 +142,42 @@ function closeChatPanel() {
   onboardingCallbacks.closeChatPanel?.();
 }
 
+function getActiveData() {
+  return onboardingCallbacks.getActiveData?.() || state.importedData;
+}
+
+function navigate(route, data) {
+  onboardingCallbacks.navigate?.(route, data);
+}
+
+function openChatProviderQuiz() {
+  if (typeof onboardingCallbacks.openChatProviderQuiz !== 'function') return false;
+  onboardingCallbacks.openChatProviderQuiz();
+  return true;
+}
+
+function openSettingsModal(tab) {
+  onboardingCallbacks.openSettingsModal?.(tab);
+}
+
+function recordChange(field) {
+  onboardingCallbacks.recordChange?.(field);
+}
+
 function renderChatMessages() {
   onboardingCallbacks.renderChatMessages?.();
+}
+
+function renderMenstrualCycleSection(data, opts) {
+  return onboardingCallbacks.renderMenstrualCycleSection?.(data, opts) || '';
+}
+
+function renderProfileButton() {
+  onboardingCallbacks.renderProfileButton?.();
+}
+
+function renderSupplementsSection() {
+  return onboardingCallbacks.renderSupplementsSection?.() || '';
 }
 
 function sendChatMessage() {
@@ -131,6 +186,18 @@ function sendChatMessage() {
 
 function setChatNudge(mode) {
   onboardingCallbacks.setChatNudge?.(mode);
+}
+
+function setProfileHeight(profileId, height, unit) {
+  onboardingCallbacks.setProfileHeight?.(profileId, height, unit);
+}
+
+function startOpenRouterOAuth() {
+  onboardingCallbacks.startOpenRouterOAuth?.();
+}
+
+function switchAIProvider(provider) {
+  onboardingCallbacks.switchAIProvider?.(provider);
 }
 
 function updateChatNudge() {
@@ -148,8 +215,7 @@ export function useChatPrompt(text) {
 
 export function requestOnboardingLabImportProvider() {
   showNotification('Lab PDFs and photos need an AI provider first. Connect AI, then import the file.', 'info');
-  if (window.openChatProviderQuiz) {
-    window.openChatProviderQuiz();
+  if (openChatProviderQuiz()) {
     return;
   }
   sessionStorage.setItem(`chat-onboard-provider-requested-${state.currentProfile}`, '1');
@@ -160,7 +226,7 @@ export function startOnboardingLabImport() {
   if (isAIPaused()) {
     showNotification('AI features are paused. Re-enable AI to import lab PDFs or report photos.', 'info');
     closeChatPanel();
-    window.openSettingsModal?.('ai');
+    openSettingsModal('ai');
     return;
   }
   if (!hasAIProvider()) {
@@ -267,9 +333,9 @@ export function saveChatProfile(advance) {
   // Save height
   const heightRaw = parseFloat(textControlById('chat-onboard-height')?.value || '');
   const heightUnit = selectById('chat-onboard-height-unit')?.value || 'cm';
-  if (heightRaw && window.setProfileHeight) {
+  if (heightRaw) {
     const heightCm = heightUnit === 'in' ? Math.round(heightRaw * 2.54 * 10) / 10 : heightRaw;
-    window.setProfileHeight(state.currentProfile, heightCm, heightUnit);
+    setProfileHeight(state.currentProfile, heightCm, heightUnit);
   }
   // Save weight as first biometric entry
   const weightRaw = parseFloat(textControlById('chat-onboard-weight')?.value || '');
@@ -284,7 +350,7 @@ export function saveChatProfile(advance) {
     saveImportedData();
   }
   saveChatLocation();
-  window.renderProfileButton?.();
+  renderProfileButton();
   _updateOnboardNextBtn();
   if (advance && name && state.profileSex) {
     // Profile complete — advance to next stage
@@ -311,7 +377,7 @@ export function saveCycleStatus(status) {
   if (!state.importedData.menstrualCycle) state.importedData.menstrualCycle = {};
   state.importedData.menstrualCycle.cycleStatus = status;
   if (!state.importedData.menstrualCycle.periods) state.importedData.menstrualCycle.periods = [];
-  window.recordChange('menstrualCycle');
+  recordChange('menstrualCycle');
   saveImportedData();
   const labels = { perimenopause: 'Perimenopause noted', postmenopause: 'Noted — postmenopause', pregnant: 'Noted — pregnant', breastfeeding: 'Noted — breastfeeding', absent: 'Noted — no active cycle' };
   showNotification(labels[status] || 'Cycle status saved', 'success');
@@ -371,7 +437,7 @@ export function saveChatPeriod() {
   mc.cycleStatus = 'regular';
   if (!mc.cycleLength) mc.cycleLength = 28;
   mc.periodLength = periodDays;
-  window.recordChange('menstrualCycle');
+  recordChange('menstrualCycle');
   saveImportedData();
   showNotification('Cycle tracking set up!', 'success');
   _refreshDashboardCycle();
@@ -407,7 +473,7 @@ export function removeChatSupplement(idx) {
 
 function _refreshDashboardSupps() {
   const el = document.querySelector('.supp-timeline-section');
-  if (el && window.renderSupplementsSection) el.outerHTML = window.renderSupplementsSection();
+  if (el && onboardingCallbacks.renderSupplementsSection) el.outerHTML = renderSupplementsSection();
 }
 
 function _refreshDashboardCycle() {
@@ -415,16 +481,16 @@ function _refreshDashboardCycle() {
   const details = /** @type {HTMLDetailsElement | null} */ (document.querySelector('.welcome-context-details'));
   if (details && !details.open) { details.setAttribute('open', ''); sessionStorage.setItem('welcome-details-open', '1'); }
   const el = document.querySelector('.cycle-section');
-  if (el && window.renderMenstrualCycleSection) {
+  if (el && onboardingCallbacks.renderMenstrualCycleSection) {
     const inDashboardCycleWidget = !!el.closest('.dashboard-widget[data-widget-id="cycle"]');
-    el.outerHTML = window.renderMenstrualCycleSection(
-      window.getActiveData(),
+    el.outerHTML = renderMenstrualCycleSection(
+      getActiveData(),
       inDashboardCycleWidget ? { variant: 'dashboard', showHeader: false } : {}
     );
-  } else if (!el && state.profileSex === 'female' && window.renderMenstrualCycleSection) {
+  } else if (!el && state.profileSex === 'female' && onboardingCallbacks.renderMenstrualCycleSection) {
     // Cycle section doesn't exist yet — insert it after context cards
     const supps = document.querySelector('.supp-timeline-section');
-    if (supps) supps.insertAdjacentHTML('beforebegin', window.renderMenstrualCycleSection(window.getActiveData()));
+    if (supps) supps.insertAdjacentHTML('beforebegin', renderMenstrualCycleSection(getActiveData()));
   }
 }
 
@@ -546,7 +612,7 @@ export function skipOnboardingExtras() {
   // Ensure the lifestyle details section is open so cycle/supplements are visible
   sessionStorage.setItem('welcome-details-open', '1');
   // Re-render dashboard to reflect cycle + supplement changes from onboarding
-  if (window.navigate) window.navigate('dashboard');
+  navigate('dashboard');
   renderChatMessages();
 }
 

--- a/tests/playwright/chat-onboarding-browser-coverage.spec.js
+++ b/tests/playwright/chat-onboarding-browser-coverage.spec.js
@@ -31,12 +31,6 @@ test('chat onboarding provider import and profile helpers cover browser paths', 
       importedData: state.importedData,
       chatHistory: state.chatHistory,
     };
-    const savedWindow = {
-      openChatProviderQuiz: window.openChatProviderQuiz,
-      openSettingsModal: window.openSettingsModal,
-      setProfileHeight: window.setProfileHeight,
-      renderProfileButton: window.renderProfileButton,
-    };
     const host = document.createElement('div');
     const calls = [];
     const profileId = `chat_onboard_${Date.now()}_${Math.random().toString(36).slice(2)}`;
@@ -106,14 +100,15 @@ test('chat onboarding provider import and profile helpers cover browser paths', 
 
       onboarding.configureChatOnboarding({
         closeChatPanel: () => { calls.push('close'); },
+        openChatProviderQuiz: () => { calls.push('provider-quiz'); },
+        openSettingsModal: tab => { calls.push(`settings:${tab}`); },
         renderChatMessages: () => { calls.push('render'); },
+        renderProfileButton: () => { calls.push('render-profile-button'); },
         sendChatMessage: () => { calls.push('send'); },
         setChatNudge: mode => { calls.push(`nudge:${mode || ''}`); },
+        setProfileHeight: (id, height, unit) => { calls.push(`height:${id}:${height}:${unit}`); },
         updateChatNudge: () => { calls.push('update-nudge'); },
       });
-      window.openSettingsModal = tab => { calls.push(`settings:${tab}`); };
-      window.setProfileHeight = (id, height, unit) => { calls.push(`height:${id}:${height}:${unit}`); };
-      window.renderProfileButton = () => { calls.push('render-profile-button'); };
       pdfInput?.addEventListener('click', onPdfClick);
 
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
@@ -127,11 +122,10 @@ test('chat onboarding provider import and profile helpers cover browser paths', 
       outcomes.promptSendsWithProvider = calls.includes('send')
         && chatInput?.value === 'Explain my ferritin';
 
-      window.openChatProviderQuiz = () => { calls.push('provider-quiz'); };
       onboarding.requestOnboardingLabImportProvider();
       outcomes.providerRequestUsesQuizWhenAvailable = calls.includes('provider-quiz');
 
-      window.openChatProviderQuiz = undefined;
+      onboarding.configureChatOnboarding({ openChatProviderQuiz: null });
       onboarding.requestOnboardingLabImportProvider();
       outcomes.providerRequestFallsBackToSessionFlag =
         sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === '1'
@@ -215,14 +209,17 @@ test('chat onboarding provider import and profile helpers cover browser paths', 
       state.chatHistory = savedState.chatHistory;
       restoreStorage(localStorage, localSnapshot);
       restoreStorage(sessionStorage, sessionSnapshot);
-      Object.assign(window, savedWindow);
       if (chatInput && savedChatInputValue != null) chatInput.value = savedChatInputValue;
       pdfInput?.removeEventListener('click', onPdfClick);
       onboarding.configureChatOnboarding({
         closeChatPanel: () => {},
+        openChatProviderQuiz: null,
+        openSettingsModal: () => {},
         renderChatMessages: () => {},
+        renderProfileButton: () => {},
         sendChatMessage: () => {},
         setChatNudge: () => {},
+        setProfileHeight: null,
         updateChatNudge: () => {},
       });
       host.remove();
@@ -346,8 +343,9 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
   await page.waitForSelector('#chat-input');
 
   const results = await page.evaluate(async ({ onboardingUrl }) => {
-    const [onboarding, { state }, profile] = await Promise.all([
+    const [onboarding, appOnboarding, { state }, profile] = await Promise.all([
       import(onboardingUrl),
+      import('/js/chat-onboarding.js'),
       import('/js/state.js'),
       import('/js/profile.js'),
     ]);
@@ -368,16 +366,6 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
       importedData: state.importedData,
       chatHistory: state.chatHistory,
     };
-    const savedWindow = {
-      recordChange: window.recordChange,
-      renderMenstrualCycleSection: window.renderMenstrualCycleSection,
-      getActiveData: window.getActiveData,
-      renderSupplementsSection: window.renderSupplementsSection,
-      navigate: window.navigate,
-      openSettingsModal: window.openSettingsModal,
-      switchAIProvider: window.switchAIProvider,
-      startOpenRouterOAuth: window.startOpenRouterOAuth,
-    };
     const host = document.createElement('div');
     const calls = [];
     const profileId = `chat_onboard_cycle_${Date.now()}_${Math.random().toString(36).slice(2)}`;
@@ -390,6 +378,46 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
       }
     };
     const waitForProviderTimer = () => new Promise(resolve => setTimeout(resolve, 350));
+    const configureOnboardingForTest = target => {
+      target.configureChatOnboarding({
+        closeChatPanel: () => { calls.push('close'); },
+        getActiveData: () => state.importedData,
+        navigate: view => { calls.push(`navigate:${view}`); },
+        openSettingsModal: tab => { calls.push(`settings:${tab}`); },
+        recordChange: key => { calls.push(`record:${key}`); },
+        renderChatMessages: () => { calls.push('render'); },
+        renderMenstrualCycleSection: (_data, options = {}) => {
+          calls.push(options.variant === 'dashboard' ? 'render-cycle-dashboard' : 'render-cycle');
+          return '<div class="cycle-section">cycle refreshed</div>';
+        },
+        renderSupplementsSection: () => {
+          calls.push('render-supps');
+          return '<div class="supp-timeline-section">supps refreshed</div>';
+        },
+        sendChatMessage: () => { calls.push('send'); },
+        setChatNudge: mode => { calls.push(`nudge:${mode || ''}`); },
+        startOpenRouterOAuth: () => { calls.push('oauth'); },
+        switchAIProvider: provider => { calls.push(`provider:${provider}`); },
+        updateChatNudge: () => { calls.push('update-nudge'); },
+      });
+    };
+    const resetOnboardingForTest = target => {
+      target.configureChatOnboarding({
+        closeChatPanel: () => {},
+        getActiveData: () => state.importedData,
+        navigate: () => {},
+        openSettingsModal: () => {},
+        recordChange: () => {},
+        renderChatMessages: () => {},
+        renderMenstrualCycleSection: null,
+        renderSupplementsSection: null,
+        sendChatMessage: () => {},
+        setChatNudge: () => {},
+        startOpenRouterOAuth: () => {},
+        switchAIProvider: () => {},
+        updateChatNudge: () => {},
+      });
+    };
 
     try {
       host.innerHTML = `
@@ -436,27 +464,8 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
       state.chatHistory = [];
       localStorage.setItem('labcharts-profiles', JSON.stringify(state.profiles));
 
-      onboarding.configureChatOnboarding({
-        closeChatPanel: () => { calls.push('close'); },
-        renderChatMessages: () => { calls.push('render'); },
-        sendChatMessage: () => { calls.push('send'); },
-        setChatNudge: mode => { calls.push(`nudge:${mode || ''}`); },
-        updateChatNudge: () => { calls.push('update-nudge'); },
-      });
-      window.recordChange = key => { calls.push(`record:${key}`); };
-      window.renderMenstrualCycleSection = (_data, options = {}) => {
-        calls.push(options.variant === 'dashboard' ? 'render-cycle-dashboard' : 'render-cycle');
-        return '<div class="cycle-section">cycle refreshed</div>';
-      };
-      window.getActiveData = () => state.importedData;
-      window.renderSupplementsSection = () => {
-        calls.push('render-supps');
-        return '<div class="supp-timeline-section">supps refreshed</div>';
-      };
-      window.navigate = view => { calls.push(`navigate:${view}`); };
-      window.openSettingsModal = tab => { calls.push(`settings:${tab}`); };
-      window.switchAIProvider = provider => { calls.push(`provider:${provider}`); };
-      window.startOpenRouterOAuth = () => { calls.push('oauth'); };
+      configureOnboardingForTest(onboarding);
+      configureOnboardingForTest(appOnboarding);
 
       const crumbs = onboarding._renderOnboardCrumbs(3, 5);
       const quizRoot = onboarding._renderProviderQuiz(null, '<Ada>');
@@ -633,15 +642,9 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
       state.chatHistory = savedState.chatHistory;
       restoreStorage(localStorage, localSnapshot);
       restoreStorage(sessionStorage, sessionSnapshot);
-      Object.assign(window, savedWindow);
       if (chatPanel && savedChatPanelClass != null) chatPanel.className = savedChatPanelClass;
-      onboarding.configureChatOnboarding({
-        closeChatPanel: () => {},
-        renderChatMessages: () => {},
-        sendChatMessage: () => {},
-        setChatNudge: () => {},
-        updateChatNudge: () => {},
-      });
+      resetOnboardingForTest(onboarding);
+      resetOnboardingForTest(appOnboarding);
       host.remove();
     }
 

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -372,6 +372,8 @@ const chatDiscussionStateSrc = read('js/chat-discussion-state.js');
 const chatDiscussionPickerSrc = read('js/chat-discussion-picker.js');
 const chatDiscussionUiSrc = read('js/chat-discussion-ui.js');
 const chatOnboardingSrc = read('js/chat-onboarding.js');
+const chatOnboardingHostBindingsSrc = read('js/chat-onboarding-host-bindings.js');
+const appUiShellModulesSrc = read('js/app-ui-shell-modules.js');
 const chatRenderSrc = read('js/chat-render.js');
 const chatSendSrc = read('js/chat-send.js');
 const labCtxSrc = read('js/lab-context.js');
@@ -597,6 +599,16 @@ assert('chat window bindings configure onboarding callbacks',
     chatWindowBindingsSrc.includes('sendChatMessage') &&
     chatWindowBindingsSrc.includes('updateChatNudge'),
   'found');
+assert('chat onboarding host bindings wire app dependencies',
+  appUiShellModulesSrc.includes("import './chat-onboarding-host-bindings.js'") &&
+    chatOnboardingHostBindingsSrc.includes("from './chat-onboarding.js'") &&
+    chatOnboardingHostBindingsSrc.includes('openSettingsModal') &&
+    chatOnboardingHostBindingsSrc.includes('switchAIProviderBridge') &&
+    chatOnboardingHostBindingsSrc.includes('renderMenstrualCycleSection'),
+  'found');
+assert('chat-onboarding uses configured deps instead of direct window callback lookups',
+  !/\bwindow\s*(?:\.|\[\s*['"])/.test(chatOnboardingSrc),
+  (chatOnboardingSrc.match(/\bwindow\s*(?:\.|\[\s*['"])/) || [''])[0]);
 
 // ─── Section 17a: Chat prompt-context helpers ───
 console.log('Section 17a: Chat prompt-context helpers');

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -56,6 +56,7 @@
     "js/chat-marker-prompts.js",
     "js/chat-message-action-attrs.js",
     "js/chat-nudge.js",
+    "js/chat-onboarding-host-bindings.js",
     "js/chat-onboarding.js",
     "js/chat-panel.js",
     "js/chat-personalities.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.33';
+self.APP_VERSION = '1.10.34';


### PR DESCRIPTION
## Summary
- Move chat onboarding host app callbacks behind `configureChatOnboarding` dependencies.
- Add `chat-onboarding-host-bindings.js` and load it from the app UI shell.
- Update browser/source guards and include the new module in the checkJS pilot.

## Validation
- `node tests/test-chat-actions.js`
- `node tests/test-prelab.js`
- `node tests/test-openrouter.js`
- `npx playwright test tests/playwright/chat-onboarding-browser-coverage.spec.js`
- `npx tsc -p tsconfig.checkjs.json --noEmit`
- `node tests/test-quality-guardrails.js`
- `npm run quality`
- `./run-tests.sh`