### PR TITLE
Delegate browser action runtime hooks

### DIFF
--- a/js/chat-marker-prompts.js
+++ b/js/chat-marker-prompts.js
@@ -8,9 +8,10 @@ import { getEffectiveRange, getEffectiveRangeForDate, getLatestValueIndex } from
 import { openChatPanel } from './chat-panel.js';
 import { createNewThread, ensureActiveThread, loadChatThreads, renameThread } from './chat-threads.js';
 import { loadChatHistory, saveChatHistory } from './chat-history.js';
+import { closeChatModalRuntime } from './chat-runtime.js';
 
 async function openSourcePrompt(prompt, threadName, { closeModal = false } = {}) {
-  if (closeModal) window.closeModal?.();
+  if (closeModal) closeChatModalRuntime();
   loadChatThreads();
   ensureActiveThread();
   await loadChatHistory();

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -12,6 +12,7 @@ import {
 import { renderSavedSummaries } from './chat-summaries.js';
 import { updateLensIndicator } from './lens.js';
 import { dismissCurrentChatNudge } from './chat-nudge.js';
+import { refreshMobileDashboardActiveTabRuntime } from './chat-runtime.js';
 
 export { setChatNudge, updateChatNudge } from './chat-nudge.js';
 
@@ -142,5 +143,5 @@ export function closeChatPanel() {
   document.body.classList.remove('chat-open', 'chat-fullscreen', 'cards-focus', 'import-focus', 'chat-autostart-reserved');
   const fab = document.getElementById('chat-fab');
   if (fab) fab.classList.remove('hidden');
-  window.refreshMobileDashboardActiveTab?.();
+  refreshMobileDashboardActiveTabRuntime();
 }

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -37,6 +37,14 @@ export function openChatContextModalRuntime() {
   getRuntimeFunction('openContextModal')?.();
 }
 
+export function closeChatModalRuntime() {
+  getRuntimeFunction('closeModal')?.();
+}
+
+export function refreshMobileDashboardActiveTabRuntime() {
+  getRuntimeFunction('refreshMobileDashboardActiveTab')?.();
+}
+
 export function isChatRuntimeStreaming() {
   return Boolean(getRuntimeFunction('isChatStreaming')?.());
 }

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -10,6 +10,7 @@ import { renderThreadList, saveChatThreadIndex } from './chat-threads.js';
 import { renderMarkdown } from './markdown.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
+import { openUtilsRuntimeWindow } from './utils-runtime.js';
 import {
   appendImportedArrayItem,
   deleteImportedArrayItems,
@@ -344,7 +345,7 @@ export function printSummary() {
   const name = _activeSummary.name || 'Summary';
   const html = renderMarkdown(_activeSummary.content);
   const dateLine = _activeSummary.date ? `Summarized ${new Date(_activeSummary.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}${_activeSummary.model ? ' \u00b7 ' + escapeHTML(_activeSummary.model) : ''}` : '';
-  const w = window.open('', '_blank');
+  const w = openUtilsRuntimeWindow('', '_blank');
   if (!w) { showNotification('Popup blocked \u2014 allow popups for this site', 'error'); return; }
   w.document.write(`<!DOCTYPE html><html><head><title>${escapeHTML(name)} - Summary</title>
 <style>body{font-family:-apple-system,system-ui,sans-serif;max-width:700px;margin:40px auto;padding:0 20px;line-height:1.6;color:#1a1a1a}

--- a/js/feedback.js
+++ b/js/feedback.js
@@ -5,6 +5,7 @@ import { escapeAttr, escapeHTML, showNotification } from './utils.js';
 import { getTheme } from './theme.js';
 import { getAIProvider } from './api.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { openUtilsRuntimeWindow } from './utils-runtime.js';
 
 const FEEDBACK_TYPES = [
   { value: 'bug', label: 'Bug Report', prefix: '[Bug]', ghLabel: 'bug', placeholder: 'Brief description of the bug' },
@@ -150,7 +151,7 @@ export function submitFeedback() {
   // Build URL (encodeURIComponent for proper %20 encoding)
   let url = `https://github.com/elkimek/get-based/issues/new?title=${encodeURIComponent(issueTitle)}&body=${encodeURIComponent(body)}`;
   if (typeDef.ghLabel) url += `&labels=${encodeURIComponent(typeDef.ghLabel)}`;
-  window.open(url, '_blank');
+  openUtilsRuntimeWindow(url, '_blank');
   showNotification('Opening GitHub issue...', 'success');
   closeFeedbackModal();
 }

--- a/js/legal-consent.js
+++ b/js/legal-consent.js
@@ -1,6 +1,8 @@
 // @ts-check
 // legal-consent.js — first-launch Terms/Privacy gate and re-consent on document updates.
 
+import { dispatchUtilsRuntimeEvent } from './utils-runtime.js';
+
 const LEGAL_ACCEPTANCE_KEY = 'labcharts-legal-acceptance';
 export const TERMS_VERSION = '2026-06-22';
 export const PRIVACY_VERSION = '2026-06-22';
@@ -106,7 +108,7 @@ function handleLegalConsentClick(event) {
     console.warn('[legal-consent] Failed to persist acceptance:', err);
   }
   closeLegalConsentGate();
-  window.dispatchEvent(new CustomEvent('legal-consent-accepted'));
+  dispatchUtilsRuntimeEvent('legal-consent-accepted');
   if (persisted) {
     globalThis.showNotification?.('Terms and Privacy accepted.', 'success', 3000);
   } else {

--- a/js/profile-share.js
+++ b/js/profile-share.js
@@ -6,6 +6,7 @@ import { getProfiles } from './profile.js';
 import { buildClientExportObject, importDataJSON } from './export.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import { addUtilsRuntimeListener } from './utils-runtime.js';
 
 export const PROFILE_SHARE_SCHEMA = 'getbased-profile-share';
 export const PROFILE_SHARE_VERSION = 1;
@@ -737,7 +738,7 @@ export function initProfileShareLinks() {
   } else {
     setTimeout(handleProfileShareDeepLink, 0);
   }
-  window.addEventListener('hashchange', handleProfileShareDeepLink);
+  addUtilsRuntimeListener('hashchange', handleProfileShareDeepLink);
 }
 
 if (typeof window !== 'undefined') {

--- a/js/utils-runtime.js
+++ b/js/utils-runtime.js
@@ -26,6 +26,32 @@ export function registerUtilsRuntimeExports(exportsByName) {
 }
 
 /**
+ * @param {string} name
+ * @param {Record<string, any>} [detail]
+ */
+export function dispatchUtilsRuntimeEvent(name, detail) {
+  const runtime = getUtilsRuntime();
+  const CustomEventCtor = runtime?.CustomEvent;
+  if (!runtime || typeof runtime.dispatchEvent !== 'function' || typeof CustomEventCtor !== 'function') return false;
+  runtime.dispatchEvent(new CustomEventCtor(name, detail === undefined ? undefined : { detail }));
+  return true;
+}
+
+/**
+ * @param {string | URL} url
+ * @param {string} [target]
+ * @param {string} [features]
+ * @returns {WindowProxy | null}
+ */
+export function openUtilsRuntimeWindow(url, target = '_blank', features) {
+  const runtime = getUtilsRuntime();
+  const open = runtime?.open;
+  if (typeof open !== 'function') return null;
+  if (features === undefined) return open.call(runtime, url, target);
+  return open.call(runtime, url, target, features);
+}
+
+/**
  * @param {EventListenerOrEventListenerObject} listener
  */
 function isEventListener(listener) {

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -428,6 +428,8 @@ const directWindowGlobalRe = /\bwindow(?:\.|\s*\[)/;
 const chatRuntimeDelegates = [
   ['chat-actions.js', chatActionsSrc],
   ['chat-history.js', chatHistorySrc],
+  ['chat-marker-prompts.js', chatMarkerPromptsSrc],
+  ['chat-panel.js', chatPanelSrc],
   ['chat-personalities.js', chatPersonalitiesSrc],
   ['chat-discussion-round-runner.js', chatDiscussionRoundRunnerSrc],
 ];

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -3,10 +3,12 @@
 
 import './_node-shim.js';
 import {
+  closeChatModalRuntime,
   getChatProviderAttestation,
   getChatRegenerateCallbacks,
   isChatRuntimeStreaming,
   openChatContextModalRuntime,
+  refreshMobileDashboardActiveTabRuntime,
   renderChatMessagesRuntime,
   updateDiscussButtonRuntime,
 } from '../js/chat-runtime.js';
@@ -31,6 +33,8 @@ const runtimeKeys = [
   'renderChatMessages',
   'updateDiscussButton',
   'openContextModal',
+  'closeModal',
+  'refreshMobileDashboardActiveTab',
   'isChatStreaming',
   'sendChatMessage',
   '_ppqAttestation',
@@ -63,6 +67,8 @@ try {
   setRuntimeValue('renderChatMessages', () => calls.push(['render']));
   setRuntimeValue('updateDiscussButton', () => calls.push(['discuss']));
   setRuntimeValue('openContextModal', () => calls.push(['context']));
+  setRuntimeValue('closeModal', () => calls.push(['close']));
+  setRuntimeValue('refreshMobileDashboardActiveTab', () => calls.push(['refresh-mobile']));
   setRuntimeValue('isChatStreaming', () => false);
   setRuntimeValue('sendChatMessage', () => calls.push(['send']));
   setRuntimeValue('_ppqAttestation', ppqAttestation);
@@ -71,10 +77,14 @@ try {
   renderChatMessagesRuntime();
   updateDiscussButtonRuntime();
   openChatContextModalRuntime();
-  assert('chat runtime invokes render/discuss/context callbacks',
+  closeChatModalRuntime();
+  refreshMobileDashboardActiveTabRuntime();
+  assert('chat runtime invokes render/discuss/context/close/refresh callbacks',
     calls.some(call => call[0] === 'render') &&
       calls.some(call => call[0] === 'discuss') &&
-      calls.some(call => call[0] === 'context'));
+      calls.some(call => call[0] === 'context') &&
+      calls.some(call => call[0] === 'close') &&
+      calls.some(call => call[0] === 'refresh-mobile'));
 
   assert('chat runtime reports non-streaming state',
     isChatRuntimeStreaming() === false);

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -261,10 +261,11 @@ assert('legal gate runs before changelog and resumes changelog only after accept
   && startupUiSrc.includes("startupRuntime().addEventListener('legal-consent-accepted'")
   && startupUiSrc.includes('return legalGateShown')
   && startupUiSrc.includes("startupRuntime().addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true })")
-  && legalConsentSrc.includes("window.dispatchEvent(new CustomEvent('legal-consent-accepted'))"));
+  && legalConsentSrc.includes("from './utils-runtime.js'")
+  && legalConsentSrc.includes("dispatchUtilsRuntimeEvent('legal-consent-accepted')"));
 assert('legal accept does not deadlock when localStorage persistence throws',
   /try\s*\{\s*storeLegalAcceptance\(\);\s*\}\s*catch\s*\(err\)\s*\{[\s\S]{0,220}\[legal-consent\] Failed to persist acceptance/.test(legalConsentSrc)
-  && /catch\s*\(err\)[\s\S]{0,260}\}\s*closeLegalConsentGate\(\);\s*window\.dispatchEvent\(new CustomEvent\('legal-consent-accepted'\)\)/.test(legalConsentSrc));
+  && /catch\s*\(err\)[\s\S]{0,260}\}\s*closeLegalConsentGate\(\);\s*dispatchUtilsRuntimeEvent\('legal-consent-accepted'\)/.test(legalConsentSrc));
 assert('deferred startup destinations wait behind legal gate',
   /const legalGateShown = scheduleStartupNudges\(\);[\s\S]{0,240}addEventListener\('legal-consent-accepted', openDeferredStartupDestinations[\s\S]{0,120}else \{\s*openDeferredStartupDestinations\(\);\s*\}/.test(startupUiSrc));
 assert('analytics consent and backup nudge resume after legal gate acceptance',

--- a/tests/utils-runtime.test.js
+++ b/tests/utils-runtime.test.js
@@ -3,9 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   addUtilsRuntimeListener,
+  dispatchUtilsRuntimeEvent,
   getAppVersionRuntime,
   getUtilsElementStyleRuntime,
   hasUtilsRuntime,
+  openUtilsRuntimeWindow,
   removeUtilsRuntimeListener,
   registerUtilsRuntimeExports,
 } from '../js/utils-runtime.js';
@@ -56,12 +58,31 @@ describe('utils runtime adapter', () => {
     expect(runtime.openExample()).toBe('ok');
   });
 
+  it('delegates runtime event dispatch and window opening', () => {
+    const dispatchEvent = vi.fn();
+    const open = vi.fn(() => ({ document: {} }));
+    class CustomEventStub {
+      constructor(name, options) {
+        this.type = name;
+        this.detail = options?.detail;
+      }
+    }
+    setRuntimeWindow({ CustomEvent: CustomEventStub, dispatchEvent, open });
+
+    expect(dispatchUtilsRuntimeEvent('demo-event', { ok: true })).toBe(true);
+    expect(dispatchEvent.mock.calls[0][0]).toMatchObject({ type: 'demo-event', detail: { ok: true } });
+    expect(openUtilsRuntimeWindow('/demo', '_blank')).toMatchObject({ document: {} });
+    expect(open).toHaveBeenCalledWith('/demo', '_blank');
+  });
+
   it('uses safe fallbacks when browser runtime hooks are missing', () => {
     delete globalThis.window;
 
     expect(hasUtilsRuntime()).toBe(false);
     expect(getAppVersionRuntime('fallback-version')).toBe('fallback-version');
     expect(registerUtilsRuntimeExports({ openExample: () => 'ok' })).toBe(false);
+    expect(dispatchUtilsRuntimeEvent('demo-event')).toBe(false);
+    expect(openUtilsRuntimeWindow('/demo')).toBeNull();
     expect(addUtilsRuntimeListener('labcharts-sync-applied', vi.fn())).toBe(false);
     expect(removeUtilsRuntimeListener('labcharts-sync-applied', vi.fn())).toBe(false);
     expect(getUtilsElementStyleRuntime({})).toBeNull();

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.128';
+self.APP_VERSION = '1.10.129';


### PR DESCRIPTION
Summary:
- Add shared runtime helpers for browser event dispatch and popup/window opening.
- Route legal consent, feedback, chat summary printing, profile share hash listeners, and chat modal callbacks through runtime adapters.
- Add source/runtime regression coverage and bump version.js to 1.10.129.

Window-burden progress:
- Counted js/ window references are at 32/202 after this PR.

Tests:
- npm test -- --reporter=dot tests/utils-runtime.test.js tests/chat-runtime.test.js
- node tests/test-chat-runtime.js
- node tests/test-chat-actions.js
- node tests/test-correctness-phase2.js
- node tests/test-profile-share.js
- node tests/test-a11y-phase3.js
- node tests/test-modal-lifecycle-integrations.js
- node tests/test-chat-message-delegated-actions.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- git diff --check
- npx playwright test tests/playwright/browser-coverage-batch.spec.js tests/playwright/chat-ui-browser-coverage.spec.js tests/playwright/chat-summary-browser-coverage.spec.js tests/playwright/chat-discussion-browser-coverage.spec.js tests/playwright/profile-share-browser-coverage.spec.js tests/playwright/profile-share-load-browser-coverage.spec.js tests/playwright/startup-helpers-browser-coverage.spec.js --project=chromium
- ./run-tests.sh