### PR TITLE
[codex] Extract provider local AI runtime hooks

### DIFF
--- a/js/provider-local-ai-controls.js
+++ b/js/provider-local-ai-controls.js
@@ -12,6 +12,11 @@ import {
 } from './api.js';
 import { getOllamaConfig, checkOllama, checkOpenAICompatible, saveOllamaConfig, setOllamaPIIEnabled } from './pii.js';
 import { detectHardware, assessModel, assessFitness, getBestModel, getUpgradeSuggestion, saveHardwareOverride, getHardwareOverride } from './hardware.js';
+import {
+  cacheLocalAiModelDetails,
+  getCachedLocalAiModelDetails,
+  updatePrivacyStatusCardFromRuntime,
+} from './provider-local-ai-runtime.js';
 
 let returnToChatIfOnboarding = function() {};
 const LOCAL_AI_NOT_CONNECTED_TEXT = 'Not connected \u2014 check URL and ensure your server is running';
@@ -60,8 +65,7 @@ export function initSettingsOllamaCheck() {
           ? ollama.modelDetails
           : (result.modelDetails || []);
         if (modelDetails.length > 0) {
-          window._lastOllamaModelDetails = modelDetails;
-          window._lastIsOllamaServer = isOllamaServer;
+          cacheLocalAiModelDetails(modelDetails, isOllamaServer);
           renderModelAdvisor(modelDetails, modelSelect, isOllamaServer);
         }
       } else if (result.available) {
@@ -72,13 +76,13 @@ export function initSettingsOllamaCheck() {
         text.textContent = 'Not connected \u2014 start your local server to use';
       }
       if (sameUrl) {
-        window.updatePrivacyStatusCard?.(result.available && result.models.length > 0);
+        updatePrivacyStatusCardFromRuntime(result.available && result.models.length > 0);
       } else {
-        window.updatePrivacyStatusCard?.();
+        updatePrivacyStatusCardFromRuntime();
       }
     });
   } else {
-    window.updatePrivacyStatusCard?.();
+    updatePrivacyStatusCardFromRuntime();
   }
 }
 
@@ -371,12 +375,11 @@ export async function testOllamaConnection() {
         ? ollamaResult.modelDetails
         : (result.modelDetails || []);
       if (modelDetails.length > 0 && modelSection && modelSelect) {
-        window._lastOllamaModelDetails = modelDetails;
-        window._lastIsOllamaServer = isOllamaServer;
+        cacheLocalAiModelDetails(modelDetails, isOllamaServer);
         renderModelAdvisor(modelDetails, modelSelect, isOllamaServer);
       }
     }
-    window.updatePrivacyStatusCard?.();
+    updatePrivacyStatusCardFromRuntime();
     returnToChatIfOnboarding();
   } catch (e) {
     dot.classList.add('disconnected');
@@ -429,18 +432,18 @@ export async function testPIIOllamaConnection() {
         piiSelect.innerHTML = models.map(m => `<option value="${escapeHTML(m)}" ${m === currentPII ? 'selected' : ''}>${escapeHTML(m)}</option>`).join('');
       }
     }
-    window.updatePrivacyStatusCard?.();
+    updatePrivacyStatusCardFromRuntime();
   } catch (e) {
     dot.classList.add('disconnected');
     text.textContent = LOCAL_AI_NOT_CONNECTED_TEXT;
-    window.updatePrivacyStatusCard?.();
+    updatePrivacyStatusCardFromRuntime();
   }
 }
 
 export function refreshModelAdvisor() {
-  const details = window._lastOllamaModelDetails || [];
+  const { modelDetails: details, isOllamaServer } = getCachedLocalAiModelDetails();
   const modelSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('local-ai-model-select'));
-  if (details.length) renderModelAdvisor(details, modelSelect, !!window._lastIsOllamaServer);
+  if (details.length) renderModelAdvisor(details, modelSelect, isOllamaServer);
 }
 
 export function copyOllamaPullCmd(cmd) {
@@ -451,14 +454,14 @@ export function applyHardwareOverride(vram) {
   const v = parseFloat(vram);
   if (isNaN(v) || v <= 0) { showNotification('Enter a valid VRAM amount in GB', 'error'); return; }
   saveHardwareOverride(v);
-  const details = window._lastOllamaModelDetails || [];
+  const { modelDetails: details, isOllamaServer } = getCachedLocalAiModelDetails();
   const modelSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('local-ai-model-select'));
-  if (details.length) renderModelAdvisor(details, modelSelect, !!window._lastIsOllamaServer);
+  if (details.length) renderModelAdvisor(details, modelSelect, isOllamaServer);
 }
 
 export function clearHardwareOverride() {
   saveHardwareOverride(null);
-  const details = window._lastOllamaModelDetails || [];
+  const { modelDetails: details, isOllamaServer } = getCachedLocalAiModelDetails();
   const modelSelect = /** @type {HTMLSelectElement | null} */ (document.getElementById('local-ai-model-select'));
-  if (details.length) renderModelAdvisor(details, modelSelect, !!window._lastIsOllamaServer);
+  if (details.length) renderModelAdvisor(details, modelSelect, isOllamaServer);
 }

--- a/js/provider-local-ai-runtime.js
+++ b/js/provider-local-ai-runtime.js
@@ -1,0 +1,47 @@
+// @ts-check
+// provider-local-ai-runtime.js - Browser runtime adapters for Local AI settings hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/** @param {boolean} [isAvailable] */
+export function updatePrivacyStatusCardFromRuntime(isAvailable) {
+  const update = getRuntimeFunction('updatePrivacyStatusCard');
+  if (!update) return;
+  if (typeof isAvailable === 'boolean') update(isAvailable);
+  else update();
+}
+
+/**
+ * @param {any[]} modelDetails
+ * @param {boolean} isOllamaServer
+ */
+export function cacheLocalAiModelDetails(modelDetails, isOllamaServer) {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return;
+  runtime._lastOllamaModelDetails = modelDetails;
+  runtime._lastIsOllamaServer = isOllamaServer;
+}
+
+export function getCachedLocalAiModelDetails() {
+  const runtime = getRuntimeWindow();
+  const modelDetails = Array.isArray(runtime?._lastOllamaModelDetails)
+    ? runtime._lastOllamaModelDetails
+    : [];
+  return {
+    modelDetails,
+    isOllamaServer: !!runtime?._lastIsOllamaServer,
+  };
+}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 510,
+  "windowReferences": 494,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -250,6 +250,7 @@ const APP_SHELL = [
   '/js/provider-wallet-panels.js',
   '/js/provider-wallet-funding-recovery.js',
   '/js/provider-wallet-delegates.js',
+  '/js/provider-local-ai-runtime.js',
   '/js/provider-local-ai-controls.js',
   '/js/provider-ppq-panels.js',
   '/js/provider-panel-renderers.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -85,6 +85,7 @@ const LEGACY_TESTS = [
   './test-wearables-fetchers.js',
   './test-wearables-runtime-config.js',
   './test-hardware.js',
+  './test-provider-local-ai-runtime.js',
   // Batch 8 — lens parsers + a11y phase 3 + marker value notes.
   './test-lens-parsers.js',
   './test-a11y-phase3.js',

--- a/tests/test-hardware.js
+++ b/tests/test-hardware.js
@@ -178,8 +178,12 @@ console.log('=== Hardware & Model Advisor Tests ===\n');
 
   const ppSrc = read('js/provider-panels.js');
   const localAiControlsSrc = read('js/provider-local-ai-controls.js');
+  const localAiRuntimeSrc = read('js/provider-local-ai-runtime.js');
   const panelRenderSrc = read('js/provider-panel-renderers.js');
   assert('Provider local AI controls imports hardware.js', localAiControlsSrc.includes("from './hardware.js'"));
+  assert('Provider local AI controls imports runtime adapter', localAiControlsSrc.includes("from './provider-local-ai-runtime.js'"));
+  assert('Provider local AI runtime owns model details cache', localAiRuntimeSrc.includes('_lastOllamaModelDetails'));
+  assert('Provider local AI controls has no direct window refs', !/\bwindow(\.|\s*\[)/.test(localAiControlsSrc));
   assert('Provider renderer has advisor placeholder', panelRenderSrc.includes('local-ai-advisor'));
   assert('Provider local AI controls calls renderModelAdvisor', localAiControlsSrc.includes('renderModelAdvisor'));
   assert('Provider panels exports copyOllamaPullCmd', ppSrc.includes('copyOllamaPullCmd'));

--- a/tests/test-provider-local-ai-runtime.js
+++ b/tests/test-provider-local-ai-runtime.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// test-provider-local-ai-runtime.js - Local AI settings runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  cacheLocalAiModelDetails,
+  getCachedLocalAiModelDetails,
+  updatePrivacyStatusCardFromRuntime,
+} from '../js/provider-local-ai-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Provider Local AI Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'updatePrivacyStatusCard',
+  '_lastOllamaModelDetails',
+  '_lastIsOllamaServer',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const privacyCalls = [];
+  setRuntimeValue('updatePrivacyStatusCard', (...args) => privacyCalls.push(args));
+
+  updatePrivacyStatusCardFromRuntime(true);
+  updatePrivacyStatusCardFromRuntime();
+  assert('updatePrivacyStatusCardFromRuntime delegates boolean and empty calls',
+    privacyCalls.length === 2 &&
+      privacyCalls[0].length === 1 &&
+      privacyCalls[0][0] === true &&
+      privacyCalls[1].length === 0);
+
+  const modelDetails = [{ name: 'llama3.2' }];
+  cacheLocalAiModelDetails(modelDetails, true);
+  const cached = getCachedLocalAiModelDetails();
+  assert('cacheLocalAiModelDetails stores details and Ollama flag on runtime',
+    cached.modelDetails === modelDetails && cached.isOllamaServer === true);
+
+  setRuntimeValue('_lastOllamaModelDetails', 'not-an-array');
+  setRuntimeValue('_lastIsOllamaServer', 1);
+  const invalidCached = getCachedLocalAiModelDetails();
+  assert('getCachedLocalAiModelDetails normalizes missing or invalid details',
+    Array.isArray(invalidCached.modelDetails) &&
+      invalidCached.modelDetails.length === 0 &&
+      invalidCached.isOllamaServer === true);
+
+  delete globalThis.window;
+  updatePrivacyStatusCardFromRuntime(false);
+  cacheLocalAiModelDetails([{ name: 'qwen2.5:14b' }], false);
+  const missingRuntimeCached = getCachedLocalAiModelDetails();
+  assert('runtime adapter no-ops safely when window is missing',
+    privacyCalls.length === 2 &&
+      missingRuntimeCached.modelDetails.length === 0 &&
+      missingRuntimeCached.isOllamaServer === false);
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -77,6 +77,7 @@
     '/js/light-sessions-view.js',
     '/js/compare-correlations.js',
     '/js/mobile-dashboard.js',
+    '/js/provider-local-ai-runtime.js',
     '/js/schema.js',
     '/js/dna-window-bindings.js',
   ];

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -355,6 +355,7 @@
     "js/marker-detail-editing.js",
     "js/notes.js",
     "js/profile-context.js",
+    "js/provider-local-ai-runtime.js",
     "js/provider-local-ai-controls.js",
     "js/provider-panel-delegates.js",
     "js/provider-ppq-panels.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -174,6 +174,7 @@
     "js/api.js",
     "js/api-provider-storage.js",
     "js/api-transport.js",
+    "js/provider-local-ai-runtime.js",
     "js/provider-local-ai-controls.js",
     "js/provider-model-controls.js",
     "js/provider-panel-delegates.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.76';
+self.APP_VERSION = '1.10.77';


### PR DESCRIPTION
## Summary
- Added provider-local-ai-runtime.js for Local AI settings runtime hooks: privacy card callback and cached model-detail state.
- Routed provider-local-ai-controls.js through the adapter so it has no direct counted window. / window[] references.
- Registered the new runtime module in the service worker, module verifier, typecheck lists, and Vitest legacy suite.
- Lowered the windowReferences quality baseline from 510 to 494 and bumped the app version to 1.10.77.

## Validation
- npm run quality
- node tests/test-provider-local-ai-runtime.js
- node tests/test-hardware.js
- node tests/verify-modules.js
- npm run typecheck
- npm run typecheck:checkjs
- npm test
- npx playwright test tests/playwright/settings-provider-browser-coverage.spec.js --workers=1
- ./run-tests.sh