### PR TITLE
Fix duplicate Chol/HDL ratio marker

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -543,9 +543,11 @@ export function getActiveData() {
         return (n != null && d != null && d !== 0) ? Math.round((n / d) * 1000) / 1000 : null;
       });
     };
+    const directCholHdlVals = getVals('calculatedRatios', 'cholHdlRatio');
     ratios.markers.tgHdlRatio.values = divide(getVals('lipids', 'triglycerides'), getVals('lipids', 'hdl'));
     ratios.markers.ldlHdlRatio.values = divide(getVals('lipids', 'ldl'), getVals('lipids', 'hdl'));
-    ratios.markers.cholHdlRatio.values = divide(getVals('lipids', 'cholesterol'), getVals('lipids', 'hdl'));
+    const computedCholHdlVals = divide(getVals('lipids', 'cholesterol'), getVals('lipids', 'hdl'));
+    ratios.markers.cholHdlRatio.values = computedCholHdlVals.map((value, i) => value != null ? value : (directCholHdlVals?.[i] ?? null));
     ratios.markers.apoBapoAIRatio.values = divide(getVals('lipids', 'apoB'), getVals('lipids', 'apoAI'));
     ratios.markers.nlr.values = divide(getVals('differential', 'neutrophils'), getVals('differential', 'lymphocytes'));
     ratios.markers.plr.values = divide(getVals('hematology', 'platelets'), getVals('differential', 'lymphocytes'));

--- a/js/pdf-import-marker-mapping.js
+++ b/js/pdf-import-marker-mapping.js
@@ -123,6 +123,20 @@ function isRecognizedUnitForMarker(key, unit) {
 // handles `null` mappedKey/suggestedKey by deriving a safe key from rawName.
 const _SAFE_MARKER_KEY = /^[a-zA-Z][a-zA-Z0-9]*\.[a-zA-Z][a-zA-Z0-9_]*$/;
 
+const IMPORTABLE_CALCULATED_MARKER_KEYS = new Set([
+  'calculatedRatios.cholHdlRatio',
+]);
+
+function _isImportableCalculatedMarkerKey(key) {
+  if (!IMPORTABLE_CALCULATED_MARKER_KEYS.has(key)) return false;
+  const [catKey, markerKey] = String(key || '').split('.');
+  return !!MARKER_SCHEMA[catKey]?.calculated && !!MARKER_SCHEMA[catKey]?.markers?.[markerKey];
+}
+
+function _hasImportReferenceKey(key, refLookup, existingKeys = null) {
+  return !!refLookup[key] || !!existingKeys?.has?.(key) || _isImportableCalculatedMarkerKey(key);
+}
+
 export function _sanitizeAIMarker(m) {
   if (typeof m.mappedKey === 'string' && !_SAFE_MARKER_KEY.test(m.mappedKey)) m.mappedKey = null;
   if (typeof m.suggestedKey === 'string' && !_SAFE_MARKER_KEY.test(m.suggestedKey)) m.suggestedKey = null;
@@ -391,7 +405,10 @@ const BLOOD_IMPORT_ALIASES = new Map([
   ['lpa', 'lipids.lpA'],
   ['lipoproteina', 'lipids.lpA'],
   ['nonhdl', 'lipids.nonHdl'],
-  ['cholhdl', 'lipids.cholHdlRatio'],
+  ['cholhdl', 'calculatedRatios.cholHdlRatio'],
+  ['cholhdlratio', 'calculatedRatios.cholHdlRatio'],
+  ['cholesterolhdlratio', 'calculatedRatios.cholHdlRatio'],
+  ['totalcholesterolhdlratio', 'calculatedRatios.cholHdlRatio'],
   ['zelezo', 'iron.iron'],
   ['ferritin', 'iron.ferritin'],
   ['transferin', 'iron.transferrin'],
@@ -489,7 +506,7 @@ function _knownImportKey(key, testType, refLookup, existingKeys, standardCats) {
   const catKey = key.split('.')[0];
   const standard = standardCats.has(catKey);
   if (testType !== 'blood' && testType !== 'biostarks' && standard) return null;
-  return (refLookup[key] || existingKeys.has(key)) ? key : null;
+  return _hasImportReferenceKey(key, refLookup, existingKeys) ? key : null;
 }
 
 function _buildExistingCustomMarkerNameLookup(existingKeys) {
@@ -627,7 +644,7 @@ function _resolveStandardBloodImportKey(marker, refLookup, differentialPercentSu
   }
   if (!key) return null;
   if (key === 'biochemistry.creatinine' && unit && unit !== normalizeUnitStr('µmol/l')) return null;
-  return refLookup[key] ? key : null;
+  return _hasImportReferenceKey(key, refLookup) ? key : null;
 }
 
 export function reconcileImportMarkerMappings(markers, options = {}) {
@@ -734,7 +751,14 @@ export function buildMarkerReference() {
   const ref = {};
   const isFemale = state.profileSex === 'female';
   for (const [catKey, cat] of Object.entries(MARKER_SCHEMA)) {
-    if (cat.calculated) continue;
+    if (cat.calculated) {
+      for (const [markerKey, marker] of Object.entries(cat.markers)) {
+        const fullKey = `${catKey}.${markerKey}`;
+        if (!_isImportableCalculatedMarkerKey(fullKey)) continue;
+        ref[fullKey] = { name: marker.name, unit: marker.unit, refMin: marker.refMin, refMax: marker.refMax };
+      }
+      continue;
+    }
     for (const [markerKey, marker] of Object.entries(cat.markers)) {
       const rMin = isFemale && marker.refMin_f != null ? marker.refMin_f : marker.refMin;
       const rMax = isFemale && marker.refMax_f != null ? marker.refMax_f : marker.refMax;

--- a/js/schema.js
+++ b/js/schema.js
@@ -78,7 +78,6 @@ export const MARKER_SCHEMA = {
       hdl: { name: "HDL Cholesterol", unit: "mmol/l", refMin: 1.00, refMax: 2.10, refMin_f: 1.20, refMax_f: 2.70, desc: "Protective cholesterol that transports fat away from arteries back to the liver; higher levels reduce cardiovascular risk." },
       ldl: { name: "LDL Cholesterol", unit: "mmol/l", refMin: 1.20, refMax: 3.00, desc: "The primary atherogenic cholesterol that deposits in artery walls; the main target for cardiovascular risk reduction." },
       nonHdl: { name: "Non-HDL Cholesterol", unit: "mmol/l", refMin: 0.00, refMax: 3.80, desc: "All atherogenic cholesterol particles combined (LDL + VLDL + remnants); a better cardiovascular predictor than LDL alone." },
-      cholHdlRatio: { name: "Chol/HDL Ratio", unit: "", refMin: 0.0, refMax: 5.0, desc: "Total cholesterol divided by HDL; a simple cardiovascular risk ratio where lower values indicate better lipid balance." },
       apoAI: { name: "Apo A-I", unit: "g/l", refMin: 1.00, refMax: 1.70, desc: "The main protein of HDL particles; reflects protective cholesterol transport capacity and cardiovascular health." },
       apoB: { name: "Apo B", unit: "g/l", refMin: 0.50, refMax: 1.00, desc: "The protein on each LDL particle; directly counts atherogenic particles, making it a superior cardiovascular risk marker." },
       lpA: { name: "Lp(a)", unit: "nmol/l", refMin: 0, refMax: 125, desc: "Lipoprotein(a), a mostly genetic atherogenic particle. Values above ~125 nmol/L (≈50 mg/dL, assay-dependent) are commonly treated as risk-enhancing." }

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -174,7 +174,7 @@ delete lipidRatioData.categories.lipids.markers.cholesterol;
 delete lipidRatioData.categories.lipids.markers.hdl;
 lipidRatioData.categories.lipids.markers.cholHdlRatio = marker('Chol/HDL Ratio', '', 0, 5, 3.1);
 const lipidRatioCardio = computeBiologyScores(lipidRatioData).find(score => score.id === 'cardiovascularLipoprotein');
-assert('cardiovascular score accepts schema Lipid Panel Chol/HDL ratio when present directly',
+assert('cardiovascular score accepts legacy Lipid Panel Chol/HDL ratio when present directly',
   lipidRatioCardio.available.some(i => i.key === 'cholHdlRatio' && i.dotKey === 'lipids.cholHdlRatio')
   && !lipidRatioCardio.missing.some(i => i.key === 'cholHdlRatio'),
   JSON.stringify({ available: lipidRatioCardio.available.map(i => [i.key, i.dotKey]), missing: lipidRatioCardio.missing }));

--- a/tests/test-calculated-markers.js
+++ b/tests/test-calculated-markers.js
@@ -554,10 +554,12 @@ const state = window._labState;
     date: '2025-06-15',
     markers: {
       'lipids.triglycerides': 1.5,
+      'lipids.cholesterol': 4.5,
       'lipids.hdl': 1.5,
       'lipids.ldl': 3.0,
       'lipids.apoB': 1.0,
       'lipids.apoAI': 1.5,
+      'calculatedRatios.cholHdlRatio': 9.9,
       'differential.neutrophils': 4.0,
       'differential.lymphocytes': 2.0,
       'hematology.platelets': 250,
@@ -578,6 +580,11 @@ const state = window._labState;
   // LDL/HDL = 3.0/1.5 = 2.0
   assert('LDL/HDL ratio is 2.0', cr?.ldlHdlRatio?.values?.[0] === 2.0,
     `expected 2.0, got ${cr?.ldlHdlRatio?.values?.[0]}`);
+
+  // Total Chol/HDL = 4.5/1.5 = 3.0; computed component ratio wins over a direct imported ratio.
+  assert('Total Chol/HDL ratio is computed from components when available',
+    cr?.cholHdlRatio?.values?.[0] === 3.0,
+    `expected 3.0, got ${cr?.cholHdlRatio?.values?.[0]}`);
 
   // ApoB/ApoAI = 1.0/1.5 = 0.667
   assert('ApoB/ApoAI ratio is 0.667', cr?.apoBapoAIRatio?.values?.[0] === 0.667,
@@ -606,6 +613,17 @@ const state = window._labState;
   data = window.getActiveData();
   const tgHdlZero = data.categories.calculatedRatios?.markers?.tgHdlRatio?.values?.[0];
   assert('TG/HDL is null when HDL is zero', tgHdlZero == null, `got ${tgHdlZero}`);
+
+  // ── Direct lab-reported Chol/HDL ratio is retained when components are unavailable ──
+  state.importedData.entries = [{
+    date: '2025-06-15',
+    markers: { 'calculatedRatios.cholHdlRatio': 3.4 }
+  }];
+
+  data = window.getActiveData();
+  const directCholHdl = data.categories.calculatedRatios?.markers?.cholHdlRatio?.values?.[0];
+  assert('Direct imported Chol/HDL ratio is retained when components are missing',
+    directCholHdl === 3.4, `expected 3.4, got ${directCholHdl}`);
 
   // ═══════════════════════════════════════
   // Cleanup

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -324,7 +324,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
     'vitamins.methylmalonicAcid', 'diabetes.fructosamine', 'calculatedRatios.cholHdlRatio',
     // Unitless or % — no conversion
     'hormones.fai', 'hormones.freeTestosteronePercentage', 'hormones.bioactiveTestosteronePercentage',
-    'iron.transferrinSat', 'lipids.cholHdlRatio',
+    'iron.transferrinSat',
     // Activity units identical in US/SI
     'hormones.hCG',
     'hematology.rdwcv', 'hematology.hematocrit',

--- a/tests/test-schema.js
+++ b/tests/test-schema.js
@@ -60,8 +60,12 @@ const pdfImportNormalizationSrc = read('js/pdf-import-marker-normalization.js');
   }
   const hormonesBlock = schemaBlock.substring(schemaBlock.indexOf('  hormones:'), schemaBlock.indexOf('  electrolytes:'));
   const diabetesBlock = schemaBlock.substring(schemaBlock.indexOf('  diabetes:'), schemaBlock.indexOf('  tumorMarkers:'));
+  const lipidsBlock = schemaBlock.substring(schemaBlock.indexOf('  lipids:'), schemaBlock.indexOf('  iron:'));
+  const calculatedRatiosBlock = schemaBlock.substring(schemaBlock.indexOf('  calculatedRatios:'));
   assert('C-peptide has one canonical standard schema home under diabetes',
     diabetesBlock.includes('cPeptide: {') && !hormonesBlock.includes('cPeptide: {'));
+  assert('Chol/HDL ratio has one schema home under calculatedRatios',
+    !lipidsBlock.includes('cholHdlRatio: {') && calculatedRatiosBlock.includes('cholHdlRatio: {'));
 
   // ═══════════════════════════════════════
   // 2. SPECIALTY_MARKER_DEFS re-exported from adapters.js

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -439,9 +439,10 @@ const importCssSrc = read('css/import.css');
     && mappingSrc.includes("'homocystein', 'coagulation.homocysteine'")
     && mappingSrc.includes("'reverset3', 'thyroid.reverseT3'")
     && mappingSrc.includes("'ddimer', 'coagulation.dDimer'")
-    && mappingSrc.includes("'cortisol', 'hormones.cortisol'"));
+    && mappingSrc.includes("'cortisol', 'hormones.cortisol'")
+    && mappingSrc.includes("'cholhdl', 'calculatedRatios.cholHdlRatio'"));
 
-  const { reconcileImportMarkerMappings } = await import('../js/pdf-import.js');
+  const { buildMarkerReference, reconcileImportMarkerMappings } = await import('../js/pdf-import.js');
   const { state } = await import('../js/state.js');
   const originalImportedData = state.importedData;
   state.importedData = {
@@ -460,6 +461,10 @@ const importCssSrc = read('css/import.css');
     }
   };
   try {
+    const markerRef = buildMarkerReference();
+    assert('Import reference exposes canonical calculated Chol/HDL ratio only',
+      markerRef['calculatedRatios.cholHdlRatio'] != null
+      && markerRef['lipids.cholHdlRatio'] == null);
     const importMarkers = [
       { rawName: 'S Glukóza', value: 4.56, unit: 'mmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.glukoza' },
       { rawName: 'P Hořčík v ery', value: 2.56, unit: 'mmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.magnesiumEry' },
@@ -480,7 +485,8 @@ const importCssSrc = read('css/import.css');
       { rawName: 'Reverse T3', value: 0.33, unit: 'nmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.reverseT3' },
       { rawName: 'D-dimer', value: 0.22, unit: 'mg/l FEU', matched: false, mappedKey: null, suggestedKey: 'custom.dDimer' },
       { rawName: 'Cortisol', value: 390, unit: 'nmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.cortisol' },
-      { rawName: 'Lp(a)', value: 42, unit: 'nmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.lpa' }
+      { rawName: 'Lp(a)', value: 42, unit: 'nmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.lpa' },
+      { rawName: 'Total Cholesterol/HDL Ratio', value: 3.4, unit: '', matched: false, mappedKey: null, suggestedKey: 'custom.cholHdlRatio' }
     ];
     reconcileImportMarkerMappings(importMarkers, { testType: 'blood' });
     assert('Czech glucose reconciles to existing schema marker',
@@ -525,6 +531,9 @@ const importCssSrc = read('css/import.css');
       && importMarkers[18].matched && importMarkers[18].mappedKey === 'hormones.cortisol'
       && importMarkers[19].matched && importMarkers[19].mappedKey === 'lipids.lpA',
       JSON.stringify(importMarkers.slice(16, 20)));
+    assert('Lab-reported total cholesterol/HDL ratio maps to canonical calculated ratio key',
+      importMarkers[20].matched && importMarkers[20].mappedKey === 'calculatedRatios.cholHdlRatio',
+      JSON.stringify(importMarkers[20]));
     const gutMarkers = [
       { rawName: 'Fecal Calprotectin', value: 20, unit: 'µg/g', matched: false, mappedKey: null, suggestedKey: 'custom.fecalCalprotectin' },
       { rawName: 'Zonulin', value: 40, unit: 'ng/ml', matched: false, mappedKey: null, suggestedKey: 'custom.zonulin' },


### PR DESCRIPTION
## Summary

Fixes #1131.

This removes the orphaned `lipids.cholHdlRatio` schema marker so the chart no longer shows a duplicate Lipid Panel tile with no data. Lab-reported Chol/HDL values now import into the canonical `calculatedRatios.cholHdlRatio` marker instead.

The runtime calculation keeps the computed component ratio when total cholesterol and HDL are available, and preserves a directly imported lab-reported Chol/HDL ratio only when those components are missing.

## Root Cause

Chol/HDL Ratio existed in two schema locations: the active calculated marker and a legacy Lipid Panel marker. Import aliases pointed at the legacy key, while the app rendered calculated ratios from the canonical key, leaving a stale duplicate chart marker.

## Validation

- `node tests/test-unit-import.js`
- `node tests/test-calculated-markers.js`
- `node tests/test-schema.js`
- `node tests/test-integration-batch2.js`
- `node tests/test-data-pipeline.js`
- `node tests/test-biology-scores.js`
- `npm run typecheck:checkjs`
- `git diff --check`