### PR TITLE
Remove AI slots debug global

### DIFF
--- a/js/ai-verdict-engine-runtime.js
+++ b/js/ai-verdict-engine-runtime.js
@@ -24,16 +24,6 @@ export function getAIVerdictConcurrencyCapRuntime(fallback = 2) {
 }
 
 /**
- * @param {() => { active: number, waiting: number, cap: number }} getDebugState
- */
-export function exposeAIVerdictSlotsDebugRuntime(getDebugState) {
-  const runtime = getAIVerdictRuntime();
-  if (!runtime || typeof getDebugState !== 'function') return false;
-  runtime._aiSlotsDebug = getDebugState;
-  return true;
-}
-
-/**
  * @param {string | null} anchor
  */
 export function refreshSunSurfacesRuntime(anchor) {

--- a/js/ai-verdict-engine.js
+++ b/js/ai-verdict-engine.js
@@ -21,7 +21,6 @@
 import { hasAIProvider, callClaudeAPI } from './api.js';
 import {
   dispatchAIVerdictUpdatedRuntime,
-  exposeAIVerdictSlotsDebugRuntime,
   getAIVerdictConcurrencyCapRuntime,
   hasAIVerdictRuntime,
   isAIVerdictEngineDisabledRuntime,
@@ -137,9 +136,10 @@ function _releaseAISlot() {
     try { next(); } catch (_) {}
   }
 }
-// Diagnostic hook — useful for tests + manual debugging without
-// breaking encapsulation. Not a public API.
-exposeAIVerdictSlotsDebugRuntime(() => ({ active: _activeAICalls, waiting: _aiCallWaiters.length, cap: _aiCap() }));
+// Diagnostic snapshot for tests + manual debugging through the module API.
+export function getAIVerdictSlotsDebug() {
+  return { active: _activeAICalls, waiting: _aiCallWaiters.length, cap: _aiCap() };
+}
 
 /**
  * Create an AI verdict engine bound to a particular feature's data shape.

--- a/tests/ai-verdict-engine-runtime.test.js
+++ b/tests/ai-verdict-engine-runtime.test.js
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   dispatchAIVerdictUpdatedRuntime,
-  exposeAIVerdictSlotsDebugRuntime,
   getAIVerdictConcurrencyCapRuntime,
   hasAIVerdictRuntime,
   isAIVerdictEngineDisabledRuntime,
@@ -37,7 +36,7 @@ describe('ai verdict engine runtime adapter', () => {
     expect(getAIVerdictConcurrencyCapRuntime(2)).toBe(5);
   });
 
-  it('publishes debug hook and delegates refresh plus update events', () => {
+  it('delegates refresh plus update events', () => {
     const refreshSunSurfaces = vi.fn();
     const dispatchEvent = vi.fn();
     class TestCustomEvent {
@@ -52,8 +51,6 @@ describe('ai verdict engine runtime adapter', () => {
     };
     setRuntimeWindow(runtime);
 
-    expect(exposeAIVerdictSlotsDebugRuntime(() => ({ active: 1, waiting: 2, cap: 3 }))).toBe(true);
-    expect(runtime._aiSlotsDebug()).toEqual({ active: 1, waiting: 2, cap: 3 });
     expect(refreshSunSurfacesRuntime('[data-id="session-1"]')).toBe(true);
     expect(dispatchAIVerdictUpdatedRuntime()).toBe(true);
     expect(refreshSunSurfaces).toHaveBeenCalledWith('[data-id="session-1"]');
@@ -66,7 +63,6 @@ describe('ai verdict engine runtime adapter', () => {
     expect(hasAIVerdictRuntime()).toBe(false);
     expect(isAIVerdictEngineDisabledRuntime()).toBe(false);
     expect(getAIVerdictConcurrencyCapRuntime(2)).toBe(2);
-    expect(exposeAIVerdictSlotsDebugRuntime(() => ({ active: 0, waiting: 0, cap: 2 }))).toBe(false);
     expect(refreshSunSurfacesRuntime(null)).toBe(false);
     expect(dispatchAIVerdictUpdatedRuntime()).toBe(false);
   });

--- a/tests/test-ai-verdict-engine.js
+++ b/tests/test-ai-verdict-engine.js
@@ -25,7 +25,7 @@ return (async function () {
 
   const eng = await import('/js/ai-verdict-engine.js?bust=' + Date.now());
   const api = await import('/js/api.js?bust=' + Date.now());
-  const { createAIVerdict, hashString, dotPrefix, VERDICT_DOT_VALUES } = eng;
+  const { createAIVerdict, getAIVerdictSlotsDebug, hashString, dotPrefix, VERDICT_DOT_VALUES } = eng;
 
   // ─── 1. hashString — deterministic + djb2 properties ──────────────
   console.log('%c 1. hashString ', 'font-weight:bold;color:#a855f7');
@@ -488,14 +488,14 @@ return (async function () {
       ]);
       // Sample mid-flight — should see at most 2 fetches active concurrently
       await new Promise(r => setTimeout(r, 100));
-      const slots = window._aiSlotsDebug?.();
+      const slots = getAIVerdictSlotsDebug();
       assert('Concurrency cap holds: at most 2 concurrent fetches',
         maxInFlight <= 2, `maxInFlight=${maxInFlight} slots=${JSON.stringify(slots)}`);
       assert('Third concurrent call waits in queue',
         slots?.waiting >= 1, `slots=${JSON.stringify(slots)}`);
       await p;
       assert('After all 3 finish: zero active, zero waiting',
-        window._aiSlotsDebug?.().active === 0 && window._aiSlotsDebug?.().waiting === 0);
+        getAIVerdictSlotsDebug().active === 0 && getAIVerdictSlotsDebug().waiting === 0);
     } finally {
       window.fetch = origFetch;
       if (prevCap === undefined) delete window._aiConcurrencyCap;

--- a/tests/test-audit-fixes.js
+++ b/tests/test-audit-fixes.js
@@ -259,38 +259,37 @@ return (async function () {
   // ─── 4. ai-verdict-engine concurrency cap clamp ────────────────────
   console.log('%c 4. _aiCap clamp [1,8] ', 'font-weight:bold;color:#0891b2');
   {
-    // Force-reload so the module's `cfg = …` reads our new window var.
-    // _aiCap is a closure-internal function but the diagnostic hook
-    // `window._aiSlotsDebug` exposes the resolved cap, which is computed
-    // on every call (not cached) — so we just toggle window._aiConcurrencyCap.
-    await import('/js/ai-verdict-engine.js?bust=' + Date.now());
-    assert('window._aiSlotsDebug is exposed', typeof window._aiSlotsDebug === 'function');
+    // The module diagnostic exposes the resolved cap, which is computed on
+    // every call (not cached), so toggle window._aiConcurrencyCap between reads.
+    const { getAIVerdictSlotsDebug } = await import('/js/ai-verdict-engine.js?bust=' + Date.now());
+    assert('AI slot diagnostics stay module-only',
+      typeof getAIVerdictSlotsDebug === 'function' && !('_aiSlotsDebug' in window));
 
     delete window._aiConcurrencyCap;
-    assert('default cap is 2', window._aiSlotsDebug().cap === 2);
+    assert('default cap is 2', getAIVerdictSlotsDebug().cap === 2);
 
     window._aiConcurrencyCap = 5;
-    assert('cap = 5 respected', window._aiSlotsDebug().cap === 5);
+    assert('cap = 5 respected', getAIVerdictSlotsDebug().cap === 5);
 
     window._aiConcurrencyCap = 999;
-    assert('cap = 999 clamped to 8', window._aiSlotsDebug().cap === 8);
+    assert('cap = 999 clamped to 8', getAIVerdictSlotsDebug().cap === 8);
 
     window._aiConcurrencyCap = 0;
-    assert('cap = 0 clamped to 1', window._aiSlotsDebug().cap === 1);
+    assert('cap = 0 clamped to 1', getAIVerdictSlotsDebug().cap === 1);
 
     window._aiConcurrencyCap = -3;
-    assert('cap = -3 clamped to 1', window._aiSlotsDebug().cap === 1);
+    assert('cap = -3 clamped to 1', getAIVerdictSlotsDebug().cap === 1);
 
     window._aiConcurrencyCap = 3.7;
-    assert('cap = 3.7 floored to 3', window._aiSlotsDebug().cap === 3);
+    assert('cap = 3.7 floored to 3', getAIVerdictSlotsDebug().cap === 3);
 
     window._aiConcurrencyCap = Infinity;
     assert('cap = Infinity rejected — falls back to default 2',
-      window._aiSlotsDebug().cap === 2);
+      getAIVerdictSlotsDebug().cap === 2);
 
     window._aiConcurrencyCap = NaN;
     assert('cap = NaN rejected — falls back to default 2',
-      window._aiSlotsDebug().cap === 2);
+      getAIVerdictSlotsDebug().cap === 2);
 
     window._aiConcurrencyCap = _origAICap;
   }

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -819,6 +819,7 @@
     'toggleThreadRail',
   ].every(name => !(name in window)));
   assert('window._appleHealth stays module-only', !('_appleHealth' in window));
+  assert('window._aiSlotsDebug stays module-only', !('_aiSlotsDebug' in window));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.224';
+self.APP_VERSION = '1.10.225';


### PR DESCRIPTION
## Summary

- stop publishing the `_aiSlotsDebug` diagnostic on `window`
- expose the same live concurrency snapshot through `getAIVerdictSlotsDebug()` in the engine module
- keep the concurrency cap and queue behavior unchanged
- convert runtime, audit, and browser tests to use the module diagnostic
- add an explicit regression guard that keeps `_aiSlotsDebug` off `window`
- bump the app cache version to 1.10.225

## Window burden remaining

Before this PR, the audit measured 373 unique window globals across 375 publication entries at 14 publication sites, grouped into 11 global families.

After this PR:

- 372 unique window globals remain
- 374 publication entries remain
- 13 publication sites remain
- 11 global families remain

This PR removes 1 unique global, 1 publication entry, and 1 complete publication site. The measured remaining work is therefore **374 entries across 13 sites**. The working estimate remains **3–10 follow-up PRs** because this residual diagnostic site was independent of the larger remaining dependency groups. This range will be recalculated in every follow-up PR description as migrations expose or consolidate dependencies.

## Test results

- `npm run quality`: 7/7 quality checks, 460 modules parsed
- module verification: 125 passed
- Vitest: 398 passed
- Playwright: 352 passed
- responsive-theme assertions: 472 passed
- focused AI verdict/audit Playwright: 5 passed
- focused AI verdict runtime Vitest: 4 passed
