### PR TITLE
Make Lens helpers module-only

### DIFF
--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -24,7 +24,7 @@ import {
   setSupplementsMedsContextEnabled,
   setWearableContextEnabled,
 } from './lab-context.js';
-import { getLensSummary } from './lens.js';
+import { getLensSummary, openKnowledgeBaseModal } from './lens.js';
 import { state } from './state.js';
 import { isSyncEnabled } from './sync.js';
 import { escapeAttr, escapeHTML } from './utils.js';
@@ -38,7 +38,6 @@ import {
 
 const appWindow = /** @type {Window & typeof globalThis & {
   openInterpretiveLensEditor?: () => void,
-  openKnowledgeBaseModal?: () => void,
   showEnableEncryptionModal?: () => void,
   showSyncSetupModal?: () => void,
   pickFolderForBackup?: () => void,
@@ -48,7 +47,7 @@ const appWindow = /** @type {Window & typeof globalThis & {
 
 configureDashboardAIActionDelegates({
   'open-interpretive-lens': () => appWindow.openInterpretiveLensEditor?.(),
-  'open-knowledge-base': () => appWindow.openKnowledgeBaseModal?.(),
+  'open-knowledge-base': () => openKnowledgeBaseModal(),
   'open-personalize-ai-picker': () => openContextModal(),
   'enable-encryption': () => appWindow.showEnableEncryptionModal?.(),
   'setup-sync': () => appWindow.showSyncSetupModal?.(),
@@ -775,8 +774,8 @@ export function openContextModal() {
       close();
       if (pick === 'lens' && typeof appWindow.openInterpretiveLensEditor === 'function') {
         appWindow.openInterpretiveLensEditor();
-      } else if (pick === 'kb' && typeof appWindow.openKnowledgeBaseModal === 'function') {
-        appWindow.openKnowledgeBaseModal();
+      } else if (pick === 'kb') {
+        openKnowledgeBaseModal();
       }
     };
   });

--- a/js/lens.js
+++ b/js/lens.js
@@ -497,15 +497,3 @@ export function handleLibraryDelete() { return lensKnowledgeBaseUi.handleLibrary
 export function handleToggleLens(checked) { return lensKnowledgeBaseUi.handleToggleLens(checked); }
 export function handleClearLensCache() { return lensKnowledgeBaseUi.handleClearLensCache(); }
 export async function handleRemoveLens() { return lensKnowledgeBaseUi.handleRemoveLens(); }
-
-Object.assign(window, {
-  getLensConfig, saveLensConfig, getLensKey, saveLensKey,
-  hasLens, queryLens, queryLensMulti, buildLensSnippet, testLensConnection, clearLensCache,
-  openKnowledgeBaseModal, closeKnowledgeBaseModal,
-  subscribeLensStatus, getLensStatus, isValidLensUrl,
-  renderCustomLensSection, handleSaveLensConfig, handleToggleLens,
-  handleClearLensCache, handleRemoveLens, updateLensIndicator,
-  handleLensBackendChange,
-  handleLocalLensDeleteDoc, handleLocalLensClear,
-  handleLibraryActivate, handleLibraryNew, handleLibraryRename, handleLibraryDelete,
-});

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -31,10 +31,6 @@ export function openEMFAssessmentFromNavRuntime() {
   getNavRuntimeFunction('openEMFAssessmentEditor')?.();
 }
 
-export function openKnowledgeBaseFromNavRuntime() {
-  getNavRuntimeFunction('openKnowledgeBaseModal')?.();
-}
-
 export function openReportBuilderFromNavRuntime() {
   getNavRuntimeFunction('openReportBuilder')?.();
 }

--- a/js/nav.js
+++ b/js/nav.js
@@ -14,9 +14,9 @@ import {
   openContextFromNavRuntime,
   openCreateMarkerFromNavRuntime,
   openEMFAssessmentFromNavRuntime,
-  openKnowledgeBaseFromNavRuntime,
   openReportBuilderFromNavRuntime,
 } from './nav-runtime.js';
+import { openKnowledgeBaseModal } from './lens.js';
 
 function _iconSvg(name) {
   const attrs = 'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"';
@@ -95,7 +95,7 @@ function handleNavActionClick(event) {
   } else if (action === 'open-light-assessment') {
     navActionDeps.openLightEnvironmentAssessment();
   } else if (action === 'open-knowledge-base') {
-    openKnowledgeBaseFromNavRuntime();
+    openKnowledgeBaseModal();
   } else if (action === 'open-report-builder') {
     openReportBuilderFromNavRuntime();
   } else if (action === 'open-context') {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 22,
-  "legacyWindowGlobalAssignments": 20,
+  "windowGlobalAssignments": 21,
+  "legacyWindowGlobalAssignments": 19,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/custom-lens.spec.js
+++ b/tests/playwright/custom-lens.spec.js
@@ -6,12 +6,13 @@ test('chat lens indicator hides when no lens is configured', async ({ page }) =>
   await expect(page.locator('#chat-lens-indicator')).toHaveCount(1);
   await expect(page.locator('#chat-lens-dot')).toHaveCount(1);
 
-  const display = await page.evaluate(() => {
+  const display = await page.evaluate(async () => {
+    const { updateLensIndicator } = await import('/js/lens.js');
+    const { updateKeyCache } = await import('/js/crypto.js');
     const indicator = document.getElementById('chat-lens-indicator');
     localStorage.removeItem('labcharts-lens-config');
-    window.updateKeyCache?.('labcharts-lens-key', '');
-    if (typeof window.updateLensIndicator !== 'function') throw new Error('window.updateLensIndicator unavailable');
-    window.updateLensIndicator();
+    updateKeyCache('labcharts-lens-key', '');
+    updateLensIndicator();
     return indicator?.style.display || '';
   });
 
@@ -21,8 +22,8 @@ test('chat lens indicator hides when no lens is configured', async ({ page }) =>
 test('knowledge base modal renders lens controls and settings AI does not', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  await page.evaluate(() => {
-    if (typeof window.openKnowledgeBaseModal !== 'function') throw new Error('window.openKnowledgeBaseModal unavailable');
+  await page.evaluate(async () => {
+    const { openKnowledgeBaseModal } = await import('/js/lens.js');
     localStorage.setItem('labcharts-lens-config', JSON.stringify({
       backend: 'external-server',
       url: 'https://kb.example.test',
@@ -31,7 +32,7 @@ test('knowledge base modal renders lens controls and settings AI does not', asyn
       testProbe: 'vitamin D deficiency supplementation',
       multiQuery: true,
     }));
-    window.openKnowledgeBaseModal();
+    openKnowledgeBaseModal();
   });
 
   const lensSection = page.locator('#custom-lens-section');
@@ -43,8 +44,9 @@ test('knowledge base modal renders lens controls and settings AI does not', asyn
   await expect(lensSection.locator('[data-lens-action="save-config"]')).toHaveCount(1);
   expect(await lensSection.evaluate((section) => !section.querySelector('[onclick], [onchange], [oninput]'))).toBe(true);
 
-  await page.evaluate(() => {
-    window.closeKnowledgeBaseModal?.();
+  await page.evaluate(async () => {
+    const { closeKnowledgeBaseModal } = await import('/js/lens.js');
+    closeKnowledgeBaseModal();
     if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
     window.openSettingsModal('ai');
   });

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -20,6 +20,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     const hadShowDirectoryPicker = Object.prototype.hasOwnProperty.call(window, 'showDirectoryPicker');
     window.showDirectoryPicker = async () => ({ name: 'Coverage Backups' });
     const dashboardAi = await import(dashboardUrl);
+    const lens = await import('/js/lens.js');
     const { state } = await import('/js/state.js');
     const outcomes = {};
 
@@ -42,7 +43,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       showSyncSetupModal: window.showSyncSetupModal,
       pickFolderForBackup: window.pickFolderForBackup,
       openInterpretiveLensEditor: window.openInterpretiveLensEditor,
-      openKnowledgeBaseModal: window.openKnowledgeBaseModal,
       handleDNAFile: window.handleDNAFile,
       setTimeout: window.setTimeout,
     };
@@ -69,7 +69,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       window.showSyncSetupModal = () => calls.push('sync');
       window.pickFolderForBackup = () => calls.push('backup');
       window.openInterpretiveLensEditor = () => calls.push('lens');
-      window.openKnowledgeBaseModal = () => calls.push('kb');
       window.handleDNAFile = file => {
         handledDnaFile = { name: file.name, textType: file.type };
       };
@@ -198,11 +197,14 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
         && calls.includes('sync')
         && calls.includes('backup');
 
+      const lensPickerClosed = await clickPickerCard(dashboardAi.openPersonalizeAIPicker, '[data-pick="lens"]');
+      const kbPickerClosed = await clickPickerCard(dashboardAi.openPersonalizeAIPicker, '[data-pick="kb"]');
       outcomes.personalizePickerRoutesLensAndKnowledgeBase =
-        await clickPickerCard(dashboardAi.openPersonalizeAIPicker, '[data-pick="lens"]')
-        && await clickPickerCard(dashboardAi.openPersonalizeAIPicker, '[data-pick="kb"]')
+        lensPickerClosed
+        && kbPickerClosed
         && calls.includes('lens')
-        && calls.includes('kb');
+        && document.querySelector('#kb-modal-overlay.show') !== null;
+      lens.closeKnowledgeBaseModal();
       outcomes.pickersScheduleFocusTimers = timers.some(delay => delay === 50);
 
       dashboardAi.triggerDNAFilePicker();

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -33,7 +33,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     const origNavigate = window.navigate;
     const origOpenEMF = window.openEMFAssessmentEditor;
     const origOpenReportBuilder = window.openReportBuilder;
-    const origOpenKB = window.openKnowledgeBaseModal;
     const origOpenContext = window.openContextModal;
     const origOpenCreateMarker = window.openCreateMarkerModal;
     const origOpenClientList = window.openClientList;
@@ -78,7 +77,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
         openLightEnvironmentAssessment: () => calls.push(['open-light-env']),
       });
       window.openReportBuilder = () => calls.push(['open-report-builder']);
-      window.openKnowledgeBaseModal = () => calls.push(['open-kb']);
       window.openContextModal = () => calls.push(['open-context']);
       window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
       window.openClientList = () => calls.push(['open-client-list']);
@@ -145,7 +143,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       window.openEMFAssessmentEditor = origOpenEMF;
       if (restoreNavActions) nav.configureNavActions(restoreNavActions);
       window.openReportBuilder = origOpenReportBuilder;
-      window.openKnowledgeBaseModal = origOpenKB;
       window.openContextModal = origOpenContext;
       window.openCreateMarkerModal = origOpenCreateMarker;
       window.openClientList = origOpenClientList;

--- a/tests/test-custom-lens.js
+++ b/tests/test-custom-lens.js
@@ -28,11 +28,11 @@ function assert(name, condition, detail) {
 
 console.log('=== Custom Lens Tests ===\n');
 
-// lens.js exposes the lens helpers; lab-context.js exposes injectLensChunks —
-// both via Object.assign(window, ...).
+// Verify Lens and lab-context helpers through their ES module exports.
 await import('../js/state.js');
-await import('../js/lens.js');
-await import('../js/lab-context.js');
+const lens = await import('../js/lens.js');
+const labContext = await import('../js/lab-context.js');
+const cryptoStore = await import('../js/crypto.js');
 
 // ─── 1. lens.js source inspection ───
 console.log('1. lens.js source inspection');
@@ -140,62 +140,56 @@ assert('Connected toast distinguishes zero-result case',
   lensKnowledgeBaseUiSrc.includes("the test query didn't find any close matches") && lensKnowledgeBaseUiSrc.includes('your endpoint works'),
   'user with non-matching probe should see the endpoint worked, not "connection failed"');
 
-// ─── 2. Window function exports ───
-console.log('\n2. Window function exports');
-assert('window.getLensConfig is function', typeof window.getLensConfig === 'function');
-assert('window.saveLensConfig is function', typeof window.saveLensConfig === 'function');
-assert('window.getLensKey is function', typeof window.getLensKey === 'function');
-assert('window.saveLensKey is function', typeof window.saveLensKey === 'function');
-assert('window.hasLens is function', typeof window.hasLens === 'function');
-assert('window.queryLens is function', typeof window.queryLens === 'function');
-assert('window.buildLensSnippet is function', typeof window.buildLensSnippet === 'function');
-assert('window.testLensConnection is function', typeof window.testLensConnection === 'function');
-assert('window.clearLensCache is function', typeof window.clearLensCache === 'function');
-assert('window.isValidLensUrl is function', typeof window.isValidLensUrl === 'function');
-assert('window.renderCustomLensSection is function', typeof window.renderCustomLensSection === 'function');
-assert('window.handleSaveLensConfig is function', typeof window.handleSaveLensConfig === 'function');
-assert('window.handleRemoveLens is function', typeof window.handleRemoveLens === 'function');
-assert('window.updateLensIndicator is function', typeof window.updateLensIndicator === 'function');
-assert('window.subscribeLensStatus is function', typeof window.subscribeLensStatus === 'function');
+// ─── 2. Module function exports ───
+console.log('\n2. Module function exports');
+for (const name of [
+  'getLensConfig', 'saveLensConfig', 'getLensKey', 'saveLensKey', 'hasLens',
+  'queryLens', 'buildLensSnippet', 'testLensConnection', 'clearLensCache',
+  'isValidLensUrl', 'renderCustomLensSection', 'handleSaveLensConfig',
+  'handleRemoveLens', 'updateLensIndicator', 'subscribeLensStatus',
+]) {
+  assert(`lens.${name} is function`, typeof lens[name] === 'function');
+}
+assert('Lens helpers stay module-only', !lensSrc.includes('Object.assign(window'));
 
 // ─── 3. URL validation ───
 console.log('\n3. URL validation');
-assert('accepts https://example.com', window.isValidLensUrl('https://example.com') === true);
-assert('accepts https://rag.example.com/query', window.isValidLensUrl('https://rag.example.com/query') === true);
-assert('accepts http://localhost:8000', window.isValidLensUrl('http://localhost:8000') === true);
-assert('accepts http://127.0.0.1:8000', window.isValidLensUrl('http://127.0.0.1:8000') === true);
-assert('rejects http://evil.com', window.isValidLensUrl('http://evil.com') === false);
-assert('rejects empty string', window.isValidLensUrl('') === false);
-assert('rejects garbage', window.isValidLensUrl('not-a-url') === false);
-assert('rejects ftp://', window.isValidLensUrl('ftp://example.com') === false);
-assert('accepts http://192.168.1.5:8000', window.isValidLensUrl('http://192.168.1.5:8000') === true);
-assert('accepts http://192.168.222.119:8321/query', window.isValidLensUrl('http://192.168.222.119:8321/query') === true);
-assert('accepts http://10.0.0.1', window.isValidLensUrl('http://10.0.0.1') === true);
-assert('accepts http://172.16.0.1', window.isValidLensUrl('http://172.16.0.1') === true);
-assert('accepts http://172.31.255.254', window.isValidLensUrl('http://172.31.255.254') === true);
-assert('rejects http://172.15.0.1 (outside /12)', window.isValidLensUrl('http://172.15.0.1') === false);
-assert('rejects http://172.32.0.1 (outside /12)', window.isValidLensUrl('http://172.32.0.1') === false);
-assert('accepts http://nas.local:8000', window.isValidLensUrl('http://nas.local:8000') === true);
-assert('accepts http://nas.local.', window.isValidLensUrl('http://nas.local.') === true);
-assert('accepts http://100.64.0.1 (Tailscale CGNAT)', window.isValidLensUrl('http://100.64.0.1') === true);
-assert('accepts http://100.127.255.254 (Tailscale CGNAT)', window.isValidLensUrl('http://100.127.255.254') === true);
-assert('rejects http://100.63.0.1 (outside CGNAT)', window.isValidLensUrl('http://100.63.0.1') === false);
-assert('rejects http://100.128.0.1 (outside CGNAT)', window.isValidLensUrl('http://100.128.0.1') === false);
-assert('accepts http://169.254.169.254 (link-local)', window.isValidLensUrl('http://169.254.169.254') === true);
-assert('accepts http://[::1]:8000', window.isValidLensUrl('http://[::1]:8000') === true);
-assert('rejects http://8.8.8.8 (public)', window.isValidLensUrl('http://8.8.8.8') === false);
-assert('rejects http://256.1.1.1 (invalid octet)', window.isValidLensUrl('http://256.1.1.1') === false);
+assert('accepts https://example.com', lens.isValidLensUrl('https://example.com') === true);
+assert('accepts https://rag.example.com/query', lens.isValidLensUrl('https://rag.example.com/query') === true);
+assert('accepts http://localhost:8000', lens.isValidLensUrl('http://localhost:8000') === true);
+assert('accepts http://127.0.0.1:8000', lens.isValidLensUrl('http://127.0.0.1:8000') === true);
+assert('rejects http://evil.com', lens.isValidLensUrl('http://evil.com') === false);
+assert('rejects empty string', lens.isValidLensUrl('') === false);
+assert('rejects garbage', lens.isValidLensUrl('not-a-url') === false);
+assert('rejects ftp://', lens.isValidLensUrl('ftp://example.com') === false);
+assert('accepts http://192.168.1.5:8000', lens.isValidLensUrl('http://192.168.1.5:8000') === true);
+assert('accepts http://192.168.222.119:8321/query', lens.isValidLensUrl('http://192.168.222.119:8321/query') === true);
+assert('accepts http://10.0.0.1', lens.isValidLensUrl('http://10.0.0.1') === true);
+assert('accepts http://172.16.0.1', lens.isValidLensUrl('http://172.16.0.1') === true);
+assert('accepts http://172.31.255.254', lens.isValidLensUrl('http://172.31.255.254') === true);
+assert('rejects http://172.15.0.1 (outside /12)', lens.isValidLensUrl('http://172.15.0.1') === false);
+assert('rejects http://172.32.0.1 (outside /12)', lens.isValidLensUrl('http://172.32.0.1') === false);
+assert('accepts http://nas.local:8000', lens.isValidLensUrl('http://nas.local:8000') === true);
+assert('accepts http://nas.local.', lens.isValidLensUrl('http://nas.local.') === true);
+assert('accepts http://100.64.0.1 (Tailscale CGNAT)', lens.isValidLensUrl('http://100.64.0.1') === true);
+assert('accepts http://100.127.255.254 (Tailscale CGNAT)', lens.isValidLensUrl('http://100.127.255.254') === true);
+assert('rejects http://100.63.0.1 (outside CGNAT)', lens.isValidLensUrl('http://100.63.0.1') === false);
+assert('rejects http://100.128.0.1 (outside CGNAT)', lens.isValidLensUrl('http://100.128.0.1') === false);
+assert('accepts http://169.254.169.254 (link-local)', lens.isValidLensUrl('http://169.254.169.254') === true);
+assert('accepts http://[::1]:8000', lens.isValidLensUrl('http://[::1]:8000') === true);
+assert('rejects http://8.8.8.8 (public)', lens.isValidLensUrl('http://8.8.8.8') === false);
+assert('rejects http://256.1.1.1 (invalid octet)', lens.isValidLensUrl('http://256.1.1.1') === false);
 
 // ─── 4. Config round-trip ───
 console.log('\n4. Config round-trip');
 const oldConfig = localStorage.getItem('labcharts-lens-config');
 localStorage.removeItem('labcharts-lens-config');
-const def = window.getLensConfig();
+const def = lens.getLensConfig();
 assert('default config has enabled:false', def.enabled === false);
 assert('default config has topK:5', def.topK === 5);
 assert('default config has empty url', def.url === '');
-window.saveLensConfig({ name: 'Test Lens', url: 'https://test.example.com', enabled: true, topK: 7 });
-const savedCfg = window.getLensConfig();
+lens.saveLensConfig({ name: 'Test Lens', url: 'https://test.example.com', enabled: true, topK: 7 });
+const savedCfg = lens.getLensConfig();
 assert('saved name persists', savedCfg.name === 'Test Lens');
 assert('saved url persists', savedCfg.url === 'https://test.example.com');
 assert('saved enabled persists', savedCfg.enabled === true);
@@ -209,27 +203,27 @@ const oldCfg = localStorage.getItem('labcharts-lens-config');
 const oldKey = localStorage.getItem('labcharts-lens-key');
 localStorage.removeItem('labcharts-lens-config');
 localStorage.removeItem('labcharts-lens-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-lens-key', '');
-assert('hasLens false with nothing', window.hasLens() === false);
-window.saveLensConfig({ backend: 'external-server', url: 'https://x.com', enabled: false, topK: 5 });
-window.updateKeyCache && window.updateKeyCache('labcharts-lens-key', 'k');
-assert('hasLens false when disabled', window.hasLens() === false);
-window.saveLensConfig({ enabled: true });
-assert('hasLens true when enabled+url+key', window.hasLens() === true);
-window.saveLensConfig({ url: '' });
-assert('hasLens false without url', window.hasLens() === false);
-window.saveLensConfig({ url: 'https://x.com' });
-window.updateKeyCache && window.updateKeyCache('labcharts-lens-key', '');
-assert('hasLens false without key', window.hasLens() === false);
+cryptoStore.updateKeyCache('labcharts-lens-key', '');
+assert('hasLens false with nothing', lens.hasLens() === false);
+lens.saveLensConfig({ backend: 'external-server', url: 'https://x.com', enabled: false, topK: 5 });
+cryptoStore.updateKeyCache('labcharts-lens-key', 'k');
+assert('hasLens false when disabled', lens.hasLens() === false);
+lens.saveLensConfig({ enabled: true });
+assert('hasLens true when enabled+url+key', lens.hasLens() === true);
+lens.saveLensConfig({ url: '' });
+assert('hasLens false without url', lens.hasLens() === false);
+lens.saveLensConfig({ url: 'https://x.com' });
+cryptoStore.updateKeyCache('labcharts-lens-key', '');
+assert('hasLens false without key', lens.hasLens() === false);
 if (oldCfg) localStorage.setItem('labcharts-lens-config', oldCfg);
 else localStorage.removeItem('labcharts-lens-config');
 if (oldKey) localStorage.setItem('labcharts-lens-key', oldKey);
 else localStorage.removeItem('labcharts-lens-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-lens-key', '');
+cryptoStore.updateKeyCache('labcharts-lens-key', '');
 
 // ─── 6. buildLensSnippet formatting ───
 console.log('\n6. buildLensSnippet formatting');
-const snip1 = window.buildLensSnippet({
+const snip1 = lens.buildLensSnippet({
   chunks: [{ text: 'chunk one text' }, { text: 'chunk two', source: 'Book p.42' }],
   sourceName: 'Test Framework',
 });
@@ -237,26 +231,26 @@ assert('snippet includes sourceName', snip1.includes('Test Framework'));
 assert('snippet numbers chunks', snip1.includes('1. chunk one') && snip1.includes('2. chunk two'));
 assert('snippet includes source citation when present', snip1.includes('Book p.42'));
 assert('snippet includes citation instruction', snip1.includes('cite the source'));
-const empty = window.buildLensSnippet(null);
+const empty = lens.buildLensSnippet(null);
 assert('snippet empty for null', empty === '');
-const noChunks = window.buildLensSnippet({ chunks: [], sourceName: 'X' });
+const noChunks = lens.buildLensSnippet({ chunks: [], sourceName: 'X' });
 assert('snippet empty for no chunks', noChunks === '');
 
 // ─── 7. injectLensChunks behavior ───
 console.log('\n7. injectLensChunks behavior');
 const lensResult = { chunks: [{ text: 'lens fact one' }], sourceName: 'MyLens' };
 const ctxWithLens = `[section:interpretiveLens]\n## Interpretive Lens\nBredesen framework\n[/section:interpretiveLens]\n\nLab data...`;
-const enriched1 = window.injectLensChunks(ctxWithLens, lensResult);
+const enriched1 = labContext.injectLensChunks(ctxWithLens, lensResult);
 assert('retains original lens text', enriched1.includes('Bredesen framework'));
 assert('injects chunk inside block', enriched1.indexOf('lens fact one') < enriched1.indexOf('[/section:interpretiveLens]'));
 assert('chunk appears after original lens text', enriched1.indexOf('lens fact one') > enriched1.indexOf('Bredesen framework'));
 const ctxWithoutLens = `Profile info\n\nLab data...`;
-const enriched2 = window.injectLensChunks(ctxWithoutLens, lensResult);
+const enriched2 = labContext.injectLensChunks(ctxWithoutLens, lensResult);
 assert('creates block when none exists', enriched2.includes('[section:interpretiveLens]') && enriched2.includes('[/section:interpretiveLens]'));
 assert('new block at top when none existed', enriched2.indexOf('[section:interpretiveLens]') < enriched2.indexOf('Profile info'));
-const passthrough = window.injectLensChunks(ctxWithLens, null);
+const passthrough = labContext.injectLensChunks(ctxWithLens, null);
 assert('null lens result is passthrough', passthrough === ctxWithLens);
-const enrichedLong = window.injectLensChunks('Profile info', {
+const enrichedLong = labContext.injectLensChunks('Profile info', {
   chunks: [{ text: 'x'.repeat(5000), source: 'Large doc' }],
   sourceName: 'BigLens',
 });
@@ -265,8 +259,8 @@ assert('long lens chunk does not inject full excerpt', !enrichedLong.includes('x
 
 // ─── 8. Status pub/sub ───
 console.log('\n8. Status pub/sub');
-const unsub = window.subscribeLensStatus(() => {});
-window.getLensStatus();
+const unsub = lens.subscribeLensStatus(() => {});
+lens.getLensStatus();
 assert('subscribeLensStatus returns function', typeof unsub === 'function');
 unsub();
 
@@ -303,7 +297,7 @@ assert('exports injectLensChunks', lcSrc.includes('export function injectLensChu
 assert('injectLensChunks handles close tag', lcSrc.includes('[/section:interpretiveLens]'));
 assert('injectLensChunks caps prompt chunk length', lcSrc.includes('LENS_PROMPT_CHUNK_CHAR_LIMIT'));
 assert('injectLensChunks caps total prompt text', lcSrc.includes('LENS_PROMPT_CHUNK_TOTAL_LIMIT'));
-assert('window exports injectLensChunks', lcSrc.includes('injectLensChunks,'));
+assert('lab-context keeps injectLensChunks module-only', !lcSrc.includes('Object.assign(window, { injectLensChunks'));
 
 // ─── 12. Wiring: sync.js registration ───
 console.log('\n12. sync.js registration');
@@ -333,7 +327,7 @@ assert("app-ai-interaction-modules.js imports './lens.js'", appAiInteractionModu
 
 // ─── 17. saveLensConfig clears cache ───
 console.log('\n17. Cache clear on config change');
-window.clearLensCache();
+lens.clearLensCache();
 assert('clearLensCache callable', true);
 
 // ─── 18. CSS classes for indicator states ───
@@ -369,20 +363,20 @@ console.log('\n21b. v1.20.x forward-compat migration');
   localStorage.setItem('labcharts-lens-config', JSON.stringify({
     name: 'My RAG', url: 'https://rag.example.com/query', enabled: true, topK: 5
   }));
-  const cfg = window.getLensConfig();
+  const cfg = lens.getLensConfig();
   assert('v1.20.x config with URL → backend=external-server',
     cfg.backend === 'external-server',
     `got ${cfg.backend}`);
   assert('v1.20.x config with URL preserves the URL',
     cfg.url === 'https://rag.example.com/query');
   localStorage.removeItem('labcharts-lens-config');
-  const fresh = window.getLensConfig();
+  const fresh = lens.getLensConfig();
   assert('fresh user with no saved config → backend=in-browser',
     fresh.backend === 'in-browser');
   localStorage.setItem('labcharts-lens-config', JSON.stringify({
     name: '', url: '', enabled: false, topK: 5
   }));
-  const never = window.getLensConfig();
+  const never = lens.getLensConfig();
   assert('v1.20.x config with empty URL → backend=in-browser',
     never.backend === 'in-browser',
     `got ${never.backend}`);
@@ -427,17 +421,17 @@ assert('Knowledge Base UI stats row renders WebGPU/WASM label',
 console.log('\n25. Functional: cache preserved on toggle');
 const _preCfg = localStorage.getItem('labcharts-lens-config');
 const _preKey = localStorage.getItem('labcharts-lens-key');
-window.saveLensConfig({ name: 'X', url: 'https://a.example.com', enabled: true, topK: 5 });
-window.updateKeyCache && window.updateKeyCache('labcharts-lens-key', 'k');
-const beforeCfg = window.getLensConfig();
-window.saveLensConfig({ enabled: false });
-const afterCfg = window.getLensConfig();
+lens.saveLensConfig({ name: 'X', url: 'https://a.example.com', enabled: true, topK: 5 });
+cryptoStore.updateKeyCache('labcharts-lens-key', 'k');
+const beforeCfg = lens.getLensConfig();
+lens.saveLensConfig({ enabled: false });
+const afterCfg = lens.getLensConfig();
 assert('enabled toggle persists', afterCfg.enabled === false && beforeCfg.enabled === true);
 if (_preCfg) localStorage.setItem('labcharts-lens-config', _preCfg);
 else localStorage.removeItem('labcharts-lens-config');
 if (_preKey) localStorage.setItem('labcharts-lens-key', _preKey);
 else localStorage.removeItem('labcharts-lens-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-lens-key', '');
+cryptoStore.updateKeyCache('labcharts-lens-key', '');
 
 // ─── 26. Audit: a11y — labels have for= attributes ───
 console.log('\n26. Accessibility: label–input associations');

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -192,16 +192,16 @@ try {
   // Section 5b (picker open/dismiss — live DOM) lives in
   // tests/playwright/dashboard-knowledge-base.spec.js.
 
-  // ─── 6. Window exports ───
+  // ─── 6. Module and remaining shell exports ───
   {
     assert('window.openContextModal exists',
       typeof window.openContextModal === 'function');
     assert('window.openPersonalizeAIPicker exists',
       typeof window.openPersonalizeAIPicker === 'function');
-    assert('window.openKnowledgeBaseModal exists',
-      typeof window.openKnowledgeBaseModal === 'function');
-    assert('window.closeKnowledgeBaseModal exists',
-      typeof window.closeKnowledgeBaseModal === 'function');
+    assert('lens.openKnowledgeBaseModal exists',
+      typeof lens.openKnowledgeBaseModal === 'function');
+    assert('lens.closeKnowledgeBaseModal exists',
+      typeof lens.closeKnowledgeBaseModal === 'function');
     assert('window.renderKnowledgeBaseSection exists',
       typeof window.renderKnowledgeBaseSection === 'function');
     assert('window.triggerDNAFilePicker exists (used by genetics empty stub)',

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -9,7 +9,6 @@ import {
   openContextFromNavRuntime,
   openCreateMarkerFromNavRuntime,
   openEMFAssessmentFromNavRuntime,
-  openKnowledgeBaseFromNavRuntime,
   openReportBuilderFromNavRuntime,
 } from '../js/nav-runtime.js';
 
@@ -32,7 +31,6 @@ const runtimeKeys = [
   'window',
   'navigate',
   'openEMFAssessmentEditor',
-  'openKnowledgeBaseModal',
   'openReportBuilder',
   'openContextModal',
   'openCreateMarkerModal',
@@ -63,7 +61,6 @@ try {
   const browserRuntime = {
     navigate(route) { calls.push(['navigate', route, this === browserRuntime]); },
     openEMFAssessmentEditor() { calls.push(['emf', this === browserRuntime]); },
-    openKnowledgeBaseModal() { calls.push(['kb', this === browserRuntime]); },
     openReportBuilder() { calls.push(['report', this === browserRuntime]); },
     openContextModal() { calls.push(['context', this === browserRuntime]); },
     openCreateMarkerModal() { calls.push(['marker', this === browserRuntime]); },
@@ -73,32 +70,30 @@ try {
 
   navigateFromNavRuntime('labs');
   openEMFAssessmentFromNavRuntime();
-  openKnowledgeBaseFromNavRuntime();
   openReportBuilderFromNavRuntime();
   openContextFromNavRuntime();
   openCreateMarkerFromNavRuntime();
   openClientListFromNavRuntime();
 
   assert('nav runtime delegates all browser callbacks',
-    calls.length === 7
+    calls.length === 6
       && calls.some(call => call[0] === 'navigate' && call[1] === 'labs' && call[2] === true)
-      && ['emf', 'kb', 'report', 'context', 'marker', 'client'].every(name => calls.some(call => call[0] === name && call[1] === true)));
+      && ['emf', 'report', 'context', 'marker', 'client'].every(name => calls.some(call => call[0] === name && call[1] === true)));
 
   exposeNavRuntimeGlobals({ runtimeProbe: 42 });
   assert('exposeNavRuntimeGlobals assigns exports to the browser runtime',
     browserRuntime.runtimeProbe === 42);
 
-  for (const key of ['navigate', 'openEMFAssessmentEditor', 'openKnowledgeBaseModal', 'openReportBuilder', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
+  for (const key of ['navigate', 'openEMFAssessmentEditor', 'openReportBuilder', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
     delete browserRuntime[key];
   }
   navigateFromNavRuntime('missing');
   openEMFAssessmentFromNavRuntime();
-  openKnowledgeBaseFromNavRuntime();
   openReportBuilderFromNavRuntime();
   openContextFromNavRuntime();
   openCreateMarkerFromNavRuntime();
   openClientListFromNavRuntime();
-  assert('nav runtime hooks no-op when browser callbacks are missing', calls.length === 7);
+  assert('nav runtime hooks no-op when browser callbacks are missing', calls.length === 6);
 
   delete globalThis.window;
   let globalRoute = '';

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,9 +187,10 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, piiModule] = await Promise.all([
+  const [apiModule, chartsModule, lensModule, piiModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/charts.js'),
+    import('../js/lens.js'),
     import('../js/pii.js'),
   ]);
   const apiExports = [
@@ -216,6 +217,19 @@
     'refBandPlugin','optimalBandPlugin','noteAnnotationPlugin','supplementBarPlugin',
     'getNotesForChart','getSupplementsForChart',
     'createLineChart','getMarkerDescription'
+  ];
+
+  // lens.js (28, module-only)
+  const lensExports = [
+    'getLensConfig','saveLensConfig','getLensKey','saveLensKey',
+    'hasLens','queryLens','queryLensMulti','buildLensSnippet','testLensConnection','clearLensCache',
+    'openKnowledgeBaseModal','closeKnowledgeBaseModal',
+    'subscribeLensStatus','getLensStatus','isValidLensUrl',
+    'renderCustomLensSection','handleSaveLensConfig','handleToggleLens',
+    'handleClearLensCache','handleRemoveLens','updateLensIndicator',
+    'handleLensBackendChange',
+    'handleLocalLensDeleteDoc','handleLocalLensClear',
+    'handleLibraryActivate','handleLibraryNew','handleLibraryRename','handleLibraryDelete',
   ];
 
   // lab-context.js
@@ -443,6 +457,7 @@
 
   for (const [moduleName, moduleApi, exports] of [
     ['charts.js', chartsModule, chartsExports],
+    ['lens.js', lensModule, lensExports],
     ['pii.js', piiModule, piiExports],
   ]) {
     for (const name of exports) {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.186';
+self.APP_VERSION = '1.10.187';


### PR DESCRIPTION
## Summary
- remove 28 legacy Lens helpers from the browser-global `window` facade
- replace dashboard Context hub and navigation coupling with direct ES module imports
- update module-contract and browser coverage to exercise the public Lens exports directly
- lower the quality baseline from 22 to 21 total `window` assignments and from 20 to 19 legacy assignments
- bump the app version to 1.10.187 for cache invalidation

## Validation
- `./run-tests.sh` (green: 351 Playwright tests, 472 responsive-theme assertions)
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- targeted Lens, dashboard, navigation, and module-verification tests