### PR TITLE
Register chat thread runtime exports

### DIFF
--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -15,6 +15,7 @@ import {
   configureChatThreadSearch, filterThreadList,
   invalidateThreadContentCache, jumpToSearchResult,
 } from './chat-thread-search.js';
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 export { filterThreadList, invalidateThreadContentCache, jumpToSearchResult };
 
@@ -386,23 +387,21 @@ configureChatThreadSearch({
 installChatThreadDelegates();
 
 // Delegated thread actions + chat.js call sites hit these names.
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    loadChatThreads,
-    saveChatThreadIndex,
-    ensureActiveThread,
-    createNewThread,
-    switchToThread,
-    deleteThread,
-    renameThread,
-    renameThreadPrompt,
-    installChatThreadDelegates,
-    autoNameThread,
-    pruneOldThreads,
-    renderThreadList,
-    invalidateThreadContentCache,
-    filterThreadList,
-    jumpToSearchResult,
-    toggleThreadRail,
-  });
-}
+registerUtilsRuntimeExports({
+  loadChatThreads,
+  saveChatThreadIndex,
+  ensureActiveThread,
+  createNewThread,
+  switchToThread,
+  deleteThread,
+  renameThread,
+  renameThreadPrompt,
+  installChatThreadDelegates,
+  autoNameThread,
+  pruneOldThreads,
+  renderThreadList,
+  invalidateThreadContentCache,
+  filterThreadList,
+  jumpToSearchResult,
+  toggleThreadRail,
+});

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.136';
+self.APP_VERSION = '1.10.137';


### PR DESCRIPTION
Summary
- Registered chat thread browser exports through `registerUtilsRuntimeExports` instead of a direct `Object.assign(window, ...)` block.
- Preserved the existing delegated thread action and chat call-site global API.
- Bumped `version.js` to `1.10.137`.

Window-burden progress: Counted `js/` window references remain at 0/202 after this PR; direct `Object.assign(window, ...)` registrations are down to 29 from 30.

Tests
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-chat-threads.js`
- `node tests/test-shell-delegated-actions.js`
- `npx playwright test tests/playwright/chat-threads-dom.spec.js tests/playwright/chat-ui-browser-coverage.spec.js tests/playwright/shell-actions-browser-coverage.spec.js`
- `git diff --check`
- `./run-tests.sh`