### PR TITLE
[codex] Extract lifestyle context runtime hooks

### DIFF
--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -82,6 +82,15 @@ import {
   renderTagsField,
   selectCtxOption,
 } from './context-card-editor-ui.js';
+import {
+  closeLifestyleContextModalAndNavigateRuntime,
+  closeLifestyleContextModalRuntime,
+  discussDietContaminantsRuntime,
+  markLifestyleContextDelegatesBoundRuntime,
+  openLightSetupFromLifestyleRuntime,
+  returnToLifestyleContextModalRuntime,
+  updateLifestyleChatHeaderModelRuntime,
+} from './context-card-lifestyle-runtime.js';
 
 /** @type {(field: string) => void} */
 let recordContextChange = () => {};
@@ -144,28 +153,16 @@ function getLifestyleIndex(el) {
   return Number.isInteger(idx) ? idx : -1;
 }
 
-function getAppWindow() { return typeof window !== 'undefined' ? /** @type {any} */ (window) : {}; }
-
 function openLightSetupFromContext() {
-  const appWindow = getAppWindow();
-  if (typeof appWindow.closeModal === 'function') appWindow.closeModal();
-  if (typeof appWindow.navigate === 'function') appWindow.navigate('light');
-  setTimeout(() => { if (typeof appWindow.reopenSunSetup === 'function') appWindow.reopenSunSetup(); }, 200);
+  openLightSetupFromLifestyleRuntime();
 }
 
 function discussDietContaminants() {
-  const appWindow = getAppWindow();
-  if (typeof appWindow.closeModal === 'function') appWindow.closeModal();
-  if (typeof appWindow.openChatPanel === 'function') appWindow.openChatPanel();
-  setTimeout(() => { if (typeof appWindow.useChatPrompt === 'function') appWindow.useChatPrompt('What food contaminants should I be concerned about based on my diet?'); }, 300);
+  discussDietContaminantsRuntime();
 }
 
 function returnToContextModal() {
-  const appWindow = getAppWindow();
-  if (typeof appWindow.closeModal === 'function') appWindow.closeModal();
-  setTimeout(() => {
-    if (typeof appWindow.openContextModal === 'function') appWindow.openContextModal();
-  }, 0);
+  returnToLifestyleContextModalRuntime();
 }
 
 /** @param {MouseEvent} event */
@@ -184,7 +181,7 @@ function handleLifestyleContextClick(event) {
     case 'clear-interpretive-lens': clearInterpretiveLens(); break;
     case 'back-to-context': returnToContextModal(); break;
     case 'discuss-diet-contaminants': discussDietContaminants(); break;
-    case 'close-modal': { const appWindow = getAppWindow(); if (typeof appWindow.closeModal === 'function') appWindow.closeModal(); break; }
+    case 'close-modal': closeLifestyleContextModalRuntime(); break;
     default:
       break;
   }
@@ -204,10 +201,8 @@ function handleLifestyleContextKeydown(event) {
 }
 
 function initLifestyleContextDelegates() {
-  if (typeof document === 'undefined' || typeof window === 'undefined') return;
-  const appWindow = getAppWindow();
-  if (appWindow.__lifestyleContextDelegatesBound) return;
-  appWindow.__lifestyleContextDelegatesBound = true;
+  if (typeof document === 'undefined') return;
+  if (!markLifestyleContextDelegatesBoundRuntime()) return;
   document.addEventListener('click', handleLifestyleContextClick, true);
   document.addEventListener('keydown', handleLifestyleContextKeydown);
 }
@@ -700,8 +695,7 @@ export function deleteHealthGoal(idx) {
 }
 
 export function closeHealthGoals() {
-  window.closeModal();
-  window.navigate(getActiveNavCategory());
+  closeLifestyleContextModalAndNavigateRuntime(getActiveNavCategory());
   if ((state.importedData.healthGoals || []).length > 0) showNotification('Health goals saved', 'success');
 }
 
@@ -709,8 +703,7 @@ export function clearHealthGoals() {
   clearImportedArray(state.importedData, 'healthGoals');
   recordContextChange('healthGoals');
   saveImportedData();
-  window.closeModal();
-  window.navigate(getActiveNavCategory());
+  closeLifestyleContextModalAndNavigateRuntime(getActiveNavCategory());
   showNotification('Health goals cleared', 'info');
 }
 
@@ -742,21 +735,19 @@ export function saveInterpretiveLens() {
   const ta = getTextInput('interpretive-lens-textarea');
   const text = ta ? ta.value.trim() : '';
   state.importedData.interpretiveLens = text || '';
-  window.updateChatHeaderModel?.();
+  updateLifestyleChatHeaderModelRuntime();
   recordContextChange('interpretiveLens');
   saveImportedData();
-  window.closeModal();
-  window.navigate(getActiveNavCategory());
+  closeLifestyleContextModalAndNavigateRuntime(getActiveNavCategory());
   showNotification(text ? 'Interpretive lens saved' : 'Interpretive lens cleared', 'success');
 }
 
 export function clearInterpretiveLens() {
   state.importedData.interpretiveLens = '';
-  window.updateChatHeaderModel?.();
+  updateLifestyleChatHeaderModelRuntime();
   recordContextChange('interpretiveLens');
   saveImportedData();
-  window.closeModal();
-  window.navigate(getActiveNavCategory());
+  closeLifestyleContextModalAndNavigateRuntime(getActiveNavCategory());
   showNotification('Interpretive lens cleared', 'info');
 }
 

--- a/js/context-card-lifestyle-runtime.js
+++ b/js/context-card-lifestyle-runtime.js
@@ -1,0 +1,68 @@
+// @ts-check
+// context-card-lifestyle-runtime.js - Browser runtime adapters for lifestyle context editors.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+const LIFESTYLE_DELEGATES_BOUND_KEY = '__lifestyleContextDelegatesBound';
+
+export function markLifestyleContextDelegatesBoundRuntime() {
+  const runtime = getRuntimeWindow();
+  if (!runtime || runtime[LIFESTYLE_DELEGATES_BOUND_KEY]) return false;
+  runtime[LIFESTYLE_DELEGATES_BOUND_KEY] = true;
+  return true;
+}
+
+export function closeLifestyleContextModalRuntime() {
+  getRuntimeFunction('closeModal')?.();
+}
+
+/** @param {string | undefined} category */
+export function navigateLifestyleContextRuntime(category) {
+  getRuntimeFunction('navigate')?.(category);
+}
+
+/** @param {string | undefined} category */
+export function closeLifestyleContextModalAndNavigateRuntime(category) {
+  closeLifestyleContextModalRuntime();
+  navigateLifestyleContextRuntime(category);
+}
+
+export function updateLifestyleChatHeaderModelRuntime() {
+  getRuntimeFunction('updateChatHeaderModel')?.();
+}
+
+export function openLightSetupFromLifestyleRuntime() {
+  closeLifestyleContextModalRuntime();
+  navigateLifestyleContextRuntime('light');
+  setTimeout(() => {
+    getRuntimeFunction('reopenSunSetup')?.();
+  }, 200);
+}
+
+export function discussDietContaminantsRuntime() {
+  closeLifestyleContextModalRuntime();
+  getRuntimeFunction('openChatPanel')?.();
+  setTimeout(() => {
+    getRuntimeFunction('useChatPrompt')?.('What food contaminants should I be concerned about based on my diet?');
+  }, 300);
+}
+
+export function returnToLifestyleContextModalRuntime() {
+  closeLifestyleContextModalRuntime();
+  setTimeout(() => {
+    getRuntimeFunction('openContextModal')?.();
+  }, 0);
+}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 309,
-  "largeJsFilesOver800Lines": 29,
+  "windowReferences": 299,
+  "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1513
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -122,6 +122,7 @@ const APP_SHELL = [
   '/js/context-card-dashboard-ai.js',
   '/js/context-card-dashboard-ai-actions.js',
   '/js/context-card-medical-history-editor.js',
+  '/js/context-card-lifestyle-runtime.js',
   '/js/context-card-lifestyle-editors.js',
   '/js/focus-card.js',
   '/js/onboarding-view.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -178,6 +178,7 @@ const LEGACY_TESTS = [
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',
   './test-chat-send-runtime.js',
+  './test-context-card-lifestyle-runtime.js',
   './test-import-drop-zone-runtime.js',
   './test-mobile-dashboard-runtime.js',
   './test-wearables-runtime.js',

--- a/tests/test-context-card-lifestyle-runtime.js
+++ b/tests/test-context-card-lifestyle-runtime.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// test-context-card-lifestyle-runtime.js - Lifestyle context runtime adapter behavior.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import './_node-shim.js';
+import {
+  closeLifestyleContextModalAndNavigateRuntime,
+  closeLifestyleContextModalRuntime,
+  discussDietContaminantsRuntime,
+  markLifestyleContextDelegatesBoundRuntime,
+  navigateLifestyleContextRuntime,
+  openLightSetupFromLifestyleRuntime,
+  returnToLifestyleContextModalRuntime,
+  updateLifestyleChatHeaderModelRuntime,
+} from '../js/context-card-lifestyle-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Context Card Lifestyle Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'closeModal',
+  'navigate',
+  'updateChatHeaderModel',
+  'reopenSunSetup',
+  'openChatPanel',
+  'useChatPrompt',
+  'openContextModal',
+  '__lifestyleContextDelegatesBound',
+  'setTimeout',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('window', globalThis);
+  setRuntimeValue('closeModal', () => calls.push(['close']));
+  setRuntimeValue('navigate', category => calls.push(['navigate', category]));
+  setRuntimeValue('updateChatHeaderModel', () => calls.push(['chat-header']));
+  setRuntimeValue('reopenSunSetup', () => calls.push(['sun-setup']));
+  setRuntimeValue('openChatPanel', () => calls.push(['chat-panel']));
+  setRuntimeValue('useChatPrompt', prompt => calls.push(['prompt', prompt]));
+  setRuntimeValue('openContextModal', () => calls.push(['context-modal']));
+  delete globalThis.__lifestyleContextDelegatesBound;
+  setRuntimeValue('setTimeout', (fn, delay) => {
+    calls.push(['timer', String(delay)]);
+    fn();
+    return 1;
+  });
+
+  const firstDelegateMark = markLifestyleContextDelegatesBoundRuntime();
+  const secondDelegateMark = markLifestyleContextDelegatesBoundRuntime();
+  closeLifestyleContextModalRuntime();
+  navigateLifestyleContextRuntime('dashboard');
+  closeLifestyleContextModalAndNavigateRuntime('labs');
+  updateLifestyleChatHeaderModelRuntime();
+  openLightSetupFromLifestyleRuntime();
+  discussDietContaminantsRuntime();
+  returnToLifestyleContextModalRuntime();
+
+  assert('lifestyle runtime delegates shell hooks',
+    firstDelegateMark === true &&
+      secondDelegateMark === false &&
+      calls.some(call => call.join('|') === 'close') &&
+      calls.some(call => call.join('|') === 'navigate|dashboard') &&
+      calls.some(call => call.join('|') === 'navigate|labs') &&
+      calls.some(call => call.join('|') === 'chat-header') &&
+      calls.some(call => call.join('|') === 'navigate|light') &&
+      calls.some(call => call.join('|') === 'sun-setup') &&
+      calls.some(call => call.join('|') === 'chat-panel') &&
+      calls.some(call => call[0] === 'prompt' && call[1].includes('food contaminants')) &&
+      calls.some(call => call.join('|') === 'context-modal'));
+  assert('lifestyle runtime preserves delayed shell actions',
+    calls.some(call => call.join('|') === 'timer|200') &&
+      calls.some(call => call.join('|') === 'timer|300') &&
+      calls.some(call => call.join('|') === 'timer|0'));
+
+  delete globalThis.window;
+  const shellCallCount = calls.filter(call => call[0] !== 'timer').length;
+  closeLifestyleContextModalRuntime();
+  navigateLifestyleContextRuntime('dashboard');
+  closeLifestyleContextModalAndNavigateRuntime('labs');
+  updateLifestyleChatHeaderModelRuntime();
+  openLightSetupFromLifestyleRuntime();
+  discussDietContaminantsRuntime();
+  returnToLifestyleContextModalRuntime();
+  assert('lifestyle runtime no-ops safely when window is missing',
+    calls.filter(call => call[0] !== 'timer').length === shellCallCount);
+
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const editorSrc = fs.readFileSync(path.join(root, 'js/context-card-lifestyle-editors.js'), 'utf8');
+  const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+  assert('lifestyle editor delegates browser globals through runtime adapter',
+    editorSrc.includes("from './context-card-lifestyle-runtime.js'") &&
+      !/\bwindow(?:\.|\s*\[)/.test(editorSrc) &&
+      swSrc.includes("'/js/context-card-lifestyle-runtime.js'"));
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -44,6 +44,7 @@
     '/js/context-card-dashboard-ai-actions.js',
     '/js/dashboard-recommendation-widget.js',
     '/js/supplement-impact.js',
+    '/js/context-card-lifestyle-runtime.js',
     '/js/context-card-lifestyle-editors.js',
     '/js/wearables-detail-modal.js',
     '/js/wearables-bp-detail-chart.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -76,6 +76,7 @@
     "js/context-card-dashboard-ai.js",
     "js/context-card-editor-ui.js",
     "js/context-card-health-dots.js",
+    "js/context-card-lifestyle-runtime.js",
     "js/context-card-lifestyle-editors.js",
     "js/context-card-medical-history-editor.js",
     "js/context-card-summaries.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,6 +76,7 @@
     "js/context-card-dashboard-ai.js",
     "js/context-card-editor-ui.js",
     "js/context-card-health-dots.js",
+    "js/context-card-lifestyle-runtime.js",
     "js/context-card-lifestyle-editors.js",
     "js/context-card-medical-history-editor.js",
     "js/context-card-summaries.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.87';
+self.APP_VERSION = '1.10.88';


### PR DESCRIPTION
## Summary
- add a lifestyle context runtime adapter for modal, navigation, chat, light setup, and delegate singleton browser hooks
- route `context-card-lifestyle-editors.js` through the adapter so the editor no longer has direct `window.` references
- register the new module in the service worker, module verification, and typecheck configs; lower the quality baseline for `windowReferences` from 309 to 299 and large JS files from 29 to 28
- bump `version.js` to `1.10.88`

## Tests
- `node tests/test-context-card-lifestyle-runtime.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot`
- `./run-tests.sh`
