### PR TITLE
[codex] Fix Spadia fatty acid imports

### DIFF
--- a/js/pdf-import-marker-normalization.js
+++ b/js/pdf-import-marker-normalization.js
@@ -84,6 +84,17 @@ function normalizeParsedImportMarker(m, { testType, detected, mode, emitDebugLog
         m.suggestedGroup = 'Fatty Acids';
         mappedKey = null;
         matched = false;
+      } else {
+        if (emitDebugLogs && isDebugMode()) {
+          console.log(`[Import Guard] Demoted invalid ${genericFattyAcidKey} for detected ${detected.product.label}`);
+        }
+        if (!markerPart && m.suggestedKey === genericFattyAcidKey) m.suggestedKey = null;
+        else if (markerPart && !m.suggestedKey) m.suggestedKey = genericFattyAcidKey;
+        m.suggestedName = m.suggestedName || m.rawName;
+        m.suggestedCategoryLabel = m.suggestedCategoryLabel || detected.product.label;
+        m.suggestedGroup = m.suggestedGroup || 'Fatty Acids';
+        mappedKey = null;
+        matched = false;
       }
     }
   }

--- a/js/pdf-import-marker-normalization.js
+++ b/js/pdf-import-marker-normalization.js
@@ -88,8 +88,11 @@ function normalizeParsedImportMarker(m, { testType, detected, mode, emitDebugLog
         if (emitDebugLogs && isDebugMode()) {
           console.log(`[Import Guard] Demoted invalid ${genericFattyAcidKey} for detected ${detected.product.label}`);
         }
-        if (!markerPart && m.suggestedKey === genericFattyAcidKey) m.suggestedKey = null;
-        else if (markerPart && !m.suggestedKey) m.suggestedKey = genericFattyAcidKey;
+        if (markerPart) {
+          m.suggestedKey = `${detected.product.prefix}.${markerPart}`;
+        } else if (m.suggestedKey === genericFattyAcidKey) {
+          m.suggestedKey = null;
+        }
         m.suggestedName = m.suggestedName || m.rawName;
         m.suggestedCategoryLabel = m.suggestedCategoryLabel || detected.product.label;
         m.suggestedGroup = m.suggestedGroup || 'Fatty Acids';

--- a/js/pdf-import-marker-normalization.js
+++ b/js/pdf-import-marker-normalization.js
@@ -57,6 +57,30 @@ function normalizeParsedImportMarker(m, { testType, detected, mode, emitDebugLog
   let mappedKey = m.mappedKey || null;
   let matched = !!mappedKey;
 
+  // Product detection is conservative for whole-report normalization when the
+  // model says "blood", but generic fattyAcids.* adapter keys are never the
+  // desired persisted keys for a detected fatty-acid product.
+  if (detected?.adapter?.id === 'fattyAcids' && detected.product?.prefix) {
+    const genericFattyAcidKey = mappedKey?.startsWith('fattyAcids.')
+      ? mappedKey
+      : (!matched && m.suggestedKey?.startsWith('fattyAcids.') ? m.suggestedKey : null);
+    if (genericFattyAcidKey) {
+      const markerPart = genericFattyAcidKey.split('.')[1];
+      const sDef = SPECIALTY_MARKER_DEFS[genericFattyAcidKey];
+      if (markerPart) {
+        if (emitDebugLogs && isDebugMode()) {
+          console.log(`[Import Guard] Rewrote ${genericFattyAcidKey} -> ${detected.product.prefix}.${markerPart} (detected ${detected.product.label})`);
+        }
+        m.suggestedKey = `${detected.product.prefix}.${markerPart}`;
+        m.suggestedName = m.suggestedName || sDef?.name || m.rawName;
+        m.suggestedCategoryLabel = detected.product.label;
+        m.suggestedGroup = 'Fatty Acids';
+        mappedKey = null;
+        matched = false;
+      }
+    }
+  }
+
   // Guard: never allow standard blood work mappings for known specialty tests.
   // Only fire for well-defined specialty types, not for mixed/comprehensive reports.
   if (matched && _specialtyTypes.includes(testType)) {

--- a/js/pdf-import-marker-normalization.js
+++ b/js/pdf-import-marker-normalization.js
@@ -9,6 +9,13 @@ import { _sanitizeAIMarker, reconcileImportMarkerMappings } from './pdf-import-m
 const _specialtyTypes = ['OAT', 'fattyAcids', 'Metabolomix+', 'DUTCH', 'HTMA', 'GI'];
 const standardCats = new Set(Object.keys(MARKER_SCHEMA));
 
+function _fattyAcidMarkerPart(key) {
+  const prefix = 'fattyAcids.';
+  if (!key?.startsWith(prefix)) return null;
+  const markerPart = key.slice(prefix.length);
+  return markerPart && !markerPart.includes('.') ? markerPart : null;
+}
+
 /**
  * @param {{ testType?: string, markers?: any[] }} parsed
  * @param {{
@@ -65,9 +72,9 @@ function normalizeParsedImportMarker(m, { testType, detected, mode, emitDebugLog
       ? mappedKey
       : (!matched && m.suggestedKey?.startsWith('fattyAcids.') ? m.suggestedKey : null);
     if (genericFattyAcidKey) {
-      const markerPart = genericFattyAcidKey.split('.')[1];
+      const markerPart = _fattyAcidMarkerPart(genericFattyAcidKey);
       const sDef = SPECIALTY_MARKER_DEFS[genericFattyAcidKey];
-      if (markerPart) {
+      if (markerPart && sDef) {
         if (emitDebugLogs && isDebugMode()) {
           console.log(`[Import Guard] Rewrote ${genericFattyAcidKey} -> ${detected.product.prefix}.${markerPart} (detected ${detected.product.label})`);
         }

--- a/js/profile.js
+++ b/js/profile.js
@@ -435,6 +435,20 @@ function _isSpadiaFattyAcidSource(value) {
   return compact.includes('spadia') && (compact.includes('fattyacid') || compact.includes('mastnekyseliny'));
 }
 
+function _isSpadiaFattyAcidMarkerMetadata(marker) {
+  const key = marker?.mappedKey || marker?.suggestedKey || '';
+  if (key.startsWith('spadiaFA.')) return true;
+  const label = _normalizeProfileMarkerLabel(marker?.suggestedCategoryLabel || '');
+  const group = _normalizeProfileMarkerLabel(marker?.suggestedGroup || '');
+  return label.includes('spadia') && (!group || group.includes('fattyacid') || group.includes('mastnekyseliny'));
+}
+
+function _isSpadiaFattyAcidSnapshot(snap) {
+  if (_isSpadiaFattyAcidSource(snap?.fileName || '')) return true;
+  if (_isSpadiaFattyAcidSource(`${snap?.labName || ''} ${snap?.productLabel || ''}`)) return true;
+  return Array.isArray(snap?.markers) && snap.markers.some(_isSpadiaFattyAcidMarkerMetadata);
+}
+
 function _entrySourceText(entry) {
   const parts = [];
   if (entry?.sourceFile) parts.push(entry.sourceFile);
@@ -580,7 +594,7 @@ function _repairSpadiaFattyAcidKeys(data) {
     }
   }
   for (const snap of data.importSnapshots || []) {
-    if (!_isSpadiaFattyAcidSource(snap?.fileName || '')) continue;
+    if (!_isSpadiaFattyAcidSnapshot(snap)) continue;
     if (!Array.isArray(snap.markers)) continue;
     for (const marker of snap.markers) {
       const oldKey = marker?.mappedKey?.startsWith('fattyAcids.') ? marker.mappedKey
@@ -609,6 +623,7 @@ function _repairSpadiaFattyAcidKeys(data) {
   for (const [oldKey, nextKey] of renamedKeys) {
     _copyGlobalProfileMarkerData(data, oldKey, nextKey);
     if (_profileHasStructuralMarkerKey(data, oldKey)) continue;
+    _copyDateScopedProfileMarkerData(data, oldKey, nextKey);
     _deleteDateScopedProfileMarkerData(data, oldKey);
     _deleteGlobalProfileMarkerData(data, oldKey);
     if (data.customMarkers) delete data.customMarkers[oldKey];

--- a/js/profile.js
+++ b/js/profile.js
@@ -576,8 +576,11 @@ function _entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker) {
 
 function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {
   if (!data.customMarkers) data.customMarkers = {};
-  const sourceDef = data.customMarkers[nextKey] || data.customMarkers[oldKey] || SPECIALTY_MARKER_DEFS[oldKey] || {};
-  const cmDef = data.customMarkers[nextKey] || {};
+  const sourceDef = data.customMarkers[oldKey] || SPECIALTY_MARKER_DEFS[oldKey] || {};
+  const cmDef = {
+    ...sourceDef,
+    ...(data.customMarkers[nextKey] || {}),
+  };
   cmDef.name = cmDef.name || sourceDef.name || nextKey.split('.').pop();
   cmDef.unit = cmDef.unit || sourceDef.unit || '%';
   cmDef.refMin = cmDef.refMin != null ? cmDef.refMin : (sourceDef.refMin != null ? sourceDef.refMin : null);

--- a/js/profile.js
+++ b/js/profile.js
@@ -480,9 +480,13 @@ function _copyDateScopedProfileMarkerData(data, oldKey, nextKey, date = null) {
   if (date) {
     copyExact(data.manualValues, date);
     copyExact(data.markerValueNotes, date);
+    copyExact(data.markerLabels, date);
+    copyExact(data.refOverrides, date);
   } else {
     copyAll(data.manualValues);
     copyAll(data.markerValueNotes);
+    copyAll(data.markerLabels);
+    copyAll(data.refOverrides);
   }
 }
 
@@ -501,9 +505,13 @@ function _deleteDateScopedProfileMarkerData(data, oldKey, date = null) {
   if (date) {
     deleteExact(data.manualValues, date);
     deleteExact(data.markerValueNotes, date);
+    deleteExact(data.markerLabels, date);
+    deleteExact(data.refOverrides, date);
   } else {
     deleteAll(data.manualValues);
     deleteAll(data.markerValueNotes);
+    deleteAll(data.markerLabels);
+    deleteAll(data.refOverrides);
   }
 }
 

--- a/js/profile.js
+++ b/js/profile.js
@@ -447,34 +447,96 @@ function _entrySourceText(entry) {
   return parts.join(' ');
 }
 
-function _remapDateScopedProfileMarkerData(data, oldKey, nextKey, date) {
-  if (!date) return;
-  const remapExact = (obj) => {
+function _copyDateScopedProfileMarkerData(data, oldKey, nextKey, date = null) {
+  const copyExact = (obj, scopedDate) => {
     if (!obj) return;
-    const from = `${oldKey}:${date}`;
-    const to = `${nextKey}:${date}`;
+    const from = `${oldKey}:${scopedDate}`;
+    const to = `${nextKey}:${scopedDate}`;
     if (obj[from] !== undefined && obj[to] === undefined) obj[to] = obj[from];
-    delete obj[from];
   };
-  remapExact(data.manualValues);
-  remapExact(data.markerValueNotes);
+  const copyAll = (obj) => {
+    if (!obj) return;
+    const prefix = `${oldKey}:`;
+    for (const key of Object.keys(obj)) {
+      if (!key.startsWith(prefix)) continue;
+      const to = `${nextKey}:${key.slice(prefix.length)}`;
+      if (obj[to] === undefined) obj[to] = obj[key];
+    }
+  };
+  if (date) {
+    copyExact(data.manualValues, date);
+    copyExact(data.markerValueNotes, date);
+  } else {
+    copyAll(data.manualValues);
+    copyAll(data.markerValueNotes);
+  }
 }
 
-function _remapGlobalProfileMarkerData(data, oldKey, nextKey) {
-  if (data.refOverrides?.[oldKey]) {
-    if (!data.refOverrides[nextKey]) data.refOverrides[nextKey] = data.refOverrides[oldKey];
-    delete data.refOverrides[oldKey];
+function _deleteDateScopedProfileMarkerData(data, oldKey, date = null) {
+  const deleteExact = (obj, scopedDate) => {
+    if (!obj) return;
+    delete obj[`${oldKey}:${scopedDate}`];
+  };
+  const deleteAll = (obj) => {
+    if (!obj) return;
+    const prefix = `${oldKey}:`;
+    for (const key of Object.keys(obj)) {
+      if (key.startsWith(prefix)) delete obj[key];
+    }
+  };
+  if (date) {
+    deleteExact(data.manualValues, date);
+    deleteExact(data.markerValueNotes, date);
+  } else {
+    deleteAll(data.manualValues);
+    deleteAll(data.markerValueNotes);
   }
+}
+
+function _copyGlobalProfileMarkerData(data, oldKey, nextKey) {
+  if (data.refOverrides?.[oldKey] && !data.refOverrides[nextKey]) data.refOverrides[nextKey] = data.refOverrides[oldKey];
   if (data.markerNotes?.[oldKey] && !data.markerNotes[nextKey]) data.markerNotes[nextKey] = data.markerNotes[oldKey];
-  if (data.markerNotes) delete data.markerNotes[oldKey];
   if (data.markerLabels?.[oldKey] && !data.markerLabels[nextKey]) data.markerLabels[nextKey] = data.markerLabels[oldKey];
+}
+
+function _deleteGlobalProfileMarkerData(data, oldKey) {
+  if (data.refOverrides) delete data.refOverrides[oldKey];
+  if (data.markerNotes) delete data.markerNotes[oldKey];
   if (data.markerLabels) delete data.markerLabels[oldKey];
 }
 
-function _profileHasMarkerKey(data, key) {
+function _profileHasStructuralMarkerKey(data, key) {
   if (data.entries?.some(entry => entry.markers && Object.prototype.hasOwnProperty.call(entry.markers, key))) return true;
   if (data.importSnapshots?.some(snap => Array.isArray(snap.markers) && snap.markers.some(m => m?.mappedKey === key || m?.suggestedKey === key))) return true;
-  return Object.keys(data.manualValues || {}).some(k => k.startsWith(`${key}:`));
+  return false;
+}
+
+function _profileHasStructuralMarkerKeyOnDate(data, key, date) {
+  if (!date) return _profileHasStructuralMarkerKey(data, key);
+  if (data.entries?.some(entry => entry.date === date && entry.markers && Object.prototype.hasOwnProperty.call(entry.markers, key))) return true;
+  if (data.importSnapshots?.some(snap => snap?.date === date && Array.isArray(snap.markers) && snap.markers.some(m => m?.mappedKey === key || m?.suggestedKey === key))) return true;
+  return false;
+}
+
+function _fattyAcidMarkerPart(key) {
+  const prefix = 'fattyAcids.';
+  if (!key?.startsWith(prefix)) return null;
+  const markerPart = key.slice(prefix.length);
+  return markerPart && !markerPart.includes('.') ? markerPart : null;
+}
+
+function _profileMarkerValuesMatch(a, b) {
+  if (a === b) return true;
+  const aNum = Number(a);
+  const bNum = Number(b);
+  return Number.isFinite(aNum) && Number.isFinite(bNum) && Math.abs(aNum - bNum) < 1e-9;
+}
+
+function _entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker) {
+  if (!entry?.markers || !Object.prototype.hasOwnProperty.call(entry.markers, oldKey)) return false;
+  if (snap?.id && entry.markerSources?.[oldKey]?.snapshotId === snap.id) return true;
+  if (_isSpadiaFattyAcidSource(_entrySourceText(entry))) return true;
+  return !!(snap?.date && entry.date === snap.date && _profileMarkerValuesMatch(entry.markers[oldKey], marker?.value));
 }
 
 function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {
@@ -491,11 +553,20 @@ function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {
   data.customMarkers[nextKey] = cmDef;
 }
 
+function _remapSpadiaFattyAcidEntry(data, entry, oldKey, nextKey) {
+  if (!renameLabEntryMarker(entry, oldKey, nextKey, { stamp: false })) return false;
+  _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
+  _copyDateScopedProfileMarkerData(data, oldKey, nextKey, entry.date);
+  if (entry.date && !_profileHasStructuralMarkerKeyOnDate(data, oldKey, entry.date)) {
+    _deleteDateScopedProfileMarkerData(data, oldKey, entry.date);
+  }
+  return true;
+}
+
 function _repairSpadiaFattyAcidKeys(data) {
   const renamedKeys = new Map();
   const remapKey = (oldKey) => {
-    if (!oldKey?.startsWith('fattyAcids.')) return null;
-    const markerPart = oldKey.split('.')[1];
+    const markerPart = _fattyAcidMarkerPart(oldKey);
     return markerPart ? `spadiaFA.${markerPart}` : null;
   };
   for (const entry of data.entries || []) {
@@ -503,10 +574,8 @@ function _repairSpadiaFattyAcidKeys(data) {
     for (const oldKey of Object.keys(entry.markers || {})) {
       const nextKey = remapKey(oldKey);
       if (!nextKey) continue;
-      if (renameLabEntryMarker(entry, oldKey, nextKey, { stamp: false })) {
+      if (_remapSpadiaFattyAcidEntry(data, entry, oldKey, nextKey)) {
         renamedKeys.set(oldKey, nextKey);
-        _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
-        _remapDateScopedProfileMarkerData(data, oldKey, nextKey, entry.date);
       }
     }
   }
@@ -528,11 +597,20 @@ function _repairSpadiaFattyAcidKeys(data) {
       marker.matched = true;
       renamedKeys.set(oldKey, nextKey);
       _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
+      _copyDateScopedProfileMarkerData(data, oldKey, nextKey, snap?.date);
+      for (const entry of data.entries || []) {
+        if (_entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker)
+          && _remapSpadiaFattyAcidEntry(data, entry, oldKey, nextKey)) {
+          renamedKeys.set(oldKey, nextKey);
+        }
+      }
     }
   }
   for (const [oldKey, nextKey] of renamedKeys) {
-    if (_profileHasMarkerKey(data, oldKey)) continue;
-    _remapGlobalProfileMarkerData(data, oldKey, nextKey);
+    _copyGlobalProfileMarkerData(data, oldKey, nextKey);
+    if (_profileHasStructuralMarkerKey(data, oldKey)) continue;
+    _deleteDateScopedProfileMarkerData(data, oldKey);
+    _deleteGlobalProfileMarkerData(data, oldKey);
     if (data.customMarkers) delete data.customMarkers[oldKey];
   }
 }

--- a/js/profile.js
+++ b/js/profile.js
@@ -430,6 +430,113 @@ function _repairUnitSuffixedStandardMarkers(data) {
   for (const key of toDelete) delete data.customMarkers[key];
 }
 
+function _isSpadiaFattyAcidSource(value) {
+  const compact = _normalizeProfileMarkerLabel(value);
+  return compact.includes('spadia') && (compact.includes('fattyacid') || compact.includes('mastnekyseliny'));
+}
+
+function _entrySourceText(entry) {
+  const parts = [];
+  if (entry?.sourceFile) parts.push(entry.sourceFile);
+  if (Array.isArray(entry?.sourceFiles)) parts.push(...entry.sourceFiles);
+  if (entry?.markerSources && typeof entry.markerSources === 'object') {
+    for (const source of Object.values(entry.markerSources)) {
+      if (source?.file) parts.push(source.file);
+    }
+  }
+  return parts.join(' ');
+}
+
+function _remapDateScopedProfileMarkerData(data, oldKey, nextKey, date) {
+  if (!date) return;
+  const remapExact = (obj) => {
+    if (!obj) return;
+    const from = `${oldKey}:${date}`;
+    const to = `${nextKey}:${date}`;
+    if (obj[from] !== undefined && obj[to] === undefined) obj[to] = obj[from];
+    delete obj[from];
+  };
+  remapExact(data.manualValues);
+  remapExact(data.markerValueNotes);
+}
+
+function _remapGlobalProfileMarkerData(data, oldKey, nextKey) {
+  if (data.refOverrides?.[oldKey]) {
+    if (!data.refOverrides[nextKey]) data.refOverrides[nextKey] = data.refOverrides[oldKey];
+    delete data.refOverrides[oldKey];
+  }
+  if (data.markerNotes?.[oldKey] && !data.markerNotes[nextKey]) data.markerNotes[nextKey] = data.markerNotes[oldKey];
+  if (data.markerNotes) delete data.markerNotes[oldKey];
+  if (data.markerLabels?.[oldKey] && !data.markerLabels[nextKey]) data.markerLabels[nextKey] = data.markerLabels[oldKey];
+  if (data.markerLabels) delete data.markerLabels[oldKey];
+}
+
+function _profileHasMarkerKey(data, key) {
+  if (data.entries?.some(entry => entry.markers && Object.prototype.hasOwnProperty.call(entry.markers, key))) return true;
+  if (data.importSnapshots?.some(snap => Array.isArray(snap.markers) && snap.markers.some(m => m?.mappedKey === key || m?.suggestedKey === key))) return true;
+  return Object.keys(data.manualValues || {}).some(k => k.startsWith(`${key}:`));
+}
+
+function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {
+  if (!data.customMarkers) data.customMarkers = {};
+  const sourceDef = data.customMarkers[nextKey] || data.customMarkers[oldKey] || SPECIALTY_MARKER_DEFS[oldKey] || {};
+  const cmDef = data.customMarkers[nextKey] || {};
+  cmDef.name = cmDef.name || sourceDef.name || nextKey.split('.').pop();
+  cmDef.unit = cmDef.unit || sourceDef.unit || '%';
+  cmDef.refMin = cmDef.refMin != null ? cmDef.refMin : (sourceDef.refMin != null ? sourceDef.refMin : null);
+  cmDef.refMax = cmDef.refMax != null ? cmDef.refMax : (sourceDef.refMax != null ? sourceDef.refMax : null);
+  cmDef.icon = cmDef.icon || sourceDef.icon || SPECIALTY_MARKER_DEFS[oldKey]?.icon;
+  cmDef.categoryLabel = 'Spadia';
+  cmDef.group = 'Fatty Acids';
+  data.customMarkers[nextKey] = cmDef;
+}
+
+function _repairSpadiaFattyAcidKeys(data) {
+  const renamedKeys = new Map();
+  const remapKey = (oldKey) => {
+    if (!oldKey?.startsWith('fattyAcids.')) return null;
+    const markerPart = oldKey.split('.')[1];
+    return markerPart ? `spadiaFA.${markerPart}` : null;
+  };
+  for (const entry of data.entries || []) {
+    if (!_isSpadiaFattyAcidSource(_entrySourceText(entry))) continue;
+    for (const oldKey of Object.keys(entry.markers || {})) {
+      const nextKey = remapKey(oldKey);
+      if (!nextKey) continue;
+      if (renameLabEntryMarker(entry, oldKey, nextKey, { stamp: false })) {
+        renamedKeys.set(oldKey, nextKey);
+        _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
+        _remapDateScopedProfileMarkerData(data, oldKey, nextKey, entry.date);
+      }
+    }
+  }
+  for (const snap of data.importSnapshots || []) {
+    if (!_isSpadiaFattyAcidSource(snap?.fileName || '')) continue;
+    if (!Array.isArray(snap.markers)) continue;
+    for (const marker of snap.markers) {
+      const oldKey = marker?.mappedKey?.startsWith('fattyAcids.') ? marker.mappedKey
+        : marker?.suggestedKey?.startsWith('fattyAcids.') ? marker.suggestedKey
+          : null;
+      const nextKey = remapKey(oldKey);
+      if (!nextKey) continue;
+      const def = SPECIALTY_MARKER_DEFS[oldKey] || {};
+      marker.mappedKey = nextKey;
+      marker.suggestedKey = null;
+      marker.suggestedName = marker.suggestedName || def.name || marker.rawName;
+      marker.suggestedCategoryLabel = 'Spadia';
+      marker.suggestedGroup = 'Fatty Acids';
+      marker.matched = true;
+      renamedKeys.set(oldKey, nextKey);
+      _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
+    }
+  }
+  for (const [oldKey, nextKey] of renamedKeys) {
+    if (_profileHasMarkerKey(data, oldKey)) continue;
+    _remapGlobalProfileMarkerData(data, oldKey, nextKey);
+    if (data.customMarkers) delete data.customMarkers[oldKey];
+  }
+}
+
 /**
  * @param {string} profileId
  * @param {ProfileData | null} [importedData]
@@ -559,6 +666,9 @@ export function migrateProfileData(data) {
   // Repair AI-imported duplicate markers such as `ALP (ukat/l)` that were
   // stored as custom keys instead of the existing standard schema marker.
   _repairUnitSuffixedStandardMarkers(data);
+  // Repair generic fattyAcids.* rows created from Spadia fatty-acid imports
+  // before product-specific category normalization existed for blood-classified reports.
+  _repairSpadiaFattyAcidKeys(data);
   // Fix corrupted FA-prefixed standard markers (bug: _normalizeFattyAcidMarkers rewrote blood work to FA categories)
   if (data.customMarkers && data.entries?.length) {
     // Phase 1: relocate markers whose key matches a standard schema marker

--- a/js/profile.js
+++ b/js/profile.js
@@ -571,7 +571,10 @@ function _entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker) {
   if (!entry?.markers || !Object.prototype.hasOwnProperty.call(entry.markers, oldKey)) return false;
   if (snap?.id && entry.markerSources?.[oldKey]?.snapshotId === snap.id) return true;
   if (_isSpadiaFattyAcidSource(_entrySourceText(entry))) return true;
-  return !!(snap?.date && entry.date === snap.date && _profileMarkerValuesMatch(entry.markers[oldKey], marker?.value));
+  if (snap?.date) {
+    return entry.date === snap.date && _profileMarkerValuesMatch(entry.markers[oldKey], marker?.value);
+  }
+  return !entry.date && _profileMarkerValuesMatch(entry.markers[oldKey], marker?.value);
 }
 
 function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {

--- a/js/profile.js
+++ b/js/profile.js
@@ -430,17 +430,24 @@ function _repairUnitSuffixedStandardMarkers(data) {
   for (const key of toDelete) delete data.customMarkers[key];
 }
 
+function _hasPositiveSpadiaLabel(value) {
+  const compact = _normalizeProfileMarkerLabel(value);
+  if (!compact.includes('spadia')) return false;
+  const text = String(value || '').toLowerCase();
+  if (/\b(?:non|not|no|without)[\s_-]*spadia\b/.test(text)) return false;
+  return !/(?:non|not|no|without)spadia/.test(compact);
+}
+
 function _isSpadiaFattyAcidSource(value) {
   const compact = _normalizeProfileMarkerLabel(value);
-  return compact.includes('spadia') && (compact.includes('fattyacid') || compact.includes('mastnekyseliny'));
+  return _hasPositiveSpadiaLabel(value) && (compact.includes('fattyacid') || compact.includes('mastnekyseliny'));
 }
 
 function _isSpadiaFattyAcidMarkerMetadata(marker) {
   const key = marker?.mappedKey || marker?.suggestedKey || '';
   if (key.startsWith('spadiaFA.')) return true;
-  const label = _normalizeProfileMarkerLabel(marker?.suggestedCategoryLabel || '');
   const group = _normalizeProfileMarkerLabel(marker?.suggestedGroup || '');
-  return label.includes('spadia') && (!group || group.includes('fattyacid') || group.includes('mastnekyseliny'));
+  return _hasPositiveSpadiaLabel(marker?.suggestedCategoryLabel || '') && (!group || group.includes('fattyacid') || group.includes('mastnekyseliny'));
 }
 
 function _hasFattyAcidSnapshotMarker(snap) {
@@ -458,7 +465,7 @@ function _isSpadiaFattyAcidSnapshot(snap) {
   if (_isSpadiaFattyAcidSource(productText)) return true;
   const sourceText = `${snap?.sourceType || ''} ${snap?.sourceName || ''} ${snap?.sourceLabel || ''} ${snap?.source || ''}`;
   if (_isSpadiaFattyAcidSource(sourceText)) return true;
-  if (_normalizeProfileMarkerLabel(`${productText} ${sourceText}`).includes('spadia') && _hasFattyAcidSnapshotMarker(snap)) return true;
+  if (_hasPositiveSpadiaLabel(`${productText} ${sourceText}`) && _hasFattyAcidSnapshotMarker(snap)) return true;
   return Array.isArray(snap?.markers) && snap.markers.some(_isSpadiaFattyAcidMarkerMetadata);
 }
 
@@ -571,10 +578,9 @@ function _entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker) {
   if (!entry?.markers || !Object.prototype.hasOwnProperty.call(entry.markers, oldKey)) return false;
   if (snap?.id && entry.markerSources?.[oldKey]?.snapshotId === snap.id) return true;
   if (_isSpadiaFattyAcidSource(_entrySourceText(entry))) return true;
-  if (snap?.date) {
-    return entry.date === snap.date && _profileMarkerValuesMatch(entry.markers[oldKey], marker?.value);
-  }
-  return !entry.date && _profileMarkerValuesMatch(entry.markers[oldKey], marker?.value);
+  if (!_profileMarkerValuesMatch(entry.markers[oldKey], marker?.value)) return false;
+  if (snap?.date && entry.date) return entry.date === snap.date;
+  return !entry.date;
 }
 
 function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {

--- a/js/profile.js
+++ b/js/profile.js
@@ -459,13 +459,28 @@ function _hasFattyAcidSnapshotMarker(snap) {
   });
 }
 
+function _snapshotSourceText(snap) {
+  const parts = [];
+  if (snap?.fileName) parts.push(snap.fileName);
+  if (snap?.sourceFile) parts.push(snap.sourceFile);
+  if (Array.isArray(snap?.sourceFiles)) parts.push(...snap.sourceFiles);
+  if (snap?.sourceType) parts.push(snap.sourceType);
+  if (snap?.sourceName) parts.push(snap.sourceName);
+  if (snap?.sourceLabel) parts.push(snap.sourceLabel);
+  if (snap?.source) parts.push(snap.source);
+  if (snap?.importer) parts.push(snap.importer);
+  if (snap?.importerName) parts.push(snap.importerName);
+  return parts.join(' ');
+}
+
 function _isSpadiaFattyAcidSnapshot(snap) {
-  if (_isSpadiaFattyAcidSource(snap?.fileName || '')) return true;
+  const fileText = `${snap?.fileName || ''} ${snap?.sourceFile || ''} ${Array.isArray(snap?.sourceFiles) ? snap.sourceFiles.join(' ') : ''}`;
+  if (_isSpadiaFattyAcidSource(fileText)) return true;
   const productText = `${snap?.labName || ''} ${snap?.productLabel || ''}`;
   if (_isSpadiaFattyAcidSource(productText)) return true;
-  const sourceText = `${snap?.sourceType || ''} ${snap?.sourceName || ''} ${snap?.sourceLabel || ''} ${snap?.source || ''}`;
+  const sourceText = _snapshotSourceText(snap);
   if (_isSpadiaFattyAcidSource(sourceText)) return true;
-  if (_hasPositiveSpadiaLabel(`${productText} ${sourceText}`) && _hasFattyAcidSnapshotMarker(snap)) return true;
+  if (_hasPositiveSpadiaLabel(`${fileText} ${productText} ${sourceText}`) && _hasFattyAcidSnapshotMarker(snap)) return true;
   return Array.isArray(snap?.markers) && snap.markers.some(_isSpadiaFattyAcidMarkerMetadata);
 }
 
@@ -580,6 +595,7 @@ function _entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker) {
   if (_isSpadiaFattyAcidSource(_entrySourceText(entry))) return true;
   if (!_profileMarkerValuesMatch(entry.markers[oldKey], marker?.value)) return false;
   if (snap?.date && entry.date) return entry.date === snap.date;
+  if (!entry.date && _entrySourceText(entry)) return false;
   return !entry.date;
 }
 
@@ -603,7 +619,9 @@ function _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey) {
 function _remapSpadiaFattyAcidEntry(data, entry, oldKey, nextKey) {
   if (!renameLabEntryMarker(entry, oldKey, nextKey, { stamp: false })) return false;
   _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
-  _copyDateScopedProfileMarkerData(data, oldKey, nextKey, entry.date);
+  if (entry.date) {
+    _copyDateScopedProfileMarkerData(data, oldKey, nextKey, entry.date);
+  }
   if (entry.date && !_profileHasStructuralMarkerKeyOnDate(data, oldKey, entry.date)) {
     _deleteDateScopedProfileMarkerData(data, oldKey, entry.date);
   }
@@ -644,7 +662,9 @@ function _repairSpadiaFattyAcidKeys(data) {
       marker.matched = true;
       renamedKeys.set(oldKey, nextKey);
       _ensureSpadiaFattyAcidCustomMarker(data, oldKey, nextKey);
-      _copyDateScopedProfileMarkerData(data, oldKey, nextKey, snap?.date);
+      if (snap?.date) {
+        _copyDateScopedProfileMarkerData(data, oldKey, nextKey, snap.date);
+      }
       for (const entry of data.entries || []) {
         if (_entryMatchesSpadiaSnapshotMarker(entry, snap, oldKey, marker)
           && _remapSpadiaFattyAcidEntry(data, entry, oldKey, nextKey)) {

--- a/js/profile.js
+++ b/js/profile.js
@@ -443,9 +443,22 @@ function _isSpadiaFattyAcidMarkerMetadata(marker) {
   return label.includes('spadia') && (!group || group.includes('fattyacid') || group.includes('mastnekyseliny'));
 }
 
+function _hasFattyAcidSnapshotMarker(snap) {
+  return Array.isArray(snap?.markers) && snap.markers.some(marker => {
+    const key = marker?.mappedKey || marker?.suggestedKey || '';
+    if (_fattyAcidMarkerPart(key) || key.startsWith('spadiaFA.')) return true;
+    const group = _normalizeProfileMarkerLabel(marker?.suggestedGroup || '');
+    return group.includes('fattyacid') || group.includes('mastnekyseliny');
+  });
+}
+
 function _isSpadiaFattyAcidSnapshot(snap) {
   if (_isSpadiaFattyAcidSource(snap?.fileName || '')) return true;
-  if (_isSpadiaFattyAcidSource(`${snap?.labName || ''} ${snap?.productLabel || ''}`)) return true;
+  const productText = `${snap?.labName || ''} ${snap?.productLabel || ''}`;
+  if (_isSpadiaFattyAcidSource(productText)) return true;
+  const sourceText = `${snap?.sourceType || ''} ${snap?.sourceName || ''} ${snap?.sourceLabel || ''} ${snap?.source || ''}`;
+  if (_isSpadiaFattyAcidSource(sourceText)) return true;
+  if (_normalizeProfileMarkerLabel(`${productText} ${sourceText}`).includes('spadia') && _hasFattyAcidSnapshotMarker(snap)) return true;
   return Array.isArray(snap?.markers) && snap.markers.some(_isSpadiaFattyAcidMarkerMetadata);
 }
 
@@ -536,7 +549,7 @@ function _profileHasStructuralMarkerKey(data, key) {
 function _profileHasStructuralMarkerKeyOnDate(data, key, date) {
   if (!date) return _profileHasStructuralMarkerKey(data, key);
   if (data.entries?.some(entry => entry.date === date && entry.markers && Object.prototype.hasOwnProperty.call(entry.markers, key))) return true;
-  if (data.importSnapshots?.some(snap => snap?.date === date && Array.isArray(snap.markers) && snap.markers.some(m => m?.mappedKey === key || m?.suggestedKey === key))) return true;
+  if (data.importSnapshots?.some(snap => (!snap?.date || snap.date === date) && Array.isArray(snap.markers) && snap.markers.some(m => m?.mappedKey === key || m?.suggestedKey === key))) return true;
   return false;
 }
 

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -353,6 +353,34 @@ const importCssSrc = read('css/import.css');
   assert('Guard checks testType !== blood',
     normalizationSrc.includes("testType !== 'blood'") && normalizationSrc.includes('Import Guard'));
 
+  const { normalizeParsedImportMarkers } = await import('../js/pdf-import-marker-normalization.js');
+  const spadiaImport = normalizeParsedImportMarkers({
+    testType: 'blood',
+    markers: [
+      { rawName: 'B Kyselina eikosapentaenová C20:5', value: 0.90, mappedKey: 'fattyAcids.epaC20_5', unit: '%', refMin: 3.23, refMax: 4.72 },
+      { rawName: 'S Vitamin A', value: 2.39, mappedKey: 'vitamins.vitaminA', unit: 'µmol/l', refMin: 1.05, refMax: 2.80 },
+    ],
+  }, {
+    fileName: 'Spadia 7-2024 Fatty Acids.pdf',
+    sourceText: 'SPADIA LAB a. s. Mastné kyseliny',
+    existingKeys: new Set(),
+  });
+  const spadiaFA = spadiaImport.markers[0];
+  const spadiaVitaminA = spadiaImport.markers[1];
+  assert('Blood-classified Spadia generic FA key is product-prefixed',
+    spadiaFA
+      && spadiaFA.matched === false
+      && spadiaFA.mappedKey === null
+      && spadiaFA.suggestedKey === 'spadiaFA.epaC20_5'
+      && spadiaFA.suggestedCategoryLabel === 'Spadia'
+      && spadiaFA.group === 'Fatty Acids',
+    JSON.stringify(spadiaFA));
+  assert('Blood-classified Spadia report keeps true blood markers mapped',
+    spadiaVitaminA
+      && spadiaVitaminA.matched === true
+      && spadiaVitaminA.mappedKey === 'vitamins.vitaminA',
+    JSON.stringify(spadiaVitaminA));
+
   // ═══════════════════════════════════════
   // 7. Import mapping reconciliation
   // ═══════════════════════════════════════
@@ -576,6 +604,71 @@ const importCssSrc = read('css/import.css');
   assert('Profile migration canonicalizes named Lipoprotein A custom duplicates',
     lipidNameAlias.entries[0].markers['lipids.lpA'] === 55
     && lipidNameAlias.customMarkers['lipids.lipoproteinMarker'] === undefined);
+
+  const savedSpadiaFA = {
+    entries: [{
+      date: '2024-07-04',
+      sourceFile: 'Spadia 7-2024 Fatty Acids.pdf',
+      sourceFiles: ['Spadia 7-2024 Fatty Acids.pdf'],
+      markers: { 'fattyAcids.epaC20_5': 0.90, 'vitamins.vitaminA': 2.39 },
+      markerSources: {
+        'fattyAcids.epaC20_5': { file: 'Spadia 7-2024 Fatty Acids.pdf', snapshotId: 'snap_spadia' },
+        'vitamins.vitaminA': { file: 'Spadia 7-2024 Fatty Acids.pdf', snapshotId: 'snap_spadia' },
+      },
+    }],
+    customMarkers: {
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', refMin: 3.23, refMax: 4.72, categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia',
+      fileName: 'Spadia 7-2024 Fatty Acids.pdf',
+      date: '2024-07-04',
+      markers: [
+        { rawName: 'B Kyselina eikosapentaenová C20:5', value: 0.90, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, matched: true },
+        { rawName: 'S Vitamin A', value: 2.39, unit: 'µmol/l', mappedKey: 'vitamins.vitaminA', suggestedKey: null, matched: true },
+      ],
+    }],
+    markerValueNotes: { 'fattyAcids.epaC20_5:2024-07-04': 'already imported note' },
+    markerLabels: { 'fattyAcids.epaC20_5': 'EPA label' },
+  };
+  migrateProfileData(savedSpadiaFA);
+  assert('Profile migration moves saved Spadia generic FA marker to spadiaFA',
+    savedSpadiaFA.entries[0].markers['spadiaFA.epaC20_5'] === 0.90
+    && savedSpadiaFA.entries[0].markers['fattyAcids.epaC20_5'] === undefined);
+  assert('Profile migration preserves standard markers in saved Spadia report',
+    savedSpadiaFA.entries[0].markers['vitamins.vitaminA'] === 2.39);
+  assert('Profile migration remaps Spadia marker source metadata',
+    savedSpadiaFA.entries[0].markerSources['spadiaFA.epaC20_5']?.snapshotId === 'snap_spadia'
+    && savedSpadiaFA.entries[0].markerSources['fattyAcids.epaC20_5'] === undefined);
+  assert('Profile migration creates Spadia category metadata',
+    savedSpadiaFA.customMarkers['spadiaFA.epaC20_5']?.categoryLabel === 'Spadia'
+    && savedSpadiaFA.customMarkers['spadiaFA.epaC20_5']?.group === 'Fatty Acids'
+    && savedSpadiaFA.customMarkers['fattyAcids.epaC20_5'] === undefined);
+  assert('Profile migration remaps saved Spadia import snapshot marker',
+    savedSpadiaFA.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.epaC20_5'
+    && savedSpadiaFA.importSnapshots[0].markers[0].suggestedCategoryLabel === 'Spadia'
+    && savedSpadiaFA.importSnapshots[0].markers[1].mappedKey === 'vitamins.vitaminA');
+  assert('Profile migration remaps saved Spadia marker notes and labels',
+    savedSpadiaFA.markerValueNotes['spadiaFA.epaC20_5:2024-07-04'] === 'already imported note'
+    && savedSpadiaFA.markerLabels['spadiaFA.epaC20_5'] === 'EPA label'
+    && savedSpadiaFA.markerValueNotes['fattyAcids.epaC20_5:2024-07-04'] === undefined
+    && savedSpadiaFA.markerLabels['fattyAcids.epaC20_5'] === undefined);
+
+  const savedGenericFA = {
+    entries: [{
+      date: '2024-07-04',
+      sourceFile: 'Other Lab Fatty Acids.pdf',
+      markers: { 'fattyAcids.epaC20_5': 0.90 },
+    }],
+    customMarkers: {
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+  };
+  migrateProfileData(savedGenericFA);
+  assert('Profile migration leaves non-Spadia generic FA marker unchanged',
+    savedGenericFA.entries[0].markers['fattyAcids.epaC20_5'] === 0.90
+    && savedGenericFA.entries[0].markers['spadiaFA.epaC20_5'] === undefined
+    && savedGenericFA.customMarkers['fattyAcids.epaC20_5']);
 
   // ═══════════════════════════════════════
   // Results

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -798,6 +798,14 @@ const importCssSrc = read('css/import.css');
       'fattyAcids.omega3Index:2024-07-01': 'import date note',
       'fattyAcids.omega3Index:2024-07-04': 'nearby manual note',
     },
+    markerLabels: {
+      'fattyAcids.omega3Index:2024-07-01': 'import date label',
+      'fattyAcids.omega3Index:2024-07-04': 'nearby manual label',
+    },
+    refOverrides: {
+      'fattyAcids.omega3Index:2024-07-01': { min: 8, max: 12 },
+      'fattyAcids.omega3Index:2024-07-04': { min: 7, max: 11 },
+    },
   };
   migrateProfileData(spadiaScopedCleanup);
   assert('Profile migration preserves all scoped metadata before generic Spadia cleanup',
@@ -806,10 +814,18 @@ const importCssSrc = read('css/import.css');
     && spadiaScopedCleanup.manualValues['spadiaFA.omega3Index:2024-07-04'] === 7.4
     && spadiaScopedCleanup.markerValueNotes['spadiaFA.omega3Index:2024-07-01'] === 'import date note'
     && spadiaScopedCleanup.markerValueNotes['spadiaFA.omega3Index:2024-07-04'] === 'nearby manual note'
+    && spadiaScopedCleanup.markerLabels['spadiaFA.omega3Index:2024-07-01'] === 'import date label'
+    && spadiaScopedCleanup.markerLabels['spadiaFA.omega3Index:2024-07-04'] === 'nearby manual label'
+    && spadiaScopedCleanup.refOverrides['spadiaFA.omega3Index:2024-07-01']?.min === 8
+    && spadiaScopedCleanup.refOverrides['spadiaFA.omega3Index:2024-07-04']?.min === 7
     && spadiaScopedCleanup.manualValues['fattyAcids.omega3Index:2024-07-01'] === undefined
     && spadiaScopedCleanup.manualValues['fattyAcids.omega3Index:2024-07-04'] === undefined
     && spadiaScopedCleanup.markerValueNotes['fattyAcids.omega3Index:2024-07-01'] === undefined
-    && spadiaScopedCleanup.markerValueNotes['fattyAcids.omega3Index:2024-07-04'] === undefined);
+    && spadiaScopedCleanup.markerValueNotes['fattyAcids.omega3Index:2024-07-04'] === undefined
+    && spadiaScopedCleanup.markerLabels['fattyAcids.omega3Index:2024-07-01'] === undefined
+    && spadiaScopedCleanup.markerLabels['fattyAcids.omega3Index:2024-07-04'] === undefined
+    && spadiaScopedCleanup.refOverrides['fattyAcids.omega3Index:2024-07-01'] === undefined
+    && spadiaScopedCleanup.refOverrides['fattyAcids.omega3Index:2024-07-04'] === undefined);
 
   // ═══════════════════════════════════════
   // Results

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -689,6 +689,40 @@ const importCssSrc = read('css/import.css');
     && savedGenericFA.entries[0].markers['spadiaFA.epaC20_5'] === undefined
     && savedGenericFA.customMarkers['fattyAcids.epaC20_5']);
 
+  const negatedSpadiaSourceMetadata = {
+    entries: [{
+      date: '2026-01-20',
+      sourceFile: 'Non-Spadia generic fatty acids.csv',
+      markers: { 'fattyAcids.epaC20_5': 0.50 },
+      markerSources: {
+        'fattyAcids.epaC20_5': { file: 'Non-Spadia generic fatty acids.csv', snapshotId: 'snap_non_spadia_generic' },
+      },
+    }],
+    customMarkers: {
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_non_spadia_generic',
+      fileName: 'Non-Spadia generic fatty acids.csv',
+      labName: 'Non-Spadia Lab',
+      sourceName: 'Non-Spadia generic fatty acids',
+      date: '2026-01-20',
+      markers: [
+        { rawName: 'EPA C20:5', value: 0.50, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, suggestedCategoryLabel: 'Fatty Acids', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
+    markerValueNotes: { 'fattyAcids.epaC20_5:2026-01-20': 'generic note' },
+  };
+  migrateProfileData(negatedSpadiaSourceMetadata);
+  assert('Profile migration does not treat negated Spadia source metadata as Spadia',
+    negatedSpadiaSourceMetadata.entries[0].markers['fattyAcids.epaC20_5'] === 0.50
+    && negatedSpadiaSourceMetadata.entries[0].markers['spadiaFA.epaC20_5'] === undefined
+    && negatedSpadiaSourceMetadata.entries[0].markerSources['fattyAcids.epaC20_5']?.snapshotId === 'snap_non_spadia_generic'
+    && negatedSpadiaSourceMetadata.importSnapshots[0].markers[0].mappedKey === 'fattyAcids.epaC20_5'
+    && negatedSpadiaSourceMetadata.markerValueNotes['fattyAcids.epaC20_5:2026-01-20'] === 'generic note'
+    && negatedSpadiaSourceMetadata.markerValueNotes['spadiaFA.epaC20_5:2026-01-20'] === undefined
+    && negatedSpadiaSourceMetadata.customMarkers['fattyAcids.epaC20_5']);
+
   const sharedGenericAndSpadiaFA = {
     entries: [
       {
@@ -836,6 +870,32 @@ const importCssSrc = read('css/import.css');
     && datelessSpadiaSnapshotNoEntrySource.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.epaC20_5'
     && datelessSpadiaSnapshotNoEntrySource.customMarkers['spadiaFA.epaC20_5']?.categoryLabel === 'Spadia'
     && datelessSpadiaSnapshotNoEntrySource.customMarkers['fattyAcids.epaC20_5'] === undefined);
+
+  const datedSpadiaSnapshotDatelessEntry = {
+    entries: [{
+      markers: { 'fattyAcids.epaC20_5': 0.90 },
+    }],
+    customMarkers: {
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_dated_dateless_entry',
+      fileName: 'EDG328K.pdf',
+      date: '2024-07-04',
+      markers: [
+        { rawName: 'EPA C20:5', value: 0.90, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
+    markerValueNotes: { 'fattyAcids.epaC20_5:2024-07-04': 'dated snapshot note' },
+  };
+  migrateProfileData(datedSpadiaSnapshotDatelessEntry);
+  assert('Profile migration value-matches dated Spadia snapshots to dateless entries without source metadata',
+    datedSpadiaSnapshotDatelessEntry.entries[0].markers['spadiaFA.epaC20_5'] === 0.90
+    && datedSpadiaSnapshotDatelessEntry.entries[0].markers['fattyAcids.epaC20_5'] === undefined
+    && datedSpadiaSnapshotDatelessEntry.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.epaC20_5'
+    && datedSpadiaSnapshotDatelessEntry.markerValueNotes['spadiaFA.epaC20_5:2024-07-04'] === 'dated snapshot note'
+    && datedSpadiaSnapshotDatelessEntry.markerValueNotes['fattyAcids.epaC20_5:2024-07-04'] === undefined
+    && datedSpadiaSnapshotDatelessEntry.customMarkers['fattyAcids.epaC20_5'] === undefined);
 
   const spadiaScopedCleanup = {
     entries: [{

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -384,12 +384,13 @@ const importCssSrc = read('css/import.css');
       && spadiaVitaminA.matched === true
       && spadiaVitaminA.mappedKey === 'vitamins.vitaminA',
     JSON.stringify(spadiaVitaminA));
-  assert('Blood-classified Spadia guard does not invent unknown product FA keys',
+  assert('Blood-classified Spadia guard product-prefixes unknown generic FA keys',
     spadiaUnknownFA
       && spadiaUnknownFA.matched === false
       && spadiaUnknownFA.mappedKey === null
-      && spadiaUnknownFA.suggestedKey === 'fattyAcids.epa'
-      && spadiaUnknownFA.suggestedKey !== 'spadiaFA.epa',
+      && spadiaUnknownFA.suggestedKey === 'spadiaFA.epa'
+      && spadiaUnknownFA.suggestedCategoryLabel === 'Spadia'
+      && spadiaUnknownFA.group === 'Fatty Acids',
     JSON.stringify(spadiaUnknownFA));
   assert('Blood-classified Spadia guard demotes malformed generic FA keys',
     spadiaMalformedFA

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -362,7 +362,7 @@ const importCssSrc = read('css/import.css');
       { rawName: 'Unknown FA Segment', value: 1.23, mappedKey: 'fattyAcids.epa', unit: '%' },
     ],
   }, {
-    fileName: 'Spadia 7-2024 Fatty Acids.pdf',
+    fileName: 'EDG328K.pdf',
     sourceText: 'SPADIA LAB a. s. Mastné kyseliny',
     existingKeys: new Set(),
   });
@@ -617,12 +617,12 @@ const importCssSrc = read('css/import.css');
   const savedSpadiaFA = {
     entries: [{
       date: '2024-07-04',
-      sourceFile: 'Spadia 7-2024 Fatty Acids.pdf',
-      sourceFiles: ['Spadia 7-2024 Fatty Acids.pdf'],
+      sourceFile: 'EDG328K.pdf',
+      sourceFiles: ['EDG328K.pdf'],
       markers: { 'fattyAcids.epaC20_5': 0.90, 'vitamins.vitaminA': 2.39 },
       markerSources: {
-        'fattyAcids.epaC20_5': { file: 'Spadia 7-2024 Fatty Acids.pdf', snapshotId: 'snap_spadia' },
-        'vitamins.vitaminA': { file: 'Spadia 7-2024 Fatty Acids.pdf', snapshotId: 'snap_spadia' },
+        'fattyAcids.epaC20_5': { file: 'EDG328K.pdf', snapshotId: 'snap_spadia' },
+        'vitamins.vitaminA': { file: 'EDG328K.pdf', snapshotId: 'snap_spadia' },
       },
     }],
     customMarkers: {
@@ -630,10 +630,10 @@ const importCssSrc = read('css/import.css');
     },
     importSnapshots: [{
       id: 'snap_spadia',
-      fileName: 'Spadia 7-2024 Fatty Acids.pdf',
+      fileName: 'EDG328K.pdf',
       date: '2024-07-04',
       markers: [
-        { rawName: 'B Kyselina eikosapentaenová C20:5', value: 0.90, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, matched: true },
+        { rawName: 'B Kyselina eikosapentaenová C20:5', value: 0.90, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
         { rawName: 'S Vitamin A', value: 2.39, unit: 'µmol/l', mappedKey: 'vitamins.vitaminA', suggestedKey: null, matched: true },
       ],
     }],
@@ -683,8 +683,9 @@ const importCssSrc = read('css/import.css');
     entries: [
       {
         date: '2024-07-04',
-        sourceFile: 'Spadia 7-2024 Fatty Acids.pdf',
+        sourceFile: 'EDG328K.pdf',
         markers: { 'fattyAcids.omega3Index': 7.1 },
+        markerSources: { 'fattyAcids.omega3Index': { file: 'EDG328K.pdf', snapshotId: 'snap_spadia_shared' } },
       },
       {
         date: '2024-08-04',
@@ -698,6 +699,14 @@ const importCssSrc = read('css/import.css');
     markerNotes: { 'fattyAcids.omega3Index': 'global note' },
     markerLabels: { 'fattyAcids.omega3Index': 'Omega label' },
     refOverrides: { 'fattyAcids.omega3Index': { min: 8, max: 12 } },
+    importSnapshots: [{
+      id: 'snap_spadia_shared',
+      fileName: 'EDG328K.pdf',
+      date: '2024-07-04',
+      markers: [
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
   };
   migrateProfileData(sharedGenericAndSpadiaFA);
   assert('Profile migration copies global metadata when generic FA key is still shared',
@@ -723,10 +732,10 @@ const importCssSrc = read('css/import.css');
     },
     importSnapshots: [{
       id: 'snap_spadia_omega3',
-      fileName: 'Spadia 7-2024 Fatty Acids.pdf',
+      fileName: 'EDG328K.pdf',
       date: '2024-07-04',
       markers: [
-        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, matched: true },
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
       ],
     }],
   };
@@ -738,12 +747,20 @@ const importCssSrc = read('css/import.css');
 
   const datelessSpadiaFA = {
     entries: [{
-      sourceFile: 'Spadia 7-2024 Fatty Acids.pdf',
+      sourceFile: 'EDG328K.pdf',
       markers: { 'fattyAcids.omega3Index': 7.1 },
+      markerSources: { 'fattyAcids.omega3Index': { file: 'EDG328K.pdf', snapshotId: 'snap_spadia_dateless' } },
     }],
     customMarkers: {
       'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
     },
+    importSnapshots: [{
+      id: 'snap_spadia_dateless',
+      fileName: 'EDG328K.pdf',
+      markers: [
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
     manualValues: { 'fattyAcids.omega3Index:2024-07-04': 7.3 },
     markerValueNotes: { 'fattyAcids.omega3Index:2024-07-04': 'dateless note' },
   };
@@ -754,6 +771,45 @@ const importCssSrc = read('css/import.css');
     && datelessSpadiaFA.markerValueNotes['spadiaFA.omega3Index:2024-07-04'] === 'dateless note'
     && datelessSpadiaFA.manualValues['fattyAcids.omega3Index:2024-07-04'] === undefined
     && datelessSpadiaFA.markerValueNotes['fattyAcids.omega3Index:2024-07-04'] === undefined);
+
+  const spadiaScopedCleanup = {
+    entries: [{
+      date: '2024-07-01',
+      sourceFile: 'EDG328K.pdf',
+      markers: { 'fattyAcids.omega3Index': 7.1 },
+      markerSources: { 'fattyAcids.omega3Index': { file: 'EDG328K.pdf', snapshotId: 'snap_spadia_cleanup' } },
+    }],
+    customMarkers: {
+      'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_cleanup',
+      fileName: 'EDG328K.pdf',
+      date: '2024-07-01',
+      markers: [
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
+    manualValues: {
+      'fattyAcids.omega3Index:2024-07-01': 7.1,
+      'fattyAcids.omega3Index:2024-07-04': 7.4,
+    },
+    markerValueNotes: {
+      'fattyAcids.omega3Index:2024-07-01': 'import date note',
+      'fattyAcids.omega3Index:2024-07-04': 'nearby manual note',
+    },
+  };
+  migrateProfileData(spadiaScopedCleanup);
+  assert('Profile migration preserves all scoped metadata before generic Spadia cleanup',
+    spadiaScopedCleanup.entries[0].markers['spadiaFA.omega3Index'] === 7.1
+    && spadiaScopedCleanup.manualValues['spadiaFA.omega3Index:2024-07-01'] === 7.1
+    && spadiaScopedCleanup.manualValues['spadiaFA.omega3Index:2024-07-04'] === 7.4
+    && spadiaScopedCleanup.markerValueNotes['spadiaFA.omega3Index:2024-07-01'] === 'import date note'
+    && spadiaScopedCleanup.markerValueNotes['spadiaFA.omega3Index:2024-07-04'] === 'nearby manual note'
+    && spadiaScopedCleanup.manualValues['fattyAcids.omega3Index:2024-07-01'] === undefined
+    && spadiaScopedCleanup.manualValues['fattyAcids.omega3Index:2024-07-04'] === undefined
+    && spadiaScopedCleanup.markerValueNotes['fattyAcids.omega3Index:2024-07-01'] === undefined
+    && spadiaScopedCleanup.markerValueNotes['fattyAcids.omega3Index:2024-07-04'] === undefined);
 
   // ═══════════════════════════════════════
   // Results

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -821,6 +821,37 @@ const importCssSrc = read('css/import.css');
     && sourceNamedSpadiaSnapshot.markerValueNotes['fattyAcids.epaC20_5:2024-07-04'] === undefined
     && sourceNamedSpadiaSnapshot.customMarkers['fattyAcids.epaC20_5'] === undefined);
 
+  const sourceFileAttributedSpadiaSnapshot = {
+    entries: [{
+      date: '2024-05-10',
+      sourceFile: 'Fatty Acids.pdf',
+      markers: { 'fattyAcids.epaC20_5': 0.90 },
+      markerSources: { 'fattyAcids.epaC20_5': { file: 'Fatty Acids.pdf', snapshotId: 'snap_spadia_source_file' } },
+    }],
+    customMarkers: {
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_source_file',
+      fileName: 'EDG328K.pdf',
+      sourceFile: 'Spadia 7-2024 Fatty Acids.pdf',
+      importer: 'spadia',
+      date: '2024-05-10',
+      markers: [
+        { rawName: 'EPA C20:5', value: 0.90, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, matched: true },
+      ],
+    }],
+    markerValueNotes: { 'fattyAcids.epaC20_5:2024-05-10': 'source file note' },
+  };
+  migrateProfileData(sourceFileAttributedSpadiaSnapshot);
+  assert('Profile migration uses Spadia snapshot sourceFile and importer metadata',
+    sourceFileAttributedSpadiaSnapshot.entries[0].markers['spadiaFA.epaC20_5'] === 0.90
+    && sourceFileAttributedSpadiaSnapshot.entries[0].markers['fattyAcids.epaC20_5'] === undefined
+    && sourceFileAttributedSpadiaSnapshot.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.epaC20_5'
+    && sourceFileAttributedSpadiaSnapshot.markerValueNotes['spadiaFA.epaC20_5:2024-05-10'] === 'source file note'
+    && sourceFileAttributedSpadiaSnapshot.markerValueNotes['fattyAcids.epaC20_5:2024-05-10'] === undefined
+    && sourceFileAttributedSpadiaSnapshot.customMarkers['fattyAcids.epaC20_5'] === undefined);
+
   const datelessSpadiaFA = {
     entries: [{
       sourceFile: 'EDG328K.pdf',
@@ -896,6 +927,70 @@ const importCssSrc = read('css/import.css');
     && datedSpadiaSnapshotDatelessEntry.markerValueNotes['spadiaFA.epaC20_5:2024-07-04'] === 'dated snapshot note'
     && datedSpadiaSnapshotDatelessEntry.markerValueNotes['fattyAcids.epaC20_5:2024-07-04'] === undefined
     && datedSpadiaSnapshotDatelessEntry.customMarkers['fattyAcids.epaC20_5'] === undefined);
+
+  const datelessSpadiaSnapshotGenericPeer = {
+    entries: [{
+      sourceFile: 'Other Lab Fatty Acids.pdf',
+      markers: { 'fattyAcids.omega3Index': 7.1 },
+    }],
+    customMarkers: {
+      'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_dateless_generic_peer',
+      fileName: 'EDG328K.pdf',
+      markers: [
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
+  };
+  migrateProfileData(datelessSpadiaSnapshotGenericPeer);
+  assert('Profile migration does not value-match dateless generic source peers into Spadia',
+    datelessSpadiaSnapshotGenericPeer.entries[0].markers['fattyAcids.omega3Index'] === 7.1
+    && datelessSpadiaSnapshotGenericPeer.entries[0].markers['spadiaFA.omega3Index'] === undefined
+    && datelessSpadiaSnapshotGenericPeer.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.omega3Index'
+    && datelessSpadiaSnapshotGenericPeer.customMarkers['fattyAcids.omega3Index']);
+
+  const undatedSpadiaSnapshotSharedScopedData = {
+    entries: [
+      {
+        sourceFile: 'Fatty Acids.pdf',
+        markers: { 'fattyAcids.omega3Index': 7.1 },
+        markerSources: { 'fattyAcids.omega3Index': { file: 'Fatty Acids.pdf', snapshotId: 'snap_spadia_undated_shared_scope' } },
+      },
+      {
+        date: '2024-08-01',
+        sourceFile: 'Other Lab Fatty Acids.pdf',
+        markers: { 'fattyAcids.omega3Index': 6.8 },
+      },
+    ],
+    customMarkers: {
+      'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_undated_shared_scope',
+      fileName: 'EDG328K.pdf',
+      markers: [
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
+    manualValues: { 'fattyAcids.omega3Index:2024-08-01': 6.8 },
+    markerValueNotes: { 'fattyAcids.omega3Index:2024-08-01': 'generic dated note' },
+    markerLabels: { 'fattyAcids.omega3Index:2024-08-01': 'generic dated label' },
+    refOverrides: { 'fattyAcids.omega3Index:2024-08-01': { min: 6, max: 9 } },
+  };
+  migrateProfileData(undatedSpadiaSnapshotSharedScopedData);
+  assert('Profile migration does not copy undated Spadia snapshot metadata onto generic dated peers',
+    undatedSpadiaSnapshotSharedScopedData.entries[0].markers['spadiaFA.omega3Index'] === 7.1
+    && undatedSpadiaSnapshotSharedScopedData.entries[1].markers['fattyAcids.omega3Index'] === 6.8
+    && undatedSpadiaSnapshotSharedScopedData.manualValues['spadiaFA.omega3Index:2024-08-01'] === undefined
+    && undatedSpadiaSnapshotSharedScopedData.markerValueNotes['spadiaFA.omega3Index:2024-08-01'] === undefined
+    && undatedSpadiaSnapshotSharedScopedData.markerLabels['spadiaFA.omega3Index:2024-08-01'] === undefined
+    && undatedSpadiaSnapshotSharedScopedData.refOverrides['spadiaFA.omega3Index:2024-08-01'] === undefined
+    && undatedSpadiaSnapshotSharedScopedData.manualValues['fattyAcids.omega3Index:2024-08-01'] === 6.8
+    && undatedSpadiaSnapshotSharedScopedData.markerValueNotes['fattyAcids.omega3Index:2024-08-01'] === 'generic dated note'
+    && undatedSpadiaSnapshotSharedScopedData.markerLabels['fattyAcids.omega3Index:2024-08-01'] === 'generic dated label'
+    && undatedSpadiaSnapshotSharedScopedData.refOverrides['fattyAcids.omega3Index:2024-08-01']?.min === 6);
 
   const spadiaScopedCleanup = {
     entries: [{

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -359,6 +359,7 @@ const importCssSrc = read('css/import.css');
     markers: [
       { rawName: 'B Kyselina eikosapentaenová C20:5', value: 0.90, mappedKey: 'fattyAcids.epaC20_5', unit: '%', refMin: 3.23, refMax: 4.72 },
       { rawName: 'S Vitamin A', value: 2.39, mappedKey: 'vitamins.vitaminA', unit: 'µmol/l', refMin: 1.05, refMax: 2.80 },
+      { rawName: 'Unknown FA Segment', value: 1.23, mappedKey: 'fattyAcids.epa', unit: '%' },
     ],
   }, {
     fileName: 'Spadia 7-2024 Fatty Acids.pdf',
@@ -367,6 +368,7 @@ const importCssSrc = read('css/import.css');
   });
   const spadiaFA = spadiaImport.markers[0];
   const spadiaVitaminA = spadiaImport.markers[1];
+  const spadiaUnknownFA = spadiaImport.markers[2];
   assert('Blood-classified Spadia generic FA key is product-prefixed',
     spadiaFA
       && spadiaFA.matched === false
@@ -380,6 +382,13 @@ const importCssSrc = read('css/import.css');
       && spadiaVitaminA.matched === true
       && spadiaVitaminA.mappedKey === 'vitamins.vitaminA',
     JSON.stringify(spadiaVitaminA));
+  assert('Blood-classified Spadia guard does not invent unknown product FA keys',
+    spadiaUnknownFA
+      && spadiaUnknownFA.matched === false
+      && spadiaUnknownFA.mappedKey === null
+      && spadiaUnknownFA.suggestedKey === 'fattyAcids.epa'
+      && spadiaUnknownFA.suggestedKey !== 'spadiaFA.epa',
+    JSON.stringify(spadiaUnknownFA));
 
   // ═══════════════════════════════════════
   // 7. Import mapping reconciliation
@@ -669,6 +678,82 @@ const importCssSrc = read('css/import.css');
     savedGenericFA.entries[0].markers['fattyAcids.epaC20_5'] === 0.90
     && savedGenericFA.entries[0].markers['spadiaFA.epaC20_5'] === undefined
     && savedGenericFA.customMarkers['fattyAcids.epaC20_5']);
+
+  const sharedGenericAndSpadiaFA = {
+    entries: [
+      {
+        date: '2024-07-04',
+        sourceFile: 'Spadia 7-2024 Fatty Acids.pdf',
+        markers: { 'fattyAcids.omega3Index': 7.1 },
+      },
+      {
+        date: '2024-08-04',
+        sourceFile: 'Other Lab Fatty Acids.pdf',
+        markers: { 'fattyAcids.omega3Index': 6.2 },
+      },
+    ],
+    customMarkers: {
+      'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    markerNotes: { 'fattyAcids.omega3Index': 'global note' },
+    markerLabels: { 'fattyAcids.omega3Index': 'Omega label' },
+    refOverrides: { 'fattyAcids.omega3Index': { min: 8, max: 12 } },
+  };
+  migrateProfileData(sharedGenericAndSpadiaFA);
+  assert('Profile migration copies global metadata when generic FA key is still shared',
+    sharedGenericAndSpadiaFA.entries[0].markers['spadiaFA.omega3Index'] === 7.1
+    && sharedGenericAndSpadiaFA.entries[1].markers['fattyAcids.omega3Index'] === 6.2
+    && sharedGenericAndSpadiaFA.markerNotes['spadiaFA.omega3Index'] === 'global note'
+    && sharedGenericAndSpadiaFA.markerNotes['fattyAcids.omega3Index'] === 'global note'
+    && sharedGenericAndSpadiaFA.markerLabels['spadiaFA.omega3Index'] === 'Omega label'
+    && sharedGenericAndSpadiaFA.markerLabels['fattyAcids.omega3Index'] === 'Omega label'
+    && sharedGenericAndSpadiaFA.refOverrides['spadiaFA.omega3Index']?.min === 8
+    && sharedGenericAndSpadiaFA.refOverrides['fattyAcids.omega3Index']?.min === 8
+    && sharedGenericAndSpadiaFA.customMarkers['spadiaFA.omega3Index']?.categoryLabel === 'Spadia'
+    && sharedGenericAndSpadiaFA.customMarkers['fattyAcids.omega3Index']);
+
+  const spadiaSnapshotOnlySource = {
+    entries: [{
+      date: '2024-07-04',
+      sourceFile: 'Fatty Acids.pdf',
+      markers: { 'fattyAcids.omega3Index': 7.1 },
+    }],
+    customMarkers: {
+      'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_omega3',
+      fileName: 'Spadia 7-2024 Fatty Acids.pdf',
+      date: '2024-07-04',
+      markers: [
+        { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, matched: true },
+      ],
+    }],
+  };
+  migrateProfileData(spadiaSnapshotOnlySource);
+  assert('Profile migration uses Spadia snapshot evidence to keep entries and snapshots aligned',
+    spadiaSnapshotOnlySource.entries[0].markers['spadiaFA.omega3Index'] === 7.1
+    && spadiaSnapshotOnlySource.entries[0].markers['fattyAcids.omega3Index'] === undefined
+    && spadiaSnapshotOnlySource.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.omega3Index');
+
+  const datelessSpadiaFA = {
+    entries: [{
+      sourceFile: 'Spadia 7-2024 Fatty Acids.pdf',
+      markers: { 'fattyAcids.omega3Index': 7.1 },
+    }],
+    customMarkers: {
+      'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    manualValues: { 'fattyAcids.omega3Index:2024-07-04': 7.3 },
+    markerValueNotes: { 'fattyAcids.omega3Index:2024-07-04': 'dateless note' },
+  };
+  migrateProfileData(datelessSpadiaFA);
+  assert('Profile migration remaps date-scoped data for dateless Spadia entries',
+    datelessSpadiaFA.entries[0].markers['spadiaFA.omega3Index'] === 7.1
+    && datelessSpadiaFA.manualValues['spadiaFA.omega3Index:2024-07-04'] === 7.3
+    && datelessSpadiaFA.markerValueNotes['spadiaFA.omega3Index:2024-07-04'] === 'dateless note'
+    && datelessSpadiaFA.manualValues['fattyAcids.omega3Index:2024-07-04'] === undefined
+    && datelessSpadiaFA.markerValueNotes['fattyAcids.omega3Index:2024-07-04'] === undefined);
 
   // ═══════════════════════════════════════
   // Results

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -360,6 +360,7 @@ const importCssSrc = read('css/import.css');
       { rawName: 'B Kyselina eikosapentaenová C20:5', value: 0.90, mappedKey: 'fattyAcids.epaC20_5', unit: '%', refMin: 3.23, refMax: 4.72 },
       { rawName: 'S Vitamin A', value: 2.39, mappedKey: 'vitamins.vitaminA', unit: 'µmol/l', refMin: 1.05, refMax: 2.80 },
       { rawName: 'Unknown FA Segment', value: 1.23, mappedKey: 'fattyAcids.epa', unit: '%' },
+      { rawName: 'Malformed FA Segment', value: 1.11, mappedKey: 'fattyAcids.epa.c20_5', unit: '%' },
     ],
   }, {
     fileName: 'EDG328K.pdf',
@@ -369,6 +370,7 @@ const importCssSrc = read('css/import.css');
   const spadiaFA = spadiaImport.markers[0];
   const spadiaVitaminA = spadiaImport.markers[1];
   const spadiaUnknownFA = spadiaImport.markers[2];
+  const spadiaMalformedFA = spadiaImport.markers[3];
   assert('Blood-classified Spadia generic FA key is product-prefixed',
     spadiaFA
       && spadiaFA.matched === false
@@ -389,6 +391,12 @@ const importCssSrc = read('css/import.css');
       && spadiaUnknownFA.suggestedKey === 'fattyAcids.epa'
       && spadiaUnknownFA.suggestedKey !== 'spadiaFA.epa',
     JSON.stringify(spadiaUnknownFA));
+  assert('Blood-classified Spadia guard demotes malformed generic FA keys',
+    spadiaMalformedFA
+      && spadiaMalformedFA.matched === false
+      && spadiaMalformedFA.mappedKey === null
+      && spadiaMalformedFA.suggestedKey === null,
+    JSON.stringify(spadiaMalformedFA));
 
   // ═══════════════════════════════════════
   // 7. Import mapping reconciliation
@@ -626,7 +634,7 @@ const importCssSrc = read('css/import.css');
       },
     }],
     customMarkers: {
-      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', refMin: 3.23, refMax: 4.72, categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', refMin: 3.23, refMax: 4.72, categoryLabel: 'Fatty Acids', group: 'Fatty Acids', customMeta: 'preserve me' },
     },
     importSnapshots: [{
       id: 'snap_spadia',
@@ -652,6 +660,7 @@ const importCssSrc = read('css/import.css');
   assert('Profile migration creates Spadia category metadata',
     savedSpadiaFA.customMarkers['spadiaFA.epaC20_5']?.categoryLabel === 'Spadia'
     && savedSpadiaFA.customMarkers['spadiaFA.epaC20_5']?.group === 'Fatty Acids'
+    && savedSpadiaFA.customMarkers['spadiaFA.epaC20_5']?.customMeta === 'preserve me'
     && savedSpadiaFA.customMarkers['fattyAcids.epaC20_5'] === undefined);
   assert('Profile migration remaps saved Spadia import snapshot marker',
     savedSpadiaFA.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.epaC20_5'

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -814,6 +814,29 @@ const importCssSrc = read('css/import.css');
     && datelessSpadiaFA.manualValues['fattyAcids.omega3Index:2024-07-04'] === undefined
     && datelessSpadiaFA.markerValueNotes['fattyAcids.omega3Index:2024-07-04'] === undefined);
 
+  const datelessSpadiaSnapshotNoEntrySource = {
+    entries: [{
+      markers: { 'fattyAcids.epaC20_5': 0.90 },
+    }],
+    customMarkers: {
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_dateless_value_match',
+      fileName: 'EDG328K.pdf',
+      markers: [
+        { rawName: 'EPA C20:5', value: 0.90, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, suggestedCategoryLabel: 'Spadia', suggestedGroup: 'Fatty Acids', matched: true },
+      ],
+    }],
+  };
+  migrateProfileData(datelessSpadiaSnapshotNoEntrySource);
+  assert('Profile migration value-matches dateless Spadia snapshots to dateless entries without source metadata',
+    datelessSpadiaSnapshotNoEntrySource.entries[0].markers['spadiaFA.epaC20_5'] === 0.90
+    && datelessSpadiaSnapshotNoEntrySource.entries[0].markers['fattyAcids.epaC20_5'] === undefined
+    && datelessSpadiaSnapshotNoEntrySource.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.epaC20_5'
+    && datelessSpadiaSnapshotNoEntrySource.customMarkers['spadiaFA.epaC20_5']?.categoryLabel === 'Spadia'
+    && datelessSpadiaSnapshotNoEntrySource.customMarkers['fattyAcids.epaC20_5'] === undefined);
+
   const spadiaScopedCleanup = {
     entries: [{
       date: '2024-07-01',

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -745,6 +745,38 @@ const importCssSrc = read('css/import.css');
     && spadiaSnapshotOnlySource.entries[0].markers['fattyAcids.omega3Index'] === undefined
     && spadiaSnapshotOnlySource.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.omega3Index');
 
+  const sourceNamedSpadiaSnapshot = {
+    entries: [{
+      date: '2024-07-04',
+      sourceFile: 'EDG328K.pdf',
+      markers: { 'fattyAcids.epaC20_5': 0.90 },
+      markerSources: { 'fattyAcids.epaC20_5': { file: 'EDG328K.pdf', snapshotId: 'snap_spadia_source_named' } },
+    }],
+    customMarkers: {
+      'fattyAcids.epaC20_5': { name: 'EPA C20:5', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [{
+      id: 'snap_spadia_source_named',
+      fileName: 'EDG328K.pdf',
+      date: '2024-07-04',
+      sourceType: 'spadia',
+      sourceName: 'Spadia report',
+      markers: [
+        { rawName: 'EPA C20:5', value: 0.90, unit: '%', mappedKey: 'fattyAcids.epaC20_5', suggestedKey: null, matched: true },
+      ],
+    }],
+    markerValueNotes: { 'fattyAcids.epaC20_5:2024-07-04': 'source metadata note' },
+  };
+  migrateProfileData(sourceNamedSpadiaSnapshot);
+  assert('Profile migration uses Spadia source metadata without filename hints',
+    sourceNamedSpadiaSnapshot.entries[0].markers['spadiaFA.epaC20_5'] === 0.90
+    && sourceNamedSpadiaSnapshot.entries[0].markers['fattyAcids.epaC20_5'] === undefined
+    && sourceNamedSpadiaSnapshot.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.epaC20_5'
+    && sourceNamedSpadiaSnapshot.importSnapshots[0].markers[0].suggestedCategoryLabel === 'Spadia'
+    && sourceNamedSpadiaSnapshot.markerValueNotes['spadiaFA.epaC20_5:2024-07-04'] === 'source metadata note'
+    && sourceNamedSpadiaSnapshot.markerValueNotes['fattyAcids.epaC20_5:2024-07-04'] === undefined
+    && sourceNamedSpadiaSnapshot.customMarkers['fattyAcids.epaC20_5'] === undefined);
+
   const datelessSpadiaFA = {
     entries: [{
       sourceFile: 'EDG328K.pdf',
@@ -826,6 +858,54 @@ const importCssSrc = read('css/import.css');
     && spadiaScopedCleanup.markerLabels['fattyAcids.omega3Index:2024-07-04'] === undefined
     && spadiaScopedCleanup.refOverrides['fattyAcids.omega3Index:2024-07-01'] === undefined
     && spadiaScopedCleanup.refOverrides['fattyAcids.omega3Index:2024-07-04'] === undefined);
+
+  const undatedGenericSnapshotReference = {
+    entries: [{
+      date: '2024-07-01',
+      sourceFile: 'EDG328K.pdf',
+      markers: { 'fattyAcids.omega3Index': 7.1 },
+      markerSources: { 'fattyAcids.omega3Index': { file: 'EDG328K.pdf', snapshotId: 'snap_spadia_dated_source' } },
+    }],
+    customMarkers: {
+      'fattyAcids.omega3Index': { name: 'Omega-3 Index', unit: '%', categoryLabel: 'Fatty Acids', group: 'Fatty Acids' },
+    },
+    importSnapshots: [
+      {
+        id: 'snap_spadia_dated_source',
+        fileName: 'EDG328K.pdf',
+        date: '2024-07-01',
+        sourceType: 'spadia',
+        sourceName: 'Spadia report',
+        markers: [
+          { rawName: 'Omega-3 Index', value: 7.1, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, matched: true },
+        ],
+      },
+      {
+        id: 'snap_generic_undated_fa',
+        fileName: 'Other Lab Fatty Acids.pdf',
+        markers: [
+          { rawName: 'Omega-3 Index', value: 6.8, unit: '%', mappedKey: 'fattyAcids.omega3Index', suggestedKey: null, matched: true },
+        ],
+      },
+    ],
+    manualValues: { 'fattyAcids.omega3Index:2024-07-01': 7.1 },
+    markerValueNotes: { 'fattyAcids.omega3Index:2024-07-01': 'shared undated snapshot note' },
+    markerLabels: { 'fattyAcids.omega3Index:2024-07-01': 'shared undated snapshot label' },
+    refOverrides: { 'fattyAcids.omega3Index:2024-07-01': { min: 8, max: 12 } },
+  };
+  migrateProfileData(undatedGenericSnapshotReference);
+  assert('Profile migration keeps old scoped metadata when an undated generic snapshot still owns the key',
+    undatedGenericSnapshotReference.entries[0].markers['spadiaFA.omega3Index'] === 7.1
+    && undatedGenericSnapshotReference.importSnapshots[0].markers[0].mappedKey === 'spadiaFA.omega3Index'
+    && undatedGenericSnapshotReference.importSnapshots[1].markers[0].mappedKey === 'fattyAcids.omega3Index'
+    && undatedGenericSnapshotReference.manualValues['spadiaFA.omega3Index:2024-07-01'] === 7.1
+    && undatedGenericSnapshotReference.manualValues['fattyAcids.omega3Index:2024-07-01'] === 7.1
+    && undatedGenericSnapshotReference.markerValueNotes['spadiaFA.omega3Index:2024-07-01'] === 'shared undated snapshot note'
+    && undatedGenericSnapshotReference.markerValueNotes['fattyAcids.omega3Index:2024-07-01'] === 'shared undated snapshot note'
+    && undatedGenericSnapshotReference.markerLabels['spadiaFA.omega3Index:2024-07-01'] === 'shared undated snapshot label'
+    && undatedGenericSnapshotReference.markerLabels['fattyAcids.omega3Index:2024-07-01'] === 'shared undated snapshot label'
+    && undatedGenericSnapshotReference.refOverrides['spadiaFA.omega3Index:2024-07-01']?.min === 8
+    && undatedGenericSnapshotReference.refOverrides['fattyAcids.omega3Index:2024-07-01']?.min === 8);
 
   // ═══════════════════════════════════════
   // Results

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.38';
+self.APP_VERSION = '1.10.39';


### PR DESCRIPTION
## Summary

Fixes Spadia fatty-acid PDF imports that were being persisted under the generic `Fatty Acids` adapter/category instead of the Spadia adapter.

## What changed

- Rewrites detected Spadia fatty-acid rows from generic `fattyAcids.*` keys to `spadiaFA.*` during PDF import normalization, even when the AI classifies the mixed report as `blood`.
- Keeps true blood markers from the same report, such as Vitamin A, mapped to their standard schema keys.
- Adds a profile migration for already-saved bad Spadia imports, including marker sources, import snapshots, notes, labels, and custom marker metadata.
- Bumps `version.js` to `1.10.39` for cache invalidation.

## Validation

- `./run-tests.sh`
  - TypeScript/checkjs passed
  - Verification: 61 passed, 0 failed
  - Vitest: 13 files / 222 tests passed
  - Dev-server origin guard: 18 passed, 0 failed
  - Playwright: 339 passed
  - Theme responsive E2E: 472 passed, 0 failed
