### PR TITLE
[codex] Extract dashboard widget runtime hooks

### DIFF
--- a/js/dashboard-widget-controls.js
+++ b/js/dashboard-widget-controls.js
@@ -4,6 +4,18 @@
 import { DASHBOARD_WIDGET_SOURCE_ORDER, dashboardBiometricSelectionKey } from './dashboard-widgets.js';
 import { escapeAttr, escapeHTML, formatValue, getStatus, safeMarkerId, showNotification } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import {
+  deleteDashboardNote,
+  getDashboardViewportHeight,
+  navigateDashboardRoute,
+  openDashboardManualLogForm,
+  openDashboardMarkerDetail,
+  openDashboardNoteEditor,
+  openDashboardWearableDetail,
+  openDashboardWearablesSettings,
+  syncDashboardWearableNow,
+  triggerDashboardDnaPicker,
+} from './dashboard-widget-runtime.js';
 
 const DASHBOARD_WIDGET_KEYBOARD_ACTIONS = new Set([
   'open-biometric-manual-log',
@@ -112,8 +124,10 @@ export function createDashboardWidgetControls(deps) {
   }
 
   function getDashboardViewportTargetWidgetId() {
-    if (typeof document === 'undefined' || typeof window === 'undefined') return '';
-    const targetLine = Math.max(120, window.innerHeight * 0.36);
+    if (typeof document === 'undefined') return '';
+    const viewportHeight = getDashboardViewportHeight();
+    if (viewportHeight == null) return '';
+    const targetLine = Math.max(120, viewportHeight * 0.36);
     const widgets = /** @type {HTMLElement[]} */ ([...document.querySelectorAll('.dashboard-widget[data-widget-id]')]);
     for (const el of widgets) {
       const rect = el.getBoundingClientRect();
@@ -260,37 +274,36 @@ export function createDashboardWidgetControls(deps) {
       resetDashboardWidgets();
       closeDashboardWidgetPicker();
     } else if (action === 'connect-source') {
-      window.openSettingsModal?.('wearables');
+      openDashboardWearablesSettings();
       closeDashboardWidgetPicker();
     } else if (action === 'open-biometric-picker') {
       openDashboardBiometricPicker();
     } else if (action === 'sync-biometric-now') {
-      window.syncWearableNow?.(actionEl);
+      syncDashboardWearableNow(actionEl);
     } else if (action === 'remove-biometric-metric') {
       removeDashboardBiometricMetric(id);
     } else if (action === 'open-biometric-detail') {
-      if (window.openWearableDetail) window.openWearableDetail(id);
-      else window.openSettingsModal?.('wearables');
+      if (!openDashboardWearableDetail(id)) openDashboardWearablesSettings();
     } else if (action === 'open-biometric-manual-log') {
-      window.openManualLogForm?.(id, event);
+      openDashboardManualLogForm(id, event);
     } else if (action === 'open-marker-detail') {
-      if (safeMarkerId(id)) window.showDetailModal?.(id);
+      if (safeMarkerId(id)) openDashboardMarkerDetail(id);
     } else if (action === 'navigate') {
       const route = actionEl.dataset.dashboardWidgetRoute || '';
-      if (/^[a-zA-Z0-9_-]+$/.test(route)) window.navigate?.(route);
+      if (/^[a-zA-Z0-9_-]+$/.test(route)) navigateDashboardRoute(route);
     } else if (action === 'trigger-dna-picker') {
-      window.triggerDNAFilePicker?.();
+      triggerDashboardDnaPicker();
     } else if (action === 'open-note-editor') {
       const rawIndex = actionEl.dataset.dashboardWidgetIndex;
       if (rawIndex == null || rawIndex === '') {
-        window.openNoteEditor?.();
+        openDashboardNoteEditor();
       } else {
         const index = Number(rawIndex);
-        if (Number.isInteger(index) && index >= 0) window.openNoteEditor?.(null, index);
+        if (Number.isInteger(index) && index >= 0) openDashboardNoteEditor(index);
       }
     } else if (action === 'delete-note') {
       const index = Number(actionEl.dataset.dashboardWidgetIndex);
-      if (Number.isInteger(index) && index >= 0) window.deleteNote?.(index);
+      if (Number.isInteger(index) && index >= 0) deleteDashboardNote(index);
     }
   }
 
@@ -412,7 +425,7 @@ export function createDashboardWidgetControls(deps) {
 
   function addDashboardWidgetFromLens(id) {
     showDashboardWidget(id);
-    if (state.currentView && state.currentView !== 'dashboard') window.navigate?.(state.currentView);
+    if (state.currentView && state.currentView !== 'dashboard') navigateDashboardRoute(state.currentView);
     showNotification('Added to Dashboard', 'success');
   }
 
@@ -422,7 +435,7 @@ export function createDashboardWidgetControls(deps) {
     if (!prefs.hidden.includes(id)) prefs.hidden.push(id);
     saveDashboardWidgetPrefs(prefs);
     if (state.currentView === 'dashboard') rerenderDashboardFromWidgetChange();
-    else if (state.currentView) window.navigate?.(state.currentView);
+    else if (state.currentView) navigateDashboardRoute(state.currentView);
     showNotification('Removed from Dashboard', 'info');
   }
 

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -1,0 +1,76 @@
+// @ts-check
+// dashboard-widget-runtime.js - Browser runtime adapters for dashboard widget controls.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function getDashboardViewportHeight() {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return null;
+  const height = Number(runtime?.innerHeight);
+  return Number.isFinite(height) && height > 0 ? height : 0;
+}
+
+export function openDashboardWearablesSettings() {
+  getRuntimeFunction('openSettingsModal')?.('wearables');
+}
+
+/** @param {Element} actionEl */
+export function syncDashboardWearableNow(actionEl) {
+  getRuntimeFunction('syncWearableNow')?.(actionEl);
+}
+
+/** @param {string} id */
+export function openDashboardWearableDetail(id) {
+  const openDetail = getRuntimeFunction('openWearableDetail');
+  if (!openDetail) return false;
+  openDetail(id);
+  return true;
+}
+
+/**
+ * @param {string} id
+ * @param {Event} event
+ */
+export function openDashboardManualLogForm(id, event) {
+  getRuntimeFunction('openManualLogForm')?.(id, event);
+}
+
+/** @param {string} id */
+export function openDashboardMarkerDetail(id) {
+  getRuntimeFunction('showDetailModal')?.(id);
+}
+
+/** @param {string} route */
+export function navigateDashboardRoute(route) {
+  getRuntimeFunction('navigate')?.(route);
+}
+
+export function triggerDashboardDnaPicker() {
+  getRuntimeFunction('triggerDNAFilePicker')?.();
+}
+
+/** @param {number | null} [index] */
+export function openDashboardNoteEditor(index = null) {
+  const openEditor = getRuntimeFunction('openNoteEditor');
+  if (!openEditor) return;
+  if (Number.isInteger(index) && index >= 0) openEditor(null, index);
+  else openEditor();
+}
+
+/** @param {number} index */
+export function deleteDashboardNote(index) {
+  getRuntimeFunction('deleteNote')?.(index);
+}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 494,
+  "windowReferences": 479,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -209,6 +209,7 @@ const APP_SHELL = [
   '/js/biology-score-thyroid.js',
   '/js/profile-context.js',
   '/js/dashboard-widgets.js',
+  '/js/dashboard-widget-runtime.js',
   '/js/dashboard-widget-controls.js',
   '/js/dashboard-widget-renderers.js',
   '/js/dashboard-recommendation-widget.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -174,6 +174,7 @@ const LEGACY_TESTS = [
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',
   './test-wearables-settings-runtime.js',
+  './test-dashboard-widget-runtime.js',
   './test-shell-delegated-actions.js',
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const controlsSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-controls.js'), 'utf8');
+const runtimeSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-runtime.js'), 'utf8');
 const compositionSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
 const renderersSrc = fs.readFileSync(path.join(root, 'js/dashboard-widget-renderers.js'), 'utf8');
 const dashboardWidgetsCss = fs.readFileSync(path.join(root, 'css/dashboard-widgets.css'), 'utf8');
@@ -33,6 +34,14 @@ console.log('=== Dashboard Widget Delegated Actions ===');
 
 assert('dashboard widget controls render no inline event attributes',
   !/\bon(?:click|input|dragstart|dragover|drop)=/.test(controlsSrc));
+assert('dashboard widget controls import runtime adapter',
+  controlsSrc.includes("from './dashboard-widget-runtime.js'"));
+assert('dashboard widget runtime owns shell callbacks',
+  runtimeSrc.includes('openSettingsModal') &&
+    runtimeSrc.includes('syncWearableNow') &&
+    runtimeSrc.includes('openNoteEditor'));
+assert('dashboard widget controls has no direct window refs',
+  !/\bwindow(\.|\s*\[)/.test(controlsSrc));
 assert('dashboard widget renderers render no inline event attributes',
   !/\bon(?:click|input|change|keydown|keyup|submit)=/.test(renderersSrc));
 assert('dashboard widget controls render delegated action attributes',

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// test-dashboard-widget-runtime.js - Dashboard widget runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  deleteDashboardNote,
+  getDashboardViewportHeight,
+  navigateDashboardRoute,
+  openDashboardManualLogForm,
+  openDashboardMarkerDetail,
+  openDashboardNoteEditor,
+  openDashboardWearableDetail,
+  openDashboardWearablesSettings,
+  syncDashboardWearableNow,
+  triggerDashboardDnaPicker,
+} from '../js/dashboard-widget-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Dashboard Widget Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'innerHeight',
+  'openSettingsModal',
+  'syncWearableNow',
+  'openWearableDetail',
+  'openManualLogForm',
+  'showDetailModal',
+  'navigate',
+  'triggerDNAFilePicker',
+  'openNoteEditor',
+  'deleteNote',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('innerHeight', 720);
+  assert('getDashboardViewportHeight reads runtime innerHeight',
+    getDashboardViewportHeight() === 720);
+
+  setRuntimeValue('innerHeight', 0);
+  assert('getDashboardViewportHeight preserves zero-height runtime fallback',
+    getDashboardViewportHeight() === 0);
+
+  const actionEl = { dataset: { dashboardWidgetAction: 'sync-biometric-now' } };
+  const event = { type: 'click' };
+  setRuntimeValue('openSettingsModal', section => calls.push(['settings', section]));
+  setRuntimeValue('syncWearableNow', el => calls.push(['sync', el?.dataset?.dashboardWidgetAction || '']));
+  setRuntimeValue('openWearableDetail', id => calls.push(['wearable-detail', id]));
+  setRuntimeValue('openManualLogForm', (id, ev) => calls.push(['manual-log', id, ev.type]));
+  setRuntimeValue('showDetailModal', id => calls.push(['marker-detail', id]));
+  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
+  setRuntimeValue('triggerDNAFilePicker', () => calls.push(['dna']));
+  setRuntimeValue('openNoteEditor', (...args) => calls.push(['note-editor', ...args.map(arg => arg ?? 'null')]));
+  setRuntimeValue('deleteNote', index => calls.push(['delete-note', index]));
+
+  openDashboardWearablesSettings();
+  syncDashboardWearableNow(actionEl);
+  const openedDetail = openDashboardWearableDetail('sleep');
+  openDashboardManualLogForm('weight', event);
+  openDashboardMarkerDetail('lipids_apob');
+  navigateDashboardRoute('labs');
+  triggerDashboardDnaPicker();
+  openDashboardNoteEditor();
+  openDashboardNoteEditor(2);
+  deleteDashboardNote(1);
+  assert('runtime adapter delegates dashboard widget shell callbacks',
+    openedDetail &&
+      calls.some(call => call.join('|') === 'settings|wearables') &&
+      calls.some(call => call.join('|') === 'sync|sync-biometric-now') &&
+      calls.some(call => call.join('|') === 'wearable-detail|sleep') &&
+      calls.some(call => call.join('|') === 'manual-log|weight|click') &&
+      calls.some(call => call.join('|') === 'marker-detail|lipids_apob') &&
+      calls.some(call => call.join('|') === 'navigate|labs') &&
+      calls.some(call => call.join('|') === 'dna') &&
+      calls.some(call => call.join('|') === 'note-editor') &&
+      calls.some(call => call.join('|') === 'note-editor|null|2') &&
+      calls.some(call => call.join('|') === 'delete-note|1'));
+
+  delete globalThis.openWearableDetail;
+  assert('openDashboardWearableDetail reports missing callback',
+    openDashboardWearableDetail('sleep') === false);
+
+  delete globalThis.window;
+  const callCountBeforeMissingRuntime = calls.length;
+  openDashboardWearablesSettings();
+  syncDashboardWearableNow(actionEl);
+  openDashboardManualLogForm('weight', event);
+  openDashboardMarkerDetail('lipids_apob');
+  navigateDashboardRoute('dashboard');
+  triggerDashboardDnaPicker();
+  openDashboardNoteEditor(3);
+  deleteDashboardNote(2);
+  assert('runtime adapter no-ops safely when window is missing',
+    getDashboardViewportHeight() === null &&
+      openDashboardWearableDetail('sleep') === false &&
+      calls.length === callCountBeforeMissingRuntime);
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -77,6 +77,7 @@
     '/js/light-sessions-view.js',
     '/js/compare-correlations.js',
     '/js/mobile-dashboard.js',
+    '/js/dashboard-widget-runtime.js',
     '/js/provider-local-ai-runtime.js',
     '/js/schema.js',
     '/js/dna-window-bindings.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -84,6 +84,7 @@
     "js/dashboard-page-view.js",
     "js/dashboard-recommendation-widget.js",
     "js/dashboard-view-composition.js",
+    "js/dashboard-widget-runtime.js",
     "js/dashboard-widget-controls.js",
     "js/dashboard-widget-renderers.js",
     "js/dashboard-widgets.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -84,6 +84,7 @@
     "js/dashboard-page-view.js",
     "js/dashboard-recommendation-widget.js",
     "js/dashboard-view-composition.js",
+    "js/dashboard-widget-runtime.js",
     "js/dashboard-widget-controls.js",
     "js/dashboard-widget-renderers.js",
     "js/dashboard-widgets.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.77';
+self.APP_VERSION = '1.10.78';


### PR DESCRIPTION
## Summary
- Added dashboard-widget-runtime.js for dashboard widget browser runtime hooks: viewport height, navigation, wearable/settings callbacks, marker detail, DNA picker, and note actions.
- Routed dashboard-widget-controls.js through the adapter so it has no direct counted window. / window[] references.
- Registered the new runtime module in the service worker, module verifier, typecheck lists, and Vitest legacy suite.
- Lowered the windowReferences quality baseline from 494 to 479 and bumped the app version to 1.10.78.

## Validation
- npm run quality
- node tests/test-dashboard-widget-runtime.js
- node tests/test-dashboard-widget-delegated-actions.js
- node tests/verify-modules.js
- npm run typecheck
- npm run typecheck:checkjs
- npm test
- npx playwright test tests/playwright/dashboard-widget-controls-browser-coverage.spec.js tests/playwright/dashboard-widget-delegated-actions-dom.spec.js --workers=1
- ./run-tests.sh