### PR TITLE
[codex] Extract chat render runtime hooks

### DIFF
--- a/js/chat-render-runtime.js
+++ b/js/chat-render-runtime.js
@@ -1,0 +1,49 @@
+// @ts-check
+// chat-render-runtime.js - Browser runtime adapters for chat render hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {any}
+ */
+function getRuntimeValue(name) {
+  const runtime = getRuntimeWindow();
+  return runtime ? runtime[name] : undefined;
+}
+
+export function isChatRenderProductRecsEnabled() {
+  try {
+    return Boolean(getRuntimeFunction('isProductRecsEnabled')?.());
+  } catch {
+    return false;
+  }
+}
+
+/** @param {unknown} slots */
+export function renderChatRecommendationSections(slots) {
+  if (!Array.isArray(slots) || !slots.length || !isChatRenderProductRecsEnabled()) return [];
+  const renderRecommendationSectionSync = getRuntimeFunction('renderRecommendationSectionSync');
+  const catalog = getRuntimeValue('_cachedCatalog');
+  const catalogSlots = catalog?.slots;
+  if (!renderRecommendationSectionSync || !catalogSlots) return [];
+  return slots.map(slot => {
+    const slotKey = String(slot || '');
+    if (!slotKey) return '';
+    const slotLabel = catalogSlots[slotKey]?.label || slotKey.split('.').pop();
+    return renderRecommendationSectionSync(slotKey, { label: slotLabel, maxProducts: 2 });
+  }).filter(Boolean);
+}

--- a/js/chat-render.js
+++ b/js/chat-render.js
@@ -15,6 +15,7 @@ import { updateChatHeaderTitle } from './chat-personalities.js';
 import { updateChatInputState } from './chat-panel.js';
 import { updateDiscussButton } from './chat-discussion.js';
 import { renderEmptyChatState } from './chat-empty-state.js';
+import { isChatRenderProductRecsEnabled, renderChatRecommendationSections } from './chat-render-runtime.js';
 
 export { _getNoDataPrompts } from './chat-empty-state.js';
 
@@ -116,15 +117,12 @@ export function renderChatMessages() {
         html += _renderLensSources(msg.lensSources, msg.lensSourceName);
       }
       // EMF hint (persisted, single-line link to assessment editor)
-      if (msg.emfHint && window.isProductRecsEnabled?.()) {
+      if (msg.emfHint && isChatRenderProductRecsEnabled()) {
         html += `<div class="chat-emf-hint"><span aria-hidden="true">💡</span> Curious about your EMF environment? <a href="#" ${chatMessageActionAttrs('open-emf-assessment')} data-umami-event="emf-nudge-chat">Open the assessment →</a></div>`;
       }
       // Rec slots (persisted on message, rendered from catalog)
-      if (msg.recSlots?.length && window.isProductRecsEnabled?.() && window.renderRecommendationSectionSync && window._cachedCatalog?.slots) {
-        const recSections = msg.recSlots.map(slot => {
-          const slotLabel = window._cachedCatalog.slots[slot]?.label || slot.split('.').pop();
-          return window.renderRecommendationSectionSync(slot, { label: slotLabel, maxProducts: 2 });
-        }).filter(Boolean);
+      if (msg.recSlots?.length) {
+        const recSections = renderChatRecommendationSections(msg.recSlots);
         if (recSections.length) {
           html += `<details class="rec-chat-wrapper" ${chatMessageActionAttrs('contain-click')}><summary class="rec-chat-summary">What can help</summary>`;
           let recBody = recSections.map(s => s.replace('rec-section-header', 'rec-chat-subheading')).join('');

--- a/service-worker.js
+++ b/service-worker.js
@@ -175,6 +175,7 @@ const APP_SHELL = [
   '/js/chat-discussion-ui.js',
   '/js/chat-onboarding.js',
   '/js/chat-empty-state.js',
+  '/js/chat-render-runtime.js',
   '/js/chat-render.js',
   '/js/chat-send.js',
   '/js/chat-send-runtime.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -180,6 +180,7 @@ const LEGACY_TESTS = [
   './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',
+  './test-chat-render-runtime.js',
   './test-chat-send-runtime.js',
   './test-context-card-lifestyle-runtime.js',
   './test-import-drop-zone-runtime.js',

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -310,6 +310,14 @@ console.log('=== Phase 3 A11y Tests ===\n');
       && importDropZoneRuntimeSrc.includes('isDropZoneImportRunning')
       && importDropZoneRuntimeSrc.includes('handleDropZoneDNAFile'));
 
+  const chatRenderSrc = read('/js/chat-render.js');
+  const chatRenderRuntimeSrc = read('/js/chat-render-runtime.js');
+  assert('chat-render browser hooks are isolated in runtime adapter',
+    chatRenderSrc.includes("from './chat-render-runtime.js'")
+      && !/\bwindow(\.|\s*\[)/.test(chatRenderSrc)
+      && chatRenderRuntimeSrc.includes('isChatRenderProductRecsEnabled')
+      && chatRenderRuntimeSrc.includes('renderChatRecommendationSections'));
+
   const chatSendRuntimeSrc = read('/js/chat-send-runtime.js');
   assert('chat-send browser hooks are isolated in runtime adapter',
     chatSendSrc.includes("from './chat-send-runtime.js'")

--- a/tests/test-chat-render-runtime.js
+++ b/tests/test-chat-render-runtime.js
@@ -1,0 +1,119 @@
+// test-chat-render-runtime.js - Chat render browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  isChatRenderProductRecsEnabled,
+  renderChatRecommendationSections,
+} from '../js/chat-render-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Chat Render Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'isProductRecsEnabled',
+  'renderRecommendationSectionSync',
+  '_cachedCatalog',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  setRuntimeValue('isProductRecsEnabled', () => {
+    calls.push(['enabled']);
+    return true;
+  });
+  setRuntimeValue('_cachedCatalog', {
+    slots: {
+      'vitamins.vitaminD': { label: 'Vitamin D' },
+    },
+  });
+  setRuntimeValue('renderRecommendationSectionSync', (slot, options) => {
+    calls.push(['render', slot, options]);
+    return `<section>${options.label}:${slot}:${options.maxProducts}</section>`;
+  });
+
+  assert('isChatRenderProductRecsEnabled delegates runtime flag',
+    isChatRenderProductRecsEnabled() === true && calls.some(call => call[0] === 'enabled'));
+
+  const sections = renderChatRecommendationSections(['vitamins.vitaminD', 'minerals.magnesium']);
+  assert('renderChatRecommendationSections renders all available slots',
+    sections.length === 2
+      && sections[0] === '<section>Vitamin D:vitamins.vitaminD:2</section>'
+      && sections[1] === '<section>magnesium:minerals.magnesium:2</section>');
+  assert('renderChatRecommendationSections passes slot labels and max product count',
+    calls.some(call => call[0] === 'render'
+      && call[1] === 'vitamins.vitaminD'
+      && call[2]?.label === 'Vitamin D'
+      && call[2]?.maxProducts === 2));
+  assert('renderChatRecommendationSections falls back to final slot segment',
+    calls.some(call => call[0] === 'render'
+      && call[1] === 'minerals.magnesium'
+      && call[2]?.label === 'magnesium'));
+
+  setRuntimeValue('isProductRecsEnabled', () => false);
+  assert('renderChatRecommendationSections returns empty when product recs are disabled',
+    renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
+
+  setRuntimeValue('isProductRecsEnabled', () => true);
+  delete globalThis.renderRecommendationSectionSync;
+  assert('renderChatRecommendationSections requires the sync renderer',
+    renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
+
+  setRuntimeValue('renderRecommendationSectionSync', () => '<section>unused</section>');
+  delete globalThis._cachedCatalog;
+  assert('renderChatRecommendationSections requires cached catalog slots',
+    renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
+
+  setRuntimeValue('_cachedCatalog', { slots: {} });
+  assert('renderChatRecommendationSections ignores non-array slot input',
+    renderChatRecommendationSections('vitamins.vitaminD').length === 0);
+
+  setRuntimeValue('isProductRecsEnabled', () => { throw new Error('boom'); });
+  assert('isChatRenderProductRecsEnabled returns false when runtime flag throws',
+    isChatRenderProductRecsEnabled() === false);
+
+  delete globalThis.window;
+  assert('runtime adapter no-ops safely when window is missing',
+    isChatRenderProductRecsEnabled() === false
+      && renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/chat-render-runtime.js?no-window-probe');
+  assert('chat-render runtime imports without a browser window', true);
+} catch (error) {
+  assert('chat-render runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -316,6 +316,7 @@ const chatWorkflowCheckJsModules = [
   'js/chat-panel.js',
   'js/chat-prompt-context.js',
   'js/chat-render.js',
+  'js/chat-render-runtime.js',
   'js/chat-send-runtime.js',
   'js/chat-summaries.js',
   'js/chat-thread-search.js',

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -232,6 +232,10 @@ globalThis.fetch = async (url, opts) => {
   assert('chat-send.js delegates supplement slot detection through runtime adapter',
     chatSendSrc.includes('detectChatSendSupplementSlots') &&
     chatSendSrc.includes("from './chat-send-runtime.js'"));
+  assert('chat-render.js delegates recommendation rendering through runtime adapter',
+    chatRenderSrc.includes('renderChatRecommendationSections')
+      && chatRenderSrc.includes("from './chat-render-runtime.js'")
+      && !/\bwindow(\.|\s*\[)/.test(chatRenderSrc));
   assert('chat-send.js detects recSlots for live rendering', chatSendSrc.includes('_recSlots'));
   assert('chat-render.js has rec-chat-wrapper class', chatRenderSrc.includes('rec-chat-wrapper'));
   assert('category-view-renderers.js has chart-rec placeholder in header', categoryViewRenderersSrc.includes('chart-rec-'));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -40,6 +40,7 @@
     '/js/import-drop-zone.js',
     '/js/import-drop-zone-runtime.js',
     '/js/ai-verdict-engine-runtime.js',
+    '/js/chat-render-runtime.js',
     '/js/chat-send-runtime.js',
     '/js/recommendation-actions.js',
     '/js/context-card-dashboard-ai.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -62,6 +62,7 @@
     "js/chat-personalities.js",
     "js/chat-prompt-context.js",
     "js/chat-render.js",
+    "js/chat-render-runtime.js",
     "js/chat-send.js",
     "js/chat-send-runtime.js",
     "js/chat-summaries.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,7 @@
     "js/chat-personalities.js",
     "js/chat-prompt-context.js",
     "js/chat-render.js",
+    "js/chat-render-runtime.js",
     "js/chat-send.js",
     "js/chat-send-runtime.js",
     "js/chat-summaries.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.104';
+self.APP_VERSION = '1.10.105';


### PR DESCRIPTION
## Summary
- Added `js/chat-render-runtime.js` to own chat render-time product recommendation browser hooks.
- Rewired `js/chat-render.js` to render persisted EMF nudges and recommendation sections through the runtime adapter instead of direct recommendation globals.
- Added adapter/source-inspection coverage and registered the module in the service worker app shell and typecheck manifests.

## Window burden
- Reduced current `js/` counted `window.`/`window[...]` references from `170` to `164` (`-6`).
- Removed all counted direct `window` member references from `js/chat-render.js` by moving `isProductRecsEnabled`, `_cachedCatalog`, and `renderRecommendationSectionSync` access behind `js/chat-render-runtime.js`.
- `npm run quality` now reports `window global references in js/` as `164/202`.

## Validation
- `node tests/test-chat-render-runtime.js`
- `node tests/test-a11y-phase3.js`
- `node tests/test-recommendations.js`
- `npm run quality`
- `./run-tests.sh`