### PR TITLE
Split Lens local store

### DIFF
--- a/js/lens-local-store.js
+++ b/js/lens-local-store.js
@@ -1,0 +1,118 @@
+// @ts-check
+// Shared OPFS and library-registry helpers for the browser-side Lens worker.
+
+export const OPFS_SUBDIR = 'lens-local';
+export const FILE_MANIFEST = 'manifest.json';
+export const FILE_VECTORS = 'vectors.bin';
+export const FILE_CHUNKS = 'chunks.json';
+export const FILE_LIBRARIES = '_libraries.json';
+export const FILE_LIBRARIES_BACKUP = '_libraries.backup.json';
+export const DEFAULT_LIBRARY_NAME = 'My Library';
+
+export function normaliseLibraryRegistry(registry) {
+  if (!registry || !Array.isArray(registry.libraries)) return null;
+
+  const seen = new Set();
+  const libraries = [];
+  for (const raw of registry.libraries) {
+    const lib = normaliseLibraryRecord(raw);
+    if (!lib || seen.has(lib.id)) continue;
+    seen.add(lib.id);
+    libraries.push(lib);
+  }
+  if (libraries.length === 0) return null;
+
+  let activeId = typeof registry.activeId === 'string' ? registry.activeId : '';
+  if (!libraries.some((lib) => lib.id === activeId)) activeId = libraries[0].id;
+  const revisionNumber = Number(registry.revision);
+  const updatedAtNumber = Number(registry.updatedAt);
+  return {
+    activeId,
+    libraries,
+    revision: Number.isFinite(revisionNumber) && revisionNumber > 0 ? revisionNumber : 0,
+    updatedAt: Number.isFinite(updatedAtNumber) && updatedAtNumber > 0 ? updatedAtNumber : 0,
+  };
+}
+
+export function sameLibraryRegistry(a, b) {
+  if (!a || !b) return false;
+  return a.revision === b.revision
+    && a.activeId === b.activeId
+    && JSON.stringify(a.libraries) === JSON.stringify(b.libraries);
+}
+
+export function normaliseLibraryRecord(raw, fallbackId = '') {
+  const id = String(raw?.id || fallbackId || '').trim();
+  if (!isSafeLibraryId(id)) return null;
+  const name = String(raw?.name || '').trim() || fallbackLibraryName(id);
+  const createdAtNumber = Number(raw?.createdAt);
+  const createdAt = Number.isFinite(createdAtNumber) && createdAtNumber > 0
+    ? createdAtNumber
+    : Date.now();
+  const model = typeof raw?.model === 'string' ? raw.model : undefined;
+  return { id, name, createdAt, model };
+}
+
+export function isSafeLibraryId(id) {
+  return /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(String(id || ''));
+}
+
+export function fallbackLibraryName(id) {
+  if (id === 'default') return DEFAULT_LIBRARY_NAME;
+  const label = String(id || '')
+    .replace(/^lib[-_]?/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+  return label || 'Recovered library';
+}
+
+export function modelKeyFromManifest(manifest, models) {
+  if (!manifest || typeof manifest !== 'object') return '';
+  for (const [key, spec] of Object.entries(models || {})) {
+    if (manifest.modelId === spec.id && Number(manifest.dim) === spec.dim) return key;
+  }
+  return '';
+}
+
+/// Read a text file from a specific directory handle. Thin wrapper over
+/// readBinaryFrom that UTF-8-decodes. Used for manifest.json + chunks.json
+/// + _libraries.json.
+export async function readOpfsFileFrom(dir, name) {
+  const bytes = await readBinaryFrom(dir, name);
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+/// Read an entire file as an ArrayBuffer. The sync-access handle returns a
+/// view backed by a scratch Uint8Array; we copy into a fresh buffer so the
+/// caller can safely use .buffer without worrying about byteOffset on a
+/// subarray view.
+export async function readBinaryFrom(dir, name) {
+  const handle = await dir.getFileHandle(name);
+  const sync = await handle.createSyncAccessHandle();
+  try {
+    const size = sync.getSize();
+    const buf = new Uint8Array(size);
+    sync.read(buf, { at: 0 });
+    const copy = new Uint8Array(buf.byteLength);
+    copy.set(buf);
+    return copy.buffer;
+  } finally {
+    sync.close();
+  }
+}
+
+/// Write bytes atomically to a specific directory: truncate + write +
+/// flush + close. flush() is what guarantees the data actually hit disk
+/// before we return; without it the browser may coalesce writes and lose
+/// data on reload if the tab closes between write and coalesce.
+export async function writeBinaryTo(dir, name, bytes) {
+  const handle = await dir.getFileHandle(name, { create: true });
+  const sync = await handle.createSyncAccessHandle();
+  try {
+    sync.truncate(0);
+    sync.write(bytes, { at: 0 });
+    sync.flush();
+  } finally {
+    sync.close();
+  }
+}

--- a/js/lens-local-worker.js
+++ b/js/lens-local-worker.js
@@ -36,6 +36,23 @@
 // pure WASM. Browser caches it after first load.
 
 import { chunkText, mmrSelect } from './lens-local-utils.js';
+import {
+  DEFAULT_LIBRARY_NAME,
+  FILE_CHUNKS,
+  FILE_LIBRARIES,
+  FILE_LIBRARIES_BACKUP,
+  FILE_MANIFEST,
+  FILE_VECTORS,
+  OPFS_SUBDIR,
+  fallbackLibraryName,
+  isSafeLibraryId,
+  modelKeyFromManifest,
+  normaliseLibraryRegistry,
+  readBinaryFrom,
+  readOpfsFileFrom,
+  sameLibraryRegistry,
+  writeBinaryTo,
+} from './lens-local-store.js';
 
 // Catalog of embedding models available for per-library selection.
 // Each entry names the transformers.js model ID, its output dimension,
@@ -144,14 +161,6 @@ let _vectors = null;            // Active library's packed Float32Array
 let _chunks = null;             // Active library's [{source, text}]
 let _registryRevision = 0;      // Monotonic registry version shared by primary + backup
 let _testFailNextRegistryPersist = false; // mock-mode test hook
-
-const OPFS_SUBDIR = 'lens-local';
-const FILE_MANIFEST = 'manifest.json';
-const FILE_VECTORS = 'vectors.bin';
-const FILE_CHUNKS = 'chunks.json';
-const FILE_LIBRARIES = '_libraries.json'; // top-level, inside /lens-local/
-const FILE_LIBRARIES_BACKUP = '_libraries.backup.json';
-const DEFAULT_LIBRARY_NAME = 'My Library';
 
 // ── Message dispatch ───────────────────────────────────────────────
 //
@@ -615,63 +624,6 @@ async function readLibraryRegistryFile(name) {
   }
 }
 
-function normaliseLibraryRegistry(registry) {
-  if (!registry || !Array.isArray(registry.libraries)) return null;
-
-  const seen = new Set();
-  const libraries = [];
-  for (const raw of registry.libraries) {
-    const lib = normaliseLibraryRecord(raw);
-    if (!lib || seen.has(lib.id)) continue;
-    seen.add(lib.id);
-    libraries.push(lib);
-  }
-  if (libraries.length === 0) return null;
-
-  let activeId = typeof registry.activeId === 'string' ? registry.activeId : '';
-  if (!libraries.some((lib) => lib.id === activeId)) activeId = libraries[0].id;
-  const revisionNumber = Number(registry.revision);
-  const updatedAtNumber = Number(registry.updatedAt);
-  return {
-    activeId,
-    libraries,
-    revision: Number.isFinite(revisionNumber) && revisionNumber > 0 ? revisionNumber : 0,
-    updatedAt: Number.isFinite(updatedAtNumber) && updatedAtNumber > 0 ? updatedAtNumber : 0,
-  };
-}
-
-function sameLibraryRegistry(a, b) {
-  if (!a || !b) return false;
-  return a.revision === b.revision
-    && a.activeId === b.activeId
-    && JSON.stringify(a.libraries) === JSON.stringify(b.libraries);
-}
-
-function normaliseLibraryRecord(raw, fallbackId = '') {
-  const id = String(raw?.id || fallbackId || '').trim();
-  if (!isSafeLibraryId(id)) return null;
-  const name = String(raw?.name || '').trim() || fallbackLibraryName(id);
-  const createdAtNumber = Number(raw?.createdAt);
-  const createdAt = Number.isFinite(createdAtNumber) && createdAtNumber > 0
-    ? createdAtNumber
-    : Date.now();
-  const model = typeof raw?.model === 'string' ? raw.model : undefined;
-  return { id, name, createdAt, model };
-}
-
-function isSafeLibraryId(id) {
-  return /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(String(id || ''));
-}
-
-function fallbackLibraryName(id) {
-  if (id === 'default') return DEFAULT_LIBRARY_NAME;
-  const label = String(id || '')
-    .replace(/^lib[-_]?/, '')
-    .replace(/[-_]+/g, ' ')
-    .trim();
-  return label || 'Recovered library';
-}
-
 async function discoverLibraryDirectories() {
   if (!_rootDir || typeof _rootDir.entries !== 'function') return [];
 
@@ -684,7 +636,7 @@ async function discoverLibraryDirectories() {
       manifest = JSON.parse(await readOpfsFileFrom(handle, FILE_MANIFEST));
     } catch {}
 
-    const model = modelKeyFromManifest(manifest) || DEFAULT_MODEL_KEY;
+    const model = modelKeyFromManifest(manifest, MODELS) || DEFAULT_MODEL_KEY;
     const indexedAt = Number(manifest?.indexedAt);
     libraries.push({
       id,
@@ -719,7 +671,7 @@ async function reconcileLibrariesWithDisk({ recoverOrphans = false } = {}) {
     }
     byId.delete(lib.id);
 
-    const diskModel = modelKeyFromManifest(disk.manifest);
+    const diskModel = modelKeyFromManifest(disk.manifest, MODELS);
     if ((!lib.model || !MODELS[lib.model]) && diskModel) {
       lib.model = diskModel;
       changed = true;
@@ -749,14 +701,6 @@ async function reconcileLibrariesWithDisk({ recoverOrphans = false } = {}) {
   }
 
   return { changed };
-}
-
-function modelKeyFromManifest(manifest) {
-  if (!manifest || typeof manifest !== 'object') return '';
-  for (const [key, spec] of Object.entries(MODELS)) {
-    if (manifest.modelId === spec.id && Number(manifest.dim) === spec.dim) return key;
-  }
-  return '';
 }
 
 async function loadActiveManifest() {
@@ -1174,49 +1118,6 @@ async function persistAll() {
   await writeBinaryTo(dir, FILE_MANIFEST, new TextEncoder().encode(JSON.stringify(_manifest)));
   await writeBinaryTo(dir, FILE_VECTORS, new Uint8Array(_vectors.buffer, _vectors.byteOffset, _vectors.byteLength));
   await writeBinaryTo(dir, FILE_CHUNKS, new TextEncoder().encode(JSON.stringify(_chunks)));
-}
-
-/// Read a text file from a specific directory handle. Thin wrapper over
-/// readBinaryFrom that UTF-8-decodes. Used for manifest.json + chunks.json
-/// + _libraries.json.
-async function readOpfsFileFrom(dir, name) {
-  const bytes = await readBinaryFrom(dir, name);
-  return new TextDecoder().decode(new Uint8Array(bytes));
-}
-
-/// Read an entire file as an ArrayBuffer. The sync-access handle returns a
-/// view backed by a scratch Uint8Array; we copy into a fresh buffer so the
-/// caller can safely use .buffer without worrying about byteOffset on a
-/// subarray view.
-async function readBinaryFrom(dir, name) {
-  const handle = await dir.getFileHandle(name);
-  const sync = await handle.createSyncAccessHandle();
-  try {
-    const size = sync.getSize();
-    const buf = new Uint8Array(size);
-    sync.read(buf, { at: 0 });
-    const copy = new Uint8Array(buf.byteLength);
-    copy.set(buf);
-    return copy.buffer;
-  } finally {
-    sync.close();
-  }
-}
-
-/// Write bytes atomically to a specific directory: truncate + write +
-/// flush + close. flush() is what guarantees the data actually hit disk
-/// before we return; without it the browser may coalesce writes and lose
-/// data on reload if the tab closes between write and coalesce.
-async function writeBinaryTo(dir, name, bytes) {
-  const handle = await dir.getFileHandle(name, { create: true });
-  const sync = await handle.createSyncAccessHandle();
-  try {
-    sync.truncate(0);
-    sync.write(bytes, { at: 0 });
-    sync.flush();
-  } finally {
-    sync.close();
-  }
 }
 
 /// Backward-compat shim: writeSync against the root lens-local/ dir. Used

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -2,5 +2,5 @@
   "inlineEventAttributes": 0,
   "windowReferences": 202,
   "largeJsFilesOver800Lines": 28,
-  "maxJsFileLines": 1252
+  "maxJsFileLines": 1216
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -468,6 +468,7 @@ const APP_SHELL = [
   '/js/lens-url.js',
   '/js/lens.js',
   '/js/lens-local.js',
+  '/js/lens-local-store.js',
   '/js/lens-local-worker.js',
   '/js/lens-local-utils.js',
   '/js/lens-local-parsers.js',

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -96,6 +96,7 @@ assert('SW APP_SHELL includes lens action delegates module', swAuditSrc.includes
 assert('SW APP_SHELL includes lens library handlers module', swAuditSrc.includes("'/js/lens-library.js'"));
 assert('SW APP_SHELL includes lens cache helper module', swAuditSrc.includes("'/js/lens-cache.js'"));
 assert('SW APP_SHELL includes lens URL helper module', swAuditSrc.includes("'/js/lens-url.js'"));
+assert('SW APP_SHELL includes lens local store helper module', swAuditSrc.includes("'/js/lens-local-store.js'"));
 assert('SW APP_SHELL includes DNA action delegates module', swAuditSrc.includes("'/js/dna-actions.js'"));
 assert('SW APP_SHELL includes DNA genotype helper module', swAuditSrc.includes("'/js/dna-genotype.js'"));
 assert('SW APP_SHELL includes DNA mtDNA helper module', swAuditSrc.includes("'/js/dna-mtdna.js'"));

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -205,6 +205,7 @@ const pwaAppShellAssets = [
   '/js/lens-library.js',
   '/js/dna-mtdna.js',
   '/js/lens-local.js',
+  '/js/lens-local-store.js',
   '/js/lens-local-worker.js',
   '/js/lens-local-utils.js',
   '/js/lens-local-parsers.js',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -211,6 +211,7 @@ const uiWorkflowCheckJsModules = [
   'js/lens-actions.js',
   'js/lens-cache.js',
   'js/lens-library.js',
+  'js/lens-local-store.js',
   'js/lens-local-worker.js',
   'js/lens-local.js',
   'js/lens-page-shell.js',

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -117,6 +117,7 @@
     "js/lens-actions.js",
     "js/lens-cache.js",
     "js/lens-library.js",
+    "js/lens-local-store.js",
     "js/lens-local-worker.js",
     "js/lens-local.js",
     "js/lens-page-shell.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -125,6 +125,7 @@
     "js/lens.js",
     "js/lens-local.js",
     "js/lens-local-parsers.js",
+    "js/lens-local-store.js",
     "js/lens-local-utils.js",
     "js/lens-local-worker.js",
     "js/light-audit-ai-analysis.js",


### PR DESCRIPTION
## Summary

- Extract Lens local worker OPFS file helpers and library registry normalization into `js/lens-local-store.js`.
- Keep the worker entry point responsible for message dispatch, active-library state, ingest/query/delete flows, and embedder lifecycle.
- Register the new worker dependency in the service worker app shell, typecheck configs, and static guard tests.
- Ratchet the JS LOC hard cap from 1252 to 1216 after the split.

## Validation

- `node --check js/lens-local-worker.js`
- `node --check js/lens-local-store.js`
- `node tests/test-audit.js`
- `node tests/test-correctness-phase2.js`
- `node tests/test-quality-guardrails.js`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/verify-modules.js`
- `npm test`
- `npm run test:playwright -- tests/playwright/lens-local-worker-browser-coverage.spec.js`