### PR TITLE
Harden light setup save path

### DIFF
--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -13,6 +13,24 @@ function getRuntimeFunction(name) {
   return typeof runtime?.[name] === 'function' ? runtime[name].bind(runtime) : null;
 }
 
+/**
+ * Invoke the currently exposed runtime binding when it differs from the local
+ * module function. This keeps delegated document handlers stable when a
+ * cache-busted module instance replaces public bindings during browser tests.
+ *
+ * @param {string} name
+ * @param {Function} localFn
+ * @param {any[]} [args]
+ */
+export function invokeSunDefaultsBinding(name, localFn, args = []) {
+  const runtime = getRuntimeWindow();
+  const runtimeFn = runtime?.[name];
+  if (typeof runtimeFn === 'function' && runtimeFn !== localFn) {
+    return runtimeFn.apply(runtime, args);
+  }
+  return localFn(...args);
+}
+
 export function hasSunDefaultsBrowserRuntime() {
   return getRuntimeWindow() !== null;
 }

--- a/js/sun-defaults.js
+++ b/js/sun-defaults.js
@@ -19,6 +19,7 @@ import {
   getSunSetupProfileLocation,
   hasSunDefaultsBrowserRuntime,
   hasSunSetupPreciseLocationRequester,
+  invokeSunDefaultsBinding,
   navigateSunDefaultsRoute,
   openSunSetupProfileLocationRuntime,
   requestSunSetupPreciseLocationRuntime,
@@ -116,15 +117,15 @@ function handleLightSetupClick(event) {
   switch (actionEl.dataset.lightSetupAction || '') {
     case 'reopen':
       event.preventDefault();
-      reopenSunSetup();
+      invokeSunDefaultsBinding('reopenSunSetup', reopenSunSetup);
       break;
     case 'dismiss':
       event.preventDefault();
-      dismissSunSetup();
+      invokeSunDefaultsBinding('dismissSunSetup', dismissSunSetup);
       break;
     case 'cancel-reopen':
       event.preventDefault();
-      cancelReopenSunSetup();
+      invokeSunDefaultsBinding('cancelReopenSunSetup', cancelReopenSunSetup);
       break;
     case 'set-step':
       event.preventDefault();
@@ -132,7 +133,7 @@ function handleLightSetupClick(event) {
       break;
     case 'save':
       event.preventDefault();
-      saveSunSetup();
+      invokeSunDefaultsBinding('saveSunSetup', saveSunSetup);
       break;
     case 'select-choice':
       event.preventDefault();
@@ -144,11 +145,11 @@ function handleLightSetupClick(event) {
       break;
     case 'open-profile-location':
       event.preventDefault();
-      openLightSetupProfileLocation();
+      invokeSunDefaultsBinding('openLightSetupProfileLocation', openLightSetupProfileLocation);
       break;
     case 'request-precise-location':
       event.preventDefault();
-      requestLightSetupPreciseLocation();
+      invokeSunDefaultsBinding('requestLightSetupPreciseLocation', requestLightSetupPreciseLocation);
       break;
   }
 }
@@ -784,10 +785,39 @@ async function requestLightSetupPreciseLocation() {
   return coords;
 }
 
-// Save handler — wired to button via window
-async function saveSunSetup() {
-  const root = document.querySelector('.light-setup-card');
-  if (!root) return;
+function readSetupFieldValue(root, id) {
+  const el = root?.querySelector?.(`#${id}`);
+  if (!el || !('value' in el)) return null;
+  const value = String(el.value || '');
+  return value || null;
+}
+
+function readSetupPhotosensitiveValue(root) {
+  const el = root?.querySelector?.('#setup-photosensitive');
+  if (!el) return 'none';
+  const type = 'type' in el ? String(el.type || '') : '';
+  if (type === 'checkbox') return el.checked ? 'moderate' : 'none';
+  return readSetupFieldValue(root, 'setup-photosensitive') || 'none';
+}
+
+function buildDefaultLightCircadianContext() {
+  return {
+    amLight: null,
+    daytime: null,
+    uvExposure: null,
+    skinType: null,
+    evening: [],
+    screenTime: null,
+    techEnv: [],
+    cold: null,
+    grounding: null,
+    mealTiming: [],
+    note: '',
+  };
+}
+
+export function collectSunSetupValues(root) {
+  if (!root) return { ok: false, reason: 'missing-root' };
   // Skin type comes from the emoji-slider range. The slider defaults to
   // position 2 (median III) but data-set="0" means the user hasn't
   // actively confirmed; they must tap a face or drag.
@@ -795,14 +825,8 @@ async function saveSunSetup() {
   const isSet = sliderEl?.dataset?.set === '1';
   const skinIdx = isSet ? parseInt(sliderEl?.value || '', 10) : -1;
   const fitzpatrick = (skinIdx >= 0 && skinIdx < 6) ? ROMAN[skinIdx] : null;
-  const homeLightEl = /** @type {HTMLSelectElement | null} */ (root.querySelector('#setup-homelight'));
-  const eyewearEl = /** @type {HTMLSelectElement | null} */ (root.querySelector('#setup-eyewear'));
-  const homeLight = homeLightEl?.value || null;
-  const eyewear = eyewearEl?.value || null;
   if (!fitzpatrick) {
-    setLightSetupStep('core');
-    showNotification('Tap a face to confirm your skin type.');
-    return;
+    return { ok: false, reason: 'skin-type-required' };
   }
   const ott = {};
   let ottScore = 0;
@@ -813,33 +837,57 @@ async function saveSunSetup() {
       if (cb.checked) ottScore++;
     }
   }
-  // photosensitiveMeds started as a boolean checkbox, then briefly used a
-  // native select. The current setup uses a hidden input driven by inline
-  // choice buttons so the option list stays inside the focused modal.
-  const psmEl = /** @type {HTMLInputElement | HTMLSelectElement | null} */ (root.querySelector('#setup-photosensitive'));
-  const photosensitiveMeds = (psmEl?.tagName === 'SELECT' || psmEl?.type === 'hidden')
-    ? (psmEl.value || 'none')
-    : (psmEl instanceof HTMLInputElement && psmEl.checked ? 'moderate' : 'none');
-  await saveSunDefaults({
-    fitzpatrick,
-    photosensitiveMeds,
-    homeLight,
-    eyewear,
-    ott,
-    ottScore,
-    completedAt: Date.now(),
+  return {
+    ok: true,
+    values: {
+      skinIdx,
+      fitzpatrick,
+      photosensitiveMeds: readSetupPhotosensitiveValue(root),
+      homeLight: readSetupFieldValue(root, 'setup-homelight'),
+      eyewear: readSetupFieldValue(root, 'setup-eyewear'),
+      ott,
+      ottScore,
+    },
+  };
+}
+
+export async function persistSunSetupValues(values, now = Date.now()) {
+  if (!values || !state.importedData) return null;
+  const d = getSunDefaults();
+  if (!d) return null;
+  Object.assign(d, {
+    fitzpatrick: values.fitzpatrick,
+    photosensitiveMeds: values.photosensitiveMeds,
+    homeLight: values.homeLight,
+    eyewear: values.eyewear,
+    ott: values.ott || {},
+    ottScore: Number(values.ottScore) || 0,
+    completedAt: now,
   });
-  // Mirror to lightCircadian.skinType so the context card reflects this answer
-  // (and vice-versa — getInitialFitzpatrick reads from lightCircadian as a fallback).
   if (!state.importedData.lightCircadian) {
-    state.importedData.lightCircadian = { amLight: null, daytime: null, uvExposure: null, skinType: null, evening: [], screenTime: null, techEnv: [], cold: null, grounding: null, mealTiming: [], note: '' };
+    state.importedData.lightCircadian = buildDefaultLightCircadianContext();
   }
-  state.importedData.lightCircadian.skinType = SKIN_TYPE[skinIdx];
+  state.importedData.lightCircadian.skinType = SKIN_TYPE[values.skinIdx];
   await saveImportedData();
+  return d;
+}
+
+async function saveSunSetup() {
+  const root = document.querySelector('.light-setup-card');
+  const collected = collectSunSetupValues(root);
+  if (!collected.ok) {
+    if (collected.reason === 'skin-type-required') {
+      setLightSetupStep('core');
+      showNotification('Tap a face to confirm your skin type.');
+    }
+    return false;
+  }
+  await persistSunSetupValues(collected.values);
   closeSunSetupOverlay();
-  showNotification(`Setup saved · light burden ${ottScore}/10`);
+  showNotification(`Setup saved · light burden ${collected.values.ottScore}/10`);
   maybeAnalyzeOnboardingAfterSave();
   navigateSunDefaultsRoute('light');
+  return true;
 }
 
 // Recompute the running Ott score whenever a checkbox toggles, and update

--- a/tests/test-sun-defaults-runtime.js
+++ b/tests/test-sun-defaults-runtime.js
@@ -8,6 +8,7 @@ import {
   getSunSetupProfileLocation,
   hasSunDefaultsBrowserRuntime,
   hasSunSetupPreciseLocationRequester,
+  invokeSunDefaultsBinding,
   navigateSunDefaultsRoute,
   openSunSetupProfileLocationRuntime,
   requestSunSetupPreciseLocationRuntime,
@@ -29,6 +30,7 @@ const runtimeKeys = [
   'openClientList',
   'requestPreciseLocation',
   'navigate',
+  'saveSunSetup',
   'sunDefaultsProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
@@ -91,6 +93,21 @@ try {
   exposeSunDefaultsBindings({ sunDefaultsProbe: probe });
   assert('exposeSunDefaultsBindings publishes runtime bindings',
     globalThis.sunDefaultsProbe === probe);
+
+  let localCalls = 0;
+  let runtimeCalls = 0;
+  const localSave = () => { localCalls++; return 'local'; };
+  const runtimeSave = () => { runtimeCalls++; return 'runtime'; };
+  setRuntimeValue('saveSunSetup', runtimeSave);
+  assert('invokeSunDefaultsBinding prefers current runtime binding when replaced',
+    invokeSunDefaultsBinding('saveSunSetup', localSave) === 'runtime' &&
+    runtimeCalls === 1 &&
+    localCalls === 0);
+  setRuntimeValue('saveSunSetup', localSave);
+  assert('invokeSunDefaultsBinding uses local function when it is current',
+    invokeSunDefaultsBinding('saveSunSetup', localSave) === 'local' &&
+    runtimeCalls === 1 &&
+    localCalls === 1);
 
   delete globalThis.getSunCoords;
   delete globalThis.getProfileLocation;

--- a/tests/test-sun-defaults.js
+++ b/tests/test-sun-defaults.js
@@ -67,6 +67,8 @@ const {
   OTT_QUESTIONS,
   getSunDefaults,
   configureSunDefaults,
+  collectSunSetupValues,
+  persistSunSetupValues,
   saveSunDefaults,
   isOnboardingComplete,
   ottScoreToLabel,
@@ -83,6 +85,7 @@ const {
     !/\bon(?:click|keydown|submit|change|input)=/.test(sunDefaultsSrc));
   assert('sun-defaults installs shared Light setup delegates',
     sunDefaultsSrc.includes('installLightSetupDelegates();') &&
+    sunDefaultsSrc.includes("invokeSunDefaultsBinding('saveSunSetup', saveSunSetup)") &&
     sunDefaultsSrc.includes("data-light-setup-action=") &&
     sunDefaultsSrc.includes("data-light-setup-input="));
   assert('sun-defaults browser hooks are isolated in runtime adapter',
@@ -278,10 +281,54 @@ const {
   assert('Subsequent save preserves earlier fitzpatrick',
     after2.fitzpatrick === 'III' && after2.eyewear === 'sunglasses');
 
+  const setupDom = new JSDOM(`<!doctype html><body>
+    <div class="light-setup-card">
+      <input id="setup-skin-range" value="3" data-set="1">
+      <input type="hidden" id="setup-photosensitive" value="severe">
+      <input type="hidden" id="setup-homelight" value="led-warm">
+      <input type="hidden" id="setup-eyewear" value="sunglasses">
+      <input type="checkbox" data-ott="morning-light-deficit" checked>
+      <input type="checkbox" data-ott="dim-workspace" checked>
+      <input type="checkbox" data-ott="low-outdoor-time">
+    </div>
+  </body>`);
+  const setupRoot = setupDom.window.document.querySelector('.light-setup-card');
+  const collected = collectSunSetupValues(setupRoot);
+  assert('collectSunSetupValues reads current hidden-choice setup UI',
+    collected.ok &&
+    collected.values.fitzpatrick === 'IV' &&
+    collected.values.skinIdx === 3 &&
+    collected.values.photosensitiveMeds === 'severe' &&
+    collected.values.homeLight === 'led-warm' &&
+    collected.values.eyewear === 'sunglasses' &&
+    collected.values.ottScore === 2 &&
+    collected.values.ott['morning-light-deficit'] === true &&
+    collected.values.ott['dim-workspace'] === true &&
+    collected.values.ott['low-outdoor-time'] === false);
+
+  const missingSkinDom = new JSDOM(`<!doctype html><body>
+    <div class="light-setup-card"><input id="setup-skin-range" value="2" data-set="0"></div>
+  </body>`);
+  const missingSkin = collectSunSetupValues(missingSkinDom.window.document.querySelector('.light-setup-card'));
+  assert('collectSunSetupValues blocks visual default skin type until confirmed',
+    missingSkin.ok === false && missingSkin.reason === 'skin-type-required');
+
+  window._labState.importedData = { entries: [], sunDefaults: {}, lightCircadian: null };
+  await persistSunSetupValues(collected.values, 1234567890);
+  assert('persistSunSetupValues saves defaults and mirrors skin context in one path',
+    window._labState.importedData.sunDefaults.fitzpatrick === 'IV' &&
+    window._labState.importedData.sunDefaults.photosensitiveMeds === 'severe' &&
+    window._labState.importedData.sunDefaults.homeLight === 'led-warm' &&
+    window._labState.importedData.sunDefaults.eyewear === 'sunglasses' &&
+    window._labState.importedData.sunDefaults.ottScore === 2 &&
+    window._labState.importedData.sunDefaults.completedAt === 1234567890 &&
+    window._labState.importedData.lightCircadian?.skinType?.startsWith('IV'));
+
   // ─── 6. isOnboardingComplete gate ─────────────────────────────────────
   console.log('%c 6. Onboarding-complete gate ', 'font-weight:bold;color:#f59e0b');
 
   // Just fitzpatrick set is not enough — needs completedAt
+  window._labState.importedData = { entries: [], sunDefaults: { fitzpatrick: 'III' } };
   assert('isOnboardingComplete falsy without completedAt',
     !isOnboardingComplete());
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.146';
+self.APP_VERSION = '1.10.147';


### PR DESCRIPTION
## Summary

Harden the Light setup save path by separating DOM value collection from persistence and adding a runtime binding handoff for delegated setup actions.

## Why

The full Playwright run exposed an intermittent failure in the Light setup overlay save flow. The likely root cause was a mismatch between document-level delegates installed by one `sun-defaults.js` module instance and cache-busted test imports that replaced public runtime bindings. That made the save path vulnerable to using stale module-local dependencies during parallel browser tests.

## Changes

- Add `collectSunSetupValues()` and `persistSunSetupValues()` so setup collection, validation, persistence, and light-circadian mirroring are directly testable.
- Add `invokeSunDefaultsBinding()` in the runtime adapter so delegated actions prefer the current exposed window binding when a newer module instance has replaced it.
- Add regression coverage for hidden-input choice collection, default skin-type validation, persistence/mirroring, and runtime binding replacement.
- Bump `version.js` to `1.10.147` for service worker cache busting.

## Impact

This should make the Light setup/onboarding save path more deterministic under full parallel browser tests and lower the review cost around future changes to this flow.

## Validation

- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm test`
- `npm run test:playwright` (`340 passed`)
- Targeted post-version browser checks for setup path and footer/version coverage (`2 passed`)