### PR TITLE
Make feedback module-only

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -10,7 +10,7 @@ import { closeClientList, configureClientListRuntime } from './client-list.js';
 import { closeEMFInterpretation } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder } from './export.js';
 import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
-import { closeFeedbackModal } from './feedback.js';
+import { closeFeedbackModal, openFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { closeModal } from './marker-detail-modal.js';
 import { closeMobileSidebar } from './nav.js';
@@ -40,6 +40,7 @@ configureSettingsRuntime({
   exportAllDataJSON,
   exportClientJSON,
   getActiveProfileId,
+  openFeedbackModal,
   openProfileShareModal,
   refreshMobileDashboardActiveTab,
   resetDashboardWidgets,

--- a/js/feedback.js
+++ b/js/feedback.js
@@ -5,7 +5,7 @@ import { escapeAttr, escapeHTML, showNotification } from './utils.js';
 import { getTheme } from './theme.js';
 import { getAIProvider } from './api.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
-import { openUtilsRuntimeWindow, registerUtilsRuntimeExports } from './utils-runtime.js';
+import { openUtilsRuntimeWindow } from './utils-runtime.js';
 
 const FEEDBACK_TYPES = [
   { value: 'bug', label: 'Bug Report', prefix: '[Bug]', ghLabel: 'bug', placeholder: 'Brief description of the bug' },
@@ -19,9 +19,6 @@ let _feedbackActionDelegatesInstalled = false;
 const FEEDBACK_ACTION_ATTR = 'data-feedback-action';
 const FEEDBACK_ACTION_SELECTOR = `[${FEEDBACK_ACTION_ATTR}]`;
 const appWindow = /** @type {Window & typeof globalThis & {
-  closeFeedbackModal?: () => void,
-  submitFeedback?: () => void,
-  _updateFeedbackPlaceholder?: () => void,
   __feedbackActionDelegatesBound?: boolean,
 }} */ (typeof window !== 'undefined' ? window : {});
 
@@ -40,7 +37,7 @@ function closestFeedbackAction(target) {
 function handleFeedbackActionClick(event) {
   const actionEl = closestFeedbackAction(event.target);
   if (!actionEl || actionEl.getAttribute(FEEDBACK_ACTION_ATTR) !== 'close') return;
-  appWindow.closeFeedbackModal?.();
+  closeFeedbackModal();
   event.preventDefault();
 }
 
@@ -48,13 +45,13 @@ function handleFeedbackActionSubmit(event) {
   const actionEl = closestFeedbackAction(event.target);
   if (!actionEl || actionEl.getAttribute(FEEDBACK_ACTION_ATTR) !== 'submit') return;
   event.preventDefault();
-  appWindow.submitFeedback?.();
+  submitFeedback();
 }
 
 function handleFeedbackActionChange(event) {
   const actionEl = closestFeedbackAction(event.target);
   if (!actionEl || actionEl.getAttribute(FEEDBACK_ACTION_ATTR) !== 'placeholder') return;
-  appWindow._updateFeedbackPlaceholder?.();
+  _updateFeedbackPlaceholder();
 }
 
 export function installFeedbackActionDelegates(root = typeof document !== 'undefined' ? document : null) {
@@ -163,5 +160,3 @@ function _updateFeedbackPlaceholder() {
   const titleInput = /** @type {HTMLInputElement | null} */ (document.getElementById('feedback-title'));
   if (titleInput) titleInput.placeholder = typeDef.placeholder;
 }
-
-registerUtilsRuntimeExports({ openFeedbackModal, closeFeedbackModal, submitFeedback, _updateFeedbackPlaceholder });

--- a/js/settings.js
+++ b/js/settings.js
@@ -61,6 +61,7 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
  *   exportAllDataJSON: () => Promise<void> | void,
  *   exportClientJSON: (profileId?: string | null) => Promise<void> | void,
  *   getActiveProfileId: () => string | null,
+ *   openFeedbackModal: () => void,
  *   openProfileShareModal: (profileId?: string) => void,
  *   clearDashboardWidgets: () => void,
  *   resetDashboardWidgets: () => void,
@@ -75,6 +76,7 @@ const settingsRuntime = {
   exportAllDataJSON: () => {},
   exportClientJSON: () => {},
   getActiveProfileId,
+  openFeedbackModal: () => {},
   openProfileShareModal: () => {},
   clearDashboardWidgets: () => {},
   resetDashboardWidgets: () => {},
@@ -548,7 +550,7 @@ function handleTweaksClick(event) {
   } else if (action === 'send-feedback') {
     event.preventDefault();
     closeTweaksPanel();
-    settingsWindow.openFeedbackModal?.();
+    settingsRuntime.openFeedbackModal();
   }
 }
 

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -2,14 +2,22 @@
 // shell-actions.js - delegated actions for static index.html controls
 
 import { handleImportStatusClick, isImportRunning } from './pdf-import-progress.js';
+import { openFeedbackModal } from './feedback.js';
 
 let shellDelegatesInstalled = false;
 const shellImportDeps = { handleImportStatusClick, isImportRunning };
+const shellFeedbackDeps = { openFeedbackModal };
 
 export function configureShellImportDeps(deps = {}) {
   const previous = { ...shellImportDeps };
   if (typeof deps.handleImportStatusClick === 'function') shellImportDeps.handleImportStatusClick = deps.handleImportStatusClick;
   if (typeof deps.isImportRunning === 'function') shellImportDeps.isImportRunning = deps.isImportRunning;
+  return previous;
+}
+
+export function configureShellFeedbackDeps(deps = {}) {
+  const previous = { ...shellFeedbackDeps };
+  if (typeof deps.openFeedbackModal === 'function') shellFeedbackDeps.openFeedbackModal = deps.openFeedbackModal;
   return previous;
 }
 
@@ -60,7 +68,7 @@ function runShellAction(action) {
     callShellRuntime('openSettingsModal', 'ai');
     return true;
   } else if (action === 'open-feedback') {
-    callShellRuntime('openFeedbackModal');
+    shellFeedbackDeps.openFeedbackModal();
     return true;
   } else if (action === 'import-status') {
     shellImportDeps.handleImportStatusClick();

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -100,6 +100,10 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       await wait(0);
       results.handleTweaksChange = localStorage.getItem('labcharts-sunset-mode') === 'true'
         && document.documentElement.dataset.sunsetMode === 'on';
+      document.querySelector('[data-tweaks-action="send-feedback"]').click();
+      results.tweaksFeedbackUsesModuleRuntime = document.getElementById('feedback-modal-overlay')?.classList.contains('show') === true
+        && !document.getElementById('tweaks-panel-overlay');
+      (await import('/js/feedback.js')).closeFeedbackModal();
 
       localStorage.removeItem('labcharts-pii-review-disable-ack');
       localStorage.setItem('labcharts-pii-review', 'true');

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -25,13 +25,15 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       isImportRunning: () => importRunning,
       handleImportStatusClick: () => calls.push(['handleImportStatusClick']),
     });
+    const previousShellFeedbackDeps = shellActions.configureShellFeedbackDeps({
+      openFeedbackModal: () => calls.push(['openFeedbackModal']),
+    });
     const originalFns = {
       toggleMobileSidebar: window.toggleMobileSidebar,
       closeMobileSidebar: window.closeMobileSidebar,
       openProfileShareModal: window.openProfileShareModal,
       openTweaksPanel: window.openTweaksPanel,
       openSettingsModal: window.openSettingsModal,
-      openFeedbackModal: window.openFeedbackModal,
       toggleChatPanel: window.toggleChatPanel,
       closeChatPanel: window.closeChatPanel,
       toggleThreadRail: window.toggleThreadRail,
@@ -191,6 +193,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
         && personalityEscape.defaultPrevented === false;
     } finally {
       shellActions.configureShellImportDeps(previousShellImportDeps);
+      shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
       for (const [name, value] of Object.entries(originalFns)) {
         if (value === undefined) delete window[name];
         else window[name] = value;

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -132,6 +132,9 @@ assert('Delegated settings handler switches tabs',
   /closestWithin\(event, '\[data-settings-tab\]', modal\)[\s\S]*switchSettingsTab/.test(src));
 assert('Delegated tweaks handler closes on backdrop click',
   /event\.target === overlay[\s\S]*closeTweaksPanel\(\)/.test(src));
+assert('Tweaks feedback action uses configured module runtime',
+  src.includes('settingsRuntime.openFeedbackModal()')
+    && !src.includes('settingsWindow.openFeedbackModal'));
 assert('Delegated settings handler switches AI providers',
   /action === 'switch-ai-provider'[\s\S]*switchAIProviderBridge\(actionEl\.dataset\.provider/.test(src));
 assert('Delegated settings handler updates PII model selection',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -55,6 +55,11 @@ assert('Shell action import-status is handled for compatibility but not rendered
   shellSrc.includes("action === 'import-status'")
     && !html.includes('data-shell-action="import-status"'));
 
+assert('Feedback shell action uses its module dependency instead of a window lookup',
+  shellSrc.includes("import { openFeedbackModal } from './feedback.js'")
+    && shellSrc.includes('shellFeedbackDeps.openFeedbackModal()')
+    && !shellSrc.includes("callShellRuntime('openFeedbackModal')"));
+
 [
   'toggle-panel',
   'close-panel',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -189,7 +189,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, feedbackModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -202,6 +202,7 @@
     import('../js/emf.js'),
     import('../js/emf-runtime.js'),
     import('../js/export.js'),
+    import('../js/feedback.js'),
     import('../js/lab-context.js'),
     import('../js/lens.js'),
     import('../js/light-tools.js'),
@@ -470,6 +471,14 @@
     'openChangelog','closeChangelog','maybeShowChangelog'
   ];
 
+  // feedback.js (4 former browser globals, now module-only; 3 are public exports)
+  const feedbackExports = [
+    'openFeedbackModal','closeFeedbackModal','submitFeedback'
+  ];
+  const feedbackLegacyGlobals = [
+    ...feedbackExports,'_updateFeedbackPlaceholder'
+  ];
+
   // nav.js (5 retained runtime hooks; delegate helpers use ESM exports)
   const navGlobals = [
     'buildSidebar','renderProfileDropdown','renderProfileButton',
@@ -689,6 +698,7 @@
     ['emf.js', emfModule, emfExports],
     ['emf-runtime.js', emfRuntimeModule, emfRuntimeExports],
     ['export.js', exportModule, exportExports],
+    ['feedback.js', feedbackModule, feedbackExports],
     ['lab-context.js', labContextModule, labContextExports],
     ['lens.js', lensModule, lensExports],
     ['light-tools.js', lightToolsModule, lightToolsExports],
@@ -774,6 +784,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of changelogExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of feedbackLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of providerPanelsExports) {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.214';
+self.APP_VERSION = '1.10.215';


### PR DESCRIPTION
## Summary

- remove the four Feedback runtime bindings from `window`
- route the shell and Tweaks feedback actions through explicit module dependencies
- keep Feedback's delegated modal handlers local to the module
- verify the former globals remain absent and cover the live shell/Tweaks flows
- bump the app cache version to 1.10.215

## Tests

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test` — 398 passed
- `node tests/verify-modules.js` — 124 passed
- focused Feedback/Shell/Settings Playwright — 3 passed
- `./run-tests.sh` — 124 module checks, 398 Vitest tests, 18 origin guards, 352 Playwright tests, and 472 responsive-theme assertions passed

## Window burden remaining

- This PR removes 4 browser globals and 1 publication site: `openFeedbackModal`, `closeFeedbackModal`, `submitFeedback`, and `_updateFeedbackPlaceholder`.
- Static inventory after this PR: **427 unique window names**, **432 binding entries**, **23 publication sites**, and **12 facade families**.
- Largest remaining families: Sun (88), Chat (86), Sync (50), shared Utils runtime (35), Client List (34), DNA (32), Wearables (32), Light Devices (25), Recommendations (22), and Theme (16).
- Estimated remaining first pass: **about 7–11 similarly scoped PRs**. Larger facades will need to be split, and intentional compatibility/debug/test hooks will be assessed individually rather than removed blindly.