### PR TITLE
Make Light Tools module-only

### DIFF
--- a/js/light-ai-save-hooks.js
+++ b/js/light-ai-save-hooks.js
@@ -2,7 +2,15 @@
 // light-ai-save-hooks.js - wire saved Light/onboarding records to AI analyzers.
 
 import { configureLightEnvAudits } from './light-env-audits.js';
-import { configureLightTools, getMeasurementsForRoom } from './light-tools.js';
+import {
+  configureLightTools,
+  getMeasurementsForRoom,
+  openCCTMeter,
+  openDarknessMeter,
+  openFlickerDetector,
+  openLuxMeter,
+  openSpectrumClassifier,
+} from './light-tools.js';
 import { configureSunDefaults } from './sun-defaults.js';
 import { hasAIProvider } from './api.js';
 import { addRoom, configureLightEnv, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';
@@ -16,7 +24,17 @@ import { getSessions, hydrateSession, logCompletedSession } from './sun-sessions
 import { maybeAnalyzeOnboardingAfterSave, renderOnboardingAIBlock } from './sun-onboarding-ai.js';
 import { solarZenithAngle } from './sun-uvdata.js';
 
-configureLightEnv({ getMeasurementsForRoom, renderMeasurementAIInline, renderRoomAIBlock, renderScreenAIBlock });
+configureLightEnv({
+  getMeasurementsForRoom,
+  renderMeasurementAIInline,
+  renderRoomAIBlock,
+  renderScreenAIBlock,
+  openSpectrumClassifier,
+  openLuxMeter,
+  openFlickerDetector,
+  openCCTMeter,
+  openDarknessMeter,
+});
 configureLightEnvAudits({ hasAIProvider, maybeAnalyzeAuditAfterSave, renderAuditAIBlock, renderAuditAIDot, openChatPanel });
 configureLightTools({
   maybeAnalyzeMeasurementAfterSave,

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -88,13 +88,18 @@ export {
 // before falling back to "Room N" so a fresh user lands on familiar labels.
 const DEFAULT_ROOM_NAMES = ['Bedroom', 'Living room', 'Kitchen', 'Office', 'Bathroom'];
 
-/** @type {{ getMeasurementsForRoom: AnyFunction | null, renderBurdenInterp: AnyFunction | null, renderMeasurementAIInline: AnyFunction | null, renderRoomAIBlock: AnyFunction | null, renderScreenAIBlock: AnyFunction | null }} */
+/** @type {{ getMeasurementsForRoom: AnyFunction | null, renderBurdenInterp: AnyFunction | null, renderMeasurementAIInline: AnyFunction | null, renderRoomAIBlock: AnyFunction | null, renderScreenAIBlock: AnyFunction | null, openSpectrumClassifier: AnyFunction | null, openLuxMeter: AnyFunction | null, openFlickerDetector: AnyFunction | null, openCCTMeter: AnyFunction | null, openDarknessMeter: AnyFunction | null }} */
 const lightEnvDeps = {
   getMeasurementsForRoom: null,
   renderBurdenInterp: null,
   renderMeasurementAIInline: null,
   renderRoomAIBlock: null,
   renderScreenAIBlock: null,
+  openSpectrumClassifier: null,
+  openLuxMeter: null,
+  openFlickerDetector: null,
+  openCCTMeter: null,
+  openDarknessMeter: null,
 };
 
 export function configureLightEnv(deps = {}) {
@@ -1050,11 +1055,11 @@ export function getRooms() {
 function openLightEnvTool(tool, roomId) {
   const opts = roomId ? { roomId } : undefined;
   const openers = {
-    spectrum: globalThis.openSpectrumClassifier,
-    lux: globalThis.openLuxMeter,
-    flicker: globalThis.openFlickerDetector,
-    cct: globalThis.openCCTMeter,
-    darkness: globalThis.openDarknessMeter,
+    spectrum: lightEnvDeps.openSpectrumClassifier,
+    lux: lightEnvDeps.openLuxMeter,
+    flicker: lightEnvDeps.openFlickerDetector,
+    cct: lightEnvDeps.openCCTMeter,
+    darkness: lightEnvDeps.openDarknessMeter,
   };
   const opener = openers[tool];
   if (typeof opener === 'function') opener(opts);

--- a/js/light-tools.js
+++ b/js/light-tools.js
@@ -777,21 +777,3 @@ export function renderLightTools() {
     </div>
   </div>`;
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    openLuxMeter,
-    openFlickerDetector,
-    openDarknessMeter,
-    openCCTMeter,
-    openSpectrumClassifier,
-    openGlassTransmission,
-    openSunriseLogger,
-    openEyeLevelAudit,
-    getMeasurements,
-    getMeasurementsForRoom,
-    saveMeasurement,
-    deleteMeasurement,
-    renderLightTools,
-  });
-}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 19,
-  "legacyWindowGlobalAssignments": 17,
+  "windowGlobalAssignments": 18,
+  "legacyWindowGlobalAssignments": 16,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -231,14 +231,16 @@ test('light environment browser coverage handles screens tools and confirm delet
       currentProfile: state.currentProfile,
       currentView: state.currentView,
       navigate: window.navigate,
-      openSpectrumClassifier: window.openSpectrumClassifier,
-      openLuxMeter: window.openLuxMeter,
-      openFlickerDetector: window.openFlickerDetector,
-      openCCTMeter: window.openCCTMeter,
-      openDarknessMeter: window.openDarknessMeter,
     };
     const outcomes = {};
     const calls = [];
+    const savedLightEnvDeps = lightEnv.configureLightEnv({
+      openSpectrumClassifier: opts => calls.push(['spectrum', opts?.roomId || null]),
+      openLuxMeter: opts => calls.push(['lux', opts?.roomId || null]),
+      openFlickerDetector: opts => calls.push(['flicker', opts?.roomId || null]),
+      openCCTMeter: opts => calls.push(['cct', opts?.roomId || null]),
+      openDarknessMeter: opts => calls.push(['darkness', opts?.roomId || null]),
+    });
     const env = () => state.importedData.lightEnvironment;
     const latestScreen = () => env().screens[env().screens.length - 1];
     const actions = lightEnv.lightEnvActionHandlers;
@@ -263,11 +265,6 @@ test('light environment browser coverage handles screens tools and confirm delet
       };
       data.invalidateActiveDataCache();
       window.navigate = (route, meta) => calls.push(['navigate', route, meta || null]);
-      window.openSpectrumClassifier = opts => calls.push(['spectrum', opts?.roomId || null]);
-      window.openLuxMeter = opts => calls.push(['lux', opts?.roomId || null]);
-      window.openFlickerDetector = opts => calls.push(['flicker', opts?.roomId || null]);
-      window.openCCTMeter = opts => calls.push(['cct', opts?.roomId || null]);
-      window.openDarknessMeter = opts => calls.push(['darkness', opts?.roomId || null]);
 
       const officeId = await lightEnv.addRoom('Office');
       const livingId = await lightEnv.addRoom('Living room');
@@ -413,11 +410,7 @@ test('light environment browser coverage handles screens tools and confirm delet
       state.currentView = saved.currentView;
       data.invalidateActiveDataCache();
       window.navigate = saved.navigate;
-      window.openSpectrumClassifier = saved.openSpectrumClassifier;
-      window.openLuxMeter = saved.openLuxMeter;
-      window.openFlickerDetector = saved.openFlickerDetector;
-      window.openCCTMeter = saved.openCCTMeter;
-      window.openDarknessMeter = saved.openDarknessMeter;
+      lightEnv.configureLightEnv(savedLightEnvDeps);
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/playwright/light-env-coverage-batch.spec.js
+++ b/tests/playwright/light-env-coverage-batch.spec.js
@@ -44,10 +44,12 @@ test('Light environment assessment drives delegated room and screen controls', a
       currentProfile: state.currentProfile,
       currentView: state.currentView,
       navigate: window.navigate,
-      openLuxMeter: window.openLuxMeter,
     };
     const outcomes = {};
     const calls = [];
+    const savedLightEnvDeps = lightEnv.configureLightEnv({
+      openLuxMeter: opts => calls.push(['open-lux', opts?.roomId || null]),
+    });
 
     const selectorFor = (action, attrs = {}) => [
       `[data-light-env-action="${action}"]`,
@@ -88,7 +90,6 @@ test('Light environment assessment drives delegated room and screen controls', a
       document.getElementById('tour-spotlight')?.remove();
       document.getElementById('tour-tooltip')?.remove();
       window.navigate = (route, meta) => calls.push(['navigate', route, meta || null]);
-      window.openLuxMeter = opts => calls.push(['open-lux', opts?.roomId || null]);
 
       const summaryHost = document.createElement('div');
       summaryHost.id = 'light-env-summary-host';
@@ -256,7 +257,7 @@ test('Light environment assessment drives delegated room and screen controls', a
       state.currentView = saved.currentView;
       data.invalidateActiveDataCache();
       window.navigate = saved.navigate;
-      window.openLuxMeter = saved.openLuxMeter;
+      lightEnv.configureLightEnv(savedLightEnvDeps);
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -129,15 +129,17 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
   await page.waitForSelector('#main-content');
 
   const results = await page.evaluate(async ({ lightPageUrl }) => {
-    const [{ state }, lightPage, lightEnv] = await Promise.all([
+    const [{ state }, lightPage, lightEnv, lightTools] = await Promise.all([
       import('/js/state.js'),
       import(lightPageUrl),
       import('/js/light-env.js'),
+      import('/js/light-tools.js'),
     ]);
     const outcomes = {};
     const RealDate = Date;
     const main = document.getElementById('main-content');
     let renderEnvironmentAssessmentSummary = lightEnv.renderEnvironmentAssessmentSummary;
+    let renderLightTools = lightTools.renderLightTools;
     const saved = {
       importedData: state.importedData,
       mainHTML: main?.innerHTML,
@@ -159,7 +161,6 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       rollingDeviceTotals: window.rollingDeviceTotals,
       renderSunSetupCard: window.renderSunSetupCard,
       renderDevicesSection: window.renderDevicesSection,
-      renderLightTools: window.renderLightTools,
     };
     let renderLightTodayDashboardChip = () => '';
     let renderLightTodayHero = () => '';
@@ -183,7 +184,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       renderSunSetupCard: typeof window.renderSunSetupCard === 'function' ? window.renderSunSetupCard : () => '',
       renderDevicesSection: typeof window.renderDevicesSection === 'function' ? window.renderDevicesSection : () => '',
       renderEnvironmentAssessmentSummary,
-      renderLightTools: typeof window.renderLightTools === 'function' ? window.renderLightTools : () => '',
+      renderLightTools,
     });
     const setHour = (hour) => {
       const fixed = new RealDate(`2026-06-11T${String(hour).padStart(2, '0')}:15:00`);
@@ -289,7 +290,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.renderSunSetupCard = () => '<div class="setup-card-test">setup</div>';
       window.renderDevicesSection = () => '<div class="devices-section-test">devices</div>';
       renderEnvironmentAssessmentSummary = () => '';
-      window.renderLightTools = () => '';
+      renderLightTools = () => '';
       window.getActiveSession = () => null;
       window.getDevices = () => [];
       window.getSessions = () => [];
@@ -349,7 +350,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.renderSunSetupCard = saved.renderSunSetupCard;
       window.renderDevicesSection = saved.renderDevicesSection;
       renderEnvironmentAssessmentSummary = lightEnv.renderEnvironmentAssessmentSummary;
-      window.renderLightTools = saved.renderLightTools;
+      renderLightTools = lightTools.renderLightTools;
       renderLightTodayDashboardChip = () => '';
       renderLightTodayHero = () => '';
       syncLightPageDeps();

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -695,11 +695,16 @@ const {
     screenUiSrc.includes('opts.renderScreenAIBlock') &&
     screenUiSrc.includes('renderScreenAIBlock(s)') &&
     aiSaveHooksSrc.includes("import { addRoom, configureLightEnv, getRooms, refreshLightEnvironmentAssessment, suggestRoomSourceFromSpectrum } from './light-env.js';") &&
-    aiSaveHooksSrc.includes("import { configureLightTools, getMeasurementsForRoom } from './light-tools.js';") &&
+    aiSaveHooksSrc.includes('configureLightTools,') &&
+    aiSaveHooksSrc.includes('getMeasurementsForRoom,') &&
+    aiSaveHooksSrc.includes("} from './light-tools.js';") &&
     aiSaveHooksSrc.includes("import { maybeAnalyzeMeasurementAfterSave, renderMeasurementAIInline } from './light-tools-ai-analysis.js';") &&
     aiSaveHooksSrc.includes("import { renderRoomAIBlock } from './light-env-ai-analysis.js';") &&
     aiSaveHooksSrc.includes("import { renderScreenAIBlock } from './light-screen-ai-analysis.js';") &&
-    aiSaveHooksSrc.includes('configureLightEnv({ getMeasurementsForRoom, renderMeasurementAIInline, renderRoomAIBlock, renderScreenAIBlock })') &&
+    aiSaveHooksSrc.includes('configureLightEnv({') &&
+    aiSaveHooksSrc.includes('renderMeasurementAIInline,') &&
+    aiSaveHooksSrc.includes('renderRoomAIBlock,') &&
+    aiSaveHooksSrc.includes('renderScreenAIBlock,') &&
     !measurementAiSrc.includes('Object.assign(window, {') &&
     !measurementAiSrc.includes('window.refreshMeasurementAIAnalysis') &&
     !measurementAiSrc.includes('window.analyzeMeasurementAI') &&

--- a/tests/test-light-tools-flow.js
+++ b/tests/test-light-tools-flow.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // test-light-tools-flow.js — Behavioral coverage for js/light-tools.js.
-// Drives every window-faceced entry point + saveMeasurement for each
+// Drives every module entry point + saveMeasurement for each
 // tool type so the internal helpers (luxZone, cctTone, classifyLight,
 // etc.) get exercised transitively.
 //
@@ -21,8 +21,8 @@ const withTimeout = (fn, ms = 1500) => Promise.race([
 console.log('=== Light Tools Flow ===\n');
 
 const { state } = await import('../js/state.js');
-await import('../js/light-tools.js');
-  assert('light-tools.js facade loaded', typeof window.openLuxMeter === 'function');
+const lightTools = await import('../js/light-tools.js');
+  assert('light-tools.js module loaded', typeof lightTools.openLuxMeter === 'function');
 
   // Snapshot lightMeasurements so we can restore after probing.
   state.importedData = state.importedData || {};
@@ -39,10 +39,10 @@ await import('../js/light-tools.js');
   const roomId = state.importedData.lightEnvironment.rooms[0].id;
 
   // ── 1. Pure data readers ─────────────────────────────────────────────
-  const all = window.getMeasurements();
+  const all = lightTools.getMeasurements();
   assert('getMeasurements returns an array', Array.isArray(all));
 
-  const roomScoped = window.getMeasurementsForRoom(roomId);
+  const roomScoped = lightTools.getMeasurementsForRoom(roomId);
   assert('getMeasurementsForRoom returns an array for an unknown room', Array.isArray(roomScoped));
 
   // ── 2. saveMeasurement for every tool type ───────────────────────────
@@ -60,7 +60,7 @@ await import('../js/light-tools.js');
     ['audit',       { rooms: [{ id: roomId, score: 6 }], note: 'probe' }],
   ];
   for (const [tool, value] of toolCases) {
-    await withTimeout(() => window.saveMeasurement(tool, value, { roomId }));
+    await withTimeout(() => lightTools.saveMeasurement(tool, value, { roomId }));
   }
   const lastCount = state.importedData.lightMeasurements.length;
   assert(`saveMeasurement persists across ${toolCases.length} tool types (got ${lastCount})`, lastCount >= 1);
@@ -68,7 +68,7 @@ await import('../js/light-tools.js');
   // ── 3. deleteMeasurement (any existing id) ───────────────────────────
   const someId = state.importedData.lightMeasurements[0]?.id;
   if (someId) {
-    await withTimeout(() => window.deleteMeasurement(someId));
+    await withTimeout(() => lightTools.deleteMeasurement(someId));
     assert('deleteMeasurement removed by id',
       !state.importedData.lightMeasurements.find(m => m.id === someId));
   } else {
@@ -76,7 +76,7 @@ await import('../js/light-tools.js');
   }
 
   // ── 4. renderLightTools (pure HTML builder, no DOM dependency) ───────
-  const html = window.renderLightTools();
+  const html = lightTools.renderLightTools();
   assert('renderLightTools returns a non-empty string',
     typeof html === 'string' && html.length > 100);
   const firstLux = html.indexOf('Lux meter');
@@ -106,8 +106,8 @@ await import('../js/light-tools.js');
     'openCCTMeter', 'openSpectrumClassifier', 'openGlassTransmission',
     'openSunriseLogger', 'openEyeLevelAudit',
   ]) {
-    await withTimeout(() => window[opener]?.());
-    assert(`${opener} entered execution`, typeof window[opener] === 'function');
+    await withTimeout(() => lightTools[opener]?.());
+    assert(`${opener} entered execution`, typeof lightTools[opener] === 'function');
   }
 
   // Restore the original state so downstream tests see what they expect.

--- a/tests/test-light-tools.js
+++ b/tests/test-light-tools.js
@@ -240,7 +240,9 @@ const tools = await import('../js/light-tools.js');
       lightToolsSrc.includes('export function configureLightTools') &&
       lightToolsSrc.includes('maybeAnalyzeMeasurementAfterSave: () => {}') &&
       !lightToolsSrc.includes('window.maybeAnalyzeMeasurementAfterSave') &&
-      lightAiSaveHooksSrc.includes("import { configureLightTools, getMeasurementsForRoom } from './light-tools.js';") &&
+      lightAiSaveHooksSrc.includes('configureLightTools,') &&
+      lightAiSaveHooksSrc.includes('getMeasurementsForRoom,') &&
+      lightAiSaveHooksSrc.includes("} from './light-tools.js';") &&
       lightAiSaveHooksSrc.includes("import { maybeAnalyzeMeasurementAfterSave, renderMeasurementAIInline } from './light-tools-ai-analysis.js';") &&
       lightAiSaveHooksSrc.includes('configureLightTools({') &&
       lightAiSaveHooksSrc.includes('maybeAnalyzeMeasurementAfterSave') &&

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -32,7 +32,7 @@ console.log('=== v1.6.7–v1.6.16 Regression Tests ===\n');
 // light-sessions-view.js → _openAllSessionsModal.
 await import('../js/state.js');
 await import('../js/sun.js');
-await import('../js/light-tools.js');
+const lightTools = await import('../js/light-tools.js');
 await import('../js/views.js');
 
 // Snapshot mutable state we touch.
@@ -140,17 +140,17 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   console.log('%c 5. Latest-per-(roomId, tool) measurement model ', 'font-weight:bold;color:#0891b2');
   {
     const S = window._labState;
-    if (!S || !window.saveMeasurement || !window.getMeasurements) {
-      assert('saveMeasurement / getMeasurements exposed', false);
+    if (!S || typeof lightTools.saveMeasurement !== 'function' || typeof lightTools.getMeasurements !== 'function') {
+      assert('saveMeasurement / getMeasurements exported', false);
     } else {
       const _saved = JSON.parse(JSON.stringify(S.importedData));
       S.importedData.lightMeasurements = [];
       delete S.importedData._deleted;
       const r = 'room_test_retain';
-      await window.saveMeasurement('flicker', 1, { roomId: r });
-      await window.saveMeasurement('flicker', 3, { roomId: r });
-      await window.saveMeasurement('lux', 800, { roomId: r });
-      const rows = window.getMeasurements();
+      await lightTools.saveMeasurement('flicker', 1, { roomId: r });
+      await lightTools.saveMeasurement('flicker', 3, { roomId: r });
+      await lightTools.saveMeasurement('lux', 800, { roomId: r });
+      const rows = lightTools.getMeasurements();
       const flickerRows = rows.filter(m => m.tool === 'flicker' && m.roomId === r);
       const luxRows = rows.filter(m => m.tool === 'lux' && m.roomId === r);
       assert('Second save supersedes first — only one flicker row per (room, tool)',
@@ -170,9 +170,9 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       // audit records in a row and asserting both survive.
       S.importedData.lightMeasurements = [];
       delete S.importedData._deleted;
-      await window.saveMeasurement('audit', 4, { roomId: null, extra: { rooms: [{ index: 1, lux: 200, label: 'Bedroom' }] } });
-      await window.saveMeasurement('audit', 3, { roomId: null, extra: { rooms: [{ index: 1, lux: 800, label: 'Office' }] } });
-      const auditRows = window.getMeasurements().filter(m => m.tool === 'audit');
+      await lightTools.saveMeasurement('audit', 4, { roomId: null, extra: { rooms: [{ index: 1, lux: 200, label: 'Bedroom' }] } });
+      await lightTools.saveMeasurement('audit', 3, { roomId: null, extra: { rooms: [{ index: 1, lux: 800, label: 'Office' }] } });
+      const auditRows = lightTools.getMeasurements().filter(m => m.tool === 'audit');
       assert('Audit walkthroughs preserved across saves (no supersession)',
         auditRows.length === 2);
       const auditTombstones = (S.importedData._deleted?.lightMeasurements || []).length;

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,11 +187,12 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, cycleModule, lensModule, piiModule, supplementsModule] = await Promise.all([
+  const [apiModule, chartsModule, cycleModule, lensModule, lightToolsModule, piiModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/charts.js'),
     import('../js/cycle.js'),
     import('../js/lens.js'),
+    import('../js/light-tools.js'),
     import('../js/pii.js'),
     import('../js/supplements.js'),
   ]);
@@ -232,6 +233,20 @@
     'handleLensBackendChange',
     'handleLocalLensDeleteDoc','handleLocalLensClear',
     'handleLibraryActivate','handleLibraryNew','handleLibraryRename','handleLibraryDelete',
+  ];
+
+  // light-tools.js (17 selected exports, module-only)
+  const lightToolsExports = [
+    'configureLightTools','installLightToolsActionDelegates',
+    'openLuxMeter','openFlickerDetector','openDarknessMeter','openCCTMeter',
+    'openSpectrumClassifier','openGlassTransmission','openSunriseLogger','openEyeLevelAudit',
+    'getMeasurements','getMeasurementsForRoom','saveMeasurement','deleteMeasurement',
+    'renderLightTools','normalizeGoldenHourMinutes','closeEyeLevelAudit'
+  ];
+  const lightToolsLegacyGlobals = [
+    'openLuxMeter','openFlickerDetector','openDarknessMeter','openCCTMeter',
+    'openSpectrumClassifier','openGlassTransmission','openSunriseLogger','openEyeLevelAudit',
+    'getMeasurements','getMeasurementsForRoom','saveMeasurement','deleteMeasurement','renderLightTools'
   ];
 
   // lab-context.js
@@ -481,6 +496,7 @@
     ['charts.js', chartsModule, chartsExports],
     ['cycle.js', cycleModule, cycleExports],
     ['lens.js', lensModule, lensExports],
+    ['light-tools.js', lightToolsModule, lightToolsExports],
     ['pii.js', piiModule, piiExports],
     ['supplements.js', supplementsModule, supplementsExports],
   ]) {
@@ -495,6 +511,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of cycleLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of lightToolsLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.189';
+self.APP_VERSION = '1.10.190';


### PR DESCRIPTION
## Summary
- remove the 13-function `window` facade from Light Tools
- inject the five Light Environment tool openers through the existing module dependency seam
- migrate browser and legacy tests to use module exports and explicit test dependencies
- lower the quality baseline from 19 to 18 total global assignments and from 17 to 16 legacy assignments
- bump the app cache version to 1.10.190

## Testing
- `./run-tests.sh`
  - 122 module verification checks
  - 396 Vitest tests
  - 351 Playwright tests
  - 472 theme/responsive checks