### PR TITLE
Delegate state profile runtime hooks

### DIFF
--- a/js/schema.js
+++ b/js/schema.js
@@ -2,6 +2,7 @@
 // schema.js — Marker definitions, unit conversions, pricing, optimal ranges
 
 import { SECONDARY_UNIT_CONVERSIONS } from './secondary-unit-conversions.js';
+import { getUtilsRuntimeFunction } from './utils-runtime.js';
 
 export { PHASE_RANGES, SBM_2015_THRESHOLDS, getEMFSeverity } from './schema-environment.js';
 
@@ -539,7 +540,8 @@ export function trackUsage(provider, modelId, inputTokens, outputTokens) {
     if (inp === 0 && out === 0) return;
 
     // Per-profile
-    const pid = window._getActiveProfileId ? window._getActiveProfileId() : 'default';
+    const getActiveProfileId = getUtilsRuntimeFunction('_getActiveProfileId');
+    const pid = getActiveProfileId ? getActiveProfileId() : 'default';
     const pKey = `labcharts-${pid}-usage`;
     const pu = JSON.parse(localStorage.getItem(pKey) || 'null') || _emptyUsage();
     pu.totalCost += cost; pu.totalInputTokens += inp; pu.totalOutputTokens += out; pu.requestCount++;

--- a/js/startup-orchestrator.js
+++ b/js/startup-orchestrator.js
@@ -11,6 +11,7 @@ import { initializeStartupServices, runPostProfileStartupMaintenance } from './s
 import { installGlobalEventListeners, registerAppRefreshCallback } from './app-event-listeners.js';
 import { showNotification } from './utils.js';
 import { restorePendingImportReviewDraft } from './import-loader.js';
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 let appStarted = false;
 
@@ -39,7 +40,7 @@ export function startApp() {
   if (appStarted) return;
   appStarted = true;
 
-  window._getActiveProfileId = () => state.currentProfile;
+  registerUtilsRuntimeExports({ _getActiveProfileId: () => state.currentProfile });
   installEMFLazyFacade();
   installGlobalEventListeners();
   registerAppRefreshCallback();

--- a/js/state.js
+++ b/js/state.js
@@ -1,6 +1,8 @@
 // @ts-check
 // state.js — Centralized mutable application state
 
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
+
 export const state = {
   chartInstances: {},
   markerRegistry: {},
@@ -25,6 +27,4 @@ export const state = {
   compareDate2: null,
 };
 
-if (typeof window !== 'undefined') {
-  window._labState = state;
-}
+registerUtilsRuntimeExports({ _labState: state });

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -693,7 +693,9 @@ assert('Updates thread metadata on switch', chatPersonalitiesSrc.includes('threa
 // ─── Section 20: state.js exposes _labState ───
 console.log('Section 20: State exposure');
 const stateSrc = read('js/state.js');
-assert('state.js exports _labState to window', stateSrc.includes('window._labState'), 'found');
+assert('state.js exports _labState through runtime adapter',
+  stateSrc.includes('registerUtilsRuntimeExports') && stateSrc.includes('_labState'),
+  'found');
 
 // ─── Cleanup ───
 if (hasState && origHistory) S.chatHistory = origHistory;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.132';
+self.APP_VERSION = '1.10.133';


### PR DESCRIPTION
Summary
- Published `_labState` through `registerUtilsRuntimeExports` instead of a direct state-module browser global assignment.
- Published `_getActiveProfileId` through the same runtime adapter and routed usage tracking through `getUtilsRuntimeFunction`.
- Updated the chat source guard and bumped `version.js` to `1.10.133`.

Window-burden progress: Counted `js/` window references are at 11/202 after this PR.

Tests
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-chat-actions.js`
- `npx playwright test tests/playwright/startup-orchestrator-browser-coverage.spec.js tests/playwright/schema-browser-coverage.spec.js`
- `npm test -- --reporter=dot tests/utils-runtime.test.js`
- `node tests/test-crypto.js`
- `git diff --check`
- `./run-tests.sh`