### PR TITLE
[codex] Extract Apple Health runtime hooks

### DIFF
--- a/js/wearables-apple-health-runtime.js
+++ b/js/wearables-apple-health-runtime.js
@@ -1,0 +1,18 @@
+// @ts-check
+// wearables-apple-health-runtime.js - Browser runtime adapters for Apple Health import hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+export function getAppleHealthJSZip() {
+  return getRuntimeWindow()?.JSZip || null;
+}
+
+/** @param {Record<string, unknown>} bindings */
+export function exposeAppleHealthDebugBindings(bindings) {
+  const runtime = getRuntimeWindow();
+  if (runtime) Object.assign(runtime, bindings);
+}

--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -20,6 +20,7 @@ import { upsertDailyBatch, setMeta } from './wearables-store.js';
 import { syncWearableSummary } from './wearables-summary.js';
 import { getActiveProfileId } from './profile.js';
 import { isDebugMode } from './utils.js';
+import { exposeAppleHealthDebugBindings, getAppleHealthJSZip } from './wearables-apple-health-runtime.js';
 
 // ─────────────────────────────────────────────────────────
 // File ingestion entry point
@@ -86,12 +87,16 @@ export async function importAppleHealthFile(file, onProgress) {
 
 let _jszipLoad = null;
 function loadJSZip() {
-  if (window.JSZip) return Promise.resolve(window.JSZip);
+  const cachedJSZip = getAppleHealthJSZip();
+  if (cachedJSZip) return Promise.resolve(cachedJSZip);
   if (_jszipLoad) return _jszipLoad;
   _jszipLoad = new Promise((resolve, reject) => {
     const s = document.createElement('script');
     s.src = '/vendor/jszip.min.js';
-    s.onload = () => window.JSZip ? resolve(window.JSZip) : reject(new Error('JSZip failed to load'));
+    s.onload = () => {
+      const loadedJSZip = getAppleHealthJSZip();
+      loadedJSZip ? resolve(loadedJSZip) : reject(new Error('JSZip failed to load'));
+    };
     s.onerror = () => reject(new Error('Failed to load /vendor/jszip.min.js'));
     document.head.appendChild(s);
   });
@@ -418,4 +423,4 @@ function normaliseUnit(metricId, value, unit) {
   }
 }
 
-if (isDebugMode?.()) window._appleHealth = { importAppleHealthFile, parseAppleHealthXml };
+if (isDebugMode?.()) exposeAppleHealthDebugBindings({ _appleHealth: { importAppleHealthFile, parseAppleHealthXml } });

--- a/service-worker.js
+++ b/service-worker.js
@@ -390,6 +390,7 @@ const APP_SHELL = [
   '/js/wearables-fitbit-auth.js',
   '/js/wearables-polar.js',
   '/js/wearables-polar-auth.js',
+  '/js/wearables-apple-health-runtime.js',
   '/js/wearables-apple-health.js',
   '/js/wearables-manual.js',
   '/js/brand-assets.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -188,6 +188,7 @@ const LEGACY_TESTS = [
   './test-mobile-dashboard-runtime.js',
   './test-sync-diagnose-runtime.js',
   './test-wearables-detail-runtime.js',
+  './test-wearables-apple-health-runtime.js',
   './test-wearables-runtime.js',
   './test-category-page-runtime.js',
   './test-category-customization-runtime.js',

--- a/tests/test-wearables-apple-health-runtime.js
+++ b/tests/test-wearables-apple-health-runtime.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Apple Health import runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  exposeAppleHealthDebugBindings,
+  getAppleHealthJSZip,
+} from '../js/wearables-apple-health-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Wearables Apple Health Runtime Tests ===');
+
+const runtimeKeys = ['window'];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const fakeJSZip = { loadAsync: () => Promise.resolve({}) };
+  const browserRuntime = { JSZip: fakeJSZip };
+  setRuntimeValue('window', browserRuntime);
+
+  assert('getAppleHealthJSZip reads the browser JSZip binding',
+    getAppleHealthJSZip() === fakeJSZip);
+
+  const debugBindings = { _appleHealth: { probe: true } };
+  exposeAppleHealthDebugBindings(debugBindings);
+  assert('exposeAppleHealthDebugBindings publishes debug bindings to the browser runtime',
+    browserRuntime._appleHealth === debugBindings._appleHealth);
+
+  delete browserRuntime.JSZip;
+  assert('getAppleHealthJSZip returns null when JSZip is unavailable',
+    getAppleHealthJSZip() === null);
+
+  delete globalThis.window;
+  exposeAppleHealthDebugBindings({ _appleHealth: { ignored: true } });
+  assert('Apple Health runtime adapter no-ops without a browser window',
+    getAppleHealthJSZip() === null && typeof globalThis._appleHealth === 'undefined');
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/wearables-apple-health-runtime.js?no-window-probe');
+  assert('Apple Health runtime imports without a browser window', true);
+} catch (error) {
+  assert('Apple Health runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -807,8 +807,14 @@ assert('Apple Health LeanBodyMass lb unit converts to kg',
 // wraps JSZip access in a memoized loader. Pin the lazy-load pattern so a
 // future refactor can't silently break it again.
 const ahSrc = await fetch('/js/wearables-apple-health.js').then(r => r.text());
+const ahRuntimeSrc = await fetch('/js/wearables-apple-health-runtime.js').then(r => r.text());
 assert('Apple Health source defines loadJSZip lazy-loader',
   /function\s+loadJSZip\s*\(\s*\)/.test(ahSrc));
+assert('Apple Health delegates browser globals to runtime adapter',
+  ahSrc.includes("from './wearables-apple-health-runtime.js'") &&
+    !/\bwindow(?:\.|\s*\[)/.test(ahSrc) &&
+    ahRuntimeSrc.includes('export function getAppleHealthJSZip') &&
+    ahRuntimeSrc.includes('export function exposeAppleHealthDebugBindings'));
 assert('loadJSZip memoizes via module-level _jszipLoad',
   /let\s+_jszipLoad\s*=\s*null/.test(ahSrc));
 assert('loadJSZip injects /vendor/jszip.min.js script tag',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -54,6 +54,7 @@
     '/js/wearables-bp-detail-chart.js',
     '/js/wearables-formatters.js',
     '/js/wearables-manual-form-ui.js',
+    '/js/wearables-apple-health-runtime.js',
     '/js/wearables-runtime.js',
     '/js/wearables-settings-runtime.js',
     '/js/wearables-connect-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -228,6 +228,7 @@
     "js/views-router.js",
     "js/views.js",
     "js/wearable-adapters.js",
+    "js/wearables-apple-health-runtime.js",
     "js/wearables-apple-health.js",
     "js/wearables-connect-runtime.js",
     "js/wearables-connect.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -322,6 +322,7 @@
     "js/views-router.js",
     "js/views.js",
     "js/wearable-adapters.js",
+    "js/wearables-apple-health-runtime.js",
     "js/wearables-apple-health.js",
     "js/wearables-connect-runtime.js",
     "js/wearables-connect.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.110';
+self.APP_VERSION = '1.10.111';


### PR DESCRIPTION
## Summary
- Added an Apple Health runtime adapter for JSZip lookup and debug binding publication.
- Rewired wearables-apple-health.js to use the adapter for lazy ZIP import and debug exports.
- Added runtime/source tests and registered the new module in the service worker cache, TypeScript configs, and Vitest legacy coverage.

## Window burden
- Reduced counted direct window global references in js/ from 139 to 134 (-5).
- Removed all direct counted window references from js/wearables-apple-health.js; browser coupling now lives behind js/wearables-apple-health-runtime.js.

## Tests
- node tests/test-wearables-apple-health-runtime.js
- node tests/test-wearables.js
- node tests/verify-modules.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npx playwright test tests/playwright/wearables-apple-health-browser-coverage.spec.js
- ./run-tests.sh