### PR TITLE
Make Sun context module-only

### DIFF
--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -38,11 +38,23 @@ import {
  *   _buildGeneticsContext?: (genetics: unknown, activeMarkerKeys: string[], options?: { includeGenomeSummary?: boolean, includePriorityFindings?: boolean, includeSnpInventory?: boolean }) => string,
  *   isGeneticsInventoryInAIContext?: () => boolean,
  *   isLightSunContextEnabled?: () => boolean,
- *   buildSunContext?: (options: { tier: string, ignoreContextToggles?: boolean }) => string,
  * }} LabContextWindowHooks
  */
 
 const labContextWindow = /** @type {Window & typeof globalThis & LabContextWindowHooks} */ (typeof window !== 'undefined' ? window : {});
+
+/** @type {{ buildSunContext: ((options: { tier: string, ignoreContextToggles?: boolean }) => string) | null }} */
+const labContextDeps = {
+  buildSunContext: null,
+};
+
+export function configureLabContext(deps = {}) {
+  const previous = { ...labContextDeps };
+  if (Object.prototype.hasOwnProperty.call(deps, 'buildSunContext')) {
+    labContextDeps.buildSunContext = deps.buildSunContext;
+  }
+  return previous;
+}
 
 // ═══════════════════════════════════════════════
 // LAB CONTEXT MEMOIZATION
@@ -974,9 +986,9 @@ function _buildLabContextInner(/** @type {LabContextOptions} */ { skipGroupFilte
   // the 30-day session table + biomarker correlations on every turn,
   // matching the pattern the rest of this file uses for every other
   // section (include if-data-exists, no keyword gating).
-  if ((ignoreContextToggles || isLightSunContextEnabled()) && typeof window !== 'undefined' && typeof labContextWindow.buildSunContext === 'function') {
+  if ((ignoreContextToggles || isLightSunContextEnabled()) && typeof labContextDeps.buildSunContext === 'function') {
     try {
-      ctx += labContextWindow.buildSunContext({ tier: 'standard', ignoreContextToggles });
+      ctx += labContextDeps.buildSunContext({ tier: 'standard', ignoreContextToggles });
     } catch (e) { /* sun context is best-effort */ }
   }
 

--- a/js/sun-context-hooks.js
+++ b/js/sun-context-hooks.js
@@ -18,8 +18,11 @@ import {
 import { getMeteoConfig } from './sun-uvdata.js';
 import { rollingDeviceTotals } from './light-devices-store.js';
 import { computeDeficitAxes, computeIndoorBurden } from './light-env.js';
+import { configureLabContext } from './lab-context.js';
 import { isDebugMode } from './utils.js';
-import { configureSunContext } from './sun-context.js';
+import { buildSunContext, configureSunContext } from './sun-context.js';
+
+configureLabContext({ buildSunContext });
 
 configureSunContext({
   bodyRegions: BODY_REGIONS,

--- a/js/sun-context.js
+++ b/js/sun-context.js
@@ -1116,13 +1116,3 @@ function formatRelative(ts) {
   const d = Math.round(hr / 24);
   return `${d}d ago`;
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    buildSunContext,
-    getSunSessionsSlice,
-    getSunSessionDetail,
-    isBodyRegionsInAIContext,
-    setBodyRegionsInAIContext,
-  });
-}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 18,
-  "legacyWindowGlobalAssignments": 16,
+  "windowGlobalAssignments": 17,
+  "legacyWindowGlobalAssignments": 15,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/dashboard-knowledge-base.spec.js
+++ b/tests/playwright/dashboard-knowledge-base.spec.js
@@ -122,7 +122,9 @@ test('Context hub data source toggles control prompt and score context', async (
         },
       },
     };
-    window.buildSunContext = () => '[section:sun]\nLight context fixture\n[/section:sun]\n\n';
+    lab.configureLabContext({
+      buildSunContext: () => '[section:sun]\nLight context fixture\n[/section:sun]\n\n',
+    });
     lab.setInsightContextCardsEnabled(true);
     lab.setSupplementsMedsContextEnabled(true);
     lab.setLabMarkersContextEnabled(true);

--- a/tests/playwright/lab-context-browser-coverage.spec.js
+++ b/tests/playwright/lab-context-browser-coverage.spec.js
@@ -35,7 +35,9 @@ test('lab context browser coverage exercises toggles lens chunks and wearable co
       unitSystem: state.unitSystem,
       rangeMode: state.rangeMode,
     };
-    const originalBuildSunContext = window.buildSunContext;
+    const originalLabContextDeps = labContext.configureLabContext({
+      buildSunContext: () => '[section:sun]\nSun context\n[/section:sun]\n\n',
+    });
 
     try {
       localStorage.clear();
@@ -156,7 +158,6 @@ test('lab context browser coverage exercises toggles lens chunks and wearable co
           },
         },
       };
-      window.buildSunContext = () => '[section:sun]\nSun context\n[/section:sun]\n\n';
       dataModule.invalidateActiveDataCache();
       labContext.invalidateLabContextCache();
 
@@ -372,7 +373,7 @@ test('lab context browser coverage exercises toggles lens chunks and wearable co
       state.profileDob = original.profileDob;
       state.unitSystem = original.unitSystem;
       state.rangeMode = original.rangeMode;
-      window.buildSunContext = originalBuildSunContext;
+      labContext.configureLabContext(originalLabContextDeps);
       dataModule.invalidateActiveDataCache();
       labContext.invalidateLabContextCache();
       await storeModule.deleteWearablesDB('lab-context-browser-coverage').catch(() => {});

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -16,10 +16,7 @@ function assert(name, condition, detail) {
 console.log('=== Light Environment Tests ===\n');
 
 await import('../js/state.js');
-// sun-context.js exposes buildSunContext via window. Two test sections
-// below gate on `typeof window.buildSunContext === 'function'`; without
-// this import they'd silently skip in Node.
-await import('../js/sun-context.js');
+const { buildSunContext } = await import('../js/sun-context.js');
 const env = await import('../js/light-env.js');
 const model = await import('../js/light-env-model.js');
 const {
@@ -887,7 +884,7 @@ const {
 
   // ─── lightEnvironmentBlock surfaces in AI context ──────────────────
   console.log('%c AI context — light environment block ', 'font-weight:bold;color:#f59e0b');
-  if (typeof window.buildSunContext === 'function') {
+  {
     const beforeCtx = window._labState.importedData;
     window._labState.importedData = {
       sunSessions: [],
@@ -906,7 +903,7 @@ const {
     // Even with zero outdoor sessions and zero device sessions, an
     // active light environment should still produce AI context — the
     // earlier gate dropped device-only AND environment-only users.
-    const ctx = window.buildSunContext({ tier: 'always' });
+    const ctx = buildSunContext({ tier: 'always' });
     assert('AI context rendered for environment-only users (rooms/screens/audits with 0 sessions)',
       typeof ctx === 'string' && ctx.length > 0);
     assert('AI context mentions Indoor light environment section',
@@ -934,7 +931,7 @@ const {
     window._labState.importedData.lightEnvironment.rooms.find(r => r.id === newId)?.name === 'Office');
 
   // ─── AI context surfaces tool-measurement warnings ─────────────────
-  if (typeof window.buildSunContext === 'function') {
+  {
     console.log('%c AI context — tool warnings ', 'font-weight:bold;color:#f59e0b');
     const beforeCtx = window._labState.importedData;
     window._labState.importedData = {
@@ -951,7 +948,7 @@ const {
         { id: 'm-cct-day', tool: 'cct', value: 5500, takenAt: (() => { const d = new Date(); d.setHours(12, 0, 0, 0); return d.getTime(); })(), roomId: 'r1' },
       ],
     };
-    const ctx = window.buildSunContext({ tier: 'always' });
+    const ctx = buildSunContext({ tier: 'always' });
     assert('AI sees flicker score ≥ 2 warning',
       /flicker score 3/.test(ctx));
     assert('AI sees bedroom-too-bright warning (>1 lux at the pillow)',

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -13,6 +13,7 @@ return (async function() {
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const main = document.getElementById('main-content');
   const S = window._labState;
+  const { buildSunContext } = await import('/js/sun-context.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -213,17 +214,12 @@ return (async function() {
   // ─── 5. AI context picks up sessions ─────────────────────────────────
   console.log('%c 5. buildSunContext picks up the session ', 'font-weight:bold;color:#6366f1');
 
-  if (typeof window.buildSunContext === 'function') {
-    const ctx = window.buildSunContext({ tier: 'always' });
-    assert('buildSunContext non-empty after a session is logged', ctx.length > 0);
-    assert('Context section markers wrap the block',
-      /\[section:sun\][\s\S]*\[\/section:sun\]/.test(ctx));
-    assert('Context reports total session count of 1',
-      /Outdoor sessions: 1/.test(ctx));
-  } else {
-    assert('window.buildSunContext exists (AI wired)', false,
-      'skipped — function missing');
-  }
+  const ctx = buildSunContext({ tier: 'always' });
+  assert('buildSunContext non-empty after a session is logged', ctx.length > 0);
+  assert('Context section markers wrap the block',
+    /\[section:sun\][\s\S]*\[\/section:sun\]/.test(ctx));
+  assert('Context reports total session count of 1',
+    /Outdoor sessions: 1/.test(ctx));
 
   // ─── 6. lab-context.js integrates the sun section ────────────────────
   console.log('%c 6. lab-context integrates sun section ', 'font-weight:bold;color:#6366f1');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,13 +187,15 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, cycleModule, lensModule, lightToolsModule, piiModule, supplementsModule] = await Promise.all([
+  const [apiModule, chartsModule, cycleModule, labContextModule, lensModule, lightToolsModule, piiModule, sunContextModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/charts.js'),
     import('../js/cycle.js'),
+    import('../js/lab-context.js'),
     import('../js/lens.js'),
     import('../js/light-tools.js'),
     import('../js/pii.js'),
+    import('../js/sun-context.js'),
     import('../js/supplements.js'),
   ]);
   const apiExports = [
@@ -247,6 +249,16 @@
     'openLuxMeter','openFlickerDetector','openDarknessMeter','openCCTMeter',
     'openSpectrumClassifier','openGlassTransmission','openSunriseLogger','openEyeLevelAudit',
     'getMeasurements','getMeasurementsForRoom','saveMeasurement','deleteMeasurement','renderLightTools'
+  ];
+
+  // sun-context.js (6, module-only)
+  const sunContextExports = [
+    'configureSunContext','buildSunContext','getSunSessionsSlice','getSunSessionDetail',
+    'isBodyRegionsInAIContext','setBodyRegionsInAIContext'
+  ];
+  const sunContextLegacyGlobals = [
+    'buildSunContext','getSunSessionsSlice','getSunSessionDetail',
+    'isBodyRegionsInAIContext','setBodyRegionsInAIContext'
   ];
 
   // lab-context.js
@@ -498,6 +510,7 @@
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
     ['pii.js', piiModule, piiExports],
+    ['sun-context.js', sunContextModule, sunContextExports],
     ['supplements.js', supplementsModule, supplementsExports],
   ]) {
     for (const name of exports) {
@@ -514,6 +527,11 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of lightToolsLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  assert('lab-context.js.configureLabContext module export',
+    typeof labContextModule.configureLabContext === 'function');
+  for (const name of sunContextLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.190';
+self.APP_VERSION = '1.10.191';


### PR DESCRIPTION
## Summary
- remove the five-function browser-global facade from Sun Context
- inject `buildSunContext` into Lab Context through an explicit dependency configured at startup
- migrate Node and browser tests to module imports and the dependency seam
- verify the former globals stay absent while all Sun Context APIs remain module exports
- lower the quality baseline from 18 to 17 total global assignments and from 16 to 15 legacy assignments
- bump the app cache version to 1.10.191

## Testing
- `./run-tests.sh`
  - 122 module verification checks
  - 396 Vitest tests
  - 351 Playwright tests
  - 472 theme/responsive checks