### PR TITLE
Fix private AI streaming reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,28 @@ Slide-out panel with streaming. 2+custom personalities, stop/discuss buttons, co
 
 ### AI Provider System
 
-Six backends: PPQ, Routstr, OpenRouter, Venice, Local AI (Ollama/LM Studio/Jan), Custom. `callClaudeAPI(opts)` in `api.js` routes to the active provider while dedicated `api-*.js` provider modules own provider calls/account helpers. `hasAIProvider()` gates all AI features. Shared OpenAI-compatible request handling lives in `api-openai-compatible.js`; lower-level retries/timeouts live in `api-transport.js`. Venice E2EE uses ECDH + AES-256-GCM with per-chunk streaming decryption and a 30-minute TTL. PPQ and supporting Routstr nodes use Tinfoil remote attestation plus EHBP; Routstr Private TEE requests expose the bearer session and `X-Routstr-Model` routing/billing metadata to the proxy while encrypting the OpenAI-compatible body and enclave response. See `api.js`, `api-openai-compatible.js`, `api-transport.js`, `tinfoil-secure-fetch.js`, `provider-panels.js`, `provider-panel-renderers.js`, `cashu-wallet.js`.
+Six backends: PPQ, Routstr, OpenRouter, Venice, Local AI (Ollama/LM Studio/Jan), Custom. `callClaudeAPI(opts)` in `api.js` routes to the active provider while dedicated `api-*.js` provider modules own provider calls/account helpers. `hasAIProvider()` gates all AI features. Shared OpenAI-compatible request handling lives in `api-openai-compatible.js`; lower-level retries/timeouts live in `api-transport.js`. Venice Encrypted TEE Mode encrypts message content with ECDH + AES-256-GCM and decrypts per-chunk streaming output with a 30-minute session TTL; the surrounding request metadata remains visible, and current getbased integration performs binding checks rather than full attestation verification. PPQ and supporting Routstr nodes use Tinfoil remote attestation plus EHBP; Routstr Private TEE requests expose the bearer session and `X-Routstr-Model` routing/billing metadata to the proxy while encrypting the OpenAI-compatible body and enclave response. See `api.js`, `api-openai-compatible.js`, `api-transport.js`, `tinfoil-secure-fetch.js`, `provider-panels.js`, `provider-panel-renderers.js`, `cashu-wallet.js`.
+
+#### Venice Encrypted TEE Mode security boundary (updated 2026-07-12)
+
+The PPQ/Routstr attestation documentation was merged directly into `getbased-docs` `main` as commit `d6be95c`. Venice was deliberately excluded pending code and documentation fixes.
+
+Current implementation:
+
+- `js/api-venice.js` creates the vendored client with `createVeniceE2EE({ apiKey })`; it does not supply a `dcapVerifier`.
+- `vendor/venice-e2ee.js` parses hex or base64 Intel TDX quotes and checks the requested model, request nonce, signing-key binding, debug mode, and optional Venice server-verification fields. It reports parsed measurements and an explicit `binding`/`dcap`/`measured` verification level. Full DCAP quote/certificate/TCB verification still requires an injected verifier, so getbased does not currently perform it.
+- The client supports caller-supplied measurement allowlists, but getbased does not configure one because Venice has not published stable expected measurements.
+- Successful response content now fails closed unless it is encrypted; only empty or whitespace-only formatting chunks pass through.
+- Message `content` fields are encrypted, but the surrounding JSON, model, roles, token limit, streaming flags, API credential, timing, sizes, and network metadata remain visible to Venice. Documentation must say this explicitly instead of implying the entire request is opaque.
+- Response chunks carry a server ephemeral public key that is not independently bound to the attested model key by the current client protocol. Determine whether Venice provides a signature or other binding before claiming authenticated enclave-origin responses.
+
+Remaining repository scope:
+
+1. Add full browser-compatible DCAP and GPU-evidence validation only after its dependency, network, and supply-chain costs are accepted; configure a measurement allowlist only from an authenticated Venice publication.
+2. Implement response-signature verification when Venice documents the signed payload format and its binding to streaming E2EE output.
+3. Keep user and developer docs explicit about message-content encryption, metadata exposure, client-side binding checks, server-reported checks, full DCAP validation, measurement validation, and remaining trust assumptions.
+
+Full measurement verification and cryptographic response-origin binding may require Venice to publish expected measurements or extend its server protocol. Do not present Venice as equivalent to the PPQ/Routstr Tinfoil path unless those guarantees are actually implemented and verified client-side. Primary references: `https://docs.venice.ai/guides/features/tee-e2ee-models` and `https://github.com/elkimek/venice-e2ee`.
 
 ### AI Verdict Engine
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All normal tracking works without AI. AI features can use:
 | **PPQ** | Private TEE mode and regular hosted models, with in-app balance/top-up support. |
 | **Routstr** | Decentralized Bitcoin AI through Nostr-discovered nodes and the built-in Cashu wallet. |
 | **OpenRouter** | A broad hosted model marketplace with OAuth or manual key setup. |
-| **Venice AI** | Hosted models with optional browser-side E2EE mode. |
+| **Venice AI** | Hosted models with optional browser-side message encryption and limited client attestation checks. |
 | **Local AI** | Any OpenAI-compatible local server, such as Ollama, LM Studio, Jan, or llama.cpp. |
 | **Custom API** | Bring your own OpenAI-compatible endpoint or proxy. |
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -14,7 +14,7 @@ getbased is licensed under [AGPL-3.0-or-later](LICENSE). The vendored and runtim
 | `qrcode-generator.js` | [qrcode-generator](https://github.com/kazuhikoarase/qrcode-generator) (Kazuhiko Arase) | bundled | MIT | https://opensource.org/licenses/mit-license.php |
 | `bip39-minimal.js` | Custom (BIP-39 wordlist is public domain) | — | AGPL-3.0-or-later (this project) | [LICENSE](LICENSE) |
 | `chartjs-adapter-native.js` | Custom (in-house Chart.js date adapter) | — | AGPL-3.0-or-later (this project) | [LICENSE](LICENSE) |
-| `venice-e2ee.js` | Custom (uses [@noble/secp256k1](https://github.com/paulmillr/noble-secp256k1) MIT, [@noble/hashes](https://github.com/paulmillr/noble-hashes) MIT) | — | AGPL-3.0-or-later (this project); bundled noble libs MIT | https://github.com/paulmillr/noble-secp256k1/blob/main/LICENSE |
+| `venice-e2ee.js` | [venice-e2ee](https://github.com/elkimek/venice-e2ee) (bundles `@noble/secp256k1` and `@noble/hashes`) | 0.2.0 | GPL-3.0-only; bundled noble libraries MIT | https://github.com/elkimek/venice-e2ee/blob/main/LICENSE |
 | `ppq-private-tee.js`, `tinfoil-browser.js` | [Tinfoil JS](https://github.com/tinfoilsh/tinfoil-js) browser SecureClient bundle for PPQ and Routstr Private TEE modes | 1.1.7 | AGPL-3.0-or-later | https://github.com/tinfoilsh/tinfoil-js/blob/main/LICENSE |
 | `ehbp-browser.js` | [EHBP](https://github.com/tinfoilsh/encrypted-http-body-protocol) encrypted HTTP transport used by Tinfoil | 0.2.3 | MIT | https://github.com/tinfoilsh/encrypted-http-body-protocol/blob/main/LICENSE |
 | `evolu/evolu-bundle.js`, `evolu/Db.worker.js` | [Evolu](https://github.com/evoluhq/evolu) | bundled | MIT | https://github.com/evoluhq/evolu/blob/main/LICENSE |

--- a/js/api-openai-compatible.js
+++ b/js/api-openai-compatible.js
@@ -4,6 +4,7 @@
 import { isDebugMode } from './utils.js';
 import {
   FETCH_REQUEST_TIMEOUT_MS,
+  createInitialResponseTimeout,
   createProxyFetch,
   fetchWithRetry,
   readWithStallTimeout,
@@ -64,28 +65,19 @@ export async function fetchWithApiRetry(url, options, retries = 2, useProxy = tr
 
 async function fetchWithOptionalTimeout(fetchImpl, endpoint, requestInit, requestTimeoutMs) {
   const timeoutMs = Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0 ? requestTimeoutMs : FETCH_REQUEST_TIMEOUT_MS;
-  const timeoutSig = AbortSignal.timeout(timeoutMs);
-  let signal;
-  if (!requestInit.signal) {
-    signal = timeoutSig;
-  } else if (typeof AbortSignal.any === 'function') {
-    signal = AbortSignal.any([requestInit.signal, timeoutSig]);
-  } else {
-    const ctl = new AbortController();
-    const fwd = (sig) => sig.addEventListener('abort', () => ctl.abort(sig.reason), { once: true });
-    if (requestInit.signal.aborted) ctl.abort(requestInit.signal.reason);
-    else fwd(requestInit.signal);
-    if (timeoutSig.aborted) ctl.abort(timeoutSig.reason);
-    else fwd(timeoutSig);
-    signal = ctl.signal;
-  }
+  const requestState = createInitialResponseTimeout(requestInit, timeoutMs);
   try {
-    return await fetchImpl(endpoint, { ...requestInit, signal });
+    return await fetchImpl(endpoint, requestState.fetchOptions);
   } catch (e) {
     const callerAborted = requestInit.signal?.aborted;
     const isTimeout = e?.name === 'TimeoutError' || (e?.name === 'AbortError' && !callerAborted);
     if (isTimeout) throw new Error(`request timed out after ${Math.round(timeoutMs / 1000)}s - check your network`);
     throw e;
+  } finally {
+    // Private TEE fetch wrappers return a streaming decrypted Response. The
+    // initial-response timeout must stop once those headers arrive or it will
+    // abort a legitimate long PPQ/Routstr response body later.
+    requestState.clearRequestTimeout();
   }
 }
 
@@ -210,7 +202,13 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
       for (const line of lines) handleSSELine(line, true);
     }
     if (buffer.startsWith('data: ')) handleSSELine(buffer, false);
-    if (!fullText && reasoningBuf) fullText = reasoningBuf;
+    if (!fullText && reasoningBuf) {
+      fullText = reasoningBuf;
+      onStream(fullText);
+    }
+    if (!fullText.trim()) {
+      throw new Error(`${providerName} stream ended without response content. No usage was reported by the app; check the provider account before retrying.`);
+    }
     return { text: fullText, usage: { inputTokens, outputTokens }, finishReason, truncated: isTokenLimitFinish(finishReason) };
   }
 
@@ -220,6 +218,9 @@ export async function callOpenAICompatibleAPI(endpoint, key, model, providerName
   const msg = choice?.message;
   let text = msg?.content || '';
   if (!text && msg?.reasoning_content) text = msg.reasoning_content.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+  if (!String(text).trim()) {
+    throw new Error(`${providerName} returned no response content. No usage was reported by the app; check the provider account before retrying.`);
+  }
   const finishReason = choice?.finish_reason || choice?.native_finish_reason || null;
   return {
     text,

--- a/js/api-transport.js
+++ b/js/api-transport.js
@@ -50,9 +50,13 @@ export function createProxyFetch(shouldUseProxy) {
   };
 }
 
-function buildFetchOptions(options, requestTimeoutMs) {
+export function createInitialResponseTimeout(options, requestTimeoutMs) {
   const timeoutMs = Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0 ? requestTimeoutMs : FETCH_REQUEST_TIMEOUT_MS;
-  const timeoutSig = AbortSignal.timeout(timeoutMs);
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    timeoutController.abort(new DOMException('The operation timed out.', 'TimeoutError'));
+  }, timeoutMs);
+  const timeoutSig = timeoutController.signal;
   let signal;
   if (!options.signal) {
     signal = timeoutSig;
@@ -72,7 +76,10 @@ function buildFetchOptions(options, requestTimeoutMs) {
     else fwd(timeoutSig);
     signal = ctl.signal;
   }
-  return { ...options, signal };
+  return {
+    fetchOptions: { ...options, signal },
+    clearRequestTimeout() { clearTimeout(timeoutId); },
+  };
 }
 
 export async function fetchWithRetry(
@@ -90,8 +97,9 @@ export async function fetchWithRetry(
   const fetchFn = useProxy ? proxyFetch : directFetch;
   for (let i = 0; i <= retries; i++) {
     let res;
+    const requestState = createInitialResponseTimeout(options, requestTimeoutMs);
     try {
-      res = await fetchFn(url, buildFetchOptions(options, requestTimeoutMs));
+      res = await fetchFn(url, requestState.fetchOptions);
     } catch (e) {
       // User-initiated abort - surface immediately without retry.
       if (options.signal?.aborted) throw e;
@@ -112,6 +120,12 @@ export async function fetchWithRetry(
         throw new Error(`request timed out after ${Math.round(timeoutMs / 1000)}s — check your network`);
       }
       throw e;
+    } finally {
+      // The timeout protects only the wait for response headers. Leaving its
+      // signal armed after fetch() resolves aborts legitimate long streams.
+      // The caller's signal remains composed into fetchOptions.signal, so the
+      // Stop button can still cancel the response body at any time.
+      requestState.clearRequestTimeout();
     }
     if (res.status !== 429 || i === retries) return res;
     const retryAfter = parseInt(res.headers.get('retry-after') || '0', 10);

--- a/js/api-venice.js
+++ b/js/api-venice.js
@@ -23,6 +23,7 @@ import {
  *   _veniceE2EE?: any,
  *   _veniceE2EEKey?: string,
  *   _veniceAttestation?: any,
+ *   _veniceLastStreamDiagnostics?: any,
  *   clearE2EESession?: () => void
  * }} VeniceApiWindow */
 
@@ -98,7 +99,18 @@ export async function callVeniceAPI(opts) {
   }
 
   const useStream = !forceNonStream;
-  const body = { model: modelId, messages: apiMessages, max_tokens: maxTokens || 4096, stream: useStream };
+  const isGlmE2EE = /(?:^|-)glm(?:-|$)/i.test(modelId);
+  const body = /** @type {any} */ ({
+    model: modelId,
+    messages: apiMessages,
+    max_tokens: maxTokens || 4096,
+    stream: useStream,
+    venice_parameters: {
+      enable_e2ee: true,
+      ...(isGlmE2EE ? { disable_thinking: true, strip_thinking_response: true } : {}),
+    },
+    ...(isGlmE2EE ? { reasoning: { enabled: false } } : {}),
+  });
   if (useStream) body.stream_options = { include_usage: true };
   let res;
   try {
@@ -133,7 +145,8 @@ export async function callVeniceAPI(opts) {
     const data = await res.json();
     const usage = data.usage || {};
     const choice = data.choices?.[0];
-    const encryptedContent = choice?.message?.content || '';
+    const encryptedContent = choice?.message?.content || choice?.message?.reasoning_content || '';
+    if (!encryptedContent) throw new Error('Venice E2EE returned no encrypted response content.');
     const text = await decryptChunk(session.privateKey, encryptedContent);
     const finishReason = choice?.finish_reason || choice?.native_finish_reason || null;
     return {
@@ -148,31 +161,70 @@ export async function callVeniceAPI(opts) {
   const decoder = new TextDecoder();
   let buffer = '';
   let fullText = '';
+  let reasoningBuf = '';
+  let hasContent = false;
   let inputTokens = 0;
   let outputTokens = 0;
   let finishReason = null;
+  const streamDiagnostics = {
+    model: modelId,
+    eventCount: 0,
+    contentChunks: 0,
+    reasoningChunks: 0,
+    deltaFields: [],
+    finishReason: null,
+    usageSeen: false,
+    doneSeen: false,
+    status: 'reading',
+  };
+  const MAX_HIDDEN_REASONING_CHUNKS = 128;
+  apiWindow._veniceLastStreamDiagnostics = streamDiagnostics;
   const handleVeniceLine = async (line, boundary) => {
     if (!line.startsWith('data: ')) return;
     const data = line.slice(6);
-    if (data === '[DONE]') return;
+    if (data === '[DONE]') {
+      streamDiagnostics.doneSeen = true;
+      return;
+    }
     try {
       const event = JSON.parse(data);
+      streamDiagnostics.eventCount += 1;
       if (event.error) throw new Error(redactApiSecretText(event.error.message || JSON.stringify(event.error), [key]));
       const choice = event.choices?.[0];
       if (choice?.finish_reason) finishReason = choice.finish_reason;
       else if (choice?.native_finish_reason) finishReason = choice.native_finish_reason;
-      if (choice?.delta?.content) {
-        const chunk = await decryptChunk(session.privateKey, choice.delta.content);
+      streamDiagnostics.finishReason = finishReason;
+      const delta = choice?.delta || choice?.message;
+      if (delta && typeof delta === 'object') {
+        for (const field of Object.keys(delta)) {
+          if (!streamDiagnostics.deltaFields.includes(field)) streamDiagnostics.deltaFields.push(field);
+        }
+      }
+      if (delta?.content) {
+        streamDiagnostics.contentChunks += 1;
+        const chunk = await decryptChunk(session.privateKey, delta.content);
+        hasContent = true;
         fullText += chunk;
         if (onStream) onStream(fullText);
+      } else if (delta?.reasoning_content && !hasContent) {
+        streamDiagnostics.reasoningChunks += 1;
+        if (streamDiagnostics.reasoningChunks > MAX_HIDDEN_REASONING_CHUNKS) {
+          streamDiagnostics.status = 'cancelled-reasoning-only';
+          try { await reader.cancel(); } catch {}
+          throw new Error(`Venice E2EE produced more than ${MAX_HIDDEN_REASONING_CHUNKS} hidden reasoning chunks without an answer. The stream was cancelled to limit further charges; choose another E2EE model or retry after Venice resolves the GLM response.`);
+        }
+        const reasoningChunk = await decryptChunk(session.privateKey, delta.reasoning_content);
+        reasoningBuf += reasoningChunk;
       }
       if (event.usage) {
+        streamDiagnostics.usageSeen = true;
         inputTokens = event.usage.prompt_tokens || inputTokens;
         outputTokens = event.usage.completion_tokens || outputTokens;
       }
     } catch (e) {
       if (e.name === 'OperationError') throw new Error('E2EE decryption failed - session may be stale. Try sending again.');
       if (boundary && e instanceof SyntaxError) return;
+      if (streamDiagnostics.status === 'reading') streamDiagnostics.status = 'error';
       throw e;
     }
   };
@@ -185,5 +237,15 @@ export async function callVeniceAPI(opts) {
     for (const line of lines) await handleVeniceLine(line, true);
   }
   if (buffer.startsWith('data: ')) await handleVeniceLine(buffer, false);
+  if (!fullText && reasoningBuf) {
+    fullText = reasoningBuf;
+    if (onStream) onStream(fullText);
+  }
+  if (!fullText.trim()) {
+    streamDiagnostics.status = 'empty';
+    const fields = streamDiagnostics.deltaFields.length ? streamDiagnostics.deltaFields.join(', ') : 'none';
+    throw new Error(`Venice E2EE stream ended without encrypted response content (events: ${streamDiagnostics.eventCount}, fields: ${fields}, finish: ${finishReason || 'none'}, usage: ${streamDiagnostics.usageSeen ? 'yes' : 'no'}).`);
+  }
+  streamDiagnostics.status = 'complete';
   return { text: fullText, usage: { inputTokens, outputTokens }, finishReason, truncated: isTokenLimitFinish(finishReason) };
 }

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,16 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.177', date: '2026-07-12', title: 'More reliable private AI chats',
+    forceShow: true,
+    items: [
+      '<b>Long private replies can finish normally.</b> Once Venice, PPQ Private, or Routstr Private has connected, getbased no longer lets the startup timer cut off a reply that is still arriving.',
+      '<b>Reasoning-heavy models no longer leave an empty chat.</b> If a model produces no visible answer, getbased now shows a clear message instead of silently removing the thinking bubble.',
+      '<b>PPQ Private handles secure-server key changes.</b> When PPQ rotates its encryption key, getbased refreshes the security evidence and reconnects instead of repeatedly failing with a key mismatch.',
+      '<b>Venice privacy labels are more precise.</b> Message contents are encrypted between your browser and Venice\'s confidential-computing endpoint, but connection metadata remains visible and getbased does not fully verify the hardware quote or running code by default.',
+    ]
+  },
+  {
     version: '1.10.169', date: '2026-07-11', title: 'Private chats on Routstr',
     forceShow: true,
     items: [

--- a/js/chat-attestation.js
+++ b/js/chat-attestation.js
@@ -19,15 +19,23 @@ export function attestationTooltip(attestation) {
     ].filter(Boolean);
     return (ok ? 'TEE attestation verified' : 'TEE attestation FAILED') + '\n' + lines.join('\n');
   }
-  const ok = attestation.nonceVerified && attestation.signingKeyBound && !attestation.debugMode;
+  const bindingChecks = attestation.nonceVerified && attestation.signingKeyBound && !attestation.debugMode;
+  const failed = !bindingChecks || (Array.isArray(attestation.errors) && attestation.errors.length > 0);
+  const level = attestation.verificationLevel || (attestation.dcapVerified ? 'dcap' : 'binding');
   const lines = [
+    `Client verification level: ${level}`,
     `Nonce: ${attestation.nonceVerified ? '\u2713' : '\u2717'}`,
     `Key binding: ${attestation.signingKeyBound ? '\u2713' : '\u2717'}`,
     `Debug mode: ${attestation.debugMode ? 'YES \u2717' : 'no \u2713'}`,
-    attestation.serverTdxValid != null ? `Server TDX: ${attestation.serverTdxValid ? '\u2713' : '\u2717'}` : null,
-    attestation.dcap ? `DCAP: ${attestation.dcap.status}` : null,
+    attestation.serverVerified != null ? `Venice-reported verification: ${attestation.serverVerified ? '\u2713' : '\u2717'}` : null,
+    attestation.serverTdxValid != null ? `Venice-reported TDX: ${attestation.serverTdxValid ? '\u2713' : '\u2717'}` : null,
+    attestation.dcap
+      ? `Client DCAP: ${attestation.dcap.status || 'unknown'}${attestation.dcapVerified ? '' : ' (not accepted)'}`
+      : 'Client DCAP: not run',
+    attestation.measurementsVerified === true ? 'Approved measurements: matched' : 'Approved measurements: not validated',
+    'Response origin binding: not verified',
   ].filter(Boolean);
-  return (ok ? 'TEE attestation verified' : 'TEE attestation FAILED') + '\n' + lines.join('\n');
+  return (failed ? 'Venice E2EE checks FAILED' : 'Venice E2EE: limited verification') + '\n' + lines.join('\n');
 }
 
 function attestationTitle(attestation) {
@@ -36,20 +44,26 @@ function attestationTitle(attestation) {
 
 export function e2eeLockHTML(attestation) {
   if (!attestation) return ' \uD83D\uDD12';
-  const ok = attestation.securityVerified != null
-    ? !!attestation.securityVerified
-    : attestation.nonceVerified && attestation.signingKeyBound && !attestation.debugMode;
-  const color = ok ? '#22c55e' : '#ef4444';
-  const mark = ok ? '\u2713' : '\u2717';
+  const tinfoil = attestation.securityVerified != null;
+  const failed = tinfoil
+    ? !attestation.securityVerified
+    : !attestation.nonceVerified || !attestation.signingKeyBound || attestation.debugMode
+      || (Array.isArray(attestation.errors) && attestation.errors.length > 0);
+  const verified = tinfoil && !!attestation.securityVerified;
+  const color = failed ? '#ef4444' : verified ? '#22c55e' : '#f59e0b';
+  const mark = failed ? '\u2717' : verified ? '\u2713' : '~';
   return ` <span title="${attestationTitle(attestation)}">\uD83D\uDD12<span style="color:${color};font-weight:bold">${mark}</span></span>`;
 }
 
 export function e2eeLockFootnote(attestation) {
   if (!attestation) return ' \u00b7 \uD83D\uDD12 e2ee';
-  const ok = attestation.securityVerified != null
-    ? !!attestation.securityVerified
-    : attestation.nonceVerified && attestation.signingKeyBound && !attestation.debugMode;
-  const color = ok ? '#22c55e' : '#ef4444';
-  const mark = ok ? '\u2713' : '\u2717';
+  const tinfoil = attestation.securityVerified != null;
+  const failed = tinfoil
+    ? !attestation.securityVerified
+    : !attestation.nonceVerified || !attestation.signingKeyBound || attestation.debugMode
+      || (Array.isArray(attestation.errors) && attestation.errors.length > 0);
+  const verified = tinfoil && !!attestation.securityVerified;
+  const color = failed ? '#ef4444' : verified ? '#22c55e' : '#f59e0b';
+  const mark = failed ? '\u2717' : verified ? '\u2713' : '~';
   return ` \u00b7 <span title="${attestationTitle(attestation)}">\uD83D\uDD12<span style="color:${color};font-weight:bold">${mark}</span> e2ee</span>`;
 }

--- a/js/chat-prompt-context.js
+++ b/js/chat-prompt-context.js
@@ -11,6 +11,7 @@ export function buildPersonalityPrompt(personality, customPersonality) {
 export function buildMultiPersonaInstruction(chatHistory, currentPersonaName) {
   const otherPersonas = new Set();
   for (const message of chatHistory || []) {
+    if (message.error) continue;
     if (message.role === 'assistant' && message.personalityName && message.personalityName !== currentPersonaName) {
       otherPersonas.add(message.personalityName);
     }
@@ -21,7 +22,7 @@ export function buildMultiPersonaInstruction(chatHistory, currentPersonaName) {
 
 export function buildTaggedChatMessages(chatHistory, currentPersonaName, limit = 30) {
   return (chatHistory || [])
-    .filter((message) => !message.joined && message.role)
+    .filter((message) => !message.joined && !message.error && message.role)
     .slice(-limit)
     .map((message) => {
       if (message.role === 'assistant' && message.personalityName && message.personalityName !== currentPersonaName) {

--- a/js/chat-render.js
+++ b/js/chat-render.js
@@ -95,7 +95,10 @@ export function renderChatMessages() {
         imageBadge = `<div class="chat-image-badge">\uD83D\uDDBC ${msg.imageCount} image${msg.imageCount !== 1 ? 's' : ''} attached</div>`;
       }
     }
-    html += `<div class="chat-msg ${cls}${autoClass}" id="chat-msg-${i}">${imageBadge}${renderMarkdown(msg.content)}${stoppedNote}`;
+    const messageBody = msg.error
+      ? `<span style="color:var(--red)">${escapeHTML(msg.content)}</span>`
+      : renderMarkdown(msg.content);
+    html += `<div class="chat-msg ${cls}${autoClass}" id="chat-msg-${i}">${imageBadge}${messageBody}${stoppedNote}`;
     if (msg.role === 'assistant' && msg.truncated) html += responseLimitNote();
     if (msg.role === 'assistant') {
       if (msg.usage && (msg.usage.inputTokens || msg.usage.outputTokens)) {

--- a/js/chat-send.js
+++ b/js/chat-send.js
@@ -4,7 +4,7 @@
 import { state } from './state.js';
 import { CHAT_SYSTEM_PROMPT } from './constants.js';
 import { calculateCost, formatCost, trackUsage } from './schema.js';
-import { escapeHTML } from './utils.js';
+import { escapeHTML, showNotification } from './utils.js';
 import {
   getActiveModelDisplay, getActiveModelId, getAIProvider, hasAIProvider,
   isPpqPrivateModeActive, isRoutstrPrivateModeActive, isVeniceE2EEActive, supportsWebSearch,
@@ -444,8 +444,22 @@ export async function sendChatMessage() {
       // to avoid double-notifying the user.
       const errEl = document.createElement('div');
       errEl.className = 'chat-msg chat-ai';
-      errEl.innerHTML = `<span style="color:var(--red)">Error: ${escapeHTML(error.message)}</span>`;
+      const errorMessage = `Error: ${error.message || 'AI request failed'}`;
+      errEl.innerHTML = `<span style="color:var(--red)">${escapeHTML(errorMessage)}</span>`;
       container.appendChild(errEl);
+      const personality = getActivePersonality();
+      state.chatHistory.push({
+        role: 'assistant',
+        content: errorMessage,
+        error: true,
+        personalityName: personality.name,
+        personalityIcon: personality.icon,
+        provider: _msgProvider,
+        modelId: _msgModelId,
+        modelDisplay: _msgModelDisplay,
+      });
+      await saveChatHistory();
+      showNotification(errorMessage, 'error', 10000);
     }
   }
 

--- a/js/provider-panel-renderers.js
+++ b/js/provider-panel-renderers.js
@@ -252,14 +252,14 @@ function renderVeniceProviderPanel() {
     </div>
     ${hasE2EEModels ? `<div style="margin-top:12px;display:flex;align-items:center;gap:8px">
       <label class="toggle-switch" style="flex-shrink:0"><input type="checkbox" id="venice-e2ee-toggle" ${getVeniceE2EE() ? 'checked' : ''} data-provider-panel-change="venice-e2ee"><span class="toggle-slider"></span></label>
-      <span style="font-size:13px">End-to-End Encryption</span>
+      <span style="font-size:13px">Encrypted TEE Mode</span>
     </div>
-    <div id="venice-e2ee-indicator" style="margin-top:6px;font-size:12px;${isVeniceE2EEActive() ? '' : 'display:none'}"><span style="color:var(--green)">&#128274;</span> Prompts encrypted in your browser, decrypted only inside a verified TEE. Web search and image attachments are disabled.</div>` : ''}`;
+    <div id="venice-e2ee-indicator" style="margin-top:6px;font-size:12px;${isVeniceE2EEActive() ? '' : 'display:none'}"><span style="color:var(--orange)">&#128274;~</span> Message content is encrypted in your browser. getbased checks quote freshness, key binding, and debug mode, but does not currently validate the full DCAP chain, GPU evidence, approved code measurements, or response signatures. Venice still sees your API key, model, roles, request settings, timing, sizes, and network metadata. Web search and images are disabled.</div>` : ''}`;
   } else {
     veniceModelHtml = `<div style="margin-top:12px;font-size:12px;color:var(--text-muted)" id="venice-model-area">Model: <span style="color:var(--text-primary)">${escapeHTML(getVeniceModelDisplay())}</span>${currentKey ? ' <span style="font-size:11px">(save key to load models)</span>' : ''}</div>`;
   }
   return `<div class="ai-provider-panel">
-    <div class="ai-provider-desc">Privacy-focused cloud AI. Uncensored models, no data stored. Requires API key.</div>
+    <div class="ai-provider-desc">Hosted Venice models with an optional encrypted-message mode. Requires an API key.</div>
     <div class="api-key-status" id="venice-key-status">
       ${currentKey ? '<span style="color:var(--green)">&#10003; Connected</span>' : '<span style="color:var(--text-muted)">No key set</span>'}
     </div>
@@ -270,7 +270,7 @@ function renderVeniceProviderPanel() {
     </div>
     ${currentKey ? '<div style="margin-top:8px;font-size:12px;color:var(--text-muted)"><span id="venice-balance">Balance: loading...</span> <a href="#" data-provider-panel-action="refresh-venice-balance" style="color:var(--accent);font-size:11px;text-decoration:none">\u21bb</a></div>' : ''}
     ${veniceModelHtml}
-    <div class="api-key-notice">Your key is stored locally and sent directly to Venice AI. No data is stored on their servers. <a href="https://venice.ai/chat?ref=lZ4P1b" target="_blank" rel="noopener" style="color:var(--accent)">Get an API key</a></div>
+    <div class="api-key-notice">Your key is stored locally and sent directly to Venice AI. Requests are handled under Venice's privacy and retention policies; getbased does not independently verify provider-side logging. <a href="https://venice.ai/chat?ref=lZ4P1b" target="_blank" rel="noopener" style="color:var(--accent)">Get an API key</a></div>
   </div>`;
 }
 

--- a/js/tinfoil-secure-fetch.js
+++ b/js/tinfoil-secure-fetch.js
@@ -39,6 +39,24 @@ function optionsCacheKey(options) {
   return JSON.stringify(resolveOptions(options));
 }
 
+/**
+ * Force the browser HTTP cache to refresh a custom attestation bundle before
+ * re-attesting after an enclave key rotation. SecureClient verifies the bundle
+ * again itself; this preflight only prevents its subsequent fetch from reusing
+ * the stale response that caused the key-config mismatch.
+ * @param {TinfoilSecureOptions} options
+ */
+async function refreshAttestationBundleCache(options) {
+  if (!options.attestationBundleURL) return;
+  const attestationURL = `${normalizeBaseUrl(options.attestationBundleURL)}/attestation`;
+  const response = await fetch(attestationURL, { cache: 'reload' });
+  if (!response.ok) {
+    throw new Error(`Failed to refresh Tinfoil attestation bundle: HTTP ${response.status}`);
+  }
+  // Fully consume the response so the browser can commit the refreshed entry.
+  await response.arrayBuffer();
+}
+
 /** @param {TinfoilSecureOptions} options */
 async function prepareTinfoilClient(options) {
   const resolved = resolveOptions(options);
@@ -165,6 +183,7 @@ export async function createTinfoilSecureFetch(options) {
         return await fetchEhbpOnce(context, options, normalized);
       } catch (error) {
         if (!(error instanceof KeyConfigMismatchError)) throw error;
+        await refreshAttestationBundleCache(options);
         context.client.reset();
         try {
           await context.client.ready();
@@ -176,7 +195,15 @@ export async function createTinfoilSecureFetch(options) {
           clientCache.delete(optionsCacheKey(options));
           throw reattestError;
         }
-        return fetchEhbpOnce(context, options, normalized);
+        try {
+          return await fetchEhbpOnce(context, options, normalized);
+        } catch (retryError) {
+          if (retryError instanceof KeyConfigMismatchError) {
+            clientCache.delete(optionsCacheKey(options));
+            context.client.reset();
+          }
+          throw retryError;
+        }
       }
     },
   };

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -395,6 +395,91 @@ describe('AI provider request contracts', () => {
     });
   });
 
+  it('returns encrypted Venice reasoning when a reasoning model emits no final content', async () => {
+    setAIProvider('venice');
+    updateKeyCache('labcharts-venice-key', 'sk-venice-reasoning');
+    setVeniceE2EE(true);
+    setVeniceModel('e2ee-glm-contract');
+    localStorage.setItem('labcharts-venice-models', '[]');
+    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify([{ id: 'e2ee-glm-contract' }]));
+    localStorage.setItem('labcharts-venice-models-fetched-at', String(Date.now()));
+    globalThis.fetch = vi.fn(async () => streamResponse([
+      'data: {"choices":[{"delta":{"reasoning_content":"encrypted-reasoning"}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":20,"completion_tokens":12}}\n\n',
+      'data: [DONE]\n\n',
+    ]));
+    const onStream = vi.fn();
+
+    await expect(callClaudeAPI({
+      messages: [{ role: 'user', content: 'reason carefully' }],
+      maxTokens: 64,
+      onStream,
+      requestTimeoutMs: 1000,
+    })).resolves.toEqual({
+      text: 'decrypted:encrypted-reasoning',
+      usage: { inputTokens: 20, outputTokens: 12 },
+      finishReason: 'stop',
+      truncated: false,
+    });
+    expect(onStream).toHaveBeenCalledWith('decrypted:encrypted-reasoning');
+    const request = providerRequestFromFetchCall();
+    expect(request.body).toMatchObject({
+      venice_parameters: {
+        enable_e2ee: true,
+        disable_thinking: true,
+        strip_thinking_response: true,
+      },
+      reasoning: { enabled: false },
+    });
+  });
+
+  it('reports an empty Venice E2EE stream instead of silently rendering a blank answer', async () => {
+    setAIProvider('venice');
+    updateKeyCache('labcharts-venice-key', 'sk-venice-empty');
+    setVeniceE2EE(true);
+    setVeniceModel('e2ee-empty-contract');
+    localStorage.setItem('labcharts-venice-models', '[]');
+    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify([{ id: 'e2ee-empty-contract' }]));
+    localStorage.setItem('labcharts-venice-models-fetched-at', String(Date.now()));
+    globalThis.fetch = vi.fn(async () => streamResponse([
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n',
+    ]));
+
+    await expect(callClaudeAPI({
+      messages: [{ role: 'user', content: 'empty response' }],
+      maxTokens: 64,
+      onStream: vi.fn(),
+      requestTimeoutMs: 1000,
+    })).rejects.toThrow('stream ended without encrypted response content');
+  });
+
+  it('cancels a runaway Venice reasoning-only stream', async () => {
+    setAIProvider('venice');
+    updateKeyCache('labcharts-venice-key', 'sk-venice-runaway');
+    setVeniceE2EE(true);
+    setVeniceModel('e2ee-glm-runaway');
+    localStorage.setItem('labcharts-venice-models', '[]');
+    localStorage.setItem('labcharts-venice-e2ee-models', JSON.stringify([{ id: 'e2ee-glm-runaway' }]));
+    localStorage.setItem('labcharts-venice-models-fetched-at', String(Date.now()));
+    const reasoningEvents = Array.from({ length: 129 }, (_, index) =>
+      `data: {"choices":[{"delta":{"reasoning_content":"encrypted-r${index}"}}]}\n\n`
+    );
+    globalThis.fetch = vi.fn(async () => streamResponse(reasoningEvents));
+
+    await expect(callClaudeAPI({
+      messages: [{ role: 'user', content: 'runaway reasoning' }],
+      maxTokens: 16384,
+      onStream: vi.fn(),
+      requestTimeoutMs: 1000,
+    })).rejects.toThrow('cancelled to limit further charges');
+    expect(globalThis._veniceLastStreamDiagnostics).toMatchObject({
+      contentChunks: 0,
+      reasoningChunks: 129,
+      status: 'cancelled-reasoning-only',
+    });
+  });
+
   it('routes advertised Routstr Tinfoil models through attested EHBP with a plaintext model hint', async () => {
     const secret = 'sk-routstr-private-contract';
     setAIProvider('routstr');
@@ -428,14 +513,14 @@ describe('AI provider request contracts', () => {
     updateKeyCache('labcharts-routstr-key', 'sk-routstr-reservation-contract');
     localStorage.setItem('labcharts-routstr-node', 'https://private-node.example');
     setRoutstrModel('tinfoil-glm-5-2');
-    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const options = baseChatOptions({ maxTokens: 16384 });
     delete options.requestTimeoutMs;
 
     await callClaudeAPI(options);
 
     expect(providerRequestFromFetchCall().body).toMatchObject({ max_tokens: 4096 });
-    expect(timeoutSpy).toHaveBeenCalledWith(180000);
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 180000);
     timeoutSpy.mockRestore();
   });
 

--- a/tests/api-transport.test.js
+++ b/tests/api-transport.test.js
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { callOpenAICompatibleAPI } from '../js/api-openai-compatible.js';
+import { fetchWithRetry } from '../js/api-transport.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('fetchWithRetry request timeout lifecycle', () => {
+  it('clears the initial-response timeout after headers arrive', async () => {
+    vi.useFakeTimers();
+    let capturedSignal;
+    const response = await fetchWithRetry(
+      'https://api.example.test/stream',
+      { method: 'POST', headers: {} },
+      {
+        retries: 0,
+        requestTimeoutMs: 1000,
+        useProxy: false,
+        directFetch: async (_url, options) => {
+          capturedSignal = options.signal;
+          return new Response('stream body', { status: 200 });
+        },
+        debug: () => false,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedSignal.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(capturedSignal.aborted).toBe(false);
+  });
+
+  it('keeps the caller stop signal active after headers arrive', async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    let capturedSignal;
+    await fetchWithRetry(
+      'https://api.example.test/stream',
+      { method: 'POST', headers: {}, signal: caller.signal },
+      {
+        retries: 0,
+        requestTimeoutMs: 1000,
+        useProxy: false,
+        directFetch: async (_url, options) => {
+          capturedSignal = options.signal;
+          return new Response('stream body', { status: 200 });
+        },
+        debug: () => false,
+      },
+    );
+
+    caller.abort(new DOMException('Stopped', 'AbortError'));
+    expect(capturedSignal.aborted).toBe(true);
+  });
+
+  it('still rejects when response headers exceed the timeout', async () => {
+    vi.useFakeTimers();
+    const pending = fetchWithRetry(
+      'https://api.example.test/slow-headers',
+      { method: 'POST', headers: {} },
+      {
+        retries: 0,
+        requestTimeoutMs: 1000,
+        useProxy: false,
+        directFetch: async (_url, options) => new Promise((_resolve, reject) => {
+          options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
+        }),
+        debug: () => false,
+      },
+    );
+
+    const rejection = expect(pending).rejects.toThrow('request timed out after 1s');
+    await vi.advanceTimersByTimeAsync(1001);
+    await rejection;
+  });
+});
+
+describe('custom secure fetch request timeout lifecycle', () => {
+  it('does not abort a PPQ/Routstr-style decrypted stream after headers arrive', async () => {
+    vi.useFakeTimers();
+    const encoder = new TextEncoder();
+    let capturedSignal;
+    const secureFetch = vi.fn(async (_url, options) => {
+      capturedSignal = options.signal;
+      return new Response(new ReadableStream({
+        start(controller) {
+          const responseTimer = setTimeout(() => {
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"secure stream ok"},"finish_reason":"stop"}]}\n\n'));
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+            controller.close();
+          }, 1500);
+          options.signal.addEventListener('abort', () => {
+            clearTimeout(responseTimer);
+            controller.error(options.signal.reason);
+          }, { once: true });
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    });
+
+    const pending = callOpenAICompatibleAPI(
+      'https://private.example.test/v1/chat/completions',
+      'sk-private-test',
+      'glm-5-2',
+      'Private TEE',
+      {
+        messages: [{ role: 'user', content: 'long private request' }],
+        maxTokens: 32,
+        onStream: vi.fn(),
+        requestTimeoutMs: 1000,
+      },
+      {},
+      { useProxy: false, fetchImpl: secureFetch },
+    );
+
+    await vi.advanceTimersByTimeAsync(1600);
+    await expect(pending).resolves.toMatchObject({
+      text: 'secure stream ok',
+      finishReason: 'stop',
+    });
+    expect(capturedSignal.aborted).toBe(false);
+  });
+
+  it('still times out a secure fetch that has not returned response headers', async () => {
+    vi.useFakeTimers();
+    const secureFetch = vi.fn(async (_url, options) => new Promise((_resolve, reject) => {
+      options.signal.addEventListener('abort', () => reject(options.signal.reason), { once: true });
+    }));
+    const pending = callOpenAICompatibleAPI(
+      'https://private.example.test/v1/chat/completions',
+      'sk-private-test',
+      'glm-5-2',
+      'Private TEE',
+      {
+        messages: [{ role: 'user', content: 'slow headers' }],
+        maxTokens: 32,
+        forceNonStream: true,
+        requestTimeoutMs: 1000,
+      },
+      {},
+      { useProxy: false, fetchImpl: secureFetch },
+    );
+
+    const rejection = expect(pending).rejects.toThrow('request timed out after 1s');
+    await vi.advanceTimersByTimeAsync(1001);
+    await rejection;
+  });
+
+  it('surfaces reasoning-only secure responses when the stream ends', async () => {
+    const onStream = vi.fn();
+    const secureFetch = vi.fn(async () => new Response(
+      'data: {"choices":[{"delta":{"reasoning_content":"reasoning fallback"}}]}\n\n'
+      + 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+      + 'data: [DONE]\n\n',
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    ));
+
+    await expect(callOpenAICompatibleAPI(
+      'https://private.example.test/v1/chat/completions',
+      'sk-private-test',
+      'glm-5-2',
+      'Private TEE',
+      {
+        messages: [{ role: 'user', content: 'reason only' }],
+        maxTokens: 32,
+        onStream,
+        requestTimeoutMs: 1000,
+      },
+      {},
+      { useProxy: false, fetchImpl: secureFetch },
+    )).resolves.toMatchObject({ text: 'reasoning fallback', finishReason: 'stop' });
+    expect(onStream).toHaveBeenCalledWith('reasoning fallback');
+  });
+
+  it('reports an empty secure stream instead of accepting a blank answer', async () => {
+    const secureFetch = vi.fn(async () => new Response(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+      + 'data: [DONE]\n\n',
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    ));
+
+    await expect(callOpenAICompatibleAPI(
+      'https://private.example.test/v1/chat/completions',
+      'sk-private-test',
+      'glm-5-2',
+      'Private TEE',
+      {
+        messages: [{ role: 'user', content: 'empty result' }],
+        maxTokens: 32,
+        onStream: vi.fn(),
+        requestTimeoutMs: 1000,
+      },
+      {},
+      { useProxy: false, fetchImpl: secureFetch },
+    )).rejects.toThrow('stream ended without response content');
+  });
+});

--- a/tests/playwright/chat-discussion-browser-coverage.spec.js
+++ b/tests/playwright/chat-discussion-browser-coverage.spec.js
@@ -160,9 +160,10 @@ test('chat prompt context attestation and discussion prompt helpers cover browse
     };
     outcomes.attestationMarkupReflectsState =
       attestation.attestationTooltip(null).includes('no data')
-      && attestation.attestationTooltip(okAttestation).includes('verified')
+      && attestation.attestationTooltip(okAttestation).includes('limited verification')
       && attestation.attestationTooltip(failedAttestation).includes('FAILED')
-      && attestation.e2eeLockHTML(okAttestation).includes('#22c55e')
+      && attestation.e2eeLockHTML(okAttestation).includes('#f59e0b')
+      && attestation.e2eeLockHTML(okAttestation).includes('~')
       && attestation.e2eeLockHTML(okAttestation).includes('&lt;quoted&gt;')
       && attestation.e2eeLockHTML(failedAttestation).includes('#ef4444')
       && attestation.e2eeLockFootnote(okAttestation).includes('e2ee');

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -855,7 +855,7 @@ Discussion focus:
       try {
         await report.generateReportAISummary({ dateRange: 'all' });
       } catch (err) {
-        emptyResponseThrows = String(err?.message || err).includes('AI returned an empty summary');
+        emptyResponseThrows = String(err?.message || err).includes('returned no response content');
       }
       outcomes.emptySummaryResponseThrows = emptyResponseThrows;
     } finally {

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -104,6 +104,13 @@ assert('version.js sets APP_VERSION', versionMatch !== null, versionMatch ? `'${
 assert('APP_VERSION is semver', versionMatch && /^\d+\.\d+\.\d+/.test(versionMatch[1]), versionMatch ? versionMatch[1] : '');
 const latestChangelogVersion = changelogSrc.match(/version:\s*'([^']+)'/)?.[1] || '';
 assert('APP_VERSION is at least latest changelog entry', appVersion && latestChangelogVersion && semverGte(appVersion, latestChangelogVersion), `${appVersion} < ${latestChangelogVersion}`);
+assert('latest changelog explains private AI reliability and Venice limits in user-readable terms',
+  /version:\s*'1\.10\.177'[\s\S]{0,1800}Long private replies can finish normally/.test(changelogSrc)
+    && /version:\s*'1\.10\.177'[\s\S]{0,1800}Reasoning-heavy models no longer leave an empty chat/.test(changelogSrc)
+    && /version:\s*'1\.10\.177'[\s\S]{0,1800}PPQ Private handles secure-server key changes/.test(changelogSrc)
+    && /version:\s*'1\.10\.177'[\s\S]{0,2200}connection metadata remains visible/.test(changelogSrc)
+    && /version:\s*'1\.10\.177'[\s\S]{0,2200}does not fully verify the hardware quote or running code by default/.test(changelogSrc)
+    && /version:\s*'1\.10\.177'[\s\S]{0,500}forceShow:\s*true/.test(changelogSrc));
 assert('latest changelog documents cycle import sources and local-data boundaries',
   /version:\s*'1\.10\.157'[\s\S]{0,1200}Apple Health, Drip, Natural Cycles[\s\S]{0,600}extracted Clue JSON/.test(changelogSrc)
   && /version:\s*'1\.10\.157'[\s\S]{0,1600}Detailed observations stay local/.test(changelogSrc)

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -636,11 +636,13 @@ assert('chat-onboarding uses configured deps instead of direct window callback l
 console.log('Section 17a: Chat prompt-context helpers');
 const taggedMessages = buildTaggedChatMessages([
   { joined: true, joinName: 'Analyst' },
+  { role: 'assistant', personalityName: 'Analyst', content: 'Error: provider failed', error: true },
   { role: 'user', content: 'Review this' },
   { role: 'assistant', personalityName: 'Analyst', content: 'First opinion' },
   { role: 'assistant', personalityName: 'House', content: 'Current opinion' },
 ], 'House');
 assert('prompt context skips joined messages', taggedMessages.length === 3, JSON.stringify(taggedMessages));
+assert('prompt context skips persisted error messages', !taggedMessages.some(message => message.content.includes('provider failed')), JSON.stringify(taggedMessages));
 assert('prompt context tags other assistant personas', taggedMessages[1]?.content.startsWith('[Response from Analyst]'), taggedMessages[1]?.content);
 assert('prompt context leaves current persona untagged', taggedMessages[2]?.content === 'Current opinion', taggedMessages[2]?.content);
 const multiPersonaInstruction = buildMultiPersonaInstruction([

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -296,8 +296,9 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
     ].join('\n');
     assert('api-transport.js: readWithStallTimeout exists',
       /function readWithStallTimeout/.test(apiTransportSrc));
-    assert('api-transport.js: fetchWithRetry composes AbortSignal.timeout + caller signal',
-      /AbortSignal\.timeout\(timeoutMs\)/.test(apiTransportSrc)
+    assert('api-transport.js: fetchWithRetry composes a clearable header timeout + caller signal',
+      /timeoutController/.test(apiTransportSrc)
+      && /clearRequestTimeout/.test(apiTransportSrc)
       && /AbortSignal\.any/.test(apiTransportSrc));
     // Polyfill path: when AbortSignal.any is unavailable, manual
     // AbortController forwards both signals. Without this older

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -42,6 +42,10 @@ assert('Venice E2EE supports forced non-stream retry path',
   && /stream:\s*useStream/.test(apiVeniceSrc)
   && /if\s*\(!useStream\)/.test(apiVeniceSrc)
   && /decryptChunk\(session\.privateKey,\s*encryptedContent\)/.test(apiVeniceSrc));
+assert('Venice GLM E2EE disables hidden reasoning and caps reasoning-only streams',
+  apiVeniceSrc.includes('disable_thinking: true')
+    && apiVeniceSrc.includes('reasoning: { enabled: false }')
+    && apiVeniceSrc.includes('MAX_HIDDEN_REASONING_CHUNKS'));
 
 // 2. api.js module exports
 assert('api.isE2EEModel is function', typeof api.isE2EEModel === 'function');
@@ -120,13 +124,17 @@ try {
   assert('crypto operations threw no error', false, e.message);
 }
 
-// 11. decryptChunk passthrough for non-hex content
-const pt1 = await e2eeMod.decryptChunk(keypair.privateKey, 'hello');
-assert('short non-hex passes through', pt1 === 'hello');
+// 11. decryptChunk fails closed for non-encrypted model output
+let plaintextError = '';
+try { await e2eeMod.decryptChunk(keypair.privateKey, 'hello'); } catch (e) { plaintextError = e.message; }
+assert('short non-hex response fails closed', plaintextError.includes('unencrypted content'), plaintextError);
 const pt2 = await e2eeMod.decryptChunk(keypair.privateKey, '');
 assert('empty string passes through', pt2 === '');
-const pt3 = await e2eeMod.decryptChunk(keypair.privateKey, null);
-assert('null passes through', pt3 === null);
+const pt3 = await e2eeMod.decryptChunk(keypair.privateKey, ' \n');
+assert('whitespace-only response passes through', pt3 === ' \n');
+let nullError = '';
+try { await e2eeMod.decryptChunk(keypair.privateKey, null); } catch (e) { nullError = e.message; }
+assert('non-string response fails closed', nullError.includes('must be a string'), nullError);
 
 // 12. createVeniceE2EE factory
 const instance = e2eeMod.createVeniceE2EE({ apiKey: 'test-key', verifyAttestation: false });
@@ -377,6 +385,29 @@ const chatAttestationSrc = read('js/chat-attestation.js');
 assert('chat send uses isVeniceE2EEActive', chatSendSrc.includes('isVeniceE2EEActive'));
 assert('chat send imports E2EE attestation helpers', chatSendSrc.includes("from './chat-attestation.js'"));
 assert('chat attestation shows lock emoji for E2EE', chatAttestationSrc.includes('\\uD83D\\uDD12'));
+const limitedVenice = {
+  verificationLevel: 'binding',
+  nonceVerified: true,
+  signingKeyBound: true,
+  debugMode: false,
+  dcapVerified: false,
+  measurementsVerified: null,
+  errors: []
+};
+const limitedTooltip = chatAttestationMod.attestationTooltip(limitedVenice);
+const limitedLock = chatAttestationMod.e2eeLockHTML(limitedVenice);
+assert('Venice tooltip distinguishes binding checks from full verification',
+  limitedTooltip.includes('limited verification')
+    && limitedTooltip.includes('Client DCAP: not run')
+    && limitedTooltip.includes('Response origin binding: not verified'),
+  limitedTooltip);
+assert('Venice binding-only lock is amber and not verified',
+  limitedLock.includes('#f59e0b') && limitedLock.includes('~') && !limitedLock.includes('#22c55e'),
+  limitedLock);
+assert('Venice provider copy names limited checks and visible metadata',
+  providerRenderSrc.includes('does not currently validate the full DCAP chain')
+    && providerRenderSrc.includes('Venice still sees your API key')
+    && providerRenderSrc.includes('does not independently verify provider-side logging'));
 assert('chat exports refreshWebSearchToggle', chatSrc.includes('refreshWebSearchToggle'));
 
 console.log(results.join('\n'));

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -395,16 +395,19 @@ return (async function() {
   // line's dataIndex=0. The value was today's manual value, but the tooltip
   // title showed the vendor row's older date.
   console.log('%c E. Manual Overlay Tooltip Date ', 'font-weight:bold;color:#f59e0b');
+  const vendorDay3 = reg.daysAgoIso(3);
+  const vendorDay2 = reg.daysAgoIso(2);
+  const vendorDay1 = reg.daysAgoIso(1);
   window._labState.importedData.wearableSummary = {
     sources: {
-      oura: { connectedSince: '2026-04-10', lastSyncAt: Date.now(), coverageDays: 3 },
+      oura: { connectedSince: vendorDay3, lastSyncAt: Date.now(), coverageDays: 3 },
       manual: { connectedSince: todayISO, lastSyncAt: Date.now(), coverageDays: 1 },
     },
     metrics: {
       rhr: {
         primarySource: 'oura',
         latest: 61,
-        latestDate: '2026-04-12',
+        latestDate: vendorDay1,
         baseline: 60,
         baselineP25: 58,
         baselineP75: 62,
@@ -415,9 +418,9 @@ return (async function() {
     },
   };
   await store.upsertDailyBatch(TEST_PROFILE, [
-    { source: 'oura', date: '2026-04-10', rhr: 60 },
-    { source: 'oura', date: '2026-04-11', rhr: 61 },
-    { source: 'oura', date: '2026-04-12', rhr: 62 },
+    { source: 'oura', date: vendorDay3, rhr: 60 },
+    { source: 'oura', date: vendorDay2, rhr: 61 },
+    { source: 'oura', date: vendorDay1, rhr: 62 },
     { source: 'manual', date: todayISO, rhr: 57 },
   ]);
   await window.openWearableDetail('rhr');

--- a/tests/tinfoil-secure-fetch.test.js
+++ b/tests/tinfoil-secure-fetch.test.js
@@ -152,4 +152,37 @@ describe('verified Tinfoil EHBP transport', () => {
     expect(secureMocks.clients[0].reset).toHaveBeenCalledOnce();
     expect(secureMocks.clients[0].ready).toHaveBeenCalledTimes(2);
   });
+
+  it('reloads a custom attestation bundle before retrying a rotated PPQ key', async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        type: 'urn:ietf:params:ehbp:error:key-config',
+      }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/problem+json' },
+      }))
+      .mockResolvedValueOnce(new Response('fresh attestation bundle'))
+      .mockResolvedValueOnce(new Response('ciphertext', {
+        headers: { 'Ehbp-Response-Nonce': 'nonce' },
+      }));
+    const secure = await createTinfoilSecureFetch({
+      baseUrl: 'https://api.ppq.ai/private/',
+      attestationBundleURL: 'https://api.ppq.ai/private',
+    });
+
+    const response = await secure.fetch('https://api.ppq.ai/private/v1/chat/completions', {
+      method: 'POST',
+      body: '{}',
+    });
+
+    expect(response.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.ppq.ai/private/attestation',
+      { cache: 'reload' },
+    );
+    expect(secureMocks.clients[0].reset).toHaveBeenCalledOnce();
+    expect(secureMocks.clients[0].ready).toHaveBeenCalledTimes(2);
+  });
 });

--- a/vendor/venice-e2ee.js
+++ b/vendor/venice-e2ee.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+
 // node_modules/@noble/secp256k1/index.js
 var secp256k1_CURVE = {
   p: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2fn,
@@ -438,12 +439,23 @@ async function encryptMessage(aesKey, clientPubKeyBytes, plaintext) {
   out.set(new Uint8Array(ct), 77);
   return toHex(out);
 }
-async function decryptChunk(clientPrivateKey, hexString) {
-  if (!hexString || hexString.length < 154 || !/^[0-9a-f]+$/i.test(hexString)) {
+async function decryptChunk(clientPrivateKey, hexString, allowPlaintext = false) {
+  if (typeof hexString !== "string") {
+    throw new TypeError("Encrypted response content must be a string");
+  }
+  if (!hexString || /^\s+$/.test(hexString)) {
     return hexString;
   }
+  const encrypted = hexString.length >= 186 && /^[0-9a-f]+$/i.test(hexString);
+  if (!encrypted) {
+    if (allowPlaintext) return hexString;
+    throw new Error("Venice E2EE response contained unencrypted content");
+  }
   const raw = fromHex(hexString);
-  if (raw[0] !== 4) return hexString;
+  if (raw[0] !== 4) {
+    if (allowPlaintext) return hexString;
+    throw new Error("Venice E2EE response has an invalid ephemeral public key");
+  }
   const serverEphemeralPubKey = toHex(raw.slice(0, 65));
   const iv = raw.slice(65, 77);
   const ciphertext = raw.slice(77);
@@ -457,7 +469,7 @@ async function decryptChunk(clientPrivateKey, hexString) {
 }
 
 // src/stream.ts
-async function* decryptSSEStream(body, privateKey) {
+async function* decryptSSEStream(body, privateKey, allowPlaintextResponses = false) {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -481,7 +493,7 @@ async function* decryptSSEStream(body, privateKey) {
         const content = event.choices?.[0]?.delta?.content;
         if (content === void 0 || content === null) continue;
         try {
-          yield await decryptChunk(privateKey, content);
+          yield await decryptChunk(privateKey, content, allowPlaintextResponses);
         } catch (e) {
           if (e instanceof DOMException && e.name === "OperationError") {
             throw new Error(
@@ -505,7 +517,7 @@ async function* decryptSSEStream(body, privateKey) {
           const content = event.choices?.[0]?.delta?.content;
           if (content !== void 0 && content !== null) {
             try {
-              yield await decryptChunk(privateKey, content);
+              yield await decryptChunk(privateKey, content, allowPlaintextResponses);
             } catch (e) {
               if (e instanceof DOMException && e.name === "OperationError") {
                 throw new Error(
@@ -802,6 +814,18 @@ var TD_ATTRIBUTES_LEN = 8;
 var REPORT_DATA_OFFSET = TDX_BODY_OFFSET + 520;
 var REPORT_DATA_LEN = 64;
 var MIN_QUOTE_LEN = REPORT_DATA_OFFSET + REPORT_DATA_LEN;
+var MEASUREMENT_LAYOUT = [
+  ["mrSeam", 16],
+  ["mrSignerSeam", 64],
+  ["mrTd", 136],
+  ["mrConfigId", 184],
+  ["mrOwner", 232],
+  ["mrOwnerConfig", 280],
+  ["rtMr0", 328],
+  ["rtMr1", 376],
+  ["rtMr2", 424],
+  ["rtMr3", 472]
+];
 var TDX_TEE_TYPE = 129;
 function deriveEthAddress(pubKeyHex) {
   let hex = pubKeyHex.startsWith("0x") ? pubKeyHex.slice(2) : pubKeyHex;
@@ -823,9 +847,20 @@ function constantTimeEqual(a, b) {
   }
   return diff === 0;
 }
-function parseTdxQuote(quoteHex) {
-  const hex = quoteHex.startsWith("0x") ? quoteHex.slice(2) : quoteHex;
-  const bytes = fromHex(hex);
+function decodeQuote(quote) {
+  const value = quote.startsWith("0x") ? quote.slice(2) : quote;
+  if (value.length % 2 === 0 && /^[0-9a-f]+$/i.test(value)) return fromHex(value);
+  try {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const binary = atob(padded);
+    return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  } catch {
+    throw new Error("TDX quote is neither valid hex nor base64");
+  }
+}
+function parseTdxQuote(quote) {
+  const bytes = decodeQuote(quote);
   if (bytes.length < MIN_QUOTE_LEN) {
     throw new Error(
       `TDX quote too short: ${bytes.length} bytes (need >= ${MIN_QUOTE_LEN})`
@@ -838,25 +873,81 @@ function parseTdxQuote(quoteHex) {
     );
   }
   return {
+    bytes,
     tdAttributes: bytes.slice(TD_ATTRIBUTES_OFFSET, TD_ATTRIBUTES_OFFSET + TD_ATTRIBUTES_LEN),
-    reportData: bytes.slice(REPORT_DATA_OFFSET, REPORT_DATA_OFFSET + REPORT_DATA_LEN)
+    reportData: bytes.slice(REPORT_DATA_OFFSET, REPORT_DATA_OFFSET + REPORT_DATA_LEN),
+    measurements: Object.fromEntries(
+      MEASUREMENT_LAYOUT.map(([name, offset]) => [
+        name,
+        toHex(bytes.slice(TDX_BODY_OFFSET + offset, TDX_BODY_OFFSET + offset + 48))
+      ])
+    )
   };
 }
-async function verifyAttestation(response, clientNonce, dcapVerifier) {
+function normalizeMeasurement(value) {
+  return value.toLowerCase().replace(/^0x/, "");
+}
+function verifyMeasurements(actual, expected, errors) {
+  let checked = 0;
+  let matched = true;
+  for (const [name, allowedValue] of Object.entries(expected)) {
+    const allowed = (Array.isArray(allowedValue) ? allowedValue : [allowedValue]).map(normalizeMeasurement);
+    checked += 1;
+    if (!actual[name] || !allowed.includes(normalizeMeasurement(actual[name]))) {
+      matched = false;
+      errors.push(`TDX measurement mismatch: ${name}`);
+    }
+  }
+  if (checked === 0) {
+    errors.push("Expected measurement policy is empty");
+    return false;
+  }
+  return matched;
+}
+async function verifyAttestation(response, clientNonce, verifierOrOptions) {
+  const options = typeof verifierOrOptions === "function" ? { dcapVerifier: verifierOrOptions } : verifierOrOptions ?? {};
+  const { dcapVerifier, requireDcap = false, expectedMeasurements, expectedModelId } = options;
   const errors = [];
   let nonceVerified = false;
   let signingKeyBound = false;
   let debugMode = false;
   let serverTdxValid = null;
+  let serverVerified = response.verified ?? null;
   let dcap;
+  let dcapVerified = false;
+  let measurements;
+  let measurementsVerified = null;
+  const result = () => ({
+    nonceVerified,
+    signingKeyBound,
+    debugMode,
+    serverTdxValid,
+    serverVerified,
+    dcap,
+    dcapVerified,
+    measurements,
+    measurementsVerified,
+    verificationLevel: dcapVerified ? measurementsVerified === true ? "measured" : "dcap" : nonceVerified && signingKeyBound && !debugMode ? "binding" : "none",
+    errors
+  });
   if (clientNonce.length !== 32) {
     errors.push(`Invalid client nonce length: ${clientNonce.length} (expected 32)`);
-    return { nonceVerified, signingKeyBound, debugMode, serverTdxValid, errors };
+    return result();
+  }
+  const clientNonceHex = toHex(clientNonce);
+  if (response.nonce && normalizeMeasurement(response.nonce) !== clientNonceHex) {
+    errors.push("Attestation response nonce does not match the requested nonce");
+  }
+  if (expectedModelId && response.model !== expectedModelId) {
+    errors.push(`Attestation model mismatch: expected ${expectedModelId}, received ${response.model || "missing"}`);
+  }
+  if (response.verified === false) {
+    errors.push("Venice reported that server-side attestation verification failed");
   }
   const signingKey = response.signing_key || response.signing_public_key;
   if (!signingKey) {
     errors.push("No signing key in attestation response");
-    return { nonceVerified, signingKeyBound, debugMode, serverTdxValid, errors };
+    return result();
   }
   if (response.server_verification) {
     const sv = response.server_verification;
@@ -866,18 +957,31 @@ async function verifyAttestation(response, clientNonce, dcapVerifier) {
         `Server TDX verification failed: ${sv.tdx.error || "unknown reason"}`
       );
     }
+    if (sv.tdx?.signatureValid === false) {
+      errors.push("Venice reported an invalid TDX quote signature");
+    }
+    if (sv.tdx?.certificateChainValid === false) {
+      errors.push("Venice reported an invalid TDX certificate chain");
+    }
+    if (sv.tdx?.attestationKeyMatch === false) {
+      errors.push("Venice reported a TDX attestation-key mismatch");
+    }
+    if (sv.nvidia && !sv.nvidia.valid) {
+      errors.push(`Venice reported failed NVIDIA attestation: ${sv.nvidia.error || "unknown reason"}`);
+    }
   }
   if (!response.intel_quote) {
     errors.push("No intel_quote in attestation response \u2014 cannot verify client-side");
-    return { nonceVerified, signingKeyBound, debugMode, serverTdxValid, errors };
+    return result();
   }
   let reportData;
   let tdAttributes;
+  let quoteBytes;
   try {
-    ({ reportData, tdAttributes } = parseTdxQuote(response.intel_quote));
+    ({ bytes: quoteBytes, reportData, tdAttributes, measurements } = parseTdxQuote(response.intel_quote));
   } catch (e) {
     errors.push(`Failed to parse TDX quote: ${e.message}`);
-    return { nonceVerified, signingKeyBound, debugMode, serverTdxValid, errors };
+    return result();
   }
   debugMode = (tdAttributes[0] & 1) !== 0;
   if (debugMode) {
@@ -930,21 +1034,35 @@ async function verifyAttestation(response, clientNonce, dcapVerifier) {
       );
     }
   }
-  if (dcapVerifier && response.intel_quote) {
-    const quoteHex = response.intel_quote.startsWith("0x") ? response.intel_quote.slice(2) : response.intel_quote;
+  if (expectedMeasurements) {
+    measurementsVerified = verifyMeasurements(measurements, expectedMeasurements, errors);
+  }
+  if (dcapVerifier) {
     try {
-      dcap = await dcapVerifier(fromHex(quoteHex));
+      dcap = await dcapVerifier(quoteBytes);
       const status = dcap.status;
-      if (status === "Revoked") {
-        errors.push("DCAP verification: TCB status is Revoked");
-      } else if (status === "OutOfDate" || status === "OutOfDateConfigurationNeeded") {
-        errors.push(`DCAP verification: TCB status is ${status} \u2014 platform firmware may need updating`);
+      const acceptedStatuses = /* @__PURE__ */ new Set([
+        "UpToDate",
+        "SWHardeningNeeded",
+        "ConfigurationNeeded",
+        "ConfigurationAndSWHardeningNeeded"
+      ]);
+      if (acceptedStatuses.has(status)) {
+        dcapVerified = true;
+      } else {
+        errors.push(`DCAP verification: unacceptable TCB status ${status || "Unknown"}`);
       }
     } catch (e) {
       errors.push(`DCAP verification failed: ${e.message}`);
     }
   }
-  return { nonceVerified, signingKeyBound, debugMode, serverTdxValid, dcap, errors };
+  if (requireDcap && !dcapVerified) {
+    errors.push(dcapVerifier ? "Full DCAP verification did not complete successfully" : "Full DCAP verification is required but no dcapVerifier was provided");
+  }
+  if (measurementsVerified === true && !dcapVerified) {
+    errors.push("Measurement allowlist requires successful DCAP verification of the quote");
+  }
+  return result();
 }
 
 // src/index.ts
@@ -956,8 +1074,14 @@ function createVeniceE2EE(options) {
     baseUrl = DEFAULT_BASE_URL,
     sessionTTL = DEFAULT_SESSION_TTL,
     verifyAttestation: shouldVerify = true,
-    dcapVerifier
+    dcapVerifier,
+    requireDcap = false,
+    expectedMeasurements,
+    allowPlaintextResponses = false
   } = options;
+  if (!shouldVerify && (requireDcap || expectedMeasurements)) {
+    throw new Error("Attestation policy cannot be required when verifyAttestation is false");
+  }
   let _session = null;
   let _pendingSession = null;
   async function fetchAttestation(modelId) {
@@ -992,7 +1116,12 @@ function createVeniceE2EE(options) {
     }
     let attestation;
     if (shouldVerify) {
-      attestation = await verifyAttestation(response, nonceBytes, dcapVerifier);
+      attestation = await verifyAttestation(response, nonceBytes, {
+        dcapVerifier,
+        requireDcap,
+        expectedMeasurements,
+        expectedModelId: modelId
+      });
       if (attestation.errors.length > 0) {
         throw new Error(
           `TEE attestation verification failed:
@@ -1034,10 +1163,10 @@ function createVeniceE2EE(options) {
     };
   }
   async function decrypt(hexChunk, session) {
-    return decryptChunk(session.privateKey, hexChunk);
+    return decryptChunk(session.privateKey, hexChunk, allowPlaintextResponses);
   }
   async function* decryptStream(body, session) {
-    yield* decryptSSEStream(body, session.privateKey);
+    yield* decryptSSEStream(body, session.privateKey, allowPlaintextResponses);
   }
   function clearSession() {
     if (_session) {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.170';
+self.APP_VERSION = '1.10.177';


### PR DESCRIPTION
## What changed

- prevent initial-response timeouts from aborting long response bodies after headers arrive
- apply the same timeout lifecycle to PPQ and Routstr Private TEE fetch wrappers
- reload PPQ attestation evidence after EHBP key rotation before re-attesting
- handle Venice GLM reasoning-only streams, empty streams, and actionable diagnostics
- preserve streamed errors in chat history without feeding them back into later prompts
- fail visibly on empty OpenAI-compatible responses and surface reasoning-only fallbacks
- vendor venice-e2ee 0.2.0 and present binding-only Venice evidence as an amber lock
- correct app copy and architecture notes to describe encrypted fields, visible metadata, and verification limits
- make the wearable manual-overlay browser fixture use relative dates so it cannot age outside the chart window

## Why

Long model responses could be aborted by a timeout that remained armed after response headers arrived. Venice GLM could also emit only hidden reasoning, leaving users with a disappearing typing bubble while usage continued. PPQ enclave key rotations could repeatedly reuse stale browser-cached attestation evidence.

The previous Venice UI and copy also implied stronger client-side attestation guarantees than getbased currently performs.

## User impact

Long Venice, PPQ Private, and Routstr Private responses can finish normally. Empty or reasoning-only provider responses now produce visible output or an actionable error. PPQ Private recovers from enclave key rotation. Venice remains encrypted, but the UI now distinguishes limited binding checks from Tinfoil's fully verified state.

## Validation

- GitHub Actions full suite: passed, including all 350 Playwright tests
- CodeQL JavaScript/TypeScript analysis: passed
- targeted provider/transport suites: 31 passed
- targeted wearable browser flows: 2 passed
- manual browser validation: long Venice E2EE, Routstr Private GLM-5.2, and PPQ Private GLM-5.2 responses completed
- vendored Venice browser bundle matches the venice-e2ee 0.2.0 build
- `git diff --check` passed


## Changelog

- added a force-shown, user-readable What's New entry for version 1.10.177 covering reply reliability, reasoning-only responses, PPQ key rotation, and Venice's privacy/verification limits