### PR TITLE
[codex] Extract API provider storage runtime hooks

### DIFF
--- a/js/api-provider-storage-runtime.js
+++ b/js/api-provider-storage-runtime.js
@@ -1,0 +1,49 @@
+// @ts-check
+// api-provider-storage-runtime.js - Browser runtime adapters for persisted provider settings.
+
+function getApiProviderStorageRuntime() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getApiProviderStorageRuntime();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function refreshAIProviderSelectionRuntime() {
+  let refreshed = false;
+  const updateHeader = getRuntimeFunction('updateChatHeaderModel');
+  if (updateHeader) {
+    updateHeader();
+    refreshed = true;
+  }
+  const refreshWebSearch = getRuntimeFunction('refreshWebSearchToggle');
+  if (refreshWebSearch) {
+    refreshWebSearch();
+    refreshed = true;
+  }
+  return refreshed;
+}
+
+export function dispatchAISettingsLocalChangedRuntime() {
+  const runtime = getApiProviderStorageRuntime();
+  if (!runtime || typeof runtime.dispatchEvent !== 'function' || typeof runtime.CustomEvent !== 'function') return false;
+  try {
+    runtime.dispatchEvent(new runtime.CustomEvent('labcharts-ai-settings-local-changed'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getOllamaConfigStorageRuntime() {
+  const getOllamaConfig = getRuntimeFunction('getOllamaConfig');
+  if (!getOllamaConfig) return {};
+  return getOllamaConfig() || {};
+}

--- a/js/api-provider-storage.js
+++ b/js/api-provider-storage.js
@@ -2,10 +2,14 @@
 // api-provider-storage.js — persisted AI provider settings, keys, and model caches.
 
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
+import {
+  dispatchAISettingsLocalChangedRuntime,
+  getOllamaConfigStorageRuntime,
+  refreshAIProviderSelectionRuntime,
+} from './api-provider-storage-runtime.js';
 
 function notifyAISelectionChanged() {
-  window.updateChatHeaderModel?.();
-  window.refreshWebSearchToggle?.();
+  refreshAIProviderSelectionRuntime();
 }
 
 export function getAIProvider() { return localStorage.getItem('labcharts-ai-provider') || 'openrouter'; }
@@ -23,7 +27,7 @@ export function markAISettingsLocal() {
   try {
     sessionStorage.setItem(AI_SETTINGS_LOCAL_LOCK_UNTIL_KEY, String(Date.now() + 5 * 60 * 1000));
   } catch {}
-  try { window.dispatchEvent(new CustomEvent('labcharts-ai-settings-local-changed')); } catch {}
+  dispatchAISettingsLocalChangedRuntime();
 }
 
 export function hasAIProvider() {
@@ -37,13 +41,13 @@ export function hasAIProvider() {
   return true; // Ollama — optimistic, errors caught at call time
 }
 
-export function getOllamaMainModel() { return localStorage.getItem('labcharts-ollama-model') || window.getOllamaConfig().model || 'llama3.2'; }
+export function getOllamaMainModel() { return localStorage.getItem('labcharts-ollama-model') || getOllamaConfigStorageRuntime().model || 'llama3.2'; }
 export function setOllamaMainModel(model) {
   localStorage.setItem('labcharts-ollama-model', model);
   markAISettingsLocal();
   notifyAISelectionChanged();
 }
-export function getOllamaPIIUrl() { return localStorage.getItem('labcharts-ollama-pii-url') || window.getOllamaConfig().url; }
+export function getOllamaPIIUrl() { return localStorage.getItem('labcharts-ollama-pii-url') || getOllamaConfigStorageRuntime().url; }
 export function setOllamaPIIUrl(url) {
   localStorage.setItem('labcharts-ollama-pii-url', url);
   markAISettingsLocal();

--- a/service-worker.js
+++ b/service-worker.js
@@ -88,6 +88,7 @@ const APP_SHELL = [
   '/js/api-runtime.js',
   '/js/api.js',
   '/js/api-models.js',
+  '/js/api-provider-storage-runtime.js',
   '/js/api-provider-storage.js',
   '/js/api-transport.js',
   '/js/startup-foundation.js',

--- a/tests/api-provider-storage-runtime.test.js
+++ b/tests/api-provider-storage-runtime.test.js
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  dispatchAISettingsLocalChangedRuntime,
+  getOllamaConfigStorageRuntime,
+  refreshAIProviderSelectionRuntime,
+} from '../js/api-provider-storage-runtime.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntimeWindow(runtime) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: runtime,
+  });
+}
+
+afterEach(() => {
+  if (savedWindow) {
+    Object.defineProperty(globalThis, 'window', savedWindow);
+  } else {
+    delete globalThis.window;
+  }
+});
+
+describe('api provider storage runtime adapter', () => {
+  it('delegates provider UI refresh hooks and Ollama config reads', () => {
+    const updateChatHeaderModel = vi.fn();
+    const refreshWebSearchToggle = vi.fn();
+    const getOllamaConfig = vi.fn(() => ({ model: 'llama-test', url: 'http://ollama.test' }));
+    setRuntimeWindow({ updateChatHeaderModel, refreshWebSearchToggle, getOllamaConfig });
+
+    expect(refreshAIProviderSelectionRuntime()).toBe(true);
+    expect(getOllamaConfigStorageRuntime()).toEqual({ model: 'llama-test', url: 'http://ollama.test' });
+    expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
+    expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);
+    expect(getOllamaConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches the local AI settings change event', () => {
+    const dispatchEvent = vi.fn();
+    class TestCustomEvent {
+      constructor(type) {
+        this.type = type;
+      }
+    }
+    setRuntimeWindow({ CustomEvent: TestCustomEvent, dispatchEvent });
+
+    expect(dispatchAISettingsLocalChangedRuntime()).toBe(true);
+    expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'labcharts-ai-settings-local-changed' }));
+  });
+
+  it('uses safe fallbacks when browser runtime hooks are missing', () => {
+    delete globalThis.window;
+
+    expect(refreshAIProviderSelectionRuntime()).toBe(false);
+    expect(dispatchAISettingsLocalChangedRuntime()).toBe(false);
+    expect(getOllamaConfigStorageRuntime()).toEqual({});
+  });
+
+  it('keeps counted api provider storage globals behind the adapter', () => {
+    const storageSrc = readFileSync(new URL('../js/api-provider-storage.js', import.meta.url), 'utf8');
+    const runtimeSrc = readFileSync(new URL('../js/api-provider-storage-runtime.js', import.meta.url), 'utf8');
+    const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
+
+    expect(storageSrc).toContain("from './api-provider-storage-runtime.js'");
+    expect(/\bwindow(?:\.|\s*\[)/.test(storageSrc)).toBe(false);
+    expect(/\bwindow(?:\.|\s*\[)/.test(runtimeSrc)).toBe(false);
+    expect(swSrc).toContain("'/js/api-provider-storage-runtime.js'");
+  });
+});

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -95,6 +95,7 @@
     '/js/provider-local-ai-runtime.js',
     '/js/provider-model-controls-runtime.js',
     '/js/api-runtime.js',
+    '/js/api-provider-storage-runtime.js',
     '/js/charts-runtime.js',
     '/js/notes-runtime.js',
     '/js/pdf-import-review-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -254,6 +254,7 @@
     "js/wearables.js",
     "js/api-runtime.js",
     "js/api-transport.js",
+    "js/api-provider-storage-runtime.js",
     "js/api-provider-storage.js",
     "js/api-models.js",
     "js/provider-model-controls-runtime.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -184,6 +184,7 @@
     "js/recommendations.js",
     "js/api-runtime.js",
     "js/api.js",
+    "js/api-provider-storage-runtime.js",
     "js/api-provider-storage.js",
     "js/api-transport.js",
     "js/provider-local-ai-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.102';
+self.APP_VERSION = '1.10.103';


### PR DESCRIPTION
## Summary
- Added `api-provider-storage-runtime.js` for provider UI refresh hooks, local AI-settings change events, and Ollama config reads.
- Routed `api-provider-storage.js` browser hooks through the adapter while preserving provider selection and model storage behavior.
- Updated service-worker/typecheck/module manifests and added focused runtime adapter coverage.

## Window burden
- Quality baseline: `windowReferences` `181` -> `176` (`-5`).
- `js/api-provider-storage.js`: counted direct `window.`/`window[...]` references `5` -> `0` by moving chat-header/web-search refreshes, AI-settings change dispatch, and Ollama config reads behind `api-provider-storage-runtime.js`.

## Tests
- `rg -n "\bwindow(?:\.|\s*\[)" js/api-provider-storage.js js/api-provider-storage-runtime.js` (no matches)
- `git diff --check`
- `node tests/verify-modules.js`
- `npm test -- --reporter=dot tests/api-provider-storage-runtime.test.js`
- `npm run quality` (`windowReferences` `176/202`)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test -- --reporter=dot tests/api-provider-storage-runtime.test.js tests/api-provider-runtime.test.js tests/provider-model-controls-runtime.test.js tests/sync-runtime.test.js`
- `npx playwright test tests/playwright/api-provider-storage-browser-coverage.spec.js tests/playwright/provider-coverage-batch.spec.js --project=chromium`
- `npm test -- --reporter=dot`
- `./run-tests.sh`