### PR TITLE
Make closeModal module-only

### DIFF
--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -2,6 +2,7 @@
 // chat-runtime.js - Browser runtime adapters for shared chat hooks.
 
 import { openContextModalRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -15,7 +16,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 /**

--- a/js/context-card-editor-ui.js
+++ b/js/context-card-editor-ui.js
@@ -2,6 +2,7 @@
 // context-card-editor-ui.js - Shared context-card editor modal and field controls
 
 import { escapeHTML } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 /**
  * @param {string} action
@@ -28,7 +29,8 @@ function closestContextEditorElement(target, selector) {
  */
 function invokeContextEditorWindowFn(fnName) {
   if (!fnName || typeof window === 'undefined') return;
-  const fn = /** @type {any} */ (window)[fnName];
+  const windowFn = /** @type {any} */ (window)[fnName];
+  const fn = typeof windowFn === 'function' ? windowFn : getViewRuntimeFunction(fnName);
   if (typeof fn === 'function') fn();
 }
 

--- a/js/context-card-lifestyle-runtime.js
+++ b/js/context-card-lifestyle-runtime.js
@@ -2,6 +2,7 @@
 // context-card-lifestyle-runtime.js - Browser runtime adapters for lifestyle context editors.
 
 import { openContextModalRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -15,7 +16,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 const LIFESTYLE_DELEGATES_BOUND_KEY = '__lifestyleContextDelegatesBound';

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -112,6 +112,7 @@ import {
   clearInterpretiveLens,
   showDietContaminantsModal,
 } from './context-card-lifestyle-editors.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const contextCardActionDelegateRoots = new WeakSet();
 const CONTEXT_CARD_ACTION_ATTR = 'data-context-card-action';
@@ -130,6 +131,12 @@ const contextCardEditorActions = /** @type {Record<string, () => void>} */ ({
 const contextCardWindow = /** @type {Window & typeof globalThis & {
   closeModal?: () => void,
 }} */ (typeof window !== 'undefined' ? window : {});
+function closeContextCardModal() {
+  const closeModal = typeof contextCardWindow.closeModal === 'function'
+    ? contextCardWindow.closeModal.bind(contextCardWindow)
+    : (typeof window !== 'undefined' ? getViewRuntimeFunction('closeModal') : null);
+  closeModal?.();
+}
 const contextCardRuntimeDeps = {
   openEMFAssessmentEditor,
 };
@@ -174,7 +181,7 @@ function handleContextCardClick(event) {
   } else if (action === 'open-emf-assessment') {
     const openAssessment = () => { void contextCardRuntimeDeps.openEMFAssessmentEditor(); };
     if (actionEl.dataset.contextCardCloseModal === 'true') {
-      contextCardWindow.closeModal?.();
+      closeContextCardModal();
       setTimeout(openAssessment, 100);
     } else {
       openAssessment();
@@ -417,7 +424,7 @@ export function saveAndRefresh(msg, field) {
   // Preserve details open state across the re-render below
   const details = /** @type {HTMLDetailsElement | null} */ (document.querySelector('.welcome-context-details'));
   if (details?.open) sessionStorage.setItem('welcome-details-open', '1');
-  appWindow.closeModal();
+  closeContextCardModal();
   showNotification(msg, 'success');
   if (typeof appWindow.onContextCardSaved === 'function') appWindow.onContextCardSaved();
   // Re-render the current view so the saved values appear on the card

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -9,6 +9,7 @@ import { startCycleTour } from './tour.js';
 import { createCyclePeriod, recentCyclePeriods, upgradeMenstrualCycleProfile } from './cycle-summary.js';
 import { clearCycleProfileData, renderCycleImportPickerControls, renderCycleImportSummarySection } from './cycle-import.js';
 import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 const CYCLE_ACTIVE_STATUSES = new Set(['regular', 'perimenopause']);
 const CYCLE_ICONS = {
   calendar: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="3" y="4" width="18" height="18" rx="2"></rect><path d="M16 2v4M8 2v4M3 10h18"></path></svg>',
@@ -22,10 +23,14 @@ const CYCLE_ICONS = {
   x: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"></path></svg>'
 };
 const appWindow = /** @type {Window & typeof globalThis & {
-  closeModal: () => void,
+  closeModal?: () => void,
   navigate: (category: string) => void,
   __cycleDelegatesBound?: boolean
 }} */ (typeof window !== 'undefined' ? window : {});
+function closeCycleModal() {
+  const closeModal = appWindow.closeModal || (typeof window !== 'undefined' ? getViewRuntimeFunction('closeModal') : null);
+  closeModal?.call(appWindow);
+}
 function cycleActionAttrs(action, extra = '') {
   return `data-cycle-action="${action}"${extra ? ` ${extra}` : ''}`;
 }
@@ -45,7 +50,7 @@ function handleCycleClick(event) {
   if (!actionEl) return;
   switch (actionEl.dataset.cycleAction || '') {
     case 'close':
-      appWindow.closeModal();
+      closeCycleModal();
       break;
     case 'delete-period':
       deletePeriodEntry(actionEl.dataset.cycleStartDate || '');
@@ -576,7 +581,7 @@ export function saveMenstrualCycle() {
   }
   recordContextCardChangeRuntime('menstrualCycle');
   saveImportedData();
-  appWindow.closeModal();
+  closeCycleModal();
   const activeNav = document.querySelector(".nav-item.active");
   appWindow.navigate(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
   showNotification('Menstrual cycle profile saved', 'success');
@@ -587,7 +592,7 @@ export async function clearMenstrualCycle() {
   if (await showConfirmDialog('Clear all menstrual cycle data? This cannot be undone.')) {
     try { await clearCycleProfileData(); }
     catch (error) { showNotification(`Menstrual cycle data could not be cleared: ${error.message}`, 'error'); return; }
-    appWindow.closeModal();
+    closeCycleModal();
     const activeNav = document.querySelector(".nav-item.active");
     appWindow.navigate(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
     showNotification('Menstrual cycle data cleared', 'info');

--- a/js/emf-interpretation.js
+++ b/js/emf-interpretation.js
@@ -9,6 +9,7 @@ import { callClaudeAPI, getAIProvider, getActiveModelId, getActiveModelDisplay }
 import { renderMarkdown } from './markdown.js';
 import { loadEMFCatalog, renderEMFMitigationRecs, isProductRecsEnabled, detectMitigationsInText } from './recommendations.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 /**
  * @typedef {{ text?: string, model?: string, provider?: string, modelId?: string, inputTokens?: number, outputTokens?: number, date?: string }} EMFInterpretation
@@ -44,7 +45,7 @@ function getEMFInterpretationRuntimeScope() {
 function getEMFInterpretationRuntimeFunction(name) {
   const runtime = getEMFInterpretationRuntimeScope();
   const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : null;
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 function closeParentEMFModalRuntime() {

--- a/js/emf.js
+++ b/js/emf.js
@@ -17,6 +17,7 @@ import { extractPDFText } from './pdf-import.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { loadEMFCatalog, renderEMFMeterRecs, isProductRecsEnabled } from './recommendations.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   closeEMFInterpretation,
   discussEMFInterpretation,
@@ -151,7 +152,7 @@ function getEMFRuntimeScope() {
 function getEMFRuntimeFunction(name) {
   const runtime = getEMFRuntimeScope();
   const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : null;
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 function closeEMFModalRuntime() {

--- a/js/notes-runtime.js
+++ b/js/notes-runtime.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+
 /**
  * @typedef {Window & typeof globalThis & {
  *   closeModal?: () => void,
@@ -13,19 +15,24 @@ function getNotesRuntimeWindow() {
   return /** @type {NotesRuntimeWindow | null} */ (typeof window !== 'undefined' ? window : null);
 }
 
-export function closeNoteModalRuntime() {
+/** @param {string} name */
+function getNotesRuntimeFunction(name) {
   const runtime = getNotesRuntimeWindow();
-  runtime?.closeModal?.();
+  if (!runtime) return null;
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
+}
+
+export function closeNoteModalRuntime() {
+  getNotesRuntimeFunction('closeModal')?.();
 }
 
 export function rememberNoteModalTriggerRuntime() {
-  const runtime = getNotesRuntimeWindow();
-  runtime?.rememberModalTrigger?.();
+  getNotesRuntimeFunction('rememberModalTrigger')?.();
 }
 
 export function navigateAfterNoteChangeRuntime(route = 'dashboard') {
-  const runtime = getNotesRuntimeWindow();
-  runtime?.navigate?.(route || 'dashboard');
+  getNotesRuntimeFunction('navigate')?.(route || 'dashboard');
 }
 
 export function isNoteActionDelegatesBoundRuntime() {

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -2,6 +2,7 @@
 // recommendations-runtime.js - Browser runtime adapters for recommendation hooks.
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const recommendationsRuntimeDeps = {
   openEMFAssessmentEditor,
@@ -27,7 +28,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 export function getRecommendationsSnpTable() {

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -16,6 +16,7 @@ import { openModalOverlay } from './modal-lifecycle.js';
 import { initSupplementActionDelegates, suppActionAttrs } from './supplement-action-delegates.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
 import { getUtilsRuntimeHostname } from './utils-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   computeAllImpacts,
   computeSupplementImpact,
@@ -40,9 +41,16 @@ export {
 } from './supplement-impact.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
-  closeModal: () => void,
+  closeModal?: () => void,
   navigate: (category: string) => void
 }} */ (window);
+
+function closeSupplementModal() {
+  const closeModal = typeof appWindow.closeModal === 'function'
+    ? appWindow.closeModal.bind(appWindow)
+    : getViewRuntimeFunction('closeModal');
+  closeModal?.();
+}
 
 /**
  * @param {string} id
@@ -685,7 +693,7 @@ export function deleteSupplement(idx) {
   if (state.importedData.supplements.length > 0) {
     openSupplementsEditor();
   } else {
-    appWindow.closeModal();
+    closeSupplementModal();
     const activeNav = document.querySelector(".nav-item.active");
     appWindow.navigate(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
   }
@@ -708,7 +716,7 @@ initSupplementActionDelegates({
   openEditor: openSupplementsEditor,
   toggleAccordion: toggleSuppAccordion,
   toggleAddForm: showAddSuppForm,
-  closeModal: () => appWindow.closeModal(),
+  closeModal: closeSupplementModal,
   askMito: askAIMitoContext,
   addIngredient: addIngredientRow,
   removeIngredient: removeIngredientRow,

--- a/js/utils-runtime.js
+++ b/js/utils-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // utils-runtime.js - Browser runtime adapters for shared utilities.
 
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+
 function getUtilsRuntime() {
   return typeof window !== 'undefined'
     ? /** @type {Window & typeof globalThis} */ (window)
@@ -39,8 +41,9 @@ export function getUtilsRuntimeValue(name, fallback = null) {
  */
 export function getUtilsRuntimeFunction(name) {
   const runtime = getUtilsRuntime();
-  const fn = runtime?.[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 /** @param {Record<string, any>} exportsByName */
@@ -57,7 +60,9 @@ export function registerUtilsRuntimeExports(exportsByName) {
  */
 export function callUtilsRuntimeFunction(name, ...args) {
   const runtime = getUtilsRuntime();
-  const fn = runtime?.[name];
+  if (!runtime) return undefined;
+  const runtimeFn = runtime[name];
+  const fn = typeof runtimeFn === 'function' ? runtimeFn : getViewRuntimeFunction(name);
   return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
 }
 

--- a/js/views.js
+++ b/js/views.js
@@ -390,5 +390,5 @@ configureViewRuntime({
   renderCorrelationChart,
 });
 
-// Core shell contracts retained while their remaining integrations migrate.
-Object.assign(window, { navigate, closeModal });
+// Core shell contract retained while its remaining integrations migrate.
+Object.assign(window, { navigate });

--- a/js/wearables-runtime.js
+++ b/js/wearables-runtime.js
@@ -2,6 +2,7 @@
 // wearables-runtime.js - Browser runtime adapters for wearable dashboard hooks.
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const wearablesRuntimeDeps = {
   openEMFAssessmentEditor,
@@ -27,7 +28,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 /**

--- a/tests/playwright/cashu-wallet-browser-coverage.spec.js
+++ b/tests/playwright/cashu-wallet-browser-coverage.spec.js
@@ -841,7 +841,7 @@ test('routstr wallet panels and delegates cover browser-only actions', async ({ 
       localStorage.removeItem('labcharts-routstr-models');
       localStorage.removeItem('labcharts-routstr-pricing');
       localStorage.removeItem('labcharts-routstr-vision-models');
-      window.closeModal?.();
+      (await import('/js/views.js')).closeModal();
       window.closeSettingsModal?.();
     }
   });

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -397,7 +397,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       }
       cryptoStore.updateKeyCache('labcharts-routstr-key', oldStorage['labcharts-routstr-key'] || '');
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
-      window.closeModal?.();
+      (await import('/js/views.js')).closeModal();
       window.closeSettingsModal?.();
     }
   });

--- a/tests/playwright/sync-environment-browser-coverage.spec.js
+++ b/tests/playwright/sync-environment-browser-coverage.spec.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 const moduleUrl = path => `${path}?syncEnvironmentCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const syncEnvironmentSource = fs.readFileSync(new URL('../../js/sync-environment.js', import.meta.url), 'utf8');
 const utilsRuntimeSource = fs.readFileSync(new URL('../../js/utils-runtime.js', import.meta.url), 'utf8');
+const viewsRuntimeBridgeSource = fs.readFileSync(new URL('../../js/views-runtime-bridge.js', import.meta.url), 'utf8');
 
 async function openBlankPage(page, path) {
   await page.route(`**${path}`, route => route.fulfill({
@@ -29,6 +30,11 @@ async function openOnionPage(page) {
     status: 200,
     contentType: 'application/javascript',
     body: utilsRuntimeSource,
+  }));
+  await page.route('**/js/views-runtime-bridge.js*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/javascript',
+    body: viewsRuntimeBridgeSource,
   }));
   await page.goto('http://relay-check.onion/sync-environment-onion-coverage', { waitUntil: 'load' });
 }

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -173,8 +173,8 @@ async function prepareScenario(page, theme, viewport) {
   });
   await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
   await waitForApp(page);
-  await page.evaluate((nextTheme) => {
-    window.closeModal?.();
+  await page.evaluate(async (nextTheme) => {
+    (await import('/js/views.js')).closeModal();
     window.closeSettingsModal?.();
     window.closeChatPanel?.();
     window.closeMobileSidebar?.();
@@ -708,7 +708,7 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
     assert(testName(theme, viewportName, 'marker detail modal fits viewport'),
       result.contained,
       JSON.stringify(result));
-    await page.evaluate(() => window.closeModal?.());
+    await page.evaluate(async () => (await import('/js/views.js')).closeModal());
     await delay(100);
   }
 }
@@ -810,7 +810,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     assert(testName(theme, viewportName, 'mobile marker modal fits phone viewport'),
       result.contained && result.sideGutters,
       JSON.stringify(result));
-    await page.evaluate(() => window.closeModal?.());
+    await page.evaluate(async () => (await import('/js/views.js')).closeModal());
     await delay(100);
   }
 
@@ -838,7 +838,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     supplements.addPeriodRow();
   });
   await delay(150);
-  result = await page.evaluate(() => {
+  result = await page.evaluate(async () => {
     const form = document.getElementById('supp-form-panel');
     const item = document.querySelector('.supp-list-item');
     const overlay = document.getElementById('modal-overlay');
@@ -885,7 +885,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
       : ['missing-form'];
     const horizontalOverflow = Math.max(document.body.scrollWidth, document.documentElement.scrollWidth) - document.documentElement.clientWidth;
     const open = overlay?.classList.contains('show');
-    window.closeModal?.();
+    (await import('/js/views.js')).closeModal();
     const state = window._labState;
     if (state?.importedData && window.__suppModalSnapshot) {
       state.importedData.supplements = JSON.parse(window.__suppModalSnapshot);

--- a/tests/playwright/views-facade-browser-coverage.spec.js
+++ b/tests/playwright/views-facade-browser-coverage.spec.js
@@ -35,7 +35,7 @@ test('views facade browser coverage exercises genome lens picker filters and qui
       'saveRecommendation', 'dismissRecommendation', 'openChatProviderQuiz', 'setOnboardingFocus',
       'renameCategory', 'renameMarker', 'revertMarkerName', 'openCreateMarkerModal',
       'loadFocusCard', 'renderLightTodayStrip', 'renderLightChannelsLive',
-      '_openChannelOnLightPage', 'rememberModalTrigger',
+      '_openChannelOnLightPage', 'rememberModalTrigger', 'closeModal',
     ];
     outcomes.viewRuntimeBridgeResolvesModuleActions = bridgedViewActions.every(name =>
       runtimeBridge.getViewRuntimeFunction(name) === views[name]);

--- a/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
+++ b/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
@@ -4,12 +4,13 @@ test('wearables detail modal covers manual migration delegated add save and canc
   await page.goto('/app', { waitUntil: 'load' });
 
   const failures = await page.evaluate(async () => {
-    const [{ state }, manual, store, { profileStorageKey }, blobStorage] = await Promise.all([
+    const [{ state }, manual, store, { profileStorageKey }, blobStorage, views] = await Promise.all([
       import('/js/state.js'),
       import('/js/wearables-manual.js'),
       import('/js/wearables-store.js'),
       import('/js/profile.js'),
       import('/js/blob-storage.js'),
+      import('/js/views.js'),
     ]);
     // Ensure delegated detail-modal handlers are installed.
     await import('/js/wearables.js');
@@ -36,7 +37,7 @@ test('wearables detail modal covers manual migration delegated add save and canc
       return false;
     };
     const closeDetailModal = async () => {
-      try { window.closeModal?.(); } catch (_) {}
+      try { views.closeModal(); } catch (_) {}
       await waitFor(() => !document.getElementById('modal-overlay')?.classList.contains('show'), 100);
     };
     const debugManualButtons = () => Array.from(document.querySelectorAll('#detail-modal [data-wearable-action="open-detail-manual-add"]'))
@@ -213,7 +214,7 @@ test('wearables detail modal covers manual migration delegated add save and canc
       check('saved bp reading appears in detail manual entries list',
         !!document.querySelector('#detail-modal .wearable-manual-entry[data-entry-date="2026-06-04"] .wearable-manual-entry-note'));
     } finally {
-      try { window.closeModal?.(); } catch (_) {}
+      try { views.closeModal(); } catch (_) {}
       await store.deleteWearablesDB(profileId).catch(() => {});
       if (originalImportedBlobValue == null) await blobStorage.deleteBlob(importedStorageKey);
       else await blobStorage.setBlob(importedStorageKey, originalImportedBlobValue);

--- a/tests/test-a11y-axe.js
+++ b/tests/test-a11y-axe.js
@@ -145,7 +145,7 @@ return (async () => {
       }
     });
     await scan('detail-modal');
-    await safeOp('close detail modal', () => window.closeModal?.());
+    await safeOp('close detail modal', () => viewsModule.closeModal());
 
     // Settings — scan each tab. Skip if openSettings isn't exposed.
     await safeOp('open settings', async () => {
@@ -163,7 +163,7 @@ return (async () => {
       });
       await scan(`settings-${tab}`);
     }
-    await safeOp('close settings', () => window.closeModal?.());
+    await safeOp('close settings', () => viewsModule.closeModal());
 
     // EMF assessment editor
     await safeOp('open EMF editor', async () => {
@@ -172,7 +172,7 @@ return (async () => {
       await new Promise(r => setTimeout(r, 400));
     });
     await scan('emf-editor');
-    await safeOp('close EMF editor', () => window.closeModal?.());
+    await safeOp('close EMF editor', () => viewsModule.closeModal());
 
     // ── 5. Report aggregated violations ────────────────────────────────
     const byImpact = { critical: [], serious: [], moderate: [], minor: [], unknown: [] };
@@ -287,7 +287,7 @@ return (async () => {
     if (snapshot.currentView) state.currentView = snapshot.currentView;
     if (snapshot.markerRegistry) state.markerRegistry = snapshot.markerRegistry;
     // Close any overlay we may have left open so the next test starts clean.
-    try { window.closeModal?.(); } catch (_) {}
+    try { viewsModule.closeModal(); } catch (_) {}
     // Re-navigate to dashboard so the DOM matches state.currentView.
     try { window.navigate?.('dashboard'); } catch (_) {}
   }

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -344,6 +344,8 @@ for (const name of expectedExports) {
 }
 assert('views.showDashboard exists', typeof viewsModule.showDashboard === 'function');
 assert('window.showDashboard stays module-only', !('showDashboard' in window));
+assert('views.closeModal exists', typeof viewsModule.closeModal === 'function');
+assert('window.closeModal stays module-only', !('closeModal' in window));
 for (const name of ['openReportBuilder', 'closeReportBuilder', 'exportPDFReport', 'exportDataJSON', 'importDataJSON', 'clearAllData']) {
   assert(`export.${name} exists`, typeof exportModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -16,6 +16,7 @@ import {
   renderRecommendationsDetailSection,
   scheduleRecommendationsTask,
 } from '../js/recommendations-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let passed = 0;
 let failed = 0;
@@ -33,6 +34,7 @@ function assert(name, condition, detail = '') {
 console.log('=== Recommendations Runtime Tests ===');
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+let previousViewRuntime = null;
 
 function setRuntime(value) {
   Object.defineProperty(globalThis, 'window', {
@@ -51,6 +53,9 @@ function restoreWindow() {
 try {
   const snpTable = { rs123: { snpHints: {} } };
   const calls = [];
+  previousViewRuntime = configureViewRuntime({
+    closeModal: () => calls.push(['bridge-close']),
+  });
   const runtime = {
     _snpTableCache: snpTable,
     closeModal() { calls.push(['close', this === runtime]); },
@@ -123,7 +128,8 @@ try {
       isRecommendationsProductRecsEnabled() === false &&
       await loadRecommendationsCatalogRuntime() === null &&
       await renderRecommendationsDetailSection('missing.slot', {}) === '' &&
-      closeRecommendationsModal() === false &&
+      closeRecommendationsModal() === true &&
+      calls.some(call => call[0] === 'bridge-close') &&
       openRecommendationsChatPanel('No-op') === false &&
       openRecommendationsEmfAssessment() === true &&
       openRecommendationsLocationEditor() === false &&
@@ -139,6 +145,7 @@ try {
       openRecommendationsChatPanel('No-op') === false &&
       registerRecommendationsRuntimeExports({ missingWindowProbe: true }) === false);
 } finally {
+  if (previousViewRuntime?.closeModal) configureViewRuntime(previousViewRuntime);
   restoreWindow();
 }
 

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -419,7 +419,7 @@ return (async function() {
   assert('Supplement source link href is saved URL', savedSuppLink?.getAttribute('href') === 'https://www.example.com/products/a?x=1');
 
   // Verify the optional dashboard widget can be shown after save
-  window.closeModal();
+  viewsModule.closeModal();
   await wait(20);
   window.navigate('dashboard');
   await wait(50);
@@ -459,7 +459,7 @@ return (async function() {
   await wait(50);
   assert('Invalid supplement URL is rejected', (S.importedData.supplements || []).length === beforeInvalidSuppCount);
   assert('Invalid URL supplement not saved', !S.importedData.supplements?.some(s => s.name === '__UI_TEST_BAD_URL__'));
-  window.closeModal();
+  viewsModule.closeModal();
   await wait(20);
 
   const beforeUnsafeSupps = (S.importedData.supplements || []).slice();
@@ -477,7 +477,7 @@ return (async function() {
   const unsafeSuppRow = Array.from(document.querySelectorAll('.supp-list-item')).find(row => row.textContent.includes('__UI_TEST_UNSAFE_SOURCE__'));
   assert('Unsafe imported source URL does not render as link', unsafeSuppRow && !unsafeSuppRow.querySelector('.supp-list-source'));
   S.importedData.supplements = beforeUnsafeSupps;
-  window.closeModal();
+  viewsModule.closeModal();
   await wait(20);
 
   // ═══════════════════════════════════════════════
@@ -510,7 +510,7 @@ return (async function() {
   await wait(50);
   assert('Remove period back to 1 row', document.querySelectorAll('.supp-period-row').length === 1);
 
-  window.closeModal();
+  viewsModule.closeModal();
   await wait(20);
 
   // ═══════════════════════════════════════════════
@@ -548,7 +548,7 @@ return (async function() {
     assert('Value cards have status classes', hasStatus);
 
     // Close
-    window.closeModal();
+    viewsModule.closeModal();
     await wait(20);
     assert('Detail modal closes', !modalOverlay.classList.contains('show'));
   } else {
@@ -598,7 +598,7 @@ return (async function() {
   } finally {
     S.profileDob = originalProfileDob;
     dataModule.invalidateActiveDataCache?.();
-    window.closeModal();
+    viewsModule.closeModal();
     await wait(20);
   }
 
@@ -628,7 +628,7 @@ return (async function() {
   assert('Editor has save button', !!saveBtn);
 
   // Close without saving
-  window.closeModal();
+  viewsModule.closeModal();
   await wait(20);
   assert('Diet editor closes', !modalOverlay.classList.contains('show'));
 
@@ -852,7 +852,7 @@ return (async function() {
     // showDetailModal populates markerRegistry, then openManualEntryForm reads it
     viewsModule.showDetailModal(testMarkerId);
     await wait(50);
-    window.closeModal();
+    viewsModule.closeModal();
     await wait(20);
     viewsModule.openManualEntryForm(testMarkerId);
     await wait(50);
@@ -862,7 +862,7 @@ return (async function() {
     const hasValueInput = !!manualModal?.querySelector('input[type="number"], input[id*="manual"], input[id*="entry"]');
     assert('Manual entry has date input', hasDateInput);
     assert('Manual entry has value input', hasValueInput);
-    window.closeModal();
+    viewsModule.closeModal();
     await wait(20);
   }
 

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -36,7 +36,8 @@ return (async function() {
   const store = await import('../js/wearables-store.js');
   const ah = await import('../js/wearables-apple-health.js');
   const reg = await import('../js/wearable-adapters.js');
-  await import('../js/wearables.js'); // registers window.openWearableDetail / closeModal / renderWearableStrip
+  await import('../js/wearables.js'); // registers window.openWearableDetail / renderWearableStrip
+  const views = await import('../js/views.js');
 
   window._labState.importedData = window._labState.importedData || {};
   const TEST_PROFILE = window._labState.currentProfile || ('__test-wearables-dom-' + Math.random().toString(36).slice(2, 8));
@@ -112,14 +113,14 @@ return (async function() {
   assert('Range toggle persists and re-renders active 6m pill',
     localStorage.getItem('wearable-detail-range') === '6m' &&
     /of last 6 months/.test(document.getElementById('detail-modal')?.textContent || ''));
-  window.closeModal();
+  views.closeModal();
   assert('closeModal clears modal chart instance', !window._labState.chartInstances?.modal);
 
   await window.openWearableDetail('activity_score');
   await new Promise(r => setTimeout(r, 60));
   assert('Rest-mode hint shown on all-zero activity score',
     /Rest Mode/.test(document.getElementById('detail-modal').innerHTML));
-  window.closeModal();
+  views.closeModal();
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
@@ -156,7 +157,7 @@ return (async function() {
     bpChart?.data?.datasets?.find(d => /^Diastolic/.test(d.label))?.data?.length === 3);
   assert('BP manual entries preserve paired sys/dia row value',
     !!document.querySelector('#detail-modal .wearable-manual-entry-val')?.textContent?.includes('120/80'));
-  window.closeModal();
+  views.closeModal();
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
@@ -194,7 +195,7 @@ return (async function() {
     .map(btn => btn.getAttribute('data-wearable-metric'));
   assert('BP modal exposes separate systolic and diastolic source swap targets',
     bpSwapTargets.includes('bp_systolic') && bpSwapTargets.includes('bp_diastolic'), bpSwapTargets.join('|'));
-  window.closeModal();
+  views.closeModal();
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
@@ -221,14 +222,14 @@ return (async function() {
     /Latest\s+121\/79 mmHg/.test(mixedManualPrimaryText)
       && !/Latest\s+124\/80 mmHg/.test(mixedManualPrimaryText)
       && !/Latest\s+125\/79 mmHg/.test(mixedManualPrimaryText), mixedManualPrimaryText);
-  window.closeModal();
+  views.closeModal();
 
   await window.openWearableDetail('bp_diastolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /systolic/i.test(d?.label || '')));
   assert('Opening bp_diastolic normalizes to the paired BP detail view',
     (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /systolic/i.test(l)) &&
     /121\/79/.test(document.getElementById('detail-modal')?.textContent || ''));
-  window.closeModal();
+  views.closeModal();
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
@@ -251,7 +252,7 @@ return (async function() {
   const splitDateText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP latest row does not synthesize a split-date summary pair when no same-date candidate exists',
     /Latest\s+—\s+No same-date pair/.test(splitDateText) && !/Latest\s+130\/78 mmHg/.test(splitDateText), splitDateText);
-  window.closeModal();
+  views.closeModal();
 
   window._labState.importedData.wearableSummary.metrics.bp_diastolic.latestDate = undefined;
   await window.openWearableDetail('bp_systolic');
@@ -259,7 +260,7 @@ return (async function() {
   const missingDateText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP latest row does not synthesize a summary pair when one latest date is missing',
     /Latest\s+—\s+No same-date pair/.test(missingDateText) && !/Latest\s+130\/78 mmHg/.test(missingDateText), missingDateText);
-  window.closeModal();
+  views.closeModal();
 
   await store.clearSource(TEST_PROFILE, 'manual');
   await store.clearSource(TEST_PROFILE, 'withings');
@@ -286,7 +287,7 @@ return (async function() {
     /Latest\s+121\/79 mmHg/.test(manualOnlyText) && !/Latest\s+125\/79 mmHg/.test(manualOnlyText), manualOnlyText);
   assert('BP manual-only fallback chart renders manual sys/dia points',
     (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /^Manual diastolic$/.test(l)));
-  window.closeModal();
+  views.closeModal();
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
@@ -332,7 +333,7 @@ return (async function() {
   await new Promise(r => setTimeout(r, 60));
   const modalSpo2Html = document.getElementById('detail-modal').innerHTML;
   assert('Modal renders SpO2 97 as integer (no .0)', !/97\.0/.test(modalSpo2Html));
-  window.closeModal();
+  views.closeModal();
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
@@ -384,7 +385,7 @@ return (async function() {
     /partial day · in progress/.test(String(tooltipLabel || '')));
   assert('Detail chart tooltip snaps by x-index, not invisible point intersection',
     stepsChart?.options?.interaction?.mode === 'index' && stepsChart.options.interaction.intersect === false);
-  window.closeModal();
+  views.closeModal();
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
@@ -437,7 +438,7 @@ return (async function() {
   assert('Manual overlay tooltip title uses the manual point date, not vendor index 0',
     manualTitle === new Date(todayISO + 'T00:00:00Z').toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' }),
     `title=${manualTitle}`);
-  window.closeModal();
+  views.closeModal();
   delete window._labState.importedData.wearableSummary;
 
   // ═══════════════════════════════════════
@@ -479,7 +480,7 @@ return (async function() {
   const tooltipCarrier = document.querySelector('#detail-modal .wearable-detail-stat[title*="overnight HRV only"]');
   assert('v1.26 P1-2: empty-state row carries the long explanation in title attr',
     !!tooltipCarrier);
-  if (window.closeModal) window.closeModal();
+  views.closeModal();
   window._labState.importedData = _origImported;
 
   console.log(`\n%c Wearables DOM: ${pass} passed, ${fail} failed `, fail > 0 ? 'background:#ef4444;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -92,7 +92,7 @@ return (async function() {
     remaining && remaining.weight == null && remaining.rhr === 62);
 
   // Close any leftover modal
-  if (window.closeModal) window.closeModal();
+  views.closeModal();
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
@@ -119,7 +119,7 @@ return (async function() {
   } else {
     assert('Found delete button on rhr modal', false);
   }
-  if (window.closeModal) window.closeModal();
+  views.closeModal();
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
@@ -159,7 +159,7 @@ return (async function() {
     !!ouraLine?.data?.some(p => p.x === '2026-05-20' && p.y === 61) &&
     !!manualOverlay?.data?.some(p => p.x === oldManualDate && p.y === 57),
     JSON.stringify(window._labState.chartInstances?.modal?.data?.datasets?.map(ds => ({ label: ds.label, n: ds.data?.length }))));
-  if (window.closeModal) window.closeModal();
+  views.closeModal();
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
@@ -202,7 +202,7 @@ return (async function() {
     document.body.click();
     await new Promise(r => setTimeout(r, 100));
   }
-  if (window.closeModal) window.closeModal();
+  views.closeModal();
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
@@ -225,7 +225,7 @@ return (async function() {
     assert('Clicking an overview metric opens the detail modal',
       document.getElementById('modal-overlay')?.classList?.contains('show'));
   }
-  if (window.closeModal) window.closeModal();
+  views.closeModal();
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
@@ -349,7 +349,7 @@ return (async function() {
   assert('Opening another biometric card closes any active BP inline form',
     !document.getElementById('wl-bp-sys') &&
     document.getElementById('modal-overlay')?.classList?.contains('show'));
-  if (window.closeModal) window.closeModal();
+  views.closeModal();
   await new Promise(r => setTimeout(r, 200));
 
   // ─────────────────────────────────────────────────────────

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -598,8 +598,8 @@
     'hasCardContent','escapeAttr','loadScriptOnce'
   ];
 
-  // views.js retains only the two core shell contracts on window.
-  const viewsLegacyExports = ['navigate','closeModal'];
+  // views.js retains only the core navigate shell contract on window.
+  const viewsLegacyExports = ['navigate'];
   const viewsFacadeModuleExports = [
     'getInitialView','showDashboard','showLabs','showBiologyScoresLens','showGenomeLens',
     'showBodyLens','showInsightLens','showRecommendations','openRecommendationDetail',
@@ -617,7 +617,7 @@
     'revertRefRange','openManualEntryForm','saveManualEntry','saveAndAddAnotherManualEntry',
     'openCreateMarkerModal','pickNewCatIcon','saveCustomMarker','deleteMarkerValue',
     'deleteCustomMarker','editMarkerValue','revertMarkerValue','editValueNote',
-    'deleteValueNote','toggleMarkerNoteEditor','saveMarkerNote','deleteMarkerNote',
+    'deleteValueNote','toggleMarkerNoteEditor','saveMarkerNote','deleteMarkerNote','closeModal',
     'rememberModalTrigger','showCompare','setCompareDate1','setCompareDate2','updateCompare',
     'swapCompareDates','renderCompareTable','showCorrelations','populateCorrelationOptions',
     'showCorrelationDropdown','filterCorrelationOptions','toggleCorrelationMarker',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.207';
+self.APP_VERSION = '1.10.208';


### PR DESCRIPTION
## Summary
- remove `closeModal` from the final `views.js` window facade, leaving only `navigate`
- route modal lifecycle consumers through the module-scoped view runtime bridge while preserving explicit browser overrides
- migrate direct browser-test callers to the `views.js` module API and update the onion-origin fixture for the new bridge dependency
- bump the app cache version to `1.10.208`

## Validation
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test` (398 passed)
- targeted Playwright regression specs (8 passed)
- `./run-tests.sh` (124 module checks, 398 unit tests, 18 origin guards, 352 Playwright tests; responsive matrix 472/472)