### PR TITLE
Delegate sync lifecycle runtime hooks

### DIFF
--- a/js/settings-agent-access-panel.js
+++ b/js/settings-agent-access-panel.js
@@ -2,6 +2,7 @@
 // settings-agent-access-panel.js — Settings → Agent Access rendering/actions.
 
 import { showNotification, bindSyncAppliedRefresh } from './utils.js';
+import { addUtilsRuntimeListener } from './utils-runtime.js';
 import { state } from './state.js';
 import {
   clearAgentAccessMigrationDirty,
@@ -364,8 +365,6 @@ export function refreshMessengerSectionForOwnerChange() {
   if (el) el.innerHTML = renderMessengerSection();
 }
 
-if (typeof window !== 'undefined') {
-  window.addEventListener('labcharts-sync-owner-changed', refreshMessengerSectionForOwnerChange);
-  bindSyncAppliedRefresh(refreshMessengerSectionForOwnerChange);
-  window.addEventListener('labcharts-profile-switched', refreshMessengerSectionForOwnerChange);
-}
+addUtilsRuntimeListener('labcharts-sync-owner-changed', refreshMessengerSectionForOwnerChange);
+bindSyncAppliedRefresh(refreshMessengerSectionForOwnerChange);
+addUtilsRuntimeListener('labcharts-profile-switched', refreshMessengerSectionForOwnerChange);

--- a/js/sync-identity.js
+++ b/js/sync-identity.js
@@ -5,6 +5,7 @@ import { loadScriptOnce, showNotification } from './utils.js';
 import {
   clearSyncDisableStorage,
 } from './sync-disable-cleanup.js';
+import { scheduleSyncRuntimeReload } from './sync-runtime.js';
 
 let _bip39Load = null;
 let _qrCodeLoad = null;
@@ -128,7 +129,7 @@ export async function restoreFromMnemonic(mnemonic, options = {}) {
       showNotification('Restored from mnemonic — reloading…', 'success');
     }
     // Reload so the app re-initializes from the restored CRDT identity.
-    setTimeout(() => window.location.reload(), 500);
+    scheduleSyncRuntimeReload(500);
     return true;
   } catch (e) {
     console.error('[sync] Restore failed:', e);

--- a/js/sync-init.js
+++ b/js/sync-init.js
@@ -9,8 +9,9 @@ import { bindSyncRecoveryEvents } from './sync-recovery.js';
 import { reconcileLocalStorageWithEvolu } from './sync-reconcile.js';
 import { bindSyncSubscriptions, startRelayProbe } from './sync-subscriptions.js';
 import {
-  getSyncAppOwner, getSyncEvolu, setSyncAppOwner, setSyncAppOwnerError,
-  setSyncEvolu, setSyncQueries, setSyncQueryLoadedPromise,
+  getSyncAppOwner, getSyncEvolu, getSyncReloadUrlRuntime,
+  setSyncAppOwner, setSyncAppOwnerError, setSyncEvolu,
+  setSyncQueries, setSyncQueryLoadedPromise,
   setSyncReadyPromise,
 } from './sync-runtime.js';
 
@@ -45,7 +46,7 @@ export async function initSync() {
     const relay = getSyncRelay();
     const evolu = createEvolu(evoluWebDeps)(Schema, {
       name: SimpleName.orThrow("getbased4"),
-      reloadUrl: window.location.pathname,
+      reloadUrl: getSyncReloadUrlRuntime(),
       enableLogging: isDebugMode(),
       transports: [{ type: "WebSocket", url: relay }],
     });

--- a/js/sync-lifecycle.js
+++ b/js/sync-lifecycle.js
@@ -14,7 +14,8 @@ import { renderSyncIndicator } from './sync-ui.js';
 import { initSync } from './sync-init.js';
 import {
   clearSyncRuntimeState, getSyncAppOwner, getSyncAppOwnerError, getSyncEvolu,
-  getSyncQueryLoadedPromise, getSyncReadyPromise, setSyncAppOwnerError,
+  getSyncQueryLoadedPromise, getSyncReadyPromise, scheduleSyncRuntimeReload,
+  setSyncAppOwnerError,
 } from './sync-runtime.js';
 
 /** @param {{ skipPush?: boolean }} [options] */
@@ -106,5 +107,5 @@ export async function disableSync() {
   showNotification('Sync disabled — reloading…', 'success');
   // Reload regardless of whether Evolu cooperated. ~250ms gives the toast
   // time to render before the page swaps.
-  setTimeout(() => window.location.reload(), 250);
+  scheduleSyncRuntimeReload(250);
 }

--- a/js/sync-messenger.js
+++ b/js/sync-messenger.js
@@ -3,6 +3,7 @@
 
 import { state } from './state.js';
 import { bindSyncAppliedRefresh } from './utils.js';
+import { addUtilsRuntimeListener } from './utils-runtime.js';
 
 const MESSENGER_TOKEN_KEY = 'labcharts-messenger-token';
 const MESSENGER_ENABLED_KEY = 'labcharts-messenger-enabled';
@@ -276,10 +277,10 @@ export function refreshAgentAccessFromSyncedProfile({ migrateLegacy = true, clea
   return withSeries;
 }
 
-if (typeof window !== 'undefined') {
-  bindSyncAppliedRefresh(() => { refreshAgentAccessFromSyncedProfile({ migrateLegacy: true }); });
-  window.addEventListener('labcharts-profile-switched', () => { refreshAgentAccessFromSyncedProfile({ migrateLegacy: false, clearWhenMissing: true }); });
-}
+bindSyncAppliedRefresh(() => { refreshAgentAccessFromSyncedProfile({ migrateLegacy: true }); });
+addUtilsRuntimeListener('labcharts-profile-switched', () => {
+  refreshAgentAccessFromSyncedProfile({ migrateLegacy: false, clearWhenMissing: true });
+});
 
 const AGENT_CONTEXT_CRYPTO_VERSION = 2;
 const AGENT_CONTEXT_AAD_PREFIX = 'getbased-agent-context-v2';

--- a/js/sync-runtime.js
+++ b/js/sync-runtime.js
@@ -85,6 +85,24 @@ export function dispatchSyncOwnerChangedRuntime(ownerId) {
   }
 }
 
+/** @param {string} [fallback] */
+export function getSyncReloadUrlRuntime(fallback = '/') {
+  const runtime = getSyncRuntimeWindow();
+  const pathname = runtime?.location?.pathname;
+  return typeof pathname === 'string' && pathname ? pathname : fallback;
+}
+
+/** @param {number} delayMs */
+export function scheduleSyncRuntimeReload(delayMs = 0) {
+  const runtime = getSyncRuntimeWindow();
+  const reload = runtime?.location?.reload;
+  if (!runtime?.location || typeof reload !== 'function') return false;
+  setTimeout(() => {
+    reload.call(runtime.location);
+  }, delayMs);
+  return true;
+}
+
 export function setSyncReadyPromise(promise) {
   _readyPromise = promise ?? null;
 }

--- a/js/sync-save-hooks.js
+++ b/js/sync-save-hooks.js
@@ -6,6 +6,7 @@ import { profileStorageKey, createDefaultProfileData, migrateProfileData } from 
 import { getEncryptionEnabled, encryptedGetItem } from './crypto.js';
 import { markChatDataLocal } from './sync-chat-apply.js';
 import { pushContextToGateway } from './sync-messenger.js';
+import { addUtilsRuntimeListener } from './utils-runtime.js';
 
 /** @type {(...args: any[]) => Promise<any>} */
 let _pushProfile = async () => {};
@@ -43,9 +44,8 @@ export function configureSyncSaveHooks({
 }
 
 export function bindSyncSaveHookEvents() {
-  if (_eventsBound || typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
-  _eventsBound = true;
-  window.addEventListener('labcharts-ai-settings-local-changed', () => {
+  if (_eventsBound) return;
+  const bound = addUtilsRuntimeListener('labcharts-ai-settings-local-changed', () => {
     if (!_isSyncEnabled() || !state.currentProfile || !state.importedData) return;
     if (_aiSettingsPushTimer) clearTimeout(_aiSettingsPushTimer);
     const profileId = state.currentProfile;
@@ -55,6 +55,7 @@ export function bindSyncSaveHookEvents() {
       _pushProfile(profileId, importedData).catch(() => {});
     }, 250);
   });
+  if (bound) _eventsBound = true;
 }
 
 export function clearSyncSaveTimers() {

--- a/tests/playwright/sync-configure-reconcile-browser-coverage.spec.js
+++ b/tests/playwright/sync-configure-reconcile-browser-coverage.spec.js
@@ -86,7 +86,7 @@ test('sync configure browser coverage seeds local profiles through identity rest
       outcomes.configureSeedSchedulesReload =
         scheduledTimers.some(timer => (
           timer.delay === 500
-          && timer.source.includes('location.reload')
+          && timer.source.includes('reload.call')
         ));
     } catch (error) {
       thrownError = error;

--- a/tests/sync-lifecycle-runtime.test.js
+++ b/tests/sync-lifecycle-runtime.test.js
@@ -20,6 +20,7 @@ function installLifecycleMocks(overrides = {}) {
     getSyncEvolu: vi.fn(() => ({ resetAppOwner: vi.fn(async () => {}) })),
     getSyncQueryLoadedPromise: vi.fn(() => Promise.resolve()),
     getSyncReadyPromise: vi.fn(() => Promise.resolve()),
+    scheduleSyncRuntimeReload: vi.fn(),
     setSyncAppOwnerError: vi.fn(),
     ...overrides,
   };
@@ -65,6 +66,7 @@ function installLifecycleMocks(overrides = {}) {
     getSyncEvolu: deps.getSyncEvolu,
     getSyncQueryLoadedPromise: deps.getSyncQueryLoadedPromise,
     getSyncReadyPromise: deps.getSyncReadyPromise,
+    scheduleSyncRuntimeReload: deps.scheduleSyncRuntimeReload,
     setSyncAppOwnerError: deps.setSyncAppOwnerError,
   }));
 
@@ -149,36 +151,25 @@ describe('sync lifecycle runtime behavior', () => {
   });
 
   it('disables sync, clears timers and snapshots, resets Evolu, and schedules reload', async () => {
-    vi.useFakeTimers();
     const resetAppOwner = vi.fn(async () => {});
-    const reload = vi.fn();
-    const priorLocation = globalThis.location;
-    globalThis.location = { reload };
     const deps = installLifecycleMocks({
       getSyncEvolu: vi.fn(() => ({ resetAppOwner })),
     });
     const { disableSync } = await loadLifecycle();
 
-    try {
-      await disableSync();
+    await disableSync();
 
-      expect(deps.setSyncEnabled).toHaveBeenCalledWith(false);
-      expect(deps.setSyncAppOwnerError).toHaveBeenCalledWith(null);
-      expect(deps.clearSyncSaveTimers).toHaveBeenCalled();
-      expect(deps.clearSyncPullTimers).toHaveBeenCalled();
-      expect(deps.clearSyncSubscriptionTimers).toHaveBeenCalled();
-      expect(deps.resetSyncStatus).toHaveBeenCalled();
-      expect(deps.renderSyncIndicator).toHaveBeenCalled();
-      expect(deps.clearSyncDisableStorage).toHaveBeenCalled();
-      expect(resetAppOwner).toHaveBeenCalledWith({ reload: false });
-      expect(deps.clearSyncRuntimeState).toHaveBeenCalled();
-      expect(deps.showNotification).toHaveBeenCalledWith('Sync disabled \u2014 reloading\u2026', 'success');
-
-      await vi.advanceTimersByTimeAsync(250);
-      expect(reload).toHaveBeenCalled();
-    } finally {
-      if (priorLocation) globalThis.location = priorLocation;
-      else delete globalThis.location;
-    }
+    expect(deps.setSyncEnabled).toHaveBeenCalledWith(false);
+    expect(deps.setSyncAppOwnerError).toHaveBeenCalledWith(null);
+    expect(deps.clearSyncSaveTimers).toHaveBeenCalled();
+    expect(deps.clearSyncPullTimers).toHaveBeenCalled();
+    expect(deps.clearSyncSubscriptionTimers).toHaveBeenCalled();
+    expect(deps.resetSyncStatus).toHaveBeenCalled();
+    expect(deps.renderSyncIndicator).toHaveBeenCalled();
+    expect(deps.clearSyncDisableStorage).toHaveBeenCalled();
+    expect(resetAppOwner).toHaveBeenCalledWith({ reload: false });
+    expect(deps.clearSyncRuntimeState).toHaveBeenCalled();
+    expect(deps.showNotification).toHaveBeenCalledWith('Sync disabled \u2014 reloading\u2026', 'success');
+    expect(deps.scheduleSyncRuntimeReload).toHaveBeenCalledWith(250);
   });
 });

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -34,7 +34,9 @@ import { applyCommittedDeltas, planProfileDeltas } from '../js/sync-push-deltas.
 import { configureSyncPush, isSyncPushInFlight, pushProfile } from '../js/sync-push.js';
 import {
   dispatchSyncOwnerChangedRuntime,
+  getSyncReloadUrlRuntime,
   refreshSyncedAIProviderUiRuntime,
+  scheduleSyncRuntimeReload,
   setSyncAppOwner,
 } from '../js/sync-runtime.js';
 import { getRecentSyncEvents, resetSyncStatus, updateSyncStatus } from '../js/sync-state.js';
@@ -222,6 +224,20 @@ describe('sync apply runtime behavior', () => {
       setSyncAppOwner(null);
       window.removeEventListener('labcharts-sync-owner-changed', recordOwnerEvent);
     }
+  });
+
+  it('routes sync reload path and delayed reload through runtime helpers', () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    vi.stubGlobal('window', { location: { pathname: '/sync-runtime-test', reload } });
+
+    expect(getSyncReloadUrlRuntime()).toBe('/sync-runtime-test');
+    expect(scheduleSyncRuntimeReload(250)).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(250);
+
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/test-settings-sync-delegated-actions.js
+++ b/tests/test-settings-sync-delegated-actions.js
@@ -40,6 +40,10 @@ assert('Settings sync delegates input events',
   /document\.addEventListener\('input', handleSettingsSyncInput\)/.test(src));
 assert('Settings sync actions are scoped to panel and modal roots',
   /closest\('#sync-section, #messenger-section, #sync-setup-overlay, #sync-restore-overlay'\)/.test(src));
+assert('Agent Access runtime refresh listeners use runtime adapter',
+  agentSrc.includes("addUtilsRuntimeListener('labcharts-sync-owner-changed'")
+    && agentSrc.includes("addUtilsRuntimeListener('labcharts-profile-switched'")
+    && !/\bwindow(?:\.|\s*\[)/.test(agentSrc));
 assert('Setup overlay backdrop nudges instead of closing',
   /target\.id === 'sync-setup-overlay'[\s\S]*nudgeSyncSetupDialog\(\)/.test(src));
 assert('Restore overlay backdrop closes restore dialog',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1246,6 +1246,17 @@ await import('../js/settings.js');
     syncRuntimeSrc.includes('export function dispatchSyncOwnerChangedRuntime')
       && syncRuntimeSrc.includes('new runtime.CustomEvent')
       && !/\bwindow(?:\.|\s*\[)/.test(syncRuntimeSrc));
+  assert('sync lifecycle reload and event hooks route through runtime adapters',
+    syncInitSrc.includes('getSyncReloadUrlRuntime()')
+      && syncIdentitySrc.includes('scheduleSyncRuntimeReload(500)')
+      && syncLifecycleSrc.includes('scheduleSyncRuntimeReload(250)')
+      && syncSaveHooksSrc.includes('addUtilsRuntimeListener')
+      && syncMessengerSrc.includes('addUtilsRuntimeListener')
+      && !/\bwindow(?:\.|\s*\[)/.test(syncInitSrc)
+      && !/\bwindow(?:\.|\s*\[)/.test(syncIdentitySrc)
+      && !/\bwindow(?:\.|\s*\[)/.test(syncLifecycleSrc)
+      && !/\bwindow(?:\.|\s*\[)/.test(syncSaveHooksSrc)
+      && !/\bwindow(?:\.|\s*\[)/.test(syncMessengerSrc));
   assert('AI setting changes schedule a sync push',
     syncSaveHooksSrc.includes("labcharts-ai-settings-local-changed")
       && syncSaveHooksSrc.includes('_pushProfile(profileId, importedData)'));
@@ -1271,7 +1282,9 @@ await import('../js/settings.js');
   // ═══════════════════════════════════════
   console.log('5. Evolu Configuration');
 
-  assert('reloadUrl uses window.location.pathname', syncInitSrc.includes('reloadUrl: window.location.pathname'));
+  assert('reloadUrl uses sync runtime path helper',
+    syncInitSrc.includes('reloadUrl: getSyncReloadUrlRuntime()')
+      && syncRuntimeSrc.includes('export function getSyncReloadUrlRuntime'));
   assert('enableLogging gated on debug mode', syncInitSrc.includes('enableLogging: isDebugMode()'));
   assert('Default relay is wss://sync.getbased.health', syncEnvironmentSrc.includes("wss://sync.getbased.health"));
   assert('Transport uses plural "transports" array (not singular)', syncInitSrc.includes('transports: [{ type:') && !syncInitSrc.includes('transport: { type:'));
@@ -1402,7 +1415,9 @@ await import('../js/settings.js');
     /Promise\.resolve\(evolu\.resetAppOwner/.test(syncLifecycleSrc),
     'awaiting resetAppOwner blocks the toggle when Evolu worker is hung');
   assert('disableSync resets Evolu identity for mnemonic regeneration', syncLifecycleSrc.includes('evolu.resetAppOwner('));
-  assert('disableSync reloads page after reset to kill Worker', syncLifecycleSrc.includes('window.location.reload()'));
+  assert('disableSync reloads page through sync runtime helper to kill Worker',
+    syncLifecycleSrc.includes('scheduleSyncRuntimeReload(250)')
+      && syncRuntimeSrc.includes('export function scheduleSyncRuntimeReload'));
   assert('disableSync clears sync timestamps',
     disableSyncSrc.includes('clearSyncDisableStorage();')
       && /key\.endsWith\('-sync-ts'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(syncDisableCleanupSrc));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.125';
+self.APP_VERSION = '1.10.126';


### PR DESCRIPTION
## Summary
- Move sync restore/disable reloads and Evolu reloadUrl path lookup behind sync runtime helpers.
- Route sync and Agent Access window-level event listeners through the existing runtime listener adapter.
- Extend source/runtime guard coverage and bump the app version for cache invalidation.

## Window burden
- Reduced counted direct `window.` global references in `js/` from 55 to 47 (-8) after #1098.
- Removed counted direct `window.` refs from the touched sync lifecycle, identity, init, save-hook, messenger, and Agent Access panel paths.
- Current quality guardrail: `window global references in js/ stays within baseline (47/202)`.

## Tests
- `npm test -- --reporter=dot tests/sync-runtime.test.js tests/sync-lifecycle-runtime.test.js`
- `node tests/test-sync.js`
- `node tests/test-settings-sync-delegated-actions.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `git diff --check`
- `npx playwright test tests/playwright/sync-lifecycle-browser-coverage.spec.js tests/playwright/sync-actions-browser-coverage.spec.js tests/playwright/settings-sync-setup-browser-coverage.spec.js --project=chromium`
- `npx playwright test tests/playwright/sync-configure-reconcile-browser-coverage.spec.js --project=chromium`
- `npm test -- --reporter=dot`
- `./run-tests.sh`