### PR TITLE
Delegate recommendation actions runtime hooks

### DIFF
--- a/js/recommendation-actions.js
+++ b/js/recommendation-actions.js
@@ -3,6 +3,11 @@
 
 import { escapeAttr, escapeHTML } from './utils.js';
 import { openModalOverlay } from './modal-lifecycle.js';
+import {
+  closeRecommendationsModal,
+  openRecommendationsChatPanel,
+  renderRecommendationsDetailSection,
+} from './recommendations-runtime.js';
 
 let recommendationDetailDelegatesInstalled = false;
 
@@ -17,7 +22,7 @@ function handleRecommendationDetailClick(event) {
   if (!actionEl || !actionEl.closest('#detail-modal')) return;
   if (actionEl.dataset.recommendationDetailAction === 'close') {
     event.preventDefault();
-    window.closeModal?.();
+    closeRecommendationsModal();
   }
 }
 
@@ -49,7 +54,7 @@ export function createRecommendationActions({
       <h3>${escapeHTML(label || 'Recommendation')}</h3>
       <div class="dashboard-widget-empty">Loading options...</div>`;
     openModalOverlay(overlay);
-    Promise.resolve(window.renderRecommendationSection?.(slotKey, { label: 'Options', maxProducts: 4, markerStatus }))
+    Promise.resolve(renderRecommendationsDetailSection(slotKey, { label: 'Options', maxProducts: 4, markerStatus }))
       .then(html => {
         modal.innerHTML = `<button type="button" class="modal-close" aria-label="Close" ${recommendationDetailActionAttrs('close')}>&times;</button>
           <h3>${escapeHTML(label || 'Recommendation')}</h3>
@@ -69,7 +74,7 @@ export function createRecommendationActions({
     const prompt = candidate
       ? `Help me evaluate this recommendation from getbased.\nSource: ${candidate.source}\nRecommendation: ${candidate.label}\nReason: ${candidate.reason}\nSuggested first action: ${candidate.primaryAction || 'none listed'}\nWhat are the pros, cons, and safer non-product alternatives?`
       : 'Help me evaluate my current getbased recommendations. Which should I prioritize and why?';
-    window.openChatPanel?.(prompt);
+    openRecommendationsChatPanel(prompt);
   }
 
   function saveRecommendation(id, on = true) {

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -35,10 +35,23 @@ export async function loadRecommendationsCatalogRuntime() {
   return await loadCatalog();
 }
 
+export async function renderRecommendationsDetailSection(slotKey, options) {
+  const renderRecommendationSection = getRuntimeFunction('renderRecommendationSection');
+  if (!renderRecommendationSection) return '';
+  return await renderRecommendationSection(slotKey, options);
+}
+
 export function closeRecommendationsModal() {
   const closeModal = getRuntimeFunction('closeModal');
   if (!closeModal) return false;
   closeModal();
+  return true;
+}
+
+export function openRecommendationsChatPanel(prompt) {
+  const openChatPanel = getRuntimeFunction('openChatPanel');
+  if (!openChatPanel) return false;
+  openChatPanel(prompt);
   return true;
 }
 

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -7,10 +7,12 @@ import {
   getRecommendationsSnpTable,
   isRecommendationsProductRecsEnabled,
   loadRecommendationsCatalogRuntime,
+  openRecommendationsChatPanel,
   openRecommendationsEmfAssessment,
   openRecommendationsLocationEditor,
   openRecommendationsPrivacySettings,
   registerRecommendationsRuntimeExports,
+  renderRecommendationsDetailSection,
   scheduleRecommendationsTask,
 } from '../js/recommendations-runtime.js';
 
@@ -54,8 +56,13 @@ try {
     openEMFAssessmentEditor() { calls.push(['emf', this === runtime]); },
     openProfileLocationEditor() { calls.push(['location', this === runtime]); },
     openSettingsTab(tab) { calls.push(['settings', tab, this === runtime]); },
+    openChatPanel(prompt) { calls.push(['chat', prompt, this === runtime]); },
     isProductRecsEnabled() { calls.push(['enabled', this === runtime]); return true; },
     async loadCatalog() { calls.push(['catalog', this === runtime]); return { slots: { magnesium: { label: 'Magnesium' } } }; },
+    async renderRecommendationSection(slotKey, options) {
+      calls.push(['render', slotKey, options, this === runtime]);
+      return `<section>${slotKey}</section>`;
+    },
     setTimeout(callback, delay) {
       calls.push(['timeout', delay, this === runtime]);
       callback();
@@ -75,6 +82,15 @@ try {
       catalog?.slots?.magnesium?.label === 'Magnesium' &&
       calls.some(call => call[0] === 'enabled' && call[1] === true) &&
       calls.some(call => call[0] === 'catalog' && call[1] === true));
+  const detailHtml = await renderRecommendationsDetailSection('minerals.magnesium', { label: 'Options' });
+  assert('recommendations runtime delegates detail rendering and chat panel hooks',
+    detailHtml === '<section>minerals.magnesium</section>' &&
+      openRecommendationsChatPanel('Discuss this') &&
+      calls.some(call => call[0] === 'render'
+        && call[1] === 'minerals.magnesium'
+        && call[2]?.label === 'Options'
+        && call[3] === true) &&
+      calls.some(call => call[0] === 'chat' && call[1] === 'Discuss this' && call[2] === true));
   assert('recommendations runtime delegates host modal and editor hooks',
     closeRecommendationsModal() &&
       openRecommendationsEmfAssessment() &&
@@ -95,14 +111,18 @@ try {
   delete runtime.openEMFAssessmentEditor;
   delete runtime.openProfileLocationEditor;
   delete runtime.openSettingsTab;
+  delete runtime.openChatPanel;
   delete runtime.isProductRecsEnabled;
   delete runtime.loadCatalog;
+  delete runtime.renderRecommendationSection;
   delete runtime._snpTableCache;
   assert('recommendations runtime handles missing optional browser hooks',
     getRecommendationsSnpTable() === null &&
       isRecommendationsProductRecsEnabled() === false &&
       await loadRecommendationsCatalogRuntime() === null &&
+      await renderRecommendationsDetailSection('missing.slot', {}) === '' &&
       closeRecommendationsModal() === false &&
+      openRecommendationsChatPanel('No-op') === false &&
       openRecommendationsEmfAssessment() === false &&
       openRecommendationsLocationEditor() === false &&
       openRecommendationsPrivacySettings() === false);
@@ -112,6 +132,8 @@ try {
     getRecommendationsSnpTable() === null &&
       isRecommendationsProductRecsEnabled() === false &&
       await loadRecommendationsCatalogRuntime() === null &&
+      await renderRecommendationsDetailSection('missing.slot', {}) === '' &&
+      openRecommendationsChatPanel('No-op') === false &&
       registerRecommendationsRuntimeExports({ missingWindowProbe: true }) === false);
 } finally {
   restoreWindow();

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -272,6 +272,12 @@ const _realFetch = globalThis.fetch;
   assert('views.js delegates recommendation actions to recommendation-actions.js',
     viewsSrc.includes("from './recommendation-actions.js'") &&
     recommendationActionsSrc.includes('export function createRecommendationActions'));
+  assert('recommendation-actions.js delegates browser globals through recommendations runtime',
+    recommendationActionsSrc.includes("from './recommendations-runtime.js'")
+      && recommendationActionsSrc.includes('closeRecommendationsModal')
+      && recommendationActionsSrc.includes('openRecommendationsChatPanel')
+      && recommendationActionsSrc.includes('renderRecommendationsDetailSection')
+      && !/\bwindow(\.|\s*\[)/.test(recommendationActionsSrc));
   assert('dashboard has Recommendations widget surface', dashboardWidgetsSrc.includes("id: 'recommendations'") && dashboardWidgetsSrc.includes('renderDashboardRecommendationsWidget'));
   assert('dismissed recommendations render a Restore action',
     dashboardRecommendationWidgetSrc.includes("candidate.dismissed ? 'Restore' : 'Dismiss'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.116';
+self.APP_VERSION = '1.10.117';


### PR DESCRIPTION
## Summary
- Move recommendation detail modal close, section rendering, and chat handoff through `js/recommendations-runtime.js`.
- Add runtime adapter coverage and a source guard so `recommendation-actions.js` stays free of direct browser-global calls.
- Bump `version.js` for app cache invalidation.

## Window burden
- Reduced counted direct `window.` global references in `js/` from 83 to 80 (-3).
- Removed all counted direct `window.` references from `js/recommendation-actions.js`; recommendation detail close, detail rendering, and chat handoff now go through `js/recommendations-runtime.js`.

## Tests
- `node tests/test-recommendations-runtime.js`
- `node tests/test-recommendations.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npx playwright test tests/playwright/recommendation-actions-browser-coverage.spec.js tests/playwright/dashboard-widget-delegated-actions-dom.spec.js`
- `./run-tests.sh`