### PR TITLE
[codex] Update AI model recommendations

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -542,6 +542,26 @@
 .settings-theme-swatch-neuromancer { background: linear-gradient(135deg, #00e5ff 0%, #ff2bd6 100%); border-radius: 0; }
 
 /* Privacy status card and collapsible configure */
+.settings-modal .settings-privacy-section {
+  padding-top: 2px;
+}
+.privacy-overview-row {
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+.privacy-overview-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: var(--radius-sm);
+  background: var(--accent-fill);
+  font-size: 15px;
+  line-height: 1;
+  flex: 0 0 auto;
+}
 .privacy-status-card {
   display: flex; align-items: flex-start; gap: 10px;
   padding: 10px 14px; border-radius: var(--radius-sm);
@@ -562,11 +582,25 @@
 .privacy-configure-toggle {
   display: flex; align-items: center; gap: 6px;
   font-size: 12px; color: var(--text-muted); cursor: pointer;
-  padding: 4px 0; user-select: none;
+  margin-top: 12px; padding: 4px 0; user-select: none;
 }
 .privacy-configure-toggle:hover { color: var(--text-secondary); }
 .privacy-configure-arrow { font-size: 9px; transition: transform 0.15s; }
 .privacy-configure-body { padding-top: 8px; }
+.privacy-setting-row {
+  padding-top: 12px;
+  margin-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.privacy-setting-row + .privacy-setting-row {
+  margin-top: 12px;
+}
+.privacy-setting-note {
+  margin-top: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
 
 /* Pending-tombstone confirm UI in Settings Sync. */
 .sync-tombstone-banner {

--- a/js/api-models.js
+++ b/js/api-models.js
@@ -39,11 +39,13 @@ export function deduplicateModels(models, familyFn) {
 
 // Curated: latest-gen medically capable models only (prefixes matched against IDs)
 const OPENROUTER_CURATED = [
-  'anthropic/claude-sonnet-4', 'anthropic/claude-opus-4',
+  'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4', 'anthropic/claude-opus-4',
   'openai/gpt-5',
   'google/gemini-3', 'google/gemini-2',
   'deepseek/deepseek',
   'qwen/qwen', 'qwen/qwq',
+  'z-ai/glm-5',
+  'moonshotai/kimi-k2',
   'x-ai/grok',
 ];
 
@@ -53,32 +55,83 @@ const OPENROUTER_CURATED = [
 // Anthropic: "claude-model-version" (hyphens: 4-6, with date suffix)
 // Venice: "model-version" (hyphens: 4-6, no provider prefix)
 const OPENROUTER_RECOMMENDED = [
-  'anthropic/claude-sonnet-4.6', 'anthropic/claude-opus-4.7',
+  'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6',
+  'anthropic/claude-opus-4.8', 'anthropic/claude-opus-4.7',
   'openai/gpt-5.5', 'openai/gpt-5.4',
-  'google/gemini-3.1-pro',
+  'google/gemini-3.5-flash', 'google/gemini-3-flash-preview',
+  'z-ai/glm-5.2',
+  'moonshotai/kimi-k2.7-code', 'moonshotai/kimi-k2.6',
   'x-ai/grok-4',
 ];
+const OPENROUTER_DEFAULT_CANDIDATES = ['openai/gpt-5.5', 'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6'];
 
 // Routstr uses bare model IDs (no provider prefix, dots: claude-sonnet-4.6)
-const ROUTSTR_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.1-pro', 'grok-4'];
+const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.2', 'z-ai/glm-5.2', 'kimi-k2.7-code', 'moonshotai/kimi-k2.7-code', 'kimi-k2.6', 'moonshotai/kimi-k2.6', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
 
 // PPQ uses bare model IDs for regular routing and private/ IDs for Tinfoil TEE models.
-const PPQ_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3-flash-preview', 'grok-4'];
+const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.2', 'glm-5.2', 'moonshotai/kimi-k2.7-code', 'kimi-k2.7-code', 'moonshotai/kimi-k2.6', 'kimi-k2.6', 'x-ai/grok-4.3', 'grok-4'];
 const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k2-6', 'private/glm-5-2', 'private/gpt-oss-120b'];
 
+function normalizedModelId(modelId) {
+  return String(modelId || '').toLowerCase().replace(/[_.]/g, '-');
+}
+
+function isClaudeSonnet5Model(modelId) {
+  return /(^|[/-])claude-sonnet-5($|[-:])/.test(normalizedModelId(modelId));
+}
+
+function isCustomRecommendedModel(modelId) {
+  if (isClaudeSonnet5Model(modelId)) return true;
+  return /(^|[/-])claude-(sonnet-4-6|opus-4-8|opus-4-7)($|[-:])/.test(normalizedModelId(modelId))
+    || /(^|[/-])gpt-5-[45]($|[-:])/.test(normalizedModelId(modelId))
+    || /(^|[/-])gemini-3-(5-flash|flash-preview)($|[-:])/.test(normalizedModelId(modelId))
+    || /(^|[/-])glm-5-2($|[-:])/.test(normalizedModelId(modelId))
+    || /(^|[/-])kimi-k2-(7-code|6)($|[-:])/.test(normalizedModelId(modelId))
+    || /(^|[/-])grok-4($|[-:])/.test(normalizedModelId(modelId));
+}
+
+function modelStartsWithRecommended(modelId, prefix) {
+  const id = normalizedModelId(modelId);
+  const p = normalizedModelId(prefix);
+  const slug = id.split('/').pop();
+  return id.startsWith(p) || slug.startsWith(p);
+}
+
+export function modelMatchesPreferredId(modelId, preferredId) {
+  if (!modelId || !preferredId) return false;
+  const id = String(modelId);
+  if (id === preferredId) return true;
+  if (id.startsWith(`${preferredId}:`) || id.startsWith(`${preferredId}-`) || id.startsWith(`${preferredId}@`)) return true;
+  const normalizedId = normalizedModelId(id);
+  const normalizedPreferred = normalizedModelId(preferredId);
+  if (normalizedId === normalizedPreferred) return true;
+  return normalizedId.startsWith(`${normalizedPreferred}:`)
+    || normalizedId.startsWith(`${normalizedPreferred}-`)
+    || normalizedId.startsWith(`${normalizedPreferred}@`);
+}
+
+export function findPreferredModel(models, preferredIds) {
+  for (const id of preferredIds) {
+    const found = models.find(function(m) { return modelMatchesPreferredId(m?.id, id); });
+    if (found) return found;
+  }
+  return null;
+}
+
 export function isRecommendedModel(provider, modelId) {
-  if (provider === 'openrouter') return OPENROUTER_RECOMMENDED.some(function(prefix) { return modelId.startsWith(prefix); });
+  if (provider === 'openrouter') return OPENROUTER_RECOMMENDED.some(function(prefix) { return modelStartsWithRecommended(modelId, prefix); });
   if (provider === 'venice') {
     if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5/.test(modelId);
-    // claude-(sonnet-4-6|opus-4-7) is intentionally narrow. When newer
+    // claude-(sonnet-5|sonnet-4-6|opus-4-8|opus-4-7) is intentionally narrow. When newer
     // versions land, broaden the alternation rather than matching all 4.x.
-    return /^(claude-(sonnet-4-6|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3(-1)?-pro|grok-4[1-9]?)(-|$)/.test(modelId);
+    return /^(claude-(sonnet-5|sonnet-4-6|opus-4-8|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3-(5-flash|flash-preview)|zai-org-glm-5-2|z-ai-glm-5-2|glm-5-2|kimi-k2-7-code|kimi-k2-6|grok-4[1-9]?)(-|$)/.test(modelId);
   }
-  if (provider === 'routstr') return ROUTSTR_RECOMMENDED.some(function(r) { return modelId === r || modelId.startsWith(r); });
+  if (provider === 'routstr') return ROUTSTR_RECOMMENDED.some(function(r) { return modelId === r || modelStartsWithRecommended(modelId, r); });
   if (provider === 'ppq') {
     if (isPpqPrivateModel(modelId)) return PPQ_PRIVATE_RECOMMENDED.includes(modelId);
-    return PPQ_RECOMMENDED.some(function(r) { return modelId === r || modelId.startsWith(r); });
+    return PPQ_RECOMMENDED.some(function(r) { return modelId === r || modelStartsWithRecommended(modelId, r); });
   }
+  if (provider === 'custom') return isCustomRecommendedModel(modelId);
   return false;
 }
 
@@ -119,8 +172,8 @@ export async function fetchOpenRouterModels(key) {
       return id.replace(/:\d{4}-\d{2}-\d{2}$/, '').replace(/-\d{8}$/, '');
     });
     models.sort(function(a, b) {
-      const aRec = OPENROUTER_RECOMMENDED.some(function(p) { return a.id.startsWith(p); });
-      const bRec = OPENROUTER_RECOMMENDED.some(function(p) { return b.id.startsWith(p); });
+      const aRec = isRecommendedModel('openrouter', a.id);
+      const bRec = isRecommendedModel('openrouter', b.id);
       if (aRec !== bRec) return aRec ? -1 : 1;
       return (a.name || a.id).localeCompare(b.name || b.id);
     });
@@ -142,7 +195,7 @@ export async function fetchOpenRouterModels(key) {
     localStorage.setItem('labcharts-openrouter-vision-models', JSON.stringify(visionIds));
     localStorage.setItem('labcharts-openrouter-models', JSON.stringify(models));
     if (!localStorage.getItem('labcharts-openrouter-model') && models.length) {
-      const claude = models.find(function(m) { return m.id === 'anthropic/claude-sonnet-4.6'; });
+      const claude = findPreferredModel(models, OPENROUTER_DEFAULT_CANDIDATES);
       if (claude) setOpenRouterModel(claude.id);
     }
     return models;

--- a/js/api-provider-storage.js
+++ b/js/api-provider-storage.js
@@ -85,6 +85,35 @@ function ppqPrivateModelsCacheKnown() {
   return localStorage.getItem('labcharts-ppq-private-models') !== null;
 }
 
+const VENICE_E2EE_DEFAULT_CANDIDATES = ['e2ee-glm-5-2', 'e2ee-glm-5-2-p', 'glm-5-2'];
+const PPQ_PRIVATE_DEFAULT_CANDIDATES = ['private/glm-5-2'];
+
+function normalizedPreferredModelId(id) {
+  return String(id || '').toLowerCase().replace(/[_.]/g, '-');
+}
+
+function modelMatchesPreferredId(modelId, preferredId) {
+  if (!modelId || !preferredId) return false;
+  const id = String(modelId);
+  const preferred = String(preferredId);
+  if (id === preferred) return true;
+  if (id.startsWith(`${preferred}:`) || id.startsWith(`${preferred}-`) || id.startsWith(`${preferred}@`)) return true;
+  const normalized = normalizedPreferredModelId(id);
+  const normalizedPreferred = normalizedPreferredModelId(preferred);
+  if (normalized === normalizedPreferred) return true;
+  return normalized.startsWith(`${normalizedPreferred}:`)
+    || normalized.startsWith(`${normalizedPreferred}-`)
+    || normalized.startsWith(`${normalizedPreferred}@`);
+}
+
+function findPreferredStoredModel(models, preferredIds) {
+  for (const id of preferredIds) {
+    const found = models.find(function(model) { return modelMatchesPreferredId(model?.id, id); });
+    if (found) return found;
+  }
+  return null;
+}
+
 export function modelSupportsVeniceE2EE(model) {
   const supports = model?.model_spec?.capabilities?.supportsE2EE;
   if (supports === true) return true;
@@ -95,6 +124,10 @@ export function modelSupportsVeniceE2EE(model) {
 function preferredVeniceModelId(models, savedId, preferLlama = false) {
   if (!models.length) return '';
   if (savedId && modelListHasId(models, savedId)) return savedId;
+  if (!preferLlama) {
+    const preferred = findPreferredStoredModel(models, VENICE_E2EE_DEFAULT_CANDIDATES);
+    if (preferred) return preferred.id;
+  }
   if (preferLlama) {
     const llama = models.find(function(m) { return m.id && m.id.includes('llama-3.3-70b'); });
     if (llama) return llama.id;
@@ -226,7 +259,8 @@ export function syncPpqModelSelection(regularModels, privateModels) {
   if (privateOn) {
     if (privateModels.length && !modelListHasId(privateModels, current)) {
       const saved = localStorage.getItem('labcharts-ppq-model-private');
-      const next = saved && modelListHasId(privateModels, saved) ? saved : privateModels[0].id;
+      const preferred = findPreferredStoredModel(privateModels, PPQ_PRIVATE_DEFAULT_CANDIDATES);
+      const next = saved && modelListHasId(privateModels, saved) ? saved : (preferred?.id || privateModels[0].id);
       setPpqModel(next);
       localStorage.setItem('labcharts-ppq-model-private', next);
     }

--- a/js/api.js
+++ b/js/api.js
@@ -69,6 +69,7 @@ import {
 } from './api-provider-storage.js';
 import {
   deduplicateModels,
+  findPreferredModel,
   fetchOpenRouterModelPricing,
   fetchOpenRouterModels,
   fetchVeniceModels,
@@ -100,6 +101,7 @@ export {
 } from './api-transport.js';
 export {
   deduplicateModels,
+  findPreferredModel,
   fetchOpenRouterModelPricing,
   fetchOpenRouterModels,
   fetchVeniceModels,
@@ -328,10 +330,11 @@ export async function exchangeOpenRouterCode(code, returnedState) {
   sessionStorage.removeItem('or_oauth_state');
   return data.key;
 }
-const ROUTSTR_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gemini-3', 'gemini-2', 'grok-4', 'grok-3', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'mimo-'];
-const ROUTSTR_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.1-pro', 'grok-4'];
-const PPQ_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'grok-', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
-const PPQ_RECOMMENDED = ['claude-sonnet-4.6', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3-flash-preview', 'grok-4'];
+const ROUTSTR_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gemini-3', 'gemini-2', 'glm-5', 'z-ai/glm-5', 'kimi-k2', 'moonshotai/kimi-k2', 'grok-4', 'x-ai/grok-4', 'grok-3', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'mimo-'];
+const ROUTSTR_DEFAULT_CANDIDATES = ['gpt-5.5', 'openai/gpt-5.5', 'claude-sonnet-5', 'claude-sonnet-4.6'];
+const PPQ_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'google/gemini-3', 'google/gemini-2', 'glm-5', 'z-ai/glm-5', 'kimi-k2', 'moonshotai/kimi-k2', 'grok-', 'x-ai/grok-4', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
+const PPQ_DEFAULT_CANDIDATES = ['gpt-5.5', 'openai/gpt-5.5', 'claude-sonnet-5', 'claude-sonnet-4.6'];
+const CUSTOM_DEFAULT_CANDIDATES = ['openai/gpt-5.5', 'gpt-5.5', 'anthropic/claude-sonnet-5', 'claude-sonnet-5', 'anthropic/claude-sonnet-4.6', 'claude-sonnet-4.6'];
 const PPQ_EXCLUDE = ['codex', 'audio', 'image', 'embed', 'tts', 'whisper', 'video', 'nano-banana'];
 const PPQ_PRIVATE_MODELS = [
   { id: 'private/kimi-k2-6', name: 'Kimi K2.6 (Private TEE)', input: ['text', 'image'], pricing: { input_per_1M_tokens: '1.58', output_per_1M_tokens: '5.51' } },
@@ -803,8 +806,8 @@ export async function fetchRoutstrModels() {
       return id.replace(/-\d{8}$/, '');
     });
     models.sort(function(a, b) {
-      const aRec = ROUTSTR_RECOMMENDED.some(function(r) { return a.id === r || a.id.startsWith(r); });
-      const bRec = ROUTSTR_RECOMMENDED.some(function(r) { return b.id === r || b.id.startsWith(r); });
+      const aRec = isRecommendedModel('routstr', a.id);
+      const bRec = isRecommendedModel('routstr', b.id);
       if (aRec !== bRec) return aRec ? -1 : 1;
       return (a.name || a.id).localeCompare(b.name || b.id);
     });
@@ -822,7 +825,7 @@ export async function fetchRoutstrModels() {
     localStorage.setItem('labcharts-routstr-vision-models', JSON.stringify(visionIds));
     localStorage.setItem('labcharts-routstr-models', JSON.stringify(models));
     if (!localStorage.getItem('labcharts-routstr-model') && models.length) {
-      const claude = models.find(function(m) { return m.id === 'claude-sonnet-4.6'; });
+      const claude = findPreferredModel(models, ROUTSTR_DEFAULT_CANDIDATES);
       if (claude) setRoutstrModel(claude.id);
     }
     return models;
@@ -957,8 +960,8 @@ export async function fetchPpqModels(key) {
       return id.replace(/-\d{8}$/, '');
     });
     models.sort(function(a, b) {
-      const aRec = PPQ_RECOMMENDED.some(function(r) { return a.id === r || a.id.startsWith(r); });
-      const bRec = PPQ_RECOMMENDED.some(function(r) { return b.id === r || b.id.startsWith(r); });
+      const aRec = isRecommendedModel('ppq', a.id);
+      const bRec = isRecommendedModel('ppq', b.id);
       if (aRec !== bRec) return aRec ? -1 : 1;
       return (a.name || a.id).localeCompare(b.name || b.id);
     });
@@ -985,7 +988,7 @@ export async function fetchPpqModels(key) {
     localStorage.setItem('labcharts-ppq-private-models', JSON.stringify(privateModels));
     syncPpqModelSelection(models, privateModels);
     if (!localStorage.getItem('labcharts-ppq-model') && models.length) {
-      const claude = models.find(function(m) { return m.id === 'claude-sonnet-4.6'; });
+      const claude = findPreferredModel(models, PPQ_DEFAULT_CANDIDATES);
       if (claude) setPpqModel(claude.id);
     }
     return getPpqPrivateMode() && privateModels.length ? privateModels : models;
@@ -1070,7 +1073,10 @@ export async function fetchCustomApiModels(baseUrl, key) {
       return { id: m.id, name: m.name || m.id };
     }).sort(function(a, b) { return a.name.localeCompare(b.name); });
     localStorage.setItem('labcharts-custom-models', JSON.stringify(models));
-    if (!getCustomApiModel() && models.length) setCustomApiModel(models[0].id);
+    if (!getCustomApiModel() && models.length) {
+      const preferred = findPreferredModel(models, CUSTOM_DEFAULT_CANDIDATES);
+      setCustomApiModel((preferred || models[0]).id);
+    }
     return models;
   } catch (e) { return []; }
 }

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -10,6 +10,14 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.48', date: '2026-07-01', title: 'Updated AI model recommendations',
+    forceShow: true,
+    items: [
+      '<b>Recommended AI models are cleaner.</b> Model pickers now show a shorter Recommended section with the latest available versions, including newer Claude, GPT, Gemini, Grok, GLM, and Kimi options when each provider offers them.',
+      '<b>Defaults are more predictable.</b> GPT-5.5 is preferred where available, with Claude fallbacks for regular cloud providers. GLM 5.2 is only auto-selected for private or end-to-end encrypted PPQ and Venice modes.',
+    ]
+  },
+  {
     version: '1.10.29', date: '2026-06-26', title: 'Biology Scores handle updates more safely',
     forceShow: true,
     items: [

--- a/js/provider-panel-renderers.js
+++ b/js/provider-panel-renderers.js
@@ -21,12 +21,74 @@ function readStoredArray(key) {
   catch { return []; }
 }
 
+function normalizedOptionId(modelId) {
+  return String(modelId || '')
+    .toLowerCase()
+    .replace(/[_.]/g, '-')
+    .replace(/:\d{4}-\d{2}-\d{2}$/, '')
+    .replace(/-\d{8}$/, '')
+    .replace(/@\d{8}$/, '');
+}
+
+function optionSlug(modelId) {
+  return normalizedOptionId(modelId).split('/').pop().replace(/^e2ee-/, '');
+}
+
+function recommendedFamilyKey(modelId) {
+  const slug = optionSlug(modelId);
+  if (slug.startsWith('claude-sonnet-')) return 'claude-sonnet';
+  if (slug.startsWith('claude-opus-')) return 'claude-opus';
+  if (/^(openai-)?gpt-5/.test(slug)) return 'gpt-5';
+  if (/^gemini-3.*pro/.test(slug)) return 'gemini-3-pro';
+  if (/^gemini-3.*flash/.test(slug)) return 'gemini-3-flash';
+  if (/^grok-4/.test(slug)) return 'grok-4';
+  if (/^qwen3/.test(slug)) return 'qwen3';
+  if (/^gpt-oss/.test(slug)) return 'gpt-oss';
+  if (/^glm-5/.test(slug)) return 'glm-5';
+  if (/^kimi-k2/.test(slug)) return 'kimi-k2';
+  return slug;
+}
+
+function modelVersionParts(modelId) {
+  const slug = optionSlug(modelId);
+  if (/^grok-41-fast($|-)/.test(slug)) return [4, 1];
+  if (/^grok-4-20($|-)/.test(slug)) return [4, 2, 0];
+  return (slug.match(/\d+/g) || []).map(Number);
+}
+
+function variantPenalty(modelId) {
+  return /(^|[-/])(beta|experimental|fast|lite|mini|preview)(-|$)/.test(normalizedOptionId(modelId)) ? -1 : 0;
+}
+
+function compareModelVersion(a, b) {
+  const aParts = modelVersionParts(a.id);
+  const bParts = modelVersionParts(b.id);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = (aParts[i] || 0) - (bParts[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return variantPenalty(a.id) - variantPenalty(b.id);
+}
+
+function latestRecommendedModels(provider, models) {
+  const bestByFamily = new Map();
+  for (const model of models) {
+    if (!isRecommendedModel(provider, model.id)) continue;
+    const family = recommendedFamilyKey(model.id);
+    const existing = bestByFamily.get(family);
+    if (!existing || compareModelVersion(model, existing) > 0) bestByFamily.set(family, model);
+  }
+  return Array.from(bestByFamily.values());
+}
+
 export function buildModelOptions(provider, models, currentModel, labelFn) {
-  const rec = models.filter(function(m) { return isRecommendedModel(provider, m.id); });
-  const rest = models.filter(function(m) { return !isRecommendedModel(provider, m.id); });
+  const rec = latestRecommendedModels(provider, models);
+  const recIds = new Set(rec.map(function(m) { return m.id; }));
+  const rest = models.filter(function(m) { return !recIds.has(m.id); });
   let html = '';
   if (rec.length) {
-    html += '<optgroup label="\u2605 Recommended for medical analysis">';
+    html += '<optgroup label="Recommended">';
     html += rec.map(function(m) { return '<option value="' + m.id + '"' + (currentModel === m.id ? ' selected' : '') + '>' + escapeHTML(labelFn(m)) + '</option>'; }).join('');
     html += '</optgroup>';
   }

--- a/js/settings.js
+++ b/js/settings.js
@@ -893,8 +893,14 @@ export function openSettingsModal(tab) {
     <div class="settings-tab-panel${_activeSettingsTab === 'privacy' ? ' active' : ''}" data-tab-panel="privacy">
       <div class="settings-group-title">AI Privacy Protection</div>
 
-      <div class="settings-section" id="privacy-section">
+      <div class="settings-section settings-privacy-section" id="privacy-section">
         ${renderPrivacySection()}
+      </div>
+
+      <div class="settings-group-title">Anonymous Usage Stats</div>
+
+      <div class="settings-section" id="privacy-analytics-section">
+        ${renderPrivacyAnalyticsSection()}
       </div>
     </div>
 
@@ -1031,8 +1037,13 @@ export function switchSettingsTab(tabId) {
 export function renderPrivacySection() {
   const piiUrl = getOllamaPIIUrl();
   const piiEnabled = isOllamaPIIEnabled();
-  return `<div class="local-ai-settings">
-    <div class="ai-provider-desc" style="margin-bottom:10px">Before any document or chat context is sent to AI for analysis — lab PDFs, EMF assessment reports, image-based imports — personal information (name, date of birth, ID numbers, address) is detected and replaced with fake data. Only lab values and content relevant to interpretation reach the AI provider.</div>
+  return `<div class="settings-action-row privacy-overview-row">
+      <div class="privacy-overview-icon" aria-hidden="true">&#128274;</div>
+      <div class="settings-copy">
+        <div class="settings-copy-title">Personal details are scrubbed before AI analysis</div>
+        <div class="settings-copy-desc">Names, dates of birth, ID numbers, and addresses are replaced before lab PDFs, EMF assessments, image imports, or chat context leave this device. Lab values and interpretation context are preserved.</div>
+      </div>
+    </div>
     <div class="privacy-status-card" id="privacy-status-card">
       <div class="privacy-status-icon" id="privacy-status-icon">&#128274;</div>
       <div class="privacy-status-body">
@@ -1040,7 +1051,7 @@ export function renderPrivacySection() {
         <div class="privacy-status-detail" id="privacy-status-detail"></div>
       </div>
     </div>
-    <div class="privacy-configure-toggle" data-settings-action="toggle-privacy-configure" style="margin-top:12px">
+    <div class="privacy-configure-toggle" data-settings-action="toggle-privacy-configure">
       <span class="privacy-configure-arrow" id="privacy-configure-arrow">&#9654;</span>
       Configure Local AI
     </div>
@@ -1063,32 +1074,40 @@ export function renderPrivacySection() {
         </div>
       </div>
     </div>
-    <div style="display:flex;align-items:start;justify-content:space-between;gap:12px;margin-top:14px">
-      <span style="font-size:13px">Use local AI for privacy protection<br><span style="font-size:11px;color:var(--text-muted)">Requires a local AI server (configure above). When disabled, regex pattern matching is used instead.</span></span>
-      <label class="toggle-switch" style="margin-top:2px">
+    <div class="settings-action-row privacy-setting-row">
+      <div class="settings-copy">
+        <div class="settings-copy-title">Use local AI for privacy protection</div>
+        <div class="settings-copy-desc">Requires a local AI server. When disabled, regex pattern matching is used instead.</div>
+      </div>
+      <label class="toggle-switch">
         <input type="checkbox" id="pii-local-toggle" ${piiEnabled ? 'checked' : ''} data-settings-action="toggle-pii-local">
         <span class="toggle-slider"></span>
       </label>
     </div>
-    <div style="display:flex;align-items:start;justify-content:space-between;gap:12px;margin-top:8px">
-      <span style="font-size:13px">Review obfuscated text before sending to AI<br><span style="font-size:11px;color:var(--text-muted)">Pause after privacy protection runs so you can inspect what the AI is about to receive. Adds one click per import — recommended.</span></span>
-      <label class="toggle-switch" style="margin-top:2px">
+    <div class="settings-action-row privacy-setting-row">
+      <div class="settings-copy">
+        <div class="settings-copy-title">Review obfuscated text before sending to AI</div>
+        <div class="settings-copy-desc">Pause after privacy protection runs so you can inspect what the AI is about to receive.</div>
+      </div>
+      <label class="toggle-switch">
         <input type="checkbox" id="pii-review-toggle" ${isPIIReviewEnabled() ? 'checked' : ''} data-settings-action="toggle-pii-review">
         <span class="toggle-slider"></span>
       </label>
     </div>
-  </div>
+  `;
+}
 
-  <div class="local-ai-settings" style="margin-top:16px">
-    <h4 style="margin:0 0 6px 0;font-size:13px;color:var(--text-primary)">Anonymous Usage Stats</h4>
-    <div class="ai-provider-desc" style="margin-bottom:10px">No health data is ever sent. I track cookieless pageviews and outbound clicks on affiliate links so I can tell which integrations actually help users — never which user, what data they were viewing, or any health context.</div>
-    <div style="display:flex;align-items:start;justify-content:space-between;gap:12px">
-      <span style="font-size:13px">Send anonymous usage stats<br><span style="font-size:11px;color:var(--text-muted)">Toggle takes effect on next launch.</span></span>
-      <label class="toggle-switch" style="margin-top:2px">
-        <input type="checkbox" id="analytics-toggle" ${isAnalyticsEnabled() ? 'checked' : ''} data-settings-action="set-analytics">
-        <span class="toggle-slider"></span>
-      </label>
+function renderPrivacyAnalyticsSection() {
+  return `<div class="settings-action-row">
+    <div class="settings-copy">
+      <div class="settings-copy-title">Send anonymous usage stats</div>
+      <div class="settings-copy-desc">Cookieless pageviews and outbound affiliate clicks only. No health data, viewed records, user identity, or health context is sent.</div>
+      <div class="privacy-setting-note">Takes effect on next launch.</div>
     </div>
+    <label class="toggle-switch">
+      <input type="checkbox" id="analytics-toggle" ${isAnalyticsEnabled() ? 'checked' : ''} data-settings-action="set-analytics">
+      <span class="toggle-slider"></span>
+    </label>
   </div>`;
 }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -1101,7 +1101,7 @@ function renderPrivacyAnalyticsSection() {
   return `<div class="settings-action-row">
     <div class="settings-copy">
       <div class="settings-copy-title">Send anonymous usage stats</div>
-      <div class="settings-copy-desc">Cookieless pageviews and outbound affiliate clicks only. No health data, viewed records, user identity, or health context is sent.</div>
+      <div class="settings-copy-desc">I track cookieless pageviews and outbound affiliate clicks only. No health data, viewed records, user identity, or health context is sent.</div>
       <div class="privacy-setting-note">Takes effect on next launch.</div>
     </div>
     <label class="toggle-switch">

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -5,12 +5,17 @@ import { updateKeyCache } from '../js/crypto.js';
 import {
   callOpenRouterAPI,
   exchangeOpenRouterCode,
+  fetchCustomApiModels,
   fetchOpenRouterModelPricing,
   fetchOpenRouterModels,
   fetchPpqModels,
   fetchRoutstrModels,
+  fetchVeniceModels,
+  getCustomApiModel,
   getOpenRouterBalance,
   getPpqBalance,
+  getPpqModel,
+  getVeniceModel,
   getVeniceBalance,
   isRecommendedModel,
   needsMaxCompletionTokens,
@@ -18,6 +23,7 @@ import {
   setCustomApiModel,
   setCustomApiUrl,
   setOpenRouterModel,
+  setPpqPrivateMode,
   setPpqModel,
   setRoutstrModel,
   setVeniceE2EE,
@@ -87,6 +93,30 @@ describe('API provider runtime behavior', () => {
           architecture: { modality: 'image->text' },
         },
         {
+          id: 'anthropic/claude-sonnet-5',
+          name: 'Claude Sonnet 5',
+          pricing: { prompt: '0.000002', completion: '0.000010' },
+          architecture: { modality: 'text+image+file->text' },
+        },
+        {
+          id: 'google/gemini-3.5-flash',
+          name: 'Gemini 3.5 Flash',
+          pricing: { prompt: '0.0000007', completion: '0.00000375' },
+          architecture: { modality: 'text+image+file->text' },
+        },
+        {
+          id: 'z-ai/glm-5.2',
+          name: 'GLM 5.2',
+          pricing: { prompt: '0.000001', completion: '0.000003' },
+          architecture: { modality: 'text->text' },
+        },
+        {
+          id: 'moonshotai/kimi-k2.7-code',
+          name: 'Kimi K2.7 Code',
+          pricing: { prompt: '0.00000056', completion: '0.0000035' },
+          architecture: { modality: 'text->text' },
+        },
+        {
           id: 'anthropic/claude-sonnet-4.6:2026-01-01',
           name: 'Claude Sonnet dated duplicate',
           pricing: { prompt: '0.000003', completion: '0.000015' },
@@ -103,14 +133,24 @@ describe('API provider runtime behavior', () => {
     });
     expect(models.map(m => m.id)).toEqual([
       'anthropic/claude-sonnet-4.6',
+      'anthropic/claude-sonnet-5',
+      'google/gemini-3.5-flash',
+      'z-ai/glm-5.2',
       'openai/gpt-5.5',
+      'moonshotai/kimi-k2.7-code',
     ]);
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-pricing'))).toMatchObject({
       'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
+      'anthropic/claude-sonnet-5': { input: 2, output: 10 },
+      'google/gemini-3.5-flash': { input: 0.7, output: 3.75 },
+      'z-ai/glm-5.2': { input: 1, output: 3 },
+      'moonshotai/kimi-k2.7-code': { input: 0.56, output: 3.5 },
       'openai/gpt-5.5': { input: 4, output: 12 },
     });
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-4.6');
-    expect(localStorage.getItem('labcharts-openrouter-model')).toBe('anthropic/claude-sonnet-4.6');
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-5');
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('google/gemini-3.5-flash');
+    expect(localStorage.getItem('labcharts-openrouter-model')).toBe('openai/gpt-5.5');
 
     expect(await fetchOpenRouterModelPricing('openai/gpt-5.5')).toEqual({ input: 4, output: 12 });
 
@@ -135,7 +175,11 @@ describe('API provider runtime behavior', () => {
       data: [
         { id: 'llama-3.1-8b', name: 'Llama', enabled: true, pricing: { prompt: '0.000001', completion: '0.000002' } },
         { id: 'claude-sonnet-4.6', name: 'Claude', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' }, architecture: { input_modalities: ['text', 'image'] } },
+        { id: 'claude-sonnet-5', name: 'Claude 5', enabled: true, pricing: { prompt: '0.000002', completion: '0.000010' }, architecture: { input_modalities: ['text', 'image'] } },
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2', enabled: true, pricing: { prompt: '0.000001', completion: '0.000003' } },
         { id: 'claude-sonnet-4.6-20260101', name: 'Claude duplicate', enabled: true },
+        { id: 'grok-41-fast', name: 'Grok 4.1 Fast', enabled: true, pricing: { prompt: '0.00000025', completion: '0.00000063' } },
+        { id: 'x-ai/grok-4.3', name: 'Grok 4.3', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' } },
         { id: 'gpt-5-preview', name: 'Preview', enabled: true },
         { id: 'grok-4', name: 'Disabled', enabled: false },
       ],
@@ -144,25 +188,90 @@ describe('API provider runtime behavior', () => {
     const routstrModels = await fetchRoutstrModels();
 
     expect(fetch).toHaveBeenCalledWith('https://node.example.com/v1/models');
-    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'llama-3.1-8b']);
-    expect(localStorage.getItem('labcharts-routstr-model')).toBe('claude-sonnet-4.6');
+    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'z-ai/glm-5.2', 'grok-41-fast', 'x-ai/grok-4.3', 'llama-3.1-8b']);
+    expect(localStorage.getItem('labcharts-routstr-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['z-ai/glm-5.2']).toEqual({ input: 1, output: 3 });
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['x-ai/grok-4.3']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-4.6');
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-5');
 
     fetch.mockResolvedValueOnce(jsonResponse({
       data: [
         { id: 'perplexity/sonar', name: 'Sonar', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '8' }, architecture: { modality: 'text->text' } },
         { id: 'claude-sonnet-4.6', name: 'Claude', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' }, architecture: { modality: 'image->text' } },
+        { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '10' }, architecture: { modality: 'image->text' } },
+        { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash', pricing: { input_per_1M_tokens: '0.7', output_per_1M_tokens: '3.75' }, architecture: { modality: 'image->text' } },
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2', pricing: { input_per_1M_tokens: '1', output_per_1M_tokens: '3.2' } },
+        { id: 'x-ai/grok-4.3', name: 'Grok 4.3', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' } },
+        { id: 'grok-4.20', name: 'Grok 4.20', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '10' } },
+        { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code', pricing: { input_per_1M_tokens: '0.56', output_per_1M_tokens: '3.5' } },
         { id: 'gpt-4-audio-preview', name: 'Audio' },
       ],
     }));
 
     const ppqModels = await fetchPpqModels('sk-ppq');
 
-    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'perplexity/sonar']);
-    expect(localStorage.getItem('labcharts-ppq-model')).toBe('claude-sonnet-4.6');
+    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'google/gemini-3.5-flash', 'z-ai/glm-5.2', 'grok-4.20', 'x-ai/grok-4.3', 'moonshotai/kimi-k2.7-code', 'perplexity/sonar']);
+    expect(localStorage.getItem('labcharts-ppq-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['google/gemini-3.5-flash']).toEqual({ input: 0.7, output: 3.75 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['z-ai/glm-5.2']).toEqual({ input: 1, output: 3.2 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['moonshotai/kimi-k2.7-code']).toEqual({ input: 0.56, output: 3.5 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-4.6');
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-5');
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('google/gemini-3.5-flash');
+  });
+
+  it('uses GPT 5.5 then Claude as fetched defaults and GLM 5.2 for private modes', async () => {
+    setCustomApiUrl('https://custom.example/v1');
+    updateKeyCache('labcharts-custom-key', 'sk-custom');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'openai/gpt-5.5', name: 'GPT 5.5' },
+        { id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5' },
+      ],
+    }));
+    await fetchCustomApiModels('https://custom.example/v1', 'sk-custom');
+    expect(getCustomApiModel()).toBe('openai/gpt-5.5');
+
+    setCustomApiModel('');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'model-a', name: 'Model A' },
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'claude-sonnet-5', name: 'Claude Sonnet 5' },
+      ],
+    }));
+    await fetchCustomApiModels('https://custom.example/v1', 'sk-custom');
+    expect(getCustomApiModel()).toBe('claude-sonnet-5');
+
+    setVeniceE2EE(true);
+    setVeniceModel('missing-e2ee-model');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'e2ee-qwen3-5-122b-a10b', name: 'Qwen E2EE', type: 'text', model_spec: { capabilities: { supportsE2EE: true } } },
+        { id: 'e2ee-glm-5-2-p', name: 'GLM 5.2 E2EE', type: 'text', model_spec: { capabilities: { supportsE2EE: true } } },
+        { id: 'llama-3.3-70b', name: 'Llama', type: 'text', model_spec: { capabilities: { supportsE2EE: false } } },
+      ],
+    }));
+    await fetchVeniceModels('venice-key');
+    expect(getVeniceModel()).toBe('e2ee-glm-5-2-p');
+
+    setPpqPrivateMode(true);
+    setPpqModel('missing-private-model');
+    fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        { id: 'claude-sonnet-4.6', name: 'Claude', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' } },
+        { id: 'private/kimi-k2-6', name: 'Kimi K2.6 Private', pricing: { input_per_1M_tokens: '1.58', output_per_1M_tokens: '5.51' } },
+        { id: 'private/glm-5-2', name: 'GLM 5.2 Private', pricing: { input_per_1M_tokens: '1.58', output_per_1M_tokens: '5.51' } },
+      ],
+    }));
+    await fetchPpqModels('sk-ppq');
+    expect(getPpqModel()).toBe('private/glm-5-2');
   });
 
   it('validates provider keys and reads balance endpoints defensively', async () => {
@@ -287,10 +396,30 @@ describe('API provider runtime behavior', () => {
     expect(needsMaxCompletionTokens('o3-mini')).toBe(true);
     expect(needsMaxCompletionTokens('anthropic/claude-sonnet-4.6')).toBe(false);
 
+    expect(isRecommendedModel('openrouter', 'anthropic/claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('openrouter', 'anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'google/gemini-3.5-flash')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'z-ai/glm-5.2')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k2.7-code')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'google/gemini-3.1-pro')).toBe(false);
+    expect(isRecommendedModel('venice', 'claude-sonnet-5')).toBe(true);
+    expect(isRecommendedModel('venice', 'gemini-3-5-flash')).toBe(true);
+    expect(isRecommendedModel('venice', 'zai-org-glm-5-2')).toBe(true);
+    expect(isRecommendedModel('venice', 'kimi-k2-7-code')).toBe(true);
     expect(isRecommendedModel('venice', 'e2ee-qwen3-5-122b')).toBe(true);
+    expect(isRecommendedModel('routstr', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-sonnet-4.6')).toBe(true);
+    expect(isRecommendedModel('routstr', 'x-ai/grok-4.3')).toBe(true);
+    expect(isRecommendedModel('ppq', 'claude-sonnet-5')).toBe(true);
+    expect(isRecommendedModel('ppq', 'x-ai/grok-4.3')).toBe(true);
+    expect(isRecommendedModel('ppq', 'google/gemini-3.5-flash')).toBe(true);
+    expect(isRecommendedModel('ppq', 'z-ai/glm-5.2')).toBe(true);
+    expect(isRecommendedModel('ppq', 'moonshotai/kimi-k2.7-code')).toBe(true);
     expect(isRecommendedModel('ppq', 'gemini-3-flash-preview')).toBe(true);
+    expect(isRecommendedModel('custom', 'claude-sonnet-5')).toBe(true);
+    expect(isRecommendedModel('custom', 'gemini-3.5-flash')).toBe(true);
+    expect(isRecommendedModel('custom', 'z-ai/glm-5.2')).toBe(true);
+    expect(isRecommendedModel('custom', 'moonshotai/kimi-k2.7-code')).toBe(true);
 
     setAIProvider('openrouter');
     setOpenRouterModel('anthropic/claude-sonnet-4.6:2026-01-01');

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -165,11 +165,26 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       }));
       localStorage.setItem('labcharts-openrouter-model', 'anthropic/claude-sonnet-4.6');
       controls.renderOpenRouterModelDropdown([
+        { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
         { id: 'google/gemini-3.1-pro', name: 'Gemini 3.1 Pro' },
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
+        { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
+        { id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5' },
         { id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6' },
         { id: 'x-ai/grok-4', name: 'Grok 4' },
       ]);
-      const openRouterRecommended = !!document.querySelector('#openrouter-model-select optgroup[label*="Recommended"] option[value="anthropic/claude-sonnet-4.6"]');
+      const openRouterRecommendedGroup = document.querySelector('#openrouter-model-select optgroup[label="Recommended"]');
+      const openRouterRecommended = !!openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-5"]')
+        && !!openRouterRecommendedGroup?.querySelector('option[value="google/gemini-3.5-flash"]')
+        && !!openRouterRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
+        && !!openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-4.6"]')
+        && !openRouterRecommendedGroup?.querySelector('option[value="google/gemini-3.1-pro"]')
+        && !openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
+        && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="anthropic/claude-sonnet-4.6"]')
+        && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="google/gemini-3.1-pro"]')
+        && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       const openRouterPricing = (document.getElementById('openrouter-model-pricing')?.textContent || '').includes('$3.00/M in');
 
       let fetchedPricing = false;
@@ -228,19 +243,55 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       ]);
       const routstrFallback = localStorage.getItem('labcharts-routstr-model') === 'routstr-a'
         && document.getElementById('routstr-model-select')?.value === 'routstr-a';
+      controls.renderRoutstrModelDropdown([
+        { id: 'grok-41-fast', name: 'Grok 4.1 Fast' },
+        { id: 'x-ai/grok-4.3', name: 'Grok 4.3' },
+      ]);
+      const routstrRecommendedGroup = document.querySelector('#routstr-model-select optgroup[label="Recommended"]');
+      const routstrLatestGrokRecommended = !!routstrRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
+        && !routstrRecommendedGroup?.querySelector('option[value="grok-41-fast"]')
+        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="grok-41-fast"]');
 
       localStorage.setItem('labcharts-ppq-model', 'ppq-b');
       localStorage.setItem('labcharts-ppq-pricing', JSON.stringify({ 'ppq-b': { input: 0.5, output: 1.5 } }));
       controls.renderPpqModelDropdown([
         { id: 'ppq-a', name: 'PPQ A' },
         { id: 'ppq-b', name: 'PPQ B' },
+        { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash Preview' },
+        { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
+        { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
+        { id: 'grok-4.20', name: 'Grok 4.20' },
+        { id: 'x-ai/grok-4.3', name: 'Grok 4.3' },
       ]);
+      const ppqRecommendedGroup = document.querySelector('#ppq-model-select optgroup[label="Recommended"]');
+      const ppqLatestGrokRecommended = !!ppqRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
+        && !ppqRecommendedGroup?.querySelector('option[value="grok-4.20"]')
+        && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="grok-4.20"]');
+      const ppqLatestGeminiRecommended = !!ppqRecommendedGroup?.querySelector('option[value="google/gemini-3.5-flash"]')
+        && !ppqRecommendedGroup?.querySelector('option[value="gemini-3-flash-preview"]')
+        && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="gemini-3-flash-preview"]');
+      const ppqLatestGlmKimiRecommended = !!ppqRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
+        && !!ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
+        && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       controls.updatePpqModelPricing('ppq-b');
       const ppqModelPricing = document.getElementById('ppq-model-select')?.value === 'ppq-b'
         && (document.getElementById('ppq-model-pricing')?.textContent || '').includes('$0.50/M in');
 
       localStorage.setItem('labcharts-custom-model', 'outside-model');
-      controls.renderCustomApiModelDropdown([{ id: 'model-a', name: 'Model A' }]);
+      controls.renderCustomApiModelDropdown([
+        { id: 'model-a', name: 'Model A' },
+        { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
+        { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
+      ]);
+      const customRecommendedGroup = document.querySelector('#custom-model-select optgroup[label="Recommended"]');
+      const customGlmKimiRecommended = !!customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
+        && !!customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
+        && !!document.querySelector('#custom-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       const customModelRenders = document.getElementById('custom-model-select')?.value === '__custom'
         && document.getElementById('custom-manual-model')?.value === 'outside-model';
       document.getElementById('custom-manual-model').value = 'manual-model';
@@ -293,8 +344,13 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         veniceE2EEEnabled,
         veniceE2EERestored,
         routstrFallback,
+        routstrLatestGrokRecommended,
         ppqModelPricing,
+        ppqLatestGrokRecommended,
+        ppqLatestGeminiRecommended,
+        ppqLatestGlmKimiRecommended,
         customModelRenders,
+        customGlmKimiRecommended,
         customManualApplied,
         delegatesCovered,
       };
@@ -401,6 +457,7 @@ test('provider panels cover provider switching key saves balances custom API and
         if (href === 'https://openrouter.ai/api/v1/models') {
           return jsonResponse({
             data: [
+              { id: 'openai/gpt-5.5', name: 'GPT 5.5', pricing: { prompt: '0.000004', completion: '0.000012' }, architecture: { modality: 'text->text' } },
               { id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet', pricing: { prompt: '0.000003', completion: '0.000015' }, architecture: { modality: 'text+image->text' } },
               { id: 'audio/not-used', name: 'Audio', pricing: { prompt: '0', completion: '0' } },
             ],
@@ -423,6 +480,8 @@ test('provider panels cover provider switching key saves balances custom API and
         if (href === 'https://api.ppq.ai/v1/models?type=chat') {
           return jsonResponse({
             data: [
+              { id: 'z-ai/glm-5.2', name: 'GLM 5.2', pricing: { input_per_1M_tokens: '1', output_per_1M_tokens: '3.2' } },
+              { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '10' }, architecture: { input_modalities: ['text', 'image'] } },
               { id: 'claude-sonnet-4.6', name: 'Claude', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' }, architecture: { input_modalities: ['text', 'image'] } },
               { id: 'codex-not-used', name: 'Codex' },
             ],
@@ -434,6 +493,8 @@ test('provider panels cover provider switching key saves balances custom API and
         if (href === 'https://routstr.example/v1/models') {
           return jsonResponse({
             data: [
+              { id: 'z-ai/glm-5.2', name: 'GLM 5.2', enabled: true, pricing: { prompt: '0.000001', completion: '0.000003' } },
+              { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', enabled: true, pricing: { prompt: '0.000002', completion: '0.000010' }, architecture: { modality: 'text+image->text' } },
               { id: 'claude-sonnet-4.6', name: 'Claude Sonnet', enabled: true, pricing: { prompt: '0.000002', completion: '0.000006' }, architecture: { modality: 'text+image->text' } },
               { id: 'mistral-large', name: 'Mistral Large', enabled: true, pricing: { prompt: '0.000001', completion: '0.000003' } },
               { id: 'codex-preview', name: 'Codex Preview', enabled: true },
@@ -441,7 +502,7 @@ test('provider panels cover provider switching key saves balances custom API and
           });
         }
         if (href === 'https://custom.example/v1/models') {
-          return jsonResponse({ data: [{ id: 'z-model', name: 'Z Model' }, { id: 'a-model', name: 'A Model' }] });
+          return jsonResponse({ data: [{ id: 'z-model', name: 'Z Model' }, { id: 'z-ai/glm-5.2', name: 'GLM 5.2' }, { id: 'openai/gpt-5.5', name: 'GPT 5.5' }, { id: 'a-model', name: 'A Model' }] });
         }
         if (href === 'https://custom.example/v1/chat/completions') {
           return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
@@ -483,7 +544,7 @@ test('provider panels cover provider switching key saves balances custom API and
       panels.refreshOpenRouterBalance();
       await wait(50);
       const openRouterSaveAndBalance = document.getElementById('openrouter-key-status')?.textContent.includes('Connected')
-        && document.getElementById('openrouter-model-select')?.value === 'anthropic/claude-sonnet-4.6'
+        && document.getElementById('openrouter-model-select')?.value === 'openai/gpt-5.5'
         && (document.getElementById('or-balance')?.textContent || '').includes('$0.75');
 
       panel.innerHTML = `
@@ -520,7 +581,7 @@ test('provider panels cover provider switching key saves balances custom API and
       await wait(0);
       const routstrSaveRendersModels = document.getElementById('routstr-key-status')?.textContent.includes('Connected')
         && localStorage.getItem('labcharts-routstr-key') === 'sk-routstr-good'
-        && document.getElementById('routstr-model-select')?.value === 'claude-sonnet-4.6'
+        && document.getElementById('routstr-model-select')?.value === 'claude-sonnet-5'
         && JSON.parse(localStorage.getItem('labcharts-routstr-vision-models') || '[]').includes('claude-sonnet-4.6');
 
       panels.handleRemoveRoutstrKey();
@@ -542,7 +603,7 @@ test('provider panels cover provider switching key saves balances custom API and
       await panels.refreshPpqBalance();
       await wait(0);
       const ppqSaveAndBalance = document.getElementById('ppq-key-status')?.textContent.includes('Connected')
-        && document.getElementById('ppq-model-select')?.value === 'claude-sonnet-4.6'
+        && document.getElementById('ppq-model-select')?.value === 'claude-sonnet-5'
         && (document.getElementById('ppq-balance')?.textContent || '').includes('$0.08');
 
       panel.innerHTML = `
@@ -553,7 +614,7 @@ test('provider panels cover provider switching key saves balances custom API and
       await wait(0);
       const customSaveRendersConnected = localStorage.getItem('labcharts-custom-url') === 'https://custom.example/v1'
         && document.getElementById('custom-key-status')?.textContent.includes('Connected')
-        && document.getElementById('custom-model-select')?.value === 'a-model';
+        && document.getElementById('custom-model-select')?.value === 'openai/gpt-5.5';
       window.handleRemoveCustomApi();
       await wait(0);
       const customRemoveRendersDisconnected = !localStorage.getItem('labcharts-custom-url')

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -54,6 +54,8 @@ assert('hasAIProvider handles custom', apiProviderStorageSrc.includes("provider 
 assert('hasAIProvider custom requires URL', apiProviderStorageSrc.includes("hasCustomApiKey() && !!getCustomApiUrl()"));
 assert('getActiveModelId handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModel()"));
 assert('getActiveModelDisplay handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
+assert('isRecommendedModel handles custom Sonnet 5', apiModelsSrc.includes("provider === 'custom'") && apiModelsSrc.includes('isCustomRecommendedModel'));
+assert('isRecommendedModel handles custom GLM and Kimi', apiModelsSrc.includes('glm-5-2') && apiModelsSrc.includes('kimi-k2-(7-code|6)'));
 assert('callClaudeAPI handles custom', apiSrc.includes("provider === 'custom') return callCustomAPI("));
 assert('supportsWebSearch false for custom', apiModelsSrc.includes("provider === 'custom') return false"));
 assert('supportsVision true for custom', apiModelsSrc.includes("provider === 'custom') return true"));

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -67,13 +67,19 @@ assert('MODEL_PRICING has openrouter block', schemaSrc.includes('openrouter:'));
 assert('Has openrouter _default fallback', schemaSrc.includes("'_default':") && schemaSrc.includes('approx: true'));
 assert('getModelPricing checks openrouter-pricing cache', schemaSrc.includes('labcharts-openrouter-pricing'));
 assert('OPENROUTER_CURATED whitelist exists', apiModelsSrc.includes('OPENROUTER_CURATED'));
+assert('Curated: anthropic/claude-sonnet-5 prefix', apiModelsSrc.includes("'anthropic/claude-sonnet-5'"));
 assert('Curated: anthropic/claude-sonnet prefix', apiModelsSrc.includes("'anthropic/claude-sonnet-4'"));
 assert('Curated: anthropic/claude-opus prefix', apiModelsSrc.includes("'anthropic/claude-opus-4'"));
 assert('Curated: openai/gpt prefix', apiModelsSrc.includes("'openai/gpt-5'"));
 assert('Curated: google/gemini-3 prefix', apiModelsSrc.includes("'google/gemini-3'"));
 assert('Curated: google/gemini-2 prefix', apiModelsSrc.includes("'google/gemini-2'"));
+assert('Recommended: Gemini 3.5 Flash', apiModelsSrc.includes("'google/gemini-3.5-flash'"));
 assert('Curated: deepseek prefix', apiModelsSrc.includes("'deepseek/deepseek'"));
 assert('Curated: qwen prefix', apiModelsSrc.includes("'qwen/qwen'"));
+assert('Curated: z-ai/glm-5 prefix', apiModelsSrc.includes("'z-ai/glm-5'"));
+assert('Curated: moonshotai/kimi-k2 prefix', apiModelsSrc.includes("'moonshotai/kimi-k2'"));
+assert('Recommended: GLM 5.2', apiModelsSrc.includes("'z-ai/glm-5.2'"));
+assert('Recommended: Kimi K2.7 Code', apiModelsSrc.includes("'moonshotai/kimi-k2.7-code'"));
 assert('Curated: x-ai/grok prefix', apiModelsSrc.includes("'x-ai/grok'"));
 assert('OPENROUTER_EXCLUDE exists', apiModelsSrc.includes('OPENROUTER_EXCLUDE'));
 assert('Excludes codex variants', apiModelsSrc.includes("'codex'"));
@@ -83,6 +89,7 @@ assert('Exclude filter applied in fetch', apiModelsSrc.includes('OPENROUTER_EXCL
 assert('fetchOpenRouterModels extracts pricing.prompt', apiModelsSrc.includes('m.pricing.prompt'));
 assert('fetchOpenRouterModels converts to per-million', apiModelsSrc.includes('* 1_000_000'));
 assert('fetchOpenRouterModels caches pricing', apiModelsSrc.includes("'labcharts-openrouter-pricing'"));
+assert('OpenRouter default prefers GPT 5.5 then Sonnet 5 when fetched', apiModelsSrc.includes("'openai/gpt-5.5', 'anthropic/claude-sonnet-5'"));
 assert('getOpenRouterPricing function exists', apiProviderStorageSrc.includes('function getOpenRouterPricing('));
 assert('window.getOpenRouterPricing is function', typeof window.getOpenRouterPricing === 'function');
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.40';
+self.APP_VERSION = '1.10.48';


### PR DESCRIPTION
## Summary

- Refresh AI model recommendations across OpenRouter, Routstr, PPQ, Venice, and Custom providers.
- Keep normal cloud defaults on GPT-5.5 with Claude fallbacks, while preferring GLM 5.2 only for Venice E2EE and PPQ private/TEE modes.
- Rename the model picker group to `Recommended` and show only the latest available version per model family.
- Update provider dropdown coverage, runtime tests, and the user-facing changelog entry.

## Validation

- `npm test -- tests/api-provider-runtime.test.js`
- `node tests/test-openrouter.js`
- `node tests/test-custom-api.js`
- `node tests/test-venice-e2ee.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-settings-delegated-actions.js`
- targeted provider/settings Playwright coverage
- desktop/mobile Privacy tab smoke checks
- `git diff --check`

## Notes

Untracked local files `AGENTS.md` and `Screenshots Redesign/` were left out of this PR.