### PR TITLE
Remove wearable settings globals

### DIFF
--- a/js/wearables-settings-panel.js
+++ b/js/wearables-settings-panel.js
@@ -20,7 +20,6 @@ import { getActiveProfileId } from './profile.js';
 import {
   closeWearableSettingsModal,
   confirmWearableSettingsAction,
-  exposeWearableSettingsBindings,
   navigateWearablesDashboard,
 } from './wearables-settings-runtime.js';
 
@@ -581,12 +580,7 @@ function refreshSettingsWearables() {
   if (section) section.innerHTML = renderWearablesSettingsSection();
 }
 
-installWearableSettingsDelegates();
-
-exposeWearableSettingsBindings({
-  setWearableStripHidden,
-  isWearableStripHidden,
-  renderWearablesSettingsSection,
+export const wearableSettingsActionHandlers = Object.freeze({
   handleManualOpenDashboard,
   handleManualDisconnect,
   handleWearableConnect,
@@ -596,3 +590,5 @@ exposeWearableSettingsBindings({
   handleAppleHealthDrop,
   handleAppleHealthFilePick,
 });
+
+installWearableSettingsDelegates();

--- a/js/wearables-settings-runtime.js
+++ b/js/wearables-settings-runtime.js
@@ -47,9 +47,3 @@ export async function confirmWearableSettingsAction(message) {
   const confirm = wearableSettingsRuntimeDeps.showConfirmDialog;
   return confirm ? !!await confirm(message) : false;
 }
-
-/** @param {Record<string, unknown>} bindings */
-export function exposeWearableSettingsBindings(bindings) {
-  const runtime = getRuntimeWindow();
-  if (runtime) Object.assign(runtime, bindings);
-}

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -1095,8 +1095,6 @@ installWearableDelegates();
 
 exposeWearablesBindings({
   renderWearableStrip,
-  setWearableStripHidden,
-  isWearableStripHidden,
   dismissWearableStub,
   toggleWearableStrip,
   openWearableDetail: openWearableDetailFromDashboard,

--- a/tests/playwright/wearables-settings-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-browser-coverage.spec.js
@@ -9,14 +9,15 @@ test('wearables settings browser coverage exercises import and connection action
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const failures = await page.evaluate(async ({ panelUrl, stateUrl, profileUrl, storeUrl, blobUrl }) => {
-    const [{ state }, { profileStorageKey }, store, blobStorage, settingsRuntime] = await Promise.all([
+    const [{ state }, { profileStorageKey }, store, blobStorage, settingsRuntime, panel] = await Promise.all([
       import(stateUrl),
       import(profileUrl),
       import(storeUrl),
       import(blobUrl),
       import('/js/wearables-settings-runtime.js'),
+      import(panelUrl),
     ]);
-    await import(panelUrl);
+    const actions = panel.wearableSettingsActionHandlers;
 
     const failures = [];
     const check = (name, condition, detail = '') => {
@@ -52,7 +53,7 @@ test('wearables settings browser coverage exercises import and connection action
         section.id = 'wearables-section';
         document.body.append(section);
       }
-      section.innerHTML = window.renderWearablesSettingsSection();
+      section.innerHTML = panel.renderWearablesSettingsSection();
       document.dispatchEvent(new Event('settings:wearables-rendered'));
       return section;
     };
@@ -79,16 +80,16 @@ test('wearables settings browser coverage exercises import and connection action
         && !!section.querySelector('#apple-health-file-input')
         && !!section.querySelector('.apple-health-dropzone'));
 
-      window.setWearableStripHidden(true);
-      const hiddenSet = window.isWearableStripHidden() === true
+      panel.setWearableStripHidden(true);
+      const hiddenSet = panel.isWearableStripHidden() === true
         && localStorage.getItem(`wearables-strip-hidden-${profileId}`) === '1';
-      window.setWearableStripHidden(false);
+      panel.setWearableStripHidden(false);
       check('wearable strip hidden toggle persists per profile',
         hiddenSet
-        && window.isWearableStripHidden() === false
+        && panel.isWearableStripHidden() === false
         && calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard'));
 
-      window.handleWearableConnect('apple_health');
+      actions.handleWearableConnect('apple_health');
       await delay(20);
       check('connect handler reports non-oauth adapter error',
         document.body.textContent.includes('Connect failed: Adapter apple_health is not OAuth2'));
@@ -98,7 +99,7 @@ test('wearables settings browser coverage exercises import and connection action
   <Record type="HKQuantityTypeIdentifierBodyMass" sourceName="Coverage Scale" unit="kg" value="72.4" startDate="2026-06-01 08:00:00 +0000" endDate="2026-06-01 08:00:00 +0000"/>
       </HealthData>`;
       const file = new File([xml], 'export.xml', { type: 'application/xml' });
-      window.handleAppleHealthDrop({ dataTransfer: { files: [file] } });
+      actions.handleAppleHealthDrop({ dataTransfer: { files: [file] } });
       let row = null;
       const imported = await waitFor(async () => {
         row = await store.getDaily(profileId, 'apple_health', '2026-06-01');
@@ -116,7 +117,7 @@ test('wearables settings browser coverage exercises import and connection action
         files: [new File(['not health xml'], 'notes.txt', { type: 'text/plain' })],
         value: 'notes.txt',
       };
-      window.handleAppleHealthFilePick(badInput);
+      actions.handleAppleHealthFilePick(badInput);
       const failedImportShown = await waitFor(() =>
         (document.querySelector('.apple-health-progress-text')?.textContent || '').includes('Unrecognised file type'));
       check('Apple Health file picker resets same-file value and surfaces import failure',
@@ -126,19 +127,19 @@ test('wearables settings browser coverage exercises import and connection action
       state.importedData.wearableConnections.apple_health.accessToken = 'coverage-token';
       const syncButton = document.createElement('button');
       const dashboardNavigationsBeforeSync = calls.filter(call => call[0] === 'navigate' && call[1] === 'dashboard').length;
-      await window.handleWearableSyncNow('apple_health', syncButton);
+      await actions.handleWearableSyncNow('apple_health', syncButton);
       check('sync-now handler restores trigger state and navigates',
         !syncButton.disabled
         && !syncButton.classList.contains('is-syncing')
         && calls.filter(call => call[0] === 'navigate' && call[1] === 'dashboard').length === dashboardNavigationsBeforeSync + 1);
 
       const beforeBackfill = state.importedData.wearableConnections.apple_health.lastSyncAt || 0;
-      await window.handleWearableBackfill('apple_health');
+      await actions.handleWearableBackfill('apple_health');
       check('backfill handler updates connection and refreshes settings',
         (state.importedData.wearableConnections.apple_health.lastSyncAt || 0) >= beforeBackfill
         && document.getElementById('wearables-section')?.textContent.includes('Imported from export.xml'));
 
-      const disconnectPromise = window.handleWearableDisconnect('apple_health');
+      const disconnectPromise = actions.handleWearableDisconnect('apple_health');
       const confirmReady = await waitFor(() => !!document.getElementById('confirm-ok'));
       document.getElementById('confirm-ok')?.click();
       await disconnectPromise;
@@ -153,7 +154,7 @@ test('wearables settings browser coverage exercises import and connection action
       document.body.append(strip);
       window.closeSettingsModal = () => calls.push(['closeSettingsModal']);
       window.requestAnimationFrame = callback => setTimeout(() => callback(Date.now()), 0);
-      window.handleManualOpenDashboard();
+      actions.handleManualOpenDashboard();
       await waitFor(() => calls.some(call => call[0] === 'scroll' && call[1] === 'wearable-strip'));
       check('manual dashboard handler closes settings navigates and scrolls strip',
         calls.some(call => call[0] === 'closeSettingsModal')
@@ -167,7 +168,7 @@ test('wearables settings browser coverage exercises import and connection action
         weight: 80.2,
       });
       settingsRuntime.configureWearableSettingsRuntimeDeps({ showConfirmDialog: async () => true });
-      await window.handleManualDisconnect();
+      await actions.handleManualDisconnect();
       const manualRows = await store.countSource(profileId, 'manual');
       check('manual disconnect handler clears manual rows and connection',
         manualRows === 0

--- a/tests/playwright/wearables-strip-actions-browser-coverage.spec.js
+++ b/tests/playwright/wearables-strip-actions-browser-coverage.spec.js
@@ -16,7 +16,7 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
       import('/js/profile.js'),
       import('/js/blob-storage.js'),
     ]);
-    await import('/js/wearables.js');
+    const wearables = await import('/js/wearables.js');
 
     const failures = [];
     const check = (name, condition, detail = '') => {
@@ -123,7 +123,7 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
         },
         metrics: {},
       };
-      window.setWearableStripHidden(true);
+      wearables.setWearableStripHidden(true);
       renderStrip();
 
       const grid = host.querySelector('.wearable-card-grid');

--- a/tests/test-wearables-settings-runtime.js
+++ b/tests/test-wearables-settings-runtime.js
@@ -6,7 +6,6 @@ import {
   closeWearableSettingsModal,
   configureWearableSettingsRuntimeDeps,
   confirmWearableSettingsAction,
-  exposeWearableSettingsBindings,
   navigateWearablesDashboard,
 } from '../js/wearables-settings-runtime.js';
 
@@ -20,7 +19,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Wearables Settings Runtime Tests ===\n');
 
-const runtimeKeys = ['window', 'navigate', 'closeSettingsModal', 'showConfirmDialog', 'wearableProbe'];
+const runtimeKeys = ['window', 'navigate', 'closeSettingsModal', 'showConfirmDialog'];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
 function setRuntimeValue(key, value) {
@@ -59,19 +58,13 @@ try {
   assert('confirmWearableSettingsAction delegates to runtime confirm dialog',
     confirmed && calls.some(call => call[0] === 'confirm' && call[1] === 'confirm me'));
 
-  const probe = () => 'ok';
-  exposeWearableSettingsBindings({ wearableProbe: probe });
-  assert('exposeWearableSettingsBindings assigns bindings to runtime window',
-    globalThis.wearableProbe === probe);
-
   delete globalThis.window;
   configureWearableSettingsRuntimeDeps({ showConfirmDialog: null });
   navigateWearablesDashboard();
   closeWearableSettingsModal();
   const missingConfirm = await confirmWearableSettingsAction('confirm me');
-  exposeWearableSettingsBindings({ wearableProbe: null });
   assert('runtime adapter no-ops safely when window is missing',
-    !missingConfirm && globalThis.wearableProbe === probe);
+    !missingConfirm);
 } finally {
   configureWearableSettingsRuntimeDeps(originalWearableSettingsRuntimeDeps);
   restoreRuntime();

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -50,6 +50,7 @@ const store = await import('../js/wearables-store.js');
 const summary = await import('../js/wearables-summary.js');
 const labCtx = await import('../js/lab-context.js');
 const oauth = await import('../js/wearables-oura-auth.js');
+const wearableSettings = await import('../js/wearables-settings-panel.js');
 
 // ═══════════════════════════════════════
 // 1. Registry shape
@@ -626,11 +627,28 @@ delete window._labState.importedData.wearableSummary;
 // ═══════════════════════════════════════
 // 10. Window exports for render handlers
 // ═══════════════════════════════════════
-console.log('10. Window Exports');
+console.log('10. Browser and module exports');
 assert('window.renderWearableStrip exists', typeof window.renderWearableStrip === 'function');
-assert('window.renderWearablesSettingsSection exists', typeof window.renderWearablesSettingsSection === 'function');
-assert('window.handleWearableConnect exists', typeof window.handleWearableConnect === 'function');
-assert('window.handleWearableDisconnect exists', typeof window.handleWearableDisconnect === 'function');
+assert('wearable settings renderer is a module export',
+  typeof wearableSettings.renderWearablesSettingsSection === 'function');
+assert('wearable settings actions are module exports',
+  typeof wearableSettings.wearableSettingsActionHandlers.handleWearableConnect === 'function'
+  && typeof wearableSettings.wearableSettingsActionHandlers.handleWearableDisconnect === 'function');
+const wearableSettingsLegacyGlobals = [
+  'setWearableStripHidden',
+  'isWearableStripHidden',
+  'renderWearablesSettingsSection',
+  'handleManualOpenDashboard',
+  'handleManualDisconnect',
+  'handleWearableConnect',
+  'handleWearableSyncNow',
+  'handleWearableBackfill',
+  'handleWearableDisconnect',
+  'handleAppleHealthDrop',
+  'handleAppleHealthFilePick',
+];
+assert('wearable settings handlers stay module-only',
+  wearableSettingsLegacyGlobals.every(name => !(name in window)));
 assert('window.syncWearableNow exists', typeof window.syncWearableNow === 'function');
 assert('window.openWearableDetail exists', typeof window.openWearableDetail === 'function');
 assert('window.setWearableDetailRange exists', typeof window.setWearableDetailRange === 'function');
@@ -2262,17 +2280,15 @@ try {
 }
 
 // Settings → Wearables row markup must omit hidden adapters.
-if (typeof window.renderWearablesSettingsSection === 'function') {
-  localStorage.removeItem(escapeKey);
-  const html = window.renderWearablesSettingsSection();
-  assert('Settings render omits WHOOP row when hidden + not connected',
-    !/data-adapter-id="whoop"/.test(html) && !/connectAdapter\('whoop'\)/.test(html));
-  assert('Settings render omits Ultrahuman row when hidden + not connected',
-    !/data-adapter-id="ultrahuman"/.test(html) && !/connectAdapter\('ultrahuman'\)/.test(html));
-  assert('Settings render still shows Oura row',
-    /data-adapter-id="oura"|connectAdapter\('oura'\)|adapter\.id === 'oura'/i.test(html) ||
-    /Oura/.test(html));
-}
+localStorage.removeItem(escapeKey);
+const settingsHtml = wearableSettings.renderWearablesSettingsSection();
+assert('Settings render omits WHOOP row when hidden + not connected',
+  !/data-adapter-id="whoop"/.test(settingsHtml) && !/connectAdapter\('whoop'\)/.test(settingsHtml));
+assert('Settings render omits Ultrahuman row when hidden + not connected',
+  !/data-adapter-id="ultrahuman"/.test(settingsHtml) && !/connectAdapter\('ultrahuman'\)/.test(settingsHtml));
+assert('Settings render still shows Oura row',
+  /data-adapter-id="oura"|connectAdapter\('oura'\)|adapter\.id === 'oura'/i.test(settingsHtml) ||
+  /Oura/.test(settingsHtml));
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -821,6 +821,19 @@
   assert('window._appleHealth stays module-only', !('_appleHealth' in window));
   assert('window._aiSlotsDebug stays module-only', !('_aiSlotsDebug' in window));
   assert('window._syncTestHooks stays module-only', !('_syncTestHooks' in window));
+  assert('wearable settings handlers stay module-only', [
+    'setWearableStripHidden',
+    'isWearableStripHidden',
+    'renderWearablesSettingsSection',
+    'handleManualOpenDashboard',
+    'handleManualDisconnect',
+    'handleWearableConnect',
+    'handleWearableSyncNow',
+    'handleWearableBackfill',
+    'handleWearableDisconnect',
+    'handleAppleHealthDrop',
+    'handleAppleHealthFilePick',
+  ].every(name => !(name in window)));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.226';
+self.APP_VERSION = '1.10.227';


### PR DESCRIPTION
## Summary

- remove the wearable-settings `window` publication and use its module API
- keep settings action test coverage through a frozen module handler map
- remove duplicate strip-visibility entries from the broader wearables facade
- guard all 11 legacy names against republishing
- bump the cache version to 1.10.227

## Window burden

- Before: **371 unique globals**, **373 publication entries**, **12 publication sites**, **11 dependency families**
- After: **360 unique globals**, **360 publication entries**, **11 publication sites**, **10 dependency families**
- This PR removes **11 unique globals**, **13 publication entries** (two names were duplicated), **1 complete publication site**, and **1 dependency family**.
- **Work remaining: approximately 2–9 focused PRs** to remove or explicitly retain the remaining 360 globals across 11 sites and 10 families.

## Validation

- `./run-tests.sh`
  - module verification: 125 passed
  - Vitest: 398 passed
  - Playwright: 352 passed
  - responsive-theme assertions: 472 passed
- `node tests/test-wearables.js`: 586 passed
- `node tests/test-wearables-settings-runtime.js`: 4 passed
- focused wearable-settings Playwright specs: 2 passed
- typecheck and checkjs passed