### PR TITLE
Make crypto module-only

### DIFF
--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -2,7 +2,7 @@
 // context-card-dashboard-ai.js - AI context and data protection CTAs
 
 import { getFolderBackupState, pickFolderForBackup } from './backup.js';
-import { getEncryptionEnabled } from './crypto.js';
+import { getEncryptionEnabled, showEnableEncryptionModal } from './crypto.js';
 import { getActiveData, saveImportedData } from './data.js';
 import {
   isGeneticsPriorityInAIContext,
@@ -39,13 +39,12 @@ import {
 
 const appWindow = /** @type {Window & typeof globalThis & {
   openInterpretiveLensEditor?: () => void,
-  showEnableEncryptionModal?: () => void,
   handleDNAFile?: (file: File) => void,
   updateChatContextStatus?: () => void,
 }} */ (typeof window !== 'undefined' ? window : {});
 
 let dashboardAISyncSetupHandler = showSyncSetupModal;
-const dashboardAIDataProtectionDeps = { pickFolderForBackup };
+const dashboardAIDataProtectionDeps = { pickFolderForBackup, showEnableEncryptionModal };
 export function configureDashboardAISyncSetup(handler = showSyncSetupModal) {
   dashboardAISyncSetupHandler = typeof handler === 'function' ? handler : showSyncSetupModal;
 }
@@ -53,6 +52,7 @@ export function configureDashboardAISyncSetup(handler = showSyncSetupModal) {
 export function configureDashboardAIDataProtectionDeps(deps = {}) {
   const previous = { ...dashboardAIDataProtectionDeps };
   if (typeof deps.pickFolderForBackup === 'function') dashboardAIDataProtectionDeps.pickFolderForBackup = deps.pickFolderForBackup;
+  if (typeof deps.showEnableEncryptionModal === 'function') dashboardAIDataProtectionDeps.showEnableEncryptionModal = deps.showEnableEncryptionModal;
   return previous;
 }
 
@@ -60,7 +60,7 @@ configureDashboardAIActionDelegates({
   'open-interpretive-lens': () => appWindow.openInterpretiveLensEditor?.(),
   'open-knowledge-base': () => openKnowledgeBaseModal(),
   'open-personalize-ai-picker': () => openContextModal(),
-  'enable-encryption': () => appWindow.showEnableEncryptionModal?.(),
+  'enable-encryption': () => dashboardAIDataProtectionDeps.showEnableEncryptionModal(),
   'setup-sync': () => dashboardAISyncSetupHandler(),
   'setup-backup': () => dashboardAIDataProtectionDeps.pickFolderForBackup(),
   'open-data-protection-picker': () => openDataProtectionPicker(),
@@ -689,7 +689,7 @@ export function openDataProtectionPicker() {
       const isConfigured = button.getAttribute('data-configured') === 'true';
       if (isConfigured) { close(); return; }
       close();
-      if (pick === 'encryption' && typeof appWindow.showEnableEncryptionModal === 'function') appWindow.showEnableEncryptionModal();
+      if (pick === 'encryption') dashboardAIDataProtectionDeps.showEnableEncryptionModal();
       else if (pick === 'sync') dashboardAISyncSetupHandler();
       else if (pick === 'backup') dashboardAIDataProtectionDeps.pickFolderForBackup();
     };

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -119,7 +119,7 @@ const SENSITIVE_PATTERNS = [
   /^labcharts-meteo-config$/,
 ];
 
-function isSensitiveKey(key) {
+export function isSensitiveKey(key) {
   return SENSITIVE_PATTERNS.some(p => p.test(key));
 }
 
@@ -1104,32 +1104,4 @@ export function toggleBackupSnapshots() {
   const open = list.style.display !== 'none';
   list.style.display = open ? 'none' : 'flex';
   if (arrow) arrow.innerHTML = open ? '&#9654;' : '&#9660;';
-}
-
-// ═══════════════════════════════════════════════
-// WINDOW EXPORTS
-// ═══════════════════════════════════════════════
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    initEncryption,
-    initBroadcastChannel,
-    getEncryptionEnabled,
-    isUnlocked,
-    encryptedSetItem,
-    encryptedGetItem,
-    showEnableEncryptionModal,
-    maybeShowEncryptionNudge,
-    maybeShowBackupNudge,
-    disableEncryption,
-    changePassphrase,
-    broadcastDataChanged,
-    renderEncryptionSection,
-    renderBackupSection,
-    isSensitiveKey,
-    getCachedKey,
-    updateKeyCache,
-    decryptKeyCache,
-    loadBackupSnapshots,
-    toggleBackupSnapshots,
-  });
 }

--- a/js/pdf-import-commit.js
+++ b/js/pdf-import-commit.js
@@ -2,6 +2,7 @@
 // pdf-import-commit.js - Import commit, snapshot deletion, and re-review actions.
 
 import { state } from './state.js';
+import { maybeShowEncryptionNudge } from './crypto.js';
 import { MARKER_SCHEMA, SPECIALTY_MARKER_DEFS } from './schema.js';
 import { showNotification } from './utils.js';
 import { saveImportedData } from './data.js';
@@ -25,13 +26,13 @@ import {
   showImportPreview,
 } from './pdf-import-review.js';
 
-/**
- * @typedef {{
- *   maybeShowEncryptionNudge?: () => void,
- * }} PdfImportCommitRuntime
- */
+const pdfImportCommitDeps = { maybeShowEncryptionNudge };
 
-const pdfImportCommitRuntime = /** @type {typeof globalThis & PdfImportCommitRuntime} */ (globalThis);
+export function configurePdfImportCommitDeps(deps = {}) {
+  const previous = { ...pdfImportCommitDeps };
+  if (typeof deps.maybeShowEncryptionNudge === 'function') pdfImportCommitDeps.maybeShowEncryptionNudge = deps.maybeShowEncryptionNudge;
+  return previous;
+}
 
 let _batchMode = false;
 
@@ -260,7 +261,7 @@ export async function confirmImport() {
     refreshImportedDataViews();
   }
   showNotification(`Imported ${importCount} markers from ${result.date}`, "success");
-  if (!_batchMode && typeof pdfImportCommitRuntime.maybeShowEncryptionNudge === 'function') pdfImportCommitRuntime.maybeShowEncryptionNudge();
+  if (!_batchMode) pdfImportCommitDeps.maybeShowEncryptionNudge();
 }
 
 function snapshotMarkerDotKey(marker) {

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -7,6 +7,7 @@ import { showNotification, showConfirmDialog, isDebugMode, isPIIReviewEnabled, h
 import { hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEOUT_MS, startOpenRouterOAuth } from './api.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
+import { maybeShowEncryptionNudge } from './crypto.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   callImportAIWithStreamFallback,
@@ -65,7 +66,6 @@ import {
  * @typedef {{
  *   openSettingsModal?: (tab?: string) => void,
  *   loadDemoData?: (sex?: string) => void,
- *   maybeShowEncryptionNudge?: () => void,
  *   importDataJSON: (file: File) => void | Promise<void>,
  *   isDNAFile?: (file: File) => boolean,
  *   isDNAFileByContent?: (file: File) => Promise<boolean>,
@@ -78,11 +78,13 @@ import {
 const pdfImportWindow = /** @type {Window & typeof globalThis & PdfImportWindowHooks} */ (window);
 
 const pdfImportDeps = {
+  maybeShowEncryptionNudge,
   startOpenRouterOAuth,
 };
 
 export function configurePdfImportDeps(deps = {}) {
   const previous = { ...pdfImportDeps };
+  if (typeof deps.maybeShowEncryptionNudge === 'function') pdfImportDeps.maybeShowEncryptionNudge = deps.maybeShowEncryptionNudge;
   if (typeof deps.startOpenRouterOAuth === 'function') pdfImportDeps.startOpenRouterOAuth = deps.startOpenRouterOAuth;
   return previous;
 }
@@ -849,7 +851,7 @@ export async function handleBatchPDFs(pdfFiles) {
   if (failed > 0) parts.push(`${failed} failed`);
   if (retryImported > 0) parts.push(`${retryImported} recovered on retry`);
   showNotification(`Batch import complete: ${parts.join(', ')}`, imported > 0 ? 'success' : 'info');
-  if (imported > 0 && typeof pdfImportWindow.maybeShowEncryptionNudge === 'function') pdfImportWindow.maybeShowEncryptionNudge();
+  if (imported > 0) pdfImportDeps.maybeShowEncryptionNudge();
 }
 
 // ═══════════════════════════════════════════════

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 12,
-  "legacyWindowGlobalAssignments": 10,
+  "windowGlobalAssignments": 11,
+  "legacyWindowGlobalAssignments": 9,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -684,7 +684,7 @@ test('context health dots and focus card cover cache fallback and empty states',
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
       localStorage.removeItem('labcharts-ai-paused');
       localStorage.removeItem('labcharts-openrouter-key');
-      window.updateKeyCache?.('labcharts-openrouter-key', '');
+      cryptoStore.updateKeyCache('labcharts-openrouter-key', '');
       document.getElementById('focus-card-body').innerHTML = '';
       await focus.loadFocusCard();
       outcomes.loadFocusCardShowsEnableAIWithoutConnectedProvider = document.getElementById('focus-card-body')?.textContent.includes('Enable AI') === true;
@@ -723,7 +723,7 @@ test('context health dots and focus card cover cache fallback and empty states',
       else localStorage.setItem('labcharts-ollama-model', saved.ollamaModel);
       if (saved.activeProfile == null) localStorage.removeItem('labcharts-active-profile');
       else localStorage.setItem('labcharts-active-profile', saved.activeProfile);
-      window.updateKeyCache?.('labcharts-openrouter-key', saved.openRouterKey || '');
+      cryptoStore.updateKeyCache('labcharts-openrouter-key', saved.openRouterKey || '');
       cryptoStore.updateKeyCache('labcharts-ollama', saved.ollamaConfigCache);
       window.fetch = saved.fetch;
       health.configureContextCardHealthDots(originalHealthDotDeps);

--- a/tests/playwright/custom-api-settings.spec.js
+++ b/tests/playwright/custom-api-settings.spec.js
@@ -31,11 +31,12 @@ test('custom API connected state renders model controls', async ({ page }) => {
 
   await page.evaluate(async () => {
     const api = await import('/js/api.js');
+    const cryptoStore = await import('/js/crypto.js');
     if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
     if (typeof window.switchAIProvider !== 'function') throw new Error('window.switchAIProvider unavailable');
 
     api.setCustomApiUrl('https://api.test.com/v1');
-    window.updateKeyCache?.('labcharts-custom-key', 'sk-test');
+    cryptoStore.updateKeyCache('labcharts-custom-key', 'sk-test');
     api.setCustomApiModel('test-model');
     localStorage.setItem('labcharts-custom-models', JSON.stringify([
       { id: 'test-model', name: 'Test Model' },
@@ -67,7 +68,6 @@ test('custom API provider delegates save model changes and removal', async ({ pa
   await page.waitForFunction(() =>
     typeof window.openSettingsModal === 'function'
       && typeof window.switchAIProvider === 'function'
-      && typeof window.updateKeyCache === 'function'
   );
 
   const results = await page.evaluate(async () => {

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -39,7 +39,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     const hadImportedData = Object.prototype.hasOwnProperty.call(state, 'importedData');
     const savedGlobals = {
       showDirectoryPicker: originalShowDirectoryPicker,
-      showEnableEncryptionModal: window.showEnableEncryptionModal,
       openInterpretiveLensEditor: window.openInterpretiveLensEditor,
       handleDNAFile: window.handleDNAFile,
       setTimeout: window.setTimeout,
@@ -60,6 +59,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     dashboardAi.configureDashboardAISyncSetup(() => calls.push('sync'));
     const previousDataProtectionDeps = dashboardAi.configureDashboardAIDataProtectionDeps({
       pickFolderForBackup: () => calls.push('backup'),
+      showEnableEncryptionModal: () => calls.push('encryption'),
     });
 
     try {
@@ -68,7 +68,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
         if (typeof fn === 'function') Promise.resolve().then(() => fn(...args));
         return timers.length;
       };
-      window.showEnableEncryptionModal = () => calls.push('encryption');
       window.openInterpretiveLensEditor = () => calls.push('lens');
       window.handleDNAFile = file => {
         handledDnaFile = { name: file.name, textType: file.type };

--- a/tests/playwright/lens-hardware-browser-coverage.spec.js
+++ b/tests/playwright/lens-hardware-browser-coverage.spec.js
@@ -145,6 +145,7 @@ test('external lens browser contract covers validation fetch cache save and remo
 
   const results = await page.evaluate(async ({ lensUrl }) => {
     const lens = await import(lensUrl);
+    const cryptoStore = await import('/js/crypto.js');
     const outcomes = {};
     const originalFetch = window.fetch;
     const saved = {
@@ -344,7 +345,7 @@ test('external lens browser contract covers validation fetch cache save and remo
       else localStorage.setItem('labcharts-ai-paused', saved.aiPaused);
       if (saved.ollamaModel === null) localStorage.removeItem('labcharts-ollama-model');
       else localStorage.setItem('labcharts-ollama-model', saved.ollamaModel);
-      window.updateKeyCache?.('labcharts-lens-key', saved.key || '');
+      cryptoStore.updateKeyCache('labcharts-lens-key', saved.key || '');
     }
 
     return outcomes;
@@ -360,6 +361,7 @@ test('in-browser lens render covers local panel status and backend switching wit
 
   const results = await page.evaluate(async ({ lensUrl }) => {
     const lens = await import(lensUrl);
+    const cryptoStore = await import('/js/crypto.js');
     const outcomes = {};
     const originalRAF = window.requestAnimationFrame;
     const saved = {
@@ -386,7 +388,7 @@ test('in-browser lens render covers local panel status and backend switching wit
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
       localStorage.setItem('labcharts-ai-paused', 'false');
       localStorage.removeItem('labcharts-openrouter-key');
-      window.updateKeyCache?.('labcharts-openrouter-key', '');
+      cryptoStore.updateKeyCache('labcharts-openrouter-key', '');
       localStorage.setItem('labcharts-lens-local-count', '12');
       localStorage.setItem('labcharts-lens-config', JSON.stringify({
         name: 'Local Papers',
@@ -395,7 +397,7 @@ test('in-browser lens render covers local panel status and backend switching wit
         backend: 'in-browser',
         multiQuery: true,
       }));
-      window.updateKeyCache?.('labcharts-lens-key', '');
+      cryptoStore.updateKeyCache('labcharts-lens-key', '');
 
       section.innerHTML = lens.renderCustomLensSection();
       document.body.appendChild(section);
@@ -463,8 +465,8 @@ test('in-browser lens render covers local panel status and backend switching wit
       else localStorage.setItem('labcharts-ai-paused', saved.aiPaused);
       if (saved.openRouterKey === null) localStorage.removeItem('labcharts-openrouter-key');
       else localStorage.setItem('labcharts-openrouter-key', saved.openRouterKey);
-      window.updateKeyCache?.('labcharts-lens-key', saved.key || '');
-      window.updateKeyCache?.('labcharts-openrouter-key', saved.openRouterKey || '');
+      cryptoStore.updateKeyCache('labcharts-lens-key', saved.key || '');
+      cryptoStore.updateKeyCache('labcharts-openrouter-key', saved.openRouterKey || '');
     }
 
     return outcomes;

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -698,9 +698,10 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
   await page.waitForSelector('#import-modal-overlay', { state: 'attached' });
 
   const results = await page.evaluate(async ({ pdfImportUrl, reviewUrl }) => {
-    const [pdfImport, review] = await Promise.all([
+    const [pdfImport, review, pdfImportCommit] = await Promise.all([
       import(pdfImportUrl),
       import(reviewUrl),
+      import('/js/pdf-import-commit.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
@@ -712,8 +713,10 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       currentProfile: state.currentProfile,
       profileSex: state.profileSex,
-      maybeShowEncryptionNudge: window.maybeShowEncryptionNudge,
     };
+    const previousCommitDeps = pdfImportCommit.configurePdfImportCommitDeps({
+      maybeShowEncryptionNudge: () => {},
+    });
     const resetNotifications = () => document.querySelectorAll('.notification-toast').forEach(el => el.remove());
 
     try {
@@ -729,8 +732,6 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
         manualValues: {},
         refOverrides: {},
       };
-      window.maybeShowEncryptionNudge = () => {};
-
       review.showImportPreview({
         date: '2026-06-07',
         fileName: 'confirm-import.pdf',
@@ -766,8 +767,7 @@ test('PDF import confirm flow covers preview persistence', async ({ page }) => {
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;
       state.profileSex = original.profileSex;
-      if (original.maybeShowEncryptionNudge) window.maybeShowEncryptionNudge = original.maybeShowEncryptionNudge;
-      else delete window.maybeShowEncryptionNudge;
+      pdfImportCommit.configurePdfImportCommitDeps(previousCommitDeps);
       review.closeImportModal();
       document.getElementById('confirm-dialog-overlay')?.classList.remove('show');
       document.getElementById('ai-needed-overlay')?.classList.remove('show');

--- a/tests/playwright/ppq-private-tee-provider.spec.js
+++ b/tests/playwright/ppq-private-tee-provider.spec.js
@@ -10,6 +10,7 @@ test('PPQ Private TEE toggle appears after cold-cache model fetch without provid
     const controls = await import(controlsUrl);
     const panels = await import(panelsUrl);
     const renderers = await import(renderersUrl);
+    const cryptoStore = await import('/js/crypto.js');
 
     const storageKeys = [
       'labcharts-ppq-key',
@@ -25,11 +26,11 @@ test('PPQ Private TEE toggle appears after cold-cache model fetch without provid
     const oldStorage = {};
     for (const key of storageKeys) oldStorage[key] = localStorage.getItem(key);
     const oldFetch = window.fetch;
-    const oldKey = window.getCachedKey?.('labcharts-ppq-key') || '';
+    const oldKey = cryptoStore.getCachedKey('labcharts-ppq-key') || '';
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
-      window.updateKeyCache?.('labcharts-ppq-key', '');
+      cryptoStore.updateKeyCache('labcharts-ppq-key', '');
       await api.savePpqKey('sk-ppq-cold-cache');
 
       let balanceCalls = 0;
@@ -87,7 +88,7 @@ test('PPQ Private TEE toggle appears after cold-cache model fetch without provid
       };
     } finally {
       window.fetch = oldFetch;
-      window.updateKeyCache?.('labcharts-ppq-key', oldKey || null);
+      cryptoStore.updateKeyCache('labcharts-ppq-key', oldKey || null);
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);
@@ -120,6 +121,7 @@ test('PPQ cold-cache model fetch does not overwrite another active provider pane
     const api = await import(apiUrl);
     const panels = await import(panelsUrl);
     const renderers = await import(renderersUrl);
+    const cryptoStore = await import('/js/crypto.js');
 
     const storageKeys = [
       'labcharts-ppq-key',
@@ -133,11 +135,11 @@ test('PPQ cold-cache model fetch does not overwrite another active provider pane
     const oldStorage = {};
     for (const key of storageKeys) oldStorage[key] = localStorage.getItem(key);
     const oldFetch = window.fetch;
-    const oldKey = window.getCachedKey?.('labcharts-ppq-key') || '';
+    const oldKey = cryptoStore.getCachedKey('labcharts-ppq-key') || '';
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
-      window.updateKeyCache?.('labcharts-ppq-key', '');
+      cryptoStore.updateKeyCache('labcharts-ppq-key', '');
       await api.savePpqKey('***');
 
       let releaseModels;
@@ -176,7 +178,7 @@ test('PPQ cold-cache model fetch does not overwrite another active provider pane
       };
     } finally {
       window.fetch = oldFetch;
-      window.updateKeyCache?.('labcharts-ppq-key', oldKey || null);
+      cryptoStore.updateKeyCache('labcharts-ppq-key', oldKey || null);
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -385,6 +385,7 @@ test('provider panels cover provider switching key saves balances custom API and
 
   const results = await page.evaluate(async ({ panelsUrl }) => {
     const panels = await import(panelsUrl);
+    const cryptoStore = await import('/js/crypto.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200, headers = {}) => new Response(JSON.stringify(body), {
       status,
@@ -445,11 +446,11 @@ test('provider panels cover provider switching key saves balances custom API and
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
-      window.updateKeyCache?.('labcharts-openrouter-key', '');
-      window.updateKeyCache?.('labcharts-venice-key', '');
-      window.updateKeyCache?.('labcharts-routstr-key', '');
-      window.updateKeyCache?.('labcharts-ppq-key', '');
-      window.updateKeyCache?.('labcharts-custom-key', '');
+      cryptoStore.updateKeyCache('labcharts-openrouter-key', '');
+      cryptoStore.updateKeyCache('labcharts-venice-key', '');
+      cryptoStore.updateKeyCache('labcharts-routstr-key', '');
+      cryptoStore.updateKeyCache('labcharts-ppq-key', '');
+      cryptoStore.updateKeyCache('labcharts-custom-key', '');
       window.open = url => { openedUrl = String(url); return null; };
       window.openSettingsModal = () => {};
       window.closeSettingsModal = () => { settingsClosed += 1; };
@@ -672,11 +673,11 @@ test('provider panels cover provider switching key saves balances custom API and
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);
       }
-      window.updateKeyCache?.('labcharts-openrouter-key', oldStorage['labcharts-openrouter-key'] || '');
-      window.updateKeyCache?.('labcharts-venice-key', oldStorage['labcharts-venice-key'] || '');
-      window.updateKeyCache?.('labcharts-routstr-key', oldStorage['labcharts-routstr-key'] || '');
-      window.updateKeyCache?.('labcharts-ppq-key', oldStorage['labcharts-ppq-key'] || '');
-      window.updateKeyCache?.('labcharts-custom-key', oldStorage['labcharts-custom-key'] || '');
+      cryptoStore.updateKeyCache('labcharts-openrouter-key', oldStorage['labcharts-openrouter-key'] || '');
+      cryptoStore.updateKeyCache('labcharts-venice-key', oldStorage['labcharts-venice-key'] || '');
+      cryptoStore.updateKeyCache('labcharts-routstr-key', oldStorage['labcharts-routstr-key'] || '');
+      cryptoStore.updateKeyCache('labcharts-ppq-key', oldStorage['labcharts-ppq-key'] || '');
+      cryptoStore.updateKeyCache('labcharts-custom-key', oldStorage['labcharts-custom-key'] || '');
       if (oldSessionPrevious == null) sessionStorage.removeItem('or_previous_ai_provider');
       else sessionStorage.setItem('or_previous_ai_provider', oldSessionPrevious);
       document.getElementById('settings-modal')?.remove();
@@ -697,6 +698,7 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
   const results = await page.evaluate(async ({ ppqUrl }) => {
     const ppq = await import(ppqUrl);
     const delegates = await import('/js/provider-panel-delegates.js');
+    const cryptoStore = await import('/js/crypto.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -729,7 +731,7 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
-      window.updateKeyCache?.('labcharts-ppq-key', '');
+      cryptoStore.updateKeyCache('labcharts-ppq-key', '');
       window.setInterval = (fn, ms) => {
         const id = nextIntervalId++;
         intervals.push({ id, fn, ms, cleared: false });
@@ -936,7 +938,7 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);
       }
-      window.updateKeyCache?.('labcharts-ppq-key', oldStorage['labcharts-ppq-key'] || '');
+      cryptoStore.updateKeyCache('labcharts-ppq-key', oldStorage['labcharts-ppq-key'] || '');
       document.getElementById('ai-provider-panel')?.remove();
       document.getElementById('ppq-topup-toggle')?.remove();
       document.getElementById('ppq-topup-area')?.remove();

--- a/tests/playwright/routstr-private-tee-provider.spec.js
+++ b/tests/playwright/routstr-private-tee-provider.spec.js
@@ -10,6 +10,7 @@ test('Routstr Private TEE support appears after discovery and toggles through th
     const renderers = await import(renderersUrl);
     const settlement = await import(settlementUrl);
     const walletRenderers = await import(walletRenderersUrl);
+    const cryptoStore = await import('/js/crypto.js');
     const storageKeys = [
       'labcharts-routstr-key',
       'labcharts-routstr-node',
@@ -24,13 +25,13 @@ test('Routstr Private TEE support appears after discovery and toggles through th
     const oldStorage = {};
     for (const key of storageKeys) oldStorage[key] = localStorage.getItem(key);
     const oldFetch = window.fetch;
-    const oldKey = window.getCachedKey?.('labcharts-routstr-key') || '';
+    const oldKey = cryptoStore.getCachedKey('labcharts-routstr-key') || '';
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
       localStorage.setItem('labcharts-routstr-key', 'sk-routstr-private-test');
       localStorage.setItem('labcharts-routstr-node', 'https://routstr-private.example');
-      window.updateKeyCache?.('labcharts-routstr-key', 'sk-routstr-private-test');
+      cryptoStore.updateKeyCache('labcharts-routstr-key', 'sk-routstr-private-test');
       window.fetch = async function(input) {
         const href = typeof input === 'string' ? input : input?.url || '';
         if (href === 'https://routstr-private.example/v1/models') {
@@ -95,7 +96,7 @@ test('Routstr Private TEE support appears after discovery and toggles through th
       };
     } finally {
       window.fetch = oldFetch;
-      window.updateKeyCache?.('labcharts-routstr-key', oldKey || null);
+      cryptoStore.updateKeyCache('labcharts-routstr-key', oldKey || null);
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -12,6 +12,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
+    const cryptoStore = await import('/js/crypto.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -209,7 +210,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       localStorage.setItem('labcharts-ai-provider', 'routstr');
       localStorage.setItem('labcharts-routstr-node', nodeUrl);
       localStorage.setItem('labcharts-routstr-key', 'sk-routstr-dom');
-      window.updateKeyCache?.('labcharts-routstr-key', 'sk-routstr-dom');
+      cryptoStore.updateKeyCache('labcharts-routstr-key', 'sk-routstr-dom');
 
       window.openSettingsModal('ai');
       await wait(100);
@@ -250,7 +251,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       const recoveryButtonCarriesToken = document.querySelector('#routstr-wallet-fund-area [data-token="cashuArecoverytoken"]') !== null;
 
       localStorage.setItem('labcharts-routstr-key', 'sk-routstr-dom');
-      window.updateKeyCache?.('labcharts-routstr-key', 'sk-routstr-dom');
+      cryptoStore.updateKeyCache('labcharts-routstr-key', 'sk-routstr-dom');
       await window.doRoutstrNodeWithdraw();
       await wait(50);
       const refundBlockedUntilSeedAck = !refundCalled
@@ -398,7 +399,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);
       }
-      window.updateKeyCache?.('labcharts-routstr-key', oldStorage['labcharts-routstr-key'] || '');
+      cryptoStore.updateKeyCache('labcharts-routstr-key', oldStorage['labcharts-routstr-key'] || '');
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       window.closeModal?.();
       window.closeSettingsModal?.();

--- a/tests/playwright/settings-provider-browser-coverage.spec.js
+++ b/tests/playwright/settings-provider-browser-coverage.spec.js
@@ -10,6 +10,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
     const controls = await import(controlsUrl);
     const pii = await import(piiUrl);
     const providerStorage = await import(providerStorageUrl);
+    const cryptoStore = await import('/js/crypto.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -39,7 +40,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
-      window.updateKeyCache?.('labcharts-ollama', '');
+      cryptoStore.updateKeyCache('labcharts-ollama', '');
       window.updatePrivacyStatusCard = () => { privacyUpdates += 1; };
       Object.defineProperty(navigator, 'clipboard', {
         configurable: true,
@@ -233,7 +234,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);
       }
-      window.updateKeyCache?.('labcharts-ollama', oldStorage['labcharts-ollama'] || '');
+      cryptoStore.updateKeyCache('labcharts-ollama', oldStorage['labcharts-ollama'] || '');
       document.getElementById('local-ai-fixture')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
     }

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -332,10 +332,10 @@ else localStorage.setItem('labcharts-profiles', _origProfiles);
 // not a test one.
 console.log('15. Encryption Patterns');
 const _encPid = 'mp567abc';
-assert('isSensitiveKey matches per-thread key', window.isSensitiveKey(`labcharts-${_encPid}-chat-t_abc123`));
-assert('isSensitiveKey matches legacy chat key', window.isSensitiveKey(`labcharts-${_encPid}-chat`));
+assert('isSensitiveKey matches per-thread key', cryptoModule.isSensitiveKey(`labcharts-${_encPid}-chat-t_abc123`));
+assert('isSensitiveKey matches legacy chat key', cryptoModule.isSensitiveKey(`labcharts-${_encPid}-chat`));
 assert('isSensitiveKey matches thread index (crypto.js SENSITIVE_PATTERNS)',
-  window.isSensitiveKey(`labcharts-${_encPid}-chat-threads`));
+  cryptoModule.isSensitiveKey(`labcharts-${_encPid}-chat-threads`));
 
 // ═══════════════════════════════════════════════
 // 16. Profile Delete Cleanup (source inspection)

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -41,10 +41,9 @@ function assert(name, condition, detail) {
 
 console.log('=== Crypto / Encryption / Backup Tests ===\n');
 
-// Load the app module surface so the Object.assign(window, …) blocks run and
-// the window-export checks below resolve.
+// Load the app module surface and verify crypto through its ESM exports.
 await import('../js/state.js');
-await import('../js/crypto.js');
+const cryptoModule = await import('../js/crypto.js');
 await import('../js/pii.js');
 await import('../js/data.js');
 await import('../js/profile.js');
@@ -65,48 +64,44 @@ if (!localStorage.getItem('labcharts-profiles')) {
 if (typeof window.initProfilesCache === 'function') await window.initProfilesCache();
 
 // ═══════════════════════════════════════════════
-// 1. Module & window exports exist
+// 1. Module exports exist without legacy window globals
 // ═══════════════════════════════════════════════
-console.log('1. Module & window exports');
-assert('window.initEncryption exists', typeof window.initEncryption === 'function');
-assert('window.initBroadcastChannel exists', typeof window.initBroadcastChannel === 'function');
-assert('window.getEncryptionEnabled exists', typeof window.getEncryptionEnabled === 'function');
-assert('window.isUnlocked exists', typeof window.isUnlocked === 'function');
-assert('window.encryptedSetItem exists', typeof window.encryptedSetItem === 'function');
-assert('window.encryptedGetItem exists', typeof window.encryptedGetItem === 'function');
-assert('window.showEnableEncryptionModal exists', typeof window.showEnableEncryptionModal === 'function');
-assert('window.disableEncryption exists', typeof window.disableEncryption === 'function');
-assert('window.changePassphrase exists', typeof window.changePassphrase === 'function');
+console.log('1. Module exports');
+const cryptoExports = [
+  'initEncryption', 'initBroadcastChannel', 'getEncryptionEnabled', 'isUnlocked',
+  'encryptedSetItem', 'encryptedGetItem', 'showEnableEncryptionModal',
+  'maybeShowEncryptionNudge', 'maybeShowBackupNudge', 'disableEncryption',
+  'changePassphrase', 'broadcastDataChanged', 'renderEncryptionSection',
+  'renderBackupSection', 'isSensitiveKey', 'getCachedKey', 'updateKeyCache',
+  'decryptKeyCache', 'loadBackupSnapshots', 'toggleBackupSnapshots',
+];
+for (const name of cryptoExports) {
+  assert(`crypto.${name} exists`, typeof cryptoModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
+}
 assert('backup.exportEncryptedBackup module export exists', typeof backupModule.exportEncryptedBackup === 'function');
 assert('backup.importEncryptedBackup module export exists', typeof backupModule.importEncryptedBackup === 'function');
 assert('window.exportEncryptedBackup stays module-only', !('exportEncryptedBackup' in window));
 assert('window.importEncryptedBackup stays module-only', !('importEncryptedBackup' in window));
-assert('window.broadcastDataChanged exists', typeof window.broadcastDataChanged === 'function');
-assert('window.renderEncryptionSection exists', typeof window.renderEncryptionSection === 'function');
-assert('window.renderBackupSection exists', typeof window.renderBackupSection === 'function');
-assert('window.isSensitiveKey exists', typeof window.isSensitiveKey === 'function');
-assert('window.getCachedKey exists', typeof window.getCachedKey === 'function');
-assert('window.updateKeyCache exists', typeof window.updateKeyCache === 'function');
-assert('window.decryptKeyCache exists', typeof window.decryptKeyCache === 'function');
 assert('window.initProfilesCache exists', typeof window.initProfilesCache === 'function');
 
 // ═══════════════════════════════════════════════
 // 2. Sensitive key detection
 // ═══════════════════════════════════════════════
 console.log('2. Sensitive key detection');
-assert('labcharts-default-imported is sensitive', window.isSensitiveKey('labcharts-default-imported'));
-assert('labcharts-abc123-imported is sensitive', window.isSensitiveKey('labcharts-abc123-imported'));
-assert('labcharts-default-chat is sensitive', window.isSensitiveKey('labcharts-default-chat'));
-assert('labcharts-profiles is sensitive', window.isSensitiveKey('labcharts-profiles'));
-assert('labcharts-api-key IS sensitive', window.isSensitiveKey('labcharts-api-key'));
-assert('labcharts-venice-key IS sensitive', window.isSensitiveKey('labcharts-venice-key'));
-assert('labcharts-openrouter-key IS sensitive', window.isSensitiveKey('labcharts-openrouter-key'));
-assert('labcharts-ollama IS sensitive', window.isSensitiveKey('labcharts-ollama'));
-assert('labcharts-ai-provider is NOT sensitive', !window.isSensitiveKey('labcharts-ai-provider'));
-assert('labcharts-default-units is NOT sensitive', !window.isSensitiveKey('labcharts-default-units'));
-assert('labcharts-encryption-enabled is NOT sensitive', !window.isSensitiveKey('labcharts-encryption-enabled'));
-assert('labcharts-time-format is NOT sensitive', !window.isSensitiveKey('labcharts-time-format'));
-assert('labcharts-default-focusCard is NOT sensitive', !window.isSensitiveKey('labcharts-default-focusCard'));
+assert('labcharts-default-imported is sensitive', cryptoModule.isSensitiveKey('labcharts-default-imported'));
+assert('labcharts-abc123-imported is sensitive', cryptoModule.isSensitiveKey('labcharts-abc123-imported'));
+assert('labcharts-default-chat is sensitive', cryptoModule.isSensitiveKey('labcharts-default-chat'));
+assert('labcharts-profiles is sensitive', cryptoModule.isSensitiveKey('labcharts-profiles'));
+assert('labcharts-api-key IS sensitive', cryptoModule.isSensitiveKey('labcharts-api-key'));
+assert('labcharts-venice-key IS sensitive', cryptoModule.isSensitiveKey('labcharts-venice-key'));
+assert('labcharts-openrouter-key IS sensitive', cryptoModule.isSensitiveKey('labcharts-openrouter-key'));
+assert('labcharts-ollama IS sensitive', cryptoModule.isSensitiveKey('labcharts-ollama'));
+assert('labcharts-ai-provider is NOT sensitive', !cryptoModule.isSensitiveKey('labcharts-ai-provider'));
+assert('labcharts-default-units is NOT sensitive', !cryptoModule.isSensitiveKey('labcharts-default-units'));
+assert('labcharts-encryption-enabled is NOT sensitive', !cryptoModule.isSensitiveKey('labcharts-encryption-enabled'));
+assert('labcharts-time-format is NOT sensitive', !cryptoModule.isSensitiveKey('labcharts-time-format'));
+assert('labcharts-default-focusCard is NOT sensitive', !cryptoModule.isSensitiveKey('labcharts-default-focusCard'));
 
 // ═══════════════════════════════════════════════
 // 3. Web Crypto API key derivation round-trip
@@ -190,11 +185,11 @@ console.log('5. Non-sensitive keys plaintext');
 try {
   const testKey = 'labcharts-test-nonsensitive';
   const testVal = 'plain-value-123';
-  await window.encryptedSetItem(testKey, testVal);
+  await cryptoModule.encryptedSetItem(testKey, testVal);
   const stored = localStorage.getItem(testKey);
   assert('Non-sensitive key stored as plaintext', stored === testVal, `got: ${stored}`);
   assert('Non-sensitive key has no v1: prefix', !stored.startsWith('v1:'));
-  const retrieved = await window.encryptedGetItem(testKey);
+  const retrieved = await cryptoModule.encryptedGetItem(testKey);
   assert('Non-sensitive key retrieved correctly', retrieved === testVal, `got: ${retrieved}`);
   localStorage.removeItem(testKey);
 } catch (e) {
@@ -206,7 +201,7 @@ try {
 // ═══════════════════════════════════════════════
 console.log('6. encryptedGetItem null handling');
 try {
-  const result = await window.encryptedGetItem('labcharts-nonexistent-key-xyz');
+  const result = await cryptoModule.encryptedGetItem('labcharts-nonexistent-key-xyz');
   assert('encryptedGetItem returns null for missing key', result === null);
 } catch (e) {
   assert('encryptedGetItem null handling', false, e.message);
@@ -251,11 +246,11 @@ try {
 // ═══════════════════════════════════════════════
 console.log('9. Security section rendering');
 try {
-  const html = window.renderEncryptionSection();
+  const html = cryptoModule.renderEncryptionSection();
   assert('renderEncryptionSection returns HTML', typeof html === 'string' && html.length > 50);
   assert('Encryption section has status card', html.includes('encryption-status-card'));
   assert('Encryption section uses delegated actions', html.includes('data-crypto-action=') && !html.includes('onclick='));
-  const backupHtml = window.renderBackupSection();
+  const backupHtml = cryptoModule.renderBackupSection();
   assert('renderBackupSection returns HTML', typeof backupHtml === 'string' && backupHtml.length > 50);
   assert('Backup section has download button', backupHtml.includes('Download Backup'));
   assert('Backup section has restore button', backupHtml.includes('Restore Backup'));
@@ -271,9 +266,9 @@ console.log('10. Encryption enabled state');
 {
   const wasEnabled = localStorage.getItem('labcharts-encryption-enabled');
   localStorage.removeItem('labcharts-encryption-enabled');
-  assert('getEncryptionEnabled returns false when disabled', window.getEncryptionEnabled() === false);
+  assert('getEncryptionEnabled returns false when disabled', cryptoModule.getEncryptionEnabled() === false);
   localStorage.setItem('labcharts-encryption-enabled', 'true');
-  assert('getEncryptionEnabled returns true when enabled', window.getEncryptionEnabled() === true);
+  assert('getEncryptionEnabled returns true when enabled', cryptoModule.getEncryptionEnabled() === true);
   if (wasEnabled) localStorage.setItem('labcharts-encryption-enabled', wasEnabled);
   else localStorage.removeItem('labcharts-encryption-enabled');
 }
@@ -285,13 +280,13 @@ console.log('11. Encryption section reflects state');
 {
   const wasEnabled = localStorage.getItem('labcharts-encryption-enabled');
   localStorage.removeItem('labcharts-encryption-enabled');
-  const offHtml = window.renderEncryptionSection();
+  const offHtml = cryptoModule.renderEncryptionSection();
   assert('OFF state shows Enable button', offHtml.includes('Enable Encryption'));
   assert('OFF state shows encryption-status-off', offHtml.includes('encryption-status-off'));
   assert('OFF state enable button is delegated', offHtml.includes('data-crypto-action="enable-encryption"'));
 
   localStorage.setItem('labcharts-encryption-enabled', 'true');
-  const onHtml = window.renderEncryptionSection();
+  const onHtml = cryptoModule.renderEncryptionSection();
   assert('ON state shows Change Passphrase', onHtml.includes('Change Passphrase'));
   assert('ON state shows Disable Encryption', onHtml.includes('Disable Encryption'));
   assert('ON state shows encryption-status-on', onHtml.includes('encryption-status-on'));
@@ -312,12 +307,12 @@ console.log('11b. Key cache sync access');
 {
   const testKey = 'labcharts-test-cache-key';
   localStorage.setItem(testKey, 'test-value');
-  assert('getCachedKey falls back to localStorage', window.getCachedKey(testKey) === 'test-value');
-  window.updateKeyCache(testKey, 'cached-value');
-  assert('getCachedKey returns cached value after updateKeyCache', window.getCachedKey(testKey) === 'cached-value');
-  window.updateKeyCache(testKey, null);
+  assert('getCachedKey falls back to localStorage', cryptoModule.getCachedKey(testKey) === 'test-value');
+  cryptoModule.updateKeyCache(testKey, 'cached-value');
+  assert('getCachedKey returns cached value after updateKeyCache', cryptoModule.getCachedKey(testKey) === 'cached-value');
+  cryptoModule.updateKeyCache(testKey, null);
   localStorage.removeItem(testKey);
-  assert('getCachedKey returns null after cleanup', window.getCachedKey(testKey) === null);
+  assert('getCachedKey returns null after cleanup', cryptoModule.getCachedKey(testKey) === null);
 }
 
 // ═══════════════════════════════════════════════
@@ -558,7 +553,6 @@ for (const name of ['scheduleAutoBackup', 'getAutoBackupSnapshots', 'restoreAuto
   assert(`backup.${name} exists`, typeof backupModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));
 }
-assert('window.loadBackupSnapshots exists', typeof window.loadBackupSnapshots === 'function');
 
 // ═══════════════════════════════════════════════
 // 21. IndexedDB labcharts-backups can be opened
@@ -615,7 +609,7 @@ try {
 // ═══════════════════════════════════════════════
 console.log('24. Backup section auto-backup UI');
 try {
-  const html = window.renderBackupSection();
+  const html = cryptoModule.renderBackupSection();
   assert('Backup section has auto-backup status', html.includes('backup-auto-status'));
   assert('Backup section has snapshot list container', html.includes('backup-snapshot-list'));
   assert('Backup section has delegated snapshot toggle and import',

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -32,6 +32,7 @@ console.log('=== Custom API Provider Tests ===\n');
 // still exposes UI handlers used by legacy HTML/event wiring.
 await import('../js/state.js');
 const api = await import('../js/api.js');
+const cryptoModule = await import('../js/crypto.js');
 await import('../js/provider-panels.js');
 
 // ─── 1. api.js source inspection ───
@@ -99,7 +100,7 @@ else localStorage.removeItem('labcharts-custom-url');
 console.log('\n4. Key management');
 const oldKey = localStorage.getItem('labcharts-custom-key');
 localStorage.removeItem('labcharts-custom-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+cryptoModule.updateKeyCache('labcharts-custom-key', '');
 assert('getCustomApiKey returns empty by default', api.getCustomApiKey() === '');
 assert('hasCustomApiKey returns false without key', api.hasCustomApiKey() === false);
 if (oldKey) localStorage.setItem('labcharts-custom-key', oldKey);
@@ -135,14 +136,14 @@ const savedKey = localStorage.getItem('labcharts-custom-key');
 api.setAIProvider('custom');
 localStorage.removeItem('labcharts-custom-url');
 localStorage.removeItem('labcharts-custom-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+cryptoModule.updateKeyCache('labcharts-custom-key', '');
 assert('hasAIProvider false without URL or key', api.hasAIProvider() === false);
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'test-key');
+cryptoModule.updateKeyCache('labcharts-custom-key', 'test-key');
 assert('hasAIProvider false with key but no URL', api.hasAIProvider() === false);
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+cryptoModule.updateKeyCache('labcharts-custom-key', '');
 api.setCustomApiUrl('https://api.example.com/v1');
 assert('hasAIProvider false with URL but no key', api.hasAIProvider() === false);
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'test-key');
+cryptoModule.updateKeyCache('labcharts-custom-key', 'test-key');
 assert('hasAIProvider true with both URL and key', api.hasAIProvider() === true);
 if (oldProvider) localStorage.setItem('labcharts-ai-provider', oldProvider);
 else localStorage.removeItem('labcharts-ai-provider');
@@ -150,7 +151,7 @@ if (savedUrl) localStorage.setItem('labcharts-custom-url', savedUrl);
 else localStorage.removeItem('labcharts-custom-url');
 if (savedKey) localStorage.setItem('labcharts-custom-key', savedKey);
 else localStorage.removeItem('labcharts-custom-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+cryptoModule.updateKeyCache('labcharts-custom-key', '');
 
 // ─── 7. getActiveModelId / getActiveModelDisplay ───
 console.log('\n7. getActiveModelId / getActiveModelDisplay');
@@ -184,7 +185,7 @@ const savedUrlErr = localStorage.getItem('labcharts-custom-url');
 const savedKeyErr = localStorage.getItem('labcharts-custom-key');
 localStorage.removeItem('labcharts-custom-url');
 localStorage.removeItem('labcharts-custom-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+cryptoModule.updateKeyCache('labcharts-custom-key', '');
 try {
   await api.callCustomAPI({ system: '', messages: [{ role: 'user', content: 'test' }] });
   assert('callCustomAPI throws without URL', false, 'did not throw');
@@ -202,7 +203,7 @@ if (savedUrlErr) localStorage.setItem('labcharts-custom-url', savedUrlErr);
 else localStorage.removeItem('labcharts-custom-url');
 if (savedKeyErr) localStorage.setItem('labcharts-custom-key', savedKeyErr);
 else localStorage.removeItem('labcharts-custom-key');
-window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', '');
+cryptoModule.updateKeyCache('labcharts-custom-key', '');
 
 // ─── 10. fetchCustomApiModels returns empty without config ───
 console.log('\n10. fetchCustomApiModels edge cases');
@@ -345,7 +346,7 @@ try {
   api.setAIProvider('custom');
   api.setCustomApiUrl('http://localhost:9999/v1');
   api.setCustomApiModel('stream-test-model');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', 'test-key');
+  cryptoModule.updateKeyCache('labcharts-custom-key', 'test-key');
 
   const encoder = new TextEncoder();
   globalThis.fetch = async () => new Response(new ReadableStream({
@@ -376,7 +377,7 @@ try {
   else localStorage.removeItem('labcharts-custom-url');
   if (savedKeyStream) localStorage.setItem('labcharts-custom-key', savedKeyStream);
   else localStorage.removeItem('labcharts-custom-key');
-  window.updateKeyCache && window.updateKeyCache('labcharts-custom-key', savedRuntimeKeyStream);
+  cryptoModule.updateKeyCache('labcharts-custom-key', savedRuntimeKeyStream);
   if (savedModelStream) localStorage.setItem('labcharts-custom-model', savedModelStream);
   else localStorage.removeItem('labcharts-custom-model');
 }

--- a/tests/test-dashboard-data-protection.js
+++ b/tests/test-dashboard-data-protection.js
@@ -30,6 +30,7 @@ console.log('=== Data Protection Dashboard Tests ===\n');
 // context-cards.js exposes the dashboard APIs; backup stays module-only.
 const cards = await import('../js/context-cards.js');
 const backupModule = await import('../js/backup.js');
+const cryptoModule = await import('../js/crypto.js');
 const settingsSyncPanel = await import('../js/settings-sync-panel.js');
 
 const make = (overrides) => ({
@@ -99,8 +100,10 @@ const make = (overrides) => ({
     typeof settingsSyncPanel.showSyncSetupModal === 'function');
   assert('window.showSyncSetupModal stays module-only',
     !('showSyncSetupModal' in window));
-  assert('window.showEnableEncryptionModal exists',
-    typeof window.showEnableEncryptionModal === 'function');
+  assert('crypto.showEnableEncryptionModal module export exists',
+    typeof cryptoModule.showEnableEncryptionModal === 'function');
+  assert('window.showEnableEncryptionModal stays module-only',
+    !('showEnableEncryptionModal' in window));
   assert('backup.pickFolderForBackup module export exists',
     typeof backupModule.pickFolderForBackup === 'function');
   assert('window.pickFolderForBackup stays module-only',

--- a/tests/test-folder-backup.js
+++ b/tests/test-folder-backup.js
@@ -22,7 +22,7 @@ const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), '
 
 await import('../js/state.js');
 const backupModule = await import('../js/backup.js');
-await import('../js/crypto.js');
+const cryptoModule = await import('../js/crypto.js');
 await import('../js/export.js'); // exposes window.buildAllDataBundle
 
   // ═══════════════════════════════════════════════
@@ -75,7 +75,7 @@ await import('../js/export.js'); // exposes window.buildAllDataBundle
   // 4. renderBackupSection includes folder UI
   // ═══════════════════════════════════════════════
   try {
-    const html = window.renderBackupSection();
+    const html = cryptoModule.renderBackupSection();
     assert('renderBackupSection has folder section container', html.includes('backup-folder-section'));
     // On Chromium, should have folder UI content; on Firefox/Safari, the inner HTML is empty
     const st = backupModule.getFolderBackupState();
@@ -133,7 +133,8 @@ await import('../js/export.js'); // exposes window.buildAllDataBundle
   // ═══════════════════════════════════════════════
   // 8. Backup nudge
   // ═══════════════════════════════════════════════
-  assert('window.maybeShowBackupNudge exists', typeof window.maybeShowBackupNudge === 'function');
+  assert('crypto.maybeShowBackupNudge module export exists', typeof cryptoModule.maybeShowBackupNudge === 'function');
+  assert('window.maybeShowBackupNudge stays module-only', !('maybeShowBackupNudge' in window));
   try {
     const backupSrc2 = read('/js/backup.js');
     const cryptoSrc = read('/js/crypto.js');

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -1576,10 +1576,9 @@ assert('Settings select offers Off / 7 / 30 / 90 options',
 
 // IDB encryption — round-trip a row through encrypt+decrypt assuming
 // encryption is OFF in tests (default), assert plaintext pass-through.
-// CRITICAL: do NOT cache-bust crypto.js — its bottom-of-file
-// Object.assign(window, …) rebinds window.updateKeyCache to a fresh
-// _keyCache, which the production module's getCachedKey can't see. That
-// leak surfaced as the test-custom-api / test-custom-lens flakes in CI.
+// CRITICAL: do NOT cache-bust crypto.js — a second module instance would own
+// a separate _keyCache from the production module. That leak surfaced as the
+// test-custom-api / test-custom-lens flakes in CI.
 const cryptoV29 = await import('../js/crypto.js');
 assert('crypto.js exports encryptObject / decryptObject / isEncryptedObject',
   typeof cryptoV29.encryptObject === 'function' &&

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -26,6 +26,7 @@
     '/js/app-ui-shell-modules.js',
     '/js/app-shell-hooks.js',
     '/js/app-event-listeners.js',
+    '/js/crypto.js',
     '/js/startup-orchestrator.js',
     '/js/startup-foundation.js',
     '/js/startup-maintenance-runtime.js',
@@ -187,10 +188,11 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, chartsModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, piiModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
+  const [apiModule, backupModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, piiModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/charts.js'),
+    import('../js/crypto.js'),
     import('../js/cycle.js'),
     import('../js/emf.js'),
     import('../js/emf-runtime.js'),
@@ -509,6 +511,16 @@
     'removeFolderBackup','getFolderBackupState','renderFolderBackupSection',
   ];
 
+  // crypto.js (20 former browser globals, now module-only)
+  const cryptoExports = [
+    'initEncryption','initBroadcastChannel','getEncryptionEnabled','isUnlocked',
+    'encryptedSetItem','encryptedGetItem','showEnableEncryptionModal',
+    'maybeShowEncryptionNudge','maybeShowBackupNudge','disableEncryption',
+    'changePassphrase','broadcastDataChanged','renderEncryptionSection',
+    'renderBackupSection','isSensitiveKey','getCachedKey','updateKeyCache',
+    'decryptKeyCache','loadBackupSnapshots','toggleBackupSnapshots'
+  ];
+
   // supplements.js (23, module-only)
   const supplementsExports = [
     'renderSupplementsSection','openSupplementsEditor','toggleSuppAccordion','showAddSuppForm',
@@ -565,6 +577,7 @@
   for (const [moduleName, moduleApi, exports] of [
     ['backup.js', backupModule, backupExports],
     ['charts.js', chartsModule, chartsExports],
+    ['crypto.js', cryptoModule, cryptoExports],
     ['cycle.js', cycleModule, cycleExports],
     ['emf.js', emfModule, emfExports],
     ['emf-runtime.js', emfRuntimeModule, emfRuntimeExports],
@@ -588,6 +601,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of backupExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of cryptoExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of cycleLegacyGlobals) {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.196';
+self.APP_VERSION = '1.10.197';


### PR DESCRIPTION
## Summary
- remove the 20-function crypto compatibility facade from `window`
- route dashboard encryption and PDF import nudge behavior through explicit module dependencies
- migrate affected tests to crypto module APIs and enforce that former globals remain absent
- lower the legacy-window quality baseline from 10 to 9 and bump the app version to 1.10.197

## Testing
- `./run-tests.sh`
  - 396 Vitest tests passed
  - 351 Playwright tests passed
  - 472 responsive/theme checks passed