### PR TITLE
Remove recommendation globals

### DIFF
--- a/js/category-page-runtime.js
+++ b/js/category-page-runtime.js
@@ -1,24 +1,24 @@
 // @ts-check
 // category-page-runtime.js - Browser runtime adapters for category page hooks.
 
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : null;
-}
+import {
+  getRecommendationModuleFunction,
+  getRecommendationsCatalogCache,
+  setRecommendationsCatalogCache,
+} from './recommendations-runtime.js';
 
 export function getCategoryPageCatalogSlots() {
-  const runtime = getRuntimeWindow();
-  return runtime?._cachedCatalog?.slots || null;
+  return getRecommendationsCatalogCache()?.slots || null;
 }
 
 export function primeCategoryPageCatalogCache() {
-  const runtime = getRuntimeWindow();
-  if (!runtime || runtime._cachedCatalog || typeof runtime.loadCatalog !== 'function') return null;
-  const catalogPromise = runtime.loadCatalog();
+  if (getRecommendationsCatalogCache()) return null;
+  const loadCatalog = getRecommendationModuleFunction('loadCatalog');
+  if (!loadCatalog) return null;
+  const catalogPromise = loadCatalog();
   if (!catalogPromise || typeof catalogPromise.then !== 'function') return null;
   return catalogPromise.then(catalog => {
-    runtime._cachedCatalog = catalog;
+    setRecommendationsCatalogCache(catalog);
     return catalog;
   });
 }

--- a/js/chat-render-runtime.js
+++ b/js/chat-render-runtime.js
@@ -1,33 +1,14 @@
 // @ts-check
 // chat-render-runtime.js - Browser runtime adapters for chat render hooks.
 
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
-}
-
-/**
- * @param {string} name
- * @returns {any}
- */
-function getRuntimeValue(name) {
-  const runtime = getRuntimeWindow();
-  return runtime ? runtime[name] : undefined;
-}
+import {
+  getRecommendationModuleFunction,
+  getRecommendationsCatalogCache,
+} from './recommendations-runtime.js';
 
 export function isChatRenderProductRecsEnabled() {
   try {
-    return Boolean(getRuntimeFunction('isProductRecsEnabled')?.());
+    return Boolean(getRecommendationModuleFunction('isProductRecsEnabled')?.());
   } catch {
     return false;
   }
@@ -36,8 +17,8 @@ export function isChatRenderProductRecsEnabled() {
 /** @param {unknown} slots */
 export function renderChatRecommendationSections(slots) {
   if (!Array.isArray(slots) || !slots.length || !isChatRenderProductRecsEnabled()) return [];
-  const renderRecommendationSectionSync = getRuntimeFunction('renderRecommendationSectionSync');
-  const catalog = getRuntimeValue('_cachedCatalog');
+  const renderRecommendationSectionSync = getRecommendationModuleFunction('renderRecommendationSectionSync');
+  const catalog = getRecommendationsCatalogCache();
   const catalogSlots = catalog?.slots;
   if (!renderRecommendationSectionSync || !catalogSlots) return [];
   return slots.map(slot => {

--- a/js/chat-send-runtime.js
+++ b/js/chat-send-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // chat-send-runtime.js - Browser runtime adapters for chat send hooks.
 
+import { getRecommendationModuleFunction } from './recommendations-runtime.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -34,13 +36,13 @@ export function getChatSendProviderAttestation(provider) {
 }
 
 export function isChatSendProductRecsEnabled() {
-  return Boolean(getRuntimeFunction('isProductRecsEnabled')?.());
+  return Boolean(getRecommendationModuleFunction('isProductRecsEnabled')?.());
 }
 
 /** @param {string} text */
 export function detectChatSendSupplementSlots(text) {
   if (!isChatSendProductRecsEnabled()) return [];
-  const detectSupplementSlots = getRuntimeFunction('detectSupplementSlots');
+  const detectSupplementSlots = getRecommendationModuleFunction('detectSupplementSlots');
   if (!detectSupplementSlots) return [];
   const slots = detectSupplementSlots(text);
   return Array.isArray(slots) ? slots : [];
@@ -49,13 +51,13 @@ export function detectChatSendSupplementSlots(text) {
 /** @param {string} text */
 export function isChatSendEMFRelevant(text) {
   if (!isChatSendProductRecsEnabled()) return false;
-  return Boolean(getRuntimeFunction('detectEMFRelevance')?.(text));
+  return Boolean(getRecommendationModuleFunction('detectEMFRelevance')?.(text));
 }
 
 export function getChatSendRecommendationRuntime() {
-  const renderRecommendationSection = getRuntimeFunction('renderRecommendationSection');
-  const renderRecommendationSectionSync = getRuntimeFunction('renderRecommendationSectionSync');
-  const loadCatalog = getRuntimeFunction('loadCatalog');
+  const renderRecommendationSection = getRecommendationModuleFunction('renderRecommendationSection');
+  const renderRecommendationSectionSync = getRecommendationModuleFunction('renderRecommendationSectionSync');
+  const loadCatalog = getRecommendationModuleFunction('loadCatalog');
   if (!renderRecommendationSection || !renderRecommendationSectionSync || !loadCatalog) return null;
   return {
     renderRecommendationSection,

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -7,6 +7,7 @@ import { saveImportedData, getActiveData } from './data.js';
 import { hasAIProvider } from './api.js';
 import { openModalOverlay } from './modal-lifecycle.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
+import { getRecommendationModuleFunction } from './recommendations-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
 import {
   appendImportedArrayItem,
@@ -451,15 +452,16 @@ configureLifestyleContextEditors({ recordChange, saveAndRefresh });
 
 // ── Card tips badges (async — waits for catalog) ──
 export async function loadContextCardTips() {
-  const appWindow = /** @type {any} */ (window);
-  if (!appWindow.isProductRecsEnabled || !appWindow.isProductRecsEnabled()) return;
-  if (!appWindow.loadCatalog || !appWindow.getCardSlotKeys) return;
-  await appWindow.loadCatalog();
+  const isProductRecsEnabled = getRecommendationModuleFunction('isProductRecsEnabled');
+  const loadCatalog = getRecommendationModuleFunction('loadCatalog');
+  const getCardSlotKeys = getRecommendationModuleFunction('getCardSlotKeys');
+  if (!isProductRecsEnabled?.() || !loadCatalog || !getCardSlotKeys) return;
+  await loadCatalog();
   const cardKeys = ['sleepRest', 'lightCircadian', 'environment', 'exercise', 'diet', 'stress'];
   for (const key of cardKeys) {
     const el = document.getElementById(`ctx-tips-${key}`);
     if (!el || el.children.length > 0) continue;
-    if (appWindow.getCardSlotKeys(key).length === 0) continue;
+    if (getCardSlotKeys(key).length === 0) continue;
     const badge = document.createElement('span');
     badge.className = 'ctx-tips-badge';
     badge.textContent = 'Tips';
@@ -471,9 +473,9 @@ export async function loadContextCardTips() {
 
 // ── Card tips modal ──
 export function openCardTipsModal(cardKey) {
-  const appWindow = /** @type {any} */ (window);
-  if (!appWindow.renderCardTipsModal) return;
-  const html = appWindow.renderCardTipsModal(cardKey);
+  const renderCardTipsModal = getRecommendationModuleFunction('renderCardTipsModal');
+  if (!renderCardTipsModal) return;
+  const html = renderCardTipsModal(cardKey);
   if (!html) return;
   // Reuse the detail modal overlay
   const overlay = document.getElementById('modal-overlay');

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -17,6 +17,10 @@ import {
 } from './mobile-dashboard.js';
 import { startEmptyTour as defaultStartEmptyTour, startTour as defaultStartTour } from './tour.js';
 import { loadDemoData } from './export.js';
+import {
+  getRecommendationModuleFunction,
+  setRecommendationsCatalogCache,
+} from './recommendations-runtime.js';
 
 let _dashboardWelcomeActionsInstalled = false;
 
@@ -308,9 +312,9 @@ export function createDashboardPageView(deps) {
     loadContextCardTips();
     loadCommitHash();
     // Preload catalog so rec sections and sorting use it immediately
-    const catalogPromise = callDashboardPageRuntime('loadCatalog');
+    const catalogPromise = getRecommendationModuleFunction('loadCatalog')?.();
     if (catalogPromise && typeof catalogPromise.then === 'function') {
-      catalogPromise.then(c => { dashboardPageRuntime()._cachedCatalog = c; });
+      catalogPromise.then(setRecommendationsCatalogCache);
     }
 
     // Auto-trigger guided tour on first populated dashboard visit as a fallback

--- a/js/dashboard-recommendation-widget.js
+++ b/js/dashboard-recommendation-widget.js
@@ -7,6 +7,12 @@ import { getEffectiveRangeForDate, getLatestValueIndex } from './marker-analysis
 import { computeBiologyScores } from './biology-scores.js';
 import { profileStorageKey } from './profile.js';
 import { escapeAttr, escapeHTML, formatValue, getStatus } from './utils.js';
+import {
+  getRecommendationModuleFunction,
+  getRecommendationsCatalogCache,
+  getRecommendationsSnpTable,
+  setRecommendationsCatalogCache,
+} from './recommendations-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let dashboardRecommendationDelegatesInstalled = false;
@@ -105,16 +111,16 @@ export function createDashboardRecommendationWidget({
   }
 
   function getCachedRecommendationsCatalog() {
-    const catalog = getDashboardRecommendationRuntimeValue('_cachedCatalog');
+    const catalog = getRecommendationsCatalogCache();
     return catalog?.slots ? catalog : null;
   }
 
   function refreshRecommendationsWhenCatalogReady() {
-    const loadCatalog = getDashboardRecommendationRuntimeValue('loadCatalog');
+    const loadCatalog = getRecommendationModuleFunction('loadCatalog');
     if (_recommendationsLoadPromise || typeof loadCatalog !== 'function') return;
     _recommendationsLoadPromise = loadCatalog()
       .then(catalog => {
-        if (catalog) dashboardRecommendationRuntime()._cachedCatalog = catalog;
+        setRecommendationsCatalogCache(catalog);
         refreshRecommendationSurfaces();
       })
       .finally(() => { _recommendationsLoadPromise = null; });
@@ -147,7 +153,7 @@ export function createDashboardRecommendationWidget({
   }
 
   function getGlobalRecommendationCandidates(ctx, catalog, { includeDismissed = false } = {}) {
-    if (!callDashboardRecommendationRuntime('isProductRecsEnabled') || !catalog?.slots) return [];
+    if (!getRecommendationModuleFunction('isProductRecsEnabled')?.() || !catalog?.slots) return [];
     const dismissed = getRecommendationStateSet('dismissed');
     const saved = getRecommendationStateSet('saved');
     const trendById = new Map((ctx.trendAlerts || []).map(alert => [alert.id, alert]));
@@ -254,9 +260,10 @@ export function createDashboardRecommendationWidget({
       }
     }
 
-    if (typeof getDashboardRecommendationRuntimeValue('buildDNAHints') === 'function' && getDashboardRecommendationRuntimeValue('_snpTableCache')) {
+    const buildDNAHints = getRecommendationModuleFunction('buildDNAHints');
+    if (buildDNAHints && getRecommendationsSnpTable()) {
       for (const slotKey of Object.keys(catalog.slots)) {
-        const hints = callDashboardRecommendationRuntime('buildDNAHints', slotKey);
+        const hints = buildDNAHints(slotKey);
         if (!hints?.length) continue;
         add({
           id: `genome:${slotKey}:dna`,
@@ -306,7 +313,7 @@ export function createDashboardRecommendationWidget({
   }
 
   function renderDashboardRecommendationsWidget(ctx) {
-    if (!callDashboardRecommendationRuntime('isProductRecsEnabled')) {
+    if (!getRecommendationModuleFunction('isProductRecsEnabled')?.()) {
       return `<button type="button" class="db-correlation-empty" ${dashboardRecommendationActionAttrs('open-privacy-settings')}>
         <strong>Recommendations are off</strong>
         <span>Enable Tips & Recommendations in settings to show data-linked next steps.</span>

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -11,6 +11,7 @@ import { loadContextCardTips } from './context-cards.js';
 import { openChatPanel } from './chat-panel.js';
 import { toggleMobileSidebar } from './nav.js';
 import { loadCatalog } from './recommendations.js';
+import { setRecommendationsCatalogCache } from './recommendations-runtime.js';
 import { createDashboardPageView } from './dashboard-page-view.js';
 import { configureLensPageShell } from './lens-page-shell.js';
 import { createDashboardWidgetRegistry } from './dashboard-widgets.js';
@@ -229,7 +230,7 @@ export function createDashboardViewComposition({
     toggleMobileSidebar,
     loadContextCardTips,
     loadCatalog,
-    cacheCatalog: catalog => { globalThis._cachedCatalog = catalog; },
+    cacheCatalog: setRecommendationsCatalogCache,
   });
 
   return {

--- a/js/light-devices-runtime.js
+++ b/js/light-devices-runtime.js
@@ -3,6 +3,7 @@
 
 import { state } from './state.js';
 import { showPromptDialog } from './utils.js';
+import { getRecommendationModuleFunction } from './recommendations-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const lightDevicesRuntimeDeps = { showPromptDialog };
@@ -83,7 +84,7 @@ export function getLightDeviceChannelDisplay(fallback = {}) {
 }
 
 export function loadLightDevicesCatalog() {
-  return getRuntimeFunction('loadCatalog')?.();
+  return getRecommendationModuleFunction('loadCatalog')?.();
 }
 
 /**
@@ -91,7 +92,7 @@ export function loadLightDevicesCatalog() {
  * @param {string} slug
  */
 export function renderLightDeviceAffiliateRowRuntime(catalog, slug) {
-  return getRuntimeFunction('renderLightDeviceAffiliateRow')?.(catalog, slug) || '';
+  return getRecommendationModuleFunction('renderLightDeviceAffiliateRow')?.(catalog, slug) || '';
 }
 
 /** @param {string} channel */

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -2,6 +2,7 @@
 // marker-detail-runtime.js - Browser runtime adapters for marker detail modal hooks.
 
 import { closeEMFInterpretation } from './emf-runtime.js';
+import { getRecommendationModuleFunction } from './recommendations-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const markerDetailRuntimeDeps = {
@@ -105,14 +106,14 @@ export function getRelevantSNPsRuntime(dotKey) {
 
 export function isProductRecsEnabledRuntime() {
   try {
-    return getRuntimeFunction('isProductRecsEnabled')?.() === true;
+    return getRecommendationModuleFunction('isProductRecsEnabled')?.() === true;
   } catch {
     return false;
   }
 }
 
 export function hasRecommendationSectionRendererRuntime() {
-  return getRuntimeFunction('renderRecommendationSection') !== null;
+  return getRecommendationModuleFunction('renderRecommendationSection') !== null;
 }
 
 /**
@@ -121,7 +122,7 @@ export function hasRecommendationSectionRendererRuntime() {
  * @returns {Promise<string>}
  */
 export async function renderRecommendationSectionRuntime(markerKey, options) {
-  const renderRecommendations = getRuntimeFunction('renderRecommendationSection');
+  const renderRecommendations = getRecommendationModuleFunction('renderRecommendationSection');
   if (!renderRecommendations) return '';
   const html = await renderRecommendations(markerKey, options);
   return typeof html === 'string' ? html : '';

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -9,6 +9,44 @@ const recommendationsRuntimeDeps = {
   openProfileLocationEditor: null,
 };
 
+/** @type {Record<string, (...args: any[]) => any>} */
+const recommendationModuleBridge = Object.create(null);
+let recommendationsCatalogCache = null;
+
+/** @param {Record<string, unknown>} api */
+export function configureRecommendationModuleBridge(api = {}) {
+  /** @type {Record<string, ((...args: any[]) => any) | null>} */
+  const previous = { ...recommendationModuleBridge };
+  for (const name of Object.keys(api)) {
+    if (!(name in previous)) previous[name] = null;
+  }
+  for (const [name, value] of Object.entries(api)) {
+    if (typeof value === 'function') {
+      recommendationModuleBridge[name] = /** @type {(...args: any[]) => any} */ (value);
+    } else if (value === null) {
+      delete recommendationModuleBridge[name];
+    }
+  }
+  return previous;
+}
+
+/** @param {string} name */
+export function getRecommendationModuleFunction(name) {
+  return typeof recommendationModuleBridge[name] === 'function'
+    ? recommendationModuleBridge[name]
+    : null;
+}
+
+export function getRecommendationsCatalogCache() {
+  return recommendationsCatalogCache;
+}
+
+/** @param {any} catalog */
+export function setRecommendationsCatalogCache(catalog) {
+  recommendationsCatalogCache = catalog || null;
+  return recommendationsCatalogCache;
+}
+
 export function configureRecommendationsRuntime(deps = {}) {
   const previous = { ...recommendationsRuntimeDeps };
   if (typeof deps.openEMFAssessmentEditor === 'function') {
@@ -46,20 +84,20 @@ export function getRecommendationsSnpTable() {
 
 export function isRecommendationsProductRecsEnabled() {
   try {
-    return Boolean(getRuntimeFunction('isProductRecsEnabled')?.());
+    return Boolean(getRecommendationModuleFunction('isProductRecsEnabled')?.());
   } catch {
     return false;
   }
 }
 
 export async function loadRecommendationsCatalogRuntime() {
-  const loadCatalog = getRuntimeFunction('loadCatalog');
+  const loadCatalog = getRecommendationModuleFunction('loadCatalog');
   if (!loadCatalog) return null;
   return await loadCatalog();
 }
 
 export async function renderRecommendationsDetailSection(slotKey, options) {
-  const renderRecommendationSection = getRuntimeFunction('renderRecommendationSection');
+  const renderRecommendationSection = getRecommendationModuleFunction('renderRecommendationSection');
   if (!renderRecommendationSection) return '';
   return await renderRecommendationSection(slotKey, options);
 }
@@ -111,12 +149,4 @@ export function scheduleRecommendationsTask(callback, delayMs = 0) {
     return null;
   }
   return schedule(callback, delayMs);
-}
-
-/** @param {Record<string, unknown>} exports */
-export function registerRecommendationsRuntimeExports(exports) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return false;
-  Object.assign(runtime, exports);
-  return true;
 }

--- a/js/recommendations.js
+++ b/js/recommendations.js
@@ -6,12 +6,13 @@ import { state } from './state.js';
 import { findGenotypeInfo, findSnpHint } from './dna.js';
 import {
   closeRecommendationsModal,
+  configureRecommendationModuleBridge,
   getRecommendationsSnpTable,
   openRecommendationsEmfAssessment,
   openRecommendationsLocationEditor,
   openRecommendationsPrivacySettings,
-  registerRecommendationsRuntimeExports,
   scheduleRecommendationsTask,
+  setRecommendationsCatalogCache,
 } from './recommendations-runtime.js';
 import {
   _addUTMParams,
@@ -51,6 +52,7 @@ export {
   _resolveCouponForRegion,
   _resolveHomepageForRegion,
   _resolveProductUrlForRegion,
+  copyCouponCode,
   getEMFMeters,
   getEMFProductsForMitigations,
   getLightDeviceProduct,
@@ -59,6 +61,7 @@ export {
   hasSeenDisclosure,
   isProductRecsEnabled,
   markDisclosureSeen,
+  markDisclosureSeen as markRecDisclosureSeen,
   recActionAttrs,
   recommendDeviceProductsForChannelDeficit,
   regionLabel,
@@ -125,16 +128,25 @@ export function initRecommendationDelegates() {
 }
 
 export async function loadCatalog() {
-  if (_catalog !== undefined) return _catalog;
+  if (_catalog !== undefined) {
+    setRecommendationsCatalogCache(_catalog);
+    return _catalog;
+  }
   if (_catalogPromise) return _catalogPromise;
   _catalogPromise = (async () => {
     try {
       const res = await fetch('data/recommendations.json');
-      if (!res.ok) { _catalog = null; return null; }
+      if (!res.ok) {
+        _catalog = null;
+        setRecommendationsCatalogCache(null);
+        return null;
+      }
       _catalog = await res.json();
+      setRecommendationsCatalogCache(_catalog);
       return _catalog;
     } catch {
       _catalog = null;
+      setRecommendationsCatalogCache(null);
       return null;
     } finally {
       _catalogPromise = null;
@@ -658,14 +670,12 @@ export function detectWearableTrendSlots(summary) {
 }
 
 // ═══════════════════════════════════════════════
-// WINDOW EXPORTS
+// CYCLE-SAFE MODULE BRIDGE
 // ═══════════════════════════════════════════════
 initRecommendationDelegates();
 
-registerRecommendationsRuntimeExports({
+configureRecommendationModuleBridge({
   isProductRecsEnabled,
-  setProductRecsEnabled,
-  markRecDisclosureSeen: markDisclosureSeen,
   renderRecommendationSection,
   renderRecommendationSectionSync,
   detectSupplementSlots,
@@ -673,16 +683,6 @@ registerRecommendationsRuntimeExports({
   buildDNAHints,
   getCardSlotKeys,
   renderCardTipsModal,
-  loadEMFCatalog,
-  getEMFMeters,
-  getEMFProductsForMitigations,
-  renderEMFMeterRecs,
-  renderEMFMitigationRecs,
   detectEMFRelevance,
-  detectMitigationsInText,
-  getLightDeviceProduct,
   renderLightDeviceAffiliateRow,
-  recommendDeviceProductsForChannelDeficit,
-  renderChannelDeficitDeviceRecs,
-  copyCouponCode,
 });

--- a/tests/playwright/chart-card-recs-browser-coverage.spec.js
+++ b/tests/playwright/chart-card-recs-browser-coverage.spec.js
@@ -41,7 +41,10 @@ test('chart card recommendation browser coverage handles badges reorder clicks a
   const results = await page.evaluate(async ({ chartCardRecsUrl }) => {
     window.__chartRecNotifications = [];
     window.__chartRecDetailCalls = [];
-    const chartCardRecs = await import(chartCardRecsUrl);
+    const [chartCardRecs, recommendationRuntime] = await Promise.all([
+      import(chartCardRecsUrl),
+      import('/js/recommendations-runtime.js'),
+    ]);
     const outcomes = {};
 
     const fixture = document.getElementById('fixture');
@@ -63,31 +66,37 @@ test('chart card recommendation browser coverage handles badges reorder clicks a
     const badgeTexts = () => Array.from(document.querySelectorAll('.ctx-tips-badge')).map(badge => badge.textContent);
 
     renderCards();
-    window.isProductRecsEnabled = () => false;
-    window.loadCatalog = () => { throw new Error('loadCatalog should not run when recs are disabled'); };
+    recommendationRuntime.configureRecommendationModuleBridge({
+      isProductRecsEnabled: () => false,
+      loadCatalog: () => { throw new Error('loadCatalog should not run when recs are disabled'); },
+    });
     await chartCardRecs.loadChartCardRecs();
     outcomes.disabledProductRecsReturnBeforeLoadingCatalog =
       document.querySelectorAll('.ctx-tips-badge').length === 0
       && window.__chartRecNotifications.length === 0;
 
-    window.isProductRecsEnabled = () => true;
-    delete window.loadCatalog;
+    recommendationRuntime.configureRecommendationModuleBridge({
+      isProductRecsEnabled: () => true,
+      loadCatalog: null,
+    });
     await chartCardRecs.loadChartCardRecs();
     outcomes.missingCatalogLoaderReturnsWithoutMutatingCards =
       document.querySelectorAll('.ctx-tips-badge').length === 0;
 
-    window.loadCatalog = async () => ({ slots: null });
+    recommendationRuntime.configureRecommendationModuleBridge({ loadCatalog: async () => ({ slots: null }) });
     await chartCardRecs.loadChartCardRecs();
     outcomes.catalogWithoutSlotsReturnsWithoutMutatingCards =
       document.querySelectorAll('.ctx-tips-badge').length === 0;
 
     localStorage.removeItem('labcharts-rec-nudge-seen');
-    window.loadCatalog = async () => ({
-      slots: {
-        'lipids.apob': {},
-        'biochemistry.glucose': {},
-        'hormones.cortisol': {},
-      },
+    recommendationRuntime.configureRecommendationModuleBridge({
+      loadCatalog: async () => ({
+        slots: {
+          'lipids.apob': {},
+          'biochemistry.glucose': {},
+          'hormones.cortisol': {},
+        },
+      }),
     });
     let bubbledClicks = 0;
     document.getElementById('card-apob').addEventListener('click', () => { bubbledClicks += 1; });

--- a/tests/playwright/chat-render-browser-coverage.spec.js
+++ b/tests/playwright/chat-render-browser-coverage.spec.js
@@ -9,10 +9,11 @@ test('chat render browser coverage handles lens sources and rich transcript UI',
   await page.waitForSelector('#chat-messages');
 
   const results = await page.evaluate(async ({ chatRenderUrl }) => {
-    const [{ state }, chatRender, chatActions] = await Promise.all([
+    const [{ state }, chatRender, chatActions, recommendationRuntime] = await Promise.all([
       import('/js/state.js'),
       import(chatRenderUrl),
       import('/js/chat-actions.js'),
+      import('/js/recommendations-runtime.js'),
     ]);
     const outcomes = {};
     const messages = document.getElementById('chat-messages');
@@ -23,10 +24,9 @@ test('chat render browser coverage handles lens sources and rich transcript UI',
       messagesHTML: messages?.innerHTML,
       messagesId: messages?.id,
       panelClass: panel?.className,
-      isProductRecsEnabled: window.isProductRecsEnabled,
-      renderRecommendationSectionSync: window.renderRecommendationSectionSync,
-      cachedCatalog: window._cachedCatalog,
     };
+    const savedCatalog = recommendationRuntime.getRecommendationsCatalogCache();
+    let previousRecommendationBridge = null;
     let emfOpens = 0;
     const restoreChatActions = chatActions.configureChatMessageActionDeps({
       openEMFAssessmentEditor: () => { emfOpens += 1; },
@@ -54,20 +54,22 @@ test('chat render browser coverage handles lens sources and rich transcript UI',
         messages.id = saved.messagesId || 'chat-messages';
       }
 
-      window.isProductRecsEnabled = () => true;
-      window._cachedCatalog = {
+      previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
+        isProductRecsEnabled: () => true,
+        renderRecommendationSectionSync: (slot, { label, maxProducts }) => `
+          <div class="rec-disclosure-banner">Disclosure for ${slot}</div>
+          <section class="rec-section" data-max="${maxProducts}">
+            <h3 class="rec-section-header">${label}</h3>
+            <p>${slot}</p>
+          </section>
+        `,
+      });
+      recommendationRuntime.setRecommendationsCatalogCache({
         slots: {
           'emf.bedroom': { label: 'Bedroom EMF' },
           'sleep.blackout': { label: 'Blackout setup' },
         },
-      };
-      window.renderRecommendationSectionSync = (slot, { label, maxProducts }) => `
-        <div class="rec-disclosure-banner">Disclosure for ${slot}</div>
-        <section class="rec-section" data-max="${maxProducts}">
-          <h3 class="rec-section-header">${label}</h3>
-          <p>${slot}</p>
-        </section>
-      `;
+      });
       state.chatHistory = [
         { joined: true, joinIcon: '*', joinName: 'Dr <Ada>' },
         { role: 'user', hidden: true, content: 'Hidden setup should not render' },
@@ -158,12 +160,10 @@ test('chat render browser coverage handles lens sources and rich transcript UI',
         messages.innerHTML = saved.messagesHTML || '';
       }
       if (panel && saved.panelClass != null) panel.className = saved.panelClass;
-      if (saved.isProductRecsEnabled === undefined) delete window.isProductRecsEnabled;
-      else window.isProductRecsEnabled = saved.isProductRecsEnabled;
-      if (saved.renderRecommendationSectionSync === undefined) delete window.renderRecommendationSectionSync;
-      else window.renderRecommendationSectionSync = saved.renderRecommendationSectionSync;
-      if (saved.cachedCatalog === undefined) delete window._cachedCatalog;
-      else window._cachedCatalog = saved.cachedCatalog;
+      if (previousRecommendationBridge) {
+        recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
+      recommendationRuntime.setRecommendationsCatalogCache(savedCatalog);
       chatActions.configureChatMessageActionDeps(restoreChatActions);
     }
 

--- a/tests/playwright/context-cards-browser-coverage.spec.js
+++ b/tests/playwright/context-cards-browser-coverage.spec.js
@@ -14,9 +14,10 @@ test('context cards browser coverage exercises notes save dots and tips', async 
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ cardsUrl }) => {
-    const [{ state }, cards] = await Promise.all([
+    const [{ state }, cards, recommendationRuntime] = await Promise.all([
       import('/js/state.js'),
       import(cardsUrl),
+      import('/js/recommendations-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const outcomes = {};
@@ -26,14 +27,11 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       closeModal: window.closeModal,
       navigate: window.navigate,
       onContextCardSaved: window.onContextCardSaved,
-      isProductRecsEnabled: window.isProductRecsEnabled,
-      loadCatalog: window.loadCatalog,
-      getCardSlotKeys: window.getCardSlotKeys,
-      renderCardTipsModal: window.renderCardTipsModal,
       aiProvider: localStorage.getItem('labcharts-ai-provider'),
       aiPaused: localStorage.getItem('labcharts-ai-paused'),
       detailsOpen: sessionStorage.getItem('welcome-details-open'),
     };
+    let previousRecommendationBridge = null;
     let host = null;
     let injectedNav = null;
     let details = null;
@@ -128,10 +126,12 @@ test('context cards browser coverage exercises notes save dots and tips', async 
         && toasts().some(text => text.includes('Stress profile saved'));
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
 
-      window.isProductRecsEnabled = () => true;
-      window.loadCatalog = async () => calls.push(['catalog']);
-      window.getCardSlotKeys = key => key === 'diet' ? ['protein'] : [];
-      window.renderCardTipsModal = key => `<div class="tips-modal" data-card="${key}">Tips for ${key}</div>`;
+      previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
+        isProductRecsEnabled: () => true,
+        loadCatalog: async () => calls.push(['catalog']),
+        getCardSlotKeys: key => key === 'diet' ? ['protein'] : [],
+        renderCardTipsModal: key => `<div class="tips-modal" data-card="${key}">Tips for ${key}</div>`,
+      });
       host.innerHTML = cards.renderProfileContextCards();
       await cards.loadContextCardTips();
       const dietBadge = document.querySelector('#ctx-tips-diet .ctx-tips-badge');
@@ -147,6 +147,9 @@ test('context cards browser coverage exercises notes save dots and tips', async 
         'triggerDNAFilePicker',
         'loadContextCardTips',
       ].every(name => typeof cards[name] === 'function' && !(name in window));
+      outcomes.recommendationHooksStayModuleOnly = [
+        'isProductRecsEnabled', 'loadCatalog', 'getCardSlotKeys', 'renderCardTipsModal',
+      ].every(name => !(name in window));
     } finally {
       state.importedData = saved.importedData;
       if (saved.closeModal) window.closeModal = saved.closeModal;
@@ -155,14 +158,9 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       else delete window.navigate;
       if (saved.onContextCardSaved) window.onContextCardSaved = saved.onContextCardSaved;
       else delete window.onContextCardSaved;
-      if (saved.isProductRecsEnabled) window.isProductRecsEnabled = saved.isProductRecsEnabled;
-      else delete window.isProductRecsEnabled;
-      if (saved.loadCatalog) window.loadCatalog = saved.loadCatalog;
-      else delete window.loadCatalog;
-      if (saved.getCardSlotKeys) window.getCardSlotKeys = saved.getCardSlotKeys;
-      else delete window.getCardSlotKeys;
-      if (saved.renderCardTipsModal) window.renderCardTipsModal = saved.renderCardTipsModal;
-      else delete window.renderCardTipsModal;
+      if (previousRecommendationBridge) {
+        recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
       if (saved.aiProvider == null) localStorage.removeItem('labcharts-ai-provider');
       else localStorage.setItem('labcharts-ai-provider', saved.aiProvider);
       if (saved.aiPaused == null) localStorage.removeItem('labcharts-ai-paused');

--- a/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
@@ -16,10 +16,11 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ recommendationWidgetUrl }) => {
-    const [widgetModule, stateModule, profileModule] = await Promise.all([
+    const [widgetModule, stateModule, profileModule, recommendationRuntime] = await Promise.all([
       import(recommendationWidgetUrl),
       import('/js/state.js'),
       import('/js/profile.js'),
+      import('/js/recommendations-runtime.js'),
     ]);
     const outcomes = {};
     const { state } = stateModule;
@@ -27,15 +28,13 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
     const originalView = state.currentView;
     const originalMarkerRegistry = state.markerRegistry;
     const savedWindow = {
-      isProductRecsEnabled: window.isProductRecsEnabled,
-      loadCatalog: window.loadCatalog,
-      _cachedCatalog: window._cachedCatalog,
       getSessions: window.getSessions,
       rollingChannelTotals: window.rollingChannelTotals,
       detectWearableTrendSlots: window.detectWearableTrendSlots,
-      buildDNAHints: window.buildDNAHints,
       _snpTableCache: window._snpTableCache,
     };
+    const savedCatalog = recommendationRuntime.getRecommendationsCatalogCache();
+    let previousRecommendationBridge = null;
     const fixture = document.getElementById('fixture');
     const calls = [];
     const profileId = 'dashboardRecommendationCoverage';
@@ -106,7 +105,16 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
       state.currentView = 'dashboard';
       state.markerRegistry = {};
       removeRecommendationKeys();
-      window.isProductRecsEnabled = () => productRecsEnabled;
+      previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
+        isProductRecsEnabled: () => productRecsEnabled,
+        buildDNAHints: slotKey => slotKey === 'genome.mthfr'
+          ? [{ gene: 'MTHFR', text: 'MTHFR variant suggests methylation support.' }]
+          : [],
+        loadCatalog: () => {
+          loadCatalogCalls += 1;
+          return new Promise(resolve => { resolveCatalog = resolve; });
+        },
+      });
       window.getSessions = () => [];
       window.rollingChannelTotals = () => ({ circadian: 0 });
       window.detectWearableTrendSlots = () => [{
@@ -114,14 +122,7 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
         reason: 'Wearable sleep trend is deteriorating.',
       }];
       window._snpTableCache = { rows: [{ id: 'rs1801133' }] };
-      window.buildDNAHints = slotKey => slotKey === 'genome.mthfr'
-        ? [{ gene: 'MTHFR', text: 'MTHFR variant suggests methylation support.' }]
-        : [];
-      window.loadCatalog = () => {
-        loadCatalogCalls += 1;
-        return new Promise(resolve => { resolveCatalog = resolve; });
-      };
-      window._cachedCatalog = null;
+      recommendationRuntime.setRecommendationsCatalogCache(null);
 
       const widget = widgetModule.createDashboardRecommendationWidget({
         markerHasData: nextMarker => Array.isArray(nextMarker?.values) && nextMarker.values.some(v => v !== null),
@@ -152,7 +153,7 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
       await Promise.resolve();
       await Promise.resolve();
       outcomes.catalogRefreshUpdatesDashboardAndRecommendationsPage =
-        window._cachedCatalog === catalog
+        recommendationRuntime.getRecommendationsCatalogCache() === catalog
         && fixture.querySelector('.dashboard-widget-body')?.innerHTML.includes('rec-next-widget')
         && calls.some(call => call.join('|') === 'showRecommendations|true');
 
@@ -227,7 +228,7 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
         && !compactCard.includes('Hidden when compact')
         && !compactCard.includes('Dismiss');
 
-      window._cachedCatalog = { slots: {} };
+      recommendationRuntime.setRecommendationsCatalogCache({ slots: {} });
       const emptyHtml = widget.renderDashboardRecommendationsWidget(activeCtx);
       const customEmptyHtml = widget.renderRecommendationsEmpty('Nothing <ready>');
       outcomes.emptyStatesRenderSafeFallbackActions =
@@ -241,6 +242,10 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
       state.currentView = originalView;
       state.markerRegistry = originalMarkerRegistry;
       fixture.innerHTML = '';
+      if (previousRecommendationBridge) {
+        recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
+      recommendationRuntime.setRecommendationsCatalogCache(savedCatalog);
       for (const [key, value] of Object.entries(savedWindow)) {
         restoreWindowProperty(key, value);
       }

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -257,6 +257,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const { profileStorageKey } = await import('/js/profile.js');
     const { dashboardBiometricSelectionKey, dashboardWidgetStorageKey } = await import('/js/dashboard-widgets.js');
     const viewsModule = await import('/js/views.js');
+    const recommendationRuntime = await import('/js/recommendations-runtime.js');
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, timeout = 1500) => {
       const started = Date.now();
@@ -286,12 +287,9 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       },
     };
     const savedFns = {
-      isProductRecsEnabled: window.isProductRecsEnabled,
-      loadCatalog: window.loadCatalog,
       detectWearableTrendSlots: window.detectWearableTrendSlots,
       rollingChannelTotals: window.rollingChannelTotals,
       getSessions: window.getSessions,
-      renderRecommendationSection: window.renderRecommendationSection,
       openChatPanel: window.openChatPanel,
       openSettingsModal: window.openSettingsModal,
       showDetailModal: window.showDetailModal,
@@ -310,8 +308,8 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       importedData: state.importedData,
       currentView: state.currentView,
     };
-    const hadCachedCatalog = Object.prototype.hasOwnProperty.call(window, '_cachedCatalog');
-    const originalCachedCatalog = window._cachedCatalog;
+    const originalCachedCatalog = recommendationRuntime.getRecommendationsCatalogCache();
+    let previousRecommendationBridge = null;
     let realNavigate;
 
     try {
@@ -374,19 +372,21 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     localStorage.removeItem(recDismissedKey);
     localStorage.removeItem(biometricKey);
 
-    window.isProductRecsEnabled = () => true;
-    delete window._cachedCatalog;
-    window.loadCatalog = async () => {
-      await delay(10);
-      return catalog;
-    };
+    previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
+      isProductRecsEnabled: () => true,
+      loadCatalog: async () => {
+        await delay(10);
+        return catalog;
+      },
+      renderRecommendationSection: async slotKey => `<div class="rec-detail-coverage">Options for ${slotKey}</div>`,
+    });
+    recommendationRuntime.setRecommendationsCatalogCache(null);
     window.detectWearableTrendSlots = () => [{
       slotKey: 'body.sleepRecovery',
       reason: 'Resting heart rate is elevated and HRV is below baseline.',
     }];
     window.rollingChannelTotals = () => ({ circadian: 0 });
     window.getSessions = () => [];
-    window.renderRecommendationSection = async slotKey => `<div class="rec-detail-coverage">Options for ${slotKey}</div>`;
     window.openChatPanel = prompt => calls.push(['chat', prompt]);
     window.openSettingsModal = panel => calls.push(['settings', panel]);
     window.showDetailModal = id => calls.push(['detail', id]);
@@ -574,8 +574,10 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       state.profileDob = originalState.profileDob;
       state.importedData = originalState.importedData;
       state.currentView = originalState.currentView;
-      if (hadCachedCatalog) window._cachedCatalog = originalCachedCatalog;
-      else delete window._cachedCatalog;
+      if (previousRecommendationBridge) {
+        recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
+      recommendationRuntime.setRecommendationsCatalogCache(originalCachedCatalog);
       for (const [name, original] of Object.entries(savedFns)) {
         if (hadFns[name]) window[name] = original;
         else delete window[name];

--- a/tests/playwright/light-devices-browser-coverage.spec.js
+++ b/tests/playwright/light-devices-browser-coverage.spec.js
@@ -31,12 +31,13 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
   });
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data, store, ai, lightDevices] = await Promise.all([
+    const [{ state }, data, store, ai, lightDevices, recommendationRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/light-devices-store.js'),
       import('/js/light-device-ai-analysis.js'),
       import('/js/light-devices.js'),
+      import('/js/recommendations-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -65,10 +66,9 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       navigate: window.navigate,
       showConfirmDialog: window.showConfirmDialog,
       maybeAnalyzeDeviceSessionAfterFinish: ai.maybeAnalyzeDeviceSessionAfterFinish,
-      loadCatalog: window.loadCatalog,
-      renderLightDeviceAffiliateRow: window.renderLightDeviceAffiliateRow,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
+    let previousRecommendationBridge = null;
     const outcomes = {};
     const calls = [];
     const preset = {
@@ -123,8 +123,10 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       store.configureLightDevicesStore({
         maybeAnalyzeDeviceSessionAfterFinish: session => calls.push(['analyze', session.id]),
       });
-      window.loadCatalog = async () => ({ products: [] });
-      window.renderLightDeviceAffiliateRow = (_catalog, slug) => `<a class="affiliate-test">${slug}</a>`;
+      previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
+        loadCatalog: async () => ({ products: [] }),
+        renderLightDeviceAffiliateRow: (_catalog, slug) => `<a class="affiliate-test">${slug}</a>`,
+      });
 
       state.currentProfile = 'light-devices-browser-coverage';
       state.currentView = 'light';
@@ -302,10 +304,9 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       store.configureLightDevicesStore({
         maybeAnalyzeDeviceSessionAfterFinish: saved.maybeAnalyzeDeviceSessionAfterFinish || (() => {}),
       });
-      if (saved.loadCatalog) window.loadCatalog = saved.loadCatalog;
-      else delete window.loadCatalog;
-      if (saved.renderLightDeviceAffiliateRow) window.renderLightDeviceAffiliateRow = saved.renderLightDeviceAffiliateRow;
-      else delete window.renderLightDeviceAffiliateRow;
+      if (previousRecommendationBridge) {
+        recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
       Element.prototype.scrollIntoView = saved.scrollIntoView;
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -791,6 +791,7 @@ test('light devices cover session detail edit log active card and rendered list 
   const results = await page.evaluate(async ({ devicesUrl, silhouetteUrl }) => {
     const lightDevices = await import(devicesUrl);
     const lightDevicesRuntime = await import('/js/light-devices-runtime.js');
+    const recommendationRuntime = await import('/js/recommendations-runtime.js');
     const silhouette = await import(silhouetteUrl);
     const { profileStorageKey } = await import('/js/profile.js');
     const blobStorage = await import('/js/blob-storage.js');
@@ -806,8 +807,6 @@ test('light devices cover session detail edit log active card and rendered list 
       formatChannelUnit: window.formatChannelUnit,
       CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
       _openChannelOnLightPage: window._openChannelOnLightPage,
-      loadCatalog: window.loadCatalog,
-      renderLightDeviceAffiliateRow: window.renderLightDeviceAffiliateRow,
       navigate: window.navigate,
       renderBodySilhouette: window.renderBodySilhouette,
       bindBodySilhouette: window.bindBodySilhouette,
@@ -815,6 +814,10 @@ test('light devices cover session detail edit log active card and rendered list 
     const calls = [];
     const previousLightDevicesRuntimeDeps = lightDevicesRuntime.configureLightDevicesRuntimeDeps({
       showPromptDialog: async () => '17',
+    });
+    const previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
+      loadCatalog: async () => ({ items: [] }),
+      renderLightDeviceAffiliateRow: (_catalog, slug) => `<a class="affiliate-test">${slug}</a>`,
     });
 
     try {
@@ -877,8 +880,6 @@ test('light devices cover session detail edit log active card and rendered list 
       lightDevices.configureLightDevices({
         renderDeviceSessionAIDetail: () => '<section class="device-ai-detail-test">Device AI</section>',
       });
-      window.loadCatalog = async () => ({ items: [] });
-      window.renderLightDeviceAffiliateRow = (_catalog, slug) => `<a class="affiliate-test">${slug}</a>`;
       window.navigate = route => calls.push(['navigate', route]);
       window.renderBodySilhouette = silhouette.renderBodySilhouette;
       window.bindBodySilhouette = silhouette.bindBodySilhouette;
@@ -967,6 +968,7 @@ test('light devices cover session detail edit log active card and rendered list 
       else localStorage.setItem(importedStorageKey, originalImportedLocalValue);
       lightDevices.configureLightDevices({ renderDeviceSessionAIDetail: () => '' });
       lightDevicesRuntime.configureLightDevicesRuntimeDeps(previousLightDevicesRuntimeDeps);
+      recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
       Object.assign(window, savedWindow);
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -670,9 +670,10 @@ test('marker detail modal covers default deps descriptions alt units and bio age
   await page.waitForSelector('#modal-overlay', { state: 'attached' });
 
   const results = await page.evaluate(async ({ modalUrl }) => {
-    const [modal, markerRuntime, { state }, data] = await Promise.all([
+    const [modal, markerRuntime, recommendationRuntime, { state }, data] = await Promise.all([
       import(modalUrl),
       import('/js/marker-detail-runtime.js'),
+      import('/js/recommendations-runtime.js'),
       import('/js/state.js'),
       import('/js/data.js'),
     ]);
@@ -701,8 +702,6 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       'renameMarker',
       'revertMarkerName',
       'askAIAboutMarker',
-      'renderRecommendationSection',
-      'isProductRecsEnabled',
       '_getRelevantSNPs',
       '_uninstallWearableModalFocusTrap',
     ];
@@ -715,6 +714,10 @@ test('marker detail modal covers default deps descriptions alt units and bio age
     const albuminKey = 'proteins.albumin';
     const restoreMarkerRuntime = markerRuntime.configureMarkerDetailRuntime({
       closeEMFInterpretation: () => calls.push(['close-emf']),
+    });
+    const restoreRecommendationRuntime = recommendationRuntime.configureRecommendationModuleBridge({
+      isProductRecsEnabled: () => true,
+      renderRecommendationSection: async id => `<div class="coverage-rec">rec ${id}</div>`,
     });
 
     try {
@@ -759,9 +762,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       window.renameMarker = id => calls.push(['rename', id]);
       window.revertMarkerName = id => calls.push(['revert-name', id]);
       window.askAIAboutMarker = id => calls.push(['ask-ai', id]);
-      window.isProductRecsEnabled = () => true;
       window._getRelevantSNPs = () => [];
-      window.renderRecommendationSection = async id => `<div class="coverage-rec">rec ${id}</div>`;
       window._uninstallWearableModalFocusTrap = () => calls.push(['uninstall-focus']);
 
       localStorage.setItem('labcharts-marker-desc', JSON.stringify({
@@ -826,6 +827,11 @@ test('marker detail modal covers default deps descriptions alt units and bio age
         else delete window[key];
       }
       markerRuntime.configureMarkerDetailRuntime(restoreMarkerRuntime);
+      recommendationRuntime.configureRecommendationModuleBridge({
+        isProductRecsEnabled: null,
+        renderRecommendationSection: null,
+        ...restoreRecommendationRuntime,
+      });
       data.invalidateActiveDataCache();
       modal.configureMarkerDetailModal({
         navigate: (category, payload) => window.navigate?.(category, payload),

--- a/tests/playwright/recommendation-actions-browser-coverage.spec.js
+++ b/tests/playwright/recommendation-actions-browser-coverage.spec.js
@@ -17,7 +17,10 @@ test('recommendation actions browser coverage handles detail modal discussion an
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ actionsUrl }) => {
-    const { createRecommendationActions } = await import(actionsUrl);
+    const [{ createRecommendationActions }, recommendationRuntime] = await Promise.all([
+      import(actionsUrl),
+      import('/js/recommendations-runtime.js'),
+    ]);
     const outcomes = {};
     const fixture = document.getElementById('fixture');
     const waitForModalSettled = () => new Promise(resolve => setTimeout(resolve, 0));
@@ -65,9 +68,9 @@ test('recommendation actions browser coverage handles detail modal discussion an
     };
 
     const saved = {
-      renderRecommendationSection: window.renderRecommendationSection,
       openChatPanel: window.openChatPanel,
     };
+    const previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge();
 
     try {
       fixture.innerHTML = '';
@@ -77,10 +80,12 @@ test('recommendation actions browser coverage handles detail modal discussion an
         && renderCalls.length === 0;
 
       let shell = renderShell();
-      window.renderRecommendationSection = async (slotKey, options) => {
-        renderCalls.push({ kind: 'render', slotKey, options });
-        return '<section class="recommendation-section">Loaded options</section>';
-      };
+      recommendationRuntime.configureRecommendationModuleBridge({
+        renderRecommendationSection: async (slotKey, options) => {
+          renderCalls.push({ kind: 'render', slotKey, options });
+          return '<section class="recommendation-section">Loaded options</section>';
+        },
+      });
       actions.openRecommendationDetail('vitamins.d', '<Unsafe & Label>', 'low');
       const loadingHtml = shell.modal.innerHTML;
       await waitForModalSettled();
@@ -97,7 +102,7 @@ test('recommendation actions browser coverage handles detail modal discussion an
           && call.options.markerStatus === 'low');
 
       shell = renderShell();
-      window.renderRecommendationSection = async () => '';
+      recommendationRuntime.configureRecommendationModuleBridge({ renderRecommendationSection: async () => '' });
       actions.openRecommendationDetail('missing.slot', 'Missing section');
       await waitForModalSettled();
       outcomes.openRecommendationDetailUsesEmptyFallbackWhenRendererReturnsBlank =
@@ -105,9 +110,9 @@ test('recommendation actions browser coverage handles detail modal discussion an
         && shell.modal.innerHTML.includes('No recommendation details available for this slot.');
 
       shell = renderShell();
-      window.renderRecommendationSection = async () => {
-        throw new Error('catalog unavailable');
-      };
+      recommendationRuntime.configureRecommendationModuleBridge({
+        renderRecommendationSection: async () => { throw new Error('catalog unavailable'); },
+      });
       actions.openRecommendationDetail('broken.slot', '');
       await waitForModalSettled();
       outcomes.openRecommendationDetailUsesErrorFallbackWhenRendererRejects =
@@ -115,7 +120,7 @@ test('recommendation actions browser coverage handles detail modal discussion an
         && shell.modal.innerHTML.includes('Could not load recommendation details.');
 
       shell = renderShell();
-      delete window.renderRecommendationSection;
+      recommendationRuntime.configureRecommendationModuleBridge({ renderRecommendationSection: null });
       actions.openRecommendationDetail('undefined.renderer', 'Undefined renderer');
       await waitForModalSettled();
       outcomes.openRecommendationDetailHandlesMissingRendererAsEmptyFallback =
@@ -153,8 +158,10 @@ test('recommendation actions browser coverage handles detail modal discussion an
 
       outcomes.allOutcomesReached = true;
     } finally {
-      if (saved.renderRecommendationSection === undefined) delete window.renderRecommendationSection;
-      else window.renderRecommendationSection = saved.renderRecommendationSection;
+      recommendationRuntime.configureRecommendationModuleBridge({
+        renderRecommendationSection: null,
+        ...previousRecommendationBridge,
+      });
       if (saved.openChatPanel === undefined) delete window.openChatPanel;
       else window.openChatPanel = saved.openChatPanel;
     }

--- a/tests/playwright/recommendations-browser-coverage.spec.js
+++ b/tests/playwright/recommendations-browser-coverage.spec.js
@@ -221,11 +221,6 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       'renderChannelDeficitDeviceRecs',
       'copyCouponCode',
     ];
-    const savedRecommendationWindowExports = recommendationWindowKeys.map(key => ({
-      key,
-      hadOwn: Object.prototype.hasOwnProperty.call(window, key),
-      value: window[key],
-    }));
     const rec = await import(recUrl);
     const recommendationsRuntime = await import(runtimeUrl);
     const savedRecommendationsRuntime = recommendationsRuntime.configureRecommendationsRuntime({
@@ -243,7 +238,6 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       openSettingsTab: window.openSettingsTab,
       clipboard: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
       setTimeout: window.setTimeout,
-      recommendationWindowExports: savedRecommendationWindowExports,
     };
     const outcomes = {};
     const host = document.createElement('div');
@@ -306,9 +300,9 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       const [catalogA, catalogB] = await Promise.all([rec.loadCatalog(), rec.loadCatalog()]);
       outcomes.loadCatalogDedupes = catalogA === catalogB && !!catalogA?.slots?.magnesium;
       outcomes.loadEMFCatalogUsesUnifiedCatalog = (await rec.loadEMFCatalog()) === catalogA;
-      outcomes.windowExportsRegistered = typeof window.renderRecommendationSection === 'function'
-        && typeof window.copyCouponCode === 'function'
-        && typeof window.detectEMFRelevance === 'function';
+      outcomes.recommendationExportsStayModuleOnly = recommendationWindowKeys.every(key =>
+        typeof rec[key] === 'function' && !(key in window)
+      );
 
       outcomes.settingToggleRoundTrips = rec.isProductRecsEnabled() === true;
       rec.markDisclosureSeen();
@@ -377,7 +371,7 @@ test('recommendations browser coverage exercises catalog renderers detectors and
         return 1;
       };
       const couponBtn = host.querySelector('.rec-coupon-code');
-      window.copyCouponCode(couponBtn);
+      rec.copyCouponCode(couponBtn);
       await wait(0);
       outcomes.copyCouponUsesClipboard = copiedCode === 'SK12'
         && couponBtn?.dataset.flashing === '1'
@@ -483,10 +477,6 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       restoreWindowProp('_snpTableCache', saved.snpTable);
       recommendationsRuntime.configureRecommendationsRuntime(savedRecommendationsRuntime);
       restoreWindowProp('openSettingsTab', saved.openSettingsTab);
-      for (const { key, hadOwn, value } of saved.recommendationWindowExports) {
-        if (hadOwn) window[key] = value;
-        else delete window[key];
-      }
       window.setTimeout = saved.setTimeout;
       if (saved.clipboard) Object.defineProperty(navigator, 'clipboard', saved.clipboard);
       else delete navigator.clipboard;

--- a/tests/test-category-page-runtime.js
+++ b/tests/test-category-page-runtime.js
@@ -5,6 +5,10 @@ import {
   getCategoryPageCatalogSlots,
   primeCategoryPageCatalogCache,
 } from '../js/category-page-runtime.js';
+import {
+  configureRecommendationModuleBridge,
+  setRecommendationsCatalogCache,
+} from '../js/recommendations-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -14,11 +18,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Category Page Runtime Tests ===\n');
 
-const runtimeKeys = [
-  'window',
-  '_cachedCatalog',
-  'loadCatalog',
-];
+const runtimeKeys = ['window'];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
 function setRuntimeValue(key, value) {
@@ -42,39 +42,43 @@ try {
   const cachedSlots = {
     'vitamins.vitaminD': { label: 'Vitamin D' },
   };
-  setRuntimeValue('_cachedCatalog', { slots: cachedSlots });
+  setRecommendationsCatalogCache({ slots: cachedSlots });
   assert('getCategoryPageCatalogSlots returns cached slot map',
     getCategoryPageCatalogSlots() === cachedSlots);
 
   let loadCalls = 0;
-  setRuntimeValue('loadCatalog', async () => {
-    loadCalls += 1;
-    return { slots: { 'minerals.magnesium': { label: 'Magnesium' } } };
+  const previousRecommendationBridge = configureRecommendationModuleBridge({
+    loadCatalog: async () => {
+      loadCalls += 1;
+      return { slots: { 'minerals.magnesium': { label: 'Magnesium' } } };
+    },
   });
   assert('primeCategoryPageCatalogCache skips when cache already exists',
     primeCategoryPageCatalogCache() === null && loadCalls === 0);
 
-  delete globalThis._cachedCatalog;
+  setRecommendationsCatalogCache(null);
   const loadedCatalog = await primeCategoryPageCatalogCache();
   assert('primeCategoryPageCatalogCache loads and stores catalog when missing',
     loadCalls === 1
       && loadedCatalog?.slots?.['minerals.magnesium']?.label === 'Magnesium'
-      && globalThis._cachedCatalog === loadedCatalog
       && getCategoryPageCatalogSlots() === loadedCatalog.slots);
 
-  delete globalThis._cachedCatalog;
-  setRuntimeValue('loadCatalog', () => ({ slots: {} }));
+  setRecommendationsCatalogCache(null);
+  configureRecommendationModuleBridge({ loadCatalog: () => ({ slots: {} }) });
   assert('primeCategoryPageCatalogCache ignores non-promise loaders',
     primeCategoryPageCatalogCache() === null && getCategoryPageCatalogSlots() === null);
 
-  delete globalThis.loadCatalog;
+  configureRecommendationModuleBridge({ loadCatalog: null });
   assert('primeCategoryPageCatalogCache no-ops when loader is missing',
     primeCategoryPageCatalogCache() === null);
 
   delete globalThis.window;
-  assert('runtime adapter no-ops safely when window is missing',
+  assert('runtime adapter no-ops safely when module hooks are missing',
     getCategoryPageCatalogSlots() === null && primeCategoryPageCatalogCache() === null);
+  configureRecommendationModuleBridge(previousRecommendationBridge);
 } finally {
+  configureRecommendationModuleBridge({ loadCatalog: null });
+  setRecommendationsCatalogCache(null);
   restoreRuntime();
 }
 

--- a/tests/test-chat-render-runtime.js
+++ b/tests/test-chat-render-runtime.js
@@ -5,6 +5,10 @@ import {
   isChatRenderProductRecsEnabled,
   renderChatRecommendationSections,
 } from '../js/chat-render-runtime.js';
+import {
+  configureRecommendationModuleBridge,
+  setRecommendationsCatalogCache,
+} from '../js/recommendations-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -14,12 +18,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Chat Render Runtime Tests ===\n');
 
-const runtimeKeys = [
-  'window',
-  'isProductRecsEnabled',
-  'renderRecommendationSectionSync',
-  '_cachedCatalog',
-];
+const runtimeKeys = ['window'];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
 function setRuntimeValue(key, value) {
@@ -41,18 +40,20 @@ function restoreRuntime() {
 
 try {
   const calls = [];
-  setRuntimeValue('isProductRecsEnabled', () => {
+  const previousRecommendationBridge = configureRecommendationModuleBridge({
+    isProductRecsEnabled: () => {
     calls.push(['enabled']);
     return true;
+    },
+    renderRecommendationSectionSync: (slot, options) => {
+      calls.push(['render', slot, options]);
+      return `<section>${options.label}:${slot}:${options.maxProducts}</section>`;
+    },
   });
-  setRuntimeValue('_cachedCatalog', {
+  setRecommendationsCatalogCache({
     slots: {
       'vitamins.vitaminD': { label: 'Vitamin D' },
     },
-  });
-  setRuntimeValue('renderRecommendationSectionSync', (slot, options) => {
-    calls.push(['render', slot, options]);
-    return `<section>${options.label}:${slot}:${options.maxProducts}</section>`;
   });
 
   assert('isChatRenderProductRecsEnabled delegates runtime flag',
@@ -73,33 +74,46 @@ try {
       && call[1] === 'minerals.magnesium'
       && call[2]?.label === 'magnesium'));
 
-  setRuntimeValue('isProductRecsEnabled', () => false);
+  configureRecommendationModuleBridge({ isProductRecsEnabled: () => false });
   assert('renderChatRecommendationSections returns empty when product recs are disabled',
     renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
 
-  setRuntimeValue('isProductRecsEnabled', () => true);
-  delete globalThis.renderRecommendationSectionSync;
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: () => true,
+    renderRecommendationSectionSync: null,
+  });
   assert('renderChatRecommendationSections requires the sync renderer',
     renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
 
-  setRuntimeValue('renderRecommendationSectionSync', () => '<section>unused</section>');
-  delete globalThis._cachedCatalog;
+  configureRecommendationModuleBridge({ renderRecommendationSectionSync: () => '<section>unused</section>' });
+  setRecommendationsCatalogCache(null);
   assert('renderChatRecommendationSections requires cached catalog slots',
     renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
 
-  setRuntimeValue('_cachedCatalog', { slots: {} });
+  setRecommendationsCatalogCache({ slots: {} });
   assert('renderChatRecommendationSections ignores non-array slot input',
     renderChatRecommendationSections('vitamins.vitaminD').length === 0);
 
-  setRuntimeValue('isProductRecsEnabled', () => { throw new Error('boom'); });
+  configureRecommendationModuleBridge({ isProductRecsEnabled: () => { throw new Error('boom'); } });
   assert('isChatRenderProductRecsEnabled returns false when runtime flag throws',
     isChatRenderProductRecsEnabled() === false);
 
   delete globalThis.window;
-  assert('runtime adapter no-ops safely when window is missing',
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    renderRecommendationSectionSync: null,
+  });
+  setRecommendationsCatalogCache(null);
+  assert('runtime adapter no-ops safely when module hooks are missing',
     isChatRenderProductRecsEnabled() === false
       && renderChatRecommendationSections(['vitamins.vitaminD']).length === 0);
+  configureRecommendationModuleBridge(previousRecommendationBridge);
 } finally {
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    renderRecommendationSectionSync: null,
+  });
+  setRecommendationsCatalogCache(null);
   restoreRuntime();
 }
 

--- a/tests/test-chat-send-runtime.js
+++ b/tests/test-chat-send-runtime.js
@@ -8,6 +8,7 @@ import {
   isChatSendEMFRelevant,
   isChatSendProductRecsEnabled,
 } from '../js/chat-send-runtime.js';
+import { configureRecommendationModuleBridge } from '../js/recommendations-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -22,12 +23,6 @@ const runtimeKeys = [
   '_ppqAttestation',
   '_routstrAttestation',
   '_veniceAttestation',
-  'isProductRecsEnabled',
-  'detectSupplementSlots',
-  'detectEMFRelevance',
-  'renderRecommendationSection',
-  'renderRecommendationSectionSync',
-  'loadCatalog',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -56,21 +51,23 @@ try {
   setRuntimeValue('_ppqAttestation', ppqAttestation);
   setRuntimeValue('_routstrAttestation', routstrAttestation);
   setRuntimeValue('_veniceAttestation', veniceAttestation);
-  setRuntimeValue('isProductRecsEnabled', () => {
-    calls.push(['enabled']);
-    return true;
+  const previousRecommendationBridge = configureRecommendationModuleBridge({
+    isProductRecsEnabled: () => {
+      calls.push(['enabled']);
+      return true;
+    },
+    detectSupplementSlots: text => {
+      calls.push(['slots', text]);
+      return ['magnesium'];
+    },
+    detectEMFRelevance: text => {
+      calls.push(['emf', text]);
+      return text.includes('WiFi');
+    },
+    renderRecommendationSection: async slot => `<section>${slot}</section>`,
+    renderRecommendationSectionSync: slot => `<section>${slot}</section>`,
+    loadCatalog: async () => ({ slots: { magnesium: { label: 'Magnesium' } } }),
   });
-  setRuntimeValue('detectSupplementSlots', text => {
-    calls.push(['slots', text]);
-    return ['magnesium'];
-  });
-  setRuntimeValue('detectEMFRelevance', text => {
-    calls.push(['emf', text]);
-    return text.includes('WiFi');
-  });
-  setRuntimeValue('renderRecommendationSection', async slot => `<section>${slot}</section>`);
-  setRuntimeValue('renderRecommendationSectionSync', slot => `<section>${slot}</section>`);
-  setRuntimeValue('loadCatalog', async () => ({ slots: { magnesium: { label: 'Magnesium' } } }));
 
   assert('getChatSendProviderAttestation reads PPQ attestation',
     getChatSendProviderAttestation('ppq') === ppqAttestation);
@@ -90,24 +87,41 @@ try {
       && typeof recommendationRuntime.renderRecommendationSectionSync === 'function'
       && typeof recommendationRuntime.loadCatalog === 'function');
 
-  setRuntimeValue('isProductRecsEnabled', () => false);
+  configureRecommendationModuleBridge({ isProductRecsEnabled: () => false });
   assert('detectChatSendSupplementSlots returns empty when product recs are disabled',
     detectChatSendSupplementSlots('try magnesium').length === 0);
   assert('isChatSendEMFRelevant returns false when product recs are disabled',
     isChatSendEMFRelevant('WiFi in bedroom') === false);
 
-  delete globalThis.renderRecommendationSectionSync;
+  configureRecommendationModuleBridge({ renderRecommendationSectionSync: null });
   assert('getChatSendRecommendationRuntime requires the sync renderer',
     getChatSendRecommendationRuntime() === null);
 
   delete globalThis.window;
-  assert('runtime adapter no-ops safely when window is missing',
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    detectSupplementSlots: null,
+    detectEMFRelevance: null,
+    renderRecommendationSection: null,
+    renderRecommendationSectionSync: null,
+    loadCatalog: null,
+  });
+  assert('runtime adapter no-ops safely when module hooks are missing',
     getChatSendProviderAttestation('ppq') === undefined
       && isChatSendProductRecsEnabled() === false
       && detectChatSendSupplementSlots('try magnesium').length === 0
       && isChatSendEMFRelevant('WiFi in bedroom') === false
       && getChatSendRecommendationRuntime() === null);
+  configureRecommendationModuleBridge(previousRecommendationBridge);
 } finally {
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    detectSupplementSlots: null,
+    detectEMFRelevance: null,
+    renderRecommendationSection: null,
+    renderRecommendationSectionSync: null,
+    loadCatalog: null,
+  });
   restoreRuntime();
 }
 

--- a/tests/test-dna-recommendations.js
+++ b/tests/test-dna-recommendations.js
@@ -21,10 +21,9 @@ function assert(name, condition, detail) {
 
 console.log('=== DNA-Aware Supplement Recommendations Tests ===\n');
 
-// recommendations.js exposes its handlers (incl. buildDNAHints) via
-// Object.assign(window, ...). state.js sets up globals it depends on.
+// recommendations.js exposes its handlers through native module exports.
 await import('../js/state.js');
-await import('../js/recommendations.js');
+const recommendationsModule = await import('../js/recommendations.js');
 
 // Original test reads data/*.json via fetch(...).then(r => r.json()) —
 // install a fetch shim that resolves relative URLs through fs.
@@ -153,12 +152,13 @@ assertCatalog('Folate slot has food forms', folateSlot?.foodForms?.length >= 2);
 console.log('3. buildDNAHints');
 
 assert('buildDNAHints exported', recSrc.includes('export function buildDNAHints'));
-assert('buildDNAHints on window', typeof window.buildDNAHints === 'function');
+assert('buildDNAHints is module-exported', typeof recommendationsModule.buildDNAHints === 'function');
+assert('buildDNAHints stays off window', !('buildDNAHints' in window));
 assert('buildDNAHints handles APOE specially', recSrc.includes('genetics.apoe') && recSrc.includes('lipids.ldl'));
 assert('buildDNAHints handles genotype reversal', recSrc.includes('[1] + g[0]') || recSrc.includes('rev'));
 
 // Test with no genetics — should return empty
-const noGenResult = window.buildDNAHints('vitamins.vitaminD');
+const noGenResult = recommendationsModule.buildDNAHints('vitamins.vitaminD');
 assert('buildDNAHints returns [] with no genetics', Array.isArray(noGenResult) && noGenResult.length === 0);
 
 // ═══════════════════════════════════════

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -287,22 +287,23 @@ assert('92. Empty for null/empty text', recsMod.detectMitigationsInText('').leng
 localStorage.setItem('labcharts-show-product-recs', 'true');
 const couponHtml = recsMod.renderEMFMeterRecs(emfCat);
 assert('93. Coupon renders as clickable button', couponHtml.includes('rec-coupon-code') && couponHtml.includes('data-rec-action="copy-coupon"'));
-assert('94. copyCouponCode exposed on window', typeof window.copyCouponCode === 'function');
-assert('94a. Coupon button has aria-label', /aria-label="Copy coupon code/.test(couponHtml));
-assert('94b. Coupon wrapper announces flash via aria-live', /aria-live="polite"/.test(couponHtml));
-assert('94c. Affiliate links carry aria-label "opens in new tab"', /opens in new tab/.test(couponHtml));
+assert('94. copyCouponCode is module-exported', typeof recsMod.copyCouponCode === 'function');
+assert('94a. copyCouponCode stays off window', !('copyCouponCode' in window));
+assert('94b. Coupon button has aria-label', /aria-label="Copy coupon code/.test(couponHtml));
+assert('94c. Coupon wrapper announces flash via aria-live', /aria-live="polite"/.test(couponHtml));
+assert('94d. Affiliate links carry aria-label "opens in new tab"', /opens in new tab/.test(couponHtml));
 const hostlistedHtml = recsMod.renderEMFMeterRecs(emfCat);
-assertCatalog('94d. Trusted SLT URL renders as link', hostlistedHtml.includes('safelivingtechnologies.com'));
+assertCatalog('94e. Trusted SLT URL renders as link', hostlistedHtml.includes('safelivingtechnologies.com'));
 const malCat = JSON.parse(JSON.stringify(emfCat));
 malCat.products['_internal.emfMeters'][0].url = 'https://attacker.com/?safelivingtechnologies.com=fake';
 const malHtml = recsMod.renderEMFMeterRecs(malCat);
-assert('94e. Allowlist blocks attacker.com URL', !malHtml.includes('attacker.com'));
+assert('94f. Allowlist blocks attacker.com URL', !malHtml.includes('attacker.com'));
 
 // Umami event tagging — six surfaces, opt-out gate inherited from Settings → Privacy
 const meterEvents = recsMod.renderEMFMeterRecs(emfCat);
-assert('94f. Meter rec links carry Umami events', /data-umami-event="emf-meter-rec-/.test(meterEvents));
+assert('94g. Meter rec links carry Umami events', /data-umami-event="emf-meter-rec-/.test(meterEvents));
 const mitEvents = recsMod.renderEMFMitigationRecs(emfCat, ['shielding paint (Yshield)']);
-assertCatalog('94g. Mitigation rec links carry Umami events', /data-umami-event="emf-mitigation-rec-/.test(mitEvents));
+assertCatalog('94h. Mitigation rec links carry Umami events', /data-umami-event="emf-mitigation-rec-/.test(mitEvents));
 const customEvent = recsMod.renderEMFMeterRecs(emfCat, { eventPrefix: 'meter-test' });
 assert('94h. Custom eventPrefix works', /data-umami-event="emf-meter-test-/.test(customEvent));
 

--- a/tests/test-light-devices-runtime.js
+++ b/tests/test-light-devices-runtime.js
@@ -14,6 +14,7 @@ import {
   refreshLightDevicesView,
   renderLightDeviceAffiliateRowRuntime,
 } from '../js/light-devices-runtime.js';
+import { configureRecommendationModuleBridge } from '../js/recommendations-runtime.js';
 
 const originalLightDevicesRuntimeDeps = configureLightDevicesRuntimeDeps();
 
@@ -32,8 +33,6 @@ const runtimeKeys = [
   'tierLabel',
   'formatChannelUnit',
   'CHANNEL_DISPLAY',
-  'loadCatalog',
-  'renderLightDeviceAffiliateRow',
   '_openChannelOnLightPage',
 ];
 const saved = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
@@ -103,25 +102,32 @@ try {
   assert('getLightDeviceChannelDisplay prefers runtime display',
     getLightDeviceChannelDisplay(fallbackDisplay).circadian.label === 'Runtime Clock');
 
-  globalThis.loadCatalog = async () => ({ slots: { light: true } });
-  assert('loadLightDevicesCatalog delegates to runtime loadCatalog',
+  const previousRecommendationBridge = configureRecommendationModuleBridge({
+    loadCatalog: async () => ({ slots: { light: true } }),
+    renderLightDeviceAffiliateRow: (_catalog, slug) => `<a>${slug}</a>`,
+  });
+  assert('loadLightDevicesCatalog delegates to module loadCatalog',
     (await loadLightDevicesCatalog()).slots.light === true);
-  delete globalThis.loadCatalog;
+  configureRecommendationModuleBridge({ loadCatalog: null });
   assert('loadLightDevicesCatalog returns undefined when hook is missing',
     await loadLightDevicesCatalog() === undefined);
 
-  globalThis.renderLightDeviceAffiliateRow = (_catalog, slug) => `<a>${slug}</a>`;
   assert('renderLightDeviceAffiliateRowRuntime delegates affiliate row rendering',
     renderLightDeviceAffiliateRowRuntime({}, 'panel-x') === '<a>panel-x</a>');
-  delete globalThis.renderLightDeviceAffiliateRow;
+  configureRecommendationModuleBridge({ renderLightDeviceAffiliateRow: null });
   assert('renderLightDeviceAffiliateRowRuntime returns empty string when hook is missing',
     renderLightDeviceAffiliateRowRuntime({}, 'panel-x') === '');
+  configureRecommendationModuleBridge(previousRecommendationBridge);
 
   globalThis._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
   openLightDeviceChannel('vitamin_d');
   assert('openLightDeviceChannel delegates to the current view binding',
     calls.some(call => call[0] === 'open-channel' && call[1] === 'vitamin_d'));
 } finally {
+  configureRecommendationModuleBridge({
+    loadCatalog: null,
+    renderLightDeviceAffiliateRow: null,
+  });
   configureLightDevicesRuntimeDeps(originalLightDevicesRuntimeDeps);
   restoreRuntime();
 }

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -620,7 +620,8 @@ const {
   assert('light-devices-runtime owns browser-shell hooks and explicit utility dependency',
     lightDevicesRuntimeSrc.includes("getRuntimeFunction('navigate')") &&
     lightDevicesRuntimeSrc.includes('lightDevicesRuntimeDeps.showPromptDialog') &&
-    lightDevicesRuntimeSrc.includes("getRuntimeFunction('loadCatalog')") &&
+    lightDevicesRuntimeSrc.includes("getRecommendationModuleFunction('loadCatalog')") &&
+    lightDevicesRuntimeSrc.includes("from './recommendations-runtime.js'") &&
     !lightDevicesRuntimeSrc.includes('publishLightDevicesWindowBindings'));
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-marker-detail-runtime.js
+++ b/tests/test-marker-detail-runtime.js
@@ -19,6 +19,7 @@ import {
   toggleDashboardQuickMarkerPinRuntime,
   uninstallWearableModalFocusTrapRuntime,
 } from '../js/marker-detail-runtime.js';
+import { configureRecommendationModuleBridge } from '../js/recommendations-runtime.js';
 import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
@@ -39,8 +40,6 @@ const runtimeKeys = [
   'askAIAboutMarker',
   'showEmojiPicker',
   '_getRelevantSNPs',
-  'isProductRecsEnabled',
-  'renderRecommendationSection',
   '_uninstallWearableModalFocusTrap',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
@@ -85,10 +84,12 @@ try {
     calls.push(['snps', dotKey]);
     return snps;
   });
-  setRuntimeValue('isProductRecsEnabled', () => true);
-  setRuntimeValue('renderRecommendationSection', async (markerKey, options) => {
-    calls.push(['recs', markerKey, options?.markerStatus || '']);
-    return '<section>recs</section>';
+  const previousRecommendationBridge = configureRecommendationModuleBridge({
+    isProductRecsEnabled: () => true,
+    renderRecommendationSection: async (markerKey, options) => {
+      calls.push(['recs', markerKey, options?.markerStatus || '']);
+      return '<section>recs</section>';
+    },
   });
   const restoreMarkerDetailRuntime = configureMarkerDetailRuntime({
     closeEMFInterpretation: () => calls.push(['emf-close']),
@@ -127,7 +128,7 @@ try {
   configureViewRuntime({ buildSidebar: () => { throw new Error('boom'); } });
   setRuntimeValue('isDashboardQuickMarkerPinned', () => { throw new Error('boom'); });
   setRuntimeValue('_getRelevantSNPs', () => { throw new Error('boom'); });
-  setRuntimeValue('isProductRecsEnabled', () => { throw new Error('boom'); });
+  configureRecommendationModuleBridge({ isProductRecsEnabled: () => { throw new Error('boom'); } });
   buildMarkerDetailSidebarRuntime();
   assert('marker detail runtime safe fallbacks catch optional hook errors',
     isDashboardQuickMarkerPinnedRuntime('lipids_apob') === false &&
@@ -137,6 +138,10 @@ try {
   configureMarkerDetailRuntime({ closeEMFInterpretation: () => {} });
 
   delete globalThis.window;
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    renderRecommendationSection: null,
+  });
   configureViewRuntime({ buildSidebar: null });
   const beforeMissingRuntimeCalls = calls.length;
   navigateMarkerDetailRuntime('dashboard');
@@ -157,7 +162,12 @@ try {
       isProductRecsEnabledRuntime() === false &&
       missingRuntimeRecs === '');
   configureMarkerDetailRuntime(restoreMarkerDetailRuntime);
+  configureRecommendationModuleBridge(previousRecommendationBridge);
 } finally {
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    renderRecommendationSection: null,
+  });
   configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   restoreRuntime();
 }

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -4,7 +4,10 @@
 import './_node-shim.js';
 import {
   closeRecommendationsModal,
+  configureRecommendationModuleBridge,
   configureRecommendationsRuntime,
+  getRecommendationModuleFunction,
+  getRecommendationsCatalogCache,
   getRecommendationsSnpTable,
   isRecommendationsProductRecsEnabled,
   loadRecommendationsCatalogRuntime,
@@ -12,9 +15,9 @@ import {
   openRecommendationsEmfAssessment,
   openRecommendationsLocationEditor,
   openRecommendationsPrivacySettings,
-  registerRecommendationsRuntimeExports,
   renderRecommendationsDetailSection,
   scheduleRecommendationsTask,
+  setRecommendationsCatalogCache,
 } from '../js/recommendations-runtime.js';
 import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
@@ -35,6 +38,7 @@ console.log('=== Recommendations Runtime Tests ===');
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 let previousViewRuntime = null;
+let previousRecommendationModule = null;
 
 function setRuntime(value) {
   Object.defineProperty(globalThis, 'window', {
@@ -62,18 +66,22 @@ try {
     openProfileLocationEditor() { calls.push(['location', this === runtime]); },
     openSettingsTab(tab) { calls.push(['settings', tab, this === runtime]); },
     openChatPanel(prompt) { calls.push(['chat', prompt, this === runtime]); },
-    isProductRecsEnabled() { calls.push(['enabled', this === runtime]); return true; },
-    async loadCatalog() { calls.push(['catalog', this === runtime]); return { slots: { magnesium: { label: 'Magnesium' } } }; },
+  };
+  previousRecommendationModule = configureRecommendationModuleBridge({
+    isProductRecsEnabled() { calls.push(['enabled']); return true; },
+    async loadCatalog() { calls.push(['catalog']); return { slots: { magnesium: { label: 'Magnesium' } } }; },
     async renderRecommendationSection(slotKey, options) {
-      calls.push(['render', slotKey, options, this === runtime]);
+      calls.push(['render', slotKey, options]);
       return `<section>${slotKey}</section>`;
     },
+  });
+  Object.assign(runtime, {
     setTimeout(callback, delay) {
       calls.push(['timeout', delay, this === runtime]);
       callback();
       return 17;
     },
-  };
+  });
   setRuntime(runtime);
   const restoreRecommendationsRuntime = configureRecommendationsRuntime({
     openEMFAssessmentEditor: () => calls.push(['emf', true]),
@@ -81,7 +89,7 @@ try {
   });
 
   const timerId = scheduleRecommendationsTask(() => calls.push(['task']), 125);
-  const registered = registerRecommendationsRuntimeExports({ recommendationProbe: () => 'ok' });
+  setRecommendationsCatalogCache({ slots: { cached: { label: 'Cached' } } });
 
   assert('recommendations runtime reads SNP table cache',
     getRecommendationsSnpTable() === snpTable);
@@ -89,16 +97,15 @@ try {
   assert('recommendations runtime delegates product recs flag and catalog loader',
     isRecommendationsProductRecsEnabled() === true &&
       catalog?.slots?.magnesium?.label === 'Magnesium' &&
-      calls.some(call => call[0] === 'enabled' && call[1] === true) &&
-      calls.some(call => call[0] === 'catalog' && call[1] === true));
+      calls.some(call => call[0] === 'enabled') &&
+      calls.some(call => call[0] === 'catalog'));
   const detailHtml = await renderRecommendationsDetailSection('minerals.magnesium', { label: 'Options' });
   assert('recommendations runtime delegates detail rendering and chat panel hooks',
     detailHtml === '<section>minerals.magnesium</section>' &&
       openRecommendationsChatPanel('Discuss this') &&
       calls.some(call => call[0] === 'render'
         && call[1] === 'minerals.magnesium'
-        && call[2]?.label === 'Options'
-        && call[3] === true) &&
+        && call[2]?.label === 'Options') &&
       calls.some(call => call[0] === 'chat' && call[1] === 'Discuss this' && call[2] === true));
   assert('recommendations runtime delegates host modal and editor hooks',
     closeRecommendationsModal() &&
@@ -113,17 +120,29 @@ try {
     timerId === 17 &&
       calls.some(call => call[0] === 'timeout' && call[1] === 125 && call[2] === true) &&
       calls.some(call => call[0] === 'task'));
-  assert('recommendations runtime registers window exports',
-    registered && runtime.recommendationProbe?.() === 'ok');
+  assert('recommendations runtime exposes cycle-safe module hooks and catalog cache',
+    typeof getRecommendationModuleFunction('loadCatalog') === 'function'
+      && getRecommendationsCatalogCache()?.slots?.cached?.label === 'Cached'
+      && !('loadCatalog' in runtime));
+  const restoreProbe = configureRecommendationModuleBridge({
+    recommendationProbe: () => 'ok',
+  });
+  const probeRegistered = getRecommendationModuleFunction('recommendationProbe')?.() === 'ok';
+  configureRecommendationModuleBridge(restoreProbe);
+  assert('recommendation module bridge snapshots remove newly added callbacks on restore',
+    probeRegistered && getRecommendationModuleFunction('recommendationProbe') === null);
 
   delete runtime.closeModal;
   delete runtime.openProfileLocationEditor;
   configureRecommendationsRuntime({ openProfileLocationEditor: null });
   delete runtime.openSettingsTab;
   delete runtime.openChatPanel;
-  delete runtime.isProductRecsEnabled;
-  delete runtime.loadCatalog;
-  delete runtime.renderRecommendationSection;
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    loadCatalog: null,
+    renderRecommendationSection: null,
+  });
+  setRecommendationsCatalogCache(null);
   delete runtime._snpTableCache;
   assert('recommendations runtime handles missing optional browser hooks',
     getRecommendationsSnpTable() === null &&
@@ -145,8 +164,15 @@ try {
       await loadRecommendationsCatalogRuntime() === null &&
       await renderRecommendationsDetailSection('missing.slot', {}) === '' &&
       openRecommendationsChatPanel('No-op') === false &&
-      registerRecommendationsRuntimeExports({ missingWindowProbe: true }) === false);
+      getRecommendationsCatalogCache() === null);
 } finally {
+  configureRecommendationModuleBridge({
+    isProductRecsEnabled: null,
+    loadCatalog: null,
+    renderRecommendationSection: null,
+    ...previousRecommendationModule,
+  });
+  setRecommendationsCatalogCache(null);
   if (previousViewRuntime?.closeModal) configureViewRuntime(previousViewRuntime);
   restoreWindow();
 }

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -21,9 +21,9 @@ function assert(name, condition, detail) {
 
 console.log('=== Supplement & Lifestyle Recommendations Tests ===\n');
 
-// recommendations.js exposes its handlers via Object.assign(window, ...).
+// Recommendations are consumed through native module exports.
 await import('../js/state.js');
-await import('../js/recommendations.js');
+const recommendationsModule = await import('../js/recommendations.js');
 
 // Original test reads data/light-device-presets.json via fetchWithRetry —
 // pass through fs read.
@@ -81,7 +81,7 @@ const _realFetch = globalThis.fetch;
       !/\bwindow(?:\.|\s*\[)/.test(recSrc) &&
       !recSrc.includes('Object.assign(window') &&
       recRuntimeSrc.includes('export function getRecommendationsSnpTable') &&
-      recRuntimeSrc.includes('export function registerRecommendationsRuntimeExports'),
+      recRuntimeSrc.includes('export function configureRecommendationModuleBridge'),
     recSrc.slice(0, 1800));
   assert('recommendations-region.js owns region hierarchy data',
     recRegionSrc.includes('REGION_HIERARCHY') &&
@@ -89,18 +89,18 @@ const _realFetch = globalThis.fetch;
     recProductsSrc.includes("from './recommendations-region.js'"));
 
   // ═══════════════════════════════════════
-  // 2. Window exports
+  // 2. Module exports
   // ═══════════════════════════════════════
   console.log('%c 2. Window Exports ', 'font-weight:bold;color:#f59e0b');
 
-  assert('isProductRecsEnabled on window', typeof window.isProductRecsEnabled === 'function');
-  assert('setProductRecsEnabled on window', typeof window.setProductRecsEnabled === 'function');
-  assert('markRecDisclosureSeen on window', typeof window.markRecDisclosureSeen === 'function');
-  assert('renderRecommendationSection on window', typeof window.renderRecommendationSection === 'function');
-  assert('renderRecommendationSectionSync on window', typeof window.renderRecommendationSectionSync === 'function');
+  assert('isProductRecsEnabled is module-exported', typeof recommendationsModule.isProductRecsEnabled === 'function');
+  assert('setProductRecsEnabled is module-exported', typeof recommendationsModule.setProductRecsEnabled === 'function');
+  assert('markDisclosureSeen is module-exported', typeof recommendationsModule.markDisclosureSeen === 'function');
+  assert('renderRecommendationSection is module-exported', typeof recommendationsModule.renderRecommendationSection === 'function');
+  assert('renderRecommendationSectionSync is module-exported', typeof recommendationsModule.renderRecommendationSectionSync === 'function');
   assert('getUserRegion routes via COUNTRY_TO_REGION table', recProductsSrc.includes('COUNTRY_TO_REGION[c]'));
-  assert('detectSupplementSlots on window', typeof window.detectSupplementSlots === 'function');
-  assert('loadCatalog on window', typeof window.loadCatalog === 'function');
+  assert('detectSupplementSlots is module-exported', typeof recommendationsModule.detectSupplementSlots === 'function');
+  assert('loadCatalog is module-exported', typeof recommendationsModule.loadCatalog === 'function');
 
   // ═══════════════════════════════════════
   // 3. Toggle on/off
@@ -108,12 +108,12 @@ const _realFetch = globalThis.fetch;
   console.log('%c 3. Toggle On/Off ', 'font-weight:bold;color:#f59e0b');
 
   const origVal = localStorage.getItem('labcharts-show-product-recs');
-  window.setProductRecsEnabled(true);
-  assert('setProductRecsEnabled(true) → enabled', window.isProductRecsEnabled() === true);
-  window.setProductRecsEnabled(false);
-  assert('setProductRecsEnabled(false) → disabled', window.isProductRecsEnabled() === false);
-  window.setProductRecsEnabled(true);
-  assert('Re-enable → true', window.isProductRecsEnabled() === true);
+  recommendationsModule.setProductRecsEnabled(true);
+  assert('setProductRecsEnabled(true) → enabled', recommendationsModule.isProductRecsEnabled() === true);
+  recommendationsModule.setProductRecsEnabled(false);
+  assert('setProductRecsEnabled(false) → disabled', recommendationsModule.isProductRecsEnabled() === false);
+  recommendationsModule.setProductRecsEnabled(true);
+  assert('Re-enable → true', recommendationsModule.isProductRecsEnabled() === true);
   // Restore
   if (origVal === null) localStorage.removeItem('labcharts-show-product-recs');
   else localStorage.setItem('labcharts-show-product-recs', origVal);
@@ -127,8 +127,8 @@ const _realFetch = globalThis.fetch;
   localStorage.removeItem('labcharts-rec-disclosure');
   // hasSeenDisclosure not on window but we can test via recSrc pattern
   assert('Disclosure key uses labcharts-rec-disclosure', recProductsSrc.includes("'labcharts-rec-disclosure'"));
-  window.markRecDisclosureSeen();
-  assert('markRecDisclosureSeen sets localStorage', localStorage.getItem('labcharts-rec-disclosure') === 'seen');
+  recommendationsModule.markDisclosureSeen();
+  assert('markDisclosureSeen sets localStorage', localStorage.getItem('labcharts-rec-disclosure') === 'seen');
   // Restore
   if (origDisc === null) localStorage.removeItem('labcharts-rec-disclosure');
   else localStorage.setItem('labcharts-rec-disclosure', origDisc);
@@ -139,15 +139,15 @@ const _realFetch = globalThis.fetch;
   console.log('%c 5. Render Gating ', 'font-weight:bold;color:#f59e0b');
 
   const origRec = localStorage.getItem('labcharts-show-product-recs');
-  window.setProductRecsEnabled(false);
-  const emptyResult = await window.renderRecommendationSection('vitamins.vitaminD', { label: 'Test' });
+  recommendationsModule.setProductRecsEnabled(false);
+  const emptyResult = await recommendationsModule.renderRecommendationSection('vitamins.vitaminD', { label: 'Test' });
   assert('renderRecommendationSection returns empty when disabled', emptyResult === '');
-  window.setProductRecsEnabled(true);
+  recommendationsModule.setProductRecsEnabled(true);
   // Catalog file may not exist — should gracefully return ''
-  const noFileResult = await window.renderRecommendationSection('nonexistent.marker', { label: 'Test' });
+  const noFileResult = await recommendationsModule.renderRecommendationSection('nonexistent.marker', { label: 'Test' });
   assert('renderRecommendationSection returns empty for unknown slot', noFileResult === '' || typeof noFileResult === 'string');
-  const originalRenderRecommendationSection = window.renderRecommendationSection;
-  window.renderRecommendationSection = undefined;
+  const { configureRecommendationModuleBridge } = await import('../js/recommendations-runtime.js');
+  const previousRecommendationBridge = configureRecommendationModuleBridge({ renderRecommendationSection: null });
   const { createRecommendationActions } = await import('../js/recommendation-actions.js');
   const originalGetElementById = document.getElementById;
   const modalStub = { className: 'modal', innerHTML: '' };
@@ -164,7 +164,7 @@ const _realFetch = globalThis.fetch;
   assert('openRecommendationDetail handles missing renderRecommendationSection without stuck loading',
     modalStub.innerHTML.includes('No recommendation details available for this slot.'));
   document.getElementById = originalGetElementById;
-  window.renderRecommendationSection = originalRenderRecommendationSection;
+  configureRecommendationModuleBridge(previousRecommendationBridge);
   // Restore
   if (origRec === null) localStorage.removeItem('labcharts-show-product-recs');
   else localStorage.setItem('labcharts-show-product-recs', origRec);
@@ -174,11 +174,11 @@ const _realFetch = globalThis.fetch;
   // ═══════════════════════════════════════
   console.log('%c 6. Keyword Scanner ', 'font-weight:bold;color:#f59e0b');
 
-  const ds = window.detectSupplementSlots;
+  const ds = recommendationsModule.detectSupplementSlots;
   assert('detectSupplementSlots("") → []', ds('').length === 0);
   assert('detectSupplementSlots(null) → []', ds(null).length === 0);
   // Dynamic scanner requires loaded catalog — test with whatever catalog is available
-  await window.loadCatalog();
+  await recommendationsModule.loadCatalog();
   const vitDResult = ds('Your vitamin D3 is low, consider supplementing D3');
   assert('detectSupplementSlots finds vitamin D slot (if catalog loaded)', vitDResult.length <= 1);
   assert('detectSupplementSlots caps at 1', ds('vitamin d magnesium omega-3 zinc iron b12 selenium ashwagandha').length <= 1);
@@ -263,7 +263,11 @@ const _realFetch = globalThis.fetch;
       && chartCardRecsSrc.includes('loadRecommendationsCatalogRuntime')
       && !/\bwindow(\.|\s*\[)/.test(chartCardRecsSrc));
   assert('marker-detail-modal.js scrollToRec auto-opens details', markerDetailSrc.includes('scrollToRec'));
-  assert('loadCatalog on window', typeof window.loadCatalog === 'function');
+  assert('recommendation globals stay module-only', [
+    'isProductRecsEnabled', 'setProductRecsEnabled', 'markRecDisclosureSeen',
+    'renderRecommendationSection', 'renderRecommendationSectionSync',
+    'detectSupplementSlots', 'loadCatalog',
+  ].every(name => !(name in window)));
   assert('nav.js exposes recommendations sidebar helper', navSrc.includes('openRecommendationsFromSidebar'));
   const recNavMarkup = navSrc.match(/data-category="recommendations"[\s\S]{0,500}/)?.[0] || '';
   assert('Recommendations sidebar routes to dedicated page',
@@ -347,8 +351,8 @@ const _realFetch = globalThis.fetch;
     recProductsSrc.includes('export function getLightDeviceProduct'));
   assert('renderLightDeviceAffiliateRow exported',
     recProductsSrc.includes('export function renderLightDeviceAffiliateRow'));
-  assert('getLightDeviceProduct on window', typeof window.getLightDeviceProduct === 'function');
-  assert('renderLightDeviceAffiliateRow on window', typeof window.renderLightDeviceAffiliateRow === 'function');
+  assert('getLightDeviceProduct is module-exported', typeof recommendationsModule.getLightDeviceProduct === 'function');
+  assert('renderLightDeviceAffiliateRow is module-exported', typeof recommendationsModule.renderLightDeviceAffiliateRow === 'function');
 
   // Synthetic catalog with a matching slug
   const stubCatalog = {
@@ -370,18 +374,18 @@ const _realFetch = globalThis.fetch;
     },
     vendors: {},
   };
-  const found = window.getLightDeviceProduct(stubCatalog, 'mitochondriak-maxi-uvb');
+  const found = recommendationsModule.getLightDeviceProduct(stubCatalog, 'mitochondriak-maxi-uvb');
   assert('getLightDeviceProduct: matching slug → product', !!found && found.key === 'mitochondriak-maxi-uvb');
-  const missing = window.getLightDeviceProduct(stubCatalog, 'unknown-device');
+  const missing = recommendationsModule.getLightDeviceProduct(stubCatalog, 'unknown-device');
   assert('getLightDeviceProduct: unknown slug → null', missing === null);
-  const noCatalog = window.getLightDeviceProduct(null, 'mitochondriak-maxi-uvb');
+  const noCatalog = recommendationsModule.getLightDeviceProduct(null, 'mitochondriak-maxi-uvb');
   assert('getLightDeviceProduct: null catalog → null', noCatalog === null);
-  const noSlug = window.getLightDeviceProduct(stubCatalog, '');
+  const noSlug = recommendationsModule.getLightDeviceProduct(stubCatalog, '');
   assert('getLightDeviceProduct: empty slug → null', noSlug === null);
 
   // Render: requires product recs enabled
-  window.setProductRecsEnabled(true);
-  const row = window.renderLightDeviceAffiliateRow(stubCatalog, 'mitochondriak-maxi-uvb');
+  recommendationsModule.setProductRecsEnabled(true);
+  const row = recommendationsModule.renderLightDeviceAffiliateRow(stubCatalog, 'mitochondriak-maxi-uvb');
   assert('renderLightDeviceAffiliateRow: produces sponsored anchor when enabled',
     row.includes('rel="noopener sponsored"') &&
     row.includes('href="') &&
@@ -395,13 +399,13 @@ const _realFetch = globalThis.fetch;
   assert('renderLightDeviceAffiliateRow: has aria-label for screen readers',
     /aria-label="View .* on .*, opens in new tab"/.test(row));
 
-  const emptyOnMiss = window.renderLightDeviceAffiliateRow(stubCatalog, 'unknown-device');
+  const emptyOnMiss = recommendationsModule.renderLightDeviceAffiliateRow(stubCatalog, 'unknown-device');
   assert('renderLightDeviceAffiliateRow: missing product → empty string', emptyOnMiss === '');
 
-  window.setProductRecsEnabled(false);
-  const offWhenDisabled = window.renderLightDeviceAffiliateRow(stubCatalog, 'mitochondriak-maxi-uvb');
+  recommendationsModule.setProductRecsEnabled(false);
+  const offWhenDisabled = recommendationsModule.renderLightDeviceAffiliateRow(stubCatalog, 'mitochondriak-maxi-uvb');
   assert('renderLightDeviceAffiliateRow: toggle off → empty string', offWhenDisabled === '');
-  window.setProductRecsEnabled(true);
+  recommendationsModule.setProductRecsEnabled(true);
 
   // Preset side: every Mitochondriak / Chroma / EMR-Tek preset must have a
   // catalogSlug equal to its id so the device card resolves to the catalog
@@ -422,9 +426,9 @@ const _realFetch = globalThis.fetch;
   // a CTA when the user has 7+ logged events but a device-fillable
   // channel (pbm_red / pbm_nir) is empty over 30 days.
   assert('recommendDeviceProductsForChannelDeficit on window',
-    typeof window.recommendDeviceProductsForChannelDeficit === 'function');
+    typeof recommendationsModule.recommendDeviceProductsForChannelDeficit === 'function');
   assert('renderChannelDeficitDeviceRecs on window',
-    typeof window.renderChannelDeficitDeviceRecs === 'function');
+    typeof recommendationsModule.renderChannelDeficitDeviceRecs === 'function');
 
   const presetStubs = [
     { id: 'mitochondriak-maxi-uvb', brand: 'Mitochondriak', model: 'Maxi UVB',
@@ -434,25 +438,25 @@ const _realFetch = globalThis.fetch;
     { id: 'no-slug', brand: 'X', model: 'Y', channels: ['pbm_red'] },
   ];
 
-  const pbmRedHits = window.recommendDeviceProductsForChannelDeficit(
+  const pbmRedHits = recommendationsModule.recommendDeviceProductsForChannelDeficit(
     stubCatalog, 'pbm_red', presetStubs);
   assert('recommendDeviceProductsForChannelDeficit: pbm_red → matching product',
     Array.isArray(pbmRedHits) && pbmRedHits.length === 1 &&
     pbmRedHits[0].key === 'mitochondriak-maxi-uvb');
 
-  const novelChannel = window.recommendDeviceProductsForChannelDeficit(
+  const novelChannel = recommendationsModule.recommendDeviceProductsForChannelDeficit(
     stubCatalog, 'imaginary_channel', presetStubs);
   assert('recommendDeviceProductsForChannelDeficit: unknown channel → []',
     Array.isArray(novelChannel) && novelChannel.length === 0);
 
-  const noPresets = window.recommendDeviceProductsForChannelDeficit(
+  const noPresets = recommendationsModule.recommendDeviceProductsForChannelDeficit(
     stubCatalog, 'pbm_red', []);
   assert('recommendDeviceProductsForChannelDeficit: empty presets → []',
     Array.isArray(noPresets) && noPresets.length === 0);
 
   // renderChannelDeficitDeviceRecs respects the toggle.
-  window.setProductRecsEnabled(true);
-  const card = window.renderChannelDeficitDeviceRecs(
+  recommendationsModule.setProductRecsEnabled(true);
+  const card = recommendationsModule.renderChannelDeficitDeviceRecs(
     stubCatalog, 'pbm_red', presetStubs, { label: 'red 660 nm (PBM)' });
   assert('renderChannelDeficitDeviceRecs: builds card with channel label',
     card.includes('rec-channel-deficit') && card.includes('red 660 nm (PBM)'));
@@ -461,12 +465,12 @@ const _realFetch = globalThis.fetch;
   assert('renderChannelDeficitDeviceRecs: Umami event uses light-deficit-rec prefix',
     /data-umami-event="light-deficit-rec-/.test(card));
 
-  window.setProductRecsEnabled(false);
-  const offCard = window.renderChannelDeficitDeviceRecs(
+  recommendationsModule.setProductRecsEnabled(false);
+  const offCard = recommendationsModule.renderChannelDeficitDeviceRecs(
     stubCatalog, 'pbm_red', presetStubs, { label: 'red 660 nm (PBM)' });
   assert('renderChannelDeficitDeviceRecs: toggle off → empty string',
     offCard === '');
-  window.setProductRecsEnabled(true);
+  recommendationsModule.setProductRecsEnabled(true);
 
   // ═══════════════════════════════════════
   // Results

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -70,9 +70,7 @@ interface Window {
   clearE2EESession?: AnyFunction;
   cleanupDiscussionState?: AnyFunction;
   destroyAllCharts?: () => void;
-  detectEMFRelevance?: AnyFunction;
   detectDNAFile?: (header: string) => string | null;
-  detectSupplementSlots?: AnyFunction;
   ensureActiveThread?: () => void;
   exportAllDataJSON?: () => Promise<void> | void;
   exportClientJSON?: (profileId: string, includeChat?: boolean) => Promise<void> | void;
@@ -194,7 +192,6 @@ interface Window {
   rememberModalTrigger?: () => void;
   renderChatMessages?: AnyFunction;
   renderMenstrualCycleSection?: AnyFunction;
-  renderRecommendationSectionSync?: AnyFunction;
   renderSavedSummaries?: AnyFunction;
   renderSupplementsSection?: AnyFunction;
   renderThreadList?: () => void;
@@ -224,14 +221,10 @@ interface Window {
   updatePrivacyStatusCard?: AnyFunction;
   refreshWebSearchToggle?: AnyFunction;
   saveImportedData?: AnyFunction;
-  loadCatalog?: AnyFunction;
-  _cachedCatalog?: { slots?: Record<string, any>; [key: string]: any } | null;
   _getRelevantSNPs?: AnyFunction;
   _uninstallWearableModalFocusTrap?: AnyFunction;
-  buildDNAHints?: AnyFunction;
   deleteNote?: AnyFunction;
   detectWearableTrendSlots?: AnyFunction;
-  isProductRecsEnabled?: () => boolean;
   loadContextCardTips?: AnyFunction;
   openManualLogForm?: AnyFunction;
   openNoteEditor?: AnyFunction;
@@ -239,10 +232,7 @@ interface Window {
   showDetailModal?: AnyFunction;
   syncWearableNow?: AnyFunction;
   triggerDNAFilePicker?: AnyFunction;
-  renderLightDeviceAffiliateRow?: AnyFunction;
-  renderRecommendationSection?: AnyFunction;
   renderLightTools?: AnyFunction;
-  renderChannelDeficitDeviceRecs?: AnyFunction;
   renderSunDataSourceSettings?: AnyFunction;
   computeUVConfidence?: AnyFunction;
   getMeteoConfig?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.232';
+self.APP_VERSION = '1.10.233';


### PR DESCRIPTION
## Summary

- remove the recommendation facade's 22 legacy `window` publications
- route chat, dashboard, context-card, marker-detail, and Light consumers through a cycle-safe module bridge
- replace the browser-global recommendation catalog cache with module-scoped state
- update Node and browser fixtures to import recommendation exports or inject module callbacks instead of manufacturing globals
- remove obsolete publication helpers and stale global declarations, add bridge restore coverage, and bump the cache version to 1.10.233

## Window burden

- Before: **267 unique globals**, **267 publication entries**, **6 publication sites**, **6 dependency families**
- After: **245 unique globals**, **245 publication entries**, **5 publication sites**, **5 dependency families**
- This PR removes **22 unique globals**, **22 publication entries**, **1 complete publication site**, and **1 complete dependency family**.
- **Work remaining: approximately 1–3 focused PRs** to remove or explicitly retain the remaining 245 globals across 5 sites and 5 families.

## Validation

- `./run-tests.sh`
  - module verification: 125 passed
  - Vitest: 398 passed
  - Playwright: 352 passed
  - responsive-theme assertions: 472 passed
- focused affected Playwright coverage: 20 passed
- `node tests/test-recommendations-runtime.js`: 10 passed
- typecheck, checkjs, vendored dependency integrity, and `git diff --check` passed
