### PR TITLE
Disable Vercel preview deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "**": false
+    }
+  },
   "buildCommand": "node scripts/fetch-catalog.mjs",
   "outputDirectory": ".",
   "routes": [


### PR DESCRIPTION
## Summary
- disable automatic Vercel deployments for non-main branches
- keep main production deployments enabled

## Validation
- parsed vercel.json with Node
- cleaned existing stale get-based preview deployments in Vercel