### PR TITLE
[codex] Preserve Knowledge Base libraries

### DIFF
--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -142,6 +142,8 @@ let _activeId = null;           // Currently active library id
 let _manifest = null;           // Active library's manifest (loaded on activate)
 let _vectors = null;            // Active library's packed Float32Array
 let _chunks = null;             // Active library's [{source, text}]
+let _registryRevision = 0;      // Monotonic registry version shared by primary + backup
+let _testFailNextRegistryPersist = false; // mock-mode test hook
 
 const OPFS_SUBDIR = 'lens-local';
 const FILE_MANIFEST = 'manifest.json';
@@ -178,6 +180,13 @@ self.addEventListener('message', async (e) => {
       case 'create_library':    return await handleCreateLibrary(msg.name, msg.model);
       case 'rename_library':    return await handleRenameLibrary(msg.libraryId, msg.name);
       case 'delete_library':    return await handleDeleteLibrary(msg.libraryId);
+      case 'test_fail_next_registry_persist':
+        if (isMockMode()) {
+          _testFailNextRegistryPersist = true;
+          self.postMessage({ type: 'test_ack' });
+          return;
+        }
+        throw new Error(`Unknown message type: ${msg.type}`);
       // Abort is a side-channel signal — skips the serial queue on the
       // main thread so it can interrupt an in-flight ingest. handleIngest
       // polls _abortRequested between embeds and commits whatever's been
@@ -189,6 +198,10 @@ self.addEventListener('message', async (e) => {
     self.postMessage({ type: 'error', message: err.message || String(err) });
   }
 });
+
+function isMockMode() {
+  return new URLSearchParams(self.location.search || '').has('mock');
+}
 
 // ── Init: load model + open OPFS ───────────────────────────────────
 
@@ -491,6 +504,7 @@ async function loadOrMigrateLibraries() {
   const registry = await readLibraryRegistry();
 
   if (registry?.payload) {
+    _registryRevision = registry.payload.revision || 0;
     _libraries = registry.payload.libraries;
     _activeId = registry.payload.activeId;
 
@@ -512,7 +526,7 @@ async function loadOrMigrateLibraries() {
     const recovered = await reconcileLibrariesWithDisk({
       recoverOrphans: registry.source !== 'primary',
     });
-    if (registry.source !== 'primary' || migrated || recovered.changed) {
+    if (registry.source !== 'primary' || registry.needsPersist || migrated || recovered.changed) {
       if (registry.source !== 'primary') {
         console.warn(`[lens-local] Restored library registry from ${registry.source}.`);
       }
@@ -573,10 +587,19 @@ async function loadOrMigrateLibraries() {
 
 async function readLibraryRegistry() {
   const primary = await readLibraryRegistryFile(FILE_LIBRARIES);
-  if (primary) return { source: 'primary', payload: primary };
-
   const backup = await readLibraryRegistryFile(FILE_LIBRARIES_BACKUP);
-  if (backup) return { source: 'backup', payload: backup };
+  if (primary && backup) {
+    if (backup.revision > primary.revision) {
+      return { source: 'backup', payload: backup, needsPersist: true };
+    }
+    return {
+      source: 'primary',
+      payload: primary,
+      needsPersist: !sameLibraryRegistry(primary, backup),
+    };
+  }
+  if (primary) return { source: 'primary', payload: primary, needsPersist: true };
+  if (backup) return { source: 'backup', payload: backup, needsPersist: true };
 
   return null;
 }
@@ -605,7 +628,21 @@ function normaliseLibraryRegistry(registry) {
 
   let activeId = typeof registry.activeId === 'string' ? registry.activeId : '';
   if (!libraries.some((lib) => lib.id === activeId)) activeId = libraries[0].id;
-  return { activeId, libraries };
+  const revisionNumber = Number(registry.revision);
+  const updatedAtNumber = Number(registry.updatedAt);
+  return {
+    activeId,
+    libraries,
+    revision: Number.isFinite(revisionNumber) && revisionNumber > 0 ? revisionNumber : 0,
+    updatedAt: Number.isFinite(updatedAtNumber) && updatedAtNumber > 0 ? updatedAtNumber : 0,
+  };
+}
+
+function sameLibraryRegistry(a, b) {
+  if (!a || !b) return false;
+  return a.revision === b.revision
+    && a.activeId === b.activeId
+    && JSON.stringify(a.libraries) === JSON.stringify(b.libraries);
 }
 
 function normaliseLibraryRecord(raw, fallbackId = '') {
@@ -675,13 +712,13 @@ async function reconcileLibrariesWithDisk({ recoverOrphans = false } = {}) {
   for (const lib of _libraries) {
     const disk = byId.get(lib.id);
     if (!disk) {
-      changed = true;
+      next.push(lib);
       continue;
     }
     byId.delete(lib.id);
 
     const diskModel = modelKeyFromManifest(disk.manifest);
-    if (diskModel && diskModel !== lib.model) {
+    if ((!lib.model || !MODELS[lib.model]) && diskModel) {
       lib.model = diskModel;
       changed = true;
     }
@@ -782,10 +819,22 @@ async function activeLibraryDir() {
 }
 
 async function persistLibraries() {
-  const payload = { activeId: _activeId, libraries: _libraries };
+  return persistLibraryRegistry(_libraries, _activeId);
+}
+
+async function persistLibraryRegistry(libraries, activeId) {
+  if (_testFailNextRegistryPersist) {
+    _testFailNextRegistryPersist = false;
+    throw new Error('Test registry persist failure');
+  }
+  const nextRevision = _registryRevision + 1;
+  const payload = { activeId, libraries, revision: nextRevision, updatedAt: Date.now() };
   const bytes = new TextEncoder().encode(JSON.stringify(payload));
-  await writeSync(FILE_LIBRARIES, bytes);
+  // Write backup first. If the worker dies before the primary write, startup
+  // chooses the newer valid registry by revision and repairs the stale copy.
   await writeSync(FILE_LIBRARIES_BACKUP, bytes);
+  await writeSync(FILE_LIBRARIES, bytes);
+  _registryRevision = nextRevision;
 }
 
 // ── Ingest ────────────────────────────────────────────────────────
@@ -1007,22 +1056,25 @@ async function handleActivateLibrary(libraryId) {
     self.postMessage(readyPayload());
     return;
   }
+  await persistLibraryRegistry(_libraries, libraryId);
   _activeId = libraryId;
-  await persistLibraries();
 
-  // Reload embedder if the target library uses a different model.
-  // Skip for mock mode (tests pin _embedder to mockEmbedder and don't
-  // want it replaced by a jsdelivr import).
-  const targetModelKey = _libraryModelKey(_activeId);
-  const params = new URLSearchParams(self.location.search || '');
-  if (targetModelKey !== _modelKey && !params.has('mock')) {
-    console.log(`[lens-local] Library model change: ${_modelKey} → ${targetModelKey}, reloading embedder`);
-    await _loadEmbedder(targetModelKey);
-  }
+  await ensureActiveLibraryEmbedderLoaded();
 
   await loadActiveManifest();
   await loadCorpusIntoMemory();
   self.postMessage(readyPayload());
+}
+
+async function ensureActiveLibraryEmbedderLoaded() {
+  // Reload embedder if the active library uses a different model.
+  // Skip for mock mode (tests pin _embedder to mockEmbedder and don't
+  // want it replaced by a jsdelivr import).
+  const targetModelKey = _libraryModelKey(_activeId);
+  if (targetModelKey !== _modelKey && !isMockMode()) {
+    console.log(`[lens-local] Library model change: ${_modelKey} → ${targetModelKey}, reloading embedder`);
+    await _loadEmbedder(targetModelKey);
+  }
 }
 
 /// Create a new library with the given display name and (optional)
@@ -1036,9 +1088,9 @@ async function handleCreateLibrary(name, modelKey) {
   const label = String(name || '').trim() || 'Untitled library';
   const id = `lib-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
   const model = (modelKey && MODELS[modelKey]) ? modelKey : DEFAULT_MODEL_KEY;
-  _libraries.push({ id, name: label, createdAt: Date.now(), model });
-  await _rootDir.getDirectoryHandle(id, { create: true });
-  await persistLibraries();
+  const nextLibraries = _libraries.concat({ id, name: label, createdAt: Date.now(), model });
+  await persistLibraryRegistry(nextLibraries, _activeId);
+  _libraries = nextLibraries;
   self.postMessage({
     type: 'library_created',
     id, name: label, model,
@@ -1050,11 +1102,14 @@ async function handleCreateLibrary(name, modelKey) {
 async function handleRenameLibrary(libraryId, name) {
   const lib = _libraries.find((l) => l.id === libraryId);
   if (!lib) throw new Error(`No library with id "${libraryId}"`);
-  lib.name = String(name || '').trim() || lib.name;
-  await persistLibraries();
+  const nextName = String(name || '').trim() || lib.name;
+  const nextLibraries = _libraries.map((l) =>
+    l.id === libraryId ? { ...l, name: nextName } : l);
+  await persistLibraryRegistry(nextLibraries, _activeId);
+  _libraries = nextLibraries;
   self.postMessage({
     type: 'library_renamed',
-    id: libraryId, name: lib.name,
+    id: libraryId, name: nextName,
     libraries: _libraries.slice(),
     activeId: _activeId,
   });
@@ -1068,19 +1123,28 @@ async function handleDeleteLibrary(libraryId) {
   const idx = _libraries.findIndex((l) => l.id === libraryId);
   if (idx === -1) throw new Error(`No library with id "${libraryId}"`);
   const wasActive = libraryId === _activeId;
-  try { await _rootDir.removeEntry(libraryId, { recursive: true }); } catch {}
-  _libraries.splice(idx, 1);
-  if (_libraries.length === 0) {
+
+  let nextLibraries = _libraries.filter((l) => l.id !== libraryId);
+  let nextActiveId = _activeId;
+  if (nextLibraries.length === 0) {
     // Auto-create a default so the UI never has to handle an empty list.
     const id = 'default';
-    _libraries = [{ id, name: DEFAULT_LIBRARY_NAME, createdAt: Date.now(), model: DEFAULT_MODEL_KEY }];
-    _activeId = id;
-    await _rootDir.getDirectoryHandle(id, { create: true });
+    nextLibraries = [{ id, name: DEFAULT_LIBRARY_NAME, createdAt: Date.now(), model: DEFAULT_MODEL_KEY }];
+    nextActiveId = id;
   } else if (wasActive) {
-    _activeId = _libraries[0].id;
+    nextActiveId = nextLibraries[0].id;
   }
-  await persistLibraries();
+
+  await persistLibraryRegistry(nextLibraries, nextActiveId);
+  _libraries = nextLibraries;
+  _activeId = nextActiveId;
+
+  try { await _rootDir.removeEntry(libraryId, { recursive: true }); } catch {}
+  if (_libraries.length === 1 && _activeId === 'default') {
+    await _rootDir.getDirectoryHandle('default', { create: true });
+  }
   if (wasActive || _libraries.length === 1) {
+    await ensureActiveLibraryEmbedderLoaded();
     await loadActiveManifest();
     await loadCorpusIntoMemory();
   }

--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -6,9 +6,10 @@
 // ingest pass is running.
 //
 // Layout on disk (OPFS, origin-scoped, persistent):
-//   /lens-local/manifest.json   — {numChunks, dim, modelId, indexedAt, docs: [...]}
-//   /lens-local/vectors.bin     — packed Float32Array, numChunks * dim * 4 bytes
-//   /lens-local/chunks.json     — array parallel to vectors: [{source, text}, …]
+//   /lens-local/_libraries.json — {activeId, libraries:[{id,name,createdAt,model}]}
+//   /lens-local/<libraryId>/manifest.json
+//   /lens-local/<libraryId>/vectors.bin
+//   /lens-local/<libraryId>/chunks.json
 //
 // Persistence strategy: load the full corpus into RAM on first query for this
 // worker session, then serve every query from memory (cosine over 10k chunks
@@ -147,6 +148,7 @@ const FILE_MANIFEST = 'manifest.json';
 const FILE_VECTORS = 'vectors.bin';
 const FILE_CHUNKS = 'chunks.json';
 const FILE_LIBRARIES = '_libraries.json'; // top-level, inside /lens-local/
+const FILE_LIBRARIES_BACKUP = '_libraries.backup.json';
 const DEFAULT_LIBRARY_NAME = 'My Library';
 
 // ── Message dispatch ───────────────────────────────────────────────
@@ -486,16 +488,12 @@ async function openOpfs() {
 /// (/lens-local/manifest.json at top level), move it into
 /// /lens-local/default/ and create a "My Library" entry.
 async function loadOrMigrateLibraries() {
-  let registry = null;
-  try {
-    const text = await readOpfsFileFrom(_rootDir, FILE_LIBRARIES);
-    registry = JSON.parse(text);
-  } catch { /* no registry yet */ }
+  const registry = await readLibraryRegistry();
 
-  if (registry && Array.isArray(registry.libraries) && registry.libraries.length > 0) {
-    _libraries = registry.libraries;
-    _activeId = registry.activeId || _libraries[0].id;
-    if (!_libraries.some((l) => l.id === _activeId)) _activeId = _libraries[0].id;
+  if (registry?.payload) {
+    _libraries = registry.payload.libraries;
+    _activeId = registry.payload.activeId;
+
     // Per-library embedding-model migration. Pre-step-2 libraries had no
     // `model` field; they were all MiniLM by definition. Fill it in so
     // downstream code can read `lib.model` uniformly, and persist once
@@ -507,8 +505,17 @@ async function loadOrMigrateLibraries() {
         migrated = true;
       }
     }
-    if (migrated) {
-      console.log('[lens-local] Filled missing lib.model → ' + DEFAULT_MODEL_KEY);
+
+    // If the primary registry is corrupted or missing but the backup is
+    // valid, also scan OPFS directories. That catches libraries created
+    // after the backup but before an update/reload killed the worker.
+    const recovered = await reconcileLibrariesWithDisk({
+      recoverOrphans: registry.source !== 'primary',
+    });
+    if (registry.source !== 'primary' || migrated || recovered.changed) {
+      if (registry.source !== 'primary') {
+        console.warn(`[lens-local] Restored library registry from ${registry.source}.`);
+      }
       await persistLibraries();
     }
     return;
@@ -539,12 +546,178 @@ async function loadOrMigrateLibraries() {
     return;
   }
 
+  // Registry absent/corrupt, but multi-library directories may still be
+  // present. Rebuild a conservative registry from those directories instead
+  // of replacing it with a fresh default and hiding the user's corpus.
+  const recoveredLibraries = await discoverLibraryDirectories();
+  if (recoveredLibraries.length > 0) {
+    _libraries = recoveredLibraries.map((lib) => ({
+      id: lib.id,
+      name: lib.name,
+      createdAt: lib.createdAt,
+      model: lib.model,
+    }));
+    _activeId = _libraries.find((lib) => lib.id === 'default')?.id || _libraries[0].id;
+    console.warn(`[lens-local] Recovered ${_libraries.length} library registry entries from OPFS directories.`);
+    await persistLibraries();
+    return;
+  }
+
   // Fresh install — create a single default library so the UI always has
   // something to show. User can rename it later.
   _libraries = [{ id: 'default', name: DEFAULT_LIBRARY_NAME, createdAt: Date.now(), model: DEFAULT_MODEL_KEY }];
   _activeId = 'default';
   await _rootDir.getDirectoryHandle('default', { create: true });
   await persistLibraries();
+}
+
+async function readLibraryRegistry() {
+  const primary = await readLibraryRegistryFile(FILE_LIBRARIES);
+  if (primary) return { source: 'primary', payload: primary };
+
+  const backup = await readLibraryRegistryFile(FILE_LIBRARIES_BACKUP);
+  if (backup) return { source: 'backup', payload: backup };
+
+  return null;
+}
+
+async function readLibraryRegistryFile(name) {
+  try {
+    const text = await readOpfsFileFrom(_rootDir, name);
+    return normaliseLibraryRegistry(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+function normaliseLibraryRegistry(registry) {
+  if (!registry || !Array.isArray(registry.libraries)) return null;
+
+  const seen = new Set();
+  const libraries = [];
+  for (const raw of registry.libraries) {
+    const lib = normaliseLibraryRecord(raw);
+    if (!lib || seen.has(lib.id)) continue;
+    seen.add(lib.id);
+    libraries.push(lib);
+  }
+  if (libraries.length === 0) return null;
+
+  let activeId = typeof registry.activeId === 'string' ? registry.activeId : '';
+  if (!libraries.some((lib) => lib.id === activeId)) activeId = libraries[0].id;
+  return { activeId, libraries };
+}
+
+function normaliseLibraryRecord(raw, fallbackId = '') {
+  const id = String(raw?.id || fallbackId || '').trim();
+  if (!isSafeLibraryId(id)) return null;
+  const name = String(raw?.name || '').trim() || fallbackLibraryName(id);
+  const createdAtNumber = Number(raw?.createdAt);
+  const createdAt = Number.isFinite(createdAtNumber) && createdAtNumber > 0
+    ? createdAtNumber
+    : Date.now();
+  const model = typeof raw?.model === 'string' ? raw.model : undefined;
+  return { id, name, createdAt, model };
+}
+
+function isSafeLibraryId(id) {
+  return /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(String(id || ''));
+}
+
+function fallbackLibraryName(id) {
+  if (id === 'default') return DEFAULT_LIBRARY_NAME;
+  const label = String(id || '')
+    .replace(/^lib[-_]?/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+  return label || 'Recovered library';
+}
+
+async function discoverLibraryDirectories() {
+  if (!_rootDir || typeof _rootDir.entries !== 'function') return [];
+
+  const libraries = [];
+  for await (const [id, handle] of _rootDir.entries()) {
+    if (handle?.kind !== 'directory' || !isSafeLibraryId(id)) continue;
+
+    let manifest = null;
+    try {
+      manifest = JSON.parse(await readOpfsFileFrom(handle, FILE_MANIFEST));
+    } catch {}
+
+    const model = modelKeyFromManifest(manifest) || DEFAULT_MODEL_KEY;
+    const indexedAt = Number(manifest?.indexedAt);
+    libraries.push({
+      id,
+      name: fallbackLibraryName(id),
+      createdAt: Number.isFinite(indexedAt) && indexedAt > 0 ? indexedAt : Date.now(),
+      model,
+      manifest,
+    });
+  }
+
+  libraries.sort((a, b) => {
+    if (a.id === 'default') return -1;
+    if (b.id === 'default') return 1;
+    return a.createdAt - b.createdAt || a.id.localeCompare(b.id);
+  });
+  return libraries;
+}
+
+async function reconcileLibrariesWithDisk({ recoverOrphans = false } = {}) {
+  const discovered = await discoverLibraryDirectories();
+  if (discovered.length === 0) return { changed: false };
+
+  const byId = new Map(discovered.map((lib) => [lib.id, lib]));
+  const next = [];
+  let changed = false;
+
+  for (const lib of _libraries) {
+    const disk = byId.get(lib.id);
+    if (!disk) {
+      changed = true;
+      continue;
+    }
+    byId.delete(lib.id);
+
+    const diskModel = modelKeyFromManifest(disk.manifest);
+    if (diskModel && diskModel !== lib.model) {
+      lib.model = diskModel;
+      changed = true;
+    }
+
+    next.push(lib);
+  }
+
+  if (recoverOrphans) {
+    for (const disk of byId.values()) {
+      next.push({
+        id: disk.id,
+        name: disk.name,
+        createdAt: disk.createdAt,
+        model: disk.model,
+      });
+      changed = true;
+    }
+  }
+
+  if (next.length > 0) {
+    _libraries = next;
+    if (!_libraries.some((lib) => lib.id === _activeId)) {
+      _activeId = _libraries[0].id;
+      changed = true;
+    }
+  }
+
+  return { changed };
+}
+
+function modelKeyFromManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object') return '';
+  for (const [key, spec] of Object.entries(MODELS)) {
+    if (manifest.modelId === spec.id && Number(manifest.dim) === spec.dim) return key;
+  }
+  return '';
 }
 
 async function loadActiveManifest() {
@@ -610,7 +783,9 @@ async function activeLibraryDir() {
 
 async function persistLibraries() {
   const payload = { activeId: _activeId, libraries: _libraries };
-  await writeSync(FILE_LIBRARIES, new TextEncoder().encode(JSON.stringify(payload)));
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  await writeSync(FILE_LIBRARIES, bytes);
+  await writeSync(FILE_LIBRARIES_BACKUP, bytes);
 }
 
 // ── Ingest ────────────────────────────────────────────────────────
@@ -892,19 +1067,20 @@ async function handleRenameLibrary(libraryId, name) {
 async function handleDeleteLibrary(libraryId) {
   const idx = _libraries.findIndex((l) => l.id === libraryId);
   if (idx === -1) throw new Error(`No library with id "${libraryId}"`);
+  const wasActive = libraryId === _activeId;
   try { await _rootDir.removeEntry(libraryId, { recursive: true }); } catch {}
   _libraries.splice(idx, 1);
   if (_libraries.length === 0) {
     // Auto-create a default so the UI never has to handle an empty list.
     const id = 'default';
-    _libraries = [{ id, name: DEFAULT_LIBRARY_NAME, createdAt: Date.now() }];
+    _libraries = [{ id, name: DEFAULT_LIBRARY_NAME, createdAt: Date.now(), model: DEFAULT_MODEL_KEY }];
     _activeId = id;
     await _rootDir.getDirectoryHandle(id, { create: true });
-  } else if (libraryId === _activeId) {
+  } else if (wasActive) {
     _activeId = _libraries[0].id;
   }
   await persistLibraries();
-  if (libraryId === _activeId || _libraries.length === 1) {
+  if (wasActive || _libraries.length === 1) {
     await loadActiveManifest();
     await loadCorpusIntoMemory();
   }

--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -520,11 +520,13 @@ async function loadOrMigrateLibraries() {
       }
     }
 
-    // If the primary registry is corrupted or missing but the backup is
-    // valid, also scan OPFS directories. That catches libraries created
-    // after the backup but before an update/reload killed the worker.
+    // A valid registry is authoritative. Do not append disk-only directories
+    // here: with backup-first writes, a newer backup may intentionally omit a
+    // library that was deleted right before the worker stopped. Full directory
+    // reconstruction still happens below when both registry files are absent
+    // or unreadable.
     const recovered = await reconcileLibrariesWithDisk({
-      recoverOrphans: registry.source !== 'primary',
+      recoverOrphans: false,
     });
     if (registry.source !== 'primary' || registry.needsPersist || migrated || recovered.changed) {
       if (registry.source !== 'primary') {

--- a/tests/playwright/lens-local-worker-browser-coverage.spec.js
+++ b/tests/playwright/lens-local-worker-browser-coverage.spec.js
@@ -239,6 +239,17 @@ test('lens local worker browser coverage exercises production embedder loading w
       check('production init benchmark is finite', Number.isFinite(ready.embedder?.msPerEmbed));
       checkEqual('production model catalog exposes BGE-base dimension', ready.models?.['bge-base-en']?.dim, 768);
 
+      const defaultIngest = await roundTrip({
+        type: 'ingest',
+        files: [{ name: 'default-model.md', text: 'MiniLM default library content. '.repeat(30) }],
+      }, 'ingest_done', 10000);
+      const defaultStats = await roundTrip({ type: 'stats' }, 'stats_result');
+      check('production default library ingests before model switch',
+        defaultIngest.stats?.chunks_indexed > 0
+        && defaultStats.total_chunks === defaultIngest.stats.chunks_indexed
+        && defaultStats.dim === 384
+        && defaultStats.model === 'Xenova/all-MiniLM-L6-v2');
+
       const bge = await roundTrip({ type: 'create_library', name: 'BGE Base', model: 'bge-base-en' }, 'library_created');
       const activeBge = await roundTrip({ type: 'activate_library', libraryId: bge.id }, 'ready', 10000);
       const bgeStats = await roundTrip({ type: 'stats' }, 'stats_result');
@@ -250,6 +261,26 @@ test('lens local worker browser coverage exercises production embedder loading w
       checkEqual('activated BGE embedder dimension', activeBge.embedder?.dim, 768);
       checkEqual('BGE stats dimension', bgeStats.dim, 768);
       checkEqual('BGE stats model id', bgeStats.model, 'Xenova/bge-base-en-v1.5');
+
+      const bgeIngest = await roundTrip({
+        type: 'ingest',
+        files: [{ name: 'bge-model.md', text: 'BGE base library content. '.repeat(30) }],
+      }, 'ingest_done', 10000);
+      const bgeAfterIngest = await roundTrip({ type: 'stats' }, 'stats_result');
+      check('production BGE library ingests with BGE dimensions',
+        bgeIngest.stats?.chunks_indexed > 0
+        && bgeAfterIngest.total_chunks === bgeIngest.stats.chunks_indexed
+        && bgeAfterIngest.dim === 768
+        && bgeAfterIngest.model === 'Xenova/bge-base-en-v1.5');
+
+      const deletedActiveBge = await roundTrip({ type: 'delete_library', libraryId: bge.id }, 'library_deleted', 10000);
+      const defaultAfterActiveDelete = await roundTrip({ type: 'stats' }, 'stats_result');
+      check('deleting active cross-model library reloads remaining library before manifest load',
+        deletedActiveBge.activeId === 'default'
+        && deletedActiveBge.numChunks === defaultStats.total_chunks
+        && defaultAfterActiveDelete.total_chunks === defaultStats.total_chunks
+        && defaultAfterActiveDelete.dim === 384
+        && defaultAfterActiveDelete.model === 'Xenova/all-MiniLM-L6-v2');
 
       await roundTrip({ type: 'clear' }, 'clear_done');
     } catch (error) {

--- a/tests/test-lens-local-worker.js
+++ b/tests/test-lens-local-worker.js
@@ -29,6 +29,15 @@ return (async function() {
     return new Worker('/js/lens-local-worker.js?mock=1', { type: 'module' });
   }
 
+  async function removeLensRegistryFiles(removeBackup = false) {
+    const root = await navigator.storage.getDirectory();
+    const lensDir = await root.getDirectoryHandle('lens-local');
+    await lensDir.removeEntry('_libraries.json').catch(() => {});
+    if (removeBackup) {
+      await lensDir.removeEntry('_libraries.backup.json').catch(() => {});
+    }
+  }
+
   function roundTrip(worker, msg, expectedType, timeoutMs = 5000) {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -190,6 +199,28 @@ return (async function() {
   console.log('%c[13] Multi-library: rename', 'font-weight:bold');
   const renamed = await roundTrip(worker, { type: 'rename_library', libraryId: created.id, name: 'Kruse Research' }, 'library_renamed');
   assert('library_renamed returns new name', renamed.name === 'Kruse Research');
+
+  // ─── Phase 13b: registry recovery across update/reload ───
+  console.log('%c[13b] Multi-library: registry recovery', 'font-weight:bold');
+  worker.terminate();
+  await removeLensRegistryFiles(false);
+  worker = spawnWorker();
+  const backupRecovered = await roundTrip(worker, { type: 'init' }, 'ready');
+  const backupRecoveredLib = backupRecovered.libraries.find((l) => l.id === created.id);
+  assert('missing primary registry recovers library metadata from backup',
+    backupRecoveredLib?.name === 'Kruse Research');
+
+  worker.terminate();
+  await removeLensRegistryFiles(true);
+  worker = spawnWorker();
+  const directoryRecovered = await roundTrip(worker, { type: 'init' }, 'ready');
+  assert('missing registry and backup recovers existing library directories',
+    directoryRecovered.libraries.some((l) => l.id === created.id));
+  await roundTrip(worker, { type: 'activate_library', libraryId: created.id }, 'ready');
+  const recoveredResearchStats = await roundTrip(worker, { type: 'stats' }, 'stats_result');
+  assert('directory-recovered library keeps ingested chunks',
+    recoveredResearchStats.total_chunks === researchAfter.total_chunks,
+    `expected ${researchAfter.total_chunks}, got ${recoveredResearchStats.total_chunks}`);
 
   // ─── Phase 14: delete a non-active library ───
   console.log('%c[14] Multi-library: delete non-active', 'font-weight:bold');

--- a/tests/test-lens-local-worker.js
+++ b/tests/test-lens-local-worker.js
@@ -169,12 +169,36 @@ return (async function() {
   assert('init has an activeName',
     typeof libReady.activeName === 'string');
 
+  // ─── Phase 10b: failed create persist does not mutate state ───
+  console.log('%c[10b] Multi-library: failed create rollback', 'font-weight:bold');
+  const beforeFailedCreate = await roundTrip(worker, { type: 'list_libraries' }, 'libraries_list');
+  await roundTrip(worker, { type: 'test_fail_next_registry_persist' }, 'test_ack');
+  try {
+    await roundTrip(worker, { type: 'create_library', name: 'Failed Persist' }, 'library_created');
+    assert('failed create_library rejects when registry persist fails', false, 'expected rejection');
+  } catch (e) {
+    assert('failed create_library rejects when registry persist fails',
+      /persist/i.test(e.message));
+  }
+  const afterFailedCreate = await roundTrip(worker, { type: 'list_libraries' }, 'libraries_list');
+  assert('failed create_library leaves registry list unchanged',
+    afterFailedCreate.libraries.length === beforeFailedCreate.libraries.length
+      && !afterFailedCreate.libraries.some((l) => l.name === 'Failed Persist'));
+
+  worker.terminate();
+  await removeLensRegistryFiles(true);
+  worker = spawnWorker();
+  const afterFailedCreateRecovery = await roundTrip(worker, { type: 'init' }, 'ready');
+  assert('failed create_library leaves no recoverable OPFS directory',
+    !afterFailedCreateRecovery.libraries.some((l) => l.name === 'Failed Persist'));
+
   // ─── Phase 11: create a second library ───
   console.log('%c[11] Multi-library: create second', 'font-weight:bold');
-  const created = await roundTrip(worker, { type: 'create_library', name: 'Research' }, 'library_created');
+  const created = await roundTrip(worker, { type: 'create_library', name: 'Research', model: 'bge-small-en' }, 'library_created');
   assert('library_created returns generated id',
     typeof created.id === 'string' && created.id.length > 0);
   assert('library_created echoes name', created.name === 'Research');
+  assert('library_created preserves chosen model', created.model === 'bge-small-en');
   assert('library_created libraries list now has 2 entries',
     Array.isArray(created.libraries) && created.libraries.length >= 2);
 
@@ -209,6 +233,9 @@ return (async function() {
   const backupRecoveredLib = backupRecovered.libraries.find((l) => l.id === created.id);
   assert('missing primary registry recovers library metadata from backup',
     backupRecoveredLib?.name === 'Kruse Research');
+  assert('backup registry recovery preserves explicit library model',
+    backupRecoveredLib?.model === 'bge-small-en' && backupRecovered.activeModel === 'bge-small-en',
+    `got ${JSON.stringify({ libModel: backupRecoveredLib?.model, activeModel: backupRecovered.activeModel })}`);
 
   worker.terminate();
   await removeLensRegistryFiles(true);

--- a/tests/test-lens-local-worker.js
+++ b/tests/test-lens-local-worker.js
@@ -38,6 +38,23 @@ return (async function() {
     }
   }
 
+  async function readLensRegistryFile(name) {
+    const root = await navigator.storage.getDirectory();
+    const lensDir = await root.getDirectoryHandle('lens-local');
+    const fileHandle = await lensDir.getFileHandle(name);
+    const file = await fileHandle.getFile();
+    return JSON.parse(await file.text());
+  }
+
+  async function writeLensRegistryFile(name, payload) {
+    const root = await navigator.storage.getDirectory();
+    const lensDir = await root.getDirectoryHandle('lens-local');
+    const fileHandle = await lensDir.getFileHandle(name, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(JSON.stringify(payload));
+    await writable.close();
+  }
+
   function roundTrip(worker, msg, expectedType, timeoutMs = 5000) {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -236,6 +253,23 @@ return (async function() {
   assert('backup registry recovery preserves explicit library model',
     backupRecoveredLib?.model === 'bge-small-en' && backupRecovered.activeModel === 'bge-small-en',
     `got ${JSON.stringify({ libModel: backupRecoveredLib?.model, activeModel: backupRecovered.activeModel })}`);
+
+  // Simulate a worker stop after the backup registry recorded a delete but
+  // before the stale primary registry and old OPFS directory were removed.
+  worker.terminate();
+  const stalePrimaryRegistry = await readLensRegistryFile('_libraries.json');
+  const interruptedDeleteRegistry = {
+    ...stalePrimaryRegistry,
+    activeId: 'default',
+    libraries: stalePrimaryRegistry.libraries.filter((l) => l.id !== created.id),
+    revision: (Number(stalePrimaryRegistry.revision) || 0) + 1,
+    updatedAt: Date.now(),
+  };
+  await writeLensRegistryFile('_libraries.backup.json', interruptedDeleteRegistry);
+  worker = spawnWorker();
+  const interruptedDeleteRecovered = await roundTrip(worker, { type: 'init' }, 'ready');
+  assert('newer backup delete registry does not resurrect stale OPFS directory',
+    !interruptedDeleteRecovered.libraries.some((l) => l.id === created.id));
 
   worker.terminate();
   await removeLensRegistryFiles(true);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.39';
+self.APP_VERSION = '1.10.40';


### PR DESCRIPTION
## What changed

- Add a backup Knowledge Base library registry in OPFS.
- Recover the library list from the backup registry when the primary registry is missing or corrupt.
- Reconstruct registry entries from existing OPFS library directories if both registry files are unavailable.
- Keep active-library deletion state in sync and include model metadata on the fallback default library.
- Add browser regression coverage for registry recovery while preserving ingested chunks.

## Why

Knowledge Base document vectors and chunks were already stored durably in OPFS, but `_libraries.json` was the only index of which library directories existed. If an update/reload interrupted a registry write, startup could create a fresh default registry and make existing ingested libraries look lost even though their data was still on disk.

## Validation

- `npx vitest run tests/_vitest-legacy.test.js -t "test-custom-lens.js"`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `PORT=8000 npx playwright test tests/playwright/ui-regression-browser-flows.spec.js -g "Lens local worker browser fixture"`
- `PORT=8000 npx playwright test tests/playwright/lens-local-worker-browser-coverage.spec.js`
- `npm test`
- `./run-tests.sh`