### PR TITLE
Fix Apple Health import routing

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,12 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.183', date: '2026-07-14', title: 'Complete Apple Health imports',
+    items: [
+      '<b>Apple Health exports keep every supported health metric.</b> Files selected through the main import button now save heart rate, HRV, weight, body composition, and other wearable data before offering menstrual-cycle review.',
+    ]
+  },
+  {
     version: '1.10.182', date: '2026-07-14', title: 'Lighter, responsive app updates',
     items: [
       '<b>Returning visits reuse the complete installed app.</b> Versioned scripts, styles, fonts, and reference files no longer re-download in the background on every load, while live APIs and synced data always stay on the network.',

--- a/js/cycle-import-file.js
+++ b/js/cycle-import-file.js
@@ -1,0 +1,67 @@
+// @ts-check
+// cycle-import-file.js - cycle export file detection and ZIP context helpers.
+
+const appWindow = /** @type {Window & typeof globalThis & { JSZip?: any }} */ (
+  typeof window !== 'undefined' ? window : {}
+);
+
+let jszipLoad = null;
+function loadJSZip() {
+  if (appWindow.JSZip) return Promise.resolve(appWindow.JSZip);
+  if (jszipLoad) return jszipLoad;
+  jszipLoad = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = '/vendor/jszip.min.js';
+    script.onload = () => appWindow.JSZip ? resolve(appWindow.JSZip) : reject(new Error('JSZip failed to load'));
+    script.onerror = () => reject(new Error('Failed to load /vendor/jszip.min.js'));
+    document.head.appendChild(script);
+  }).catch(err => {
+    jszipLoad = null;
+    throw err;
+  });
+  return jszipLoad;
+}
+
+export function cycleFileKind(file) {
+  const name = String(file?.name || '').toLowerCase();
+  if (name.endsWith('.zip') || /zip/.test(file?.type || '')) return 'zip';
+  if (name.endsWith('.xml') || /xml/.test(file?.type || '')) return 'xml';
+  if (name.endsWith('.json') || name.endsWith('.cluedata') || file?.type === 'application/json') return 'json';
+  if (name.endsWith('.csv') || file?.type === 'text/csv') return 'csv';
+  return 'text';
+}
+
+export async function buildCycleFileContext(file) {
+  const kind = cycleFileKind(file);
+  const context = { file, kind, text: null, archive: null, entries: [] };
+  if (kind === 'zip') {
+    const JSZip = await loadJSZip();
+    try {
+      context.archive = await JSZip.loadAsync(file);
+    } catch (err) {
+      if (/encrypt|password/i.test(String(err?.message || err))) {
+        throw new Error('This cycle ZIP is password-protected. Extract it first, then import the Clue JSON file inside.');
+      }
+      throw err;
+    }
+    context.entries = Object.values(context.archive.files || {}).filter(entry => !entry.dir);
+  } else if (kind !== 'xml') {
+    context.text = await file.text();
+  }
+  return context;
+}
+
+export function appleHealthArchiveEntry(context) {
+  return context.entries.find(entry => {
+    const name = String(entry.name || '').toLowerCase();
+    return name === 'export.xml' || name === 'apple_health_export/export.xml';
+  }) || null;
+}
+
+export function clueArchiveEntries(context) {
+  return context.entries.filter(entry => /(?:\.json|\.cluedata)$/i.test(entry.name || '') || /clue/i.test(entry.name || ''));
+}
+
+export function naturalCyclesArchiveEntries(context) {
+  return context.entries.filter(entry => /\.csv$/i.test(entry.name || ''));
+}

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -365,6 +365,10 @@ export async function isCycleImportFile(file) {
 export async function parseCycleImportFile(file) {
   if (!file) return null;
   const context = await buildCycleFileContext(file);
+  return parseCycleImportContext(context);
+}
+
+async function parseCycleImportContext(context) {
   for (const adapter of CYCLE_IMPORT_ADAPTERS) {
     if (!await adapter.detect(context)) continue;
     const parsed = await adapter.parse(context);
@@ -744,10 +748,25 @@ export function installCycleImportDelegates() {
 
 export async function handleCycleImportFile(file) {
   let parsed = null;
+  let importLabel = 'Cycle';
   try {
-    parsed = await parseCycleImportFile(file);
+    const context = await buildCycleFileContext(file);
+    const appleHealthEntry = context.kind === 'zip' ? appleHealthArchiveEntry(context) : null;
+    if (context.kind === 'xml' || appleHealthEntry) {
+      importLabel = 'Apple Health';
+      const xmlBlob = context.kind === 'xml' ? context.file : await appleHealthEntry.async('blob');
+      const { importAppleHealthFile } = await import('./wearables-apple-health.js');
+      showNotification('Importing Apple Health data...', 'info', 1600);
+      const result = await importAppleHealthFile(file, null, { xmlBlob });
+      const cycleSuffix = result.cycleImport ? ` + ${result.cycleImport.periods} cycle periods` : '';
+      showNotification(`Apple Health imported - ${result.rows} days${cycleSuffix}`, 'success', 3000);
+      if (result.cycleError) showNotification(`Cycle import skipped: ${result.cycleError}`, 'info', 5000);
+      appWindow.navigate?.('dashboard');
+      return true;
+    }
+    parsed = await parseCycleImportContext(context);
   } catch (err) {
-    showNotification(`Cycle import failed: ${err.message}`, 'error');
+    showNotification(`${importLabel} import failed: ${err.message}`, 'error');
     return false;
   }
   if (!parsed) {

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -23,6 +23,13 @@ import {
   parseNaturalCyclesCsvBundle,
 } from './cycle-import-adapters.js';
 import {
+  appleHealthArchiveEntry,
+  buildCycleFileContext,
+  clueArchiveEntries,
+  cycleFileKind,
+  naturalCyclesArchiveEntries,
+} from './cycle-import-file.js';
+import {
   clearCycleImport,
   clearCycleDB,
   clearCycleSource,
@@ -56,7 +63,6 @@ const appWindow = /** @type {Window & typeof globalThis & {
   navigate?: (category: string) => void,
   renderProfileButton?: () => void,
   closeModal?: () => void,
-  JSZip?: any,
 }} */ (typeof window !== 'undefined' ? window : {});
 
 let pendingCycleImport = null;
@@ -243,68 +249,8 @@ export async function parseAppleHealthCycleBlob(blob, fileName = 'apple-health-e
   return finalizeAppleHealthCycleImport(byKey, fileName);
 }
 
-let jszipLoad = null;
-function loadJSZip() {
-  if (appWindow.JSZip) return Promise.resolve(appWindow.JSZip);
-  if (jszipLoad) return jszipLoad;
-  jszipLoad = new Promise((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = '/vendor/jszip.min.js';
-    script.onload = () => appWindow.JSZip ? resolve(appWindow.JSZip) : reject(new Error('JSZip failed to load'));
-    script.onerror = () => reject(new Error('Failed to load /vendor/jszip.min.js'));
-    document.head.appendChild(script);
-  }).catch(err => {
-    jszipLoad = null;
-    throw err;
-  });
-  return jszipLoad;
-}
-
-function cycleFileKind(file) {
-  const name = String(file?.name || '').toLowerCase();
-  if (name.endsWith('.zip') || /zip/.test(file?.type || '')) return 'zip';
-  if (name.endsWith('.xml') || /xml/.test(file?.type || '')) return 'xml';
-  if (name.endsWith('.json') || name.endsWith('.cluedata') || file?.type === 'application/json') return 'json';
-  if (name.endsWith('.csv') || file?.type === 'text/csv') return 'csv';
-  return 'text';
-}
 export function isAppleHealthCycleFile(file) {
   return cycleFileKind(file) === 'xml';
-}
-
-async function buildCycleFileContext(file) {
-  const kind = cycleFileKind(file);
-  const context = { file, kind, text: null, archive: null, entries: [] };
-  if (kind === 'zip') {
-    const JSZip = await loadJSZip();
-    try {
-      context.archive = await JSZip.loadAsync(file);
-    } catch (err) {
-      if (/encrypt|password/i.test(String(err?.message || err))) {
-        throw new Error('This cycle ZIP is password-protected. Extract it first, then import the Clue JSON file inside.');
-      }
-      throw err;
-    }
-    context.entries = Object.values(context.archive.files || {}).filter(entry => !entry.dir);
-  } else if (kind !== 'xml') {
-    context.text = await file.text();
-  }
-  return context;
-}
-
-function appleHealthArchiveEntry(context) {
-  return context.entries.find(entry => {
-    const name = String(entry.name || '').toLowerCase();
-    return name === 'export.xml' || name === 'apple_health_export/export.xml';
-  }) || null;
-}
-
-function clueArchiveEntries(context) {
-  return context.entries.filter(entry => /(?:\.json|\.cluedata)$/i.test(entry.name || '') || /clue/i.test(entry.name || ''));
-}
-
-function naturalCyclesArchiveEntries(context) {
-  return context.entries.filter(entry => /\.csv$/i.test(entry.name || ''));
 }
 
 export const CYCLE_IMPORT_ADAPTERS = Object.freeze([

--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -35,13 +35,15 @@ export async function importAppleHealthFile(file, onProgress, options = {}) {
   onProgress?.({ stage: 'reading', pct: 0 });
 
   const name = (file.name || '').toLowerCase();
-  let xmlBlob;
-  if (name.endsWith('.zip') || file.type === 'application/zip' || file.type === 'application/x-zip-compressed') {
-    xmlBlob = await extractExportXmlBlob(file, onProgress);
-  } else if (name.endsWith('.xml') || file.type === 'application/xml' || file.type === 'text/xml') {
-    xmlBlob = file;
-  } else {
-    throw new Error(`Unrecognised file type (got "${name}") — expected Apple Health export.zip or export.xml`);
+  let xmlBlob = options.xmlBlob || null;
+  if (!xmlBlob) {
+    if (name.endsWith('.zip') || file.type === 'application/zip' || file.type === 'application/x-zip-compressed') {
+      xmlBlob = await extractExportXmlBlob(file, onProgress);
+    } else if (name.endsWith('.xml') || file.type === 'application/xml' || file.type === 'text/xml') {
+      xmlBlob = file;
+    } else {
+      throw new Error(`Unrecognised file type (got "${name}") — expected Apple Health export.zip or export.xml`);
+    }
   }
   if (!xmlBlob || xmlBlob.size === 0) throw new Error('Empty XML payload');
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -134,6 +134,7 @@ const APP_SHELL = [
   '/js/supplements.js',
   '/js/supplement-impact.js',
   '/js/cycle-import-adapters.js',
+  '/js/cycle-import-file.js',
   '/js/cycle-import.js',
   '/js/cycle-store.js',
   '/js/cycle-summary.js',

--- a/tests/playwright/cycle-import-browser-coverage.spec.js
+++ b/tests/playwright/cycle-import-browser-coverage.spec.js
@@ -28,6 +28,9 @@ const CLUE_JSON = JSON.stringify({
 });
 
 const APPLE_HEALTH_CYCLE_XML = `<HealthData>
+  <Record type="HKQuantityTypeIdentifierHeartRateVariabilitySDNN" unit="ms" sourceName="Watch" startDate="2026-03-01 01:00:00 +0000" value="47" />
+  <Record type="HKQuantityTypeIdentifierRestingHeartRate" unit="count/min" sourceName="Watch" startDate="2026-03-01 07:00:00 +0000" value="58" />
+  <Record type="HKQuantityTypeIdentifierBodyMass" unit="kg" sourceName="Scale" startDate="2026-03-01 08:00:00 +0000" value="68.5" />
   <Record type="HKCategoryTypeIdentifierMenstrualFlow" value="HKCategoryValueMenstrualFlowLight" startDate="2026-03-01 08:00:00 +0000" />
   <Record type="HKCategoryTypeIdentifierMenstrualFlow" value="HKCategoryValueMenstrualFlowHeavy" startDate="2026-03-02 08:00:00 +0000" />
 </HealthData>`;
@@ -228,6 +231,70 @@ test('Apple Health Settings import closes Settings before showing cycle review',
     await (await import('/js/cycle-store.js')).deleteCycleDB(id).catch(() => {});
     await (await import('/js/wearables-store.js')).deleteWearablesDB(id).catch(() => {});
   }, profileId);
+});
+
+test('shared Apple Health ZIP import saves wearable metrics before cycle review', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+  const profileId = await initializeCycleProfile(page, 'apple_health_shared_import');
+  await page.addScriptTag({ url: '/vendor/jszip.min.js' });
+  const zipBase64 = await page.evaluate(async xml => {
+    const zip = new window.JSZip();
+    zip.file('apple_health_export/export.xml', xml);
+    return zip.generateAsync({ type: 'base64' });
+  }, APPLE_HEALTH_CYCLE_XML);
+
+  await page.locator('#pdf-input').setInputFiles({
+    name: 'export.zip',
+    mimeType: 'application/zip',
+    buffer: Buffer.from(zipBase64, 'base64'),
+  });
+
+  const preview = page.locator('#import-modal-overlay');
+  await expect(preview).toHaveClass(/show/);
+  await expect(page.locator('#import-modal')).toContainText('Apple Health');
+
+  const wearableImport = await page.evaluate(async id => {
+    const [{ state }, store] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/wearables-store.js'),
+    ]);
+    const row = await store.getDaily(id, 'apple_health', '2026-03-01');
+    return {
+      row,
+      connection: state.importedData.wearableConnections?.apple_health,
+    };
+  }, profileId);
+  expect(wearableImport.row).toMatchObject({
+    hrv_sdnn: 47,
+    rhr: 58,
+    weight: 68.5,
+  });
+  expect(wearableImport.connection).toMatchObject({
+    source: 'file-import',
+    fileName: 'export.zip',
+    coverageDays: 1,
+  });
+
+  await page.locator('[data-cycle-import-action="confirm"]').click();
+  await expect(preview).not.toHaveClass(/show/);
+  await expect.poll(() => page.evaluate(() => window._labState.importedData.menstrualCycle?.periods?.length || 0)).toBe(1);
+
+  const periods = await page.evaluate(id => {
+    const result = window._labState.importedData.menstrualCycle.periods.map(period => ({
+      startDate: period.startDate,
+      endDate: period.endDate,
+      source: period.source,
+    }));
+    return Promise.all([
+      import('/js/cycle-store.js').then(store => store.deleteCycleDB(id).catch(() => {})),
+      import('/js/wearables-store.js').then(store => store.deleteWearablesDB(id).catch(() => {})),
+    ]).then(() => result);
+  }, profileId);
+  expect(periods).toEqual([{
+    startDate: '2026-03-01',
+    endDate: '2026-03-02',
+    source: 'apple_health',
+  }]);
 });
 
 test('Body cycle action opens the contextual cycle picker', async ({ page }, testInfo) => {

--- a/tests/test-audit.js
+++ b/tests/test-audit.js
@@ -89,6 +89,7 @@ assert('SW APP_SHELL includes modal lifecycle module', swAuditSrc.includes("'/js
 assert('SW APP_SHELL includes marker analysis module', swAuditSrc.includes("'/js/marker-analysis.js'"));
 assert('SW APP_SHELL includes cycle import modules',
   swAuditSrc.includes("'/js/cycle-import-adapters.js'")
+  && swAuditSrc.includes("'/js/cycle-import-file.js'")
   && swAuditSrc.includes("'/js/cycle-import.js'")
   && swAuditSrc.includes("'/js/cycle-store.js'")
   && swAuditSrc.includes("'/js/cycle-summary.js'"));

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -396,6 +396,7 @@
     "js/commit-hash.js",
     "js/compare-correlations.js",
     "js/cycle-import-adapters.js",
+    "js/cycle-import-file.js",
     "js/cycle-import.js",
     "js/cycle-store.js",
     "js/cycle-summary.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.182';
+self.APP_VERSION = '1.10.183';


### PR DESCRIPTION
## Summary

- Route Apple Health XML and ZIP files selected through the shared importer into the complete wearable import pipeline before cycle review.
- Reuse the already extracted Apple Health XML blob so shared ZIP imports are not decompressed twice.
- Add browser regression coverage proving HRV, resting heart rate, weight, Apple connection metadata, and menstrual-cycle periods all persist from one export.
- Bump the app version to 1.10.183 and document the fix in What's New.

## Root cause

Menstrual-cycle import support classified every Apple Health XML/ZIP as a cycle file. The shared input and drop-zone then called the cycle-only handler, which never invoked the wearable importer, so HR, HRV, weight, body composition, and connection metadata were skipped.

## User impact

Apple Health exports now behave consistently whether imported from Settings or the main import control. Supported wearable metrics are saved locally first, and menstrual-cycle data still receives its review step.

## Validation

- `npx vitest run tests/cycle-import-phase1.test.js tests/import-file-input-runtime.test.js` — 31 passed
- Apple Health/cycle Playwright coverage — 10 passed
- `./run-tests.sh` — type checks, vendor checks, Node/Vitest suites, the Apple Health regression, and 350/351 browser tests passed. One unrelated external-lens cache timing assertion failed under full-suite load and passed when rerun alone.
