### PR TITLE
[codex] Extract charts runtime hooks

### DIFF
--- a/js/charts-runtime.js
+++ b/js/charts-runtime.js
@@ -1,0 +1,42 @@
+// @ts-check
+// charts-runtime.js - Browser runtime adapters for Chart.js orchestration.
+
+function getChartsRuntime() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+export function getChartConstructorRuntime() {
+  return getChartsRuntime()?.Chart || null;
+}
+
+export function hasChartRuntime() {
+  return typeof getChartConstructorRuntime() === 'function';
+}
+
+export function isChartDateAdapterReadyRuntime() {
+  return getChartsRuntime()?.__labChartDateAdapterLoaded === true;
+}
+
+export function markChartDateAdapterReadyRuntime() {
+  const runtime = getChartsRuntime();
+  if (!runtime) return false;
+  runtime.__labChartDateAdapterLoaded = true;
+  return true;
+}
+
+export function getChartViewportWidthRuntime() {
+  const width = Number(getChartsRuntime()?.innerWidth);
+  return Number.isFinite(width) && width > 0 ? width : 1024;
+}
+
+/**
+ * @param {HTMLCanvasElement} canvas
+ * @param {any} config
+ * @returns {any | null}
+ */
+export function createChartRuntime(canvas, config) {
+  const ChartCtor = getChartConstructorRuntime();
+  return typeof ChartCtor === 'function' ? new ChartCtor(canvas, config) : null;
+}

--- a/js/charts.js
+++ b/js/charts.js
@@ -5,28 +5,32 @@ import { state } from './state.js';
 import { getStatus, formatValue, loadScriptOnce } from './utils.js';
 import { getChartColors } from './theme.js';
 import { getEffectiveRange, getEffectiveRangeForDate, getPhaseRefEnvelope } from './marker-analysis.js';
+import {
+  createChartRuntime,
+  getChartConstructorRuntime,
+  getChartViewportWidthRuntime,
+  hasChartRuntime,
+  isChartDateAdapterReadyRuntime,
+  markChartDateAdapterReadyRuntime,
+} from './charts-runtime.js';
 
 const CHART_JS_SRC = '/vendor/chart.min.js';
 const CHART_DATE_ADAPTER_SRC = '/vendor/chartjs-adapter-native.js';
-
-const chartWindow = /** @type {Window & typeof globalThis & {
-  __labChartDateAdapterLoaded?: boolean
-}} */ (typeof window !== 'undefined' ? window : {});
 
 let _chartJsLoad = null;
 let _chartDateAdapterLoad = null;
 
 export function isChartDateAdapterReady() {
-  return chartWindow.__labChartDateAdapterLoaded === true;
+  return isChartDateAdapterReadyRuntime();
 }
 
 function ensureChartDateAdapter() {
-  if (isChartDateAdapterReady()) return Promise.resolve(window.Chart);
+  if (isChartDateAdapterReady()) return Promise.resolve(getChartConstructorRuntime());
   if (!_chartDateAdapterLoad) {
     _chartDateAdapterLoad = loadScriptOnce(CHART_DATE_ADAPTER_SRC)
       .then(() => {
-        chartWindow.__labChartDateAdapterLoaded = true;
-        return window.Chart;
+        markChartDateAdapterReadyRuntime();
+        return getChartConstructorRuntime();
       })
       .catch(err => {
         _chartDateAdapterLoad = null;
@@ -37,13 +41,14 @@ function ensureChartDateAdapter() {
 }
 
 export async function ensureChartJs() {
-  if (window.Chart) return ensureChartDateAdapter();
+  if (hasChartRuntime()) return ensureChartDateAdapter();
   if (!_chartJsLoad) {
     _chartJsLoad = loadScriptOnce(CHART_JS_SRC)
       .then(() => ensureChartDateAdapter())
       .then(() => {
-        if (!window.Chart) throw new Error('Chart.js did not initialize');
-        return window.Chart;
+        const ChartCtor = getChartConstructorRuntime();
+        if (!ChartCtor) throw new Error('Chart.js did not initialize');
+        return ChartCtor;
       });
   }
   return _chartJsLoad;
@@ -142,7 +147,7 @@ export const noteAnnotationPlugin = {
     const isTime = x.type === 'time';
     const chartDates = opts.chartDates || [];
     const dots = [];
-    const DOT_RADIUS = window.innerWidth <= 768 ? 8 : 5;
+    const DOT_RADIUS = getChartViewportWidthRuntime() <= 768 ? 8 : 5;
     const DOT_Y = top + DOT_RADIUS + 2;
     for (const note of opts.notes) {
       let pixelX;
@@ -465,7 +470,7 @@ export const phaseBandPlugin = {
 export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels) {
   const canvas = document.getElementById("chart-" + id);
   if (!canvas) return;
-  if (!window.Chart) {
+  if (!hasChartRuntime()) {
     ensureChartJs().then(() => {
       if (document.getElementById("chart-" + id)) createLineChart(id, marker, dateLabels, chartDates, phaseLabels);
     }).catch(() => {});
@@ -567,7 +572,7 @@ export function createLineChart(id, marker, dateLabels, chartDates, phaseLabels)
         ticks: { color: tc.tickColor, font: { size: 11 }, maxTicksLimit: 6, autoSkip: true, maxRotation: 0 },
         grid: { display: false } }
     : { ticks: { color: tc.tickColor, font: { size: 11 }, maxRotation: 0, autoSkip: true }, grid: { display: false } };
-  state.chartInstances[id] = new window.Chart(/** @type {HTMLCanvasElement} */ (canvas), {
+  state.chartInstances[id] = createChartRuntime(/** @type {HTMLCanvasElement} */ (canvas), {
     type: "line",
     data: { labels: chartLabels, datasets },
     options: { responsive:true, maintainAspectRatio:false,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 238,
+  "windowReferences": 230,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -110,6 +110,7 @@ const APP_SHELL = [
   '/js/blob-storage.js',
   '/js/data-merge.js',
   '/js/pii.js',
+  '/js/charts-runtime.js',
   '/js/charts.js',
   '/js/notes.js',
   '/js/supplement-action-delegates.js',

--- a/tests/charts-runtime.test.js
+++ b/tests/charts-runtime.test.js
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+  createChartRuntime,
+  getChartConstructorRuntime,
+  getChartViewportWidthRuntime,
+  hasChartRuntime,
+  isChartDateAdapterReadyRuntime,
+  markChartDateAdapterReadyRuntime,
+} from '../js/charts-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+});
+
+describe('charts runtime adapter', () => {
+  it('delegates Chart constructor and date-adapter readiness', () => {
+    class ChartStub {
+      constructor(canvas, config) {
+        this.canvas = canvas;
+        this.config = config;
+      }
+    }
+    const runtime = { Chart: ChartStub, innerWidth: 640 };
+    const canvas = { id: 'chart-demo' };
+    const config = { type: 'line' };
+    setRuntimeWindow(runtime);
+
+    expect(getChartConstructorRuntime()).toBe(ChartStub);
+    expect(hasChartRuntime()).toBe(true);
+    expect(getChartViewportWidthRuntime()).toBe(640);
+    expect(isChartDateAdapterReadyRuntime()).toBe(false);
+    expect(markChartDateAdapterReadyRuntime()).toBe(true);
+    expect(isChartDateAdapterReadyRuntime()).toBe(true);
+    expect(createChartRuntime(canvas, config)).toMatchObject({ canvas, config });
+  });
+
+  it('uses safe fallbacks when a browser runtime is missing', () => {
+    delete globalThis.window;
+
+    expect(getChartConstructorRuntime()).toBeNull();
+    expect(hasChartRuntime()).toBe(false);
+    expect(getChartViewportWidthRuntime()).toBe(1024);
+    expect(markChartDateAdapterReadyRuntime()).toBe(false);
+    expect(isChartDateAdapterReadyRuntime()).toBe(false);
+    expect(createChartRuntime({ id: 'chart-demo' }, { type: 'line' })).toBeNull();
+  });
+
+  it('keeps charts.js browser globals behind the adapter', () => {
+    const chartsSrc = readFileSync(new URL('../js/charts.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(chartsSrc).toContain("from './charts-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(chartsSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/charts-runtime.js'");
+  });
+});

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -91,6 +91,7 @@
     '/js/dashboard-widget-runtime.js',
     '/js/provider-local-ai-runtime.js',
     '/js/api-runtime.js',
+    '/js/charts-runtime.js',
     '/js/pdf-import-review-runtime.js',
     '/js/theme-runtime.js',
     '/js/schema.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -348,6 +348,7 @@
     "js/category-view-renderers.js",
     "js/changelog.js",
     "js/chart-card-recs.js",
+    "js/charts-runtime.js",
     "js/charts.js",
     "js/commit-hash.js",
     "js/compare-correlations.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "js/category-page-view.js",
     "js/category-view-renderers.js",
     "js/chart-card-recs.js",
+    "js/charts-runtime.js",
     "js/charts.js",
     "js/chat-actions.js",
     "js/chat-attestation.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.94';
+self.APP_VERSION = '1.10.95';


### PR DESCRIPTION
## Summary
- Add `charts-runtime.js` for Chart constructor access, date-adapter readiness, chart creation, and viewport width.
- Route `charts.js` through the adapter so the chart module no longer owns counted direct `window` references.
- Register the adapter in service-worker/module/typecheck lists, add focused runtime coverage, lower the quality baseline, and bump `APP_VERSION` to `1.10.95`.

## Window burden
- Quality baseline: `windowReferences` `238` -> `230` (`-8`).
- `js/charts.js`: direct `window.`/`window[...]` references `8` -> `0` by moving Chart constructor, date-adapter, chart creation, and viewport access behind `charts-runtime.js`.

## Tests
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot tests/charts-runtime.test.js`
- `node tests/test-cycle-improvements.js`
- `node tests/test-phase-ranges.js`
- `node tests/test-audit.js`
- `npx playwright test tests/playwright/charts-browser-coverage.spec.js tests/playwright/category-view-renderers-browser-coverage.spec.js tests/playwright/compare-correlations-browser-coverage.spec.js --project=chromium`
- `npm test -- --reporter=dot`
- `./run-tests.sh`