### PR TITLE
Remove product prompts from Light guidance

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,12 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.178', date: '2026-07-13', title: 'Cleaner Light guidance',
+    items: [
+      '<b>Light Guidance stays focused on your exposure.</b> It now combines sun safety with one useful next step, without treating unused red-light device channels as deficiencies or inserting product prompts.',
+    ]
+  },
+  {
     version: '1.10.177', date: '2026-07-12', title: 'More reliable private AI chats',
     forceShow: true,
     items: [

--- a/js/light-page-view-hooks.js
+++ b/js/light-page-view-hooks.js
@@ -1,7 +1,6 @@
 // @ts-check
 // light-page-view-hooks.js - wire Light page feature dependencies at startup.
 
-import { loadCatalog, renderChannelDeficitDeviceRecs } from './recommendations.js';
 import {
   CHANNEL_DISPLAY,
   channelTier,
@@ -24,7 +23,6 @@ import { renderSetupCard as renderSunSetupCard } from './sun-defaults.js';
 import { _openChannelOnLightPage } from './light-channel-view.js';
 import {
   ensureActiveDeviceTicker,
-  loadLightDevicePresets,
   openAddDeviceDialog,
   quickLogDeviceSession,
   renderActiveDeviceSessionCard,
@@ -48,8 +46,6 @@ configureLightPageView({
   getDevices,
   getSessions,
   getSunCoords,
-  loadCatalog,
-  loadLightDevicePresets,
   openAddDeviceDialog,
   openChannelOnLightPage: _openChannelOnLightPage,
   openDetailedSessionDialog,
@@ -57,7 +53,6 @@ configureLightPageView({
   quickLogDeviceSession,
   quickLogSunSession,
   renderActiveDeviceSessionCard,
-  renderChannelDeficitDeviceRecs,
   renderChannelMixVerdict,
   renderDevicesSection,
   renderEnvironmentAssessmentSummary,

--- a/js/light-page-view.js
+++ b/js/light-page-view.js
@@ -48,9 +48,6 @@ const lightPageDeps = {
   renderActiveDeviceSessionCard: () => '',
   renderSunSetupCard: () => '',
   renderChannelMixVerdict: staticFallback => staticFallback,
-  renderChannelDeficitDeviceRecs: () => '',
-  loadCatalog: async () => null,
-  loadLightDevicePresets: async () => null,
   renderDevicesSection: async () => '',
   renderEnvironmentAssessmentSummary: () => '',
   renderLightTools: () => '',
@@ -510,14 +507,6 @@ export function showLight(_data) {
     opts: { source: 'Light', dashboardId: '' },
   });
 
-  // Slot id for the async-populated channel-deficit device recommendation
-  // panel. Declared at top scope so the post-render population block can
-  // reference it even when the page rendered without the parent
-  // sessions-list section (e.g. all sessions deleted, but device sessions
-  // push totalSessions ≥ 7 anyway). Stays null when the assignment branch
-  // didn't run; the population block guards on truthiness.
-  let deficitRecSlotId = null;
-
   // Combine sun + device totals so channels reflect every light source
   const devTotals7d = lightPageDeps.rollingDeviceTotals(7) || {};
   const devTotals30d = lightPageDeps.rollingDeviceTotals(30) || {};
@@ -603,20 +592,10 @@ export function showLight(_data) {
     const _staticSuggestion = renderSuggestion(combined7d);
     guidanceBody += lightPageDeps.renderChannelMixVerdict(_staticSuggestion) || _staticSuggestion;
 
-    // Channel-deficit device recommendations — async slot. Surfaces a
-    // CTA card with matching catalog devices when (a) the user has a
-    // real baseline (≥7 logs) and (b) a device-fillable channel is
-    // empty over 30 days. PBM red/NIR are the cleanest cases — solar
-    // exposure can't realistically fill those, so a panel is the
-    // right answer. Catalog + presets are async-loaded; the slot
-    // stays empty if recs are off, region filters everything out, or
-    // the catalog isn't reachable.
-    deficitRecSlotId = `light-deficit-rec-slot-${Date.now()}`;
-    guidanceBody += `<div id="${escapeAttr(deficitRecSlotId)}"></div>`;
     widgets.push({
       id: 'light-guidance',
       title: 'Guidance',
-      description: 'Burn risk, channel synthesis, and device-fillable gaps',
+      description: 'Burn risk and a high-leverage next step from your channel mix',
       body: guidanceBody,
       size: 'full',
       opts: { source: 'Light', dashboardId: '' },
@@ -686,33 +665,6 @@ export function showLight(_data) {
 
   main.innerHTML = html;
   main.querySelector('.light-page')?.classList.add('is-ready');
-
-  // Populate the channel-deficit device-rec slot. Same baseline gate as
-  // sun-context.js: ≥7 logged events of any kind. Device-fillable
-  // channels only — sun-derived deficits (vit_d, circadian, etc.) get
-  // suggested actions via renderSuggestion above; we don't try to sell
-  // a panel as a sun substitute.
-  if (deficitRecSlotId && totalSessions >= 7) {
-    const slot = document.getElementById(deficitRecSlotId);
-    if (slot) {
-      const DEVICE_CHANNELS = [
-        { key: 'pbm_red', label: 'red 660 nm (PBM)' },
-        { key: 'pbm_nir', label: 'near-IR 810/850 nm (PBM)' },
-      ];
-      const empty = DEVICE_CHANNELS.filter(c => (combined30d[c.key] || 0) === 0);
-      if (empty.length) {
-        Promise.all([lightPageDeps.loadCatalog(), lightPageDeps.loadLightDevicePresets()])
-          .then(([catalog, presetData]) => {
-            if (!catalog || !presetData?.presets) return;
-            const blocks = empty
-              .map(c => lightPageDeps.renderChannelDeficitDeviceRecs(catalog, c.key, presetData.presets, { label: escapeHTML(c.label) }))
-              .filter(Boolean);
-            if (blocks.length && slot.isConnected) slot.innerHTML = blocks.join('');
-          })
-          .catch(() => { /* recs are best-effort */ });
-      }
-    }
-  }
 
   Promise.resolve(lightPageDeps.renderDevicesSection()).then((devHtml) => {
     const slot = document.getElementById(devicesSlotId);

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -306,6 +306,27 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       lightPage.showLight(state.importedData);
       outcomes.emptyLightPageShowsCountryBandHint =
         main?.textContent.includes('Calculations use your country (~49.2° lat)') === true;
+
+      // Guidance should interpret logged exposure, not present unused PBM
+      // channels as deficiencies or mix product discovery into health advice.
+      window.getSessions = () => Array.from({ length: 7 }, (_, index) => ({
+        id: `sun-${index}`,
+        startedAt: Date.now() - (index + 1) * 86_400_000,
+        endedAt: Date.now() - (index + 1) * 86_400_000 + 600_000,
+      }));
+      window.rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
+      window.rollingDeviceTotals = () => ({ pbm_red: 0, pbm_nir: 0 });
+      syncLightPageDeps();
+      lightPage.showLight(state.importedData);
+      const guidance = main?.querySelector('[data-widget-id="light-guidance"], #light-guidance');
+      outcomes.guidanceKeepsProductsOutOfExposureAdvice =
+        main?.textContent.includes('Guidance') === true
+        && main?.textContent.includes('Burn risk and a high-leverage next step') === true
+        && main?.textContent.includes('Fill the red 660 nm') === false
+        && main?.textContent.includes('Fill the near-IR 810/850 nm') === false
+        && main?.querySelector('.rec-channel-deficit') === null
+        && main?.querySelector('[id^="light-deficit-rec-slot-"]') === null
+        && guidance !== null;
     } finally {
       state.importedData = saved.importedData;
       if (main && saved.mainHTML != null) main.innerHTML = saved.mainHTML;

--- a/tests/test-light-page-view-delegated-actions.js
+++ b/tests/test-light-page-view-delegated-actions.js
@@ -54,12 +54,16 @@ assert('Light page view exposes dependency configurator',
     && /Object\.assign\(lightPageDeps, deps\)/.test(src));
 assert('Light page view avoids direct window globals',
   !/window\./.test(src));
-assert('Light page feature hook wires runtime dependencies',
+assert('Light page feature hook wires exposure dependencies without product recommendation coupling',
   /configureLightPageView\(\{/.test(hooksSrc)
     && /renderLightTodayHero/.test(hooksSrc)
     && /renderDevicesSection/.test(hooksSrc)
     && /renderLightTools/.test(hooksSrc)
-    && /renderChannelDeficitDeviceRecs/.test(hooksSrc));
+    && /renderChannelMixVerdict/.test(hooksSrc)
+    && !/renderChannelDeficitDeviceRecs/.test(hooksSrc)
+    && !/loadCatalog/.test(hooksSrc)
+    && !/loadLightDevicePresets/.test(hooksSrc)
+    && !/from '\.\/recommendations\.js'/.test(hooksSrc));
 assert('Light Today AI renderers are wired without a window facade',
   todayAiSrc.includes('registerAIActionHandler')
     && !todayAiSrc.includes('Object.assign(globalThis')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.177';
+self.APP_VERSION = '1.10.178';


### PR DESCRIPTION
## Summary

- keep Light Guidance focused on sun safety and one high-leverage next step from the channel mix
- remove the PBM red/NIR product-deficit slots and their catalog/preset dependency wiring
- add regression coverage that prevents product recommendations from returning to exposure advice
- bump the app version to 1.10.178 and document the behavior change

## Why

The Guidance widget treated unused PBM device channels as deficiencies and mixed affiliate product prompts into health guidance. Those prompts were not based on user goals, biomarkers, or an established need, and the duplicated red/NIR calls made the widget feel sales-oriented rather than useful.

## Validation

- `./run-tests.sh`
  - TypeScript and check-JS typechecks passed
  - module verification: 122 passed
  - Vitest: 390 passed
  - Playwright: 350 passed, including 472 responsive/theme checks