### PR TITLE
Delegate EMF editor runtime hooks

### DIFF
--- a/js/emf.js
+++ b/js/emf.js
@@ -123,6 +123,38 @@ let _editingAssessmentId = null;
 let _activeRoomIdx = 0;
 let emfEditorDelegatesInstalled = false;
 
+/**
+ * @returns {Record<string, any>}
+ */
+function getEMFRuntimeScope() {
+  return typeof window !== 'undefined'
+    ? /** @type {Record<string, any>} */ (window)
+    : /** @type {Record<string, any>} */ (globalThis);
+}
+
+/**
+ * @param {string} name
+ * @returns {((...args: any[]) => any) | null}
+ */
+function getEMFRuntimeFunction(name) {
+  const runtime = getEMFRuntimeScope();
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
+}
+
+function closeEMFModalRuntime() {
+  getEMFRuntimeFunction('closeModal')?.();
+}
+
+/**
+ * @param {string} message
+ * @param {{ placeholder?: string, okLabel?: string }} [options]
+ * @returns {Promise<string | null | undefined> | string | null | undefined}
+ */
+function showEMFPromptRuntime(message, options) {
+  return getEMFRuntimeFunction('showPromptDialog')?.(message, options);
+}
+
 function emfAttrString(attrs) {
   return Object.entries(attrs)
     .filter(([, value]) => value !== undefined && value !== null)
@@ -152,7 +184,7 @@ function removeEMFEditorDelegates() {
 
 function closeEMFPreviewModal() {
   removeEMFEditorDelegates();
-  window.closeModal?.();
+  closeEMFModalRuntime();
 }
 
 function closeEMFEditorModal() {
@@ -160,7 +192,7 @@ function closeEMFEditorModal() {
   saveImportedData();
   document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el));
   removeEMFEditorDelegates();
-  window.closeModal?.();
+  closeEMFModalRuntime();
 }
 
 function _emfNumberAttr(el, name, fallback = 0) {
@@ -538,7 +570,7 @@ export async function handleEMFRoomDropdown(assessmentId, currentRoomIdx, value,
   }
   // Custom room
   if (value === '_custom') {
-    const name = await window.showPromptDialog('Room name:', {
+    const name = await showEMFPromptRuntime('Room name:', {
       placeholder: 'e.g. Master Bedroom',
       okLabel: 'Create',
     });

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -70,7 +70,11 @@ assert('EMF editor close path preserves save and lightbox cleanup',
     emfSrc.includes('collectActiveAssessmentState();') &&
     emfSrc.includes("document.querySelectorAll('.emf-lightbox').forEach(el => removeModalOverlay(el));") &&
     emfSrc.includes('removeEMFEditorDelegates();') &&
-    emfSrc.includes('window.closeModal?.();'));
+    emfSrc.includes('closeEMFModalRuntime();'));
+assert('EMF editor runtime hooks avoid counted direct window globals',
+  emfSrc.includes("getEMFRuntimeFunction('closeModal')") &&
+    emfSrc.includes("getEMFRuntimeFunction('showPromptDialog')") &&
+    !/\bwindow(?:\.|\s*\[)/.test(emfSrc));
 assert('EMF editor X button uses saving close action',
   editorSrc.includes('class="modal-close" aria-label="Close" ${emfActionAttrs(\'close-editor\')}'));
 assert('EMF import preview close path does not persist editor state',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.120';
+self.APP_VERSION = '1.10.121';


### PR DESCRIPTION
## Summary
- Route EMF editor close and preview close actions through local runtime hook lookup instead of direct `window.closeModal` calls.
- Route the custom-room prompt through the same EMF runtime lookup for `showPromptDialog`.
- Tighten the EMF delegated-action guard so counted direct `window.` refs cannot return to `js/emf.js`.

## Window burden
- Reduced counted direct `window.` global references in `js/` from 71 to 68 (-3).
- Removed all counted direct `window.` refs from `js/emf.js`; EMF editor close and custom-room prompt hooks now bind through runtime helpers.

## Validation
- `node tests/test-emf-delegated-actions.js`
- `node tests/test-emf.js`
- `node tests/test-emf-flow.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `node tests/test-v1-6-shipped.js`
- `git diff --check`
- `./run-tests.sh`
