### PR TITLE
Trim settings window facade

### DIFF
--- a/js/settings-runtime.js
+++ b/js/settings-runtime.js
@@ -61,11 +61,17 @@ export function addSettingsRuntimeEventListener(type, listener) {
   if (addEventListener) addEventListener(type, listener);
 }
 
-/** @param {{ settingsVisible?: boolean }} [options] */
+/**
+ * @param {{
+ *   settingsVisible?: boolean,
+ *   updateSettingsUI?: () => void,
+ *   updateTweaksUI?: () => void,
+ * }} [options]
+ */
 export function refreshSettingsRuntimeSurfaces(options = {}) {
   const runtime = getRuntimeWindow();
-  runtime.updateSettingsUI?.();
-  runtime.updateTweaksUI?.();
+  (options.updateSettingsUI || runtime.updateSettingsUI)?.();
+  (options.updateTweaksUI || runtime.updateTweaksUI)?.();
   if (options.settingsVisible) runtime.refreshSettingsWearables?.();
 }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -179,7 +179,11 @@ export function applyAccentOverride(id = getAccentOverride()) {
 
 function refreshVisualSurfaces() {
   const settingsVisible = document.getElementById('settings-modal')?.classList.contains('show') === true;
-  refreshSettingsRuntimeSurfaces({ settingsVisible });
+  refreshSettingsRuntimeSurfaces({
+    settingsVisible,
+    updateSettingsUI,
+    updateTweaksUI,
+  });
   scheduleChartThemeRefresh();
 }
 
@@ -1050,26 +1054,9 @@ export function closeSettingsModal() {
 publishSettingsGlobals({
   openSettingsModal,
   closeSettingsModal,
-  switchSettingsTab,
-  renderPrivacySection,
-  renderSunDataSourceSettings,
-  togglePrivacyConfigure,
-  toggleOllamaPII,
-  confirmDisablePIIReview,
   updatePrivacyStatusCard,
-  updateSettingsUI,
-  renderDataEntriesSection,
-  refreshDataEntriesSection,
-  removeImportedEntryFromSettings,
-  renameImportedEntryDateFromSettings,
-  resetCurrentProfileUsage,
   openTweaksPanel,
   closeTweaksPanel,
-  selectTweaksTheme,
-  selectTweaksAccent,
-  toggleTweaksSunsetMode,
-  toggleTweaksCrtEffects,
   applyAccentOverride,
-  scheduleChartThemeRefresh,
   updateTweaksUI,
 });

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -23,6 +23,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
   await preparePage(page);
 
   const results = await page.evaluate(async () => {
+    const settingsModule = await import('/js/settings.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 80; attempt += 1) {
@@ -77,7 +78,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       localStorage.removeItem('labcharts-crt-effects');
       localStorage.setItem('labcharts-theme', 'dark');
       localStorage.setItem('labcharts-time-format', '24h');
-      window.openSettingsModal('display');
+      settingsModule.openSettingsModal('display');
       const modal = document.getElementById('settings-modal');
       modal.insertAdjacentHTML('beforeend', '<button type="button" class="settings-theme-btn" data-theme-id="glass" data-settings-action="select-theme">Glass</button>');
       const themeBtn = modal.querySelector('[data-settings-action="select-theme"]');
@@ -92,7 +93,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
         && timeBtn.classList.contains('active')
         && window.formatTime('14:05') === '2:05 PM';
 
-      window.openTweaksPanel();
+      settingsModule.openTweaksPanel();
       const sunsetToggle = document.getElementById('tweaks-sunset-mode');
       sunsetToggle.checked = true;
       sunsetToggle.dispatchEvent(new Event('change', { bubbles: true }));
@@ -103,7 +104,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       localStorage.removeItem('labcharts-pii-review-disable-ack');
       localStorage.setItem('labcharts-pii-review', 'true');
       localStorage.setItem('labcharts-ollama-pii-enabled', 'false');
-      window.openSettingsModal('privacy');
+      settingsModule.openSettingsModal('privacy');
       document.querySelector('[data-settings-action="toggle-privacy-configure"]').click();
       const privacyBody = document.getElementById('privacy-configure-body');
       results.togglePrivacyConfigure = privacyBody.style.display === 'block';
@@ -140,7 +141,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
         totalOutputTokens: 1200,
         requestCount: 4,
       }));
-      window.openSettingsModal('ai');
+      settingsModule.openSettingsModal('ai');
       document.querySelector('#ai-usage-section [data-settings-action="reset-profile-usage"]').click();
       await wait(0);
       results.resetCurrentProfileUsage = localStorage.getItem(usageKey) === null
@@ -151,7 +152,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
         meteoConfig = { ...cfg };
         savedMeteoConfigs.push({ ...cfg });
       };
-      document.body.insertAdjacentHTML('beforeend', `<section id="sun-source-fixture">${window.renderSunDataSourceSettings()}</section>`);
+      document.body.insertAdjacentHTML('beforeend', `<section id="sun-source-fixture">${settingsModule.renderSunDataSourceSettings()}</section>`);
       const sunSection = document.getElementById('sun-data-source-section');
       const selfhostRadio = sunSection.querySelector('input[value="selfhost"]');
       selfhostRadio.checked = true;
@@ -193,7 +194,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       restoreStorage('labcharts-pii-review-disable-ack', saved.piiAck);
       restoreStorage(usageKey, saved.usage);
       restoreStorage('labcharts-global-usage', saved.globalUsage);
-      window.closeTweaksPanel?.();
+      settingsModule.closeTweaksPanel();
       document.getElementById('sun-source-fixture')?.remove();
       document.getElementById('confirm-dialog-overlay')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
@@ -214,6 +215,7 @@ test('settings browser coverage renames imported entry dates through the data se
   const results = await page.evaluate(async () => {
     const dataModule = await import('/js/data.js');
     const reviewRuntime = await import('/js/pdf-import-review-runtime.js');
+    const settingsModule = await import('/js/settings.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 80; attempt += 1) {
@@ -259,9 +261,9 @@ test('settings browser coverage renames imported entry dates through the data se
       window.navigate = view => calls.push(`navigate:${view}`);
 
       document.body.insertAdjacentHTML('beforeend', '<section id="data-entries-section"></section>');
-      window.refreshDataEntriesSection();
+      settingsModule.refreshDataEntriesSection();
 
-      const renamePromise = window.renameImportedEntryDateFromSettings('2026-02-01');
+      const renamePromise = settingsModule.renameImportedEntryDateFromSettings('2026-02-01');
       await waitFor(() => document.getElementById('prompt-dialog-input'), 'rename prompt');
       const input = document.getElementById('prompt-dialog-input');
       input.value = '2026-02-03';

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -551,7 +551,7 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
   assert(testName(theme, viewportName, 'theme default accent swatch follows theme'),
     result.defaultAccent === result.expectedDefaultAccent,
     JSON.stringify(result));
-  await page.evaluate(() => window.selectTweaksAccent?.('rose'));
+  await page.evaluate(async () => (await import('/js/settings.js')).selectTweaksAccent('rose'));
   await delay(80);
   result = await page.evaluate(() => ({
     storedAccent: localStorage.getItem('labcharts-accent-override') || '',
@@ -561,9 +561,10 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
   assert(testName(theme, viewportName, 'custom accent applies through tweaks'),
     result.storedAccent === 'rose' && result.rootAccent === '#f43f5e' && result.activeAccent === 'rose',
     JSON.stringify(result));
-  await page.evaluate(() => {
-    window.toggleTweaksCrtEffects?.(true);
-    window.updateTweaksUI?.();
+  await page.evaluate(async () => {
+    const settingsModule = await import('/js/settings.js');
+    settingsModule.toggleTweaksCrtEffects(true);
+    settingsModule.updateTweaksUI();
   });
   await delay(80);
   result = await page.evaluate((theme) => {
@@ -595,9 +596,10 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
         ? result.bodyAfterContent !== 'none' && result.bodyAfterPosition === 'fixed' && result.bodyAfterAnimation.includes('crt-flicker') && result.bodyAfterAnimation.includes('crt-sweep') && result.bodyAfterBlend === 'overlay'
         : result.bodyAfterContent === 'none'),
     JSON.stringify(result));
-  await page.evaluate(() => {
-    window.toggleTweaksCrtEffects?.(false);
-    window.updateTweaksUI?.();
+  await page.evaluate(async () => {
+    const settingsModule = await import('/js/settings.js');
+    settingsModule.toggleTweaksCrtEffects(false);
+    settingsModule.updateTweaksUI();
   });
   await delay(80);
   result = await page.evaluate((theme) => {
@@ -666,9 +668,10 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
   assert(testName(theme, viewportName, 'accent override restores after sunset mode'),
     result.sunsetAttr === '' && result.restoredAccent === '#f43f5e',
     JSON.stringify(result));
-  await page.evaluate(() => {
-    window.selectTweaksAccent?.('');
-    window.closeTweaksPanel?.();
+  await page.evaluate(async () => {
+    const settingsModule = await import('/js/settings.js');
+    settingsModule.selectTweaksAccent('');
+    settingsModule.closeTweaksPanel();
   });
   await delay(100);
 

--- a/tests/test-a11y-axe.js
+++ b/tests/test-a11y-axe.js
@@ -34,6 +34,7 @@ return (async () => {
   const { state } = await import('/js/state.js');
   const { loadDemoData } = await import('/js/export.js');
   const viewsModule = await import('/js/views.js');
+  const settingsModule = await import('/js/settings.js');
   // Capture full state shape so we can restore even if we mutate
   // currentProfile / importedData / markerRegistry / etc along the way.
   const snapshot = {
@@ -156,10 +157,8 @@ return (async () => {
     });
     for (const tab of ['display', 'ai', 'privacy', 'data', 'wearables', 'agent']) {
       await safeOp(`switch to settings/${tab}`, async () => {
-        if (typeof window.switchSettingsTab === 'function') {
-          window.switchSettingsTab(tab);
-          await new Promise(r => setTimeout(r, 250));
-        }
+        settingsModule.switchSettingsTab(tab);
+        await new Promise(r => setTimeout(r, 250));
       });
       await scan(`settings-${tab}`);
     }

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -32,6 +32,7 @@ return (async function() {
   const profile = await import('/js/profile.js');
   const exportModule = await import('/js/export.js');
   const contextCards = await import('/js/context-cards.js');
+  const settingsModule = await import('/js/settings.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -81,8 +82,8 @@ return (async function() {
       }],
       manualValues: {}
     });
-    const entriesHtml = window.renderDataEntriesSection();
-    assert('Settings Data remove wrapper is callable', typeof window.removeImportedEntryFromSettings === 'function');
+    const entriesHtml = settingsModule.renderDataEntriesSection();
+    assert('Settings Data remove wrapper is callable', typeof settingsModule.removeImportedEntryFromSettings === 'function');
     assert('PDF import remove action is module-only', typeof pdfImport.removeImportedEntry === 'function'
       && !('removeImportedEntry' in window));
     assert('Settings Data remove button uses delegated action',
@@ -90,7 +91,7 @@ return (async function() {
     assert('Settings Data edit button uses delegated action',
       entriesHtml.includes('data-settings-action="rename-imported-entry"') && entriesHtml.includes('data-entry-date="2099-12-31"'));
     assert('Settings Data hides marker-tombstone-only sync rows', !entriesHtml.includes('0 markers'));
-    await window.removeImportedEntryFromSettings('2099-12-31');
+    await settingsModule.removeImportedEntryFromSettings('2099-12-31');
     await wait(50);
     assert('Settings Data remove wrapper deletes entry',
       !(S.importedData.entries || []).some(e => e.date === '2099-12-31'));
@@ -262,7 +263,7 @@ return (async function() {
   const settingsOverlay = document.getElementById('settings-modal-overlay');
 
   // Open to AI tab
-  window.openSettingsModal('ai');
+  settingsModule.openSettingsModal('ai');
   await wait(50);
   assert('Settings modal opens', settingsOverlay.classList.contains('show'));
   assert('AI tab is active', !!document.querySelector('.settings-tab-btn[data-tab="ai"].active'));
@@ -270,7 +271,7 @@ return (async function() {
   assert('Provider buttons rendered', document.querySelectorAll('.ai-provider-btn').length >= 5);
 
   // Switch to display tab
-  window.switchSettingsTab('display');
+  settingsModule.switchSettingsTab('display');
   await wait(20);
   assert('Display tab active after switch', !!document.querySelector('.settings-tab-btn[data-tab="display"].active'));
   assert('AI tab no longer active', !document.querySelector('.settings-tab-btn[data-tab="ai"].active'));
@@ -284,8 +285,8 @@ return (async function() {
   window.setTheme('dark');
   window.setSunsetMode?.(false);
   window.setCrtEffectsEnabled?.(false);
-  window.applyAccentOverride?.();
-  window.openTweaksPanel?.();
+  settingsModule.applyAccentOverride();
+  settingsModule.openTweaksPanel();
   await wait(30);
   assert('Tweaks owns theme controls', !!document.querySelector('#tweaks-panel .tweaks-theme-grid'));
   assert('Tweaks owns accent controls', !!document.querySelector('#tweaks-panel .tweaks-accent-row'));
@@ -293,7 +294,7 @@ return (async function() {
   const darkCrtRow = document.querySelector('#tweaks-crt-effects-row');
   assert('Tweaks hides CRT effects control on unsupported themes', !!darkCrtRow && darkCrtRow.hidden && !!document.querySelector('#tweaks-crt-effects')?.disabled);
   assert('Tweaks no longer shows Try it actions', !(document.getElementById('tweaks-panel')?.textContent || '').includes('Try it'));
-  window.selectTweaksTheme?.('cyberterm');
+  settingsModule.selectTweaksTheme('cyberterm');
   const cyberCrtReady = await waitFor(() => {
     const row = document.querySelector('#tweaks-crt-effects-row');
     const toggle = document.querySelector('#tweaks-crt-effects');
@@ -302,19 +303,19 @@ return (async function() {
   const cyberCrtRow = document.querySelector('#tweaks-crt-effects-row');
   assert('Tweaks shows CRT effects control on supported themes', cyberCrtReady,
     `theme=${document.documentElement.dataset.theme || 'dark'} hidden=${cyberCrtRow?.hidden}`);
-  window.toggleTweaksCrtEffects?.(true);
+  settingsModule.toggleTweaksCrtEffects(true);
   await wait(20);
   assert('CRT effects toggle persists visual mode', document.documentElement.dataset.crtEffects === 'on' && localStorage.getItem('labcharts-crt-effects') === 'true');
-  window.toggleTweaksCrtEffects?.(false);
-  window.selectTweaksTheme?.('dark');
+  settingsModule.toggleTweaksCrtEffects(false);
+  settingsModule.selectTweaksTheme('dark');
   await wait(80);
-  window.selectTweaksAccent?.('rose');
+  settingsModule.selectTweaksAccent('rose');
   await wait(30);
   const defaultSwatchAccent = document.querySelector('.tweaks-accent-btn[data-accent-id=""] .tweaks-accent-swatch')?.style.getPropertyValue('--tweak-accent')?.trim()?.toLowerCase();
   const rootAccent = document.documentElement.style.getPropertyValue('--accent').trim().toLowerCase();
   assert('Custom accent applies to the app', rootAccent === '#f43f5e', rootAccent);
   assert('Theme default swatch stays on the theme default color', defaultSwatchAccent === '#4f8cff', defaultSwatchAccent);
-  window.closeTweaksPanel?.();
+  settingsModule.closeTweaksPanel();
   if (origAccentForTweaks) localStorage.setItem('labcharts-accent-override', origAccentForTweaks);
   else localStorage.removeItem('labcharts-accent-override');
   if (origSunsetForTweaks) window.setSunsetMode?.(true);
@@ -322,17 +323,17 @@ return (async function() {
   if (origCrtForTweaks) window.setCrtEffectsEnabled?.(true);
   else window.setCrtEffectsEnabled?.(false);
   window.setTheme(origThemeForTweaks);
-  window.applyAccentOverride?.(origAccentForTweaks || '');
+  settingsModule.applyAccentOverride(origAccentForTweaks || '');
 
   // Switch to data tab
-  window.switchSettingsTab('data');
+  settingsModule.switchSettingsTab('data');
   await wait(20);
   assert('Data tab active', !!document.querySelector('.settings-tab-btn[data-tab="data"].active'));
   assert('Data panel has encryption section', !!document.getElementById('encryption-section'));
   assert('Data panel has backup section', !!document.getElementById('backup-section'));
 
   // Close
-  window.closeSettingsModal();
+  settingsModule.closeSettingsModal();
   await wait(20);
   assert('Settings modal closes', !settingsOverlay.classList.contains('show'));
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -189,7 +189,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -208,6 +208,7 @@
     import('../js/pii.js'),
     import('../js/profile.js'),
     import('../js/provider-panels.js'),
+    import('../js/settings.js'),
     import('../js/settings-sync-panel.js'),
     import('../js/sun-context.js'),
     import('../js/sun-spectrum.js'),
@@ -507,13 +508,24 @@
     'detectLatitudeWithAI'
   ];
 
-  // settings.js (8)
-  const settingsExports = [
+  // settings.js (7 retained runtime hooks; internal flows use ESM exports)
+  const settingsGlobals = [
     'openSettingsModal','closeSettingsModal',
-    'renderPrivacySection',
-    'togglePrivacyConfigure','updatePrivacyStatusCard',
-    'updateSettingsUI',
-    'renderDataEntriesSection','refreshDataEntriesSection','configureSettingsRuntime'
+    'openTweaksPanel','closeTweaksPanel',
+    'updatePrivacyStatusCard','applyAccentOverride','updateTweaksUI'
+  ];
+  const settingsModuleOnlyExports = [
+    'switchSettingsTab','renderPrivacySection','renderSunDataSourceSettings',
+    'togglePrivacyConfigure','toggleOllamaPII','confirmDisablePIIReview',
+    'updateSettingsUI','renderDataEntriesSection','refreshDataEntriesSection',
+    'removeImportedEntryFromSettings','renameImportedEntryDateFromSettings',
+    'resetCurrentProfileUsage','selectTweaksTheme','selectTweaksAccent',
+    'toggleTweaksSunsetMode','toggleTweaksCrtEffects'
+  ];
+  const settingsModuleExports = [
+    ...settingsGlobals,
+    ...settingsModuleOnlyExports,
+    'configureSettingsRuntime',
   ];
 
   // provider-panels.js (74 former browser globals, now module-only)
@@ -659,6 +671,7 @@
     ['pii.js', piiModule, piiExports],
     ['profile.js', profileModule, profileExports],
     ['provider-panels.js', providerPanelsModule, providerPanelsExports],
+    ['settings.js', settingsModule, settingsModuleExports],
     ['settings-sync-panel.js', settingsSyncPanelModule, settingsSyncPanelExports],
     ['sun-context.js', sunContextModule, sunContextExports],
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
@@ -698,6 +711,10 @@
   for (const name of profileExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of settingsModuleOnlyExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  assert('window.scheduleChartThemeRefresh stays module-internal', !('scheduleChartThemeRefresh' in window));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
@@ -740,7 +757,7 @@
     'client-list.js': clientListExports,
     'nav.js': navExports,
     'notes.js': notesExports,
-    'settings.js': settingsExports,
+    'settings.js': settingsGlobals,
     'theme.js': themeExports,
     'views.js': viewsLegacyExports,
   };

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.209';
+self.APP_VERSION = '1.10.210';


### PR DESCRIPTION
## Summary
- reduce the Settings/Tweaks browser facade from 24 globals to 7 runtime hooks
- keep internal Settings flows on ESM exports and pass UI refresh callbacks explicitly across the runtime adapter
- add regression coverage for the module-only boundary and bump the app cache version

## Window burden remaining
- This PR removes 17 Settings/Tweaks globals (24 → 7).
- Static inventory after this PR: 447 unique window-published names (452 binding entries) across 27 publication sites, grouped into 14 façade families.
- Largest remaining families: Sun (88 entries), Chat (86), Sync (50), shared Utils bridges (42), Client List (34), DNA (32), Wearables (32), and Light Devices (25).
- Estimated remaining first pass: roughly 12–16 similarly scoped PRs. Some audited shell/runtime hooks will intentionally remain; the goal is zero accidental globals, not zero browser integration points.

## Tests
- `./run-tests.sh`
- `npm run quality`

Full results: 124 module checks, 398 Vitest tests, 18 origin guards, 352 Playwright tests, and 472 responsive-theme assertions passed.