### PR TITLE
Reduce settings data window coupling

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -14,16 +14,24 @@ import { closeFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { closeModal } from './marker-detail-modal.js';
 import { closeMobileSidebar } from './nav.js';
-import { closeSettingsModal, closeTweaksPanel } from './settings.js';
+import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
 import { navigate } from './views.js';
 import { openProfileShareModal } from './profile-share.js';
+import { getActiveProfileId } from './profile.js';
 
 configureClientListRuntime({
   exportAllDataJSON,
   exportClientJSON,
   importDataJSON,
   loadDemoData,
+  openProfileShareModal,
+});
+
+configureSettingsRuntime({
+  exportAllDataJSON,
+  exportClientJSON,
+  getActiveProfileId,
   openProfileShareModal,
 });
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -29,6 +29,28 @@ import {
 
 const settingsWindow = /** @type {SettingsWindow} */ (window);
 
+/**
+ * @typedef {{
+ *   exportAllDataJSON: () => Promise<void> | void,
+ *   exportClientJSON: (profileId?: string | null) => Promise<void> | void,
+ *   getActiveProfileId: () => string | null,
+ *   openProfileShareModal: (profileId?: string) => void,
+ * }} SettingsRuntime
+ */
+
+/** @type {SettingsRuntime} */
+const settingsRuntime = {
+  exportAllDataJSON: () => {},
+  exportClientJSON: () => {},
+  getActiveProfileId: () => null,
+  openProfileShareModal: () => {},
+};
+
+/** @param {Partial<SettingsRuntime>} [runtime] */
+export function configureSettingsRuntime(runtime = {}) {
+  Object.assign(settingsRuntime, runtime);
+}
+
 installSettingsProviderBridge();
 
 export {
@@ -387,14 +409,14 @@ async function handleSettingsClick(event) {
     }
   } else if (action === 'export-client') {
     event.preventDefault();
-    settingsWindow.exportClientJSON?.(settingsWindow.getActiveProfileId?.());
+    settingsRuntime.exportClientJSON(settingsRuntime.getActiveProfileId());
   } else if (action === 'share-profile') {
     event.preventDefault();
     closeSettingsModal();
-    setTimeout(() => settingsWindow.openProfileShareModal?.(), 120);
+    setTimeout(() => settingsRuntime.openProfileShareModal(), 120);
   } else if (action === 'export-all-clients') {
     event.preventDefault();
-    settingsWindow.exportAllDataJSON?.();
+    settingsRuntime.exportAllDataJSON();
   } else if (action === 'clear-all-data') {
     event.preventDefault();
     settingsWindow.clearAllData?.();

--- a/js/settings.js
+++ b/js/settings.js
@@ -40,10 +40,10 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
 
 /** @type {SettingsRuntime} */
 const settingsRuntime = {
-  exportAllDataJSON: () => {},
-  exportClientJSON: () => {},
-  getActiveProfileId: () => null,
-  openProfileShareModal: () => {},
+  exportAllDataJSON: () => settingsWindow.exportAllDataJSON?.(),
+  exportClientJSON: (profileId) => settingsWindow.exportClientJSON?.(profileId),
+  getActiveProfileId: () => settingsWindow.getActiveProfileId?.() || null,
+  openProfileShareModal: (profileId) => settingsWindow.openProfileShareModal?.(profileId),
 };
 
 /** @param {Partial<SettingsRuntime>} [runtime] */

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -95,7 +95,9 @@ assert('Profile share module is startup-loaded',
   appDataIoSrc.includes("import './profile-share.js';"));
 assert('Settings Data tab exposes Share Profile action',
   settingsDataSrc.includes("data-settings-action=\"share-profile\"") &&
-  settingsSrc.includes('settingsWindow.openProfileShareModal?.()'));
+  settingsSrc.includes('settingsRuntime.openProfileShareModal()') &&
+  read('js/app-shell-hooks.js').includes('configureSettingsRuntime') &&
+  read('js/app-shell-hooks.js').includes('openProfileShareModal'));
 assert('Share modal has dedicated shared-modal styling',
   modalCss.includes('#profile-share-overlay.modal-overlay') &&
   modalCss.includes('.profile-share-modal') &&

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -96,6 +96,7 @@ assert('Profile share module is startup-loaded',
 assert('Settings Data tab exposes Share Profile action',
   settingsDataSrc.includes("data-settings-action=\"share-profile\"") &&
   settingsSrc.includes('settingsRuntime.openProfileShareModal()') &&
+  settingsSrc.includes('openProfileShareModal: (profileId) => settingsWindow.openProfileShareModal?.(profileId)') &&
   read('js/app-shell-hooks.js').includes('configureSettingsRuntime') &&
   read('js/app-shell-hooks.js').includes('openProfileShareModal'));
 assert('Share modal has dedicated shared-modal styling',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -283,7 +283,7 @@
     'renderPrivacySection',
     'togglePrivacyConfigure','updatePrivacyStatusCard',
     'updateSettingsUI',
-    'renderDataEntriesSection','refreshDataEntriesSection'
+    'renderDataEntriesSection','refreshDataEntriesSection','configureSettingsRuntime'
   ];
 
   // provider-panels.js (72)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.36';
+self.APP_VERSION = '1.10.37';


### PR DESCRIPTION
## Summary
- inject Settings Data export/share actions through the app shell instead of resolving them from `window` in settings handlers
- keep Data-tab export/share behavior wired to explicit module imports
- bump app shell version for cache refresh

## Verification
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test -- --run`
- `node tests/test-profile-share.js && node tests/verify-modules.js`
- `PORT=8188 npx playwright test tests/playwright/profile-share-browser-coverage.spec.js --project=chromium`
