### PR TITLE
Delegate runtime value hooks

### DIFF
--- a/js/context-card-medical-history-editor.js
+++ b/js/context-card-medical-history-editor.js
@@ -12,6 +12,7 @@ import {
   renderNoteField,
   selectCtxOption,
 } from './context-card-editor-ui.js';
+import { callUtilsRuntimeFunction } from './utils-runtime.js';
 
 /** @type {(field: string) => void} */
 let recordContextChange = () => {};
@@ -543,7 +544,7 @@ export function saveDiagnoses() {
 export function closeDiagnoses() {
   editingConditionIndex = -1;
   editingFamilyHistoryIndex = -1;
-  window.closeModal();
+  callUtilsRuntimeFunction('closeModal');
 }
 
 export function clearDiagnoses() {

--- a/js/lens-local-parsers.js
+++ b/js/lens-local-parsers.js
@@ -11,6 +11,7 @@
 // ingest a PDF or DOCX don't pay the parser cost.
 
 import { getPdfDocument } from './pdfjs-loader.js';
+import { getUtilsRuntimeValue } from './utils-runtime.js';
 
 const SUPPORTED_TEXT_EXTS = new Set(['txt', 'md', 'markdown', 'rst', 'json', 'csv', 'log']);
 
@@ -80,7 +81,7 @@ async function extractPdf(file) {
  */
 async function extractDocx(file) {
   await loadScript('/vendor/mammoth.browser.min.js');
-  const mammoth = window.mammoth;
+  const mammoth = getUtilsRuntimeValue('mammoth');
   if (!mammoth) throw new Error('mammoth failed to load');
   const buffer = await file.arrayBuffer();
   const result = await mammoth.extractRawText({ arrayBuffer: buffer });
@@ -97,7 +98,7 @@ async function extractDocx(file) {
  */
 async function extractZip(file) {
   await loadScript('/vendor/jszip.min.js');
-  const JSZip = window.JSZip;
+  const JSZip = getUtilsRuntimeValue('JSZip');
   if (!JSZip) throw new Error('JSZip failed to load');
   const buffer = await file.arrayBuffer();
   const zip = await JSZip.loadAsync(buffer);

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -11,6 +11,7 @@ import { renderProfileContextCards, loadContextHealthDots } from './context-card
 import { computeBiologyScores, getBiologyScoreLensWidgets, renderBiologicalCoherenceLensHero, renderBiologyScoreCoveragePlanner, renderBiologyScoresActionSummary, scheduleBiologyScoreAIReconcile } from './biology-scores.js';
 import { getBiologyProfileContext } from './profile-context.js';
 import { renderBiologyScoreContextAI, hasCurrentBiologyScoreContextReview, hasBiologyScoreContextReview } from './biology-score-context-ai.js';
+import { getRecommendationsSnpTable, isRecommendationsProductRecsEnabled } from './recommendations-runtime.js';
 
 function markerHasData(marker) {
   return marker.values?.some(v => v !== null) ?? false;
@@ -311,7 +312,7 @@ export function createLensPageHandlers(deps) {
       <button type="button" class="dashboard-action-btn" ${lensPageActionAttrs('open-privacy-settings')}>Disclosure & settings</button>`;
     let html = `<div id="recommendations-page">`;
     html += renderLensHeader('Recommendations', 'A global action plan built from Labs, Body, Light, Genome, and Insight signals. Product links stay behind the existing disclosure.', actions);
-    if (!window.isProductRecsEnabled?.()) {
+    if (!isRecommendationsProductRecsEnabled()) {
       html += renderLensWidget('recommendations-disabled', 'Recommendations are off', 'Enable Tips & Recommendations to build this action surface', `<button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${lensPageActionAttrs('open-privacy-settings')}>Open settings</button>`, 'full', { source: 'Recommendations', dashboardId: '' });
       html += `</div>`;
       main.innerHTML = html;
@@ -324,7 +325,7 @@ export function createLensPageHandlers(deps) {
       main.innerHTML = html;
       return;
     }
-    if (state.importedData?.genetics?.snps && !window._snpTableCache) {
+    if (state.importedData?.genetics?.snps && !getRecommendationsSnpTable()) {
       ensureSNPTable().then(() => { if (state.currentView === 'recommendations') showRecommendations(getActiveData()); }).catch(() => {});
     }
     html += `${renderRecommendationsPageGroups(ctx, catalog)}</div>`;

--- a/js/light-device-session-modal.js
+++ b/js/light-device-session-modal.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { BODY_REGIONS } from './sun.js';
+import { getUtilsRuntimeFunction } from './utils-runtime.js';
 
 /**
  * @param {string} name
@@ -12,9 +13,7 @@ import { BODY_REGIONS } from './sun.js';
  * @returns {any}
  */
 function _windowDep(name, fallback = null) {
-  if (typeof window === 'undefined') return fallback;
-  const value = window[name];
-  return typeof value === 'function' ? value : fallback;
+  return getUtilsRuntimeFunction(name) || fallback;
 }
 
 /**

--- a/js/utils-runtime.js
+++ b/js/utils-runtime.js
@@ -23,6 +23,26 @@ export function getUtilsRuntimeHostname(fallback = '') {
   return typeof hostname === 'string' ? hostname : fallback;
 }
 
+/**
+ * @param {string} name
+ * @param {any} [fallback]
+ */
+export function getUtilsRuntimeValue(name, fallback = null) {
+  const runtime = getUtilsRuntime();
+  if (!runtime || !(name in runtime)) return fallback;
+  return runtime[name];
+}
+
+/**
+ * @param {string} name
+ * @returns {Function | null}
+ */
+export function getUtilsRuntimeFunction(name) {
+  const runtime = getUtilsRuntime();
+  const fn = runtime?.[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
+}
+
 /** @param {Record<string, any>} exportsByName */
 export function registerUtilsRuntimeExports(exportsByName) {
   const runtime = getUtilsRuntime();

--- a/tests/utils-runtime.test.js
+++ b/tests/utils-runtime.test.js
@@ -7,7 +7,9 @@ import {
   dispatchUtilsRuntimeEvent,
   getAppVersionRuntime,
   getUtilsElementStyleRuntime,
+  getUtilsRuntimeFunction,
   getUtilsRuntimeHostname,
+  getUtilsRuntimeValue,
   hasUtilsRuntime,
   openUtilsRuntimeWindow,
   removeUtilsRuntimeListener,
@@ -62,15 +64,20 @@ describe('utils runtime adapter', () => {
     expect(runtime.openExample()).toBe('ok');
   });
 
-  it('delegates hostname reads and named runtime function calls', () => {
+  it('delegates hostname reads named runtime values and named runtime function calls', () => {
     const openSettingsModal = vi.fn(section => `opened:${section}`);
+    const mammoth = { extractRawText: vi.fn() };
     setRuntimeWindow({
       location: { hostname: 'localhost' },
+      mammoth,
       openSettingsModal,
     });
 
     expect(getUtilsRuntimeHostname()).toBe('localhost');
+    expect(getUtilsRuntimeValue('mammoth')).toBe(mammoth);
+    expect(getUtilsRuntimeFunction('openSettingsModal')?.('data')).toBe('opened:data');
     expect(callUtilsRuntimeFunction('openSettingsModal', 'data')).toBe('opened:data');
+    expect(openSettingsModal).toHaveBeenCalledTimes(2);
     expect(openSettingsModal).toHaveBeenCalledWith('data');
   });
 
@@ -124,6 +131,8 @@ describe('utils runtime adapter', () => {
     expect(hasUtilsRuntime()).toBe(false);
     expect(getAppVersionRuntime('fallback-version')).toBe('fallback-version');
     expect(getUtilsRuntimeHostname('fallback-host')).toBe('fallback-host');
+    expect(getUtilsRuntimeValue('mammoth', 'fallback-value')).toBe('fallback-value');
+    expect(getUtilsRuntimeFunction('openExample')).toBeNull();
     expect(registerUtilsRuntimeExports({ openExample: () => 'ok' })).toBe(false);
     expect(callUtilsRuntimeFunction('openExample')).toBeUndefined();
     expect(dispatchUtilsRuntimeEvent('demo-event')).toBe(false);

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.130';
+self.APP_VERSION = '1.10.131';


### PR DESCRIPTION
Summary
- Added shared utility runtime accessors for named browser values and bound runtime functions.
- Routed light device session fallback hooks, medical-history modal close, lens recommendation flag/SNP cache, and lens-local vendor parser globals through adapters.
- Bumped version.js to 1.10.131.

Window-burden progress: Counted js/ window references are at 19/202 after this PR.

Tests
- npm test -- --reporter=dot tests/utils-runtime.test.js tests/lens-local-runtime.test.js
- node tests/test-recommendations-runtime.js
- node tests/test-lens-parsers.js
- node tests/test-a11y-phase3.js
- npx playwright test tests/playwright/family-history-dom.spec.js tests/playwright/lens-local-parsers-browser-coverage.spec.js tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js tests/playwright/recommendations-browser-coverage.spec.js tests/playwright/modal-session-coverage-batch.spec.js
- node tests/test-recommendations.js
- node tests/test-dna.js
- node tests/test-correctness-phase2.js
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- git diff --check
- ./run-tests.sh