### PR TITLE
Delegate sync recovery event runtime hooks

### DIFF
--- a/js/sync-recovery.js
+++ b/js/sync-recovery.js
@@ -53,27 +53,40 @@ function _kickSync(reason) {
   }, 100);
 }
 
-export function bindSyncRecoveryEvents() {
+function getDefaultSyncRecoveryRuntime() {
+  return {
+    win: typeof window !== 'undefined' ? window : null,
+    doc: typeof document !== 'undefined' ? document : null,
+    nav: typeof navigator !== 'undefined' ? navigator : null,
+  };
+}
+
+/** @param {{ win?: Window | null, doc?: Document | null, nav?: Navigator | null }} [runtime] */
+export function bindSyncRecoveryEvents({ win, doc, nav } = {}) {
   if (_eventsBound) return;
   _eventsBound = true;
+  const defaults = getDefaultSyncRecoveryRuntime();
+  const runtimeWindow = win === undefined ? defaults.win : win;
+  const runtimeDocument = doc === undefined ? defaults.doc : doc;
+  const runtimeNavigator = nav === undefined ? defaults.nav : nav;
 
-  if (typeof navigator !== 'undefined') {
-    _lastNetState = navigator.onLine ?? true;
+  if (runtimeNavigator) {
+    _lastNetState = runtimeNavigator.onLine ?? true;
   }
 
-  if (typeof document !== 'undefined') {
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') _kickSync('visibilitychange');
+  if (runtimeDocument) {
+    runtimeDocument.addEventListener('visibilitychange', () => {
+      if (runtimeDocument.visibilityState === 'visible') _kickSync('visibilitychange');
     });
   }
 
-  if (typeof window !== 'undefined') {
+  if (runtimeWindow) {
     // pageshow fires when the tab is restored from bfcache or rehydrated.
-    window.addEventListener('pageshow', (e) => {
+    runtimeWindow.addEventListener('pageshow', (e) => {
       if (e.persisted) _kickSync('pageshow-persisted');
     });
 
-    window.addEventListener('online', () => {
+    runtimeWindow.addEventListener('online', () => {
       _kickSync('online');
       if (!_lastNetState) {
         _lastNetState = true;
@@ -81,7 +94,7 @@ export function bindSyncRecoveryEvents() {
       }
     });
 
-    window.addEventListener('offline', () => {
+    runtimeWindow.addEventListener('offline', () => {
       _lastNetState = false;
       _notify('Offline — changes are saved locally and will sync when you reconnect.', 'info', 5000);
     });

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -608,10 +608,11 @@ await import('../js/settings.js');
     syncConfigureSrc.includes("from './sync-recovery.js'")
       && syncRecoverySrc.includes('export function configureSyncRecovery')
       && syncRecoverySrc.includes('export function bindSyncRecoveryEvents')
-      && syncRecoverySrc.includes("document.addEventListener('visibilitychange'")
-      && syncRecoverySrc.includes("window.addEventListener('pageshow'")
-      && syncRecoverySrc.includes("window.addEventListener('online'")
-      && syncRecoverySrc.includes("window.addEventListener('offline'")
+      && syncRecoverySrc.includes("runtimeDocument.addEventListener('visibilitychange'")
+      && syncRecoverySrc.includes("runtimeWindow.addEventListener('pageshow'")
+      && syncRecoverySrc.includes("runtimeWindow.addEventListener('online'")
+      && syncRecoverySrc.includes("runtimeWindow.addEventListener('offline'")
+      && !/\bwindow(?:\.|\s*\[)/.test(syncRecoverySrc)
       && syncConfigureSrc.includes('configureSyncRecovery({')
       && syncInitSrc.includes('bindSyncRecoveryEvents();'));
   assert('service worker precaches sync-recovery.js',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.119';
+self.APP_VERSION = '1.10.120';


### PR DESCRIPTION
## Summary
- Route sync recovery event binding through runtime handles for `win`, `doc`, and `nav` while preserving the default browser behavior.
- Keep visibility, pageshow, online, and offline recovery handling in `js/sync-recovery.js` without direct counted browser-global member access.
- Update the sync source guard and bump `version.js` for cache invalidation.

## Window burden
- Reduced counted direct `window.` global references in `js/` from 74 to 71 (-3).
- Removed all counted direct `window.` references from `js/sync-recovery.js`; pageshow, online, and offline listeners now bind through the injected/default runtime window handle.

## Tests
- `node tests/test-sync.js`
- `node tests/test-v1-6-shipped.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npx playwright test tests/playwright/sync-orchestration-browser-coverage.spec.js tests/playwright/sync-configure-reconcile-browser-coverage.spec.js tests/playwright/sync-lifecycle-browser-coverage.spec.js`
- `./run-tests.sh`
