### PR TITLE
[codex] Extract recommendations runtime hooks

### DIFF
--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -1,0 +1,74 @@
+// @ts-check
+// recommendations-runtime.js - Browser runtime adapters for recommendation hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+export function getRecommendationsSnpTable() {
+  const runtime = getRuntimeWindow();
+  return runtime?._snpTableCache || null;
+}
+
+export function closeRecommendationsModal() {
+  const closeModal = getRuntimeFunction('closeModal');
+  if (!closeModal) return false;
+  closeModal();
+  return true;
+}
+
+export function openRecommendationsEmfAssessment() {
+  const openEMFAssessmentEditor = getRuntimeFunction('openEMFAssessmentEditor');
+  if (!openEMFAssessmentEditor) return false;
+  openEMFAssessmentEditor();
+  return true;
+}
+
+export function openRecommendationsLocationEditor() {
+  const openProfileLocationEditor = getRuntimeFunction('openProfileLocationEditor');
+  if (!openProfileLocationEditor) return false;
+  openProfileLocationEditor();
+  return true;
+}
+
+export function openRecommendationsPrivacySettings() {
+  const openSettingsTab = getRuntimeFunction('openSettingsTab');
+  if (!openSettingsTab) return false;
+  openSettingsTab('privacy');
+  return true;
+}
+
+/**
+ * @param {() => void} callback
+ * @param {number} delayMs
+ */
+export function scheduleRecommendationsTask(callback, delayMs = 0) {
+  const runtime = getRuntimeWindow();
+  const schedule = runtime && typeof runtime.setTimeout === 'function'
+    ? runtime.setTimeout.bind(runtime)
+    : (typeof setTimeout === 'function' ? setTimeout : null);
+  if (!schedule) {
+    callback();
+    return null;
+  }
+  return schedule(callback, delayMs);
+}
+
+/** @param {Record<string, unknown>} exports */
+export function registerRecommendationsRuntimeExports(exports) {
+  const runtime = getRuntimeWindow();
+  if (!runtime) return false;
+  Object.assign(runtime, exports);
+  return true;
+}

--- a/js/recommendations.js
+++ b/js/recommendations.js
@@ -10,6 +10,15 @@ import {
   regionLabel as formatRegionLabel,
   regionLookupChain as lookupRegionChain,
 } from './recommendations-region.js';
+import {
+  closeRecommendationsModal,
+  getRecommendationsSnpTable,
+  openRecommendationsEmfAssessment,
+  openRecommendationsLocationEditor,
+  openRecommendationsPrivacySettings,
+  registerRecommendationsRuntimeExports,
+  scheduleRecommendationsTask,
+} from './recommendations-runtime.js';
 
 // ═══════════════════════════════════════════════
 // CATALOG CACHE
@@ -40,7 +49,6 @@ function handleRecommendationActionClick(event) {
   if (!target) return;
   const actionEl = /** @type {HTMLElement | null} */ (target.closest('[data-rec-action]'));
   if (!actionEl) return;
-  const appWindow = /** @type {any} */ (window);
   const action = actionEl.dataset.recAction || '';
 
   if (action === 'copy-coupon') {
@@ -48,14 +56,14 @@ function handleRecommendationActionClick(event) {
     copyCouponCode(actionEl);
   } else if (action === 'close-modal') {
     event.preventDefault();
-    appWindow.closeModal?.();
+    closeRecommendationsModal();
   } else if (action === 'open-emf-assessment') {
     event.preventDefault();
-    appWindow.closeModal?.();
-    setTimeout(() => appWindow.openEMFAssessmentEditor?.(), 100);
+    closeRecommendationsModal();
+    scheduleRecommendationsTask(openRecommendationsEmfAssessment, 100);
   } else if (action === 'edit-region') {
     event.preventDefault();
-    (appWindow.openProfileLocationEditor || (() => {}))();
+    openRecommendationsLocationEditor();
   } else if (action === 'accept-disclosure') {
     event.preventDefault();
     event.stopPropagation();
@@ -64,7 +72,7 @@ function handleRecommendationActionClick(event) {
     for (const el of document.querySelectorAll('.rec-section-gated')) el.classList.remove('rec-section-gated');
   } else if (action === 'open-privacy-settings') {
     event.preventDefault();
-    appWindow.openSettingsTab?.('privacy');
+    openRecommendationsPrivacySettings();
   }
 }
 
@@ -349,7 +357,7 @@ function copyCouponCode(btn) {
     const orig = btn.textContent;
     btn.dataset.flashing = '1';
     btn.textContent = label;
-    setTimeout(() => {
+    scheduleRecommendationsTask(() => {
       btn.textContent = orig;
       delete btn.dataset.flashing;
     }, 1400);
@@ -561,7 +569,7 @@ const CARD_LABELS = {
 function _buildCardDNASection(cardKey) {
   const genetics = state.importedData?.genetics;
   if (!genetics || !genetics.snps) return '';
-  const snpTable = window._snpTableCache;
+  const snpTable = getRecommendationsSnpTable();
   if (!snpTable) return '';
   const hints = [];
   const apoeRsids = new Set(['rs429358', 'rs7412']);
@@ -644,7 +652,7 @@ function _buildEMFNudge() {
 export function buildDNAHints(slotKey) {
   const genetics = state.importedData?.genetics;
   if (!genetics || !genetics.snps) return [];
-  const snpTable = window._snpTableCache;
+  const snpTable = getRecommendationsSnpTable();
   if (!snpTable) return [];
 
   const hints = [];
@@ -733,8 +741,7 @@ function buildDisclosureFooter() {
   const r = getUserRegion();
   const label = regionLabel(r);
   // Link points to wherever the user can change their country. Click handler
-  // delegates to the host app via a global (window.openProfileLocationEditor)
-  // so this module stays decoupled. Falls back to '#' if no host is wired.
+  // delegates through the runtime adapter so this module stays decoupled.
   const editLink = `<a href="#" class="rec-region-edit" ${recActionAttrs('edit-region')} aria-label="Change country for product recommendations">change</a>`;
   return `<div class="rec-disclosure">Affiliate links are marked. Brands cannot pay for placement. <span class="rec-region-tag">Showing for ${escapeHTML(label)} · ${editLink}</span></div>`;
 }
@@ -967,8 +974,8 @@ export function detectSupplementSlots(text) {
 
   // Second pass: gene name matching for DNA-aware detection
   const genetics = state.importedData?.genetics;
-  if (genetics?.snps && window._snpTableCache) {
-    const snpTable = window._snpTableCache;
+  const snpTable = genetics?.snps ? getRecommendationsSnpTable() : null;
+  if (genetics?.snps && snpTable) {
     for (const [rsid, stored] of Object.entries(genetics.snps)) {
       const entry = snpTable[rsid];
       if (!entry || !entry.snpHints) continue;
@@ -1169,7 +1176,7 @@ export function renderChannelDeficitDeviceRecs(catalog, channelKey, presets, opt
 // ═══════════════════════════════════════════════
 initRecommendationDelegates();
 
-Object.assign(window, {
+registerRecommendationsRuntimeExports({
   isProductRecsEnabled,
   setProductRecsEnabled,
   markRecDisclosureSeen: markDisclosureSeen,

--- a/service-worker.js
+++ b/service-worker.js
@@ -258,6 +258,7 @@ const APP_SHELL = [
   '/js/compare-correlations.js',
   '/js/mobile-dashboard.js',
   '/js/views.js',
+  '/js/recommendations-runtime.js',
   '/js/recommendations.js',
   '/js/recommendations-region.js',
   '/js/crypto.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -183,6 +183,7 @@ const LEGACY_TESTS = [
   './test-views-router-runtime.js',
   './test-chat-render-runtime.js',
   './test-chat-send-runtime.js',
+  './test-recommendations-runtime.js',
   './test-context-card-lifestyle-runtime.js',
   './test-import-drop-zone-runtime.js',
   './test-mobile-dashboard-runtime.js',

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Recommendations runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  closeRecommendationsModal,
+  getRecommendationsSnpTable,
+  openRecommendationsEmfAssessment,
+  openRecommendationsLocationEditor,
+  openRecommendationsPrivacySettings,
+  registerRecommendationsRuntimeExports,
+  scheduleRecommendationsTask,
+} from '../js/recommendations-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Recommendations Runtime Tests ===');
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntime(value) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreWindow() {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+try {
+  const snpTable = { rs123: { snpHints: {} } };
+  const calls = [];
+  const runtime = {
+    _snpTableCache: snpTable,
+    closeModal() { calls.push(['close', this === runtime]); },
+    openEMFAssessmentEditor() { calls.push(['emf', this === runtime]); },
+    openProfileLocationEditor() { calls.push(['location', this === runtime]); },
+    openSettingsTab(tab) { calls.push(['settings', tab, this === runtime]); },
+    setTimeout(callback, delay) {
+      calls.push(['timeout', delay, this === runtime]);
+      callback();
+      return 17;
+    },
+  };
+  setRuntime(runtime);
+
+  const timerId = scheduleRecommendationsTask(() => calls.push(['task']), 125);
+  const registered = registerRecommendationsRuntimeExports({ recommendationProbe: () => 'ok' });
+
+  assert('recommendations runtime reads SNP table cache',
+    getRecommendationsSnpTable() === snpTable);
+  assert('recommendations runtime delegates host modal and editor hooks',
+    closeRecommendationsModal() &&
+      openRecommendationsEmfAssessment() &&
+      openRecommendationsLocationEditor() &&
+      openRecommendationsPrivacySettings() &&
+      calls.some(call => call[0] === 'close' && call[1] === true) &&
+      calls.some(call => call[0] === 'emf' && call[1] === true) &&
+      calls.some(call => call[0] === 'location' && call[1] === true) &&
+      calls.some(call => call[0] === 'settings' && call[1] === 'privacy' && call[2] === true));
+  assert('recommendations runtime delegates timers with browser binding',
+    timerId === 17 &&
+      calls.some(call => call[0] === 'timeout' && call[1] === 125 && call[2] === true) &&
+      calls.some(call => call[0] === 'task'));
+  assert('recommendations runtime registers window exports',
+    registered && runtime.recommendationProbe?.() === 'ok');
+
+  delete runtime.closeModal;
+  delete runtime.openEMFAssessmentEditor;
+  delete runtime.openProfileLocationEditor;
+  delete runtime.openSettingsTab;
+  delete runtime._snpTableCache;
+  assert('recommendations runtime handles missing optional browser hooks',
+    getRecommendationsSnpTable() === null &&
+      closeRecommendationsModal() === false &&
+      openRecommendationsEmfAssessment() === false &&
+      openRecommendationsLocationEditor() === false &&
+      openRecommendationsPrivacySettings() === false);
+
+  delete globalThis.window;
+  assert('recommendations runtime no-ops without browser window',
+    getRecommendationsSnpTable() === null &&
+      registerRecommendationsRuntimeExports({ missingWindowProbe: true }) === false);
+} finally {
+  restoreWindow();
+}
+
+try {
+  delete globalThis.window;
+  await import('../js/recommendations-runtime.js?no-window-probe');
+  assert('recommendations runtime imports without a browser window', true);
+} catch (error) {
+  assert('recommendations runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  restoreWindow();
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -28,7 +28,7 @@ await import('../js/recommendations.js');
 // Original test reads data/light-device-presets.json via fetchWithRetry —
 // pass through fs read.
 const _realFetch = globalThis.fetch;
-globalThis.fetch = async (url, opts) => {
+  globalThis.fetch = async (url, opts) => {
   if (typeof url === 'string' && !/^https?:/.test(url)) {
     const rel = url.replace(/^\//, '');
     try { return new Response(read(rel), { status: 200 }); }
@@ -37,6 +37,7 @@ globalThis.fetch = async (url, opts) => {
   return _realFetch(url, opts);
 };
   const recSrc = await fetchWithRetry('js/recommendations.js');
+  const recRuntimeSrc = await fetchWithRetry('js/recommendations-runtime.js');
   const recRegionSrc = await fetchWithRetry('js/recommendations-region.js');
   const mainSrc = await fetchWithRetry('js/main.js');
   const chatRenderSrc = await fetchWithRetry('js/chat-render.js');
@@ -73,6 +74,13 @@ globalThis.fetch = async (url, opts) => {
   assert('recommendations.js exports renderRecommendationSection', recSrc.includes('export async function renderRecommendationSection'));
   assert('recommendations.js exports renderRecommendationSectionSync', recSrc.includes('export function renderRecommendationSectionSync'));
   assert('recommendations.js exports detectSupplementSlots', recSrc.includes('export function detectSupplementSlots'));
+  assert('recommendations.js delegates browser hooks through runtime adapter',
+    recSrc.includes("from './recommendations-runtime.js'") &&
+      !/\bwindow(?:\.|\s*\[)/.test(recSrc) &&
+      !recSrc.includes('Object.assign(window') &&
+      recRuntimeSrc.includes('export function getRecommendationsSnpTable') &&
+      recRuntimeSrc.includes('export function registerRecommendationsRuntimeExports'),
+    recSrc.slice(0, 1800));
   assert('recommendations-region.js owns region hierarchy data',
     recRegionSrc.includes('REGION_HIERARCHY') &&
     recRegionSrc.includes('COUNTRY_TO_REGION') &&
@@ -295,6 +303,7 @@ globalThis.fetch = async (url, opts) => {
   console.log('%c 12. Infrastructure ', 'font-weight:bold;color:#f59e0b');
 
   assert('SW includes recommendations.js', swSrc.includes('/js/recommendations.js'));
+  assert('SW includes recommendations-runtime.js', swSrc.includes('/js/recommendations-runtime.js'));
   assert('SW includes recommendations-region.js', swSrc.includes('/js/recommendations-region.js'));
   assert('SW includes recommendation-actions.js', swSrc.includes('/js/recommendation-actions.js'));
   assert('SW includes dashboard-recommendation-widget.js', swSrc.includes('/js/dashboard-recommendation-widget.js'));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -42,6 +42,7 @@
     '/js/ai-verdict-engine-runtime.js',
     '/js/chat-render-runtime.js',
     '/js/chat-send-runtime.js',
+    '/js/recommendations-runtime.js',
     '/js/recommendation-actions.js',
     '/js/context-card-dashboard-ai.js',
     '/js/context-card-dashboard-ai-actions.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -185,6 +185,7 @@
     "js/profile.js",
     "js/profile-runtime.js",
     "js/provider-panels.js",
+    "js/recommendations-runtime.js",
     "js/recommendations.js",
     "js/settings.js",
     "js/settings-runtime.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -186,6 +186,7 @@
     "js/profile-runtime.js",
     "js/profile-share.js",
     "js/recommendation-actions.js",
+    "js/recommendations-runtime.js",
     "js/recommendations.js",
     "js/api-runtime.js",
     "js/api.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.112';
+self.APP_VERSION = '1.10.113';


### PR DESCRIPTION
## Summary
- Added a Recommendations runtime adapter for SNP cache access, host modal/settings/location hooks, runtime export registration, and timer scheduling.
- Rewired recommendations.js delegated actions, coupon flash cleanup, DNA hinting, and export registration through the adapter.
- Added runtime/source tests and registered the new module in the service worker cache, TypeScript configs, and static module verification.

## Window burden
- Reduced counted direct window global references in js/ from 129 to 124 (-5).
- Removed all counted direct window references from js/recommendations.js; host browser coupling now lives behind js/recommendations-runtime.js.

## Tests
- node tests/test-recommendations-runtime.js
- node tests/test-recommendations.js
- node tests/verify-modules.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npx playwright test tests/playwright/recommendations-browser-coverage.spec.js tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js tests/playwright/recommendation-actions-browser-coverage.spec.js tests/playwright/chart-card-recs-browser-coverage.spec.js
- ./run-tests.sh