### PR TITLE
Remove client list globals

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -24,14 +24,14 @@ import {
   renderThreadList,
   toggleThreadRail,
 } from './chat-threads.js';
-import { closeClientList, configureClientListRuntime } from './client-list.js';
+import { closeClientList, configureClientListRuntime, openClientList, openProfileLocationEditor } from './client-list.js';
 import { closeEMFInterpretation } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder } from './export.js';
 import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
 import { closeFeedbackModal, openFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { closeModal } from './marker-detail-modal.js';
-import { closeMobileSidebar } from './nav.js';
+import { closeMobileSidebar, configureNavActions } from './nav.js';
 import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
@@ -44,9 +44,11 @@ import {
 } from './views.js';
 import { openProfileShareModal } from './profile-share.js';
 import { getActiveProfileId } from './profile.js';
+import { configureRecommendationsRuntime } from './recommendations-runtime.js';
 import { configureShellChatImageDeps, configureShellChatThreadDeps } from './shell-actions.js';
 import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
+import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
 
 configureClientListRuntime({
   exportAllDataJSON,
@@ -68,6 +70,10 @@ configureSettingsRuntime({
   resetDashboardWidgets,
   toggleDashboardOrganizeMode,
 });
+
+configureNavActions({ openClientList });
+configureRecommendationsRuntime({ openProfileLocationEditor });
+configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
 configureChatMessageActionDeps({ openImageLightbox, removeImageAttachment });

--- a/js/client-list-runtime.js
+++ b/js/client-list-runtime.js
@@ -47,12 +47,6 @@ export function getClientHaplogroupList() {
   return Array.isArray(list) ? list : [];
 }
 
-/** @param {() => void} [fallback] */
-export function closeClientListFromRuntime(fallback) {
-  const close = getRuntimeFunction('closeClientList') || fallback;
-  close?.();
-}
-
 /** @param {string} route */
 export function navigateClientListRoute(route) {
   getRuntimeFunction('navigate')?.(route);
@@ -82,10 +76,4 @@ export function hasClientListAIProvider() {
   } catch {
     return false;
   }
-}
-
-/** @param {Record<string, any>} bindings */
-export function publishClientListWindowBindings(bindings) {
-  if (typeof window === 'undefined') return;
-  Object.assign(getRuntimeWindow(), bindings);
 }

--- a/js/client-list.js
+++ b/js/client-list.js
@@ -8,11 +8,9 @@ import { LATITUDE_BANDS } from './constants.js';
 import { getAvatarColor } from './nav.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
-  closeClientListFromRuntime,
   getClientHaplogroupList,
   hasClientListAIProvider,
   navigateClientListRoute,
-  publishClientListWindowBindings,
   refreshClientProfileButton,
   setClientManualHaplogroup,
   showClientListNotification,
@@ -533,7 +531,7 @@ export function openClientForm(profileId) {
 
 function _clGoToHealthMetrics(event) {
   if (event) event.preventDefault();
-  closeClientListFromRuntime(closeClientList);
+  closeClientList();
   navigateClientListRoute('dashboard');
   requestAnimationFrame(() => {
     document.getElementById('wearable-strip')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -1056,7 +1054,7 @@ function _clHeightUnitChanged() {
 // .show class); openClientForm(id) replaces the list view with the form.
 // Calling openClientForm alone leaves the overlay hidden — the form
 // renders in the DOM but isn't visible to the user.
-function openProfileLocationEditor() {
+export function openProfileLocationEditor() {
   // Close any other modal that might be on top first (marker modal, etc.)
   // so the client-list overlay isn't sitting behind it.
   const otherOverlay = document.getElementById('modal-overlay');
@@ -1072,12 +1070,3 @@ function openProfileLocationEditor() {
 }
 
 installClientListDelegates();
-
-publishClientListWindowBindings({
-  openClientList, closeClientList, openClientForm, openProfileLocationEditor,
-  _clSearch, _clSort, _clStatusFilter, _clTagFilter, _clSelect,
-  _clSaveForm, _clSetSex, _clUpdateLat, _clTagKeydown, _clRemoveTag, _clBackToList,
-  _clAvatarChanged, _clRemoveAvatar, _clHaplogroupChanged,
-  _clToggleToolsMenu, _clCloseMenus: _closeMenus, _clToggleMenu, _clEdit, _clPin, _clUnpin, _clFlag, _clUnflag, _clArchive, _clUnarchive, _clExport, _clExportChat, _clDelete,
-  _clUpdateBMI, _clHeightUnitChanged, _clGoToHealthMetrics,
-});

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -65,10 +65,6 @@ export function openCreateMarkerFromNavRuntime() {
   getNavRuntimeFunction('openCreateMarkerModal')?.();
 }
 
-export function openClientListFromNavRuntime() {
-  getNavRuntimeFunction('openClientList')?.();
-}
-
 /**
  * @param {Record<string, any>} globals
  */

--- a/js/nav.js
+++ b/js/nav.js
@@ -10,7 +10,6 @@ import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
   exposeNavRuntimeGlobals,
   navigateFromNavRuntime,
-  openClientListFromNavRuntime,
   openContextFromNavRuntime,
   openCreateMarkerFromNavRuntime,
   openEMFAssessmentFromNavRuntime,
@@ -43,6 +42,7 @@ function _iconSvg(name) {
 let navDelegatesInstalled = false;
 const navActionDeps = {
   openLightEnvironmentAssessment: () => {},
+  openClientList: () => {},
 };
 
 export function configureNavActions(deps = {}) {
@@ -105,7 +105,7 @@ function handleNavActionClick(event) {
   } else if (action === 'toggle-group') {
     toggleNavGroup(actionEl.dataset.navGroup || '');
   } else if (action === 'open-client-list') {
-    openClientListFromNavRuntime();
+    navActionDeps.openClientList();
   } else {
     handled = false;
   }

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -6,12 +6,18 @@ import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const recommendationsRuntimeDeps = {
   openEMFAssessmentEditor,
+  openProfileLocationEditor: null,
 };
 
 export function configureRecommendationsRuntime(deps = {}) {
   const previous = { ...recommendationsRuntimeDeps };
   if (typeof deps.openEMFAssessmentEditor === 'function') {
     recommendationsRuntimeDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
+  }
+  if ('openProfileLocationEditor' in deps) {
+    recommendationsRuntimeDeps.openProfileLocationEditor = typeof deps.openProfileLocationEditor === 'function'
+      ? deps.openProfileLocationEditor
+      : null;
   }
   return previous;
 }
@@ -78,7 +84,7 @@ export function openRecommendationsEmfAssessment() {
 }
 
 export function openRecommendationsLocationEditor() {
-  const openProfileLocationEditor = getRuntimeFunction('openProfileLocationEditor');
+  const openProfileLocationEditor = recommendationsRuntimeDeps.openProfileLocationEditor;
   if (!openProfileLocationEditor) return false;
   openProfileLocationEditor();
   return true;

--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -4,11 +4,20 @@
 import { getProfileLocation } from './profile.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const sunDefaultsRuntimeDeps = { getProfileLocation };
+const sunDefaultsRuntimeDeps = {
+  getProfileLocation,
+  openProfileLocationEditor: null,
+  openClientList: null,
+};
 
 export function configureSunDefaultsRuntimeDeps(deps = {}) {
   const previous = { ...sunDefaultsRuntimeDeps };
   if (typeof deps.getProfileLocation === 'function') sunDefaultsRuntimeDeps.getProfileLocation = deps.getProfileLocation;
+  for (const name of ['openProfileLocationEditor', 'openClientList']) {
+    if (name in deps) {
+      sunDefaultsRuntimeDeps[name] = typeof deps[name] === 'function' ? deps[name] : null;
+    }
+  }
   return previous;
 }
 
@@ -44,12 +53,12 @@ export function getSunSetupProfileLocation() {
 }
 
 export function openSunSetupProfileLocationRuntime() {
-  const openProfileLocationEditor = getRuntimeFunction('openProfileLocationEditor');
+  const openProfileLocationEditor = sunDefaultsRuntimeDeps.openProfileLocationEditor;
   if (openProfileLocationEditor) {
     openProfileLocationEditor();
     return true;
   }
-  const openClientList = getRuntimeFunction('openClientList');
+  const openClientList = sunDefaultsRuntimeDeps.openClientList;
   if (openClientList) {
     openClientList();
     return true;

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -2,11 +2,12 @@ import { expect, test } from './coverage-fixture.js';
 
 test('client list live menu actions dispatch exports share demos and profile state changes', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openClientList === 'function');
+  await page.evaluate(() => import('/js/client-list.js'));
 
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
-    const { configureClientListRuntime } = await import('/js/client-list.js');
+    const clientList = await import('/js/client-list.js');
+    const { configureClientListRuntime } = clientList;
     const profile = await import('/js/profile.js');
     const outcomes = {};
     const calls = [];
@@ -75,7 +76,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
       inputClick: HTMLInputElement.prototype.click,
     };
     const openList = async () => {
-      window.openClientList();
+      clientList.openClientList();
       await waitFor(() => document.getElementById('client-list-overlay')?.classList.contains('show'), 'client list overlay');
       await waitFor(() => document.activeElement?.id === 'cl-search', 'client list search focus');
     };
@@ -235,8 +236,12 @@ test('client list live menu actions dispatch exports share demos and profile sta
       outcomes.outsideClickClosesFloatingMenus = !document.getElementById('cl-active-menu')?.classList.contains('show')
         && !document.getElementById('cl-tools-menu')?.classList.contains('show');
     } finally {
-      window._clSort?.('lastUpdated');
-      window.closeClientList?.();
+      const sort = document.querySelector('.cl-sort');
+      if (sort) {
+        sort.value = 'lastUpdated';
+        sort.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      clientList.closeClientList();
       state.profiles = saved.profiles;
       state.currentProfile = saved.currentProfile;
       state.importedData = saved.importedData;
@@ -263,10 +268,11 @@ test('client list live menu actions dispatch exports share demos and profile sta
 
 test('client list form live actions cover health link avatar haplogroup and location editor', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openClientList === 'function');
+  await page.evaluate(() => import('/js/client-list.js'));
 
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
+    const clientList = await import('/js/client-list.js');
     const clientListRuntime = await import('/js/client-list-runtime.js');
     const outcomes = {};
     const calls = [];
@@ -349,8 +355,8 @@ test('client list form live actions cover health link avatar haplogroup and loca
         document.body.appendChild(strip);
       }
 
-      window.openClientList();
-      window.openClientForm('client-active');
+      clientList.openClientList();
+      clientList.openClientForm('client-active');
       await waitFor(() => !!document.querySelector('.cl-form'), 'client edit form');
       document.querySelector('[data-cl-action="health-metrics"]')?.click();
       await waitFor(() => calls.some(call => call[0] === 'navigate'), 'health metrics navigation');
@@ -359,8 +365,8 @@ test('client list form live actions cover health link avatar haplogroup and loca
         && calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard')
         && calls.some(call => call[0] === 'scroll' && call[1] === 'wearable-strip');
 
-      window.openClientList();
-      window.openClientForm('client-active');
+      clientList.openClientList();
+      clientList.openClientForm('client-active');
       await waitFor(() => !!document.querySelector('.cl-form'), 'reopened client edit form');
       document.querySelector('.cl-avatar-picker')?.dispatchEvent(new KeyboardEvent('keydown', {
         key: 'Enter',
@@ -387,14 +393,14 @@ test('client list form live actions cover health link avatar haplogroup and loca
         && calls.some(call => call[0] === 'notification' && call[1] === '"Active Browser" updated' && call[2] === 'info');
 
       document.getElementById('modal-overlay')?.classList.add('show');
-      window.openProfileLocationEditor();
+      clientList.openProfileLocationEditor();
       await waitFor(() => document.activeElement?.id === 'cl-country', 'location editor focus');
       outcomes.locationEditorOpensVisibleFormAndHidesOtherModal = document.getElementById('client-list-overlay')?.classList.contains('show') === true
         && !document.getElementById('modal-overlay')?.classList.contains('show')
         && document.getElementById('cl-country')?.value === 'Czech Republic'
         && calls.some(call => call[0] === 'scroll' && call[1] === 'cl-country');
     } finally {
-      window.closeClientList?.();
+      clientList.closeClientList();
       state.profiles = saved.profiles;
       state.currentProfile = saved.currentProfile;
       state.importedData = saved.importedData;
@@ -426,10 +432,11 @@ test('client list form live actions cover health link avatar haplogroup and loca
 
 test('client list remaining browser helpers cover filters avatar upload tags and profile metadata actions', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openClientList === 'function');
+  await page.evaluate(() => import('/js/client-list.js'));
 
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
+    const clientList = await import('/js/client-list.js');
     const outcomes = {};
     const calls = [];
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -512,32 +519,36 @@ test('client list remaining browser helpers cover filters avatar upload tags and
       window.renderProfileButton = () => calls.push(['render-profile-button']);
       window.showNotification = (...args) => calls.push(['notification', ...args]);
 
-      window.openClientList();
+      clientList.openClientList();
       await waitFor(() => document.getElementById('client-list-overlay')?.classList.contains('show'), 'client list open');
-      window._clSearch('alpha');
+      const search = document.getElementById('cl-search');
+      search.value = 'alpha';
+      search.dispatchEvent(new Event('input', { bubbles: true }));
       await waitFor(() => rowNames().join('|') === 'Alpha Helper', 'client search render');
       outcomes.searchHelperFiltersList = document.getElementById('cl-search')?.value === 'alpha'
         && rowNames().join('|') === 'Alpha Helper';
 
-      window._clSearch('');
+      document.getElementById('cl-search').value = '';
+      document.getElementById('cl-search').dispatchEvent(new Event('input', { bubbles: true }));
       await waitFor(() => rowNames().length === 2, 'cleared search render');
-      window._clSort('az');
+      document.querySelector('.cl-sort').value = 'az';
+      document.querySelector('.cl-sort').dispatchEvent(new Event('change', { bubbles: true }));
       await waitFor(() => rowNames().join('|') === 'Zeta Helper|Alpha Helper', 'pinned sort render');
-      window._clTagFilter('metabolic');
+      document.querySelector('[data-cl-action="tag-filter"][data-cl-tag="metabolic"]')?.click();
       await waitFor(() => rowNames().join('|') === 'Alpha Helper', 'tag filter render');
-      window._clTagFilter('metabolic');
+      document.querySelector('[data-cl-action="tag-filter"][data-cl-tag="metabolic"]')?.click();
       await waitFor(() => rowNames().length === 2, 'tag filter toggle clear');
       outcomes.sortAndTagFilterHelpersRerenderList = rowNames().includes('Zeta Helper')
         && rowNames().includes('Alpha Helper');
 
-      window.openClientForm('client-list-helper-main');
+      clientList.openClientForm('client-list-helper-main');
       await waitFor(() => !!document.querySelector('.cl-form'), 'helper edit form');
-      window._clSetSex('male');
+      document.querySelector('[data-cl-action="set-sex"][data-cl-sex="male"]')?.click();
       outcomes.setSexHelperTogglesActiveButton = document.querySelector('#cl-sex-toggle .sex-toggle-btn.active')?.dataset.sex === 'male';
 
       document.getElementById('cl-country').value = 'Slovakia';
       document.getElementById('cl-zip').value = '81101';
-      window._clUpdateLat();
+      document.getElementById('cl-zip').dispatchEvent(new Event('input', { bubbles: true }));
       outcomes.latitudeHelperUsesCacheAndZipSuffix = document.getElementById('cl-lat-display')?.textContent.includes('ZIP-refined') === true
         && document.getElementById('cl-lat-display')?.textContent.includes('48') === true;
 
@@ -552,7 +563,7 @@ test('client list remaining browser helpers cover filters avatar upload tags and
       outcomes.tagKeyboardAndRemoveHelpersMutatePills = ![...document.querySelectorAll('.cl-tag-pill')]
         .some(el => el.textContent.includes('coach'));
 
-      window._clHeightUnitChanged();
+      document.getElementById('cl-height-unit-toggle')?.click();
       outcomes.heightUnitHelperConvertsAndUpdatesBmi = document.getElementById('cl-height-unit')?.value === 'in'
         && document.getElementById('cl-height-unit-toggle')?.textContent === 'in'
         && document.getElementById('cl-height')?.placeholder === 'inches'
@@ -571,32 +582,37 @@ test('client list remaining browser helpers cover filters avatar upload tags and
         configurable: true,
         value: [file],
       });
-      await window._clAvatarChanged(avatarInput);
+      avatarInput.dispatchEvent(new Event('change', { bubbles: true }));
+      await waitFor(() => document.getElementById('cl-avatar-img') instanceof HTMLImageElement, 'avatar preview');
       outcomes.avatarChangeHelperResizesAndShowsPreview = document.getElementById('cl-avatar-img') instanceof HTMLImageElement
         && document.getElementById('cl-avatar-img')?.getAttribute('src')?.startsWith('data:image/jpeg')
         && !!document.querySelector('.cl-avatar-remove');
 
-      window._clBackToList();
+      document.querySelector('[data-cl-action="back-to-list"]')?.click();
       await waitFor(() => !!document.getElementById('cl-search'), 'back to client list');
       outcomes.backToListHelperRestoresSearchView = !!document.getElementById('cl-search')
         && !document.querySelector('.cl-form');
 
-      window._clUnpin('client-list-helper-main');
+      document.querySelector('[data-cl-action="toggle-menu"][data-cl-profile-id="client-list-helper-main"]')?.click();
+      await waitFor(() => !!document.querySelector('[data-cl-action="unpin-profile"][data-cl-profile-id="client-list-helper-main"]'), 'unpin menu action');
+      document.querySelector('[data-cl-action="unpin-profile"][data-cl-profile-id="client-list-helper-main"]')?.click();
       await waitFor(() => state.profiles.find(p => p.id === 'client-list-helper-main')?.pinned === false, 'profile unpinned');
-      window._clArchive('client-list-helper-secondary');
+      document.querySelector('[data-cl-action="toggle-menu"][data-cl-profile-id="client-list-helper-secondary"]')?.click();
+      await waitFor(() => !!document.querySelector('[data-cl-action="archive-profile"][data-cl-profile-id="client-list-helper-secondary"]'), 'archive menu action');
+      document.querySelector('[data-cl-action="archive-profile"][data-cl-profile-id="client-list-helper-secondary"]')?.click();
       await waitFor(() => state.profiles.find(p => p.id === 'client-list-helper-secondary')?.status === 'archived', 'profile archived');
-      window._clEdit('client-list-helper-main');
+      document.querySelector('[data-cl-action="edit-profile"][data-cl-profile-id="client-list-helper-main"]')?.click();
       await waitFor(() => !!document.querySelector('.cl-form'), 'edit helper opens form');
-      window._clBackToList();
+      document.querySelector('[data-cl-action="back-to-list"]')?.click();
       await waitFor(() => !!document.getElementById('cl-search'), 'back after edit');
-      window._clSelect('client-list-helper-main');
+      document.querySelector('[data-cl-action="select-profile"][data-cl-profile-id="client-list-helper-main"]')?.click();
       outcomes.profileMetadataHelpersUnpinArchiveEditAndSelect =
         state.profiles.find(p => p.id === 'client-list-helper-main')?.pinned === false
         && state.profiles.find(p => p.id === 'client-list-helper-secondary')?.status === 'archived'
         && calls.filter(call => call[0] === 'render-profile-button').length >= 2
         && !document.getElementById('client-list-overlay')?.classList.contains('show');
     } finally {
-      window.closeClientList?.();
+      clientList.closeClientList();
       state.profiles = saved.profiles;
       state.currentProfile = saved.currentProfile;
       state.importedData = saved.importedData;

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -36,7 +36,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     const origProfiles = state.profiles;
     const origNavigate = window.navigate;
     const origOpenCreateMarker = window.openCreateMarkerModal;
-    const origOpenClientList = window.openClientList;
     const origGroupStorage = localStorage.getItem('labcharts-navgroup-Hormones');
     let restoreNavActions = null;
     let restoreNavRuntime = null;
@@ -81,12 +80,12 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       });
       restoreNavActions = nav.configureNavActions({
         openLightEnvironmentAssessment: () => calls.push(['open-light-env']),
+        openClientList: () => calls.push(['open-client-list']),
       });
       restoreContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
         openContextModal: () => calls.push(['open-context']),
       });
       window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
-      window.openClientList = () => calls.push(['open-client-list']);
       window.buildSidebar(fixtureData);
       window.renderProfileButton();
       nav.openRecommendationsFromSidebar();
@@ -151,7 +150,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       if (restoreNavActions) nav.configureNavActions(restoreNavActions);
       if (restoreContextCardsRuntime) contextCardsRuntime.configureContextCardsRuntimeCallbacks(restoreContextCardsRuntime);
       window.openCreateMarkerModal = origOpenCreateMarker;
-      window.openClientList = origOpenClientList;
       if (origGroupStorage == null) localStorage.removeItem('labcharts-navgroup-Hormones');
       else localStorage.setItem('labcharts-navgroup-Hormones', origGroupStorage);
       window.buildSidebar?.();

--- a/tests/playwright/recommendations-browser-coverage.spec.js
+++ b/tests/playwright/recommendations-browser-coverage.spec.js
@@ -194,7 +194,7 @@ test('recommendations browser coverage exercises catalog renderers detectors and
 
   await page.goto('/app', { waitUntil: 'load' });
 
-  const results = await page.evaluate(async ({ recUrl }) => {
+  const results = await page.evaluate(async ({ recUrl, runtimeUrl }) => {
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const { state } = await import('/js/state.js');
     const recommendationWindowKeys = [
@@ -227,6 +227,10 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       value: window[key],
     }));
     const rec = await import(recUrl);
+    const recommendationsRuntime = await import(runtimeUrl);
+    const savedRecommendationsRuntime = recommendationsRuntime.configureRecommendationsRuntime({
+      openProfileLocationEditor: () => {},
+    });
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
       const key = localStorage.key(i);
       return [key, localStorage.getItem(key)];
@@ -236,7 +240,6 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       profiles: clone(state.profiles),
       importedData: clone(state.importedData),
       snpTable: window._snpTableCache,
-      openProfileLocationEditor: window.openProfileLocationEditor,
       openSettingsTab: window.openSettingsTab,
       clipboard: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
       setTimeout: window.setTimeout,
@@ -293,7 +296,6 @@ test('recommendations browser coverage exercises catalog renderers detectors and
           },
         },
       };
-      window.openProfileLocationEditor = () => {};
       window.openSettingsTab = () => {};
 
       localStorage.setItem('labcharts-show-product-recs', 'false');
@@ -479,7 +481,7 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       state.profiles = saved.profiles;
       state.importedData = saved.importedData;
       restoreWindowProp('_snpTableCache', saved.snpTable);
-      restoreWindowProp('openProfileLocationEditor', saved.openProfileLocationEditor);
+      recommendationsRuntime.configureRecommendationsRuntime(savedRecommendationsRuntime);
       restoreWindowProp('openSettingsTab', saved.openSettingsTab);
       for (const { key, hadOwn, value } of saved.recommendationWindowExports) {
         if (hadOwn) window[key] = value;
@@ -496,7 +498,10 @@ test('recommendations browser coverage exercises catalog renderers detectors and
     }
 
     return outcomes;
-  }, { recUrl: moduleUrl('/js/recommendations.js') });
+  }, {
+    recUrl: moduleUrl('/js/recommendations.js'),
+    runtimeUrl: '/js/recommendations-runtime.js',
+  });
 
   expectAll(results);
 });

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -47,8 +47,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       profileDob: state.profileDob,
       navigate: window.navigate,
       getSunCoords: window.getSunCoords,
-      openProfileLocationEditor: window.openProfileLocationEditor,
-      openClientList: window.openClientList,
       requestPreciseLocation: window.requestPreciseLocation,
     };
     const calls = [];
@@ -56,6 +54,8 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
     let precise = false;
     const previousSunDefaultsRuntimeDeps = sunDefaultsRuntime.configureSunDefaultsRuntimeDeps({
       getProfileLocation: () => ({ country: 'Czechia', zip: '' }),
+      openProfileLocationEditor: () => calls.push(['profile-location']),
+      openClientList: () => calls.push(['client-list']),
     });
 
     try {
@@ -75,8 +75,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       window.getSunCoords = () => precise
         ? { source: 'profile-precise', lat: 50.087 }
         : { source: 'country-band', lat: 49.2 };
-      window.openProfileLocationEditor = () => calls.push(['profile-location']);
-      window.openClientList = () => calls.push(['client-list']);
       window.requestPreciseLocation = async () => {
         calls.push(['precise-location']);
         await wait(0);
@@ -209,8 +207,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       Object.assign(window, {
         navigate: saved.navigate,
         getSunCoords: saved.getSunCoords,
-        openProfileLocationEditor: saved.openProfileLocationEditor,
-        openClientList: saved.openClientList,
         requestPreciseLocation: saved.requestPreciseLocation,
       });
       sunDefaults.configureSunDefaults({

--- a/tests/test-client-list-delegated-actions.js
+++ b/tests/test-client-list-delegated-actions.js
@@ -56,9 +56,11 @@ assert('client-list routes app-shell actions through injectable runtime',
     clientListSrc.includes('clientListRuntime.exportClientJSON(id, true)') &&
     clientListSrc.includes('clientListRuntime.importDataJSON(file)') &&
     clientListSrc.includes('clientListRuntime.loadDemoData(actionEl.dataset.clDemo'));
-assert('client-list routes browser globals through client-list runtime adapter',
+assert('client-list keeps browser adapters explicit and publishes no window bindings',
   clientListSrc.includes("from './client-list-runtime.js'") &&
-    clientListSrc.includes('publishClientListWindowBindings') &&
+    clientListSrc.includes('navigateClientListRoute') &&
+    clientListSrc.includes('showClientListNotification') &&
+    !clientListSrc.includes('publishClientListWindowBindings') &&
     !/\bwindow(?:\.|\s*\[)/.test(clientListSrc));
 assert('client-list modal uses shared overlay lifecycle helpers',
   clientListSrc.includes("from './modal-lifecycle.js'") &&

--- a/tests/test-client-list-runtime.js
+++ b/tests/test-client-list-runtime.js
@@ -4,12 +4,10 @@
 import './_node-shim.js';
 import { getCachedKey, updateKeyCache } from '../js/crypto.js';
 import {
-  closeClientListFromRuntime,
   configureClientListRuntimeDeps,
   getClientHaplogroupList,
   hasClientListAIProvider,
   navigateClientListRoute,
-  publishClientListWindowBindings,
   refreshClientProfileButton,
   setClientManualHaplogroup,
   showClientListNotification,
@@ -27,12 +25,10 @@ console.log('=== Client List Runtime Tests ===\n');
 
 const runtimeKeys = [
   'HAPLOGROUP_LIST',
-  'closeClientList',
   'navigate',
   'renderProfileButton',
   'showNotification',
   'setManualHaplogroup',
-  '__clientListRuntimeProbe',
 ];
 const saved = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
 const savedAIStorage = {
@@ -65,14 +61,6 @@ try {
   globalThis.HAPLOGROUP_LIST = 'H1';
   assert('getClientHaplogroupList falls back to empty array for invalid runtime value',
     getClientHaplogroupList().length === 0);
-
-  globalThis.closeClientList = () => calls.push(['close']);
-  closeClientListFromRuntime(() => calls.push(['fallback-close']));
-  delete globalThis.closeClientList;
-  closeClientListFromRuntime(() => calls.push(['fallback-close']));
-  assert('closeClientListFromRuntime prefers runtime close and falls back when missing',
-    calls.filter(call => call[0] === 'close').length === 1 &&
-    calls.filter(call => call[0] === 'fallback-close').length === 1);
 
   globalThis.navigate = route => calls.push(['navigate', route]);
   navigateClientListRoute('dashboard');
@@ -116,9 +104,6 @@ try {
   assert('hasClientListAIProvider returns false when selected provider is unconfigured',
     hasClientListAIProvider() === false);
 
-  publishClientListWindowBindings({ __clientListRuntimeProbe: () => 'ok' });
-  assert('publishClientListWindowBindings installs legacy globals',
-    globalThis.__clientListRuntimeProbe?.() === 'ok');
 } finally {
   configureClientListRuntimeDeps(originalClientListRuntimeDeps);
   restoreRuntime();

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -417,7 +417,6 @@ assert('94al. regionLabel(null/empty) → worldwide',
   recsMod.regionLabel(null) === 'worldwide' && recsMod.regionLabel('') === 'worldwide');
 
 // Region indicator + change-link wiring (smoke test for the disclosure footer)
-delete window.openProfileLocationEditor;
 localStorage.setItem('labcharts-show-product-recs', 'true');
 const discMeterHtml = recsMod.renderEMFMeterRecs(emfCat);
 assert('94am. Disclosure footer renders region indicator', /Showing for /.test(discMeterHtml));

--- a/tests/test-nav-delegated-actions.js
+++ b/tests/test-nav-delegated-actions.js
@@ -40,7 +40,7 @@ assert('nav.js routes browser globals through runtime adapter',
   navSrc.includes("from './nav-runtime.js'") &&
     navSrc.includes('navigateFromNavRuntime(') &&
     navSrc.includes('openEMFAssessmentFromNavRuntime()') &&
-    navSrc.includes('openClientListFromNavRuntime()') &&
+    navSrc.includes('navActionDeps.openClientList()') &&
     navSrc.includes('exposeNavRuntimeGlobals({') &&
     !/\bwindow(?:\.|\s*\[)/.test(navSrc));
 

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -6,7 +6,6 @@ import {
   configureNavRuntime,
   exposeNavRuntimeGlobals,
   navigateFromNavRuntime,
-  openClientListFromNavRuntime,
   openContextFromNavRuntime,
   openCreateMarkerFromNavRuntime,
   openEMFAssessmentFromNavRuntime,
@@ -35,7 +34,6 @@ const runtimeKeys = [
   'navigate',
   'openContextModal',
   'openCreateMarkerModal',
-  'openClientList',
   'runtimeProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
@@ -66,7 +64,6 @@ try {
     navigate(route) { calls.push(['navigate', route, this === browserRuntime]); },
     openContextModal() { calls.push(['legacy-context']); },
     openCreateMarkerModal() { calls.push(['marker', this === browserRuntime]); },
-    openClientList() { calls.push(['client', this === browserRuntime]); },
   };
   setRuntimeValue('window', browserRuntime);
   const restoreNavRuntime = configureNavRuntime({
@@ -79,18 +76,17 @@ try {
   openReportBuilderFromNavRuntime();
   openContextFromNavRuntime();
   openCreateMarkerFromNavRuntime();
-  openClientListFromNavRuntime();
 
   assert('nav runtime delegates all browser callbacks',
-    calls.length === 6
+    calls.length === 5
       && calls.some(call => call[0] === 'navigate' && call[1] === 'labs' && call[2] === true)
-      && ['emf', 'report', 'context', 'marker', 'client'].every(name => calls.some(call => call[0] === name && call[1] === true)));
+      && ['emf', 'report', 'context', 'marker'].every(name => calls.some(call => call[0] === name && call[1] === true)));
 
   exposeNavRuntimeGlobals({ runtimeProbe: 42 });
   assert('exposeNavRuntimeGlobals assigns exports to the browser runtime',
     browserRuntime.runtimeProbe === 42);
 
-  for (const key of ['navigate', 'openContextModal', 'openCreateMarkerModal', 'openClientList']) {
+  for (const key of ['navigate', 'openContextModal', 'openCreateMarkerModal']) {
     delete browserRuntime[key];
   }
   const previousViewRuntime = configureViewRuntime({
@@ -103,9 +99,8 @@ try {
   openReportBuilderFromNavRuntime();
   openContextFromNavRuntime();
   openCreateMarkerFromNavRuntime();
-  openClientListFromNavRuntime();
   assert('nav runtime falls back to module navigation when the browser callback is missing',
-    calls.length === 7 && calls.some(call => call[0] === 'module-navigate' && call[1] === 'missing'));
+    calls.length === 6 && calls.some(call => call[0] === 'module-navigate' && call[1] === 'missing'));
 
   delete globalThis.window;
   let globalRoute = '';

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -77,6 +77,7 @@ try {
   setRuntime(runtime);
   const restoreRecommendationsRuntime = configureRecommendationsRuntime({
     openEMFAssessmentEditor: () => calls.push(['emf', true]),
+    openProfileLocationEditor: () => runtime.openProfileLocationEditor(),
   });
 
   const timerId = scheduleRecommendationsTask(() => calls.push(['task']), 125);
@@ -117,6 +118,7 @@ try {
 
   delete runtime.closeModal;
   delete runtime.openProfileLocationEditor;
+  configureRecommendationsRuntime({ openProfileLocationEditor: null });
   delete runtime.openSettingsTab;
   delete runtime.openChatPanel;
   delete runtime.isProductRecsEnabled;

--- a/tests/test-sun-defaults-runtime.js
+++ b/tests/test-sun-defaults-runtime.js
@@ -24,8 +24,6 @@ const runtimeKeys = [
   'window',
   'getSunCoords',
   'getProfileLocation',
-  'openProfileLocationEditor',
-  'openClientList',
   'requestPreciseLocation',
   'navigate',
 ];
@@ -52,9 +50,11 @@ function restoreRuntime() {
 try {
   const calls = [];
   setRuntimeValue('getSunCoords', () => ({ lat: 50.08, lon: 14.42, source: 'profile-precise' }));
-  configureSunDefaultsRuntimeDeps({ getProfileLocation: () => ({ country: 'Czech Republic', zip: '' }) });
-  setRuntimeValue('openProfileLocationEditor', () => calls.push(['profile-location']));
-  setRuntimeValue('openClientList', () => calls.push(['client-list']));
+  configureSunDefaultsRuntimeDeps({
+    getProfileLocation: () => ({ country: 'Czech Republic', zip: '' }),
+    openProfileLocationEditor: () => calls.push(['profile-location']),
+    openClientList: () => calls.push(['client-list']),
+  });
   setRuntimeValue('requestPreciseLocation', () => {
     calls.push(['precise']);
     return Promise.resolve({ lat: 50.1, lon: 14.4 });
@@ -69,7 +69,7 @@ try {
     openSunSetupProfileLocationRuntime() === true &&
     calls.some(call => call[0] === 'profile-location'));
 
-  delete globalThis.openProfileLocationEditor;
+  configureSunDefaultsRuntimeDeps({ openProfileLocationEditor: null });
   assert('openSunSetupProfileLocationRuntime falls back to client list',
     openSunSetupProfileLocationRuntime() === true &&
     calls.some(call => call[0] === 'client-list'));
@@ -85,8 +85,10 @@ try {
     calls.some(call => call[0] === 'navigate' && call[1] === 'light'));
 
   delete globalThis.getSunCoords;
-  configureSunDefaultsRuntimeDeps({ getProfileLocation: () => ({ country: '', zip: '' }) });
-  delete globalThis.openClientList;
+  configureSunDefaultsRuntimeDeps({
+    getProfileLocation: () => ({ country: '', zip: '' }),
+    openClientList: null,
+  });
   delete globalThis.requestPreciseLocation;
   delete globalThis.navigate;
   assert('missing runtime functions return safe fallbacks',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -190,12 +190,13 @@
 
   // Module-only surfaces are verified through their ESM exports. Remaining UI
   // modules below still publish legacy window hooks while migration continues.
-  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, feedbackModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, nostrModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, themeModule, utilsModule, viewsModule] = await Promise.all([
+  const [apiModule, backupModule, cashuWalletModule, changelogModule, chartsModule, clientListModule, contextCardsModule, cryptoModule, cycleModule, dataModule, emfModule, emfRuntimeModule, exportModule, feedbackModule, labContextModule, lensModule, lightToolsModule, mobileDashboardModule, navModule, nostrModule, notesModule, pdfImportModule, piiModule, profileModule, providerPanelsModule, settingsModule, settingsSyncPanelModule, sunContextModule, sunSpectrumModule, supplementsModule, themeModule, utilsModule, viewsModule] = await Promise.all([
     import('../js/api.js'),
     import('../js/backup.js'),
     import('../js/cashu-wallet.js'),
     import('../js/changelog.js'),
     import('../js/charts.js'),
+    import('../js/client-list.js'),
     import('../js/context-cards.js'),
     import('../js/crypto.js'),
     import('../js/cycle.js'),
@@ -390,9 +391,19 @@
     'recordChange','showDietContaminantsModal','openCardTipsModal','loadContextCardTips'
   ];
 
-  // client-list.js (3)
+  // client-list.js (5 exports, 34 former browser globals now module-only)
   const clientListExports = [
-    'openClientList','closeClientList','openClientForm','configureClientListRuntime'
+    'openClientList','closeClientList','openClientForm','openProfileLocationEditor',
+    'configureClientListRuntime'
+  ];
+  const clientListLegacyGlobals = [
+    'openClientList','closeClientList','openClientForm','openProfileLocationEditor',
+    '_clSearch','_clSort','_clStatusFilter','_clTagFilter','_clSelect','_clSaveForm',
+    '_clSetSex','_clUpdateLat','_clTagKeydown','_clRemoveTag','_clBackToList',
+    '_clAvatarChanged','_clRemoveAvatar','_clHaplogroupChanged','_clToggleToolsMenu',
+    '_clCloseMenus','_clToggleMenu','_clEdit','_clPin','_clUnpin','_clFlag','_clUnflag',
+    '_clArchive','_clUnarchive','_clExport','_clExportChat','_clDelete','_clUpdateBMI',
+    '_clHeightUnitChanged','_clGoToHealthMetrics'
   ];
 
   // cycle.js (15, module-only)
@@ -704,6 +715,7 @@
     ['cashu-wallet.js', cashuWalletModule, cashuWalletExports],
     ['changelog.js', changelogModule, changelogExports],
     ['charts.js', chartsModule, chartsExports],
+    ['client-list.js', clientListModule, clientListExports],
     ['context-cards.js', contextCardsModule, contextCardsExports],
     ['crypto.js', cryptoModule, cryptoExports],
     ['cycle.js', cycleModule, cycleExports],
@@ -747,6 +759,9 @@
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of cryptoExports) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
+  for (const name of clientListLegacyGlobals) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
   for (const name of cycleLegacyGlobals) {
@@ -942,7 +957,6 @@
 
   const allModules = {
     'chat.js': chatExports,
-    'client-list.js': clientListExports,
     'nav.js': navGlobals,
     'settings.js': settingsGlobals,
     'views.js': viewsLegacyExports,

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -170,15 +170,12 @@ interface Window {
   nostrDiscoverNodes?: AnyFunction;
   nostrSetSelectedNode?: (url: string) => void;
   openChatPanel: AnyFunction;
-  openClientList?: () => void;
-  closeClientList: () => void;
   openEMFAssessmentEditor?: () => void;
   openSettingsModal: (tab?: string) => void;
   openChatProviderQuiz?: AnyFunction;
   openImportReviewFromSnapshot?: (snapshotId: string) => void;
   pdfjsLib?: unknown;
   openProfileShareModal?: (profileId?: string) => void;
-  openProfileLocationEditor?: AnyFunction;
   quickLogSunSession?: () => Promise<void> | void;
   openDetailedSessionDialog?: AnyFunction;
   requestPreciseLocation?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.230';
+self.APP_VERSION = '1.10.231';


### PR DESCRIPTION
## Summary

- remove the client-list facade's 34 legacy `window` publications
- route nav, recommendations, and Sun setup consumers through explicit module/runtime dependencies
- exercise private client-list behavior through delegated DOM actions instead of browser globals
- remove obsolete publication/redirection helpers and stale global declarations
- add module-only regression coverage for all 34 removed names and bump the cache version to 1.10.231

## Window burden

- Before: **306 unique globals**, **306 publication entries**, **8 publication sites**, **8 dependency families**
- After: **272 unique globals**, **272 publication entries**, **7 publication sites**, **7 dependency families**
- This PR removes **34 unique globals**, **34 publication entries**, **1 complete publication site**, and **1 complete dependency family**.
- **Work remaining: approximately 1–5 focused PRs** to remove or explicitly retain the remaining 272 globals across 7 sites and 7 families.

## Validation

- `./run-tests.sh`
  - module verification: 125 passed
  - Vitest: 398 passed
  - Playwright: 352 passed
  - responsive-theme assertions: 472 passed
- `node tests/test-client-list-runtime.js`: 10 passed
- `node tests/test-client-list-delegated-actions.js`: 38 passed
- focused client-list Vitest coverage: 1 passed
- typecheck, checkjs, quality guardrails, and `git diff --check` passed