### PR TITLE
[codex] Extract touch tooltip runtime hooks

### DIFF
--- a/js/touch-tooltip-runtime.js
+++ b/js/touch-tooltip-runtime.js
@@ -1,0 +1,40 @@
+// @ts-check
+// touch-tooltip-runtime.js - Browser runtime adapters for app tooltips.
+
+function getTouchTooltipRuntime() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+export function hasTouchTooltipRuntime() {
+  return getTouchTooltipRuntime() !== null;
+}
+
+export function isTouchTooltipTouchRuntime() {
+  const runtime = getTouchTooltipRuntime();
+  const matchMedia = runtime?.matchMedia;
+  if (typeof matchMedia !== 'function') return false;
+  return !!(
+    matchMedia.call(runtime, '(hover: none)').matches
+    || matchMedia.call(runtime, '(pointer: coarse)').matches
+  );
+}
+
+export function getTouchTooltipViewportRuntime() {
+  const runtime = getTouchTooltipRuntime();
+  const width = Number.isFinite(runtime?.innerWidth) ? runtime.innerWidth : 1024;
+  const height = Number.isFinite(runtime?.innerHeight) ? runtime.innerHeight : 768;
+  return { width, height };
+}
+
+/**
+ * @param {{ onScroll?: EventListener, onResize?: EventListener }} listeners
+ */
+export function addTouchTooltipWindowListenersRuntime({ onScroll, onResize } = {}) {
+  const runtime = getTouchTooltipRuntime();
+  if (!runtime || typeof runtime.addEventListener !== 'function') return false;
+  if (typeof onScroll === 'function') runtime.addEventListener('scroll', onScroll, true);
+  if (typeof onResize === 'function') runtime.addEventListener('resize', onResize);
+  return true;
+}

--- a/js/touch-tooltip.js
+++ b/js/touch-tooltip.js
@@ -7,6 +7,13 @@
 // the existing markup working while rendering one styled, viewport-clamped
 // tooltip for hover, focus, and long-press.
 
+import {
+  addTouchTooltipWindowListenersRuntime,
+  getTouchTooltipViewportRuntime,
+  hasTouchTooltipRuntime,
+  isTouchTooltipTouchRuntime,
+} from './touch-tooltip-runtime.js';
+
 const HOLD_MS = 500;
 const MAX_DRIFT_PX = 10;
 const TOOLTIP_ID = 'app-tooltip';
@@ -20,8 +27,7 @@ let _touchAnchor = null;
 let _lastTouchAt = 0;
 
 function _isTouchDevice() {
-  return typeof window !== 'undefined'
-    && (window.matchMedia('(hover: none)').matches || window.matchMedia('(pointer: coarse)').matches);
+  return isTouchTooltipTouchRuntime();
 }
 
 function _tooltipText(el) {
@@ -98,9 +104,10 @@ function _positionTooltip() {
     top = anchor.bottom + gap;
     placement = 'bottom';
   }
+  const viewport = getTouchTooltipViewportRuntime();
   let left = anchor.centerX - (tipRect.width / 2);
-  left = Math.max(margin, Math.min(left, window.innerWidth - tipRect.width - margin));
-  top = Math.max(margin, Math.min(top, window.innerHeight - tipRect.height - margin));
+  left = Math.max(margin, Math.min(left, viewport.width - tipRect.width - margin));
+  top = Math.max(margin, Math.min(top, viewport.height - tipRect.height - margin));
   _tooltip.style.left = `${Math.round(left)}px`;
   _tooltip.style.top = `${Math.round(top)}px`;
   _tooltip.dataset.placement = placement;
@@ -228,14 +235,16 @@ function _initAppTooltip() {
     }, { passive: true });
   }
   document.addEventListener('click', _hideTooltip, true);
-  window.addEventListener('scroll', () => {
-    if (_activeTarget && !_touchAnchor) _positionTooltip();
-    else if (_activeTarget) _hideTooltip();
-  }, true);
-  window.addEventListener('resize', _hideTooltip);
+  addTouchTooltipWindowListenersRuntime({
+    onScroll: () => {
+      if (_activeTarget && !_touchAnchor) _positionTooltip();
+      else if (_activeTarget) _hideTooltip();
+    },
+    onResize: _hideTooltip,
+  });
 }
 
-if (typeof window !== 'undefined') {
+if (hasTouchTooltipRuntime()) {
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', _initAppTooltip);
   } else {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "inlineEventAttributes": 0,
-  "windowReferences": 208,
+  "windowReferences": 202,
   "largeJsFilesOver800Lines": 28,
   "maxJsFileLines": 1511
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -350,6 +350,7 @@ const APP_SHELL = [
   '/js/food-contaminants.js',
   '/js/cashu-wallet.js',
   '/js/nostr-discovery.js',
+  '/js/touch-tooltip-runtime.js',
   '/js/touch-tooltip.js',
   '/js/url-safety.js',
   // Wearables (added v1.22.0)

--- a/tests/touch-tooltip-runtime.test.js
+++ b/tests/touch-tooltip-runtime.test.js
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import {
+  addTouchTooltipWindowListenersRuntime,
+  getTouchTooltipViewportRuntime,
+  hasTouchTooltipRuntime,
+  isTouchTooltipTouchRuntime,
+} from '../js/touch-tooltip-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+});
+
+describe('touch tooltip runtime adapter', () => {
+  it('delegates media queries viewport reads and window listeners', () => {
+    const addEventListener = vi.fn();
+    const matchMedia = vi.fn(query => ({
+      matches: query === '(pointer: coarse)',
+      media: query,
+    }));
+    const onScroll = vi.fn();
+    const onResize = vi.fn();
+    setRuntimeWindow({
+      innerWidth: 360,
+      innerHeight: 640,
+      matchMedia,
+      addEventListener,
+    });
+
+    expect(hasTouchTooltipRuntime()).toBe(true);
+    expect(isTouchTooltipTouchRuntime()).toBe(true);
+    expect(matchMedia).toHaveBeenCalledWith('(hover: none)');
+    expect(matchMedia).toHaveBeenCalledWith('(pointer: coarse)');
+    expect(getTouchTooltipViewportRuntime()).toEqual({ width: 360, height: 640 });
+    expect(addTouchTooltipWindowListenersRuntime({ onScroll, onResize })).toBe(true);
+    expect(addEventListener).toHaveBeenCalledWith('scroll', onScroll, true);
+    expect(addEventListener).toHaveBeenCalledWith('resize', onResize);
+  });
+
+  it('uses safe fallbacks when browser runtime hooks are unavailable', () => {
+    delete globalThis.window;
+
+    expect(hasTouchTooltipRuntime()).toBe(false);
+    expect(isTouchTooltipTouchRuntime()).toBe(false);
+    expect(getTouchTooltipViewportRuntime()).toEqual({ width: 1024, height: 768 });
+    expect(addTouchTooltipWindowListenersRuntime({ onScroll: vi.fn(), onResize: vi.fn() })).toBe(false);
+  });
+
+  it('keeps touch-tooltip.js browser globals behind the adapter', () => {
+    const tooltipSrc = readFileSync(new URL('../js/touch-tooltip.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(tooltipSrc).toContain("from './touch-tooltip-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(tooltipSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/touch-tooltip-runtime.js'");
+  });
+});

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -97,6 +97,7 @@
     '/js/charts-runtime.js',
     '/js/pdf-import-review-runtime.js',
     '/js/theme-runtime.js',
+    '/js/touch-tooltip-runtime.js',
     '/js/schema.js',
     '/js/dna-window-bindings.js',
     '/js/sync-diagnose-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -396,6 +396,7 @@
     "js/supplement-impact.js",
     "js/supplement-warnings.js",
     "js/supplements.js",
+    "js/touch-tooltip-runtime.js",
     "js/touch-tooltip.js"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -303,6 +303,7 @@
     "js/supplements.js",
     "js/theme.js",
     "js/theme-runtime.js",
+    "js/touch-tooltip-runtime.js",
     "js/touch-tooltip.js",
     "js/tour.js",
     "js/url-safety.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.98';
+self.APP_VERSION = '1.10.99';


### PR DESCRIPTION
## Summary
- Added `touch-tooltip-runtime.js` to isolate app tooltip browser runtime access.
- Routed touch media detection, viewport reads, and window scroll/resize listener binding through the runtime adapter.
- Added service worker, typecheck, static verification, and Vitest coverage for the new module and bumped `version.js` for cache invalidation.

## Window burden
- Quality baseline: `windowReferences` `208` -> `202` (`-6`).
- `js/touch-tooltip.js`: direct `window.`/`window[...]` references `6` -> `0` by moving touch media queries, viewport bounds, and window scroll/resize listener binding behind `touch-tooltip-runtime.js`.

## Validation
- `git diff --check`
- `node tests/verify-modules.js`
- `npm run quality`
- `npm test -- --reporter=dot tests/touch-tooltip-runtime.test.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot`
- `npx playwright test tests/playwright/ui-helper-modules-browser-coverage.spec.js --project=chromium`
- `./run-tests.sh`