### PR TITLE
Make export module-only

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -8,7 +8,7 @@ import { updateChatNudge } from './chat-nudge.js';
 import { closeSummaryModal } from './chat-summaries.js';
 import { closeClientList, configureClientListRuntime } from './client-list.js';
 import { closeEMFInterpretation } from './emf-interpretation.js';
-import { closeReportBuilder } from './export.js';
+import { clearAllData, closeReportBuilder } from './export.js';
 import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
 import { closeFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
@@ -29,6 +29,7 @@ configureClientListRuntime({
 });
 
 configureSettingsRuntime({
+  clearAllData,
   exportAllDataJSON,
   exportClientJSON,
   getActiveProfileId,

--- a/js/client-list.js
+++ b/js/client-list.js
@@ -39,7 +39,9 @@ const clientListRuntime = {
 
 /** @param {Partial<ClientListRuntime>} [runtime] */
 export function configureClientListRuntime(runtime = {}) {
+  const previous = { ...clientListRuntime };
   Object.assign(clientListRuntime, runtime);
+  return previous;
 }
 
 let _search = '';

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -16,8 +16,17 @@ import {
   getMobileDashboardCounts,
 } from './mobile-dashboard.js';
 import { startEmptyTour as defaultStartEmptyTour, startTour as defaultStartTour } from './tour.js';
+import { loadDemoData } from './export.js';
 
 let _dashboardWelcomeActionsInstalled = false;
+
+const dashboardPageRuntimeDeps = { loadDemoData };
+
+export function configureDashboardPageRuntimeDeps(deps = {}) {
+  const previous = { ...dashboardPageRuntimeDeps };
+  if (typeof deps.loadDemoData === 'function') dashboardPageRuntimeDeps.loadDemoData = deps.loadDemoData;
+  return previous;
+}
 
 const DASHBOARD_WELCOME_ACTION_ATTR = 'data-dashboard-welcome-action';
 const DASHBOARD_WELCOME_ACTION_SELECTOR = `[${DASHBOARD_WELCOME_ACTION_ATTR}]`;
@@ -68,7 +77,7 @@ function handleDashboardWelcomeActionClick(event) {
   } else if (action === 'direct-import') {
     document.getElementById('pdf-input')?.click();
   } else if (action === 'load-demo') {
-    appWindow.loadDemoData?.(actionEl.dataset.dashboardWelcomeDemo || 'female');
+    void dashboardPageRuntimeDeps.loadDemoData(actionEl.dataset.dashboardWelcomeDemo || 'female');
   } else {
     return;
   }

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -181,7 +181,3 @@ export async function refreshImportRuntimeShell(options = {}) {
   if (profileButton) renderProfileButton?.();
   navigate?.(route);
 }
-
-export function publishExportGlobals(api) {
-  Object.assign(getRuntimeWindow(), api);
-}

--- a/js/export.js
+++ b/js/export.js
@@ -25,7 +25,6 @@ import {
   destroyWalletRuntimeDB,
   getWalletBundleSettings,
   markDemoLoadingProfile,
-  publishExportGlobals,
   refreshImportRuntimeShell,
 } from './export-runtime.js';
 
@@ -552,5 +551,3 @@ export async function loadDemoData(sex = 'male') {
     showNotification('Could not load demo data: ' + err.message, 'error');
   }
 }
-
-publishExportGlobals({ openReportBuilder, closeReportBuilder, generateReportAISummary, exportPDFReport, exportDataJSON, exportClientJSON, exportAllDataJSON, buildAllDataBundle, importDataJSON, clearAllData, loadDemoData });

--- a/js/import-drop-zone-runtime.js
+++ b/js/import-drop-zone-runtime.js
@@ -3,11 +3,13 @@
 
 import { isImportRunning } from './pdf-import-progress.js';
 import { showNotification } from './utils.js';
+import { importDataJSON } from './export.js';
 
-const importDropZoneRuntimeDeps = { isImportRunning, showNotification };
+const importDropZoneRuntimeDeps = { importDataJSON, isImportRunning, showNotification };
 
 export function configureImportDropZoneRuntimeDeps(deps = {}) {
   const previous = { ...importDropZoneRuntimeDeps };
+  if (typeof deps.importDataJSON === 'function') importDropZoneRuntimeDeps.importDataJSON = deps.importDataJSON;
   if (typeof deps.isImportRunning === 'function') importDropZoneRuntimeDeps.isImportRunning = deps.isImportRunning;
   if ('showNotification' in deps) {
     importDropZoneRuntimeDeps.showNotification = typeof deps.showNotification === 'function'
@@ -68,7 +70,7 @@ export function showDropZoneImportNotification(message, type = 'info') {
 
 /** @param {File} file */
 export function importDropZoneJSONFile(file) {
-  return requireRuntimeFunction('importDataJSON')(file);
+  return importDropZoneRuntimeDeps.importDataJSON(file);
 }
 
 /** @param {string} header */

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -2,15 +2,20 @@
 // nav-runtime.js - Browser runtime hooks for sidebar navigation.
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
+import { openReportBuilder } from './export.js';
 
 const navRuntimeDeps = {
   openEMFAssessmentEditor,
+  openReportBuilder,
 };
 
 export function configureNavRuntime(deps = {}) {
   const previous = { ...navRuntimeDeps };
   if (typeof deps.openEMFAssessmentEditor === 'function') {
     navRuntimeDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
+  }
+  if (typeof deps.openReportBuilder === 'function') {
+    navRuntimeDeps.openReportBuilder = deps.openReportBuilder;
   }
   return previous;
 }
@@ -46,7 +51,7 @@ export function openEMFAssessmentFromNavRuntime() {
 }
 
 export function openReportBuilderFromNavRuntime() {
-  getNavRuntimeFunction('openReportBuilder')?.();
+  navRuntimeDeps.openReportBuilder();
 }
 
 export function openContextFromNavRuntime() {

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -8,6 +8,7 @@ import { hasAIProvider, getAIProvider, getActiveModelId, AI_IMPORT_REQUEST_TIMEO
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { getProfileLocation, getActiveProfileId } from './profile.js';
 import { maybeShowEncryptionNudge } from './crypto.js';
+import { importDataJSON, loadDemoData } from './export.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   callImportAIWithStreamFallback,
@@ -65,8 +66,6 @@ import {
 /**
  * @typedef {{
  *   openSettingsModal?: (tab?: string) => void,
- *   loadDemoData?: (sex?: string) => void,
- *   importDataJSON: (file: File) => void | Promise<void>,
  *   isDNAFile?: (file: File) => boolean,
  *   isDNAFileByContent?: (file: File) => Promise<boolean>,
  *   detectDNAFile?: (header: string) => string | null,
@@ -78,12 +77,16 @@ import {
 const pdfImportWindow = /** @type {Window & typeof globalThis & PdfImportWindowHooks} */ (window);
 
 const pdfImportDeps = {
+  importDataJSON,
+  loadDemoData,
   maybeShowEncryptionNudge,
   startOpenRouterOAuth,
 };
 
 export function configurePdfImportDeps(deps = {}) {
   const previous = { ...pdfImportDeps };
+  if (typeof deps.importDataJSON === 'function') pdfImportDeps.importDataJSON = deps.importDataJSON;
+  if (typeof deps.loadDemoData === 'function') pdfImportDeps.loadDemoData = deps.loadDemoData;
   if (typeof deps.maybeShowEncryptionNudge === 'function') pdfImportDeps.maybeShowEncryptionNudge = deps.maybeShowEncryptionNudge;
   if (typeof deps.startOpenRouterOAuth === 'function') pdfImportDeps.startOpenRouterOAuth = deps.startOpenRouterOAuth;
   return previous;
@@ -178,10 +181,8 @@ export function showAINeededDialog(action = 'import') {
   document.getElementById('ai-needed-key').onclick = () => { close(); if (pdfImportWindow.openSettingsModal) pdfImportWindow.openSettingsModal('ai'); };
   document.getElementById('ai-needed-demo').onclick = () => {
     close();
-    if (pdfImportWindow.loadDemoData) {
-      const sex = state.profileSex === 'female' ? 'female' : 'male';
-      pdfImportWindow.loadDemoData(sex);
-    }
+    const sex = state.profileSex === 'female' ? 'female' : 'male';
+    void pdfImportDeps.loadDemoData(sex);
   };
   document.getElementById('ai-needed-cancel').onclick = close;
   overlay.onclick = (e) => { if (e.target === overlay) close(); };
@@ -365,7 +366,7 @@ export function setupDropZone() {
       showNotification("Unsupported file type. Use PDF, Excel, text, image, JSON, DNA raw data, or an Apple Health, Drip, Natural Cycles, or Clue export.", "error");
       return;
     }
-    for (const f of jsonFiles) await pdfImportWindow.importDataJSON(f);
+    for (const f of jsonFiles) await pdfImportDeps.importDataJSON(f);
     if (cycleFiles.length > 0) { for (const f of cycleFiles) await handleCycleImportFile(f); }
     if (dnaFiles.length > 0) {
       for (const f of dnaFiles) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -49,6 +49,7 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
 
 /**
  * @typedef {{
+ *   clearAllData: () => Promise<void> | void,
  *   exportAllDataJSON: () => Promise<void> | void,
  *   exportClientJSON: (profileId?: string | null) => Promise<void> | void,
  *   getActiveProfileId: () => string | null,
@@ -58,8 +59,9 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
 
 /** @type {SettingsRuntime} */
 const settingsRuntime = {
-  exportAllDataJSON: () => settingsWindow.exportAllDataJSON?.(),
-  exportClientJSON: (profileId) => settingsWindow.exportClientJSON?.(profileId),
+  clearAllData: () => {},
+  exportAllDataJSON: () => {},
+  exportClientJSON: () => {},
   getActiveProfileId,
   openProfileShareModal: () => {},
 };
@@ -448,7 +450,7 @@ async function handleSettingsClick(event) {
     settingsRuntime.exportAllDataJSON();
   } else if (action === 'clear-all-data') {
     event.preventDefault();
-    settingsWindow.clearAllData?.();
+    settingsRuntime.clearAllData();
   } else if (action === 'reset-profile-usage') {
     event.preventDefault();
     resetCurrentProfileUsage();

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 7,
-  "legacyWindowGlobalAssignments": 5,
+  "windowGlobalAssignments": 8,
+  "legacyWindowGlobalAssignments": 6,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 8,
-  "legacyWindowGlobalAssignments": 6,
+  "windowGlobalAssignments": 7,
+  "legacyWindowGlobalAssignments": 5,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/client-list-runtime.test.js
+++ b/tests/client-list-runtime.test.js
@@ -45,10 +45,6 @@ beforeEach(() => {
   window.renderProfileButton = vi.fn();
   window.showNotification = vi.fn();
   configureClientListRuntimeDeps({ showNotification: window.showNotification });
-  window.exportAllDataJSON = vi.fn();
-  window.exportClientJSON = vi.fn();
-  window.importDataJSON = vi.fn();
-  window.loadDemoData = vi.fn();
   window.navigate = vi.fn();
   window.showConfirmDialog = vi.fn(async () => false);
   state.currentProfile = 'alice';

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -12,6 +12,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
     const calls = [];
     const confirmQueue = [];
     let previousProfileDeps = null;
+    let previousClientListRuntime = null;
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 60; attempt += 1) {
@@ -70,10 +71,6 @@ test('client list live menu actions dispatch exports share demos and profile sta
       bodyOverflow: document.body.style.overflow,
       storage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
       renderProfileButton: window.renderProfileButton,
-      exportAllDataJSON: window.exportAllDataJSON,
-      exportClientJSON: window.exportClientJSON,
-      importDataJSON: window.importDataJSON,
-      loadDemoData: window.loadDemoData,
       showConfirmDialog: window.showConfirmDialog,
       inputClick: HTMLInputElement.prototype.click,
     };
@@ -121,16 +118,16 @@ test('client list live menu actions dispatch exports share demos and profile sta
       localStorage.setItem('labcharts-client-bob-chat-threads', JSON.stringify([{ id: 'thread-a' }]));
       localStorage.setItem('labcharts-client-bob-chat-t_thread-a', JSON.stringify([{ role: 'user', content: 'delete me' }]));
       window.renderProfileButton = () => calls.push(['render-profile-button']);
-      window.exportAllDataJSON = () => calls.push(['export-all']);
-      window.exportClientJSON = (...args) => calls.push(['export-client', ...args]);
-      window.importDataJSON = file => calls.push(['import-json', file?.name || '']);
-      window.loadDemoData = demo => calls.push(['load-demo', demo]);
+      const exportAllDataJSON = () => calls.push(['export-all']);
+      const exportClientJSON = (...args) => calls.push(['export-client', ...args]);
+      const importDataJSON = file => calls.push(['import-json', file?.name || '']);
+      const loadDemoData = demo => calls.push(['load-demo', demo]);
       const openProfileShareModal = id => calls.push(['share-profile', id]);
-      configureClientListRuntime({
-        exportAllDataJSON: window.exportAllDataJSON,
-        exportClientJSON: window.exportClientJSON,
-        importDataJSON: window.importDataJSON,
-        loadDemoData: window.loadDemoData,
+      previousClientListRuntime = configureClientListRuntime({
+        exportAllDataJSON,
+        exportClientJSON,
+        importDataJSON,
+        loadDemoData,
         openProfileShareModal,
       });
       window.showConfirmDialog = async message => {
@@ -249,10 +246,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
         else localStorage.setItem(key, value);
       }
       window.renderProfileButton = saved.renderProfileButton;
-      window.exportAllDataJSON = saved.exportAllDataJSON;
-      window.exportClientJSON = saved.exportClientJSON;
-      window.importDataJSON = saved.importDataJSON;
-      window.loadDemoData = saved.loadDemoData;
+      if (previousClientListRuntime) configureClientListRuntime(previousClientListRuntime);
       window.showConfirmDialog = saved.showConfirmDialog;
       if (previousProfileDeps) profile.configureProfileDeps(previousProfileDeps);
       HTMLInputElement.prototype.click = saved.inputClick;

--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -17,11 +17,11 @@ test('import file input and drop zone route browser file types and busy states',
     const calls = [];
     let importRunning = false;
     const previousDropZoneRuntimeDeps = dropZoneRuntime.configureImportDropZoneRuntimeDeps({
+      importDataJSON: file => { calls.push(['json', file.name]); },
       isImportRunning: () => importRunning,
       showNotification: (message, type) => { calls.push(['notify', type, message]); },
     });
     const originals = {
-      importDataJSON: window.importDataJSON,
       isDNAFileByContent: window.isDNAFileByContent,
       detectDNAFile: window.detectDNAFile,
       handleMtDNAFile: window.handleMtDNAFile,
@@ -54,7 +54,6 @@ test('import file input and drop zone route browser file types and busy states',
     };
 
     try {
-      window.importDataJSON = file => { calls.push(['json', file.name]); };
       window.isDNAFileByContent = async file => (await file.text()).includes('MTDNA');
       window.detectDNAFile = header => header.includes('MTDNA') ? 'mtdna' : 'autosomal';
       window.handleMtDNAFile = async file => { calls.push(['mtdna', file.name]); };

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -34,7 +34,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     const origImportedData = state.importedData;
     const origProfiles = state.profiles;
     const origNavigate = window.navigate;
-    const origOpenReportBuilder = window.openReportBuilder;
     const origOpenContext = window.openContextModal;
     const origOpenCreateMarker = window.openCreateMarkerModal;
     const origOpenClientList = window.openClientList;
@@ -77,11 +76,11 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       };
       restoreNavRuntime = navRuntime.configureNavRuntime({
         openEMFAssessmentEditor: () => calls.push(['open-emf']),
+        openReportBuilder: () => calls.push(['open-report-builder']),
       });
       restoreNavActions = nav.configureNavActions({
         openLightEnvironmentAssessment: () => calls.push(['open-light-env']),
       });
-      window.openReportBuilder = () => calls.push(['open-report-builder']);
       window.openContextModal = () => calls.push(['open-context']);
       window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
       window.openClientList = () => calls.push(['open-client-list']);
@@ -147,7 +146,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       window.navigate = origNavigate;
       if (restoreNavRuntime) navRuntime.configureNavRuntime(restoreNavRuntime);
       if (restoreNavActions) nav.configureNavActions(restoreNavActions);
-      window.openReportBuilder = origOpenReportBuilder;
       window.openContextModal = origOpenContext;
       window.openCreateMarkerModal = origOpenCreateMarker;
       window.openClientList = origOpenClientList;

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -18,17 +18,16 @@ test('PDF import progress and AI-needed dialog cover browser UI states', async (
     const saved = {
       profileSex: state.profileSex,
       openSettingsModal: window.openSettingsModal,
-      loadDemoData: window.loadDemoData,
       navigate: window.navigate,
     };
     const calls = [];
     const previousPdfImportDeps = pdfImport.configurePdfImportDeps({
+      loadDemoData: sex => calls.push(['demo', sex]),
       startOpenRouterOAuth: () => calls.push(['oauth']),
     });
 
     try {
       window.openSettingsModal = tab => calls.push(['settings', tab]);
-      window.loadDemoData = sex => calls.push(['demo', sex]);
       window.navigate = view => calls.push(['navigate', view]);
       state.profileSex = 'female';
 
@@ -130,7 +129,6 @@ test('PDF import progress and AI-needed dialog cover browser UI states', async (
       state.profileSex = saved.profileSex;
       pdfImport.configurePdfImportDeps(previousPdfImportDeps);
       window.openSettingsModal = saved.openSettingsModal;
-      window.loadDemoData = saved.loadDemoData;
       window.navigate = saved.navigate;
       progress.hideImportProgress('cancel');
       document.getElementById('import-modal-overlay')?.classList.remove('show');

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -475,12 +475,12 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       openChatPanel: window.openChatPanel,
       closeChatPanel: window.closeChatPanel,
       openSettingsModal: window.openSettingsModal,
-      loadDemoData: window.loadDemoData,
       mainHtml: document.getElementById('main-content')?.innerHTML || '',
     };
     const calls = [];
     const outcomes = {};
     let hadPdfInput = false;
+    let previousDashboardPageRuntimeDeps = null;
 
     try {
       state.currentProfile = 'dashboard-welcome-delegates';
@@ -496,7 +496,9 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       window.openChatPanel = () => calls.push(['open-chat']);
       window.closeChatPanel = () => calls.push(['close-chat']);
       window.openSettingsModal = tab => calls.push(['settings', tab]);
-      window.loadDemoData = sex => calls.push(['demo', sex]);
+      previousDashboardPageRuntimeDeps = dashboardPage.configureDashboardPageRuntimeDeps({
+        loadDemoData: sex => calls.push(['demo', sex]),
+      });
 
       let pdfInput = document.getElementById('pdf-input');
       hadPdfInput = !!pdfInput;
@@ -571,11 +573,13 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       data.invalidateActiveDataCache();
       if (saved.demoLoadingProfileId === undefined) delete window._demoLoadingProfileId;
       else window._demoLoadingProfileId = saved.demoLoadingProfileId;
+      if (previousDashboardPageRuntimeDeps) {
+        dashboardPage.configureDashboardPageRuntimeDeps(previousDashboardPageRuntimeDeps);
+      }
       Object.assign(window, {
         openChatPanel: saved.openChatPanel,
         closeChatPanel: saved.closeChatPanel,
         openSettingsModal: saved.openSettingsModal,
-        loadDemoData: saved.loadDemoData,
       });
       document.body.classList.remove('empty-dashboard-active', 'chat-autostart-reserved');
       localStorage.clear();

--- a/tests/test-a11y-axe.js
+++ b/tests/test-a11y-axe.js
@@ -32,6 +32,7 @@ return (async () => {
   console.log('%c A11y (axe-core) ', 'background:#7c3aed;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
   const { state } = await import('/js/state.js');
+  const { loadDemoData } = await import('/js/export.js');
   // Capture full state shape so we can restore even if we mutate
   // currentProfile / importedData / markerRegistry / etc along the way.
   const snapshot = {
@@ -78,8 +79,8 @@ return (async () => {
     // async + side-effecty (creates a profile, switches to it); we wait
     // longer than feels necessary because subsequent renderViews assume
     // markerRegistry has been populated by buildSidebar.
-    if (!state.importedData?.entries?.length && typeof window.loadDemoData === 'function') {
-      try { await window.loadDemoData('male'); } catch (e) { note('loadDemoData failed: ' + e.message); }
+    if (!state.importedData?.entries?.length) {
+      try { await loadDemoData('male'); } catch (e) { note('loadDemoData failed: ' + e.message); }
       await new Promise(r => setTimeout(r, 3000));
     }
     if (!state.markerRegistry || Object.keys(state.markerRegistry).length === 0) {

--- a/tests/test-biometrics.js
+++ b/tests/test-biometrics.js
@@ -16,6 +16,7 @@ console.log('=== Biometrics Tests ===\n');
 await import('../js/state.js');
 const profile = await import('../js/profile.js');
 const labContext = await import('../js/lab-context.js');
+const exportModule = await import('../js/export.js');
 // Initialize profiles so getProfiles() / setProfileHeight() have something
 // to mutate. The Playwright environment runs main.js which seeds this.
 if (!window._labState.profiles) {
@@ -144,7 +145,7 @@ if (!window._labState.profiles) {
   // ═══════════════════════════════════════
   console.log('8. Export');
 
-  if (typeof window.exportClientJSON === 'function') {
+  if (typeof exportModule.exportClientJSON === 'function') {
     // Can't easily test the download, but verify the data is in importedData
     assert('biometrics in importedData', state.importedData.biometrics != null);
     assert('biometrics.weight has entries', state.importedData.biometrics.weight.length > 0);

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -50,7 +50,7 @@ const profileModule = await import('../js/profile.js');
 cryptoModule.configureCryptoProfileDeps({ migrateProfileData: profileModule.migrateProfileData });
 await import('../js/nav.js');
 await import('../js/views.js');
-await import('../js/export.js');
+const exportModule = await import('../js/export.js');
 await import('../js/settings.js');
 await import('../js/chat.js');
 await import('../js/utils.js');
@@ -329,8 +329,6 @@ const expectedExports = [
   'buildSidebar', 'renderProfileDropdown',
   // views.js
   'navigate', 'showDashboard',
-  // export.js
-  'openReportBuilder', 'closeReportBuilder', 'exportPDFReport', 'exportDataJSON', 'importDataJSON', 'clearAllData',
   // settings.js
   'openSettingsModal', 'closeSettingsModal',
   // chat.js
@@ -338,6 +336,10 @@ const expectedExports = [
 ];
 for (const name of expectedExports) {
   assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
+}
+for (const name of ['openReportBuilder', 'closeReportBuilder', 'exportPDFReport', 'exportDataJSON', 'importDataJSON', 'clearAllData']) {
+  assert(`export.${name} exists`, typeof exportModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
 }
 for (const name of ['getProfiles', 'saveProfiles', 'loadProfile', 'switchProfile', 'createProfile', 'deleteProfile', 'getProfileSex', 'setProfileSex', 'getProfileDob']) {
   assert(`profile.${name} exists`, typeof profileModule[name] === 'function');
@@ -461,7 +463,8 @@ try {
     exportSrc.includes("from './export-runtime.js'") &&
     exportSrc.includes('getWalletBundleSettings') &&
     exportSrc.includes('refreshImportRuntimeShell') &&
-    exportSrc.includes('publishExportGlobals') &&
+    !exportSrc.includes('publishExportGlobals') &&
+    !exportRuntimeSrc.includes('publishExportGlobals') &&
     exportRuntimeSrc.includes('export async function refreshImportRuntimeShell'));
   assert('export-runtime falls back to published globals when shell module imports fail',
     exportRuntimeSrc.includes('function getRuntimeFunction(module, name)') &&

--- a/tests/test-demo.js
+++ b/tests/test-demo.js
@@ -21,9 +21,8 @@ function assert(name, condition, detail) {
 
 console.log('=== Demo Data Onboarding Tests ===\n');
 
-// export.js exposes window.loadDemoData via Object.assign(window, ...).
 const { state } = await import('../js/state.js');
-await import('../js/export.js');
+const exportModule = await import('../js/export.js');
 const { findOrCreateLabEntry } = await import('../js/lab-entry-mutations.js');
 const { setLabEntryMarker } = await import('../js/lab-entry.js');
 const { migrateProfileData } = await import('../js/profile.js');
@@ -109,9 +108,10 @@ const { buildBiologyScoreContextFingerprint, buildBiologyScoreContextFingerprint
     console.log('  ⚠️  Empty dashboard not visible (data already loaded) — skipping DOM checks');
   }
 
-  // ── 5. Window exports ──
-  console.log('\n5. Window exports');
-  assert('loadDemoData on window', typeof window.loadDemoData === 'function');
+  // ── 5. Module exports ──
+  console.log('\n5. Module exports');
+  assert('loadDemoData is exported', typeof exportModule.loadDemoData === 'function');
+  assert('loadDemoData stays module-only', !('loadDemoData' in window));
 
   // ── 6. Service worker ──
   console.log('\n6. service-worker.js — Cache version');

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -10,6 +10,7 @@ return (async function() {
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const S = window._labState;
   const backupModule = await import('/js/backup.js');
+  const exportModule = await import('/js/export.js');
   const profile = await import('/js/profile.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
@@ -44,12 +45,12 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c 1. Export function availability ', 'font-weight:bold;color:#f59e0b');
 
-  assert('exportDataJSON is callable', typeof window.exportDataJSON === 'function');
-  assert('exportClientJSON is callable', typeof window.exportClientJSON === 'function');
-  assert('exportAllDataJSON is callable', typeof window.exportAllDataJSON === 'function');
-  assert('buildAllDataBundle is callable', typeof window.buildAllDataBundle === 'function');
-  assert('importDataJSON is callable', typeof window.importDataJSON === 'function');
-  assert('clearAllData is callable', typeof window.clearAllData === 'function');
+  assert('exportDataJSON is callable', typeof exportModule.exportDataJSON === 'function');
+  assert('exportClientJSON is callable', typeof exportModule.exportClientJSON === 'function');
+  assert('exportAllDataJSON is callable', typeof exportModule.exportAllDataJSON === 'function');
+  assert('buildAllDataBundle is callable', typeof exportModule.buildAllDataBundle === 'function');
+  assert('importDataJSON is callable', typeof exportModule.importDataJSON === 'function');
+  assert('clearAllData is callable', typeof exportModule.clearAllData === 'function');
 
   // ═══════════════════════════════════════
   // 2. exportClientJSON — source verification
@@ -214,7 +215,7 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c 3. buildAllDataBundle live call ', 'font-weight:bold;color:#f59e0b');
 
-  const raw = await window.buildAllDataBundle();
+  const raw = await exportModule.buildAllDataBundle();
   assert('buildAllDataBundle returns non-null', raw != null);
 
   // buildAllDataBundle returns a JSON string
@@ -325,7 +326,7 @@ return (async function() {
   await wait(20);
 
   // Rebuild bundle after adding supplement
-  const raw2 = await window.buildAllDataBundle();
+  const raw2 = await exportModule.buildAllDataBundle();
   const bundle2 = JSON.parse(raw2);
   const myProfile2 = bundle2.profiles.find(p => p.id === currentId);
   const bundleSupps = myProfile2?.data?.supplements || [];
@@ -359,7 +360,7 @@ return (async function() {
   window.saveImportedData();
   await wait(20);
 
-  const raw3 = await window.buildAllDataBundle();
+  const raw3 = await exportModule.buildAllDataBundle();
   const bundle3 = JSON.parse(raw3);
   const myProfile3 = bundle3.profiles.find(p => p.id === currentId);
   const pData = myProfile3?.data || {};
@@ -401,7 +402,7 @@ return (async function() {
   window.saveImportedData();
   await wait(20);
 
-  const raw4 = await window.buildAllDataBundle();
+  const raw4 = await exportModule.buildAllDataBundle();
   const bundle4 = JSON.parse(raw4);
   const myProfile4 = bundle4.profiles.find(p => p.id === currentId);
   const pData4 = myProfile4?.data || {};
@@ -424,7 +425,7 @@ return (async function() {
   // ═══════════════════════════════════════
   console.log('%c 9. clearAllData source inspection ', 'font-weight:bold;color:#f59e0b');
 
-  assert('clearAllData exists', typeof window.clearAllData === 'function');
+  assert('clearAllData exists', typeof exportModule.clearAllData === 'function');
 
   // Verify it clears the expected storage keys. The `-imported` blob lives in
   // IndexedDB now → encryptedRemoveItem hits both backends.
@@ -614,22 +615,22 @@ return (async function() {
   }
 
   // ═══════════════════════════════════════
-  // 14. Window exports
+  // 14. Module exports
   // ═══════════════════════════════════════
-  console.log('%c 14. Window exports ', 'font-weight:bold;color:#f59e0b');
+  console.log('%c 14. Module exports ', 'font-weight:bold;color:#f59e0b');
 
-  assert('Window has exportPDFReport', typeof window.exportPDFReport === 'function');
-  assert('Window has openReportBuilder', typeof window.openReportBuilder === 'function');
-  assert('Window has closeReportBuilder', typeof window.closeReportBuilder === 'function');
-  assert('Window has exportDataJSON', typeof window.exportDataJSON === 'function');
-  assert('Window has exportClientJSON', typeof window.exportClientJSON === 'function');
-  assert('Window has exportAllDataJSON', typeof window.exportAllDataJSON === 'function');
-  assert('Window has buildAllDataBundle', typeof window.buildAllDataBundle === 'function');
-  assert('Window has importDataJSON', typeof window.importDataJSON === 'function');
-  assert('Window has clearAllData', typeof window.clearAllData === 'function');
-  assert('Window has loadDemoData', typeof window.loadDemoData === 'function');
+  assert('Module has exportPDFReport', typeof exportModule.exportPDFReport === 'function');
+  assert('Module has openReportBuilder', typeof exportModule.openReportBuilder === 'function');
+  assert('Module has closeReportBuilder', typeof exportModule.closeReportBuilder === 'function');
+  assert('Module has exportDataJSON', typeof exportModule.exportDataJSON === 'function');
+  assert('Module has exportClientJSON', typeof exportModule.exportClientJSON === 'function');
+  assert('Module has exportAllDataJSON', typeof exportModule.exportAllDataJSON === 'function');
+  assert('Module has buildAllDataBundle', typeof exportModule.buildAllDataBundle === 'function');
+  assert('Module has importDataJSON', typeof exportModule.importDataJSON === 'function');
+  assert('Module has clearAllData', typeof exportModule.clearAllData === 'function');
+  assert('Module has loadDemoData', typeof exportModule.loadDemoData === 'function');
 
-  window.openReportBuilder();
+  exportModule.openReportBuilder();
   await wait(20);
   const reportBuilder = document.getElementById('report-builder-overlay');
   assert('Report builder modal renders', !!reportBuilder);
@@ -647,7 +648,7 @@ return (async function() {
   assert('Report builder requires lab categories for lab-derived sections',
     !!document.getElementById('report-builder-overlay') &&
       (document.getElementById('notification-container')?.textContent || '').includes('Choose at least one lab category'));
-  window.closeReportBuilder();
+  exportModule.closeReportBuilder();
   assert('Report builder closes cleanly', !document.getElementById('report-builder-overlay'));
 
   {
@@ -703,7 +704,7 @@ return (async function() {
         { date: isoDate(inWindow), text: 'Between-draw report note retained' },
         { date: isoDate(outsideWindow), text: 'Old report note excluded' }
       ]);
-      window.exportPDFReport({ preset: 'personal', dateRange: '1y', sections: ['notes'], categoryKeys: null });
+      exportModule.exportPDFReport({ preset: 'personal', dateRange: '1y', sections: ['notes'], categoryKeys: null });
       assert('Report notes include in-window notes without matching lab draw',
         capturedReport.includes('Between-draw report note retained') &&
           !capturedReport.includes('Old report note excluded'));
@@ -722,7 +723,7 @@ return (async function() {
           capturedReport.includes('<dt>Resting pulse</dt><dd>61 bpm (May 15, 2026)</dd>'));
 
       capturedReport = '';
-      window.exportPDFReport({ preset: 'personal', dateRange: '3m', sections: ['categories'], categoryKeys: null });
+      exportModule.exportPDFReport({ preset: 'personal', dateRange: '3m', sections: ['categories'], categoryKeys: null });
       assert('Report date window with no matching lab draws stays empty',
         capturedReport.includes('No lab dates in selected range') && !capturedReport.includes('<h2>Biochemistry</h2>'));
 
@@ -735,7 +736,7 @@ return (async function() {
           { relative: 'paternal_grandfather', condition: "Alzheimer's Disease", onsetAge: 70, note: 'died' }
         ]
       };
-      window.exportPDFReport({ preset: 'clinician', dateRange: 'all', sections: ['context'], categoryKeys: null });
+      exportModule.exportPDFReport({ preset: 'clinician', dateRange: 'all', sections: ['context'], categoryKeys: null });
       assert('Report medical history formats family history as readable text',
         capturedReport.includes('Father: Psoriasis (onset 18)') &&
           capturedReport.includes('Paternal Grandfather: Alzheimer') &&
@@ -750,7 +751,7 @@ return (async function() {
         snps: {}
       };
       window._snpTableCache = {};
-      window.exportPDFReport({ preset: 'personal', dateRange: 'all', sections: ['summary', 'genetics'], categoryKeys: null });
+      exportModule.exportPDFReport({ preset: 'personal', dateRange: 'all', sections: ['summary', 'genetics'], categoryKeys: null });
       assert('Report summary can include genetics without crashing',
         capturedReport.includes('<strong>APOE:</strong> E3/E4'));
 
@@ -878,7 +879,7 @@ return (async function() {
       // importDataJSON consumes a File object via FileReader. Synthesize one.
       const blob = new Blob([JSON.stringify(demo)], { type: 'application/json' });
       const file = new File([blob], 'demo-female.json', { type: 'application/json' });
-      await window.importDataJSON(file);
+      await exportModule.importDataJSON(file);
 
       // FileReader is async — poll the imported state up to 5s for the
       // first Light & Sun field to land.
@@ -1031,7 +1032,7 @@ return (async function() {
       const beforeRepeat = (S.importedData?.sunSessions || []).length;
       const file2 = new File([new Blob([JSON.stringify(demo)], { type: 'application/json' })],
         'demo-female.json', { type: 'application/json' });
-      await window.importDataJSON(file2);
+      await exportModule.importDataJSON(file2);
       assert('re-importing same demo does NOT duplicate sunSessions',
         (S.importedData?.sunSessions || []).length === beforeRepeat,
         `before=${beforeRepeat}, after=${(S.importedData?.sunSessions || []).length}`);
@@ -1058,7 +1059,7 @@ return (async function() {
   //    code paths
   //  • someone re-introducing the "navigate fires loadContextHealthDots
   //    before our cache lands" race
-  if (typeof window !== 'undefined' && typeof window.loadDemoData === 'function') {
+  if (typeof exportModule.loadDemoData === 'function') {
     console.log('%c 16. Demo prefill end-to-end (zero AI calls) ', 'font-weight:bold;color:#f59e0b');
     const snapshot2 = JSON.parse(JSON.stringify(S.importedData || {}));
     const origProfile = S.currentProfile;
@@ -1077,7 +1078,7 @@ return (async function() {
       return origFetch.apply(this, arguments);
     };
     try {
-      await window.loadDemoData('female');
+      await exportModule.loadDemoData('female');
       // Wait long enough for: import resolve → navigate('dashboard') →
       // loadFocusCard + loadContextHealthDots fire-and-forget paths.
       await wait(4000);
@@ -1154,7 +1155,7 @@ return (async function() {
       S.currentProfile = origProfile;
     }
   } else {
-    assert('Demo prefill end-to-end test skipped — window.loadDemoData unavailable', true);
+    assert('Demo prefill end-to-end test skipped — module loadDemoData unavailable', true);
   }
 
   // ═══════════════════════════════════════

--- a/tests/test-folder-backup.js
+++ b/tests/test-folder-backup.js
@@ -23,7 +23,7 @@ const read = (rel) => fs.readFileSync(path.join(ROOT, rel.replace(/^\//, '')), '
 await import('../js/state.js');
 const backupModule = await import('../js/backup.js');
 const cryptoModule = await import('../js/crypto.js');
-await import('../js/export.js'); // exposes window.buildAllDataBundle
+const exportModule = await import('../js/export.js');
 
   // ═══════════════════════════════════════════════
   // 1. Module exports exist without legacy window globals
@@ -36,7 +36,8 @@ await import('../js/export.js'); // exposes window.buildAllDataBundle
     assert(`backup.${name} exists`, typeof backupModule[name] === 'function');
     assert(`window.${name} stays module-only`, !(name in window));
   }
-  assert('window.buildAllDataBundle exists', typeof window.buildAllDataBundle === 'function');
+  assert('export module exposes buildAllDataBundle', typeof exportModule.buildAllDataBundle === 'function');
+  assert('buildAllDataBundle stays module-only', !('buildAllDataBundle' in window));
 
   // ═══════════════════════════════════════════════
   // 2. getFolderBackupState() returns correct shape
@@ -56,7 +57,7 @@ await import('../js/export.js'); // exposes window.buildAllDataBundle
   // 3. buildAllDataBundle() returns valid JSON
   // ═══════════════════════════════════════════════
   try {
-    const json = await window.buildAllDataBundle();
+    const json = await exportModule.buildAllDataBundle();
     if (json) {
       assert('buildAllDataBundle returns string', typeof json === 'string');
       const parsed = JSON.parse(json);

--- a/tests/test-import-drop-zone-runtime.js
+++ b/tests/test-import-drop-zone-runtime.js
@@ -25,7 +25,6 @@ const runtimeKeys = [
   'window',
   'document',
   'showNotification',
-  'importDataJSON',
   'detectDNAFile',
   'handleMtDNAFile',
   'handleDNAFile',
@@ -57,10 +56,10 @@ try {
   const picker = { click: () => calls.push(['picker']) };
 
   configureImportDropZoneRuntimeDeps({
+    importDataJSON: file => calls.push(['json', file.name]),
     isImportRunning: () => true,
     showNotification: (message, type) => calls.push(['notify', type, message]),
   });
-  setRuntimeValue('importDataJSON', file => calls.push(['json', file.name]));
   setRuntimeValue('detectDNAFile', header => header.includes('MT') ? 'mtdna' : 'autosomal');
   setRuntimeValue('handleMtDNAFile', file => calls.push(['mtdna', file.name]));
   setRuntimeValue('handleDNAFile', file => calls.push(['dna', file.name]));

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -31,7 +31,6 @@ console.log('=== Nav Runtime Tests ===');
 const runtimeKeys = [
   'window',
   'navigate',
-  'openReportBuilder',
   'openContextModal',
   'openCreateMarkerModal',
   'openClientList',
@@ -60,7 +59,6 @@ try {
   const calls = [];
   const browserRuntime = {
     navigate(route) { calls.push(['navigate', route, this === browserRuntime]); },
-    openReportBuilder() { calls.push(['report', this === browserRuntime]); },
     openContextModal() { calls.push(['context', this === browserRuntime]); },
     openCreateMarkerModal() { calls.push(['marker', this === browserRuntime]); },
     openClientList() { calls.push(['client', this === browserRuntime]); },
@@ -68,6 +66,7 @@ try {
   setRuntimeValue('window', browserRuntime);
   const restoreNavRuntime = configureNavRuntime({
     openEMFAssessmentEditor: () => calls.push(['emf', true]),
+    openReportBuilder: () => calls.push(['report', true]),
   });
 
   navigateFromNavRuntime('labs');
@@ -86,10 +85,10 @@ try {
   assert('exposeNavRuntimeGlobals assigns exports to the browser runtime',
     browserRuntime.runtimeProbe === 42);
 
-  for (const key of ['navigate', 'openReportBuilder', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
+  for (const key of ['navigate', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
     delete browserRuntime[key];
   }
-  configureNavRuntime({ openEMFAssessmentEditor: () => {} });
+  configureNavRuntime({ openEMFAssessmentEditor: () => {}, openReportBuilder: () => {} });
   navigateFromNavRuntime('missing');
   openEMFAssessmentFromNavRuntime();
   openReportBuilderFromNavRuntime();

--- a/tests/test-profile-share.js
+++ b/tests/test-profile-share.js
@@ -146,11 +146,10 @@ assert('Profile share helpers stay module-only',
   !profileShareSrc.includes('Object.assign(window'));
 
 console.log('4. Export/import reuse and credential boundaries');
-const exportGlobalPublish = exportSrc.match(/publishExportGlobals\(\s*\{([^}]*)\}\)/);
 assert('buildClientExportObject stays module-only, not window-exposed',
   exportSrc.includes('export async function buildClientExportObject') &&
-  exportGlobalPublish &&
-  !exportGlobalPublish[1].includes('buildClientExportObject'));
+  !exportSrc.includes('publishExportGlobals') &&
+  !exportSrc.includes('Object.assign(window'));
 assert('exportClientJSON downloads the reusable export object',
   exportSrc.includes('exportObj = await buildClientExportObject(profileId, includeChat)') &&
   exportSrc.includes('new Blob([JSON.stringify(exportObj, null, 2)]'));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -28,6 +28,7 @@ return (async function() {
   const supplements = await import('/js/supplements.js');
   const pdfImport = await import('/js/pdf-import.js');
   const profile = await import('/js/profile.js');
+  const exportModule = await import('/js/export.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -719,13 +720,13 @@ return (async function() {
   // ═══════════════════════════════════════════════
   console.log('%c 12. Export sanity', 'font-weight:bold;color:#6366f1');
 
-  assert('exportDataJSON is callable', typeof window.exportDataJSON === 'function');
-  assert('exportAllDataJSON is callable', typeof window.exportAllDataJSON === 'function');
-  assert('exportPDFReport is callable', typeof window.exportPDFReport === 'function');
+  assert('exportDataJSON is callable', typeof exportModule.exportDataJSON === 'function');
+  assert('exportAllDataJSON is callable', typeof exportModule.exportAllDataJSON === 'function');
+  assert('exportPDFReport is callable', typeof exportModule.exportPDFReport === 'function');
 
-  if (typeof window.buildAllDataBundle === 'function') {
+  if (typeof exportModule.buildAllDataBundle === 'function') {
     try {
-      const raw = await window.buildAllDataBundle();
+      const raw = await exportModule.buildAllDataBundle();
       const bundle = typeof raw === 'string' ? JSON.parse(raw) : raw;
       assert('buildAllDataBundle returns data', bundle != null);
       assert('Bundle has profiles', Array.isArray(bundle?.profiles));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -188,7 +188,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
+  const [apiModule, backupModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/charts.js'),
@@ -196,6 +196,7 @@
     import('../js/cycle.js'),
     import('../js/emf.js'),
     import('../js/emf-runtime.js'),
+    import('../js/export.js'),
     import('../js/lab-context.js'),
     import('../js/lens.js'),
     import('../js/light-tools.js'),
@@ -420,9 +421,11 @@
     'registerRefreshCallback','_runRegisteredRefreshCallback'
   ];
 
-  // export.js (8)
+  // export.js (11 former browser globals, now module-only)
   const exportExports = [
-    'openReportBuilder','closeReportBuilder','exportPDFReport','exportDataJSON','exportClientJSON','exportAllDataJSON','importDataJSON','clearAllData'
+    'openReportBuilder','closeReportBuilder','generateReportAISummary','exportPDFReport',
+    'exportDataJSON','exportClientJSON','exportAllDataJSON','buildAllDataBundle',
+    'importDataJSON','clearAllData','loadDemoData'
   ];
 
   // nav.js (5)
@@ -593,6 +596,7 @@
     ['cycle.js', cycleModule, cycleExports],
     ['emf.js', emfModule, emfExports],
     ['emf-runtime.js', emfRuntimeModule, emfRuntimeExports],
+    ['export.js', exportModule, exportExports],
     ['lab-context.js', labContextModule, labContextExports],
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
@@ -651,13 +655,15 @@
   for (const name of utilsExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of exportExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
 
   const allModules = {
     'chat.js': chatExports,
     'client-list.js': clientListExports,
     'context-cards.js': contextCardsExports,
     'data.js': dataExports,
-    'export.js': exportExports,
     'nav.js': navExports,
     'notes.js': notesExports,
     'settings.js': settingsExports,
@@ -912,13 +918,13 @@
   // ═══════════════════════════════════════════════
   // 18. EXPORT FUNCTIONS — exist
   // ═══════════════════════════════════════════════
-  assert('exportPDFReport is function', typeof window.exportPDFReport === 'function');
-  assert('openReportBuilder is function', typeof window.openReportBuilder === 'function');
-  assert('closeReportBuilder is function', typeof window.closeReportBuilder === 'function');
-  assert('exportDataJSON is function', typeof window.exportDataJSON === 'function');
-  assert('exportClientJSON is function', typeof window.exportClientJSON === 'function');
-  assert('exportAllDataJSON is function', typeof window.exportAllDataJSON === 'function');
-  assert('clearAllData is function', typeof window.clearAllData === 'function');
+  assert('exportPDFReport is function', typeof exportModule.exportPDFReport === 'function');
+  assert('openReportBuilder is function', typeof exportModule.openReportBuilder === 'function');
+  assert('closeReportBuilder is function', typeof exportModule.closeReportBuilder === 'function');
+  assert('exportDataJSON is function', typeof exportModule.exportDataJSON === 'function');
+  assert('exportClientJSON is function', typeof exportModule.exportClientJSON === 'function');
+  assert('exportAllDataJSON is function', typeof exportModule.exportAllDataJSON === 'function');
+  assert('clearAllData is function', typeof exportModule.clearAllData === 'function');
 
   // ═══════════════════════════════════════════════
   // 19. CYCLE HELPERS — pure function checks

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.200';
+self.APP_VERSION = '1.10.201';


### PR DESCRIPTION
## Summary
- remove 11 export, import, report, and demo helpers from the global `window` surface
- route navigation, settings, dashboard demos, PDF imports, drop-zone imports, and client-list actions through module imports or explicit runtime dependencies
- add module-only regression coverage and bump the app version to 1.10.201

## Tests
- `./run-tests.sh`
  - 123 module verification checks
  - 396 Vitest tests
  - 18 origin guard tests
  - 351 Playwright tests
  - 472 responsive/theme checks
- `npm run quality`