### PR TITLE
Fix chat onboarding flow

### DIFF
--- a/css/chat-onboarding.css
+++ b/css/chat-onboarding.css
@@ -56,6 +56,7 @@
   gap: 8px; padding: 0 2px 10px;
   border-bottom: 1px solid var(--border); margin-bottom: 12px;
 }
+.chat-onboard-crumbs-main { display: inline-flex; align-items: center; gap: 7px; min-width: 0; }
 .chat-onboard-crumbs-label { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; }
 .chat-onboard-crumbs-dots { display: inline-flex; gap: 5px; align-items: center; }
 .chat-onboard-crumb {
@@ -63,6 +64,25 @@
   background: var(--border); transition: background 0.2s;
 }
 .chat-onboard-crumb.active { background: var(--accent); }
+.chat-onboard-back-btn {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.chat-onboard-back-btn:hover { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent); }
+.chat-onboard-back-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .chat-setup-btn {
   display: inline-flex; align-items: center; gap: 6px; padding: 8px 20px;
   border-radius: 8px; border: none; background: var(--accent-gradient);
@@ -149,6 +169,21 @@ select.chat-onboard-unit-select:hover { border-color: var(--accent); }
   display: inline-flex;
   align-items: center;
 }
+.chat-onboard-complete-label {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 0 10px;
+  padding: 3px 0 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
 .chat-onboard-cta {
   display: inline-flex; align-items: center; gap: 6px; padding: 10px 18px;
   border-radius: 10px; border: 1px solid var(--accent); background: transparent;
@@ -156,6 +191,44 @@ select.chat-onboard-unit-select:hover { border-color: var(--accent); }
   transition: all 0.2s; text-align: left;
 }
 .chat-onboard-cta:hover { background: var(--accent); color: #fff; }
+.chat-onboard-step4-actions { gap: 7px; }
+.chat-onboard-primary-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.chat-onboard-primary-actions-single {
+  grid-template-columns: minmax(0, 1fr);
+}
+.chat-onboard-primary-actions .chat-onboard-cta {
+  justify-content: center;
+  text-align: center;
+  min-width: 0;
+}
+.chat-onboard-tertiary-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  padding-top: 2px;
+}
+.chat-onboard-text-action {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.3;
+  padding: 3px 2px;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+.chat-onboard-text-action:hover { color: var(--accent); }
+.chat-onboard-text-action:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 .chat-onboard-task-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -326,4 +399,10 @@ select.chat-onboard-unit-select:hover { border-color: var(--accent); }
 }
 .chat-panel-fullscreen .chat-context-cards .profile-context-cards {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+}
+
+@media (max-width: 420px) {
+  .chat-onboard-primary-actions {
+    grid-template-columns: 1fr;
+  }
 }

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -9,10 +9,11 @@ import { renderProfileContextCards } from './context-cards.js';
 import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
 import { getActivePersonality } from './chat-personalities.js';
 import {
+  chatOnboardingActionAttrs,
   _countFilledCards, _renderOnboardCrumbs, _renderProviderQuiz,
   _updateOnboardNextBtn, onboardHeightUnitChanged,
-  requestOnboardingLabImportProvider, saveChatLocation, saveChatProfile,
-  setChatProfileSex, skipOnboardingExtras, startOnboardingLabImport,
+  continueAfterContextCards, requestOnboardingLabImportProvider, saveChatLocation, saveChatProfile,
+  setChatProfileSex, skipContextCards, skipOnboardingExtras, startOnboardingLabImport,
   useChatPrompt,
 } from './chat-onboarding.js';
 
@@ -70,6 +71,10 @@ function handleChatEmptyClick(event) {
     callChatEmptyRuntime('_resumeAI');
   } else if (action === 'skip-extras') {
     skipOnboardingExtras();
+  } else if (action === 'continue-after-context-cards') {
+    continueAfterContextCards();
+  } else if (action === 'skip-context-cards') {
+    skipContextCards();
   } else if (action === 'open-cycle-editor') {
     closeChatPanel();
     callChatEmptyRuntime('openMenstrualCycleEditor');
@@ -164,20 +169,28 @@ export function _getNoDataPrompts() {
 export function renderEmptyChatState(container, panel) {
   installChatEmptyStateDelegates(container);
   const context = getEmptyChatContext();
+  const forcedStep = sessionStorage.getItem(`chat-onboard-force-step-${state.currentProfile}`) || '';
 
+  if (forcedStep === 'profile') return renderProfileOnboardingState(container, panel, context);
   if (!context.hasProfile) return renderProfileOnboardingState(container, panel, context);
   if (isAIPaused()) return renderAIPausedState(container, panel, context);
+  if (forcedStep === 'provider') return renderProviderSetupState(container, panel, context);
+  if (!context.hasData && forcedStep === 'extras') return renderOptionalContextState(container, panel, context);
   if (shouldRenderProviderSetup()) return renderProviderSetupState(container, panel, context);
 
   const filled = _countFilledCards();
   const extrasDone = localStorage.getItem(`labcharts-onboard-extras-done-${state.currentProfile}`);
-  const forceContextCards = sessionStorage.getItem(`chat-onboard-force-context-cards-${state.currentProfile}`) === '1';
+  const contextCardsSkipped = localStorage.getItem(`labcharts-onboard-context-cards-skipped-${state.currentProfile}`) === '1';
+  const contextCardsDone = localStorage.getItem(`labcharts-onboard-context-cards-done-${state.currentProfile}`) === '1';
+  const forceContextCards = forcedStep === 'cards' || sessionStorage.getItem(`chat-onboard-force-context-cards-${state.currentProfile}`) === '1';
 
   if (!context.hasData && !extrasDone && !forceContextCards) return renderOptionalContextState(container, panel, context);
   if (filled >= 9 && !context.hasData) return renderFullContextNoDataState(container, panel, context);
+  if (!context.hasData && contextCardsSkipped && !forceContextCards) return renderContextImportHandoffState(container, panel, context, true);
+  if (!context.hasData && contextCardsDone && !forceContextCards) return renderContextImportHandoffState(container, panel, context, false);
   if (!context.hasData && filled > 0) return renderPartialContextNoDataState(container, panel, context, filled);
   if (!context.hasData) return renderInitialNoDataState(container, panel, context);
-  if (filled < 3) return renderDataContextNudgeState(container, context);
+  if (filled < 3 && !contextCardsSkipped) return renderDataContextNudgeState(container, context);
 
   return renderGeneralPromptState(container, context);
 }
@@ -198,6 +211,10 @@ function setOnboardingActive(panel) {
 
 function renderChatContextCards() {
   return `<div class="chat-context-cards">${renderProfileContextCards()}</div>`;
+}
+
+function renderOnboardingCompleteLabel(label) {
+  return `<div class="chat-onboard-complete-label">${escapeHTML(label)}</div>`;
 }
 
 function shouldRenderProviderSetup() {
@@ -287,11 +304,25 @@ function renderAIPausedState(container, panel, { personality, name }) {
 
 function renderProviderSetupState(container, panel, { personality, name }) {
   setOnboardingActive(panel);
+  if (hasAIProvider()) return renderProviderConnectedState(container, { personality, name });
   const branch = sessionStorage.getItem(`chat-onboard-provider-branch-${state.currentProfile}`) || '';
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
       ${_renderOnboardCrumbs(2)}
       ${_renderProviderQuiz(branch, name)}
+    </div>`;
+  return true;
+}
+
+function renderProviderConnectedState(container, { personality, name }) {
+  container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
+    <div class="chat-msg chat-ai">
+      ${renderOnboardingCompleteLabel('AI connected')}
+      <p>${escapeHTML(name)}, AI is connected. You can continue the setup or change providers from AI settings.</p>
+      <div class="chat-onboard-actions">
+        <button type="button" class="chat-onboard-cta" ${chatOnboardingActionAttrs('go-onboarding-step', { step: 3 })}>Continue</button>
+        <button type="button" class="chat-prompt-btn" ${chatOnboardingActionAttrs('open-ai-settings')}>Change AI provider</button>
+      </div>
     </div>`;
   return true;
 }
@@ -311,13 +342,12 @@ function renderOptionalContextState(container, panel, { personality }) {
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
       ${_renderOnboardCrumbs(3)}
-      <p>${hasAIProvider() ? 'Great, we are connected.' : 'Nice. We can collect useful context first and connect AI when recommendations or AI imports need it.'} These optional context pieces make later interpretation more useful, but you can skip them and import labs now.</p>
+      <p>${hasAIProvider() ? 'Great, we are connected.' : 'Nice. We can collect useful context first and connect AI when recommendations or AI imports need it.'} These optional context pieces make later interpretation more useful. Add any that matter now, or continue to the context cards.</p>
       <div class="chat-onboard-task-grid">${cards}</div>
       ${renderAffiliateDnaKitLink(hasSnps)}
       <div class="chat-onboard-note">You can change all of this later from the dashboard, settings, or client profile.</div>
       <div class="chat-onboard-actions chat-onboard-actions-row">
-        <button type="button" class="chat-onboard-cta" data-chat-empty-action="skip-extras">Continue to import</button>
-        <button type="button" class="chat-prompt-btn" data-chat-empty-action="skip-extras">Skip optional setup</button>
+        <button type="button" class="chat-onboard-cta" data-chat-empty-action="skip-extras">Continue to context cards</button>
       </div>
     </div>`;
   return true;
@@ -408,17 +438,19 @@ function renderWearableTask() {
 }
 
 function renderFullContextNoDataState(container, panel, { personality, name }) {
-  setOnboardingActive(panel);
+  panel?.classList.remove('chat-onboarding-active');
+  const providerConnected = hasAIProvider();
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
-      ${_renderOnboardCrumbs(4)}
-      <p>${escapeHTML(name)}, you filled everything in — I have a really complete picture of your lifestyle now. ${hasAIProvider() ? 'Even without lab data, I can already help:' : 'Import your labs or connect an AI provider to get personalized insights.'}</p>
+      ${renderOnboardingCompleteLabel('Context complete')}
+      <p>${escapeHTML(name)}, your context cards are complete. ${providerConnected ? 'Next, import labs or ask what to test when you are ready.' : 'Next, connect AI when you are ready to import labs or get recommendations.'}</p>
       <div class="chat-onboard-actions">
-        ${hasAIProvider()
-          ? `<button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on my full profile, what blood tests should I get and why?">What tests should I get?</button>
+        ${providerConnected
+          ? `<button type="button" class="chat-onboard-cta" data-chat-empty-action="start-lab-import">Import a lab file</button>
+             <button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on my full profile, what blood tests should I get and why?">Just tell me what to test</button>
              <button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="What can you tell about my health from my lifestyle info?">Analyze my lifestyle</button>`
-          : `<button type="button" class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
-             <button type="button" class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
+          : `<button type="button" class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>`}
+        <button type="button" class="chat-prompt-btn" ${chatOnboardingActionAttrs('go-onboarding-step', { step: 4 })}>Review context cards</button>
       </div>
     </div>`;
   return true;
@@ -435,13 +467,42 @@ function renderPartialContextNoDataState(container, panel, { personality, name }
       <p>${filled >= 6 ? `Almost there, ${escapeHTML(name)}!` : filled >= 3 ? `Nice progress, ${escapeHTML(name)}!` : `Good start, ${escapeHTML(name)}!`} You've filled ${filled} of 9 context areas.</p>
       <div class="chat-onboard-progress"><div class="chat-onboard-progress-bar" style="width:${progressPct}%"></div></div>
       <p style="font-size:12px;color:var(--text-muted);margin:4px 0 0">The more context I have, the better I can interpret results and recommend what to test. Everything is optional.</p>
-      <div class="chat-onboard-actions">
-        <button type="button" class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Continue context cards - ${remaining} area${remaining !== 1 ? 's' : ''} left</button>
-        ${providerConnected
-          ? `<button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="Based on what you know about me so far, what blood tests should I get?">Skip ahead - recommend tests</button>`
-          : `<button type="button" class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI for recommendations</button>`}
-      </div>
       ${renderChatContextCards()}
+      <div class="chat-onboard-actions chat-onboard-step4-actions">
+        <div class="chat-onboard-primary-actions chat-onboard-primary-actions-single">
+          <button type="button" class="chat-onboard-cta" data-chat-empty-action="continue-after-context-cards">${providerConnected ? 'Continue to import' : 'Continue'}</button>
+        </div>
+        <div class="chat-onboard-tertiary-actions">
+          <button type="button" class="chat-onboard-text-action" data-chat-empty-action="skip-context-cards">Skip context cards</button>
+        </div>
+      </div>
+    </div>`;
+  return true;
+}
+
+function renderContextImportHandoffState(container, panel, { personality, name }, skipped) {
+  panel?.classList.remove('chat-onboarding-active');
+  const providerConnected = hasAIProvider();
+  const filled = _countFilledCards();
+  const contextCopy = skipped
+    ? `Context cards are skipped for now, ${escapeHTML(name)}. You can add them later from Profile Context when they are useful.`
+    : filled > 0
+      ? `Context is saved for now, ${escapeHTML(name)}.`
+      : `Context cards are saved for later, ${escapeHTML(name)}.`;
+  const nextCopy = providerConnected
+    ? 'Next, import labs or ask what to test when you are ready.'
+    : 'Next, connect AI when you are ready to import labs or get recommendations.';
+  container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
+    <div class="chat-msg chat-ai">
+      ${renderOnboardingCompleteLabel('Setup ready')}
+      <p>${contextCopy} ${nextCopy}</p>
+      <div class="chat-onboard-actions">
+        ${providerConnected
+          ? `<button type="button" class="chat-onboard-cta" data-chat-empty-action="start-lab-import">Import a lab file</button>
+             <button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="I don't have any labs yet. Based on my profile, what blood tests should I get and why?">Just tell me what to test</button>`
+          : `<button type="button" class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>`}
+        <button type="button" class="chat-prompt-btn" ${chatOnboardingActionAttrs('go-onboarding-step', { step: 4 })}>Add context cards</button>
+      </div>
     </div>`;
   return true;
 }
@@ -452,19 +513,16 @@ function renderInitialNoDataState(container, panel, { personality, name }) {
   container.innerHTML = `<div class="chat-persona-label">${personality.icon} ${escapeHTML(personality.name)}</div>
     <div class="chat-msg chat-ai">
       ${_renderOnboardCrumbs(4)}
-      <p>You're ready to go, ${escapeHTML(name)}. Tell me what you have or what you want to understand, and I'll guide the next step.</p>
-      <p style="font-size:13px;margin:4px 0"><strong>Have lab results?</strong> ${providerConnected ? "Import them directly and I'll build the dashboard." : 'Connect AI first for lab PDFs or photos. JSON and DNA files can still be imported from the header.'}</p>
-      <p style="font-size:13px;margin:4px 0"><strong>No labs yet?</strong> Add useful context below${providerConnected ? ', then ask for recommended tests when you are ready.' : ', then connect AI when you want recommendations.'}</p>
-      <div class="chat-onboard-actions">
-        ${providerConnected
-          ? `<button type="button" class="chat-onboard-cta" data-chat-empty-action="start-lab-import">Import a lab file</button>
-             <button type="button" class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
-             <button type="button" class="chat-prompt-btn" data-chat-empty-action="use-prompt" data-prompt="I don't have any labs yet. Based on my profile, what blood tests should I get and why?">Just tell me what to test</button>`
-          : `<button type="button" class="chat-onboard-cta" data-chat-empty-action="request-lab-import-provider">Connect AI to import labs</button>
-             <button type="button" class="chat-onboard-cta" data-chat-empty-action="scroll-context-cards">Add context below</button>
-             <button type="button" class="chat-prompt-btn" data-chat-empty-action="open-provider-quiz">Connect AI when ready</button>`}
-      </div>
+      <p><strong>Add optional context.</strong> These cards improve lab interpretation. Fill any that matter now; everything is optional.</p>
       ${renderChatContextCards()}
+      <div class="chat-onboard-actions chat-onboard-step4-actions">
+        <div class="chat-onboard-primary-actions chat-onboard-primary-actions-single">
+          <button type="button" class="chat-onboard-cta" data-chat-empty-action="continue-after-context-cards">${providerConnected ? 'Continue to import' : 'Continue'}</button>
+        </div>
+        <div class="chat-onboard-tertiary-actions">
+          <button type="button" class="chat-onboard-text-action" data-chat-empty-action="skip-context-cards">Skip context cards</button>
+        </div>
+      </div>
     </div>`;
   return true;
 }

--- a/js/chat-nudge.js
+++ b/js/chat-nudge.js
@@ -58,12 +58,14 @@ export function updateChatNudge() {
     if (dismissed !== 'data') setChatNudge('data');
     else setChatNudge(null);
   } else {
+    const contextCardsSkipped = localStorage.getItem(`labcharts-onboard-context-cards-skipped-${state.currentProfile}`) === '1';
+    const contextCardsDone = localStorage.getItem(`labcharts-onboard-context-cards-done-${state.currentProfile}`) === '1';
     const filledCards = ['diagnoses', 'diet', 'exercise', 'sleepRest', 'lightCircadian', 'stress', 'loveLife', 'environment', 'healthGoals']
       .filter(k => {
         const v = state.importedData?.[k];
         return v && typeof v === 'object' && Object.values(v).some(f => f != null && f !== '' && !(Array.isArray(f) && f.length === 0));
       }).length;
-    if (filledCards < 3 && dismissed !== 'context') setChatNudge('context');
+    if (!contextCardsSkipped && !contextCardsDone && filledCards < 3 && dismissed !== 'context') setChatNudge('context');
     else setChatNudge(null);
   }
 }

--- a/js/chat-onboarding.js
+++ b/js/chat-onboarding.js
@@ -70,6 +70,7 @@ function isChatOnboardingActionScope(actionEl) {
 }
 
 function openAiSettings() {
+  clearForcedOnboardingStep();
   closeChatPanel();
   setTimeout(() => {
     openSettingsModal('ai');
@@ -77,6 +78,7 @@ function openAiSettings() {
 }
 
 function openAiProviderSettings(provider) {
+  clearForcedOnboardingStep();
   closeChatPanel();
   setTimeout(() => {
     openSettingsModal('ai');
@@ -95,6 +97,7 @@ function handleChatOnboardingClick(event) {
   if (action === 'back-to-provider-quiz') {
     backToProviderQuiz();
   } else if (action === 'start-openrouter-oauth') {
+    clearForcedOnboardingStep();
     startOpenRouterOAuth();
   } else if (action === 'open-ai-settings') {
     openAiSettings();
@@ -104,6 +107,8 @@ function handleChatOnboardingClick(event) {
     setProviderQuizBranch(actionEl.dataset.chatProviderBranch || '');
   } else if (action === 'skip-provider-setup') {
     skipProviderSetup();
+  } else if (action === 'go-onboarding-step') {
+    goToOnboardingStep(Number(actionEl.dataset.chatStep || ''));
   }
 }
 
@@ -202,6 +207,14 @@ function switchAIProvider(provider) {
 
 function updateChatNudge() {
   onboardingCallbacks.updateChatNudge?.();
+}
+
+function forcedStepKey() {
+  return `chat-onboard-force-step-${state.currentProfile}`;
+}
+
+function clearForcedOnboardingStep() {
+  sessionStorage.removeItem(forcedStepKey());
 }
 
 export function useChatPrompt(text) {
@@ -353,7 +366,17 @@ export function saveChatProfile(advance) {
   renderProfileButton();
   _updateOnboardNextBtn();
   if (advance && name && state.profileSex) {
+    const shouldContinueOnboarding = !state.importedData?.entries?.length && !isAIPaused();
+    if (sessionStorage.getItem(forcedStepKey()) === 'profile' && shouldContinueOnboarding) {
+      goToOnboardingStep(hasAIProvider() ? 3 : 2);
+      return;
+    }
+    if (shouldContinueOnboarding) {
+      goToOnboardingStep(hasAIProvider() ? 3 : 2);
+      return;
+    }
     // Profile complete — advance to next stage
+    clearForcedOnboardingStep();
     updateChatNudge();
     renderChatMessages();
   }
@@ -494,14 +517,47 @@ function _refreshDashboardCycle() {
   }
 }
 
+function getOnboardingProgressMeta(currentStep) {
+  const providerConnected = hasAIProvider();
+  const labels = {
+    1: 'Basics',
+    2: 'AI setup',
+    3: 'Add-ons',
+    4: 'Context',
+  };
+  if (providerConnected && currentStep === 1) {
+    return {
+      step: 1,
+      total: 3,
+      label: labels[1],
+    };
+  }
+  if (providerConnected && currentStep >= 3) {
+    return {
+      step: currentStep - 1,
+      total: 3,
+      label: labels[currentStep] || 'Setup',
+    };
+  }
+  return {
+    step: currentStep,
+    total: 4,
+    label: labels[currentStep] || 'Setup',
+  };
+}
+
 // Thin progress strip shown at the top of each onboarding chat message.
-// 4 steps: 1) profile, 2) AI setup, 3) extras (cycle/supplements), 4) cards
-// + import. The dots make the funnel feel finite — a wall of unknown
-// length is a big drop-off driver for non-tech users.
-export function _renderOnboardCrumbs(currentStep, totalSteps = 4) {
-  const dots = Array.from({ length: totalSteps }, (_, i) => `<span class="chat-onboard-crumb${i + 1 <= currentStep ? ' active' : ''}"></span>`).join('');
-  return `<div class="chat-onboard-crumbs" aria-label="Onboarding step ${currentStep} of ${totalSteps}">
-    <span class="chat-onboard-crumbs-label">Step ${currentStep} of ${totalSteps}</span>
+// AI-connected users skip the AI setup phase, so the displayed progress is
+// mapped to a 3-step path while navigation still uses the internal 4 routes.
+export function _renderOnboardCrumbs(currentStep) {
+  const progress = getOnboardingProgressMeta(currentStep);
+  const dots = Array.from({ length: progress.total }, (_, i) => `<span class="chat-onboard-crumb${i + 1 <= progress.step ? ' active' : ''}"></span>`).join('');
+  const previousStep = currentStep === 3 && hasAIProvider() ? 1 : currentStep - 1;
+  const back = currentStep > 1
+    ? `<button type="button" class="chat-onboard-back-btn" ${chatOnboardingActionAttrs('go-onboarding-step', { step: previousStep })} aria-label="Back to previous onboarding step" title="Previous step">&larr;</button>`
+    : '';
+  return `<div class="chat-onboard-crumbs" aria-label="Onboarding step ${progress.step} of ${progress.total}: ${escapeAttr(progress.label)}">
+    <span class="chat-onboard-crumbs-main">${back}<span class="chat-onboard-crumbs-label">Step ${progress.step} of ${progress.total} &middot; ${escapeHTML(progress.label)}</span></span>
     <span class="chat-onboard-crumbs-dots" aria-hidden="true">${dots}</span>
   </div>`;
 }
@@ -548,7 +604,7 @@ export function _renderProviderQuiz(branch, name) {
       </div></div>`;
   }
   // Root question
-  return `<div class="chat-provider-quiz"><p>Welcome, ${safeName}! One more step &mdash; pick how you want to power the AI:</p>
+  return `<div class="chat-provider-quiz"><p>Welcome, ${safeName}! Next, pick how you want to power the AI:</p>
     <div class="chat-quiz-options">
       <button type="button" class="chat-quiz-option chat-quiz-recommended" ${chatOnboardingActionAttrs('set-provider-branch', { 'provider-branch': 'card' })}>
         <span class="chat-quiz-icon" aria-hidden="true">&#128179;</span>
@@ -604,7 +660,7 @@ export function skipProviderSetup() {
   localStorage.setItem(`labcharts-onboard-provider-skipped-${state.currentProfile}`, '1');
   sessionStorage.removeItem(`chat-onboard-provider-requested-${state.currentProfile}`);
   sessionStorage.removeItem(`chat-onboard-provider-branch-${state.currentProfile}`);
-  renderChatMessages();
+  goToOnboardingStep(3);
 }
 
 export function skipOnboardingExtras() {
@@ -613,6 +669,60 @@ export function skipOnboardingExtras() {
   sessionStorage.setItem('welcome-details-open', '1');
   // Re-render dashboard to reflect cycle + supplement changes from onboarding
   navigate('dashboard');
+  if (sessionStorage.getItem(forcedStepKey()) === 'extras') {
+    goToOnboardingStep(4);
+    return;
+  }
+  clearForcedOnboardingStep();
+  renderChatMessages();
+}
+
+export function skipContextCards() {
+  clearForcedOnboardingStep();
+  localStorage.setItem(`labcharts-onboard-extras-done-${state.currentProfile}`, '1');
+  localStorage.setItem(`labcharts-onboard-context-cards-skipped-${state.currentProfile}`, '1');
+  localStorage.removeItem(`labcharts-onboard-context-cards-done-${state.currentProfile}`);
+  sessionStorage.removeItem(`chat-onboard-force-context-cards-${state.currentProfile}`);
+  sessionStorage.setItem('welcome-details-open', '1');
+  navigate('dashboard');
+  updateChatNudge();
+  renderChatMessages();
+}
+
+export function continueAfterContextCards() {
+  clearForcedOnboardingStep();
+  localStorage.setItem(`labcharts-onboard-extras-done-${state.currentProfile}`, '1');
+  localStorage.setItem(`labcharts-onboard-context-cards-done-${state.currentProfile}`, '1');
+  localStorage.removeItem(`labcharts-onboard-context-cards-skipped-${state.currentProfile}`);
+  sessionStorage.removeItem(`chat-onboard-force-context-cards-${state.currentProfile}`);
+  sessionStorage.setItem('welcome-details-open', '1');
+  navigate('dashboard');
+  updateChatNudge();
+  renderChatMessages();
+}
+
+export function goToOnboardingStep(step) {
+  const target = Number(step);
+  if (!Number.isFinite(target)) return;
+  const profileId = state.currentProfile;
+  if (target <= 1) {
+    sessionStorage.setItem(forcedStepKey(), 'profile');
+  } else if (target === 2) {
+    sessionStorage.setItem(forcedStepKey(), 'provider');
+    sessionStorage.setItem(`chat-onboard-provider-requested-${profileId}`, '1');
+    sessionStorage.removeItem(`chat-onboard-provider-branch-${profileId}`);
+  } else if (target === 3) {
+    sessionStorage.setItem(forcedStepKey(), 'extras');
+    sessionStorage.removeItem(`chat-onboard-provider-requested-${profileId}`);
+    sessionStorage.removeItem(`chat-onboard-provider-branch-${profileId}`);
+    sessionStorage.removeItem(`chat-onboard-force-context-cards-${profileId}`);
+  } else {
+    sessionStorage.setItem(forcedStepKey(), 'cards');
+    sessionStorage.removeItem(`chat-onboard-provider-requested-${profileId}`);
+    sessionStorage.removeItem(`chat-onboard-provider-branch-${profileId}`);
+    sessionStorage.setItem(`chat-onboard-force-context-cards-${profileId}`, '1');
+    localStorage.setItem(`labcharts-onboard-extras-done-${profileId}`, '1');
+  }
   renderChatMessages();
 }
 
@@ -626,6 +736,8 @@ export function _countFilledCards() {
 }
 
 export function onContextCardSaved() {
+  localStorage.removeItem(`labcharts-onboard-context-cards-skipped-${state.currentProfile}`);
+  localStorage.removeItem(`labcharts-onboard-context-cards-done-${state.currentProfile}`);
   const filled = _countFilledCards();
   const hasData = state.importedData?.entries?.length > 0;
   if (!hasData) {

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -154,6 +154,219 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
   expectAll(results);
 });
 
+test('chat onboarding walks connected and disconnected funnels coherently', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  const results = await page.evaluate(async () => {
+    const [
+      { renderEmptyChatState },
+      { state },
+      data,
+      chatOnboarding,
+    ] = await Promise.all([
+      import('/js/chat-empty-state.js'),
+      import('/js/state.js'),
+      import('/js/data.js'),
+      import('/js/chat-onboarding.js'),
+    ]);
+
+    const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
+    const saved = {
+      currentProfile: state.currentProfile,
+      profiles: clone(state.profiles),
+      profileSex: state.profileSex,
+      profileDob: state.profileDob,
+      currentChatPersonality: state.currentChatPersonality,
+      importedData: clone(state.importedData),
+      chatHistory: clone(state.chatHistory),
+    };
+    const localSnapshot = new Map(Array.from({ length: localStorage.length }, (_, i) => {
+      const key = localStorage.key(i);
+      return [key, localStorage.getItem(key)];
+    }));
+    const sessionSnapshot = new Map(Array.from({ length: sessionStorage.length }, (_, i) => {
+      const key = sessionStorage.key(i);
+      return [key, sessionStorage.getItem(key)];
+    }));
+    const existingPanel = document.getElementById('chat-panel');
+    const panel = existingPanel || document.createElement('div');
+    const container = document.createElement('div');
+    const savedPanelClass = panel.className;
+    const savedPanelId = panel.id;
+    const calls = [];
+    const outcomes = {};
+
+    const baseImportedData = () => ({
+      entries: [],
+      notes: [],
+      supplements: [],
+      healthGoals: [],
+      diagnoses: null,
+      diet: null,
+      exercise: null,
+      sleepRest: null,
+      lightCircadian: null,
+      stress: null,
+      loveLife: null,
+      environment: null,
+      menstrualCycle: null,
+      genetics: null,
+      wearableConnections: {},
+      interpretiveLens: '',
+      contextNotes: '',
+      customMarkers: {},
+      markerNotes: {},
+      markerValueNotes: {},
+      changeHistory: [],
+    });
+    const restoreStorage = (storage, snapshot) => {
+      storage.clear();
+      for (const [key, value] of snapshot) {
+        if (key && value != null) storage.setItem(key, value);
+      }
+    };
+    const setProvider = connected => {
+      localStorage.setItem('labcharts-ai-paused', 'false');
+      localStorage.setItem('labcharts-ai-provider', connected ? 'ollama' : 'custom');
+      if (!connected) {
+        localStorage.removeItem('labcharts-custom-url');
+        localStorage.removeItem('labcharts-custom-key');
+      }
+    };
+    const setupProfile = (profileId, connected) => {
+      localStorage.clear();
+      sessionStorage.clear();
+      setProvider(connected);
+      state.currentProfile = profileId;
+      state.profiles = [{ id: profileId, name: 'Default', tags: [], notes: '', status: 'active' }];
+      state.profileSex = null;
+      state.profileDob = null;
+      state.currentChatPersonality = 'default';
+      state.importedData = baseImportedData();
+      state.chatHistory = [];
+      data.invalidateActiveDataCache();
+      container.innerHTML = '';
+      panel.className = '';
+      renderEmptyChatState(container, panel);
+    };
+    const text = () => container.textContent || '';
+    const click = selector => {
+      const el = container.querySelector(selector);
+      if (!el) return false;
+      el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      return true;
+    };
+    const finishStep1 = () => {
+      const nameInput = container.querySelector('#chat-onboard-name');
+      if (nameInput) nameInput.value = 'Ada';
+      click('[data-chat-empty-action="set-profile-sex"][data-sex="female"]');
+      click('[data-chat-empty-action="save-profile-advance"]');
+    };
+    const clickBack = () => click('.chat-onboard-back-btn[data-chat-onboarding-action="go-onboarding-step"]');
+    const continueStep3 = () => click('[data-chat-empty-action="skip-extras"]');
+
+    try {
+      panel.id = 'chat-panel';
+      if (!existingPanel) document.body.append(panel);
+      panel.append(container);
+      chatOnboarding.configureChatOnboarding({
+        navigate: route => calls.push(`navigate:${route}`),
+        renderChatMessages: () => renderEmptyChatState(container, panel),
+        renderProfileButton: () => {},
+        setChatNudge: () => {},
+        updateChatNudge: () => {},
+      });
+
+      setupProfile('walk-connected', true);
+      outcomes.connectedStartsAtProfile = text().includes('Step 1 of 3')
+        && text().includes('Basics');
+      finishStep1();
+      outcomes.connectedSkipsProviderToStep3 = text().includes('Step 2 of 3')
+        && text().includes('Add-ons')
+        && !text().includes('pick how you want to power the AI');
+      clickBack();
+      outcomes.connectedBackFromStep3ReturnsToProfile = text().includes('Step 1 of 3')
+        && text().includes('Basics');
+      finishStep1();
+      outcomes.connectedProfileContinueReturnsToStep3 = text().includes('Step 2 of 3')
+        && text().includes('Add-ons');
+      continueStep3();
+      outcomes.connectedStep3ContinuesToCardsOnly = text().includes('Step 3 of 3')
+        && text().includes('Context')
+        && text().includes('Add optional context')
+        && !!container.querySelector('.chat-context-cards')
+        && !container.querySelector('[data-chat-empty-action="start-lab-import"]');
+      click('[data-chat-empty-action="continue-after-context-cards"]');
+      outcomes.connectedCardsContinueShowsImportHandoff = text().includes('Context cards are saved for later')
+        && text().includes('Setup ready')
+        && text().includes('import labs or ask what to test')
+        && !text().includes('Step 4 of 4')
+        && !!container.querySelector('[data-chat-empty-action="start-lab-import"]')
+        && !!container.querySelector('[data-chat-empty-action="use-prompt"]')
+        && !!container.querySelector('[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="4"]');
+      click('[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="4"]');
+      outcomes.connectedHandoffReturnShowsCards = text().includes('Step 3 of 3')
+        && text().includes('Context')
+        && !!container.querySelector('.chat-context-cards');
+
+      setupProfile('walk-disconnected', false);
+      finishStep1();
+      outcomes.disconnectedProfileContinuesToProvider = text().includes('Step 2 of 4')
+        && text().includes('AI setup')
+        && text().includes('Next, pick how you want to power the AI')
+        && !text().includes('One more step');
+      click('[data-chat-onboarding-action="skip-provider-setup"]');
+      outcomes.disconnectedProviderSkipContinuesToStep3 = text().includes('Step 3 of 4')
+        && text().includes('Add-ons')
+        && text().includes('Continue to context cards');
+      clickBack();
+      outcomes.disconnectedBackFromStep3ReturnsToProvider = text().includes('Step 2 of 4')
+        && text().includes('AI setup')
+        && text().includes('pick how you want to power the AI');
+      click('[data-chat-onboarding-action="skip-provider-setup"]');
+      continueStep3();
+      outcomes.disconnectedStep4KeepsCardsBeforeConnect = text().includes('Step 4 of 4')
+        && text().includes('Context')
+        && !!container.querySelector('.chat-context-cards')
+        && container.querySelector('[data-chat-empty-action="continue-after-context-cards"]')?.textContent?.trim() === 'Continue'
+        && !container.querySelector('[data-chat-empty-action="request-lab-import-provider"]');
+      click('[data-chat-empty-action="continue-after-context-cards"]');
+      outcomes.disconnectedHandoffHasSingleConnectAndContextReturn = text().includes('connect AI when you are ready')
+        && text().includes('Setup ready')
+        && !text().includes('Step 4 of 4')
+        && container.querySelectorAll('[data-chat-empty-action="request-lab-import-provider"]').length === 1
+        && container.querySelectorAll('[data-chat-empty-action="open-provider-quiz"]').length === 0
+        && !!container.querySelector('[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="4"]');
+    } finally {
+      state.currentProfile = saved.currentProfile;
+      state.profiles = saved.profiles;
+      state.profileSex = saved.profileSex;
+      state.profileDob = saved.profileDob;
+      state.currentChatPersonality = saved.currentChatPersonality;
+      state.importedData = saved.importedData;
+      state.chatHistory = saved.chatHistory;
+      data.invalidateActiveDataCache();
+      restoreStorage(localStorage, localSnapshot);
+      restoreStorage(sessionStorage, sessionSnapshot);
+      chatOnboarding.configureChatOnboarding({
+        navigate: () => {},
+        renderChatMessages: () => {},
+        renderProfileButton: () => {},
+        setChatNudge: () => {},
+        updateChatNudge: () => {},
+      });
+      container.remove();
+      panel.className = savedPanelClass;
+      panel.id = savedPanelId;
+      if (!existingPanel) panel.remove();
+    }
+
+    return outcomes;
+  });
+
+  expectAll(results);
+});
+
 test('chat empty-state renders remaining prompt states and actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
@@ -254,6 +467,9 @@ test('chat empty-state renders remaining prompt states and actions', async ({ pa
     });
     const clearBranchStorage = () => {
       localStorage.removeItem(`labcharts-onboard-extras-done-${profileId}`);
+      localStorage.removeItem(`labcharts-onboard-context-cards-skipped-${profileId}`);
+      localStorage.removeItem(`labcharts-onboard-context-cards-done-${profileId}`);
+      sessionStorage.removeItem(`chat-onboard-force-step-${profileId}`);
       sessionStorage.removeItem(`chat-onboard-force-context-cards-${profileId}`);
       sessionStorage.removeItem(`chat-onboard-provider-requested-${profileId}`);
       sessionStorage.removeItem(`chat-onboard-provider-branch-${profileId}`);
@@ -277,6 +493,7 @@ test('chat empty-state renders remaining prompt states and actions', async ({ pa
       clearBranchStorage();
       setProviderState({ connected: opts.connected !== false, paused: !!opts.paused });
       if (opts.extrasDone) localStorage.setItem(`labcharts-onboard-extras-done-${profileId}`, '1');
+      if (opts.contextCardsSkipped) localStorage.setItem(`labcharts-onboard-context-cards-skipped-${profileId}`, '1');
       if (opts.forceContextCards) sessionStorage.setItem(`chat-onboard-force-context-cards-${profileId}`, '1');
       if (opts.providerRequested) sessionStorage.setItem(`chat-onboard-provider-requested-${profileId}`, '1');
       if (opts.providerBranch) sessionStorage.setItem(`chat-onboard-provider-branch-${profileId}`, opts.providerBranch);
@@ -349,33 +566,130 @@ test('chat empty-state renders remaining prompt states and actions', async ({ pa
 
       setFixture(fullContextData(), { extrasDone: true });
       const fullText = renderText();
+      container.querySelector('[data-chat-empty-action="start-lab-import"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       container.querySelector('[data-chat-empty-action="use-prompt"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       const promptInputValue = document.getElementById('chat-input')?.value || '';
-      outcomes.fullContextNoDataStateMarksPanelActive = panel.classList.contains('chat-onboarding-active');
-      outcomes.fullContextNoDataStateRendersCopy = fullText.includes('filled everything in');
+      outcomes.fullContextNoDataStateLeavesPanelInactive = !panel.classList.contains('chat-onboarding-active');
+      outcomes.fullContextNoDataStateRendersHandoffCopy = fullText.includes('Context complete')
+        && fullText.includes('context cards are complete')
+        && fullText.includes('import labs or ask what to test')
+        && !fullText.includes('Step 4 of 4');
+      outcomes.fullContextNoDataStateOffersImportAndReview =
+        calls.some(call => call[0] === 'input-click' && call[1] === 'pdf-input')
+        && !!container.querySelector('.chat-prompt-btn[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="4"]');
       outcomes.fullContextNoDataPromptFillsInput = promptInputValue.includes('what blood tests should I get');
       outcomes.fullContextNoDataPromptTriggersSend = calls.some(call => call[0] === 'send-chat');
 
+      setFixture(fullContextData(), { extrasDone: true, connected: false });
+      const fullDisconnectedText = renderText();
+      outcomes.fullContextNoDataDisconnectedHasSingleConnectAction =
+        fullDisconnectedText.includes('connect AI when you are ready')
+        && fullDisconnectedText.includes('Context complete')
+        && !fullDisconnectedText.includes('Step 4 of 4')
+        && container.querySelectorAll('[data-chat-empty-action="request-lab-import-provider"]').length === 1
+        && container.querySelectorAll('[data-chat-empty-action="open-provider-quiz"]').length === 0
+        && !!container.querySelector('.chat-prompt-btn[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="4"]');
+
       setFixture(partialContextData(), { extrasDone: true });
       const partialText = renderText();
-      container.querySelector('[data-chat-empty-action="scroll-context-cards"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      container.querySelector('[data-chat-empty-action="skip-context-cards"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       outcomes.partialContextNoDataStateMarksPanelActive = panel.classList.contains('chat-onboarding-active');
       outcomes.partialContextNoDataStateRendersProgress = partialText.includes("You've filled 2 of 9 context areas");
       outcomes.partialContextNoDataStateRendersCards = !!container.querySelector('.chat-context-cards');
-      outcomes.partialContextNoDataStateScrollsCards = calls.some(call => call[0] === 'scroll');
+      outcomes.partialContextNoDataStateKeepsHandoffBelowCards =
+        !!container.querySelector('.chat-context-cards + .chat-onboard-actions')
+        && !!container.querySelector('[data-chat-empty-action="continue-after-context-cards"]');
+      outcomes.partialContextNoDataStateSkipsCards = localStorage.getItem(`labcharts-onboard-context-cards-skipped-${profileId}`) === '1'
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${profileId}`) === null
+        && calls.some(call => call[0] === 'render-chat');
 
       setFixture(baseImportedData({}), { extrasDone: true });
       const initialText = renderText();
-      container.querySelector('[data-chat-empty-action="start-lab-import"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       outcomes.initialNoDataStateMarksPanelActive = panel.classList.contains('chat-onboarding-active');
-      outcomes.initialNoDataStateRendersCopy = initialText.includes("You're ready to go");
-      outcomes.initialNoDataStateStartsLabImport = calls.some(call => call[0] === 'input-click' && call[1] === 'pdf-input');
+      outcomes.initialNoDataStateRendersCopy = initialText.includes('Add optional context');
+      outcomes.initialNoDataStateDoesNotPushImportBeforeCards =
+        !!container.querySelector('.chat-context-cards')
+        && !!container.querySelector('.chat-context-cards + .chat-onboard-actions')
+        && !container.querySelector('[data-chat-empty-action="start-lab-import"]');
+      outcomes.initialNoDataStateOffersCardSkip = !!container.querySelector('[data-chat-empty-action="skip-context-cards"]');
+      outcomes.initialNoDataStateUsesCompactActionHierarchy =
+        container.querySelectorAll('.chat-onboard-step4-actions .chat-onboard-cta').length === 1
+        && container.querySelectorAll('.chat-onboard-step4-actions .chat-onboard-text-action').length === 1
+        && !!container.querySelector('.chat-onboard-primary-actions')
+        && !!container.querySelector('.chat-onboard-primary-actions-single')
+        && !!container.querySelector('.chat-onboard-tertiary-actions');
+      container.querySelector('[data-chat-empty-action="continue-after-context-cards"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      const handoffText = renderText();
+      container.querySelector('[data-chat-empty-action="start-lab-import"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      outcomes.contextHandoffAppearsAfterContinueAndStartsLabImport =
+        localStorage.getItem(`labcharts-onboard-context-cards-done-${profileId}`) === '1'
+        && handoffText.includes('Context cards are saved for later')
+        && handoffText.includes('Setup ready')
+        && handoffText.includes('import labs or ask what to test')
+        && !handoffText.includes('Step 4 of 4')
+        && calls.some(call => call[0] === 'input-click' && call[1] === 'pdf-input');
+
+      setFixture(baseImportedData({}), { extrasDone: true, connected: false });
+      renderText();
+      container.querySelector('[data-chat-empty-action="continue-after-context-cards"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      const disconnectedHandoffText = renderText();
+      outcomes.contextHandoffDisconnectedUsesSingleConnectAction =
+        disconnectedHandoffText.includes('connect AI when you are ready')
+        && disconnectedHandoffText.includes('Setup ready')
+        && !disconnectedHandoffText.includes('Step 4 of 4')
+        && container.querySelectorAll('[data-chat-empty-action="request-lab-import-provider"]').length === 1
+        && container.querySelectorAll('[data-chat-empty-action="open-provider-quiz"]').length === 0
+        && !!container.querySelector('.chat-prompt-btn[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="4"]');
+
+      setFixture(baseImportedData({}), { extrasDone: true, contextCardsSkipped: true });
+      const skippedText = renderText();
+      outcomes.skippedContextNoDataStateLeavesPanelInactive = !panel.classList.contains('chat-onboarding-active');
+      outcomes.skippedContextNoDataStateOmitsCards = skippedText.includes('Context cards are skipped for now')
+        && skippedText.includes('Setup ready')
+        && !skippedText.includes('Step 4 of 4')
+        && !container.querySelector('.chat-onboard-back-btn[data-chat-onboarding-action="go-onboarding-step"]')
+        && !!container.querySelector('.chat-prompt-btn[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="4"]')
+        && !container.querySelector('.chat-context-cards');
+
+      setFixture(baseImportedData({}), { extrasDone: true });
+      sessionStorage.setItem(`chat-onboard-force-step-${profileId}`, 'provider');
+      const forcedProviderText = renderText();
+      outcomes.forcedProviderStepShowsConnectedStateWhenProviderExists = forcedProviderText.includes('AI is connected')
+        && forcedProviderText.includes('AI connected')
+        && !forcedProviderText.includes('Step 2 of 4')
+        && forcedProviderText.includes('Continue')
+        && !!container.querySelector('[data-chat-onboarding-action="go-onboarding-step"][data-chat-step="3"]')
+        && panel.classList.contains('chat-onboarding-active');
+
+      setFixture(baseImportedData({}), { extrasDone: true, connected: false });
+      sessionStorage.setItem(`chat-onboard-force-step-${profileId}`, 'provider');
+      const forcedDisconnectedProviderText = renderText();
+      outcomes.forcedProviderStepShowsPickerWithoutProvider = forcedDisconnectedProviderText.includes('pick how you want to power the AI')
+        && panel.classList.contains('chat-onboarding-active');
+
+      setFixture(baseImportedData({}), { extrasDone: true, contextCardsSkipped: true });
+      sessionStorage.setItem(`chat-onboard-force-step-${profileId}`, 'extras');
+      const forcedExtrasText = renderText();
+      outcomes.forcedExtrasStepOverridesDoneFlags = forcedExtrasText.includes('These optional context pieces')
+        && panel.classList.contains('chat-onboarding-active');
+
+      setFixture(baseImportedData({}), { extrasDone: true, contextCardsSkipped: true });
+      sessionStorage.setItem(`chat-onboard-force-step-${profileId}`, 'cards');
+      const forcedCardsText = renderText();
+      outcomes.forcedCardsStepOverridesSkippedFlag = forcedCardsText.includes('Add optional context')
+        && !!container.querySelector('.chat-context-cards');
 
       setFixture(labData({}), { extrasDone: true });
       const nudgeText = renderText();
       container.querySelector('[data-chat-empty-action="set-onboarding-focus"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       outcomes.dataContextNudgeStateRendersCopy = nudgeText.includes('I can see your lab results');
       outcomes.dataContextNudgeStateRunsFocusAction = calls.some(call => call[0] === 'focus' && call[1] === 'cards');
+
+      setFixture(labData({}), { extrasDone: true, contextCardsSkipped: true });
+      const skippedDataText = renderText();
+      outcomes.skippedContextWithLabDataUsesGeneralPrompts =
+        !skippedDataText.includes('I can see your lab results')
+        && skippedDataText.includes('What are my most concerning results?');
 
       setFixture(labData({ diagnoses: { conditions: [{ name: 'baseline' }] }, diet: { style: 'high protein' }, exercise: { frequency: 'daily' } }), { extrasDone: true });
       const generalText = renderText();

--- a/tests/playwright/chat-nudge-browser-coverage.spec.js
+++ b/tests/playwright/chat-nudge-browser-coverage.spec.js
@@ -30,6 +30,7 @@ test('chat nudge browser coverage handles badge storage dismissal and staged upd
       'labcharts-chat-nudge-dismissed-chat-nudge-test',
       'labcharts-chat-nudge-dismissed-no-profile',
       'labcharts-chat-nudge-dismissed-named-profile',
+      'labcharts-onboard-context-cards-skipped-named-profile',
     ];
     const saved = {
       state: {
@@ -135,6 +136,7 @@ test('chat nudge browser coverage handles badge storage dismissal and staged upd
         && !fabHasNudge();
 
       localStorage.removeItem('labcharts-chat-nudge-dismissed-named-profile');
+      localStorage.removeItem('labcharts-onboard-context-cards-skipped-named-profile');
       state.importedData = {
         entries: [{ date: '2026-06-11', markers: {} }],
         diagnoses: { text: 'low ferritin' },
@@ -151,6 +153,15 @@ test('chat nudge browser coverage handles badge storage dismissal and staged upd
         && !fabHasNudge();
 
       localStorage.removeItem('labcharts-chat-nudge-dismissed-named-profile');
+      localStorage.setItem('labcharts-onboard-context-cards-skipped-named-profile', '1');
+      nudge.setChatNudge('context');
+      nudge.updateChatNudge();
+      outcomes.updateChatNudgeRespectsSkippedContextCards =
+        nudgeStage() == null
+        && !fabHasNudge();
+
+      localStorage.removeItem('labcharts-chat-nudge-dismissed-named-profile');
+      localStorage.removeItem('labcharts-onboard-context-cards-skipped-named-profile');
       state.importedData = {
         entries: [{ date: '2026-06-11', markers: {} }],
         diagnoses: { text: 'low ferritin' },
@@ -187,6 +198,7 @@ test('chat nudge browser coverage handles badge storage dismissal and staged upd
     'updateChatNudgeShowsApiStageUntilDismissed',
     'updateChatNudgeShowsDataStageUntilDismissed',
     'updateChatNudgeShowsContextStageUntilDismissedWhenFewCardsAreFilled',
+    'updateChatNudgeRespectsSkippedContextCards',
     'updateChatNudgeClearsWhenEnoughContextCardsAreFilled',
     'allOutcomesReached',
   ];

--- a/tests/playwright/chat-onboarding-browser-coverage.spec.js
+++ b/tests/playwright/chat-onboarding-browser-coverage.spec.js
@@ -307,6 +307,27 @@ test('chat onboarding browser coverage keeps default callbacks safe before chat 
         && state.profileDob === '1985-04-12'
         && localStorage.getItem('labcharts-chat-nudge') === null;
 
+      localStorage.setItem('labcharts-ai-paused', 'false');
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      sessionStorage.setItem(`chat-onboard-force-step-${profileId}`, 'profile');
+      localStorage.setItem(`labcharts-onboard-extras-done-${profileId}`, '1');
+      localStorage.setItem(`labcharts-onboard-context-cards-skipped-${profileId}`, '1');
+      onboarding.saveChatProfile(true);
+      outcomes.forcedProfileContinueSkipsConnectedProviderToExtras =
+        sessionStorage.getItem(`chat-onboard-force-step-${profileId}`) === 'extras'
+        && sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === null
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${profileId}`) === null;
+
+      localStorage.setItem('labcharts-ai-provider', 'custom');
+      localStorage.removeItem('labcharts-custom-url');
+      localStorage.removeItem('labcharts-custom-key');
+      sessionStorage.setItem(`chat-onboard-force-step-${profileId}`, 'profile');
+      onboarding.saveChatProfile(true);
+      outcomes.forcedProfileContinueUsesProviderStepWhenDisconnected =
+        sessionStorage.getItem(`chat-onboard-force-step-${profileId}`) === 'provider'
+        && sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === '1'
+        && sessionStorage.getItem(`chat-onboard-provider-branch-${profileId}`) === null;
+
       state.importedData = {
         ...profile.createDefaultProfileData(),
         entries: [],
@@ -329,7 +350,7 @@ test('chat onboarding browser coverage keeps default callbacks safe before chat 
     }
     if (thrownError) throw thrownError;
 
-    outcomes.allDefaultCallbackOutcomesReached = Object.keys(outcomes).length === 2;
+    outcomes.allDefaultCallbackOutcomesReached = Object.keys(outcomes).length === 4;
     return outcomes;
   }, { onboardingUrl: moduleUrl('/js/chat-onboarding.js') });
 
@@ -467,14 +488,33 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
       configureOnboardingForTest(onboarding);
       configureOnboardingForTest(appOnboarding);
 
-      const crumbs = onboarding._renderOnboardCrumbs(3, 5);
+      localStorage.setItem('labcharts-ai-paused', 'false');
+      localStorage.setItem('labcharts-ai-provider', 'custom');
+      localStorage.removeItem('labcharts-custom-url');
+      localStorage.removeItem('labcharts-custom-key');
+      const crumbs = onboarding._renderOnboardCrumbs(3);
+      localStorage.setItem('labcharts-ai-provider', 'ollama');
+      const connectedCrumbs = onboarding._renderOnboardCrumbs(3);
+      const connectedContextCrumbs = onboarding._renderOnboardCrumbs(4);
       const quizRoot = onboarding._renderProviderQuiz(null, '<Ada>');
       const quizCard = onboarding._renderProviderQuiz('card', 'Ada');
       const quizLocal = onboarding._renderProviderQuiz('local', 'Ada');
       const quizBitcoin = onboarding._renderProviderQuiz('bitcoin', 'Ada');
-      outcomes.renderHelpersEscapeAndBranch = crumbs.includes('Step 3 of 5')
+      outcomes.renderHelpersEscapeAndBranch = crumbs.includes('Step 3 of 4')
+        && crumbs.includes('Add-ons')
         && (crumbs.match(/chat-onboard-crumb active/g) || []).length === 3
+        && crumbs.includes('data-chat-onboarding-action="go-onboarding-step"')
+        && crumbs.includes('data-chat-step="2"')
+        && connectedCrumbs.includes('Step 2 of 3')
+        && connectedCrumbs.includes('Add-ons')
+        && connectedCrumbs.includes('data-chat-step="1"')
+        && (connectedCrumbs.match(/chat-onboard-crumb active/g) || []).length === 2
+        && connectedContextCrumbs.includes('Step 3 of 3')
+        && connectedContextCrumbs.includes('Context')
+        && crumbs.includes('chat-onboard-back-btn')
         && quizRoot.includes('Welcome, &lt;Ada&gt;')
+        && quizRoot.includes('Next, pick how you want to power the AI')
+        && !quizRoot.includes('One more step')
         && quizRoot.includes('chat-quiz-recommended')
         && quizCard.includes('or-oauth-btn')
         && quizLocal.includes('Local AI setup')
@@ -532,13 +572,60 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
       onboarding.skipProviderSetup();
       outcomes.skipProviderSetupMarksLocalAndClearsSession =
         localStorage.getItem(`labcharts-onboard-provider-skipped-${profileId}`) === '1'
-        && sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === null;
+        && sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === null
+        && sessionStorage.getItem(`chat-onboard-provider-branch-${profileId}`) === null
+        && sessionStorage.getItem(`chat-onboard-force-step-${profileId}`) === 'extras';
+
+      sessionStorage.setItem(`chat-onboard-force-step-${profileId}`, 'provider');
+      sessionStorage.setItem(`chat-onboard-provider-requested-${profileId}`, '1');
+      localStorage.setItem(`labcharts-onboard-context-cards-skipped-${profileId}`, '1');
+      onboarding.skipProviderSetup();
+      outcomes.skipProviderSetupFromSkippedCardsStillAdvancesToExtras =
+        sessionStorage.getItem(`chat-onboard-force-step-${profileId}`) === 'extras'
+        && sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === null
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${profileId}`) === null;
 
       onboarding.skipOnboardingExtras();
       outcomes.skipExtrasMarksDoneAndNavigates =
         localStorage.getItem(`labcharts-onboard-extras-done-${profileId}`) === '1'
         && sessionStorage.getItem('welcome-details-open') === '1'
         && calls.includes('navigate:dashboard');
+      outcomes.skipExtrasFromForcedWizardShowsContextCardsAgain =
+        sessionStorage.getItem(`chat-onboard-force-step-${profileId}`) === 'cards'
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${profileId}`) === '1'
+        && localStorage.getItem(`labcharts-onboard-context-cards-skipped-${profileId}`) === '1';
+
+      sessionStorage.setItem(`chat-onboard-force-context-cards-${profileId}`, '1');
+      onboarding.skipContextCards();
+      outcomes.skipContextCardsMarksLocalClearsForceAndRefreshes =
+        localStorage.getItem(`labcharts-onboard-extras-done-${profileId}`) === '1'
+        && localStorage.getItem(`labcharts-onboard-context-cards-skipped-${profileId}`) === '1'
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${profileId}`) === null
+        && sessionStorage.getItem('welcome-details-open') === '1'
+        && calls.includes('update-nudge')
+        && calls.filter(call => call === 'render').length >= 2;
+
+      const forceStepKey = `chat-onboard-force-step-${profileId}`;
+      onboarding.goToOnboardingStep(1);
+      const forcedProfile = sessionStorage.getItem(forceStepKey) === 'profile';
+      onboarding.goToOnboardingStep(2);
+      const forcedProvider = sessionStorage.getItem(forceStepKey) === 'provider'
+        && sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === '1'
+        && sessionStorage.getItem(`chat-onboard-provider-branch-${profileId}`) === null;
+      sessionStorage.setItem(`chat-onboard-force-context-cards-${profileId}`, '1');
+      onboarding.goToOnboardingStep(3);
+      const forcedExtras = sessionStorage.getItem(forceStepKey) === 'extras'
+        && sessionStorage.getItem(`chat-onboard-provider-requested-${profileId}`) === null
+        && sessionStorage.getItem(`chat-onboard-provider-branch-${profileId}`) === null
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${profileId}`) === null;
+      onboarding.goToOnboardingStep(4);
+      outcomes.goToOnboardingStepSetsExpectedSessionTargets =
+        forcedProfile
+        && forcedProvider
+        && forcedExtras
+        && sessionStorage.getItem(forceStepKey) === 'cards'
+        && sessionStorage.getItem(`chat-onboard-force-context-cards-${profileId}`) === '1'
+        && localStorage.getItem(`labcharts-onboard-extras-done-${profileId}`) === '1';
 
       onboarding.showCycleNoMensesOptions();
       outcomes.noMensesOptionsSwitchViews =
@@ -610,11 +697,14 @@ test('chat onboarding cycle supplement and provider quiz helpers cover browser p
         loveLife: { status: 'connected' },
         environment: { air: 'filtered' },
       };
+      localStorage.setItem(`labcharts-onboard-context-cards-skipped-${profileId}`, '1');
       outcomes.countFilledCardsSeesAllContextCards = onboarding._countFilledCards() === 9;
       onboarding.onContextCardSaved();
       outcomes.contextCardSavedNudgesReadyAndRendersOpenPanel =
         calls.includes('nudge:ready')
         && calls.filter(call => call === 'render').length >= 5;
+      outcomes.contextCardSavedClearsCardSkip =
+        localStorage.getItem(`labcharts-onboard-context-cards-skipped-${profileId}`) === null;
 
       state.importedData = {
         ...profile.createDefaultProfileData(),

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.147';
+self.APP_VERSION = '1.10.156';


### PR DESCRIPTION
## Summary
- make chat onboarding navigation coherent for AI-connected and disconnected users
- make Step 4 context-card first, with import/test choices only after continue or skip
- replace raw step numbering with dynamic Step X of N phase labels and non-numbered handoff labels
- add browser coverage for the connected/disconnected onboarding funnels and skipped context-card state

## Verification
- npm run typecheck:checkjs
- npx playwright test tests/playwright/chat-empty-state.spec.js tests/playwright/chat-onboarding-browser-coverage.spec.js tests/playwright/chat-nudge-browser-coverage.spec.js