### PR TITLE
[codex] Extract sync diagnose runtime hooks

### DIFF
--- a/js/sync-diagnose-cutover-actions.js
+++ b/js/sync-diagnose-cutover-actions.js
@@ -13,16 +13,15 @@ import {
   enablePhase2CutoverForDiagnose,
   pushProfileForDiagnose,
 } from './sync-diagnose-actions-context.js';
+import { confirmSyncDiagnoseActionRuntime } from './sync-diagnose-runtime.js';
 
 // "Reset window" - drops the rolling per-push telemetry log so the user
-// can start a fresh measurement window.
+// can start a fresh measurement span.
 export async function confirmResetDeltaTelemetry(btn) {
   const t = state.currentProfile ? getDeltaTelemetry(state.currentProfile) : null;
   const n = t?.summary?.count || 0;
   const message = `Reset the push-efficiency log? Drops the ${n} recent push entries used to compute the percentage. Your data and relay state aren't touched.`;
-  const proceed = (typeof window.showConfirmDialog === 'function')
-    ? await window.showConfirmDialog(message)
-    : true;
+  const proceed = await confirmSyncDiagnoseActionRuntime(message);
   if (!proceed) return;
   if (state.currentProfile && resetDeltaTelemetry(state.currentProfile)) {
     try { showNotification('Telemetry window reset', 'success'); } catch {}
@@ -45,9 +44,7 @@ export async function confirmEnablePhase2(btn) {
     return;
   }
   const message = `Switch this device to lean sync mode?\n\nFrom now on, this device will only push per-row deltas instead of the full data blob. Other devices keep working normally.\n\nReversible any time via Disable.`;
-  const proceed = (typeof window.showConfirmDialog === 'function')
-    ? await window.showConfirmDialog(message)
-    : true;
+  const proceed = await confirmSyncDiagnoseActionRuntime(message);
   if (!proceed) return;
   const result = enablePhase2CutoverForDiagnose(state.currentProfile);
   if (result.ok) {
@@ -75,9 +72,7 @@ export async function confirmBackfillBlockers(btn) {
     return;
   }
   const message = `Force a push for ${blockers.length} item${blockers.length === 1 ? '' : 's'} that haven't synced as deltas yet?\n\n${blockers.join(', ')}\n\nSafe — this just re-sends data that should already be on the relay.`;
-  const proceed = (typeof window.showConfirmDialog === 'function')
-    ? await window.showConfirmDialog(message)
-    : true;
+  const proceed = await confirmSyncDiagnoseActionRuntime(message);
   if (!proceed) return;
   let cleared = 0;
   for (const name of blockers) {
@@ -98,9 +93,7 @@ export async function confirmBackfillBlockers(btn) {
 export async function confirmDisablePhase2(btn) {
   if (!state.currentProfile) return;
   const message = `Switch this device back to full-blob sync?\n\nPushes will include the full data blob again as a safety net. Use this if a peer device is missing data after going lean.\n\nNo data loss either way.`;
-  const proceed = (typeof window.showConfirmDialog === 'function')
-    ? await window.showConfirmDialog(message)
-    : true;
+  const proceed = await confirmSyncDiagnoseActionRuntime(message);
   if (!proceed) return;
   if (disablePhase2CutoverForDiagnose(state.currentProfile)) {
     try { showNotification('Phase 2 disabled — back to dual-write', 'success'); } catch {}

--- a/js/sync-diagnose-identity-actions.js
+++ b/js/sync-diagnose-identity-actions.js
@@ -9,6 +9,7 @@ import {
   enableSyncForDiagnose,
   restoreMnemonicForDiagnose,
 } from './sync-diagnose-actions-context.js';
+import { confirmSyncDiagnoseActionRuntime } from './sync-diagnose-runtime.js';
 
 // "Rotate identity" - generate a fresh 24-word BIP-39 mnemonic, show
 // it (with QR for cross-device entry), confirm the user saved it, then
@@ -25,9 +26,7 @@ export async function confirmRotateIdentity(btn) {
     "• The old identity's data stays on the relay until it ages out (no immediate loss), but new pushes will go under the new identity.\n" +
     "• This is the recovery path when this device's relay-health check shows wedged (red dot above).\n\n" +
     "Proceed?";
-  const proceed = (typeof window.showConfirmDialog === 'function')
-    ? await window.showConfirmDialog(warning)
-    : true;
+  const proceed = await confirmSyncDiagnoseActionRuntime(warning);
   if (!proceed) return;
 
   // Stage 2: generate the new mnemonic. BIP-39 256 bits = 24 words.

--- a/js/sync-diagnose-relay-actions.js
+++ b/js/sync-diagnose-relay-actions.js
@@ -7,6 +7,7 @@ import {
 } from './sync-relay-health.js';
 import { toggleSyncDetail } from './sync-ui.js';
 import { showSyncDiagnoseForActions } from './sync-diagnose-actions-context.js';
+import { confirmSyncDiagnoseActionRuntime } from './sync-diagnose-runtime.js';
 
 // "Compact storage" - calls POST /self/compact-owner on the relay,
 // HMAC-signed with the user's own writeKey. Drops every Evolu message
@@ -20,9 +21,7 @@ export async function confirmCompactRelay(btn) {
   // Helper unavailable (utils.js failed to load) -> proceed without
   // confirmation rather than dead-end the user. Safety net mirrors the
   // pattern in the confirm* helpers in the sibling action modules.
-  const proceed = (typeof window.showConfirmDialog === 'function')
-    ? await window.showConfirmDialog(message)
-    : true;
+  const proceed = await confirmSyncDiagnoseActionRuntime(message);
   if (!proceed) return;
   if (btn) { btn.disabled = true; btn.textContent = 'Compacting…'; }
   try {

--- a/js/sync-diagnose-runtime.js
+++ b/js/sync-diagnose-runtime.js
@@ -1,0 +1,27 @@
+// @ts-check
+// sync-diagnose-runtime.js - Browser runtime adapters for Sync Diagnose shell hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {string} message
+ * @param {{ fallback?: boolean }} [opts]
+ */
+export async function confirmSyncDiagnoseActionRuntime(message, opts = {}) {
+  const confirm = getRuntimeFunction('showConfirmDialog');
+  if (!confirm) return opts.fallback ?? true;
+  return !!await confirm(message);
+}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 299,
+  "windowReferences": 286,
   "largeJsFilesOver800Lines": 28,
-  "maxJsFileLines": 1513
+  "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -312,6 +312,7 @@ const APP_SHELL = [
   '/js/sync-diagnostics-snapshot.js',
   '/js/sync-diagnostics-text.js',
   '/js/sync-diagnose-actions-context.js',
+  '/js/sync-diagnose-runtime.js',
   '/js/sync-diagnose-relay-actions.js',
   '/js/sync-diagnose-identity-actions.js',
   '/js/sync-diagnose-cutover-actions.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -181,6 +181,7 @@ const LEGACY_TESTS = [
   './test-context-card-lifestyle-runtime.js',
   './test-import-drop-zone-runtime.js',
   './test-mobile-dashboard-runtime.js',
+  './test-sync-diagnose-runtime.js',
   './test-wearables-runtime.js',
   './test-wearables-settings-runtime.js',
   './test-dashboard-widget-runtime.js',

--- a/tests/test-sync-diagnose-runtime.js
+++ b/tests/test-sync-diagnose-runtime.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// test-sync-diagnose-runtime.js - Sync Diagnose runtime adapter behavior.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import './_node-shim.js';
+import { confirmSyncDiagnoseActionRuntime } from '../js/sync-diagnose-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Sync Diagnose Runtime Tests ===\n');
+
+const runtimeKeys = ['window', 'showConfirmDialog'];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('window', globalThis);
+  setRuntimeValue('showConfirmDialog', async message => {
+    calls.push(message);
+    return message === 'confirm';
+  });
+
+  const confirmed = await confirmSyncDiagnoseActionRuntime('confirm');
+  const cancelled = await confirmSyncDiagnoseActionRuntime('cancel');
+  assert('sync diagnose runtime delegates confirm dialog',
+    confirmed === true && cancelled === false && calls.join('|') === 'confirm|cancel');
+
+  delete globalThis.showConfirmDialog;
+  const defaultFallback = await confirmSyncDiagnoseActionRuntime('missing');
+  const explicitFallback = await confirmSyncDiagnoseActionRuntime('missing', { fallback: false });
+  assert('sync diagnose runtime preserves missing-confirm fallback',
+    defaultFallback === true && explicitFallback === false);
+
+  delete globalThis.window;
+  const noWindowFallback = await confirmSyncDiagnoseActionRuntime('missing');
+  assert('sync diagnose runtime no-ops safely when window is missing',
+    noWindowFallback === true);
+
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const cutoverSrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-cutover-actions.js'), 'utf8');
+  const relaySrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-relay-actions.js'), 'utf8');
+  const identitySrc = fs.readFileSync(path.join(root, 'js/sync-diagnose-identity-actions.js'), 'utf8');
+  const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+  assert('sync diagnose action modules delegate browser globals through runtime adapter',
+    cutoverSrc.includes("from './sync-diagnose-runtime.js'") &&
+      relaySrc.includes("from './sync-diagnose-runtime.js'") &&
+      identitySrc.includes("from './sync-diagnose-runtime.js'") &&
+      !/\bwindow(?:\.|\s*\[)/.test(cutoverSrc) &&
+      !/\bwindow(?:\.|\s*\[)/.test(relaySrc) &&
+      !/\bwindow(?:\.|\s*\[)/.test(identitySrc) &&
+      swSrc.includes("'/js/sync-diagnose-runtime.js'"));
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -95,6 +95,7 @@ await import('../js/settings.js');
   const syncDiagnoseRelayActionsSrc = await fetchWithRetry('js/sync-diagnose-relay-actions.js');
   const syncDiagnoseIdentityActionsSrc = await fetchWithRetry('js/sync-diagnose-identity-actions.js');
   const syncDiagnoseCutoverActionsSrc = await fetchWithRetry('js/sync-diagnose-cutover-actions.js');
+  const syncDiagnoseRuntimeSrc = await fetchWithRetry('js/sync-diagnose-runtime.js');
   const syncDiagnoseUiSrc = await fetchWithRetry('js/sync-diagnose-ui.js');
   const syncDiagnoseRenderSrc = await fetchWithRetry('js/sync-diagnose-render.js');
   const syncActionsSrc = await fetchWithRetry('js/sync-actions.js');
@@ -140,7 +141,7 @@ await import('../js/settings.js');
   const syncDeltaRegistrySearchSrc = `${syncDeltaRegistrySrc}\n${syncDeltaSurfacesSrc}\n${syncDeltaSurfaceConfigSrc}\n${syncDeltaIdSrc}`;
   const syncDeltaObservabilitySearchSrc = `${syncDeltaObservabilitySrc}\n${syncDeltaObservabilityContextSrc}\n${syncDeltaPullSnapshotSrc}\n${syncDeltaTelemetrySrc}\n${syncDeltaReadinessSrc}`;
   const syncDiagnosticsSearchSrc = `${syncDiagnosticsSrc}\n${syncDiagnosticsContextSrc}\n${syncDiagnosticsSnapshotSrc}\n${syncDiagnosticsTextSrc}`;
-  const deltaSearchSrc = `${syncSrc}\n${syncPushSrc}\n${syncPushDeltasSrc}\n${syncReconcileSrc}\n${syncPullSrc}\n${syncPullMergeSrc}\n${syncPullMaintenanceSrc}\n${syncPullActiveRefreshSrc}\n${syncPullRebroadcastSrc}\n${syncCutoverSrc}\n${syncDeltaSrc}\n${syncDeltaPlannerSearchSrc}\n${syncDeltaSnapshotSrc}\n${syncDeltaMergeSrc}\n${syncDeltaMergeSearchSrc}\n${syncDeltaRegistrySearchSrc}\n${syncDeltaObservabilitySearchSrc}\n${syncDiagnosticsSearchSrc}\n${syncDiagnoseActionsSrc}\n${syncDiagnoseActionsContextSrc}\n${syncDiagnoseRelayActionsSrc}\n${syncDiagnoseIdentityActionsSrc}\n${syncDiagnoseCutoverActionsSrc}\n${syncDiagnoseUiSrc}\n${syncDiagnoseRenderSrc}\n${syncWindowBindingsSrc}`;
+  const deltaSearchSrc = `${syncSrc}\n${syncPushSrc}\n${syncPushDeltasSrc}\n${syncReconcileSrc}\n${syncPullSrc}\n${syncPullMergeSrc}\n${syncPullMaintenanceSrc}\n${syncPullActiveRefreshSrc}\n${syncPullRebroadcastSrc}\n${syncCutoverSrc}\n${syncDeltaSrc}\n${syncDeltaPlannerSearchSrc}\n${syncDeltaSnapshotSrc}\n${syncDeltaMergeSrc}\n${syncDeltaMergeSearchSrc}\n${syncDeltaRegistrySearchSrc}\n${syncDeltaObservabilitySearchSrc}\n${syncDiagnosticsSearchSrc}\n${syncDiagnoseActionsSrc}\n${syncDiagnoseActionsContextSrc}\n${syncDiagnoseRelayActionsSrc}\n${syncDiagnoseIdentityActionsSrc}\n${syncDiagnoseCutoverActionsSrc}\n${syncDiagnoseRuntimeSrc}\n${syncDiagnoseUiSrc}\n${syncDiagnoseRenderSrc}\n${syncWindowBindingsSrc}`;
   const exportBlockIncludes = (src, names) => [...src.matchAll(/export\s+\{([^}]*)\};/g)]
     .some(([, block]) => names.every(name => new RegExp(`\\b${name}\\b`).test(block)));
 
@@ -496,6 +497,15 @@ await import('../js/settings.js');
       && syncDiagnoseActionsContextSrc.includes('export async function pushProfileForDiagnose')
       && syncDiagnoseActionsContextSrc.includes('export function enablePhase2CutoverForDiagnose')
       && syncDiagnoseActionsContextSrc.includes('export function disablePhase2CutoverForDiagnose'));
+  assert('sync-diagnose-runtime.js owns Sync Diagnose browser hooks',
+    syncDiagnoseRuntimeSrc.includes('export async function confirmSyncDiagnoseActionRuntime')
+      && syncDiagnoseRuntimeSrc.includes('showConfirmDialog')
+      && syncDiagnoseRelayActionsSrc.includes("from './sync-diagnose-runtime.js'")
+      && syncDiagnoseIdentityActionsSrc.includes("from './sync-diagnose-runtime.js'")
+      && syncDiagnoseCutoverActionsSrc.includes("from './sync-diagnose-runtime.js'")
+      && !/\bwindow(?:\.|\s*\[)/.test(syncDiagnoseRelayActionsSrc)
+      && !/\bwindow(?:\.|\s*\[)/.test(syncDiagnoseIdentityActionsSrc)
+      && !/\bwindow(?:\.|\s*\[)/.test(syncDiagnoseCutoverActionsSrc));
   assert('sync-diagnose-relay-actions.js owns relay Diagnose actions',
     syncDiagnoseRelayActionsSrc.includes('export async function confirmCompactRelay')
       && syncDiagnoseRelayActionsSrc.includes('export async function refreshRelayStorage')
@@ -517,6 +527,7 @@ await import('../js/settings.js');
     serviceWorkerSrc.includes("'/js/sync-diagnose-actions.js'"));
   assert('service worker precaches Sync Diagnose action helper modules',
     serviceWorkerSrc.includes("'/js/sync-diagnose-actions-context.js'")
+      && serviceWorkerSrc.includes("'/js/sync-diagnose-runtime.js'")
       && serviceWorkerSrc.includes("'/js/sync-diagnose-relay-actions.js'")
       && serviceWorkerSrc.includes("'/js/sync-diagnose-identity-actions.js'")
       && serviceWorkerSrc.includes("'/js/sync-diagnose-cutover-actions.js'"));
@@ -2042,8 +2053,9 @@ await import('../js/settings.js');
     /Phase 1 dual-write health/.test(deltaSearchSrc));
   assert('Diagnose Copy text includes ratio + cutover hint',
     /ratio \(delta:blob\)[\s\S]{0,200}Phase 2 cutover safe/.test(deltaSearchSrc));
-  assert('Reset window button confirms via showConfirmDialog',
-    /confirmResetDeltaTelemetry[\s\S]{0,1500}showConfirmDialog/.test(deltaSearchSrc));
+  assert('Reset telemetry button confirms via Sync Diagnose runtime adapter',
+    /confirmResetDeltaTelemetry[\s\S]{0,1500}confirmSyncDiagnoseActionRuntime/.test(syncDiagnoseCutoverActionsSrc)
+      && syncDiagnoseRuntimeSrc.includes('showConfirmDialog'));
   assert('Telemetry helpers exposed on window',
     /window[\s\S]{0,4000}getDeltaTelemetry,\s*\n\s*resetDeltaTelemetry,\s*\n\s*confirmResetDeltaTelemetry/.test(deltaSearchSrc));
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -91,6 +91,7 @@
     '/js/theme-runtime.js',
     '/js/schema.js',
     '/js/dna-window-bindings.js',
+    '/js/sync-diagnose-runtime.js',
   ];
 
   function assertServiceWorkerCache(sw) {

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -294,6 +294,7 @@
     "js/sync-diagnose-relay-actions.js",
     "js/sync-diagnose-actions.js",
     "js/sync-diagnose-render.js",
+    "js/sync-diagnose-runtime.js",
     "js/sync-diagnose-ui.js",
     "js/sync-diagnostics.js",
     "js/sync-schema.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -274,6 +274,7 @@
     "js/sync-diagnose-identity-actions.js",
     "js/sync-diagnose-relay-actions.js",
     "js/sync-diagnose-render.js",
+    "js/sync-diagnose-runtime.js",
     "js/sync-diagnose-ui.js",
     "js/sync-diagnostics-context.js",
     "js/sync-diagnostics-snapshot.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.88';
+self.APP_VERSION = '1.10.89';


### PR DESCRIPTION
## Summary
- add a `sync-diagnose-runtime.js` adapter for Sync Diagnose confirm-dialog browser hooks
- route cutover, relay, and identity Sync Diagnose actions through the adapter instead of direct `window.` calls
- register the runtime module in the service worker, module verification, and typecheck configs
- add focused runtime/source coverage and update sync source-shape tests
- lower quality baselines: `windowReferences` 299 -> 286 and `maxJsFileLines` 1513 -> 1511
- bump `version.js` to `1.10.89`

## Tests
- `node tests/test-sync-diagnose-runtime.js`
- `node tests/test-sync.js`
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot`
- `./run-tests.sh`
