### PR TITLE
Make notes module-only

### DIFF
--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -4,6 +4,31 @@
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
+/** @type {Record<string, Function | null>} */
+const dashboardNoteActions = {
+  openNoteEditor: null,
+  deleteNote: null,
+};
+
+/** @param {Record<string, any>} [actions] */
+export function configureDashboardNoteActions(actions = {}) {
+  const previous = { ...dashboardNoteActions };
+  for (const name of Object.keys(dashboardNoteActions)) {
+    if (name in actions) {
+      dashboardNoteActions[name] = typeof actions[name] === 'function' ? actions[name] : null;
+    }
+  }
+  return previous;
+}
+
+/** @param {string} name */
+function callDashboardNoteAction(name, ...args) {
+  const action = dashboardNoteActions[name];
+  if (typeof action !== 'function') return false;
+  action(...args);
+  return true;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -97,13 +122,11 @@ export function triggerDashboardDnaPicker() {
 
 /** @param {number | null} [index] */
 export function openDashboardNoteEditor(index = null) {
-  const openEditor = getRuntimeFunction('openNoteEditor');
-  if (!openEditor) return;
-  if (Number.isInteger(index) && index >= 0) openEditor(null, index);
-  else openEditor();
+  if (Number.isInteger(index) && index >= 0) callDashboardNoteAction('openNoteEditor', null, index);
+  else callDashboardNoteAction('openNoteEditor');
 }
 
 /** @param {number} index */
 export function deleteDashboardNote(index) {
-  getRuntimeFunction('deleteNote')?.(index);
+  callDashboardNoteAction('deleteNote', index);
 }

--- a/js/notes-runtime.js
+++ b/js/notes-runtime.js
@@ -46,10 +46,3 @@ export function markNoteActionDelegatesBoundRuntime() {
   runtime.__noteActionDelegatesBound = true;
   return true;
 }
-
-export function exposeNoteEditorRuntime(actions) {
-  const runtime = getNotesRuntimeWindow();
-  if (!runtime) return false;
-  Object.assign(runtime, actions);
-  return true;
-}

--- a/js/notes.js
+++ b/js/notes.js
@@ -10,9 +10,9 @@ import {
   replaceImportedArrayItem,
 } from './data-merge.js';
 import { openModalOverlay } from './modal-lifecycle.js';
+import { configureDashboardNoteActions } from './dashboard-widget-runtime.js';
 import {
   closeNoteModalRuntime,
-  exposeNoteEditorRuntime,
   isNoteActionDelegatesBoundRuntime,
   markNoteActionDelegatesBoundRuntime,
   navigateAfterNoteChangeRuntime,
@@ -169,4 +169,4 @@ export async function deleteNote(idx) {
   }
 }
 
-exposeNoteEditorRuntime({ openNoteEditor, saveNote, deleteNote });
+configureDashboardNoteActions({ openNoteEditor, deleteNote });

--- a/tests/notes-runtime.test.js
+++ b/tests/notes-runtime.test.js
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   closeNoteModalRuntime,
-  exposeNoteEditorRuntime,
   isNoteActionDelegatesBoundRuntime,
   markNoteActionDelegatesBoundRuntime,
   navigateAfterNoteChangeRuntime,
@@ -46,20 +45,13 @@ describe('notes runtime adapter', () => {
     expect(navigate).toHaveBeenNthCalledWith(2, 'dashboard');
   });
 
-  it('tracks delegated action binding and exposes note actions', () => {
+  it('tracks delegated action binding', () => {
     const runtime = {};
-    const actions = {
-      openNoteEditor: vi.fn(),
-      saveNote: vi.fn(),
-      deleteNote: vi.fn(),
-    };
     setRuntimeWindow(runtime);
 
     expect(isNoteActionDelegatesBoundRuntime()).toBe(false);
     expect(markNoteActionDelegatesBoundRuntime()).toBe(true);
     expect(isNoteActionDelegatesBoundRuntime()).toBe(true);
-    expect(exposeNoteEditorRuntime(actions)).toBe(true);
-    expect(runtime).toMatchObject(actions);
   });
 
   it('uses safe fallbacks when browser runtime hooks are missing', () => {
@@ -70,15 +62,17 @@ describe('notes runtime adapter', () => {
     expect(() => navigateAfterNoteChangeRuntime('dashboard')).not.toThrow();
     expect(isNoteActionDelegatesBoundRuntime()).toBe(false);
     expect(markNoteActionDelegatesBoundRuntime()).toBe(false);
-    expect(exposeNoteEditorRuntime({ openNoteEditor: vi.fn() })).toBe(false);
   });
 
-  it('keeps counted notes browser globals behind the adapter', () => {
+  it('keeps note actions module-only behind explicit dashboard callbacks', () => {
     const notesSrc = readFileSync(new URL('../js/notes.js', import.meta.url), 'utf8');
     const runtimeSrc = readFileSync(new URL('../js/notes-runtime.js', import.meta.url), 'utf8');
     const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
 
     expect(notesSrc).toContain("from './notes-runtime.js'");
+    expect(notesSrc).toContain("from './dashboard-widget-runtime.js'");
+    expect(notesSrc).toContain('configureDashboardNoteActions({ openNoteEditor, deleteNote });');
+    expect(notesSrc).not.toContain('exposeNoteEditorRuntime');
     expect(/\bwindow(?:\.|\s*\[)/.test(notesSrc)).toBe(false);
     expect(/\bwindow(?:\.|\s*\[)/.test(runtimeSrc)).toBe(false);
     expect(swSrc).toContain("'/js/notes-runtime.js'");

--- a/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
@@ -15,9 +15,10 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ controlsUrl }) => {
-    const [controlsModule, contextCardsRuntime] = await Promise.all([
+    const [controlsModule, contextCardsRuntime, dashboardWidgetRuntime] = await Promise.all([
       import(controlsUrl),
       import('/js/context-cards-runtime.js'),
+      import('/js/dashboard-widget-runtime.js'),
     ]);
     const outcomes = {};
     const fixture = document.getElementById('fixture');
@@ -28,12 +29,14 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
       openWearableDetail: window.openWearableDetail,
       openManualLogForm: window.openManualLogForm,
       showDetailModal: window.showDetailModal,
-      openNoteEditor: window.openNoteEditor,
-      deleteNote: window.deleteNote,
     };
     const calls = [];
     const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
       triggerDNAFilePicker: () => calls.push(['dna']),
+    });
+    const previousDashboardNoteActions = dashboardWidgetRuntime.configureDashboardNoteActions({
+      openNoteEditor: (...args) => calls.push(['noteEditor', args.length, ...args.map(arg => arg ?? 'null')]),
+      deleteNote: index => calls.push(['deleteNote', index]),
     });
     const clone = value => JSON.parse(JSON.stringify(value));
     let prefs = {
@@ -139,8 +142,6 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
       window.openWearableDetail = id => calls.push(['wearableDetail', id]);
       window.openManualLogForm = (id, event) => calls.push(['manualLog', id, event.type]);
       window.showDetailModal = id => calls.push(['markerDetail', id]);
-      window.openNoteEditor = (...args) => calls.push(['noteEditor', args.length, ...args.map(arg => arg ?? 'null')]);
-      window.deleteNote = index => calls.push(['deleteNote', index]);
       Storage.prototype.removeItem = function removeItem(key) {
         calls.push(['removeStorage', key]);
         return originalRemoveItem.call(this, key);
@@ -304,6 +305,7 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
         && controls.isOrganizeMode() === false;
     } finally {
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
+      dashboardWidgetRuntime.configureDashboardNoteActions(previousDashboardNoteActions);
       Storage.prototype.removeItem = originalRemoveItem;
       for (const [key, value] of Object.entries(saved)) {
         if (value === undefined) delete window[key];

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -5,11 +5,12 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
   await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, viewsModule] = await Promise.all([
+    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, dashboardWidgetRuntime, viewsModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/dashboard-widgets.js'),
       import('/js/context-cards-runtime.js'),
+      import('/js/dashboard-widget-runtime.js'),
       import('/js/views.js'),
     ]);
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -18,8 +19,6 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     const savedFns = {
       showDetailModal: window.showDetailModal,
       navigate: window.navigate,
-      openNoteEditor: window.openNoteEditor,
-      deleteNote: window.deleteNote,
       syncWearableNow: window.syncWearableNow,
     };
     const hadFns = {};
@@ -33,6 +32,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     let hadWearableConnections = false;
     let bodyActionHost;
     let previousContextCardsRuntime = null;
+    let previousDashboardNoteActions = null;
 
     try {
       if (!dataModule.getActiveData()?.dates?.length) {
@@ -166,10 +166,12 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
         triggerDNAFilePicker: () => bodyActionCalls.push(['dna']),
       });
+      previousDashboardNoteActions = dashboardWidgetRuntime.configureDashboardNoteActions({
+        openNoteEditor: (scope, index) => bodyActionCalls.push(['note', index]),
+        deleteNote: index => bodyActionCalls.push(['delete-note', index]),
+      });
       window.showDetailModal = id => bodyActionCalls.push(['detail', id]);
       window.navigate = route => bodyActionCalls.push(['navigate', route]);
-      window.openNoteEditor = (scope, index) => bodyActionCalls.push(['note', index]);
-      window.deleteNote = index => bodyActionCalls.push(['delete-note', index]);
       bodyActionHost = document.createElement('div');
       bodyActionHost.innerHTML = `
         <button type="button" data-dashboard-widget-action="open-marker-detail" data-dashboard-widget-id="lipids_apoB">Marker</button>
@@ -222,6 +224,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       };
     } finally {
       if (previousContextCardsRuntime) contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
+      if (previousDashboardNoteActions) dashboardWidgetRuntime.configureDashboardNoteActions(previousDashboardNoteActions);
       bodyActionHost?.remove();
       for (const [name, original] of Object.entries(savedFns)) {
         if (hadFns[name]) window[name] = original;

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -38,10 +38,11 @@ assert('dashboard widget controls render no inline event attributes',
   !/\bon(?:click|input|dragstart|dragover|drop)=/.test(controlsSrc));
 assert('dashboard widget controls import runtime adapter',
   controlsSrc.includes("from './dashboard-widget-runtime.js'"));
-assert('dashboard widget runtime owns shell callbacks',
+assert('dashboard widget runtime owns shell callbacks and explicit note actions',
   runtimeSrc.includes('openSettingsModal') &&
     runtimeSrc.includes('syncWearableNow') &&
-    runtimeSrc.includes('openNoteEditor'));
+    runtimeSrc.includes('configureDashboardNoteActions') &&
+    runtimeSrc.includes('dashboardNoteActions'));
 assert('dashboard widget controls has no direct window refs',
   !/\bwindow(\.|\s*\[)/.test(controlsSrc));
 assert('dashboard widget renderers import runtime adapter',

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -3,6 +3,7 @@
 
 import './_node-shim.js';
 import {
+  configureDashboardNoteActions,
   deleteDashboardNote,
   getDashboardDeviceSessions,
   getDashboardLightSessions,
@@ -40,8 +41,6 @@ const runtimeKeys = [
   'showDetailModal',
   'navigate',
   'triggerDNAFilePicker',
-  'openNoteEditor',
-  'deleteNote',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -66,6 +65,10 @@ try {
   const calls = [];
   const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
     triggerDNAFilePicker: () => calls.push(['dna']),
+  });
+  const previousDashboardNoteActions = configureDashboardNoteActions({
+    openNoteEditor: (...args) => calls.push(['note-editor', ...args.map(arg => arg ?? 'null')]),
+    deleteNote: index => calls.push(['delete-note', index]),
   });
   setRuntimeValue('innerHeight', 720);
   assert('getDashboardViewportHeight reads runtime innerHeight',
@@ -103,8 +106,6 @@ try {
   setRuntimeValue('showDetailModal', id => calls.push(['marker-detail', id]));
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
   setRuntimeValue('triggerDNAFilePicker', () => calls.push(['legacy-dna']));
-  setRuntimeValue('openNoteEditor', (...args) => calls.push(['note-editor', ...args.map(arg => arg ?? 'null')]));
-  setRuntimeValue('deleteNote', index => calls.push(['delete-note', index]));
 
   openDashboardWearablesSettings();
   syncDashboardWearableNow(actionEl);
@@ -134,6 +135,7 @@ try {
     openDashboardWearableDetail('sleep') === false);
 
   configureContextCardsRuntimeCallbacks({ triggerDNAFilePicker: null });
+  configureDashboardNoteActions({ openNoteEditor: null, deleteNote: null });
   delete globalThis.window;
   const callCountBeforeMissingRuntime = calls.length;
   openDashboardWearablesSettings();
@@ -151,6 +153,7 @@ try {
       getDashboardSnpTableCache() === null &&
       openDashboardWearableDetail('sleep') === false &&
       calls.length === callCountBeforeMissingRuntime);
+  configureDashboardNoteActions(previousDashboardNoteActions);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
   restoreRuntime();

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -189,7 +189,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, navModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -205,6 +205,7 @@
     import('../js/lens.js'),
     import('../js/light-tools.js'),
     import('../js/nav.js'),
+    import('../js/notes.js'),
     import('../js/pdf-import.js'),
     import('../js/pii.js'),
     import('../js/profile.js'),
@@ -477,7 +478,7 @@
     'configureNavActions',
   ];
 
-  // notes.js (3)
+  // notes.js (3 former browser globals, now module-only)
   const notesExports = [
     'openNoteEditor','saveNote','deleteNote'
   ];
@@ -678,6 +679,7 @@
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
     ['nav.js', navModule, navModuleExports],
+    ['notes.js', notesModule, notesExports],
     ['pdf-import.js', pdfImportModule, pdfImportExports],
     ['pii.js', piiModule, piiExports],
     ['profile.js', profileModule, profileExports],
@@ -717,6 +719,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of navModuleOnlyExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of notesExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of pdfImportExports) {
@@ -770,7 +775,6 @@
     'chat.js': chatExports,
     'client-list.js': clientListExports,
     'nav.js': navGlobals,
-    'notes.js': notesExports,
     'settings.js': settingsGlobals,
     'theme.js': themeExports,
     'views.js': viewsLegacyExports,

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.211';
+self.APP_VERSION = '1.10.212';


### PR DESCRIPTION
## Summary

- remove the three remaining Notes browser globals
- route dashboard note actions through explicit module callbacks
- add module-boundary coverage and bump the app cache version

## Window burden remaining

- This PR removes 3 Notes globals (3 → 0) and eliminates one publication site and façade family.
- Static inventory after this PR: **438 unique window-published names** (**443 binding entries**) across **26 publication sites**, grouped into **13 façade families**.
- Largest remaining families: Sun (88), Chat (86), Sync (50), shared Utils (42), Client List (34), DNA (32), Wearables (32), and Light Devices (25).
- Estimated remaining first pass: **10–14 similarly scoped PRs**.
- Some intentional browser integration hooks will remain; the target is zero accidental globals, not zero browser integration points.

## Tests

- `./run-tests.sh`
  - module verification: 124 passed
  - unit tests: 398 passed
  - origin guards: 18 passed
  - Playwright: 352 passed
  - responsive theme assertions: 472 passed
- focused dashboard/Notes Playwright coverage: 12 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
