### PR TITLE
Make chat context status module-only

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -3,8 +3,10 @@
 
 import { configureAppEventListeners } from './app-event-listeners.js';
 import { closeChangelog } from './changelog.js';
+import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
 import { closeChatPanel, configureChatPanel, toggleChatPanel } from './chat-panel.js';
 import { updateChatNudge } from './chat-nudge.js';
+import { updateChatContextStatus } from './chat-personalities.js';
 import { closeSummaryModal } from './chat-summaries.js';
 import { closeClientList, configureClientListRuntime } from './client-list.js';
 import { closeEMFInterpretation } from './emf-interpretation.js';
@@ -48,6 +50,7 @@ configureSettingsRuntime({
 });
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
+configureDashboardAIContextStatus(updateChatContextStatus);
 
 configureAppEventListeners({
   closeChangelog,

--- a/js/chat-personalities.js
+++ b/js/chat-personalities.js
@@ -15,7 +15,6 @@ import {
   openChatContextModalRuntime,
   renderChatMessagesRuntime,
 } from './chat-runtime.js';
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 const PERSONA_ICONS = ['🧠', '🎭', '🔮', '🌿', '⚡', '🦊', '🧬', '🌊', '🔥', '🏛️'];
 
@@ -582,5 +581,3 @@ IMPORTANT: On the very first line, output ONLY a single emoji that best captures
   }
   if (genBtn) { genBtn.disabled = false; genBtn.textContent = 'Generate'; }
 }
-
-registerUtilsRuntimeExports({ updateChatContextStatus });

--- a/js/context-card-dashboard-ai-runtime.js
+++ b/js/context-card-dashboard-ai-runtime.js
@@ -1,0 +1,15 @@
+// @ts-check
+// context-card-dashboard-ai-runtime.js - dependency-light Context hub callbacks
+
+const noopContextStatus = () => {};
+let contextStatusHandler = noopContextStatus;
+
+export function configureDashboardAIContextStatus(handler = noopContextStatus) {
+  const previous = contextStatusHandler;
+  contextStatusHandler = typeof handler === 'function' ? handler : noopContextStatus;
+  return previous;
+}
+
+export function notifyDashboardAIContextStatusChanged() {
+  contextStatusHandler();
+}

--- a/js/context-card-dashboard-ai.js
+++ b/js/context-card-dashboard-ai.js
@@ -37,10 +37,10 @@ import {
   installDashboardAIActionDelegates,
 } from './context-card-dashboard-ai-actions.js';
 import { openInterpretiveLensEditorRuntime } from './context-cards-runtime.js';
+import { notifyDashboardAIContextStatusChanged } from './context-card-dashboard-ai-runtime.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
   handleDNAFile?: (file: File) => void,
-  updateChatContextStatus?: () => void,
 }} */ (typeof window !== 'undefined' ? window : {});
 
 let dashboardAISyncSetupHandler = showSyncSetupModal;
@@ -727,7 +727,7 @@ function bindContextSourceToggles(overlay) {
         const next = /** @type {HTMLInputElement | null} */ (document.getElementById(focusId));
         next?.focus();
       }
-      appWindow.updateChatContextStatus?.();
+      notifyDashboardAIContextStatusChanged();
     };
   });
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -76,6 +76,7 @@ const APP_SHELL = [
   '/js/app-ui-shell-modules.js',
   '/js/app-shell-hooks.js',
   '/js/app-event-listeners.js',
+  '/js/context-card-dashboard-ai-runtime.js',
   '/js/startup-orchestrator.js',
   '/js/schema.js',
   '/js/schema-environment.js',

--- a/tests/playwright/dashboard-ai-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-ai-browser-coverage.spec.js
@@ -20,6 +20,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     const hadShowDirectoryPicker = Object.prototype.hasOwnProperty.call(window, 'showDirectoryPicker');
     window.showDirectoryPicker = async () => ({ name: 'Coverage Backups' });
     const dashboardAi = await import(dashboardUrl);
+    const dashboardAiRuntime = await import('/js/context-card-dashboard-ai-runtime.js');
     const lens = await import('/js/lens.js');
     const { state } = await import('/js/state.js');
     const contextCardsRuntime = await import('/js/context-cards-runtime.js');
@@ -57,6 +58,9 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
     let handledDnaFile = null;
 
     dashboardAi.configureDashboardAISyncSetup(() => calls.push('sync'));
+    const previousContextStatusHandler = dashboardAiRuntime.configureDashboardAIContextStatus(
+      () => calls.push('context-status')
+    );
     const previousDataProtectionDeps = dashboardAi.configureDashboardAIDataProtectionDeps({
       pickFolderForBackup: () => calls.push('backup'),
       showEnableEncryptionModal: () => calls.push('encryption'),
@@ -209,6 +213,18 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       lens.closeKnowledgeBaseModal();
       outcomes.pickersScheduleFocusTimers = timers.some(delay => delay === 50);
 
+      dashboardAi.openContextModal();
+      const contextToggle = /** @type {HTMLInputElement | null} */ (
+        document.querySelector('#context-hub-overlay [data-context-toggle]')
+      );
+      if (contextToggle) {
+        contextToggle.checked = !contextToggle.checked;
+        contextToggle.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      outcomes.contextToggleUsesConfiguredModuleCallback = calls.includes('context-status')
+        && !('updateChatContextStatus' in window);
+      document.querySelector('#context-hub-overlay')?.remove();
+
       dashboardAi.triggerDNAFilePicker();
       const input = document.getElementById('dna-dashboard-input');
       const transfer = new DataTransfer();
@@ -241,6 +257,7 @@ test('dashboard AI browser coverage exercises CTA rendering picker routing and D
       document.querySelectorAll('#data-protection-picker-overlay,#ai-personalize-picker-overlay,#dna-dashboard-input')
         .forEach(el => el.remove());
       dashboardAi.configureDashboardAISyncSetup();
+      dashboardAiRuntime.configureDashboardAIContextStatus(previousContextStatusHandler);
       dashboardAi.configureDashboardAIDataProtectionDeps(previousDataProtectionDeps);
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       HTMLInputElement.prototype.click = originalInputClick;

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -60,6 +60,11 @@ assert('Feedback shell action uses its module dependency instead of a window loo
     && shellSrc.includes('shellFeedbackDeps.openFeedbackModal()')
     && !shellSrc.includes("callShellRuntime('openFeedbackModal')"));
 
+assert('App shell wires Context hub status refresh without a window lookup',
+  appShellHooksSrc.includes("import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js'")
+    && appShellHooksSrc.includes("import { updateChatContextStatus } from './chat-personalities.js'")
+    && appShellHooksSrc.includes('configureDashboardAIContextStatus(updateChatContextStatus);'));
+
 [
   'toggle-panel',
   'close-panel',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -26,6 +26,7 @@
     '/js/app-ui-shell-modules.js',
     '/js/app-shell-hooks.js',
     '/js/app-event-listeners.js',
+    '/js/context-card-dashboard-ai-runtime.js',
     '/js/crypto.js',
     '/js/startup-orchestrator.js',
     '/js/startup-foundation.js',
@@ -779,6 +780,7 @@
     'regenerateLastMessage',
     'toggleContextDetails',
   ].every(name => !(name in window)));
+  assert('window.updateChatContextStatus stays module-only', !('updateChatContextStatus' in window));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -87,6 +87,7 @@
     "js/client-list.js",
     "js/constants.js",
     "js/context-card-dashboard-ai-actions.js",
+    "js/context-card-dashboard-ai-runtime.js",
     "js/context-card-dashboard-ai.js",
     "js/context-card-editor-ui.js",
     "js/context-card-health-dots.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.219';
+self.APP_VERSION = '1.10.220';


### PR DESCRIPTION
## Summary

- replace the Context hub's optional `window.updateChatContextStatus` lookup with a dependency-light runtime callback
- wire `updateChatContextStatus` explicitly from the app shell
- keep the callback bridge in a small module so `context-card-dashboard-ai.js` remains below the large-file guardrail
- cache and check-JS the new runtime module, add browser/static invariants, and bump the app cache version to `1.10.220`

## Window burden remaining

After this PR, the inventory is:

- **416 unique window globals**
- **418 publication entries**
- **18 publication sites**
- **12 global families**

This PR removes **1 unique global**, **1 publication entry**, and **1 publication site**. An estimated **2–6 coherent follow-up PRs** remain; most residual burden is concentrated in the larger Sun, Chat, Sync, client-list, DNA, wearables, and light-device compatibility facades.

## Tests

- `./run-tests.sh`
  - 398 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive/theme checks passed
- focused Context hub and shell checks: 221 assertions passed
- focused Chromium Context hub coverage: 7 tests passed
- typecheck, check-JS, quality guardrails, service-worker cache verification, and module verification passed