### PR TITLE
Delegate EMF, sync, and import runtime hooks

### DIFF
--- a/js/emf-interpretation.js
+++ b/js/emf-interpretation.js
@@ -18,6 +18,33 @@ import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-li
 
 let _aiAbortController = null;
 
+/**
+ * @returns {Record<string, any>}
+ */
+function getEMFInterpretationRuntimeScope() {
+  return typeof window !== 'undefined'
+    ? /** @type {Record<string, any>} */ (window)
+    : /** @type {Record<string, any>} */ (globalThis);
+}
+
+/**
+ * @param {string} name
+ * @returns {((...args: any[]) => any) | null}
+ */
+function getEMFInterpretationRuntimeFunction(name) {
+  const runtime = getEMFInterpretationRuntimeScope();
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
+}
+
+function closeParentEMFModalRuntime() {
+  getEMFInterpretationRuntimeFunction('closeModal')?.();
+}
+
+function openEMFInterpretationChatRuntime(message) {
+  getEMFInterpretationRuntimeFunction('openChatPanel')?.(message);
+}
+
 function getAssessments(deps) {
   return deps?.getAssessments?.() || state.importedData.emfAssessment?.assessments || [];
 }
@@ -278,8 +305,8 @@ export function discussEMFInterpretation() {
   const text = overlay?._interpretText;
   if (!text) return;
   closeEMFInterpretation();
-  window.closeModal();
-  window.openChatPanel(`I'd like to discuss this EMF assessment interpretation further. Here's the interpretation:\n\n${text}\n\nWhat questions should I prioritize, and what are the most important next steps?`);
+  closeParentEMFModalRuntime();
+  openEMFInterpretationChatRuntime(`I'd like to discuss this EMF assessment interpretation further. Here's the interpretation:\n\n${text}\n\nWhat questions should I prioritize, and what are the most important next steps?`);
 }
 
 function _collectMitigationTags(assessment) {

--- a/js/pdf-import-progress.js
+++ b/js/pdf-import-progress.js
@@ -2,6 +2,7 @@
 // pdf-import-progress.js — PDF import progress UI and header status state
 
 import { IMPORT_STEPS } from './constants.js';
+import { navigateImportReviewRuntime } from './pdf-import-review-runtime.js';
 import { escapeHTML } from './utils.js';
 
 const STEP_START_PCT = [5, 8, 12, 15, 95];
@@ -118,7 +119,7 @@ export function handleImportStatusClick() {
     if (progressBar) {
       progressBar.scrollIntoView({ behavior: 'smooth', block: 'center' });
     } else {
-      window.navigate('dashboard');
+      navigateImportReviewRuntime('dashboard');
     }
     return;
   }

--- a/js/pdf-import-review-runtime.js
+++ b/js/pdf-import-review-runtime.js
@@ -41,6 +41,14 @@ export function getPendingImportRefLookup() {
 }
 
 /** @param {string} route */
+export function navigateImportReviewRuntime(route = 'dashboard') {
+  const navigate = getRuntimeFunction('navigate');
+  if (!navigate) return false;
+  navigate(route);
+  return true;
+}
+
+/** @param {string} route */
 export function refreshImportedDataViewsRuntime(route = 'dashboard') {
   let refreshed = false;
   const buildSidebar = getRuntimeFunction('buildSidebar');
@@ -53,11 +61,7 @@ export function refreshImportedDataViewsRuntime(route = 'dashboard') {
     updateHeaderDates();
     refreshed = true;
   }
-  const navigate = getRuntimeFunction('navigate');
-  if (navigate) {
-    navigate(route);
-    refreshed = true;
-  }
+  if (navigateImportReviewRuntime(route)) refreshed = true;
   return refreshed;
 }
 

--- a/js/sync-apply.js
+++ b/js/sync-apply.js
@@ -3,6 +3,7 @@
 
 import { encryptedSetItem, encryptedGetItem } from './crypto.js';
 import { AI_SETTINGS_KEYS, DISPLAY_PREF_SUFFIXES } from './sync-payload-collectors.js';
+import { refreshSyncedAIProviderUiRuntime } from './sync-runtime.js';
 
 export {
   applyChatData, getChatDataLocalLockRemainingMs, markChatDataLocal,
@@ -58,8 +59,7 @@ export async function applyAISettings(settings) {
     changed = true;
   }
   if (changed) {
-    window.updateChatHeaderModel?.();
-    window.refreshWebSearchToggle?.();
+    refreshSyncedAIProviderUiRuntime();
   }
 }
 

--- a/js/sync-runtime.js
+++ b/js/sync-runtime.js
@@ -10,6 +10,21 @@ let _appOwnerError = null;
 let _readyPromise = null;
 let _queryLoadedPromise = null;
 
+function getSyncRuntimeWindow() {
+  return typeof window !== 'undefined'
+    ? /** @type {any} */ (window)
+    : null;
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+function getRuntimeFunction(name) {
+  const runtime = getSyncRuntimeWindow();
+  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+}
+
 export function getSyncEvolu() { return _evolu; }
 export function getSyncProfileQuery() { return _profileQuery; }
 export function getSyncTombstoneQuery() { return _tombstoneQuery; }
@@ -36,13 +51,38 @@ export function setSyncAppOwner(owner) {
   const next = owner ?? null;
   _appOwner = next;
   const nextId = next?.id || null;
-  if (prevId !== nextId && typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
-    try { window.dispatchEvent(new CustomEvent('labcharts-sync-owner-changed', { detail: { ownerId: nextId, ready: !!nextId } })); } catch (_) {}
-  }
+  if (prevId !== nextId) dispatchSyncOwnerChangedRuntime(nextId);
 }
 
 export function setSyncAppOwnerError(error) {
   _appOwnerError = error ?? null;
+}
+
+export function refreshSyncedAIProviderUiRuntime() {
+  let refreshed = false;
+  const updateHeader = getRuntimeFunction('updateChatHeaderModel');
+  if (updateHeader) {
+    updateHeader();
+    refreshed = true;
+  }
+  const refreshWebSearch = getRuntimeFunction('refreshWebSearchToggle');
+  if (refreshWebSearch) {
+    refreshWebSearch();
+    refreshed = true;
+  }
+  return refreshed;
+}
+
+/** @param {string | null} ownerId */
+export function dispatchSyncOwnerChangedRuntime(ownerId) {
+  const runtime = getSyncRuntimeWindow();
+  if (!runtime || typeof runtime.dispatchEvent !== 'function' || typeof runtime.CustomEvent !== 'function') return false;
+  try {
+    runtime.dispatchEvent(new runtime.CustomEvent('labcharts-sync-owner-changed', { detail: { ownerId, ready: !!ownerId } }));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function setSyncReadyPromise(promise) {

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -32,6 +32,11 @@ import { parseSyncPayload } from '../js/sync-payload.js';
 import { maybeScheduleRebroadcast } from '../js/sync-pull-rebroadcast.js';
 import { applyCommittedDeltas, planProfileDeltas } from '../js/sync-push-deltas.js';
 import { configureSyncPush, isSyncPushInFlight, pushProfile } from '../js/sync-push.js';
+import {
+  dispatchSyncOwnerChangedRuntime,
+  refreshSyncedAIProviderUiRuntime,
+  setSyncAppOwner,
+} from '../js/sync-runtime.js';
 import { getRecentSyncEvents, resetSyncStatus, updateSyncStatus } from '../js/sync-state.js';
 import { state } from '../js/state.js';
 import {
@@ -192,6 +197,31 @@ describe('sync apply runtime behavior', () => {
     expect(localStorage.getItem(`labcharts-${PROFILE_ID}-rangeMode`)).toBe('functional');
     expect(localStorage.getItem(`labcharts-${PROFILE_ID}-phaseOverlay`)).toBe('1');
     expect(localStorage.getItem(`labcharts-${PROFILE_ID}-unknown`)).toBeNull();
+  });
+
+  it('routes synced AI and owner UI hooks through sync runtime helpers', () => {
+    const events = [];
+    const recordOwnerEvent = event => {
+      events.push(event.detail);
+    };
+    window.updateChatHeaderModel = vi.fn();
+    window.refreshWebSearchToggle = vi.fn();
+    window.addEventListener('labcharts-sync-owner-changed', recordOwnerEvent);
+
+    try {
+      expect(refreshSyncedAIProviderUiRuntime()).toBe(true);
+      expect(window.updateChatHeaderModel).toHaveBeenCalledTimes(1);
+      expect(window.refreshWebSearchToggle).toHaveBeenCalledTimes(1);
+
+      expect(dispatchSyncOwnerChangedRuntime('owner-runtime')).toBe(true);
+      expect(events.at(-1)).toEqual({ ownerId: 'owner-runtime', ready: true });
+
+      setSyncAppOwner({ id: 'owner-state' });
+      expect(events.at(-1)).toEqual({ ownerId: 'owner-state', ready: true });
+    } finally {
+      setSyncAppOwner(null);
+      window.removeEventListener('labcharts-sync-owner-changed', recordOwnerEvent);
+    }
   });
 });
 

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -75,6 +75,11 @@ assert('EMF editor runtime hooks avoid counted direct window globals',
   emfSrc.includes("getEMFRuntimeFunction('closeModal')") &&
     emfSrc.includes("getEMFRuntimeFunction('showPromptDialog')") &&
     !/\bwindow(?:\.|\s*\[)/.test(emfSrc));
+assert('EMF interpretation runtime hooks avoid counted direct window globals',
+  emfInterpretationSrc.includes('function getEMFInterpretationRuntimeFunction') &&
+    emfInterpretationSrc.includes("getEMFInterpretationRuntimeFunction('closeModal')") &&
+    emfInterpretationSrc.includes("getEMFInterpretationRuntimeFunction('openChatPanel')") &&
+    !/\bwindow(?:\.|\s*\[)/.test(emfInterpretationSrc));
 assert('EMF editor X button uses saving close action',
   editorSrc.includes('class="modal-close" aria-label="Close" ${emfActionAttrs(\'close-editor\')}'));
 assert('EMF import preview close path does not persist editor state',

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -320,7 +320,9 @@ assert('sync preserves fresh OpenRouter OAuth provider/key against stale pull',
 assert('sync preserves fresh local AI settings against stale pull',
   syncApplySrc.includes('AI_SETTINGS_LOCAL_LOCK_UNTIL_KEY') && syncApplySrc.includes('shouldKeepLocalAISetting(key)'));
 assert('sync refreshes AI header after remote AI settings apply',
-  syncApplySrc.includes('window.updateChatHeaderModel?.()') && syncApplySrc.includes('window.refreshWebSearchToggle?.()'));
+  syncApplySrc.includes('refreshSyncedAIProviderUiRuntime()')
+    && !syncApplySrc.includes('window.updateChatHeaderModel')
+    && !syncApplySrc.includes('window.refreshWebSearchToggle'));
 assert('startup sync reconciliation pushes local AI setting drift',
   syncConfigureSrc.includes("from './sync-reconcile.js'")
     && syncSrc.includes("from './sync-configure.js'")

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1235,7 +1235,17 @@ await import('../js/settings.js');
   assert('applyAISettings has allowlist check', syncApplySrc.includes('AI_SETTINGS_KEYS.includes(key)'));
   assert('applyAISettings has size guard', syncApplySrc.includes('val.length > 10000'));
   assert('applyAISettings honors fresh local AI setting lock', syncApplySrc.includes('AI_SETTINGS_LOCAL_LOCK_UNTIL_KEY') && syncApplySrc.includes('shouldKeepLocalAISetting(key)'));
-  assert('applyAISettings refreshes chat provider UI on remote changes', syncApplySrc.includes('window.updateChatHeaderModel?.()') && syncApplySrc.includes('window.refreshWebSearchToggle?.()'));
+  assert('applyAISettings refreshes chat provider UI through sync runtime hooks',
+    syncApplySrc.includes('refreshSyncedAIProviderUiRuntime()')
+      && syncRuntimeSrc.includes('export function refreshSyncedAIProviderUiRuntime')
+      && syncRuntimeSrc.includes("getRuntimeFunction('updateChatHeaderModel')")
+      && syncRuntimeSrc.includes("getRuntimeFunction('refreshWebSearchToggle')")
+      && !syncApplySrc.includes('window.updateChatHeaderModel')
+      && !syncApplySrc.includes('window.refreshWebSearchToggle'));
+  assert('sync runtime owner event dispatch avoids counted direct window refs',
+    syncRuntimeSrc.includes('export function dispatchSyncOwnerChangedRuntime')
+      && syncRuntimeSrc.includes('new runtime.CustomEvent')
+      && !/\bwindow(?:\.|\s*\[)/.test(syncRuntimeSrc));
   assert('AI setting changes schedule a sync push',
     syncSaveHooksSrc.includes("labcharts-ai-settings-local-changed")
       && syncSaveHooksSrc.includes('_pushProfile(profileId, importedData)'));

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -30,6 +30,7 @@ const settingsDataSrc = read('js/settings-data.js');
 const settingsSrc = read('js/settings.js');
 const reviewSrc = read('js/pdf-import-review.js');
 const reviewRuntimeSrc = read('js/pdf-import-review-runtime.js');
+const progressSrc = read('js/pdf-import-progress.js');
 const labEntrySrc = read('js/lab-entry.js');
 const profileSrc = read('js/profile.js');
 const importCssSrc = read('css/import.css');
@@ -174,6 +175,11 @@ const importCssSrc = read('css/import.css');
       && persistenceSrc.includes('refreshImportedDataViewsRuntime(state.currentView')
       && reviewRuntimeSrc.includes('export function refreshImportedDataViewsRuntime')
       && !/\bwindow(?:\.|\s*\[)/.test(persistenceSrc));
+  assert('PDF import progress delegates dashboard fallback navigation through runtime adapter',
+    progressSrc.includes("from './pdf-import-review-runtime.js'")
+      && progressSrc.includes("navigateImportReviewRuntime('dashboard')")
+      && reviewRuntimeSrc.includes('export function navigateImportReviewRuntime')
+      && !/\bwindow(?:\.|\s*\[)/.test(progressSrc));
   assert('Re-review modal uses update wording instead of import wording',
     /parseResult\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc)
       && /result\._reReviewSnapshotId[\s\S]{0,140}Update Import/.test(reviewSrc));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.124';
+self.APP_VERSION = '1.10.125';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.123';
+self.APP_VERSION = '1.10.124';


### PR DESCRIPTION
## Summary
- Route EMF interpretation chat handoff calls through local runtime helpers.
- Move synced AI provider UI refresh and sync-owner event dispatch behind sync runtime adapters.
- Move PDF import progress dashboard fallback navigation through the import review runtime adapter.
- Extend source/runtime guard coverage and bump the app version for cache invalidation.

## Window burden
- Reduced counted direct `window.` global references in `js/` from 62 to 55 (-7) across this PR.
- Removed the counted direct `window.` refs from the EMF interpretation handoff and from the touched sync/PDF import runtime paths.
- Current quality guardrail: `window global references in js/ stays within baseline (55/202)`.

## Tests
- `node tests/test-emf-delegated-actions.js`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`
- `npm run test:playwright -- tests/playwright/emf-edge-browser-coverage.spec.js`
- `npm test -- --reporter=dot tests/sync-runtime.test.js`
- `node tests/test-sync.js`
- `node tests/test-openrouter.js`
- `node tests/test-unit-import.js`
- `npx playwright test tests/playwright/sync-helper-browser-coverage.spec.js tests/playwright/sync-lifecycle-browser-coverage.spec.js --project=chromium`
- `npx playwright test tests/playwright/pdf-import-browser-coverage.spec.js --project=chromium`
- `./run-tests.sh`