### PR TITLE
Register feedback runtime exports

### DIFF
--- a/js/feedback.js
+++ b/js/feedback.js
@@ -5,7 +5,7 @@ import { escapeAttr, escapeHTML, showNotification } from './utils.js';
 import { getTheme } from './theme.js';
 import { getAIProvider } from './api.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
-import { openUtilsRuntimeWindow } from './utils-runtime.js';
+import { openUtilsRuntimeWindow, registerUtilsRuntimeExports } from './utils-runtime.js';
 
 const FEEDBACK_TYPES = [
   { value: 'bug', label: 'Bug Report', prefix: '[Bug]', ghLabel: 'bug', placeholder: 'Brief description of the bug' },
@@ -164,4 +164,4 @@ function _updateFeedbackPlaceholder() {
   if (titleInput) titleInput.placeholder = typeDef.placeholder;
 }
 
-Object.assign(window, { openFeedbackModal, closeFeedbackModal, submitFeedback, _updateFeedbackPlaceholder });
+registerUtilsRuntimeExports({ openFeedbackModal, closeFeedbackModal, submitFeedback, _updateFeedbackPlaceholder });

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.135';
+self.APP_VERSION = '1.10.136';


### PR DESCRIPTION
Summary
- Registered feedback modal browser exports through `registerUtilsRuntimeExports` instead of a direct `Object.assign(window, ...)` block.
- Preserved the existing feedback modal global API used by shell actions and tests.
- Bumped `version.js` to `1.10.136`.

Window-burden progress: Counted `js/` window references remain at 0/202 after this PR; direct `Object.assign(window, ...)` registrations are down to 30 from 31.

Tests
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-a11y-phase3.js`
- `node tests/test-shell-delegated-actions.js`
- `npx playwright test tests/playwright/browser-coverage-batch.spec.js tests/playwright/shell-actions-browser-coverage.spec.js`
- `git diff --check`
- `./run-tests.sh`