### PR TITLE
Improve cycle import review UX

### DIFF
--- a/css/import.css
+++ b/css/import.css
@@ -19,6 +19,11 @@
   padding: 0;
 }
 #import-modal.import-preview-modal { max-width: 920px; }
+#import-modal.cycle-import-preview-modal,
+.modal.cycle-import-preview-modal {
+  width: min(94vw, 820px);
+  max-width: 820px;
+}
 .import-preview-head {
   background: color-mix(in srgb, var(--bg-secondary) 96%, var(--bg-card));
 }
@@ -288,6 +293,88 @@ select.import-unit-input {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
   margin-top: 14px;
+}
+.cycle-import-conflict-warning {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.cycle-import-conflict-warning strong { color: var(--text-primary); }
+.cycle-import-table-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+}
+.cycle-import-table-heading strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 800;
+}
+.cycle-import-table-heading span {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: right;
+}
+.cycle-import-table-wrap { margin-top: 8px; }
+.cycle-import-status-heading,
+.cycle-import-status-cell { width: 118px; }
+.cycle-import-row-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 7px;
+  border: 1px solid;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.cycle-import-row-status-ready {
+  border-color: color-mix(in srgb, var(--green) 28%, var(--border));
+  background: color-mix(in srgb, var(--green) 9%, transparent);
+  color: var(--green);
+}
+.cycle-import-row-status-conflict {
+  border-color: color-mix(in srgb, var(--yellow) 36%, var(--border));
+  background: color-mix(in srgb, var(--yellow) 10%, transparent);
+  color: var(--yellow);
+}
+.cycle-import-table tr[data-import-status="unmatched"] {
+  background: color-mix(in srgb, var(--yellow) 5%, transparent);
+}
+.cycle-import-privacy-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-card) 54%, transparent);
+  color: var(--text-secondary);
+}
+.cycle-import-privacy-icon {
+  flex: 0 0 auto;
+  font-size: 14px;
+  line-height: 1.4;
+}
+.cycle-import-privacy-note > span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+.cycle-import-privacy-note strong {
+  color: var(--text-primary);
+  font-size: 12px;
+}
+.cycle-import-privacy-note small {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
 }
 .cycle-import-conflict-option {
   display: flex;
@@ -863,6 +950,10 @@ select.import-unit-input {
     justify-content: center;
     min-width: 92px;
   }
+  .cycle-import-preview-modal .import-review-stat {
+    flex-basis: calc(50% - 6px);
+    min-width: 130px;
+  }
   .import-review-controls {
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;
@@ -1041,6 +1132,12 @@ select.import-unit-input {
     min-height: 44px;
     padding: 10px;
   }
+  .cycle-import-table-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .cycle-import-table-heading span { text-align: left; }
   .import-review-actions {
     position: sticky;
     bottom: 0;

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,7 +11,7 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
-    version: '1.10.156', date: '2026-07-10', title: 'Import your menstrual cycle history',
+    version: '1.10.157', date: '2026-07-10', title: 'Import your menstrual cycle history',
     forceShow: true,
     items: [
       '<b>Cycle history can now come with you.</b> Import Apple Health, Drip, Natural Cycles, or an extracted Clue JSON export and review the detected periods before saving.',

--- a/js/cycle-import-adapters.js
+++ b/js/cycle-import-adapters.js
@@ -102,11 +102,6 @@ export function mergeCycleImportObservations(source, groups) {
   return Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date));
 }
 
-const SCHEMA_REVIEW_WARNINGS = {
-  clue: 'Clue export formats can change. This adapter is validated with synthetic fixtures; review the detected periods before importing.',
-  natural_cycles: 'Natural Cycles export formats can change. This adapter is validated with synthetic fixtures; review the detected periods before importing.',
-};
-
 function finalizeImport(source, sourceLabel, fileName, observations, emptyPeriodWarning) {
   const merged = mergeCycleImportObservations(source, [observations]);
   if (!merged.length) return null;
@@ -123,10 +118,7 @@ function finalizeImport(source, sourceLabel, fileName, observations, emptyPeriod
     importId,
     observations: merged.map(row => ({ ...row, importId })),
     periods,
-    warnings: [
-      ...(!periods.length ? [emptyPeriodWarning] : []),
-      ...(SCHEMA_REVIEW_WARNINGS[source] ? [SCHEMA_REVIEW_WARNINGS[source]] : []),
-    ],
+    warnings: !periods.length ? [emptyPeriodWarning] : [],
     detectedRange: {
       firstDate: merged[0]?.date || null,
       lastDate: merged[merged.length - 1]?.date || null,
@@ -270,7 +262,7 @@ export function parseDripCycleCsv(text, fileName = 'drip.csv') {
     'Drip',
     fileName,
     observations,
-    'No period episodes could be derived from bleeding rows.',
+    'Drip includes daily observations, but no periods were detected.',
   );
 }
 
@@ -358,7 +350,7 @@ export function parseNaturalCyclesCsv(text, fileName = 'tracking_data.csv') {
     'Natural Cycles',
     fileName,
     observations,
-    'Natural Cycles had daily observations, but no menstrual-flow episodes were derived.',
+    'Natural Cycles includes daily observations, but no periods were detected.',
   );
 }
 
@@ -374,7 +366,7 @@ export function parseNaturalCyclesCsvBundle(files, archiveName = 'natural-cycles
     'Natural Cycles',
     archiveName,
     mergeCycleImportObservations('natural_cycles', parsed.map(result => result.observations)),
-    'Natural Cycles had daily observations, but no menstrual-flow episodes were derived.',
+    'Natural Cycles includes daily observations, but no periods were detected.',
   );
 }
 
@@ -487,6 +479,6 @@ export function parseClueCycleJson(value, fileName = 'clue-data.json') {
     'Clue',
     fileName,
     observations,
-    'Clue had tracked cycle observations, but no menstrual-flow episodes were derived.',
+    'Clue includes tracked cycle observations, but no periods were detected.',
   );
 }

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -581,68 +581,68 @@ export async function clearCycleProfileData() {
 }
 
 function conflictSummary(plan) {
-  if (!plan.conflicts.length) return 'No overlapping period entries found.';
-  return `${plan.conflicts.length} imported period${plan.conflicts.length !== 1 ? 's' : ''} overlap existing entries.`;
+  const count = plan.conflicts.length;
+  return `${count} imported period${count !== 1 ? 's' : ''} overlap${count === 1 ? 's' : ''} existing entries.`;
 }
-
-function renderPeriodRows(periods) {
-  return periods.slice(0, 18).map(period => `<tr>
-    <td data-label="Start">${escapeHTML(period.startDate || '')}</td>
-    <td data-label="End">${escapeHTML(period.endDate || period.startDate || '')}</td>
-    <td data-label="Flow">${escapeHTML(period.flow || 'moderate')}</td>
-    <td data-label="Symptoms">${escapeHTML((period.symptoms || []).join(', '))}</td>
-  </tr>`).join('');
+function renderPeriodRows(periods, conflictStarts, conflictMode) {
+  return periods.slice(0, 18).map(period => {
+    const hasConflict = conflictStarts.has(period.startDate);
+    const status = hasConflict
+      ? conflictMode === 'replace-overlapping' ? 'Overlap · replace' : 'Overlap · skip'
+      : 'Ready';
+    return `<tr data-import-status="${hasConflict ? 'unmatched' : 'matched'}">
+      <td class="cycle-import-status-cell" data-label="Status"><span class="cycle-import-row-status ${hasConflict ? 'cycle-import-row-status-conflict' : 'cycle-import-row-status-ready'}">${status}</span></td>
+      <td data-label="Start">${escapeHTML(period.startDate || '')}</td><td data-label="End">${escapeHTML(period.endDate || period.startDate || '')}</td>
+      <td data-label="Flow">${escapeHTML(period.flow || 'moderate')}</td><td data-label="Symptoms">${escapeHTML((period.symptoms || []).join(', '))}</td>
+    </tr>`;
+  }).join('');
 }
 
 function renderCycleImportPreview(parsed, conflictMode = 'keep-existing') {
   const plan = buildCycleImportPlan(parsed, state.importedData.menstrualCycle, conflictMode);
   const source = parsed.sourceLabel || sourceLabel(parsed.source);
+  const observationCount = parsed.observations?.length || 0;
+  const conflictStarts = new Set(plan.conflicts.map(item => item.period.startDate));
+  const importCount = plan.importedToApply.length;
+  const confirmLabel = importCount ? `Import ${importCount} period${importCount !== 1 ? 's' : ''}`
+    : observationCount ? `Import ${observationCount} daily observation${observationCount !== 1 ? 's' : ''}` : 'Complete import';
   return `<div class="gb-modal-head import-preview-head">
-      <div>
-        <div class="gb-modal-kicker">Cycle import</div>
-        <div class="gb-modal-title">${escapeHTML(source)}</div>
-      </div>
+      <div><div class="gb-modal-kicker">Cycle import · ${escapeHTML(source)}</div><div class="gb-modal-title">Review cycle import</div></div>
       <button type="button" class="modal-close" ${importActionAttrs('close')} aria-label="Close import preview">&times;</button>
     </div>
     <div class="gb-form-body import-review-body">
       <div class="import-review-summary">
-        <div class="import-review-file">
-          <span class="import-review-label">File</span>
-          <strong>${escapeHTML(parsed.sourceFile || source)}</strong>
-        </div>
-        <div class="import-review-file">
-          <span class="import-review-label">Range</span>
-          <strong>${escapeHTML(parsed.detectedRange?.firstDate || '?')} - ${escapeHTML(parsed.detectedRange?.lastDate || '?')}</strong>
-        </div>
-        <div class="import-review-stats">
-          <span class="import-review-stat"><strong>${parsed.observations?.length || 0}</strong> daily observations</span>
-          <span class="import-review-stat import-review-stat-matched"><strong>${plan.importedPeriods.length}</strong> derived periods</span>
-          <span class="import-review-stat import-review-stat-unmatched"><strong>${plan.conflicts.length}</strong> conflicts</span>
-          <span class="import-review-stat"><strong>${plan.importedToApply.length}</strong> periods to sync</span>
+        <div class="import-review-file"><span class="import-review-label">File</span><strong>${escapeHTML(parsed.sourceFile || source)}</strong></div>
+        <div class="import-review-file"><span class="import-review-label">Range</span><strong>${escapeHTML(parsed.detectedRange?.firstDate || '?')} - ${escapeHTML(parsed.detectedRange?.lastDate || '?')}</strong></div>
+        <div class="import-review-stats" aria-label="Cycle import summary">
+          <span class="import-review-stat"><strong>${observationCount}</strong> daily observations</span><span class="import-review-stat import-review-stat-matched"><strong>${plan.importedPeriods.length}</strong> periods found</span>
+          ${plan.conflicts.length ? `<span class="import-review-stat import-review-stat-unmatched"><strong>${plan.conflicts.length}</strong> overlap${plan.conflicts.length !== 1 ? 's' : ''}</span>
+          <span class="import-review-stat import-review-stat-new"><strong>${importCount}</strong> will import</span>` : ''}
         </div>
       </div>
-      <div class="import-review-warning">${escapeHTML(conflictSummary(plan))} Daily observations stay on this device; compact period episodes sync across devices.</div>
-      ${parsed.warnings?.length ? `<div class="import-review-warning">${parsed.warnings.map(escapeHTML).join('<br>')}</div>` : ''}
-      <div class="cycle-import-conflicts" role="radiogroup" aria-label="Cycle import conflict handling">
-        ${[
-          ['keep-existing', 'Keep existing', 'Import non-overlapping periods and leave conflicts unchanged.'],
-          ['replace-overlapping', 'Replace overlaps', 'Replace overlapping existing period entries with imported periods.'],
-        ].map(([value, label, desc]) => `<label class="cycle-import-conflict-option">
-          <input type="radio" name="cycle-import-conflict" value="${value}" ${conflictMode === value ? 'checked' : ''} ${importActionAttrs('conflict-mode')}>
-          <span><strong>${label}</strong><small>${desc}</small></span>
+      ${plan.conflicts.length ? `<div class="import-review-warning cycle-import-conflict-warning" role="alert"><strong>${escapeHTML(conflictSummary(plan))}</strong><span>Choose how to handle the overlapping periods below.</span></div>` : ''}
+      ${parsed.warnings?.length ? `<div class="import-review-warning" role="alert">${parsed.warnings.map(escapeHTML).join('<br>')}</div>` : ''}
+      ${plan.conflicts.length ? `<div class="cycle-import-conflicts" role="radiogroup" aria-label="Cycle import conflict handling">
+        ${[['keep-existing', 'Keep existing', 'Import non-overlapping periods and leave conflicts unchanged.'],
+          ['replace-overlapping', 'Replace overlaps', 'Replace overlapping existing period entries with imported periods.']]
+          .map(([value, label, desc]) => `<label class="cycle-import-conflict-option">
+          <input type="radio" name="cycle-import-conflict" value="${value}" ${conflictMode === value ? 'checked' : ''} ${importActionAttrs('conflict-mode')}><span><strong>${label}</strong><small>${desc}</small></span>
         </label>`).join('')}
-      </div>
-      <div class="import-table-wrap cycle-import-table-wrap">
-        <table class="import-table import-review-table cycle-import-table">
-          <thead><tr><th>Start</th><th>End</th><th>Flow</th><th>Symptoms</th></tr></thead>
-          <tbody>${renderPeriodRows(plan.importedPeriods)}</tbody>
+      </div>` : ''}
+      <div class="cycle-import-table-heading"><strong>${plan.importedPeriods.length ? 'Periods found' : 'No periods found'}</strong><span>${plan.importedPeriods.length ? 'Check the dates and details before importing.' : 'Daily observations can still be saved on this device.'}</span></div>
+      ${plan.importedPeriods.length ? `<div class="import-table-wrap cycle-import-table-wrap">
+        <table class="import-table import-review-table cycle-import-table" aria-label="Periods detected in this import">
+          <thead><tr><th class="cycle-import-status-heading">Status</th><th>Start</th><th>End</th><th>Flow</th><th>Symptoms</th></tr></thead><tbody>${renderPeriodRows(plan.importedPeriods, conflictStarts, conflictMode)}</tbody>
         </table>
+      </div>` : ''}
+      ${plan.importedPeriods.length > 18 ? `<div class="cycle-import-more">Showing 18 of ${plan.importedPeriods.length} periods.</div>` : ''}
+      <div class="cycle-import-privacy-note">
+        <span class="cycle-import-privacy-icon" aria-hidden="true">&#128274;</span><span><strong>Daily details stay on this device.</strong><small>Period summaries can sync across devices when cross-device sync is enabled.</small></span>
       </div>
-      ${plan.importedPeriods.length > 18 ? `<div class="cycle-import-more">Showing 18 of ${plan.importedPeriods.length} derived periods.</div>` : ''}
     </div>
     <div class="import-review-actions">
-      <button type="button" class="dashboard-action-btn" ${importActionAttrs('close')}>Cancel</button>
-      <button type="button" class="dashboard-action-btn dashboard-action-btn-primary" ${importActionAttrs('confirm')}>Import cycle data</button>
+      <button type="button" class="import-btn import-btn-secondary" ${importActionAttrs('close')}>Cancel</button>
+      <button type="button" class="import-btn import-btn-primary" ${importActionAttrs('confirm')}>${confirmLabel}</button>
     </div>`;
 }
 

--- a/tests/cycle-import-phase1.test.js
+++ b/tests/cycle-import-phase1.test.js
@@ -356,7 +356,7 @@ describe('cycle import phase 1 primitives', () => {
     const parsed = parseNaturalCyclesCsv(NATURAL_CYCLES_CSV, 'tracking_data.csv');
     expect(parsed).toMatchObject({ source: 'natural_cycles', sourceLabel: 'Natural Cycles' });
     expect(parsed.observations).toHaveLength(5);
-    expect(parsed.warnings.join(' ')).toContain('synthetic fixtures');
+    expect(parsed.warnings).toEqual([]);
     expect(parsed.observations[0]).toMatchObject({
       bbtC: 36.4,
       bleeding: { flow: 'light', excluded: false },
@@ -387,7 +387,7 @@ describe('cycle import phase 1 primitives', () => {
 
     expect(parsed).toMatchObject({ source: 'clue', sourceLabel: 'Clue' });
     expect(parsed.observations).toHaveLength(5);
-    expect(parsed.warnings.join(' ')).toContain('synthetic fixtures');
+    expect(parsed.warnings).toEqual([]);
     expect(parsed.observations[0]).toMatchObject({
       bbtC: 36.41,
       bleeding: { flow: 'light', excluded: false },
@@ -404,6 +404,18 @@ describe('cycle import phase 1 primitives', () => {
       ovulationTest: 'positive',
     });
     expect(parsed.periods.map(period => period.startDate)).toEqual(['2026-07-01', '2026-08-01']);
+  });
+
+  it('only warns when tracked observations do not produce a period', () => {
+    const parsed = parseClueCycleJson({
+      source: 'Clue',
+      data: [{ day: '2026-09-01', temperature: 36.5, pain: ['cramps'] }],
+    }, 'ClueBackup.json');
+
+    expect(parsed.periods).toEqual([]);
+    expect(parsed.warnings).toEqual([
+      'Clue includes tracked cycle observations, but no periods were detected.',
+    ]);
   });
 
   it('keeps menstrual flow when Clue or Natural Cycles also marks spotting that day', () => {

--- a/tests/playwright/cycle-import-browser-coverage.spec.js
+++ b/tests/playwright/cycle-import-browser-coverage.spec.js
@@ -65,10 +65,16 @@ test('Drip CSV import previews, commits, and opens cycle history', async ({ page
 
   const preview = page.locator('#import-modal-overlay');
   await expect(preview).toHaveClass(/show/);
-  await expect(page.locator('#import-modal')).toContainText('Drip');
+  await expect(page.locator('#import-modal .gb-modal-title')).toHaveText('Review cycle import');
+  await expect(page.locator('#import-modal .gb-modal-kicker')).toContainText('Drip');
   await expect(page.locator('#import-modal')).toContainText('4 daily observations');
-  await expect(page.locator('#import-modal')).toContainText('2 derived periods');
-  await expect(page.locator('#import-modal')).toContainText('Daily observations stay on this device');
+  await expect(page.locator('#import-modal')).toContainText('2 periods found');
+  await expect(page.locator('#import-modal')).toContainText('Daily details stay on this device');
+  await expect(page.locator('#import-modal')).not.toContainText('No overlapping period entries found');
+  await expect(page.locator('#import-modal .import-review-warning')).toHaveCount(0);
+  await expect(page.locator('#import-modal .cycle-import-conflicts')).toHaveCount(0);
+  await expect(page.locator('#import-modal .cycle-import-row-status-ready')).toHaveCount(2);
+  await expect(page.locator('[data-cycle-import-action="confirm"]')).toHaveText('Import 2 periods');
   await expect(page.locator('#import-modal tbody tr')).toHaveCount(2);
   await page.screenshot({ path: testInfo.outputPath('cycle-import-preview-desktop.png') });
 
@@ -140,7 +146,8 @@ test('Natural Cycles ZIP import reaches the cycle preview through the file input
   await expect(preview).toHaveClass(/show/);
   await expect(page.locator('#import-modal')).toContainText('Natural Cycles');
   await expect(page.locator('#import-modal')).toContainText('5 daily observations');
-  await expect(page.locator('#import-modal')).toContainText('2 derived periods');
+  await expect(page.locator('#import-modal')).toContainText('2 periods found');
+  await expect(page.locator('#import-modal .import-review-warning')).toHaveCount(0);
   await page.locator('#import-modal .modal-close').click();
   await expect(preview).not.toHaveClass(/show/);
   await page.evaluate(async id => (await import('/js/cycle-store.js')).deleteCycleDB(id), profileId);
@@ -160,7 +167,9 @@ test('Clue JSON import is classified as cycle data and reaches the preview', asy
   await expect(preview).toHaveClass(/show/);
   await expect(page.locator('#import-modal')).toContainText('Clue');
   await expect(page.locator('#import-modal')).toContainText('5 daily observations');
-  await expect(page.locator('#import-modal')).toContainText('2 derived periods');
+  await expect(page.locator('#import-modal')).toContainText('2 periods found');
+  await expect(page.locator('#import-modal')).not.toContainText('synthetic fixtures');
+  await expect(page.locator('#import-modal .import-review-warning')).toHaveCount(0);
   await page.locator('#import-modal .modal-close').click();
   await expect(preview).not.toHaveClass(/show/);
   await page.evaluate(async id => (await import('/js/cycle-store.js')).deleteCycleDB(id), profileId);
@@ -317,4 +326,39 @@ test('cycle import preview stays within a mobile viewport', async ({ page }, tes
   await page.screenshot({ path: testInfo.outputPath('cycle-import-preview-mobile.png') });
   await page.locator('#import-modal .modal-close').click();
   await expect(overlay).not.toHaveClass(/show/);
+});
+
+test('cycle import only shows conflict controls and row warnings for real overlaps', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  const profileId = await initializeCycleProfile(page, 'cycle_import_conflicts');
+
+  await page.evaluate((csv) => {
+    import('/js/cycle-import.js').then(cycleImport => {
+      window._labState.importedData.menstrualCycle = {
+        periods: [{
+          startDate: '2026-04-01',
+          endDate: '2026-04-04',
+          flow: 'moderate',
+          source: 'manual',
+        }],
+      };
+      const parsed = cycleImport.parseDripCycleCsv(csv, 'drip-conflicts.csv');
+      void cycleImport.showCycleImportPreview(parsed);
+    });
+  }, DRIP_CSV);
+
+  const modal = page.locator('#import-modal');
+  await expect(page.locator('#import-modal-overlay')).toHaveClass(/show/);
+  await expect(modal.locator('.import-review-warning')).toContainText('1 imported period overlaps existing entries');
+  await expect(modal.locator('.cycle-import-conflicts')).toBeVisible();
+  await expect(modal.locator('.cycle-import-row-status-conflict')).toHaveText('Overlap · skip');
+  await expect(modal.locator('.cycle-import-row-status-ready')).toHaveCount(1);
+  await expect(modal.locator('[data-cycle-import-action="confirm"]')).toHaveText('Import 1 period');
+
+  await modal.locator('input[value="replace-overlapping"]').check();
+  await expect(modal.locator('.cycle-import-row-status-conflict')).toHaveText('Overlap · replace');
+  await expect(modal.locator('[data-cycle-import-action="confirm"]')).toHaveText('Import 2 periods');
+
+  await modal.locator('.modal-close').click();
+  await page.evaluate(async id => (await import('/js/cycle-store.js')).deleteCycleDB(id), profileId);
 });

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -105,9 +105,9 @@ assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMat
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
 assert('latest changelog documents cycle import sources and local-data boundaries',
-  /version:\s*'1\.10\.156'[\s\S]{0,1200}Apple Health, Drip, Natural Cycles[\s\S]{0,600}extracted Clue JSON/.test(changelogSrc)
-  && /version:\s*'1\.10\.156'[\s\S]{0,1600}Detailed observations stay local/.test(changelogSrc)
-  && /version:\s*'1\.10\.156'[\s\S]{0,1600}Remove one batch, one source, or all cycle data/.test(changelogSrc));
+  /version:\s*'1\.10\.157'[\s\S]{0,1200}Apple Health, Drip, Natural Cycles[\s\S]{0,600}extracted Clue JSON/.test(changelogSrc)
+  && /version:\s*'1\.10\.157'[\s\S]{0,1600}Detailed observations stay local/.test(changelogSrc)
+  && /version:\s*'1\.10\.157'[\s\S]{0,1600}Remove one batch, one source, or all cycle data/.test(changelogSrc));
 assert('latest changelog documents granular Context management in user-readable terms',
   /version:\s*'1\.10\.62'[\s\S]{0,1600}Control what AI uses as context/.test(changelogSrc)
     && /version:\s*'1\.10\.62'[\s\S]{0,1600}You can now choose what AI uses/.test(changelogSrc)

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.156';
+self.APP_VERSION = '1.10.157';


### PR DESCRIPTION
## What changed

- Reworks the cycle import preview around a task-oriented header, clearer summary counts, and period-first review hierarchy.
- Shows warning banners and conflict controls only when imported periods actually overlap existing entries.
- Adds row-level Ready, Overlap · skip, and Overlap · replace outcomes with a live import count.
- Moves local/sync behavior into a neutral privacy note and removes unconditional Clue/Natural Cycles fixture disclaimers.
- Aligns modal width, buttons, responsive stats, and mobile layout with the app's existing import design.
- Keeps actionable warnings when observations do not produce any detected periods.
- Bumps the app and cycle-import changelog version to `1.10.157` so production service-worker caches refresh and the release entry remains eligible to display.

## Why

The preview rendered successful zero-conflict status and standing adapter caveats as yellow warnings. This made normal imports look unhealthy, created warning fatigue, and pushed the dates users needed to review below non-actionable content—especially on mobile.

The previous cycle-import release entry also reused `1.10.156`, which meant users who had already seen that version might not receive the forced release note and production caches would not get a new version key for this follow-up.

## User impact

Normal imports now feel calm and predictable. Users see the periods first, only get conflict choices when those choices matter, and can identify exactly which rows will be skipped or replace existing data. Version `1.10.157` ensures the updated UI is picked up cleanly by the PWA.

## Validation

- `npm test` — 27 files / 348 tests passed
- Focused changelog/version contract — 85 assertions passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npx playwright test tests/playwright/cycle-import-browser-coverage.spec.js` — 8 desktop, mobile, and conflict-flow tests passed
- Desktop and mobile screenshots visually reviewed