### PR TITLE
Delegate Chart.js runtime construction

### DIFF
--- a/js/category-view-renderers.js
+++ b/js/category-view-renderers.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr, getStatus, formatValue, getTrend, safeMarkerId } from './utils.js';
 import { getChartColors } from './theme.js';
 import { ensureChartJs } from './charts.js';
+import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 import { getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex, statusIcon } from './marker-analysis.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
 
@@ -294,7 +295,7 @@ export function renderFattyAcidsView(cat, categoryKey) {
 }
 
 export function renderFattyAcidsCharts(cat) {
-  if (!window.Chart) {
+  if (!hasChartRuntime()) {
     ensureChartJs().then(() => {
       if (document.getElementById("chart-fa-bar")) renderFattyAcidsCharts(cat);
     }).catch(() => {});
@@ -313,7 +314,7 @@ export function renderFattyAcidsCharts(cat) {
   }
   const ctx = /** @type {HTMLCanvasElement | null} */ (document.getElementById("chart-fa-bar"));
   if (!ctx) return;
-  state.chartInstances["fa-bar"] = new window.Chart(ctx, {
+  const chart = createChartRuntime(ctx, {
     type: "bar",
     data: { labels: names, datasets: [
       { label:"Value", data:vals, backgroundColor:bgC, borderColor:brC, borderWidth:1, borderRadius:4 },
@@ -325,4 +326,5 @@ export function renderFattyAcidsCharts(cat) {
       scales: { x:{ticks:{color:tc.tickColor,font:{size:10},maxRotation:45},grid:{display:false}}, y:{ticks:{color:tc.tickColor},grid:{color:tc.gridColor}} }
     }
   });
+  if (chart) state.chartInstances["fa-bar"] = chart;
 }

--- a/js/compare-correlations.js
+++ b/js/compare-correlations.js
@@ -8,6 +8,7 @@ import { getChartColors } from './theme.js';
 import { getActiveData } from './data.js';
 import { getEffectiveRange, getEffectiveRangeForDate } from './marker-analysis.js';
 import { ensureChartJs, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin } from './charts.js';
+import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 
 /** @type {{ renderTableColgroup: (cols: string[]) => string, renderScrollableTableShell: (...args: any[]) => string, renderCategoryGlyph: (...args: any[]) => string }} */
 const compareCorrelationDeps = {
@@ -365,7 +366,7 @@ export function renderCorrelationChart() {
   if (state.chartInstances["correlation"]) { state.chartInstances["correlation"].destroy(); delete state.chartInstances["correlation"]; }
   const canvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById("chart-correlation"));
   if (!canvas) return;
-  if (!window.Chart) {
+  if (!hasChartRuntime()) {
     ensureChartJs().then(() => {
       if (document.getElementById("chart-correlation")) renderCorrelationChart();
     }).catch(() => {});
@@ -395,7 +396,7 @@ export function renderCorrelationChart() {
   const minY = Math.min(0, ...allVals) - 10;
   const maxY = Math.max(100, ...allVals) + 10;
   const tc = getChartColors();
-  state.chartInstances["correlation"] = new window.Chart(canvas, {
+  const chart = createChartRuntime(canvas, {
     type: "line",
     data: { labels: data.dateLabels, datasets },
     options: {
@@ -426,6 +427,7 @@ export function renderCorrelationChart() {
     },
     plugins: [refBandPlugin, noteAnnotationPlugin, supplementBarPlugin]
   });
+  if (chart) state.chartInstances["correlation"] = chart;
 }
 
 installCompareCorrelationDelegates();

--- a/js/wearables-bp-detail-chart.js
+++ b/js/wearables-bp-detail-chart.js
@@ -3,11 +3,12 @@
 import { state } from './state.js';
 import { adapterById, isMetricValueMeaningful } from './wearable-adapters.js';
 import { ensureChartJs, isChartDateAdapterReady } from './charts.js';
+import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 import { getChartColors } from './theme.js';
 import { formatValue, shortDate } from './wearables-formatters.js';
 
 export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diastolicSeries = [], manualSeries = [], pairedMetric = null) {
-  if (!window.Chart || !isChartDateAdapterReady()) {
+  if (!hasChartRuntime() || !isChartDateAdapterReady()) {
     const retryToken = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     canvas.dataset.bpRenderToken = retryToken;
     ensureChartJs().then(() => {
@@ -137,7 +138,7 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
     return items?.[0]?.label || '';
   };
 
-  state.chartInstances['modal'] = new window.Chart(canvas, {
+  const chart = createChartRuntime(canvas, {
     type: 'line',
     data: { datasets },
     options: {
@@ -170,4 +171,5 @@ export function renderBloodPressureChart(canvas, canon, m, systolicSeries, diast
       },
     },
   });
+  if (chart) state.chartInstances['modal'] = chart;
 }

--- a/tests/charts-runtime.test.js
+++ b/tests/charts-runtime.test.js
@@ -66,4 +66,19 @@ describe('charts runtime adapter', () => {
     expect(/\bwindow(?:\.|\s*\[)/.test(chartsSrc)).toBe(false);
     expect(swSrc).toContain("'/js/charts-runtime.js'");
   });
+
+  it('keeps Chart.js construction behind the runtime adapter', () => {
+    const chartConsumers = [
+      readFileSync(new URL('../js/category-view-renderers.js', import.meta.url), 'utf8'),
+      readFileSync(new URL('../js/compare-correlations.js', import.meta.url), 'utf8'),
+      readFileSync(new URL('../js/wearables-bp-detail-chart.js', import.meta.url), 'utf8'),
+    ];
+
+    for (const src of chartConsumers) {
+      expect(src).toContain("from './charts-runtime.js'");
+      expect(src).toContain('createChartRuntime');
+      expect(src).toContain('hasChartRuntime');
+      expect(src).not.toContain('window.Chart');
+    }
+  });
 });

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.126';
+self.APP_VERSION = '1.10.127';


### PR DESCRIPTION
Summary:
- Route fatty-acid, correlation, and wearable BP chart readiness/construction through charts-runtime.js.
- Add a runtime-source regression guard for Chart.js consumers.
- Bump version.js to 1.10.127 for cache invalidation.

Tests:
- npm test -- --reporter=dot tests/charts-runtime.test.js
- node tests/test-wearables.js
- node tests/test-compare-correlations-delegated-actions.js
- node tests/test-table-heatmap-empty.js
- node tests/test-audit.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- git diff --check
- npx playwright test tests/playwright/category-view-renderers-browser-coverage.spec.js tests/playwright/compare-correlations-browser-coverage.spec.js tests/playwright/charts-browser-coverage.spec.js tests/playwright/wearables-bp-merge.spec.js tests/playwright/wearables-detail-manual-browser-coverage.spec.js --project=chromium
- ./run-tests.sh