### PR TITLE
[codex] Extract sun defaults runtime hooks

### DIFF
--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -1,0 +1,71 @@
+// @ts-check
+// sun-defaults-runtime.js - Browser runtime adapters for Light setup defaults.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/** @param {string} name */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return typeof runtime?.[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function hasSunDefaultsBrowserRuntime() {
+  return getRuntimeWindow() !== null;
+}
+
+export function getSunSetupCoords() {
+  try {
+    return getRuntimeFunction('getSunCoords')?.() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function getSunSetupProfileLocation() {
+  try {
+    return getRuntimeFunction('getProfileLocation')?.() || {};
+  } catch {
+    return {};
+  }
+}
+
+export function openSunSetupProfileLocationRuntime() {
+  const openProfileLocationEditor = getRuntimeFunction('openProfileLocationEditor');
+  if (openProfileLocationEditor) {
+    openProfileLocationEditor();
+    return true;
+  }
+  const openClientList = getRuntimeFunction('openClientList');
+  if (openClientList) {
+    openClientList();
+    return true;
+  }
+  return false;
+}
+
+export function hasSunSetupPreciseLocationRequester() {
+  return getRuntimeFunction('requestPreciseLocation') !== null;
+}
+
+export function requestSunSetupPreciseLocationRuntime() {
+  try {
+    return getRuntimeFunction('requestPreciseLocation')?.() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** @param {string} route */
+export function navigateSunDefaultsRoute(route) {
+  getRuntimeFunction('navigate')?.(route);
+}
+
+/** @param {Record<string, any>} bindings */
+export function exposeSunDefaultsBindings(bindings) {
+  const runtime = getRuntimeWindow();
+  if (runtime) Object.assign(runtime, bindings);
+}

--- a/js/sun-defaults.js
+++ b/js/sun-defaults.js
@@ -13,6 +13,16 @@ import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { saveImportedData } from './data.js';
 import { SKIN_TYPE } from './constants.js';
+import {
+  exposeSunDefaultsBindings,
+  getSunSetupCoords,
+  getSunSetupProfileLocation,
+  hasSunDefaultsBrowserRuntime,
+  hasSunSetupPreciseLocationRequester,
+  navigateSunDefaultsRoute,
+  openSunSetupProfileLocationRuntime,
+  requestSunSetupPreciseLocationRuntime,
+} from './sun-defaults-runtime.js';
 
 // Map between Fitzpatrick Roman numeral and the SKIN_TYPE label used by the
 // Light & Circadian context card so both surfaces stay in sync.
@@ -703,12 +713,8 @@ function formatSetupLatitude(lat) {
 }
 
 function getSetupLocationStatus() {
-  const c = (typeof window !== 'undefined' && window.getSunCoords)
-    ? window.getSunCoords()
-    : null;
-  const loc = (typeof window !== 'undefined' && window.getProfileLocation)
-    ? window.getProfileLocation()
-    : {};
+  const c = getSunSetupCoords();
+  const loc = getSunSetupProfileLocation();
   const country = (loc?.country || '').trim();
   const lat = c ? formatSetupLatitude(c.lat) : '';
 
@@ -765,21 +771,15 @@ function refreshSetupLocationStatus() {
 
 function openLightSetupProfileLocation() {
   cancelReopenSunSetup();
-  setTimeout(() => {
-    if (window.openProfileLocationEditor) {
-      window.openProfileLocationEditor();
-    } else if (window.openClientList) {
-      window.openClientList();
-    }
-  }, 0);
+  setTimeout(openSunSetupProfileLocationRuntime, 0);
 }
 
 async function requestLightSetupPreciseLocation() {
-  if (!window.requestPreciseLocation) {
+  if (!hasSunSetupPreciseLocationRequester()) {
     showNotification('Precise location is unavailable here.');
     return null;
   }
-  const coords = await window.requestPreciseLocation();
+  const coords = await requestSunSetupPreciseLocationRuntime();
   refreshSetupLocationStatus();
   return coords;
 }
@@ -839,7 +839,7 @@ async function saveSunSetup() {
   closeSunSetupOverlay();
   showNotification(`Setup saved · light burden ${ottScore}/10`);
   maybeAnalyzeOnboardingAfterSave();
-  if (window.navigate) window.navigate('light');
+  navigateSunDefaultsRoute('light');
 }
 
 // Recompute the running Ott score whenever a checkbox toggles, and update
@@ -960,12 +960,12 @@ function _refreshSetupProgress() {
 async function dismissSunSetup() {
   await saveSunDefaults({ fitzpatrick: 'III', skipped: true, completedAt: Date.now() });
   closeSunSetupOverlay();
-  if (window.navigate) window.navigate('light');
+  navigateSunDefaultsRoute('light');
 }
 
-if (typeof window !== 'undefined') {
+if (hasSunDefaultsBrowserRuntime()) {
   installLightSetupDelegates();
-  Object.assign(window, {
+  exposeSunDefaultsBindings({
     getSunDefaults,
     saveSunDefaults,
     isLightOnboardingComplete: isOnboardingComplete,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 387,
+  "windowReferences": 373,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -388,6 +388,7 @@ const APP_SHELL = [
   '/js/sun-context-hooks.js',
   '/js/sun-correlations.js',
   '/js/sun-defaults.js',
+  '/js/sun-defaults-runtime.js',
   '/js/sun-onboarding-ai.js',
   '/js/sun-spectrum.js',
   '/js/sun-uvdata.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -98,6 +98,7 @@ const LEGACY_TESTS = [
   // Batch 10 — sun + light pure-logic ports.
   './test-sun-correlations.js',
   './test-sun-defaults.js',
+  './test-sun-defaults-runtime.js',
   './test-sun.js',
   './test-light-env.js',
   './test-light-env-store.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -115,6 +115,7 @@ const domainUiCheckJsModules = [
   'js/provider-panels.js',
   'js/sun-context.js',
   'js/sun-defaults.js',
+  'js/sun-defaults-runtime.js',
   'js/sun-spectrum.js',
   'js/sun-uvdata.js',
 ];

--- a/tests/test-sun-defaults-runtime.js
+++ b/tests/test-sun-defaults-runtime.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// test-sun-defaults-runtime.js - Light setup browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  exposeSunDefaultsBindings,
+  getSunSetupCoords,
+  getSunSetupProfileLocation,
+  hasSunDefaultsBrowserRuntime,
+  hasSunSetupPreciseLocationRequester,
+  navigateSunDefaultsRoute,
+  openSunSetupProfileLocationRuntime,
+  requestSunSetupPreciseLocationRuntime,
+} from '../js/sun-defaults-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Sun Defaults Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'getSunCoords',
+  'getProfileLocation',
+  'openProfileLocationEditor',
+  'openClientList',
+  'requestPreciseLocation',
+  'navigate',
+  'sunDefaultsProbe',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('getSunCoords', () => ({ lat: 50.08, lon: 14.42, source: 'profile-precise' }));
+  setRuntimeValue('getProfileLocation', () => ({ country: 'Czech Republic' }));
+  setRuntimeValue('openProfileLocationEditor', () => calls.push(['profile-location']));
+  setRuntimeValue('openClientList', () => calls.push(['client-list']));
+  setRuntimeValue('requestPreciseLocation', () => {
+    calls.push(['precise']);
+    return Promise.resolve({ lat: 50.1, lon: 14.4 });
+  });
+  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
+
+  assert('hasSunDefaultsBrowserRuntime detects browser runtime',
+    hasSunDefaultsBrowserRuntime() === true);
+  assert('getSunSetupCoords delegates to runtime coords provider',
+    getSunSetupCoords()?.source === 'profile-precise');
+  assert('getSunSetupProfileLocation delegates to profile location provider',
+    getSunSetupProfileLocation().country === 'Czech Republic');
+  assert('openSunSetupProfileLocationRuntime prefers profile editor',
+    openSunSetupProfileLocationRuntime() === true &&
+    calls.some(call => call[0] === 'profile-location'));
+
+  delete globalThis.openProfileLocationEditor;
+  assert('openSunSetupProfileLocationRuntime falls back to client list',
+    openSunSetupProfileLocationRuntime() === true &&
+    calls.some(call => call[0] === 'client-list'));
+
+  assert('hasSunSetupPreciseLocationRequester detects location requester',
+    hasSunSetupPreciseLocationRequester() === true);
+  const coords = await requestSunSetupPreciseLocationRuntime();
+  assert('requestSunSetupPreciseLocationRuntime delegates to precise requester',
+    coords?.lat === 50.1 && calls.some(call => call[0] === 'precise'));
+
+  navigateSunDefaultsRoute('light');
+  assert('navigateSunDefaultsRoute delegates route navigation',
+    calls.some(call => call[0] === 'navigate' && call[1] === 'light'));
+
+  const probe = () => 'ok';
+  exposeSunDefaultsBindings({ sunDefaultsProbe: probe });
+  assert('exposeSunDefaultsBindings publishes runtime bindings',
+    globalThis.sunDefaultsProbe === probe);
+
+  delete globalThis.getSunCoords;
+  delete globalThis.getProfileLocation;
+  delete globalThis.openClientList;
+  delete globalThis.requestPreciseLocation;
+  delete globalThis.navigate;
+  assert('missing runtime functions return safe fallbacks',
+    getSunSetupCoords() === null &&
+    Object.keys(getSunSetupProfileLocation()).length === 0 &&
+    openSunSetupProfileLocationRuntime() === false &&
+    hasSunSetupPreciseLocationRequester() === false &&
+    requestSunSetupPreciseLocationRuntime() === null);
+
+  delete globalThis.window;
+  const beforeNoWindowCalls = calls.length;
+  navigateSunDefaultsRoute('light');
+  exposeSunDefaultsBindings({ sunDefaultsProbe: null });
+  assert('runtime adapter no-ops safely when window is missing',
+    hasSunDefaultsBrowserRuntime() === false &&
+    getSunSetupCoords() === null &&
+    Object.keys(getSunSetupProfileLocation()).length === 0 &&
+    openSunSetupProfileLocationRuntime() === false &&
+    hasSunSetupPreciseLocationRequester() === false &&
+    requestSunSetupPreciseLocationRuntime() === null &&
+    calls.length === beforeNoWindowCalls &&
+    globalThis.sunDefaultsProbe === probe);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/sun-defaults-runtime.js?no-window-probe');
+  assert('sun-defaults runtime imports without a browser window', true);
+} catch (error) {
+  assert('sun-defaults runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sun-defaults.js
+++ b/tests/test-sun-defaults.js
@@ -22,6 +22,7 @@ console.log('=== Sun Defaults Tests ===\n');
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const sunDefaultsSrc = fs.readFileSync(path.join(root, 'js/sun-defaults.js'), 'utf8');
+const sunDefaultsRuntimeSrc = fs.readFileSync(path.join(root, 'js/sun-defaults-runtime.js'), 'utf8');
 const appLightSunSrc = fs.readFileSync(path.join(root, 'js/app-light-sun-modules.js'), 'utf8');
 const aiSaveHooksSrc = fs.readFileSync(path.join(root, 'js/light-ai-save-hooks.js'), 'utf8');
 const onboardingAiSrc = fs.readFileSync(path.join(root, 'js/sun-onboarding-ai.js'), 'utf8');
@@ -84,6 +85,12 @@ const {
     sunDefaultsSrc.includes('installLightSetupDelegates();') &&
     sunDefaultsSrc.includes("data-light-setup-action=") &&
     sunDefaultsSrc.includes("data-light-setup-input="));
+  assert('sun-defaults browser hooks are isolated in runtime adapter',
+    sunDefaultsSrc.includes("from './sun-defaults-runtime.js'") &&
+    !/\bwindow(\.|\s*\[)/.test(sunDefaultsSrc) &&
+    sunDefaultsRuntimeSrc.includes('getSunSetupCoords') &&
+    sunDefaultsRuntimeSrc.includes('exposeSunDefaultsBindings') &&
+    swSrc.includes("'/js/sun-defaults-runtime.js'"));
   assert('sun-defaults AI hooks route through startup wiring',
     typeof configureSunDefaults === 'function' &&
     sunDefaultsSrc.includes('maybeAnalyzeOnboardingAfterSave: () => {}') &&

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -76,6 +76,7 @@
     '/js/light-channel-view.js',
     '/js/light-channel-view-hooks.js',
     '/js/light-channel-view-ui-hooks.js',
+    '/js/sun-defaults-runtime.js',
     '/js/sun-channel-metrics.js',
     '/js/sun-context-hooks.js',
     '/js/light-sessions-view.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -198,6 +198,7 @@
     "js/sun-context-hooks.js",
     "js/sun-correlations.js",
     "js/sun-defaults.js",
+    "js/sun-defaults-runtime.js",
     "js/sun-onboarding-ai.js",
     "js/sun-session-actions.js",
     "js/sun-session-ai-render-hooks.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -210,6 +210,7 @@
     "js/sun-context.js",
     "js/sun-correlations.js",
     "js/sun-defaults.js",
+    "js/sun-defaults-runtime.js",
     "js/sun-onboarding-ai.js",
     "js/sun-session-actions.js",
     "js/sun-session-model.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.84';
+self.APP_VERSION = '1.10.85';


### PR DESCRIPTION
Summary
- Add js/sun-defaults-runtime.js for Light setup coords, profile location, precise location, navigation, and legacy binding hooks.
- Update js/sun-defaults.js to use the runtime adapter and remove direct browser-global reads.
- Add runtime/source coverage, register the module for cache/module/type checks, bump APP_VERSION to 1.10.85, and lower the window-reference baseline from 387 to 373.

Validation
- node tests/test-sun-defaults-runtime.js
- node tests/test-sun-defaults.js
- npm run quality
- node tests/verify-modules.js
- npm run typecheck
- npm run typecheck:checkjs
- npm test -- --reporter=dot
- ./run-tests.sh