### PR TITLE
[codex] Extract provider model controls runtime hooks

### DIFF
--- a/js/provider-model-controls-runtime.js
+++ b/js/provider-model-controls-runtime.js
@@ -1,0 +1,45 @@
+// @ts-check
+// provider-model-controls-runtime.js - Browser runtime adapters for provider model controls.
+
+function getProviderModelControlsRuntime() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getProviderModelControlsRuntime();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function clearProviderE2EESessionRuntime() {
+  const clearSession = getRuntimeFunction('clearE2EESession');
+  if (!clearSession) return false;
+  clearSession();
+  return true;
+}
+
+export function refreshProviderModelUiRuntime() {
+  let refreshed = false;
+  const updateHeader = getRuntimeFunction('updateChatHeaderModel');
+  if (updateHeader) {
+    updateHeader();
+    refreshed = true;
+  }
+  const refreshWebSearch = getRuntimeFunction('refreshWebSearchToggle');
+  if (refreshWebSearch) {
+    refreshWebSearch();
+    refreshed = true;
+  }
+  return refreshed;
+}
+
+export function callProviderModelSmokeTestRuntime() {
+  const callClaudeAPI = getRuntimeFunction('callClaudeAPI');
+  if (!callClaudeAPI) throw new Error('AI provider runtime is unavailable.');
+  return callClaudeAPI({ messages: [{ role: 'user', content: 'hi' }], maxTokens: 1 });
+}

--- a/js/provider-model-controls.js
+++ b/js/provider-model-controls.js
@@ -20,6 +20,11 @@ import {
   setVeniceModel,
 } from './api.js';
 import { buildModelOptions } from './provider-panel-renderers.js';
+import {
+  callProviderModelSmokeTestRuntime,
+  clearProviderE2EESessionRuntime,
+  refreshProviderModelUiRuntime,
+} from './provider-model-controls-runtime.js';
 
 export function updateVeniceModelPricing(modelId) {
   const el = document.getElementById('venice-model-pricing');
@@ -40,13 +45,13 @@ export function onVeniceModelDropdownChange(value) {
   const previous = getVeniceModel();
   setVeniceModel(value);
   localStorage.setItem(getVeniceE2EE() ? 'labcharts-venice-model-e2ee' : 'labcharts-venice-model-regular', value);
-  if (previous !== value) window.clearE2EESession?.();
+  if (previous !== value) clearProviderE2EESessionRuntime();
   updateVeniceModelPricing(value);
 }
 
 export function toggleVeniceE2EE(on) {
   setVeniceE2EE(on);
-  if (!on) window.clearE2EESession?.();
+  if (!on) clearProviderE2EESessionRuntime();
   // Swap model dropdown to E2EE or regular model list.
   const listKey = on ? 'labcharts-venice-e2ee-models' : 'labcharts-venice-models';
   let models = []; try { models = JSON.parse(localStorage.getItem(listKey) || '[]'); } catch {}
@@ -61,8 +66,7 @@ export function toggleVeniceE2EE(on) {
   }
   const el = document.getElementById('venice-e2ee-indicator');
   if (el) el.style.display = on ? '' : 'none';
-  window.updateChatHeaderModel?.();
-  window.refreshWebSearchToggle?.();
+  refreshProviderModelUiRuntime();
 }
 
 export function updateOpenRouterModelPricing(modelId) {
@@ -111,7 +115,7 @@ export async function applyCustomOpenRouterModel(modelId) {
   const indicator = document.getElementById('openrouter-model-health');
   if (indicator) { indicator.textContent = '\u23f3'; indicator.title = 'Checking...'; indicator.style.color = 'var(--text-muted)'; }
   try {
-    await window.callClaudeAPI({ messages: [{ role: 'user', content: 'hi' }], maxTokens: 1 });
+    await callProviderModelSmokeTestRuntime();
     if (indicator) { indicator.textContent = '\u2713'; indicator.title = 'Model responding'; indicator.style.color = 'var(--green)'; }
     if (input && !inDropdown) input.style.borderColor = 'var(--green)';
     showNotification('Model set: ' + id, 'info');
@@ -182,8 +186,7 @@ export function togglePpqPrivateMode(on) {
   }
   const el = document.getElementById('ppq-private-indicator');
   if (el) el.style.display = on ? '' : 'none';
-  window.updateChatHeaderModel?.();
-  window.refreshWebSearchToggle?.();
+  refreshProviderModelUiRuntime();
 }
 
 export function updatePpqModelPricing(modelId) {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 215,
+  "windowReferences": 208,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -266,6 +266,7 @@ const APP_SHELL = [
   '/js/provider-local-ai-controls.js',
   '/js/provider-ppq-panels.js',
   '/js/provider-panel-renderers.js',
+  '/js/provider-model-controls-runtime.js',
   '/js/provider-model-controls.js',
   '/js/provider-panels.js',
   '/js/dna-actions.js',

--- a/tests/provider-model-controls-runtime.test.js
+++ b/tests/provider-model-controls-runtime.test.js
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+  callProviderModelSmokeTestRuntime,
+  clearProviderE2EESessionRuntime,
+  refreshProviderModelUiRuntime,
+} from '../js/provider-model-controls-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+});
+
+describe('provider model controls runtime adapter', () => {
+  it('delegates provider model runtime hooks at call time', async () => {
+    const clearE2EESession = vi.fn();
+    const updateChatHeaderModel = vi.fn();
+    const refreshWebSearchToggle = vi.fn();
+    const callClaudeAPI = vi.fn(async () => ({ content: 'ok' }));
+    setRuntimeWindow({
+      clearE2EESession,
+      updateChatHeaderModel,
+      refreshWebSearchToggle,
+      callClaudeAPI,
+    });
+
+    expect(clearProviderE2EESessionRuntime()).toBe(true);
+    expect(refreshProviderModelUiRuntime()).toBe(true);
+    await expect(callProviderModelSmokeTestRuntime()).resolves.toEqual({ content: 'ok' });
+
+    expect(clearE2EESession).toHaveBeenCalledTimes(1);
+    expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
+    expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);
+    expect(callClaudeAPI).toHaveBeenCalledWith({
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 1,
+    });
+  });
+
+  it('uses safe no-op fallbacks when browser hooks are missing', () => {
+    delete globalThis.window;
+
+    expect(clearProviderE2EESessionRuntime()).toBe(false);
+    expect(refreshProviderModelUiRuntime()).toBe(false);
+    expect(() => callProviderModelSmokeTestRuntime()).toThrow('AI provider runtime is unavailable.');
+  });
+
+  it('keeps provider-model-controls.js browser globals behind the adapter', () => {
+    const controlsSrc = readFileSync(new URL('../js/provider-model-controls.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(controlsSrc).toContain("from './provider-model-controls-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(controlsSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/provider-model-controls-runtime.js'");
+  });
+});

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -66,6 +66,7 @@ assert('SW CACHE_NAME uses semver', swAuditSrc.includes('`labcharts-v${self.APP_
 assert('SW treats app.getbased.health as production host', swAuditSrc.includes("'app.getbased.health'"));
 assert('SW APP_SHELL includes API models module', swAuditSrc.includes("'/js/api-models.js'"));
 assert('SW APP_SHELL includes API provider storage module', swAuditSrc.includes("'/js/api-provider-storage.js'"));
+assert('SW APP_SHELL includes provider model controls runtime module', swAuditSrc.includes("'/js/provider-model-controls-runtime.js'"));
 assert('SW APP_SHELL includes provider model controls module', swAuditSrc.includes("'/js/provider-model-controls.js'"));
 assert('SW APP_SHELL includes provider local AI controls module', swAuditSrc.includes("'/js/provider-local-ai-controls.js'"));
 assert('SW APP_SHELL includes provider PPQ panels module', swAuditSrc.includes("'/js/provider-ppq-panels.js'"));

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -197,6 +197,7 @@ assert('SW uses importScripts for version', swSrc.includes("importScripts('/vers
 assert('SW CACHE_NAME uses semver', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
 assert('SW bypasses openrouter.ai', swSrc.includes('openrouter.ai'));
 assert('SW caches provider-panel-renderers.js', swSrc.includes('/js/provider-panel-renderers.js'));
+assert('SW caches provider-model-controls-runtime.js', swSrc.includes('/js/provider-model-controls-runtime.js'));
 assert('SW caches provider-model-controls.js', swSrc.includes('/js/provider-model-controls.js'));
 
 // ─── 7. Window function exports ───

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -92,6 +92,7 @@
     '/js/mobile-dashboard.js',
     '/js/dashboard-widget-runtime.js',
     '/js/provider-local-ai-runtime.js',
+    '/js/provider-model-controls-runtime.js',
     '/js/api-runtime.js',
     '/js/charts-runtime.js',
     '/js/pdf-import-review-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -255,6 +255,7 @@
     "js/api-transport.js",
     "js/api-provider-storage.js",
     "js/api-models.js",
+    "js/provider-model-controls-runtime.js",
     "js/provider-model-controls.js",
     "js/provider-panel-renderers.js",
     "js/provider-qr.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -186,6 +186,7 @@
     "js/api-transport.js",
     "js/provider-local-ai-runtime.js",
     "js/provider-local-ai-controls.js",
+    "js/provider-model-controls-runtime.js",
     "js/provider-model-controls.js",
     "js/provider-panel-delegates.js",
     "js/provider-panel-renderers.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.97';
+self.APP_VERSION = '1.10.98';


### PR DESCRIPTION
## Summary
- Added `provider-model-controls-runtime.js` to isolate browser runtime hooks used by provider model controls.
- Routed Venice/PPQ model UI refreshes, E2EE session cleanup, and the OpenRouter model smoke test through the runtime adapter.
- Added service worker, typecheck, and static verification coverage for the new module and bumped `version.js` for cache invalidation.

## Window burden
- Quality baseline: `windowReferences` `215` -> `208` (`-7`).
- `js/provider-model-controls.js`: direct `window.`/`window[...]` references `7` -> `0` by moving E2EE cleanup, chat header refresh, web search refresh, and provider smoke-test API calls behind `provider-model-controls-runtime.js`.

## Validation
- `git diff --check`
- `node tests/verify-modules.js`
- `npm run quality`
- `npm test -- --reporter=dot tests/provider-model-controls-runtime.test.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot`
- `npx playwright test tests/playwright/provider-coverage-batch.spec.js tests/playwright/provider-model-controls-edge-browser-coverage.spec.js --project=chromium`
- `./run-tests.sh`