### PR TITLE
Make supplement helpers module-only

### DIFF
--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -6,6 +6,7 @@ import { hasAIProvider, isAIPaused } from './api.js';
 import { getActiveData } from './data.js';
 import { getProfileLocation, getProfiles } from './profile.js';
 import { renderProfileContextCards } from './context-cards.js';
+import { openSupplementsEditor } from './supplements.js';
 import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
 import { getActivePersonality } from './chat-personalities.js';
 import {
@@ -80,7 +81,7 @@ function handleChatEmptyClick(event) {
     callChatEmptyRuntime('openMenstrualCycleEditor');
   } else if (action === 'open-supplements-editor') {
     closeChatPanel();
-    callChatEmptyRuntime('openSupplementsEditor');
+    openSupplementsEditor();
   } else if (action === 'import-dna') {
     closeChatPanel();
     callChatEmptyRuntime('triggerDNAFilePicker');

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -242,7 +242,7 @@ function _getOuterTimesFromForm() {
 /**
  * @param {Element} inputEl
  */
-function updateIngTotal(inputEl) {
+export function updateIngTotal(inputEl) {
   const row = inputEl.closest('.supp-ingredient-row');
   if (!row) return;
   const amount = getElementValue(row.querySelector('.supp-ing-amount'));
@@ -254,7 +254,7 @@ function updateIngTotal(inputEl) {
   totalEl.textContent = total ? formatSupplementTotal(total) : '';
 }
 
-function updateAllIngTotals() {
+export function updateAllIngTotals() {
   const rows = document.querySelectorAll('#supp-ingredients .supp-ingredient-row');
   for (const row of rows) {
     const amountInput = row.querySelector('.supp-ing-amount');
@@ -262,7 +262,7 @@ function updateAllIngTotals() {
   }
 }
 
-function addIngredientRow() {
+export function addIngredientRow() {
   const container = document.getElementById('supp-ingredients');
   if (!container) return;
   const idx = container.children.length;
@@ -275,7 +275,7 @@ function addIngredientRow() {
 /**
  * @param {Element} btn
  */
-function removeIngredientRow(btn) {
+export function removeIngredientRow(btn) {
   btn.closest('.supp-ingredient-row')?.remove();
 }
 
@@ -288,7 +288,7 @@ function _periodRowHtml(idx, start = '', end = '', showRemove = true) {
   </div>`;
 }
 
-function addPeriodRow() {
+export function addPeriodRow() {
   const container = document.getElementById('supp-periods');
   if (!container) return;
   const idx = container.children.length;
@@ -302,7 +302,7 @@ function addPeriodRow() {
 /**
  * @param {Element} btn
  */
-function removePeriodRow(btn) {
+export function removePeriodRow(btn) {
   const container = document.getElementById('supp-periods');
   if (!container) return;
   btn.closest('.supp-period-row')?.remove();
@@ -340,7 +340,7 @@ function _collectIngredients() {
   return ingredients.length > 0 ? ingredients : undefined;
 }
 
-async function scanSupplementLabel(input) {
+export async function scanSupplementLabel(input) {
   const file = input.files?.[0];
   input.value = '';
   if (!file || !isValidImageType(file.type)) { showNotification('Please select an image (JPG, PNG, WebP)', 'error'); return; }
@@ -383,7 +383,7 @@ function _applyParsedSupplement(parsed) {
   if (dosageInput && !dosageInput.value.trim() && _valid(parsed.dosage)) dosageInput.value = parsed.dosage;
 }
 
-async function fetchSupplementFromURL() {
+export async function fetchSupplementFromURL() {
   const rawUrl = getFieldValue('supp-url').trim();
   if (!rawUrl) { showNotification('Paste a product URL first', 'error'); return; }
   const parsedUrl = _parseHttpUrl(rawUrl);
@@ -691,7 +691,7 @@ export function deleteSupplement(idx) {
   }
 }
 
-function askAIMitoContext() {
+export function askAIMitoContext() {
   const askButton = document.querySelector('[aria-label="Ask AI"]');
   if (askButton instanceof HTMLElement) askButton.click();
   setTimeout(() => {
@@ -723,5 +723,3 @@ initSupplementActionDelegates({
   updateIngredientTotal: updateIngTotal,
   updateAllIngredientTotals: updateAllIngTotals,
 });
-
-Object.assign(window, { renderSupplementsSection, openSupplementsEditor, toggleSuppAccordion, showAddSuppForm, saveSupplement, deleteSupplement, askAIMitoContext, computeAllImpacts, getSupplementPeriods, addIngredientRow, removeIngredientRow, addPeriodRow, removePeriodRow, scanSupplementLabel, fetchSupplementFromURL, refreshSupplementImpact, updateIngTotal, updateAllIngTotals, ingredientDailyTotal });

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 21,
-  "legacyWindowGlobalAssignments": 19,
+  "windowGlobalAssignments": 20,
+  "legacyWindowGlobalAssignments": 18,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -27,7 +27,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     const savedFns = {
       closeChatPanel: window.closeChatPanel,
       openMenstrualCycleEditor: window.openMenstrualCycleEditor,
-      openSupplementsEditor: window.openSupplementsEditor,
       triggerDNAFilePicker: window.triggerDNAFilePicker,
       openSettingsModal: window.openSettingsModal,
     };
@@ -47,7 +46,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
 
       window.closeChatPanel = () => calls.push('close-chat');
       window.openMenstrualCycleEditor = () => calls.push('open-cycle');
-      window.openSupplementsEditor = () => calls.push('open-supplements');
       window.triggerDNAFilePicker = () => calls.push('import-dna');
       window.openSettingsModal = tab => calls.push(`open-settings:${tab}`);
       HTMLInputElement.prototype.click = function() {
@@ -128,9 +126,10 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
         countrySaved: getProfileLocation('chat-empty-test').country === 'Germany',
         optionalActionsCalled: calls.includes('close-chat')
           && calls.includes('open-cycle')
-          && calls.includes('open-supplements')
           && calls.includes('import-dna')
           && calls.includes('open-settings:wearables'),
+        supplementsEditorOpenedThroughModule: document.getElementById('modal-overlay')?.classList.contains('show') === true
+          && document.querySelector('#detail-modal h3')?.textContent === 'Supplements & Medications',
         mtdnaInputScoped: inputClicks.includes('scoped') && !inputClicks.includes('stray'),
         optionalActionsStopPropagation: bubbledClicks === bubbledBeforeOptionalActions,
       };
@@ -143,6 +142,7 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       if (saved.profilesStorage === null) localStorage.removeItem('labcharts-profiles');
       else localStorage.setItem('labcharts-profiles', saved.profilesStorage);
       Object.assign(window, savedFns);
+      document.getElementById('modal-overlay')?.classList.remove('show');
       HTMLInputElement.prototype.click = savedInputClick;
       strayMtDnaInput.remove();
       container.remove();

--- a/tests/playwright/supplement-impact-browser-coverage.spec.js
+++ b/tests/playwright/supplement-impact-browser-coverage.spec.js
@@ -46,6 +46,7 @@ test('supplement impact browser coverage exercises render cache AI and refresh p
       { state },
       data,
       { profileStorageKey },
+      supplements,
     ] = await Promise.all([
       import(impactUrl),
       import('/js/state.js'),
@@ -199,7 +200,8 @@ test('supplement impact browser coverage exercises render cache AI and refresh p
       outcomes.cachedRenderShowsRefresh = !!host.querySelector('.supp-impact-refresh');
 
       host.querySelector('.supp-impact-refresh')?.click();
-      outcomes.refreshUsesWindowRegisteredHandler = typeof window.refreshSupplementImpact === 'function';
+      outcomes.refreshUsesModuleHandler = typeof supplements.refreshSupplementImpact === 'function'
+        && !('refreshSupplementImpact' in window);
       outcomes.refreshClearsSummaryImmediately = document.getElementById('supp-impact-summary-0')?.textContent === '';
       outcomes.refreshShowsShimmerImmediately = document.getElementById('supp-impact-dot-0')?.classList.contains('ctx-health-dot-shimmer') === true;
       await waitUntil(() => document.getElementById('supp-impact-summary-0')?.textContent?.includes('needs review'), 'refreshed impact summary');

--- a/tests/playwright/supplements-browser-coverage.spec.js
+++ b/tests/playwright/supplements-browser-coverage.spec.js
@@ -18,8 +18,6 @@ function expectAll(outcomes) {
 test('supplements browser coverage handles editor ingredients imports sync and AI handoff', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openSupplementsEditor === 'function'
-    && typeof window.fetchSupplementFromURL === 'function');
   await page.evaluate(() => {
     window.endTour?.();
     document.getElementById('tour-overlay')?.remove();
@@ -29,9 +27,10 @@ test('supplements browser coverage handles editor ingredients imports sync and A
   });
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data] = await Promise.all([
+    const [{ state }, data, supplements] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
+      import('/js/supplements.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -137,26 +136,26 @@ test('supplements browser coverage handles editor ingredients imports sync and A
       };
       data.invalidateActiveDataCache();
 
-      window.openSupplementsEditor();
+      supplements.openSupplementsEditor();
       await waitUntil(() => document.getElementById('modal-overlay')?.classList.contains('show'), 'supplement editor open');
-      window.toggleSuppAccordion(0);
+      supplements.toggleSuppAccordion(0);
       await waitUntil(() => !!document.querySelector('.supp-list-expanded'), 'supplement row expanded');
       const expanded = document.querySelector('.supp-list-expanded');
       const activeRow = document.querySelector('.supp-list-item[data-idx="0"]');
       const activeBeforeClose = activeRow?.classList.contains('supp-list-item-active') === true;
-      window.toggleSuppAccordion(0);
+      supplements.toggleSuppAccordion(0);
       outcomes.toggleSuppAccordionOpensAndClosesExistingRows =
         expanded?.dataset.expandedIdx === '0'
         && activeBeforeClose
         && !document.querySelector('.supp-list-expanded');
 
-      window.showAddSuppForm();
+      supplements.showAddSuppForm();
       await waitUntil(() => !!document.getElementById('supp-form-panel'), 'add form open');
       const timesInput = document.getElementById('supp-times');
       timesInput.value = '2';
       timesInput.dispatchEvent(new Event('input', { bubbles: true }));
-      window.addIngredientRow();
-      window.addIngredientRow();
+      supplements.addIngredientRow();
+      supplements.addIngredientRow();
       await waitUntil(() => document.querySelectorAll('#supp-ingredients .supp-ingredient-row').length === 2, 'ingredient rows added');
       const addRowFocusedLastName = document.activeElement?.classList.contains('supp-ing-name') === true;
       const firstRow = document.querySelector('#supp-ingredients .supp-ingredient-row');
@@ -165,13 +164,13 @@ test('supplements browser coverage handles editor ingredients imports sync and A
       amountInput.dispatchEvent(new Event('input', { bubbles: true }));
       const timesOverride = firstRow.querySelector('.supp-ing-times');
       timesOverride.value = '3';
-      window.updateIngTotal(timesOverride);
+      supplements.updateIngTotal(timesOverride);
       const overriddenTotal = firstRow.querySelector('.supp-ing-total')?.textContent || '';
       const secondRemove = document.querySelectorAll('#supp-ingredients .supp-ing-remove')[1];
-      window.removeIngredientRow(secondRemove);
+      supplements.removeIngredientRow(secondRemove);
       const remainingRows = document.querySelectorAll('#supp-ingredients .supp-ingredient-row').length;
       timesOverride.value = '';
-      window.updateAllIngTotals();
+      supplements.updateAllIngTotals();
       const outerTotal = firstRow.querySelector('.supp-ing-total')?.textContent || '';
       outcomes.ingredientTotalsUseRowOverrideOuterTimesAndRemoval =
         overriddenTotal === '375 mg/day'
@@ -180,7 +179,7 @@ test('supplements browser coverage handles editor ingredients imports sync and A
         && addRowFocusedLastName;
 
       document.getElementById('supp-url').value = ' https://example.test/products/magnesium ';
-      await window.fetchSupplementFromURL();
+      await supplements.fetchSupplementFromURL();
       await waitUntil(() => (document.getElementById('supp-name')?.value || '') === 'Magnesium Complex', 'URL import fields populated');
       const importedRows = Array.from(document.querySelectorAll('#supp-ingredients .supp-ingredient-row'))
         .map(row => ({
@@ -208,13 +207,13 @@ test('supplements browser coverage handles editor ingredients imports sync and A
         value: [new File(['not an image'], 'label.txt', { type: 'text/plain' })],
       });
       document.body.appendChild(badInput);
-      await window.scanSupplementLabel(badInput);
+      await supplements.scanSupplementLabel(badInput);
       outcomes.scanSupplementLabelRejectsInvalidFile =
         Array.from(document.querySelectorAll('.notification-toast'))
           .some(el => (el.textContent || '').includes('Please select an image'));
       badInput.remove();
 
-      window.openSupplementsEditor(0);
+      supplements.openSupplementsEditor(0);
       await waitUntil(() => !!document.querySelector('.supp-list-expanded'), 'edit form open');
       state.importedData.supplements[0].note = 'synced note from remote';
       window.dispatchEvent(new Event('labcharts-sync-applied'));
@@ -235,7 +234,7 @@ test('supplements browser coverage handles editor ingredients imports sync and A
       textarea.addEventListener('input', () => calls.push(['chat-input']));
       aiFixture.append(askButton, textarea);
       document.body.prepend(aiFixture);
-      window.askAIMitoContext();
+      supplements.askAIMitoContext();
       await waitUntil(() => textarea.value.includes('mitochondrial effects'), 'AI context prompt inserted');
       outcomes.askAIMitoContextClicksAIAndSeedsChatPrompt =
         calls.some(call => call[0] === 'ask-ai-click')

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -808,7 +808,8 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     await delay(100);
   }
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
+    const supplements = await import('/js/supplements.js');
     const state = window._labState;
     window.__suppModalSnapshot = JSON.stringify(state?.importedData?.supplements || []);
     if (state?.importedData) {
@@ -825,10 +826,10 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
         note: '',
       }];
     }
-    window.openSupplementsEditor?.();
-    window.showAddSuppForm?.();
-    window.addIngredientRow?.();
-    window.addPeriodRow?.();
+    supplements.openSupplementsEditor();
+    supplements.showAddSuppForm();
+    supplements.addIngredientRow();
+    supplements.addPeriodRow();
   });
   await delay(150);
   result = await page.evaluate(() => {

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -25,6 +25,7 @@ return (async function() {
   }
   const main = document.getElementById('main-content');
   const S = window._labState;
+  const supplements = await import('/js/supplements.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -374,12 +375,12 @@ return (async function() {
   const initialSuppCount = (S.importedData.supplements || []).length;
 
   // Open supplement editor
-  window.openSupplementsEditor();
+  supplements.openSupplementsEditor();
   await wait(50);
   assert('Supplement editor opens', modalOverlay.classList.contains('show'));
 
   // Show add form
-  window.showAddSuppForm();
+  supplements.showAddSuppForm();
   await wait(20);
   const nameInput = document.getElementById('supp-name');
   assert('Add form has name input', !!nameInput);
@@ -395,7 +396,7 @@ return (async function() {
   if (sourceInput) sourceInput.value = 'https://www.example.com/products/a?x=1';
 
   // Save
-  window.saveSupplement(-1);
+  supplements.saveSupplement(-1);
   await wait(50);
 
   // Verify data saved
@@ -424,7 +425,7 @@ return (async function() {
   // Delete the test supplement
   const testIdx = S.importedData.supplements.findIndex(s => s.name === '__UI_TEST_SUPP__');
   if (testIdx >= 0) {
-    window.deleteSupplement(testIdx);
+    supplements.deleteSupplement(testIdx);
     await wait(50);
   }
   assert('Supplement removed from state', (S.importedData.supplements || []).length === initialSuppCount);
@@ -436,9 +437,9 @@ return (async function() {
   const stillShows = suppSectionAfter?.innerHTML.includes('__UI_TEST_SUPP__');
   assert('Dashboard no longer shows deleted supplement', !stillShows);
 
-  window.openSupplementsEditor();
+  supplements.openSupplementsEditor();
   await wait(50);
-  window.showAddSuppForm();
+  supplements.showAddSuppForm();
   await wait(20);
   const invalidNameInput = document.getElementById('supp-name');
   if (invalidNameInput) invalidNameInput.value = '__UI_TEST_BAD_URL__';
@@ -447,7 +448,7 @@ return (async function() {
   const invalidSourceInput = document.getElementById('supp-url');
   if (invalidSourceInput) invalidSourceInput.value = 'javascript:alert(1)';
   const beforeInvalidSuppCount = (S.importedData.supplements || []).length;
-  window.saveSupplement(-1);
+  supplements.saveSupplement(-1);
   await wait(50);
   assert('Invalid supplement URL is rejected', (S.importedData.supplements || []).length === beforeInvalidSuppCount);
   assert('Invalid URL supplement not saved', !S.importedData.supplements?.some(s => s.name === '__UI_TEST_BAD_URL__'));
@@ -464,7 +465,7 @@ return (async function() {
     note: '',
     sourceUrl: 'javascript://example.com/%0Aalert(1)'
   }];
-  window.openSupplementsEditor();
+  supplements.openSupplementsEditor();
   await wait(50);
   const unsafeSuppRow = Array.from(document.querySelectorAll('.supp-list-item')).find(row => row.textContent.includes('__UI_TEST_UNSAFE_SOURCE__'));
   assert('Unsafe imported source URL does not render as link', unsafeSuppRow && !unsafeSuppRow.querySelector('.supp-list-source'));
@@ -477,9 +478,9 @@ return (async function() {
   // ═══════════════════════════════════════════════
   console.log('%c 6. Supplement periods', 'font-weight:bold;color:#6366f1');
 
-  window.openSupplementsEditor();
+  supplements.openSupplementsEditor();
   await wait(50);
-  window.showAddSuppForm();
+  supplements.showAddSuppForm();
   await wait(20);
 
   // Count initial period rows
@@ -487,7 +488,7 @@ return (async function() {
   assert('Editor starts with 1 period row', periodRows.length === 1);
 
   // Add a second period
-  window.addPeriodRow();
+  supplements.addPeriodRow();
   await wait(50);
   const afterAdd = document.querySelectorAll('.supp-period-row');
   assert('Add period creates 2 rows', afterAdd.length === 2);
@@ -498,7 +499,7 @@ return (async function() {
   assert('Remove buttons visible with 2 rows', visibleRemove.length >= 1);
 
   // Remove second row
-  if (afterAdd[1]) window.removePeriodRow(afterAdd[1].querySelector('.supp-period-remove'));
+  if (afterAdd[1]) supplements.removePeriodRow(afterAdd[1].querySelector('.supp-period-remove'));
   await wait(50);
   assert('Remove period back to 1 row', document.querySelectorAll('.supp-period-row').length === 1);
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,11 +187,12 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, lensModule, piiModule] = await Promise.all([
+  const [apiModule, chartsModule, lensModule, piiModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/charts.js'),
     import('../js/lens.js'),
     import('../js/pii.js'),
+    import('../js/supplements.js'),
   ]);
   const apiExports = [
     'getVeniceKey','saveVeniceKey','hasVeniceKey',
@@ -414,10 +415,22 @@
     'removeFolderBackup','getFolderBackupState','renderFolderBackupSection',
   ];
 
-  // supplements.js (4)
+  // supplements.js (23, module-only)
   const supplementsExports = [
-    'renderSupplementsSection','openSupplementsEditor',
-    'saveSupplement','deleteSupplement'
+    'renderSupplementsSection','openSupplementsEditor','toggleSuppAccordion','showAddSuppForm',
+    'saveSupplement','deleteSupplement','askAIMitoContext',
+    'computeAllImpacts','computeSupplementImpact','effectiveTimesPerDay',
+    'getSupplementPeriods','ingredientDailyTotal','parseAmount',
+    'refreshSupplementImpact','renderSupplementImpact',
+    'addIngredientRow','removeIngredientRow','addPeriodRow','removePeriodRow',
+    'scanSupplementLabel','fetchSupplementFromURL','updateIngTotal','updateAllIngTotals'
+  ];
+  const supplementLegacyGlobals = [
+    'renderSupplementsSection','openSupplementsEditor','toggleSuppAccordion','showAddSuppForm',
+    'saveSupplement','deleteSupplement','askAIMitoContext','computeAllImpacts',
+    'getSupplementPeriods','addIngredientRow','removeIngredientRow','addPeriodRow',
+    'removePeriodRow','scanSupplementLabel','fetchSupplementFromURL',
+    'refreshSupplementImpact','updateIngTotal','updateAllIngTotals','ingredientDailyTotal'
   ];
 
   // theme.js (8)
@@ -459,6 +472,7 @@
     ['charts.js', chartsModule, chartsExports],
     ['lens.js', lensModule, lensExports],
     ['pii.js', piiModule, piiExports],
+    ['supplements.js', supplementsModule, supplementsExports],
   ]) {
     for (const name of exports) {
       const val = moduleApi[name];
@@ -466,6 +480,9 @@
       assert(`${moduleName}.${name} module export`, val !== undefined, isFunc ? 'function' : typeof val);
     }
     console.log(`Checked ${exports.length} ${moduleName} module exports`);
+  }
+  for (const name of supplementLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
   }
 
   const allModules = {
@@ -483,7 +500,6 @@
     'settings.js': settingsExports,
     'provider-panels.js': providerPanelsExports,
     'backup.js': backupExports,
-    'supplements.js': supplementsExports,
     'theme.js': themeExports,
     'utils.js': utilsExports,
     'views.js': viewsExports,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.187';
+self.APP_VERSION = '1.10.188';


### PR DESCRIPTION
## Summary
- remove all 19 legacy Supplements helpers from the browser-global `window` facade
- route the chat onboarding supplement action through a direct ES module import
- expose editor helpers through the Supplements module for direct browser and UI-flow coverage
- verify the former global surface stays module-only
- lower the quality baseline from 21 to 20 total `window` assignments and from 19 to 18 legacy assignments
- bump the app version to 1.10.188 for cache invalidation

## Validation
- `./run-tests.sh` (green: 351 Playwright tests, 472 responsive-theme assertions)
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`
- targeted supplement, chat onboarding, UI-flow, and responsive-theme tests