### PR TITLE
[codex] Extract sync pull refresh runtime hooks

### DIFF
--- a/js/sync-pull-active-refresh-runtime.js
+++ b/js/sync-pull-active-refresh-runtime.js
@@ -1,0 +1,42 @@
+// @ts-check
+// sync-pull-active-refresh-runtime.js - Browser runtime adapters for active sync pull refresh hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function refreshPulledChatRuntime() {
+  getRuntimeFunction('loadChatThreads')?.();
+  getRuntimeFunction('ensureActiveThread')?.();
+  getRuntimeFunction('renderThreadList')?.();
+  getRuntimeFunction('loadChatHistory')?.();
+}
+
+export function rebuildPulledSidebarRuntime() {
+  try { getRuntimeFunction('buildSidebar')?.(); } catch {}
+}
+
+/**
+ * @param {string} route
+ * @param {Record<string, unknown> | undefined} [options]
+ */
+export function navigatePulledActiveViewRuntime(route, options) {
+  getRuntimeFunction('navigate')?.(route, options);
+}
+
+export function dispatchSyncAppliedRuntime() {
+  const runtime = getRuntimeWindow();
+  if (!runtime || typeof runtime.CustomEvent !== 'function' || typeof runtime.dispatchEvent !== 'function') return;
+  try { runtime.dispatchEvent(new runtime.CustomEvent('labcharts-sync-applied')); } catch (_) {}
+}

--- a/js/sync-pull-active-refresh.js
+++ b/js/sync-pull-active-refresh.js
@@ -4,6 +4,12 @@
 import { state } from './state.js';
 import { showNotification } from './utils.js';
 import { migrateProfileData } from './profile.js';
+import {
+  dispatchSyncAppliedRuntime,
+  navigatePulledActiveViewRuntime,
+  rebuildPulledSidebarRuntime,
+  refreshPulledChatRuntime,
+} from './sync-pull-active-refresh-runtime.js';
 
 const UPDATE_TOAST_COOLDOWN_MS = 2500;
 let lastUpdateToastProfileId = null;
@@ -57,10 +63,7 @@ export function refreshActiveProfileAfterPull({
 
   // Reload chat threads + active thread messages into memory and re-render.
   if (chatApplied) {
-    window.loadChatThreads?.();
-    window.ensureActiveThread?.();
-    window.renderThreadList?.();
-    window.loadChatHistory?.(); // reloads state.chatHistory from localStorage + renders
+    refreshPulledChatRuntime();
   }
 
   // Re-render whatever view the user is on so the merged state becomes
@@ -82,7 +85,7 @@ export function refreshActiveProfileAfterPull({
   // those entries appear/disappear without waiting for the next
   // local action. Cheap (~1ms) and doesn't disturb in-progress
   // forms in the main pane.
-  if (window.buildSidebar) try { window.buildSidebar(); } catch (e) {}
+  rebuildPulledSidebarRuntime();
 
   if (!shouldRefreshVisibleData) {
     // Profile-field / chat / displayPrefs handlers above already
@@ -91,7 +94,7 @@ export function refreshActiveProfileAfterPull({
     // survives duplicate no-op pull triggers.
     dbg(debug, `Pulled active profile ${profileId.slice(0,8)} — no visible data change, skipping re-render of '${cat}'`);
   } else {
-    window.navigate?.(cat, hasOpenModalOverlay() ? { preserveScroll: true } : undefined);
+    navigatePulledActiveViewRuntime(cat, hasOpenModalOverlay() ? { preserveScroll: true } : undefined);
     if (cat !== 'dashboard' && shouldShowUpdateToast(profileId)) {
       showNotification('Data updated from another device', 'success');
     }
@@ -103,9 +106,7 @@ export function refreshActiveProfileAfterPull({
   // navigate() above already rebuilt the inline page; this
   // event covers floating modals that aren't part of the main
   // tree. Greptile PR #178 P2 comment.
-  if (shouldRefreshVisibleData && typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
-    try { window.dispatchEvent(new CustomEvent('labcharts-sync-applied')); } catch (_) {}
-  }
+  if (shouldRefreshVisibleData) dispatchSyncAppliedRuntime();
 
   return true;
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 275,
+  "windowReferences": 266,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -328,6 +328,7 @@ const APP_SHELL = [
   '/js/sync-reconcile.js',
   '/js/sync-pull-merge.js',
   '/js/sync-pull-maintenance.js',
+  '/js/sync-pull-active-refresh-runtime.js',
   '/js/sync-pull-active-refresh.js',
   '/js/sync-pull-rebroadcast.js',
   '/js/sync-pull.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -133,6 +133,7 @@ const LEGACY_TESTS = [
   './test-dashboard-genetics-empty.js',
   './test-sync.js',
   './test-sync-modal-refresh.js',
+  './test-sync-pull-active-refresh-runtime.js',
   // Batch 17 — recommendations module.
   './test-recommendations.js',
   // Batch 19 — DNA-aware recommendation integration + image utils

--- a/tests/test-sync-pull-active-refresh-runtime.js
+++ b/tests/test-sync-pull-active-refresh-runtime.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// test-sync-pull-active-refresh-runtime.js - Active sync pull refresh runtime adapter behavior.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import './_node-shim.js';
+import {
+  dispatchSyncAppliedRuntime,
+  navigatePulledActiveViewRuntime,
+  rebuildPulledSidebarRuntime,
+  refreshPulledChatRuntime,
+} from '../js/sync-pull-active-refresh-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Sync Pull Active Refresh Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'loadChatThreads',
+  'ensureActiveThread',
+  'renderThreadList',
+  'loadChatHistory',
+  'buildSidebar',
+  'navigate',
+  'CustomEvent',
+  'dispatchEvent',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('window', globalThis);
+  setRuntimeValue('loadChatThreads', () => calls.push(['loadChatThreads']));
+  setRuntimeValue('ensureActiveThread', () => calls.push(['ensureActiveThread']));
+  setRuntimeValue('renderThreadList', () => calls.push(['renderThreadList']));
+  setRuntimeValue('loadChatHistory', () => calls.push(['loadChatHistory']));
+  setRuntimeValue('buildSidebar', () => calls.push(['buildSidebar']));
+  setRuntimeValue('navigate', (route, options) => calls.push(['navigate', route, options?.preserveScroll]));
+  setRuntimeValue('CustomEvent', class CustomEvent {
+    constructor(type) { this.type = type; }
+  });
+  setRuntimeValue('dispatchEvent', event => {
+    calls.push(['dispatchEvent', event.type]);
+    return true;
+  });
+
+  refreshPulledChatRuntime();
+  rebuildPulledSidebarRuntime();
+  navigatePulledActiveViewRuntime('labs', { preserveScroll: true });
+  dispatchSyncAppliedRuntime();
+
+  assert('sync pull active refresh runtime delegates shell hooks',
+    calls.map(call => call.join('|')).join(',') === [
+      'loadChatThreads',
+      'ensureActiveThread',
+      'renderThreadList',
+      'loadChatHistory',
+      'buildSidebar',
+      'navigate|labs|true',
+      'dispatchEvent|labcharts-sync-applied',
+    ].join(','));
+
+  setRuntimeValue('buildSidebar', () => { throw new Error('sidebar boom'); });
+  assert('sync pull active refresh runtime guards sidebar rebuild failures',
+    rebuildPulledSidebarRuntime() === undefined);
+
+  delete globalThis.window;
+  const beforeNoWindowCalls = calls.length;
+  refreshPulledChatRuntime();
+  rebuildPulledSidebarRuntime();
+  navigatePulledActiveViewRuntime('labs', { preserveScroll: true });
+  dispatchSyncAppliedRuntime();
+  assert('sync pull active refresh runtime no-ops safely when window is missing',
+    calls.length === beforeNoWindowCalls);
+
+  setRuntimeValue('window', globalThis);
+  delete globalThis.CustomEvent;
+  delete globalThis.dispatchEvent;
+  dispatchSyncAppliedRuntime();
+  assert('sync pull active refresh runtime skips event dispatch when unsupported',
+    calls.length === beforeNoWindowCalls);
+
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const refreshSrc = fs.readFileSync(path.join(root, 'js/sync-pull-active-refresh.js'), 'utf8');
+  const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+  assert('sync pull active refresh delegates browser globals through runtime adapter',
+    refreshSrc.includes("from './sync-pull-active-refresh-runtime.js'") &&
+      !/\bwindow(?:\.|\s*\[)/.test(refreshSrc) &&
+      swSrc.includes("'/js/sync-pull-active-refresh-runtime.js'"));
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -107,6 +107,7 @@ await import('../js/settings.js');
   const syncReconcileSrc = await fetchWithRetry('js/sync-reconcile.js');
   const syncPullMergeSrc = await fetchWithRetry('js/sync-pull-merge.js');
   const syncPullMaintenanceSrc = await fetchWithRetry('js/sync-pull-maintenance.js');
+  const syncPullActiveRefreshRuntimeSrc = await fetchWithRetry('js/sync-pull-active-refresh-runtime.js');
   const syncPullActiveRefreshSrc = await fetchWithRetry('js/sync-pull-active-refresh.js');
   const syncPullRebroadcastSrc = await fetchWithRetry('js/sync-pull-rebroadcast.js');
   const syncPullSrc = await fetchWithRetry('js/sync-pull.js');
@@ -657,10 +658,20 @@ await import('../js/settings.js');
       && syncPullActiveRefreshSrc.includes('shouldRefreshVisibleData')
       && syncPullActiveRefreshSrc.includes('hasOpenModalOverlay')
       && syncPullActiveRefreshSrc.includes('preserveScroll: true')
-      && syncPullActiveRefreshSrc.includes('window.navigate?.(cat,')
-      && syncPullActiveRefreshSrc.includes("new CustomEvent('labcharts-sync-applied')"));
+      && syncPullActiveRefreshSrc.includes('navigatePulledActiveViewRuntime(cat,')
+      && syncPullActiveRefreshSrc.includes('dispatchSyncAppliedRuntime()')
+      && syncPullActiveRefreshRuntimeSrc.includes("new runtime.CustomEvent('labcharts-sync-applied')"));
   assert('service worker precaches sync-pull-active-refresh.js',
     serviceWorkerSrc.includes("'/js/sync-pull-active-refresh.js'"));
+  assert('sync-pull-active-refresh-runtime.js owns active refresh browser hooks',
+    syncPullActiveRefreshSrc.includes("from './sync-pull-active-refresh-runtime.js'")
+      && !/\bwindow(?:\.|\s*\[)/.test(syncPullActiveRefreshSrc)
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('loadChatThreads')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('buildSidebar')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('navigate')?.(route, options)")
+      && syncPullActiveRefreshRuntimeSrc.includes("runtime.dispatchEvent(new runtime.CustomEvent('labcharts-sync-applied'))"));
+  assert('service worker precaches sync-pull-active-refresh-runtime.js',
+    serviceWorkerSrc.includes("'/js/sync-pull-active-refresh-runtime.js'"));
   assert('modal refresh dirty-form guard is shared',
     utilsSrc.includes('export function hasDirtyFormFields')
       && utilsSrc.includes("querySelectorAll('input, textarea, select')")
@@ -757,7 +768,8 @@ await import('../js/settings.js');
       notesSrc.includes("openModalOverlay(overlay, { initialFocus: '#note-textarea', focusDelay: 50 })") &&
       notesSrc.includes('window.rememberModalTrigger?.()'));
   assert('active-profile sync broadcasts shared modal refresh event without marker special-casing',
-    syncPullActiveRefreshSrc.includes("new CustomEvent('labcharts-sync-applied')")
+    syncPullActiveRefreshSrc.includes('dispatchSyncAppliedRuntime()')
+      && syncPullActiveRefreshRuntimeSrc.includes("new runtime.CustomEvent('labcharts-sync-applied')")
       && !syncPullActiveRefreshSrc.includes('marker-detail-modal')
       && !syncPullActiveRefreshSrc.includes('showDetailModal(openId)')
       && !syncPullActiveRefreshSrc.includes('refreshOpenMarkerDetailModal'));
@@ -768,7 +780,7 @@ await import('../js/settings.js');
       && syncPullMergeSrc.includes('const localDataChanged = !importedDataMatches(localImportedBeforeMerge, merged)')
       && syncPullActiveRefreshSrc.includes('UPDATE_TOAST_COOLDOWN_MS')
       && syncPullActiveRefreshSrc.includes('shouldShowUpdateToast(profileId)')
-      && /if\s*\(shouldRefreshVisibleData[\s\S]{0,250}dispatchEvent\(new CustomEvent\('labcharts-sync-applied'\)/.test(syncPullActiveRefreshSrc));
+      && /if\s*\(shouldRefreshVisibleData\)\s*dispatchSyncAppliedRuntime\(\)/.test(syncPullActiveRefreshSrc));
   assert('sync-pull-rebroadcast.js owns pull-side rebroadcast scheduling',
     syncPullRebroadcastSrc.includes('export function maybeScheduleRebroadcast')
       && syncPullRebroadcastSrc.includes('consumeRebroadcastBudget(profileId)')
@@ -1323,7 +1335,9 @@ await import('../js/settings.js');
   // v1.7.4: pull re-renders whatever view the user is on, not just dashboard
   // (so a Light & Sun page picks up newly-merged sun sessions immediately
   // instead of just showing a "Data updated" toast).
-  assert('Pull re-renders the active view', syncPullActiveRefreshSrc.includes('window.navigate?.(cat,'));
+  assert('Pull re-renders the active view',
+    syncPullActiveRefreshSrc.includes('navigatePulledActiveViewRuntime(cat,')
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('navigate')?.(route, options)"));
   assert('Pull calls migrateProfileData', syncPullActiveRefreshSrc.includes('migrateProfileData(state.importedData)'));
   assert('enableSync pulls before first enable push to avoid publishing stale local state',
     /await forcePull\(\)[\s\S]{0,300}await pushAllProfiles\(\)/.test(syncLifecycleSrc));
@@ -1484,8 +1498,11 @@ await import('../js/settings.js');
     syncPullSrc.includes('const chatApplied = chatData ? await applyChatData(profileId, chatData) : false')
       && syncPullActiveRefreshSrc.includes('if (chatApplied)'));
   assert('active chat thread is reselected after remote thread deletion',
-    syncPullActiveRefreshSrc.includes('window.loadChatThreads?.();')
-      && syncPullActiveRefreshSrc.includes('window.ensureActiveThread?.();'));
+    syncPullActiveRefreshSrc.includes('refreshPulledChatRuntime();')
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('loadChatThreads')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('ensureActiveThread')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('renderThreadList')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('loadChatHistory')?.()"));
   {
     const prevProfileId = state.currentProfile;
     const profileId = 'syncapplydel';
@@ -2837,7 +2854,8 @@ await import('../js/settings.js');
   // refresh the page to see a Genetics nav entry land from a peer's DNA
   // import. Lives in sync-pull-active-refresh.js's active-profile post-merge block.
   assert('onSyncReceived rebuilds sidebar after every pull (catches nav items gated on per-row data)',
-    /profileId\s*!==\s*state\.currentProfile[\s\S]{0,2400}window\.buildSidebar[\s\S]{0,1200}shouldRefreshVisibleData/.test(deltaSearchSrc));
+    /profileId\s*!==\s*state\.currentProfile[\s\S]{0,2400}rebuildPulledSidebarRuntime\(\)[\s\S]{0,1200}shouldRefreshVisibleData/.test(deltaSearchSrc)
+      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('buildSidebar')?.()"));
 
   const localWithSnps = {
     genetics: {

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -93,6 +93,7 @@
     '/js/schema.js',
     '/js/dna-window-bindings.js',
     '/js/sync-diagnose-runtime.js',
+    '/js/sync-pull-active-refresh-runtime.js',
   ];
 
   function assertServiceWorkerCache(sw) {

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -320,6 +320,7 @@
     "js/sync-init.js",
     "js/sync-lifecycle.js",
     "js/sync-runtime.js",
+    "js/sync-pull-active-refresh-runtime.js",
     "js/sync-pull-active-refresh.js",
     "js/sync-pull-maintenance.js",
     "js/sync-pull-merge.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -280,6 +280,7 @@
     "js/sync-diagnostics-snapshot.js",
     "js/sync-diagnostics-text.js",
     "js/sync-diagnostics.js",
+    "js/sync-pull-active-refresh-runtime.js",
     "js/sync-pull-active-refresh.js",
     "js/sync-pull-maintenance.js",
     "js/sync-pull-merge.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.90';
+self.APP_VERSION = '1.10.91';


### PR DESCRIPTION
## Summary
- Add `sync-pull-active-refresh-runtime.js` for active pull refresh chat, sidebar, navigation, and `labcharts-sync-applied` browser hooks.
- Route `sync-pull-active-refresh.js` through the runtime adapter so the module no longer owns direct `window` references.
- Register the adapter in the service worker/module/typecheck lists, update source/runtime coverage, lower the quality baseline to `266` window references, and bump `APP_VERSION` to `1.10.91`.

## Tests
- `node tests/test-sync-pull-active-refresh-runtime.js`
- `node tests/test-sync-modal-refresh.js`
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `npm test -- --reporter=dot`
- `npx playwright test tests/playwright/sync-pull-refresh-browser-coverage.spec.js --project=chromium`
- `./run-tests.sh`