### PR TITLE
Register Nostr discovery runtime exports

### DIFF
--- a/js/nostr-discovery.js
+++ b/js/nostr-discovery.js
@@ -4,6 +4,7 @@
 
 import { isDebugMode } from './utils.js';
 import { isValidExternalUrl } from './url-safety.js';
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 // ═══════════════════════════════════════════════
 // CONSTANTS
@@ -221,9 +222,9 @@ export function clearNodeCache() {
 }
 
 // ═══════════════════════════════════════════════
-// WINDOW EXPORTS
+// RUNTIME EXPORTS
 // ═══════════════════════════════════════════════
-Object.assign(window, {
+registerUtilsRuntimeExports({
   nostrDiscoverNodes: discoverNodes,
   nostrGetSelectedNode: getSelectedNodeUrl,
   nostrSetSelectedNode: setSelectedNodeUrl,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.138';
+self.APP_VERSION = '1.10.139';


### PR DESCRIPTION
Summary
- Register the Nostr discovery legacy globals through registerUtilsRuntimeExports instead of direct Object.assign(window, ...).
- Rename the local export-section comment to runtime exports and bump version.js for cache invalidation.

Window-burden progress: Counted js/ window references remain at 0/202 after this PR; direct Object.assign(window, ...) registrations are down to 27 from 28.

Tests
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- node tests/test-cashu-wallet.js
- node tests/test-crypto.js
- node tests/test-provider-panel-renderers-runtime.js
- npx playwright test tests/playwright/nostr-chat-continuation-browser-coverage.spec.js tests/playwright/cashu-wallet-browser-coverage.spec.js tests/playwright/report-export-browser-coverage.spec.js tests/playwright/core-browser-flows.spec.js
- git diff --check
- ./run-tests.sh