### PR TITLE
Make Settings Sync panel module-only

### DIFF
--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -27,6 +27,7 @@ import {
 import { getLensSummary, openKnowledgeBaseModal } from './lens.js';
 import { state } from './state.js';
 import { isSyncEnabled } from './sync.js';
+import { showSyncSetupModal } from './settings-sync-panel.js';
 import { escapeAttr, escapeHTML } from './utils.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { migrateStoredContextSourceSettingsToProfile } from './context-source-registry.js';
@@ -39,18 +40,23 @@ import {
 const appWindow = /** @type {Window & typeof globalThis & {
   openInterpretiveLensEditor?: () => void,
   showEnableEncryptionModal?: () => void,
-  showSyncSetupModal?: () => void,
   pickFolderForBackup?: () => void,
   handleDNAFile?: (file: File) => void,
   updateChatContextStatus?: () => void,
 }} */ (typeof window !== 'undefined' ? window : {});
+
+let dashboardAISyncSetupHandler = showSyncSetupModal;
+
+export function configureDashboardAISyncSetup(handler = showSyncSetupModal) {
+  dashboardAISyncSetupHandler = typeof handler === 'function' ? handler : showSyncSetupModal;
+}
 
 configureDashboardAIActionDelegates({
   'open-interpretive-lens': () => appWindow.openInterpretiveLensEditor?.(),
   'open-knowledge-base': () => openKnowledgeBaseModal(),
   'open-personalize-ai-picker': () => openContextModal(),
   'enable-encryption': () => appWindow.showEnableEncryptionModal?.(),
-  'setup-sync': () => appWindow.showSyncSetupModal?.(),
+  'setup-sync': () => dashboardAISyncSetupHandler(),
   'setup-backup': () => appWindow.pickFolderForBackup?.(),
   'open-data-protection-picker': () => openDataProtectionPicker(),
 });
@@ -679,7 +685,7 @@ export function openDataProtectionPicker() {
       if (isConfigured) { close(); return; }
       close();
       if (pick === 'encryption' && typeof appWindow.showEnableEncryptionModal === 'function') appWindow.showEnableEncryptionModal();
-      else if (pick === 'sync' && typeof appWindow.showSyncSetupModal === 'function') appWindow.showSyncSetupModal();
+      else if (pick === 'sync') dashboardAISyncSetupHandler();
       else if (pick === 'backup' && typeof appWindow.pickFolderForBackup === 'function') appWindow.pickFolderForBackup();
     };
   });

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -732,28 +732,3 @@ export function hydrateSettingsSyncPanel() {
 }
 
 installSettingsSyncDelegates();
-
-Object.assign(window, {
-  toggleSync,
-  toggleMnemonicVisibility,
-  copyMnemonic,
-  copySyncIdentityCode,
-  openRestoreMnemonicDialog,
-  closeRestoreMnemonicDialog,
-  confirmRestoreMnemonic,
-  saveSyncRelay,
-  closeSyncSetup,
-  syncSetupNew,
-  syncSetupRestore,
-  syncSetupBack,
-  syncSetupDoRestore,
-  syncSetupDone,
-  showSyncSetupModal,
-  toggleMessenger,
-  toggleMessengerToken,
-  toggleMessengerContextKey,
-  copyMessengerToken,
-  copyMessengerContextKey,
-  regenerateMessengerToken,
-  regenerateMessengerContextKey,
-});

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 16,
-  "legacyWindowGlobalAssignments": 14,
+  "windowGlobalAssignments": 15,
+  "legacyWindowGlobalAssignments": 13,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -40,7 +40,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     const savedGlobals = {
       showDirectoryPicker: originalShowDirectoryPicker,
       showEnableEncryptionModal: window.showEnableEncryptionModal,
-      showSyncSetupModal: window.showSyncSetupModal,
       pickFolderForBackup: window.pickFolderForBackup,
       openInterpretiveLensEditor: window.openInterpretiveLensEditor,
       handleDNAFile: window.handleDNAFile,
@@ -59,6 +58,8 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     let clickedInputId = null;
     let handledDnaFile = null;
 
+    dashboardAi.configureDashboardAISyncSetup(() => calls.push('sync'));
+
     try {
       window.setTimeout = (fn, delay, ...args) => {
         timers.push(delay);
@@ -66,7 +67,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
         return timers.length;
       };
       window.showEnableEncryptionModal = () => calls.push('encryption');
-      window.showSyncSetupModal = () => calls.push('sync');
       window.pickFolderForBackup = () => calls.push('backup');
       window.openInterpretiveLensEditor = () => calls.push('lens');
       window.handleDNAFile = file => {
@@ -238,6 +238,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       host.remove();
       document.querySelectorAll('#data-protection-picker-overlay,#ai-personalize-picker-overlay,#dna-dashboard-input')
         .forEach(el => el.remove());
+      dashboardAi.configureDashboardAISyncSetup();
       HTMLInputElement.prototype.click = originalInputClick;
       for (const [name, original] of Object.entries(savedGlobals)) {
         if (name === 'showDirectoryPicker' && !hadShowDirectoryPicker) delete window[name];

--- a/tests/playwright/settings-provider-browser-coverage.spec.js
+++ b/tests/playwright/settings-provider-browser-coverage.spec.js
@@ -353,7 +353,10 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       setupOverlay.querySelector('[data-sync-setup-action="setup-back"]').click();
       const setupBackRestoresChoices = setupOverlay.querySelector('#sync-setup-choices')?.style.display === '';
 
-      window.syncSetupDone();
+      const setupDoneButton = document.createElement('button');
+      setupDoneButton.dataset.syncSetupAction = 'setup-done';
+      setupOverlay.querySelector('.confirm-dialog')?.appendChild(setupDoneButton);
+      setupDoneButton.click();
       const setupDoneCloses = !setupOverlay.classList.contains('show');
 
       syncState.setSyncEnabled(true);

--- a/tests/playwright/settings-sync-setup-browser-coverage.spec.js
+++ b/tests/playwright/settings-sync-setup-browser-coverage.spec.js
@@ -145,6 +145,15 @@ test('settings sync setup browser coverage exercises mnemonic setup restore and 
       throw new Error('sync-section fixture missing');
     }
     const outcomes = {};
+    const legacyWindowGlobals = [
+      'toggleSync', 'toggleMnemonicVisibility', 'copyMnemonic', 'copySyncIdentityCode',
+      'openRestoreMnemonicDialog', 'closeRestoreMnemonicDialog', 'confirmRestoreMnemonic',
+      'saveSyncRelay', 'closeSyncSetup', 'syncSetupNew', 'syncSetupRestore', 'syncSetupBack',
+      'syncSetupDoRestore', 'syncSetupDone', 'showSyncSetupModal', 'toggleMessenger',
+      'toggleMessengerToken', 'toggleMessengerContextKey', 'copyMessengerToken',
+      'copyMessengerContextKey', 'regenerateMessengerToken', 'regenerateMessengerContextKey',
+    ];
+    outcomes.legacyWindowFacadeStaysAbsent = legacyWindowGlobals.every(name => !(name in window));
 
     try {
       syncSection.innerHTML = syncPanel.renderSyncSection();

--- a/tests/test-dashboard-data-protection.js
+++ b/tests/test-dashboard-data-protection.js
@@ -28,12 +28,9 @@ function assert(name, condition, detail) {
 console.log('=== Data Protection Dashboard Tests ===\n');
 
 // context-cards.js exposes renderDataProtectionCta + openDataProtectionPicker +
-// showEnableEncryptionModal + pickFolderForBackup; showSyncSetupModal is
-// bound by settings-sync-panel.js through settings.js (Playwright gets it for
-// free via main.js — in Node we import settings explicitly so the section-7
-// window-export check sees it).
+// showEnableEncryptionModal + pickFolderForBackup. Sync setup stays module-only.
 const cards = await import('../js/context-cards.js');
-await import('../js/settings.js');
+const settingsSyncPanel = await import('../js/settings-sync-panel.js');
 
 const make = (overrides) => ({
   encryption: false,
@@ -94,12 +91,14 @@ const make = (overrides) => ({
 // Section 6 (picker open/dismiss — live DOM) lives in
 // tests/playwright/dashboard-data-protection.spec.js.
 
-// ─── 7. Window exports ───────────────────────────────────
+// ─── 7. Public APIs ──────────────────────────────────────
 {
   assert('window.openDataProtectionPicker exists',
     typeof window.openDataProtectionPicker === 'function');
-  assert('window.showSyncSetupModal exists',
-    typeof window.showSyncSetupModal === 'function');
+  assert('settings-sync-panel.showSyncSetupModal exists',
+    typeof settingsSyncPanel.showSyncSetupModal === 'function');
+  assert('window.showSyncSetupModal stays module-only',
+    !('showSyncSetupModal' in window));
   assert('window.showEnableEncryptionModal exists',
     typeof window.showEnableEncryptionModal === 'function');
   assert('window.pickFolderForBackup exists',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -35,8 +35,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Cross-Device Sync Tests ===\n');
 
-// Load sync.js + settings.js so their window bindings populate
-// window.enableSync, window.toggleSync, etc.
+// Load the sync window bindings and the module-only Settings Sync panel.
 const { state } = await import('../js/state.js');
 const syncActions = await import('../js/sync-actions.js');
 const syncSaveHooks = await import('../js/sync-save-hooks.js');
@@ -48,6 +47,7 @@ const syncSubscriptions = await import('../js/sync-subscriptions.js');
 const syncPayloadCollectors = await import('../js/sync-payload-collectors.js');
 const syncStorageCleanup = await import('../js/sync-storage-cleanup.js');
 await import('../js/sync.js');
+const settingsSyncPanel = await import('../js/settings-sync-panel.js');
 await import('../js/settings.js');
 
   const syncSrc = await fetchWithRetry('js/sync.js');
@@ -1705,14 +1705,25 @@ await import('../js/settings.js');
     assert(`window.${fn} exists`, typeof window[fn] === 'function');
   }
 
-  const settingsWindowFns = [
-    'toggleSync', 'toggleMnemonicVisibility', 'copyMnemonic',
-    'saveSyncRelay', 'closeSyncSetup', 'syncSetupNew',
-    'syncSetupRestore', 'syncSetupBack', 'syncSetupDoRestore', 'syncSetupDone',
-    'toggleMessenger', 'toggleMessengerToken', 'copyMessengerToken', 'regenerateMessengerToken'
+  const settingsSyncPanelExports = [
+    'renderMessengerSection', 'renderSyncSection', 'showSyncSetupModal',
+    'closeSyncSetup', 'closeRestoreMnemonicDialog', 'hydrateSettingsSyncPanel',
   ];
-  for (const fn of settingsWindowFns) {
-    assert(`window.${fn} exists`, typeof window[fn] === 'function');
+  for (const fn of settingsSyncPanelExports) {
+    assert(`settings-sync-panel.${fn} exists`, typeof settingsSyncPanel[fn] === 'function');
+  }
+
+  const settingsLegacyWindowFns = [
+    'toggleSync', 'toggleMnemonicVisibility', 'copyMnemonic',
+    'copySyncIdentityCode', 'openRestoreMnemonicDialog', 'closeRestoreMnemonicDialog',
+    'confirmRestoreMnemonic', 'saveSyncRelay', 'closeSyncSetup', 'syncSetupNew',
+    'syncSetupRestore', 'syncSetupBack', 'syncSetupDoRestore', 'syncSetupDone',
+    'showSyncSetupModal', 'toggleMessenger', 'toggleMessengerToken',
+    'toggleMessengerContextKey', 'copyMessengerToken', 'copyMessengerContextKey',
+    'regenerateMessengerToken', 'regenerateMessengerContextKey',
+  ];
+  for (const fn of settingsLegacyWindowFns) {
+    assert(`window.${fn} stays module-only`, !(fn in window));
   }
 
   // ═══════════════════════════════════════

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,7 +187,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, cycleModule, labContextModule, lensModule, lightToolsModule, piiModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
+  const [apiModule, chartsModule, cycleModule, labContextModule, lensModule, lightToolsModule, piiModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/charts.js'),
     import('../js/cycle.js'),
@@ -195,6 +195,7 @@
     import('../js/lens.js'),
     import('../js/light-tools.js'),
     import('../js/pii.js'),
+    import('../js/settings-sync-panel.js'),
     import('../js/sun-context.js'),
     import('../js/sun-spectrum.js'),
     import('../js/supplements.js'),
@@ -250,6 +251,20 @@
     'openLuxMeter','openFlickerDetector','openDarknessMeter','openCCTMeter',
     'openSpectrumClassifier','openGlassTransmission','openSunriseLogger','openEyeLevelAudit',
     'getMeasurements','getMeasurementsForRoom','saveMeasurement','deleteMeasurement','renderLightTools'
+  ];
+
+  // settings-sync-panel.js (6, module-only)
+  const settingsSyncPanelExports = [
+    'renderMessengerSection','renderSyncSection','showSyncSetupModal',
+    'closeSyncSetup','closeRestoreMnemonicDialog','hydrateSettingsSyncPanel'
+  ];
+  const settingsSyncPanelLegacyGlobals = [
+    'toggleSync','toggleMnemonicVisibility','copyMnemonic','copySyncIdentityCode',
+    'openRestoreMnemonicDialog','closeRestoreMnemonicDialog','confirmRestoreMnemonic',
+    'saveSyncRelay','closeSyncSetup','syncSetupNew','syncSetupRestore','syncSetupBack',
+    'syncSetupDoRestore','syncSetupDone','showSyncSetupModal','toggleMessenger',
+    'toggleMessengerToken','toggleMessengerContextKey','copyMessengerToken',
+    'copyMessengerContextKey','regenerateMessengerToken','regenerateMessengerContextKey'
   ];
 
   // sun-context.js (6, module-only)
@@ -521,6 +536,7 @@
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
     ['pii.js', piiModule, piiExports],
+    ['settings-sync-panel.js', settingsSyncPanelModule, settingsSyncPanelExports],
     ['sun-context.js', sunContextModule, sunContextExports],
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
     ['supplements.js', supplementsModule, supplementsExports],
@@ -539,6 +555,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of lightToolsLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   assert('lab-context.js.configureLabContext module export',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.192';
+self.APP_VERSION = '1.10.193';


### PR DESCRIPTION
## Summary
- remove the 22-function Settings Sync `window` facade now that panel controls use delegated events
- route the dashboard Sync setup CTA through an explicit module dependency
- migrate sync and dashboard coverage to module APIs/delegated actions and assert legacy globals remain absent
- reduce the quality baseline from 16 to 15 total assignments and 14 to 13 legacy assignments
- bump the app version to 1.10.193

## Testing
- `./run-tests.sh`
  - 396 Vitest tests passed
  - 351 Playwright tests passed
  - 472 responsive/theme checks passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- focused Settings Sync/dashboard tests
- `git diff --check`