### PR TITLE
Make changelog module-only

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -3,7 +3,7 @@
 // APP_VERSION comes from /version.js (loaded as classic script before modules)
 
 import { escapeHTML } from './utils.js';
-import { getAppVersionRuntime, registerUtilsRuntimeExports } from './utils-runtime.js';
+import { getAppVersionRuntime } from './utils-runtime.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 
 const CHANGELOG_ACTION_ATTR = 'data-changelog-action';
@@ -537,5 +537,3 @@ export function maybeShowChangelog() {
   );
   if (hasForceShowAheadOfSeen) openChangelog(false);
 }
-
-registerUtilsRuntimeExports({ openChangelog, closeChangelog, maybeShowChangelog });

--- a/js/settings.js
+++ b/js/settings.js
@@ -39,6 +39,7 @@ import {
 import { loadPdfImport } from './import-loader.js';
 import { startGuidedTour } from './tour.js';
 import { getActiveProfileId } from './profile.js';
+import { openChangelog } from './changelog.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   confirmDisablePIIReview,
@@ -418,7 +419,7 @@ async function handleSettingsClick(event) {
   } else if (action === 'open-changelog') {
     event.preventDefault();
     closeSettingsModal();
-    setTimeout(() => settingsWindow.openChangelog?.(true), 300);
+    setTimeout(() => openChangelog(true), 300);
   } else if (action === 'switch-ai-provider') {
     event.preventDefault();
     switchAIProviderBridge(actionEl.dataset.provider || 'openrouter');

--- a/tests/playwright/changelog.spec.js
+++ b/tests/playwright/changelog.spec.js
@@ -10,18 +10,18 @@ test('changelog modal opens, closes, and marks the current version as seen', asy
   await expect(overlay).toHaveCount(1);
   await expect(modal).toHaveCount(1);
 
-  await page.evaluate(() => {
-    if (typeof window.openChangelog !== 'function') throw new Error('window.openChangelog unavailable');
-    window.openChangelog(true);
+  await page.evaluate(async () => {
+    const { openChangelog } = await import('/js/changelog.js');
+    openChangelog(true);
   });
 
   await expect(overlay).toHaveClass(SHOW_CLASS_TOKEN);
   await expect(modal.locator('.modal-close')).toHaveCount(1);
   await expect(modal).toContainText("What's New");
 
-  await page.evaluate(() => {
-    if (typeof window.closeChangelog !== 'function') throw new Error('window.closeChangelog unavailable');
-    window.closeChangelog();
+  await page.evaluate(async () => {
+    const { closeChangelog } = await import('/js/changelog.js');
+    closeChangelog();
   });
 
   await expect(overlay).not.toHaveClass(SHOW_CLASS_TOKEN);
@@ -31,25 +31,24 @@ test('changelog modal opens, closes, and marks the current version as seen', asy
 test('changelog forceShow entries auto-open until the latest version is seen', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  const result = await page.evaluate(() => {
-    if (typeof window.maybeShowChangelog !== 'function') throw new Error('window.maybeShowChangelog unavailable');
-    if (typeof window.closeChangelog !== 'function') throw new Error('window.closeChangelog unavailable');
+  const result = await page.evaluate(async () => {
+    const { closeChangelog, maybeShowChangelog } = await import('/js/changelog.js');
 
     const overlay = document.getElementById('changelog-modal-overlay');
     if (!overlay) throw new Error('changelog overlay unavailable');
 
     localStorage.setItem('labcharts-changelog-seen', '1.7.0');
     overlay.classList.remove('show');
-    window.maybeShowChangelog();
+    maybeShowChangelog();
     const opensWhenForceShowIsNewer = overlay.classList.contains('show') === true;
 
-    window.closeChangelog();
-    window.maybeShowChangelog();
+    closeChangelog();
+    maybeShowChangelog();
     const staysClosedAfterLatestSeen = overlay.classList.contains('show') === false;
 
     localStorage.setItem('labcharts-changelog-seen', window.APP_VERSION);
     overlay.classList.remove('show');
-    window.maybeShowChangelog();
+    maybeShowChangelog();
     const staysClosedWhenNoForceShowIsNewer = overlay.classList.contains('show') === false;
 
     return {
@@ -69,9 +68,9 @@ test('changelog forceShow entries auto-open until the latest version is seen', a
 test('changelog renders whitelisted inline tags and safe links', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  await page.evaluate(() => {
-    if (typeof window.openChangelog !== 'function') throw new Error('window.openChangelog unavailable');
-    window.openChangelog(true);
+  await page.evaluate(async () => {
+    const { openChangelog } = await import('/js/changelog.js');
+    openChangelog(true);
   });
 
   const itemsHTML = await page.locator('#changelog-modal').evaluate((modal) => modal.innerHTML);

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -24,10 +24,10 @@ function assert(name, condition, detail) {
 
 console.log("=== What's New + Auto-Gating Tests ===\n");
 
-// changelog.js exposes openChangelog / closeChangelog / maybeShowChangelog.
+// Changelog actions are module-only.
 await import('../js/state.js');
 const { hasCardContent } = await import('../js/utils.js');
-await import('../js/changelog.js');
+const changelogModule = await import('../js/changelog.js');
 
 const changelogSrc = await fetchWithRetry('js/changelog.js');
 const utilsSrc = await fetchWithRetry('js/utils.js');
@@ -62,9 +62,12 @@ assert('changelog.js delegates modal close button without inline handlers',
   changelogSrc.includes('data-changelog-action') &&
     changelogSrc.includes('installChangelogDelegates(modal)') &&
     !/\bon(?:click|change|input|submit|keydown|keyup)=/.test(changelogSrc));
-assert('changelog.js registers legacy globals through utils runtime',
-  changelogSrc.includes('registerUtilsRuntimeExports({ openChangelog, closeChangelog, maybeShowChangelog })')
-    && !/Object\.assign\(window/.test(changelogSrc));
+assert('changelog.js keeps its actions module-only',
+  !changelogSrc.includes('registerUtilsRuntimeExports')
+    && !/Object\.assign\(window/.test(changelogSrc)
+    && typeof changelogModule.openChangelog === 'function'
+    && typeof changelogModule.closeChangelog === 'function'
+    && typeof changelogModule.maybeShowChangelog === 'function');
 assert('changelog.js has getMajorMinor helper', changelogSrc.includes('function getMajorMinor'));
 assert('maybeShowChangelog compares major.minor only', changelogSrc.includes('getMajorMinor(seen) !== getMajorMinor('));
 // forceShow patch-bump escape hatch — when a maintainer flags an entry as
@@ -288,13 +291,13 @@ assert('APP_VERSION is at least the Biology Scores main release',
   versionMatch && semverGte(appVersion, '1.9.0'), appVersion);
 
 // ═══════════════════════════════════════
-// 11. Window exports
+// 11. Module boundary
 // ═══════════════════════════════════════
-console.log('11. Window Exports');
+console.log('11. Module Boundary');
 
-assert('closeChangelog on window', typeof window.closeChangelog === 'function');
-assert('openChangelog on window', typeof window.openChangelog === 'function');
-assert('maybeShowChangelog on window', typeof window.maybeShowChangelog === 'function');
+assert('closeChangelog stays off window', !('closeChangelog' in window));
+assert('openChangelog stays off window', !('openChangelog' in window));
+assert('maybeShowChangelog stays off window', !('maybeShowChangelog' in window));
 
 // ═══════════════════════════════════════
 // 12. Source-code regex defenses (inline-tag whitelist + href safety)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -189,10 +189,11 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
+    import('../js/changelog.js'),
     import('../js/charts.js'),
     import('../js/context-cards.js'),
     import('../js/crypto.js'),
@@ -464,6 +465,11 @@
     'cashuRestoreWalletFromSeed','cashuGetMintUrl','cashuSetMintUrl','cashuGetFeePct'
   ];
 
+  // changelog.js (3 former browser globals, now module-only)
+  const changelogExports = [
+    'openChangelog','closeChangelog','maybeShowChangelog'
+  ];
+
   // nav.js (5 retained runtime hooks; delegate helpers use ESM exports)
   const navGlobals = [
     'buildSidebar','renderProfileDropdown','renderProfileButton',
@@ -674,6 +680,7 @@
   for (const [moduleName, moduleApi, exports] of [
     ['backup.js', backupModule, backupExports],
     ['cashu-wallet.js', cashuWalletModule, cashuWalletExports],
+    ['changelog.js', changelogModule, changelogExports],
     ['charts.js', chartsModule, chartsExports],
     ['context-cards.js', contextCardsModule, contextCardsExports],
     ['crypto.js', cryptoModule, cryptoExports],
@@ -764,6 +771,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of cashuWalletLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of changelogExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of providerPanelsExports) {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.213';
+self.APP_VERSION = '1.10.214';


### PR DESCRIPTION
## Summary

- remove the three Changelog browser globals
- launch What's New from Settings through the changelog module
- update module/browser boundary coverage and bump the app cache version

## Window burden remaining

- This PR removes 3 Changelog globals (3 → 0) and eliminates one publication site; the broader shared Utils façade family remains.
- Static inventory after this PR: **431 unique window-published names** (**436 binding entries**) across **24 publication sites**, grouped into **12 façade families**.
- Largest remaining families: Sun (88), Chat (86), Sync (50), shared Utils (39), Client List (34), DNA (32), Wearables (32), and Light Devices (25).
- Estimated remaining first pass: **8–12 similarly scoped PRs**.
- Some intentional browser integration hooks will remain; the target is zero accidental globals, not zero browser integration points.

## Tests

- `./run-tests.sh`
  - module verification: 124 passed
  - unit tests: 398 passed
  - origin guards: 18 passed
  - Playwright: 352 passed
  - responsive theme assertions: 472 passed
- focused Changelog/Settings Playwright coverage: 5 passed
- targeted Changelog assertions: 86 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
