### PR TITLE
[codex] Reduce mobile dashboard window coupling

### DIFF
--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -422,7 +422,7 @@ configureMedicalHistoryEditor({ recordChange, saveAndRefresh });
 configureLifestyleContextEditors({ recordChange, saveAndRefresh });
 
 // ── Card tips badges (async — waits for catalog) ──
-async function loadContextCardTips() {
+export async function loadContextCardTips() {
   const appWindow = /** @type {any} */ (window);
   if (!appWindow.isProductRecsEnabled || !appWindow.isProductRecsEnabled()) return;
   if (!appWindow.loadCatalog || !appWindow.getCardSlotKeys) return;

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -7,6 +7,10 @@ import { getEffectiveRangeForDate, getLatestValueIndex } from './marker-analysis
 import { canonicalMetric } from './wearable-adapters.js';
 import { setupDropZone } from './import-drop-zone.js';
 import { loadCommitHash } from './commit-hash.js';
+import { loadContextCardTips } from './context-cards.js';
+import { openChatPanel } from './chat-panel.js';
+import { toggleMobileSidebar } from './nav.js';
+import { loadCatalog } from './recommendations.js';
 import { createDashboardPageView } from './dashboard-page-view.js';
 import { configureLensPageShell } from './lens-page-shell.js';
 import { createDashboardWidgetRegistry } from './dashboard-widgets.js';
@@ -213,6 +217,12 @@ export function createDashboardViewComposition({
     renderDashboardWidget,
     setupDropZone,
     loadCommitHash,
+    navigate,
+    openChatPanel,
+    toggleMobileSidebar,
+    loadContextCardTips,
+    loadCatalog,
+    cacheCatalog: catalog => { globalThis._cachedCatalog = catalog; },
   });
 
   return {

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -41,6 +41,12 @@ const MOBILE_DASHBOARD_ACTION_SELECTOR = `[${MOBILE_DASHBOARD_ACTION_ATTR}]`;
  *   renderDashboardWidget: (entry: MobileDashboardWidgetEntry, prefs: MobileDashboardWidgetPrefs, index: number, visibleEntries: MobileDashboardWidgetEntry[]) => string,
  *   setupDropZone: () => void,
  *   loadCommitHash: () => void,
+ *   navigate: (route: string) => void,
+ *   openChatPanel: () => void,
+ *   toggleMobileSidebar: () => void,
+ *   loadContextCardTips: () => any,
+ *   loadCatalog: () => Promise<any>,
+ *   cacheCatalog: (catalog: any) => void,
  * }} MobileDashboardDeps
  */
 
@@ -54,6 +60,12 @@ const mobileDashboardDeps = {
   renderDashboardWidget: (_entry, _prefs, _index, _visibleEntries) => '',
   setupDropZone: () => {},
   loadCommitHash: () => {},
+  navigate: () => {},
+  openChatPanel: () => {},
+  toggleMobileSidebar: () => {},
+  loadContextCardTips: () => {},
+  loadCatalog: async () => null,
+  cacheCatalog: () => {},
 };
 
 /** @param {Partial<MobileDashboardDeps>} [deps] */
@@ -91,9 +103,9 @@ function handleMobileDashboardActionClick(event) {
     const tab = actionEl.dataset.mobileDashboardTab || 'dashboard';
     const route = actionEl.dataset.mobileDashboardRoute || tab;
     mobileDashboardSetTab(tab);
-    window.navigate?.(route);
+    mobileDashboardDeps.navigate(route);
   } else if (action === 'open-chat') {
-    window.openChatPanel?.();
+    mobileDashboardDeps.openChatPanel();
   } else if (action === 'open-search') {
     openMobileDashboardSearch();
   } else {
@@ -192,7 +204,7 @@ if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
   initMobileChromeStateSync();
   const mobileDashboardMedia = window.matchMedia(MOBILE_DASHBOARD_QUERY);
   const refreshDashboardForBreakpoint = () => {
-    if (state.currentView === 'dashboard') window.navigate?.('dashboard');
+    if (state.currentView === 'dashboard') mobileDashboardDeps.navigate('dashboard');
     else syncMobileBottomNav(state.currentView || 'dashboard');
   };
   if (typeof mobileDashboardMedia.addEventListener === 'function') {
@@ -470,15 +482,14 @@ function renderMobileDashboardWidgetStack(ctx) {
 }
 
 export function openMobileDashboardSearch() {
-  const appWindow = /** @type {any} */ (window);
-  if (appWindow.toggleMobileSidebar) appWindow.toggleMobileSidebar();
+  mobileDashboardDeps.toggleMobileSidebar();
   setTimeout(() => document.getElementById('sidebar-search')?.focus(), 80);
 }
 
 export function mobileDashboardJump(section) {
   const route = ['dashboard', 'labs', 'genome', 'body', 'light', 'insight', 'recommendations'].includes(section) ? section : 'dashboard';
   mobileDashboardSetTab(route === 'genome' || route === 'recommendations' ? 'dashboard' : route);
-  window.navigate?.(route);
+  mobileDashboardDeps.navigate(route);
 }
 
 export function renderMobileDashboard(data, { resetScroll = false } = {}) {
@@ -518,9 +529,9 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
   mobileDashboardDeps.setupDropZone();
   refreshMobileDashboardActiveTab();
   loadContextHealthDots();
-  if (window.loadContextCardTips) window.loadContextCardTips();
+  mobileDashboardDeps.loadContextCardTips();
   mobileDashboardDeps.loadCommitHash();
-  if (window.loadCatalog) window.loadCatalog().then(c => { window._cachedCatalog = c; });
+  mobileDashboardDeps.loadCatalog().then(c => { mobileDashboardDeps.cacheCatalog(c); });
 }
 
 Object.assign(window, {

--- a/tests/playwright/mobile-dashboard-browser-coverage.spec.js
+++ b/tests/playwright/mobile-dashboard-browser-coverage.spec.js
@@ -18,11 +18,6 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
     const mediaListeners = [];
     const saved = {
       matchMedia: window.matchMedia,
-      navigate: window.navigate,
-      toggleMobileSidebar: window.toggleMobileSidebar,
-      openChatPanel: window.openChatPanel,
-      loadContextCardTips: window.loadContextCardTips,
-      loadCatalog: window.loadCatalog,
       scrollTo: window.scrollTo,
     };
 
@@ -38,17 +33,9 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
       removeListener: () => {},
       dispatchEvent: () => false,
     });
-    window.navigate = route => calls.push(['navigate', route]);
-    window.toggleMobileSidebar = () => calls.push(['toggleMobileSidebar']);
-    window.openChatPanel = () => calls.push(['openChatPanel']);
     window.scrollTo = (...args) => calls.push(['scrollTo', ...args]);
 
     const mobileDashboard = await import(mobileDashboardUrl);
-    window.loadContextCardTips = () => calls.push(['loadContextCardTips']);
-    window.loadCatalog = async () => {
-      calls.push(['loadCatalog']);
-      return { catalog: true };
-    };
     const state = window._labState;
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const originalState = {
@@ -100,6 +87,17 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
           },
         },
       };
+      mobileDashboard.configureMobileDashboardView({
+        navigate: route => calls.push(['navigate', route]),
+        toggleMobileSidebar: () => calls.push(['toggleMobileSidebar']),
+        openChatPanel: () => calls.push(['openChatPanel']),
+        loadContextCardTips: () => calls.push(['loadContextCardTips']),
+        loadCatalog: async () => {
+          calls.push(['loadCatalog']);
+          return { catalog: true };
+        },
+        cacheCatalog: catalog => calls.push(['cacheCatalog', catalog?.catalog === true]),
+      });
 
       outcomes.breakpointListenerWasRegistered = mediaListeners.length > 0
         && mobileDashboard.isMobileDashboardViewport() === true;
@@ -118,6 +116,7 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
         && document.getElementById('mobile-bottom-tabs')?.querySelector('[data-tab="labs"]')?.classList.contains('active') === true;
 
       mobileDashboard.renderMobileDashboard(mobileData, { resetScroll: true });
+      await wait(0);
       const firstRenderHtml = document.getElementById('main-content')?.innerHTML || '';
       const defaultDepsOk = document.body.classList.contains('mobile-dashboard-active') === true
         && document.documentElement.classList.contains('mobile-dashboard-active') === true
@@ -125,7 +124,8 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
         && firstRenderHtml.includes('No widgets are visible.')
         && calls.some(call => call[0] === 'scrollTo' && call[1] === 0 && call[2] === 0)
         && calls.some(call => call[0] === 'loadContextCardTips')
-        && calls.some(call => call[0] === 'loadCatalog');
+        && calls.some(call => call[0] === 'loadCatalog')
+        && calls.some(call => call[0] === 'cacheCatalog' && call[1] === true);
       outcomes.defaultDepsRenderEmptyWidgetStackAndRunShellHooks = defaultDepsOk || {
         bodyActive: document.body.classList.contains('mobile-dashboard-active'),
         rootActive: document.documentElement.classList.contains('mobile-dashboard-active'),
@@ -187,18 +187,16 @@ test('mobile dashboard browser coverage exercises defaults breakpoint search and
       if (activeProfile == null) localStorage.removeItem('labcharts-active-profile');
       else localStorage.setItem('labcharts-active-profile', activeProfile);
       window.matchMedia = saved.matchMedia;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
-      if (saved.toggleMobileSidebar) window.toggleMobileSidebar = saved.toggleMobileSidebar;
-      else delete window.toggleMobileSidebar;
-      if (saved.openChatPanel) window.openChatPanel = saved.openChatPanel;
-      else delete window.openChatPanel;
-      if (saved.loadContextCardTips) window.loadContextCardTips = saved.loadContextCardTips;
-      else delete window.loadContextCardTips;
-      if (saved.loadCatalog) window.loadCatalog = saved.loadCatalog;
-      else delete window.loadCatalog;
       if (saved.scrollTo) window.scrollTo = saved.scrollTo;
       else delete window.scrollTo;
+      mobileDashboard.configureMobileDashboardView({
+        navigate: () => {},
+        toggleMobileSidebar: () => {},
+        openChatPanel: () => {},
+        loadContextCardTips: () => {},
+        loadCatalog: async () => null,
+        cacheCatalog: () => {},
+      });
       document.body.classList.remove('mobile-dashboard-active', 'mobile-tabs-active');
       document.documentElement.classList.remove('mobile-dashboard-active', 'mobile-tabs-active');
       document.documentElement.style.removeProperty('--mobile-visual-bottom-offset');

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -68,6 +68,14 @@ return (async function() {
     dashboardControlsSrc.includes('function renderDashboardWidget(entry, prefs, index, visibleEntries)') &&
     mobileDashboardSrc.includes('${mobileWidgetStack}') &&
     css.includes('.m-dashboard-widgets'));
+  assert('mobile dashboard host callbacks are configured through deps',
+    mobileDashboardSrc.includes('configureMobileDashboardView(deps = {})') &&
+    !mobileDashboardSrc.includes('window.navigate') &&
+    !mobileDashboardSrc.includes('window.openChatPanel') &&
+    !mobileDashboardSrc.includes('window.toggleMobileSidebar') &&
+    !mobileDashboardSrc.includes('window.loadContextCardTips') &&
+    !mobileDashboardSrc.includes('window.loadCatalog') &&
+    !mobileDashboardSrc.includes('window._cachedCatalog'));
   assert('mobile dashboard no longer has static duplicate dashboard sections',
     !mobileDashboardSrc.includes('id="mobile-light-section"') &&
     !mobileDashboardSrc.includes('id="mobile-body-section"') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.34';
+self.APP_VERSION = '1.10.35';


### PR DESCRIPTION
## Summary
- Move mobile dashboard host callbacks for navigation, chat, sidebar search, context tips, and catalog caching behind `configureMobileDashboardView` dependencies.
- Wire those dependencies from dashboard view composition using concrete module imports.
- Update mobile browser coverage and source guards, and bump `version.js` for cache invalidation.

## Validation
- `npx playwright test tests/playwright/mobile-dashboard-browser-coverage.spec.js`
- `npx tsc -p tsconfig.checkjs.json --noEmit`
- `npm run quality`
- `./run-tests.sh`