### PR TITLE
[codex] Extract tour runtime hooks

### DIFF
--- a/js/tour-runtime.js
+++ b/js/tour-runtime.js
@@ -1,0 +1,72 @@
+// @ts-check
+// tour-runtime.js - Browser runtime adapters for guided tour hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {unknown} value
+ * @param {number} fallback
+ */
+function normalizeViewportDimension(value, fallback) {
+  const dimension = Number(value);
+  return Number.isFinite(dimension) ? dimension : fallback;
+}
+
+const DEFAULT_STYLE = Object.freeze({ display: '', visibility: '', opacity: '' });
+const HIDDEN_STYLE = Object.freeze({ display: 'none', visibility: 'hidden', opacity: '0' });
+
+export function getTourViewportSize() {
+  const runtime = getRuntimeWindow();
+  return {
+    width: normalizeViewportDimension(runtime?.innerWidth, 1024),
+    height: normalizeViewportDimension(runtime?.innerHeight, 768),
+  };
+}
+
+/**
+ * @param {Element | null} element
+ * @returns {{ display?: string, visibility?: string, opacity?: string }}
+ */
+export function getTourComputedStyle(element) {
+  if (!element) return HIDDEN_STYLE;
+  const readStyle = getRuntimeFunction('getComputedStyle');
+  if (!readStyle) return DEFAULT_STYLE;
+  try {
+    return readStyle(element) || DEFAULT_STYLE;
+  } catch (_) {
+    return DEFAULT_STYLE;
+  }
+}
+
+export function openTourChatPanel() {
+  getRuntimeFunction('openChatPanel')?.();
+}
+
+/**
+ * @param {() => void} callback
+ * @param {number} delayMs
+ */
+export function scheduleTourTask(callback, delayMs = 0) {
+  const runtime = getRuntimeWindow();
+  const schedule = runtime && typeof runtime.setTimeout === 'function'
+    ? runtime.setTimeout.bind(runtime)
+    : (typeof setTimeout === 'function' ? setTimeout : null);
+  if (!schedule) {
+    callback();
+    return null;
+  }
+  return schedule(callback, delayMs);
+}

--- a/js/tour.js
+++ b/js/tour.js
@@ -4,6 +4,7 @@
 import { state } from './state.js';
 import { profileStorageKey } from './profile.js';
 import { escapeAttr, isStartupNudgeBlocked } from './utils.js';
+import { getTourComputedStyle, getTourViewportSize, openTourChatPanel, scheduleTourTask } from './tour-runtime.js';
 
 const EMPTY_TOUR_STEPS = [
   { target: null, title: 'Welcome to getbased', text: 'This quick tour is for a fresh profile. After the tour, guided chat will help you decide what to add first.', position: 'center' },
@@ -106,11 +107,12 @@ function _isActiveProfileDemo() {
 function isTourTargetVisible(el) {
   if (!el) return false;
   const rect = el.getBoundingClientRect();
-  const style = window.getComputedStyle(el);
+  const style = getTourComputedStyle(el);
+  const { width: viewportWidth } = getTourViewportSize();
   return rect.width > 0 &&
     rect.height > 0 &&
     rect.right > 0 &&
-    rect.left < window.innerWidth &&
+    rect.left < viewportWidth &&
     style.display !== 'none' &&
     style.visibility !== 'hidden' &&
     style.opacity !== '0';
@@ -250,8 +252,7 @@ function positionTooltip(rect, position) {
   if (!tooltip) return;
   const gap = 12;
   const pad = 8;
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  const { width: vw, height: vh } = getTourViewportSize();
 
   // Temporarily make tooltip visible to measure it
   tooltip.style.left = '0';
@@ -330,9 +331,9 @@ export function endTour() {
   if (spotlight) spotlight.remove();
   if (tooltip) tooltip.remove();
   if (shouldOpenEmptyChat) {
-    setTimeout(() => {
+    scheduleTourTask(() => {
       const panel = document.getElementById('chat-panel');
-      if (!panel?.classList.contains('open')) window.openChatPanel?.();
+      if (!panel?.classList.contains('open')) openTourChatPanel();
     }, 250);
   }
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -192,6 +192,7 @@ const APP_SHELL = [
   '/js/settings-sync-panel.js',
   '/js/settings-agent-access-panel.js',
   '/js/feedback.js',
+  '/js/tour-runtime.js',
   '/js/tour.js',
   '/js/changelog.js',
   '/js/client-list-runtime.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -177,6 +177,7 @@ const LEGACY_TESTS = [
   // wearables-bp-merge source-inspection. The wearables-bp live DOM probe
   // moved to Playwright.
   './test-tour.js',
+  './test-tour-runtime.js',
   './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',

--- a/tests/test-tour-runtime.js
+++ b/tests/test-tour-runtime.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Guided tour runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  getTourComputedStyle,
+  getTourViewportSize,
+  openTourChatPanel,
+  scheduleTourTask,
+} from '../js/tour-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Tour Runtime Tests ===');
+
+const runtimeKeys = ['window'];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const target = { id: 'tour-target' };
+  const browserRuntime = {
+    innerWidth: 390,
+    innerHeight: 844,
+    getComputedStyle(element) {
+      calls.push(['style', element?.id, this === browserRuntime]);
+      return { display: 'block', visibility: 'visible', opacity: '1' };
+    },
+    openChatPanel() {
+      calls.push(['chat', this === browserRuntime]);
+    },
+    setTimeout(callback, delay) {
+      calls.push(['timeout', delay, this === browserRuntime]);
+      callback();
+      return 99;
+    },
+  };
+  setRuntimeValue('window', browserRuntime);
+
+  const viewport = getTourViewportSize();
+  const style = getTourComputedStyle(/** @type {Element} */ (target));
+  openTourChatPanel();
+  const taskId = scheduleTourTask(() => calls.push(['task']), 250);
+
+  assert('getTourViewportSize reads browser viewport dimensions',
+    viewport.width === 390 && viewport.height === 844);
+  assert('getTourComputedStyle delegates style reads with browser binding',
+    style.display === 'block' &&
+      calls.some(call => call[0] === 'style' && call[1] === 'tour-target' && call[2] === true));
+  assert('openTourChatPanel delegates chat opening with browser binding',
+    calls.some(call => call[0] === 'chat' && call[1] === true));
+  assert('scheduleTourTask delegates timers with browser binding',
+    taskId === 99 &&
+      calls.some(call => call[0] === 'timeout' && call[1] === 250 && call[2] === true) &&
+      calls.some(call => call[0] === 'task'));
+
+  browserRuntime.innerWidth = undefined;
+  browserRuntime.innerHeight = NaN;
+  delete browserRuntime.getComputedStyle;
+  delete browserRuntime.openChatPanel;
+  const fallbackViewport = getTourViewportSize();
+  const fallbackStyle = getTourComputedStyle(/** @type {Element} */ (target));
+  const beforeMissingChat = calls.length;
+  openTourChatPanel();
+
+  assert('tour viewport helper falls back when browser dimensions are invalid',
+    fallbackViewport.width === 1024 && fallbackViewport.height === 768);
+  assert('tour style helper returns visible defaults when computed styles are unavailable',
+    fallbackStyle.display === '' && fallbackStyle.visibility === '' && fallbackStyle.opacity === '');
+  assert('tour chat hook no-ops when callback is missing',
+    calls.length === beforeMissingChat);
+  assert('tour style helper treats missing elements as hidden',
+    getTourComputedStyle(null).display === 'none');
+
+  delete globalThis.window;
+  const noWindowViewport = getTourViewportSize();
+  const noWindowStyle = getTourComputedStyle(/** @type {Element} */ (target));
+  assert('tour runtime adapter handles missing browser window',
+    noWindowViewport.width === 1024 &&
+      noWindowViewport.height === 768 &&
+      noWindowStyle.display === '');
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/tour-runtime.js?no-window-probe');
+  assert('tour runtime imports without a browser window', true);
+} catch (error) {
+  assert('tour runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-tour.js
+++ b/tests/test-tour.js
@@ -34,6 +34,7 @@ console.log('=== Guided Tour Tests ===\n');
 console.log('1. Source Inspection');
 
 const tourSrc = read('js/tour.js');
+const tourRuntimeSrc = read('js/tour-runtime.js');
 
 assert('tour.js has startTour export', tourSrc.includes('export function startTour'));
 assert('tour.js has endTour export', tourSrc.includes('export function endTour'));
@@ -45,8 +46,17 @@ assert('tour.js has EMPTY_TOUR_STEPS array', tourSrc.includes('const EMPTY_TOUR_
 assert('tour.js has TOUR_STEPS array', tourSrc.includes('const TOUR_STEPS'));
 assert('tour.js imports state', tourSrc.includes("import { state } from './state.js'"));
 assert('tour.js imports profileStorageKey', tourSrc.includes("import { profileStorageKey } from './profile.js'"));
+assert('tour.js imports runtime browser hooks',
+  tourSrc.includes("import { getTourComputedStyle, getTourViewportSize, openTourChatPanel, scheduleTourTask } from './tour-runtime.js'"));
 assert('tour.js exports testable step navigation', tourSrc.includes('export function goToTourStep'));
 assert('tour.js does not publish tour API on window', !tourSrc.includes('Object.assign(window,') && !tourSrc.includes('window._tourGoToStep'));
+assert('tour.js keeps direct browser globals behind runtime adapter',
+  !/\bwindow(?:\.|\s*\[)/.test(tourSrc));
+assert('tour-runtime.js owns viewport style and chat adapters',
+  tourRuntimeSrc.includes('export function getTourViewportSize') &&
+    tourRuntimeSrc.includes('export function getTourComputedStyle') &&
+    tourRuntimeSrc.includes('export function openTourChatPanel') &&
+    tourRuntimeSrc.includes('export function scheduleTourTask'));
 assert('startTour respects auto flag', tourSrc.includes('if (auto && isTourCompleted(') && tourSrc.includes(') return'));
 assert('startup auto tours wait behind open modals', tourSrc.includes('function isStartupTourKey(') && tourSrc.includes('if (auto && isStartupTourKey(storageKey) && isStartupNudgeBlocked()) return false;'));
 assert('startTour returns whether tour opened', tourSrc.includes('return runTour(TOUR_STEPS') && tourSrc.includes('return true'));
@@ -65,7 +75,7 @@ assert('Empty step 2: Guided chat panel', tourSrc.includes("target: '.welcome-pr
 assert('Empty step 3: Demo cards', tourSrc.includes("target: '.demo-cards', title: 'Try a Populated Profile'"));
 assert('Empty step 4: Profile button', tourSrc.includes("target: '.profile-compact-btn', title: 'Profiles Stay Separate'"));
 assert('Empty step 5: Settings', tourSrc.includes("target: '.settings-btn', title: 'Settings & Connections'"));
-assert('Empty tour opens chat after completion', tourSrc.includes("activeTour?.storageKey === profileKey('emptyTour')") && tourSrc.includes('window.openChatPanel?.()'));
+assert('Empty tour opens chat after completion', tourSrc.includes("activeTour?.storageKey === profileKey('emptyTour')") && tourSrc.includes('scheduleTourTask') && tourSrc.includes('openTourChatPanel()'));
 
 const emptyStepsStart = tourSrc.indexOf('const EMPTY_TOUR_STEPS');
 const appStepsStart = tourSrc.indexOf('const TOUR_STEPS');
@@ -225,6 +235,7 @@ console.log('22. Service Worker');
 const swSrc = read('service-worker.js');
 
 assert('SW APP_SHELL includes /js/tour.js', swSrc.includes("'/js/tour.js'"));
+assert('SW APP_SHELL includes /js/tour-runtime.js', swSrc.includes("'/js/tour-runtime.js'"));
 assert('SW uses importScripts for version', swSrc.includes("importScripts('/version.js')"));
 assert('SW CACHE_NAME uses semver', swSrc.includes('`labcharts-v${self.APP_VERSION}`'));
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -105,6 +105,7 @@
     '/js/notes-runtime.js',
     '/js/pdf-import-review-runtime.js',
     '/js/theme-runtime.js',
+    '/js/tour-runtime.js',
     '/js/touch-tooltip-runtime.js',
     '/js/utils-runtime.js',
     '/js/schema.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -219,6 +219,7 @@
     "js/sun.js",
     "js/theme.js",
     "js/theme-runtime.js",
+    "js/tour-runtime.js",
     "js/tour.js",
     "js/url-safety.js",
     "js/utils-runtime.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -312,6 +312,7 @@
     "js/theme.js",
     "js/theme-runtime.js",
     "js/touch-tooltip-runtime.js",
+    "js/tour-runtime.js",
     "js/touch-tooltip.js",
     "js/tour.js",
     "js/url-safety.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.109';
+self.APP_VERSION = '1.10.110';


### PR DESCRIPTION
## Summary
- Added a tour runtime adapter for viewport, computed style, timer, and chat-panel hooks.
- Rewired tour.js to use the adapter so direct browser globals are outside the tour engine.
- Added runtime/source tests and registered the new module in the service worker cache, TypeScript configs, and Vitest legacy coverage.

## Window burden
- Reduced counted direct window global references in js/ from 144 to 139 (-5).
- Removed all direct counted window references from js/tour.js; browser coupling now lives behind js/tour-runtime.js.

## Tests
- node tests/test-tour-runtime.js
- node tests/test-tour.js
- node tests/verify-modules.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npx playwright test tests/playwright/tour-dom.spec.js
- ./run-tests.sh