### PR TITLE
Make mobile dashboard module-only

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -3,7 +3,7 @@
 
 import { configureAppEventListeners } from './app-event-listeners.js';
 import { closeChangelog } from './changelog.js';
-import { closeChatPanel, toggleChatPanel } from './chat-panel.js';
+import { closeChatPanel, configureChatPanel, toggleChatPanel } from './chat-panel.js';
 import { updateChatNudge } from './chat-nudge.js';
 import { closeSummaryModal } from './chat-summaries.js';
 import { closeClientList, configureClientListRuntime } from './client-list.js';
@@ -19,6 +19,7 @@ import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-pane
 import {
   clearDashboardWidgets,
   navigate,
+  refreshMobileDashboardActiveTab,
   resetDashboardWidgets,
   toggleDashboardOrganizeMode,
 } from './views.js';
@@ -40,9 +41,12 @@ configureSettingsRuntime({
   exportClientJSON,
   getActiveProfileId,
   openProfileShareModal,
+  refreshMobileDashboardActiveTab,
   resetDashboardWidgets,
   toggleDashboardOrganizeMode,
 });
+
+configureChatPanel({ refreshMobileDashboardActiveTab });
 
 configureAppEventListeners({
   closeChangelog,

--- a/js/chat-panel.js
+++ b/js/chat-panel.js
@@ -12,18 +12,20 @@ import {
 import { renderSavedSummaries } from './chat-summaries.js';
 import { updateLensIndicator } from './lens.js';
 import { dismissCurrentChatNudge } from './chat-nudge.js';
-import { refreshMobileDashboardActiveTabRuntime } from './chat-runtime.js';
 
 export { setChatNudge, updateChatNudge } from './chat-nudge.js';
 
 const panelCallbacks = {
   restoreDiscussionContinuePrompt: null,
+  refreshMobileDashboardActiveTab: null,
 };
 let chatThreadInputBlocked = false;
 
-/** @param {{ restoreDiscussionContinuePrompt?: (() => void) | null }} [callbacks] */
+/** @param {{ restoreDiscussionContinuePrompt?: (() => void) | null, refreshMobileDashboardActiveTab?: (() => void) | null }} [callbacks] */
 export function configureChatPanel(callbacks = {}) {
+  const previous = { ...panelCallbacks };
   Object.assign(panelCallbacks, callbacks);
+  return previous;
 }
 
 // ═══════════════════════════════════════════════
@@ -152,5 +154,5 @@ export function closeChatPanel() {
   document.body.classList.remove('chat-open', 'chat-fullscreen', 'cards-focus', 'import-focus', 'chat-autostart-reserved');
   const fab = document.getElementById('chat-fab');
   if (fab) fab.classList.remove('hidden');
-  refreshMobileDashboardActiveTabRuntime();
+  panelCallbacks.refreshMobileDashboardActiveTab?.();
 }

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -46,10 +46,6 @@ export function closeChatModalRuntime() {
   getRuntimeFunction('closeModal')?.();
 }
 
-export function refreshMobileDashboardActiveTabRuntime() {
-  getRuntimeFunction('refreshMobileDashboardActiveTab')?.();
-}
-
 export function isChatRuntimeStreaming() {
   return Boolean(getRuntimeFunction('isChatStreaming')?.());
 }

--- a/js/mobile-dashboard-runtime.js
+++ b/js/mobile-dashboard-runtime.js
@@ -80,9 +80,3 @@ export function scrollMobileDashboardToTop() {
   const runtime = getRuntimeWindow();
   if (runtime && typeof runtime.scrollTo === 'function') runtime.scrollTo(0, 0);
 }
-
-/** @param {Record<string, any>} bindings */
-export function exposeMobileDashboardBindings(bindings) {
-  const runtime = getRuntimeWindow();
-  if (runtime) Object.assign(runtime, bindings);
-}

--- a/js/mobile-dashboard.js
+++ b/js/mobile-dashboard.js
@@ -12,7 +12,6 @@ import {
   addMobileDashboardBreakpointListener,
   addMobileDashboardVisualViewportListener,
   addMobileDashboardWindowListener,
-  exposeMobileDashboardBindings,
   getMobileDashboardVisualBottomOffset,
   isMobileDashboardRuntimeViewport,
   scrollMobileDashboardToTop,
@@ -209,14 +208,6 @@ const refreshDashboardForBreakpoint = () => {
 };
 addMobileDashboardBreakpointListener(MOBILE_DASHBOARD_QUERY, refreshDashboardForBreakpoint);
 initMobileChromeStateSync();
-
-// Keep legacy mobile dashboard globals available as soon as the module loads.
-exposeMobileDashboardBindings({
-  openMobileDashboardSearch,
-  mobileDashboardJump,
-  mobileDashboardSetTab,
-  refreshMobileDashboardActiveTab,
-});
 
 export function getMobileDashboardProfile() {
   const profiles = getProfiles() || [];

--- a/js/settings.js
+++ b/js/settings.js
@@ -64,6 +64,7 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
  *   clearDashboardWidgets: () => void,
  *   resetDashboardWidgets: () => void,
  *   toggleDashboardOrganizeMode: (force?: boolean) => void,
+ *   refreshMobileDashboardActiveTab: () => void,
  * }} SettingsRuntime
  */
 
@@ -77,6 +78,7 @@ const settingsRuntime = {
   clearDashboardWidgets: () => {},
   resetDashboardWidgets: () => {},
   toggleDashboardOrganizeMode: () => {},
+  refreshMobileDashboardActiveTab: () => {},
 };
 
 /** @param {Partial<SettingsRuntime>} [runtime] */
@@ -1048,7 +1050,7 @@ export function updateSettingsUI() {
 export function closeSettingsModal() {
   closeModalOverlay('settings-modal-overlay');
   if (settingsWindow.updateChatNudge) settingsWindow.updateChatNudge();
-  settingsWindow.refreshMobileDashboardActiveTab?.();
+  settingsRuntime.refreshMobileDashboardActiveTab();
 }
 
 publishSettingsGlobals({

--- a/tests/playwright/chat-ui-browser-coverage.spec.js
+++ b/tests/playwright/chat-ui-browser-coverage.spec.js
@@ -338,15 +338,16 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
       sendDisabled: sendBtn?.disabled,
       labelDisplay: label?.style.display,
       checkboxChecked: checkbox?.checked,
-      refreshMobileDashboardActiveTab: window.refreshMobileDashboardActiveTab,
     };
     let mobileRefreshes = 0;
+    const previousChatPanelCallbacks = chatPanel.configureChatPanel({
+      refreshMobileDashboardActiveTab: () => { mobileRefreshes++; },
+    });
 
     try {
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
       localStorage.setItem('labcharts-ai-paused', 'false');
       localStorage.setItem('labcharts-chat-fullscreen', 'false');
-      window.refreshMobileDashboardActiveTab = () => { mobileRefreshes++; };
       panel?.classList.remove('open', 'chat-panel-fullscreen');
       backdrop?.classList.remove('open');
       document.body.classList.remove('chat-open', 'chat-fullscreen', 'chat-autostart-reserved');
@@ -397,8 +398,7 @@ test('chat panel browser coverage toggles web search and panel chrome', async ({
         && fab?.classList.contains('hidden') === false
         && mobileRefreshes === 1;
     } finally {
-      if (original.refreshMobileDashboardActiveTab === undefined) delete window.refreshMobileDashboardActiveTab;
-      else window.refreshMobileDashboardActiveTab = original.refreshMobileDashboardActiveTab;
+      chatPanel.configureChatPanel(previousChatPanelCallbacks);
       chatPanel.closeChatPanel();
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -430,7 +430,6 @@ const chatRuntimeDelegates = [
   ['chat-actions.js', chatActionsSrc],
   ['chat-history.js', chatHistorySrc],
   ['chat-marker-prompts.js', chatMarkerPromptsSrc],
-  ['chat-panel.js', chatPanelSrc],
   ['chat-personalities.js', chatPersonalitiesSrc],
   ['chat-discussion-round-runner.js', chatDiscussionRoundRunnerSrc],
 ];
@@ -439,6 +438,12 @@ assert('chat modules delegate direct window globals to chat runtime',
     chatRuntimeSrc.includes('export function renderChatMessagesRuntime') &&
     chatRuntimeSrc.includes('export function getChatProviderAttestation'),
   chatRuntimeDelegates.find(([name, src]) => !src.includes("from './chat-runtime.js'") || directWindowGlobalRe.test(src))?.[0] || 'missing runtime export');
+assert('chat panel refreshes the mobile dashboard through an explicit module callback',
+  chatPanelSrc.includes('refreshMobileDashboardActiveTab: null') &&
+    chatPanelSrc.includes('panelCallbacks.refreshMobileDashboardActiveTab?.()') &&
+    !chatPanelSrc.includes("from './chat-runtime.js'") &&
+    !directWindowGlobalRe.test(chatPanelSrc),
+  'found');
 assert('chat-send.js imports chat icon helpers', chatSendSrc.includes("from './chat-icons.js'"), 'found');
 assert('chat-icons.js exports button content helper', chatIconsSrc.includes('export function setIconButtonContent'), 'found');
 assert('chat window bindings import chat summary helpers',

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -8,7 +8,6 @@ import {
   getChatRegenerateCallbacks,
   isChatRuntimeStreaming,
   openChatContextModalRuntime,
-  refreshMobileDashboardActiveTabRuntime,
   renderChatMessagesRuntime,
   updateDiscussButtonRuntime,
 } from '../js/chat-runtime.js';
@@ -35,7 +34,6 @@ const runtimeKeys = [
   'updateDiscussButton',
   'openContextModal',
   'closeModal',
-  'refreshMobileDashboardActiveTab',
   'isChatStreaming',
   'sendChatMessage',
   '_ppqAttestation',
@@ -74,7 +72,6 @@ try {
   setRuntimeValue('updateDiscussButton', () => calls.push(['discuss']));
   setRuntimeValue('openContextModal', () => calls.push(['legacy-context']));
   setRuntimeValue('closeModal', () => calls.push(['close']));
-  setRuntimeValue('refreshMobileDashboardActiveTab', () => calls.push(['refresh-mobile']));
   setRuntimeValue('isChatStreaming', () => false);
   setRuntimeValue('sendChatMessage', () => calls.push(['send']));
   setRuntimeValue('_ppqAttestation', ppqAttestation);
@@ -85,13 +82,11 @@ try {
   updateDiscussButtonRuntime();
   openChatContextModalRuntime();
   closeChatModalRuntime();
-  refreshMobileDashboardActiveTabRuntime();
-  assert('chat runtime invokes render/discuss/context/close/refresh callbacks',
+  assert('chat runtime invokes render/discuss/context/close callbacks',
     calls.some(call => call[0] === 'render') &&
       calls.some(call => call[0] === 'discuss') &&
       calls.some(call => call[0] === 'context') &&
-      calls.some(call => call[0] === 'close') &&
-      calls.some(call => call[0] === 'refresh-mobile'));
+      calls.some(call => call[0] === 'close'));
 
   assert('chat runtime reports non-streaming state',
     isChatRuntimeStreaming() === false);

--- a/tests/test-mobile-dashboard-runtime.js
+++ b/tests/test-mobile-dashboard-runtime.js
@@ -5,7 +5,6 @@ import {
   addMobileDashboardBreakpointListener,
   addMobileDashboardVisualViewportListener,
   addMobileDashboardWindowListener,
-  exposeMobileDashboardBindings,
   getMobileDashboardVisualBottomOffset,
   isMobileDashboardRuntimeViewport,
   scrollMobileDashboardToTop,
@@ -27,7 +26,6 @@ const runtimeKeys = [
   'visualViewport',
   'innerHeight',
   'scrollTo',
-  'mobileDashboardProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -104,11 +102,6 @@ try {
   scrollMobileDashboardToTop();
   assert('scrollMobileDashboardToTop delegates to scrollTo',
     calls.some(call => call[0] === 'scroll' && call[1] === 0 && call[2] === 0));
-  const probe = () => 'ok';
-  exposeMobileDashboardBindings({ mobileDashboardProbe: probe });
-  assert('exposeMobileDashboardBindings assigns runtime exports',
-    globalThis.mobileDashboardProbe === probe);
-
   setRuntimeValue('matchMedia', query => ({
     media: query,
     matches: true,
@@ -133,9 +126,8 @@ try {
   addMobileDashboardWindowListener('resize', resizeListener);
   addMobileDashboardVisualViewportListener('resize', resizeListener);
   scrollMobileDashboardToTop();
-  exposeMobileDashboardBindings({ mobileDashboardProbe: null });
   assert('optional browser actions no-op without window',
-    calls.length === beforeNoWindowCalls && globalThis.mobileDashboardProbe === probe);
+    calls.length === beforeNoWindowCalls);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-mobile.js
+++ b/tests/test-mobile.js
@@ -42,6 +42,7 @@ return (async function() {
   const mobileDashboardSrc = await fetchWithRetry('js/mobile-dashboard.js');
   const dashboardControlsSrc = await fetchWithRetry('js/dashboard-widget-controls.js');
   const routerSrc = await fetchWithRetry('js/views-router.js');
+  const appShellHooksSrc = await fetchWithRetry('js/app-shell-hooks.js');
   assert('mobile landing does not auto-open fullscreen chat',
     dashboardPageViewSrc.includes('isDesktopChatOnboardingViewport') &&
     dashboardPageViewSrc.includes("if (!isDesktopChatOnboardingViewport || getDashboardPageRuntimeValue('innerWidth') <= 768) return"));
@@ -81,19 +82,20 @@ return (async function() {
     mobileDashboardSrc.includes("from './mobile-dashboard-runtime.js'") &&
     !/\bwindow(\.|\s*\[)/.test(mobileDashboardSrc) &&
     mobileDashboardRuntimeSrc.includes('isMobileDashboardRuntimeViewport') &&
-    mobileDashboardRuntimeSrc.includes('exposeMobileDashboardBindings'));
+    !mobileDashboardRuntimeSrc.includes('exposeMobileDashboardBindings'));
   const breakpointListenerIndex = mobileDashboardSrc.indexOf('addMobileDashboardBreakpointListener(MOBILE_DASHBOARD_QUERY, refreshDashboardForBreakpoint);');
   const chromeSyncIndex = mobileDashboardSrc.indexOf('initMobileChromeStateSync();');
-  const exposeBindingsIndex = mobileDashboardSrc.indexOf('exposeMobileDashboardBindings({');
   const renderMobileDashboardIndex = mobileDashboardSrc.indexOf('export function renderMobileDashboard');
   assert('mobile dashboard chrome sync starts even without breakpoint listener support',
     breakpointListenerIndex >= 0 &&
     chromeSyncIndex > breakpointListenerIndex &&
     !mobileDashboardSrc.includes('if (addMobileDashboardBreakpointListener'));
-  assert('mobile dashboard legacy globals publish before first dashboard render',
-    exposeBindingsIndex >= 0 &&
-    renderMobileDashboardIndex > exposeBindingsIndex &&
-    mobileDashboardSrc.includes('refreshMobileDashboardActiveTab,'));
+  assert('mobile dashboard actions stay module-only and use shell dependency wiring',
+    renderMobileDashboardIndex >= 0 &&
+    !mobileDashboardSrc.includes('exposeMobileDashboardBindings') &&
+    appShellHooksSrc.includes('configureChatPanel({ refreshMobileDashboardActiveTab })') &&
+    appShellHooksSrc.includes('configureSettingsRuntime({') &&
+    appShellHooksSrc.includes('refreshMobileDashboardActiveTab,'));
   assert('mobile dashboard no longer has static duplicate dashboard sections',
     !mobileDashboardSrc.includes('id="mobile-light-section"') &&
     !mobileDashboardSrc.includes('id="mobile-body-section"') &&

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -189,7 +189,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -204,6 +204,7 @@
     import('../js/lab-context.js'),
     import('../js/lens.js'),
     import('../js/light-tools.js'),
+    import('../js/mobile-dashboard.js'),
     import('../js/nav.js'),
     import('../js/notes.js'),
     import('../js/pdf-import.js'),
@@ -478,6 +479,12 @@
     'configureNavActions',
   ];
 
+  // mobile-dashboard.js (4 former browser globals, now module-only)
+  const mobileDashboardExports = [
+    'openMobileDashboardSearch','mobileDashboardJump',
+    'mobileDashboardSetTab','refreshMobileDashboardActiveTab'
+  ];
+
   // notes.js (3 former browser globals, now module-only)
   const notesExports = [
     'openNoteEditor','saveNote','deleteNote'
@@ -678,6 +685,7 @@
     ['lab-context.js', labContextModule, labContextExports],
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
+    ['mobile-dashboard.js', mobileDashboardModule, mobileDashboardExports],
     ['nav.js', navModule, navModuleExports],
     ['notes.js', notesModule, notesExports],
     ['pdf-import.js', pdfImportModule, pdfImportExports],
@@ -719,6 +727,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of navModuleOnlyExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of mobileDashboardExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of notesExports) {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.212';
+self.APP_VERSION = '1.10.213';


### PR DESCRIPTION
## Summary

- remove the four remaining Mobile Dashboard browser globals
- wire Settings and Chat refresh behavior through explicit module callbacks
- add module-boundary coverage and bump the app cache version

## Window burden remaining

- This PR removes 4 Mobile Dashboard globals (4 → 0) and eliminates one publication site and façade family.
- Static inventory after this PR: **434 unique window-published names** (**439 binding entries**) across **25 publication sites**, grouped into **12 façade families**.
- Largest remaining families: Sun (88), Chat (86), Sync (50), shared Utils (42), Client List (34), DNA (32), Wearables (32), and Light Devices (25).
- Estimated remaining first pass: **9–13 similarly scoped PRs**.
- Some intentional browser integration hooks will remain; the target is zero accidental globals, not zero browser integration points.

## Tests

- `./run-tests.sh`
  - module verification: 124 passed
  - unit tests: 398 passed
  - origin guards: 18 passed
  - Playwright: 352 passed
  - responsive theme assertions: 472 passed
- focused Mobile Dashboard/Chat/Settings Playwright coverage: 8 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
