### PR TITLE
Make chat images module-only

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -3,6 +3,14 @@
 
 import { configureAppEventListeners } from './app-event-listeners.js';
 import { closeChangelog } from './changelog.js';
+import { configureChatMessageActionDeps } from './chat-actions.js';
+import {
+  initChatImageHandlers,
+  openImageLightbox,
+  removeImageAttachment,
+  toggleHDMode,
+  updateAttachButtonVisibility,
+} from './chat-images.js';
 import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
 import { closeChatPanel, configureChatPanel, toggleChatPanel } from './chat-panel.js';
 import { updateChatNudge } from './chat-nudge.js';
@@ -27,6 +35,8 @@ import {
 } from './views.js';
 import { openProfileShareModal } from './profile-share.js';
 import { getActiveProfileId } from './profile.js';
+import { configureShellChatImageDeps } from './shell-actions.js';
+import { configureStartupUIDeps } from './startup-ui.js';
 
 configureClientListRuntime({
   exportAllDataJSON,
@@ -50,6 +60,9 @@ configureSettingsRuntime({
 });
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
+configureChatMessageActionDeps({ openImageLightbox, removeImageAttachment });
+configureShellChatImageDeps({ toggleHDMode });
+configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });
 configureDashboardAIContextStatus(updateChatContextStatus);
 
 configureAppEventListeners({

--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -16,12 +16,20 @@ import { openEMFAssessmentEditor } from './emf-runtime.js';
 
 const chatMessageActionDeps = {
   openEMFAssessmentEditor,
+  openImageLightbox: /** @type {(src: string) => void} */ (() => {}),
+  removeImageAttachment: /** @type {(index: number) => void} */ (() => {}),
 };
 
 export function configureChatMessageActionDeps(deps = {}) {
   const previous = { ...chatMessageActionDeps };
   if (typeof deps.openEMFAssessmentEditor === 'function') {
     chatMessageActionDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
+  }
+  if (typeof deps.openImageLightbox === 'function') {
+    chatMessageActionDeps.openImageLightbox = deps.openImageLightbox;
+  }
+  if (typeof deps.removeImageAttachment === 'function') {
+    chatMessageActionDeps.removeImageAttachment = deps.removeImageAttachment;
   }
   return previous;
 }
@@ -70,11 +78,11 @@ function runChatMessageAction(actionEl, event) {
   } else if (action === 'remove-image-attachment') {
     const index = readMessageIndex(actionEl);
     if (index == null) return;
-    appWindow.removeImageAttachment?.(index);
+    chatMessageActionDeps.removeImageAttachment(index);
   } else if (action === 'open-image-lightbox') {
     const src = actionEl instanceof HTMLImageElement ? actionEl.src : actionEl.dataset.chatMessageSrc;
     if (!src) return;
-    appWindow.openImageLightbox?.(src);
+    chatMessageActionDeps.openImageLightbox(src);
   } else if (action === 'open-emf-assessment') {
     void chatMessageActionDeps.openEMFAssessmentEditor();
   } else if (action === 'jump-search-result') {

--- a/js/chat-images.js
+++ b/js/chat-images.js
@@ -14,7 +14,6 @@ import { resizeImage, isValidImageType } from './image-utils.js';
 import { hasAIProvider, supportsVision } from './api.js';
 import { openModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
 import { chatMessageActionAttrs } from './chat-message-action-attrs.js';
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 const MAX_ATTACHMENTS = 5;
 const THUMB_SIZE = 80;
@@ -225,16 +224,3 @@ export function initChatImageHandlers() {
     });
   }
 }
-
-// Keep legacy runtime exports; main.js / chat.js init also wires
-// initChatImageHandlers() on DOMContentLoaded.
-registerUtilsRuntimeExports({
-  toggleHDMode,
-  addImageAttachment,
-  removeImageAttachment,
-  renderAttachmentPreview,
-  openImageLightbox,
-  clearAttachments,
-  updateAttachButtonVisibility,
-  initChatImageHandlers,
-});

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -7,6 +7,7 @@ import { openFeedbackModal } from './feedback.js';
 let shellDelegatesInstalled = false;
 const shellImportDeps = { handleImportStatusClick, isImportRunning };
 const shellFeedbackDeps = { openFeedbackModal };
+const shellChatImageDeps = { toggleHDMode: () => {} };
 
 export function configureShellImportDeps(deps = {}) {
   const previous = { ...shellImportDeps };
@@ -18,6 +19,12 @@ export function configureShellImportDeps(deps = {}) {
 export function configureShellFeedbackDeps(deps = {}) {
   const previous = { ...shellFeedbackDeps };
   if (typeof deps.openFeedbackModal === 'function') shellFeedbackDeps.openFeedbackModal = deps.openFeedbackModal;
+  return previous;
+}
+
+export function configureShellChatImageDeps(deps = {}) {
+  const previous = { ...shellChatImageDeps };
+  if (typeof deps.toggleHDMode === 'function') shellChatImageDeps.toggleHDMode = deps.toggleHDMode;
   return previous;
 }
 
@@ -109,7 +116,7 @@ function runChatAction(action, actionEl) {
     clickFileInput('chat-image-input');
     return true;
   } else if (action === 'toggle-hd') {
-    callShellRuntime('toggleHDMode');
+    shellChatImageDeps.toggleHDMode();
     return true;
   } else if (action === 'start-discussion') {
     callShellRuntime('startDiscussion');

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -14,7 +14,11 @@ import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 import { maybeShowAnalyticsConsent } from './utils.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const startupUIDeps = { maybeShowAnalyticsConsent };
+const startupUIDeps = {
+  initChatImageHandlers: () => {},
+  maybeShowAnalyticsConsent,
+  updateAttachButtonVisibility: () => {},
+};
 
 export function configureStartupUIDeps(deps = {}) {
   const previous = { ...startupUIDeps };
@@ -22,6 +26,12 @@ export function configureStartupUIDeps(deps = {}) {
     startupUIDeps.maybeShowAnalyticsConsent = typeof deps.maybeShowAnalyticsConsent === 'function'
       ? /** @type {typeof maybeShowAnalyticsConsent} */ (deps.maybeShowAnalyticsConsent)
       : null;
+  }
+  if (typeof deps.initChatImageHandlers === 'function') {
+    startupUIDeps.initChatImageHandlers = deps.initChatImageHandlers;
+  }
+  if (typeof deps.updateAttachButtonVisibility === 'function') {
+    startupUIDeps.updateAttachButtonVisibility = deps.updateAttachButtonVisibility;
   }
   return previous;
 }
@@ -141,7 +151,7 @@ function refreshStartupChrome() {
 
 function initializeChatAttachments() {
   // Init chat image attachment handlers (paste, drag-drop, file input).
-  requireStartupRuntime('initChatImageHandlers');
-  requireStartupRuntime('updateAttachButtonVisibility');
+  startupUIDeps.initChatImageHandlers();
+  startupUIDeps.updateAttachButtonVisibility();
   requireStartupRuntime('updateChatNudge');
 }

--- a/tests/playwright/chat-ui-browser-coverage.spec.js
+++ b/tests/playwright/chat-ui-browser-coverage.spec.js
@@ -44,6 +44,17 @@ test('chat image attachments cover previews handlers and lightbox controls', asy
       chatImages.clearAttachments();
       chatImages.updateAttachButtonVisibility();
 
+      outcomes.chatImageHandlersStayModuleOnly = [
+        'toggleHDMode',
+        'addImageAttachment',
+        'removeImageAttachment',
+        'renderAttachmentPreview',
+        'openImageLightbox',
+        'clearAttachments',
+        'updateAttachButtonVisibility',
+        'initChatImageHandlers',
+      ].every(name => typeof window[name] === 'undefined');
+
       outcomes.attachButtonsVisibleForVisionProvider = attachBtn?.style.display === 'flex'
         && hdBtn?.style.display === 'flex'
         && hdBtn?.classList.contains('active') === false;
@@ -677,10 +688,10 @@ test('chat discussion picker lifecycle and resume binding cover browser state pa
 
       localStorage.setItem('labcharts-ai-paused', 'true');
       window._resumeAI();
-      outcomes.resumeBindingUnpausesAndExportsChatFns = localStorage.getItem('labcharts-ai-paused') === 'false'
+      outcomes.resumeBindingUnpausesAndKeepsChatImageHelpersModuleOnly = localStorage.getItem('labcharts-ai-paused') === 'false'
         && typeof window.summarizeThread === 'function'
         && typeof window.startDiscussion === 'function'
-        && typeof window.clearAttachments === 'function';
+        && typeof window.clearAttachments === 'undefined';
     } finally {
       state.currentProfile = original.currentProfile;
       state.chatHistory = original.chatHistory;

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -28,6 +28,9 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     const previousShellFeedbackDeps = shellActions.configureShellFeedbackDeps({
       openFeedbackModal: () => calls.push(['openFeedbackModal']),
     });
+    const previousShellChatImageDeps = shellActions.configureShellChatImageDeps({
+      toggleHDMode: () => calls.push(['toggleHDMode']),
+    });
     const originalFns = {
       toggleMobileSidebar: window.toggleMobileSidebar,
       closeMobileSidebar: window.closeMobileSidebar,
@@ -43,7 +46,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       toggleChatFullscreen: window.toggleChatFullscreen,
       togglePersonalityBar: window.togglePersonalityBar,
       setChatPersonality: window.setChatPersonality,
-      toggleHDMode: window.toggleHDMode,
       startDiscussion: window.startDiscussion,
       sendChatMessage: window.sendChatMessage,
       filterThreadList: window.filterThreadList,
@@ -194,6 +196,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     } finally {
       shellActions.configureShellImportDeps(previousShellImportDeps);
       shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
+      shellActions.configureShellChatImageDeps(previousShellChatImageDeps);
       for (const [name, value] of Object.entries(originalFns)) {
         if (value === undefined) delete window[name];
         else window[name] = value;

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -408,12 +408,6 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
     window.openChatPanel = () => {
       window.__startupUICalls.push('openChatPanel');
     };
-    window.initChatImageHandlers = () => {
-      window.__startupUICalls.push('initChatImageHandlers');
-    };
-    window.updateAttachButtonVisibility = () => {
-      window.__startupUICalls.push('updateAttachButtonVisibility');
-    };
     window.updateChatNudge = () => {
       window.__startupUICalls.push('updateChatNudge');
     };
@@ -441,8 +435,14 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
     try {
       const startupUi = await import(startupUiUrl);
       startupUi.configureStartupUIDeps({
+        initChatImageHandlers: () => {
+          window.__startupUICalls.push('initChatImageHandlers');
+        },
         maybeShowAnalyticsConsent: () => {
           window.__startupUICalls.push('maybeShowAnalyticsConsent');
+        },
+        updateAttachButtonVisibility: () => {
+          window.__startupUICalls.push('updateAttachButtonVisibility');
         },
       });
       startupUi.renderStartupUI();

--- a/tests/test-chat-message-delegated-actions.js
+++ b/tests/test-chat-message-delegated-actions.js
@@ -71,6 +71,11 @@ assert('chat-actions delegates dynamic chat controls',
     'continue-discussion',
     'end-discussion',
   ].every(action => actionsSrc.includes(`action === '${action}'`)));
+assert('chat image message actions use configured module dependencies',
+  actionsSrc.includes('chatMessageActionDeps.removeImageAttachment(index)')
+    && actionsSrc.includes('chatMessageActionDeps.openImageLightbox(src)')
+    && !actionsSrc.includes('appWindow.removeImageAttachment')
+    && !actionsSrc.includes('appWindow.openImageLightbox'));
 
 const renderSrc = read('js/chat-render.js');
 const sendSrc = read('js/chat-send.js');

--- a/tests/test-image-utils.js
+++ b/tests/test-image-utils.js
@@ -29,7 +29,7 @@ await import('../js/state.js');
 const api = await import('../js/api.js');
 const imageUtils = await import('../js/image-utils.js');
 const pdfImport = await import('../js/pdf-import.js');
-await import('../js/chat-images.js');
+const chatImages = await import('../js/chat-images.js');
 const { resizeImage, isValidImageType, formatImageBlock, buildVisionContent } = imageUtils;
 
 // ═══════════════════════════════════════
@@ -47,11 +47,20 @@ assert('image utility exports stay module-scoped',
   && typeof window.formatImageBlock === 'undefined'
   && typeof window.buildVisionContent === 'undefined');
 assert('supportsVision exported from api module', typeof api.supportsVision === 'function');
-assert('addImageAttachment exported', typeof window.addImageAttachment === 'function');
-assert('removeImageAttachment exported', typeof window.removeImageAttachment === 'function');
-assert('clearAttachments exported', typeof window.clearAttachments === 'function');
-assert('updateAttachButtonVisibility exported', typeof window.updateAttachButtonVisibility === 'function');
-assert('initChatImageHandlers exported', typeof window.initChatImageHandlers === 'function');
+const chatImageExports = [
+  'toggleHDMode',
+  'addImageAttachment',
+  'removeImageAttachment',
+  'renderAttachmentPreview',
+  'openImageLightbox',
+  'clearAttachments',
+  'updateAttachButtonVisibility',
+  'initChatImageHandlers',
+];
+for (const name of chatImageExports) {
+  assert(`chat-images.${name} exported`, typeof chatImages[name] === 'function');
+  assert(`window.${name} stays module-only`, typeof window[name] === 'undefined');
+}
 
 // ═══════════════════════════════════════
 // 2. isValidImageType

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -60,6 +60,16 @@ assert('Feedback shell action uses its module dependency instead of a window loo
     && shellSrc.includes('shellFeedbackDeps.openFeedbackModal()')
     && !shellSrc.includes("callShellRuntime('openFeedbackModal')"));
 
+assert('Chat HD shell action uses its module dependency instead of a window lookup',
+  shellSrc.includes('shellChatImageDeps.toggleHDMode()')
+    && !shellSrc.includes("callShellRuntime('toggleHDMode')"));
+
+assert('App shell wires module-only chat image consumers',
+  appShellHooksSrc.includes("from './chat-images.js'")
+    && appShellHooksSrc.includes('configureChatMessageActionDeps({ openImageLightbox, removeImageAttachment });')
+    && appShellHooksSrc.includes('configureShellChatImageDeps({ toggleHDMode });')
+    && appShellHooksSrc.includes('configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });'));
+
 assert('App shell wires Context hub status refresh without a window lookup',
   appShellHooksSrc.includes("import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js'")
     && appShellHooksSrc.includes("import { updateChatContextStatus } from './chat-personalities.js'")

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -781,6 +781,16 @@
     'toggleContextDetails',
   ].every(name => !(name in window)));
   assert('window.updateChatContextStatus stays module-only', !('updateChatContextStatus' in window));
+  assert('chat image handlers stay module-only', [
+    'toggleHDMode',
+    'addImageAttachment',
+    'removeImageAttachment',
+    'renderAttachmentPreview',
+    'openImageLightbox',
+    'clearAttachments',
+    'updateAttachButtonVisibility',
+    'initChatImageHandlers',
+  ].every(name => !(name in window)));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.220';
+self.APP_VERSION = '1.10.221';


### PR DESCRIPTION
## Summary

- keep all eight chat image helpers module-only
- inject image actions into chat message and shell delegates
- wire startup attachment handlers through the app shell
- update browser and static regression coverage
- bump the app version to 1.10.221

## Window burden remaining

After this PR:

- **408 unique `window` globals remain**
- **410 publication entries remain**
- **17 publication sites remain**
- **12 global families remain**

This PR removes 8 unique globals, 8 publication entries, and 1 publication site. Based on the remaining coherent facade boundaries, the current estimate is **1–5 follow-up PRs** to finish the `window`-burden reduction; the range depends on whether the larger chat, sync, sun, and wearable facades can be retired whole or need to be split safely.

## Tests

- `./run-tests.sh`
  - 125 module verification checks passed
  - 398 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive-theme assertions passed
