### PR TITLE
Make profile module-only

### DIFF
--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -4,7 +4,7 @@
 import { state } from './state.js';
 import { hasAIProvider, isAIPaused } from './api.js';
 import { getActiveData } from './data.js';
-import { getProfileLocation, getProfiles } from './profile.js';
+import { getProfileHeight, getProfileLocation, getProfiles } from './profile.js';
 import { renderProfileContextCards } from './context-cards.js';
 import { openMenstrualCycleEditor } from './cycle.js';
 import { openSupplementsEditor } from './supplements.js';
@@ -54,7 +54,7 @@ function closeChatPanel() {
 }
 
 function getChatProfileHeight(profileId) {
-  return callChatEmptyRuntime('getProfileHeight', profileId) || { height: null, unit: 'cm' };
+  return getProfileHeight(profileId);
 }
 
 function handleChatEmptyClick(event) {

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -10,9 +10,17 @@ import { ensureImportedArray } from './data-merge.js';
 const appWindow = /** @type {Window & typeof globalThis & {
   __WEARABLES_TEST?: boolean,
   buildSidebar: () => void,
-  migrateProfileData: (data: any) => void,
   navigate: (view: string) => void,
 }} */ (typeof window !== 'undefined' ? window : {});
+const cryptoProfileDeps = {
+  migrateProfileData: /** @type {null | ((data: any) => void)} */ (null),
+};
+
+export function configureCryptoProfileDeps(deps = {}) {
+  const previous = { ...cryptoProfileDeps };
+  if (typeof deps.migrateProfileData === 'function') cryptoProfileDeps.migrateProfileData = deps.migrateProfileData;
+  return previous;
+}
 const cryptoActionDelegateRoots = new WeakSet();
 const CRYPTO_ACTION_DELEGATE_KEY = Symbol.for('getbased.cryptoActionDelegatesInstalled');
 const CRYPTO_ACTION_ATTR = 'data-crypto-action';
@@ -1000,7 +1008,7 @@ export function initBroadcastChannel() {
           state.importedData = JSON.parse(raw);
           ensureImportedArray(state.importedData, 'notes');
           ensureImportedArray(state.importedData, 'supplements');
-          appWindow.migrateProfileData(state.importedData);
+          cryptoProfileDeps.migrateProfileData?.(state.importedData);
           appWindow.buildSidebar();
           // buildSidebar resets the .active class to Dashboard, so source
           // the target view from state.currentView (kept in sync by

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -4,7 +4,7 @@
 import { state } from './state.js';
 import { escapeAttr, escapeHTML, formatDate } from './utils.js';
 import { getActiveData } from './data.js';
-import { profileStorageKey } from './profile.js';
+import { getProfiles, profileStorageKey } from './profile.js';
 import { loadContextHealthDots } from './context-cards.js';
 import { hasAIProvider, isAIPaused } from './api.js';
 import { loadCommitHash } from './commit-hash.js';
@@ -304,7 +304,7 @@ export function createDashboardPageView(deps) {
 
     // Auto-trigger guided tour on first populated dashboard visit as a fallback
     // for users who imported before seeing the empty-state tour.
-    const _p = callDashboardPageRuntime('getProfiles')?.find(p => p.id === state.currentProfile);
+    const _p = getProfiles().find(p => p.id === state.currentProfile);
     const _hasProfile = _p?.name && _p.name !== 'Default' && state.profileSex;
     if (_hasProfile && hasData) {
       startTour(true);

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -3,11 +3,13 @@
 
 import { installDNAWindowBindings } from './dna-window-bindings.js';
 import { isImportRunning } from './pdf-import-progress.js';
+import { getLatitudeFromLocation } from './profile.js';
 
-const dnaRuntimeDeps = { isImportRunning };
+const dnaRuntimeDeps = { getLatitudeFromLocation, isImportRunning };
 
 export function configureDnaRuntimeDeps(deps = {}) {
   const previous = { ...dnaRuntimeDeps };
+  if (typeof deps.getLatitudeFromLocation === 'function') dnaRuntimeDeps.getLatitudeFromLocation = deps.getLatitudeFromLocation;
   if (typeof deps.isImportRunning === 'function') dnaRuntimeDeps.isImportRunning = deps.isImportRunning;
   return previous;
 }
@@ -95,7 +97,7 @@ export function updateDnaChatNudge() {
 /** @returns {string | null} */
 export function getDnaProfileLatitudeBand() {
   try {
-    return getRuntimeFunction('getLatitudeFromLocation')?.() || null;
+    return dnaRuntimeDeps.getLatitudeFromLocation() || null;
   } catch {
     return null;
   }

--- a/js/lab-context.js
+++ b/js/lab-context.js
@@ -7,7 +7,7 @@ import { getStatus, hasCardContent, hashString, isDebugMode } from './utils.js';
 import { formatTime } from './theme.js';
 import { getActiveData } from './data.js';
 import { getAllFlaggedMarkers, getEffectiveRangeForDate, getLatestValueIndex } from './marker-analysis.js';
-import { getProfileLocation, getLatitudeFromLocation } from './profile.js';
+import { getProfileHeight, getProfileLocation, getLatitudeFromLocation } from './profile.js';
 import { getBloodDrawPhases, getNextBestDrawDate, detectPerimenopausePattern, detectCycleIronAlerts } from './cycle.js';
 import { isHormonalContraception, recentCyclePeriods, upgradeMenstrualCycleProfile } from './cycle-summary.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
@@ -603,7 +603,7 @@ function _buildLabContextInner(/** @type {LabContextOptions} */ { skipGroupFilte
 
   // ── 7b. Biometrics ──
   const bio = state.importedData.biometrics;
-  const _profileHeight = labContextWindow.getProfileHeight ? labContextWindow.getProfileHeight(state.currentProfile) : { height: null, unit: 'cm' };
+  const _profileHeight = getProfileHeight(state.currentProfile);
   const profileHeightCm = Number(_profileHeight.height) || 0;
   if (includeInsightCards && (profileHeightCm || (bio && (bio.weight?.length || bio.bp?.length || bio.pulse?.length)))) {
     ctx += `[section:biometrics]\n## Biometrics\n`;

--- a/js/profile.js
+++ b/js/profile.js
@@ -998,36 +998,3 @@ export function getLatitudeFromLocation(optCountry, optZip) {
   }
   return null;
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, {
-    profileStorageKey,
-    getProfiles,
-    saveProfiles,
-    initProfilesCache,
-    createDefaultProfileData,
-    createProfile,
-    deleteProfile,
-    renameProfile,
-    switchProfile,
-    migrateProfileData,
-    getProfileSex,
-    setProfileSex,
-    getProfileDob,
-    setProfileDob,
-    getProfileLocation,
-    setProfileLocation,
-    getProfileHeight,
-    setProfileHeight,
-    getLocationCache,
-    latitudeToBand,
-    getLatitudeFromLocation,
-    updateProfileMeta,
-    getAllTags,
-    touchProfileTimestamp,
-    loadProfile,
-    getActiveProfileId,
-    setActiveProfileId,
-    detectLatitudeWithAI,
-  });
-}

--- a/js/settings.js
+++ b/js/settings.js
@@ -32,6 +32,7 @@ import {
 } from './settings-privacy.js';
 import { loadPdfImport } from './import-loader.js';
 import { startGuidedTour } from './tour.js';
+import { getActiveProfileId } from './profile.js';
 import {
   confirmDisablePIIReview,
   refreshDataEntriesSection,
@@ -59,7 +60,7 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
 const settingsRuntime = {
   exportAllDataJSON: () => settingsWindow.exportAllDataJSON?.(),
   exportClientJSON: (profileId) => settingsWindow.exportClientJSON?.(profileId),
-  getActiveProfileId: () => settingsWindow.getActiveProfileId?.() || null,
+  getActiveProfileId,
   openProfileShareModal: () => {},
 };
 

--- a/js/startup-profile.js
+++ b/js/startup-profile.js
@@ -12,8 +12,10 @@ import {
   migrateProfileData,
   initProfilesCache,
 } from './profile.js';
-import { encryptedGetItem, encryptedSetItem } from './crypto.js';
+import { configureCryptoProfileDeps, encryptedGetItem, encryptedSetItem } from './crypto.js';
 import { ensureImportedArray } from './data-merge.js';
+
+configureCryptoProfileDeps({ migrateProfileData });
 
 async function migrateLegacyProfileStorage() {
   if (localStorage.getItem('labcharts-profiles')) return;

--- a/js/sun-body-silhouette-runtime.js
+++ b/js/sun-body-silhouette-runtime.js
@@ -1,6 +1,17 @@
 // @ts-check
 // sun-body-silhouette-runtime.js - Browser runtime adapters for the sun body picker.
 
+import { getActiveProfileId, getProfiles } from './profile.js';
+
+const sunBodySilhouetteRuntimeDeps = { getActiveProfileId, getProfiles };
+
+export function configureSunBodySilhouetteRuntimeDeps(deps = {}) {
+  const previous = { ...sunBodySilhouetteRuntimeDeps };
+  if (typeof deps.getActiveProfileId === 'function') sunBodySilhouetteRuntimeDeps.getActiveProfileId = deps.getActiveProfileId;
+  if (typeof deps.getProfiles === 'function') sunBodySilhouetteRuntimeDeps.getProfiles = deps.getProfiles;
+  return previous;
+}
+
 function getSilhouetteRuntime() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -15,7 +26,7 @@ function getRuntimeFunction(name) {
 
 export function getActiveSilhouetteProfileIdRuntime() {
   try {
-    return getRuntimeFunction('getActiveProfileId')?.() || null;
+    return sunBodySilhouetteRuntimeDeps.getActiveProfileId() || null;
   } catch {
     return null;
   }
@@ -23,7 +34,7 @@ export function getActiveSilhouetteProfileIdRuntime() {
 
 export function getSilhouetteProfilesRuntime() {
   try {
-    const profiles = getRuntimeFunction('getProfiles')?.();
+    const profiles = sunBodySilhouetteRuntimeDeps.getProfiles();
     return Array.isArray(profiles) ? profiles : [];
   } catch {
     return [];

--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -1,6 +1,16 @@
 // @ts-check
 // sun-defaults-runtime.js - Browser runtime adapters for Light setup defaults.
 
+import { getProfileLocation } from './profile.js';
+
+const sunDefaultsRuntimeDeps = { getProfileLocation };
+
+export function configureSunDefaultsRuntimeDeps(deps = {}) {
+  const previous = { ...sunDefaultsRuntimeDeps };
+  if (typeof deps.getProfileLocation === 'function') sunDefaultsRuntimeDeps.getProfileLocation = deps.getProfileLocation;
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -45,9 +55,9 @@ export function getSunSetupCoords() {
 
 export function getSunSetupProfileLocation() {
   try {
-    return getRuntimeFunction('getProfileLocation')?.() || {};
+    return sunDefaultsRuntimeDeps.getProfileLocation() || { country: '', zip: '' };
   } catch {
-    return {};
+    return { country: '', zip: '' };
   }
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 10,
-  "legacyWindowGlobalAssignments": 8,
+  "windowGlobalAssignments": 9,
+  "legacyWindowGlobalAssignments": 7,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/biology-scores-dashboard-lens.spec.js
+++ b/tests/playwright/biology-scores-dashboard-lens.spec.js
@@ -4,12 +4,12 @@ async function prepareDemoProfile(page) {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForFunction(() =>
     typeof window.navigate === 'function'
-      && typeof window.getActiveProfileId === 'function'
       && typeof window.saveImportedData === 'function'
   );
 
   await page.evaluate(async () => {
-    const profileId = window.getActiveProfileId?.() || localStorage.getItem('labcharts-active-profile') || 'default';
+    const { getActiveProfileId } = await import('/js/profile.js');
+    const profileId = getActiveProfileId() || localStorage.getItem('labcharts-active-profile') || 'default';
     localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
 

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -47,6 +47,7 @@ test('crypto storage wrappers cover encryption cache blob and enable disable flo
       wearablesTest: window.__WEARABLES_TEST,
       storage: Object.fromEntries(keys.map(key => [key, localStorage.getItem(key)])),
     };
+    let previousCryptoProfileDeps;
 
     try {
       for (const key of keys) localStorage.removeItem(key);
@@ -393,7 +394,6 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       view: state.currentView,
       importedData: state.importedData,
       buildSidebar: window.buildSidebar,
-      migrateProfileData: window.migrateProfileData,
       navigate: window.navigate,
       storage: Object.fromEntries(keys.map(key => [key, localStorage.getItem(key)])),
     };
@@ -403,10 +403,10 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       document.getElementById('passphrase-overlay')?.remove();
       state.currentProfile = profileId;
       state.currentView = 'settings';
-      window.migrateProfileData = data => {
+      previousCryptoProfileDeps = cryptoStore.configureCryptoProfileDeps({ migrateProfileData: data => {
         calls.migrated += 1;
         data.migratedByTest = true;
-      };
+      } });
       window.buildSidebar = () => { calls.sidebar += 1; };
       window.navigate = view => { calls.navigated.push(view); };
       await cryptoStore.encryptedSetItem(importedKey, JSON.stringify({
@@ -522,8 +522,7 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       state.importedData = saved.importedData;
       if (saved.buildSidebar === undefined) delete window.buildSidebar;
       else window.buildSidebar = saved.buildSidebar;
-      if (saved.migrateProfileData === undefined) delete window.migrateProfileData;
-      else window.migrateProfileData = saved.migrateProfileData;
+      if (previousCryptoProfileDeps) cryptoStore.configureCryptoProfileDeps(previousCryptoProfileDeps);
       if (saved.navigate === undefined) delete window.navigate;
       else window.navigate = saved.navigate;
       if (originalBroadcastDescriptor) {

--- a/tests/playwright/dna-browser-coverage.spec.js
+++ b/tests/playwright/dna-browser-coverage.spec.js
@@ -309,7 +309,11 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     };
 
     const { state } = await import('/js/state.js');
-    const dna = await import(`/js/dna.js?dnaMtdnaCoverage=${Date.now()}-${Math.random()}`);
+    const [dna, dnaRuntime] = await Promise.all([
+      import(`/js/dna.js?dnaMtdnaCoverage=${Date.now()}-${Math.random()}`),
+      import('/js/dna-runtime.js'),
+    ]);
+    const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps();
 
     const profileId = `dna-mtdna-coverage-${Date.now()}`;
     state.currentProfile = profileId;
@@ -332,28 +336,28 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     check('parseMtDNAMutations handles simple and 23andMe rows', jMutations.length === 9 && mt23Mutations.length === 6 && mt23Mutations[0].raw === '295T');
     check('resolveHaplogroup resolves direct and H fallback', resolvedJ?.haplogroup === 'J' && resolvedH?.haplogroup === 'H');
 
-    window.getLatitudeFromLocation = () => '<25\u00B0 latitude (tropical)';
+    dnaRuntime.configureDnaRuntimeDeps({ getLatitudeFromLocation: () => '<25\u00B0 latitude (tropical)' });
     const mismatch = dna.detectMtDNAMismatch({
       mtdna: {
         haplogroup: 'J',
         coupling: { shortLabel: 'uncoupled', climate: 'Cold (Northern European)', matchedLatBands: [3, 4], implications: 'test implications' },
       },
     });
-    window.getLatitudeFromLocation = () => '50-60\u00B0 (northern)';
+    dnaRuntime.configureDnaRuntimeDeps({ getLatitudeFromLocation: () => '50-60\u00B0 (northern)' });
     const matched = dna.detectMtDNAMismatch({
       mtdna: {
         haplogroup: 'J',
         coupling: { shortLabel: 'uncoupled', climate: 'Cold (Northern European)', matchedLatBands: [3, 4] },
       },
     });
-    window.getLatitudeFromLocation = () => 'unknown';
+    dnaRuntime.configureDnaRuntimeDeps({ getLatitudeFromLocation: () => 'unknown' });
     const invalidBand = dna.detectMtDNAMismatch({ mtdna: { haplogroup: 'J', coupling: { matchedLatBands: [3, 4] } } });
     check('detectMtDNAMismatch covers mismatch, match, invalid band', mismatch?.mismatch === true && matched?.mismatch === false && invalidBand === null);
 
     await window.handleMtDNAFile(textFile('not mtdna', 'empty-mtdna.txt'));
     check('empty mtDNA file does not open preview', !document.getElementById('dna-modal-overlay')?.classList.contains('show'));
 
-    window.getLatitudeFromLocation = () => '<25\u00B0 latitude (tropical)';
+    dnaRuntime.configureDnaRuntimeDeps({ getLatitudeFromLocation: () => '<25\u00B0 latitude (tropical)' });
     await window.handleMtDNAFile(textFile(jText, 'genome-mtdna.txt'));
     await wait();
     let overlay = document.getElementById('dna-modal-overlay');
@@ -388,6 +392,7 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     dna.ensureHaplogroupTable();
     check('haplogroup list exported', Array.isArray(window.HAPLOGROUP_LIST) && window.HAPLOGROUP_LIST.includes('J'));
 
+    dnaRuntime.configureDnaRuntimeDeps(previousDnaRuntimeDeps);
     return { failures };
   });
 

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -55,9 +55,10 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
   await prepareApp(page);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, shell] = await Promise.all([
+    const [{ state }, shell, profile] = await Promise.all([
       import('/js/state.js'),
       import('/js/lens-page-shell.js'),
+      import('/js/profile.js'),
     ]);
     const originalView = state.currentView;
     const originalAddDashboard = window.addDashboardWidgetFromLens;
@@ -69,7 +70,7 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
     const originalOpenBiometricPicker = window.openDashboardBiometricPicker;
     const originalOpenChat = window.openChatPanel;
     const originalNavigate = window.navigate;
-    const profileId = window.getActiveProfileId?.() || state.currentProfile || 'default';
+    const profileId = profile.getActiveProfileId() || state.currentProfile || 'default';
     const labsOrderKey = `labcharts-${profileId}-lensPageOrder-labs-v1`;
     const savedLabsOrder = localStorage.getItem(labsOrderKey);
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -10,12 +10,10 @@ test('report builder modal delegates presets categories AI state and preview exp
 
   const results = await page.evaluate(async ({ builderUrl }) => {
     const builder = await import(builderUrl);
+    const profile = await import('/js/profile.js');
     const state = window._labState;
     const outcomes = {};
-    if (typeof window.getProfiles !== 'function' || typeof window.saveProfiles !== 'function') {
-      throw new Error('Profile helpers are required for report export coverage setup.');
-    }
-    const originalProfiles = window.getProfiles();
+    const originalProfiles = profile.getProfiles();
     if (!Array.isArray(originalProfiles)) {
       throw new Error('Expected getProfiles to return the current profile list.');
     }
@@ -87,7 +85,7 @@ test('report builder modal delegates presets categories AI state and preview exp
         customMarkers: {},
       };
       window.invalidateActiveDataCache?.();
-      await window.saveProfiles([{
+      await profile.saveProfiles([{
         id: 'report-export-coverage',
         name: 'Report Coverage',
         sex: 'male',
@@ -223,7 +221,7 @@ test('report builder modal delegates presets categories AI state and preview exp
       state.profileDob = original.profileDob;
       state.dateRangeFilter = original.dateRangeFilter;
       window.invalidateActiveDataCache?.();
-      await window.saveProfiles(original.profiles);
+      await profile.saveProfiles(original.profiles);
       window.open = original.open;
       if (original.aiProvider == null) localStorage.removeItem('labcharts-ai-provider');
       else localStorage.setItem('labcharts-ai-provider', original.aiProvider);
@@ -248,16 +246,14 @@ test('report payload and HTML cover filtered context genetics and supplement bra
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ reportUrl, htmlUrl }) => {
-    const [report, html] = await Promise.all([
+    const [report, html, profile] = await Promise.all([
       import(reportUrl),
       import(htmlUrl),
+      import('/js/profile.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
-    if (typeof window.getProfiles !== 'function' || typeof window.saveProfiles !== 'function') {
-      throw new Error('Profile helpers are required for report export coverage setup.');
-    }
-    const originalProfiles = window.getProfiles();
+    const originalProfiles = profile.getProfiles();
     const original = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       currentProfile: state.currentProfile,
@@ -378,7 +374,7 @@ test('report payload and HTML cover filtered context genetics and supplement bra
         },
       };
       window.invalidateActiveDataCache?.();
-      await window.saveProfiles([{
+      await profile.saveProfiles([{
         id: 'report-payload-coverage',
         name: 'Payload Coverage',
         sex: 'female',
@@ -466,7 +462,7 @@ test('report payload and HTML cover filtered context genetics and supplement bra
       state.unitSystem = original.unitSystem;
       window._snpTableCache = original.snpTable;
       window.invalidateActiveDataCache?.();
-      await window.saveProfiles(original.profiles);
+      await profile.saveProfiles(original.profiles);
     }
 
     return outcomes;
@@ -747,12 +743,10 @@ test('report AI summary generation covers unavailable success and empty-response
 
   const results = await page.evaluate(async ({ reportUrl }) => {
     const report = await import(reportUrl);
+    const profile = await import('/js/profile.js');
     const state = window._labState;
     const outcomes = {};
-    if (typeof window.getProfiles !== 'function' || typeof window.saveProfiles !== 'function') {
-      throw new Error('Profile helpers are required for report AI summary coverage setup.');
-    }
-    const originalProfiles = window.getProfiles();
+    const originalProfiles = profile.getProfiles();
     const original = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       currentProfile: state.currentProfile,
@@ -793,7 +787,7 @@ Discussion focus:
         customMarkers: {},
       };
       window.invalidateActiveDataCache?.();
-      await window.saveProfiles([{
+      await profile.saveProfiles([{
         id: 'report-ai-coverage',
         name: 'Report AI Coverage',
         sex: 'male',
@@ -864,7 +858,7 @@ Discussion focus:
       state.profileSex = original.profileSex;
       state.profileDob = original.profileDob;
       window.invalidateActiveDataCache?.();
-      await window.saveProfiles(original.profiles);
+      await profile.saveProfiles(original.profiles);
       window.fetch = original.fetch;
       if (original.aiProvider == null) localStorage.removeItem('labcharts-ai-provider');
       else localStorage.setItem('labcharts-ai-provider', original.aiProvider);

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -9,8 +9,9 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ sunDefaultsUrl }) => {
-    const [sunDefaults, { state }, data] = await Promise.all([
+    const [sunDefaults, sunDefaultsRuntime, { state }, data] = await Promise.all([
       import(sunDefaultsUrl),
+      import('/js/sun-defaults-runtime.js'),
       import('/js/state.js'),
       import('/js/data.js'),
     ]);
@@ -46,7 +47,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       profileDob: state.profileDob,
       navigate: window.navigate,
       getSunCoords: window.getSunCoords,
-      getProfileLocation: window.getProfileLocation,
       openProfileLocationEditor: window.openProfileLocationEditor,
       openClientList: window.openClientList,
       requestPreciseLocation: window.requestPreciseLocation,
@@ -54,6 +54,9 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
     const calls = [];
     const outcomes = {};
     let precise = false;
+    const previousSunDefaultsRuntimeDeps = sunDefaultsRuntime.configureSunDefaultsRuntimeDeps({
+      getProfileLocation: () => ({ country: 'Czechia', zip: '' }),
+    });
 
     try {
       state.currentProfile = 'setup-onboarding-coverage';
@@ -72,7 +75,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       window.getSunCoords = () => precise
         ? { source: 'profile-precise', lat: 50.087 }
         : { source: 'country-band', lat: 49.2 };
-      window.getProfileLocation = () => ({ country: 'Czechia' });
       window.openProfileLocationEditor = () => calls.push(['profile-location']);
       window.openClientList = () => calls.push(['client-list']);
       window.requestPreciseLocation = async () => {
@@ -207,7 +209,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       Object.assign(window, {
         navigate: saved.navigate,
         getSunCoords: saved.getSunCoords,
-        getProfileLocation: saved.getProfileLocation,
         openProfileLocationEditor: saved.openProfileLocationEditor,
         openClientList: saved.openClientList,
         requestPreciseLocation: saved.requestPreciseLocation,
@@ -216,6 +217,7 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
         maybeAnalyzeOnboardingAfterSave: () => {},
         renderOnboardingAIBlock: () => '',
       });
+      sunDefaultsRuntime.configureSunDefaultsRuntimeDeps(previousSunDefaultsRuntimeDeps);
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -107,6 +107,7 @@ test('startup profile migrates legacy storage and applies saved display state', 
       }
     `,
     '**/js/crypto.js*': `
+      export function configureCryptoProfileDeps() {}
       export async function encryptedGetItem(key) {
         window.__encryptedReads.push(key);
         return localStorage.getItem(key);

--- a/tests/playwright/sun-body-silhouette-browser-coverage.spec.js
+++ b/tests/playwright/sun-body-silhouette-browser-coverage.spec.js
@@ -15,13 +15,13 @@ test('sun body silhouette covers stock render region map overlay and input paths
   await page.goto('/app', { waitUntil: 'load' });
 
   const outcomes = await page.evaluate(async ({ pathsUrl, silhouetteUrl }) => {
-    const silhouette = await import(silhouetteUrl);
+    const [silhouette, silhouetteRuntime] = await Promise.all([
+      import(silhouetteUrl),
+      import('/js/sun-body-silhouette-runtime.js'),
+    ]);
     const paths = await import(pathsUrl);
     const outcomes = {};
-    const saved = {
-      getActiveProfileId: window.getActiveProfileId,
-      getProfiles: window.getProfiles,
-    };
+    const previousSilhouetteRuntimeDeps = silhouetteRuntime.configureSunBodySilhouetteRuntimeDeps();
     const hosts = [];
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, attempts = 120) => {
@@ -50,8 +50,10 @@ test('sun body silhouette covers stock render region map overlay and input paths
 
     try {
       silhouette.resetBodySilhouetteState();
-      window.getActiveProfileId = () => 'profile-female';
-      window.getProfiles = () => [{ id: 'profile-female', sex: 'female' }];
+      silhouetteRuntime.configureSunBodySilhouetteRuntimeDeps({
+        getActiveProfileId: () => 'profile-female',
+        getProfiles: () => [{ id: 'profile-female', sex: 'female' }],
+      });
 
       const femaleParts = paths.buildBodyParts('female');
       const maleParts = paths.buildBodyParts('male');
@@ -74,12 +76,10 @@ test('sun body silhouette covers stock render region map overlay and input paths
         && !!femaleHost.querySelector('mask#sun-fig-mask-front image[href="/er-mask.png"]')
         && !!femaleHost.querySelector('image[href="/er.svg"]');
 
-      window.getActiveProfileId = () => {
-        throw new Error('profile lookup unavailable');
-      };
-      window.getProfiles = () => {
-        throw new Error('profiles unavailable');
-      };
+      silhouetteRuntime.configureSunBodySilhouetteRuntimeDeps({
+        getActiveProfileId: () => { throw new Error('profile lookup unavailable'); },
+        getProfiles: () => { throw new Error('profiles unavailable'); },
+      });
       const fallbackHost = mount(new Set());
       outcomes.profileLookupFailureFallsBackToMale = fallbackHost.querySelector('svg.sun-silhouette')?.dataset.sex === 'male';
 
@@ -155,10 +155,7 @@ test('sun body silhouette covers stock render region map overlay and input paths
       outcomes.detachedOverlayReadyDoesNotMutateHost = detachedHost.innerHTML === detachedSnapshot;
     } finally {
       silhouette.resetBodySilhouetteState();
-      if (saved.getActiveProfileId) window.getActiveProfileId = saved.getActiveProfileId;
-      else delete window.getActiveProfileId;
-      if (saved.getProfiles) window.getProfiles = saved.getProfiles;
-      else delete window.getProfiles;
+      silhouetteRuntime.configureSunBodySilhouetteRuntimeDeps(previousSilhouetteRuntimeDeps);
       for (const host of hosts) host.remove();
     }
 

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -55,9 +55,10 @@ async function waitForApp(page) {
 
 async function seedDemoData(page) {
   await page.evaluate(async () => {
+    const profileModule = await import('/js/profile.js');
     const demo = await fetch('/data/demo-male.json', { cache: 'no-store' }).then(r => r.json());
     const profileId = window._labState.currentProfile || 'default';
-    const profiles = window.getProfiles?.() || [];
+    const profiles = profileModule.getProfiles() || [];
     let profile = profiles.find(p => p.id === profileId);
     if (!profile) {
       profile = { id: profileId, name: 'E2E Dashboard' };
@@ -68,8 +69,8 @@ async function seedDemoData(page) {
     profile.dob = '1987-11-22';
     profile.location = { country: 'united states', zip: '10001' };
     profile.tags = Array.from(new Set([...(Array.isArray(profile.tags) ? profile.tags : []), 'demo']));
-    await window.saveProfiles?.(profiles);
-    const profileKey = window.profileStorageKey || ((id, suffix) => `labcharts-${id}-${suffix}`);
+    await profileModule.saveProfiles(profiles);
+    const profileKey = profileModule.profileStorageKey;
     localStorage.setItem(profileKey(profileId, 'onboarded'), 'profile-set');
     localStorage.setItem(profileKey(profileId, 'emptyTour'), 'completed');
     localStorage.setItem(profileKey(profileId, 'tour'), 'completed');

--- a/tests/sun-body-silhouette-runtime.test.js
+++ b/tests/sun-body-silhouette-runtime.test.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 
 import {
   addSunOverlayReadyListenerRuntime,
+  configureSunBodySilhouetteRuntimeDeps,
   dispatchSunOverlayReadyRuntime,
   getActiveSilhouetteProfileIdRuntime,
   getSilhouetteProfilesRuntime,
@@ -11,6 +12,7 @@ import {
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 const savedCustomEvent = Object.getOwnPropertyDescriptor(globalThis, 'CustomEvent');
+const defaultRuntimeDeps = configureSunBodySilhouetteRuntimeDeps();
 
 function setRuntimeWindow(runtime) {
   Object.defineProperty(globalThis, 'window', {
@@ -21,6 +23,7 @@ function setRuntimeWindow(runtime) {
 }
 
 afterEach(() => {
+  configureSunBodySilhouetteRuntimeDeps(defaultRuntimeDeps);
   if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
   else delete globalThis.window;
   if (savedCustomEvent) Object.defineProperty(globalThis, 'CustomEvent', savedCustomEvent);
@@ -37,9 +40,11 @@ describe('sun body silhouette runtime adapter', () => {
     const listener = () => {};
     const profiles = [{ id: 'profile-female', sex: 'female' }];
     const calls = [];
-    setRuntimeWindow({
+    configureSunBodySilhouetteRuntimeDeps({
       getActiveProfileId: () => 'profile-female',
       getProfiles: () => profiles,
+    });
+    setRuntimeWindow({
       CustomEvent: CustomEventStub,
       dispatchEvent: event => calls.push(['dispatch', event.type, event instanceof CustomEventStub]),
       addEventListener: (type, fn) => calls.push(['add', type, fn]),
@@ -59,9 +64,11 @@ describe('sun body silhouette runtime adapter', () => {
   });
 
   it('uses safe fallbacks when browser hooks are missing or fail', () => {
-    setRuntimeWindow({
+    configureSunBodySilhouetteRuntimeDeps({
       getActiveProfileId: () => { throw new Error('profile unavailable'); },
       getProfiles: () => { throw new Error('profiles unavailable'); },
+    });
+    setRuntimeWindow({
       dispatchEvent: () => { throw new Error('dispatch unavailable'); },
       addEventListener: null,
       removeEventListener: null,

--- a/tests/test-biometrics.js
+++ b/tests/test-biometrics.js
@@ -14,7 +14,7 @@ function assert(name, condition, detail) {
 console.log('=== Biometrics Tests ===\n');
 
 await import('../js/state.js');
-await import('../js/profile.js');
+const profile = await import('../js/profile.js');
 const labContext = await import('../js/lab-context.js');
 // Initialize profiles so getProfiles() / setProfileHeight() have something
 // to mutate. The Playwright environment runs main.js which seeds this.
@@ -26,28 +26,29 @@ if (!window._labState.profiles) {
 
   // Save originals
   const origBio = state.importedData.biometrics;
-  const origProfiles = JSON.parse(JSON.stringify(window.getProfiles()));
+  const origProfiles = JSON.parse(JSON.stringify(profile.getProfiles()));
 
   // ═══════════════════════════════════════
   // 1. Profile height getter/setter
   // ═══════════════════════════════════════
   console.log('1. Height on Profile');
 
-  assert('getProfileHeight is a function', typeof window.getProfileHeight === 'function');
-  assert('setProfileHeight is a function', typeof window.setProfileHeight === 'function');
+  assert('getProfileHeight is a module function', typeof profile.getProfileHeight === 'function');
+  assert('setProfileHeight is a module function', typeof profile.setProfileHeight === 'function');
+  assert('profile height helpers stay module-only', !('getProfileHeight' in window) && !('setProfileHeight' in window));
 
-  window.setProfileHeight(profileId, 180, 'cm');
-  let h = window.getProfileHeight(profileId);
+  profile.setProfileHeight(profileId, 180, 'cm');
+  let h = profile.getProfileHeight(profileId);
   assert('Height stored correctly', h.height === 180, `got ${h.height}`);
   assert('Height unit stored correctly', h.unit === 'cm', `got ${h.unit}`);
 
-  window.setProfileHeight(profileId, 175.5, 'in');
-  h = window.getProfileHeight(profileId);
+  profile.setProfileHeight(profileId, 175.5, 'in');
+  h = profile.getProfileHeight(profileId);
   assert('Height updates', h.height === 175.5);
   assert('Height unit updates', h.unit === 'in');
 
   // Restore
-  window.setProfileHeight(profileId, null, 'cm');
+  profile.setProfileHeight(profileId, null, 'cm');
 
   // ═══════════════════════════════════════
   // 2. Biometrics data migration
@@ -55,7 +56,7 @@ if (!window._labState.profiles) {
   console.log('2. Data Migration');
 
   const testData = {};
-  window.migrateProfileData(testData);
+  profile.migrateProfileData(testData);
   assert('migrateProfileData backfills biometrics', testData.biometrics === null);
 
   // ═══════════════════════════════════════
@@ -111,7 +112,7 @@ if (!window._labState.profiles) {
 
   // BMI = weight(kg) / height(m)^2
   // 82 kg / (1.80)^2 = 25.3
-  window.setProfileHeight(profileId, 180, 'cm');
+  profile.setProfileHeight(profileId, 180, 'cm');
   // Latest weight is 2026-03-15 at 185 lbs = 83.9 kg
   // BMI = 83.9 / 3.24 = 25.9
   const latestWeight = [...state.importedData.biometrics.weight].sort((a, b) => b.date.localeCompare(a.date))[0];
@@ -171,7 +172,7 @@ if (!window._labState.profiles) {
   // ═══════════════════════════════════════
   state.importedData.biometrics = origBio;
   // Restore original profiles (height)
-  window.setProfileHeight(profileId, origProfiles.find(p => p.id === profileId)?.height || null, origProfiles.find(p => p.id === profileId)?.heightUnit || 'cm');
+  profile.setProfileHeight(profileId, origProfiles.find(p => p.id === profileId)?.height || null, origProfiles.find(p => p.id === profileId)?.heightUnit || 'cm');
 
   // ═══════════════════════════════════════
   // Summary

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -46,7 +46,8 @@ await import('../js/state.js');
 const cryptoModule = await import('../js/crypto.js');
 await import('../js/pii.js');
 await import('../js/data.js');
-await import('../js/profile.js');
+const profileModule = await import('../js/profile.js');
+cryptoModule.configureCryptoProfileDeps({ migrateProfileData: profileModule.migrateProfileData });
 await import('../js/nav.js');
 await import('../js/views.js');
 await import('../js/export.js');
@@ -61,7 +62,7 @@ const backupModule = await import('../js/backup.js');
 if (!localStorage.getItem('labcharts-profiles')) {
   localStorage.setItem('labcharts-profiles', JSON.stringify([{ id: 'default', name: 'Test Profile' }]));
 }
-if (typeof window.initProfilesCache === 'function') await window.initProfilesCache();
+await profileModule.initProfilesCache();
 
 // ═══════════════════════════════════════════════
 // 1. Module exports exist without legacy window globals
@@ -83,7 +84,8 @@ assert('backup.exportEncryptedBackup module export exists', typeof backupModule.
 assert('backup.importEncryptedBackup module export exists', typeof backupModule.importEncryptedBackup === 'function');
 assert('window.exportEncryptedBackup stays module-only', !('exportEncryptedBackup' in window));
 assert('window.importEncryptedBackup stays module-only', !('importEncryptedBackup' in window));
-assert('window.initProfilesCache exists', typeof window.initProfilesCache === 'function');
+assert('profile.initProfilesCache exists', typeof profileModule.initProfilesCache === 'function');
+assert('window.initProfilesCache stays module-only', !('initProfilesCache' in window));
 
 // ═══════════════════════════════════════════════
 // 2. Sensitive key detection
@@ -323,9 +325,6 @@ const expectedExports = [
   // data.js
   'saveImportedData', 'getActiveData', 'filterDatesByRange', 'destroyAllCharts',
   'detectTrendAlerts', 'switchUnitSystem', 'switchRangeMode', 'updateHeaderDates',
-  // profile.js
-  'getProfiles', 'saveProfiles', 'loadProfile', 'switchProfile', 'createProfile',
-  'deleteProfile', 'getProfileSex', 'setProfileSex', 'getProfileDob',
   // nav.js
   'buildSidebar', 'renderProfileDropdown',
   // views.js
@@ -341,6 +340,10 @@ const expectedExports = [
 ];
 for (const name of expectedExports) {
   assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
+}
+for (const name of ['getProfiles', 'saveProfiles', 'loadProfile', 'switchProfile', 'createProfile', 'deleteProfile', 'getProfileSex', 'setProfileSex', 'getProfileDob']) {
+  assert(`profile.${name} exists`, typeof profileModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
 }
 
 // ═══════════════════════════════════════════════
@@ -398,7 +401,7 @@ try {
 // ═══════════════════════════════════════════════
 console.log('15. Profiles cache');
 try {
-  const profiles = window.getProfiles();
+  const profiles = profileModule.getProfiles();
   assert('getProfiles returns array', Array.isArray(profiles));
   assert('getProfiles has at least one profile', profiles.length >= 1);
   assert('First profile has id', profiles[0] && typeof profiles[0].id === 'string');

--- a/tests/test-dna-runtime.js
+++ b/tests/test-dna-runtime.js
@@ -50,7 +50,6 @@ const runtimeKeys = [
   '_saveAndRefresh',
   '_snpTableCache',
   'buildSidebar',
-  'getLatitudeFromLocation',
   'handleDNAFile',
   'isDebugMode',
   'navigate',
@@ -107,12 +106,10 @@ try {
   assert('updateDnaChatNudge delegates chat nudge refresh',
     calls.some(call => call[0] === 'updateChatNudge'));
 
-  globalThis.getLatitudeFromLocation = () => '40-50° (temperate)';
+  configureDnaRuntimeDeps({ getLatitudeFromLocation: () => '40-50° (temperate)' });
   assert('getDnaProfileLatitudeBand delegates profile latitude lookup',
     getDnaProfileLatitudeBand() === '40-50° (temperate)');
-  globalThis.getLatitudeFromLocation = () => {
-    throw new Error('location failed');
-  };
+  configureDnaRuntimeDeps({ getLatitudeFromLocation: () => { throw new Error('location failed'); } });
   assert('getDnaProfileLatitudeBand reports null on runtime errors',
     getDnaProfileLatitudeBand() === null);
 

--- a/tests/test-dna.js
+++ b/tests/test-dna.js
@@ -494,7 +494,8 @@ assert('dna-runtime owns DNA browser-global integration points',
   dnaRuntimeSrc.includes('_pendingDNAImport') &&
     dnaRuntimeSrc.includes('_pendingMtDNA') &&
     dnaRuntimeSrc.includes('_snpTableCache') &&
-    dnaRuntimeSrc.includes("getRuntimeFunction('getLatitudeFromLocation')") &&
+    dnaRuntimeSrc.includes("from './profile.js'") &&
+    dnaRuntimeSrc.includes('dnaRuntimeDeps.getLatitudeFromLocation()') &&
     dnaRuntimeSrc.includes("getRuntimeFunction('navigate')") &&
     dnaRuntimeSrc.includes('installDNAWindowBindings'));
 assert('dna-mtdna delegates browser runtime hooks to dna-runtime',

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -10,11 +10,12 @@ return (async function() {
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const S = window._labState;
   const backupModule = await import('/js/backup.js');
+  const profile = await import('/js/profile.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
-  const testProfileId = window.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
-  await window.switchProfile(testProfileId);
+  const testProfileId = profile.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
+  await profile.switchProfile(testProfileId);
 
   try {
 
@@ -662,7 +663,7 @@ return (async function() {
     const originalBiometrics = S.importedData.biometrics ? JSON.parse(JSON.stringify(S.importedData.biometrics)) : S.importedData.biometrics;
     const originalProfileSex = S.profileSex;
     const originalProfileDob = S.profileDob;
-    const originalProfiles = JSON.parse(JSON.stringify(window.getProfiles?.() || []));
+    const originalProfiles = JSON.parse(JSON.stringify(profile.getProfiles() || []));
     const originalSnpTable = window._snpTableCache;
     const oldOpen = window.open;
     const oldSetTimeout = window.setTimeout;
@@ -677,7 +678,7 @@ return (async function() {
     });
     window.setTimeout = fn => { if (typeof fn === 'function') fn(); return 0; };
     try {
-      const profiles = window.getProfiles?.() || [];
+      const profiles = profile.getProfiles() || [];
       let activeProfile = profiles.find(p => p.id === S.currentProfile);
       if (!activeProfile) {
         activeProfile = { id: S.currentProfile || 'default', name: 'Test Profile' };
@@ -692,7 +693,7 @@ return (async function() {
       });
       S.profileSex = 'male';
       S.profileDob = '1980-01-02';
-      await window.saveProfiles?.(profiles);
+      await profile.saveProfiles(profiles);
       S.importedData.biometrics = {
         weight: [{ date: '2026-05-15', value: 82, unit: 'kg', source: 'manual' }],
         bp: [{ date: '2026-05-15', sys: 118, dia: 76, source: 'manual' }],
@@ -814,7 +815,7 @@ return (async function() {
       S.importedData.biometrics = originalBiometrics;
       S.profileSex = originalProfileSex;
       S.profileDob = originalProfileDob;
-      await window.saveProfiles?.(originalProfiles);
+      await profile.saveProfiles(originalProfiles);
       window._snpTableCache = originalSnpTable;
       window.open = oldOpen;
       window.setTimeout = oldSetTimeout;
@@ -837,7 +838,7 @@ return (async function() {
   {
     // Snapshot then nuke state.importedData so the import has a clean slate.
     const snapshot = JSON.parse(JSON.stringify(S.importedData || {}));
-    const profilesBeforeDemoImport = JSON.parse(JSON.stringify(window.getProfiles?.() || []));
+    const profilesBeforeDemoImport = JSON.parse(JSON.stringify(profile.getProfiles() || []));
     const origSex = S.profileSex;
     const origDob = S.profileDob;
     S.importedData = { entries: [], notes: [], supplements: [], healthGoals: [],
@@ -867,11 +868,11 @@ return (async function() {
 
       // Demo JSON imports are guarded in product code. Exercise the allowed
       // path by marking the throwaway fixture profile as a demo profile.
-      const profiles = window.getProfiles?.() || [];
+      const profiles = profile.getProfiles() || [];
       const activeProfile = profiles.find(p => p.id === S.currentProfile);
       if (activeProfile && !activeProfile.tags?.includes('demo')) {
         activeProfile.tags = Array.from(new Set([...(activeProfile.tags || []), 'demo']));
-        await window.saveProfiles?.(profiles);
+        await profile.saveProfiles(profiles);
       }
 
       // importDataJSON consumes a File object via FileReader. Synthesize one.
@@ -1039,7 +1040,7 @@ return (async function() {
       S.importedData = snapshot;
       S.profileSex = origSex;
       S.profileDob = origDob;
-      await window.saveProfiles?.(profilesBeforeDemoImport);
+      await profile.saveProfiles(profilesBeforeDemoImport);
     }
   }
 
@@ -1081,7 +1082,7 @@ return (async function() {
       // loadFocusCard + loadContextHealthDots fire-and-forget paths.
       await wait(4000);
       const profileId = S.currentProfile;
-      const profileName = window.getProfiles?.().find(p => p.id === profileId)?.name;
+      const profileName = profile.getProfiles().find(p => p.id === profileId)?.name;
       assert('Demo profile created with expected name',
         profileName === 'Demo Sarah', `got "${profileName}"`);
 
@@ -1169,9 +1170,9 @@ return (async function() {
   } finally {
     // Restore original profile and delete the throwaway
     try {
-      const profiles = window.getProfiles();
-      await window.switchProfile(origProfileId);
-      window.saveProfiles(profiles.filter(p => p.id !== testProfileId));
+      const profiles = profile.getProfiles();
+      await profile.switchProfile(origProfileId);
+      profile.saveProfiles(profiles.filter(p => p.id !== testProfileId));
     } catch (e) {
       console.error('Test cleanup failed:', e);
     }

--- a/tests/test-schema.js
+++ b/tests/test-schema.js
@@ -8,6 +8,7 @@ import './_node-shim.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { migrateProfileData } from '../js/profile.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
@@ -132,14 +133,14 @@ const pdfImportNormalizationSrc = read('js/pdf-import-marker-normalization.js');
   assert('Migration includes icon', profileSrc.includes('icon: def.icon'));
 
   // Behavioral test: migrateProfileData with specialty entry data
-  if (typeof window.migrateProfileData === 'function') {
+  if (typeof migrateProfileData === 'function') {
     const testData = {
       entries: [
         { date: '2025-01-01', markers: { 'oatMicrobial.citramalic': 1.5, 'biochemistry.glucose': 5.2 } },
         { date: '2025-02-01', markers: { 'toxicElements.lead': 0.8 } }
       ]
     };
-    const migrated = window.migrateProfileData(testData);
+    const migrated = migrateProfileData(testData);
     assert('Migration creates customMarkers for oatMicrobial.citramalic',
       migrated.customMarkers && migrated.customMarkers['oatMicrobial.citramalic'] != null);
     assert('Migration creates customMarkers for toxicElements.lead',
@@ -155,12 +156,12 @@ const pdfImportNormalizationSrc = read('js/pdf-import-marker-normalization.js');
     assert('Entry marker values untouched', testData.entries[0].markers['oatMicrobial.citramalic'] === 1.5);
 
     // Idempotency test
-    const migrated2 = window.migrateProfileData(migrated);
+    const migrated2 = migrateProfileData(migrated);
     assert('Migration is idempotent', JSON.stringify(migrated2.customMarkers) === JSON.stringify(migrated.customMarkers));
 
     // No-op for empty entries
     const emptyData = { entries: [] };
-    const migratedEmpty = window.migrateProfileData(emptyData);
+    const migratedEmpty = migrateProfileData(emptyData);
     assert('Migration no-op for empty entries', Object.keys(migratedEmpty.customMarkers || {}).length === 0);
   }
 

--- a/tests/test-sun-defaults-runtime.js
+++ b/tests/test-sun-defaults-runtime.js
@@ -3,6 +3,7 @@
 
 import './_node-shim.js';
 import {
+  configureSunDefaultsRuntimeDeps,
   exposeSunDefaultsBindings,
   getSunSetupCoords,
   getSunSetupProfileLocation,
@@ -34,6 +35,7 @@ const runtimeKeys = [
   'sunDefaultsProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+const originalSunDefaultsRuntimeDeps = configureSunDefaultsRuntimeDeps();
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -55,7 +57,7 @@ function restoreRuntime() {
 try {
   const calls = [];
   setRuntimeValue('getSunCoords', () => ({ lat: 50.08, lon: 14.42, source: 'profile-precise' }));
-  setRuntimeValue('getProfileLocation', () => ({ country: 'Czech Republic' }));
+  configureSunDefaultsRuntimeDeps({ getProfileLocation: () => ({ country: 'Czech Republic', zip: '' }) });
   setRuntimeValue('openProfileLocationEditor', () => calls.push(['profile-location']));
   setRuntimeValue('openClientList', () => calls.push(['client-list']));
   setRuntimeValue('requestPreciseLocation', () => {
@@ -110,13 +112,13 @@ try {
     localCalls === 1);
 
   delete globalThis.getSunCoords;
-  delete globalThis.getProfileLocation;
+  configureSunDefaultsRuntimeDeps({ getProfileLocation: () => ({ country: '', zip: '' }) });
   delete globalThis.openClientList;
   delete globalThis.requestPreciseLocation;
   delete globalThis.navigate;
   assert('missing runtime functions return safe fallbacks',
     getSunSetupCoords() === null &&
-    Object.keys(getSunSetupProfileLocation()).length === 0 &&
+    getSunSetupProfileLocation().country === '' &&
     openSunSetupProfileLocationRuntime() === false &&
     hasSunSetupPreciseLocationRequester() === false &&
     requestSunSetupPreciseLocationRuntime() === null);
@@ -128,13 +130,14 @@ try {
   assert('runtime adapter no-ops safely when window is missing',
     hasSunDefaultsBrowserRuntime() === false &&
     getSunSetupCoords() === null &&
-    Object.keys(getSunSetupProfileLocation()).length === 0 &&
+    getSunSetupProfileLocation().country === '' &&
     openSunSetupProfileLocationRuntime() === false &&
     hasSunSetupPreciseLocationRequester() === false &&
     requestSunSetupPreciseLocationRuntime() === null &&
     calls.length === beforeNoWindowCalls &&
     globalThis.sunDefaultsProbe === probe);
 } finally {
+  configureSunDefaultsRuntimeDeps(originalSunDefaultsRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -15,11 +15,12 @@ return (async function() {
   const S = window._labState;
   const { buildSunContext } = await import('/js/sun-context.js');
   const { buildLabContext } = await import('/js/lab-context.js');
+  const profile = await import('/js/profile.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
-  const testProfileId = window.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
-  await window.switchProfile(testProfileId);
+  const testProfileId = profile.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
+  await profile.switchProfile(testProfileId);
 
   try {
 
@@ -479,9 +480,9 @@ return (async function() {
   } finally {
     // Restore original profile and delete the throwaway
     try {
-      const profiles = window.getProfiles();
-      await window.switchProfile(origProfileId);
-      window.saveProfiles(profiles.filter(p => p.id !== testProfileId));
+      const profiles = profile.getProfiles();
+      await profile.switchProfile(origProfileId);
+      profile.saveProfiles(profiles.filter(p => p.id !== testProfileId));
     } catch (e) {
       console.error('Test cleanup failed:', e);
     }

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -27,11 +27,12 @@ return (async function() {
   const S = window._labState;
   const supplements = await import('/js/supplements.js');
   const pdfImport = await import('/js/pdf-import.js');
+  const profile = await import('/js/profile.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
-  const testProfileId = window.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
-  await window.switchProfile(testProfileId);
+  const testProfileId = profile.createProfile('__test_' + Date.now(), { tags: ['test'], skipInitialSync: true });
+  await profile.switchProfile(testProfileId);
 
   try {
 
@@ -218,7 +219,7 @@ return (async function() {
 
   // Lens pages are dedicated workspaces; they should not duplicate sidebar
   // category navigation, and their page sections should be reorderable.
-  const lensOrderProfile = window.getActiveProfileId?.() || S.currentProfile || 'default';
+  const lensOrderProfile = profile.getActiveProfileId() || S.currentProfile || 'default';
   const labsOrderKey = `labcharts-${lensOrderProfile}-lensPageOrder-labs-v1`;
   const savedLabsOrder = localStorage.getItem(labsOrderKey);
   localStorage.removeItem(labsOrderKey);
@@ -741,30 +742,30 @@ return (async function() {
   // ═══════════════════════════════════════════════
   console.log('%c 13. Profile operations', 'font-weight:bold;color:#6366f1');
 
-  const origProfileId = window.getActiveProfileId();
-  const origProfileCount = window.getProfiles().length;
+  const origProfileId = profile.getActiveProfileId();
+  const origProfileCount = profile.getProfiles().length;
 
   // Create test profile
-  const testProfileId = window.createProfile('__UI_TEST_PROFILE__');
+  const testProfileId = profile.createProfile('__UI_TEST_PROFILE__');
   assert('Profile created', !!testProfileId);
-  assert('Profile count increased', window.getProfiles().length === origProfileCount + 1);
+  assert('Profile count increased', profile.getProfiles().length === origProfileCount + 1);
 
   // Switch to new profile
-  window.switchProfile(testProfileId);
+  profile.switchProfile(testProfileId);
   await wait(50);
-  assert('Switched to new profile', window.getActiveProfileId() === testProfileId);
+  assert('Switched to new profile', profile.getActiveProfileId() === testProfileId);
   assert('Dashboard re-rendered for new profile', main.innerHTML.length > 100);
 
   // Switch back to original
-  window.switchProfile(origProfileId);
+  profile.switchProfile(origProfileId);
   await wait(50);
-  assert('Switched back to original profile', window.getActiveProfileId() === origProfileId);
+  assert('Switched back to original profile', profile.getActiveProfileId() === origProfileId);
 
   // Delete test profile (bypass confirm dialog — use saveProfiles to update cache)
-  window.saveProfiles(window.getProfiles().filter(p => p.id !== testProfileId));
+  profile.saveProfiles(profile.getProfiles().filter(p => p.id !== testProfileId));
   localStorage.removeItem(`labcharts-${testProfileId}-imported`);
-  assert('Test profile deleted', window.getProfiles().length === origProfileCount);
-  assert('Active profile unchanged', window.getActiveProfileId() === origProfileId);
+  assert('Test profile deleted', profile.getProfiles().length === origProfileCount);
+  assert('Active profile unchanged', profile.getActiveProfileId() === origProfileId);
 
   // ═══════════════════════════════════════════════
   // 14. SIDEBAR SEARCH — filter nav items
@@ -876,9 +877,9 @@ return (async function() {
   } finally {
     // Restore original profile and delete the throwaway
     try {
-      const profiles = window.getProfiles();
-      await window.switchProfile(origProfileId);
-      window.saveProfiles(profiles.filter(p => p.id !== testProfileId));
+      const profiles = profile.getProfiles();
+      await profile.switchProfile(origProfileId);
+      profile.saveProfiles(profiles.filter(p => p.id !== testProfileId));
     } catch (e) {
       console.error('Test cleanup failed:', e);
     }

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -188,7 +188,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
+  const [apiModule, backupModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/charts.js'),
@@ -201,6 +201,7 @@
     import('../js/light-tools.js'),
     import('../js/pdf-import.js'),
     import('../js/pii.js'),
+    import('../js/profile.js'),
     import('../js/settings-sync-panel.js'),
     import('../js/sun-context.js'),
     import('../js/sun-spectrum.js'),
@@ -455,13 +456,14 @@
     'checkOllama'
   ];
 
-  // profile.js (28)
+  // profile.js (28 former browser globals, now module-only)
   const profileExports = [
     'profileStorageKey',
-    'getProfiles','saveProfiles','createDefaultProfileData','createProfile','deleteProfile','renameProfile','switchProfile',
+    'getProfiles','saveProfiles','initProfilesCache','createDefaultProfileData','createProfile','deleteProfile','renameProfile','switchProfile',
     'migrateProfileData',
     'getProfileSex','setProfileSex','getProfileDob','setProfileDob',
     'getProfileLocation','setProfileLocation',
+    'getProfileHeight','setProfileHeight',
     'getLocationCache',
     'latitudeToBand','getLatitudeFromLocation',
     'updateProfileMeta','getAllTags','touchProfileTimestamp',
@@ -591,6 +593,7 @@
     ['light-tools.js', lightToolsModule, lightToolsExports],
     ['pdf-import.js', pdfImportModule, pdfImportExports],
     ['pii.js', piiModule, piiExports],
+    ['profile.js', profileModule, profileExports],
     ['settings-sync-panel.js', settingsSyncPanelModule, settingsSyncPanelExports],
     ['sun-context.js', sunContextModule, sunContextExports],
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
@@ -624,6 +627,9 @@
   for (const name of pdfImportExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of profileExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
@@ -645,7 +651,6 @@
     'export.js': exportExports,
     'nav.js': navExports,
     'notes.js': notesExports,
-    'profile.js': profileExports,
     'settings.js': settingsExports,
     'provider-panels.js': providerPanelsExports,
     'theme.js': themeExports,
@@ -764,12 +769,12 @@
   // ═══════════════════════════════════════════════
   // 8. PROFILE SYSTEM — basic operations
   // ═══════════════════════════════════════════════
-  const profiles = window.getProfiles();
+  const profiles = profileModule.getProfiles();
   assert('getProfiles returns array', Array.isArray(profiles));
   assert('At least one profile', profiles.length >= 1);
-  const activeId = window.getActiveProfileId();
+  const activeId = profileModule.getActiveProfileId();
   assert('Active profile ID is string', typeof activeId === 'string' && activeId.length > 0);
-  const storageKey = window.profileStorageKey(activeId, 'imported');
+  const storageKey = profileModule.profileStorageKey(activeId, 'imported');
   assert('profileStorageKey works', typeof storageKey === 'string' && storageKey.includes(activeId));
 
   // ═══════════════════════════════════════════════

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.198';
+self.APP_VERSION = '1.10.199';


### PR DESCRIPTION
## Summary
- remove the 28-function `profile.js` window facade
- replace profile lookups in DNA, Light setup, silhouette, dashboard, chat, lab context, Settings, and crypto restore flows with explicit module dependencies
- wire cross-tab profile migration during startup without introducing circular initialization
- update Node and browser coverage to use the profile module API and assert the former globals stay absent
- reduce the quality baseline to 9 total window assignments / 7 legacy assignments
- bump the app cache version to 1.10.199

## Testing
- `./run-tests.sh`
  - 396 Vitest tests passed
  - 351 Playwright tests passed
  - 472 theme/responsive checks passed