### PR TITLE
[codex] Delegate chart card recs runtime hooks

### DIFF
--- a/js/chart-card-recs.js
+++ b/js/chart-card-recs.js
@@ -3,11 +3,11 @@
 
 import { showNotification } from './utils.js';
 import { showDetailModal } from './marker-detail-modal.js';
+import { isRecommendationsProductRecsEnabled, loadRecommendationsCatalogRuntime } from './recommendations-runtime.js';
 
 export async function loadChartCardRecs() {
-  if (!window.isProductRecsEnabled || !window.isProductRecsEnabled()) return;
-  if (!window.loadCatalog) return;
-  const catalog = await window.loadCatalog();
+  if (!isRecommendationsProductRecsEnabled()) return;
+  const catalog = await loadRecommendationsCatalogRuntime();
   if (!catalog || !catalog.slots) return;
 
   const els = document.querySelectorAll('[id^="chart-rec-"]');

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -21,6 +21,20 @@ export function getRecommendationsSnpTable() {
   return runtime?._snpTableCache || null;
 }
 
+export function isRecommendationsProductRecsEnabled() {
+  try {
+    return Boolean(getRuntimeFunction('isProductRecsEnabled')?.());
+  } catch {
+    return false;
+  }
+}
+
+export async function loadRecommendationsCatalogRuntime() {
+  const loadCatalog = getRuntimeFunction('loadCatalog');
+  if (!loadCatalog) return null;
+  return await loadCatalog();
+}
+
 export function closeRecommendationsModal() {
   const closeModal = getRuntimeFunction('closeModal');
   if (!closeModal) return false;

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -5,6 +5,8 @@ import './_node-shim.js';
 import {
   closeRecommendationsModal,
   getRecommendationsSnpTable,
+  isRecommendationsProductRecsEnabled,
+  loadRecommendationsCatalogRuntime,
   openRecommendationsEmfAssessment,
   openRecommendationsLocationEditor,
   openRecommendationsPrivacySettings,
@@ -52,6 +54,8 @@ try {
     openEMFAssessmentEditor() { calls.push(['emf', this === runtime]); },
     openProfileLocationEditor() { calls.push(['location', this === runtime]); },
     openSettingsTab(tab) { calls.push(['settings', tab, this === runtime]); },
+    isProductRecsEnabled() { calls.push(['enabled', this === runtime]); return true; },
+    async loadCatalog() { calls.push(['catalog', this === runtime]); return { slots: { magnesium: { label: 'Magnesium' } } }; },
     setTimeout(callback, delay) {
       calls.push(['timeout', delay, this === runtime]);
       callback();
@@ -65,6 +69,12 @@ try {
 
   assert('recommendations runtime reads SNP table cache',
     getRecommendationsSnpTable() === snpTable);
+  const catalog = await loadRecommendationsCatalogRuntime();
+  assert('recommendations runtime delegates product recs flag and catalog loader',
+    isRecommendationsProductRecsEnabled() === true &&
+      catalog?.slots?.magnesium?.label === 'Magnesium' &&
+      calls.some(call => call[0] === 'enabled' && call[1] === true) &&
+      calls.some(call => call[0] === 'catalog' && call[1] === true));
   assert('recommendations runtime delegates host modal and editor hooks',
     closeRecommendationsModal() &&
       openRecommendationsEmfAssessment() &&
@@ -85,9 +95,13 @@ try {
   delete runtime.openEMFAssessmentEditor;
   delete runtime.openProfileLocationEditor;
   delete runtime.openSettingsTab;
+  delete runtime.isProductRecsEnabled;
+  delete runtime.loadCatalog;
   delete runtime._snpTableCache;
   assert('recommendations runtime handles missing optional browser hooks',
     getRecommendationsSnpTable() === null &&
+      isRecommendationsProductRecsEnabled() === false &&
+      await loadRecommendationsCatalogRuntime() === null &&
       closeRecommendationsModal() === false &&
       openRecommendationsEmfAssessment() === false &&
       openRecommendationsLocationEditor() === false &&
@@ -96,6 +110,8 @@ try {
   delete globalThis.window;
   assert('recommendations runtime no-ops without browser window',
     getRecommendationsSnpTable() === null &&
+      isRecommendationsProductRecsEnabled() === false &&
+      await loadRecommendationsCatalogRuntime() === null &&
       registerRecommendationsRuntimeExports({ missingWindowProbe: true }) === false);
 } finally {
   restoreWindow();

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -255,6 +255,11 @@ const _realFetch = globalThis.fetch;
       && categoryPageViewSrc.includes('getCategoryPageCatalogSlots')
       && !/\bwindow(\.|\s*\[)/.test(categoryPageViewSrc));
   assert('chart-card-recs.js has loadChartCardRecs function', chartCardRecsSrc.includes('function loadChartCardRecs'));
+  assert('chart-card-recs.js delegates catalog globals through recommendations runtime',
+    chartCardRecsSrc.includes("from './recommendations-runtime.js'")
+      && chartCardRecsSrc.includes('isRecommendationsProductRecsEnabled')
+      && chartCardRecsSrc.includes('loadRecommendationsCatalogRuntime')
+      && !/\bwindow(\.|\s*\[)/.test(chartCardRecsSrc));
   assert('marker-detail-modal.js scrollToRec auto-opens details', markerDetailSrc.includes('scrollToRec'));
   assert('loadCatalog on window', typeof window.loadCatalog === 'function');
   assert('nav.js exposes recommendations sidebar helper', navSrc.includes('openRecommendationsFromSidebar'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.115';
+self.APP_VERSION = '1.10.116';


### PR DESCRIPTION
## Summary
- Added recommendations runtime helpers for the product-recommendations flag and catalog loader.
- Rewired chart-card recommendation badges through those helpers instead of direct browser globals.
- Extended runtime/source tests and bumped the app version for cache invalidation.

## Window burden
- Reduced counted direct window global references in js/ from 87 to 83 (-4).
- Removed all counted direct window references from chart-card-recs.js; product recommendation enablement and catalog loading now go through js/recommendations-runtime.js.

## Tests
- node tests/test-recommendations-runtime.js
- node tests/test-recommendations.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- npx playwright test tests/playwright/chart-card-recs-browser-coverage.spec.js tests/playwright/recommendations-browser-coverage.spec.js
- ./run-tests.sh