### PR TITLE
Make navigate module-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Shared prompt block in `js/lighting-hardware-caveats.js` — load-bearing instru
 
 Storage: per-row CRDT for row-level (sun session, device, room, screen, audit, measurement); singleton fields for aggregates (`lightDailyVerdicts[date]`, `lightEnvironment.burdenAI`, `channelMixAI`, `sunDefaults.aiAnalysis`). Auto-fire on completion events (session stop, save, finish), manual on edit-flurry / aggregates.
 
-Element-anchor scroll preservation (`createNavigate()` in `views-router.js`, exposed as `window.navigate` by `views.js`) restores the focused element's viewport-top after a rebuild — replaces an earlier pixel-based attempt that broke when content above the viewport changed height. Force layout via `void document.body.offsetHeight` before reading rect, then RAF re-apply during the stabilization window.
+Element-anchor scroll preservation (`createNavigate()` in `views-router.js`, exported through `views.js` and registered in `views-runtime-bridge.js`) restores the focused element's viewport-top after a rebuild — replaces an earlier pixel-based attempt that broke when content above the viewport changed height. Force layout via `void document.body.offsetHeight` before reading rect, then RAF re-apply during the stabilization window.
 
 Canonical map of AI vs deterministic surfaces: https://docs.getbased.health/developers/ai-surfaces-map (was `docs/guide/ai-overview.md` in the retired VitePress site). Architecture memo: `memory/project_ai_verdict_arc_2026_05_06.md`.
 

--- a/js/biology-score-context-ai.js
+++ b/js/biology-score-context-ai.js
@@ -14,6 +14,7 @@ import {
 import { callClaudeAPI, hasAIProvider, isAIPaused } from './api.js';
 import { state } from './state.js';
 import { escapeAttr, escapeHTML, hashString } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const biologyScoreContextAIDeps = {
   callClaudeAPI,
@@ -355,14 +356,15 @@ export function installBiologyScoreContextAIDelegates() {
     event.preventDefault();
     try {
       const w = /** @type {any} */ (window);
+      const navigate = w.navigate || getViewRuntimeFunction('navigate');
       if (action === 'analyze-context-ai') {
         el.setAttribute('disabled', 'true'); el.textContent = 'Analyzing…';
         const review = await generateBiologyScoreContextReview(getActiveData());
-        await saveBiologyScoreContextReview(review); w.navigate?.('biology-scores');
+        await saveBiologyScoreContextReview(review); navigate?.('biology-scores');
       } else if (action === 'apply-context-ai') {
-        await applyBiologyScoreContextFlag(el.dataset.contextFlag || ''); w.showNotification?.('Context flag applied', 'success'); w.navigate?.('biology-scores');
+        await applyBiologyScoreContextFlag(el.dataset.contextFlag || ''); w.showNotification?.('Context flag applied', 'success'); navigate?.('biology-scores');
       } else {
-        await dismissBiologyScoreContextFlag(el.dataset.contextFlag || ''); w.showNotification?.('Context suggestion dismissed', 'info'); w.navigate?.('biology-scores');
+        await dismissBiologyScoreContextFlag(el.dataset.contextFlag || ''); w.showNotification?.('Context suggestion dismissed', 'info'); navigate?.('biology-scores');
       }
     } catch (err) { (/** @type {any} */ (window)).showNotification?.(err?.message || 'Context AI failed', 'error'); }
     finally { el.removeAttribute('disabled'); }

--- a/js/category-customization-runtime.js
+++ b/js/category-customization-runtime.js
@@ -2,6 +2,7 @@
 // category-customization-runtime.js - Browser runtime hooks for category customization.
 
 import { showPromptDialog } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const categoryCustomizationRuntimeDeps = { showPromptDialog };
 
@@ -31,7 +32,8 @@ function getRuntimeScope() {
 function getRuntimeFunction(name) {
   const runtime = getRuntimeScope();
   const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : null;
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' && typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
 }
 
 /**

--- a/js/client-list-runtime.js
+++ b/js/client-list-runtime.js
@@ -3,6 +3,7 @@
 
 import { hasAIProvider } from './api.js';
 import { showNotification } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const clientListRuntimeDeps = { showNotification };
 
@@ -28,7 +29,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' && typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
 }
 
 /**

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -130,12 +130,19 @@ const contextCardEditorActions = /** @type {Record<string, () => void>} */ ({
 });
 const contextCardWindow = /** @type {Window & typeof globalThis & {
   closeModal?: () => void,
+  navigate?: (category: string) => void,
 }} */ (typeof window !== 'undefined' ? window : {});
 function closeContextCardModal() {
   const closeModal = typeof contextCardWindow.closeModal === 'function'
     ? contextCardWindow.closeModal.bind(contextCardWindow)
     : (typeof window !== 'undefined' ? getViewRuntimeFunction('closeModal') : null);
   closeModal?.();
+}
+function navigateContextCardView(category) {
+  const navigate = typeof contextCardWindow.navigate === 'function'
+    ? contextCardWindow.navigate.bind(contextCardWindow)
+    : (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
+  navigate?.(category);
 }
 const contextCardRuntimeDeps = {
   openEMFAssessmentEditor,
@@ -433,7 +440,7 @@ export function saveAndRefresh(msg, field) {
   // update until a reload or navigation. Mirrors the BroadcastChannel
   // handler in crypto.js:initBroadcastChannel. See #123.
   const activeNav = /** @type {HTMLElement | null} */ (document.querySelector('.nav-item.active'));
-  if (typeof appWindow.navigate === 'function') appWindow.navigate(activeNav?.dataset.category || 'dashboard');
+  navigateContextCardView(activeNav?.dataset.category || 'dashboard');
   // Refresh health dots for the saved card (fingerprint will have changed).
   // Must run after navigate() so the ctx-dot-* elements exist in the new DOM.
   loadContextHealthDots();

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -6,15 +6,21 @@ import { showNotification, showConfirmDialog, escapeAttr, escapeHTML } from './u
 import { profileStorageKey } from './profile.js';
 import { getBlob, setBlob, deleteBlob, shouldUseBlob } from './blob-storage.js';
 import { ensureImportedArray } from './data-merge.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
   __WEARABLES_TEST?: boolean,
   buildSidebar: () => void,
-  navigate: (view: string) => void,
+  navigate?: (view: string) => void,
 }} */ (typeof window !== 'undefined' ? window : {});
 const cryptoProfileDeps = {
   migrateProfileData: /** @type {null | ((data: any) => void)} */ (null),
 };
+
+function navigateCryptoView(view) {
+  const navigate = appWindow.navigate || (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
+  navigate?.call(appWindow, view);
+}
 
 export function configureCryptoProfileDeps(deps = {}) {
   const previous = { ...cryptoProfileDeps };
@@ -1013,7 +1019,7 @@ export function initBroadcastChannel() {
           // buildSidebar resets the .active class to Dashboard, so source
           // the target view from state.currentView (kept in sync by
           // navigate) rather than re-reading the stale DOM.
-          appWindow.navigate(state.currentView || 'dashboard');
+          navigateCryptoView(state.currentView || 'dashboard');
         } catch { /* ignore parse errors */ }
       }
     }

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -9,6 +9,7 @@ import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { endTour } from './tour.js';
 import { escapeAttr, escapeHTML, showConfirmDialog, showNotification } from './utils.js';
 import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   buildCycleCoverage,
   normalizeCyclePeriods,
@@ -66,6 +67,14 @@ const appWindow = /** @type {Window & typeof globalThis & {
 
 let pendingCycleImport = null;
 let cycleImportDelegatesInstalled = false;
+
+function navigateCycleImportView(category) {
+  const navigate = typeof appWindow.navigate === 'function'
+    ? appWindow.navigate.bind(appWindow)
+    : (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
+  navigate?.(category);
+  return typeof navigate === 'function';
+}
 
 async function openCycleEditorFromImport() {
   const { openMenstrualCycleEditor } = await import('./cycle.js');
@@ -668,10 +677,10 @@ async function handleCycleImportAction(event) {
       });
       showNotification(`Cycle import complete - ${result.periods} periods, ${result.observations} local observations`, 'success', 1200);
       closeCycleImportPreview(result);
-      appWindow.navigate?.('body');
+      const didNavigate = navigateCycleImportView('body');
       setTimeout(() => {
         openCycleEditorFromImport().catch(error => showNotification(`Could not reopen cycle history: ${error.message}`, 'error'));
-      }, appWindow.navigate ? 1550 : 0);
+      }, didNavigate ? 1550 : 0);
     } catch (err) {
       target.removeAttribute('disabled');
       showNotification(`Cycle import failed: ${err.message}`, 'error');
@@ -713,7 +722,7 @@ export async function handleCycleImportFile(file) {
       const cycleSuffix = result.cycleImport ? ` + ${result.cycleImport.periods} cycle periods` : '';
       showNotification(`Apple Health imported - ${result.rows} days${cycleSuffix}`, 'success', 3000);
       if (result.cycleError) showNotification(`Cycle import skipped: ${result.cycleError}`, 'info', 5000);
-      appWindow.navigate?.('dashboard');
+      navigateCycleImportView('dashboard');
       return true;
     }
     parsed = await parseCycleImportContext(context);

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -1,5 +1,4 @@
 // @ts-check
-// cycle.js — Menstrual cycle tracking, phase calculation, editor, alerts
 import { state } from './state.js';
 import { PERIOD_SYMPTOMS } from './constants.js';
 import { escapeHTML, showNotification, showConfirmDialog, linearRegression } from './utils.js';
@@ -24,13 +23,14 @@ const CYCLE_ICONS = {
 };
 const appWindow = /** @type {Window & typeof globalThis & {
   closeModal?: () => void,
-  navigate: (category: string) => void,
+  navigate?: (category: string) => void,
   __cycleDelegatesBound?: boolean
 }} */ (typeof window !== 'undefined' ? window : {});
 function closeCycleModal() {
   const closeModal = appWindow.closeModal || (typeof window !== 'undefined' ? getViewRuntimeFunction('closeModal') : null);
   closeModal?.call(appWindow);
 }
+function navigateCycleView(category) { (appWindow.navigate || (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null))?.call(appWindow, category); }
 function cycleActionAttrs(action, extra = '') {
   return `data-cycle-action="${action}"${extra ? ` ${extra}` : ''}`;
 }
@@ -583,7 +583,7 @@ export function saveMenstrualCycle() {
   saveImportedData();
   closeCycleModal();
   const activeNav = document.querySelector(".nav-item.active");
-  appWindow.navigate(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
+  navigateCycleView(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
   showNotification('Menstrual cycle profile saved', 'success');
   // Auto-trigger cycle tour after dashboard re-renders
   setTimeout(() => { startCycleTour(true); }, 600);
@@ -594,7 +594,7 @@ export async function clearMenstrualCycle() {
     catch (error) { showNotification(`Menstrual cycle data could not be cleared: ${error.message}`, 'error'); return; }
     closeCycleModal();
     const activeNav = document.querySelector(".nav-item.active");
-    appWindow.navigate(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
+    navigateCycleView(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
     showNotification('Menstrual cycle data cleared', 'info');
   }
 }

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -16,6 +16,7 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
+  if (!runtime) return null;
   if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
   return getViewRuntimeFunction(name);
 }

--- a/js/data.js
+++ b/js/data.js
@@ -40,12 +40,17 @@ export {
  * @typedef {[MarkerValueGetter | 'age' | 'crp', number, number, boolean, number | null, 'ceil' | 'floor' | null, (number | undefined)?]} BortzFeature
  * @typedef {{
  *   buildSidebar: (data?: unknown) => void,
- *   navigate: (route?: string, data?: unknown) => void,
+ *   navigate?: (route?: string, data?: unknown) => void,
  *   showDetailModal?: (id: string) => void,
  * }} DataWindowHooks
  */
 
 const dataWindow = /** @type {Window & typeof globalThis & DataWindowHooks} */ (typeof window !== 'undefined' ? window : {});
+
+function navigateDataView(route, data) {
+  const navigate = dataWindow.navigate || (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
+  navigate?.call(dataWindow, route, data);
+}
 
 /** @type {{ invalidateLabContextCache: (() => void) | null }} */
 const dataContextDeps = {
@@ -848,7 +853,7 @@ export function setDateRange(range) {
   // state.currentView (set by navigate) rather than the DOM, since the
   // DOM's active class has just been clobbered by buildSidebar.
   dataWindow.buildSidebar();
-  dataWindow.navigate(state.currentView || 'dashboard');
+  navigateDataView(state.currentView || 'dashboard');
 }
 
 export function renderChartLayersDropdown() {
@@ -920,21 +925,21 @@ export function setSuppOverlay(mode) {
   state.suppOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'suppOverlay'), state.suppOverlayMode);
   const activeCat = _getActiveNavCategory();
-  dataWindow.navigate(activeCat);
+  navigateDataView(activeCat);
 }
 
 export function setNoteOverlay(mode) {
   state.noteOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'noteOverlay'), state.noteOverlayMode);
   const activeCat = _getActiveNavCategory();
-  dataWindow.navigate(activeCat);
+  navigateDataView(activeCat);
 }
 
 export function setPhaseOverlay(mode) {
   state.phaseOverlayMode = mode === 'off' ? 'off' : 'on';
   localStorage.setItem(profileStorageKey(state.currentProfile, 'phaseOverlay'), state.phaseOverlayMode);
   const activeCat = _getActiveNavCategory();
-  dataWindow.navigate(activeCat);
+  navigateDataView(activeCat);
 }
 
 export function recalculateHOMAIR(entry) {
@@ -968,7 +973,7 @@ export function switchUnitSystem(system) {
   const data = getActiveData();
   dataWindow.buildSidebar(data);
   updateHeaderDates(data);
-  dataWindow.navigate(state.currentView || 'dashboard', data);
+  navigateDataView(state.currentView || 'dashboard', data);
   const showDetailModal = dataWindow.showDetailModal || getViewRuntimeFunction('showDetailModal');
   if (openId && showDetailModal) {
     showDetailModal(openId);
@@ -1032,7 +1037,7 @@ export function switchRangeMode(mode) {
     if (token !== _rangeModeRefreshToken || state.rangeMode !== nextMode) return;
     const data = getActiveData();
     dataWindow.buildSidebar(data);
-    dataWindow.navigate(state.currentView || 'dashboard', data);
+    navigateDataView(state.currentView || 'dashboard', data);
   const showDetailModal = dataWindow.showDetailModal || getViewRuntimeFunction('showDetailModal');
   if (openId && state._activeDetailMarkerId === openId && showDetailModal) {
     showDetailModal(openId);

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -6,6 +6,7 @@ import { isImportRunning } from './pdf-import-progress.js';
 import { getLatitudeFromLocation } from './profile.js';
 import { isDebugMode, showConfirmDialog } from './utils.js';
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const dnaRuntimeDeps = { getLatitudeFromLocation, isDebugMode, isImportRunning, showConfirmDialog };
 
@@ -34,7 +35,9 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' && typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
 }
 
 /** @returns {boolean} */

--- a/js/dna-window-bindings.js
+++ b/js/dna-window-bindings.js
@@ -1,6 +1,8 @@
 // @ts-check
 // dna-window-bindings.js - legacy browser globals for DNA modules
 
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+
 export function installDNAWindowBindings(win, deps) {
   if (!win) return;
   const { state, saveImportedData, buildGeneticsContext, getRelevantSNPs, ...bindings } = deps;
@@ -12,7 +14,10 @@ export function installDNAWindowBindings(win, deps) {
     _saveAndRefresh: async () => {
       if (!await saveImportedData()) return false;
       if (win.buildSidebar) try { win.buildSidebar(); } catch (e) {}
-      if (win.navigate) win.navigate('dashboard');
+      const navigate = win.navigate || (typeof window !== 'undefined' && win === window
+        ? getViewRuntimeFunction('navigate')
+        : null);
+      navigate?.call(win, 'dashboard');
       return true;
     },
   });

--- a/js/export.js
+++ b/js/export.js
@@ -9,6 +9,7 @@ import { encryptedGetItem, getEncryptionEnabled, encryptedRemoveItem } from './c
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
 import { setLabEntryMarker } from './lab-entry.js';
 import { importDataJSON } from './export-import.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   generateReportAISummary as generateReportAISummaryImpl,
 } from './export-report.js';
@@ -543,7 +544,8 @@ export async function loadDemoData(sex = 'male') {
         const w = /** @type {any} */ (window);
         if (w.buildSidebar) w.buildSidebar();
         updateHeaderDates();
-        if (w.navigate && state.currentView === 'biology-scores') w.navigate('biology-scores');
+        const navigate = w.navigate || getViewRuntimeFunction('navigate');
+        if (navigate && state.currentView === 'biology-scores') navigate.call(w, 'biology-scores');
       }
     } catch (_) { /* demo Biology Scores post-import unlock is best-effort */ }
   } catch (err) {

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -6,6 +6,7 @@ import { escapeHTML, escapeAttr } from './utils.js';
 import { profileStorageKey } from './profile.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const LENS_PAGE_ORDER_VERSION = 1;
 
@@ -24,7 +25,7 @@ function lensPageRuntime() {
 }
 
 function callLensPageRuntime(name, ...args) {
-  const fn = lensPageRuntime()[name];
+  const fn = lensPageRuntime()[name] || (name === 'navigate' ? getViewRuntimeFunction(name) : null);
   if (typeof fn === 'function') fn(...args);
 }
 

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -52,6 +52,7 @@ import {
 import { installLightEnvActionDelegates, lightEnvActionAttrs } from './light-env-actions.js';
 import { SCREEN_HOURS_BUCKETS, renderScreenCard } from './light-env-screen-ui.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 export { getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit } from './light-env-audits.js';
 export {
@@ -553,8 +554,11 @@ function refreshLightEnvironmentUI(options = {}) {
   refreshLightEnvironmentAssessment();
   if (options.scrollAnchor) scrollLightEnvironmentAssessmentTo(options.scrollAnchor, options.fallbackScrollAnchor);
   else if (priorScrollTop) setLightEnvironmentAssessmentScrollTop(priorScrollTop);
-  if (typeof globalThis.navigate === 'function' && state.currentView === 'light') {
-    globalThis.navigate('light', options.scrollAnchor ? { scrollAnchor: options.scrollAnchor } : undefined);
+  const navigate = typeof globalThis.navigate === 'function'
+    ? globalThis.navigate
+    : (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
+  if (navigate && state.currentView === 'light') {
+    navigate.call(globalThis, 'light', options.scrollAnchor ? { scrollAnchor: options.scrollAnchor } : undefined);
   }
 }
 

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -28,6 +28,7 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
+  if (!runtime) return null;
   if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
   return getViewRuntimeFunction(name);
 }

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -38,7 +38,8 @@ function getNavRuntimeScope() {
 function getNavRuntimeFunction(name) {
   const runtime = getNavRuntimeScope();
   const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
 }
 
 /**

--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // onboarding-view-runtime.js - Browser runtime adapters for dashboard onboarding hooks.
 
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -13,7 +15,10 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 /** @param {unknown} data */

--- a/js/pdf-import-review-runtime.js
+++ b/js/pdf-import-review-runtime.js
@@ -2,6 +2,7 @@
 // pdf-import-review-runtime.js - Browser runtime adapters for import review state.
 
 import { updateHeaderDates } from './data.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -32,7 +33,8 @@ export function configurePdfImportReviewRuntimeDeps(deps = {}) {
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
   const fn = runtime?.[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : null;
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' && runtime ? getViewRuntimeFunction(name) : null;
 }
 
 export function clearPendingImportRuntime() {

--- a/js/settings.js
+++ b/js/settings.js
@@ -39,6 +39,7 @@ import {
 import { loadPdfImport } from './import-loader.js';
 import { startGuidedTour } from './tour.js';
 import { getActiveProfileId } from './profile.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   confirmDisablePIIReview,
   refreshDataEntriesSection,
@@ -297,7 +298,8 @@ function applySettingsToggle(actionEl) {
   const checked = actionEl instanceof HTMLInputElement && actionEl.checked;
   if (action === 'set-product-recs') {
     setProductRecsEnabled(checked);
-    settingsWindow.navigate?.('dashboard');
+    const navigate = settingsWindow.navigate || getViewRuntimeFunction('navigate');
+    navigate?.call(settingsWindow, 'dashboard');
     return true;
   }
   if (action === 'set-debug-mode') {

--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -2,6 +2,7 @@
 // sun-defaults-runtime.js - Browser runtime adapters for Light setup defaults.
 
 import { getProfileLocation } from './profile.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const sunDefaultsRuntimeDeps = { getProfileLocation };
 
@@ -20,7 +21,10 @@ function getRuntimeWindow() {
 /** @param {string} name */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return typeof runtime?.[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 /**

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -42,7 +42,7 @@ export {
 
 const appWindow = /** @type {Window & typeof globalThis & {
   closeModal?: () => void,
-  navigate: (category: string) => void
+  navigate?: (category: string) => void
 }} */ (window);
 
 function closeSupplementModal() {
@@ -50,6 +50,13 @@ function closeSupplementModal() {
     ? appWindow.closeModal.bind(appWindow)
     : getViewRuntimeFunction('closeModal');
   closeModal?.();
+}
+
+function navigateSupplementView(category) {
+  const navigate = typeof appWindow.navigate === 'function'
+    ? appWindow.navigate.bind(appWindow)
+    : getViewRuntimeFunction('navigate');
+  navigate?.(category);
 }
 
 /**
@@ -695,7 +702,7 @@ export function deleteSupplement(idx) {
   } else {
     closeSupplementModal();
     const activeNav = document.querySelector(".nav-item.active");
-    appWindow.navigate(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
+    navigateSupplementView(activeNav instanceof HTMLElement ? activeNav.dataset.category || "dashboard" : "dashboard");
   }
 }
 

--- a/js/sync-pull-active-refresh-runtime.js
+++ b/js/sync-pull-active-refresh-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // sync-pull-active-refresh-runtime.js - Browser runtime adapters for active sync pull refresh hooks.
 
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -13,7 +15,10 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 export function refreshPulledChatRuntime() {

--- a/js/views-router-runtime.js
+++ b/js/views-router-runtime.js
@@ -2,6 +2,7 @@
 // views-router-runtime.js - Browser runtime adapters for routing scroll/window hooks.
 
 import { syncImportStatusFab } from './pdf-import-progress.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const viewsRouterRuntimeDeps = { syncImportStatusFab };
 
@@ -23,7 +24,10 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 export function getViewportScrollPosition() {

--- a/js/views.js
+++ b/js/views.js
@@ -306,6 +306,7 @@ configureCompareCorrelationViews({
 
 configureViewRuntime({
   getInitialView,
+  navigate,
   showDashboard,
   showLabs,
   showBiologyScoresLens,
@@ -389,6 +390,3 @@ configureViewRuntime({
   renderCorrelationChips,
   renderCorrelationChart,
 });
-
-// Core shell contract retained while its remaining integrations migrate.
-Object.assign(window, { navigate });

--- a/js/wearables-connect-runtime.js
+++ b/js/wearables-connect-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // wearables-connect-runtime.js - Browser runtime adapters for wearable connect orchestration.
 
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -13,7 +15,10 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 export function getWearableOAuthSearchParamsRuntime() {

--- a/js/wearables-settings-runtime.js
+++ b/js/wearables-settings-runtime.js
@@ -2,6 +2,7 @@
 // wearables-settings-runtime.js - Browser runtime adapters for wearable settings hooks.
 
 import { showConfirmDialog } from './utils.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const wearableSettingsRuntimeDeps = { showConfirmDialog };
 
@@ -27,7 +28,10 @@ function getRuntimeWindow() {
  */
 function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
+  if (!runtime) return null;
+  const fn = runtime[name];
+  if (typeof fn === 'function') return fn.bind(runtime);
+  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 export function closeWearableSettingsModal() {

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -77,7 +77,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
       state.profileSex = originalSex;
       state.profileDob = originalDob;
       window.renameCategory = originalRenameCategory;
-      if (originalView) window.navigate?.(originalView);
+      if (originalView) viewsModule.navigate(originalView);
     }
   });
 

--- a/tests/playwright/biology-scores-dashboard-lens.spec.js
+++ b/tests/playwright/biology-scores-dashboard-lens.spec.js
@@ -2,10 +2,7 @@ import { expect, test } from './coverage-fixture.js';
 
 async function prepareDemoProfile(page) {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.navigate === 'function'
-      && !!window._labState
-  );
+  await page.waitForFunction(() => !!window._labState);
 
   await page.evaluate(async () => {
     const [{ getActiveProfileId }, dataModule] = await Promise.all([
@@ -43,7 +40,7 @@ test('dashboard renders Biological Coherence hero and domain rows', async ({ pag
   await prepareDemoProfile(page);
 
   await page.evaluate(async () => {
-    window.navigate?.('dashboard');
+    (await import('/js/views.js')).navigate('dashboard');
     await new Promise(r => setTimeout(r, 300));
   });
 
@@ -65,7 +62,7 @@ test('dashboard coherence domain row navigates to Biology Scores lens and scroll
   await prepareDemoProfile(page);
 
   const targetScoreId = await page.evaluate(async () => {
-    window.navigate?.('dashboard');
+    (await import('/js/views.js')).navigate('dashboard');
     await new Promise(r => setTimeout(r, 300));
     const row = document.querySelector('[data-widget-id="biology-score-biologicalCoherence"] .bc-micro-domain[data-biology-score-id]');
     if (!row) throw new Error('No coherence domain row found');
@@ -88,7 +85,7 @@ test('dashboard individual biology score widget is clickable and navigates to it
   await page.evaluate(async () => {
     const { showDashboardWidget } = await import('/js/dashboard-widgets.js');
     showDashboardWidget?.('biology-score-metabolicFlexibility', { force: true });
-    window.navigate?.('dashboard');
+    (await import('/js/views.js')).navigate('dashboard');
     await new Promise(r => setTimeout(r, 300));
     const widget = document.querySelector('[data-widget-id="biology-score-metabolicFlexibility"]');
     const clickTarget = widget?.querySelector('[data-biology-score-action="jump-to-domain"]');
@@ -106,7 +103,7 @@ test('Biology Scores lens renders coherence hero with dashboard toggle and score
   await prepareDemoProfile(page);
 
   await page.evaluate(async () => {
-    window.navigate?.('biology-scores');
+    (await import('/js/views.js')).navigate('biology-scores');
     await new Promise(r => setTimeout(r, 500));
   });
 
@@ -124,7 +121,7 @@ test('dashboard domain rows without primaryScoreId get no-jump visual cue', asyn
   await prepareDemoProfile(page);
 
   await page.evaluate(async () => {
-    window.navigate?.('dashboard');
+    (await import('/js/views.js')).navigate('dashboard');
     await new Promise(r => setTimeout(r, 300));
   });
 

--- a/tests/playwright/browser-script-runner.js
+++ b/tests/playwright/browser-script-runner.js
@@ -27,7 +27,7 @@ export async function runBrowserScript(page, testPath, options = {}) {
   try {
     if (options.viewport) await page.setViewportSize(options.viewport);
     await page.goto('/app', { waitUntil: 'load' });
-    await page.waitForFunction(() => window._labState && typeof window.navigate === 'function', null, {
+    await page.waitForFunction(() => window._labState && document.getElementById('main-content'), null, {
       timeout: options.readyTimeout ?? 15_000,
     });
 

--- a/tests/playwright/cycle-import-browser-coverage.spec.js
+++ b/tests/playwright/cycle-import-browser-coverage.spec.js
@@ -319,7 +319,7 @@ test('Body cycle action opens the contextual cycle picker', async ({ page }, tes
     localStorage.setItem(`labcharts-${id}-tour`, '1');
     localStorage.setItem(`labcharts-${id}-cycleTour`, '1');
     endTour({ openEmptyChat: false });
-    window.navigate('body');
+    (await import('/js/views.js')).navigate('body');
     await new Promise(resolve => setTimeout(resolve, 150));
     endTour({ openEmptyChat: false });
     window.closeMobileSidebar?.();

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -2,7 +2,7 @@ import { expect, test } from './coverage-fixture.js';
 
 test('dashboard widget delegated actions cover organize, picker, biometrics, and body actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.navigate === 'function');
+  await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
     const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, viewsModule] = await Promise.all([
@@ -46,7 +46,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
 
       viewsModule.closeDashboardWidgetPicker?.();
       viewsModule.toggleDashboardOrganizeMode?.(false);
-      window.navigate?.('dashboard');
+      viewsModule.navigate('dashboard');
       await delay(100);
 
       const customizeBtn = document.querySelector('.dashboard-sticky-actions [data-dashboard-widget-action="toggle-organize"]');
@@ -127,7 +127,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       };
       localStorage.setItem(biometricSelectionKey, JSON.stringify(['bp_systolic', 'rhr']));
       viewsModule.addDashboardBiometricMetric?.('rhr');
-      window.navigate?.('dashboard');
+      viewsModule.navigate('dashboard');
       await delay(250);
 
       const biometricWidget = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
@@ -235,7 +235,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       else if (state.importedData) delete state.importedData.wearableConnections;
       viewsModule.closeDashboardWidgetPicker?.();
       viewsModule.toggleDashboardOrganizeMode?.(false);
-      if (originalView) window.navigate?.(originalView);
+      if (originalView) viewsModule.navigate(originalView);
     }
   });
 
@@ -246,9 +246,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
 
 test('dashboard widget state transitions cover layout, recommendations, and picker branches', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.navigate === 'function'
-  );
+  await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
@@ -396,7 +394,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const readJson = key => JSON.parse(localStorage.getItem(key) || '[]');
     const dashboardWidget = id => document.querySelector(`.dashboard-widget[data-widget-id="${id}"]`);
 
-    window.navigate('dashboard');
+    viewsModule.navigate('dashboard');
     const recCardsHydrated = await waitFor(() =>
       document.querySelectorAll('.dashboard-widget[data-widget-id="recommendations"] .rec-next-card').length > 0
     );
@@ -415,7 +413,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     await delay(100);
     const bookmarkStored = firstRecId && readJson(recSavedKey).includes(firstRecId);
 
-    window.navigate('recommendations');
+    viewsModule.navigate('recommendations');
     const recommendationsPageRenders = await waitFor(() =>
       document.querySelectorAll('#recommendations-page .rec-next-card').length > 0
     );
@@ -428,7 +426,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     viewsModule.saveRecommendation?.(firstRecId, false);
 
     viewsModule.resetDashboardWidgets();
-    window.navigate('dashboard');
+    viewsModule.navigate('dashboard');
     await waitFor(() => dashboardWidget('focus'));
     viewsModule.moveDashboardWidget('focus', 1);
     await delay(100);
@@ -484,10 +482,11 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       removedFromLens = readPrefs().hidden.includes('alerts')
         && lensNavigateCalls.filter(route => route === 'labs').length >= 2;
     } finally {
-      window.navigate = realNavigate;
+      if (realNavigate) window.navigate = realNavigate;
+      else delete window.navigate;
     }
     state.currentView = 'dashboard';
-    window.navigate('dashboard');
+    viewsModule.navigate('dashboard');
     await waitFor(() => dashboardWidget('focus') || document.querySelector('.dashboard-widget'));
 
     localStorage.setItem(biometricKey, JSON.stringify([]));
@@ -515,7 +514,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       && !document.getElementById('dashboard-widget-picker-overlay');
 
     viewsModule.resetDashboardWidgets();
-    window.navigate('dashboard');
+    viewsModule.navigate('dashboard');
     await waitFor(() => dashboardWidget('focus') && dashboardWidget('spotlight'));
     viewsModule.toggleDashboardOrganizeMode(true);
     await waitFor(() => document.querySelector('.dashboard-widgets.is-organizing'));
@@ -562,6 +561,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     };
     } finally {
       if (realNavigate && window.navigate !== realNavigate) window.navigate = realNavigate;
+      else if (!realNavigate) delete window.navigate;
       viewsModule.closeDashboardWidgetPicker?.();
       viewsModule.toggleDashboardOrganizeMode?.(false);
       document.getElementById('dashboard-widget-picker-overlay')?.remove();

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -11,7 +11,7 @@ async function prepareApp(page) {
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.navigate === 'function');
+  await page.waitForFunction(() => !!window._labState);
 }
 
 test('lens page shell default dashboard deps render fallback widgets', async ({ page }) => {
@@ -55,12 +55,13 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
   await prepareApp(page);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, shell, profile, contextCardsRuntime] = await Promise.all([
+    const [{ state }, dataModule, shell, profile, contextCardsRuntime, views] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/lens-page-shell.js'),
       import('/js/profile.js'),
       import('/js/context-cards-runtime.js'),
+      import('/js/views.js'),
     ]);
     const originalView = state.currentView;
     const originalReimportDNA = window.reimportDNA;
@@ -94,7 +95,7 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       }
 
       localStorage.removeItem(labsOrderKey);
-      window.navigate?.('labs');
+      views.navigate('labs');
       await delay(120);
 
       const widgets = document.querySelector('.lens-page-widgets[data-lens-route="labs"]');
@@ -157,10 +158,11 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       window.openSettingsModal = originalOpenSettings;
       window.openChatPanel = originalOpenChat;
       shell.configureLensPageShell(restoreShell);
-      window.navigate = originalNavigate;
+      if (originalNavigate) window.navigate = originalNavigate;
+      else delete window.navigate;
       if (savedLabsOrder == null) localStorage.removeItem(labsOrderKey);
       else localStorage.setItem(labsOrderKey, savedLabsOrder);
-      if (originalView) originalNavigate?.(originalView);
+      if (originalView) views.navigate(originalView);
     }
   });
 

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -6,7 +6,7 @@ function moduleUrl(path) {
 
 test('Light page view delegates session, link, channel, and prompt actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.navigate === 'function');
+  await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
     const { configureLightPageView, renderDashboardLightChannelPills, renderLightSessionLogActions } = await import('/js/light-page-view.js');

--- a/tests/playwright/openrouter-settings.spec.js
+++ b/tests/playwright/openrouter-settings.spec.js
@@ -1,9 +1,18 @@
 import { expect, test } from './coverage-fixture.js';
 
 test('OpenRouter provider controls render from Settings AI', async ({ page }) => {
+  await page.addInitScript(() => {
+    const profileId = localStorage.getItem('labcharts-active-profile') || 'default';
+    localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
+    localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
+  });
   await page.goto('/app', { waitUntil: 'load' });
 
   await page.evaluate(() => {
+    window.endTour?.();
+    document.getElementById('tour-overlay')?.remove();
+    document.getElementById('tour-spotlight')?.remove();
+    document.getElementById('tour-tooltip')?.remove();
     if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
     window.openSettingsModal('ai');
   });

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -115,7 +115,6 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
     await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
     await page.waitForFunction(
       () => window._labState
-        && typeof window.navigate === 'function'
         && typeof window.openSunSessionDetail === 'function'
         && typeof window.openDeviceSessionDetail === 'function',
       null,
@@ -166,7 +165,7 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
         else el.remove();
       });
       await saveImportedData({ immediate: true });
-      window.navigate('dashboard');
+      (await import('/js/views.js')).navigate('dashboard');
     }, { profileId: PROFILE_ID, imported: importedData });
     return { context, page, label };
   } catch (error) {
@@ -325,7 +324,7 @@ async function markerModalSnapshot(page) {
 }
 
 async function navigateLight(page) {
-  await page.evaluate(() => window.navigate('light'));
+  await page.evaluate(async () => (await import('/js/views.js')).navigate('light'));
   await page.waitForFunction(() => window._labState.currentView === 'light', null, { timeout: 5000 });
 }
 

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -45,8 +45,7 @@ function delay(ms) {
 
 async function waitForApp(page) {
   await page.waitForFunction(
-    () => typeof window.navigate === 'function'
-      && window._labState
+    () => window._labState
       && typeof window.buildSidebar === 'function',
     null,
     { timeout: 15000 }
@@ -108,7 +107,7 @@ async function seedDemoData(page) {
     window._labState.profileDob = '1987-11-22';
     await dataModule.saveImportedData();
     window.buildSidebar?.();
-    window.navigate?.('dashboard');
+    (await import('/js/views.js')).navigate('dashboard');
     window.closeChatPanel?.();
   });
   await page.waitForSelector('#main-content', { timeout: 10000 });
@@ -907,7 +906,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
   await delay(100);
 
   for (const tab of ['labs', 'body', 'light', 'insight']) {
-    await page.evaluate(() => window.navigate?.('dashboard'));
+    await page.evaluate(async () => (await import('/js/views.js')).navigate('dashboard'));
     await delay(180);
     if (tab === 'light') await seedMobileLightSessions(page);
     await page.click(`.m-tab[data-tab="${tab}"]`);

--- a/tests/playwright/views-facade-browser-coverage.spec.js
+++ b/tests/playwright/views-facade-browser-coverage.spec.js
@@ -35,7 +35,7 @@ test('views facade browser coverage exercises genome lens picker filters and qui
       'saveRecommendation', 'dismissRecommendation', 'openChatProviderQuiz', 'setOnboardingFocus',
       'renameCategory', 'renameMarker', 'revertMarkerName', 'openCreateMarkerModal',
       'loadFocusCard', 'renderLightTodayStrip', 'renderLightChannelsLive',
-      '_openChannelOnLightPage', 'rememberModalTrigger', 'closeModal',
+      '_openChannelOnLightPage', 'rememberModalTrigger', 'closeModal', 'navigate',
     ];
     outcomes.viewRuntimeBridgeResolvesModuleActions = bridgedViewActions.every(name =>
       runtimeBridge.getViewRuntimeFunction(name) === views[name]);

--- a/tests/test-a11y-axe.js
+++ b/tests/test-a11y-axe.js
@@ -91,7 +91,7 @@ return (async () => {
     // ── 3. Helpers ──────────────────────────────────────────────────────
     const allViolations = new Map();
     async function safeNav(view) {
-      try { window.navigate?.(view); } catch (e) { note(`navigate(${view}) threw: ${e.message}`); }
+      try { viewsModule.navigate(view); } catch (e) { note(`navigate(${view}) threw: ${e.message}`); }
       await new Promise(r => setTimeout(r, 700));
     }
     function clearTransientUi() {
@@ -289,7 +289,7 @@ return (async () => {
     // Close any overlay we may have left open so the next test starts clean.
     try { viewsModule.closeModal(); } catch (_) {}
     // Re-navigate to dashboard so the DOM matches state.currentView.
-    try { window.navigate?.('dashboard'); } catch (_) {}
+    try { viewsModule.navigate('dashboard'); } catch (_) {}
   }
 
   console.log(`\n%c Axe Result: ${pass} passed, ${fail} failed, ${info} info `,

--- a/tests/test-category-customization-runtime.js
+++ b/tests/test-category-customization-runtime.js
@@ -8,6 +8,7 @@ import {
   navigateCategoryCustomizationRuntime,
   showCategoryCustomizationPrompt,
 } from '../js/category-customization-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 const originalCategoryCustomizationRuntimeDeps = configureCategoryCustomizationRuntimeDeps();
 
@@ -48,6 +49,7 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  let previousViewRuntime = null;
   const browserRuntime = {
     innerWidth: 812,
     innerHeight: 640,
@@ -89,13 +91,17 @@ try {
 
   delete browserRuntime.navigate;
   delete browserRuntime.buildSidebar;
+  previousViewRuntime = configureViewRuntime({
+    navigate: route => calls.push(['module-navigate', route]),
+  });
   configureCategoryCustomizationRuntimeDeps({ showPromptDialog: null });
   delete browserRuntime.innerWidth;
   delete browserRuntime.innerHeight;
   navigateCategoryCustomizationRuntime('missing');
   assert('runtime hooks no-op when browser callbacks are missing',
     getCategoryCustomizationBuildSidebar() === null
-      && await showCategoryCustomizationPrompt('Missing callback') === undefined);
+      && await showCategoryCustomizationPrompt('Missing callback') === undefined
+      && calls.some(call => call[0] === 'module-navigate' && call[1] === 'missing'));
   const fallbackViewport = getCategoryCustomizationViewportSize();
   assert('viewport helper falls back when dimensions are missing',
     fallbackViewport.width === 1024 && fallbackViewport.height === 768);
@@ -105,6 +111,7 @@ try {
   setRuntimeValue('navigate', route => { globalNavigateCalled = route === 'dashboard'; });
   navigateCategoryCustomizationRuntime('dashboard');
   assert('runtime hooks fall back to globalThis when window is missing', globalNavigateCalled);
+  configureViewRuntime(previousViewRuntime);
 } finally {
   configureCategoryCustomizationRuntimeDeps(originalCategoryCustomizationRuntimeDeps);
   restoreRuntime();

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -332,8 +332,6 @@ for (const name of dataExports) {
 const expectedExports = [
   // nav.js
   'buildSidebar', 'renderProfileDropdown',
-  // views.js shell contracts
-  'navigate',
   // settings.js
   'openSettingsModal', 'closeSettingsModal',
   // chat.js
@@ -346,6 +344,8 @@ assert('views.showDashboard exists', typeof viewsModule.showDashboard === 'funct
 assert('window.showDashboard stays module-only', !('showDashboard' in window));
 assert('views.closeModal exists', typeof viewsModule.closeModal === 'function');
 assert('window.closeModal stays module-only', !('closeModal' in window));
+assert('views.navigate exists', typeof viewsModule.navigate === 'function');
+assert('window.navigate stays module-only', !('navigate' in window));
 for (const name of ['openReportBuilder', 'closeReportBuilder', 'exportPDFReport', 'exportDataJSON', 'importDataJSON', 'clearAllData']) {
   assert(`export.${name} exists`, typeof exportModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -14,6 +14,7 @@ return (async function() {
   const exportModule = await import('/js/export.js');
   const contextCards = await import('/js/context-cards.js');
   const profile = await import('/js/profile.js');
+  const views = await import('/js/views.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -36,7 +37,7 @@ return (async function() {
     S.profileDob = '1987-11-22';
     dataModule.saveImportedData();
     window.buildSidebar();
-    window.navigate('dashboard');
+    views.navigate('dashboard');
     await wait(50);
   }
   const data = dataModule.getActiveData();

--- a/tests/test-integration-batch2.js
+++ b/tests/test-integration-batch2.js
@@ -212,7 +212,7 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   if (saveRefreshMatch) {
     const body = saveRefreshMatch[1];
     assert('saveAndRefresh calls navigate for in-tab re-render (#123)',
-      /window\.navigate\s*\(/.test(body) || /\bnavigate\s*\(/.test(body),
+      /navigateContextCardView\s*\(/.test(body),
       'without this, saved context card values stay hidden until reload');
   }
 
@@ -222,10 +222,11 @@ console.log('=== Integration Tests — Batch 2 Fixes ===\n');
   // truthy in Node) — clean cross-environment skip.
   const _rtState = window._labState;
   const _isNode = typeof process !== 'undefined' && !!process.versions?.node;
-  if (!_isNode && typeof contextCards.saveAndRefresh === 'function' && typeof window.navigate === 'function' && _rtState) {
+  if (!_isNode && typeof contextCards.saveAndRefresh === 'function' && _rtState) {
     const sv_stress = _rtState.importedData?.stress;
     try {
-      window.navigate('dashboard');
+      const { navigate } = await import('../js/views.js');
+      navigate('dashboard');
       await new Promise(r => setTimeout(r, 50));
       // Stress card should exist (context cards always render on dashboard)
       const stressCardBefore = document.querySelector('.profile-context-cards');

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -848,7 +848,8 @@ const {
     screenNavCall?.route === 'light' &&
     screenNavCall?.data?.scrollAnchor === '.light-env-screen-card[data-id="screen_single"]',
     JSON.stringify(screenNavCall));
-  window.navigate = beforeNavigate;
+  if (beforeNavigate) window.navigate = beforeNavigate;
+  else delete window.navigate;
   window._labState.currentView = beforeScreenToggleView;
   window._labState.importedData = beforeScreenToggleState;
 

--- a/tests/test-manual-entry-flow.js
+++ b/tests/test-manual-entry-flow.js
@@ -216,14 +216,14 @@ console.log('=== Manual Entry Flow Tests ===\n');
 
   const dataSrc = read('js/data.js');
   assert('switchUnitSystem uses state.currentView (no .nav-item.active query)',
-    /switchUnitSystem[\s\S]{0,800}dataWindow\.navigate\(state\.currentView \|\| 'dashboard'/.test(dataSrc) &&
+    /switchUnitSystem[\s\S]{0,800}navigateDataView\(state\.currentView \|\| 'dashboard'/.test(dataSrc) &&
     !/switchUnitSystem[\s\S]{0,800}document\.querySelector\(".nav-item\.active"\)/.test(dataSrc));
   const switchRangeModeBody = dataSrc.match(/export function switchRangeMode\(mode\)[\s\S]*?\n}\n\nexport function updateHeaderDates/)?.[0] || '';
   assert('switchRangeMode uses state.currentView (no .nav-item.active query)',
-    /dataWindow\.navigate\(state\.currentView \|\| 'dashboard'/.test(switchRangeModeBody) &&
+    /navigateDataView\(state\.currentView \|\| 'dashboard'/.test(switchRangeModeBody) &&
     !/document\.querySelector\(["']\.nav-item\.active["']\)/.test(switchRangeModeBody));
   assert('setDateRange uses state.currentView',
-    /setDateRange[\s\S]{0,1500}navigate\(state\.currentView \|\| 'dashboard'/.test(dataSrc));
+    /setDateRange[\s\S]{0,1500}navigateDataView\(state\.currentView \|\| 'dashboard'/.test(dataSrc));
 
   const cryptoSrc = read('js/crypto.js');
   assert('BroadcastChannel cross-tab reload uses state.currentView',

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -13,6 +13,7 @@ import {
   openReportBuilderFromNavRuntime,
 } from '../js/nav-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let passed = 0;
 let failed = 0;
@@ -92,6 +93,9 @@ try {
   for (const key of ['navigate', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
     delete browserRuntime[key];
   }
+  const previousViewRuntime = configureViewRuntime({
+    navigate: route => calls.push(['module-navigate', route]),
+  });
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
   configureNavRuntime({ openEMFAssessmentEditor: () => {}, openReportBuilder: () => {} });
   navigateFromNavRuntime('missing');
@@ -100,7 +104,8 @@ try {
   openContextFromNavRuntime();
   openCreateMarkerFromNavRuntime();
   openClientListFromNavRuntime();
-  assert('nav runtime hooks no-op when browser callbacks are missing', calls.length === 6);
+  assert('nav runtime falls back to module navigation when the browser callback is missing',
+    calls.length === 7 && calls.some(call => call[0] === 'module-navigate' && call[1] === 'missing'));
 
   delete globalThis.window;
   let globalRoute = '';
@@ -109,6 +114,7 @@ try {
   exposeNavRuntimeGlobals({ runtimeProbe: 'global' });
   assert('nav runtime falls back to globalThis without window',
     globalRoute === 'recommendations' && globalThis.runtimeProbe === 'global');
+  configureViewRuntime(previousViewRuntime);
   configureNavRuntime(restoreNavRuntime);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -47,7 +47,7 @@ return (async function() {
   // ─── 1. Dashboard Light Today uses the same hero surface as /light ──
   console.log('%c 1. Light Today hero on dashboard ', 'font-weight:bold;color:#6366f1');
 
-  window.navigate?.('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(80);
   if (!main.querySelector('.dashboard-widget[data-widget-id="light-today"]')) {
     viewsModule.showDashboardWidget?.('light-today');
@@ -85,7 +85,7 @@ return (async function() {
   });
   assert('logCompletedSession returns id', typeof id === 'string');
 
-  window.navigate?.('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(80);
   const todayWidgetAfter = main.querySelector('.dashboard-widget[data-widget-id="light-today"]');
   assert('Dashboard Light Today still renders as hero after logging',
@@ -99,7 +99,7 @@ return (async function() {
   // ─── 3. /light page renders Light & Sun list ─────────────────────────
   console.log('%c 3. /light dedicated page ', 'font-weight:bold;color:#6366f1');
 
-  window.navigate?.('light');
+  viewsModule.navigate('light');
   await wait(120);
   assert('Light & Sun page header renders',
     /Light &amp; Sun|Light & Sun/.test(main.innerHTML));
@@ -450,7 +450,7 @@ return (async function() {
     await window.logDeviceSession({ deviceId: 'D-badge-moded', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true, mode: 'red-nir-only' });
     await window.logDeviceSession({ deviceId: 'D-badge-plain', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
 
-    window.navigate?.('light');
+    viewsModule.navigate('light');
     await wait(80);
     const rows = document.querySelectorAll('.light-session-device');
     assert('3 device-session rows render after logging', rows.length >= 3);

--- a/tests/test-sync-modal-refresh.js
+++ b/tests/test-sync-modal-refresh.js
@@ -361,7 +361,8 @@ try {
   document.getElementById = originalGetElementById;
   document.querySelector = originalQuerySelector;
   window.buildSidebar = originalBuildSidebar;
-  window.navigate = originalNavigate;
+  if (originalNavigate) window.navigate = originalNavigate;
+  else delete window.navigate;
   window.CustomEvent = originalCustomEvent;
   state.currentProfile = originalRefreshCurrentProfile;
   state.currentView = originalRefreshCurrentView;

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -57,7 +57,7 @@ return (async function() {
     S.profileDob = '1987-11-22';
     dataModule.saveImportedData();
     window.buildSidebar();
-    window.navigate('dashboard');
+    viewsModule.navigate('dashboard');
     await wait(50);
   }
   const data = dataModule.getActiveData();
@@ -100,7 +100,7 @@ return (async function() {
     S.importedData = originalImportedData;
     dataModule.saveImportedData();
     window.buildSidebar();
-    window.navigate('dashboard');
+    viewsModule.navigate('dashboard');
     await wait(50);
   }
 
@@ -135,7 +135,7 @@ return (async function() {
   // 1. DASHBOARD — renders all key sections
   // ═══════════════════════════════════════════════
   console.log('%c 1. Dashboard rendering', 'font-weight:bold;color:#6366f1');
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(50);
 
   assert('Dashboard has main content', main.innerHTML.length > 500);
@@ -199,7 +199,7 @@ return (async function() {
   console.log('%c 2. Navigation', 'font-weight:bold;color:#6366f1');
 
   // Navigate to biochemistry
-  window.navigate('biochemistry');
+  viewsModule.navigate('biochemistry');
   await wait(50);
   const bioNav = sidebar.querySelector('.nav-item[data-category="biochemistry"]');
   assert('Biochemistry nav item active', bioNav?.classList.contains('active'));
@@ -207,17 +207,17 @@ return (async function() {
   assert('Main content updated for biochemistry', main.innerHTML.includes('biochemistry') || main.innerHTML.includes('Biochemistry') || main.querySelector('canvas'));
 
   // Navigate to compare
-  window.navigate('compare');
+  viewsModule.navigate('compare');
   await wait(50);
   assert('Compare view rendered', !!main.querySelector('#compare-select-1') || main.innerHTML.includes('Compare'));
 
   // Navigate to correlations
-  window.navigate('correlations');
+  viewsModule.navigate('correlations');
   await wait(50);
   assert('Correlations view rendered', main.innerHTML.includes('orrelation'));
 
   // Back to dashboard
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(50);
   assert('Back to dashboard', !!sidebar.querySelector('.nav-item.active[data-category="dashboard"]'));
 
@@ -227,7 +227,7 @@ return (async function() {
   const labsOrderKey = `labcharts-${lensOrderProfile}-lensPageOrder-labs-v1`;
   const savedLabsOrder = localStorage.getItem(labsOrderKey);
   localStorage.removeItem(labsOrderKey);
-  window.navigate('labs');
+  viewsModule.navigate('labs');
   await wait(80);
   const labsPageWidgets = main.querySelector('.lens-page-widgets[data-lens-route="labs"]');
   assert('Labs page uses compact Current Priority banner',
@@ -252,7 +252,7 @@ return (async function() {
   }
   if (savedLabsOrder == null) localStorage.removeItem(labsOrderKey);
   else localStorage.setItem(labsOrderKey, savedLabsOrder);
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(50);
 
   // ═══════════════════════════════════════════════
@@ -421,7 +421,7 @@ return (async function() {
   // Verify the optional dashboard widget can be shown after save
   viewsModule.closeModal();
   await wait(20);
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(50);
   viewsModule.showDashboardWidget?.('supplements');
   await wait(50);
@@ -438,7 +438,7 @@ return (async function() {
   assert('Supplement removed from state', (S.importedData.supplements || []).length === initialSuppCount);
 
   // Verify dashboard updated after delete
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(50);
   const suppSectionAfter = main.querySelector('.supp-timeline-section');
   const stillShows = suppSectionAfter?.innerHTML.includes('__UI_TEST_SUPP__');
@@ -607,7 +607,7 @@ return (async function() {
   // ═══════════════════════════════════════════════
   console.log('%c 7. Context cards', 'font-weight:bold;color:#6366f1');
 
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(50);
 
   // Open diet editor
@@ -648,7 +648,7 @@ return (async function() {
   // ═══════════════════════════════════════════════
   console.log('%c 8. Compare view', 'font-weight:bold;color:#6366f1');
 
-  window.navigate('compare');
+  viewsModule.navigate('compare');
   await wait(50);
 
   if (data.dates.length >= 2) {
@@ -776,7 +776,7 @@ return (async function() {
   // ═══════════════════════════════════════════════
   console.log('%c 14. Sidebar search', 'font-weight:bold;color:#6366f1');
 
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(50);
   const staticNavCategories = new Set([
     'dashboard', 'labs', 'biology-scores', 'correlations', 'compare', 'recommendations',
@@ -869,7 +869,7 @@ return (async function() {
   // ═══════════════════════════════════════════════
   // SUMMARY
   // ═══════════════════════════════════════════════
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   await wait(20);
 
   console.log(`\n%c UI Flows: ${pass} passed, ${fail} failed `,

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -596,7 +596,7 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       && dataSrc.includes("import { scheduleUtilsAfterNextPaint } from './utils-runtime.js';")
       && /scheduleUtilsAfterNextPaint\(fn\)/.test(dataSrc)
       && /const token\s*=\s*\+\+_rangeModeRefreshToken/.test(dataSrc)
-      && /_afterNextPaint\(\(\) => \{[\s\S]{0,500}dataWindow\.navigate\(state\.currentView \|\| 'dashboard',\s*data\)/.test(dataSrc));
+      && /_afterNextPaint\(\(\) => \{[\s\S]{0,500}navigateDataView\(state\.currentView \|\| 'dashboard',\s*data\)/.test(dataSrc));
     assert('range mode refresh preserves current category card order',
       /function _captureCategoryCardOrderForRangeRefresh\(route\)/.test(dataSrc)
       && /state\._preserveCategoryCardOrder\s*=\s*preservedOrder/.test(dataSrc)

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -47,7 +47,7 @@ return (async function() {
   await manual.refreshManualSummary(TEST_PROFILE_ID);
 
   // Wait for navigate to render the dashboard with the overview widget.
-  if (window.navigate) window.navigate('dashboard');
+  views.navigate('dashboard');
   await new Promise(r => setTimeout(r, 200));
 
   // ═══════════════════════════════════════
@@ -209,7 +209,7 @@ return (async function() {
   // 6. Biometrics Overview tile click opens detail modal
   // ═══════════════════════════════════════
   console.log('%c 6. Overview Tile → Modal ', 'font-weight:bold;color:#f59e0b');
-  if (window.navigate) window.navigate('dashboard');
+  views.navigate('dashboard');
   await new Promise(r => setTimeout(r, 200));
   const overview = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
   assert('Biometrics Overview renders on dashboard when wearableSummary populated',
@@ -271,7 +271,7 @@ return (async function() {
     sum.metrics.resilience_level = { primarySource: 'oura', latest: 3, latestDate: '2026-04-22',
       baseline: 3, baselineP25: 3, baselineP75: 3,
       rolling: { d7: 3, d30: 3, d90: 3 }, trend30d: 'flat', weekly: [3] };
-    if (window.navigate) window.navigate('dashboard');
+    views.navigate('dashboard');
     await new Promise(r => setTimeout(r, 300));
     const selectedOverview = document.querySelector('.dashboard-widget[data-widget-id="wearables"]');
     assert('Unselected biometrics stay out of the overview by default',
@@ -306,7 +306,7 @@ return (async function() {
     assert('Picker add places the chosen biometric inside Biometrics Overview',
       !!overviewWithCardio && /Cardio age/i.test(overviewWithCardio.textContent || ''));
     window._labState.importedData.wearableConnections.oura.lastSyncAt = Date.now() - (13 * 60 * 60 * 1000);
-    if (window.navigate) window.navigate('dashboard');
+    views.navigate('dashboard');
     await new Promise(r => setTimeout(r, 300));
     assert('Stale connected data shows the dashboard sync button',
       !!document.querySelector('.db-biometric-sync-btn'));
@@ -322,7 +322,7 @@ return (async function() {
     delete resetSummary.metrics.bp_systolic;
     delete resetSummary.metrics.bp_diastolic;
   }
-  if (window.navigate) window.navigate('dashboard');
+  views.navigate('dashboard');
   await new Promise(r => setTimeout(r, 300));
   const bpEmptyCard = document.querySelector('.db-biometric-overview-grid .wearable-card-empty[data-empty-metric="bp_systolic"]');
   assert('Empty BP card renders inside Biometrics Overview',
@@ -369,7 +369,7 @@ return (async function() {
   window._labState.currentProfile = origCurrentProfile;
   window._labState.importedData = origState;
   try { const { deleteWearablesDB } = await import('/js/wearables-store.js'); await deleteWearablesDB(TEST_PROFILE_ID); } catch {}
-  if (window.navigate) window.navigate('dashboard');
+  views.navigate('dashboard');
 
   console.log(`\n%c Tests complete: ${pass} passed, ${fail} failed `, fail ? 'background:#ef4444;color:#fff;padding:4px 12px;border-radius:4px' : 'background:#22c55e;color:#fff;padding:4px 12px;border-radius:4px');
   if (typeof window.__TEST_RESULTS !== 'undefined') window.__TEST_RESULTS = { pass, fail };

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -598,10 +598,10 @@
     'hasCardContent','escapeAttr','loadScriptOnce'
   ];
 
-  // views.js retains only the core navigate shell contract on window.
-  const viewsLegacyExports = ['navigate'];
+  // views.js is module-only; cycle-sensitive consumers use views-runtime-bridge.js.
+  const viewsLegacyExports = [];
   const viewsFacadeModuleExports = [
-    'getInitialView','showDashboard','showLabs','showBiologyScoresLens','showGenomeLens',
+    'getInitialView','navigate','showDashboard','showLabs','showBiologyScoresLens','showGenomeLens',
     'showBodyLens','showInsightLens','showRecommendations','openRecommendationDetail',
     'discussRecommendation','saveRecommendation','dismissRecommendation','showLight',
     '_expandLightToolsSection','_toggleChannelDetail','_openChannelOnLightPage',
@@ -949,7 +949,7 @@
   // 14. NAVIGATION — category switching
   // ═══════════════════════════════════════════════
   // Navigate to a known category — sidebar only shows categories with data
-  window.navigate('biochemistry');
+  viewsModule.navigate('biochemistry');
   const bioNavItem = document.querySelector('.nav-item[data-category="biochemistry"]');
   if (bioNavItem) {
     assert('Navigation activates biochemistry nav item', bioNavItem.classList.contains('active'));
@@ -960,11 +960,11 @@
   assert('Main content updated after navigate', main?.innerHTML.includes('biochemistry') || main?.innerHTML.includes('Biochemistry') || main?.innerHTML.includes('category'));
 
   // Navigate to compare
-  window.navigate('compare');
+  viewsModule.navigate('compare');
   assert('Compare view loads', main?.innerHTML.includes('compare') || main?.innerHTML.includes('Compare'));
 
   // Navigate back to dashboard
-  window.navigate('dashboard');
+  viewsModule.navigate('dashboard');
   assert('Dashboard renders after navigate', main?.innerHTML.includes('dashboard') || main?.innerHTML.includes('Dashboard') || main?.innerHTML.includes('drop-zone') || main?.innerHTML.includes('context-card'));
 
   // ═══════════════════════════════════════════════

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.208';
+self.APP_VERSION = '1.10.209';


### PR DESCRIPTION
## Summary

- remove the final `window.navigate` export from `views.js`
- register `navigate` in the module runtime bridge and migrate browser consumers to override-first bridge lookups
- update browser/unit coverage for module-owned navigation and stabilize the OpenRouter settings fixture against the first-run tour
- bump the app cache version to `1.10.209`

## Tests

- `./run-tests.sh` — 124 module checks, 398 Vitest tests, 18 origin guards, 352 Playwright tests, and 472 theme assertions passed
- `npm run quality` — 7/7 guardrails passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `git diff --check`