### PR TITLE
[codex] Extract provider panel renderer runtime hooks

### DIFF
--- a/js/provider-panel-renderers-runtime.js
+++ b/js/provider-panel-renderers-runtime.js
@@ -1,0 +1,39 @@
+// @ts-check
+// provider-panel-renderers-runtime.js - Browser runtime hooks for provider panel renderers.
+
+/**
+ * @returns {Record<string, any>}
+ */
+function getProviderPanelRendererRuntimeScope() {
+  return typeof window !== 'undefined'
+    ? /** @type {Record<string, any>} */ (window)
+    : /** @type {Record<string, any>} */ (globalThis);
+}
+
+/**
+ * @param {string} name
+ * @returns {((...args: any[]) => any) | null}
+ */
+function getProviderPanelRendererRuntimeFunction(name) {
+  const runtime = getProviderPanelRendererRuntimeScope();
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
+}
+
+export function getSelectedRoutstrNodeFromRuntime() {
+  return getProviderPanelRendererRuntimeFunction('nostrGetSelectedNode')?.() || null;
+}
+
+export function discoverRoutstrNodesFromRuntime() {
+  const discover = getProviderPanelRendererRuntimeFunction('nostrDiscoverNodes');
+  if (!discover) return null;
+  const result = discover();
+  return result && typeof result.then === 'function' ? result : null;
+}
+
+/**
+ * @param {string} nodeUrl
+ */
+export function setSelectedRoutstrNodeFromRuntime(nodeUrl) {
+  getProviderPanelRendererRuntimeFunction('nostrSetSelectedNode')?.(nodeUrl);
+}

--- a/js/provider-panel-renderers.js
+++ b/js/provider-panel-renderers.js
@@ -15,6 +15,11 @@ import {
 } from './api.js';
 import { getOllamaConfig } from './pii.js';
 import { buildRoutstrNodeActions, routstrWalletActionButtons } from './provider-wallet-panels.js';
+import {
+  discoverRoutstrNodesFromRuntime,
+  getSelectedRoutstrNodeFromRuntime,
+  setSelectedRoutstrNodeFromRuntime,
+} from './provider-panel-renderers-runtime.js';
 
 function readStoredArray(key) {
   try { return JSON.parse(localStorage.getItem(key) || '[]'); }
@@ -137,7 +142,7 @@ function renderOpenRouterProviderPanel() {
 function renderRoutstrProviderPanel() {
   const currentKey = getRoutstrKey();
   const rsModel = getRoutstrModel();
-  const nodeUrl = window.nostrGetSelectedNode ? window.nostrGetSelectedNode() : null;
+  const nodeUrl = getSelectedRoutstrNodeFromRuntime();
   const cachedRSModels = readStoredArray('labcharts-routstr-models');
   let rsModelHtml;
   if (cachedRSModels.length > 0) {
@@ -169,14 +174,15 @@ function renderRoutstrProviderPanel() {
     <div id="routstr-wallet-fund-area" style="display:none"></div>
   </div>`;
 
-  if (!nodeUrl && window.nostrDiscoverNodes) {
-    window.nostrDiscoverNodes().then(nodes => {
+  const discovery = !nodeUrl ? discoverRoutstrNodesFromRuntime() : null;
+  if (discovery) {
+    discovery.then(nodes => {
       const online = nodes.filter(n => n.online);
       if (online.length) {
         const best = online[0];
         const bestUrl = (best.urls && best.urls[0]) || '';
         if (!bestUrl) return;
-        window.nostrSetSelectedNode(bestUrl);
+        setSelectedRoutstrNodeFromRuntime(bestUrl);
         const label = document.getElementById('routstr-node-label');
         if (label) label.innerHTML = escapeHTML(best.name || bestUrl.replace(/^https?:\/\//, ''));
         const acts = document.getElementById('routstr-node-actions');

--- a/service-worker.js
+++ b/service-worker.js
@@ -273,6 +273,7 @@ const APP_SHELL = [
   '/js/provider-local-ai-runtime.js',
   '/js/provider-local-ai-controls.js',
   '/js/provider-ppq-panels.js',
+  '/js/provider-panel-renderers-runtime.js',
   '/js/provider-panel-renderers.js',
   '/js/provider-model-controls-runtime.js',
   '/js/provider-model-controls.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -209,6 +209,7 @@ const LEGACY_TESTS = [
   './test-wearables-delegated-actions.js',
   './test-client-list-delegated-actions.js',
   './test-provider-wallet-delegated-actions.js',
+  './test-provider-panel-renderers-runtime.js',
   './test-provider-panel-delegated-actions.js',
   './test-chat-empty-state-delegated-actions.js',
   './test-modal-lifecycle-integrations.js',

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -42,6 +42,12 @@ assert('provider panel renderers emit delegated action attributes',
   renderSrc.includes('data-provider-panel-action') &&
     renderSrc.includes('data-provider-panel-change') &&
     renderSrc.includes('data-provider-panel-key'));
+assert('provider panel renderers route Nostr browser globals through runtime adapter',
+  renderSrc.includes("from './provider-panel-renderers-runtime.js'") &&
+    renderSrc.includes('getSelectedRoutstrNodeFromRuntime()') &&
+    renderSrc.includes('discoverRoutstrNodesFromRuntime()') &&
+    renderSrc.includes('setSelectedRoutstrNodeFromRuntime(bestUrl)') &&
+    !/\bwindow(?:\.|\s*\[)/.test(renderSrc));
 assert('provider model controls emit delegated model attributes',
   modelControlsSrc.includes('data-provider-panel-change') &&
     modelControlsSrc.includes('data-provider-panel-key'));

--- a/tests/test-provider-panel-renderers-runtime.js
+++ b/tests/test-provider-panel-renderers-runtime.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Provider panel renderer runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  discoverRoutstrNodesFromRuntime,
+  getSelectedRoutstrNodeFromRuntime,
+  setSelectedRoutstrNodeFromRuntime,
+} from '../js/provider-panel-renderers-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Provider Panel Renderers Runtime Tests ===');
+
+const runtimeKeys = [
+  'window',
+  'nostrGetSelectedNode',
+  'nostrDiscoverNodes',
+  'nostrSetSelectedNode',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const browserRuntime = {
+    nostrGetSelectedNode() {
+      calls.push(['get', this === browserRuntime]);
+      return 'https://node.selected.test';
+    },
+    nostrDiscoverNodes() {
+      calls.push(['discover', this === browserRuntime]);
+      return Promise.resolve([{ online: true, urls: ['https://node.discovered.test'] }]);
+    },
+    nostrSetSelectedNode(nodeUrl) {
+      calls.push(['set', nodeUrl, this === browserRuntime]);
+    },
+  };
+  setRuntimeValue('window', browserRuntime);
+
+  assert('getSelectedRoutstrNodeFromRuntime delegates selected node lookup',
+    getSelectedRoutstrNodeFromRuntime() === 'https://node.selected.test'
+      && calls.some(call => call[0] === 'get' && call[1] === true));
+
+  const discovered = await discoverRoutstrNodesFromRuntime();
+  assert('discoverRoutstrNodesFromRuntime delegates node discovery',
+    discovered?.[0]?.urls?.[0] === 'https://node.discovered.test'
+      && calls.some(call => call[0] === 'discover' && call[1] === true));
+
+  setSelectedRoutstrNodeFromRuntime('https://node.saved.test');
+  assert('setSelectedRoutstrNodeFromRuntime delegates selected node updates',
+    calls.some(call => call[0] === 'set' && call[1] === 'https://node.saved.test' && call[2] === true));
+
+  delete browserRuntime.nostrGetSelectedNode;
+  delete browserRuntime.nostrDiscoverNodes;
+  delete browserRuntime.nostrSetSelectedNode;
+  setSelectedRoutstrNodeFromRuntime('missing');
+  assert('provider renderer runtime hooks no-op when callbacks are missing',
+    getSelectedRoutstrNodeFromRuntime() === null && discoverRoutstrNodesFromRuntime() === null);
+
+  browserRuntime.nostrDiscoverNodes = () => [];
+  assert('discoverRoutstrNodesFromRuntime ignores non-promise discovery callbacks',
+    discoverRoutstrNodesFromRuntime() === null);
+
+  delete globalThis.window;
+  setRuntimeValue('nostrGetSelectedNode', () => 'https://global.node.test');
+  assert('provider renderer runtime falls back to globalThis without window',
+    getSelectedRoutstrNodeFromRuntime() === 'https://global.node.test');
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/provider-panel-renderers-runtime.js?no-window-probe');
+  assert('provider panel renderers runtime imports without a browser window', true);
+} catch (error) {
+  assert('provider panel renderers runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -98,6 +98,7 @@
     '/js/dashboard-widget-runtime.js',
     '/js/provider-local-ai-runtime.js',
     '/js/provider-model-controls-runtime.js',
+    '/js/provider-panel-renderers-runtime.js',
     '/js/api-runtime.js',
     '/js/api-provider-storage-runtime.js',
     '/js/charts-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -261,6 +261,7 @@
     "js/api-models.js",
     "js/provider-model-controls-runtime.js",
     "js/provider-model-controls.js",
+    "js/provider-panel-renderers-runtime.js",
     "js/provider-panel-renderers.js",
     "js/provider-qr.js",
     "js/provider-wallet-delegates.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -196,6 +196,7 @@
     "js/provider-model-controls-runtime.js",
     "js/provider-model-controls.js",
     "js/provider-panel-delegates.js",
+    "js/provider-panel-renderers-runtime.js",
     "js/provider-panel-renderers.js",
     "js/provider-panels.js",
     "js/provider-ppq-panels.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.108';
+self.APP_VERSION = '1.10.109';


### PR DESCRIPTION
## Summary
- Add `js/provider-panel-renderers-runtime.js` for Routstr node browser runtime hooks used by provider panel renderers.
- Route selected-node lookup, async node discovery, and selected-node updates through the adapter.
- Add focused runtime coverage and strengthen provider panel source guards against direct browser globals in the renderer.
- Bump `version.js` to 1.10.109 for shipped app changes.

## Window burden
- Direct `window.`/`window[...]` references in `js/` are down from 149 to 144 (-5).
- Moved Routstr selected-node lookup, node discovery, and selected-node update hooks behind `js/provider-panel-renderers-runtime.js`.
- `js/provider-panel-renderers.js` now has zero counted direct browser-global references.

## Tests
- `node tests/test-provider-panel-renderers-runtime.js`
- `node tests/test-provider-panel-delegated-actions.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `./run-tests.sh`