### PR TITLE
Harden proxy request policy

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -4,121 +4,15 @@
 
 export const config = { runtime: 'edge' };
 
+import {
+  PROXY_MAX_REQUEST_BYTES,
+  PROXY_MAX_RESPONSE_BYTES,
+  isAllowedProxyUrl,
+  normalizeProxyMethod,
+  sanitizeProxyHeaders,
+} from '../lib/proxy-policy.js';
+
 const DEFAULT_UVDATA_UPSTREAM = 'https://uvdata.getbased.health';
-
-// Allowlisted provider URL prefixes — these always pass without further
-// checks. User-configured endpoints (Custom API, decentralized Routstr
-// nodes) are allowed too, but only over HTTPS with a non-private host.
-const ALLOWED_ORIGINS = [
-  'https://openrouter.ai/',
-  'https://api.venice.ai/',
-  'https://api.routstr.com/',
-  'https://api.ppq.ai/',
-  'https://api.ouraring.com/',
-  'https://api.prod.whoop.com/',
-  'https://partner.ultrahuman.com/',
-  'https://wbsapi.withings.net/',
-  'https://api.fitbit.com/',
-  'https://www.polaraccesslink.com/',
-  'https://polarremote.com/',
-];
-
-/// Block literal IPs in private / reserved / cloud-metadata ranges so
-/// attackers can't use the proxy to probe Vercel's internal network or
-/// hit cloud metadata services (AWS/GCP 169.254.169.254, Azure
-/// 168.63.129.16). Hostnames that DNS-resolve to private IPs would still
-/// reach them; that's the next-tier fix (DNS resolution + re-check
-/// before fetch), out of scope for this pass.
-function _isBlockedHost(host) {
-  if (!host) return true;
-  // Strip IPv6 brackets if present — URL.hostname keeps them on bracketed
-  // literals depending on runtime, so normalise both shapes.
-  const h = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
-  // Loopback + localhost aliases
-  if (h === 'localhost' || h === '127.0.0.1' || h === '::1') return true;
-  if (h.endsWith('.local') || h.endsWith('.localhost')) return true;
-  // Azure metadata
-  if (h === '168.63.129.16') return true;
-
-  // IPv6 literal: block loopback, unique-local (fc00::/7), link-local
-  // (fe80::/10), unspecified (::), IPv4-mapped (::ffff:127.0.0.1 / :a.b.c.d
-  // / :hex), and IPv4-compatible (::w.x.y.z). The check is conservative:
-  // any string containing ':' is treated as IPv6 and inspected.
-  if (h.includes(':')) {
-    const lower = h.toLowerCase();
-    if (lower === '::' || lower === '0:0:0:0:0:0:0:0') return true;
-    // fc00::/7 unique-local: high byte 0xfc or 0xfd (binary 1111110x)
-    if (/^fc[0-9a-f]{2}:/.test(lower) || /^fd[0-9a-f]{2}:/.test(lower)) return true;
-    // fe80::/10 link-local
-    if (/^fe[89ab][0-9a-f]:/.test(lower)) return true;
-    // IPv4-mapped/translated: ::ffff:a.b.c.d / ::ffff:0:a.b.c.d / ::a.b.c.d
-    const v4Embed = lower.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-    if (v4Embed) return _isBlockedHost(v4Embed[1]);
-    // IPv4-mapped hex form ::ffff:7f00:0001 etc — parse each 16-bit
-    // group independently so compressed forms like ::ffff:c0a8:101 keep
-    // their byte boundaries (192.168.1.1, not 12.10.129.1).
-    if (lower.startsWith('::ffff:')) {
-      const tail = lower.slice(7);
-      const groups = tail.split(':');
-      if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
-        const g0 = parseInt(groups[0], 16);
-        const g1 = parseInt(groups[1], 16);
-        const a = (g0 >> 8) & 0xff;
-        const b = g0 & 0xff;
-        const c = (g1 >> 8) & 0xff;
-        const d = g1 & 0xff;
-        return _isBlockedHost(`${a}.${b}.${c}.${d}`);
-      }
-    }
-    // 6to4 = 2002:WWXX:YYZZ::/48, with WWXX:YYZZ encoding IPv4.
-    const sixToFour = /^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4})(?::|$)/.exec(lower);
-    if (sixToFour) {
-      const g0 = parseInt(sixToFour[1], 16);
-      const g1 = parseInt(sixToFour[2], 16);
-      const a = (g0 >> 8) & 0xff;
-      const b = g0 & 0xff;
-      const c = (g1 >> 8) & 0xff;
-      const d = g1 & 0xff;
-      return _isBlockedHost(`${a}.${b}.${c}.${d}`);
-    }
-    // Unknown / private IPv6 ranges we haven't enumerated — be safe and
-    // allow only globally routable (2000::/3) IPv6 addresses through.
-    return !/^[23][0-9a-f]{3}:/.test(lower);
-  }
-
-  // IPv4 literal check — reject strictly-decimal 0-255 octets in reserved ranges
-  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
-  if (!m) return false;
-  for (let i = 1; i <= 4; i++) {
-    const octet = m[i];
-    // Strict decimal — reject leading zeros (0255 is octal territory)
-    if (octet.length > 1 && octet[0] === '0') return true;
-    const n = +octet;
-    if (n > 255) return true;
-  }
-  const a = +m[1], b = +m[2];
-  if (a === 10) return true;                          // 10.0.0.0/8
-  if (a === 127) return true;                         // loopback
-  if (a === 169 && b === 254) return true;            // link-local + AWS/GCP metadata
-  if (a === 172 && b >= 16 && b <= 31) return true;   // 172.16.0.0/12
-  if (a === 192 && b === 168) return true;            // 192.168.0.0/16
-  if (a === 100 && b >= 64 && b <= 127) return true;  // CGNAT 100.64.0.0/10
-  if (a === 0) return true;                           // 0.0.0.0/8
-  return false;
-}
-
-function isAllowedUrl(url) {
-  if (ALLOWED_ORIGINS.some(origin => url.startsWith(origin))) return true;
-  // Allow any HTTPS endpoint (Custom API, decentralized Routstr nodes)
-  // provided the host is public — blocks SSRF into Vercel's internal
-  // network and cloud metadata services.
-  try {
-    const u = new URL(url);
-    if (u.protocol !== 'https:') return false;
-    if (_isBlockedHost(u.hostname)) return false;
-    return true;
-  } catch { return false; }
-}
 
 export default async function handler(req) {
   // CORS preflight
@@ -138,7 +32,21 @@ export default async function handler(req) {
 
   let payload;
   try {
-    payload = await req.json();
+    const contentLength = parseInt(req.headers.get('content-length') || '0', 10);
+    if (contentLength > PROXY_MAX_REQUEST_BYTES) {
+      return new Response(JSON.stringify({ error: 'Proxy request body too large' }), {
+        status: 413,
+        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+      });
+    }
+    const rawBody = await req.text();
+    if (new TextEncoder().encode(rawBody).length > PROXY_MAX_REQUEST_BYTES) {
+      return new Response(JSON.stringify({ error: 'Proxy request body too large' }), {
+        status: 413,
+        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+      });
+    }
+    payload = JSON.parse(rawBody);
   } catch {
     return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
       status: 400,
@@ -212,21 +120,34 @@ export default async function handler(req) {
 
   const { url, headers, body, method: upstreamMethod } = payload;
 
-  if (!url || !isAllowedUrl(url)) {
+  if (!url || !isAllowedProxyUrl(url)) {
     return new Response(JSON.stringify({ error: 'URL not allowed' }), {
       status: 403,
       headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
     });
   }
+  const fetchMethod = normalizeProxyMethod(upstreamMethod);
+  if (!fetchMethod) {
+    return new Response(JSON.stringify({ error: 'Proxy method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+    });
+  }
+  const safeHeaders = sanitizeProxyHeaders(headers);
+  if (!safeHeaders.ok) {
+    return new Response(JSON.stringify({ error: safeHeaders.error }), {
+      status: 400,
+      headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+    });
+  }
 
   try {
-    const fetchMethod = (upstreamMethod || 'POST').toUpperCase();
+    const reqHeaders = { ...safeHeaders.headers };
+    const hasCT = Object.keys(reqHeaders).some(k => k.toLowerCase() === 'content-type');
+    if (fetchMethod !== 'GET' && !hasCT) reqHeaders['Content-Type'] = 'application/json';
     const fetchOpts = {
       method: fetchMethod,
-      headers: {
-        ...(fetchMethod !== 'GET' ? { 'Content-Type': 'application/json' } : {}),
-        ...headers,
-      },
+      headers: reqHeaders,
     };
     if (fetchMethod !== 'GET' && body) {
       fetchOpts.body = typeof body === 'string' ? body : JSON.stringify(body);
@@ -238,7 +159,7 @@ export default async function handler(req) {
     const isStream = contentType.includes('text/event-stream') || contentType.includes('application/x-ndjson');
 
     if (!isStream) {
-      const responseBody = await upstreamRes.text();
+      const responseBody = await readResponseTextWithCap(upstreamRes);
       return new Response(responseBody, {
         status: upstreamRes.status,
         headers: {
@@ -249,7 +170,7 @@ export default async function handler(req) {
     }
 
     // Stream SSE response through
-    return new Response(upstreamRes.body, {
+    return new Response(capReadableStream(upstreamRes.body, PROXY_MAX_RESPONSE_BYTES), {
       status: upstreamRes.status,
       headers: {
         ...corsHeaders(req),
@@ -264,6 +185,57 @@ export default async function handler(req) {
       headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
     });
   }
+}
+
+async function readResponseTextWithCap(response) {
+  const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
+  if (contentLength > PROXY_MAX_RESPONSE_BYTES) throw new Error('Proxy response exceeds size cap');
+  const reader = response.body?.getReader?.();
+  if (!reader) return response.text();
+  const chunks = [];
+  let bytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value?.byteLength || 0;
+    if (bytes > PROXY_MAX_RESPONSE_BYTES) {
+      try { await reader.cancel(); } catch {}
+      throw new Error('Proxy response exceeds size cap');
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(bytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(out);
+}
+
+function capReadableStream(body, maxBytes) {
+  if (!body?.getReader || typeof ReadableStream !== 'function') return body;
+  const reader = body.getReader();
+  let bytes = 0;
+  return new ReadableStream({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      bytes += value?.byteLength || 0;
+      if (bytes > maxBytes) {
+        try { await reader.cancel(); } catch {}
+        controller.error(new Error('Proxy response exceeds size cap'));
+        return;
+      }
+      controller.enqueue(value);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
 }
 
 // Origins permitted to call /api/proxy. Lock to our production surfaces +

--- a/dev-server.js
+++ b/dev-server.js
@@ -14,6 +14,14 @@ import { fileURLToPath } from 'node:url';
 import { execFile, spawn } from 'node:child_process';
 import crypto from 'node:crypto';
 import zlib from 'node:zlib';
+import {
+  PROXY_MAX_REQUEST_BYTES,
+  PROXY_MAX_RESPONSE_BYTES,
+  isAllowedProxyUrl,
+  isProxyHostBlocked,
+  normalizeProxyMethod,
+  sanitizeProxyHeaders,
+} from './lib/proxy-policy.js';
 
 export const DEFAULT_UVDATA_UPSTREAM = 'https://uvdata.getbased.health';
 
@@ -302,87 +310,9 @@ if (fs.existsSync(ENV_LOCAL)) {
   console.log(`Loaded .env.local (${Object.keys(process.env).filter(k => k.endsWith('_CLIENT_SECRET')).length} secrets visible)`);
 }
 
-// ─── Proxy SSRF guard — mirrors api/proxy.js ALLOWED_ORIGINS + _isBlockedHost
-// Keep in sync with api/proxy.js when adding new vendor hosts.
-const _PROXY_ALLOWED_ORIGINS = [
-  'https://openrouter.ai/',
-  'https://api.venice.ai/',
-  'https://api.routstr.com/',
-  'https://api.ppq.ai/',
-  'https://api.ouraring.com/',
-  'https://api.prod.whoop.com/',
-  'https://partner.ultrahuman.com/',
-  'https://wbsapi.withings.net/',
-  'https://api.fitbit.com/',
-  'https://www.polaraccesslink.com/',
-  'https://polarremote.com/',
-];
-export function _proxyHostBlocked(host) {
-  if (!host) return true;
-  const h = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
-  if (h === 'localhost' || h === '127.0.0.1' || h === '::1') return true;
-  if (h.endsWith('.local') || h.endsWith('.localhost')) return true;
-  if (h === '168.63.129.16') return true;
-  // IPv6 literal: same allowlist-only-2000::/3 strategy as api/proxy.js
-  if (h.includes(':')) {
-    const lower = h.toLowerCase();
-    if (lower === '::' || lower === '0:0:0:0:0:0:0:0') return true;
-    if (/^fc[0-9a-f]{2}:/.test(lower) || /^fd[0-9a-f]{2}:/.test(lower)) return true;
-    if (/^fe[89ab][0-9a-f]:/.test(lower)) return true;
-    const v4Embed = lower.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-    if (v4Embed) return _proxyHostBlocked(v4Embed[1]);
-    if (lower.startsWith('::ffff:')) {
-      const tail = lower.slice(7);
-      const groups = tail.split(':');
-      if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
-        const g0 = parseInt(groups[0], 16);
-        const g1 = parseInt(groups[1], 16);
-        const a = (g0 >> 8) & 0xff;
-        const b = g0 & 0xff;
-        const c = (g1 >> 8) & 0xff;
-        const d = g1 & 0xff;
-        return _proxyHostBlocked(`${a}.${b}.${c}.${d}`);
-      }
-    }
-    const sixToFour = /^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4})(?::|$)/.exec(lower);
-    if (sixToFour) {
-      const g0 = parseInt(sixToFour[1], 16);
-      const g1 = parseInt(sixToFour[2], 16);
-      const a = (g0 >> 8) & 0xff;
-      const b = g0 & 0xff;
-      const c = (g1 >> 8) & 0xff;
-      const d = g1 & 0xff;
-      return _proxyHostBlocked(`${a}.${b}.${c}.${d}`);
-    }
-    return !/^[23][0-9a-f]{3}:/.test(lower);
-  }
-  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
-  if (!m) return false;
-  for (let i = 1; i <= 4; i++) {
-    const octet = m[i];
-    if (octet.length > 1 && octet[0] === '0') return true;
-    const n = +octet;
-    if (n > 255) return true;
-  }
-  const a = +m[1], b = +m[2];
-  if (a === 10) return true;
-  if (a === 127) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 192 && b === 168) return true;
-  if (a === 100 && b >= 64 && b <= 127) return true;
-  if (a === 0) return true;
-  return false;
-}
-export function _isAllowedProxyUrl(url) {
-  if (_PROXY_ALLOWED_ORIGINS.some(o => url.startsWith(o))) return true;
-  try {
-    const u = new URL(url);
-    if (u.protocol !== 'https:') return false;
-    if (_proxyHostBlocked(u.hostname)) return false;
-    return true;
-  } catch { return false; }
-}
+// ─── Proxy SSRF guard — shared with api/proxy.js
+export const _proxyHostBlocked = isProxyHostBlocked;
+export const _isAllowedProxyUrl = isAllowedProxyUrl;
 
 const MIME = {
   '.html': 'text/html', '.css': 'text/css', '.js': 'text/javascript',
@@ -591,6 +521,45 @@ const PROFILE_SHARE_MANAGE_TOKEN_HASH_RE = /^[a-f0-9]{64}$/;
 export function _sendProfileShareJSON(req, res, status, body) {
   res.writeHead(status, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', ...corsHeaders(req) });
   res.end(JSON.stringify(body));
+}
+export function _sendCappedProxyResponse(req, res, proxyRes) {
+  const ct = proxyRes.headers?.['content-type'] || 'application/json';
+  const contentLength = parseInt(proxyRes.headers?.['content-length'] || '0', 10);
+  const proxyCorsHeaders = { ...corsHeaders(req), 'Access-Control-Allow-Methods': 'POST, OPTIONS', 'Access-Control-Allow-Headers': 'Content-Type' };
+  const fail = (message) => {
+    try { proxyRes.destroy?.(); } catch {}
+    res.writeHead(502, { 'Content-Type': 'application/json', ...corsHeaders(req) });
+    res.end(JSON.stringify({ error: message }));
+  };
+  if (contentLength > PROXY_MAX_RESPONSE_BYTES) {
+    fail('Proxy response exceeds size cap');
+    return;
+  }
+  const chunks = [];
+  let responseBytes = 0;
+  let finished = false;
+  proxyRes.on('data', chunk => {
+    if (finished) return;
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    responseBytes += buf.length;
+    if (responseBytes > PROXY_MAX_RESPONSE_BYTES) {
+      finished = true;
+      fail('Proxy response exceeds size cap');
+      return;
+    }
+    chunks.push(buf);
+  });
+  proxyRes.on('end', () => {
+    if (finished) return;
+    finished = true;
+    res.writeHead(proxyRes.statusCode || 200, { 'Content-Type': ct, ...proxyCorsHeaders });
+    res.end(Buffer.concat(chunks, responseBytes));
+  });
+  proxyRes.on('error', (e) => {
+    if (finished) return;
+    finished = true;
+    fail('Upstream error: ' + (e?.message || e));
+  });
 }
 export function _validateProfileShareEnvelope(envelope) {
   if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) throw new Error('Missing encrypted profile payload.');
@@ -967,8 +936,22 @@ const server = http.createServer((req, res) => {
   // API: AI proxy — mirrors Vercel Edge Function for local CORS bypass
   if (pathname === '/api/proxy' && req.method === 'POST') {
     let body = '';
-    req.on('data', chunk => body += chunk);
+    let bytes = 0;
+    let aborted = false;
+    req.on('data', chunk => {
+      if (aborted) return;
+      bytes += chunk.length;
+      if (bytes > PROXY_MAX_REQUEST_BYTES) {
+        aborted = true;
+        res.writeHead(413, { 'Content-Type': 'application/json', ...corsHeaders(req) });
+        res.end('{"error":"Proxy request body too large"}');
+        req.destroy();
+        return;
+      }
+      body += chunk;
+    });
     req.on('end', () => {
+      if (aborted) return;
       try {
         const payload = JSON.parse(body);
 
@@ -1239,19 +1222,26 @@ const server = http.createServer((req, res) => {
         }
         const parsedUrl = new URL(targetUrl);
         const mod = parsedUrl.protocol === 'https:' ? https : http;
-        const fetchMethod = (upMethod || 'POST').toUpperCase();
+        const fetchMethod = normalizeProxyMethod(upMethod);
+        if (!fetchMethod) {
+          res.writeHead(405, { 'Content-Type': 'application/json', ...corsHeaders(req) });
+          res.end('{"error":"Proxy method not allowed"}'); return;
+        }
+        const safeHeaders = sanitizeProxyHeaders(fwdHeaders);
+        if (!safeHeaders.ok) {
+          res.writeHead(400, { 'Content-Type': 'application/json', ...corsHeaders(req) });
+          res.end(JSON.stringify({ error: safeHeaders.error })); return;
+        }
         // Caller-provided headers win. We fall back to application/json ONLY
         // if the caller didn't supply a Content-Type — otherwise Fitbit / any
         // form-urlencoded token endpoint breaks (it gets our form body tagged
         // as JSON and can't parse the `client_id` out). Matches the spread
         // order already used in api/proxy.js.
-        const reqHeaders = { ...fwdHeaders };
+        const reqHeaders = { ...safeHeaders.headers };
         const hasCT = Object.keys(reqHeaders).some(k => k.toLowerCase() === 'content-type');
         if (fetchMethod !== 'GET' && !hasCT) reqHeaders['Content-Type'] = 'application/json';
         const proxyReq = mod.request(targetUrl, { method: fetchMethod, headers: reqHeaders }, (proxyRes) => {
-          const ct = proxyRes.headers['content-type'] || 'application/json';
-          res.writeHead(proxyRes.statusCode, { 'Content-Type': ct, ...corsHeaders(req), 'Access-Control-Allow-Methods': 'POST, OPTIONS', 'Access-Control-Allow-Headers': 'Content-Type' });
-          proxyRes.pipe(res);
+          _sendCappedProxyResponse(req, res, proxyRes);
         });
         proxyReq.on('error', (e) => {
           res.writeHead(502, { 'Content-Type': 'application/json', ...corsHeaders(req) });

--- a/lib/proxy-policy.js
+++ b/lib/proxy-policy.js
@@ -1,0 +1,144 @@
+// @ts-check
+// Shared proxy safety policy for Vercel Edge and local dev-server.
+
+export const PROXY_ALLOWED_URL_PREFIXES = [
+  'https://openrouter.ai/',
+  'https://api.venice.ai/',
+  'https://api.routstr.com/',
+  'https://api.ppq.ai/',
+  'https://api.ouraring.com/',
+  'https://api.prod.whoop.com/',
+  'https://partner.ultrahuman.com/',
+  'https://wbsapi.withings.net/',
+  'https://api.fitbit.com/',
+  'https://www.polaraccesslink.com/',
+  'https://polarremote.com/',
+];
+
+export const PROXY_ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT']);
+export const PROXY_MAX_REQUEST_BYTES = 8 * 1024 * 1024;
+export const PROXY_MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
+
+const HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const PROXY_ALLOWED_HEADER_NAMES = new Set([
+  'accept',
+  'authorization',
+  'content-type',
+  'api-key',
+  'x-api-key',
+  'anthropic-version',
+  'openai-organization',
+  'openai-project',
+  'http-referer',
+  'x-title',
+]);
+const PROXY_BLOCKED_HEADER_NAMES = new Set([
+  'connection',
+  'content-length',
+  'cookie',
+  'host',
+  'proxy-authorization',
+  'set-cookie',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+export function isProxyHostBlocked(host) {
+  if (!host) return true;
+  const h = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  if (h === 'localhost' || h === '127.0.0.1' || h === '::1') return true;
+  if (h.endsWith('.local') || h.endsWith('.localhost')) return true;
+  if (h === '168.63.129.16') return true;
+  if (h.includes(':')) {
+    const lower = h.toLowerCase();
+    if (lower === '::' || lower === '0:0:0:0:0:0:0:0') return true;
+    if (/^fc[0-9a-f]{2}:/.test(lower) || /^fd[0-9a-f]{2}:/.test(lower)) return true;
+    if (/^fe[89ab][0-9a-f]:/.test(lower)) return true;
+    const v4Embed = lower.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+    if (v4Embed) return isProxyHostBlocked(v4Embed[1]);
+    if (lower.startsWith('::ffff:')) {
+      const tail = lower.slice(7);
+      const groups = tail.split(':');
+      if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
+        const g0 = parseInt(groups[0], 16);
+        const g1 = parseInt(groups[1], 16);
+        const a = (g0 >> 8) & 0xff;
+        const b = g0 & 0xff;
+        const c = (g1 >> 8) & 0xff;
+        const d = g1 & 0xff;
+        return isProxyHostBlocked(`${a}.${b}.${c}.${d}`);
+      }
+    }
+    const sixToFour = /^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4})(?::|$)/.exec(lower);
+    if (sixToFour) {
+      const g0 = parseInt(sixToFour[1], 16);
+      const g1 = parseInt(sixToFour[2], 16);
+      const a = (g0 >> 8) & 0xff;
+      const b = g0 & 0xff;
+      const c = (g1 >> 8) & 0xff;
+      const d = g1 & 0xff;
+      return isProxyHostBlocked(`${a}.${b}.${c}.${d}`);
+    }
+    return !/^[23][0-9a-f]{3}:/.test(lower);
+  }
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
+  if (!m) return false;
+  for (let i = 1; i <= 4; i++) {
+    const octet = m[i];
+    if (octet.length > 1 && octet[0] === '0') return true;
+    const n = +octet;
+    if (n > 255) return true;
+  }
+  const a = +m[1], b = +m[2];
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 0) return true;
+  return false;
+}
+
+export function isAllowedProxyUrl(url) {
+  if (PROXY_ALLOWED_URL_PREFIXES.some(origin => url.startsWith(origin))) return true;
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'https:') return false;
+    if (isProxyHostBlocked(u.hostname)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeProxyMethod(method) {
+  const normalized = String(method || 'POST').trim().toUpperCase();
+  return PROXY_ALLOWED_METHODS.has(normalized) ? normalized : null;
+}
+
+export function sanitizeProxyHeaders(headers = {}) {
+  if (headers == null) return { ok: true, headers: {} };
+  if (typeof headers !== 'object' || Array.isArray(headers)) {
+    return { ok: false, error: 'Proxy headers must be an object' };
+  }
+  const out = {};
+  for (const [rawName, rawValue] of Object.entries(headers)) {
+    if (rawValue == null) continue;
+    const name = String(rawName || '').trim();
+    const lower = name.toLowerCase();
+    if (!name || !HEADER_NAME_RE.test(name)) return { ok: false, error: `Proxy header not allowed: ${name || '(empty)'}` };
+    if (PROXY_BLOCKED_HEADER_NAMES.has(lower) || lower.startsWith('x-forwarded-')) {
+      return { ok: false, error: `Proxy header not allowed: ${name}` };
+    }
+    if (!PROXY_ALLOWED_HEADER_NAMES.has(lower)) {
+      return { ok: false, error: `Proxy header not allowed: ${name}` };
+    }
+    const value = String(rawValue);
+    if (/[\r\n]/.test(value)) return { ok: false, error: `Proxy header has invalid value: ${name}` };
+    out[name] = value;
+  }
+  return { ok: true, headers: out };
+}

--- a/tests/api-network-runtime.test.js
+++ b/tests/api-network-runtime.test.js
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import commitHandler from '../api/commit.js';
 import proxyHandler from '../api/proxy.js';
+import {
+  PROXY_MAX_REQUEST_BYTES,
+  PROXY_MAX_RESPONSE_BYTES,
+} from '../lib/proxy-policy.js';
 import shareHandler from '../api/share.js';
 
 const realFetch = globalThis.fetch;
@@ -371,6 +375,121 @@ describe('AI proxy runtime behavior', () => {
     }));
     expect(failed.status).toBe(502);
     expect(await responseJson(failed)).toEqual({ error: 'Upstream error: offline' });
+  });
+
+  it('preserves provider-compatible headers for proxied custom API calls', async () => {
+    globalThis.fetch = vi.fn(async () => jsonResponse({ ok: true }));
+
+    const modelList = await proxyHandler(makeProxyRequest({
+      url: 'https://custom.example.com/v1/models',
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer custom-key',
+        'api-key': 'azure-key',
+        'OpenAI-Organization': 'org_123',
+        'OpenAI-Project': 'proj_123',
+      },
+    }));
+    expect(modelList.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledWith('https://custom.example.com/v1/models', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer custom-key',
+        'api-key': 'azure-key',
+        'OpenAI-Organization': 'org_123',
+        'OpenAI-Project': 'proj_123',
+      },
+    });
+
+    const chatBody = JSON.stringify({
+      model: 'openai/gpt-5.5',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_completion_tokens: 32,
+    });
+    const chat = await proxyHandler(makeProxyRequest({
+      url: 'https://openrouter.ai/api/v1/chat/completions',
+      headers: {
+        Authorization: 'Bearer sk-or',
+        'HTTP-Referer': 'https://app.getbased.health',
+        'X-Title': 'getbased',
+        'anthropic-version': '2023-06-01',
+        'x-api-key': 'anthropic-key',
+      },
+      body: chatBody,
+    }));
+    expect(chat.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenLastCalledWith('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sk-or',
+        'HTTP-Referer': 'https://app.getbased.health',
+        'X-Title': 'getbased',
+        'anthropic-version': '2023-06-01',
+        'x-api-key': 'anthropic-key',
+        'Content-Type': 'application/json',
+      },
+      body: chatBody,
+    });
+  });
+
+  it('constrains the generic proxy envelope before forwarding upstream', async () => {
+    globalThis.fetch = vi.fn(async () => jsonResponse({ ok: true }));
+
+    const badMethod = await proxyHandler(makeProxyRequest({
+      url: 'https://models.example.com/v1/delete',
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer key' },
+    }));
+    expect(badMethod.status).toBe(405);
+    expect(await responseJson(badMethod)).toEqual({ error: 'Proxy method not allowed' });
+
+    const badHeader = await proxyHandler(makeProxyRequest({
+      url: 'https://models.example.com/v1/chat',
+      headers: { Host: 'metadata.google.internal' },
+    }));
+    expect(badHeader.status).toBe(400);
+    expect(await responseJson(badHeader)).toEqual({ error: 'Proxy header not allowed: Host' });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    const oversizedRequest = await proxyHandler(makeProxyRequest(undefined, {
+      rawBody: '{"pad":"' + 'x'.repeat(PROXY_MAX_REQUEST_BYTES + 1) + '"}',
+    }));
+    expect(oversizedRequest.status).toBe(413);
+    expect(await responseJson(oversizedRequest)).toEqual({ error: 'Proxy request body too large' });
+
+    globalThis.fetch = vi.fn(async () => new Response('{}', {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'content-length': String(PROXY_MAX_RESPONSE_BYTES + 1),
+      },
+    }));
+    const oversizedResponse = await proxyHandler(makeProxyRequest({
+      url: 'https://models.example.com/v1/chat',
+      headers: { Authorization: 'Bearer key' },
+    }));
+    expect(oversizedResponse.status).toBe(502);
+    expect(await responseJson(oversizedResponse)).toEqual({
+      error: 'Upstream error: Proxy response exceeds size cap',
+    });
+
+    globalThis.fetch = vi.fn(async () => jsonResponse({ ok: true }));
+    const put = await proxyHandler(makeProxyRequest({
+      url: 'https://www.polaraccesslink.com/v3/users/u/activity-transactions/t',
+      method: 'PUT',
+      headers: { Authorization: 'Bearer polar' },
+    }));
+    expect(put.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://www.polaraccesslink.com/v3/users/u/activity-transactions/t',
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: 'Bearer polar',
+          'Content-Type': 'application/json',
+        },
+      },
+    );
   });
 
   it('relays wearable OAuth token requests with server-side secrets', async () => {

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -275,8 +275,11 @@ assert('SW keeps same-origin localhost eligible for offline app-shell handling',
 // ─── 17. Proxy supports GET passthrough ───
 console.log('\n17. Proxy GET support');
 const proxySrc = read('api/proxy.js');
+const proxyPolicySrc = read('lib/proxy-policy.js');
 assert('proxy extracts method field', proxySrc.includes('method: upstreamMethod'));
-assert('proxy defaults to POST', proxySrc.includes("upstreamMethod || 'POST'"));
+assert('proxy defaults to POST through shared method policy',
+  proxySrc.includes('normalizeProxyMethod(upstreamMethod)')
+  && proxyPolicySrc.includes("String(method || 'POST')"));
 assert('proxy skips body for GET', proxySrc.includes("fetchMethod !== 'GET'"));
 assert('_customApiFetchModels uses proxy', apiCustomSrc.includes('function _customApiFetchModels('));
 assert('_customApiFetchModels bases proxy decision on explicit URL', apiCustomSrc.includes('shouldProxyCustomApiUrl(url)'));

--- a/tests/test-dev-server-helpers.js
+++ b/tests/test-dev-server-helpers.js
@@ -37,9 +37,15 @@ import {
   _browserLaunchCandidates,
   openDevBrowser,
   _sendProfileShareJSON,
+  _sendCappedProxyResponse,
   _validateProfileShareEnvelope,
   _handleProfileShareDev,
 } from '../dev-server.js';
+import {
+  PROXY_MAX_RESPONSE_BYTES,
+  normalizeProxyMethod,
+  sanitizeProxyHeaders,
+} from '../lib/proxy-policy.js';
 
 let passed = 0, failed = 0;
 const DEV_SERVER_PORT = parseInt(process.argv[2], 10) || 8000;
@@ -57,6 +63,30 @@ function assertThrows(name, fn, pattern) {
     const message = String(err?.message || err);
     assert(name, pattern ? pattern.test(message) : true, message);
   }
+}
+function makeMockResponse() {
+  return {
+    status: null,
+    headers: null,
+    chunks: [],
+    headersSent: false,
+    ended: false,
+    writeHead(status, headers) {
+      this.status = status;
+      this.headers = headers;
+      this.headersSent = true;
+    },
+    end(chunk = '') {
+      if (chunk) this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+      this.ended = true;
+    },
+    text() {
+      return Buffer.concat(this.chunks).toString();
+    },
+  };
+}
+function makeMockRequest(origin = LOOPBACK_ORIGIN) {
+  return { headers: { origin } };
 }
 
 console.log('\n── parseEnvLocal ──');
@@ -257,6 +287,76 @@ assert('blocks 6to4 private IP',       !_isAllowedProxyUrl('https://[2002:c0a8:0
 assert('blocks cloud metadata',        !_isAllowedProxyUrl('https://169.254.169.254/latest/meta-data/'));
 assert('blocks .local',                !_isAllowedProxyUrl('https://box.local/admin'));
 assert('blocks malformed URL',         !_isAllowedProxyUrl('not a url'));
+
+console.log('\n── shared proxy request policy ──');
+
+assert('proxy method policy allows current app method set',
+  normalizeProxyMethod('GET') === 'GET'
+  && normalizeProxyMethod('post') === 'POST'
+  && normalizeProxyMethod('PUT') === 'PUT');
+assert('proxy method policy rejects unused tunnel methods',
+  normalizeProxyMethod('DELETE') === null
+  && normalizeProxyMethod('PATCH') === null);
+{
+  const sanitized = sanitizeProxyHeaders({
+    Authorization: 'Bearer token',
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'x-api-key': 'custom-key',
+  });
+  assert('proxy header policy preserves allowed API headers',
+    sanitized.ok
+      && sanitized.headers.Authorization === 'Bearer token'
+      && sanitized.headers.Accept === 'application/json'
+      && sanitized.headers['Content-Type'] === 'application/json'
+      && sanitized.headers['x-api-key'] === 'custom-key',
+    JSON.stringify(sanitized));
+}
+assert('proxy header policy rejects hop-by-hop headers',
+  sanitizeProxyHeaders({ Host: 'metadata.google.internal' }).ok === false
+  && sanitizeProxyHeaders({ 'X-Forwarded-Host': 'metadata.google.internal' }).ok === false);
+assert('proxy header policy rejects CRLF header injection',
+  sanitizeProxyHeaders({ Authorization: 'Bearer ok\r\nX-Bad: yes' }).ok === false);
+{
+  const upstream = new EventEmitter();
+  upstream.headers = { 'content-type': 'text/plain' };
+  upstream.statusCode = 201;
+  upstream.destroy = () => {};
+  const res = makeMockResponse();
+  _sendCappedProxyResponse(makeMockRequest(), res, upstream);
+  upstream.emit('data', Buffer.from('hello'));
+  assert('dev proxy waits to send unknown-length upstream headers until body cap is known',
+    res.headersSent === false && res.ended === false);
+  upstream.emit('end');
+  assert('dev proxy forwards complete unknown-length upstream response',
+    res.status === 201
+      && res.headers['Content-Type'] === 'text/plain'
+      && res.headers['Access-Control-Allow-Origin'] === LOOPBACK_ORIGIN
+      && res.text() === 'hello',
+    `${res.status} ${JSON.stringify(res.headers)} ${res.text()}`);
+}
+{
+  let destroyed = false;
+  const upstream = new EventEmitter();
+  upstream.headers = { 'content-type': 'application/json' };
+  upstream.statusCode = 200;
+  upstream.destroy = () => { destroyed = true; };
+  const res = makeMockResponse();
+  _sendCappedProxyResponse(makeMockRequest(), res, upstream);
+  upstream.emit('data', Buffer.alloc(PROXY_MAX_RESPONSE_BYTES));
+  assert('dev proxy does not send a partial success response at exactly the cap',
+    res.headersSent === false && res.ended === false);
+  upstream.emit('data', Buffer.alloc(1));
+  assert('dev proxy returns explicit 502 when unknown-length upstream exceeds cap',
+    res.status === 502
+      && destroyed
+      && res.headers['Content-Type'] === 'application/json'
+      && res.text() === '{"error":"Proxy response exceeds size cap"}',
+    `${res.status} ${JSON.stringify(res.headers)} ${res.text()}`);
+  upstream.emit('end');
+  assert('dev proxy cap failure is not overwritten by upstream end',
+    res.status === 502 && res.text() === '{"error":"Proxy response exceeds size cap"}');
+}
 
 console.log('\n── origin/CORS/profile share helpers ──');
 

--- a/tests/test-security-phase1.js
+++ b/tests/test-security-phase1.js
@@ -108,6 +108,20 @@ if (exists('dev-server.js')) {
   assert('dev-server.js re-checks redirect destinations',
     devSrc.match(/_isAllowedProxyUrl\(loc\)|_isAllowedProxyUrl\(redirect\)/g)?.length >= 3,
     '/api/check-url + /api/fetch-page + /proxy redirect-follow paths each need their own guard');
+  assert('dev-server.js uses shared proxy policy for generic proxy envelope',
+    devSrc.includes("from './lib/proxy-policy.js'")
+      && devSrc.includes('normalizeProxyMethod(upMethod)')
+      && devSrc.includes('sanitizeProxyHeaders(fwdHeaders)')
+      && devSrc.includes('PROXY_MAX_REQUEST_BYTES')
+      && devSrc.includes('PROXY_MAX_RESPONSE_BYTES'));
+  const edgeProxySrc = read('api/proxy.js');
+  assert('api/proxy.js uses shared proxy policy for URL and envelope guards',
+    edgeProxySrc.includes("from '../lib/proxy-policy.js'")
+      && edgeProxySrc.includes('isAllowedProxyUrl(url)')
+      && edgeProxySrc.includes('normalizeProxyMethod(upstreamMethod)')
+      && edgeProxySrc.includes('sanitizeProxyHeaders(headers)')
+      && edgeProxySrc.includes('PROXY_MAX_REQUEST_BYTES')
+      && edgeProxySrc.includes('PROXY_MAX_RESPONSE_BYTES'));
 } else {
   console.log('  (dev-server.js not present — production build, skipping CORS source asserts)');
 }


### PR DESCRIPTION
Fixes #1131

## Summary
- centralize the generic proxy allowlist, SSRF host guard, method policy, header policy, and byte caps in `lib/proxy-policy.js`
- apply the shared policy in both the Vercel Edge proxy and local dev server proxy
- preserve API-provider-compatible headers for proxied custom/OpenAI-compatible calls while blocking hop-by-hop and forged forwarding headers
- add regression coverage for provider headers, method constraints, request/response caps, and shared policy wiring

## Provider compatibility
- First-class AI providers still call their provider endpoints directly: OpenRouter, Venice, Routstr, PPQ, and local AI provider modules were not changed.
- The generic proxy still permits GET/POST/PUT, which covers custom API model fetches, chat completions, and existing Polar flows.
- Allowed proxied provider headers include `Authorization`, `api-key`, `x-api-key`, `OpenAI-Organization`, `OpenAI-Project`, `HTTP-Referer`, `X-Title`, and `anthropic-version`.

## Validation
- `npx vitest run tests/api-network-runtime.test.js tests/api-provider-runtime.test.js tests/api-runtime.test.js`
- `node tests/test-custom-api.js`
- `node tests/test-openrouter.js`
- `node tests/test-venice-e2ee.js`
- `node tests/test-ppq-provider.js`
- `node tests/test-cashu-wallet.js`
- `node tests/test-provider-local-ai-runtime.js`
- `node tests/test-dev-server-helpers.js`
- `node tests/test-security-phase1.js`
- `npm test`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npx vercel build --yes`
- `git diff --check`