### PR TITLE
Keep Biology Scores unlocked

### DIFF
--- a/js/biology-score-context-ai.js
+++ b/js/biology-score-context-ai.js
@@ -242,18 +242,12 @@ export function hasCurrentBiologyScoreContextReview(data) {
   return review.range === range && review.fingerprint === expected;
 }
 
-export function hasBiologyScoreContextReview(data = null) {
+export function hasBiologyScoreContextReview(_data = null) {
   const review = (/** @type {any} */ (state.importedData))?.biologyScoreContextAI;
-  if (!review?.updatedAt) return false;
-  if (!data) return true;
-  if (hasCurrentBiologyScoreContextReview(data)) return true;
-  const range = state.dateRangeFilter || 'all';
-  const expected = buildBiologyScoreContextMaterialSignature(data, range);
-  if (review.contextSignaturesByRange && typeof review.contextSignaturesByRange === 'object') {
-    return review.contextSignaturesByRange[range] === expected;
-  }
-  if (review.contextSignature) return review.range === range && review.contextSignature === expected;
-  return false;
+  // A completed review is a one-time availability gate. Context freshness is
+  // tracked separately so changing data or app-side fingerprint logic can ask
+  // for a refresh without hiding scores the user has already unlocked.
+  return !!review?.updatedAt;
 }
 
 function buildReviewContext(data) {
@@ -343,7 +337,7 @@ export function renderBiologyScoreContextAI(data = null) {
   const current = data ? hasCurrentBiologyScoreContextReview(data) : !!review?.updatedAt;
   const hasReview = !!review?.updatedAt;
   const buttonLabel = hasReview ? 'Refresh check' : 'Unlock Biology Scores';
-  const status = current ? 'Context is up to date.' : hasReview ? 'Context needs a refresh.' : 'Context check required.';
+  const status = current ? 'Context is up to date.' : hasReview ? 'Context changed. Refresh recommended; your scores stay available.' : 'Context check required.';
   return `<section class="biology-context-ai-panel${current ? '' : ' biology-context-ai-required'}">
     <div class="biology-context-ai-head"><div><div class="biology-scores-eyebrow">Context check</div><p>Review the context used by Biology Scores.</p></div><button type="button" class="dashboard-action-btn dashboard-action-btn-primary" data-biology-score-action="analyze-context-ai">${buttonLabel}</button></div>
     <p class="biology-scores-note">${escapeHTML(status)}</p>

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,6 +11,12 @@ const changelogDelegateRoots = new WeakSet();
 
 const CHANGELOG = [
   {
+    version: '1.10.185', date: '2026-07-14', title: 'Biology Scores stay unlocked',
+    items: [
+      '<b>Biology Scores no longer relock after app or health-context updates.</b> Once you complete the context check, scores stay visible and changed context appears as a refresh recommendation.',
+    ]
+  },
+  {
     version: '1.10.184', date: '2026-07-14', title: 'Smoother updates and more reliable health tracking',
     items: [
       '<b>App updates are lighter and stay under your control.</b> Returning visits reuse installed files, while a small check lets you know when a new version is ready.',

--- a/js/lens-pages.js
+++ b/js/lens-pages.js
@@ -166,7 +166,7 @@ export function createLensPageHandlers(deps) {
   function renderBiologyScoreContextStatus(scoreData) {
     const review = state.importedData?.biologyScoreContextAI;
     const suggestions = Array.isArray(review?.suggestions) ? review.suggestions.length : 0;
-    const status = hasCurrentBiologyScoreContextReview(scoreData) ? 'Context checked' : 'Context needs refresh';
+    const status = hasCurrentBiologyScoreContextReview(scoreData) ? 'Context checked' : 'Context changed · refresh recommended';
     const contextMeta = suggestions
       ? `${suggestions} suggested context ${suggestions === 1 ? 'flag' : 'flags'}`
       : 'No suggested context flags';

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -641,37 +641,46 @@ assert('one Biology Scores context check unlocks all timeframe tabs', rangeUnloc
 const staleReview = { summary: 'Older context check kept usable', suggestions: [], fingerprint: 'biology-context:old-app-build', contextSignature: buildBiologyScoreContextMaterialSignature(data), contextSignaturesByRange: buildBiologyScoreContextMaterialSignaturesByRange(data), range: 'all', updatedAt: Date.now() - 86400000 };
 state.importedData.biologyScoreContextAI = staleReview;
 const staleWidgetHtml = renderDashboardBiologicalCoherenceWidget({ data });
-assert('stale Biology Scores fingerprint keeps scores visible only when the material context signature still matches',
+assert('stale Biology Scores fingerprint keeps scores visible after the first context review',
   !hasCurrentBiologyScoreContextReview(data) && !staleWidgetHtml.includes('Biology Scores locked') && staleWidgetHtml.includes('db-bio-coherence-hero'),
   staleWidgetHtml);
 state.importedData.supplements = [{ name: 'TRT note', dose: 'hormone therapy; low muscle mass; acute illness near draw', startDate: '2026-06-10', notes: 'context modifier terms' }];
 const supplementChangedWidgetHtml = renderDashboardBiologicalCoherenceWidget({ data });
-assert('changed supplement context invalidates stale Biology Scores material signature before old context flags can unlock scores',
-  supplementChangedWidgetHtml.includes('Biology Scores locked'),
+assert('changed supplement context keeps Biology Scores visible and recommends a context refresh',
+  buildBiologyScoreContextMaterialSignature(data) !== staleReview.contextSignature
+    && !supplementChangedWidgetHtml.includes('Biology Scores locked')
+    && supplementChangedWidgetHtml.includes('db-bio-coherence-hero')
+    && renderBiologyScoreContextAI(data).includes('Context changed. Refresh recommended; your scores stay available.'),
   supplementChangedWidgetHtml);
 state.importedData.supplements = [{ name: 'Long supplement note', notes: `${'safe context '.repeat(30)} baseline tail` }];
 const longSupplementReview = { ...staleReview, contextSignature: buildBiologyScoreContextMaterialSignature(data), contextSignaturesByRange: buildBiologyScoreContextMaterialSignaturesByRange(data) };
 state.importedData.biologyScoreContextAI = longSupplementReview;
 state.importedData.supplements = [{ name: 'Long supplement note', notes: `${'safe context '.repeat(30)} hormone therapy low muscle mass acute illness near draw` }];
 const longSupplementChangedWidgetHtml = renderDashboardBiologicalCoherenceWidget({ data });
-assert('supplement material signature includes text beyond old truncation boundaries',
-  longSupplementChangedWidgetHtml.includes('Biology Scores locked'),
+assert('long supplement context changes do not relock Biology Scores',
+  buildBiologyScoreContextMaterialSignature(data) !== longSupplementReview.contextSignature
+    && !longSupplementChangedWidgetHtml.includes('Biology Scores locked')
+    && longSupplementChangedWidgetHtml.includes('db-bio-coherence-hero'),
   longSupplementChangedWidgetHtml);
-state.importedData.supplements = Array.from({ length: 31 }, (_, i) => ({ name: `Supplement ${i + 1}`, notes: i === 30 ? 'hormone therapy low muscle mass acute illness near draw' : 'ordinary' }));
+state.importedData.supplements = Array.from({ length: 31 }, (_, i) => ({ name: `Supplement ${i + 1}`, notes: 'ordinary' }));
+const overflowSupplementBaselineSignature = buildBiologyScoreContextMaterialSignature(data);
+state.importedData.supplements[30].notes = 'hormone therapy low muscle mass acute illness near draw';
 const overflowSupplementChangedWidgetHtml = renderDashboardBiologicalCoherenceWidget({ data });
-assert('supplement material signature includes score-relevant items beyond the old first-30 cap',
-  overflowSupplementChangedWidgetHtml.includes('Biology Scores locked'),
+assert('additional supplement context items do not relock Biology Scores',
+  buildBiologyScoreContextMaterialSignature(data) !== overflowSupplementBaselineSignature
+    && !overflowSupplementChangedWidgetHtml.includes('Biology Scores locked')
+    && overflowSupplementChangedWidgetHtml.includes('db-bio-coherence-hero'),
   overflowSupplementChangedWidgetHtml);
 delete state.importedData.supplements;
 state.importedData.biologyScoreContextAI = { summary: 'Legacy context review kept usable', suggestions: [], fingerprint: 'biology-context:old-app-build', range: 'all', updatedAt: Date.now() - 86400000 };
 const legacyStaleWidgetHtml = renderDashboardBiologicalCoherenceWidget({ data });
-assert('legacy Biology Scores reviews without material signatures lock on stale fingerprints because changed labs/profile context cannot be ruled out',
-  !hasCurrentBiologyScoreContextReview(data) && legacyStaleWidgetHtml.includes('Biology Scores locked'),
+assert('legacy Biology Scores reviews remain unlocked when their fingerprint becomes stale',
+  !hasCurrentBiologyScoreContextReview(data) && !legacyStaleWidgetHtml.includes('Biology Scores locked') && legacyStaleWidgetHtml.includes('db-bio-coherence-hero'),
   legacyStaleWidgetHtml);
 state.importedData.biologyScoreContextAI = { ...staleReview, contextSignature: 'biology-context-material:different', contextSignaturesByRange: { all: 'biology-context-material:different' } };
 const mismatchedWidgetHtml = renderDashboardBiologicalCoherenceWidget({ data });
-assert('mismatched Biology Scores material context locks instead of trusting any review timestamp',
-  mismatchedWidgetHtml.includes('Biology Scores locked'),
+assert('mismatched Biology Scores material context requests refresh without relocking scores',
+  !mismatchedWidgetHtml.includes('Biology Scores locked') && mismatchedWidgetHtml.includes('db-bio-coherence-hero'),
   mismatchedWidgetHtml);
 state.importedData.biologyScoreContextAI = { summary: 'Context checked for tests', suggestions: [], fingerprint: buildBiologyScoreContextFingerprint(data), fingerprintsByRange: buildBiologyScoreContextFingerprintsByRange(data), contextSignature: buildBiologyScoreContextMaterialSignature(data), contextSignaturesByRange: buildBiologyScoreContextMaterialSignaturesByRange(data), unlockedRanges: ['all', '1y', '6m', '3m'], range: state.dateRangeFilter || 'all', updatedAt: Date.now() };
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.184';
+self.APP_VERSION = '1.10.185';


### PR DESCRIPTION
## What changed

- make the Biology Scores context review a one-time availability gate
- keep scores visible when labs, wearables, light history, profile context, or app-side fingerprint logic changes
- retain fingerprint freshness checks and show a non-blocking refresh recommendation
- add regression coverage for stale and legacy reviews, context changes, and material-signature detection
- bump the app version to 1.10.185 and add user-facing release notes

## Root cause

The unlock check treated context fingerprint mismatches as an availability failure. Those fingerprints include rolling health context and derived app-side summaries, so normal data refreshes and releases could invalidate an earlier review and hide Biology Scores again.

## User impact

Users still complete one context check before seeing Biology Scores. After that, scores remain available; changed context is surfaced as a refresh recommendation instead of relocking the feature.

## Validation

- `./run-tests.sh`
- targeted Biology Scores regression suite: 216 passed
- Vitest: 396 passed
- Playwright: 351 passed
