### PR TITLE
[codex] Extract views router runtime wiring

### DIFF
--- a/js/views-router-runtime.js
+++ b/js/views-router-runtime.js
@@ -1,0 +1,73 @@
+// @ts-check
+// views-router-runtime.js - Browser runtime adapters for routing scroll/window hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function getViewportScrollPosition() {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return null;
+  return {
+    x: Number.isFinite(runtime.scrollX) ? runtime.scrollX : (runtime.pageXOffset || 0),
+    y: Number.isFinite(runtime.scrollY) ? runtime.scrollY : (runtime.pageYOffset || 0),
+  };
+}
+
+export function closeMobileSidebarFromRuntime() {
+  getRuntimeFunction('closeMobileSidebar')?.();
+}
+
+export function syncImportStatusFabFromRuntime() {
+  getRuntimeFunction('syncImportStatusFab')?.();
+}
+
+/** @param {() => void} cancel */
+export function addViewportInputCancelListeners(cancel) {
+  const runtime = getRuntimeWindow();
+  if (!runtime || typeof runtime.addEventListener !== 'function') return () => {};
+  const inputOpts = { passive: true, capture: true };
+  runtime.addEventListener('wheel', cancel, inputOpts);
+  runtime.addEventListener('touchstart', cancel, inputOpts);
+  runtime.addEventListener('keydown', cancel, inputOpts);
+  return () => {
+    if (typeof runtime.removeEventListener !== 'function') return;
+    runtime.removeEventListener('wheel', cancel, inputOpts);
+    runtime.removeEventListener('touchstart', cancel, inputOpts);
+    runtime.removeEventListener('keydown', cancel, inputOpts);
+  };
+}
+
+/** @param {{ x?: number, y?: number } | null} pos */
+export function restoreViewportScroll(pos) {
+  const scrollTo = getRuntimeFunction('scrollTo');
+  if (!pos || !scrollTo) return;
+  try { scrollTo({ left: pos.x || 0, top: pos.y || 0, behavior: 'instant' }); } catch (_) {
+    try { scrollTo(pos.x || 0, pos.y || 0); } catch (__) {}
+  }
+}
+
+export function getViewportHeight() {
+  const runtime = getRuntimeWindow();
+  return Number.isFinite(runtime?.innerHeight) ? runtime.innerHeight : 0;
+}
+
+/** @param {number} delta */
+export function scrollViewportBy(delta) {
+  const scrollBy = getRuntimeFunction('scrollBy');
+  if (!scrollBy) return;
+  try { scrollBy({ top: delta, behavior: 'instant' }); } catch (_) {
+    try { scrollBy(0, delta); } catch (__) {}
+  }
+}

--- a/js/views-router-runtime.js
+++ b/js/views-router-runtime.js
@@ -60,7 +60,14 @@ export function restoreViewportScroll(pos) {
 
 export function getViewportHeight() {
   const runtime = getRuntimeWindow();
-  return Number.isFinite(runtime?.innerHeight) ? runtime.innerHeight : 0;
+  if (!runtime) return 0;
+  const height = Number(runtime.innerHeight);
+  if (Number.isFinite(height) && height > 0) return height;
+  const rootHeight = Number(runtime.document?.documentElement?.clientHeight);
+  if (Number.isFinite(rootHeight) && rootHeight > 0) return rootHeight;
+  const bodyHeight = Number(runtime.document?.body?.clientHeight);
+  if (Number.isFinite(bodyHeight) && bodyHeight > 0) return bodyHeight;
+  return 0;
 }
 
 /** @param {number} delta */

--- a/js/views-router.js
+++ b/js/views-router.js
@@ -213,6 +213,7 @@ function _syncSidebarActive(routeCategory) {
 function _captureScrollAnchor() {
   let el = document.activeElement;
   const vh = getViewportHeight();
+  const hasViewportHeight = vh > 0;
   // Walk up looking for a stable selector
   while (el && el !== document.body && el !== document.documentElement) {
     const sel = _stableSelectorFor(el);
@@ -220,7 +221,7 @@ function _captureScrollAnchor() {
       const rect = el.getBoundingClientRect();
       // Skip if the anchor is off-screen — would still work but
       // intent-wise we want a viewport-visible anchor.
-      if (rect.bottom > 0 && rect.top < vh) {
+      if (rect.bottom > 0 && (!hasViewportHeight || rect.top < vh)) {
         return { selector: sel, viewportTop: rect.top };
       }
     }
@@ -243,17 +244,17 @@ function _captureScrollAnchor() {
   // room card has its rect-center off-screen, so smaller off-to-the-
   // side elements with centers inside the viewport beat it.
   const candidates = document.querySelectorAll('[data-id], [data-screen-id], [data-room-id]');
-  const viewportCenter = vh / 2;
+  const viewportCenter = hasViewportHeight ? vh / 2 : 0;
   let containingBest = null;
   let containingBestArea = Infinity;
   let centerBest = null;
   let centerBestDist = Infinity;
   for (const c of candidates) {
     const rect = c.getBoundingClientRect();
-    if (rect.bottom <= 0 || rect.top >= vh) continue;
+    if (rect.bottom <= 0 || (hasViewportHeight && rect.top >= vh)) continue;
     const sel = _stableSelectorFor(c);
     if (!sel) continue;
-    const containsCenter = rect.top <= viewportCenter && rect.bottom >= viewportCenter;
+    const containsCenter = hasViewportHeight && rect.top <= viewportCenter && rect.bottom >= viewportCenter;
     if (containsCenter) {
       const area = rect.width * rect.height;
       if (area < containingBestArea) {
@@ -262,7 +263,7 @@ function _captureScrollAnchor() {
       }
     } else {
       const center = rect.top + rect.height / 2;
-      const dist = Math.abs(center - viewportCenter);
+      const dist = hasViewportHeight ? Math.abs(center - viewportCenter) : Math.abs(Math.max(rect.top, 0));
       if (dist < centerBestDist) {
         centerBestDist = dist;
         centerBest = { selector: sel, viewportTop: rect.top };

--- a/js/views-router.js
+++ b/js/views-router.js
@@ -5,6 +5,15 @@ import { state } from './state.js';
 import { getActiveData } from './data.js';
 import { profileStorageKey } from './profile.js';
 import { safeMarkerId } from './utils.js';
+import {
+  addViewportInputCancelListeners,
+  closeMobileSidebarFromRuntime,
+  getViewportHeight,
+  getViewportScrollPosition,
+  restoreViewportScroll,
+  scrollViewportBy,
+  syncImportStatusFabFromRuntime,
+} from './views-router-runtime.js';
 
 export const CORE_ROUTES = new Set([
   'dashboard',
@@ -63,12 +72,7 @@ export function createNavigate({ routeHandlers, syncMobileBottomNav, destroyAllC
     const routeData = optionsOnlyData ? undefined : data;
     const routeCategory = isKnownRoute(requestedCategory, routeData) ? requestedCategory : 'dashboard';
     const activeCategory = routeCategory;
-    const preservedScroll = preserveScroll && typeof window !== 'undefined'
-      ? {
-          x: Number.isFinite(window.scrollX) ? window.scrollX : (window.pageXOffset || 0),
-          y: Number.isFinite(window.scrollY) ? window.scrollY : (window.pageYOffset || 0),
-        }
-      : null;
+    const preservedScroll = preserveScroll ? getViewportScrollPosition() : null;
 
     // Detect "re-render in place" (callsite is requesting a refresh of the
     // current view, not a real navigation). On in-place re-renders we use
@@ -113,12 +117,11 @@ export function createNavigate({ routeHandlers, syncMobileBottomNav, destroyAllC
     }
     _syncSidebarActive(activeCategory);
     // Close mobile sidebar on navigation
-    const appWindow = /** @type {any} */ (window);
-    if (appWindow.closeMobileSidebar) appWindow.closeMobileSidebar();
+    closeMobileSidebarFromRuntime();
     if (routeCategory !== "dashboard" && typeof document !== 'undefined') {
       document.body.classList.remove('mobile-dashboard-active', 'empty-dashboard-active');
     }
-    if (appWindow.syncImportStatusFab) appWindow.syncImportStatusFab();
+    syncImportStatusFabFromRuntime();
     destroyAllCharts?.();
     if (routeCategory === "dashboard") routeHandlers.dashboard?.(routeData);
     else if (routeCategory === "labs") routeHandlers.labs?.(routeData);
@@ -167,14 +170,9 @@ export function createNavigate({ routeHandlers, syncMobileBottomNav, destroyAllC
       const start = Date.now();
       let cancelled = false;
       const cancel = () => { cancelled = true; };
-      const inputOpts = { passive: true, capture: true };
-      window.addEventListener('wheel', cancel, inputOpts);
-      window.addEventListener('touchstart', cancel, inputOpts);
-      window.addEventListener('keydown', cancel, inputOpts);
+      const removeCancelListeners = addViewportInputCancelListeners(cancel);
       const cleanup = () => {
-        window.removeEventListener('wheel', cancel, inputOpts);
-        window.removeEventListener('touchstart', cancel, inputOpts);
-        window.removeEventListener('keydown', cancel, inputOpts);
+        removeCancelListeners();
         if (myToken === _navAnchorToken) _activeAnchor = null;
       };
       const reapply = () => {
@@ -189,10 +187,7 @@ export function createNavigate({ routeHandlers, syncMobileBottomNav, destroyAllC
 }
 
 function _restorePixelScroll(pos) {
-  if (!pos || typeof window === 'undefined' || typeof window.scrollTo !== 'function') return;
-  try { window.scrollTo({ left: pos.x || 0, top: pos.y || 0, behavior: 'instant' }); } catch (_) {
-    try { window.scrollTo(pos.x || 0, pos.y || 0); } catch (__) {}
-  }
+  restoreViewportScroll(pos);
 }
 
 function _syncSidebarActive(routeCategory) {
@@ -217,6 +212,7 @@ function _syncSidebarActive(routeCategory) {
 //      navigation wasn't user-initiated (e.g. async refresh).
 function _captureScrollAnchor() {
   let el = document.activeElement;
+  const vh = getViewportHeight();
   // Walk up looking for a stable selector
   while (el && el !== document.body && el !== document.documentElement) {
     const sel = _stableSelectorFor(el);
@@ -224,7 +220,7 @@ function _captureScrollAnchor() {
       const rect = el.getBoundingClientRect();
       // Skip if the anchor is off-screen — would still work but
       // intent-wise we want a viewport-visible anchor.
-      if (rect.bottom > 0 && rect.top < window.innerHeight) {
+      if (rect.bottom > 0 && rect.top < vh) {
         return { selector: sel, viewportTop: rect.top };
       }
     }
@@ -247,7 +243,6 @@ function _captureScrollAnchor() {
   // room card has its rect-center off-screen, so smaller off-to-the-
   // side elements with centers inside the viewport beat it.
   const candidates = document.querySelectorAll('[data-id], [data-screen-id], [data-room-id]');
-  const vh = window.innerHeight;
   const viewportCenter = vh / 2;
   let containingBest = null;
   let containingBestArea = Infinity;
@@ -301,8 +296,6 @@ function _restoreScrollAnchor(anchor) {
   const rect = el.getBoundingClientRect();
   const delta = rect.top - anchor.viewportTop;
   if (Math.abs(delta) > 1) {
-    try { window.scrollBy({ top: delta, behavior: 'instant' }); } catch (_) {
-      try { window.scrollBy(0, delta); } catch (__) {}
-    }
+    scrollViewportBy(delta);
   }
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 547,
+  "windowReferences": 528,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -183,6 +183,7 @@ const APP_SHELL = [
   '/js/client-list-runtime.js',
   '/js/client-list.js',
   '/js/nav.js',
+  '/js/views-router-runtime.js',
   '/js/views-router.js',
   '/js/dashboard-view-composition.js',
   '/js/dashboard-page-view.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -171,6 +171,7 @@ const LEGACY_TESTS = [
   './test-tour.js',
   './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
+  './test-views-router-runtime.js',
   './test-shell-delegated-actions.js',
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -342,6 +342,7 @@ const startupAppShellCheckJsModules = [
   'js/startup-ui.js',
   'js/theme.js',
   'js/tour.js',
+  'js/views-router-runtime.js',
   'js/views-router.js',
 ];
 const missingStartupAppShellCheckJsModules = startupAppShellCheckJsModules

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -251,6 +251,10 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
     assert('views-router.js routes viewport globals through runtime adapter',
       routerSrc.includes("from './views-router-runtime.js'")
       && !/\bwindow(?:\.|\s*\[)/.test(routerSrc));
+    assert('views-router.js: zero viewport height still allows anchor capture',
+      /hasViewportHeight\s*=\s*vh\s*>\s*0/.test(routerSrc)
+      && /!hasViewportHeight\s*\|\|\s*rect\.top\s*<\s*vh/.test(routerSrc)
+      && /hasViewportHeight\s*&&\s*rect\.top\s*>=\s*vh/.test(routerSrc));
     // v1.6.10: token cancellation across navigates.
     assert('views-router.js: _navAnchorToken bumped per navigate, old loops bail',
       /_navAnchorToken/.test(routerSrc) && /myToken\s*!==\s*_navAnchorToken/.test(routerSrc));

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -214,12 +214,13 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   console.log('%c 6. Scroll-anchor system ', 'font-weight:bold;color:#0891b2');
   {
     const routerSrc = fetchSrc('js/views-router.js');
+    const routerRuntimeSrc = fetchSrc('js/views-router-runtime.js');
     assert('views-router.js: _captureScrollAnchor exists', /function _captureScrollAnchor/.test(routerSrc));
     assert('views-router.js: _restoreScrollAnchor exists', /function _restoreScrollAnchor/.test(routerSrc));
     assert('views-router.js: modal-safe preserveScroll path exists',
       routerSrc.includes('preserveScroll')
       && routerSrc.includes('function _restorePixelScroll')
-      && routerSrc.includes('window.scrollTo'));
+      && routerSrc.includes('restoreViewportScroll'));
     assert('views-router.js: two-tier heuristic (containingBest + centerBest)',
       /containingBest[\s\S]{0,500}centerBest/.test(routerSrc));
     assert('views-router.js: containing-tier picks SMALLEST area (innermost)',
@@ -243,9 +244,13 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /1200/.test(routerSrc) && /requestAnimationFrame\(reapply\)/.test(routerSrc));
     // v1.6.10: user-input cancel for the loop.
     assert('views-router.js: anchor loop cancels on wheel/touchstart/keydown',
-      /addEventListener\('wheel'/.test(routerSrc)
-      && /addEventListener\('touchstart'/.test(routerSrc)
-      && /addEventListener\('keydown'/.test(routerSrc));
+      routerSrc.includes('addViewportInputCancelListeners(cancel)')
+      && /addEventListener\('wheel'/.test(routerRuntimeSrc)
+      && /addEventListener\('touchstart'/.test(routerRuntimeSrc)
+      && /addEventListener\('keydown'/.test(routerRuntimeSrc));
+    assert('views-router.js routes viewport globals through runtime adapter',
+      routerSrc.includes("from './views-router-runtime.js'")
+      && !/\bwindow(?:\.|\s*\[)/.test(routerSrc));
     // v1.6.10: token cancellation across navigates.
     assert('views-router.js: _navAnchorToken bumped per navigate, old loops bail',
       /_navAnchorToken/.test(routerSrc) && /myToken\s*!==\s*_navAnchorToken/.test(routerSrc));

--- a/tests/test-views-router-runtime.js
+++ b/tests/test-views-router-runtime.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// test-views-router-runtime.js - Views router browser runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  addViewportInputCancelListeners,
+  closeMobileSidebarFromRuntime,
+  getViewportHeight,
+  getViewportScrollPosition,
+  restoreViewportScroll,
+  scrollViewportBy,
+  syncImportStatusFabFromRuntime,
+} from '../js/views-router-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+console.log('=== Views Router Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'scrollX',
+  'scrollY',
+  'pageXOffset',
+  'pageYOffset',
+  'innerHeight',
+  'scrollTo',
+  'scrollBy',
+  'addEventListener',
+  'removeEventListener',
+  'closeMobileSidebar',
+  'syncImportStatusFab',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+
+  setRuntimeValue('scrollX', 12);
+  setRuntimeValue('scrollY', 34);
+  setRuntimeValue('pageXOffset', 56);
+  setRuntimeValue('pageYOffset', 78);
+  assert('getViewportScrollPosition prefers scrollX/Y',
+    JSON.stringify(getViewportScrollPosition()) === JSON.stringify({ x: 12, y: 34 }));
+
+  setRuntimeValue('scrollX', NaN);
+  setRuntimeValue('scrollY', NaN);
+  assert('getViewportScrollPosition falls back to page offsets',
+    JSON.stringify(getViewportScrollPosition()) === JSON.stringify({ x: 56, y: 78 }));
+
+  setRuntimeValue('closeMobileSidebar', () => calls.push(['close-sidebar']));
+  setRuntimeValue('syncImportStatusFab', () => calls.push(['sync-fab']));
+  closeMobileSidebarFromRuntime();
+  syncImportStatusFabFromRuntime();
+  assert('shell callbacks delegate to runtime hooks',
+    calls.some(call => call[0] === 'close-sidebar') &&
+    calls.some(call => call[0] === 'sync-fab'));
+
+  const listenerAdds = [];
+  const listenerRemoves = [];
+  setRuntimeValue('addEventListener', (type, fn, opts) => listenerAdds.push([type, fn, opts]));
+  setRuntimeValue('removeEventListener', (type, fn, opts) => listenerRemoves.push([type, fn, opts]));
+  const cancel = () => calls.push(['cancel']);
+  const cleanup = addViewportInputCancelListeners(cancel);
+  cleanup();
+  assert('addViewportInputCancelListeners installs and removes wheel touch key guards',
+    listenerAdds.map(call => call[0]).join(',') === 'wheel,touchstart,keydown' &&
+    listenerRemoves.map(call => call[0]).join(',') === 'wheel,touchstart,keydown' &&
+    listenerAdds.every(call => call[1] === cancel && call[2]?.passive === true && call[2]?.capture === true));
+
+  setRuntimeValue('scrollTo', (...args) => calls.push(['scroll-to', args]));
+  restoreViewportScroll({ x: 5, y: 9 });
+  assert('restoreViewportScroll uses object scrollTo when available',
+    calls.some(call => call[0] === 'scroll-to' && call[1]?.[0]?.left === 5 && call[1]?.[0]?.top === 9));
+
+  setRuntimeValue('scrollTo', (...args) => {
+    if (args.length === 1 && typeof args[0] === 'object') throw new Error('object unsupported');
+    calls.push(['scroll-to-fallback', args]);
+  });
+  restoreViewportScroll({ x: 7, y: 11 });
+  assert('restoreViewportScroll falls back to positional scrollTo',
+    calls.some(call => call[0] === 'scroll-to-fallback' && call[1]?.[0] === 7 && call[1]?.[1] === 11));
+
+  setRuntimeValue('innerHeight', 777);
+  assert('getViewportHeight reads runtime viewport height',
+    getViewportHeight() === 777);
+
+  setRuntimeValue('scrollBy', (...args) => calls.push(['scroll-by', args]));
+  scrollViewportBy(13);
+  assert('scrollViewportBy uses object scrollBy when available',
+    calls.some(call => call[0] === 'scroll-by' && call[1]?.[0]?.top === 13));
+
+  setRuntimeValue('scrollBy', (...args) => {
+    if (args.length === 1 && typeof args[0] === 'object') throw new Error('object unsupported');
+    calls.push(['scroll-by-fallback', args]);
+  });
+  scrollViewportBy(17);
+  assert('scrollViewportBy falls back to positional scrollBy',
+    calls.some(call => call[0] === 'scroll-by-fallback' && call[1]?.[0] === 0 && call[1]?.[1] === 17));
+
+  delete globalThis.window;
+  assert('runtime adapter no-ops safely when window is missing',
+    getViewportScrollPosition() === null &&
+    getViewportHeight() === 0 &&
+    typeof addViewportInputCancelListeners(() => {}) === 'function');
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-views-router-runtime.js
+++ b/tests/test-views-router-runtime.js
@@ -22,6 +22,7 @@ console.log('=== Views Router Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
+  'document',
   'scrollX',
   'scrollY',
   'pageXOffset',
@@ -104,6 +105,22 @@ try {
   setRuntimeValue('innerHeight', 777);
   assert('getViewportHeight reads runtime viewport height',
     getViewportHeight() === 777);
+
+  setRuntimeValue('innerHeight', 0);
+  setRuntimeValue('document', {
+    documentElement: { clientHeight: 642 },
+    body: { clientHeight: 321 },
+  });
+  assert('getViewportHeight falls back to documentElement height when innerHeight is zero',
+    getViewportHeight() === 642);
+
+  setRuntimeValue('innerHeight', NaN);
+  setRuntimeValue('document', {
+    documentElement: { clientHeight: 0 },
+    body: { clientHeight: 321 },
+  });
+  assert('getViewportHeight falls back to body height when root height is unavailable',
+    getViewportHeight() === 321);
 
   setRuntimeValue('scrollBy', (...args) => calls.push(['scroll-by', args]));
   scrollViewportBy(13);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -56,6 +56,7 @@
     '/js/category-customization.js',
     '/js/commit-hash.js',
     '/js/client-list-runtime.js',
+    '/js/views-router-runtime.js',
     '/js/focus-card.js',
     '/js/onboarding-view.js',
     '/js/marker-detail-modal.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -207,6 +207,7 @@
     "js/tour.js",
     "js/url-safety.js",
     "js/utils.js",
+    "js/views-router-runtime.js",
     "js/views-router.js",
     "js/views.js",
     "js/wearable-adapters.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -288,6 +288,7 @@
     "js/tour.js",
     "js/url-safety.js",
     "js/utils.js",
+    "js/views-router-runtime.js",
     "js/views-router.js",
     "js/views.js",
     "js/wearable-adapters.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.74';
+self.APP_VERSION = '1.10.75';


### PR DESCRIPTION
## Summary
- Added a `views-router-runtime` adapter for viewport scroll, input cancel listeners, and shell runtime hooks.
- Routed `views-router.js` through the adapter so the router no longer has direct counted `window.` / `window[...]` references.
- Registered the new module in the app shell, service worker cache, quality/module/typecheck lists, and lowered the `windowReferences` quality baseline from 547 to 528.

## Validation
- `node tests/test-views-router-runtime.js`
- `node tests/test-v1-6-shipped.js`
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test`
- `npx playwright test tests/playwright/views-router-browser-coverage.spec.js --workers=1`
- `./run-tests.sh` reached 339/340 Playwright tests, with one export/import browser fixture mismatch that did not reproduce in isolation.
- `npx playwright test tests/playwright/core-browser-flows.spec.js -g "export/import browser fixture" --workers=1`