### PR TITLE
[codex] Extract settings runtime wiring

### DIFF
--- a/js/settings-runtime.js
+++ b/js/settings-runtime.js
@@ -91,8 +91,12 @@ export function getSettingsMeteoConfig() {
 export function saveSettingsMeteoConfig(config) {
   const saveMeteoConfig = getRuntimeFunction('saveMeteoConfig');
   if (!saveMeteoConfig) return false;
-  saveMeteoConfig(config);
-  return true;
+  try {
+    saveMeteoConfig(config);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** @param {Record<string, any>} api */

--- a/js/settings-runtime.js
+++ b/js/settings-runtime.js
@@ -1,0 +1,101 @@
+// @ts-check
+// settings-runtime.js - Browser runtime adapters for Settings and Tweaks flows.
+
+const DEFAULT_METEO_CONFIG = Object.freeze({
+  mode: 'auto',
+  selfhostUrl: '',
+  selfhostBearer: '',
+  privacyRounding: 0.1,
+});
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : /** @type {any} */ (globalThis);
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {FrameRequestCallback} callback
+ * @returns {number | null}
+ */
+export function requestSettingsFrame(callback) {
+  const requestFrame = getRuntimeFunction('requestAnimationFrame');
+  return requestFrame ? requestFrame(callback) : null;
+}
+
+/** @param {number} frameId */
+export function cancelSettingsFrame(frameId) {
+  const cancelFrame = getRuntimeFunction('cancelAnimationFrame');
+  if (cancelFrame) cancelFrame(frameId);
+}
+
+/**
+ * @param {string} query
+ * @returns {boolean}
+ */
+export function settingsMediaMatches(query) {
+  const matchMedia = getRuntimeFunction('matchMedia');
+  if (!matchMedia) return false;
+  try {
+    return matchMedia(query)?.matches === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string} type
+ * @param {EventListenerOrEventListenerObject} listener
+ */
+export function addSettingsRuntimeEventListener(type, listener) {
+  const addEventListener = getRuntimeFunction('addEventListener');
+  if (addEventListener) addEventListener(type, listener);
+}
+
+/** @param {{ settingsVisible?: boolean }} [options] */
+export function refreshSettingsRuntimeSurfaces(options = {}) {
+  const runtime = getRuntimeWindow();
+  runtime.updateSettingsUI?.();
+  runtime.updateTweaksUI?.();
+  if (options.settingsVisible) runtime.refreshSettingsWearables?.();
+}
+
+/** @param {{ batchSize?: number }} [options] */
+export function refreshSettingsChartThemeColors(options = {}) {
+  getRuntimeFunction('refreshChartThemeColors')?.(options);
+}
+
+export function getSettingsMeteoConfig() {
+  const getMeteoConfig = getRuntimeFunction('getMeteoConfig');
+  if (!getMeteoConfig) return { ...DEFAULT_METEO_CONFIG };
+  try {
+    return getMeteoConfig() || { ...DEFAULT_METEO_CONFIG };
+  } catch {
+    return { ...DEFAULT_METEO_CONFIG };
+  }
+}
+
+/**
+ * @param {Record<string, any>} config
+ * @returns {boolean}
+ */
+export function saveSettingsMeteoConfig(config) {
+  const saveMeteoConfig = getRuntimeFunction('saveMeteoConfig');
+  if (!saveMeteoConfig) return false;
+  saveMeteoConfig(config);
+  return true;
+}
+
+/** @param {Record<string, any>} api */
+export function publishSettingsGlobals(api) {
+  Object.assign(getRuntimeWindow(), api);
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -1154,19 +1154,27 @@ function setMeteoMode(mode) {
   if (fields) fields.style.display = mode === 'selfhost' ? '' : 'none';
 }
 
+function notifyMeteoSaveUnavailable() {
+  showNotification('Sun data-source settings are still loading. Try again in a moment.', 'warning');
+}
+
 function saveMeteoSelfhost() {
   const cfg = getSettingsMeteoConfig();
   const url = /** @type {HTMLInputElement | null} */ (document.getElementById('meteo-selfhost-url'))?.value?.trim() || '';
   const bearer = /** @type {HTMLInputElement | null} */ (document.getElementById('meteo-selfhost-bearer'))?.value?.trim() || '';
   cfg.selfhostUrl = url;
   cfg.selfhostBearer = bearer;
-  saveSettingsMeteoConfig(cfg);
+  if (!saveSettingsMeteoConfig(cfg)) {
+    notifyMeteoSaveUnavailable();
+  }
 }
 
 function toggleMeteoRounding(enabled) {
   const cfg = getSettingsMeteoConfig();
   cfg.privacyRounding = enabled ? 0.1 : 0;
-  saveSettingsMeteoConfig(cfg);
+  if (!saveSettingsMeteoConfig(cfg)) {
+    notifyMeteoSaveUnavailable();
+  }
 }
 
 export function togglePrivacyConfigure() {

--- a/js/settings.js
+++ b/js/settings.js
@@ -13,6 +13,17 @@ import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
 import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { installSettingsProviderBridge, switchAIProviderBridge } from './settings-provider-bridge.js';
+import {
+  addSettingsRuntimeEventListener,
+  cancelSettingsFrame,
+  getSettingsMeteoConfig,
+  publishSettingsGlobals,
+  refreshSettingsChartThemeColors,
+  refreshSettingsRuntimeSurfaces,
+  requestSettingsFrame,
+  saveSettingsMeteoConfig,
+  settingsMediaMatches,
+} from './settings-runtime.js';
 import { loadPdfImport } from './import-loader.js';
 import { startGuidedTour } from './tour.js';
 import {
@@ -142,30 +153,29 @@ export function applyAccentOverride(id = getAccentOverride()) {
 }
 
 function refreshVisualSurfaces() {
-  window.updateSettingsUI?.();
-  window.updateTweaksUI?.();
+  const settingsVisible = document.getElementById('settings-modal')?.classList.contains('show') === true;
+  refreshSettingsRuntimeSurfaces({ settingsVisible });
   scheduleChartThemeRefresh();
-  if (document.getElementById('settings-modal')?.classList.contains('show')) {
-    window.refreshSettingsWearables?.();
-  }
 }
 
 let chartThemeRefreshFrame = 0;
 let chartThemeRefreshTimer = 0;
 function scheduleChartThemeRefresh() {
-  if (chartThemeRefreshFrame && typeof window.cancelAnimationFrame === 'function') window.cancelAnimationFrame(chartThemeRefreshFrame);
+  if (chartThemeRefreshFrame) cancelSettingsFrame(chartThemeRefreshFrame);
   if (chartThemeRefreshTimer) clearTimeout(chartThemeRefreshTimer);
-  const refresh = () => window.refreshChartThemeColors?.({ batchSize: 4 });
-  if (typeof window.requestAnimationFrame === 'function') {
-    chartThemeRefreshFrame = window.requestAnimationFrame(() => {
-      chartThemeRefreshFrame = 0;
-      chartThemeRefreshTimer = setTimeout(() => {
-        chartThemeRefreshTimer = 0;
-        refresh();
-      }, 0);
-    });
+  const refresh = () => refreshSettingsChartThemeColors({ batchSize: 4 });
+  const frame = requestSettingsFrame(() => {
+    chartThemeRefreshFrame = 0;
+    chartThemeRefreshTimer = setTimeout(() => {
+      chartThemeRefreshTimer = 0;
+      refresh();
+    }, 0);
+  });
+  if (frame !== null) {
+    chartThemeRefreshFrame = frame;
   } else {
     chartThemeRefreshTimer = setTimeout(() => {
+      chartThemeRefreshFrame = 0;
       chartThemeRefreshTimer = 0;
       refresh();
     }, 0);
@@ -189,21 +199,38 @@ function applyThemeChange(themeId) {
 function scheduleThemeChange(themeId) {
   pendingThemeId = themeId;
   markThemeControls(themeId);
-  if (themeChangeFrame && typeof window.cancelAnimationFrame === 'function') window.cancelAnimationFrame(themeChangeFrame);
+  if (themeChangeFrame) cancelSettingsFrame(themeChangeFrame);
   if (themeChangeTimer) clearTimeout(themeChangeTimer);
   const commit = () => {
     themeChangeTimer = 0;
     applyThemeChange(pendingThemeId);
   };
-  if (typeof window.requestAnimationFrame === 'function') {
-    themeChangeFrame = window.requestAnimationFrame(() => {
-      themeChangeFrame = window.requestAnimationFrame(() => {
-        themeChangeFrame = 0;
-        commit();
-      });
+  const frame = requestSettingsFrame(() => {
+    const nextFrame = requestSettingsFrame(() => {
+      themeChangeFrame = 0;
+      commit();
     });
+    if (nextFrame !== null) {
+      themeChangeFrame = nextFrame;
+    } else {
+      themeChangeFrame = 0;
+      commit();
+    }
+  });
+  if (frame !== null) {
+    themeChangeFrame = frame;
   } else {
-    themeChangeTimer = setTimeout(commit, 0);
+    themeChangeTimer = setTimeout(() => {
+      themeChangeFrame = 0;
+      commit();
+    }, 0);
+  }
+}
+
+function requestSettingsScrollFrame(callback) {
+  const frame = requestSettingsFrame(callback);
+  if (frame === null) {
+    setTimeout(callback, 0);
   }
 }
 
@@ -540,7 +567,7 @@ function installTweaksDelegates(overlay) {
 }
 
 export function selectTweaksTheme(themeId) {
-  if (themeChangeFrame && typeof window.cancelAnimationFrame === 'function') window.cancelAnimationFrame(themeChangeFrame);
+  if (themeChangeFrame) cancelSettingsFrame(themeChangeFrame);
   if (themeChangeTimer) clearTimeout(themeChangeTimer);
   themeChangeFrame = 0;
   themeChangeTimer = 0;
@@ -684,15 +711,13 @@ export function openTweaksPanel() {
     openModalOverlay(overlay, {
       initialFocus: '#tweaks-panel button',
       focusDelay: 0,
-      scrollLock: window.matchMedia?.('(max-width: 768px)').matches === true,
+      scrollLock: settingsMediaMatches('(max-width: 768px)'),
     });
   }
 }
 
 applyAccentOverride();
-if (typeof window !== 'undefined') {
-  window.addEventListener('labcharts-themechange', () => applyAccentOverride());
-}
+addSettingsRuntimeEventListener('labcharts-themechange', () => applyAccentOverride());
 installSunDataSourceDelegates();
 
 export function openSettingsModal(tab) {
@@ -925,10 +950,10 @@ export function openSettingsModal(tab) {
 }
 
 function scrollActiveSettingsTabIntoView() {
-  requestAnimationFrame(() => {
+  requestSettingsScrollFrame(() => {
     const bar = document.querySelector('#settings-modal .settings-tabs-bar');
     const active = /** @type {HTMLElement | null | undefined} */ (bar?.querySelector('.settings-tab-btn.active'));
-    if (!bar || !active || window.matchMedia('(min-width: 721px)').matches) return;
+    if (!bar || !active || settingsMediaMatches('(min-width: 721px)')) return;
     const padding = 12;
     const activeLeft = active.offsetLeft;
     const activeRight = activeLeft + active.offsetWidth;
@@ -1077,7 +1102,7 @@ function renderPrivacyAnalyticsSection() {
 }
 
 function _renderMeteoModeOption(mode, label, desc) {
-  const cur = (typeof window !== 'undefined' && window.getMeteoConfig) ? window.getMeteoConfig().mode : 'auto';
+  const cur = getSettingsMeteoConfig().mode || 'auto';
   const checked = cur === mode;
   return `<label style="display:flex;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:var(--radius-sm);cursor:pointer;${checked ? 'background:var(--bg-card);border-color:var(--accent);' : ''}">
     <input type="radio" name="meteo-mode" value="${mode}" ${checked ? 'checked' : ''} data-sun-source-action="set-meteo-mode" style="margin-top:3px">
@@ -1095,7 +1120,7 @@ function _renderMeteoModeOption(mode, label, desc) {
 // privacy-flavored but stays here for cohesion (one place to configure
 // the data source).
 export function renderSunDataSourceSettings() {
-  const cfg = (typeof window !== 'undefined' && window.getMeteoConfig) ? window.getMeteoConfig() : { mode: 'auto', selfhostUrl: '', selfhostBearer: '', privacyRounding: 0.1 };
+  const cfg = getSettingsMeteoConfig();
   return `<div class="local-ai-settings" id="sun-data-source-section">
     <h4 style="margin:0 0 6px 0;font-size:13px;color:var(--text-primary)">☀ Sun data source</h4>
     <div class="ai-provider-desc" style="margin-bottom:10px">Where the Light &amp; Sun lens fetches UV / ozone / atmosphere data. Lat/lon defaults to your country (no automatic geolocation). Manual entry always works.</div>
@@ -1122,33 +1147,26 @@ export function renderSunDataSourceSettings() {
 }
 
 function setMeteoMode(mode) {
-  if (!settingsWindow.getMeteoConfig || !settingsWindow.saveMeteoConfig) return;
-  const cfg = settingsWindow.getMeteoConfig();
+  const cfg = getSettingsMeteoConfig();
   cfg.mode = mode;
-  settingsWindow.saveMeteoConfig(cfg);
+  if (!saveSettingsMeteoConfig(cfg)) return;
   const fields = document.getElementById('meteo-selfhost-fields');
   if (fields) fields.style.display = mode === 'selfhost' ? '' : 'none';
 }
 
 function saveMeteoSelfhost() {
-  if (!settingsWindow.getMeteoConfig || !settingsWindow.saveMeteoConfig) return;
-  const cfg = settingsWindow.getMeteoConfig();
+  const cfg = getSettingsMeteoConfig();
   const url = /** @type {HTMLInputElement | null} */ (document.getElementById('meteo-selfhost-url'))?.value?.trim() || '';
   const bearer = /** @type {HTMLInputElement | null} */ (document.getElementById('meteo-selfhost-bearer'))?.value?.trim() || '';
   cfg.selfhostUrl = url;
   cfg.selfhostBearer = bearer;
-  settingsWindow.saveMeteoConfig(cfg);
+  saveSettingsMeteoConfig(cfg);
 }
 
 function toggleMeteoRounding(enabled) {
-  if (!settingsWindow.getMeteoConfig || !settingsWindow.saveMeteoConfig) return;
-  const cfg = settingsWindow.getMeteoConfig();
+  const cfg = getSettingsMeteoConfig();
   cfg.privacyRounding = enabled ? 0.1 : 0;
-  settingsWindow.saveMeteoConfig(cfg);
-}
-
-if (typeof window !== 'undefined') {
-  window.renderSunDataSourceSettings = renderSunDataSourceSettings;
+  saveSettingsMeteoConfig(cfg);
 }
 
 export function togglePrivacyConfigure() {
@@ -1231,11 +1249,12 @@ export function closeSettingsModal() {
   settingsWindow.refreshMobileDashboardActiveTab?.();
 }
 
-Object.assign(window, {
+publishSettingsGlobals({
   openSettingsModal,
   closeSettingsModal,
   switchSettingsTab,
   renderPrivacySection,
+  renderSunDataSourceSettings,
   togglePrivacyConfigure,
   toggleOllamaPII,
   confirmDisablePIIReview,

--- a/js/settings.js
+++ b/js/settings.js
@@ -1149,7 +1149,10 @@ export function renderSunDataSourceSettings() {
 function setMeteoMode(mode) {
   const cfg = getSettingsMeteoConfig();
   cfg.mode = mode;
-  if (!saveSettingsMeteoConfig(cfg)) return;
+  if (!saveSettingsMeteoConfig(cfg)) {
+    notifyMeteoSaveUnavailable();
+    return;
+  }
   const fields = document.getElementById('meteo-selfhost-fields');
   if (fields) fields.style.display = mode === 'selfhost' ? '' : 'none';
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 1088,
+  "windowReferences": 613,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -174,6 +174,7 @@ const APP_SHELL = [
   '/js/settings.js',
   '/js/settings-data.js',
   '/js/settings-provider-bridge.js',
+  '/js/settings-runtime.js',
   '/js/settings-sync-panel.js',
   '/js/settings-agent-access-panel.js',
   '/js/feedback.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -167,6 +167,7 @@ const LEGACY_TESTS = [
   // wearables-bp-merge source-inspection. The wearables-bp live DOM probe
   // moved to Playwright.
   './test-tour.js',
+  './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
   './test-shell-delegated-actions.js',
   './test-nav-delegated-actions.js',

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -528,12 +528,22 @@ try {
 console.log('19. settings.js security + backup');
 try {
   const src = await fetchWithRetry('js/settings.js');
+  const runtimeSrc = await fetchWithRetry('js/settings-runtime.js');
   assert('settings.js imports renderEncryptionSection', src.includes('renderEncryptionSection'));
   assert('settings.js imports renderBackupSection', src.includes('renderBackupSection'));
   assert('settings.js has Security group', src.includes('Security'));
   assert('settings.js has Backup group', src.includes('Backup'));
   assert('settings.js has encryption-section id', src.includes('encryption-section'));
   assert('settings.js has backup-section id', src.includes('backup-section'));
+  assert('settings.js delegates browser runtime hooks to settings-runtime',
+    src.includes("from './settings-runtime.js'") &&
+    !/\bwindow(?:\.|\s*\[)/.test(src));
+  assert('settings-runtime.js owns Settings browser-global publication',
+    runtimeSrc.includes('export function publishSettingsGlobals') &&
+    runtimeSrc.includes('Object.assign(getRuntimeWindow(), api)') &&
+    runtimeSrc.includes("getRuntimeFunction('requestAnimationFrame')") &&
+    runtimeSrc.includes("getRuntimeFunction('matchMedia')") &&
+    runtimeSrc.includes("getRuntimeFunction('getMeteoConfig')"));
 } catch (e) {
   assert('settings.js security check', false, e.message);
 }

--- a/tests/test-modal-lifecycle-integrations.js
+++ b/tests/test-modal-lifecycle-integrations.js
@@ -152,8 +152,9 @@ assert('settings modal opens and closes through shared overlay lifecycle helpers
 
 assert('settings tweaks panel uses shared overlay lifecycle helpers',
   settingsSrc.includes("from './modal-lifecycle.js'") &&
+    settingsSrc.includes("from './settings-runtime.js'") &&
     settingsSrc.includes('removeModalOverlay(overlay)') &&
-    /openModalOverlay\s*\(\s*overlay\s*,\s*\{[\s\S]*initialFocus:\s*['"]#tweaks-panel button['"][\s\S]*scrollLock:\s*window\.matchMedia\?\.\(['"]\(max-width: 768px\)['"]\)\.matches === true[\s\S]*\}\s*\)/.test(settingsSrc) &&
+    /openModalOverlay\s*\(\s*overlay\s*,\s*\{[\s\S]*initialFocus:\s*['"]#tweaks-panel button['"][\s\S]*scrollLock:\s*settingsMediaMatches\(['"]\(max-width: 768px\)['"]\)[\s\S]*\}\s*\)/.test(settingsSrc) &&
     !settingsSrc.includes('_tweaksPriorBodyOverflow') &&
     !settingsSrc.includes("document.body.style.overflow = 'hidden'"));
 

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -91,6 +91,7 @@ const highValueCheckJsModules = [
   'js/profile-runtime.js',
   'js/recommendations.js',
   'js/settings.js',
+  'js/settings-runtime.js',
   'js/sun.js',
   'js/wearables.js',
 ];

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -139,6 +139,10 @@ assert('Sun data-source delegate is installed on document change',
   /document\.addEventListener\('change', handleSunDataSourceChange\)/.test(src));
 assert('Sun data-source delegate is scoped to its section',
   /function closestSunDataSourceControl[\s\S]*closest\('#sun-data-source-section'\)/.test(src));
+assert('Sun data-source save handlers surface unavailable runtime saves',
+  /function notifyMeteoSaveUnavailable\(\)[\s\S]*Sun data-source settings are still loading/.test(src) &&
+    /function saveMeteoSelfhost\(\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(src) &&
+    /function toggleMeteoRounding\(enabled\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(src));
 assert('Legacy Sun data-source window handlers are removed',
   !src.includes('window._setMeteoMode')
     && !src.includes('window._saveMeteoSelfhost')

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -37,7 +37,7 @@ const tweaksBlock = matchBlock('Tweaks panel', /export function openTweaksPanel\
 const renderThemeButtonBlock = matchBlock('renderThemeButton', /function renderThemeButton[\s\S]*?\n}\n\nfunction getAccentOverride/);
 
 const inlineHandlerRe = /\bon(?:click|change|input|submit|keydown|keyup)=/;
-const tweaksLifecycleOpenRe = /openModalOverlay\s*\(\s*overlay\s*,\s*\{[\s\S]*initialFocus:\s*['"]#tweaks-panel button['"][\s\S]*focusDelay:\s*0[\s\S]*scrollLock:\s*window\.matchMedia\?\.\(['"]\(max-width: 768px\)['"]\)\.matches === true[\s\S]*\}\s*\)/;
+const tweaksLifecycleOpenRe = /openModalOverlay\s*\(\s*overlay\s*,\s*\{[\s\S]*initialFocus:\s*['"]#tweaks-panel button['"][\s\S]*focusDelay:\s*0[\s\S]*scrollLock:\s*settingsMediaMatches\(['"]\(max-width: 768px\)['"]\)[\s\S]*\}\s*\)/;
 
 assert('settings.js has no inline event attributes',
   !inlineHandlerRe.test(src));
@@ -58,6 +58,7 @@ assert('Tweaks panel installs delegated change listener',
   /overlay\.addEventListener\('change', handleTweaksChange\)/.test(src));
 assert('Tweaks panel uses shared overlay lifecycle helpers',
   src.includes("from './modal-lifecycle.js'") &&
+    src.includes("from './settings-runtime.js'") &&
     tweaksBlock &&
     tweaksLifecycleOpenRe.test(tweaksBlock) &&
     /removeModalOverlay\(overlay\)/.test(src) &&

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -141,6 +141,7 @@ assert('Sun data-source delegate is scoped to its section',
   /function closestSunDataSourceControl[\s\S]*closest\('#sun-data-source-section'\)/.test(src));
 assert('Sun data-source save handlers surface unavailable runtime saves',
   /function notifyMeteoSaveUnavailable\(\)[\s\S]*Sun data-source settings are still loading/.test(src) &&
+    /function setMeteoMode\(mode\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*return;[\s\S]*\}/.test(src) &&
     /function saveMeteoSelfhost\(\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(src) &&
     /function toggleMeteoRounding\(enabled\)[\s\S]*if \(!saveSettingsMeteoConfig\(cfg\)\) \{[\s\S]*notifyMeteoSaveUnavailable\(\);[\s\S]*\}/.test(src));
 assert('Legacy Sun data-source window handlers are removed',

--- a/tests/test-settings-runtime.js
+++ b/tests/test-settings-runtime.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// test-settings-runtime.js — Settings runtime adapter behavior.
+
+import {
+  getSettingsMeteoConfig,
+  saveSettingsMeteoConfig,
+} from '../js/settings-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Settings Runtime Adapters ===');
+
+const originalGetMeteoConfig = globalThis.getMeteoConfig;
+const originalSaveMeteoConfig = globalThis.saveMeteoConfig;
+
+try {
+  delete globalThis.getMeteoConfig;
+  delete globalThis.saveMeteoConfig;
+
+  assert('missing getMeteoConfig returns defaults',
+    getSettingsMeteoConfig().mode === 'auto');
+  assert('missing saveMeteoConfig reports unavailable',
+    saveSettingsMeteoConfig({ mode: 'manual' }) === false);
+
+  globalThis.getMeteoConfig = () => ({ mode: 'manual', privacyRounding: 0 });
+  assert('runtime getMeteoConfig is delegated',
+    getSettingsMeteoConfig().mode === 'manual' &&
+      getSettingsMeteoConfig().privacyRounding === 0);
+
+  globalThis.getMeteoConfig = () => {
+    throw new Error('read failed');
+  };
+  assert('thrown getMeteoConfig returns defaults',
+    getSettingsMeteoConfig().mode === 'auto');
+
+  let savedConfig = null;
+  globalThis.saveMeteoConfig = (config) => {
+    savedConfig = config;
+  };
+  assert('runtime saveMeteoConfig reports success',
+    saveSettingsMeteoConfig({ mode: 'selfhost' }) === true &&
+      savedConfig?.mode === 'selfhost');
+
+  globalThis.saveMeteoConfig = () => {
+    throw new Error('write failed');
+  };
+  assert('thrown saveMeteoConfig reports unavailable',
+    saveSettingsMeteoConfig({ mode: 'open-meteo' }) === false);
+} finally {
+  if (originalGetMeteoConfig === undefined) {
+    delete globalThis.getMeteoConfig;
+  } else {
+    globalThis.getMeteoConfig = originalGetMeteoConfig;
+  }
+
+  if (originalSaveMeteoConfig === undefined) {
+    delete globalThis.saveMeteoConfig;
+  } else {
+    globalThis.saveMeteoConfig = originalSaveMeteoConfig;
+  }
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -173,6 +173,7 @@
     "js/provider-panels.js",
     "js/recommendations.js",
     "js/settings.js",
+    "js/settings-runtime.js",
     "js/service-worker-update.js",
     "js/shell-actions.js",
     "js/startup-foundation.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -183,6 +183,7 @@
     "js/schema.js",
     "js/schema-environment.js",
     "js/settings.js",
+    "js/settings-runtime.js",
     "js/settings-sync-panel.js",
     "js/settings-agent-access-panel.js",
     "js/shell-actions.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.67';
+self.APP_VERSION = '1.10.68';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.69';
+self.APP_VERSION = '1.10.70';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.68';
+self.APP_VERSION = '1.10.69';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.66';
+self.APP_VERSION = '1.10.67';


### PR DESCRIPTION
## Summary

- Add `js/settings-runtime.js` as the browser-runtime adapter for Settings/Tweaks global hooks.
- Route Settings RAF, media query, theme event, chart refresh, Sun data-source config, and global publication through the adapter.
- Precache/typecheck the new module, bump `version.js`, and tighten the `window` coupling guardrail to the current measured count.
- Update source guards and security coverage so `settings.js` stays free of direct `window.` references.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `node tests/test-settings-delegated-actions.js`
- `node tests/test-modal-lifecycle-integrations.js`
- `node tests/test-crypto.js`
- `node tests/test-light-page-view-delegated-actions.js`
- `node tests/test-profile-share.js`
- `node tests/test-unit-import.js`
- `npx playwright test tests/playwright/settings-browser-coverage.spec.js --workers=1`
- `./run-tests.sh`