### PR TITLE
[codex] Extract API runtime hooks

### DIFF
--- a/js/api-runtime.js
+++ b/js/api-runtime.js
@@ -1,0 +1,42 @@
+// @ts-check
+// api-runtime.js - Browser runtime adapters for AI provider orchestration.
+
+function getApiRuntime() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+export function getApiLocationOriginRuntime() {
+  return getApiRuntime()?.location?.origin || '';
+}
+
+export function getApiLocationPathnameRuntime() {
+  return getApiRuntime()?.location?.pathname || '';
+}
+
+/**
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function setApiLocationHrefRuntime(url) {
+  const runtime = getApiRuntime();
+  if (!runtime?.location) return false;
+  runtime.location.href = url;
+  return true;
+}
+
+export function getOllamaConfigRuntime() {
+  const runtime = getApiRuntime();
+  if (!runtime || typeof runtime.getOllamaConfig !== 'function') {
+    throw new Error('Ollama config runtime is unavailable.');
+  }
+  return runtime.getOllamaConfig();
+}
+
+export function showOpenRouterInsufficientBalanceDialogRuntime() {
+  const runtime = getApiRuntime();
+  if (!runtime?.showInsufficientBalanceDialog) return false;
+  try { runtime.showInsufficientBalanceDialog(); } catch {}
+  return true;
+}

--- a/js/api.js
+++ b/js/api.js
@@ -83,6 +83,13 @@ import {
   validateOpenRouterKey,
   validateVeniceKey,
 } from './api-models.js';
+import {
+  getApiLocationOriginRuntime,
+  getApiLocationPathnameRuntime,
+  getOllamaConfigRuntime,
+  setApiLocationHrefRuntime,
+  showOpenRouterInsufficientBalanceDialogRuntime,
+} from './api-runtime.js';
 
 /** @typedef {Window & typeof globalThis & {
  *   _veniceE2EE?: any,
@@ -259,10 +266,10 @@ export async function startOpenRouterOAuth() {
   if (_isValidAIProvider(previousProvider)) sessionStorage.setItem(OPENROUTER_OAUTH_PREVIOUS_PROVIDER_KEY, previousProvider);
   sessionStorage.setItem('or_pkce_verifier', codeVerifier);
   sessionStorage.setItem('or_oauth_state', `sha256:${stateDigest}`);
-  const callbackUrl = window.location.origin + window.location.pathname;
+  const callbackUrl = getApiLocationOriginRuntime() + getApiLocationPathnameRuntime();
   // PKCE verifier-mismatch alone catches code-injection but not login-CSRF;
   // `state` binds the redirect to the tab that initiated it.
-  window.location.href = 'https://openrouter.ai/auth?callback_url=' + encodeURIComponent(callbackUrl) + '&code_challenge=' + encodeURIComponent(codeChallenge) + '&code_challenge_method=S256&state=' + encodeURIComponent(state);
+  setApiLocationHrefRuntime('https://openrouter.ai/auth?callback_url=' + encodeURIComponent(callbackUrl) + '&code_challenge=' + encodeURIComponent(codeChallenge) + '&code_challenge_method=S256&state=' + encodeURIComponent(state));
 }
 
 export function rememberOpenRouterOAuthPreviousProvider(provider = getAIProvider()) {
@@ -316,7 +323,7 @@ export async function exchangeOpenRouterCode(code, returnedState) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'HTTP-Referer': window.location.origin,
+      'HTTP-Referer': getApiLocationOriginRuntime(),
       'X-Title': 'getbased'
     },
     body: JSON.stringify({ code, code_verifier: codeVerifier, code_challenge_method: 'S256' })
@@ -370,7 +377,7 @@ async function _fetchWithRetry(url, options, retries = 2, useProxy = true, reque
 }
 
 export async function callOllamaChat({ system, messages, maxTokens, onStream, signal }) {
-  const config = window.getOllamaConfig();
+  const config = getOllamaConfigRuntime();
   const model = getOllamaMainModel();
   const ollamaMessages = [];
   if (system) ollamaMessages.push({ role: 'system', content: system });
@@ -551,11 +558,7 @@ async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { sys
       // line — otherwise the user sees the modal AND a duplicate
       // inline error for the same condition (Greptile #192 review).
       const modalShown = providerName === 'OpenRouter'
-        && typeof window !== 'undefined'
-        && !!window.showInsufficientBalanceDialog;
-      if (modalShown) {
-        try { window.showInsufficientBalanceDialog(); } catch {}
-      }
+        && showOpenRouterInsufficientBalanceDialogRuntime();
       const balanceErr = /** @type {Error & { _modalShown?: boolean }} */ (new Error(`Insufficient ${providerName} balance.${hint}`));
       if (modalShown) balanceErr._modalShown = true;
       throw balanceErr;
@@ -647,7 +650,7 @@ async function callOpenAICompatibleAPI(endpoint, key, model, providerName, { sys
 }
 
 export async function callOpenAICompatibleLocalAPI(opts) {
-  const config = window.getOllamaConfig();
+  const config = getOllamaConfigRuntime();
   const model = getOllamaMainModel();
   const url = config.url.replace(/\/+$/, '');
   const key = config.apiKey || 'not-needed';
@@ -782,7 +785,7 @@ export async function callOpenRouterAPI(opts) {
   return callOpenAICompatibleAPI(
     'https://openrouter.ai/api/v1/chat/completions',
     key, getOpenRouterModel(), 'OpenRouter', opts,
-    { 'HTTP-Referer': window.location.origin, 'X-Title': 'getbased' },
+    { 'HTTP-Referer': getApiLocationOriginRuntime(), 'X-Title': 'getbased' },
     { extraBody }
   );
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 247,
+  "windowReferences": 238,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -84,6 +84,7 @@ const APP_SHELL = [
   '/js/utils.js',
   '/js/theme.js',
   '/js/theme-runtime.js',
+  '/js/api-runtime.js',
   '/js/api.js',
   '/js/api-models.js',
   '/js/api-provider-storage.js',

--- a/tests/api-runtime.test.js
+++ b/tests/api-runtime.test.js
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+  getApiLocationOriginRuntime,
+  getApiLocationPathnameRuntime,
+  getOllamaConfigRuntime,
+  setApiLocationHrefRuntime,
+  showOpenRouterInsufficientBalanceDialogRuntime,
+} from '../js/api-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+});
+
+describe('api runtime adapter', () => {
+  it('delegates browser location reads and redirects', () => {
+    const runtime = {
+      location: {
+        origin: 'https://getbased.test',
+        pathname: '/app',
+        href: 'https://getbased.test/app',
+      },
+    };
+    setRuntimeWindow(runtime);
+
+    expect(getApiLocationOriginRuntime()).toBe('https://getbased.test');
+    expect(getApiLocationPathnameRuntime()).toBe('/app');
+    expect(setApiLocationHrefRuntime('https://openrouter.ai/auth')).toBe(true);
+    expect(runtime.location.href).toBe('https://openrouter.ai/auth');
+  });
+
+  it('delegates Ollama config and OpenRouter balance dialog access', () => {
+    const config = { url: 'http://localhost:11434', model: 'llama3.2', apiKey: '' };
+    const showInsufficientBalanceDialog = vi.fn();
+    setRuntimeWindow({ getOllamaConfig: () => config, showInsufficientBalanceDialog });
+
+    expect(getOllamaConfigRuntime()).toBe(config);
+    expect(showOpenRouterInsufficientBalanceDialogRuntime()).toBe(true);
+    expect(showInsufficientBalanceDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops safely when a browser runtime is missing', () => {
+    delete globalThis.window;
+
+    expect(getApiLocationOriginRuntime()).toBe('');
+    expect(getApiLocationPathnameRuntime()).toBe('');
+    expect(setApiLocationHrefRuntime('https://openrouter.ai/auth')).toBe(false);
+    expect(showOpenRouterInsufficientBalanceDialogRuntime()).toBe(false);
+    expect(() => getOllamaConfigRuntime()).toThrow('Ollama config runtime is unavailable.');
+  });
+
+  it('keeps api.js browser globals behind the adapter', () => {
+    const apiSrc = readFileSync(new URL('../js/api.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(apiSrc).toContain("from './api-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(apiSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/api-runtime.js'");
+  });
+});

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -90,6 +90,7 @@
     '/js/mobile-dashboard.js',
     '/js/dashboard-widget-runtime.js',
     '/js/provider-local-ai-runtime.js',
+    '/js/api-runtime.js',
     '/js/pdf-import-review-runtime.js',
     '/js/theme-runtime.js',
     '/js/schema.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -249,6 +249,7 @@
     "js/wearables-withings-auth.js",
     "js/wearables-withings.js",
     "js/wearables.js",
+    "js/api-runtime.js",
     "js/api-transport.js",
     "js/api-provider-storage.js",
     "js/api-models.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -179,6 +179,7 @@
     "js/profile-share.js",
     "js/recommendation-actions.js",
     "js/recommendations.js",
+    "js/api-runtime.js",
     "js/api.js",
     "js/api-provider-storage.js",
     "js/api-transport.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.93';
+self.APP_VERSION = '1.10.94';


### PR DESCRIPTION
## Summary
- Add api-runtime.js for browser location, Local AI config, and OpenRouter balance-dialog runtime hooks.
- Route api.js through the adapter so the API provider orchestration module no longer owns counted direct window references.
- Register the adapter in service-worker/module/typecheck lists, add focused runtime coverage, lower the quality baseline to 238 window references, and bump APP_VERSION to 1.10.94.

## Tests
- node tests/verify-modules.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npm test -- --reporter=dot tests/api-runtime.test.js tests/api-provider-runtime.test.js
- node tests/test-openrouter.js
- node tests/test-security-phase1.js
- npx playwright test tests/playwright/api-provider-calls-browser-coverage.spec.js tests/playwright/startup-oauth-browser-coverage.spec.js --project=chromium
- npm test -- --reporter=dot
- ./run-tests.sh