### PR TITLE
[codex] Extract biology scores runtime hooks

### DIFF
--- a/js/biology-scores-runtime.js
+++ b/js/biology-scores-runtime.js
@@ -1,0 +1,82 @@
+// @ts-check
+// biology-scores-runtime.js - Browser runtime adapters for Biology Scores UI hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/** @param {string} route */
+export function navigateBiologyScoresRoute(route = 'biology-scores') {
+  getRuntimeFunction('navigate')?.(route || 'biology-scores');
+}
+
+export function canOpenBiologyScoresChatPanel() {
+  return Boolean(getRuntimeFunction('openChatPanel'));
+}
+
+/** @param {string=} prompt */
+export function openBiologyScoresChatPanel(prompt) {
+  const openChatPanel = getRuntimeFunction('openChatPanel');
+  if (!openChatPanel) return false;
+  if (prompt === undefined) openChatPanel();
+  else openChatPanel(prompt);
+  return true;
+}
+
+/** @param {string} prompt */
+export function useBiologyScoresChatPrompt(prompt) {
+  getRuntimeFunction('useChatPrompt')?.(prompt);
+}
+
+/**
+ * @param {string} message
+ * @param {string} type
+ */
+export function showBiologyScoresNotification(message, type = 'info') {
+  getRuntimeFunction('showNotification')?.(message, type);
+}
+
+export function hasBiologyScoresAIProvider() {
+  const hasAIProvider = getRuntimeFunction('hasAIProvider');
+  return hasAIProvider ? Boolean(hasAIProvider()) : null;
+}
+
+export function getBiologyScoresActiveData() {
+  return getRuntimeFunction('getActiveData')?.() || {};
+}
+
+/** @param {string} markerId */
+export function openBiologyScoreMarkerDetail(markerId) {
+  if (!markerId) return false;
+  const showDetailModal = getRuntimeFunction('showDetailModal');
+  if (!showDetailModal) return false;
+  showDetailModal(markerId);
+  return true;
+}
+
+/**
+ * @param {() => void} callback
+ * @param {number} delayMs
+ */
+export function scheduleBiologyScoresTask(callback, delayMs = 0) {
+  const runtime = getRuntimeWindow();
+  const schedule = runtime && typeof runtime.setTimeout === 'function'
+    ? runtime.setTimeout.bind(runtime)
+    : (typeof setTimeout === 'function' ? setTimeout : null);
+  if (!schedule) {
+    callback();
+    return null;
+  }
+  return schedule(callback, delayMs);
+}

--- a/js/biology-scores.js
+++ b/js/biology-scores.js
@@ -29,6 +29,17 @@ import { state } from './state.js';
 import { createNewThread } from './chat-threads.js';
 import { renderMarkdown } from './markdown.js';
 import { buildBiologyScoreCoveragePlannerModel, formatBiologyScoreCoveragePlannerPrompt } from './biology-score-coverage-planner.js';
+import {
+  canOpenBiologyScoresChatPanel,
+  getBiologyScoresActiveData,
+  hasBiologyScoresAIProvider,
+  navigateBiologyScoresRoute,
+  openBiologyScoreMarkerDetail,
+  openBiologyScoresChatPanel,
+  scheduleBiologyScoresTask,
+  showBiologyScoresNotification,
+  useBiologyScoresChatPrompt,
+} from './biology-scores-runtime.js';
 
 let biologyScoreDelegatesInstalled = false;
 function installBiologyScoreDelegates() {
@@ -41,41 +52,39 @@ function installBiologyScoreDelegates() {
     const el = /** @type {HTMLElement} */ (actionEl);
     const action = el.dataset.biologyScoreAction;
     if (action === 'open-lens') {
-      window.navigate?.('biology-scores');
+      navigateBiologyScoresRoute('biology-scores');
       event.preventDefault();
     } else if (action === 'interpret-lens') {
-      window.openChatPanel?.();
-      setTimeout(() => {
-        const usePrompt = (/** @type {any} */ (window)).useChatPrompt;
-        usePrompt?.('Interpret my Biology Scores. Focus on the strongest and most strained patterns, any stale or mixed-date scores that need retesting, and the most useful next checks. Treat the scores as deterministic pattern summaries, not diagnoses.');
+      openBiologyScoresChatPanel();
+      scheduleBiologyScoresTask(() => {
+        useBiologyScoresChatPrompt('Interpret my Biology Scores. Focus on the strongest and most strained patterns, any stale or mixed-date scores that need retesting, and the most useful next checks. Treat the scores as deterministic pattern summaries, not diagnoses.');
       }, 250);
       event.preventDefault();
     } else if (action === 'plan-coverage-chat') {
-      const appWindow = /** @type {any} */ (window);
-      if (typeof appWindow.openChatPanel !== 'function') {
-        appWindow.showNotification?.('Chat is not available on this screen.', 'error');
+      if (!canOpenBiologyScoresChatPanel()) {
+        showBiologyScoresNotification('Chat is not available on this screen.', 'error');
         event.preventDefault();
         return;
       }
-      if (typeof appWindow.hasAIProvider === 'function' && !appWindow.hasAIProvider()) {
-        appWindow.showNotification?.('Connect an AI provider before making a lab plan.', 'error');
-        appWindow.openChatPanel?.();
+      if (hasBiologyScoresAIProvider() === false) {
+        showBiologyScoresNotification('Connect an AI provider before making a lab plan.', 'error');
+        openBiologyScoresChatPanel();
         event.preventDefault();
         return;
       }
-      const rawData = appWindow.getActiveData?.() || {};
+      const rawData = getBiologyScoresActiveData();
       const scoreData = filterDatesByRange(rawData, { fallbackToAll: false });
       const scores = computeBiologyScores(scoreData);
       const detailScores = scores.filter((score) => score.id !== 'biologicalCoherence');
       const coherence = scores.find((score) => score.id === 'biologicalCoherence');
       const planner = buildBiologyScoreCoveragePlannerModel(detailScores, coherence);
       createNewThread();
-      appWindow.openChatPanel(formatBiologyScoreCoveragePlannerPrompt(planner));
+      openBiologyScoresChatPanel(formatBiologyScoreCoveragePlannerPrompt(planner));
       event.preventDefault();
     } else if (action === 'interpret-score-ai') {
       event.preventDefault();
       runEmbeddedScoreAI(el).catch((err) => {
-        window.showNotification?.(err?.message || 'Could not generate Biology Score answer', 'error');
+        showBiologyScoresNotification(err?.message || 'Could not generate Biology Score answer', 'error');
       });
     } else if (action === 'jump-to-domain') {
       const scoreId = el.dataset.biologyScoreId;
@@ -84,13 +93,13 @@ function installBiologyScoreDelegates() {
       if (state.currentView === 'biology-scores') {
         jumpToScore(scoreId);
       } else {
-        window.navigate?.('biology-scores');
+        navigateBiologyScoresRoute('biology-scores');
         jumpToScoreWhenReady(scoreId);
       }
     } else if (action === 'open-marker') {
       const markerId = el.dataset.biologyMarkerId;
       if (markerId) {
-        window.showDetailModal?.(markerId);
+        openBiologyScoreMarkerDetail(markerId);
         event.preventDefault();
       }
     }
@@ -130,7 +139,7 @@ async function runEmbeddedScoreAI(el) {
   const scoreId = el.dataset.biologyScoreId;
   const answerEl = scoreId ? document.querySelector(`[data-biology-score-ai-answer="${CSS.escape(scoreId)}"]`) : null;
   if (!scoreId || !answerEl) return;
-  const rawData = (/** @type {any} */ (globalThis)).getActiveData?.() || {};
+  const rawData = getBiologyScoresActiveData();
   const scoreData = filterDatesByRange(rawData, { fallbackToAll: false });
   const score = computeBiologyScores(scoreData).find(item => item.id === scoreId);
   if (!score) throw new Error('Score not found');

--- a/service-worker.js
+++ b/service-worker.js
@@ -207,6 +207,7 @@ const APP_SHELL = [
   '/js/lens-pages.js',
   '/js/lens-page-shell.js',
   '/js/lens-library.js',
+  '/js/biology-scores-runtime.js',
   '/js/biology-scores.js',
   '/js/biology-score-ai.js',
   '/js/biology-score-ai-context.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -187,6 +187,7 @@ const LEGACY_TESTS = [
   './test-import-drop-zone-runtime.js',
   './test-mobile-dashboard-runtime.js',
   './test-sync-diagnose-runtime.js',
+  './test-biology-scores-runtime.js',
   './test-wearables-detail-runtime.js',
   './test-wearables-apple-health-runtime.js',
   './test-wearables-runtime.js',

--- a/tests/test-biology-scores-runtime.js
+++ b/tests/test-biology-scores-runtime.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Biology Scores runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  canOpenBiologyScoresChatPanel,
+  getBiologyScoresActiveData,
+  hasBiologyScoresAIProvider,
+  navigateBiologyScoresRoute,
+  openBiologyScoreMarkerDetail,
+  openBiologyScoresChatPanel,
+  scheduleBiologyScoresTask,
+  showBiologyScoresNotification,
+  useBiologyScoresChatPrompt,
+} from '../js/biology-scores-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Biology Scores Runtime Tests ===');
+
+const runtimeKeys = ['window'];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const activeData = { dates: ['2026-06-01'], categories: {} };
+  const browserRuntime = {
+    navigate(route) { calls.push(['navigate', route, this === browserRuntime]); },
+    openChatPanel(prompt) { calls.push(['chat', prompt, this === browserRuntime]); },
+    useChatPrompt(prompt) { calls.push(['prompt', prompt, this === browserRuntime]); },
+    showNotification(message, type) { calls.push(['notification', message, type, this === browserRuntime]); },
+    hasAIProvider() { calls.push(['has-ai', this === browserRuntime]); return false; },
+    getActiveData() { calls.push(['data', this === browserRuntime]); return activeData; },
+    showDetailModal(markerId) { calls.push(['detail', markerId, this === browserRuntime]); },
+    setTimeout(callback, delay) {
+      calls.push(['timeout', delay, this === browserRuntime]);
+      callback();
+      return 42;
+    },
+  };
+  setRuntimeValue('window', browserRuntime);
+
+  navigateBiologyScoresRoute('biology-scores');
+  openBiologyScoresChatPanel();
+  openBiologyScoresChatPanel('Plan labs');
+  useBiologyScoresChatPrompt('Interpret score');
+  showBiologyScoresNotification('Saved', 'success');
+  const providerStatus = hasBiologyScoresAIProvider();
+  const data = getBiologyScoresActiveData();
+  openBiologyScoreMarkerDetail('biochemistry_glucose');
+  const timerId = scheduleBiologyScoresTask(() => calls.push(['task']), 125);
+
+  assert('biology runtime delegates navigation',
+    calls.some(call => call[0] === 'navigate' && call[1] === 'biology-scores' && call[2] === true));
+  assert('biology runtime delegates chat panel opens with optional prompts',
+    canOpenBiologyScoresChatPanel() &&
+      calls.some(call => call[0] === 'chat' && call[1] === undefined && call[2] === true) &&
+      calls.some(call => call[0] === 'chat' && call[1] === 'Plan labs' && call[2] === true));
+  assert('biology runtime delegates prompt notification and provider hooks',
+    providerStatus === false &&
+      calls.some(call => call[0] === 'prompt' && call[1] === 'Interpret score' && call[2] === true) &&
+      calls.some(call => call[0] === 'notification' && call[1] === 'Saved' && call[2] === 'success' && call[3] === true) &&
+      calls.some(call => call[0] === 'has-ai' && call[1] === true));
+  assert('biology runtime delegates active data and marker detail hooks',
+    data === activeData &&
+      calls.some(call => call[0] === 'data' && call[1] === true) &&
+      calls.some(call => call[0] === 'detail' && call[1] === 'biochemistry_glucose' && call[2] === true));
+  assert('biology runtime delegates timers with browser binding',
+    timerId === 42 &&
+      calls.some(call => call[0] === 'timeout' && call[1] === 125 && call[2] === true) &&
+      calls.some(call => call[0] === 'task'));
+
+  delete browserRuntime.openChatPanel;
+  delete browserRuntime.hasAIProvider;
+  delete browserRuntime.getActiveData;
+  assert('biology runtime handles missing optional browser hooks',
+    !canOpenBiologyScoresChatPanel() &&
+      openBiologyScoresChatPanel('missing') === false &&
+      hasBiologyScoresAIProvider() === null &&
+      Object.keys(getBiologyScoresActiveData()).length === 0);
+
+  delete globalThis.window;
+  assert('biology runtime adapter no-ops without a browser window',
+    !canOpenBiologyScoresChatPanel() &&
+      openBiologyScoreMarkerDetail('biochemistry_glucose') === false &&
+      openBiologyScoresChatPanel() === false);
+} finally {
+  restoreRuntime();
+}
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+try {
+  delete globalThis.window;
+  await import('../js/biology-scores-runtime.js?no-window-probe');
+  assert('biology runtime imports without a browser window', true);
+} catch (error) {
+  assert('biology runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -950,6 +950,14 @@ assert('Biology Score AI answers save with immediate sync so refresh/cross-devic
   biologyScoreSectionsSrc.includes("saveImportedData({ reason: 'biology-score-ai', immediate: true })"),
   biologyScoreSectionsSrc.slice(biologyScoreSectionsSrc.indexOf('export async function writeScoreAIAnswer'), biologyScoreSectionsSrc.indexOf('export function renderScoreAIAnswer')));
 const biologyScoresSrc = await fs.promises.readFile(new URL('../js/biology-scores.js', import.meta.url), 'utf8');
+const biologyScoresRuntimeSrc = await fs.promises.readFile(new URL('../js/biology-scores-runtime.js', import.meta.url), 'utf8');
+assert('Biology Scores delegates browser globals to runtime adapter',
+  biologyScoresSrc.includes("from './biology-scores-runtime.js'") &&
+    !/\bwindow(?:\.|\s*\[)/.test(biologyScoresSrc) &&
+    biologyScoresRuntimeSrc.includes('export function navigateBiologyScoresRoute') &&
+    biologyScoresRuntimeSrc.includes('export function openBiologyScoresChatPanel') &&
+    biologyScoresRuntimeSrc.includes('export function openBiologyScoreMarkerDetail'),
+  biologyScoresSrc.slice(0, 1800));
 assert('refreshing a stale Biology Score AI explanation removes the stale warning in-place',
   /biology-score-ai-stale/.test(biologyScoresSrc)
   && /closest\('\.biology-score-ai'\)/.test(biologyScoresSrc)
@@ -1038,6 +1046,7 @@ window.callClaudeAPI = savedContextAIState.callClaudeAPI;
 
 const swSrc = fs.readFileSync(path.join(ROOT, 'service-worker.js'), 'utf8');
 const biologyScoreShellFiles = [
+  '/js/biology-scores-runtime.js',
   '/js/biology-scores.js',
   '/js/biology-score-ai.js',
   '/js/biology-score-ai-context.js',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -62,6 +62,7 @@
     '/js/dashboard-page-view.js',
     '/js/mobile-dashboard-runtime.js',
     '/js/lens-page-shell.js',
+    '/js/biology-scores-runtime.js',
     '/js/chart-card-recs.js',
     '/js/category-customization-runtime.js',
     '/js/category-glyphs.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -32,6 +32,7 @@
     "js/biology-score-thyroid.js",
     "js/biology-score-tier1-definitions.js",
     "js/biology-score-tier2-definitions.js",
+    "js/biology-scores-runtime.js",
     "js/biology-scores.js",
     "js/chat-actions.js",
     "js/chat-attestation.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "js/ai-verdict-engine.js",
     "js/backup.js",
     "js/blob-storage.js",
+    "js/biology-scores-runtime.js",
     "js/brand-assets.js",
     "js/cashu-wallet.js",
     "js/category-customization-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.111';
+self.APP_VERSION = '1.10.112';


### PR DESCRIPTION
## Summary
- Added a Biology Scores runtime adapter for navigation, chat, notifications, active-data reads, marker detail, and timer hooks.
- Rewired biology-scores.js delegated actions and embedded AI refresh to use the adapter instead of direct browser globals.
- Added runtime/source tests and registered the new module in the service worker cache, TypeScript configs, and Vitest legacy coverage.

## Window burden
- Reduced counted direct window global references in js/ from 134 to 129 (-5).
- Removed all direct counted window references from js/biology-scores.js; browser coupling now lives behind js/biology-scores-runtime.js.

## Tests
- node tests/test-biology-scores-runtime.js
- node tests/test-biology-scores.js
- node tests/verify-modules.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npx playwright test tests/playwright/biology-scores-dashboard-lens.spec.js
- npx playwright test tests/playwright/core-browser-flows.spec.js -g "export/import browser fixture"
- ./run-tests.sh