### PR TITLE
Remove legacy theme globals

### DIFF
--- a/js/theme-runtime.js
+++ b/js/theme-runtime.js
@@ -30,12 +30,3 @@ export function refreshThemeDependentsFromRuntime(options = {}) {
   else runtime.refreshChartThemeColors?.({ batchSize: 4 });
   if (options.settingsModalOpen) runtime.refreshSettingsWearables?.();
 }
-
-/**
- * @param {Record<string, any>} exportsByName
- */
-export function registerThemeRuntimeExports(exportsByName) {
-  const runtime = getThemeRuntimeWindow();
-  if (!runtime) return;
-  Object.assign(runtime, exportsByName);
-}

--- a/js/theme.js
+++ b/js/theme.js
@@ -28,7 +28,6 @@ export const THEMES = [
  * @typedef {{
  *   dispatchThemeChange: (detail: Record<string, any>) => void,
  *   refreshThemeDependentsFromRuntime: (options?: { settingsModalOpen?: boolean }) => void,
- *   registerThemeRuntimeExports: (exportsByName: Record<string, any>) => void,
  * }} ThemeRuntimeHooks
  */
 
@@ -56,11 +55,6 @@ const fallbackThemeRuntime = {
     else runtime.refreshChartThemeColors?.({ batchSize: 4 });
     if (options.settingsModalOpen) runtime.refreshSettingsWearables?.();
   },
-  registerThemeRuntimeExports(exportsByName) {
-    const runtime = getFallbackThemeRuntimeGlobal();
-    if (!runtime) return;
-    Object.assign(runtime, exportsByName);
-  },
 };
 
 /** @type {ThemeRuntimeHooks} */
@@ -79,9 +73,6 @@ if (typeof globalThis !== 'undefined') {
         refreshThemeDependentsFromRuntime: typeof runtime.refreshThemeDependentsFromRuntime === 'function'
           ? runtime.refreshThemeDependentsFromRuntime
           : fallbackThemeRuntime.refreshThemeDependentsFromRuntime,
-        registerThemeRuntimeExports: typeof runtime.registerThemeRuntimeExports === 'function'
-          ? runtime.registerThemeRuntimeExports
-          : fallbackThemeRuntime.registerThemeRuntimeExports,
       };
     })
     .catch(() => {});
@@ -93,10 +84,6 @@ function dispatchThemeChange(detail) {
 
 function refreshThemeDependentsFromRuntime(options) {
   themeRuntimeHooks.refreshThemeDependentsFromRuntime(options);
-}
-
-function registerThemeRuntimeExports(exportsByName) {
-  themeRuntimeHooks.registerThemeRuntimeExports(exportsByName);
 }
 
 export function getTimeFormat() { return localStorage.getItem('labcharts-time-format') || '24h'; }
@@ -234,5 +221,3 @@ export function getChartColors() {
     green: g('--green'), red: g('--red'), yellow: g('--yellow'),
   };
 }
-
-registerThemeRuntimeExports({ getTheme, getThemeColor, getThemeColorScheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, setTheme, toggleTheme, getTimeFormat, setTimeFormat, formatTime, parseTimeInput, getChartColors, THEMES });

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -24,6 +24,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
 
   const results = await page.evaluate(async () => {
     const settingsModule = await import('/js/settings.js');
+    const themeModule = await import('/js/theme.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 80; attempt += 1) {
@@ -91,7 +92,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       timeBtn.click();
       results.setTimeFormatFromDisplaySettings = localStorage.getItem('labcharts-time-format') === '12h'
         && timeBtn.classList.contains('active')
-        && window.formatTime('14:05') === '2:05 PM';
+        && themeModule.formatTime('14:05') === '2:05 PM';
 
       settingsModule.openTweaksPanel();
       const sunsetToggle = document.getElementById('tweaks-sunset-mode');
@@ -202,7 +203,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       document.getElementById('sun-source-fixture')?.remove();
       document.getElementById('confirm-dialog-overlay')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
-      if (saved.theme) window.setTheme?.(saved.theme);
+      if (saved.theme) themeModule.setTheme(saved.theme);
     }
   });
 

--- a/tests/playwright/settings-toggles.spec.js
+++ b/tests/playwright/settings-toggles.spec.js
@@ -29,12 +29,12 @@ async function preparePage(page) {
 test('Settings display toggles persist through delegated slider actions', async ({ page }) => {
   await preparePage(page);
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
 
     localStorage.removeItem('labcharts-show-product-recs');
     localStorage.removeItem('labcharts-debug');
-    window.setTheme?.('cyberterm');
+    (await import('/js/theme.js')).setTheme('cyberterm');
     window.openSettingsModal('display');
   });
 
@@ -72,12 +72,12 @@ test('Settings data sync toggle opens and cancels setup modal', async ({ page })
 test('Tweaks panel toggles sunset and CRT effects with theme gating', async ({ page }) => {
   await preparePage(page);
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     if (typeof window.openTweaksPanel !== 'function') throw new Error('window.openTweaksPanel unavailable');
 
     localStorage.removeItem('labcharts-sunset-mode');
     localStorage.removeItem('labcharts-crt-effects');
-    window.setTheme?.('cyberterm');
+    (await import('/js/theme.js')).setTheme('cyberterm');
     window.openTweaksPanel();
   });
 
@@ -100,9 +100,10 @@ test('Tweaks panel toggles sunset and CRT effects with theme gating', async ({ p
     crtDataset: 'on',
   });
 
-  await page.evaluate(() => {
-    window.setTheme?.('dark');
-    window.setCrtEffectsEnabled?.(false);
+  await page.evaluate(async () => {
+    const themeModule = await import('/js/theme.js');
+    themeModule.setTheme('dark');
+    themeModule.setCrtEffectsEnabled(false);
     window.openTweaksPanel();
   });
 

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -173,6 +173,7 @@ async function prepareScenario(page, theme, viewport) {
   await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
   await waitForApp(page);
   await page.evaluate(async (nextTheme) => {
+    const themeModule = await import('/js/theme.js');
     (await import('/js/views.js')).closeModal();
     window.closeSettingsModal?.();
     window.closeChatPanel?.();
@@ -182,14 +183,12 @@ async function prepareScenario(page, theme, viewport) {
     localStorage.removeItem('labcharts-accent-override');
     localStorage.removeItem('labcharts-sunset-mode');
     localStorage.removeItem('labcharts-crt-effects');
-    if (typeof window.setSunsetMode === 'function') window.setSunsetMode(false);
-    else delete document.documentElement.dataset.sunsetMode;
-    if (typeof window.setCrtEffectsEnabled === 'function') window.setCrtEffectsEnabled(false);
-    else delete document.documentElement.dataset.crtEffects;
+    themeModule.setSunsetMode(false);
+    themeModule.setCrtEffectsEnabled(false);
     window.applyAccentOverride?.('');
     if (nextTheme === 'dark') localStorage.setItem('labcharts-theme', 'dark');
     else localStorage.setItem('labcharts-theme', nextTheme);
-    if (typeof window.setTheme === 'function') window.setTheme(nextTheme);
+    themeModule.setTheme(nextTheme);
   }, theme);
   await seedDemoData(page);
   await page.evaluate(() => {
@@ -505,14 +504,15 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
 
   await page.evaluate(() => window.openTweaksPanel?.());
   await delay(150);
-  result = await page.evaluate((theme) => {
+  result = await page.evaluate(async (theme) => {
+    const themeModule = await import('/js/theme.js');
     const panel = document.getElementById('tweaks-panel');
     const r = panel?.getBoundingClientRect();
     const defaultSwatch = panel?.querySelector('.tweaks-accent-btn[data-accent-id=""] .tweaks-accent-swatch');
     const defaultAccent = defaultSwatch?.style.getPropertyValue('--tweak-accent')?.trim()?.toLowerCase() || '';
     const crtRow = panel?.querySelector('#tweaks-crt-effects-row');
     const crtToggle = panel?.querySelector('#tweaks-crt-effects');
-    const crtSupported = !!window.supportsCrtEffects?.(theme);
+    const crtSupported = themeModule.supportsCrtEffects(theme);
     const crtRowVisible = !!crtRow && !crtRow.hidden && getComputedStyle(crtRow).display !== 'none';
     return {
       open: !!panel,
@@ -567,8 +567,8 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
     settingsModule.updateTweaksUI();
   });
   await delay(80);
-  result = await page.evaluate((theme) => {
-    const supported = !!window.supportsCrtEffects?.(theme);
+  result = await page.evaluate(async (theme) => {
+    const supported = (await import('/js/theme.js')).supportsCrtEffects(theme);
     const crtRow = document.getElementById('tweaks-crt-effects-row');
     const crtToggle = document.getElementById('tweaks-crt-effects');
     const crtRowVisible = !!crtRow && !crtRow.hidden && getComputedStyle(crtRow).display !== 'none';
@@ -602,8 +602,8 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
     settingsModule.updateTweaksUI();
   });
   await delay(80);
-  result = await page.evaluate((theme) => {
-    const supported = !!window.supportsCrtEffects?.(theme);
+  result = await page.evaluate(async (theme) => {
+    const supported = (await import('/js/theme.js')).supportsCrtEffects(theme);
     const crtRow = document.getElementById('tweaks-crt-effects-row');
     const crtToggle = document.getElementById('tweaks-crt-effects');
     const crtRowVisible = !!crtRow && !crtRow.hidden && getComputedStyle(crtRow).display !== 'none';
@@ -625,8 +625,8 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
       && result.crtToggleDisabled === !result.supported
       && result.bodyAfterContent === 'none',
     JSON.stringify(result));
-  await page.evaluate(() => {
-    window.setSunsetMode?.(true);
+  await page.evaluate(async () => {
+    (await import('/js/theme.js')).setSunsetMode(true);
     window.applyAccentOverride?.();
     window.updateTweaksUI?.();
   });
@@ -655,8 +655,8 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
       && result.sunsetToggle
       && result.themeColors.every(color => color === SUNSET_THEME_COLOR),
     JSON.stringify(result));
-  await page.evaluate(() => {
-    window.setSunsetMode?.(false);
+  await page.evaluate(async () => {
+    (await import('/js/theme.js')).setSunsetMode(false);
     window.applyAccentOverride?.();
     window.updateTweaksUI?.();
   });

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -186,12 +186,13 @@ console.log('=== Phase 3 A11y Tests ===\n');
     themeSrc.includes('getThemeColorScheme') &&
     themeSrc.includes('document.documentElement.style.colorScheme'),
     'custom dark themes need dark system controls after switching themes');
-  assert('theme browser globals are isolated in runtime adapter',
+  assert('theme browser hooks stay isolated while theme APIs remain module-only',
     themeSrc.includes("import('./theme-runtime.js')")
       && themeSrc.includes('fallbackThemeRuntime')
       && !/\bwindow\b/.test(themeSrc)
       && themeRuntimeSrc.includes('dispatchThemeChange')
-      && themeRuntimeSrc.includes('registerThemeRuntimeExports'));
+      && !themeSrc.includes('registerThemeRuntimeExports')
+      && !themeRuntimeSrc.includes('registerThemeRuntimeExports'));
   assert('document root defaults to dark browser controls outside light theme',
     /html\s*\{[^}]*background:\s*var\(--bg-primary\)[^}]*color-scheme:\s*dark/.test(cssSrc) &&
     /\[data-theme="light"\]\s*\{[^}]*color-scheme:\s*light/.test(cssSrc));

--- a/tests/test-theme-runtime.js
+++ b/tests/test-theme-runtime.js
@@ -6,7 +6,6 @@ import './_node-shim.js';
 import {
   dispatchThemeChange,
   refreshThemeDependentsFromRuntime,
-  registerThemeRuntimeExports,
 } from '../js/theme-runtime.js';
 
 let pass = 0, fail = 0;
@@ -24,7 +23,6 @@ const RUNTIME_FIELDS = [
   'scheduleChartThemeRefresh',
   'refreshChartThemeColors',
   'refreshSettingsWearables',
-  '__themeRuntimeProbe',
 ];
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
@@ -89,10 +87,6 @@ try {
   refreshThemeDependentsFromRuntime({ settingsModalOpen: false });
   assert('theme dependents fall back to chart color refresh', chartRefreshOptions?.batchSize === 4);
 
-  const probe = () => 'ok';
-  registerThemeRuntimeExports({ __themeRuntimeProbe: probe });
-  assert('theme runtime exports assign to window', globalThis.__themeRuntimeProbe === probe);
-
   delete globalThis.window;
   assert('no-window dispatch is safe', (() => {
     dispatchThemeChange({ theme: 'dark' });
@@ -102,8 +96,6 @@ try {
     refreshThemeDependentsFromRuntime({ settingsModalOpen: true });
     return true;
   })());
-  registerThemeRuntimeExports({ __themeRuntimeProbe: 'no-window' });
-  assert('no-window exports are no-ops', globalThis.__themeRuntimeProbe === probe);
 } finally {
   for (const field of RUNTIME_FIELDS) {
     restoreDescriptor(globalThis, field, originalFieldDescriptors.get(field));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -34,6 +34,7 @@ return (async function() {
   const contextCards = await import('/js/context-cards.js');
   const settingsModule = await import('/js/settings.js');
   const navModule = await import('/js/nav.js');
+  const themeModule = await import('/js/theme.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -279,13 +280,13 @@ return (async function() {
   assert('Display panel visible', !!document.querySelector('.settings-tab-panel[data-tab-panel="display"].active'));
   assert('Display settings does not duplicate theme picker', !document.querySelector('.settings-theme-grid'));
 
-  const origThemeForTweaks = window.getTheme();
+  const origThemeForTweaks = themeModule.getTheme();
   const origAccentForTweaks = localStorage.getItem('labcharts-accent-override');
   const origSunsetForTweaks = localStorage.getItem('labcharts-sunset-mode');
   const origCrtForTweaks = localStorage.getItem('labcharts-crt-effects');
-  window.setTheme('dark');
-  window.setSunsetMode?.(false);
-  window.setCrtEffectsEnabled?.(false);
+  themeModule.setTheme('dark');
+  themeModule.setSunsetMode(false);
+  themeModule.setCrtEffectsEnabled(false);
   settingsModule.applyAccentOverride();
   settingsModule.openTweaksPanel();
   await wait(30);
@@ -319,11 +320,9 @@ return (async function() {
   settingsModule.closeTweaksPanel();
   if (origAccentForTweaks) localStorage.setItem('labcharts-accent-override', origAccentForTweaks);
   else localStorage.removeItem('labcharts-accent-override');
-  if (origSunsetForTweaks) window.setSunsetMode?.(true);
-  else window.setSunsetMode?.(false);
-  if (origCrtForTweaks) window.setCrtEffectsEnabled?.(true);
-  else window.setCrtEffectsEnabled?.(false);
-  window.setTheme(origThemeForTweaks);
+  themeModule.setSunsetMode(!!origSunsetForTweaks);
+  themeModule.setCrtEffectsEnabled(!!origCrtForTweaks);
+  themeModule.setTheme(origThemeForTweaks);
   settingsModule.applyAccentOverride(origAccentForTweaks || '');
 
   // Switch to data tab
@@ -689,10 +688,10 @@ return (async function() {
   // ═══════════════════════════════════════════════
   console.log('%c 10. Theme toggle', 'font-weight:bold;color:#6366f1');
 
-  const origTheme = window.getTheme();
-  window.toggleTheme();
+  const origTheme = themeModule.getTheme();
+  themeModule.toggleTheme();
   await wait(20);
-  const newTheme = window.getTheme();
+  const newTheme = themeModule.getTheme();
   assert('Theme toggled', newTheme !== origTheme);
   const htmlEl = document.documentElement;
   if (newTheme === 'light') {
@@ -701,9 +700,9 @@ return (async function() {
     assert('Dark theme removes data-theme attr', htmlEl.getAttribute('data-theme') === null);
   }
   // Restore
-  window.toggleTheme();
+  themeModule.toggleTheme();
   await wait(20);
-  assert('Theme restored', window.getTheme() === origTheme);
+  assert('Theme restored', themeModule.getTheme() === origTheme);
 
   // ═══════════════════════════════════════════════
   // 11. CHAT PANEL — open, close

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -190,7 +190,7 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, feedbackModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, nostrModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, feedbackModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, nostrModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, themeModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
@@ -220,6 +220,7 @@
     import('../js/sun-context.js'),
     import('../js/sun-spectrum.js'),
     import('../js/supplements.js'),
+    import('../js/theme.js'),
     import('../js/utils.js'),
     import('../js/views.js'),
   ]);
@@ -637,9 +638,11 @@
     'refreshSupplementImpact','updateIngTotal','updateAllIngTotals','ingredientDailyTotal'
   ];
 
-  // theme.js (8)
+  // theme.js (16 former browser globals, now module-only)
   const themeExports = [
-    'getTheme','setTheme','toggleTheme',
+    'THEMES','getTheme','getThemeColor','getThemeColorScheme',
+    'isSunsetMode','setSunsetMode','isCrtEffectsEnabled','setCrtEffectsEnabled',
+    'supportsCrtEffects','setTheme','toggleTheme',
     'getTimeFormat','setTimeFormat','formatTime','parseTimeInput',
     'getChartColors'
   ];
@@ -725,6 +728,7 @@
     ['sun-context.js', sunContextModule, sunContextExports],
     ['sun-spectrum.js', sunSpectrumModule, sunSpectrumExports],
     ['supplements.js', supplementsModule, supplementsExports],
+    ['theme.js', themeModule, themeExports],
     ['utils.js', utilsModule, utilsExports],
     ['views.js facade', viewsModule, viewsFacadeModuleExports],
     ['views.js dashboard widgets', viewsModule, viewsDashboardWidgetExports],
@@ -770,6 +774,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of settingsModuleOnlyExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of themeExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   assert('window.scheduleChartThemeRefresh stays module-internal', !('scheduleChartThemeRefresh' in window));
@@ -863,7 +870,6 @@
     'client-list.js': clientListExports,
     'nav.js': navGlobals,
     'settings.js': settingsGlobals,
-    'theme.js': themeExports,
     'views.js': viewsLegacyExports,
   };
 
@@ -963,17 +969,17 @@
     `Got ${typeof ref}, keys: ${ref ? Object.keys(ref).length : 0}`);
 
   // getChartColors depends on theme.js — returns object with CSS var values (may be empty strings in headless)
-  const colors = window.getChartColors();
+  const colors = themeModule.getChartColors();
   assert('getChartColors returns object with expected keys', typeof colors === 'object' && 'tooltipBg' in colors && 'tickColor' in colors,
     colors ? Object.keys(colors).join(',') : 'null');
 
   // formatTime depends on theme.js
-  const formatted = window.formatTime('14:30');
+  const formatted = themeModule.formatTime('14:30');
   assert('formatTime works', typeof formatted === 'string' && formatted.length > 0);
 
   // parseTimeInput round-trip
-  assert('parseTimeInput("2:30 PM") → 14:30', window.parseTimeInput('2:30 PM') === '14:30');
-  assert('parseTimeInput("14:30") → 14:30', window.parseTimeInput('14:30') === '14:30');
+  assert('parseTimeInput("2:30 PM") → 14:30', themeModule.parseTimeInput('2:30 PM') === '14:30');
+  assert('parseTimeInput("14:30") → 14:30', themeModule.parseTimeInput('14:30') === '14:30');
 
   // ═══════════════════════════════════════════════
   // 8. PROFILE SYSTEM — basic operations
@@ -989,7 +995,7 @@
   // ═══════════════════════════════════════════════
   // 9. THEME SYSTEM — toggle works
   // ═══════════════════════════════════════════════
-  const currentTheme = window.getTheme();
+  const currentTheme = themeModule.getTheme();
   assert('getTheme returns string', currentTheme === 'dark' || currentTheme === 'light');
   const htmlEl = document.documentElement;
   // Dark theme removes data-theme attribute; light sets it to 'light'

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.223';
+self.APP_VERSION = '1.10.224';


### PR DESCRIPTION
## Summary

- stop publishing the 16 theme APIs and constants on `window`
- keep every production consumer on direct ES module imports
- retain the cache-transition-safe runtime hooks for theme events and dependent UI refreshes
- convert browser and legacy UI tests to import `theme.js` directly
- add explicit regression guards for all 16 former globals
- bump the app cache version to 1.10.224

## Window burden remaining

Before this PR, the audit measured 389 unique window globals across 391 publication entries at 15 publication sites, grouped into 12 global families.

After this PR:

- 373 unique window globals remain
- 375 publication entries remain
- 14 publication sites remain
- 11 global families remain

This PR removes 16 unique globals, 16 publication entries, one complete publication site, and the remaining theme global family. The measured remaining work is therefore **375 entries across 14 sites**. Based on the current dependency grouping, the working estimate is **3–10 follow-up PRs** to finish reducing the remaining window burden. This range will be recalculated in every follow-up PR description as migrations expose or consolidate dependencies.

## Test results

- `npm run quality`: 7/7 quality checks, 460 modules parsed
- module verification: 125 passed
- Vitest: 398 passed
- Playwright: 352 passed
- responsive-theme assertions: 472 passed
- focused theme/settings/UI Playwright: 11 passed
- theme runtime adapter: 9 passed
- Phase 3 accessibility contracts: 72 passed
