### PR TITLE
[codex] Extract wearables settings runtime hooks

### DIFF
--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -17,6 +17,12 @@ import {
 } from './wearables-connect.js';
 import { syncWearableSummary } from './wearables-summary.js';
 import { getActiveProfileId } from './profile.js';
+import {
+  closeWearableSettingsModal,
+  confirmWearableSettingsAction,
+  exposeWearableSettingsBindings,
+  navigateWearablesDashboard,
+} from './wearables-settings-runtime.js';
 
 let wearableSettingsDelegatesInstalled = false;
 
@@ -161,7 +167,7 @@ export function setWearableStripHidden(hidden) {
   const key = _wearableStripHiddenKey();
   if (hidden) localStorage.setItem(key, '1');
   else localStorage.removeItem(key);
-  if (window.navigate) window.navigate('dashboard');
+  navigateWearablesDashboard();
 }
 
 // Vendor logo / mark beside the adapter name. Backed by brands/<vendor>/
@@ -407,16 +413,15 @@ function handleManualOpenDashboard() {
   // Settings modal is an overlay; let the caller close it by dispatching the
   // same Escape path the close button uses. We just navigate the underlying
   // dashboard — the user hits Escape / closes Settings manually.
-  if (window.closeSettings) window.closeSettings();
-  if (window.navigate) window.navigate('dashboard');
+  closeWearableSettingsModal();
+  navigateWearablesDashboard();
   requestAnimationFrame(() => {
     document.getElementById('wearable-strip')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   });
 }
 
 async function handleManualDisconnect() {
-  if (typeof window.showConfirmDialog !== 'function') return;
-  if (await window.showConfirmDialog(
+  if (await confirmWearableSettingsAction(
     'Delete all manual entries? This removes every weight / BP / pulse entry you\'ve logged manually. Data from connected wearables (Oura, Withings, etc.) is untouched. Can\'t be undone.'
   )) {
     try {
@@ -434,7 +439,7 @@ async function handleManualDisconnect() {
       await refreshManualSummary(profileId);
       showNotification?.('All manual entries deleted', 'success');
       refreshSettingsWearables();
-      if (window.navigate) window.navigate('dashboard');
+      navigateWearablesDashboard();
     } catch (e) {
       showNotification?.(`Couldn't delete: ${e.message}`, 'error', 4000);
     }
@@ -518,7 +523,7 @@ async function importAppleHealthFlow(file) {
     });
     showNotification?.(`Apple Health imported — ${res.rows} days`, 'success', 3000);
     refreshSettingsWearables();
-    if (window.navigate) window.navigate('dashboard');
+    navigateWearablesDashboard();
   } catch (e) {
     showNotification?.(`Apple Health import failed: ${e.message}`, 'error', 6000);
     if (text) text.textContent = `Failed: ${e.message}`;
@@ -535,7 +540,7 @@ async function handleWearableSyncNow(adapterId, triggerEl) {
     const res = await syncNow(adapterId, { force: true });
     showNotification?.(`${name} synced (${res.rows ?? 0} new)`, 'success', 2500);
     refreshSettingsWearables();
-    if (window.navigate) window.navigate('dashboard');
+    navigateWearablesDashboard();
   } catch { /* syncNow already notified */ }
   finally {
     btn?.classList.remove('is-syncing');
@@ -551,7 +556,7 @@ async function handleWearableBackfill(adapterId) {
     await syncWearableSummary(getActiveProfileId(), listConnectedSources());
     showNotification?.(`${name} backfilled ${bf.rows} days`, 'success');
     refreshSettingsWearables();
-    if (window.navigate) window.navigate('dashboard');
+    navigateWearablesDashboard();
   } catch (e) {
     showNotification?.(`Backfill failed: ${e.message}`, 'error', 4000);
   }
@@ -563,7 +568,7 @@ async function handleWearableDisconnect(adapterId) {
     await disconnectWearable(adapterId, { deleteData: true });
     showNotification?.(`${name} disconnected`, 'success');
     refreshSettingsWearables();
-    if (window.navigate) window.navigate('dashboard');
+    navigateWearablesDashboard();
   }
 }
 
@@ -574,7 +579,7 @@ function refreshSettingsWearables() {
 
 installWearableSettingsDelegates();
 
-Object.assign(window, {
+exposeWearableSettingsBindings({
   setWearableStripHidden,
   isWearableStripHidden,
   renderWearablesSettingsSection,

--- a/js/wearables-settings-runtime.js
+++ b/js/wearables-settings-runtime.js
@@ -1,0 +1,37 @@
+// @ts-check
+// wearables-settings-runtime.js - Browser runtime adapters for wearable settings hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function closeWearableSettingsModal() {
+  getRuntimeFunction('closeSettings')?.();
+}
+
+export function navigateWearablesDashboard() {
+  getRuntimeFunction('navigate')?.('dashboard');
+}
+
+/** @param {string} message */
+export async function confirmWearableSettingsAction(message) {
+  const confirm = getRuntimeFunction('showConfirmDialog');
+  return confirm ? !!await confirm(message) : false;
+}
+
+/** @param {Record<string, unknown>} bindings */
+export function exposeWearableSettingsBindings(bindings) {
+  const runtime = getRuntimeWindow();
+  if (runtime) Object.assign(runtime, bindings);
+}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 528,
+  "windowReferences": 510,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -343,6 +343,7 @@ const APP_SHELL = [
   '/js/wearables-detail-modal.js',
   '/js/wearables-formatters.js',
   '/js/wearables-manual-form-ui.js',
+  '/js/wearables-settings-runtime.js',
   '/js/wearables-settings-panel.js',
   '/js/wearables-store.js',
   '/js/wearables-summary.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -172,6 +172,7 @@ const LEGACY_TESTS = [
   './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',
+  './test-wearables-settings-runtime.js',
   './test-shell-delegated-actions.js',
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -267,6 +267,7 @@ const wearablesWorkflowCheckJsModules = [
   'js/wearables-oura.js',
   'js/wearables-polar-auth.js',
   'js/wearables-polar.js',
+  'js/wearables-settings-runtime.js',
   'js/wearables-settings-panel.js',
   'js/wearables-store.js',
   'js/wearables-summary.js',

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -305,7 +305,11 @@ try {
   assert('deleteManualEntryFromDetail uses promise-style showConfirmDialog',
     /await\s+window\.showConfirmDialog\(/.test(delFn));
   assert('handleManualDisconnect uses promise-style showConfirmDialog',
-    /await\s+window\.showConfirmDialog\(/.test(handleDisconnectFn));
+    /await\s+confirmWearableSettingsAction\(/.test(handleDisconnectFn));
+  assert('wearables settings panel routes dashboard refresh through runtime adapter',
+    wearablesSettingsSrc.includes("from './wearables-settings-runtime.js'")
+    && wearablesSettingsSrc.includes('navigateWearablesDashboard()')
+    && !/\bwindow(?:\.|\s*\[)/.test(wearablesSettingsSrc));
 
   // ═══════════════════════════════════════
   // Note + chip parity (this-branch additions)

--- a/tests/test-wearables-settings-runtime.js
+++ b/tests/test-wearables-settings-runtime.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// test-wearables-settings-runtime.js - Wearables settings runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  closeWearableSettingsModal,
+  confirmWearableSettingsAction,
+  exposeWearableSettingsBindings,
+  navigateWearablesDashboard,
+} from '../js/wearables-settings-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Wearables Settings Runtime Tests ===\n');
+
+const runtimeKeys = ['window', 'navigate', 'closeSettings', 'showConfirmDialog', 'wearableProbe'];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
+  setRuntimeValue('closeSettings', () => calls.push(['close-settings']));
+  setRuntimeValue('showConfirmDialog', async message => {
+    calls.push(['confirm', message]);
+    return message === 'confirm me';
+  });
+
+  navigateWearablesDashboard();
+  closeWearableSettingsModal();
+  const confirmed = await confirmWearableSettingsAction('confirm me');
+  assert('navigateWearablesDashboard delegates to dashboard route',
+    calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard'));
+  assert('closeWearableSettingsModal delegates to settings close hook',
+    calls.some(call => call[0] === 'close-settings'));
+  assert('confirmWearableSettingsAction delegates to runtime confirm dialog',
+    confirmed && calls.some(call => call[0] === 'confirm' && call[1] === 'confirm me'));
+
+  const probe = () => 'ok';
+  exposeWearableSettingsBindings({ wearableProbe: probe });
+  assert('exposeWearableSettingsBindings assigns bindings to runtime window',
+    globalThis.wearableProbe === probe);
+
+  delete globalThis.window;
+  navigateWearablesDashboard();
+  closeWearableSettingsModal();
+  const missingConfirm = await confirmWearableSettingsAction('confirm me');
+  exposeWearableSettingsBindings({ wearableProbe: null });
+  assert('runtime adapter no-ops safely when window is missing',
+    !missingConfirm && globalThis.wearableProbe === probe);
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -47,6 +47,7 @@
     '/js/wearables-bp-detail-chart.js',
     '/js/wearables-formatters.js',
     '/js/wearables-manual-form-ui.js',
+    '/js/wearables-settings-runtime.js',
     '/js/dashboard-view-composition.js',
     '/js/dashboard-page-view.js',
     '/js/lens-page-shell.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -224,6 +224,7 @@
     "js/wearables-oura.js",
     "js/wearables-polar-auth.js",
     "js/wearables-polar.js",
+    "js/wearables-settings-runtime.js",
     "js/wearables-settings-panel.js",
     "js/wearables-store.js",
     "js/wearables-summary.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -304,6 +304,7 @@
     "js/wearables-oura.js",
     "js/wearables-polar-auth.js",
     "js/wearables-polar.js",
+    "js/wearables-settings-runtime.js",
     "js/wearables-settings-panel.js",
     "js/wearables-store.js",
     "js/wearables-summary.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.75';
+self.APP_VERSION = '1.10.76';


### PR DESCRIPTION
## Summary
- Added `wearables-settings-runtime.js` for Settings/Wearables runtime hooks: settings close, dashboard navigation, confirmation, and window binding export.
- Routed `wearables-settings-panel.js` through that adapter so the panel has no direct counted `window.` / `window[...]` references.
- Registered the new runtime module in the service worker, module verifier, checkJs/typecheck lists, and Vitest legacy suite.
- Lowered the `windowReferences` quality baseline from 528 to 510 and bumped the app version to `1.10.76`.

## Validation
- `node tests/test-wearables-settings-runtime.js`
- `node tests/test-wearables-manual.js`
- `node tests/test-wearables.js`
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test`
- `npx playwright test tests/playwright/wearables-settings-browser-coverage.spec.js tests/playwright/wearables-settings-panel-browser-coverage.spec.js --workers=1`
- `./run-tests.sh`