### PR TITLE
[codex] Extract onboarding runtime hooks

### DIFF
--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -1,0 +1,64 @@
+// @ts-check
+// onboarding-view-runtime.js - Browser runtime adapters for dashboard onboarding hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/** @param {unknown} data */
+export function rebuildOnboardingSidebarRuntime(data) {
+  getRuntimeFunction('buildSidebar')?.(data);
+}
+
+/**
+ * @param {string} route
+ * @param {unknown} data
+ * @param {Function | null} [preferredNavigate]
+ */
+export function navigateOnboardingRuntime(route, data, preferredNavigate = null) {
+  const navigate = typeof preferredNavigate === 'function'
+    ? preferredNavigate
+    : getRuntimeFunction('navigate');
+  navigate?.(route, data);
+}
+
+export function openOnboardingChatPanelRuntime() {
+  const openChatPanel = getRuntimeFunction('openChatPanel');
+  return openChatPanel ? Promise.resolve(openChatPanel()) : null;
+}
+
+export function openOnboardingProviderChatRuntime() {
+  const openChatPanel = getRuntimeFunction('openChatPanel');
+  if (openChatPanel) {
+    openChatPanel();
+    return true;
+  }
+  const toggleChatPanel = getRuntimeFunction('toggleChatPanel');
+  if (toggleChatPanel) {
+    toggleChatPanel();
+    return true;
+  }
+  return false;
+}
+
+export function createOnboardingChatThreadRuntime() {
+  const createNewThread = getRuntimeFunction('createNewThread');
+  if (!createNewThread) return false;
+  createNewThread();
+  return true;
+}
+
+export function renderOnboardingChatMessagesRuntime() {
+  getRuntimeFunction('renderChatMessages')?.();
+}

--- a/js/onboarding-view.js
+++ b/js/onboarding-view.js
@@ -6,6 +6,14 @@ import { getActiveData, updateHeaderDates } from './data.js';
 import { profileStorageKey, setProfileSex, setProfileDob } from './profile.js';
 import { hasAIProvider } from './api.js';
 import { escapeAttr, showNotification } from './utils.js';
+import {
+  createOnboardingChatThreadRuntime,
+  navigateOnboardingRuntime,
+  openOnboardingChatPanelRuntime,
+  openOnboardingProviderChatRuntime,
+  rebuildOnboardingSidebarRuntime,
+  renderOnboardingChatMessagesRuntime,
+} from './onboarding-view-runtime.js';
 
 let _navigate = null;
 let _onboardingActionsInstalled = false;
@@ -123,9 +131,9 @@ export function completeOnboardingProfile() {
   if (sex) { state.profileSex = sex; setProfileSex(state.currentProfile, sex); }
   if (dob) { state.profileDob = dob; setProfileDob(state.currentProfile, dob); }
   const data = getActiveData();
-  window.buildSidebar(data);
+  rebuildOnboardingSidebarRuntime(data);
   updateHeaderDates(data);
-  (_navigate || window.navigate)?.('dashboard', data);
+  navigateOnboardingRuntime('dashboard', data, _navigate);
   showNotification("Profile set up \u2014 you're all set!", 'success');
 }
 
@@ -189,14 +197,15 @@ export function setOnboardingFocus(mode) {
     const cards = document.querySelector('.profile-context-cards');
     if (cards) {
       setTimeout(() => cards.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100);
-    } else if (window.openChatPanel) {
-      const appWindow = /** @type {any} */ (window);
+    } else {
+      const openChatPanel = openOnboardingChatPanelRuntime();
+      if (!openChatPanel) return;
       body.classList.remove('cards-focus');
-      Promise.resolve(appWindow.openChatPanel()).then(() => {
-        if (!document.querySelector('#chat-panel .chat-context-cards') && state.chatHistory.length > 0 && appWindow.createNewThread) {
-          appWindow.createNewThread();
+      openChatPanel.then(() => {
+        if (!document.querySelector('#chat-panel .chat-context-cards') && state.chatHistory.length > 0 && createOnboardingChatThreadRuntime()) {
+          // Thread creation re-renders the empty-state card set.
         } else {
-          window.renderChatMessages?.();
+          renderOnboardingChatMessagesRuntime();
         }
         setTimeout(() => {
           document.querySelector('#chat-panel .chat-context-cards')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -213,7 +222,6 @@ export function openChatProviderQuiz() {
   localStorage.removeItem(skipKey);
   sessionStorage.setItem(`chat-onboard-provider-requested-${state.currentProfile}`, '1');
   sessionStorage.removeItem(`chat-onboard-provider-branch-${state.currentProfile}`);
-  if (window.openChatPanel) window.openChatPanel();
-  else if (window.toggleChatPanel) window.toggleChatPanel();
-  if (window.renderChatMessages) window.renderChatMessages();
+  openOnboardingProviderChatRuntime();
+  renderOnboardingChatMessagesRuntime();
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 266,
+  "windowReferences": 256,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -125,6 +125,7 @@ const APP_SHELL = [
   '/js/context-card-lifestyle-runtime.js',
   '/js/context-card-lifestyle-editors.js',
   '/js/focus-card.js',
+  '/js/onboarding-view-runtime.js',
   '/js/onboarding-view.js',
   '/js/emf-facade.js',
   '/js/emf.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -134,6 +134,7 @@ const LEGACY_TESTS = [
   './test-sync.js',
   './test-sync-modal-refresh.js',
   './test-sync-pull-active-refresh-runtime.js',
+  './test-onboarding-view-runtime.js',
   // Batch 17 — recommendations module.
   './test-recommendations.js',
   // Batch 19 — DNA-aware recommendation integration + image utils

--- a/tests/test-onboarding-view-runtime.js
+++ b/tests/test-onboarding-view-runtime.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// test-onboarding-view-runtime.js - Dashboard onboarding runtime adapter behavior.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import './_node-shim.js';
+import {
+  createOnboardingChatThreadRuntime,
+  navigateOnboardingRuntime,
+  openOnboardingChatPanelRuntime,
+  openOnboardingProviderChatRuntime,
+  rebuildOnboardingSidebarRuntime,
+  renderOnboardingChatMessagesRuntime,
+} from '../js/onboarding-view-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Onboarding View Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'buildSidebar',
+  'navigate',
+  'openChatPanel',
+  'toggleChatPanel',
+  'createNewThread',
+  'renderChatMessages',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('window', globalThis);
+  setRuntimeValue('buildSidebar', data => calls.push(['buildSidebar', data?.id]));
+  setRuntimeValue('navigate', (route, data) => calls.push(['navigate', route, data?.id]));
+  setRuntimeValue('openChatPanel', () => {
+    calls.push(['openChatPanel']);
+    return 'opened';
+  });
+  setRuntimeValue('toggleChatPanel', () => calls.push(['toggleChatPanel']));
+  setRuntimeValue('createNewThread', () => calls.push(['createNewThread']));
+  setRuntimeValue('renderChatMessages', () => calls.push(['renderChatMessages']));
+
+  rebuildOnboardingSidebarRuntime({ id: 'sidebar-data' });
+  navigateOnboardingRuntime('labs', { id: 'fallback-data' });
+  navigateOnboardingRuntime('dashboard', { id: 'preferred-data' }, (route, data) => calls.push(['preferredNavigate', route, data.id]));
+  const openResult = await openOnboardingChatPanelRuntime();
+  const providerOpened = openOnboardingProviderChatRuntime();
+  const createdThread = createOnboardingChatThreadRuntime();
+  renderOnboardingChatMessagesRuntime();
+
+  assert('onboarding runtime delegates shell and chat hooks',
+    openResult === 'opened' &&
+      providerOpened === true &&
+      createdThread === true &&
+      calls.map(call => call.join('|')).join(',') === [
+        'buildSidebar|sidebar-data',
+        'navigate|labs|fallback-data',
+        'preferredNavigate|dashboard|preferred-data',
+        'openChatPanel',
+        'openChatPanel',
+        'createNewThread',
+        'renderChatMessages',
+      ].join(','));
+
+  delete globalThis.openChatPanel;
+  assert('onboarding provider chat falls back to toggle',
+    openOnboardingProviderChatRuntime() === true &&
+      calls.at(-1)?.join('|') === 'toggleChatPanel');
+
+  delete globalThis.toggleChatPanel;
+  assert('onboarding provider chat reports unavailable shell hooks',
+    openOnboardingProviderChatRuntime() === false);
+
+  delete globalThis.createNewThread;
+  assert('onboarding runtime reports unavailable thread creation',
+    createOnboardingChatThreadRuntime() === false);
+
+  delete globalThis.window;
+  const beforeNoWindowCalls = calls.length;
+  rebuildOnboardingSidebarRuntime({ id: 'ignored' });
+  navigateOnboardingRuntime('labs', { id: 'ignored' });
+  assert('onboarding runtime no-ops safely when window is missing',
+    openOnboardingChatPanelRuntime() === null &&
+      openOnboardingProviderChatRuntime() === false &&
+      createOnboardingChatThreadRuntime() === false &&
+      renderOnboardingChatMessagesRuntime() === undefined &&
+      calls.length === beforeNoWindowCalls);
+
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const onboardingSrc = fs.readFileSync(path.join(root, 'js/onboarding-view.js'), 'utf8');
+  const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
+  assert('onboarding view delegates browser globals through runtime adapter',
+    onboardingSrc.includes("from './onboarding-view-runtime.js'") &&
+      !/\bwindow(?:\.|\s*\[)/.test(onboardingSrc) &&
+      swSrc.includes("'/js/onboarding-view-runtime.js'"));
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -30,6 +30,7 @@ const chatRenderSrc = read('js/chat-render.js');
 const chatSendSrc = read('js/chat-send.js');
 const labCtxSrc = read('js/lab-context.js');
 const onboardingViewSrc = read('js/onboarding-view.js');
+const onboardingRuntimeSrc = read('js/onboarding-view-runtime.js');
 
   assert('No sentinel return string', !labCtxSrc.includes("return 'No lab data is currently loaded for this profile.'"),
     'The old sentinel early-return should be removed');
@@ -292,7 +293,8 @@ const onboardingViewSrc = read('js/onboarding-view.js');
       !chatEmptyStateSrc.includes('${!hasAIProvider() ? `<div class="chat-context-cards"'),
     'Context cards should stay available inside chat even after AI is connected');
   assert('Card onboarding focus opens card UI instead of AI prompt prefill',
-    onboardingViewSrc.includes('window.openChatPanel()') &&
+    onboardingViewSrc.includes('openOnboardingChatPanelRuntime()') &&
+      onboardingRuntimeSrc.includes("getRuntimeFunction('openChatPanel')") &&
       onboardingViewSrc.includes('chat-onboard-force-context-cards') &&
       chatEmptyStateSrc.includes('forceContextCards') &&
       onboardingViewSrc.includes('#chat-panel .chat-context-cards') &&

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -65,6 +65,7 @@
     '/js/client-list-runtime.js',
     '/js/views-router-runtime.js',
     '/js/focus-card.js',
+    '/js/onboarding-view-runtime.js',
     '/js/onboarding-view.js',
     '/js/marker-detail-modal.js',
     '/js/marker-detail-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -164,6 +164,7 @@
     "js/mobile-dashboard-runtime.js",
     "js/modal-lifecycle.js",
     "js/nav.js",
+    "js/onboarding-view-runtime.js",
     "js/onboarding-view.js",
     "js/pdf-import-ai-utils.js",
     "js/pdf-import-marker-mapping.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -162,6 +162,7 @@
     "js/nav.js",
     "js/notes.js",
     "js/nostr-discovery.js",
+    "js/onboarding-view-runtime.js",
     "js/onboarding-view.js",
     "js/pdf-import.js",
     "js/pdf-import-marker-mapping.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.91';
+self.APP_VERSION = '1.10.92';


### PR DESCRIPTION
## Summary
- Add `onboarding-view-runtime.js` for dashboard onboarding shell/chat hooks: sidebar rebuild, navigation, chat panel open/toggle, thread creation, and chat rendering.
- Route `onboarding-view.js` through the runtime adapter so the view no longer owns direct `window` references.
- Register the adapter in the service worker/module/typecheck lists, update pre-lab/runtime coverage, lower the quality baseline to `256` window references, and bump `APP_VERSION` to `1.10.92`.

## Tests
- `node tests/test-onboarding-view-runtime.js`
- `node tests/test-prelab.js`
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-integration-batch2.js`
- `npm test -- --reporter=dot`
- `./run-tests.sh`