### PR TITLE
[codex] Extract dashboard widget renderer runtime hooks

### DIFF
--- a/js/dashboard-widget-renderers.js
+++ b/js/dashboard-widget-renderers.js
@@ -4,6 +4,12 @@
 import { state } from './state.js';
 import { DEFAULT_METRIC_ORDER, canonicalMetric, metricsForSources } from './wearable-adapters.js';
 import { dashboardWidgetActionAttrs } from './dashboard-widget-controls.js';
+import {
+  getDashboardDeviceSessions,
+  getDashboardLightSessions,
+  getDashboardSnpTableCache,
+  openDashboardMarkerDetail,
+} from './dashboard-widget-runtime.js';
 import { dashboardBiometricSelectionKey, DASHBOARD_MANUAL_BIOMETRIC_METRICS } from './dashboard-widgets.js';
 import { createDashboardRecommendationWidget } from './dashboard-recommendation-widget.js';
 import { ensureSNPTable, findGenotypeInfo, getSnpCategoryLabel } from './dna.js';
@@ -96,8 +102,8 @@ export function createDashboardWidgetRenderers(deps) {
   }
 
   function renderDashboardLightChannelsWidget() {
-    const sessions = (window.getSessions && window.getSessions()) || [];
-    const deviceSessionsAll = (window.getDeviceSessions && window.getDeviceSessions()) || [];
+    const sessions = getDashboardLightSessions();
+    const deviceSessionsAll = getDashboardDeviceSessions();
     const totalSessions = sessions.length + deviceSessionsAll.length;
     const lead = totalSessions === 0
       ? 'No light sessions yet. Start logging sun or device exposure to fill your channel rhythm.'
@@ -305,7 +311,7 @@ export function createDashboardWidgetRenderers(deps) {
     saveDashboardQuickMarkerPins(pins);
     showNotification(pinned ? 'Pinned to Quick Markers' : 'Removed from Quick Markers', pinned ? 'success' : 'info');
     if (state.currentView === 'dashboard') rerenderDashboardFromWidgetChange();
-    if (state._activeDetailMarkerId === id) window.showDetailModal?.(id);
+    if (state._activeDetailMarkerId === id) openDashboardMarkerDetail(id);
   }
 
   function getDashboardQuickMarkerCoreRanks() {
@@ -907,7 +913,7 @@ export function createDashboardWidgetRenderers(deps) {
     const genetics = state.importedData?.genetics;
     const snps = genetics?.snps || {};
     const apoe = genetics?.apoe;
-    const snpTable = typeof window !== 'undefined' ? window._snpTableCache : null;
+    const snpTable = getDashboardSnpTableCache();
     const snpCount = Object.keys(snps).length;
     if (snpCount && !snpTable) {
       refreshDashboardGenomeWidgetWhenSNPTableReady();

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -1,5 +1,5 @@
 // @ts-check
-// dashboard-widget-runtime.js - Browser runtime adapters for dashboard widget controls.
+// dashboard-widget-runtime.js - Browser runtime adapters for dashboard widget controls and renderers.
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -25,6 +25,34 @@ export function getDashboardViewportHeight() {
 
 export function openDashboardWearablesSettings() {
   getRuntimeFunction('openSettingsModal')?.('wearables');
+}
+
+export function getDashboardLightSessions() {
+  const getSessions = getRuntimeFunction('getSessions');
+  if (!getSessions) return [];
+  try {
+    const sessions = getSessions();
+    return Array.isArray(sessions) ? sessions : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getDashboardDeviceSessions() {
+  const getDeviceSessions = getRuntimeFunction('getDeviceSessions');
+  if (!getDeviceSessions) return [];
+  try {
+    const sessions = getDeviceSessions();
+    return Array.isArray(sessions) ? sessions : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getDashboardSnpTableCache() {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return null;
+  return runtime._snpTableCache || null;
 }
 
 /** @param {Element} actionEl */

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -42,6 +42,10 @@ assert('dashboard widget runtime owns shell callbacks',
     runtimeSrc.includes('openNoteEditor'));
 assert('dashboard widget controls has no direct window refs',
   !/\bwindow(\.|\s*\[)/.test(controlsSrc));
+assert('dashboard widget renderers import runtime adapter',
+  renderersSrc.includes("from './dashboard-widget-runtime.js'"));
+assert('dashboard widget renderers have no direct window refs',
+  !/\bwindow(\.|\s*\[)/.test(renderersSrc));
 assert('dashboard widget renderers render no inline event attributes',
   !/\bon(?:click|input|change|keydown|keyup|submit)=/.test(renderersSrc));
 assert('dashboard widget controls render delegated action attributes',

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -4,6 +4,9 @@
 import './_node-shim.js';
 import {
   deleteDashboardNote,
+  getDashboardDeviceSessions,
+  getDashboardLightSessions,
+  getDashboardSnpTableCache,
   getDashboardViewportHeight,
   navigateDashboardRoute,
   openDashboardManualLogForm,
@@ -26,6 +29,9 @@ console.log('=== Dashboard Widget Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'innerHeight',
+  'getSessions',
+  'getDeviceSessions',
+  '_snpTableCache',
   'openSettingsModal',
   'syncWearableNow',
   'openWearableDetail',
@@ -64,6 +70,25 @@ try {
   setRuntimeValue('innerHeight', 0);
   assert('getDashboardViewportHeight preserves zero-height runtime fallback',
     getDashboardViewportHeight() === 0);
+
+  const snpTable = { rs123: { rsid: 'rs123' } };
+  setRuntimeValue('getSessions', () => [{ id: 'sun-1' }]);
+  setRuntimeValue('getDeviceSessions', () => [{ id: 'device-1' }]);
+  setRuntimeValue('_snpTableCache', snpTable);
+  assert('runtime adapter reads dashboard renderer data hooks',
+    getDashboardLightSessions().length === 1 &&
+      getDashboardLightSessions()[0].id === 'sun-1' &&
+      getDashboardDeviceSessions().length === 1 &&
+      getDashboardDeviceSessions()[0].id === 'device-1' &&
+      getDashboardSnpTableCache() === snpTable);
+
+  setRuntimeValue('getSessions', () => { throw new Error('boom'); });
+  setRuntimeValue('getDeviceSessions', () => ({ id: 'not-array' }));
+  setRuntimeValue('_snpTableCache', null);
+  assert('runtime adapter falls back for missing renderer data hooks',
+    getDashboardLightSessions().length === 0 &&
+      getDashboardDeviceSessions().length === 0 &&
+      getDashboardSnpTableCache() === null);
 
   const actionEl = { dataset: { dashboardWidgetAction: 'sync-biometric-now' } };
   const event = { type: 'click' };
@@ -116,6 +141,9 @@ try {
   deleteDashboardNote(2);
   assert('runtime adapter no-ops safely when window is missing',
     getDashboardViewportHeight() === null &&
+      getDashboardLightSessions().length === 0 &&
+      getDashboardDeviceSessions().length === 0 &&
+      getDashboardSnpTableCache() === null &&
       openDashboardWearableDetail('sleep') === false &&
       calls.length === callCountBeforeMissingRuntime);
 } finally {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.103';
+self.APP_VERSION = '1.10.104';


### PR DESCRIPTION
## Summary
- Extended `dashboard-widget-runtime.js` with safe renderer data hooks for light sessions, device sessions, and the SNP table cache.
- Routed `dashboard-widget-renderers.js` through the runtime adapter for light channel counts, active marker-detail refresh, and genome SNP cache access.
- Added focused runtime/source guards and bumped `version.js` for cache invalidation.

## Window burden
- Quality baseline: `windowReferences` `176` -> `170` (`-6`).
- `js/dashboard-widget-renderers.js`: counted direct `window.`/`window[...]` references `6` -> `0` by moving `getSessions`, `getDeviceSessions`, `showDetailModal`, and `_snpTableCache` access behind `dashboard-widget-runtime.js`.

## Tests
- `rg -n "\bwindow(?:\.|\s*\[)" js/dashboard-widget-renderers.js js/dashboard-widget-runtime.js` (no matches)
- `git diff --check`
- `node tests/test-dashboard-widget-runtime.js`
- `node tests/test-dashboard-widget-delegated-actions.js`
- `npm run quality` (`windowReferences` `170/202`)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/verify-modules.js`
- `npm test -- --reporter=dot tests/_vitest-legacy.test.js`
- `npx playwright test tests/playwright/dashboard-widget-controls-browser-coverage.spec.js tests/playwright/dashboard-widget-delegated-actions-dom.spec.js tests/playwright/dashboard-widgets-browser-coverage.spec.js tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js --project=chromium`
- `npm test -- --reporter=dot`
- `./run-tests.sh`