### PR TITLE
Remove wearable dashboard globals

### DIFF
--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -4,6 +4,7 @@
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 import { getDeviceSessions } from './light-devices-store.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { getWearablesModuleFunction } from './wearables-runtime.js';
 
 /** @type {Record<string, Function | null>} */
 const dashboardNoteActions = {
@@ -86,12 +87,12 @@ export function getDashboardSnpTableCache() {
 
 /** @param {Element} actionEl */
 export function syncDashboardWearableNow(actionEl) {
-  getRuntimeFunction('syncWearableNow')?.(actionEl);
+  getWearablesModuleFunction('syncWearableNow')?.(actionEl);
 }
 
 /** @param {string} id */
 export function openDashboardWearableDetail(id) {
-  const openDetail = getRuntimeFunction('openWearableDetail');
+  const openDetail = getWearablesModuleFunction('openWearableDetail');
   if (!openDetail) return false;
   openDetail(id);
   return true;
@@ -102,7 +103,7 @@ export function openDashboardWearableDetail(id) {
  * @param {Event} event
  */
 export function openDashboardManualLogForm(id, event) {
-  getRuntimeFunction('openManualLogForm')?.(id, event);
+  getWearablesModuleFunction('openManualLogForm')?.(id, event);
 }
 
 /** @param {string} id */

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -4,6 +4,7 @@
 import { closeEMFInterpretation } from './emf-runtime.js';
 import { getRecommendationModuleFunction } from './recommendations-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { getWearablesModuleFunction } from './wearables-runtime.js';
 
 const markerDetailRuntimeDeps = {
   closeEMFInterpretation,
@@ -133,5 +134,5 @@ export function closeEMFInterpretationRuntime() {
 }
 
 export function uninstallWearableModalFocusTrapRuntime() {
-  getRuntimeFunction('_uninstallWearableModalFocusTrap')?.();
+  getWearablesModuleFunction('_uninstallWearableModalFocusTrap')?.();
 }

--- a/js/wearables-runtime.js
+++ b/js/wearables-runtime.js
@@ -8,6 +8,33 @@ const wearablesRuntimeDeps = {
   openEMFAssessmentEditor,
 };
 
+/** @type {Record<string, (...args: any[]) => any>} */
+const wearableModuleBridge = Object.create(null);
+
+/** @param {Record<string, unknown>} api */
+export function configureWearablesModuleBridge(api = {}) {
+  /** @type {Record<string, ((...args: any[]) => any) | null>} */
+  const previous = { ...wearableModuleBridge };
+  for (const name of Object.keys(api)) {
+    if (!(name in previous)) previous[name] = null;
+  }
+  for (const [name, value] of Object.entries(api)) {
+    if (typeof value === 'function') {
+      wearableModuleBridge[name] = /** @type {(...args: any[]) => any} */ (value);
+    } else if (value === null) {
+      delete wearableModuleBridge[name];
+    }
+  }
+  return previous;
+}
+
+/** @param {string} name */
+export function getWearablesModuleFunction(name) {
+  return typeof wearableModuleBridge[name] === 'function'
+    ? wearableModuleBridge[name]
+    : null;
+}
+
 export function configureWearablesRuntime(deps = {}) {
   const previous = { ...wearablesRuntimeDeps };
   if (typeof deps.openEMFAssessmentEditor === 'function') {
@@ -72,10 +99,4 @@ export function getWearablesViewportSize() {
     width: normalizeViewportDimension(runtime?.innerWidth, 1024),
     height: normalizeViewportDimension(runtime?.innerHeight, 768),
   };
-}
-
-/** @param {Record<string, unknown>} bindings */
-export function exposeWearablesBindings(bindings) {
-  const runtime = getRuntimeWindow();
-  if (runtime) Object.assign(runtime, bindings);
 }

--- a/js/wearables.js
+++ b/js/wearables.js
@@ -37,14 +37,14 @@ import {
   closeManualAddFromDetail,
   deleteManualEntryFromDetail,
   openManualAddFromDetail,
-  openWearableDetail,
+  openWearableDetail as openWearableDetailModal,
   saveManualEntryFromDetail,
   setWearableDetailRange,
   wearableActionAttrs,
 } from './wearables-detail-modal.js';
 import {
   closeWearablesModal,
-  exposeWearablesBindings,
+  configureWearablesModuleBridge,
   getWearablesViewportSize,
   navigateWearables,
   openEMFAssessmentAfterWearablesModalClose,
@@ -52,6 +52,15 @@ import {
 } from './wearables-runtime.js';
 
 export { isWearableStripHidden, setWearableStripHidden, renderWearablesSettingsSection } from './wearables-settings-panel.js';
+export {
+  _uninstallWearableModalFocusTrap,
+  closeManualAddFromDetail,
+  deleteManualEntryFromDetail,
+  openManualAddFromDetail,
+  saveManualEntryFromDetail,
+  setWearableDetailRange,
+  toggleManualLogChip,
+};
 
 let wearableDelegatesInstalled = false;
 
@@ -74,7 +83,7 @@ function handleWearableActionClick(event) {
     openManualLogForm(metricId, event, { delegated: true });
   } else if (action === 'open-detail') {
     if (actionEl.closest('.wearable-card-reorder-wrap')) return;
-    openWearableDetailFromDashboard(metricId);
+    openWearableDetail(metricId);
   } else if (action === 'choose-source') {
     chooseWearableSource(metricId, event);
   } else if (action === 'open-settings-wearables') {
@@ -158,9 +167,9 @@ function resetOpenManualLogForms({ exceptMetricId = '' } = {}) {
   return true;
 }
 
-function openWearableDetailFromDashboard(metricId, opts = {}) {
+export function openWearableDetail(metricId, opts = {}) {
   resetOpenManualLogForms();
-  return openWearableDetail(metricId, opts);
+  return openWearableDetailModal(metricId, opts);
 }
 
 // ─────────────────────────────────────────────────────────
@@ -487,7 +496,7 @@ function renderWearableStripStub() {
   </section>`;
 }
 
-function dismissWearableStub() {
+export function dismissWearableStub() {
   localStorage.setItem(`labcharts-wearable-stub-dismissed-${state.currentProfile}`, '1');
   navigateWearables('dashboard');
 }
@@ -740,7 +749,7 @@ export function renderWearableStrip() {
 // INTERACTIONS
 // ─────────────────────────────────────────────────────────
 
-function toggleWearableStrip() {
+export function toggleWearableStrip() {
   const grid = document.querySelector('.wearable-card-grid');
   const footer = document.querySelector('.wearable-strip-footer');
   const arrow = document.querySelector('.wearable-collapse-arrow');
@@ -769,7 +778,7 @@ function toggleWearableStrip() {
 // Per-metric primary-source override picker. Reads connected sources that
 // actually have data for this metric and lets the user pick one. The summary
 // pipeline respects `state.importedData.wearablePrimaryOverride[metricId]`.
-async function chooseWearableSource(metricId, event) {
+export async function chooseWearableSource(metricId, event) {
   const canon = canonicalMetric(metricId);
   if (!canon) return;
   const connected = listConnectedSources();
@@ -878,7 +887,7 @@ async function chooseWearableSource(metricId, event) {
   }, 0);
 }
 
-async function syncWearableNow(triggerEl) {
+export async function syncWearableNow(triggerEl) {
   const sources = Object.keys(listConnectedSources());
   if (sources.length === 0) {
     showNotification?.('Connect a wearable in Settings → Wearables first', 'info');
@@ -913,12 +922,12 @@ async function syncWearableNow(triggerEl) {
 // Reorder mode — toggle + per-card move handlers. Keeps the reorder flag
 // ephemeral (state._wearableReorderMode) so it auto-resets on reload; the
 // card ORDER itself is persisted per-profile in importedData.wearableCardOrder.
-function toggleWearableReorder() {
+export function toggleWearableReorder() {
   state._wearableReorderMode = !state._wearableReorderMode;
   navigateWearables('dashboard');
 }
 
-async function moveWearableCard(metricId, delta) {
+export async function moveWearableCard(metricId, delta) {
   const summary = state.importedData?.wearableSummary;
   if (!summary) return;
   // Rebuild the CURRENT display order the same way renderWearableStrip does,
@@ -968,7 +977,7 @@ async function moveWearableCard(metricId, delta) {
 // ─────────────────────────────────────────────────────────
 
 
-function openManualLogForm(metricId, event, opts = {}) {
+export function openManualLogForm(metricId, event, opts = {}) {
   if (!opts.delegated && event?.target?.closest?.('[data-wearable-action]')) return;
   if (event) event.stopPropagation();
   let card = document.querySelector(`.wearable-card-empty[data-empty-metric="${metricId}"]`);
@@ -1042,7 +1051,7 @@ function openManualLogForm(metricId, event, opts = {}) {
   });
 }
 
-async function saveManualLog(kind, event) {
+export async function saveManualLog(kind, event) {
   if (event) event.stopPropagation();
   const { logManualMetric, logManualBP, refreshManualSummary } = await import('./wearables-manual.js');
   const profileId = state.currentProfile;
@@ -1085,7 +1094,7 @@ async function saveManualLog(kind, event) {
   }
 }
 
-function cancelManualLog(event) {
+export function cancelManualLog(event) {
   if (event) event.stopPropagation();
   // Re-render the current dashboard/body surface to restore the empty card.
   rerenderCurrentView();
@@ -1093,23 +1102,9 @@ function cancelManualLog(event) {
 
 installWearableDelegates();
 
-exposeWearablesBindings({
-  renderWearableStrip,
-  dismissWearableStub,
-  toggleWearableStrip,
-  openWearableDetail: openWearableDetailFromDashboard,
-  setWearableDetailRange,
-  _uninstallWearableModalFocusTrap,
+configureWearablesModuleBridge({
+  openWearableDetail,
   syncWearableNow,
-  chooseWearableSource,
   openManualLogForm,
-  saveManualLog,
-  cancelManualLog,
-  toggleManualLogChip,
-  openManualAddFromDetail,
-  closeManualAddFromDetail,
-  saveManualEntryFromDetail,
-  deleteManualEntryFromDetail,
-  toggleWearableReorder,
-  moveWearableCard,
+  _uninstallWearableModalFocusTrap,
 });

--- a/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
@@ -15,19 +15,17 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ controlsUrl }) => {
-    const [controlsModule, contextCardsRuntime, dashboardWidgetRuntime] = await Promise.all([
+    const [controlsModule, contextCardsRuntime, dashboardWidgetRuntime, wearablesRuntime] = await Promise.all([
       import(controlsUrl),
       import('/js/context-cards-runtime.js'),
       import('/js/dashboard-widget-runtime.js'),
+      import('/js/wearables-runtime.js'),
     ]);
     const outcomes = {};
     const fixture = document.getElementById('fixture');
     const saved = {
       navigate: window.navigate,
       openSettingsModal: window.openSettingsModal,
-      syncWearableNow: window.syncWearableNow,
-      openWearableDetail: window.openWearableDetail,
-      openManualLogForm: window.openManualLogForm,
       showDetailModal: window.showDetailModal,
     };
     const calls = [];
@@ -37,6 +35,11 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     const previousDashboardNoteActions = dashboardWidgetRuntime.configureDashboardNoteActions({
       openNoteEditor: (...args) => calls.push(['noteEditor', args.length, ...args.map(arg => arg ?? 'null')]),
       deleteNote: index => calls.push(['deleteNote', index]),
+    });
+    const previousWearablesBridge = wearablesRuntime.configureWearablesModuleBridge({
+      syncWearableNow: el => calls.push(['sync', el?.dataset.dashboardWidgetAction || '']),
+      openWearableDetail: id => calls.push(['wearableDetail', id]),
+      openManualLogForm: (id, event) => calls.push(['manualLog', id, event.type]),
     });
     const clone = value => JSON.parse(JSON.stringify(value));
     let prefs = {
@@ -138,9 +141,6 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     try {
       window.navigate = route => calls.push(['navigate', route]);
       window.openSettingsModal = section => calls.push(['settings', section]);
-      window.syncWearableNow = el => calls.push(['sync', el?.dataset.dashboardWidgetAction || '']);
-      window.openWearableDetail = id => calls.push(['wearableDetail', id]);
-      window.openManualLogForm = (id, event) => calls.push(['manualLog', id, event.type]);
       window.showDetailModal = id => calls.push(['markerDetail', id]);
       Storage.prototype.removeItem = function removeItem(key) {
         calls.push(['removeStorage', key]);
@@ -306,6 +306,7 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     } finally {
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       dashboardWidgetRuntime.configureDashboardNoteActions(previousDashboardNoteActions);
+      wearablesRuntime.configureWearablesModuleBridge(previousWearablesBridge);
       Storage.prototype.removeItem = originalRemoveItem;
       for (const [key, value] of Object.entries(saved)) {
         if (value === undefined) delete window[key];

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -5,12 +5,13 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
   await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, dashboardWidgetRuntime, viewsModule, navModule] = await Promise.all([
+    const [{ state }, dataModule, dashboardWidgetsModule, contextCardsRuntime, dashboardWidgetRuntime, wearablesRuntime, viewsModule, navModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/dashboard-widgets.js'),
       import('/js/context-cards-runtime.js'),
       import('/js/dashboard-widget-runtime.js'),
+      import('/js/wearables-runtime.js'),
       import('/js/views.js'),
       import('/js/nav.js'),
     ]);
@@ -20,7 +21,6 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     const savedFns = {
       showDetailModal: window.showDetailModal,
       navigate: window.navigate,
-      syncWearableNow: window.syncWearableNow,
     };
     const hadFns = {};
     for (const name of Object.keys(savedFns)) {
@@ -34,6 +34,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     let bodyActionHost;
     let previousContextCardsRuntime = null;
     let previousDashboardNoteActions = null;
+    let previousWearablesBridge = null;
 
     try {
       if (!dataModule.getActiveData()?.dates?.length) {
@@ -136,9 +137,11 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
       const biometricSurfaceHasNoInlineHandlers = !!biometricWidget
         && !biometricWidget.querySelector('.db-biometric-overview-actions [onclick], .db-biometric-overview-grid [onclick], .db-biometric-overview-grid [onkeydown]');
       let syncCalled = false;
-      window.syncWearableNow = button => {
-        syncCalled = button?.classList?.contains('db-biometric-sync-btn') === true;
-      };
+      previousWearablesBridge = wearablesRuntime.configureWearablesModuleBridge({
+        syncWearableNow: button => {
+          syncCalled = button?.classList?.contains('db-biometric-sync-btn') === true;
+        },
+      });
       const syncBtn = biometricWidget?.querySelector('[data-dashboard-widget-action="sync-biometric-now"]');
       syncBtn?.click();
       await delay(50);
@@ -226,6 +229,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     } finally {
       if (previousContextCardsRuntime) contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       if (previousDashboardNoteActions) dashboardWidgetRuntime.configureDashboardNoteActions(previousDashboardNoteActions);
+      if (previousWearablesBridge) wearablesRuntime.configureWearablesModuleBridge(previousWearablesBridge);
       bodyActionHost?.remove();
       for (const [name, original] of Object.entries(savedFns)) {
         if (hadFns[name]) window[name] = original;
@@ -258,6 +262,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const { dashboardBiometricSelectionKey, dashboardWidgetStorageKey } = await import('/js/dashboard-widgets.js');
     const viewsModule = await import('/js/views.js');
     const recommendationRuntime = await import('/js/recommendations-runtime.js');
+    const wearablesRuntime = await import('/js/wearables-runtime.js');
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, timeout = 1500) => {
       const started = Date.now();
@@ -293,9 +298,6 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       openChatPanel: window.openChatPanel,
       openSettingsModal: window.openSettingsModal,
       showDetailModal: window.showDetailModal,
-      openWearableDetail: window.openWearableDetail,
-      openManualLogForm: window.openManualLogForm,
-      syncWearableNow: window.syncWearableNow,
     };
     const hadFns = {};
     for (const name of Object.keys(savedFns)) {
@@ -310,6 +312,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     };
     const originalCachedCatalog = recommendationRuntime.getRecommendationsCatalogCache();
     let previousRecommendationBridge = null;
+    let previousWearablesBridge = null;
     let realNavigate;
 
     try {
@@ -390,9 +393,11 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     window.openChatPanel = prompt => calls.push(['chat', prompt]);
     window.openSettingsModal = panel => calls.push(['settings', panel]);
     window.showDetailModal = id => calls.push(['detail', id]);
-    window.openWearableDetail = id => calls.push(['wearable-detail', id]);
-    window.openManualLogForm = (id, event) => calls.push(['manual-log', id, event?.type || '']);
-    window.syncWearableNow = button => calls.push(['sync', button?.classList?.contains('db-biometric-sync-btn') === true]);
+    previousWearablesBridge = wearablesRuntime.configureWearablesModuleBridge({
+      openWearableDetail: id => calls.push(['wearable-detail', id]),
+      openManualLogForm: (id, event) => calls.push(['manual-log', id, event?.type || '']),
+      syncWearableNow: button => calls.push(['sync', button?.classList?.contains('db-biometric-sync-btn') === true]),
+    });
 
     const readPrefs = () => JSON.parse(localStorage.getItem(widgetPrefsKey) || '{"order":[],"hidden":[]}');
     const readJson = key => JSON.parse(localStorage.getItem(key) || '[]');
@@ -576,6 +581,9 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       state.currentView = originalState.currentView;
       if (previousRecommendationBridge) {
         recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
+      if (previousWearablesBridge) {
+        wearablesRuntime.configureWearablesModuleBridge(previousWearablesBridge);
       }
       recommendationRuntime.setRecommendationsCatalogCache(originalCachedCatalog);
       for (const [name, original] of Object.entries(savedFns)) {

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -670,10 +670,11 @@ test('marker detail modal covers default deps descriptions alt units and bio age
   await page.waitForSelector('#modal-overlay', { state: 'attached' });
 
   const results = await page.evaluate(async ({ modalUrl }) => {
-    const [modal, markerRuntime, recommendationRuntime, { state }, data] = await Promise.all([
+    const [modal, markerRuntime, recommendationRuntime, wearablesRuntime, { state }, data] = await Promise.all([
       import(modalUrl),
       import('/js/marker-detail-runtime.js'),
       import('/js/recommendations-runtime.js'),
+      import('/js/wearables-runtime.js'),
       import('/js/state.js'),
       import('/js/data.js'),
     ]);
@@ -703,7 +704,6 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       'revertMarkerName',
       'askAIAboutMarker',
       '_getRelevantSNPs',
-      '_uninstallWearableModalFocusTrap',
     ];
     const savedWindow = Object.fromEntries(windowKeys.map(key => [
       key,
@@ -718,6 +718,9 @@ test('marker detail modal covers default deps descriptions alt units and bio age
     const restoreRecommendationRuntime = recommendationRuntime.configureRecommendationModuleBridge({
       isProductRecsEnabled: () => true,
       renderRecommendationSection: async id => `<div class="coverage-rec">rec ${id}</div>`,
+    });
+    const restoreWearablesRuntime = wearablesRuntime.configureWearablesModuleBridge({
+      _uninstallWearableModalFocusTrap: () => calls.push(['uninstall-focus']),
     });
 
     try {
@@ -763,7 +766,6 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       window.revertMarkerName = id => calls.push(['revert-name', id]);
       window.askAIAboutMarker = id => calls.push(['ask-ai', id]);
       window._getRelevantSNPs = () => [];
-      window._uninstallWearableModalFocusTrap = () => calls.push(['uninstall-focus']);
 
       localStorage.setItem('labcharts-marker-desc', JSON.stringify({
         'coverage.cached': 'Cached marker description',
@@ -832,6 +834,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
         renderRecommendationSection: null,
         ...restoreRecommendationRuntime,
       });
+      wearablesRuntime.configureWearablesModuleBridge(restoreWearablesRuntime);
       data.invalidateActiveDataCache();
       modal.configureMarkerDetailModal({
         navigate: (category, payload) => window.navigate?.(category, payload),

--- a/tests/playwright/wearables-bp-merge.spec.js
+++ b/tests/playwright/wearables-bp-merge.spec.js
@@ -3,8 +3,9 @@ import { expect, test } from './coverage-fixture.js';
 test('blood pressure manual log form is idempotent', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  const result = await page.evaluate(() => {
-    if (typeof window.openManualLogForm !== 'function') {
+  const result = await page.evaluate(async () => {
+    const wearables = await import('/js/wearables.js');
+    if (typeof wearables.openManualLogForm !== 'function') {
       return { available: false };
     }
 
@@ -14,10 +15,10 @@ test('blood pressure manual log form is idempotent', async ({ page }) => {
     document.body.appendChild(card);
 
     try {
-      window.openManualLogForm('bp_systolic');
+      wearables.openManualLogForm('bp_systolic');
       const formCountFirst = card.querySelectorAll('.wearable-log-form').length;
 
-      window.openManualLogForm('bp_systolic');
+      wearables.openManualLogForm('bp_systolic');
       const formCountSecond = card.querySelectorAll('.wearable-log-form').length;
       const sysInputPresent = !!document.getElementById('wl-bp-sys');
 
@@ -33,7 +34,7 @@ test('blood pressure manual log form is idempotent', async ({ page }) => {
   });
 
   if (!result.available) {
-    throw new Error('window.openManualLogForm is not exposed - wearables.js handler missing');
+    throw new Error('wearables.openManualLogForm is not exported');
   }
   expect(result.formCountFirst).toBe(1);
   expect(result.formCountSecond).toBe(1);

--- a/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
+++ b/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
@@ -12,8 +12,7 @@ test('wearables detail modal covers manual migration delegated add save and canc
       import('/js/blob-storage.js'),
       import('/js/views.js'),
     ]);
-    // Ensure delegated detail-modal handlers are installed.
-    await import('/js/wearables.js');
+    const wearables = await import('/js/wearables.js');
     const failures = [];
     const check = (name, condition, detail = '') => {
       if (!condition) failures.push(detail ? `${name}: ${detail}` : name);
@@ -52,7 +51,7 @@ test('wearables detail modal covers manual migration delegated add save and canc
     );
     const openAddForm = async metric => {
       await closeDetailModal();
-      await window.openWearableDetail(metric);
+      await wearables.openWearableDetail(metric);
       const triggerSelector = addTriggerSelector(metric);
       const triggerReady = await waitForDetailIdle(metric);
       if (!triggerReady) throw new Error(`manual add trigger not ready for ${metric}; available add buttons: ${debugManualButtons()}`);
@@ -209,7 +208,7 @@ test('wearables detail modal covers manual migration delegated add save and canc
       check('bp detail submit settles rerender before final assertion',
         await waitForDetailIdle('bp_systolic'));
 
-      await window.openWearableDetail('bp_systolic');
+      await wearables.openWearableDetail('bp_systolic');
       await waitFor(() => !!document.querySelector('#detail-modal .wearable-manual-entry[data-entry-date="2026-06-04"]'));
       check('saved bp reading appears in detail manual entries list',
         !!document.querySelector('#detail-modal .wearable-manual-entry[data-entry-date="2026-06-04"] .wearable-manual-entry-note'));

--- a/tests/playwright/wearables-strip-actions-browser-coverage.spec.js
+++ b/tests/playwright/wearables-strip-actions-browser-coverage.spec.js
@@ -52,7 +52,7 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
     const navigations = [];
 
     const renderStrip = () => {
-      host.innerHTML = window.renderWearableStrip();
+      host.innerHTML = wearables.renderWearableStrip();
       return host.querySelector('#wearable-strip') || host.querySelector('.wearable-strip');
     };
 
@@ -134,12 +134,12 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
         && !!host.querySelector('[data-empty-metric="bp_systolic"]')
         && !!host.querySelector('[data-empty-metric="rhr"]'));
 
-      window.toggleWearableStrip();
+      wearables.toggleWearableStrip();
       check('toggleWearableStrip collapses grid and updates persisted state',
         grid?.classList.contains('hidden')
         && arrow?.getAttribute('aria-expanded') === 'false'
         && localStorage.getItem('wearables-strip-collapsed') === '1');
-      window.toggleWearableStrip();
+      wearables.toggleWearableStrip();
       check('toggleWearableStrip expands grid and restores aria state',
         !grid?.classList.contains('hidden')
         && arrow?.getAttribute('aria-expanded') === 'true'
@@ -147,19 +147,19 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
 
       const syncButton = document.createElement('button');
       syncButton.className = 'wearable-strip-sync';
-      await window.syncWearableNow(syncButton);
+      await wearables.syncWearableNow(syncButton);
       check('syncWearableNow disables and restores trigger around manual no-op sync',
         syncButton.disabled === false
         && !syncButton.classList.contains('is-syncing'));
       check('syncWearableNow reports already up to date for tokenless manual source',
         document.getElementById('notification-container')?.textContent.includes('already up to date'));
 
-      window.toggleWearableReorder();
+      wearables.toggleWearableReorder();
       await wait(20);
       check('toggleWearableReorder flips state and rerenders dashboard',
         state._wearableReorderMode === true
         && host.querySelector('.wearable-card-grid-reorder'));
-      await window.moveWearableCard('weight', 1);
+      await wearables.moveWearableCard('weight', 1);
       await wait(20);
       check('moveWearableCard persists visible-order swap',
         Array.isArray(state.importedData.wearableCardOrder)
@@ -169,7 +169,7 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
       state._wearableReorderMode = false;
       renderStrip();
 
-      window.openManualLogForm('weight');
+      wearables.openManualLogForm('weight');
       check('openManualLogForm renders weight form in empty card',
         !!host.querySelector('#wl-weight-val')
         && !!host.querySelector('#wl-weight-date')
@@ -177,7 +177,7 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
       host.querySelector('#wl-weight-val').value = '73.5';
       host.querySelector('#wl-weight-date').value = '2026-06-10';
       host.querySelector('#wl-weight-note').value = 'coverage strip action';
-      await window.saveManualLog('weight');
+      await wearables.saveManualLog('weight');
       const saved = await waitFor(async () => {
         const row = await store.getDaily(profileId, 'manual', '2026-06-10');
         return row?.weight === 73.5 && row?.note === 'coverage strip action';

--- a/tests/test-a11y-phase3.js
+++ b/tests/test-a11y-phase3.js
@@ -300,7 +300,8 @@ console.log('=== Phase 3 A11y Tests ===\n');
   assert('wearables dashboard browser hooks are isolated in runtime adapter',
     wearSrc.includes("from './wearables-runtime.js'")
       && !/\bwindow\b/.test(wearSrc)
-      && wearRuntimeSrc.includes('exposeWearablesBindings')
+      && wearRuntimeSrc.includes('configureWearablesModuleBridge')
+      && wearRuntimeSrc.includes('getWearablesModuleFunction')
       && wearRuntimeSrc.includes('getWearablesViewportSize'));
 
   const importDropZoneSrc = read('/js/import-drop-zone.js');

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -20,6 +20,7 @@ import {
   triggerDashboardDnaPicker,
 } from '../js/dashboard-widget-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
+import { configureWearablesModuleBridge } from '../js/wearables-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -35,15 +36,13 @@ const runtimeKeys = [
   'getSessions',
   '_snpTableCache',
   'openSettingsModal',
-  'syncWearableNow',
-  'openWearableDetail',
-  'openManualLogForm',
   'showDetailModal',
   'navigate',
   'triggerDNAFilePicker',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const savedImportedData = state.importedData;
+let previousWearablesModule = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -101,9 +100,11 @@ try {
   const actionEl = { dataset: { dashboardWidgetAction: 'sync-biometric-now' } };
   const event = { type: 'click' };
   setRuntimeValue('openSettingsModal', section => calls.push(['settings', section]));
-  setRuntimeValue('syncWearableNow', el => calls.push(['sync', el?.dataset?.dashboardWidgetAction || '']));
-  setRuntimeValue('openWearableDetail', id => calls.push(['wearable-detail', id]));
-  setRuntimeValue('openManualLogForm', (id, ev) => calls.push(['manual-log', id, ev.type]));
+  previousWearablesModule = configureWearablesModuleBridge({
+    syncWearableNow: el => calls.push(['sync', el?.dataset?.dashboardWidgetAction || '']),
+    openWearableDetail: id => calls.push(['wearable-detail', id]),
+    openManualLogForm: (id, ev) => calls.push(['manual-log', id, ev.type]),
+  });
   setRuntimeValue('showDetailModal', id => calls.push(['marker-detail', id]));
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
   setRuntimeValue('triggerDNAFilePicker', () => calls.push(['legacy-dna']));
@@ -131,12 +132,16 @@ try {
       calls.some(call => call.join('|') === 'note-editor|null|2') &&
       calls.some(call => call.join('|') === 'delete-note|1'));
 
-  delete globalThis.openWearableDetail;
+  configureWearablesModuleBridge({ openWearableDetail: null });
   assert('openDashboardWearableDetail reports missing callback',
     openDashboardWearableDetail('sleep') === false);
 
   configureContextCardsRuntimeCallbacks({ triggerDNAFilePicker: null });
   configureDashboardNoteActions({ openNoteEditor: null, deleteNote: null });
+  configureWearablesModuleBridge({
+    syncWearableNow: null,
+    openManualLogForm: null,
+  });
   delete globalThis.window;
   const callCountBeforeMissingRuntime = calls.length;
   openDashboardWearablesSettings();
@@ -157,6 +162,12 @@ try {
   configureDashboardNoteActions(previousDashboardNoteActions);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
+  configureWearablesModuleBridge({
+    syncWearableNow: null,
+    openWearableDetail: null,
+    openManualLogForm: null,
+    ...previousWearablesModule,
+  });
   state.importedData = savedImportedData;
   restoreRuntime();
 }

--- a/tests/test-marker-detail-runtime.js
+++ b/tests/test-marker-detail-runtime.js
@@ -21,6 +21,7 @@ import {
 } from '../js/marker-detail-runtime.js';
 import { configureRecommendationModuleBridge } from '../js/recommendations-runtime.js';
 import { configureViewRuntime } from '../js/views-runtime-bridge.js';
+import { configureWearablesModuleBridge } from '../js/wearables-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -40,10 +41,10 @@ const runtimeKeys = [
   'askAIAboutMarker',
   'showEmojiPicker',
   '_getRelevantSNPs',
-  '_uninstallWearableModalFocusTrap',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 let previousViewRuntime = null;
+let previousWearablesModule = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -94,7 +95,9 @@ try {
   const restoreMarkerDetailRuntime = configureMarkerDetailRuntime({
     closeEMFInterpretation: () => calls.push(['emf-close']),
   });
-  setRuntimeValue('_uninstallWearableModalFocusTrap', () => calls.push(['focus-trap']));
+  previousWearablesModule = configureWearablesModuleBridge({
+    _uninstallWearableModalFocusTrap: () => calls.push(['focus-trap']),
+  });
 
   navigateMarkerDetailRuntime('dashboard', { from: 'marker' });
   buildMarkerDetailSidebarRuntime();
@@ -143,6 +146,7 @@ try {
     renderRecommendationSection: null,
   });
   configureViewRuntime({ buildSidebar: null });
+  configureWearablesModuleBridge({ _uninstallWearableModalFocusTrap: null });
   const beforeMissingRuntimeCalls = calls.length;
   navigateMarkerDetailRuntime('dashboard');
   buildMarkerDetailSidebarRuntime();
@@ -164,6 +168,10 @@ try {
   configureMarkerDetailRuntime(restoreMarkerDetailRuntime);
   configureRecommendationModuleBridge(previousRecommendationBridge);
 } finally {
+  configureWearablesModuleBridge({
+    _uninstallWearableModalFocusTrap: null,
+    ...previousWearablesModule,
+  });
   configureRecommendationModuleBridge({
     isProductRecsEnabled: null,
     renderRecommendationSection: null,

--- a/tests/test-wearables-delegated-actions.js
+++ b/tests/test-wearables-delegated-actions.js
@@ -65,9 +65,10 @@ assert('wearables module installs idempotent click keydown and submit delegates'
 assert('wearables delegated clicks are scoped to wearables surfaces',
   stripSrc.includes("closest('.wearable-strip, #detail-modal, .db-biometric-overview-grid')"));
 assert('wearables detail opens reset any active manual inline form',
-  stripSrc.includes('function openWearableDetailFromDashboard') &&
+  stripSrc.includes('export function openWearableDetail') &&
     stripSrc.includes('resetOpenManualLogForms();') &&
-    stripSrc.includes('openWearableDetail: openWearableDetailFromDashboard'));
+    stripSrc.includes('configureWearablesModuleBridge({') &&
+    stripSrc.includes('openWearableDetail,'));
 assert('wearables delegated manual log open bypasses only the legacy inline-card guard',
   stripSrc.includes("openManualLogForm(metricId, event, { delegated: true })") &&
     stripSrc.includes("!opts.delegated && event?.target?.closest?.('[data-wearable-action]')") &&

--- a/tests/test-wearables-dom.js
+++ b/tests/test-wearables-dom.js
@@ -36,7 +36,7 @@ return (async function() {
   const store = await import('../js/wearables-store.js');
   const ah = await import('../js/wearables-apple-health.js');
   const reg = await import('../js/wearable-adapters.js');
-  await import('../js/wearables.js'); // registers window.openWearableDetail / renderWearableStrip
+  const wearables = await import('../js/wearables.js');
   const views = await import('../js/views.js');
 
   window._labState.importedData = window._labState.importedData || {};
@@ -56,7 +56,7 @@ return (async function() {
         hrv_rmssd: { primarySource: 'oura', latest: 42, latestDate: '2026-04-22', baseline: 40, baselineP25: 36, baselineP75: 44, rolling: { d7: 42, d30: 40, d90: 40 }, trend30d: 'rising', weekly: [38, 40, 42] },
       },
     };
-    stripHost.innerHTML = window.renderWearableStrip();
+    stripHost.innerHTML = wearables.renderWearableStrip();
     document.body.prepend(stripHost);
     const emptyWeightCard = stripHost.querySelector('.wearable-card-empty[data-empty-metric="weight"]');
     assert('Strip renders empty manual card with delegated open action',
@@ -88,7 +88,7 @@ return (async function() {
     { source: 'oura', date: '2026-04-22', hrv_rmssd: 42, activity_score: 0 },
   ]);
 
-  await window.openWearableDetail('hrv_rmssd');
+  await wearables.openWearableDetail('hrv_rmssd');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.[0]?.data?.length === 3);
   assert('Detail modal opens on a valid metric', document.getElementById('modal-overlay').classList.contains('show'));
   const modalHtml = document.getElementById('detail-modal').innerHTML;
@@ -108,7 +108,7 @@ return (async function() {
     rangeButtons.map(b => b.textContent.trim()).join('|') === '90d|6m|1y|All');
   assert('Detail modal defaults to 90d range',
     document.querySelector('#detail-modal .wearable-detail-range .ctx-btn-option.active')?.textContent?.trim() === '90d');
-  window.setWearableDetailRange('hrv_rmssd', '6m');
+  wearables.setWearableDetailRange('hrv_rmssd', '6m');
   await waitFor(() => document.querySelector('#detail-modal .wearable-detail-range .ctx-btn-option.active')?.textContent?.trim() === '6m');
   assert('Range toggle persists and re-renders active 6m pill',
     localStorage.getItem('wearable-detail-range') === '6m' &&
@@ -116,7 +116,7 @@ return (async function() {
   views.closeModal();
   assert('closeModal clears modal chart instance', !window._labState.chartInstances?.modal);
 
-  await window.openWearableDetail('activity_score');
+  await wearables.openWearableDetail('activity_score');
   await new Promise(r => setTimeout(r, 60));
   assert('Rest-mode hint shown on all-zero activity score',
     /Rest Mode/.test(document.getElementById('detail-modal').innerHTML));
@@ -140,7 +140,7 @@ return (async function() {
     { source: 'manual', date: '2026-04-21', bp_systolic: 121, bp_diastolic: 79 },
     { source: 'manual', date: '2026-04-22', bp_systolic: 120, bp_diastolic: 80, note: 'after walk', tags: ['rested'] },
   ]);
-  await window.openWearableDetail('bp_systolic');
+  await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /Diastolic/.test(d?.label || '')));
   const bpModalText = document.getElementById('detail-modal')?.textContent || '';
   const bpChart = window._labState.chartInstances?.modal;
@@ -177,7 +177,7 @@ return (async function() {
     { source: 'manual', date: '2026-06-20', bp_diastolic: 80 },
     { source: 'manual', date: '2026-06-22', bp_diastolic: 78 },
   ]);
-  await window.openWearableDetail('bp_systolic');
+  await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic/.test(d?.label || '')));
   const mixedModalText = document.getElementById('detail-modal')?.textContent || '';
   const mixedChartLabels = window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || [];
@@ -215,7 +215,7 @@ return (async function() {
     { source: 'manual', date: '2026-06-21', bp_systolic: 122, bp_diastolic: 80 },
     { source: 'manual', date: '2026-06-22', bp_systolic: 121, bp_diastolic: 79 },
   ]);
-  await window.openWearableDetail('bp_systolic');
+  await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Diastolic \(Manual/.test(d?.label || '')));
   const mixedManualPrimaryText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP mixed manual-diastolic fallback chooses the newest same-date pair across chart and manual candidates',
@@ -224,7 +224,7 @@ return (async function() {
       && !/Latest\s+125\/79 mmHg/.test(mixedManualPrimaryText), mixedManualPrimaryText);
   views.closeModal();
 
-  await window.openWearableDetail('bp_diastolic');
+  await wearables.openWearableDetail('bp_diastolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /systolic/i.test(d?.label || '')));
   assert('Opening bp_diastolic normalizes to the paired BP detail view',
     (window._labState.chartInstances?.modal?.data?.datasets?.map(d => d.label) || []).some(l => /systolic/i.test(l)) &&
@@ -247,7 +247,7 @@ return (async function() {
     { source: 'withings', date: '2026-06-24', bp_systolic: 130 },
     { source: 'manual', date: '2026-06-22', bp_diastolic: 78 },
   ]);
-  await window.openWearableDetail('bp_systolic');
+  await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => /No same-date pair/.test(document.getElementById('detail-modal')?.textContent || ''));
   const splitDateText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP latest row does not synthesize a split-date summary pair when no same-date candidate exists',
@@ -255,7 +255,7 @@ return (async function() {
   views.closeModal();
 
   window._labState.importedData.wearableSummary.metrics.bp_diastolic.latestDate = undefined;
-  await window.openWearableDetail('bp_systolic');
+  await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => /No same-date pair/.test(document.getElementById('detail-modal')?.textContent || ''));
   const missingDateText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP latest row does not synthesize a summary pair when one latest date is missing',
@@ -278,7 +278,7 @@ return (async function() {
     { source: 'manual', date: '2026-06-21', bp_systolic: 122, bp_diastolic: 80 },
     { source: 'manual', date: '2026-06-22', bp_systolic: 121, bp_diastolic: 79 },
   ]);
-  await window.openWearableDetail('bp_systolic');
+  await wearables.openWearableDetail('bp_systolic');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => /^Manual systolic$/.test(d?.label || '')));
   const manualOnlyText = document.getElementById('detail-modal')?.textContent || '';
   assert('BP modal hides empty chart hint when manual readings are charted',
@@ -329,7 +329,7 @@ return (async function() {
   await store.upsertDailyBatch(TEST_PROFILE, [
     { source: 'oura', date: '2026-04-22', spo2_avg: 97 },
   ]);
-  await window.openWearableDetail('spo2_avg');
+  await wearables.openWearableDetail('spo2_avg');
   await new Promise(r => setTimeout(r, 60));
   const modalSpo2Html = document.getElementById('detail-modal').innerHTML;
   assert('Modal renders SpO2 97 as integer (no .0)', !/97\.0/.test(modalSpo2Html));
@@ -364,7 +364,7 @@ return (async function() {
     { source: 'oura', date: yesterdayISO, steps: 9000 },
     { source: 'oura', date: todayISO, steps: 1200 },
   ]);
-  await window.openWearableDetail('steps');
+  await wearables.openWearableDetail('steps');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.[0]?.data?.some(p => p?.x === todayISO));
   const stepsChart = window._labState.chartInstances?.modal;
   const todayIdx = stepsChart?.data?.datasets?.[0]?.data?.findIndex(p => p?.x === todayISO);
@@ -424,7 +424,7 @@ return (async function() {
     { source: 'oura', date: vendorDay1, rhr: 62 },
     { source: 'manual', date: todayISO, rhr: 57 },
   ]);
-  await window.openWearableDetail('rhr');
+  await wearables.openWearableDetail('rhr');
   await waitFor(() => window._labState?.chartInstances?.modal?.data?.datasets?.some(d => d?._kind === 'manual'));
   const rhrChart = window._labState.chartInstances?.modal;
   const manualDs = rhrChart?.data?.datasets?.find(d => d?._kind === 'manual');
@@ -472,7 +472,7 @@ return (async function() {
     },
     changeHistory: [],
   };
-  await window.openWearableDetail('hrv_rmssd');
+  await wearables.openWearableDetail('hrv_rmssd');
   await new Promise(r => setTimeout(r, 250));
   const modalText = document.getElementById('detail-modal')?.textContent || '';
   assert('v1.26 P1-2: HRV modal shows empty-state row "Not from Oura · why?" (behavior)',

--- a/tests/test-wearables-manual.js
+++ b/tests/test-wearables-manual.js
@@ -8,8 +8,8 @@
 //
 // Run: node tests/test-wearables-manual.js  (or via npm test)
 //
-// Full port — no DOM rendering. The window-export checks rely on wearables.js
-// registering its handlers on window; IndexedDB runs via fake-indexeddb.
+// Full port — no DOM rendering. Wearable handler export checks use the module
+// facade; IndexedDB runs via fake-indexeddb.
 
 import './_node-shim.js';
 
@@ -44,13 +44,12 @@ function assert(name, condition, detail) {
 
 console.log('=== Manual-as-wearable-source Tests ===\n');
 
-// state.js → window._labState; wearables.js registers the openManualLogForm /
-// saveManualLog / toggleManualLogChip window handlers the export checks probe.
+// state.js exposes the legacy test-state bridge; wearable actions are modules.
 await import('../js/state.js');
 const manual = await import('../js/wearables-manual.js');
 const store = await import('../js/wearables-store.js');
 const adapters = await import('../js/wearable-adapters.js');
-await import('../js/wearables.js');
+const wearables = await import('../js/wearables.js');
 
 // ═══════════════════════════════════════
 // 1. Module exports
@@ -77,9 +76,10 @@ assert('MANUAL_TAGS includes core context set',
 assert('deleteManualMetric exported', typeof manual.deleteManualMetric === 'function');
 assert('refreshManualSummary exported', typeof manual.refreshManualSummary === 'function');
 
-assert('openManualLogForm on window', typeof window.openManualLogForm === 'function');
-assert('saveManualLog on window', typeof window.saveManualLog === 'function');
-assert('cancelManualLog on window', typeof window.cancelManualLog === 'function');
+assert('manual dashboard actions are module exports',
+  typeof wearables.openManualLogForm === 'function'
+    && typeof wearables.saveManualLog === 'function'
+    && typeof wearables.cancelManualLog === 'function');
 
 const wearablesSrc = await fetch('js/wearables.js').then(r => r.text());
 const wearablesDetailSrc = await fetch('js/wearables-detail-modal.js').then(r => r.text());
@@ -291,7 +291,8 @@ try {
     weightRow?.tags?.includes('post-workout'));
 
   assert('wearables.js renders tag chips on bp form', wearablesSrc.includes('_renderTagChips'));
-  assert('toggleManualLogChip on window', typeof window.toggleManualLogChip === 'function');
+  assert('toggleManualLogChip is a module export',
+    typeof wearables.toggleManualLogChip === 'function');
 
   const saveFn = wearablesDetailSrc.match(/async function saveManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';
   const delFn = wearablesDetailSrc.match(/async function deleteManualEntryFromDetail[\s\S]*?\n\}\s*\n/)?.[0] || '';

--- a/tests/test-wearables-runtime.js
+++ b/tests/test-wearables-runtime.js
@@ -3,8 +3,9 @@
 import './_node-shim.js';
 import {
   closeWearablesModal,
+  configureWearablesModuleBridge,
   configureWearablesRuntime,
-  exposeWearablesBindings,
+  getWearablesModuleFunction,
   getWearablesViewportSize,
   navigateWearables,
   openEMFAssessmentAfterWearablesModalClose,
@@ -27,7 +28,6 @@ const runtimeKeys = [
   'setTimeout',
   'innerWidth',
   'innerHeight',
-  'wearableProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -105,10 +105,13 @@ try {
       && lateCalls.some(call => call[0] === 'emf-editor'));
   configureWearablesRuntime(restoreWearablesRuntime);
 
-  const probe = () => 'ok';
-  exposeWearablesBindings({ wearableProbe: probe });
-  assert('exposeWearablesBindings assigns runtime exports',
-    globalThis.wearableProbe === probe);
+  const restoreWearablesBridge = configureWearablesModuleBridge({ wearableProbe: () => 'ok' });
+  assert('wearables module bridge registers callbacks without browser globals',
+    getWearablesModuleFunction('wearableProbe')?.() === 'ok'
+      && !('wearableProbe' in globalThis));
+  configureWearablesModuleBridge(restoreWearablesBridge);
+  assert('wearables module bridge snapshots remove newly added callbacks on restore',
+    getWearablesModuleFunction('wearableProbe') === null);
 
   const beforeNoWindowCalls = calls.length;
   delete globalThis.window;
@@ -116,10 +119,9 @@ try {
   closeWearablesModal();
   openWearablesSettings();
   openEMFAssessmentAfterWearablesModalClose(50);
-  exposeWearablesBindings({ wearableProbe: null });
   const fallbackViewport = getWearablesViewportSize();
   assert('runtime adapter no-ops safely when window is missing',
-    calls.length === beforeNoWindowCalls && globalThis.wearableProbe === probe);
+    calls.length === beforeNoWindowCalls);
   assert('viewport helper returns fallback size without window',
     fallbackViewport.width === 1024 && fallbackViewport.height === 768);
 } finally {

--- a/tests/test-wearables-ui-flows.js
+++ b/tests/test-wearables-ui-flows.js
@@ -17,6 +17,7 @@ return (async function() {
   const manual    = await import('../js/wearables-manual.js' + bust);
   const store     = await import('../js/wearables-store.js' + bust);
   const summary   = await import('../js/wearables-summary.js' + bust);
+  const wearables = await import('../js/wearables.js');
   const views     = await import('../js/views.js');
 
   // ─────────────────────────────────────────────────────────
@@ -54,7 +55,7 @@ return (async function() {
   // 1. Detail modal opens via openWearableDetail
   // ═══════════════════════════════════════
   console.log('%c 1. Detail Modal Open ', 'font-weight:bold;color:#f59e0b');
-  await window.openWearableDetail('weight');
+  await wearables.openWearableDetail('weight');
   await new Promise(r => setTimeout(r, 300));
   const overlay = document.getElementById('modal-overlay');
   assert('Modal overlay opens via openWearableDetail',
@@ -99,7 +100,7 @@ return (async function() {
   // 3. Cancel button does NOT trigger delete
   // ═══════════════════════════════════════
   console.log('%c 3. Cancel — no delete ', 'font-weight:bold;color:#f59e0b');
-  await window.openWearableDetail('rhr');
+  await wearables.openWearableDetail('rhr');
   await new Promise(r => setTimeout(r, 300));
   const delBtn2 = document.querySelector('#detail-modal .wearable-manual-entry-del');
   if (delBtn2) {
@@ -145,12 +146,12 @@ return (async function() {
     oldRhrSummary?.primarySource === 'oura' && oldRhrSummary?.latest === 61,
     JSON.stringify(oldRhrSummary));
   localStorage.setItem('wearable-detail-range', '90d');
-  await window.openWearableDetail('rhr');
+  await wearables.openWearableDetail('rhr');
   await new Promise(r => setTimeout(r, 300));
   assert('Older manual RHR appears in the default detail manual-entry list',
     !!document.querySelector(`#detail-modal .wearable-manual-entry[data-entry-date="${oldManualDate}"]`));
   localStorage.setItem('wearable-detail-range', 'all');
-  await window.openWearableDetail('rhr');
+  await wearables.openWearableDetail('rhr');
   await new Promise(r => setTimeout(r, 500));
   const chartDatasets = window._labState.chartInstances?.modal?.data?.datasets || [];
   const manualOverlay = chartDatasets.find(ds => ds.label === 'Manual');
@@ -182,7 +183,7 @@ return (async function() {
              rolling: { d7: 62, d30: 62, d90: 62 }, trend30d: 'flat', weekly: [62] },
     },
   };
-  await window.openWearableDetail('rhr');
+  await wearables.openWearableDetail('rhr');
   await new Promise(r => setTimeout(r, 300));
   const swapBtn = document.querySelector('#detail-modal .wearable-modal-source-swap');
   assert('Source-swap button renders on detail modal when ≥2 wearables connected',

--- a/tests/test-wearables.js
+++ b/tests/test-wearables.js
@@ -553,8 +553,7 @@ try {
 // 9. Render-helper divide-by-zero guards
 // ═══════════════════════════════════════
 console.log('9. Render Guards');
-// Force-load wearables.js (side-effect module that registers window.*).
-await import('../js/wearables.js');
+const wearablesModule = await import('../js/wearables.js');
 // deltaClassFor / formatDelta are not exported — they're internal to the strip
 // render. We test them via the full render path: a metric with baseline=0 must
 // NOT produce "NaN%" in the rendered HTML, and the delta cell must still carry
@@ -568,7 +567,7 @@ const zeroBaselineSummary = {
 // Stash summary so renderWearableStrip reads it
 window._labState.importedData = window._labState.importedData || {};
 window._labState.importedData.wearableSummary = zeroBaselineSummary;
-const html = window.renderWearableStrip();
+const html = wearablesModule.renderWearableStrip();
 assert('render never emits NaN% on zero baseline', !/NaN/.test(html));
 // v1.26.0: zero-baseline metrics suppress the delta entirely (was "→ —"),
 // since "→ —" reads like "we measured something." A missing delta pill is
@@ -589,7 +588,7 @@ const mixedCoverageSummary = {
   },
 };
 window._labState.importedData.wearableSummary = mixedCoverageSummary;
-const mixedHtml = window.renderWearableStrip();
+const mixedHtml = wearablesModule.renderWearableStrip();
 assert('header source label omits zero-coverage vendor', !/wearable-source-label[^>]*>[^<]*Polar/.test(mixedHtml));
 assert('header source label still shows the data-bearing vendor', /wearable-source-label[^>]*>[^<]*Oura/.test(mixedHtml));
 assert('coverage label reflects only data-bearing source', /·\s*15d/.test(mixedHtml));
@@ -609,7 +608,7 @@ const stalenessSummary = {
   },
 };
 window._labState.importedData.wearableSummary = stalenessSummary;
-const stripStaleHtml = window.renderWearableStrip();
+const stripStaleHtml = wearablesModule.renderWearableStrip();
 assert('Stale metric (HRV) gets "as of {date}" hint when its latestDate < source max',
   /wearable-staleness[^>]*>\s*as of\s*[A-Z][a-z]+/.test(stripStaleHtml));
 // Only one staleness hint should appear in the strip (HRV) — sleep_score's
@@ -628,7 +627,30 @@ delete window._labState.importedData.wearableSummary;
 // 10. Window exports for render handlers
 // ═══════════════════════════════════════
 console.log('10. Browser and module exports');
-assert('window.renderWearableStrip exists', typeof window.renderWearableStrip === 'function');
+const wearableDashboardModuleExports = [
+  'renderWearableStrip',
+  'dismissWearableStub',
+  'toggleWearableStrip',
+  'openWearableDetail',
+  'setWearableDetailRange',
+  '_uninstallWearableModalFocusTrap',
+  'syncWearableNow',
+  'chooseWearableSource',
+  'openManualLogForm',
+  'saveManualLog',
+  'cancelManualLog',
+  'toggleManualLogChip',
+  'openManualAddFromDetail',
+  'closeManualAddFromDetail',
+  'saveManualEntryFromDetail',
+  'deleteManualEntryFromDetail',
+  'toggleWearableReorder',
+  'moveWearableCard',
+];
+assert('wearable dashboard handlers are module exports',
+  wearableDashboardModuleExports.every(name => typeof wearablesModule[name] === 'function'));
+assert('wearable dashboard handlers stay off window',
+  wearableDashboardModuleExports.every(name => !(name in window)));
 assert('wearable settings renderer is a module export',
   typeof wearableSettings.renderWearablesSettingsSection === 'function');
 assert('wearable settings actions are module exports',
@@ -649,9 +671,6 @@ const wearableSettingsLegacyGlobals = [
 ];
 assert('wearable settings handlers stay module-only',
   wearableSettingsLegacyGlobals.every(name => !(name in window)));
-assert('window.syncWearableNow exists', typeof window.syncWearableNow === 'function');
-assert('window.openWearableDetail exists', typeof window.openWearableDetail === 'function');
-assert('window.setWearableDetailRange exists', typeof window.setWearableDetailRange === 'function');
 assert('handleWearablePATConnect removed (Ultrahuman moved to OAuth2)',
   typeof window.handleWearablePATConnect === 'undefined');
 
@@ -1160,7 +1179,7 @@ const strip2 = {
   },
 };
 window._labState.importedData.wearableSummary = strip2;
-const stripSpo2Html = window.renderWearableStrip();
+const stripSpo2Html = wearablesModule.renderWearableStrip();
 // Strip renderer is a pure string-builder — assert it here in Node. The
 // matching *modal*-renderer parity check (openWearableDetail) lives in
 // test-wearables-dom.js. Neither should produce "97.0 %" — both "97 %".
@@ -1799,7 +1818,7 @@ window._labState.importedData = {
 };
 // BEHAVIOR: source badge appears on EVERY populated card whenever ≥2
 // wearables connected — was grep-only in 17a until now.
-const stripHtml = window.renderWearableStrip();
+const stripHtml = wearablesModule.renderWearableStrip();
 // Count cards that have a source-badge button. With 2 sources connected
 // and 2 metrics in the summary, both should carry one.
 const badgeMatches = stripHtml.match(/wearable-source-badge wearable-source-badge-btn/g) || [];

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -222,15 +222,11 @@ interface Window {
   refreshWebSearchToggle?: AnyFunction;
   saveImportedData?: AnyFunction;
   _getRelevantSNPs?: AnyFunction;
-  _uninstallWearableModalFocusTrap?: AnyFunction;
   deleteNote?: AnyFunction;
   detectWearableTrendSlots?: AnyFunction;
   loadContextCardTips?: AnyFunction;
-  openManualLogForm?: AnyFunction;
   openNoteEditor?: AnyFunction;
-  openWearableDetail?: AnyFunction;
   showDetailModal?: AnyFunction;
-  syncWearableNow?: AnyFunction;
   triggerDNAFilePicker?: AnyFunction;
   renderLightTools?: AnyFunction;
   renderSunDataSourceSettings?: AnyFunction;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.233';
+self.APP_VERSION = '1.10.234';


### PR DESCRIPTION
## Summary

- remove the 18-function wearable dashboard facade from `window`
- route dashboard-widget and marker-detail consumers through a cycle-safe module bridge
- expose wearable actions as ES module exports and update Node/browser coverage to use them
- remove obsolete wearable global types and bump the cache version to `1.10.234`

## Window burden

- after #1204: 245 published bindings across 5 publication families
- after this PR: 227 published bindings across 4 publication families
- reduction: 18 bindings and the wearable publication family

## Dependency

This is stacked on #1204. Merge #1204 first; this PR will then narrow to the single `Remove wearable dashboard globals` commit.

## Validation

- `./run-tests.sh`
  - 125/125 module verification checks
  - 398/398 Vitest tests
  - 352/352 Playwright tests
  - 472/472 responsive-theme assertions
- affected Playwright subset: 15/15 passed
- targeted wearable/runtime suites: 813 assertions passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `git diff --check`
