### PR TITLE
Protect encrypted chat thread index

### DIFF
--- a/js/chat-discussion-round-state.js
+++ b/js/chat-discussion-round-state.js
@@ -53,7 +53,7 @@ export async function saveRoundChatHistory(threadId, messages) {
   if (thread) {
     if (thread.messageCount !== messages.length) thread.updatedAt = new Date().toISOString();
     thread.messageCount = messages.length;
-    saveChatThreadIndex();
+    await saveChatThreadIndex();
     renderThreadList();
   }
 }

--- a/js/chat-history.js
+++ b/js/chat-history.js
@@ -50,7 +50,7 @@ export async function saveChatHistory() {
     const p = getActivePersonality();
     thread.personalityName = p.name;
     thread.personalityIcon = p.icon;
-    saveChatThreadIndex();
+    await saveChatThreadIndex();
     renderThreadList();
   }
 }
@@ -68,7 +68,7 @@ export async function clearChatHistory() {
         delete thread.summaryDate;
         delete thread.summaryModel;
         delete thread.summaryCost;
-        saveChatThreadIndex();
+        await saveChatThreadIndex();
         renderThreadList();
         if (state.importedData.chatSummaries) {
           deleteImportedArrayItems(state.importedData, 'chatSummaries', s => s.threadId === state.currentThreadId);

--- a/js/chat-marker-prompts.js
+++ b/js/chat-marker-prompts.js
@@ -12,7 +12,8 @@ import { closeChatModalRuntime } from './chat-runtime.js';
 
 async function openSourcePrompt(prompt, threadName, { closeModal = false } = {}) {
   if (closeModal) closeChatModalRuntime();
-  loadChatThreads();
+  const threadsLoaded = await loadChatThreads();
+  if (threadsLoaded === false) return;
   ensureActiveThread();
   await loadChatHistory();
   if (state.chatHistory.length > 0) {

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -19,6 +19,7 @@ export { setChatNudge, updateChatNudge } from './chat-nudge.js';
 const panelCallbacks = {
   restoreDiscussionContinuePrompt: null,
 };
+let chatThreadInputBlocked = false;
 
 /** @param {{ restoreDiscussionContinuePrompt?: (() => void) | null }} [callbacks] */
 export function configureChatPanel(callbacks = {}) {
@@ -44,6 +45,10 @@ function updateWebSearchToggleVisibility() {
 
 export function refreshWebSearchToggle() {
   updateWebSearchToggleVisibility();
+}
+
+export function isChatThreadInputBlocked() {
+  return chatThreadInputBlocked;
 }
 
 // ═══════════════════════════════════════════════
@@ -107,6 +112,7 @@ export async function openChatPanel(prefillMessage) {
   updateWebSearchToggleVisibility();
   // Load threads and ensure active thread
   const threadsLoaded = await loadChatThreads();
+  chatThreadInputBlocked = threadsLoaded === false;
   if (threadsLoaded !== false) ensureActiveThread();
   restoreRailState();
   renderThreadList();
@@ -115,7 +121,7 @@ export async function openChatPanel(prefillMessage) {
   panelCallbacks.restoreDiscussionContinuePrompt?.();
   updateChatInputState();
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('chat-input'));
-  if (input) {
+  if (input && !chatThreadInputBlocked) {
     if (prefillMessage) input.value = prefillMessage;
     input.focus();
   }
@@ -125,13 +131,16 @@ export function updateChatInputState() {
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('chat-input'));
   const sendBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('chat-send-btn'));
   const noAI = !hasAIProvider();
+  const blocked = chatThreadInputBlocked;
   if (input) {
-    input.disabled = noAI;
-    input.placeholder = noAI
-      ? (isAIPaused() ? 'AI features are paused' : 'Connect an AI provider in Settings to chat')
-      : 'Ask about your lab results...';
+    input.disabled = noAI || blocked;
+    input.placeholder = blocked
+      ? 'Conversations are paused to protect saved chats'
+      : noAI
+        ? (isAIPaused() ? 'AI features are paused' : 'Connect an AI provider in Settings to chat')
+        : 'Ask about your lab results...';
   }
-  if (sendBtn) sendBtn.disabled = noAI;
+  if (sendBtn) sendBtn.disabled = noAI || blocked;
   updateWebSearchToggleVisibility();
 }
 

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -106,12 +106,12 @@ export async function openChatPanel(prefillMessage) {
   if (wsCb) wsCb.checked = getChatWebSearchEnabled();
   updateWebSearchToggleVisibility();
   // Load threads and ensure active thread
-  loadChatThreads();
-  ensureActiveThread();
+  const threadsLoaded = await loadChatThreads();
+  if (threadsLoaded !== false) ensureActiveThread();
   restoreRailState();
   renderThreadList();
   renderSavedSummaries();
-  await loadChatHistory();
+  if (threadsLoaded !== false) await loadChatHistory();
   panelCallbacks.restoreDiscussionContinuePrompt?.();
   updateChatInputState();
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('chat-input'));

--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -206,7 +206,7 @@ export async function setChatPersonality(id, opts = {}) {
     const p = getActivePersonality();
     thread.personalityName = p.name;
     thread.personalityIcon = p.icon;
-    saveChatThreadIndex();
+    await saveChatThreadIndex();
   }
   if (state.chatHistory.length === 0) {
     renderChatMessagesRuntime();

--- a/js/chat-send.js
+++ b/js/chat-send.js
@@ -33,7 +33,7 @@ import {
 } from './chat-personalities.js';
 import { saveChatHistory } from './chat-history.js';
 import { buildActionBar, chatMessageActionAttrs } from './chat-actions.js';
-import { getChatWebSearchEnabled } from './chat-panel.js';
+import { getChatWebSearchEnabled, isChatThreadInputBlocked } from './chat-panel.js';
 import {
   getCurrentDiscussionState, sendDiscussionUserTurn, updateDiscussButton,
 } from './chat-discussion.js';
@@ -126,6 +126,10 @@ export function updateSendButtonState() {
   const sendBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('chat-send-btn'));
   if (!sendBtn) return;
   const hasContent = (input && input.value.trim()) || hasPendingAttachments();
+  if (input?.disabled && !_chatAbortController) {
+    sendBtn.disabled = true;
+    return;
+  }
   sendBtn.disabled = !hasContent && !_chatAbortController;
 }
 configureChatImages({ updateSendButtonState });
@@ -160,6 +164,7 @@ export async function sendChatMessage() {
     _chatAbortController = null;
     return;
   }
+  if (isChatThreadInputBlocked()) return;
 
   const input = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('chat-input'));
   const sendBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('chat-send-btn'));
@@ -175,6 +180,7 @@ export async function sendChatMessage() {
   // Ensure we have a thread
   if (!state.currentThreadId) {
     createNewThread();
+    if (!state.currentThreadId) return;
   }
 
   const discussionState = text && !hasImages ? getCurrentDiscussionState() : null;

--- a/js/chat-summaries.js
+++ b/js/chat-summaries.js
@@ -134,7 +134,7 @@ async function _generateSummary() {
     thread.summaryDate = now;
     thread.summaryModel = _modelDisplay;
     if (costInfo) thread.summaryCost = costInfo;
-    saveChatThreadIndex();
+    await saveChatThreadIndex();
 
     await _saveSummaryToProfile({
       id: 's_' + Date.now().toString(36),

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -11,6 +11,7 @@ import { deleteImportedArrayItems } from './data-merge.js';
 import { onChatSaved } from './sync.js';
 import { chatDeletedThreadsKey } from './sync-payload-collectors.js';
 import { CHAT_PERSONALITIES } from './constants.js';
+import { encryptedGetItem } from './crypto.js';
 import {
   configureChatThreadSearch, filterThreadList,
   invalidateThreadContentCache, jumpToSearchResult,
@@ -24,6 +25,8 @@ const THREAD_ICON_EDIT = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M
 const THREAD_ICON_DELETE = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>';
 const CHAT_DELETED_PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 let chatThreadDelegatesInstalled = false;
+let blockedThreadIndexKey = null;
+let blockedThreadIndexNoticeShown = false;
 const noop = () => {};
 const asyncNoop = async () => {};
 const defaultPersonality = () => ({ name: 'Default', icon: '' });
@@ -76,53 +79,117 @@ function generateThreadId() {
   return 't_' + Date.now().toString(36);
 }
 
+function clearThreadIndexWriteBlock(key) {
+  if (blockedThreadIndexKey !== key) return;
+  blockedThreadIndexKey = null;
+  blockedThreadIndexNoticeShown = false;
+}
+
+function blockThreadIndexWrites(key) {
+  if (blockedThreadIndexKey !== key) blockedThreadIndexNoticeShown = false;
+  blockedThreadIndexKey = key;
+}
+
+function isThreadIndexWriteBlocked(key = getChatThreadsKey()) {
+  return blockedThreadIndexKey === key;
+}
+
+function notifyThreadIndexBlocked() {
+  if (blockedThreadIndexNoticeShown) return;
+  blockedThreadIndexNoticeShown = true;
+  showNotification('Conversations could not be read, so new chat creation is paused to protect saved chats.', 'error', 6000);
+}
+
+function parseThreadIndex(raw) {
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : null;
+}
+
 // ═══════════════════════════════════════════════
 // THREAD INDEX CRUD
 // ═══════════════════════════════════════════════
-export function loadChatThreads() {
-  const raw = localStorage.getItem(getChatThreadsKey());
-  if (raw) {
-    try {
-      state.chatThreads = JSON.parse(raw);
-    } catch { state.chatThreads = []; }
-  } else {
-    // Migration: convert legacy flat chat array to a thread
-    state.chatThreads = [];
-    const legacyKey = `labcharts-${state.currentProfile}-chat`;
-    const legacyRaw = localStorage.getItem(legacyKey);
-    if (legacyRaw) {
-      try {
-        const messages = JSON.parse(legacyRaw);
-        if (Array.isArray(messages) && messages.length > 0) {
-          const threadId = 't_migrated';
-          const now = new Date().toISOString();
-          state.chatThreads = [{
-            id: threadId,
-            name: 'Previous Chat',
-            createdAt: now,
-            updatedAt: now,
-            messageCount: messages.length,
-            personality: state.currentChatPersonality || 'default'
-          }];
-          // Write per-thread messages (plaintext — encryption handled by save)
-          localStorage.setItem(getChatThreadKey(threadId), legacyRaw);
-          saveChatThreadIndex();
-          // Leave legacy key in place for rollback safety
-        }
-      } catch {}
+export async function loadChatThreads() {
+  const key = getChatThreadsKey();
+  const storedRaw = localStorage.getItem(key);
+  if (storedRaw !== null) {
+    let raw = null;
+    try { raw = await encryptedGetItem(key); } catch { raw = null; }
+    if (raw === null) {
+      blockThreadIndexWrites(key);
+      notifyThreadIndexBlocked();
+      return false;
     }
+    try {
+      const threads = parseThreadIndex(raw);
+      if (!threads) throw new Error('Invalid chat thread index');
+      state.chatThreads = threads;
+      clearThreadIndexWriteBlock(key);
+      return true;
+    } catch {
+      blockThreadIndexWrites(key);
+      notifyThreadIndexBlocked();
+      return false;
+    }
+  }
+
+  // Migration: convert legacy flat chat array to a thread.
+  clearThreadIndexWriteBlock(key);
+  state.chatThreads = [];
+  const legacyKey = `labcharts-${state.currentProfile}-chat`;
+  const legacyStoredRaw = localStorage.getItem(legacyKey);
+  if (legacyStoredRaw === null) return true;
+
+  let legacyRaw = null;
+  try { legacyRaw = await encryptedGetItem(legacyKey); } catch { legacyRaw = null; }
+  if (legacyRaw === null) {
+    blockThreadIndexWrites(key);
+    notifyThreadIndexBlocked();
+    return false;
+  }
+  try {
+    const messages = JSON.parse(legacyRaw);
+    if (Array.isArray(messages) && messages.length > 0) {
+      const threadId = 't_migrated';
+      const now = new Date().toISOString();
+      state.chatThreads = [{
+        id: threadId,
+        name: 'Previous Chat',
+        createdAt: now,
+        updatedAt: now,
+        messageCount: messages.length,
+        personality: state.currentChatPersonality || 'default'
+      }];
+      // Write per-thread messages (plaintext — encryption handled by save)
+      localStorage.setItem(getChatThreadKey(threadId), legacyRaw);
+      saveChatThreadIndex();
+      // Leave legacy key in place for rollback safety
+    }
+    return true;
+  } catch {
+    blockThreadIndexWrites(key);
+    notifyThreadIndexBlocked();
+    return false;
   }
 }
 
 export function saveChatThreadIndex({ sync = true } = {}) {
+  if (isThreadIndexWriteBlocked()) {
+    notifyThreadIndexBlocked();
+    return false;
+  }
   localStorage.setItem(getChatThreadsKey(), JSON.stringify(state.chatThreads));
   if (sync) onChatSaved();
+  return true;
 }
 
 export function ensureActiveThread() {
+  if (isThreadIndexWriteBlocked()) {
+    notifyThreadIndexBlocked();
+    return false;
+  }
   if (state.currentThreadId) {
     const exists = state.chatThreads.find(t => t.id === state.currentThreadId);
-    if (exists) return;
+    if (exists) return true;
   }
   // Pick most recent thread or create new
   if (state.chatThreads.length > 0) {
@@ -131,9 +198,14 @@ export function ensureActiveThread() {
   } else {
     createNewThread({ sync: false });
   }
+  return true;
 }
 
 export function createNewThread({ sync = true } = {}) {
+  if (isThreadIndexWriteBlocked()) {
+    notifyThreadIndexBlocked();
+    return null;
+  }
   const id = generateThreadId();
   const now = new Date().toISOString();
   const p = chatThreadDeps.getActivePersonality() || defaultPersonality();

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -11,7 +11,7 @@ import { deleteImportedArrayItems } from './data-merge.js';
 import { onChatSaved } from './sync.js';
 import { chatDeletedThreadsKey } from './sync-payload-collectors.js';
 import { CHAT_PERSONALITIES } from './constants.js';
-import { encryptedGetItem } from './crypto.js';
+import { encryptedGetItem, encryptedSetItem } from './crypto.js';
 import {
   configureChatThreadSearch, filterThreadList,
   invalidateThreadContentCache, jumpToSearchResult,
@@ -159,9 +159,8 @@ export async function loadChatThreads() {
         messageCount: messages.length,
         personality: state.currentChatPersonality || 'default'
       }];
-      // Write per-thread messages (plaintext — encryption handled by save)
-      localStorage.setItem(getChatThreadKey(threadId), legacyRaw);
-      saveChatThreadIndex();
+      await encryptedSetItem(getChatThreadKey(threadId), legacyRaw);
+      await saveChatThreadIndex();
       // Leave legacy key in place for rollback safety
     }
     return true;
@@ -177,9 +176,18 @@ export function saveChatThreadIndex({ sync = true } = {}) {
     notifyThreadIndexBlocked();
     return false;
   }
-  localStorage.setItem(getChatThreadsKey(), JSON.stringify(state.chatThreads));
-  if (sync) onChatSaved();
-  return true;
+  const key = getChatThreadsKey();
+  const value = JSON.stringify(state.chatThreads);
+  return encryptedSetItem(key, value)
+    .then(() => {
+      if (sync) onChatSaved();
+      return true;
+    })
+    .catch((err) => {
+      console.warn('[chat-threads] failed to save thread index', err?.message || err);
+      showNotification('Could not save conversation list', 'error');
+      return false;
+    });
 }
 
 export function ensureActiveThread() {
@@ -263,7 +271,7 @@ export async function deleteThread(threadId) {
     recordDeletedChatThread(threadId);
     // Remove from index
     state.chatThreads = state.chatThreads.filter(t => t.id !== threadId);
-    saveChatThreadIndex();
+    await saveChatThreadIndex();
     // Remove per-thread messages
     localStorage.removeItem(getChatThreadKey(threadId));
     // Remove saved summary

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -109,7 +109,7 @@ async function refreshChatThreadsRuntime(chatThreads) {
   const renderThreadList = getRuntimeFunction(chatThreads, 'renderThreadList');
   let threadsLoaded = true;
 
-  if (loadChatThreads) await loadChatThreads();
+  if (loadChatThreads) threadsLoaded = await loadChatThreads() !== false;
   else threadsLoaded = await loadChatThreadsFromStorageFallback();
   if (!threadsLoaded) return;
 

--- a/js/profile-runtime.js
+++ b/js/profile-runtime.js
@@ -30,9 +30,9 @@ export async function reloadProfileRuntimeShell(profileId) {
   ]);
 
   chatPersonalities.loadChatPersonality();
-  chatThreads.loadChatThreads?.();
-  if (state.chatThreads.length > 0) chatThreads.ensureActiveThread?.();
-  await chatHistory.loadChatHistory?.();
+  const threadsLoaded = await chatThreads.loadChatThreads?.();
+  if (threadsLoaded !== false && state.chatThreads.length > 0) chatThreads.ensureActiveThread?.();
+  if (threadsLoaded !== false) await chatHistory.loadChatHistory?.();
   if (state.currentProfile !== profileId) return;
 
   chatThreads.renderThreadList?.();

--- a/js/sync-chat-apply.js
+++ b/js/sync-chat-apply.js
@@ -39,9 +39,10 @@ export function getChatDataLocalLockRemainingMs(profileId) {
 }
 
 /** @param {string} profileId */
-function hasMeaningfulLocalChatData(profileId) {
+async function hasMeaningfulLocalChatData(profileId) {
   try {
-    const raw = localStorage.getItem(`labcharts-${profileId}-chat-threads`);
+    const key = `labcharts-${profileId}-chat-threads`;
+    const raw = await encryptedGetItem(key) || localStorage.getItem(key);
     const threads = raw ? JSON.parse(raw) : [];
     if (!Array.isArray(threads)) return false;
     return threads.some(thread => (Number(thread?.messageCount) || 0) > 0);
@@ -51,9 +52,9 @@ function hasMeaningfulLocalChatData(profileId) {
 }
 
 /** @param {string} profileId */
-function shouldKeepLocalChatData(profileId) {
+async function shouldKeepLocalChatData(profileId) {
   return getChatDataLocalLockRemainingMs(profileId) > 0
-    && hasMeaningfulLocalChatData(profileId);
+    && await hasMeaningfulLocalChatData(profileId);
 }
 
 /** @param {any} thread */
@@ -128,7 +129,7 @@ async function applyChatThreadTombstones(profileId, existingThreads, deletedThre
     keptThreads.push(thread);
   }
   if (changed) {
-    localStorage.setItem(`labcharts-${profileId}-chat-threads`, JSON.stringify(keptThreads));
+    await encryptedSetItem(`labcharts-${profileId}-chat-threads`, JSON.stringify(keptThreads));
   }
   return changed;
 }
@@ -138,8 +139,8 @@ async function applyChatThreadTombstones(profileId, existingThreads, deletedThre
  */
 export async function applyChatData(profileId, chatData) {
   if (!chatData || !Array.isArray(chatData.threads)) return false;
-  // Thread index: always plain localStorage (matches saveChatThreadIndex in chat.js).
-  // encryptAllSensitiveKeys handles at-rest encryption when session ends.
+  // The thread index is a sensitive key, so writes must use the same encrypted
+  // wrapper as normal chat saves.
   const threadsKey = `labcharts-${profileId}-chat-threads`;
   const existingRaw = await encryptedGetItem(threadsKey) || localStorage.getItem(threadsKey);
   let existingThreads = [];
@@ -155,7 +156,7 @@ export async function applyChatData(profileId, chatData) {
   }
   const tombstonesChanged = await applyChatThreadTombstones(profileId, existingThreads, deletedThreads);
 
-  if (shouldKeepLocalChatData(profileId)) {
+  if (await shouldKeepLocalChatData(profileId)) {
     writeLocalDeletedThreads(profileId, deletedThreads);
     dbg(`Skipped chatData for ${profileId.slice(0, 8)} - local chat has newer unsynced changes`);
     logSyncEvent('skip', `Chat pull skipped ${profileId.slice(0, 8)} - local changes pending`);
@@ -183,7 +184,7 @@ export async function applyChatData(profileId, chatData) {
 
   const mergedThreads = Array.from(mergedById.values())
     .sort((a, b) => (threadUpdatedAtMs(b) - threadUpdatedAtMs(a)) || String(a.id).localeCompare(String(b.id)));
-  localStorage.setItem(threadsKey, JSON.stringify(mergedThreads));
+  await encryptedSetItem(threadsKey, JSON.stringify(mergedThreads));
 
   for (const thread of existingThreads) {
     if (!thread || typeof thread.id !== 'string') continue;

--- a/js/sync-chat-apply.js
+++ b/js/sync-chat-apply.js
@@ -4,7 +4,7 @@
 import { state } from './state.js';
 import { isDebugMode } from './utils.js';
 import {
-  getEncryptionEnabled, encryptedSetItem, encryptedGetItem, encryptedRemoveItem,
+  getEncryptionEnabled, isUnlocked, encryptedSetItem, encryptedGetItem, encryptedRemoveItem,
 } from './crypto.js';
 import { chatDeletedThreadsKey } from './sync-payload-collectors.js';
 import { logSyncEvent } from './sync-state.js';
@@ -139,6 +139,11 @@ async function applyChatThreadTombstones(profileId, existingThreads, deletedThre
  */
 export async function applyChatData(profileId, chatData) {
   if (!chatData || !Array.isArray(chatData.threads)) return false;
+  if (getEncryptionEnabled() && !isUnlocked()) {
+    dbg(`Skipped chatData for ${profileId.slice(0, 8)} - encryption is locked`);
+    logSyncEvent('skip', `Chat pull skipped ${profileId.slice(0, 8)} - encryption locked`);
+    return false;
+  }
   // The thread index is a sensitive key, so writes must use the same encrypted
   // wrapper as normal chat saves.
   const threadsKey = `labcharts-${profileId}-chat-threads`;

--- a/js/sync-pull-active-refresh-runtime.js
+++ b/js/sync-pull-active-refresh-runtime.js
@@ -17,10 +17,21 @@ function getRuntimeFunction(name) {
 }
 
 export function refreshPulledChatRuntime() {
-  getRuntimeFunction('loadChatThreads')?.();
-  getRuntimeFunction('ensureActiveThread')?.();
-  getRuntimeFunction('renderThreadList')?.();
-  getRuntimeFunction('loadChatHistory')?.();
+  const finishRefresh = (threadsLoaded) => {
+    if (threadsLoaded === false) {
+      getRuntimeFunction('renderThreadList')?.();
+      return false;
+    }
+    getRuntimeFunction('ensureActiveThread')?.();
+    getRuntimeFunction('renderThreadList')?.();
+    return getRuntimeFunction('loadChatHistory')?.();
+  };
+
+  const loaded = getRuntimeFunction('loadChatThreads')?.();
+  if (loaded && typeof loaded.then === 'function') {
+    return loaded.then(finishRefresh);
+  }
+  return finishRefresh(loaded);
 }
 
 export function rebuildPulledSidebarRuntime() {

--- a/tests/playwright/chat-ui-browser-coverage.spec.js
+++ b/tests/playwright/chat-ui-browser-coverage.spec.js
@@ -310,7 +310,10 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
   await page.waitForSelector('#chat-panel');
 
   const results = await page.evaluate(async ({ chatPanelUrl }) => {
-    const chatPanel = await import(chatPanelUrl);
+    const [{ state }, chatPanel] = await Promise.all([
+      import('/js/state.js'),
+      import(chatPanelUrl),
+    ]);
     const outcomes = {};
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
       const key = localStorage.key(i);
@@ -320,14 +323,19 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
     const backdrop = document.getElementById('chat-backdrop');
     const fab = document.getElementById('chat-fab');
     const input = document.getElementById('chat-input');
+    const sendBtn = document.getElementById('chat-send-btn');
     const label = document.querySelector('#chat-panel .chat-websearch-toggle-label');
     const checkbox = document.getElementById('chat-websearch-checkbox');
+    const threadIndexKey = `labcharts-${state.currentProfile}-chat-threads`;
     const original = {
       panelClass: panel?.className,
       backdropClass: backdrop?.className,
       bodyClass: document.body.className,
       fabClass: fab?.className,
       inputValue: input?.value,
+      inputDisabled: input?.disabled,
+      inputPlaceholder: input?.placeholder,
+      sendDisabled: sendBtn?.disabled,
       labelDisplay: label?.style.display,
       checkboxChecked: checkbox?.checked,
       refreshMobileDashboardActiveTab: window.refreshMobileDashboardActiveTab,
@@ -359,6 +367,19 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
       chatPanel.refreshWebSearchToggle();
       outcomes.webSearchToggleHidesForUnsupportedProvider = label?.style.display === 'none';
 
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      localStorage.setItem(threadIndexKey, '{bad json');
+      input?.blur();
+      await chatPanel.openChatPanel('blocked prompt');
+      outcomes.blockedThreadIndexDisablesComposer =
+        input?.disabled === true
+        && sendBtn?.disabled === true
+        && input?.placeholder === 'Conversations are paused to protect saved chats'
+        && document.activeElement !== input;
+
+      chatPanel.closeChatPanel();
+      localStorage.removeItem(threadIndexKey);
+      mobileRefreshes = 0;
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
       chatPanel.toggleChatPanel();
       outcomes.togglePanelOpensChrome =
@@ -388,6 +409,9 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
       document.body.className = original.bodyClass;
       if (fab && original.fabClass != null) fab.className = original.fabClass;
       if (input && original.inputValue != null) input.value = original.inputValue;
+      if (input && original.inputDisabled != null) input.disabled = original.inputDisabled;
+      if (input && original.inputPlaceholder != null) input.placeholder = original.inputPlaceholder;
+      if (sendBtn && original.sendDisabled != null) sendBtn.disabled = original.sendDisabled;
       if (label && original.labelDisplay != null) label.style.display = original.labelDisplay;
       if (checkbox && original.checkboxChecked != null) checkbox.checked = original.checkboxChecked;
     }

--- a/tests/playwright/sync-chat-apply-browser-coverage.spec.js
+++ b/tests/playwright/sync-chat-apply-browser-coverage.spec.js
@@ -200,10 +200,14 @@ test('sync chat apply covers browser storage merge tombstone lock and encryption
       });
       const storedSecret = localStorage.getItem(msgKey('secret'));
       const decryptedSecret = await cryptoModule.encryptedGetItem(msgKey('secret'));
-      outcomes.encryptionEnabledWritesSensitiveMessagesEncrypted =
+      const storedSecretThreads = localStorage.getItem(threadsKey);
+      const decryptedSecretThreads = await cryptoModule.encryptedGetItem(threadsKey);
+      outcomes.encryptionEnabledWritesSensitiveChatDataEncrypted =
         encryptedApplied === true
         && storedSecret?.startsWith('v1:')
-        && JSON.parse(decryptedSecret || '[]')?.[0]?.content === 'encrypted remote message';
+        && storedSecretThreads?.startsWith('v1:')
+        && JSON.parse(decryptedSecret || '[]')?.[0]?.content === 'encrypted remote message'
+        && JSON.parse(decryptedSecretThreads || '[]')?.some(thread => thread.id === 'secret');
     } finally {
       // Ensure the test-only crypto cleanup can run even if setup failed early.
       window.__WEARABLES_TEST = true;

--- a/tests/playwright/sync-chat-apply-browser-coverage.spec.js
+++ b/tests/playwright/sync-chat-apply-browser-coverage.spec.js
@@ -39,6 +39,7 @@ test('sync chat apply covers browser storage merge tombstone lock and encryption
       'locked-gone',
       'locked-remote',
       'secret',
+      'locked-secret',
     ];
     const storageKeys = [
       'labcharts-encryption-enabled',
@@ -208,6 +209,16 @@ test('sync chat apply covers browser storage merge tombstone lock and encryption
         && storedSecretThreads?.startsWith('v1:')
         && JSON.parse(decryptedSecret || '[]')?.[0]?.content === 'encrypted remote message'
         && JSON.parse(decryptedSecretThreads || '[]')?.some(thread => thread.id === 'secret');
+
+      await cryptoModule._setTestSessionKey(null);
+      const lockedEncryptedApplied = await chatApply.applyChatData(profileId, {
+        threads: [{ id: 'locked-secret', messageCount: 1, updatedAt: '2026-06-08T15:30:00.000Z' }],
+        messages: { 'locked-secret': [{ role: 'assistant', content: 'must wait for unlock' }] },
+      });
+      outcomes.encryptionLockedSkipsChatApplyWithoutPlaintextRewrite =
+        lockedEncryptedApplied === false
+        && localStorage.getItem(threadsKey) === storedSecretThreads
+        && localStorage.getItem(msgKey('locked-secret')) === null;
     } finally {
       // Ensure the test-only crypto cleanup can run even if setup failed early.
       window.__WEARABLES_TEST = true;

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -459,6 +459,10 @@ assert('chat.js imports chat render helpers', chatSrc.includes("from './chat-ren
 assert('chat-render.js exports renderChatMessages', chatRenderSrc.includes('export function renderChatMessages'), 'found');
 assert('chat.js imports chat send helpers', chatSrc.includes("from './chat-send.js'"), 'found');
 assert('chat-send.js exports sendChatMessage', chatSendSrc.includes('export async function sendChatMessage'), 'found');
+assert('sendChatMessage exits when blocked thread creation refuses a thread',
+  chatSendSrc.includes('isChatThreadInputBlocked()')
+    && /createNewThread\(\);[\s\S]{0,120}if \(!state\.currentThreadId\) return;/.test(chatSendSrc),
+  'found');
 assert('chat.js imports marker prompt helpers', chatSrc.includes("from './chat-marker-prompts.js'"), 'found');
 assert('chat-marker-prompts.js exports marker and correlation prompts',
   chatMarkerPromptsSrc.includes('export function askAIAboutMarker') &&

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -42,9 +42,9 @@ console.log('=== Chat Threads Tests ===\n');
 // in backup.js, the thread handlers in chat-threads.js, saveChatHistory /
 // loadChatHistory in chat.js — all exposed via Object.assign(window, ...).
 const stateModule = await import('../js/state.js');
-await import('../js/crypto.js');
+const cryptoModule = await import('../js/crypto.js');
 await import('../js/backup.js');
-await import('../js/chat-threads.js');
+const chatThreadsModule = await import('../js/chat-threads.js');
 await import('../js/chat.js');
 
 const st = stateModule.state;
@@ -157,7 +157,7 @@ const legacyMessages = [
   { role: 'assistant', content: 'Hi there!' }
 ];
 localStorage.setItem(legacyKey, JSON.stringify(legacyMessages));
-window.loadChatThreads();
+await chatThreadsModule.loadChatThreads();
 assert('migration creates 1 thread', st.chatThreads.length === 1);
 assert('migrated thread id is t_migrated', st.chatThreads[0].id === 't_migrated');
 assert('migrated thread named "Previous Chat"', st.chatThreads[0].name === 'Previous Chat');
@@ -193,13 +193,68 @@ assert('messages loaded back', st.chatHistory.length === 2);
 assert('message content matches', st.chatHistory[0].content === 'Test message');
 localStorage.removeItem(window.getChatThreadKey(rtThreadId));
 
-// Section 10 (rail-toggle persistence) + Section 11 (search filtering)
+// ═══════════════════════════════════════════════
+// 10. Encrypted Thread Index Load Guard
+// ═══════════════════════════════════════════════
+console.log('10. Encrypted Thread Index Load Guard');
+const _origWearablesTest = globalThis.__WEARABLES_TEST;
+const _origEncryptionEnabled = localStorage.getItem('labcharts-encryption-enabled');
+const guardedIndexKey = chatThreadsModule.getChatThreadsKey();
+globalThis.__WEARABLES_TEST = true;
+localStorage.setItem('labcharts-encryption-enabled', 'true');
+await cryptoModule._setTestSessionKey('thread-index-passphrase');
+const encryptedThread = {
+  id: 't_encrypted_index',
+  name: 'Encrypted Index',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  messageCount: 3,
+  personality: 'default'
+};
+await cryptoModule.encryptedSetItem(guardedIndexKey, JSON.stringify([encryptedThread]));
+const encryptedIndexRaw = localStorage.getItem(guardedIndexKey);
+assert('thread index can be encrypted at rest', encryptedIndexRaw?.startsWith('v1:'));
+st.chatThreads = [];
+const encryptedLoadResult = await chatThreadsModule.loadChatThreads();
+assert('loadChatThreads decrypts encrypted thread index', encryptedLoadResult === true && st.chatThreads[0]?.id === encryptedThread.id);
+
+await cryptoModule._setTestSessionKey(null);
+st.chatThreads = [{
+  id: 't_memory_guard',
+  name: 'Memory Guard',
+  createdAt: encryptedThread.createdAt,
+  updatedAt: encryptedThread.updatedAt,
+  messageCount: 1,
+  personality: 'default'
+}];
+st.currentThreadId = null;
+const blockedLoadResult = await chatThreadsModule.loadChatThreads();
+assert('locked encrypted thread index reports blocked load', blockedLoadResult === false);
+assert('blocked load preserves in-memory thread list', st.chatThreads.length === 1 && st.chatThreads[0].id === 't_memory_guard');
+st.chatThreads = [];
+const saveWhileBlocked = chatThreadsModule.saveChatThreadIndex();
+assert('blocked thread index refuses overwrite', saveWhileBlocked === false);
+assert('blocked thread index stays untouched on disk', localStorage.getItem(guardedIndexKey) === encryptedIndexRaw);
+chatThreadsModule.ensureActiveThread();
+assert('ensureActiveThread does not create while index is blocked', st.chatThreads.length === 0);
+await sleep(2); chatThreadsModule.createNewThread();
+assert('createNewThread does not create while index is blocked', st.chatThreads.length === 0);
+
+localStorage.removeItem(guardedIndexKey);
+await chatThreadsModule.loadChatThreads();
+await cryptoModule._setTestSessionKey(null);
+if (_origEncryptionEnabled === null) localStorage.removeItem('labcharts-encryption-enabled');
+else localStorage.setItem('labcharts-encryption-enabled', _origEncryptionEnabled);
+if (_origWearablesTest === undefined) delete globalThis.__WEARABLES_TEST;
+else globalThis.__WEARABLES_TEST = _origWearablesTest;
+
+// Section 11 (rail-toggle persistence) + Section 12 (search filtering)
 // live in tests/playwright/chat-threads-dom.spec.js.
 
 // ═══════════════════════════════════════════════
-// 12. Thread Pruning (50 max)
+// 13. Thread Pruning (50 max)
 // ═══════════════════════════════════════════════
-console.log('12. Thread Pruning (50 max)');
+console.log('13. Thread Pruning (50 max)');
 st.chatThreads = [];
 for (let i = 0; i < 55; i++) {
   const ts = new Date(Date.now() - (55 - i) * 60000).toISOString();
@@ -221,9 +276,9 @@ for (let i = 0; i < 55; i++) {
 }
 
 // ═══════════════════════════════════════════════
-// 13. Backup Snapshot
+// 14. Backup Snapshot
 // ═══════════════════════════════════════════════
-console.log('13. Backup Snapshot');
+console.log('14. Backup Snapshot');
 // buildBackupSnapshot() early-returns null when `labcharts-profiles` is
 // absent (backup.js:104). Playwright has the bootstrapped profile registry;
 // in Node we seed a minimal one so the snapshot path runs.
@@ -253,7 +308,7 @@ if (!_origProfiles) localStorage.removeItem('labcharts-profiles');
 else localStorage.setItem('labcharts-profiles', _origProfiles);
 
 // ═══════════════════════════════════════════════
-// 14. Encryption Patterns
+// 15. Encryption Patterns
 // ═══════════════════════════════════════════════
 // crypto.js's SENSITIVE_PATTERNS all anchor on `^labcharts-[^-]+-chat…$`.
 // Real profile ids come from createProfile() as `Date.now().toString(36)`
@@ -266,7 +321,7 @@ else localStorage.setItem('labcharts-profiles', _origProfiles);
 // IS encrypted. The stale assertion is corrected here to match the code;
 // if plaintext-index is the intended design, that's a crypto.js change,
 // not a test one.
-console.log('14. Encryption Patterns');
+console.log('15. Encryption Patterns');
 const _encPid = 'mp567abc';
 assert('isSensitiveKey matches per-thread key', window.isSensitiveKey(`labcharts-${_encPid}-chat-t_abc123`));
 assert('isSensitiveKey matches legacy chat key', window.isSensitiveKey(`labcharts-${_encPid}-chat`));
@@ -274,9 +329,9 @@ assert('isSensitiveKey matches thread index (crypto.js SENSITIVE_PATTERNS)',
   window.isSensitiveKey(`labcharts-${_encPid}-chat-threads`));
 
 // ═══════════════════════════════════════════════
-// 15. Profile Delete Cleanup (source inspection)
+// 16. Profile Delete Cleanup (source inspection)
 // ═══════════════════════════════════════════════
-console.log('15. Profile Delete Cleanup (source inspection)');
+console.log('16. Profile Delete Cleanup (source inspection)');
 const profileSrc = read('js/profile.js');
 const profileRuntimeSrc = read('js/profile-runtime.js');
 assert('deleteProfile removes chat-threads key', profileSrc.includes('chat-threads'));
@@ -287,16 +342,16 @@ assert('loadProfile resets currentThreadId', profileSrc.includes('state.currentT
 assert('loadProfile delegates runtime refresh after profile switch',
   profileSrc.includes('await reloadProfileRuntimeShell(profileId)'));
 assert('profile-runtime reloads active profile chat threads',
-  profileRuntimeSrc.includes('chatThreads.loadChatThreads?.()'));
+  profileRuntimeSrc.includes('await chatThreads.loadChatThreads?.()'));
 assert('profile-runtime reloads active profile chat history',
   profileRuntimeSrc.includes('await chatHistory.loadChatHistory?.()'));
 assert('profile-runtime rerenders chat rail after profile switch',
   profileRuntimeSrc.includes('chatThreads.renderThreadList?.()'));
 
 // ═══════════════════════════════════════════════
-// 16. Thread Search Extraction (source inspection)
+// 17. Thread Search Extraction (source inspection)
 // ═══════════════════════════════════════════════
-console.log('16. Thread Search Extraction (source inspection)');
+console.log('17. Thread Search Extraction (source inspection)');
 const chatThreadsSrc = read('js/chat-threads.js');
 const chatWindowBindingsSrc = read('js/chat-window-bindings.js');
 const chatThreadSearchSrc = read('js/chat-thread-search.js');
@@ -346,9 +401,9 @@ assert('chat-threads installs an idempotent click delegate',
   chatThreadsSrc.includes('installChatThreadDelegates();'));
 
 // ═══════════════════════════════════════════════
-// 17. CSS Inspection
+// 18. CSS Inspection
 // ═══════════════════════════════════════════════
-console.log('17. CSS Inspection');
+console.log('18. CSS Inspection');
 const cssSrc = ['styles.css', 'css/chat-panel.css', 'css/chat-personality.css', 'css/chat-messages.css', 'css/chat-composer.css', 'css/chat-onboarding.css', 'css/chat-responsive.css', 'css/chat-actions.css', 'css/chat-mobile.css', 'css/chat-redesign.css'].map(read).join('\n');
 const indexSrc = read('index.html');
 assert('CSS has .chat-thread-rail', cssSrc.includes('.chat-thread-rail'));
@@ -363,9 +418,9 @@ assert('chat thread list is keyboard focusable', indexSrc.includes('id="chat-thr
 assert('CSS has focus-visible thread list outline', cssSrc.includes('.chat-thread-list:focus-visible'));
 
 // ═══════════════════════════════════════════════
-// 18. ensureActiveThread
+// 19. ensureActiveThread
 // ═══════════════════════════════════════════════
-console.log('18. ensureActiveThread');
+console.log('19. ensureActiveThread');
 const chatLockKey = 'labcharts-chat-local-lock-until';
 const previousChatLock = sessionStorage.getItem(chatLockKey);
 sessionStorage.removeItem(chatLockKey);
@@ -390,9 +445,9 @@ window.ensureActiveThread();
 assert('picks most recent thread', st.currentThreadId === 't_new');
 
 // ═══════════════════════════════════════════════
-// 19. Thread Personality
+// 20. Thread Personality
 // ═══════════════════════════════════════════════
-console.log('19. Thread Personality');
+console.log('20. Thread Personality');
 st.chatThreads = [];
 st.currentThreadId = null;
 st.currentChatPersonality = 'house';

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -212,11 +212,20 @@ const encryptedThread = {
   personality: 'default'
 };
 await cryptoModule.encryptedSetItem(guardedIndexKey, JSON.stringify([encryptedThread]));
-const encryptedIndexRaw = localStorage.getItem(guardedIndexKey);
+let encryptedIndexRaw = localStorage.getItem(guardedIndexKey);
 assert('thread index can be encrypted at rest', encryptedIndexRaw?.startsWith('v1:'));
 st.chatThreads = [];
 const encryptedLoadResult = await chatThreadsModule.loadChatThreads();
 assert('loadChatThreads decrypts encrypted thread index', encryptedLoadResult === true && st.chatThreads[0]?.id === encryptedThread.id);
+st.chatThreads[0].name = 'Encrypted Index Saved';
+const encryptedSaveResult = await chatThreadsModule.saveChatThreadIndex({ sync: false });
+encryptedIndexRaw = localStorage.getItem(guardedIndexKey);
+const encryptedSavedPlaintext = await cryptoModule.encryptedGetItem(guardedIndexKey);
+const encryptedSavedThreads = JSON.parse(encryptedSavedPlaintext || '[]');
+assert('saveChatThreadIndex keeps unlocked encrypted index encrypted',
+  encryptedSaveResult === true && encryptedIndexRaw?.startsWith('v1:'));
+assert('saveChatThreadIndex encrypted write round-trips index JSON',
+  encryptedSavedThreads[0]?.name === 'Encrypted Index Saved');
 
 await cryptoModule._setTestSessionKey(null);
 st.chatThreads = [{

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -667,7 +667,7 @@ await import('../js/settings.js');
   assert('sync-pull-active-refresh-runtime.js owns active refresh browser hooks',
     syncPullActiveRefreshSrc.includes("from './sync-pull-active-refresh-runtime.js'")
       && !/\bwindow(?:\.|\s*\[)/.test(syncPullActiveRefreshSrc)
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('loadChatThreads')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("const loaded = getRuntimeFunction('loadChatThreads')?.()")
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('buildSidebar')?.()")
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('navigate')?.(route, options)")
       && syncPullActiveRefreshRuntimeSrc.includes("runtime.dispatchEvent(new runtime.CustomEvent('labcharts-sync-applied'))"));
@@ -1530,7 +1530,8 @@ await import('../js/settings.js');
       && syncPullActiveRefreshSrc.includes('if (chatApplied)'));
   assert('active chat thread is reselected after remote thread deletion',
     syncPullActiveRefreshSrc.includes('refreshPulledChatRuntime();')
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('loadChatThreads')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("const loaded = getRuntimeFunction('loadChatThreads')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("if (threadsLoaded === false)")
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('ensureActiveThread')?.()")
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('renderThreadList')?.()")
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('loadChatHistory')?.()"));

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1425,6 +1425,9 @@ await import('../js/settings.js');
     syncDisableCleanupSrc.includes("key === 'labcharts-sync-restore-join-pending'"));
   assert('applyChatData encrypts thread index writes',
     syncChatApplySrc.includes('await encryptedSetItem(threadsKey, JSON.stringify(mergedThreads))'));
+  assert('applyChatData skips chat writes while encryption is locked',
+    syncChatApplySrc.includes('getEncryptionEnabled() && !isUnlocked()')
+      && syncChatApplySrc.includes('encryption locked'));
 
   // ═══════════════════════════════════════
   // 9. SETTINGS UI

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1423,8 +1423,8 @@ await import('../js/settings.js');
       && /key\.endsWith\('-sync-ts'\)[\s\S]{0,200}localStorage\.removeItem\(key\)/.test(syncDisableCleanupSrc));
   assert('disableSync clears restore-join pending marker',
     syncDisableCleanupSrc.includes("key === 'labcharts-sync-restore-join-pending'"));
-  assert('applyChatData uses plain localStorage for thread index (matches saveChatThreadIndex)',
-    syncChatApplySrc.includes("localStorage.setItem(threadsKey, JSON.stringify(mergedThreads))"));
+  assert('applyChatData encrypts thread index writes',
+    syncChatApplySrc.includes('await encryptedSetItem(threadsKey, JSON.stringify(mergedThreads))'));
 
   // ═══════════════════════════════════════
   // 9. SETTINGS UI
@@ -1520,7 +1520,9 @@ await import('../js/settings.js');
       && syncChatApplySrc.includes('normalizeDeletedThreads(chatData.deletedThreads)')
       && syncChatApplySrc.includes('encryptedRemoveItem(`labcharts-${profileId}-chat-t_${thread.id}`)'));
   assert('applyChatData skips stale remote chat while local save is fresh',
-    syncChatApplySrc.includes('CHAT_LOCAL_LOCK_UNTIL_KEY') && syncChatApplySrc.includes('shouldKeepLocalChatData(profileId)'));
+    syncChatApplySrc.includes('CHAT_LOCAL_LOCK_UNTIL_KEY') && syncChatApplySrc.includes('await shouldKeepLocalChatData(profileId)'));
+  assert('applyChatData local freshness guard reads encrypted thread indexes',
+    syncChatApplySrc.includes('await encryptedGetItem(key) || localStorage.getItem(key)'));
   assert('chat freshness lock is shorter than two minutes',
     syncChatApplySrc.includes('const CHAT_LOCAL_LOCK_MS = 90 * 1000'));
   assert('skipped chat pulls retry after the local freshness lock expires',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.145';
+self.APP_VERSION = '1.10.146';

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.144';
+self.APP_VERSION = '1.10.145';

--- a/version.js
+++ b/version.js
@@ -1,5 +1,5 @@
 // version.js — Single source of truth for app version (semver)
 // Classic script (not ES module) so it works in both browser and service worker.
-// Browser: <script src="version.js"> sets window.APP_VERSION
+// Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.143';
+self.APP_VERSION = '1.10.144';


### PR DESCRIPTION
## Summary

- Load the chat thread index through `encryptedGetItem` so encrypted-at-rest indexes are readable after unlock.
- Add a write-block guard when a present thread index is unreadable or malformed, preventing empty fallback thread creation from overwriting the stored index.
- Update chat/profile/export/sync refresh call sites to respect the loader result before selecting or creating an active thread.
- Add regression coverage for encrypted index load and locked/unreadable overwrite protection.

Fixes #1127.

## Validation

- `node tests/test-chat-threads.js`
- `node tests/test-sync-pull-active-refresh-runtime.js`
- `node tests/test-sync.js`
- `npm test`
- `npm run typecheck:checkjs`
- `node scripts/quality-guardrails.mjs`
- `git diff --check`
- `./run-tests.sh` completed with one unrelated non-deterministic export/import browser fixture failure; rerunning `npx playwright test tests/playwright/core-browser-flows.spec.js -g "export/import browser fixture"` passed.