### PR TITLE
Remove light device globals

### DIFF
--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -130,6 +130,7 @@ export function createDashboardPageView(deps) {
     isDashboardOrganizeMode,
     loadFocusCard,
     loadContextCardTips,
+    ensureActiveDeviceTicker = () => {},
     startEmptyTour = defaultStartEmptyTour,
     startTour = defaultStartTour,
   } = deps;
@@ -182,7 +183,7 @@ export function createDashboardPageView(deps) {
     // page loaded — keeps the dashboard Light Today surface ticking after a
     // hard reload mid-session.
     if (getDashboardPageRuntimeValue('_resumeActiveTickerIfNeeded')) try { callDashboardPageRuntime('_resumeActiveTickerIfNeeded'); } catch (e) {}
-    if (getDashboardPageRuntimeValue('ensureActiveDeviceTicker')) try { callDashboardPageRuntime('ensureActiveDeviceTicker'); } catch (e) {}
+    try { ensureActiveDeviceTicker(); } catch (e) {}
     if (!data) data = getActiveData();
     const main = document.getElementById("main-content");
     const wasMobileDashboardActive = document.body.classList.contains('mobile-dashboard-active');

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -18,6 +18,7 @@ import { createDashboardWidgetControls } from './dashboard-widget-controls.js';
 import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js';
 import { configureMarkerDetailModal } from './marker-detail-modal.js';
 import { renderLightConditionsWidgetBody } from './light-conditions-now.js';
+import { ensureActiveDeviceTicker } from './light-devices.js';
 import { renderDashboardLightChannelPills, renderLightSessionLogActions } from './light-page-view.js';
 import { renderLightTodayHero } from './light-today-ai.js';
 import { navigateViewportRuntime } from './views-router-runtime.js';
@@ -203,6 +204,7 @@ export function createDashboardViewComposition({
     isDashboardOrganizeMode: () => dashboardWidgetControls.isOrganizeMode(),
     loadFocusCard,
     loadContextCardTips,
+    ensureActiveDeviceTicker,
   });
 
   configureLensPageShell({

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -2,6 +2,7 @@
 // dashboard-widget-runtime.js - Browser runtime adapters for dashboard widget controls and renderers.
 
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
+import { getDeviceSessions } from './light-devices-store.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 /** @type {Record<string, Function | null>} */
@@ -69,8 +70,6 @@ export function getDashboardLightSessions() {
 }
 
 export function getDashboardDeviceSessions() {
-  const getDeviceSessions = getRuntimeFunction('getDeviceSessions');
-  if (!getDeviceSessions) return [];
   try {
     const sessions = getDeviceSessions();
     return Array.isArray(sessions) ? sessions : [];

--- a/js/light-channels-ai-analysis.js
+++ b/js/light-channels-ai-analysis.js
@@ -20,6 +20,7 @@ import { hasAIProvider } from './api.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
 import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
+import { getDeviceSessions, rollingDeviceTotals } from './light-devices-store.js';
 
 function _getMix() {
   return state.importedData?.channelMixAI || null;
@@ -54,7 +55,7 @@ function _rollingChannelTotals(days) {
 }
 
 function _rollingDeviceTotals(days) {
-  return _callRuntime('rollingDeviceTotals', days) || {};
+  return rollingDeviceTotals(days) || {};
 }
 
 function _getSessions() {
@@ -62,7 +63,7 @@ function _getSessions() {
 }
 
 function _getDeviceSessions() {
-  return _callRuntime('getDeviceSessions') || [];
+  return getDeviceSessions();
 }
 
 function _weeklyChannelTier(value, channelKey) {

--- a/js/light-device-ai-analysis.js
+++ b/js/light-device-ai-analysis.js
@@ -10,7 +10,7 @@ import { state } from './state.js';
 import { escapeHTML, escapeAttr } from './utils.js';
 import { hasAIProvider } from './api.js';
 import { getSunDefaults } from './sun-defaults.js';
-import { getDevices, getDeviceSessions } from './light-devices.js';
+import { getDevices, getDeviceSessions } from './light-devices-store.js';
 import { CHANNEL_DISPLAY, channelTier, tierLabel, formatChannelUnit, BODY_REGIONS } from './sun.js';
 import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';

--- a/js/light-devices-actions.js
+++ b/js/light-devices-actions.js
@@ -7,6 +7,24 @@ const LIGHT_DEVICE_SESSION_ID_ATTR = 'data-light-device-session-id';
 const LIGHT_DEVICES_ACTION_DELEGATE_KEY = Symbol.for('getbased.lightDevicesActionDelegatesInstalled');
 const lightDevicesActionDelegateRoots = new WeakSet();
 
+const lightDevicesActions = {
+  stopDeviceSessionAndNotify: null,
+  openAddDeviceDialog: null,
+  deleteLightDevice: null,
+  openDeviceSessionDialog: null,
+};
+
+/** @param {Record<string, Function | null>} [actions] */
+export function configureLightDevicesActions(actions = {}) {
+  const previous = { ...lightDevicesActions };
+  for (const name of Object.keys(lightDevicesActions)) {
+    if (name in actions) {
+      lightDevicesActions[name] = typeof actions[name] === 'function' ? actions[name] : null;
+    }
+  }
+  return previous;
+}
+
 function closestLightDevicesAction(target) {
   return target?.closest?.(`[${LIGHT_DEVICES_ACTION_ATTR}]`) || null;
 }
@@ -15,7 +33,6 @@ function handleLightDevicesActionClick(event) {
   const actionEl = closestLightDevicesAction(event.target);
   if (!actionEl || !event.currentTarget?.contains?.(actionEl)) return;
   const action = actionEl.getAttribute(LIGHT_DEVICES_ACTION_ATTR);
-  const appWindow = /** @type {any} */ (window);
   if (action === 'suppress') {
     event.stopPropagation();
     return;
@@ -23,18 +40,18 @@ function handleLightDevicesActionClick(event) {
   if (action === 'stop-device-session') {
     event.stopPropagation();
     const sessionId = actionEl.getAttribute(LIGHT_DEVICE_SESSION_ID_ATTR) || '';
-    if (sessionId) appWindow.stopDeviceSessionAndNotify?.(sessionId);
+    if (sessionId) lightDevicesActions.stopDeviceSessionAndNotify?.(sessionId);
     return;
   }
-  if (action === 'add-device') { appWindow.openAddDeviceDialog?.(); return; }
+  if (action === 'add-device') { lightDevicesActions.openAddDeviceDialog?.(); return; }
   if (action === 'delete-device') {
     const deviceId = actionEl.getAttribute(LIGHT_DEVICE_ID_ATTR) || '';
-    if (deviceId) appWindow.deleteLightDevice?.(deviceId);
+    if (deviceId) lightDevicesActions.deleteLightDevice?.(deviceId);
     return;
   }
   if (action === 'log-device-session') {
     const deviceId = actionEl.getAttribute(LIGHT_DEVICE_ID_ATTR) || '';
-    if (deviceId) appWindow.openDeviceSessionDialog?.(deviceId);
+    if (deviceId) lightDevicesActions.openDeviceSessionDialog?.(deviceId);
   }
 }
 

--- a/js/light-devices-runtime.js
+++ b/js/light-devices-runtime.js
@@ -98,24 +98,3 @@ export function renderLightDeviceAffiliateRowRuntime(catalog, slug) {
 export function openLightDeviceChannel(channel) {
   getRuntimeFunction('_openChannelOnLightPage')?.(channel);
 }
-
-/** @param {string} id */
-export function editLightDeviceSessionDurationFromRuntime(id) {
-  getRuntimeFunction('editDeviceSessionDuration')?.(id);
-}
-
-/** @param {string} id */
-export function editLightDeviceSessionModeFromRuntime(id) {
-  getRuntimeFunction('editDeviceSessionMode')?.(id);
-}
-
-/** @param {string} id */
-export function deleteLightDeviceSessionFromRuntime(id) {
-  getRuntimeFunction('deleteDeviceSession')?.(id);
-}
-
-/** @param {Record<string, any>} bindings */
-export function publishLightDevicesWindowBindings(bindings) {
-  if (typeof window === 'undefined') return;
-  Object.assign(getRuntimeWindow(), bindings);
-}

--- a/js/light-devices.js
+++ b/js/light-devices.js
@@ -40,18 +40,14 @@ import {
 } from './light-devices-store.js';
 import { openDeviceSessionDialog as openDeviceSessionDialogModal } from './light-device-session-modal.js';
 import { configureLightDeviceSetup, openAddDeviceDialog, openCustomDeviceDialog } from './light-device-setup-modal.js';
-import { installLightDevicesActionDelegates } from './light-devices-actions.js';
+import { configureLightDevicesActions, installLightDevicesActionDelegates } from './light-devices-actions.js';
 import {
-  deleteLightDeviceSessionFromRuntime,
-  editLightDeviceSessionDurationFromRuntime,
-  editLightDeviceSessionModeFromRuntime,
   getLightDeviceChannelDisplay,
   getLightDeviceChannelHelpers,
   loadLightDevicesCatalog,
   navigateLightDevicesRoute,
   openLightDeviceChannel,
   promptLightDeviceSessionDuration,
-  publishLightDevicesWindowBindings,
   refreshLightDevicesView,
   renderLightDeviceAffiliateRowRuntime,
 } from './light-devices-runtime.js';
@@ -394,17 +390,17 @@ export function openDeviceSessionDetail(id) {
     }
     if (target.closest('#device-detail-edit-duration')) {
       closeDialog();
-      editLightDeviceSessionDurationFromRuntime(sess.id);
+      editDeviceSessionDuration(sess.id);
       return;
     }
     if (target.closest('#device-detail-edit-mode')) {
       closeDialog();
-      editLightDeviceSessionModeFromRuntime(sess.id);
+      editDeviceSessionMode(sess.id);
       return;
     }
     if (target.closest('#device-detail-delete')) {
       closeDialog();
-      deleteLightDeviceSessionFromRuntime(sess.id);
+      deleteDeviceSessionWithConfirm(sess.id);
     }
   });
   overlay.addEventListener('keydown', (event) => {
@@ -727,7 +723,7 @@ export async function deleteDeviceSessionWithConfirm(id) {
   refreshLightDevicesView();
 }
 
-// ─── Window export ─────────────────────────────────────────────────────
+// ─── UI wrappers ───────────────────────────────────────────────────────
 
 export async function deleteLightDeviceAndRefresh(id) {
   await deleteDevice(id);
@@ -744,30 +740,9 @@ export async function stopDeviceSessionAndNotify(id) {
   refreshLightDevicesView();
 }
 
-publishLightDevicesWindowBindings({
-  loadLightDevicePresets,
-  getDevices,
-  getDeviceSessions,
-  addDeviceFromPreset,
-  hydrateDevicesFromPresets,
-  deleteLightDevice: deleteLightDeviceAndRefresh,
-  logDeviceSession,
-  startDeviceSession,
-  stopDeviceSession,
-  updateDeviceSession,
-  editDeviceSessionDuration,
-  editDeviceSessionMode,
-  getActiveDeviceSession,
-  renderActiveDeviceSessionCard,
-  ensureActiveDeviceTicker,
+configureLightDevicesActions({
   stopDeviceSessionAndNotify,
-  deleteDeviceSession: deleteDeviceSessionWithConfirm,
-  rollingDeviceTotals,
-  renderDevicesSection,
-  openDeviceSessionDetail,
   openAddDeviceDialog,
-  openCustomDeviceDialog,
-  addCustomDevice,
+  deleteLightDevice: deleteLightDeviceAndRefresh,
   openDeviceSessionDialog,
-  quickLogDeviceSession,
 });

--- a/js/startup-maintenance-runtime.js
+++ b/js/startup-maintenance-runtime.js
@@ -29,18 +29,6 @@ export function getStartupSunEngineVersionRuntime() {
   return getStartupMaintenanceRuntime()?.SUN_ENGINE_VERSION || '?';
 }
 
-export function hasLightDevicePresetHydrationRuntime() {
-  return getRuntimeFunction('hydrateDevicesFromPresets') !== null;
-}
-
-export function hydrateLightDevicesFromPresetsRuntime() {
-  try {
-    return getRuntimeFunction('hydrateDevicesFromPresets')?.() || Promise.resolve(false);
-  } catch {
-    return Promise.resolve(false);
-  }
-}
-
 /** @param {any[]} args */
 export function logStartupMaintenanceRuntime(...args) {
   const runtime = getStartupMaintenanceRuntime();

--- a/js/startup-maintenance.js
+++ b/js/startup-maintenance.js
@@ -4,11 +4,10 @@
 import { state } from './state.js';
 import { initWearableScheduler, loadWearableRuntimeConfig, syncStaleWearablesNow } from './wearables-connect.js';
 import { migrateBiometricsToManual, hasManualData } from './wearables-manual.js';
+import { hydrateDevicesFromPresets } from './light-devices.js';
 import {
   getStartupSunEngineVersionRuntime,
-  hasLightDevicePresetHydrationRuntime,
   hasSunSessionRehydrateRuntime,
-  hydrateLightDevicesFromPresetsRuntime,
   logStartupMaintenanceRuntime,
   rehydrateStaleSunSessionsRuntime,
 } from './startup-maintenance-runtime.js';
@@ -56,11 +55,9 @@ function hydrateUserLightDevicesFromPresets() {
   // / Trinity device records have no `modes` array, so the session-log
   // dialog can't render the mode picker for them. Idempotent - re-runs
   // are no-ops once devices carry the fields.
-  if (hasLightDevicePresetHydrationRuntime()) {
-    hydrateLightDevicesFromPresetsRuntime().then(dirty => {
-      if (dirty) logStartupMaintenanceRuntime('[light] hydrated user devices from preset library');
-    }).catch(() => {});
-  }
+  hydrateDevicesFromPresets().then(dirty => {
+    if (dirty) logStartupMaintenanceRuntime('[light] hydrated user devices from preset library');
+  }).catch(() => {});
 }
 
 function migrateLegacyBiometrics() {

--- a/js/sun-runtime.js
+++ b/js/sun-runtime.js
@@ -2,6 +2,7 @@
 // sun-runtime.js - Browser runtime adapters for Sun session facade hooks.
 
 import { isDebugMode } from './utils.js';
+import { getDeviceSessions } from './light-devices-store.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const sunRuntimeDeps = { isDebugMode };
@@ -45,7 +46,7 @@ export function isSunDebugRuntime() {
 
 export function getSunDeviceSessionsRuntime() {
   try {
-    const sessions = getRuntimeFunction('getDeviceSessions')?.();
+    const sessions = getDeviceSessions();
     return Array.isArray(sessions) ? sessions : [];
   } catch {
     return [];

--- a/tests/playwright/light-ai-analysis-coverage-batch.spec.js
+++ b/tests/playwright/light-ai-analysis-coverage-batch.spec.js
@@ -643,12 +643,10 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       refreshSunSurfaces: window._refreshSunSurfaces,
       solarZenithAngle: window.solarZenithAngle,
       rollingChannelTotals: window.rollingChannelTotals,
-      rollingDeviceTotals: window.rollingDeviceTotals,
       rollingVitaminDIU: window.rollingVitaminDIU,
       weeklyChannelTier: window.weeklyChannelTier,
       tierLabel: window.tierLabel,
       getSessions: window.getSessions,
-      getDeviceSessions: window.getDeviceSessions,
       disableAIVerdicts: window.DISABLE_AI_VERDICTS,
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
@@ -783,14 +781,14 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       window.rollingChannelTotals = days => days === 7
         ? { vitamin_d: 260, circadian: 180, nir_solar: 130, no_cv: 60, pomc: 55, violet_eye: 30 }
         : { vitamin_d: 540, circadian: 360, nir_solar: 320, no_cv: 140, pomc: 120, violet_eye: 45 };
-      window.rollingDeviceTotals = days => days === 7
+      const rollingDeviceTotals = days => days === 7
         ? { circadian: 90, nir_solar: 50 }
         : { circadian: 180, nir_solar: 90 };
       window.rollingVitaminDIU = () => 900;
       todayAI.configureLightTodayAI({
         solarZenithAngle: window.solarZenithAngle,
         rollingChannelTotals: window.rollingChannelTotals,
-        rollingDeviceTotals: window.rollingDeviceTotals,
+        rollingDeviceTotals,
         rollingVitaminDIU: window.rollingVitaminDIU,
       });
       window.weeklyChannelTier = (value, key) => {
@@ -803,7 +801,6 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       };
       window.tierLabel = tier => ['none', 'low', 'moderate', 'good', 'strong'][tier] || 'none';
       window.getSessions = () => state.importedData.sunSessions;
-      window.getDeviceSessions = () => state.importedData.deviceSessions;
       const queuedAIResponses = [];
       window.fetch = async (url, options = {}) => {
         if (String(url).includes('/v1/chat/completions')) {
@@ -976,18 +973,15 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       window._refreshSunSurfaces = saved.refreshSunSurfaces;
       window.solarZenithAngle = saved.solarZenithAngle;
       window.rollingChannelTotals = saved.rollingChannelTotals;
-      window.rollingDeviceTotals = saved.rollingDeviceTotals;
       window.rollingVitaminDIU = saved.rollingVitaminDIU;
       todayAI.configureLightTodayAI({
         solarZenithAngle: saved.solarZenithAngle,
         rollingChannelTotals: saved.rollingChannelTotals,
-        rollingDeviceTotals: saved.rollingDeviceTotals,
         rollingVitaminDIU: saved.rollingVitaminDIU,
       });
       window.weeklyChannelTier = saved.weeklyChannelTier;
       window.tierLabel = saved.tierLabel;
       window.getSessions = saved.getSessions;
-      window.getDeviceSessions = saved.getDeviceSessions;
       if (saved.disableAIVerdicts === undefined) delete window.DISABLE_AI_VERDICTS;
       else window.DISABLE_AI_VERDICTS = saved.disableAIVerdicts;
       if (saved.provider == null) localStorage.removeItem('labcharts-ai-provider');

--- a/tests/playwright/light-devices-browser-coverage.spec.js
+++ b/tests/playwright/light-devices-browser-coverage.spec.js
@@ -21,8 +21,7 @@ function expectAll(outcomes) {
 test('light devices browser coverage handles store mutations UI wrappers and picker flows', async ({ page }) => {
   await page.addInitScript(seedCompletedTour);
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.quickLogDeviceSession === 'function'
-    && typeof window.openAddDeviceDialog === 'function');
+  await page.evaluate(() => import('/js/light-devices.js'));
   await page.evaluate(() => {
     window.endTour?.();
     document.getElementById('tour-overlay')?.remove();
@@ -32,11 +31,12 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
   });
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data, store, ai] = await Promise.all([
+    const [{ state }, data, store, ai, lightDevices] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/light-devices-store.js'),
       import('/js/light-device-ai-analysis.js'),
+      import('/js/light-devices.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -187,9 +187,9 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       const activeSession = store.getActiveDeviceSession();
       activeSession.startedAt = Date.now() - 125000;
       const activeHost = document.createElement('div');
-      activeHost.innerHTML = window.renderActiveDeviceSessionCard();
+      activeHost.innerHTML = lightDevices.renderActiveDeviceSessionCard();
       document.body.appendChild(activeHost);
-      window.ensureActiveDeviceTicker();
+      lightDevices.ensureActiveDeviceTicker();
       const elapsedText = activeHost.querySelector('[data-live-elapsed-for]')?.textContent || '';
       outcomes.startDeviceSessionRejectsSecondAndTickerUpdatesCard =
         !!activeId
@@ -197,7 +197,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
         && elapsedText.startsWith('2:')
         && activeHost.textContent.includes('CoverageLight Panel Pro');
 
-      await window.stopDeviceSessionAndNotify(activeId);
+      await lightDevices.stopDeviceSessionAndNotify(activeId);
       const stoppedSession = store.getDeviceSessions().find(s => s.id === activeId);
       outcomes.stopDeviceSessionWrapperSavesDosesNotifiesAndNavigates =
         !!stoppedSession?.endedAt
@@ -218,7 +218,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
         notes: 'desk work',
         mode: 'therapy',
       });
-      const deleteSessionPromise = window.deleteDeviceSession(logged.id);
+      const deleteSessionPromise = lightDevices.deleteDeviceSessionWithConfirm(logged.id);
       await waitUntil(() => !!document.getElementById('confirm-ok'), 'delete session confirm open');
       document.getElementById('confirm-ok')?.click();
       await deleteSessionPromise;
@@ -226,7 +226,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
         !store.getDeviceSessions().some(s => s.id === logged.id)
         && calls.filter(call => call[0] === 'navigate' && call[1] === 'light').length >= 2;
 
-      await window.deleteLightDevice(customDevice.id);
+      await lightDevices.deleteLightDeviceAndRefresh(customDevice.id);
       outcomes.deleteLightDeviceWrapperRemovesDeviceAndRefreshes =
         !store.getDevices().some(d => d.id === customDevice.id)
         && calls.filter(call => call[0] === 'navigate' && call[1] === 'light').length >= 3;
@@ -234,7 +234,11 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       state.importedData.lightDevices = [];
       state.importedData.deviceSessions = [];
       const navBeforePresetAdd = calls.filter(call => call[0] === 'navigate' && call[1] === 'light').length;
-      await window.openAddDeviceDialog();
+      const devicesHost = document.createElement('div');
+      devicesHost.innerHTML = await lightDevices.renderDevicesSection();
+      document.body.appendChild(devicesHost);
+      devicesHost.querySelector('[data-light-devices-action="add-device"]')?.click();
+      await waitUntil(() => !!document.querySelector('[aria-label="Add light device"]'), 'delegated add device action');
       const addOverlay = document.querySelector('[aria-label="Add light device"]')?.closest('.modal-overlay');
       const firstPreset = addOverlay?.querySelector('.light-device-preset-row');
       const addButton = addOverlay?.querySelector('#add-device-confirm');
@@ -244,6 +248,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       outcomes.productionPresetDialogUsesLoadedPresetsAddWrapperAndRefresh =
         !!store.getDevices()[0]?.presetId
         && calls.filter(call => call[0] === 'navigate' && call[1] === 'light').length > navBeforePresetAdd;
+      devicesHost.remove();
 
       await store.addCustomDevice({
         brand: 'SecondLight',
@@ -253,7 +258,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
         mwPerCm2At15cm: 45,
         recommendedDistanceCm: 15,
       });
-      window.quickLogDeviceSession();
+      lightDevices.quickLogDeviceSession();
       await waitUntil(() => !!document.querySelector('[aria-label="Pick a device to log a session"]'), 'device picker open');
       const pickerOverlay = document.querySelector('[aria-label="Pick a device to log a session"]')?.closest('.modal-overlay');
       const pickerRows = Array.from(pickerOverlay?.querySelectorAll('.light-device-picker-row') || []);
@@ -267,7 +272,7 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
         && sessionOverlay.textContent.includes('Log session');
       sessionOverlay?.remove();
 
-      await window.openCustomDeviceDialog();
+      await lightDevices.openCustomDeviceDialog();
       const customOverlay = document.querySelector('[aria-label="Add custom light device"]')?.closest('.modal-overlay');
       const badInput = customOverlay?.querySelector('#custom-dev-image');
       Object.defineProperty(badInput, 'files', {

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -146,8 +146,6 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       mainHTML: main?.innerHTML,
       Date: window.Date,
       getSessions: window.getSessions,
-      getDeviceSessions: window.getDeviceSessions,
-      getDevices: window.getDevices,
       getActiveSession: window.getActiveSession,
       cumulativeMEDToday: window.cumulativeMEDToday,
       cumulativeMEDYesterday: window.cumulativeMEDYesterday,
@@ -159,9 +157,11 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       channelTier: window.channelTier,
       dailyChannelBreakdown: window.dailyChannelBreakdown,
       rollingChannelTotals: window.rollingChannelTotals,
-      rollingDeviceTotals: window.rollingDeviceTotals,
-      renderDevicesSection: window.renderDevicesSection,
     };
+    let getDevices = () => [];
+    let getDeviceSessions = () => [];
+    let rollingDeviceTotals = () => ({});
+    let renderDevicesSection = () => '';
     let renderLightTodayDashboardChip = () => '';
     let renderLightTodayHero = () => '';
     let renderSunSetupCard = sunDefaults.renderSetupCard;
@@ -170,11 +170,11 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       weeklyChannelTier: typeof window.weeklyChannelTier === 'function' ? window.weeklyChannelTier : () => 0,
       channelTier: typeof window.channelTier === 'function' ? window.channelTier : () => 0,
       getSessions: typeof window.getSessions === 'function' ? window.getSessions : () => [],
-      getDevices: typeof window.getDevices === 'function' ? window.getDevices : () => [],
-      getDeviceSessions: typeof window.getDeviceSessions === 'function' ? window.getDeviceSessions : () => [],
+      getDevices,
+      getDeviceSessions,
       getActiveSession: typeof window.getActiveSession === 'function' ? window.getActiveSession : () => null,
       rollingChannelTotals: typeof window.rollingChannelTotals === 'function' ? window.rollingChannelTotals : () => ({}),
-      rollingDeviceTotals: typeof window.rollingDeviceTotals === 'function' ? window.rollingDeviceTotals : () => ({}),
+      rollingDeviceTotals,
       cumulativeMEDToday: typeof window.cumulativeMEDToday === 'function' ? window.cumulativeMEDToday : () => 0,
       cumulativeMEDYesterday: typeof window.cumulativeMEDYesterday === 'function' ? window.cumulativeMEDYesterday : () => 0,
       rollingVitaminDIU: typeof window.rollingVitaminDIU === 'function' ? window.rollingVitaminDIU : () => 0,
@@ -183,7 +183,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       renderLightTodayDashboardChip,
       renderLightTodayHero,
       renderSunSetupCard,
-      renderDevicesSection: typeof window.renderDevicesSection === 'function' ? window.renderDevicesSection : () => '',
+      renderDevicesSection,
       renderEnvironmentAssessmentSummary,
       renderLightTools,
     });
@@ -224,10 +224,10 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
         device: index === 1 ? 80 : 0,
       }));
       window.rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
-      window.rollingDeviceTotals = () => ({ nir_solar: 120 });
+      rollingDeviceTotals = () => ({ nir_solar: 120 });
       window.getSessions = () => [];
-      window.getDeviceSessions = () => [];
-      window.getDevices = () => [];
+      getDeviceSessions = () => [];
+      getDevices = () => [];
       window.getActiveSession = () => null;
       window.cumulativeMEDToday = () => 0.72;
       window.cumulativeMEDYesterday = () => 0.4;
@@ -264,13 +264,13 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
         lightEnvironment: { rooms: [] },
       };
       setHour(22);
-      window.getDevices = () => [{ brand: 'Joovv', model: 'Solo' }];
+      getDevices = () => [{ brand: 'Joovv', model: 'Solo' }];
       syncLightPageDeps();
       const oneDevice = lightPage.renderLightTodayStrip();
-      window.getDevices = () => [{ brand: 'Joovv', model: 'Solo' }, { brand: 'SAD', model: 'Desk' }];
+      getDevices = () => [{ brand: 'Joovv', model: 'Solo' }, { brand: 'SAD', model: 'Desk' }];
       syncLightPageDeps();
       const manyDevices = lightPage.renderLightTodayStrip();
-      window.getDevices = () => [];
+      getDevices = () => [];
       syncLightPageDeps();
       const noDevices = lightPage.renderLightTodayStrip();
       outcomes.nonSolarCtasAdaptToDeviceAndRoomState =
@@ -289,13 +289,13 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
 
       renderLightTodayHero = () => '';
       renderSunSetupCard = () => '<div class="setup-card-test">setup</div>';
-      window.renderDevicesSection = () => '<div class="devices-section-test">devices</div>';
+      renderDevicesSection = () => '<div class="devices-section-test">devices</div>';
       renderEnvironmentAssessmentSummary = () => '';
       renderLightTools = () => '';
       window.getActiveSession = () => null;
-      window.getDevices = () => [];
+      getDevices = () => [];
       window.getSessions = () => [];
-      window.getDeviceSessions = () => [];
+      getDeviceSessions = () => [];
       window.getSunCoords = () => null;
       syncLightPageDeps();
       lightPage.showLight(state.importedData);
@@ -317,7 +317,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
         endedAt: Date.now() - (index + 1) * 86_400_000 + 600_000,
       }));
       window.rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
-      window.rollingDeviceTotals = () => ({ pbm_red: 0, pbm_nir: 0 });
+      rollingDeviceTotals = () => ({ pbm_red: 0, pbm_nir: 0 });
       syncLightPageDeps();
       lightPage.showLight(state.importedData);
       const guidance = main?.querySelector('[data-widget-id="light-guidance"], #light-guidance');
@@ -334,8 +334,6 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       if (main && saved.mainHTML != null) main.innerHTML = saved.mainHTML;
       window.Date = saved.Date || RealDate;
       window.getSessions = saved.getSessions;
-      window.getDeviceSessions = saved.getDeviceSessions;
-      window.getDevices = saved.getDevices;
       window.getActiveSession = saved.getActiveSession;
       window.cumulativeMEDToday = saved.cumulativeMEDToday;
       window.cumulativeMEDYesterday = saved.cumulativeMEDYesterday;
@@ -347,8 +345,10 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       window.channelTier = saved.channelTier;
       window.dailyChannelBreakdown = saved.dailyChannelBreakdown;
       window.rollingChannelTotals = saved.rollingChannelTotals;
-      window.rollingDeviceTotals = saved.rollingDeviceTotals;
-      window.renderDevicesSection = saved.renderDevicesSection;
+      getDevices = () => [];
+      getDeviceSessions = () => [];
+      rollingDeviceTotals = () => ({});
+      renderDevicesSection = () => '';
       renderEnvironmentAssessmentSummary = lightEnv.renderEnvironmentAssessmentSummary;
       renderLightTools = lightTools.renderLightTools;
       renderLightTodayDashboardChip = () => '';

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -227,6 +227,12 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
         return true;
       }
     `,
+    '**/js/light-devices.js*': `
+      export async function hydrateDevicesFromPresets() {
+        window.__startupMaintenanceCalls.push('hydrateDevicesFromPresets');
+        return true;
+      }
+    `,
     '**/js/wearables-summary.js*': `
       export async function syncWearableSummary(profileId, sources) {
         window.__startupMaintenanceCalls.push(['syncWearableSummary', profileId, sources]);
@@ -238,7 +244,6 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
     const originalSetTimeout = window.setTimeout;
     const originalConsoleLog = console.log;
     const originalRehydrate = window.rehydrateStaleSessions;
-    const originalHydrate = window.hydrateDevicesFromPresets;
     const originalEngineVersion = window.SUN_ENGINE_VERSION;
     const logs = [];
 
@@ -259,10 +264,6 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
     window.rehydrateStaleSessions = async () => {
       window.__startupMaintenanceCalls.push('rehydrateStaleSessions');
       return { rehydrated: 2 };
-    };
-    window.hydrateDevicesFromPresets = async () => {
-      window.__startupMaintenanceCalls.push('hydrateDevicesFromPresets');
-      return true;
     };
 
     const waitUntil = async predicate => {
@@ -309,8 +310,6 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
       console.log = originalConsoleLog;
       if (originalRehydrate) window.rehydrateStaleSessions = originalRehydrate;
       else delete window.rehydrateStaleSessions;
-      if (originalHydrate) window.hydrateDevicesFromPresets = originalHydrate;
-      else delete window.hydrateDevicesFromPresets;
       if (originalEngineVersion === undefined) delete window.SUN_ENGINE_VERSION;
       else window.SUN_ENGINE_VERSION = originalEngineVersion;
     }

--- a/tests/playwright/sun-browser-coverage.spec.js
+++ b/tests/playwright/sun-browser-coverage.spec.js
@@ -87,7 +87,6 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       profiles: localStorage.getItem('labcharts-profiles'),
       buildSidebar: window.buildSidebar,
       navigate: window.navigate,
-      getDeviceSessions: window.getDeviceSessions,
       geolocation: Object.getOwnPropertyDescriptor(navigator, 'geolocation'),
     };
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -160,13 +159,6 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
     try {
       window.buildSidebar = () => {};
       window.navigate = () => {};
-      window.getDeviceSessions = () => [{
-        id: 'device-vitd',
-        startedAt: todayStart + 11 * 3600000,
-        endedAt: todayStart + 11.2 * 3600000,
-        bodyArea: 'whole-body',
-        doses: { vitamin_d: 2200, no_cv: 300, circadian: 800 },
-      }];
 
       state.currentProfile = profileId;
       state.profiles = [{
@@ -186,10 +178,10 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
         sunSessions: [todaySession, yesterdaySession, oldSession, activeSession],
         deviceSessions: [{
           id: 'stored-device-vitd',
-          startedAt: todayStart + 13 * 3600000,
-          endedAt: todayStart + 13.1 * 3600000,
-          bodyAreas: ['face', 'arms-front'],
-          doses: { vitamin_d: 1200 },
+          startedAt: todayStart + 11 * 3600000,
+          endedAt: todayStart + 11.2 * 3600000,
+          bodyArea: 'whole-body',
+          doses: { vitamin_d: 2200, no_cv: 300, circadian: 800 },
         }],
         supplements: [{
           name: 'D stack',
@@ -333,7 +325,6 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       else localStorage.setItem('labcharts-profiles', saved.profiles);
       window.buildSidebar = saved.buildSidebar;
       window.navigate = saved.navigate;
-      window.getDeviceSessions = saved.getDeviceSessions;
       if (saved.geolocation) Object.defineProperty(navigator, 'geolocation', saved.geolocation);
       else delete navigator.geolocation;
       document.querySelectorAll('.notification-container,.notification-toast,#prompt-dialog-overlay,#confirm-dialog-overlay,.modal-overlay').forEach(el => el.remove());

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -114,9 +114,9 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
     });
     await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
     await page.waitForFunction(
-      () => window._labState
+      async () => window._labState
         && typeof window.openSunSessionDetail === 'function'
-        && typeof window.openDeviceSessionDetail === 'function',
+        && typeof (await import('/js/light-devices.js')).openDeviceSessionDetail === 'function',
       null,
       { timeout: 15000 }
     );
@@ -340,7 +340,10 @@ async function openSunSessionModal(page) {
 
 async function openDeviceSessionModal(page) {
   await navigateLight(page);
-  await page.evaluate(({ id }) => window.openDeviceSessionDetail(id), { id: DEVICE_SESSION_ID });
+  await page.evaluate(async ({ id }) => {
+    const { openDeviceSessionDetail } = await import('/js/light-devices.js');
+    openDeviceSessionDetail(id);
+  }, { id: DEVICE_SESSION_ID });
   await page.waitForFunction(
     () => document.querySelector('.modal-overlay.show .sun-detail-modal[data-session-kind="device"]'),
     null,
@@ -356,7 +359,8 @@ async function updateSunDuration(page, durationMin) {
 
 async function updateDeviceDuration(page, durationMin) {
   await page.evaluate(async ({ id, duration }) => {
-    await window.updateDeviceSession(id, { durationMin: duration });
+    const { updateDeviceSession } = await import('/js/light-devices-store.js');
+    await updateDeviceSession(id, { durationMin: duration });
   }, { id: DEVICE_SESSION_ID, duration: durationMin });
 }
 

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -143,8 +143,9 @@ async function seedMobileLightSessions(page) {
       safety: { medFraction: 0.42, fitzpatrick: 'III' },
       atmosphere: { uvIndex: 6 },
     });
-    if (typeof window.logDeviceSession === 'function') {
-      await window.logDeviceSession({
+    const { logDeviceSession } = await import('/js/light-devices-store.js');
+    if (typeof logDeviceSession === 'function') {
+      await logDeviceSession({
         deviceId: 'D-mobile-long',
         durationMin: 22,
         distanceCm: 15,

--- a/tests/startup-maintenance-runtime.test.js
+++ b/tests/startup-maintenance-runtime.test.js
@@ -3,9 +3,7 @@ import { readFileSync } from 'node:fs';
 
 import {
   getStartupSunEngineVersionRuntime,
-  hasLightDevicePresetHydrationRuntime,
   hasSunSessionRehydrateRuntime,
-  hydrateLightDevicesFromPresetsRuntime,
   logStartupMaintenanceRuntime,
   rehydrateStaleSunSessionsRuntime,
 } from '../js/startup-maintenance-runtime.js';
@@ -34,10 +32,6 @@ describe('startup maintenance runtime adapter', () => {
         calls.push('rehydrate');
         return Promise.resolve({ rehydrated: 2 });
       },
-      hydrateDevicesFromPresets: () => {
-        calls.push('hydrate-devices');
-        return Promise.resolve(true);
-      },
       console: {
         log: (...args) => calls.push(['log', ...args]),
       },
@@ -46,12 +40,9 @@ describe('startup maintenance runtime adapter', () => {
     expect(hasSunSessionRehydrateRuntime()).toBe(true);
     expect(await rehydrateStaleSunSessionsRuntime()).toEqual({ rehydrated: 2 });
     expect(getStartupSunEngineVersionRuntime()).toBe('runtime-test');
-    expect(hasLightDevicePresetHydrationRuntime()).toBe(true);
-    expect(await hydrateLightDevicesFromPresetsRuntime()).toBe(true);
     expect(logStartupMaintenanceRuntime('[startup]', 'ok')).toBe(true);
     expect(calls).toEqual([
       'rehydrate',
-      'hydrate-devices',
       ['log', '[startup]', 'ok'],
     ]);
   });
@@ -59,7 +50,6 @@ describe('startup maintenance runtime adapter', () => {
   it('uses safe fallbacks when browser hooks are missing or fail', async () => {
     setRuntimeWindow({
       rehydrateStaleSessions: () => { throw new Error('rehydrate unavailable'); },
-      hydrateDevicesFromPresets: () => { throw new Error('hydrate unavailable'); },
       console: {
         log: () => { throw new Error('log unavailable'); },
       },
@@ -68,16 +58,12 @@ describe('startup maintenance runtime adapter', () => {
     expect(hasSunSessionRehydrateRuntime()).toBe(true);
     expect(await rehydrateStaleSunSessionsRuntime()).toBeNull();
     expect(getStartupSunEngineVersionRuntime()).toBe('?');
-    expect(hasLightDevicePresetHydrationRuntime()).toBe(true);
-    expect(await hydrateLightDevicesFromPresetsRuntime()).toBe(false);
     expect(logStartupMaintenanceRuntime('[startup]', 'ignored')).toBe(false);
 
     delete globalThis.window;
     expect(hasSunSessionRehydrateRuntime()).toBe(false);
     expect(await rehydrateStaleSunSessionsRuntime()).toBeNull();
     expect(getStartupSunEngineVersionRuntime()).toBe('?');
-    expect(hasLightDevicePresetHydrationRuntime()).toBe(false);
-    expect(await hydrateLightDevicesFromPresetsRuntime()).toBe(false);
     expect(logStartupMaintenanceRuntime('[startup]', 'ignored')).toBe(false);
   });
 
@@ -86,6 +72,7 @@ describe('startup maintenance runtime adapter', () => {
     const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
 
     expect(startupSrc).toContain("from './startup-maintenance-runtime.js'");
+    expect(startupSrc).toContain("import { hydrateDevicesFromPresets } from './light-devices.js';");
     expect(/\bwindow(?:\.|\s*\[)/.test(startupSrc)).toBe(false);
     expect(swSrc).toContain("'/js/startup-maintenance-runtime.js'");
   });

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -2,6 +2,7 @@
 // test-dashboard-widget-runtime.js - Dashboard widget runtime adapter behavior.
 
 import './_node-shim.js';
+import { state } from '../js/state.js';
 import {
   configureDashboardNoteActions,
   deleteDashboardNote,
@@ -32,7 +33,6 @@ const runtimeKeys = [
   'window',
   'innerHeight',
   'getSessions',
-  'getDeviceSessions',
   '_snpTableCache',
   'openSettingsModal',
   'syncWearableNow',
@@ -43,6 +43,7 @@ const runtimeKeys = [
   'triggerDNAFilePicker',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+const savedImportedData = state.importedData;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -80,7 +81,7 @@ try {
 
   const snpTable = { rs123: { rsid: 'rs123' } };
   setRuntimeValue('getSessions', () => [{ id: 'sun-1' }]);
-  setRuntimeValue('getDeviceSessions', () => [{ id: 'device-1' }]);
+  state.importedData = { deviceSessions: [{ id: 'device-1' }] };
   setRuntimeValue('_snpTableCache', snpTable);
   assert('runtime adapter reads dashboard renderer data hooks',
     getDashboardLightSessions().length === 1 &&
@@ -90,7 +91,7 @@ try {
       getDashboardSnpTableCache() === snpTable);
 
   setRuntimeValue('getSessions', () => { throw new Error('boom'); });
-  setRuntimeValue('getDeviceSessions', () => ({ id: 'not-array' }));
+  state.importedData = { deviceSessions: [] };
   setRuntimeValue('_snpTableCache', null);
   assert('runtime adapter falls back for missing renderer data hooks',
     getDashboardLightSessions().length === 0 &&
@@ -156,6 +157,7 @@ try {
   configureDashboardNoteActions(previousDashboardNoteActions);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
+  state.importedData = savedImportedData;
   restoreRuntime();
 }
 

--- a/tests/test-light-devices-runtime.js
+++ b/tests/test-light-devices-runtime.js
@@ -5,16 +5,12 @@ import './_node-shim.js';
 import { state } from '../js/state.js';
 import {
   configureLightDevicesRuntimeDeps,
-  deleteLightDeviceSessionFromRuntime,
-  editLightDeviceSessionDurationFromRuntime,
-  editLightDeviceSessionModeFromRuntime,
   getLightDeviceChannelDisplay,
   getLightDeviceChannelHelpers,
   loadLightDevicesCatalog,
   navigateLightDevicesRoute,
   openLightDeviceChannel,
   promptLightDeviceSessionDuration,
-  publishLightDevicesWindowBindings,
   refreshLightDevicesView,
   renderLightDeviceAffiliateRowRuntime,
 } from '../js/light-devices-runtime.js';
@@ -39,10 +35,6 @@ const runtimeKeys = [
   'loadCatalog',
   'renderLightDeviceAffiliateRow',
   '_openChannelOnLightPage',
-  'editDeviceSessionDuration',
-  'editDeviceSessionMode',
-  'deleteDeviceSession',
-  '__lightRuntimeProbe',
 ];
 const saved = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
 const savedView = state.currentView;
@@ -126,22 +118,9 @@ try {
     renderLightDeviceAffiliateRowRuntime({}, 'panel-x') === '');
 
   globalThis._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
-  globalThis.editDeviceSessionDuration = id => calls.push(['edit-duration', id]);
-  globalThis.editDeviceSessionMode = id => calls.push(['edit-mode', id]);
-  globalThis.deleteDeviceSession = id => calls.push(['delete-session', id]);
   openLightDeviceChannel('vitamin_d');
-  editLightDeviceSessionDurationFromRuntime('sess-1');
-  editLightDeviceSessionModeFromRuntime('sess-1');
-  deleteLightDeviceSessionFromRuntime('sess-1');
-  assert('detail runtime callbacks delegate to current window bindings',
-    calls.some(call => call[0] === 'open-channel' && call[1] === 'vitamin_d') &&
-    calls.some(call => call[0] === 'edit-duration' && call[1] === 'sess-1') &&
-    calls.some(call => call[0] === 'edit-mode' && call[1] === 'sess-1') &&
-    calls.some(call => call[0] === 'delete-session' && call[1] === 'sess-1'));
-
-  publishLightDevicesWindowBindings({ __lightRuntimeProbe: () => 'ok' });
-  assert('publishLightDevicesWindowBindings installs legacy globals',
-    globalThis.__lightRuntimeProbe?.() === 'ok');
+  assert('openLightDeviceChannel delegates to the current view binding',
+    calls.some(call => call[0] === 'open-channel' && call[1] === 'vitamin_d'));
 } finally {
   configureLightDevicesRuntimeDeps(originalLightDevicesRuntimeDeps);
   restoreRuntime();

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -40,9 +40,9 @@ const sessionEngine = await import('../js/light-device-session-engine.js');
 const { synthesizeDeviceSpectrum } = await import('../js/sun-spectrum.js');
 const {
   getDevices, getDeviceSessions,
-  addDeviceFromPreset, addCustomDevice, deleteDevice,
+  addDeviceFromPreset, addCustomDevice, deleteDevice, hydrateDevicesFromPresets,
   logDeviceSession, deleteDeviceSession,
-  rollingDeviceTotals,
+  rollingDeviceTotals, updateDeviceSession,
 } = dev;
 const {
   DEVICE_TYPE_CHANNELS,
@@ -370,16 +370,16 @@ const {
   // needs profile state — covered by Playwright.
   const SKIP_DISTANCE_SCALING = true;
   console.log('  SKIP: distance scaling e2e — needs profile state; covered by Playwright.');
-  if (!SKIP_DISTANCE_SCALING && typeof window.logDeviceSession === 'function') {
+  if (!SKIP_DISTANCE_SCALING) {
     const distDevice = {
       id: 'D-dist', brand: 'Test', model: 'PBM',
       peakWavelengths: [660], mwPerCm2At15cm: 50,
       recommendedDistanceCm: 30, peakShares: [1.0],
     };
     window._labState.importedData = { lightDevices: [distDevice], deviceSessions: [] };
-    await window.logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 30, bodyArea: 'torso', eyesProtected: true });
-    await window.logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
-    await window.logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 5, bodyArea: 'torso', eyesProtected: true });
+    await logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 30, bodyArea: 'torso', eyesProtected: true });
+    await logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
+    await logDeviceSession({ deviceId: 'D-dist', durationMin: 10, distanceCm: 5, bodyArea: 'torso', eyesProtected: true });
     const sess = window._labState.importedData.deviceSessions;
     const at30 = sess[0]?.doses?.pbm_red || 0;
     const at15 = sess[1]?.doses?.pbm_red || 0;
@@ -402,19 +402,19 @@ const {
   // (the user's history shouldn't vanish), surfacing a "Removed device"
   // label rather than a stale brand reference. Pin the contract.
   console.log('%c deleteDevice + orphan session contract ', 'font-weight:bold;color:#f59e0b');
-  if (typeof window.logDeviceSession === 'function' && typeof window.deleteDevice === 'function') {
+  {
     const ephemeral = {
       id: 'D-ephemeral', brand: 'Test', model: 'Ephemeral',
       peakWavelengths: [660], mwPerCm2At15cm: 50,
       recommendedDistanceCm: 15, peakShares: [1.0],
     };
     window._labState.importedData = { lightDevices: [ephemeral], deviceSessions: [] };
-    await window.logDeviceSession({ deviceId: 'D-ephemeral', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
+    await logDeviceSession({ deviceId: 'D-ephemeral', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
     const sessId = window._labState.importedData.deviceSessions[0]?.id;
     assert('logDeviceSession persists session with deviceId reference',
       sessId && window._labState.importedData.deviceSessions[0].deviceId === 'D-ephemeral');
     // Now delete the device.
-    await window.deleteDevice('D-ephemeral');
+    await deleteDevice('D-ephemeral');
     const stillThere = window._labState.importedData.deviceSessions[0];
     assert('Sessions persist after parent device is deleted (no auto-purge)',
       stillThere && stillThere.id === sessId);
@@ -447,7 +447,7 @@ const {
   // assertions on the device-library logic flowing.
   const SKIP_RECOMPUTE_PATH = true;
   console.log('  SKIP: device-session recompute path — needs profile state; covered by Playwright.');
-  if (!SKIP_RECOMPUTE_PATH && typeof window.logDeviceSession === 'function' && typeof window.updateDeviceSession === 'function') {
+  if (!SKIP_RECOMPUTE_PATH) {
     // Maxi UVB shape with full mode schema
     const maxiDevice = {
       id: 'D-maxi-test', brand: 'Test', model: 'Maxi UVB',
@@ -468,7 +468,7 @@ const {
     window._labState.importedData = { lightDevices: [maxiDevice], deviceSessions: [] };
 
     // 1. Log session without explicit mode → resolves to default 'all-on'
-    await window.logDeviceSession({
+    await logDeviceSession({
       deviceId: 'D-maxi-test', durationMin: 6, distanceCm: 60, bodyArea: 'torso', eyesProtected: true,
     });
     const sess0 = window._labState.importedData.deviceSessions[0];
@@ -482,7 +482,7 @@ const {
     // 2. Strip mode to simulate legacy session, then recompute
     const legacyId = sess0.id;
     delete sess0.mode;
-    await window.updateDeviceSession(legacyId, { durationMin: 12 });
+    await updateDeviceSession(legacyId, { durationMin: 12 });
     const recomputed = window._labState.importedData.deviceSessions.find(s => s.id === legacyId);
     assert('Legacy recompute: mode auto-fills to default after edit',
       recomputed?.mode === 'all-on', `mode=${recomputed?.mode}`);
@@ -498,7 +498,7 @@ const {
       `ratio=${ratioPbm.toFixed(3)}`);
 
     // 3. Switch mode mid-edit → vitamin_d crashes, pbm_red preserved
-    await window.updateDeviceSession(legacyId, { mode: 'red-nir-only' });
+    await updateDeviceSession(legacyId, { mode: 'red-nir-only' });
     const switched = window._labState.importedData.deviceSessions.find(s => s.id === legacyId);
     assert('Mode switch (all-on → red-nir-only): mode persists',
       switched?.mode === 'red-nir-only');
@@ -513,7 +513,7 @@ const {
       `before=${recomputed.doses.pbm_red.toFixed(2)} after=${pbmAfterSwitch.toFixed(2)}`);
 
     // 4. Coupling enforcement: invalid mode silently falls back to default
-    await window.updateDeviceSession(legacyId, { mode: 'completely-fake-mode' });
+    await updateDeviceSession(legacyId, { mode: 'completely-fake-mode' });
     const validated = window._labState.importedData.deviceSessions.find(s => s.id === legacyId);
     assert('Mode validation: unknown mode-id falls back to default',
       validated?.mode === 'all-on');
@@ -525,14 +525,14 @@ const {
       recommendedDistanceCm: 15, peakShares: [0.5, 0.5],
     };
     window._labState.importedData = { lightDevices: [pbmDevice], deviceSessions: [] };
-    await window.logDeviceSession({
+    await logDeviceSession({
       deviceId: 'D-pbm-test', durationMin: 5, distanceCm: 15, bodyArea: 'torso', eyesProtected: true,
     });
     const pbmSess = window._labState.importedData.deviceSessions[0];
     assert('Non-moded device: session.mode stays null',
       pbmSess?.mode === null, `mode=${pbmSess?.mode}`);
     const basePbmDose = pbmSess.doses.pbm_red;
-    await window.updateDeviceSession(pbmSess.id, { durationMin: 10 });
+    await updateDeviceSession(pbmSess.id, { durationMin: 10 });
     const pbmRecomputed = window._labState.importedData.deviceSessions.find(s => s.id === pbmSess.id);
     assert('Non-moded device: recompute scales linearly (no mode drift)',
       Math.abs(pbmRecomputed.doses.pbm_red / basePbmDose - 2.0) < 0.05,
@@ -550,18 +550,18 @@ const {
   // library onto matching user devices. Idempotent — second run is a
   // no-op since fields are now present.
   console.log('%c hydrateDevicesFromPresets backfill ', 'font-weight:bold;color:#f59e0b');
-  if (typeof window.hydrateDevicesFromPresets === 'function' && typeof window.addDeviceFromPreset === 'function') {
+  {
     window._labState.importedData = { lightDevices: [], deviceSessions: [] };
     // Add a Maxi UVB then strip the Round-7 fields, simulating a device
     // record persisted to localStorage before the schema additions.
-    await window.addDeviceFromPreset('mitochondriak-maxi-uvb');
+    await addDeviceFromPreset('mitochondriak-maxi-uvb');
     const dev = window._labState.importedData.lightDevices[0];
     delete dev.channelGroups;
     delete dev.modes;
     delete dev.coupling;
     assert('Pre-hydration: legacy device record has no `modes`',
       !Array.isArray(dev.modes));
-    const dirty = await window.hydrateDevicesFromPresets();
+    const dirty = await hydrateDevicesFromPresets();
     const hydrated = window._labState.importedData.lightDevices[0];
     assert('hydrateDevicesFromPresets reports dirty when fields were missing',
       dirty === true);
@@ -572,7 +572,7 @@ const {
     assert('Hydration backfills `coupling`',
       Array.isArray(hydrated.coupling) && hydrated.coupling.length >= 1);
     // Second run is a no-op — fields already present.
-    const dirty2 = await window.hydrateDevicesFromPresets();
+    const dirty2 = await hydrateDevicesFromPresets();
     assert('hydrateDevicesFromPresets is idempotent (second run = no-op)',
       dirty2 === false);
     // Custom devices (no presetId) skip hydration even if they're missing fields.
@@ -580,7 +580,7 @@ const {
       id: 'D-custom-no-preset', brand: 'Custom', model: 'Test',
       peakWavelengths: [660], mwPerCm2At15cm: 50,
     });
-    await window.hydrateDevicesFromPresets();
+    await hydrateDevicesFromPresets();
     const customDev = window._labState.importedData.lightDevices.find(d => d.id === 'D-custom-no-preset');
     assert('Hydration skips custom (no-presetId) devices',
       !customDev.modes && !customDev.channelGroups);
@@ -592,9 +592,9 @@ const {
   // mode schema already populated, so the user doesn't need to wait for
   // the boot-time hydration migration to fire.
   console.log('%c addDeviceFromPreset copies Round-7 schema ', 'font-weight:bold;color:#f59e0b');
-  if (typeof window.addDeviceFromPreset === 'function') {
+  {
     window._labState.importedData = { lightDevices: [], deviceSessions: [] };
-    await window.addDeviceFromPreset('mitochondriak-maxi-uvb');
+    await addDeviceFromPreset('mitochondriak-maxi-uvb');
     const fresh = window._labState.importedData.lightDevices[0];
     assert('Fresh-add: device carries `modes` immediately',
       Array.isArray(fresh.modes) && fresh.modes.length >= 2);
@@ -603,7 +603,7 @@ const {
     assert('Fresh-add: device carries `coupling` immediately',
       Array.isArray(fresh.coupling));
     // Non-moded preset (Pulse) → fields stay null
-    await window.addDeviceFromPreset('mitochondriak-pulse');
+    await addDeviceFromPreset('mitochondriak-pulse');
     const pulse = window._labState.importedData.lightDevices.find(d => d.presetId === 'mitochondriak-pulse');
     assert('Fresh-add: non-moded preset (Pulse) has null modes',
       pulse.modes === null);
@@ -621,7 +621,7 @@ const {
     lightDevicesRuntimeSrc.includes("getRuntimeFunction('navigate')") &&
     lightDevicesRuntimeSrc.includes('lightDevicesRuntimeDeps.showPromptDialog') &&
     lightDevicesRuntimeSrc.includes("getRuntimeFunction('loadCatalog')") &&
-    lightDevicesRuntimeSrc.includes('publishLightDevicesWindowBindings'));
+    !lightDevicesRuntimeSrc.includes('publishLightDevicesWindowBindings'));
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-sun-runtime.js
+++ b/tests/test-sun-runtime.js
@@ -2,6 +2,7 @@
 // test-sun-runtime.js - Sun session browser adapter behavior.
 
 import './_node-shim.js';
+import { state } from '../js/state.js';
 import {
   addSunProfileSwitchListener,
   configureSunRuntimeDeps,
@@ -31,7 +32,6 @@ console.log('=== Sun Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'navigator',
-  'getDeviceSessions',
   'buildSidebar',
   'navigate',
   'renderLightChannelsLive',
@@ -42,6 +42,7 @@ const runtimeKeys = [
   'sunRuntimeProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+const savedImportedData = state.importedData;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -63,7 +64,7 @@ function restoreRuntime() {
 try {
   const calls = [];
   const deviceSessions = [{ id: 'device-1', doses: { vitamin_d: 12 } }];
-  setRuntimeValue('getDeviceSessions', () => deviceSessions);
+  state.importedData = { deviceSessions };
   setRuntimeValue('buildSidebar', () => calls.push(['sidebar']));
   setRuntimeValue('navigate', (view, options) => calls.push(['navigate', view, options?.scrollAnchor]));
   setRuntimeValue('renderLightChannelsLive', () => calls.push(['channels-live']));
@@ -77,7 +78,7 @@ try {
     hasSunBrowserRuntime() === true);
   assert('isSunDebugRuntime delegates debug mode safely',
     isSunDebugRuntime() === true);
-  assert('getSunDeviceSessionsRuntime delegates to runtime provider',
+  assert('getSunDeviceSessionsRuntime reads the device session store',
     getSunDeviceSessionsRuntime() === deviceSessions);
   rebuildSunSidebarRuntime();
   navigateSunRuntime('light', { scrollAnchor: 'light-session-log' });
@@ -114,7 +115,7 @@ try {
   assert('exposeSunRuntimeBindings publishes runtime bindings',
     globalThis.sunRuntimeProbe === probe);
 
-  setRuntimeValue('getDeviceSessions', () => { throw new Error('boom'); });
+  state.importedData = { deviceSessions: [] };
   setRuntimeValue('renderLightTodayStrip', () => { throw new Error('boom'); });
   setRuntimeValue('buildSidebar', () => { throw new Error('boom'); });
   setRuntimeValue('navigate', () => { throw new Error('boom'); });
@@ -156,6 +157,7 @@ try {
     calls.length === beforeNoWindowCalls &&
     globalThis.sunRuntimeProbe === probe);
 } finally {
+  state.importedData = savedImportedData;
   configureSunRuntimeDeps(originalSunRuntimeDeps);
   restoreRuntime();
 }

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -15,6 +15,7 @@ return (async function() {
   const S = window._labState;
   const dataModule = await import('/js/data.js');
   const viewsModule = await import('/js/views.js');
+  const lightDevices = await import('/js/light-devices.js');
   const { buildSunContext } = await import('/js/sun-context.js');
   const { buildLabContext } = await import('/js/lab-context.js');
   const profile = await import('/js/profile.js');
@@ -347,7 +348,7 @@ return (async function() {
   // for single-mode devices, and must filter out coupling-violating
   // modes (so e.g. Maxi UVB never offers a UV-only choice).
   console.log('%c 8b. Mode picker UI on session log dialog ', 'font-weight:bold;color:#6366f1');
-  if (typeof window.openDeviceSessionDialog === 'function') {
+  if (typeof lightDevices.openDeviceSessionDialog === 'function') {
     document.querySelectorAll('.modal-overlay').forEach(el => el.remove());
 
     // Inject a fresh moded device + a non-moded device into state so we
@@ -377,7 +378,7 @@ return (async function() {
     S.importedData.lightDevices = [modedDevice, plainDevice];
 
     // Moded device → picker present
-    await window.openDeviceSessionDialog('D-test-moded');
+    await lightDevices.openDeviceSessionDialog('D-test-moded');
     await wait(40);
     const dlgModed = document.querySelector('.modal-overlay.show');
     const picker = dlgModed?.querySelector('.dev-mode-picker');
@@ -402,7 +403,7 @@ return (async function() {
     dlgModed?.remove();
 
     // Non-moded device → picker absent
-    await window.openDeviceSessionDialog('D-test-plain');
+    await lightDevices.openDeviceSessionDialog('D-test-plain');
     await wait(40);
     const dlgPlain = document.querySelector('.modal-overlay.show');
     const noPicker = dlgPlain?.querySelector('#dev-session-mode');
@@ -417,7 +418,7 @@ return (async function() {
   // chips get the accent variant so the user can skim history for
   // non-default sessions. Non-moded devices skip the chip entirely.
   console.log('%c 8c. Mode badge on session list rows ', 'font-weight:bold;color:#6366f1');
-  if (typeof window.logDeviceSession === 'function') {
+  if (typeof lightDevices.logDeviceSession === 'function') {
     document.querySelectorAll('.modal-overlay').forEach(el => el.remove());
     // Reuse the moded device from 8b but log three sessions: default
     // mode, non-default mode, plus a session on the plain device.
@@ -446,9 +447,9 @@ return (async function() {
     // newest-first across BOTH kinds, so leftover sun sessions from earlier
     // tests would push device sessions out of the top slice.
     S.importedData.sunSessions = [];
-    await window.logDeviceSession({ deviceId: 'D-badge-moded', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true, mode: 'all-on' });
-    await window.logDeviceSession({ deviceId: 'D-badge-moded', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true, mode: 'red-nir-only' });
-    await window.logDeviceSession({ deviceId: 'D-badge-plain', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
+    await lightDevices.logDeviceSession({ deviceId: 'D-badge-moded', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true, mode: 'all-on' });
+    await lightDevices.logDeviceSession({ deviceId: 'D-badge-moded', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true, mode: 'red-nir-only' });
+    await lightDevices.logDeviceSession({ deviceId: 'D-badge-plain', durationMin: 10, distanceCm: 15, bodyArea: 'torso', eyesProtected: true });
 
     viewsModule.navigate('light');
     await wait(80);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -867,6 +867,33 @@
     '_skinTypeToFitzpatrick',
     '_skinFaceKeydown',
   ].every(name => !(name in window)));
+  assert('light device helpers stay module-only', [
+    'loadLightDevicePresets',
+    'getDevices',
+    'getDeviceSessions',
+    'addDeviceFromPreset',
+    'hydrateDevicesFromPresets',
+    'deleteLightDevice',
+    'logDeviceSession',
+    'startDeviceSession',
+    'stopDeviceSession',
+    'updateDeviceSession',
+    'editDeviceSessionDuration',
+    'editDeviceSessionMode',
+    'getActiveDeviceSession',
+    'renderActiveDeviceSessionCard',
+    'ensureActiveDeviceTicker',
+    'stopDeviceSessionAndNotify',
+    'deleteDeviceSession',
+    'rollingDeviceTotals',
+    'renderDevicesSection',
+    'openDeviceSessionDetail',
+    'openAddDeviceDialog',
+    'openCustomDeviceDialog',
+    'addCustomDevice',
+    'openDeviceSessionDialog',
+    'quickLogDeviceSession',
+  ].every(name => !(name in window)));
   for (const name of settingsSyncPanelLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -86,7 +86,6 @@ interface Window {
   getProfileLocation?: AnyFunction;
   getOllamaConfig?: AnyFunction;
   getProfiles?: () => Array<{ id?: string; name?: string | null; sex?: string | null }>;
-  hydrateDevicesFromPresets?: () => Promise<boolean>;
   HAPLOGROUP_LIST?: string[];
   hasAIProvider?: () => boolean;
   fetchAtmosphere?: AnyFunction;
@@ -117,14 +116,11 @@ interface Window {
   renderLightTodayStrip?: AnyFunction;
   renderSunSessionRow?: AnyFunction;
   rollingChannelTotals?: (days?: number) => Record<string, number>;
-  rollingDeviceTotals?: (days?: number) => Record<string, number>;
   rollingVitaminDIU?: (days?: number) => number;
   weeklyChannelTier?: (value: number, channel?: string) => number;
   tierLabel?: (tier: number) => string;
   getSessions?: () => any[];
   getActiveSession?: AnyFunction;
-  getDevices?: AnyFunction;
-  getDeviceSessions?: () => any[];
   cumulativeMEDToday?: AnyFunction;
   cumulativeMEDYesterday?: AnyFunction;
   vitaminDBudgetStatus?: AnyFunction;
@@ -184,8 +180,6 @@ interface Window {
   openProfileShareModal?: (profileId?: string) => void;
   openProfileLocationEditor?: AnyFunction;
   quickLogSunSession?: () => Promise<void> | void;
-  quickLogDeviceSession?: AnyFunction;
-  openAddDeviceDialog?: AnyFunction;
   openDetailedSessionDialog?: AnyFunction;
   requestPreciseLocation?: AnyFunction;
   pauseSunSession?: (id?: string) => Promise<void> | void;
@@ -251,16 +245,12 @@ interface Window {
   showDetailModal?: AnyFunction;
   syncWearableNow?: AnyFunction;
   triggerDNAFilePicker?: AnyFunction;
-  loadLightDevicePresets?: AnyFunction;
   renderLightDeviceAffiliateRow?: AnyFunction;
   renderRecommendationSection?: AnyFunction;
   renderLightTools?: AnyFunction;
-  renderActiveDeviceSessionCard?: AnyFunction;
   renderChannelDeficitDeviceRecs?: AnyFunction;
-  renderDevicesSection?: AnyFunction;
   renderSunDataSourceSettings?: AnyFunction;
   computeUVConfidence?: AnyFunction;
-  ensureActiveDeviceTicker?: AnyFunction;
   getMeteoConfig?: AnyFunction;
   ingredientDailyTotal?: AnyFunction;
   maybeShowAnalyticsConsent?: () => void;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.229';
+self.APP_VERSION = '1.10.230';


### PR DESCRIPTION
## Summary

- remove the Light-device facade's 25 legacy `window` publications
- route dashboard, Sun, startup maintenance, and Light-channel AI consumers through direct store/module dependencies
- inject delegated device-card actions and the dashboard device ticker explicitly instead of resolving browser globals
- keep session detail actions module-local and remove obsolete runtime publication/redirection helpers
- update Node and browser tests for the module-only contract, remove stale global declarations, and bump the cache version to 1.10.230

## Window burden

- Before: **331 unique globals**, **331 publication entries**, **9 publication sites**, **9 dependency families**
- After: **306 unique globals**, **306 publication entries**, **8 publication sites**, **8 dependency families**
- This PR removes **25 unique globals**, **25 publication entries**, **1 complete publication site**, and **1 complete dependency family**.
- **Work remaining: approximately 1–6 focused PRs** to remove or explicitly retain the remaining 306 globals across 8 sites and 8 families.

## Validation

- `./run-tests.sh`
  - module verification: 125 passed
  - Vitest: 398 passed
  - Playwright: 352 passed
  - responsive-theme assertions: 472 passed
- focused Light-device, Light-page, startup, Sun, and aggregate-AI Playwright specs: 13 passed
- focused two-device sync and responsive-theme Playwright specs: 2 passed
- `node tests/test-light-devices.js`: 62 passed
- `node tests/test-light-devices-runtime.js`: 14 passed
- `node tests/test-dashboard-widget-runtime.js`: 7 passed
- `node tests/test-sun-runtime.js`: 13 passed
- typecheck, checkjs, and quality guardrails passed