### PR TITLE
Remove sun UV data globals

### DIFF
--- a/js/settings-runtime.js
+++ b/js/settings-runtime.js
@@ -1,12 +1,40 @@
 // @ts-check
 // settings-runtime.js - Browser runtime adapters for Settings and Tweaks flows.
 
+import { getMeteoConfig, saveMeteoConfig } from './sun-uvdata-config.js';
+
 const DEFAULT_METEO_CONFIG = Object.freeze({
   mode: 'auto',
   selfhostUrl: '',
   selfhostBearer: '',
   privacyRounding: 0.1,
 });
+
+const settingsRuntimeDeps = {
+  getMeteoConfig,
+  saveMeteoConfig,
+};
+
+/**
+ * @param {{
+ *   getMeteoConfig?: (() => Record<string, any>) | null,
+ *   saveMeteoConfig?: ((config: Record<string, any>) => void) | null,
+ * }} [deps]
+ */
+export function configureSettingsRuntimeDeps(deps = {}) {
+  const previous = { ...settingsRuntimeDeps };
+  if ('getMeteoConfig' in deps) {
+    settingsRuntimeDeps.getMeteoConfig = typeof deps.getMeteoConfig === 'function'
+      ? deps.getMeteoConfig
+      : null;
+  }
+  if ('saveMeteoConfig' in deps) {
+    settingsRuntimeDeps.saveMeteoConfig = typeof deps.saveMeteoConfig === 'function'
+      ? deps.saveMeteoConfig
+      : null;
+  }
+  return previous;
+}
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
@@ -76,10 +104,10 @@ export function refreshSettingsRuntimeSurfaces(options = {}) {
 }
 
 export function getSettingsMeteoConfig() {
-  const getMeteoConfig = getRuntimeFunction('getMeteoConfig');
-  if (!getMeteoConfig) return { ...DEFAULT_METEO_CONFIG };
+  const readMeteoConfig = settingsRuntimeDeps.getMeteoConfig;
+  if (!readMeteoConfig) return { ...DEFAULT_METEO_CONFIG };
   try {
-    return getMeteoConfig() || { ...DEFAULT_METEO_CONFIG };
+    return readMeteoConfig() || { ...DEFAULT_METEO_CONFIG };
   } catch {
     return { ...DEFAULT_METEO_CONFIG };
   }
@@ -90,10 +118,10 @@ export function getSettingsMeteoConfig() {
  * @returns {boolean}
  */
 export function saveSettingsMeteoConfig(config) {
-  const saveMeteoConfig = getRuntimeFunction('saveMeteoConfig');
-  if (!saveMeteoConfig) return false;
+  const writeMeteoConfig = settingsRuntimeDeps.saveMeteoConfig;
+  if (!writeMeteoConfig) return false;
   try {
-    saveMeteoConfig(config);
+    writeMeteoConfig(config);
     return true;
   } catch {
     return false;

--- a/js/sun-uvdata.js
+++ b/js/sun-uvdata.js
@@ -1,7 +1,7 @@
 // @ts-check
 // sun-uvdata.js — Multi-source UV/ozone/atmosphere client for Sun Sessions
 import { isValidExternalUrl } from './url-safety.js';
-import { exposeSunRuntimeBindings, hasSunBrowserRuntime, isSunDebugRuntime } from './sun-runtime.js';
+import { isSunDebugRuntime } from './sun-runtime.js';
 import { initMeteoConfigCache, getMeteoConfig, saveMeteoConfig } from './sun-uvdata-config.js';
 export { initMeteoConfigCache, getMeteoConfig, saveMeteoConfig };
 
@@ -984,17 +984,3 @@ export {
   shapeNoaaResponse as _testShapeNoaaResponse,
   isUSCoords as _testIsUSCoords,
 };
-
-// Expose legacy browser globals for non-module call sites.
-if (hasSunBrowserRuntime()) {
-  exposeSunRuntimeBindings({
-    fetchAtmosphere,
-    manualAtmosphere,
-    interpolateAtmosphere,
-    getMeteoConfig,
-    saveMeteoConfig,
-    purgeMeteoCache,
-    solarZenithAngle,
-    computeUVConfidence,
-  });
-}

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -24,6 +24,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
 
   const results = await page.evaluate(async () => {
     const settingsModule = await import('/js/settings.js');
+    const settingsRuntime = await import('/js/settings-runtime.js');
     const themeModule = await import('/js/theme.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
@@ -45,8 +46,6 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       currentProfile: state.currentProfile,
       profiles: state.profiles,
       fetch: window.fetch,
-      getMeteoConfig: window.getMeteoConfig,
-      saveMeteoConfig: window.saveMeteoConfig,
       theme: localStorage.getItem('labcharts-theme'),
       accent: localStorage.getItem('labcharts-accent'),
       timeFormat: localStorage.getItem('labcharts-time-format'),
@@ -66,6 +65,7 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       privacyRounding: 0.1,
     };
     const savedMeteoConfigs = [];
+    let originalSettingsRuntimeDeps = null;
 
     try {
       window.fetch = async url => {
@@ -152,11 +152,13 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       results.resetCurrentProfileUsage = localStorage.getItem(usageKey) === null
         && document.getElementById('ai-usage-section').textContent.includes('0 requests');
 
-      window.getMeteoConfig = () => ({ ...meteoConfig });
-      window.saveMeteoConfig = cfg => {
-        meteoConfig = { ...cfg };
-        savedMeteoConfigs.push({ ...cfg });
-      };
+      originalSettingsRuntimeDeps = settingsRuntime.configureSettingsRuntimeDeps({
+        getMeteoConfig: () => ({ ...meteoConfig }),
+        saveMeteoConfig: cfg => {
+          meteoConfig = { ...cfg };
+          savedMeteoConfigs.push({ ...cfg });
+        },
+      });
       document.body.insertAdjacentHTML('beforeend', `<section id="sun-source-fixture">${settingsModule.renderSunDataSourceSettings()}</section>`);
       const sunSection = document.getElementById('sun-data-source-section');
       const selfhostRadio = sunSection.querySelector('input[value="selfhost"]');
@@ -181,8 +183,9 @@ test('settings browser coverage exercises delegates for themes tweaks privacy us
       return results;
     } finally {
       window.fetch = saved.fetch;
-      window.getMeteoConfig = saved.getMeteoConfig;
-      window.saveMeteoConfig = saved.saveMeteoConfig;
+      if (originalSettingsRuntimeDeps) {
+        settingsRuntime.configureSettingsRuntimeDeps(originalSettingsRuntimeDeps);
+      }
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       const restoreStorage = (key, value) => {

--- a/tests/playwright/sun-uvdata-browser-coverage.spec.js
+++ b/tests/playwright/sun-uvdata-browser-coverage.spec.js
@@ -11,7 +11,7 @@ function expectAll(outcomes) {
   expect(failed).toEqual([]);
 }
 
-test('sun uvdata browser coverage handles config cache globals and purging', async ({ page }) => {
+test('sun uvdata browser coverage handles config cache module API and purging', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
   const outcomes = await page.evaluate(async ({ sunUrl }) => {
@@ -48,15 +48,16 @@ test('sun uvdata browser coverage handles config cache globals and purging', asy
         && localStorage.getItem('meteo:v2:keep-a') === 'fresh-cache'
         && localStorage.getItem('meteo-cache-v2-purged') === '1';
 
-      outcomes.browserGlobalsExposeUvdataExports =
-        window.fetchAtmosphere === mod.fetchAtmosphere
-        && window.manualAtmosphere === mod.manualAtmosphere
-        && window.interpolateAtmosphere === mod.interpolateAtmosphere
-        && window.getMeteoConfig === mod.getMeteoConfig
-        && window.saveMeteoConfig === mod.saveMeteoConfig
-        && window.purgeMeteoCache === mod.purgeMeteoCache
-        && window.solarZenithAngle === mod.solarZenithAngle
-        && window.computeUVConfidence === mod.computeUVConfidence;
+      outcomes.uvdataExportsStayModuleOnly = [
+        'fetchAtmosphere',
+        'manualAtmosphere',
+        'interpolateAtmosphere',
+        'getMeteoConfig',
+        'saveMeteoConfig',
+        'purgeMeteoCache',
+        'solarZenithAngle',
+        'computeUVConfidence',
+      ].every(name => !(name in window));
 
       const manualMeter = mod.manualAtmosphere({
         uvIndex: 5.8,

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -555,12 +555,15 @@ try {
   assert('settings.js delegates browser runtime hooks to settings-runtime',
     src.includes("from './settings-runtime.js'") &&
     !/\bwindow(?:\.|\s*\[)/.test(src));
-  assert('settings-runtime.js owns Settings browser-global publication',
+  assert('settings-runtime.js owns Settings browser adapters and injects meteo config modules',
     runtimeSrc.includes('export function publishSettingsGlobals') &&
     runtimeSrc.includes('Object.assign(getRuntimeWindow(), api)') &&
     runtimeSrc.includes("getRuntimeFunction('requestAnimationFrame')") &&
     runtimeSrc.includes("getRuntimeFunction('matchMedia')") &&
-    runtimeSrc.includes("getRuntimeFunction('getMeteoConfig')"));
+    runtimeSrc.includes("from './sun-uvdata-config.js'") &&
+    runtimeSrc.includes('settingsRuntimeDeps.getMeteoConfig') &&
+    !runtimeSrc.includes("getRuntimeFunction('getMeteoConfig')") &&
+    !runtimeSrc.includes("getRuntimeFunction('saveMeteoConfig')"));
 } catch (e) {
   assert('settings.js security check', false, e.message);
 }

--- a/tests/test-settings-runtime.js
+++ b/tests/test-settings-runtime.js
@@ -2,6 +2,7 @@
 // test-settings-runtime.js — Settings runtime adapter behavior.
 
 import {
+  configureSettingsRuntimeDeps,
   getSettingsMeteoConfig,
   saveSettingsMeteoConfig,
 } from '../js/settings-runtime.js';
@@ -21,54 +22,51 @@ function assert(name, condition, detail = '') {
 
 console.log('=== Settings Runtime Adapters ===');
 
-const originalGetMeteoConfig = globalThis.getMeteoConfig;
-const originalSaveMeteoConfig = globalThis.saveMeteoConfig;
+const originalSettingsRuntimeDeps = configureSettingsRuntimeDeps({
+  getMeteoConfig: null,
+  saveMeteoConfig: null,
+});
 
 try {
-  delete globalThis.getMeteoConfig;
-  delete globalThis.saveMeteoConfig;
-
   assert('missing getMeteoConfig returns defaults',
     getSettingsMeteoConfig().mode === 'auto');
   assert('missing saveMeteoConfig reports unavailable',
     saveSettingsMeteoConfig({ mode: 'manual' }) === false);
 
-  globalThis.getMeteoConfig = () => ({ mode: 'manual', privacyRounding: 0 });
+  configureSettingsRuntimeDeps({
+    getMeteoConfig: () => ({ mode: 'manual', privacyRounding: 0 }),
+  });
   assert('runtime getMeteoConfig is delegated',
     getSettingsMeteoConfig().mode === 'manual' &&
       getSettingsMeteoConfig().privacyRounding === 0);
 
-  globalThis.getMeteoConfig = () => {
-    throw new Error('read failed');
-  };
+  configureSettingsRuntimeDeps({
+    getMeteoConfig: () => {
+      throw new Error('read failed');
+    },
+  });
   assert('thrown getMeteoConfig returns defaults',
     getSettingsMeteoConfig().mode === 'auto');
 
   let savedConfig = null;
-  globalThis.saveMeteoConfig = (config) => {
-    savedConfig = config;
-  };
+  configureSettingsRuntimeDeps({
+    saveMeteoConfig: config => {
+      savedConfig = config;
+    },
+  });
   assert('runtime saveMeteoConfig reports success',
     saveSettingsMeteoConfig({ mode: 'selfhost' }) === true &&
       savedConfig?.mode === 'selfhost');
 
-  globalThis.saveMeteoConfig = () => {
-    throw new Error('write failed');
-  };
+  configureSettingsRuntimeDeps({
+    saveMeteoConfig: () => {
+      throw new Error('write failed');
+    },
+  });
   assert('thrown saveMeteoConfig reports unavailable',
     saveSettingsMeteoConfig({ mode: 'open-meteo' }) === false);
 } finally {
-  if (originalGetMeteoConfig === undefined) {
-    delete globalThis.getMeteoConfig;
-  } else {
-    globalThis.getMeteoConfig = originalGetMeteoConfig;
-  }
-
-  if (originalSaveMeteoConfig === undefined) {
-    delete globalThis.saveMeteoConfig;
-  } else {
-    globalThis.saveMeteoConfig = originalSaveMeteoConfig;
-  }
+  configureSettingsRuntimeDeps(originalSettingsRuntimeDeps);
 }
 
 console.log(`\nResults: ${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -834,6 +834,16 @@
     'handleAppleHealthDrop',
     'handleAppleHealthFilePick',
   ].every(name => !(name in window)));
+  assert('sun UV data helpers stay module-only', [
+    'fetchAtmosphere',
+    'manualAtmosphere',
+    'interpolateAtmosphere',
+    'getMeteoConfig',
+    'saveMeteoConfig',
+    'purgeMeteoCache',
+    'solarZenithAngle',
+    'computeUVConfidence',
+  ].every(name => !(name in window)));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.227';
+self.APP_VERSION = '1.10.228';


### PR DESCRIPTION
## Summary

- remove the atmospheric/UV module's eight legacy `window` publications
- route Settings meteo-config reads and writes through explicit configurable module dependencies
- update browser and source guards to enforce the module-only contract
- bump the cache version to 1.10.228

## Window burden

- Before: **360 unique globals**, **360 publication entries**, **11 publication sites**, **10 dependency families**
- After: **352 unique globals**, **352 publication entries**, **10 publication sites**, **10 dependency families**
- This PR removes **8 unique globals**, **8 publication entries**, and **1 complete publication site**.
- The dependency-family count is unchanged because the primary Sun facade still uses the shared Sun runtime publication family.
- **Work remaining: approximately 2–8 focused PRs** to remove or explicitly retain the remaining 352 globals across 10 sites and 10 families.

## Validation

- `./run-tests.sh`
  - module verification: 125 passed
  - Vitest: 398 passed
  - Playwright: 352 passed
  - responsive-theme assertions: 472 passed
- `node tests/test-sun-uvdata.js`: 83 passed
- `node tests/test-sun-uvdata-flow.js`: 17 passed
- `node tests/test-settings-runtime.js`: 6 passed
- focused Settings and UV-data Playwright specs: 5 passed
- typecheck and checkjs passed