### PR TITLE
Register chat action runtime exports

### DIFF
--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -12,6 +12,7 @@ import {
   chatMessageActionAttrs,
 } from './chat-message-action-attrs.js';
 import { getChatRegenerateCallbacks, isChatRuntimeStreaming } from './chat-runtime.js';
+import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 let chatMessageDelegatesInstalled = false;
 export { chatMessageActionAttrs } from './chat-message-action-attrs.js';
@@ -206,7 +207,7 @@ export function toggleContextDetails(msgIndex) {
   if (arrow) arrow.textContent = open ? '\u25B8' : '\u25BE';
 }
 
-Object.assign(window, {
+registerUtilsRuntimeExports({
   regenerateLastMessage,
   copyMessage,
   toggleContextDetails,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets window.APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.139';
+self.APP_VERSION = '1.10.140';


### PR DESCRIPTION
Summary
- Register the chat action legacy globals through registerUtilsRuntimeExports instead of direct Object.assign(window, ...).
- Bump version.js for cache invalidation.

Window-burden progress: Counted js/ window references remain at 0/202 after this PR; direct Object.assign(window, ...) registrations are down to 26 from 27.

Tests
- npm run quality
- npm run typecheck
- npm run typecheck:checkjs
- node tests/test-chat-actions.js
- node tests/test-chat-message-delegated-actions.js
- node tests/test-chat-runtime.js
- npx playwright test tests/playwright/chat-actions-dom.spec.js tests/playwright/chat-ui-browser-coverage.spec.js tests/playwright/browser-coverage-batch.spec.js
- git diff --check
- ./run-tests.sh