### PR TITLE
Delegate host and frame runtime hooks

### DIFF
--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -20,6 +20,7 @@ import { configureMarkerDetailModal } from './marker-detail-modal.js';
 import { renderLightConditionsWidgetBody } from './light-conditions-now.js';
 import { renderDashboardLightChannelPills, renderLightSessionLogActions } from './light-page-view.js';
 import { renderLightTodayHero } from './light-today-ai.js';
+import { navigateViewportRuntime } from './views-router-runtime.js';
 import {
   configureMobileDashboardView,
   getMobileDashboardMarkers,
@@ -46,7 +47,7 @@ export function createDashboardViewComposition({
   let dashboardWidgetControls;
 
   function rerenderDashboardFromWidgetChange() {
-    if (state.currentView === 'dashboard') window.navigate?.('dashboard');
+    if (state.currentView === 'dashboard') navigateViewportRuntime('dashboard');
   }
 
   const dashboardWidgetRenderers = createDashboardWidgetRenderers({

--- a/js/data.js
+++ b/js/data.js
@@ -9,6 +9,7 @@ import { profileStorageKey, touchProfileTimestamp, migrateProfileData } from './
 import { encryptedSetItem, broadcastDataChanged, scheduleAutoBackup } from './crypto.js';
 import { onDataSaved } from './sync.js';
 import { recalculateLabEntryHOMAIR } from './lab-entry.js';
+import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';
 import {
   countFlagged,
   detectTrendAlerts,
@@ -994,11 +995,7 @@ function _captureCategoryCardOrderForRangeRefresh(route) {
 }
 
 function _afterNextPaint(fn) {
-  if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
-    setTimeout(fn, 0);
-    return;
-  }
-  window.requestAnimationFrame(() => setTimeout(fn, 0));
+  scheduleUtilsAfterNextPaint(fn);
 }
 
 export function switchRangeMode(mode) {

--- a/js/light-device-setup-modal.js
+++ b/js/light-device-setup-modal.js
@@ -10,6 +10,7 @@ import { escapeHTML, escapeAttr, showNotification, isDebugMode } from './utils.j
 import { callClaudeAPI, hasAIProvider, supportsVision } from './api.js';
 import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } from './image-utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
+import { getUtilsRuntimeHostname } from './utils-runtime.js';
 
 /**
  * @param {ParentNode} root
@@ -405,7 +406,7 @@ async function _fetchCustomDeviceFromURL(overlay) {
   try {
     // Same fetch path supplements.js uses — /api/fetch-page on localhost,
     // POST /api/proxy on hosted. Reuses the existing trusted-host gates.
-    const isLocal = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const isLocal = ['localhost', '127.0.0.1'].includes(getUtilsRuntimeHostname());
     let html;
     if (isLocal) {
       const res = await fetch('/api/fetch-page?url=' + encodeURIComponent(url));

--- a/js/provider-ppq-panels.js
+++ b/js/provider-ppq-panels.js
@@ -17,6 +17,7 @@ import { updateKeyCache } from './crypto.js';
 import { ensureQRCode } from './provider-qr.js';
 import { renderAIProviderPanel } from './provider-panel-renderers.js';
 import { renderPpqModelDropdown } from './provider-model-controls.js';
+import { callUtilsRuntimeFunction } from './utils-runtime.js';
 
 let returnToChatIfOnboarding = function() {};
 let _ppqCreating = false;
@@ -216,7 +217,7 @@ export async function handleRemovePpqKey() {
     localStorage.removeItem('labcharts-ppq-private-vision-models');
     localStorage.removeItem('labcharts-ppq-credit-id');
     showNotification('PPQ key removed', 'info');
-    window.openSettingsModal?.();
+    callUtilsRuntimeFunction('openSettingsModal');
   }
 }
 

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -15,6 +15,7 @@ import { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } f
 import { openModalOverlay } from './modal-lifecycle.js';
 import { initSupplementActionDelegates, suppActionAttrs } from './supplement-action-delegates.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
+import { getUtilsRuntimeHostname } from './utils-runtime.js';
 import {
   computeAllImpacts,
   computeSupplementImpact,
@@ -392,7 +393,7 @@ async function fetchSupplementFromURL() {
   if (btn instanceof HTMLButtonElement) { btn.textContent = 'Fetching...'; btn.disabled = true; }
   try {
     // Fetch page HTML — use /api/fetch-page on localhost, proxy GET on hosted
-    const isLocal = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const isLocal = ['localhost', '127.0.0.1'].includes(getUtilsRuntimeHostname());
     let html;
     if (isLocal) {
       const res = await fetch('/api/fetch-page?url=' + encodeURIComponent(url));

--- a/js/sync-environment.js
+++ b/js/sync-environment.js
@@ -1,6 +1,8 @@
 // @ts-check
 // sync-environment.js - relay URL and browser capability helpers.
 
+import { getUtilsRuntimeHostname } from './utils-runtime.js';
+
 const SYNC_RELAY_KEY = 'labcharts-sync-relay';
 const DEFAULT_RELAY = 'wss://sync.getbased.health';
 const ONION_RELAY = 'ws://udou6gehyfpfccdjpibmuttaoauawmh5cgzszffnskbvczppvr2sfjad.onion';
@@ -8,7 +10,7 @@ const ONION_RELAY = 'ws://udou6gehyfpfccdjpibmuttaoauawmh5cgzszffnskbvczppvr2sfj
 export function getSyncRelay() {
   const custom = localStorage.getItem(SYNC_RELAY_KEY);
   // On .onion, always use the onion relay (ignore stored clearnet relay)
-  if (window.location.hostname.endsWith('.onion')) return ONION_RELAY;
+  if (getUtilsRuntimeHostname().endsWith('.onion')) return ONION_RELAY;
   return custom || DEFAULT_RELAY;
 }
 

--- a/js/utils-runtime.js
+++ b/js/utils-runtime.js
@@ -17,12 +17,28 @@ export function getAppVersionRuntime(fallback = '') {
   return typeof version === 'string' && version ? version : fallback;
 }
 
+/** @param {string} [fallback] */
+export function getUtilsRuntimeHostname(fallback = '') {
+  const hostname = getUtilsRuntime()?.location?.hostname;
+  return typeof hostname === 'string' ? hostname : fallback;
+}
+
 /** @param {Record<string, any>} exportsByName */
 export function registerUtilsRuntimeExports(exportsByName) {
   const runtime = getUtilsRuntime();
   if (!runtime || !exportsByName) return false;
   Object.assign(runtime, exportsByName);
   return true;
+}
+
+/**
+ * @param {string} name
+ * @param {...any} args
+ */
+export function callUtilsRuntimeFunction(name, ...args) {
+  const runtime = getUtilsRuntime();
+  const fn = runtime?.[name];
+  return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
 }
 
 /**
@@ -49,6 +65,18 @@ export function openUtilsRuntimeWindow(url, target = '_blank', features) {
   if (typeof open !== 'function') return null;
   if (features === undefined) return open.call(runtime, url, target);
   return open.call(runtime, url, target, features);
+}
+
+/** @param {() => void} fn */
+export function scheduleUtilsAfterNextPaint(fn) {
+  const runtime = getUtilsRuntime();
+  const requestAnimationFrame = runtime?.requestAnimationFrame;
+  if (typeof requestAnimationFrame !== 'function') {
+    setTimeout(fn, 0);
+    return false;
+  }
+  requestAnimationFrame.call(runtime, () => setTimeout(fn, 0));
+  return true;
 }
 
 /**

--- a/js/views-router-runtime.js
+++ b/js/views-router-runtime.js
@@ -33,6 +33,11 @@ export function syncImportStatusFabFromRuntime() {
   getRuntimeFunction('syncImportStatusFab')?.();
 }
 
+/** @param {string} view */
+export function navigateViewportRuntime(view) {
+  getRuntimeFunction('navigate')?.(view);
+}
+
 /** @param {() => void} cancel */
 export function addViewportInputCancelListeners(cancel) {
   const runtime = getRuntimeWindow();

--- a/tests/playwright/sync-environment-browser-coverage.spec.js
+++ b/tests/playwright/sync-environment-browser-coverage.spec.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 
 const moduleUrl = path => `${path}?syncEnvironmentCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syncEnvironmentSource = fs.readFileSync(new URL('../../js/sync-environment.js', import.meta.url), 'utf8');
+const utilsRuntimeSource = fs.readFileSync(new URL('../../js/utils-runtime.js', import.meta.url), 'utf8');
 
 async function openBlankPage(page, path) {
   await page.route(`**${path}`, route => route.fulfill({
@@ -23,6 +24,11 @@ async function openOnionPage(page) {
     status: 200,
     contentType: 'application/javascript',
     body: syncEnvironmentSource,
+  }));
+  await page.route('**/js/utils-runtime.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: utilsRuntimeSource,
   }));
   await page.goto('http://relay-check.onion/sync-environment-onion-coverage', { waitUntil: 'load' });
 }

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -587,7 +587,8 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       && /recLinks\.length > 0 && !modalOpen/.test(chartCardRecsSrc));
     assert('data.js: range mode switch paints the active pill before view refresh',
       /function _afterNextPaint\(fn\)/.test(dataSrc)
-      && /window\.requestAnimationFrame\(\(\) => setTimeout\(fn,\s*0\)\)/.test(dataSrc)
+      && dataSrc.includes("import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';")
+      && /scheduleUtilsAfterNextPaint\(fn\)/.test(dataSrc)
       && /const token\s*=\s*\+\+_rangeModeRefreshToken/.test(dataSrc)
       && /_afterNextPaint\(\(\) => \{[\s\S]{0,500}dataWindow\.navigate\(state\.currentView \|\| 'dashboard',\s*data\)/.test(dataSrc));
     assert('range mode refresh preserves current category card order',

--- a/tests/test-views-router-runtime.js
+++ b/tests/test-views-router-runtime.js
@@ -7,6 +7,7 @@ import {
   closeMobileSidebarFromRuntime,
   getViewportHeight,
   getViewportScrollPosition,
+  navigateViewportRuntime,
   restoreViewportScroll,
   scrollViewportBy,
   syncImportStatusFabFromRuntime,
@@ -34,6 +35,7 @@ const runtimeKeys = [
   'removeEventListener',
   'closeMobileSidebar',
   'syncImportStatusFab',
+  'navigate',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -71,11 +73,14 @@ try {
 
   setRuntimeValue('closeMobileSidebar', () => calls.push(['close-sidebar']));
   setRuntimeValue('syncImportStatusFab', () => calls.push(['sync-fab']));
+  setRuntimeValue('navigate', view => calls.push(['navigate', view]));
   closeMobileSidebarFromRuntime();
   syncImportStatusFabFromRuntime();
+  navigateViewportRuntime('dashboard');
   assert('shell callbacks delegate to runtime hooks',
     calls.some(call => call[0] === 'close-sidebar') &&
-    calls.some(call => call[0] === 'sync-fab'));
+    calls.some(call => call[0] === 'sync-fab') &&
+    calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard'));
 
   const listenerAdds = [];
   const listenerRemoves = [];

--- a/tests/utils-runtime.test.js
+++ b/tests/utils-runtime.test.js
@@ -3,13 +3,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   addUtilsRuntimeListener,
+  callUtilsRuntimeFunction,
   dispatchUtilsRuntimeEvent,
   getAppVersionRuntime,
   getUtilsElementStyleRuntime,
+  getUtilsRuntimeHostname,
   hasUtilsRuntime,
   openUtilsRuntimeWindow,
   removeUtilsRuntimeListener,
   registerUtilsRuntimeExports,
+  scheduleUtilsAfterNextPaint,
 } from '../js/utils-runtime.js';
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
@@ -23,6 +26,7 @@ function setRuntimeWindow(runtime) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   if (savedWindow) {
     Object.defineProperty(globalThis, 'window', savedWindow);
   } else {
@@ -58,6 +62,18 @@ describe('utils runtime adapter', () => {
     expect(runtime.openExample()).toBe('ok');
   });
 
+  it('delegates hostname reads and named runtime function calls', () => {
+    const openSettingsModal = vi.fn(section => `opened:${section}`);
+    setRuntimeWindow({
+      location: { hostname: 'localhost' },
+      openSettingsModal,
+    });
+
+    expect(getUtilsRuntimeHostname()).toBe('localhost');
+    expect(callUtilsRuntimeFunction('openSettingsModal', 'data')).toBe('opened:data');
+    expect(openSettingsModal).toHaveBeenCalledWith('data');
+  });
+
   it('delegates runtime event dispatch and window opening', () => {
     const dispatchEvent = vi.fn();
     const open = vi.fn(() => ({ document: {} }));
@@ -75,12 +91,41 @@ describe('utils runtime adapter', () => {
     expect(open).toHaveBeenCalledWith('/demo', '_blank');
   });
 
+  it('schedules callbacks after the next paint when requestAnimationFrame is available', () => {
+    vi.useFakeTimers();
+    const requestAnimationFrame = vi.fn(callback => {
+      callback();
+      return 1;
+    });
+    const callback = vi.fn();
+    setRuntimeWindow({ requestAnimationFrame });
+
+    expect(scheduleUtilsAfterNextPaint(callback)).toBe(true);
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(callback).not.toHaveBeenCalled();
+    vi.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a timer when requestAnimationFrame is unavailable', () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    setRuntimeWindow({});
+
+    expect(scheduleUtilsAfterNextPaint(callback)).toBe(false);
+    expect(callback).not.toHaveBeenCalled();
+    vi.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   it('uses safe fallbacks when browser runtime hooks are missing', () => {
     delete globalThis.window;
 
     expect(hasUtilsRuntime()).toBe(false);
     expect(getAppVersionRuntime('fallback-version')).toBe('fallback-version');
+    expect(getUtilsRuntimeHostname('fallback-host')).toBe('fallback-host');
     expect(registerUtilsRuntimeExports({ openExample: () => 'ok' })).toBe(false);
+    expect(callUtilsRuntimeFunction('openExample')).toBeUndefined();
     expect(dispatchUtilsRuntimeEvent('demo-event')).toBe(false);
     expect(openUtilsRuntimeWindow('/demo')).toBeNull();
     expect(addUtilsRuntimeListener('labcharts-sync-applied', vi.fn())).toBe(false);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.129';
+self.APP_VERSION = '1.10.130';


### PR DESCRIPTION
Summary
- Added shared utility runtime helpers for hostname lookup, named runtime callbacks, and next-paint scheduling.
- Routed supplement/device URL fetch host checks, sync onion relay detection, PPQ settings reopen, dashboard rerender navigation, and range refresh scheduling through adapters.
- Updated adapter/source/browser coverage and bumped version.js to 1.10.130.

Window-burden progress: Counted js/ window references are at 25/202 after this PR.

Tests
- npm test -- --reporter=dot tests/utils-runtime.test.js
- node tests/test-views-router-runtime.js
- node tests/test-sync.js
- node tests/test-provider-panel-delegated-actions.js
- node tests/test-light-devices.js
- node tests/test-v1-6-shipped.js
- node tests/test-correctness-phase2.js
- node tests/test-supplement-impact.js
- node tests/test-dashboard-widget-runtime.js
- node tests/test-dna.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- git diff --check
- npx playwright test tests/playwright/data-browser-coverage.spec.js tests/playwright/supplements-browser-coverage.spec.js tests/playwright/light-devices-browser-coverage.spec.js tests/playwright/provider-coverage-batch.spec.js tests/playwright/sync-environment-browser-coverage.spec.js tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
- ./run-tests.sh