### PR TITLE
Extract import drop-zone runtime hooks

### DIFF
--- a/js/import-drop-zone-runtime.js
+++ b/js/import-drop-zone-runtime.js
@@ -1,0 +1,75 @@
+// @ts-check
+// import-drop-zone-runtime.js - Browser runtime adapters for drop-zone imports.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+function getRuntimeDocument() {
+  return typeof document !== 'undefined'
+    ? /** @type {Document} */ (document)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function}
+ */
+function requireRuntimeFunction(name) {
+  const fn = getRuntimeFunction(name);
+  if (!fn) throw new TypeError(`${name} is not available`);
+  return fn;
+}
+
+export function isDropZoneImportRunning() {
+  return Boolean(getRuntimeFunction('isImportRunning')?.());
+}
+
+export function openDropZoneFilePicker() {
+  const picker = getRuntimeDocument()?.getElementById('pdf-input');
+  if (picker && typeof picker.click === 'function') picker.click();
+}
+
+/**
+ * @param {string} message
+ * @param {string} [type]
+ */
+export function showDropZoneImportNotification(message, type = 'info') {
+  getRuntimeFunction('showNotification')?.(message, type);
+}
+
+/** @param {File} file */
+export function importDropZoneJSONFile(file) {
+  return requireRuntimeFunction('importDataJSON')(file);
+}
+
+/** @param {string} header */
+export function detectDropZoneDNAFile(header) {
+  const detectDNAFile = getRuntimeFunction('detectDNAFile');
+  return detectDNAFile ? detectDNAFile(header) : null;
+}
+
+export function hasDropZoneMtDNAHandler() {
+  return Boolean(getRuntimeFunction('handleMtDNAFile'));
+}
+
+/** @param {File} file */
+export async function handleDropZoneMtDNAFile(file) {
+  return await requireRuntimeFunction('handleMtDNAFile')(file);
+}
+
+/** @param {File} file */
+export async function handleDropZoneDNAFile(file) {
+  return await requireRuntimeFunction('handleDNAFile')(file);
+}

--- a/js/import-drop-zone.js
+++ b/js/import-drop-zone.js
@@ -2,18 +2,28 @@
 // import-drop-zone.js — shared import drop-zone event binding
 
 import { loadPdfImport } from './import-loader.js';
+import {
+  detectDropZoneDNAFile,
+  handleDropZoneDNAFile,
+  handleDropZoneMtDNAFile,
+  hasDropZoneMtDNAHandler,
+  importDropZoneJSONFile,
+  isDropZoneImportRunning,
+  openDropZoneFilePicker,
+  showDropZoneImportNotification,
+} from './import-drop-zone-runtime.js';
 
 export function setupDropZone() {
   const dropZone = document.getElementById("drop-zone");
   if (!dropZone || dropZone.dataset.lazyDropZoneBound === 'true') return;
   dropZone.dataset.lazyDropZoneBound = 'true';
   dropZone.addEventListener("click", () => {
-    if (window.isImportRunning && window.isImportRunning()) return;
-    document.getElementById('pdf-input')?.click();
+    if (isDropZoneImportRunning()) return;
+    openDropZoneFilePicker();
   });
   dropZone.addEventListener("dragover", e => {
     e.preventDefault();
-    if (!(window.isImportRunning && window.isImportRunning())) dropZone.classList.add("drag-over");
+    if (!isDropZoneImportRunning()) dropZone.classList.add("drag-over");
   });
   dropZone.addEventListener("dragleave", e => {
     e.preventDefault();
@@ -22,8 +32,8 @@ export function setupDropZone() {
   dropZone.addEventListener("drop", async e => {
     e.preventDefault();
     dropZone.classList.remove("drag-over");
-    if (window.isImportRunning && window.isImportRunning()) {
-      window.showNotification?.("Import already in progress", "info");
+    if (isDropZoneImportRunning()) {
+      showDropZoneImportNotification("Import already in progress", "info");
       return;
     }
     const files = Array.from(e.dataTransfer?.files || []);
@@ -32,22 +42,22 @@ export function setupDropZone() {
     try {
       importMod = await loadPdfImport();
     } catch (err) {
-      window.showNotification?.('Could not load import module - check your connection and try again.', 'error');
+      showDropZoneImportNotification('Could not load import module - check your connection and try again.', 'error');
       return;
     }
     const { jsonFiles, pdfFiles, imageFiles, dnaFiles, textFiles, unsupportedCount } = await importMod.classifyImportFiles(files);
     if (unsupportedCount > 0 && jsonFiles.length === 0 && pdfFiles.length === 0 && imageFiles.length === 0 && dnaFiles.length === 0 && textFiles.length === 0) {
-      window.showNotification?.("Unsupported file type. Use PDF, Excel (.xlsx), text, CSV, image, JSON, or DNA raw data (.txt/.csv).", "error");
+      showDropZoneImportNotification("Unsupported file type. Use PDF, Excel (.xlsx), text, CSV, image, JSON, or DNA raw data (.txt/.csv).", "error");
       return;
     }
-    for (const f of jsonFiles) window.importDataJSON(f);
+    for (const f of jsonFiles) importDropZoneJSONFile(f);
     if (dnaFiles.length > 0) {
       for (const f of dnaFiles) {
         const header = await f.slice(0, 1500).text();
-        const fmt = window.detectDNAFile ? window.detectDNAFile(header) : null;
-        if ((fmt === 'mtdna' || fmt === '23andme-mito') && window.handleMtDNAFile) await window.handleMtDNAFile(f);
-        else if (fmt === '23andme-y') { window.showNotification?.('Y-chromosome DNA files are not supported', 'info'); }
-        else await window.handleDNAFile(f);
+        const fmt = detectDropZoneDNAFile(header);
+        if ((fmt === 'mtdna' || fmt === '23andme-mito') && hasDropZoneMtDNAHandler()) await handleDropZoneMtDNAFile(f);
+        else if (fmt === '23andme-y') { showDropZoneImportNotification('Y-chromosome DNA files are not supported', 'info'); }
+        else await handleDropZoneDNAFile(f);
       }
     }
     else if (textFiles.length > 0) { for (const f of textFiles) await importMod.handleTextFile(f); }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 433,
+  "windowReferences": 417,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -100,6 +100,7 @@ const APP_SHELL = [
   '/js/secondary-unit-conversions.js',
   '/js/import-file-input.js',
   '/js/import-drop-zone.js',
+  '/js/import-drop-zone-runtime.js',
   '/js/ai-verdict-engine.js',
   '/js/profile.js',
   '/js/profile-runtime.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -175,6 +175,7 @@ const LEGACY_TESTS = [
   './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',
+  './test-import-drop-zone-runtime.js',
   './test-wearables-runtime.js',
   './test-wearables-settings-runtime.js',
   './test-dashboard-widget-runtime.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -302,6 +302,14 @@ console.log('=== Phase 3 A11y Tests ===\n');
       && wearRuntimeSrc.includes('exposeWearablesBindings')
       && wearRuntimeSrc.includes('getWearablesViewportSize'));
 
+  const importDropZoneSrc = read('/js/import-drop-zone.js');
+  const importDropZoneRuntimeSrc = read('/js/import-drop-zone-runtime.js');
+  assert('import drop-zone browser hooks are isolated in runtime adapter',
+    importDropZoneSrc.includes("from './import-drop-zone-runtime.js'")
+      && !/\bwindow\b/.test(importDropZoneSrc)
+      && importDropZoneRuntimeSrc.includes('isDropZoneImportRunning')
+      && importDropZoneRuntimeSrc.includes('handleDropZoneDNAFile'));
+
   // ─── 12b. Light-device browse modals close on backdrop click ───
   // Browse-style modals (Add device, picker) close on backdrop; form-input
   // modals (Log device session) require explicit Cancel/Save so accidental

--- a/tests/test-import-drop-zone-runtime.js
+++ b/tests/test-import-drop-zone-runtime.js
@@ -1,0 +1,117 @@
+// test-import-drop-zone-runtime.js - Import drop-zone browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  detectDropZoneDNAFile,
+  handleDropZoneDNAFile,
+  handleDropZoneMtDNAFile,
+  hasDropZoneMtDNAHandler,
+  importDropZoneJSONFile,
+  isDropZoneImportRunning,
+  openDropZoneFilePicker,
+  showDropZoneImportNotification,
+} from '../js/import-drop-zone-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Import Drop Zone Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'document',
+  'isImportRunning',
+  'showNotification',
+  'importDataJSON',
+  'detectDNAFile',
+  'handleMtDNAFile',
+  'handleDNAFile',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const jsonFile = new File(['{}'], 'profile.json', { type: 'application/json' });
+  const dnaFile = new File(['dna'], 'genome.txt', { type: 'text/plain' });
+  const picker = { click: () => calls.push(['picker']) };
+
+  setRuntimeValue('isImportRunning', () => true);
+  setRuntimeValue('showNotification', (message, type) => calls.push(['notify', type, message]));
+  setRuntimeValue('importDataJSON', file => calls.push(['json', file.name]));
+  setRuntimeValue('detectDNAFile', header => header.includes('MT') ? 'mtdna' : 'autosomal');
+  setRuntimeValue('handleMtDNAFile', file => calls.push(['mtdna', file.name]));
+  setRuntimeValue('handleDNAFile', file => calls.push(['dna', file.name]));
+  setRuntimeValue('document', { getElementById: id => id === 'pdf-input' ? picker : null });
+
+  openDropZoneFilePicker();
+  showDropZoneImportNotification('Import already in progress', 'info');
+  importDropZoneJSONFile(jsonFile);
+  await handleDropZoneMtDNAFile(dnaFile);
+  await handleDropZoneDNAFile(dnaFile);
+
+  assert('isDropZoneImportRunning delegates busy state', isDropZoneImportRunning() === true);
+  assert('openDropZoneFilePicker clicks the PDF input', calls.some(call => call[0] === 'picker'));
+  assert('showDropZoneImportNotification delegates message and type',
+    calls.some(call => call[0] === 'notify' && call[1] === 'info' && call[2] === 'Import already in progress'));
+  assert('importDropZoneJSONFile delegates JSON import',
+    calls.some(call => call[0] === 'json' && call[1] === 'profile.json'));
+  assert('detectDropZoneDNAFile delegates DNA detection',
+    detectDropZoneDNAFile('MT raw data') === 'mtdna');
+  assert('hasDropZoneMtDNAHandler reports handler presence', hasDropZoneMtDNAHandler() === true);
+  assert('handleDropZoneMtDNAFile delegates mtDNA import',
+    calls.some(call => call[0] === 'mtdna' && call[1] === 'genome.txt'));
+  assert('handleDropZoneDNAFile delegates DNA import',
+    calls.some(call => call[0] === 'dna' && call[1] === 'genome.txt'));
+
+  delete globalThis.handleDNAFile;
+  try {
+    await handleDropZoneDNAFile(dnaFile);
+    assert('required DNA import handler fails loudly when missing', false, 'no error thrown');
+  } catch (error) {
+    assert('required DNA import handler fails loudly when missing',
+      String(error?.message || error).includes('handleDNAFile'));
+  }
+
+  delete globalThis.window;
+  showDropZoneImportNotification('hidden', 'info');
+  openDropZoneFilePicker();
+  assert('runtime adapter no-ops optional hooks when window is missing',
+    isDropZoneImportRunning() === false && detectDropZoneDNAFile('MT raw data') === null);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/import-drop-zone.js?no-window-probe');
+  assert('import drop-zone module imports without a browser window', true);
+} catch (error) {
+  assert('import drop-zone module imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -197,6 +197,7 @@ const uiWorkflowCheckJsModules = [
   'js/dashboard-widget-controls.js',
   'js/dashboard-widgets.js',
   'js/import-drop-zone.js',
+  'js/import-drop-zone-runtime.js',
   'js/import-file-input.js',
   'js/import-loader.js',
   'js/import-marker-map-modal.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -37,6 +37,7 @@
     '/js/views.js',
     '/js/import-file-input.js',
     '/js/import-drop-zone.js',
+    '/js/import-drop-zone-runtime.js',
     '/js/recommendation-actions.js',
     '/js/context-card-dashboard-ai.js',
     '/js/context-card-dashboard-ai-actions.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -100,6 +100,7 @@
     "js/export.js",
     "js/export-runtime.js",
     "js/import-drop-zone.js",
+    "js/import-drop-zone-runtime.js",
     "js/import-file-input.js",
     "js/import-loader.js",
     "js/import-marker-map-modal.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -104,6 +104,7 @@
     "js/hardware.js",
     "js/image-utils.js",
     "js/import-drop-zone.js",
+    "js/import-drop-zone-runtime.js",
     "js/import-file-input.js",
     "js/import-loader.js",
     "js/lab-entry.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.81';
+self.APP_VERSION = '1.10.82';


### PR DESCRIPTION
## Summary
- Extract import drop-zone browser-global hooks into `js/import-drop-zone-runtime.js`.
- Route drop-zone busy state, picker opening, notifications, JSON import, and DNA handlers through the adapter.
- Add focused runtime coverage, module/cache/typecheck registration, guardrail baseline update, and app version bump to `1.10.82`.

## Validation
- `node tests/test-import-drop-zone-runtime.js`
- `node tests/test-a11y-phase3.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/verify-modules.js`
- `node tests/test-correctness-phase2.js`
- `npm test -- --reporter=dot`
- `npx playwright test tests/playwright/import-review-browser-coverage.spec.js tests/playwright/import-loader-browser-coverage.spec.js --workers=1 --reporter=line`
- `./run-tests.sh`