### PR TITLE
[codex] Extract startup maintenance runtime hooks

### DIFF
--- a/js/startup-maintenance-runtime.js
+++ b/js/startup-maintenance-runtime.js
@@ -1,0 +1,55 @@
+// @ts-check
+// startup-maintenance-runtime.js - Browser runtime adapters for startup maintenance hooks.
+
+function getStartupMaintenanceRuntime() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/** @param {string} name */
+function getRuntimeFunction(name) {
+  const runtime = getStartupMaintenanceRuntime();
+  return typeof runtime?.[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function hasSunSessionRehydrateRuntime() {
+  return getRuntimeFunction('rehydrateStaleSessions') !== null;
+}
+
+export function rehydrateStaleSunSessionsRuntime() {
+  try {
+    return getRuntimeFunction('rehydrateStaleSessions')?.() || Promise.resolve(null);
+  } catch {
+    return Promise.resolve(null);
+  }
+}
+
+export function getStartupSunEngineVersionRuntime() {
+  return getStartupMaintenanceRuntime()?.SUN_ENGINE_VERSION || '?';
+}
+
+export function hasLightDevicePresetHydrationRuntime() {
+  return getRuntimeFunction('hydrateDevicesFromPresets') !== null;
+}
+
+export function hydrateLightDevicesFromPresetsRuntime() {
+  try {
+    return getRuntimeFunction('hydrateDevicesFromPresets')?.() || Promise.resolve(false);
+  } catch {
+    return Promise.resolve(false);
+  }
+}
+
+/** @param {any[]} args */
+export function logStartupMaintenanceRuntime(...args) {
+  const runtime = getStartupMaintenanceRuntime();
+  const logger = runtime?.console?.log;
+  if (typeof logger !== 'function') return false;
+  try {
+    logger.apply(runtime.console, args);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/js/startup-maintenance.js
+++ b/js/startup-maintenance.js
@@ -4,6 +4,14 @@
 import { state } from './state.js';
 import { initWearableScheduler, loadWearableRuntimeConfig, syncStaleWearablesNow } from './wearables-connect.js';
 import { migrateBiometricsToManual, hasManualData } from './wearables-manual.js';
+import {
+  getStartupSunEngineVersionRuntime,
+  hasLightDevicePresetHydrationRuntime,
+  hasSunSessionRehydrateRuntime,
+  hydrateLightDevicesFromPresetsRuntime,
+  logStartupMaintenanceRuntime,
+  rehydrateStaleSunSessionsRuntime,
+} from './startup-maintenance-runtime.js';
 
 export function initializeStartupServices() {
   // Self-host OAuth client_id overrides - fire-and-forget. Resolves before
@@ -29,13 +37,13 @@ function scheduleSunSessionRehydrate() {
   // it doesn't block init; one network call per stale session,
   // serialized inside rehydrateStaleSessions. No-op when everything is
   // already stamped at the current version.
-  if (typeof window.rehydrateStaleSessions === 'function') {
+  if (hasSunSessionRehydrateRuntime()) {
     setTimeout(() => {
-      window.rehydrateStaleSessions().then(r => {
+      rehydrateStaleSunSessionsRuntime().then(r => {
         if (r?.rehydrated) {
           // Surface in debug console only - not worth a user-facing
           // notification for a silent self-heal.
-          if (window.console && console.log) console.log('[sun] self-healed', r.rehydrated, 'session(s) under v' + (window.SUN_ENGINE_VERSION || '?'));
+          logStartupMaintenanceRuntime('[sun] self-healed', r.rehydrated, 'session(s) under v' + getStartupSunEngineVersionRuntime());
         }
       }).catch(() => {});
     }, 1500); // give the engine modules time to settle
@@ -48,9 +56,9 @@ function hydrateUserLightDevicesFromPresets() {
   // / Trinity device records have no `modes` array, so the session-log
   // dialog can't render the mode picker for them. Idempotent - re-runs
   // are no-ops once devices carry the fields.
-  if (typeof window.hydrateDevicesFromPresets === 'function') {
-    window.hydrateDevicesFromPresets().then(dirty => {
-      if (dirty && window.console && console.log) console.log('[light] hydrated user devices from preset library');
+  if (hasLightDevicePresetHydrationRuntime()) {
+    hydrateLightDevicesFromPresetsRuntime().then(dirty => {
+      if (dirty) logStartupMaintenanceRuntime('[light] hydrated user devices from preset library');
     }).catch(() => {});
   }
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 222,
+  "windowReferences": 215,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -90,6 +90,7 @@ const APP_SHELL = [
   '/js/api-provider-storage.js',
   '/js/api-transport.js',
   '/js/startup-foundation.js',
+  '/js/startup-maintenance-runtime.js',
   '/js/startup-profile.js',
   '/js/startup-oauth-callbacks.js',
   '/js/startup-maintenance.js',

--- a/tests/startup-maintenance-runtime.test.js
+++ b/tests/startup-maintenance-runtime.test.js
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+  getStartupSunEngineVersionRuntime,
+  hasLightDevicePresetHydrationRuntime,
+  hasSunSessionRehydrateRuntime,
+  hydrateLightDevicesFromPresetsRuntime,
+  logStartupMaintenanceRuntime,
+  rehydrateStaleSunSessionsRuntime,
+} from '../js/startup-maintenance-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+});
+
+describe('startup maintenance runtime adapter', () => {
+  it('delegates startup maintenance hooks and logging', async () => {
+    const calls = [];
+    setRuntimeWindow({
+      SUN_ENGINE_VERSION: 'runtime-test',
+      rehydrateStaleSessions: () => {
+        calls.push('rehydrate');
+        return Promise.resolve({ rehydrated: 2 });
+      },
+      hydrateDevicesFromPresets: () => {
+        calls.push('hydrate-devices');
+        return Promise.resolve(true);
+      },
+      console: {
+        log: (...args) => calls.push(['log', ...args]),
+      },
+    });
+
+    expect(hasSunSessionRehydrateRuntime()).toBe(true);
+    expect(await rehydrateStaleSunSessionsRuntime()).toEqual({ rehydrated: 2 });
+    expect(getStartupSunEngineVersionRuntime()).toBe('runtime-test');
+    expect(hasLightDevicePresetHydrationRuntime()).toBe(true);
+    expect(await hydrateLightDevicesFromPresetsRuntime()).toBe(true);
+    expect(logStartupMaintenanceRuntime('[startup]', 'ok')).toBe(true);
+    expect(calls).toEqual([
+      'rehydrate',
+      'hydrate-devices',
+      ['log', '[startup]', 'ok'],
+    ]);
+  });
+
+  it('uses safe fallbacks when browser hooks are missing or fail', async () => {
+    setRuntimeWindow({
+      rehydrateStaleSessions: () => { throw new Error('rehydrate unavailable'); },
+      hydrateDevicesFromPresets: () => { throw new Error('hydrate unavailable'); },
+      console: {
+        log: () => { throw new Error('log unavailable'); },
+      },
+    });
+
+    expect(hasSunSessionRehydrateRuntime()).toBe(true);
+    expect(await rehydrateStaleSunSessionsRuntime()).toBeNull();
+    expect(getStartupSunEngineVersionRuntime()).toBe('?');
+    expect(hasLightDevicePresetHydrationRuntime()).toBe(true);
+    expect(await hydrateLightDevicesFromPresetsRuntime()).toBe(false);
+    expect(logStartupMaintenanceRuntime('[startup]', 'ignored')).toBe(false);
+
+    delete globalThis.window;
+    expect(hasSunSessionRehydrateRuntime()).toBe(false);
+    expect(await rehydrateStaleSunSessionsRuntime()).toBeNull();
+    expect(getStartupSunEngineVersionRuntime()).toBe('?');
+    expect(hasLightDevicePresetHydrationRuntime()).toBe(false);
+    expect(await hydrateLightDevicesFromPresetsRuntime()).toBe(false);
+    expect(logStartupMaintenanceRuntime('[startup]', 'ignored')).toBe(false);
+  });
+
+  it('keeps startup-maintenance.js browser globals behind the adapter', () => {
+    const startupSrc = readFileSync(new URL('../js/startup-maintenance.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(startupSrc).toContain("from './startup-maintenance-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(startupSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/startup-maintenance-runtime.js'");
+  });
+});

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -28,6 +28,7 @@
     '/js/app-event-listeners.js',
     '/js/startup-orchestrator.js',
     '/js/startup-foundation.js',
+    '/js/startup-maintenance-runtime.js',
     '/js/startup-profile.js',
     '/js/startup-oauth-callbacks.js',
     '/js/startup-maintenance.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -188,6 +188,7 @@
     "js/service-worker-update.js",
     "js/shell-actions.js",
     "js/startup-foundation.js",
+    "js/startup-maintenance-runtime.js",
     "js/startup-maintenance.js",
     "js/startup-oauth-callbacks.js",
     "js/startup-orchestrator.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -203,6 +203,7 @@
     "js/shell-actions.js",
     "js/silhouette-paths.js",
     "js/startup-foundation.js",
+    "js/startup-maintenance-runtime.js",
     "js/startup-maintenance.js",
     "js/startup-oauth-callbacks.js",
     "js/startup-orchestrator.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.96';
+self.APP_VERSION = '1.10.97';


### PR DESCRIPTION
## Summary
- Add `startup-maintenance-runtime.js` for startup maintenance rehydrate, light-device preset hydration, engine-version, and logging hooks.
- Route `startup-maintenance.js` through the adapter so startup maintenance no longer owns counted direct `window` references.
- Register the adapter in service-worker/module/typecheck lists, add focused runtime coverage, lower the quality baseline, and bump `APP_VERSION` to `1.10.97`.

## Window burden
- Quality baseline: `windowReferences` `222` -> `215` (`-7`).
- `js/startup-maintenance.js`: direct `window.`/`window[...]` references `7` -> `0` by moving startup self-heal, device hydration, engine-version, and debug logging hooks behind `startup-maintenance-runtime.js`.

## Tests
- `node tests/verify-modules.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot tests/startup-maintenance-runtime.test.js`
- `npx playwright test tests/playwright/startup-helpers-browser-coverage.spec.js tests/playwright/startup-orchestrator-browser-coverage.spec.js --project=chromium`
- `npm test -- --reporter=dot`
- `./run-tests.sh`