### PR TITLE
[codex] Extract wearables detail runtime hooks

### DIFF
--- a/js/wearables-detail-modal.js
+++ b/js/wearables-detail-modal.js
@@ -18,6 +18,14 @@ import { formatValue, shortDate } from './wearables-formatters.js';
 import { _collectActiveChips, _renderNoteField, _renderTagChips, inputValueById, inputValueFromElement } from './wearables-manual-form-ui.js';
 import { renderBloodPressureChart } from './wearables-bp-detail-chart.js';
 import { openModalOverlay } from './modal-lifecycle.js';
+import {
+  closeWearableDetailModalRuntime,
+  confirmWearableDetailActionRuntime,
+  createWearableDetailChartRuntime,
+  hasWearableDetailChartRuntime,
+  navigateWearableDetailRuntime,
+  rememberWearableDetailModalTriggerRuntime,
+} from './wearables-detail-runtime.js';
 
 const WEARABLE_DETAIL_RANGES = [
   { key: '90d', days: 90, label: '90d', coverageSuffix: 'of last 90 days', emptyWindow: 'the last 90 days' },
@@ -75,7 +83,7 @@ export async function openWearableDetail(metricId, opts = {}) {
     return;
   }
 
-  if (!opts.fromRangeToggle) window.rememberModalTrigger?.();
+  if (!opts.fromRangeToggle) rememberWearableDetailModalTriggerRuntime();
 
   const rangeKey = getWearableDetailRange();
   const rangeDef = WEARABLE_DETAIL_RANGES.find(r => r.key === rangeKey) || WEARABLE_DETAIL_RANGES[0];
@@ -505,7 +513,7 @@ function _buildEMFSleepHint(metricId, m) {
 }
 
 function renderWearableChart(canvas, canon, m, series, manualSeries = []) {
-  if (!window.Chart || !isChartDateAdapterReady()) {
+  if (!hasWearableDetailChartRuntime() || !isChartDateAdapterReady()) {
     ensureChartJs().then(() => {
       const currentCanvas = document.getElementById(canvas.id);
       if (currentCanvas) renderWearableChart(currentCanvas, canon, m, series, manualSeries);
@@ -591,7 +599,7 @@ function renderWearableChart(canvas, canon, m, series, manualSeries = []) {
     });
   }
 
-  state.chartInstances['modal'] = new window.Chart(canvas, {
+  const chart = createWearableDetailChartRuntime(canvas, {
     type: 'line',
     data: { datasets },
     options: {
@@ -630,6 +638,7 @@ function renderWearableChart(canvas, canon, m, series, manualSeries = []) {
       },
     },
   });
+  if (chart) state.chartInstances['modal'] = chart;
 }
 
 export function openManualAddFromDetail(metricId, event) {
@@ -751,7 +760,7 @@ export async function saveManualEntryFromDetail(metricId, kind) {
     await refreshManualSummary(profileId);
     if (op !== _currentManualEntryOp(metricId)) return;
     showNotification?.('Saved', 'success');
-    if (window.navigate) window.navigate('dashboard');
+    navigateWearableDetailRuntime('dashboard');
     openWearableDetail(metricId);
   } catch (e) {
     showNotification?.(`Couldn't save: ${e.message}`, 'error', 4000);
@@ -760,10 +769,9 @@ export async function saveManualEntryFromDetail(metricId, kind) {
 
 export async function deleteManualEntryFromDetail(metricId, date) {
   const op = _bumpManualEntryOp(metricId);
-  if (typeof window.showConfirmDialog !== 'function') return;
   const canon = canonicalMetric(metricId);
   const label = canon?.label || metricId;
-  if (await window.showConfirmDialog(`Delete this ${label.toLowerCase()} reading from ${date}?`)) {
+  if (await confirmWearableDetailActionRuntime(`Delete this ${label.toLowerCase()} reading from ${date}?`)) {
     try {
       const { deleteManualMetric, refreshManualSummary } = await import('./wearables-manual.js');
       const profileId = getActiveProfileId();
@@ -776,12 +784,12 @@ export async function deleteManualEntryFromDetail(metricId, date) {
       await refreshManualSummary(profileId);
       if (op !== _currentManualEntryOp(metricId)) return;
       showNotification?.('Deleted', 'success');
-      if (window.navigate) window.navigate('dashboard');
+      navigateWearableDetailRuntime('dashboard');
       const stillHasMetric = !!state.importedData?.wearableSummary?.metrics?.[metricId];
       if (stillHasMetric) {
         openWearableDetail(metricId);
-      } else if (window.closeModal) {
-        window.closeModal();
+      } else {
+        closeWearableDetailModalRuntime();
       }
     } catch (e) {
       showNotification?.(`Couldn't delete: ${e.message}`, 'error', 4000);

--- a/js/wearables-detail-runtime.js
+++ b/js/wearables-detail-runtime.js
@@ -1,0 +1,52 @@
+// @ts-check
+// wearables-detail-runtime.js - Browser runtime adapters for wearable detail modal hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function rememberWearableDetailModalTriggerRuntime() {
+  getRuntimeFunction('rememberModalTrigger')?.();
+}
+
+export function hasWearableDetailChartRuntime() {
+  const runtime = getRuntimeWindow();
+  return typeof runtime?.Chart === 'function';
+}
+
+/**
+ * @param {HTMLCanvasElement} canvas
+ * @param {Record<string, unknown>} config
+ * @returns {unknown}
+ */
+export function createWearableDetailChartRuntime(canvas, config) {
+  const runtime = getRuntimeWindow();
+  const ChartCtor = runtime?.Chart;
+  return typeof ChartCtor === 'function' ? new ChartCtor(canvas, config) : null;
+}
+
+/** @param {string} [route] */
+export function navigateWearableDetailRuntime(route = 'dashboard') {
+  getRuntimeFunction('navigate')?.(route || 'dashboard');
+}
+
+export function closeWearableDetailModalRuntime() {
+  getRuntimeFunction('closeModal')?.();
+}
+
+/** @param {string} message */
+export async function confirmWearableDetailActionRuntime(message) {
+  const confirm = getRuntimeFunction('showConfirmDialog');
+  return confirm ? !!await confirm(message) : false;
+}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 286,
+  "windowReferences": 275,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -350,6 +350,7 @@ const APP_SHELL = [
   '/js/wearable-adapters.js',
   '/js/wearables.js',
   '/js/wearables-bp-detail-chart.js',
+  '/js/wearables-detail-runtime.js',
   '/js/wearables-detail-modal.js',
   '/js/wearables-formatters.js',
   '/js/wearables-manual-form-ui.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -182,6 +182,7 @@ const LEGACY_TESTS = [
   './test-import-drop-zone-runtime.js',
   './test-mobile-dashboard-runtime.js',
   './test-sync-diagnose-runtime.js',
+  './test-wearables-detail-runtime.js',
   './test-wearables-runtime.js',
   './test-wearables-settings-runtime.js',
   './test-dashboard-widget-runtime.js',

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -102,11 +102,13 @@ return (async function() {
   // Detail modal closing must return focus to the triggering element so
   // keyboard users don't land on <body> and lose their place. The wiring
   // is: rememberModalTrigger() captures activeElement on open,
-  // closeModal() restores it. Exposed on window for wearables.js to call.
+  // closeModal() restores it. Wearables detail opens route through a
+  // runtime adapter so the modal module stays browser-global free.
   const viewsSrc = await fetch('js/views.js').then(r => r.text());
   const markerDetailSrc = await fetch('js/marker-detail-modal.js').then(r => r.text());
   const dashboardWidgetsSrc = await fetch('js/dashboard-widgets.js').then(r => r.text());
   const wearablesDetailSrc = await fetch('js/wearables-detail-modal.js').then(r => r.text());
+  const wearablesDetailRuntimeSrc = await fetch('js/wearables-detail-runtime.js').then(r => r.text());
   assert('marker-detail-modal.js defines rememberModalTrigger', /function rememberModalTrigger\s*\(/.test(markerDetailSrc));
   assert('marker-detail-modal.js defines restoreModalTrigger', /function restoreModalTrigger\s*\(/.test(markerDetailSrc));
   assert('showDetailModal captures trigger before opening', /showDetailModal[\s\S]*?rememberModalTrigger\(\)/.test(markerDetailSrc));
@@ -116,7 +118,9 @@ return (async function() {
       /function closeModal\(\)[\s\S]{0,180}closeModalOverlay\('modal-overlay'\)/.test(markerDetailSrc));
   assert('rememberModalTrigger exported', markerDetailSrc.includes('export function rememberModalTrigger'));
   assert('rememberModalTrigger on window', /window\s*,\s*\{[\s\S]*?rememberModalTrigger/.test(viewsSrc));
-  assert('wearable detail modal captures trigger', wearablesDetailSrc.includes('window.rememberModalTrigger?.()'));
+  assert('wearable detail modal captures trigger',
+    wearablesDetailSrc.includes('rememberWearableDetailModalTriggerRuntime();') &&
+      /getRuntimeFunction\('rememberModalTrigger'\)\?\.\(\)/.test(wearablesDetailRuntimeSrc));
   assert('restoreModalTrigger guards against detached elements', /document\.contains\(el\)/.test(markerDetailSrc));
 
   // ═══════════════════════════════════════════════

--- a/tests/test-wearables-detail-runtime.js
+++ b/tests/test-wearables-detail-runtime.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// test-wearables-detail-runtime.js - Wearable detail modal runtime adapter behavior.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import './_node-shim.js';
+import {
+  closeWearableDetailModalRuntime,
+  confirmWearableDetailActionRuntime,
+  createWearableDetailChartRuntime,
+  hasWearableDetailChartRuntime,
+  navigateWearableDetailRuntime,
+  rememberWearableDetailModalTriggerRuntime,
+} from '../js/wearables-detail-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Wearables Detail Runtime Tests ===\n');
+
+const runtimeKeys = ['window', 'rememberModalTrigger', 'navigate', 'closeModal', 'showConfirmDialog', 'Chart'];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('window', globalThis);
+  setRuntimeValue('rememberModalTrigger', () => calls.push(['remember']));
+  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
+  setRuntimeValue('closeModal', () => calls.push(['close']));
+  setRuntimeValue('showConfirmDialog', async message => {
+    calls.push(['confirm', message]);
+    return message === 'delete';
+  });
+  setRuntimeValue('Chart', function Chart(canvas, config) {
+    this.canvas = canvas;
+    this.config = config;
+    calls.push(['chart', canvas.id, config.type]);
+  });
+
+  rememberWearableDetailModalTriggerRuntime();
+  navigateWearableDetailRuntime('dashboard');
+  closeWearableDetailModalRuntime();
+  const confirmed = await confirmWearableDetailActionRuntime('delete');
+  const cancelled = await confirmWearableDetailActionRuntime('keep');
+  const chart = createWearableDetailChartRuntime({ id: 'chart-modal' }, { type: 'line' });
+
+  assert('wearable detail runtime delegates shell hooks',
+    calls.some(call => call.join('|') === 'remember') &&
+      calls.some(call => call.join('|') === 'navigate|dashboard') &&
+      calls.some(call => call.join('|') === 'close') &&
+      calls.some(call => call.join('|') === 'confirm|delete') &&
+      confirmed === true &&
+      cancelled === false);
+  assert('wearable detail runtime constructs Chart instances',
+    hasWearableDetailChartRuntime() === true &&
+      chart?.canvas?.id === 'chart-modal' &&
+      chart?.config?.type === 'line' &&
+      calls.some(call => call.join('|') === 'chart|chart-modal|line'));
+
+  delete globalThis.showConfirmDialog;
+  delete globalThis.Chart;
+  const missingConfirm = await confirmWearableDetailActionRuntime('delete');
+  const missingChart = createWearableDetailChartRuntime({ id: 'chart-modal' }, { type: 'line' });
+  assert('wearable detail runtime handles missing optional hooks',
+    missingConfirm === false &&
+      hasWearableDetailChartRuntime() === false &&
+      missingChart === null);
+
+  delete globalThis.window;
+  const beforeNoWindowCalls = calls.length;
+  rememberWearableDetailModalTriggerRuntime();
+  navigateWearableDetailRuntime('dashboard');
+  closeWearableDetailModalRuntime();
+  const noWindowConfirm = await confirmWearableDetailActionRuntime('delete');
+  const noWindowChart = createWearableDetailChartRuntime({ id: 'chart-modal' }, { type: 'line' });
+  assert('wearable detail runtime no-ops safely when window is missing',
+    calls.length === beforeNoWindowCalls &&
+      noWindowConfirm === false &&
+      noWindowChart === null);
+
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const detailSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-modal.js'), 'utf8');
+  const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+  assert('wearable detail modal delegates browser globals through runtime adapter',
+    detailSrc.includes("from './wearables-detail-runtime.js'") &&
+      !/\bwindow(?:\.|\s*\[)/.test(detailSrc) &&
+      swSrc.includes("'/js/wearables-detail-runtime.js'"));
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -83,6 +83,7 @@ assert('cancelManualLog on window', typeof window.cancelManualLog === 'function'
 
 const wearablesSrc = await fetch('js/wearables.js').then(r => r.text());
 const wearablesDetailSrc = await fetch('js/wearables-detail-modal.js').then(r => r.text());
+const wearablesDetailRuntimeSrc = await fetch('js/wearables-detail-runtime.js').then(r => r.text());
 const manualFormUiSrc = await fetch('js/wearables-manual-form-ui.js').then(r => r.text());
 const wearablesSettingsSrc = await fetch('js/wearables-settings-panel.js').then(r => r.text());
 const inlineHandlerRe = /\bon(?:click|keydown|submit|change|input)=/;
@@ -295,15 +296,16 @@ try {
   const saveFn = wearablesDetailSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';
   const delFn = wearablesDetailSrc.match(/async function deleteManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';
   assert('saveManualEntryFromDetail re-renders dashboard strip',
-    /window\.navigate\([^)]*\)/.test(saveFn) && /['"]dashboard['"]/.test(saveFn));
+    /navigateWearableDetailRuntime\([^)]*dashboard/.test(saveFn));
   assert('deleteManualEntryFromDetail re-renders dashboard strip',
-    /window\.navigate\([^)]*\)/.test(delFn) && /['"]dashboard['"]/.test(delFn));
+    /navigateWearableDetailRuntime\([^)]*dashboard/.test(delFn));
   assert('deleteManualEntryFromDetail closes modal when last reading is removed',
-    /closeModal/.test(delFn));
+    /closeWearableDetailModalRuntime\(\)/.test(delFn));
 
   const handleDisconnectFn = wearablesSettingsSrc.match(/async function handleManualDisconnect[\s\S]*?\n\}\s*\n/)?.[0] || '';
   assert('deleteManualEntryFromDetail uses promise-style showConfirmDialog',
-    /await\s+window\.showConfirmDialog\(/.test(delFn));
+    /await\s+confirmWearableDetailActionRuntime\(/.test(delFn) &&
+      wearablesDetailRuntimeSrc.includes('showConfirmDialog'));
   assert('handleManualDisconnect uses promise-style showConfirmDialog',
     /await\s+confirmWearableSettingsAction\(/.test(handleDisconnectFn));
   assert('wearables settings panel routes dashboard refresh through runtime adapter',

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1821,6 +1821,7 @@ assert('Service-worker static cache lists wearables-manual.js',
   /\/js\/wearables-manual\.js/.test(swSrc));
 assert('Service-worker static cache lists extracted wearable detail modules',
   /\/js\/wearables-detail-modal\.js/.test(swSrc) &&
+  /\/js\/wearables-detail-runtime\.js/.test(swSrc) &&
   /\/js\/wearables-bp-detail-chart\.js/.test(swSrc) &&
   /\/js\/wearables-formatters\.js/.test(swSrc) &&
   /\/js\/wearables-manual-form-ui\.js/.test(swSrc));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -47,6 +47,7 @@
     '/js/context-card-lifestyle-runtime.js',
     '/js/context-card-lifestyle-editors.js',
     '/js/wearables-detail-modal.js',
+    '/js/wearables-detail-runtime.js',
     '/js/wearables-bp-detail-chart.js',
     '/js/wearables-formatters.js',
     '/js/wearables-manual-form-ui.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -224,6 +224,7 @@
     "js/wearables-apple-health.js",
     "js/wearables-connect.js",
     "js/wearables-bp-detail-chart.js",
+    "js/wearables-detail-runtime.js",
     "js/wearables-detail-modal.js",
     "js/wearables-fitbit-auth.js",
     "js/wearables-fitbit.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -306,6 +306,7 @@
     "js/wearable-adapters.js",
     "js/wearables-apple-health.js",
     "js/wearables-connect.js",
+    "js/wearables-detail-runtime.js",
     "js/wearables-detail-modal.js",
     "js/wearables-fitbit-auth.js",
     "js/wearables-fitbit.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.89';
+self.APP_VERSION = '1.10.90';


### PR DESCRIPTION
## Summary
- Add js/wearables-detail-runtime.js for wearable detail modal shell hooks, Chart construction, dashboard navigation, close-modal, and confirm-dialog calls.
- Route js/wearables-detail-modal.js through the runtime adapter so it has no direct window references.
- Register the new runtime in service worker, module verification, and typecheck configs.
- Add focused runtime coverage and update legacy/source assertions.
- Lower the window reference quality baseline from 286 to 275 and bump APP_VERSION to 1.10.90.

## Tests
- node tests/test-wearables-detail-runtime.js
- node tests/test-wearables-manual.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- node tests/test-wearables.js
- node tests/verify-modules.js
- npm test -- --reporter=dot
- npx playwright test tests/playwright/core-browser-flows.spec.js --project=chromium
- ./run-tests.sh