### PR TITLE
[codex] Extract theme runtime hooks

### DIFF
--- a/js/theme-runtime.js
+++ b/js/theme-runtime.js
@@ -1,0 +1,41 @@
+// @ts-check
+// theme-runtime.js - Browser runtime adapters for theme module globals.
+
+function getThemeRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {Record<string, any>} detail
+ */
+export function dispatchThemeChange(detail) {
+  const runtime = getThemeRuntimeWindow();
+  const CustomEventCtor = runtime?.CustomEvent;
+  if (!runtime || typeof CustomEventCtor !== 'function') return;
+  runtime.dispatchEvent(new CustomEventCtor('labcharts-themechange', { detail }));
+}
+
+/**
+ * @param {{ settingsModalOpen?: boolean }} [options]
+ */
+export function refreshThemeDependentsFromRuntime(options = {}) {
+  const runtime = getThemeRuntimeWindow();
+  if (!runtime) return;
+  runtime.applyAccentOverride?.();
+  runtime.updateSettingsUI?.();
+  runtime.updateTweaksUI?.();
+  if (typeof runtime.scheduleChartThemeRefresh === 'function') runtime.scheduleChartThemeRefresh();
+  else runtime.refreshChartThemeColors?.({ batchSize: 4 });
+  if (options.settingsModalOpen) runtime.refreshSettingsWearables?.();
+}
+
+/**
+ * @param {Record<string, any>} exportsByName
+ */
+export function registerThemeRuntimeExports(exportsByName) {
+  const runtime = getThemeRuntimeWindow();
+  if (!runtime) return;
+  Object.assign(runtime, exportsByName);
+}

--- a/js/theme.js
+++ b/js/theme.js
@@ -24,6 +24,81 @@ export const THEMES = [
   { id: 'neuromancer',   label: 'Neuromancer' },
 ];
 
+/**
+ * @typedef {{
+ *   dispatchThemeChange: (detail: Record<string, any>) => void,
+ *   refreshThemeDependentsFromRuntime: (options?: { settingsModalOpen?: boolean }) => void,
+ *   registerThemeRuntimeExports: (exportsByName: Record<string, any>) => void,
+ * }} ThemeRuntimeHooks
+ */
+
+function getFallbackThemeRuntimeGlobal() {
+  return typeof globalThis !== 'undefined'
+    ? /** @type {any} */ (globalThis)
+    : null;
+}
+
+/** @type {ThemeRuntimeHooks} */
+const fallbackThemeRuntime = {
+  dispatchThemeChange(detail) {
+    const runtime = getFallbackThemeRuntimeGlobal();
+    const CustomEventCtor = runtime?.CustomEvent;
+    if (!runtime || typeof CustomEventCtor !== 'function') return;
+    runtime.dispatchEvent(new CustomEventCtor('labcharts-themechange', { detail }));
+  },
+  refreshThemeDependentsFromRuntime(options = {}) {
+    const runtime = getFallbackThemeRuntimeGlobal();
+    if (!runtime) return;
+    runtime.applyAccentOverride?.();
+    runtime.updateSettingsUI?.();
+    runtime.updateTweaksUI?.();
+    if (typeof runtime.scheduleChartThemeRefresh === 'function') runtime.scheduleChartThemeRefresh();
+    else runtime.refreshChartThemeColors?.({ batchSize: 4 });
+    if (options.settingsModalOpen) runtime.refreshSettingsWearables?.();
+  },
+  registerThemeRuntimeExports(exportsByName) {
+    const runtime = getFallbackThemeRuntimeGlobal();
+    if (!runtime) return;
+    Object.assign(runtime, exportsByName);
+  },
+};
+
+/** @type {ThemeRuntimeHooks} */
+let themeRuntimeHooks = fallbackThemeRuntime;
+
+// Static imports of newly-added modules can break already-installed service
+// worker clients during cache transitions. Use the split runtime when it is
+// fetchable, but keep this module evaluable with the fallback above.
+if (typeof globalThis !== 'undefined') {
+  import('./theme-runtime.js')
+    .then(runtime => {
+      themeRuntimeHooks = {
+        dispatchThemeChange: typeof runtime.dispatchThemeChange === 'function'
+          ? runtime.dispatchThemeChange
+          : fallbackThemeRuntime.dispatchThemeChange,
+        refreshThemeDependentsFromRuntime: typeof runtime.refreshThemeDependentsFromRuntime === 'function'
+          ? runtime.refreshThemeDependentsFromRuntime
+          : fallbackThemeRuntime.refreshThemeDependentsFromRuntime,
+        registerThemeRuntimeExports: typeof runtime.registerThemeRuntimeExports === 'function'
+          ? runtime.registerThemeRuntimeExports
+          : fallbackThemeRuntime.registerThemeRuntimeExports,
+      };
+    })
+    .catch(() => {});
+}
+
+function dispatchThemeChange(detail) {
+  themeRuntimeHooks.dispatchThemeChange(detail);
+}
+
+function refreshThemeDependentsFromRuntime(options) {
+  themeRuntimeHooks.refreshThemeDependentsFromRuntime(options);
+}
+
+function registerThemeRuntimeExports(exportsByName) {
+  themeRuntimeHooks.registerThemeRuntimeExports(exportsByName);
+}
+
 export function getTimeFormat() { return localStorage.getItem('labcharts-time-format') || '24h'; }
 export function setTimeFormat(fmt) { localStorage.setItem('labcharts-time-format', fmt); }
 
@@ -105,11 +180,7 @@ export function setSunsetMode(enabled) {
   if (on) document.documentElement.dataset.sunsetMode = 'on';
   else delete document.documentElement.dataset.sunsetMode;
   applyThemeChrome(getTheme());
-  if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
-    window.dispatchEvent(new CustomEvent('labcharts-themechange', {
-      detail: { theme: getTheme(), sunsetMode: on },
-    }));
-  }
+  dispatchThemeChange({ theme: getTheme(), sunsetMode: on });
 }
 
 export function setCrtEffectsEnabled(enabled) {
@@ -117,11 +188,7 @@ export function setCrtEffectsEnabled(enabled) {
   if (on) localStorage.setItem(CRT_EFFECTS_KEY, 'true');
   else localStorage.removeItem(CRT_EFFECTS_KEY);
   applyCrtEffectsAttr(on);
-  if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
-    window.dispatchEvent(new CustomEvent('labcharts-themechange', {
-      detail: { theme: getTheme(), crtEffects: on },
-    }));
-  }
+  dispatchThemeChange({ theme: getTheme(), crtEffects: on });
 }
 
 export function setTheme(theme) {
@@ -130,22 +197,14 @@ export function setTheme(theme) {
   if (theme === 'dark') delete document.documentElement.dataset.theme;
   else document.documentElement.dataset.theme = theme;
   applyThemeChrome(theme);
-  if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
-    window.dispatchEvent(new CustomEvent('labcharts-themechange', { detail: { theme } }));
-  }
+  dispatchThemeChange({ theme });
 }
 
 function refreshThemeDependents() {
-  window.applyAccentOverride?.();
-  window.updateSettingsUI?.();
-  window.updateTweaksUI?.();
-  if (window.scheduleChartThemeRefresh) window.scheduleChartThemeRefresh();
-  else window.refreshChartThemeColors?.({ batchSize: 4 });
   // If the Settings modal is open, the wearables list uses theme-aware
   // iconLight/iconDark assets, so refresh that panel in place.
-  if (document.getElementById('settings-modal')?.classList.contains('show')) {
-    window.refreshSettingsWearables?.();
-  }
+  const settingsModalOpen = document.getElementById('settings-modal')?.classList.contains('show') || false;
+  refreshThemeDependentsFromRuntime({ settingsModalOpen });
 }
 
 let toggleReturnTheme = 'dark';
@@ -176,4 +235,4 @@ export function getChartColors() {
   };
 }
 
-Object.assign(window, { getTheme, getThemeColor, getThemeColorScheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, setTheme, toggleTheme, getTimeFormat, setTimeFormat, formatTime, parseTimeInput, getChartColors, THEMES });
+registerThemeRuntimeExports({ getTheme, getThemeColor, getThemeColorScheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, setTheme, toggleTheme, getTimeFormat, setTimeFormat, formatTime, parseTimeInput, getChartColors, THEMES });

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 466,
+  "windowReferences": 453,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -83,6 +83,7 @@ const APP_SHELL = [
   '/js/state.js',
   '/js/utils.js',
   '/js/theme.js',
+  '/js/theme-runtime.js',
   '/js/api.js',
   '/js/api-models.js',
   '/js/api-provider-storage.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -87,6 +87,7 @@ const LEGACY_TESTS = [
   './test-hardware.js',
   './test-provider-local-ai-runtime.js',
   './test-pdf-import-review-runtime.js',
+  './test-theme-runtime.js',
   // Batch 8 — lens parsers + a11y phase 3 + marker value notes.
   './test-lens-parsers.js',
   './test-a11y-phase3.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -180,11 +180,18 @@ console.log('=== Phase 3 A11y Tests ===\n');
     indexSrc.includes("document.querySelectorAll('meta[name=\"theme-color\"]')"),
     'mobile system bars should not wait for main.js to pick up the stored app theme');
   const themeSrc = read('/js/theme.js');
+  const themeRuntimeSrc = read('/js/theme-runtime.js');
   assert('runtime theme changes update browser chrome color scheme',
     themeSrc.includes('function applyThemeChrome') &&
     themeSrc.includes('getThemeColorScheme') &&
     themeSrc.includes('document.documentElement.style.colorScheme'),
     'custom dark themes need dark system controls after switching themes');
+  assert('theme browser globals are isolated in runtime adapter',
+    themeSrc.includes("import('./theme-runtime.js')")
+      && themeSrc.includes('fallbackThemeRuntime')
+      && !/\bwindow\b/.test(themeSrc)
+      && themeRuntimeSrc.includes('dispatchThemeChange')
+      && themeRuntimeSrc.includes('registerThemeRuntimeExports'));
   assert('document root defaults to dark browser controls outside light theme',
     /html\s*\{[^}]*background:\s*var\(--bg-primary\)[^}]*color-scheme:\s*dark/.test(cssSrc) &&
     /\[data-theme="light"\]\s*\{[^}]*color-scheme:\s*light/.test(cssSrc));

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -97,6 +97,7 @@ assert('SW APP_SHELL includes DNA mtDNA helper module', swAuditSrc.includes("'/j
 assert('SW APP_SHELL includes service worker update module', swAuditSrc.includes("'/js/service-worker-update.js'"));
 assert('index loads app shell CSS bundle', indexSrc.includes('href="css/app-shell.css"'));
 assert('SW APP_SHELL includes app shell CSS bundle', swAuditSrc.includes("'/css/app-shell.css'"));
+assert('SW APP_SHELL includes theme runtime module', swAuditSrc.includes("'/js/theme-runtime.js'"));
 assert('app shell CSS loads after core CSS and before feature CSS',
   indexSrc.indexOf('href="styles.css"') < indexSrc.indexOf('href="css/app-shell.css"') &&
   indexSrc.indexOf('href="css/app-shell.css"') < indexSrc.indexOf('href="css/import.css"') &&

--- a/tests/test-theme-runtime.js
+++ b/tests/test-theme-runtime.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// test-theme-runtime.js - Theme browser-runtime adapter coverage.
+
+import './_node-shim.js';
+
+import {
+  dispatchThemeChange,
+  refreshThemeDependentsFromRuntime,
+  registerThemeRuntimeExports,
+} from '../js/theme-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+const RUNTIME_FIELDS = [
+  'CustomEvent',
+  'dispatchEvent',
+  'applyAccentOverride',
+  'updateSettingsUI',
+  'updateTweaksUI',
+  'scheduleChartThemeRefresh',
+  'refreshChartThemeColors',
+  'refreshSettingsWearables',
+  '__themeRuntimeProbe',
+];
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalFieldDescriptors = new Map(
+  RUNTIME_FIELDS.map(field => [field, Object.getOwnPropertyDescriptor(globalThis, field)])
+);
+
+function restoreDescriptor(target, key, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+    return;
+  }
+  delete target[key];
+}
+
+function resetRuntimeWindow() {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: globalThis,
+  });
+  for (const field of RUNTIME_FIELDS) delete globalThis[field];
+}
+
+console.log('=== Theme Runtime Tests ===\n');
+
+try {
+  resetRuntimeWindow();
+
+  const events = [];
+  globalThis.CustomEvent = class {
+    constructor(type, init = {}) {
+      this.type = type;
+      this.detail = init.detail;
+    }
+  };
+  globalThis.dispatchEvent = event => {
+    events.push(event);
+    return true;
+  };
+
+  dispatchThemeChange({ theme: 'glass', sunsetMode: true });
+  assert('theme change dispatches browser event', events.length === 1);
+  assert('theme change event has expected type', events[0]?.type === 'labcharts-themechange');
+  assert('theme change event carries detail', events[0]?.detail?.theme === 'glass' && events[0]?.detail?.sunsetMode === true);
+
+  const calls = [];
+  globalThis.applyAccentOverride = () => calls.push('accent');
+  globalThis.updateSettingsUI = () => calls.push('settings');
+  globalThis.updateTweaksUI = () => calls.push('tweaks');
+  globalThis.scheduleChartThemeRefresh = () => calls.push('schedule');
+  globalThis.refreshSettingsWearables = () => calls.push('wearables');
+  refreshThemeDependentsFromRuntime({ settingsModalOpen: true });
+  assert('theme dependents refresh accent/settings/tweaks', calls.includes('accent') && calls.includes('settings') && calls.includes('tweaks'));
+  assert('theme dependents prefer scheduled chart refresh', calls.includes('schedule'));
+  assert('theme dependents refresh wearables when settings modal is open', calls.includes('wearables'));
+
+  delete globalThis.scheduleChartThemeRefresh;
+  let chartRefreshOptions = null;
+  globalThis.refreshChartThemeColors = options => { chartRefreshOptions = options; };
+  refreshThemeDependentsFromRuntime({ settingsModalOpen: false });
+  assert('theme dependents fall back to chart color refresh', chartRefreshOptions?.batchSize === 4);
+
+  const probe = () => 'ok';
+  registerThemeRuntimeExports({ __themeRuntimeProbe: probe });
+  assert('theme runtime exports assign to window', globalThis.__themeRuntimeProbe === probe);
+
+  delete globalThis.window;
+  assert('no-window dispatch is safe', (() => {
+    dispatchThemeChange({ theme: 'dark' });
+    return true;
+  })());
+  assert('no-window dependent refresh is safe', (() => {
+    refreshThemeDependentsFromRuntime({ settingsModalOpen: true });
+    return true;
+  })());
+  registerThemeRuntimeExports({ __themeRuntimeProbe: 'no-window' });
+  assert('no-window exports are no-ops', globalThis.__themeRuntimeProbe === probe);
+} finally {
+  for (const field of RUNTIME_FIELDS) {
+    restoreDescriptor(globalThis, field, originalFieldDescriptors.get(field));
+  }
+  restoreDescriptor(globalThis, 'window', originalWindowDescriptor);
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+if (fail) process.exit(1);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -80,6 +80,7 @@
     '/js/dashboard-widget-runtime.js',
     '/js/provider-local-ai-runtime.js',
     '/js/pdf-import-review-runtime.js',
+    '/js/theme-runtime.js',
     '/js/schema.js',
     '/js/dna-window-bindings.js',
   ];

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -206,6 +206,7 @@
     "js/sun-uvdata.js",
     "js/sun.js",
     "js/theme.js",
+    "js/theme-runtime.js",
     "js/tour.js",
     "js/url-safety.js",
     "js/utils.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -287,6 +287,7 @@
     "js/supplement-warnings.js",
     "js/supplements.js",
     "js/theme.js",
+    "js/theme-runtime.js",
     "js/touch-tooltip.js",
     "js/tour.js",
     "js/url-safety.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.79';
+self.APP_VERSION = '1.10.80';


### PR DESCRIPTION
## Summary
- move theme browser event dispatch, dependent window callbacks, and global export registration into theme-runtime.js
- add runtime adapter coverage and source checks so theme.js stays free of direct window references
- register the runtime module in the service worker, verification, typecheck, and Vitest surfaces
- tighten the window reference budget from 466 to 453 and bump app cache version to 1.10.80

## Validation
- npm run quality
- node tests/test-theme-runtime.js
- node tests/test-a11y-phase3.js
- node tests/test-audit.js
- node tests/verify-modules.js
- npm run typecheck
- npm run typecheck:checkjs
- npm test
- npx playwright test tests/playwright/theme-responsive-e2e.spec.js tests/playwright/theme-cta-hover-contrast.spec.js --workers=1
- ./run-tests.sh