### PR TITLE
Make usage profile lookup module-only

### DIFF
--- a/js/schema.js
+++ b/js/schema.js
@@ -2,7 +2,7 @@
 // schema.js — Marker definitions, unit conversions, pricing, optimal ranges
 
 import { SECONDARY_UNIT_CONVERSIONS } from './secondary-unit-conversions.js';
-import { getUtilsRuntimeFunction } from './utils-runtime.js';
+import { state } from './state.js';
 
 export { PHASE_RANGES, SBM_2015_THRESHOLDS, getEMFSeverity } from './schema-environment.js';
 
@@ -545,8 +545,7 @@ export function trackUsage(provider, modelId, inputTokens, outputTokens) {
     if (inp === 0 && out === 0) return;
 
     // Per-profile
-    const getActiveProfileId = getUtilsRuntimeFunction('_getActiveProfileId');
-    const pid = getActiveProfileId ? getActiveProfileId() : 'default';
+    const pid = state.currentProfile || 'default';
     const pKey = `labcharts-${pid}-usage`;
     const pu = JSON.parse(localStorage.getItem(pKey) || 'null') || _emptyUsage();
     pu.totalCost += cost; pu.totalInputTokens += inp; pu.totalOutputTokens += out; pu.requestCount++;

--- a/js/startup-orchestrator.js
+++ b/js/startup-orchestrator.js
@@ -1,7 +1,6 @@
 // @ts-check
 // startup-orchestrator.js - app startup wiring and phase ordering
 
-import { state } from './state.js';
 import { initializeStartupFoundation } from './startup-foundation.js';
 import { initializeProfileData } from './startup-profile.js';
 import { handleStartupOAuthCallbacks } from './startup-oauth-callbacks.js';
@@ -10,7 +9,6 @@ import { initializeStartupServices, runPostProfileStartupMaintenance } from './s
 import { installGlobalEventListeners, registerAppRefreshCallback } from './app-event-listeners.js';
 import { showNotification } from './utils.js';
 import { restorePendingImportReviewDraft } from './import-loader.js';
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 let appStarted = false;
 
@@ -39,7 +37,6 @@ export function startApp() {
   if (appStarted) return;
   appStarted = true;
 
-  registerUtilsRuntimeExports({ _getActiveProfileId: () => state.currentProfile });
   installGlobalEventListeners();
   registerAppRefreshCallback();
 

--- a/tests/playwright/chat-discussion-browser-coverage.spec.js
+++ b/tests/playwright/chat-discussion-browser-coverage.spec.js
@@ -294,7 +294,6 @@ test('chat discussion request builder covers personality model assistant and usa
       const key = localStorage.key(index);
       return [key, key ? localStorage.getItem(key) : null];
     }));
-    const originalProfileGetter = window._getActiveProfileId;
     const original = {
       currentProfile: state.currentProfile,
       importedData: state.importedData,
@@ -330,7 +329,6 @@ test('chat discussion request builder covers personality model assistant and usa
         icon: 'P',
         promptText: 'Challenge weak claims.',
       }]));
-      window._getActiveProfileId = () => 'chat-discussion-coverage';
       data.invalidateActiveDataCache();
       labContext.invalidateLabContextCache();
 
@@ -403,7 +401,6 @@ test('chat discussion request builder covers personality model assistant and usa
       state.profileDob = original.profileDob;
       state.currentChatPersonality = original.currentChatPersonality;
       state.chatHistory = original.chatHistory;
-      window._getActiveProfileId = originalProfileGetter;
       data.invalidateActiveDataCache();
       labContext.invalidateLabContextCache();
       localStorage.clear();

--- a/tests/playwright/schema-browser-coverage.spec.js
+++ b/tests/playwright/schema-browser-coverage.spec.js
@@ -15,7 +15,10 @@ test('schema browser coverage exercises units pricing usage phase ranges and EMF
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ schemaUrl }) => {
-    const schema = await import(schemaUrl);
+    const [schema, { state }] = await Promise.all([
+      import(schemaUrl),
+      import('/js/state.js'),
+    ]);
     const outcomes = {};
 
     const approxEqual = (actual, expected, epsilon = 0.000001) =>
@@ -34,7 +37,7 @@ test('schema browser coverage exercises units pricing usage phase ranges and EMF
       }
     };
 
-    const originalProfileGetter = window._getActiveProfileId;
+    const originalProfile = state.currentProfile;
     try {
       resetStorage();
 
@@ -98,7 +101,7 @@ test('schema browser coverage exercises units pricing usage phase ranges and EMF
         && schema.formatCost(0.0042) === '$0.0042'
         && schema.formatCost(0.12) === '$0.120';
 
-      window._getActiveProfileId = () => 'schema-profile';
+      state.currentProfile = 'schema-profile';
       schema.trackUsage('venice', 'deepseek-v3', 1000000, 500000);
       schema.trackUsage('venice', 'deepseek-v3', 0, 0);
       const profileUsage = schema.getProfileUsage('schema-profile');
@@ -136,8 +139,7 @@ test('schema browser coverage exercises units pricing usage phase ranges and EMF
         && schema.getEMFSeverity('missing', 10) === null
         && schema.getEMFSeverity('rfMicrowave', null) === null;
     } finally {
-      if (originalProfileGetter) window._getActiveProfileId = originalProfileGetter;
-      else delete window._getActiveProfileId;
+      state.currentProfile = originalProfile;
       resetStorage();
     }
 

--- a/tests/playwright/startup-orchestrator-browser-coverage.spec.js
+++ b/tests/playwright/startup-orchestrator-browser-coverage.spec.js
@@ -93,7 +93,6 @@ test('startup orchestrator browser coverage reports startup sequence failures', 
     ]);
     const outcomes = {};
     const originalProfile = state.currentProfile;
-    const originalGetter = window._getActiveProfileId;
     const originalConsoleError = console.error;
 
     try {
@@ -113,11 +112,11 @@ test('startup orchestrator browser coverage reports startup sequence failures', 
         'startup failure notification'
       );
 
-      outcomes.startAppInstallsOneSetOfShellHooks =
+      outcomes.startAppInstallsOneSetOfShellHooksWithoutUsageGlobal =
         !window.__startupCalls.includes('emf')
         && window.__startupCalls.filter(call => call === 'events').length === 1
         && window.__startupCalls.filter(call => call === 'refresh').length === 1
-        && window._getActiveProfileId() === 'startup-orchestrator-coverage-profile';
+        && !('_getActiveProfileId' in window);
       outcomes.startupFailureStopsLaterPhasesAndReportsError =
         window.__startupCalls.includes('foundation')
         && !window.__startupCalls.includes('services')
@@ -133,8 +132,6 @@ test('startup orchestrator browser coverage reports startup sequence failures', 
         && window.__startupNotifications[0].duration === 6000;
     } finally {
       state.currentProfile = originalProfile;
-      if (originalGetter) window._getActiveProfileId = originalGetter;
-      else delete window._getActiveProfileId;
       console.error = originalConsoleError;
     }
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -772,6 +772,7 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   assert('window.scheduleChartThemeRefresh stays module-internal', !('scheduleChartThemeRefresh' in window));
+  assert('window._getActiveProfileId stays module-only', !('_getActiveProfileId' in window));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.217';
+self.APP_VERSION = '1.10.218';


### PR DESCRIPTION
## Summary
- remove the startup-published `window._getActiveProfileId` helper
- have usage accounting read the active profile directly from the shared state module
- update schema, discussion, and startup browser coverage for the module-only path
- bump the app cache version to 1.10.218

## Testing
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test` — 398 tests passed
- focused schema/discussion/startup Playwright coverage — 3 tests passed
- `./run-tests.sh` — 352 Playwright tests passed; responsive theme matrix 472/472

## Window burden remaining
This PR removes 1 unique global (1 assignment entry) and eliminates 1 publication site.

After this PR, the audited runtime surface contains:
- **421 unique globals**
- **426 assignment entries**
- **20 publication sites**
- **12 remaining families**

Remaining assignment entries by family:
- Sun: 88
- Chat: 86
- Sync: 50
- Client List: 34
- DNA: 32
- Wearables: 32
- shared Utils publication sites: 29
- Light Devices: 25
- Recommendations: 22
- Theme: 16
- Settings: 7
- Nav: 5

At the current first-pass scope, this is approximately **4–8 more PRs**. That estimate excludes globals deliberately retained as public integration/debug hooks after review and may change as the larger Chat, Sun, and Sync facades are decomposed.