### PR TITLE
Trim nav window facade

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -449,4 +449,10 @@ export function closeMobileSidebar() {
   closeModalOverlay('sidebar-backdrop', { restoreFocus: false });
 }
 
-exposeNavRuntimeGlobals({ buildSidebar, filterSidebar, toggleNavGroup, renderProfileDropdown, renderProfileButton, getAvatarColor, syncSidebarActive, toggleMobileSidebar, closeMobileSidebar, openRecommendationsFromSidebar, installNavActionDelegates });
+exposeNavRuntimeGlobals({
+  buildSidebar,
+  renderProfileDropdown,
+  renderProfileButton,
+  toggleMobileSidebar,
+  closeMobileSidebar,
+});

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -73,7 +73,7 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       window.navigate = route => {
         calls.push(['navigate', route]);
         state.currentView = route;
-        window.syncSidebarActive?.(route);
+        nav.syncSidebarActive(route);
       };
       restoreNavRuntime = navRuntime.configureNavRuntime({
         openEMFAssessmentEditor: () => calls.push(['open-emf']),

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -33,6 +33,7 @@ return (async function() {
   const exportModule = await import('/js/export.js');
   const contextCards = await import('/js/context-cards.js');
   const settingsModule = await import('/js/settings.js');
+  const navModule = await import('/js/nav.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -805,7 +806,7 @@ return (async function() {
   if (totalBefore >= 2 && sidebarSearch && searchTerm) {
     // Filter with a term taken from an item that is eligible to hide.
     sidebarSearch.value = searchTerm;
-    window.filterSidebar();
+    navModule.filterSidebar();
     await wait(20);
     const hiddenNav = getFilterableNavItems().filter(el => el.style.display === 'none');
     assert('Sidebar search filters items', hiddenNav.length > 0);
@@ -813,7 +814,7 @@ return (async function() {
 
     // Clear filter
     sidebarSearch.value = '';
-    window.filterSidebar();
+    navModule.filterSidebar();
     await wait(20);
     const afterClear = getFilterableNavItems().filter(el => el.style.display === 'none');
     assert('Sidebar search clear restores all', afterClear.length === 0);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -189,7 +189,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, navModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -204,6 +204,7 @@
     import('../js/lab-context.js'),
     import('../js/lens.js'),
     import('../js/light-tools.js'),
+    import('../js/nav.js'),
     import('../js/pdf-import.js'),
     import('../js/pii.js'),
     import('../js/profile.js'),
@@ -461,10 +462,19 @@
     'cashuRestoreWalletFromSeed','cashuGetMintUrl','cashuSetMintUrl','cashuGetFeePct'
   ];
 
-  // nav.js (5)
-  const navExports = [
-    'buildSidebar','filterSidebar','toggleNavGroup',
-    'renderProfileDropdown','renderProfileButton','getAvatarColor'
+  // nav.js (5 retained runtime hooks; delegate helpers use ESM exports)
+  const navGlobals = [
+    'buildSidebar','renderProfileDropdown','renderProfileButton',
+    'toggleMobileSidebar','closeMobileSidebar'
+  ];
+  const navModuleOnlyExports = [
+    'filterSidebar','toggleNavGroup','getAvatarColor',
+    'syncSidebarActive','openRecommendationsFromSidebar','installNavActionDelegates'
+  ];
+  const navModuleExports = [
+    ...navGlobals,
+    ...navModuleOnlyExports,
+    'configureNavActions',
   ];
 
   // notes.js (3)
@@ -667,6 +677,7 @@
     ['lab-context.js', labContextModule, labContextExports],
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
+    ['nav.js', navModule, navModuleExports],
     ['pdf-import.js', pdfImportModule, pdfImportExports],
     ['pii.js', piiModule, piiExports],
     ['profile.js', profileModule, profileExports],
@@ -703,6 +714,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of lightToolsLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of navModuleOnlyExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of pdfImportExports) {
@@ -755,7 +769,7 @@
   const allModules = {
     'chat.js': chatExports,
     'client-list.js': clientListExports,
-    'nav.js': navExports,
+    'nav.js': navGlobals,
     'notes.js': notesExports,
     'settings.js': settingsGlobals,
     'theme.js': themeExports,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.210';
+self.APP_VERSION = '1.10.211';


### PR DESCRIPTION
## Summary
- reduce the Nav browser façade from 11 globals to 5 retained shell/runtime hooks
- keep filtering, group toggles, active-state sync, avatar color, recommendations routing, and delegate installation on ESM exports
- migrate direct test callers to the Nav module and add module-boundary assertions

## Window burden remaining
- This PR removes 6 Nav globals (11 → 5).
- Static inventory after this PR: 441 unique window-published names (446 binding entries) across 27 publication sites, grouped into 14 façade families.
- Largest remaining families: Sun (88 entries), Chat (86), Sync (50), shared Utils bridges (42), Client List (34), DNA (32), Wearables (32), and Light Devices (25).
- Estimated remaining first pass: roughly 11–15 similarly scoped PRs. Some audited shell/runtime hooks will intentionally remain; the goal is zero accidental globals, not zero browser integration points.

## Tests
- `./run-tests.sh`
- `npm run quality`

Full results: 124 module checks, 398 Vitest tests, 18 origin guards, 352 Playwright tests, and 472 responsive-theme assertions passed.