### PR TITLE
Make Sun Spectrum module-only

### DIFF
--- a/js/light-device-session-engine.js
+++ b/js/light-device-session-engine.js
@@ -6,6 +6,12 @@
 // spectrum synthesis, and SAD-lux fallback.
 
 import { BODY_REGIONS } from './sun-body-silhouette.js';
+import {
+  computeChannelDoses as computeSpectrumChannelDoses,
+  effectiveDeviceForMode as getEffectiveDeviceForMode,
+  synthesizeDeviceSpectrum as synthesizeSpectrumForDevice,
+  validateModeCoupling as validateDeviceModeCoupling,
+} from './sun-spectrum.js';
 
 /**
  * @typedef {object} DeviceSessionDoseInput
@@ -38,12 +44,11 @@ export const DEVICE_TYPE_CHANNELS = {
 };
 
 function _runtimeDeps(deps = {}) {
-  const w = typeof window !== 'undefined' ? window : {};
   return {
-    validateModeCoupling: deps.validateModeCoupling || w.validateModeCoupling,
-    effectiveDeviceForMode: deps.effectiveDeviceForMode || w.effectiveDeviceForMode,
-    synthesizeDeviceSpectrum: deps.synthesizeDeviceSpectrum || w.synthesizeDeviceSpectrum,
-    computeChannelDoses: deps.computeChannelDoses || w.computeChannelDoses,
+    validateModeCoupling: deps.validateModeCoupling || validateDeviceModeCoupling,
+    effectiveDeviceForMode: deps.effectiveDeviceForMode || getEffectiveDeviceForMode,
+    synthesizeDeviceSpectrum: deps.synthesizeDeviceSpectrum || synthesizeSpectrumForDevice,
+    computeChannelDoses: deps.computeChannelDoses || computeSpectrumChannelDoses,
   };
 }
 

--- a/js/sun-spectrum.js
+++ b/js/sun-spectrum.js
@@ -720,7 +720,7 @@ const VITD_SATURATION_IU = 20000;
 // limited to ~11k regardless of how aggressive the panel is. Real
 // biology lands closer to 15k per 100%-body for Type II skin; we use
 // 30k to avoid under-attributing yield for sub-saturating sessions.
-const VITD_PER_SESSION_BODYFRAC_CAP_IU = 30000;
+export const VITD_PER_SESSION_BODYFRAC_CAP_IU = 30000;
 
 // UVI threshold gate. Webb 2018, Lehmann 2013, McKenzie 2009 (NIWA):
 // no meaningful vit D synthesis below UVI ~2-3 because the 295-300 nm
@@ -1076,29 +1076,3 @@ export function validateModeCoupling(device, modeId) {
 
 export const SUN_CHANNELS = CHANNELS.map(({ id, key, label }) => ({ id, key, label }));
 export { erythemalAt, vitaminDAt, melanopicAt, opn5At, ccoAt, noReleaseAt };
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    reconstructSpectrum,
-    synthesizeDeviceSpectrum,
-    effectiveDeviceForMode,
-    validateModeCoupling,
-    heuristicPeakShares,
-    computeChannelDoses,
-    erythemalSED,
-    fractionOfMED,
-    vitaminDIU,
-    vitaminDIURaw,
-    vitaminDIUPerSession,
-    VITD_DAILY_SATURATION_IU,
-    VITD_PER_SESSION_BODYFRAC_CAP_IU,
-    vitaminDIURange,
-    geneticVitaminDMultiplier,
-    pbmJoulesPerCm2,
-    circadianMelanopicLux,
-    retinalUVdose,
-    glassTransmission,
-    sunscreenTransmission,
-    SUN_CHANNELS,
-  });
-}

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 17,
-  "legacyWindowGlobalAssignments": 15,
+  "windowGlobalAssignments": 16,
+  "legacyWindowGlobalAssignments": 14,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/light-ai-analysis-coverage-batch.spec.js
+++ b/tests/playwright/light-ai-analysis-coverage-batch.spec.js
@@ -20,7 +20,6 @@ test('sun and device session AI analysis covers contexts fingerprints and render
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
       solarZenithAngle: window.solarZenithAngle,
-      vitaminDIU: window.vitaminDIU,
       refreshSunSurfaces: window._refreshSunSurfaces,
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
@@ -328,7 +327,6 @@ test('sun and device session AI analysis covers contexts fingerprints and render
       window.fetch = saved.fetch;
       window.getOllamaConfig = saved.getOllamaConfig;
       window.solarZenithAngle = saved.solarZenithAngle;
-      window.vitaminDIU = saved.vitaminDIU;
       window._refreshSunSurfaces = saved.refreshSunSurfaces;
       if (saved.provider == null) localStorage.removeItem('labcharts-ai-provider');
       else localStorage.setItem('labcharts-ai-provider', saved.provider);

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -12,15 +12,6 @@ test('sun session UI covers list detail edit delete and past-session save paths'
     const state = window._labState;
     const outcomes = {};
     const originalView = state.currentView;
-    const savedWindow = {
-      solarZenithAngle: window.solarZenithAngle,
-      reconstructSpectrum: window.reconstructSpectrum,
-      vitaminDIU: window.vitaminDIU,
-      vitaminDIUPerSession: window.vitaminDIUPerSession,
-      pbmJoulesPerCm2: window.pbmJoulesPerCm2,
-      circadianMelanopicLux: window.circadianMelanopicLux,
-      geneticVitaminDMultiplier: window.geneticVitaminDMultiplier,
-    };
     let sessions = [
       {
         id: 'sun-ended',
@@ -71,16 +62,16 @@ test('sun session UI covers list detail edit delete and past-session save paths'
 
     try {
       state.currentView = 'light';
-      window.solarZenithAngle = () => 42.4;
-      window.reconstructSpectrum = () => ({
+      const solarZenithAngle = () => 42.4;
+      const reconstructSpectrum = () => ({
         wavelengths: [280, 300, 320, 340, 360, 380, 400, 420],
         irradiance: [0.2, 0.4, 1.2, 2.2, 2.1, 1.6, 0.8, 0.1],
       });
-      window.vitaminDIU = () => 1500;
-      window.vitaminDIUPerSession = () => 2400;
-      window.pbmJoulesPerCm2 = () => 8.6;
-      window.circadianMelanopicLux = () => 12500;
-      window.geneticVitaminDMultiplier = () => ({
+      const vitaminDIU = () => 1500;
+      const vitaminDIUPerSession = () => 2400;
+      const pbmJoulesPerCm2 = () => 8.6;
+      const circadianMelanopicLux = () => 12500;
+      const geneticVitaminDMultiplier = () => ({
         mult: 0.82,
         contributors: [{ gene: 'GC', genotype: 'TT', multiplier: 0.82 }],
       });
@@ -132,13 +123,13 @@ test('sun session UI covers list detail edit delete and past-session save paths'
         renderSessionAIInline: () => '<span class="ai-inline-test">AI inline</span>',
         renderSessionAIDetail: () => '<section class="ai-detail-test">AI detail</section>',
         navigate: route => calls.push(['navigate', route]),
-        solarZenithAngle: window.solarZenithAngle,
-        reconstructSpectrum: window.reconstructSpectrum,
-        geneticVitaminDMultiplier: window.geneticVitaminDMultiplier,
-        vitaminDIU: window.vitaminDIU,
-        vitaminDIUPerSession: window.vitaminDIUPerSession,
-        pbmJoulesPerCm2: window.pbmJoulesPerCm2,
-        circadianMelanopicLux: window.circadianMelanopicLux,
+        solarZenithAngle,
+        reconstructSpectrum,
+        geneticVitaminDMultiplier,
+        vitaminDIU,
+        vitaminDIUPerSession,
+        pbmJoulesPerCm2,
+        circadianMelanopicLux,
       });
 
       const listHost = document.createElement('div');
@@ -210,7 +201,6 @@ test('sun session UI covers list detail edit delete and past-session save paths'
         && calls.some(call => call[0] === 'delete' && call[1] === 'sun-ended')
         && calls.some(call => call[0] === 'refresh');
     } finally {
-      Object.assign(window, savedWindow);
       state.currentView = originalView;
       sunUI.configureSunSessionUI({
         getSessions: () => [],
@@ -267,19 +257,6 @@ test('sun active session covers start dialog stop summary and live dose helpers'
     const state = window._labState;
     const outcomes = {};
     const originalImported = JSON.parse(JSON.stringify(state.importedData || {}));
-    const savedWindow = {
-      fetchAtmosphere: window.fetchAtmosphere,
-      reconstructSpectrum: window.reconstructSpectrum,
-      computeChannelDoses: window.computeChannelDoses,
-      erythemalSED: window.erythemalSED,
-      fractionOfMED: window.fractionOfMED,
-      solarZenithAngle: window.solarZenithAngle,
-      interpolateAtmosphere: window.interpolateAtmosphere,
-      vitaminDIU: window.vitaminDIU,
-      vitaminDIUPerSession: window.vitaminDIUPerSession,
-      renderLightChannelsLive: window.renderLightChannelsLive,
-      renderLightTodayStrip: window.renderLightTodayStrip,
-    };
     let sessions = [{
       id: 'last-ended',
       startedAt: Date.now() - 3600000,
@@ -351,29 +328,29 @@ test('sun active session covers start dialog stop summary and live dose helpers'
         surfaceOptions: [{ key: 'grass', label: 'Grass' }, { key: 'sand', label: 'Sand' }],
       });
 
-      window.fetchAtmosphere = async () => ({ uvIndex: 11.2, cloudCover: 10, ozoneDU: 290, source: 'open_meteo', confidence: 0.9, temperatureC: 34 });
-      window.reconstructSpectrum = () => ({ wavelengths: [300, 350, 400], irradiance: [1.2, 0.9, 0.4] });
-      window.computeChannelDoses = ({ durationMin }) => ({ vitamin_d: 3 * durationMin, circadian: 2 * durationMin });
-      window.erythemalSED = ({ durationMin }) => 0.4 * durationMin;
-      window.fractionOfMED = ({ sed, medScale }) => sed / (10 * medScale);
-      window.solarZenithAngle = () => 35;
-      window.interpolateAtmosphere = atm => ({ ...atm, uvIndex: atm.uvIndex + 0.2 });
-      window.vitaminDIU = () => 1300;
-      window.vitaminDIUPerSession = () => 2600;
-      window.renderLightChannelsLive = () => calls.push(['render-live']);
-      window.renderLightTodayStrip = () => '<div id="today-light-strip-test">today</div>';
+      const fetchAtmosphere = async () => ({ uvIndex: 11.2, cloudCover: 10, ozoneDU: 290, source: 'open_meteo', confidence: 0.9, temperatureC: 34 });
+      const reconstructSpectrum = () => ({ wavelengths: [300, 350, 400], irradiance: [1.2, 0.9, 0.4] });
+      const computeChannelDoses = ({ durationMin }) => ({ vitamin_d: 3 * durationMin, circadian: 2 * durationMin });
+      const erythemalSED = ({ durationMin }) => 0.4 * durationMin;
+      const fractionOfMED = ({ sed, medScale }) => sed / (10 * medScale);
+      const solarZenithAngle = () => 35;
+      const interpolateAtmosphere = atm => ({ ...atm, uvIndex: atm.uvIndex + 0.2 });
+      const vitaminDIU = () => 1300;
+      const vitaminDIUPerSession = () => 2600;
+      const renderLightChannelsLive = () => calls.push(['render-live']);
+      const renderLightTodayStrip = () => '<div id="today-light-strip-test">today</div>';
       active.configureSunActiveSession({
-        fetchAtmosphere: window.fetchAtmosphere,
-        reconstructSpectrum: window.reconstructSpectrum,
-        computeChannelDoses: window.computeChannelDoses,
-        erythemalSED: window.erythemalSED,
-        fractionOfMED: window.fractionOfMED,
-        solarZenithAngle: window.solarZenithAngle,
-        interpolateAtmosphere: window.interpolateAtmosphere,
-        vitaminDIU: window.vitaminDIU,
-        vitaminDIUPerSession: window.vitaminDIUPerSession,
-        renderLightChannelsLive: window.renderLightChannelsLive,
-        renderLightTodayStrip: window.renderLightTodayStrip,
+        fetchAtmosphere,
+        reconstructSpectrum,
+        computeChannelDoses,
+        erythemalSED,
+        fractionOfMED,
+        solarZenithAngle,
+        interpolateAtmosphere,
+        vitaminDIU,
+        vitaminDIUPerSession,
+        renderLightChannelsLive,
+        renderLightTodayStrip,
       });
 
       await active.openStartSunSessionDialog();
@@ -414,7 +391,7 @@ test('sun active session covers start dialog stop summary and live dose helpers'
         committedDoses: { pomc: 4 },
         committedSED: 0.5,
         committedRetinalUV: 2,
-        fractionOfMEDFn: window.fractionOfMED,
+        fractionOfMEDFn: fractionOfMED,
         pending: false,
       });
       const live = active.liveDosesFor(sessions.find(sess => sess.id === 'active-sun'));
@@ -442,7 +419,6 @@ test('sun active session covers start dialog stop summary and live dose helpers'
       outcomes.elapsedFormattingCoversHourAndMinute = active._formatElapsed(3723000) === '1:02:03'
         && active._formatElapsed(65000) === '1:05';
     } finally {
-      Object.assign(window, savedWindow);
       state.importedData = originalImported;
       active.resetSunActiveSessionState();
       active.configureSunActiveSession({

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -190,20 +190,16 @@ test('sun session UI covers chip units and detailed dialog validation paths', as
     const saved = {
       currentView: state.currentView,
       importedData: JSON.parse(JSON.stringify(state.importedData)),
-      vitaminDIU: window.vitaminDIU,
-      vitaminDIUPerSession: window.vitaminDIUPerSession,
-      pbmJoulesPerCm2: window.pbmJoulesPerCm2,
-      circadianMelanopicLux: window.circadianMelanopicLux,
       navigate: window.navigate,
     };
 
     try {
       state.currentView = 'light';
       state.importedData = { ...state.importedData, genetics: { snps: [] } };
-      window.vitaminDIU = () => 900;
-      window.vitaminDIUPerSession = () => 1550;
-      window.pbmJoulesPerCm2 = () => 12.4;
-      window.circadianMelanopicLux = () => 12600;
+      const vitaminDIU = () => 900;
+      const vitaminDIUPerSession = () => 1550;
+      const pbmJoulesPerCm2 = () => 12.4;
+      const circadianMelanopicLux = () => 12600;
       window.navigate = route => calls.push(['navigate', route]);
 
       sunUI.configureSunSessionUI({
@@ -238,10 +234,10 @@ test('sun session UI covers chip units and detailed dialog validation paths', as
         tierLabel: tier => ['none', 'low', 'moderate', 'high'][tier] || 'none',
         formatChannelUnit: (key, value) => `${Math.round(value)} ${key}`,
         tooShortForChannelVerdictMin: 2,
-        vitaminDIU: window.vitaminDIU,
-        vitaminDIUPerSession: window.vitaminDIUPerSession,
-        pbmJoulesPerCm2: window.pbmJoulesPerCm2,
-        circadianMelanopicLux: window.circadianMelanopicLux,
+        vitaminDIU,
+        vitaminDIUPerSession,
+        pbmJoulesPerCm2,
+        circadianMelanopicLux,
       });
 
       const chipHost = document.createElement('div');
@@ -286,10 +282,6 @@ test('sun session UI covers chip units and detailed dialog validation paths', as
     } finally {
       state.currentView = saved.currentView;
       state.importedData = saved.importedData;
-      window.vitaminDIU = saved.vitaminDIU;
-      window.vitaminDIUPerSession = saved.vitaminDIUPerSession;
-      window.pbmJoulesPerCm2 = saved.pbmJoulesPerCm2;
-      window.circadianMelanopicLux = saved.circadianMelanopicLux;
       if (saved.navigate) window.navigate = saved.navigate;
       else delete window.navigate;
       sunUI.configureSunSessionUI({

--- a/tests/playwright/sun-sessions-store-browser-coverage.spec.js
+++ b/tests/playwright/sun-sessions-store-browser-coverage.spec.js
@@ -31,13 +31,6 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
       profiles: clone(state.profiles),
-      fetchAtmosphere: window.fetchAtmosphere,
-      reconstructSpectrum: window.reconstructSpectrum,
-      computeChannelDoses: window.computeChannelDoses,
-      erythemalSED: window.erythemalSED,
-      fractionOfMED: window.fractionOfMED,
-      retinalUVdose: window.retinalUVdose,
-      solarZenithAngle: window.solarZenithAngle,
       consoleWarn: console.warn,
     };
     const results = {};
@@ -94,7 +87,7 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
       });
       console.warn = (...args) => warnings.push(args.map(String).join(' '));
 
-      window.fetchAtmosphere = async () => {
+      const fetchAtmosphere = async () => {
         fetchCalls += 1;
         return {
           uvIndex: 5,
@@ -103,26 +96,26 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
           airQuality: { aod: 0.15 },
         };
       };
-      window.reconstructSpectrum = args => {
+      const reconstructSpectrum = args => {
         lastSpectrumArgs = args;
         return { wavelengths: [300, 305], irradiance: [1, 0.8] };
       };
-      window.computeChannelDoses = args => {
+      const computeChannelDoses = args => {
         lastDoseArgs = args;
         return { vitamin_d: 66, circadian: 11 };
       };
-      window.erythemalSED = () => 13;
-      window.fractionOfMED = () => 0.25;
-      window.retinalUVdose = () => 0.02;
-      window.solarZenithAngle = () => 35;
+      const erythemalSED = () => 13;
+      const fractionOfMED = () => 0.25;
+      const retinalUVdose = () => 0.02;
+      const solarZenithAngle = () => 35;
       store.configureSunSessionsStore({
-        fetchAtmosphere: window.fetchAtmosphere,
-        reconstructSpectrum: window.reconstructSpectrum,
-        computeChannelDoses: window.computeChannelDoses,
-        erythemalSED: window.erythemalSED,
-        fractionOfMED: window.fractionOfMED,
-        retinalUVdose: window.retinalUVdose,
-        solarZenithAngle: window.solarZenithAngle,
+        fetchAtmosphere,
+        reconstructSpectrum,
+        computeChannelDoses,
+        erythemalSED,
+        fractionOfMED,
+        retinalUVdose,
+        solarZenithAngle,
       });
 
       const activeId = await store.startSession({
@@ -261,13 +254,6 @@ test('sun sessions store browser coverage exercises lifecycle edits hydration an
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       data.invalidateActiveDataCache();
-      window.fetchAtmosphere = saved.fetchAtmosphere;
-      window.reconstructSpectrum = saved.reconstructSpectrum;
-      window.computeChannelDoses = saved.computeChannelDoses;
-      window.erythemalSED = saved.erythemalSED;
-      window.fractionOfMED = saved.fractionOfMED;
-      window.retinalUVdose = saved.retinalUVdose;
-      window.solarZenithAngle = saved.solarZenithAngle;
       console.warn = saved.consoleWarn;
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/sun-spectrum-browser-coverage.spec.js
+++ b/tests/playwright/sun-spectrum-browser-coverage.spec.js
@@ -15,34 +15,14 @@ test('sun spectrum browser coverage exercises reconstruction doses devices and s
   await page.goto('/sun-spectrum-blank', { waitUntil: 'load' });
 
   const outcomes = await page.evaluate(async () => {
-    const windowKeys = [
-      'reconstructSpectrum',
-      'synthesizeDeviceSpectrum',
-      'effectiveDeviceForMode',
-      'validateModeCoupling',
-      'heuristicPeakShares',
-      'computeChannelDoses',
-      'erythemalSED',
-      'fractionOfMED',
-      'vitaminDIU',
-      'vitaminDIURaw',
-      'vitaminDIUPerSession',
-      'VITD_DAILY_SATURATION_IU',
-      'VITD_PER_SESSION_BODYFRAC_CAP_IU',
-      'vitaminDIURange',
-      'geneticVitaminDMultiplier',
-      'pbmJoulesPerCm2',
-      'circadianMelanopicLux',
-      'retinalUVdose',
-      'glassTransmission',
-      'sunscreenTransmission',
-      'SUN_CHANNELS',
+    const legacyNames = [
+      'reconstructSpectrum','synthesizeDeviceSpectrum','effectiveDeviceForMode','validateModeCoupling',
+      'heuristicPeakShares','computeChannelDoses','erythemalSED','fractionOfMED',
+      'vitaminDIU','vitaminDIURaw','vitaminDIUPerSession','VITD_DAILY_SATURATION_IU',
+      'VITD_PER_SESSION_BODYFRAC_CAP_IU','vitaminDIURange','geneticVitaminDMultiplier',
+      'pbmJoulesPerCm2','circadianMelanopicLux','retinalUVdose','glassTransmission',
+      'sunscreenTransmission','SUN_CHANNELS',
     ];
-    const savedWindowExports = windowKeys.map(key => ({
-      key,
-      hadOwn: Object.prototype.hasOwnProperty.call(window, key),
-      value: window[key],
-    }));
     const mod = await import(`/js/sun-spectrum.js?browserCoverage=${Date.now()}`);
     const outcomes = {};
     const sum = values => values.reduce((total, value) => total + value, 0);
@@ -52,11 +32,11 @@ test('sun spectrum browser coverage exercises reconstruction doses devices and s
       && spectrum.wavelengths.length === spectrum.irradiance.length
       && max(spectrum.irradiance) > 0;
 
-    try {
-      outcomes.windowExportsRegistered = window.reconstructSpectrum === mod.reconstructSpectrum
-        && window.vitaminDIUPerSession === mod.vitaminDIUPerSession
-        && Array.isArray(window.SUN_CHANNELS)
-        && window.SUN_CHANNELS.length === 8;
+    outcomes.moduleExportsAvailable = typeof mod.reconstructSpectrum === 'function'
+      && typeof mod.vitaminDIUPerSession === 'function'
+      && Array.isArray(mod.SUN_CHANNELS)
+      && mod.SUN_CHANNELS.length === 8;
+    outcomes.legacyWindowGlobalsStayAbsent = legacyNames.every(name => !(name in window));
 
       outcomes.channelMetadata = mod.SUN_CHANNELS.map(channel => channel.key).join('|')
         === 'vitamin_d|pomc|no_cv|violet_eye|circadian|nir_solar|pbm_red|pbm_nir';
@@ -236,7 +216,7 @@ test('sun spectrum browser coverage exercises reconstruction doses devices and s
         && mod.vitaminDIU(100, 'II', 8, true) === 2 * mod.vitaminDIU(100, 'II', 8, false)
         && mod.vitaminDIU(10000, 'II', 8) === mod.VITD_DAILY_SATURATION_IU
         && mod.vitaminDIURaw(100, 'II', 8, false, genetics) < mod.vitaminDIURaw(100, 'II', 8)
-        && mod.vitaminDIUPerSession(10000, 'II', 8, false, null, 0.37) === Math.round(0.37 * window.VITD_PER_SESSION_BODYFRAC_CAP_IU)
+        && mod.vitaminDIUPerSession(10000, 'II', 8, false, null, 0.37) === Math.round(0.37 * mod.VITD_PER_SESSION_BODYFRAC_CAP_IU)
         && mod.vitaminDIUPerSession(10000, 'II', 8, false, null, null) === mod.VITD_DAILY_SATURATION_IU
         && mod.vitaminDIUPerSession(10, 'II', 8, false, null, 0.37) === mod.vitaminDIURaw(10, 'II', 8);
 
@@ -302,13 +282,6 @@ test('sun spectrum browser coverage exercises reconstruction doses devices and s
         && mod.validateModeCoupling(modeDevice, 'red-only').ok === true
         && mod.validateModeCoupling(modeDevice, 'uv-only').ok === false
         && /UV requires/.test(mod.validateModeCoupling(modeDevice, 'uv-only').error);
-    } finally {
-      for (const { key, hadOwn, value } of savedWindowExports) {
-        if (hadOwn) window[key] = value;
-        else delete window[key];
-      }
-    }
-
     return outcomes;
   });
 

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -37,6 +37,7 @@ console.log('=== Light Devices Tests ===\n');
 await import('../js/state.js');
 const dev = await import('../js/light-devices.js');
 const sessionEngine = await import('../js/light-device-session-engine.js');
+const { synthesizeDeviceSpectrum } = await import('../js/sun-spectrum.js');
 const {
   getDevices, getDeviceSessions,
   addDeviceFromPreset, addCustomDevice, deleteDevice,
@@ -320,12 +321,12 @@ const {
   // (which gives 5% UVB / 35% red by default for hybrid panels), the
   // explicit shares match UVB but amplify the red peak ~2.7×.
   console.log('%c peakShares — explicit override of heuristic ', 'font-weight:bold;color:#f59e0b');
-  if (typeof window.synthesizeDeviceSpectrum === 'function') {
-    const heuristicDefault = window.synthesizeDeviceSpectrum({
+  {
+    const heuristicDefault = synthesizeDeviceSpectrum({
       peakWavelengths: [297, 660],
       mwPerCm2At15cm: 100,
     });
-    const heavyRed = window.synthesizeDeviceSpectrum({
+    const heavyRed = synthesizeDeviceSpectrum({
       peakWavelengths: [297, 660],
       mwPerCm2At15cm: 100,
       peakShares: [0.05, 0.95],

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,7 +187,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, cycleModule, labContextModule, lensModule, lightToolsModule, piiModule, sunContextModule, supplementsModule] = await Promise.all([
+  const [apiModule, chartsModule, cycleModule, labContextModule, lensModule, lightToolsModule, piiModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/charts.js'),
     import('../js/cycle.js'),
@@ -196,6 +196,7 @@
     import('../js/light-tools.js'),
     import('../js/pii.js'),
     import('../js/sun-context.js'),
+    import('../js/sun-spectrum.js'),
     import('../js/supplements.js'),
   ]);
   const apiExports = [
@@ -259,6 +260,16 @@
   const sunContextLegacyGlobals = [
     'buildSunContext','getSunSessionsSlice','getSunSessionDetail',
     'isBodyRegionsInAIContext','setBodyRegionsInAIContext'
+  ];
+
+  // sun-spectrum.js (21 former browser globals, now module-only)
+  const sunSpectrumExports = [
+    'reconstructSpectrum','synthesizeDeviceSpectrum','effectiveDeviceForMode','validateModeCoupling',
+    'heuristicPeakShares','computeChannelDoses','erythemalSED','fractionOfMED',
+    'vitaminDIU','vitaminDIURaw','vitaminDIUPerSession','VITD_DAILY_SATURATION_IU',
+    'VITD_PER_SESSION_BODYFRAC_CAP_IU','vitaminDIURange','geneticVitaminDMultiplier',
+    'pbmJoulesPerCm2','circadianMelanopicLux','retinalUVdose','glassTransmission',
+    'sunscreenTransmission','SUN_CHANNELS'
   ];
 
   // lab-context.js
@@ -511,6 +522,7 @@
     ['light-tools.js', lightToolsModule, lightToolsExports],
     ['pii.js', piiModule, piiExports],
     ['sun-context.js', sunContextModule, sunContextExports],
+    ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
     ['supplements.js', supplementsModule, supplementsExports],
   ]) {
     for (const name of exports) {
@@ -532,6 +544,9 @@
   assert('lab-context.js.configureLabContext module export',
     typeof labContextModule.configureLabContext === 'function');
   for (const name of sunContextLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of sunSpectrumExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.191';
+self.APP_VERSION = '1.10.192';


### PR DESCRIPTION
## Summary
- remove the 21-function Sun Spectrum `window` facade while preserving the complete ES module API
- route Light Device session calculations through explicit Sun Spectrum imports
- migrate browser coverage scaffolding to configured dependencies and assert the legacy globals stay absent
- reduce the quality baseline from 17 to 16 total assignments and 15 to 14 legacy assignments
- bump the app version to 1.10.192

## Testing
- `./run-tests.sh`
  - 396 Vitest tests passed
  - 351 Playwright tests passed
  - 472 responsive/theme checks passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`