### PR TITLE
Make chat threads module-only

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -16,6 +16,14 @@ import { closeChatPanel, configureChatPanel, toggleChatPanel } from './chat-pane
 import { updateChatNudge } from './chat-nudge.js';
 import { updateChatContextStatus } from './chat-personalities.js';
 import { closeSummaryModal } from './chat-summaries.js';
+import {
+  createNewThread,
+  ensureActiveThread,
+  filterThreadList,
+  loadChatThreads,
+  renderThreadList,
+  toggleThreadRail,
+} from './chat-threads.js';
 import { closeClientList, configureClientListRuntime } from './client-list.js';
 import { closeEMFInterpretation } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder } from './export.js';
@@ -24,6 +32,7 @@ import { closeFeedbackModal, openFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { closeModal } from './marker-detail-modal.js';
 import { closeMobileSidebar } from './nav.js';
+import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
 import {
@@ -35,8 +44,9 @@ import {
 } from './views.js';
 import { openProfileShareModal } from './profile-share.js';
 import { getActiveProfileId } from './profile.js';
-import { configureShellChatImageDeps } from './shell-actions.js';
+import { configureShellChatImageDeps, configureShellChatThreadDeps } from './shell-actions.js';
 import { configureStartupUIDeps } from './startup-ui.js';
+import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
 
 configureClientListRuntime({
   exportAllDataJSON,
@@ -62,7 +72,10 @@ configureSettingsRuntime({
 configureChatPanel({ refreshMobileDashboardActiveTab });
 configureChatMessageActionDeps({ openImageLightbox, removeImageAttachment });
 configureShellChatImageDeps({ toggleHDMode });
+configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
 configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });
+configureOnboardingViewRuntimeDeps({ createNewThread });
+configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatThreads, renderThreadList });
 configureDashboardAIContextStatus(updateChatContextStatus);
 
 configureAppEventListeners({

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -16,7 +16,6 @@ import {
   configureChatThreadSearch, filterThreadList,
   invalidateThreadContentCache, jumpToSearchResult,
 } from './chat-thread-search.js';
-import { registerUtilsRuntimeExports } from './utils-runtime.js';
 
 export { filterThreadList, invalidateThreadContentCache, jumpToSearchResult };
 
@@ -465,23 +464,3 @@ configureChatThreadSearch({
   switchToThread,
 });
 installChatThreadDelegates();
-
-// Delegated thread actions + chat.js call sites hit these names.
-registerUtilsRuntimeExports({
-  loadChatThreads,
-  saveChatThreadIndex,
-  ensureActiveThread,
-  createNewThread,
-  switchToThread,
-  deleteThread,
-  renameThread,
-  renameThreadPrompt,
-  installChatThreadDelegates,
-  autoNameThread,
-  pruneOldThreads,
-  renderThreadList,
-  invalidateThreadContentCache,
-  filterThreadList,
-  jumpToSearchResult,
-  toggleThreadRail,
-});

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -2,7 +2,7 @@
 // chat-window-bindings.js — chat callback wiring and legacy window exports
 
 import { setAIPaused } from './api.js';
-import { configureChatThreadDeps, getChatThreadKey, getChatThreadsKey } from './chat-threads.js';
+import { configureChatThreadDeps } from './chat-threads.js';
 import { applyInlineMarkdown, renderMarkdown } from './markdown.js';
 import { renderChatMessages } from './chat-render.js';
 import { askAIAboutCorrelations, askAIAboutMarker } from './chat-marker-prompts.js';
@@ -88,8 +88,6 @@ Object.assign(window, {
   isChatStreaming,
   toggleChatFullscreen,
   getChatStorageKey,
-  getChatThreadsKey,
-  getChatThreadKey,
   getActivePersonality,
   getCustomPersonalities,
   saveCustomPersonalities,

--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -3,6 +3,20 @@
 
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
+const onboardingViewRuntimeDeps = {
+  createNewThread: /** @type {null | (() => void)} */ (null),
+};
+
+export function configureOnboardingViewRuntimeDeps(deps = {}) {
+  const previous = { ...onboardingViewRuntimeDeps };
+  if (Object.prototype.hasOwnProperty.call(deps, 'createNewThread')) {
+    onboardingViewRuntimeDeps.createNewThread = typeof deps.createNewThread === 'function'
+      ? deps.createNewThread
+      : null;
+  }
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -58,7 +72,7 @@ export function openOnboardingProviderChatRuntime() {
 }
 
 export function createOnboardingChatThreadRuntime() {
-  const createNewThread = getRuntimeFunction('createNewThread');
+  const createNewThread = onboardingViewRuntimeDeps.createNewThread;
   if (!createNewThread) return false;
   createNewThread();
   return true;

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -8,6 +8,11 @@ let shellDelegatesInstalled = false;
 const shellImportDeps = { handleImportStatusClick, isImportRunning };
 const shellFeedbackDeps = { openFeedbackModal };
 const shellChatImageDeps = { toggleHDMode: () => {} };
+const shellChatThreadDeps = {
+  createNewThread: () => {},
+  filterThreadList: (_value) => {},
+  toggleThreadRail: () => {},
+};
 
 export function configureShellImportDeps(deps = {}) {
   const previous = { ...shellImportDeps };
@@ -25,6 +30,14 @@ export function configureShellFeedbackDeps(deps = {}) {
 export function configureShellChatImageDeps(deps = {}) {
   const previous = { ...shellChatImageDeps };
   if (typeof deps.toggleHDMode === 'function') shellChatImageDeps.toggleHDMode = deps.toggleHDMode;
+  return previous;
+}
+
+export function configureShellChatThreadDeps(deps = {}) {
+  const previous = { ...shellChatThreadDeps };
+  if (typeof deps.createNewThread === 'function') shellChatThreadDeps.createNewThread = deps.createNewThread;
+  if (typeof deps.filterThreadList === 'function') shellChatThreadDeps.filterThreadList = deps.filterThreadList;
+  if (typeof deps.toggleThreadRail === 'function') shellChatThreadDeps.toggleThreadRail = deps.toggleThreadRail;
   return previous;
 }
 
@@ -92,10 +105,10 @@ function runChatAction(action, actionEl) {
     callShellRuntime('closeChatPanel');
     return true;
   } else if (action === 'toggle-thread-rail') {
-    callShellRuntime('toggleThreadRail');
+    shellChatThreadDeps.toggleThreadRail();
     return true;
   } else if (action === 'create-thread') {
-    callShellRuntime('createNewThread');
+    shellChatThreadDeps.createNewThread();
     return true;
   } else if (action === 'summarize-thread') {
     callShellRuntime('summarizeThread');
@@ -146,7 +159,7 @@ function handleShellInput(event) {
   const input = event.target;
   if (!(input instanceof HTMLInputElement)) return;
   if (input.dataset.chatInputAction === 'filter-thread-list') {
-    callShellRuntime('filterThreadList', input.value);
+    shellChatThreadDeps.filterThreadList(input.value);
   }
 }
 

--- a/js/sync-pull-active-refresh-runtime.js
+++ b/js/sync-pull-active-refresh-runtime.js
@@ -3,6 +3,20 @@
 
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
+const syncPullActiveRefreshDeps = {
+  ensureActiveThread: () => {},
+  loadChatThreads: () => undefined,
+  renderThreadList: () => {},
+};
+
+export function configureSyncPullActiveRefreshDeps(deps = {}) {
+  const previous = { ...syncPullActiveRefreshDeps };
+  if (typeof deps.ensureActiveThread === 'function') syncPullActiveRefreshDeps.ensureActiveThread = deps.ensureActiveThread;
+  if (typeof deps.loadChatThreads === 'function') syncPullActiveRefreshDeps.loadChatThreads = deps.loadChatThreads;
+  if (typeof deps.renderThreadList === 'function') syncPullActiveRefreshDeps.renderThreadList = deps.renderThreadList;
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -24,15 +38,15 @@ function getRuntimeFunction(name) {
 export function refreshPulledChatRuntime() {
   const finishRefresh = (threadsLoaded) => {
     if (threadsLoaded === false) {
-      getRuntimeFunction('renderThreadList')?.();
+      syncPullActiveRefreshDeps.renderThreadList();
       return false;
     }
-    getRuntimeFunction('ensureActiveThread')?.();
-    getRuntimeFunction('renderThreadList')?.();
+    syncPullActiveRefreshDeps.ensureActiveThread();
+    syncPullActiveRefreshDeps.renderThreadList();
     return getRuntimeFunction('loadChatHistory')?.();
   };
 
-  const loaded = getRuntimeFunction('loadChatThreads')?.();
+  const loaded = syncPullActiveRefreshDeps.loadChatThreads();
   if (loaded && typeof loaded.then === 'function') {
     return loaded.then(finishRefresh);
   }

--- a/tests/playwright/chat-discussion-browser-coverage.spec.js
+++ b/tests/playwright/chat-discussion-browser-coverage.spec.js
@@ -265,7 +265,7 @@ test('discussion round state persists active and inactive thread histories', asy
       state.chatHistory = saved.chatHistory;
       if (saved.encryptionEnabled == null) localStorage.removeItem('labcharts-encryption-enabled');
       else localStorage.setItem('labcharts-encryption-enabled', saved.encryptionEnabled);
-      window.renderThreadList?.();
+      chatThreads.renderThreadList();
     }
 
     return outcomes;

--- a/tests/playwright/chat-threads-dom.spec.js
+++ b/tests/playwright/chat-threads-dom.spec.js
@@ -2,13 +2,7 @@ import { expect, test } from './coverage-fixture.js';
 
 test('chat thread rail and delegated thread actions work in the live DOM', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.toggleThreadRail === 'function'
-      && typeof window.renderThreadList === 'function'
-      && typeof window.filterThreadList === 'function'
-      && typeof window.autoNameThread === 'function'
-      && !!window._labState
-  );
+  await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
     const chatThreads = await import('/js/chat-threads.js');
@@ -51,13 +45,33 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
       outcomes.chatThreadNewButtonExists = !!document.querySelector('.chat-thread-new-btn');
       outcomes.chatHeaderLeftExists = !!document.querySelector('.chat-header-left');
       outcomes.chatPanelIsRow = getComputedStyle(chatPanel).flexDirection === 'row';
+      outcomes.chatThreadHelpersStayModuleOnly = [
+        'getChatThreadsKey',
+        'getChatThreadKey',
+        'loadChatThreads',
+        'saveChatThreadIndex',
+        'ensureActiveThread',
+        'createNewThread',
+        'switchToThread',
+        'deleteThread',
+        'renameThread',
+        'renameThreadPrompt',
+        'installChatThreadDelegates',
+        'autoNameThread',
+        'pruneOldThreads',
+        'renderThreadList',
+        'invalidateThreadContentCache',
+        'filterThreadList',
+        'jumpToSearchResult',
+        'toggleThreadRail',
+      ].every(name => typeof window[name] === 'undefined');
 
       rail?.classList.remove('open');
       localStorage.removeItem(railKey);
-      window.toggleThreadRail();
+      chatThreads.toggleThreadRail();
       outcomes.railOpensAndPersists = rail?.classList.contains('open') === true
         && localStorage.getItem(railKey) === 'true';
-      window.toggleThreadRail();
+      chatThreads.toggleThreadRail();
       outcomes.railClosesAndPersists = rail?.classList.contains('open') === false
         && localStorage.getItem(railKey) === 'false';
 
@@ -67,8 +81,8 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
         { id: 't_c', name: 'Cholesterol Overview', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), messageCount: 2, personality: 'default' },
       ];
       state.chatThreads = threadFixtures.map(thread => ({ ...thread }));
-      window.saveChatThreadIndex();
-      window.renderThreadList();
+      chatThreads.saveChatThreadIndex();
+      chatThreads.renderThreadList();
       outcomes.allThreadsRendered = document.querySelectorAll('.chat-thread-item').length === 3;
 
       const threadItem = document.querySelector('.chat-thread-item[data-thread-id="t_a"]');
@@ -103,7 +117,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
       );
 
       state.chatThreads.find(thread => thread.id === 't_a').name = 'Thyroid Panel Discussion';
-      window.renderThreadList();
+      chatThreads.renderThreadList();
       document.querySelector('.chat-thread-item[data-thread-id="t_c"] .chat-thread-item-action.delete')?.click();
       const confirmOk = await waitFor(() => document.getElementById('confirm-ok'));
       document.getElementById('confirm-ok')?.click();
@@ -111,18 +125,18 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
         && await waitFor(() => !state.chatThreads.some(thread => thread.id === 't_c'));
 
       state.chatThreads = threadFixtures.map(thread => ({ ...thread }));
-      window.renderThreadList();
-      window.filterThreadList('thyroid');
+      chatThreads.renderThreadList();
+      chatThreads.filterThreadList('thyroid');
       outcomes.searchFilterShowsOne = document.querySelectorAll('.chat-thread-item').length === 1;
-      window.filterThreadList('');
+      chatThreads.filterThreadList('');
       outcomes.emptyFilterShowsAll = document.querySelectorAll('.chat-thread-item').length === 3;
-      window.filterThreadList('nonexistent');
+      chatThreads.filterThreadList('nonexistent');
       outcomes.noMatchShowsEmptyState = document.querySelectorAll('.chat-thread-item').length === 0
         && document.querySelector('#chat-thread-list div')?.textContent.includes('No matching') === true;
-      window.filterThreadList('');
+      chatThreads.filterThreadList('');
 
       const existingThreadName = state.chatThreads.find(thread => thread.id === 't_b')?.name;
-      window.autoNameThread('t_b', 'This should not rename an existing thread');
+      chatThreads.autoNameThread('t_b', 'This should not rename an existing thread');
       state.chatThreads.unshift({
         id: 't_new',
         name: 'New Conversation',
@@ -131,7 +145,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
         messageCount: 1,
         personality: 'default',
       });
-      window.autoNameThread('t_new', 'What are my vitamin D levels looking like over the past year?');
+      chatThreads.autoNameThread('t_new', 'What are my vitamin D levels looking like over the past year?');
       const expectedAutoName = 'What are my vitamin D levels looking\u2026';
       outcomes.autoNameThreadRenamesOnlyNewConversations =
         state.chatThreads.find(thread => thread.id === 't_b')?.name === existingThreadName
@@ -143,9 +157,9 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
       chatThreads.configureChatThreadDeps(savedThreadDeps);
       if (originalRailState == null) localStorage.removeItem(railKey);
       else localStorage.setItem(railKey, originalRailState);
-      if (originalThreads.length > 0) window.saveChatThreadIndex();
-      else localStorage.removeItem(window.getChatThreadsKey());
-      window.renderThreadList?.();
+      if (originalThreads.length > 0) chatThreads.saveChatThreadIndex();
+      else localStorage.removeItem(chatThreads.getChatThreadsKey());
+      chatThreads.renderThreadList();
     }
 
     return outcomes;

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -31,6 +31,11 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     const previousShellChatImageDeps = shellActions.configureShellChatImageDeps({
       toggleHDMode: () => calls.push(['toggleHDMode']),
     });
+    const previousShellChatThreadDeps = shellActions.configureShellChatThreadDeps({
+      createNewThread: () => calls.push(['createNewThread']),
+      filterThreadList: value => calls.push(['filterThreadList', value]),
+      toggleThreadRail: () => calls.push(['toggleThreadRail']),
+    });
     const originalFns = {
       toggleMobileSidebar: window.toggleMobileSidebar,
       closeMobileSidebar: window.closeMobileSidebar,
@@ -39,8 +44,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       openSettingsModal: window.openSettingsModal,
       toggleChatPanel: window.toggleChatPanel,
       closeChatPanel: window.closeChatPanel,
-      toggleThreadRail: window.toggleThreadRail,
-      createNewThread: window.createNewThread,
       summarizeThread: window.summarizeThread,
       clearChatHistory: window.clearChatHistory,
       toggleChatFullscreen: window.toggleChatFullscreen,
@@ -48,7 +51,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       setChatPersonality: window.setChatPersonality,
       startDiscussion: window.startDiscussion,
       sendChatMessage: window.sendChatMessage,
-      filterThreadList: window.filterThreadList,
       setChatWebSearchEnabled: window.setChatWebSearchEnabled,
       handleChatKeydown: window.handleChatKeydown,
     };
@@ -197,6 +199,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       shellActions.configureShellImportDeps(previousShellImportDeps);
       shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
       shellActions.configureShellChatImageDeps(previousShellChatImageDeps);
+      shellActions.configureShellChatThreadDeps(previousShellChatThreadDeps);
       for (const [name, value] of Object.entries(originalFns)) {
         if (value === undefined) delete window[name];
         else window[name] = value;

--- a/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
+++ b/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
@@ -16,9 +16,10 @@ async function openBlankPage(page) {
 test('sync pull refresh browser coverage exercises active refresh and stale hash cleanup paths', async ({ page }) => {
   await openBlankPage(page);
 
-  const results = await page.evaluate(async ({ refreshUrl, maintenanceUrl, stateUrl }) => {
-    const [refreshModule, maintenance, { state }] = await Promise.all([
+  const results = await page.evaluate(async ({ refreshUrl, refreshRuntimeUrl, maintenanceUrl, stateUrl }) => {
+    const [refreshModule, refreshRuntime, maintenance, { state }] = await Promise.all([
       import(refreshUrl),
+      import(refreshRuntimeUrl),
       import(maintenanceUrl),
       import(stateUrl),
     ]);
@@ -33,9 +34,6 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
       },
       buildSidebar: window.buildSidebar,
       navigate: window.navigate,
-      loadChatThreads: window.loadChatThreads,
-      ensureActiveThread: window.ensureActiveThread,
-      renderThreadList: window.renderThreadList,
       loadChatHistory: window.loadChatHistory,
     };
     const restoreWindowFn = (name, value) => {
@@ -43,6 +41,11 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
       else window[name] = value;
     };
     const calls = [];
+    const previousThreadDeps = refreshRuntime.configureSyncPullActiveRefreshDeps({
+      loadChatThreads: () => { calls.push('loadChatThreads'); },
+      ensureActiveThread: () => { calls.push('ensureActiveThread'); },
+      renderThreadList: () => { calls.push('renderThreadList'); },
+    });
     const debugCalls = [];
     let syncAppliedEvents = 0;
     const onSyncApplied = () => { syncAppliedEvents += 1; };
@@ -51,9 +54,6 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
       window.addEventListener('labcharts-sync-applied', onSyncApplied);
       window.buildSidebar = () => { calls.push('buildSidebar'); };
       window.navigate = (category, options) => { calls.push({ type: 'navigate', category, options: options || null }); };
-      window.loadChatThreads = () => { calls.push('loadChatThreads'); };
-      window.ensureActiveThread = () => { calls.push('ensureActiveThread'); };
-      window.renderThreadList = () => { calls.push('renderThreadList'); };
       window.loadChatHistory = () => { calls.push('loadChatHistory'); };
 
       state.currentProfile = activeProfileId;
@@ -153,10 +153,8 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
       state.importedData = original.state.importedData;
       restoreWindowFn('buildSidebar', original.buildSidebar);
       restoreWindowFn('navigate', original.navigate);
-      restoreWindowFn('loadChatThreads', original.loadChatThreads);
-      restoreWindowFn('ensureActiveThread', original.ensureActiveThread);
-      restoreWindowFn('renderThreadList', original.renderThreadList);
       restoreWindowFn('loadChatHistory', original.loadChatHistory);
+      refreshRuntime.configureSyncPullActiveRefreshDeps(previousThreadDeps);
       document.querySelector('.modal-overlay.show')?.remove();
       document.querySelectorAll('.notification-toast').forEach(toast => toast.remove());
       localStorage.removeItem('labcharts-sync-hash-v2-migrated');
@@ -170,6 +168,7 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
     return outcomes;
   }, {
     refreshUrl: moduleUrl('/js/sync-pull-active-refresh.js'),
+    refreshRuntimeUrl: '/js/sync-pull-active-refresh-runtime.js',
     maintenanceUrl: moduleUrl('/js/sync-pull-maintenance.js'),
     stateUrl: '/js/state.js',
   });

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// test-chat-threads.js — Chat thread feature. Window-export checks, state
+// test-chat-threads.js — Chat thread feature. Module-boundary checks, state
 // shape, thread CRUD (create / auto-name / rename / delete), legacy
 // migration, save/load round-trip, 50-thread pruning, backup snapshot,
 // encryption-pattern matching, ensureActiveThread, thread-personality
@@ -39,8 +39,7 @@ const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 console.log('=== Chat Threads Tests ===\n');
 
 // state.js → state + isSensitiveKey lives in crypto.js, buildBackupSnapshot
-// is module-only in backup.js, and the thread handlers remain on the legacy
-// browser facade while that migration continues.
+// is module-only in backup.js, and thread handlers are imported directly.
 const stateModule = await import('../js/state.js');
 const cryptoModule = await import('../js/crypto.js');
 const backupModule = await import('../js/backup.js');
@@ -52,7 +51,7 @@ const st = stateModule.state;
 // ═══════════════════════════════════════════════
 // 1. Source Inspection — Window Exports
 // ═══════════════════════════════════════════════
-console.log('1. Window Exports');
+console.log('1. Module Exports');
 const threadFns = [
   'getChatThreadsKey', 'getChatThreadKey',
   'loadChatThreads', 'saveChatThreadIndex',
@@ -62,10 +61,12 @@ const threadFns = [
   'autoNameThread', 'pruneOldThreads',
   'renderThreadList', 'filterThreadList',
   'installChatThreadDelegates',
+  'invalidateThreadContentCache', 'jumpToSearchResult',
   'toggleThreadRail'
 ];
 for (const fn of threadFns) {
-  assert(`window.${fn} exists`, typeof window[fn] === 'function');
+  assert(`chatThreadsModule.${fn} exists`, typeof chatThreadsModule[fn] === 'function');
+  assert(`window.${fn} stays module-only`, typeof window[fn] === 'undefined');
 }
 
 // ═══════════════════════════════════════════════
@@ -88,9 +89,9 @@ const profileId = st.currentProfile;
 
 st.chatThreads = [];
 st.currentThreadId = null;
-localStorage.removeItem(window.getChatThreadsKey());
+localStorage.removeItem(chatThreadsModule.getChatThreadsKey());
 
-await sleep(2); window.createNewThread();
+await sleep(2); chatThreadsModule.createNewThread();
 assert('createNewThread creates 1 thread', st.chatThreads.length === 1);
 assert('thread has valid id', st.chatThreads[0].id.startsWith('t_'));
 assert('thread name is "New Conversation"', st.chatThreads[0].name === 'New Conversation');
@@ -106,43 +107,43 @@ const firstThreadId = st.chatThreads[0].id;
 // 5. Thread CRUD — Auto-name
 // ═══════════════════════════════════════════════
 console.log('5. Thread CRUD — Auto-name');
-window.autoNameThread(firstThreadId, 'What are my vitamin D levels looking like over the past year?');
+chatThreadsModule.autoNameThread(firstThreadId, 'What are my vitamin D levels looking like over the past year?');
 const namedThread = st.chatThreads.find(t => t.id === firstThreadId);
 assert('auto-name applied', namedThread.name !== 'New Conversation');
 assert('auto-name <= 41 chars (40 + ellipsis)', namedThread.name.length <= 41);
 assert('auto-name has ellipsis for long text', namedThread.name.endsWith('…'));
 
-await sleep(2); window.createNewThread();
+await sleep(2); chatThreadsModule.createNewThread();
 const shortThreadId = st.chatThreads[0].id;
-window.autoNameThread(shortThreadId, 'Thyroid panel');
+chatThreadsModule.autoNameThread(shortThreadId, 'Thyroid panel');
 const shortThread = st.chatThreads.find(t => t.id === shortThreadId);
 assert('short message name has no ellipsis', shortThread.name === 'Thyroid panel');
 
-window.autoNameThread(shortThreadId, 'Different message');
+chatThreadsModule.autoNameThread(shortThreadId, 'Different message');
 assert('auto-name does not overwrite existing name', shortThread.name === 'Thyroid panel');
 
 // ═══════════════════════════════════════════════
 // 6. Thread CRUD — Rename
 // ═══════════════════════════════════════════════
 console.log('6. Thread CRUD — Rename');
-window.renameThread(shortThreadId, 'My Custom Name');
+chatThreadsModule.renameThread(shortThreadId, 'My Custom Name');
 assert('rename applied', shortThread.name === 'My Custom Name');
-window.renameThread(shortThreadId, '');
+chatThreadsModule.renameThread(shortThreadId, '');
 assert('empty rename ignored', shortThread.name === 'My Custom Name');
 
 // ═══════════════════════════════════════════════
 // 7. Thread CRUD — Delete
 // ═══════════════════════════════════════════════
 console.log('7. Thread CRUD — Delete');
-await sleep(2); window.createNewThread();
+await sleep(2); chatThreadsModule.createNewThread();
 const deleteTargetId = st.currentThreadId;
-localStorage.setItem(window.getChatThreadKey(deleteTargetId), JSON.stringify([{ role: 'user', content: 'test' }]));
+localStorage.setItem(chatThreadsModule.getChatThreadKey(deleteTargetId), JSON.stringify([{ role: 'user', content: 'test' }]));
 const countBefore = st.chatThreads.length;
 st.chatThreads = st.chatThreads.filter(t => t.id !== deleteTargetId);
-window.saveChatThreadIndex();
-localStorage.removeItem(window.getChatThreadKey(deleteTargetId));
+chatThreadsModule.saveChatThreadIndex();
+localStorage.removeItem(chatThreadsModule.getChatThreadKey(deleteTargetId));
 assert('thread removed from index', st.chatThreads.length === countBefore - 1);
-assert('thread messages removed from localStorage', localStorage.getItem(window.getChatThreadKey(deleteTargetId)) === null);
+assert('thread messages removed from localStorage', localStorage.getItem(chatThreadsModule.getChatThreadKey(deleteTargetId)) === null);
 
 // ═══════════════════════════════════════════════
 // 8. Legacy Migration
@@ -150,7 +151,7 @@ assert('thread messages removed from localStorage', localStorage.getItem(window.
 console.log('8. Legacy Migration');
 st.chatThreads = [];
 st.currentThreadId = null;
-localStorage.removeItem(window.getChatThreadsKey());
+localStorage.removeItem(chatThreadsModule.getChatThreadsKey());
 const legacyKey = `labcharts-${profileId}-chat`;
 const legacyMessages = [
   { role: 'user', content: 'Hello' },
@@ -162,11 +163,11 @@ assert('migration creates 1 thread', st.chatThreads.length === 1);
 assert('migrated thread id is t_migrated', st.chatThreads[0].id === 't_migrated');
 assert('migrated thread named "Previous Chat"', st.chatThreads[0].name === 'Previous Chat');
 assert('migrated thread messageCount matches', st.chatThreads[0].messageCount === 2);
-const migratedMessages = JSON.parse(localStorage.getItem(window.getChatThreadKey('t_migrated')));
+const migratedMessages = JSON.parse(localStorage.getItem(chatThreadsModule.getChatThreadKey('t_migrated')));
 assert('migrated messages written to per-thread key', migratedMessages && migratedMessages.length === 2);
 assert('legacy key preserved (rollback safety)', localStorage.getItem(legacyKey) !== null);
 localStorage.removeItem(legacyKey);
-localStorage.removeItem(window.getChatThreadKey('t_migrated'));
+localStorage.removeItem(chatThreadsModule.getChatThreadKey('t_migrated'));
 
 // ═══════════════════════════════════════════════
 // 9. Save/Load Round-trip
@@ -174,24 +175,24 @@ localStorage.removeItem(window.getChatThreadKey('t_migrated'));
 console.log('9. Save/Load Round-trip');
 st.chatThreads = [];
 st.currentThreadId = null;
-localStorage.removeItem(window.getChatThreadsKey());
-await sleep(2); window.createNewThread();
+localStorage.removeItem(chatThreadsModule.getChatThreadsKey());
+await sleep(2); chatThreadsModule.createNewThread();
 const rtThreadId = st.currentThreadId;
 st.chatHistory = [
   { role: 'user', content: 'Test message' },
   { role: 'assistant', content: 'Test response' }
 ];
 await window.saveChatHistory();
-const savedIndex = JSON.parse(localStorage.getItem(window.getChatThreadsKey()));
+const savedIndex = JSON.parse(localStorage.getItem(chatThreadsModule.getChatThreadsKey()));
 assert('thread index saved to localStorage', savedIndex && savedIndex.length === 1);
 assert('thread index messageCount updated', savedIndex[0].messageCount === 2);
-const savedMessages = JSON.parse(localStorage.getItem(window.getChatThreadKey(rtThreadId)));
+const savedMessages = JSON.parse(localStorage.getItem(chatThreadsModule.getChatThreadKey(rtThreadId)));
 assert('messages saved to per-thread key', savedMessages && savedMessages.length === 2);
 st.chatHistory = [];
 await window.loadChatHistory();
 assert('messages loaded back', st.chatHistory.length === 2);
 assert('message content matches', st.chatHistory[0].content === 'Test message');
-localStorage.removeItem(window.getChatThreadKey(rtThreadId));
+localStorage.removeItem(chatThreadsModule.getChatThreadKey(rtThreadId));
 
 // ═══════════════════════════════════════════════
 // 10. Encrypted Thread Index Load Guard
@@ -276,12 +277,12 @@ for (let i = 0; i < 55; i++) {
     personality: 'default'
   });
 }
-window.pruneOldThreads();
+chatThreadsModule.pruneOldThreads();
 assert('pruned to 50 threads', st.chatThreads.length === 50, 'Got ' + st.chatThreads.length);
 assert('oldest threads removed', !st.chatThreads.find(t => t.id === 't_prune_0'));
 assert('newest threads kept', !!st.chatThreads.find(t => t.id === 't_prune_54'));
 for (let i = 0; i < 55; i++) {
-  localStorage.removeItem(window.getChatThreadKey(`t_prune_${i}`));
+  localStorage.removeItem(chatThreadsModule.getChatThreadKey(`t_prune_${i}`));
 }
 
 // ═══════════════════════════════════════════════
@@ -298,8 +299,8 @@ if (!_origProfiles) {
 st.chatThreads = [
   { id: 't_backup1', name: 'Backup Test', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), messageCount: 1, personality: 'default' }
 ];
-window.saveChatThreadIndex();
-localStorage.setItem(window.getChatThreadKey('t_backup1'), JSON.stringify([{ role: 'user', content: 'backup test' }]));
+chatThreadsModule.saveChatThreadIndex();
+localStorage.setItem(chatThreadsModule.getChatThreadKey('t_backup1'), JSON.stringify([{ role: 'user', content: 'backup test' }]));
 
 const snapshot = backupModule.buildBackupSnapshot();
 assert('snapshot exists', !!snapshot);
@@ -312,7 +313,7 @@ if (snapshot) {
     assert('chatRailOpen in backup prefs', profileBackup.keys.hasOwnProperty('chatRailOpen') || true, '(optional — only present if set)');
   }
 }
-localStorage.removeItem(window.getChatThreadKey('t_backup1'));
+localStorage.removeItem(chatThreadsModule.getChatThreadKey('t_backup1'));
 if (!_origProfiles) localStorage.removeItem('labcharts-profiles');
 else localStorage.setItem('labcharts-profiles', _origProfiles);
 
@@ -435,7 +436,7 @@ const previousChatLock = sessionStorage.getItem(chatLockKey);
 sessionStorage.removeItem(chatLockKey);
 st.chatThreads = [];
 st.currentThreadId = null;
-window.ensureActiveThread();
+chatThreadsModule.ensureActiveThread();
 assert('creates thread when none exist', st.chatThreads.length === 1);
 assert('sets currentThreadId', !!st.currentThreadId);
 assert('auto-created empty thread does not mark chat as locally edited',
@@ -450,7 +451,7 @@ st.chatThreads = [
   { id: 't_new', name: 'New', createdAt: newTs, updatedAt: newTs, messageCount: 2, personality: 'default' }
 ];
 st.currentThreadId = 'nonexistent';
-window.ensureActiveThread();
+chatThreadsModule.ensureActiveThread();
 assert('picks most recent thread', st.currentThreadId === 't_new');
 
 // ═══════════════════════════════════════════════
@@ -460,7 +461,7 @@ console.log('20. Thread Personality');
 st.chatThreads = [];
 st.currentThreadId = null;
 st.currentChatPersonality = 'house';
-await sleep(2); window.createNewThread();
+await sleep(2); chatThreadsModule.createNewThread();
 const pThread = st.chatThreads.find(t => t.id === st.currentThreadId);
 assert('new thread inherits current personality', pThread && pThread.personality === 'house');
 
@@ -471,9 +472,9 @@ st.chatThreads = origThreads;
 st.currentThreadId = origThreadId;
 st.chatHistory = origHistory;
 if (origThreads.length > 0) {
-  window.saveChatThreadIndex();
+  chatThreadsModule.saveChatThreadIndex();
 } else {
-  localStorage.removeItem(window.getChatThreadsKey());
+  localStorage.removeItem(chatThreadsModule.getChatThreadsKey());
 }
 for (const key of Object.keys(localStorage)) {
   if (key.includes('chat-t_t_') || key.includes('t_prune_') || key.includes('t_backup')) {

--- a/tests/test-custom-personality.js
+++ b/tests/test-custom-personality.js
@@ -34,6 +34,7 @@ console.log('=== Multiple Custom Personalities Tests ===\n');
 await import('../js/state.js');
 await import('../js/chat.js');
 const { buildPersonalityPrompt } = await import('../js/chat-prompt-context.js');
+const { createNewThread } = await import('../js/chat-threads.js');
 
 const profileId = localStorage.getItem('labcharts-current-profile') || 'default';
 const key = `labcharts-${profileId}-chatPersonalityCustom`;
@@ -176,7 +177,7 @@ assert('prompt context uses Persona: prefix', buildPersonalityPrompt({ id: 'cust
 
 // ── 14. Thread metadata ──
 console.log('14. Thread metadata');
-const createSrc = window.createNewThread.toString();
+const createSrc = createNewThread.toString();
 assert('createNewThread has personalityName', createSrc.includes('personalityName'));
 assert('createNewThread has personalityIcon', createSrc.includes('personalityIcon'));
 const saveSrc = window.saveChatHistory.toString();

--- a/tests/test-onboarding-view-runtime.js
+++ b/tests/test-onboarding-view-runtime.js
@@ -6,6 +6,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import './_node-shim.js';
 import {
+  configureOnboardingViewRuntimeDeps,
   createOnboardingChatThreadRuntime,
   navigateOnboardingRuntime,
   openOnboardingChatPanelRuntime,
@@ -28,7 +29,6 @@ const runtimeKeys = [
   'navigate',
   'openChatPanel',
   'toggleChatPanel',
-  'createNewThread',
   'renderChatMessages',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
@@ -52,6 +52,9 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  const previousDeps = configureOnboardingViewRuntimeDeps({
+    createNewThread: () => calls.push(['createNewThread']),
+  });
   setRuntimeValue('window', globalThis);
   setRuntimeValue('buildSidebar', data => calls.push(['buildSidebar', data?.id]));
   setRuntimeValue('navigate', (route, data) => calls.push(['navigate', route, data?.id]));
@@ -60,7 +63,6 @@ try {
     return 'opened';
   });
   setRuntimeValue('toggleChatPanel', () => calls.push(['toggleChatPanel']));
-  setRuntimeValue('createNewThread', () => calls.push(['createNewThread']));
   setRuntimeValue('renderChatMessages', () => calls.push(['renderChatMessages']));
 
   rebuildOnboardingSidebarRuntime({ id: 'sidebar-data' });
@@ -94,7 +96,7 @@ try {
   assert('onboarding provider chat reports unavailable shell hooks',
     openOnboardingProviderChatRuntime() === false);
 
-  delete globalThis.createNewThread;
+  configureOnboardingViewRuntimeDeps({ createNewThread: null });
   assert('onboarding runtime reports unavailable thread creation',
     createOnboardingChatThreadRuntime() === false);
 
@@ -108,6 +110,8 @@ try {
       createOnboardingChatThreadRuntime() === false &&
       renderOnboardingChatMessagesRuntime() === undefined &&
       calls.length === beforeNoWindowCalls);
+
+  configureOnboardingViewRuntimeDeps(previousDeps);
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const onboardingSrc = fs.readFileSync(path.join(root, 'js/onboarding-view.js'), 'utf8');

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -70,6 +70,20 @@ assert('App shell wires module-only chat image consumers',
     && appShellHooksSrc.includes('configureShellChatImageDeps({ toggleHDMode });')
     && appShellHooksSrc.includes('configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });'));
 
+assert('Chat thread shell actions use module dependencies instead of window lookups',
+  shellSrc.includes('shellChatThreadDeps.toggleThreadRail()')
+    && shellSrc.includes('shellChatThreadDeps.createNewThread()')
+    && shellSrc.includes('shellChatThreadDeps.filterThreadList(input.value)')
+    && !shellSrc.includes("callShellRuntime('toggleThreadRail')")
+    && !shellSrc.includes("callShellRuntime('createNewThread')")
+    && !shellSrc.includes("callShellRuntime('filterThreadList'"));
+
+assert('App shell wires module-only chat thread consumers',
+  appShellHooksSrc.includes("from './chat-threads.js'")
+    && appShellHooksSrc.includes('configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });')
+    && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ createNewThread });')
+    && appShellHooksSrc.includes('configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatThreads, renderThreadList });'));
+
 assert('App shell wires Context hub status refresh without a window lookup',
   appShellHooksSrc.includes("import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js'")
     && appShellHooksSrc.includes("import { updateChatContextStatus } from './chat-personalities.js'")
@@ -98,7 +112,7 @@ assert('Thread search uses delegated input/search action',
   html.includes('data-chat-input-action="filter-thread-list"')
     && shellSrc.includes("document.addEventListener('input', handleShellInput)")
     && shellSrc.includes("document.addEventListener('search', handleShellInput)")
-    && shellSrc.includes("callShellRuntime('filterThreadList', input.value)"));
+    && shellSrc.includes('shellChatThreadDeps.filterThreadList(input.value)'));
 assert('Web search toggle uses delegated change action',
   html.includes('data-chat-change-action="set-websearch"')
     && shellSrc.includes("document.addEventListener('change', handleShellChange)")

--- a/tests/test-sync-pull-active-refresh-runtime.js
+++ b/tests/test-sync-pull-active-refresh-runtime.js
@@ -6,6 +6,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import './_node-shim.js';
 import {
+  configureSyncPullActiveRefreshDeps,
   dispatchSyncAppliedRuntime,
   navigatePulledActiveViewRuntime,
   rebuildPulledSidebarRuntime,
@@ -22,9 +23,6 @@ console.log('=== Sync Pull Active Refresh Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'loadChatThreads',
-  'ensureActiveThread',
-  'renderThreadList',
   'loadChatHistory',
   'buildSidebar',
   'navigate',
@@ -50,12 +48,15 @@ function restoreRuntime() {
   }
 }
 
+const calls = [];
+const previousDeps = configureSyncPullActiveRefreshDeps({
+  loadChatThreads: () => calls.push(['loadChatThreads']),
+  ensureActiveThread: () => calls.push(['ensureActiveThread']),
+  renderThreadList: () => calls.push(['renderThreadList']),
+});
+
 try {
-  const calls = [];
   setRuntimeValue('window', globalThis);
-  setRuntimeValue('loadChatThreads', () => calls.push(['loadChatThreads']));
-  setRuntimeValue('ensureActiveThread', () => calls.push(['ensureActiveThread']));
-  setRuntimeValue('renderThreadList', () => calls.push(['renderThreadList']));
   setRuntimeValue('loadChatHistory', () => calls.push(['loadChatHistory']));
   setRuntimeValue('buildSidebar', () => calls.push(['buildSidebar']));
   setRuntimeValue('navigate', (route, options) => calls.push(['navigate', route, options?.preserveScroll]));
@@ -87,6 +88,11 @@ try {
   assert('sync pull active refresh runtime guards sidebar rebuild failures',
     rebuildPulledSidebarRuntime() === undefined);
 
+  configureSyncPullActiveRefreshDeps({
+    loadChatThreads: () => undefined,
+    ensureActiveThread: () => {},
+    renderThreadList: () => {},
+  });
   delete globalThis.window;
   const beforeNoWindowCalls = calls.length;
   refreshPulledChatRuntime();
@@ -111,6 +117,7 @@ try {
       !/\bwindow(?:\.|\s*\[)/.test(refreshSrc) &&
       swSrc.includes("'/js/sync-pull-active-refresh-runtime.js'"));
 } finally {
+  configureSyncPullActiveRefreshDeps(previousDeps);
   restoreRuntime();
 }
 

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -670,7 +670,7 @@ await import('../js/settings.js');
   assert('sync-pull-active-refresh-runtime.js owns active refresh browser hooks',
     syncPullActiveRefreshSrc.includes("from './sync-pull-active-refresh-runtime.js'")
       && !/\bwindow(?:\.|\s*\[)/.test(syncPullActiveRefreshSrc)
-      && syncPullActiveRefreshRuntimeSrc.includes("const loaded = getRuntimeFunction('loadChatThreads')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes('const loaded = syncPullActiveRefreshDeps.loadChatThreads()')
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('buildSidebar')?.()")
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('navigate')?.(route, options)")
       && syncPullActiveRefreshRuntimeSrc.includes("runtime.dispatchEvent(new runtime.CustomEvent('labcharts-sync-applied'))"));
@@ -1578,10 +1578,10 @@ await import('../js/settings.js');
       && syncPullActiveRefreshSrc.includes('if (chatApplied)'));
   assert('active chat thread is reselected after remote thread deletion',
     syncPullActiveRefreshSrc.includes('refreshPulledChatRuntime();')
-      && syncPullActiveRefreshRuntimeSrc.includes("const loaded = getRuntimeFunction('loadChatThreads')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes('const loaded = syncPullActiveRefreshDeps.loadChatThreads()')
       && syncPullActiveRefreshRuntimeSrc.includes("if (threadsLoaded === false)")
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('ensureActiveThread')?.()")
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('renderThreadList')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes('syncPullActiveRefreshDeps.ensureActiveThread()')
+      && syncPullActiveRefreshRuntimeSrc.includes('syncPullActiveRefreshDeps.renderThreadList()')
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('loadChatHistory')?.()"));
   {
     const prevProfileId = state.currentProfile;

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -791,6 +791,26 @@
     'updateAttachButtonVisibility',
     'initChatImageHandlers',
   ].every(name => !(name in window)));
+  assert('chat thread helpers stay module-only', [
+    'getChatThreadsKey',
+    'getChatThreadKey',
+    'loadChatThreads',
+    'saveChatThreadIndex',
+    'ensureActiveThread',
+    'createNewThread',
+    'switchToThread',
+    'deleteThread',
+    'renameThread',
+    'renameThreadPrompt',
+    'installChatThreadDelegates',
+    'autoNameThread',
+    'pruneOldThreads',
+    'renderThreadList',
+    'invalidateThreadContentCache',
+    'filterThreadList',
+    'jumpToSearchResult',
+    'toggleThreadRail',
+  ].every(name => !(name in window)));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.221';
+self.APP_VERSION = '1.10.222';


### PR DESCRIPTION
## Summary

- keep all 18 chat-thread helpers module-only
- remove the remaining thread-key helpers from the chat window facade
- inject thread actions into shell, onboarding, and sync-refresh consumers
- convert thread tests and browser fixtures to direct module APIs
- bump the app version to 1.10.222

## Window burden remaining

After this PR:

- **390 unique `window` globals remain**
- **392 publication entries remain**
- **16 publication sites remain**
- **12 global families remain**

This PR removes 18 unique globals, 18 publication entries, and 1 complete publication site. The measured remaining work is therefore 392 entries across 16 sites. Based on the size and coupling of the remaining chat, sync, sun, wearable, and UI facades, the current estimate is **4–12 coherent follow-up PRs**; larger facades may be retired together where their consumers already have module boundaries.

## Tests

- `npm run quality`
  - 7 guardrails passed
  - 460 JavaScript/ESM files parsed
- `./run-tests.sh`
  - 125 module verification checks passed
  - 398 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive-theme assertions passed
