### PR TITLE
[codex] Extract chat send runtime hooks

### DIFF
--- a/js/chat-send-runtime.js
+++ b/js/chat-send-runtime.js
@@ -1,0 +1,62 @@
+// @ts-check
+// chat-send-runtime.js - Browser runtime adapters for chat send hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {any}
+ */
+function getRuntimeValue(name) {
+  const runtime = getRuntimeWindow();
+  return runtime ? runtime[name] : undefined;
+}
+
+/** @param {string} provider */
+export function getChatSendProviderAttestation(provider) {
+  return getRuntimeValue(provider === 'ppq' ? '_ppqAttestation' : '_veniceAttestation');
+}
+
+export function isChatSendProductRecsEnabled() {
+  return Boolean(getRuntimeFunction('isProductRecsEnabled')?.());
+}
+
+/** @param {string} text */
+export function detectChatSendSupplementSlots(text) {
+  if (!isChatSendProductRecsEnabled()) return [];
+  const detectSupplementSlots = getRuntimeFunction('detectSupplementSlots');
+  if (!detectSupplementSlots) return [];
+  const slots = detectSupplementSlots(text);
+  return Array.isArray(slots) ? slots : [];
+}
+
+/** @param {string} text */
+export function isChatSendEMFRelevant(text) {
+  if (!isChatSendProductRecsEnabled()) return false;
+  return Boolean(getRuntimeFunction('detectEMFRelevance')?.(text));
+}
+
+export function getChatSendRecommendationRuntime() {
+  const renderRecommendationSection = getRuntimeFunction('renderRecommendationSection');
+  const renderRecommendationSectionSync = getRuntimeFunction('renderRecommendationSectionSync');
+  const loadCatalog = getRuntimeFunction('loadCatalog');
+  if (!renderRecommendationSection || !renderRecommendationSectionSync || !loadCatalog) return null;
+  return {
+    renderRecommendationSection,
+    renderRecommendationSectionSync,
+    loadCatalog,
+  };
+}

--- a/js/chat-send.js
+++ b/js/chat-send.js
@@ -37,6 +37,12 @@ import { getChatWebSearchEnabled } from './chat-panel.js';
 import {
   getCurrentDiscussionState, sendDiscussionUserTurn, updateDiscussButton,
 } from './chat-discussion.js';
+import {
+  detectChatSendSupplementSlots,
+  getChatSendProviderAttestation,
+  getChatSendRecommendationRuntime,
+  isChatSendEMFRelevant,
+} from './chat-send-runtime.js';
 
 // ═══════════════════════════════════════════════
 // ABORT CONTROLLER (stop streaming)
@@ -219,7 +225,7 @@ export async function sendChatMessage() {
   const _msgModelId = getActiveModelId(_msgProvider);
   const _msgModelDisplay = getActiveModelDisplay(_msgProvider);
   const _msgE2EE = (_msgProvider === 'venice' && isVeniceE2EEActive()) || (_msgProvider === 'ppq' && isPpqPrivateModeActive());
-  const _msgAttestation = _msgProvider === 'ppq' ? window._ppqAttestation : window._veniceAttestation;
+  const _msgAttestation = getChatSendProviderAttestation(_msgProvider);
   const webSearchSupported = supportsWebSearch(_msgProvider);
   const webSearchEnabled = getChatWebSearchEnabled() && webSearchSupported;
   let aiMsgEl = null;
@@ -303,7 +309,7 @@ export async function sendChatMessage() {
       const cost = calculateCost(_msgProvider, _msgModelId, usage.inputTokens, usage.outputTokens);
       const totalTokens = (usage.inputTokens || 0) + (usage.outputTokens || 0);
       const webTag = webSearchEnabled ? ' \u00b7 \ud83c\udf10 web' : '';
-      const e2eeTag = _msgE2EE ? e2eeLockFootnote(_msgProvider === 'ppq' ? window._ppqAttestation : window._veniceAttestation) : '';
+      const e2eeTag = _msgE2EE ? e2eeLockFootnote(getChatSendProviderAttestation(_msgProvider)) : '';
       const footnote = document.createElement('div');
       footnote.className = 'chat-cost-footnote';
       footnote.innerHTML = `${escapeHTML(_msgModelDisplay)} \u00b7 ${escapeHTML(formatCost(cost))} \u00b7 ${totalTokens.toLocaleString()} tokens${webTag}${e2eeTag}`;
@@ -317,7 +323,7 @@ export async function sendChatMessage() {
       assistantMsg.finishReason = aiResult.finishReason || 'length';
     }
     if (webSearchEnabled) assistantMsg.webSearch = true;
-    if (_msgE2EE) { assistantMsg.e2ee = true; assistantMsg.attestation = (_msgProvider === 'ppq' ? window._ppqAttestation : window._veniceAttestation) || _msgAttestation || null; }
+    if (_msgE2EE) { assistantMsg.e2ee = true; assistantMsg.attestation = getChatSendProviderAttestation(_msgProvider) || _msgAttestation || null; }
     attachLensSources(assistantMsg, _lensResultForMsg);
     if (usage && (usage.inputTokens || usage.outputTokens)) {
       assistantMsg.usage = { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens };
@@ -326,7 +332,7 @@ export async function sendChatMessage() {
     state.chatHistory.push(assistantMsg);
 
     // Detect supplement slots from AI text — persist on message for re-rendering
-    const _recSlots = (window.isProductRecsEnabled && window.isProductRecsEnabled() && window.detectSupplementSlots) ? window.detectSupplementSlots(fullText) : [];
+    const _recSlots = detectChatSendSupplementSlots(fullText);
     if (_recSlots.length) assistantMsg.recSlots = _recSlots;
 
     // EMF hint with profile-level 30-day cooldown. Fires only when (a) EMF is
@@ -336,10 +342,9 @@ export async function sendChatMessage() {
     // to the DOM (so a stop-mid-stream doesn't burn the cooldown).
     (function maybeInjectEMFHint() {
       try {
-        if (!window.isProductRecsEnabled?.() || !window.detectEMFRelevance) return;
         const userText = state.chatHistory[state.chatHistory.length - 2]?.content || '';
         const turnText = `${userText}\n${fullText}`;
-        if (!window.detectEMFRelevance(turnText)) return;
+        if (!isChatSendEMFRelevant(turnText)) return;
         const assessments = state.importedData?.emfAssessment?.assessments || [];
         if (assessments.length) {
           const latest = assessments.reduce((a, b) => (a.date > b.date ? a : b));
@@ -376,9 +381,9 @@ export async function sendChatMessage() {
     while (actionBarContainer.firstChild) aiMsgEl.appendChild(actionBarContainer.firstChild);
 
     // Async-render supplement recommendations before action bar
-    const renderRecommendationSectionSync = window.renderRecommendationSectionSync;
-    const loadCatalog = window.loadCatalog;
-    if (_recSlots.length && window.renderRecommendationSection && renderRecommendationSectionSync && loadCatalog) {
+    const recommendationRuntime = getChatSendRecommendationRuntime();
+    if (_recSlots.length && recommendationRuntime) {
+      const { renderRecommendationSectionSync, loadCatalog } = recommendationRuntime;
       loadCatalog().then(catalog => {
         if (!catalog?.slots || !aiMsgEl.isConnected) return;
         const sections = _recSlots.map(slot => {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 417,
+  "windowReferences": 401,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -168,6 +168,7 @@ const APP_SHELL = [
   '/js/chat-empty-state.js',
   '/js/chat-render.js',
   '/js/chat-send.js',
+  '/js/chat-send-runtime.js',
   '/js/chat-icons.js',
   '/js/chat-personalities.js',
   '/js/chat-history.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -175,6 +175,7 @@ const LEGACY_TESTS = [
   './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',
+  './test-chat-send-runtime.js',
   './test-import-drop-zone-runtime.js',
   './test-wearables-runtime.js',
   './test-wearables-settings-runtime.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -310,6 +310,13 @@ console.log('=== Phase 3 A11y Tests ===\n');
       && importDropZoneRuntimeSrc.includes('isDropZoneImportRunning')
       && importDropZoneRuntimeSrc.includes('handleDropZoneDNAFile'));
 
+  const chatSendRuntimeSrc = read('/js/chat-send-runtime.js');
+  assert('chat-send browser hooks are isolated in runtime adapter',
+    chatSendSrc.includes("from './chat-send-runtime.js'")
+      && !/\bwindow(\.|\s*\[)/.test(chatSendSrc)
+      && chatSendRuntimeSrc.includes('getChatSendProviderAttestation')
+      && chatSendRuntimeSrc.includes('getChatSendRecommendationRuntime'));
+
   // ─── 12b. Light-device browse modals close on backdrop click ───
   // Browse-style modals (Add device, picker) close on backdrop; form-input
   // modals (Log device session) require explicit Cancel/Save so accidental

--- a/tests/test-chat-send-runtime.js
+++ b/tests/test-chat-send-runtime.js
@@ -1,0 +1,122 @@
+// test-chat-send-runtime.js - Chat send browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  detectChatSendSupplementSlots,
+  getChatSendProviderAttestation,
+  getChatSendRecommendationRuntime,
+  isChatSendEMFRelevant,
+  isChatSendProductRecsEnabled,
+} from '../js/chat-send-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Chat Send Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  '_ppqAttestation',
+  '_veniceAttestation',
+  'isProductRecsEnabled',
+  'detectSupplementSlots',
+  'detectEMFRelevance',
+  'renderRecommendationSection',
+  'renderRecommendationSectionSync',
+  'loadCatalog',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const ppqAttestation = { provider: 'ppq', verified: true };
+  const veniceAttestation = { provider: 'venice', verified: true };
+  setRuntimeValue('_ppqAttestation', ppqAttestation);
+  setRuntimeValue('_veniceAttestation', veniceAttestation);
+  setRuntimeValue('isProductRecsEnabled', () => {
+    calls.push(['enabled']);
+    return true;
+  });
+  setRuntimeValue('detectSupplementSlots', text => {
+    calls.push(['slots', text]);
+    return ['magnesium'];
+  });
+  setRuntimeValue('detectEMFRelevance', text => {
+    calls.push(['emf', text]);
+    return text.includes('WiFi');
+  });
+  setRuntimeValue('renderRecommendationSection', async slot => `<section>${slot}</section>`);
+  setRuntimeValue('renderRecommendationSectionSync', slot => `<section>${slot}</section>`);
+  setRuntimeValue('loadCatalog', async () => ({ slots: { magnesium: { label: 'Magnesium' } } }));
+
+  assert('getChatSendProviderAttestation reads PPQ attestation',
+    getChatSendProviderAttestation('ppq') === ppqAttestation);
+  assert('getChatSendProviderAttestation reads Venice attestation for other providers',
+    getChatSendProviderAttestation('venice') === veniceAttestation);
+  assert('isChatSendProductRecsEnabled delegates runtime flag',
+    isChatSendProductRecsEnabled() === true && calls.some(call => call[0] === 'enabled'));
+  assert('detectChatSendSupplementSlots delegates when product recs are enabled',
+    detectChatSendSupplementSlots('try magnesium').includes('magnesium'));
+  assert('isChatSendEMFRelevant delegates when product recs are enabled',
+    isChatSendEMFRelevant('WiFi in bedroom') === true && isChatSendEMFRelevant('generic fatigue') === false);
+  const recommendationRuntime = getChatSendRecommendationRuntime();
+  assert('getChatSendRecommendationRuntime returns bound renderer functions',
+    typeof recommendationRuntime?.renderRecommendationSection === 'function'
+      && typeof recommendationRuntime.renderRecommendationSectionSync === 'function'
+      && typeof recommendationRuntime.loadCatalog === 'function');
+
+  setRuntimeValue('isProductRecsEnabled', () => false);
+  assert('detectChatSendSupplementSlots returns empty when product recs are disabled',
+    detectChatSendSupplementSlots('try magnesium').length === 0);
+  assert('isChatSendEMFRelevant returns false when product recs are disabled',
+    isChatSendEMFRelevant('WiFi in bedroom') === false);
+
+  delete globalThis.renderRecommendationSectionSync;
+  assert('getChatSendRecommendationRuntime requires the sync renderer',
+    getChatSendRecommendationRuntime() === null);
+
+  delete globalThis.window;
+  assert('runtime adapter no-ops safely when window is missing',
+    getChatSendProviderAttestation('ppq') === undefined
+      && isChatSendProductRecsEnabled() === false
+      && detectChatSendSupplementSlots('try magnesium').length === 0
+      && isChatSendEMFRelevant('WiFi in bedroom') === false
+      && getChatSendRecommendationRuntime() === null);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/chat-send-runtime.js?no-window-probe');
+  assert('chat-send runtime imports without a browser window', true);
+} catch (error) {
+  assert('chat-send runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -312,6 +312,7 @@ const chatWorkflowCheckJsModules = [
   'js/chat-panel.js',
   'js/chat-prompt-context.js',
   'js/chat-render.js',
+  'js/chat-send-runtime.js',
   'js/chat-summaries.js',
   'js/chat-thread-search.js',
   'js/chat-window-bindings.js',

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -229,7 +229,9 @@ globalThis.fetch = async (url, opts) => {
   assert('marker-detail-modal.js has rec-modal placeholder', markerDetailSrc.includes('rec-modal-'));
   assert('marker-detail-modal.js calls renderRecommendationSection', markerDetailSrc.includes('renderRecommendationSection'));
   assert('marker-detail-modal.js shows recs for any marker with catalog slot', markerDetailSrc.includes('isProductRecsEnabled'));
-  assert('chat-send.js calls detectSupplementSlots', chatSendSrc.includes('detectSupplementSlots'));
+  assert('chat-send.js delegates supplement slot detection through runtime adapter',
+    chatSendSrc.includes('detectChatSendSupplementSlots') &&
+    chatSendSrc.includes("from './chat-send-runtime.js'"));
   assert('chat-send.js detects recSlots for live rendering', chatSendSrc.includes('_recSlots'));
   assert('chat-render.js has rec-chat-wrapper class', chatRenderSrc.includes('rec-chat-wrapper'));
   assert('category-view-renderers.js has chart-rec placeholder in header', categoryViewRenderersSrc.includes('chart-rec-'));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -38,6 +38,7 @@
     '/js/import-file-input.js',
     '/js/import-drop-zone.js',
     '/js/import-drop-zone-runtime.js',
+    '/js/chat-send-runtime.js',
     '/js/recommendation-actions.js',
     '/js/context-card-dashboard-ai.js',
     '/js/context-card-dashboard-ai-actions.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -63,6 +63,7 @@
     "js/chat-prompt-context.js",
     "js/chat-render.js",
     "js/chat-send.js",
+    "js/chat-send-runtime.js",
     "js/chat-summaries.js",
     "js/chat-thread-search.js",
     "js/chat-threads.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,6 +60,7 @@
     "js/chat-prompt-context.js",
     "js/chat-render.js",
     "js/chat-send.js",
+    "js/chat-send-runtime.js",
     "js/chat-summaries.js",
     "js/chat-thread-search.js",
     "js/chat-threads.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.82';
+self.APP_VERSION = '1.10.83';


### PR DESCRIPTION
## Summary
- Add js/chat-send-runtime.js to wrap chat send browser hooks for attestation, recommendations, EMF relevance, and catalog/render access.
- Update js/chat-send.js to use the runtime adapter instead of direct window property reads.
- Add focused adapter coverage, source guards, module/cache registration, checkJs registration, and bump APP_VERSION to 1.10.83.
- Lower the window-reference quality baseline from 417 to 401.

## Validation
- node tests/test-chat-send-runtime.js
- node tests/test-a11y-phase3.js
- npm run quality
- node tests/verify-modules.js
- npm run typecheck
- npm run typecheck:checkjs
- node tests/test-chat-actions.js
- node tests/test-recommendations.js
- npm test -- --reporter=dot
- npx playwright test tests/playwright/browser-coverage-batch.spec.js -g "chat send controls cover button state typewriter and abort paths"
- npx playwright test tests/playwright/recommendations-browser-coverage.spec.js
- ./run-tests.sh