### PR TITLE
Reduce legacy window facades

### DIFF
--- a/js/api-local.js
+++ b/js/api-local.js
@@ -2,12 +2,11 @@
 // api-local.js - Ollama/LM Studio/Jan provider adapters.
 
 import { readWithStallTimeout } from './api-transport.js';
-import { getOllamaMainModel } from './api-provider-storage.js';
-import { getOllamaConfigRuntime } from './api-runtime.js';
+import { getOllamaConfig, getOllamaMainModel } from './api-provider-storage.js';
 import { callOpenAICompatibleAPI } from './api-openai-compatible.js';
 
 export async function callOllamaChat({ system, messages, maxTokens, onStream, signal }) {
-  const config = getOllamaConfigRuntime();
+  const config = getOllamaConfig();
   const model = getOllamaMainModel();
   const ollamaMessages = [];
   if (system) ollamaMessages.push({ role: 'system', content: system });
@@ -104,7 +103,7 @@ export async function callOllamaChat({ system, messages, maxTokens, onStream, si
 }
 
 export async function callOpenAICompatibleLocalAPI(opts) {
-  const config = getOllamaConfigRuntime();
+  const config = getOllamaConfig();
   const model = getOllamaMainModel();
   const url = config.url.replace(/\/+$/, '');
   const key = config.apiKey || 'not-needed';

--- a/js/api-provider-storage-runtime.js
+++ b/js/api-provider-storage-runtime.js
@@ -49,9 +49,3 @@ export function touchRoutstrSessionClock() {
   localStorage.setItem('labcharts-routstr-session-updated-at', String(updatedAt));
   return updatedAt;
 }
-
-export function getOllamaConfigStorageRuntime() {
-  const getOllamaConfig = getRuntimeFunction('getOllamaConfig');
-  if (!getOllamaConfig) return {};
-  return getOllamaConfig() || {};
-}

--- a/js/api-provider-storage.js
+++ b/js/api-provider-storage.js
@@ -4,7 +4,6 @@
 import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
 import {
   dispatchAISettingsLocalChangedRuntime,
-  getOllamaConfigStorageRuntime,
   refreshAIProviderSelectionRuntime,
   touchRoutstrSessionClock,
 } from './api-provider-storage-runtime.js';
@@ -42,13 +41,25 @@ export function hasAIProvider() {
   return true; // Ollama — optimistic, errors caught at call time
 }
 
-export function getOllamaMainModel() { return localStorage.getItem('labcharts-ollama-model') || getOllamaConfigStorageRuntime().model || 'llama3.2'; }
+export function getOllamaConfig() {
+  const defaults = { url: 'http://localhost:11434', model: 'llama3.2', mode: 'ollama', apiKey: '' };
+  try { return { ...defaults, ...JSON.parse(getCachedKey('labcharts-ollama')) }; }
+  catch { return defaults; }
+}
+export async function saveOllamaConfig(config) {
+  const json = JSON.stringify(config);
+  await encryptedSetItem('labcharts-ollama', json);
+  updateKeyCache('labcharts-ollama', json);
+  markAISettingsLocal();
+}
+
+export function getOllamaMainModel() { return localStorage.getItem('labcharts-ollama-model') || getOllamaConfig().model || 'llama3.2'; }
 export function setOllamaMainModel(model) {
   localStorage.setItem('labcharts-ollama-model', model);
   markAISettingsLocal();
   notifyAISelectionChanged();
 }
-export function getOllamaPIIUrl() { return localStorage.getItem('labcharts-ollama-pii-url') || getOllamaConfigStorageRuntime().url; }
+export function getOllamaPIIUrl() { return localStorage.getItem('labcharts-ollama-pii-url') || getOllamaConfig().url; }
 export function setOllamaPIIUrl(url) {
   localStorage.setItem('labcharts-ollama-pii-url', url);
   markAISettingsLocal();

--- a/js/api-runtime.js
+++ b/js/api-runtime.js
@@ -26,14 +26,6 @@ export function setApiLocationHrefRuntime(url) {
   return true;
 }
 
-export function getOllamaConfigRuntime() {
-  const runtime = getApiRuntime();
-  if (!runtime || typeof runtime.getOllamaConfig !== 'function') {
-    throw new Error('Ollama config runtime is unavailable.');
-  }
-  return runtime.getOllamaConfig();
-}
-
 export function showOpenRouterInsufficientBalanceDialogRuntime() {
   const runtime = getApiRuntime();
   if (!runtime?.showInsufficientBalanceDialog) return false;

--- a/js/api.js
+++ b/js/api.js
@@ -37,6 +37,8 @@ export {
   setAIPaused,
   markAISettingsLocal,
   hasAIProvider,
+  getOllamaConfig,
+  saveOllamaConfig,
   getOllamaMainModel,
   setOllamaMainModel,
   getOllamaPIIUrl,

--- a/js/charts.js
+++ b/js/charts.js
@@ -660,7 +660,3 @@ export function getMarkerDescription(markerId) {
   const cache = JSON.parse(localStorage.getItem('labcharts-marker-desc') || '{}');
   return cache[markerId] || null;
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, { refBandPlugin, optimalBandPlugin, noteAnnotationPlugin, supplementBarPlugin, phaseBandPlugin, getNotesForChart, getSupplementsForChart, createLineChart, refreshChartThemeColors, getMarkerDescription, ensureChartJs, isChartDateAdapterReady });
-}

--- a/js/pii.js
+++ b/js/pii.js
@@ -2,8 +2,7 @@
 // pii.js — PII obfuscation (Ollama + regex), diff viewer
 
 import { showNotification, escapeHTML } from './utils.js';
-import { getOllamaPIIModel, getOllamaPIIUrl, markAISettingsLocal } from './api.js';
-import { getCachedKey, updateKeyCache, encryptedSetItem } from './crypto.js';
+import { getOllamaConfig, getOllamaPIIModel, getOllamaPIIUrl } from './api.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
 import { state } from './state.js';
 
@@ -48,21 +47,6 @@ export function fakeDate() {
   return `${String(d).padStart(2,'0')}.${String(m).padStart(2,'0')}.${y}`;
 }
 export function fakePatientId() { return randomDigits(10); }
-
-// ═══════════════════════════════════════════════
-// OLLAMA INTEGRATION
-// ═══════════════════════════════════════════════
-export function getOllamaConfig() {
-  const defaults = { url: 'http://localhost:11434', model: 'llama3.2', mode: 'ollama', apiKey: '' };
-  try { return { ...defaults, ...JSON.parse(getCachedKey('labcharts-ollama')) }; }
-  catch { return defaults; }
-}
-export async function saveOllamaConfig(config) {
-  const json = JSON.stringify(config);
-  await encryptedSetItem('labcharts-ollama', json);
-  updateKeyCache('labcharts-ollama', json);
-  markAISettingsLocal();
-}
 
 export async function checkOllama(url) {
   const baseUrl = url || getOllamaConfig().url;
@@ -851,5 +835,3 @@ export function reviewPIIBeforeSend(originalText, { obfuscatedText = '', streamF
     }
   });
 }
-
-Object.assign(window, { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend, getOllamaConfig, checkOllama, checkOpenAICompatible, showPIIDiffViewer, isOllamaPIIEnabled, setOllamaPIIEnabled });

--- a/js/profile-share.js
+++ b/js/profile-share.js
@@ -742,16 +742,5 @@ export function initProfileShareLinks() {
 }
 
 if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    openProfileShareModal,
-    closeProfileShareModal,
-    openSharedProfileImportModal,
-    createProfileShare,
-    deleteProfileShareEnvelope,
-    encryptProfileShareEnvelope,
-    decryptProfileShareEnvelope,
-    parseProfileShareIdFromLocation,
-    buildProfileShareUrl,
-  });
   initProfileShareLinks();
 }

--- a/js/provider-local-ai-controls.js
+++ b/js/provider-local-ai-controls.js
@@ -3,14 +3,16 @@
 
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import {
+  getOllamaConfig,
   getOllamaMainModel,
   getOllamaPIIModel,
   getOllamaPIIUrl,
+  saveOllamaConfig,
   setOllamaMainModel,
   setOllamaPIIModel,
   setOllamaPIIUrl,
 } from './api.js';
-import { getOllamaConfig, checkOllama, checkOpenAICompatible, saveOllamaConfig, setOllamaPIIEnabled } from './pii.js';
+import { checkOllama, checkOpenAICompatible, setOllamaPIIEnabled } from './pii.js';
 import { detectHardware, assessModel, assessFitness, getBestModel, getUpgradeSuggestion, saveHardwareOverride, getHardwareOverride } from './hardware.js';
 import {
   cacheLocalAiModelDetails,

--- a/js/provider-panel-renderers.js
+++ b/js/provider-panel-renderers.js
@@ -12,9 +12,9 @@ import {
   getVeniceE2EE, setVeniceE2EE, isVeniceE2EEActive,
   getVeniceModelDisplay, getOpenRouterModelDisplay,
   getRoutstrModelDisplay, getPpqModelDisplay,
-  renderModelPricingHint, isRecommendedModel
+  renderModelPricingHint, isRecommendedModel,
+  getOllamaConfig
 } from './api.js';
-import { getOllamaConfig } from './pii.js';
 import { buildRoutstrNodeActions, routstrWalletActionButtons } from './provider-wallet-panels.js';
 import {
   discoverRoutstrNodesFromRuntime,

--- a/js/settings-privacy.js
+++ b/js/settings-privacy.js
@@ -1,8 +1,8 @@
 // @ts-check
 // settings-privacy.js - Settings privacy and Sun data-source controls.
 
-import { getOllamaPIIUrl, getOllamaPIIModel } from './api.js';
-import { isOllamaPIIEnabled, setOllamaPIIEnabled, getOllamaConfig, checkOpenAICompatible } from './pii.js';
+import { getOllamaConfig, getOllamaPIIUrl, getOllamaPIIModel } from './api.js';
+import { isOllamaPIIEnabled, setOllamaPIIEnabled, checkOpenAICompatible } from './pii.js';
 import { escapeAttr, isPIIReviewEnabled, isAnalyticsEnabled, showNotification } from './utils.js';
 import {
   getSettingsMeteoConfig,

--- a/js/settings-runtime.js
+++ b/js/settings-runtime.js
@@ -69,11 +69,6 @@ export function refreshSettingsRuntimeSurfaces(options = {}) {
   if (options.settingsVisible) runtime.refreshSettingsWearables?.();
 }
 
-/** @param {{ batchSize?: number }} [options] */
-export function refreshSettingsChartThemeColors(options = {}) {
-  getRuntimeFunction('refreshChartThemeColors')?.(options);
-}
-
 export function getSettingsMeteoConfig() {
   const getMeteoConfig = getRuntimeFunction('getMeteoConfig');
   if (!getMeteoConfig) return { ...DEFAULT_METEO_CONFIG };

--- a/js/settings.js
+++ b/js/settings.js
@@ -2,6 +2,7 @@
 // settings.js — Settings modal (profile, display, AI provider, privacy)
 
 import { state } from './state.js';
+import { refreshChartThemeColors } from './charts.js';
 import { escapeHTML, escapeAttr, isDebugMode, setDebugMode, setAnalyticsEnabled, showNotification, showConfirmDialog } from './utils.js';
 import { getTheme, setTheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, getTimeFormat, setTimeFormat, THEMES } from './theme.js';
 import { switchUnitSystem, toggleAltUnits, switchRangeMode } from './data.js';
@@ -16,7 +17,6 @@ import {
   addSettingsRuntimeEventListener,
   cancelSettingsFrame,
   publishSettingsGlobals,
-  refreshSettingsChartThemeColors,
   refreshSettingsRuntimeSurfaces,
   requestSettingsFrame,
   settingsMediaMatches,
@@ -60,7 +60,7 @@ const settingsRuntime = {
   exportAllDataJSON: () => settingsWindow.exportAllDataJSON?.(),
   exportClientJSON: (profileId) => settingsWindow.exportClientJSON?.(profileId),
   getActiveProfileId: () => settingsWindow.getActiveProfileId?.() || null,
-  openProfileShareModal: (profileId) => settingsWindow.openProfileShareModal?.(profileId),
+  openProfileShareModal: () => {},
 };
 
 /** @param {Partial<SettingsRuntime>} [runtime] */
@@ -174,7 +174,7 @@ let chartThemeRefreshTimer = 0;
 function scheduleChartThemeRefresh() {
   if (chartThemeRefreshFrame) cancelSettingsFrame(chartThemeRefreshFrame);
   if (chartThemeRefreshTimer) clearTimeout(chartThemeRefreshTimer);
-  const refresh = () => refreshSettingsChartThemeColors({ batchSize: 4 });
+  const refresh = () => refreshChartThemeColors({ batchSize: 4 });
   const frame = requestSettingsFrame(() => {
     chartThemeRefreshFrame = 0;
     chartThemeRefreshTimer = setTimeout(() => {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 25,
-  "legacyWindowGlobalAssignments": 23,
+  "windowGlobalAssignments": 22,
+  "legacyWindowGlobalAssignments": 20,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/api-provider-contracts.test.js
+++ b/tests/api-provider-contracts.test.js
@@ -43,9 +43,9 @@ import {
 
 const realFetch = globalThis.fetch;
 const realLocationDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'location');
-const realGetOllamaConfig = globalThis.getOllamaConfig;
 
 const PROVIDER_KEY_CACHE_KEYS = [
+  'labcharts-ollama',
   'labcharts-openrouter-key',
   'labcharts-venice-key',
   'labcharts-routstr-key',
@@ -136,11 +136,11 @@ beforeEach(() => {
     writable: true,
     value: { origin: 'https://app.getbased.health', pathname: '/app', href: 'https://app.getbased.health/app' },
   });
-  globalThis.getOllamaConfig = () => ({
+  updateKeyCache('labcharts-ollama', JSON.stringify({
     url: 'http://localhost:11434',
     model: 'llama3.2',
     apiKey: 'local-api-key',
-  });
+  }));
   globalThis.showInsufficientBalanceDialog = undefined;
   delete globalThis._routstrAttestation;
   createTinfoilSecureFetchMock.mockReset();
@@ -154,8 +154,6 @@ afterEach(() => {
   globalThis.fetch = realFetch;
   if (realLocationDescriptor) Object.defineProperty(globalThis, 'location', realLocationDescriptor);
   else delete globalThis.location;
-  if (realGetOllamaConfig) globalThis.getOllamaConfig = realGetOllamaConfig;
-  else delete globalThis.getOllamaConfig;
   clearProviderKeyCaches();
   vi.restoreAllMocks();
 });

--- a/tests/api-provider-storage-runtime.test.js
+++ b/tests/api-provider-storage-runtime.test.js
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   dispatchAISettingsLocalChangedRuntime,
-  getOllamaConfigStorageRuntime,
   refreshAIProviderSelectionRuntime,
 } from '../js/api-provider-storage-runtime.js';
 
@@ -26,17 +25,14 @@ afterEach(() => {
 });
 
 describe('api provider storage runtime adapter', () => {
-  it('delegates provider UI refresh hooks and Ollama config reads', () => {
+  it('delegates provider UI refresh hooks', () => {
     const updateChatHeaderModel = vi.fn();
     const refreshWebSearchToggle = vi.fn();
-    const getOllamaConfig = vi.fn(() => ({ model: 'llama-test', url: 'http://ollama.test' }));
-    setRuntimeWindow({ updateChatHeaderModel, refreshWebSearchToggle, getOllamaConfig });
+    setRuntimeWindow({ updateChatHeaderModel, refreshWebSearchToggle });
 
     expect(refreshAIProviderSelectionRuntime()).toBe(true);
-    expect(getOllamaConfigStorageRuntime()).toEqual({ model: 'llama-test', url: 'http://ollama.test' });
     expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
     expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);
-    expect(getOllamaConfig).toHaveBeenCalledTimes(1);
   });
 
   it('dispatches the local AI settings change event', () => {
@@ -57,7 +53,6 @@ describe('api provider storage runtime adapter', () => {
 
     expect(refreshAIProviderSelectionRuntime()).toBe(false);
     expect(dispatchAISettingsLocalChangedRuntime()).toBe(false);
-    expect(getOllamaConfigStorageRuntime()).toEqual({});
   });
 
   it('keeps counted api provider storage globals behind the adapter', () => {

--- a/tests/api-runtime.test.js
+++ b/tests/api-runtime.test.js
@@ -4,7 +4,6 @@ import { readFileSync } from 'node:fs';
 import {
   getApiLocationOriginRuntime,
   getApiLocationPathnameRuntime,
-  getOllamaConfigRuntime,
   setApiLocationHrefRuntime,
   showOpenRouterInsufficientBalanceDialogRuntime,
 } from '../js/api-runtime.js';
@@ -41,12 +40,10 @@ describe('api runtime adapter', () => {
     expect(runtime.location.href).toBe('https://openrouter.ai/auth');
   });
 
-  it('delegates Ollama config and OpenRouter balance dialog access', () => {
-    const config = { url: 'http://localhost:11434', model: 'llama3.2', apiKey: '' };
+  it('delegates OpenRouter balance dialog access', () => {
     const showInsufficientBalanceDialog = vi.fn();
-    setRuntimeWindow({ getOllamaConfig: () => config, showInsufficientBalanceDialog });
+    setRuntimeWindow({ showInsufficientBalanceDialog });
 
-    expect(getOllamaConfigRuntime()).toBe(config);
     expect(showOpenRouterInsufficientBalanceDialogRuntime()).toBe(true);
     expect(showInsufficientBalanceDialog).toHaveBeenCalledTimes(1);
   });
@@ -58,7 +55,6 @@ describe('api runtime adapter', () => {
     expect(getApiLocationPathnameRuntime()).toBe('');
     expect(setApiLocationHrefRuntime('https://openrouter.ai/auth')).toBe(false);
     expect(showOpenRouterInsufficientBalanceDialogRuntime()).toBe(false);
-    expect(() => getOllamaConfigRuntime()).toThrow('Ollama config runtime is unavailable.');
   });
 
   it('keeps API provider browser globals behind runtime adapters', () => {
@@ -70,7 +66,8 @@ describe('api runtime adapter', () => {
 
     expect(openRouterSrc).toContain("from './api-runtime.js'");
     expect(openRouterOAuthSrc).toContain("from './api-runtime.js'");
-    expect(localSrc).toContain("from './api-runtime.js'");
+    expect(localSrc).toContain("from './api-provider-storage.js'");
+    expect(localSrc).not.toContain("from './api-runtime.js'");
     expect(apiSrc).not.toContain('Object.assign(window');
     expect(/\bwindow(?:\.|\s*\[)/.test(openRouterSrc)).toBe(false);
     expect(/\bwindow(?:\.|\s*\[)/.test(openRouterOAuthSrc)).toBe(false);

--- a/tests/playwright/api-provider-storage-browser-coverage.spec.js
+++ b/tests/playwright/api-provider-storage-browser-coverage.spec.js
@@ -22,6 +22,7 @@ test('api provider storage browser coverage handles provider gates and model cac
     const storageKeys = [
       'labcharts-ai-provider',
       'labcharts-ai-paused',
+      'labcharts-ollama',
       'labcharts-ollama-model',
       'labcharts-ollama-pii-url',
       'labcharts-ollama-pii-model',
@@ -52,6 +53,7 @@ test('api provider storage browser coverage handles provider gates and model cac
       'labcharts-api-provider-storage-bad-array',
     ];
     const cachedKeyNames = [
+      'labcharts-ollama',
       'labcharts-venice-key',
       'labcharts-openrouter-key',
       'labcharts-routstr-key',
@@ -65,7 +67,6 @@ test('api provider storage browser coverage handles provider gates and model cac
       keyCache: Object.fromEntries(cachedKeyNames.map(key => [key, cryptoStore.getCachedKey(key)])),
       updateChatHeaderModel: window.updateChatHeaderModel,
       refreshWebSearchToggle: window.refreshWebSearchToggle,
-      getOllamaConfig: window.getOllamaConfig,
     };
 
     const restoreStoredValue = (store, key, value) => {
@@ -84,7 +85,6 @@ test('api provider storage browser coverage handles provider gates and model cac
       for (const key of cachedKeyNames) cryptoStore.updateKeyCache(key, null);
       window.updateChatHeaderModel = () => { headerUpdates += 1; };
       window.refreshWebSearchToggle = () => { searchRefreshes += 1; };
-      window.getOllamaConfig = () => ({ url: 'http://localhost:11434', model: 'llama-default' });
       window.addEventListener('labcharts-ai-settings-local-changed', onLocalSettingsChanged);
 
       const defaultProvider = storage.getAIProvider();
@@ -135,6 +135,7 @@ test('api provider storage browser coverage handles provider gates and model cac
         && customAvailable
         && optimisticLocalProvider;
 
+      await storage.saveOllamaConfig({ url: 'http://localhost:11434', model: 'llama-default', mode: 'ollama', apiKey: '' });
       const defaultOllamaModel = storage.getOllamaMainModel();
       const defaultPiiUrl = storage.getOllamaPIIUrl();
       const defaultPiiModelFromWindowConfig = storage.getOllamaPIIModel();
@@ -143,7 +144,7 @@ test('api provider storage browser coverage handles provider gates and model cac
       const defaultPiiModelFromMainModel = storage.getOllamaPIIModel();
       storage.setOllamaPIIUrl('http://pii.local:11434');
       storage.setOllamaPIIModel('privacy-qwen:7b');
-      outcomes.ollamaSettingsUseWindowDefaultsAndPersistOverrides =
+      outcomes.ollamaSettingsUseStoredConfigAndPersistOverrides =
         defaultOllamaModel === 'llama-default'
         && savedOllamaModel === 'qwen2.5:7b'
         && defaultPiiUrl === 'http://localhost:11434'
@@ -272,7 +273,6 @@ test('api provider storage browser coverage handles provider gates and model cac
       window.removeEventListener('labcharts-ai-settings-local-changed', onLocalSettingsChanged);
       window.updateChatHeaderModel = saved.updateChatHeaderModel;
       window.refreshWebSearchToggle = saved.refreshWebSearchToggle;
-      window.getOllamaConfig = saved.getOllamaConfig;
       for (const [key, value] of Object.entries(saved.localStorage)) {
         restoreStoredValue(localStorage, key, value);
       }

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -74,7 +74,6 @@ test('client list live menu actions dispatch exports share demos and profile sta
       exportClientJSON: window.exportClientJSON,
       importDataJSON: window.importDataJSON,
       loadDemoData: window.loadDemoData,
-      openProfileShareModal: window.openProfileShareModal,
       showConfirmDialog: window.showConfirmDialog,
       inputClick: HTMLInputElement.prototype.click,
     };
@@ -126,13 +125,13 @@ test('client list live menu actions dispatch exports share demos and profile sta
       window.exportClientJSON = (...args) => calls.push(['export-client', ...args]);
       window.importDataJSON = file => calls.push(['import-json', file?.name || '']);
       window.loadDemoData = demo => calls.push(['load-demo', demo]);
-      window.openProfileShareModal = id => calls.push(['share-profile', id]);
+      const openProfileShareModal = id => calls.push(['share-profile', id]);
       configureClientListRuntime({
         exportAllDataJSON: window.exportAllDataJSON,
         exportClientJSON: window.exportClientJSON,
         importDataJSON: window.importDataJSON,
         loadDemoData: window.loadDemoData,
-        openProfileShareModal: window.openProfileShareModal,
+        openProfileShareModal,
       });
       window.showConfirmDialog = async message => {
         calls.push(['confirm', message]);
@@ -254,7 +253,6 @@ test('client list live menu actions dispatch exports share demos and profile sta
       window.exportClientJSON = saved.exportClientJSON;
       window.importDataJSON = saved.importDataJSON;
       window.loadDemoData = saved.loadDemoData;
-      window.openProfileShareModal = saved.openProfileShareModal;
       window.showConfirmDialog = saved.showConfirmDialog;
       if (previousProfileDeps) profile.configureProfileDeps(previousProfileDeps);
       HTMLInputElement.prototype.click = saved.inputClick;

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -465,7 +465,7 @@ test('context health dots and focus card cover cache fallback and empty states',
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ healthUrl, focusUrl }) => {
-    const [{ state }, health, focus, summaries, profile, data, labContext] = await Promise.all([
+    const [{ state }, health, focus, summaries, profile, data, labContext, cryptoStore] = await Promise.all([
       import('/js/state.js'),
       import(healthUrl),
       import(focusUrl),
@@ -473,6 +473,7 @@ test('context health dots and focus card cover cache fallback and empty states',
       import('/js/profile.js'),
       import('/js/data.js'),
       import('/js/lab-context.js'),
+      import('/js/crypto.js'),
     ]);
     const outcomes = {};
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -486,9 +487,10 @@ test('context health dots and focus card cover cache fallback and empty states',
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
       openRouterKey: localStorage.getItem('labcharts-openrouter-key'),
+      ollamaConfig: localStorage.getItem('labcharts-ollama'),
+      ollamaConfigCache: cryptoStore.getCachedKey('labcharts-ollama'),
       ollamaModel: localStorage.getItem('labcharts-ollama-model'),
       fetch: window.fetch,
-      getOllamaConfig: window.getOllamaConfig,
       buildLabContext: window.buildLabContext,
     };
     const cacheKeys = [];
@@ -568,7 +570,7 @@ test('context health dots and focus card cover cache fallback and empty states',
         exercise: { dot: 'purple', tip: 'invalid color' },
       });
       const aiCalls = [];
-      window.getOllamaConfig = () => ({ url: 'http://ollama.test', model: 'context-test-model', mode: 'ollama', apiKey: '' });
+      cryptoStore.updateKeyCache('labcharts-ollama', JSON.stringify({ url: 'http://ollama.test', model: 'context-test-model', mode: 'ollama', apiKey: '' }));
       window.buildLabContext = () => summaries.CONTEXT_CARD_KEYS.map(key => `[section:${key}]\n${key} section\n[/section:${key}]`).join('\n');
       window.fetch = async (url, options = {}) => {
         const href = typeof url === 'string' ? url : url?.url || '';
@@ -607,7 +609,6 @@ test('context health dots and focus card cover cache fallback and empty states',
         && localStorage.getItem(healthCacheKey) !== null;
 
       window.fetch = saved.fetch;
-      window.getOllamaConfig = saved.getOllamaConfig;
       if (saved.buildLabContext === undefined) delete window.buildLabContext;
       else window.buildLabContext = saved.buildLabContext;
 
@@ -653,7 +654,6 @@ test('context health dots and focus card cover cache fallback and empty states',
       localStorage.removeItem('labcharts-ai-paused');
       localStorage.setItem('labcharts-ollama-model', 'context-test-model');
       const focusAiCalls = [];
-      window.getOllamaConfig = () => ({ url: 'http://ollama.test', model: 'context-test-model', mode: 'ollama', apiKey: '' });
       window.fetch = async (url, options = {}) => {
         const href = typeof url === 'string' ? url : url?.url || '';
         if (href === 'http://ollama.test/v1/chat/completions') {
@@ -681,7 +681,6 @@ test('context health dots and focus card cover cache fallback and empty states',
         && document.getElementById('focus-card-body')?.textContent.includes('Vitamin D is low. Recheck with ApoB') === true
         && streamedFocusCache.text === 'Vitamin D is low. Recheck with ApoB.';
       window.fetch = saved.fetch;
-      window.getOllamaConfig = saved.getOllamaConfig;
 
       localStorage.removeItem(focusCacheKey);
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
@@ -720,13 +719,15 @@ test('context health dots and focus card cover cache fallback and empty states',
       else localStorage.setItem('labcharts-ai-paused', saved.paused);
       if (saved.openRouterKey == null) localStorage.removeItem('labcharts-openrouter-key');
       else localStorage.setItem('labcharts-openrouter-key', saved.openRouterKey);
+      if (saved.ollamaConfig == null) localStorage.removeItem('labcharts-ollama');
+      else localStorage.setItem('labcharts-ollama', saved.ollamaConfig);
       if (saved.ollamaModel == null) localStorage.removeItem('labcharts-ollama-model');
       else localStorage.setItem('labcharts-ollama-model', saved.ollamaModel);
       if (saved.activeProfile == null) localStorage.removeItem('labcharts-active-profile');
       else localStorage.setItem('labcharts-active-profile', saved.activeProfile);
       window.updateKeyCache?.('labcharts-openrouter-key', saved.openRouterKey || '');
+      cryptoStore.updateKeyCache('labcharts-ollama', saved.ollamaConfigCache);
       window.fetch = saved.fetch;
-      window.getOllamaConfig = saved.getOllamaConfig;
       if (saved.buildLabContext === undefined) delete window.buildLabContext;
       else window.buildLabContext = saved.buildLabContext;
       for (const key of cacheKeys) localStorage.removeItem(key);

--- a/tests/playwright/pii-browser-coverage.spec.js
+++ b/tests/playwright/pii-browser-coverage.spec.js
@@ -144,9 +144,9 @@ test('PII browser coverage exercises config probes regex obfuscation and diff he
         /^\d{2}\.\d{2}\.\d{4}$/.test(pii.fakeDate()) &&
         /^\d{10}$/.test(pii.fakePatientId()));
 
-      const defaultConfig = pii.getOllamaConfig();
-      await pii.saveOllamaConfig({ url: 'http://local-ai.test/', model: 'privacy-model', mode: 'openai', apiKey: 'pii-key' });
-      const savedConfig = pii.getOllamaConfig();
+      const defaultConfig = providerStorage.getOllamaConfig();
+      await providerStorage.saveOllamaConfig({ url: 'http://local-ai.test/', model: 'privacy-model', mode: 'openai', apiKey: 'pii-key' });
+      const savedConfig = providerStorage.getOllamaConfig();
       check('Ollama config defaults and encrypted save cache work',
         defaultConfig.url === 'http://localhost:11434' &&
         savedConfig.model === 'privacy-model' &&
@@ -444,7 +444,13 @@ test('PII browser coverage exercises review modal search edit streaming stop ret
         stopState &&
         retryState &&
         streamedResult.includes('Reviewed after retry') &&
-        unloadCalls.some(body => body.includes('"keep_alive":0')));
+        unloadCalls.some(body => body.includes('"keep_alive":0')),
+        JSON.stringify({
+          stopState,
+          retryState,
+          keptEdit: streamedResult.includes('Reviewed after retry'),
+          unloadedModel: unloadCalls.some(body => body.includes('"keep_alive":0')),
+        }));
     } finally {
       window.fetch = saved.fetch;
       document.body.style.overflow = saved.bodyOverflow;

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -45,7 +45,6 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       fetch: window.fetch,
       initSettingsOllamaCheck: window.initSettingsOllamaCheck,
       initSettingsModelFetch: window.initSettingsModelFetch,
-      refreshChartThemeColors: window.refreshChartThemeColors,
       getMeteoConfig: window.getMeteoConfig,
       saveMeteoConfig: window.saveMeteoConfig,
       theme: localStorage.getItem('labcharts-theme'),
@@ -77,8 +76,6 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       };
       window.initSettingsOllamaCheck = () => {};
       window.initSettingsModelFetch = () => {};
-      window.refreshChartThemeColors = () => {};
-
       localStorage.removeItem('labcharts-accent');
       localStorage.removeItem('labcharts-sunset-mode');
       localStorage.removeItem('labcharts-crt-effects');
@@ -184,7 +181,6 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       window.fetch = saved.fetch;
       window.initSettingsOllamaCheck = saved.initSettingsOllamaCheck;
       window.initSettingsModelFetch = saved.initSettingsModelFetch;
-      window.refreshChartThemeColors = saved.refreshChartThemeColors;
       window.getMeteoConfig = saved.getMeteoConfig;
       window.saveMeteoConfig = saved.saveMeteoConfig;
       state.currentProfile = saved.currentProfile;

--- a/tests/playwright/settings-provider-browser-coverage.spec.js
+++ b/tests/playwright/settings-provider-browser-coverage.spec.js
@@ -6,9 +6,10 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
-  const results = await page.evaluate(async ({ controlsUrl, piiUrl }) => {
+  const results = await page.evaluate(async ({ controlsUrl, piiUrl, providerStorageUrl }) => {
     const controls = await import(controlsUrl);
     const pii = await import(piiUrl);
+    const providerStorage = await import(providerStorageUrl);
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -199,7 +200,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
         && document.getElementById('pii-model-select')?.options.length === 2
         && localStorage.getItem('labcharts-ollama-pii-enabled') === 'true';
 
-      await pii.saveOllamaConfig({ url: 'https://remote.example/v1', model: 'remote-model', mode: 'openai-compatible', apiKey: '' });
+      await providerStorage.saveOllamaConfig({ url: 'https://remote.example/v1', model: 'remote-model', mode: 'openai-compatible', apiKey: '' });
       document.getElementById('local-ai-model-select').innerHTML = '<option value="remote-small">remote-small</option><option value="remote-huge">remote-huge</option>';
       await controls.renderModelAdvisor([
         { name: 'remote-small', size: 2000000000, quantLevel: 'Q4', paramSize: '2B' },
@@ -239,6 +240,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
   }, {
     controlsUrl: moduleUrl('/js/provider-local-ai-controls.js'),
     piiUrl: moduleUrl('/js/pii.js'),
+    providerStorageUrl: moduleUrl('/js/api-provider-storage.js'),
   });
 
   for (const [name, passed] of Object.entries(results)) {

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -28,8 +28,7 @@ console.log('=== Cycle Improvements Test Suite ===\n');
 await import('../js/state.js');
 await import('../js/data.js');
 await import('../js/cycle.js');
-// charts.js exposes phaseBandPlugin etc. via Object.assign(window, ...).
-await import('../js/charts.js');
+const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 1: PERIOD_SYMPTOMS constant ──
   console.log('Section 1: PERIOD_SYMPTOMS constant');
   {
@@ -115,9 +114,9 @@ await import('../js/charts.js');
   // ── Section 7: phaseBandPlugin ──
   console.log('Section 7: phaseBandPlugin');
   {
-    assert('phaseBandPlugin exists on window', typeof window.phaseBandPlugin === 'object');
-    assert('phaseBandPlugin has id phaseBands', window.phaseBandPlugin?.id === 'phaseBands');
-    assert('phaseBandPlugin has beforeDraw', typeof window.phaseBandPlugin?.beforeDraw === 'function');
+    assert('phaseBandPlugin is a module export', typeof phaseBandPlugin === 'object');
+    assert('phaseBandPlugin has id phaseBands', phaseBandPlugin?.id === 'phaseBands');
+    assert('phaseBandPlugin has beforeDraw', typeof phaseBandPlugin?.beforeDraw === 'function');
   }
 
   // ── Section 8: createLineChart accepts 5th param ──

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -96,7 +96,7 @@ assert('Profile share module is startup-loaded',
 assert('Settings Data tab exposes Share Profile action',
   settingsDataSrc.includes("data-settings-action=\"share-profile\"") &&
   settingsSrc.includes('settingsRuntime.openProfileShareModal()') &&
-  settingsSrc.includes('openProfileShareModal: (profileId) => settingsWindow.openProfileShareModal?.(profileId)') &&
+  settingsSrc.includes('openProfileShareModal: () => {}') &&
   read('js/app-shell-hooks.js').includes('configureSettingsRuntime') &&
   read('js/app-shell-hooks.js').includes('openProfileShareModal'));
 assert('Share modal has dedicated shared-modal styling',
@@ -139,10 +139,11 @@ assert('Share result uses icon copy buttons',
   profileShareSrc.includes('class="profile-share-icon-btn" data-profile-share-action="copy"') &&
   profileShareSrc.includes('aria-label="Copy link"') &&
   profileShareSrc.includes('aria-label="Copy password"'));
-assert('Window exports share helpers',
-  profileShareSrc.includes('openProfileShareModal') &&
-  profileShareSrc.includes('decryptProfileShareEnvelope') &&
-  profileShareSrc.includes('parseProfileShareIdFromLocation'));
+assert('Profile share helpers stay module-only',
+  profileShareSrc.includes('export function openProfileShareModal') &&
+  profileShareSrc.includes('export async function decryptProfileShareEnvelope') &&
+  profileShareSrc.includes('export function parseProfileShareIdFromLocation') &&
+  !profileShareSrc.includes('Object.assign(window'));
 
 console.log('4. Export/import reuse and credential boundaries');
 const exportGlobalPublish = exportSrc.match(/publishExportGlobals\(\s*\{([^}]*)\}\)/);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -185,8 +185,13 @@
   // 2. WINDOW EXPORTS — all 300+ functions registered
   // ═══════════════════════════════════════════════
 
-  // api.js is module-only; UI modules below still publish legacy window hooks.
-  const apiModule = await import('../js/api.js');
+  // Module-only surfaces are verified through their ESM exports. Remaining UI
+  // modules below still publish legacy window hooks while migration continues.
+  const [apiModule, chartsModule, piiModule] = await Promise.all([
+    import('../js/api.js'),
+    import('../js/charts.js'),
+    import('../js/pii.js'),
+  ]);
   const apiExports = [
     'getVeniceKey','saveVeniceKey','hasVeniceKey',
     'getVeniceModel','setVeniceModel','getVeniceModelDisplay',
@@ -196,6 +201,7 @@
     'getRoutstrModel','setRoutstrModel','getRoutstrModelDisplay',
     'getPpqKey','savePpqKey','hasPpqKey',
     'getPpqModel','setPpqModel','getPpqModelDisplay',
+    'getOllamaConfig','saveOllamaConfig',
     'getOllamaMainModel','setOllamaMainModel',
     'getOllamaPIIUrl','setOllamaPIIUrl','getOllamaPIIModel','setOllamaPIIModel',
     'fetchVeniceModels','fetchOpenRouterModels','fetchRoutstrModels','fetchPpqModels',
@@ -205,7 +211,7 @@
     'callOllamaChat','callVeniceAPI','callOpenRouterAPI','callRoutstrAPI','callPpqAPI','callClaudeAPI'
   ];
 
-  // charts.js (8)
+  // charts.js (8, module-only)
   const chartsExports = [
     'refBandPlugin','optimalBandPlugin','noteAnnotationPlugin','supplementBarPlugin',
     'getNotesForChart','getSupplementsForChart',
@@ -326,11 +332,11 @@
     'showBatchImportProgress','showImportPreviewAsync'
   ];
 
-  // pii.js (7)
+  // pii.js (7, module-only)
   const piiExports = [
     'obfuscatePDFText','sanitizeWithOllama','checkOllamaPII',
     'reviewPIIBeforeSend',
-    'getOllamaConfig','checkOllama'
+    'checkOllama'
   ];
 
   // profile.js (28)
@@ -435,8 +441,19 @@
   }
   console.log(`Checked ${apiExports.length} api.js module exports`);
 
+  for (const [moduleName, moduleApi, exports] of [
+    ['charts.js', chartsModule, chartsExports],
+    ['pii.js', piiModule, piiExports],
+  ]) {
+    for (const name of exports) {
+      const val = moduleApi[name];
+      const isFunc = typeof val === 'function';
+      assert(`${moduleName}.${name} module export`, val !== undefined, isFunc ? 'function' : typeof val);
+    }
+    console.log(`Checked ${exports.length} ${moduleName} module exports`);
+  }
+
   const allModules = {
-    'charts.js': chartsExports,
     'lab-context.js': labContextExports,
     'chat.js': chatExports,
     'client-list.js': clientListExports,
@@ -447,7 +464,6 @@
     'nav.js': navExports,
     'notes.js': notesExports,
     'pdf-import.js': pdfImportExports,
-    'pii.js': piiExports,
     'profile.js': profileExports,
     'settings.js': settingsExports,
     'provider-panels.js': providerPanelsExports,
@@ -697,7 +713,7 @@
   // ═══════════════════════════════════════════════
   // 17. PII FUNCTIONS — exist and callable
   // ═══════════════════════════════════════════════
-  const testPII = window.obfuscatePDFText('John Smith born 1990-01-01 SSN 123-45-6789');
+  const testPII = piiModule.obfuscatePDFText('John Smith born 1990-01-01 SSN 123-45-6789');
   assert('obfuscatePDFText returns object', testPII && typeof testPII === 'object');
   assert('obfuscatePDFText has obfuscated field', typeof testPII.obfuscated === 'string');
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.185';
+self.APP_VERSION = '1.10.186';


### PR DESCRIPTION
## What changed

- remove legacy `window` publication from charts, PII, and profile sharing
- move Ollama configuration ownership into provider storage and replace hidden browser-global coupling with direct module imports
- update browser/runtime tests and lower the quality baseline from 25 to 22 total global assignments (23 to 20 legacy assignments)
- bump the app cache version to 1.10.186

## Why

These module APIs are already consumed through ES imports. Keeping duplicate browser globals increases coupling and made the Ollama configuration path depend on module load order.

## Impact

No intended end-user behavior change. Ollama and PII configuration now use an explicit module path, including model unload after streaming privacy review.

## Validation

- `./run-tests.sh`
- `npm run test:playwright -- --reporter=dot` — 351 passed
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`