### PR TITLE
Delegate PDF import persistence runtime hooks

### DIFF
--- a/js/pdf-import-persistence.js
+++ b/js/pdf-import-persistence.js
@@ -6,6 +6,7 @@ import { showNotification, showPromptDialog } from './utils.js';
 import { saveImportedData } from './data.js';
 import { clearTombstone, deleteImportedArrayItems, recordTombstone } from './data-merge.js';
 import { deleteLabEntryMarker, isSnapshotDerivedHOMAIR } from './lab-entry.js';
+import { refreshImportedDataViewsRuntime } from './pdf-import-review-runtime.js';
 
 export function snapshotImportedData() {
   try { return JSON.stringify(state.importedData || {}); } catch { return null; }
@@ -17,10 +18,8 @@ export function restoreImportedDataSnapshot(snapshot) {
 }
 
 export function refreshImportedDataViews() {
-  window.buildSidebar();
-  window.updateHeaderDates();
   // buildSidebar resets .active to Dashboard; use state.currentView.
-  window.navigate(state.currentView || 'dashboard');
+  refreshImportedDataViewsRuntime(state.currentView || 'dashboard');
 }
 
 function isValidISOCalendarDate(date) {

--- a/js/pdf-import-review-runtime.js
+++ b/js/pdf-import-review-runtime.js
@@ -7,6 +7,16 @@ function getRuntimeWindow() {
     : null;
 }
 
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getRuntimeWindow();
+  const fn = runtime?.[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
+}
+
 export function clearPendingImportRuntime() {
   const runtime = getRuntimeWindow();
   if (!runtime) return;
@@ -28,6 +38,27 @@ export function getPendingImportFromRuntime() {
 export function getPendingImportRefLookup() {
   const runtime = getRuntimeWindow();
   return runtime?._pendingImportRefLookup || null;
+}
+
+/** @param {string} route */
+export function refreshImportedDataViewsRuntime(route = 'dashboard') {
+  let refreshed = false;
+  const buildSidebar = getRuntimeFunction('buildSidebar');
+  if (buildSidebar) {
+    buildSidebar();
+    refreshed = true;
+  }
+  const updateHeaderDates = getRuntimeFunction('updateHeaderDates');
+  if (updateHeaderDates) {
+    updateHeaderDates();
+    refreshed = true;
+  }
+  const navigate = getRuntimeFunction('navigate');
+  if (navigate) {
+    navigate(route);
+    refreshed = true;
+  }
+  return refreshed;
 }
 
 /**

--- a/tests/test-pdf-import-review-runtime.js
+++ b/tests/test-pdf-import-review-runtime.js
@@ -11,6 +11,7 @@ import {
   getPendingImportRefLookup,
   hasBatchImportContext,
   markImportReviewDelegatesBound,
+  refreshImportedDataViewsRuntime,
   setPendingImportRuntime,
   showPIIDiffViewerFromRuntime,
   startBatchImport,
@@ -29,8 +30,11 @@ const RUNTIME_FIELDS = [
   '_batchImportResolve',
   '_batchImportContext',
   '__importReviewDelegatesBound',
+  'buildSidebar',
   'confirmImport',
+  'navigate',
   'showPIIDiffViewer',
+  'updateHeaderDates',
 ];
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
@@ -66,6 +70,18 @@ try {
   setPendingImportRuntime(parseResult, refLookup);
   assert('pending import stored in runtime', getPendingImportFromRuntime() === parseResult);
   assert('pending import ref lookup stored in runtime', getPendingImportRefLookup() === refLookup);
+
+  const viewCalls = [];
+  globalThis.buildSidebar = function() { viewCalls.push(['sidebar', this === globalThis]); };
+  globalThis.updateHeaderDates = function() { viewCalls.push(['dates', this === globalThis]); };
+  globalThis.navigate = function(route) { viewCalls.push(['navigate', route, this === globalThis]); };
+  assert('import persistence view refresh delegates through runtime hooks',
+    refreshImportedDataViewsRuntime('labs') === true &&
+      JSON.stringify(viewCalls) === JSON.stringify([
+        ['sidebar', true],
+        ['dates', true],
+        ['navigate', 'labs', true],
+      ]));
 
   clearPendingImportRuntime();
   assert('pending import clears to null', globalThis._pendingImport === null);
@@ -111,6 +127,7 @@ try {
   assert('PII diff callback preserves window receiver', diffThis === globalThis);
 
   delete globalThis.window;
+  assert('no-window view refresh returns false', refreshImportedDataViewsRuntime('labs') === false);
   assert('no-window pending import reads as null', getPendingImportFromRuntime() === null);
   assert('no-window ref lookup reads as null', getPendingImportRefLookup() === null);
   assert('no-window batch context reads as null', getBatchImportContext() === null);

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -169,6 +169,11 @@ const importCssSrc = read('css/import.css');
       && !/\bwindow(?:\.|\s*\[)/.test(reviewSrc)
       && reviewRuntimeSrc.includes('runtime._pendingImport')
       && reviewRuntimeSrc.includes('runtime._batchImportContext'));
+  assert('PDF import persistence delegates view refresh through runtime adapter',
+    persistenceSrc.includes("from './pdf-import-review-runtime.js'")
+      && persistenceSrc.includes('refreshImportedDataViewsRuntime(state.currentView')
+      && reviewRuntimeSrc.includes('export function refreshImportedDataViewsRuntime')
+      && !/\bwindow(?:\.|\s*\[)/.test(persistenceSrc));
   assert('Re-review modal uses update wording instead of import wording',
     /parseResult\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc)
       && /result\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.118';
+self.APP_VERSION = '1.10.119';


### PR DESCRIPTION
## Summary
- Move imported-data view refresh hooks through `js/pdf-import-review-runtime.js`.
- Keep `refreshImportedDataViews()` using `state.currentView` while removing direct browser globals from `js/pdf-import-persistence.js`.
- Add runtime/source guard coverage and bump `version.js`.

## Window burden
- Reduced counted direct `window.` global references in `js/` from 77 to 74 (-3).
- Removed all counted direct `window.` references from `js/pdf-import-persistence.js`; sidebar refresh, header-date refresh, and navigation now go through `js/pdf-import-review-runtime.js`.

## Tests
- `node tests/test-pdf-import-review-runtime.js`
- `node tests/test-unit-import.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npx playwright test tests/playwright/import-review-browser-coverage.spec.js tests/playwright/settings-browser-coverage.spec.js`
- `npx playwright test tests/playwright/core-browser-flows.spec.js -g "export/import browser fixture"`
- `./run-tests.sh` (first run hit a transient page-error stack overflow after the export/import fixture reported 260 passed/0 failed; isolated fixture rerun passed; second full run passed)
