### PR TITLE
Fix differential percent import normalization

### DIFF
--- a/js/pdf-import-marker-mapping.js
+++ b/js/pdf-import-marker-mapping.js
@@ -12,6 +12,30 @@ function normalizeUnitStr(s) {
   return s.toLowerCase().replace(/\s/g, '').replace(/[\u00b5\u03bc]/g, 'u').replace(/^mcg/, 'ug').replace(/^iu\//, 'u/').replace(/^ug\/l$/, 'ng/ml');
 }
 
+function isPercentImportUnit(unit) {
+  const norm = normalizeUnitStr(String(unit || ''));
+  return norm === '%' || norm === 'pct' || norm === 'percent' || norm === 'percentage';
+}
+
+function isFractionStoredPercentMarker(key) {
+  const [catKey, markerKey] = String(key || '').split('.');
+  const marker = MARKER_SCHEMA[catKey]?.markers?.[markerKey];
+  const conv = UNIT_CONVERSIONS[key];
+  return !!marker
+    && (marker.unit || '') === ''
+    && marker.refMax != null
+    && marker.refMax <= 1
+    && conv?.type === 'multiply'
+    && conv.factor === 100
+    && isPercentImportUnit(conv.usUnit);
+}
+
+function normalizeFractionStoredPercentValue(key, value, unit) {
+  if (!isFractionStoredPercentMarker(key) || !isPercentImportUnit(unit)) return null;
+  const siValue = value > 1 ? value / 100 : value;
+  return parseFloat(siValue.toPrecision(6));
+}
+
 export const GENERIC_IMPORT_UNITS = [
   '',
   '%',
@@ -78,7 +102,10 @@ function isRecognizedUnitForMarker(key, unit) {
   const siUnit = getSchemaUnitForMarker(key);
   if (siUnit && aiUnit === normalizeUnitStr(siUnit)) return true;
   const primaryConv = UNIT_CONVERSIONS[key];
-  if (primaryConv?.type === 'multiply' && primaryConv.usUnit && aiUnit === normalizeUnitStr(primaryConv.usUnit)) return true;
+  if (primaryConv?.type === 'multiply' && primaryConv.usUnit) {
+    if (aiUnit === normalizeUnitStr(primaryConv.usUnit)) return true;
+    if (isPercentImportUnit(aiUnit) && isPercentImportUnit(primaryConv.usUnit)) return true;
+  }
   if (primaryConv?.type === 'hba1c' && aiUnit === '%') return true;
   const secondaryList = SECONDARY_UNIT_CONVERSIONS[key];
   if (secondaryList) {
@@ -655,6 +682,8 @@ export function normalizeToSI(key, value, unit) {
   // When a unit string is present, systematically evaluate all conversion registries
   if (unit) {
     const aiUnit = normalizeUnitStr(unit);
+    const fractionPercentValue = normalizeFractionStoredPercentValue(key, value, aiUnit);
+    if (fractionPercentValue != null) return fractionPercentValue;
 
     // 1. Evaluate primary US conversions
     const primaryConv = UNIT_CONVERSIONS[key];

--- a/js/profile-marker-migrations.js
+++ b/js/profile-marker-migrations.js
@@ -229,6 +229,24 @@ function _hasPositiveSpadiaLabel(value) {
   return !/(?:non|not|no|without)spadia/.test(compact);
 }
 
+const FRACTION_STORED_PERCENT_MARKERS = new Set([
+  'differential.neutrophilsPct',
+  'differential.lymphocytesPct',
+  'differential.monocytesPct',
+]);
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {boolean}
+ */
+function _isProfilePercentUnit(value) {
+  const normalized = String(value || '')
+    .toLowerCase()
+    .replace(/\s/g, '')
+    .replace(/[\u00b5\u03bc]/g, 'u');
+  return normalized === '%' || normalized === 'pct' || normalized === 'percent' || normalized === 'percentage';
+}
+
 /**
  * @param {string | null | undefined} value
  * @returns {boolean}
@@ -449,6 +467,73 @@ function _profileMarkerValuesMatch(a, b) {
 }
 
 /**
+ * @param {any} marker
+ * @returns {{ key: string, value: number, dividedValue: number } | null}
+ */
+function _fractionStoredPercentSnapshotMarker(marker) {
+  const key = marker?.mappedKey || marker?.suggestedKey || '';
+  if (!FRACTION_STORED_PERCENT_MARKERS.has(key)) return null;
+  if (!_isProfilePercentUnit(marker?.unit)) return null;
+  const value = Number(marker?.value);
+  if (!Number.isFinite(value) || value < 0 || value > 1) return null;
+  return {
+    key,
+    value,
+    dividedValue: parseFloat((value / 100).toPrecision(6)),
+  };
+}
+
+/**
+ * @param {ProfileData} data
+ * @param {string} key
+ * @param {any} marker
+ * @returns {void}
+ */
+function _repairFractionStoredPercentRefOverride(data, key, marker) {
+  const override = data.refOverrides?.[key];
+  if (!override || !_isProfilePercentUnit(marker?.unit)) return;
+  const pairs = [
+    ['refMin', 'refMin'],
+    ['refMax', 'refMax'],
+    ['labRefMin', 'refMin'],
+    ['labRefMax', 'refMax'],
+  ];
+  for (const [overrideField, markerField] of pairs) {
+    const raw = Number(marker?.[markerField]);
+    if (!Number.isFinite(raw) || raw < 0 || raw > 1) continue;
+    const divided = parseFloat((raw / 100).toPrecision(6));
+    if (_profileMarkerValuesMatch(override[overrideField], divided)) {
+      override[overrideField] = raw;
+    }
+  }
+}
+
+/**
+ * @param {ProfileData} data
+ * @returns {void}
+ */
+function _repairFractionStoredPercentImports(data) {
+  if (!Array.isArray(data.importSnapshots) || !Array.isArray(data.entries)) return;
+  for (const snap of data.importSnapshots) {
+    if (!Array.isArray(snap?.markers)) continue;
+    for (const marker of snap.markers) {
+      const percentMarker = _fractionStoredPercentSnapshotMarker(marker);
+      if (!percentMarker) continue;
+      const { key, value, dividedValue } = percentMarker;
+      for (const entry of data.entries) {
+        if (!entry?.markers || !Object.prototype.hasOwnProperty.call(entry.markers, key)) continue;
+        const source = entry.markerSources?.[key];
+        const sourceMatches = (snap?.id && source?.snapshotId === snap.id)
+          || (snap?.date && entry.date === snap.date && _profileMarkerValuesMatch(entry.markers[key], dividedValue));
+        if (!sourceMatches) continue;
+        if (_profileMarkerValuesMatch(entry.markers[key], dividedValue)) entry.markers[key] = value;
+      }
+      _repairFractionStoredPercentRefOverride(data, key, marker);
+    }
+  }
+}
+
+/**
  * @param {any} entry
  * @param {any} snap
  * @param {string} oldKey
@@ -574,5 +659,6 @@ export function repairProfileMarkerData(data) {
   _repairCanonicalMarkerAliases(data);
   _repairNamedStandardMarkerAliases(data);
   _repairUnitSuffixedStandardMarkers(data);
+  _repairFractionStoredPercentImports(data);
   _repairSpadiaFattyAcidKeys(data);
 }

--- a/tests/test-secondary-unit-conversions.js
+++ b/tests/test-secondary-unit-conversions.js
@@ -64,6 +64,22 @@ assert('testosterone nmol/L passes through', normalizeToSI('hormones.testosteron
 assert('SI passthrough is case-insensitive (mmol/L vs schema mmol/l)', normalizeToSI('biochemistry.glucose', 5.5, 'MMOL/L') === 5.5);
 
 // ═══════════════════════════════════════════════
+// 2b. Fraction-stored percent imports
+// ═══════════════════════════════════════════════
+console.log(' 2b. Fraction-stored percent imports ');
+
+assert('differential neutrophils 0.609 % stays 0.609 fraction',
+  normalizeToSI('differential.neutrophilsPct', 0.609, '%') === 0.609);
+assert('differential neutrophils 60.9 % converts to 0.609 fraction',
+  approx(normalizeToSI('differential.neutrophilsPct', 60.9, '%'), 0.609));
+assert('differential monocytes 0.074 PERCENTAGE stays 0.074 fraction',
+  normalizeToSI('differential.monocytesPct', 0.074, 'PERCENTAGE') === 0.074);
+assert('differential monocytes 7.4 PERCENTAGE converts to 0.074 fraction',
+  approx(normalizeToSI('differential.monocytesPct', 7.4, 'PERCENTAGE'), 0.074));
+assert('HbA1c percent conversion is unchanged',
+  approx(normalizeToSI('diabetes.hba1c', 5.7, '%'), 38.8, 0.5));
+
+// ═══════════════════════════════════════════════
 // 3. Unknown explicit-unit passthrough (no heuristic guessing)
 // ═══════════════════════════════════════════════
 console.log(' 3. Unknown explicit-unit passthrough ');

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -615,6 +615,45 @@ const importCssSrc = read('css/import.css');
     && cPeptideAlias.customMarkers['hormones.cPeptide'] === undefined
     && cPeptideAlias.markerValueNotes['diabetes.cPeptide:2026-05-01'] === 'legacy category');
 
+  const dividedDifferentialPct = {
+    entries: [{
+      date: '2026-06-01',
+      markers: {
+        'differential.neutrophilsPct': 0.00609,
+        'differential.monocytesPct': 0.00074,
+        'differential.lymphocytesPct': 0.328,
+      },
+      markerSources: {
+        'differential.neutrophilsPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
+        'differential.monocytesPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
+        'differential.lymphocytesPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
+      },
+    }],
+    importSnapshots: [{
+      id: 'snap_cbc_fraction_pct',
+      fileName: 'cbc.pdf',
+      date: '2026-06-01',
+      markers: [
+        { rawName: 'B Neutrofily', value: 0.609, unit: '%', mappedKey: 'differential.neutrophilsPct', matched: true, refMin: 0.45, refMax: 0.70 },
+        { rawName: 'B Monocyty', value: 0.074, unit: 'PERCENTAGE', mappedKey: 'differential.monocytesPct', matched: true, refMin: 0.02, refMax: 0.12 },
+        { rawName: 'B Lymfocyty', value: 0.328, unit: '%', mappedKey: 'differential.lymphocytesPct', matched: true, refMin: 0.20, refMax: 0.45 },
+      ],
+    }],
+    refOverrides: {
+      'differential.neutrophilsPct': { refMin: 0.0045, refMax: 0.007, labRefMin: 0.0045, labRefMax: 0.007, refSource: 'import' },
+    },
+  };
+  migrateProfileData(dividedDifferentialPct);
+  assert('Profile migration repairs fraction-stored differential percent values divided during import',
+    dividedDifferentialPct.entries[0].markers['differential.neutrophilsPct'] === 0.609
+    && dividedDifferentialPct.entries[0].markers['differential.monocytesPct'] === 0.074
+    && dividedDifferentialPct.entries[0].markers['differential.lymphocytesPct'] === 0.328);
+  assert('Profile migration repairs divided imported differential percent reference overrides',
+    dividedDifferentialPct.refOverrides['differential.neutrophilsPct'].refMin === 0.45
+    && dividedDifferentialPct.refOverrides['differential.neutrophilsPct'].refMax === 0.70
+    && dividedDifferentialPct.refOverrides['differential.neutrophilsPct'].labRefMin === 0.45
+    && dividedDifferentialPct.refOverrides['differential.neutrophilsPct'].labRefMax === 0.70);
+
   const lipidAliases = {
     entries: [{ date: '2026-05-01', markers: { 'lipids.lpa': 42, 'lipids.totalCholesterol': 4.6, 'lipids.hdlCholesterol': 1.4, 'lipids.cholHdlRatio': 3.3 } }],
     customMarkers: {


### PR DESCRIPTION
## Summary

Fixes WBC differential percentage imports where fraction-scale values such as `0.609 %` were shown correctly in Review Import but saved as `0.00609`, causing chart markers to render 100x too low.

## Root Cause

The import normalizer treated `%` for fraction-stored differential markers as a display unit that always needed division by 100. Some labs already emit these values as fractions while still labeling the unit `%`.

## Changes

- Preserve fraction-scale values for fraction-stored percent markers like Neutrophils %, Lymphocytes %, and Monocytes %.
- Continue converting percent-point values such as `60.9 %` to `0.609`.
- Add a profile repair migration for already-imported entries whose saved import snapshot proves the value was divided during import.
- Add regression coverage for the normalization and profile repair paths.

## Validation

- `node tests/test-secondary-unit-conversions.js`
- `node tests/test-unit-import.js`
- `node tests/test-normalize-units.js`
- `npm run typecheck:checkjs`
