### PR TITLE
Delegate marker detail editing runtime hooks

### DIFF
--- a/js/marker-detail-editing.js
+++ b/js/marker-detail-editing.js
@@ -7,6 +7,10 @@ import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, showPrompt
 import { getActiveData, updateHeaderDates, convertDisplayToSI } from './data.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
 import {
+  buildMarkerDetailSidebarRuntime,
+  navigateMarkerDetailRuntime,
+} from './marker-detail-runtime.js';
+import {
   deleteManualMarkerValue,
   editManualMarkerValue,
   getMarkerValueNote,
@@ -23,11 +27,13 @@ import {
 
 const markerDetailDeps = /** @type {{
   navigate: (category?: string, data?: any) => any,
+  buildSidebar: () => any,
   showDetailModal: (id?: string, opts?: any) => any,
   openManualEntryForm: (id?: string, prefillDate?: string) => any,
   closeModal: () => any,
 }} */ ({
-  navigate: (category, data) => window.navigate?.(category, data),
+  navigate: navigateMarkerDetailRuntime,
+  buildSidebar: buildMarkerDetailSidebarRuntime,
   showDetailModal: () => {},
   openManualEntryForm: () => {},
   closeModal: () => {},
@@ -46,6 +52,10 @@ function showDetailModal(id, opts) {
 
 function openManualEntryForm(id, prefillDate) {
   return markerDetailDeps.openManualEntryForm(id, prefillDate);
+}
+
+function buildSidebar() {
+  return markerDetailDeps.buildSidebar();
 }
 
 function closeModal() {
@@ -123,7 +133,7 @@ export async function saveManualEntry(id, opts = {}) {
   await saveManualMarkerValue({ dotKey, date, storedValue, noteText });
   // Remember the date session-wide so the next manual entry defaults to it.
   try { sessionStorage.setItem('labcharts-last-manual-date', date); } catch (_) {}
-  window.buildSidebar();
+  buildSidebar();
   updateHeaderDates();
   const targetCat = id.indexOf('_') !== -1 ? id.slice(0, id.indexOf('_')) : null;
   const data = getActiveData();
@@ -155,7 +165,7 @@ export async function deleteMarkerValue(id, date) {
   if (await showConfirmDialog(`Delete this value (${date})? This can't be undone.`)) {
     const deleted = await deleteManualMarkerValue(dotKey, date);
     if (!deleted) return;
-    window.buildSidebar();
+    buildSidebar();
     updateHeaderDates();
     // Re-open the detail modal to show updated values. buildSidebar
     // resets .active to Dashboard, so use state.currentView (kept in

--- a/js/marker-detail-modal.js
+++ b/js/marker-detail-modal.js
@@ -89,6 +89,7 @@ export function configureMarkerDetailModal(deps = {}) {
 
 configureMarkerDetailEditing({
   navigate: (...args) => markerDetailDeps.navigate(...args),
+  buildSidebar: () => buildMarkerDetailSidebarRuntime(),
   showDetailModal: (...args) => showDetailModal(...args),
   openManualEntryForm: (...args) => openManualEntryForm(...args),
   closeModal: () => closeModal(),

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -77,6 +77,12 @@ assert('marker-detail-modal delegates browser globals through runtime adapter',
     runtimeSrc.includes('export function navigateMarkerDetailRuntime') &&
     runtimeSrc.includes('export function hasRecommendationSectionRendererRuntime') &&
     runtimeSrc.includes('export async function renderRecommendationSectionRuntime'));
+assert('marker-detail-editing delegates browser shell hooks through runtime adapter',
+  editingSrc.includes("from './marker-detail-runtime.js'") &&
+    editingSrc.includes('buildMarkerDetailSidebarRuntime') &&
+    editingSrc.includes('navigateMarkerDetailRuntime') &&
+    editingSrc.includes('buildSidebar: buildMarkerDetailSidebarRuntime') &&
+    !/\bwindow(?:\.|\s*\[)/.test(editingSrc));
 assert('marker-detail-modal only creates recommendation placeholders when renderer can fill them',
   modalSrc.includes('const shouldRenderRecommendations = isProductRecsEnabledRuntime() && hasRecommendationSectionRendererRuntime();') &&
     modalSrc.includes('if (shouldRenderRecommendations)'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.117';
+self.APP_VERSION = '1.10.118';


### PR DESCRIPTION
## Summary
- Move marker-detail editing shell refresh defaults through `js/marker-detail-runtime.js` instead of direct browser globals.
- Add `buildSidebar` to the existing marker detail editing dependency boundary and wire it from the modal setup.
- Add a source guard so `js/marker-detail-editing.js` stays free of direct `window.` references, and bump `version.js`.

## Window burden
- Reduced counted direct `window.` global references in `js/` from 80 to 77 (-3).
- Removed all counted direct `window.` references from `js/marker-detail-editing.js`; navigation and sidebar refresh defaults now go through `js/marker-detail-runtime.js` and the existing editing dependency boundary.

## Tests
- `node tests/test-marker-detail-delegated-actions.js`
- `node tests/test-manual-entry-flow.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npx playwright test tests/playwright/marker-detail-browser-coverage.spec.js tests/playwright/modal-session-coverage-batch.spec.js`
- `./run-tests.sh`