### PR TITLE
[codex] Extract category customization runtime hooks

### DIFF
--- a/js/category-customization-runtime.js
+++ b/js/category-customization-runtime.js
@@ -1,0 +1,58 @@
+// @ts-check
+// category-customization-runtime.js - Browser runtime hooks for category customization.
+
+/**
+ * @returns {Record<string, any>}
+ */
+function getRuntimeScope() {
+  return typeof window !== 'undefined'
+    ? /** @type {Record<string, any>} */ (window)
+    : /** @type {Record<string, any>} */ (globalThis);
+}
+
+/**
+ * @param {string} name
+ * @returns {((...args: any[]) => any) | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeScope();
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
+}
+
+/**
+ * @param {string} route
+ * @param {any} [data]
+ */
+export function navigateCategoryCustomizationRuntime(route, data) {
+  getRuntimeFunction('navigate')?.(route, data);
+}
+
+/**
+ * @returns {((data?: any) => void) | null}
+ */
+export function getCategoryCustomizationBuildSidebar() {
+  return /** @type {((data?: any) => void) | null} */ (getRuntimeFunction('buildSidebar'));
+}
+
+/**
+ * @param {string} message
+ * @param {{ defaultValue?: string, okLabel?: string }} [options]
+ * @returns {Promise<string | null | undefined> | string | null | undefined}
+ */
+export function showCategoryCustomizationPrompt(message, options) {
+  return getRuntimeFunction('showPromptDialog')?.(message, options);
+}
+
+/**
+ * @returns {{ width: number, height: number }}
+ */
+export function getCategoryCustomizationViewportSize() {
+  const runtime = getRuntimeScope();
+  const width = Number(runtime.innerWidth);
+  const height = Number(runtime.innerHeight);
+  return {
+    width: Number.isFinite(width) ? width : 1024,
+    height: Number.isFinite(height) ? height : 768,
+  };
+}

--- a/js/category-customization.js
+++ b/js/category-customization.js
@@ -5,14 +5,19 @@ import { state } from './state.js';
 import { escapeHTML, showNotification } from './utils.js';
 import { getActiveData, saveImportedData } from './data.js';
 import { showDetailModal } from './marker-detail-modal.js';
+import {
+  getCategoryCustomizationBuildSidebar,
+  getCategoryCustomizationViewportSize,
+  navigateCategoryCustomizationRuntime,
+  showCategoryCustomizationPrompt,
+} from './category-customization-runtime.js';
 
-let _navigate = (route, data) => window.navigate?.(route, data);
+let _navigate = navigateCategoryCustomizationRuntime;
 /** @type {((data?: any) => void) | null} */
 let _buildSidebar = null;
 
 function getFallbackBuildSidebar() {
-  const runtime = typeof window !== 'undefined' ? /** @type {any} */ (window) : /** @type {any} */ (globalThis);
-  return typeof runtime.buildSidebar === 'function' ? runtime.buildSidebar : null;
+  return getCategoryCustomizationBuildSidebar();
 }
 
 /**
@@ -39,7 +44,7 @@ export async function renameCategory(categoryKey) {
   const cat = data.categories[categoryKey];
   if (!cat) return;
   const currentLabel = cat.label;
-  const newLabel = await window.showPromptDialog('Rename category:', {
+  const newLabel = await showCategoryCustomizationPrompt('Rename category:', {
     defaultValue: currentLabel,
     okLabel: 'Rename',
   });
@@ -65,7 +70,7 @@ export async function renameMarker(id) {
   const catKey = id.slice(0, idx), mKey = id.slice(idx + 1);
   const marker = data.categories[catKey]?.markers[mKey];
   if (!marker) return;
-  const newName = await window.showPromptDialog('Rename marker:', {
+  const newName = await showCategoryCustomizationPrompt('Rename marker:', {
     defaultValue: marker.name,
     okLabel: 'Rename',
   });
@@ -114,8 +119,9 @@ export function showEmojiPicker(anchorEl, callback, opts = {}) {
 
   // Position near anchor
   const rect = anchorEl.getBoundingClientRect();
-  picker.style.left = Math.min(rect.left, window.innerWidth - 340) + 'px';
-  picker.style.top = Math.min(rect.bottom + 4, window.innerHeight - 420) + 'px';
+  const viewport = getCategoryCustomizationViewportSize();
+  picker.style.left = Math.min(rect.left, viewport.width - 340) + 'px';
+  picker.style.top = Math.min(rect.bottom + 4, viewport.height - 420) + 'px';
 
   let activeCat = null;
   let searchTerm = '';

--- a/service-worker.js
+++ b/service-worker.js
@@ -230,6 +230,7 @@ const APP_SHELL = [
   '/js/dashboard-recommendation-widget.js',
   '/js/recommendation-actions.js',
   '/js/chart-card-recs.js',
+  '/js/category-customization-runtime.js',
   '/js/category-glyphs.js',
   '/js/category-page-runtime.js',
   '/js/category-page-view.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -189,6 +189,7 @@ const LEGACY_TESTS = [
   './test-wearables-detail-runtime.js',
   './test-wearables-runtime.js',
   './test-category-page-runtime.js',
+  './test-category-customization-runtime.js',
   './test-wearables-settings-runtime.js',
   './test-dashboard-widget-runtime.js',
   './test-marker-detail-runtime.js',

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -111,9 +111,12 @@ test('category customization covers rename icon and emoji picker browser paths',
       outcomes.renameCategoryRefreshesSidebarThroughConfiguredCallback = calls.some(call => call[0] === 'sidebar' && call[1] === true);
       outcomes.renameCategoryRefreshesForcedRoute = calls.some(call => call[0] === 'navigate' && call[1] === 'lipids' && call[2] === true);
       outcomes.categoryCustomizationDoesNotUseWindowBuildSidebar = categorySrc.includes('buildSidebar?:')
+        && categorySrc.includes("from './category-customization-runtime.js'")
+        && categorySrc.includes('showCategoryCustomizationPrompt')
+        && categorySrc.includes('getCategoryCustomizationViewportSize')
         && categorySrc.includes('getFallbackBuildSidebar')
         && categorySrc.includes('buildSidebar?.(data)')
-        && !categorySrc.includes('window.buildSidebar');
+        && !/\bwindow(?:\.|\s*\[)/.test(categorySrc);
       outcomes.renameMissingCategoryNoops = await category.renameCategory('missing-category') === undefined;
 
       window.showPromptDialog = async () => '  ApoB Better Name  ';

--- a/tests/test-category-customization-runtime.js
+++ b/tests/test-category-customization-runtime.js
@@ -1,0 +1,119 @@
+// test-category-customization-runtime.js - Category customization browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  getCategoryCustomizationBuildSidebar,
+  getCategoryCustomizationViewportSize,
+  navigateCategoryCustomizationRuntime,
+  showCategoryCustomizationPrompt,
+} from '../js/category-customization-runtime.js';
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+console.log('=== Category Customization Runtime Tests ===\n');
+
+const runtimeKeys = [
+  'window',
+  'navigate',
+  'buildSidebar',
+  'showPromptDialog',
+  'innerWidth',
+  'innerHeight',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const browserRuntime = {
+    innerWidth: 812,
+    innerHeight: 640,
+    navigate(route, data) {
+      calls.push(['navigate', route, data?.category]);
+    },
+    buildSidebar(data) {
+      calls.push(['buildSidebar', data?.category, this === browserRuntime]);
+    },
+    async showPromptDialog(message, options) {
+      calls.push(['prompt', message, options?.defaultValue, this === browserRuntime]);
+      return '  renamed  ';
+    },
+  };
+  setRuntimeValue('window', browserRuntime);
+
+  navigateCategoryCustomizationRuntime('lipids', { category: 'lipids' });
+  assert('navigateCategoryCustomizationRuntime delegates to browser navigate',
+    calls.some(call => call[0] === 'navigate' && call[1] === 'lipids' && call[2] === 'lipids'));
+
+  getCategoryCustomizationBuildSidebar()?.({ category: 'minerals' });
+  assert('getCategoryCustomizationBuildSidebar returns a bound runtime callback',
+    calls.some(call => call[0] === 'buildSidebar' && call[1] === 'minerals' && call[2] === true));
+
+  const promptResult = await showCategoryCustomizationPrompt('Rename marker:', {
+    defaultValue: 'ApoB',
+    okLabel: 'Rename',
+  });
+  assert('showCategoryCustomizationPrompt delegates and returns prompt value',
+    promptResult === '  renamed  '
+      && calls.some(call => call[0] === 'prompt' && call[1] === 'Rename marker:' && call[2] === 'ApoB' && call[3] === true));
+
+  const viewport = getCategoryCustomizationViewportSize();
+  assert('getCategoryCustomizationViewportSize reads browser dimensions',
+    viewport.width === 812 && viewport.height === 640);
+
+  delete browserRuntime.navigate;
+  delete browserRuntime.buildSidebar;
+  delete browserRuntime.showPromptDialog;
+  delete browserRuntime.innerWidth;
+  delete browserRuntime.innerHeight;
+  navigateCategoryCustomizationRuntime('missing');
+  assert('runtime hooks no-op when browser callbacks are missing',
+    getCategoryCustomizationBuildSidebar() === null
+      && await showCategoryCustomizationPrompt('Missing callback') === undefined);
+  const fallbackViewport = getCategoryCustomizationViewportSize();
+  assert('viewport helper falls back when dimensions are missing',
+    fallbackViewport.width === 1024 && fallbackViewport.height === 768);
+
+  delete globalThis.window;
+  let globalNavigateCalled = false;
+  setRuntimeValue('navigate', route => { globalNavigateCalled = route === 'dashboard'; });
+  navigateCategoryCustomizationRuntime('dashboard');
+  assert('runtime hooks fall back to globalThis when window is missing', globalNavigateCalled);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/category-customization-runtime.js?no-window-probe');
+  assert('category customization runtime imports without a browser window', true);
+} catch (error) {
+  assert('category customization runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+process.exit(fail > 0 ? 1 : 0);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -62,6 +62,7 @@
     '/js/mobile-dashboard-runtime.js',
     '/js/lens-page-shell.js',
     '/js/chart-card-recs.js',
+    '/js/category-customization-runtime.js',
     '/js/category-glyphs.js',
     '/js/category-page-runtime.js',
     '/js/category-page-view.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -349,6 +349,7 @@
     "js/backup.js",
     "js/blob-storage.js",
     "js/brand-assets.js",
+    "js/category-customization-runtime.js",
     "js/category-customization.js",
     "js/category-glyphs.js",
     "js/category-page-runtime.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "js/blob-storage.js",
     "js/brand-assets.js",
     "js/cashu-wallet.js",
+    "js/category-customization-runtime.js",
     "js/category-customization.js",
     "js/category-glyphs.js",
     "js/category-page-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.106';
+self.APP_VERSION = '1.10.107';


### PR DESCRIPTION
## Summary
- Add `js/category-customization-runtime.js` for category customization browser runtime hooks.
- Route rename prompts, navigation, sidebar fallback, and emoji picker viewport sizing through the adapter.
- Add focused runtime coverage and strengthen the Playwright source guard for direct browser globals.
- Bump `version.js` to 1.10.107 for shipped app changes.

## Window burden
- Direct `window.`/`window[...]` references in `js/` are down from 159 to 154 (-5).
- Moved category customization navigation, `showPromptDialog`, sidebar fallback, and viewport size reads behind `js/category-customization-runtime.js`.
- `js/category-customization.js` now has zero counted direct browser-global references.

## Tests
- `node tests/test-category-customization-runtime.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `./run-tests.sh`