### PR TITLE
Make data APIs module-only

### DIFF
--- a/js/biology-score-context-ai.js
+++ b/js/biology-score-context-ai.js
@@ -1,7 +1,7 @@
 // @ts-check
 // biology-score-context-ai.js — AI-assisted context flag review for deterministic Biology Scores.
 
-import { filterDatesByRange, saveImportedData } from './data.js';
+import { filterDatesByRange, getActiveData, invalidateActiveDataCache, saveImportedData } from './data.js';
 import {
   isGeneticsPriorityInAIContext,
   isGeneticsSummaryInAIContext,
@@ -298,17 +298,15 @@ export async function applyBiologyScoreContextFlag(flag) {
   if (Array.isArray(review?.suggestions)) {
     review.suggestions = review.suggestions.filter(s => s.flag !== flag);
     review.updatedAt = Date.now();
-    const activeData = (/** @type {any} */ (window)).getActiveData?.();
-    if (activeData) {
-      review.fingerprint = buildBiologyScoreContextFingerprint(dataForReviewRange(activeData, state.dateRangeFilter || 'all'), state.dateRangeFilter || 'all');
-      review.fingerprintsByRange = buildBiologyScoreContextFingerprintsByRange(activeData);
-      review.contextSignature = buildBiologyScoreContextMaterialSignature(dataForReviewRange(activeData, state.dateRangeFilter || 'all'), state.dateRangeFilter || 'all');
-      review.contextSignaturesByRange = buildBiologyScoreContextMaterialSignaturesByRange(activeData);
-      review.unlockedRanges = [...CONTEXT_REVIEW_RANGES];
-    }
+    const activeData = getActiveData();
+    review.fingerprint = buildBiologyScoreContextFingerprint(dataForReviewRange(activeData, state.dateRangeFilter || 'all'), state.dateRangeFilter || 'all');
+    review.fingerprintsByRange = buildBiologyScoreContextFingerprintsByRange(activeData);
+    review.contextSignature = buildBiologyScoreContextMaterialSignature(dataForReviewRange(activeData, state.dateRangeFilter || 'all'), state.dateRangeFilter || 'all');
+    review.contextSignaturesByRange = buildBiologyScoreContextMaterialSignaturesByRange(activeData);
+    review.unlockedRanges = [...CONTEXT_REVIEW_RANGES];
   }
   await saveImportedData({ reason: 'biology-score-context-flag' });
-  (/** @type {any} */ (window)).invalidateActiveDataCache?.();
+  invalidateActiveDataCache();
 }
 
 export async function dismissBiologyScoreContextFlag(flag) {
@@ -359,7 +357,7 @@ export function installBiologyScoreContextAIDelegates() {
       const w = /** @type {any} */ (window);
       if (action === 'analyze-context-ai') {
         el.setAttribute('disabled', 'true'); el.textContent = 'Analyzing…';
-        const review = await generateBiologyScoreContextReview(w.getActiveData?.() || {});
+        const review = await generateBiologyScoreContextReview(getActiveData());
         await saveBiologyScoreContextReview(review); w.navigate?.('biology-scores');
       } else if (action === 'apply-context-ai') {
         await applyBiologyScoreContextFlag(el.dataset.contextFlag || ''); w.showNotification?.('Context flag applied', 'success'); w.navigate?.('biology-scores');

--- a/js/biology-scores-runtime.js
+++ b/js/biology-scores-runtime.js
@@ -2,12 +2,18 @@
 // biology-scores-runtime.js - Browser runtime adapters for Biology Scores UI hooks.
 
 import { hasAIProvider } from './api.js';
+import { getActiveData } from './data.js';
 import { showNotification } from './utils.js';
 
-const biologyScoresRuntimeDeps = { showNotification };
+const biologyScoresRuntimeDeps = { getActiveData, showNotification };
 
 export function configureBiologyScoresRuntimeDeps(deps = {}) {
   const previous = { ...biologyScoresRuntimeDeps };
+  if ('getActiveData' in deps) {
+    biologyScoresRuntimeDeps.getActiveData = typeof deps.getActiveData === 'function'
+      ? /** @type {typeof getActiveData} */ (deps.getActiveData)
+      : null;
+  }
   if ('showNotification' in deps) {
     biologyScoresRuntimeDeps.showNotification = typeof deps.showNotification === 'function'
       ? /** @type {typeof showNotification} */ (deps.showNotification)
@@ -71,7 +77,7 @@ export function hasBiologyScoresAIProvider() {
 }
 
 export function getBiologyScoresActiveData() {
-  return getRuntimeFunction('getActiveData')?.() || {};
+  return biologyScoresRuntimeDeps.getActiveData?.() || {};
 }
 
 /** @param {string} markerId */

--- a/js/biology-scores.js
+++ b/js/biology-scores.js
@@ -1,7 +1,7 @@
 // @ts-check
 // biology-scores.js — Biology Scores orchestrator and public API.
 
-import { filterDatesByRange } from './data.js';
+import { filterDatesByRange, getActiveData } from './data.js';
 import { generateBiologyScoreAIAnswer } from './biology-score-ai.js';
 import { computeBiologicalCoherence } from './biology-score-coherence.js';
 import { getBiologyScoreCopy } from './biology-score-copy.js';
@@ -294,7 +294,7 @@ function reconcileBiologyScoreAIPanels() {
   if (typeof document === 'undefined') return;
   const panels = Array.from(document.querySelectorAll('[data-biology-score-ai-panel]'));
   if (!panels.length) return;
-  const rawData = (/** @type {any} */ (globalThis)).getActiveData?.() || {};
+  const rawData = getActiveData();
   const scoreData = filterDatesByRange(rawData, { fallbackToAll: false });
   const scoreMap = new Map(computeBiologyScores(scoreData).map(score => [score.id, score]));
   for (const panel of panels) {

--- a/js/data.js
+++ b/js/data.js
@@ -1069,7 +1069,3 @@ export function updateHeaderRangeToggle() {
     btn.setAttribute('aria-pressed', active ? 'true' : 'false');
   }
 }
-
-if (typeof window !== 'undefined') {
-  Object.assign(window, { saveImportedData, getFocusCardFingerprint, getActiveData, invalidateActiveDataCache, applyUnitConversion, filterDatesByRange, recalculateHOMAIR, renderDateRangeFilter, setDateRange, renderChartLayersDropdown, toggleChartLayersDropdown, setSuppOverlay, setNoteOverlay, setPhaseOverlay, destroyAllCharts, countFlagged, getLatestValueIndex, getAllFlaggedMarkers, statusIcon, detectTrendAlerts, getKeyTrendMarkers, switchUnitSystem, toggleAltUnits, getEffectiveRange, getEffectiveRangeForDate, getPhaseRefEnvelope, switchRangeMode, updateHeaderDates, updateHeaderRangeToggle, registerRefreshCallback });
-}

--- a/js/export.js
+++ b/js/export.js
@@ -3,7 +3,7 @@
 
 import { state } from './state.js';
 import { showNotification, showConfirmDialog } from './utils.js';
-import { saveImportedData } from './data.js';
+import { saveImportedData, updateHeaderDates } from './data.js';
 import { getProfiles, profileStorageKey, saveProfiles, migrateProfileData } from './profile.js';
 import { encryptedGetItem, getEncryptionEnabled, encryptedRemoveItem } from './crypto.js';
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
@@ -542,7 +542,7 @@ export async function loadDemoData(sex = 'male') {
         await saveImportedData({ skipSync: true, reason: 'demo-biology-score-context' });
         const w = /** @type {any} */ (window);
         if (w.buildSidebar) w.buildSidebar();
-        if (w.updateHeaderDates) w.updateHeaderDates();
+        updateHeaderDates();
         if (w.navigate && state.currentView === 'biology-scores') w.navigate('biology-scores');
       }
     } catch (_) { /* demo Biology Scores post-import unlock is best-effort */ }

--- a/js/pdf-import-review-runtime.js
+++ b/js/pdf-import-review-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // pdf-import-review-runtime.js - Browser runtime adapters for import review state.
 
+import { updateHeaderDates } from './data.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -9,11 +11,17 @@ function getRuntimeWindow() {
 
 const pdfImportReviewRuntimeDeps = {
   confirmImport: () => import('./pdf-import-commit.js').then(module => module.confirmImport()),
+  updateHeaderDates,
 };
 
 export function configurePdfImportReviewRuntimeDeps(deps = {}) {
   const previous = { ...pdfImportReviewRuntimeDeps };
   if (typeof deps.confirmImport === 'function') pdfImportReviewRuntimeDeps.confirmImport = deps.confirmImport;
+  if ('updateHeaderDates' in deps) {
+    pdfImportReviewRuntimeDeps.updateHeaderDates = typeof deps.updateHeaderDates === 'function'
+      ? /** @type {typeof updateHeaderDates} */ (deps.updateHeaderDates)
+      : null;
+  }
   return previous;
 }
 
@@ -59,15 +67,15 @@ export function navigateImportReviewRuntime(route = 'dashboard') {
 
 /** @param {string} route */
 export function refreshImportedDataViewsRuntime(route = 'dashboard') {
+  if (!getRuntimeWindow()) return false;
   let refreshed = false;
   const buildSidebar = getRuntimeFunction('buildSidebar');
   if (buildSidebar) {
     buildSidebar();
     refreshed = true;
   }
-  const updateHeaderDates = getRuntimeFunction('updateHeaderDates');
-  if (updateHeaderDates) {
-    updateHeaderDates();
+  if (pdfImportReviewRuntimeDeps.updateHeaderDates) {
+    pdfImportReviewRuntimeDeps.updateHeaderDates();
     refreshed = true;
   }
   if (navigateImportReviewRuntime(route)) refreshed = true;

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 5,
-  "legacyWindowGlobalAssignments": 3,
+  "windowGlobalAssignments": 4,
+  "legacyWindowGlobalAssignments": 2,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -9,7 +9,10 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
   );
 
   const results = await page.evaluate(async () => {
-    const { state } = await import('/js/state.js');
+    const [{ state }, dataModule] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/data.js'),
+    ]);
     const originalData = state.importedData;
     const originalSex = state.profileSex;
     const originalDob = state.profileDob;
@@ -23,7 +26,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
         state.importedData = await resp.json();
         state.profileSex = 'male';
         state.profileDob = '1987-11-22';
-        window.saveImportedData?.();
+        await dataModule.saveImportedData();
         window.buildSidebar?.();
       }
 

--- a/tests/playwright/biology-scores-dashboard-lens.spec.js
+++ b/tests/playwright/biology-scores-dashboard-lens.spec.js
@@ -4,25 +4,28 @@ async function prepareDemoProfile(page) {
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForFunction(() =>
     typeof window.navigate === 'function'
-      && typeof window.saveImportedData === 'function'
+      && !!window._labState
   );
 
   await page.evaluate(async () => {
-    const { getActiveProfileId } = await import('/js/profile.js');
+    const [{ getActiveProfileId }, dataModule] = await Promise.all([
+      import('/js/profile.js'),
+      import('/js/data.js'),
+    ]);
     const profileId = getActiveProfileId() || localStorage.getItem('labcharts-active-profile') || 'default';
     localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
 
-    if (!window.getActiveData?.()?.dates?.length) {
+    if (!dataModule.getActiveData()?.dates?.length) {
       const resp = await fetch('data/demo-male.json');
       const { state } = await import('/js/state.js');
       state.importedData = await resp.json();
       state.profileSex = 'male';
       state.profileDob = '1987-11-22';
       const { buildBiologyScoreContextFingerprint, buildBiologyScoreContextFingerprintsByRange } = await import('/js/biology-score-context-ai.js');
-      const activeData = window.getActiveData?.() || {};
+      const activeData = dataModule.getActiveData();
       state.importedData.biologyScoreContextAI = { summary: 'Context checked for Playwright demo', suggestions: [], fingerprint: buildBiologyScoreContextFingerprint(activeData), fingerprintsByRange: buildBiologyScoreContextFingerprintsByRange(activeData), unlockedRanges: ['all', '1y', '6m', '3m'], range: 'all', updatedAt: Date.now() };
-      window.saveImportedData?.();
+      await dataModule.saveImportedData();
       window.buildSidebar?.();
     }
 
@@ -31,7 +34,7 @@ async function prepareDemoProfile(page) {
     state.importedData.profile.firstName = 'Alex';
     state.importedData.profile.age = 38;
     const { buildBiologyScoreContextFingerprint, buildBiologyScoreContextFingerprintsByRange } = await import('/js/biology-score-context-ai.js');
-    const activeData = window.getActiveData?.() || {};
+    const activeData = dataModule.getActiveData();
     state.importedData.biologyScoreContextAI = { summary: 'Context checked for Playwright demo', suggestions: [], fingerprint: buildBiologyScoreContextFingerprint(activeData), fingerprintsByRange: buildBiologyScoreContextFingerprintsByRange(activeData), unlockedRanges: ['all', '1y', '6m', '3m'], range: 'all', updatedAt: Date.now() };
   });
 }

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -9,8 +9,9 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
   );
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dashboardWidgetsModule, contextCardsRuntime] = await Promise.all([
+    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime] = await Promise.all([
       import('/js/state.js'),
+      import('/js/data.js'),
       import('/js/dashboard-widgets.js'),
       import('/js/context-cards-runtime.js'),
     ]);
@@ -37,12 +38,12 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     let previousContextCardsRuntime = null;
 
     try {
-      if (!window.getActiveData?.()?.dates?.length) {
+      if (!dataModule.getActiveData()?.dates?.length) {
         const resp = await fetch('data/demo-male.json');
         state.importedData = await resp.json();
         state.profileSex = 'male';
         state.profileDob = '1987-11-22';
-        window.saveImportedData?.();
+        await dataModule.saveImportedData();
         window.buildSidebar?.();
       }
 

--- a/tests/playwright/data-browser-coverage.spec.js
+++ b/tests/playwright/data-browser-coverage.spec.js
@@ -27,6 +27,17 @@ test('data browser coverage exercises display toggles range refresh and helpers'
     const state = window._labState;
     const calls = [];
     const outcomes = {};
+    const formerGlobalNames = [
+      'saveImportedData', 'getFocusCardFingerprint', 'getActiveData', 'invalidateActiveDataCache',
+      'applyUnitConversion', 'filterDatesByRange', 'recalculateHOMAIR', 'renderDateRangeFilter',
+      'setDateRange', 'renderChartLayersDropdown', 'toggleChartLayersDropdown', 'setSuppOverlay',
+      'setNoteOverlay', 'setPhaseOverlay', 'destroyAllCharts', 'countFlagged', 'getLatestValueIndex',
+      'getAllFlaggedMarkers', 'statusIcon', 'detectTrendAlerts', 'getKeyTrendMarkers', 'switchUnitSystem',
+      'toggleAltUnits', 'getEffectiveRange', 'getEffectiveRangeForDate', 'getPhaseRefEnvelope',
+      'switchRangeMode', 'updateHeaderDates', 'updateHeaderRangeToggle', 'registerRefreshCallback',
+    ];
+    outcomes.dataApisStayModuleOnly = formerGlobalNames.every(name =>
+      typeof dataMod[name] === 'function' && !(name in window));
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const profileId = 'data-browser-coverage-profile';
     const saved = {

--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -663,16 +663,19 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
 
   const results = await page.evaluate(async ({ persistenceUrl }) => {
     const persistence = await import(persistenceUrl);
+    const reviewRuntime = await import('/js/pdf-import-review-runtime.js');
     const state = window._labState;
     const outcomes = {};
     const originals = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       currentView: state.currentView,
       buildSidebar: window.buildSidebar,
-      updateHeaderDates: window.updateHeaderDates,
       navigate: window.navigate,
     };
     const viewCalls = [];
+    const previousReviewRuntime = reviewRuntime.configurePdfImportReviewRuntimeDeps({
+      updateHeaderDates: () => { viewCalls.push('updateHeaderDates'); },
+    });
     const waitForPrompt = async () => {
       for (let attempt = 0; attempt < 40; attempt++) {
         const input = document.getElementById('prompt-dialog-input');
@@ -690,7 +693,6 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
 
     try {
       window.buildSidebar = () => { viewCalls.push('buildSidebar'); };
-      window.updateHeaderDates = () => { viewCalls.push('updateHeaderDates'); };
       window.navigate = view => { viewCalls.push(`navigate:${view}`); };
       state.currentView = 'labs';
       state.importedData = {
@@ -758,8 +760,8 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
       state.importedData = originals.importedData;
       state.currentView = originals.currentView;
       window.buildSidebar = originals.buildSidebar;
-      window.updateHeaderDates = originals.updateHeaderDates;
       window.navigate = originals.navigate;
+      reviewRuntime.configurePdfImportReviewRuntimeDeps(previousReviewRuntime);
       document.getElementById('prompt-dialog-overlay')?.classList.remove('show');
     }
 

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -55,8 +55,9 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
   await prepareApp(page);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, shell, profile, contextCardsRuntime] = await Promise.all([
+    const [{ state }, dataModule, shell, profile, contextCardsRuntime] = await Promise.all([
       import('/js/state.js'),
+      import('/js/data.js'),
       import('/js/lens-page-shell.js'),
       import('/js/profile.js'),
       import('/js/context-cards-runtime.js'),
@@ -83,12 +84,12 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
     });
 
     try {
-      if (!window.getActiveData?.()?.dates?.length) {
+      if (!dataModule.getActiveData()?.dates?.length) {
         const resp = await fetch('data/demo-male.json');
         state.importedData = await resp.json();
         state.profileSex = 'male';
         state.profileDob = '1987-11-22';
-        window.saveImportedData?.();
+        await dataModule.saveImportedData();
         window.buildSidebar?.();
       }
 

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -10,6 +10,7 @@ test('report builder modal delegates presets categories AI state and preview exp
 
   const results = await page.evaluate(async ({ builderUrl }) => {
     const builder = await import(builderUrl);
+    const dataModule = await import('/js/data.js');
     const profile = await import('/js/profile.js');
     const state = window._labState;
     const outcomes = {};
@@ -84,7 +85,7 @@ test('report builder modal delegates presets categories AI state and preview exp
         },
         customMarkers: {},
       };
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       await profile.saveProfiles([{
         id: 'report-export-coverage',
         name: 'Report Coverage',
@@ -220,7 +221,7 @@ test('report builder modal delegates presets categories AI state and preview exp
       state.profileSex = original.profileSex;
       state.profileDob = original.profileDob;
       state.dateRangeFilter = original.dateRangeFilter;
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       await profile.saveProfiles(original.profiles);
       window.open = original.open;
       if (original.aiProvider == null) localStorage.removeItem('labcharts-ai-provider');
@@ -246,10 +247,11 @@ test('report payload and HTML cover filtered context genetics and supplement bra
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ reportUrl, htmlUrl }) => {
-    const [report, html, profile] = await Promise.all([
+    const [report, html, profile, dataModule] = await Promise.all([
       import(reportUrl),
       import(htmlUrl),
       import('/js/profile.js'),
+      import('/js/data.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
@@ -373,7 +375,7 @@ test('report payload and HTML cover filtered context genetics and supplement bra
           },
         },
       };
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       await profile.saveProfiles([{
         id: 'report-payload-coverage',
         name: 'Payload Coverage',
@@ -461,7 +463,7 @@ test('report payload and HTML cover filtered context genetics and supplement bra
       state.rangeMode = original.rangeMode;
       state.unitSystem = original.unitSystem;
       window._snpTableCache = original.snpTable;
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       await profile.saveProfiles(original.profiles);
     }
 
@@ -482,6 +484,7 @@ test('report HTML renderer covers sparse single-date trend and print branches', 
 
   const results = await page.evaluate(async ({ htmlUrl }) => {
     const html = await import(htmlUrl);
+    const dataModule = await import('/js/data.js');
     const state = window._labState;
     const outcomes = {};
     const original = {
@@ -561,7 +564,7 @@ test('report HTML renderer covers sparse single-date trend and print branches', 
         customMarkers: {},
       };
       window._snpTableCache = null;
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
 
       const emptyReport = html.buildReportHTML(
         'Sparse <Profile>',
@@ -724,7 +727,7 @@ test('report HTML renderer covers sparse single-date trend and print branches', 
       state.unitSystem = original.unitSystem;
       window.open = original.open;
       window._snpTableCache = original.snpTable;
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
     }
 
     return outcomes;
@@ -743,6 +746,7 @@ test('report AI summary generation covers unavailable success and empty-response
 
   const results = await page.evaluate(async ({ reportUrl }) => {
     const report = await import(reportUrl);
+    const dataModule = await import('/js/data.js');
     const profile = await import('/js/profile.js');
     const state = window._labState;
     const outcomes = {};
@@ -786,7 +790,7 @@ Discussion focus:
         contextNotes: 'Prefers concise practitioner reports.',
         customMarkers: {},
       };
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       await profile.saveProfiles([{
         id: 'report-ai-coverage',
         name: 'Report AI Coverage',
@@ -857,7 +861,7 @@ Discussion focus:
       state.currentProfile = original.currentProfile;
       state.profileSex = original.profileSex;
       state.profileDob = original.profileDob;
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       await profile.saveProfiles(original.profiles);
       window.fetch = original.fetch;
       if (original.aiProvider == null) localStorage.removeItem('labcharts-ai-provider');
@@ -885,6 +889,7 @@ test('report export helpers cover option normalization AI markup and popup block
   const results = await page.evaluate(async ({ reportUrl, htmlUrl }) => {
     const report = await import(reportUrl);
     const html = await import(htmlUrl);
+    const dataModule = await import('/js/data.js');
     const state = window._labState;
     const outcomes = {};
     const original = {
@@ -906,7 +911,7 @@ test('report export helpers cover option normalization AI markup and popup block
         supplements: [],
         customMarkers: {},
       };
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
 
       const normalized = report.normalizeReportOptions({
         preset: 'missing',
@@ -941,7 +946,7 @@ test('report export helpers cover option normalization AI markup and popup block
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;
       state.profileSex = original.profileSex;
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       window.open = original.open;
     }
 
@@ -961,10 +966,11 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ exportUrl, profileUrl, cryptoUrl }) => {
-    const [exportFacade, profileStore, cryptoStore] = await Promise.all([
+    const [exportFacade, profileStore, cryptoStore, dataModule] = await Promise.all([
       import(exportUrl),
       import(profileUrl),
       import(cryptoUrl),
+      import('/js/data.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
@@ -1277,7 +1283,7 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;
       await profileStore.saveProfiles(original.profiles);
-      window.invalidateActiveDataCache?.();
+      dataModule.invalidateActiveDataCache?.();
       setOrRemove('labcharts-active-profile', original.activeProfile);
       setOrRemove('labcharts-encryption-enabled', original.encryptionEnabled);
       setOrRemove('labcharts-ai-provider', original.aiProvider);

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -213,6 +213,7 @@ test('settings browser coverage renames imported entry dates through the data se
 
   const results = await page.evaluate(async () => {
     const dataModule = await import('/js/data.js');
+    const reviewRuntime = await import('/js/pdf-import-review-runtime.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 80; attempt += 1) {
@@ -229,13 +230,15 @@ test('settings browser coverage renames imported entry dates through the data se
       currentProfile: state.currentProfile,
       currentView: state.currentView,
       buildSidebar: window.buildSidebar,
-      updateHeaderDates: window.updateHeaderDates,
       navigate: window.navigate,
       storage: localStorage.getItem(`labcharts-${profileId}-imported`),
     };
     const calls = [];
     const originalDataContextDeps = dataModule.configureDataContextDependencies({
       invalidateLabContextCache: () => calls.push('invalidateLabContextCache'),
+    });
+    const originalReviewRuntimeDeps = reviewRuntime.configurePdfImportReviewRuntimeDeps({
+      updateHeaderDates: () => calls.push('updateHeaderDates'),
     });
 
     try {
@@ -253,7 +256,6 @@ test('settings browser coverage renames imported entry dates through the data se
         changeHistory: [],
       };
       window.buildSidebar = () => calls.push('buildSidebar');
-      window.updateHeaderDates = () => calls.push('updateHeaderDates');
       window.navigate = view => calls.push(`navigate:${view}`);
 
       document.body.insertAdjacentHTML('beforeend', '<section id="data-entries-section"></section>');
@@ -281,9 +283,9 @@ test('settings browser coverage renames imported entry dates through the data se
       state.currentProfile = saved.currentProfile;
       state.currentView = saved.currentView;
       window.buildSidebar = saved.buildSidebar;
-      window.updateHeaderDates = saved.updateHeaderDates;
       window.navigate = saved.navigate;
       dataModule.configureDataContextDependencies(originalDataContextDeps);
+      reviewRuntime.configurePdfImportReviewRuntimeDeps(originalReviewRuntimeDeps);
       if (saved.storage == null) localStorage.removeItem(`labcharts-${profileId}-imported`);
       else localStorage.setItem(`labcharts-${profileId}-imported`, saved.storage);
       document.getElementById('data-entries-section')?.remove();

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -115,7 +115,6 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
     await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
     await page.waitForFunction(
       () => window._labState
-        && typeof window.saveImportedData === 'function'
         && typeof window.showDetailModal === 'function'
         && typeof window.navigate === 'function'
         && typeof window.openSunSessionDetail === 'function'
@@ -154,6 +153,7 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
       { timeout: 15000 }
     );
     await page.evaluate(async ({ profileId, imported }) => {
+      const { saveImportedData } = await import('/js/data.js');
       localStorage.clear();
       sessionStorage.clear();
       localStorage.setItem('labcharts-active-profile', profileId);
@@ -166,7 +166,7 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
         if (el.id) el.classList.remove('show');
         else el.remove();
       });
-      await window.saveImportedData({ immediate: true });
+      await saveImportedData({ immediate: true });
       window.navigate('dashboard');
     }, { profileId: PROFILE_ID, imported: importedData });
     return { context, page, label };
@@ -390,6 +390,7 @@ async function closeFloatingModals(page) {
 
 async function enableAgentAccessForSync(page) {
   return page.evaluate(async () => {
+    const { saveImportedData } = await import('/js/data.js');
     const token = 'syncagent'.padEnd(64, 'a');
     const contextKey = `gbctx_v1_${'S'.repeat(43)}`;
     const now = Date.now();
@@ -405,7 +406,7 @@ async function enableAgentAccessForSync(page) {
     window._labState.importedData.agentAccessWearableSeriesDays = 30;
     localStorage.removeItem('labcharts-messenger-token');
     localStorage.removeItem('labcharts-agent-context-key');
-    await window.saveImportedData({ immediate: true });
+    await saveImportedData({ immediate: true });
     return JSON.parse(JSON.stringify(window._labState.importedData));
   });
 }
@@ -428,10 +429,11 @@ async function agentAccessSnapshot(page) {
 
 async function disableAgentAccessForSync(page) {
   return page.evaluate(async () => {
+    const { saveImportedData } = await import('/js/data.js');
     const messenger = window.__syncE2EMessenger;
     if (!messenger) throw new Error('sync-messenger helper module not loaded');
     const previousToken = messenger.disableMessengerTokenLocal();
-    await window.saveImportedData({ immediate: true });
+    await saveImportedData({ immediate: true });
     return {
       previousToken,
       imported: JSON.parse(JSON.stringify(window._labState.importedData)),

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -55,6 +55,7 @@ async function waitForApp(page) {
 
 async function seedDemoData(page) {
   await page.evaluate(async () => {
+    const dataModule = await import('/js/data.js');
     const profileModule = await import('/js/profile.js');
     const demo = await fetch('/data/demo-male.json', { cache: 'no-store' }).then(r => r.json());
     const profileId = window._labState.currentProfile || 'default';
@@ -105,7 +106,7 @@ async function seedDemoData(page) {
     window._labState.importedData = demo;
     window._labState.profileSex = 'male';
     window._labState.profileDob = '1987-11-22';
-    window.saveImportedData?.();
+    await dataModule.saveImportedData();
     window.buildSidebar?.();
     window.navigate?.('dashboard');
     window.closeChatPanel?.();
@@ -672,8 +673,9 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
   });
   await delay(100);
 
-  const markerId = await page.evaluate(() => {
-    const data = window.getActiveData?.();
+  const markerId = await page.evaluate(async () => {
+    const { getActiveData } = await import('/js/data.js');
+    const data = getActiveData();
     for (const [catKey, cat] of Object.entries(data?.categories || {})) {
       for (const [markerKey, marker] of Object.entries(cat.markers || {})) {
         if ((marker.values || []).some(v => v != null && Number.isFinite(Number(v)))) return `${catKey}_${markerKey}`;

--- a/tests/test-biology-scores-runtime.js
+++ b/tests/test-biology-scores-runtime.js
@@ -84,6 +84,7 @@ try {
   };
   setRuntimeValue('window', browserRuntime);
   configureBiologyScoresRuntimeDeps({
+    getActiveData: browserRuntime.getActiveData.bind(browserRuntime),
     showNotification: browserRuntime.showNotification.bind(browserRuntime),
   });
   localStorage.setItem('labcharts-ai-provider', 'openrouter');
@@ -122,6 +123,7 @@ try {
 
   delete browserRuntime.openChatPanel;
   delete browserRuntime.getActiveData;
+  configureBiologyScoresRuntimeDeps({ getActiveData: null });
   assert('biology runtime handles missing optional browser hooks',
     !canOpenBiologyScoresChatPanel() &&
       openBiologyScoresChatPanel('missing') === false &&

--- a/tests/test-calculated-markers.js
+++ b/tests/test-calculated-markers.js
@@ -29,10 +29,9 @@ function assert(name, condition, detail) {
 
 console.log('=== Calculated Markers Tests ===\n');
 
-// Bring in state.js + data.js so window._labState exists and getActiveData
-// is wired up (data.js does Object.assign(window, { getActiveData, ... })).
+// Bring in state.js and the module-only data API.
 await import('../js/state.js');
-await import('../js/data.js');
+const dataModule = await import('../js/data.js');
 
 const state = window._labState;
 
@@ -71,7 +70,7 @@ const state = window._labState;
     }
   }];
 
-  let data = window.getActiveData();
+  let data = dataModule.getActiveData();
   let phenoVal = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[0];
 
   // Expected: xb = -19.907 - 0.0336*45 + 0.0095*80 + 0.1953*5.5 + 0.0954*ln(1.5)
@@ -99,7 +98,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   phenoVal = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[0];
   assert('PhenoAge is null when WBC missing', phenoVal === null || phenoVal === undefined, `got ${phenoVal}`);
 
@@ -114,7 +113,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   phenoVal = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[0];
   assert('PhenoAge is null when DOB missing', phenoVal == null, `got ${phenoVal}`);
 
@@ -129,7 +128,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   phenoVal = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[0];
   assert('PhenoAge is null when CRP is zero (ln undefined)', phenoVal == null, `got ${phenoVal}`);
 
@@ -146,7 +145,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   phenoVal = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[0];
   assert('PhenoAge is null when only standard CRP is provided (no fallback)', phenoVal == null, `got ${phenoVal}`);
 
@@ -196,7 +195,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   let bortzVal = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[0];
 
   // BAA = sum((centered - mean) × coeff) for all 22 features, biological age = age + 10 × BAA
@@ -220,7 +219,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   bortzVal = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[0];
   assert('Bortz Age is null when apoAI missing', bortzVal == null, `got ${bortzVal}`);
 
@@ -240,7 +239,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   bortzVal = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[0];
   assert('Bortz Age is null when DOB missing', bortzVal == null, `got ${bortzVal}`);
 
@@ -276,7 +275,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const bioAge = data.categories.calculatedRatios?.markers?.biologicalAge?.values?.[0];
   const phenoCheck = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[0];
   const bortzCheck = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[0];
@@ -306,7 +305,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const bioAgePheno = data.categories.calculatedRatios?.markers?.biologicalAge?.values?.[0];
   const phenoOnly = data.categories.calculatedRatios?.markers?.phenoAge?.values?.[0];
   const bortzNull = data.categories.calculatedRatios?.markers?.bortzAge?.values?.[0];
@@ -316,7 +315,7 @@ const state = window._labState;
 
   // ── Biological Age: both null → null ──
   state.profileDob = null;
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const bioAgeNull = data.categories.calculatedRatios?.markers?.biologicalAge?.values?.[0];
   assert('Biological Age is null when both components null', bioAgeNull == null, `got ${bioAgeNull}`);
 
@@ -338,7 +337,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const bunCreat = data.categories.calculatedRatios?.markers?.bunCreatRatio?.values?.[0];
   assert('BUN/Creat ratio computes correctly', bunCreat === 17.0, `expected 17.0, got ${bunCreat}`);
 
@@ -351,7 +350,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const bunCreatZero = data.categories.calculatedRatios?.markers?.bunCreatRatio?.values?.[0];
   assert('BUN/Creat is null when creatinine is zero', bunCreatZero == null, `got ${bunCreatZero}`);
 
@@ -363,7 +362,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const bunCreatNoUrea = data.categories.calculatedRatios?.markers?.bunCreatRatio?.values?.[0];
   assert('BUN/Creat is null when urea missing', bunCreatNoUrea == null, `got ${bunCreatNoUrea}`);
 
@@ -391,14 +390,14 @@ const state = window._labState;
     markers: { 'electrolytes.sodium': 145 }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const fwd = data.categories.calculatedRatios?.markers?.freeWaterDeficit?.values?.[0];
   assert('FWD computes for male with weight', fwd === 1.71, `expected 1.71, got ${fwd}`);
 
   // ── FWD: female → uses 0.5 TBW factor ──
   state.profileSex = 'female';
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const fwdF = data.categories.calculatedRatios?.markers?.freeWaterDeficit?.values?.[0];
   // 80 × 0.5 × (145/140 - 1) = 40 × 0.0357... = 1.43
   assert('FWD uses 0.5 factor for female', fwdF === 1.43, `expected 1.43, got ${fwdF}`);
@@ -407,7 +406,7 @@ const state = window._labState;
   state.profileSex = 'male';
   state.importedData.biometrics = null;
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const fwdDef = data.categories.calculatedRatios?.markers?.freeWaterDeficit?.values?.[0];
   // 70 × 0.6 × (145/140 - 1) = 42 × 0.0357... = 1.5
   assert('FWD falls back to 70kg default', fwdDef === 1.5, `expected 1.5, got ${fwdDef}`);
@@ -418,7 +417,7 @@ const state = window._labState;
     markers: { 'electrolytes.sodium': 0 }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const fwdZero = data.categories.calculatedRatios?.markers?.freeWaterDeficit?.values?.[0];
   assert('FWD is null when sodium is zero', fwdZero == null, `got ${fwdZero}`);
 
@@ -428,7 +427,7 @@ const state = window._labState;
     markers: { 'biochemistry.glucose': 5.5 }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const fwdMissing = data.categories.calculatedRatios?.markers?.freeWaterDeficit?.values?.[0];
   assert('FWD is null when sodium missing', fwdMissing == null, `got ${fwdMissing}`);
 
@@ -439,7 +438,7 @@ const state = window._labState;
   }];
   state.importedData.biometrics = null;
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const fwdNeg = data.categories.calculatedRatios?.markers?.freeWaterDeficit?.values?.[0];
   // 70 × 0.6 × (130/140 - 1) = 42 × (-0.07143) = -3.0
   assert('FWD is negative for low sodium (overhydration)', fwdNeg < 0, `got ${fwdNeg}`);
@@ -460,7 +459,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const crpHdl = data.categories.calculatedRatios?.markers?.crpHdlRatio?.values?.[0];
   // 1.5 / (1.5 × 38.67) = 1.5 / 58.005 = 0.0259
   assert('CRP/HDL ratio computes correctly', crpHdl === 0.0259, `expected 0.0259, got ${crpHdl}`);
@@ -484,7 +483,7 @@ const state = window._labState;
     markers: { 'proteins.hsCRP': 1.5, 'lipids.hdl': 0 }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const crpHdlZeroHdl = data.categories.calculatedRatios?.markers?.crpHdlRatio?.values?.[0];
   assert('CRP/HDL is null when HDL is zero', crpHdlZeroHdl == null, `got ${crpHdlZeroHdl}`);
 
@@ -494,7 +493,7 @@ const state = window._labState;
     markers: { 'lipids.hdl': 1.5 }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const crpHdlNoCrp = data.categories.calculatedRatios?.markers?.crpHdlRatio?.values?.[0];
   assert('CRP/HDL is null when hs-CRP missing', crpHdlNoCrp == null, `got ${crpHdlNoCrp}`);
 
@@ -507,7 +506,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const crpHdlStd = data.categories.calculatedRatios?.markers?.crpHdlRatio?.values?.[0];
   assert('CRP/HDL does NOT use standard CRP (requires hs-CRP)', crpHdlStd == null, `got ${crpHdlStd}`);
 
@@ -535,7 +534,7 @@ const state = window._labState;
     }
   ];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const bunArr = data.categories.calculatedRatios?.markers?.bunCreatRatio?.values;
   assert('Multi-date: 3 values in array', bunArr?.length === 3, `got ${bunArr?.length}`);
 
@@ -570,7 +569,7 @@ const state = window._labState;
     }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const cr = data.categories.calculatedRatios?.markers;
 
   // TG/HDL = 1.5/1.5 = 1.0
@@ -610,7 +609,7 @@ const state = window._labState;
     markers: { 'lipids.triglycerides': 1.5, 'lipids.hdl': 0 }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const tgHdlZero = data.categories.calculatedRatios?.markers?.tgHdlRatio?.values?.[0];
   assert('TG/HDL is null when HDL is zero', tgHdlZero == null, `got ${tgHdlZero}`);
 
@@ -620,7 +619,7 @@ const state = window._labState;
     markers: { 'calculatedRatios.cholHdlRatio': 3.4 }
   }];
 
-  data = window.getActiveData();
+  data = dataModule.getActiveData();
   const directCholHdl = data.categories.calculatedRatios?.markers?.cholHdlRatio?.values?.[0];
   assert('Direct imported Chol/HDL ratio is retained when components are missing',
     directCholHdl === 3.4, `expected 3.4, got ${directCholHdl}`);

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -45,7 +45,7 @@ console.log('=== Crypto / Encryption / Backup Tests ===\n');
 await import('../js/state.js');
 const cryptoModule = await import('../js/crypto.js');
 await import('../js/pii.js');
-await import('../js/data.js');
+const dataModule = await import('../js/data.js');
 const profileModule = await import('../js/profile.js');
 cryptoModule.configureCryptoProfileDeps({ migrateProfileData: profileModule.migrateProfileData });
 await import('../js/nav.js');
@@ -318,13 +318,18 @@ console.log('11b. Key cache sync access');
 }
 
 // ═══════════════════════════════════════════════
-// 12. All existing window exports still present (regression)
+// 12. Legacy globals and module-only data APIs
 // ═══════════════════════════════════════════════
 console.log('12. Window exports regression');
-const expectedExports = [
-  // data.js
+const dataExports = [
   'saveImportedData', 'getActiveData', 'filterDatesByRange', 'destroyAllCharts',
   'detectTrendAlerts', 'switchUnitSystem', 'switchRangeMode', 'updateHeaderDates',
+];
+for (const name of dataExports) {
+  assert(`data.${name} exists`, typeof dataModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
+}
+const expectedExports = [
   // nav.js
   'buildSidebar', 'renderProfileDropdown',
   // views.js

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -23,9 +23,9 @@ function assert(name, condition, detail = '') {
 
 console.log('=== Cycle Improvements Test Suite ===\n');
 
-// Load state + data.js + cycle.js so the data globals and cycle module exist.
+// Load state, the module-only data API, and cycle.js.
 await import('../js/state.js');
-await import('../js/data.js');
+const dataModule = await import('../js/data.js');
 const cycle = await import('../js/cycle.js');
 const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 1: PERIOD_SYMPTOMS constant ──
@@ -70,7 +70,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
       { date: '2025-02-01', markers: { 'biochemistry.glucose': 4.9 } }
     ];
 
-    const data = window.getActiveData();
+    const data = dataModule.getActiveData();
     assert('data.phaseLabels exists for female+cycle', Array.isArray(data.phaseLabels));
     assert('data.phaseLabels length matches dates', data.phaseLabels.length === data.dates.length, `${data.phaseLabels?.length} vs ${data.dates.length}`);
     assert('data.phaseLabels contains menstrual for Jan 3', data.phaseLabels[0] === 'menstrual', `got "${data.phaseLabels?.[0]}"`);
@@ -79,7 +79,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
 
     // Test without cycle → no phaseLabels
     state.profileSex = 'male';
-    const dataM = window.getActiveData();
+    const dataM = dataModule.getActiveData();
     assert('data.phaseLabels absent for male', !dataM.phaseLabels);
 
     state.profileSex = origSex;
@@ -97,7 +97,8 @@ const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 5: setPhaseOverlay function ──
   console.log('Section 5: setPhaseOverlay function');
   {
-    assert('setPhaseOverlay is a window function', typeof window.setPhaseOverlay === 'function');
+    assert('setPhaseOverlay is a module API', typeof dataModule.setPhaseOverlay === 'function');
+    assert('setPhaseOverlay stays off window', !('setPhaseOverlay' in window));
     const src = read('js/data.js');
     assert('setPhaseOverlay sets phaseOverlayMode', src.includes("state.phaseOverlayMode = mode === 'off' ? 'off' : 'on'"));
     assert('setPhaseOverlay persists to localStorage', src.includes("'phaseOverlay'") && src.includes('setPhaseOverlay'));
@@ -211,7 +212,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
         { startDate: '2025-02-01', endDate: '2025-02-05', flow: 'light' }
       ]
     };
-    const data1 = window.getActiveData();
+    const data1 = dataModule.getActiveData();
     const alerts1 = cycle.detectCycleIronAlerts(mc1, data1);
     assert('No alerts for no heavy flow', alerts1.length === 0);
 
@@ -232,7 +233,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
     const { state } = await import('../js/state.js');
     const origEntries = state.importedData.entries;
     state.importedData.entries = [{ date: '2025-01-10', markers: { 'biochemistry.glucose': 5.0 } }];
-    const data2 = window.getActiveData();
+    const data2 = dataModule.getActiveData();
     const alerts2 = cycle.detectCycleIronAlerts(mc2, data2);
     assert('Info alert when no iron panel + heavy flow', alerts2.some(a => a.severity === 'info'), `got ${JSON.stringify(alerts2.map(a=>a.severity))}`);
     state.importedData.entries = origEntries;

--- a/tests/test-data-pipeline.js
+++ b/tests/test-data-pipeline.js
@@ -32,9 +32,9 @@ const wait = ms => new Promise(r => setTimeout(r, ms));
 
 console.log('=== Data Pipeline Tests ===\n');
 
-// Bring in state.js + data.js — getActiveData lives on window after data.js loads.
+// Bring in state.js + the module-only data API.
 await import('../js/state.js');
-await import('../js/data.js');
+const dataModule = await import('../js/data.js');
 
 const S = window._labState;
 
@@ -63,7 +63,7 @@ const S = window._labState;
   // ═══════════════════════════════════════════════
   console.log('%c 1. Basic Structure ', 'font-weight:bold;color:#f59e0b');
 
-  const data = window.getActiveData();
+  const data = dataModule.getActiveData();
   assert('getActiveData returns object', typeof data === 'object' && data !== null);
   assert('data has dates array', Array.isArray(data.dates));
   assert('data has dateLabels array', Array.isArray(data.dateLabels));
@@ -157,7 +157,7 @@ const S = window._labState;
 
   // Switch to US units and get data
   S.unitSystem = 'US';
-  const usData = window.getActiveData();
+  const usData = dataModule.getActiveData();
 
   // Glucose: 4.8 mmol/L * 18.018 = 86.4864 -> toPrecision(4) = 86.49
   // Index dynamically against the anchor date — earlier backfilled
@@ -192,10 +192,10 @@ const S = window._labState;
   // Range mode changes which band/status is displayed, but marker values and
   // units are unit-system concerns. Keep range toggles out of the data cache
   // key so the header Optimal/Reference switch cannot rebuild converted data.
-  const usDataBeforeRangeToggle = window.getActiveData();
+  const usDataBeforeRangeToggle = dataModule.getActiveData();
   const gBeforeRangeToggle = usDataBeforeRangeToggle.categories.biochemistry.markers.glucose;
   S.rangeMode = 'reference';
-  const usDataAfterRangeToggle = window.getActiveData();
+  const usDataAfterRangeToggle = dataModule.getActiveData();
   const gAfterRangeToggle = usDataAfterRangeToggle.categories.biochemistry.markers.glucose;
   assert('range mode changes do not rebuild active marker data',
     usDataAfterRangeToggle === usDataBeforeRangeToggle);
@@ -208,9 +208,10 @@ const S = window._labState;
   // Switch back to EU
   S.unitSystem = 'EU';
 
-  // Test convertDisplayToSI (window export)
-  if (typeof window.applyUnitConversion === 'function') {
-    assert('applyUnitConversion is exposed on window', true);
+  // Test the module export used by display conversion callers.
+  if (typeof dataModule.applyUnitConversion === 'function') {
+    assert('applyUnitConversion is exposed by the data module', true);
+    assert('applyUnitConversion stays off window', !('applyUnitConversion' in window));
   }
 
   // ═══════════════════════════════════════════════
@@ -220,13 +221,13 @@ const S = window._labState;
 
   // Test filterDatesByRange with 'all'
   S.dateRangeFilter = 'all';
-  const allData = window.getActiveData();
-  const filteredAll = window.filterDatesByRange(allData);
+  const allData = dataModule.getActiveData();
+  const filteredAll = dataModule.filterDatesByRange(allData);
   assert('filterDatesByRange "all" keeps all dates', filteredAll.dates.length === allData.dates.length);
 
   // Test with '3m' — only dates within last 3 months
   S.dateRangeFilter = '3m';
-  const filtered3m = window.filterDatesByRange(allData);
+  const filtered3m = dataModule.filterDatesByRange(allData);
   assert('filterDatesByRange "3m" returns object with dates', Array.isArray(filtered3m.dates));
   assert('filterDatesByRange "3m" returns object with categories', typeof filtered3m.categories === 'object');
   // The 3m filter should have fewer or equal dates
@@ -242,7 +243,7 @@ const S = window._labState;
 
   // Test with '1y' — dates within last year
   S.dateRangeFilter = '1y';
-  const filtered1y = window.filterDatesByRange(allData);
+  const filtered1y = dataModule.filterDatesByRange(allData);
   assert('filterDatesByRange "1y" has dates', Array.isArray(filtered1y.dates));
   assert('filterDatesByRange "1y" has <= all dates', filtered1y.dates.length <= allData.dates.length);
 
@@ -255,7 +256,7 @@ const S = window._labState;
       glucose: { values: [5.0], unit: 'mmol/l', refMin: 4.11, refMax: 5.6 }
     }}}
   };
-  const oldFiltered = window.filterDatesByRange(oldData);
+  const oldFiltered = dataModule.filterDatesByRange(oldData);
   assert('filterDatesByRange falls back to all when no dates in range', oldFiltered.dates.length === 1,
     `got ${oldFiltered.dates.length}`);
 
@@ -266,13 +267,12 @@ const S = window._labState;
   // ═══════════════════════════════════════════════
   console.log('%c 6. getStatus ', 'font-weight:bold;color:#f59e0b');
 
-  // getStatus is on utils.js, exposed indirectly. We can test via window or source check
-  // It's imported by data.js but not on window directly. Let's test via the source + data behavior
+  // getStatus is on utils.js and used indirectly by the data module.
   const dataSrc = (await (await fetch('js/utils.js')).text());
   assert('getStatus exported from utils.js', dataSrc.includes('export function getStatus'));
 
   // Test through getAllFlaggedMarkers which uses getStatus internally
-  const flagged = window.getAllFlaggedMarkers(allData);
+  const flagged = dataModule.getAllFlaggedMarkers(allData);
   assert('getAllFlaggedMarkers returns array', Array.isArray(flagged));
   // Each flagged marker should have status 'high' or 'low'
   const allFlagStatuses = flagged.every(f => f.status === 'high' || f.status === 'low');
@@ -287,14 +287,14 @@ const S = window._labState;
 
   // Test getEffectiveRange — uses optimal when in optimal mode
   S.rangeMode = 'optimal';
-  const effRange = window.getEffectiveRange(tsh);
+  const effRange = dataModule.getEffectiveRange(tsh);
   assert('getEffectiveRange in optimal mode uses optimal if available',
     (tsh.optimalMin != null && effRange.min === tsh.optimalMin) ||
     (tsh.optimalMin == null && effRange.min === tsh.refMin),
     `min=${effRange.min}, optMin=${tsh.optimalMin}, refMin=${tsh.refMin}`);
 
   S.rangeMode = 'reference';
-  const refRange = window.getEffectiveRange(tsh);
+  const refRange = dataModule.getEffectiveRange(tsh);
   assert('getEffectiveRange in reference mode uses ref range',
     refRange.min === tsh.refMin && refRange.max === tsh.refMax,
     `min=${refRange.min} vs refMin=${tsh.refMin}, max=${refRange.max} vs refMax=${tsh.refMax}`);
@@ -306,7 +306,7 @@ const S = window._labState;
   // ═══════════════════════════════════════════════
   console.log('%c 7. Trend Detection ', 'font-weight:bold;color:#f59e0b');
 
-  const alerts = window.detectTrendAlerts(allData);
+  const alerts = dataModule.detectTrendAlerts(allData);
   assert('detectTrendAlerts returns array', Array.isArray(alerts));
 
   // Each alert should have required fields
@@ -352,7 +352,7 @@ const S = window._labState;
       }
     }
   };
-  const synAlerts = window.detectTrendAlerts(syntheticData);
+  const synAlerts = dataModule.detectTrendAlerts(syntheticData);
   assert('synthetic sudden_high detected', synAlerts.some(a => a.concern === 'sudden_high'),
     `alerts: ${JSON.stringify(synAlerts.map(a => a.concern))}`);
 
@@ -361,7 +361,7 @@ const S = window._labState;
   // ═══════════════════════════════════════════════
   console.log('%c 8. Key Trend Markers ', 'font-weight:bold;color:#f59e0b');
 
-  const keyTrends = window.getKeyTrendMarkers(allData);
+  const keyTrends = dataModule.getKeyTrendMarkers(allData);
   assert('getKeyTrendMarkers returns array', Array.isArray(keyTrends));
   assert('getKeyTrendMarkers has entries with demo data', keyTrends.length > 0, `got ${keyTrends.length}`);
   assert('getKeyTrendMarkers max 8 entries', keyTrends.length <= 8, `got ${keyTrends.length}`);
@@ -473,7 +473,7 @@ const S = window._labState;
   S.importedData.customMarkers = {
     'testCat.testMarker': { name: 'Test Custom', unit: 'mg/L', refMin: 1, refMax: 10, categoryLabel: 'Test Category' }
   };
-  const customData = window.getActiveData();
+  const customData = dataModule.getActiveData();
   assert('custom marker category created in data', 'testCat' in customData.categories,
     'expected "testCat" in categories');
   if (customData.categories.testCat) {
@@ -502,7 +502,7 @@ const S = window._labState;
 
   // Switch to female and verify
   S.profileSex = 'female';
-  const femData = window.getActiveData();
+  const femData = dataModule.getActiveData();
   const creatFem = femData.categories.biochemistry.markers.creatinine;
   assert('female creatinine refMin = 44', creatFem.refMin === 44, `got ${creatFem.refMin}`);
   assert('female creatinine refMax = 80', creatFem.refMax === 80, `got ${creatFem.refMax}`);
@@ -510,20 +510,24 @@ const S = window._labState;
   S.profileSex = 'male';
 
   // ═══════════════════════════════════════════════
-  // 12. Window exports exist (regression)
+  // 12. Data APIs stay module-only
   // ═══════════════════════════════════════════════
-  console.log('%c 12. Window Exports ', 'font-weight:bold;color:#f59e0b');
+  console.log('%c 12. Module-only APIs ', 'font-weight:bold;color:#f59e0b');
 
   const dataExports = [
-    'saveImportedData', 'getFocusCardFingerprint', 'getActiveData',
+    'saveImportedData', 'getFocusCardFingerprint', 'getActiveData', 'invalidateActiveDataCache',
     'applyUnitConversion', 'filterDatesByRange', 'recalculateHOMAIR',
-    'detectTrendAlerts', 'getKeyTrendMarkers', 'switchUnitSystem',
+    'renderDateRangeFilter', 'setDateRange', 'renderChartLayersDropdown',
+    'toggleChartLayersDropdown', 'setSuppOverlay', 'setNoteOverlay', 'setPhaseOverlay',
+    'destroyAllCharts', 'detectTrendAlerts', 'getKeyTrendMarkers', 'switchUnitSystem', 'toggleAltUnits',
     'getEffectiveRange', 'getEffectiveRangeForDate', 'getPhaseRefEnvelope',
     'switchRangeMode', 'countFlagged', 'getLatestValueIndex',
-    'getAllFlaggedMarkers', 'statusIcon',
+    'getAllFlaggedMarkers', 'statusIcon', 'updateHeaderDates', 'updateHeaderRangeToggle',
+    'registerRefreshCallback',
   ];
   for (const name of dataExports) {
-    assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
+    assert(`data.${name} exists`, typeof dataModule[name] === 'function', `typeof: ${typeof dataModule[name]}`);
+    assert(`window.${name} stays absent`, !(name in window), `typeof: ${typeof window[name]}`);
   }
 
   // ═══════════════════════════════════════════════
@@ -532,20 +536,20 @@ const S = window._labState;
   console.log('%c 13. Helper Functions ', 'font-weight:bold;color:#f59e0b');
 
   // getLatestValueIndex
-  assert('getLatestValueIndex finds last non-null', window.getLatestValueIndex([null, 5, 3, null]) === 2);
-  assert('getLatestValueIndex returns -1 for all-null', window.getLatestValueIndex([null, null]) === -1);
-  assert('getLatestValueIndex handles single value', window.getLatestValueIndex([7]) === 0);
-  assert('getLatestValueIndex handles empty array', window.getLatestValueIndex([]) === -1);
+  assert('getLatestValueIndex finds last non-null', dataModule.getLatestValueIndex([null, 5, 3, null]) === 2);
+  assert('getLatestValueIndex returns -1 for all-null', dataModule.getLatestValueIndex([null, null]) === -1);
+  assert('getLatestValueIndex handles single value', dataModule.getLatestValueIndex([7]) === 0);
+  assert('getLatestValueIndex handles empty array', dataModule.getLatestValueIndex([]) === -1);
 
   // statusIcon
-  assert('statusIcon normal is checkmark', window.statusIcon('normal') === '\u2713');
-  assert('statusIcon high is up triangle', window.statusIcon('high') === '\u25B2');
-  assert('statusIcon low is down triangle', window.statusIcon('low') === '\u25BC');
-  assert('statusIcon missing is empty', window.statusIcon('missing') === '');
+  assert('statusIcon normal is checkmark', dataModule.statusIcon('normal') === '\u2713');
+  assert('statusIcon high is up triangle', dataModule.statusIcon('high') === '\u25B2');
+  assert('statusIcon low is down triangle', dataModule.statusIcon('low') === '\u25BC');
+  assert('statusIcon missing is empty', dataModule.statusIcon('missing') === '');
 
   // getPhaseRefEnvelope — returns null when no phase ranges
   const noPhaseMarker = { values: [5], refMin: 4, refMax: 6 };
-  assert('getPhaseRefEnvelope null for no phases', window.getPhaseRefEnvelope(noPhaseMarker) === null);
+  assert('getPhaseRefEnvelope null for no phases', dataModule.getPhaseRefEnvelope(noPhaseMarker) === null);
 
   // countFlagged
   const mockMarkers = [
@@ -554,8 +558,8 @@ const S = window._labState;
     { values: [2], refMin: 4, refMax: 8 },    // low
   ];
   // countFlagged uses getEffectiveRangeForDate, which needs refMin/refMax on marker
-  assert('countFlagged counts out-of-range markers', window.countFlagged(mockMarkers) === 2,
-    `got ${window.countFlagged(mockMarkers)}`);
+  assert('countFlagged counts out-of-range markers', dataModule.countFlagged(mockMarkers) === 2,
+    `got ${dataModule.countFlagged(mockMarkers)}`);
 
   // ═══════════════════════════════════════════════
   // 14. Data source inspection

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -10,6 +10,7 @@ return (async function() {
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const S = window._labState;
   const backupModule = await import('/js/backup.js');
+  const dataModule = await import('/js/data.js');
   const exportModule = await import('/js/export.js');
   const contextCards = await import('/js/context-cards.js');
   const profile = await import('/js/profile.js');
@@ -33,12 +34,12 @@ return (async function() {
     S.importedData = demo;
     S.profileSex = 'male';
     S.profileDob = '1987-11-22';
-    window.saveImportedData();
+    dataModule.saveImportedData();
     window.buildSidebar();
     window.navigate('dashboard');
     await wait(50);
   }
-  const data = window.getActiveData();
+  const data = dataModule.getActiveData();
   assert('Setup: demo data loaded', data.dates.length > 0, `${data.dates.length} dates`);
 
   // ═══════════════════════════════════════
@@ -323,7 +324,7 @@ return (async function() {
   if (!S.importedData.supplements) S.importedData.supplements = [];
   const origSuppCount = S.importedData.supplements.length;
   S.importedData.supplements.push({ name: '__EXPORT_TEST_SUPP__', dosage: '100mg', startDate: '2026-01-01', periods: [{ start: '2026-01-01', end: null }] });
-  window.saveImportedData();
+  dataModule.saveImportedData();
   await wait(20);
 
   // Rebuild bundle after adding supplement
@@ -340,7 +341,7 @@ return (async function() {
 
   // Clean up test supplement
   S.importedData.supplements = S.importedData.supplements.filter(s => s.name !== '__EXPORT_TEST_SUPP__');
-  window.saveImportedData();
+  dataModule.saveImportedData();
   await wait(20);
 
   // ═══════════════════════════════════════
@@ -358,7 +359,7 @@ return (async function() {
   S.importedData.diet = { type: 'paleo', restrictions: ['dairy'], note: 'test diet' };
   S.importedData.exercise = { frequency: 'daily', types: ['running'], intensity: 'moderate', note: '' };
   S.importedData.interpretiveLens = '__TEST_LENS__';
-  window.saveImportedData();
+  dataModule.saveImportedData();
   await wait(20);
 
   const raw3 = await exportModule.buildAllDataBundle();
@@ -379,7 +380,7 @@ return (async function() {
   S.importedData.diet = origDiet;
   S.importedData.exercise = origExercise;
   S.importedData.interpretiveLens = origLens;
-  window.saveImportedData();
+  dataModule.saveImportedData();
   await wait(20);
 
   // ═══════════════════════════════════════
@@ -400,7 +401,7 @@ return (async function() {
   S.importedData.refOverrides['biochemistry.glucose'] = {
     ref: { low: 3.5, high: 6.0 }, optimal: { low: 4.0, high: 5.5 }
   };
-  window.saveImportedData();
+  dataModule.saveImportedData();
   await wait(20);
 
   const raw4 = await exportModule.buildAllDataBundle();
@@ -418,7 +419,7 @@ return (async function() {
   // Restore originals
   S.importedData.customMarkers = origCustom;
   S.importedData.refOverrides = origOverrides;
-  window.saveImportedData();
+  dataModule.saveImportedData();
   await wait(20);
 
   // ═══════════════════════════════════════
@@ -1138,7 +1139,7 @@ return (async function() {
         `got ${JSON.stringify(bioReview || {}).slice(0, 160)}`);
       try {
         const { hasCurrentBiologyScoreContextReview } = await import('../js/biology-score-context-ai.js');
-        const scoreData = window.filterDatesByRange?.(window.getActiveData?.() || {}, { fallbackToAll: false }) || window.getActiveData?.() || {};
+        const scoreData = dataModule.filterDatesByRange?.(dataModule.getActiveData?.() || {}, { fallbackToAll: false }) || dataModule.getActiveData?.() || {};
         assert('Biology Scores demo context review matches live fingerprints',
           hasCurrentBiologyScoreContextReview(scoreData),
           'demo Biology Scores would still show the unlock gate');

--- a/tests/test-multi-unit.js
+++ b/tests/test-multi-unit.js
@@ -267,8 +267,8 @@ console.log('\n-- source-shape pins (UI wiring) --');
     /localStorage\.setItem\(profileStorageKey\(state\.currentProfile, 'showAltUnits'\)/.test(data));
   assert('data.js toggleAltUnits refreshes open detail modal via state._activeDetailMarkerId',
     /state\._activeDetailMarkerId[\s\S]{0,200}window\.showDetailModal/.test(data));
-  assert('data.js exports toggleAltUnits on window',
-    /Object\.assign\(window, \{[^}]*toggleAltUnits/.test(data));
+  assert('data.js keeps toggleAltUnits module-only',
+    /export function toggleAltUnits\(force\)/.test(data) && !data.includes('Object.assign(window'));
 
   // state.js: showAltUnits default off
   assert('state.js declares showAltUnits: false',

--- a/tests/test-pdf-import-review-runtime.js
+++ b/tests/test-pdf-import-review-runtime.js
@@ -38,6 +38,7 @@ const RUNTIME_FIELDS = [
 ];
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalReviewRuntimeDeps = configurePdfImportReviewRuntimeDeps();
 const originalFieldDescriptors = new Map(
   RUNTIME_FIELDS.map(field => [field, Object.getOwnPropertyDescriptor(globalThis, field)])
 );
@@ -73,8 +74,11 @@ try {
 
   const viewCalls = [];
   globalThis.buildSidebar = function() { viewCalls.push(['sidebar', this === globalThis]); };
-  globalThis.updateHeaderDates = function() { viewCalls.push(['dates', this === globalThis]); };
+  globalThis.updateHeaderDates = function() { viewCalls.push(['legacy-dates']); };
   globalThis.navigate = function(route) { viewCalls.push(['navigate', route, this === globalThis]); };
+  configurePdfImportReviewRuntimeDeps({
+    updateHeaderDates: () => viewCalls.push(['dates', true]),
+  });
   assert('import persistence view refresh delegates through runtime hooks',
     refreshImportedDataViewsRuntime('labs') === true &&
       JSON.stringify(viewCalls) === JSON.stringify([
@@ -107,12 +111,11 @@ try {
   assert('delegate binding flag stored in runtime', globalThis.__importReviewDelegatesBound === true);
 
   let confirmCalls = 0;
-  const previousReviewRuntimeDeps = configurePdfImportReviewRuntimeDeps({
+  configurePdfImportReviewRuntimeDeps({
     confirmImport: () => { confirmCalls++; },
   });
   confirmImportFromRuntime();
   assert('confirm callback uses configured module dependency', confirmCalls === 1);
-  configurePdfImportReviewRuntimeDeps(previousReviewRuntimeDeps);
 
   let diffArgs = null;
   let diffThis = null;
@@ -140,6 +143,7 @@ try {
   showPIIDiffViewerFromRuntime('raw', 'safe');
   assert('no-window writes are no-ops', noWindowResolveCalled === false);
 } finally {
+  configurePdfImportReviewRuntimeDeps(originalReviewRuntimeDeps);
   for (const field of RUNTIME_FIELDS) {
     restoreDescriptor(globalThis, field, originalFieldDescriptors.get(field));
   }

--- a/tests/test-phase-ranges.js
+++ b/tests/test-phase-ranges.js
@@ -21,14 +21,13 @@ function assert(name, condition, detail) {
 
 console.log('=== Phase-Aware Reference Ranges Test ===\n');
 
-// Section 1 reads schema source; later sections need window.* handlers
-// exposed by data.js (Object.assign(window, …) at module load).
+// Section 1 reads schema source; later sections use the data module API.
 const schemaSource = read('js/schema.js');
 const schemaEnvironmentSource = read('js/schema-environment.js');
 const schema = await import('../js/schema.js');
 const dataSource = read('js/data.js');
 const markerAnalysisSource = read('js/marker-analysis.js');
-await import('../js/data.js'); // populates window.getEffectiveRangeForDate etc
+const dataModule = await import('../js/data.js');
 const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css');
   assert('PHASE_RANGES re-exported from schema.js', schemaSource.includes('PHASE_RANGES') && schemaSource.includes('./schema-environment.js'));
   assert('PHASE_RANGES defined in schema-environment.js', schemaEnvironmentSource.includes('export const PHASE_RANGES'));
@@ -81,14 +80,16 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
   assert('marker-analysis exports getEffectiveRangeForDate', markerAnalysisSource.includes('export function getEffectiveRangeForDate'));
   assert('marker-analysis exports getPhaseRefEnvelope', markerAnalysisSource.includes('export function getPhaseRefEnvelope'));
   assert('data.js re-exports marker-analysis helpers', dataSource.includes("} from './marker-analysis.js'"));
-  assert('data.js window exports getEffectiveRangeForDate', dataSource.includes('getEffectiveRangeForDate') && dataSource.includes('Object.assign(window'));
-  assert('data.js window exports getPhaseRefEnvelope', dataSource.includes('getPhaseRefEnvelope'));
+  assert('data.js exports getEffectiveRangeForDate', dataSource.includes('getEffectiveRangeForDate'));
+  assert('data.js exports getPhaseRefEnvelope', dataSource.includes('getPhaseRefEnvelope'));
+  assert('data.js does not install a window facade', !dataSource.includes('Object.assign(window'));
 
   // ═══════════════════════════════════════
   // 4. getEffectiveRangeForDate function
   // ═══════════════════════════════════════
   console.log('Section 4: getEffectiveRangeForDate');
-  assert('getEffectiveRangeForDate on window', typeof window.getEffectiveRangeForDate === 'function');
+  assert('getEffectiveRangeForDate is a module API', typeof dataModule.getEffectiveRangeForDate === 'function');
+  assert('getEffectiveRangeForDate stays off window', !('getEffectiveRangeForDate' in window));
 
   // Test with phase ranges present
   const mockMarkerWithPhase = {
@@ -101,35 +102,36 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
       { min: 180, max: 780 }   // luteal
     ]
   };
-  const r0 = window.getEffectiveRangeForDate(mockMarkerWithPhase, 0);
+  const r0 = dataModule.getEffectiveRangeForDate(mockMarkerWithPhase, 0);
   assert('Phase range returned for index 0', r0.min === 45 && r0.max === 400, `got ${r0.min}-${r0.max}`);
-  const r1 = window.getEffectiveRangeForDate(mockMarkerWithPhase, 1);
+  const r1 = dataModule.getEffectiveRangeForDate(mockMarkerWithPhase, 1);
   assert('Phase range returned for index 1', r1.min === 400 && r1.max === 1470, `got ${r1.min}-${r1.max}`);
-  const r2 = window.getEffectiveRangeForDate(mockMarkerWithPhase, 2);
+  const r2 = dataModule.getEffectiveRangeForDate(mockMarkerWithPhase, 2);
   assert('Fallback for null phase range', r2.min === 45.4 && r2.max === 854.0, `got ${r2.min}-${r2.max}`);
-  const r3 = window.getEffectiveRangeForDate(mockMarkerWithPhase, 3);
+  const r3 = dataModule.getEffectiveRangeForDate(mockMarkerWithPhase, 3);
   assert('Phase range returned for index 3', r3.min === 180 && r3.max === 780, `got ${r3.min}-${r3.max}`);
 
   // Test without phase ranges (fallback)
   const mockMarkerNoPhase = { refMin: 10, refMax: 50, optimalMin: null, optimalMax: null };
-  const rf = window.getEffectiveRangeForDate(mockMarkerNoPhase, 0);
+  const rf = dataModule.getEffectiveRangeForDate(mockMarkerNoPhase, 0);
   assert('Fallback when no phaseRefRanges', rf.min === 10 && rf.max === 50, `got ${rf.min}-${rf.max}`);
 
   // ═══════════════════════════════════════
   // 5. getPhaseRefEnvelope function
   // ═══════════════════════════════════════
   console.log('Section 5: getPhaseRefEnvelope');
-  assert('getPhaseRefEnvelope on window', typeof window.getPhaseRefEnvelope === 'function');
+  assert('getPhaseRefEnvelope is a module API', typeof dataModule.getPhaseRefEnvelope === 'function');
+  assert('getPhaseRefEnvelope stays off window', !('getPhaseRefEnvelope' in window));
 
-  const env = window.getPhaseRefEnvelope(mockMarkerWithPhase);
+  const env = dataModule.getPhaseRefEnvelope(mockMarkerWithPhase);
   assert('Envelope min is smallest across phases', env.min === 45, `got ${env.min}`);
   assert('Envelope max is largest across phases', env.max === 1470, `got ${env.max}`);
 
-  const envNull = window.getPhaseRefEnvelope(mockMarkerNoPhase);
+  const envNull = dataModule.getPhaseRefEnvelope(mockMarkerNoPhase);
   assert('Envelope null when no phaseRefRanges', envNull === null);
 
   const allNulls = { phaseRefRanges: [null, null, null] };
-  const envAllNull = window.getPhaseRefEnvelope(allNulls);
+  const envAllNull = dataModule.getPhaseRefEnvelope(allNulls);
   assert('Envelope null when all entries null', envAllNull === null);
 
   // ═══════════════════════════════════════
@@ -166,7 +168,7 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
       contextNotes: '', supplements: []
     };
 
-    const data = window.getActiveData();
+    const data = dataModule.getActiveData();
     const estradiol = data.categories.hormones?.markers?.estradiol;
     const progesterone = data.categories.hormones?.markers?.progesterone;
 
@@ -198,7 +200,7 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
     // ═══════════════════════════════════════
     console.log('Section 7: Male profile (no phase ranges)');
     window.state.profileSex = 'male';
-    const maleData = window.getActiveData();
+    const maleData = dataModule.getActiveData();
     const maleEstradiol = maleData.categories.hormones?.markers?.estradiol;
     assert('Male estradiol has no phaseRefRanges', !maleEstradiol?.phaseRefRanges);
     assert('Male estradiol has no phaseLabels', !maleEstradiol?.phaseLabels);
@@ -209,7 +211,7 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
     console.log('Section 8: Female without cycle data');
     window.state.profileSex = 'female';
     window.state.importedData.menstrualCycle = null;
-    const noCycleData = window.getActiveData();
+    const noCycleData = dataModule.getActiveData();
     const noCycleEstradiol = noCycleData.categories.hormones?.markers?.estradiol;
     assert('No cycle → no phaseRefRanges', !noCycleEstradiol?.phaseRefRanges);
 
@@ -218,7 +220,7 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
     // ═══════════════════════════════════════
     console.log('Section 9: Female with cycle profile but no periods');
     window.state.importedData.menstrualCycle = { cycleLength: 28, periodLength: 5, regularity: 'regular', flow: 'moderate', periods: [] };
-    const noPeriodsData = window.getActiveData();
+    const noPeriodsData = dataModule.getActiveData();
     const noPeriodsEstradiol = noPeriodsData.categories.hormones?.markers?.estradiol;
     assert('No periods → no phaseRefRanges', !noPeriodsEstradiol?.phaseRefRanges);
 
@@ -231,7 +233,7 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
       periods: [{ startDate: '2025-12-01', endDate: '2025-12-05', flow: 'moderate', notes: '' }]
     };
     // 2025-12-05 is in menstrual range, 2026-01-15 is >35 days from last period (28+7=35) → null
-    const partialData = window.getActiveData();
+    const partialData = dataModule.getActiveData();
     const partialE = partialData.categories.hormones?.markers?.estradiol;
     assert('First date has phase range', partialE?.phaseRefRanges?.[0] !== null);
     assert('Second date has null phase range (too far)', partialE?.phaseRefRanges?.[1] === null,
@@ -250,7 +252,7 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
       ]
     };
     window.state.unitSystem = 'US';
-    const usData = window.getActiveData();
+    const usData = dataModule.getActiveData();
     const usEstradiol = usData.categories.hormones?.markers?.estradiol;
     // Estradiol conversion: pmol/l → pg/ml, factor = 0.2724 (from UNIT_CONVERSIONS)
     if (usEstradiol?.phaseRefRanges?.[0]) {
@@ -277,10 +279,10 @@ const cssSource = read('styles.css') + '\n' + read('css/marker-detail-modal.css'
         { startDate: '2025-12-29', endDate: '2026-01-02', flow: 'moderate', notes: '' },
       ]
     };
-    const fullData = window.getActiveData();
+    const fullData = dataModule.getActiveData();
     // Manually test filterDatesByRange
     window.state.dateRangeFilter = 'all';
-    const filteredAll = window.filterDatesByRange(fullData);
+    const filteredAll = dataModule.filterDatesByRange(fullData);
     const fEst = filteredAll.categories.hormones?.markers?.estradiol;
     assert('filterDatesByRange all — phaseRefRanges preserved', !!fEst?.phaseRefRanges);
     assert('filterDatesByRange all — phaseLabels preserved', !!fEst?.phaseLabels);

--- a/tests/test-schema.js
+++ b/tests/test-schema.js
@@ -8,6 +8,7 @@ import './_node-shim.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as dataModule from '../js/data.js';
 import { migrateProfileData } from '../js/profile.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -199,7 +200,7 @@ const pdfImportNormalizationSrc = read('js/pdf-import-marker-normalization.js');
   // ═══════════════════════════════════════
   console.log('%c 7. Data Pipeline Integration ', 'font-weight:bold;color:#f59e0b');
 
-  if (typeof window.getActiveData === 'function') {
+  if (typeof dataModule.getActiveData === 'function') {
     // Temporarily inject test custom markers to verify icon propagation
     const origCustom = window.importedData?.customMarkers;
     const origEntries = window.importedData?.entries;
@@ -208,7 +209,7 @@ const pdfImportNormalizationSrc = read('js/pdf-import-marker-normalization.js');
         'testCat.testMarker': { name: 'Test', unit: 'mg/l', refMin: 1, refMax: 10, categoryLabel: 'Test Category', icon: '\uD83E\uDDA0' }
       };
       window.importedData.entries = [];
-      const data = window.getActiveData();
+      const data = dataModule.getActiveData();
       assert('Custom category created with def.icon', data.categories.testCat && data.categories.testCat.icon === '\uD83E\uDDA0');
       assert('Custom category has correct label', data.categories.testCat && data.categories.testCat.label === 'Test Category');
 
@@ -216,7 +217,7 @@ const pdfImportNormalizationSrc = read('js/pdf-import-marker-normalization.js');
       window.importedData.customMarkers = {
         'noIconCat.marker1': { name: 'No Icon', unit: 'mg/l', refMin: 1, refMax: 10, categoryLabel: 'No Icon Cat' }
       };
-      const data2 = window.getActiveData();
+      const data2 = dataModule.getActiveData();
       assert('Custom category without icon gets bookmark default', data2.categories.noIconCat && data2.categories.noIconCat.icon === '\uD83D\uDD16');
 
       // Restore

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -13,6 +13,7 @@ return (async function() {
   const wait = ms => new Promise(r => setTimeout(r, ms));
   const main = document.getElementById('main-content');
   const S = window._labState;
+  const dataModule = await import('/js/data.js');
   const { buildSunContext } = await import('/js/sun-context.js');
   const { buildLabContext } = await import('/js/lab-context.js');
   const profile = await import('/js/profile.js');
@@ -36,7 +37,7 @@ return (async function() {
     lightMeasurements: [],
     wearableSummary: { metrics: { steps: { latest: 4200, baseline: 3600 } }, sources: {} },
   });
-  await window.saveImportedData?.();
+  await dataModule.saveImportedData?.();
 
   // Dismiss any leftover dialogs from prior tests
   document.querySelectorAll('.modal-overlay.show').forEach(el => el.classList.remove('show'));
@@ -473,7 +474,7 @@ return (async function() {
   // ─── 9. Cleanup: restore original state ──────────────────────────────
   document.querySelectorAll('.modal-overlay').forEach(el => el.remove());
   S.importedData = orig;
-  await window.saveImportedData?.();
+  await dataModule.saveImportedData?.();
 
   console.log(`Light & Sun UI: ${pass} passed, ${fail} failed`);
 

--- a/tests/test-trend-alerts.js
+++ b/tests/test-trend-alerts.js
@@ -617,8 +617,8 @@ const { detectTrendAlerts, getKeyTrendMarkers, getEffectiveRange } = await impor
   assert('KEY_TRENDS_MAX = 8 in getKeyTrendMarkers',
     markerAnalysisSrc.includes('KEY_TRENDS_MAX = 8') &&
     markerAnalysisSrc.includes('MAX = KEY_TRENDS_MAX'));
-  assert('detectTrendAlerts on window', dataSrc.includes('detectTrendAlerts'));
-  assert('getKeyTrendMarkers on window', dataSrc.includes('getKeyTrendMarkers'));
+  assert('detectTrendAlerts re-exported by data.js', dataSrc.includes('detectTrendAlerts'));
+  assert('getKeyTrendMarkers re-exported by data.js', dataSrc.includes('getKeyTrendMarkers'));
 
   const utilsSrc = read('js/utils.js');
   assert('linearRegression exported', utilsSrc.includes('export function linearRegression'));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -25,6 +25,7 @@ return (async function() {
   }
   const main = document.getElementById('main-content');
   const S = window._labState;
+  const dataModule = await import('/js/data.js');
   const supplements = await import('/js/supplements.js');
   const pdfImport = await import('/js/pdf-import.js');
   const profile = await import('/js/profile.js');
@@ -53,12 +54,12 @@ return (async function() {
     S.importedData = demo;
     S.profileSex = 'male';
     S.profileDob = '1987-11-22';
-    window.saveImportedData();
+    dataModule.saveImportedData();
     window.buildSidebar();
     window.navigate('dashboard');
     await wait(50);
   }
-  const data = window.getActiveData();
+  const data = dataModule.getActiveData();
   assert('Setup: demo data loaded', data.dates.length > 0, `${data.dates.length} dates`);
 
   // ═══════════════════════════════════════════════
@@ -96,7 +97,7 @@ return (async function() {
       S.importedData._deleted?.entries?.includes('2099-12-31'));
   } finally {
     S.importedData = originalImportedData;
-    window.saveImportedData();
+    dataModule.saveImportedData();
     window.buildSidebar();
     window.navigate('dashboard');
     await wait(50);
@@ -560,7 +561,7 @@ return (async function() {
   const originalProfileDob = S.profileDob;
   try {
     S.profileDob = originalProfileDob || '1987-11-22';
-    window.invalidateActiveDataCache?.();
+    dataModule.invalidateActiveDataCache?.();
     window.showDetailModal('calculatedRatios_biologicalAge');
     await waitFor(() => document.querySelector('#detail-modal .bio-age-breakdown'));
     const bioModal = document.getElementById('detail-modal');
@@ -573,7 +574,7 @@ return (async function() {
       !/Not calculated\s+—\s+.*PhenoAge/.test(bioText));
 
     S.profileDob = '';
-    window.invalidateActiveDataCache?.();
+    dataModule.invalidateActiveDataCache?.();
     window.showDetailModal('calculatedRatios_biologicalAge');
     await waitFor(() => /Date of birth/.test(document.getElementById('detail-modal')?.textContent || ''));
     const missingDobModal = document.getElementById('detail-modal');
@@ -587,7 +588,7 @@ return (async function() {
         .some(el => /Date of birth/.test(el.textContent || '')));
 
     S.profileDob = '2999-01-01';
-    window.invalidateActiveDataCache?.();
+    dataModule.invalidateActiveDataCache?.();
     window.showDetailModal('calculatedRatios_biologicalAge');
     await waitFor(() => /Valid date of birth/.test(document.getElementById('detail-modal')?.textContent || ''));
     bioText = document.getElementById('detail-modal')?.textContent || '';
@@ -595,7 +596,7 @@ return (async function() {
       /Valid date of birth/.test(bioText) && !/missing 0 of/.test(bioText));
   } finally {
     S.profileDob = originalProfileDob;
-    window.invalidateActiveDataCache?.();
+    dataModule.invalidateActiveDataCache?.();
     window.closeModal();
     await wait(20);
   }
@@ -827,18 +828,18 @@ return (async function() {
 
   // Note overlay toggle
   const noteModeBefore = S.noteOverlayMode || 'off';
-  window.setNoteOverlay(noteModeBefore === 'on' ? 'off' : 'on');
+  dataModule.setNoteOverlay(noteModeBefore === 'on' ? 'off' : 'on');
   await wait(50);
   assert('Note overlay toggled', S.noteOverlayMode !== noteModeBefore);
-  window.setNoteOverlay(noteModeBefore); // restore
+  dataModule.setNoteOverlay(noteModeBefore); // restore
   await wait(50);
 
   // Supplement overlay toggle
   const suppModeBefore = S.suppOverlayMode || 'off';
-  window.setSuppOverlay(suppModeBefore === 'on' ? 'off' : 'on');
+  dataModule.setSuppOverlay(suppModeBefore === 'on' ? 'off' : 'on');
   await wait(50);
   assert('Supplement overlay toggled', S.suppOverlayMode !== suppModeBefore);
-  window.setSuppOverlay(suppModeBefore); // restore
+  dataModule.setSuppOverlay(suppModeBefore); // restore
   await wait(50);
 
   // ═══════════════════════════════════════════════

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -188,7 +188,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -196,6 +196,7 @@
     import('../js/context-cards.js'),
     import('../js/crypto.js'),
     import('../js/cycle.js'),
+    import('../js/data.js'),
     import('../js/emf.js'),
     import('../js/emf-runtime.js'),
     import('../js/export.js'),
@@ -411,18 +412,18 @@
   const emfLegacyGlobals = emfExports.filter(name => name !== 'configureEMFAIDeps');
   const emfRuntimeExports = ['loadEMFModule','openEMFAssessmentEditor','closeEMFInterpretation'];
 
-  // data.js (26)
+  // data.js (30 former browser globals plus one test hook, now module-only)
   const dataExports = [
     'saveImportedData','getFocusCardFingerprint',
-    'getActiveData','applyUnitConversion',
+    'getActiveData','invalidateActiveDataCache','applyUnitConversion',
     'filterDatesByRange','recalculateHOMAIR',
     'renderDateRangeFilter','setDateRange',
     'renderChartLayersDropdown','toggleChartLayersDropdown','setSuppOverlay','setNoteOverlay',
-    'destroyAllCharts',
+    'setPhaseOverlay','destroyAllCharts',
     'countFlagged','getLatestValueIndex','getAllFlaggedMarkers',
     'statusIcon',
     'detectTrendAlerts','getKeyTrendMarkers',
-    'switchUnitSystem','getEffectiveRange','switchRangeMode',
+    'switchUnitSystem','toggleAltUnits','getEffectiveRange','getEffectiveRangeForDate','getPhaseRefEnvelope','switchRangeMode',
     'updateHeaderDates','updateHeaderRangeToggle',
     'registerRefreshCallback','_runRegisteredRefreshCallback'
   ];
@@ -625,6 +626,7 @@
     ['context-cards.js', contextCardsModule, contextCardsExports],
     ['crypto.js', cryptoModule, cryptoExports],
     ['cycle.js', cycleModule, cycleExports],
+    ['data.js', dataModule, dataExports],
     ['emf.js', emfModule, emfExports],
     ['emf-runtime.js', emfRuntimeModule, emfRuntimeExports],
     ['export.js', exportModule, exportExports],
@@ -699,11 +701,13 @@
   for (const name of contextCardsExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of dataExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
 
   const allModules = {
     'chat.js': chatExports,
     'client-list.js': clientListExports,
-    'data.js': dataExports,
     'nav.js': navExports,
     'notes.js': notesExports,
     'settings.js': settingsExports,
@@ -782,7 +786,7 @@
   // ═══════════════════════════════════════════════
   // 6. DATA PIPELINE — getActiveData works
   // ═══════════════════════════════════════════════
-  const data = window.getActiveData();
+  const data = dataModule.getActiveData();
   assert('getActiveData returns object', typeof data === 'object' && data !== null);
   assert('getActiveData has categories', data.categories && typeof data.categories === 'object');
   assert('getActiveData has dates array', Array.isArray(data.dates));
@@ -944,7 +948,7 @@
   // ═══════════════════════════════════════════════
   // 16. UNIT/RANGE SYSTEM — works
   // ═══════════════════════════════════════════════
-  const effectiveRange = window.getEffectiveRange({ refMin: 3.5, refMax: 5.0, optMin: 3.8, optMax: 4.5 });
+  const effectiveRange = dataModule.getEffectiveRange({ refMin: 3.5, refMax: 5.0, optMin: 3.8, optMax: 4.5 });
   assert('getEffectiveRange returns object', effectiveRange && typeof effectiveRange.min === 'number');
 
   // ═══════════════════════════════════════════════

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.204';
+self.APP_VERSION = '1.10.205';


### PR DESCRIPTION
## Summary

- remove the 30-function `data.js` compatibility facade from `window`
- migrate Biology Scores, PDF import review, demo loading, and test consumers to direct or injected ESM APIs
- assert the data surface stays module-only, reduce the quality baseline to 4 total / 2 legacy window assignments, and bump the cache version to `1.10.205`

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality` (7/7 checks; 4 total / 2 legacy assignments)
- `npm test` (398 passed)
- `./run-tests.sh` (123 static, 398 Vitest, 352 Playwright, and 472 responsive assertions passed)
