### PR TITLE
Remove Settings globals

### DIFF
--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -11,6 +11,7 @@ import { openMenstrualCycleEditor } from './cycle.js';
 import { openSupplementsEditor } from './supplements.js';
 import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
 import { getActivePersonality } from './chat-personalities.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   chatOnboardingActionAttrs,
@@ -47,7 +48,7 @@ function chatEmptyRuntime() {
 }
 
 function callChatEmptyRuntime(name, ...args) {
-  const fn = chatEmptyRuntime()[name];
+  const fn = getSettingsModuleFunction(name) || chatEmptyRuntime()[name];
   const runtimeFn = typeof fn === 'function' ? fn : getViewRuntimeFunction(name);
   return runtimeFn ? runtimeFn(...args) : undefined;
 }

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -21,6 +21,7 @@ import {
   getRecommendationModuleFunction,
   setRecommendationsCatalogCache,
 } from './recommendations-runtime.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 
 let _dashboardWelcomeActionsInstalled = false;
 
@@ -77,7 +78,7 @@ function handleDashboardWelcomeActionClick(event) {
     appWindow.openChatPanel?.();
   } else if (action === 'open-ai-settings') {
     appWindow.closeChatPanel?.();
-    appWindow.openSettingsModal?.('ai');
+    getSettingsModuleFunction('openSettingsModal')?.('ai');
   } else if (action === 'direct-import') {
     document.getElementById('pdf-input')?.click();
   } else if (action === 'load-demo') {

--- a/js/dashboard-recommendation-widget.js
+++ b/js/dashboard-recommendation-widget.js
@@ -13,6 +13,7 @@ import {
   getRecommendationsSnpTable,
   setRecommendationsCatalogCache,
 } from './recommendations-runtime.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let dashboardRecommendationDelegatesInstalled = false;
@@ -27,7 +28,9 @@ function getDashboardRecommendationRuntimeValue(name) {
 
 function callDashboardRecommendationRuntime(name, ...args) {
   const runtime = dashboardRecommendationRuntime();
-  const fn = getDashboardRecommendationRuntimeValue(name) || getViewRuntimeFunction(name);
+  const fn = getSettingsModuleFunction(name)
+    || getDashboardRecommendationRuntimeValue(name)
+    || getViewRuntimeFunction(name);
   return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
 }
 

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -3,6 +3,7 @@
 
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 import { getDeviceSessions } from './light-devices-store.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { getWearablesModuleFunction } from './wearables-runtime.js';
 
@@ -56,7 +57,7 @@ export function getDashboardViewportHeight() {
 }
 
 export function openDashboardWearablesSettings() {
-  getRuntimeFunction('openSettingsModal')?.('wearables');
+  getSettingsModuleFunction('openSettingsModal')?.('wearables');
 }
 
 export function getDashboardLightSessions() {

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -6,6 +6,7 @@ import { escapeHTML, escapeAttr } from './utils.js';
 import { profileStorageKey } from './profile.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const LENS_PAGE_ORDER_VERSION = 1;
@@ -25,7 +26,9 @@ function lensPageRuntime() {
 }
 
 function callLensPageRuntime(name, ...args) {
-  const fn = lensPageRuntime()[name] || (name === 'navigate' ? getViewRuntimeFunction(name) : null);
+  const fn = getSettingsModuleFunction(name)
+    || lensPageRuntime()[name]
+    || (name === 'navigate' ? getViewRuntimeFunction(name) : null);
   if (typeof fn === 'function') fn(...args);
 }
 

--- a/js/pdf-import.js
+++ b/js/pdf-import.js
@@ -62,10 +62,10 @@ import {
   openImportReviewFromSnapshot,
   setPdfImportBatchMode,
 } from './pdf-import-commit.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 
 /**
  * @typedef {{
- *   openSettingsModal?: (tab?: string) => void,
  *   isDNAFile?: (file: File) => boolean,
  *   isDNAFileByContent?: (file: File) => Promise<boolean>,
  *   detectDNAFile?: (header: string) => string | null,
@@ -178,7 +178,10 @@ export function showAINeededDialog(action = 'import') {
   openModalOverlay(overlay, { initialFocus: '#ai-needed-or', focusDelay: 50 });
   const close = () => closeModalOverlay(overlay);
   document.getElementById('ai-needed-or').onclick = () => { close(); pdfImportDeps.startOpenRouterOAuth(); };
-  document.getElementById('ai-needed-key').onclick = () => { close(); if (pdfImportWindow.openSettingsModal) pdfImportWindow.openSettingsModal('ai'); };
+  document.getElementById('ai-needed-key').onclick = () => {
+    close();
+    getSettingsModuleFunction('openSettingsModal')?.('ai');
+  };
   document.getElementById('ai-needed-demo').onclick = () => {
     close();
     const sex = state.profileSex === 'female' ? 'female' : 'male';

--- a/js/provider-local-ai-runtime.js
+++ b/js/provider-local-ai-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // provider-local-ai-runtime.js - Browser runtime adapters for Local AI settings hooks.
 
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -18,7 +20,7 @@ function getRuntimeFunction(name) {
 
 /** @param {boolean} [isAvailable] */
 export function updatePrivacyStatusCardFromRuntime(isAvailable) {
-  const update = getRuntimeFunction('updatePrivacyStatusCard');
+  const update = getSettingsModuleFunction('updatePrivacyStatusCard');
   if (!update) return;
   if (typeof isAvailable === 'boolean') update(isAvailable);
   else update();

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -100,6 +100,7 @@ import {
   doRoutstrWalletRestore,
   walletRuntime
 } from './provider-wallet-panels.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 function providerPanelRuntime() {
@@ -112,7 +113,7 @@ function getProviderPanelRuntimeValue(name) {
 
 function callProviderPanelRuntime(name, ...args) {
   const runtime = providerPanelRuntime();
-  const fn = runtime[name] || getViewRuntimeFunction(name);
+  const fn = getSettingsModuleFunction(name) || runtime[name] || getViewRuntimeFunction(name);
   return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
 }
 

--- a/js/provider-ppq-panels.js
+++ b/js/provider-ppq-panels.js
@@ -17,7 +17,7 @@ import { updateKeyCache } from './crypto.js';
 import { ensureQRCode } from './provider-qr.js';
 import { renderAIProviderPanel } from './provider-panel-renderers.js';
 import { renderPpqModelDropdown } from './provider-model-controls.js';
-import { callUtilsRuntimeFunction } from './utils-runtime.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 
 let returnToChatIfOnboarding = function() {};
 let _ppqCreating = false;
@@ -217,7 +217,7 @@ export async function handleRemovePpqKey() {
     localStorage.removeItem('labcharts-ppq-private-vision-models');
     localStorage.removeItem('labcharts-ppq-credit-id');
     showNotification('PPQ key removed', 'info');
-    callUtilsRuntimeFunction('openSettingsModal');
+    getSettingsModuleFunction('openSettingsModal')?.();
   }
 }
 

--- a/js/settings-runtime-bridge.js
+++ b/js/settings-runtime-bridge.js
@@ -1,0 +1,29 @@
+// @ts-check
+// settings-runtime-bridge.js - Cycle-safe access to Settings module actions.
+
+/** @type {Record<string, (...args: any[]) => any>} */
+const settingsModuleBridge = Object.create(null);
+
+/** @param {Record<string, unknown>} api */
+export function configureSettingsModuleBridge(api = {}) {
+  /** @type {Record<string, ((...args: any[]) => any) | null>} */
+  const previous = { ...settingsModuleBridge };
+  for (const name of Object.keys(api)) {
+    if (!(name in previous)) previous[name] = null;
+  }
+  for (const [name, value] of Object.entries(api)) {
+    if (typeof value === 'function') {
+      settingsModuleBridge[name] = /** @type {(...args: any[]) => any} */ (value);
+    } else if (value === null) {
+      delete settingsModuleBridge[name];
+    }
+  }
+  return previous;
+}
+
+/** @param {string} name */
+export function getSettingsModuleFunction(name) {
+  return typeof settingsModuleBridge[name] === 'function'
+    ? settingsModuleBridge[name]
+    : null;
+}

--- a/js/settings-runtime.js
+++ b/js/settings-runtime.js
@@ -2,6 +2,7 @@
 // settings-runtime.js - Browser runtime adapters for Settings and Tweaks flows.
 
 import { getMeteoConfig, saveMeteoConfig } from './sun-uvdata-config.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 
 const DEFAULT_METEO_CONFIG = Object.freeze({
   mode: 'auto',
@@ -98,8 +99,8 @@ export function addSettingsRuntimeEventListener(type, listener) {
  */
 export function refreshSettingsRuntimeSurfaces(options = {}) {
   const runtime = getRuntimeWindow();
-  (options.updateSettingsUI || runtime.updateSettingsUI)?.();
-  (options.updateTweaksUI || runtime.updateTweaksUI)?.();
+  (options.updateSettingsUI || getSettingsModuleFunction('updateSettingsUI'))?.();
+  (options.updateTweaksUI || getSettingsModuleFunction('updateTweaksUI'))?.();
   if (options.settingsVisible) runtime.refreshSettingsWearables?.();
 }
 
@@ -126,9 +127,4 @@ export function saveSettingsMeteoConfig(config) {
   } catch {
     return false;
   }
-}
-
-/** @param {Record<string, any>} api */
-export function publishSettingsGlobals(api) {
-  Object.assign(getRuntimeWindow(), api);
 }

--- a/js/settings-sync-panel.js
+++ b/js/settings-sync-panel.js
@@ -17,6 +17,7 @@ import {
   setAgentAccessWearableSeriesDays,
 } from './sync.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { saveImportedData } from './data.js';
 import { state } from './state.js';
 import {
@@ -57,7 +58,6 @@ function restoreImportedDataSnapshot(snapshot) {
 const appWindow = /** @type {Window & typeof globalThis & {
   applyPendingTombstone?: (id: string) => Promise<void>,
   listPendingTombstones?: () => Array<{ id: string, name: string, at?: string | number | Date }>,
-  openSettingsModal?: (tab?: string) => void,
   pushContextToGateway?: () => void,
   rejectPendingTombstone?: (id: string) => Promise<void>,
   updateSyncIndicator?: () => void,
@@ -110,10 +110,10 @@ async function handleSettingsSyncClick(event) {
 
   if (action === 'apply-tombstone') {
     await appWindow.applyPendingTombstone?.(actionEl.dataset.tombId || '');
-    appWindow.openSettingsModal?.('data');
+    getSettingsModuleFunction('openSettingsModal')?.('data');
   } else if (action === 'reject-tombstone') {
     await appWindow.rejectPendingTombstone?.(actionEl.dataset.tombId || '');
-    appWindow.openSettingsModal?.('data');
+    getSettingsModuleFunction('openSettingsModal')?.('data');
   } else if (action === 'toggle-mnemonic') {
     toggleMnemonicVisibility();
   } else if (action === 'copy-mnemonic') {

--- a/js/settings.js
+++ b/js/settings.js
@@ -22,11 +22,11 @@ import {
 import {
   addSettingsRuntimeEventListener,
   cancelSettingsFrame,
-  publishSettingsGlobals,
   refreshSettingsRuntimeSurfaces,
   requestSettingsFrame,
   settingsMediaMatches,
 } from './settings-runtime.js';
+import { configureSettingsModuleBridge } from './settings-runtime-bridge.js';
 import {
   installSunDataSourceDelegates,
   renderPrivacyAnalyticsSection,
@@ -1056,12 +1056,13 @@ export function closeSettingsModal() {
   settingsRuntime.refreshMobileDashboardActiveTab();
 }
 
-publishSettingsGlobals({
+configureSettingsModuleBridge({
   openSettingsModal,
   closeSettingsModal,
   updatePrivacyStatusCard,
   openTweaksPanel,
   closeTweaksPanel,
   applyAccentOverride,
+  updateSettingsUI,
   updateTweaksUI,
 });

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -3,6 +3,7 @@
 
 import { handleImportStatusClick, isImportRunning } from './pdf-import-progress.js';
 import { openFeedbackModal } from './feedback.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let shellDelegatesInstalled = false;
@@ -47,7 +48,7 @@ function shellRuntime() {
 }
 
 function callShellRuntime(name, ...args) {
-  const fn = shellRuntime()[name];
+  const fn = getSettingsModuleFunction(name) || shellRuntime()[name];
   if (typeof fn === 'function') fn(...args);
 }
 

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -12,6 +12,7 @@ import { maybeShowBackupNudge } from './crypto.js';
 import { maybeShowLegalConsentGate } from './legal-consent.js';
 import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 import { maybeShowAnalyticsConsent } from './utils.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const startupUIDeps = {
@@ -46,14 +47,14 @@ function getStartupRuntimeValue(name) {
 
 function callStartupRuntime(name, ...args) {
   const runtime = startupRuntime();
-  const fn = runtime[name] || getViewRuntimeFunction(name);
+  const fn = getSettingsModuleFunction(name) || runtime[name] || getViewRuntimeFunction(name);
   if (typeof fn !== 'function') return undefined;
   return fn.apply(runtime, args);
 }
 
 function requireStartupRuntime(name, ...args) {
   const runtime = startupRuntime();
-  const fn = runtime[name] || getViewRuntimeFunction(name);
+  const fn = getSettingsModuleFunction(name) || runtime[name] || getViewRuntimeFunction(name);
   if (typeof fn !== 'function') {
     throw new TypeError(`Startup runtime function ${name} is not available`);
   }

--- a/js/sync-ui.js
+++ b/js/sync-ui.js
@@ -4,6 +4,7 @@
 import { showNotification, isDebugMode, escapeAttr, escapeHTML } from './utils.js';
 import { getSyncRelay } from './sync-environment.js';
 import { getRelayQuotaEstimate } from './sync-relay-health.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import {
   getRecentSyncEvents,
   getSyncDisplayState as getSyncDisplayStateFromStatus,
@@ -39,7 +40,7 @@ function handleSyncUIClick(event) {
     appWindow.location?.reload?.();
   } else if (action === 'open-settings') {
     toggleSyncDetail();
-    appWindow.openSettingsModal?.('data');
+    getSettingsModuleFunction('openSettingsModal')?.('data');
   } else if (action === 'force-resend') {
     void appWindow.forceResendCurrentProfile?.();
     toggleSyncDetail();

--- a/js/theme-runtime.js
+++ b/js/theme-runtime.js
@@ -1,6 +1,8 @@
 // @ts-check
 // theme-runtime.js - Browser runtime adapters for theme module globals.
 
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
+
 function getThemeRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -23,9 +25,9 @@ export function dispatchThemeChange(detail) {
 export function refreshThemeDependentsFromRuntime(options = {}) {
   const runtime = getThemeRuntimeWindow();
   if (!runtime) return;
-  runtime.applyAccentOverride?.();
-  runtime.updateSettingsUI?.();
-  runtime.updateTweaksUI?.();
+  getSettingsModuleFunction('applyAccentOverride')?.();
+  getSettingsModuleFunction('updateSettingsUI')?.();
+  getSettingsModuleFunction('updateTweaksUI')?.();
   if (typeof runtime.scheduleChartThemeRefresh === 'function') runtime.scheduleChartThemeRefresh();
   else runtime.refreshChartThemeColors?.({ batchSize: 4 });
   if (options.settingsModalOpen) runtime.refreshSettingsWearables?.();

--- a/js/wearables-runtime.js
+++ b/js/wearables-runtime.js
@@ -2,6 +2,7 @@
 // wearables-runtime.js - Browser runtime adapters for wearable dashboard hooks.
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const wearablesRuntimeDeps = {
@@ -79,7 +80,7 @@ export function closeWearablesModal() {
 }
 
 export function openWearablesSettings() {
-  getRuntimeFunction('openSettingsModal')?.('wearables');
+  getSettingsModuleFunction('openSettingsModal')?.('wearables');
 }
 
 /** @param {number} delayMs */

--- a/js/wearables-settings-runtime.js
+++ b/js/wearables-settings-runtime.js
@@ -2,6 +2,7 @@
 // wearables-settings-runtime.js - Browser runtime adapters for wearable settings hooks.
 
 import { showConfirmDialog } from './utils.js';
+import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const wearableSettingsRuntimeDeps = { showConfirmDialog };
@@ -35,7 +36,7 @@ function getRuntimeFunction(name) {
 }
 
 export function closeWearableSettingsModal() {
-  getRuntimeFunction('closeSettingsModal')?.();
+  getSettingsModuleFunction('closeSettingsModal')?.();
 }
 
 export function navigateWearablesDashboard() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -213,6 +213,7 @@ const APP_SHELL = [
   '/js/settings-data.js',
   '/js/settings-provider-bridge.js',
   '/js/settings-runtime.js',
+  '/js/settings-runtime-bridge.js',
   '/js/settings-sync-panel.js',
   '/js/settings-agent-access-panel.js',
   '/js/feedback.js',

--- a/tests/playwright/cashu-wallet-browser-coverage.spec.js
+++ b/tests/playwright/cashu-wallet-browser-coverage.spec.js
@@ -842,7 +842,7 @@ test('routstr wallet panels and delegates cover browser-only actions', async ({ 
       localStorage.removeItem('labcharts-routstr-pricing');
       localStorage.removeItem('labcharts-routstr-vision-models');
       (await import('/js/views.js')).closeModal();
-      window.closeSettingsModal?.();
+      (await import('/js/settings.js')).closeSettingsModal();
     }
   });
 

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -10,11 +10,12 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async () => {
-    const [{ renderEmptyChatState }, { state }, { getProfileLocation }, contextCardsRuntime] = await Promise.all([
+    const [{ renderEmptyChatState }, { state }, { getProfileLocation }, contextCardsRuntime, settingsBridge] = await Promise.all([
       import('/js/chat-empty-state.js'),
       import('/js/state.js'),
       import('/js/profile.js'),
       import('/js/context-cards-runtime.js'),
+      import('/js/settings-runtime-bridge.js'),
     ]);
 
     const saved = {
@@ -27,7 +28,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     };
     const savedFns = {
       closeChatPanel: window.closeChatPanel,
-      openSettingsModal: window.openSettingsModal,
     };
     const savedInputClick = HTMLInputElement.prototype.click;
     const chatMessages = document.getElementById('chat-messages');
@@ -36,6 +36,9 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     const calls = [];
     const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
       triggerDNAFilePicker: () => calls.push('import-dna'),
+    });
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: tab => calls.push(`open-settings:${tab}`),
     });
     const inputClicks = [];
     const container = document.createElement('div');
@@ -47,7 +50,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       if (chatMessages) chatMessages.innerHTML = '';
 
       window.closeChatPanel = () => calls.push('close-chat');
-      window.openSettingsModal = tab => calls.push(`open-settings:${tab}`);
       HTMLInputElement.prototype.click = function() {
         inputClicks.push(this === strayMtDnaInput ? 'stray' : panel.contains(this) ? 'scoped' : 'other');
       };
@@ -137,6 +139,7 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       };
     } finally {
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       state.profileSex = saved.profileSex;

--- a/tests/playwright/custom-api-settings.spec.js
+++ b/tests/playwright/custom-api-settings.spec.js
@@ -3,9 +3,8 @@ import { expect, test } from './coverage-fixture.js';
 test('custom API provider panel renders from Settings AI', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  await page.evaluate(() => {
-    if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
-    window.openSettingsModal('ai');
+  await page.evaluate(async () => {
+    (await import('/js/settings.js')).openSettingsModal('ai');
   });
 
   const providerButtons = page.locator('.ai-provider-btn');
@@ -47,7 +46,7 @@ test('custom API connected state renders model controls', async ({ page }) => {
   await page.evaluate(async () => {
     const api = await import('/js/api.js');
     const cryptoStore = await import('/js/crypto.js');
-    if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
+    const settings = await import('/js/settings.js');
     api.setCustomApiUrl('https://api.test.com/v1');
     cryptoStore.updateKeyCache('labcharts-custom-key', 'sk-test');
     api.setCustomApiModel('test-model');
@@ -56,7 +55,7 @@ test('custom API connected state renders model controls', async ({ page }) => {
       { id: 'other-model', name: 'Other Model' },
     ]));
     api.setAIProvider('custom');
-    window.openSettingsModal('ai');
+    settings.openSettingsModal('ai');
   });
   await page.locator('.ai-provider-btn[data-provider="custom"]').dispatchEvent('click');
 
@@ -78,12 +77,12 @@ test('custom API provider delegates save model changes and removal', async ({ pa
   ];
 
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openSettingsModal === 'function');
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
     const crypto = await import('/js/crypto.js');
     const providerPanels = await import('/js/provider-panels.js');
+    const settings = await import('/js/settings.js');
     const outcomes = {};
     const storageKeys = [
       'labcharts-ai-provider',
@@ -156,7 +155,7 @@ test('custom API provider delegates save model changes and removal', async ({ pa
         return savedFetch.call(window, url, options);
       };
 
-      window.openSettingsModal('ai');
+      settings.openSettingsModal('ai');
       await waitFor(() => document.getElementById('ai-provider-panel'), 'settings AI panel');
       providerPanels.switchAIProvider('custom');
       await waitFor(() =>
@@ -232,7 +231,7 @@ test('custom API provider delegates save model changes and removal', async ({ pa
       await restoreCustomKey();
       if (savedSessionLock == null) sessionStorage.removeItem('labcharts-ai-settings-local-lock-until');
       else sessionStorage.setItem('labcharts-ai-settings-local-lock-until', savedSessionLock);
-      window.closeSettingsModal?.();
+      settings.closeSettingsModal();
       document.querySelectorAll('.notification-toast').forEach(toast => toast.remove());
     }
 

--- a/tests/playwright/custom-lens.spec.js
+++ b/tests/playwright/custom-lens.spec.js
@@ -46,9 +46,9 @@ test('knowledge base modal renders lens controls and settings AI does not', asyn
 
   await page.evaluate(async () => {
     const { closeKnowledgeBaseModal } = await import('/js/lens.js');
+    const settings = await import('/js/settings.js');
     closeKnowledgeBaseModal();
-    if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
-    window.openSettingsModal('ai');
+    settings.openSettingsModal('ai');
   });
 
   await expect(page.locator('.settings-tab-panel[data-tab-panel="ai"] #custom-lens-section')).toHaveCount(0);

--- a/tests/playwright/cycle-import-browser-coverage.spec.js
+++ b/tests/playwright/cycle-import-browser-coverage.spec.js
@@ -210,7 +210,7 @@ test('cycle import confirms before changing an explicitly male profile', async (
 test('Apple Health Settings import closes Settings before showing cycle review', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
   const profileId = await initializeCycleProfile(page, 'apple_health_settings_cycle');
-  await page.evaluate(() => window.openSettingsModal('wearables'));
+  await page.evaluate(async () => (await import('/js/settings.js')).openSettingsModal('wearables'));
   const settings = page.locator('#settings-modal-overlay');
   await expect(settings).toHaveClass(/show/);
   await page.locator('#apple-health-file-input').setInputFiles({

--- a/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
@@ -15,17 +15,17 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ controlsUrl }) => {
-    const [controlsModule, contextCardsRuntime, dashboardWidgetRuntime, wearablesRuntime] = await Promise.all([
+    const [controlsModule, contextCardsRuntime, dashboardWidgetRuntime, settingsRuntimeBridge, wearablesRuntime] = await Promise.all([
       import(controlsUrl),
       import('/js/context-cards-runtime.js'),
       import('/js/dashboard-widget-runtime.js'),
+      import('/js/settings-runtime-bridge.js'),
       import('/js/wearables-runtime.js'),
     ]);
     const outcomes = {};
     const fixture = document.getElementById('fixture');
     const saved = {
       navigate: window.navigate,
-      openSettingsModal: window.openSettingsModal,
       showDetailModal: window.showDetailModal,
     };
     const calls = [];
@@ -40,6 +40,9 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
       syncWearableNow: el => calls.push(['sync', el?.dataset.dashboardWidgetAction || '']),
       openWearableDetail: id => calls.push(['wearableDetail', id]),
       openManualLogForm: (id, event) => calls.push(['manualLog', id, event.type]),
+    });
+    const previousSettingsBridge = settingsRuntimeBridge.configureSettingsModuleBridge({
+      openSettingsModal: section => calls.push(['settings', section]),
     });
     const clone = value => JSON.parse(JSON.stringify(value));
     let prefs = {
@@ -140,7 +143,6 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
 
     try {
       window.navigate = route => calls.push(['navigate', route]);
-      window.openSettingsModal = section => calls.push(['settings', section]);
       window.showDetailModal = id => calls.push(['markerDetail', id]);
       Storage.prototype.removeItem = function removeItem(key) {
         calls.push(['removeStorage', key]);
@@ -306,6 +308,7 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     } finally {
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       dashboardWidgetRuntime.configureDashboardNoteActions(previousDashboardNoteActions);
+      settingsRuntimeBridge.configureSettingsModuleBridge(previousSettingsBridge);
       wearablesRuntime.configureWearablesModuleBridge(previousWearablesBridge);
       Storage.prototype.removeItem = originalRemoveItem;
       for (const [key, value] of Object.entries(saved)) {

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -262,6 +262,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const { dashboardBiometricSelectionKey, dashboardWidgetStorageKey } = await import('/js/dashboard-widgets.js');
     const viewsModule = await import('/js/views.js');
     const recommendationRuntime = await import('/js/recommendations-runtime.js');
+    const settingsRuntimeBridge = await import('/js/settings-runtime-bridge.js');
     const wearablesRuntime = await import('/js/wearables-runtime.js');
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, timeout = 1500) => {
@@ -296,7 +297,6 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       rollingChannelTotals: window.rollingChannelTotals,
       getSessions: window.getSessions,
       openChatPanel: window.openChatPanel,
-      openSettingsModal: window.openSettingsModal,
       showDetailModal: window.showDetailModal,
     };
     const hadFns = {};
@@ -312,6 +312,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     };
     const originalCachedCatalog = recommendationRuntime.getRecommendationsCatalogCache();
     let previousRecommendationBridge = null;
+    let previousSettingsBridge = null;
     let previousWearablesBridge = null;
     let realNavigate;
 
@@ -391,8 +392,10 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     window.rollingChannelTotals = () => ({ circadian: 0 });
     window.getSessions = () => [];
     window.openChatPanel = prompt => calls.push(['chat', prompt]);
-    window.openSettingsModal = panel => calls.push(['settings', panel]);
     window.showDetailModal = id => calls.push(['detail', id]);
+    previousSettingsBridge = settingsRuntimeBridge.configureSettingsModuleBridge({
+      openSettingsModal: panel => calls.push(['settings', panel]),
+    });
     previousWearablesBridge = wearablesRuntime.configureWearablesModuleBridge({
       openWearableDetail: id => calls.push(['wearable-detail', id]),
       openManualLogForm: (id, event) => calls.push(['manual-log', id, event?.type || '']),
@@ -581,6 +584,9 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       state.currentView = originalState.currentView;
       if (previousRecommendationBridge) {
         recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
+      if (previousSettingsBridge) {
+        settingsRuntimeBridge.configureSettingsModuleBridge(previousSettingsBridge);
       }
       if (previousWearablesBridge) {
         wearablesRuntime.configureWearablesModuleBridge(previousWearablesBridge);

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -55,19 +55,19 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
   await prepareApp(page);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, shell, profile, contextCardsRuntime, views, nav] = await Promise.all([
+    const [{ state }, dataModule, shell, profile, contextCardsRuntime, settingsBridge, views, nav] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/lens-page-shell.js'),
       import('/js/profile.js'),
       import('/js/context-cards-runtime.js'),
+      import('/js/settings-runtime-bridge.js'),
       import('/js/views.js'),
       import('/js/nav.js'),
     ]);
     const originalView = state.currentView;
     const originalReimportDNA = window.reimportDNA;
     const originalConfirmDeleteDNA = window.confirmDeleteDNA;
-    const originalOpenSettings = window.openSettingsModal;
     const originalOpenChat = window.openChatPanel;
     const originalNavigate = window.navigate;
     const profileId = profile.getActiveProfileId() || state.currentProfile || 'default';
@@ -77,6 +77,9 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
     const calls = [];
     const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
       triggerDNAFilePicker: () => calls.push(['trigger-dna']),
+    });
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: pane => calls.push(['settings', pane]),
     });
     const restoreShell = shell.configureLensPageShell({
       addDashboardWidgetFromLens: id => calls.push(['add', id]),
@@ -113,7 +116,6 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
 
       window.reimportDNA = () => calls.push(['reimport-dna']);
       window.confirmDeleteDNA = () => calls.push(['delete-dna']);
-      window.openSettingsModal = pane => calls.push(['settings', pane]);
       window.openChatPanel = () => calls.push(['chat']);
       window.navigate = route => calls.push(['navigate', route]);
       const actionFixture = document.createElement('div');
@@ -154,9 +156,9 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       };
     } finally {
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       window.reimportDNA = originalReimportDNA;
       window.confirmDeleteDNA = originalConfirmDeleteDNA;
-      window.openSettingsModal = originalOpenSettings;
       window.openChatPanel = originalOpenChat;
       shell.configureLensPageShell(restoreShell);
       if (originalNavigate) window.navigate = originalNavigate;

--- a/tests/playwright/openrouter-settings.spec.js
+++ b/tests/playwright/openrouter-settings.spec.js
@@ -8,13 +8,12 @@ test('OpenRouter provider controls render from Settings AI', async ({ page }) =>
   });
   await page.goto('/app', { waitUntil: 'load' });
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     window.endTour?.();
     document.getElementById('tour-overlay')?.remove();
     document.getElementById('tour-spotlight')?.remove();
     document.getElementById('tour-tooltip')?.remove();
-    if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
-    window.openSettingsModal('ai');
+    (await import('/js/settings.js')).openSettingsModal('ai');
   });
 
   const providerButtons = page.locator('.ai-provider-btn');

--- a/tests/playwright/pdf-import-browser-coverage.spec.js
+++ b/tests/playwright/pdf-import-browser-coverage.spec.js
@@ -9,15 +9,15 @@ test('PDF import progress and AI-needed dialog cover browser UI states', async (
   await page.waitForSelector('.header-import-btn', { state: 'attached' });
 
   const results = await page.evaluate(async ({ progressUrl, pdfImportUrl }) => {
-    const [progress, pdfImport] = await Promise.all([
+    const [progress, pdfImport, settingsBridge] = await Promise.all([
       import(progressUrl),
       import(pdfImportUrl),
+      import('/js/settings-runtime-bridge.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
     const saved = {
       profileSex: state.profileSex,
-      openSettingsModal: window.openSettingsModal,
       navigate: window.navigate,
     };
     const calls = [];
@@ -25,9 +25,11 @@ test('PDF import progress and AI-needed dialog cover browser UI states', async (
       loadDemoData: sex => calls.push(['demo', sex]),
       startOpenRouterOAuth: () => calls.push(['oauth']),
     });
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: tab => calls.push(['settings', tab]),
+    });
 
     try {
-      window.openSettingsModal = tab => calls.push(['settings', tab]);
       window.navigate = view => calls.push(['navigate', view]);
       state.profileSex = 'female';
 
@@ -128,7 +130,7 @@ test('PDF import progress and AI-needed dialog cover browser UI states', async (
     } finally {
       state.profileSex = saved.profileSex;
       pdfImport.configurePdfImportDeps(previousPdfImportDeps);
-      window.openSettingsModal = saved.openSettingsModal;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       window.navigate = saved.navigate;
       progress.hideImportProgress('cancel');
       document.getElementById('import-modal-overlay')?.classList.remove('show');

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -386,6 +386,7 @@ test('provider panels cover provider switching key saves balances custom API and
   const results = await page.evaluate(async ({ panelsUrl }) => {
     const panels = await import(panelsUrl);
     const cryptoStore = await import('/js/crypto.js');
+    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200, headers = {}) => new Response(JSON.stringify(body), {
       status,
@@ -429,8 +430,6 @@ test('provider panels cover provider switching key saves balances custom API and
     const oldGlobals = {
       fetch: window.fetch,
       open: window.open,
-      openSettingsModal: window.openSettingsModal,
-      closeSettingsModal: window.closeSettingsModal,
       openChatPanel: window.openChatPanel,
       loadFocusCard: window.loadFocusCard,
       clearE2EESession: window.clearE2EESession,
@@ -441,6 +440,10 @@ test('provider panels cover provider switching key saves balances custom API and
     let chatOpened = 0;
     let focusLoads = 0;
     let e2eeClears = 0;
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: () => {},
+      closeSettingsModal: () => { settingsClosed += 1; },
+    });
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
@@ -450,8 +453,6 @@ test('provider panels cover provider switching key saves balances custom API and
       cryptoStore.updateKeyCache('labcharts-ppq-key', '');
       cryptoStore.updateKeyCache('labcharts-custom-key', '');
       window.open = url => { openedUrl = String(url); return null; };
-      window.openSettingsModal = () => {};
-      window.closeSettingsModal = () => { settingsClosed += 1; };
       window.openChatPanel = () => { chatOpened += 1; };
       window.loadFocusCard = () => { focusLoads += 1; };
       window.clearE2EESession = () => { e2eeClears += 1; };
@@ -660,8 +661,7 @@ test('provider panels cover provider switching key saves balances custom API and
     } finally {
       window.fetch = oldGlobals.fetch;
       window.open = oldGlobals.open;
-      window.openSettingsModal = oldGlobals.openSettingsModal;
-      window.closeSettingsModal = oldGlobals.closeSettingsModal;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       window.openChatPanel = oldGlobals.openChatPanel;
       window.loadFocusCard = oldGlobals.loadFocusCard;
       window.clearE2EESession = oldGlobals.clearE2EESession;
@@ -695,6 +695,7 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
     const ppq = await import(ppqUrl);
     const delegates = await import('/js/provider-panel-delegates.js');
     const cryptoStore = await import('/js/crypto.js');
+    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -715,7 +716,6 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
       fetch: window.fetch,
       setInterval: window.setInterval,
       clearInterval: window.clearInterval,
-      openSettingsModal: window.openSettingsModal,
       clipboard: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
     };
     const intervals = [];
@@ -724,6 +724,9 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
     let returnToChatCount = 0;
     let settingsOpened = 0;
     let createMode = 'paid';
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: () => { settingsOpened += 1; },
+    });
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
@@ -786,8 +789,6 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
         </div>
       `);
       const panel = document.getElementById('ai-provider-panel');
-      window.openSettingsModal = () => { settingsOpened += 1; };
-
       panel.innerHTML = `
         <input id="ppq-key-input" value="sk-ppq-default">
         <button id="save-ppq-key-btn">Save</button>
@@ -926,7 +927,7 @@ test('ppq panels cover account reveal topup picker invoice states and cleanup', 
       window.fetch = oldGlobals.fetch;
       window.setInterval = oldGlobals.setInterval;
       window.clearInterval = oldGlobals.clearInterval;
-      window.openSettingsModal = oldGlobals.openSettingsModal;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       if (oldGlobals.clipboard) Object.defineProperty(navigator, 'clipboard', oldGlobals.clipboard);
       else delete navigator.clipboard;
       ppq.configurePpqPanels({ returnToChatIfOnboarding: () => {} });

--- a/tests/playwright/routstr-wallet-dom.spec.js
+++ b/tests/playwright/routstr-wallet-dom.spec.js
@@ -2,12 +2,12 @@ import { expect, test } from './coverage-fixture.js';
 
 test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openSettingsModal === 'function');
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
     const cryptoStore = await import('/js/crypto.js');
     const providerPanels = await import('/js/provider-panels.js');
+    const settings = await import('/js/settings.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -208,7 +208,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       localStorage.setItem('labcharts-routstr-key', 'sk-routstr-dom');
       cryptoStore.updateKeyCache('labcharts-routstr-key', 'sk-routstr-dom');
 
-      window.openSettingsModal('ai');
+      settings.openSettingsModal('ai');
       await wait(100);
       providerPanels.switchAIProvider('routstr');
       await wait(150);
@@ -398,7 +398,7 @@ test('Routstr wallet DOM flows recover deposits, refunds, and seed onboarding', 
       cryptoStore.updateKeyCache('labcharts-routstr-key', oldStorage['labcharts-routstr-key'] || '');
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       (await import('/js/views.js')).closeModal();
-      window.closeSettingsModal?.();
+      settings.closeSettingsModal();
     }
   });
 

--- a/tests/playwright/settings-browser-coverage.spec.js
+++ b/tests/playwright/settings-browser-coverage.spec.js
@@ -9,7 +9,6 @@ async function preparePage(page) {
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openSettingsModal === 'function');
   await page.evaluate(() => {
     window.endTour?.();
     document.getElementById('tour-overlay')?.remove();

--- a/tests/playwright/settings-provider-browser-coverage.spec.js
+++ b/tests/playwright/settings-provider-browser-coverage.spec.js
@@ -11,6 +11,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
     const pii = await import(piiUrl);
     const providerStorage = await import(providerStorageUrl);
     const cryptoStore = await import('/js/crypto.js');
+    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
       status,
@@ -29,7 +30,6 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
     for (const key of storageKeys) oldStorage[key] = localStorage.getItem(key);
     const oldGlobals = {
       fetch: window.fetch,
-      updatePrivacyStatusCard: window.updatePrivacyStatusCard,
       clipboard: navigator.clipboard,
     };
     const writes = [];
@@ -37,11 +37,13 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
     let chatReturns = 0;
     let corsProbe = false;
     let localFetchCount = 0;
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      updatePrivacyStatusCard: () => { privacyUpdates += 1; },
+    });
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
       cryptoStore.updateKeyCache('labcharts-ollama', '');
-      window.updatePrivacyStatusCard = () => { privacyUpdates += 1; };
       Object.defineProperty(navigator, 'clipboard', {
         configurable: true,
         value: {
@@ -226,7 +228,7 @@ test('local AI settings controls cover connection, advisor, privacy, and hardwar
       };
     } finally {
       window.fetch = oldGlobals.fetch;
-      window.updatePrivacyStatusCard = oldGlobals.updatePrivacyStatusCard;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       if (oldGlobals.clipboard) {
         Object.defineProperty(navigator, 'clipboard', { configurable: true, value: oldGlobals.clipboard });
       }
@@ -258,6 +260,7 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
     const syncState = await import(syncStateUrl);
     const syncRuntime = await import(syncRuntimeUrl);
     const syncMessenger = await import(syncMessengerUrl);
+    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 60; attempt += 1) {
@@ -283,7 +286,6 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       applyPendingTombstone: window.applyPendingTombstone,
       rejectPendingTombstone: window.rejectPendingTombstone,
       listPendingTombstones: window.listPendingTombstones,
-      openSettingsModal: window.openSettingsModal,
       updateSyncIndicator: window.updateSyncIndicator,
       pushContextToGateway: window.pushContextToGateway,
       clipboard: navigator.clipboard,
@@ -296,6 +298,9 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
     const openedTabs = [];
     let syncIndicatorUpdates = 0;
     let pushedContexts = 0;
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: tab => { openedTabs.push(tab); },
+    });
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
@@ -303,7 +308,6 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       window.applyPendingTombstone = async id => { applied.push(id); };
       window.rejectPendingTombstone = async id => { rejected.push(id); };
       window.listPendingTombstones = () => [{ id: 'profile-old', name: 'Old Profile', at: '2026-06-07T12:00:00Z' }];
-      window.openSettingsModal = tab => { openedTabs.push(tab); };
       window.updateSyncIndicator = () => { syncIndicatorUpdates += 1; };
       window.pushContextToGateway = () => { pushedContexts += 1; };
       window.fetch = async () => new Response('', { status: 200 });
@@ -497,7 +501,7 @@ test('settings sync and agent access delegates cover setup, restore, relay, tomb
       window.applyPendingTombstone = oldGlobals.applyPendingTombstone;
       window.rejectPendingTombstone = oldGlobals.rejectPendingTombstone;
       window.listPendingTombstones = oldGlobals.listPendingTombstones;
-      window.openSettingsModal = oldGlobals.openSettingsModal;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       window.updateSyncIndicator = oldGlobals.updateSyncIndicator;
       window.pushContextToGateway = oldGlobals.pushContextToGateway;
       window.fetch = oldGlobals.fetch;

--- a/tests/playwright/settings-toggles.spec.js
+++ b/tests/playwright/settings-toggles.spec.js
@@ -9,7 +9,6 @@ async function preparePage(page) {
     localStorage.setItem(`labcharts-${profileId}-tour`, 'completed');
   });
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() => typeof window.openSettingsModal === 'function');
   await page.evaluate(() => {
     return import('/js/state.js').then(({ state }) => {
       const profileId = state.currentProfile || localStorage.getItem('labcharts-active-profile') || 'default';
@@ -30,12 +29,11 @@ test('Settings display toggles persist through delegated slider actions', async 
   await preparePage(page);
 
   await page.evaluate(async () => {
-    if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
-
+    const settings = await import('/js/settings.js');
     localStorage.removeItem('labcharts-show-product-recs');
     localStorage.removeItem('labcharts-debug');
     (await import('/js/theme.js')).setTheme('cyberterm');
-    window.openSettingsModal('display');
+    settings.openSettingsModal('display');
   });
 
   await expect(page.locator('#settings-modal-overlay')).toHaveClass(SHOW_CLASS_TOKEN);
@@ -52,11 +50,10 @@ test('Settings data sync toggle opens and cancels setup modal', async ({ page })
   await preparePage(page);
 
   await page.evaluate(async () => {
-    if (typeof window.openSettingsModal !== 'function') throw new Error('window.openSettingsModal unavailable');
-
+    const settings = await import('/js/settings.js');
     const syncState = await import('/js/sync-settings-state.js');
     syncState.setSyncEnabled(false);
-    window.openSettingsModal('data');
+    settings.openSettingsModal('data');
   });
 
   await page.locator('#sync-section [data-sync-action="toggle-sync"] + .chat-toggle-slider').click();
@@ -73,12 +70,11 @@ test('Tweaks panel toggles sunset and CRT effects with theme gating', async ({ p
   await preparePage(page);
 
   await page.evaluate(async () => {
-    if (typeof window.openTweaksPanel !== 'function') throw new Error('window.openTweaksPanel unavailable');
-
+    const settings = await import('/js/settings.js');
     localStorage.removeItem('labcharts-sunset-mode');
     localStorage.removeItem('labcharts-crt-effects');
     (await import('/js/theme.js')).setTheme('cyberterm');
-    window.openTweaksPanel();
+    settings.openTweaksPanel();
   });
 
   const tweaksOverlay = page.locator('#tweaks-panel-overlay');
@@ -102,9 +98,10 @@ test('Tweaks panel toggles sunset and CRT effects with theme gating', async ({ p
 
   await page.evaluate(async () => {
     const themeModule = await import('/js/theme.js');
+    const settings = await import('/js/settings.js');
     themeModule.setTheme('dark');
     themeModule.setCrtEffectsEnabled(false);
-    window.openTweaksPanel();
+    settings.openTweaksPanel();
   });
 
   const crtInput = page.locator('#tweaks-crt-effects');
@@ -127,17 +124,17 @@ test('Tweaks panel uses lifecycle scroll lock on mobile', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await preparePage(page);
 
-  await page.evaluate(() => {
-    if (typeof window.openTweaksPanel !== 'function') throw new Error('window.openTweaksPanel unavailable');
+  await page.evaluate(async () => {
+    const settings = await import('/js/settings.js');
     document.body.style.overflow = 'auto';
-    window.openTweaksPanel();
+    settings.openTweaksPanel();
   });
 
   const tweaksOverlay = page.locator('#tweaks-panel-overlay');
   await expect(tweaksOverlay).toHaveClass(SHOW_CLASS_TOKEN);
   await expect.poll(async () => page.evaluate(() => document.body.style.overflow)).toBe('hidden');
 
-  await page.evaluate(() => window.closeTweaksPanel?.());
+  await page.evaluate(async () => (await import('/js/settings.js')).closeTweaksPanel());
   await expect(tweaksOverlay).toHaveCount(0);
   await expect.poll(async () => page.evaluate(() => document.body.style.overflow)).toBe('auto');
 });

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -454,11 +454,12 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
   await page.waitForSelector('#main-content', { state: 'attached' });
 
   const results = await page.evaluate(async ({ dashboardPageUrl }) => {
-    const [dashboardPage, { state }, profile, data] = await Promise.all([
+    const [dashboardPage, { state }, profile, data, settingsBridge] = await Promise.all([
       import(dashboardPageUrl),
       import('/js/state.js'),
       import('/js/profile.js'),
       import('/js/data.js'),
+      import('/js/settings-runtime-bridge.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
@@ -472,13 +473,15 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       demoLoadingProfileId: window._demoLoadingProfileId,
       openChatPanel: window.openChatPanel,
       closeChatPanel: window.closeChatPanel,
-      openSettingsModal: window.openSettingsModal,
       mainHtml: document.getElementById('main-content')?.innerHTML || '',
     };
     const calls = [];
     const outcomes = {};
     let hadPdfInput = false;
     let previousDashboardPageRuntimeDeps = null;
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: tab => calls.push(['settings', tab]),
+    });
 
     try {
       state.currentProfile = 'dashboard-welcome-delegates';
@@ -493,7 +496,6 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
 
       window.openChatPanel = () => calls.push(['open-chat']);
       window.closeChatPanel = () => calls.push(['close-chat']);
-      window.openSettingsModal = tab => calls.push(['settings', tab]);
       previousDashboardPageRuntimeDeps = dashboardPage.configureDashboardPageRuntimeDeps({
         loadDemoData: sex => calls.push(['demo', sex]),
       });
@@ -574,10 +576,10 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       if (previousDashboardPageRuntimeDeps) {
         dashboardPage.configureDashboardPageRuntimeDeps(previousDashboardPageRuntimeDeps);
       }
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       Object.assign(window, {
         openChatPanel: saved.openChatPanel,
         closeChatPanel: saved.closeChatPanel,
-        openSettingsModal: saved.openSettingsModal,
       });
       document.body.classList.remove('empty-dashboard-active', 'chat-autostart-reserved');
       localStorage.clear();

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -18,6 +18,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
 
   const results = await page.evaluate(async ({ shellActionsUrl }) => {
     const shellActions = await import(shellActionsUrl);
+    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const calls = [];
@@ -43,8 +44,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     });
     const originalFns = {
       openProfileShareModal: window.openProfileShareModal,
-      openTweaksPanel: window.openTweaksPanel,
-      openSettingsModal: window.openSettingsModal,
       toggleChatPanel: window.toggleChatPanel,
       closeChatPanel: window.closeChatPanel,
       summarizeThread: window.summarizeThread,
@@ -57,6 +56,10 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       setChatWebSearchEnabled: window.setChatWebSearchEnabled,
       handleChatKeydown: window.handleChatKeydown,
     };
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openTweaksPanel: (...args) => calls.push(['openTweaksPanel', ...args]),
+      openSettingsModal: (...args) => calls.push(['openSettingsModal', ...args]),
+    });
     const bind = (name) => {
       window[name] = (...args) => calls.push([name, ...args]);
     };
@@ -208,6 +211,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
       shellActions.configureShellChatImageDeps(previousShellChatImageDeps);
       shellActions.configureShellChatThreadDeps(previousShellChatThreadDeps);
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       for (const [name, value] of Object.entries(originalFns)) {
         if (value === undefined) delete window[name];
         else window[name] = value;

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -389,6 +389,7 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
   });
 
   const outcomes = await page.evaluate(async ({ startupUiUrl }) => {
+    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const originalSetTimeout = window.setTimeout;
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     window.__startupUICalls = [];
@@ -401,9 +402,9 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
     window.navigate = view => {
       window.__startupUICalls.push(['navigate', view]);
     };
-    window.openSettingsModal = section => {
-      window.__startupUICalls.push(['openSettingsModal', section]);
-    };
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: section => window.__startupUICalls.push(['openSettingsModal', section]),
+    });
     window.openChatPanel = () => {
       window.__startupUICalls.push('openChatPanel');
     };
@@ -482,6 +483,7 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
           && window.__startupUICalls.includes('bindImportFileInput'),
       };
     } finally {
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       window.setTimeout = originalSetTimeout;
       window.requestAnimationFrame = originalRequestAnimationFrame;
       delete window._openSettingsAfterInit;

--- a/tests/playwright/sync-actions-browser-coverage.spec.js
+++ b/tests/playwright/sync-actions-browser-coverage.spec.js
@@ -374,9 +374,10 @@ test('sync indicator popover renders debug actions and copies activity', async (
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ uiUrl }) => {
-    const [syncUi, syncState] = await Promise.all([
+    const [syncUi, syncState, settingsBridge] = await Promise.all([
       import(uiUrl),
       import('/js/sync-state.js'),
+      import('/js/settings-runtime-bridge.js'),
     ]);
     const outcomes = {};
     const copied = [];
@@ -395,11 +396,13 @@ test('sync indicator popover renders debug actions and copies activity', async (
       cleanStorage: window.cleanStorage,
       checkRelayConnection: window.checkRelayConnection,
       showSyncDiagnose: window.showSyncDiagnose,
-      openSettingsModal: window.openSettingsModal,
     };
     let enabled = false;
     const slot = document.getElementById('sync-indicator-slot') || document.createElement('div');
     const actionCalls = [];
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      openSettingsModal: tab => { actionCalls.push(`settings:${tab}`); },
+    });
 
     try {
       window.syncNow = () => { actionCalls.push('sync-now'); };
@@ -410,7 +413,6 @@ test('sync indicator popover renders debug actions and copies activity', async (
         return true;
       };
       window.showSyncDiagnose = () => { actionCalls.push('diagnose'); };
-      window.openSettingsModal = tab => { actionCalls.push(`settings:${tab}`); };
 
       slot.id = 'sync-indicator-slot';
       if (!slot.parentNode) document.body.appendChild(slot);
@@ -557,7 +559,7 @@ test('sync indicator popover renders debug actions and copies activity', async (
       window.cleanStorage = saved.cleanStorage;
       window.checkRelayConnection = saved.checkRelayConnection;
       window.showSyncDiagnose = saved.showSyncDiagnose;
-      window.openSettingsModal = saved.openSettingsModal;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       document.getElementById('sync-popover')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       document.querySelectorAll('.notification-container').forEach(el => el.remove());

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -174,8 +174,9 @@ async function prepareScenario(page, theme, viewport) {
   await waitForApp(page);
   await page.evaluate(async (nextTheme) => {
     const themeModule = await import('/js/theme.js');
+    const settings = await import('/js/settings.js');
     (await import('/js/views.js')).closeModal();
-    window.closeSettingsModal?.();
+    settings.closeSettingsModal();
     window.closeChatPanel?.();
     (await import('/js/nav.js')).closeMobileSidebar();
     document.querySelectorAll('#tour-overlay, #tour-spotlight, #tour-tooltip').forEach(el => el.remove());
@@ -185,7 +186,7 @@ async function prepareScenario(page, theme, viewport) {
     localStorage.removeItem('labcharts-crt-effects');
     themeModule.setSunsetMode(false);
     themeModule.setCrtEffectsEnabled(false);
-    window.applyAccentOverride?.('');
+    settings.applyAccentOverride('');
     if (nextTheme === 'dark') localStorage.setItem('labcharts-theme', 'dark');
     else localStorage.setItem('labcharts-theme', nextTheme);
     themeModule.setTheme(nextTheme);
@@ -482,7 +483,7 @@ async function evaluateBaseChecks(page, theme, viewport) {
 }
 
 async function checkDesktopModals(page, theme, viewportName, assert) {
-  await page.evaluate(() => window.openSettingsModal?.('display'));
+  await page.evaluate(async () => (await import('/js/settings.js')).openSettingsModal('display'));
   await delay(200);
   let result = await page.evaluate(() => {
     const overlay = document.getElementById('settings-modal-overlay');
@@ -499,10 +500,10 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
   assert(testName(theme, viewportName, 'settings modal opens visibly'), result.open && result.visible);
   assert(testName(theme, viewportName, 'settings modal fits viewport'), result.contained, JSON.stringify(result));
   assert(testName(theme, viewportName, 'settings display does not duplicate theme picker'), !result.hasDuplicateThemeGrid, JSON.stringify(result));
-  await page.evaluate(() => window.closeSettingsModal?.());
+  await page.evaluate(async () => (await import('/js/settings.js')).closeSettingsModal());
   await delay(100);
 
-  await page.evaluate(() => window.openTweaksPanel?.());
+  await page.evaluate(async () => (await import('/js/settings.js')).openTweaksPanel());
   await delay(150);
   result = await page.evaluate(async (theme) => {
     const themeModule = await import('/js/theme.js');
@@ -627,8 +628,9 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
     JSON.stringify(result));
   await page.evaluate(async () => {
     (await import('/js/theme.js')).setSunsetMode(true);
-    window.applyAccentOverride?.();
-    window.updateTweaksUI?.();
+    const settings = await import('/js/settings.js');
+    settings.applyAccentOverride();
+    settings.updateTweaksUI();
   });
   await delay(80);
   result = await page.evaluate((sunsetThemeColor) => {
@@ -657,8 +659,9 @@ async function checkDesktopModals(page, theme, viewportName, assert) {
     JSON.stringify(result));
   await page.evaluate(async () => {
     (await import('/js/theme.js')).setSunsetMode(false);
-    window.applyAccentOverride?.();
-    window.updateTweaksUI?.();
+    const settings = await import('/js/settings.js');
+    settings.applyAccentOverride();
+    settings.updateTweaksUI();
   });
   await delay(80);
   result = await page.evaluate(() => ({
@@ -743,7 +746,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
     result.rootDashboardActive && result.tabbarOutsideShell && result.movedUp,
     JSON.stringify(result));
 
-  await page.evaluate(() => window.openTweaksPanel?.());
+  await page.evaluate(async () => (await import('/js/settings.js')).openTweaksPanel());
   await delay(150);
   result = await page.evaluate((theme) => {
     const panel = document.getElementById('tweaks-panel');
@@ -790,7 +793,7 @@ async function checkMobileInteractions(page, theme, viewportName, assert) {
       result.bodyContained && result.bodyScrollLocked && result.horizontalOverflow <= 1 &&
       result.overflowingChildren === 0 && result.terminalShadowContained,
     JSON.stringify(result));
-  await page.evaluate(() => window.closeTweaksPanel?.());
+  await page.evaluate(async () => (await import('/js/settings.js')).closeTweaksPanel());
   await delay(100);
 
   const quickMarker = await page.$('.m-dashboard-widgets .dashboard-widget[data-widget-id="quick-markers"] .db-quick-marker-tile');

--- a/tests/playwright/wearables-settings-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-browser-coverage.spec.js
@@ -9,12 +9,13 @@ test('wearables settings browser coverage exercises import and connection action
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const failures = await page.evaluate(async ({ panelUrl, stateUrl, profileUrl, storeUrl, blobUrl }) => {
-    const [{ state }, { profileStorageKey }, store, blobStorage, settingsRuntime, panel] = await Promise.all([
+    const [{ state }, { profileStorageKey }, store, blobStorage, settingsRuntime, settingsBridge, panel] = await Promise.all([
       import(stateUrl),
       import(profileUrl),
       import(storeUrl),
       import(blobUrl),
       import('/js/wearables-settings-runtime.js'),
+      import('/js/settings-runtime-bridge.js'),
       import(panelUrl),
     ]);
     const actions = panel.wearableSettingsActionHandlers;
@@ -38,13 +39,15 @@ test('wearables settings browser coverage exercises import and connection action
     const originalCurrentProfile = state.currentProfile;
     const originalImported = state.importedData;
     const originalNavigate = window.navigate;
-    const originalCloseSettingsModal = window.closeSettingsModal;
     const originalSettingsRuntimeDeps = settingsRuntime.configureWearableSettingsRuntimeDeps();
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     const originalImportedLocalValue = localStorage.getItem(importedKey);
     const originalImportedBlobValue = await blobStorage.getBlob(importedKey);
     const originalStripHidden = localStorage.getItem(`wearables-strip-hidden-${profileId}`);
     const calls = [];
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      closeSettingsModal: () => calls.push(['closeSettingsModal']),
+    });
 
     const renderSettings = () => {
       let section = document.getElementById('wearables-section');
@@ -152,7 +155,6 @@ test('wearables settings browser coverage exercises import and connection action
       strip.id = 'wearable-strip';
       strip.scrollIntoView = () => calls.push(['scroll', 'wearable-strip']);
       document.body.append(strip);
-      window.closeSettingsModal = () => calls.push(['closeSettingsModal']);
       window.requestAnimationFrame = callback => setTimeout(() => callback(Date.now()), 0);
       actions.handleManualOpenDashboard();
       await waitFor(() => calls.some(call => call[0] === 'scroll' && call[1] === 'wearable-strip'));
@@ -187,8 +189,7 @@ test('wearables settings browser coverage exercises import and connection action
       state.importedData = originalImported;
       if (originalNavigate) window.navigate = originalNavigate;
       else delete window.navigate;
-      if (originalCloseSettingsModal) window.closeSettingsModal = originalCloseSettingsModal;
-      else delete window.closeSettingsModal;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       settingsRuntime.configureWearableSettingsRuntimeDeps(originalSettingsRuntimeDeps);
       window.requestAnimationFrame = originalRequestAnimationFrame;
       document.querySelectorAll('#wearables-section,#wearable-strip,#confirm-dialog-overlay,.notification-container').forEach(el => el.remove());

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -19,10 +19,11 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       return false;
     };
 
-    const [{ state }, settings, store] = await Promise.all([
+    const [{ state }, settings, store, settingsBridge] = await Promise.all([
       import('/js/state.js'),
       import('/js/wearables-settings-panel.js'),
       import('/js/wearables-store.js'),
+      import('/js/settings-runtime-bridge.js'),
     ]);
 
     const profileId = `wearables-settings-render-${Date.now()}`;
@@ -35,12 +36,14 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
     const oldProfiles = state.profiles;
     const oldImportedData = state.importedData;
     const oldNavigate = window.navigate;
-    const oldCloseSettingsModal = window.closeSettingsModal;
     const oldScrollIntoView = Element.prototype.scrollIntoView;
     const navigations = [];
     const docsClicks = [];
     let closedSettings = 0;
     let scrolledToStrip = 0;
+    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
+      closeSettingsModal: () => { closedSettings += 1; },
+    });
 
     try {
       localStorage.setItem('labcharts-active-profile', profileId);
@@ -100,7 +103,6 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       ]);
 
       window.navigate = route => { navigations.push(route); };
-      window.closeSettingsModal = () => { closedSettings += 1; };
       Element.prototype.scrollIntoView = function scrollIntoView() {
         if (this.id === 'wearable-strip') scrolledToStrip += 1;
       };
@@ -191,7 +193,7 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       state.profiles = oldProfiles;
       state.importedData = oldImportedData;
       window.navigate = oldNavigate;
-      window.closeSettingsModal = oldCloseSettingsModal;
+      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       Element.prototype.scrollIntoView = oldScrollIntoView;
     }
     return failures;

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -51,7 +51,7 @@ cryptoModule.configureCryptoProfileDeps({ migrateProfileData: profileModule.migr
 const navModule = await import('../js/nav.js');
 const viewsModule = await import('../js/views.js');
 const exportModule = await import('../js/export.js');
-await import('../js/settings.js');
+const settingsModule = await import('../js/settings.js');
 await import('../js/chat.js');
 await import('../js/utils.js');
 const backupModule = await import('../js/backup.js');
@@ -333,12 +333,11 @@ for (const name of ['buildSidebar', 'renderProfileDropdown']) {
   assert(`nav.${name} exists`, typeof navModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));
 }
-const expectedExports = [
-  // settings.js
-  'openSettingsModal', 'closeSettingsModal',
-  // chat.js
-  'toggleChatPanel', 'closeChatPanel',
-];
+for (const name of ['openSettingsModal', 'closeSettingsModal']) {
+  assert(`settings.${name} exists`, typeof settingsModule[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
+}
+const expectedExports = ['toggleChatPanel', 'closeChatPanel'];
 for (const name of expectedExports) {
   assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
 }
@@ -548,6 +547,7 @@ console.log('19. settings.js security + backup');
 try {
   const src = await fetchWithRetry('js/settings.js');
   const runtimeSrc = await fetchWithRetry('js/settings-runtime.js');
+  const runtimeBridgeSrc = await fetchWithRetry('js/settings-runtime-bridge.js');
   assert('settings.js imports renderEncryptionSection', src.includes('renderEncryptionSection'));
   assert('settings.js imports renderBackupSection', src.includes('renderBackupSection'));
   assert('settings.js has Security group', src.includes('Security'));
@@ -558,8 +558,9 @@ try {
     src.includes("from './settings-runtime.js'") &&
     !/\bwindow(?:\.|\s*\[)/.test(src));
   assert('settings-runtime.js owns Settings browser adapters and injects meteo config modules',
-    runtimeSrc.includes('export function publishSettingsGlobals') &&
-    runtimeSrc.includes('Object.assign(getRuntimeWindow(), api)') &&
+    runtimeBridgeSrc.includes('export function configureSettingsModuleBridge') &&
+    runtimeBridgeSrc.includes('export function getSettingsModuleFunction') &&
+    !runtimeBridgeSrc.includes('Object.assign(window') &&
     runtimeSrc.includes("getRuntimeFunction('requestAnimationFrame')") &&
     runtimeSrc.includes("getRuntimeFunction('matchMedia')") &&
     runtimeSrc.includes("from './sun-uvdata-config.js'") &&

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -20,6 +20,7 @@ import {
   triggerDashboardDnaPicker,
 } from '../js/dashboard-widget-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
+import { configureSettingsModuleBridge } from '../js/settings-runtime-bridge.js';
 import { configureWearablesModuleBridge } from '../js/wearables-runtime.js';
 
 let pass = 0, fail = 0;
@@ -35,7 +36,6 @@ const runtimeKeys = [
   'innerHeight',
   'getSessions',
   '_snpTableCache',
-  'openSettingsModal',
   'showDetailModal',
   'navigate',
   'triggerDNAFilePicker',
@@ -43,6 +43,7 @@ const runtimeKeys = [
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const savedImportedData = state.importedData;
 let previousWearablesModule = null;
+let previousSettingsModule = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -99,7 +100,9 @@ try {
 
   const actionEl = { dataset: { dashboardWidgetAction: 'sync-biometric-now' } };
   const event = { type: 'click' };
-  setRuntimeValue('openSettingsModal', section => calls.push(['settings', section]));
+  previousSettingsModule = configureSettingsModuleBridge({
+    openSettingsModal: section => calls.push(['settings', section]),
+  });
   previousWearablesModule = configureWearablesModuleBridge({
     syncWearableNow: el => calls.push(['sync', el?.dataset?.dashboardWidgetAction || '']),
     openWearableDetail: id => calls.push(['wearable-detail', id]),
@@ -142,6 +145,7 @@ try {
     syncWearableNow: null,
     openManualLogForm: null,
   });
+  configureSettingsModuleBridge({ openSettingsModal: null });
   delete globalThis.window;
   const callCountBeforeMissingRuntime = calls.length;
   openDashboardWearablesSettings();
@@ -162,6 +166,10 @@ try {
   configureDashboardNoteActions(previousDashboardNoteActions);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
+  configureSettingsModuleBridge({
+    openSettingsModal: null,
+    ...previousSettingsModule,
+  });
   configureWearablesModuleBridge({
     syncWearableNow: null,
     openWearableDetail: null,

--- a/tests/test-provider-local-ai-runtime.js
+++ b/tests/test-provider-local-ai-runtime.js
@@ -7,6 +7,7 @@ import {
   getCachedLocalAiModelDetails,
   updatePrivacyStatusCardFromRuntime,
 } from '../js/provider-local-ai-runtime.js';
+import { configureSettingsModuleBridge } from '../js/settings-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -18,7 +19,6 @@ console.log('=== Provider Local AI Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'updatePrivacyStatusCard',
   '_lastOllamaModelDetails',
   '_lastIsOllamaServer',
 ];
@@ -43,7 +43,9 @@ function restoreRuntime() {
 
 try {
   const privacyCalls = [];
-  setRuntimeValue('updatePrivacyStatusCard', (...args) => privacyCalls.push(args));
+  const previousSettingsBridge = configureSettingsModuleBridge({
+    updatePrivacyStatusCard: (...args) => privacyCalls.push(args),
+  });
 
   updatePrivacyStatusCardFromRuntime(true);
   updatePrivacyStatusCardFromRuntime();
@@ -68,6 +70,7 @@ try {
       invalidCached.isOllamaServer === true);
 
   delete globalThis.window;
+  configureSettingsModuleBridge({ updatePrivacyStatusCard: null });
   updatePrivacyStatusCardFromRuntime(false);
   cacheLocalAiModelDetails([{ name: 'qwen2.5:14b' }], false);
   const missingRuntimeCached = getCachedLocalAiModelDetails();
@@ -75,6 +78,7 @@ try {
     privacyCalls.length === 2 &&
       missingRuntimeCached.modelDetails.length === 0 &&
       missingRuntimeCached.isOllamaServer === false);
+  configureSettingsModuleBridge(previousSettingsBridge);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-settings-runtime.js
+++ b/tests/test-settings-runtime.js
@@ -6,6 +6,10 @@ import {
   getSettingsMeteoConfig,
   saveSettingsMeteoConfig,
 } from '../js/settings-runtime.js';
+import {
+  configureSettingsModuleBridge,
+  getSettingsModuleFunction,
+} from '../js/settings-runtime-bridge.js';
 
 let passed = 0;
 let failed = 0;
@@ -28,6 +32,14 @@ const originalSettingsRuntimeDeps = configureSettingsRuntimeDeps({
 });
 
 try {
+  const previousSettingsBridge = configureSettingsModuleBridge({ settingsProbe: () => 'ok' });
+  assert('settings module bridge registers callbacks without browser globals',
+    getSettingsModuleFunction('settingsProbe')?.() === 'ok'
+      && !('settingsProbe' in globalThis));
+  configureSettingsModuleBridge(previousSettingsBridge);
+  assert('settings module bridge snapshots remove newly added callbacks on restore',
+    getSettingsModuleFunction('settingsProbe') === null);
+
   assert('missing getMeteoConfig returns defaults',
     getSettingsMeteoConfig().mode === 'auto');
   assert('missing saveMeteoConfig reports unavailable',

--- a/tests/test-theme-runtime.js
+++ b/tests/test-theme-runtime.js
@@ -7,6 +7,7 @@ import {
   dispatchThemeChange,
   refreshThemeDependentsFromRuntime,
 } from '../js/theme-runtime.js';
+import { configureSettingsModuleBridge } from '../js/settings-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -50,6 +51,7 @@ function resetRuntimeWindow() {
 
 console.log('=== Theme Runtime Tests ===\n');
 
+let previousSettingsBridge = null;
 try {
   resetRuntimeWindow();
 
@@ -71,9 +73,11 @@ try {
   assert('theme change event carries detail', events[0]?.detail?.theme === 'glass' && events[0]?.detail?.sunsetMode === true);
 
   const calls = [];
-  globalThis.applyAccentOverride = () => calls.push('accent');
-  globalThis.updateSettingsUI = () => calls.push('settings');
-  globalThis.updateTweaksUI = () => calls.push('tweaks');
+  previousSettingsBridge = configureSettingsModuleBridge({
+    applyAccentOverride: () => calls.push('accent'),
+    updateSettingsUI: () => calls.push('settings'),
+    updateTweaksUI: () => calls.push('tweaks'),
+  });
   globalThis.scheduleChartThemeRefresh = () => calls.push('schedule');
   globalThis.refreshSettingsWearables = () => calls.push('wearables');
   refreshThemeDependentsFromRuntime({ settingsModalOpen: true });
@@ -97,6 +101,7 @@ try {
     return true;
   })());
 } finally {
+  if (previousSettingsBridge) configureSettingsModuleBridge(previousSettingsBridge);
   for (const field of RUNTIME_FIELDS) {
     restoreDescriptor(globalThis, field, originalFieldDescriptors.get(field));
   }

--- a/tests/test-wearables-runtime.js
+++ b/tests/test-wearables-runtime.js
@@ -11,6 +11,7 @@ import {
   openEMFAssessmentAfterWearablesModalClose,
   openWearablesSettings,
 } from '../js/wearables-runtime.js';
+import { configureSettingsModuleBridge } from '../js/settings-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -24,7 +25,6 @@ const runtimeKeys = [
   'window',
   'navigate',
   'closeModal',
-  'openSettingsModal',
   'setTimeout',
   'innerWidth',
   'innerHeight',
@@ -52,7 +52,9 @@ try {
   const calls = [];
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
   setRuntimeValue('closeModal', () => calls.push(['close-modal']));
-  setRuntimeValue('openSettingsModal', section => calls.push(['settings', section]));
+  const restoreSettingsBridge = configureSettingsModuleBridge({
+    openSettingsModal: section => calls.push(['settings', section]),
+  });
   const restoreWearablesRuntime = configureWearablesRuntime({
     openEMFAssessmentEditor: () => calls.push(['emf-editor']),
   });
@@ -113,6 +115,7 @@ try {
   assert('wearables module bridge snapshots remove newly added callbacks on restore',
     getWearablesModuleFunction('wearableProbe') === null);
 
+  configureSettingsModuleBridge({ openSettingsModal: null });
   const beforeNoWindowCalls = calls.length;
   delete globalThis.window;
   navigateWearables('dashboard');
@@ -124,6 +127,7 @@ try {
     calls.length === beforeNoWindowCalls);
   assert('viewport helper returns fallback size without window',
     fallbackViewport.width === 1024 && fallbackViewport.height === 768);
+  configureSettingsModuleBridge(restoreSettingsBridge);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-wearables-settings-runtime.js
+++ b/tests/test-wearables-settings-runtime.js
@@ -8,6 +8,7 @@ import {
   confirmWearableSettingsAction,
   navigateWearablesDashboard,
 } from '../js/wearables-settings-runtime.js';
+import { configureSettingsModuleBridge } from '../js/settings-runtime-bridge.js';
 
 const originalWearableSettingsRuntimeDeps = configureWearableSettingsRuntimeDeps();
 
@@ -19,7 +20,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Wearables Settings Runtime Tests ===\n');
 
-const runtimeKeys = ['window', 'navigate', 'closeSettingsModal', 'showConfirmDialog'];
+const runtimeKeys = ['window', 'navigate', 'showConfirmDialog'];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
 function setRuntimeValue(key, value) {
@@ -42,7 +43,9 @@ function restoreRuntime() {
 try {
   const calls = [];
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
-  setRuntimeValue('closeSettingsModal', () => calls.push(['close-settings']));
+  const previousSettingsBridge = configureSettingsModuleBridge({
+    closeSettingsModal: () => calls.push(['close-settings']),
+  });
   configureWearableSettingsRuntimeDeps({ showConfirmDialog: async message => {
     calls.push(['confirm', message]);
     return message === 'confirm me';
@@ -59,12 +62,14 @@ try {
     confirmed && calls.some(call => call[0] === 'confirm' && call[1] === 'confirm me'));
 
   delete globalThis.window;
+  configureSettingsModuleBridge({ closeSettingsModal: null });
   configureWearableSettingsRuntimeDeps({ showConfirmDialog: null });
   navigateWearablesDashboard();
   closeWearableSettingsModal();
   const missingConfirm = await confirmWearableSettingsAction('confirm me');
   assert('runtime adapter no-ops safely when window is missing',
     !missingConfirm);
+  configureSettingsModuleBridge(previousSettingsBridge);
 } finally {
   configureWearableSettingsRuntimeDeps(originalWearableSettingsRuntimeDeps);
   restoreRuntime();

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -64,6 +64,7 @@
     '/js/wearables-auth-runtime.js',
     '/js/wearables-settings-runtime.js',
     '/js/wearables-connect-runtime.js',
+    '/js/settings-runtime-bridge.js',
     '/js/dashboard-view-composition.js',
     '/js/dashboard-page-view.js',
     '/js/mobile-dashboard-runtime.js',
@@ -563,7 +564,7 @@
     'detectLatitudeWithAI'
   ];
 
-  // settings.js (7 retained runtime hooks; internal flows use ESM exports)
+  // settings.js (all Settings actions stay module-only)
   const settingsGlobals = [
     'openSettingsModal','closeSettingsModal',
     'openTweaksPanel','closeTweaksPanel',
@@ -794,6 +795,9 @@
   for (const name of settingsModuleOnlyExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
+  for (const name of settingsGlobals) {
+    assert(`window.${name} stays module-only`, !(name in window));
+  }
   for (const name of themeExports) {
     assert(`window.${name} stays module-only`, !(name in window));
   }
@@ -960,7 +964,6 @@
 
   const allModules = {
     'chat.js': chatExports,
-    'settings.js': settingsGlobals,
     'views.js': viewsLegacyExports,
   };
 
@@ -1097,7 +1100,7 @@
   // ═══════════════════════════════════════════════
   // 10. SETTINGS MODAL — opens and closes
   // ═══════════════════════════════════════════════
-  window.openSettingsModal();
+  settingsModule.openSettingsModal();
   const settingsOverlay = document.getElementById('settings-modal-overlay');
   assert('Settings modal opens', settingsOverlay?.classList.contains('show'));
   const settingsContent = document.getElementById('settings-modal');
@@ -1105,7 +1108,7 @@
   // Check sections exist
   assert('Settings has Profile section', settingsContent?.innerHTML.includes('Profile') || settingsContent?.innerHTML.includes('profile'));
   assert('Settings has AI Provider section', settingsContent?.innerHTML.includes('AI Provider') || settingsContent?.innerHTML.includes('provider'));
-  window.closeSettingsModal();
+  settingsModule.closeSettingsModal();
   assert('Settings modal closes', !settingsOverlay?.classList.contains('show'));
 
   // 11. GLOSSARY removed in v1.3.25 — feature retired. Section

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -214,6 +214,7 @@
     "js/settings.js",
     "js/settings-privacy.js",
     "js/settings-runtime.js",
+    "js/settings-runtime-bridge.js",
     "js/service-worker-update.js",
     "js/shell-actions.js",
     "js/startup-foundation.js",

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -22,7 +22,6 @@ interface Window {
   _demoLoadingProfileId?: string;
   _snpTableCache?: unknown;
   APP_VERSION?: string;
-  applyAccentOverride?: () => void;
   callClaudeAPI?: (request: {
     system?: string;
     messages: Array<{ role: string; content: string }>;
@@ -63,10 +62,8 @@ interface Window {
   closeReportBuilder?: () => void;
   closeRestoreMnemonicDialog?: () => void;
   closeSettings?: () => void;
-  closeSettingsModal: () => void;
   closeSummaryModal?: () => void;
   closeSyncSetup?: () => Promise<void> | void;
-  closeTweaksPanel: () => void;
   clearE2EESession?: AnyFunction;
   cleanupDiscussionState?: AnyFunction;
   destroyAllCharts?: () => void;
@@ -167,7 +164,6 @@ interface Window {
   nostrSetSelectedNode?: (url: string) => void;
   openChatPanel: AnyFunction;
   openEMFAssessmentEditor?: () => void;
-  openSettingsModal: (tab?: string) => void;
   openChatProviderQuiz?: AnyFunction;
   openImportReviewFromSnapshot?: (snapshotId: string) => void;
   pdfjsLib?: unknown;
@@ -218,7 +214,6 @@ interface Window {
   updateChatHeaderModel?: AnyFunction;
   updateAttachButtonVisibility: () => void;
   updateChatNudge: () => void;
-  updatePrivacyStatusCard?: AnyFunction;
   refreshWebSearchToggle?: AnyFunction;
   saveImportedData?: AnyFunction;
   _getRelevantSNPs?: AnyFunction;
@@ -263,8 +258,6 @@ interface Window {
   updateHeaderDates?: () => void;
   updateHeaderRangeToggle?: () => void;
   updatePersonalityBar?: () => void;
-  updateSettingsUI?: () => void;
-  updateTweaksUI?: () => void;
 }
 
 declare var getMeasurementsForRoom: AnyFunction | undefined;

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.234';
+self.APP_VERSION = '1.10.235';


### PR DESCRIPTION
## Summary

- remove the seven-function Settings and Tweaks facade from `window`
- route Settings consumers through a dependency-free, cycle-safe module bridge
- keep Settings actions as ES module exports and update Node/browser coverage to use the bridge or direct imports
- remove obsolete Settings global types, pre-cache and type-check the bridge, and bump the cache version to `1.10.235`

## Window burden

- before this PR: 227 published bindings across 4 publication families
- after this PR: 220 published bindings across 3 publication families
- reduction: 7 bindings and the Settings publication family

## Validation

- `./run-tests.sh`
  - 126/126 module verification checks
  - 398/398 Vitest tests
  - 352/352 Playwright tests
  - 472/472 responsive-theme assertions
- affected Playwright subset: 68/68 passed
- final `npm test`: 398/398 tests
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`
