### PR TITLE
Make utilities module-only

### DIFF
--- a/js/biology-scores-runtime.js
+++ b/js/biology-scores-runtime.js
@@ -2,6 +2,19 @@
 // biology-scores-runtime.js - Browser runtime adapters for Biology Scores UI hooks.
 
 import { hasAIProvider } from './api.js';
+import { showNotification } from './utils.js';
+
+const biologyScoresRuntimeDeps = { showNotification };
+
+export function configureBiologyScoresRuntimeDeps(deps = {}) {
+  const previous = { ...biologyScoresRuntimeDeps };
+  if ('showNotification' in deps) {
+    biologyScoresRuntimeDeps.showNotification = typeof deps.showNotification === 'function'
+      ? /** @type {typeof showNotification} */ (deps.showNotification)
+      : null;
+  }
+  return previous;
+}
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -46,7 +59,7 @@ export function useBiologyScoresChatPrompt(prompt) {
  * @param {string} type
  */
 export function showBiologyScoresNotification(message, type = 'info') {
-  getRuntimeFunction('showNotification')?.(message, type);
+  biologyScoresRuntimeDeps.showNotification?.(message, type);
 }
 
 export function hasBiologyScoresAIProvider() {

--- a/js/category-customization-runtime.js
+++ b/js/category-customization-runtime.js
@@ -1,6 +1,20 @@
 // @ts-check
 // category-customization-runtime.js - Browser runtime hooks for category customization.
 
+import { showPromptDialog } from './utils.js';
+
+const categoryCustomizationRuntimeDeps = { showPromptDialog };
+
+export function configureCategoryCustomizationRuntimeDeps(deps = {}) {
+  const previous = { ...categoryCustomizationRuntimeDeps };
+  if ('showPromptDialog' in deps) {
+    categoryCustomizationRuntimeDeps.showPromptDialog = typeof deps.showPromptDialog === 'function'
+      ? /** @type {typeof showPromptDialog} */ (deps.showPromptDialog)
+      : null;
+  }
+  return previous;
+}
+
 /**
  * @returns {Record<string, any>}
  */
@@ -41,7 +55,7 @@ export function getCategoryCustomizationBuildSidebar() {
  * @returns {Promise<string | null | undefined> | string | null | undefined}
  */
 export function showCategoryCustomizationPrompt(message, options) {
-  return getRuntimeFunction('showPromptDialog')?.(message, options);
+  return categoryCustomizationRuntimeDeps.showPromptDialog?.(message, options);
 }
 
 /**

--- a/js/client-list-runtime.js
+++ b/js/client-list-runtime.js
@@ -2,6 +2,19 @@
 // client-list-runtime.js - Browser runtime adapters for client-list UI shell hooks.
 
 import { hasAIProvider } from './api.js';
+import { showNotification } from './utils.js';
+
+const clientListRuntimeDeps = { showNotification };
+
+export function configureClientListRuntimeDeps(deps = {}) {
+  const previous = { ...clientListRuntimeDeps };
+  if ('showNotification' in deps) {
+    clientListRuntimeDeps.showNotification = typeof deps.showNotification === 'function'
+      ? /** @type {typeof showNotification} */ (deps.showNotification)
+      : null;
+  }
+  return previous;
+}
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -51,7 +64,7 @@ export function refreshClientProfileButton() {
  * @param {string} type
  */
 export function showClientListNotification(message, type) {
-  getRuntimeFunction('showNotification')?.(message, type);
+  clientListRuntimeDeps.showNotification?.(message, type);
 }
 
 /** @param {string} haplogroup */

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -4,13 +4,20 @@
 import { installDNAWindowBindings } from './dna-window-bindings.js';
 import { isImportRunning } from './pdf-import-progress.js';
 import { getLatitudeFromLocation } from './profile.js';
+import { isDebugMode, showConfirmDialog } from './utils.js';
 
-const dnaRuntimeDeps = { getLatitudeFromLocation, isImportRunning };
+const dnaRuntimeDeps = { getLatitudeFromLocation, isDebugMode, isImportRunning, showConfirmDialog };
 
 export function configureDnaRuntimeDeps(deps = {}) {
   const previous = { ...dnaRuntimeDeps };
   if (typeof deps.getLatitudeFromLocation === 'function') dnaRuntimeDeps.getLatitudeFromLocation = deps.getLatitudeFromLocation;
+  if (typeof deps.isDebugMode === 'function') dnaRuntimeDeps.isDebugMode = deps.isDebugMode;
   if (typeof deps.isImportRunning === 'function') dnaRuntimeDeps.isImportRunning = deps.isImportRunning;
+  if ('showConfirmDialog' in deps) {
+    dnaRuntimeDeps.showConfirmDialog = typeof deps.showConfirmDialog === 'function'
+      ? /** @type {typeof showConfirmDialog} */ (deps.showConfirmDialog)
+      : null;
+  }
   return previous;
 }
 
@@ -32,7 +39,7 @@ function getRuntimeFunction(name) {
 /** @returns {boolean} */
 function isDnaDebugMode() {
   try {
-    return getRuntimeFunction('isDebugMode')?.() === true;
+    return dnaRuntimeDeps.isDebugMode() === true;
   } catch {
     return false;
   }
@@ -105,7 +112,7 @@ export function getDnaProfileLatitudeBand() {
 
 /** @returns {Promise<boolean>} */
 export async function confirmDnaDeleteDialog() {
-  const confirmDialog = getRuntimeFunction('showConfirmDialog');
+  const confirmDialog = dnaRuntimeDeps.showConfirmDialog;
   if (!confirmDialog) return false;
   try {
     return await confirmDialog('Delete genetic data? This cannot be undone.') === true;

--- a/js/emf.js
+++ b/js/emf.js
@@ -8,7 +8,7 @@ import { SBM_2015_THRESHOLDS, getEMFSeverity } from './schema.js';
 const SAFE_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 function safeMediaType(t) { return SAFE_IMAGE_TYPES.includes(t) ? t : 'image/png'; }
 import { EMF_ROOM_PRESETS, EMF_SOURCES, EMF_MITIGATIONS, EMF_METER_PRESETS } from './constants.js';
-import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, isPIIReviewEnabled } from './utils.js';
+import { escapeHTML, escapeAttr, showNotification, showConfirmDialog, showPromptDialog, isPIIReviewEnabled } from './utils.js';
 import { saveImportedData } from './data.js';
 import { resizeImage, isValidImageType } from './image-utils.js';
 import { callClaudeAPI, hasAIProvider } from './api.js';
@@ -164,7 +164,7 @@ function closeEMFModalRuntime() {
  * @returns {Promise<string | null | undefined> | string | null | undefined}
  */
 function showEMFPromptRuntime(message, options) {
-  return getEMFRuntimeFunction('showPromptDialog')?.(message, options);
+  return showPromptDialog(message, options);
 }
 
 function emfAttrString(attrs) {

--- a/js/import-drop-zone-runtime.js
+++ b/js/import-drop-zone-runtime.js
@@ -2,12 +2,18 @@
 // import-drop-zone-runtime.js - Browser runtime adapters for drop-zone imports.
 
 import { isImportRunning } from './pdf-import-progress.js';
+import { showNotification } from './utils.js';
 
-const importDropZoneRuntimeDeps = { isImportRunning };
+const importDropZoneRuntimeDeps = { isImportRunning, showNotification };
 
 export function configureImportDropZoneRuntimeDeps(deps = {}) {
   const previous = { ...importDropZoneRuntimeDeps };
   if (typeof deps.isImportRunning === 'function') importDropZoneRuntimeDeps.isImportRunning = deps.isImportRunning;
+  if ('showNotification' in deps) {
+    importDropZoneRuntimeDeps.showNotification = typeof deps.showNotification === 'function'
+      ? /** @type {typeof showNotification} */ (deps.showNotification)
+      : null;
+  }
   return previous;
 }
 
@@ -57,7 +63,7 @@ export function openDropZoneFilePicker() {
  * @param {string} [type]
  */
 export function showDropZoneImportNotification(message, type = 'info') {
-  getRuntimeFunction('showNotification')?.(message, type);
+  importDropZoneRuntimeDeps.showNotification?.(message, type);
 }
 
 /** @param {File} file */

--- a/js/light-devices-runtime.js
+++ b/js/light-devices-runtime.js
@@ -2,6 +2,19 @@
 // light-devices-runtime.js - Browser runtime adapters for light-device UI shell hooks.
 
 import { state } from './state.js';
+import { showPromptDialog } from './utils.js';
+
+const lightDevicesRuntimeDeps = { showPromptDialog };
+
+export function configureLightDevicesRuntimeDeps(deps = {}) {
+  const previous = { ...lightDevicesRuntimeDeps };
+  if ('showPromptDialog' in deps) {
+    lightDevicesRuntimeDeps.showPromptDialog = typeof deps.showPromptDialog === 'function'
+      ? /** @type {typeof showPromptDialog} */ (deps.showPromptDialog)
+      : null;
+  }
+  return previous;
+}
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -37,7 +50,7 @@ export function refreshLightDevicesView() {
 
 /** @param {number} current */
 export function promptLightDeviceSessionDuration(current) {
-  return getRuntimeFunction('showPromptDialog')?.('New duration (in minutes)', {
+  return lightDevicesRuntimeDeps.showPromptDialog?.('New duration (in minutes)', {
     defaultValue: String(current),
     okLabel: 'Save',
     placeholder: 'e.g. 12',

--- a/js/startup-oauth-callbacks.js
+++ b/js/startup-oauth-callbacks.js
@@ -13,6 +13,19 @@ import {
   markOpenRouterOAuthSettingsLocal,
 } from './api.js';
 import { handleOAuthCallbackOnLoad } from './wearables-connect.js';
+import { showNotification as showAppNotification } from './utils.js';
+
+const startupOAuthCallbackDeps = { showNotification: showAppNotification };
+
+export function configureStartupOAuthCallbackDeps(deps = {}) {
+  const previous = { ...startupOAuthCallbackDeps };
+  if ('showNotification' in deps) {
+    startupOAuthCallbackDeps.showNotification = typeof deps.showNotification === 'function'
+      ? /** @type {typeof showAppNotification} */ (deps.showNotification)
+      : null;
+  }
+  return previous;
+}
 
 function startupRuntime() {
   return /** @type {Record<string, any>} */ (globalThis);
@@ -39,7 +52,7 @@ function replaceCurrentUrl() {
 }
 
 function showNotification(message, type, duration) {
-  callStartupRuntime('showNotification', message, type, duration);
+  startupOAuthCallbackDeps.showNotification?.(message, type, duration);
 }
 
 function openChatAfterInit() {

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -11,6 +11,19 @@ import { buildSidebar, renderProfileDropdown } from './nav.js';
 import { maybeShowBackupNudge } from './crypto.js';
 import { maybeShowLegalConsentGate } from './legal-consent.js';
 import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
+import { maybeShowAnalyticsConsent } from './utils.js';
+
+const startupUIDeps = { maybeShowAnalyticsConsent };
+
+export function configureStartupUIDeps(deps = {}) {
+  const previous = { ...startupUIDeps };
+  if ('maybeShowAnalyticsConsent' in deps) {
+    startupUIDeps.maybeShowAnalyticsConsent = typeof deps.maybeShowAnalyticsConsent === 'function'
+      ? /** @type {typeof maybeShowAnalyticsConsent} */ (deps.maybeShowAnalyticsConsent)
+      : null;
+  }
+  return previous;
+}
 
 function startupRuntime() {
   return /** @type {any} */ (globalThis);
@@ -87,7 +100,7 @@ function scheduleStartupNudges() {
   // New and tours also stay behind the gate; legal must be the topmost first
   // interaction for new users and stale-version re-consent.
   const showAnalyticsConsent = () => {
-    callStartupRuntime('maybeShowAnalyticsConsent');
+    startupUIDeps.maybeShowAnalyticsConsent?.();
   };
   if (legalGateShown) {
     startupRuntime().addEventListener('legal-consent-accepted', () => setTimeout(showAnalyticsConsent, 800), { once: true });

--- a/js/sun-runtime.js
+++ b/js/sun-runtime.js
@@ -1,6 +1,16 @@
 // @ts-check
 // sun-runtime.js - Browser runtime adapters for Sun session facade hooks.
 
+import { isDebugMode } from './utils.js';
+
+const sunRuntimeDeps = { isDebugMode };
+
+export function configureSunRuntimeDeps(deps = {}) {
+  const previous = { ...sunRuntimeDeps };
+  if (typeof deps.isDebugMode === 'function') sunRuntimeDeps.isDebugMode = deps.isDebugMode;
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -25,7 +35,7 @@ export function hasSunBrowserRuntime() {
 
 export function isSunDebugRuntime() {
   try {
-    return getRuntimeFunction('isDebugMode')?.() === true;
+    return sunRuntimeDeps.isDebugMode() === true;
   } catch {
     return false;
   }

--- a/js/sync-diagnose-runtime.js
+++ b/js/sync-diagnose-runtime.js
@@ -1,6 +1,20 @@
 // @ts-check
 // sync-diagnose-runtime.js - Browser runtime adapters for Sync Diagnose shell hooks.
 
+import { showConfirmDialog } from './utils.js';
+
+const syncDiagnoseRuntimeDeps = { showConfirmDialog };
+
+export function configureSyncDiagnoseRuntimeDeps(deps = {}) {
+  const previous = { ...syncDiagnoseRuntimeDeps };
+  if ('showConfirmDialog' in deps) {
+    syncDiagnoseRuntimeDeps.showConfirmDialog = typeof deps.showConfirmDialog === 'function'
+      ? /** @type {typeof showConfirmDialog} */ (deps.showConfirmDialog)
+      : null;
+  }
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -21,7 +35,7 @@ function getRuntimeFunction(name) {
  * @param {{ fallback?: boolean }} [opts]
  */
 export async function confirmSyncDiagnoseActionRuntime(message, opts = {}) {
-  const confirm = getRuntimeFunction('showConfirmDialog');
+  const confirm = syncDiagnoseRuntimeDeps.showConfirmDialog;
   if (!confirm) return opts.fallback ?? true;
   return !!await confirm(message);
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -663,7 +663,3 @@ export function loadScriptOnce(src) {
   _scriptLoadPromises.set(src, p);
   return p;
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, { showNotification, showConfirmDialog, showPromptDialog, isDebugMode, setDebugMode, isPIIReviewEnabled, setPIIReviewEnabled, isAnalyticsEnabled, setAnalyticsEnabled, maybeShowAnalyticsConsent, dismissAnalyticsConsent, dismissAnalyticsConsentAndDisable, hasCardContent, escapeAttr, loadScriptOnce });
-}

--- a/js/wearables-detail-runtime.js
+++ b/js/wearables-detail-runtime.js
@@ -1,6 +1,20 @@
 // @ts-check
 // wearables-detail-runtime.js - Browser runtime adapters for wearable detail modal hooks.
 
+import { showConfirmDialog } from './utils.js';
+
+const wearableDetailRuntimeDeps = { showConfirmDialog };
+
+export function configureWearableDetailRuntimeDeps(deps = {}) {
+  const previous = { ...wearableDetailRuntimeDeps };
+  if ('showConfirmDialog' in deps) {
+    wearableDetailRuntimeDeps.showConfirmDialog = typeof deps.showConfirmDialog === 'function'
+      ? /** @type {typeof showConfirmDialog} */ (deps.showConfirmDialog)
+      : null;
+  }
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -47,6 +61,6 @@ export function closeWearableDetailModalRuntime() {
 
 /** @param {string} message */
 export async function confirmWearableDetailActionRuntime(message) {
-  const confirm = getRuntimeFunction('showConfirmDialog');
+  const confirm = wearableDetailRuntimeDeps.showConfirmDialog;
   return confirm ? !!await confirm(message) : false;
 }

--- a/js/wearables-settings-runtime.js
+++ b/js/wearables-settings-runtime.js
@@ -1,6 +1,20 @@
 // @ts-check
 // wearables-settings-runtime.js - Browser runtime adapters for wearable settings hooks.
 
+import { showConfirmDialog } from './utils.js';
+
+const wearableSettingsRuntimeDeps = { showConfirmDialog };
+
+export function configureWearableSettingsRuntimeDeps(deps = {}) {
+  const previous = { ...wearableSettingsRuntimeDeps };
+  if ('showConfirmDialog' in deps) {
+    wearableSettingsRuntimeDeps.showConfirmDialog = typeof deps.showConfirmDialog === 'function'
+      ? /** @type {typeof showConfirmDialog} */ (deps.showConfirmDialog)
+      : null;
+  }
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -26,7 +40,7 @@ export function navigateWearablesDashboard() {
 
 /** @param {string} message */
 export async function confirmWearableSettingsAction(message) {
-  const confirm = getRuntimeFunction('showConfirmDialog');
+  const confirm = wearableSettingsRuntimeDeps.showConfirmDialog;
   return confirm ? !!await confirm(message) : false;
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 9,
-  "legacyWindowGlobalAssignments": 7,
+  "windowGlobalAssignments": 8,
+  "legacyWindowGlobalAssignments": 6,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/client-list-runtime.test.js
+++ b/tests/client-list-runtime.test.js
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { state } from '../js/state.js';
+import { configureClientListRuntimeDeps } from '../js/client-list-runtime.js';
 
 let importId = 0;
 
@@ -43,6 +44,7 @@ beforeEach(() => {
   globalThis.requestAnimationFrame = window.requestAnimationFrame;
   window.renderProfileButton = vi.fn();
   window.showNotification = vi.fn();
+  configureClientListRuntimeDeps({ showNotification: window.showNotification });
   window.exportAllDataJSON = vi.fn();
   window.exportClientJSON = vi.fn();
   window.importDataJSON = vi.fn();
@@ -65,6 +67,7 @@ describe('client list runtime behavior', () => {
     const showNotificationSpy = vi.fn();
     window.renderProfileButton = renderProfileButtonSpy;
     window.showNotification = showNotificationSpy;
+    configureClientListRuntimeDeps({ showNotification: showNotificationSpy });
     const topLevelNames = () => [...document.querySelectorAll('.cl-list > .cl-row .cl-row-name')].map(el => el.textContent);
 
     clientList.openClientList();

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -927,10 +927,14 @@ test('sync diagnose action helpers cover guarded UI branches', async ({ page }) 
     const cutoverActions = await import(cutoverUrl);
     const relayActions = await import(relayUrl);
     const actionContext = await import('/js/sync-diagnose-actions-context.js');
+    const confirmRuntime = await import('/js/sync-diagnose-runtime.js');
     const relayHealth = await import('/js/sync-relay-health.js');
     const state = window._labState;
     const outcomes = {};
-    const originalShowConfirm = window.showConfirmDialog;
+    let confirmAnswer = false;
+    const originalConfirmDeps = confirmRuntime.configureSyncDiagnoseRuntimeDeps({
+      showConfirmDialog: async () => confirmAnswer,
+    });
     const originalFetch = window.fetch;
     const hadBip39 = Object.prototype.hasOwnProperty.call(window, 'bip39');
     const originalBip39 = window.bip39;
@@ -953,7 +957,7 @@ test('sync diagnose action helpers cover guarded UI branches', async ({ page }) 
     }
 
     try {
-      window.showConfirmDialog = async () => false;
+      confirmAnswer = false;
       await identityActions.confirmRotateIdentity();
       outcomes.rotateCancelStopsBeforeModal = !document.querySelector('[aria-label="Rotate sync identity"]');
 
@@ -974,7 +978,7 @@ test('sync diagnose action helpers cover guarded UI branches', async ({ page }) 
         disablePhase2Cutover: () => false,
         showSyncDiagnose: async () => {},
       });
-      window.showConfirmDialog = async () => true;
+      confirmAnswer = true;
       window.bip39 = { generateMnemonic: async () => mnemonic };
       window.qrcode = function fakeQRCode() {
         return {
@@ -1028,7 +1032,7 @@ test('sync diagnose action helpers cover guarded UI branches', async ({ page }) 
         },
         showSyncDiagnose: async () => { showDiagnoseCalls++; },
       });
-      window.showConfirmDialog = async () => true;
+      confirmAnswer = true;
 
       const resetModal = makeModalButton('Reset window');
       await cutoverActions.confirmResetDeltaTelemetry(resetModal.btn);
@@ -1072,14 +1076,14 @@ test('sync diagnose action helpers cover guarded UI branches', async ({ page }) 
         return { ok: false, status: 404, json: async () => ({}) };
       };
 
-      window.showConfirmDialog = async () => false;
+      confirmAnswer = false;
       const compactCancel = makeModalButton('Compact storage');
       await relayActions.confirmCompactRelay(compactCancel.btn);
       outcomes.compactCancelSkipsFetch = fetchCalls.length === 0
         && compactCancel.btn.disabled === false;
       compactCancel.overlay.remove();
 
-      window.showConfirmDialog = async () => true;
+      confirmAnswer = true;
       const compactModal = makeModalButton('Compact storage');
       await relayActions.confirmCompactRelay(compactModal.btn);
       outcomes.compactRelayPostsAndCloses = fetchCalls.some(call => call.method === 'POST'
@@ -1092,7 +1096,7 @@ test('sync diagnose action helpers cover guarded UI branches', async ({ page }) 
         && !document.body.contains(refreshModal.overlay)
         && showDiagnoseCalls === 1;
     } finally {
-      window.showConfirmDialog = originalShowConfirm;
+      confirmRuntime.configureSyncDiagnoseRuntimeDeps(originalConfirmDeps);
       window.fetch = originalFetch;
       if (hadBip39) window.bip39 = originalBip39;
       else delete window.bip39;

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -273,8 +273,12 @@ test('client list form live actions cover health link avatar haplogroup and loca
 
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
+    const clientListRuntime = await import('/js/client-list-runtime.js');
     const outcomes = {};
     const calls = [];
+    const previousClientListRuntimeDeps = clientListRuntime.configureClientListRuntimeDeps({
+      showNotification: (...args) => calls.push(['notification', ...args]),
+    });
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 60; attempt += 1) {
@@ -293,7 +297,6 @@ test('client list form live actions cover health link avatar haplogroup and loca
       storage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
       bodyOverflow: document.body.style.overflow,
       renderProfileButton: window.renderProfileButton,
-      showNotification: window.showNotification,
       navigate: window.navigate,
       HAPLOGROUP_LIST: window.HAPLOGROUP_LIST,
       setManualHaplogroup: window.setManualHaplogroup,
@@ -331,7 +334,6 @@ test('client list form live actions cover health link avatar haplogroup and loca
       localStorage.removeItem('labcharts-ai-paused');
       localStorage.removeItem('labcharts-openrouter-key');
       window.renderProfileButton = () => calls.push(['render-profile-button']);
-      window.showNotification = (...args) => calls.push(['notification', ...args]);
       window.navigate = route => calls.push(['navigate', route]);
       window.HAPLOGROUP_LIST = ['H', 'J', 'K'];
       window.setManualHaplogroup = async haplogroup => {
@@ -408,7 +410,7 @@ test('client list form live actions cover health link avatar haplogroup and loca
         else localStorage.setItem(key, value);
       }
       window.renderProfileButton = saved.renderProfileButton;
-      window.showNotification = saved.showNotification;
+      clientListRuntime.configureClientListRuntimeDeps(previousClientListRuntimeDeps);
       window.navigate = saved.navigate;
       window.HAPLOGROUP_LIST = saved.HAPLOGROUP_LIST;
       window.setManualHaplogroup = saved.setManualHaplogroup;

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -57,9 +57,10 @@ test('category customization covers rename icon and emoji picker browser paths',
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ categoryUrl }) => {
-    const [{ state }, category] = await Promise.all([
+    const [{ state }, category, categoryRuntime] = await Promise.all([
       import('/js/state.js'),
       import(categoryUrl),
+      import('/js/category-customization-runtime.js'),
     ]);
     const categorySrc = await fetch(categoryUrl).then(response => response.text());
     const outcomes = {};
@@ -68,11 +69,14 @@ test('category customization covers rename icon and emoji picker browser paths',
     const saved = {
       importedData: clone(state.importedData),
       currentView: state.currentView,
-      prompt: window.showPromptDialog,
       buildSidebar: window.buildSidebar,
       navigate: window.navigate,
     };
     const calls = [];
+    let promptValue = null;
+    const previousCategoryRuntimeDeps = categoryRuntime.configureCategoryCustomizationRuntimeDeps({
+      showPromptDialog: async () => promptValue,
+    });
 
     try {
       const demo = await fetch('data/demo-male.json').then(r => r.json());
@@ -94,7 +98,7 @@ test('category customization covers rename icon and emoji picker browser paths',
       window.navigate = (route, data) => calls.push(['navigate', route, !!data?.categories?.lipids]);
       window.buildSidebar = data => calls.push(['fallbackSidebar', !!data?.categories?.lipids]);
 
-      window.showPromptDialog = async () => '  Fallback Lipids  ';
+      promptValue = '  Fallback Lipids  ';
       await category.renameCategory('lipids');
       outcomes.renameCategoryKeepsSidebarFallback = state.importedData.categoryLabels?.lipids === 'Fallback Lipids'
         && calls.some(call => call[0] === 'fallbackSidebar' && call[1] === true);
@@ -104,7 +108,7 @@ test('category customization covers rename icon and emoji picker browser paths',
         navigate: window.navigate,
       });
 
-      window.showPromptDialog = async () => '  Better Lipids  ';
+      promptValue = '  Better Lipids  ';
       await category.renameCategory('lipids');
       outcomes.renameCategoryStoresTrimmedLabel = state.importedData.categoryLabels?.lipids === 'Better Lipids';
       outcomes.renameCategoryUpdatesCustomMarkerLabel = state.importedData.customMarkers['lipids.contextCustom']?.categoryLabel === 'Better Lipids';
@@ -119,7 +123,7 @@ test('category customization covers rename icon and emoji picker browser paths',
         && !/\bwindow(?:\.|\s*\[)/.test(categorySrc);
       outcomes.renameMissingCategoryNoops = await category.renameCategory('missing-category') === undefined;
 
-      window.showPromptDialog = async () => '  ApoB Better Name  ';
+      promptValue = '  ApoB Better Name  ';
       await category.renameMarker('lipids_apoB');
       outcomes.renameMarkerStoresDotKeyLabel = state.importedData.markerLabels?.['lipids.apoB'] === 'ApoB Better Name';
       category.revertMarkerName('lipids_apoB');
@@ -184,7 +188,7 @@ test('category customization covers rename icon and emoji picker browser paths',
     } finally {
       state.importedData = saved.importedData;
       state.currentView = saved.currentView;
-      window.showPromptDialog = saved.prompt;
+      categoryRuntime.configureCategoryCustomizationRuntimeDeps(previousCategoryRuntimeDeps);
       window.buildSidebar = saved.buildSidebar;
       window.navigate = saved.navigate;
       category.configureCategoryCustomization({

--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -18,6 +18,7 @@ test('import file input and drop zone route browser file types and busy states',
     let importRunning = false;
     const previousDropZoneRuntimeDeps = dropZoneRuntime.configureImportDropZoneRuntimeDeps({
       isImportRunning: () => importRunning,
+      showNotification: (message, type) => { calls.push(['notify', type, message]); },
     });
     const originals = {
       importDataJSON: window.importDataJSON,
@@ -25,7 +26,6 @@ test('import file input and drop zone route browser file types and busy states',
       detectDNAFile: window.detectDNAFile,
       handleMtDNAFile: window.handleMtDNAFile,
       handleDNAFile: window.handleDNAFile,
-      showNotification: window.showNotification,
     };
     const input = document.getElementById('pdf-input');
     const originalDropZone = document.getElementById('drop-zone');
@@ -59,7 +59,6 @@ test('import file input and drop zone route browser file types and busy states',
       window.detectDNAFile = header => header.includes('MTDNA') ? 'mtdna' : 'autosomal';
       window.handleMtDNAFile = async file => { calls.push(['mtdna', file.name]); };
       window.handleDNAFile = async file => { calls.push(['dna', file.name]); };
-      window.showNotification = (message, type) => { calls.push(['notify', type, message]); };
 
       importRunning = true;
       setInputFiles(new File(['{"ok":true}'], 'busy.json', { type: 'application/json' }));

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -790,6 +790,7 @@ test('light devices cover session detail edit log active card and rendered list 
 
   const results = await page.evaluate(async ({ devicesUrl, silhouetteUrl }) => {
     const lightDevices = await import(devicesUrl);
+    const lightDevicesRuntime = await import('/js/light-devices-runtime.js');
     const silhouette = await import(silhouetteUrl);
     const { profileStorageKey } = await import('/js/profile.js');
     const blobStorage = await import('/js/blob-storage.js');
@@ -807,12 +808,14 @@ test('light devices cover session detail edit log active card and rendered list 
       _openChannelOnLightPage: window._openChannelOnLightPage,
       loadCatalog: window.loadCatalog,
       renderLightDeviceAffiliateRow: window.renderLightDeviceAffiliateRow,
-      showPromptDialog: window.showPromptDialog,
       navigate: window.navigate,
       renderBodySilhouette: window.renderBodySilhouette,
       bindBodySilhouette: window.bindBodySilhouette,
     };
     const calls = [];
+    const previousLightDevicesRuntimeDeps = lightDevicesRuntime.configureLightDevicesRuntimeDeps({
+      showPromptDialog: async () => '17',
+    });
 
     try {
       state.currentView = 'light';
@@ -876,7 +879,6 @@ test('light devices cover session detail edit log active card and rendered list 
       });
       window.loadCatalog = async () => ({ items: [] });
       window.renderLightDeviceAffiliateRow = (_catalog, slug) => `<a class="affiliate-test">${slug}</a>`;
-      window.showPromptDialog = async () => '17';
       window.navigate = route => calls.push(['navigate', route]);
       window.renderBodySilhouette = silhouette.renderBodySilhouette;
       window.bindBodySilhouette = silhouette.bindBodySilhouette;
@@ -964,6 +966,7 @@ test('light devices cover session detail edit log active card and rendered list 
       if (originalImportedLocalValue == null) localStorage.removeItem(importedStorageKey);
       else localStorage.setItem(importedStorageKey, originalImportedLocalValue);
       lightDevices.configureLightDevices({ renderDeviceSessionAIDetail: () => '' });
+      lightDevicesRuntime.configureLightDevicesRuntimeDeps(previousLightDevicesRuntimeDeps);
       Object.assign(window, savedWindow);
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -402,9 +402,6 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
     window.navigate = view => {
       window.__startupUICalls.push(['navigate', view]);
     };
-    window.maybeShowAnalyticsConsent = () => {
-      window.__startupUICalls.push('maybeShowAnalyticsConsent');
-    };
     window.openSettingsModal = section => {
       window.__startupUICalls.push(['openSettingsModal', section]);
     };
@@ -443,6 +440,11 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
 
     try {
       const startupUi = await import(startupUiUrl);
+      startupUi.configureStartupUIDeps({
+        maybeShowAnalyticsConsent: () => {
+          window.__startupUICalls.push('maybeShowAnalyticsConsent');
+        },
+      });
       startupUi.renderStartupUI();
       const deferredWorkCompleted = await waitUntil(() => window.__startupUICalls
         .filter(call => call === 'renderSyncIndicator').length >= 2);

--- a/tests/playwright/startup-oauth-browser-coverage.spec.js
+++ b/tests/playwright/startup-oauth-browser-coverage.spec.js
@@ -33,7 +33,6 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     const savedLocal = snapshotStorage(localStorage);
     const savedSession = snapshotStorage(sessionStorage);
     const originalFetch = window.fetch;
-    const originalShowNotification = window.showNotification;
     const originalBalanceDialog = window.showInsufficientBalanceDialog;
     const originalSetTimeout = window.setTimeout;
     const originalReplaceState = history.replaceState;
@@ -49,6 +48,11 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     let replaceCalls = [];
     let balanceDialogs = 0;
     let fakeWearableCompletes = 0;
+    const originalStartupOAuthDeps = startup.configureStartupOAuthCallbackDeps({
+      showNotification: (message, type, duration) => {
+        notifications.push({ message: String(message), type, duration });
+      },
+    });
 
     const resetCase = (query = '') => {
       localStorage.clear();
@@ -66,9 +70,6 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     try {
       window.updateChatHeaderModel = () => {};
       window.refreshWebSearchToggle = () => {};
-      window.showNotification = (message, type, duration) => {
-        notifications.push({ message: String(message), type, duration });
-      };
       window.showInsufficientBalanceDialog = () => {
         balanceDialogs += 1;
       };
@@ -263,7 +264,7 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
         && replaceCalls.length === 0;
     } finally {
       window.fetch = originalFetch;
-      window.showNotification = originalShowNotification;
+      startup.configureStartupOAuthCallbackDeps(originalStartupOAuthDeps);
       window.showInsufficientBalanceDialog = originalBalanceDialog;
       window.setTimeout = originalSetTimeout;
       history.replaceState = originalReplaceState;

--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -579,13 +579,21 @@ test('sync identity rotation modal covers cancel copy malformed and apply paths'
   const results = await page.evaluate(async ({ identityUrl }) => {
     // The cache-busted identity module statically imports this canonical
     // singleton, so configuring it here injects deps into that fresh instance.
-    const [identityActions, context] = await Promise.all([
+    const [identityActions, context, confirmRuntime] = await Promise.all([
       import(identityUrl),
       import('/js/sync-diagnose-actions-context.js'),
+      import('/js/sync-diagnose-runtime.js'),
     ]);
     const outcomes = {};
     const calls = [];
     const copied = [];
+    let confirmAnswer = false;
+    const previousConfirmDeps = confirmRuntime.configureSyncDiagnoseRuntimeDeps({
+      showConfirmDialog: async message => {
+        calls.push(['confirm', message]);
+        return confirmAnswer;
+      },
+    });
     const words = Array.from({ length: 24 }, (_, index) => `word${index + 1}`).join(' ');
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 60; attempt += 1) {
@@ -595,22 +603,18 @@ test('sync identity rotation modal covers cancel copy malformed and apply paths'
       throw new Error(`Timed out waiting for ${label}`);
     };
     const saved = {
-      confirm: window.showConfirmDialog,
       bip39: window.bip39,
       qrcode: window.qrcode,
       clipboardOwn: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
     };
 
     try {
-      window.showConfirmDialog = async message => {
-        calls.push(['confirm', message]);
-        return false;
-      };
+      confirmAnswer = false;
       await identityActions.confirmRotateIdentity(document.body);
       outcomes.cancelStopsBeforeMnemonic = calls.some(call => call[0] === 'confirm')
         && !document.querySelector('[aria-label="Rotate sync identity"]');
 
-      window.showConfirmDialog = async () => true;
+      confirmAnswer = true;
       window.bip39 = { generateMnemonic: async () => 'too few words' };
       await identityActions.confirmRotateIdentity(document.body);
       outcomes.malformedMnemonicNotifies = Array.from(document.querySelectorAll('.notification-toast.error'))
@@ -675,7 +679,7 @@ test('sync identity rotation modal covers cancel copy malformed and apply paths'
         restoreFromMnemonic: async () => false,
         isSyncEnabled: () => false,
       });
-      window.showConfirmDialog = saved.confirm;
+      confirmRuntime.configureSyncDiagnoseRuntimeDeps(previousConfirmDeps);
       if (saved.bip39 === undefined) delete window.bip39;
       else window.bip39 = saved.bip39;
       if (saved.qrcode === undefined) delete window.qrcode;

--- a/tests/playwright/sync-diagnose-identity-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-diagnose-identity-actions-browser-coverage.spec.js
@@ -9,13 +9,13 @@ test('sync diagnose identity actions cover rotate modal and apply paths', async 
   await page.waitForSelector('body');
 
   const results = await page.evaluate(async ({ actionsUrl }) => {
-    const [actions, context] = await Promise.all([
+    const [actions, context, confirmRuntime] = await Promise.all([
       import(actionsUrl),
       import('/js/sync-diagnose-actions-context.js'),
+      import('/js/sync-diagnose-runtime.js'),
     ]);
     const outcomes = {};
     const saved = {
-      showConfirmDialog: window.showConfirmDialog,
       bip39: window.bip39,
       qrcode: window.qrcode,
       clipboard: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
@@ -41,6 +41,12 @@ test('sync diagnose identity actions cover rotate modal and apply paths', async 
     };
     const words = Array.from({ length: 24 }, (_, index) => `word${index + 1}`);
     let confirmResponses = [];
+    const previousConfirmDeps = confirmRuntime.configureSyncDiagnoseRuntimeDeps({
+      showConfirmDialog: async message => {
+        confirmMessages.push(String(message || ''));
+        return confirmResponses.length ? confirmResponses.shift() : true;
+      },
+    });
     let generatedBits = null;
     let qrData = null;
     let qrMade = false;
@@ -51,11 +57,6 @@ test('sync diagnose identity actions cover rotate modal and apply paths', async 
     try {
       document.querySelectorAll('.modal-overlay').forEach(overlay => overlay.remove());
       clearNotifications();
-      window.showConfirmDialog = async message => {
-        confirmMessages.push(String(message || ''));
-        return confirmResponses.length ? confirmResponses.shift() : true;
-      };
-
       confirmResponses = [false];
       await actions.confirmRotateIdentity();
       outcomes.warningCancelStopsBeforeMnemonic = confirmMessages[0]?.includes('Rotate sync identity') === true
@@ -181,7 +182,7 @@ test('sync diagnose identity actions cover rotate modal and apply paths', async 
         restoreFromMnemonic: async () => false,
         isSyncEnabled: () => false,
       });
-      window.showConfirmDialog = saved.showConfirmDialog;
+      confirmRuntime.configureSyncDiagnoseRuntimeDeps(previousConfirmDeps);
       if (saved.bip39 === undefined) delete window.bip39;
       else window.bip39 = saved.bip39;
       if (saved.qrcode === undefined) delete window.qrcode;

--- a/tests/playwright/wearables-settings-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-browser-coverage.spec.js
@@ -9,11 +9,12 @@ test('wearables settings browser coverage exercises import and connection action
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const failures = await page.evaluate(async ({ panelUrl, stateUrl, profileUrl, storeUrl, blobUrl }) => {
-    const [{ state }, { profileStorageKey }, store, blobStorage] = await Promise.all([
+    const [{ state }, { profileStorageKey }, store, blobStorage, settingsRuntime] = await Promise.all([
       import(stateUrl),
       import(profileUrl),
       import(storeUrl),
       import(blobUrl),
+      import('/js/wearables-settings-runtime.js'),
     ]);
     await import(panelUrl);
 
@@ -37,7 +38,7 @@ test('wearables settings browser coverage exercises import and connection action
     const originalImported = state.importedData;
     const originalNavigate = window.navigate;
     const originalCloseSettingsModal = window.closeSettingsModal;
-    const originalShowConfirmDialog = window.showConfirmDialog;
+    const originalSettingsRuntimeDeps = settingsRuntime.configureWearableSettingsRuntimeDeps();
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     const originalImportedLocalValue = localStorage.getItem(importedKey);
     const originalImportedBlobValue = await blobStorage.getBlob(importedKey);
@@ -165,7 +166,7 @@ test('wearables settings browser coverage exercises import and connection action
         date: '2026-06-02',
         weight: 80.2,
       });
-      window.showConfirmDialog = async () => true;
+      settingsRuntime.configureWearableSettingsRuntimeDeps({ showConfirmDialog: async () => true });
       await window.handleManualDisconnect();
       const manualRows = await store.countSource(profileId, 'manual');
       check('manual disconnect handler clears manual rows and connection',
@@ -187,8 +188,7 @@ test('wearables settings browser coverage exercises import and connection action
       else delete window.navigate;
       if (originalCloseSettingsModal) window.closeSettingsModal = originalCloseSettingsModal;
       else delete window.closeSettingsModal;
-      if (originalShowConfirmDialog) window.showConfirmDialog = originalShowConfirmDialog;
-      else delete window.showConfirmDialog;
+      settingsRuntime.configureWearableSettingsRuntimeDeps(originalSettingsRuntimeDeps);
       window.requestAnimationFrame = originalRequestAnimationFrame;
       document.querySelectorAll('#wearables-section,#wearable-strip,#confirm-dialog-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -219,10 +219,11 @@ test('wearables settings panel browser coverage deletes manual data after confir
       return false;
     };
 
-    const [{ state }, settings, store] = await Promise.all([
+    const [{ state }, settings, store, settingsRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/wearables-settings-panel.js'),
       import('/js/wearables-store.js'),
+      import('/js/wearables-settings-runtime.js'),
     ]);
 
     const profileId = `wearables-settings-delete-${Date.now()}`;
@@ -231,7 +232,7 @@ test('wearables settings panel browser coverage deletes manual data after confir
     const oldProfiles = state.profiles;
     const oldImportedData = state.importedData;
     const oldNavigate = window.navigate;
-    const oldShowConfirmDialog = window.showConfirmDialog;
+    const oldSettingsRuntimeDeps = settingsRuntime.configureWearableSettingsRuntimeDeps();
     const navigations = [];
     const confirmMessages = [];
 
@@ -278,10 +279,10 @@ test('wearables settings panel browser coverage deletes manual data after confir
       ]);
 
       window.navigate = route => { navigations.push(route); };
-      window.showConfirmDialog = async message => {
+      settingsRuntime.configureWearableSettingsRuntimeDeps({ showConfirmDialog: async message => {
         confirmMessages.push(message);
         return true;
-      };
+      } });
       document.body.insertAdjacentHTML('beforeend', `
         <section id="wearables-section">${settings.renderWearablesSettingsSection()}</section>
       `);
@@ -318,7 +319,7 @@ test('wearables settings panel browser coverage deletes manual data after confir
       state.profiles = oldProfiles;
       state.importedData = oldImportedData;
       window.navigate = oldNavigate;
-      window.showConfirmDialog = oldShowConfirmDialog;
+      settingsRuntime.configureWearableSettingsRuntimeDeps(oldSettingsRuntimeDeps);
     }
     return failures;
   });

--- a/tests/test-biology-scores-runtime.js
+++ b/tests/test-biology-scores-runtime.js
@@ -5,6 +5,7 @@ import './_node-shim.js';
 import { getCachedKey, updateKeyCache } from '../js/crypto.js';
 import {
   canOpenBiologyScoresChatPanel,
+  configureBiologyScoresRuntimeDeps,
   getBiologyScoresActiveData,
   hasBiologyScoresAIProvider,
   navigateBiologyScoresRoute,
@@ -14,6 +15,8 @@ import {
   showBiologyScoresNotification,
   useBiologyScoresChatPrompt,
 } from '../js/biology-scores-runtime.js';
+
+const originalBiologyScoresRuntimeDeps = configureBiologyScoresRuntimeDeps();
 
 let passed = 0;
 let failed = 0;
@@ -80,6 +83,9 @@ try {
     },
   };
   setRuntimeValue('window', browserRuntime);
+  configureBiologyScoresRuntimeDeps({
+    showNotification: browserRuntime.showNotification.bind(browserRuntime),
+  });
   localStorage.setItem('labcharts-ai-provider', 'openrouter');
   localStorage.removeItem('labcharts-ai-paused');
   localStorage.removeItem('labcharts-openrouter-key');
@@ -128,6 +134,7 @@ try {
       openBiologyScoreMarkerDetail('biochemistry_glucose') === false &&
       openBiologyScoresChatPanel() === false);
 } finally {
+  configureBiologyScoresRuntimeDeps(originalBiologyScoresRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-category-customization-runtime.js
+++ b/tests/test-category-customization-runtime.js
@@ -2,11 +2,14 @@
 
 import './_node-shim.js';
 import {
+  configureCategoryCustomizationRuntimeDeps,
   getCategoryCustomizationBuildSidebar,
   getCategoryCustomizationViewportSize,
   navigateCategoryCustomizationRuntime,
   showCategoryCustomizationPrompt,
 } from '../js/category-customization-runtime.js';
+
+const originalCategoryCustomizationRuntimeDeps = configureCategoryCustomizationRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -60,6 +63,9 @@ try {
     },
   };
   setRuntimeValue('window', browserRuntime);
+  configureCategoryCustomizationRuntimeDeps({
+    showPromptDialog: browserRuntime.showPromptDialog.bind(browserRuntime),
+  });
 
   navigateCategoryCustomizationRuntime('lipids', { category: 'lipids' });
   assert('navigateCategoryCustomizationRuntime delegates to browser navigate',
@@ -83,7 +89,7 @@ try {
 
   delete browserRuntime.navigate;
   delete browserRuntime.buildSidebar;
-  delete browserRuntime.showPromptDialog;
+  configureCategoryCustomizationRuntimeDeps({ showPromptDialog: null });
   delete browserRuntime.innerWidth;
   delete browserRuntime.innerHeight;
   navigateCategoryCustomizationRuntime('missing');
@@ -100,6 +106,7 @@ try {
   navigateCategoryCustomizationRuntime('dashboard');
   assert('runtime hooks fall back to globalThis when window is missing', globalNavigateCalled);
 } finally {
+  configureCategoryCustomizationRuntimeDeps(originalCategoryCustomizationRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -24,10 +24,9 @@ function assert(name, condition, detail) {
 
 console.log("=== What's New + Auto-Gating Tests ===\n");
 
-// utils.js exposes hasCardContent via Object.assign(window, ...).
 // changelog.js exposes openChangelog / closeChangelog / maybeShowChangelog.
 await import('../js/state.js');
-await import('../js/utils.js');
+const { hasCardContent } = await import('../js/utils.js');
 await import('../js/changelog.js');
 
 const changelogSrc = await fetchWithRetry('js/changelog.js');
@@ -199,14 +198,10 @@ assert("Settings has What's New button", settingsSrc.includes("What's New"));
 console.log('6. hasCardContent Utility');
 
 assert('hasCardContent exported from utils.js', utilsSrc.includes('export function hasCardContent'));
-assert('hasCardContent on window', typeof window.hasCardContent === 'function');
+assert('hasCardContent stays module-only', !('hasCardContent' in window));
 
-// Behavioral tests — pure-logic, run anywhere. Guard the call site so
-// that if `hasCardContent` ever fails to attach to window the rest of
-// the file still runs (the existence assertion above already records
-// the failure — without the guard, hcc(null) throws TypeError and
-// sections 7–12 silently skip).
-const hcc = window.hasCardContent;
+// Behavioral tests — pure logic through the module export.
+const hcc = hasCardContent;
 if (typeof hcc === 'function') {
   assert('hasCardContent(null) => false', hcc(null) === false);
   assert('hasCardContent(undefined) => false', hcc(undefined) === false);

--- a/tests/test-client-list-runtime.js
+++ b/tests/test-client-list-runtime.js
@@ -5,6 +5,7 @@ import './_node-shim.js';
 import { getCachedKey, updateKeyCache } from '../js/crypto.js';
 import {
   closeClientListFromRuntime,
+  configureClientListRuntimeDeps,
   getClientHaplogroupList,
   hasClientListAIProvider,
   navigateClientListRoute,
@@ -13,6 +14,8 @@ import {
   setClientManualHaplogroup,
   showClientListNotification,
 } from '../js/client-list-runtime.js';
+
+const originalClientListRuntimeDeps = configureClientListRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -81,7 +84,9 @@ try {
   assert('refreshClientProfileButton delegates to runtime profile refresh',
     calls.some(call => call[0] === 'render-profile-button'));
 
-  globalThis.showNotification = (message, type) => calls.push(['notification', message, type]);
+  configureClientListRuntimeDeps({
+    showNotification: (message, type) => calls.push(['notification', message, type]),
+  });
   showClientListNotification('"Ada" updated', 'info');
   assert('showClientListNotification delegates runtime notification',
     calls.some(call => call[0] === 'notification' && call[1] === '"Ada" updated' && call[2] === 'info'));
@@ -115,6 +120,7 @@ try {
   assert('publishClientListWindowBindings installs legacy globals',
     globalThis.__clientListRuntimeProbe?.() === 'ok');
 } finally {
+  configureClientListRuntimeDeps(originalClientListRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -258,7 +258,7 @@ assert('PDF lazy import failure notifies from drop zone',
   /try\s*{\s*importMod\s*=\s*await loadPdfImport\(\);[\s\S]{0,220}catch\s*\(err\)\s*{[\s\S]{0,220}Could not load import module - check your connection and try again\./.test(importDropZoneSrc),
   'drop-zone import path should fail loudly');
 assert('analytics consent remains deferred after first paint and behind legal gate',
-  /const showAnalyticsConsent = \(\) => \{\s*callStartupRuntime\('maybeShowAnalyticsConsent'\);\s*\};/.test(startupUiSrc)
+  /const showAnalyticsConsent = \(\) => \{\s*startupUIDeps\.maybeShowAnalyticsConsent\?\.\(\);\s*\};/.test(startupUiSrc)
   && /if \(legalGateShown\) \{\s*startupRuntime\(\)\.addEventListener\('legal-consent-accepted', \(\) => setTimeout\(showAnalyticsConsent, 800\), \{ once: true \}\);\s*\} else \{\s*setTimeout\(showAnalyticsConsent, 800\);\s*\}/.test(startupUiSrc),
   'first-run banner should stay deferred and must resume after Terms/Privacy acceptance');
 assert('legal gate runs before changelog and resumes changelog only after accept',

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -335,14 +335,15 @@ const expectedExports = [
   'openSettingsModal', 'closeSettingsModal',
   // chat.js
   'toggleChatPanel', 'closeChatPanel',
-  // utils.js
-  'showNotification', 'showConfirmDialog',
 ];
 for (const name of expectedExports) {
   assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
 }
 for (const name of ['getProfiles', 'saveProfiles', 'loadProfile', 'switchProfile', 'createProfile', 'deleteProfile', 'getProfileSex', 'setProfileSex', 'getProfileDob']) {
   assert(`profile.${name} exists`, typeof profileModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
+}
+for (const name of ['showNotification', 'showConfirmDialog', 'showPromptDialog', 'isDebugMode', 'setDebugMode', 'isPIIReviewEnabled', 'setPIIReviewEnabled', 'isAnalyticsEnabled', 'setAnalyticsEnabled', 'maybeShowAnalyticsConsent', 'dismissAnalyticsConsent', 'dismissAnalyticsConsentAndDisable', 'hasCardContent', 'escapeAttr', 'loadScriptOnce']) {
   assert(`window.${name} stays module-only`, !(name in window));
 }
 

--- a/tests/test-dna-runtime.js
+++ b/tests/test-dna-runtime.js
@@ -113,16 +113,16 @@ try {
   assert('getDnaProfileLatitudeBand reports null on runtime errors',
     getDnaProfileLatitudeBand() === null);
 
-  globalThis.showConfirmDialog = async message => {
+  configureDnaRuntimeDeps({ showConfirmDialog: async message => {
     calls.push(['confirm', message]);
     return true;
-  };
+  } });
   assert('confirmDnaDeleteDialog delegates confirmation',
     await confirmDnaDeleteDialog() === true &&
       calls.some(call => call[0] === 'confirm' && call[1].includes('Delete genetic data')));
-  globalThis.showConfirmDialog = async () => {
+  configureDnaRuntimeDeps({ showConfirmDialog: async () => {
     throw new Error('dialog failed');
-  };
+  } });
   assert('confirmDnaDeleteDialog reports false on dialog errors',
     await confirmDnaDeleteDialog() === false);
 
@@ -171,12 +171,12 @@ try {
   let warnLogged = false;
   console.error = () => { errorLogged = true; };
   console.warn = () => { warnLogged = true; };
-  globalThis.isDebugMode = () => false;
+  configureDnaRuntimeDeps({ isDebugMode: () => false });
   logDnaDebugError('hidden');
   logDnaDebugWarn('hidden');
   assert('debug logs are gated off when debug mode is false',
     !errorLogged && !warnLogged);
-  globalThis.isDebugMode = () => true;
+  configureDnaRuntimeDeps({ isDebugMode: () => true });
   logDnaDebugError('shown');
   logDnaDebugWarn('shown');
   assert('debug logs are emitted when debug mode is true',

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -73,7 +73,7 @@ assert('EMF editor close path preserves save and lightbox cleanup',
     emfSrc.includes('closeEMFModalRuntime();'));
 assert('EMF editor runtime hooks avoid counted direct window globals',
   emfSrc.includes("getEMFRuntimeFunction('closeModal')") &&
-    emfSrc.includes("getEMFRuntimeFunction('showPromptDialog')") &&
+    emfSrc.includes('return showPromptDialog(message, options);') &&
     !/\bwindow(?:\.|\s*\[)/.test(emfSrc));
 assert('EMF interpretation runtime hooks avoid counted direct window globals',
   emfInterpretationSrc.includes('function getEMFInterpretationRuntimeFunction') &&

--- a/tests/test-import-drop-zone-runtime.js
+++ b/tests/test-import-drop-zone-runtime.js
@@ -56,8 +56,10 @@ try {
   const dnaFile = new File(['dna'], 'genome.txt', { type: 'text/plain' });
   const picker = { click: () => calls.push(['picker']) };
 
-  configureImportDropZoneRuntimeDeps({ isImportRunning: () => true });
-  setRuntimeValue('showNotification', (message, type) => calls.push(['notify', type, message]));
+  configureImportDropZoneRuntimeDeps({
+    isImportRunning: () => true,
+    showNotification: (message, type) => calls.push(['notify', type, message]),
+  });
   setRuntimeValue('importDataJSON', file => calls.push(['json', file.name]));
   setRuntimeValue('detectDNAFile', header => header.includes('MT') ? 'mtdna' : 'autosomal');
   setRuntimeValue('handleMtDNAFile', file => calls.push(['mtdna', file.name]));

--- a/tests/test-light-devices-runtime.js
+++ b/tests/test-light-devices-runtime.js
@@ -4,6 +4,7 @@
 import './_node-shim.js';
 import { state } from '../js/state.js';
 import {
+  configureLightDevicesRuntimeDeps,
   deleteLightDeviceSessionFromRuntime,
   editLightDeviceSessionDurationFromRuntime,
   editLightDeviceSessionModeFromRuntime,
@@ -17,6 +18,8 @@ import {
   refreshLightDevicesView,
   renderLightDeviceAffiliateRowRuntime,
 } from '../js/light-devices-runtime.js';
+
+const originalLightDevicesRuntimeDeps = configureLightDevicesRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -69,17 +72,17 @@ try {
     calls.filter(call => call[0] === 'navigate' && call[1] === 'light').length === 2);
 
   let promptArgs = null;
-  globalThis.showPromptDialog = async (...args) => {
+  configureLightDevicesRuntimeDeps({ showPromptDialog: async (...args) => {
     promptArgs = args;
     return '17';
-  };
+  } });
   const raw = await promptLightDeviceSessionDuration(12);
   assert('promptLightDeviceSessionDuration delegates with duration defaults',
     raw === '17' &&
     promptArgs?.[0] === 'New duration (in minutes)' &&
     promptArgs?.[1]?.defaultValue === '12' &&
     promptArgs?.[1]?.okLabel === 'Save');
-  delete globalThis.showPromptDialog;
+  configureLightDevicesRuntimeDeps({ showPromptDialog: null });
   assert('promptLightDeviceSessionDuration returns undefined when prompt hook is missing',
     await promptLightDeviceSessionDuration(3) === undefined);
 
@@ -140,6 +143,7 @@ try {
   assert('publishLightDevicesWindowBindings installs legacy globals',
     globalThis.__lightRuntimeProbe?.() === 'ok');
 } finally {
+  configureLightDevicesRuntimeDeps(originalLightDevicesRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -617,9 +617,9 @@ const {
   assert('light-devices routes shell hooks through light-devices-runtime',
     lightDevicesSrc.includes("from './light-devices-runtime.js'") &&
     !/\bwindow\./.test(lightDevicesSrc));
-  assert('light-devices-runtime owns browser-shell hooks and legacy publication',
+  assert('light-devices-runtime owns browser-shell hooks and explicit utility dependency',
     lightDevicesRuntimeSrc.includes("getRuntimeFunction('navigate')") &&
-    lightDevicesRuntimeSrc.includes("getRuntimeFunction('showPromptDialog')") &&
+    lightDevicesRuntimeSrc.includes('lightDevicesRuntimeDeps.showPromptDialog') &&
     lightDevicesRuntimeSrc.includes("getRuntimeFunction('loadCatalog')") &&
     lightDevicesRuntimeSrc.includes('publishLightDevicesWindowBindings'));
 

--- a/tests/test-no-native-dialogs.js
+++ b/tests/test-no-native-dialogs.js
@@ -103,8 +103,8 @@ function main() {
   const utils = fs.readFileSync(path.join(JS_DIR, 'utils.js'), 'utf8');
   assert('utils.js exports showPromptDialog',
     /export function showPromptDialog/.test(utils));
-  assert('showPromptDialog is exposed on window',
-    /Object\.assign\(window,[^)]*showPromptDialog/.test(utils));
+  assert('showPromptDialog stays module-only',
+    !/Object\.assign\(window,[^)]*showPromptDialog/.test(utils));
 
   console.log(`\nTotal: ${passed} passed, ${failed} failed.`);
   process.exit(failed > 0 ? 1 : 0);

--- a/tests/test-sun-runtime.js
+++ b/tests/test-sun-runtime.js
@@ -4,6 +4,7 @@
 import './_node-shim.js';
 import {
   addSunProfileSwitchListener,
+  configureSunRuntimeDeps,
   exposeSunRuntimeBindings,
   getSunDeviceSessionsRuntime,
   hasSunBrowserRuntime,
@@ -16,6 +17,8 @@ import {
   renderLightTodayStripRuntime,
   requestSunGeolocationPositionRuntime,
 } from '../js/sun-runtime.js';
+
+const originalSunRuntimeDeps = configureSunRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -68,7 +71,7 @@ try {
   setRuntimeValue('_openChannelOnLightPage', channel => calls.push(['channel', channel]));
   const profileListener = () => calls.push(['profile-switch']);
   setRuntimeValue('addEventListener', (type, listener) => calls.push(['listener', type, listener]));
-  setRuntimeValue('isDebugMode', () => true);
+  configureSunRuntimeDeps({ isDebugMode: () => true });
 
   assert('hasSunBrowserRuntime detects browser runtime',
     hasSunBrowserRuntime() === true);
@@ -117,7 +120,7 @@ try {
   setRuntimeValue('navigate', () => { throw new Error('boom'); });
   setRuntimeValue('renderLightChannelsLive', () => { throw new Error('boom'); });
   setRuntimeValue('_openChannelOnLightPage', () => { throw new Error('boom'); });
-  setRuntimeValue('isDebugMode', () => { throw new Error('boom'); });
+  configureSunRuntimeDeps({ isDebugMode: () => { throw new Error('boom'); } });
   rebuildSunSidebarRuntime();
   navigateSunRuntime('dashboard');
   renderLightChannelsLiveRuntime();
@@ -153,6 +156,7 @@ try {
     calls.length === beforeNoWindowCalls &&
     globalThis.sunRuntimeProbe === probe);
 } finally {
+  configureSunRuntimeDeps(originalSunRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-sync-diagnose-runtime.js
+++ b/tests/test-sync-diagnose-runtime.js
@@ -5,7 +5,12 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import './_node-shim.js';
-import { confirmSyncDiagnoseActionRuntime } from '../js/sync-diagnose-runtime.js';
+import {
+  configureSyncDiagnoseRuntimeDeps,
+  confirmSyncDiagnoseActionRuntime,
+} from '../js/sync-diagnose-runtime.js';
+
+const originalSyncDiagnoseRuntimeDeps = configureSyncDiagnoseRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -38,17 +43,17 @@ function restoreRuntime() {
 try {
   const calls = [];
   setRuntimeValue('window', globalThis);
-  setRuntimeValue('showConfirmDialog', async message => {
+  configureSyncDiagnoseRuntimeDeps({ showConfirmDialog: async message => {
     calls.push(message);
     return message === 'confirm';
-  });
+  } });
 
   const confirmed = await confirmSyncDiagnoseActionRuntime('confirm');
   const cancelled = await confirmSyncDiagnoseActionRuntime('cancel');
   assert('sync diagnose runtime delegates confirm dialog',
     confirmed === true && cancelled === false && calls.join('|') === 'confirm|cancel');
 
-  delete globalThis.showConfirmDialog;
+  configureSyncDiagnoseRuntimeDeps({ showConfirmDialog: null });
   const defaultFallback = await confirmSyncDiagnoseActionRuntime('missing');
   const explicitFallback = await confirmSyncDiagnoseActionRuntime('missing', { fallback: false });
   assert('sync diagnose runtime preserves missing-confirm fallback',
@@ -73,6 +78,7 @@ try {
       !/\bwindow(?:\.|\s*\[)/.test(identitySrc) &&
       swSrc.includes("'/js/sync-diagnose-runtime.js'"));
 } finally {
+  configureSyncDiagnoseRuntimeDeps(originalSyncDiagnoseRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-wearables-detail-runtime.js
+++ b/tests/test-wearables-detail-runtime.js
@@ -7,12 +7,15 @@ import { fileURLToPath } from 'url';
 import './_node-shim.js';
 import {
   closeWearableDetailModalRuntime,
+  configureWearableDetailRuntimeDeps,
   confirmWearableDetailActionRuntime,
   createWearableDetailChartRuntime,
   hasWearableDetailChartRuntime,
   navigateWearableDetailRuntime,
   rememberWearableDetailModalTriggerRuntime,
 } from '../js/wearables-detail-runtime.js';
+
+const originalWearableDetailRuntimeDeps = configureWearableDetailRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -48,10 +51,10 @@ try {
   setRuntimeValue('rememberModalTrigger', () => calls.push(['remember']));
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
   setRuntimeValue('closeModal', () => calls.push(['close']));
-  setRuntimeValue('showConfirmDialog', async message => {
+  configureWearableDetailRuntimeDeps({ showConfirmDialog: async message => {
     calls.push(['confirm', message]);
     return message === 'delete';
-  });
+  } });
   setRuntimeValue('Chart', function Chart(canvas, config) {
     this.canvas = canvas;
     this.config = config;
@@ -78,7 +81,7 @@ try {
       chart?.config?.type === 'line' &&
       calls.some(call => call.join('|') === 'chart|chart-modal|line'));
 
-  delete globalThis.showConfirmDialog;
+  configureWearableDetailRuntimeDeps({ showConfirmDialog: null });
   delete globalThis.Chart;
   const missingConfirm = await confirmWearableDetailActionRuntime('delete');
   const missingChart = createWearableDetailChartRuntime({ id: 'chart-modal' }, { type: 'line' });
@@ -107,6 +110,7 @@ try {
       !/\bwindow(?:\.|\s*\[)/.test(detailSrc) &&
       swSrc.includes("'/js/wearables-detail-runtime.js'"));
 } finally {
+  configureWearableDetailRuntimeDeps(originalWearableDetailRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-wearables-settings-runtime.js
+++ b/tests/test-wearables-settings-runtime.js
@@ -4,10 +4,13 @@
 import './_node-shim.js';
 import {
   closeWearableSettingsModal,
+  configureWearableSettingsRuntimeDeps,
   confirmWearableSettingsAction,
   exposeWearableSettingsBindings,
   navigateWearablesDashboard,
 } from '../js/wearables-settings-runtime.js';
+
+const originalWearableSettingsRuntimeDeps = configureWearableSettingsRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -41,10 +44,10 @@ try {
   const calls = [];
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
   setRuntimeValue('closeSettingsModal', () => calls.push(['close-settings']));
-  setRuntimeValue('showConfirmDialog', async message => {
+  configureWearableSettingsRuntimeDeps({ showConfirmDialog: async message => {
     calls.push(['confirm', message]);
     return message === 'confirm me';
-  });
+  } });
 
   navigateWearablesDashboard();
   closeWearableSettingsModal();
@@ -62,6 +65,7 @@ try {
     globalThis.wearableProbe === probe);
 
   delete globalThis.window;
+  configureWearableSettingsRuntimeDeps({ showConfirmDialog: null });
   navigateWearablesDashboard();
   closeWearableSettingsModal();
   const missingConfirm = await confirmWearableSettingsAction('confirm me');
@@ -69,6 +73,7 @@ try {
   assert('runtime adapter no-ops safely when window is missing',
     !missingConfirm && globalThis.wearableProbe === probe);
 } finally {
+  configureWearableSettingsRuntimeDeps(originalWearableSettingsRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -188,7 +188,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule] = await Promise.all([
+  const [apiModule, backupModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/charts.js'),
@@ -206,6 +206,7 @@
     import('../js/sun-context.js'),
     import('../js/sun-spectrum.js'),
     import('../js/supplements.js'),
+    import('../js/utils.js'),
   ]);
   const apiExports = [
     'getVeniceKey','saveVeniceKey','hasVeniceKey',
@@ -553,9 +554,13 @@
     'getChartColors'
   ];
 
-  // utils.js (2)
+  // utils.js (15 former browser globals, now module-only)
   const utilsExports = [
-    'showNotification','showConfirmDialog'
+    'showNotification','showConfirmDialog','showPromptDialog',
+    'isDebugMode','setDebugMode','isPIIReviewEnabled','setPIIReviewEnabled',
+    'isAnalyticsEnabled','setAnalyticsEnabled','maybeShowAnalyticsConsent',
+    'dismissAnalyticsConsent','dismissAnalyticsConsentAndDisable',
+    'hasCardContent','escapeAttr','loadScriptOnce'
   ];
 
   // views.js (36 — closeImportModal removed, lives in pdf-import.js)
@@ -598,6 +603,7 @@
     ['sun-context.js', sunContextModule, sunContextExports],
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
     ['supplements.js', supplementsModule, supplementsExports],
+    ['utils.js', utilsModule, utilsExports],
   ]) {
     for (const name of exports) {
       const val = moduleApi[name];
@@ -642,6 +648,9 @@
   for (const name of sunSpectrumExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of utilsExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
 
   const allModules = {
     'chat.js': chatExports,
@@ -654,7 +663,6 @@
     'settings.js': settingsExports,
     'provider-panels.js': providerPanelsExports,
     'theme.js': themeExports,
-    'utils.js': utilsExports,
     'views.js': viewsExports,
   };
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.199';
+self.APP_VERSION = '1.10.200';


### PR DESCRIPTION
## Summary
- remove 15 shared utility functions from the global `window` surface
- wire runtime consumers through direct module imports and explicit dependency injection hooks
- add module-only regression coverage, lower the facade quality baseline to 8 total / 6 legacy assignments, and bump the app version to 1.10.200

## Tests
- `./run-tests.sh`
  - 123 module verification checks
  - 396 Vitest tests
  - 18 origin guard tests
  - 351 Playwright tests
  - 472 responsive/theme checks