### PR TITLE
Remove nav globals

### DIFF
--- a/js/category-customization-runtime.js
+++ b/js/category-customization-runtime.js
@@ -48,7 +48,7 @@ export function navigateCategoryCustomizationRuntime(route, data) {
  * @returns {((data?: any) => void) | null}
  */
 export function getCategoryCustomizationBuildSidebar() {
-  return /** @type {((data?: any) => void) | null} */ (getRuntimeFunction('buildSidebar'));
+  return /** @type {((data?: any) => void) | null} */ (getViewRuntimeFunction('buildSidebar'));
 }
 
 /**

--- a/js/client-list-runtime.js
+++ b/js/client-list-runtime.js
@@ -53,7 +53,7 @@ export function navigateClientListRoute(route) {
 }
 
 export function refreshClientProfileButton() {
-  getRuntimeFunction('renderProfileButton')?.();
+  getViewRuntimeFunction('renderProfileButton')?.();
 }
 
 /**

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -10,7 +10,6 @@ import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
   __WEARABLES_TEST?: boolean,
-  buildSidebar: () => void,
   navigate?: (view: string) => void,
 }} */ (typeof window !== 'undefined' ? window : {});
 const cryptoProfileDeps = {
@@ -20,6 +19,10 @@ const cryptoProfileDeps = {
 function navigateCryptoView(view) {
   const navigate = appWindow.navigate || (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
   navigate?.call(appWindow, view);
+}
+
+function buildCryptoSidebar() {
+  getViewRuntimeFunction('buildSidebar')?.();
 }
 
 export function configureCryptoProfileDeps(deps = {}) {
@@ -1015,7 +1018,7 @@ export function initBroadcastChannel() {
           ensureImportedArray(state.importedData, 'notes');
           ensureImportedArray(state.importedData, 'supplements');
           cryptoProfileDeps.migrateProfileData?.(state.importedData);
-          appWindow.buildSidebar();
+          buildCryptoSidebar();
           // buildSidebar resets the .active class to Dashboard, so source
           // the target view from state.currentView (kept in sync by
           // navigate) rather than re-reading the stale DOM.

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -61,7 +61,6 @@ const SOURCE_LABELS = {
 };
 const appWindow = /** @type {Window & typeof globalThis & {
   navigate?: (category: string) => void,
-  renderProfileButton?: () => void,
   closeModal?: () => void,
 }} */ (typeof window !== 'undefined' ? window : {});
 
@@ -74,6 +73,10 @@ function navigateCycleImportView(category) {
     : (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
   navigate?.(category);
   return typeof navigate === 'function';
+}
+
+function renderCycleProfileButton() {
+  getViewRuntimeFunction('renderProfileButton')?.();
 }
 
 async function openCycleEditorFromImport() {
@@ -112,7 +115,7 @@ function restoreCycleState(snapshot, profileId, { restoreSex = false } = {}) {
   if (restoreSex && state.profileSex !== snapshot.profileSex) {
     state.profileSex = snapshot.profileSex;
     setProfileSex(profileId, snapshot.profileSex || null);
-    appWindow.renderProfileButton?.();
+    renderCycleProfileButton();
   }
 }
 async function persistCycleState() {
@@ -432,7 +435,7 @@ export async function commitCycleImport(parsed, { conflictMode = 'keep-existing'
     if (state.profileSex !== 'female') {
       state.profileSex = 'female';
       setProfileSex(profileId, 'female');
-      appWindow.renderProfileButton?.();
+      renderCycleProfileButton();
     }
     const plan = buildCycleImportPlan(parsed, state.importedData.menstrualCycle, conflictMode);
     const coverage = buildCycleCoverage(plan.mergedPeriods, state.importedData.menstrualCycle?.coverage || null);

--- a/js/data.js
+++ b/js/data.js
@@ -39,7 +39,6 @@ export {
  * @typedef {() => Array<number | null | undefined> | undefined} MarkerValueGetter
  * @typedef {[MarkerValueGetter | 'age' | 'crp', number, number, boolean, number | null, 'ceil' | 'floor' | null, (number | undefined)?]} BortzFeature
  * @typedef {{
- *   buildSidebar: (data?: unknown) => void,
  *   navigate?: (route?: string, data?: unknown) => void,
  *   showDetailModal?: (id: string) => void,
  * }} DataWindowHooks
@@ -50,6 +49,10 @@ const dataWindow = /** @type {Window & typeof globalThis & DataWindowHooks} */ (
 function navigateDataView(route, data) {
   const navigate = dataWindow.navigate || (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
   navigate?.call(dataWindow, route, data);
+}
+
+function buildDataSidebar(data) {
+  getViewRuntimeFunction('buildSidebar')?.(data);
 }
 
 /** @type {{ invalidateLabContextCache: (() => void) | null }} */
@@ -852,7 +855,7 @@ export function setDateRange(range) {
   // re-applies the correct active class. Source the target view from
   // state.currentView (set by navigate) rather than the DOM, since the
   // DOM's active class has just been clobbered by buildSidebar.
-  dataWindow.buildSidebar();
+  buildDataSidebar();
   navigateDataView(state.currentView || 'dashboard');
 }
 
@@ -971,7 +974,7 @@ export function switchUnitSystem(system) {
   // Matches the pattern in toggleAltUnits().
   const openId = state._activeDetailMarkerId;
   const data = getActiveData();
-  dataWindow.buildSidebar(data);
+  buildDataSidebar(data);
   updateHeaderDates(data);
   navigateDataView(state.currentView || 'dashboard', data);
   const showDetailModal = dataWindow.showDetailModal || getViewRuntimeFunction('showDetailModal');
@@ -1036,7 +1039,7 @@ export function switchRangeMode(mode) {
   _afterNextPaint(() => {
     if (token !== _rangeModeRefreshToken || state.rangeMode !== nextMode) return;
     const data = getActiveData();
-    dataWindow.buildSidebar(data);
+    buildDataSidebar(data);
     navigateDataView(state.currentView || 'dashboard', data);
   const showDetailModal = dataWindow.showDetailModal || getViewRuntimeFunction('showDetailModal');
   if (openId && state._activeDetailMarkerId === openId && showDetailModal) {

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -70,7 +70,7 @@ export function navigateDnaRoute(route) {
 }
 
 export function refreshDnaSidebar() {
-  const buildSidebar = getRuntimeFunction('buildSidebar');
+  const buildSidebar = getViewRuntimeFunction('buildSidebar');
   if (!buildSidebar) return;
   try {
     buildSidebar();

--- a/js/dna-window-bindings.js
+++ b/js/dna-window-bindings.js
@@ -13,7 +13,8 @@ export function installDNAWindowBindings(win, deps) {
     _getState: () => state,
     _saveAndRefresh: async () => {
       if (!await saveImportedData()) return false;
-      if (win.buildSidebar) try { win.buildSidebar(); } catch (e) {}
+      const buildSidebar = getViewRuntimeFunction('buildSidebar');
+      if (buildSidebar) try { buildSidebar(); } catch (e) {}
       const navigate = win.navigate || (typeof window !== 'undefined' && win === window
         ? getViewRuntimeFunction('navigate')
         : null);

--- a/js/export.js
+++ b/js/export.js
@@ -542,7 +542,7 @@ export async function loadDemoData(sex = 'male') {
         };
         await saveImportedData({ skipSync: true, reason: 'demo-biology-score-context' });
         const w = /** @type {any} */ (window);
-        if (w.buildSidebar) w.buildSidebar();
+        getViewRuntimeFunction('buildSidebar')?.();
         updateHeaderDates();
         const navigate = w.navigate || getViewRuntimeFunction('navigate');
         if (navigate && state.currentView === 'biology-scores') navigate.call(w, 'biology-scores');

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -43,7 +43,7 @@ export function navigateMarkerDetailRuntime(category, data) {
 
 export function buildMarkerDetailSidebarRuntime() {
   try {
-    getRuntimeFunction('buildSidebar')?.();
+    getViewRuntimeFunction('buildSidebar')?.();
   } catch {
     // Best-effort shell refresh.
   }

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -64,10 +64,3 @@ export function openContextFromNavRuntime() {
 export function openCreateMarkerFromNavRuntime() {
   getNavRuntimeFunction('openCreateMarkerModal')?.();
 }
-
-/**
- * @param {Record<string, any>} globals
- */
-export function exposeNavRuntimeGlobals(globals) {
-  Object.assign(getNavRuntimeScope(), globals);
-}

--- a/js/nav.js
+++ b/js/nav.js
@@ -8,7 +8,6 @@ import { countFlagged } from './marker-analysis.js';
 import { getProfiles } from './profile.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import {
-  exposeNavRuntimeGlobals,
   navigateFromNavRuntime,
   openContextFromNavRuntime,
   openCreateMarkerFromNavRuntime,
@@ -448,11 +447,3 @@ export function closeMobileSidebar() {
   document.getElementById('sidebar-nav')?.classList.remove('mobile-open');
   closeModalOverlay('sidebar-backdrop', { restoreFocus: false });
 }
-
-exposeNavRuntimeGlobals({
-  buildSidebar,
-  renderProfileDropdown,
-  renderProfileButton,
-  toggleMobileSidebar,
-  closeMobileSidebar,
-});

--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -37,7 +37,7 @@ function getRuntimeFunction(name) {
 
 /** @param {unknown} data */
 export function rebuildOnboardingSidebarRuntime(data) {
-  getRuntimeFunction('buildSidebar')?.(data);
+  getViewRuntimeFunction('buildSidebar')?.(data);
 }
 
 /**

--- a/js/pdf-import-review-runtime.js
+++ b/js/pdf-import-review-runtime.js
@@ -71,7 +71,7 @@ export function navigateImportReviewRuntime(route = 'dashboard') {
 export function refreshImportedDataViewsRuntime(route = 'dashboard') {
   if (!getRuntimeWindow()) return false;
   let refreshed = false;
-  const buildSidebar = getRuntimeFunction('buildSidebar');
+  const buildSidebar = getViewRuntimeFunction('buildSidebar');
   if (buildSidebar) {
     buildSidebar();
     refreshed = true;

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -3,6 +3,7 @@
 
 import { handleImportStatusClick, isImportRunning } from './pdf-import-progress.js';
 import { openFeedbackModal } from './feedback.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let shellDelegatesInstalled = false;
 const shellImportDeps = { handleImportStatusClick, isImportRunning };
@@ -63,10 +64,10 @@ function clickFileInput(id) {
 
 function runShellAction(action) {
   if (action === 'toggle-mobile-sidebar') {
-    callShellRuntime('toggleMobileSidebar');
+    getViewRuntimeFunction('toggleMobileSidebar')?.();
     return true;
   } else if (action === 'close-mobile-sidebar') {
-    callShellRuntime('closeMobileSidebar');
+    getViewRuntimeFunction('closeMobileSidebar')?.();
     return true;
   } else if (action === 'trigger-import') {
     if (shellImportDeps.isImportRunning()) {

--- a/js/sun-runtime.js
+++ b/js/sun-runtime.js
@@ -55,7 +55,7 @@ export function getSunDeviceSessionsRuntime() {
 
 export function rebuildSunSidebarRuntime() {
   try {
-    getRuntimeFunction('buildSidebar')?.();
+    getViewRuntimeFunction('buildSidebar')?.();
   } catch {
     // Best-effort compatibility hook.
   }

--- a/js/sync-pull-active-refresh-runtime.js
+++ b/js/sync-pull-active-refresh-runtime.js
@@ -54,7 +54,7 @@ export function refreshPulledChatRuntime() {
 }
 
 export function rebuildPulledSidebarRuntime() {
-  try { getRuntimeFunction('buildSidebar')?.(); } catch {}
+  try { getViewRuntimeFunction('buildSidebar')?.(); } catch {}
 }
 
 /**

--- a/js/sync-pull.js
+++ b/js/sync-pull.js
@@ -18,6 +18,7 @@ import { clearRestoreJoinPending, isRestoreJoinPending } from './sync-identity.j
 import {
   logSyncEvent, updateSyncStatus,
 } from './sync-state.js';
+import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 // These use var + self-preserving defaults because sync.js can be re-entered
 // through app module cycles while sync-pull.js is still evaluating. An early
@@ -290,7 +291,7 @@ export async function onSyncReceived() {
 
     // Rebuild profile dropdown if profiles changed
     if (profilesChanged) {
-      (/** @type {any} */ (window)).renderProfileDropdown?.();
+      getViewRuntimeFunction('renderProfileDropdown')?.();
     }
   } finally {
     _pulling = false;

--- a/js/views-router-runtime.js
+++ b/js/views-router-runtime.js
@@ -40,7 +40,7 @@ export function getViewportScrollPosition() {
 }
 
 export function closeMobileSidebarFromRuntime() {
-  getRuntimeFunction('closeMobileSidebar')?.();
+  getViewRuntimeFunction('closeMobileSidebar')?.();
 }
 
 export function syncImportStatusFabFromRuntime() {

--- a/js/views-runtime-bridge.js
+++ b/js/views-runtime-bridge.js
@@ -10,6 +10,8 @@ export function configureViewRuntime(api = {}) {
   for (const [name, value] of Object.entries(api)) {
     if (typeof value === 'function') {
       viewRuntime[name] = /** @type {(...args: any[]) => any} */ (value);
+    } else if (value === null) {
+      delete viewRuntime[name];
     }
   }
   return previous;

--- a/js/views.js
+++ b/js/views.js
@@ -2,7 +2,13 @@
 // views.js — route facade and compatibility exports
 
 import { getActiveData, destroyAllCharts } from './data.js';
-import { buildSidebar } from './nav.js';
+import {
+  buildSidebar,
+  closeMobileSidebar,
+  renderProfileButton,
+  renderProfileDropdown,
+  toggleMobileSidebar,
+} from './nav.js';
 import { setupDropZone } from './import-drop-zone.js';
 import { createRecommendationActions } from './recommendation-actions.js';
 import { configureViewRuntime } from './views-runtime-bridge.js';
@@ -305,8 +311,12 @@ configureCompareCorrelationViews({
 // ═══════════════════════════════════════════════
 
 configureViewRuntime({
+  buildSidebar,
+  closeMobileSidebar,
   getInitialView,
   navigate,
+  renderProfileButton,
+  renderProfileDropdown,
   showDashboard,
   showLabs,
   showBiologyScoresLens,
@@ -343,6 +353,7 @@ configureViewRuntime({
   completeOnboardingProfile,
   dismissOnboarding,
   showCategory,
+  toggleMobileSidebar,
   renameCategory,
   renameMarker,
   revertMarkerName,

--- a/tests/client-list-runtime.test.js
+++ b/tests/client-list-runtime.test.js
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { state } from '../js/state.js';
 import { configureClientListRuntimeDeps } from '../js/client-list-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let importId = 0;
 
@@ -42,7 +43,7 @@ beforeEach(() => {
   `;
   window.requestAnimationFrame = (fn) => fn();
   globalThis.requestAnimationFrame = window.requestAnimationFrame;
-  window.renderProfileButton = vi.fn();
+  configureViewRuntime({ renderProfileButton: vi.fn() });
   window.showNotification = vi.fn();
   configureClientListRuntimeDeps({ showNotification: window.showNotification });
   window.navigate = vi.fn();
@@ -61,7 +62,7 @@ describe('client list runtime behavior', () => {
     const clientList = await loadClientList();
     const renderProfileButtonSpy = vi.fn();
     const showNotificationSpy = vi.fn();
-    window.renderProfileButton = renderProfileButtonSpy;
+    configureViewRuntime({ renderProfileButton: renderProfileButtonSpy });
     window.showNotification = showNotificationSpy;
     configureClientListRuntimeDeps({ showNotification: showNotificationSpy });
     const topLevelNames = () => [...document.querySelectorAll('.cl-list > .cl-row .cl-row-name')].map(el => el.textContent);

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -5,10 +5,11 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
   await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, viewsModule] = await Promise.all([
+    const [{ state }, dataModule, viewsModule, navModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/views.js'),
+      import('/js/nav.js'),
     ]);
     const originalData = state.importedData;
     const originalSex = state.profileSex;
@@ -24,7 +25,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
         state.profileSex = 'male';
         state.profileDob = '1987-11-22';
         await dataModule.saveImportedData();
-        window.buildSidebar?.();
+        navModule.buildSidebar();
       }
 
       viewsModule.showCategory('biochemistry');

--- a/tests/playwright/biology-scores-dashboard-lens.spec.js
+++ b/tests/playwright/biology-scores-dashboard-lens.spec.js
@@ -5,9 +5,10 @@ async function prepareDemoProfile(page) {
   await page.waitForFunction(() => !!window._labState);
 
   await page.evaluate(async () => {
-    const [{ getActiveProfileId }, dataModule] = await Promise.all([
+    const [{ getActiveProfileId }, dataModule, navModule] = await Promise.all([
       import('/js/profile.js'),
       import('/js/data.js'),
+      import('/js/nav.js'),
     ]);
     const profileId = getActiveProfileId() || localStorage.getItem('labcharts-active-profile') || 'default';
     localStorage.setItem(`labcharts-${profileId}-emptyTour`, 'completed');
@@ -23,7 +24,7 @@ async function prepareDemoProfile(page) {
       const activeData = dataModule.getActiveData();
       state.importedData.biologyScoreContextAI = { summary: 'Context checked for Playwright demo', suggestions: [], fingerprint: buildBiologyScoreContextFingerprint(activeData), fingerprintsByRange: buildBiologyScoreContextFingerprintsByRange(activeData), unlockedRanges: ['all', '1y', '6m', '3m'], range: 'all', updatedAt: Date.now() };
       await dataModule.saveImportedData();
-      window.buildSidebar?.();
+      navModule.buildSidebar();
     }
 
     const { state } = await import('/js/state.js');

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -9,6 +9,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
     const clientList = await import('/js/client-list.js');
     const { configureClientListRuntime } = clientList;
     const profile = await import('/js/profile.js');
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const calls = [];
     const confirmQueue = [];
@@ -71,10 +72,12 @@ test('client list live menu actions dispatch exports share demos and profile sta
       importedData: clone(state.importedData),
       bodyOverflow: document.body.style.overflow,
       storage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
-      renderProfileButton: window.renderProfileButton,
       showConfirmDialog: window.showConfirmDialog,
       inputClick: HTMLInputElement.prototype.click,
     };
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      renderProfileButton: () => calls.push(['render-profile-button']),
+    });
     const openList = async () => {
       clientList.openClientList();
       await waitFor(() => document.getElementById('client-list-overlay')?.classList.contains('show'), 'client list overlay');
@@ -118,7 +121,6 @@ test('client list live menu actions dispatch exports share demos and profile sta
       localStorage.setItem('labcharts-profiles', JSON.stringify(state.profiles));
       localStorage.setItem('labcharts-client-bob-chat-threads', JSON.stringify([{ id: 'thread-a' }]));
       localStorage.setItem('labcharts-client-bob-chat-t_thread-a', JSON.stringify([{ role: 'user', content: 'delete me' }]));
-      window.renderProfileButton = () => calls.push(['render-profile-button']);
       const exportAllDataJSON = () => calls.push(['export-all']);
       const exportClientJSON = (...args) => calls.push(['export-client', ...args]);
       const importDataJSON = file => calls.push(['import-json', file?.name || '']);
@@ -250,7 +252,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
         if (value == null) localStorage.removeItem(key);
         else localStorage.setItem(key, value);
       }
-      window.renderProfileButton = saved.renderProfileButton;
+      viewRuntime.configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
       if (previousClientListRuntime) configureClientListRuntime(previousClientListRuntime);
       window.showConfirmDialog = saved.showConfirmDialog;
       if (previousProfileDeps) profile.configureProfileDeps(previousProfileDeps);
@@ -274,6 +276,7 @@ test('client list form live actions cover health link avatar haplogroup and loca
     const { state } = await import('/js/state.js');
     const clientList = await import('/js/client-list.js');
     const clientListRuntime = await import('/js/client-list-runtime.js');
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const calls = [];
     const previousClientListRuntimeDeps = clientListRuntime.configureClientListRuntimeDeps({
@@ -296,7 +299,6 @@ test('client list form live actions cover health link avatar haplogroup and loca
       importedData: clone(state.importedData),
       storage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
       bodyOverflow: document.body.style.overflow,
-      renderProfileButton: window.renderProfileButton,
       navigate: window.navigate,
       HAPLOGROUP_LIST: window.HAPLOGROUP_LIST,
       setManualHaplogroup: window.setManualHaplogroup,
@@ -305,6 +307,9 @@ test('client list form live actions cover health link avatar haplogroup and loca
       modalOverlayClass: document.getElementById('modal-overlay')?.className,
       hadWearableStrip: !!document.getElementById('wearable-strip'),
     };
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      renderProfileButton: () => calls.push(['render-profile-button']),
+    });
 
     try {
       state.currentProfile = 'client-active';
@@ -333,7 +338,6 @@ test('client list form live actions cover health link avatar haplogroup and loca
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
       localStorage.removeItem('labcharts-ai-paused');
       localStorage.removeItem('labcharts-openrouter-key');
-      window.renderProfileButton = () => calls.push(['render-profile-button']);
       window.navigate = route => calls.push(['navigate', route]);
       window.HAPLOGROUP_LIST = ['H', 'J', 'K'];
       window.setManualHaplogroup = async haplogroup => {
@@ -409,7 +413,7 @@ test('client list form live actions cover health link avatar haplogroup and loca
         if (value == null) localStorage.removeItem(key);
         else localStorage.setItem(key, value);
       }
-      window.renderProfileButton = saved.renderProfileButton;
+      viewRuntime.configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
       clientListRuntime.configureClientListRuntimeDeps(previousClientListRuntimeDeps);
       window.navigate = saved.navigate;
       window.HAPLOGROUP_LIST = saved.HAPLOGROUP_LIST;
@@ -437,6 +441,7 @@ test('client list remaining browser helpers cover filters avatar upload tags and
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
     const clientList = await import('/js/client-list.js');
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const calls = [];
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -461,9 +466,11 @@ test('client list remaining browser helpers cover filters avatar upload tags and
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       bodyOverflow: document.body.style.overflow,
-      renderProfileButton: window.renderProfileButton,
       showNotification: window.showNotification,
     };
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      renderProfileButton: () => calls.push(['render-profile-button']),
+    });
 
     try {
       localStorage.clear();
@@ -516,7 +523,6 @@ test('client list remaining browser helpers cover filters avatar upload tags and
         },
       ];
       localStorage.setItem('labcharts-profiles', JSON.stringify(state.profiles));
-      window.renderProfileButton = () => calls.push(['render-profile-button']);
       window.showNotification = (...args) => calls.push(['notification', ...args]);
 
       clientList.openClientList();
@@ -619,7 +625,7 @@ test('client list remaining browser helpers cover filters avatar upload tags and
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       document.body.style.overflow = saved.bodyOverflow;
-      window.renderProfileButton = saved.renderProfileButton;
+      viewRuntime.configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
       window.showNotification = saved.showNotification;
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -57,10 +57,11 @@ test('category customization covers rename icon and emoji picker browser paths',
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ categoryUrl }) => {
-    const [{ state }, category, categoryRuntime] = await Promise.all([
+    const [{ state }, category, categoryRuntime, viewRuntime] = await Promise.all([
       import('/js/state.js'),
       import(categoryUrl),
       import('/js/category-customization-runtime.js'),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const categorySrc = await fetch(categoryUrl).then(response => response.text());
     const outcomes = {};
@@ -69,13 +70,15 @@ test('category customization covers rename icon and emoji picker browser paths',
     const saved = {
       importedData: clone(state.importedData),
       currentView: state.currentView,
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
     };
     const calls = [];
     let promptValue = null;
     const previousCategoryRuntimeDeps = categoryRuntime.configureCategoryCustomizationRuntimeDeps({
       showPromptDialog: async () => promptValue,
+    });
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: data => calls.push(['fallbackSidebar', !!data?.categories?.lipids]),
     });
 
     try {
@@ -96,7 +99,6 @@ test('category customization covers rename icon and emoji picker browser paths',
       };
       state.currentView = 'dashboard';
       window.navigate = (route, data) => calls.push(['navigate', route, !!data?.categories?.lipids]);
-      window.buildSidebar = data => calls.push(['fallbackSidebar', !!data?.categories?.lipids]);
 
       promptValue = '  Fallback Lipids  ';
       await category.renameCategory('lipids');
@@ -189,10 +191,10 @@ test('category customization covers rename icon and emoji picker browser paths',
       state.importedData = saved.importedData;
       state.currentView = saved.currentView;
       categoryRuntime.configureCategoryCustomizationRuntimeDeps(previousCategoryRuntimeDeps);
-      window.buildSidebar = saved.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       window.navigate = saved.navigate;
       category.configureCategoryCustomization({
-        buildSidebar: saved.buildSidebar || (() => {}),
+        buildSidebar: previousViewRuntime.buildSidebar || (() => {}),
         navigate: saved.navigate || (() => {}),
       });
       document.querySelector('.emoji-picker')?.remove();

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -373,9 +373,10 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
     });
 
     const cryptoStore = await import(cryptoUrl);
-    const [{ state }, profileModule] = await Promise.all([
+    const [{ state }, profileModule, viewRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/profile.js'),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const profileId = `crypto-broadcast-${Date.now()}`;
     const importedKey = profileModule.profileStorageKey(profileId, 'imported');
@@ -393,10 +394,10 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       profile: state.currentProfile,
       view: state.currentView,
       importedData: state.importedData,
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
       storage: Object.fromEntries(keys.map(key => [key, localStorage.getItem(key)])),
     };
+    let previousViewRuntime = null;
 
     try {
       for (const key of keys) localStorage.removeItem(key);
@@ -407,7 +408,9 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
         calls.migrated += 1;
         data.migratedByTest = true;
       } });
-      window.buildSidebar = () => { calls.sidebar += 1; };
+      previousViewRuntime = viewRuntime.configureViewRuntime({
+        buildSidebar: () => { calls.sidebar += 1; },
+      });
       window.navigate = view => { calls.navigated.push(view); };
       await cryptoStore.encryptedSetItem(importedKey, JSON.stringify({
         entries: [{ date: '2026-06-09', markers: { metabolic: { glucose: 5.2 } } }],
@@ -520,8 +523,7 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       state.currentProfile = saved.profile;
       state.currentView = saved.view;
       state.importedData = saved.importedData;
-      if (saved.buildSidebar === undefined) delete window.buildSidebar;
-      else window.buildSidebar = saved.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       if (previousCryptoProfileDeps) cryptoStore.configureCryptoProfileDeps(previousCryptoProfileDeps);
       if (saved.navigate === undefined) delete window.navigate;
       else window.navigate = saved.navigate;

--- a/tests/playwright/cycle-import-browser-coverage.spec.js
+++ b/tests/playwright/cycle-import-browser-coverage.spec.js
@@ -322,7 +322,7 @@ test('Body cycle action opens the contextual cycle picker', async ({ page }, tes
     (await import('/js/views.js')).navigate('body');
     await new Promise(resolve => setTimeout(resolve, 150));
     endTour({ openEmptyChat: false });
-    window.closeMobileSidebar?.();
+    (await import('/js/nav.js')).closeMobileSidebar();
     return id;
   });
 

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -5,13 +5,14 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
   await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, dashboardWidgetRuntime, viewsModule] = await Promise.all([
+    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, dashboardWidgetRuntime, viewsModule, navModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/dashboard-widgets.js'),
       import('/js/context-cards-runtime.js'),
       import('/js/dashboard-widget-runtime.js'),
       import('/js/views.js'),
+      import('/js/nav.js'),
     ]);
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const originalView = state.currentView;
@@ -41,7 +42,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
         state.profileSex = 'male';
         state.profileDob = '1987-11-22';
         await dataModule.saveImportedData();
-        window.buildSidebar?.();
+        navModule.buildSidebar();
       }
 
       viewsModule.closeDashboardWidgetPicker?.();

--- a/tests/playwright/data-browser-coverage.spec.js
+++ b/tests/playwright/data-browser-coverage.spec.js
@@ -24,6 +24,7 @@ test('data browser coverage exercises display toggles range refresh and helpers'
 
   const results = await page.evaluate(async ({ dataUrl }) => {
     const dataMod = await import(dataUrl);
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const state = window._labState;
     const calls = [];
     const outcomes = {};
@@ -52,7 +53,6 @@ test('data browser coverage exercises display toggles range refresh and helpers'
       rangeMode: state.rangeMode,
       activeDetailMarkerId: state._activeDetailMarkerId,
       preserveCategoryCardOrder: clone(state._preserveCategoryCardOrder),
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
       showDetailModal: window.showDetailModal,
       requestAnimationFrame: window.requestAnimationFrame,
@@ -61,10 +61,12 @@ test('data browser coverage exercises display toggles range refresh and helpers'
       phaseOverlay: localStorage.getItem(`labcharts-${profileId}-phaseOverlay`),
       rangeModeStorage: localStorage.getItem(`labcharts-${profileId}-rangeMode`),
     };
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: data => calls.push(['buildSidebar', data?.dates?.length || 0]),
+    });
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
     try {
-      window.buildSidebar = data => calls.push(['buildSidebar', data?.dates?.length || 0]);
       window.navigate = (route, data) => calls.push(['navigate', route, data?.dates?.length || 0]);
       window.showDetailModal = id => calls.push(['showDetailModal', id]);
       window.requestAnimationFrame = callback => {
@@ -219,8 +221,7 @@ test('data browser coverage exercises display toggles range refresh and helpers'
       else state._activeDetailMarkerId = saved.activeDetailMarkerId;
       if (saved.preserveCategoryCardOrder === undefined) delete state._preserveCategoryCardOrder;
       else state._preserveCategoryCardOrder = saved.preserveCategoryCardOrder;
-      if (saved.buildSidebar) window.buildSidebar = saved.buildSidebar;
-      else delete window.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       if (saved.navigate) window.navigate = saved.navigate;
       else delete window.navigate;
       if (saved.showDetailModal) window.showDetailModal = saved.showDetailModal;

--- a/tests/playwright/dna-browser-coverage.spec.js
+++ b/tests/playwright/dna-browser-coverage.spec.js
@@ -187,6 +187,7 @@ test('DNA autosomal import UI coverage exercises preview, confirm, render, and d
     const { state } = await import('/js/state.js');
     const dna = await import(`/js/dna.js?dnaAutosomalCoverage=${Date.now()}-${Math.random()}`);
     const dnaRuntime = await import('/js/dna-runtime.js');
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     let importRunning = false;
     const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps({
       isImportRunning: () => importRunning,
@@ -199,7 +200,9 @@ test('DNA autosomal import UI coverage exercises preview, confirm, render, and d
 
     document.body.innerHTML = '<div id="notification-container"></div><div class="chat-onboard-dna"></div><main id="fixture"></main>';
     const calls = [];
-    window.buildSidebar = () => calls.push('sidebar');
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => calls.push('sidebar'),
+    });
     window.navigate = route => calls.push(`navigate:${route}`);
     window.updateChatNudge = () => calls.push('nudge');
 
@@ -284,6 +287,7 @@ rs999999\t1\t100\tAG
     check('notifications rendered during flow', /DNA import|Imported|health-relevant/.test(toastText));
 
     dnaRuntime.configureDnaRuntimeDeps(previousDnaRuntimeDeps);
+    viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
     return { failures };
   });
 
@@ -309,9 +313,10 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     };
 
     const { state } = await import('/js/state.js');
-    const [dna, dnaRuntime] = await Promise.all([
+    const [dna, dnaRuntime, viewRuntime] = await Promise.all([
       import(`/js/dna.js?dnaMtdnaCoverage=${Date.now()}-${Math.random()}`),
       import('/js/dna-runtime.js'),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps();
 
@@ -322,7 +327,9 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
 
     document.body.innerHTML = '<div id="notification-container"></div><main id="fixture"></main>';
     const calls = [];
-    window.buildSidebar = () => calls.push('sidebar');
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => calls.push('sidebar'),
+    });
     window.navigate = route => calls.push(`navigate:${route}`);
 
     const hapTable = await dna.loadHaplogroupTable();
@@ -393,6 +400,7 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     check('haplogroup list exported', Array.isArray(window.HAPLOGROUP_LIST) && window.HAPLOGROUP_LIST.includes('J'));
 
     dnaRuntime.configureDnaRuntimeDeps(previousDnaRuntimeDeps);
+    viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
     return { failures };
   });
 

--- a/tests/playwright/import-review-browser-coverage.spec.js
+++ b/tests/playwright/import-review-browser-coverage.spec.js
@@ -664,17 +664,20 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
   const results = await page.evaluate(async ({ persistenceUrl }) => {
     const persistence = await import(persistenceUrl);
     const reviewRuntime = await import('/js/pdf-import-review-runtime.js');
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const state = window._labState;
     const outcomes = {};
     const originals = {
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       currentView: state.currentView,
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
     };
     const viewCalls = [];
     const previousReviewRuntime = reviewRuntime.configurePdfImportReviewRuntimeDeps({
       updateHeaderDates: () => { viewCalls.push('updateHeaderDates'); },
+    });
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => { viewCalls.push('buildSidebar'); },
     });
     const waitForPrompt = async () => {
       for (let attempt = 0; attempt < 40; attempt++) {
@@ -692,7 +695,6 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
     };
 
     try {
-      window.buildSidebar = () => { viewCalls.push('buildSidebar'); };
       window.navigate = view => { viewCalls.push(`navigate:${view}`); };
       state.currentView = 'labs';
       state.importedData = {
@@ -759,7 +761,7 @@ test('PDF import persistence covers snapshots removal and date rename prompts', 
     } finally {
       state.importedData = originals.importedData;
       state.currentView = originals.currentView;
-      window.buildSidebar = originals.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       window.navigate = originals.navigate;
       reviewRuntime.configurePdfImportReviewRuntimeDeps(previousReviewRuntime);
       document.getElementById('prompt-dialog-overlay')?.classList.remove('show');

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -55,13 +55,14 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
   await prepareApp(page);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, shell, profile, contextCardsRuntime, views] = await Promise.all([
+    const [{ state }, dataModule, shell, profile, contextCardsRuntime, views, nav] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/lens-page-shell.js'),
       import('/js/profile.js'),
       import('/js/context-cards-runtime.js'),
       import('/js/views.js'),
+      import('/js/nav.js'),
     ]);
     const originalView = state.currentView;
     const originalReimportDNA = window.reimportDNA;
@@ -91,7 +92,7 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
         state.profileSex = 'male';
         state.profileDob = '1987-11-22';
         await dataModule.saveImportedData();
-        window.buildSidebar?.();
+        nav.buildSidebar();
       }
 
       localStorage.removeItem(labsOrderKey);

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -9,10 +9,11 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ editingUrl }) => {
-    const [editing, { state }, data] = await Promise.all([
+    const [editing, { state }, data, viewRuntime] = await Promise.all([
       import(editingUrl),
       import('/js/state.js'),
       import('/js/data.js'),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const outcomes = {};
     const calls = [];
@@ -40,11 +41,13 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       unitSystem: state.unitSystem,
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
     };
     const id = 'proteins_albumin';
     const dotKey = 'proteins.albumin';
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => calls.push(['sidebar']),
+    });
 
     try {
       state.currentProfile = 'marker-detail-default-deps-coverage';
@@ -67,7 +70,6 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
       state.markerRegistry = {
         [id]: active.categories.proteins.markers.albumin,
       };
-      window.buildSidebar = () => calls.push(['sidebar']);
       window.navigate = (category, payload) => calls.push(['navigate', category, payload || null]);
 
       fillManualForm({ date: '2026-06-04', value: '44' });
@@ -92,8 +94,7 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       state.unitSystem = saved.unitSystem;
-      if (saved.buildSidebar) window.buildSidebar = saved.buildSidebar;
-      else delete window.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       if (saved.navigate) window.navigate = saved.navigate;
       else delete window.navigate;
       data.invalidateActiveDataCache();
@@ -114,10 +115,11 @@ test('marker detail editing covers manual values notes delete and revert workflo
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ editingUrl }) => {
-    const [editing, { state }, data] = await Promise.all([
+    const [editing, { state }, data, viewRuntime] = await Promise.all([
       import(editingUrl),
       import('/js/state.js'),
       import('/js/data.js'),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const outcomes = {};
     const calls = [];
@@ -173,11 +175,13 @@ test('marker detail editing covers manual values notes delete and revert workflo
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       unitSystem: state.unitSystem,
-      buildSidebar: window.buildSidebar,
     };
     const id = 'proteins_albumin';
     const dotKey = 'proteins.albumin';
     const note500 = 'manual note '.repeat(80);
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => calls.push(['sidebar']),
+    });
 
     try {
       state.currentProfile = 'marker-detail-coverage';
@@ -204,7 +208,6 @@ test('marker detail editing covers manual values notes delete and revert workflo
       state.markerRegistry = {
         [id]: active.categories.proteins.markers.albumin,
       };
-      window.buildSidebar = () => calls.push(['sidebar']);
       editing.configureMarkerDetailEditing({
         navigate: route => calls.push(['navigate', route]),
         showDetailModal: (modalId, opts) => calls.push(['detail', modalId, opts || null]),
@@ -300,8 +303,7 @@ test('marker detail editing covers manual values notes delete and revert workflo
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       state.unitSystem = saved.unitSystem;
-      if (saved.buildSidebar) window.buildSidebar = saved.buildSidebar;
-      else delete window.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       data.invalidateActiveDataCache();
       editing.configureMarkerDetailEditing({
         navigate: (...args) => window.navigate?.(...args),

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -8,10 +8,11 @@ test('marker detail modal covers custom marker create delete and focus restore p
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ markerUrl }) => {
-    const [{ state }, data, markerModal] = await Promise.all([
+    const [{ state }, data, markerModal, viewRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import(markerUrl),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const outcomes = {};
     const calls = [];
@@ -21,9 +22,11 @@ test('marker detail modal covers custom marker create delete and focus restore p
       importedData: clone(state.importedData),
       currentView: state.currentView,
       activeDetailMarkerId: state._activeDetailMarkerId,
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
     };
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => calls.push(['sidebar']),
+    });
 
     const ensureShell = () => {
       if (!document.getElementById('modal-overlay')) {
@@ -49,7 +52,6 @@ test('marker detail modal covers custom marker create delete and focus restore p
         refOverrides: {},
       };
       data.invalidateActiveDataCache();
-      window.buildSidebar = () => calls.push(['sidebar']);
       window.navigate = route => calls.push(['navigate', route]);
       markerModal.configureMarkerDetailModal({
         navigate: route => calls.push(['dep-navigate', route]),
@@ -151,8 +153,7 @@ test('marker detail modal covers custom marker create delete and focus restore p
       state.importedData = saved.importedData;
       state.currentView = saved.currentView;
       state._activeDetailMarkerId = saved.activeDetailMarkerId;
-      if (saved.buildSidebar) window.buildSidebar = saved.buildSidebar;
-      else delete window.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       if (saved.navigate) window.navigate = saved.navigate;
       else delete window.navigate;
       data.invalidateActiveDataCache();

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -7,7 +7,7 @@ async function prepareApp(page) {
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.buildSidebar === 'function');
+  await page.evaluate(() => import('/js/nav.js'));
   await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
     const profileId = state.currentProfile || localStorage.getItem('labcharts-active-profile') || 'default';
@@ -86,8 +86,8 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
         openContextModal: () => calls.push(['open-context']),
       });
       window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
-      window.buildSidebar(fixtureData);
-      window.renderProfileButton();
+      nav.buildSidebar(fixtureData);
+      nav.renderProfileButton();
       nav.openRecommendationsFromSidebar();
 
       const inlineHandler = document.querySelector('#sidebar-nav [onclick], #sidebar-nav [oninput], #sidebar-nav [onkeydown], #profile-selector [onclick]');
@@ -152,8 +152,8 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       window.openCreateMarkerModal = origOpenCreateMarker;
       if (origGroupStorage == null) localStorage.removeItem('labcharts-navgroup-Hormones');
       else localStorage.setItem('labcharts-navgroup-Hormones', origGroupStorage);
-      window.buildSidebar?.();
-      window.renderProfileButton?.();
+      nav.buildSidebar();
+      nav.renderProfileButton();
     }
   });
 
@@ -166,18 +166,19 @@ test('mobile sidebar uses shared lifecycle scroll lock', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await prepareApp(page);
 
-  const results = await page.evaluate(() => {
+  const results = await page.evaluate(async () => {
+    const nav = await import('/js/nav.js');
     const sidebar = document.getElementById('sidebar-nav');
     const backdrop = document.getElementById('sidebar-backdrop');
     if (!sidebar || !backdrop) throw new Error('mobile sidebar fixture missing');
 
     document.body.style.overflow = 'auto';
-    window.toggleMobileSidebar?.();
+    nav.toggleMobileSidebar();
     const opened = sidebar.classList.contains('mobile-open')
       && backdrop.classList.contains('show')
       && document.body.style.overflow === 'hidden';
 
-    window.closeMobileSidebar?.();
+    nav.closeMobileSidebar();
     const closed = !sidebar.classList.contains('mobile-open')
       && !backdrop.classList.contains('show')
       && document.body.style.overflow === 'auto';

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -224,6 +224,7 @@ test('settings browser coverage renames imported entry dates through the data se
     const dataModule = await import('/js/data.js');
     const reviewRuntime = await import('/js/pdf-import-review-runtime.js');
     const settingsModule = await import('/js/settings.js');
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 80; attempt += 1) {
@@ -239,7 +240,6 @@ test('settings browser coverage renames imported entry dates through the data se
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       currentProfile: state.currentProfile,
       currentView: state.currentView,
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
       storage: localStorage.getItem(`labcharts-${profileId}-imported`),
     };
@@ -249,6 +249,9 @@ test('settings browser coverage renames imported entry dates through the data se
     });
     const originalReviewRuntimeDeps = reviewRuntime.configurePdfImportReviewRuntimeDeps({
       updateHeaderDates: () => calls.push('updateHeaderDates'),
+    });
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => calls.push('buildSidebar'),
     });
 
     try {
@@ -265,7 +268,6 @@ test('settings browser coverage renames imported entry dates through the data se
         },
         changeHistory: [],
       };
-      window.buildSidebar = () => calls.push('buildSidebar');
       window.navigate = view => calls.push(`navigate:${view}`);
 
       document.body.insertAdjacentHTML('beforeend', '<section id="data-entries-section"></section>');
@@ -292,7 +294,7 @@ test('settings browser coverage renames imported entry dates through the data se
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       state.currentView = saved.currentView;
-      window.buildSidebar = saved.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       window.navigate = saved.navigate;
       dataModule.configureDataContextDependencies(originalDataContextDeps);
       reviewRuntime.configurePdfImportReviewRuntimeDeps(originalReviewRuntimeDeps);

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -237,12 +237,13 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ onboardingUrl }) => {
-    const [onboarding, { state }, profile, data, crypto] = await Promise.all([
+    const [onboarding, { state }, profile, data, crypto, viewRuntime] = await Promise.all([
       import(onboardingUrl),
       import('/js/state.js'),
       import('/js/profile.js'),
       import('/js/data.js'),
       import('/js/crypto.js'),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
@@ -267,7 +268,6 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       navigate: window.navigate,
-      buildSidebar: window.buildSidebar,
       openChatPanel: window.openChatPanel,
       toggleChatPanel: window.toggleChatPanel,
       renderChatMessages: window.renderChatMessages,
@@ -275,6 +275,9 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
     };
     const outcomes = {};
     const calls = [];
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: payload => calls.push(['sidebar', !!payload]),
+    });
     const host = document.createElement('div');
     host.id = 'onboarding-coverage-host';
     let cards = null;
@@ -290,7 +293,6 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       onboarding.configureOnboardingView({
         navigate: (route, payload) => calls.push(['navigate', route, !!payload]),
       });
-      window.buildSidebar = payload => calls.push(['sidebar', !!payload]);
 
       const onboardedKey = profile.profileStorageKey(state.currentProfile, 'onboarded');
       localStorage.removeItem(onboardedKey);
@@ -422,8 +424,8 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       state.profileDob = saved.profileDob;
       data.invalidateActiveDataCache();
       onboarding.configureOnboardingView({ navigate: saved.navigate });
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       Object.assign(window, {
-        buildSidebar: saved.buildSidebar,
         openChatPanel: saved.openChatPanel,
         toggleChatPanel: saved.toggleChatPanel,
         renderChatMessages: saved.renderChatMessages,

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -18,6 +18,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
 
   const results = await page.evaluate(async ({ shellActionsUrl }) => {
     const shellActions = await import(shellActionsUrl);
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const calls = [];
     let importRunning = false;
@@ -36,9 +37,11 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       filterThreadList: value => calls.push(['filterThreadList', value]),
       toggleThreadRail: () => calls.push(['toggleThreadRail']),
     });
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      toggleMobileSidebar: () => calls.push(['toggleMobileSidebar']),
+      closeMobileSidebar: () => calls.push(['closeMobileSidebar']),
+    });
     const originalFns = {
-      toggleMobileSidebar: window.toggleMobileSidebar,
-      closeMobileSidebar: window.closeMobileSidebar,
       openProfileShareModal: window.openProfileShareModal,
       openTweaksPanel: window.openTweaksPanel,
       openSettingsModal: window.openSettingsModal,
@@ -196,6 +199,11 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
         && personalitySpace.defaultPrevented === true
         && personalityEscape.defaultPrevented === false;
     } finally {
+      viewRuntime.configureViewRuntime({
+        toggleMobileSidebar: null,
+        closeMobileSidebar: null,
+        ...previousViewRuntime,
+      });
       shellActions.configureShellImportDeps(previousShellImportDeps);
       shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
       shellActions.configureShellChatImageDeps(previousShellChatImageDeps);

--- a/tests/playwright/sun-browser-coverage.spec.js
+++ b/tests/playwright/sun-browser-coverage.spec.js
@@ -68,10 +68,11 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
   await page.goto('/app', { waitUntil: 'load' });
 
   const outcomes = await page.evaluate(async ({ sunUrl, utilsUrl }) => {
-    const [{ state }, sun, utils] = await Promise.all([
+    const [{ state }, sun, utils, viewRuntime] = await Promise.all([
       import('/js/state.js'),
       import(sunUrl),
       import(utilsUrl),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const outcomes = {};
     const profileId = `sun-browser-${Date.now()}`;
@@ -85,10 +86,10 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       profilesState: state.profiles ? JSON.parse(JSON.stringify(state.profiles)) : state.profiles,
       currentProfile: state.currentProfile,
       profiles: localStorage.getItem('labcharts-profiles'),
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
       geolocation: Object.getOwnPropertyDescriptor(navigator, 'geolocation'),
     };
+    const previousViewRuntime = viewRuntime.configureViewRuntime({ buildSidebar: () => {} });
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, attempts = 100) => {
       for (let i = 0; i < attempts; i += 1) {
@@ -157,7 +158,6 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
     };
 
     try {
-      window.buildSidebar = () => {};
       window.navigate = () => {};
 
       state.currentProfile = profileId;
@@ -323,7 +323,7 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       state.currentProfile = saved.currentProfile;
       if (saved.profiles == null) localStorage.removeItem('labcharts-profiles');
       else localStorage.setItem('labcharts-profiles', saved.profiles);
-      window.buildSidebar = saved.buildSidebar;
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       window.navigate = saved.navigate;
       if (saved.geolocation) Object.defineProperty(navigator, 'geolocation', saved.geolocation);
       else delete navigator.geolocation;

--- a/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
+++ b/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
@@ -17,11 +17,12 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ refreshUrl, refreshRuntimeUrl, maintenanceUrl, stateUrl }) => {
-    const [refreshModule, refreshRuntime, maintenance, { state }] = await Promise.all([
+    const [refreshModule, refreshRuntime, maintenance, { state }, viewRuntime] = await Promise.all([
       import(refreshUrl),
       import(refreshRuntimeUrl),
       import(maintenanceUrl),
       import(stateUrl),
+      import('/js/views-runtime-bridge.js'),
     ]);
     const outcomes = {};
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -32,7 +33,6 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
         currentView: state.currentView,
         importedData: clone(state.importedData),
       },
-      buildSidebar: window.buildSidebar,
       navigate: window.navigate,
       loadChatHistory: window.loadChatHistory,
     };
@@ -46,13 +46,15 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
       ensureActiveThread: () => { calls.push('ensureActiveThread'); },
       renderThreadList: () => { calls.push('renderThreadList'); },
     });
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      buildSidebar: () => { calls.push('buildSidebar'); },
+    });
     const debugCalls = [];
     let syncAppliedEvents = 0;
     const onSyncApplied = () => { syncAppliedEvents += 1; };
 
     try {
       window.addEventListener('labcharts-sync-applied', onSyncApplied);
-      window.buildSidebar = () => { calls.push('buildSidebar'); };
       window.navigate = (category, options) => { calls.push({ type: 'navigate', category, options: options || null }); };
       window.loadChatHistory = () => { calls.push('loadChatHistory'); };
 
@@ -151,7 +153,7 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
       state.currentProfile = original.state.currentProfile;
       state.currentView = original.state.currentView;
       state.importedData = original.state.importedData;
-      restoreWindowFn('buildSidebar', original.buildSidebar);
+      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       restoreWindowFn('navigate', original.navigate);
       restoreWindowFn('loadChatHistory', original.loadChatHistory);
       refreshRuntime.configureSyncPullActiveRefreshDeps(previousThreadDeps);

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -45,8 +45,7 @@ function delay(ms) {
 
 async function waitForApp(page) {
   await page.waitForFunction(
-    () => window._labState
-      && typeof window.buildSidebar === 'function',
+    () => !!window._labState,
     null,
     { timeout: 15000 }
   );
@@ -106,7 +105,7 @@ async function seedDemoData(page) {
     window._labState.profileSex = 'male';
     window._labState.profileDob = '1987-11-22';
     await dataModule.saveImportedData();
-    window.buildSidebar?.();
+    (await import('/js/nav.js')).buildSidebar();
     (await import('/js/views.js')).navigate('dashboard');
     window.closeChatPanel?.();
   });
@@ -178,7 +177,7 @@ async function prepareScenario(page, theme, viewport) {
     (await import('/js/views.js')).closeModal();
     window.closeSettingsModal?.();
     window.closeChatPanel?.();
-    window.closeMobileSidebar?.();
+    (await import('/js/nav.js')).closeMobileSidebar();
     document.querySelectorAll('#tour-overlay, #tour-spotlight, #tour-tooltip').forEach(el => el.remove());
     document.querySelectorAll('.modal-overlay.show').forEach(el => el.classList.remove('show'));
     localStorage.removeItem('labcharts-accent-override');
@@ -724,7 +723,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     focused: document.activeElement?.id === 'sidebar-search',
   }));
   assert(testName(theme, viewportName, 'menu opens mobile sidebar'), result.open, JSON.stringify(result));
-  await page.evaluate(() => window.closeMobileSidebar?.());
+  await page.evaluate(async () => (await import('/js/nav.js')).closeMobileSidebar());
   await delay(100);
 
   result = await page.evaluate(() => {

--- a/tests/playwright/views-router-browser-coverage.spec.js
+++ b/tests/playwright/views-router-browser-coverage.spec.js
@@ -22,6 +22,7 @@ test('views router browser coverage exercises route state and scroll restoration
       import(stateUrl),
     ]);
     const routerRuntime = await import('/js/views-router-runtime.js');
+    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const { state } = stateModule;
     const fixture = document.getElementById('fixture');
@@ -29,8 +30,6 @@ test('views router browser coverage exercises route state and scroll restoration
     const originalCurrentView = state.currentView;
     const originalScrollTo = window.scrollTo;
     const originalScrollBy = window.scrollBy;
-    const originalCloseMobileSidebar = window.closeMobileSidebar;
-    const hadCloseMobileSidebar = Object.prototype.hasOwnProperty.call(window, 'closeMobileSidebar');
     const originalScrollX = Object.getOwnPropertyDescriptor(window, 'scrollX');
     const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY');
     const originalPageXOffset = Object.getOwnPropertyDescriptor(window, 'pageXOffset');
@@ -41,6 +40,9 @@ test('views router browser coverage exercises route state and scroll restoration
     const coverageLastViewKey = profileModule.profileStorageKey(coverageProfile, 'lastViewV1');
     const extraLastViewKey = profileModule.profileStorageKey(extraProfile, 'lastViewV1');
     const calls = [];
+    const previousViewRuntime = viewRuntime.configureViewRuntime({
+      closeMobileSidebar: () => calls.push(['closeSidebar']),
+    });
     const previousRouterRuntimeDeps = routerRuntime.configureViewsRouterRuntimeDeps({
       syncImportStatusFab: () => calls.push(['syncFab']),
     });
@@ -93,7 +95,6 @@ test('views router browser coverage exercises route state and scroll restoration
       state.currentView = 'dashboard';
       localStorage.removeItem(coverageLastViewKey);
       localStorage.removeItem(extraLastViewKey);
-      window.closeMobileSidebar = () => calls.push(['closeSidebar']);
       window.scrollTo = arg => {
         scrollToCalls.push(typeof arg === 'object' ? { left: arg.left, top: arg.top, behavior: arg.behavior } : arg);
       };
@@ -274,8 +275,7 @@ test('views router browser coverage exercises route state and scroll restoration
       state.currentView = originalCurrentView;
       window.scrollTo = originalScrollTo;
       window.scrollBy = originalScrollBy;
-      if (hadCloseMobileSidebar) window.closeMobileSidebar = originalCloseMobileSidebar;
-      else delete window.closeMobileSidebar;
+      viewRuntime.configureViewRuntime({ closeMobileSidebar: null, ...previousViewRuntime });
       routerRuntime.configureViewsRouterRuntimeDeps(previousRouterRuntimeDeps);
       restoreDescriptor('scrollX', originalScrollX);
       restoreDescriptor('scrollY', originalScrollY);

--- a/tests/test-category-customization-runtime.js
+++ b/tests/test-category-customization-runtime.js
@@ -65,6 +65,9 @@ try {
     },
   };
   setRuntimeValue('window', browserRuntime);
+  previousViewRuntime = configureViewRuntime({
+    buildSidebar: browserRuntime.buildSidebar.bind(browserRuntime),
+  });
   configureCategoryCustomizationRuntimeDeps({
     showPromptDialog: browserRuntime.showPromptDialog.bind(browserRuntime),
   });
@@ -91,7 +94,8 @@ try {
 
   delete browserRuntime.navigate;
   delete browserRuntime.buildSidebar;
-  previousViewRuntime = configureViewRuntime({
+  configureViewRuntime({
+    buildSidebar: null,
     navigate: route => calls.push(['module-navigate', route]),
   });
   configureCategoryCustomizationRuntimeDeps({ showPromptDialog: null });
@@ -111,7 +115,7 @@ try {
   setRuntimeValue('navigate', route => { globalNavigateCalled = route === 'dashboard'; });
   navigateCategoryCustomizationRuntime('dashboard');
   assert('runtime hooks fall back to globalThis when window is missing', globalNavigateCalled);
-  configureViewRuntime(previousViewRuntime);
+  configureViewRuntime({ buildSidebar: null, navigate: null, ...previousViewRuntime });
 } finally {
   configureCategoryCustomizationRuntimeDeps(originalCategoryCustomizationRuntimeDeps);
   restoreRuntime();

--- a/tests/test-client-list-runtime.js
+++ b/tests/test-client-list-runtime.js
@@ -12,6 +12,7 @@ import {
   setClientManualHaplogroup,
   showClientListNotification,
 } from '../js/client-list-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 const originalClientListRuntimeDeps = configureClientListRuntimeDeps();
 
@@ -26,7 +27,6 @@ console.log('=== Client List Runtime Tests ===\n');
 const runtimeKeys = [
   'HAPLOGROUP_LIST',
   'navigate',
-  'renderProfileButton',
   'showNotification',
   'setManualHaplogroup',
 ];
@@ -37,6 +37,7 @@ const savedAIStorage = {
   openrouterKey: localStorage.getItem('labcharts-openrouter-key'),
   openrouterCachedKey: getCachedKey('labcharts-openrouter-key'),
 };
+let previousViewRuntime = null;
 
 function restoreRuntime() {
   for (const key of runtimeKeys) {
@@ -67,7 +68,9 @@ try {
   assert('navigateClientListRoute delegates to runtime navigate',
     calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard'));
 
-  globalThis.renderProfileButton = () => calls.push(['render-profile-button']);
+  previousViewRuntime = configureViewRuntime({
+    renderProfileButton: () => calls.push(['render-profile-button']),
+  });
   refreshClientProfileButton();
   assert('refreshClientProfileButton delegates to runtime profile refresh',
     calls.some(call => call[0] === 'render-profile-button'));
@@ -105,6 +108,7 @@ try {
     hasClientListAIProvider() === false);
 
 } finally {
+  configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
   configureClientListRuntimeDeps(originalClientListRuntimeDeps);
   restoreRuntime();
 }

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -48,7 +48,7 @@ await import('../js/pii.js');
 const dataModule = await import('../js/data.js');
 const profileModule = await import('../js/profile.js');
 cryptoModule.configureCryptoProfileDeps({ migrateProfileData: profileModule.migrateProfileData });
-await import('../js/nav.js');
+const navModule = await import('../js/nav.js');
 const viewsModule = await import('../js/views.js');
 const exportModule = await import('../js/export.js');
 await import('../js/settings.js');
@@ -329,9 +329,11 @@ for (const name of dataExports) {
   assert(`data.${name} exists`, typeof dataModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));
 }
+for (const name of ['buildSidebar', 'renderProfileDropdown']) {
+  assert(`nav.${name} exists`, typeof navModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
+}
 const expectedExports = [
-  // nav.js
-  'buildSidebar', 'renderProfileDropdown',
   // settings.js
   'openSettingsModal', 'closeSettingsModal',
   // chat.js

--- a/tests/test-dna-runtime.js
+++ b/tests/test-dna-runtime.js
@@ -26,6 +26,7 @@ import {
   updateDnaChatNudge,
 } from '../js/dna-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let passed = 0;
 let failed = 0;
@@ -50,7 +51,6 @@ const runtimeKeys = [
   '_pendingMtDNA',
   '_saveAndRefresh',
   '_snpTableCache',
-  'buildSidebar',
   'handleDNAFile',
   'isDebugMode',
   'navigate',
@@ -63,13 +63,16 @@ const originalError = console.error;
 const originalWarn = console.warn;
 const originalDnaRuntimeDeps = configureDnaRuntimeDeps();
 const originalContextCardsRuntime = configureContextCardsRuntimeCallbacks();
+let previousViewRuntime = null;
 
 try {
   for (const key of runtimeKeys) delete globalThis[key];
 
   const calls = [];
   globalThis.navigate = route => calls.push(['navigate', route]);
-  globalThis.buildSidebar = () => calls.push(['sidebar']);
+  previousViewRuntime = configureViewRuntime({
+    buildSidebar: () => calls.push(['sidebar']),
+  });
   refreshDnaShell('dashboard');
   assert('refreshDnaShell refreshes sidebar then navigates',
     JSON.stringify(calls.slice(0, 2)) === JSON.stringify([['sidebar'], ['navigate', 'dashboard']]));
@@ -79,9 +82,9 @@ try {
   assert('navigateDnaRoute delegates route changes',
     calls.length === 1 && calls[0][0] === 'navigate' && calls[0][1] === 'genome');
 
-  globalThis.buildSidebar = () => {
+  configureViewRuntime({ buildSidebar: () => {
     throw new Error('sidebar failed');
-  };
+  } });
   let sidebarThrew = false;
   try { refreshDnaSidebar(); } catch (_) { sidebarThrew = true; }
   assert('refreshDnaSidebar swallows sidebar refresh errors', !sidebarThrew);
@@ -199,6 +202,7 @@ try {
       globalThis._getState() === state &&
       typeof globalThis._saveAndRefresh === 'function');
 } finally {
+  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   configureDnaRuntimeDeps(originalDnaRuntimeDeps);
   configureContextCardsRuntimeCallbacks(originalContextCardsRuntime);
   console.error = originalError;

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -15,6 +15,7 @@ return (async function() {
   const contextCards = await import('/js/context-cards.js');
   const profile = await import('/js/profile.js');
   const views = await import('/js/views.js');
+  const nav = await import('/js/nav.js');
 
   // ── Profile safety guard: run tests in a throwaway profile ──
   const origProfileId = S.currentProfile;
@@ -36,7 +37,7 @@ return (async function() {
     S.profileSex = 'male';
     S.profileDob = '1987-11-22';
     dataModule.saveImportedData();
-    window.buildSidebar();
+    nav.buildSidebar();
     views.navigate('dashboard');
     await wait(50);
   }

--- a/tests/test-marker-detail-runtime.js
+++ b/tests/test-marker-detail-runtime.js
@@ -19,6 +19,7 @@ import {
   toggleDashboardQuickMarkerPinRuntime,
   uninstallWearableModalFocusTrapRuntime,
 } from '../js/marker-detail-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -31,7 +32,6 @@ console.log('=== Marker Detail Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'navigate',
-  'buildSidebar',
   'isDashboardQuickMarkerPinned',
   'toggleDashboardQuickMarkerPin',
   'renameMarker',
@@ -44,6 +44,7 @@ const runtimeKeys = [
   '_uninstallWearableModalFocusTrap',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+let previousViewRuntime = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -68,7 +69,9 @@ try {
   const snps = [{ rsid: 'rs1801133' }];
 
   setRuntimeValue('navigate', (category, data) => calls.push(['navigate', category, data?.from || '']));
-  setRuntimeValue('buildSidebar', () => calls.push(['sidebar']));
+  previousViewRuntime = configureViewRuntime({
+    buildSidebar: () => calls.push(['sidebar']),
+  });
   setRuntimeValue('isDashboardQuickMarkerPinned', id => id === 'lipids_apob');
   setRuntimeValue('toggleDashboardQuickMarkerPin', id => calls.push(['pin', id]));
   setRuntimeValue('renameMarker', id => calls.push(['rename', id]));
@@ -121,7 +124,7 @@ try {
       renderedRecs === '<section>recs</section>' &&
       anchor.textContent === ':test:');
 
-  setRuntimeValue('buildSidebar', () => { throw new Error('boom'); });
+  configureViewRuntime({ buildSidebar: () => { throw new Error('boom'); } });
   setRuntimeValue('isDashboardQuickMarkerPinned', () => { throw new Error('boom'); });
   setRuntimeValue('_getRelevantSNPs', () => { throw new Error('boom'); });
   setRuntimeValue('isProductRecsEnabled', () => { throw new Error('boom'); });
@@ -134,6 +137,7 @@ try {
   configureMarkerDetailRuntime({ closeEMFInterpretation: () => {} });
 
   delete globalThis.window;
+  configureViewRuntime({ buildSidebar: null });
   const beforeMissingRuntimeCalls = calls.length;
   navigateMarkerDetailRuntime('dashboard');
   buildMarkerDetailSidebarRuntime();
@@ -154,6 +158,7 @@ try {
       missingRuntimeRecs === '');
   configureMarkerDetailRuntime(restoreMarkerDetailRuntime);
 } finally {
+  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   restoreRuntime();
 }
 

--- a/tests/test-nav-delegated-actions.js
+++ b/tests/test-nav-delegated-actions.js
@@ -36,12 +36,12 @@ assert('nav.js installs idempotent click and input delegates',
   navSrc.includes('let navDelegatesInstalled = false') &&
     navSrc.includes("document.addEventListener('click', handleNavActionClick)") &&
     navSrc.includes("document.addEventListener('input', handleNavInput)"));
-assert('nav.js routes browser globals through runtime adapter',
+assert('nav.js routes external actions through adapters and publishes no globals',
   navSrc.includes("from './nav-runtime.js'") &&
     navSrc.includes('navigateFromNavRuntime(') &&
     navSrc.includes('openEMFAssessmentFromNavRuntime()') &&
     navSrc.includes('navActionDeps.openClientList()') &&
-    navSrc.includes('exposeNavRuntimeGlobals({') &&
+    !navSrc.includes('exposeNavRuntimeGlobals') &&
     !/\bwindow(?:\.|\s*\[)/.test(navSrc));
 
 [

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -4,7 +4,6 @@
 import './_node-shim.js';
 import {
   configureNavRuntime,
-  exposeNavRuntimeGlobals,
   navigateFromNavRuntime,
   openContextFromNavRuntime,
   openCreateMarkerFromNavRuntime,
@@ -34,7 +33,6 @@ const runtimeKeys = [
   'navigate',
   'openContextModal',
   'openCreateMarkerModal',
-  'runtimeProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -82,10 +80,6 @@ try {
       && calls.some(call => call[0] === 'navigate' && call[1] === 'labs' && call[2] === true)
       && ['emf', 'report', 'context', 'marker'].every(name => calls.some(call => call[0] === name && call[1] === true)));
 
-  exposeNavRuntimeGlobals({ runtimeProbe: 42 });
-  assert('exposeNavRuntimeGlobals assigns exports to the browser runtime',
-    browserRuntime.runtimeProbe === 42);
-
   for (const key of ['navigate', 'openContextModal', 'openCreateMarkerModal']) {
     delete browserRuntime[key];
   }
@@ -106,9 +100,8 @@ try {
   let globalRoute = '';
   setRuntimeValue('navigate', route => { globalRoute = route; });
   navigateFromNavRuntime('recommendations');
-  exposeNavRuntimeGlobals({ runtimeProbe: 'global' });
   assert('nav runtime falls back to globalThis without window',
-    globalRoute === 'recommendations' && globalThis.runtimeProbe === 'global');
+    globalRoute === 'recommendations');
   configureViewRuntime(previousViewRuntime);
   configureNavRuntime(restoreNavRuntime);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);

--- a/tests/test-onboarding-view-runtime.js
+++ b/tests/test-onboarding-view-runtime.js
@@ -14,6 +14,7 @@ import {
   rebuildOnboardingSidebarRuntime,
   renderOnboardingChatMessagesRuntime,
 } from '../js/onboarding-view-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -25,7 +26,6 @@ console.log('=== Onboarding View Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'buildSidebar',
   'navigate',
   'openChatPanel',
   'toggleChatPanel',
@@ -52,11 +52,14 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  let previousViewRuntime = null;
   const previousDeps = configureOnboardingViewRuntimeDeps({
     createNewThread: () => calls.push(['createNewThread']),
   });
   setRuntimeValue('window', globalThis);
-  setRuntimeValue('buildSidebar', data => calls.push(['buildSidebar', data?.id]));
+  previousViewRuntime = configureViewRuntime({
+    buildSidebar: data => calls.push(['buildSidebar', data?.id]),
+  });
   setRuntimeValue('navigate', (route, data) => calls.push(['navigate', route, data?.id]));
   setRuntimeValue('openChatPanel', () => {
     calls.push(['openChatPanel']);
@@ -101,6 +104,7 @@ try {
     createOnboardingChatThreadRuntime() === false);
 
   delete globalThis.window;
+  configureViewRuntime({ buildSidebar: null });
   const beforeNoWindowCalls = calls.length;
   rebuildOnboardingSidebarRuntime({ id: 'ignored' });
   navigateOnboardingRuntime('labs', { id: 'ignored' });
@@ -112,6 +116,7 @@ try {
       calls.length === beforeNoWindowCalls);
 
   configureOnboardingViewRuntimeDeps(previousDeps);
+  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const onboardingSrc = fs.readFileSync(path.join(root, 'js/onboarding-view.js'), 'utf8');

--- a/tests/test-pdf-import-review-runtime.js
+++ b/tests/test-pdf-import-review-runtime.js
@@ -18,6 +18,7 @@ import {
   startBatchImport,
   takeBatchImportResolve,
 } from '../js/pdf-import-review-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -31,7 +32,6 @@ const RUNTIME_FIELDS = [
   '_batchImportResolve',
   '_batchImportContext',
   '__importReviewDelegatesBound',
-  'buildSidebar',
   'navigate',
   'showPIIDiffViewer',
   'updateHeaderDates',
@@ -39,6 +39,7 @@ const RUNTIME_FIELDS = [
 
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
 const originalReviewRuntimeDeps = configurePdfImportReviewRuntimeDeps();
+let previousViewRuntime = null;
 const originalFieldDescriptors = new Map(
   RUNTIME_FIELDS.map(field => [field, Object.getOwnPropertyDescriptor(globalThis, field)])
 );
@@ -73,7 +74,9 @@ try {
   assert('pending import ref lookup stored in runtime', getPendingImportRefLookup() === refLookup);
 
   const viewCalls = [];
-  globalThis.buildSidebar = function() { viewCalls.push(['sidebar', this === globalThis]); };
+  previousViewRuntime = configureViewRuntime({
+    buildSidebar: () => viewCalls.push(['sidebar']),
+  });
   globalThis.updateHeaderDates = function() { viewCalls.push(['legacy-dates']); };
   globalThis.navigate = function(route) { viewCalls.push(['navigate', route, this === globalThis]); };
   configurePdfImportReviewRuntimeDeps({
@@ -82,7 +85,7 @@ try {
   assert('import persistence view refresh delegates through runtime hooks',
     refreshImportedDataViewsRuntime('labs') === true &&
       JSON.stringify(viewCalls) === JSON.stringify([
-        ['sidebar', true],
+        ['sidebar'],
         ['dates', true],
         ['navigate', 'labs', true],
       ]));
@@ -143,6 +146,7 @@ try {
   showPIIDiffViewerFromRuntime('raw', 'safe');
   assert('no-window writes are no-ops', noWindowResolveCalled === false);
 } finally {
+  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   configurePdfImportReviewRuntimeDeps(originalReviewRuntimeDeps);
   for (const field of RUNTIME_FIELDS) {
     restoreDescriptor(globalThis, field, originalFieldDescriptors.get(field));

--- a/tests/test-sun-runtime.js
+++ b/tests/test-sun-runtime.js
@@ -18,6 +18,7 @@ import {
   renderLightTodayStripRuntime,
   requestSunGeolocationPositionRuntime,
 } from '../js/sun-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 const originalSunRuntimeDeps = configureSunRuntimeDeps();
 
@@ -32,7 +33,6 @@ console.log('=== Sun Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'navigator',
-  'buildSidebar',
   'navigate',
   'renderLightChannelsLive',
   'renderLightTodayStrip',
@@ -43,6 +43,7 @@ const runtimeKeys = [
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const savedImportedData = state.importedData;
+let previousViewRuntime = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -65,7 +66,9 @@ try {
   const calls = [];
   const deviceSessions = [{ id: 'device-1', doses: { vitamin_d: 12 } }];
   state.importedData = { deviceSessions };
-  setRuntimeValue('buildSidebar', () => calls.push(['sidebar']));
+  previousViewRuntime = configureViewRuntime({
+    buildSidebar: () => calls.push(['sidebar']),
+  });
   setRuntimeValue('navigate', (view, options) => calls.push(['navigate', view, options?.scrollAnchor]));
   setRuntimeValue('renderLightChannelsLive', () => calls.push(['channels-live']));
   setRuntimeValue('renderLightTodayStrip', () => '<section>today</section>');
@@ -117,7 +120,7 @@ try {
 
   state.importedData = { deviceSessions: [] };
   setRuntimeValue('renderLightTodayStrip', () => { throw new Error('boom'); });
-  setRuntimeValue('buildSidebar', () => { throw new Error('boom'); });
+  configureViewRuntime({ buildSidebar: () => { throw new Error('boom'); } });
   setRuntimeValue('navigate', () => { throw new Error('boom'); });
   setRuntimeValue('renderLightChannelsLive', () => { throw new Error('boom'); });
   setRuntimeValue('_openChannelOnLightPage', () => { throw new Error('boom'); });
@@ -144,6 +147,7 @@ try {
     rejected === true);
 
   delete globalThis.window;
+  configureViewRuntime({ buildSidebar: null });
   const beforeNoWindowCalls = calls.length;
   rebuildSunSidebarRuntime();
   navigateSunRuntime('light');
@@ -157,6 +161,7 @@ try {
     calls.length === beforeNoWindowCalls &&
     globalThis.sunRuntimeProbe === probe);
 } finally {
+  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   state.importedData = savedImportedData;
   configureSunRuntimeDeps(originalSunRuntimeDeps);
   restoreRuntime();

--- a/tests/test-sync-modal-refresh.js
+++ b/tests/test-sync-modal-refresh.js
@@ -11,6 +11,7 @@ const { configureSyncDelta } = await import('../js/sync-delta.js');
 const { mergePulledImportedData } = await import('../js/sync-pull-merge.js');
 const { refreshActiveProfileAfterPull } = await import('../js/sync-pull-active-refresh.js');
 const { createNavigate } = await import('../js/views-router.js');
+const { configureViewRuntime } = await import('../js/views-runtime-bridge.js');
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -289,12 +290,12 @@ try {
 }
 
 const originalQuerySelector = document.querySelector;
-const originalBuildSidebar = window.buildSidebar;
 const originalNavigate = window.navigate;
 const originalCustomEvent = window.CustomEvent;
 const originalRefreshCurrentProfile = state.currentProfile;
 const originalRefreshCurrentView = state.currentView;
 const originalRefreshImportedData = state.importedData;
+const previousViewRuntime = configureViewRuntime({ buildSidebar: () => {} });
 
 try {
   let toastCount = 0;
@@ -306,7 +307,6 @@ try {
   };
   document.getElementById = id => id === 'notification-container' ? container : null;
   document.querySelector = () => null;
-  window.buildSidebar = () => {};
   window.navigate = () => { navigateCount++; };
   window.CustomEvent = class CustomEvent {
     constructor(type) { this.type = type; }
@@ -360,7 +360,7 @@ try {
 } finally {
   document.getElementById = originalGetElementById;
   document.querySelector = originalQuerySelector;
-  window.buildSidebar = originalBuildSidebar;
+  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   if (originalNavigate) window.navigate = originalNavigate;
   else delete window.navigate;
   window.CustomEvent = originalCustomEvent;

--- a/tests/test-sync-pull-active-refresh-runtime.js
+++ b/tests/test-sync-pull-active-refresh-runtime.js
@@ -12,6 +12,7 @@ import {
   rebuildPulledSidebarRuntime,
   refreshPulledChatRuntime,
 } from '../js/sync-pull-active-refresh-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -24,7 +25,6 @@ console.log('=== Sync Pull Active Refresh Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'loadChatHistory',
-  'buildSidebar',
   'navigate',
   'CustomEvent',
   'dispatchEvent',
@@ -49,6 +49,7 @@ function restoreRuntime() {
 }
 
 const calls = [];
+let previousViewRuntime = null;
 const previousDeps = configureSyncPullActiveRefreshDeps({
   loadChatThreads: () => calls.push(['loadChatThreads']),
   ensureActiveThread: () => calls.push(['ensureActiveThread']),
@@ -58,7 +59,9 @@ const previousDeps = configureSyncPullActiveRefreshDeps({
 try {
   setRuntimeValue('window', globalThis);
   setRuntimeValue('loadChatHistory', () => calls.push(['loadChatHistory']));
-  setRuntimeValue('buildSidebar', () => calls.push(['buildSidebar']));
+  previousViewRuntime = configureViewRuntime({
+    buildSidebar: () => calls.push(['buildSidebar']),
+  });
   setRuntimeValue('navigate', (route, options) => calls.push(['navigate', route, options?.preserveScroll]));
   setRuntimeValue('CustomEvent', class CustomEvent {
     constructor(type) { this.type = type; }
@@ -84,7 +87,7 @@ try {
       'dispatchEvent|labcharts-sync-applied',
     ].join(','));
 
-  setRuntimeValue('buildSidebar', () => { throw new Error('sidebar boom'); });
+  configureViewRuntime({ buildSidebar: () => { throw new Error('sidebar boom'); } });
   assert('sync pull active refresh runtime guards sidebar rebuild failures',
     rebuildPulledSidebarRuntime() === undefined);
 
@@ -94,6 +97,7 @@ try {
     renderThreadList: () => {},
   });
   delete globalThis.window;
+  configureViewRuntime({ buildSidebar: null });
   const beforeNoWindowCalls = calls.length;
   refreshPulledChatRuntime();
   rebuildPulledSidebarRuntime();
@@ -117,6 +121,7 @@ try {
       !/\bwindow(?:\.|\s*\[)/.test(refreshSrc) &&
       swSrc.includes("'/js/sync-pull-active-refresh-runtime.js'"));
 } finally {
+  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   configureSyncPullActiveRefreshDeps(previousDeps);
   restoreRuntime();
 }

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -672,7 +672,7 @@ await import('../js/settings.js');
     syncPullActiveRefreshSrc.includes("from './sync-pull-active-refresh-runtime.js'")
       && !/\bwindow(?:\.|\s*\[)/.test(syncPullActiveRefreshSrc)
       && syncPullActiveRefreshRuntimeSrc.includes('const loaded = syncPullActiveRefreshDeps.loadChatThreads()')
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('buildSidebar')?.()")
+      && syncPullActiveRefreshRuntimeSrc.includes("getViewRuntimeFunction('buildSidebar')?.()")
       && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('navigate')?.(route, options)")
       && syncPullActiveRefreshRuntimeSrc.includes("runtime.dispatchEvent(new runtime.CustomEvent('labcharts-sync-applied'))"));
   assert('service worker precaches sync-pull-active-refresh-runtime.js',
@@ -2951,7 +2951,7 @@ await import('../js/settings.js');
   // import. Lives in sync-pull-active-refresh.js's active-profile post-merge block.
   assert('onSyncReceived rebuilds sidebar after every pull (catches nav items gated on per-row data)',
     /profileId\s*!==\s*state\.currentProfile[\s\S]{0,2400}rebuildPulledSidebarRuntime\(\)[\s\S]{0,1200}shouldRefreshVisibleData/.test(deltaSearchSrc)
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('buildSidebar')?.()"));
+      && syncPullActiveRefreshRuntimeSrc.includes("getViewRuntimeFunction('buildSidebar')?.()"));
 
   const localWithSnps = {
     genetics: {

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -59,7 +59,7 @@ return (async function() {
     S.profileSex = 'male';
     S.profileDob = '1987-11-22';
     dataModule.saveImportedData();
-    window.buildSidebar();
+    navModule.buildSidebar();
     viewsModule.navigate('dashboard');
     await wait(50);
   }
@@ -102,7 +102,7 @@ return (async function() {
   } finally {
     S.importedData = originalImportedData;
     dataModule.saveImportedData();
-    window.buildSidebar();
+    navModule.buildSidebar();
     viewsModule.navigate('dashboard');
     await wait(50);
   }

--- a/tests/test-views-router-runtime.js
+++ b/tests/test-views-router-runtime.js
@@ -13,6 +13,7 @@ import {
   scrollViewportBy,
   syncImportStatusFabFromRuntime,
 } from '../js/views-router-runtime.js';
+import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -34,11 +35,11 @@ const runtimeKeys = [
   'scrollBy',
   'addEventListener',
   'removeEventListener',
-  'closeMobileSidebar',
   'navigate',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const originalViewsRouterRuntimeDeps = configureViewsRouterRuntimeDeps();
+let previousViewRuntime = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -72,7 +73,9 @@ try {
   assert('getViewportScrollPosition falls back to page offsets',
     JSON.stringify(getViewportScrollPosition()) === JSON.stringify({ x: 56, y: 78 }));
 
-  setRuntimeValue('closeMobileSidebar', () => calls.push(['close-sidebar']));
+  previousViewRuntime = configureViewRuntime({
+    closeMobileSidebar: () => calls.push(['close-sidebar']),
+  });
   configureViewsRouterRuntimeDeps({ syncImportStatusFab: () => calls.push(['sync-fab']) });
   setRuntimeValue('navigate', view => calls.push(['navigate', view]));
   closeMobileSidebarFromRuntime();
@@ -147,6 +150,7 @@ try {
     getViewportHeight() === 0 &&
     typeof addViewportInputCancelListeners(() => {}) === 'function');
 } finally {
+  configureViewRuntime({ closeMobileSidebar: null, ...previousViewRuntime });
   configureViewsRouterRuntimeDeps(originalViewsRouterRuntimeDeps);
   restoreRuntime();
 }

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -501,8 +501,8 @@
     'nostrDiscoverNodes','nostrGetSelectedNode','nostrSetSelectedNode','nostrClearNodeCache'
   ];
 
-  // nav.js (5 retained runtime hooks; delegate helpers use ESM exports)
-  const navGlobals = [
+  // nav.js (5 former browser globals and delegate helpers, now module-only)
+  const navLegacyGlobals = [
     'buildSidebar','renderProfileDropdown','renderProfileButton',
     'toggleMobileSidebar','closeMobileSidebar'
   ];
@@ -511,7 +511,7 @@
     'syncSidebarActive','openRecommendationsFromSidebar','installNavActionDelegates'
   ];
   const navModuleExports = [
-    ...navGlobals,
+    ...navLegacyGlobals,
     ...navModuleOnlyExports,
     'configureNavActions',
   ];
@@ -776,6 +776,9 @@
   for (const name of navModuleOnlyExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of navLegacyGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
   for (const name of mobileDashboardExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
@@ -957,7 +960,6 @@
 
   const allModules = {
     'chat.js': chatExports,
-    'nav.js': navGlobals,
     'settings.js': settingsGlobals,
     'views.js': viewsLegacyExports,
   };

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -23,7 +23,6 @@ interface Window {
   _snpTableCache?: unknown;
   APP_VERSION?: string;
   applyAccentOverride?: () => void;
-  buildSidebar?: AnyFunction;
   callClaudeAPI?: (request: {
     system?: string;
     messages: Array<{ role: string; content: string }>;
@@ -61,7 +60,6 @@ interface Window {
   closeChatPanel: () => void;
   closeFeedbackModal: () => void;
   closeImportModal: () => void;
-  closeMobileSidebar: () => void;
   closeReportBuilder?: () => void;
   closeRestoreMnemonicDialog?: () => void;
   closeSettings?: () => void;
@@ -194,7 +192,6 @@ interface Window {
   refreshMobileDashboardActiveTab?: AnyFunction;
   refreshSettingsWearables?: () => void;
   rememberModalTrigger?: () => void;
-  renderProfileButton?: () => void;
   renderChatMessages?: AnyFunction;
   renderMenstrualCycleSection?: AnyFunction;
   renderRecommendationSectionSync?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.231';
+self.APP_VERSION = '1.10.232';


### PR DESCRIPTION
## Summary

- remove the nav facade's 5 legacy `window` publications
- route sidebar, profile, and mobile-nav consumers through the existing module runtime bridge
- update browser and Node fixtures to import nav exports or inject module callbacks instead of manufacturing globals
- remove obsolete nav publication helpers and stale global declarations
- add module-only regression coverage and bump the cache version to 1.10.232

## Window burden

- Before: **272 unique globals**, **272 publication entries**, **7 publication sites**, **7 dependency families**
- After: **267 unique globals**, **267 publication entries**, **6 publication sites**, **6 dependency families**
- This PR removes **5 unique globals**, **5 publication entries**, **1 complete publication site**, and **1 complete dependency family**.
- **Work remaining: approximately 1–4 focused PRs** to remove or explicitly retain the remaining 267 globals across 6 sites and 6 families.

## Validation

- `./run-tests.sh`
  - module verification: 125 passed
  - Vitest: 398 passed
  - Playwright: 352 passed
  - responsive-theme assertions: 472 passed
- focused affected Playwright coverage: 65 passed
- quality guardrails: 7 passed
- typecheck, checkjs, vendored dependency integrity, and `git diff --check` passed