### PR TITLE
Make backup module-only

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -8,13 +8,37 @@ import { collectCycleBackup, restoreCycleBackup } from './backup-cycle.js';
 import { parseBackupSnapshot, serializeBackupSnapshot } from './backup-serialization.js';
 export { parseBackupSnapshot, serializeBackupSnapshot } from './backup-serialization.js';
 
-// Use runtime-owned globals to avoid circular import (crypto.js imports from backup.js)
+// Crypto imports this module for backup UI helpers, so inject the two crypto
+// operations backup needs instead of coupling the modules through globals.
 const appWindow = /** @type {Window & typeof globalThis & {
-  encryptedGetItem?: (key: string) => Promise<string | null>,
-  getEncryptionEnabled?: () => boolean,
   showDirectoryPicker?: (options?: { mode?: 'read' | 'readwrite' }) => Promise<any>,
 }} */ (typeof window !== 'undefined' ? window : {});
-const getEncryptionEnabled = () => appWindow.getEncryptionEnabled?.() || false;
+
+/** @typedef {{ encryptedGetItem: (key: string) => Promise<string | null>, getEncryptionEnabled: () => boolean }} BackupRuntimeDeps */
+// `var` is intentional: the profile → crypto cycle can configure backup
+// while this module is still initializing, before lexical bindings are ready.
+/** @type {BackupRuntimeDeps | undefined} */
+var backupRuntimeDeps;
+
+function getBackupRuntimeDeps() {
+  if (!backupRuntimeDeps) {
+    backupRuntimeDeps = {
+      encryptedGetItem: async () => null,
+      getEncryptionEnabled: () => false,
+    };
+  }
+  return backupRuntimeDeps;
+}
+
+export function configureBackupRuntimeDeps(deps = {}) {
+  const runtimeDeps = getBackupRuntimeDeps();
+  const previous = { ...runtimeDeps };
+  if (typeof deps.encryptedGetItem === 'function') runtimeDeps.encryptedGetItem = deps.encryptedGetItem;
+  if (typeof deps.getEncryptionEnabled === 'function') runtimeDeps.getEncryptionEnabled = deps.getEncryptionEnabled;
+  return previous;
+}
+
+const getEncryptionEnabled = () => Boolean(getBackupRuntimeDeps().getEncryptionEnabled());
 const isEncryptedValue = (v) => typeof v === 'string' && v.startsWith('v1:');
 const backupActionDelegateRoots = new WeakSet();
 const BACKUP_ACTION_DELEGATE_KEY = Symbol.for('getbased.backupActionDelegatesInstalled');
@@ -257,7 +281,7 @@ export async function buildFullBackupSnapshot() {
   if (snap.profiles.length === 0 && snap.profileList && isEncryptedValue(snap.profileList)) {
     let profileList = null;
     try {
-      const decrypted = await appWindow.encryptedGetItem?.('labcharts-profiles');
+      const decrypted = await getBackupRuntimeDeps().encryptedGetItem('labcharts-profiles');
       if (decrypted) profileList = JSON.parse(decrypted);
     } catch {}
     if (Array.isArray(profileList)) {
@@ -734,22 +758,4 @@ export function renderFolderBackupSection() {
   }
   html += '</div>';
   return html;
-}
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    buildBackupSnapshot,
-    exportEncryptedBackup,
-    importEncryptedBackup,
-    scheduleAutoBackup,
-    getAutoBackupSnapshots,
-    restoreAutoBackup,
-    openBackupDB,
-    initFolderBackup,
-    pickFolderForBackup,
-    reauthorizeFolderBackup,
-    removeFolderBackup,
-    getFolderBackupState,
-    renderFolderBackupSection,
-  });
 }

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -1,7 +1,7 @@
 // @ts-check
 // context-card-dashboard-ai.js - AI context and data protection CTAs
 
-import { getFolderBackupState } from './backup.js';
+import { getFolderBackupState, pickFolderForBackup } from './backup.js';
 import { getEncryptionEnabled } from './crypto.js';
 import { getActiveData, saveImportedData } from './data.js';
 import {
@@ -40,15 +40,20 @@ import {
 const appWindow = /** @type {Window & typeof globalThis & {
   openInterpretiveLensEditor?: () => void,
   showEnableEncryptionModal?: () => void,
-  pickFolderForBackup?: () => void,
   handleDNAFile?: (file: File) => void,
   updateChatContextStatus?: () => void,
 }} */ (typeof window !== 'undefined' ? window : {});
 
 let dashboardAISyncSetupHandler = showSyncSetupModal;
-
+const dashboardAIDataProtectionDeps = { pickFolderForBackup };
 export function configureDashboardAISyncSetup(handler = showSyncSetupModal) {
   dashboardAISyncSetupHandler = typeof handler === 'function' ? handler : showSyncSetupModal;
+}
+
+export function configureDashboardAIDataProtectionDeps(deps = {}) {
+  const previous = { ...dashboardAIDataProtectionDeps };
+  if (typeof deps.pickFolderForBackup === 'function') dashboardAIDataProtectionDeps.pickFolderForBackup = deps.pickFolderForBackup;
+  return previous;
 }
 
 configureDashboardAIActionDelegates({
@@ -57,7 +62,7 @@ configureDashboardAIActionDelegates({
   'open-personalize-ai-picker': () => openContextModal(),
   'enable-encryption': () => appWindow.showEnableEncryptionModal?.(),
   'setup-sync': () => dashboardAISyncSetupHandler(),
-  'setup-backup': () => appWindow.pickFolderForBackup?.(),
+  'setup-backup': () => dashboardAIDataProtectionDeps.pickFolderForBackup(),
   'open-data-protection-picker': () => openDataProtectionPicker(),
 });
 
@@ -686,7 +691,7 @@ export function openDataProtectionPicker() {
       close();
       if (pick === 'encryption' && typeof appWindow.showEnableEncryptionModal === 'function') appWindow.showEnableEncryptionModal();
       else if (pick === 'sync') dashboardAISyncSetupHandler();
-      else if (pick === 'backup' && typeof appWindow.pickFolderForBackup === 'function') appWindow.pickFolderForBackup();
+      else if (pick === 'backup') dashboardAIDataProtectionDeps.pickFolderForBackup();
     };
   });
 }

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -34,6 +34,7 @@ import {
   refreshAllHealthDots as refreshAllHealthDotsImpl,
 } from './context-card-health-dots.js';
 import {
+  configureDashboardAIDataProtectionDeps,
   openDataProtectionPicker,
   openContextModal,
   openPersonalizeAIPicker,
@@ -246,6 +247,7 @@ export {
   clearDiagnoses,
 } from './context-card-medical-history-editor.js';
 export {
+  configureDashboardAIDataProtectionDeps,
   openDataProtectionPicker,
   openContextModal,
   openPersonalizeAIPicker,

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -10,7 +10,6 @@ import { ensureImportedArray } from './data-merge.js';
 const appWindow = /** @type {Window & typeof globalThis & {
   __WEARABLES_TEST?: boolean,
   buildSidebar: () => void,
-  getFolderBackupState?: () => { folderName?: string | null, permissionLost?: boolean },
   migrateProfileData: (data: any) => void,
   navigate: (view: string) => void,
 }} */ (typeof window !== 'undefined' ? window : {});
@@ -700,7 +699,7 @@ export function maybeShowBackupNudge() {
   });
   if (!hasAnyData) return;
   // Skip if folder backup is active and healthy
-  const _fbState = appWindow.getFolderBackupState?.();
+  const _fbState = getFolderBackupState();
   if (_fbState?.folderName && !_fbState?.permissionLost) return;
   // Skip if snoozed
   const snoozedUntil = localStorage.getItem('labcharts-backup-nudge-snoozed-until');
@@ -978,8 +977,10 @@ export async function changePassphrase() {
 
 // ═══════════════════════════════════════════════
 // Backup/restore, auto-backup, folder backup extracted to js/backup.js
-import { buildBackupSnapshot, exportEncryptedBackup, importEncryptedBackup, scheduleAutoBackup, getAutoBackupSnapshots, restoreAutoBackup, openBackupDB, initFolderBackup, getFolderBackupState, renderFolderBackupSection, MAX_SNAPSHOTS } from './backup.js';
+import { buildBackupSnapshot, configureBackupRuntimeDeps, exportEncryptedBackup, importEncryptedBackup, scheduleAutoBackup, getAutoBackupSnapshots, restoreAutoBackup, openBackupDB, initFolderBackup, getFolderBackupState, renderFolderBackupSection, MAX_SNAPSHOTS } from './backup.js';
 export { buildBackupSnapshot, scheduleAutoBackup, openBackupDB, initFolderBackup };
+
+configureBackupRuntimeDeps({ encryptedGetItem, getEncryptionEnabled });
 
 // ═══════════════════════════════════════════════
 // CROSS-TAB SYNC (BroadcastChannel)

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 13,
-  "legacyWindowGlobalAssignments": 11,
+  "windowGlobalAssignments": 12,
+  "legacyWindowGlobalAssignments": 10,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/backup-browser-coverage.spec.js
+++ b/tests/playwright/backup-browser-coverage.spec.js
@@ -29,10 +29,11 @@ test('backup browser coverage exercises export import auto backup and folder sta
       revokeObjectURL: URL.revokeObjectURL,
       anchorClick: HTMLAnchorElement.prototype.click,
       setTimeout: window.setTimeout,
-      getEncryptionEnabled: window.getEncryptionEnabled,
-      encryptedGetItem: window.encryptedGetItem,
       showDirectoryPicker: Object.getOwnPropertyDescriptor(window, 'showDirectoryPicker'),
     };
+    const previousBackupRuntimeDeps = backup.configureBackupRuntimeDeps({
+      getEncryptionEnabled: () => true,
+    });
     const delay = ms => new Promise(resolve => originalSetTimeout(resolve, ms));
     const waitFor = async (predicate, attempts = 100) => {
       for (let i = 0; i < attempts; i += 1) {
@@ -98,7 +99,6 @@ test('backup browser coverage exercises export import auto backup and folder sta
       await blobStorage.deleteBlob(importedKey);
       await blobStorage.deleteBlob(restoredImportedKey);
 
-      window.getEncryptionEnabled = () => true;
       localStorage.setItem('labcharts-profiles', originalProfileList);
       localStorage.setItem(importedKey, JSON.stringify({ entries: [{ date: '2026-06-09', markers: { ferritin: 41 } }] }));
       localStorage.setItem(`labcharts-${profileId}-chat`, JSON.stringify([{ role: 'user', content: 'hello' }]));
@@ -270,10 +270,7 @@ test('backup browser coverage exercises export import auto backup and folder sta
       URL.createObjectURL = saved.createObjectURL;
       URL.revokeObjectURL = saved.revokeObjectURL;
       HTMLAnchorElement.prototype.click = saved.anchorClick;
-      if (saved.getEncryptionEnabled === undefined) delete window.getEncryptionEnabled;
-      else window.getEncryptionEnabled = saved.getEncryptionEnabled;
-      if (saved.encryptedGetItem === undefined) delete window.encryptedGetItem;
-      else window.encryptedGetItem = saved.encryptedGetItem;
+      backup.configureBackupRuntimeDeps(previousBackupRuntimeDeps);
       if (saved.showDirectoryPicker) Object.defineProperty(window, 'showDirectoryPicker', saved.showDirectoryPicker);
       else delete window.showDirectoryPicker;
       await blobStorage.deleteBlob(importedKey);

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -395,7 +395,6 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       buildSidebar: window.buildSidebar,
       migrateProfileData: window.migrateProfileData,
       navigate: window.navigate,
-      getFolderBackupState: window.getFolderBackupState,
       storage: Object.fromEntries(keys.map(key => [key, localStorage.getItem(key)])),
     };
 
@@ -453,7 +452,6 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       localStorage.removeItem('labcharts-last-manual-backup');
       localStorage.removeItem('labcharts-folder-backup-last');
       document.getElementById('tour-overlay')?.remove();
-      window.getFolderBackupState = () => ({ folderName: null, permissionLost: false });
       cryptoStore.maybeShowBackupNudge();
       await waitFor(() => !!document.getElementById('backup-nudge-snooze'), 'backup nudge');
       document.getElementById('backup-nudge-snooze').click();
@@ -528,8 +526,6 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       else window.migrateProfileData = saved.migrateProfileData;
       if (saved.navigate === undefined) delete window.navigate;
       else window.navigate = saved.navigate;
-      if (saved.getFolderBackupState === undefined) delete window.getFolderBackupState;
-      else window.getFolderBackupState = saved.getFolderBackupState;
       if (originalBroadcastDescriptor) {
         Object.defineProperty(window, 'BroadcastChannel', originalBroadcastDescriptor);
       } else {

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -40,7 +40,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     const savedGlobals = {
       showDirectoryPicker: originalShowDirectoryPicker,
       showEnableEncryptionModal: window.showEnableEncryptionModal,
-      pickFolderForBackup: window.pickFolderForBackup,
       openInterpretiveLensEditor: window.openInterpretiveLensEditor,
       handleDNAFile: window.handleDNAFile,
       setTimeout: window.setTimeout,
@@ -59,6 +58,9 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     let handledDnaFile = null;
 
     dashboardAi.configureDashboardAISyncSetup(() => calls.push('sync'));
+    const previousDataProtectionDeps = dashboardAi.configureDashboardAIDataProtectionDeps({
+      pickFolderForBackup: () => calls.push('backup'),
+    });
 
     try {
       window.setTimeout = (fn, delay, ...args) => {
@@ -67,7 +69,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
         return timers.length;
       };
       window.showEnableEncryptionModal = () => calls.push('encryption');
-      window.pickFolderForBackup = () => calls.push('backup');
       window.openInterpretiveLensEditor = () => calls.push('lens');
       window.handleDNAFile = file => {
         handledDnaFile = { name: file.name, textType: file.type };
@@ -239,6 +240,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       document.querySelectorAll('#data-protection-picker-overlay,#ai-personalize-picker-overlay,#dna-dashboard-input')
         .forEach(el => el.remove());
       dashboardAi.configureDashboardAISyncSetup();
+      dashboardAi.configureDashboardAIDataProtectionDeps(previousDataProtectionDeps);
       HTMLInputElement.prototype.click = originalInputClick;
       for (const [name, original] of Object.entries(savedGlobals)) {
         if (name === 'showDirectoryPicker' && !hadShowDirectoryPicker) delete window[name];

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -39,11 +39,11 @@ const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 console.log('=== Chat Threads Tests ===\n');
 
 // state.js → state + isSensitiveKey lives in crypto.js, buildBackupSnapshot
-// in backup.js, the thread handlers in chat-threads.js, saveChatHistory /
-// loadChatHistory in chat.js — all exposed via Object.assign(window, ...).
+// is module-only in backup.js, and the thread handlers remain on the legacy
+// browser facade while that migration continues.
 const stateModule = await import('../js/state.js');
 const cryptoModule = await import('../js/crypto.js');
-await import('../js/backup.js');
+const backupModule = await import('../js/backup.js');
 const chatThreadsModule = await import('../js/chat-threads.js');
 await import('../js/chat.js');
 
@@ -301,7 +301,7 @@ st.chatThreads = [
 window.saveChatThreadIndex();
 localStorage.setItem(window.getChatThreadKey('t_backup1'), JSON.stringify([{ role: 'user', content: 'backup test' }]));
 
-const snapshot = window.buildBackupSnapshot();
+const snapshot = backupModule.buildBackupSnapshot();
 assert('snapshot exists', !!snapshot);
 if (snapshot) {
   const profileBackup = snapshot.profiles.find(p => p.profileId === profileId);

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -54,7 +54,7 @@ await import('../js/export.js');
 await import('../js/settings.js');
 await import('../js/chat.js');
 await import('../js/utils.js');
-await import('../js/backup.js');
+const backupModule = await import('../js/backup.js');
 
 // Seed a minimal profile registry — the app bootstraps one via
 // initProfilesCache() on page load; in Node we seed it so the section-15
@@ -77,8 +77,10 @@ assert('window.encryptedGetItem exists', typeof window.encryptedGetItem === 'fun
 assert('window.showEnableEncryptionModal exists', typeof window.showEnableEncryptionModal === 'function');
 assert('window.disableEncryption exists', typeof window.disableEncryption === 'function');
 assert('window.changePassphrase exists', typeof window.changePassphrase === 'function');
-assert('window.exportEncryptedBackup exists', typeof window.exportEncryptedBackup === 'function');
-assert('window.importEncryptedBackup exists', typeof window.importEncryptedBackup === 'function');
+assert('backup.exportEncryptedBackup module export exists', typeof backupModule.exportEncryptedBackup === 'function');
+assert('backup.importEncryptedBackup module export exists', typeof backupModule.importEncryptedBackup === 'function');
+assert('window.exportEncryptedBackup stays module-only', !('exportEncryptedBackup' in window));
+assert('window.importEncryptedBackup stays module-only', !('importEncryptedBackup' in window));
 assert('window.broadcastDataChanged exists', typeof window.broadcastDataChanged === 'function');
 assert('window.renderEncryptionSection exists', typeof window.renderEncryptionSection === 'function');
 assert('window.renderBackupSection exists', typeof window.renderBackupSection === 'function');
@@ -549,14 +551,13 @@ try {
 }
 
 // ═══════════════════════════════════════════════
-// 20. Auto-backup window exports
+// 20. Auto-backup module exports
 // ═══════════════════════════════════════════════
-console.log('20. Auto-backup window exports');
-assert('window.scheduleAutoBackup exists', typeof window.scheduleAutoBackup === 'function');
-assert('window.getAutoBackupSnapshots exists', typeof window.getAutoBackupSnapshots === 'function');
-assert('window.restoreAutoBackup exists', typeof window.restoreAutoBackup === 'function');
-assert('window.openBackupDB exists', typeof window.openBackupDB === 'function');
-assert('window.buildBackupSnapshot exists', typeof window.buildBackupSnapshot === 'function');
+console.log('20. Auto-backup module exports');
+for (const name of ['scheduleAutoBackup', 'getAutoBackupSnapshots', 'restoreAutoBackup', 'openBackupDB', 'buildBackupSnapshot']) {
+  assert(`backup.${name} exists`, typeof backupModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
+}
 assert('window.loadBackupSnapshots exists', typeof window.loadBackupSnapshots === 'function');
 
 // ═══════════════════════════════════════════════
@@ -564,7 +565,7 @@ assert('window.loadBackupSnapshots exists', typeof window.loadBackupSnapshots ==
 // ═══════════════════════════════════════════════
 console.log('21. labcharts-backups IndexedDB');
 try {
-  const db = await window.openBackupDB();
+  const db = await backupModule.openBackupDB();
   assert('IndexedDB opens successfully', db instanceof IDBDatabase);
   assert('IndexedDB has snapshots store', db.objectStoreNames.contains('snapshots'));
 } catch (e) {
@@ -645,7 +646,7 @@ try {
 // ═══════════════════════════════════════════════
 console.log('26. getAutoBackupSnapshots');
 try {
-  const snapshots = await window.getAutoBackupSnapshots();
+  const snapshots = await backupModule.getAutoBackupSnapshots();
   assert('getAutoBackupSnapshots returns array', Array.isArray(snapshots));
 } catch (e) {
   assert('getAutoBackupSnapshots', false, e.message);
@@ -656,7 +657,7 @@ try {
 // ═══════════════════════════════════════════════
 console.log('27. buildBackupSnapshot');
 try {
-  const snapshot = window.buildBackupSnapshot();
+  const snapshot = backupModule.buildBackupSnapshot();
   // The profile registry is seeded at test startup, so a falsy return
   // means a runtime error, not an empty profile list — assert the object
   // type directly rather than letting a falsy value pass silently.

--- a/tests/test-dashboard-data-protection.js
+++ b/tests/test-dashboard-data-protection.js
@@ -27,9 +27,9 @@ function assert(name, condition, detail) {
 
 console.log('=== Data Protection Dashboard Tests ===\n');
 
-// context-cards.js exposes renderDataProtectionCta + openDataProtectionPicker +
-// showEnableEncryptionModal + pickFolderForBackup. Sync setup stays module-only.
+// context-cards.js exposes the dashboard APIs; backup stays module-only.
 const cards = await import('../js/context-cards.js');
+const backupModule = await import('../js/backup.js');
 const settingsSyncPanel = await import('../js/settings-sync-panel.js');
 
 const make = (overrides) => ({
@@ -101,8 +101,12 @@ const make = (overrides) => ({
     !('showSyncSetupModal' in window));
   assert('window.showEnableEncryptionModal exists',
     typeof window.showEnableEncryptionModal === 'function');
-  assert('window.pickFolderForBackup exists',
-    typeof window.pickFolderForBackup === 'function');
+  assert('backup.pickFolderForBackup module export exists',
+    typeof backupModule.pickFolderForBackup === 'function');
+  assert('window.pickFolderForBackup stays module-only',
+    !('pickFolderForBackup' in window));
+  assert('dashboard backup dependency is configurable for tests',
+    typeof cards.configureDashboardAIDataProtectionDeps === 'function');
 }
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -9,6 +9,7 @@ return (async function() {
   }
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const S = window._labState;
+  const backupModule = await import('/js/backup.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -529,8 +530,9 @@ return (async function() {
   localStorage.setItem('labcharts-custom-url', 'https://api.example.com/v1');
   localStorage.setItem('labcharts-custom-model', 'gpt-test');
 
-  const snap = window.buildBackupSnapshot && window.buildBackupSnapshot();
-  assert('buildBackupSnapshot exposed', !!snap, 'window.buildBackupSnapshot missing');
+  const snap = backupModule.buildBackupSnapshot();
+  assert('buildBackupSnapshot module export works', !!snap);
+  assert('buildBackupSnapshot stays off window', !('buildBackupSnapshot' in window));
   if (snap) {
     assert('snapshot.settings carries custom-key', snap.settings['labcharts-custom-key'] === 'sk-roundtrip-test');
     assert('snapshot.settings carries custom-url', snap.settings['labcharts-custom-url'] === 'https://api.example.com/v1');
@@ -559,26 +561,24 @@ return (async function() {
   // the v1: envelope as `[]` and the localStorage fallback found nothing
   // because v1.6.x moved *-imported blobs to IndexedDB. Result: every backup
   // silently shipped profiles:[] (~1 KB file). buildFullBackupSnapshot now
-  // detects that case and re-enumerates via window.encryptedGetItem.
+  // detects that case and re-enumerates through its injected crypto dependency.
   console.log('%c 13b. Encrypted backup re-enumerates profiles ', 'font-weight:bold;color:#f59e0b');
 
   const backupSrcEnc = await fetch('/js/backup.js').then(r => r.text());
   assert('buildFullBackupSnapshot detects encrypted profile list',
     backupSrcEnc.includes('isEncryptedValue(snap.profileList)'));
-  assert('buildFullBackupSnapshot decrypts via window.encryptedGetItem',
-    backupSrcEnc.includes("encryptedGetItem?.('labcharts-profiles')"));
+  assert('buildFullBackupSnapshot decrypts via injected encryptedGetItem',
+    backupSrcEnc.includes("getBackupRuntimeDeps().encryptedGetItem('labcharts-profiles')"));
   assert('Re-enumeration only fires when profiles array is empty (no double-write)',
     /snap\.profiles\.length\s*===\s*0\s*&&\s*snap\.profileList\s*&&\s*isEncryptedValue/.test(backupSrcEnc));
   assert('Re-enumeration uses PER_PROFILE_PREF_SUFFIXES (parity with sync path)',
     /for\s*\(\s*const\s+suffix\s+of\s+PER_PROFILE_PREF_SUFFIXES\s*\)/.test(backupSrcEnc));
 
   // Functional roundtrip: spoof the encrypted-list state and verify the
-  // snapshot recovers a profile. Stub window.encryptedGetItem so this works
-  // without an actual passphrase setup. Stash the real values, swap in
-  // spoofs, run the async builder, restore originals.
+  // snapshot recovers a profile. Inject encryptedGetItem so this works
+  // without an actual passphrase setup, then restore the production deps.
   const _profileKey = 'labcharts-profiles';
   const _origProfilesRaw = localStorage.getItem(_profileKey);
-  const _origEncryptedGetItem = window.encryptedGetItem;
   let realProfiles = [];
   try { realProfiles = JSON.parse(_origProfilesRaw || '[]'); } catch {}
   if (Array.isArray(realProfiles) && realProfiles.length > 0) {
@@ -586,15 +586,14 @@ return (async function() {
     // Make the on-disk value look encrypted (v1: prefix → isEncryptedValue
     // returns true → buildBackupSnapshot parses it as []).
     localStorage.setItem(_profileKey, 'v1:fake-ciphertext-only-the-prefix-matters');
-    // Stub encryptedGetItem to return the decrypted JSON for the profiles
-    // key only; everything else falls through to the real impl.
-    window.encryptedGetItem = async (key) => {
-      if (key === _profileKey) return decryptedJson;
-      return _origEncryptedGetItem ? _origEncryptedGetItem(key) : null;
-    };
+    const previousBackupDeps = backupModule.configureBackupRuntimeDeps({
+      encryptedGetItem: async (key) => {
+        if (key === _profileKey) return decryptedJson;
+        return null;
+      },
+    });
     try {
-      const backupMod = await import('/js/backup.js');
-      const recoveredSnap = await backupMod.buildFullBackupSnapshot();
+      const recoveredSnap = await backupModule.buildFullBackupSnapshot();
       assert('buildFullBackupSnapshot recovers profile list when encrypted',
         recoveredSnap?.profiles?.length === realProfiles.length,
         `expected ${realProfiles.length} profiles, got ${recoveredSnap?.profiles?.length ?? 'null'}`);
@@ -606,7 +605,7 @@ return (async function() {
       // Restore originals so subsequent tests see a clean state.
       if (_origProfilesRaw !== null) localStorage.setItem(_profileKey, _origProfilesRaw);
       else localStorage.removeItem(_profileKey);
-      window.encryptedGetItem = _origEncryptedGetItem;
+      backupModule.configureBackupRuntimeDeps(previousBackupDeps);
     }
   } else {
     assert('Setup: at least one profile present for encrypted-recovery test', false,

--- a/tests/test-folder-backup.js
+++ b/tests/test-folder-backup.js
@@ -21,25 +21,28 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), 'utf-8');
 
 await import('../js/state.js');
-await import('../js/backup.js');
+const backupModule = await import('../js/backup.js');
 await import('../js/crypto.js');
 await import('../js/export.js'); // exposes window.buildAllDataBundle
 
   // ═══════════════════════════════════════════════
-  // 1. Window exports exist
+  // 1. Module exports exist without legacy window globals
   // ═══════════════════════════════════════════════
-  assert('window.initFolderBackup exists', typeof window.initFolderBackup === 'function');
-  assert('window.pickFolderForBackup exists', typeof window.pickFolderForBackup === 'function');
-  assert('window.reauthorizeFolderBackup exists', typeof window.reauthorizeFolderBackup === 'function');
-  assert('window.removeFolderBackup exists', typeof window.removeFolderBackup === 'function');
-  assert('window.getFolderBackupState exists', typeof window.getFolderBackupState === 'function');
+  const folderBackupExports = [
+    'initFolderBackup', 'pickFolderForBackup', 'reauthorizeFolderBackup',
+    'removeFolderBackup', 'getFolderBackupState',
+  ];
+  for (const name of folderBackupExports) {
+    assert(`backup.${name} exists`, typeof backupModule[name] === 'function');
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
   assert('window.buildAllDataBundle exists', typeof window.buildAllDataBundle === 'function');
 
   // ═══════════════════════════════════════════════
   // 2. getFolderBackupState() returns correct shape
   // ═══════════════════════════════════════════════
   try {
-    const st = window.getFolderBackupState();
+    const st = backupModule.getFolderBackupState();
     assert('getFolderBackupState returns object', typeof st === 'object' && st !== null);
     assert('state has supported boolean', typeof st.supported === 'boolean');
     assert('state has folderName (string or null)', st.folderName === null || typeof st.folderName === 'string');
@@ -75,7 +78,7 @@ await import('../js/export.js'); // exposes window.buildAllDataBundle
     const html = window.renderBackupSection();
     assert('renderBackupSection has folder section container', html.includes('backup-folder-section'));
     // On Chromium, should have folder UI content; on Firefox/Safari, the inner HTML is empty
-    const st = window.getFolderBackupState();
+    const st = backupModule.getFolderBackupState();
     if (st.supported) {
       assert('Folder section has description text', html.includes('backup-folder-desc'));
       assert('Folder section has delegated set/change button', html.includes('data-backup-action="pick-folder"'));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -187,8 +187,9 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, chartsModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, piiModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
+  const [apiModule, backupModule, chartsModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, piiModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
+    import('../js/backup.js'),
     import('../js/charts.js'),
     import('../js/cycle.js'),
     import('../js/emf.js'),
@@ -562,6 +563,7 @@
   console.log(`Checked ${apiExports.length} api.js module exports`);
 
   for (const [moduleName, moduleApi, exports] of [
+    ['backup.js', backupModule, backupExports],
     ['charts.js', chartsModule, chartsExports],
     ['cycle.js', cycleModule, cycleExports],
     ['emf.js', emfModule, emfExports],
@@ -583,6 +585,9 @@
     console.log(`Checked ${exports.length} ${moduleName} module exports`);
   }
   for (const name of supplementLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of backupExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of cycleLegacyGlobals) {
@@ -619,7 +624,6 @@
     'profile.js': profileExports,
     'settings.js': settingsExports,
     'provider-panels.js': providerPanelsExports,
-    'backup.js': backupExports,
     'theme.js': themeExports,
     'utils.js': utilsExports,
     'views.js': viewsExports,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.195';
+self.APP_VERSION = '1.10.196';


### PR DESCRIPTION
## Summary

- remove the 13-function backup browser-global facade
- inject the two crypto operations needed by backup without breaking the existing module cycle
- route backup nudges and dashboard backup actions through direct module dependencies
- tighten the quality baseline from 13/11 to 12/10 assignment groups
- bump the app cache version to 1.10.196

## Verification

- `./run-tests.sh`
  - 396 Vitest tests
  - 351 Playwright tests
  - 472 responsive/theme checks
- `npm run quality`
- `npm run typecheck`
- `npm run typecheck:checkjs`