### PR TITLE
Harden API provider contracts

### DIFF
--- a/js/api-openai-compatible.js
+++ b/js/api-openai-compatible.js
@@ -39,6 +39,18 @@ export function useCustomApiProxy() {
 
 const proxyFetch = createProxyFetch(useCustomApiProxy);
 
+export function redactApiSecretText(value, secrets = []) {
+  let text = String(value ?? '');
+  for (const secret of secrets) {
+    const s = String(secret || '');
+    if (s.length >= 6) text = text.split(s).join('[redacted]');
+  }
+  return text
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{6,}/gi, 'Bearer [redacted]')
+    .replace(/\bsk-[A-Za-z0-9._~+/=-]{6,}/g, '[redacted]')
+    .replace(/\bcashu[A-Za-z0-9._~+/=-]{8,}/gi, '[redacted]');
+}
+
 export async function fetchWithApiRetry(url, options, retries = 2, useProxy = true, requestTimeoutMs = FETCH_REQUEST_TIMEOUT_MS) {
   return fetchWithRetry(url, options, {
     retries,
@@ -116,7 +128,7 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
       ? await fetchWithOptionalTimeout(fetchImpl, endpoint, requestInit, requestTimeoutMs)
       : await fetchWithApiRetry(endpoint, requestInit, 2, useProxy, requestTimeoutMs);
   } catch (e) {
-    throw new Error(`Cannot reach ${providerName} API: ${e.message}`);
+    throw new Error(`Cannot reach ${providerName} API: ${redactApiSecretText(e.message, [key])}`);
   }
 
   if (!res.ok) {
@@ -126,7 +138,7 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
       if (!errType || errType === 'AuthError' || errType === 'authentication_error') {
         throw new Error(`Invalid ${providerName} API key. Check your settings.`);
       }
-      throw new Error(`${providerName} API error: ${errType}`);
+      throw new Error(`${providerName} API error: ${redactApiSecretText(errType, [key])}`);
     }
     if (res.status === 402) {
       const hint = providerName === 'Routstr' ? ' Top up with Lightning or Cashu.'
@@ -140,7 +152,10 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
     }
     if (res.status === 429) throw new Error('Rate limited. Please wait a moment and try again.');
     let errMsg = `${providerName} API error (${res.status})`;
-    try { const errBody = await res.json(); errMsg += `: ${errBody.error?.message || JSON.stringify(errBody.error)}`; } catch {}
+    try {
+      const errBody = await res.json();
+      errMsg += `: ${redactApiSecretText(errBody.error?.message || JSON.stringify(errBody.error), [key])}`;
+    } catch {}
     throw new Error(errMsg);
   }
 
@@ -160,7 +175,7 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
       if (data === '[DONE]') return;
       try {
         const event = JSON.parse(data);
-        if (event.error) throw new Error(event.error.message || JSON.stringify(event.error));
+        if (event.error) throw new Error(redactApiSecretText(event.error.message || JSON.stringify(event.error), [key]));
         const choice = event.choices?.[0];
         const delta = choice?.delta;
         if (choice?.finish_reason) finishReason = choice.finish_reason;

--- a/js/api-venice.js
+++ b/js/api-venice.js
@@ -16,6 +16,7 @@ import {
   callOpenAICompatibleAPI,
   fetchWithApiRetry,
   isTokenLimitFinish,
+  redactApiSecretText,
 } from './api-openai-compatible.js';
 
 /** @typedef {Window & typeof globalThis & {
@@ -79,7 +80,7 @@ export async function callVeniceAPI(opts) {
   try {
     session = await apiWindow._veniceE2EE.createSession(modelId);
   } catch (e) {
-    throw new Error(`Venice E2EE setup failed: ${e.message}`);
+    throw new Error(`Venice E2EE setup failed: ${redactApiSecretText(e.message, [key])}`);
   }
   apiWindow._veniceAttestation = session.attestation ?? apiWindow._veniceAttestation ?? null;
   document.querySelector('.chat-header-model')?.dispatchEvent(new CustomEvent('e2ee-attestation'));
@@ -114,14 +115,17 @@ export async function callVeniceAPI(opts) {
       signal
     }, 2, true, requestTimeoutMs);
   } catch (e) {
-    throw new Error(`Cannot reach Venice API: ${e.message}`);
+    throw new Error(`Cannot reach Venice API: ${redactApiSecretText(e.message, [key])}`);
   }
 
   if (!res.ok) {
     if (res.status === 401) throw new Error('Invalid Venice API key. Check your settings.');
     if (res.status === 429) throw new Error('Rate limited. Please wait a moment and try again.');
     let errMsg = `Venice API error (${res.status})`;
-    try { const b = await res.json(); errMsg += `: ${b.error?.message || JSON.stringify(b.error)}`; } catch {}
+    try {
+      const b = await res.json();
+      errMsg += `: ${redactApiSecretText(b.error?.message || JSON.stringify(b.error), [key])}`;
+    } catch {}
     throw new Error(errMsg);
   }
 
@@ -153,6 +157,7 @@ export async function callVeniceAPI(opts) {
     if (data === '[DONE]') return;
     try {
       const event = JSON.parse(data);
+      if (event.error) throw new Error(redactApiSecretText(event.error.message || JSON.stringify(event.error), [key]));
       const choice = event.choices?.[0];
       if (choice?.finish_reason) finishReason = choice.finish_reason;
       else if (choice?.native_finish_reason) finishReason = choice.native_finish_reason;

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -1,0 +1,408 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../vendor/venice-e2ee.js', () => ({
+  createVeniceE2EE: vi.fn(() => ({
+    createSession: vi.fn(async () => ({
+      aesKey: 'mock-aes-key',
+      publicKey: 'mock-public-key',
+      privateKey: 'mock-private-key',
+      pubKeyHex: 'mock-client-pub-key',
+      modelPubKeyHex: 'mock-model-pub-key',
+      attestation: { verified: true },
+    })),
+    clearSession: vi.fn(),
+  })),
+  encryptMessage: vi.fn(async (_aesKey, _publicKey, text) => `encrypted:${text}`),
+  decryptChunk: vi.fn(async (_privateKey, text) => `decrypted:${text}`),
+}));
+
+import { updateKeyCache } from '../js/crypto.js';
+import {
+  callClaudeAPI,
+  setAIProvider,
+  setCustomApiModel,
+  setCustomApiUrl,
+  setOllamaMainModel,
+  setOpenRouterModel,
+  setPpqModel,
+  setPpqPrivateMode,
+  setRoutstrModel,
+  setVeniceE2EE,
+  setVeniceModel,
+} from '../js/api.js';
+
+const realFetch = globalThis.fetch;
+const realLocationDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'location');
+const realGetOllamaConfig = globalThis.getOllamaConfig;
+
+const PROVIDER_KEY_CACHE_KEYS = [
+  'labcharts-openrouter-key',
+  'labcharts-venice-key',
+  'labcharts-routstr-key',
+  'labcharts-ppq-key',
+  'labcharts-custom-key',
+];
+
+function clearProviderKeyCaches() {
+  for (const key of PROVIDER_KEY_CACHE_KEYS) updateKeyCache(key, '');
+}
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status || 200,
+    headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+function chatCompletionResponse(text = 'contract ok') {
+  return jsonResponse({
+    choices: [{ message: { content: text }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 11, completion_tokens: 13 },
+  });
+}
+
+function streamResponse(chunks) {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function requestFromLastFetch() {
+  const [url, init] = globalThis.fetch.mock.calls.at(-1);
+  return {
+    url,
+    init,
+    headers: init.headers || {},
+    body: init.body ? JSON.parse(init.body) : null,
+  };
+}
+
+function providerRequestFromFetchCall() {
+  const request = requestFromLastFetch();
+  if (request.url !== '/api/proxy') {
+    return {
+      proxied: false,
+      url: request.url,
+      headers: request.headers,
+      body: request.body,
+    };
+  }
+
+  const envelope = request.body;
+  return {
+    proxied: true,
+    url: envelope.url,
+    headers: envelope.headers || {},
+    body: JSON.parse(envelope.body),
+    proxyEnvelope: envelope,
+  };
+}
+
+function baseChatOptions(overrides = {}) {
+  return {
+    system: 'system prompt',
+    messages: [{ role: 'user', content: 'hello provider' }],
+    maxTokens: 32,
+    requestTimeoutMs: 1000,
+    forceNonStream: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  clearProviderKeyCaches();
+  globalThis.fetch = vi.fn(async () => chatCompletionResponse());
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    writable: true,
+    value: { origin: 'https://app.getbased.health', pathname: '/app', href: 'https://app.getbased.health/app' },
+  });
+  globalThis.getOllamaConfig = () => ({
+    url: 'http://localhost:11434',
+    model: 'llama3.2',
+    apiKey: 'local-api-key',
+  });
+  globalThis.showInsufficientBalanceDialog = undefined;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  if (realLocationDescriptor) Object.defineProperty(globalThis, 'location', realLocationDescriptor);
+  else delete globalThis.location;
+  if (realGetOllamaConfig) globalThis.getOllamaConfig = realGetOllamaConfig;
+  else delete globalThis.getOllamaConfig;
+  clearProviderKeyCaches();
+  vi.restoreAllMocks();
+});
+
+const providerContracts = [
+  {
+    name: 'OpenRouter',
+    key: 'sk-or-contract',
+    setup() {
+      setAIProvider('openrouter');
+      updateKeyCache('labcharts-openrouter-key', this.key);
+      setOpenRouterModel('openai/gpt-5.5');
+    },
+    options: { webSearch: true },
+    assertRequest(request) {
+      expect(request.proxied).toBe(false);
+      expect(request.url).toBe('https://openrouter.ai/api/v1/chat/completions');
+      expect(request.headers).toMatchObject({
+        Authorization: `Bearer ${this.key}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'https://app.getbased.health',
+        'X-Title': 'getbased',
+      });
+      expect(request.body).toMatchObject({
+        model: 'openai/gpt-5.5',
+        max_completion_tokens: 32,
+        plugins: [{ id: 'web' }],
+      });
+      expect(request.body).not.toHaveProperty('max_tokens');
+    },
+  },
+  {
+    name: 'Venice',
+    key: 'sk-venice-contract',
+    setup() {
+      setAIProvider('venice');
+      updateKeyCache('labcharts-venice-key', this.key);
+      setVeniceE2EE(false);
+      setVeniceModel('llama-3.3-70b');
+      localStorage.setItem('labcharts-venice-models', JSON.stringify([{ id: 'llama-3.3-70b' }]));
+      localStorage.setItem('labcharts-venice-e2ee-models', '[]');
+    },
+    options: { webSearch: true },
+    assertRequest(request) {
+      expect(request.proxied).toBe(false);
+      expect(request.url).toBe('https://api.venice.ai/api/v1/chat/completions');
+      expect(request.headers).toMatchObject({
+        Authorization: `Bearer ${this.key}`,
+        'Content-Type': 'application/json',
+      });
+      expect(request.body).toMatchObject({
+        model: 'llama-3.3-70b',
+        max_tokens: 32,
+        venice_parameters: { enable_web_search: 'on' },
+      });
+    },
+  },
+  {
+    name: 'Routstr',
+    key: 'sk-routstr-contract',
+    setup() {
+      setAIProvider('routstr');
+      updateKeyCache('labcharts-routstr-key', this.key);
+      setRoutstrModel('llama-3.1-8b');
+      localStorage.setItem('labcharts-routstr-node', 'https://node.example.com/');
+    },
+    assertRequest(request) {
+      expect(request.proxied).toBe(false);
+      expect(request.url).toBe('https://node.example.com/v1/chat/completions');
+      expect(request.headers).toMatchObject({
+        Authorization: `Bearer ${this.key}`,
+        'Content-Type': 'application/json',
+      });
+      expect(request.body).toMatchObject({
+        model: 'llama-3.1-8b',
+        max_tokens: 32,
+      });
+    },
+  },
+  {
+    name: 'PPQ',
+    key: 'sk-ppq-contract',
+    setup() {
+      setAIProvider('ppq');
+      updateKeyCache('labcharts-ppq-key', this.key);
+      setPpqPrivateMode(false);
+      setPpqModel('perplexity/sonar');
+    },
+    options: { webSearch: true },
+    assertRequest(request) {
+      expect(request.proxied).toBe(false);
+      expect(request.url).toBe('https://api.ppq.ai/chat/completions');
+      expect(request.headers).toMatchObject({
+        Authorization: `Bearer ${this.key}`,
+        'Content-Type': 'application/json',
+      });
+      expect(request.body).toMatchObject({
+        model: 'perplexity/sonar',
+        max_tokens: 32,
+        plugins: [{ id: 'web' }],
+      });
+    },
+  },
+  {
+    name: 'Custom remote',
+    key: 'custom-contract-key',
+    setup() {
+      setAIProvider('custom');
+      updateKeyCache('labcharts-custom-key', this.key);
+      setCustomApiUrl('https://custom.example/v1/');
+      setCustomApiModel('custom-model');
+    },
+    assertRequest(request) {
+      expect(request.proxied).toBe(true);
+      expect(request.url).toBe('https://custom.example/v1/chat/completions');
+      expect(request.headers).toEqual({ Authorization: `Bearer ${this.key}` });
+      expect(request.proxyEnvelope).not.toHaveProperty('method');
+      expect(request.body).toMatchObject({
+        model: 'custom-model',
+        max_tokens: 32,
+      });
+    },
+  },
+  {
+    name: 'Local AI',
+    key: 'local-api-key',
+    setup() {
+      setAIProvider('ollama');
+      setOllamaMainModel('llama3.2');
+    },
+    options: { jsonMode: true },
+    assertRequest(request) {
+      expect(request.proxied).toBe(false);
+      expect(request.url).toBe('http://localhost:11434/v1/chat/completions');
+      expect(request.headers).toMatchObject({
+        Authorization: `Bearer ${this.key}`,
+        'Content-Type': 'application/json',
+      });
+      expect(request.body).toMatchObject({
+        model: 'llama3.2',
+        max_tokens: 32,
+        response_format: { type: 'json_object' },
+      });
+    },
+  },
+];
+
+describe('AI provider request contracts', () => {
+  it.each(providerContracts)('routes $name through its expected chat-completion contract', async (contract) => {
+    contract.setup();
+
+    await expect(callClaudeAPI(baseChatOptions(contract.options))).resolves.toEqual({
+      text: 'contract ok',
+      usage: { inputTokens: 11, outputTokens: 13 },
+      finishReason: 'stop',
+      truncated: false,
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const request = providerRequestFromFetchCall();
+    contract.assertRequest(request);
+    expect(JSON.stringify(request.body)).not.toContain(contract.key);
+  });
+
+  it('parses OpenAI-compatible SSE streams without changing provider headers', async () => {
+    setAIProvider('openrouter');
+    updateKeyCache('labcharts-openrouter-key', 'sk-or-stream');
+    setOpenRouterModel('openai/gpt-4o');
+    globalThis.fetch = vi.fn(async () => streamResponse([
+      'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"max_tokens"}],"usage":{"prompt_tokens":7,"completion_tokens":8}}\n\n',
+      'data: [DONE]\n\n',
+    ]));
+    const onStream = vi.fn();
+
+    await expect(callClaudeAPI({
+      messages: [{ role: 'user', content: 'stream please' }],
+      maxTokens: 16,
+      onStream,
+      requestTimeoutMs: 1000,
+    })).resolves.toEqual({
+      text: 'Hello',
+      usage: { inputTokens: 7, outputTokens: 8 },
+      finishReason: 'max_tokens',
+      truncated: true,
+    });
+
+    const request = providerRequestFromFetchCall();
+    expect(request.url).toBe('https://openrouter.ai/api/v1/chat/completions');
+    expect(request.headers.Authorization).toBe('Bearer sk-or-stream');
+    expect(request.body).toMatchObject({
+      model: 'openai/gpt-4o',
+      max_tokens: 16,
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+    expect(onStream).toHaveBeenNthCalledWith(1, 'Hel');
+    expect(onStream).toHaveBeenNthCalledWith(2, 'Hello');
+  });
+
+  it('surfaces redacted Venice E2EE SSE provider errors', async () => {
+    const secret = 'sk-venice-stream-secret';
+    setAIProvider('venice');
+    updateKeyCache('labcharts-venice-key', secret);
+    setVeniceE2EE(true);
+    setVeniceModel('e2ee-contract-model');
+    localStorage.setItem('labcharts-venice-models', '[]');
+    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify([{ id: 'e2ee-contract-model' }]));
+    localStorage.setItem('labcharts-venice-models-fetched-at', String(Date.now()));
+    globalThis.fetch = vi.fn(async () => streamResponse([
+      `data: {"error":{"message":"provider echoed ${secret}"}}\n\n`,
+    ]));
+
+    let caught;
+    try {
+      await callClaudeAPI({
+        messages: [{ role: 'user', content: 'stream through e2ee' }],
+        maxTokens: 16,
+        onStream: vi.fn(),
+        requestTimeoutMs: 1000,
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught.message).toContain('[redacted]');
+    expect(caught.message).not.toContain(secret);
+    const request = providerRequestFromFetchCall();
+    expect(request.url).toBe('https://api.venice.ai/api/v1/chat/completions');
+    expect(request.headers.Authorization).toBe(`Bearer ${secret}`);
+    expect(request.body).toMatchObject({
+      model: 'e2ee-contract-model',
+      max_tokens: 16,
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+  });
+
+  it('fails before fetch for missing keys and redacts configured secrets from provider errors', async () => {
+    setAIProvider('openrouter');
+    setOpenRouterModel('openai/gpt-4o');
+
+    await expect(callClaudeAPI(baseChatOptions())).rejects.toThrow('No OpenRouter API key configured');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    const secret = 'sk-or-contract-secret';
+    updateKeyCache('labcharts-openrouter-key', secret);
+    globalThis.fetch = vi.fn(async () => jsonResponse({
+      error: { message: `upstream echoed ${secret}` },
+    }, { status: 500 }));
+
+    let caught;
+    try {
+      await callClaudeAPI(baseChatOptions());
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught.message).toContain('[redacted]');
+    expect(caught.message).not.toContain(secret);
+    const request = providerRequestFromFetchCall();
+    expect(request.headers.Authorization).toBe(`Bearer ${secret}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Add mocked contract coverage for OpenRouter, Venice, Routstr, PPQ, Custom remote, and Local AI chat calls.
- Assert endpoint, auth headers, request body shape, proxy routing, streaming SSE parsing, missing-key behavior, and that request bodies do not contain provider secrets.
- Redact configured API secrets from surfaced provider errors, including Venice E2EE-specific errors.

## Validation
- `./node_modules/.bin/vitest run tests/api-provider-contracts.test.js --bail=1`
- `./node_modules/.bin/vitest run tests/api-provider-runtime.test.js tests/api-runtime.test.js tests/api-network-runtime.test.js --bail=1`
- `npm test`
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`