### PR TITLE
Make Lab Context module-only

### DIFF
--- a/js/context-card-health-dots.js
+++ b/js/context-card-health-dots.js
@@ -4,11 +4,25 @@
 import { state } from './state.js';
 import { callClaudeAPI, getActiveModelId, getAIProvider, hasAIProvider } from './api.js';
 import { CONTEXT_CARD_KEYS } from './context-card-summaries.js';
+import { buildLabContext } from './lab-context.js';
 import { profileStorageKey } from './profile.js';
 import { trackUsage } from './schema.js';
 import { hashString, hasCardContent, showNotification } from './utils.js';
 
 const DOT_COLORS = ['green', 'yellow', 'red', 'gray'];
+
+/** @type {{ buildLabContext: typeof buildLabContext }} */
+const contextHealthDotDeps = {
+  buildLabContext,
+};
+
+export function configureContextCardHealthDots(deps = {}) {
+  const previous = { ...contextHealthDotDeps };
+  if (typeof deps.buildLabContext === 'function') {
+    contextHealthDotDeps.buildLabContext = deps.buildLabContext;
+  }
+  return previous;
+}
 
 export function applyDotColor(key, color) {
   const dot = document.getElementById('ctx-dot-' + key);
@@ -106,9 +120,7 @@ function applyGrayDots(keys) {
 }
 
 function buildContextForStaleKeys(keys, staleKeys) {
-  const appWindow = /** @type {any} */ (window);
-  if (typeof appWindow.buildLabContext !== 'function') return '';
-  let ctx = appWindow.buildLabContext();
+  let ctx = contextHealthDotDeps.buildLabContext();
   if (typeof ctx !== 'string') return '';
   if (staleKeys.length >= keys.length) return ctx;
 

--- a/js/data.js
+++ b/js/data.js
@@ -39,13 +39,25 @@ export {
  * @typedef {[MarkerValueGetter | 'age' | 'crp', number, number, boolean, number | null, 'ceil' | 'floor' | null, (number | undefined)?]} BortzFeature
  * @typedef {{
  *   buildSidebar: (data?: unknown) => void,
- *   invalidateLabContextCache?: () => void,
  *   navigate: (route?: string, data?: unknown) => void,
  *   showDetailModal?: (id: string) => void,
  * }} DataWindowHooks
  */
 
 const dataWindow = /** @type {Window & typeof globalThis & DataWindowHooks} */ (typeof window !== 'undefined' ? window : {});
+
+/** @type {{ invalidateLabContextCache: (() => void) | null }} */
+const dataContextDeps = {
+  invalidateLabContextCache: null,
+};
+
+export function configureDataContextDependencies(deps = {}) {
+  const previous = { ...dataContextDeps };
+  if (Object.prototype.hasOwnProperty.call(deps, 'invalidateLabContextCache')) {
+    dataContextDeps.invalidateLabContextCache = deps.invalidateLabContextCache;
+  }
+  return previous;
+}
 
 const DATA_ACTION_ATTR = 'data-lab-data-action';
 const DATA_CHANGE_ATTR = 'data-lab-data-change';
@@ -269,7 +281,7 @@ export async function saveImportedData(options = {}) {
     broadcastDataChanged(state.currentProfile);
     scheduleAutoBackup();
     touchProfileTimestamp(state.currentProfile);
-    if (dataWindow.invalidateLabContextCache) dataWindow.invalidateLabContextCache();
+    dataContextDeps.invalidateLabContextCache?.();
     onDataSaved(options);
   } catch (e) {
     if (dataWindow.isDebugMode?.()) console.warn('Post-save hook failed after data was persisted:', e);

--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -1093,36 +1093,3 @@ function _formatLensChunks(result) {
   lines.push('When your interpretation draws on these excerpts, cite the source. When it does not, say so.');
   return lines.join('\n');
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    buildLabContext,
-    invalidateLabContextCache,
-    getContextSummary,
-    isGroupInAIContext,
-    setGroupInAIContext,
-    isInsightContextCardsEnabled,
-    setInsightContextCardsEnabled,
-    isSupplementsMedsContextEnabled,
-    setSupplementsMedsContextEnabled,
-    isLabMarkersContextEnabled,
-    setLabMarkersContextEnabled,
-    isGeneticsSummaryInAIContext,
-    setGeneticsSummaryInAIContext,
-    isGeneticsPriorityInAIContext,
-    setGeneticsPriorityInAIContext,
-    isGeneticsInventoryInAIContext,
-    setGeneticsInventoryInAIContext,
-    isLightSunContextEnabled,
-    setLightSunContextEnabled,
-    isWearableContextEnabled,
-    setWearableContextEnabled,
-    isAgentWearableSeriesEnabled,
-    setAgentWearableSeriesEnabled,
-    getAgentWearableSeriesDays,
-    setAgentWearableSeriesDays,
-    buildWearableContext,
-    buildWearableSeriesSection,
-    injectLensChunks,
-  });
-}

--- a/js/sun-context-hooks.js
+++ b/js/sun-context-hooks.js
@@ -18,11 +18,13 @@ import {
 import { getMeteoConfig } from './sun-uvdata.js';
 import { rollingDeviceTotals } from './light-devices-store.js';
 import { computeDeficitAxes, computeIndoorBurden } from './light-env.js';
-import { configureLabContext } from './lab-context.js';
+import { configureDataContextDependencies } from './data.js';
+import { configureLabContext, invalidateLabContextCache } from './lab-context.js';
 import { isDebugMode } from './utils.js';
 import { buildSunContext, configureSunContext } from './sun-context.js';
 
 configureLabContext({ buildSunContext });
+configureDataContextDependencies({ invalidateLabContextCache });
 
 configureSunContext({
   bodyRegions: BODY_REGIONS,
@@ -33,6 +35,7 @@ configureSunContext({
   cumulativeMEDToday,
   getMeteoConfig,
   isDebugMode,
+  invalidateLabContextCache,
   pbmJoulesPerCm2,
   rollingChannelTotals,
   rollingDeviceTotals,

--- a/js/sun-context.js
+++ b/js/sun-context.js
@@ -32,6 +32,7 @@ const sunContextDeps = {
   cumulativeMEDToday: () => 0,
   getMeteoConfig: () => ({ privacyRounding: 0.01 }),
   isDebugMode: () => false,
+  invalidateLabContextCache: null,
   pbmJoulesPerCm2: null,
   rollingChannelTotals: () => ({}),
   rollingDeviceTotals: () => ({}),
@@ -91,7 +92,7 @@ export function isBodyRegionsInAIContext() {
 }
 export function setBodyRegionsInAIContext(on) {
   localStorage.setItem(_bodyRegionsCtxKey(), on ? 'on' : 'off');
-  if (typeof window !== 'undefined') /** @type {any} */ (window).invalidateLabContextCache?.();
+  sunContextDeps.invalidateLabContextCache?.();
 }
 
 // ─── Public API ────────────────────────────────────────────────────────

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 15,
-  "legacyWindowGlobalAssignments": 13,
+  "windowGlobalAssignments": 14,
+  "legacyWindowGlobalAssignments": 12,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -491,8 +491,8 @@ test('context health dots and focus card cover cache fallback and empty states',
       ollamaConfigCache: cryptoStore.getCachedKey('labcharts-ollama'),
       ollamaModel: localStorage.getItem('labcharts-ollama-model'),
       fetch: window.fetch,
-      buildLabContext: window.buildLabContext,
     };
+    const originalHealthDotDeps = health.configureContextCardHealthDots();
     const cacheKeys = [];
     const host = document.createElement('div');
 
@@ -571,7 +571,9 @@ test('context health dots and focus card cover cache fallback and empty states',
       });
       const aiCalls = [];
       cryptoStore.updateKeyCache('labcharts-ollama', JSON.stringify({ url: 'http://ollama.test', model: 'context-test-model', mode: 'ollama', apiKey: '' }));
-      window.buildLabContext = () => summaries.CONTEXT_CARD_KEYS.map(key => `[section:${key}]\n${key} section\n[/section:${key}]`).join('\n');
+      health.configureContextCardHealthDots({
+        buildLabContext: () => summaries.CONTEXT_CARD_KEYS.map(key => `[section:${key}]\n${key} section\n[/section:${key}]`).join('\n'),
+      });
       window.fetch = async (url, options = {}) => {
         const href = typeof url === 'string' ? url : url?.url || '';
         if (href === 'http://ollama.test/v1/chat/completions') {
@@ -609,8 +611,7 @@ test('context health dots and focus card cover cache fallback and empty states',
         && localStorage.getItem(healthCacheKey) !== null;
 
       window.fetch = saved.fetch;
-      if (saved.buildLabContext === undefined) delete window.buildLabContext;
-      else window.buildLabContext = saved.buildLabContext;
+      health.configureContextCardHealthDots(originalHealthDotDeps);
 
       const demo = await fetch('data/demo-male.json').then(r => r.json());
       state.importedData = demo;
@@ -728,8 +729,7 @@ test('context health dots and focus card cover cache fallback and empty states',
       window.updateKeyCache?.('labcharts-openrouter-key', saved.openRouterKey || '');
       cryptoStore.updateKeyCache('labcharts-ollama', saved.ollamaConfigCache);
       window.fetch = saved.fetch;
-      if (saved.buildLabContext === undefined) delete window.buildLabContext;
-      else window.buildLabContext = saved.buildLabContext;
+      health.configureContextCardHealthDots(originalHealthDotDeps);
       for (const key of cacheKeys) localStorage.removeItem(key);
       host.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());

--- a/tests/playwright/lab-context-browser-coverage.spec.js
+++ b/tests/playwright/lab-context-browser-coverage.spec.js
@@ -23,6 +23,22 @@ test('lab context browser coverage exercises toggles lens chunks and wearable co
     ]);
     const { state } = stateModule;
     const outcomes = {};
+    const legacyWindowGlobals = [
+      'buildLabContext', 'invalidateLabContextCache', 'getContextSummary',
+      'isGroupInAIContext', 'setGroupInAIContext',
+      'isInsightContextCardsEnabled', 'setInsightContextCardsEnabled',
+      'isSupplementsMedsContextEnabled', 'setSupplementsMedsContextEnabled',
+      'isLabMarkersContextEnabled', 'setLabMarkersContextEnabled',
+      'isGeneticsSummaryInAIContext', 'setGeneticsSummaryInAIContext',
+      'isGeneticsPriorityInAIContext', 'setGeneticsPriorityInAIContext',
+      'isGeneticsInventoryInAIContext', 'setGeneticsInventoryInAIContext',
+      'isLightSunContextEnabled', 'setLightSunContextEnabled',
+      'isWearableContextEnabled', 'setWearableContextEnabled',
+      'isAgentWearableSeriesEnabled', 'setAgentWearableSeriesEnabled',
+      'getAgentWearableSeriesDays', 'setAgentWearableSeriesDays',
+      'buildWearableContext', 'buildWearableSeriesSection', 'injectLensChunks',
+    ];
+    outcomes.legacyWindowFacadeStaysAbsent = legacyWindowGlobals.every(name => !(name in window));
     const storage = new Map(Array.from({ length: localStorage.length }, (_, index) => {
       const key = localStorage.key(index);
       return [key, key ? localStorage.getItem(key) : null];

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -218,6 +218,7 @@ test('settings browser coverage renames imported entry dates through the data se
   await preparePage(page);
 
   const results = await page.evaluate(async () => {
+    const dataModule = await import('/js/data.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 80; attempt += 1) {
@@ -236,10 +237,12 @@ test('settings browser coverage renames imported entry dates through the data se
       buildSidebar: window.buildSidebar,
       updateHeaderDates: window.updateHeaderDates,
       navigate: window.navigate,
-      invalidateLabContextCache: window.invalidateLabContextCache,
       storage: localStorage.getItem(`labcharts-${profileId}-imported`),
     };
     const calls = [];
+    const originalDataContextDeps = dataModule.configureDataContextDependencies({
+      invalidateLabContextCache: () => calls.push('invalidateLabContextCache'),
+    });
 
     try {
       state.currentProfile = profileId;
@@ -258,7 +261,6 @@ test('settings browser coverage renames imported entry dates through the data se
       window.buildSidebar = () => calls.push('buildSidebar');
       window.updateHeaderDates = () => calls.push('updateHeaderDates');
       window.navigate = view => calls.push(`navigate:${view}`);
-      window.invalidateLabContextCache = () => calls.push('invalidateLabContextCache');
 
       document.body.insertAdjacentHTML('beforeend', '<section id="data-entries-section"></section>');
       window.refreshDataEntriesSection();
@@ -287,7 +289,7 @@ test('settings browser coverage renames imported entry dates through the data se
       window.buildSidebar = saved.buildSidebar;
       window.updateHeaderDates = saved.updateHeaderDates;
       window.navigate = saved.navigate;
-      window.invalidateLabContextCache = saved.invalidateLabContextCache;
+      dataModule.configureDataContextDependencies(originalDataContextDeps);
       if (saved.storage == null) localStorage.removeItem(`labcharts-${profileId}-imported`);
       else localStorage.setItem(`labcharts-${profileId}-imported`, saved.storage);
       document.getElementById('data-entries-section')?.remove();

--- a/tests/playwright/settings-provider-browser-coverage.spec.js
+++ b/tests/playwright/settings-provider-browser-coverage.spec.js
@@ -284,8 +284,6 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       listPendingTombstones: window.listPendingTombstones,
       openSettingsModal: window.openSettingsModal,
       updateSyncIndicator: window.updateSyncIndicator,
-      getAgentWearableSeriesDays: window.getAgentWearableSeriesDays,
-      setAgentWearableSeriesDays: window.setAgentWearableSeriesDays,
       pushContextToGateway: window.pushContextToGateway,
       clipboard: navigator.clipboard,
       fetch: window.fetch,
@@ -297,7 +295,6 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
     const openedTabs = [];
     let syncIndicatorUpdates = 0;
     let pushedContexts = 0;
-    let seriesDays = 0;
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
@@ -307,8 +304,6 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       window.listPendingTombstones = () => [{ id: 'profile-old', name: 'Old Profile', at: '2026-06-07T12:00:00Z' }];
       window.openSettingsModal = tab => { openedTabs.push(tab); };
       window.updateSyncIndicator = () => { syncIndicatorUpdates += 1; };
-      window.getAgentWearableSeriesDays = () => seriesDays;
-      window.setAgentWearableSeriesDays = days => { seriesDays = days; localStorage.setItem('labcharts-agent-wearable-series-days', String(days)); };
       window.pushContextToGateway = () => { pushedContexts += 1; };
       window.fetch = async () => new Response('', { status: 200 });
       window.WebSocket = class {
@@ -437,7 +432,8 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       const seriesProfileId = localStorage.getItem('labcharts-active-profile') || 'default';
       const seriesDelegated = syncMessenger.getAgentAccessState().wearableSeriesDays === 30
         && localStorage.getItem(`labcharts-${seriesProfileId}-agent-wearable-series`) === '30'
-        && seriesDays === 0
+        && !('getAgentWearableSeriesDays' in window)
+        && !('setAgentWearableSeriesDays' in window)
         && pushedContexts >= 1;
       messengerSection.querySelector('[data-sync-action="regenerate-messenger-token"]').click();
       await waitFor(() => syncMessenger.getMessengerToken() !== token
@@ -502,8 +498,6 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       window.listPendingTombstones = oldGlobals.listPendingTombstones;
       window.openSettingsModal = oldGlobals.openSettingsModal;
       window.updateSyncIndicator = oldGlobals.updateSyncIndicator;
-      window.getAgentWearableSeriesDays = oldGlobals.getAgentWearableSeriesDays;
-      window.setAgentWearableSeriesDays = oldGlobals.setAgentWearableSeriesDays;
       window.pushContextToGateway = oldGlobals.pushContextToGateway;
       window.fetch = oldGlobals.fetch;
       window.WebSocket = oldGlobals.WebSocket;

--- a/tests/test-biometrics.js
+++ b/tests/test-biometrics.js
@@ -15,7 +15,7 @@ console.log('=== Biometrics Tests ===\n');
 
 await import('../js/state.js');
 await import('../js/profile.js');
-await import('../js/lab-context.js');
+const labContext = await import('../js/lab-context.js');
 // Initialize profiles so getProfiles() / setProfileHeight() have something
 // to mutate. The Playwright environment runs main.js which seeds this.
 if (!window._labState.profiles) {
@@ -130,17 +130,13 @@ if (!window._labState.profiles) {
   // ═══════════════════════════════════════
   console.log('7. AI Context');
 
-  if (typeof window.buildLabContext === 'function') {
-    const ctx = window.buildLabContext();
-    assert('AI context includes biometrics section', ctx.includes('[section:biometrics]'));
-    assert('AI context includes height', ctx.includes('Height:'));
-    assert('AI context includes weight', ctx.includes('Weight'));
-    assert('AI context includes BMI', ctx.includes('BMI:'));
-    assert('AI context includes BP', ctx.includes('Blood Pressure'));
-    assert('AI context includes pulse', ctx.includes('Resting Pulse'));
-  } else {
-    assert('buildLabContext exists', false, 'function not found on window');
-  }
+  const ctx = labContext.buildLabContext();
+  assert('AI context includes biometrics section', ctx.includes('[section:biometrics]'));
+  assert('AI context includes height', ctx.includes('Height:'));
+  assert('AI context includes weight', ctx.includes('Weight'));
+  assert('AI context includes BMI', ctx.includes('BMI:'));
+  assert('AI context includes BP', ctx.includes('Blood Pressure'));
+  assert('AI context includes pulse', ctx.includes('Resting Pulse'));
 
   // ═══════════════════════════════════════
   // 8. Export includes biometrics

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -31,7 +31,7 @@ console.log('=== Chat Actions Tests ===\n');
 // state.js exposes window._labState; chat.js + lab-context.js expose the
 // action-bar / context-summary handlers via Object.assign(window, ...).
 await import('../js/state.js');
-await import('../js/lab-context.js');
+const labContext = await import('../js/lab-context.js');
 await import('../js/chat.js');
 const { buildActionBar } = await import('../js/chat-actions.js');
 const { buildSummaryTranscript } = await import('../js/chat-summaries.js');
@@ -55,12 +55,13 @@ assert('window._labState exists', hasState, hasState ? 'found' : 'not found');
 // ─── Section 1: Window exports ───
 console.log('Section 1: Window Exports');
 const requiredExports = [
-  'getContextSummary', 'regenerateLastMessage',
-  'copyMessage', 'toggleContextDetails'
+  'regenerateLastMessage', 'copyMessage', 'toggleContextDetails'
 ];
 for (const fn of requiredExports) {
   assert(`window.${fn} exists`, typeof window[fn] === 'function', typeof window[fn]);
 }
+assert('lab-context.getContextSummary exists', typeof labContext.getContextSummary === 'function');
+assert('window.getContextSummary stays module-only', !('getContextSummary' in window));
 assert('window.readAloud removed', typeof window.readAloud === 'undefined', typeof window.readAloud);
 
 // ─── Section 1a: Discuss Button UI ───
@@ -195,7 +196,7 @@ if (hasState) {
 
 // ─── Section 2: getContextSummary() ───
 console.log('Section 2: getContextSummary()');
-const summary = window.getContextSummary();
+const summary = labContext.getContextSummary();
 assert('getContextSummary returns array', Array.isArray(summary), typeof summary);
 if (summary.length > 0) {
   assert('Summary items have label', typeof summary[0].label === 'string', summary[0].label);

--- a/tests/test-sun-context.js
+++ b/tests/test-sun-context.js
@@ -16,8 +16,6 @@ function assert(name, condition, detail) {
 console.log('=== Sun Context Tests ===\n');
 
 await import('../js/state.js');
-// lab-context.js exposes buildLabContext via window — section 11 below
-// gates on its presence. Importing it makes the gate fire.
 const labCtxMod = await import('../js/lab-context.js');
 const ctxMod = await import('../js/sun-context.js');
 await import('../js/sun-context-hooks.js');
@@ -433,20 +431,16 @@ labCtxMod.setLightSunContextEnabled(true);
   // session table whenever sun sessions are present.
   console.log('%c 11. Sun standard-tier always included when data exists ', 'font-weight:bold;color:#f59e0b');
 
-  if (typeof window.buildLabContext === 'function') {
-    const labCtx = window.buildLabContext({});
-    const sessions = window.getSessions ? window.getSessions().filter(s => s.endedAt) : [];
-    if (sessions.length > 0) {
-      assert('Lab context always carries [section:sun] when sessions exist',
-        /\[section:sun\][\s\S]*\[\/section:sun\]/.test(labCtx));
-      assert('Lab context always includes weekly-trend (standard tier) when sessions exist',
-        /### Weekly trend \(last 6w/.test(labCtx));
-    } else {
-      assert('Lab context skips [section:sun] when no sessions',
-        !/\[section:sun\]/.test(labCtx));
-    }
+  const labCtx = labCtxMod.buildLabContext({});
+  const completedSessions = window.getSessions ? window.getSessions().filter(s => s.endedAt) : [];
+  if (completedSessions.length > 0) {
+    assert('Lab context always carries [section:sun] when sessions exist',
+      /\[section:sun\][\s\S]*\[\/section:sun\]/.test(labCtx));
+    assert('Lab context always includes weekly-trend (standard tier) when sessions exist',
+      /### Weekly trend \(last 6w/.test(labCtx));
   } else {
-    assert('window.buildLabContext exists', false, 'skipped — function missing');
+    assert('Lab context skips [section:sun] when no sessions',
+      !/\[section:sun\]/.test(labCtx));
   }
 
   // ─── 12. Token-budget guard ──────────────────────────────────────────

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -14,6 +14,7 @@ return (async function() {
   const main = document.getElementById('main-content');
   const S = window._labState;
   const { buildSunContext } = await import('/js/sun-context.js');
+  const { buildLabContext } = await import('/js/lab-context.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -224,17 +225,10 @@ return (async function() {
   // ─── 6. lab-context.js integrates the sun section ────────────────────
   console.log('%c 6. lab-context integrates sun section ', 'font-weight:bold;color:#6366f1');
 
-  if (typeof window.buildLabContext === 'function') {
-    const labCtx = window.buildLabContext({ scope: 'full' });
-    assert('Full lab context includes the sun section',
-      typeof labCtx === 'string' && /\[section:sun\]/.test(labCtx),
-      `len=${typeof labCtx === 'string' ? labCtx.length : 'not-a-string'}`);
-  } else {
-    // buildLabContext is the public AI feed; the section must be wired
-    // through it for the chat panel to see sun data.
-    assert('window.buildLabContext exists', false,
-      'skipped — buildLabContext not on window');
-  }
+  const labCtx = buildLabContext({ scope: 'full' });
+  assert('Full lab context includes the sun section',
+    typeof labCtx === 'string' && /\[section:sun\]/.test(labCtx),
+    `len=${typeof labCtx === 'string' ? labCtx.length : 'not-a-string'}`);
 
   // ─── 7. Modal lifecycle wiring exists for Light & Sun modals ─────────
   // Modal focus/backdrop/scroll-lock belongs to the shared lifecycle module;

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -2211,11 +2211,10 @@ assert('Series elides metrics with zero non-null daily values in the window',
   /nonNullCount\s*===\s*0\)\s*continue/.test(labWearablesSrc) ||
   /nonNullCount\s*===\s*0\)\s*\{\s*continue/.test(labWearablesSrc));
 
-// Window exports for the toggle handler in Settings → Agent Access.
-assert('window.isAgentWearableSeriesEnabled exists',
-  typeof window.isAgentWearableSeriesEnabled === 'function');
-assert('window.setAgentWearableSeriesEnabled exists',
-  typeof window.setAgentWearableSeriesEnabled === 'function');
+assert('window.isAgentWearableSeriesEnabled stays module-only',
+  !('isAgentWearableSeriesEnabled' in window));
+assert('window.setAgentWearableSeriesEnabled stays module-only',
+  !('setAgentWearableSeriesEnabled' in window));
 assert('window.pushContextToGateway is exposed (toggle re-pushes immediately)',
   typeof window.pushContextToGateway === 'function');
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -287,8 +287,23 @@
     'sunscreenTransmission','SUN_CHANNELS'
   ];
 
-  // lab-context.js
+  // lab-context.js (30, module-only)
   const labContextExports = [
+    'configureLabContext','buildLabContext','invalidateLabContextCache','getContextSummary',
+    'isGroupInAIContext','setGroupInAIContext',
+    'isInsightContextCardsEnabled','setInsightContextCardsEnabled',
+    'isSupplementsMedsContextEnabled','setSupplementsMedsContextEnabled',
+    'isLabMarkersContextEnabled','setLabMarkersContextEnabled',
+    'isGeneticsSummaryInAIContext','setGeneticsSummaryInAIContext',
+    'isGeneticsPriorityInAIContext','setGeneticsPriorityInAIContext',
+    'isGeneticsInventoryInAIContext','setGeneticsInventoryInAIContext',
+    'isLightSunContextEnabled','setLightSunContextEnabled',
+    'isWearableContextEnabled','setWearableContextEnabled',
+    'isAgentWearableSeriesEnabled','setAgentWearableSeriesEnabled',
+    'getAgentWearableSeriesDays','setAgentWearableSeriesDays',
+    'buildWearableContext','buildWearableSeriesSection','injectLensChunks'
+  ];
+  const labContextLegacyGlobals = [
     'buildLabContext','invalidateLabContextCache','getContextSummary',
     'isGroupInAIContext','setGroupInAIContext',
     'isInsightContextCardsEnabled','setInsightContextCardsEnabled',
@@ -298,7 +313,10 @@
     'isGeneticsPriorityInAIContext','setGeneticsPriorityInAIContext',
     'isGeneticsInventoryInAIContext','setGeneticsInventoryInAIContext',
     'isLightSunContextEnabled','setLightSunContextEnabled',
-    'isWearableContextEnabled','setWearableContextEnabled'
+    'isWearableContextEnabled','setWearableContextEnabled',
+    'isAgentWearableSeriesEnabled','setAgentWearableSeriesEnabled',
+    'getAgentWearableSeriesDays','setAgentWearableSeriesDays',
+    'buildWearableContext','buildWearableSeriesSection','injectLensChunks'
   ];
 
   // chat.js (23)
@@ -533,6 +551,7 @@
   for (const [moduleName, moduleApi, exports] of [
     ['charts.js', chartsModule, chartsExports],
     ['cycle.js', cycleModule, cycleExports],
+    ['lab-context.js', labContextModule, labContextExports],
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
     ['pii.js', piiModule, piiExports],
@@ -560,8 +579,9 @@
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
-  assert('lab-context.js.configureLabContext module export',
-    typeof labContextModule.configureLabContext === 'function');
+  for (const name of labContextLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
   for (const name of sunContextLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
@@ -570,7 +590,6 @@
   }
 
   const allModules = {
-    'lab-context.js': labContextExports,
     'chat.js': chatExports,
     'client-list.js': clientListExports,
     'context-cards.js': contextCardsExports,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.193';
+self.APP_VERSION = '1.10.194';


### PR DESCRIPTION
## Summary
- remove the 29-function Lab Context `window` facade while preserving the complete ES module API
- wire data-save and Sun preference cache invalidation through explicit startup dependencies
- route context-card health scoring through an injectable module dependency
- migrate browser and Node coverage to module APIs and assert the former globals remain absent
- reduce the quality baseline from 15 to 14 total assignments and 13 to 12 legacy assignments
- bump the app version to 1.10.194

## Testing
- `./run-tests.sh`
  - 396 Vitest tests passed
  - 351 Playwright tests passed
  - 472 responsive/theme checks passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- focused Lab Context, Settings, Sun, health-dot, biometrics, chat, and wearable tests
- `git diff --check`