### PR TITLE
Delegate camera and PDF runtime hooks

### DIFF
--- a/js/light-tool-camera-modals.js
+++ b/js/light-tool-camera-modals.js
@@ -11,6 +11,7 @@ import {
   loadLuxCalibration,
   saveLuxCalibration,
 } from './light-tool-camera.js';
+import { getUtilsRuntimeFunction, getUtilsRuntimeValue } from './utils-runtime.js';
 
 /**
  * @template {Element} T
@@ -70,7 +71,7 @@ export function closeGlassTransmission() { closeCameraTool('close-glass'); }
 
 /** @param {{ saveMeasurement?: AnyFunction }} [deps] */
 function getSaveMeasurement(deps = {}) {
-  const fn = deps.saveMeasurement || (typeof window !== 'undefined' ? window.saveMeasurement : null);
+  const fn = deps.saveMeasurement || getUtilsRuntimeFunction('saveMeasurement');
   if (typeof fn !== 'function') throw new Error('saveMeasurement dependency is required');
   return fn;
 }
@@ -258,9 +259,10 @@ export async function openLuxMeter(opts = {}, deps = {}) {
       if (calibrationPanel) calibrationPanel.style.display = 'none';
     }
   };
-  if ('AmbientLightSensor' in window) {
+  const AmbientLightSensorCtor = getUtilsRuntimeValue('AmbientLightSensor');
+  if (typeof AmbientLightSensorCtor === 'function') {
     try {
-      const sensor = new window.AmbientLightSensor({ frequency: 4 });
+      const sensor = new AmbientLightSensorCtor({ frequency: 4 });
       sensor.addEventListener('reading', () => {
         currentLux = sensor.illuminance;
         renderLux(currentLux);

--- a/js/pdfjs-loader.js
+++ b/js/pdfjs-loader.js
@@ -2,8 +2,10 @@
 // Cached dynamic loader for pdf.js (ESM-only since v4.x). Loads on first
 // PDF interaction rather than on every page load, and pins
 // `isEvalSupported: false` defense-in-depth at the entry point so call
-// sites can't forget it. Also exposes the module on `window.pdfjsLib`
+// sites can't forget it. Also exposes the module through the browser runtime
 // for any legacy reference that hasn't migrated to the loader yet.
+
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 /**
  * @typedef {{ items: Array<{ str?: string, transform?: number[] }> }} PdfTextContent
@@ -36,7 +38,7 @@ export function loadPdfJs() {
     if (!pdfjs.GlobalWorkerOptions.workerSrc) {
       pdfjs.GlobalWorkerOptions.workerSrc = '/vendor/pdf.worker.min.mjs';
     }
-    window.pdfjsLib = pdfjs;
+    registerUtilsRuntimeExports({ pdfjsLib: pdfjs });
     return pdfjs;
   });
   return _pdfjsPromise;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.131';
+self.APP_VERSION = '1.10.132';


### PR DESCRIPTION
Summary
- Routed light camera modal `saveMeasurement` and `AmbientLightSensor` access through shared utility runtime helpers.
- Published the PDF.js legacy runtime binding through `registerUtilsRuntimeExports`.
- Bumped `version.js` to `1.10.132`.

Window-burden progress: Counted `js/` window references are at 15/202 after this PR.

Tests
- `npm test -- --reporter=dot tests/utils-runtime.test.js`
- `node tests/test-light-tools.js`
- `node tests/test-security-phase1.js`
- `npx playwright test tests/playwright/light-tool-camera-modals-browser-coverage.spec.js tests/playwright/light-tool-camera-modals-edge-browser-coverage.spec.js tests/playwright/pdfjs-loader-browser-coverage.spec.js tests/playwright/lens-local-parsers-browser-coverage.spec.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `git diff --check`
- `./run-tests.sh`