### PR TITLE
Trim views window facade

### DIFF
--- a/js/biology-scores-runtime.js
+++ b/js/biology-scores-runtime.js
@@ -4,6 +4,7 @@
 import { hasAIProvider } from './api.js';
 import { getActiveData } from './data.js';
 import { showNotification } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const biologyScoresRuntimeDeps = { getActiveData, showNotification };
 
@@ -34,7 +35,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
+  return getViewRuntimeFunction(name);
 }
 
 /** @param {string} route */

--- a/js/category-page-view.js
+++ b/js/category-page-view.js
@@ -23,6 +23,7 @@ import {
   renderFattyAcidsCharts,
 } from './category-view-renderers.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const categoryPageActionDelegateRoots = new WeakSet();
 
@@ -57,7 +58,8 @@ function handleCategoryPageActionClick(event) {
   const categoryKey = actionEl.dataset.categoryPageCategory || '';
   if (!safeMarkerId(categoryKey)) return;
   if (action === 'rename-category') {
-    appWindow.renameCategory?.(categoryKey);
+    const renameCategory = appWindow.renameCategory || getViewRuntimeFunction('renameCategory');
+    renameCategory?.(categoryKey);
   } else if (action === 'switch-view') {
     const view = actionEl.dataset.categoryPageView || '';
     if (view !== 'charts' && view !== 'table' && view !== 'heatmap') return;

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -11,6 +11,7 @@ import { openMenstrualCycleEditor } from './cycle.js';
 import { openSupplementsEditor } from './supplements.js';
 import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
 import { getActivePersonality } from './chat-personalities.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   chatOnboardingActionAttrs,
   _countFilledCards, _renderOnboardCrumbs, _renderProviderQuiz,
@@ -47,7 +48,8 @@ function chatEmptyRuntime() {
 
 function callChatEmptyRuntime(name, ...args) {
   const fn = chatEmptyRuntime()[name];
-  return typeof fn === 'function' ? fn(...args) : undefined;
+  const runtimeFn = typeof fn === 'function' ? fn : getViewRuntimeFunction(name);
+  return runtimeFn ? runtimeFn(...args) : undefined;
 }
 
 function closeChatPanel() {

--- a/js/dashboard-recommendation-widget.js
+++ b/js/dashboard-recommendation-widget.js
@@ -7,6 +7,7 @@ import { getEffectiveRangeForDate, getLatestValueIndex } from './marker-analysis
 import { computeBiologyScores } from './biology-scores.js';
 import { profileStorageKey } from './profile.js';
 import { escapeAttr, escapeHTML, formatValue, getStatus } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let dashboardRecommendationDelegatesInstalled = false;
 
@@ -20,7 +21,7 @@ function getDashboardRecommendationRuntimeValue(name) {
 
 function callDashboardRecommendationRuntime(name, ...args) {
   const runtime = dashboardRecommendationRuntime();
-  const fn = getDashboardRecommendationRuntimeValue(name);
+  const fn = getDashboardRecommendationRuntimeValue(name) || getViewRuntimeFunction(name);
   return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
 }
 

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -2,6 +2,7 @@
 // dashboard-widget-runtime.js - Browser runtime adapters for dashboard widget controls and renderers.
 
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -15,7 +16,8 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
+  return getViewRuntimeFunction(name);
 }
 
 export function getDashboardViewportHeight() {

--- a/js/data.js
+++ b/js/data.js
@@ -2,6 +2,7 @@
 // data.js — Data pipeline, unit conversion, date range, trend detection
 
 import { state } from './state.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { getBiologyProfileContext } from './profile-context.js';
 import { MARKER_SCHEMA, UNIT_CONVERSIONS, OPTIMAL_RANGES, PHASE_RANGES } from './schema.js';
 import { escapeAttr, hashString, showNotification } from './utils.js';
@@ -968,8 +969,9 @@ export function switchUnitSystem(system) {
   dataWindow.buildSidebar(data);
   updateHeaderDates(data);
   dataWindow.navigate(state.currentView || 'dashboard', data);
-  if (openId && typeof dataWindow.showDetailModal === 'function') {
-    dataWindow.showDetailModal(openId);
+  const showDetailModal = dataWindow.showDetailModal || getViewRuntimeFunction('showDetailModal');
+  if (openId && showDetailModal) {
+    showDetailModal(openId);
   }
 }
 
@@ -988,8 +990,9 @@ export function toggleAltUnits(force) {
   // Refresh the currently-visible detail modal so the alt-unit lines update
   // without a full navigate (the modal lives outside the page rebuild).
   const openId = state._activeDetailMarkerId;
-  if (openId && typeof dataWindow.showDetailModal === 'function') {
-    dataWindow.showDetailModal(openId);
+  const showDetailModal = dataWindow.showDetailModal || getViewRuntimeFunction('showDetailModal');
+  if (openId && showDetailModal) {
+    showDetailModal(openId);
   }
 }
 
@@ -1030,8 +1033,9 @@ export function switchRangeMode(mode) {
     const data = getActiveData();
     dataWindow.buildSidebar(data);
     dataWindow.navigate(state.currentView || 'dashboard', data);
-    if (openId && state._activeDetailMarkerId === openId && typeof dataWindow.showDetailModal === 'function') {
-      dataWindow.showDetailModal(openId);
+  const showDetailModal = dataWindow.showDetailModal || getViewRuntimeFunction('showDetailModal');
+  if (openId && state._activeDetailMarkerId === openId && showDetailModal) {
+    showDetailModal(openId);
     }
   });
 }

--- a/js/light-devices-runtime.js
+++ b/js/light-devices-runtime.js
@@ -3,6 +3,7 @@
 
 import { state } from './state.js';
 import { showPromptDialog } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const lightDevicesRuntimeDeps = { showPromptDialog };
 
@@ -28,7 +29,8 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (typeof runtime[name] === 'function') return runtime[name].bind(runtime);
+  return getViewRuntimeFunction(name);
 }
 
 /**

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -2,6 +2,7 @@
 // marker-detail-runtime.js - Browser runtime adapters for marker detail modal hooks.
 
 import { closeEMFInterpretation } from './emf-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const markerDetailRuntimeDeps = {
   closeEMFInterpretation,
@@ -27,7 +28,8 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
+  return getViewRuntimeFunction(name);
 }
 
 /**

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -4,6 +4,7 @@
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { openReportBuilder } from './export.js';
 import { openContextModalRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const navRuntimeDeps = {
   openEMFAssessmentEditor,
@@ -37,7 +38,7 @@ function getNavRuntimeScope() {
 function getNavRuntimeFunction(name) {
   const runtime = getNavRuntimeScope();
   const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : null;
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 /**

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -100,6 +100,7 @@ import {
   doRoutstrWalletRestore,
   walletRuntime
 } from './provider-wallet-panels.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 function providerPanelRuntime() {
   return /** @type {Record<string, any>} */ (globalThis);
@@ -111,7 +112,7 @@ function getProviderPanelRuntimeValue(name) {
 
 function callProviderPanelRuntime(name, ...args) {
   const runtime = providerPanelRuntime();
-  const fn = runtime[name];
+  const fn = runtime[name] || getViewRuntimeFunction(name);
   return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
 }
 

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -12,6 +12,7 @@ import { maybeShowBackupNudge } from './crypto.js';
 import { maybeShowLegalConsentGate } from './legal-consent.js';
 import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 import { maybeShowAnalyticsConsent } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const startupUIDeps = { maybeShowAnalyticsConsent };
 
@@ -35,14 +36,14 @@ function getStartupRuntimeValue(name) {
 
 function callStartupRuntime(name, ...args) {
   const runtime = startupRuntime();
-  const fn = runtime[name];
+  const fn = runtime[name] || getViewRuntimeFunction(name);
   if (typeof fn !== 'function') return undefined;
   return fn.apply(runtime, args);
 }
 
 function requireStartupRuntime(name, ...args) {
   const runtime = startupRuntime();
-  const fn = runtime[name];
+  const fn = runtime[name] || getViewRuntimeFunction(name);
   if (typeof fn !== 'function') {
     throw new TypeError(`Startup runtime function ${name} is not available`);
   }

--- a/js/sun-runtime.js
+++ b/js/sun-runtime.js
@@ -2,6 +2,7 @@
 // sun-runtime.js - Browser runtime adapters for Sun session facade hooks.
 
 import { isDebugMode } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const sunRuntimeDeps = { isDebugMode };
 
@@ -26,7 +27,8 @@ function getRuntimeNavigator() {
 /** @param {string} name */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return typeof runtime?.[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (typeof runtime?.[name] === 'function') return runtime[name].bind(runtime);
+  return getViewRuntimeFunction(name);
 }
 
 export function hasSunBrowserRuntime() {

--- a/js/views-runtime-bridge.js
+++ b/js/views-runtime-bridge.js
@@ -1,0 +1,21 @@
+// @ts-check
+// views-runtime-bridge.js - Module-scoped access to cycle-sensitive view actions.
+
+/** @type {Record<string, (...args: any[]) => any>} */
+const viewRuntime = Object.create(null);
+
+/** @param {Record<string, unknown>} api */
+export function configureViewRuntime(api = {}) {
+  const previous = { ...viewRuntime };
+  for (const [name, value] of Object.entries(api)) {
+    if (typeof value === 'function') {
+      viewRuntime[name] = /** @type {(...args: any[]) => any} */ (value);
+    }
+  }
+  return previous;
+}
+
+/** @param {string} name */
+export function getViewRuntimeFunction(name) {
+  return typeof viewRuntime[name] === 'function' ? viewRuntime[name] : null;
+}

--- a/js/views.js
+++ b/js/views.js
@@ -5,6 +5,7 @@ import { getActiveData, destroyAllCharts } from './data.js';
 import { buildSidebar } from './nav.js';
 import { setupDropZone } from './import-drop-zone.js';
 import { createRecommendationActions } from './recommendation-actions.js';
+import { configureViewRuntime } from './views-runtime-bridge.js';
 import { createNavigate, getInitialView as getRouterInitialView } from './views-router.js';
 import { createDashboardViewComposition } from './dashboard-view-composition.js';
 import { createLensPageHandlers } from './lens-pages.js';
@@ -109,10 +110,23 @@ export {
   renderFattyAcidsView,
   renderFattyAcidsCharts,
   showCategory,
+  renameCategory,
+  renameMarker,
+  revertMarkerName,
+  changeCategoryIcon,
   switchView,
   showLight,
+  _expandLightToolsSection,
+  _toggleChannelDetail,
+  _openChannelOnLightPage,
+  _openAllSessionsModal,
   renderLightTodayStrip,
   renderLightChannelsLive,
+  renderConditionsNow,
+  _refreshConditionsNow,
+  _inspectConditionsNow,
+  _setManualUvi,
+  _clearManualUvi,
   moveLensPageWidget,
   fetchCustomMarkerDescription,
   showDetailModal,
@@ -287,11 +301,10 @@ configureCompareCorrelationViews({
 
 
 // ═══════════════════════════════════════════════
-// WINDOW EXPORTS
+// CYCLE-SENSITIVE RUNTIME ACTIONS
 // ═══════════════════════════════════════════════
 
-Object.assign(window, {
-  navigate,
+configureViewRuntime({
   getInitialView,
   showDashboard,
   showLabs,
@@ -376,3 +389,6 @@ Object.assign(window, {
   renderCorrelationChips,
   renderCorrelationChart,
 });
+
+// Core shell contracts retained while their remaining integrations migrate.
+Object.assign(window, { navigate, closeModal });

--- a/js/wearables-detail-runtime.js
+++ b/js/wearables-detail-runtime.js
@@ -2,6 +2,7 @@
 // wearables-detail-runtime.js - Browser runtime adapters for wearable detail modal hooks.
 
 import { showConfirmDialog } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const wearableDetailRuntimeDeps = { showConfirmDialog };
 
@@ -27,7 +28,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
+  return getViewRuntimeFunction(name);
 }
 
 export function rememberWearableDetailModalTriggerRuntime() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -223,6 +223,7 @@ const APP_SHELL = [
   '/js/nav-runtime.js',
   '/js/nav.js',
   '/js/views-router-runtime.js',
+  '/js/views-runtime-bridge.js',
   '/js/views-router.js',
   '/js/dashboard-view-composition.js',
   '/js/dashboard-page-view.js',

--- a/tests/playwright/all-sessions-modal.spec.js
+++ b/tests/playwright/all-sessions-modal.spec.js
@@ -7,11 +7,12 @@ test('all sessions modal renders scrollable session list', async ({ page }) => {
 
   const before = await page.locator('.modal-overlay').count();
 
-  await page.evaluate((sessionCount) => {
+  await page.evaluate(async (sessionCount) => {
+    const viewsModule = await import('/js/views.js');
     const state = window._labState;
     if (!state?.importedData) throw new Error('window._labState.importedData unavailable');
-    if (typeof window._openAllSessionsModal !== 'function') {
-      throw new Error('window._openAllSessionsModal unavailable');
+    if (typeof viewsModule._openAllSessionsModal !== 'function') {
+      throw new Error('views._openAllSessionsModal unavailable');
     }
 
     state.importedData.sunSessions = Array.from({ length: sessionCount }, (_, i) => ({
@@ -25,7 +26,7 @@ test('all sessions modal renders scrollable session list', async ({ page }) => {
     }));
     state.importedData.deviceSessions = [];
 
-    window._openAllSessionsModal();
+    viewsModule._openAllSessionsModal();
   }, SESSION_COUNT);
 
   await expect(page.locator('.modal-overlay')).toHaveCount(before + 1);

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -2,16 +2,13 @@ import { expect, test } from './coverage-fixture.js';
 
 test('audit runtime guards no-op on adversarial marker ids', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.showCategory === 'function'
-      && typeof window.renderChartCard === 'function'
-      && !!window._labState
-  );
+  await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule] = await Promise.all([
+    const [{ state }, dataModule, viewsModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
+      import('/js/views.js'),
     ]);
     const originalData = state.importedData;
     const originalSex = state.profileSex;
@@ -30,7 +27,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
         window.buildSidebar?.();
       }
 
-      window.showCategory('biochemistry');
+      viewsModule.showCategory('biochemistry');
       await delay(50);
       const beforeHeading = document.querySelector('.category-header h2')?.textContent || null;
       const tableBtn = document.querySelector('[data-category-page-action="switch-view"][data-category-page-view="table"]');
@@ -50,21 +47,21 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
       let quoteInjectionNoop = false;
       let protoNoop = false;
       if (beforeHeading) {
-        window.showCategory("hormones');alert(1);//");
+        viewsModule.showCategory("hormones');alert(1);//");
         await delay(30);
         quoteInjectionNoop = document.querySelector('.category-header h2')?.textContent === beforeHeading;
 
-        window.showCategory('__proto__');
+        viewsModule.showCategory('__proto__');
         await delay(30);
         protoNoop = document.querySelector('.category-header h2')?.textContent === beforeHeading;
       }
 
       const overlay = document.getElementById('modal-overlay');
       const openBefore = !!overlay?.classList.contains('show');
-      window.showDetailModal("biochemistry_glucose');alert(2);//");
+      viewsModule.showDetailModal("biochemistry_glucose');alert(2);//");
       await delay(30);
 
-      const safeRender = window.renderChartCard('biochemistry_glucose', { name: 'Glucose', values: [5] }, ['2025-01-01']) || '';
+      const safeRender = viewsModule.renderChartCard('biochemistry_glucose', { name: 'Glucose', values: [5] }, ['2025-01-01']) || '';
       return {
         controlCategoryRendered: !!beforeHeading,
         quoteInjectionNoop,
@@ -72,7 +69,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
         categoryDelegatesSwitchViews,
         categoryDelegatesRename,
         detailModalInjectionNoop: !!overlay?.classList.contains('show') === openBefore,
-        unsafeChartCardEmpty: window.renderChartCard("foo';evil('", { name: 'x', values: [1] }, ['2025-01-01']) === '',
+        unsafeChartCardEmpty: viewsModule.renderChartCard("foo';evil('", { name: 'x', values: [1] }, ['2025-01-01']) === '',
         safeChartCardRenders: safeRender.includes('biochemistry_glucose') && safeRender.includes('chart-card'),
       };
     } finally {

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -248,7 +248,6 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForFunction(() =>
     typeof window.navigate === 'function'
-      && typeof window.openRecommendationDetail === 'function'
   );
 
   const results = await page.evaluate(async () => {
@@ -425,8 +424,8 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     dismissButton?.click();
     await delay(100);
     const dismissStored = firstRecId && readJson(recDismissedKey).length > 0;
-    window.dismissRecommendation?.(firstRecId, false);
-    window.saveRecommendation?.(firstRecId, false);
+    viewsModule.dismissRecommendation?.(firstRecId, false);
+    viewsModule.saveRecommendation?.(firstRecId, false);
 
     viewsModule.resetDashboardWidgets();
     window.navigate('dashboard');

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -115,7 +115,6 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
     await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
     await page.waitForFunction(
       () => window._labState
-        && typeof window.showDetailModal === 'function'
         && typeof window.navigate === 'function'
         && typeof window.openSunSessionDetail === 'function'
         && typeof window.openDeviceSessionDetail === 'function',
@@ -218,8 +217,9 @@ async function applyMergedImportedData(page, mergedImportedData, remoteBroughtNe
 }
 
 async function openMarkerModal(page) {
-  await page.evaluate(({ markerId }) => {
-    window.showDetailModal(markerId);
+  await page.evaluate(async ({ markerId }) => {
+    const viewsModule = await import('/js/views.js');
+    viewsModule.showDetailModal(markerId);
   }, { markerId: MARKER_ID });
   await page.waitForFunction(
     () => document.getElementById('modal-overlay')?.classList?.contains('show')
@@ -231,6 +231,7 @@ async function openMarkerModal(page) {
 
 async function editOpenMarkerValue(page, newValue) {
   await page.evaluate(async ({ markerId, date, markerKey, mirrorKey, next }) => {
+    const viewsModule = await import('/js/views.js');
     const waitFor = async (fn, timeoutMs = 2500) => {
       const start = Date.now();
       while (Date.now() - start < timeoutMs) {
@@ -243,7 +244,7 @@ async function editOpenMarkerValue(page, newValue) {
       .find(el => /\d/.test(el.textContent || ''));
     if (!valueEl) throw new Error('No marker history value element found');
     const current = parseFloat(valueEl.textContent);
-    window.editMarkerValue(markerId, date, current, { target: valueEl });
+    viewsModule.editMarkerValue(markerId, date, current, { target: valueEl });
     const input = valueEl.querySelector('input.ref-edit-input');
     if (!input) throw new Error('Marker edit input did not render');
     input.value = String(next);

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -685,7 +685,10 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
   });
   assert(testName(theme, viewportName, 'demo marker available for modal test'), !!markerId);
   if (markerId) {
-    await page.evaluate(id => window.showDetailModal?.(id), markerId);
+    await page.evaluate(async id => {
+      const viewsModule = await import('/js/views.js');
+      viewsModule.showDetailModal?.(id);
+    }, markerId);
     await delay(250);
     result = await page.evaluate(() => {
       const overlay = document.getElementById('modal-overlay');
@@ -1045,18 +1048,20 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     }
   }
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
+    const viewsModule = await import('/js/views.js');
     window.scrollTo(0, 0);
-    window.showCategory?.('biochemistry');
+    viewsModule.showCategory?.('biochemistry');
   });
   await page.waitForSelector('.category-header', { timeout: 5000 });
   for (const view of ['table', 'heatmap']) {
     const shellKind = view === 'table' ? 'data' : 'heatmap';
     const wrapperClass = view === 'table' ? 'data-table-wrapper' : 'heatmap-wrapper';
-    await page.evaluate((view) => {
+    await page.evaluate(async (view) => {
+      const viewsModule = await import('/js/views.js');
       const btns = document.querySelectorAll('.view-toggle .view-btn');
       const btn = btns[view === 'table' ? 1 : 2];
-      window.switchView?.(view, 'biochemistry', btn);
+      viewsModule.switchView?.(view, 'biochemistry', btn);
       window.scrollTo(0, 0);
     }, view);
     await page.waitForSelector(`.gb-table-shell-${shellKind} .gb-table-sticky-head`, { state: 'attached', timeout: 5000 });

--- a/tests/playwright/views-facade-browser-coverage.spec.js
+++ b/tests/playwright/views-facade-browser-coverage.spec.js
@@ -18,10 +18,11 @@ test('views facade browser coverage exercises genome lens picker filters and qui
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ viewsUrl }) => {
-    const [views, stateModule, profileModule] = await Promise.all([
+    const [views, stateModule, profileModule, runtimeBridge] = await Promise.all([
       import(viewsUrl),
       import('/js/state.js'),
       import('/js/profile.js'),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const { state } = stateModule;
     const profileId = `viewsFacadeCoverage${Date.now().toString(36)}`;
@@ -29,6 +30,16 @@ test('views facade browser coverage exercises genome lens picker filters and qui
     const biometricKey = profileModule.profileStorageKey(profileId, 'dashboardBiometricMetricsV1');
     const quickPinsKey = profileModule.profileStorageKey(profileId, 'dashboardQuickMarkerPinsV1');
     const outcomes = {};
+    const bridgedViewActions = [
+      'getInitialView', 'showDetailModal', 'openRecommendationDetail', 'discussRecommendation',
+      'saveRecommendation', 'dismissRecommendation', 'openChatProviderQuiz', 'setOnboardingFocus',
+      'renameCategory', 'renameMarker', 'revertMarkerName', 'openCreateMarkerModal',
+      'loadFocusCard', 'renderLightTodayStrip', 'renderLightChannelsLive',
+      '_openChannelOnLightPage', 'rememberModalTrigger',
+    ];
+    outcomes.viewRuntimeBridgeResolvesModuleActions = bridgedViewActions.every(name =>
+      runtimeBridge.getViewRuntimeFunction(name) === views[name]);
+    outcomes.bridgedViewActionsStayOffWindow = bridgedViewActions.every(name => !(name in window));
     const waitForToastText = async expectedTexts => {
       for (let i = 0; i < 20; i++) {
         const text = document.getElementById('notification-container')?.textContent || '';

--- a/tests/test-a11y-axe.js
+++ b/tests/test-a11y-axe.js
@@ -33,6 +33,7 @@ return (async () => {
 
   const { state } = await import('/js/state.js');
   const { loadDemoData } = await import('/js/export.js');
+  const viewsModule = await import('/js/views.js');
   // Capture full state shape so we can restore even if we mutate
   // currentProfile / importedData / markerRegistry / etc along the way.
   const snapshot = {
@@ -138,8 +139,8 @@ return (async () => {
     // Detail modal
     await safeNav('dashboard');
     await safeOp('open detail modal', async () => {
-      if (typeof window.showDetailModal === 'function') {
-        window.showDetailModal('hormones_insulin');
+      if (typeof viewsModule.showDetailModal === 'function') {
+        viewsModule.showDetailModal('hormones_insulin');
         await new Promise(r => setTimeout(r, 600));
       }
     });

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -49,7 +49,7 @@ const dataModule = await import('../js/data.js');
 const profileModule = await import('../js/profile.js');
 cryptoModule.configureCryptoProfileDeps({ migrateProfileData: profileModule.migrateProfileData });
 await import('../js/nav.js');
-await import('../js/views.js');
+const viewsModule = await import('../js/views.js');
 const exportModule = await import('../js/export.js');
 await import('../js/settings.js');
 await import('../js/chat.js');
@@ -332,8 +332,8 @@ for (const name of dataExports) {
 const expectedExports = [
   // nav.js
   'buildSidebar', 'renderProfileDropdown',
-  // views.js
-  'navigate', 'showDashboard',
+  // views.js shell contracts
+  'navigate',
   // settings.js
   'openSettingsModal', 'closeSettingsModal',
   // chat.js
@@ -342,6 +342,8 @@ const expectedExports = [
 for (const name of expectedExports) {
   assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
 }
+assert('views.showDashboard exists', typeof viewsModule.showDashboard === 'function');
+assert('window.showDashboard stays module-only', !('showDashboard' in window));
 for (const name of ['openReportBuilder', 'closeReportBuilder', 'exportPDFReport', 'exportDataJSON', 'importDataJSON', 'clearAllData']) {
   assert(`export.${name} exists`, typeof exportModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -112,7 +112,6 @@ return (async function() {
   // is: rememberModalTrigger() captures activeElement on open,
   // closeModal() restores it. Wearables detail opens route through a
   // runtime adapter so the modal module stays browser-global free.
-  const viewsSrc = await fetch('js/views.js').then(r => r.text());
   const markerDetailSrc = await fetch('js/marker-detail-modal.js').then(r => r.text());
   const dashboardWidgetsSrc = await fetch('js/dashboard-widgets.js').then(r => r.text());
   const wearablesDetailSrc = await fetch('js/wearables-detail-modal.js').then(r => r.text());
@@ -125,7 +124,8 @@ return (async function() {
     markerDetailSrc.includes("from './modal-lifecycle.js'") &&
       /function closeModal\(\)[\s\S]{0,180}closeModalOverlay\('modal-overlay'\)/.test(markerDetailSrc));
   assert('rememberModalTrigger exported', markerDetailSrc.includes('export function rememberModalTrigger'));
-  assert('rememberModalTrigger on window', /window\s*,\s*\{[\s\S]*?rememberModalTrigger/.test(viewsSrc));
+  assert('rememberModalTrigger is a views module API', typeof viewsModule.rememberModalTrigger === 'function');
+  assert('rememberModalTrigger stays off window', !('rememberModalTrigger' in window));
   assert('wearable detail modal captures trigger',
     wearablesDetailSrc.includes('rememberWearableDetailModalTriggerRuntime();') &&
       /getRuntimeFunction\('rememberModalTrigger'\)\?\.\(\)/.test(wearablesDetailRuntimeSrc));
@@ -531,7 +531,7 @@ return (async function() {
   }
 
   if (testMarkerId) {
-    window.showDetailModal(testMarkerId);
+    viewsModule.showDetailModal(testMarkerId);
     await wait(50);
     assert('Detail modal opens', modalOverlay.classList.contains('show'));
 
@@ -563,7 +563,7 @@ return (async function() {
   try {
     S.profileDob = originalProfileDob || '1987-11-22';
     dataModule.invalidateActiveDataCache?.();
-    window.showDetailModal('calculatedRatios_biologicalAge');
+    viewsModule.showDetailModal('calculatedRatios_biologicalAge');
     await waitFor(() => document.querySelector('#detail-modal .bio-age-breakdown'));
     const bioModal = document.getElementById('detail-modal');
     let bioText = bioModal?.textContent || '';
@@ -576,7 +576,7 @@ return (async function() {
 
     S.profileDob = '';
     dataModule.invalidateActiveDataCache?.();
-    window.showDetailModal('calculatedRatios_biologicalAge');
+    viewsModule.showDetailModal('calculatedRatios_biologicalAge');
     await waitFor(() => /Date of birth/.test(document.getElementById('detail-modal')?.textContent || ''));
     const missingDobModal = document.getElementById('detail-modal');
     bioText = missingDobModal?.textContent || '';
@@ -590,7 +590,7 @@ return (async function() {
 
     S.profileDob = '2999-01-01';
     dataModule.invalidateActiveDataCache?.();
-    window.showDetailModal('calculatedRatios_biologicalAge');
+    viewsModule.showDetailModal('calculatedRatios_biologicalAge');
     await waitFor(() => /Valid date of birth/.test(document.getElementById('detail-modal')?.textContent || ''));
     bioText = document.getElementById('detail-modal')?.textContent || '';
     assert('Biological Age detail surfaces invalid DOB instead of zero missing inputs',
@@ -661,11 +661,11 @@ return (async function() {
     const val1Before = sel1?.value;
     const val2Before = sel2?.value;
     if (val1Before && val2Before && val1Before !== val2Before) {
-      window.swapCompareDates();
+      viewsModule.swapCompareDates();
       await wait(50);
       assert('Swap dates reverses selectors', sel1.value === val2Before && sel2.value === val1Before);
       // Swap back
-      window.swapCompareDates();
+      viewsModule.swapCompareDates();
       await wait(20);
     }
 
@@ -850,11 +850,11 @@ return (async function() {
 
   if (testMarkerId) {
     // showDetailModal populates markerRegistry, then openManualEntryForm reads it
-    window.showDetailModal(testMarkerId);
+    viewsModule.showDetailModal(testMarkerId);
     await wait(50);
     window.closeModal();
     await wait(20);
-    window.openManualEntryForm(testMarkerId);
+    viewsModule.openManualEntryForm(testMarkerId);
     await wait(50);
     assert('Manual entry modal opens', modalOverlay.classList.contains('show'));
     const manualModal = document.getElementById('detail-modal');

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -33,7 +33,7 @@ console.log('=== v1.6.7–v1.6.16 Regression Tests ===\n');
 await import('../js/state.js');
 await import('../js/sun.js');
 const lightTools = await import('../js/light-tools.js');
-await import('../js/views.js');
+const viewsModule = await import('../js/views.js');
 
 // Snapshot mutable state we touch.
 const _origImported = window._labState ? JSON.parse(JSON.stringify(window._labState.importedData)) : null;
@@ -401,18 +401,19 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       viewsSrc.includes("from './light-sessions-view.js'"));
     assert('light sessions view: _toggleAllSessions and _showAllSessions removed',
       !/_toggleAllSessions/.test(sessionsSrc) && !/_showAllSessions/.test(sessionsSrc));
-    // First: existence check — should pass in both node + browser
-    // (sun.js / views.js exposes the function via Object.assign(window,...)).
-    assert('window._openAllSessionsModal exposed on window',
-      typeof window._openAllSessionsModal === 'function');
+    // First: module API existence check — should pass in both Node + browser.
+    assert('views._openAllSessionsModal is exported',
+      typeof viewsModule._openAllSessionsModal === 'function');
+    assert('window._openAllSessionsModal stays module-only',
+      !('_openAllSessionsModal' in window));
     // Behaviour: only in a real browser — Node's document shim returns null
     // for getElementById, so showAllSessionsModal would write innerHTML to
     // null. Playwright covers the runtime path.
-    if (!_isNode && typeof window._openAllSessionsModal === 'function') {
+    if (!_isNode && typeof viewsModule._openAllSessionsModal === 'function') {
       const before = document.querySelectorAll('.modal-overlay').length;
-      try { window._openAllSessionsModal(); } catch (e) {}
+      try { viewsModule._openAllSessionsModal(); } catch (e) {}
       const after = document.querySelectorAll('.modal-overlay').length;
-      assert('window._openAllSessionsModal opens a modal-overlay', after > before);
+      assert('views._openAllSessionsModal opens a modal-overlay', after > before);
       const m = document.querySelectorAll('.modal-overlay');
       if (m.length > before) m[m.length - 1].remove();
     }

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -78,6 +78,7 @@
     '/js/client-list-runtime.js',
     '/js/nav-runtime.js',
     '/js/views-router-runtime.js',
+    '/js/views-runtime-bridge.js',
     '/js/focus-card.js',
     '/js/onboarding-view-runtime.js',
     '/js/onboarding-view.js',
@@ -597,20 +598,30 @@
     'hasCardContent','escapeAttr','loadScriptOnce'
   ];
 
-  // views.js (36 — closeImportModal removed, lives in pdf-import.js)
-  const viewsExports = [
-    'navigate','showDashboard',
-    'renderFocusCard','loadFocusCard','refreshFocusCard',
-    'renderOnboardingBanner','completeOnboardingSex','completeOnboardingProfile','dismissOnboarding',
-    'showCategory','switchView',
-    'renderChartCard','renderTableView','renderHeatmapView','renderFattyAcidsView','renderFattyAcidsCharts',
-    'fetchCustomMarkerDescription',
-    'showDetailModal','openManualEntryForm','saveManualEntry','deleteMarkerValue',
-    'closeModal',
-    'showCompare','setCompareDate1','setCompareDate2','updateCompare','swapCompareDates','renderCompareTable',
-    'showCorrelations','populateCorrelationOptions','showCorrelationDropdown',
-    'filterCorrelationOptions','toggleCorrelationMarker','applyCorrelationPreset',
-    'renderCorrelationChips','renderCorrelationChart'
+  // views.js retains only the two core shell contracts on window.
+  const viewsLegacyExports = ['navigate','closeModal'];
+  const viewsFacadeModuleExports = [
+    'getInitialView','showDashboard','showLabs','showBiologyScoresLens','showGenomeLens',
+    'showBodyLens','showInsightLens','showRecommendations','openRecommendationDetail',
+    'discussRecommendation','saveRecommendation','dismissRecommendation','showLight',
+    '_expandLightToolsSection','_toggleChannelDetail','_openChannelOnLightPage',
+    '_openAllSessionsModal','renderLightTodayStrip','renderLightChannelsLive',
+    'renderConditionsNow','_refreshConditionsNow','_inspectConditionsNow','_setManualUvi',
+    '_clearManualUvi','renderFocusCard','buildFocusContext','loadFocusCard','refreshFocusCard',
+    'renderOnboardingBanner','renderAIConnectionReminder','dismissAIReminder',
+    'openChatProviderQuiz','setOnboardingFocus','completeOnboardingSex',
+    'completeOnboardingProfile','dismissOnboarding','showCategory','renameCategory',
+    'renameMarker','revertMarkerName','changeCategoryIcon','switchView','renderChartCard',
+    'renderTableView','renderHeatmapView','renderFattyAcidsView','renderFattyAcidsCharts',
+    'fetchCustomMarkerDescription','showDetailModal','editRefRange','saveRefRange',
+    'revertRefRange','openManualEntryForm','saveManualEntry','saveAndAddAnotherManualEntry',
+    'openCreateMarkerModal','pickNewCatIcon','saveCustomMarker','deleteMarkerValue',
+    'deleteCustomMarker','editMarkerValue','revertMarkerValue','editValueNote',
+    'deleteValueNote','toggleMarkerNoteEditor','saveMarkerNote','deleteMarkerNote',
+    'rememberModalTrigger','showCompare','setCompareDate1','setCompareDate2','updateCompare',
+    'swapCompareDates','renderCompareTable','showCorrelations','populateCorrelationOptions',
+    'showCorrelationDropdown','filterCorrelationOptions','toggleCorrelationMarker',
+    'applyCorrelationPreset','renderCorrelationChips','renderCorrelationChart'
   ];
   const viewsDashboardWidgetExports = [
     'toggleDashboardOrganizeMode','moveDashboardWidget','moveLensPageWidget',
@@ -653,6 +664,7 @@
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
     ['supplements.js', supplementsModule, supplementsExports],
     ['utils.js', utilsModule, utilsExports],
+    ['views.js facade', viewsModule, viewsFacadeModuleExports],
     ['views.js dashboard widgets', viewsModule, viewsDashboardWidgetExports],
   ]) {
     for (const name of exports) {
@@ -719,6 +731,9 @@
   for (const name of viewsDashboardWidgetExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of viewsFacadeModuleExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
 
   const allModules = {
     'chat.js': chatExports,
@@ -727,7 +742,7 @@
     'notes.js': notesExports,
     'settings.js': settingsExports,
     'theme.js': themeExports,
-    'views.js': viewsExports,
+    'views.js': viewsLegacyExports,
   };
 
   let totalExports = 0;

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -253,6 +253,7 @@
     "js/utils.js",
     "js/views-router-runtime.js",
     "js/views-router.js",
+    "js/views-runtime-bridge.js",
     "js/views.js",
     "js/wearable-adapters.js",
     "js/wearables-apple-health-runtime.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.206';
+self.APP_VERSION = '1.10.207';


### PR DESCRIPTION
## Summary

- shrink the `views.js` window facade from 84 names to the two remaining shell contracts, `navigate` and `closeModal`
- route cycle-sensitive internal consumers through a module-scoped view runtime bridge while preserving explicit browser test overrides
- migrate direct consumers and browser tests to module APIs, precache the bridge, and bump the app cache version to 1.10.207

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test` — 398 passed
- module verification — 124 passed
- focused Playwright coverage — 37 passed, including 472 responsive assertions
- full Playwright run — 351 passed; one unrelated OpenRouter settings click was intercepted by the welcome-tour overlay, then passed in isolation in 1.8s