### PR TITLE
Make cycle helpers module-only

### DIFF
--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -6,6 +6,7 @@ import { hasAIProvider, isAIPaused } from './api.js';
 import { getActiveData } from './data.js';
 import { getProfileLocation, getProfiles } from './profile.js';
 import { renderProfileContextCards } from './context-cards.js';
+import { openMenstrualCycleEditor } from './cycle.js';
 import { openSupplementsEditor } from './supplements.js';
 import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
 import { getActivePersonality } from './chat-personalities.js';
@@ -78,7 +79,7 @@ function handleChatEmptyClick(event) {
     skipContextCards();
   } else if (action === 'open-cycle-editor') {
     closeChatPanel();
-    callChatEmptyRuntime('openMenstrualCycleEditor');
+    openMenstrualCycleEditor();
   } else if (action === 'open-supplements-editor') {
     closeChatPanel();
     openSupplementsEditor();

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -59,7 +59,6 @@ const SOURCE_LABELS = {
 };
 const appWindow = /** @type {Window & typeof globalThis & {
   recordChange?: (field: string) => void,
-  openMenstrualCycleEditor?: () => void,
   navigate?: (category: string) => void,
   renderProfileButton?: () => void,
   closeModal?: () => void,
@@ -67,6 +66,11 @@ const appWindow = /** @type {Window & typeof globalThis & {
 
 let pendingCycleImport = null;
 let cycleImportDelegatesInstalled = false;
+
+async function openCycleEditorFromImport() {
+  const { openMenstrualCycleEditor } = await import('./cycle.js');
+  openMenstrualCycleEditor();
+}
 
 function importActionAttrs(action, data = {}) {
   const attrs = [`${CYCLE_IMPORT_ACTION}="${escapeAttr(action)}"`];
@@ -665,7 +669,9 @@ async function handleCycleImportAction(event) {
       showNotification(`Cycle import complete - ${result.periods} periods, ${result.observations} local observations`, 'success', 1200);
       closeCycleImportPreview(result);
       appWindow.navigate?.('body');
-      setTimeout(() => { appWindow.openMenstrualCycleEditor?.(); }, appWindow.navigate ? 1550 : 0);
+      setTimeout(() => {
+        openCycleEditorFromImport().catch(error => showNotification(`Could not reopen cycle history: ${error.message}`, 'error'));
+      }, appWindow.navigate ? 1550 : 0);
     } catch (err) {
       target.removeAttribute('disabled');
       showNotification(`Cycle import failed: ${err.message}`, 'error');
@@ -675,13 +681,13 @@ async function handleCycleImportAction(event) {
     if (!source || !await showConfirmDialog(`Remove all ${sourceLabel(source)} cycle data from this profile?`)) return;
     await deleteCycleSourceFromProfile(source);
     showNotification(`${sourceLabel(source)} cycle data removed`, 'info');
-    appWindow.openMenstrualCycleEditor?.();
+    await openCycleEditorFromImport();
   } else if (action === 'delete-import') {
     const importId = target.dataset.cycleImportImportId || '';
     if (!importId || !await showConfirmDialog('Remove this imported cycle batch?')) return;
     await deleteCycleImportFromProfile(importId);
     showNotification('Imported cycle batch removed', 'info');
-    appWindow.openMenstrualCycleEditor?.();
+    await openCycleEditorFromImport();
   }
 }
 

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -594,7 +594,7 @@ export async function clearMenstrualCycle() {
   }
 }
 
-function _toggleCycleEditorFields() {
+export function _toggleCycleEditorFields() {
   const status = getFieldValue('mc-cycle-status');
   const fields = document.getElementById('mc-active-fields');
   const periodLog = document.getElementById('mc-period-log-section');
@@ -790,8 +790,4 @@ export function renderMenstrualCycleSection(data, opts = {}) {
   }
   html += `</div>`;
   return html;
-}
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, { getCyclePhase, getNextBestDrawDate, getBloodDrawPhases, detectPerimenopausePattern, detectCycleIronAlerts, renderMenstrualCycleSection, openMenstrualCycleEditor, saveMenstrualCycle, clearMenstrualCycle, syncMenstrualCycleProfileFromForm, addPeriodEntry, deletePeriodEntry, toggleCycleSymptomTag, _toggleCycleEditorFields });
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 20,
-  "legacyWindowGlobalAssignments": 18,
+  "windowGlobalAssignments": 19,
+  "legacyWindowGlobalAssignments": 17,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -26,7 +26,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     };
     const savedFns = {
       closeChatPanel: window.closeChatPanel,
-      openMenstrualCycleEditor: window.openMenstrualCycleEditor,
       triggerDNAFilePicker: window.triggerDNAFilePicker,
       openSettingsModal: window.openSettingsModal,
     };
@@ -45,7 +44,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       if (chatMessages) chatMessages.innerHTML = '';
 
       window.closeChatPanel = () => calls.push('close-chat');
-      window.openMenstrualCycleEditor = () => calls.push('open-cycle');
       window.triggerDNAFilePicker = () => calls.push('import-dna');
       window.openSettingsModal = tab => calls.push(`open-settings:${tab}`);
       HTMLInputElement.prototype.click = function() {
@@ -110,6 +108,8 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       renderEmptyChatState(container, panel);
       const bubbledBeforeOptionalActions = bubbledClicks;
       container.querySelector('[data-chat-empty-action="open-cycle-editor"]')?.click();
+      const cycleEditorOpenedThroughModule = document.getElementById('modal-overlay')?.classList.contains('show') === true
+        && document.querySelector('#detail-modal .gb-modal-title')?.textContent === 'Menstrual Cycle';
       container.querySelector('[data-chat-empty-action="open-supplements-editor"]')?.click();
       container.querySelector('[data-chat-empty-action="import-dna"]')?.click();
       container.querySelector('[data-chat-empty-action="import-mtdna"]')?.click();
@@ -125,9 +125,9 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
         heightConverted: heightInput.value === '70.9',
         countrySaved: getProfileLocation('chat-empty-test').country === 'Germany',
         optionalActionsCalled: calls.includes('close-chat')
-          && calls.includes('open-cycle')
           && calls.includes('import-dna')
           && calls.includes('open-settings:wearables'),
+        cycleEditorOpenedThroughModule,
         supplementsEditorOpenedThroughModule: document.getElementById('modal-overlay')?.classList.contains('show') === true
           && document.querySelector('#detail-modal h3')?.textContent === 'Supplements & Medications',
         mtdnaInputScoped: inputClicks.includes('scoped') && !inputClicks.includes('stray'),

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -23,11 +23,10 @@ function assert(name, condition, detail = '') {
 
 console.log('=== Cycle Improvements Test Suite ===\n');
 
-// Load state + data.js + cycle.js so window.getActiveData /
-// setPhaseOverlay / detectPerimenopausePattern / etc. exist.
+// Load state + data.js + cycle.js so the data globals and cycle module exist.
 await import('../js/state.js');
 await import('../js/data.js');
-await import('../js/cycle.js');
+const cycle = await import('../js/cycle.js');
 const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 1: PERIOD_SYMPTOMS constant ──
   console.log('Section 1: PERIOD_SYMPTOMS constant');
@@ -148,7 +147,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 11: detectPerimenopausePattern ──
   console.log('Section 11: detectPerimenopausePattern');
   {
-    assert('detectPerimenopausePattern is a window function', typeof window.detectPerimenopausePattern === 'function');
+    assert('detectPerimenopausePattern is a module function', typeof cycle.detectPerimenopausePattern === 'function');
 
     // Returns null for <35 age
     const youngMC = {
@@ -161,7 +160,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
       ]
     };
     const youngDob = '2005-01-01'; // ~20 years old
-    const youngResult = window.detectPerimenopausePattern(youngMC, youngDob);
+    const youngResult = cycle.detectPerimenopausePattern(youngMC, youngDob);
     assert('Returns null for age <35', youngResult === null);
 
     // Returns null for <4 periods
@@ -171,11 +170,11 @@ const { phaseBandPlugin } = await import('../js/charts.js');
         { startDate: '2025-02-01', endDate: '2025-02-05', flow: 'moderate' }
       ]
     };
-    const result2 = window.detectPerimenopausePattern(fewMC, '1980-01-01');
+    const result2 = cycle.detectPerimenopausePattern(fewMC, '1980-01-01');
     assert('Returns null for <4 periods', result2 === null);
 
     // Returns null for no DOB
-    assert('Returns null for no DOB', window.detectPerimenopausePattern(youngMC, null) === null);
+    assert('Returns null for no DOB', cycle.detectPerimenopausePattern(youngMC, null) === null);
   }
 
   // ── Section 12: detectPerimenopausePattern with qualifying data ──
@@ -192,7 +191,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
         { startDate: '2024-07-05', endDate: '2024-07-10', flow: 'heavy' }
       ]
     };
-    const periResult = window.detectPerimenopausePattern(periMC, '1979-01-01'); // ~45-46
+    const periResult = cycle.detectPerimenopausePattern(periMC, '1979-01-01'); // ~45-46
     assert('Detects perimenopause for qualifying data', periResult !== null);
     assert('Has indicators array', Array.isArray(periResult?.indicators));
     assert('Has 2+ indicators', periResult?.indicators?.length >= 2, `got ${periResult?.indicators?.length}: ${periResult?.indicators?.join(', ')}`);
@@ -203,7 +202,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 13: detectCycleIronAlerts empty ──
   console.log('Section 13: detectCycleIronAlerts empty cases');
   {
-    assert('detectCycleIronAlerts is a window function', typeof window.detectCycleIronAlerts === 'function');
+    assert('detectCycleIronAlerts is a module function', typeof cycle.detectCycleIronAlerts === 'function');
 
     // No heavy flow → no alerts
     const mc1 = {
@@ -213,11 +212,11 @@ const { phaseBandPlugin } = await import('../js/charts.js');
       ]
     };
     const data1 = window.getActiveData();
-    const alerts1 = window.detectCycleIronAlerts(mc1, data1);
+    const alerts1 = cycle.detectCycleIronAlerts(mc1, data1);
     assert('No alerts for no heavy flow', alerts1.length === 0);
 
     // Null mc → empty
-    assert('No alerts for null mc', window.detectCycleIronAlerts(null, data1).length === 0);
+    assert('No alerts for null mc', cycle.detectCycleIronAlerts(null, data1).length === 0);
   }
 
   // ── Section 14: detectCycleIronAlerts with heavy flow ──
@@ -234,7 +233,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
     const origEntries = state.importedData.entries;
     state.importedData.entries = [{ date: '2025-01-10', markers: { 'biochemistry.glucose': 5.0 } }];
     const data2 = window.getActiveData();
-    const alerts2 = window.detectCycleIronAlerts(mc2, data2);
+    const alerts2 = cycle.detectCycleIronAlerts(mc2, data2);
     assert('Info alert when no iron panel + heavy flow', alerts2.some(a => a.severity === 'info'), `got ${JSON.stringify(alerts2.map(a=>a.severity))}`);
     state.importedData.entries = origEntries;
   }

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,9 +187,10 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, lensModule, piiModule, supplementsModule] = await Promise.all([
+  const [apiModule, chartsModule, cycleModule, lensModule, piiModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/charts.js'),
+    import('../js/cycle.js'),
     import('../js/lens.js'),
     import('../js/pii.js'),
     import('../js/supplements.js'),
@@ -296,13 +297,21 @@
     'openClientList','closeClientList','openClientForm','configureClientListRuntime'
   ];
 
-  // cycle.js (10)
+  // cycle.js (15, module-only)
   const cycleExports = [
     'getCyclePhase','getNextBestDrawDate','getBloodDrawPhases',
+    'calculateCycleStats','detectPerimenopausePattern','detectCycleIronAlerts',
     'renderMenstrualCycleSection',
     'openMenstrualCycleEditor','saveMenstrualCycle','clearMenstrualCycle',
     'syncMenstrualCycleProfileFromForm',
-    'addPeriodEntry','deletePeriodEntry'
+    'addPeriodEntry','deletePeriodEntry','toggleCycleSymptomTag','_toggleCycleEditorFields'
+  ];
+  const cycleLegacyGlobals = [
+    'getCyclePhase','getNextBestDrawDate','getBloodDrawPhases',
+    'detectPerimenopausePattern','detectCycleIronAlerts','renderMenstrualCycleSection',
+    'openMenstrualCycleEditor','saveMenstrualCycle','clearMenstrualCycle',
+    'syncMenstrualCycleProfileFromForm','addPeriodEntry','deletePeriodEntry',
+    'toggleCycleSymptomTag','_toggleCycleEditorFields'
   ];
 
   // data.js (26)
@@ -470,6 +479,7 @@
 
   for (const [moduleName, moduleApi, exports] of [
     ['charts.js', chartsModule, chartsExports],
+    ['cycle.js', cycleModule, cycleExports],
     ['lens.js', lensModule, lensExports],
     ['pii.js', piiModule, piiExports],
     ['supplements.js', supplementsModule, supplementsExports],
@@ -484,13 +494,15 @@
   for (const name of supplementLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of cycleLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
 
   const allModules = {
     'lab-context.js': labContextExports,
     'chat.js': chatExports,
     'client-list.js': clientListExports,
     'context-cards.js': contextCardsExports,
-    'cycle.js': cycleExports,
     'data.js': dataExports,
     'export.js': exportExports,
     'nav.js': navExports,
@@ -762,7 +774,7 @@
   // ═══════════════════════════════════════════════
   // 19. CYCLE HELPERS — pure function checks
   // ═══════════════════════════════════════════════
-  const phase = window.getCyclePhase('2026-02-15', {
+  const phase = cycleModule.getCyclePhase('2026-02-15', {
     cycleLength: 28, periodLength: 5, regularity: 'regular',
     periods: [{ startDate: '2026-02-01' }]
   });

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.188';
+self.APP_VERSION = '1.10.189';


### PR DESCRIPTION
## Summary
- remove all 14 legacy menstrual-cycle helpers from the browser-global `window` facade
- route chat onboarding directly through the Cycle ES module
- replace cycle-import's hidden editor global with a lazy module import that avoids the existing circular module graph
- verify the former global surface stays module-only and update cycle behavior coverage
- lower the quality baseline from 20 to 19 total `window` assignments and from 18 to 17 legacy assignments
- bump the app version to 1.10.189 for cache invalidation

## Validation
- `./run-tests.sh` (green: 351 Playwright tests, 472 responsive-theme assertions)
- `npx vitest run tests/cycle-import-phase1.test.js` (23/23)
- `node tests/test-cycle-improvements.js` (75/75)
- targeted cycle, cycle-import, onboarding, dashboard, and lens browser tests
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`