### PR TITLE
Remove Sun globals

### DIFF
--- a/js/ai-verdict-engine-runtime.js
+++ b/js/ai-verdict-engine-runtime.js
@@ -1,6 +1,21 @@
 // @ts-check
 // ai-verdict-engine-runtime.js - Browser runtime adapters for AI verdicts.
 
+const aiVerdictRuntimeDeps = {
+  refreshSunSurfaces: null,
+};
+
+/** @param {{ refreshSunSurfaces?: ((anchor: string | null) => any) | null }} deps */
+export function configureAIVerdictRuntimeDeps(deps = {}) {
+  const previous = { ...aiVerdictRuntimeDeps };
+  if ('refreshSunSurfaces' in deps) {
+    aiVerdictRuntimeDeps.refreshSunSurfaces = typeof deps.refreshSunSurfaces === 'function'
+      ? deps.refreshSunSurfaces
+      : null;
+  }
+  return previous;
+}
+
 function getAIVerdictRuntime() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -27,7 +42,7 @@ export function getAIVerdictConcurrencyCapRuntime(fallback = 2) {
  * @param {string | null} anchor
  */
 export function refreshSunSurfacesRuntime(anchor) {
-  const refreshSunSurfaces = getAIVerdictRuntime()?._refreshSunSurfaces;
+  const refreshSunSurfaces = aiVerdictRuntimeDeps.refreshSunSurfaces;
   if (typeof refreshSunSurfaces !== 'function') return false;
   try {
     refreshSunSurfaces(anchor);

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -17,6 +17,7 @@ import {
 } from './mobile-dashboard.js';
 import { startEmptyTour as defaultStartEmptyTour, startTour as defaultStartTour } from './tour.js';
 import { loadDemoData } from './export.js';
+import { resumeActiveTickerIfNeeded } from './sun-active-session.js';
 import {
   getRecommendationModuleFunction,
   setRecommendationsCatalogCache,
@@ -187,7 +188,7 @@ export function createDashboardPageView(deps) {
     // Resume the live-session ticker if a session was started before this
     // page loaded — keeps the dashboard Light Today surface ticking after a
     // hard reload mid-session.
-    if (getDashboardPageRuntimeValue('_resumeActiveTickerIfNeeded')) try { callDashboardPageRuntime('_resumeActiveTickerIfNeeded'); } catch (e) {}
+    try { resumeActiveTickerIfNeeded(); } catch (e) {}
     try { ensureActiveDeviceTicker(); } catch (e) {}
     if (!data) data = getActiveData();
     const main = document.getElementById("main-content");

--- a/js/dashboard-recommendation-widget.js
+++ b/js/dashboard-recommendation-widget.js
@@ -14,6 +14,8 @@ import {
   setRecommendationsCatalogCache,
 } from './recommendations-runtime.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
+import { rollingChannelTotals } from './sun.js';
+import { getSessions } from './sun-sessions-store.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let dashboardRecommendationDelegatesInstalled = false;
@@ -232,10 +234,10 @@ export function createDashboardRecommendationWidget({
       });
     }
 
-    const sessions = (callDashboardRecommendationRuntime('getSessions') || []).filter(s => s?.startedAt || s?.endedAt);
+    const sessions = getSessions().filter(s => s?.startedAt || s?.endedAt);
     const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
     const hasRecentLightSession = sessions.some(s => Number(s.endedAt || s.startedAt || 0) >= sevenDaysAgo);
-    const totals7d = callDashboardRecommendationRuntime('rollingChannelTotals', 7) || {};
+    const totals7d = rollingChannelTotals(7) || {};
     if (catalog.slots['light.morningLight'] && (!hasRecentLightSession || Number(totals7d.circadian || 0) <= 0)) {
       add({
         id: 'light:light.morningLight:recent',

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -4,6 +4,7 @@
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 import { getDeviceSessions } from './light-devices-store.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
+import { getSessions } from './sun-sessions-store.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { getWearablesModuleFunction } from './wearables-runtime.js';
 
@@ -61,8 +62,6 @@ export function openDashboardWearablesSettings() {
 }
 
 export function getDashboardLightSessions() {
-  const getSessions = getRuntimeFunction('getSessions');
-  if (!getSessions) return [];
   try {
     const sessions = getSessions();
     return Array.isArray(sessions) ? sessions : [];

--- a/js/light-channels-ai-analysis.js
+++ b/js/light-channels-ai-analysis.js
@@ -21,6 +21,33 @@ import { createAIVerdict, hashString, dotPrefix } from './ai-verdict-engine.js';
 import { formatHealthGoalsText } from './health-goals-utils.js';
 import { aiActionAttrs, registerAIActionHandler } from './ai-action-delegates.js';
 import { getDeviceSessions, rollingDeviceTotals } from './light-devices-store.js';
+import { rollingChannelTotals, tierLabel, weeklyChannelTier } from './sun.js';
+import { getSessions } from './sun-sessions-store.js';
+
+const lightChannelsAIAnalysisDeps = {
+  rollingChannelTotals,
+  getSessions,
+  weeklyChannelTier,
+  tierLabel,
+};
+
+/**
+ * @param {{
+ *   rollingChannelTotals?: ((days: number) => Record<string, number>) | null,
+ *   getSessions?: (() => any[]) | null,
+ *   weeklyChannelTier?: ((value: number, channelKey: string) => number) | null,
+ *   tierLabel?: ((tier: number) => string) | null,
+ * }} deps
+ */
+export function configureLightChannelsAIAnalysisDeps(deps = {}) {
+  const previous = { ...lightChannelsAIAnalysisDeps };
+  for (const name of Object.keys(lightChannelsAIAnalysisDeps)) {
+    if (name in deps && typeof deps[name] === 'function') {
+      lightChannelsAIAnalysisDeps[name] = deps[name];
+    }
+  }
+  return previous;
+}
 
 function _getMix() {
   return state.importedData?.channelMixAI || null;
@@ -41,17 +68,8 @@ const _CHANNEL_DEF = {
   violet_eye: { label: 'Violet-eye dopamine',     biology: '360–440 nm at the eye → retinal dopamine, myopia + mood' },
 };
 
-function _runtime() {
-  return /** @type {Record<string, any>} */ (globalThis);
-}
-
-function _callRuntime(name, ...args) {
-  const fn = _runtime()[name];
-  return typeof fn === 'function' ? fn(...args) : null;
-}
-
 function _rollingChannelTotals(days) {
-  return _callRuntime('rollingChannelTotals', days) || {};
+  return lightChannelsAIAnalysisDeps.rollingChannelTotals(days) || {};
 }
 
 function _rollingDeviceTotals(days) {
@@ -59,7 +77,7 @@ function _rollingDeviceTotals(days) {
 }
 
 function _getSessions() {
-  return _callRuntime('getSessions') || [];
+  return lightChannelsAIAnalysisDeps.getSessions();
 }
 
 function _getDeviceSessions() {
@@ -67,15 +85,11 @@ function _getDeviceSessions() {
 }
 
 function _weeklyChannelTier(value, channelKey) {
-  const tier = _runtime().weeklyChannelTier;
-  return typeof tier === 'function' ? tier(value, channelKey) : 0;
+  return lightChannelsAIAnalysisDeps.weeklyChannelTier(value, channelKey);
 }
 
 function _tierLabel(tier) {
-  const label = _runtime().tierLabel;
-  return typeof label === 'function'
-    ? label(tier)
-    : (['none', 'low', 'moderate', 'good', 'strong'][tier] || '?');
+  return lightChannelsAIAnalysisDeps.tierLabel(tier);
 }
 
 function _channelTotals() {

--- a/js/light-device-session-modal.js
+++ b/js/light-device-session-modal.js
@@ -4,7 +4,7 @@
 import { state } from './state.js';
 import { escapeHTML, escapeAttr, showNotification } from './utils.js';
 import { openAppendedModalOverlay, removeModalOverlay } from './modal-lifecycle.js';
-import { BODY_REGIONS } from './sun.js';
+import { BODY_REGIONS, bindBodySilhouette, renderBodySilhouette } from './sun-body-silhouette.js';
 import { getUtilsRuntimeFunction } from './utils-runtime.js';
 
 /**
@@ -24,8 +24,8 @@ function _resolveSessionDialogDeps(deps = {}) {
   return {
     ...deps,
     validateModeCoupling: deps.validateModeCoupling || _windowDep('validateModeCoupling', () => ({ ok: true })),
-    renderBodySilhouette: deps.renderBodySilhouette || _windowDep('renderBodySilhouette'),
-    bindBodySilhouette: deps.bindBodySilhouette || _windowDep('bindBodySilhouette'),
+    renderBodySilhouette: deps.renderBodySilhouette || renderBodySilhouette,
+    bindBodySilhouette: deps.bindBodySilhouette || bindBodySilhouette,
     navigate: deps.navigate || _windowDep('navigate'),
   };
 }

--- a/js/light-devices-runtime.js
+++ b/js/light-devices-runtime.js
@@ -4,15 +4,35 @@
 import { state } from './state.js';
 import { showPromptDialog } from './utils.js';
 import { getRecommendationModuleFunction } from './recommendations-runtime.js';
+import { CHANNEL_DISPLAY, channelTier, formatChannelUnit, tierLabel } from './sun.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const lightDevicesRuntimeDeps = { showPromptDialog };
+/** @type {{
+ *   showPromptDialog: typeof showPromptDialog | null,
+ *   channelTier: typeof channelTier | null,
+ *   tierLabel: typeof tierLabel | null,
+ *   formatChannelUnit: typeof formatChannelUnit | null,
+ *   channelDisplay: Record<string, any> | null,
+ * }} */
+const lightDevicesRuntimeDeps = {
+  showPromptDialog,
+  channelTier,
+  tierLabel,
+  formatChannelUnit,
+  channelDisplay: CHANNEL_DISPLAY,
+};
 
+/** @param {Partial<typeof lightDevicesRuntimeDeps>} deps */
 export function configureLightDevicesRuntimeDeps(deps = {}) {
   const previous = { ...lightDevicesRuntimeDeps };
-  if ('showPromptDialog' in deps) {
-    lightDevicesRuntimeDeps.showPromptDialog = typeof deps.showPromptDialog === 'function'
-      ? /** @type {typeof showPromptDialog} */ (deps.showPromptDialog)
+  for (const name of ['showPromptDialog', 'channelTier', 'tierLabel', 'formatChannelUnit']) {
+    if (name in deps) {
+      lightDevicesRuntimeDeps[name] = typeof deps[name] === 'function' ? deps[name] : null;
+    }
+  }
+  if ('channelDisplay' in deps) {
+    lightDevicesRuntimeDeps.channelDisplay = deps.channelDisplay && typeof deps.channelDisplay === 'object'
+      ? deps.channelDisplay
       : null;
   }
   return previous;
@@ -34,14 +54,6 @@ function getRuntimeFunction(name) {
   return getViewRuntimeFunction(name);
 }
 
-/**
- * @param {string} name
- * @returns {any}
- */
-function getRuntimeValue(name) {
-  return getRuntimeWindow()[name];
-}
-
 /** @param {string} route */
 export function navigateLightDevicesRoute(route) {
   getRuntimeFunction('navigate')?.(route);
@@ -61,26 +73,16 @@ export function promptLightDeviceSessionDuration(current) {
 }
 
 export function getLightDeviceChannelHelpers() {
-  const channelTier = /** @type {(value: any, channelKey?: string) => number} */ (
-    getRuntimeFunction('channelTier') || (() => 0)
-  );
-  const tierLabel = /** @type {(tier: number) => string} */ (
-    getRuntimeFunction('tierLabel') || (() => 'none')
-  );
-  const formatChannelUnit = /** @type {(...args: any[]) => string} */ (
-    getRuntimeFunction('formatChannelUnit') || (() => '')
-  );
   return {
-    channelTier,
-    tierLabel,
-    formatChannelUnit,
+    channelTier: lightDevicesRuntimeDeps.channelTier || (() => 0),
+    tierLabel: lightDevicesRuntimeDeps.tierLabel || (() => 'none'),
+    formatChannelUnit: lightDevicesRuntimeDeps.formatChannelUnit || (() => ''),
   };
 }
 
 /** @param {Record<string, any>} fallback */
 export function getLightDeviceChannelDisplay(fallback = {}) {
-  const display = getRuntimeValue('CHANNEL_DISPLAY');
-  return display && typeof display === 'object' ? display : fallback;
+  return lightDevicesRuntimeDeps.channelDisplay || fallback;
 }
 
 export function loadLightDevicesCatalog() {

--- a/js/profile-context.js
+++ b/js/profile-context.js
@@ -3,6 +3,22 @@
 
 import { state } from './state.js';
 import { CONTEXT_SOURCE_IDS, isContextSourceEnabled } from './context-source-registry.js';
+import { rollingVitaminDIU } from './sun-channel-metrics.js';
+
+const profileContextLightDeps = {
+  rollingChannelTotals: null,
+};
+
+/** @param {{ rollingChannelTotals?: ((days?: number) => any) | null }} deps */
+export function configureProfileContextLightDeps(deps = {}) {
+  const previous = { ...profileContextLightDeps };
+  if ('rollingChannelTotals' in deps) {
+    profileContextLightDeps.rollingChannelTotals = typeof deps.rollingChannelTotals === 'function'
+      ? deps.rollingChannelTotals
+      : null;
+  }
+  return previous;
+}
 
 const LOW_MUSCLE_TERMS = ['low muscle mass', 'muscle wasting', 'muscle atrophy', 'sarcopenia', 'wheelchair', 'neuromuscular', 'cmt', 'charcot', 'neuropathy', 'myopathy', 'muscular dystrophy', 'cachexia', 'amputation'];
 const LOW_SUNLIGHT_TERMS = ['wheelchair', 'bedbound', 'housebound', 'minimal sun', 'minimal outdoor', 'low sunlight', 'little sun', 'no sun', 'indoors', 'homebound', 'limited mobility', 'minimal uvb', 'low uvb'];
@@ -121,10 +137,9 @@ function collectLightModifiers(data, options = {}) {
   const recentAny = [...sunSessions, ...deviceSessions].filter(s => Number(s?.endedAt || s?.startedAt || 0) >= now - 14 * DAY_MS);
   let vitD7 = null, circadian7 = null;
   try {
-    const w = /** @type {any} */ (typeof window !== 'undefined' ? window : {});
-    if (typeof w.rollingVitaminDIU === 'function') vitD7 = Number(w.rollingVitaminDIU(7));
-    if (typeof w.rollingChannelTotals === 'function') {
-      const totals = w.rollingChannelTotals(7) || {};
+    vitD7 = Number(rollingVitaminDIU(7));
+    if (profileContextLightDeps.rollingChannelTotals) {
+      const totals = profileContextLightDeps.rollingChannelTotals(7) || {};
       if (Number.isFinite(totals.circadian)) circadian7 = Number(totals.circadian);
     }
   } catch {}

--- a/js/startup-maintenance-runtime.js
+++ b/js/startup-maintenance-runtime.js
@@ -1,32 +1,48 @@
 // @ts-check
 // startup-maintenance-runtime.js - Browser runtime adapters for startup maintenance hooks.
 
+import { SUN_ENGINE_VERSION, rehydrateStaleSessions } from './sun-sessions-store.js';
+
+const startupMaintenanceSunDeps = {
+  rehydrateStaleSessions,
+  getSunEngineVersion: () => SUN_ENGINE_VERSION,
+};
+
+/** @param {{ rehydrateStaleSessions?: (() => any) | null, getSunEngineVersion?: (() => any) | null }} deps */
+export function configureStartupMaintenanceSunDeps(deps = {}) {
+  const previous = { ...startupMaintenanceSunDeps };
+  for (const name of ['rehydrateStaleSessions', 'getSunEngineVersion']) {
+    if (name in deps) {
+      startupMaintenanceSunDeps[name] = typeof deps[name] === 'function' ? deps[name] : null;
+    }
+  }
+  return previous;
+}
+
 function getStartupMaintenanceRuntime() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
 }
 
-/** @param {string} name */
-function getRuntimeFunction(name) {
-  const runtime = getStartupMaintenanceRuntime();
-  return typeof runtime?.[name] === 'function' ? runtime[name].bind(runtime) : null;
-}
-
 export function hasSunSessionRehydrateRuntime() {
-  return getRuntimeFunction('rehydrateStaleSessions') !== null;
+  return startupMaintenanceSunDeps.rehydrateStaleSessions !== null;
 }
 
 export function rehydrateStaleSunSessionsRuntime() {
   try {
-    return getRuntimeFunction('rehydrateStaleSessions')?.() || Promise.resolve(null);
+    return startupMaintenanceSunDeps.rehydrateStaleSessions?.() || Promise.resolve(null);
   } catch {
     return Promise.resolve(null);
   }
 }
 
 export function getStartupSunEngineVersionRuntime() {
-  return getStartupMaintenanceRuntime()?.SUN_ENGINE_VERSION || '?';
+  try {
+    return startupMaintenanceSunDeps.getSunEngineVersion?.() || '?';
+  } catch {
+    return '?';
+  }
 }
 
 /** @param {any[]} args */

--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -6,6 +6,8 @@ import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const sunDefaultsRuntimeDeps = {
   getProfileLocation,
+  getSunCoords: null,
+  requestPreciseLocation: null,
   openProfileLocationEditor: null,
   openClientList: null,
 };
@@ -13,7 +15,7 @@ const sunDefaultsRuntimeDeps = {
 export function configureSunDefaultsRuntimeDeps(deps = {}) {
   const previous = { ...sunDefaultsRuntimeDeps };
   if (typeof deps.getProfileLocation === 'function') sunDefaultsRuntimeDeps.getProfileLocation = deps.getProfileLocation;
-  for (const name of ['openProfileLocationEditor', 'openClientList']) {
+  for (const name of ['getSunCoords', 'requestPreciseLocation', 'openProfileLocationEditor', 'openClientList']) {
     if (name in deps) {
       sunDefaultsRuntimeDeps[name] = typeof deps[name] === 'function' ? deps[name] : null;
     }
@@ -38,7 +40,7 @@ function getRuntimeFunction(name) {
 
 export function getSunSetupCoords() {
   try {
-    return getRuntimeFunction('getSunCoords')?.() || null;
+    return sunDefaultsRuntimeDeps.getSunCoords?.() || null;
   } catch {
     return null;
   }
@@ -67,12 +69,12 @@ export function openSunSetupProfileLocationRuntime() {
 }
 
 export function hasSunSetupPreciseLocationRequester() {
-  return getRuntimeFunction('requestPreciseLocation') !== null;
+  return sunDefaultsRuntimeDeps.requestPreciseLocation !== null;
 }
 
 export function requestSunSetupPreciseLocationRuntime() {
   try {
-    return getRuntimeFunction('requestPreciseLocation')?.() || null;
+    return sunDefaultsRuntimeDeps.requestPreciseLocation?.() || null;
   } catch {
     return null;
   }

--- a/js/sun-runtime.js
+++ b/js/sun-runtime.js
@@ -122,9 +122,3 @@ export function addSunProfileSwitchListener(listener) {
     runtime.addEventListener('labcharts-profile-switched', listener);
   }
 }
-
-/** @param {Record<string, any>} bindings */
-export function exposeSunRuntimeBindings(bindings) {
-  const runtime = getRuntimeWindow();
-  if (runtime) Object.assign(runtime, bindings);
-}

--- a/js/sun.js
+++ b/js/sun.js
@@ -26,11 +26,6 @@ import {
   renderBodySilhouette,
   bindBodySilhouette,
   resetBodySilhouetteState,
-  _testLoadRegionMap,
-  _testRegionAtSource,
-  _testRegionColorRGB,
-  _testStockImg,
-  _testRegionBandLandmarks,
 } from './sun-body-silhouette.js';
 import {
   configureSunActiveSession,
@@ -41,7 +36,6 @@ import {
   commitSunLiveSlice as _commitCurrentSlice,
   setSunLiveState as _setLiveState,
   clearSunLiveState as _clearLiveState,
-  ensureActiveTicker as _ensureActiveTicker,
   resumeActiveTickerIfNeeded as _resumeActiveTickerIfNeeded,
   hydrateSunSessionFromProfileCoords as _hydrateFromProfileCoords,
   resetSunActiveSessionState,
@@ -96,8 +90,6 @@ import {
   renderSunSessionRow,
   openDetailedSessionDialog,
   openSunSessionDetail,
-  deleteSunSession,
-  editSunSessionDuration,
 } from './sun-session-ui.js';
 import {
   TOO_SHORT_FOR_CHANNEL_VERDICT_MIN,
@@ -109,7 +101,6 @@ import {
 } from './sun-channel-metrics.js';
 import {
   addSunProfileSwitchListener,
-  exposeSunRuntimeBindings,
   getSunDeviceSessionsRuntime,
   hasSunBrowserRuntime,
   hasSunGeolocationRuntime,
@@ -120,6 +111,9 @@ import {
   renderLightTodayStripRuntime,
   requestSunGeolocationPositionRuntime,
 } from './sun-runtime.js';
+import { configureAIVerdictRuntimeDeps } from './ai-verdict-engine-runtime.js';
+import { configureProfileContextLightDeps } from './profile-context.js';
+import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
 export { BODY_REGIONS, renderBodySilhouette, bindBodySilhouette };
 export { renderSessionsList, renderSunSessionRow, openDetailedSessionDialog, openSunSessionDetail };
 export { quickLogSunSession, openStartSunSessionDialog, _wireBackdropClose, trapModalFocus };
@@ -160,11 +154,9 @@ export {
 // NOTE: sun-ai-analysis.js is intentionally NOT imported here — it
 // imports from this file (getSessions, formatChannelUnit, etc.), and a
 // reciprocal import would create a circular dependency that risks TDZ
-// errors at module-init time. Other features (rooms, screens, audits,
-// burden) already access their AI modules through browser-runtime
-// lookups; sun follows the same pattern for consistency + cycle-safety.
-// main.js imports both modules in a deterministic order so the runtime
-// functions are available by the time sun.js's exports are first invoked.
+// errors at module-init time. main.js imports both modules in a
+// deterministic order, while the verdict runtime receives the internal
+// surface-refresh callback explicitly below.
 
 // `label` is the row-meta display; `pickerLabel` is what the dropdown
 // option shows (where the safety nudge belongs). Earlier the row-meta
@@ -804,6 +796,10 @@ configureSunSessionUI({
   circadianMelanopicLux,
 });
 
+configureAIVerdictRuntimeDeps({ refreshSunSurfaces: _refreshSurfaces });
+configureProfileContextLightDeps({ rollingChannelTotals });
+configureSunDefaultsRuntimeDeps({ getSunCoords, requestPreciseLocation });
+
 // Reset all sun.js module-singleton state. Called on profile switch so
 // caches/timers from profile A don't bleed into profile B (e.g. region-
 // map decoded canvas data is profile-agnostic but the overlay cache key
@@ -816,71 +812,5 @@ function _resetSunModuleState() {
 }
 
 if (hasSunBrowserRuntime()) {
-  // Exposed so sun-ai-analysis.js can request a re-render after an async
-  // analyzeSunSessionAI() completes — keeps that module from importing
-  // sun.js's internal _refreshSurfaces directly (would be a back-edge).
   addSunProfileSwitchListener(_resetSunModuleState);
-  exposeSunRuntimeBindings({
-    SUN_ENGINE_VERSION,
-    _refreshSunSurfaces: _refreshSurfaces,
-    quickLogSunSession,
-    startSession,
-    stopSession,
-    pauseSession, resumeSession,
-    pauseSunSession, resumeSunSession,
-    applySunscreenMidSession,
-    changeCoverageMidSession,
-    flipSidesMidSession,
-    setOzoneOverrideMidSession,
-    _forgotStopPrompt,
-    logCompletedSession,
-    updateSession,
-    editSunSessionDuration,
-    deleteSunSession,
-    hydrateSession,
-    rehydrateStaleSessions,
-    getSessions,
-    getActiveSession,
-    rollingChannelTotals,
-    dailyChannelBreakdown,
-    dailyVitaminDIUBreakdown,
-    rollingVitaminDIU,
-    cumulativeMEDToday,
-    cumulativeMEDYesterday,
-    cumulativeVitaminDIUToday,
-    vitaminDBudgetStatus,
-    _applyAtmOverrides,
-    renderSessionsList,
-    renderSunSessionRow,
-    getSunCoords,
-    requestPreciseLocation,
-    openDetailedSessionDialog,
-    openStartSunSessionDialog,
-    openSunSessionDetail,
-    renderBodySilhouette,
-    bindBodySilhouette,
-    // Test-only: region-map internals exposed for assertion in
-    // tests/test-silhouette-region-map.js. Not for app code — the
-    // public API for click→region resolution is the silhouette
-    // picker's click handler in bindBodySilhouette.
-    _testLoadRegionMap,
-    _testRegionAtSource,
-    _testRegionColorRGB,
-    _testStockImg,
-    _testRegionBandLandmarks,
-    trapModalFocus,
-    _wireBackdropClose,
-    _resumeActiveTickerIfNeeded,
-    _ensureActiveTicker,
-    BODY_REGIONS,
-    EXPOSURE_PRESETS,
-    EYE_MODES,
-    LENS_TINTS,
-    CHANNEL_DISPLAY,
-    channelTier,
-    weeklyChannelTier,
-    tierLabel,
-    formatChannelUnit,
-    tierDots,
-  });
 }

--- a/tests/ai-verdict-engine-runtime.test.js
+++ b/tests/ai-verdict-engine-runtime.test.js
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  configureAIVerdictRuntimeDeps,
   dispatchAIVerdictUpdatedRuntime,
   getAIVerdictConcurrencyCapRuntime,
   hasAIVerdictRuntime,
@@ -10,6 +11,7 @@ import {
 } from '../js/ai-verdict-engine-runtime.js';
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalRuntimeDeps = configureAIVerdictRuntimeDeps();
 
 function setRuntimeWindow(runtime) {
   Object.defineProperty(globalThis, 'window', {
@@ -20,6 +22,7 @@ function setRuntimeWindow(runtime) {
 }
 
 afterEach(() => {
+  configureAIVerdictRuntimeDeps(originalRuntimeDeps);
   if (savedWindow) {
     Object.defineProperty(globalThis, 'window', savedWindow);
   } else {
@@ -45,11 +48,11 @@ describe('ai verdict engine runtime adapter', () => {
       }
     }
     const runtime = {
-      _refreshSunSurfaces: refreshSunSurfaces,
       CustomEvent: TestCustomEvent,
       dispatchEvent,
     };
     setRuntimeWindow(runtime);
+    configureAIVerdictRuntimeDeps({ refreshSunSurfaces });
 
     expect(refreshSunSurfacesRuntime('[data-id="session-1"]')).toBe(true);
     expect(dispatchAIVerdictUpdatedRuntime()).toBe(true);
@@ -59,6 +62,7 @@ describe('ai verdict engine runtime adapter', () => {
 
   it('uses safe fallbacks when browser runtime hooks are missing', () => {
     delete globalThis.window;
+    configureAIVerdictRuntimeDeps({ refreshSunSurfaces: null });
 
     expect(hasAIVerdictRuntime()).toBe(false);
     expect(isAIVerdictEngineDisabledRuntime()).toBe(false);

--- a/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
@@ -28,8 +28,6 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
     const originalView = state.currentView;
     const originalMarkerRegistry = state.markerRegistry;
     const savedWindow = {
-      getSessions: window.getSessions,
-      rollingChannelTotals: window.rollingChannelTotals,
       detectWearableTrendSlots: window.detectWearableTrendSlots,
       _snpTableCache: window._snpTableCache,
     };
@@ -115,8 +113,6 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
           return new Promise(resolve => { resolveCatalog = resolve; });
         },
       });
-      window.getSessions = () => [];
-      window.rollingChannelTotals = () => ({ circadian: 0 });
       window.detectWearableTrendSlots = () => [{
         slotKey: 'body.sleep',
         reason: 'Wearable sleep trend is deteriorating.',

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -294,8 +294,6 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     };
     const savedFns = {
       detectWearableTrendSlots: window.detectWearableTrendSlots,
-      rollingChannelTotals: window.rollingChannelTotals,
-      getSessions: window.getSessions,
       openChatPanel: window.openChatPanel,
       showDetailModal: window.showDetailModal,
     };
@@ -389,8 +387,6 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       slotKey: 'body.sleepRecovery',
       reason: 'Resting heart rate is elevated and HRV is below baseline.',
     }];
-    window.rollingChannelTotals = () => ({ circadian: 0 });
-    window.getSessions = () => [];
     window.openChatPanel = prompt => calls.push(['chat', prompt]);
     window.showDetailModal = id => calls.push(['detail', id]);
     previousSettingsBridge = settingsRuntimeBridge.configureSettingsModuleBridge({

--- a/tests/playwright/light-ai-analysis-coverage-batch.spec.js
+++ b/tests/playwright/light-ai-analysis-coverage-batch.spec.js
@@ -8,10 +8,11 @@ test('sun and device session AI analysis covers contexts fingerprints and render
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ sunUrl, deviceUrl, apiUrl }) => {
-    const [sun, device, api] = await Promise.all([
+    const [sun, device, api, aiVerdictRuntime] = await Promise.all([
       import(sunUrl),
       import(deviceUrl),
       import(apiUrl),
+      import('/js/ai-verdict-engine-runtime.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
@@ -20,11 +21,13 @@ test('sun and device session AI analysis covers contexts fingerprints and render
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
       solarZenithAngle: window.solarZenithAngle,
-      refreshSunSurfaces: window._refreshSunSurfaces,
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
       ollamaModel: localStorage.getItem('labcharts-ollama-model'),
     };
+    const previousAIVerdictRuntimeDeps = aiVerdictRuntime.configureAIVerdictRuntimeDeps({
+      refreshSunSurfaces: () => {},
+    });
 
     const setPausedProvider = () => {
       localStorage.setItem('labcharts-ai-provider', 'ollama');
@@ -136,7 +139,6 @@ test('sun and device session AI analysis covers contexts fingerprints and render
         lightDevices: [lightDevice],
         deviceSessions: [deviceSession, priorDeviceSession],
       };
-      window._refreshSunSurfaces = () => {};
       const sunContext = sun.buildSingleSessionContext(sunSession);
       outcomes.sunContextIncludesSolarPhase = sunContext.includes('Solar phase:')
         && sunContext.includes('sunrise window');
@@ -327,7 +329,7 @@ test('sun and device session AI analysis covers contexts fingerprints and render
       window.fetch = saved.fetch;
       window.getOllamaConfig = saved.getOllamaConfig;
       window.solarZenithAngle = saved.solarZenithAngle;
-      window._refreshSunSurfaces = saved.refreshSunSurfaces;
+      aiVerdictRuntime.configureAIVerdictRuntimeDeps(previousAIVerdictRuntimeDeps);
       if (saved.provider == null) localStorage.removeItem('labcharts-ai-provider');
       else localStorage.setItem('labcharts-ai-provider', saved.provider);
       if (saved.paused == null) localStorage.removeItem('labcharts-ai-paused');
@@ -352,11 +354,12 @@ test('light environment AI analysis covers audit room screen and onboarding verd
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ auditUrl, roomUrl, screenUrl, onboardingUrl }) => {
-    const [audit, roomAI, screenAI, onboarding] = await Promise.all([
+    const [audit, roomAI, screenAI, onboarding, aiVerdictRuntime] = await Promise.all([
       import(auditUrl),
       import(roomUrl),
       import(screenUrl),
       import(onboardingUrl),
+      import('/js/ai-verdict-engine-runtime.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
@@ -364,11 +367,13 @@ test('light environment AI analysis covers audit room screen and onboarding verd
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
-      refreshSunSurfaces: window._refreshSunSurfaces,
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
       ollamaModel: localStorage.getItem('labcharts-ollama-model'),
     };
+    const previousAIVerdictRuntimeDeps = aiVerdictRuntime.configureAIVerdictRuntimeDeps({
+      refreshSunSurfaces: () => {},
+    });
     const setPausedProvider = () => {
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ai-paused', 'true');
@@ -464,7 +469,6 @@ test('light environment AI analysis covers audit room screen and onboarding verd
           { date: '2026-06-01', values: { lipids: { '25-oh-vitamin-d': 24 } } },
         ],
       };
-      window._refreshSunSurfaces = () => {};
       window.fetch = async (url, options = {}) => {
         if (String(url).includes('/v1/chat/completions')) {
           return new Response(JSON.stringify({
@@ -603,7 +607,7 @@ test('light environment AI analysis covers audit room screen and onboarding verd
       state.importedData = saved.importedData;
       window.fetch = saved.fetch;
       window.getOllamaConfig = saved.getOllamaConfig;
-      window._refreshSunSurfaces = saved.refreshSunSurfaces;
+      aiVerdictRuntime.configureAIVerdictRuntimeDeps(previousAIVerdictRuntimeDeps);
       if (saved.provider == null) localStorage.removeItem('labcharts-ai-provider');
       else localStorage.setItem('labcharts-ai-provider', saved.provider);
       if (saved.paused == null) localStorage.removeItem('labcharts-ai-paused');
@@ -629,10 +633,11 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ channelUrl, burdenUrl, todayUrl }) => {
-    const [channelAI, burdenAI, todayAI] = await Promise.all([
+    const [channelAI, burdenAI, todayAI, aiVerdictRuntime] = await Promise.all([
       import(channelUrl),
       import(burdenUrl),
       import(todayUrl),
+      import('/js/ai-verdict-engine-runtime.js'),
     ]);
     const state = window._labState;
     const outcomes = {};
@@ -640,13 +645,7 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       importedData: JSON.parse(JSON.stringify(state.importedData || {})),
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
-      refreshSunSurfaces: window._refreshSunSurfaces,
       solarZenithAngle: window.solarZenithAngle,
-      rollingChannelTotals: window.rollingChannelTotals,
-      rollingVitaminDIU: window.rollingVitaminDIU,
-      weeklyChannelTier: window.weeklyChannelTier,
-      tierLabel: window.tierLabel,
-      getSessions: window.getSessions,
       disableAIVerdicts: window.DISABLE_AI_VERDICTS,
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
@@ -668,6 +667,10 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       localStorage.setItem('labcharts-ollama-model', 'test-light-model');
       window.getOllamaConfig = () => ({ url: 'http://ollama.test', apiKey: '' });
     };
+    const previousAIVerdictRuntimeDeps = aiVerdictRuntime.configureAIVerdictRuntimeDeps({
+      refreshSunSurfaces: () => {},
+    });
+    let previousChannelAIAnalysisDeps = null;
 
     try {
       const today = new Date();
@@ -776,22 +779,15 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
         },
         lightDailyVerdicts: {},
       };
-      window._refreshSunSurfaces = () => {};
       window.solarZenithAngle = date => (date.getHours() < 7 ? 87 : 28);
-      window.rollingChannelTotals = days => days === 7
+      const rollingChannelTotals = days => days === 7
         ? { vitamin_d: 260, circadian: 180, nir_solar: 130, no_cv: 60, pomc: 55, violet_eye: 30 }
         : { vitamin_d: 540, circadian: 360, nir_solar: 320, no_cv: 140, pomc: 120, violet_eye: 45 };
       const rollingDeviceTotals = days => days === 7
         ? { circadian: 90, nir_solar: 50 }
         : { circadian: 180, nir_solar: 90 };
-      window.rollingVitaminDIU = () => 900;
-      todayAI.configureLightTodayAI({
-        solarZenithAngle: window.solarZenithAngle,
-        rollingChannelTotals: window.rollingChannelTotals,
-        rollingDeviceTotals,
-        rollingVitaminDIU: window.rollingVitaminDIU,
-      });
-      window.weeklyChannelTier = (value, key) => {
+      const rollingVitaminDIU = () => 900;
+      const weeklyChannelTier = (value, key) => {
         if (key === 'vitamin_d' && value >= 250) return 3;
         if (value >= 260) return 4;
         if (value >= 150) return 3;
@@ -799,8 +795,19 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
         if (value > 0) return 1;
         return 0;
       };
-      window.tierLabel = tier => ['none', 'low', 'moderate', 'good', 'strong'][tier] || 'none';
-      window.getSessions = () => state.importedData.sunSessions;
+      const tierLabel = tier => ['none', 'low', 'moderate', 'good', 'strong'][tier] || 'none';
+      todayAI.configureLightTodayAI({
+        solarZenithAngle: window.solarZenithAngle,
+        rollingChannelTotals,
+        rollingDeviceTotals,
+        rollingVitaminDIU,
+      });
+      previousChannelAIAnalysisDeps = channelAI.configureLightChannelsAIAnalysisDeps({
+        rollingChannelTotals,
+        weeklyChannelTier,
+        tierLabel,
+        getSessions: () => state.importedData.sunSessions,
+      });
       const queuedAIResponses = [];
       window.fetch = async (url, options = {}) => {
         if (String(url).includes('/v1/chat/completions')) {
@@ -823,16 +830,9 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
         && channelContext.includes('Health goals: SAD support; Raise vitamin D')
         && channelContext.includes('Latest 25-OH-D: 29');
       const channelFp = channelAI.getChannelMixFingerprint();
-      window.weeklyChannelTier = () => 0;
+      channelAI.configureLightChannelsAIAnalysisDeps({ weeklyChannelTier: () => 0 });
       const channelFpChanged = channelAI.getChannelMixFingerprint();
-      window.weeklyChannelTier = (value, key) => {
-        if (key === 'vitamin_d' && value >= 250) return 3;
-        if (value >= 260) return 4;
-        if (value >= 150) return 3;
-        if (value >= 60) return 2;
-        if (value > 0) return 1;
-        return 0;
-      };
+      channelAI.configureLightChannelsAIAnalysisDeps({ weeklyChannelTier });
       outcomes.channelFingerprintChangesWithTierMix = !!channelFp && channelFp !== channelFpChanged;
 
       const burdenContext = burdenAI.buildBurdenContext();
@@ -970,18 +970,12 @@ test('light aggregate AI analysis covers channel burden and daily verdicts', asy
       state.importedData = saved.importedData;
       window.fetch = saved.fetch;
       window.getOllamaConfig = saved.getOllamaConfig;
-      window._refreshSunSurfaces = saved.refreshSunSurfaces;
+      aiVerdictRuntime.configureAIVerdictRuntimeDeps(previousAIVerdictRuntimeDeps);
       window.solarZenithAngle = saved.solarZenithAngle;
-      window.rollingChannelTotals = saved.rollingChannelTotals;
-      window.rollingVitaminDIU = saved.rollingVitaminDIU;
-      todayAI.configureLightTodayAI({
-        solarZenithAngle: saved.solarZenithAngle,
-        rollingChannelTotals: saved.rollingChannelTotals,
-        rollingVitaminDIU: saved.rollingVitaminDIU,
-      });
-      window.weeklyChannelTier = saved.weeklyChannelTier;
-      window.tierLabel = saved.tierLabel;
-      window.getSessions = saved.getSessions;
+      todayAI.configureLightTodayAI({});
+      if (previousChannelAIAnalysisDeps) {
+        channelAI.configureLightChannelsAIAnalysisDeps(previousChannelAIAnalysisDeps);
+      }
       if (saved.disableAIVerdicts === undefined) delete window.DISABLE_AI_VERDICTS;
       else window.DISABLE_AI_VERDICTS = saved.disableAIVerdicts;
       if (saved.provider == null) localStorage.removeItem('labcharts-ai-provider');

--- a/tests/playwright/light-page-view.spec.js
+++ b/tests/playwright/light-page-view.spec.js
@@ -10,9 +10,6 @@ test('Light page view delegates session, link, channel, and prompt actions', asy
 
   const results = await page.evaluate(async () => {
     const { configureLightPageView, renderDashboardLightChannelPills, renderLightSessionLogActions } = await import('/js/light-page-view.js');
-    const savedFns = {
-      dailyChannelBreakdown: window.dailyChannelBreakdown,
-    };
     const calls = [];
     const host = document.createElement('div');
     const channelDisplay = {
@@ -44,11 +41,6 @@ test('Light page view delegates session, link, channel, and prompt actions', asy
         openLightEnvironmentAssessment: () => calls.push(['open-light-environment']),
         renderLightTools: () => '<section id="light-tools-expanded-test">Expanded tools</section>',
       });
-      window.dailyChannelBreakdown = () => Array.from({ length: 7 }, (_, i) => ({
-        sun: i === 0 ? 10 : 0,
-        device: 0,
-      }));
-
       document.body.appendChild(host);
       host.innerHTML = `
         ${renderLightSessionLogActions()}
@@ -113,7 +105,6 @@ test('Light page view delegates session, link, channel, and prompt actions', asy
         openLightEnvironmentAssessment: () => {},
         renderLightTools: () => '',
       });
-      window.dailyChannelBreakdown = savedFns.dailyChannelBreakdown;
       host.remove();
       document.getElementById('light-tools-expanded-test')?.remove();
     }
@@ -145,19 +136,18 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       importedData: state.importedData,
       mainHTML: main?.innerHTML,
       Date: window.Date,
-      getSessions: window.getSessions,
-      getActiveSession: window.getActiveSession,
-      cumulativeMEDToday: window.cumulativeMEDToday,
-      cumulativeMEDYesterday: window.cumulativeMEDYesterday,
-      rollingVitaminDIU: window.rollingVitaminDIU,
-      vitaminDBudgetStatus: window.vitaminDBudgetStatus,
-      getSunCoords: window.getSunCoords,
-      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
-      weeklyChannelTier: window.weeklyChannelTier,
-      channelTier: window.channelTier,
-      dailyChannelBreakdown: window.dailyChannelBreakdown,
-      rollingChannelTotals: window.rollingChannelTotals,
     };
+    let channelDisplay = {};
+    let weeklyChannelTier = () => 0;
+    let channelTier = () => 0;
+    let getSessions = () => [];
+    let getActiveSession = () => null;
+    let rollingChannelTotals = () => ({});
+    let cumulativeMEDToday = () => 0;
+    let cumulativeMEDYesterday = () => 0;
+    let rollingVitaminDIU = () => 0;
+    let vitaminDBudgetStatus = () => null;
+    let getSunCoords = () => null;
     let getDevices = () => [];
     let getDeviceSessions = () => [];
     let rollingDeviceTotals = () => ({});
@@ -166,20 +156,20 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
     let renderLightTodayHero = () => '';
     let renderSunSetupCard = sunDefaults.renderSetupCard;
     const syncLightPageDeps = () => lightPage.configureLightPageView({
-      channelDisplay: window.CHANNEL_DISPLAY || {},
-      weeklyChannelTier: typeof window.weeklyChannelTier === 'function' ? window.weeklyChannelTier : () => 0,
-      channelTier: typeof window.channelTier === 'function' ? window.channelTier : () => 0,
-      getSessions: typeof window.getSessions === 'function' ? window.getSessions : () => [],
+      channelDisplay,
+      weeklyChannelTier,
+      channelTier,
+      getSessions,
       getDevices,
       getDeviceSessions,
-      getActiveSession: typeof window.getActiveSession === 'function' ? window.getActiveSession : () => null,
-      rollingChannelTotals: typeof window.rollingChannelTotals === 'function' ? window.rollingChannelTotals : () => ({}),
+      getActiveSession,
+      rollingChannelTotals,
       rollingDeviceTotals,
-      cumulativeMEDToday: typeof window.cumulativeMEDToday === 'function' ? window.cumulativeMEDToday : () => 0,
-      cumulativeMEDYesterday: typeof window.cumulativeMEDYesterday === 'function' ? window.cumulativeMEDYesterday : () => 0,
-      rollingVitaminDIU: typeof window.rollingVitaminDIU === 'function' ? window.rollingVitaminDIU : () => 0,
-      vitaminDBudgetStatus: typeof window.vitaminDBudgetStatus === 'function' ? window.vitaminDBudgetStatus : () => null,
-      getSunCoords: typeof window.getSunCoords === 'function' ? window.getSunCoords : () => null,
+      cumulativeMEDToday,
+      cumulativeMEDYesterday,
+      rollingVitaminDIU,
+      vitaminDBudgetStatus,
+      getSunCoords,
       renderLightTodayDashboardChip,
       renderLightTodayHero,
       renderSunSetupCard,
@@ -216,29 +206,25 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
         sunDefaults: null,
         lightEnvironment: null,
       };
-      window.CHANNEL_DISPLAY = channelMeta;
-      window.weeklyChannelTier = value => value > 100 ? 2 : 0;
-      window.channelTier = window.weeklyChannelTier;
-      window.dailyChannelBreakdown = () => Array.from({ length: 7 }, (_, index) => ({
-        sun: index === 0 ? 120 : 0,
-        device: index === 1 ? 80 : 0,
-      }));
-      window.rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
+      channelDisplay = channelMeta;
+      weeklyChannelTier = value => value > 100 ? 2 : 0;
+      channelTier = weeklyChannelTier;
+      rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
       rollingDeviceTotals = () => ({ nir_solar: 120 });
-      window.getSessions = () => [];
+      getSessions = () => [];
       getDeviceSessions = () => [];
       getDevices = () => [];
-      window.getActiveSession = () => null;
-      window.cumulativeMEDToday = () => 0.72;
-      window.cumulativeMEDYesterday = () => 0.4;
-      window.rollingVitaminDIU = () => 1800;
-      window.vitaminDBudgetStatus = () => ({
+      getActiveSession = () => null;
+      cumulativeMEDToday = () => 0.72;
+      cumulativeMEDYesterday = () => 0.4;
+      rollingVitaminDIU = () => 1800;
+      vitaminDBudgetStatus = () => ({
         supplementIU: 5000,
         sunIU: 1200,
         total: 6200,
         exceedsSupplementUL: true,
       });
-      window.getSunCoords = () => ({ lat: 50, lon: 14, altitudeM: 1700, source: 'profile-precise' });
+      getSunCoords = () => ({ lat: 50, lon: 14, altitudeM: 1700, source: 'profile-precise' });
       renderLightTodayDashboardChip = () => '<div class="light-dashboard-chip-test">chip</div>';
       syncLightPageDeps();
 
@@ -280,7 +266,7 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
         && oneDevice.includes('Map a room');
 
       setHour(10);
-      window.getActiveSession = () => ({ id: 'active-sun', startedAt: Date.now() - 95_000 });
+      getActiveSession = () => ({ id: 'active-sun', startedAt: Date.now() - 95_000 });
       syncLightPageDeps();
       const activeStrip = lightPage.renderLightTodayStrip();
       outcomes.activeSessionStripShowsStopElapsed =
@@ -292,18 +278,18 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       renderDevicesSection = () => '<div class="devices-section-test">devices</div>';
       renderEnvironmentAssessmentSummary = () => '';
       renderLightTools = () => '';
-      window.getActiveSession = () => null;
+      getActiveSession = () => null;
       getDevices = () => [];
-      window.getSessions = () => [];
+      getSessions = () => [];
       getDeviceSessions = () => [];
-      window.getSunCoords = () => null;
+      getSunCoords = () => null;
       syncLightPageDeps();
       lightPage.showLight(state.importedData);
       outcomes.emptyLightPagePromptsForMissingCoords =
         main?.textContent.includes('set your country in the profile editor') === true
         && main?.querySelector('[data-light-page-action="request-precise-location"]') !== null;
 
-      window.getSunCoords = () => ({ source: 'country-band', lat: 49.2, lon: 16.6 });
+      getSunCoords = () => ({ source: 'country-band', lat: 49.2, lon: 16.6 });
       syncLightPageDeps();
       lightPage.showLight(state.importedData);
       outcomes.emptyLightPageShowsCountryBandHint =
@@ -311,12 +297,12 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
 
       // Guidance should interpret logged exposure, not present unused PBM
       // channels as deficiencies or mix product discovery into health advice.
-      window.getSessions = () => Array.from({ length: 7 }, (_, index) => ({
+      getSessions = () => Array.from({ length: 7 }, (_, index) => ({
         id: `sun-${index}`,
         startedAt: Date.now() - (index + 1) * 86_400_000,
         endedAt: Date.now() - (index + 1) * 86_400_000 + 600_000,
       }));
-      window.rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
+      rollingChannelTotals = () => ({ vitamin_d: 250, circadian: 40 });
       rollingDeviceTotals = () => ({ pbm_red: 0, pbm_nir: 0 });
       syncLightPageDeps();
       lightPage.showLight(state.importedData);
@@ -333,18 +319,17 @@ test('Light page today strip and empty-state hints cover adaptive branches', asy
       state.importedData = saved.importedData;
       if (main && saved.mainHTML != null) main.innerHTML = saved.mainHTML;
       window.Date = saved.Date || RealDate;
-      window.getSessions = saved.getSessions;
-      window.getActiveSession = saved.getActiveSession;
-      window.cumulativeMEDToday = saved.cumulativeMEDToday;
-      window.cumulativeMEDYesterday = saved.cumulativeMEDYesterday;
-      window.rollingVitaminDIU = saved.rollingVitaminDIU;
-      window.vitaminDBudgetStatus = saved.vitaminDBudgetStatus;
-      window.getSunCoords = saved.getSunCoords;
-      window.CHANNEL_DISPLAY = saved.CHANNEL_DISPLAY;
-      window.weeklyChannelTier = saved.weeklyChannelTier;
-      window.channelTier = saved.channelTier;
-      window.dailyChannelBreakdown = saved.dailyChannelBreakdown;
-      window.rollingChannelTotals = saved.rollingChannelTotals;
+      channelDisplay = {};
+      weeklyChannelTier = () => 0;
+      channelTier = () => 0;
+      getSessions = () => [];
+      getActiveSession = () => null;
+      rollingChannelTotals = () => ({});
+      cumulativeMEDToday = () => 0;
+      cumulativeMEDYesterday = () => 0;
+      rollingVitaminDIU = () => 0;
+      vitaminDBudgetStatus = () => null;
+      getSunCoords = () => null;
       getDevices = () => [];
       getDeviceSessions = () => [];
       rollingDeviceTotals = () => ({});

--- a/tests/playwright/light-screen-ai-browser-coverage.spec.js
+++ b/tests/playwright/light-screen-ai-browser-coverage.spec.js
@@ -8,10 +8,11 @@ test('light screen AI browser coverage refreshes and auto-analyzes screen verdic
   await page.goto('/app', { waitUntil: 'load' });
 
   const outcomes = await page.evaluate(async ({ screenUrl }) => {
-    const [screenAI, { state }, data] = await Promise.all([
+    const [screenAI, { state }, data, aiVerdictRuntime] = await Promise.all([
       import(screenUrl),
       import('/js/state.js'),
       import('/js/data.js'),
+      import('/js/ai-verdict-engine-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -31,7 +32,6 @@ test('light screen AI browser coverage refreshes and auto-analyzes screen verdic
       currentProfile: state.currentProfile,
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
-      refreshSunSurfaces: window._refreshSunSurfaces,
       disableAIVerdicts: window.DISABLE_AI_VERDICTS,
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
@@ -58,6 +58,9 @@ test('light screen AI browser coverage refreshes and auto-analyzes screen verdic
     };
     let aiCalls = 0;
     let releaseRefreshFetch = null;
+    const previousAIVerdictRuntimeDeps = aiVerdictRuntime.configureAIVerdictRuntimeDeps({
+      refreshSunSurfaces: anchor => { refreshAnchors.push(anchor || ''); },
+    });
 
     try {
       state.currentProfile = 'light-screen-ai-browser-coverage';
@@ -76,7 +79,6 @@ test('light screen AI browser coverage refreshes and auto-analyzes screen verdic
       localStorage.setItem('labcharts-ollama-model', 'screen-coverage-model');
       window.DISABLE_AI_VERDICTS = false;
       window.getOllamaConfig = () => ({ url: 'http://ollama.test', apiKey: '' });
-      window._refreshSunSurfaces = anchor => { refreshAnchors.push(anchor || ''); };
       window.fetch = async (url, options = {}) => {
         if (String(url).includes('/v1/chat/completions')) {
           aiCalls += 1;
@@ -128,7 +130,7 @@ test('light screen AI browser coverage refreshes and auto-analyzes screen verdic
       data.invalidateActiveDataCache();
       window.fetch = saved.fetch;
       window.getOllamaConfig = saved.getOllamaConfig;
-      window._refreshSunSurfaces = saved.refreshSunSurfaces;
+      aiVerdictRuntime.configureAIVerdictRuntimeDeps(previousAIVerdictRuntimeDeps);
       if (saved.disableAIVerdicts === undefined) delete window.DISABLE_AI_VERDICTS;
       else window.DISABLE_AI_VERDICTS = saved.disableAIVerdicts;
       if (saved.provider == null) localStorage.removeItem('labcharts-ai-provider');

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -788,11 +788,10 @@ test('light camera tool modals cover mocked camera readings and save paths', asy
 test('light devices cover session detail edit log active card and rendered list paths', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  const results = await page.evaluate(async ({ devicesUrl, silhouetteUrl }) => {
+  const results = await page.evaluate(async ({ devicesUrl }) => {
     const lightDevices = await import(devicesUrl);
     const lightDevicesRuntime = await import('/js/light-devices-runtime.js');
     const recommendationRuntime = await import('/js/recommendations-runtime.js');
-    const silhouette = await import(silhouetteUrl);
     const { profileStorageKey } = await import('/js/profile.js');
     const blobStorage = await import('/js/blob-storage.js');
     const state = window._labState;
@@ -802,18 +801,21 @@ test('light devices cover session detail edit log active card and rendered list 
     const originalImportedLocalValue = localStorage.getItem(importedStorageKey);
     const originalImportedBlobValue = await blobStorage.getBlob(importedStorageKey);
     const savedWindow = {
-      channelTier: window.channelTier,
-      tierLabel: window.tierLabel,
-      formatChannelUnit: window.formatChannelUnit,
-      CHANNEL_DISPLAY: window.CHANNEL_DISPLAY,
       _openChannelOnLightPage: window._openChannelOnLightPage,
       navigate: window.navigate,
-      renderBodySilhouette: window.renderBodySilhouette,
-      bindBodySilhouette: window.bindBodySilhouette,
     };
     const calls = [];
     const previousLightDevicesRuntimeDeps = lightDevicesRuntime.configureLightDevicesRuntimeDeps({
       showPromptDialog: async () => '17',
+      channelTier: value => value > 30 ? 3 : value > 10 ? 2 : value > 0 ? 1 : 0,
+      tierLabel: tier => ['none', 'low', 'moderate', 'high'][tier] || 'none',
+      formatChannelUnit: (key, value) => `${Math.round(value)} ${key}`,
+      channelDisplay: {
+        vitamin_d: { icon: 'D', label: 'Vitamin D', what: 'Vitamin D' },
+        circadian: { icon: 'C', label: 'Circadian', what: 'Circadian' },
+        pbm_red: { icon: 'R', label: 'Red', what: 'Red light' },
+        pbm_nir: { icon: 'N', label: 'NIR', what: 'NIR' },
+      },
     });
     const previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
       loadCatalog: async () => ({ items: [] }),
@@ -867,22 +869,11 @@ test('light devices cover session detail edit log active card and rendered list 
         lightDevices: [device],
         deviceSessions: [session],
       };
-      window.channelTier = value => value > 30 ? 3 : value > 10 ? 2 : value > 0 ? 1 : 0;
-      window.tierLabel = tier => ['none', 'low', 'moderate', 'high'][tier] || 'none';
-      window.formatChannelUnit = (key, value) => `${Math.round(value)} ${key}`;
-      window.CHANNEL_DISPLAY = {
-        vitamin_d: { icon: 'D', label: 'Vitamin D', what: 'Vitamin D' },
-        circadian: { icon: 'C', label: 'Circadian', what: 'Circadian' },
-        pbm_red: { icon: 'R', label: 'Red', what: 'Red light' },
-        pbm_nir: { icon: 'N', label: 'NIR', what: 'NIR' },
-      };
       window._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
       lightDevices.configureLightDevices({
         renderDeviceSessionAIDetail: () => '<section class="device-ai-detail-test">Device AI</section>',
       });
       window.navigate = route => calls.push(['navigate', route]);
-      window.renderBodySilhouette = silhouette.renderBodySilhouette;
-      window.bindBodySilhouette = silhouette.bindBodySilhouette;
 
       const devicesHtml = await lightDevices.renderDevicesSection();
       const devicesHost = document.createElement('div');
@@ -976,7 +967,6 @@ test('light devices cover session detail edit log active card and rendered list 
     return outcomes;
   }, {
     devicesUrl: moduleUrl('/js/light-devices.js'),
-    silhouetteUrl: moduleUrl('/js/sun-body-silhouette.js'),
   });
 
   for (const [name, passed] of Object.entries(results)) {

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -46,8 +46,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       navigate: window.navigate,
-      getSunCoords: window.getSunCoords,
-      requestPreciseLocation: window.requestPreciseLocation,
     };
     const calls = [];
     const outcomes = {};
@@ -56,6 +54,15 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       getProfileLocation: () => ({ country: 'Czechia', zip: '' }),
       openProfileLocationEditor: () => calls.push(['profile-location']),
       openClientList: () => calls.push(['client-list']),
+      getSunCoords: () => precise
+        ? { source: 'profile-precise', lat: 50.087 }
+        : { source: 'country-band', lat: 49.2 },
+      requestPreciseLocation: async () => {
+        calls.push(['precise-location']);
+        await wait(0);
+        precise = true;
+        return { lat: 50.087, lon: 14.421 };
+      },
     });
 
     try {
@@ -72,15 +79,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       data.invalidateActiveDataCache();
 
       window.navigate = route => calls.push(['navigate', route]);
-      window.getSunCoords = () => precise
-        ? { source: 'profile-precise', lat: 50.087 }
-        : { source: 'country-band', lat: 49.2 };
-      window.requestPreciseLocation = async () => {
-        calls.push(['precise-location']);
-        await wait(0);
-        precise = true;
-        return { lat: 50.087, lon: 14.421 };
-      };
       sunDefaults.configureSunDefaults({
         maybeAnalyzeOnboardingAfterSave: () => calls.push(['onboarding-ai']),
         renderOnboardingAIBlock: () => '<div id="setup-ai-block">AI setup block</div>',
@@ -204,11 +202,7 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       data.invalidateActiveDataCache();
-      Object.assign(window, {
-        navigate: saved.navigate,
-        getSunCoords: saved.getSunCoords,
-        requestPreciseLocation: saved.requestPreciseLocation,
-      });
+      window.navigate = saved.navigate;
       sunDefaults.configureSunDefaults({
         maybeAnalyzeOnboardingAfterSave: () => {},
         renderOnboardingAIBlock: () => '',

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -243,15 +243,21 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
   const outcomes = await page.evaluate(async ({ maintenanceUrl }) => {
     const originalSetTimeout = window.setTimeout;
     const originalConsoleLog = console.log;
-    const originalRehydrate = window.rehydrateStaleSessions;
-    const originalEngineVersion = window.SUN_ENGINE_VERSION;
     const logs = [];
-
     window.__startupMaintenanceCalls = [];
     window.__startupMaintenanceState = {
       currentProfile: 'startup-maintenance-profile',
       importedData: { biometrics: { weight: 70 } },
     };
+    const startupRuntime = await import('/js/startup-maintenance-runtime.js');
+    const previousStartupSunDeps = startupRuntime.configureStartupMaintenanceSunDeps({
+      getSunEngineVersion: () => 'maintenance-test',
+      rehydrateStaleSessions: async () => {
+        window.__startupMaintenanceCalls.push('rehydrateStaleSessions');
+        return { rehydrated: 2 };
+      },
+    });
+
     window.setTimeout = (callback, delay, ...args) => {
       window.__startupMaintenanceCalls.push(['setTimeout', delay]);
       callback(...args);
@@ -260,12 +266,6 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
     console.log = (...args) => {
       logs.push(args.map(arg => String(arg)).join(' '));
     };
-    window.SUN_ENGINE_VERSION = 'maintenance-test';
-    window.rehydrateStaleSessions = async () => {
-      window.__startupMaintenanceCalls.push('rehydrateStaleSessions');
-      return { rehydrated: 2 };
-    };
-
     const waitUntil = async predicate => {
       for (let attempt = 0; attempt < 50; attempt += 1) {
         if (predicate()) return true;
@@ -308,10 +308,7 @@ test('startup maintenance starts services and runs non-blocking migrations', asy
     } finally {
       window.setTimeout = originalSetTimeout;
       console.log = originalConsoleLog;
-      if (originalRehydrate) window.rehydrateStaleSessions = originalRehydrate;
-      else delete window.rehydrateStaleSessions;
-      if (originalEngineVersion === undefined) delete window.SUN_ENGINE_VERSION;
-      else window.SUN_ENGINE_VERSION = originalEngineVersion;
+      startupRuntime.configureStartupMaintenanceSunDeps(previousStartupSunDeps);
     }
   }, {
     maintenanceUrl: moduleUrl('/js/startup-maintenance.js'),

--- a/tests/playwright/sun-browser-coverage.spec.js
+++ b/tests/playwright/sun-browser-coverage.spec.js
@@ -4,6 +4,22 @@ function moduleUrl(path) {
   return `${path}?sunBrowserCoverage=${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+const FORMER_SUN_GLOBALS = [
+  'SUN_ENGINE_VERSION', '_refreshSunSurfaces', 'quickLogSunSession', 'startSession', 'stopSession',
+  'pauseSession', 'resumeSession', 'pauseSunSession', 'resumeSunSession', 'applySunscreenMidSession',
+  'changeCoverageMidSession', 'flipSidesMidSession', 'setOzoneOverrideMidSession', '_forgotStopPrompt',
+  'logCompletedSession', 'updateSession', 'editSunSessionDuration', 'deleteSunSession', 'hydrateSession',
+  'rehydrateStaleSessions', 'getSessions', 'getActiveSession', 'rollingChannelTotals', 'dailyChannelBreakdown',
+  'dailyVitaminDIUBreakdown', 'rollingVitaminDIU', 'cumulativeMEDToday', 'cumulativeMEDYesterday',
+  'cumulativeVitaminDIUToday', 'vitaminDBudgetStatus', '_applyAtmOverrides', 'renderSessionsList',
+  'renderSunSessionRow', 'getSunCoords', 'requestPreciseLocation', 'openDetailedSessionDialog',
+  'openStartSunSessionDialog', 'openSunSessionDetail', 'renderBodySilhouette', 'bindBodySilhouette',
+  '_testLoadRegionMap', '_testRegionAtSource', '_testRegionColorRGB', '_testStockImg',
+  '_testRegionBandLandmarks', 'trapModalFocus', '_wireBackdropClose', '_resumeActiveTickerIfNeeded',
+  '_ensureActiveTicker', 'BODY_REGIONS', 'EXPOSURE_PRESETS', 'EYE_MODES', 'LENS_TINTS',
+  'CHANNEL_DISPLAY', 'channelTier', 'weeklyChannelTier', 'tierLabel', 'formatChannelUnit', 'tierDots',
+];
+
 function expectAll(outcomes) {
   const failed = Object.entries(outcomes)
     .filter(([, value]) => value !== true)
@@ -67,7 +83,7 @@ test('sun session model browser coverage exercises safety defaults and caveats',
 test('sun browser coverage exercises facade totals prompts and location paths', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
 
-  const outcomes = await page.evaluate(async ({ sunUrl, utilsUrl }) => {
+  const outcomes = await page.evaluate(async ({ sunUrl, utilsUrl, formerSunGlobals }) => {
     const [{ state }, sun, utils, viewRuntime] = await Promise.all([
       import('/js/state.js'),
       import(sunUrl),
@@ -202,9 +218,10 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       outcomes.promptAllowEmptyPreservesDefaultSemantics = defaultEmptyResult === null
         && allowEmptyResult === '';
 
-      outcomes.windowFacadeExports = window.rollingChannelTotals === sun.rollingChannelTotals
-        && typeof window.applySunscreenMidSession === 'function'
-        && window.SUN_ENGINE_VERSION === sun.SUN_ENGINE_VERSION;
+      outcomes.sunFacadeStaysModuleOnly = formerSunGlobals.every(name => !(name in window))
+        && typeof sun.rollingChannelTotals === 'function'
+        && typeof sun.applySunscreenMidSession === 'function'
+        && Number.isFinite(sun.SUN_ENGINE_VERSION);
       outcomes.tierHelpersCoverDailyWeeklyAndFallbacks = sun.channelTier(0, 'vitamin_d') === 0
         && sun.channelTier(200, 'vitamin_d') === 3
         && sun.weeklyChannelTier(560, 'pomc') === 4
@@ -330,7 +347,11 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       document.querySelectorAll('.notification-container,.notification-toast,#prompt-dialog-overlay,#confirm-dialog-overlay,.modal-overlay').forEach(el => el.remove());
     }
     return outcomes;
-  }, { sunUrl: moduleUrl('/js/sun.js'), utilsUrl: moduleUrl('/js/utils.js') });
+  }, {
+    sunUrl: moduleUrl('/js/sun.js'),
+    utilsUrl: moduleUrl('/js/utils.js'),
+    formerSunGlobals: FORMER_SUN_GLOBALS,
+  });
 
   expectAll(outcomes);
 });

--- a/tests/playwright/sun-onboarding-ai-browser-coverage.spec.js
+++ b/tests/playwright/sun-onboarding-ai-browser-coverage.spec.js
@@ -8,10 +8,11 @@ test('sun onboarding AI browser coverage refreshes and auto-analyzes completed s
   await page.goto('/app', { waitUntil: 'load' });
 
   const outcomes = await page.evaluate(async ({ onboardingUrl }) => {
-    const [onboarding, { state }, data] = await Promise.all([
+    const [onboarding, { state }, data, aiVerdictRuntime] = await Promise.all([
       import(onboardingUrl),
       import('/js/state.js'),
       import('/js/data.js'),
+      import('/js/ai-verdict-engine-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -30,20 +31,21 @@ test('sun onboarding AI browser coverage refreshes and auto-analyzes completed s
       importedData: clone(state.importedData),
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
-      refreshSunSurfaces: window._refreshSunSurfaces,
       provider: localStorage.getItem('labcharts-ai-provider'),
       paused: localStorage.getItem('labcharts-ai-paused'),
       ollamaModel: localStorage.getItem('labcharts-ollama-model'),
     };
     const results = {};
     let aiCalls = 0;
+    const previousAIVerdictRuntimeDeps = aiVerdictRuntime.configureAIVerdictRuntimeDeps({
+      refreshSunSurfaces: () => {},
+    });
 
     try {
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.removeItem('labcharts-ai-paused');
       localStorage.setItem('labcharts-ollama-model', 'sun-onboarding-coverage-model');
       window.getOllamaConfig = () => ({ url: 'http://ollama.test', apiKey: '' });
-      window._refreshSunSurfaces = () => {};
       window.fetch = async (url, options = {}) => {
         if (String(url).includes('/v1/chat/completions')) {
           aiCalls += 1;
@@ -113,7 +115,7 @@ test('sun onboarding AI browser coverage refreshes and auto-analyzes completed s
       data.invalidateActiveDataCache();
       window.fetch = saved.fetch;
       window.getOllamaConfig = saved.getOllamaConfig;
-      window._refreshSunSurfaces = saved.refreshSunSurfaces;
+      aiVerdictRuntime.configureAIVerdictRuntimeDeps(previousAIVerdictRuntimeDeps);
       if (saved.provider == null) localStorage.removeItem('labcharts-ai-provider');
       else localStorage.setItem('labcharts-ai-provider', saved.provider);
       if (saved.paused == null) localStorage.removeItem('labcharts-ai-paused');

--- a/tests/playwright/sync-two-device-e2e.spec.js
+++ b/tests/playwright/sync-two-device-e2e.spec.js
@@ -115,7 +115,7 @@ async function makePage(browser, label, importedData, recordPageError, testInfo)
     await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
     await page.waitForFunction(
       async () => window._labState
-        && typeof window.openSunSessionDetail === 'function'
+        && typeof (await import('/js/sun-session-ui.js')).openSunSessionDetail === 'function'
         && typeof (await import('/js/light-devices.js')).openDeviceSessionDetail === 'function',
       null,
       { timeout: 15000 }
@@ -330,7 +330,10 @@ async function navigateLight(page) {
 
 async function openSunSessionModal(page) {
   await navigateLight(page);
-  await page.evaluate(({ id }) => window.openSunSessionDetail(id), { id: SUN_SESSION_ID });
+  await page.evaluate(async ({ id }) => {
+    const { openSunSessionDetail } = await import('/js/sun-session-ui.js');
+    openSunSessionDetail(id);
+  }, { id: SUN_SESSION_ID });
   await page.waitForFunction(
     () => document.querySelector('.modal-overlay.show .sun-detail-modal[data-session-kind="sun"]'),
     null,
@@ -353,7 +356,8 @@ async function openDeviceSessionModal(page) {
 
 async function updateSunDuration(page, durationMin) {
   await page.evaluate(async ({ id, duration }) => {
-    await window.updateSession(id, { durationMin: duration });
+    const { updateSession } = await import('/js/sun-sessions-store.js');
+    await updateSession(id, { durationMin: duration });
   }, { id: SUN_SESSION_ID, duration: durationMin });
 }
 

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -116,7 +116,8 @@ async function seedDemoData(page) {
 async function seedMobileLightSessions(page) {
   await page.evaluate(async () => {
     const S = window._labState;
-    if (!S?.importedData || typeof window.logCompletedSession !== 'function') return;
+    const { logCompletedSession } = await import('/js/sun-sessions-store.js');
+    if (!S?.importedData || typeof logCompletedSession !== 'function') return;
     const now = Date.now();
     S.importedData.sunSessions = [];
     S.importedData.deviceSessions = [];
@@ -133,7 +134,7 @@ async function seedMobileLightSessions(page) {
         { id: 'red-nir-only', label: 'Red plus near infrared recovery preset', groups: ['red', 'nir'] },
       ],
     }];
-    await window.logCompletedSession({
+    await logCompletedSession({
       startedAt: now - 4 * 3600000,
       endedAt: now - 3.5 * 3600000,
       bodyExposure: { preset: 'tshirt', fraction: 0.30, regions: ['arms-front', 'legs-front'], sunscreenSPF: null, glassBetween: false },
@@ -153,7 +154,7 @@ async function seedMobileLightSessions(page) {
         mode: 'red-nir-only',
       });
     }
-    await window.logCompletedSession({
+    await logCompletedSession({
       startedAt: now - 2 * 86400000,
       endedAt: now - 2 * 86400000 + 35 * 60000,
       bodyExposure: { preset: 'shorts', fraction: 0.45, regions: ['chest', 'arms-front', 'legs-front'], sunscreenSPF: 30, glassBetween: false },

--- a/tests/startup-maintenance-runtime.test.js
+++ b/tests/startup-maintenance-runtime.test.js
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 import {
+  configureStartupMaintenanceSunDeps,
   getStartupSunEngineVersionRuntime,
   hasSunSessionRehydrateRuntime,
   logStartupMaintenanceRuntime,
@@ -9,6 +10,7 @@ import {
 } from '../js/startup-maintenance-runtime.js';
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalSunDeps = configureStartupMaintenanceSunDeps();
 
 function setRuntimeWindow(runtime) {
   Object.defineProperty(globalThis, 'window', {
@@ -19,6 +21,7 @@ function setRuntimeWindow(runtime) {
 }
 
 afterEach(() => {
+  configureStartupMaintenanceSunDeps(originalSunDeps);
   if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
   else delete globalThis.window;
 });
@@ -27,19 +30,21 @@ describe('startup maintenance runtime adapter', () => {
   it('delegates startup maintenance hooks and logging', async () => {
     const calls = [];
     setRuntimeWindow({
-      SUN_ENGINE_VERSION: 'runtime-test',
+      console: {
+        log: (...args) => calls.push(['log', ...args]),
+      },
+    });
+    configureStartupMaintenanceSunDeps({
+      getSunEngineVersion: () => 'module-test',
       rehydrateStaleSessions: () => {
         calls.push('rehydrate');
         return Promise.resolve({ rehydrated: 2 });
-      },
-      console: {
-        log: (...args) => calls.push(['log', ...args]),
       },
     });
 
     expect(hasSunSessionRehydrateRuntime()).toBe(true);
     expect(await rehydrateStaleSunSessionsRuntime()).toEqual({ rehydrated: 2 });
-    expect(getStartupSunEngineVersionRuntime()).toBe('runtime-test');
+    expect(getStartupSunEngineVersionRuntime()).toBe('module-test');
     expect(logStartupMaintenanceRuntime('[startup]', 'ok')).toBe(true);
     expect(calls).toEqual([
       'rehydrate',
@@ -49,10 +54,13 @@ describe('startup maintenance runtime adapter', () => {
 
   it('uses safe fallbacks when browser hooks are missing or fail', async () => {
     setRuntimeWindow({
-      rehydrateStaleSessions: () => { throw new Error('rehydrate unavailable'); },
       console: {
         log: () => { throw new Error('log unavailable'); },
       },
+    });
+    configureStartupMaintenanceSunDeps({
+      rehydrateStaleSessions: () => { throw new Error('rehydrate unavailable'); },
+      getSunEngineVersion: () => { throw new Error('version unavailable'); },
     });
 
     expect(hasSunSessionRehydrateRuntime()).toBe(true);
@@ -61,6 +69,7 @@ describe('startup maintenance runtime adapter', () => {
     expect(logStartupMaintenanceRuntime('[startup]', 'ignored')).toBe(false);
 
     delete globalThis.window;
+    configureStartupMaintenanceSunDeps({ rehydrateStaleSessions: null, getSunEngineVersion: null });
     expect(hasSunSessionRehydrateRuntime()).toBe(false);
     expect(await rehydrateStaleSunSessionsRuntime()).toBeNull();
     expect(getStartupSunEngineVersionRuntime()).toBe('?');

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -34,7 +34,6 @@ console.log('=== Dashboard Widget Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'innerHeight',
-  'getSessions',
   '_snpTableCache',
   'showDetailModal',
   'navigate',
@@ -80,8 +79,10 @@ try {
     getDashboardViewportHeight() === 0);
 
   const snpTable = { rs123: { rsid: 'rs123' } };
-  setRuntimeValue('getSessions', () => [{ id: 'sun-1' }]);
-  state.importedData = { deviceSessions: [{ id: 'device-1' }] };
+  state.importedData = {
+    sunSessions: [{ id: 'sun-1' }],
+    deviceSessions: [{ id: 'device-1' }],
+  };
   setRuntimeValue('_snpTableCache', snpTable);
   assert('runtime adapter reads dashboard renderer data hooks',
     getDashboardLightSessions().length === 1 &&
@@ -90,8 +91,7 @@ try {
       getDashboardDeviceSessions()[0].id === 'device-1' &&
       getDashboardSnpTableCache() === snpTable);
 
-  setRuntimeValue('getSessions', () => { throw new Error('boom'); });
-  state.importedData = { deviceSessions: [] };
+  state.importedData = { sunSessions: [], deviceSessions: [] };
   setRuntimeValue('_snpTableCache', null);
   assert('runtime adapter falls back for missing renderer data hooks',
     getDashboardLightSessions().length === 0 &&

--- a/tests/test-light-devices-runtime.js
+++ b/tests/test-light-devices-runtime.js
@@ -29,10 +29,6 @@ console.log('=== Light Devices Runtime Tests ===\n');
 const runtimeKeys = [
   'navigate',
   'showPromptDialog',
-  'channelTier',
-  'tierLabel',
-  'formatChannelUnit',
-  'CHANNEL_DISPLAY',
   '_openChannelOnLightPage',
 ];
 const saved = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
@@ -77,30 +73,30 @@ try {
   assert('promptLightDeviceSessionDuration returns undefined when prompt hook is missing',
     await promptLightDeviceSessionDuration(3) === undefined);
 
-  globalThis.channelTier = (value, key) => key === 'pbm_red' && value > 0 ? 3 : 0;
-  globalThis.tierLabel = tier => tier === 3 ? 'high' : 'none';
-  globalThis.formatChannelUnit = (key, value) => `${Math.round(value)} ${key}`;
+  configureLightDevicesRuntimeDeps({
+    channelTier: (value, key) => key === 'pbm_red' && value > 0 ? 3 : 0,
+    tierLabel: tier => tier === 3 ? 'high' : 'none',
+    formatChannelUnit: (key, value) => `${Math.round(value)} ${key}`,
+  });
   const helpers = getLightDeviceChannelHelpers();
-  assert('getLightDeviceChannelHelpers reads runtime channel helpers',
+  assert('getLightDeviceChannelHelpers reads configured module helpers',
     helpers.channelTier(1, 'pbm_red') === 3 &&
     helpers.tierLabel(3) === 'high' &&
     helpers.formatChannelUnit('pbm_red', 4.4) === '4 pbm_red');
-  delete globalThis.channelTier;
-  delete globalThis.tierLabel;
-  delete globalThis.formatChannelUnit;
+  configureLightDevicesRuntimeDeps({ channelTier: null, tierLabel: null, formatChannelUnit: null });
   const fallbackHelpers = getLightDeviceChannelHelpers();
   assert('getLightDeviceChannelHelpers provides safe fallbacks',
     fallbackHelpers.channelTier(99, 'pbm_red') === 0 &&
     fallbackHelpers.tierLabel(4) === 'none' &&
     fallbackHelpers.formatChannelUnit('pbm_red', 5) === '');
 
-  delete globalThis.CHANNEL_DISPLAY;
   const fallbackDisplay = { pbm_red: { label: 'Fallback Red' } };
+  configureLightDevicesRuntimeDeps({ channelDisplay: null });
   assert('getLightDeviceChannelDisplay falls back to imported display',
     getLightDeviceChannelDisplay(fallbackDisplay).pbm_red.label === 'Fallback Red');
-  globalThis.CHANNEL_DISPLAY = { circadian: { label: 'Runtime Clock' } };
-  assert('getLightDeviceChannelDisplay prefers runtime display',
-    getLightDeviceChannelDisplay(fallbackDisplay).circadian.label === 'Runtime Clock');
+  configureLightDevicesRuntimeDeps({ channelDisplay: { circadian: { label: 'Module Clock' } } });
+  assert('getLightDeviceChannelDisplay prefers configured module display',
+    getLightDeviceChannelDisplay(fallbackDisplay).circadian.label === 'Module Clock');
 
   const previousRecommendationBridge = configureRecommendationModuleBridge({
     loadCatalog: async () => ({ slots: { light: true } }),

--- a/tests/test-silhouette-region-map.js
+++ b/tests/test-silhouette-region-map.js
@@ -24,20 +24,18 @@ return (async function() {
 
   console.log('%c Silhouette Region Map Tests ', 'background:#f59e0b;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
 
-  // Wait for sun.js wiring to land helpers on window.
-  if (typeof window._testLoadRegionMap !== 'function') {
-    await import('/js/sun.js?bust=' + Date.now());
-  }
-  const _loadRegionMap = window._testLoadRegionMap;
-  const _regionAtSource = window._testRegionAtSource;
-  const REGION_COLOR_RGB = window._testRegionColorRGB;
-  const STOCK_IMG = window._testStockImg;
-  const L = window._testRegionBandLandmarks;
+  const silhouette = await import('/js/sun-body-silhouette.js');
+  const _loadRegionMap = silhouette._testLoadRegionMap;
+  const _regionAtSource = silhouette._testRegionAtSource;
+  const REGION_COLOR_RGB = silhouette._testRegionColorRGB;
+  const STOCK_IMG = silhouette._testStockImg;
+  const L = silhouette._testRegionBandLandmarks;
 
-  assert('Test helpers exposed on window',
+  assert('Test helpers remain module-only exports',
     typeof _loadRegionMap === 'function' &&
     typeof _regionAtSource === 'function' &&
-    REGION_COLOR_RGB && STOCK_IMG && L);
+    REGION_COLOR_RGB && STOCK_IMG && L &&
+    !('_testLoadRegionMap' in window));
   if (fail > 0) {
     console.log(`%c ${pass} passed, ${fail} failed, ${pass + fail} total — stopping early`, 'color:#ef4444');
     return;

--- a/tests/test-sun-context.js
+++ b/tests/test-sun-context.js
@@ -18,6 +18,7 @@ console.log('=== Sun Context Tests ===\n');
 await import('../js/state.js');
 const labCtxMod = await import('../js/lab-context.js');
 const ctxMod = await import('../js/sun-context.js');
+const { getSessions } = await import('../js/sun-sessions-store.js');
 await import('../js/sun-context-hooks.js');
 const { buildSunContext, configureSunContext } = ctxMod;
 labCtxMod.setLightSunContextEnabled(true);
@@ -432,7 +433,7 @@ labCtxMod.setLightSunContextEnabled(true);
   console.log('%c 11. Sun standard-tier always included when data exists ', 'font-weight:bold;color:#f59e0b');
 
   const labCtx = labCtxMod.buildLabContext({});
-  const completedSessions = window.getSessions ? window.getSessions().filter(s => s.endedAt) : [];
+  const completedSessions = getSessions().filter(s => s.endedAt);
   if (completedSessions.length > 0) {
     assert('Lab context always carries [section:sun] when sessions exist',
       /\[section:sun\][\s\S]*\[\/section:sun\]/.test(labCtx));

--- a/tests/test-sun-defaults-runtime.js
+++ b/tests/test-sun-defaults-runtime.js
@@ -22,9 +22,7 @@ console.log('=== Sun Defaults Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'getSunCoords',
   'getProfileLocation',
-  'requestPreciseLocation',
   'navigate',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
@@ -49,15 +47,15 @@ function restoreRuntime() {
 
 try {
   const calls = [];
-  setRuntimeValue('getSunCoords', () => ({ lat: 50.08, lon: 14.42, source: 'profile-precise' }));
   configureSunDefaultsRuntimeDeps({
+    getSunCoords: () => ({ lat: 50.08, lon: 14.42, source: 'profile-precise' }),
     getProfileLocation: () => ({ country: 'Czech Republic', zip: '' }),
+    requestPreciseLocation: () => {
+      calls.push(['precise']);
+      return Promise.resolve({ lat: 50.1, lon: 14.4 });
+    },
     openProfileLocationEditor: () => calls.push(['profile-location']),
     openClientList: () => calls.push(['client-list']),
-  });
-  setRuntimeValue('requestPreciseLocation', () => {
-    calls.push(['precise']);
-    return Promise.resolve({ lat: 50.1, lon: 14.4 });
   });
   setRuntimeValue('navigate', route => calls.push(['navigate', route]));
 
@@ -84,12 +82,12 @@ try {
   assert('navigateSunDefaultsRoute delegates route navigation',
     calls.some(call => call[0] === 'navigate' && call[1] === 'light'));
 
-  delete globalThis.getSunCoords;
   configureSunDefaultsRuntimeDeps({
+    getSunCoords: null,
     getProfileLocation: () => ({ country: '', zip: '' }),
+    requestPreciseLocation: null,
     openClientList: null,
   });
-  delete globalThis.requestPreciseLocation;
   delete globalThis.navigate;
   assert('missing runtime functions return safe fallbacks',
     getSunSetupCoords() === null &&

--- a/tests/test-sun-runtime.js
+++ b/tests/test-sun-runtime.js
@@ -2,11 +2,11 @@
 // test-sun-runtime.js - Sun session browser adapter behavior.
 
 import './_node-shim.js';
+import { readFileSync } from 'node:fs';
 import { state } from '../js/state.js';
 import {
   addSunProfileSwitchListener,
   configureSunRuntimeDeps,
-  exposeSunRuntimeBindings,
   getSunDeviceSessionsRuntime,
   hasSunBrowserRuntime,
   hasSunGeolocationRuntime,
@@ -39,7 +39,6 @@ const runtimeKeys = [
   '_openChannelOnLightPage',
   'addEventListener',
   'isDebugMode',
-  'sunRuntimeProbe',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const savedImportedData = state.importedData;
@@ -113,10 +112,9 @@ try {
   assert('requestSunGeolocationPositionRuntime delegates with options',
     resolvedPosition === position && capturedOptions?.timeout === 8000 && capturedOptions?.enableHighAccuracy === true);
 
-  const probe = () => 'ok';
-  exposeSunRuntimeBindings({ sunRuntimeProbe: probe });
-  assert('exposeSunRuntimeBindings publishes runtime bindings',
-    globalThis.sunRuntimeProbe === probe);
+  const runtimeSource = readFileSync(new URL('../js/sun-runtime.js', import.meta.url), 'utf8');
+  assert('sun runtime does not publish module APIs on the browser global',
+    !runtimeSource.includes('exposeSunRuntimeBindings') && !runtimeSource.includes('Object.assign(runtime'));
 
   state.importedData = { deviceSessions: [] };
   setRuntimeValue('renderLightTodayStrip', () => { throw new Error('boom'); });
@@ -153,13 +151,11 @@ try {
   navigateSunRuntime('light');
   renderLightChannelsLiveRuntime();
   openSunChannelOnLightPageRuntime('no_cv');
-  exposeSunRuntimeBindings({ sunRuntimeProbe: null });
   assert('runtime adapter no-ops safely when window is missing',
     hasSunBrowserRuntime() === false &&
     getSunDeviceSessionsRuntime().length === 0 &&
     renderLightTodayStripRuntime() === '' &&
-    calls.length === beforeNoWindowCalls &&
-    globalThis.sunRuntimeProbe === probe);
+    calls.length === beforeNoWindowCalls);
 } finally {
   configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   state.importedData = savedImportedData;

--- a/tests/test-sun-ui-flow.js
+++ b/tests/test-sun-ui-flow.js
@@ -16,6 +16,10 @@ return (async function() {
   const dataModule = await import('/js/data.js');
   const viewsModule = await import('/js/views.js');
   const lightDevices = await import('/js/light-devices.js');
+  const sun = await import('/js/sun.js');
+  const sunSessionUI = await import('/js/sun-session-ui.js');
+  const sunSessionsStore = await import('/js/sun-sessions-store.js');
+  const modalLifecycle = await import('/js/modal-lifecycle.js');
   const { buildSunContext } = await import('/js/sun-context.js');
   const { buildLabContext } = await import('/js/lab-context.js');
   const profile = await import('/js/profile.js');
@@ -75,7 +79,7 @@ return (async function() {
   // ─── 2. Logging a session keeps the dashboard hero surface stable ────
   console.log('%c 2. Logging a session keeps the dashboard hero ', 'font-weight:bold;color:#6366f1');
 
-  const id = await window.logCompletedSession({
+  const id = await sunSessionsStore.logCompletedSession({
     startedAt: Date.now() - 30 * 60 * 1000,
     endedAt: Date.now() - 1000,
     bodyExposure: { preset: 'tshirt', fraction: 0.30, regions: [], sunscreenSPF: null, glassBetween: false },
@@ -156,8 +160,8 @@ return (async function() {
   // ─── 4. Session detail modal opens + has a working delete button ─────
   console.log('%c 4. Session detail modal ', 'font-weight:bold;color:#6366f1');
 
-  if (typeof window.openSunSessionDetail === 'function') {
-    window.openSunSessionDetail(id);
+  if (typeof sunSessionUI.openSunSessionDetail === 'function') {
+    sunSessionUI.openSunSessionDetail(id);
     await wait(100);
     let overlay = document.querySelector('.modal-overlay');
     assert('Session detail modal mounts an overlay', !!overlay);
@@ -183,7 +187,7 @@ return (async function() {
       assert('Delegated detail close button removes the modal',
         !document.body.contains(overlay));
 
-      window.openSunSessionDetail(id);
+      sunSessionUI.openSunSessionDetail(id);
       await wait(80);
       overlay = document.querySelector('.modal-overlay');
       assert('Session detail modal remounts after delegated close', !!overlay);
@@ -212,7 +216,7 @@ return (async function() {
       }
     }
   } else {
-    assert('window.openSunSessionDetail exists (UI wired)', false,
+    assert('openSunSessionDetail module export exists (UI wired)', false,
       'skipped — function missing');
   }
 
@@ -240,8 +244,10 @@ return (async function() {
   // installing window globals first.
   console.log('%c 7. Backdrop-close helper wired ', 'font-weight:bold;color:#6366f1');
 
-  assert('sun.js keeps window._wireBackdropClose compatibility export',
-    typeof window._wireBackdropClose === 'function');
+  assert('modal lifecycle helpers stay available as module exports',
+    typeof modalLifecycle.wireBackdropClose === 'function'
+      && typeof modalLifecycle.trapModalFocus === 'function'
+      && !('_wireBackdropClose' in window));
 
   const modalLifecycleSrc = await fetch('js/modal-lifecycle.js').then(r => r.text());
   const sunActiveSrc = await fetch('js/sun-active-session.js').then(r => r.text());
@@ -280,13 +286,13 @@ return (async function() {
 
   // Tear down any leftover overlays, ensure no active session.
   document.querySelectorAll('.modal-overlay').forEach(el => el.remove());
-  const _activeNow = window.getActiveSession?.();
-  if (_activeNow) await window.stopSession?.(_activeNow.id);
+  const _activeNow = sunSessionsStore.getActiveSession();
+  if (_activeNow) await sunSessionsStore.stopSession(_activeNow.id);
 
-  if (typeof window.openStartSunSessionDialog !== 'function') {
+  if (typeof sun.openStartSunSessionDialog !== 'function') {
     assert('openStartSunSessionDialog exists', false, 'skipped — function missing');
   } else {
-    await window.openStartSunSessionDialog();
+    await sun.openStartSunSessionDialog();
     await wait(80);
     let dlg = document.querySelector('.modal-overlay.show, .sun-start-modal')?.closest('.modal-overlay');
     if (!dlg) dlg = document.querySelector('.modal-overlay');
@@ -313,19 +319,19 @@ return (async function() {
     }
 
     // Active session has both regions
-    const sess = window.getActiveSession?.();
+    const sess = sunSessionsStore.getActiveSession();
     const got = sess?.bodyExposure?.regions || [];
     assert('Active session has bodyExposure.regions = [arms-front, legs-front]',
       got.length === PICK.length && PICK.every(r => got.includes(r)),
       `got=${JSON.stringify(got)}`);
 
     // Stop session — the prefill on reopen uses the LAST COMPLETED session.
-    if (sess) await window.stopSession?.(sess.id);
+    if (sess) await sunSessionsStore.stopSession(sess.id);
     await wait(80);
 
     // Reopen, assert the 2 regions are pre-selected (aria-pressed=true)
     document.querySelectorAll('.modal-overlay').forEach(el => el.remove());
-    await window.openStartSunSessionDialog();
+    await sun.openStartSunSessionDialog();
     await wait(80);
     const dlg2 = document.querySelector('.modal-overlay');
     assert('Dialog reopens', !!dlg2);

--- a/tests/test-sun.js
+++ b/tests/test-sun.js
@@ -620,10 +620,29 @@ const {
   assert('Sun browser hooks are isolated in runtime adapter',
     sunSrc.includes("from './sun-runtime.js'") &&
     !/\bwindow(?:\.|\s*\[)/.test(sunSrc) &&
+    !sunSrc.includes('exposeSunRuntimeBindings') &&
+    !runtimeSrc.includes('exposeSunRuntimeBindings') &&
     runtimeSrc.includes('export function getSunDeviceSessionsRuntime') &&
     runtimeSrc.includes('export function renderLightTodayStripRuntime') &&
     runtimeSrc.includes('export function requestSunGeolocationPositionRuntime') &&
     swSrc.includes("'/js/sun-runtime.js'"));
+  const formerSunGlobals = [
+    'SUN_ENGINE_VERSION', '_refreshSunSurfaces', 'quickLogSunSession', 'startSession', 'stopSession',
+    'pauseSession', 'resumeSession', 'pauseSunSession', 'resumeSunSession', 'applySunscreenMidSession',
+    'changeCoverageMidSession', 'flipSidesMidSession', 'setOzoneOverrideMidSession', '_forgotStopPrompt',
+    'logCompletedSession', 'updateSession', 'editSunSessionDuration', 'deleteSunSession', 'hydrateSession',
+    'rehydrateStaleSessions', 'getSessions', 'getActiveSession', 'rollingChannelTotals', 'dailyChannelBreakdown',
+    'dailyVitaminDIUBreakdown', 'rollingVitaminDIU', 'cumulativeMEDToday', 'cumulativeMEDYesterday',
+    'cumulativeVitaminDIUToday', 'vitaminDBudgetStatus', '_applyAtmOverrides', 'renderSessionsList',
+    'renderSunSessionRow', 'getSunCoords', 'requestPreciseLocation', 'openDetailedSessionDialog',
+    'openStartSunSessionDialog', 'openSunSessionDetail', 'renderBodySilhouette', 'bindBodySilhouette',
+    '_testLoadRegionMap', '_testRegionAtSource', '_testRegionColorRGB', '_testStockImg',
+    '_testRegionBandLandmarks', 'trapModalFocus', '_wireBackdropClose', '_resumeActiveTickerIfNeeded',
+    '_ensureActiveTicker', 'BODY_REGIONS', 'EXPOSURE_PRESETS', 'EYE_MODES', 'LENS_TINTS',
+    'CHANNEL_DISPLAY', 'channelTier', 'weeklyChannelTier', 'tierLabel', 'formatChannelUnit', 'tierDots',
+  ];
+  assert('Sun facade stays module-only after import',
+    formerSunGlobals.every(name => !(name in window)));
   assert('Service worker precaches extracted sun session modules',
     swSrc.includes("'/js/sun-session-model.js'") &&
     swSrc.includes("'/js/sun-sessions-store.js'") &&

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -31,7 +31,7 @@ console.log('=== v1.6.7–v1.6.16 Regression Tests ===\n');
 // sun.js → dailyVitaminDIUBreakdown, light-tools.js → saveMeasurement,
 // light-sessions-view.js → _openAllSessionsModal.
 await import('../js/state.js');
-await import('../js/sun.js');
+const { dailyVitaminDIUBreakdown, rollingVitaminDIU } = await import('../js/sun.js');
 const lightTools = await import('../js/light-tools.js');
 const viewsModule = await import('../js/views.js');
 
@@ -91,8 +91,8 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
   console.log('%c 4. dailyVitaminDIUBreakdown ↔ rollingVitaminDIU parity ', 'font-weight:bold;color:#0891b2');
   {
     const S = window._labState;
-    if (!S || !window.dailyVitaminDIUBreakdown || !window.rollingVitaminDIU) {
-      assert('dailyVitaminDIUBreakdown exposed on window', !!window.dailyVitaminDIUBreakdown);
+    if (!S || typeof dailyVitaminDIUBreakdown !== 'function' || typeof rollingVitaminDIU !== 'function') {
+      assert('dailyVitaminDIUBreakdown exported by sun.js', false);
     } else {
       const _saved = JSON.parse(JSON.stringify(S.importedData));
       // Two synthetic sessions with known channel-au + body fraction
@@ -117,10 +117,10 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
         },
       ];
       S.importedData.deviceSessions = [];
-      const buckets = window.dailyVitaminDIUBreakdown(7);
+      const buckets = dailyVitaminDIUBreakdown(7);
       const dayTotals = buckets.map(b => Math.round(b.sun + b.device));
       const total = dayTotals.reduce((a, b) => a + b, 0);
-      const rolling = Math.round(window.rollingVitaminDIU(7));
+      const rolling = Math.round(rollingVitaminDIU(7));
       assert('dailyVitaminDIUBreakdown returns 7 buckets', buckets.length === 7);
       assert('breakdown total matches rollingVitaminDIU(7)',
         Math.abs(total - rolling) <= 1, `breakdown=${total} rolling=${rolling}`);

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -227,6 +227,26 @@
     import('../js/utils.js'),
     import('../js/views.js'),
   ]);
+  const sunModule = await import('../js/sun.js');
+  const formerSunGlobals = [
+    'SUN_ENGINE_VERSION', '_refreshSunSurfaces', 'quickLogSunSession', 'startSession', 'stopSession',
+    'pauseSession', 'resumeSession', 'pauseSunSession', 'resumeSunSession', 'applySunscreenMidSession',
+    'changeCoverageMidSession', 'flipSidesMidSession', 'setOzoneOverrideMidSession', '_forgotStopPrompt',
+    'logCompletedSession', 'updateSession', 'editSunSessionDuration', 'deleteSunSession', 'hydrateSession',
+    'rehydrateStaleSessions', 'getSessions', 'getActiveSession', 'rollingChannelTotals', 'dailyChannelBreakdown',
+    'dailyVitaminDIUBreakdown', 'rollingVitaminDIU', 'cumulativeMEDToday', 'cumulativeMEDYesterday',
+    'cumulativeVitaminDIUToday', 'vitaminDBudgetStatus', '_applyAtmOverrides', 'renderSessionsList',
+    'renderSunSessionRow', 'getSunCoords', 'requestPreciseLocation', 'openDetailedSessionDialog',
+    'openStartSunSessionDialog', 'openSunSessionDetail', 'renderBodySilhouette', 'bindBodySilhouette',
+    '_testLoadRegionMap', '_testRegionAtSource', '_testRegionColorRGB', '_testStockImg',
+    '_testRegionBandLandmarks', 'trapModalFocus', '_wireBackdropClose', '_resumeActiveTickerIfNeeded',
+    '_ensureActiveTicker', 'BODY_REGIONS', 'EXPOSURE_PRESETS', 'EYE_MODES', 'LENS_TINTS',
+    'CHANNEL_DISPLAY', 'channelTier', 'weeklyChannelTier', 'tierLabel', 'formatChannelUnit', 'tierDots',
+  ];
+  assert('Sun facade remains available through ESM exports',
+    typeof sunModule.rollingChannelTotals === 'function' && typeof sunModule.openSunSessionDetail === 'function');
+  assert('Sun facade does not publish legacy window globals',
+    formerSunGlobals.every(name => !(name in window)));
   const apiExports = [
     'getVeniceKey','saveVeniceKey','hasVeniceKey',
     'getVeniceModel','setVeniceModel','getVeniceModelDisplay',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.237';
+self.APP_VERSION = '1.10.238';


### PR DESCRIPTION
## Summary

- remove the 59-binding Sun facade from `window` while preserving the `sun.js` ESM API
- replace production Sun-global consumers with direct imports or explicit dependency injection
- migrate browser and Node fixtures to module APIs and add regression guards covering all 59 former names
- bump the app cache version to `1.10.238`

This reduces explicit app-level window bindings from 139 to 80, leaving only the Chat family.

## Testing

- `./run-tests.sh` — 352 browser tests passed; typechecks, vendor verification, module verification, and all 398 Vitest tests passed
- TypeScript AST audit — zero production accesses to the 59 former Sun globals