### PR TITLE
Add manual SNP and report imports

### DIFF
--- a/css/dashboard-widgets.css
+++ b/css/dashboard-widgets.css
@@ -73,8 +73,14 @@
 .dashboard-widget-inline-controls {
   display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px;
 }
-.biology-scores-lens-header .dashboard-widget-inline-controls {
+.lens-page-header .dashboard-widget-inline-controls {
   margin-top: 14px;
+  column-gap: 14px;
+  row-gap: 10px;
+}
+.genome-lens-header .lens-header-affiliate {
+  flex-basis: 100%;
+  margin-top: 2px;
 }
 .biology-score-header-actions {
   display: flex;

--- a/css/genetics.css
+++ b/css/genetics.css
@@ -16,13 +16,16 @@
 .genetics-loading-stub:hover { border-color: var(--border); background: var(--bg-card); }
 .genetics-empty-stub-icon { font-size: 20px; line-height: 1; flex-shrink: 0; margin-top: 1px; }
 .genetics-empty-stub-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.genetics-empty-actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 6px; }
+.genetics-empty-actions .genetics-action-link { font-size: 12px; color: var(--accent); }
+.genetics-empty-actions .genetics-action-link:hover { color: var(--purple); }
 .genetics-empty-stub-title { font-weight: 600; color: var(--text-primary); font-size: 14px; }
 .genetics-empty-stub-sub { font-size: 12px; color: var(--text-muted); line-height: 1.45; }
 .genetics-empty-stub-arrow { font-size: 16px; color: var(--text-muted); align-self: center; flex-shrink: 0; }
 .genetics-empty-stub:hover .genetics-empty-stub-arrow { color: var(--purple); }
 
 /* DNA Import Preview */
-.dna-preview-modal { max-width: 560px; max-height: 80vh; display: flex; flex-direction: column; }
+.dna-preview-modal { width: min(90vw, 560px); max-width: 560px; max-height: 80vh; display: flex; flex-direction: column; padding: 0; overflow: hidden; }
 .dna-preview-header { padding: 16px 20px 12px; border-bottom: 1px solid var(--border); }
 .dna-preview-title { font-size: 16px; font-weight: 600; margin-bottom: 4px; }
 .dna-preview-stats { font-size: 12px; color: var(--text-muted); }
@@ -44,6 +47,48 @@
 .dna-preview-group.expanded .dna-preview-expand-hint { display: none; }
 .dna-preview-disclaimer { padding: 8px 20px; font-size: 11px; color: var(--text-muted); border-top: 1px solid var(--border); }
 .dna-preview-actions { padding: 12px 20px; display: flex; gap: 8px; justify-content: flex-end; border-top: 1px solid var(--border); }
+.dna-manual-modal { width: min(92vw, 640px); max-width: 640px; max-height: min(88vh, 760px); }
+.dna-manual-header { background: linear-gradient(135deg, color-mix(in srgb, var(--purple) 10%, transparent), transparent 60%); }
+.dna-manual-snp-body { display: grid; gap: 14px; background: var(--bg-secondary); padding-bottom: 16px; }
+.dna-manual-card { border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg-card); padding: 12px; }
+.dna-manual-card-bulk { background: color-mix(in srgb, var(--bg-card) 94%, var(--purple) 6%); }
+.dna-manual-section-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
+.dna-manual-section-head span { font-size: 13px; font-weight: 700; color: var(--text-primary); }
+.dna-manual-section-head small { font-size: 11px; color: var(--text-muted); font-weight: 500; text-align: right; }
+.dna-manual-grid { display: grid; grid-template-columns: minmax(0, 1fr) 104px; gap: 10px; }
+.dna-manual-field { display: grid; gap: 6px; font-size: 11px; font-weight: 700; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em; }
+.dna-manual-source { padding: 0 2px; max-width: none; }
+.dna-manual-input,
+.dna-manual-textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+  transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+}
+.dna-manual-input { min-height: 40px; padding: 9px 11px; }
+.dna-manual-genotype { text-transform: uppercase; font-family: var(--font-mono); letter-spacing: 0.08em; }
+.dna-manual-textarea { resize: vertical; min-height: 104px; padding: 10px 11px; font-family: var(--font-mono); line-height: 1.45; }
+.dna-manual-input::placeholder,
+.dna-manual-textarea::placeholder { color: var(--text-muted); opacity: 0.72; }
+.dna-manual-input:hover,
+.dna-manual-textarea:hover { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
+.dna-manual-input:focus,
+.dna-manual-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg-card);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.dna-manual-help { margin: 0; padding: 4px 2px 0; font-size: 12px; color: var(--text-muted); line-height: 1.45; }
+@media (max-width: 560px) {
+  .dna-preview-modal { max-width: min(96vw, 560px); }
+  .dna-manual-grid { grid-template-columns: 1fr; }
+  .dna-manual-section-head { display: grid; }
+  .dna-manual-section-head small { text-align: left; }
+}
 
 /* Shared genetics detail references used by marker details and the Genome page. */
 .detail-genetics { margin: 12px 0; padding: 10px 12px; background: var(--bg-hover); border-radius: var(--radius-sm); border: 1px solid var(--border); }

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -10,6 +10,15 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.49', date: '2026-07-01', title: 'Add SNPs from small genetic reports',
+    forceShow: true,
+    items: [
+      '<b>Genome import is less all-or-nothing.</b> You can now add a single SNP manually when a lab only reports one or two variants instead of giving you a raw DNA file.',
+      '<b>Clinical SNP reports are supported as a review flow.</b> Report PDFs or text that mention catalog rsIDs and genotypes are parsed locally, shown in the same DNA preview, and then merged into your existing genetics data instead of replacing it.',
+      '<b>Strand normalization is visible in storage.</b> getbased keeps the reported genotype and the catalog-normalized genotype, so report calls like MTHFR <code>CC</code> can still map safely to the existing health SNP catalog.',
+    ]
+  },
+  {
     version: '1.10.48', date: '2026-07-01', title: 'Updated AI model recommendations',
     forceShow: true,
     items: [

--- a/js/data.js
+++ b/js/data.js
@@ -260,16 +260,20 @@ export async function saveImportedData(options = {}) {
     // keys to IndexedDB. Going through localStorage.setItem directly
     // would bypass that routing and re-introduce the 5 MB quota wall.
     await encryptedSetItem(key, value);
+  } catch (e) {
+    showNotification('Storage limit reached — clear old data or profiles to free space.', 'error');
+    return false;
+  }
+  try {
     broadcastDataChanged(state.currentProfile);
     scheduleAutoBackup();
     touchProfileTimestamp(state.currentProfile);
     if (dataWindow.invalidateLabContextCache) dataWindow.invalidateLabContextCache();
     onDataSaved(options);
-    return true;
   } catch (e) {
-    showNotification('Storage limit reached — clear old data or profiles to free space.', 'error');
-    return false;
+    if (dataWindow.isDebugMode?.()) console.warn('Post-save hook failed after data was persisted:', e);
   }
+  return true;
 }
 
 export function getFocusCardFingerprint() {

--- a/js/dna-actions.js
+++ b/js/dna-actions.js
@@ -29,6 +29,15 @@ function handleDnaActionClick(event) {
   if (action === 'import-file') {
     event.preventDefault();
     dnaActionHandlers.triggerDNAFilePicker?.();
+  } else if (action === 'add-manual-snp') {
+    event.preventDefault();
+    dnaActionHandlers.openManualSnpModal?.();
+  } else if (action === 'save-manual-snp') {
+    event.preventDefault();
+    dnaActionHandlers.saveManualSnpFromModal?.();
+  } else if (action === 'import-snp-report') {
+    event.preventDefault();
+    dnaActionHandlers.importSnpReport?.();
   } else if (action === 'toggle-genetics-collapse') {
     event.preventDefault();
     dnaActionHandlers.toggleGeneticsCollapse?.();

--- a/js/dna.js
+++ b/js/dna.js
@@ -357,6 +357,32 @@ function inferAnnotatedReportGenotype(rsid, entry, cells, columns) {
   return null;
 }
 
+const DNA_COMPLEMENT = { A: 'T', T: 'A', C: 'G', G: 'C' };
+function reverseComplementGenotype(genotype) {
+  return String(genotype || '').toUpperCase().split('').reverse().map(ch => DNA_COMPLEMENT[ch] || ch).join('');
+}
+function findGenotypeMatch(entry, genotype) {
+  const raw = String(genotype || '').trim().toUpperCase();
+  if (!entry || !entry.genotypes || !/^[ACGT]{1,2}$/.test(raw)) return null;
+  const tries = [];
+  const push = (value) => { if (value && !tries.includes(value)) tries.push(value); };
+  push(raw);
+  if (raw.length === 2) push(raw[1] + raw[0]);
+  push(sortAlleles(raw));
+  const rc = reverseComplementGenotype(raw);
+  const alleles = new Set(Object.keys(entry.genotypes).join('').split(''));
+  const palindromic = alleles.size === 2 && ((alleles.has('A') && alleles.has('T')) || (alleles.has('C') && alleles.has('G')));
+  if (!palindromic) {
+    push(rc);
+    if (rc.length === 2) push(rc[1] + rc[0]);
+    push(sortAlleles(rc));
+  }
+  for (const key of tries) {
+    if (entry.genotypes[key] != null) return { key, info: entry.genotypes[key] };
+  }
+  return null;
+}
+
 function parseAnnotatedSnpReport(text, snpTable) {
   const lines = text.split(/\r?\n/);
   const headerIndex = lines.findIndex(line => line.trim() && !line.trim().startsWith('#'));
@@ -387,6 +413,55 @@ function parseAnnotatedSnpReport(text, snpTable) {
     if (genotype) matches[rsid] = genotype;
   }
   return { matches, source: 'annotated-snp-report', totalLines: totalData, format: 'annotated-snp-report' };
+}
+
+function parseClinicalSnpGenotypeTail(tail) {
+  const cleaned = String(tail || '').replace(/\s+/g, ' ');
+  const matches = [...cleaned.matchAll(/(?:^|[^A-Z])([ACGT]{2})(?=\s*(?:[–-]|—|\b|$))/g)];
+  if (!matches.length) return null;
+  // Lab PDFs often prefix result rows with timestamps like 11:48CC; the last
+  // allele pair near the zygosity prose is the actual genotype.
+  return matches[matches.length - 1][1];
+}
+
+export function parseClinicalSnpReportText(text, options = {}) {
+  const source = options.source || options.fileName || 'Clinical SNP report';
+  const snpTable = _snpTable;
+  const body = String(text || '').replace(/\u00A0/g, ' ');
+  const matches = {};
+  let totalLines = 0;
+  const rsMatches = [...body.matchAll(/\b(rs\d+)\b/gi)];
+  for (let i = 0; i < rsMatches.length; i++) {
+    const rsid = rsMatches[i][1].toLowerCase();
+    const entry = snpTable?.[rsid];
+    if (!entry || matches[rsid]) continue;
+    totalLines++;
+    const start = Math.max(0, rsMatches[i].index - 90);
+    const end = i + 1 < rsMatches.length ? Math.min(body.length, rsMatches[i + 1].index) : Math.min(body.length, rsMatches[i].index + 220);
+    const chunk = body.slice(start, end);
+    const genotype = parseClinicalSnpGenotypeTail(chunk);
+    if (!genotype) continue;
+    const match = findGenotypeMatch(entry, genotype);
+    if (!match) continue;
+    matches[rsid] = {
+      genotype,
+      normalizedGenotype: match.key,
+      gene: entry.gene,
+      variant: entry.variant,
+      category: entry.category,
+      markers: entry.markers || [],
+      effect: match.info.effect,
+      valence: match.info.valence,
+      note: match.info.note,
+      source: { type: options.type || 'report-text', label: source, fileName: options.fileName || null, rawText: chunk.trim().slice(0, 500) },
+    };
+  }
+  return {
+    matches,
+    source,
+    totalLines,
+    coverage: { found: Object.keys(matches).length, total: Object.keys(snpTable || {}).filter(k => k.startsWith('rs')).length },
+  };
 }
 
 // Eagerly load SNP table when genetics data exists (e.g. after JSON import)
@@ -510,6 +585,63 @@ function resolveAPOE(matches) {
 // STORAGE
 // ═══════════════════════════════════════════════
 
+function recalculateGeneticsSummary(genetics) {
+  if (!genetics) return;
+  const apoe = resolveAPOE(genetics.snps || {});
+  const apoeRsids = apoe ? new Set(['rs429358', 'rs7412']) : new Set();
+  let significant = 0, moderate = 0, mild = 0, normal = 0;
+  for (const [rsid, data] of Object.entries(genetics.snps || {})) {
+    if (apoeRsids.has(rsid)) continue;
+    if (data.effect === 'significant') significant++;
+    else if (data.effect === 'moderate') moderate++;
+    else if (data.effect === 'mild') mild++;
+    else if (data.effect === 'none') normal++;
+  }
+  genetics.effects = { significant, moderate, mild, normal };
+  genetics.coverage = { found: Object.keys(genetics.snps || {}).length, total: Object.keys(_snpTable || {}).filter(k => k.startsWith('rs')).length };
+  if (apoe) genetics.apoe = apoe;
+  else delete genetics.apoe;
+}
+
+export function upsertGeneticsSnp(profileData, rsidInput, genotypeInput, source = {}) {
+  const rsid = String(rsidInput || '').trim().toLowerCase();
+  const genotype = String(genotypeInput || '').trim().toUpperCase();
+  if (!/^rs\d+$/.test(rsid)) return { ok: false, error: 'Enter a valid rsID, e.g. rs1801133.' };
+  if (!/^[ACGT]{1,2}$/.test(genotype)) return { ok: false, error: 'Enter a genotype using A/C/G/T, e.g. CT.' };
+  const entry = _snpTable?.[rsid];
+  if (!entry) return { ok: false, error: 'This SNP is not in the getbased health SNP catalog yet.' };
+  const match = findGenotypeMatch(entry, genotype);
+  if (!match) return { ok: false, error: 'That genotype does not match this SNP catalog entry.' };
+  if (!profileData.genetics) {
+    profileData.genetics = { source: 'Manual SNPs', importDate: new Date().toISOString().slice(0, 10), coverage: { found: 0, total: 0 }, effects: {}, snps: {}, catalogVersion: _catalogSignature(_snpTable) };
+  }
+  if (!profileData.genetics.snps) profileData.genetics.snps = {};
+  const sourceMeta = {
+    type: source.type || 'manual',
+    label: source.label || source.fileName || 'Manual entry',
+    fileName: source.fileName || null,
+    rawText: source.rawText || null,
+    addedAt: source.addedAt || new Date().toISOString(),
+  };
+  profileData.genetics.snps[rsid] = {
+    genotype,
+    normalizedGenotype: match.key,
+    gene: entry.gene,
+    variant: entry.variant,
+    category: entry.category || null,
+    markers: entry.markers || [],
+    effect: match.info.effect,
+    valence: match.info.valence,
+    note: match.info.note,
+    source: sourceMeta,
+  };
+  profileData.genetics.source = sourceMeta.label || profileData.genetics.source || 'Manual SNPs';
+  profileData.genetics.importDate = new Date().toISOString().slice(0, 10);
+  profileData.genetics.catalogVersion = _catalogSignature(_snpTable);
+  recalculateGeneticsSummary(profileData.genetics);
+  return { ok: true, rsid, snp: profileData.genetics.snps[rsid] };
+}
+
 export function saveGeneticsData(profileData, parseResult) {
   // Count effects for quick display (avoids needing SNP table at render time)
   const apoe = resolveAPOE(parseResult.matches);
@@ -533,6 +665,7 @@ export function saveGeneticsData(profileData, parseResult) {
   for (const [rsid, data] of Object.entries(parseResult.matches)) {
     profileData.genetics.snps[rsid] = {
       genotype: data.genotype,
+      normalizedGenotype: data.normalizedGenotype || findGenotypeMatch(_snpTable?.[rsid], data.genotype)?.key || data.genotype,
       gene: data.gene,
       variant: data.variant,
       category: data.category || null,
@@ -666,7 +799,12 @@ export function renderGeneticsSection() {
       <span class="genetics-empty-stub-icon" aria-hidden="true">&#129516;</span>
       <span class="genetics-empty-stub-body">
         <span class="genetics-empty-stub-title">Add your DNA data</span>
-        <span class="genetics-empty-stub-sub">Upload raw data from Ancestry, 23andMe, MyHeritage, FTDNA, or Living DNA — AI factors your variants into every lab interpretation. Files stay on this device.</span>
+        <span class="genetics-empty-stub-sub">Upload raw DNA, import a lab report PDF, or add one SNP manually. Files stay on this device.</span>
+        <span class="genetics-empty-actions">
+          <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-file')}>Raw DNA file</button>
+          <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-snp-report')}>Report PDF/text</button>
+          <button type="button" class="genetics-action-link" ${dnaActionAttrs('add-manual-snp')}>Add SNP manually</button>
+        </span>
       </span>
       <span class="genetics-empty-stub-arrow" aria-hidden="true">&rarr;</span>
     </div>`;
@@ -894,7 +1032,9 @@ export function renderGeneticsSection() {
   }
 
   html += `<div class="genetics-actions">
-    <button type="button" class="genetics-action-link" ${dnaActionAttrs('reimport-dna')}>Re-import</button>
+    <button type="button" class="genetics-action-link" ${dnaActionAttrs('add-manual-snp')}>Add SNP</button>
+    <button type="button" class="genetics-action-link" ${dnaActionAttrs('import-snp-report')}>Import report</button>
+    <button type="button" class="genetics-action-link" ${dnaActionAttrs('reimport-dna')}>Re-import raw DNA</button>
     <button type="button" class="genetics-action-link genetics-action-delete" ${dnaActionAttrs('delete-dna')}>Delete</button>
   </div>`;
   html += `</div></div>`;
@@ -928,6 +1068,167 @@ function reimportDNA() {
     if (file && window.handleDNAFile) window.handleDNAFile(file);
   };
   input.click();
+}
+
+let _dnaModalEscapeBound = false, _dnaBackdropMouseDownInside = false;
+
+function nudgeDnaModal() {
+  const dialog = document.querySelector('#dna-modal-overlay .modal');
+  if (!(dialog instanceof HTMLElement)) return;
+  dialog.classList.remove('modal-nudge'); void dialog.offsetWidth;
+  dialog.classList.add('modal-nudge');
+  dialog.addEventListener('animationend', () => dialog.classList.remove('modal-nudge'), { once: true });
+}
+
+function handleDnaBackdropMouseDown(event) {
+  const target = event.target;
+  _dnaBackdropMouseDownInside = target instanceof Element && !!target.closest('.modal');
+}
+
+function handleDnaBackdropClick(event) {
+  const target = event.target;
+  if (_dnaBackdropMouseDownInside) { _dnaBackdropMouseDownInside = false; return; }
+  if (!(target instanceof Element) || target.id !== 'dna-modal-overlay') return;
+  event.preventDefault();
+  nudgeDnaModal();
+}
+
+function handleDnaModalEscape(event) {
+  const overlay = document.getElementById('dna-modal-overlay');
+  if (event.key !== 'Escape' || !overlay?.classList.contains('show')) return;
+  event.preventDefault();
+  closeDNAImportPreview();
+}
+
+function openDnaModalOverlay(overlay, initialFocus) {
+  if (!overlay.dataset.dnaBackdropNudgeWired) {
+    overlay.addEventListener('mousedown', handleDnaBackdropMouseDown);
+    overlay.addEventListener('click', handleDnaBackdropClick);
+    overlay.dataset.dnaBackdropNudgeWired = '1';
+  }
+  if (!_dnaModalEscapeBound) { document.addEventListener('keydown', handleDnaModalEscape); _dnaModalEscapeBound = true; }
+  openModalOverlay(overlay, { initialFocus, focusDelay: 30, scrollLock: true });
+}
+
+async function openManualSnpModal() {
+  await loadSNPTable();
+  dnaWindow._pendingDNAImport = null;
+  const html = `<div class="dna-preview-header dna-manual-header">
+      <div>
+        <div class="dna-preview-title">Add SNPs manually</div>
+        <div class="dna-preview-stats">Paste one SNP or a whole small report table. Same path, no duplicate modes.</div>
+      </div>
+    </div>
+    <div class="dna-preview-body dna-manual-snp-body">
+      <div class="dna-manual-card dna-manual-card-bulk">
+        <div class="dna-manual-section-head">
+          <span>SNP calls</span>
+          <small>One per line: rsID + genotype. Notes after that are optional.</small>
+        </div>
+        <textarea id="manual-snp-bulk" class="dna-manual-textarea" rows="7" spellcheck="false" placeholder="rs1801133 CC&#10;rs1801131 AC&#10;rs429358 TT APOE report"></textarea>
+      </div>
+      <label class="dna-manual-field dna-manual-source">Source label
+        <input id="manual-snp-source" class="dna-manual-input" type="text" placeholder="Manual entry / lab report name" autocomplete="off">
+      </label>
+      <p class="dna-manual-help">Use a single line for one SNP, or paste a dozen lines. getbased validates each rsID, normalizes strand-aware genotypes, and merges accepted rows into existing genome data.</p>
+    </div>
+    <div class="dna-preview-actions">
+      <button type="button" class="import-btn import-btn-secondary" ${dnaActionAttrs('close-preview')}>Cancel</button>
+      <button type="button" class="import-btn import-btn-primary" ${dnaActionAttrs('save-manual-snp')}>Save SNPs</button>
+    </div>`;
+  let overlay = document.getElementById('dna-modal-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'dna-modal-overlay';
+    overlay.className = 'modal-overlay';
+    document.body.appendChild(overlay);
+  }
+  overlay.innerHTML = `<div class="modal dna-preview-modal dna-manual-modal" role="dialog" aria-label="Add SNPs manually">${html}</div>`;
+  openDnaModalOverlay(overlay, '#manual-snp-bulk');
+}
+
+export function parseManualSnpRows(singleRsid, singleGenotype, bulkText) {
+  const rows = [];
+  const addRow = (rsid, genotype, note = '') => rows.push({ rsid: String(rsid || '').trim(), genotype: String(genotype || '').trim(), note: String(note || '').trim() });
+  if (String(singleRsid || '').trim() || String(singleGenotype || '').trim()) addRow(singleRsid, singleGenotype);
+  for (const rawLine of String(bulkText || '').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const match = line.match(/^(rs\d+)\s*[,;:\t ]\s*([ACGT]{1,2})\b\s*(.*)$/i);
+    if (match) addRow(match[1], match[2], match[3]);
+    else rows.push({ rsid: '', genotype: '', note: line, error: `Could not read "${line}". Use: rs1801133 CC` });
+  }
+  return rows;
+}
+
+async function saveManualSnpFromModal() {
+  await loadSNPTable();
+  const rsid = /** @type {HTMLInputElement | null} */ (document.getElementById('manual-snp-rsid'))?.value || '';
+  const genotype = /** @type {HTMLInputElement | null} */ (document.getElementById('manual-snp-genotype'))?.value || '';
+  const bulk = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('manual-snp-bulk'))?.value || '';
+  const label = /** @type {HTMLInputElement | null} */ (document.getElementById('manual-snp-source'))?.value || 'Manual SNP entry';
+  const rows = parseManualSnpRows(rsid, genotype, bulk);
+  if (rows.length === 0) { showNotification('Add at least one rsID + genotype pair.', 'error'); return; }
+
+  const originalData = state.importedData;
+  const draftData = JSON.parse(JSON.stringify(originalData || {}));
+  const accepted = [], errors = [];
+  for (const [index, row] of rows.entries()) {
+    if (row.error) { errors.push(`Line ${index + 1}: ${row.error}`); continue; }
+    const source = { type: 'manual', label, rawText: [row.rsid, row.genotype, row.note].filter(Boolean).join(' ') || null };
+    const result = upsertGeneticsSnp(draftData, row.rsid, row.genotype, source);
+    if (!result.ok) errors.push(`${row.rsid || `Line ${index + 1}`}: ${result.error || 'Could not save SNP'}`);
+    else accepted.push(result);
+  }
+  if (accepted.length === 0) { showNotification(errors.slice(0, 3).join(' · ') || 'Could not save SNPs', 'error', 7000); return; }
+  state.importedData = draftData;
+  if (!await saveImportedData()) { state.importedData = originalData; return; }
+  closeModalOverlay('dna-modal-overlay');
+  const errorSuffix = errors.length ? ` (${errors.length} skipped)` : '';
+  showNotification(`Saved ${accepted.length} SNP${accepted.length === 1 ? '' : 's'}${errorSuffix}`, errors.length ? 'info' : 'success', 5000);
+  if (errors.length && window.isDebugMode?.()) console.warn('Manual SNP import skipped rows:', errors);
+  if (window.buildSidebar) try { window.buildSidebar(); } catch (e) {}
+  if (window.navigate) window.navigate('genome');
+}
+
+async function importSnpReport() {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.pdf,.txt,.csv,.text';
+  input.onchange = async () => {
+    const file = input.files?.[0];
+    if (!file) return;
+    await handleSnpReportFile(file);
+  };
+  input.click();
+}
+
+async function handleSnpReportFile(file) {
+  if (_dnaImportRunning) { showNotification('DNA import already in progress', 'info'); return; }
+  _dnaImportRunning = true;
+  try {
+    showNotification('Reading SNP report...', 'info');
+    await loadSNPTable({ forceFresh: true });
+    let text = '';
+    if (/\.pdf$/i.test(file.name) || file.type === 'application/pdf') {
+      const { extractPDFText } = await import('./pdf-import.js');
+      text = await extractPDFText(file);
+    } else {
+      text = await file.text();
+    }
+    const result = parseClinicalSnpReportText(text, { source: file.name, fileName: file.name, type: 'pdf-report' });
+    result.mergeSnps = true;
+    if (Object.keys(result.matches).length === 0) {
+      showNotification('No catalog SNP results found in this report. Add the SNP manually.', 'error');
+      _dnaImportRunning = false;
+      return;
+    }
+    showDNAImportPreview(result, file.name);
+  } catch (e) {
+    if (window.isDebugMode?.()) console.error('SNP report import error:', e);
+    showNotification(e.message || 'Failed to read SNP report', 'error');
+    _dnaImportRunning = false;
+  }
 }
 
 // ═══════════════════════════════════════════════
@@ -1041,21 +1342,30 @@ function showDNAImportPreview(result, fileName) {
     document.body.appendChild(overlay);
   }
   overlay.innerHTML = `<div class="modal dna-preview-modal" role="dialog">${html}</div>`;
-  openModalOverlay(overlay);
+  openDnaModalOverlay(overlay, '.import-btn-primary');
 }
 
 function closeDNAImportPreview() {
   dnaWindow._pendingDNAImport = null;
   _dnaImportRunning = false;
   closeModalOverlay('dna-modal-overlay');
+  if (_dnaModalEscapeBound) { document.removeEventListener('keydown', handleDnaModalEscape); _dnaModalEscapeBound = false; }
 }
 
 async function confirmDNAImport() {
   const result = dnaWindow._pendingDNAImport;
   if (!result) return;
-  saveGeneticsData(state.importedData, result);
+  const originalData = state.importedData;
+  const draftData = JSON.parse(JSON.stringify(originalData || {}));
+  if (result.mergeSnps) {
+    for (const [rsid, snp] of Object.entries(result.matches || {})) {
+      const saved = upsertGeneticsSnp(draftData, rsid, snp.genotype, snp.source || { type: 'report-text', label: result.source });
+      if (!saved.ok) { showNotification(saved.error || `Could not save ${rsid}`, 'error'); _dnaImportRunning = false; return; }
+    }
+  } else saveGeneticsData(draftData, result);
+  state.importedData = draftData;
   if (!await saveImportedData()) {
-    _dnaImportRunning = false;
+    state.importedData = originalData; _dnaImportRunning = false;
     return;
   }
   dnaWindow._pendingDNAImport = null;
@@ -1153,7 +1463,7 @@ async function confirmDeleteDNA() {
   }
 }
 
-initDnaActionDelegates({ triggerDNAFilePicker: () => window.triggerDNAFilePicker?.(), closeDNAImportPreview, closeMtDNAPreview, confirmDeleteDNA, confirmDNAImport, confirmMtDNAImport, deleteMtDNAData, reimportDNA, toggleGeneticsCollapse, toggleGeneticsExpand });
+initDnaActionDelegates({ triggerDNAFilePicker: () => window.triggerDNAFilePicker?.(), closeDNAImportPreview, closeMtDNAPreview, confirmDeleteDNA, confirmDNAImport, confirmMtDNAImport, deleteMtDNAData, importSnpReport, openManualSnpModal, reimportDNA, saveManualSnpFromModal, toggleGeneticsCollapse, toggleGeneticsExpand });
 
 // ═══════════════════════════════════════════════
 // WINDOW EXPORTS
@@ -1162,7 +1472,14 @@ Object.assign(window, {
   isDNAFile,
   isDNAFileByContent,
   detectDNAFile,
+  parseClinicalSnpReportText,
+  parseManualSnpRows,
+  upsertGeneticsSnp,
   handleDNAFile,
+  handleSnpReportFile,
+  importSnpReport,
+  openManualSnpModal,
+  saveManualSnpFromModal,
   closeDNAImportPreview,
   confirmDNAImport,
   confirmDeleteDNA,

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -57,6 +57,10 @@ function handleLensPageShellClick(event) {
     callLensPageRuntime('removeDashboardWidgetFromLens', id);
   } else if (action === 'import-dna') {
     callLensPageRuntime('triggerDNAFilePicker');
+  } else if (action === 'import-snp-report') {
+    callLensPageRuntime('importSnpReport');
+  } else if (action === 'add-manual-snp') {
+    callLensPageRuntime('openManualSnpModal');
   } else if (action === 'reimport-dna') {
     if (typeof lensPageRuntime().reimportDNA === 'function') callLensPageRuntime('reimportDNA');
     else callLensPageRuntime('triggerDNAFilePicker');

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -217,8 +217,10 @@ export function createLensPageHandlers(deps) {
     const genetics = state.importedData?.genetics || {};
     const hasSnps = Object.keys(genetics.snps || {}).length > 0;
     const affiliate = hasSnps ? '' : `<span class="lens-header-affiliate">No raw file? We recommend a <a href="https://www.dpbolvw.net/q2101xdmjdl0212824AA4024989447" target="_blank" rel="noopener sponsored">LivingDNA kit</a>.</span>`;
-    let html = renderLensHeader('Genome', 'Dedicated DNA workspace: actionable genetic modifiers, import status, mtDNA, and lab-linked context.',
-      `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('import-dna')}>Import DNA file</button>${affiliate}`);
+    const genomeActions = `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('import-dna')}>Import raw DNA</button>
+      <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('import-snp-report')}>Import report</button>
+      <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('add-manual-snp')}>Add SNP manually</button>${affiliate}`;
+    let html = renderLensHeader('Genome', 'Dedicated DNA workspace: actionable genetic modifiers, import status, mtDNA, and lab-linked context.', genomeActions, { className: 'genome-lens-header' });
     html += renderLensPageWidgets('genome', [
       { id: 'genome', title: 'Actionable Genetic Modifiers', description: 'Priority SNP context relevant to labs and goals', body: renderDashboardGenomeWidget(), size: 'full', opts: { source: 'Genome' } },
       importDetails ? { id: 'genome-import', title: 'Import Details', description: 'Source, counts, mtDNA, and file management', body: importDetails, size: 'full', opts: { source: 'Genome', dashboardId: '' } } : null,

--- a/tests/test-data-pipeline.js
+++ b/tests/test-data-pipeline.js
@@ -574,6 +574,8 @@ const S = window._labState;
   assert('marker-analysis has detectTrendAlerts function', markerAnalysisSrc.includes('export function detectTrendAlerts('));
   assert('marker-analysis has getKeyTrendMarkers function', markerAnalysisSrc.includes('export function getKeyTrendMarkers('));
   assert('data.js keeps marker-analysis compatibility exports', dataJsSrc.includes("} from './marker-analysis.js'"));
+  assert('saveImportedData reports failure only for persistence errors, not post-save hooks',
+    /await encryptedSetItem\(key, value\);\s*\}\s*catch \(e\) \{[\s\S]*?return false;[\s\S]*?\}\s*try \{[\s\S]*?onDataSaved\(options\);[\s\S]*?\}\s*catch \(e\) \{[\s\S]*?Post-save hook failed after data was persisted[\s\S]*?\}\s*return true;/.test(dataJsSrc));
 
   // PhenoAge coefficients present
   assert('data.js has PhenoAge xb calculation', dataJsSrc.includes('-19.907'));

--- a/tests/test-dna.js
+++ b/tests/test-dna.js
@@ -61,6 +61,9 @@ assert('detectDNAFile exported', typeof dna.detectDNAFile === 'function');
 assert('isDNAFile exported', typeof dna.isDNAFile === 'function');
 assert('parseDNAFile exported', typeof dna.parseDNAFile === 'function');
 assert('saveGeneticsData exported', typeof dna.saveGeneticsData === 'function');
+assert('upsertGeneticsSnp exported', typeof dna.upsertGeneticsSnp === 'function');
+assert('parseManualSnpRows exported', typeof dna.parseManualSnpRows === 'function');
+assert('parseClinicalSnpReportText exported', typeof dna.parseClinicalSnpReportText === 'function');
 assert('deleteGeneticsData exported', typeof dna.deleteGeneticsData === 'function');
 assert('buildGeneticsContext exported', typeof dna.buildGeneticsContext === 'function');
 assert('buildFullGeneticsContext exported', typeof dna.buildFullGeneticsContext === 'function');
@@ -315,6 +318,37 @@ assert('SNP has variant', profileData.genetics?.snps?.rs1801133?.variant === 'C6
 assert('SNP has functional category', profileData.genetics?.snps?.rs1801133?.category === 'methylation');
 assert('SNP has marker links', Array.isArray(profileData.genetics?.snps?.rs1801133?.markers));
 
+const manualProfile = { genetics: JSON.parse(JSON.stringify(profileData.genetics)) };
+const beforeManualCount = Object.keys(manualProfile.genetics.snps || {}).length;
+const manualC677T = dna.upsertGeneticsSnp(manualProfile, 'rs1801133', 'CC', {
+  type: 'manual',
+  label: 'Unilabs thrombophilia report',
+  rawText: 'CC – homozygot pre štandardnú alelu'
+});
+assert('Manual SNP upsert succeeds for catalog SNP', manualC677T.ok === true, manualC677T.error);
+assert('Manual SNP preserves existing SNP map instead of replacing genetics', Object.keys(manualProfile.genetics.snps || {}).length === beforeManualCount);
+assert('Manual SNP keeps reported genotype', manualProfile.genetics.snps.rs1801133?.genotype === 'CC');
+assert('Manual SNP records normalized catalog genotype', manualProfile.genetics.snps.rs1801133?.normalizedGenotype === 'GG');
+assert('Manual SNP stores source metadata', manualProfile.genetics.snps.rs1801133?.source?.type === 'manual' && manualProfile.genetics.snps.rs1801133?.source?.label === 'Unilabs thrombophilia report');
+assert('Manual SNP rejects unknown rsID', dna.upsertGeneticsSnp(manualProfile, 'rs999999999', 'AA', { type: 'manual' }).ok === false);
+assert('Manual SNP rejects malformed genotype', dna.upsertGeneticsSnp(manualProfile, 'rs1801133', 'C?', { type: 'manual' }).ok === false);
+const manualRows = dna.parseManualSnpRows('rs1801133', 'CC', 'rs1801131 AC Unilabs line\nrs429358;TT\nnot parseable');
+assert('Manual SNP bulk parser combines single row and pasted rows', manualRows.length === 4 && manualRows[0].rsid === 'rs1801133' && manualRows[1].rsid === 'rs1801131' && manualRows[1].note === 'Unilabs line');
+assert('Manual SNP bulk parser accepts semicolon delimiters', manualRows[2].rsid === 'rs429358' && manualRows[2].genotype === 'TT');
+assert('Manual SNP bulk parser reports unreadable lines without throwing', manualRows[3].error && manualRows[3].note === 'not parseable');
+const bulkProfile = { genetics: { snps: {} } };
+for (const row of manualRows.slice(0, 3)) dna.upsertGeneticsSnp(bulkProfile, row.rsid, row.genotype, { type: 'manual', label: 'Bulk paste', rawText: row.note });
+assert('Manual SNP bulk rows can save multiple catalog SNPs', Object.keys(bulkProfile.genetics.snps).length === 3 && bulkProfile.genetics.snps.rs1801131?.normalizedGenotype === 'TG');
+
+const clinicalReportText = `Trombofilné varianty\nMTHFR: 677C>T   rs1801133 BPO\n04.05.26 11:48CC – homozygot pre štandardnú alelu\nMTHFR: 1298A>C   rs1801131 BPO\n04.05.26 11:48AC – heterozygot`;
+const clinicalResult = dna.parseClinicalSnpReportText(clinicalReportText, { source: 'Unilabs report' });
+assert('Clinical SNP report detects two report SNPs', Object.keys(clinicalResult.matches).length === 2, JSON.stringify(clinicalResult.matches));
+assert('Clinical SNP report extracts rs1801133 reported genotype', clinicalResult.matches.rs1801133?.genotype === 'CC');
+assert('Clinical SNP report normalizes rs1801133 CC to catalog reference', clinicalResult.matches.rs1801133?.normalizedGenotype === 'GG');
+assert('Clinical SNP report extracts rs1801131 heterozygous genotype', clinicalResult.matches.rs1801131?.genotype === 'AC');
+assert('Clinical SNP report normalizes rs1801131 AC to catalog heterozygous', clinicalResult.matches.rs1801131?.normalizedGenotype === 'TG');
+assert('Clinical SNP report carries source label', clinicalResult.source === 'Unilabs report');
+
 // Delete
 dna.deleteGeneticsData(profileData);
 assert('deleteGeneticsData removes genetics', profileData.genetics === undefined);
@@ -353,6 +387,7 @@ console.log('11. Window Exports');
 assert('window.isDNAFile exists', typeof window.isDNAFile === 'function');
 assert('window.handleDNAFile exists', typeof window.handleDNAFile === 'function');
 assert('window.confirmDNAImport exists', typeof window.confirmDNAImport === 'function');
+assert('window.openManualSnpModal exists', typeof window.openManualSnpModal === 'function');
 assert('window.closeDNAImportPreview exists', typeof window.closeDNAImportPreview === 'function');
 assert('window.deleteGeneticsData exists', typeof window.deleteGeneticsData === 'function');
 assert('window._buildGeneticsContext exists', typeof window._buildGeneticsContext === 'function');
@@ -400,12 +435,26 @@ assert('Genome lens avoids duplicated full genetics surfaces',
   lensPagesSrc.includes("renderLensPageWidgets('genome'") &&
   !viewsSrc.includes('Imported Genome Data'));
 
+assert('Genome lens exposes raw, report, and manual SNP import actions with scoped spacing class',
+  lensPagesSrc.includes("lensPageActionAttrs('import-dna')") &&
+  lensPagesSrc.includes("lensPageActionAttrs('import-snp-report')") &&
+  lensPagesSrc.includes("lensPageActionAttrs('add-manual-snp')") &&
+  lensPagesSrc.includes('Add SNP manually') &&
+  lensPagesSrc.includes("className: 'genome-lens-header'"));
+const lensShellSrc = await fetchWithRetry('js/lens-page-shell.js');
+assert('Genome lens action delegate opens report and manual SNP flows',
+  lensShellSrc.includes("action === 'import-snp-report'") &&
+  lensShellSrc.includes("callLensPageRuntime('importSnpReport')") &&
+  lensShellSrc.includes("action === 'add-manual-snp'") &&
+  lensShellSrc.includes("callLensPageRuntime('openManualSnpModal')"));
+
 const stylesSrc = [
   await fetchWithRetry('styles.css'),
   await fetchWithRetry('css/dashboard-core.css'),
   await fetchWithRetry('css/dashboard-widgets.css'),
   await fetchWithRetry('css/dashboard-welcome.css'),
   await fetchWithRetry('css/dashboard-data.css'),
+  await fetchWithRetry('css/genetics.css'),
 ].join('\n');
 const genomeCategoryCss = (stylesSrc.match(/\.db-genome-category\s*\{([^}]*)\}/) || [null, ''])[1];
 assert('dashboard genome category groups avoid duplicate severity border',
@@ -414,21 +463,63 @@ assert('dashboard genome category groups avoid duplicate severity border',
   genomeCategoryCss.includes('color-mix(in srgb, var(--bg-secondary)'));
 assert('dashboard genome SNP rows keep severity left border',
   stylesSrc.includes('.db-snp-significant') && stylesSrc.includes('border-left-color: var(--db-snp-tone)'));
+assert('Lens page headers space CTA controls away from header copy',
+  stylesSrc.includes('.lens-page-header .dashboard-widget-inline-controls') &&
+  stylesSrc.includes('margin-top: 14px') &&
+  stylesSrc.includes('column-gap: 14px') &&
+  stylesSrc.includes('row-gap: 10px'));
+assert('Genome lens header keeps affiliate link on its own row',
+  stylesSrc.includes('.genome-lens-header .lens-header-affiliate') &&
+  stylesSrc.includes('flex-basis: 100%'));
 
 const dnaSrc = await fetchWithRetry('js/dna.js');
 const dnaMtDnaSrc = await fetchWithRetry('js/dna-mtdna.js');
 assert('genetics section collapses non-priority SNP calls', dnaSrc.includes('genetics-other-snps') && dnaSrc.includes('Other imported SNPs'));
+assert('genetics actions expose manual SNP and report import escape hatches',
+  dnaSrc.includes("dnaActionAttrs('add-manual-snp')") &&
+  dnaSrc.includes("dnaActionAttrs('import-snp-report')") &&
+  dnaSrc.includes("accept = '.pdf,.txt,.csv,.text'") &&
+  dnaSrc.includes('manual-snp-bulk') &&
+  dnaSrc.includes('Save SNPs') &&
+  dnaSrc.includes('Same path, no duplicate modes'));
+assert('manual SNP UI uses one paste surface instead of duplicate single/bulk mechanisms',
+  dnaSrc.includes('<textarea id="manual-snp-bulk"') &&
+  !dnaSrc.includes('id="manual-snp-rsid"') &&
+  !dnaSrc.includes('id="manual-snp-genotype"') &&
+  !dnaSrc.includes('Single SNP'));
+assert('manual SNP modal uses genetics-styled controls instead of generic form-input fields',
+  dnaSrc.includes('dna-manual-input') &&
+  dnaSrc.includes('dna-manual-textarea') &&
+  !dnaSrc.includes('id="manual-snp-rsid" class="form-input"'));
+assert('manual SNP CSS gives inputs app-native surfaces and focus rings',
+  stylesSrc.includes('.dna-manual-input') &&
+  stylesSrc.includes('background: var(--bg-primary)') &&
+  stylesSrc.includes('box-shadow: 0 0 0 3px'));
+assert('manual/report SNP imports stage changes in a draft and restore memory on save failure',
+  dnaSrc.includes('const originalData = state.importedData') &&
+  dnaSrc.includes('const draftData = JSON.parse(JSON.stringify(originalData || {}))') &&
+  dnaSrc.includes('upsertGeneticsSnp(draftData') &&
+  dnaSrc.includes('state.importedData = draftData') &&
+  dnaSrc.includes('state.importedData = originalData'));
+assert('manual/report SNP imports merge through upsert instead of replacing genetics',
+  dnaSrc.includes('result.mergeSnps') && dnaSrc.includes('upsertGeneticsSnp(draftData'));
 assert('DNA import preview separates beneficial findings', dnaSrc.includes('Beneficial findings') && dnaSrc.includes("impact: m.valence === 'protective' ? 'beneficial' : m.effect"));
-assert('DNA preview modal uses shared overlay lifecycle helpers',
+assert('DNA preview modal uses shared overlay lifecycle helpers and backdrop nudge',
   dnaSrc.includes("from './modal-lifecycle.js'") &&
+    dnaSrc.includes('nudgeDnaModal') &&
+    dnaSrc.includes("classList.add('modal-nudge')") &&
+    dnaSrc.includes('handleDnaBackdropClick') &&
+    dnaSrc.includes("target.id !== 'dna-modal-overlay'") &&
+    dnaSrc.includes('handleDnaModalEscape') &&
+    dnaSrc.includes("event.key !== 'Escape'") &&
     dnaMtDnaSrc.includes("from './modal-lifecycle.js'") &&
-    dnaSrc.includes('openModalOverlay(overlay)') &&
+    dnaSrc.includes('openDnaModalOverlay(overlay') &&
     dnaMtDnaSrc.includes('openModalOverlay(overlay)') &&
     ((dnaSrc.match(/closeModalOverlay\('dna-modal-overlay'\)/g) || []).length
-      + (dnaMtDnaSrc.match(/closeModalOverlay\('dna-modal-overlay'\)/g) || []).length) === 3);
+      + (dnaMtDnaSrc.match(/closeModalOverlay\('dna-modal-overlay'\)/g) || []).length) === 4);
 assert('DNA import success waits for persistence',
-  /async function confirmDNAImport\(\)[\s\S]{0,220}await saveImportedData\(\)/.test(dnaSrc));
-const dnaSaveFailureBlock = (dnaSrc.match(/if \(!await saveImportedData\(\)\) \{([\s\S]*?)\n  \}/) || [null, ''])[1];
+  /async function confirmDNAImport\(\)[\s\S]{0,900}await saveImportedData\(\)/.test(dnaSrc));
+const dnaSaveFailureBlock = (dnaSrc.match(/async function confirmDNAImport\(\)[\s\S]*?if \(!await saveImportedData\(\)\) \{([\s\S]*?)\n  \}/) || [null, ''])[1];
 assert('DNA import save failure resets running flag but keeps preview retryable',
   dnaSaveFailureBlock.includes('_dnaImportRunning = false') &&
   dnaSaveFailureBlock.includes('return;') &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.48';
+self.APP_VERSION = '1.10.49';


### PR DESCRIPTION
## Summary
- adds a unified manual SNP entry modal for one or many rsID/genotype calls
- parses small clinical SNP reports locally and merges accepted SNPs into existing genome data
- improves Genome/lens header spacing and keeps the LivingDNA link on its own row
- bumps the in-app changelog/version to 1.10.49

## Verification
- `npm run typecheck`
- `npm test`
- `node tests/test-dna.js`
- `node tests/test-changelog.js`
- Browser smoke on `http://127.0.0.1:8174/app`: manual batch saved `rs1801133 CC` and `rs1801131 AC`; backdrop nudges, Escape closes; lens headers have 14px CTA spacing

## Notes
- `npm run quality` now passes 4/5 guardrails; the remaining failure is the existing `large JS files >=800 lines` baseline drift (`30 > 29`) already present on `origin/main`. This branch keeps `js/dna.js` at the hard cap (`1513/1513`) rather than increasing it.
