### PR TITLE
Make Nostr discovery module-only

### DIFF
--- a/js/export-import.js
+++ b/js/export-import.js
@@ -20,8 +20,8 @@ import {
   clearDemoLoadingProfile,
   isDemoLoadingProfile,
   refreshImportRuntimeShell,
-  restoreWalletBundleSettings,
 } from './export-runtime.js';
+import { setSelectedNodeUrl } from './nostr-discovery.js';
 
 async function _importChatData(profileId, chat) {
   if (!chat || !Array.isArray(chat.threads)) return;
@@ -672,7 +672,7 @@ async function _importDatabaseBundle(json) {
   // state is not a safe wallet backup.
   if (json.wallet) {
     try {
-      await restoreWalletBundleSettings(json.wallet);
+      if (json.wallet.nodeUrl) setSelectedNodeUrl(json.wallet.nodeUrl);
     } catch (e) {
       if (isDebugMode()) console.log('[import] Wallet restore failed:', e.message);
     }

--- a/js/export-runtime.js
+++ b/js/export-runtime.js
@@ -121,22 +121,6 @@ async function refreshChatThreadsRuntime(chatThreads) {
   else renderThreadListFallback();
 }
 
-export async function getWalletBundleSettings() {
-  const runtime = getRuntimeWindow();
-  const nodeUrl = typeof runtime.nostrGetSelectedNode === 'function'
-    ? runtime.nostrGetSelectedNode()
-    : null;
-  return { nodeUrl };
-}
-
-export async function restoreWalletBundleSettings(wallet) {
-  if (!wallet) return;
-  const runtime = getRuntimeWindow();
-  if (wallet.nodeUrl && typeof runtime.nostrSetSelectedNode === 'function') {
-    runtime.nostrSetSelectedNode(wallet.nodeUrl);
-  }
-}
-
 export async function destroyWalletRuntimeDB() {
   await destroyWalletDB();
 }

--- a/js/export.js
+++ b/js/export.js
@@ -9,6 +9,7 @@ import { encryptedGetItem, getEncryptionEnabled, encryptedRemoveItem } from './c
 import { findOrCreateLabEntry } from './lab-entry-mutations.js';
 import { setLabEntryMarker } from './lab-entry.js';
 import { importDataJSON } from './export-import.js';
+import { getSelectedNodeUrl } from './nostr-discovery.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   generateReportAISummary as generateReportAISummaryImpl,
@@ -24,7 +25,6 @@ import {
 import {
   clearDemoLoadingProfile,
   destroyWalletRuntimeDB,
-  getWalletBundleSettings,
   markDemoLoadingProfile,
   refreshImportRuntimeShell,
 } from './export-runtime.js';
@@ -273,7 +273,7 @@ export async function buildAllDataBundle() {
   }
   // Wallet identity and proofs are deliberately excluded: exporting only a
   // seed or mint would create an incomplete and unsafe wallet backup.
-  const { nodeUrl: walletNodeUrl } = await getWalletBundleSettings();
+  const walletNodeUrl = getSelectedNodeUrl();
   if (walletNodeUrl) {
     bundle.wallet = { nodeUrl: walletNodeUrl };
   }

--- a/js/nostr-discovery.js
+++ b/js/nostr-discovery.js
@@ -4,7 +4,6 @@
 
 import { isDebugMode } from './utils.js';
 import { isValidExternalUrl } from './url-safety.js';
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
 import {
   dispatchAISettingsLocalChangedRuntime,
   touchRoutstrSessionClock,
@@ -228,13 +227,3 @@ export function clearNodeCache() {
   _cachedNodes = null;
   _cacheTime = 0;
 }
-
-// ═══════════════════════════════════════════════
-// RUNTIME EXPORTS
-// ═══════════════════════════════════════════════
-registerUtilsRuntimeExports({
-  nostrDiscoverNodes: discoverNodes,
-  nostrGetSelectedNode: getSelectedNodeUrl,
-  nostrSetSelectedNode: setSelectedNodeUrl,
-  nostrClearNodeCache: clearNodeCache,
-});

--- a/js/provider-panel-renderers-runtime.js
+++ b/js/provider-panel-renderers-runtime.js
@@ -1,32 +1,30 @@
 // @ts-check
-// provider-panel-renderers-runtime.js - Browser runtime hooks for provider panel renderers.
+// provider-panel-renderers-runtime.js - Nostr dependencies for provider panel renderers.
 
-/**
- * @returns {Record<string, any>}
- */
-function getProviderPanelRendererRuntimeScope() {
-  return typeof window !== 'undefined'
-    ? /** @type {Record<string, any>} */ (window)
-    : /** @type {Record<string, any>} */ (globalThis);
-}
+import { discoverNodes, getSelectedNodeUrl, setSelectedNodeUrl } from './nostr-discovery.js';
 
-/**
- * @param {string} name
- * @returns {((...args: any[]) => any) | null}
- */
-function getProviderPanelRendererRuntimeFunction(name) {
-  const runtime = getProviderPanelRendererRuntimeScope();
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : null;
+const providerPanelRendererDefaults = {
+  discoverNodes,
+  getSelectedNodeUrl,
+  setSelectedNodeUrl,
+};
+const providerPanelRendererRuntime = { ...providerPanelRendererDefaults };
+
+export function configureProviderPanelRendererRuntime(overrides = {}) {
+  const previous = { ...providerPanelRendererRuntime };
+  Object.assign(providerPanelRendererRuntime, providerPanelRendererDefaults, overrides);
+  return previous;
 }
 
 export function getSelectedRoutstrNodeFromRuntime() {
-  return getProviderPanelRendererRuntimeFunction('nostrGetSelectedNode')?.() || null;
+  return typeof providerPanelRendererRuntime.getSelectedNodeUrl === 'function'
+    ? providerPanelRendererRuntime.getSelectedNodeUrl() || null
+    : null;
 }
 
 export function discoverRoutstrNodesFromRuntime() {
-  const discover = getProviderPanelRendererRuntimeFunction('nostrDiscoverNodes');
-  if (!discover) return null;
+  const discover = providerPanelRendererRuntime.discoverNodes;
+  if (typeof discover !== 'function') return null;
   const result = discover();
   return result && typeof result.then === 'function' ? result : null;
 }
@@ -35,5 +33,7 @@ export function discoverRoutstrNodesFromRuntime() {
  * @param {string} nodeUrl
  */
 export function setSelectedRoutstrNodeFromRuntime(nodeUrl) {
-  getProviderPanelRendererRuntimeFunction('nostrSetSelectedNode')?.(nodeUrl);
+  if (typeof providerPanelRendererRuntime.setSelectedNodeUrl === 'function') {
+    providerPanelRendererRuntime.setSelectedNodeUrl(nodeUrl);
+  }
 }

--- a/tests/playwright/nostr-chat-continuation-browser-coverage.spec.js
+++ b/tests/playwright/nostr-chat-continuation-browser-coverage.spec.js
@@ -143,10 +143,10 @@ test('nostr discovery browser coverage handles relay parsing cache health and se
       const onionUrlSkipped = nodes.find(node => node.id === 'provider-b');
       const noPublicUrl = nodes.find(node => node.id === 'provider-c');
 
-      outcomes.windowExportsAreInstalled = window.nostrDiscoverNodes === nostr.discoverNodes
-        && window.nostrGetSelectedNode === nostr.getSelectedNodeUrl
-        && window.nostrSetSelectedNode === nostr.setSelectedNodeUrl
-        && window.nostrClearNodeCache === nostr.clearNodeCache;
+      outcomes.discoveryApiStaysModuleOnly = !('nostrDiscoverNodes' in window)
+        && !('nostrGetSelectedNode' in window)
+        && !('nostrSetSelectedNode' in window)
+        && !('nostrClearNodeCache' in window);
 
       outcomes.relaysSendKindRequestAndResolveOnEose = wsInstances.length === 4
         && wsInstances.some(ws => {

--- a/tests/playwright/report-export-browser-coverage.spec.js
+++ b/tests/playwright/report-export-browser-coverage.spec.js
@@ -985,14 +985,14 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
       aiProvider: localStorage.getItem('labcharts-ai-provider'),
       aiPaused: localStorage.getItem('labcharts-ai-paused'),
       openrouterKey: localStorage.getItem('labcharts-openrouter-key'),
+      routstrNode: localStorage.getItem('labcharts-routstr-node'),
+      routstrSessionUpdatedAt: localStorage.getItem('labcharts-routstr-session-updated-at'),
       fileReader: window.FileReader,
       createObjectURL: URL.createObjectURL,
       revokeObjectURL: URL.revokeObjectURL,
       anchorClick: HTMLAnchorElement.prototype.click,
       cashuGetMintUrl: window.cashuGetMintUrl,
-      nostrGetSelectedNode: window.nostrGetSelectedNode,
       cashuSetMintUrl: window.cashuSetMintUrl,
-      nostrSetSelectedNode: window.nostrSetSelectedNode,
     };
     const waitFor = async (predicate, label) => {
       for (let i = 0; i < 80; i += 1) {
@@ -1060,8 +1060,8 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
       localStorage.setItem(`labcharts-${profileId}-chat-threads`, JSON.stringify([{
         id: 'thread-one',
         title: 'Export thread',
-        createdAt: 1,
-        updatedAt: 2,
+        createdAt: '2026-06-03T08:00:00.000Z',
+        updatedAt: '2026-06-03T09:00:00.000Z',
       }]));
       localStorage.setItem(`labcharts-${profileId}-chat-t_thread-one`, JSON.stringify([
         { role: 'user', content: 'What changed?' },
@@ -1085,7 +1085,7 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
         });
       };
       window.cashuGetMintUrl = async () => 'https://mint.example';
-      window.nostrGetSelectedNode = () => 'wss://relay.example';
+      localStorage.setItem('labcharts-routstr-node', 'https://node.export.test');
 
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ai-paused', 'true');
@@ -1115,7 +1115,7 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
         && allDataBundle.type === 'database'
         && allDataBundle.profiles.length === 1
         && allDataBundle.profiles[0].chat.threads[0].id === 'thread-one'
-        && allDataBundle.wallet.nodeUrl === 'wss://relay.example'
+        && allDataBundle.wallet.nodeUrl === 'https://node.export.test'
         && !Object.prototype.hasOwnProperty.call(allDataBundle.wallet, 'mintUrl')
         && revokedUrls.length === 3;
 
@@ -1175,11 +1175,6 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
         writable: true,
         value: async url => { restoredMintUrl = url; },
       });
-      Object.defineProperty(window, 'nostrSetSelectedNode', {
-        configurable: true,
-        writable: true,
-        value: () => {},
-      });
       const databaseBundle = {
         type: 'database',
         profiles: [
@@ -1229,7 +1224,7 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
         ],
         wallet: {
           mintUrl: 'https://mint.restore',
-          nodeUrl: 'wss://relay.restore',
+          nodeUrl: 'https://node.restore.test',
         },
       };
       await exportFacade.importDataJSON(new File([JSON.stringify(databaseBundle)], 'database-bundle.json', { type: 'application/json' }));
@@ -1246,6 +1241,7 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
         && mergedThreads.some(thread => thread.id === 'bundle-thread')
         && !!newBundleProfile
         && restoredMintUrl === null;
+      outcomes.databaseBundleRestoresNodeThroughModuleRuntime = localStorage.getItem('labcharts-routstr-node') === 'https://node.restore.test';
 
       const clearPromise = exportFacade.clearAllData();
       const cancelButton = await waitFor(() => document.getElementById('confirm-cancel'), 'clear data cancel button');
@@ -1262,12 +1258,8 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
       HTMLAnchorElement.prototype.click = original.anchorClick;
       if (original.cashuGetMintUrl === undefined) delete window.cashuGetMintUrl;
       else window.cashuGetMintUrl = original.cashuGetMintUrl;
-      if (original.nostrGetSelectedNode === undefined) delete window.nostrGetSelectedNode;
-      else window.nostrGetSelectedNode = original.nostrGetSelectedNode;
       if (original.cashuSetMintUrl === undefined) delete window.cashuSetMintUrl;
       else window.cashuSetMintUrl = original.cashuSetMintUrl;
-      if (original.nostrSetSelectedNode === undefined) delete window.nostrSetSelectedNode;
-      else window.nostrSetSelectedNode = original.nostrSetSelectedNode;
 
       const originalIds = new Set(original.profiles.map(profile => profile.id));
       const touchedIds = new Set([profileId]);
@@ -1289,6 +1281,8 @@ test('export facade covers JSON downloads imports chat bundle and clear cancel',
       setOrRemove('labcharts-ai-provider', original.aiProvider);
       setOrRemove('labcharts-ai-paused', original.aiPaused);
       setOrRemove('labcharts-openrouter-key', original.openrouterKey);
+      setOrRemove('labcharts-routstr-node', original.routstrNode);
+      setOrRemove('labcharts-routstr-session-updated-at', original.routstrSessionUpdatedAt);
       document.getElementById('confirm-dialog-overlay')?.classList.remove('show');
     }
 

--- a/tests/test-cashu-wallet.js
+++ b/tests/test-cashu-wallet.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // test-cashu-wallet.js — Cashu wallet module, Nostr discovery, integration
-// points. Module + window exports, wallet security/proof-management/recovery/
+// points. Module exports, wallet security/proof-management/recovery/
 // fee-mechanism source inspection, Nostr protocol + node parsing, API node-URL
 // guard, sync + export/import + service-worker wiring, BIP-39 seed generation,
 // and SSRF-validation wiring on setMintUrl / setSelectedNodeUrl.
@@ -48,7 +48,7 @@ await import('../js/crypto.js');
 // bip39-minimal.js self-assigns to globalThis.bip39.
 await import('../vendor/bip39-minimal.js');
 const wallet = await import('../js/cashu-wallet.js');
-await import('../js/nostr-discovery.js');
+const discoveryModule = await import('../js/nostr-discovery.js');
 
 const walletSrc = await fetchWithRetry('js/cashu-wallet.js');
 const walletStoreSrc = await fetchWithRetry('js/cashu-wallet-store.js');
@@ -217,8 +217,10 @@ for (const fn of discoveryExports) {
 
 const discoveryWindowExports = ['nostrDiscoverNodes', 'nostrGetSelectedNode', 'nostrSetSelectedNode', 'nostrClearNodeCache'];
 for (const fn of discoveryWindowExports) {
-  assert(`window.${fn} exists`, typeof window[fn] === 'function');
+  assert(`window.${fn} stays module-only`, !(fn in window));
 }
+assert('Nostr discovery no longer registers runtime exports',
+  !discoverySrc.includes('registerUtilsRuntimeExports'));
 
 // ═══════════════════════════════════════
 // 8. NOSTR DISCOVERY — PROTOCOL
@@ -292,13 +294,12 @@ console.log('12. Export/Import Integration');
 assert('Bundle includes wallet settings', exportSrc.includes('bundle.wallet'));
 const exportImportSrc = await fetchWithRetry('js/export-import.js');
 assert('Bundle never restores incomplete wallet identity',
-  exportImportSrc.includes('restoreWalletBundleSettings') &&
+  exportImportSrc.includes('setSelectedNodeUrl') &&
   !exportRuntimeSrc.includes('wallet.mintUrl') &&
   !exportRuntimeSrc.includes('wallet.mnemonic'));
-assert('Bundle restores node URL through export runtime',
-  exportImportSrc.includes('restoreWalletBundleSettings') &&
-  exportRuntimeSrc.includes('wallet.nodeUrl') &&
-  exportRuntimeSrc.includes('nostrSetSelectedNode'));
+assert('Bundle restores node URL through the Nostr module',
+  exportImportSrc.includes("from './nostr-discovery.js'") &&
+  exportImportSrc.includes('setSelectedNodeUrl(json.wallet.nodeUrl)'));
 assert('clearAllData destroys wallet DB through export runtime',
   exportSrc.includes('destroyWalletRuntimeDB') &&
   exportRuntimeSrc.includes("import { destroyWalletDB } from './cashu-wallet.js'") &&
@@ -463,7 +464,7 @@ assert('Two generations differ', mnemonic !== mnemonic2);
 // sites actually invokes it.
 console.log('18. SSRF Validation Wiring');
 
-const discovery = await import('../js/nostr-discovery.js');
+const discovery = discoveryModule;
 
 async function expectMintRejection(url, label) {
   let threw = false;

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -470,7 +470,6 @@ try {
     swSrc.includes("'/js/profile-runtime.js'"));
   assert('export.js delegates browser runtime wiring to export-runtime',
     exportSrc.includes("from './export-runtime.js'") &&
-    exportSrc.includes('getWalletBundleSettings') &&
     exportSrc.includes('refreshImportRuntimeShell') &&
     !exportSrc.includes('publishExportGlobals') &&
     !exportRuntimeSrc.includes('publishExportGlobals') &&
@@ -499,6 +498,11 @@ try {
     exportRuntimeSrc.includes('if (chat) await refreshChatThreadsRuntime(chatThreads)'));
   assert('export.js no longer calls import UI globals through window',
     !/window\.(loadChatThreads|buildSidebar|updateHeaderDates|renderProfileButton|navigate|cashuGetMintUrl|nostrGetSelectedNode|cashuRestoreWalletFromSeed|cashuSetMintUrl|nostrSetSelectedNode|cashuDestroyWalletDB)/.test(exportSrc));
+  assert('export.js uses the Nostr module for wallet metadata',
+    exportSrc.includes("from './nostr-discovery.js'") &&
+    exportSrc.includes('getSelectedNodeUrl()') &&
+    !exportRuntimeSrc.includes('nostrGetSelectedNode') &&
+    !exportRuntimeSrc.includes('nostrSetSelectedNode'));
   assert('Service worker precaches export runtime module',
     swSrc.includes("'/js/export-runtime.js'"));
 } catch (e) {

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -490,12 +490,13 @@ return (async function() {
 
   assert('Bundle wallet export includes only node URL in source', exportSrc.includes('bundle.wallet = { nodeUrl:'));
   assert('Bundle wallet export excludes Cashu mint and seed settings',
-    exportSrc.includes('getWalletBundleSettings') &&
+    exportSrc.includes('getSelectedNodeUrl') &&
     !exportRuntimeSrc.includes('cashuGetMintUrl') &&
     !exportRuntimeSrc.includes('cashuGetWalletMnemonic'));
-  assert('Bundle wallet checks nostrGetSelectedNode through export runtime',
-    exportSrc.includes('getWalletBundleSettings') &&
-    exportRuntimeSrc.includes('nostrGetSelectedNode'));
+  assert('Bundle wallet reads the selected node through the Nostr module',
+    exportSrc.includes("from './nostr-discovery.js'") &&
+    exportSrc.includes('getSelectedNodeUrl()') &&
+    exportImportSrc.includes('setSelectedNodeUrl(json.wallet.nodeUrl)'));
 
   // ═══════════════════════════════════════
   // 12. exportDataJSON is alias for exportClientJSON

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const renderSrc = fs.readFileSync(path.join(root, 'js/provider-panel-renderers.js'), 'utf8');
+const renderRuntimeSrc = fs.readFileSync(path.join(root, 'js/provider-panel-renderers-runtime.js'), 'utf8');
 const modelControlsSrc = fs.readFileSync(path.join(root, 'js/provider-model-controls.js'), 'utf8');
 const delegatesSrc = fs.readFileSync(path.join(root, 'js/provider-panel-delegates.js'), 'utf8');
 const panelsSrc = fs.readFileSync(path.join(root, 'js/provider-panels.js'), 'utf8');
@@ -42,12 +43,15 @@ assert('provider panel renderers emit delegated action attributes',
   renderSrc.includes('data-provider-panel-action') &&
     renderSrc.includes('data-provider-panel-change') &&
     renderSrc.includes('data-provider-panel-key'));
-assert('provider panel renderers route Nostr browser globals through runtime adapter',
+assert('provider panel renderers route Nostr module dependencies through runtime adapter',
   renderSrc.includes("from './provider-panel-renderers-runtime.js'") &&
     renderSrc.includes('getSelectedRoutstrNodeFromRuntime()') &&
     renderSrc.includes('discoverRoutstrNodesFromRuntime()') &&
     renderSrc.includes('setSelectedRoutstrNodeFromRuntime(bestUrl)') &&
-    !/\bwindow(?:\.|\s*\[)/.test(renderSrc));
+    !/\bwindow(?:\.|\s*\[)/.test(renderSrc) &&
+    renderRuntimeSrc.includes("from './nostr-discovery.js'") &&
+    renderRuntimeSrc.includes('configureProviderPanelRendererRuntime') &&
+    !/\bwindow(?:\.|\s*\[)/.test(renderRuntimeSrc));
 assert('provider model controls emit delegated model attributes',
   modelControlsSrc.includes('data-provider-panel-change') &&
     modelControlsSrc.includes('data-provider-panel-key'));

--- a/tests/test-provider-panel-renderers-runtime.js
+++ b/tests/test-provider-panel-renderers-runtime.js
@@ -3,6 +3,7 @@
 
 import './_node-shim.js';
 import {
+  configureProviderPanelRendererRuntime,
   discoverRoutstrNodesFromRuntime,
   getSelectedRoutstrNodeFromRuntime,
   setSelectedRoutstrNodeFromRuntime,
@@ -23,78 +24,50 @@ function assert(name, condition, detail = '') {
 
 console.log('=== Provider Panel Renderers Runtime Tests ===');
 
-const runtimeKeys = [
-  'window',
-  'nostrGetSelectedNode',
-  'nostrDiscoverNodes',
-  'nostrSetSelectedNode',
-];
-const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
-
-function setRuntimeValue(key, value) {
-  Object.defineProperty(globalThis, key, {
-    configurable: true,
-    writable: true,
-    enumerable: true,
-    value,
-  });
-}
-
-function restoreRuntime() {
-  for (const key of runtimeKeys) {
-    const descriptor = savedDescriptors.get(key);
-    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
-    else delete globalThis[key];
-  }
-}
-
+let previousRuntime;
 try {
   const calls = [];
-  const browserRuntime = {
-    nostrGetSelectedNode() {
-      calls.push(['get', this === browserRuntime]);
+  previousRuntime = configureProviderPanelRendererRuntime({
+    getSelectedNodeUrl() {
+      calls.push(['get']);
       return 'https://node.selected.test';
     },
-    nostrDiscoverNodes() {
-      calls.push(['discover', this === browserRuntime]);
+    discoverNodes() {
+      calls.push(['discover']);
       return Promise.resolve([{ online: true, urls: ['https://node.discovered.test'] }]);
     },
-    nostrSetSelectedNode(nodeUrl) {
-      calls.push(['set', nodeUrl, this === browserRuntime]);
+    setSelectedNodeUrl(nodeUrl) {
+      calls.push(['set', nodeUrl]);
     },
-  };
-  setRuntimeValue('window', browserRuntime);
+  });
 
   assert('getSelectedRoutstrNodeFromRuntime delegates selected node lookup',
     getSelectedRoutstrNodeFromRuntime() === 'https://node.selected.test'
-      && calls.some(call => call[0] === 'get' && call[1] === true));
+      && calls.some(call => call[0] === 'get'));
 
   const discovered = await discoverRoutstrNodesFromRuntime();
   assert('discoverRoutstrNodesFromRuntime delegates node discovery',
     discovered?.[0]?.urls?.[0] === 'https://node.discovered.test'
-      && calls.some(call => call[0] === 'discover' && call[1] === true));
+      && calls.some(call => call[0] === 'discover'));
 
   setSelectedRoutstrNodeFromRuntime('https://node.saved.test');
   assert('setSelectedRoutstrNodeFromRuntime delegates selected node updates',
-    calls.some(call => call[0] === 'set' && call[1] === 'https://node.saved.test' && call[2] === true));
+    calls.some(call => call[0] === 'set' && call[1] === 'https://node.saved.test'));
 
-  delete browserRuntime.nostrGetSelectedNode;
-  delete browserRuntime.nostrDiscoverNodes;
-  delete browserRuntime.nostrSetSelectedNode;
+  configureProviderPanelRendererRuntime({
+    getSelectedNodeUrl: null,
+    discoverNodes: null,
+    setSelectedNodeUrl: null,
+  });
   setSelectedRoutstrNodeFromRuntime('missing');
   assert('provider renderer runtime hooks no-op when callbacks are missing',
     getSelectedRoutstrNodeFromRuntime() === null && discoverRoutstrNodesFromRuntime() === null);
 
-  browserRuntime.nostrDiscoverNodes = () => [];
+  configureProviderPanelRendererRuntime({ discoverNodes: () => [] });
   assert('discoverRoutstrNodesFromRuntime ignores non-promise discovery callbacks',
     discoverRoutstrNodesFromRuntime() === null);
-
-  delete globalThis.window;
-  setRuntimeValue('nostrGetSelectedNode', () => 'https://global.node.test');
-  assert('provider renderer runtime falls back to globalThis without window',
-    getSelectedRoutstrNodeFromRuntime() === 'https://global.node.test');
 } finally {
-  restoreRuntime();
+  configureProviderPanelRendererRuntime(previousRuntime);
 }
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -189,7 +189,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, feedbackModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, feedbackModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, nostrModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -208,6 +208,7 @@
     import('../js/light-tools.js'),
     import('../js/mobile-dashboard.js'),
     import('../js/nav.js'),
+    import('../js/nostr-discovery.js'),
     import('../js/notes.js'),
     import('../js/pdf-import.js'),
     import('../js/pii.js'),
@@ -479,6 +480,14 @@
     ...feedbackExports,'_updateFeedbackPlaceholder'
   ];
 
+  // nostr-discovery.js (4 former browser globals, now module-only)
+  const nostrExports = [
+    'discoverNodes','getSelectedNodeUrl','setSelectedNodeUrl','clearNodeCache'
+  ];
+  const nostrLegacyGlobals = [
+    'nostrDiscoverNodes','nostrGetSelectedNode','nostrSetSelectedNode','nostrClearNodeCache'
+  ];
+
   // nav.js (5 retained runtime hooks; delegate helpers use ESM exports)
   const navGlobals = [
     'buildSidebar','renderProfileDropdown','renderProfileButton',
@@ -704,6 +713,7 @@
     ['light-tools.js', lightToolsModule, lightToolsExports],
     ['mobile-dashboard.js', mobileDashboardModule, mobileDashboardExports],
     ['nav.js', navModule, navModuleExports],
+    ['nostr-discovery.js', nostrModule, nostrExports],
     ['notes.js', notesModule, notesExports],
     ['pdf-import.js', pdfImportModule, pdfImportExports],
     ['pii.js', piiModule, piiExports],
@@ -787,6 +797,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of feedbackLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of nostrLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of providerPanelsExports) {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.215';
+self.APP_VERSION = '1.10.216';


### PR DESCRIPTION
## Summary
- remove the four legacy Nostr discovery globals and keep the discovery API module-only
- replace export/import and provider-panel global lookups with direct ESM dependencies
- preserve provider-renderer test seams through an explicit runtime configurator
- cover module-only browser behavior and real database-bundle node restore
- bump the app cache version to 1.10.216

## Testing
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test` — 398 tests passed
- focused Playwright regressions — 3 tests passed
- `./run-tests.sh` — 351/352 Playwright tests passed; the unrelated sidebar-search UI fixture missed once under the full parallel load and passed immediately when rerun in isolation

## Window burden remaining
This PR removes 4 unique globals (4 assignment entries) and eliminates 1 publication site.

After this PR, the audited runtime surface contains:
- **423 unique globals**
- **428 assignment entries**
- **22 publication sites**
- **12 remaining families**

Remaining assignment entries by family:
- Sun: 88
- Chat: 86
- Sync: 50
- Client List: 34
- DNA: 32
- Wearables: 32
- shared Utils publication sites: 31
- Light Devices: 25
- Recommendations: 22
- Theme: 16
- Settings: 7
- Nav: 5

At the current first-pass scope, this is approximately **6–10 more PRs**. That estimate excludes globals deliberately retained as public integration/debug hooks after review and may change as the larger Chat, Sun, and Sync facades are decomposed.