### PR TITLE
Make PDF.js loader module-only

### DIFF
--- a/js/pdfjs-loader.js
+++ b/js/pdfjs-loader.js
@@ -2,10 +2,7 @@
 // Cached dynamic loader for pdf.js (ESM-only since v4.x). Loads on first
 // PDF interaction rather than on every page load, and pins
 // `isEvalSupported: false` defense-in-depth at the entry point so call
-// sites can't forget it. Also exposes the module through the browser runtime
-// for any legacy reference that hasn't migrated to the loader yet.
-
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
+// sites can't forget it.
 
 /**
  * @typedef {{ items: Array<{ str?: string, transform?: number[] }> }} PdfTextContent
@@ -38,7 +35,6 @@ export function loadPdfJs() {
     if (!pdfjs.GlobalWorkerOptions.workerSrc) {
       pdfjs.GlobalWorkerOptions.workerSrc = '/vendor/pdf.worker.min.mjs';
     }
-    registerUtilsRuntimeExports({ pdfjsLib: pdfjs });
     return pdfjs;
   });
   return _pdfjsPromise;

--- a/tests/playwright/pdfjs-loader-browser-coverage.spec.js
+++ b/tests/playwright/pdfjs-loader-browser-coverage.spec.js
@@ -38,10 +38,10 @@ test('pdfjs loader browser coverage caches module and pins safe document options
 
     const firstPdfjs = await loader.loadPdfJs();
     const secondPdfjs = await loader.loadPdfJs();
-    outcomes.loadPdfJsCachesModuleSetsWorkerAndLegacyGlobal =
+    outcomes.loadPdfJsCachesModuleSetsWorkerAndStaysModuleOnly =
       firstPdfjs === secondPdfjs
       && firstPdfjs.GlobalWorkerOptions.workerSrc === '/vendor/pdf.worker.min.mjs'
-      && window.pdfjsLib === firstPdfjs;
+      && !('pdfjsLib' in window);
 
     const bytes = new Uint8Array([37, 80, 68, 70]).buffer;
     const bytesDocument = await loader.getPdfDocument(bytes, {
@@ -104,7 +104,7 @@ test('pdfjs loader browser coverage preserves preconfigured worker', async ({ pa
     const pdfjs = await loader.loadPdfJs();
     outcomes.loadPdfJsKeepsExistingWorkerSrc =
       pdfjs.GlobalWorkerOptions.workerSrc === '/custom/pdf.worker.mjs'
-      && window.pdfjsLib === pdfjs;
+      && !('pdfjsLib' in window);
 
     outcomes.allOutcomesReached = true;
     return outcomes;

--- a/tests/test-security-phase1.js
+++ b/tests/test-security-phase1.js
@@ -37,6 +37,8 @@ assert('isEvalSupported wins over extraOpts (via spread order)',
   loaderSrc.includes('...extraOpts, isEvalSupported: false }') &&
   !loaderSrc.includes('isEvalSupported: false, ...extraOpts'),
   'pin must apply after spread or a caller passing { isEvalSupported: true } reopens the CVE');
+assert('pdfjs-loader stays module-only',
+  !loaderSrc.includes('registerUtilsRuntimeExports') && !loaderSrc.includes('pdfjsLib:'));
 
 const importSrc = read('js/pdf-import.js');
 const importFileUtilsSrc = read('js/pdf-import-file-utils.js');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.216';
+self.APP_VERSION = '1.10.217';


### PR DESCRIPTION
## Summary
- stop publishing the lazily loaded PDF.js module as `window.pdfjsLib`
- keep PDF parsing behind the existing `loadPdfJs` and `getPdfDocument` ESM APIs
- update browser and security coverage to lock in the module-only boundary
- bump the app cache version to 1.10.217

## Testing
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `node tests/test-security-phase1.js` — 34 tests passed
- `npm test` — 398 tests passed
- focused PDF.js Playwright coverage — 2 tests passed
- `./run-tests.sh` — 352 Playwright tests passed; responsive theme matrix 472/472

## Window burden remaining
This PR removes 1 unique global (1 assignment entry) and eliminates 1 publication site.

After this PR, the audited runtime surface contains:
- **422 unique globals**
- **427 assignment entries**
- **21 publication sites**
- **12 remaining families**

Remaining assignment entries by family:
- Sun: 88
- Chat: 86
- Sync: 50
- Client List: 34
- DNA: 32
- Wearables: 32
- shared Utils publication sites: 30
- Light Devices: 25
- Recommendations: 22
- Theme: 16
- Settings: 7
- Nav: 5

At the current first-pass scope, this is approximately **5–9 more PRs**. That estimate excludes globals deliberately retained as public integration/debug hooks after review and may change as the larger Chat, Sun, and Sync facades are decomposed.