### PR TITLE
[codex] Extract nav runtime hooks

### DIFF
--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -1,0 +1,59 @@
+// @ts-check
+// nav-runtime.js - Browser runtime hooks for sidebar navigation.
+
+/**
+ * @returns {Record<string, any>}
+ */
+function getNavRuntimeScope() {
+  return typeof window !== 'undefined'
+    ? /** @type {Record<string, any>} */ (window)
+    : /** @type {Record<string, any>} */ (globalThis);
+}
+
+/**
+ * @param {string} name
+ * @returns {((...args: any[]) => any) | null}
+ */
+function getNavRuntimeFunction(name) {
+  const runtime = getNavRuntimeScope();
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
+}
+
+/**
+ * @param {string} route
+ */
+export function navigateFromNavRuntime(route) {
+  getNavRuntimeFunction('navigate')?.(route);
+}
+
+export function openEMFAssessmentFromNavRuntime() {
+  getNavRuntimeFunction('openEMFAssessmentEditor')?.();
+}
+
+export function openKnowledgeBaseFromNavRuntime() {
+  getNavRuntimeFunction('openKnowledgeBaseModal')?.();
+}
+
+export function openReportBuilderFromNavRuntime() {
+  getNavRuntimeFunction('openReportBuilder')?.();
+}
+
+export function openContextFromNavRuntime() {
+  getNavRuntimeFunction('openContextModal')?.();
+}
+
+export function openCreateMarkerFromNavRuntime() {
+  getNavRuntimeFunction('openCreateMarkerModal')?.();
+}
+
+export function openClientListFromNavRuntime() {
+  getNavRuntimeFunction('openClientList')?.();
+}
+
+/**
+ * @param {Record<string, any>} globals
+ */
+export function exposeNavRuntimeGlobals(globals) {
+  Object.assign(getNavRuntimeScope(), globals);
+}

--- a/js/nav.js
+++ b/js/nav.js
@@ -7,6 +7,16 @@ import { getActiveData, filterDatesByRange } from './data.js';
 import { countFlagged } from './marker-analysis.js';
 import { getProfiles } from './profile.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import {
+  exposeNavRuntimeGlobals,
+  navigateFromNavRuntime,
+  openClientListFromNavRuntime,
+  openContextFromNavRuntime,
+  openCreateMarkerFromNavRuntime,
+  openEMFAssessmentFromNavRuntime,
+  openKnowledgeBaseFromNavRuntime,
+  openReportBuilderFromNavRuntime,
+} from './nav-runtime.js';
 
 function _iconSvg(name) {
   const attrs = 'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"';
@@ -75,28 +85,27 @@ function handleNavActionClick(event) {
   const target = event.target instanceof Element ? event.target : null;
   const actionEl = /** @type {HTMLElement | null} */ (target?.closest('[data-nav-action]') || null);
   if (!actionEl || !_navActionScope(actionEl)) return;
-  const appWindow = /** @type {any} */ (window);
 
   const action = actionEl.dataset.navAction;
   let handled = true;
   if (action === 'navigate') {
-    window.navigate?.(actionEl.dataset.navRoute || actionEl.dataset.category || 'dashboard');
+    navigateFromNavRuntime(actionEl.dataset.navRoute || actionEl.dataset.category || 'dashboard');
   } else if (action === 'open-emf-assessment') {
-    window.openEMFAssessmentEditor?.();
+    openEMFAssessmentFromNavRuntime();
   } else if (action === 'open-light-assessment') {
     navActionDeps.openLightEnvironmentAssessment();
   } else if (action === 'open-knowledge-base') {
-    appWindow.openKnowledgeBaseModal?.();
+    openKnowledgeBaseFromNavRuntime();
   } else if (action === 'open-report-builder') {
-    appWindow.openReportBuilder?.();
+    openReportBuilderFromNavRuntime();
   } else if (action === 'open-context') {
-    appWindow.openContextModal?.();
+    openContextFromNavRuntime();
   } else if (action === 'open-custom-marker') {
-    appWindow.openCreateMarkerModal?.();
+    openCreateMarkerFromNavRuntime();
   } else if (action === 'toggle-group') {
     toggleNavGroup(actionEl.dataset.navGroup || '');
   } else if (action === 'open-client-list') {
-    window.openClientList?.();
+    openClientListFromNavRuntime();
   } else {
     handled = false;
   }
@@ -130,7 +139,7 @@ function _renderConditionalNavItem({ key, icon, label, route = 'dashboard', acti
 }
 
 export function openRecommendationsFromSidebar() {
-  if (window.navigate) window.navigate('recommendations');
+  navigateFromNavRuntime('recommendations');
 }
 
 export function syncSidebarActive(route = state.currentView || 'dashboard') {
@@ -440,4 +449,4 @@ export function closeMobileSidebar() {
   closeModalOverlay('sidebar-backdrop', { restoreFocus: false });
 }
 
-Object.assign(window, { buildSidebar, filterSidebar, toggleNavGroup, renderProfileDropdown, renderProfileButton, getAvatarColor, syncSidebarActive, toggleMobileSidebar, closeMobileSidebar, openRecommendationsFromSidebar, installNavActionDelegates });
+exposeNavRuntimeGlobals({ buildSidebar, filterSidebar, toggleNavGroup, renderProfileDropdown, renderProfileButton, getAvatarColor, syncSidebarActive, toggleMobileSidebar, closeMobileSidebar, openRecommendationsFromSidebar, installNavActionDelegates });

--- a/service-worker.js
+++ b/service-worker.js
@@ -196,6 +196,7 @@ const APP_SHELL = [
   '/js/changelog.js',
   '/js/client-list-runtime.js',
   '/js/client-list.js',
+  '/js/nav-runtime.js',
   '/js/nav.js',
   '/js/views-router-runtime.js',
   '/js/views-router.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -194,6 +194,7 @@ const LEGACY_TESTS = [
   './test-dashboard-widget-runtime.js',
   './test-marker-detail-runtime.js',
   './test-shell-delegated-actions.js',
+  './test-nav-runtime.js',
   './test-nav-delegated-actions.js',
   './test-dashboard-widget-delegated-actions.js',
   './test-lens-page-shell-delegated-actions.js',

--- a/tests/test-nav-delegated-actions.js
+++ b/tests/test-nav-delegated-actions.js
@@ -36,6 +36,13 @@ assert('nav.js installs idempotent click and input delegates',
   navSrc.includes('let navDelegatesInstalled = false') &&
     navSrc.includes("document.addEventListener('click', handleNavActionClick)") &&
     navSrc.includes("document.addEventListener('input', handleNavInput)"));
+assert('nav.js routes browser globals through runtime adapter',
+  navSrc.includes("from './nav-runtime.js'") &&
+    navSrc.includes('navigateFromNavRuntime(') &&
+    navSrc.includes('openEMFAssessmentFromNavRuntime()') &&
+    navSrc.includes('openClientListFromNavRuntime()') &&
+    navSrc.includes('exposeNavRuntimeGlobals({') &&
+    !/\bwindow(?:\.|\s*\[)/.test(navSrc));
 
 [
   'navigate',

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Runtime sidebar nav adapter behavior.
+
+import './_node-shim.js';
+import {
+  exposeNavRuntimeGlobals,
+  navigateFromNavRuntime,
+  openClientListFromNavRuntime,
+  openContextFromNavRuntime,
+  openCreateMarkerFromNavRuntime,
+  openEMFAssessmentFromNavRuntime,
+  openKnowledgeBaseFromNavRuntime,
+  openReportBuilderFromNavRuntime,
+} from '../js/nav-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Nav Runtime Tests ===');
+
+const runtimeKeys = [
+  'window',
+  'navigate',
+  'openEMFAssessmentEditor',
+  'openKnowledgeBaseModal',
+  'openReportBuilder',
+  'openContextModal',
+  'openCreateMarkerModal',
+  'openClientList',
+  'runtimeProbe',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const browserRuntime = {
+    navigate(route) { calls.push(['navigate', route, this === browserRuntime]); },
+    openEMFAssessmentEditor() { calls.push(['emf', this === browserRuntime]); },
+    openKnowledgeBaseModal() { calls.push(['kb', this === browserRuntime]); },
+    openReportBuilder() { calls.push(['report', this === browserRuntime]); },
+    openContextModal() { calls.push(['context', this === browserRuntime]); },
+    openCreateMarkerModal() { calls.push(['marker', this === browserRuntime]); },
+    openClientList() { calls.push(['client', this === browserRuntime]); },
+  };
+  setRuntimeValue('window', browserRuntime);
+
+  navigateFromNavRuntime('labs');
+  openEMFAssessmentFromNavRuntime();
+  openKnowledgeBaseFromNavRuntime();
+  openReportBuilderFromNavRuntime();
+  openContextFromNavRuntime();
+  openCreateMarkerFromNavRuntime();
+  openClientListFromNavRuntime();
+
+  assert('nav runtime delegates all browser callbacks',
+    calls.length === 7
+      && calls.some(call => call[0] === 'navigate' && call[1] === 'labs' && call[2] === true)
+      && ['emf', 'kb', 'report', 'context', 'marker', 'client'].every(name => calls.some(call => call[0] === name && call[1] === true)));
+
+  exposeNavRuntimeGlobals({ runtimeProbe: 42 });
+  assert('exposeNavRuntimeGlobals assigns exports to the browser runtime',
+    browserRuntime.runtimeProbe === 42);
+
+  for (const key of ['navigate', 'openEMFAssessmentEditor', 'openKnowledgeBaseModal', 'openReportBuilder', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
+    delete browserRuntime[key];
+  }
+  navigateFromNavRuntime('missing');
+  openEMFAssessmentFromNavRuntime();
+  openKnowledgeBaseFromNavRuntime();
+  openReportBuilderFromNavRuntime();
+  openContextFromNavRuntime();
+  openCreateMarkerFromNavRuntime();
+  openClientListFromNavRuntime();
+  assert('nav runtime hooks no-op when browser callbacks are missing', calls.length === 7);
+
+  delete globalThis.window;
+  let globalRoute = '';
+  setRuntimeValue('navigate', route => { globalRoute = route; });
+  navigateFromNavRuntime('recommendations');
+  exposeNavRuntimeGlobals({ runtimeProbe: 'global' });
+  assert('nav runtime falls back to globalThis without window',
+    globalRoute === 'recommendations' && globalThis.runtimeProbe === 'global');
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/nav-runtime.js?no-window-probe');
+  assert('nav runtime imports without a browser window', true);
+} catch (error) {
+  assert('nav runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -69,6 +69,7 @@
     '/js/category-customization.js',
     '/js/commit-hash.js',
     '/js/client-list-runtime.js',
+    '/js/nav-runtime.js',
     '/js/views-router-runtime.js',
     '/js/focus-card.js',
     '/js/onboarding-view-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -164,6 +164,7 @@
     "js/mobile-dashboard.js",
     "js/mobile-dashboard-runtime.js",
     "js/modal-lifecycle.js",
+    "js/nav-runtime.js",
     "js/nav.js",
     "js/onboarding-view-runtime.js",
     "js/onboarding-view.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -164,6 +164,7 @@
     "js/mobile-dashboard.js",
     "js/mobile-dashboard-runtime.js",
     "js/modal-lifecycle.js",
+    "js/nav-runtime.js",
     "js/nav.js",
     "js/notes-runtime.js",
     "js/notes.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.107';
+self.APP_VERSION = '1.10.108';


### PR DESCRIPTION
## Summary
- Add `js/nav-runtime.js` for sidebar navigation browser runtime hooks.
- Route nav delegated actions, recommendation routing, and nav global exports through the adapter.
- Add focused runtime coverage and strengthen the nav source guard against direct browser-global call sites.
- Bump `version.js` to 1.10.108 for shipped app changes.

## Window burden
- Direct `window.`/`window[...]` references in `js/` are down from 154 to 149 (-5).
- Moved sidebar navigation, EMF/client/modal open callbacks, and nav global export wiring behind `js/nav-runtime.js`.
- `js/nav.js` now has zero counted direct browser-global references.

## Tests
- `node tests/test-nav-runtime.js`
- `node tests/test-nav-delegated-actions.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `./run-tests.sh`