### PR TITLE
Reduce client list window coupling

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -6,9 +6,10 @@ import { closeChangelog } from './changelog.js';
 import { closeChatPanel, toggleChatPanel } from './chat-panel.js';
 import { updateChatNudge } from './chat-nudge.js';
 import { closeSummaryModal } from './chat-summaries.js';
-import { closeClientList } from './client-list.js';
+import { closeClientList, configureClientListRuntime } from './client-list.js';
 import { closeEMFInterpretation } from './emf-interpretation.js';
 import { closeReportBuilder } from './export.js';
+import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
 import { closeFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { closeModal } from './marker-detail-modal.js';
@@ -16,6 +17,15 @@ import { closeMobileSidebar } from './nav.js';
 import { closeSettingsModal, closeTweaksPanel } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
 import { navigate } from './views.js';
+import { openProfileShareModal } from './profile-share.js';
+
+configureClientListRuntime({
+  exportAllDataJSON,
+  exportClientJSON,
+  importDataJSON,
+  loadDemoData,
+  openProfileShareModal,
+});
 
 configureAppEventListeners({
   closeChangelog,

--- a/js/client-list.js
+++ b/js/client-list.js
@@ -8,6 +8,30 @@ import { LATITUDE_BANDS } from './constants.js';
 import { getAvatarColor } from './nav.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
+/**
+ * @typedef {{
+ *   exportAllDataJSON: () => Promise<void> | void,
+ *   exportClientJSON: (profileId: string, includeChat?: boolean) => Promise<void> | void,
+ *   importDataJSON: (file: File) => Promise<void> | void,
+ *   loadDemoData: (sex?: string) => Promise<void> | void,
+ *   openProfileShareModal: (profileId?: string) => void,
+ * }} ClientListRuntime
+ */
+
+/** @type {ClientListRuntime} */
+const clientListRuntime = {
+  exportAllDataJSON: () => {},
+  exportClientJSON: () => {},
+  importDataJSON: () => {},
+  loadDemoData: () => {},
+  openProfileShareModal: () => {},
+};
+
+/** @param {Partial<ClientListRuntime>} [runtime] */
+export function configureClientListRuntime(runtime = {}) {
+  Object.assign(clientListRuntime, runtime);
+}
+
 let _search = '';
 let _sort = 'lastUpdated';
 let _statusFilter = 'active';
@@ -816,12 +840,12 @@ function _closeMenus() {
   if (m) m.classList.remove('show');
   if (tools) tools.classList.remove('show');
 }
-function _clExport(id) { _closeMenus(); window.exportClientJSON(id); }
-function _clExportChat(id) { _closeMenus(); window.exportClientJSON(id, true); }
+function _clExport(id) { _closeMenus(); clientListRuntime.exportClientJSON(id); }
+function _clExportChat(id) { _closeMenus(); clientListRuntime.exportClientJSON(id, true); }
 function _clShare(id) {
   _closeMenus();
   closeClientList();
-  setTimeout(() => window.openProfileShareModal?.(id), 120);
+  setTimeout(() => clientListRuntime.openProfileShareModal(id), 120);
 }
 function _clDelete(id) { _closeMenus(); deleteProfile(id, () => renderClientList()); }
 
@@ -854,8 +878,8 @@ function _handleClientClick(event) {
   else if (action === 'edit-profile') _clEdit(id);
   else if (action === 'toggle-tools-menu') _clToggleToolsMenu(event);
   else if (action === 'trigger-json-import') { _closeMenus(); _clickFileInput('cl-json-import'); }
-  else if (action === 'export-all') { _closeMenus(); window.exportAllDataJSON?.(); }
-  else if (action === 'load-demo') { closeClientList(); window.loadDemoData?.(actionEl.dataset.clDemo || 'female'); }
+  else if (action === 'export-all') { _closeMenus(); clientListRuntime.exportAllDataJSON(); }
+  else if (action === 'load-demo') { closeClientList(); clientListRuntime.loadDemoData(actionEl.dataset.clDemo || 'female'); }
   else if (action === 'tag-filter') _clTagFilter(actionEl.dataset.clTag || '');
   else if (action === 'toggle-menu') _clToggleMenu(event, id, actionEl);
   else if (action === 'choose-avatar') _clickFileInput('cl-avatar-input');
@@ -898,7 +922,7 @@ function _handleClientChange(event) {
     const file = el.files?.[0];
     if (!file) return;
     closeClientList();
-    window.importDataJSON?.(file);
+    clientListRuntime.importDataJSON(file);
     el.value = '';
   } else if (action === 'sort' && el instanceof HTMLSelectElement) {
     _clSort(el.value);

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -6,6 +6,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
 
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
+    const { configureClientListRuntime } = await import('/js/client-list.js');
     const outcomes = {};
     const calls = [];
     const confirmQueue = [];
@@ -124,6 +125,13 @@ test('client list live menu actions dispatch exports share demos and profile sta
       window.importDataJSON = file => calls.push(['import-json', file?.name || '']);
       window.loadDemoData = demo => calls.push(['load-demo', demo]);
       window.openProfileShareModal = id => calls.push(['share-profile', id]);
+      configureClientListRuntime({
+        exportAllDataJSON: window.exportAllDataJSON,
+        exportClientJSON: window.exportClientJSON,
+        importDataJSON: window.importDataJSON,
+        loadDemoData: window.loadDemoData,
+        openProfileShareModal: window.openProfileShareModal,
+      });
       window.showConfirmDialog = async message => {
         calls.push(['confirm', message]);
         return confirmQueue.shift() === true;

--- a/tests/test-client-list-delegated-actions.js
+++ b/tests/test-client-list-delegated-actions.js
@@ -49,7 +49,13 @@ assert('client-list menu buttons are data-driven',
     !clientListSrc.includes('onclick:'));
 assert('client-list can open share modal for selected profile',
   clientListSrc.includes('function _clShare(id)') &&
-    clientListSrc.includes('window.openProfileShareModal?.(id)'));
+    clientListSrc.includes('clientListRuntime.openProfileShareModal(id)'));
+assert('client-list routes app-shell actions through injectable runtime',
+  clientListSrc.includes('export function configureClientListRuntime') &&
+    clientListSrc.includes('clientListRuntime.exportAllDataJSON()') &&
+    clientListSrc.includes('clientListRuntime.exportClientJSON(id, true)') &&
+    clientListSrc.includes('clientListRuntime.importDataJSON(file)') &&
+    clientListSrc.includes('clientListRuntime.loadDemoData(actionEl.dataset.clDemo'));
 assert('client-list modal uses shared overlay lifecycle helpers',
   clientListSrc.includes("from './modal-lifecycle.js'") &&
     clientListUsesScrollLockedOverlay &&

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -123,7 +123,9 @@ assert('Share profile has a top-level header action',
   read('js/shell-actions.js').includes("callShellRuntime('openProfileShareModal')"));
 assert('Mobile share path moves into client list menu',
   read('js/client-list.js').includes("label: 'Share Profile', action: 'share-profile'") &&
-  read('js/client-list.js').includes('window.openProfileShareModal?.(id)') &&
+  read('js/client-list.js').includes('clientListRuntime.openProfileShareModal(id)') &&
+  read('js/app-shell-hooks.js').includes('configureClientListRuntime') &&
+  read('js/app-shell-hooks.js').includes('openProfileShareModal') &&
   /@media \(max-width: 768px\), \(pointer: coarse\)[\s\S]*\.header-share-btn\s*\{[\s\S]*display:\s*none/.test(redesignCss));
 assert('Share modal can target a selected profile id',
   profileShareSrc.includes('openProfileShareModal(profileId = state.currentProfile)') &&

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -202,7 +202,7 @@
 
   // client-list.js (3)
   const clientListExports = [
-    'openClientList','closeClientList','openClientForm'
+    'openClientList','closeClientList','openClientForm','configureClientListRuntime'
   ];
 
   // cycle.js (10)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.35';
+self.APP_VERSION = '1.10.36';


### PR DESCRIPTION
## Summary
- inject client-list export/import/demo/share actions through the app shell instead of reading browser globals in handlers
- keep the profile-share mobile path wired through explicit runtime dependencies
- bump the app shell version for the JS cache-bust

## Verification
- `npm run typecheck`
- `npm run quality`
- `npm test -- --run`
- `PORT=8187 npx playwright test tests/playwright/client-list-browser-coverage.spec.js --project=chromium`
