### PR TITLE
[codex] Extract marker detail runtime hooks

### DIFF
--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -14,6 +14,22 @@ import { getInsulinMirrorMarkerKey } from './lab-entry.js';
 import { installMarkerDetailActionDelegates, markerDetailActionAttrs } from './marker-detail-actions.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
+  askAIAboutMarkerRuntime,
+  buildMarkerDetailSidebarRuntime,
+  closeEMFInterpretationRuntime,
+  getRelevantSNPsRuntime,
+  hasRecommendationSectionRendererRuntime,
+  isDashboardQuickMarkerPinnedRuntime,
+  isProductRecsEnabledRuntime,
+  navigateMarkerDetailRuntime,
+  renameMarkerRuntime,
+  renderRecommendationSectionRuntime,
+  revertMarkerNameRuntime,
+  showEmojiPickerRuntime,
+  toggleDashboardQuickMarkerPinRuntime,
+  uninstallWearableModalFocusTrapRuntime,
+} from './marker-detail-runtime.js';
+import {
   configureMarkerDetailEditing,
   editRefRange,
   saveRefRange,
@@ -55,13 +71,13 @@ const markerDetailDeps = /** @type {{
   askAIAboutMarker: (id?: string) => any,
   showEmojiPicker: (el: Element, callback: (emoji?: string | null) => void, opts?: any) => any,
 }} */ ({
-  navigate: (category, data) => window.navigate?.(category, data),
-  isDashboardQuickMarkerPinned: () => false,
-  toggleDashboardQuickMarkerPin: (id) => globalThis.toggleDashboardQuickMarkerPin?.(id),
-  renameMarker: (id) => globalThis.renameMarker?.(id),
-  revertMarkerName: (id) => globalThis.revertMarkerName?.(id),
-  askAIAboutMarker: (id) => globalThis.askAIAboutMarker?.(id),
-  showEmojiPicker: () => {},
+  navigate: navigateMarkerDetailRuntime,
+  isDashboardQuickMarkerPinned: isDashboardQuickMarkerPinnedRuntime,
+  toggleDashboardQuickMarkerPin: toggleDashboardQuickMarkerPinRuntime,
+  renameMarker: renameMarkerRuntime,
+  revertMarkerName: revertMarkerNameRuntime,
+  askAIAboutMarker: askAIAboutMarkerRuntime,
+  showEmojiPicker: showEmojiPickerRuntime,
 });
 
 /**
@@ -700,7 +716,8 @@ export function showDetailModal(id, opts = {}) {
     }
   }
   // Collect inline SNPs for the unified rec section (genetics + actionable tips together)
-  const _inlineSNPs = (state.importedData.genetics?.snps && window._getRelevantSNPs) ? window._getRelevantSNPs(dotKey) : [];
+  const _inlineSNPs = state.importedData.genetics?.snps ? getRelevantSNPsRuntime(dotKey) : [];
+  const shouldRenderRecommendations = isProductRecsEnabledRuntime() && hasRecommendationSectionRendererRuntime();
   html += `<div class="gb-detail-actions">
     <div class="gb-detail-action-row">
       <button class="manual-entry-btn" ${markerDetailActionAttrs('open-manual-entry', { id })}>+ Add Value Manually</button>
@@ -721,7 +738,7 @@ export function showDetailModal(id, opts = {}) {
 	    </div>
 	  </div>`;
   // Recommendation placeholder — shown for any marker with a catalog slot
-  if (window.isProductRecsEnabled && window.isProductRecsEnabled()) {
+  if (shouldRenderRecommendations) {
     html += `<div id="rec-modal-${id}"></div>`;
   }
   html += `</div>`;
@@ -738,10 +755,10 @@ export function showDetailModal(id, opts = {}) {
     }, 0);
   }
   // Async-fill recommendation section (unified: genetics + actionable tips)
-  if (window.renderRecommendationSection) {
+  if (shouldRenderRecommendations) {
     const _latestVal = marker.values?.filter(v => v !== null).pop();
     const _markerStatus = _latestVal != null ? getStatus(_latestVal, r.min, r.max) : 'missing';
-    window.renderRecommendationSection(id.replace('_','.'), { label: 'What can help', maxProducts: 3, inlineSNPs: _inlineSNPs, markerStatus: _markerStatus })
+    renderRecommendationSectionRuntime(id.replace('_','.'), { label: 'What can help', maxProducts: 3, inlineSNPs: _inlineSNPs, markerStatus: _markerStatus })
       .then(h => {
         const el = document.getElementById('rec-modal-' + id);
         if (h && el) {
@@ -1028,7 +1045,7 @@ export function saveCustomMarker() {
     };
   }
   saveImportedData();
-  window.buildSidebar();
+  buildMarkerDetailSidebarRuntime();
   closeModal();
   showNotification(`Created "${name}" in ${catLabel}`, 'success');
   // Register marker and open manual entry to add first value
@@ -1071,7 +1088,7 @@ export async function deleteCustomMarker(id) {
     deleteEmptyLabEntries(state.importedData);
     saveImportedData();
     closeModal();
-    window.buildSidebar();
+    buildMarkerDetailSidebarRuntime();
     updateHeaderDates();
     markerDetailDeps.navigate('dashboard');
     showNotification(`Deleted "${def.name}"${isLastInCat && siblingsInCat.length > 1 ? ` and ${siblingsInCat.length - 1} other marker(s)` : ''}`, 'info');
@@ -1092,10 +1109,10 @@ export function closeModal() {
   }
   if (state.chartInstances["modal"]) { state.chartInstances["modal"].destroy(); delete state.chartInstances["modal"]; }
   document.removeEventListener('click', closeSuggestionsOnClickOutside);
-  if (window.closeEMFInterpretation) window.closeEMFInterpretation();
+  closeEMFInterpretationRuntime();
   // Detail-modal Tab focus trap (wearables) — uninstall explicitly so the
   // global keydown handler doesn't outlive the modal it scoped to.
-  if (window._uninstallWearableModalFocusTrap) window._uninstallWearableModalFocusTrap();
+  uninstallWearableModalFocusTrapRuntime();
   // Clear the active-detail-marker pointer so a later toggleAltUnits (fired
   // from Settings → Display) doesn't re-open this modal on top of Settings.
   state._activeDetailMarkerId = null;

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -1,0 +1,119 @@
+// @ts-check
+// marker-detail-runtime.js - Browser runtime adapters for marker detail modal hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {string | undefined} category
+ * @param {any} [data]
+ */
+export function navigateMarkerDetailRuntime(category, data) {
+  getRuntimeFunction('navigate')?.(category, data);
+}
+
+export function buildMarkerDetailSidebarRuntime() {
+  try {
+    getRuntimeFunction('buildSidebar')?.();
+  } catch {
+    // Best-effort shell refresh.
+  }
+}
+
+/**
+ * @param {string | undefined} id
+ * @returns {boolean}
+ */
+export function isDashboardQuickMarkerPinnedRuntime(id) {
+  try {
+    return getRuntimeFunction('isDashboardQuickMarkerPinned')?.(id) === true;
+  } catch {
+    return false;
+  }
+}
+
+/** @param {string | undefined} id */
+export function toggleDashboardQuickMarkerPinRuntime(id) {
+  getRuntimeFunction('toggleDashboardQuickMarkerPin')?.(id);
+}
+
+/** @param {string | undefined} id */
+export function renameMarkerRuntime(id) {
+  getRuntimeFunction('renameMarker')?.(id);
+}
+
+/** @param {string | undefined} id */
+export function revertMarkerNameRuntime(id) {
+  getRuntimeFunction('revertMarkerName')?.(id);
+}
+
+/** @param {string | undefined} id */
+export function askAIAboutMarkerRuntime(id) {
+  getRuntimeFunction('askAIAboutMarker')?.(id);
+}
+
+/**
+ * @param {Element} el
+ * @param {(emoji?: string | null) => void} callback
+ * @param {any} [opts]
+ */
+export function showEmojiPickerRuntime(el, callback, opts) {
+  getRuntimeFunction('showEmojiPicker')?.(el, callback, opts);
+}
+
+/**
+ * @param {string} dotKey
+ * @returns {any[]}
+ */
+export function getRelevantSNPsRuntime(dotKey) {
+  try {
+    const snps = getRuntimeFunction('_getRelevantSNPs')?.(dotKey);
+    return Array.isArray(snps) ? snps : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isProductRecsEnabledRuntime() {
+  try {
+    return getRuntimeFunction('isProductRecsEnabled')?.() === true;
+  } catch {
+    return false;
+  }
+}
+
+export function hasRecommendationSectionRendererRuntime() {
+  return getRuntimeFunction('renderRecommendationSection') !== null;
+}
+
+/**
+ * @param {string} markerKey
+ * @param {any} options
+ * @returns {Promise<string>}
+ */
+export async function renderRecommendationSectionRuntime(markerKey, options) {
+  const renderRecommendations = getRuntimeFunction('renderRecommendationSection');
+  if (!renderRecommendations) return '';
+  const html = await renderRecommendations(markerKey, options);
+  return typeof html === 'string' ? html : '';
+}
+
+export function closeEMFInterpretationRuntime() {
+  getRuntimeFunction('closeEMFInterpretation')?.();
+}
+
+export function uninstallWearableModalFocusTrapRuntime() {
+  getRuntimeFunction('_uninstallWearableModalFocusTrap')?.();
+}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 322,
+  "windowReferences": 309,
   "largeJsFilesOver800Lines": 29,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -226,6 +226,7 @@ const APP_SHELL = [
   '/js/category-customization.js',
   '/js/commit-hash.js',
   '/js/marker-detail-modal.js',
+  '/js/marker-detail-runtime.js',
   '/js/marker-detail-actions.js',
   '/js/marker-detail-editing.js',
   '/js/marker-detail-store.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -183,6 +183,7 @@ const LEGACY_TESTS = [
   './test-wearables-runtime.js',
   './test-wearables-settings-runtime.js',
   './test-dashboard-widget-runtime.js',
+  './test-marker-detail-runtime.js',
   './test-shell-delegated-actions.js',
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -10,6 +10,7 @@ const root = path.resolve(__dirname, '..');
 const modalSrc = fs.readFileSync(path.join(root, 'js/marker-detail-modal.js'), 'utf8');
 const editingSrc = fs.readFileSync(path.join(root, 'js/marker-detail-editing.js'), 'utf8');
 const actionSrc = fs.readFileSync(path.join(root, 'js/marker-detail-actions.js'), 'utf8');
+const runtimeSrc = fs.readFileSync(path.join(root, 'js/marker-detail-runtime.js'), 'utf8');
 const dashboardSrc = fs.readFileSync(path.join(root, 'js/dashboard-view-composition.js'), 'utf8');
 const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
 
@@ -68,6 +69,17 @@ assert('dashboard passes the quick-marker pin dependency instead of relying on a
     modalSrc.includes("markerDetailActionAttrs('quick-pin', { id })"));
 assert('service worker precaches marker-detail-actions.js',
   swSrc.includes("'/js/marker-detail-actions.js'"));
+assert('service worker precaches marker-detail-runtime.js',
+  swSrc.includes("'/js/marker-detail-runtime.js'"));
+assert('marker-detail-modal delegates browser globals through runtime adapter',
+  modalSrc.includes("from './marker-detail-runtime.js'") &&
+    !/\bwindow(?:\.|\s*\[)/.test(modalSrc) &&
+    runtimeSrc.includes('export function navigateMarkerDetailRuntime') &&
+    runtimeSrc.includes('export function hasRecommendationSectionRendererRuntime') &&
+    runtimeSrc.includes('export async function renderRecommendationSectionRuntime'));
+assert('marker-detail-modal only creates recommendation placeholders when renderer can fill them',
+  modalSrc.includes('const shouldRenderRecommendations = isProductRecsEnabledRuntime() && hasRecommendationSectionRendererRuntime();') &&
+    modalSrc.includes('if (shouldRenderRecommendations)'));
 
 [
   'close-modal',

--- a/tests/test-marker-detail-runtime.js
+++ b/tests/test-marker-detail-runtime.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// test-marker-detail-runtime.js - Marker detail runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  askAIAboutMarkerRuntime,
+  buildMarkerDetailSidebarRuntime,
+  closeEMFInterpretationRuntime,
+  getRelevantSNPsRuntime,
+  hasRecommendationSectionRendererRuntime,
+  isDashboardQuickMarkerPinnedRuntime,
+  isProductRecsEnabledRuntime,
+  navigateMarkerDetailRuntime,
+  renameMarkerRuntime,
+  renderRecommendationSectionRuntime,
+  revertMarkerNameRuntime,
+  showEmojiPickerRuntime,
+  toggleDashboardQuickMarkerPinRuntime,
+  uninstallWearableModalFocusTrapRuntime,
+} from '../js/marker-detail-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Marker Detail Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'navigate',
+  'buildSidebar',
+  'isDashboardQuickMarkerPinned',
+  'toggleDashboardQuickMarkerPin',
+  'renameMarker',
+  'revertMarkerName',
+  'askAIAboutMarker',
+  'showEmojiPicker',
+  '_getRelevantSNPs',
+  'isProductRecsEnabled',
+  'renderRecommendationSection',
+  'closeEMFInterpretation',
+  '_uninstallWearableModalFocusTrap',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const anchor = { textContent: '', dataset: {} };
+  const snps = [{ rsid: 'rs1801133' }];
+
+  setRuntimeValue('navigate', (category, data) => calls.push(['navigate', category, data?.from || '']));
+  setRuntimeValue('buildSidebar', () => calls.push(['sidebar']));
+  setRuntimeValue('isDashboardQuickMarkerPinned', id => id === 'lipids_apob');
+  setRuntimeValue('toggleDashboardQuickMarkerPin', id => calls.push(['pin', id]));
+  setRuntimeValue('renameMarker', id => calls.push(['rename', id]));
+  setRuntimeValue('revertMarkerName', id => calls.push(['revert', id]));
+  setRuntimeValue('askAIAboutMarker', id => calls.push(['ask', id]));
+  setRuntimeValue('showEmojiPicker', (el, callback, opts) => {
+    calls.push(['emoji', opts?.showReset ? 'reset' : 'plain']);
+    callback(':test:');
+  });
+  setRuntimeValue('_getRelevantSNPs', dotKey => {
+    calls.push(['snps', dotKey]);
+    return snps;
+  });
+  setRuntimeValue('isProductRecsEnabled', () => true);
+  setRuntimeValue('renderRecommendationSection', async (markerKey, options) => {
+    calls.push(['recs', markerKey, options?.markerStatus || '']);
+    return '<section>recs</section>';
+  });
+  setRuntimeValue('closeEMFInterpretation', () => calls.push(['emf-close']));
+  setRuntimeValue('_uninstallWearableModalFocusTrap', () => calls.push(['focus-trap']));
+
+  navigateMarkerDetailRuntime('dashboard', { from: 'marker' });
+  buildMarkerDetailSidebarRuntime();
+  toggleDashboardQuickMarkerPinRuntime('lipids_apob');
+  renameMarkerRuntime('lipids_apob');
+  revertMarkerNameRuntime('lipids_apob');
+  askAIAboutMarkerRuntime('lipids_apob');
+  showEmojiPickerRuntime(anchor, emoji => { anchor.textContent = emoji || ''; }, { showReset: true });
+  closeEMFInterpretationRuntime();
+  uninstallWearableModalFocusTrapRuntime();
+  const renderedRecs = await renderRecommendationSectionRuntime('lipids.apob', { markerStatus: 'high' });
+
+  assert('marker detail runtime delegates modal shell hooks',
+    calls.some(call => call.join('|') === 'navigate|dashboard|marker') &&
+      calls.some(call => call.join('|') === 'sidebar') &&
+      calls.some(call => call.join('|') === 'pin|lipids_apob') &&
+      calls.some(call => call.join('|') === 'rename|lipids_apob') &&
+      calls.some(call => call.join('|') === 'revert|lipids_apob') &&
+      calls.some(call => call.join('|') === 'ask|lipids_apob') &&
+      calls.some(call => call.join('|') === 'emoji|reset') &&
+      calls.some(call => call.join('|') === 'emf-close') &&
+      calls.some(call => call.join('|') === 'focus-trap'));
+  assert('marker detail runtime returns browser-derived values',
+    isDashboardQuickMarkerPinnedRuntime('lipids_apob') === true &&
+      getRelevantSNPsRuntime('lipids.apob') === snps &&
+      hasRecommendationSectionRendererRuntime() === true &&
+      isProductRecsEnabledRuntime() === true &&
+      renderedRecs === '<section>recs</section>' &&
+      anchor.textContent === ':test:');
+
+  setRuntimeValue('buildSidebar', () => { throw new Error('boom'); });
+  setRuntimeValue('isDashboardQuickMarkerPinned', () => { throw new Error('boom'); });
+  setRuntimeValue('_getRelevantSNPs', () => { throw new Error('boom'); });
+  setRuntimeValue('isProductRecsEnabled', () => { throw new Error('boom'); });
+  buildMarkerDetailSidebarRuntime();
+  assert('marker detail runtime safe fallbacks catch optional hook errors',
+    isDashboardQuickMarkerPinnedRuntime('lipids_apob') === false &&
+      getRelevantSNPsRuntime('lipids.apob').length === 0 &&
+      isProductRecsEnabledRuntime() === false);
+
+  delete globalThis.window;
+  const beforeMissingRuntimeCalls = calls.length;
+  navigateMarkerDetailRuntime('dashboard');
+  buildMarkerDetailSidebarRuntime();
+  toggleDashboardQuickMarkerPinRuntime('lipids_apob');
+  renameMarkerRuntime('lipids_apob');
+  revertMarkerNameRuntime('lipids_apob');
+  askAIAboutMarkerRuntime('lipids_apob');
+  showEmojiPickerRuntime(anchor, () => {});
+  closeEMFInterpretationRuntime();
+  uninstallWearableModalFocusTrapRuntime();
+  const missingRuntimeRecs = await renderRecommendationSectionRuntime('lipids.apob', {});
+  assert('marker detail runtime no-ops safely when window is missing',
+    calls.length === beforeMissingRuntimeCalls &&
+      isDashboardQuickMarkerPinnedRuntime('lipids_apob') === false &&
+      hasRecommendationSectionRendererRuntime() === false &&
+      getRelevantSNPsRuntime('lipids.apob').length === 0 &&
+      isProductRecsEnabledRuntime() === false &&
+      missingRuntimeRecs === '');
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -111,6 +111,7 @@ const domainUiCheckJsModules = [
   'js/light-conditions-now.js',
   'js/light-env.js',
   'js/marker-detail-modal.js',
+  'js/marker-detail-runtime.js',
   'js/pdf-import-review.js',
   'js/provider-panels.js',
   'js/sun-context.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -65,6 +65,7 @@
     '/js/focus-card.js',
     '/js/onboarding-view.js',
     '/js/marker-detail-modal.js',
+    '/js/marker-detail-runtime.js',
     '/js/marker-detail-editing.js',
     '/js/light-conditions-now.js',
     '/js/light-conditions-now-hooks.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -158,6 +158,7 @@
     "js/light-tools.js",
     "js/main.js",
     "js/marker-detail-modal.js",
+    "js/marker-detail-runtime.js",
     "js/mobile-dashboard.js",
     "js/mobile-dashboard-runtime.js",
     "js/modal-lifecycle.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -153,6 +153,7 @@
     "js/marker-detail-actions.js",
     "js/marker-detail-editing.js",
     "js/marker-detail-modal.js",
+    "js/marker-detail-runtime.js",
     "js/marker-detail-store.js",
     "js/mobile-dashboard.js",
     "js/mobile-dashboard-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.86';
+self.APP_VERSION = '1.10.87';


### PR DESCRIPTION
## Summary

This PR reduces direct browser-global coupling in the marker detail modal by moving modal shell hooks behind a focused runtime adapter.

Changes include:
- add `js/marker-detail-runtime.js` for marker detail navigation, sidebar refresh, recommendation rendering, SNP lookup, emoji picker, AI handoff, and cleanup hooks
- route `js/marker-detail-modal.js` through the runtime adapter so it no longer directly calls `window.*`
- add focused runtime adapter coverage and strengthen the delegated-action static guard
- add the new runtime module to service-worker precache, module verification, and typecheck coverage
- lower the combined `windowReferences` quality budget from 322 to 309 after #1060
- bump `version.js` to 1.10.87 for cache invalidation

## Validation

Before rebasing onto the merged #1060 base:
- `./run-tests.sh`

After rebasing onto current `main`:
- `node tests/test-marker-detail-runtime.js`
- `node tests/test-marker-detail-delegated-actions.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot`