### PR TITLE
Register chat image runtime exports

### DIFF
--- a/js/chat-images.js
+++ b/js/chat-images.js
@@ -14,6 +14,7 @@ import { resizeImage, isValidImageType } from './image-utils.js';
 import { hasAIProvider, supportsVision } from './api.js';
 import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 const MAX_ATTACHMENTS = 5;
 const THUMB_SIZE = 80;
@@ -225,9 +226,9 @@ export function initChatImageHandlers() {
   }
 }
 
-// Keep legacy window exports; main.js / chat.js init also wires
+// Keep legacy runtime exports; main.js / chat.js init also wires
 // initChatImageHandlers() on DOMContentLoaded.
-Object.assign(window, {
+registerUtilsRuntimeExports({
   toggleHDMode,
   addImageAttachment,
   removeImageAttachment,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.137';
+self.APP_VERSION = '1.10.138';


### PR DESCRIPTION
Summary
- Register the chat image legacy globals through registerUtilsRuntimeExports instead of direct Object.assign(window, ...).
- Bump version.js for cache invalidation.

Window-burden progress: Counted js/ window references remain at 0/202 after this PR; direct Object.assign(window, ...) registrations are down to 28 from 29.

Tests
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- node tests/test-image-utils.js
- node tests/test-modal-lifecycle-integrations.js
- node tests/test-chat-message-delegated-actions.js
- npx playwright test tests/playwright/chat-ui-browser-coverage.spec.js tests/playwright/chat-actions-dom.spec.js
- git diff --check
- ./run-tests.sh