### PR TITLE
[codex] Extract light devices runtime wiring

### DIFF
--- a/js/light-devices-runtime.js
+++ b/js/light-devices-runtime.js
@@ -1,0 +1,106 @@
+// @ts-check
+// light-devices-runtime.js - Browser runtime adapters for light-device UI shell hooks.
+
+import { state } from './state.js';
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : /** @type {any} */ (globalThis);
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {any}
+ */
+function getRuntimeValue(name) {
+  return getRuntimeWindow()[name];
+}
+
+/** @param {string} route */
+export function navigateLightDevicesRoute(route) {
+  getRuntimeFunction('navigate')?.(route);
+}
+
+export function refreshLightDevicesView() {
+  if (state.currentView === 'light') navigateLightDevicesRoute('light');
+}
+
+/** @param {number} current */
+export function promptLightDeviceSessionDuration(current) {
+  return getRuntimeFunction('showPromptDialog')?.('New duration (in minutes)', {
+    defaultValue: String(current),
+    okLabel: 'Save',
+    placeholder: 'e.g. 12',
+  });
+}
+
+export function getLightDeviceChannelHelpers() {
+  const channelTier = /** @type {(value: any, channelKey?: string) => number} */ (
+    getRuntimeFunction('channelTier') || (() => 0)
+  );
+  const tierLabel = /** @type {(tier: number) => string} */ (
+    getRuntimeFunction('tierLabel') || (() => 'none')
+  );
+  const formatChannelUnit = /** @type {(...args: any[]) => string} */ (
+    getRuntimeFunction('formatChannelUnit') || (() => '')
+  );
+  return {
+    channelTier,
+    tierLabel,
+    formatChannelUnit,
+  };
+}
+
+/** @param {Record<string, any>} fallback */
+export function getLightDeviceChannelDisplay(fallback = {}) {
+  const display = getRuntimeValue('CHANNEL_DISPLAY');
+  return display && typeof display === 'object' ? display : fallback;
+}
+
+export function loadLightDevicesCatalog() {
+  return getRuntimeFunction('loadCatalog')?.();
+}
+
+/**
+ * @param {any} catalog
+ * @param {string} slug
+ */
+export function renderLightDeviceAffiliateRowRuntime(catalog, slug) {
+  return getRuntimeFunction('renderLightDeviceAffiliateRow')?.(catalog, slug) || '';
+}
+
+/** @param {string} channel */
+export function openLightDeviceChannel(channel) {
+  getRuntimeFunction('_openChannelOnLightPage')?.(channel);
+}
+
+/** @param {string} id */
+export function editLightDeviceSessionDurationFromRuntime(id) {
+  getRuntimeFunction('editDeviceSessionDuration')?.(id);
+}
+
+/** @param {string} id */
+export function editLightDeviceSessionModeFromRuntime(id) {
+  getRuntimeFunction('editDeviceSessionMode')?.(id);
+}
+
+/** @param {string} id */
+export function deleteLightDeviceSessionFromRuntime(id) {
+  getRuntimeFunction('deleteDeviceSession')?.(id);
+}
+
+/** @param {Record<string, any>} bindings */
+export function publishLightDevicesWindowBindings(bindings) {
+  if (typeof window === 'undefined') return;
+  Object.assign(getRuntimeWindow(), bindings);
+}

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -18,7 +18,6 @@
 //   importedData.lightDevices[]   — user's owned devices
 //   importedData.deviceSessions[] — session log
 
-import { state } from './state.js';
 import { bindDetachedModalSyncRefresh, escapeHTML, escapeAttr, formatDate, showNotification, showConfirmDialog } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { CHANNEL_DISPLAY } from './sun.js';
@@ -42,6 +41,20 @@ import {
 import { openDeviceSessionDialog as openDeviceSessionDialogModal } from './light-device-session-modal.js';
 import { configureLightDeviceSetup, openAddDeviceDialog, openCustomDeviceDialog } from './light-device-setup-modal.js';
 import { installLightDevicesActionDelegates } from './light-devices-actions.js';
+import {
+  deleteLightDeviceSessionFromRuntime,
+  editLightDeviceSessionDurationFromRuntime,
+  editLightDeviceSessionModeFromRuntime,
+  getLightDeviceChannelDisplay,
+  getLightDeviceChannelHelpers,
+  loadLightDevicesCatalog,
+  navigateLightDevicesRoute,
+  openLightDeviceChannel,
+  promptLightDeviceSessionDuration,
+  publishLightDevicesWindowBindings,
+  refreshLightDevicesView,
+  renderLightDeviceAffiliateRowRuntime,
+} from './light-devices-runtime.js';
 
 /** @type {{ renderDeviceSessionAIDetail: (sess: any) => string }} */
 const lightDevicesDeps = {
@@ -175,7 +188,7 @@ export async function editDeviceSessionMode(id) {
     if (next === sess.mode) return;
     await updateDeviceSession(id, { mode: next });
     showNotification('Mode updated. Doses recomputed.', 'success');
-    if (window.navigate && state.currentView === 'light') window.navigate('light');
+    refreshLightDevicesView();
   });
 }
 
@@ -189,11 +202,7 @@ export async function editDeviceSessionDuration(id) {
     return;
   }
   const current = Math.max(0, Math.round(sess.durationMin || 0));
-  const raw = await window.showPromptDialog?.('New duration (in minutes)', {
-    defaultValue: String(current),
-    okLabel: 'Save',
-    placeholder: 'e.g. 12',
-  });
+  const raw = await promptLightDeviceSessionDuration(current);
   if (raw === null || raw === undefined) return;
   const parsed = parseFloat(raw);
   if (!Number.isFinite(parsed) || parsed < 0 || parsed > 600) {
@@ -204,7 +213,7 @@ export async function editDeviceSessionDuration(id) {
   if (next === current) return;
   await updateDeviceSession(id, { durationMin: next });
   showNotification(`Session duration set to ${next} min. Doses recomputed.`, 'success');
-  if (window.navigate && state.currentView === 'light') window.navigate('light');
+  refreshLightDevicesView();
 }
 
 // ─── UI: per-device-session detail modal ──────────────────────────────
@@ -235,14 +244,9 @@ export function openDeviceSessionDetail(id) {
   const sessions = getDeviceSessions();
   const sess = sessions.find(s => s.id === id);
   if (!sess) return;
-  const appWindow = /** @type {any} */ (window);
   const device = getDevices().find(d => d.id === sess.deviceId) || null;
-  /** @type {(value: any, channelKey?: string) => number} */
-  const channelTier = window.channelTier || (() => 0);
-  /** @type {(tier: number) => string} */
-  const tierLabel = window.tierLabel || (() => 'none');
-  /** @type {(...args: any[]) => string} */
-  const formatChannelUnit = window.formatChannelUnit || (() => '');
+  const { channelTier, tierLabel, formatChannelUnit } = getLightDeviceChannelHelpers();
+  const channelDisplay = getLightDeviceChannelDisplay(CHANNEL_DISPLAY);
   const channelOrder = ['vitamin_d', 'circadian', 'nir_solar', 'no_cv', 'pomc', 'violet_eye', 'pbm_red', 'pbm_nir'];
 
   const start = formatDate(new Date(sess.startedAt).toISOString().slice(0, 10));
@@ -294,7 +298,7 @@ export function openDeviceSessionDetail(id) {
   const channelRows = sess.doses ? channelOrder
     .filter(k => sess.doses[k] != null)
     .map(k => {
-      const meta = (window.CHANNEL_DISPLAY || {})[k] || {};
+      const meta = channelDisplay[k] || {};
       const v = sess.doses[k] || 0;
       const t = channelTier(v, k);
       const tlabel = tierLabel(t);
@@ -385,22 +389,22 @@ export function openDeviceSessionDetail(id) {
     if (channelRow && overlay.contains(channelRow)) {
       const channel = channelRow.getAttribute('data-channel') || '';
       closeDialog();
-      appWindow._openChannelOnLightPage?.(channel);
+      openLightDeviceChannel(channel);
       return;
     }
     if (target.closest('#device-detail-edit-duration')) {
       closeDialog();
-      appWindow.editDeviceSessionDuration?.(sess.id);
+      editLightDeviceSessionDurationFromRuntime(sess.id);
       return;
     }
     if (target.closest('#device-detail-edit-mode')) {
       closeDialog();
-      appWindow.editDeviceSessionMode?.(sess.id);
+      editLightDeviceSessionModeFromRuntime(sess.id);
       return;
     }
     if (target.closest('#device-detail-delete')) {
       closeDialog();
-      appWindow.deleteDeviceSession?.(sess.id);
+      deleteLightDeviceSessionFromRuntime(sess.id);
     }
   });
   overlay.addEventListener('keydown', (event) => {
@@ -411,7 +415,7 @@ export function openDeviceSessionDetail(id) {
     event.preventDefault();
     const channel = channelRow.getAttribute('data-channel') || '';
     closeDialog();
-    appWindow._openChannelOnLightPage?.(channel);
+    openLightDeviceChannel(channel);
   });
   bindDetachedModalSyncRefresh({
     overlay,
@@ -504,7 +508,7 @@ export async function renderDevicesSection() {
   // Both fall back gracefully on missing data.
   let catalog = null;
   try {
-    if (window.loadCatalog) catalog = await window.loadCatalog();
+    catalog = await loadLightDevicesCatalog();
   } catch { /* offline / 404 — page still renders without affiliate row */ }
   let typesMeta = {};
   try {
@@ -539,9 +543,7 @@ export async function renderDevicesSection() {
   html += `<div class="light-devices-grid">`;
   for (const dev of devices) {
     const slug = dev.catalogSlug || dev.presetId || null;
-    const affRow = (slug && window.renderLightDeviceAffiliateRow)
-      ? window.renderLightDeviceAffiliateRow(catalog, slug)
-      : '';
+    const affRow = slug ? renderLightDeviceAffiliateRowRuntime(catalog, slug) : '';
     const typeMeta = typesMeta[dev.type] || {};
     const typeIcon = typeMeta.icon || '🔴';
     const typeLabel = typeMeta.label || dev.type || 'Device';
@@ -644,7 +646,7 @@ configureLightDeviceSetup({
   addCustomDevice,
   wireModal: _wireModal,
   refreshLightView: () => {
-    if (window.navigate && state.currentView === 'light') window.navigate('light');
+    refreshLightDevicesView();
   },
 });
 
@@ -661,7 +663,7 @@ export async function openDeviceSessionDialog(deviceId) {
     validateModeCoupling,
     renderBodySilhouette,
     bindBodySilhouette,
-    navigate: route => window.navigate?.(route),
+    navigate: navigateLightDevicesRoute,
   });
 }
 
@@ -722,48 +724,50 @@ function _openDevicePicker(devices) {
 export async function deleteDeviceSessionWithConfirm(id) {
   if (!await showConfirmDialog("Delete this device session? This can't be undone.")) return;
   await deleteDeviceSession(id);
-  if (window.navigate && state.currentView === 'light') window.navigate('light');
+  refreshLightDevicesView();
 }
 
 // ─── Window export ─────────────────────────────────────────────────────
 
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    loadLightDevicePresets,
-    getDevices,
-    getDeviceSessions,
-    addDeviceFromPreset,
-    hydrateDevicesFromPresets,
-    deleteLightDevice: async (id) => {
-      await deleteDevice(id);
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
-    },
-    logDeviceSession,
-    startDeviceSession,
-    stopDeviceSession,
-    updateDeviceSession,
-    editDeviceSessionDuration,
-    editDeviceSessionMode,
-    getActiveDeviceSession,
-    renderActiveDeviceSessionCard,
-    ensureActiveDeviceTicker,
-    stopDeviceSessionAndNotify: async (id) => {
-      const sess = await stopDeviceSession(id);
-      if (sess) {
-        const device = getDevices().find(d => d.id === sess.deviceId);
-        const dur = Math.round(sess.durationMin || 0);
-        showNotification(`Saved · ${dur} min ${device ? device.brand + ' ' + device.model : 'device'} session.`);
-      }
-      if (window.navigate && state.currentView === 'light') window.navigate('light');
-    },
-    deleteDeviceSession: deleteDeviceSessionWithConfirm,
-    rollingDeviceTotals,
-    renderDevicesSection,
-    openDeviceSessionDetail,
-    openAddDeviceDialog,
-    openCustomDeviceDialog,
-    addCustomDevice,
-    openDeviceSessionDialog,
-    quickLogDeviceSession,
-  });
+export async function deleteLightDeviceAndRefresh(id) {
+  await deleteDevice(id);
+  refreshLightDevicesView();
 }
+
+export async function stopDeviceSessionAndNotify(id) {
+  const sess = await stopDeviceSession(id);
+  if (sess) {
+    const device = getDevices().find(d => d.id === sess.deviceId);
+    const dur = Math.round(sess.durationMin || 0);
+    showNotification(`Saved · ${dur} min ${device ? device.brand + ' ' + device.model : 'device'} session.`);
+  }
+  refreshLightDevicesView();
+}
+
+publishLightDevicesWindowBindings({
+  loadLightDevicePresets,
+  getDevices,
+  getDeviceSessions,
+  addDeviceFromPreset,
+  hydrateDevicesFromPresets,
+  deleteLightDevice: deleteLightDeviceAndRefresh,
+  logDeviceSession,
+  startDeviceSession,
+  stopDeviceSession,
+  updateDeviceSession,
+  editDeviceSessionDuration,
+  editDeviceSessionMode,
+  getActiveDeviceSession,
+  renderActiveDeviceSessionCard,
+  ensureActiveDeviceTicker,
+  stopDeviceSessionAndNotify,
+  deleteDeviceSession: deleteDeviceSessionWithConfirm,
+  rollingDeviceTotals,
+  renderDevicesSection,
+  openDeviceSessionDetail,
+  openAddDeviceDialog,
+  openCustomDeviceDialog,
+  addCustomDevice,
+  openDeviceSessionDialog,
+  quickLogDeviceSession,
+});

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 589,
+  "windowReferences": 567,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -386,6 +386,7 @@ const APP_SHELL = [
   '/js/light-channels-ai-analysis.js',
   '/js/light-device-ai-analysis.js',
   '/js/light-sun-ai-hooks.js',
+  '/js/light-devices-runtime.js',
   '/js/light-devices.js',
   '/js/light-devices-actions.js',
   '/js/light-devices-store.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -98,6 +98,7 @@ const LEGACY_TESTS = [
   './test-sun.js',
   './test-light-env.js',
   './test-light-env-store.js',
+  './test-light-devices-runtime.js',
   './test-light-devices.js',
   './test-sun-context.js',
   './test-sun-uvdata.js',

--- a/tests/test-light-devices-runtime.js
+++ b/tests/test-light-devices-runtime.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// test-light-devices-runtime.js — Light-device browser runtime adapter behavior.
+
+import './_node-shim.js';
+import { state } from '../js/state.js';
+import {
+  deleteLightDeviceSessionFromRuntime,
+  editLightDeviceSessionDurationFromRuntime,
+  editLightDeviceSessionModeFromRuntime,
+  getLightDeviceChannelDisplay,
+  getLightDeviceChannelHelpers,
+  loadLightDevicesCatalog,
+  navigateLightDevicesRoute,
+  openLightDeviceChannel,
+  promptLightDeviceSessionDuration,
+  publishLightDevicesWindowBindings,
+  refreshLightDevicesView,
+  renderLightDeviceAffiliateRowRuntime,
+} from '../js/light-devices-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+console.log('=== Light Devices Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'navigate',
+  'showPromptDialog',
+  'channelTier',
+  'tierLabel',
+  'formatChannelUnit',
+  'CHANNEL_DISPLAY',
+  'loadCatalog',
+  'renderLightDeviceAffiliateRow',
+  '_openChannelOnLightPage',
+  'editDeviceSessionDuration',
+  'editDeviceSessionMode',
+  'deleteDeviceSession',
+  '__lightRuntimeProbe',
+];
+const saved = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
+const savedView = state.currentView;
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    if (typeof saved[key] === 'undefined') delete globalThis[key];
+    else globalThis[key] = saved[key];
+  }
+  state.currentView = savedView;
+}
+
+try {
+  const calls = [];
+  globalThis.navigate = route => calls.push(['navigate', route]);
+  navigateLightDevicesRoute('light');
+  assert('navigateLightDevicesRoute delegates to runtime navigate',
+    calls.some(call => call[0] === 'navigate' && call[1] === 'light'));
+
+  state.currentView = 'dashboard';
+  refreshLightDevicesView();
+  assert('refreshLightDevicesView skips non-light view',
+    calls.filter(call => call[0] === 'navigate').length === 1);
+  state.currentView = 'light';
+  refreshLightDevicesView();
+  assert('refreshLightDevicesView refreshes current light view',
+    calls.filter(call => call[0] === 'navigate' && call[1] === 'light').length === 2);
+
+  let promptArgs = null;
+  globalThis.showPromptDialog = async (...args) => {
+    promptArgs = args;
+    return '17';
+  };
+  const raw = await promptLightDeviceSessionDuration(12);
+  assert('promptLightDeviceSessionDuration delegates with duration defaults',
+    raw === '17' &&
+    promptArgs?.[0] === 'New duration (in minutes)' &&
+    promptArgs?.[1]?.defaultValue === '12' &&
+    promptArgs?.[1]?.okLabel === 'Save');
+  delete globalThis.showPromptDialog;
+  assert('promptLightDeviceSessionDuration returns undefined when prompt hook is missing',
+    await promptLightDeviceSessionDuration(3) === undefined);
+
+  globalThis.channelTier = (value, key) => key === 'pbm_red' && value > 0 ? 3 : 0;
+  globalThis.tierLabel = tier => tier === 3 ? 'high' : 'none';
+  globalThis.formatChannelUnit = (key, value) => `${Math.round(value)} ${key}`;
+  const helpers = getLightDeviceChannelHelpers();
+  assert('getLightDeviceChannelHelpers reads runtime channel helpers',
+    helpers.channelTier(1, 'pbm_red') === 3 &&
+    helpers.tierLabel(3) === 'high' &&
+    helpers.formatChannelUnit('pbm_red', 4.4) === '4 pbm_red');
+  delete globalThis.channelTier;
+  delete globalThis.tierLabel;
+  delete globalThis.formatChannelUnit;
+  const fallbackHelpers = getLightDeviceChannelHelpers();
+  assert('getLightDeviceChannelHelpers provides safe fallbacks',
+    fallbackHelpers.channelTier(99, 'pbm_red') === 0 &&
+    fallbackHelpers.tierLabel(4) === 'none' &&
+    fallbackHelpers.formatChannelUnit('pbm_red', 5) === '');
+
+  delete globalThis.CHANNEL_DISPLAY;
+  const fallbackDisplay = { pbm_red: { label: 'Fallback Red' } };
+  assert('getLightDeviceChannelDisplay falls back to imported display',
+    getLightDeviceChannelDisplay(fallbackDisplay).pbm_red.label === 'Fallback Red');
+  globalThis.CHANNEL_DISPLAY = { circadian: { label: 'Runtime Clock' } };
+  assert('getLightDeviceChannelDisplay prefers runtime display',
+    getLightDeviceChannelDisplay(fallbackDisplay).circadian.label === 'Runtime Clock');
+
+  globalThis.loadCatalog = async () => ({ slots: { light: true } });
+  assert('loadLightDevicesCatalog delegates to runtime loadCatalog',
+    (await loadLightDevicesCatalog()).slots.light === true);
+  delete globalThis.loadCatalog;
+  assert('loadLightDevicesCatalog returns undefined when hook is missing',
+    await loadLightDevicesCatalog() === undefined);
+
+  globalThis.renderLightDeviceAffiliateRow = (_catalog, slug) => `<a>${slug}</a>`;
+  assert('renderLightDeviceAffiliateRowRuntime delegates affiliate row rendering',
+    renderLightDeviceAffiliateRowRuntime({}, 'panel-x') === '<a>panel-x</a>');
+  delete globalThis.renderLightDeviceAffiliateRow;
+  assert('renderLightDeviceAffiliateRowRuntime returns empty string when hook is missing',
+    renderLightDeviceAffiliateRowRuntime({}, 'panel-x') === '');
+
+  globalThis._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
+  globalThis.editDeviceSessionDuration = id => calls.push(['edit-duration', id]);
+  globalThis.editDeviceSessionMode = id => calls.push(['edit-mode', id]);
+  globalThis.deleteDeviceSession = id => calls.push(['delete-session', id]);
+  openLightDeviceChannel('vitamin_d');
+  editLightDeviceSessionDurationFromRuntime('sess-1');
+  editLightDeviceSessionModeFromRuntime('sess-1');
+  deleteLightDeviceSessionFromRuntime('sess-1');
+  assert('detail runtime callbacks delegate to current window bindings',
+    calls.some(call => call[0] === 'open-channel' && call[1] === 'vitamin_d') &&
+    calls.some(call => call[0] === 'edit-duration' && call[1] === 'sess-1') &&
+    calls.some(call => call[0] === 'edit-mode' && call[1] === 'sess-1') &&
+    calls.some(call => call[0] === 'delete-session' && call[1] === 'sess-1'));
+
+  publishLightDevicesWindowBindings({ __lightRuntimeProbe: () => 'ok' });
+  assert('publishLightDevicesWindowBindings installs legacy globals',
+    globalThis.__lightRuntimeProbe?.() === 'ok');
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 const _ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = rel => fs.readFileSync(path.join(_ROOT, rel), 'utf8');
 const _realFetch = globalThis.fetch;
 globalThis.fetch = async (url, opts) => {
   if (typeof url === 'string' && !/^https?:/.test(url)) {
@@ -607,6 +608,19 @@ const {
       pulse.modes === null);
     window._labState.importedData = orig;
   }
+
+  // ─── Runtime adapter ownership ─────────────────────────────────────
+  console.log('%c runtime adapter ownership ', 'font-weight:bold;color:#f59e0b');
+  const lightDevicesSrc = read('js/light-devices.js');
+  const lightDevicesRuntimeSrc = read('js/light-devices-runtime.js');
+  assert('light-devices routes shell hooks through light-devices-runtime',
+    lightDevicesSrc.includes("from './light-devices-runtime.js'") &&
+    !/\bwindow\./.test(lightDevicesSrc));
+  assert('light-devices-runtime owns browser-shell hooks and legacy publication',
+    lightDevicesRuntimeSrc.includes("getRuntimeFunction('navigate')") &&
+    lightDevicesRuntimeSrc.includes("getRuntimeFunction('showPromptDialog')") &&
+    lightDevicesRuntimeSrc.includes("getRuntimeFunction('loadCatalog')") &&
+    lightDevicesRuntimeSrc.includes('publishLightDevicesWindowBindings'));
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -86,6 +86,7 @@ const highValueCheckJsModules = [
   'js/export.js',
   'js/export-runtime.js',
   'js/lens.js',
+  'js/light-devices-runtime.js',
   'js/light-tool-camera-modals.js',
   'js/pdf-import.js',
   'js/profile.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -64,6 +64,7 @@
     '/js/light-page-view.js',
     '/js/light-page-view-hooks.js',
     '/js/light-page-view-ui-hooks.js',
+    '/js/light-devices-runtime.js',
     '/js/light-devices-actions.js',
     '/js/light-channel-view.js',
     '/js/light-channel-view-hooks.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -127,6 +127,7 @@
     "js/light-device-session-modal.js",
     "js/light-device-setup-modal.js",
     "js/light-devices-actions.js",
+    "js/light-devices-runtime.js",
     "js/light-devices.js",
     "js/light-devices-store.js",
     "js/light-env.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -124,6 +124,7 @@
     "js/light-device-session-modal.js",
     "js/light-device-setup-modal.js",
     "js/light-devices-actions.js",
+    "js/light-devices-runtime.js",
     "js/light-devices-store.js",
     "js/light-devices.js",
     "js/light-env-actions.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.72';
+self.APP_VERSION = '1.10.73';


### PR DESCRIPTION
## Summary
- Extract light-device shell/global access into `js/light-devices-runtime.js`.
- Remove direct guardrail-counted `window` references from `js/light-devices.js` while preserving legacy browser exports.
- Add focused runtime adapter coverage and lower the app `windowReferences` baseline from 589 to 567.

## Validation
- `node tests/test-light-devices-runtime.js`
- `node tests/test-light-devices.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test`
- `npx playwright test tests/playwright/light-devices-browser-coverage.spec.js --workers=1`
- `npx playwright test tests/playwright/light-sun-coverage-batch.spec.js --workers=1`
- `./run-tests.sh` reached one unrelated Playwright assertion failure in `setup-onboarding-coverage-batch.spec.js`; immediate isolated rerun of that spec passed (`3 passed`).