### PR TITLE
Make dashboard widget APIs module-only

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -16,7 +16,12 @@ import { closeModal } from './marker-detail-modal.js';
 import { closeMobileSidebar } from './nav.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
-import { navigate } from './views.js';
+import {
+  clearDashboardWidgets,
+  navigate,
+  resetDashboardWidgets,
+  toggleDashboardOrganizeMode,
+} from './views.js';
 import { openProfileShareModal } from './profile-share.js';
 import { getActiveProfileId } from './profile.js';
 
@@ -29,11 +34,14 @@ configureClientListRuntime({
 });
 
 configureSettingsRuntime({
+  clearDashboardWidgets,
   clearAllData,
   exportAllDataJSON,
   exportClientJSON,
   getActiveProfileId,
   openProfileShareModal,
+  resetDashboardWidgets,
+  toggleDashboardOrganizeMode,
 });
 
 configureAppEventListeners({

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -206,8 +206,11 @@ export function createDashboardViewComposition({
   });
 
   configureLensPageShell({
+    addDashboardWidgetFromLens: (...args) => dashboardWidgetControls.addDashboardWidgetFromLens(...args),
     getAvailableDashboardFixedWidgetIds,
     getDashboardWidgetPrefs,
+    openDashboardBiometricPicker: () => dashboardWidgetControls.openDashboardBiometricPicker(),
+    removeDashboardWidgetFromLens: (...args) => dashboardWidgetControls.removeDashboardWidgetFromLens(...args),
   });
 
   configureMobileDashboardView({

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -10,9 +10,12 @@ import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.
 const LENS_PAGE_ORDER_VERSION = 1;
 
 let _shellDeps = {
+  addDashboardWidgetFromLens: (_id) => {},
   getAvailableDashboardFixedWidgetIds: () => [],
   getDashboardWidgetPrefs: () => ({ hidden: [] }),
   openEMFAssessmentEditor,
+  openDashboardBiometricPicker: () => {},
+  removeDashboardWidgetFromLens: (_id) => {},
 };
 let lensPageShellDelegatesInstalled = false;
 
@@ -57,9 +60,9 @@ function handleLensPageShellClick(event) {
   if (action === 'move-widget') {
     moveLensPageWidget(actionEl.dataset.lensPageRoute || '', id, actionEl.dataset.lensPageDirection || 0);
   } else if (action === 'add-dashboard-widget') {
-    callLensPageRuntime('addDashboardWidgetFromLens', id);
+    _shellDeps.addDashboardWidgetFromLens(id);
   } else if (action === 'remove-dashboard-widget') {
-    callLensPageRuntime('removeDashboardWidgetFromLens', id);
+    _shellDeps.removeDashboardWidgetFromLens(id);
   } else if (action === 'import-dna') {
     triggerContextCardDNAFilePickerRuntime();
   } else if (action === 'import-snp-report') {
@@ -74,7 +77,7 @@ function handleLensPageShellClick(event) {
   } else if (action === 'open-wearables-settings') {
     callLensPageRuntime('openSettingsModal', 'wearables');
   } else if (action === 'open-biometric-picker') {
-    callLensPageRuntime('openDashboardBiometricPicker');
+    _shellDeps.openDashboardBiometricPicker();
   } else if (action === 'open-ai-chat') {
     callLensPageRuntime('openChatPanel');
   } else if (action === 'open-emf-assessment') {

--- a/js/settings.js
+++ b/js/settings.js
@@ -60,6 +60,9 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
  *   exportClientJSON: (profileId?: string | null) => Promise<void> | void,
  *   getActiveProfileId: () => string | null,
  *   openProfileShareModal: (profileId?: string) => void,
+ *   clearDashboardWidgets: () => void,
+ *   resetDashboardWidgets: () => void,
+ *   toggleDashboardOrganizeMode: (force?: boolean) => void,
  * }} SettingsRuntime
  */
 
@@ -70,6 +73,9 @@ const settingsRuntime = {
   exportClientJSON: () => {},
   getActiveProfileId,
   openProfileShareModal: () => {},
+  clearDashboardWidgets: () => {},
+  resetDashboardWidgets: () => {},
+  toggleDashboardOrganizeMode: () => {},
 };
 
 /** @param {Partial<SettingsRuntime>} [runtime] */
@@ -520,15 +526,15 @@ function handleTweaksClick(event) {
     selectTweaksAccent(actionEl.dataset.accentId || '');
   } else if (action === 'reset-dashboard') {
     event.preventDefault();
-    settingsWindow.resetDashboardWidgets?.();
+    settingsRuntime.resetDashboardWidgets();
     closeTweaksPanel();
   } else if (action === 'clear-dashboard') {
     event.preventDefault();
-    settingsWindow.clearDashboardWidgets?.();
+    settingsRuntime.clearDashboardWidgets();
     closeTweaksPanel();
   } else if (action === 'organize-dashboard') {
     event.preventDefault();
-    settingsWindow.toggleDashboardOrganizeMode?.(true);
+    settingsRuntime.toggleDashboardOrganizeMode(true);
     closeTweaksPanel();
   } else if (action === 'send-feedback') {
     event.preventDefault();

--- a/js/views.js
+++ b/js/views.js
@@ -236,7 +236,7 @@ export const closeDashboardWidgetPicker = () => dashboardView.closeDashboardWidg
 export const startDashboardWidgetDrag = (...args) => dashboardView.startDashboardWidgetDrag(...args);
 export const allowDashboardWidgetDrop = (...args) => dashboardView.allowDashboardWidgetDrop(...args);
 export const dropDashboardWidget = (...args) => dashboardView.dropDashboardWidget(...args);
-const toggleDashboardQuickMarkerPin = (...args) => dashboardView.toggleDashboardQuickMarkerPin(...args);
+export const toggleDashboardQuickMarkerPin = (...args) => dashboardView.toggleDashboardQuickMarkerPin(...args);
 
 const lensPageHandlers = createLensPageHandlers({
   setupDropZone,
@@ -274,31 +274,6 @@ export function openRecommendationDetail(...args) { return recommendationActions
 export function discussRecommendation(...args) { return recommendationActions.discussRecommendation(...args); }
 export function saveRecommendation(...args) { return recommendationActions.saveRecommendation(...args); }
 export function dismissRecommendation(...args) { return recommendationActions.dismissRecommendation(...args); }
-
-Object.assign(window, {
-  toggleDashboardOrganizeMode,
-  moveDashboardWidget,
-  moveLensPageWidget,
-  hideDashboardWidget,
-  showDashboardWidget,
-  addDashboardWidgetFromLens,
-  removeDashboardWidgetFromLens,
-  addDashboardMarkerWidget,
-  addDashboardBiometricMetric,
-  addDashboardBiometricWidget,
-  removeDashboardBiometricMetric,
-  filterDashboardMarkerWidgetPicker,
-  filterDashboardBiometricWidgetPicker,
-  resetDashboardWidgets,
-  clearDashboardWidgets,
-  toggleDashboardQuickMarkerPin,
-  openDashboardWidgetPicker,
-  openDashboardBiometricPicker,
-  closeDashboardWidgetPicker,
-  startDashboardWidgetDrag,
-  allowDashboardWidgetDrop,
-  dropDashboardWidget,
-});
 
 configureCompareCorrelationViews({
   renderTableColgroup,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -1,8 +1,8 @@
 {
   "inlineEventAttributes": 0,
   "windowReferences": 0,
-  "windowGlobalAssignments": 4,
-  "legacyWindowGlobalAssignments": 2,
+  "windowGlobalAssignments": 3,
+  "legacyWindowGlobalAssignments": 1,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -2,18 +2,15 @@ import { expect, test } from './coverage-fixture.js';
 
 test('dashboard widget delegated actions cover organize, picker, biometrics, and body actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.navigate === 'function'
-      && typeof window.toggleDashboardOrganizeMode === 'function'
-      && typeof window.openDashboardWidgetPicker === 'function'
-  );
+  await page.waitForFunction(() => typeof window.navigate === 'function');
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime] = await Promise.all([
+    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, viewsModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/dashboard-widgets.js'),
       import('/js/context-cards-runtime.js'),
+      import('/js/views.js'),
     ]);
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const originalView = state.currentView;
@@ -47,8 +44,8 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
         window.buildSidebar?.();
       }
 
-      window.closeDashboardWidgetPicker?.();
-      window.toggleDashboardOrganizeMode?.(false);
+      viewsModule.closeDashboardWidgetPicker?.();
+      viewsModule.toggleDashboardOrganizeMode?.(false);
       window.navigate?.('dashboard');
       await delay(100);
 
@@ -75,7 +72,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       await delay(50);
       const pickerCloseRemovesOverlay = !document.getElementById('dashboard-widget-picker-overlay');
 
-      window.openDashboardWidgetPicker?.();
+      viewsModule.openDashboardWidgetPicker?.();
       await delay(100);
       overlay = document.getElementById('dashboard-widget-picker-overlay');
       const markerSearch = document.getElementById('dashboard-marker-widget-search');
@@ -129,7 +126,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
         },
       };
       localStorage.setItem(biometricSelectionKey, JSON.stringify(['bp_systolic', 'rhr']));
-      window.addDashboardBiometricMetric?.('rhr');
+      viewsModule.addDashboardBiometricMetric?.('rhr');
       window.navigate?.('dashboard');
       await delay(250);
 
@@ -148,7 +145,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       biometricWidget?.querySelector('[data-dashboard-widget-action="open-biometric-picker"]')?.click();
       await delay(100);
       const biometricPickerOpens = !!document.querySelector('.dashboard-biometric-picker');
-      window.closeDashboardWidgetPicker?.();
+      viewsModule.closeDashboardWidgetPicker?.();
       await delay(50);
 
       const bpCard = document.querySelector('.db-biometric-overview-grid [data-dashboard-widget-action="open-biometric-manual-log"][data-dashboard-widget-id="bp_systolic"]');
@@ -236,8 +233,8 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       else if (state.importedData) delete state.importedData.wearableSummary;
       if (hadWearableConnections) state.importedData.wearableConnections = originalWearableConnections;
       else if (state.importedData) delete state.importedData.wearableConnections;
-      window.closeDashboardWidgetPicker?.();
-      window.toggleDashboardOrganizeMode?.(false);
+      viewsModule.closeDashboardWidgetPicker?.();
+      viewsModule.toggleDashboardOrganizeMode?.(false);
       if (originalView) window.navigate?.(originalView);
     }
   });
@@ -251,8 +248,6 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForFunction(() =>
     typeof window.navigate === 'function'
-      && typeof window.resetDashboardWidgets === 'function'
-      && typeof window.addDashboardMarkerWidget === 'function'
       && typeof window.openRecommendationDetail === 'function'
   );
 
@@ -260,6 +255,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const { state } = await import('/js/state.js');
     const { profileStorageKey } = await import('/js/profile.js');
     const { dashboardBiometricSelectionKey, dashboardWidgetStorageKey } = await import('/js/dashboard-widgets.js');
+    const viewsModule = await import('/js/views.js');
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, timeout = 1500) => {
       const started = Date.now();
@@ -432,42 +428,42 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     window.dismissRecommendation?.(firstRecId, false);
     window.saveRecommendation?.(firstRecId, false);
 
-    window.resetDashboardWidgets();
+    viewsModule.resetDashboardWidgets();
     window.navigate('dashboard');
     await waitFor(() => dashboardWidget('focus'));
-    window.moveDashboardWidget('focus', 1);
+    viewsModule.moveDashboardWidget('focus', 1);
     await delay(100);
     const movedOrder = readPrefs().order;
     const moveWidgetReordersPrefs = movedOrder.indexOf('spotlight') >= 0
       && movedOrder.indexOf('focus') > movedOrder.indexOf('spotlight');
     const beforeInvalidMove = JSON.stringify(readPrefs());
-    window.moveDashboardWidget('missing-widget', 1);
+    viewsModule.moveDashboardWidget('missing-widget', 1);
     await delay(50);
     const invalidMoveNoops = JSON.stringify(readPrefs()) === beforeInvalidMove;
 
-    window.hideDashboardWidget('focus');
+    viewsModule.hideDashboardWidget('focus');
     await delay(100);
     const hideWidgetUpdatesPrefs = readPrefs().hidden.includes('focus') && !dashboardWidget('focus');
-    window.showDashboardWidget('focus');
+    viewsModule.showDashboardWidget('focus');
     const showWidgetRestoresDom = await waitFor(() => !!dashboardWidget('focus') && !readPrefs().hidden.includes('focus'));
 
-    window.clearDashboardWidgets();
+    viewsModule.clearDashboardWidgets();
     await delay(100);
     const clearWidgetsShowsEmptyState = !!document.querySelector('.dashboard-widget.is-empty .dashboard-widget-empty')
       && readPrefs().hidden.includes('focus')
       && readPrefs().hidden.includes('notes');
-    window.showDashboardWidget('notes');
+    viewsModule.showDashboardWidget('notes');
     const notesWidgetRenders = await waitFor(() =>
       dashboardWidget('notes')?.textContent?.includes('Started dashboard coverage note')
     );
 
     const beforeBadMarker = JSON.stringify(readPrefs());
-    window.addDashboardMarkerWidget('not_real');
+    viewsModule.addDashboardMarkerWidget('not_real');
     await delay(50);
     const badMarkerNoops = JSON.stringify(readPrefs()) === beforeBadMarker;
-    window.addDashboardMarkerWidget('lipids_apoB');
+    viewsModule.addDashboardMarkerWidget('lipids_apoB');
     const markerWidgetAdded = await waitFor(() => !!dashboardWidget('marker_lipids_apoB'));
-    window.hideDashboardWidget('marker_lipids_apoB');
+    viewsModule.hideDashboardWidget('marker_lipids_apoB');
     await delay(100);
     const markerWidgetRemovedByHide = !readPrefs().order.includes('marker_lipids_apoB')
       && !readPrefs().hidden.includes('marker_lipids_apoB');
@@ -482,10 +478,10 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
         state.currentView = route;
       };
       state.currentView = 'labs';
-      window.addDashboardWidgetFromLens('alerts');
+      viewsModule.addDashboardWidgetFromLens('alerts');
       addedFromLens = !readPrefs().hidden.includes('alerts')
         && lensNavigateCalls.includes('labs');
-      window.removeDashboardWidgetFromLens('alerts');
+      viewsModule.removeDashboardWidgetFromLens('alerts');
       removedFromLens = readPrefs().hidden.includes('alerts')
         && lensNavigateCalls.filter(route => route === 'labs').length >= 2;
     } finally {
@@ -496,16 +492,16 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     await waitFor(() => dashboardWidget('focus') || document.querySelector('.dashboard-widget'));
 
     localStorage.setItem(biometricKey, JSON.stringify([]));
-    window.addDashboardBiometricMetric('bp_systolic');
+    viewsModule.addDashboardBiometricMetric('bp_systolic');
     await waitFor(() => readJson(biometricKey).includes('bp_systolic'));
-    window.addDashboardBiometricWidget('rhr');
+    viewsModule.addDashboardBiometricWidget('rhr');
     await waitFor(() => readJson(biometricKey).includes('rhr'));
     const biometricSelectionAddsManualAndWearable = readJson(biometricKey).includes('bp_systolic')
       && readJson(biometricKey).includes('rhr');
-    window.removeDashboardBiometricMetric('rhr');
+    viewsModule.removeDashboardBiometricMetric('rhr');
     await delay(50);
     const biometricRemovePersists = !readJson(biometricKey).includes('rhr');
-    window.openDashboardBiometricPicker();
+    viewsModule.openDashboardBiometricPicker();
     await waitFor(() => !!document.querySelector('.dashboard-biometric-picker'));
     const biometricSearch = document.getElementById('dashboard-biometric-widget-search');
     if (biometricSearch) {
@@ -519,10 +515,10 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const connectSourceClosesPicker = calls.some(([kind, panel]) => kind === 'settings' && panel === 'wearables')
       && !document.getElementById('dashboard-widget-picker-overlay');
 
-    window.resetDashboardWidgets();
+    viewsModule.resetDashboardWidgets();
     window.navigate('dashboard');
     await waitFor(() => dashboardWidget('focus') && dashboardWidget('spotlight'));
-    window.toggleDashboardOrganizeMode(true);
+    viewsModule.toggleDashboardOrganizeMode(true);
     await waitFor(() => document.querySelector('.dashboard-widgets.is-organizing'));
     const dragEl = document.querySelector('[data-dashboard-widget-drag-id="focus"]');
     const dataTransfer = {
@@ -532,14 +528,14 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       setDragImage() { calls.push(['drag-image']); },
     };
     let preventCount = 0;
-    window.startDashboardWidgetDrag({ dataTransfer, currentTarget: dragEl }, 'focus', dragEl);
-    window.allowDashboardWidgetDrop({ preventDefault() { preventCount += 1; } });
-    window.dropDashboardWidget({ dataTransfer, preventDefault() { preventCount += 1; } }, 'spotlight');
+    viewsModule.startDashboardWidgetDrag({ dataTransfer, currentTarget: dragEl }, 'focus', dragEl);
+    viewsModule.allowDashboardWidgetDrop({ preventDefault() { preventCount += 1; } });
+    viewsModule.dropDashboardWidget({ dataTransfer, preventDefault() { preventCount += 1; } }, 'spotlight');
     await delay(100);
     const dragPrefs = readPrefs();
     const dragDropReordersPrefs = preventCount >= 2
       && dragPrefs.order.indexOf('focus') > dragPrefs.order.indexOf('spotlight');
-    window.toggleDashboardOrganizeMode(false);
+    viewsModule.toggleDashboardOrganizeMode(false);
 
     return {
       recCardsHydrated,
@@ -567,8 +563,8 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     };
     } finally {
       if (realNavigate && window.navigate !== realNavigate) window.navigate = realNavigate;
-      window.closeDashboardWidgetPicker?.();
-      window.toggleDashboardOrganizeMode?.(false);
+      viewsModule.closeDashboardWidgetPicker?.();
+      viewsModule.toggleDashboardOrganizeMode?.(false);
       document.getElementById('dashboard-widget-picker-overlay')?.remove();
       state.currentProfile = originalState.currentProfile;
       state.profileSex = originalState.profileSex;

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -63,12 +63,9 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       import('/js/context-cards-runtime.js'),
     ]);
     const originalView = state.currentView;
-    const originalAddDashboard = window.addDashboardWidgetFromLens;
-    const originalRemoveDashboard = window.removeDashboardWidgetFromLens;
     const originalReimportDNA = window.reimportDNA;
     const originalConfirmDeleteDNA = window.confirmDeleteDNA;
     const originalOpenSettings = window.openSettingsModal;
-    const originalOpenBiometricPicker = window.openDashboardBiometricPicker;
     const originalOpenChat = window.openChatPanel;
     const originalNavigate = window.navigate;
     const profileId = profile.getActiveProfileId() || state.currentProfile || 'default';
@@ -80,7 +77,10 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       triggerDNAFilePicker: () => calls.push(['trigger-dna']),
     });
     const restoreShell = shell.configureLensPageShell({
+      addDashboardWidgetFromLens: id => calls.push(['add', id]),
       openEMFAssessmentEditor: () => calls.push(['emf']),
+      openDashboardBiometricPicker: () => calls.push(['biometrics']),
+      removeDashboardWidgetFromLens: id => calls.push(['remove', id]),
     });
 
     try {
@@ -103,8 +103,6 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       await delay(120);
       const afterFirst = document.querySelector('.lens-page-widgets[data-lens-route="labs"] .dashboard-widget[data-widget-id]')?.dataset.widgetId || '';
 
-      window.addDashboardWidgetFromLens = id => calls.push(['add', id]);
-      window.removeDashboardWidgetFromLens = id => calls.push(['remove', id]);
       const dashboardToggle = document.querySelector('.lens-page-widgets[data-lens-route="labs"] .lens-widget-dashboard-toggle[data-lens-page-action]');
       const toggleAction = dashboardToggle?.dataset.lensPageAction || '';
       const toggleId = dashboardToggle?.dataset.lensPageId || '';
@@ -114,7 +112,6 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       window.reimportDNA = () => calls.push(['reimport-dna']);
       window.confirmDeleteDNA = () => calls.push(['delete-dna']);
       window.openSettingsModal = pane => calls.push(['settings', pane]);
-      window.openDashboardBiometricPicker = () => calls.push(['biometrics']);
       window.openChatPanel = () => calls.push(['chat']);
       window.navigate = route => calls.push(['navigate', route]);
       const actionFixture = document.createElement('div');
@@ -154,13 +151,10 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
         ].every(expected => calls.some(call => call[0] === expected[0] && (expected.length < 2 || call[1] === expected[1]))),
       };
     } finally {
-      window.addDashboardWidgetFromLens = originalAddDashboard;
-      window.removeDashboardWidgetFromLens = originalRemoveDashboard;
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       window.reimportDNA = originalReimportDNA;
       window.confirmDeleteDNA = originalConfirmDeleteDNA;
       window.openSettingsModal = originalOpenSettings;
-      window.openDashboardBiometricPicker = originalOpenBiometricPicker;
       window.openChatPanel = originalOpenChat;
       shell.configureLensPageShell(restoreShell);
       window.navigate = originalNavigate;

--- a/tests/playwright/views-facade-browser-coverage.spec.js
+++ b/tests/playwright/views-facade-browser-coverage.spec.js
@@ -126,8 +126,9 @@ test('views facade browser coverage exercises genome lens picker filters and qui
     outcomes.biometricPickerFilterKeepsEmptyHidden = document.getElementById('dashboard-biometric-widget-empty')?.hidden === true;
 
     state.currentView = 'labs';
-    const quickPinFacade = window.toggleDashboardQuickMarkerPin;
-    outcomes.quickPinWindowFacadeExists = typeof quickPinFacade === 'function';
+    const quickPinFacade = views.toggleDashboardQuickMarkerPin;
+    outcomes.quickPinModuleApiExists = typeof quickPinFacade === 'function';
+    outcomes.quickPinStaysOffWindow = !('toggleDashboardQuickMarkerPin' in window);
     if (typeof quickPinFacade === 'function') quickPinFacade('lipids_apoB');
     const pinsAfterAdd = JSON.parse(localStorage.getItem(quickPinsKey) || '[]');
     if (typeof quickPinFacade === 'function') quickPinFacade('lipids_apoB');

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -14,6 +14,7 @@ return (async function() {
   const main = document.getElementById('main-content');
   const S = window._labState;
   const dataModule = await import('/js/data.js');
+  const viewsModule = await import('/js/views.js');
   const { buildSunContext } = await import('/js/sun-context.js');
   const { buildLabContext } = await import('/js/lab-context.js');
   const profile = await import('/js/profile.js');
@@ -49,7 +50,7 @@ return (async function() {
   window.navigate?.('dashboard');
   await wait(80);
   if (!main.querySelector('.dashboard-widget[data-widget-id="light-today"]')) {
-    window.showDashboardWidget?.('light-today');
+    viewsModule.showDashboardWidget?.('light-today');
     await wait(120);
   }
   const todayWidget = main.querySelector('.dashboard-widget[data-widget-id="light-today"]');

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -26,6 +26,7 @@ return (async function() {
   const main = document.getElementById('main-content');
   const S = window._labState;
   const dataModule = await import('/js/data.js');
+  const viewsModule = await import('/js/views.js');
   const supplements = await import('/js/supplements.js');
   const pdfImport = await import('/js/pdf-import.js');
   const profile = await import('/js/profile.js');
@@ -422,7 +423,7 @@ return (async function() {
   await wait(20);
   window.navigate('dashboard');
   await wait(50);
-  window.showDashboardWidget?.('supplements');
+  viewsModule.showDashboardWidget?.('supplements');
   await wait(50);
   const suppSection = main.querySelector('.supp-timeline-section');
   assert('Optional Supplements widget renders on dashboard after save', !!suppSection);
@@ -632,7 +633,7 @@ return (async function() {
   assert('Diet editor closes', !modalOverlay.classList.contains('show'));
 
   // Verify optional Profile Context widget can render on dashboard
-  window.showDashboardWidget?.('profile-context');
+  viewsModule.showDashboardWidget?.('profile-context');
   await wait(80);
   const ctxCards = main.querySelectorAll('.context-card');
   assert('Profile Context widget renders on dashboard', ctxCards.length >= 5);

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -17,6 +17,7 @@ return (async function() {
   const manual    = await import('../js/wearables-manual.js' + bust);
   const store     = await import('../js/wearables-store.js' + bust);
   const summary   = await import('../js/wearables-summary.js' + bust);
+  const views     = await import('../js/views.js');
 
   // ─────────────────────────────────────────────────────────
   // Test profile + state isolation
@@ -231,7 +232,7 @@ return (async function() {
   // 7. Modular metric selection — add/remove inside the overview
   // ═══════════════════════════════════════
   console.log('%c 7. Modular Metric Selection ', 'font-weight:bold;color:#f59e0b');
-  await window.addDashboardBiometricMetric?.('weight');
+  await views.addDashboardBiometricMetric?.('weight');
   await new Promise(r => setTimeout(r, 300));
   const overviewAfterAdd = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
   assert('Adding weight keeps it inside Biometrics Overview',
@@ -277,14 +278,14 @@ return (async function() {
       selectedOverview && !/Cardio age/i.test(selectedOverview.textContent || '') && !/Resilience/i.test(selectedOverview.textContent || ''));
     assert('Fresh connected data does not show a dashboard sync button',
       !document.querySelector('.db-biometric-sync-btn'));
-    window.openDashboardWidgetPicker?.();
+    views.openDashboardWidgetPicker?.();
     await new Promise(r => setTimeout(r, 200));
     const pickerOptions = Array.from(document.querySelectorAll('.dashboard-biometric-widget-option'));
     assert('Picker offers additional biometrics for the overview',
       pickerOptions.some(btn => /Cardio age/i.test(btn.textContent || '')) &&
       pickerOptions.some(btn => /Resilience/i.test(btn.textContent || '')));
-    window.closeDashboardWidgetPicker?.();
-    window.openDashboardBiometricPicker?.();
+    views.closeDashboardWidgetPicker?.();
+    views.openDashboardBiometricPicker?.();
     await new Promise(r => setTimeout(r, 200));
     const biometricOnlyText = document.getElementById('dashboard-widget-picker-overlay')?.textContent || '';
     const biometricOnlyOptions = Array.from(document.querySelectorAll('.dashboard-biometric-widget-option'));
@@ -298,8 +299,8 @@ return (async function() {
     assert('Biometric-only picker still offers wearable/manual metrics',
       biometricOnlyOptions.some(btn => /Cardio age/i.test(btn.textContent || '')) &&
       biometricOnlyOptions.some(btn => /Resilience/i.test(btn.textContent || '')));
-    window.closeDashboardWidgetPicker?.();
-    await window.addDashboardBiometricMetric?.('cardio_age');
+    views.closeDashboardWidgetPicker?.();
+    await views.addDashboardBiometricMetric?.('cardio_age');
     await new Promise(r => setTimeout(r, 300));
     const overviewWithCardio = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
     assert('Picker add places the chosen biometric inside Biometrics Overview',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -188,7 +188,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -212,6 +212,7 @@
     import('../js/sun-spectrum.js'),
     import('../js/supplements.js'),
     import('../js/utils.js'),
+    import('../js/views.js'),
   ]);
   const apiExports = [
     'getVeniceKey','saveVeniceKey','hasVeniceKey',
@@ -611,6 +612,16 @@
     'filterCorrelationOptions','toggleCorrelationMarker','applyCorrelationPreset',
     'renderCorrelationChips','renderCorrelationChart'
   ];
+  const viewsDashboardWidgetExports = [
+    'toggleDashboardOrganizeMode','moveDashboardWidget','moveLensPageWidget',
+    'hideDashboardWidget','showDashboardWidget','addDashboardWidgetFromLens',
+    'removeDashboardWidgetFromLens','addDashboardMarkerWidget','addDashboardBiometricMetric',
+    'addDashboardBiometricWidget','removeDashboardBiometricMetric',
+    'filterDashboardMarkerWidgetPicker','filterDashboardBiometricWidgetPicker',
+    'resetDashboardWidgets','clearDashboardWidgets','toggleDashboardQuickMarkerPin',
+    'openDashboardWidgetPicker','openDashboardBiometricPicker','closeDashboardWidgetPicker',
+    'startDashboardWidgetDrag','allowDashboardWidgetDrop','dropDashboardWidget'
+  ];
 
   for (const name of apiExports) {
     const val = apiModule[name];
@@ -642,6 +653,7 @@
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
     ['supplements.js', supplementsModule, supplementsExports],
     ['utils.js', utilsModule, utilsExports],
+    ['views.js dashboard widgets', viewsModule, viewsDashboardWidgetExports],
   ]) {
     for (const name of exports) {
       const val = moduleApi[name];
@@ -702,6 +714,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of dataExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of viewsDashboardWidgetExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.205';
+self.APP_VERSION = '1.10.206';


### PR DESCRIPTION
## Summary

- remove the 22-function dashboard-widget compatibility facade from `views.js`
- inject dashboard actions into the lens shell and Settings instead of reading them from `window`
- migrate browser-flow callers to the `views.js` module API and assert the full widget surface stays module-only
- reduce the quality baseline to 3 total / 1 legacy window assignments and bump the cache version to `1.10.206`

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality` (7/7 checks; 3 total / 1 legacy assignment)
- `npm test` (398 passed)
- focused Playwright coverage (11 passed; 472 responsive assertions)
- `./run-tests.sh` (123 static, 398 Vitest, 352 Playwright, and 472 responsive assertions passed)
