### PR TITLE
[codex] Extract notes runtime hooks

### DIFF
--- a/js/notes-runtime.js
+++ b/js/notes-runtime.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+/**
+ * @typedef {Window & typeof globalThis & {
+ *   closeModal?: () => void,
+ *   rememberModalTrigger?: () => void,
+ *   navigate?: (route: string) => void,
+ *   __noteActionDelegatesBound?: boolean,
+ * }} NotesRuntimeWindow
+ */
+
+function getNotesRuntimeWindow() {
+  return /** @type {NotesRuntimeWindow | null} */ (typeof window !== 'undefined' ? window : null);
+}
+
+export function closeNoteModalRuntime() {
+  const runtime = getNotesRuntimeWindow();
+  runtime?.closeModal?.();
+}
+
+export function rememberNoteModalTriggerRuntime() {
+  const runtime = getNotesRuntimeWindow();
+  runtime?.rememberModalTrigger?.();
+}
+
+export function navigateAfterNoteChangeRuntime(route = 'dashboard') {
+  const runtime = getNotesRuntimeWindow();
+  runtime?.navigate?.(route || 'dashboard');
+}
+
+export function isNoteActionDelegatesBoundRuntime() {
+  const runtime = getNotesRuntimeWindow();
+  return !!runtime?.__noteActionDelegatesBound;
+}
+
+export function markNoteActionDelegatesBoundRuntime() {
+  const runtime = getNotesRuntimeWindow();
+  if (!runtime) return false;
+  runtime.__noteActionDelegatesBound = true;
+  return true;
+}
+
+export function exposeNoteEditorRuntime(actions) {
+  const runtime = getNotesRuntimeWindow();
+  if (!runtime) return false;
+  Object.assign(runtime, actions);
+  return true;
+}

--- a/js/notes.js
+++ b/js/notes.js
@@ -10,17 +10,19 @@ import {
   replaceImportedArrayItem,
 } from './data-merge.js';
 import { openModalOverlay } from './modal-lifecycle.js';
+import {
+  closeNoteModalRuntime,
+  exposeNoteEditorRuntime,
+  isNoteActionDelegatesBoundRuntime,
+  markNoteActionDelegatesBoundRuntime,
+  navigateAfterNoteChangeRuntime,
+  rememberNoteModalTriggerRuntime,
+} from './notes-runtime.js';
 
 let _noteActionDelegatesInstalled = false;
 
 const NOTE_ACTION_ATTR = 'data-note-action';
 const NOTE_ACTION_SELECTOR = `[${NOTE_ACTION_ATTR}]`;
-const appWindow = /** @type {Window & typeof globalThis & {
-  closeModal?: () => void,
-  saveNote?: (idx?: number | null) => void,
-  deleteNote?: (idx: number) => Promise<void>,
-  __noteActionDelegatesBound?: boolean,
-}} */ (typeof window !== 'undefined' ? window : {});
 
 function noteActionAttrs(action, attrs = {}) {
   let html = `${NOTE_ACTION_ATTR}="${escapeAttr(action)}"`;
@@ -51,13 +53,13 @@ function handleNoteActionClick(event) {
   if (!actionEl) return;
   const action = actionEl.getAttribute(NOTE_ACTION_ATTR);
   if (action === 'close') {
-    appWindow.closeModal?.();
+    closeNoteModalRuntime();
   } else if (action === 'save') {
-    appWindow.saveNote?.(parseNoteIndex(actionEl));
+    saveNote(parseNoteIndex(actionEl));
   } else if (action === 'delete') {
     const idx = parseNoteIndex(actionEl);
     if (idx === null) return;
-    appWindow.deleteNote?.(idx);
+    deleteNote(idx);
   } else {
     return;
   }
@@ -65,9 +67,9 @@ function handleNoteActionClick(event) {
 }
 
 export function installNoteActionDelegates(root = typeof document !== 'undefined' ? document : null) {
-  if (!root || _noteActionDelegatesInstalled || appWindow.__noteActionDelegatesBound) return;
+  if (!root || _noteActionDelegatesInstalled || isNoteActionDelegatesBoundRuntime()) return;
   _noteActionDelegatesInstalled = true;
-  appWindow.__noteActionDelegatesBound = true;
+  markNoteActionDelegatesBoundRuntime();
   root.addEventListener('click', handleNoteActionClick);
 }
 
@@ -88,7 +90,7 @@ function refreshOpenNoteEditorOnSync({ modal }) {
   if (nextIdx >= 0) {
     openNoteEditor(null, nextIdx);
   } else {
-    window.closeModal?.();
+    closeNoteModalRuntime();
   }
 }
 
@@ -128,7 +130,7 @@ export function openNoteEditor(date, existingIdx) {
   modal.dataset.syncRefreshMode = isEditing ? 'edit' : 'add';
   modal.dataset.syncRefreshIndex = isEditing ? String(existingIdx) : '';
   modal.dataset.syncRefreshDate = defaultDate || '';
-  if (!wasOpen) window.rememberModalTrigger?.();
+  if (!wasOpen) rememberNoteModalTriggerRuntime();
   openModalOverlay(overlay, { initialFocus: '#note-textarea', focusDelay: 50 });
 }
 
@@ -148,9 +150,9 @@ export function saveNote(idx) {
     appendImportedArrayItem(state.importedData, 'notes', nextNote);
   }
   saveImportedData();
-  window.closeModal();
+  closeNoteModalRuntime();
   const activeNav = /** @type {HTMLElement | null} */ (document.querySelector(".nav-item.active"));
-  window.navigate(activeNav?.dataset.category ?? "dashboard");
+  navigateAfterNoteChangeRuntime(activeNav?.dataset.category ?? "dashboard");
   showNotification('Note saved', 'success');
 }
 
@@ -160,11 +162,11 @@ export async function deleteNote(idx) {
   if (await showConfirmDialog("Delete this note? This can't be undone.")) {
     deleteImportedArrayItem(state.importedData, 'notes', idx);
     saveImportedData();
-    window.closeModal();
+    closeNoteModalRuntime();
     const activeNav = /** @type {HTMLElement | null} */ (document.querySelector(".nav-item.active"));
-    window.navigate(activeNav?.dataset.category ?? "dashboard");
+    navigateAfterNoteChangeRuntime(activeNav?.dataset.category ?? "dashboard");
     showNotification('Note deleted', 'info');
   }
 }
 
-Object.assign(window, { openNoteEditor, saveNote, deleteNote });
+exposeNoteEditorRuntime({ openNoteEditor, saveNote, deleteNote });

--- a/service-worker.js
+++ b/service-worker.js
@@ -115,6 +115,7 @@ const APP_SHELL = [
   '/js/pii.js',
   '/js/charts-runtime.js',
   '/js/charts.js',
+  '/js/notes-runtime.js',
   '/js/notes.js',
   '/js/supplement-action-delegates.js',
   '/js/supplements.js',

--- a/tests/notes-runtime.test.js
+++ b/tests/notes-runtime.test.js
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  closeNoteModalRuntime,
+  exposeNoteEditorRuntime,
+  isNoteActionDelegatesBoundRuntime,
+  markNoteActionDelegatesBoundRuntime,
+  navigateAfterNoteChangeRuntime,
+  rememberNoteModalTriggerRuntime,
+} from '../js/notes-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) {
+    Object.defineProperty(globalThis, 'window', savedWindow);
+  } else {
+    delete globalThis.window;
+  }
+});
+
+describe('notes runtime adapter', () => {
+  it('delegates modal focus, close, and navigation hooks', () => {
+    const closeModal = vi.fn();
+    const rememberModalTrigger = vi.fn();
+    const navigate = vi.fn();
+    setRuntimeWindow({ closeModal, rememberModalTrigger, navigate });
+
+    closeNoteModalRuntime();
+    rememberNoteModalTriggerRuntime();
+    navigateAfterNoteChangeRuntime('labs');
+    navigateAfterNoteChangeRuntime('');
+
+    expect(closeModal).toHaveBeenCalledTimes(1);
+    expect(rememberModalTrigger).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenNthCalledWith(1, 'labs');
+    expect(navigate).toHaveBeenNthCalledWith(2, 'dashboard');
+  });
+
+  it('tracks delegated action binding and exposes note actions', () => {
+    const runtime = {};
+    const actions = {
+      openNoteEditor: vi.fn(),
+      saveNote: vi.fn(),
+      deleteNote: vi.fn(),
+    };
+    setRuntimeWindow(runtime);
+
+    expect(isNoteActionDelegatesBoundRuntime()).toBe(false);
+    expect(markNoteActionDelegatesBoundRuntime()).toBe(true);
+    expect(isNoteActionDelegatesBoundRuntime()).toBe(true);
+    expect(exposeNoteEditorRuntime(actions)).toBe(true);
+    expect(runtime).toMatchObject(actions);
+  });
+
+  it('uses safe fallbacks when browser runtime hooks are missing', () => {
+    delete globalThis.window;
+
+    expect(() => closeNoteModalRuntime()).not.toThrow();
+    expect(() => rememberNoteModalTriggerRuntime()).not.toThrow();
+    expect(() => navigateAfterNoteChangeRuntime('dashboard')).not.toThrow();
+    expect(isNoteActionDelegatesBoundRuntime()).toBe(false);
+    expect(markNoteActionDelegatesBoundRuntime()).toBe(false);
+    expect(exposeNoteEditorRuntime({ openNoteEditor: vi.fn() })).toBe(false);
+  });
+
+  it('keeps counted notes browser globals behind the adapter', () => {
+    const notesSrc = readFileSync(new URL('../js/notes.js', import.meta.url), 'utf8');
+    const runtimeSrc = readFileSync(new URL('../js/notes-runtime.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(notesSrc).toContain("from './notes-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(notesSrc)).toBe(false);
+    expect(/\bwindow(?:\.|\s*\[)/.test(runtimeSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/notes-runtime.js'");
+  });
+});

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -769,8 +769,9 @@ await import('../js/settings.js');
       && markerDetailModalSrc.includes('delete detailModal.dataset.syncRefreshEditIdx'));
   assert('notes editor opens through shared overlay lifecycle helper',
     notesSrc.includes("from './modal-lifecycle.js'") &&
+      notesSrc.includes("from './notes-runtime.js'") &&
       notesSrc.includes("openModalOverlay(overlay, { initialFocus: '#note-textarea', focusDelay: 50 })") &&
-      notesSrc.includes('window.rememberModalTrigger?.()'));
+      notesSrc.includes('rememberNoteModalTriggerRuntime()'));
   assert('active-profile sync broadcasts shared modal refresh event without marker special-casing',
     syncPullActiveRefreshSrc.includes('dispatchSyncAppliedRuntime()')
       && syncPullActiveRefreshRuntimeSrc.includes("new runtime.CustomEvent('labcharts-sync-applied')")

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -96,6 +96,7 @@
     '/js/provider-model-controls-runtime.js',
     '/js/api-runtime.js',
     '/js/charts-runtime.js',
+    '/js/notes-runtime.js',
     '/js/pdf-import-review-runtime.js',
     '/js/theme-runtime.js',
     '/js/touch-tooltip-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -376,6 +376,7 @@
     "js/marker-analysis.js",
     "js/marker-detail-actions.js",
     "js/marker-detail-editing.js",
+    "js/notes-runtime.js",
     "js/notes.js",
     "js/profile-context.js",
     "js/provider-local-ai-runtime.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -162,6 +162,7 @@
     "js/mobile-dashboard-runtime.js",
     "js/modal-lifecycle.js",
     "js/nav.js",
+    "js/notes-runtime.js",
     "js/notes.js",
     "js/nostr-discovery.js",
     "js/onboarding-view-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.101';
+self.APP_VERSION = '1.10.102';


### PR DESCRIPTION
## Summary
- Added `notes-runtime.js` for notes modal close/focus, delegated-action binding state, navigation, and global action exposure hooks.
- Routed `notes.js` modal and navigation host hooks through the runtime adapter while preserving the note editor add/edit/delete behavior.
- Updated service-worker/typecheck/module manifests, refreshed the sync source assertion, and added focused runtime adapter coverage.

## Window burden
- Quality baseline: `windowReferences` `187` -> `181` (`-6`).
- `js/notes.js`: counted direct `window.`/`window[...]` references `6` -> `0` by moving close-modal, remember-trigger, navigation, and delegate binding/exposure hooks behind `notes-runtime.js`.

## Tests
- `rg -n "\bwindow(?:\.|\s*\[)" js/notes.js js/notes-runtime.js` (no matches)
- `git diff --check`
- `node tests/verify-modules.js`
- `npm test -- --reporter=dot tests/notes-runtime.test.js`
- `node tests/test-sync.js`
- `npm run quality` (`windowReferences` `181/202`)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot`
- `./run-tests.sh`