### PR TITLE
Remove Apple Health debug global

### DIFF
--- a/js/wearables-apple-health-runtime.js
+++ b/js/wearables-apple-health-runtime.js
@@ -10,9 +10,3 @@ function getRuntimeWindow() {
 export function getAppleHealthJSZip() {
   return getRuntimeWindow()?.JSZip || null;
 }
-
-/** @param {Record<string, unknown>} bindings */
-export function exposeAppleHealthDebugBindings(bindings) {
-  const runtime = getRuntimeWindow();
-  if (runtime) Object.assign(runtime, bindings);
-}

--- a/js/wearables-apple-health.js
+++ b/js/wearables-apple-health.js
@@ -20,7 +20,7 @@ import { upsertDailyBatch, setMeta } from './wearables-store.js';
 import { syncWearableSummary } from './wearables-summary.js';
 import { getActiveProfileId } from './profile.js';
 import { isDebugMode } from './utils.js';
-import { exposeAppleHealthDebugBindings, getAppleHealthJSZip } from './wearables-apple-health-runtime.js';
+import { getAppleHealthJSZip } from './wearables-apple-health-runtime.js';
 
 // ─────────────────────────────────────────────────────────
 // File ingestion entry point
@@ -442,5 +442,3 @@ function normaliseUnit(metricId, value, unit) {
       return (!unit || unit === canonUnit) ? value : null;
   }
 }
-
-if (isDebugMode?.()) exposeAppleHealthDebugBindings({ _appleHealth: { importAppleHealthFile, parseAppleHealthXml } });

--- a/tests/test-wearables-apple-health-runtime.js
+++ b/tests/test-wearables-apple-health-runtime.js
@@ -2,10 +2,7 @@
 // Apple Health import runtime adapter behavior.
 
 import './_node-shim.js';
-import {
-  exposeAppleHealthDebugBindings,
-  getAppleHealthJSZip,
-} from '../js/wearables-apple-health-runtime.js';
+import { getAppleHealthJSZip } from '../js/wearables-apple-health-runtime.js';
 
 let passed = 0;
 let failed = 0;
@@ -50,17 +47,14 @@ try {
   assert('getAppleHealthJSZip reads the browser JSZip binding',
     getAppleHealthJSZip() === fakeJSZip);
 
-  const debugBindings = { _appleHealth: { probe: true } };
-  exposeAppleHealthDebugBindings(debugBindings);
-  assert('exposeAppleHealthDebugBindings publishes debug bindings to the browser runtime',
-    browserRuntime._appleHealth === debugBindings._appleHealth);
+  assert('Apple Health debug helpers stay module-only',
+    typeof browserRuntime._appleHealth === 'undefined');
 
   delete browserRuntime.JSZip;
   assert('getAppleHealthJSZip returns null when JSZip is unavailable',
     getAppleHealthJSZip() === null);
 
   delete globalThis.window;
-  exposeAppleHealthDebugBindings({ _appleHealth: { ignored: true } });
   assert('Apple Health runtime adapter no-ops without a browser window',
     getAppleHealthJSZip() === null && typeof globalThis._appleHealth === 'undefined');
 } finally {

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -814,7 +814,10 @@ assert('Apple Health delegates browser globals to runtime adapter',
   ahSrc.includes("from './wearables-apple-health-runtime.js'") &&
     !/\bwindow(?:\.|\s*\[)/.test(ahSrc) &&
     ahRuntimeSrc.includes('export function getAppleHealthJSZip') &&
-    ahRuntimeSrc.includes('export function exposeAppleHealthDebugBindings'));
+    !ahRuntimeSrc.includes('exposeAppleHealthDebugBindings'));
+assert('Apple Health debug bridge stays off window',
+  !ahSrc.includes('exposeAppleHealthDebugBindings') &&
+    typeof window._appleHealth === 'undefined');
 assert('loadJSZip memoizes via module-level _jszipLoad',
   /let\s+_jszipLoad\s*=\s*null/.test(ahSrc));
 assert('loadJSZip injects /vendor/jszip.min.js script tag',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -811,6 +811,7 @@
     'jumpToSearchResult',
     'toggleThreadRail',
   ].every(name => !(name in window)));
+  assert('window._appleHealth stays module-only', !('_appleHealth' in window));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.222';
+self.APP_VERSION = '1.10.223';


### PR DESCRIPTION
## Summary

- remove the unused `_appleHealth` debug bridge
- keep the Apple Health importer and parser as direct ES module APIs
- retain the lazy JSZip browser runtime adapter
- add regression guards that keep the debug surface off `window`
- bump the app cache version to 1.10.223

## Window burden remaining

Before this PR, the audit measured 390 unique window globals across 392 publication entries at 16 publication sites, grouped into 12 global families.

After this PR:

- 389 unique window globals remain
- 391 publication entries remain
- 15 publication sites remain
- 12 global families remain

This PR removes 1 unique global, 1 publication entry, and 1 complete publication site. The measured remaining work is therefore 391 entries across 15 sites. Based on the current grouping of those sites into coherent migrations, the working estimate is **4–11 follow-up PRs** to finish reducing the remaining window burden. This range will be recalculated in every follow-up PR description as migrations expose or consolidate dependencies.

## Test results

- `npm run quality`: 7/7 quality checks, 460 modules parsed
- module verification: 125 passed
- Vitest: 398 passed
- Playwright: 352 passed
- responsive-theme assertions: 472 passed
- Apple Health focused Node tests: 5 passed
- wearables focused Node tests: 586 passed
- Apple Health/wearables focused Playwright: 3 passed
