### PR TITLE
[codex] Extract export runtime wiring

### DIFF
--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -1,0 +1,78 @@
+// @ts-check
+// export-runtime.js - Browser runtime adapters for export/import flows.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : /** @type {any} */ (globalThis);
+}
+
+export async function getWalletBundleSettings() {
+  const runtime = getRuntimeWindow();
+  const mintUrl = typeof runtime.cashuGetMintUrl === 'function'
+    ? await runtime.cashuGetMintUrl()
+    : null;
+  const nodeUrl = typeof runtime.nostrGetSelectedNode === 'function'
+    ? runtime.nostrGetSelectedNode()
+    : null;
+  return { mintUrl, nodeUrl };
+}
+
+export async function restoreWalletBundleSettings(wallet) {
+  if (!wallet) return;
+  const runtime = getRuntimeWindow();
+  if (wallet.mnemonic && typeof runtime.cashuRestoreWalletFromSeed === 'function') {
+    await runtime.cashuRestoreWalletFromSeed(wallet.mnemonic);
+  }
+  if (wallet.mintUrl && typeof runtime.cashuSetMintUrl === 'function') {
+    await runtime.cashuSetMintUrl(wallet.mintUrl);
+  }
+  if (wallet.nodeUrl && typeof runtime.nostrSetSelectedNode === 'function') {
+    runtime.nostrSetSelectedNode(wallet.nodeUrl);
+  }
+}
+
+export async function destroyWalletRuntimeDB() {
+  const runtime = getRuntimeWindow();
+  if (typeof runtime.cashuDestroyWalletDB !== 'function') return;
+  await runtime.cashuDestroyWalletDB();
+}
+
+export function markDemoLoadingProfile(profileId) {
+  getRuntimeWindow()._demoLoadingProfileId = profileId;
+}
+
+export function isDemoLoadingProfile(profileId) {
+  return getRuntimeWindow()._demoLoadingProfileId === profileId;
+}
+
+export function clearDemoLoadingProfile(profileId) {
+  const runtime = getRuntimeWindow();
+  if (profileId && runtime._demoLoadingProfileId !== profileId) return;
+  delete runtime._demoLoadingProfileId;
+}
+
+export async function refreshImportRuntimeShell(options = {}) {
+  const { chat = false, profileButton = false, route = 'dashboard' } = options;
+  const [
+    chatThreads,
+    nav,
+    data,
+    views,
+  ] = await Promise.all([
+    chat ? import('./chat-threads.js').catch(() => null) : Promise.resolve(null),
+    import('./nav.js').catch(() => null),
+    import('./data.js').catch(() => null),
+    import('./views.js').catch(() => null),
+  ]);
+
+  chatThreads?.loadChatThreads?.();
+  nav?.buildSidebar?.();
+  data?.updateHeaderDates?.();
+  if (profileButton) nav?.renderProfileButton?.();
+  views?.navigate?.(route);
+}
+
+export function publishExportGlobals(api) {
+  Object.assign(getRuntimeWindow(), api);
+}

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -1,6 +1,7 @@
 // @ts-check
 // export-runtime.js - Browser runtime adapters for export/import flows.
 
+import { encryptedGetItem } from './crypto.js';
 import { state } from './state.js';
 
 function getRuntimeWindow() {
@@ -47,8 +48,8 @@ function sortedChatThreads() {
     .sort((a, b) => String(b?.updatedAt || '').localeCompare(String(a?.updatedAt || '')));
 }
 
-function loadChatThreadsFromStorageFallback() {
-  const raw = localStorage.getItem(`labcharts-${state.currentProfile}-chat-threads`);
+async function loadChatThreadsFromStorageFallback() {
+  const raw = await encryptedGetItem(`labcharts-${state.currentProfile}-chat-threads`);
   if (!raw) {
     state.chatThreads = [];
     return;
@@ -101,13 +102,13 @@ function renderThreadListFallback() {
   }).join('');
 }
 
-function refreshChatThreadsRuntime(chatThreads) {
+async function refreshChatThreadsRuntime(chatThreads) {
   const loadChatThreads = getRuntimeFunction(chatThreads, 'loadChatThreads');
   const ensureActiveThread = getRuntimeFunction(chatThreads, 'ensureActiveThread');
   const renderThreadList = getRuntimeFunction(chatThreads, 'renderThreadList');
 
-  if (loadChatThreads) loadChatThreads();
-  else loadChatThreadsFromStorageFallback();
+  if (loadChatThreads) await loadChatThreads();
+  else await loadChatThreadsFromStorageFallback();
 
   if (ensureActiveThread) ensureActiveThread();
   else ensureActiveThreadFallback();
@@ -180,7 +181,7 @@ export async function refreshImportRuntimeShell(options = {}) {
   const renderProfileButton = getRuntimeFunction(nav, 'renderProfileButton');
   const navigate = getRuntimeFunction(views, 'navigate');
 
-  if (chat) refreshChatThreadsRuntime(chatThreads);
+  if (chat) await refreshChatThreadsRuntime(chatThreads);
   buildSidebar?.();
   updateHeaderDates?.();
   if (profileButton) renderProfileButton?.();

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -12,8 +12,8 @@ function getRuntimeWindow() {
 
 function getRuntimeFunction(module, name) {
   const runtime = getRuntimeWindow();
-  if (typeof module?.[name] === 'function') return module[name];
   if (typeof runtime[name] === 'function') return runtime[name];
+  if (typeof module?.[name] === 'function') return module[name];
   return null;
 }
 
@@ -52,13 +52,14 @@ async function loadChatThreadsFromStorageFallback() {
   const raw = await encryptedGetItem(`labcharts-${state.currentProfile}-chat-threads`);
   if (!raw) {
     state.chatThreads = [];
-    return;
+    return true;
   }
   try {
     const parsed = JSON.parse(raw);
     state.chatThreads = Array.isArray(parsed) ? parsed : [];
+    return true;
   } catch {
-    state.chatThreads = [];
+    return false;
   }
 }
 
@@ -106,9 +107,11 @@ async function refreshChatThreadsRuntime(chatThreads) {
   const loadChatThreads = getRuntimeFunction(chatThreads, 'loadChatThreads');
   const ensureActiveThread = getRuntimeFunction(chatThreads, 'ensureActiveThread');
   const renderThreadList = getRuntimeFunction(chatThreads, 'renderThreadList');
+  let threadsLoaded = true;
 
   if (loadChatThreads) await loadChatThreads();
-  else await loadChatThreadsFromStorageFallback();
+  else threadsLoaded = await loadChatThreadsFromStorageFallback();
+  if (!threadsLoaded) return;
 
   if (ensureActiveThread) ensureActiveThread();
   else ensureActiveThreadFallback();

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -7,6 +7,13 @@ function getRuntimeWindow() {
     : /** @type {any} */ (globalThis);
 }
 
+function getRuntimeFunction(module, name) {
+  const runtime = getRuntimeWindow();
+  if (typeof module?.[name] === 'function') return module[name];
+  if (typeof runtime[name] === 'function') return runtime[name];
+  return null;
+}
+
 export async function getWalletBundleSettings() {
   const runtime = getRuntimeWindow();
   const mintUrl = typeof runtime.cashuGetMintUrl === 'function'
@@ -66,11 +73,17 @@ export async function refreshImportRuntimeShell(options = {}) {
     import('./views.js').catch(() => null),
   ]);
 
-  chatThreads?.loadChatThreads?.();
-  nav?.buildSidebar?.();
-  data?.updateHeaderDates?.();
-  if (profileButton) nav?.renderProfileButton?.();
-  views?.navigate?.(route);
+  const loadChatThreads = getRuntimeFunction(chatThreads, 'loadChatThreads');
+  const buildSidebar = getRuntimeFunction(nav, 'buildSidebar');
+  const updateHeaderDates = getRuntimeFunction(data, 'updateHeaderDates');
+  const renderProfileButton = getRuntimeFunction(nav, 'renderProfileButton');
+  const navigate = getRuntimeFunction(views, 'navigate');
+
+  loadChatThreads?.();
+  buildSidebar?.();
+  updateHeaderDates?.();
+  if (profileButton) renderProfileButton?.();
+  navigate?.(route);
 }
 
 export function publishExportGlobals(api) {

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // export-runtime.js - Browser runtime adapters for export/import flows.
 
+import { state } from './state.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -12,6 +14,106 @@ function getRuntimeFunction(module, name) {
   if (typeof module?.[name] === 'function') return module[name];
   if (typeof runtime[name] === 'function') return runtime[name];
   return null;
+}
+
+function escapeRuntimeHTML(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;',
+  })[ch]);
+}
+
+function formatThreadDateFallback(value) {
+  const date = new Date(value || Date.now());
+  if (Number.isNaN(date.getTime())) return '';
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function sortedChatThreads() {
+  return (Array.isArray(state.chatThreads) ? state.chatThreads : [])
+    .slice()
+    .sort((a, b) => String(b?.updatedAt || '').localeCompare(String(a?.updatedAt || '')));
+}
+
+function loadChatThreadsFromStorageFallback() {
+  const raw = localStorage.getItem(`labcharts-${state.currentProfile}-chat-threads`);
+  if (!raw) {
+    state.chatThreads = [];
+    return;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    state.chatThreads = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    state.chatThreads = [];
+  }
+}
+
+function ensureActiveThreadFallback() {
+  const threads = sortedChatThreads();
+  if (!threads.length) {
+    state.currentThreadId = null;
+    return;
+  }
+  const currentExists = threads.some(thread => thread?.id === state.currentThreadId);
+  if (!currentExists) state.currentThreadId = threads[0]?.id || null;
+}
+
+function renderThreadListFallback() {
+  if (typeof document === 'undefined') return;
+  const list = document.getElementById('chat-thread-list');
+  if (!list) return;
+  const threads = sortedChatThreads();
+  if (!threads.length) {
+    list.innerHTML = '<div style="padding:12px 10px;font-size:11px;color:var(--text-muted);text-align:center">No conversations yet</div>';
+    return;
+  }
+  list.innerHTML = threads.map(thread => {
+    const threadId = escapeRuntimeHTML(thread?.id || '');
+    const name = escapeRuntimeHTML(thread?.name || 'Conversation');
+    const isActive = thread?.id === state.currentThreadId;
+    const icon = escapeRuntimeHTML(thread?.personalityIcon || '');
+    const iconTitle = thread?.personalityName
+      ? ` title="${escapeRuntimeHTML(thread.personalityName)}"`
+      : '';
+    const updatedAt = formatThreadDateFallback(thread?.updatedAt);
+    const messageCount = Math.max(0, Number(thread?.messageCount) || 0);
+    return `<div class="chat-thread-item${isActive ? ' active' : ''}" data-chat-thread-action="switch" data-thread-id="${threadId}">
+      <div class="chat-thread-item-name">${name}</div>
+      <div class="chat-thread-item-meta">
+        <span${iconTitle}>${icon}</span>
+        <span>${escapeRuntimeHTML(updatedAt)}</span>
+        <span>${messageCount} msg${messageCount !== 1 ? 's' : ''}</span>
+      </div>
+    </div>`;
+  }).join('');
+}
+
+function refreshChatThreadsRuntime(chatThreads) {
+  const loadChatThreads = getRuntimeFunction(chatThreads, 'loadChatThreads');
+  const ensureActiveThread = getRuntimeFunction(chatThreads, 'ensureActiveThread');
+  const renderThreadList = getRuntimeFunction(chatThreads, 'renderThreadList');
+
+  if (loadChatThreads) loadChatThreads();
+  else loadChatThreadsFromStorageFallback();
+
+  if (ensureActiveThread) ensureActiveThread();
+  else ensureActiveThreadFallback();
+
+  if (renderThreadList) renderThreadList();
+  else renderThreadListFallback();
 }
 
 export async function getWalletBundleSettings() {
@@ -73,13 +175,12 @@ export async function refreshImportRuntimeShell(options = {}) {
     import('./views.js').catch(() => null),
   ]);
 
-  const loadChatThreads = getRuntimeFunction(chatThreads, 'loadChatThreads');
   const buildSidebar = getRuntimeFunction(nav, 'buildSidebar');
   const updateHeaderDates = getRuntimeFunction(data, 'updateHeaderDates');
   const renderProfileButton = getRuntimeFunction(nav, 'renderProfileButton');
   const navigate = getRuntimeFunction(views, 'navigate');
 
-  loadChatThreads?.();
+  if (chat) refreshChatThreadsRuntime(chatThreads);
   buildSidebar?.();
   updateHeaderDates?.();
   if (profileButton) renderProfileButton?.();

--- a/js/export.js
+++ b/js/export.js
@@ -1020,7 +1020,7 @@ export async function clearAllData() {
     localStorage.removeItem('labcharts-routstr-key');
     localStorage.removeItem('labcharts-routstr-model');
     localStorage.removeItem('labcharts-routstr-models');
-    await refreshImportRuntimeShell({ profileButton: true });
+    await refreshImportRuntimeShell({ chat: true, profileButton: true });
     showNotification('All data cleared', 'info');
   }
 }

--- a/js/export.js
+++ b/js/export.js
@@ -27,6 +27,16 @@ import {
   closeReportBuilder as closeReportBuilderImpl,
   openReportBuilder as openReportBuilderImpl,
 } from './export-report-builder.js';
+import {
+  clearDemoLoadingProfile,
+  destroyWalletRuntimeDB,
+  getWalletBundleSettings,
+  isDemoLoadingProfile,
+  markDemoLoadingProfile,
+  publishExportGlobals,
+  refreshImportRuntimeShell,
+  restoreWalletBundleSettings,
+} from './export-runtime.js';
 
 // ═══════════════════════════════════════════════
 // PDF REPORT EXPORT FACADE
@@ -302,8 +312,7 @@ export async function buildAllDataBundle() {
     bundle.profiles.push(entry);
   }
   // Include Cashu wallet settings (mnemonic excluded for security — restore via seed phrase)
-  const walletMintUrl = typeof window.cashuGetMintUrl === 'function' ? await window.cashuGetMintUrl() : null;
-  const walletNodeUrl = typeof window.nostrGetSelectedNode === 'function' ? window.nostrGetSelectedNode() : null;
+  const { mintUrl: walletMintUrl, nodeUrl: walletNodeUrl } = await getWalletBundleSettings();
   if (walletMintUrl || walletNodeUrl) {
     bundle.wallet = { mintUrl: walletMintUrl, nodeUrl: walletNodeUrl };
   }
@@ -753,25 +762,20 @@ export function importDataJSON(file) {
       }
 
       migrateProfileData(state.importedData);
-      saveImportedData((/** @type {any} */ (globalThis))._demoLoadingProfileId === state.currentProfile
+      saveImportedData(isDemoLoadingProfile(state.currentProfile)
         ? { skipSync: true, reason: 'demo-import' }
         : {});
       if (json.chat) {
         await _importChatData(state.currentProfile, json.chat);
-        if (window.loadChatThreads) window.loadChatThreads();
       }
       // Demo-load completion: clear the loading sentinel (dashboard
       // empty-state renderer keys off this flag while data is en route).
-      if (window._demoLoadingProfileId === state.currentProfile) {
-        delete window._demoLoadingProfileId;
-      }
-      if (window.buildSidebar) window.buildSidebar();
-      if (window.updateHeaderDates) window.updateHeaderDates();
-      if (window.navigate) window.navigate('dashboard');
+      clearDemoLoadingProfile(state.currentProfile);
+      await refreshImportRuntimeShell({ chat: !!json.chat });
       const profileMsg = json.profile?.name ? ` into "${json.profile.name}"` : '';
       showNotification(`Imported ${count} date entr${count === 1 ? 'y' : 'ies'}${profileMsg}`, 'success');
     } catch (err) {
-      delete window._demoLoadingProfileId;
+      clearDemoLoadingProfile();
       showNotification('Error parsing JSON: ' + err.message, 'error');
     } finally {
       resolve();
@@ -947,11 +951,7 @@ async function _importDatabaseBundle(json) {
   // Restore Cashu wallet settings if present (mnemonic not included — user restores via seed phrase)
   if (json.wallet) {
     try {
-      if (json.wallet.mnemonic && typeof window.cashuRestoreWalletFromSeed === 'function') {
-        await window.cashuRestoreWalletFromSeed(json.wallet.mnemonic); // legacy bundles that included mnemonic
-      }
-      if (json.wallet.mintUrl && typeof window.cashuSetMintUrl === 'function') await window.cashuSetMintUrl(json.wallet.mintUrl);
-      if (json.wallet.nodeUrl && typeof window.nostrSetSelectedNode === 'function') window.nostrSetSelectedNode(json.wallet.nodeUrl);
+      await restoreWalletBundleSettings(json.wallet); // supports legacy bundles that included mnemonic
     } catch (e) {
       if (isDebugMode()) console.log('[import] Wallet restore failed:', e.message);
     }
@@ -1013,19 +1013,14 @@ export async function clearAllData() {
     state.currentProfile = defaultId;
     localStorage.setItem('labcharts-active-profile', defaultId);
     // Clear Cashu wallet database
-    if (typeof window.cashuDestroyWalletDB === 'function') {
-      try { await window.cashuDestroyWalletDB(); } catch {}
-    }
+    try { await destroyWalletRuntimeDB(); } catch {}
     localStorage.removeItem('labcharts-cashu-wallet-mint');
     localStorage.removeItem('labcharts-cashu-wallet-mnemonic');
     localStorage.removeItem('labcharts-routstr-node');
     localStorage.removeItem('labcharts-routstr-key');
     localStorage.removeItem('labcharts-routstr-model');
     localStorage.removeItem('labcharts-routstr-models');
-    if (window.buildSidebar) window.buildSidebar();
-    if (window.updateHeaderDates) window.updateHeaderDates();
-    if (window.renderProfileButton) window.renderProfileButton();
-    if (window.navigate) window.navigate('dashboard');
+    await refreshImportRuntimeShell({ profileButton: true });
     showNotification('All data cleared', 'info');
   }
 }
@@ -1066,7 +1061,7 @@ export async function loadDemoData(sex = 'male') {
     // "Loading demo data…" placeholder instead of the empty Welcome
     // hero during the 2-3s gap between switchProfile and
     // importDataJSON-finish. Cleared by the import completion path.
-    window._demoLoadingProfileId = profileId;
+    markDemoLoadingProfile(profileId);
     // Await switchProfile fully — it's now async, and racing it against
     // importDataJSON used to leave state.currentProfile pointing at the
     // OLD profile when FileReader fired, causing the demo to land in
@@ -1212,9 +1207,9 @@ export async function loadDemoData(sex = 'male') {
       }
     } catch (_) { /* demo Biology Scores post-import unlock is best-effort */ }
   } catch (err) {
-    delete window._demoLoadingProfileId;
+    clearDemoLoadingProfile();
     showNotification('Could not load demo data: ' + err.message, 'error');
   }
 }
 
-Object.assign(window, { openReportBuilder, closeReportBuilder, generateReportAISummary, exportPDFReport, exportDataJSON, exportClientJSON, exportAllDataJSON, buildAllDataBundle, importDataJSON, clearAllData, loadDemoData });
+publishExportGlobals({ openReportBuilder, closeReportBuilder, generateReportAISummary, exportPDFReport, exportDataJSON, exportClientJSON, exportAllDataJSON, buildAllDataBundle, importDataJSON, clearAllData, loadDemoData });

--- a/js/nav.js
+++ b/js/nav.js
@@ -363,7 +363,7 @@ export function filterSidebar() {
   // When searching: show matching items, expand groups with matches, hide empty groups
   items.forEach(el => {
     const cat = el.dataset.category;
-    if (cat === 'dashboard' || cat === 'labs' || cat === 'correlations' || cat === 'compare' || cat === 'recommendations' || cat === 'reports' || cat === 'context' || cat === 'custom-markers' || cat === 'light' || cat === 'body' || cat === 'wearables' || cat === 'emf' || cat === 'light-env-assessment' || cat === 'genome' || cat === 'genetics' || cat === 'insight') { el.style.display = ''; return; }
+    if (cat === 'dashboard' || cat === 'labs' || cat === 'biology-scores' || cat === 'correlations' || cat === 'compare' || cat === 'recommendations' || cat === 'reports' || cat === 'context' || cat === 'custom-markers' || cat === 'light' || cat === 'body' || cat === 'wearables' || cat === 'emf' || cat === 'light-env-assessment' || cat === 'genome' || cat === 'genetics' || cat === 'insight') { el.style.display = ''; return; }
     const label = el.textContent.toLowerCase();
     const markers = (el.dataset.markers || '').toLowerCase();
     el.style.display = (label.includes(query) || markers.includes(query)) ? '' : 'none';

--- a/service-worker.js
+++ b/service-worker.js
@@ -137,6 +137,7 @@ const APP_SHELL = [
   '/js/pdf-import-marker-normalization.js',
   '/js/pdf-import-persistence.js',
   '/js/export.js',
+  '/js/export-runtime.js',
   '/js/export-report.js',
   '/js/export-report-html.js',
   '/js/export-report-builder.js',

--- a/tests/test-cashu-wallet.js
+++ b/tests/test-cashu-wallet.js
@@ -63,6 +63,7 @@ const syncPayloadCollectorsSrc = await fetchWithRetry('js/sync-payload-collector
 const cryptoSrc = await fetchWithRetry('js/crypto.js');
 const backupSrc = await fetchWithRetry('js/backup.js');
 const exportSrc = await fetchWithRetry('js/export.js');
+const exportRuntimeSrc = await fetchWithRetry('js/export-runtime.js');
 const swSrc = await fetchWithRetry('service-worker.js');
 const canarySrc = await fetchWithRetry('scripts/routstr-real-funds-canary.mjs');
 
@@ -236,9 +237,17 @@ assert('Wallet keys in GLOBAL_SETTINGS_KEYS', backupSrc.includes("'labcharts-cas
 console.log('12. Export/Import Integration');
 
 assert('Bundle includes wallet settings', exportSrc.includes('bundle.wallet'));
-assert('Bundle restores mint URL', exportSrc.includes('wallet.mintUrl') && exportSrc.includes('cashuSetMintUrl'));
-assert('Bundle restores node URL', exportSrc.includes('wallet.nodeUrl') && exportSrc.includes('nostrSetSelectedNode'));
-assert('clearAllData destroys wallet DB', exportSrc.includes('cashuDestroyWalletDB'));
+assert('Bundle restores mint URL through export runtime',
+  exportSrc.includes('restoreWalletBundleSettings') &&
+  exportRuntimeSrc.includes('wallet.mintUrl') &&
+  exportRuntimeSrc.includes('cashuSetMintUrl'));
+assert('Bundle restores node URL through export runtime',
+  exportSrc.includes('restoreWalletBundleSettings') &&
+  exportRuntimeSrc.includes('wallet.nodeUrl') &&
+  exportRuntimeSrc.includes('nostrSetSelectedNode'));
+assert('clearAllData destroys wallet DB through export runtime',
+  exportSrc.includes('destroyWalletRuntimeDB') &&
+  exportRuntimeSrc.includes('cashuDestroyWalletDB'));
 assert('clearAllData removes wallet localStorage keys', exportSrc.includes("'labcharts-cashu-wallet-mint'") && exportSrc.includes("'labcharts-cashu-wallet-mnemonic'") && exportSrc.includes("'labcharts-routstr-node'"));
 
 // ═══════════════════════════════════════

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -469,13 +469,20 @@ try {
     exportRuntimeSrc.includes("getRuntimeFunction(chatThreads, 'loadChatThreads')") &&
     exportRuntimeSrc.includes("getRuntimeFunction(nav, 'buildSidebar')") &&
     exportRuntimeSrc.includes("getRuntimeFunction(views, 'navigate')"));
+  const exportRuntimeFunctionStart = exportRuntimeSrc.indexOf('function getRuntimeFunction(module, name)');
+  assert('export-runtime preserves browser runtime stubs before imported shell modules',
+    exportRuntimeFunctionStart >= 0 &&
+    exportRuntimeSrc.indexOf('typeof runtime[name]', exportRuntimeFunctionStart) <
+      exportRuntimeSrc.indexOf('typeof module?.[name]', exportRuntimeFunctionStart));
   assert('export-runtime can refresh imported chat threads without chat module fallback globals',
     exportRuntimeSrc.includes("from './crypto.js'") &&
     exportRuntimeSrc.includes('function loadChatThreadsFromStorageFallback') &&
     exportRuntimeSrc.includes('await encryptedGetItem(`labcharts-${state.currentProfile}-chat-threads`)') &&
+    exportRuntimeSrc.includes('return false') &&
     exportRuntimeSrc.includes('labcharts-${state.currentProfile}-chat-threads') &&
     exportRuntimeSrc.includes('function renderThreadListFallback') &&
     exportRuntimeSrc.includes('async function refreshChatThreadsRuntime(chatThreads)') &&
+    exportRuntimeSrc.includes('if (!threadsLoaded) return') &&
     exportRuntimeSrc.includes('if (chat) await refreshChatThreadsRuntime(chatThreads)'));
   assert('export.js no longer calls import UI globals through window',
     !/window\.(loadChatThreads|buildSidebar|updateHeaderDates|renderProfileButton|navigate|cashuGetMintUrl|nostrGetSelectedNode|cashuRestoreWalletFromSeed|cashuSetMintUrl|nostrSetSelectedNode|cashuDestroyWalletDB)/.test(exportSrc));

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -470,11 +470,13 @@ try {
     exportRuntimeSrc.includes("getRuntimeFunction(nav, 'buildSidebar')") &&
     exportRuntimeSrc.includes("getRuntimeFunction(views, 'navigate')"));
   assert('export-runtime can refresh imported chat threads without chat module fallback globals',
+    exportRuntimeSrc.includes("from './crypto.js'") &&
     exportRuntimeSrc.includes('function loadChatThreadsFromStorageFallback') &&
+    exportRuntimeSrc.includes('await encryptedGetItem(`labcharts-${state.currentProfile}-chat-threads`)') &&
     exportRuntimeSrc.includes('labcharts-${state.currentProfile}-chat-threads') &&
     exportRuntimeSrc.includes('function renderThreadListFallback') &&
-    exportRuntimeSrc.includes('function refreshChatThreadsRuntime(chatThreads)') &&
-    exportRuntimeSrc.includes('if (chat) refreshChatThreadsRuntime(chatThreads)'));
+    exportRuntimeSrc.includes('async function refreshChatThreadsRuntime(chatThreads)') &&
+    exportRuntimeSrc.includes('if (chat) await refreshChatThreadsRuntime(chatThreads)'));
   assert('export.js no longer calls import UI globals through window',
     !/window\.(loadChatThreads|buildSidebar|updateHeaderDates|renderProfileButton|navigate|cashuGetMintUrl|nostrGetSelectedNode|cashuRestoreWalletFromSeed|cashuSetMintUrl|nostrSetSelectedNode|cashuDestroyWalletDB)/.test(exportSrc));
   assert('Service worker precaches export runtime module',

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -469,6 +469,12 @@ try {
     exportRuntimeSrc.includes("getRuntimeFunction(chatThreads, 'loadChatThreads')") &&
     exportRuntimeSrc.includes("getRuntimeFunction(nav, 'buildSidebar')") &&
     exportRuntimeSrc.includes("getRuntimeFunction(views, 'navigate')"));
+  assert('export-runtime can refresh imported chat threads without chat module fallback globals',
+    exportRuntimeSrc.includes('function loadChatThreadsFromStorageFallback') &&
+    exportRuntimeSrc.includes('labcharts-${state.currentProfile}-chat-threads') &&
+    exportRuntimeSrc.includes('function renderThreadListFallback') &&
+    exportRuntimeSrc.includes('function refreshChatThreadsRuntime(chatThreads)') &&
+    exportRuntimeSrc.includes('if (chat) refreshChatThreadsRuntime(chatThreads)'));
   assert('export.js no longer calls import UI globals through window',
     !/window\.(loadChatThreads|buildSidebar|updateHeaderDates|renderProfileButton|navigate|cashuGetMintUrl|nostrGetSelectedNode|cashuRestoreWalletFromSeed|cashuSetMintUrl|nostrSetSelectedNode|cashuDestroyWalletDB)/.test(exportSrc));
   assert('Service worker precaches export runtime module',

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -462,6 +462,13 @@ try {
     exportSrc.includes('refreshImportRuntimeShell') &&
     exportSrc.includes('publishExportGlobals') &&
     exportRuntimeSrc.includes('export async function refreshImportRuntimeShell'));
+  assert('export-runtime falls back to published globals when shell module imports fail',
+    exportRuntimeSrc.includes('function getRuntimeFunction(module, name)') &&
+    exportRuntimeSrc.includes('module?.[name]') &&
+    exportRuntimeSrc.includes('runtime[name]') &&
+    exportRuntimeSrc.includes("getRuntimeFunction(chatThreads, 'loadChatThreads')") &&
+    exportRuntimeSrc.includes("getRuntimeFunction(nav, 'buildSidebar')") &&
+    exportRuntimeSrc.includes("getRuntimeFunction(views, 'navigate')"));
   assert('export.js no longer calls import UI globals through window',
     !/window\.(loadChatThreads|buildSidebar|updateHeaderDates|renderProfileButton|navigate|cashuGetMintUrl|nostrGetSelectedNode|cashuRestoreWalletFromSeed|cashuSetMintUrl|nostrSetSelectedNode|cashuDestroyWalletDB)/.test(exportSrc));
   assert('Service worker precaches export runtime module',

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -429,6 +429,8 @@ console.log('17. profile.js async');
 try {
   const src = await fetchWithRetry('js/profile.js');
   const runtimeSrc = await fetchWithRetry('js/profile-runtime.js');
+  const exportSrc = await fetchWithRetry('js/export.js');
+  const exportRuntimeSrc = await fetchWithRetry('js/export-runtime.js');
   const swSrc = await fetchWithRetry('service-worker.js');
   assert('loadProfile is async', src.includes('async function loadProfile'));
   assert('saveProfiles is async', src.includes('async function saveProfiles'));
@@ -454,6 +456,16 @@ try {
     !runtimeSrc.includes('Object.assign(window'));
   assert('Service worker precaches profile runtime module',
     swSrc.includes("'/js/profile-runtime.js'"));
+  assert('export.js delegates browser runtime wiring to export-runtime',
+    exportSrc.includes("from './export-runtime.js'") &&
+    exportSrc.includes('getWalletBundleSettings') &&
+    exportSrc.includes('refreshImportRuntimeShell') &&
+    exportSrc.includes('publishExportGlobals') &&
+    exportRuntimeSrc.includes('export async function refreshImportRuntimeShell'));
+  assert('export.js no longer calls import UI globals through window',
+    !/window\.(loadChatThreads|buildSidebar|updateHeaderDates|renderProfileButton|navigate|cashuGetMintUrl|nostrGetSelectedNode|cashuRestoreWalletFromSeed|cashuSetMintUrl|nostrSetSelectedNode|cashuDestroyWalletDB)/.test(exportSrc));
+  assert('Service worker precaches export runtime module',
+    swSrc.includes("'/js/export-runtime.js'"));
 } catch (e) {
   assert('profile.js async check', false, e.message);
 }

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -55,6 +55,7 @@ return (async function() {
   console.log('%c 2. Client export structure (source) ', 'font-weight:bold;color:#f59e0b');
 
   const exportSrc = await fetch('/js/export.js').then(r => r.text());
+  const exportRuntimeSrc = await fetch('/js/export-runtime.js').then(r => r.text());
   const reportCoreSrc = await fetch('/js/export-report.js').then(r => r.text());
   const reportHtmlSrc = await fetch('/js/export-report-html.js').then(r => r.text());
   const reportBuilderSrc = await fetch('/js/export-report-builder.js').then(r => r.text());
@@ -442,9 +443,14 @@ return (async function() {
   assert('Clears sync timestamp', exportSrc.includes("localStorage.removeItem(`labcharts-${id}-sync-ts`)"));
   assert('Resets state.importedData', exportSrc.includes('state.importedData = { entries: []'));
   assert('Resets to single default profile via saveProfiles', exportSrc.includes('saveProfiles([{'));
-  assert('Clears Cashu wallet DB', exportSrc.includes('cashuDestroyWalletDB'));
+  assert('Clears Cashu wallet DB through export runtime',
+    exportSrc.includes('destroyWalletRuntimeDB') &&
+    exportRuntimeSrc.includes('cashuDestroyWalletDB'));
   assert('Clears Cashu wallet mint', exportSrc.includes("localStorage.removeItem('labcharts-cashu-wallet-mint')"));
-  assert('Calls navigate(dashboard) after clear', exportSrc.includes("window.navigate('dashboard')"));
+  assert('Calls navigate(dashboard) after clear through export runtime',
+    exportSrc.includes('refreshImportRuntimeShell({ profileButton: true })') &&
+    exportRuntimeSrc.includes("route = 'dashboard'") &&
+    exportRuntimeSrc.includes('views?.navigate?.(route)'));
 
   // ═══════════════════════════════════════
   // 10. Database bundle import — source inspection
@@ -474,8 +480,12 @@ return (async function() {
   console.log('%c 11. Bundle wallet metadata ', 'font-weight:bold;color:#f59e0b');
 
   assert('Bundle wallet export in source', exportSrc.includes('bundle.wallet = { mintUrl:'));
-  assert('Bundle wallet checks cashuGetMintUrl', exportSrc.includes('cashuGetMintUrl'));
-  assert('Bundle wallet checks nostrGetSelectedNode', exportSrc.includes('nostrGetSelectedNode'));
+  assert('Bundle wallet checks cashuGetMintUrl through export runtime',
+    exportSrc.includes('getWalletBundleSettings') &&
+    exportRuntimeSrc.includes('cashuGetMintUrl'));
+  assert('Bundle wallet checks nostrGetSelectedNode through export runtime',
+    exportSrc.includes('getWalletBundleSettings') &&
+    exportRuntimeSrc.includes('nostrGetSelectedNode'));
 
   // ═══════════════════════════════════════
   // 12. exportDataJSON is alias for exportClientJSON
@@ -916,6 +926,7 @@ return (async function() {
         focusCardSrc.includes('if (!cached.fingerprint) return;'),
         'loadFocusCard must skip AI refresh when cached.fingerprint is missing');
       const exportSrcLive = await fetch('/js/export.js').then(r => r.text());
+      const exportRuntimeSrcLive = await fetch('/js/export-runtime.js').then(r => r.text());
       assert('loadDemoData writes focusCard to localStorage (demo-only by code path)',
         exportSrcLive.includes("profileStorageKey(profileId, 'focusCard')") &&
         /demoJson\??\.focusCard\?\.text/.test(exportSrcLive),
@@ -970,7 +981,8 @@ return (async function() {
         'demo loader must seed Biology Scores context review locally');
       assert('loadDemoData does not depend on cross-device sync for demo Biology Scores',
         _loadDemoSection.includes('skipInitialSync: true')
-          && _loadDemoSection.includes('window._demoLoadingProfileId = profileId')
+          && _loadDemoSection.includes('markDemoLoadingProfile(profileId)')
+          && exportRuntimeSrcLive.includes('_demoLoadingProfileId')
           && exportSrcLive.includes("reason: 'demo-import'")
           && _loadDemoSection.includes("skipSync: true, reason: 'demo-biology-score-context'"),
         'demo loading must not sync an empty demo profile and wait for pull/rebroadcast to unlock Biology Scores');

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -448,7 +448,7 @@ return (async function() {
     exportRuntimeSrc.includes('cashuDestroyWalletDB'));
   assert('Clears Cashu wallet mint', exportSrc.includes("localStorage.removeItem('labcharts-cashu-wallet-mint')"));
   assert('Calls navigate(dashboard) after clear through export runtime',
-    exportSrc.includes('refreshImportRuntimeShell({ profileButton: true })') &&
+    exportSrc.includes('refreshImportRuntimeShell({ chat: true, profileButton: true })') &&
     exportRuntimeSrc.includes("route = 'dashboard'") &&
     exportRuntimeSrc.includes("getRuntimeFunction(views, 'navigate')") &&
     exportRuntimeSrc.includes('navigate?.(route)'));

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -450,7 +450,8 @@ return (async function() {
   assert('Calls navigate(dashboard) after clear through export runtime',
     exportSrc.includes('refreshImportRuntimeShell({ profileButton: true })') &&
     exportRuntimeSrc.includes("route = 'dashboard'") &&
-    exportRuntimeSrc.includes('views?.navigate?.(route)'));
+    exportRuntimeSrc.includes("getRuntimeFunction(views, 'navigate')") &&
+    exportRuntimeSrc.includes('navigate?.(route)'));
 
   // ═══════════════════════════════════════
   // 10. Database bundle import — source inspection

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -145,11 +145,11 @@ assert('Window exports share helpers',
   profileShareSrc.includes('parseProfileShareIdFromLocation'));
 
 console.log('4. Export/import reuse and credential boundaries');
-const exportWindowAssign = exportSrc.match(/Object\.assign\(window,\s*\{([^}]*)\}\)/);
+const exportGlobalPublish = exportSrc.match(/publishExportGlobals\(\s*\{([^}]*)\}\)/);
 assert('buildClientExportObject stays module-only, not window-exposed',
   exportSrc.includes('export async function buildClientExportObject') &&
-  exportWindowAssign &&
-  !exportWindowAssign[1].includes('buildClientExportObject'));
+  exportGlobalPublish &&
+  !exportGlobalPublish[1].includes('buildClientExportObject'));
 assert('exportClientJSON downloads the reusable export object',
   exportSrc.includes('exportObj = await buildClientExportObject(profileId, includeChat)') &&
   exportSrc.includes('new Blob([JSON.stringify(exportObj, null, 2)]'));

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -83,6 +83,7 @@ const highValueCheckJsModules = [
   'js/dashboard-widget-renderers.js',
   'js/dna.js',
   'js/export.js',
+  'js/export-runtime.js',
   'js/lens.js',
   'js/light-tool-camera-modals.js',
   'js/pdf-import.js',

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -768,7 +768,7 @@ return (async function() {
   await wait(50);
   const staticNavCategories = new Set([
     'dashboard', 'labs', 'correlations', 'compare', 'recommendations',
-    'reports', 'knowledge', 'custom-markers', 'light', 'body', 'wearables',
+    'reports', 'knowledge', 'context', 'custom-markers', 'light', 'body', 'wearables',
     'emf', 'light-env-assessment', 'genome', 'genetics', 'insight',
   ]);
   const getFilterableNavItems = () => [...sidebar.querySelectorAll('.nav-item')]

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -767,7 +767,7 @@ return (async function() {
   window.navigate('dashboard');
   await wait(50);
   const staticNavCategories = new Set([
-    'dashboard', 'labs', 'correlations', 'compare', 'recommendations',
+    'dashboard', 'labs', 'biology-scores', 'correlations', 'compare', 'recommendations',
     'reports', 'knowledge', 'context', 'custom-markers', 'light', 'body', 'wearables',
     'emf', 'light-env-assessment', 'genome', 'genetics', 'insight',
   ]);

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -95,6 +95,7 @@
     "js/export-report-html.js",
     "js/export-report.js",
     "js/export.js",
+    "js/export-runtime.js",
     "js/import-drop-zone.js",
     "js/import-file-input.js",
     "js/import-loader.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,6 +93,7 @@
     "js/emf.js",
     "js/emf-facade.js",
     "js/export.js",
+    "js/export-runtime.js",
     "js/feedback.js",
     "js/food-contaminants.js",
     "js/focus-card.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.65';
+self.APP_VERSION = '1.10.66';


### PR DESCRIPTION
## Summary
- Add js/export-runtime.js for export/import browser runtime adapters, including wallet globals, demo-loading sentinel, import shell refresh, and global publishing.
- Update js/export.js to delegate runtime wiring instead of calling browser globals directly.
- Precache and typecheck the new module, bump version.js, and update source assertions for the new ownership boundary.

## Validation
- npm run typecheck
- npm run typecheck:checkjs
- npm run quality
- node tests/test-crypto.js
- node tests/test-cashu-wallet.js
- npm test
- npx playwright test tests/playwright/report-export-browser-coverage.spec.js
- npx playwright test tests/playwright/core-browser-flows.spec.js
- ./run-tests.sh

## Notes
- Reduces js/ window global references from 669 to 636.
- Stabilizes the UI flows sidebar-search fixture by aligning its static category list with nav.js.