### PR TITLE
[codex] Extract PDF import review runtime state

### DIFF
--- a/js/pdf-import-review-runtime.js
+++ b/js/pdf-import-review-runtime.js
@@ -1,0 +1,88 @@
+// @ts-check
+// pdf-import-review-runtime.js - Browser runtime adapters for import review state.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+export function clearPendingImportRuntime() {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return;
+  runtime._pendingImport = null;
+  runtime._pendingImportRefLookup = null;
+}
+
+export function confirmImportFromRuntime() {
+  const runtime = getRuntimeWindow();
+  const confirmImport = runtime?.confirmImport;
+  if (typeof confirmImport === 'function') confirmImport.call(runtime);
+}
+
+export function getPendingImportFromRuntime() {
+  const runtime = getRuntimeWindow();
+  return runtime?._pendingImport || null;
+}
+
+export function getPendingImportRefLookup() {
+  const runtime = getRuntimeWindow();
+  return runtime?._pendingImportRefLookup || null;
+}
+
+/**
+ * @param {any} parseResult
+ * @param {Record<string, any>} refLookup
+ */
+export function setPendingImportRuntime(parseResult, refLookup) {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return;
+  runtime._pendingImport = parseResult;
+  runtime._pendingImportRefLookup = refLookup;
+}
+
+export function getBatchImportContext() {
+  const runtime = getRuntimeWindow();
+  return runtime?._batchImportContext || null;
+}
+
+export function hasBatchImportContext() {
+  return !!getBatchImportContext();
+}
+
+export function markImportReviewDelegatesBound() {
+  const runtime = getRuntimeWindow();
+  if (!runtime || runtime.__importReviewDelegatesBound) return false;
+  runtime.__importReviewDelegatesBound = true;
+  return true;
+}
+
+/**
+ * @param {any} original
+ * @param {any} obfuscated
+ */
+export function showPIIDiffViewerFromRuntime(original, obfuscated) {
+  const runtime = getRuntimeWindow();
+  const showPIIDiffViewer = runtime?.showPIIDiffViewer;
+  if (typeof showPIIDiffViewer === 'function') showPIIDiffViewer.call(runtime, original, obfuscated);
+}
+
+export function takeBatchImportResolve() {
+  const runtime = getRuntimeWindow();
+  const resolve = runtime?._batchImportResolve;
+  if (typeof resolve !== 'function') return null;
+  runtime._batchImportResolve = null;
+  runtime._batchImportContext = null;
+  return resolve;
+}
+
+/**
+ * @param {(action: string) => void} resolve
+ * @param {{ current: number, total: number }} context
+ */
+export function startBatchImport(resolve, context) {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return;
+  runtime._batchImportResolve = resolve;
+  runtime._batchImportContext = context;
+}

--- a/js/pdf-import-review.js
+++ b/js/pdf-import-review.js
@@ -30,10 +30,22 @@ import {
   renderImportMapInput,
   setImportExcludeButtonState,
 } from './import-review-row-actions.js';
+import {
+  clearPendingImportRuntime,
+  confirmImportFromRuntime,
+  getBatchImportContext,
+  getPendingImportFromRuntime,
+  getPendingImportRefLookup,
+  hasBatchImportContext,
+  markImportReviewDelegatesBound,
+  setPendingImportRuntime,
+  showPIIDiffViewerFromRuntime,
+  startBatchImport,
+  takeBatchImportResolve,
+} from './pdf-import-review-runtime.js';
 
 function clearPendingImport() {
-  window._pendingImport = null;
-  window._pendingImportRefLookup = null;
+  clearPendingImportRuntime();
   clearImportReviewDraft();
 }
 
@@ -55,18 +67,13 @@ function closestImportReviewElement(target, selector) {
   return el instanceof HTMLElement && el.closest('#import-modal') ? el : null;
 }
 
-function getImportReviewWindow() {
-  return typeof window !== 'undefined' ? /** @type {any} */ (window) : {};
-}
-
 function persistImportReviewDraftForState(parseResult = getPendingImport()) {
-  const appWindow = getImportReviewWindow();
   if (!parseResult) return;
   if (!parseResult._importProfileId) parseResult._importProfileId = state.currentProfile;
   saveImportReviewDraft(parseResult, {
     profileId: state.currentProfile || 'default',
     excludedIndices: Array.from(getExcludedImportIndices()),
-    isBatch: !!appWindow._batchImportContext,
+    isBatch: hasBatchImportContext(),
     debug: isDebugMode(),
   });
 }
@@ -129,16 +136,14 @@ function handleImportReviewClick(event) {
       openImportMarkerMapPicker(actionEl);
       break;
     case 'privacy-details': {
-      const appWindow = getImportReviewWindow();
       const pending = getPendingImport();
-      if (typeof appWindow.showPIIDiffViewer === 'function' && pending?.privacyOriginal && pending?.privacyObfuscated) {
-        appWindow.showPIIDiffViewer(pending.privacyOriginal, pending.privacyObfuscated);
+      if (pending?.privacyOriginal && pending?.privacyObfuscated) {
+        showPIIDiffViewerFromRuntime(pending.privacyOriginal, pending.privacyObfuscated);
       }
       break;
     }
     case 'confirm': {
-      const appWindow = getImportReviewWindow();
-      if (typeof appWindow.confirmImport === 'function') appWindow.confirmImport();
+      confirmImportFromRuntime();
       break;
     }
     default:
@@ -223,10 +228,7 @@ function updateImportMarkerUnitValue(controlEl, nextUnit) {
 }
 
 function initImportReviewDelegates() {
-  if (typeof document === 'undefined' || typeof window === 'undefined') return;
-  const appWindow = getImportReviewWindow();
-  if (appWindow.__importReviewDelegatesBound) return;
-  appWindow.__importReviewDelegatesBound = true;
+  if (typeof document === 'undefined' || !markImportReviewDelegatesBound()) return;
   document.addEventListener('click', handleImportReviewClick);
   document.addEventListener('input', handleImportReviewInput);
   document.addEventListener('change', handleImportReviewChange);
@@ -236,14 +238,12 @@ function initImportReviewDelegates() {
 initImportReviewDelegates();
 
 export function getPendingImport() {
-  return window._pendingImport || null;
+  return getPendingImportFromRuntime();
 }
 
 export function resolveImportPreviewBatch(action) {
-  if (!window._batchImportResolve) return false;
-  const resolve = window._batchImportResolve;
-  window._batchImportResolve = null;
-  window._batchImportContext = null;
+  const resolve = takeBatchImportResolve();
+  if (!resolve) return false;
   hideImportOverlay();
   clearPendingImport();
   restoreDropZoneVisibility();
@@ -413,7 +413,7 @@ function openImportMarkerMapPicker(controlEl) {
   const idx = parseInt(controlEl.dataset.markerIdx, 10);
   const marker = result.markers[idx];
   if (!marker) return;
-  const refLookup = getImportReviewWindow()._pendingImportRefLookup || buildMarkerReference();
+  const refLookup = getPendingImportRefLookup() || buildMarkerReference();
   openImportMarkerMapModal({
     marker,
     currentKey: marker.mappedKey || '',
@@ -430,7 +430,7 @@ export function showImportPreview(parseResult) {
   const newMarkers = markers.filter(m => !m.matched && m.suggestedKey);
   const unmatched = markers.filter(m => !m.matched && !m.suggestedKey);
   const importCount = matched.length + newMarkers.length;
-  const batchCtx = window._batchImportContext;
+  const batchCtx = getBatchImportContext();
   const batchLabel = batchCtx ? `File ${batchCtx.current} of ${batchCtx.total}` : 'Lab import';
   modal.className = 'modal import-preview-modal';
   let html = `<div class="gb-modal-head import-preview-head">
@@ -588,8 +588,7 @@ export function showImportPreview(parseResult) {
       <button type="button" class="import-btn import-btn-primary" id="import-confirm-btn" ${importReviewActionAttrs('confirm')}${importDisabled}>${confirmLabel}</button>
     </div>`;
   if (!parseResult._importProfileId) parseResult._importProfileId = state.currentProfile;
-  window._pendingImport = parseResult;
-  window._pendingImportRefLookup = refLookup;
+  setPendingImportRuntime(parseResult, refLookup);
   modal.innerHTML = html;
   openModalOverlay(overlay);
   restoreExcludedImportRows(parseResult);
@@ -619,7 +618,7 @@ export function mapUnmatchedMarkerInput(inputEl) {
 
 function resolveImportMarkerKey(raw) {
   if (!raw) return '';
-  const refLookup = window._pendingImportRefLookup || buildMarkerReference();
+  const refLookup = getPendingImportRefLookup() || buildMarkerReference();
   if (refLookup[raw]) return raw;
   const normalized = raw.toLowerCase();
   for (const [key, def] of Object.entries(refLookup)) {
@@ -787,8 +786,7 @@ export function showImportPreviewAsync(result, current, total) {
   const dropZone = document.getElementById('drop-zone');
   if (dropZone) dropZone.style.display = 'none';
   return new Promise(resolve => {
-    window._batchImportResolve = resolve;
-    window._batchImportContext = { current, total };
+    startBatchImport(resolve, { current, total });
     showImportPreview(result);
   });
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 479,
+  "windowReferences": 466,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -133,6 +133,7 @@ const APP_SHELL = [
   '/js/pdf-import-progress.js',
   '/js/pdf-import-ai-utils.js',
   '/js/pdf-import-review.js',
+  '/js/pdf-import-review-runtime.js',
   '/js/pdf-import-marker-mapping.js',
   '/js/pdf-import-marker-normalization.js',
   '/js/pdf-import-persistence.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -86,6 +86,7 @@ const LEGACY_TESTS = [
   './test-wearables-runtime-config.js',
   './test-hardware.js',
   './test-provider-local-ai-runtime.js',
+  './test-pdf-import-review-runtime.js',
   // Batch 8 — lens parsers + a11y phase 3 + marker value notes.
   './test-lens-parsers.js',
   './test-a11y-phase3.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -73,6 +73,7 @@ assert('SW APP_SHELL includes API transport module', swAuditSrc.includes("'/js/a
 assert('SW APP_SHELL includes settings data module', swAuditSrc.includes("'/js/settings-data.js'"));
 assert('SW APP_SHELL includes settings provider bridge module', swAuditSrc.includes("'/js/settings-provider-bridge.js'"));
 assert('SW APP_SHELL includes PDF import review module', swAuditSrc.includes("'/js/pdf-import-review.js'"));
+assert('SW APP_SHELL includes PDF import review runtime module', swAuditSrc.includes("'/js/pdf-import-review-runtime.js'"));
 assert('SW APP_SHELL includes modal lifecycle module', swAuditSrc.includes("'/js/modal-lifecycle.js'"));
 assert('SW APP_SHELL includes marker analysis module', swAuditSrc.includes("'/js/marker-analysis.js'"));
 assert('SW APP_SHELL includes PDF import support modules',

--- a/tests/test-pdf-import-review-runtime.js
+++ b/tests/test-pdf-import-review-runtime.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// test-pdf-import-review-runtime.js - Import review browser-runtime adapter coverage.
+
+import './_node-shim.js';
+
+import {
+  clearPendingImportRuntime,
+  confirmImportFromRuntime,
+  getBatchImportContext,
+  getPendingImportFromRuntime,
+  getPendingImportRefLookup,
+  hasBatchImportContext,
+  markImportReviewDelegatesBound,
+  setPendingImportRuntime,
+  showPIIDiffViewerFromRuntime,
+  startBatchImport,
+  takeBatchImportResolve,
+} from '../js/pdf-import-review-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+const RUNTIME_FIELDS = [
+  '_pendingImport',
+  '_pendingImportRefLookup',
+  '_batchImportResolve',
+  '_batchImportContext',
+  '__importReviewDelegatesBound',
+  'confirmImport',
+  'showPIIDiffViewer',
+];
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalFieldDescriptors = new Map(
+  RUNTIME_FIELDS.map(field => [field, Object.getOwnPropertyDescriptor(globalThis, field)])
+);
+
+function restoreDescriptor(target, key, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+    return;
+  }
+  delete target[key];
+}
+
+function resetRuntimeWindow() {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: globalThis,
+  });
+  for (const field of RUNTIME_FIELDS) delete globalThis[field];
+}
+
+console.log('=== PDF Import Review Runtime Tests ===\n');
+
+try {
+  resetRuntimeWindow();
+
+  const parseResult = { date: '2026-01-01', markers: [] };
+  const refLookup = { 'biochemistry.glucose': { name: 'Glucose' } };
+  setPendingImportRuntime(parseResult, refLookup);
+  assert('pending import stored in runtime', getPendingImportFromRuntime() === parseResult);
+  assert('pending import ref lookup stored in runtime', getPendingImportRefLookup() === refLookup);
+
+  clearPendingImportRuntime();
+  assert('pending import clears to null', globalThis._pendingImport === null);
+  assert('pending import ref lookup clears to null', globalThis._pendingImportRefLookup === null);
+  assert('cleared pending import reads as null', getPendingImportFromRuntime() === null);
+  assert('cleared pending ref lookup reads as null', getPendingImportRefLookup() === null);
+
+  let resolvedAction = '';
+  const context = { current: 2, total: 5 };
+  startBatchImport(action => { resolvedAction = action; }, context);
+  assert('batch import context is available', getBatchImportContext() === context);
+  assert('batch import context predicate is true', hasBatchImportContext());
+  const resolve = takeBatchImportResolve();
+  assert('batch import resolver can be taken', typeof resolve === 'function');
+  assert('taking resolver clears batch context', globalThis._batchImportContext === null);
+  assert('taking resolver clears runtime resolver', globalThis._batchImportResolve === null);
+  resolve?.('import');
+  assert('taken resolver remains callable', resolvedAction === 'import');
+  assert('missing batch resolver returns null', takeBatchImportResolve() === null);
+
+  assert('delegate binding marker sets once', markImportReviewDelegatesBound() === true);
+  assert('delegate binding marker rejects second bind', markImportReviewDelegatesBound() === false);
+  assert('delegate binding flag stored in runtime', globalThis.__importReviewDelegatesBound === true);
+
+  let confirmCalls = 0;
+  let confirmThis = null;
+  globalThis.confirmImport = function() {
+    confirmCalls++;
+    confirmThis = this;
+  };
+  confirmImportFromRuntime();
+  assert('confirm callback is called from runtime', confirmCalls === 1);
+  assert('confirm callback preserves window receiver', confirmThis === globalThis);
+
+  let diffArgs = null;
+  let diffThis = null;
+  globalThis.showPIIDiffViewer = function(original, obfuscated) {
+    diffArgs = [original, obfuscated];
+    diffThis = this;
+  };
+  showPIIDiffViewerFromRuntime('raw', 'safe');
+  assert('PII diff callback receives payload', diffArgs?.[0] === 'raw' && diffArgs?.[1] === 'safe');
+  assert('PII diff callback preserves window receiver', diffThis === globalThis);
+
+  delete globalThis.window;
+  assert('no-window pending import reads as null', getPendingImportFromRuntime() === null);
+  assert('no-window ref lookup reads as null', getPendingImportRefLookup() === null);
+  assert('no-window batch context reads as null', getBatchImportContext() === null);
+  assert('no-window batch predicate is false', hasBatchImportContext() === false);
+  assert('no-window delegate bind is false', markImportReviewDelegatesBound() === false);
+  assert('no-window resolver take returns null', takeBatchImportResolve() === null);
+  let noWindowResolveCalled = false;
+  setPendingImportRuntime({ markers: [] }, {});
+  clearPendingImportRuntime();
+  startBatchImport(() => { noWindowResolveCalled = true; }, { current: 1, total: 1 });
+  confirmImportFromRuntime();
+  showPIIDiffViewerFromRuntime('raw', 'safe');
+  assert('no-window writes are no-ops', noWindowResolveCalled === false);
+} finally {
+  for (const field of RUNTIME_FIELDS) {
+    restoreDescriptor(globalThis, field, originalFieldDescriptors.get(field));
+  }
+  restoreDescriptor(globalThis, 'window', originalWindowDescriptor);
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+if (fail) process.exit(1);

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -29,6 +29,7 @@ const persistenceSrc = read('js/pdf-import-persistence.js');
 const settingsDataSrc = read('js/settings-data.js');
 const settingsSrc = read('js/settings.js');
 const reviewSrc = read('js/pdf-import-review.js');
+const reviewRuntimeSrc = read('js/pdf-import-review-runtime.js');
 const labEntrySrc = read('js/lab-entry.js');
 const profileSrc = read('js/profile.js');
 const importCssSrc = read('css/import.css');
@@ -163,6 +164,11 @@ const importCssSrc = read('css/import.css');
 
   assert('Review snapshot modal tolerates stored costInfo without a cost field',
     /parseResult\.costInfo && typeof parseResult\.costInfo\.cost === ['"]number['"]/.test(reviewSrc));
+  assert('Import review browser state is isolated in runtime adapter',
+    reviewSrc.includes("from './pdf-import-review-runtime.js'")
+      && !/\bwindow(?:\.|\s*\[)/.test(reviewSrc)
+      && reviewRuntimeSrc.includes('runtime._pendingImport')
+      && reviewRuntimeSrc.includes('runtime._batchImportContext'));
   assert('Re-review modal uses update wording instead of import wording',
     /parseResult\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc)
       && /result\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -79,6 +79,7 @@
     '/js/mobile-dashboard.js',
     '/js/dashboard-widget-runtime.js',
     '/js/provider-local-ai-runtime.js',
+    '/js/pdf-import-review-runtime.js',
     '/js/schema.js',
     '/js/dna-window-bindings.js',
   ];

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -167,6 +167,7 @@
     "js/pdf-import-preflight.js",
     "js/pdf-import-progress.js",
     "js/pdf-import-review.js",
+    "js/pdf-import-review-runtime.js",
     "js/pdf-import-spreadsheet.js",
     "js/pdf-import.js",
     "js/pdfjs-loader.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -165,6 +165,7 @@
     "js/pdf-import-preflight.js",
     "js/pdf-import-progress.js",
     "js/pdf-import-review.js",
+    "js/pdf-import-review-runtime.js",
     "js/pdfjs-loader.js",
     "js/pii.js",
     "js/profile.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.78';
+self.APP_VERSION = '1.10.79';


### PR DESCRIPTION
## Summary
- move PDF import review pending-import and batch-import browser state into a runtime adapter
- route import review global callbacks and delegate binding through the adapter so the review module has no direct window state reads
- add runtime regression coverage, service-worker/typecheck/Vitest registration, and tighten the window reference budget from 479 to 466
- bump app cache version to 1.10.79

## Validation
- npm run quality
- node tests/test-pdf-import-review-runtime.js
- node tests/test-unit-import.js
- node tests/test-audit.js
- node tests/verify-modules.js
- npm run typecheck
- npm run typecheck:checkjs
- npm test
- npx playwright test tests/playwright/import-review-browser-coverage.spec.js tests/playwright/pdf-import-browser-coverage.spec.js --workers=1
- ./run-tests.sh