### PR TITLE
Delegate app version runtime hooks

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -3,6 +3,7 @@
 // APP_VERSION comes from /version.js (loaded as classic script before modules)
 
 import { escapeHTML } from './utils.js';
+import { getAppVersionRuntime, registerUtilsRuntimeExports } from './utils-runtime.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 const CHANGELOG_ACTION_ATTR = 'data-changelog-action';
@@ -357,7 +358,7 @@ function getSeenVersion() {
 }
 
 function markChangelogSeen() {
-  localStorage.setItem('labcharts-changelog-seen', String(window.APP_VERSION));
+  localStorage.setItem('labcharts-changelog-seen', getAppVersionRuntime());
 }
 
 // Changelog items are authored in source code (CHANGELOG above) — trusted.
@@ -461,10 +462,11 @@ function _semverGt(a, b) {
 export function maybeShowChangelog() {
   if (document.getElementById('legal-consent-overlay')) return;
   const seen = getSeenVersion();
+  const appVersion = getAppVersionRuntime();
   // First visit — no changelog, just mark as seen
   if (!seen) { markChangelogSeen(); return; }
   // Only show What's New on minor/major bumps, not patch
-  if (getMajorMinor(seen) !== getMajorMinor(window.APP_VERSION)) {
+  if (appVersion && getMajorMinor(seen) !== getMajorMinor(appVersion)) {
     openChangelog(false);
     return;
   }
@@ -480,4 +482,4 @@ export function maybeShowChangelog() {
   if (hasForceShowAheadOfSeen) openChangelog(false);
 }
 
-Object.assign(window, { openChangelog, closeChangelog, maybeShowChangelog });
+registerUtilsRuntimeExports({ openChangelog, closeChangelog, maybeShowChangelog });

--- a/js/commit-hash.js
+++ b/js/commit-hash.js
@@ -2,6 +2,7 @@
 // commit-hash.js - Footer app version and commit hash hydration
 
 import { escapeHTML } from './utils.js';
+import { getAppVersionRuntime } from './utils-runtime.js';
 
 let _cachedCommitHash = null;
 
@@ -19,7 +20,7 @@ function cacheAndRenderCommitHash(el, sha) {
 
 export function loadCommitHash() {
   const vEl = document.getElementById('app-version-text');
-  if (vEl && !vEl.textContent) vEl.textContent = window.APP_VERSION || '';
+  if (vEl && !vEl.textContent) vEl.textContent = getAppVersionRuntime();
   const el = document.getElementById('app-commit-hash');
   if (!el) return;
   if (_cachedCommitHash) {

--- a/js/utils-runtime.js
+++ b/js/utils-runtime.js
@@ -11,6 +11,20 @@ export function hasUtilsRuntime() {
   return getUtilsRuntime() !== null;
 }
 
+/** @param {string} [fallback] */
+export function getAppVersionRuntime(fallback = '') {
+  const version = getUtilsRuntime()?.APP_VERSION;
+  return typeof version === 'string' && version ? version : fallback;
+}
+
+/** @param {Record<string, any>} exportsByName */
+export function registerUtilsRuntimeExports(exportsByName) {
+  const runtime = getUtilsRuntime();
+  if (!runtime || !exportsByName) return false;
+  Object.assign(runtime, exportsByName);
+  return true;
+}
+
 /**
  * @param {EventListenerOrEventListenerObject} listener
  */

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -47,7 +47,10 @@ const versionSrc = await fetchWithRetry('version.js');
 // ═══════════════════════════════════════
 console.log('1. Changelog Module Structure');
 
-assert('changelog.js uses window.APP_VERSION', changelogSrc.includes('window.APP_VERSION'));
+assert('changelog.js delegates APP_VERSION through utils runtime',
+  changelogSrc.includes("from './utils-runtime.js'")
+    && changelogSrc.includes('getAppVersionRuntime')
+    && !changelogSrc.includes('window.APP_VERSION'));
 assert('changelog.js has CHANGELOG array', changelogSrc.includes('const CHANGELOG'));
 assert('changelog.js exports openChangelog', changelogSrc.includes('export function openChangelog'));
 assert('changelog.js exports closeChangelog', changelogSrc.includes('export function closeChangelog'));
@@ -60,6 +63,9 @@ assert('changelog.js delegates modal close button without inline handlers',
   changelogSrc.includes('data-changelog-action') &&
     changelogSrc.includes('installChangelogDelegates(modal)') &&
     !/\bon(?:click|change|input|submit|keydown|keyup)=/.test(changelogSrc));
+assert('changelog.js registers legacy globals through utils runtime',
+  changelogSrc.includes('registerUtilsRuntimeExports({ openChangelog, closeChangelog, maybeShowChangelog })')
+    && !/Object\.assign\(window/.test(changelogSrc));
 assert('changelog.js has getMajorMinor helper', changelogSrc.includes('function getMajorMinor'));
 assert('maybeShowChangelog compares major.minor only', changelogSrc.includes('getMajorMinor(seen) !== getMajorMinor('));
 // forceShow patch-bump escape hatch — when a maintainer flags an entry as

--- a/tests/utils-runtime.test.js
+++ b/tests/utils-runtime.test.js
@@ -3,9 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   addUtilsRuntimeListener,
+  getAppVersionRuntime,
   getUtilsElementStyleRuntime,
   hasUtilsRuntime,
   removeUtilsRuntimeListener,
+  registerUtilsRuntimeExports,
 } from '../js/utils-runtime.js';
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
@@ -45,10 +47,21 @@ describe('utils runtime adapter', () => {
     expect(getComputedStyle).toHaveBeenCalledWith(el);
   });
 
+  it('delegates app version reads and runtime export registration', () => {
+    const runtime = { APP_VERSION: '1.2.3' };
+    setRuntimeWindow(runtime);
+
+    expect(getAppVersionRuntime()).toBe('1.2.3');
+    expect(registerUtilsRuntimeExports({ openExample: () => 'ok' })).toBe(true);
+    expect(runtime.openExample()).toBe('ok');
+  });
+
   it('uses safe fallbacks when browser runtime hooks are missing', () => {
     delete globalThis.window;
 
     expect(hasUtilsRuntime()).toBe(false);
+    expect(getAppVersionRuntime('fallback-version')).toBe('fallback-version');
+    expect(registerUtilsRuntimeExports({ openExample: () => 'ok' })).toBe(false);
     expect(addUtilsRuntimeListener('labcharts-sync-applied', vi.fn())).toBe(false);
     expect(removeUtilsRuntimeListener('labcharts-sync-applied', vi.fn())).toBe(false);
     expect(getUtilsElementStyleRuntime({})).toBeNull();

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.127';
+self.APP_VERSION = '1.10.128';


### PR DESCRIPTION
Summary:
- Add shared utils-runtime helpers for APP_VERSION reads and legacy runtime export registration.
- Route changelog version checks and footer version hydration through those helpers.
- Update source guards and bump version.js to 1.10.128.

Window-burden progress:
- Counted js/ window references are at 38/202 after this PR.

Tests:
- npm test -- --reporter=dot tests/utils-runtime.test.js
- node tests/test-changelog.js
- node tests/test-a11y-phase3.js
- node tests/test-correctness-phase2.js
- node tests/test-settings-delegated-actions.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- git diff --check
- npx playwright test tests/playwright/changelog.spec.js tests/playwright/commit-hash-browser-coverage.spec.js tests/playwright/startup-helpers-browser-coverage.spec.js --project=chromium
- ./run-tests.sh