### PR TITLE
[codex] Extract category page runtime hooks

### DIFF
--- a/js/category-page-runtime.js
+++ b/js/category-page-runtime.js
@@ -1,0 +1,24 @@
+// @ts-check
+// category-page-runtime.js - Browser runtime adapters for category page hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+export function getCategoryPageCatalogSlots() {
+  const runtime = getRuntimeWindow();
+  return runtime?._cachedCatalog?.slots || null;
+}
+
+export function primeCategoryPageCatalogCache() {
+  const runtime = getRuntimeWindow();
+  if (!runtime || runtime._cachedCatalog || typeof runtime.loadCatalog !== 'function') return null;
+  const catalogPromise = runtime.loadCatalog();
+  if (!catalogPromise || typeof catalogPromise.then !== 'function') return null;
+  return catalogPromise.then(catalog => {
+    runtime._cachedCatalog = catalog;
+    return catalog;
+  });
+}

--- a/js/category-page-view.js
+++ b/js/category-page-view.js
@@ -14,6 +14,7 @@ import { getEffectiveRangeForDate, getLatestValueIndex } from './marker-analysis
 import { createLineChart } from './charts.js';
 import { loadChartCardRecs } from './chart-card-recs.js';
 import { renderCategoryGlyph } from './category-glyphs.js';
+import { getCategoryPageCatalogSlots, primeCategoryPageCatalogCache } from './category-page-runtime.js';
 import {
   renderChartCard,
   renderTableView,
@@ -99,8 +100,8 @@ function sortCategoryChartEntries(entries, categoryKey) {
 
   // Default category landing sort: markers with catalog slots first, then
   // by status (out-of-range before normal).
-  const catalog = window._cachedCatalog;
-  const hasSlot = (k) => catalog?.slots?.[categoryKey + '.' + k] ? 0 : 1;
+  const catalogSlots = getCategoryPageCatalogSlots();
+  const hasSlot = (k) => catalogSlots?.[categoryKey + '.' + k] ? 0 : 1;
   const statusOrder = { high: 0, low: 0, normal: 1, missing: 2 };
   entries.sort(([ka, a], [kb, b]) => {
     const slotDiff = hasSlot(ka) - hasSlot(kb);
@@ -120,7 +121,7 @@ export function showCategory(categoryKey, preData) {
   // customMarker key can't break out of the HTML attribute context.
   if (!safeMarkerId(categoryKey)) return;
   // Ensure catalog is preloaded for sorting and rec links
-  if (window.loadCatalog && !window._cachedCatalog) window.loadCatalog().then(c => { window._cachedCatalog = c; });
+  primeCategoryPageCatalogCache();
   const rawData = preData || getActiveData();
   const data = filterDatesByRange(rawData);
   const cat = data.categories[categoryKey];

--- a/service-worker.js
+++ b/service-worker.js
@@ -231,6 +231,7 @@ const APP_SHELL = [
   '/js/recommendation-actions.js',
   '/js/chart-card-recs.js',
   '/js/category-glyphs.js',
+  '/js/category-page-runtime.js',
   '/js/category-page-view.js',
   '/js/category-view-renderers.js',
   '/js/category-customization.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -188,6 +188,7 @@ const LEGACY_TESTS = [
   './test-sync-diagnose-runtime.js',
   './test-wearables-detail-runtime.js',
   './test-wearables-runtime.js',
+  './test-category-page-runtime.js',
   './test-wearables-settings-runtime.js',
   './test-dashboard-widget-runtime.js',
   './test-marker-detail-runtime.js',

--- a/tests/test-category-page-runtime.js
+++ b/tests/test-category-page-runtime.js
@@ -1,0 +1,94 @@
+// test-category-page-runtime.js - Category page browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  getCategoryPageCatalogSlots,
+  primeCategoryPageCatalogCache,
+} from '../js/category-page-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Category Page Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  '_cachedCatalog',
+  'loadCatalog',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const cachedSlots = {
+    'vitamins.vitaminD': { label: 'Vitamin D' },
+  };
+  setRuntimeValue('_cachedCatalog', { slots: cachedSlots });
+  assert('getCategoryPageCatalogSlots returns cached slot map',
+    getCategoryPageCatalogSlots() === cachedSlots);
+
+  let loadCalls = 0;
+  setRuntimeValue('loadCatalog', async () => {
+    loadCalls += 1;
+    return { slots: { 'minerals.magnesium': { label: 'Magnesium' } } };
+  });
+  assert('primeCategoryPageCatalogCache skips when cache already exists',
+    primeCategoryPageCatalogCache() === null && loadCalls === 0);
+
+  delete globalThis._cachedCatalog;
+  const loadedCatalog = await primeCategoryPageCatalogCache();
+  assert('primeCategoryPageCatalogCache loads and stores catalog when missing',
+    loadCalls === 1
+      && loadedCatalog?.slots?.['minerals.magnesium']?.label === 'Magnesium'
+      && globalThis._cachedCatalog === loadedCatalog
+      && getCategoryPageCatalogSlots() === loadedCatalog.slots);
+
+  delete globalThis._cachedCatalog;
+  setRuntimeValue('loadCatalog', () => ({ slots: {} }));
+  assert('primeCategoryPageCatalogCache ignores non-promise loaders',
+    primeCategoryPageCatalogCache() === null && getCategoryPageCatalogSlots() === null);
+
+  delete globalThis.loadCatalog;
+  assert('primeCategoryPageCatalogCache no-ops when loader is missing',
+    primeCategoryPageCatalogCache() === null);
+
+  delete globalThis.window;
+  assert('runtime adapter no-ops safely when window is missing',
+    getCategoryPageCatalogSlots() === null && primeCategoryPageCatalogCache() === null);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/category-page-runtime.js?no-window-probe');
+  assert('category-page runtime imports without a browser window', true);
+} catch (error) {
+  assert('category-page runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -241,6 +241,11 @@ globalThis.fetch = async (url, opts) => {
   assert('category-view-renderers.js has chart-rec placeholder in header', categoryViewRenderersSrc.includes('chart-rec-'));
   assert('category-view-renderers.js keeps chart title text separate from tips host', categoryViewRenderersSrc.includes('chart-card-title-text') && categoryViewRenderersSrc.includes('chart-card-tips-host'));
   assert('category-page-view.js imports chart card recommendation module', categoryPageViewSrc.includes("from './chart-card-recs.js'"));
+  assert('category-page-view.js delegates catalog globals through runtime adapter',
+    categoryPageViewSrc.includes("from './category-page-runtime.js'")
+      && categoryPageViewSrc.includes('primeCategoryPageCatalogCache')
+      && categoryPageViewSrc.includes('getCategoryPageCatalogSlots')
+      && !/\bwindow(\.|\s*\[)/.test(categoryPageViewSrc));
   assert('chart-card-recs.js has loadChartCardRecs function', chartCardRecsSrc.includes('function loadChartCardRecs'));
   assert('marker-detail-modal.js scrollToRec auto-opens details', markerDetailSrc.includes('scrollToRec'));
   assert('loadCatalog on window', typeof window.loadCatalog === 'function');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -63,6 +63,7 @@
     '/js/lens-page-shell.js',
     '/js/chart-card-recs.js',
     '/js/category-glyphs.js',
+    '/js/category-page-runtime.js',
     '/js/category-page-view.js',
     '/js/category-customization.js',
     '/js/commit-hash.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -351,6 +351,7 @@
     "js/brand-assets.js",
     "js/category-customization.js",
     "js/category-glyphs.js",
+    "js/category-page-runtime.js",
     "js/category-page-view.js",
     "js/category-view-renderers.js",
     "js/changelog.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "js/cashu-wallet.js",
     "js/category-customization.js",
     "js/category-glyphs.js",
+    "js/category-page-runtime.js",
     "js/category-page-view.js",
     "js/category-view-renderers.js",
     "js/chart-card-recs.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.105';
+self.APP_VERSION = '1.10.106';


### PR DESCRIPTION
## Summary
- Added `js/category-page-runtime.js` to own category page recommendation catalog cache access.
- Rewired `js/category-page-view.js` to prime/read recommendation catalog state through the runtime adapter instead of direct browser globals.
- Added adapter/source-inspection coverage and registered the new module in the service worker app shell and typecheck/module manifests.

## Window burden
- Reduced current `js/` counted `window.`/`window[...]` references from `164` to `159` (`-5`).
- Removed all counted direct `window` member references from `js/category-page-view.js` by moving `_cachedCatalog` and `loadCatalog` access behind `js/category-page-runtime.js`.
- `npm run quality` now reports `window global references in js/` as `159/202`.

## Validation
- `node tests/test-category-page-runtime.js`
- `node tests/test-recommendations.js`
- `npm run quality`
- `npm run typecheck:checkjs`
- `./run-tests.sh`