### PR TITLE
[codex] Extract shared chat runtime hooks

### DIFF
--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -11,6 +11,7 @@ import {
   CHAT_MESSAGE_INDEX_ATTR,
   chatMessageActionAttrs,
 } from './chat-message-action-attrs.js';
+import { getChatRegenerateCallbacks, isChatRuntimeStreaming } from './chat-runtime.js';
 
 let chatMessageDelegatesInstalled = false;
 export { chatMessageActionAttrs } from './chat-message-action-attrs.js';
@@ -156,10 +157,10 @@ export function buildActionBar(msgIndex) {
 
 export function regenerateLastMessage() {
   if (state.chatHistory.length < 2) return;
-  if (window.isChatStreaming?.()) return;
-  const renderChatMessages = window.renderChatMessages;
-  const sendChatMessage = window.sendChatMessage;
-  if (typeof renderChatMessages !== 'function' || typeof sendChatMessage !== 'function') return;
+  if (isChatRuntimeStreaming()) return;
+  const callbacks = getChatRegenerateCallbacks();
+  if (!callbacks) return;
+  const { renderChatMessages, sendChatMessage } = callbacks;
 
   state.chatHistory.pop();
   const lastUserMsg = state.chatHistory[state.chatHistory.length - 1];

--- a/js/chat-discussion-round-runner.js
+++ b/js/chat-discussion-round-runner.js
@@ -25,6 +25,7 @@ import {
   createDiscussionPersonaLabel, createDiscussionTypingIndicator, renderDiscussionRoundError,
   renderFinalDiscussionMessage,
 } from './chat-discussion-round-view.js';
+import { getChatProviderAttestation } from './chat-runtime.js';
 
 export async function runDiscussionRound(personas, steerPrompt, opts = {}) {
   const container = document.getElementById('chat-messages');
@@ -94,6 +95,7 @@ export async function runDiscussionRound(personas, steerPrompt, opts = {}) {
       const fullText = aiResult.text;
       const usage = /** @type {{ inputTokens?: number, outputTokens?: number } | undefined} */ (aiResult.usage);
       const responseTruncated = isAIResponseTruncated(aiResult);
+      const attestation = getChatProviderAttestation('venice');
 
       typewriter.stop();
       renderFinalDiscussionMessage({
@@ -115,7 +117,7 @@ export async function runDiscussionRound(personas, steerPrompt, opts = {}) {
         usage,
         webSearch: request.webSearch,
         e2ee: request.e2ee,
-        attestation: window._veniceAttestation,
+        attestation,
       });
 
       const assistantMsg = buildDiscussionAssistantMessage({
@@ -123,7 +125,7 @@ export async function runDiscussionRound(personas, steerPrompt, opts = {}) {
         request,
         aiResult,
         responseTruncated,
-        attestation: window._veniceAttestation,
+        attestation,
       });
       if (usage && (usage.inputTokens || usage.outputTokens)) {
         assistantMsg.usage = { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens };

--- a/js/chat-history.js
+++ b/js/chat-history.js
@@ -12,6 +12,7 @@ import {
 } from './chat-threads.js';
 import { renderSavedSummaries } from './chat-summaries.js';
 import { getActivePersonality, updateChatHeaderTitle } from './chat-personalities.js';
+import { renderChatMessagesRuntime, updateDiscussButtonRuntime } from './chat-runtime.js';
 
 export function getChatStorageKey() {
   return `labcharts-${state.currentProfile}-chat`;
@@ -20,7 +21,7 @@ export function getChatStorageKey() {
 export async function loadChatHistory() {
   if (!state.currentThreadId) {
     state.chatHistory = [];
-    window.renderChatMessages?.();
+    renderChatMessagesRuntime();
     return;
   }
   try {
@@ -28,7 +29,7 @@ export async function loadChatHistory() {
     const stored = await encryptedGetItem(key);
     state.chatHistory = stored ? JSON.parse(stored) : [];
   } catch { state.chatHistory = []; }
-  window.renderChatMessages?.();
+  renderChatMessagesRuntime();
 }
 
 export async function saveChatHistory() {
@@ -76,9 +77,9 @@ export async function clearChatHistory() {
         renderSavedSummaries();
       }
     }
-    window.renderChatMessages?.();
+    renderChatMessagesRuntime();
     updateChatHeaderTitle();
-    window.updateDiscussButton?.();
+    updateDiscussButtonRuntime();
     showNotification('Chat history cleared', 'info');
   }
 }

--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -10,6 +10,11 @@ import { CHAT_ICON_EDIT, CHAT_ICON_X } from './chat-icons.js';
 import { e2eeLockHTML } from './chat-attestation.js';
 import { getLensSummary } from './lens.js';
 import { CONTEXT_SOURCE_IDS, isContextSourceEnabled } from './context-source-registry.js';
+import {
+  getChatProviderAttestation,
+  openChatContextModalRuntime,
+  renderChatMessagesRuntime,
+} from './chat-runtime.js';
 
 const PERSONA_ICONS = ['🧠', '🎭', '🔮', '🌿', '⚡', '🦊', '🧬', '🌊', '🔥', '🏛️'];
 
@@ -203,7 +208,7 @@ export async function setChatPersonality(id, opts = {}) {
     saveChatThreadIndex();
   }
   if (state.chatHistory.length === 0) {
-    window.renderChatMessages?.();
+    renderChatMessagesRuntime();
   }
   renderThreadList();
   updateChatHeaderTitle();
@@ -287,10 +292,7 @@ function ensureChatContextStatus(el) {
     status = document.createElement('button');
     status.type = 'button';
     status.className = 'chat-context-status';
-    status.addEventListener('click', () => {
-      const opener = /** @type {any} */ (window).openContextModal;
-      if (typeof opener === 'function') opener();
-    });
+    status.addEventListener('click', () => openChatContextModalRuntime());
     parent.appendChild(status);
   }
   return status;
@@ -342,7 +344,7 @@ export function updateChatHeaderModel() {
   const e2ee = provider === 'venice' && isVeniceE2EEActive();
   const ppqPrivate = provider === 'ppq' && isPpqPrivateModeActive();
   if (e2ee || ppqPrivate) {
-    el.innerHTML = escapeHTML(display) + e2eeLockHTML(ppqPrivate ? window._ppqAttestation : window._veniceAttestation);
+    el.innerHTML = escapeHTML(display) + e2eeLockHTML(getChatProviderAttestation(ppqPrivate ? 'ppq' : 'venice'));
   } else {
     el.textContent = display;
   }
@@ -505,7 +507,7 @@ export async function deleteCustomPersonality(id) {
     }
     updatePersonalityBar();
     updateChatHeaderTitle();
-    window.renderChatMessages?.();
+    renderChatMessagesRuntime();
   }
 }
 

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -1,0 +1,54 @@
+// @ts-check
+// chat-runtime.js - Browser runtime adapters for shared chat hooks.
+
+function getRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {any}
+ */
+function getRuntimeValue(name) {
+  const runtime = getRuntimeWindow();
+  return runtime ? runtime[name] : undefined;
+}
+
+export function renderChatMessagesRuntime() {
+  getRuntimeFunction('renderChatMessages')?.();
+}
+
+export function updateDiscussButtonRuntime() {
+  getRuntimeFunction('updateDiscussButton')?.();
+}
+
+export function openChatContextModalRuntime() {
+  getRuntimeFunction('openContextModal')?.();
+}
+
+export function isChatRuntimeStreaming() {
+  return Boolean(getRuntimeFunction('isChatStreaming')?.());
+}
+
+export function getChatRegenerateCallbacks() {
+  const renderChatMessages = getRuntimeFunction('renderChatMessages');
+  const sendChatMessage = getRuntimeFunction('sendChatMessage');
+  if (!renderChatMessages || !sendChatMessage) return null;
+  return { renderChatMessages, sendChatMessage };
+}
+
+/** @param {string} provider */
+export function getChatProviderAttestation(provider) {
+  return getRuntimeValue(provider === 'ppq' ? '_ppqAttestation' : '_veniceAttestation');
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -175,6 +175,7 @@ const APP_SHELL = [
   '/js/chat-discussion-ui.js',
   '/js/chat-onboarding.js',
   '/js/chat-empty-state.js',
+  '/js/chat-runtime.js',
   '/js/chat-render-runtime.js',
   '/js/chat-render.js',
   '/js/chat-send.js',

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -181,6 +181,7 @@ const LEGACY_TESTS = [
   './test-settings-runtime.js',
   './test-settings-delegated-actions.js',
   './test-views-router-runtime.js',
+  './test-chat-runtime.js',
   './test-chat-render-runtime.js',
   './test-chat-send-runtime.js',
   './test-recommendations-runtime.js',

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -347,6 +347,7 @@ console.log('Section 17: Source inspection');
 const chatSrc = read('js/chat.js');
 const chatWindowBindingsSrc = read('js/chat-window-bindings.js');
 const chatActionsSrc = read('js/chat-actions.js');
+const chatRuntimeSrc = read('js/chat-runtime.js');
 const chatMessageActionAttrsSrc = read('js/chat-message-action-attrs.js');
 const chatAttestationSrc = read('js/chat-attestation.js');
 const chatIconsSrc = read('js/chat-icons.js');
@@ -415,11 +416,26 @@ assert('chat incomplete heuristic does not continue on terminal high/low adjecti
 assert('chat renders output-limit note', chatContinuationSrc.includes('output limit reached'), 'found');
 assert('chat persists truncated assistant state', chatSendSrc.includes('assistantMsg.truncated = true'), 'found');
 assert('renderChatMessages restores truncated note', chatRenderSrc.includes('msg.truncated') && chatRenderSrc.includes('responseLimitNote()'), 'found');
-assert('regenerateLastMessage checks streaming state via chat.js callback',
-  chatActionsSrc.includes('window.isChatStreaming?.()') && chatSendSrc.includes('export function isChatStreaming'), 'found');
+assert('regenerateLastMessage checks streaming state via chat runtime',
+  chatActionsSrc.includes('isChatRuntimeStreaming()') &&
+    chatRuntimeSrc.includes("getRuntimeFunction('isChatStreaming')") &&
+    chatSendSrc.includes('export function isChatStreaming'), 'found');
 assert('regenerateLastMessage checks render/send callbacks before mutating',
-  chatActionsSrc.indexOf("typeof renderChatMessages !== 'function'") < chatActionsSrc.indexOf('state.chatHistory.pop()')
-    && chatActionsSrc.indexOf("typeof sendChatMessage !== 'function'") < chatActionsSrc.indexOf('state.chatHistory.pop()'), 'found');
+  chatActionsSrc.indexOf('const callbacks = getChatRegenerateCallbacks()') < chatActionsSrc.indexOf('state.chatHistory.pop()')
+    && chatRuntimeSrc.includes("getRuntimeFunction('renderChatMessages')")
+    && chatRuntimeSrc.includes("getRuntimeFunction('sendChatMessage')"), 'found');
+const directWindowGlobalRe = /\bwindow(?:\.|\s*\[)/;
+const chatRuntimeDelegates = [
+  ['chat-actions.js', chatActionsSrc],
+  ['chat-history.js', chatHistorySrc],
+  ['chat-personalities.js', chatPersonalitiesSrc],
+  ['chat-discussion-round-runner.js', chatDiscussionRoundRunnerSrc],
+];
+assert('chat modules delegate direct window globals to chat runtime',
+  chatRuntimeDelegates.every(([, src]) => src.includes("from './chat-runtime.js'") && !directWindowGlobalRe.test(src)) &&
+    chatRuntimeSrc.includes('export function renderChatMessagesRuntime') &&
+    chatRuntimeSrc.includes('export function getChatProviderAttestation'),
+  chatRuntimeDelegates.find(([name, src]) => !src.includes("from './chat-runtime.js'") || directWindowGlobalRe.test(src))?.[0] || 'missing runtime export');
 assert('chat-send.js imports chat icon helpers', chatSendSrc.includes("from './chat-icons.js'"), 'found');
 assert('chat-icons.js exports button content helper', chatIconsSrc.includes('export function setIconButtonContent'), 'found');
 assert('chat window bindings import chat summary helpers',

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Chat shared browser adapter behavior.
+
+import './_node-shim.js';
+import {
+  getChatProviderAttestation,
+  getChatRegenerateCallbacks,
+  isChatRuntimeStreaming,
+  openChatContextModalRuntime,
+  renderChatMessagesRuntime,
+  updateDiscussButtonRuntime,
+} from '../js/chat-runtime.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  PASS: ${name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL: ${name}${detail ? ` -- ${detail}` : ''}`);
+  }
+}
+
+console.log('=== Chat Runtime Tests ===');
+
+const runtimeKeys = [
+  'window',
+  'renderChatMessages',
+  'updateDiscussButton',
+  'openContextModal',
+  'isChatStreaming',
+  'sendChatMessage',
+  '_ppqAttestation',
+  '_veniceAttestation',
+];
+const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+
+function setRuntimeValue(key, value) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value,
+  });
+}
+
+function restoreRuntime() {
+  for (const key of runtimeKeys) {
+    const descriptor = savedDescriptors.get(key);
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+}
+
+try {
+  const calls = [];
+  const ppqAttestation = { provider: 'ppq', verified: true };
+  const veniceAttestation = { provider: 'venice', verified: true };
+  setRuntimeValue('window', globalThis);
+  setRuntimeValue('renderChatMessages', () => calls.push(['render']));
+  setRuntimeValue('updateDiscussButton', () => calls.push(['discuss']));
+  setRuntimeValue('openContextModal', () => calls.push(['context']));
+  setRuntimeValue('isChatStreaming', () => false);
+  setRuntimeValue('sendChatMessage', () => calls.push(['send']));
+  setRuntimeValue('_ppqAttestation', ppqAttestation);
+  setRuntimeValue('_veniceAttestation', veniceAttestation);
+
+  renderChatMessagesRuntime();
+  updateDiscussButtonRuntime();
+  openChatContextModalRuntime();
+  assert('chat runtime invokes render/discuss/context callbacks',
+    calls.some(call => call[0] === 'render') &&
+      calls.some(call => call[0] === 'discuss') &&
+      calls.some(call => call[0] === 'context'));
+
+  assert('chat runtime reports non-streaming state',
+    isChatRuntimeStreaming() === false);
+  setRuntimeValue('isChatStreaming', () => true);
+  assert('chat runtime reports streaming state',
+    isChatRuntimeStreaming() === true);
+
+  const callbacks = getChatRegenerateCallbacks();
+  callbacks?.renderChatMessages();
+  callbacks?.sendChatMessage();
+  assert('chat runtime returns regenerate callbacks when both are present',
+    typeof callbacks?.renderChatMessages === 'function' &&
+      typeof callbacks?.sendChatMessage === 'function' &&
+      calls.filter(call => call[0] === 'render').length === 2 &&
+      calls.filter(call => call[0] === 'send').length === 1);
+
+  delete globalThis.sendChatMessage;
+  assert('chat runtime requires send callback for regeneration',
+    getChatRegenerateCallbacks() === null);
+
+  assert('chat runtime reads provider attestations',
+    getChatProviderAttestation('ppq') === ppqAttestation &&
+      getChatProviderAttestation('venice') === veniceAttestation);
+
+  delete globalThis.window;
+  assert('chat runtime no-ops without a browser window',
+    isChatRuntimeStreaming() === false &&
+      getChatRegenerateCallbacks() === null &&
+      getChatProviderAttestation('ppq') === undefined);
+} finally {
+  restoreRuntime();
+}
+
+try {
+  delete globalThis.window;
+  await import('../js/chat-runtime.js?no-window-probe');
+  assert('chat runtime imports without a browser window', true);
+} catch (error) {
+  assert('chat runtime imports without a browser window', false, error?.message || String(error));
+} finally {
+  restoreRuntime();
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -40,6 +40,7 @@
     '/js/import-drop-zone.js',
     '/js/import-drop-zone-runtime.js',
     '/js/ai-verdict-engine-runtime.js',
+    '/js/chat-runtime.js',
     '/js/chat-render-runtime.js',
     '/js/chat-send-runtime.js',
     '/js/recommendations-runtime.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -64,6 +64,7 @@
     "js/chat-prompt-context.js",
     "js/chat-render.js",
     "js/chat-render-runtime.js",
+    "js/chat-runtime.js",
     "js/chat-send.js",
     "js/chat-send-runtime.js",
     "js/chat-summaries.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,7 @@
     "js/chat-prompt-context.js",
     "js/chat-render.js",
     "js/chat-render-runtime.js",
+    "js/chat-runtime.js",
     "js/chat-send.js",
     "js/chat-send-runtime.js",
     "js/chat-summaries.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.114';
+self.APP_VERSION = '1.10.115';


### PR DESCRIPTION
## Summary
- Added a shared chat runtime adapter for render/discuss/context callbacks, regenerate flow callback discovery, streaming state, and provider attestation reads.
- Rewired chat history, personalities, message actions, and discussion round execution through the adapter.
- Added runtime/source tests and registered the new adapter in the service worker cache, TypeScript configs, and module verification.

## Window burden
- Reduced counted direct window global references in js/ from 100 to 87 (-13).
- Removed all counted direct window references from chat-history.js, chat-personalities.js, chat-actions.js, and chat-discussion-round-runner.js; browser coupling now lives behind js/chat-runtime.js.

## Tests
- node tests/test-chat-runtime.js
- node tests/test-chat-actions.js
- node tests/test-integration-batch2.js
- node tests/verify-modules.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- node tests/test-custom-personality.js
- npx playwright test tests/playwright/chat-actions-dom.spec.js tests/playwright/chat-history-diagnose-browser-coverage.spec.js tests/playwright/custom-personality-dom.spec.js tests/playwright/chat-discussion-browser-coverage.spec.js tests/playwright/chat-discussion-edge-browser-coverage.spec.js
- ./run-tests.sh