### PR TITLE
Make chat actions module-only

### DIFF
--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -12,7 +12,6 @@ import {
   chatMessageActionAttrs,
 } from './chat-message-action-attrs.js';
 import { getChatRegenerateCallbacks, isChatRuntimeStreaming } from './chat-runtime.js';
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 
 const chatMessageActionDeps = {
@@ -219,9 +218,3 @@ export function toggleContextDetails(msgIndex) {
   details.style.display = open ? 'none' : 'flex';
   if (arrow) arrow.textContent = open ? '\u25B8' : '\u25BE';
 }
-
-registerUtilsRuntimeExports({
-  regenerateLastMessage,
-  copyMessage,
-  toggleContextDetails,
-});

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -28,9 +28,6 @@ import {
   clearChatHistory, getChatStorageKey, loadChatHistory, saveChatHistory,
 } from './chat-history.js';
 import {
-  buildActionBar, copyMessage, regenerateLastMessage, toggleContextDetails,
-} from './chat-actions.js';
-import {
   closeChatPanel, configureChatPanel, getChatWebSearchEnabled,
   refreshWebSearchToggle, setChatWebSearchEnabled,
   toggleChatFullscreen, toggleChatPanel, openChatPanel, updateChatInputState,
@@ -149,10 +146,6 @@ Object.assign(window, {
   getThreadPersonaCount,
   askAIAboutMarker,
   askAIAboutCorrelations,
-  buildActionBar,
-  regenerateLastMessage,
-  copyMessage,
-  toggleContextDetails,
   getChatWebSearchEnabled,
   setChatWebSearchEnabled,
   setChatNudge,

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -4,13 +4,12 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForFunction(() =>
     typeof window.renderChatMessages === 'function'
-      && typeof window.toggleContextDetails === 'function'
       && !!window._labState
   );
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
-    const { buildActionBar } = await import('/js/chat-actions.js');
+    const chatActions = await import('/js/chat-actions.js');
     const state = window._labState;
     const originalHistory = JSON.parse(JSON.stringify(state.chatHistory || []));
     const outcomes = {};
@@ -34,7 +33,7 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
         outcomes.userMessagesHaveNoActionBars = userMsgs.length > 0 && userMsgs[0].querySelector('.chat-action-bar') === null;
       } else {
         const doc = new DOMParser().parseFromString(
-          `<div class="chat-msg chat-ai">${buildActionBar(1)}</div><div class="chat-msg chat-user">Hello</div>`,
+          `<div class="chat-msg chat-ai">${chatActions.buildActionBar(1)}</div><div class="chat-msg chat-user">Hello</div>`,
           'text/html'
         );
         const aiMsg = doc.querySelector('.chat-msg.chat-ai');
@@ -51,18 +50,25 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
       testDiv.innerHTML = '<div id="chat-ctx-details-1" style="display:none">content</div><span id="chat-ctx-arrow-1">▸</span>';
       document.body.appendChild(testDiv);
       try {
-        window.toggleContextDetails(1);
+        chatActions.toggleContextDetails(1);
         const details = document.getElementById('chat-ctx-details-1');
         const arrow = document.getElementById('chat-ctx-arrow-1');
         outcomes.toggleContextDetailsOpens = details?.style.display === 'flex';
         outcomes.toggleContextArrowOpens = arrow?.textContent === '▾';
 
-        window.toggleContextDetails(1);
+        chatActions.toggleContextDetails(1);
         outcomes.toggleContextDetailsCloses = details?.style.display === 'none';
         outcomes.toggleContextArrowCloses = arrow?.textContent === '▸';
       } finally {
         testDiv.remove();
       }
+
+      outcomes.chatActionsStayModuleOnly = [
+        'buildActionBar',
+        'copyMessage',
+        'regenerateLastMessage',
+        'toggleContextDetails',
+      ].every(name => typeof window[name] === 'undefined');
 
       const keyDiv = document.createElement('div');
       keyDiv.innerHTML = '<div id="chat-ctx-details-42" style="display:none">content</div>' +

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// test-chat-actions.js — Chat action buttons + context summary. Window-export
+// test-chat-actions.js — Chat action buttons + context summary. Module-surface
 // checks, getContextSummary() shape, buildActionBar() HTML output (Regenerate
 // only on last AI msg, Copy always, context toggle, area counts), backward
 // compat, plus source-inspection of chat.js / chat-actions.js / lab-context.js / settings.js /
@@ -28,12 +28,14 @@ function assert(name, condition, detail) {
 
 console.log('=== Chat Actions Tests ===\n');
 
-// state.js exposes window._labState; chat.js + lab-context.js expose the
-// action-bar / context-summary handlers via Object.assign(window, ...).
+// state.js exposes window._labState; chat actions and context summaries stay
+// on their module surfaces.
 await import('../js/state.js');
 const labContext = await import('../js/lab-context.js');
 await import('../js/chat.js');
-const { buildActionBar } = await import('../js/chat-actions.js');
+const {
+  buildActionBar, copyMessage, regenerateLastMessage, toggleContextDetails,
+} = await import('../js/chat-actions.js');
 const { buildSummaryTranscript } = await import('../js/chat-summaries.js');
 const {
   attachLensSources, buildMultiPersonaInstruction, buildTaggedChatMessages, buildWebSearchHint,
@@ -52,13 +54,12 @@ const S = window._labState;
 const hasState = S && typeof S === 'object';
 assert('window._labState exists', hasState, hasState ? 'found' : 'not found');
 
-// ─── Section 1: Window exports ───
-console.log('Section 1: Window Exports');
-const requiredExports = [
-  'regenerateLastMessage', 'copyMessage', 'toggleContextDetails'
-];
-for (const fn of requiredExports) {
-  assert(`window.${fn} exists`, typeof window[fn] === 'function', typeof window[fn]);
+// ─── Section 1: Module exports ───
+console.log('Section 1: Module Exports');
+const moduleActions = { buildActionBar, copyMessage, regenerateLastMessage, toggleContextDetails };
+for (const [name, action] of Object.entries(moduleActions)) {
+  assert(`chat-actions.${name} exists`, typeof action === 'function', typeof action);
+  assert(`window.${name} stays module-only`, typeof window[name] === 'undefined', typeof window[name]);
 }
 assert('lab-context.getContextSummary exists', typeof labContext.getContextSummary === 'function');
 assert('window.getContextSummary stays module-only', !('getContextSummary' in window));
@@ -383,7 +384,13 @@ assert('lab-context.js has getContextSummary', labCtxSrc.includes('function getC
 assert('chat.js loads window bindings entry', chatSrc.includes("import './chat-window-bindings.js'"), 'found');
 assert('chat.js imports action helpers', chatSrc.includes("from './chat-actions.js'"), 'found');
 assert('chat-actions.js exports buildActionBar', chatActionsSrc.includes('export function buildActionBar'), 'found');
-assert('chat-actions.js keeps buildActionBar off window', !chatActionsSrc.includes('  buildActionBar,'), 'not a window handler');
+assert('chat actions stay off the runtime window registry',
+  !chatActionsSrc.includes('registerUtilsRuntimeExports')
+    && !chatWindowBindingsSrc.includes('  buildActionBar,')
+    && !chatWindowBindingsSrc.includes('  regenerateLastMessage,')
+    && !chatWindowBindingsSrc.includes('  copyMessage,')
+    && !chatWindowBindingsSrc.includes('  toggleContextDetails,'),
+  'not window handlers');
 assert('chat-actions.js installs delegated chat message actions',
   chatActionsSrc.includes("from './chat-message-action-attrs.js'")
     && chatActionsSrc.includes("export { chatMessageActionAttrs } from './chat-message-action-attrs.js'")

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -773,6 +773,12 @@
   }
   assert('window.scheduleChartThemeRefresh stays module-internal', !('scheduleChartThemeRefresh' in window));
   assert('window._getActiveProfileId stays module-only', !('_getActiveProfileId' in window));
+  assert('chat action handlers stay module-only', [
+    'buildActionBar',
+    'copyMessage',
+    'regenerateLastMessage',
+    'toggleContextDetails',
+  ].every(name => !(name in window)));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.218';
+self.APP_VERSION = '1.10.219';


### PR DESCRIPTION
## Summary

- keep chat action rendering and handlers on the `chat-actions.js` module surface
- remove their duplicate publications from the shared runtime registry and chat window facade
- update Node and browser coverage to assert the four actions remain available by import and absent from `window`
- bump the app cache version to `1.10.219`

## Window burden remaining

After this PR, the inventory is:

- **417 unique window globals**
- **419 publication entries**
- **19 publication sites**
- **12 global families**

This PR removes **4 unique globals**, **7 publication entries**, and **1 publication site**. An estimated **3–7 coherent follow-up PRs** remain; most residual burden is concentrated in the larger Sun, Chat, Sync, client-list, DNA, wearables, and light-device compatibility facades.

## Tests

- `./run-tests.sh`
  - 398 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive/theme checks passed
- focused chat-action tests: 176 assertions passed
- focused Chromium chat-action coverage: 2 tests passed
- typecheck, check-JS, quality guardrails, and module verification passed