### PR TITLE
Remove sync test hooks global

### DIFF
--- a/js/sync-payload.js
+++ b/js/sync-payload.js
@@ -109,14 +109,6 @@ export async function _gunzipToStringCapped(bytes, maxBytes = _PER_ROW_DECOMPRES
   return out;
 }
 
-if (typeof window !== 'undefined') {
-  const syncWindow = /** @type {Window & typeof globalThis & { _syncTestHooks?: any }} */ (window);
-  syncWindow._syncTestHooks = Object.assign(syncWindow._syncTestHooks || {}, {
-    gunzipCapped: _gunzipToStringCapped,
-    perRowCapBytes: _PER_ROW_DECOMPRESSED_CAP_BYTES,
-  });
-}
-
 /** @param {Uint8Array} bytes */
 export function _bytesToBase64(bytes) {
   let s = '';

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -44,6 +44,7 @@ const syncChatApply = await import('../js/sync-chat-apply.js');
 const syncDelta = await import('../js/sync-delta.js');
 const dataMerge = await import('../js/data-merge.js');
 const syncSubscriptions = await import('../js/sync-subscriptions.js');
+const syncPayload = await import('../js/sync-payload.js');
 const syncPayloadCollectors = await import('../js/sync-payload-collectors.js');
 const syncStorageCleanup = await import('../js/sync-storage-cleanup.js');
 await import('../js/sync.js');
@@ -2453,8 +2454,11 @@ await import('../js/settings.js');
   // that gunzips to (cap + 1) bytes and asserts it throws. Catches
   // off-by-one and "checks size only after full buffer" regressions
   // that source inspection alone can't detect.
-  if (typeof window !== 'undefined' && window._syncTestHooks?.gunzipCapped) {
-    const { gunzipCapped, perRowCapBytes } = window._syncTestHooks;
+  if (typeof CompressionStream !== 'undefined' && typeof DecompressionStream !== 'undefined') {
+    const {
+      _gunzipToStringCapped: gunzipCapped,
+      _PER_ROW_DECOMPRESSED_CAP_BYTES: perRowCapBytes,
+    } = syncPayload;
     // Test against a SMALL synthetic cap to keep this assertion fast —
     // a real 1MB test would burn 100ms+ of CPU on slow CI runners.
     const TEST_CAP = 1024; // 1 KB
@@ -2500,6 +2504,7 @@ await import('../js/settings.js');
       perRowCapBytes === 1024 * 1024,
       `cap=${perRowCapBytes}, expected ${1024 * 1024}`);
   }
+  assert('_syncTestHooks stays module-only', !('_syncTestHooks' in window));
 
   // Snapshot-poisoning fix
   assert('_applyArrayDelta returns boolean success',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -820,6 +820,7 @@
   ].every(name => !(name in window)));
   assert('window._appleHealth stays module-only', !('_appleHealth' in window));
   assert('window._aiSlotsDebug stays module-only', !('_aiSlotsDebug' in window));
+  assert('window._syncTestHooks stays module-only', !('_syncTestHooks' in window));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.225';
+self.APP_VERSION = '1.10.226';


### PR DESCRIPTION
## Summary

- remove the test-only `window._syncTestHooks` publication from the sync payload module
- exercise the decompression cap through the module's existing named exports
- guard both the sync test and module verification against republishing the legacy global
- bump the app cache version to `1.10.226`

## Window burden

- Before: **372 unique globals**, **374 publication entries**, **13 publication sites**, **11 dependency families**
- After: **371 unique globals**, **373 publication entries**, **12 publication sites**, **11 dependency families**
- This PR removes **1 unique global**, **1 publication entry**, and **1 complete publication site**.
- **Work remaining: approximately 3–10 focused PRs** to remove or explicitly retain the remaining 371 globals across 12 sites. The family count stays at 11 because this test-only diagnostic site was independent of the larger runtime dependency groups.

## Validation

- `./run-tests.sh`
  - module verification: 125 passed
  - Vitest: 398 passed
  - Playwright: 352 passed
  - responsive theme assertions: 472 passed
- `node tests/test-sync.js`: 786 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`