### PR TITLE
[codex] Extract wearable auth runtime hooks

### DIFF
--- a/js/wearables-auth-runtime.js
+++ b/js/wearables-auth-runtime.js
@@ -1,0 +1,37 @@
+// @ts-check
+// wearables-auth-runtime.js - Browser runtime adapters for wearable OAuth modules.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+export function getWearableAuthLocation() {
+  return getRuntimeWindow()?.location || null;
+}
+
+export function getWearableAuthProfileId() {
+  return getRuntimeWindow()?._labState?.currentProfile || null;
+}
+
+/** @param {string} url */
+export function redirectWearableAuth(url) {
+  const location = getWearableAuthLocation();
+  if (!location) return false;
+  location.href = url;
+  return true;
+}
+
+/**
+ * @param {string} name
+ * @param {Record<string, unknown>} api
+ * @param {boolean} enabled
+ */
+export function exposeWearableAuthDebug(name, api, enabled = false) {
+  if (!enabled) return false;
+  const runtime = getRuntimeWindow();
+  if (!runtime) return false;
+  runtime[name] = api;
+  return true;
+}

--- a/js/wearables-fitbit-auth.js
+++ b/js/wearables-fitbit-auth.js
@@ -11,6 +11,12 @@
 // Docs:      https://dev.fitbit.com/build/reference/web-api/
 
 import { isDebugMode } from './utils.js';
+import {
+  exposeWearableAuthDebug,
+  getWearableAuthLocation,
+  getWearableAuthProfileId,
+  redirectWearableAuth,
+} from './wearables-auth-runtime.js';
 
 const AUTHORIZE_URL = 'https://www.fitbit.com/oauth2/authorize';
 const TOKEN_URL     = 'https://api.fitbit.com/oauth2/token';
@@ -61,9 +67,10 @@ export const deriveCodeChallenge = sha256Base64Url;
 // Authorize
 // ─────────────────────────────────────────────────────────
 
-export function pickRedirectUri(registeredUris, windowLocation = window.location) {
-  const origin = windowLocation.origin;
-  const hrefBase = origin + windowLocation.pathname;
+export function pickRedirectUri(registeredUris, locationLike = getWearableAuthLocation()) {
+  const origin = locationLike?.origin;
+  if (!origin) throw new Error('No registered Fitbit redirect URI matches current origin unknown');
+  const hrefBase = origin + locationLike.pathname;
   const exact = registeredUris.find(u => u === hrefBase || u === hrefBase + '/');
   if (exact) return exact;
   const byOrigin = registeredUris.find(u => u.startsWith(origin));
@@ -91,10 +98,10 @@ export async function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_FI
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId, codeVerifier,
-    profileId: window._labState?.currentProfile || null,
+    profileId: getWearableAuthProfileId(),
   }));
   const url = await buildAuthorizeUrl({ clientId, redirectUri, scopes, state, codeVerifier });
-  window.location.href = url;
+  redirectWearableAuth(url);
 }
 
 // ─────────────────────────────────────────────────────────
@@ -227,4 +234,4 @@ export async function withFreshToken(connection, clientId, refreshedWrite, readL
   return run();
 }
 
-if (isDebugMode?.()) window._fitbitAuth = { buildAuthorizeUrl, completeOAuthCallback, isFitbitCallback, refreshTokens, withFreshToken };
+exposeWearableAuthDebug('_fitbitAuth', { buildAuthorizeUrl, completeOAuthCallback, isFitbitCallback, refreshTokens, withFreshToken }, Boolean(isDebugMode?.()));

--- a/js/wearables-oura-auth.js
+++ b/js/wearables-oura-auth.js
@@ -11,6 +11,12 @@
 // out of the browser via the proxy.
 
 import { isDebugMode } from './utils.js';
+import {
+  exposeWearableAuthDebug,
+  getWearableAuthLocation,
+  getWearableAuthProfileId,
+  redirectWearableAuth,
+} from './wearables-auth-runtime.js';
 
 const AUTHORIZE_URL = 'https://cloud.ouraring.com/oauth/authorize';
 const PROXY_URL = '/api/proxy';
@@ -43,10 +49,11 @@ function randomState() {
 
 // The redirect_uri must exactly match what's registered in the Oura developer
 // portal. We pick the registered URI that matches the current origin + path.
-export function pickRedirectUri(registeredUris, windowLocation = window.location) {
-  const origin = windowLocation.origin;
+export function pickRedirectUri(registeredUris, locationLike = getWearableAuthLocation()) {
+  const origin = locationLike?.origin;
+  if (!origin) throw new Error('No registered Oura redirect URI matches current origin unknown');
   // Prefer exact match on origin + pathname; fall back to origin match alone.
-  const hrefBase = origin + windowLocation.pathname;
+  const hrefBase = origin + locationLike.pathname;
   const exact = registeredUris.find(u => u === hrefBase || u === hrefBase + '/');
   if (exact) return exact;
   const byOrigin = registeredUris.find(u => u.startsWith(origin));
@@ -74,10 +81,10 @@ export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_OURA_SCO
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: window._labState?.currentProfile || null,
+    profileId: getWearableAuthProfileId(),
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
-  window.location.href = url;
+  redirectWearableAuth(url);
 }
 
 // ─────────────────────────────────────────────────────────
@@ -233,4 +240,4 @@ export async function withFreshToken(connection, clientId, refreshedWrite, readL
   return run();
 }
 
-if (isDebugMode?.()) window._ouraAuth = { buildAuthorizeUrl, completeOAuthCallback, isOuraCallback, refreshTokens, withFreshToken };
+exposeWearableAuthDebug('_ouraAuth', { buildAuthorizeUrl, completeOAuthCallback, isOuraCallback, refreshTokens, withFreshToken }, Boolean(isDebugMode?.()));

--- a/js/wearables-polar-auth.js
+++ b/js/wearables-polar-auth.js
@@ -16,6 +16,12 @@
 //      connection blob). wearables-polar.js handles that call, not this file.
 
 import { isDebugMode } from './utils.js';
+import {
+  exposeWearableAuthDebug,
+  getWearableAuthLocation,
+  getWearableAuthProfileId,
+  redirectWearableAuth,
+} from './wearables-auth-runtime.js';
 
 const AUTHORIZE_URL    = 'https://flow.polar.com/oauth2/authorization';
 const PROXY_URL        = '/api/proxy';
@@ -31,9 +37,10 @@ function randomState() {
   return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
 
-export function pickRedirectUri(registeredUris, windowLocation = window.location) {
-  const origin = windowLocation.origin;
-  const hrefBase = origin + windowLocation.pathname;
+export function pickRedirectUri(registeredUris, locationLike = getWearableAuthLocation()) {
+  const origin = locationLike?.origin;
+  if (!origin) throw new Error('No registered Polar redirect URI matches current origin unknown');
+  const hrefBase = origin + locationLike.pathname;
   const exact = registeredUris.find(u => u === hrefBase || u === hrefBase + '/');
   if (exact) return exact;
   const byOrigin = registeredUris.find(u => u.startsWith(origin));
@@ -57,10 +64,10 @@ export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_POLAR_SC
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: window._labState?.currentProfile || null,
+    profileId: getWearableAuthProfileId(),
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
-  window.location.href = url;
+  redirectWearableAuth(url);
 }
 
 export async function completeOAuthCallback(urlParams) {
@@ -182,4 +189,4 @@ export async function withFreshToken(connection, clientId, refreshedWrite, readL
 // export surface makes the drift test simpler.
 export const deriveCodeChallenge = null;
 
-if (isDebugMode?.()) window._polarAuth = { buildAuthorizeUrl, completeOAuthCallback, isPolarCallback, refreshTokens, withFreshToken };
+exposeWearableAuthDebug('_polarAuth', { buildAuthorizeUrl, completeOAuthCallback, isPolarCallback, refreshTokens, withFreshToken }, Boolean(isDebugMode?.()));

--- a/js/wearables-ultrahuman-auth.js
+++ b/js/wearables-ultrahuman-auth.js
@@ -16,6 +16,12 @@
 // reaches the browser. Same server-side-flow pattern as Oura + Withings.
 
 import { isDebugMode } from './utils.js';
+import {
+  exposeWearableAuthDebug,
+  getWearableAuthLocation,
+  getWearableAuthProfileId,
+  redirectWearableAuth,
+} from './wearables-auth-runtime.js';
 
 const AUTHORIZE_URL = 'https://auth.ultrahuman.com/authorise';
 const PROXY_URL     = '/api/proxy';
@@ -31,9 +37,10 @@ function randomState() {
   return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
 
-export function pickRedirectUri(registeredUris, windowLocation = window.location) {
-  const origin = windowLocation.origin;
-  const hrefBase = origin + windowLocation.pathname;
+export function pickRedirectUri(registeredUris, locationLike = getWearableAuthLocation()) {
+  const origin = locationLike?.origin;
+  if (!origin) throw new Error('No registered Ultrahuman redirect URI matches current origin unknown');
+  const hrefBase = origin + locationLike.pathname;
   const exact = registeredUris.find(u => u === hrefBase || u === hrefBase + '/');
   if (exact) return exact;
   const byOrigin = registeredUris.find(u => u.startsWith(origin));
@@ -57,10 +64,10 @@ export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_ULTRAHUM
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: window._labState?.currentProfile || null,
+    profileId: getWearableAuthProfileId(),
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
-  window.location.href = url;
+  redirectWearableAuth(url);
 }
 
 export async function completeOAuthCallback(urlParams) {
@@ -172,4 +179,4 @@ export async function withFreshToken(connection, clientId, refreshedWrite, readL
   return run();
 }
 
-if (isDebugMode?.()) window._ultrahumanAuth = { buildAuthorizeUrl, completeOAuthCallback, isUltrahumanCallback, refreshTokens, withFreshToken };
+exposeWearableAuthDebug('_ultrahumanAuth', { buildAuthorizeUrl, completeOAuthCallback, isUltrahumanCallback, refreshTokens, withFreshToken }, Boolean(isDebugMode?.()));

--- a/js/wearables-whoop-auth.js
+++ b/js/wearables-whoop-auth.js
@@ -10,6 +10,12 @@
 // Refresh uses the refresh_token (granted via the `offline` scope).
 
 import { isDebugMode } from './utils.js';
+import {
+  exposeWearableAuthDebug,
+  getWearableAuthLocation,
+  getWearableAuthProfileId,
+  redirectWearableAuth,
+} from './wearables-auth-runtime.js';
 
 const AUTHORIZE_URL = 'https://api.prod.whoop.com/oauth/oauth2/auth';
 const TOKEN_URL     = 'https://api.prod.whoop.com/oauth/oauth2/token';
@@ -51,9 +57,10 @@ export const deriveCodeChallenge = sha256Base64Url;
 // Authorize
 // ─────────────────────────────────────────────────────────
 
-export function pickRedirectUri(registeredUris, windowLocation = window.location) {
-  const origin = windowLocation.origin;
-  const hrefBase = origin + windowLocation.pathname;
+export function pickRedirectUri(registeredUris, locationLike = getWearableAuthLocation()) {
+  const origin = locationLike?.origin;
+  if (!origin) throw new Error('No registered WHOOP redirect URI matches current origin unknown');
+  const hrefBase = origin + locationLike.pathname;
   const exact = registeredUris.find(u => u === hrefBase || u === hrefBase + '/');
   if (exact) return exact;
   const byOrigin = registeredUris.find(u => u.startsWith(origin));
@@ -81,10 +88,10 @@ export async function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WH
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId, codeVerifier,
-    profileId: window._labState?.currentProfile || null, // pin profile so a mid-OAuth switch lands in the initiating profile
+    profileId: getWearableAuthProfileId(), // pin profile so a mid-OAuth switch lands in the initiating profile
   }));
   const url = await buildAuthorizeUrl({ clientId, redirectUri, scopes, state, codeVerifier });
-  window.location.href = url;
+  redirectWearableAuth(url);
 }
 
 // ─────────────────────────────────────────────────────────
@@ -217,4 +224,4 @@ export async function withFreshToken(connection, clientId, refreshedWrite, readL
   return run();
 }
 
-if (isDebugMode?.()) window._whoopAuth = { buildAuthorizeUrl, completeOAuthCallback, isWhoopCallback, refreshTokens, withFreshToken };
+exposeWearableAuthDebug('_whoopAuth', { buildAuthorizeUrl, completeOAuthCallback, isWhoopCallback, refreshTokens, withFreshToken }, Boolean(isDebugMode?.()));

--- a/js/wearables-withings-auth.js
+++ b/js/wearables-withings-auth.js
@@ -13,6 +13,12 @@
 // /api/proxy). PKCE is NOT supported by Withings.
 
 import { isDebugMode } from './utils.js';
+import {
+  exposeWearableAuthDebug,
+  getWearableAuthLocation,
+  getWearableAuthProfileId,
+  redirectWearableAuth,
+} from './wearables-auth-runtime.js';
 
 const AUTHORIZE_URL = 'https://account.withings.com/oauth2_user/authorize2';
 const PROXY_URL     = '/api/proxy';
@@ -28,9 +34,10 @@ function randomState() {
   return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
 }
 
-export function pickRedirectUri(registeredUris, windowLocation = window.location) {
-  const origin = windowLocation.origin;
-  const hrefBase = origin + windowLocation.pathname;
+export function pickRedirectUri(registeredUris, locationLike = getWearableAuthLocation()) {
+  const origin = locationLike?.origin;
+  if (!origin) throw new Error('No registered Withings redirect URI matches current origin unknown');
+  const hrefBase = origin + locationLike.pathname;
   const exact = registeredUris.find(u => u === hrefBase || u === hrefBase + '/');
   if (exact) return exact;
   const byOrigin = registeredUris.find(u => u.startsWith(origin));
@@ -54,10 +61,10 @@ export function beginOAuth({ clientId, registeredUris, scopes = DEFAULT_WITHINGS
   const redirectUri = pickRedirectUri(registeredUris);
   sessionStorage.setItem(STATE_KEY, JSON.stringify({
     state, redirectUri, startedAt: Date.now(), clientId,
-    profileId: window._labState?.currentProfile || null,
+    profileId: getWearableAuthProfileId(),
   }));
   const url = buildAuthorizeUrl({ clientId, redirectUri, scopes, state });
-  window.location.href = url;
+  redirectWearableAuth(url);
 }
 
 export async function completeOAuthCallback(urlParams) {
@@ -188,4 +195,4 @@ export async function withFreshToken(connection, clientId, refreshedWrite, readL
   return run();
 }
 
-if (isDebugMode?.()) window._withingsAuth = { buildAuthorizeUrl, completeOAuthCallback, isWithingsCallback, refreshTokens, withFreshToken };
+exposeWearableAuthDebug('_withingsAuth', { buildAuthorizeUrl, completeOAuthCallback, isWithingsCallback, refreshTokens, withFreshToken }, Boolean(isDebugMode?.()));

--- a/service-worker.js
+++ b/service-worker.js
@@ -374,6 +374,7 @@ const APP_SHELL = [
   '/js/wearables-formatters.js',
   '/js/wearables-manual-form-ui.js',
   '/js/wearables-runtime.js',
+  '/js/wearables-auth-runtime.js',
   '/js/wearables-settings-runtime.js',
   '/js/wearables-settings-panel.js',
   '/js/wearables-store.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -191,6 +191,7 @@ const LEGACY_TESTS = [
   './test-biology-scores-runtime.js',
   './test-wearables-detail-runtime.js',
   './test-wearables-apple-health-runtime.js',
+  './test-wearables-auth-runtime.js',
   './test-wearables-runtime.js',
   './test-category-page-runtime.js',
   './test-category-customization-runtime.js',

--- a/tests/test-wearables-auth-runtime.js
+++ b/tests/test-wearables-auth-runtime.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Wearable OAuth runtime adapter behavior.
+
+import './_node-shim.js';
+import {
+  exposeWearableAuthDebug,
+  getWearableAuthLocation,
+  getWearableAuthProfileId,
+  redirectWearableAuth,
+} from '../js/wearables-auth-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Wearables Auth Runtime Tests ===');
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+function setRuntime(value) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreWindow() {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete globalThis.window;
+}
+
+try {
+  const location = { origin: 'https://app.example', pathname: '/app', href: 'https://app.example/app' };
+  const runtime = {
+    location,
+    _labState: { currentProfile: 'profile-123' },
+  };
+  setRuntime(runtime);
+
+  assert('wearables auth runtime reads browser location',
+    getWearableAuthLocation() === location);
+  assert('wearables auth runtime reads active profile id',
+    getWearableAuthProfileId() === 'profile-123');
+  assert('wearables auth runtime redirects through location href',
+    redirectWearableAuth('https://provider.example/auth') &&
+      location.href === 'https://provider.example/auth');
+  assert('wearables auth runtime skips debug export when disabled',
+    exposeWearableAuthDebug('_testAuth', { ok: true }, false) === false &&
+      runtime._testAuth === undefined);
+  assert('wearables auth runtime exports debug API when enabled',
+    exposeWearableAuthDebug('_testAuth', { ok: true }, true) === true &&
+      runtime._testAuth.ok === true);
+
+  delete runtime._labState;
+  delete runtime.location;
+  assert('wearables auth runtime handles missing optional browser globals',
+    getWearableAuthLocation() === null &&
+      getWearableAuthProfileId() === null &&
+      redirectWearableAuth('https://provider.example/auth') === false);
+
+  delete globalThis.window;
+  assert('wearables auth runtime no-ops without browser window',
+    getWearableAuthLocation() === null &&
+      getWearableAuthProfileId() === null &&
+      exposeWearableAuthDebug('_missingWindowAuth', { ok: true }, true) === false);
+} finally {
+  restoreWindow();
+}
+
+try {
+  delete globalThis.window;
+  await import('../js/wearables-auth-runtime.js?no-window-probe');
+  assert('wearables auth runtime imports without a browser window', true);
+} catch (error) {
+  assert('wearables auth runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  restoreWindow();
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -823,6 +823,26 @@ assert('extractExportXml awaits loadJSZip() instead of bare window.JSZip',
   /const\s+JSZip\s*=\s*await\s+loadJSZip\(\)/.test(ahSrc));
 assert('No bare "JSZip not loaded" throw left in extractExportXml',
   !ahSrc.includes('JSZip not loaded — Apple Health'));
+const authRuntimeSrc = await fetch('/js/wearables-auth-runtime.js').then(r => r.text());
+const authModuleFiles = [
+  '/js/wearables-fitbit-auth.js',
+  '/js/wearables-oura-auth.js',
+  '/js/wearables-polar-auth.js',
+  '/js/wearables-ultrahuman-auth.js',
+  '/js/wearables-whoop-auth.js',
+  '/js/wearables-withings-auth.js',
+];
+const authModuleSources = await Promise.all(authModuleFiles.map(file => fetch(file).then(r => r.text())));
+assert('Wearable OAuth modules delegate browser globals to auth runtime',
+  authModuleSources.every(src =>
+    src.includes("from './wearables-auth-runtime.js'") &&
+    src.includes('getWearableAuthProfileId') &&
+    src.includes('redirectWearableAuth') &&
+    src.includes('exposeWearableAuthDebug') &&
+    !/\bwindow(?:\.|\s*\[)/.test(src)) &&
+    authRuntimeSrc.includes('export function getWearableAuthLocation') &&
+    authRuntimeSrc.includes('export function exposeWearableAuthDebug'),
+  authModuleFiles.find((file, index) => /\bwindow(?:\.|\s*\[)/.test(authModuleSources[index])) || 'missing runtime import');
 // (JSZip functional smoke — needs real browser <script> injection —
 // lives in test-wearables-dom.js. The loadJSZip source-pattern asserts
 // above run in Node.)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -57,6 +57,7 @@
     '/js/wearables-manual-form-ui.js',
     '/js/wearables-apple-health-runtime.js',
     '/js/wearables-runtime.js',
+    '/js/wearables-auth-runtime.js',
     '/js/wearables-settings-runtime.js',
     '/js/wearables-connect-runtime.js',
     '/js/dashboard-view-composition.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -232,6 +232,7 @@
     "js/wearable-adapters.js",
     "js/wearables-apple-health-runtime.js",
     "js/wearables-apple-health.js",
+    "js/wearables-auth-runtime.js",
     "js/wearables-connect-runtime.js",
     "js/wearables-connect.js",
     "js/wearables-bp-detail-chart.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -326,6 +326,7 @@
     "js/wearable-adapters.js",
     "js/wearables-apple-health-runtime.js",
     "js/wearables-apple-health.js",
+    "js/wearables-auth-runtime.js",
     "js/wearables-connect-runtime.js",
     "js/wearables-connect.js",
     "js/wearables-detail-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.113';
+self.APP_VERSION = '1.10.114';


### PR DESCRIPTION
## Summary
- Added a shared wearable OAuth runtime adapter for location/profile reads, auth redirects, and debug exports.
- Rewired Fitbit, Oura, Polar, Ultrahuman, WHOOP, and Withings auth modules through the adapter.
- Added runtime/source tests and registered the new adapter in the service worker cache, TypeScript configs, and module verification.

## Window burden
- Reduced counted direct window global references in js/ from 124 to 100 (-24).
- Removed all counted direct window references from the six wearable OAuth auth modules; browser coupling now lives behind js/wearables-auth-runtime.js.

## Tests
- node tests/test-wearables-auth-runtime.js
- node tests/test-wearables.js
- node tests/verify-modules.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npx playwright test tests/playwright/wearables-auth-browser-coverage.spec.js tests/playwright/wearables-connect-browser-coverage.spec.js
- ./run-tests.sh