### PR TITLE
Make context cards module-only

### DIFF
--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -6,6 +6,7 @@ import { hasAIProvider, isAIPaused } from './api.js';
 import { getActiveData } from './data.js';
 import { getProfileHeight, getProfileLocation, getProfiles } from './profile.js';
 import { renderProfileContextCards } from './context-cards.js';
+import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 import { openMenstrualCycleEditor } from './cycle.js';
 import { openSupplementsEditor } from './supplements.js';
 import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
@@ -85,7 +86,7 @@ function handleChatEmptyClick(event) {
     openSupplementsEditor();
   } else if (action === 'import-dna') {
     closeChatPanel();
-    callChatEmptyRuntime('triggerDNAFilePicker');
+    triggerContextCardDNAFilePickerRuntime();
   } else if (action === 'import-mtdna') {
     const input = /** @type {HTMLInputElement | null} */ (event.currentTarget?.querySelector('#mtdna-onboard-input') || null);
     closeChatPanel();

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // chat-runtime.js - Browser runtime adapters for shared chat hooks.
 
+import { openContextModalRuntime } from './context-cards-runtime.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -34,7 +36,7 @@ export function updateDiscussButtonRuntime() {
 }
 
 export function openChatContextModalRuntime() {
-  getRuntimeFunction('openContextModal')?.();
+  openContextModalRuntime();
 }
 
 export function closeChatModalRuntime() {

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -36,9 +36,9 @@ import {
   dashboardAIActionAttrs,
   installDashboardAIActionDelegates,
 } from './context-card-dashboard-ai-actions.js';
+import { openInterpretiveLensEditorRuntime } from './context-cards-runtime.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
-  openInterpretiveLensEditor?: () => void,
   handleDNAFile?: (file: File) => void,
   updateChatContextStatus?: () => void,
 }} */ (typeof window !== 'undefined' ? window : {});
@@ -57,7 +57,7 @@ export function configureDashboardAIDataProtectionDeps(deps = {}) {
 }
 
 configureDashboardAIActionDelegates({
-  'open-interpretive-lens': () => appWindow.openInterpretiveLensEditor?.(),
+  'open-interpretive-lens': () => openInterpretiveLensEditorRuntime(),
   'open-knowledge-base': () => openKnowledgeBaseModal(),
   'open-personalize-ai-picker': () => openContextModal(),
   'enable-encryption': () => dashboardAIDataProtectionDeps.showEnableEncryptionModal(),
@@ -783,8 +783,8 @@ export function openContextModal() {
     button.onclick = () => {
       const pick = button.getAttribute('data-pick');
       close();
-      if (pick === 'lens' && typeof appWindow.openInterpretiveLensEditor === 'function') {
-        appWindow.openInterpretiveLensEditor();
+      if (pick === 'lens') {
+        openInterpretiveLensEditorRuntime();
       } else if (pick === 'kb') {
         openKnowledgeBaseModal();
       }

--- a/js/context-card-lifestyle-runtime.js
+++ b/js/context-card-lifestyle-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // context-card-lifestyle-runtime.js - Browser runtime adapters for lifestyle context editors.
 
+import { openContextModalRuntime } from './context-cards-runtime.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -63,6 +65,6 @@ export function discussDietContaminantsRuntime() {
 export function returnToLifestyleContextModalRuntime() {
   closeLifestyleContextModalRuntime();
   setTimeout(() => {
-    getRuntimeFunction('openContextModal')?.();
+    openContextModalRuntime();
   }, 0);
 }

--- a/js/context-cards-runtime.js
+++ b/js/context-cards-runtime.js
@@ -1,0 +1,51 @@
+// @ts-check
+// context-cards-runtime.js - Explicit callbacks for context-card integrations.
+
+/** @type {Record<string, Function | null>} */
+const contextCardsRuntimeCallbacks = {
+  openContextModal: null,
+  openInterpretiveLensEditor: null,
+  recordChange: null,
+  triggerDNAFilePicker: null,
+};
+
+/** @param {Record<string, any>} [callbacks] */
+export function configureContextCardsRuntimeCallbacks(callbacks = {}) {
+  const previous = { ...contextCardsRuntimeCallbacks };
+  for (const name of Object.keys(contextCardsRuntimeCallbacks)) {
+    if (name in callbacks) {
+      contextCardsRuntimeCallbacks[name] = typeof callbacks[name] === 'function'
+        ? callbacks[name]
+        : null;
+    }
+  }
+  return previous;
+}
+
+function callContextCardsRuntime(name, ...args) {
+  const callback = contextCardsRuntimeCallbacks[name];
+  if (typeof callback !== 'function') return false;
+  try {
+    callback(...args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function openContextModalRuntime() {
+  return callContextCardsRuntime('openContextModal');
+}
+
+export function openInterpretiveLensEditorRuntime() {
+  return callContextCardsRuntime('openInterpretiveLensEditor');
+}
+
+/** @param {string} field */
+export function recordContextCardChangeRuntime(field) {
+  return callContextCardsRuntime('recordChange', field);
+}
+
+export function triggerContextCardDNAFilePickerRuntime() {
+  return callContextCardsRuntime('triggerDNAFilePicker');
+}

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -1,5 +1,5 @@
 // @ts-check
-// context-cards.js - dashboard context card facade and shared lifecycle
+// context-cards.js - dashboard context card module surface and shared lifecycle
 
 import { state } from './state.js';
 import { escapeAttr, escapeHTML, showNotification } from './utils.js';
@@ -7,6 +7,7 @@ import { saveImportedData, getActiveData } from './data.js';
 import { hasAIProvider } from './api.js';
 import { openModalOverlay } from './modal-lifecycle.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
+import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
 import {
   appendImportedArrayItem,
   ensureImportedArray,
@@ -455,7 +456,7 @@ export async function loadContextCardTips() {
 }
 
 // ── Card tips modal ──
-function openCardTipsModal(cardKey) {
+export function openCardTipsModal(cardKey) {
   const appWindow = /** @type {any} */ (window);
   if (!appWindow.renderCardTipsModal) return;
   const html = appWindow.renderCardTipsModal(cardKey);
@@ -468,91 +469,9 @@ function openCardTipsModal(cardKey) {
   openModalOverlay(overlay);
 }
 
-// ── Window exports for onclick handlers ──
-Object.assign(window, {
-  getConditionsSummary,
-  getDietSummary,
-  getExerciseSummary,
-  getSleepSummary,
-  getLightCircadianSummary,
-  getStressSummary,
-  getLoveLifeSummary,
-  getEnvironmentSummary,
-  getGoalsSummary,
-  isContextFilled,
-  renderProfileContextCards,
-  debounceContextNotes,
-  applyDotColor,
-  applyAISummary,
-  getCardFingerprint,
-  loadContextHealthDots,
-  refreshAllHealthDots,
-  renderSelectField,
-  selectCtxOption,
-  getSelectedOption,
-  renderTagsField,
-  toggleCtxTag,
-  getSelectedTags,
-  renderNoteField,
-  contextEditorActions,
-  saveAndRefresh,
-  openDiagnosesEditor,
-  renderDiagnosesModal,
-  filterConditionSuggestions,
-  selectConditionSuggestion,
-  closeSuggestionsOnClickOutside,
-  syncDiagnosesNote,
-  addCondition,
-  editCondition,
-  cancelConditionEdit,
-  deleteCondition,
-  addFamilyHistoryEntry,
-  editFamilyHistoryEntry,
-  cancelFamilyHistoryEdit,
-  deleteFamilyHistoryEntry,
-  filterFamilyConditionSuggestions,
-  selectFamilyConditionSuggestion,
-  saveDiagnoses,
-  closeDiagnoses,
-  clearDiagnoses,
-  openDietEditor,
-  saveDiet,
-  clearDiet,
-  openSleepRestEditor,
-  saveSleepRest,
-  clearSleepRest,
-  openLightCircadianEditor,
-  saveLightCircadian,
-  clearLightCircadian,
-  openExerciseEditor,
-  saveExercise,
-  clearExercise,
-  openStressEditor,
-  saveStress,
-  clearStress,
-  openLoveLifeEditor,
-  saveLoveLife,
-  clearLoveLife,
-  openEnvironmentEditor,
-  saveEnvironment,
-  clearEnvironment,
-  openHealthGoalsEditor,
-  renderHealthGoalsModal,
-  addHealthGoal,
-  deleteHealthGoal,
-  closeHealthGoals,
-  clearHealthGoals,
-  openInterpretiveLensEditor,
-  saveInterpretiveLens,
-  clearInterpretiveLens,
-  renderInterpretiveLensSection,
-  renderKnowledgeBaseSection,
+configureContextCardsRuntimeCallbacks({
   openContextModal,
-  openPersonalizeAIPicker,
-  openDataProtectionPicker,
-  triggerDNAFilePicker,
+  openInterpretiveLensEditor,
   recordChange,
-  showDietContaminantsModal,
-  openCardTipsModal,
-  loadContextCardTips,
+  triggerDNAFilePicker,
 });

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -8,6 +8,7 @@ import { getActiveProfileId, setProfileSex } from './profile.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { endTour } from './tour.js';
 import { escapeAttr, escapeHTML, showConfirmDialog, showNotification } from './utils.js';
+import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
 import {
   buildCycleCoverage,
   normalizeCyclePeriods,
@@ -58,7 +59,6 @@ const SOURCE_LABELS = {
   manual: 'Manual',
 };
 const appWindow = /** @type {Window & typeof globalThis & {
-  recordChange?: (field: string) => void,
   navigate?: (category: string) => void,
   renderProfileButton?: () => void,
   closeModal?: () => void,
@@ -435,7 +435,7 @@ export async function commitCycleImport(parsed, { conflictMode = 'keep-existing'
     };
     const base = { ...(state.importedData.menstrualCycle || {}), periods: plan.mergedPeriods, coverage };
     state.importedData.menstrualCycle = await applyRawObservationCounts(base, profileId, parsed.source);
-    appWindow.recordChange?.('menstrualCycle');
+    recordContextCardChangeRuntime('menstrualCycle');
     await persistCycleState();
     return {
       observations: observations.length,
@@ -479,7 +479,7 @@ export async function deleteCycleImportFromProfile(importId) {
   };
   const remainingRows = rawRows.filter(row => row.importId !== importId);
   state.importedData.menstrualCycle = await applyRawObservationCounts(next, profileId, source, remainingRows);
-  appWindow.recordChange?.('menstrualCycle');
+  recordContextCardChangeRuntime('menstrualCycle');
   let persisted = false;
   try {
     await persistCycleState();
@@ -502,7 +502,7 @@ export async function deleteCycleSourceFromProfile(source) {
   const rawRows = await getAllCycleObservationsRaw(profileId).catch(() => []);
   const next = { ...mc, periods: (mc.periods || []).filter(period => period.source !== source) };
   state.importedData.menstrualCycle = await applyRawObservationCounts(next, profileId, source, rawRows.filter(row => row.source !== source));
-  appWindow.recordChange?.('menstrualCycle');
+  recordContextCardChangeRuntime('menstrualCycle');
   let persisted = false;
   try {
     await persistCycleState();
@@ -520,7 +520,7 @@ export async function clearCycleProfileData() {
   const profileId = getActiveProfileId();
   const snapshot = snapshotCycleState();
   state.importedData.menstrualCycle = null;
-  appWindow.recordChange?.('menstrualCycle');
+  recordContextCardChangeRuntime('menstrualCycle');
   let persisted = false;
   try {
     await persistCycleState();

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -8,6 +8,7 @@ import { openModalOverlay } from './modal-lifecycle.js';
 import { startCycleTour } from './tour.js';
 import { createCyclePeriod, recentCyclePeriods, upgradeMenstrualCycleProfile } from './cycle-summary.js';
 import { clearCycleProfileData, renderCycleImportPickerControls, renderCycleImportSummarySection } from './cycle-import.js';
+import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
 const CYCLE_ACTIVE_STATUSES = new Set(['regular', 'perimenopause']);
 const CYCLE_ICONS = {
   calendar: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="3" y="4" width="18" height="18" rx="2"></rect><path d="M16 2v4M8 2v4M3 10h18"></path></svg>',
@@ -23,7 +24,6 @@ const CYCLE_ICONS = {
 const appWindow = /** @type {Window & typeof globalThis & {
   closeModal: () => void,
   navigate: (category: string) => void,
-  recordChange: (field: string) => void,
   __cycleDelegatesBound?: boolean
 }} */ (typeof window !== 'undefined' ? window : {});
 function cycleActionAttrs(action, extra = '') {
@@ -574,7 +574,7 @@ export function saveMenstrualCycle() {
       state.importedData.menstrualCycle = upgradeMenstrualCycleProfile(state.importedData.menstrualCycle, { now: updatedAt });
     }
   }
-  appWindow.recordChange('menstrualCycle');
+  recordContextCardChangeRuntime('menstrualCycle');
   saveImportedData();
   appWindow.closeModal();
   const activeNav = document.querySelector(".nav-item.active");

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -129,6 +129,7 @@ export function createDashboardPageView(deps) {
     renderDashboardWidget,
     isDashboardOrganizeMode,
     loadFocusCard,
+    loadContextCardTips,
     startEmptyTour = defaultStartEmptyTour,
     startTour = defaultStartTour,
   } = deps;
@@ -303,7 +304,7 @@ export function createDashboardPageView(deps) {
     // cached text with a fresh AI response during startup.
     if (hasData) loadFocusCard({ refreshStale: false });
     loadContextHealthDots();
-    callDashboardPageRuntime('loadContextCardTips');
+    loadContextCardTips();
     loadCommitHash();
     // Preload catalog so rec sections and sorting use it immediately
     const catalogPromise = callDashboardPageRuntime('loadCatalog');

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -202,6 +202,7 @@ export function createDashboardViewComposition({
     renderDashboardWidget,
     isDashboardOrganizeMode: () => dashboardWidgetControls.isOrganizeMode(),
     loadFocusCard,
+    loadContextCardTips,
   });
 
   configureLensPageShell({

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // dashboard-widget-runtime.js - Browser runtime adapters for dashboard widget controls and renderers.
 
+import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -87,7 +89,7 @@ export function navigateDashboardRoute(route) {
 }
 
 export function triggerDashboardDnaPicker() {
-  getRuntimeFunction('triggerDNAFilePicker')?.();
+  triggerContextCardDNAFilePickerRuntime();
 }
 
 /** @param {number | null} [index] */

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -5,6 +5,7 @@ import { installDNAWindowBindings } from './dna-window-bindings.js';
 import { isImportRunning } from './pdf-import-progress.js';
 import { getLatitudeFromLocation } from './profile.js';
 import { isDebugMode, showConfirmDialog } from './utils.js';
+import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 
 const dnaRuntimeDeps = { getLatitudeFromLocation, isDebugMode, isImportRunning, showConfirmDialog };
 
@@ -94,7 +95,7 @@ export function callDnaFileHandler(file) {
 }
 
 export function triggerDnaFilePicker() {
-  getRuntimeFunction('triggerDNAFilePicker')?.();
+  triggerContextCardDNAFilePickerRuntime();
 }
 
 export function updateDnaChatNudge() {

--- a/js/lens-actions.js
+++ b/js/lens-actions.js
@@ -2,6 +2,7 @@
 // lens-actions.js - delegated actions for the Knowledge Base settings surface
 
 import { escapeAttr } from './utils.js';
+import { openContextModalRuntime } from './context-cards-runtime.js';
 
 let lensActionDelegatesInstalled = false;
 let lensActionHandlers = {};
@@ -56,8 +57,7 @@ function handleLensActionClick(event) {
   } else if (action === 'open-context') {
     event.preventDefault();
     lensActionHandlers.closeKnowledgeBaseModal?.();
-    const opener = /** @type {any} */ (typeof window !== 'undefined' ? window : {}).openContextModal;
-    if (typeof opener === 'function') setTimeout(() => opener(), 0);
+    setTimeout(() => openContextModalRuntime(), 0);
   } else if (action === 'delete-doc') {
     event.preventDefault();
     lensActionHandlers.handleLocalLensDeleteDoc?.(actionEl.dataset.lensSource || '');

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -5,6 +5,7 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
 import { profileStorageKey } from './profile.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
+import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 
 const LENS_PAGE_ORDER_VERSION = 1;
 
@@ -60,14 +61,14 @@ function handleLensPageShellClick(event) {
   } else if (action === 'remove-dashboard-widget') {
     callLensPageRuntime('removeDashboardWidgetFromLens', id);
   } else if (action === 'import-dna') {
-    callLensPageRuntime('triggerDNAFilePicker');
+    triggerContextCardDNAFilePickerRuntime();
   } else if (action === 'import-snp-report') {
     callLensPageRuntime('importSnpReport');
   } else if (action === 'add-manual-snp') {
     callLensPageRuntime('openManualSnpModal');
   } else if (action === 'reimport-dna') {
     if (typeof lensPageRuntime().reimportDNA === 'function') callLensPageRuntime('reimportDNA');
-    else callLensPageRuntime('triggerDNAFilePicker');
+    else triggerContextCardDNAFilePickerRuntime();
   } else if (action === 'delete-dna') {
     callLensPageRuntime('confirmDeleteDNA');
   } else if (action === 'open-wearables-settings') {

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -3,6 +3,7 @@
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { openReportBuilder } from './export.js';
+import { openContextModalRuntime } from './context-cards-runtime.js';
 
 const navRuntimeDeps = {
   openEMFAssessmentEditor,
@@ -55,7 +56,7 @@ export function openReportBuilderFromNavRuntime() {
 }
 
 export function openContextFromNavRuntime() {
-  getNavRuntimeFunction('openContextModal')?.();
+  openContextModalRuntime();
 }
 
 export function openCreateMarkerFromNavRuntime() {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 6,
-  "legacyWindowGlobalAssignments": 4,
+  "windowGlobalAssignments": 5,
+  "legacyWindowGlobalAssignments": 3,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -140,6 +140,7 @@ const APP_SHELL = [
   '/js/cycle-summary.js',
   '/js/cycle.js',
   '/js/context-cards.js',
+  '/js/context-cards-runtime.js',
   '/js/context-source-registry.js',
   '/js/context-card-summaries.js',
   '/js/context-card-editor-ui.js',

--- a/tests/context-cards-runtime.test.js
+++ b/tests/context-cards-runtime.test.js
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  configureContextCardsRuntimeCallbacks,
+  openContextModalRuntime,
+  openInterpretiveLensEditorRuntime,
+  recordContextCardChangeRuntime,
+  triggerContextCardDNAFilePickerRuntime,
+} from '../js/context-cards-runtime.js';
+
+let previousCallbacks;
+
+beforeEach(() => {
+  previousCallbacks = configureContextCardsRuntimeCallbacks({
+    openContextModal: null,
+    openInterpretiveLensEditor: null,
+    recordChange: null,
+    triggerDNAFilePicker: null,
+  });
+});
+
+afterEach(() => {
+  configureContextCardsRuntimeCallbacks(previousCallbacks);
+  vi.restoreAllMocks();
+});
+
+describe('context-card runtime callbacks', () => {
+  it('routes context, lens, history, and DNA actions explicitly', () => {
+    const callbacks = {
+      openContextModal: vi.fn(),
+      openInterpretiveLensEditor: vi.fn(),
+      recordChange: vi.fn(),
+      triggerDNAFilePicker: vi.fn(),
+    };
+    configureContextCardsRuntimeCallbacks(callbacks);
+
+    expect(openContextModalRuntime()).toBe(true);
+    expect(openInterpretiveLensEditorRuntime()).toBe(true);
+    expect(recordContextCardChangeRuntime('menstrualCycle')).toBe(true);
+    expect(triggerContextCardDNAFilePickerRuntime()).toBe(true);
+    expect(callbacks.openContextModal).toHaveBeenCalledOnce();
+    expect(callbacks.openInterpretiveLensEditor).toHaveBeenCalledOnce();
+    expect(callbacks.recordChange).toHaveBeenCalledWith('menstrualCycle');
+    expect(callbacks.triggerDNAFilePicker).toHaveBeenCalledOnce();
+  });
+
+  it('fails safely when callbacks are missing or throw', () => {
+    expect(openContextModalRuntime()).toBe(false);
+    configureContextCardsRuntimeCallbacks({
+      openContextModal: () => { throw new Error('boom'); },
+    });
+    expect(openContextModalRuntime()).toBe(false);
+  });
+});

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -10,10 +10,11 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async () => {
-    const [{ renderEmptyChatState }, { state }, { getProfileLocation }] = await Promise.all([
+    const [{ renderEmptyChatState }, { state }, { getProfileLocation }, contextCardsRuntime] = await Promise.all([
       import('/js/chat-empty-state.js'),
       import('/js/state.js'),
       import('/js/profile.js'),
+      import('/js/context-cards-runtime.js'),
     ]);
 
     const saved = {
@@ -26,7 +27,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     };
     const savedFns = {
       closeChatPanel: window.closeChatPanel,
-      triggerDNAFilePicker: window.triggerDNAFilePicker,
       openSettingsModal: window.openSettingsModal,
     };
     const savedInputClick = HTMLInputElement.prototype.click;
@@ -34,6 +34,9 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     const savedChatMessagesHTML = chatMessages?.innerHTML;
 
     const calls = [];
+    const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+      triggerDNAFilePicker: () => calls.push('import-dna'),
+    });
     const inputClicks = [];
     const container = document.createElement('div');
     const panel = document.createElement('div');
@@ -44,7 +47,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       if (chatMessages) chatMessages.innerHTML = '';
 
       window.closeChatPanel = () => calls.push('close-chat');
-      window.triggerDNAFilePicker = () => calls.push('import-dna');
       window.openSettingsModal = tab => calls.push(`open-settings:${tab}`);
       HTMLInputElement.prototype.click = function() {
         inputClicks.push(this === strayMtDnaInput ? 'stray' : panel.contains(this) ? 'scoped' : 'other');
@@ -134,6 +136,7 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
         optionalActionsStopPropagation: bubbledClicks === bubbledBeforeOptionalActions,
       };
     } finally {
+      contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       state.profileSex = saved.profileSex;

--- a/tests/playwright/context-cards-browser-coverage.spec.js
+++ b/tests/playwright/context-cards-browser-coverage.spec.js
@@ -133,13 +133,20 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       window.getCardSlotKeys = key => key === 'diet' ? ['protein'] : [];
       window.renderCardTipsModal = key => `<div class="tips-modal" data-card="${key}">Tips for ${key}</div>`;
       host.innerHTML = cards.renderProfileContextCards();
-      await window.loadContextCardTips();
+      await cards.loadContextCardTips();
       const dietBadge = document.querySelector('#ctx-tips-diet .ctx-tips-badge');
       dietBadge?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       outcomes.cardTipsBadgeLoadsCatalogAndOpensModal = calls.some(call => call[0] === 'catalog')
         && !!dietBadge
         && document.getElementById('modal-overlay')?.classList.contains('show') === true
         && document.getElementById('detail-modal')?.textContent.includes('Tips for diet');
+      outcomes.contextCardApisStayModuleOnly = [
+        'openContextModal',
+        'openDietEditor',
+        'recordChange',
+        'triggerDNAFilePicker',
+        'loadContextCardTips',
+      ].every(name => typeof cards[name] === 'function' && !(name in window));
     } finally {
       state.importedData = saved.importedData;
       if (saved.closeModal) window.closeModal = saved.closeModal;

--- a/tests/playwright/cycle-browser-coverage.spec.js
+++ b/tests/playwright/cycle-browser-coverage.spec.js
@@ -14,11 +14,12 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ cycleUrl }) => {
-    const [{ state }, cycle, tour, cycleStore] = await Promise.all([
+    const [{ state }, cycle, tour, cycleStore, contextCardsRuntime] = await Promise.all([
       import('/js/state.js'),
       import(cycleUrl),
       import('/js/tour.js'),
       import('/js/cycle-store.js'),
+      import('/js/context-cards-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const outcomes = {};
@@ -30,8 +31,10 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       profileDob: state.profileDob,
       closeModal: window.closeModal,
       navigate: window.navigate,
-      recordChange: window.recordChange,
     };
+    const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+      recordChange: field => calls.push(['record', field]),
+    });
     const cycleTourKey = `labcharts-${state.currentProfile}-cycleTour`;
     const savedCycleTourState = localStorage.getItem(cycleTourKey);
     const waitFor = async (predicate, attempts = 25, delayMs = 0) => {
@@ -78,7 +81,6 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
           document.body.appendChild(injectedCycleSurface);
         }
       };
-      window.recordChange = field => calls.push(['record', field]);
       tour.endTour({ openEmptyChat: false });
       localStorage.removeItem(cycleTourKey);
 
@@ -242,8 +244,7 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       else delete window.closeModal;
       if (saved.navigate) window.navigate = saved.navigate;
       else delete window.navigate;
-      if (saved.recordChange) window.recordChange = saved.recordChange;
-      else delete window.recordChange;
+      contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       tour.endTour();
       if (savedCycleTourState) localStorage.setItem(cycleTourKey, savedCycleTourState);
       else localStorage.removeItem(cycleTourKey);

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -22,6 +22,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     const dashboardAi = await import(dashboardUrl);
     const lens = await import('/js/lens.js');
     const { state } = await import('/js/state.js');
+    const contextCardsRuntime = await import('/js/context-cards-runtime.js');
     const outcomes = {};
 
     const snapshotStorage = storage => new Map(Array.from({ length: storage.length }, (_, index) => storage.key(index))
@@ -39,7 +40,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     const hadImportedData = Object.prototype.hasOwnProperty.call(state, 'importedData');
     const savedGlobals = {
       showDirectoryPicker: originalShowDirectoryPicker,
-      openInterpretiveLensEditor: window.openInterpretiveLensEditor,
       handleDNAFile: window.handleDNAFile,
       setTimeout: window.setTimeout,
     };
@@ -61,6 +61,9 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       pickFolderForBackup: () => calls.push('backup'),
       showEnableEncryptionModal: () => calls.push('encryption'),
     });
+    const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+      openInterpretiveLensEditor: () => calls.push('lens'),
+    });
 
     try {
       window.setTimeout = (fn, delay, ...args) => {
@@ -68,7 +71,6 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
         if (typeof fn === 'function') Promise.resolve().then(() => fn(...args));
         return timers.length;
       };
-      window.openInterpretiveLensEditor = () => calls.push('lens');
       window.handleDNAFile = file => {
         handledDnaFile = { name: file.name, textType: file.type };
       };
@@ -240,6 +242,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
         .forEach(el => el.remove());
       dashboardAi.configureDashboardAISyncSetup();
       dashboardAi.configureDashboardAIDataProtectionDeps(previousDataProtectionDeps);
+      contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       HTMLInputElement.prototype.click = originalInputClick;
       for (const [name, original] of Object.entries(savedGlobals)) {
         if (name === 'showDirectoryPicker' && !hadShowDirectoryPicker) delete window[name];

--- a/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
@@ -15,7 +15,10 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ controlsUrl }) => {
-    const controlsModule = await import(controlsUrl);
+    const [controlsModule, contextCardsRuntime] = await Promise.all([
+      import(controlsUrl),
+      import('/js/context-cards-runtime.js'),
+    ]);
     const outcomes = {};
     const fixture = document.getElementById('fixture');
     const saved = {
@@ -25,11 +28,13 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
       openWearableDetail: window.openWearableDetail,
       openManualLogForm: window.openManualLogForm,
       showDetailModal: window.showDetailModal,
-      triggerDNAFilePicker: window.triggerDNAFilePicker,
       openNoteEditor: window.openNoteEditor,
       deleteNote: window.deleteNote,
     };
     const calls = [];
+    const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+      triggerDNAFilePicker: () => calls.push(['dna']),
+    });
     const clone = value => JSON.parse(JSON.stringify(value));
     let prefs = {
       order: ['summary', 'wearables', 'notes', 'light'],
@@ -134,7 +139,6 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
       window.openWearableDetail = id => calls.push(['wearableDetail', id]);
       window.openManualLogForm = (id, event) => calls.push(['manualLog', id, event.type]);
       window.showDetailModal = id => calls.push(['markerDetail', id]);
-      window.triggerDNAFilePicker = () => calls.push(['dna']);
       window.openNoteEditor = (...args) => calls.push(['noteEditor', args.length, ...args.map(arg => arg ?? 'null')]);
       window.deleteNote = index => calls.push(['deleteNote', index]);
       Storage.prototype.removeItem = function removeItem(key) {
@@ -299,6 +303,7 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
         && calls.some(call => call[0] === 'removeStorage')
         && controls.isOrganizeMode() === false;
     } finally {
+      contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       Storage.prototype.removeItem = originalRemoveItem;
       for (const [key, value] of Object.entries(saved)) {
         if (value === undefined) delete window[key];

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -9,15 +9,17 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
   );
 
   const results = await page.evaluate(async () => {
-    const { state } = await import('/js/state.js');
-    const dashboardWidgetsModule = await import('/js/dashboard-widgets.js');
+    const [{ state }, dashboardWidgetsModule, contextCardsRuntime] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/dashboard-widgets.js'),
+      import('/js/context-cards-runtime.js'),
+    ]);
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const originalView = state.currentView;
     const biometricSelectionKey = dashboardWidgetsModule.dashboardBiometricSelectionKey();
     const savedFns = {
       showDetailModal: window.showDetailModal,
       navigate: window.navigate,
-      triggerDNAFilePicker: window.triggerDNAFilePicker,
       openNoteEditor: window.openNoteEditor,
       deleteNote: window.deleteNote,
       syncWearableNow: window.syncWearableNow,
@@ -32,6 +34,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     let hadWearableSummary = false;
     let hadWearableConnections = false;
     let bodyActionHost;
+    let previousContextCardsRuntime = null;
 
     try {
       if (!window.getActiveData?.()?.dates?.length) {
@@ -162,9 +165,11 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       const selectedAfterRemove = JSON.parse(localStorage.getItem(biometricSelectionKey) || '[]');
 
       const bodyActionCalls = [];
+      previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+        triggerDNAFilePicker: () => bodyActionCalls.push(['dna']),
+      });
       window.showDetailModal = id => bodyActionCalls.push(['detail', id]);
       window.navigate = route => bodyActionCalls.push(['navigate', route]);
-      window.triggerDNAFilePicker = () => bodyActionCalls.push(['dna']);
       window.openNoteEditor = (scope, index) => bodyActionCalls.push(['note', index]);
       window.deleteNote = index => bodyActionCalls.push(['delete-note', index]);
       bodyActionHost = document.createElement('div');
@@ -218,6 +223,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
           && bodyActionCalls.some(c => c[0] === 'delete-note' && c[1] === 2),
       };
     } finally {
+      if (previousContextCardsRuntime) contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       bodyActionHost?.remove();
       for (const [name, original] of Object.entries(savedFns)) {
         if (hadFns[name]) window[name] = original;

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -55,15 +55,15 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
   await prepareApp(page);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, shell, profile] = await Promise.all([
+    const [{ state }, shell, profile, contextCardsRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/lens-page-shell.js'),
       import('/js/profile.js'),
+      import('/js/context-cards-runtime.js'),
     ]);
     const originalView = state.currentView;
     const originalAddDashboard = window.addDashboardWidgetFromLens;
     const originalRemoveDashboard = window.removeDashboardWidgetFromLens;
-    const originalTriggerDNA = window.triggerDNAFilePicker;
     const originalReimportDNA = window.reimportDNA;
     const originalConfirmDeleteDNA = window.confirmDeleteDNA;
     const originalOpenSettings = window.openSettingsModal;
@@ -75,6 +75,9 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
     const savedLabsOrder = localStorage.getItem(labsOrderKey);
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const calls = [];
+    const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+      triggerDNAFilePicker: () => calls.push(['trigger-dna']),
+    });
     const restoreShell = shell.configureLensPageShell({
       openEMFAssessmentEditor: () => calls.push(['emf']),
     });
@@ -107,7 +110,6 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       dashboardToggle?.click();
       await delay(50);
 
-      window.triggerDNAFilePicker = () => calls.push(['trigger-dna']);
       window.reimportDNA = () => calls.push(['reimport-dna']);
       window.confirmDeleteDNA = () => calls.push(['delete-dna']);
       window.openSettingsModal = pane => calls.push(['settings', pane]);
@@ -153,7 +155,7 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
     } finally {
       window.addDashboardWidgetFromLens = originalAddDashboard;
       window.removeDashboardWidgetFromLens = originalRemoveDashboard;
-      window.triggerDNAFilePicker = originalTriggerDNA;
+      contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       window.reimportDNA = originalReimportDNA;
       window.confirmDeleteDNA = originalConfirmDeleteDNA;
       window.openSettingsModal = originalOpenSettings;

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -24,22 +24,23 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
   await prepareApp(page);
 
   const results = await page.evaluate(async () => {
-    const [nav, navRuntime, { state }] = await Promise.all([
+    const [nav, navRuntime, { state }, contextCardsRuntime] = await Promise.all([
       import('/js/nav.js'),
       import('/js/nav-runtime.js'),
       import('/js/state.js'),
+      import('/js/context-cards-runtime.js'),
     ]);
     const origDateRangeFilter = state.dateRangeFilter;
     const origCurrentView = state.currentView;
     const origImportedData = state.importedData;
     const origProfiles = state.profiles;
     const origNavigate = window.navigate;
-    const origOpenContext = window.openContextModal;
     const origOpenCreateMarker = window.openCreateMarkerModal;
     const origOpenClientList = window.openClientList;
     const origGroupStorage = localStorage.getItem('labcharts-navgroup-Hormones');
     let restoreNavActions = null;
     let restoreNavRuntime = null;
+    let restoreContextCardsRuntime = null;
 
     try {
       const fixtureData = {
@@ -81,7 +82,9 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       restoreNavActions = nav.configureNavActions({
         openLightEnvironmentAssessment: () => calls.push(['open-light-env']),
       });
-      window.openContextModal = () => calls.push(['open-context']);
+      restoreContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+        openContextModal: () => calls.push(['open-context']),
+      });
       window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
       window.openClientList = () => calls.push(['open-client-list']);
       window.buildSidebar(fixtureData);
@@ -146,7 +149,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       window.navigate = origNavigate;
       if (restoreNavRuntime) navRuntime.configureNavRuntime(restoreNavRuntime);
       if (restoreNavActions) nav.configureNavActions(restoreNavActions);
-      window.openContextModal = origOpenContext;
+      if (restoreContextCardsRuntime) contextCardsRuntime.configureContextCardsRuntimeCallbacks(restoreContextCardsRuntime);
       window.openCreateMarkerModal = origOpenCreateMarker;
       window.openClientList = origOpenClientList;
       if (origGroupStorage == null) localStorage.removeItem('labcharts-navgroup-Hormones');

--- a/tests/test-change-history.js
+++ b/tests/test-change-history.js
@@ -20,15 +20,16 @@ function assert(name, condition, detail) {
 
 console.log('=== Change History Tests ===\n');
 
-// context-cards.js exposes recordChange via Object.assign(window, ...).
+// Change-history recording is a module-only context-cards API.
 await import('../js/state.js');
-await import('../js/context-cards.js');
+const contextCards = await import('../js/context-cards.js');
   // ═══════════════════════════════════════
   // 1. recordChange function exists
   // ═══════════════════════════════════════
   console.log('1. Function Exports');
 
-  assert('recordChange is a window function', typeof window.recordChange === 'function');
+  assert('recordChange is a module function', typeof contextCards.recordChange === 'function');
+  assert('recordChange stays off window', !('recordChange' in window));
 
   // ═══════════════════════════════════════
   // 2. Basic recording
@@ -43,7 +44,7 @@ await import('../js/context-cards.js');
   window._labState.importedData.changeHistory = [];
   window._labState.importedData.diet = { type: 'omnivore', restrictions: [], pattern: null, note: '' };
 
-  window.recordChange('diet');
+  contextCards.recordChange('diet');
   assert('Records first change', window._labState.importedData.changeHistory.length === 1);
   assert('Entry has field', window._labState.importedData.changeHistory[0].field === 'diet');
   assert('Entry has date (ISO)', /^\d{4}-\d{2}-\d{2}$/.test(window._labState.importedData.changeHistory[0].date));
@@ -56,7 +57,7 @@ await import('../js/context-cards.js');
   // ═══════════════════════════════════════
   console.log('3. Dedup — Identical Snapshot');
 
-  window.recordChange('diet');
+  contextCards.recordChange('diet');
   assert('Identical snapshot not duplicated', window._labState.importedData.changeHistory.length === 1);
 
   // ═══════════════════════════════════════
@@ -65,7 +66,7 @@ await import('../js/context-cards.js');
   console.log('4. Dedup — Same Day Overwrite');
 
   window._labState.importedData.diet = { type: 'low-carb', restrictions: ['gluten'], pattern: '2 meals', note: '' };
-  window.recordChange('diet');
+  contextCards.recordChange('diet');
   assert('Same-day update overwrites (no new entry)', window._labState.importedData.changeHistory.length === 1);
   assert('Snapshot updated to new value', window._labState.importedData.changeHistory[0].snapshot.type === 'low-carb');
 
@@ -75,7 +76,7 @@ await import('../js/context-cards.js');
   console.log('5. Multiple Fields');
 
   window._labState.importedData.exercise = { frequency: '3x/week', types: ['strength'], intensity: 'moderate', note: '' };
-  window.recordChange('exercise');
+  contextCards.recordChange('exercise');
   assert('Different field creates new entry', window._labState.importedData.changeHistory.length === 2);
   assert('Exercise entry recorded', window._labState.importedData.changeHistory[1].field === 'exercise');
 
@@ -89,7 +90,7 @@ await import('../js/context-cards.js');
   // Force a past date entry so "clear" on today creates a new one
   h[0].date = '2025-01-01';
   window._labState.importedData.diet = null;
-  window.recordChange('diet');
+  contextCards.recordChange('diet');
   const nullEntry = h.find(e => e.field === 'diet' && e.snapshot === null);
   assert('Null field recorded with null snapshot', nullEntry != null);
 
@@ -107,7 +108,7 @@ await import('../js/context-cards.js');
   }
   // Force a new unique entry
   window._labState.importedData.stress = { level: 'high', sources: ['work'] };
-  window.recordChange('stress');
+  contextCards.recordChange('stress');
   assert('History capped at 200', window._labState.importedData.changeHistory.length <= 200, `length: ${window._labState.importedData.changeHistory.length}`);
 
   // ═══════════════════════════════════════
@@ -117,7 +118,7 @@ await import('../js/context-cards.js');
 
   window._labState.importedData.changeHistory = [];
   window._labState.importedData.interpretiveLens = 'Functional medicine';
-  window.recordChange('interpretiveLens');
+  contextCards.recordChange('interpretiveLens');
   assert('String field snapshot is a string', typeof window._labState.importedData.changeHistory[0].snapshot === 'string');
   assert('String field value correct', window._labState.importedData.changeHistory[0].snapshot === 'Functional medicine');
 
@@ -128,7 +129,7 @@ await import('../js/context-cards.js');
 
   window._labState.importedData.changeHistory = [];
   window._labState.importedData.healthGoals = [{ text: 'Reduce inflammation', severity: 'major' }];
-  window.recordChange('healthGoals');
+  contextCards.recordChange('healthGoals');
   assert('Array field recorded', window._labState.importedData.changeHistory.length === 1);
   assert('Array snapshot is array', Array.isArray(window._labState.importedData.changeHistory[0].snapshot));
   assert('Array snapshot deep copy', window._labState.importedData.changeHistory[0].snapshot !== window._labState.importedData.healthGoals);
@@ -205,7 +206,8 @@ await import('../js/context-cards.js');
   assert('debounceContextNotes calls recordChange', ctxSrc.includes("recordChange('contextNotes')"));
 
   const cycleSrc = read('js/cycle.js');
-  assert('saveMenstrualCycle calls recordChange', cycleSrc.includes("recordChange('menstrualCycle')"));
+  assert('saveMenstrualCycle records context changes through the runtime callback',
+    cycleSrc.includes("recordContextCardChangeRuntime('menstrualCycle')"));
 
   // Restore original state
   window._labState.importedData.changeHistory = origHistory || [];

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -12,6 +12,7 @@ import {
   renderChatMessagesRuntime,
   updateDiscussButtonRuntime,
 } from '../js/chat-runtime.js';
+import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
 
 let passed = 0;
 let failed = 0;
@@ -62,13 +63,16 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
+    openContextModal: () => calls.push(['context']),
+  });
   const ppqAttestation = { provider: 'ppq', verified: true };
   const routstrAttestation = { provider: 'routstr', verified: true };
   const veniceAttestation = { provider: 'venice', verified: true };
   setRuntimeValue('window', globalThis);
   setRuntimeValue('renderChatMessages', () => calls.push(['render']));
   setRuntimeValue('updateDiscussButton', () => calls.push(['discuss']));
-  setRuntimeValue('openContextModal', () => calls.push(['context']));
+  setRuntimeValue('openContextModal', () => calls.push(['legacy-context']));
   setRuntimeValue('closeModal', () => calls.push(['close']));
   setRuntimeValue('refreshMobileDashboardActiveTab', () => calls.push(['refresh-mobile']));
   setRuntimeValue('isChatStreaming', () => false);
@@ -113,11 +117,13 @@ try {
       getChatProviderAttestation('routstr') === routstrAttestation &&
       getChatProviderAttestation('venice') === veniceAttestation);
 
+  configureContextCardsRuntimeCallbacks({ openContextModal: null });
   delete globalThis.window;
   assert('chat runtime no-ops without a browser window',
     isChatRuntimeStreaming() === false &&
       getChatRegenerateCallbacks() === null &&
       getChatProviderAttestation('ppq') === undefined);
+  configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-context-card-lifestyle-runtime.js
+++ b/tests/test-context-card-lifestyle-runtime.js
@@ -15,6 +15,7 @@ import {
   returnToLifestyleContextModalRuntime,
   updateLifestyleChatHeaderModelRuntime,
 } from '../js/context-card-lifestyle-runtime.js';
+import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -57,6 +58,9 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
+    openContextModal: () => calls.push(['context-modal']),
+  });
   setRuntimeValue('window', globalThis);
   setRuntimeValue('closeModal', () => calls.push(['close']));
   setRuntimeValue('navigate', category => calls.push(['navigate', category]));
@@ -64,7 +68,7 @@ try {
   setRuntimeValue('reopenSunSetup', () => calls.push(['sun-setup']));
   setRuntimeValue('openChatPanel', () => calls.push(['chat-panel']));
   setRuntimeValue('useChatPrompt', prompt => calls.push(['prompt', prompt]));
-  setRuntimeValue('openContextModal', () => calls.push(['context-modal']));
+  setRuntimeValue('openContextModal', () => calls.push(['legacy-context-modal']));
   delete globalThis.__lifestyleContextDelegatesBound;
   setRuntimeValue('setTimeout', (fn, delay) => {
     calls.push(['timer', String(delay)]);
@@ -99,6 +103,7 @@ try {
       calls.some(call => call.join('|') === 'timer|300') &&
       calls.some(call => call.join('|') === 'timer|0'));
 
+  configureContextCardsRuntimeCallbacks({ openContextModal: null });
   delete globalThis.window;
   const shellCallCount = calls.filter(call => call[0] !== 'timer').length;
   closeLifestyleContextModalRuntime();
@@ -118,6 +123,7 @@ try {
     editorSrc.includes("from './context-card-lifestyle-runtime.js'") &&
       !/\bwindow(?:\.|\s*\[)/.test(editorSrc) &&
       swSrc.includes("'/js/context-card-lifestyle-runtime.js'"));
+  configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-dashboard-data-protection.js
+++ b/tests/test-dashboard-data-protection.js
@@ -94,8 +94,10 @@ const make = (overrides) => ({
 
 // ─── 7. Public APIs ──────────────────────────────────────
 {
-  assert('window.openDataProtectionPicker exists',
-    typeof window.openDataProtectionPicker === 'function');
+  assert('cards.openDataProtectionPicker exists',
+    typeof cards.openDataProtectionPicker === 'function');
+  assert('window.openDataProtectionPicker stays module-only',
+    !('openDataProtectionPicker' in window));
   assert('settings-sync-panel.showSyncSetupModal exists',
     typeof settingsSyncPanel.showSyncSetupModal === 'function');
   assert('window.showSyncSetupModal stays module-only',

--- a/tests/test-dashboard-genetics-empty.js
+++ b/tests/test-dashboard-genetics-empty.js
@@ -15,8 +15,7 @@ console.log('=== Genetics empty-state CTA tests ===\n');
 
 const dna = await import('../js/dna.js');
 const { state } = await import('../js/state.js');
-// context-cards.js exposes window.triggerDNAFilePicker.
-await import('../js/context-cards.js');
+const contextCards = await import('../js/context-cards.js');
   if (!state.importedData) state.importedData = {};
   const savedGenetics = state.importedData.genetics;
 
@@ -60,10 +59,12 @@ await import('../js/context-cards.js');
         !html.includes('genetics-empty-stub'));
     }
 
-    // ─── 4. window.triggerDNAFilePicker exists (used by stub delegate) ───
+    // ─── 4. DNA picker is a module API used by delegated actions ───
     {
-      assert('window.triggerDNAFilePicker is a function',
-        typeof window.triggerDNAFilePicker === 'function');
+      assert('contextCards.triggerDNAFilePicker is a function',
+        typeof contextCards.triggerDNAFilePicker === 'function');
+      assert('window.triggerDNAFilePicker stays module-only',
+        !('triggerDNAFilePicker' in window));
     }
   } finally {
     state.importedData.genetics = savedGenetics;

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -192,20 +192,25 @@ try {
   // Section 5b (picker open/dismiss — live DOM) lives in
   // tests/playwright/dashboard-knowledge-base.spec.js.
 
-  // ─── 6. Module and remaining shell exports ───
+  // ─── 6. Module exports ───
   {
-    assert('window.openContextModal exists',
-      typeof window.openContextModal === 'function');
-    assert('window.openPersonalizeAIPicker exists',
-      typeof window.openPersonalizeAIPicker === 'function');
+    assert('cards.openContextModal exists',
+      typeof cards.openContextModal === 'function');
+    assert('cards.openPersonalizeAIPicker exists',
+      typeof cards.openPersonalizeAIPicker === 'function');
     assert('lens.openKnowledgeBaseModal exists',
       typeof lens.openKnowledgeBaseModal === 'function');
     assert('lens.closeKnowledgeBaseModal exists',
       typeof lens.closeKnowledgeBaseModal === 'function');
-    assert('window.renderKnowledgeBaseSection exists',
-      typeof window.renderKnowledgeBaseSection === 'function');
-    assert('window.triggerDNAFilePicker exists (used by genetics empty stub)',
-      typeof window.triggerDNAFilePicker === 'function');
+    assert('cards.renderKnowledgeBaseSection exists',
+      typeof cards.renderKnowledgeBaseSection === 'function');
+    assert('cards.triggerDNAFilePicker exists',
+      typeof cards.triggerDNAFilePicker === 'function');
+    assert('context-card APIs stay module-only',
+      !('openContextModal' in window)
+      && !('openPersonalizeAIPicker' in window)
+      && !('renderKnowledgeBaseSection' in window)
+      && !('triggerDNAFilePicker' in window));
   }
 
   // ─── 8. Current-head Greptile regressions ───

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -17,6 +17,7 @@ import {
   syncDashboardWearableNow,
   triggerDashboardDnaPicker,
 } from '../js/dashboard-widget-runtime.js';
+import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -63,6 +64,9 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
+    triggerDNAFilePicker: () => calls.push(['dna']),
+  });
   setRuntimeValue('innerHeight', 720);
   assert('getDashboardViewportHeight reads runtime innerHeight',
     getDashboardViewportHeight() === 720);
@@ -98,7 +102,7 @@ try {
   setRuntimeValue('openManualLogForm', (id, ev) => calls.push(['manual-log', id, ev.type]));
   setRuntimeValue('showDetailModal', id => calls.push(['marker-detail', id]));
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
-  setRuntimeValue('triggerDNAFilePicker', () => calls.push(['dna']));
+  setRuntimeValue('triggerDNAFilePicker', () => calls.push(['legacy-dna']));
   setRuntimeValue('openNoteEditor', (...args) => calls.push(['note-editor', ...args.map(arg => arg ?? 'null')]));
   setRuntimeValue('deleteNote', index => calls.push(['delete-note', index]));
 
@@ -129,6 +133,7 @@ try {
   assert('openDashboardWearableDetail reports missing callback',
     openDashboardWearableDetail('sleep') === false);
 
+  configureContextCardsRuntimeCallbacks({ triggerDNAFilePicker: null });
   delete globalThis.window;
   const callCountBeforeMissingRuntime = calls.length;
   openDashboardWearablesSettings();
@@ -146,6 +151,7 @@ try {
       getDashboardSnpTableCache() === null &&
       openDashboardWearableDetail('sleep') === false &&
       calls.length === callCountBeforeMissingRuntime);
+  configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-dna-runtime.js
+++ b/tests/test-dna-runtime.js
@@ -25,6 +25,7 @@ import {
   triggerDnaFilePicker,
   updateDnaChatNudge,
 } from '../js/dna-runtime.js';
+import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
 
 let passed = 0;
 let failed = 0;
@@ -61,6 +62,7 @@ const originals = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key
 const originalError = console.error;
 const originalWarn = console.warn;
 const originalDnaRuntimeDeps = configureDnaRuntimeDeps();
+const originalContextCardsRuntime = configureContextCardsRuntimeCallbacks();
 
 try {
   for (const key of runtimeKeys) delete globalThis[key];
@@ -96,7 +98,10 @@ try {
   assert('callDnaFileHandler delegates file handling',
     calls.some(call => call[0] === 'handleDNAFile' && call[1] === 'dna.txt'));
 
-  globalThis.triggerDNAFilePicker = () => calls.push(['triggerDNAFilePicker']);
+  globalThis.triggerDNAFilePicker = () => calls.push(['legacyTriggerDNAFilePicker']);
+  configureContextCardsRuntimeCallbacks({
+    triggerDNAFilePicker: () => calls.push(['triggerDNAFilePicker']),
+  });
   triggerDnaFilePicker();
   assert('triggerDnaFilePicker delegates picker opening',
     calls.some(call => call[0] === 'triggerDNAFilePicker'));
@@ -195,6 +200,7 @@ try {
       typeof globalThis._saveAndRefresh === 'function');
 } finally {
   configureDnaRuntimeDeps(originalDnaRuntimeDeps);
+  configureContextCardsRuntimeCallbacks(originalContextCardsRuntime);
   console.error = originalError;
   console.warn = originalWarn;
   for (const key of runtimeKeys) {

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -11,6 +11,7 @@ return (async function() {
   const S = window._labState;
   const backupModule = await import('/js/backup.js');
   const exportModule = await import('/js/export.js');
+  const contextCards = await import('/js/context-cards.js');
   const profile = await import('/js/profile.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
@@ -1120,8 +1121,8 @@ return (async function() {
       // would compute against the live state. If migrateProfileData /
       // same-date merge drifts, fingerprints diverge and dots fall through
       // to AI fire on next render.
-      if (typeof window.getCardFingerprint === 'function') {
-        const liveFps = expectedKeys.map(k => ({k, live: window.getCardFingerprint(k), cached: ctxCached?.fingerprints?.[k]}));
+      if (typeof contextCards.getCardFingerprint === 'function') {
+        const liveFps = expectedKeys.map(k => ({k, live: contextCards.getCardFingerprint(k), cached: ctxCached?.fingerprints?.[k]}));
         const mismatched = liveFps.filter(x => x.live !== x.cached);
         assert('All 9 cached fingerprints match live fingerprints (proves migration + merge applied correctly)',
           mismatched.length === 0,

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -26,6 +26,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   console.log('1. Module imports');
 
   const { UNIT_CONVERSIONS, MARKER_SCHEMA, OPTIMAL_RANGES } = await import('../js/schema.js');
+  const contextCards = await import('../js/context-cards.js');
 
   assert('UNIT_CONVERSIONS loaded', UNIT_CONVERSIONS != null);
   assert('MARKER_SCHEMA loaded', MARKER_SCHEMA != null);
@@ -199,7 +200,8 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   const ctxSrc = read('/js/context-cards.js');
   assert('saveAndRefresh preserves details state', ctxSrc.includes("welcome-context-details") && ctxSrc.includes('sessionStorage'));
   assert('refreshAllHealthDots function exists', ctxSrc.includes('function refreshAllHealthDots'));
-  assert('refreshAllHealthDots exposed on window', ctxSrc.includes('refreshAllHealthDots'));
+  assert('refreshAllHealthDots is a module API', typeof contextCards.refreshAllHealthDots === 'function');
+  assert('context-card APIs stay off window', !('refreshAllHealthDots' in window));
   assert('Refresh button in renderProfileContextCards', ctxSrc.includes('ctx-refresh-all-btn'));
 
   // saveAndRefresh must trigger a re-render of the current view — BroadcastChannel
@@ -220,7 +222,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   // truthy in Node) — clean cross-environment skip.
   const _rtState = window._labState;
   const _isNode = typeof process !== 'undefined' && !!process.versions?.node;
-  if (!_isNode && typeof window.saveAndRefresh === 'function' && typeof window.navigate === 'function' && _rtState) {
+  if (!_isNode && typeof contextCards.saveAndRefresh === 'function' && typeof window.navigate === 'function' && _rtState) {
     const sv_stress = _rtState.importedData?.stress;
     try {
       window.navigate('dashboard');
@@ -230,7 +232,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
       if (stressCardBefore) {
         // Simulate a save: mutate state then call saveAndRefresh (same path as saveStress)
         _rtState.importedData.stress = { level: 'moderate', sources: ['work'], management: ['exercise'], note: '' };
-        window.saveAndRefresh('Stress profile saved', 'stress');
+        contextCards.saveAndRefresh('Stress profile saved', 'stress');
         await new Promise(r => setTimeout(r, 50));
         // After re-render, the stress card body should contain the summary text
         // produced by getStressSummary: "moderate stress — work — manages: exercise"

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -12,6 +12,7 @@ import {
   openEMFAssessmentFromNavRuntime,
   openReportBuilderFromNavRuntime,
 } from '../js/nav-runtime.js';
+import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
 
 let passed = 0;
 let failed = 0;
@@ -57,9 +58,12 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
+    openContextModal: () => calls.push(['context', true]),
+  });
   const browserRuntime = {
     navigate(route) { calls.push(['navigate', route, this === browserRuntime]); },
-    openContextModal() { calls.push(['context', this === browserRuntime]); },
+    openContextModal() { calls.push(['legacy-context']); },
     openCreateMarkerModal() { calls.push(['marker', this === browserRuntime]); },
     openClientList() { calls.push(['client', this === browserRuntime]); },
   };
@@ -88,6 +92,7 @@ try {
   for (const key of ['navigate', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
     delete browserRuntime[key];
   }
+  configureContextCardsRuntimeCallbacks({ openContextModal: null });
   configureNavRuntime({ openEMFAssessmentEditor: () => {}, openReportBuilder: () => {} });
   navigateFromNavRuntime('missing');
   openEMFAssessmentFromNavRuntime();
@@ -105,6 +110,7 @@ try {
   assert('nav runtime falls back to globalThis without window',
     globalRoute === 'recommendations' && globalThis.runtimeProbe === 'global');
   configureNavRuntime(restoreNavRuntime);
+  configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -29,6 +29,7 @@ return (async function() {
   const pdfImport = await import('/js/pdf-import.js');
   const profile = await import('/js/profile.js');
   const exportModule = await import('/js/export.js');
+  const contextCards = await import('/js/context-cards.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -608,7 +609,7 @@ return (async function() {
   await wait(50);
 
   // Open diet editor
-  window.openDietEditor();
+  contextCards.openDietEditor();
   await wait(50);
   assert('Diet editor opens', modalOverlay.classList.contains('show'));
   const editorModal = document.getElementById('detail-modal');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -188,11 +188,12 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
     import('../js/charts.js'),
+    import('../js/context-cards.js'),
     import('../js/crypto.js'),
     import('../js/cycle.js'),
     import('../js/emf.js'),
@@ -345,14 +346,14 @@
     'askAIAboutMarker','askAIAboutCorrelations'
   ];
 
-  // context-cards.js (57+)
+  // context-cards.js (85 former browser globals, now module-only)
   const contextCardsExports = [
     'getConditionsSummary','getDietSummary','getExerciseSummary',
     'getSleepSummary','getLightCircadianSummary','getStressSummary',
     'getLoveLifeSummary','getEnvironmentSummary','getGoalsSummary',
     'isContextFilled',
     'renderProfileContextCards','debounceContextNotes',
-    'applyDotColor','applyAISummary','getCardFingerprint','loadContextHealthDots',
+    'applyDotColor','applyAISummary','getCardFingerprint','loadContextHealthDots','refreshAllHealthDots',
     'renderSelectField','selectCtxOption','getSelectedOption',
     'renderTagsField','toggleCtxTag','getSelectedTags',
     'renderNoteField','contextEditorActions','saveAndRefresh',
@@ -360,7 +361,8 @@
     'filterConditionSuggestions','selectConditionSuggestion','closeSuggestionsOnClickOutside',
     'syncDiagnosesNote','addCondition','editCondition','cancelConditionEdit','deleteCondition',
     'addFamilyHistoryEntry','editFamilyHistoryEntry','cancelFamilyHistoryEdit','deleteFamilyHistoryEntry',
-    'saveDiagnoses','clearDiagnoses',
+    'filterFamilyConditionSuggestions','selectFamilyConditionSuggestion',
+    'saveDiagnoses','closeDiagnoses','clearDiagnoses',
     'openDietEditor','saveDiet','clearDiet',
     'openSleepRestEditor','saveSleepRest','clearSleepRest',
     'openLightCircadianEditor','saveLightCircadian','clearLightCircadian',
@@ -369,9 +371,11 @@
     'openLoveLifeEditor','saveLoveLife','clearLoveLife',
     'openEnvironmentEditor','saveEnvironment','clearEnvironment',
     'openHealthGoalsEditor','renderHealthGoalsModal',
-    'addHealthGoal','deleteHealthGoal','clearHealthGoals',
+    'addHealthGoal','deleteHealthGoal','closeHealthGoals','clearHealthGoals',
     'openInterpretiveLensEditor','saveInterpretiveLens','clearInterpretiveLens',
-    'renderInterpretiveLensSection','openContextModal'
+    'renderInterpretiveLensSection','renderKnowledgeBaseSection',
+    'openContextModal','openPersonalizeAIPicker','openDataProtectionPicker','triggerDNAFilePicker',
+    'recordChange','showDietContaminantsModal','openCardTipsModal','loadContextCardTips'
   ];
 
   // client-list.js (3)
@@ -618,6 +622,7 @@
     ['backup.js', backupModule, backupExports],
     ['cashu-wallet.js', cashuWalletModule, cashuWalletExports],
     ['charts.js', chartsModule, chartsExports],
+    ['context-cards.js', contextCardsModule, contextCardsExports],
     ['crypto.js', cryptoModule, cryptoExports],
     ['cycle.js', cycleModule, cycleExports],
     ['emf.js', emfModule, emfExports],
@@ -691,11 +696,13 @@
   for (const name of providerPanelsExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of contextCardsExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
 
   const allModules = {
     'chat.js': chatExports,
     'client-list.js': clientListExports,
-    'context-cards.js': contextCardsExports,
     'data.js': dataExports,
     'nav.js': navExports,
     'notes.js': notesExports,
@@ -891,18 +898,18 @@
   }
 
   // Summary functions work without crashing
-  assert('getGoalsSummary works', typeof window.getGoalsSummary() === 'string' || window.getGoalsSummary() === '');
-  assert('getConditionsSummary works', typeof window.getConditionsSummary() === 'string' || window.getConditionsSummary() === '');
-  assert('getDietSummary works', typeof window.getDietSummary() === 'string' || window.getDietSummary() === '');
-  assert('getExerciseSummary works', typeof window.getExerciseSummary() === 'string' || window.getExerciseSummary() === '');
-  assert('getSleepSummary works', typeof window.getSleepSummary() === 'string' || window.getSleepSummary() === '');
-  assert('getLightCircadianSummary works', typeof window.getLightCircadianSummary() === 'string' || window.getLightCircadianSummary() === '');
-  assert('getStressSummary works', typeof window.getStressSummary() === 'string' || window.getStressSummary() === '');
-  assert('getLoveLifeSummary works', typeof window.getLoveLifeSummary() === 'string' || window.getLoveLifeSummary() === '');
-  assert('getEnvironmentSummary works', typeof window.getEnvironmentSummary() === 'string' || window.getEnvironmentSummary() === '');
+  assert('getGoalsSummary works', typeof contextCardsModule.getGoalsSummary() === 'string' || contextCardsModule.getGoalsSummary() === '');
+  assert('getConditionsSummary works', typeof contextCardsModule.getConditionsSummary() === 'string' || contextCardsModule.getConditionsSummary() === '');
+  assert('getDietSummary works', typeof contextCardsModule.getDietSummary() === 'string' || contextCardsModule.getDietSummary() === '');
+  assert('getExerciseSummary works', typeof contextCardsModule.getExerciseSummary() === 'string' || contextCardsModule.getExerciseSummary() === '');
+  assert('getSleepSummary works', typeof contextCardsModule.getSleepSummary() === 'string' || contextCardsModule.getSleepSummary() === '');
+  assert('getLightCircadianSummary works', typeof contextCardsModule.getLightCircadianSummary() === 'string' || contextCardsModule.getLightCircadianSummary() === '');
+  assert('getStressSummary works', typeof contextCardsModule.getStressSummary() === 'string' || contextCardsModule.getStressSummary() === '');
+  assert('getLoveLifeSummary works', typeof contextCardsModule.getLoveLifeSummary() === 'string' || contextCardsModule.getLoveLifeSummary() === '');
+  assert('getEnvironmentSummary works', typeof contextCardsModule.getEnvironmentSummary() === 'string' || contextCardsModule.getEnvironmentSummary() === '');
 
   // isContextFilled
-  assert('isContextFilled returns boolean', typeof window.isContextFilled('diet') === 'boolean');
+  assert('isContextFilled returns boolean', typeof contextCardsModule.isContextFilled('diet') === 'boolean');
 
   // ═══════════════════════════════════════════════
   // 14. NAVIGATION — category switching

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -95,6 +95,7 @@
     "js/context-card-medical-history-editor.js",
     "js/context-card-summaries.js",
     "js/context-source-registry.js",
+    "js/context-cards-runtime.js",
     "js/context-cards.js",
     "js/crypto.js",
     "js/dashboard-page-view.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.203';
+self.APP_VERSION = '1.10.204';


### PR DESCRIPTION
## Summary
- remove the 85-name `context-cards.js` window facade and keep its API as native ES module exports
- route Context, Interpretive Lens, DNA picker, and change-history integrations through explicit runtime callbacks
- inject desktop Context tip loading directly, cache the new runtime module, and lower the window-assignment quality baseline
- bump the app cache version to `1.10.204`

## Validation
- `./run-tests.sh` — 123 static verification checks, 398 Vitest tests, 352 Playwright tests, and 472 responsive/theme checks passed
- `npm run quality` — 7/7 guardrails passed
- `git diff --check`