### PR TITLE
[codex] Extract mobile dashboard runtime hooks

### DIFF
--- a/js/mobile-dashboard-runtime.js
+++ b/js/mobile-dashboard-runtime.js
@@ -1,0 +1,77 @@
+// @ts-check
+// mobile-dashboard-runtime.js - Browser runtime adapters for mobile dashboard shell hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/** @param {string} query */
+export function isMobileDashboardRuntimeViewport(query) {
+  const runtime = getRuntimeWindow();
+  return Boolean(runtime && typeof runtime.matchMedia === 'function' && runtime.matchMedia(query).matches);
+}
+
+export function getMobileDashboardVisualBottomOffset() {
+  const runtime = getRuntimeWindow();
+  const visualViewport = runtime?.visualViewport;
+  if (!runtime || !visualViewport) return 0;
+  const root = typeof document !== 'undefined' ? document.documentElement : null;
+  const layoutHeight = runtime.innerHeight || root?.clientHeight || visualViewport.height;
+  const visualBottom = (visualViewport.offsetTop || 0) + (visualViewport.height || 0);
+  return Math.max(0, Math.ceil(layoutHeight - visualBottom));
+}
+
+/**
+ * @param {string} type
+ * @param {EventListenerOrEventListenerObject} listener
+ * @param {AddEventListenerOptions | boolean} [options]
+ */
+export function addMobileDashboardWindowListener(type, listener, options) {
+  const runtime = getRuntimeWindow();
+  if (runtime && typeof runtime.addEventListener === 'function') {
+    runtime.addEventListener(type, listener, options);
+  }
+}
+
+/**
+ * @param {string} type
+ * @param {EventListenerOrEventListenerObject} listener
+ * @param {AddEventListenerOptions | boolean} [options]
+ */
+export function addMobileDashboardVisualViewportListener(type, listener, options) {
+  const visualViewport = getRuntimeWindow()?.visualViewport;
+  if (visualViewport && typeof visualViewport.addEventListener === 'function') {
+    visualViewport.addEventListener(type, listener, options);
+  }
+}
+
+/**
+ * @param {string} query
+ * @param {(event?: any) => void} listener
+ */
+export function addMobileDashboardBreakpointListener(query, listener) {
+  const runtime = getRuntimeWindow();
+  if (!runtime || typeof runtime.matchMedia !== 'function') return false;
+  const media = runtime.matchMedia(query);
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', listener);
+  } else if (typeof media.addListener === 'function') {
+    media.addListener(listener);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+export function scrollMobileDashboardToTop() {
+  const runtime = getRuntimeWindow();
+  if (runtime && typeof runtime.scrollTo === 'function') runtime.scrollTo(0, 0);
+}
+
+/** @param {Record<string, any>} bindings */
+export function exposeMobileDashboardBindings(bindings) {
+  const runtime = getRuntimeWindow();
+  if (runtime) Object.assign(runtime, bindings);
+}

--- a/js/mobile-dashboard-runtime.js
+++ b/js/mobile-dashboard-runtime.js
@@ -7,6 +7,14 @@ function getRuntimeWindow() {
     : null;
 }
 
+function finitePositiveNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 /** @param {string} query */
 export function isMobileDashboardRuntimeViewport(query) {
   const runtime = getRuntimeWindow();
@@ -18,8 +26,11 @@ export function getMobileDashboardVisualBottomOffset() {
   const visualViewport = runtime?.visualViewport;
   if (!runtime || !visualViewport) return 0;
   const root = typeof document !== 'undefined' ? document.documentElement : null;
-  const layoutHeight = runtime.innerHeight || root?.clientHeight || visualViewport.height;
-  const visualBottom = (visualViewport.offsetTop || 0) + (visualViewport.height || 0);
+  const layoutHeight = finitePositiveNumber(runtime.innerHeight) || finitePositiveNumber(root?.clientHeight);
+  const offsetTop = finiteNumber(visualViewport.offsetTop);
+  const visualHeight = finitePositiveNumber(visualViewport.height);
+  if (layoutHeight == null || offsetTop == null || visualHeight == null) return 0;
+  const visualBottom = offsetTop + visualHeight;
   return Math.max(0, Math.ceil(layoutHeight - visualBottom));
 }
 

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -8,6 +8,15 @@ import { getAllFlaggedMarkers, getEffectiveRangeForDate, getLatestValueIndex } f
 import { getProfiles } from './profile.js';
 import { canonicalMetric, metricsForSources } from './wearable-adapters.js';
 import { loadContextHealthDots } from './context-cards.js';
+import {
+  addMobileDashboardBreakpointListener,
+  addMobileDashboardVisualViewportListener,
+  addMobileDashboardWindowListener,
+  exposeMobileDashboardBindings,
+  getMobileDashboardVisualBottomOffset,
+  isMobileDashboardRuntimeViewport,
+  scrollMobileDashboardToTop,
+} from './mobile-dashboard-runtime.js';
 
 const MOBILE_DASHBOARD_QUERY = '(max-width: 799px)';
 const MOBILE_WEARABLE_PRIORITY = [
@@ -123,16 +132,7 @@ export function installMobileDashboardActionDelegates(root = typeof document !==
 installMobileDashboardActionDelegates();
 
 export function isMobileDashboardViewport() {
-  return typeof window !== 'undefined'
-    && typeof window.matchMedia === 'function'
-    && window.matchMedia(MOBILE_DASHBOARD_QUERY).matches;
-}
-
-function getMobileVisualBottomOffset() {
-  if (typeof window === 'undefined' || !window.visualViewport) return 0;
-  const layoutHeight = window.innerHeight || document.documentElement?.clientHeight || window.visualViewport.height;
-  const visualBottom = window.visualViewport.offsetTop + window.visualViewport.height;
-  return Math.max(0, Math.ceil(layoutHeight - visualBottom));
+  return isMobileDashboardRuntimeViewport(MOBILE_DASHBOARD_QUERY);
 }
 
 function syncMobileChromeRootState() {
@@ -143,7 +143,7 @@ function syncMobileChromeRootState() {
   root.classList.toggle('mobile-dashboard-active', dashboardActive);
   root.classList.toggle('mobile-tabs-active', tabsActive);
   if (dashboardActive || tabsActive) {
-    root.style.setProperty('--mobile-visual-bottom-offset', `${getMobileVisualBottomOffset()}px`);
+    root.style.setProperty('--mobile-visual-bottom-offset', `${getMobileDashboardVisualBottomOffset()}px`);
   } else {
     root.style.removeProperty('--mobile-visual-bottom-offset');
   }
@@ -161,9 +161,9 @@ function initMobileChromeStateSync() {
   };
   if (document.body) start();
   else document.addEventListener('DOMContentLoaded', start, { once: true });
-  window.addEventListener('resize', syncMobileChromeRootState, { passive: true });
-  window.visualViewport?.addEventListener('resize', syncMobileChromeRootState, { passive: true });
-  window.visualViewport?.addEventListener('scroll', syncMobileChromeRootState, { passive: true });
+  addMobileDashboardWindowListener('resize', syncMobileChromeRootState, { passive: true });
+  addMobileDashboardVisualViewportListener('resize', syncMobileChromeRootState, { passive: true });
+  addMobileDashboardVisualViewportListener('scroll', syncMobileChromeRootState, { passive: true });
 }
 
 function getMobileBottomTabForRoute(route) {
@@ -200,18 +200,12 @@ export function refreshMobileDashboardActiveTab() {
   mobileDashboardSetTab('dashboard', { fromScroll: true });
 }
 
-if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+const refreshDashboardForBreakpoint = () => {
+  if (state.currentView === 'dashboard') mobileDashboardDeps.navigate('dashboard');
+  else syncMobileBottomNav(state.currentView || 'dashboard');
+};
+if (addMobileDashboardBreakpointListener(MOBILE_DASHBOARD_QUERY, refreshDashboardForBreakpoint)) {
   initMobileChromeStateSync();
-  const mobileDashboardMedia = window.matchMedia(MOBILE_DASHBOARD_QUERY);
-  const refreshDashboardForBreakpoint = () => {
-    if (state.currentView === 'dashboard') mobileDashboardDeps.navigate('dashboard');
-    else syncMobileBottomNav(state.currentView || 'dashboard');
-  };
-  if (typeof mobileDashboardMedia.addEventListener === 'function') {
-    mobileDashboardMedia.addEventListener('change', refreshDashboardForBreakpoint);
-  } else if (typeof mobileDashboardMedia.addListener === 'function') {
-    mobileDashboardMedia.addListener(refreshDashboardForBreakpoint);
-  }
 }
 
 export function getMobileDashboardProfile() {
@@ -523,9 +517,7 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
     <button type="button" class="m-chat-fab" ${mobileDashboardActionAttrs('open-chat')} aria-label="Ask AI">${renderMobileIcon('chat')}</button>
     ${renderMobileBottomTabs('dashboard')}`;
 
-  if (resetScroll && typeof window.scrollTo === 'function') {
-    window.scrollTo(0, 0);
-  }
+  if (resetScroll) scrollMobileDashboardToTop();
   mobileDashboardDeps.setupDropZone();
   refreshMobileDashboardActiveTab();
   loadContextHealthDots();
@@ -534,7 +526,7 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
   mobileDashboardDeps.loadCatalog().then(c => { mobileDashboardDeps.cacheCatalog(c); });
 }
 
-Object.assign(window, {
+exposeMobileDashboardBindings({
   openMobileDashboardSearch,
   mobileDashboardJump,
   mobileDashboardSetTab,

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -142,10 +142,13 @@ function syncMobileChromeRootState() {
   const tabsActive = document.body.classList.contains('mobile-tabs-active');
   root.classList.toggle('mobile-dashboard-active', dashboardActive);
   root.classList.toggle('mobile-tabs-active', tabsActive);
+  const rootStyle = root.style;
   if (dashboardActive || tabsActive) {
-    root.style.setProperty('--mobile-visual-bottom-offset', `${getMobileDashboardVisualBottomOffset()}px`);
-  } else {
-    root.style.removeProperty('--mobile-visual-bottom-offset');
+    if (typeof rootStyle?.setProperty === 'function') {
+      rootStyle.setProperty('--mobile-visual-bottom-offset', `${getMobileDashboardVisualBottomOffset()}px`);
+    }
+  } else if (typeof rootStyle?.removeProperty === 'function') {
+    rootStyle.removeProperty('--mobile-visual-bottom-offset');
   }
 }
 
@@ -204,9 +207,16 @@ const refreshDashboardForBreakpoint = () => {
   if (state.currentView === 'dashboard') mobileDashboardDeps.navigate('dashboard');
   else syncMobileBottomNav(state.currentView || 'dashboard');
 };
-if (addMobileDashboardBreakpointListener(MOBILE_DASHBOARD_QUERY, refreshDashboardForBreakpoint)) {
-  initMobileChromeStateSync();
-}
+addMobileDashboardBreakpointListener(MOBILE_DASHBOARD_QUERY, refreshDashboardForBreakpoint);
+initMobileChromeStateSync();
+
+// Keep legacy mobile dashboard globals available as soon as the module loads.
+exposeMobileDashboardBindings({
+  openMobileDashboardSearch,
+  mobileDashboardJump,
+  mobileDashboardSetTab,
+  refreshMobileDashboardActiveTab,
+});
 
 export function getMobileDashboardProfile() {
   const profiles = getProfiles() || [];
@@ -525,10 +535,3 @@ export function renderMobileDashboard(data, { resetScroll = false } = {}) {
   mobileDashboardDeps.loadCommitHash();
   mobileDashboardDeps.loadCatalog().then(c => { mobileDashboardDeps.cacheCatalog(c); });
 }
-
-exposeMobileDashboardBindings({
-  openMobileDashboardSearch,
-  mobileDashboardJump,
-  mobileDashboardSetTab,
-  refreshMobileDashboardActiveTab,
-});

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 401,
+  "windowReferences": 387,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -191,6 +191,7 @@ const APP_SHELL = [
   '/js/views-router.js',
   '/js/dashboard-view-composition.js',
   '/js/dashboard-page-view.js',
+  '/js/mobile-dashboard-runtime.js',
   '/js/lens-pages.js',
   '/js/lens-page-shell.js',
   '/js/lens-library.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -177,6 +177,7 @@ const LEGACY_TESTS = [
   './test-views-router-runtime.js',
   './test-chat-send-runtime.js',
   './test-import-drop-zone-runtime.js',
+  './test-mobile-dashboard-runtime.js',
   './test-wearables-runtime.js',
   './test-wearables-settings-runtime.js',
   './test-dashboard-widget-runtime.js',

--- a/tests/test-mobile-dashboard-runtime.js
+++ b/tests/test-mobile-dashboard-runtime.js
@@ -84,6 +84,23 @@ try {
     viewportListeners.some(([type, listener, passive]) => type === 'scroll' && listener === resizeListener && passive === true));
   assert('getMobileDashboardVisualBottomOffset computes keyboard inset',
     getMobileDashboardVisualBottomOffset() === 88);
+  setRuntimeValue('visualViewport', {
+    offsetTop: 24,
+    addEventListener: (type, listener, options) => viewportListeners.push([type, listener, options?.passive === true]),
+  });
+  assert('getMobileDashboardVisualBottomOffset ignores transient missing viewport height',
+    getMobileDashboardVisualBottomOffset() === 0);
+  setRuntimeValue('visualViewport', {
+    height: 700,
+    addEventListener: (type, listener, options) => viewportListeners.push([type, listener, options?.passive === true]),
+  });
+  assert('getMobileDashboardVisualBottomOffset ignores transient missing viewport offset',
+    getMobileDashboardVisualBottomOffset() === 0);
+  setRuntimeValue('visualViewport', {
+    offsetTop: 24,
+    height: 700,
+    addEventListener: (type, listener, options) => viewportListeners.push([type, listener, options?.passive === true]),
+  });
   scrollMobileDashboardToTop();
   assert('scrollMobileDashboardToTop delegates to scrollTo',
     calls.some(call => call[0] === 'scroll' && call[1] === 0 && call[2] === 0));
@@ -100,6 +117,12 @@ try {
   assert('addMobileDashboardBreakpointListener supports legacy addListener',
     addMobileDashboardBreakpointListener('(max-width: 799px)', breakpointListener) === true &&
     mediaListeners.some(([type, listener]) => type === 'legacy' && listener === breakpointListener));
+  setRuntimeValue('matchMedia', query => ({
+    media: query,
+    matches: true,
+  }));
+  assert('addMobileDashboardBreakpointListener reports unsupported listener registration',
+    addMobileDashboardBreakpointListener('(max-width: 799px)', breakpointListener) === false);
 
   delete globalThis.window;
   assert('runtime adapter no-ops safely when window is missing',

--- a/tests/test-mobile-dashboard-runtime.js
+++ b/tests/test-mobile-dashboard-runtime.js
@@ -1,0 +1,133 @@
+// test-mobile-dashboard-runtime.js - Mobile dashboard browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  addMobileDashboardBreakpointListener,
+  addMobileDashboardVisualViewportListener,
+  addMobileDashboardWindowListener,
+  exposeMobileDashboardBindings,
+  getMobileDashboardVisualBottomOffset,
+  isMobileDashboardRuntimeViewport,
+  scrollMobileDashboardToTop,
+} from '../js/mobile-dashboard-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Mobile Dashboard Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'document',
+  'matchMedia',
+  'addEventListener',
+  'visualViewport',
+  'innerHeight',
+  'scrollTo',
+  'mobileDashboardProbe',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const mediaListeners = [];
+  const viewportListeners = [];
+  setRuntimeValue('matchMedia', query => ({
+    media: query,
+    matches: query === '(max-width: 799px)',
+    addEventListener: (type, listener) => mediaListeners.push([type, listener]),
+  }));
+  setRuntimeValue('addEventListener', (type, listener, options) => calls.push(['window-listener', type, options?.passive === true, listener]));
+  setRuntimeValue('visualViewport', {
+    offsetTop: 24,
+    height: 700,
+    addEventListener: (type, listener, options) => viewportListeners.push([type, listener, options?.passive === true]),
+  });
+  setRuntimeValue('innerHeight', 812);
+  setRuntimeValue('document', { documentElement: { clientHeight: 790 } });
+  setRuntimeValue('scrollTo', (x, y) => calls.push(['scroll', x, y]));
+
+  const breakpointListener = () => calls.push(['breakpoint']);
+  const resizeListener = () => calls.push(['resize']);
+
+  assert('isMobileDashboardRuntimeViewport delegates matchMedia matches',
+    isMobileDashboardRuntimeViewport('(max-width: 799px)') === true &&
+    isMobileDashboardRuntimeViewport('(min-width: 800px)') === false);
+  assert('addMobileDashboardBreakpointListener registers media change handler',
+    addMobileDashboardBreakpointListener('(max-width: 799px)', breakpointListener) === true &&
+    mediaListeners.some(([type, listener]) => type === 'change' && listener === breakpointListener));
+  addMobileDashboardWindowListener('resize', resizeListener, { passive: true });
+  assert('addMobileDashboardWindowListener registers browser listener',
+    calls.some(call => call[0] === 'window-listener' && call[1] === 'resize' && call[2] === true && call[3] === resizeListener));
+  addMobileDashboardVisualViewportListener('scroll', resizeListener, { passive: true });
+  assert('addMobileDashboardVisualViewportListener registers viewport listener',
+    viewportListeners.some(([type, listener, passive]) => type === 'scroll' && listener === resizeListener && passive === true));
+  assert('getMobileDashboardVisualBottomOffset computes keyboard inset',
+    getMobileDashboardVisualBottomOffset() === 88);
+  scrollMobileDashboardToTop();
+  assert('scrollMobileDashboardToTop delegates to scrollTo',
+    calls.some(call => call[0] === 'scroll' && call[1] === 0 && call[2] === 0));
+  const probe = () => 'ok';
+  exposeMobileDashboardBindings({ mobileDashboardProbe: probe });
+  assert('exposeMobileDashboardBindings assigns runtime exports',
+    globalThis.mobileDashboardProbe === probe);
+
+  setRuntimeValue('matchMedia', query => ({
+    media: query,
+    matches: true,
+    addListener: listener => mediaListeners.push(['legacy', listener]),
+  }));
+  assert('addMobileDashboardBreakpointListener supports legacy addListener',
+    addMobileDashboardBreakpointListener('(max-width: 799px)', breakpointListener) === true &&
+    mediaListeners.some(([type, listener]) => type === 'legacy' && listener === breakpointListener));
+
+  delete globalThis.window;
+  assert('runtime adapter no-ops safely when window is missing',
+    isMobileDashboardRuntimeViewport('(max-width: 799px)') === false &&
+    getMobileDashboardVisualBottomOffset() === 0 &&
+    addMobileDashboardBreakpointListener('(max-width: 799px)', breakpointListener) === false);
+  const beforeNoWindowCalls = calls.length;
+  addMobileDashboardWindowListener('resize', resizeListener);
+  addMobileDashboardVisualViewportListener('resize', resizeListener);
+  scrollMobileDashboardToTop();
+  exposeMobileDashboardBindings({ mobileDashboardProbe: null });
+  assert('optional browser actions no-op without window',
+    calls.length === beforeNoWindowCalls && globalThis.mobileDashboardProbe === probe);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/mobile-dashboard-runtime.js?no-window-probe');
+  assert('mobile-dashboard runtime imports without a browser window', true);
+} catch (error) {
+  assert('mobile-dashboard runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -82,6 +82,18 @@ return (async function() {
     !/\bwindow(\.|\s*\[)/.test(mobileDashboardSrc) &&
     mobileDashboardRuntimeSrc.includes('isMobileDashboardRuntimeViewport') &&
     mobileDashboardRuntimeSrc.includes('exposeMobileDashboardBindings'));
+  const breakpointListenerIndex = mobileDashboardSrc.indexOf('addMobileDashboardBreakpointListener(MOBILE_DASHBOARD_QUERY, refreshDashboardForBreakpoint);');
+  const chromeSyncIndex = mobileDashboardSrc.indexOf('initMobileChromeStateSync();');
+  const exposeBindingsIndex = mobileDashboardSrc.indexOf('exposeMobileDashboardBindings({');
+  const renderMobileDashboardIndex = mobileDashboardSrc.indexOf('export function renderMobileDashboard');
+  assert('mobile dashboard chrome sync starts even without breakpoint listener support',
+    breakpointListenerIndex >= 0 &&
+    chromeSyncIndex > breakpointListenerIndex &&
+    !mobileDashboardSrc.includes('if (addMobileDashboardBreakpointListener'));
+  assert('mobile dashboard legacy globals publish before first dashboard render',
+    exposeBindingsIndex >= 0 &&
+    renderMobileDashboardIndex > exposeBindingsIndex &&
+    mobileDashboardSrc.includes('refreshMobileDashboardActiveTab,'));
   assert('mobile dashboard no longer has static duplicate dashboard sections',
     !mobileDashboardSrc.includes('id="mobile-light-section"') &&
     !mobileDashboardSrc.includes('id="mobile-body-section"') &&

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -76,6 +76,12 @@ return (async function() {
     !mobileDashboardSrc.includes('window.loadContextCardTips') &&
     !mobileDashboardSrc.includes('window.loadCatalog') &&
     !mobileDashboardSrc.includes('window._cachedCatalog'));
+  const mobileDashboardRuntimeSrc = await fetchWithRetry('js/mobile-dashboard-runtime.js');
+  assert('mobile dashboard browser chrome hooks are isolated in runtime adapter',
+    mobileDashboardSrc.includes("from './mobile-dashboard-runtime.js'") &&
+    !/\bwindow(\.|\s*\[)/.test(mobileDashboardSrc) &&
+    mobileDashboardRuntimeSrc.includes('isMobileDashboardRuntimeViewport') &&
+    mobileDashboardRuntimeSrc.includes('exposeMobileDashboardBindings'));
   assert('mobile dashboard no longer has static duplicate dashboard sections',
     !mobileDashboardSrc.includes('id="mobile-light-section"') &&
     !mobileDashboardSrc.includes('id="mobile-body-section"') &&

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -139,6 +139,7 @@ const broadSurfaceCheckJsModules = [
   'js/light-devices.js',
   'js/light-tools.js',
   'js/mobile-dashboard.js',
+  'js/mobile-dashboard-runtime.js',
   'js/pii.js',
   'js/profile-share.js',
   'js/views.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -53,6 +53,7 @@
     '/js/wearables-settings-runtime.js',
     '/js/dashboard-view-composition.js',
     '/js/dashboard-page-view.js',
+    '/js/mobile-dashboard-runtime.js',
     '/js/lens-page-shell.js',
     '/js/chart-card-recs.js',
     '/js/category-glyphs.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -159,6 +159,7 @@
     "js/main.js",
     "js/marker-detail-modal.js",
     "js/mobile-dashboard.js",
+    "js/mobile-dashboard-runtime.js",
     "js/modal-lifecycle.js",
     "js/nav.js",
     "js/onboarding-view.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -155,6 +155,7 @@
     "js/marker-detail-modal.js",
     "js/marker-detail-store.js",
     "js/mobile-dashboard.js",
+    "js/mobile-dashboard-runtime.js",
     "js/modal-lifecycle.js",
     "js/nav.js",
     "js/notes.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.83';
+self.APP_VERSION = '1.10.84';


### PR DESCRIPTION
Summary
- Add js/mobile-dashboard-runtime.js for media query, visual viewport, resize, scroll, and global binding hooks.
- Update js/mobile-dashboard.js to use the runtime adapter and remove direct browser-global reads.
- Register the new module for cache/module/type checks, add focused runtime coverage and a source guard, bump APP_VERSION to 1.10.84, and lower the window-reference baseline from 401 to 387.

Validation
- node tests/test-mobile-dashboard-runtime.js
- npm run quality
- node tests/verify-modules.js
- npm run typecheck
- npm run typecheck:checkjs
- npm test -- --reporter=dot
- npx playwright test tests/playwright/mobile-dashboard-browser-coverage.spec.js
- ./run-tests.sh