### PR TITLE
Register chat personality runtime export

### DIFF
--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -15,6 +15,7 @@ import {
   openChatContextModalRuntime,
   renderChatMessagesRuntime,
 } from './chat-runtime.js';
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 const PERSONA_ICONS = ['🧠', '🎭', '🔮', '🌿', '⚡', '🦊', '🧬', '🌊', '🔥', '🏛️'];
 
@@ -581,6 +582,4 @@ IMPORTANT: On the very first line, output ONLY a single emoji that best captures
   if (genBtn) { genBtn.disabled = false; genBtn.textContent = 'Generate'; }
 }
 
-if (typeof window !== 'undefined') {
-  Object.assign(window, { updateChatContextStatus });
-}
+registerUtilsRuntimeExports({ updateChatContextStatus });

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.134';
+self.APP_VERSION = '1.10.135';


### PR DESCRIPTION
Summary
- Registered `updateChatContextStatus` through `registerUtilsRuntimeExports` instead of a direct `Object.assign(window, ...)` block.
- Preserved the browser-global export contract for chat context status refreshes.
- Bumped `version.js` to `1.10.135`.

Window-burden progress: Counted `js/` window references remain at 0/202 after this PR; direct `Object.assign(window, ...)` registrations are down to 31 from 32.

Tests
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-chat-personality-delegated-actions.js`
- `node tests/test-dashboard-knowledge-base.js`
- `npm test -- --reporter=dot tests/chat-runtime.test.js`
- `npx playwright test tests/playwright/custom-personality-dom.spec.js tests/playwright/dashboard-knowledge-base.spec.js`
- `git diff --check`
- `./run-tests.sh`