### PR TITLE
Make provider panels module-only

### DIFF
--- a/js/api-runtime.js
+++ b/js/api-runtime.js
@@ -7,6 +7,27 @@ function getApiRuntime() {
     : null;
 }
 
+/** @type {{ showInsufficientBalanceDialog: Function }} */
+const apiRuntimeCallbacks = {
+  showInsufficientBalanceDialog: () => {
+    if (typeof document === 'undefined') return false;
+    import('./provider-panels.js')
+      .then(providerPanels => providerPanels.showInsufficientBalanceDialog())
+      .catch(() => {});
+    return true;
+  },
+};
+
+export function configureApiRuntimeCallbacks(callbacks = {}) {
+  const previous = { ...apiRuntimeCallbacks };
+  if ('showInsufficientBalanceDialog' in callbacks) {
+    apiRuntimeCallbacks.showInsufficientBalanceDialog = typeof callbacks.showInsufficientBalanceDialog === 'function'
+      ? callbacks.showInsufficientBalanceDialog
+      : () => false;
+  }
+  return previous;
+}
+
 export function getApiLocationOriginRuntime() {
   return getApiRuntime()?.location?.origin || '';
 }
@@ -27,8 +48,9 @@ export function setApiLocationHrefRuntime(url) {
 }
 
 export function showOpenRouterInsufficientBalanceDialogRuntime() {
-  const runtime = getApiRuntime();
-  if (!runtime?.showInsufficientBalanceDialog) return false;
-  try { runtime.showInsufficientBalanceDialog(); } catch {}
-  return true;
+  try {
+    return apiRuntimeCallbacks.showInsufficientBalanceDialog() !== false;
+  } catch {
+    return false;
+  }
 }

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -626,7 +626,7 @@ export function handleRemoveRoutstrKey() {
 }
 
 // ─── Custom API handlers ───
-async function handleSaveCustomApi() {
+export async function handleSaveCustomApi() {
   const urlInput = /** @type {HTMLInputElement | null} */ (document.getElementById('custom-url-input'));
   const keyInput = /** @type {HTMLInputElement | null} */ (document.getElementById('custom-key-input'));
   if (!urlInput || !keyInput) return;
@@ -646,7 +646,7 @@ async function handleSaveCustomApi() {
   if (models.length) renderCustomApiModelDropdown(models);
 }
 
-function handleRemoveCustomApi() {
+export function handleRemoveCustomApi() {
   localStorage.removeItem('labcharts-custom-url');
   localStorage.removeItem('labcharts-custom-model');
   localStorage.removeItem('labcharts-custom-models');
@@ -715,84 +715,4 @@ installProviderPanelDelegates({
   setOllamaMainModel,
   refreshModelAdvisor,
   applyCustomOpenRouterModel
-});
-
-// ═══════════════════════════════════════════════
-// WINDOW EXPORTS (for HTML onclick handlers)
-// ═══════════════════════════════════════════════
-Object.assign(window, {
-  renderAIProviderPanel,
-  toggleAIPause,
-  switchAIProvider,
-  initSettingsModelFetch,
-  initSettingsOllamaCheck,
-  testOllamaConnection,
-  testPIIOllamaConnection,
-  refreshVeniceBalance,
-  updateVeniceModelPricing,
-  onVeniceModelDropdownChange,
-  toggleVeniceE2EE,
-  togglePpqPrivateMode,
-  updateOpenRouterModelPricing,
-  updateRoutstrModelPricing,
-  handleSaveVeniceKey,
-  handleRemoveVeniceKey,
-  renderVeniceModelDropdown,
-  handleSaveOpenRouterKey,
-  handleRemoveOpenRouterKey,
-  renderOpenRouterModelDropdown,
-  applyCustomOpenRouterModel,
-  onOpenRouterDropdownChange,
-  handleSaveRoutstrKey,
-  handleRemoveRoutstrKey,
-  renderRoutstrModelDropdown,
-  refreshCashuWalletBalance,
-  refreshRoutstrBalance,
-  showRoutstrWalletFund,
-  rsWalletFundCustomInput,
-  doRoutstrWalletFundCustom,
-  doRoutstrWalletFund,
-  doRoutstrWalletReceiveCashu,
-  showRoutstrMintEdit,
-  doRoutstrMintChange,
-  showRoutstrWalletBackup,
-  showRoutstrNodePicker,
-  connectRoutstrNode,
-  doRoutstrNodeDeposit,
-  doRoutstrNodeWithdraw,
-  _setActiveNodeAction,
-  walletSeedAcknowledged,
-  setupRoutstrWalletSeed,
-  showWalletSeedPhrase,
-  showRoutstrWithdraw,
-  showRoutstrWithdrawLightning,
-  showRoutstrWithdrawToken,
-  doRoutstrSendToken,
-  doRoutstrWithdrawQuote,
-  doRoutstrWithdrawExecute,
-  doRoutstrWalletRestore,
-  handleCreatePpqAccount,
-  dismissPpqKeyReveal,
-  handleSavePpqKey,
-  handleRemovePpqKey,
-  renderPpqModelDropdown,
-  updatePpqModelPricing,
-  refreshPpqBalance,
-  showPpqTopup,
-  selectPpqMethod,
-  doPpqTopup,
-  ppqShowCustomInput,
-  doPpqTopupCustom,
-  cancelPpqTopup,
-  refreshOpenRouterBalance,
-  showInsufficientBalanceDialog,
-  handleSaveCustomApi,
-  handleRemoveCustomApi,
-  renderCustomApiModelDropdown,
-  applyCustomApiManualModel,
-  updateCustomModelPricing,
-  copyOllamaPullCmd,
-  refreshModelAdvisor,
-  applyHardwareOverride,
-  clearHardwareOverride,
 });

--- a/js/settings-provider-bridge.js
+++ b/js/settings-provider-bridge.js
@@ -9,10 +9,6 @@ import {
   setAIProvider,
 } from './api.js';
 
-/** @typedef {Window & typeof globalThis & Record<string, any>} SettingsProviderBridgeWindow */
-
-const settingsWindow = /** @type {SettingsProviderBridgeWindow} */ (window);
-
 let _providerPanelsLoad = null;
 
 function loadProviderPanels() {
@@ -21,26 +17,11 @@ function loadProviderPanels() {
 }
 
 export function renderAIProviderPanelBridge(provider) {
-  loadProviderPanels().then(() => {
+  loadProviderPanels().then(providerPanels => {
     const panel = document.getElementById('ai-provider-panel');
-    if (panel && typeof settingsWindow.renderAIProviderPanel === 'function' && settingsWindow.renderAIProviderPanel !== renderAIProviderPanelBridge) {
-      panel.innerHTML = settingsWindow.renderAIProviderPanel(provider || getAIProvider());
-    }
+    if (panel) panel.innerHTML = providerPanels.renderAIProviderPanel(provider || getAIProvider());
   }).catch(() => {});
   return '<div class="ai-provider-panel"><div class="ai-provider-desc">Loading provider settings...</div></div>';
-}
-
-/** @param {string} name */
-function installProviderPanelBridge(name) {
-  const registry = /** @type {Record<string, any>} */ (settingsWindow);
-  if (typeof registry[name] === 'function') return;
-  const bridge = async function(...args) {
-    await loadProviderPanels();
-    const fn = registry[name];
-    if (typeof fn !== 'function' || fn === bridge) return undefined;
-    return fn(...args);
-  };
-  registry[name] = bridge;
 }
 
 function setProviderButtonState(provider) {
@@ -61,88 +42,20 @@ export function switchAIProviderBridge(provider) {
   setProviderButtonState(provider);
   const panel = document.getElementById('ai-provider-panel');
   if (panel) panel.innerHTML = '<div class="ai-provider-panel"><div class="ai-provider-desc">Loading provider settings...</div></div>';
-  loadProviderPanels().then(() => {
-    const fn = settingsWindow.switchAIProvider;
-    if (typeof fn === 'function' && fn !== switchAIProviderBridge) return fn(provider);
-    if (panel && typeof settingsWindow.renderAIProviderPanel === 'function') panel.innerHTML = settingsWindow.renderAIProviderPanel(provider);
-  }).catch(() => {});
+  loadProviderPanels().then(providerPanels => providerPanels.switchAIProvider(provider)).catch(() => {});
 }
 
-const PROVIDER_PANEL_BRIDGE_NAMES = [
-  'toggleAIPause',
-  'initSettingsModelFetch',
-  'initSettingsOllamaCheck',
-  'testOllamaConnection',
-  'testPIIOllamaConnection',
-  'refreshVeniceBalance',
-  'updateVeniceModelPricing',
-  'onVeniceModelDropdownChange',
-  'toggleVeniceE2EE',
-  'updateOpenRouterModelPricing',
-  'updateRoutstrModelPricing',
-  'handleSaveVeniceKey',
-  'handleRemoveVeniceKey',
-  'renderVeniceModelDropdown',
-  'handleSaveOpenRouterKey',
-  'handleRemoveOpenRouterKey',
-  'renderOpenRouterModelDropdown',
-  'applyCustomOpenRouterModel',
-  'onOpenRouterDropdownChange',
-  'handleSaveRoutstrKey',
-  'handleRemoveRoutstrKey',
-  'renderRoutstrModelDropdown',
-  'refreshCashuWalletBalance',
-  'refreshRoutstrBalance',
-  'showRoutstrWalletFund',
-  'rsWalletFundCustomInput',
-  'doRoutstrWalletFundCustom',
-  'doRoutstrWalletFund',
-  'doRoutstrWalletReceiveCashu',
-  'showRoutstrMintEdit',
-  'doRoutstrMintChange',
-  'showRoutstrWalletBackup',
-  'showRoutstrNodePicker',
-  'connectRoutstrNode',
-  'doRoutstrNodeDeposit',
-  'doRoutstrNodeWithdraw',
-  '_setActiveNodeAction',
-  'walletSeedAcknowledged',
-  'showWalletSeedPhrase',
-  'showRoutstrWithdraw',
-  'showRoutstrWithdrawLightning',
-  'showRoutstrWithdrawToken',
-  'doRoutstrSendToken',
-  'doRoutstrWithdrawQuote',
-  'doRoutstrWithdrawExecute',
-  'doRoutstrWalletRestore',
-  'handleCreatePpqAccount',
-  'dismissPpqKeyReveal',
-  'handleSavePpqKey',
-  'handleRemovePpqKey',
-  'renderPpqModelDropdown',
-  'updatePpqModelPricing',
-  'refreshPpqBalance',
-  'showPpqTopup',
-  'selectPpqMethod',
-  'doPpqTopup',
-  'ppqShowCustomInput',
-  'doPpqTopupCustom',
-  'cancelPpqTopup',
-  'refreshOpenRouterBalance',
-  'showInsufficientBalanceDialog',
-  'handleSaveCustomApi',
-  'handleRemoveCustomApi',
-  'renderCustomApiModelDropdown',
-  'applyCustomApiManualModel',
-  'updateCustomModelPricing',
-  'copyOllamaPullCmd',
-  'refreshModelAdvisor',
-  'applyHardwareOverride',
-  'clearHardwareOverride',
-];
+export function toggleAIPauseBridge(enabled) {
+  return loadProviderPanels().then(providerPanels => providerPanels.toggleAIPause(enabled));
+}
 
-export function installSettingsProviderBridge() {
-  settingsWindow.renderAIProviderPanel = renderAIProviderPanelBridge;
-  settingsWindow.switchAIProvider = switchAIProviderBridge;
-  PROVIDER_PANEL_BRIDGE_NAMES.forEach(installProviderPanelBridge);
+export function testPIIOllamaConnectionBridge() {
+  return loadProviderPanels().then(providerPanels => providerPanels.testPIIOllamaConnection());
+}
+
+export function initSettingsProviderPanels() {
+  return loadProviderPanels().then(providerPanels => {
+    providerPanels.initSettingsOllamaCheck();
+    providerPanels.initSettingsModelFetch();
+  });
 }

--- a/js/settings-provider-bridge.js
+++ b/js/settings-provider-bridge.js
@@ -19,7 +19,7 @@ function loadProviderPanels() {
 export function renderAIProviderPanelBridge(provider) {
   loadProviderPanels().then(providerPanels => {
     const panel = document.getElementById('ai-provider-panel');
-    if (panel) panel.innerHTML = providerPanels.renderAIProviderPanel(provider || getAIProvider());
+    if (panel) panel.innerHTML = providerPanels.renderAIProviderPanel(getAIProvider());
   }).catch(() => {});
   return '<div class="ai-provider-panel"><div class="ai-provider-desc">Loading provider settings...</div></div>';
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -12,7 +12,13 @@ import { renderSyncSection, renderMessengerSection, hydrateSettingsSyncPanel } f
 import { renderWearablesSettingsSection } from './wearables-settings-panel.js';
 import { isProductRecsEnabled, setProductRecsEnabled } from './recommendations.js';
 import { closeModalOverlay, openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
-import { installSettingsProviderBridge, switchAIProviderBridge } from './settings-provider-bridge.js';
+import {
+  initSettingsProviderPanels,
+  renderAIProviderPanelBridge,
+  switchAIProviderBridge,
+  testPIIOllamaConnectionBridge,
+  toggleAIPauseBridge,
+} from './settings-provider-bridge.js';
 import {
   addSettingsRuntimeEventListener,
   cancelSettingsFrame,
@@ -70,8 +76,6 @@ const settingsRuntime = {
 export function configureSettingsRuntime(runtime = {}) {
   Object.assign(settingsRuntime, runtime);
 }
-
-installSettingsProviderBridge();
 
 export {
   confirmDisablePIIReview,
@@ -295,7 +299,7 @@ function applySettingsToggle(actionEl) {
     return true;
   }
   if (action === 'toggle-ai-pause') {
-    settingsWindow.toggleAIPause?.(checked);
+    void toggleAIPauseBridge(checked);
     return true;
   }
   if (action === 'toggle-pii-local') {
@@ -409,7 +413,7 @@ async function handleSettingsClick(event) {
     togglePrivacyConfigure();
   } else if (action === 'test-pii-ollama') {
     event.preventDefault();
-    settingsWindow.testPIIOllamaConnection?.();
+    void testPIIOllamaConnectionBridge();
   } else if (action === 'rename-imported-entry') {
     event.preventDefault();
     void renameImportedEntryDateFromSettings(actionEl.dataset.entryDate || '');
@@ -854,7 +858,7 @@ export function openSettingsModal(tab) {
           <button class="ai-provider-btn${provider === 'custom' ? ' active' : ''}" data-provider="custom" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg> Custom</button>
           <button class="ai-provider-btn${provider === 'ollama' ? ' active' : ''}" data-provider="ollama" data-settings-action="switch-ai-provider"><svg class="ai-provider-logo" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 15h-2v-6h2v6zm4 0h-2v-6h2v6zm-3-8c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1s1 .45 1 1v2c0 .55-.45 1-1 1z"/></svg> Local</button>
         </div>
-        <div id="ai-provider-panel">${settingsWindow.renderAIProviderPanel(provider)}</div>
+        <div id="ai-provider-panel">${renderAIProviderPanelBridge(provider)}</div>
       </div>
 
       <div class="settings-group-title">AI Usage</div>
@@ -923,8 +927,7 @@ export function openSettingsModal(tab) {
     </div>`;
   installSettingsDelegates(modal);
   openModalOverlay(overlay);
-  settingsWindow.initSettingsOllamaCheck();
-  settingsWindow.initSettingsModelFetch();
+  void initSettingsProviderPanels();
   loadBackupSnapshots();
   loadSettingsCommitHash();
   hydrateSettingsSyncPanel();
@@ -995,8 +998,7 @@ export function switchSettingsTab(tabId) {
   scrollActiveSettingsTabIntoView();
   // Re-run init for tabs that need async setup
   if (tabId === 'ai') {
-    settingsWindow.initSettingsOllamaCheck();
-    settingsWindow.initSettingsModelFetch();
+    void initSettingsProviderPanels();
   }
   if (tabId === 'data') {
     refreshDataEntriesSection();

--- a/js/startup-oauth-callbacks.js
+++ b/js/startup-oauth-callbacks.js
@@ -15,13 +15,23 @@ import {
 import { handleOAuthCallbackOnLoad } from './wearables-connect.js';
 import { showNotification as showAppNotification } from './utils.js';
 
-const startupOAuthCallbackDeps = { showNotification: showAppNotification };
+/** @type {{ showNotification: Function | null, showInsufficientBalanceDialog: Function | null }} */
+const startupOAuthCallbackDeps = {
+  showNotification: showAppNotification,
+  showInsufficientBalanceDialog: () => import('./provider-panels.js')
+    .then(providerPanels => providerPanels.showInsufficientBalanceDialog()),
+};
 
 export function configureStartupOAuthCallbackDeps(deps = {}) {
   const previous = { ...startupOAuthCallbackDeps };
   if ('showNotification' in deps) {
     startupOAuthCallbackDeps.showNotification = typeof deps.showNotification === 'function'
       ? /** @type {typeof showAppNotification} */ (deps.showNotification)
+      : null;
+  }
+  if ('showInsufficientBalanceDialog' in deps) {
+    startupOAuthCallbackDeps.showInsufficientBalanceDialog = typeof deps.showInsufficientBalanceDialog === 'function'
+      ? deps.showInsufficientBalanceDialog
       : null;
   }
   return previous;
@@ -59,10 +69,6 @@ function openChatAfterInit() {
   startupRuntime()._openChatAfterInit = true;
 }
 
-function showInsufficientBalanceDialog() {
-  callStartupRuntime('showInsufficientBalanceDialog');
-}
-
 async function handleOpenRouterOAuthCallback(oauthCode, oauthState) {
   replaceCurrentUrl();
 
@@ -88,8 +94,8 @@ async function handleOpenRouterOAuthCallback(oauthCode, oauthState) {
     try {
       const balance = await getOpenRouterBalance();
       const remaining = balance?.remaining;
-      if (typeof remaining === 'number' && Number.isFinite(remaining) && remaining <= 0 && typeof startupRuntime().showInsufficientBalanceDialog === 'function') {
-        setTimeout(() => showInsufficientBalanceDialog(), 1500);
+      if (typeof remaining === 'number' && Number.isFinite(remaining) && remaining <= 0 && typeof startupOAuthCallbackDeps.showInsufficientBalanceDialog === 'function') {
+        setTimeout(() => startupOAuthCallbackDeps.showInsufficientBalanceDialog(), 1500);
       }
     } catch {}
   } catch (e) {

--- a/js/sync-runtime.js
+++ b/js/sync-runtime.js
@@ -10,6 +10,27 @@ let _appOwnerError = null;
 let _readyPromise = null;
 let _queryLoadedPromise = null;
 
+/** @type {{ refreshRoutstrBalance: Function }} */
+const syncRuntimeCallbacks = {
+  refreshRoutstrBalance: () => {
+    if (typeof document === 'undefined') return false;
+    import('./provider-wallet-panels.js')
+      .then(providerPanels => providerPanels.refreshRoutstrBalance())
+      .catch(() => {});
+    return true;
+  },
+};
+
+export function configureSyncRuntimeCallbacks(callbacks = {}) {
+  const previous = { ...syncRuntimeCallbacks };
+  if ('refreshRoutstrBalance' in callbacks) {
+    syncRuntimeCallbacks.refreshRoutstrBalance = typeof callbacks.refreshRoutstrBalance === 'function'
+      ? callbacks.refreshRoutstrBalance
+      : () => false;
+  }
+  return previous;
+}
+
 function getSyncRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -74,10 +95,11 @@ export function refreshSyncedAIProviderUiRuntime() {
 }
 
 export function refreshSyncedRoutstrBalanceRuntime() {
-  const refreshBalance = getRuntimeFunction('refreshRoutstrBalance');
-  if (!refreshBalance) return false;
-  refreshBalance();
-  return true;
+  try {
+    return syncRuntimeCallbacks.refreshRoutstrBalance() !== false;
+  } catch {
+    return false;
+  }
 }
 
 /** @param {string | null} ownerId */

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 7,
-  "legacyWindowGlobalAssignments": 5,
+  "windowGlobalAssignments": 6,
+  "legacyWindowGlobalAssignments": 4,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -35,9 +35,11 @@ import {
   validatePpqKey,
   validateRoutstrKey,
 } from '../js/api.js';
+import { configureApiRuntimeCallbacks } from '../js/api-runtime.js';
 
 const realFetch = globalThis.fetch;
 const realLocation = globalThis.location;
+let previousApiRuntimeCallbacks;
 
 function jsonResponse(body, init = {}) {
   return new Response(JSON.stringify(body), {
@@ -66,7 +68,7 @@ beforeEach(() => {
   clearKeyCaches();
   globalThis.fetch = vi.fn();
   globalThis.location = { origin: 'https://getbased.test', pathname: '/app' };
-  window.showInsufficientBalanceDialog = undefined;
+  previousApiRuntimeCallbacks = configureApiRuntimeCallbacks({ showInsufficientBalanceDialog: () => false });
 });
 
 afterEach(() => {
@@ -74,6 +76,7 @@ afterEach(() => {
   if (realLocation) globalThis.location = realLocation;
   else delete globalThis.location;
   clearKeyCaches();
+  configureApiRuntimeCallbacks(previousApiRuntimeCallbacks);
   vi.restoreAllMocks();
 });
 
@@ -430,13 +433,14 @@ describe('API provider runtime behavior', () => {
     expect(forcedBody).not.toHaveProperty('stream_options');
     expect(onStream).not.toHaveBeenCalled();
 
-    window.showInsufficientBalanceDialog = vi.fn();
+    const showInsufficientBalanceDialog = vi.fn();
+    configureApiRuntimeCallbacks({ showInsufficientBalanceDialog });
     fetch.mockResolvedValueOnce(new Response('{}', { status: 402 }));
     await expect(callOpenRouterAPI({
       messages: [{ role: 'user', content: 'hello again' }],
       requestTimeoutMs: 50,
     })).rejects.toMatchObject({ _modalShown: true });
-    expect(window.showInsufficientBalanceDialog).toHaveBeenCalledTimes(1);
+    expect(showInsufficientBalanceDialog).toHaveBeenCalledTimes(1);
   });
 
   it('reports model capabilities across providers', () => {

--- a/tests/api-runtime.test.js
+++ b/tests/api-runtime.test.js
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 import {
+  configureApiRuntimeCallbacks,
   getApiLocationOriginRuntime,
   getApiLocationPathnameRuntime,
   setApiLocationHrefRuntime,
@@ -19,6 +20,7 @@ function setRuntimeWindow(runtime) {
 }
 
 afterEach(() => {
+  configureApiRuntimeCallbacks({ showInsufficientBalanceDialog: () => false });
   if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
   else delete globalThis.window;
 });
@@ -42,7 +44,7 @@ describe('api runtime adapter', () => {
 
   it('delegates OpenRouter balance dialog access', () => {
     const showInsufficientBalanceDialog = vi.fn();
-    setRuntimeWindow({ showInsufficientBalanceDialog });
+    configureApiRuntimeCallbacks({ showInsufficientBalanceDialog });
 
     expect(showOpenRouterInsufficientBalanceDialogRuntime()).toBe(true);
     expect(showInsufficientBalanceDialog).toHaveBeenCalledTimes(1);
@@ -50,6 +52,7 @@ describe('api runtime adapter', () => {
 
   it('no-ops safely when a browser runtime is missing', () => {
     delete globalThis.window;
+    configureApiRuntimeCallbacks({ showInsufficientBalanceDialog: () => false });
 
     expect(getApiLocationOriginRuntime()).toBe('');
     expect(getApiLocationPathnameRuntime()).toBe('');

--- a/tests/playwright/custom-api-settings.spec.js
+++ b/tests/playwright/custom-api-settings.spec.js
@@ -15,10 +15,7 @@ test('custom API provider panel renders from Settings AI', async ({ page }) => {
   expect(providerValues).toContain('custom');
   expect(providerValues.indexOf('custom')).toBeLessThan(providerValues.indexOf('ollama'));
 
-  await page.evaluate(() => {
-    if (typeof window.switchAIProvider !== 'function') throw new Error('window.switchAIProvider unavailable');
-    window.switchAIProvider('custom');
-  });
+  await page.locator('.ai-provider-btn[data-provider="custom"]').click();
 
   await expect(page.locator('#custom-url-input')).toHaveCount(1);
   await expect(page.locator('#custom-key-input')).toHaveCount(1);
@@ -33,8 +30,6 @@ test('custom API connected state renders model controls', async ({ page }) => {
     const api = await import('/js/api.js');
     const cryptoStore = await import('/js/crypto.js');
     if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
-    if (typeof window.switchAIProvider !== 'function') throw new Error('window.switchAIProvider unavailable');
-
     api.setCustomApiUrl('https://api.test.com/v1');
     cryptoStore.updateKeyCache('labcharts-custom-key', 'sk-test');
     api.setCustomApiModel('test-model');
@@ -44,8 +39,8 @@ test('custom API connected state renders model controls', async ({ page }) => {
     ]));
     api.setAIProvider('custom');
     window.openSettingsModal('ai');
-    window.switchAIProvider('custom');
   });
+  await page.locator('.ai-provider-btn[data-provider="custom"]').click();
 
   await expect(page.locator('#custom-key-status')).toContainText('Connected');
   await expect(page.locator('#custom-model-select')).toHaveCount(1);
@@ -65,14 +60,12 @@ test('custom API provider delegates save model changes and removal', async ({ pa
   ];
 
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.openSettingsModal === 'function'
-      && typeof window.switchAIProvider === 'function'
-  );
+  await page.waitForFunction(() => typeof window.openSettingsModal === 'function');
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
     const crypto = await import('/js/crypto.js');
+    const providerPanels = await import('/js/provider-panels.js');
     const outcomes = {};
     const storageKeys = [
       'labcharts-ai-provider',
@@ -147,7 +140,7 @@ test('custom API provider delegates save model changes and removal', async ({ pa
 
       window.openSettingsModal('ai');
       await waitFor(() => document.getElementById('ai-provider-panel'), 'settings AI panel');
-      window.switchAIProvider('custom');
+      providerPanels.switchAIProvider('custom');
       await waitFor(() =>
         document.getElementById('custom-url-input') && document.getElementById('custom-key-input'),
         'custom API panel controls'

--- a/tests/playwright/custom-api-settings.spec.js
+++ b/tests/playwright/custom-api-settings.spec.js
@@ -15,12 +15,30 @@ test('custom API provider panel renders from Settings AI', async ({ page }) => {
   expect(providerValues).toContain('custom');
   expect(providerValues.indexOf('custom')).toBeLessThan(providerValues.indexOf('ollama'));
 
-  await page.locator('.ai-provider-btn[data-provider="custom"]').click();
+  await page.locator('.ai-provider-btn[data-provider="custom"]').dispatchEvent('click');
 
   await expect(page.locator('#custom-url-input')).toHaveCount(1);
   await expect(page.locator('#custom-key-input')).toHaveCount(1);
   await expect(page.locator('.ai-provider-panel .import-btn-primary')).toHaveCount(1);
   await expect(page.locator('.ai-provider-panel .ai-provider-desc')).toContainText('OpenAI-compatible');
+});
+
+test('lazy provider render follows a provider switch made while loading', async ({ page }) => {
+  await page.goto('/app', { waitUntil: 'load' });
+
+  await page.evaluate(async () => {
+    const api = await import('/js/api.js');
+    const bridge = await import('/js/settings-provider-bridge.js');
+    api.setAIProvider('openrouter');
+    const panel = document.createElement('div');
+    panel.id = 'ai-provider-panel';
+    panel.innerHTML = bridge.renderAIProviderPanelBridge('openrouter');
+    document.body.appendChild(panel);
+    api.setAIProvider('custom');
+  });
+
+  await expect(page.locator('#custom-url-input')).toHaveCount(1);
+  await expect(page.locator('#openrouter-key-input')).toHaveCount(0);
 });
 
 test('custom API connected state renders model controls', async ({ page }) => {
@@ -40,7 +58,7 @@ test('custom API connected state renders model controls', async ({ page }) => {
     api.setAIProvider('custom');
     window.openSettingsModal('ai');
   });
-  await page.locator('.ai-provider-btn[data-provider="custom"]').click();
+  await page.locator('.ai-provider-btn[data-provider="custom"]').dispatchEvent('click');
 
   await expect(page.locator('#custom-key-status')).toContainText('Connected');
   await expect(page.locator('#custom-model-select')).toHaveCount(1);

--- a/tests/playwright/openrouter-settings.spec.js
+++ b/tests/playwright/openrouter-settings.spec.js
@@ -32,10 +32,7 @@ test('OpenRouter provider controls render from Settings AI', async ({ page }) =>
   });
   expect(viewportWidth <= 720 || overflowingProvider === null).toBe(true);
 
-  await page.evaluate(() => {
-    if (typeof window.switchAIProvider !== 'function') throw new Error('window.switchAIProvider unavailable');
-    window.switchAIProvider('openrouter');
-  });
+  await page.locator('.ai-provider-btn[data-provider="openrouter"]').click();
 
   await expect(page.locator('#openrouter-key-input')).toHaveCount(1);
   await expect(page.locator('#openrouter-key-status')).toHaveCount(1);

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -434,8 +434,6 @@ test('provider panels cover provider switching key saves balances custom API and
       openChatPanel: window.openChatPanel,
       loadFocusCard: window.loadFocusCard,
       clearE2EESession: window.clearE2EESession,
-      handleSaveCustomApi: window.handleSaveCustomApi,
-      handleRemoveCustomApi: window.handleRemoveCustomApi,
     };
 
     let openedUrl = '';
@@ -625,12 +623,12 @@ test('provider panels cover provider switching key saves balances custom API and
         <input id="custom-url-input" value="https://custom.example/v1/">
         <input id="custom-key-input" value="sk-custom">
       `;
-      await window.handleSaveCustomApi();
+      await panels.handleSaveCustomApi();
       await wait(0);
       const customSaveRendersConnected = localStorage.getItem('labcharts-custom-url') === 'https://custom.example/v1'
         && document.getElementById('custom-key-status')?.textContent.includes('Connected')
         && document.getElementById('custom-model-select')?.value === 'openai/gpt-5.5';
-      window.handleRemoveCustomApi();
+      panels.handleRemoveCustomApi();
       await wait(0);
       const customRemoveRendersDisconnected = !localStorage.getItem('labcharts-custom-url')
         && document.getElementById('custom-key-status')?.textContent.includes('Not connected');
@@ -667,8 +665,6 @@ test('provider panels cover provider switching key saves balances custom API and
       window.openChatPanel = oldGlobals.openChatPanel;
       window.loadFocusCard = oldGlobals.loadFocusCard;
       window.clearE2EESession = oldGlobals.clearE2EESession;
-      window.handleSaveCustomApi = oldGlobals.handleSaveCustomApi;
-      window.handleRemoveCustomApi = oldGlobals.handleRemoveCustomApi;
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -2,17 +2,12 @@ import { expect, test } from './coverage-fixture.js';
 
 test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.openSettingsModal === 'function'
-      && typeof window.switchAIProvider === 'function'
-      && typeof window.connectRoutstrNode === 'function'
-      && typeof window.doRoutstrNodeDeposit === 'function'
-      && typeof window.doRoutstrNodeWithdraw === 'function'
-  );
+  await page.waitForFunction(() => typeof window.openSettingsModal === 'function');
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
     const cryptoStore = await import('/js/crypto.js');
+    const providerPanels = await import('/js/provider-panels.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -215,7 +210,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
 
       window.openSettingsModal('ai');
       await wait(100);
-      window.switchAIProvider('routstr');
+      providerPanels.switchAIProvider('routstr');
       await wait(150);
 
       const walletRenders = !!document.getElementById('routstr-wallet-balance');
@@ -223,23 +218,23 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       const fundedLegacySessionGetsSyncClock = Number(localStorage.getItem('labcharts-routstr-session-updated-at') || 0) > 0;
       const unseededWalletStatusRenders = (document.getElementById('routstr-wallet-device-status')?.textContent || '').includes('No 12-word wallet seed');
 
-      await window.connectRoutstrNode(nodeUrl);
+      await providerPanels.connectRoutstrNode(nodeUrl);
       await wait(100);
       const fundedWalletRefusesMintSwitch = setMintUrl === null
         && currentMint === 'https://mint-old.example'
         && document.getElementById('routstr-node-picker')?.style.display === 'none';
 
       walletBalance = 0;
-      await window.connectRoutstrNode(nodeUrl);
+      await providerPanels.connectRoutstrNode(nodeUrl);
       await wait(100);
       const emptyWalletSwitchesMint = setMintUrl === 'https://mint-required.example';
 
       walletBalance = 1500;
-      await window.connectRoutstrNode(nodeUrl);
+      await providerPanels.connectRoutstrNode(nodeUrl);
       await wait(100);
       const connectRendersDepositPicker = !!document.getElementById('routstr-deposit-amount');
 
-      await window.doRoutstrNodeDeposit(nodeUrl, 500);
+      await providerPanels.doRoutstrNodeDeposit(nodeUrl, 500);
       await wait(150);
       const fundAreaText = document.getElementById('routstr-wallet-fund-area')?.textContent || '';
       const depositUsesSessionKey = depositArgs?.url === nodeUrl
@@ -253,7 +248,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
 
       localStorage.setItem('labcharts-routstr-key', 'sk-routstr-dom');
       cryptoStore.updateKeyCache('labcharts-routstr-key', 'sk-routstr-dom');
-      await window.doRoutstrNodeWithdraw();
+      await providerPanels.doRoutstrNodeWithdraw();
       await wait(50);
       const refundBlockedUntilSeedAck = !refundCalled
         && !!document.getElementById('routstr-seed-continue');
@@ -261,7 +256,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       if (refundSeedAck) {
         refundSeedAck.checked = true;
         refundSeedAck.dispatchEvent(new Event('change', { bubbles: true }));
-        window.walletSeedAcknowledged();
+        providerPanels.walletSeedAcknowledged();
       }
       await wait(150);
       const refundUsesSessionKey = refundCalled;
@@ -272,7 +267,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       const refundClearsPendingWithdraw = clearPendingWithdrawCalled;
       const routstrKeyClearsAfterRefund = !api.getRoutstrKey();
 
-      await window.showWalletSeedPhrase();
+      await providerPanels.showWalletSeedPhrase();
       await wait(50);
       const restoreInput = document.getElementById('routstr-restore-seed');
       const restoreTextareaRenders = !!restoreInput;
@@ -281,12 +276,12 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       if (restoreInput) {
         restoreInput.value = 'abandon ability able about above absent absorb abstract absurd abuse access accident';
       }
-      await window.doRoutstrWalletRestore();
+      await providerPanels.doRoutstrWalletRestore();
       await wait(50);
       const restoreUsesNormalizedMnemonic = restoredMnemonic === restoreInput?.value;
       const restoreReportsBalance = (document.getElementById('routstr-restore-status')?.textContent || '').includes('4,321');
 
-      await window.showRoutstrWalletFund();
+      await providerPanels.showRoutstrWalletFund();
       await wait(50);
       const continueBtn = document.getElementById('routstr-seed-continue');
       const ack = document.getElementById('routstr-seed-ack');
@@ -298,7 +293,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
         ack.checked = true;
         ack.dispatchEvent(new Event('change', { bubbles: true }));
         seedAckEnablesContinue = !continueBtn.disabled;
-        window.walletSeedAcknowledged();
+        providerPanels.walletSeedAcknowledged();
         await wait(50);
         seedAckProceedsToFunding = !!document.getElementById('routstr-wcashu-input');
       }

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -43,8 +43,6 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       currentProfile: state.currentProfile,
       profiles: state.profiles,
       fetch: window.fetch,
-      initSettingsOllamaCheck: window.initSettingsOllamaCheck,
-      initSettingsModelFetch: window.initSettingsModelFetch,
       getMeteoConfig: window.getMeteoConfig,
       saveMeteoConfig: window.saveMeteoConfig,
       theme: localStorage.getItem('labcharts-theme'),
@@ -74,8 +72,6 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
         if (href.endsWith('/api/commit')) return jsonResponse({ sha: 'abcdef1234567890', ref: 'main' });
         return jsonResponse({});
       };
-      window.initSettingsOllamaCheck = () => {};
-      window.initSettingsModelFetch = () => {};
       localStorage.removeItem('labcharts-accent');
       localStorage.removeItem('labcharts-sunset-mode');
       localStorage.removeItem('labcharts-crt-effects');
@@ -179,8 +175,6 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       return results;
     } finally {
       window.fetch = saved.fetch;
-      window.initSettingsOllamaCheck = saved.initSettingsOllamaCheck;
-      window.initSettingsModelFetch = saved.initSettingsModelFetch;
       window.getMeteoConfig = saved.getMeteoConfig;
       window.saveMeteoConfig = saved.saveMeteoConfig;
       state.currentProfile = saved.currentProfile;

--- a/tests/playwright/startup-oauth-browser-coverage.spec.js
+++ b/tests/playwright/startup-oauth-browser-coverage.spec.js
@@ -33,7 +33,6 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     const savedLocal = snapshotStorage(localStorage);
     const savedSession = snapshotStorage(sessionStorage);
     const originalFetch = window.fetch;
-    const originalBalanceDialog = window.showInsufficientBalanceDialog;
     const originalSetTimeout = window.setTimeout;
     const originalReplaceState = history.replaceState;
     const originalPushState = history.pushState;
@@ -51,6 +50,9 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     const originalStartupOAuthDeps = startup.configureStartupOAuthCallbackDeps({
       showNotification: (message, type, duration) => {
         notifications.push({ message: String(message), type, duration });
+      },
+      showInsufficientBalanceDialog: () => {
+        balanceDialogs += 1;
       },
     });
 
@@ -70,9 +72,6 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     try {
       window.updateChatHeaderModel = () => {};
       window.refreshWebSearchToggle = () => {};
-      window.showInsufficientBalanceDialog = () => {
-        balanceDialogs += 1;
-      };
       history.replaceState = function replaceStateSpy(state, title, url) {
         replaceCalls.push({ title, url });
         return originalReplaceState.call(history, state, title, url);
@@ -265,7 +264,6 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     } finally {
       window.fetch = originalFetch;
       startup.configureStartupOAuthCallbackDeps(originalStartupOAuthDeps);
-      window.showInsufficientBalanceDialog = originalBalanceDialog;
       window.setTimeout = originalSetTimeout;
       history.replaceState = originalReplaceState;
       window.updateChatHeaderModel = originalUpdateChatHeaderModel;

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -43,6 +43,7 @@ import { maybeScheduleRebroadcast } from '../js/sync-pull-rebroadcast.js';
 import { applyCommittedDeltas, planProfileDeltas } from '../js/sync-push-deltas.js';
 import { configureSyncPush, isSyncPushInFlight, pushProfile } from '../js/sync-push.js';
 import {
+  configureSyncRuntimeCallbacks,
   dispatchSyncOwnerChangedRuntime,
   getSyncReloadUrlRuntime,
   refreshSyncedAIProviderUiRuntime,
@@ -79,6 +80,8 @@ import { buildAgentAccessSetupCommand } from '../js/settings-agent-access-panel.
 const PROFILE_ID = 'profile-runtime';
 const PROFILE_QUERY = Symbol('profile-query');
 const ITEM_ROW_QUERY = Symbol('item-row-query');
+let previousSyncRuntimeCallbacks;
+let refreshRoutstrBalance;
 
 function deltaKey(profileId, arrayName) {
   return `labcharts-${profileId}-delta-${arrayName}`;
@@ -152,7 +155,8 @@ beforeEach(() => {
   updateKeyCache('labcharts-cashu-wallet-mnemonic', '');
   window.updateChatHeaderModel = vi.fn();
   window.refreshWebSearchToggle = vi.fn();
-  window.refreshRoutstrBalance = vi.fn();
+  refreshRoutstrBalance = vi.fn();
+  previousSyncRuntimeCallbacks = configureSyncRuntimeCallbacks({ refreshRoutstrBalance });
   state.currentProfile = PROFILE_ID;
   state.importedData = { entries: [], agentAccess: null };
   localStorage.setItem('labcharts-active-profile', PROFILE_ID);
@@ -162,6 +166,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  configureSyncRuntimeCallbacks(previousSyncRuntimeCallbacks);
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -245,7 +250,7 @@ describe('sync apply runtime behavior', () => {
     expect(getCachedKey('labcharts-routstr-key')).toBe('sk-remote-funded');
     expect(localStorage.getItem('labcharts-routstr-node')).toBe('https://node.remote.test');
     expect(localStorage.getItem('labcharts-routstr-session-updated-at')).toBe('200');
-    expect(window.refreshRoutstrBalance).toHaveBeenCalledTimes(1);
+    expect(refreshRoutstrBalance).toHaveBeenCalledTimes(1);
 
     await applyAISettings({
       'labcharts-routstr-key': 'sk-stale',
@@ -253,7 +258,7 @@ describe('sync apply runtime behavior', () => {
       'labcharts-routstr-session-updated-at': '150',
     });
     expect(getCachedKey('labcharts-routstr-key')).toBe('sk-remote-funded');
-    expect(window.refreshRoutstrBalance).toHaveBeenCalledTimes(1);
+    expect(refreshRoutstrBalance).toHaveBeenCalledTimes(1);
 
     await applyAISettings({
       'labcharts-routstr-key': 'sk-legacy-profile-row',
@@ -261,14 +266,14 @@ describe('sync apply runtime behavior', () => {
     });
     expect(getCachedKey('labcharts-routstr-key')).toBe('sk-remote-funded');
     expect(localStorage.getItem('labcharts-routstr-node')).toBe('https://node.remote.test');
-    expect(window.refreshRoutstrBalance).toHaveBeenCalledTimes(1);
+    expect(refreshRoutstrBalance).toHaveBeenCalledTimes(1);
 
     await applyAISettings({
       'labcharts-routstr-key': 'sk-remote-funded',
       'labcharts-routstr-node': 'https://node.remote.test',
       'labcharts-routstr-session-updated-at': '300',
     });
-    expect(window.refreshRoutstrBalance).toHaveBeenCalledTimes(2);
+    expect(refreshRoutstrBalance).toHaveBeenCalledTimes(2);
   });
 
   it('applies remote AI settings, respects local locks, and writes display prefs', async () => {

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -28,12 +28,11 @@ function assert(name, condition, detail) {
 
 console.log('=== Custom API Provider Tests ===\n');
 
-// api.js exposes Custom-provider helpers as ES module exports. provider-panels.js
-// still exposes UI handlers used by legacy HTML/event wiring.
+// Custom-provider helpers and provider-panel UI handlers are module-only APIs.
 await import('../js/state.js');
 const api = await import('../js/api.js');
 const cryptoModule = await import('../js/crypto.js');
-await import('../js/provider-panels.js');
+const providerPanels = await import('../js/provider-panels.js');
 
 // ─── 1. api.js source inspection ───
 console.log('1. api.js source inspection');
@@ -80,10 +79,11 @@ assert('api.getCustomApiModelDisplay is function', typeof api.getCustomApiModelD
 assert('api.fetchCustomApiModels is function', typeof api.fetchCustomApiModels === 'function');
 assert('api.validateCustomApiKey is function', typeof api.validateCustomApiKey === 'function');
 assert('api.callCustomAPI is function', typeof api.callCustomAPI === 'function');
-assert('window.handleSaveCustomApi is function', typeof window.handleSaveCustomApi === 'function');
-assert('window.handleRemoveCustomApi is function', typeof window.handleRemoveCustomApi === 'function');
-assert('window.renderCustomApiModelDropdown is function', typeof window.renderCustomApiModelDropdown === 'function');
-assert('window.applyCustomApiManualModel is function', typeof window.applyCustomApiManualModel === 'function');
+assert('providerPanels.handleSaveCustomApi is function', typeof providerPanels.handleSaveCustomApi === 'function');
+assert('providerPanels.handleRemoveCustomApi is function', typeof providerPanels.handleRemoveCustomApi === 'function');
+assert('providerPanels.renderCustomApiModelDropdown is function', typeof providerPanels.renderCustomApiModelDropdown === 'function');
+assert('providerPanels.applyCustomApiManualModel is function', typeof providerPanels.applyCustomApiManualModel === 'function');
+assert('custom provider handlers stay off window', !('handleSaveCustomApi' in window));
 
 // ─── 3. URL management ───
 console.log('\n3. URL management');

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -131,6 +131,7 @@ assert('settings provider bridge has eager provider switch', settingsBridgeSrc.i
 assert('eager provider bridge persists selection synchronously', settingsBridgeSrc.includes('setAIProvider(provider);'));
 assert('settings provider bridge resolves module APIs without publishing globals',
   settingsBridgeSrc.includes('providerPanels.switchAIProvider(provider)') &&
+    settingsBridgeSrc.includes('providerPanels.renderAIProviderPanel(getAIProvider())') &&
     !settingsBridgeSrc.includes('settingsWindow') &&
     !settingsBridgeSrc.includes('PROVIDER_PANEL_BRIDGE_NAMES'));
 assert('settings records existing provider before provider-key onboarding return',

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -26,11 +26,10 @@ function assert(name, condition, detail) {
 
 console.log('=== OpenRouter Integration Tests ===\n');
 
-// api.js exposes provider helpers as ES module exports; provider-panels.js
-// still exposes UI handlers used by legacy HTML/event wiring.
+// Provider helpers and provider-panel UI handlers are module-only APIs.
 await import('../js/state.js');
 const api = await import('../js/api.js');
-await import('../js/provider-panels.js');
+const providerPanels = await import('../js/provider-panels.js');
 
 // ─── 1. api.js source inspection ───
 console.log('1. api.js source inspection');
@@ -125,9 +124,15 @@ const settingsSrc = read('js/settings.js');
 assert('provider button with data-provider="openrouter"', settingsSrc.includes('data-provider="openrouter"'));
 assert('OpenRouter provider button uses delegated settings action',
   /<button[^>]*data-provider="openrouter"[^>]*data-settings-action="switch-ai-provider"/.test(settingsSrc));
-assert('settings installs provider bridge module', settingsSrc.includes('installSettingsProviderBridge();'));
+assert('settings calls provider bridge APIs directly',
+  settingsSrc.includes('renderAIProviderPanelBridge(provider)') &&
+    settingsSrc.includes('initSettingsProviderPanels()'));
 assert('settings provider bridge has eager provider switch', settingsBridgeSrc.includes('function switchAIProviderBridge(provider)'));
 assert('eager provider bridge persists selection synchronously', settingsBridgeSrc.includes('setAIProvider(provider);'));
+assert('settings provider bridge resolves module APIs without publishing globals',
+  settingsBridgeSrc.includes('providerPanels.switchAIProvider(provider)') &&
+    !settingsBridgeSrc.includes('settingsWindow') &&
+    !settingsBridgeSrc.includes('PROVIDER_PANEL_BRIDGE_NAMES'));
 assert('settings records existing provider before provider-key onboarding return',
   settingsSrc.includes('settingsWindow._settingsHadProvider = hasAIProvider();')
     && ppSrc.includes("if (getProviderPanelRuntimeValue('_settingsHadProvider')) return"));
@@ -144,10 +149,12 @@ assert('initSettingsModelFetch fetches OpenRouter', ppSrc.includes('fetchOpenRou
 const orPanelIdx = providerRenderSrc.indexOf("provider === 'openrouter'");
 const venicePanelIdx = providerRenderSrc.indexOf("provider === 'venice'");
 assert('renderAIProviderPanel: openrouter before venice', orPanelIdx < venicePanelIdx, `openrouter@${orPanelIdx}, venice@${venicePanelIdx}`);
-assert('window exports handleSaveOpenRouterKey', ppSrc.includes('handleSaveOpenRouterKey,'));
-assert('window exports handleRemoveOpenRouterKey', ppSrc.includes('handleRemoveOpenRouterKey,'));
-assert('window exports renderOpenRouterModelDropdown', ppSrc.includes('renderOpenRouterModelDropdown,'));
-assert('window exports updateOpenRouterModelPricing', ppSrc.includes('updateOpenRouterModelPricing,'));
+assert('provider panels export handleSaveOpenRouterKey as a module API', typeof providerPanels.handleSaveOpenRouterKey === 'function');
+assert('provider panels export handleRemoveOpenRouterKey as a module API', typeof providerPanels.handleRemoveOpenRouterKey === 'function');
+assert('provider panels export renderOpenRouterModelDropdown as a module API', typeof providerPanels.renderOpenRouterModelDropdown === 'function');
+assert('provider panels export updateOpenRouterModelPricing as a module API', typeof providerPanels.updateOpenRouterModelPricing === 'function');
+assert('provider panels do not publish the legacy window facade',
+  !ppSrc.includes('Object.assign(window') && !('handleSaveOpenRouterKey' in window));
 assert('OpenRouter OAuth remembers previous provider before empty-key switch',
   ppSrc.includes('rememberOpenRouterOAuthPreviousProvider(previousProvider)'));
 assert('manual OpenRouter key save clears pending OAuth restore state',
@@ -215,10 +222,10 @@ assert('api.getOpenRouterModelDisplay is function', typeof api.getOpenRouterMode
 assert('api.fetchOpenRouterModels is function', typeof api.fetchOpenRouterModels === 'function');
 assert('api.validateOpenRouterKey is function', typeof api.validateOpenRouterKey === 'function');
 assert('api.callOpenRouterAPI is function', typeof api.callOpenRouterAPI === 'function');
-assert('window.handleSaveOpenRouterKey is function', typeof window.handleSaveOpenRouterKey === 'function');
-assert('window.handleRemoveOpenRouterKey is function', typeof window.handleRemoveOpenRouterKey === 'function');
-assert('window.renderOpenRouterModelDropdown is function', typeof window.renderOpenRouterModelDropdown === 'function');
-assert('window.updateOpenRouterModelPricing is function', typeof window.updateOpenRouterModelPricing === 'function');
+assert('providerPanels.handleSaveOpenRouterKey is function', typeof providerPanels.handleSaveOpenRouterKey === 'function');
+assert('providerPanels.handleRemoveOpenRouterKey is function', typeof providerPanels.handleRemoveOpenRouterKey === 'function');
+assert('providerPanels.renderOpenRouterModelDropdown is function', typeof providerPanels.renderOpenRouterModelDropdown === 'function');
+assert('providerPanels.updateOpenRouterModelPricing is function', typeof providerPanels.updateOpenRouterModelPricing === 'function');
 
 // ─── 8. Key/model management (localStorage) ───
 console.log('\n8. Key/model management');

--- a/tests/test-ppq-provider.js
+++ b/tests/test-ppq-provider.js
@@ -20,7 +20,7 @@ function assert(name, condition, detail) {
 
 console.log('=== PPQ Provider Panel Tests ===\n');
 
-await import('../js/provider-panels.js');
+const providerPanels = await import('../js/provider-panels.js');
 
 const panelsSrc = read('js/provider-panels.js');
 const ppqSrc = read('js/provider-ppq-panels.js');
@@ -81,13 +81,14 @@ assert('Tinfoil browser bundle exports SecureClient', typeof tinfoilModule.Secur
 assert('EHBP browser bundle exports request primitives', typeof ehbpModule.Identity === 'function' && typeof ehbpModule.decryptResponseWithToken === 'function');
 
 console.log('\n3. Runtime exports');
-assert('window.handleCreatePpqAccount exported', typeof window.handleCreatePpqAccount === 'function');
-assert('window.handleSavePpqKey exported', typeof window.handleSavePpqKey === 'function');
-assert('window.handleRemovePpqKey exported', typeof window.handleRemovePpqKey === 'function');
-assert('window.refreshPpqBalance exported', typeof window.refreshPpqBalance === 'function');
-assert('window.showPpqTopup exported', typeof window.showPpqTopup === 'function');
-assert('window.doPpqTopup exported', typeof window.doPpqTopup === 'function');
-assert('window.cancelPpqTopup exported', typeof window.cancelPpqTopup === 'function');
+assert('providerPanels.handleCreatePpqAccount exported', typeof providerPanels.handleCreatePpqAccount === 'function');
+assert('providerPanels.handleSavePpqKey exported', typeof providerPanels.handleSavePpqKey === 'function');
+assert('providerPanels.handleRemovePpqKey exported', typeof providerPanels.handleRemovePpqKey === 'function');
+assert('providerPanels.refreshPpqBalance exported', typeof providerPanels.refreshPpqBalance === 'function');
+assert('providerPanels.showPpqTopup exported', typeof providerPanels.showPpqTopup === 'function');
+assert('providerPanels.doPpqTopup exported', typeof providerPanels.doPpqTopup === 'function');
+assert('providerPanels.cancelPpqTopup exported', typeof providerPanels.cancelPpqTopup === 'function');
+assert('PPQ panel handlers stay off window', !('handleCreatePpqAccount' in window));
 
 console.log('\n4. App shell');
 assert('service worker caches PPQ module', swSrc.includes("'/js/provider-ppq-panels.js'"));

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -56,6 +56,9 @@ assert('provider-panels installs provider panel delegates',
     panelsSrc.includes('installProviderPanelDelegates({') &&
     panelsSrc.includes('handleSaveOpenRouterKey') &&
     panelsSrc.includes('setOllamaMainModel'));
+assert('provider panel handlers stay module-only',
+  !panelsSrc.includes('Object.assign(window') &&
+    !panelsSrc.includes('WINDOW EXPORTS'));
 assert('provider panel delegates install idempotent listeners',
   delegatesSrc.includes('let providerPanelDelegatesInstalled = false') &&
     delegatesSrc.includes("document.addEventListener('click', _handleProviderPanelClick)") &&

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1268,7 +1268,7 @@ await import('../js/settings.js');
     syncApplySrc.includes('remoteRoutstrIsNewer')
       && syncApplySrc.includes('localRoutstrIsNewer')
       && syncApplySrc.includes('refreshSyncedRoutstrBalanceRuntime()')
-      && syncRuntimeSrc.includes("getRuntimeFunction('refreshRoutstrBalance')")
+      && syncRuntimeSrc.includes('syncRuntimeCallbacks.refreshRoutstrBalance()')
       && apiProviderStorageSrc.includes('export function touchRoutstrSession()')
       && apiProviderStorageRuntimeSrc.includes('export function touchRoutstrSessionClock()')
       && apiProviderStorageRuntimeSrc.includes('Math.max(Date.now(), previous + 1)')

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -188,7 +188,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -204,6 +204,7 @@
     import('../js/pdf-import.js'),
     import('../js/pii.js'),
     import('../js/profile.js'),
+    import('../js/provider-panels.js'),
     import('../js/settings-sync-panel.js'),
     import('../js/sun-context.js'),
     import('../js/sun-spectrum.js'),
@@ -508,7 +509,7 @@
     'renderDataEntriesSection','refreshDataEntriesSection','configureSettingsRuntime'
   ];
 
-  // provider-panels.js (72)
+  // provider-panels.js (74 former browser globals, now module-only)
   const providerPanelsExports = [
     'renderAIProviderPanel','toggleAIPause','switchAIProvider',
     'initSettingsModelFetch','initSettingsOllamaCheck',
@@ -524,14 +525,14 @@
     'doRoutstrWalletReceiveCashu','showRoutstrMintEdit','doRoutstrMintChange',
     'showRoutstrWalletBackup','showRoutstrNodePicker','connectRoutstrNode',
     'doRoutstrNodeDeposit','doRoutstrNodeWithdraw','_setActiveNodeAction',
-    'walletSeedAcknowledged','showWalletSeedPhrase',
+    'walletSeedAcknowledged','setupRoutstrWalletSeed','showWalletSeedPhrase',
     'showRoutstrWithdraw','showRoutstrWithdrawLightning','showRoutstrWithdrawToken',
     'doRoutstrSendToken','doRoutstrWithdrawQuote','doRoutstrWithdrawExecute','doRoutstrWalletRestore',
     'handleCreatePpqAccount','dismissPpqKeyReveal',
     'handleSavePpqKey','handleRemovePpqKey','renderPpqModelDropdown',
     'updatePpqModelPricing','refreshPpqBalance',
     'showPpqTopup','selectPpqMethod','doPpqTopup','ppqShowCustomInput','doPpqTopupCustom','cancelPpqTopup',
-    'refreshOpenRouterBalance',
+    'refreshOpenRouterBalance','showInsufficientBalanceDialog',
     'handleSaveCustomApi','handleRemoveCustomApi','renderCustomApiModelDropdown',
     'applyCustomApiManualModel','updateCustomModelPricing',
     'copyOllamaPullCmd','refreshModelAdvisor',
@@ -628,6 +629,7 @@
     ['pdf-import.js', pdfImportModule, pdfImportExports],
     ['pii.js', piiModule, piiExports],
     ['profile.js', profileModule, profileExports],
+    ['provider-panels.js', providerPanelsModule, providerPanelsExports],
     ['settings-sync-panel.js', settingsSyncPanelModule, settingsSyncPanelExports],
     ['sun-context.js', sunContextModule, sunContextExports],
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
@@ -686,6 +688,9 @@
   for (const name of cashuWalletLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of providerPanelsExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
 
   const allModules = {
     'chat.js': chatExports,
@@ -695,7 +700,6 @@
     'nav.js': navExports,
     'notes.js': notesExports,
     'settings.js': settingsExports,
-    'provider-panels.js': providerPanelsExports,
     'theme.js': themeExports,
     'views.js': viewsExports,
   };

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.202';
+self.APP_VERSION = '1.10.203';


### PR DESCRIPTION
## Summary
- remove the 74-name provider-panel `window` facade and its lazy global bridge registry
- call provider-panel ES module exports directly from Settings and route runtime/OAuth/sync integrations through explicit callbacks
- lower the legacy-global quality baseline and bump the app cache version to 1.10.203

## Validation
- `./run-tests.sh` — 123 module checks, 396 Vitest tests, 18 origin/security tests, 351 Playwright tests, 472 responsive checks
- `npm run quality`
- `git diff --check`