### PR TITLE
[codex] Extract profile runtime wiring

### DIFF
--- a/js/profile-runtime.js
+++ b/js/profile-runtime.js
@@ -1,0 +1,62 @@
+// @ts-check
+// profile-runtime.js - Browser runtime refresh hooks for profile lifecycle.
+
+import { state } from './state.js';
+
+export async function invalidateProfileContextCache() {
+  try {
+    const mod = await import('./lab-context.js');
+    mod.invalidateLabContextCache?.();
+  } catch (_) {}
+}
+
+export async function reloadProfileRuntimeShell(profileId) {
+  const [
+    chatPersonalities,
+    chatThreads,
+    chatHistory,
+    chatDiscussion,
+    data,
+    nav,
+    views,
+  ] = await Promise.all([
+    import('./chat-personalities.js'),
+    import('./chat-threads.js'),
+    import('./chat-history.js'),
+    import('./chat-discussion.js'),
+    import('./data.js'),
+    import('./nav.js'),
+    import('./views.js'),
+  ]);
+
+  chatPersonalities.loadChatPersonality();
+  chatThreads.loadChatThreads?.();
+  if (state.chatThreads.length > 0) chatThreads.ensureActiveThread?.();
+  await chatHistory.loadChatHistory?.();
+  if (state.currentProfile !== profileId) return;
+
+  chatThreads.renderThreadList?.();
+  chatPersonalities.updateChatHeaderTitle?.();
+  chatPersonalities.updatePersonalityBar?.();
+  chatDiscussion.updateDiscussButton?.();
+  data.destroyAllCharts();
+  nav.buildSidebar();
+  views.navigate(views.getInitialView?.() || 'dashboard');
+  data.updateHeaderDates();
+  data.updateHeaderRangeToggle();
+  nav.renderProfileButton();
+}
+
+export async function refreshProfileButton() {
+  try {
+    const mod = await import('./nav.js');
+    mod.renderProfileButton();
+  } catch (_) {}
+}
+
+export function dispatchProfileSwitched(profileId) {
+  if (typeof globalThis.CustomEvent !== 'function') return;
+  try {
+    globalThis.dispatchEvent(new CustomEvent('labcharts-profile-switched', { detail: { profileId } }));
+  } catch (_) {}
+}

--- a/js/profile.js
+++ b/js/profile.js
@@ -4,7 +4,8 @@
 import { state } from './state.js';
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS } from './schema.js';
 import { COUNTRY_LATITUDES, LATITUDE_BANDS } from './constants.js';
-import { showNotification } from './utils.js';
+import { callClaudeAPI } from './api.js';
+import { isDebugMode, showConfirmDialog, showNotification } from './utils.js';
 import { encryptedSetItem, encryptedGetItem, encryptedRemoveItem } from './crypto.js';
 import { normalizeLightEnvironmentEveningFields } from './light-env-evening.js';
 import {
@@ -14,6 +15,28 @@ import {
   syncLabEntryInsulinMirror,
 } from './lab-entry.js';
 import { normalizeContextSourceSettings } from './context-source-registry.js';
+import {
+  dispatchProfileSwitched,
+  invalidateProfileContextCache,
+  refreshProfileButton,
+  reloadProfileRuntimeShell,
+} from './profile-runtime.js';
+
+const profileDeps = {
+  callClaudeAPI,
+  isDebugMode,
+  showConfirmDialog,
+  showNotification,
+};
+
+export function configureProfileDeps(deps = {}) {
+  const previous = { ...profileDeps };
+  if (typeof deps.callClaudeAPI === 'function') profileDeps.callClaudeAPI = deps.callClaudeAPI;
+  if (typeof deps.isDebugMode === 'function') profileDeps.isDebugMode = deps.isDebugMode;
+  if (typeof deps.showConfirmDialog === 'function') profileDeps.showConfirmDialog = deps.showConfirmDialog;
+  if (typeof deps.showNotification === 'function') profileDeps.showNotification = deps.showNotification;
+  return previous;
+}
 
 /**
  * @typedef {{ country: string, zip: string }} ProfileLocation
@@ -154,7 +177,8 @@ export async function saveProfiles(profiles) {
     const value = JSON.stringify(profiles);
     await encryptedSetItem('labcharts-profiles', value);
   } catch (e) {
-    showNotification('Storage limit reached — could not save profile changes.', 'error');
+    profileDeps.showNotification('Storage limit reached — could not save profile changes.', 'error');
+    throw e;
   }
 }
 
@@ -955,7 +979,7 @@ export function migrateProfileData(data) {
 export async function loadProfile(profileId) {
   state.currentProfile = profileId;
   setActiveProfileId(profileId);
-  /** @type {any} */ (window).invalidateLabContextCache?.();
+  await invalidateProfileContextCache();
   const savedImported = await encryptedGetItem(profileStorageKey(profileId, 'imported'));
   const defaultData = createDefaultProfileData();
   state.importedData = savedImported ? (function() {
@@ -987,11 +1011,7 @@ export async function loadProfile(profileId) {
       } catch {}
       // Surface to the user via the global notification system if available;
       // fall back to console so headless paths still log it.
-      if (typeof window !== 'undefined' && window.showNotification) {
-        window.showNotification('Profile data was corrupted and could not be loaded. The original bytes were saved as a backup — open Settings → Data to export them or contact support.', 'error', 12000);
-      } else {
-        console.error('[loadProfile] corrupted JSON for', profileId, '— saved to imported-corrupt');
-      }
+      profileDeps.showNotification('Profile data was corrupted and could not be loaded. The original bytes were saved as a backup — open Settings → Data to export them or contact support.', 'error', 12000);
       return defaultData;
     }
   })() : defaultData;
@@ -1013,21 +1033,7 @@ export async function loadProfile(profileId) {
   state.chatThreads = [];
   state.currentThreadId = null;
   state.markerRegistry = {};
-  window.loadChatPersonality();
-  window.loadChatThreads?.();
-  if (state.chatThreads.length > 0) window.ensureActiveThread?.();
-  await window.loadChatHistory?.();
-  if (state.currentProfile !== profileId) return;
-  window.renderThreadList?.();
-  window.updateChatHeaderTitle?.();
-  window.updatePersonalityBar?.();
-  window.updateDiscussButton?.();
-  window.destroyAllCharts();
-  window.buildSidebar();
-  window.navigate(window.getInitialView?.() || 'dashboard');
-  window.updateHeaderDates();
-  window.updateHeaderRangeToggle();
-  window.renderProfileButton();
+  await reloadProfileRuntimeShell(profileId);
   // Refresh wearable summary for the freshly-loaded profile so the strip
   // reflects THIS profile's L1 IDB rather than carrying over stale state
   // from the boot profile. Both modules dynamic-imported to avoid circular
@@ -1138,10 +1144,10 @@ export function touchProfileTimestamp(profileId) {
  */
 export async function deleteProfile(profileId, onComplete) {
   const profiles = getProfiles();
-  if (profiles.length <= 1) { showNotification("Cannot delete the last profile", "error"); return; }
-  if (await window.showConfirmDialog('Delete this profile and all its data? This cannot be undone.')) {
+  if (profiles.length <= 1) { profileDeps.showNotification("Cannot delete the last profile", "error"); return; }
+  if (await profileDeps.showConfirmDialog('Delete this profile and all its data? This cannot be undone.')) {
     const updated = profiles.filter(p => p.id !== profileId);
-    saveProfiles(updated);
+    await saveProfiles(updated);
     // The `-imported` blob lives in IndexedDB now → encryptedRemoveItem
     // hits both backends so the IDB residue is also wiped.
     await encryptedRemoveItem(profileStorageKey(profileId, 'imported'));
@@ -1184,11 +1190,11 @@ export async function deleteProfile(profileId, onComplete) {
     // tombstoned rows; CRDT LWW handles cross-device conflict resolution.
     import('./sync.js').then(m => m.deleteProfileFromRelay(profileId)).catch(() => {});
     if (state.currentProfile === profileId) {
-      loadProfile(updated[0].id);
+      await loadProfile(updated[0].id);
     } else {
-      window.renderProfileButton();
+      await refreshProfileButton();
     }
-    showNotification('Profile deleted', 'info');
+    profileDeps.showNotification('Profile deleted', 'info');
     if (onComplete) onComplete();
   }
 }
@@ -1209,13 +1215,11 @@ export async function switchProfile(profileId) {
   await loadProfile(profileId);
   const profiles = getProfiles();
   const p = profiles.find(p => p.id === profileId);
-  showNotification(`Switched to ${p ? p.name : 'profile'}`, 'info');
+  profileDeps.showNotification(`Switched to ${p ? p.name : 'profile'}`, 'info');
   // Modules with per-profile module-singleton state (sun.js region map cache,
   // overlay cache, tick counters, in-flight rehydrate flag) listen for this
   // event so their caches don't bleed across profiles after a switch.
-  if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
-    try { window.dispatchEvent(new CustomEvent('labcharts-profile-switched', { detail: { profileId } })); } catch (_) {}
-  }
+  dispatchProfileSwitched(profileId);
   // Push updated context to messenger gateway so bots see the new profile
   import('./sync.js').then(m => m.pushContextToGateway()).catch(() => {});
 }
@@ -1343,7 +1347,7 @@ export async function detectLatitudeWithAI(country, zip) {
   if (getLocationCache()[cacheKey] !== undefined) return;
   try {
     var locationStr = zip ? country + ' ' + zip : country;
-    var { text: response } = await window.callClaudeAPI({
+    var { text: response } = await profileDeps.callClaudeAPI({
       system: 'You are a geography assistant. Reply with ONLY a number \u2014 the approximate latitude in decimal degrees (positive for North, negative for South). No text, no degree symbol, just the number.',
       messages: [{ role: 'user', content: 'Latitude of: ' + locationStr }],
       maxTokens: 10
@@ -1359,7 +1363,7 @@ export async function detectLatitudeWithAI(country, zip) {
       }
     }
   } catch(e) {
-    if (window.isDebugMode()) console.warn('[Location] AI detection failed:', e);
+    if (profileDeps.isDebugMode()) console.warn('[Location] AI detection failed:', e);
   }
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -101,6 +101,7 @@ const APP_SHELL = [
   '/js/import-drop-zone.js',
   '/js/ai-verdict-engine.js',
   '/js/profile.js',
+  '/js/profile-runtime.js',
   '/js/data.js',
   '/js/marker-analysis.js',
   '/js/blob-storage.js',

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -7,9 +7,11 @@ test('client list live menu actions dispatch exports share demos and profile sta
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
     const { configureClientListRuntime } = await import('/js/client-list.js');
+    const profile = await import('/js/profile.js');
     const outcomes = {};
     const calls = [];
     const confirmQueue = [];
+    let previousProfileDeps = null;
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 60; attempt += 1) {
@@ -136,6 +138,9 @@ test('client list live menu actions dispatch exports share demos and profile sta
         calls.push(['confirm', message]);
         return confirmQueue.shift() === true;
       };
+      previousProfileDeps = profile.configureProfileDeps({
+        showConfirmDialog: window.showConfirmDialog,
+      });
       HTMLInputElement.prototype.click = function() {
         calls.push(['input-click', this.id || this.type || 'input']);
       };
@@ -251,6 +256,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
       window.loadDemoData = saved.loadDemoData;
       window.openProfileShareModal = saved.openProfileShareModal;
       window.showConfirmDialog = saved.showConfirmDialog;
+      if (previousProfileDeps) profile.configureProfileDeps(previousProfileDeps);
       HTMLInputElement.prototype.click = saved.inputClick;
       document.querySelectorAll('.notification-container,.notification-toast').forEach(el => el.remove());
     }

--- a/tests/playwright/profile-browser-coverage.spec.js
+++ b/tests/playwright/profile-browser-coverage.spec.js
@@ -24,10 +24,9 @@ test('profile browser coverage exercises migration height and latitude helpers',
       profiles: clone(state.profiles),
       currentProfile: state.currentProfile,
       storage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
-      callClaudeAPI: window.callClaudeAPI,
-      isDebugMode: window.isDebugMode,
       locationDisplay: document.getElementById('loc-lat-display'),
     };
+    let previousProfileDeps = null;
     const profileId = 'profile-browser-coverage';
     let latitudeCalls = 0;
 
@@ -91,11 +90,13 @@ test('profile browser coverage exercises migration height and latitude helpers',
       const latDisplay = document.createElement('div');
       latDisplay.id = 'loc-lat-display';
       document.body.appendChild(latDisplay);
-      window.callClaudeAPI = async () => {
-        latitudeCalls += 1;
-        return { text: '-34.6' };
-      };
-      window.isDebugMode = () => false;
+      previousProfileDeps = profile.configureProfileDeps({
+        callClaudeAPI: async () => {
+          latitudeCalls += 1;
+          return { text: '-34.6' };
+        },
+        isDebugMode: () => false,
+      });
 
       await profile.detectLatitudeWithAI('Argentina', 'C1000');
       await profile.detectLatitudeWithAI('Argentina', 'C1000');
@@ -112,10 +113,7 @@ test('profile browser coverage exercises migration height and latitude helpers',
         if (value == null) localStorage.removeItem(key);
         else localStorage.setItem(key, value);
       }
-      if (saved.callClaudeAPI === undefined) delete window.callClaudeAPI;
-      else window.callClaudeAPI = saved.callClaudeAPI;
-      if (saved.isDebugMode === undefined) delete window.isDebugMode;
-      else window.isDebugMode = saved.isDebugMode;
+      if (previousProfileDeps) profile.configureProfileDeps(previousProfileDeps);
       document.getElementById('loc-lat-display')?.remove();
       if (saved.locationDisplay) document.body.appendChild(saved.locationDisplay);
     }

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -278,14 +278,20 @@ assert('isSensitiveKey matches thread index (crypto.js SENSITIVE_PATTERNS)',
 // ═══════════════════════════════════════════════
 console.log('15. Profile Delete Cleanup (source inspection)');
 const profileSrc = read('js/profile.js');
+const profileRuntimeSrc = read('js/profile-runtime.js');
 assert('deleteProfile removes chat-threads key', profileSrc.includes('chat-threads'));
 assert('deleteProfile removes chat-t_ keys', profileSrc.includes('chat-t_'));
 assert('deleteProfile removes chatRailOpen', profileSrc.includes('chatRailOpen'));
 assert('loadProfile resets chatThreads', profileSrc.includes('state.chatThreads = []'));
 assert('loadProfile resets currentThreadId', profileSrc.includes('state.currentThreadId = null'));
-assert('loadProfile reloads active profile chat threads', profileSrc.includes('window.loadChatThreads?.()'));
-assert('loadProfile reloads active profile chat history', profileSrc.includes('await window.loadChatHistory?.()'));
-assert('loadProfile rerenders chat rail after profile switch', profileSrc.includes('window.renderThreadList?.()'));
+assert('loadProfile delegates runtime refresh after profile switch',
+  profileSrc.includes('await reloadProfileRuntimeShell(profileId)'));
+assert('profile-runtime reloads active profile chat threads',
+  profileRuntimeSrc.includes('chatThreads.loadChatThreads?.()'));
+assert('profile-runtime reloads active profile chat history',
+  profileRuntimeSrc.includes('await chatHistory.loadChatHistory?.()'));
+assert('profile-runtime rerenders chat rail after profile switch',
+  profileRuntimeSrc.includes('chatThreads.renderThreadList?.()'));
 
 // ═══════════════════════════════════════════════
 // 16. Thread Search Extraction (source inspection)

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -428,10 +428,32 @@ try {
 console.log('17. profile.js async');
 try {
   const src = await fetchWithRetry('js/profile.js');
+  const runtimeSrc = await fetchWithRetry('js/profile-runtime.js');
+  const swSrc = await fetchWithRetry('service-worker.js');
   assert('loadProfile is async', src.includes('async function loadProfile'));
   assert('saveProfiles is async', src.includes('async function saveProfiles'));
   assert('initProfilesCache exists', src.includes('async function initProfilesCache'));
   assert('loadProfile uses encryptedGetItem', src.includes('encryptedGetItem'));
+  assert('profile.js delegates browser refresh wiring to profile-runtime',
+    src.includes("from './profile-runtime.js'") &&
+    src.includes('await invalidateProfileContextCache()') &&
+    src.includes('await reloadProfileRuntimeShell(profileId)') &&
+    runtimeSrc.includes('export async function invalidateProfileContextCache') &&
+    runtimeSrc.includes('export async function reloadProfileRuntimeShell'));
+  assert('profile delete awaits profile list save before completion',
+    src.includes('await saveProfiles(updated)') &&
+    (src.includes('await loadProfile(updated[0].id)') || src.includes('await refreshProfileButton()')));
+  assert('saveProfiles rejects failed profile-list writes',
+    /catch \(e\) \{[\s\S]{0,200}throw e;/.test(src));
+  assert('profile.js no longer calls profile-load UI globals through window',
+    !/window\.(loadChatPersonality|loadChatThreads|loadChatHistory|renderThreadList|destroyAllCharts|buildSidebar|navigate|renderProfileButton)/.test(src));
+  assert('profile-runtime keeps profile UI refresh module-owned',
+    runtimeSrc.includes("import('./chat-personalities.js')") &&
+    runtimeSrc.includes("import('./chat-threads.js')") &&
+    runtimeSrc.includes("import('./data.js')") &&
+    !runtimeSrc.includes('Object.assign(window'));
+  assert('Service worker precaches profile runtime module',
+    swSrc.includes("'/js/profile-runtime.js'"));
 } catch (e) {
   assert('profile.js async check', false, e.message);
 }

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -87,6 +87,7 @@ const highValueCheckJsModules = [
   'js/light-tool-camera-modals.js',
   'js/pdf-import.js',
   'js/profile.js',
+  'js/profile-runtime.js',
   'js/recommendations.js',
   'js/settings.js',
   'js/sun.js',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -517,6 +517,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   {
     const startupUiSrc = fetchSrc('js/startup-ui.js');
     const profileSrc = fetchSrc('js/profile.js');
+    const profileRuntimeSrc = fetchSrc('js/profile-runtime.js');
     const viewsSrc = fetchSrc('js/views.js');
     const routerSrc = fetchSrc('js/views-router.js');
     const navSrc = fetchSrc('js/nav.js');
@@ -536,7 +537,8 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /requireStartupRuntime\('navigate',\s*callStartupRuntime\('getInitialView'\)\s*\|\|\s*'dashboard'\)/.test(startupUiSrc)
       && !/window\.showDashboard\(\);/.test(startupUiSrc));
     assert('profile.js: profile switch restores that profile route',
-      /window\.navigate\(window\.getInitialView\?\.\(\) \|\| 'dashboard'\)/.test(profileSrc));
+      profileSrc.includes('await reloadProfileRuntimeShell(profileId)')
+      && /views\.navigate\(views\.getInitialView\?\.\(\) \|\| 'dashboard'\)/.test(profileRuntimeSrc));
     assert('nav.js: sidebar rebuild preserves current route selection',
       /export function syncSidebarActive/.test(navSrc)
       && /nav\.innerHTML\s*=\s*html;\s*syncSidebarActive\(state\.currentView \|\| 'dashboard'\)/.test(navSrc));

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -168,6 +168,7 @@
     "js/pii.js",
     "js/profile-share.js",
     "js/profile.js",
+    "js/profile-runtime.js",
     "js/provider-panels.js",
     "js/recommendations.js",
     "js/settings.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -163,6 +163,7 @@
     "js/pdfjs-loader.js",
     "js/pii.js",
     "js/profile.js",
+    "js/profile-runtime.js",
     "js/profile-share.js",
     "js/recommendation-actions.js",
     "js/recommendations.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.64';
+self.APP_VERSION = '1.10.65';


### PR DESCRIPTION
## Summary
- Extract profile-switch browser refresh wiring from js/profile.js into js/profile-runtime.js.
- Route profile runtime collaborators through module imports/dependencies instead of profile.js direct window lookups.
- Register the new module in service worker cache, typecheck configs, quality guardrails, and update profile-focused tests.

## Impact
- Reduces direct window global references in js/ from 692 to 669.
- Keeps profile switching behavior covered: chat threads/history, route restoration, profile delete confirmation, and latitude detection seams.
- Bumps APP_VERSION to 1.10.65 for app-file cache invalidation.

## Validation
- npm run quality
- npx playwright test tests/playwright/client-list-browser-coverage.spec.js
- npx playwright test tests/playwright/profile-browser-coverage.spec.js
- ./run-tests.sh
