### PR TITLE
[codex] Extract sun body silhouette runtime hooks

### DIFF
--- a/js/sun-body-silhouette-runtime.js
+++ b/js/sun-body-silhouette-runtime.js
@@ -1,0 +1,61 @@
+// @ts-check
+// sun-body-silhouette-runtime.js - Browser runtime adapters for the sun body picker.
+
+function getSilhouetteRuntime() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/** @param {string} name */
+function getRuntimeFunction(name) {
+  const runtime = getSilhouetteRuntime();
+  return typeof runtime?.[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function getActiveSilhouetteProfileIdRuntime() {
+  try {
+    return getRuntimeFunction('getActiveProfileId')?.() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function getSilhouetteProfilesRuntime() {
+  try {
+    const profiles = getRuntimeFunction('getProfiles')?.();
+    return Array.isArray(profiles) ? profiles : [];
+  } catch {
+    return [];
+  }
+}
+
+export function dispatchSunOverlayReadyRuntime() {
+  const runtime = getSilhouetteRuntime();
+  const EventCtor = typeof runtime?.CustomEvent === 'function'
+    ? runtime.CustomEvent
+    : (typeof CustomEvent === 'function' ? CustomEvent : null);
+  if (!runtime || typeof runtime.dispatchEvent !== 'function' || !EventCtor) return false;
+  try {
+    runtime.dispatchEvent(new EventCtor('sun-overlay-ready'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** @param {EventListenerOrEventListenerObject} listener */
+export function addSunOverlayReadyListenerRuntime(listener) {
+  const runtime = getSilhouetteRuntime();
+  if (!runtime || typeof runtime.addEventListener !== 'function') return false;
+  runtime.addEventListener('sun-overlay-ready', listener);
+  return true;
+}
+
+/** @param {EventListenerOrEventListenerObject} listener */
+export function removeSunOverlayReadyListenerRuntime(listener) {
+  const runtime = getSilhouetteRuntime();
+  if (!runtime || typeof runtime.removeEventListener !== 'function') return false;
+  runtime.removeEventListener('sun-overlay-ready', listener);
+  return true;
+}

--- a/js/sun-body-silhouette.js
+++ b/js/sun-body-silhouette.js
@@ -3,6 +3,13 @@
 
 import { escapeAttr } from './utils.js';
 import { buildBody, buildLandmarks, buildDetails } from './silhouette-paths.js';
+import {
+  addSunOverlayReadyListenerRuntime,
+  dispatchSunOverlayReadyRuntime,
+  getActiveSilhouetteProfileIdRuntime,
+  getSilhouetteProfilesRuntime,
+  removeSunOverlayReadyListenerRuntime,
+} from './sun-body-silhouette-runtime.js';
 
 // Anatomical regions for the silhouette picker. Limbs split into front/back
 // so front-of-legs and back-of-legs are independent — matters for
@@ -36,9 +43,9 @@ export const BODY_REGIONS = [
 // don't render an empty picker for first-time users.
 function _activeProfileSex() {
   try {
-    const id = (typeof window !== 'undefined' && window.getActiveProfileId) ? window.getActiveProfileId() : null;
+    const id = getActiveSilhouetteProfileIdRuntime();
     if (!id) return 'male';
-    const profiles = (typeof window !== 'undefined' && window.getProfiles) ? window.getProfiles() : [];
+    const profiles = getSilhouetteProfilesRuntime();
     const p = profiles.find(p => p.id === id);
     const s = (p?.sex || '').toString().toLowerCase();
     if (s.startsWith('f')) return 'female';
@@ -488,7 +495,7 @@ export function renderBodySilhouette(selected) {
   // caller re-renders when ready (renderBodySilhouette is sync; bind binds
   // the load promise + rebakes via dispatchEvent('sun-overlay-ready')).
   const selOverlayUrl = _renderSelectionOverlay(selected, () => {
-    try { window.dispatchEvent(new CustomEvent('sun-overlay-ready')); } catch (e) {}
+    dispatchSunOverlayReadyRuntime();
   });
   const overlayMatchesSelection = !!selOverlayUrl && _overlayCache.key === _selectedKey(selected);
   const overlayState = selected?.size
@@ -616,12 +623,12 @@ export function bindBodySilhouette(rootEl, selected, onChange) {
   // (e.g., rootEl moved to a new parent).
   const _onOverlayReady = () => {
     if (!_alive()) {
-      window.removeEventListener('sun-overlay-ready', _onOverlayReady);
+      removeSunOverlayReadyListenerRuntime(_onOverlayReady);
       return;
     }
     rerender();
   };
-  window.addEventListener('sun-overlay-ready', _onOverlayReady);
+  addSunOverlayReadyListenerRuntime(_onOverlayReady);
   if (typeof document !== 'undefined' && document.body && typeof MutationObserver === 'function') {
     // Subtree observation — modal-close typically removes a grandparent
     // overlay (rootEl's immediate parent stays attached to it), so we
@@ -630,7 +637,7 @@ export function bindBodySilhouette(rootEl, selected, onChange) {
     // when still connected.
     const detachObs = new MutationObserver(() => {
       if (!rootEl.isConnected) {
-        window.removeEventListener('sun-overlay-ready', _onOverlayReady);
+        removeSunOverlayReadyListenerRuntime(_onOverlayReady);
         detachObs.disconnect();
       }
     });

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 230,
+  "windowReferences": 222,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -392,6 +392,7 @@ const APP_SHELL = [
   '/js/sun-session-ai-render-hooks.js',
   '/js/sun-session-actions.js',
   '/js/sun-runtime.js',
+  '/js/sun-body-silhouette-runtime.js',
   '/js/sun-body-silhouette.js',
   '/js/sun-ai-analysis.js',
   '/js/sun-context.js',

--- a/tests/sun-body-silhouette-runtime.test.js
+++ b/tests/sun-body-silhouette-runtime.test.js
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+  addSunOverlayReadyListenerRuntime,
+  dispatchSunOverlayReadyRuntime,
+  getActiveSilhouetteProfileIdRuntime,
+  getSilhouetteProfilesRuntime,
+  removeSunOverlayReadyListenerRuntime,
+} from '../js/sun-body-silhouette-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const savedCustomEvent = Object.getOwnPropertyDescriptor(globalThis, 'CustomEvent');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+  if (savedCustomEvent) Object.defineProperty(globalThis, 'CustomEvent', savedCustomEvent);
+  else delete globalThis.CustomEvent;
+});
+
+describe('sun body silhouette runtime adapter', () => {
+  it('delegates profile lookup and overlay-ready events', () => {
+    class CustomEventStub {
+      constructor(type) {
+        this.type = type;
+      }
+    }
+    const listener = () => {};
+    const profiles = [{ id: 'profile-female', sex: 'female' }];
+    const calls = [];
+    setRuntimeWindow({
+      getActiveProfileId: () => 'profile-female',
+      getProfiles: () => profiles,
+      CustomEvent: CustomEventStub,
+      dispatchEvent: event => calls.push(['dispatch', event.type, event instanceof CustomEventStub]),
+      addEventListener: (type, fn) => calls.push(['add', type, fn]),
+      removeEventListener: (type, fn) => calls.push(['remove', type, fn]),
+    });
+
+    expect(getActiveSilhouetteProfileIdRuntime()).toBe('profile-female');
+    expect(getSilhouetteProfilesRuntime()).toBe(profiles);
+    expect(dispatchSunOverlayReadyRuntime()).toBe(true);
+    expect(addSunOverlayReadyListenerRuntime(listener)).toBe(true);
+    expect(removeSunOverlayReadyListenerRuntime(listener)).toBe(true);
+    expect(calls).toEqual([
+      ['dispatch', 'sun-overlay-ready', true],
+      ['add', 'sun-overlay-ready', listener],
+      ['remove', 'sun-overlay-ready', listener],
+    ]);
+  });
+
+  it('uses safe fallbacks when browser hooks are missing or fail', () => {
+    setRuntimeWindow({
+      getActiveProfileId: () => { throw new Error('profile unavailable'); },
+      getProfiles: () => { throw new Error('profiles unavailable'); },
+      dispatchEvent: () => { throw new Error('dispatch unavailable'); },
+      addEventListener: null,
+      removeEventListener: null,
+    });
+    delete globalThis.CustomEvent;
+
+    expect(getActiveSilhouetteProfileIdRuntime()).toBeNull();
+    expect(getSilhouetteProfilesRuntime()).toEqual([]);
+    expect(dispatchSunOverlayReadyRuntime()).toBe(false);
+    expect(addSunOverlayReadyListenerRuntime(() => {})).toBe(false);
+    expect(removeSunOverlayReadyListenerRuntime(() => {})).toBe(false);
+
+    delete globalThis.window;
+    expect(getActiveSilhouetteProfileIdRuntime()).toBeNull();
+    expect(getSilhouetteProfilesRuntime()).toEqual([]);
+    expect(dispatchSunOverlayReadyRuntime()).toBe(false);
+    expect(addSunOverlayReadyListenerRuntime(() => {})).toBe(false);
+    expect(removeSunOverlayReadyListenerRuntime(() => {})).toBe(false);
+  });
+
+  it('keeps sun-body-silhouette.js browser globals behind the adapter', () => {
+    const silhouetteSrc = readFileSync(new URL('../js/sun-body-silhouette.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(silhouetteSrc).toContain("from './sun-body-silhouette-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(silhouetteSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/sun-body-silhouette-runtime.js'");
+  });
+});

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -83,6 +83,7 @@
     '/js/light-channel-view-ui-hooks.js',
     '/js/sun-runtime.js',
     '/js/sun-defaults-runtime.js',
+    '/js/sun-body-silhouette-runtime.js',
     '/js/sun-channel-metrics.js',
     '/js/sun-context-hooks.js',
     '/js/light-sessions-view.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -195,6 +195,7 @@
     "js/startup-ui.js",
     "js/sun-active-session.js",
     "js/sun-ai-analysis.js",
+    "js/sun-body-silhouette-runtime.js",
     "js/sun-body-silhouette.js",
     "js/sun-channel-metrics.js",
     "js/sun-context.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -210,6 +210,7 @@
     "js/startup-ui.js",
     "js/sun-active-session.js",
     "js/sun-ai-analysis.js",
+    "js/sun-body-silhouette-runtime.js",
     "js/sun-body-silhouette.js",
     "js/sun-channel-metrics.js",
     "js/sun-context.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.95';
+self.APP_VERSION = '1.10.96';


### PR DESCRIPTION
## Summary
- Add `sun-body-silhouette-runtime.js` for profile lookup and `sun-overlay-ready` event dispatch/listener wiring.
- Route `sun-body-silhouette.js` through the adapter so the picker keeps browser runtime hooks out of the source module.
- Register the adapter in service-worker/module/typecheck lists, add focused runtime coverage, lower the quality baseline, and bump `APP_VERSION` to `1.10.96`.

## Window burden
- Quality baseline: `windowReferences` `230` -> `222` (`-8`).
- `js/sun-body-silhouette.js`: direct `window.`/`window[...]` references `8` -> `0` by moving profile getters and overlay-ready event wiring behind `sun-body-silhouette-runtime.js`.

## Tests
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot tests/sun-body-silhouette-runtime.test.js`
- `node tests/test-v1-6-shipped.js`
- `npm test -- --reporter=dot`
- `npx playwright test tests/playwright/sun-body-silhouette-browser-coverage.spec.js --project=chromium`
- `./run-tests.sh`