### PR TITLE
Add differential percent import integrity

### DIFF
--- a/js/pdf-import-commit.js
+++ b/js/pdf-import-commit.js
@@ -118,7 +118,7 @@ export async function confirmImport() {
   }
   entry.updatedAt = importTs;
   for (const m of matched) {
-    setLabEntryMarker(entry, m.mappedKey, normalizeToSI(m.mappedKey, m.value, m.unit), {
+    setLabEntryMarker(entry, m.mappedKey, normalizeToSI(m.mappedKey, m.value, m.unit, m), {
       now: importTs,
       source: { file: result.fileName || null, at: importTs, snapshotId },
     });
@@ -148,7 +148,7 @@ export async function confirmImport() {
   }
   // Save new (custom) marker values and definitions
   for (const m of newMarkers) {
-    setLabEntryMarker(entry, m.suggestedKey, normalizeToSI(m.suggestedKey, m.value, m.unit), {
+    setLabEntryMarker(entry, m.suggestedKey, normalizeToSI(m.suggestedKey, m.value, m.unit, m), {
       now: importTs,
       source: { file: result.fileName || null, at: importTs, snapshotId },
     });
@@ -177,8 +177,8 @@ export async function confirmImport() {
       if (m.refMin == null && m.refMax == null) continue;
       const ovr = state.importedData.refOverrides[m.mappedKey] || {};
       // Convert ranges from PDF units to SI (same as marker values)
-      const siMin = m.refMin != null ? normalizeToSI(m.mappedKey, m.refMin, m.unit) : null;
-      const siMax = m.refMax != null ? normalizeToSI(m.mappedKey, m.refMax, m.unit) : null;
+      const siMin = m.refMin != null ? normalizeToSI(m.mappedKey, m.refMin, m.unit, m) : null;
+      const siMax = m.refMax != null ? normalizeToSI(m.mappedKey, m.refMax, m.unit, m) : null;
       // Look up schema default to avoid storing redundant overrides
       const [ck, mk] = m.mappedKey.split('.');
       const schemaDef = MARKER_SCHEMA[ck]?.markers?.[mk];
@@ -289,7 +289,7 @@ function restoreLatestSnapshotMarkerForKey(entry, removedSnapshot, dotKey, now =
   const replacement = findLatestRestorableSnapshotMarker(removedSnapshot.date, removedSnapshot.id, dotKey);
   if (!replacement) return false;
   const { snap, marker } = replacement;
-  setLabEntryMarker(entry, dotKey, normalizeToSI(dotKey, marker.value, marker.unit), {
+  setLabEntryMarker(entry, dotKey, normalizeToSI(dotKey, marker.value, marker.unit, marker), {
     now,
     source: { file: snap.fileName || null, at: snap.importedAt || now, snapshotId: snap.id },
   });

--- a/js/pdf-import-marker-mapping.js
+++ b/js/pdf-import-marker-mapping.js
@@ -30,9 +30,11 @@ function isFractionStoredPercentMarker(key) {
     && isPercentImportUnit(conv.usUnit);
 }
 
-function normalizeFractionStoredPercentValue(key, value, unit) {
+function normalizeFractionStoredPercentValue(key, value, unit, context = null) {
   if (!isFractionStoredPercentMarker(key) || !isPercentImportUnit(unit)) return null;
-  const siValue = value > 1 ? value / 100 : value;
+  const [catKey, markerKey] = String(key || '').split('.');
+  const [schemaRefMax, reportRefMax] = [Number(MARKER_SCHEMA[catKey]?.markers?.[markerKey]?.refMax), Number(context?.refMax)];
+  const siValue = value > 1 || (reportRefMax > 1 && reportRefMax > schemaRefMax && !(Number.isFinite(schemaRefMax) && value <= schemaRefMax)) ? value / 100 : value;
   return parseFloat(siValue.toPrecision(6));
 }
 
@@ -628,8 +630,6 @@ function _resolveStandardBloodImportKey(marker, refLookup, differentialPercentSu
     const pctKey = `differential.${differentialStem}Pct`;
     return refLookup[pctKey] ? pctKey : null;
   }
-  if (compactBase === 'eosinofily' || compactBase === 'basofily') return null;
-
   const lookup = _buildStandardBloodNameLookup();
   const labels = [marker.rawName, marker.suggestedName];
   if (marker.mappedKey) labels.push(marker.mappedKey.split('.').pop());
@@ -688,7 +688,7 @@ export function reconcileImportMarkerMappings(markers, options = {}) {
   return markers;
 }
 
-export function normalizeToSI(key, value, unit) {
+export function normalizeToSI(key, value, unit, context = null) {
   if (value == null || isNaN(value)) return null;
 
   // Hematocrit: schema stores as % (40–50) but some labs report as fraction l/l (0.40–0.50)
@@ -699,7 +699,7 @@ export function normalizeToSI(key, value, unit) {
   // When a unit string is present, systematically evaluate all conversion registries
   if (unit) {
     const aiUnit = normalizeUnitStr(unit);
-    const fractionPercentValue = normalizeFractionStoredPercentValue(key, value, aiUnit);
+    const fractionPercentValue = normalizeFractionStoredPercentValue(key, value, aiUnit, context);
     if (fractionPercentValue != null) return fractionPercentValue;
 
     // 1. Evaluate primary US conversions

--- a/js/pdf-import-review.js
+++ b/js/pdf-import-review.js
@@ -539,8 +539,8 @@ export function showImportPreview(parseResult) {
     if (m.refMin == null && m.refMax == null) continue;
     const schemaRef = refLookup[m.mappedKey];
     if (!schemaRef) continue;
-    const siMin = m.refMin != null ? normalizeToSI(m.mappedKey, m.refMin, m.unit) : null;
-    const siMax = m.refMax != null ? normalizeToSI(m.mappedKey, m.refMax, m.unit) : null;
+    const siMin = m.refMin != null ? normalizeToSI(m.mappedKey, m.refMin, m.unit, m) : null;
+    const siMax = m.refMax != null ? normalizeToSI(m.mappedKey, m.refMax, m.unit, m) : null;
     if ((siMin !== schemaRef.refMin && !(siMin != null && schemaRef.refMin != null && Math.abs(siMin - schemaRef.refMin) < 0.001)) ||
         (siMax !== schemaRef.refMax && !(siMax != null && schemaRef.refMax != null && Math.abs(siMax - schemaRef.refMax) < 0.001))) {
       rangesDiffCount++;

--- a/js/profile-marker-migrations.js
+++ b/js/profile-marker-migrations.js
@@ -233,6 +233,8 @@ const FRACTION_STORED_PERCENT_MARKERS = new Set([
   'differential.neutrophilsPct',
   'differential.lymphocytesPct',
   'differential.monocytesPct',
+  'differential.eosinophilsPct',
+  'differential.basophilsPct',
 ]);
 
 /**
@@ -468,18 +470,26 @@ function _profileMarkerValuesMatch(a, b) {
 
 /**
  * @param {any} marker
- * @returns {{ key: string, value: number, dividedValue: number } | null}
+ * @returns {{ key: string, canonicalValue: number, dividedValue: number | null, wholePercentValue: number | null } | null}
  */
 function _fractionStoredPercentSnapshotMarker(marker) {
   const key = marker?.mappedKey || marker?.suggestedKey || '';
   if (!FRACTION_STORED_PERCENT_MARKERS.has(key)) return null;
   if (!_isProfilePercentUnit(marker?.unit)) return null;
   const value = Number(marker?.value);
-  if (!Number.isFinite(value) || value < 0 || value > 1) return null;
+  if (!Number.isFinite(value) || value < 0 || value > 100) return null;
+  const [catKey, markerKey] = key.split('.');
+  const schemaRefMax = Number(MARKER_SCHEMA[catKey]?.markers?.[markerKey]?.refMax);
+  const markerRefMax = Number(marker?.refMax);
+  const snapshotRangeUsesWholePercent = Number.isFinite(markerRefMax) && markerRefMax > 1;
+  const valueLooksCanonical = Number.isFinite(schemaRefMax) && value <= schemaRefMax;
+  const valueUsesWholePercent = value > 1 || (snapshotRangeUsesWholePercent && !valueLooksCanonical);
+  const canonicalValue = valueUsesWholePercent ? parseFloat((value / 100).toPrecision(6)) : value;
   return {
     key,
-    value,
-    dividedValue: parseFloat((value / 100).toPrecision(6)),
+    canonicalValue,
+    dividedValue: valueUsesWholePercent ? null : parseFloat((value / 100).toPrecision(6)),
+    wholePercentValue: valueUsesWholePercent ? value : null,
   };
 }
 
@@ -498,12 +508,21 @@ function _repairFractionStoredPercentRefOverride(data, key, marker) {
     ['labRefMin', 'refMin'],
     ['labRefMax', 'refMax'],
   ];
+  const markerRefMax = Number(marker?.refMax);
+  const snapshotRangeUsesWholePercent = Number.isFinite(markerRefMax) && markerRefMax > 1;
+  const [catKey, markerKey] = key.split('.');
+  const schemaRefMax = Number(MARKER_SCHEMA[catKey]?.markers?.[markerKey]?.refMax);
   for (const [overrideField, markerField] of pairs) {
     const raw = Number(marker?.[markerField]);
-    if (!Number.isFinite(raw) || raw < 0 || raw > 1) continue;
-    const divided = parseFloat((raw / 100).toPrecision(6));
-    if (_profileMarkerValuesMatch(override[overrideField], divided)) {
+    if (!Number.isFinite(raw) || raw < 0 || raw > 100) continue;
+    const rawLooksCanonical = Number.isFinite(schemaRefMax) && raw <= schemaRefMax;
+    const rawUsesWholePercent = raw > 1 || (snapshotRangeUsesWholePercent && !rawLooksCanonical);
+    const canonical = rawUsesWholePercent ? parseFloat((raw / 100).toPrecision(6)) : raw;
+    const divided = rawUsesWholePercent ? null : parseFloat((raw / 100).toPrecision(6));
+    if (divided != null && _profileMarkerValuesMatch(override[overrideField], divided)) {
       override[overrideField] = raw;
+    } else if (raw > 1 && _profileMarkerValuesMatch(override[overrideField], raw)) {
+      override[overrideField] = canonical;
     }
   }
 }
@@ -519,16 +538,28 @@ function _repairFractionStoredPercentImports(data) {
     for (const marker of snap.markers) {
       const percentMarker = _fractionStoredPercentSnapshotMarker(marker);
       if (!percentMarker) continue;
-      const { key, value, dividedValue } = percentMarker;
+      const { key, canonicalValue, dividedValue, wholePercentValue } = percentMarker;
+      if (!marker.mappedKey && marker.suggestedKey === key) {
+        marker.mappedKey = key;
+        marker.suggestedKey = null;
+        marker.matched = true;
+      }
       for (const entry of data.entries) {
         if (!entry?.markers || !Object.prototype.hasOwnProperty.call(entry.markers, key)) continue;
         const source = entry.markerSources?.[key];
         const sourceMatches = (snap?.id && source?.snapshotId === snap.id)
-          || (snap?.date && entry.date === snap.date && _profileMarkerValuesMatch(entry.markers[key], dividedValue));
+          || (snap?.date && entry.date === snap.date && (
+            (dividedValue != null && _profileMarkerValuesMatch(entry.markers[key], dividedValue))
+            || (wholePercentValue != null && _profileMarkerValuesMatch(entry.markers[key], wholePercentValue))
+          ));
         if (!sourceMatches) continue;
-        if (_profileMarkerValuesMatch(entry.markers[key], dividedValue)) entry.markers[key] = value;
+        if (dividedValue != null && _profileMarkerValuesMatch(entry.markers[key], dividedValue)) entry.markers[key] = canonicalValue;
+        if (wholePercentValue != null && _profileMarkerValuesMatch(entry.markers[key], wholePercentValue)) entry.markers[key] = canonicalValue;
       }
       _repairFractionStoredPercentRefOverride(data, key, marker);
+      if (data.customMarkers?.[key] && MARKER_SCHEMA[key.split('.')[0]]?.markers?.[key.split('.')[1]]) {
+        delete data.customMarkers[key];
+      }
     }
   }
 }

--- a/js/schema.js
+++ b/js/schema.js
@@ -183,7 +183,9 @@ export const MARKER_SCHEMA = {
       basophils: { name: "Basophils #", unit: "10^9/l", refMin: 0.0, refMax: 0.2, desc: "The rarest white blood cells involved in allergic reactions and histamine release; markedly elevated in some blood cancers." },
       neutrophilsPct: { name: "Neutrophils %", unit: "", refMin: 0.45, refMax: 0.70, desc: "Proportion of white blood cells that are neutrophils; shifts in percentage help distinguish bacterial from viral infections." },
       lymphocytesPct: { name: "Lymphocytes %", unit: "", refMin: 0.20, refMax: 0.45, desc: "Proportion of white blood cells that are lymphocytes; relatively elevated in viral infections and lymphoproliferative disorders." },
-      monocytesPct: { name: "Monocytes %", unit: "", refMin: 0.02, refMax: 0.12, desc: "Proportion of white blood cells that are monocytes; elevated in chronic inflammation, tuberculosis, and recovery phases." }
+      monocytesPct: { name: "Monocytes %", unit: "", refMin: 0.02, refMax: 0.12, desc: "Proportion of white blood cells that are monocytes; elevated in chronic inflammation, tuberculosis, and recovery phases." },
+      eosinophilsPct: { name: "Eosinophils %", unit: "", refMin: 0.00, refMax: 0.05, desc: "Proportion of white blood cells that are eosinophils; elevated percentages are commonly associated with allergic, asthmatic, and parasitic patterns." },
+      basophilsPct: { name: "Basophils %", unit: "", refMin: 0.00, refMax: 0.02, desc: "Proportion of white blood cells that are basophils; small shifts can appear with allergic inflammation or some myeloproliferative patterns." }
     }
   },
   boneMetabolism: {
@@ -302,6 +304,8 @@ export const UNIT_CONVERSIONS = {
   'differential.neutrophilsPct': { factor: 100, usUnit: '%', type: 'multiply' },
   'differential.lymphocytesPct': { factor: 100, usUnit: '%', type: 'multiply' },
   'differential.monocytesPct': { factor: 100, usUnit: '%', type: 'multiply' },
+  'differential.eosinophilsPct': { factor: 100, usUnit: '%', type: 'multiply' },
+  'differential.basophilsPct': { factor: 100, usUnit: '%', type: 'multiply' },
   'boneMetabolism.osteocalcin': { factor: 1, usUnit: 'ng/ml', type: 'multiply' },
   'tumorMarkers.psa': { factor: 1, usUnit: 'ng/ml', type: 'multiply' },
   'tumorMarkers.afp': { factor: 1.21, usUnit: 'ng/ml', type: 'multiply' },

--- a/tests/_vitest-legacy.test.js
+++ b/tests/_vitest-legacy.test.js
@@ -81,6 +81,7 @@ const LEGACY_TESTS = [
   // and the expanded normalizeToSI() paths (secondary conv, SI passthrough,
   // unknown-unit passthrough, urea/BUN edge cases).
   './test-secondary-unit-conversions.js',
+  './test-import-chart-data-integrity.js',
   // Batch 7 — wearables fetchers + hardware advisor.
   './test-wearables-fetchers.js',
   './test-wearables-runtime-config.js',

--- a/tests/test-import-chart-data-integrity.js
+++ b/tests/test-import-chart-data-integrity.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+// test-import-chart-data-integrity.js - import normalization must preserve
+// chart semantics for markers whose imported unit labels look like percent.
+//
+// Run: node tests/test-import-chart-data-integrity.js (or via npm test)
+
+import './_node-shim.js';
+
+const savedGetComputedStyle = globalThis.getComputedStyle;
+const chartColorValues = {
+  '--bg-card': '#111111',
+  '--text-primary': '#f8fafc',
+  '--text-secondary': '#cbd5e1',
+  '--border': '#334155',
+  '--text-muted': '#94a3b8',
+  '--chart-grid': '#1f2937',
+  '--accent': '#38bdf8',
+  '--accent-fill': 'rgba(56,189,248,0.12)',
+  '--chart-tooltip-bg': '#020617',
+  '--green': '#22c55e',
+  '--red': '#ef4444',
+  '--yellow': '#f59e0b',
+  '--ref-band': 'rgba(34,197,94,0.10)',
+  '--ref-border': 'rgba(34,197,94,0.35)',
+};
+
+globalThis.getComputedStyle = () => ({
+  getPropertyValue: prop => chartColorValues[prop] || '#000000',
+});
+
+let pass = 0, fail = 0;
+function assert(name, condition, detail) {
+  if (condition) { pass++; console.log(`  PASS: ${name}`); }
+  else { fail++; console.log(`  FAIL: ${name}${detail ? ' - ' + detail : ''}`); }
+}
+
+const approx = (a, b, eps = 1e-6) => Math.abs(a - b) <= eps;
+
+console.log('=== Import to Chart Data Integrity Tests ===\n');
+
+const { MARKER_SCHEMA } = await import('../js/schema.js');
+const { state } = await import('../js/state.js');
+const { normalizeToSI } = await import('../js/pdf-import-marker-mapping.js');
+const { renderChartCard } = await import('../js/category-view-renderers.js');
+const { createLineChart } = await import('../js/charts.js');
+
+const saved = {
+  getElementById: document.getElementById,
+  chartInstances: state.chartInstances,
+  markerRegistry: state.markerRegistry,
+  rangeMode: state.rangeMode,
+  Chart: window.Chart,
+};
+
+const canvases = new Map();
+document.getElementById = id => canvases.get(id) || null;
+window.Chart = class ChartStub {
+  constructor(canvas, config) {
+    this.canvas = canvas;
+    this.config = config;
+    this.data = config.data;
+    this.options = config.options;
+  }
+  update() {}
+  destroy() {}
+};
+
+function schemaMarker(dotKey) {
+  const dot = dotKey.indexOf('.');
+  const catKey = dotKey.slice(0, dot);
+  const markerKey = dotKey.slice(dot + 1);
+  return MARKER_SCHEMA[catKey]?.markers?.[markerKey] || null;
+}
+
+function markerFromImport(dotKey, rawValue, rawUnit, importContext = null) {
+  const schema = schemaMarker(dotKey);
+  const normalized = normalizeToSI(dotKey, rawValue, rawUnit, importContext);
+  return {
+    ...schema,
+    values: [normalized],
+  };
+}
+
+function assertImportedMarkerCharts(caseDef) {
+  const {
+    name,
+    key,
+    rawValue,
+    rawUnit,
+    expectedStored,
+    expectedDisplay,
+    importContext = null,
+    forbiddenDisplays = [],
+  } = caseDef;
+  const id = key.replace('.', '_');
+  const marker = markerFromImport(key, rawValue, rawUnit, importContext);
+  const stored = marker.values[0];
+  const unitLabel = marker.unit ? ` ${marker.unit}` : '';
+
+  assert(`${name}: schema marker exists`, !!schemaMarker(key), key);
+  assert(`${name}: import stores canonical chart value`,
+    approx(stored, expectedStored),
+    `stored ${stored}, expected ${expectedStored}`);
+
+  state.rangeMode = 'reference';
+  state.markerRegistry = {};
+  state.chartInstances = {};
+
+  const html = renderChartCard(id, marker, ['Imported']);
+  assert(`${name}: chart card latest value uses canonical value`,
+    html.includes(`class="chart-card-latest-value val-normal">${expectedDisplay}</strong>`),
+    expectedDisplay);
+  assert(`${name}: compact chart value uses canonical value`,
+    html.includes(`class="chart-value-num val-normal">${expectedDisplay}</div>`),
+    expectedDisplay);
+  assert(`${name}: chart card status remains normal`,
+    html.includes('class="chart-card chart-card-normal"'),
+    html.slice(0, 160));
+  for (const forbidden of forbiddenDisplays) {
+    assert(`${name}: chart card does not show ${forbidden}`,
+      !html.includes(forbidden),
+      forbidden);
+  }
+
+  const canvas = { id: `chart-${id}`, style: {}, getContext: () => ({}) };
+  canvases.set(`chart-${id}`, canvas);
+  createLineChart(id, marker, ['Imported']);
+  const chart = state.chartInstances[id];
+  const chartValue = chart?.data?.datasets?.[0]?.data?.[0];
+  assert(`${name}: Chart.js dataset receives canonical value`,
+    approx(chartValue, expectedStored),
+    `dataset ${chartValue}, expected ${expectedStored}`);
+
+  const label = chart?.options?.plugins?.tooltip?.callbacks?.label?.({
+    dataset: chart.data.datasets[0],
+    parsed: { y: expectedStored },
+  });
+  assert(`${name}: Chart.js tooltip formats canonical value`,
+    String(label).trim() === `${expectedDisplay}${unitLabel}`.trim(),
+    `tooltip "${label}"`);
+}
+
+try {
+  assertImportedMarkerCharts({
+    name: 'neutrophils fraction percent import',
+    key: 'differential.neutrophilsPct',
+    rawValue: 0.609,
+    rawUnit: '%',
+    importContext: { refMin: 45, refMax: 70 },
+    expectedStored: 0.609,
+    expectedDisplay: '0.609',
+    forbiddenDisplays: ['0.006', '0.00609'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'monocytes fraction percent import',
+    key: 'differential.monocytesPct',
+    rawValue: 0.074,
+    rawUnit: 'PERCENTAGE',
+    expectedStored: 0.074,
+    expectedDisplay: '0.074',
+    forbiddenDisplays: ['0.001', '0.00074'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'lymphocytes fraction percent import',
+    key: 'differential.lymphocytesPct',
+    rawValue: 0.332,
+    rawUnit: '%',
+    expectedStored: 0.332,
+    expectedDisplay: '0.332',
+    forbiddenDisplays: ['0.003', '0.00332'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'eosinophils fraction percent import',
+    key: 'differential.eosinophilsPct',
+    rawValue: 0.041,
+    rawUnit: '%',
+    expectedStored: 0.041,
+    expectedDisplay: '0.041',
+    forbiddenDisplays: ['0.00041'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'basophils fraction percent import',
+    key: 'differential.basophilsPct',
+    rawValue: 0.006,
+    rawUnit: '%',
+    expectedStored: 0.006,
+    expectedDisplay: '0.006',
+    forbiddenDisplays: ['0.00006'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'whole-number differential percent import',
+    key: 'differential.neutrophilsPct',
+    rawValue: 60.9,
+    rawUnit: '%',
+    expectedStored: 0.609,
+    expectedDisplay: '0.609',
+    forbiddenDisplays: ['60.9'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'whole-number lymphocytes percent import',
+    key: 'differential.lymphocytesPct',
+    rawValue: 33.2,
+    rawUnit: '%',
+    expectedStored: 0.332,
+    expectedDisplay: '0.332',
+    forbiddenDisplays: ['33.2'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'whole-number eosinophils percent import',
+    key: 'differential.eosinophilsPct',
+    rawValue: 4.1,
+    rawUnit: '%',
+    expectedStored: 0.041,
+    expectedDisplay: '0.041',
+    forbiddenDisplays: ['4.10'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'whole-number basophils percent import',
+    key: 'differential.basophilsPct',
+    rawValue: 0.6,
+    rawUnit: '%',
+    importContext: { refMin: 0, refMax: 2 },
+    expectedStored: 0.006,
+    expectedDisplay: '0.006',
+    forbiddenDisplays: ['0.600'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'native percent marker import',
+    key: 'hormones.freeTestosteronePercentage',
+    rawValue: 2.1,
+    rawUnit: '%',
+    expectedStored: 2.1,
+    expectedDisplay: '2.10',
+    forbiddenDisplays: ['0.021'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'HbA1c percent import',
+    key: 'diabetes.hba1c',
+    rawValue: 5.7,
+    rawUnit: '%',
+    expectedStored: 38.8,
+    expectedDisplay: '38.8',
+    forbiddenDisplays: ['5.70'],
+  });
+
+  assertImportedMarkerCharts({
+    name: 'absolute differential count import',
+    key: 'differential.neutrophils',
+    rawValue: 3.22,
+    rawUnit: '10^9/l',
+    expectedStored: 3.22,
+    expectedDisplay: '3.22',
+    forbiddenDisplays: ['0.032'],
+  });
+} finally {
+  document.getElementById = saved.getElementById;
+  state.chartInstances = saved.chartInstances;
+  state.markerRegistry = saved.markerRegistry;
+  state.rangeMode = saved.rangeMode;
+  if (saved.Chart === undefined) delete window.Chart;
+  else window.Chart = saved.Chart;
+  if (savedGetComputedStyle === undefined) delete globalThis.getComputedStyle;
+  else globalThis.getComputedStyle = savedGetComputedStyle;
+}
+
+console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
+if (fail > 0) process.exit(1);

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -43,6 +43,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
     'proteins.ceruloplasmin', 'lipids.apoB', 'lipids.apoAI',
     'hematology.mchc',
     'differential.neutrophilsPct', 'differential.lymphocytesPct', 'differential.monocytesPct',
+    'differential.eosinophilsPct', 'differential.basophilsPct',
     'boneMetabolism.osteocalcin', 'tumorMarkers.psa',
     'vitamins.vitaminA', 'vitamins.calcitriol'
   ];

--- a/tests/test-secondary-unit-conversions.js
+++ b/tests/test-secondary-unit-conversions.js
@@ -70,12 +70,26 @@ console.log(' 2b. Fraction-stored percent imports ');
 
 assert('differential neutrophils 0.609 % stays 0.609 fraction',
   normalizeToSI('differential.neutrophilsPct', 0.609, '%') === 0.609);
+assert('differential neutrophils 0.609 % stays 0.609 even with whole-percent lab range',
+  normalizeToSI('differential.neutrophilsPct', 0.609, '%', { refMin: 45, refMax: 70 }) === 0.609);
 assert('differential neutrophils 60.9 % converts to 0.609 fraction',
   approx(normalizeToSI('differential.neutrophilsPct', 60.9, '%'), 0.609));
+assert('differential lymphocytes 0.332 % stays 0.332 fraction',
+  normalizeToSI('differential.lymphocytesPct', 0.332, '%') === 0.332);
+assert('differential lymphocytes 33.2 % converts to 0.332 fraction',
+  approx(normalizeToSI('differential.lymphocytesPct', 33.2, '%'), 0.332));
 assert('differential monocytes 0.074 PERCENTAGE stays 0.074 fraction',
   normalizeToSI('differential.monocytesPct', 0.074, 'PERCENTAGE') === 0.074);
 assert('differential monocytes 7.4 PERCENTAGE converts to 0.074 fraction',
   approx(normalizeToSI('differential.monocytesPct', 7.4, 'PERCENTAGE'), 0.074));
+assert('differential eosinophils 0.041 % stays 0.041 fraction',
+  normalizeToSI('differential.eosinophilsPct', 0.041, '%') === 0.041);
+assert('differential eosinophils 4.1 % converts to 0.041 fraction',
+  approx(normalizeToSI('differential.eosinophilsPct', 4.1, '%'), 0.041));
+assert('differential basophils 0.006 % stays 0.006 fraction',
+  normalizeToSI('differential.basophilsPct', 0.006, '%') === 0.006);
+assert('differential basophils 0.6 % with whole-percent lab range converts to 0.006 fraction',
+  approx(normalizeToSI('differential.basophilsPct', 0.6, '%', { refMin: 0, refMax: 2 }), 0.006));
 assert('HbA1c percent conversion is unchanged',
   approx(normalizeToSI('diabetes.hba1c', 5.7, '%'), 38.8, 0.5));
 

--- a/tests/test-unit-import.js
+++ b/tests/test-unit-import.js
@@ -62,9 +62,9 @@ const importCssSrc = read('css/import.css');
   assert('pdf-import facade re-exports commit actions',
     /export\s*\{[^}]*confirmImport[^}]*deleteImportSnapshot[^}]*openImportReviewFromSnapshot[^}]*\}\s*from\s*['"]\.\/pdf-import-commit\.js['"]/.test(src));
   assert('matched markers normalized',
-    confirmBlock.includes('normalizeToSI(m.mappedKey, m.value, m.unit)'));
+    confirmBlock.includes('normalizeToSI(m.mappedKey, m.value, m.unit, m)'));
   assert('new (custom) markers normalized',
-    confirmBlock.includes('normalizeToSI(m.suggestedKey, m.value, m.unit)'));
+    confirmBlock.includes('normalizeToSI(m.suggestedKey, m.value, m.unit, m)'));
   assert('confirmImport waits for async save before closing UI',
     commitSrc.includes('export async function confirmImport') && /await\s+saveImportedData\([^)]*\)/.test(confirmBlock));
   assert('PDF import requests immediate sync push after durable save',
@@ -486,7 +486,8 @@ const importCssSrc = read('css/import.css');
       { rawName: 'D-dimer', value: 0.22, unit: 'mg/l FEU', matched: false, mappedKey: null, suggestedKey: 'custom.dDimer' },
       { rawName: 'Cortisol', value: 390, unit: 'nmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.cortisol' },
       { rawName: 'Lp(a)', value: 42, unit: 'nmol/l', matched: false, mappedKey: null, suggestedKey: 'custom.lpa' },
-      { rawName: 'Total Cholesterol/HDL Ratio', value: 3.4, unit: '', matched: false, mappedKey: null, suggestedKey: 'custom.cholHdlRatio' }
+      { rawName: 'Total Cholesterol/HDL Ratio', value: 3.4, unit: '', matched: false, mappedKey: null, suggestedKey: 'custom.cholHdlRatio' },
+      { rawName: 'Basophils %', value: 0.6, unit: '%', refMin: 0, refMax: 2, matched: false, mappedKey: null, suggestedKey: 'custom.basophilsPct' }
     ];
     reconcileImportMarkerMappings(importMarkers, { testType: 'blood' });
     assert('Czech glucose reconciles to existing schema marker',
@@ -523,8 +524,10 @@ const importCssSrc = read('css/import.css');
       importMarkers[13].matched && importMarkers[13].mappedKey === 'differential.lymphocytesPct');
     assert('Differential monocyte percentage label maps to percentage marker despite AI absolute key',
       importMarkers[14].matched && importMarkers[14].mappedKey === 'differential.monocytesPct');
-    assert('Unsupported differential percent does not overwrite absolute-count or stale custom marker',
-      !importMarkers[15].matched && importMarkers[15].mappedKey === null && importMarkers[15].suggestedKey === 'differential.eosinophilsPct');
+    assert('Differential eosinophil percent maps to percentage marker',
+      importMarkers[15].matched && importMarkers[15].mappedKey === 'differential.eosinophilsPct');
+    assert('Differential basophil percent maps to percentage marker',
+      importMarkers[21].matched && importMarkers[21].mappedKey === 'differential.basophilsPct');
     assert('Biology-score specialty-adjacent blood markers reconcile to standard schema keys',
       importMarkers[16].matched && importMarkers[16].mappedKey === 'thyroid.reverseT3'
       && importMarkers[17].matched && importMarkers[17].mappedKey === 'coagulation.dDimer'
@@ -624,6 +627,50 @@ const importCssSrc = read('css/import.css');
     && cPeptideAlias.customMarkers['hormones.cPeptide'] === undefined
     && cPeptideAlias.markerValueNotes['diabetes.cPeptide:2026-05-01'] === 'legacy category');
 
+  const legacyUnsupportedDifferentialPct = {
+    entries: [{
+      date: '2026-05-20',
+      markers: {
+        'differential.eosinophilsPct': 4.1,
+        'differential.basophilsPct': 0.6,
+      },
+      markerSources: {
+        'differential.eosinophilsPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_new_pct' },
+        'differential.basophilsPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_new_pct' },
+      },
+    }],
+    customMarkers: {
+      'differential.eosinophilsPct': { name: 'Eosinophils %', unit: '%', refMin: 0, refMax: 5 },
+      'differential.basophilsPct': { name: 'Basophils %', unit: '%', refMin: 0, refMax: 2 },
+    },
+    importSnapshots: [{
+      id: 'snap_cbc_new_pct',
+      fileName: 'cbc.pdf',
+      date: '2026-05-20',
+      markers: [
+        { rawName: 'Eosinophils %', value: 4.1, unit: '%', suggestedKey: 'differential.eosinophilsPct', matched: false, refMin: 0, refMax: 5 },
+        { rawName: 'Basophils %', value: 0.6, unit: '%', suggestedKey: 'differential.basophilsPct', matched: false, refMin: 0, refMax: 2 },
+      ],
+    }],
+    refOverrides: {
+      'differential.eosinophilsPct': { refMin: 0, refMax: 5, labRefMin: 0, labRefMax: 5, refSource: 'import' },
+      'differential.basophilsPct': { refMin: 0, refMax: 2, labRefMin: 0, labRefMax: 2, refSource: 'import' },
+    },
+  };
+  migrateProfileData(legacyUnsupportedDifferentialPct);
+  assert('Profile migration canonicalizes newly-supported differential percent custom markers',
+    legacyUnsupportedDifferentialPct.entries[0].markers['differential.eosinophilsPct'] === 0.041
+    && legacyUnsupportedDifferentialPct.entries[0].markers['differential.basophilsPct'] === 0.006
+    && legacyUnsupportedDifferentialPct.customMarkers['differential.eosinophilsPct'] === undefined
+    && legacyUnsupportedDifferentialPct.customMarkers['differential.basophilsPct'] === undefined);
+  assert('Profile migration repairs newly-supported differential percent snapshots and ranges',
+    legacyUnsupportedDifferentialPct.importSnapshots[0].markers[0].mappedKey === 'differential.eosinophilsPct'
+    && legacyUnsupportedDifferentialPct.importSnapshots[0].markers[0].suggestedKey === null
+    && legacyUnsupportedDifferentialPct.importSnapshots[0].markers[0].matched === true
+    && legacyUnsupportedDifferentialPct.importSnapshots[0].markers[1].mappedKey === 'differential.basophilsPct'
+    && legacyUnsupportedDifferentialPct.refOverrides['differential.eosinophilsPct'].refMax === 0.05
+    && legacyUnsupportedDifferentialPct.refOverrides['differential.basophilsPct'].refMax === 0.02);
+
   const dividedDifferentialPct = {
     entries: [{
       date: '2026-06-01',
@@ -631,11 +678,15 @@ const importCssSrc = read('css/import.css');
         'differential.neutrophilsPct': 0.00609,
         'differential.monocytesPct': 0.00074,
         'differential.lymphocytesPct': 0.328,
+        'differential.eosinophilsPct': 0.00041,
+        'differential.basophilsPct': 0.00006,
       },
       markerSources: {
         'differential.neutrophilsPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
         'differential.monocytesPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
         'differential.lymphocytesPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
+        'differential.eosinophilsPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
+        'differential.basophilsPct': { file: 'cbc.pdf', snapshotId: 'snap_cbc_fraction_pct' },
       },
     }],
     importSnapshots: [{
@@ -646,6 +697,8 @@ const importCssSrc = read('css/import.css');
         { rawName: 'B Neutrofily', value: 0.609, unit: '%', mappedKey: 'differential.neutrophilsPct', matched: true, refMin: 0.45, refMax: 0.70 },
         { rawName: 'B Monocyty', value: 0.074, unit: 'PERCENTAGE', mappedKey: 'differential.monocytesPct', matched: true, refMin: 0.02, refMax: 0.12 },
         { rawName: 'B Lymfocyty', value: 0.328, unit: '%', mappedKey: 'differential.lymphocytesPct', matched: true, refMin: 0.20, refMax: 0.45 },
+        { rawName: 'B Eosinofily', value: 0.041, unit: '%', mappedKey: 'differential.eosinophilsPct', matched: true, refMin: 0.00, refMax: 0.05 },
+        { rawName: 'B Basofily', value: 0.006, unit: '%', mappedKey: 'differential.basophilsPct', matched: true, refMin: 0.00, refMax: 0.02 },
       ],
     }],
     refOverrides: {
@@ -656,7 +709,9 @@ const importCssSrc = read('css/import.css');
   assert('Profile migration repairs fraction-stored differential percent values divided during import',
     dividedDifferentialPct.entries[0].markers['differential.neutrophilsPct'] === 0.609
     && dividedDifferentialPct.entries[0].markers['differential.monocytesPct'] === 0.074
-    && dividedDifferentialPct.entries[0].markers['differential.lymphocytesPct'] === 0.328);
+    && dividedDifferentialPct.entries[0].markers['differential.lymphocytesPct'] === 0.328
+    && dividedDifferentialPct.entries[0].markers['differential.eosinophilsPct'] === 0.041
+    && dividedDifferentialPct.entries[0].markers['differential.basophilsPct'] === 0.006);
   assert('Profile migration repairs divided imported differential percent reference overrides',
     dividedDifferentialPct.refOverrides['differential.neutrophilsPct'].refMin === 0.45
     && dividedDifferentialPct.refOverrides['differential.neutrophilsPct'].refMax === 0.70


### PR DESCRIPTION
## Summary
- add Eosinophils % and Basophils % to the WBC differential schema as fraction-stored percentage markers
- map imported eosinophil/basophil percent rows to the new canonical keys instead of leaving them custom or absolute-count adjacent
- make import normalization use marker range context for ambiguous low percent values while preserving canonical fractional inputs
- add migration repair for older imported differential percent rows and chart-integrity coverage through card rendering, Chart.js datasets, and tooltips

## Validation
- node tests/test-secondary-unit-conversions.js
- node tests/test-import-chart-data-integrity.js
- node tests/test-unit-import.js
- node tests/test-integration-batch2.js
- ./node_modules/.bin/vitest run tests/_vitest-legacy.test.js --bail=1 --silent
- npm run quality
- git diff --check