### PR TITLE
feat: accept secondary clinical units in manual entry

### DIFF
--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -2,7 +2,7 @@
 // marker-detail-editing.js — Marker value, range, and note mutation workflows
 
 import { state } from './state.js';
-import { getAlternateUnit, convertUserInputToSI } from './schema.js';
+import { convertUserInputToSI, convertSIToInputUnit } from './schema.js';
 import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, showPromptDialog } from './utils.js';
 import { getActiveData, updateHeaderDates, convertDisplayToSI } from './data.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
@@ -83,11 +83,16 @@ export async function saveManualEntry(id, opts = {}) {
   const usingAltUnit = !!(marker && inputUnit && inputUnit !== marker.unit);
   let checkRefMin = marker?.refMin, checkRefMax = marker?.refMax, checkUnit = marker?.unit;
   if (marker && usingAltUnit) {
-    const isUSMode = state.unitSystem === 'US';
-    const altMin = marker.refMin != null ? getAlternateUnit(dotKey, marker.refMin, isUSMode) : null;
-    const altMax = marker.refMax != null ? getAlternateUnit(dotKey, marker.refMax, isUSMode) : null;
-    checkRefMin = altMin?.value ?? null;
-    checkRefMax = altMax?.value ?? null;
+    // Express the marker's reference range in the user's chosen unit so the
+    // sanity check compares like-with-like. Refs come from getActiveData in
+    // *display* units (US-converted in US mode), so round-trip through SI:
+    // display → SI (convertDisplayToSI) → inputUnit (convertSIToInputUnit).
+    // This is secondary-unit aware (e.g. mg/L for Lp(a)), unlike the old
+    // primary-only getAlternateUnit path.
+    const refMinSI = marker.refMin != null ? convertDisplayToSI(dotKey, marker.refMin) : null;
+    const refMaxSI = marker.refMax != null ? convertDisplayToSI(dotKey, marker.refMax) : null;
+    checkRefMin = refMinSI != null ? convertSIToInputUnit(dotKey, refMinSI, inputUnit) : null;
+    checkRefMax = refMaxSI != null ? convertSIToInputUnit(dotKey, refMaxSI, inputUnit) : null;
     checkUnit = inputUnit;
   }
   // Range sanity check: catches decimal/unit slips (e.g. typing 100 mg/dL when SI ref is 4–6 mmol/L).

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -2,7 +2,7 @@
 // marker-detail-modal.js — Marker detail, manual entry, custom marker, and range modal flows
 
 import { state } from './state.js';
-import { trackUsage, UNIT_CONVERSIONS, getAlternateUnit } from './schema.js';
+import { trackUsage, UNIT_CONVERSIONS, SECONDARY_UNIT_CONVERSIONS, getAlternateUnit } from './schema.js';
 import { bindDetailModalSyncRefresh, escapeHTML, escapeAttr, getStatus, formatValue, showNotification, showConfirmDialog, safeMarkerId } from './utils.js';
 import { getActiveData, saveImportedData, updateHeaderDates } from './data.js';
 import { getEffectiveRange, getEffectiveRangeForDate } from './marker-analysis.js';
@@ -816,22 +816,33 @@ export function openManualEntryForm(id, prefillDate) {
   if (marker.refMin != null && marker.refMax != null) {
     placeholderHint = `e.g. ${formatValue((marker.refMin + marker.refMax) / 2)}`;
   }
-  // Per-field unit picker: surface the alternate unit when this marker has a
-  // UNIT_CONVERSIONS entry, so users entering a value from a lab report in the
-  // other system don't have to mentally convert. Default = current display unit.
+  // Per-field unit picker: surface every unit this marker can be entered in — the
+  // current display unit (default), the alternate US/EU unit, and any secondary
+  // clinical units (e.g. mg/L for Lp(a)) — so users entering a value from a lab
+  // report don't have to mentally convert. Default = current display unit.
   const dotKeyForUnit = id.replace('_', '.');
   const _meIsUS = state.unitSystem === 'US';
   const _meConv = UNIT_CONVERSIONS[dotKeyForUnit];
-  let _meAltUnit = null;
+  const _meUnits = [marker.unit];
   if (_meConv) {
     const probe = marker.refMax ?? marker.refMin ?? 1;
     const alt = getAlternateUnit(dotKeyForUnit, probe, _meIsUS);
-    if (alt) _meAltUnit = alt.unit;
+    if (alt?.unit) _meUnits.push(alt.unit);
   }
-  const unitPickerHtml = _meAltUnit
+  for (const sec of (SECONDARY_UNIT_CONVERSIONS[dotKeyForUnit] || [])) {
+    if (sec.unit) _meUnits.push(sec.unit);
+  }
+  // Dedup case-insensitively, keeping the display unit first (selected).
+  const _meSeen = new Set();
+  const _meOptions = _meUnits.filter(u => {
+    const k = String(u).toLowerCase();
+    if (!u || _meSeen.has(k)) return false;
+    _meSeen.add(k);
+    return true;
+  });
+  const unitPickerHtml = _meOptions.length > 1
     ? `<select id="me-unit" class="me-unit-select" aria-label="Input unit">
-         <option value="${escapeHTML(marker.unit)}" selected>${escapeHTML(marker.unit)}</option>
-         <option value="${escapeHTML(_meAltUnit)}">${escapeHTML(_meAltUnit)}</option>
+         ${_meOptions.map((u, i) => `<option value="${escapeHTML(u)}"${i === 0 ? ' selected' : ''}>${escapeHTML(u)}</option>`).join('')}
        </select>`
     : `<span style="color:var(--text-muted);font-weight:400">(${escapeHTML(marker.unit)})</span>`;
   modal.innerHTML = `<div class="gb-modal-head">

--- a/js/schema.js
+++ b/js/schema.js
@@ -1,6 +1,8 @@
 // @ts-check
 // schema.js — Marker definitions, unit conversions, pricing, optimal ranges
 
+import { SECONDARY_UNIT_CONVERSIONS } from './secondary-unit-conversions.js';
+
 // ═══════════════════════════════════════════════
 // MARKER SCHEMA (no personal data — just biomarker definitions)
 // ═══════════════════════════════════════════════
@@ -346,7 +348,7 @@ export const UNIT_CONVERSIONS = {
   'differential.basophils':   { factor: 1, usUnit: 'K/µL',    type: 'multiply' }
 };
 
-export { SECONDARY_UNIT_CONVERSIONS } from './secondary-unit-conversions.js';
+export { SECONDARY_UNIT_CONVERSIONS };
 
 // Returns the converted {value, unit} in the *other* unit system for dual-display,
 // or null when no conversion exists. `displayValue` is what the user currently sees
@@ -378,18 +380,55 @@ export function getAlternateUnit(dotKey, displayValue, isUSMode) {
 }
 
 // Convert a value the user typed in `inputUnit` to canonical SI for storage.
-// Used by manual-entry's per-field unit picker.
+// Used by manual-entry's per-field unit picker. Handles the SI unit, the primary
+// US-conventional unit (UNIT_CONVERSIONS), and any secondary clinical unit
+// (SECONDARY_UNIT_CONVERSIONS, e.g. mg/L for Lp(a) or g/L for cholesterol).
 export function convertUserInputToSI(dotKey, value, inputUnit) {
-  const conv = UNIT_CONVERSIONS[dotKey];
-  if (!conv || !Number.isFinite(value)) return value;
+  if (!Number.isFinite(value)) return value;
   const dot = dotKey.indexOf('.');
   if (dot < 0) return value;
   const cat = dotKey.slice(0, dot), mkr = dotKey.slice(dot + 1);
   const siUnit = MARKER_SCHEMA[cat]?.markers?.[mkr]?.unit;
-  if (inputUnit === siUnit) return value;
-  if (conv.type === 'multiply') return parseFloat((value / conv.factor).toPrecision(6));
-  if (conv.type === 'hba1c') return parseFloat(((value - 2.15) * 10.929).toFixed(1));
-  return value;
+  // SI input (or no unit chosen) is already canonical.
+  if (!inputUnit || inputUnit === siUnit) return value;
+  const conv = UNIT_CONVERSIONS[dotKey];
+  if (conv) {
+    if (conv.type === 'multiply' && inputUnit === conv.usUnit) return parseFloat((value / conv.factor).toPrecision(6));
+    if (conv.type === 'hba1c' && inputUnit === '%') return parseFloat(((value - 2.15) * 10.929).toFixed(1));
+  }
+  const secondaries = SECONDARY_UNIT_CONVERSIONS[dotKey];
+  if (secondaries) {
+    for (const sec of secondaries) {
+      if (sec.type === 'multiply' && inputUnit === sec.unit) return parseFloat((value / sec.factor).toPrecision(6));
+      if (sec.type === 'hba1c' && inputUnit === sec.unit) return parseFloat(((value - 2.15) * 10.929).toFixed(1));
+    }
+  }
+  return value; // unrecognized unit — store as typed rather than guessing
+}
+
+// Inverse of convertUserInputToSI: express a canonical-SI value in `targetUnit`
+// (SI / primary US / secondary clinical). Used by manual entry's range sanity
+// check so the "did you mean?" warning compares in the unit the user is typing.
+export function convertSIToInputUnit(dotKey, siValue, targetUnit) {
+  if (!Number.isFinite(siValue)) return siValue;
+  const dot = dotKey.indexOf('.');
+  if (dot < 0) return siValue;
+  const cat = dotKey.slice(0, dot), mkr = dotKey.slice(dot + 1);
+  const siUnit = MARKER_SCHEMA[cat]?.markers?.[mkr]?.unit;
+  if (!targetUnit || targetUnit === siUnit) return siValue;
+  const conv = UNIT_CONVERSIONS[dotKey];
+  if (conv) {
+    if (conv.type === 'multiply' && targetUnit === conv.usUnit) return parseFloat((siValue * conv.factor).toPrecision(6));
+    if (conv.type === 'hba1c' && targetUnit === '%') return parseFloat(((siValue / 10.929) + 2.15).toFixed(1));
+  }
+  const secondaries = SECONDARY_UNIT_CONVERSIONS[dotKey];
+  if (secondaries) {
+    for (const sec of secondaries) {
+      if (sec.type === 'multiply' && targetUnit === sec.unit) return parseFloat((siValue * sec.factor).toPrecision(6));
+      if (sec.type === 'hba1c' && targetUnit === sec.unit) return parseFloat(((siValue / 10.929) + 2.15).toFixed(1));
+    }
+  }
+  return siValue;
 }
 
 // ═══════════════════════════════════════════════

--- a/js/secondary-unit-conversions.js
+++ b/js/secondary-unit-conversions.js
@@ -206,6 +206,15 @@ export const SECONDARY_UNIT_CONVERSIONS = {
     { unit: 'mg/l', factor: 1000, type: 'multiply' },
     { unit: 'g/l', factor: 1, type: 'multiply' }
   ],
+  // Lp(a): SI unit is nmol/l (particle count). Mass units (mg/l, mg/dl) report total
+  // particle mass and have NO exact molar conversion — the ratio depends on apo(a)
+  // isoform size and the assay. ~2.4 nmol/L per mg/dL (i.e. ~0.24 nmol/L per mg/L, so
+  // factor 4.167) is a widely-used approximation only; the 2022 EAS consensus
+  // discourages mg↔nmol conversion for clinical decisions. Sanity check: Unilabs SK's
+  // 0–300 mg/L (= 0–30 mg/dL) upper-normal ≈ 72 nmol/L, near the schema optimalMax 75.
+  'lipids.lpA': [
+    { unit: 'mg/l', factor: 4.167, type: 'multiply' }
+  ],
   'iron.iron': [
     { unit: 'µg/l', factor: 55.85, type: 'multiply' },
     { unit: 'mg/l', factor: 0.05585, type: 'multiply' },

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.37';
+self.APP_VERSION = '1.10.38';


### PR DESCRIPTION
## What

Adds `mg/L` as a recognized unit for Lp(a) (`lipids.lpA`) and makes the manual-entry unit picker offer **every** secondary clinical unit a marker supports — not just the primary US/EU alternate.

Previously manual entry read only the primary `UNIT_CONVERSIONS`, so units already accepted by the PDF-import pipeline (mg/L for Lp(a), g/L for cholesterol, etc.) couldn't be entered by hand.

## Why

EU labs (e.g. Unilabs SK) report Lp(a) in **mg/L** (ref 0–300), but the marker was nmol/L-only — and Lp(a) was the only lipid without mass units in `SECONDARY_UNIT_CONVERSIONS`.

Lp(a) mass↔molar has **no exact conversion** (apo(a) isoform/assay dependent). The factor used (~2.4 nmol/L per mg/dL → `4.167` for mg/L) is a documented approximation only; the 2022 EAS consensus discourages mg↔nmol conversion for clinical thresholds. The caveat is documented inline. Sanity check: the lab's 0–300 mg/L upper-normal ≈ 72 nmol/L, near the schema `optimalMax` of 75.

## Changes

- **`secondary-unit-conversions.js`** — register `lipids.lpA` → mg/L (factor `4.167`), with the assay-dependence caveat inline.
- **`schema.js`** — `convertUserInputToSI` now matches primary **and** secondary units via explicit unit comparison (previously it assumed any non-SI input was the primary US unit); add the inverse `convertSIToInputUnit`. Turned the `SECONDARY_UNIT_CONVERSIONS` re-export into a real import so both functions can use it.
- **`marker-detail-modal.js`** — the manual-entry unit picker lists every valid unit, deduped (also fixes factor-1 markers that previously showed the same unit twice).
- **`marker-detail-editing.js`** — the range sanity-check converts refs through SI (display → SI → input unit) so the "did you mean?" warning is correct for any unit and display mode.

## Testing

- **Live app round-trip:** entered `161.7 mg/L` → stored `38.8 nmol/L`, provenance `file: null` (manual).
- **No regression:** glucose via primary `mg/dL` and secondary `mg/L` both normalize to `4.995 mmol/L`; cholesterol `g/L` works.
- **Node tests pass:** `manual-entry-flow` (52), `multi-unit` (150/152\*), `marker-detail-delegated-actions` (75), `secondary-unit-conversions` (24), `unit-import` (110), `provenance` (14), `marker-value-notes` (44).
- **`npm run typecheck:checkjs`:** 0 errors.

\* The 2 `multi-unit` failures (`updateSettingsUI`, `toggleAltUnits`) are pre-existing/DOM-environmental — they fail identically on a clean `main` without this change.
