### PR TITLE
Reduce Vercel edge request volume

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,13 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.182', date: '2026-07-14', title: 'Lighter, responsive app updates',
+    items: [
+      '<b>Returning visits reuse the complete installed app.</b> Versioned scripts, styles, fonts, and reference files no longer re-download in the background on every load, while live APIs and synced data always stay on the network.',
+      '<b>Update notices stay timely without installing every deployment.</b> A lightweight foreground check finds new versions, and the full offline update downloads only after you choose Update. Reloading still forces an immediate update check.',
+    ]
+  },
+  {
     version: '1.10.181', date: '2026-07-13', title: 'Consistent PTH chart values',
     items: [
       '<b>PTH results now share one chart scale.</b> Older pg/mL imports are converted to pmol/L alongside newer PTH results, including values imported before PTH became a standard marker.',

--- a/js/pdf-import-marker-mapping.js
+++ b/js/pdf-import-marker-mapping.js
@@ -39,30 +39,12 @@ function normalizeFractionStoredPercentValue(key, value, unit, context = null) {
 }
 
 export const GENERIC_IMPORT_UNITS = [
-  '',
-  '%',
-  'ratio',
-  'arb.j.',
-  'U/l',
-  'IU/l',
-  '\u00b5kat/l',
-  '/\u00b5l',
-  '10^9/l',
-  '10^12/l',
-  'g/l',
-  'mg/l',
-  '\u00b5g/l',
-  'ng/ml',
-  'ng/l',
-  'mol/l',
-  'mmol/l',
-  '\u00b5mol/l',
-  'nmol/l',
-  'pmol/l',
-  'g/mol',
-  'fL',
-  'pg',
-  'mm/h',
+  '', '%', 'ratio', 'arb.j.',
+  'U/l', 'IU/l', '\u00b5kat/l',
+  '/\u00b5l', '10^9/l', '10^12/l',
+  'g/l', 'mg/l', '\u00b5g/l', 'ng/ml', 'ng/l',
+  'mol/l', 'mmol/l', '\u00b5mol/l', 'nmol/l', 'pmol/l',
+  'g/mol', 'fL', 'pg', 'mm/h',
 ];
 
 function normalizeGenericImportUnit(unit) {

--- a/js/service-worker-update.js
+++ b/js/service-worker-update.js
@@ -4,11 +4,17 @@
 const UPDATE_BANNER_ID = 'version-update-banner';
 const UPDATE_ACTION_ATTR = 'data-version-update-action';
 const DEV_SW_QUERY_RE = /(?:^|[?&])dev-sw=1(?:&|$)/;
-const UPDATE_CHECK_INTERVAL_MS = 60 * 1000;
+const UPDATE_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+const VERSION_CHECK_URL = '/version.js?update-check=1';
+const LAST_VERSION_CHECK_KEY = 'labcharts-version-update-last-check';
+const APP_VERSION_RE = /\bAPP_VERSION\s*=\s*(['"])([^'"]+)\1/;
 
 let pendingRegistration = null;
 let dismissedWaitingWorker = null;
+let availableVersion = '';
+let dismissedAvailableVersion = '';
 let updateRequested = false;
+let updateInstallPending = false;
 let reloadAvailable = false;
 let lastUpdateCheckAt = 0;
 
@@ -33,6 +39,37 @@ function getDefaultServiceWorkerContainer() {
  */
 function getDefaultCacheStorage() {
   return getDefaultServiceWorkerWindow()?.caches || null;
+}
+
+export function parseAppVersionScript(source) {
+  return String(source || '').match(APP_VERSION_RE)?.[2] || '';
+}
+
+export function isReloadNavigation(win = getDefaultServiceWorkerWindow()) {
+  const navigation = /** @type {PerformanceNavigationTiming | undefined} */ (
+    win?.performance?.getEntriesByType?.('navigation')?.[0]
+  );
+  if (navigation?.type === 'reload') return true;
+  return win?.performance?.navigation?.type === 1;
+}
+
+function getCurrentAppVersion(win) {
+  return String(win?.APP_VERSION || '').trim();
+}
+
+function getStoredLastCheckAt(win) {
+  try {
+    return Number(win?.localStorage?.getItem(LAST_VERSION_CHECK_KEY)) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function storeLastCheckAt(win, checkedAt) {
+  lastUpdateCheckAt = checkedAt;
+  try {
+    win?.localStorage?.setItem(LAST_VERSION_CHECK_KEY, String(checkedAt));
+  } catch {}
 }
 
 let reloadPage = () => {
@@ -76,7 +113,9 @@ export function hideVersionUpdateBanner() {
 
 export function showVersionUpdateBanner(registration) {
   const waitingWorker = getServiceWorker(registration);
-  if (!reloadAvailable && (!waitingWorker || waitingWorker === dismissedWaitingWorker)) return false;
+  const detectedUpdate = !!availableVersion && availableVersion !== dismissedAvailableVersion;
+  const waitingUpdate = !!waitingWorker && waitingWorker !== dismissedWaitingWorker;
+  if (!reloadAvailable && !detectedUpdate && !waitingUpdate && !updateInstallPending) return false;
 
   pendingRegistration = registration || pendingRegistration;
 
@@ -109,15 +148,29 @@ export function showVersionUpdateBanner(registration) {
 function renderVersionUpdateBanner(banner) {
   const copy = banner.querySelector('.version-update-copy');
   const primaryButton = banner.querySelector(`[${UPDATE_ACTION_ATTR}="apply"]`);
+  const dismissButton = banner.querySelector(`[${UPDATE_ACTION_ATTR}="dismiss"]`);
   if (reloadAvailable) {
     if (copy) copy.innerHTML = '<strong>New version installed.</strong> Reload when you are ready.';
     if (primaryButton) primaryButton.textContent = 'Reload';
+    if (primaryButton) primaryButton.disabled = false;
+    if (dismissButton) dismissButton.disabled = false;
     banner.setAttribute('aria-label', 'App update ready to reload');
+    return;
+  }
+
+  if (updateInstallPending) {
+    if (copy) copy.innerHTML = '<strong>Installing update…</strong> The app will reload when it is ready.';
+    if (primaryButton) primaryButton.textContent = 'Installing…';
+    if (primaryButton) primaryButton.disabled = true;
+    if (dismissButton) dismissButton.disabled = true;
+    banner.setAttribute('aria-label', 'App update installing');
     return;
   }
 
   if (copy) copy.innerHTML = '<strong>New version available.</strong> Update when you are ready.';
   if (primaryButton) primaryButton.textContent = 'Update';
+  if (primaryButton) primaryButton.disabled = false;
+  if (dismissButton) dismissButton.disabled = false;
   banner.setAttribute('aria-label', 'App update available');
 }
 
@@ -136,6 +189,7 @@ function handleVersionUpdateActionClick(event) {
 
   if (action === 'dismiss') {
     if (!reloadAvailable) dismissedWaitingWorker = getServiceWorker(pendingRegistration);
+    if (!reloadAvailable && availableVersion) dismissedAvailableVersion = availableVersion;
     hideVersionUpdateBanner();
   }
 }
@@ -148,11 +202,42 @@ export function applyPendingServiceWorkerUpdate(registration = pendingRegistrati
   }
 
   const waitingWorker = getServiceWorker(registration);
-  if (!waitingWorker) return false;
+  if (waitingWorker) {
+    updateRequested = true;
+    updateInstallPending = false;
+    waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+    hideVersionUpdateBanner();
+    return true;
+  }
+
+  if (!availableVersion || !registration?.update) return false;
 
   updateRequested = true;
-  waitingWorker.postMessage({ type: 'SKIP_WAITING' });
-  hideVersionUpdateBanner();
+  updateInstallPending = true;
+  dismissedAvailableVersion = '';
+  showVersionUpdateBanner(registration);
+
+  if (registration.installing) return true;
+
+  registration.update().then(() => {
+    if (!updateInstallPending) return;
+    const installedWorker = getServiceWorker(registration);
+    if (installedWorker) {
+      updateInstallPending = false;
+      installedWorker.postMessage({ type: 'SKIP_WAITING' });
+      hideVersionUpdateBanner();
+      return;
+    }
+    if (!registration.installing) {
+      updateRequested = false;
+      updateInstallPending = false;
+      showVersionUpdateBanner(registration);
+    }
+  }).catch(() => {
+    updateRequested = false;
+    updateInstallPending = false;
+    showVersionUpdateBanner(registration);
+  });
   return true;
 }
 
@@ -173,21 +258,70 @@ export function watchServiceWorkerRegistration(
     installingWorker.addEventListener('statechange', () => {
       if (installingWorker.state === 'installed'
           && canPromptForUpdate(registration, serviceWorkerContainer)) {
+        if (updateRequested && updateInstallPending) {
+          updateInstallPending = false;
+          installingWorker.postMessage({ type: 'SKIP_WAITING' });
+          hideVersionUpdateBanner();
+          return;
+        }
         dismissedWaitingWorker = null;
         reloadAvailable = false;
+        showVersionUpdateBanner(registration);
+      }
+      if (installingWorker.state === 'redundant' && updateInstallPending) {
+        updateRequested = false;
+        updateInstallPending = false;
         showVersionUpdateBanner(registration);
       }
     });
   });
 }
 
-function requestServiceWorkerUpdate(registration, serviceWorkerContainer, { force = false } = {}) {
-  if (!registration?.update) return;
-
+/**
+ * @param {any} registration
+ * @param {any} serviceWorkerContainer
+ * @param {any} win
+ * @param {{ force?: boolean, fetchImpl?: typeof fetch }} [options]
+ */
+export async function checkForAppVersionUpdate(
+  registration,
+  serviceWorkerContainer,
+  win = getDefaultServiceWorkerWindow(),
+  options = {}
+) {
+  const { force = false, fetchImpl } = options;
+  if (!win) return false;
+  const fetchVersion = fetchImpl || win.fetch?.bind?.(win);
+  if (!fetchVersion) return false;
   const now = Date.now();
-  if (!force && now - lastUpdateCheckAt < UPDATE_CHECK_INTERVAL_MS) return;
-  lastUpdateCheckAt = now;
+  const sharedLastCheckAt = Math.max(lastUpdateCheckAt, getStoredLastCheckAt(win));
+  if (!force && now - sharedLastCheckAt < UPDATE_CHECK_INTERVAL_MS) return false;
+  storeLastCheckAt(win, now);
 
+  try {
+    const response = await fetchVersion(VERSION_CHECK_URL, {
+      cache: 'no-store',
+      credentials: 'same-origin',
+    });
+    if (!response?.ok) return false;
+    const remoteVersion = parseAppVersionScript(await response.text());
+    const currentVersion = getCurrentAppVersion(win);
+    if (!remoteVersion || !currentVersion || remoteVersion === currentVersion) return false;
+
+    if (availableVersion !== remoteVersion) {
+      availableVersion = remoteVersion;
+      dismissedAvailableVersion = '';
+    }
+    pendingRegistration = registration || pendingRegistration;
+    if (serviceWorkerContainer?.controller) showVersionUpdateBanner(registration);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function requestServiceWorkerUpdateForReload(registration, serviceWorkerContainer) {
+  if (!registration?.update) return;
   registration.update().then(() => {
     if (canPromptForUpdate(registration, serviceWorkerContainer)) {
       showVersionUpdateBanner(registration);
@@ -196,14 +330,21 @@ function requestServiceWorkerUpdate(registration, serviceWorkerContainer, { forc
 }
 
 function scheduleServiceWorkerUpdateChecks(registration, serviceWorkerContainer, win) {
-  if (!registration?.update || !win) return;
+  if (!win) return;
 
   const check = (force = false) => {
     if (win.document?.visibilityState === 'hidden') return;
-    requestServiceWorkerUpdate(registration, serviceWorkerContainer, { force });
+    checkForAppVersionUpdate(registration, serviceWorkerContainer, win, { force }).catch(() => {});
   };
 
-  check(true);
+  if (isReloadNavigation(win)) {
+    // An explicit reload is user intent to get current code. Let the browser
+    // perform a full worker update immediately; routine foreground checks stay
+    // lightweight and never install before the user accepts the banner.
+    requestServiceWorkerUpdateForReload(registration, serviceWorkerContainer);
+  } else {
+    check();
+  }
   win.addEventListener?.('focus', () => check());
   win.document?.addEventListener?.('visibilitychange', () => {
     if (win.document?.visibilityState === 'visible') check();

--- a/service-worker.js
+++ b/service-worker.js
@@ -541,6 +541,12 @@ function cacheResponse(request, response) {
     .catch(() => {});
 }
 
+function matchCurrentCache(request) {
+  return resolveCacheName()
+    .then((name) => caches.open(name))
+    .then((cache) => cache.match(request));
+}
+
 function fetchAndCache(request) {
   return fetch(request).then((response) => {
     cacheResponse(request, response);
@@ -549,7 +555,7 @@ function fetchAndCache(request) {
 }
 
 function cachedAppShell() {
-  return caches.match('/app').then((cachedApp) => cachedApp || caches.match('/index.html'));
+  return matchCurrentCache('/app').then((cachedApp) => cachedApp || matchCurrentCache('/index.html'));
 }
 
 const NETWORK_ONLY_HOSTS = new Set([
@@ -626,10 +632,25 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Network-first: version.js — must always fetch fresh so SW detects new versions
-  if (url.pathname === '/version.js') {
+  // Live same-origin endpoints must never be stored in the versioned app cache.
+  // This covers AI/wearable proxy calls, encrypted profile shares, and commit
+  // metadata while keeping the cache-first production path static-only.
+  if (sameOrigin && url.pathname.startsWith('/api/')) return;
+
+  // The lightweight update probe is always fresh. The normal production
+  // version.js stays atomic with the active versioned cache so the page never
+  // compares a new version global against older cached modules.
+  if (url.pathname === '/version.js' && url.searchParams.get('update-check') === '1') {
     event.respondWith(
-      fetchAndCache(event.request).catch(() => caches.match(event.request))
+      fetchAndCache(event.request).catch(() => matchCurrentCache(event.request))
+    );
+    return;
+  }
+
+  // Preview/local builds still need a fresh version script on every load.
+  if (url.pathname === '/version.js' && !IS_PROD) {
+    event.respondWith(
+      fetchAndCache(event.request).catch(() => matchCurrentCache(event.request))
     );
     return;
   }
@@ -644,7 +665,7 @@ self.addEventListener('fetch', (event) => {
   // cached app document for /app and any refreshed same-origin navigation.
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      caches.match(event.request).then((cached) => {
+      matchCurrentCache(event.request).then((cached) => {
         const fetched = fetchAndCache(event.request).catch(() => cached || cachedAppShell());
         return cached || fetched;
       })
@@ -657,16 +678,15 @@ self.addEventListener('fetch', (event) => {
   // JS/CSS from the previous commit-shaped cache.
   if (!IS_PROD) {
     event.respondWith(
-      fetchAndCache(event.request).catch(() => caches.match(event.request))
+      fetchAndCache(event.request).catch(() => matchCurrentCache(event.request))
     );
     return;
   }
 
-  // Stale-while-revalidate: production app shell files
+  // Cache-first: a completed install already contains the atomic, versioned
+  // production app shell. Avoid revalidating hundreds of unchanged modules on
+  // every load; a miss is fetched once and stored in the current version cache.
   event.respondWith(
-    caches.match(event.request).then((cached) => {
-      const fetched = fetchAndCache(event.request).catch(() => cached);
-      return cached || fetched;
-    })
+    matchCurrentCache(event.request).then((cached) => cached || fetchAndCache(event.request))
   );
 });

--- a/tests/service-worker-runtime.test.js
+++ b/tests/service-worker-runtime.test.js
@@ -12,6 +12,12 @@ function jsonResponse(body, init = {}) {
   });
 }
 
+function cacheKey(request) {
+  if (typeof request === 'string') return request;
+  const url = new URL(request.url);
+  return `${url.pathname}${url.search}`;
+}
+
 function makeCaches() {
   const opened = new Map();
   const matches = new Map();
@@ -19,9 +25,11 @@ function makeCaches() {
     addAll: vi.fn(async (entries) => {
       for (const entry of entries) matches.set(entry, new Response(`cached:${entry}`));
     }),
+    match: vi.fn(async (request) => {
+      return matches.get(cacheKey(request));
+    }),
     put: vi.fn(async (request, response) => {
-      const key = typeof request === 'string' ? request : new URL(request.url).pathname;
-      matches.set(key, response);
+      matches.set(cacheKey(request), response);
     }),
   };
   const caches = {
@@ -30,8 +38,7 @@ function makeCaches() {
       return cache;
     }),
     match: vi.fn(async (request) => {
-      const key = typeof request === 'string' ? request : new URL(request.url).pathname;
-      return matches.get(key);
+      return matches.get(cacheKey(request));
     }),
     keys: vi.fn(async () => ['labcharts-vold', 'labcharts-v9.9.9-deadbeef']),
     delete: vi.fn(async () => true),
@@ -132,7 +139,7 @@ describe('service worker runtime cache behavior', () => {
     expect(globalThis.fetch).toHaveBeenCalledWith('/api/commit', { cache: 'no-store' });
   });
 
-  it('uses network-first, navigation fallback, and stale-while-revalidate fetch routes', async () => {
+  it('uses network-first preview assets, navigation fallback, and network-only APIs', async () => {
     const { cache, listeners, matches } = await loadServiceWorker();
     await Promise.resolve();
 
@@ -147,6 +154,10 @@ describe('service worker runtime cache behavior', () => {
     const nonGet = makeFetchEvent('https://preview.getbased.health/api/share', { method: 'POST' });
     listeners.get('fetch')(nonGet);
     expect(nonGet.response()).toBeNull();
+
+    const apiGet = makeFetchEvent('https://preview.getbased.health/api/share?id=encrypted-profile');
+    listeners.get('fetch')(apiGet);
+    expect(apiGet.response()).toBeNull();
 
     const version = makeFetchEvent('https://preview.getbased.health/version.js');
     listeners.get('fetch')(version);
@@ -163,14 +174,38 @@ describe('service worker runtime cache behavior', () => {
     expect(await (await navigate.response()).text()).toBe('cached-app-shell');
 
     matches.set('/styles.css', new Response('cached-css'));
-    const staleWhileRevalidate = makeFetchEvent('https://preview.getbased.health/styles.css');
-    listeners.get('fetch')(staleWhileRevalidate);
-    expect(await (await staleWhileRevalidate.response()).text()).toBe('cached-css');
+    const offlineAsset = makeFetchEvent('https://preview.getbased.health/styles.css');
+    listeners.get('fetch')(offlineAsset);
+    expect(await (await offlineAsset.response()).text()).toBe('cached-css');
 
     globalThis.fetch = vi.fn(async () => new Response('fresh-module', { status: 200 }));
     const appModule = makeFetchEvent('https://preview.getbased.health/js/main.js');
     listeners.get('fetch')(appModule);
     expect(await (await appModule.response()).text()).toBe('fresh-module');
+  });
+
+  it('serves production static assets from the current version cache without revalidation', async () => {
+    const { cache, listeners, matches } = await loadServiceWorker({ hostname: 'app.getbased.health' });
+    await Promise.resolve();
+
+    matches.set('/styles.css', new Response('cached-production-css'));
+    matches.set('/version.js', new Response("self.APP_VERSION = '9.9.9';"));
+    globalThis.fetch = vi.fn(async () => new Response("self.APP_VERSION = '9.9.10';", { status: 200 }));
+    const cachedAsset = makeFetchEvent('https://app.getbased.health/styles.css');
+    listeners.get('fetch')(cachedAsset);
+
+    expect(await (await cachedAsset.response()).text()).toBe('cached-production-css');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    const activeVersion = makeFetchEvent('https://app.getbased.health/version.js');
+    listeners.get('fetch')(activeVersion);
+    expect(await (await activeVersion.response()).text()).toContain("'9.9.9'");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    const versionProbe = makeFetchEvent('https://app.getbased.health/version.js?update-check=1');
+    listeners.get('fetch')(versionProbe);
+    expect(await (await versionProbe.response()).text()).toContain("'9.9.10'");
+    await vi.waitFor(() => expect(cache.put).toHaveBeenCalledWith(versionProbe.request, expect.any(Response)));
   });
 
   it('uses plain versioned cache names on production hosts', async () => {

--- a/tests/service-worker-update.test.js
+++ b/tests/service-worker-update.test.js
@@ -68,16 +68,21 @@ describe('service worker update prompt', () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it('registers with fresh update checks for open tabs', async () => {
+  it('registers with lightweight five-minute version checks for open tabs', async () => {
     const { registerServiceWorkerUpdates } = serviceWorkerUpdate;
     let intervalCallback = null;
+    const fetchVersion = vi.fn(async () => new Response("self.APP_VERSION = '1.2.3';"));
     const registration = {
       waiting: null,
       addEventListener: vi.fn(),
       update: vi.fn(async () => {}),
     };
     const win = {
+      APP_VERSION: '1.2.3',
+      fetch: fetchVersion,
       location: { hostname: 'getbased.health', search: '', reload: vi.fn() },
+      localStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+      performance: { getEntriesByType: vi.fn(() => [{ type: 'navigate' }]) },
       document: {
         visibilityState: 'visible',
         addEventListener: vi.fn(),
@@ -101,11 +106,113 @@ describe('service worker update prompt', () => {
     });
 
     expect(serviceWorkerContainer.register).toHaveBeenCalledWith('/service-worker.js', { updateViaCache: 'none' });
-    expect(registration.update).toHaveBeenCalledTimes(1);
+    expect(fetchVersion).toHaveBeenCalledWith('/version.js?update-check=1', {
+      cache: 'no-store',
+      credentials: 'same-origin',
+    });
+    expect(registration.update).not.toHaveBeenCalled();
     expect(win.addEventListener).toHaveBeenCalledWith('focus', expect.any(Function));
     expect(win.document.addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
-    expect(win.setInterval).toHaveBeenCalledWith(expect.any(Function), 60 * 1000);
+    expect(win.setInterval).toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
     expect(intervalCallback).toEqual(expect.any(Function));
+  });
+
+  it('uses an explicit reload to request a full worker update immediately', async () => {
+    const { registerServiceWorkerUpdates } = serviceWorkerUpdate;
+    const registration = {
+      waiting: null,
+      addEventListener: vi.fn(),
+      update: vi.fn(async () => {}),
+    };
+    const fetchVersion = vi.fn();
+    const win = {
+      APP_VERSION: '1.2.3',
+      fetch: fetchVersion,
+      location: { hostname: 'getbased.health', search: '', reload: vi.fn() },
+      performance: { getEntriesByType: vi.fn(() => [{ type: 'reload' }]) },
+      document: { visibilityState: 'visible', addEventListener: vi.fn() },
+      addEventListener: vi.fn(),
+      setInterval: vi.fn(),
+    };
+    const serviceWorkerContainer = {
+      controller: {},
+      register: vi.fn(async () => registration),
+      addEventListener: vi.fn(),
+    };
+
+    await registerServiceWorkerUpdates({ win, serviceWorkerContainer, cacheStorage: null });
+
+    expect(registration.update).toHaveBeenCalledTimes(1);
+    expect(fetchVersion).not.toHaveBeenCalled();
+  });
+
+  it('detects a new version cheaply and installs only after the update action', async () => {
+    const { checkForAppVersionUpdate } = serviceWorkerUpdate;
+    const waiting = { postMessage: vi.fn() };
+    const registration = {
+      waiting: null,
+      installing: null,
+      update: vi.fn(async () => {
+        registration.waiting = waiting;
+      }),
+    };
+    const serviceWorkerContainer = { controller: {} };
+    const win = {
+      APP_VERSION: '1.2.3',
+      localStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+    };
+    const fetchImpl = vi.fn(async () => new Response("self.APP_VERSION = '1.2.4';"));
+
+    await expect(checkForAppVersionUpdate(
+      registration,
+      serviceWorkerContainer,
+      win,
+      { force: true, fetchImpl }
+    )).resolves.toBe(true);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(registration.update).not.toHaveBeenCalled();
+    const banner = document.getElementById('version-update-banner');
+    expect(banner.textContent).toContain('New version available');
+
+    banner.querySelector('[data-version-update-action="apply"]').click();
+    await vi.waitFor(() => expect(registration.update).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' }));
+    expect(document.getElementById('version-update-banner')).toBeNull();
+  });
+
+  it('shares the version-check throttle across tabs while allowing forced reload checks', async () => {
+    const { checkForAppVersionUpdate } = serviceWorkerUpdate;
+    const stored = new Map();
+    const localStorage = {
+      getItem: vi.fn((key) => stored.get(key) || null),
+      setItem: vi.fn((key, value) => stored.set(key, value)),
+    };
+    const win = { APP_VERSION: '1.2.3', localStorage };
+    const registration = { waiting: null };
+    const serviceWorkerContainer = { controller: {} };
+    const firstFetch = vi.fn(async () => new Response("self.APP_VERSION = '1.2.3';"));
+    const secondFetch = vi.fn(async () => new Response("self.APP_VERSION = '1.2.3';"));
+
+    await checkForAppVersionUpdate(registration, serviceWorkerContainer, win, { fetchImpl: firstFetch });
+    await checkForAppVersionUpdate(registration, serviceWorkerContainer, win, { fetchImpl: secondFetch });
+    expect(firstFetch).toHaveBeenCalledTimes(1);
+    expect(secondFetch).not.toHaveBeenCalled();
+
+    await checkForAppVersionUpdate(registration, serviceWorkerContainer, win, {
+      force: true,
+      fetchImpl: secondFetch,
+    });
+    expect(secondFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('recognizes explicit reload navigations and parses the deployed version script', () => {
+    const { isReloadNavigation, parseAppVersionScript } = serviceWorkerUpdate;
+
+    expect(isReloadNavigation({ performance: { getEntriesByType: () => [{ type: 'reload' }] } })).toBe(true);
+    expect(isReloadNavigation({ performance: { getEntriesByType: () => [{ type: 'navigate' }] } })).toBe(false);
+    expect(parseAppVersionScript("self.APP_VERSION = '1.10.182';")).toBe('1.10.182');
+    expect(parseAppVersionScript('not a version script')).toBe('');
   });
 
   it('shows a banner and activates only from the update action', () => {

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -227,8 +227,8 @@ for (const asset of pwaAppShellAssets) {
 }
 assert('SW has offline navigation fallback for /app',
   swSrc.includes("event.request.mode === 'navigate'") &&
-  swSrc.includes("caches.match('/app')") &&
-  swSrc.includes("caches.match('/index.html')"),
+  swSrc.includes("matchCurrentCache('/app')") &&
+  swSrc.includes("matchCurrentCache('/index.html')"),
   'installed PWA start_url=/app needs a cached document while offline');
 assert('SW does not cache HTTP error responses',
   /if \(!response \|\| response\.status === 206 \|\| !response\.ok\) return Promise\.resolve\(\);/.test(swSrc),

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -196,10 +196,10 @@ return (async function() {
   assert('SW CACHE_NAME uses semver', swMobileSrc.includes('`labcharts-v${self.APP_VERSION}`'));
   assert('SW precaches installed app start_url',
     swMobileSrc.includes("'/app'") &&
-    swMobileSrc.includes("caches.match('/app')"));
+    swMobileSrc.includes("matchCurrentCache('/app')"));
   assert('SW falls back for offline navigations',
     swMobileSrc.includes("event.request.mode === 'navigate'") &&
-    swMobileSrc.includes("caches.match('/index.html')"));
+    swMobileSrc.includes("matchCurrentCache('/index.html')"));
   assert('SW precaches mobile runtime vendors',
     swMobileSrc.includes("'/vendor/qrcode-generator.js'") &&
     swMobileSrc.includes("'/vendor/venice-e2ee.js'") &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.181';
+self.APP_VERSION = '1.10.182';


### PR DESCRIPTION
## Summary

- make the versioned production app shell cache-first while keeping same-origin API endpoints network-only
- replace minute-by-minute full service-worker update checks with a lightweight five-minute version probe shared across tabs
- preserve the update notification, defer the full atomic precache until the user accepts it, and force a full worker check on explicit reload
- bump the app version to 1.10.182 and add focused service-worker/runtime regression coverage

## Why

The previous stale-while-revalidate path sent requests for hundreds of cached modules on ordinary reloads. Frequent full service-worker update checks also added avoidable traffic. This contributed to the Vercel free team's Edge Request usage reaching 75% of its monthly allowance.

## Impact

A production-host HTTPS smoke test reduced a controlled reload from approximately 457 server requests to 23 (about 95%). An already-cached stylesheet generated zero origin requests.

Users still receive the existing update banner. The large atomic app-shell download occurs only when they click **Update**, while an explicit browser reload requests a full service-worker update check immediately.

## Validation

- `./run-tests.sh`
  - 396 Vitest tests passed
  - 18 origin-guard tests passed
  - 350 Playwright tests passed
  - 472 responsive-theme assertions passed
- targeted service-worker suites: 16 tests passed
- production-host HTTPS request-volume smoke test passed
- `git diff --check` passed

## Existing guardrail

`npm run quality` still reports 24 app JavaScript files at or above 800 lines against the repository baseline of 23. None of the files changed by this PR crossed that threshold.