### PR TITLE
Remove unused Chat globals

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -5,6 +5,11 @@ import { configureAppEventListeners } from './app-event-listeners.js';
 import { closeChangelog } from './changelog.js';
 import { configureChatMessageActionDeps } from './chat-actions.js';
 import {
+  continueDiscussion,
+  endDiscussion,
+  startDiscussionFromPicker,
+} from './chat-discussion.js';
+import {
   initChatImageHandlers,
   openImageLightbox,
   removeImageAttachment,
@@ -13,9 +18,19 @@ import {
 } from './chat-images.js';
 import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
 import { closeChatPanel, configureChatPanel, toggleChatPanel } from './chat-panel.js';
+import { askAIAboutCorrelations } from './chat-marker-prompts.js';
+import { onContextCardSaved } from './chat-onboarding.js';
 import { updateChatNudge } from './chat-nudge.js';
 import { updateChatContextStatus } from './chat-personalities.js';
-import { closeSummaryModal } from './chat-summaries.js';
+import {
+  closeSummaryModal,
+  copySummary,
+  deleteSavedSummary,
+  downloadSummary,
+  printSummary,
+  viewSavedSummary,
+} from './chat-summaries.js';
+import { jumpToSearchResult } from './chat-thread-search.js';
 import {
   createNewThread,
   ensureActiveThread,
@@ -25,6 +40,8 @@ import {
   toggleThreadRail,
 } from './chat-threads.js';
 import { closeClientList, configureClientListRuntime, openClientList, openProfileLocationEditor } from './client-list.js';
+import { configureCompareCorrelationViews } from './compare-correlations.js';
+import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
 import { closeEMFInterpretation } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder } from './export.js';
 import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
@@ -76,7 +93,22 @@ configureRecommendationsRuntime({ openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
-configureChatMessageActionDeps({ openImageLightbox, removeImageAttachment });
+configureChatMessageActionDeps({
+  closeSummaryModal,
+  continueDiscussion,
+  copySummary,
+  deleteSavedSummary,
+  downloadSummary,
+  endDiscussion,
+  jumpToSearchResult,
+  openImageLightbox,
+  printSummary,
+  removeImageAttachment,
+  startDiscussionFromPicker,
+  viewSavedSummary,
+});
+configureCompareCorrelationViews({ askAIAboutCorrelations });
+configureContextCardsRuntimeCallbacks({ onContextCardSaved });
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
 configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });

--- a/js/chat-actions.js
+++ b/js/chat-actions.js
@@ -15,21 +15,28 @@ import { getChatRegenerateCallbacks, isChatRuntimeStreaming } from './chat-runti
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 
 const chatMessageActionDeps = {
+  closeSummaryModal: /** @type {() => void} */ (() => {}),
+  continueDiscussion: /** @type {() => void | Promise<void>} */ (() => {}),
+  copySummary: /** @type {() => void} */ (() => {}),
+  deleteSavedSummary: /** @type {(id: string) => void | Promise<void>} */ (() => {}),
+  downloadSummary: /** @type {() => void} */ (() => {}),
+  endDiscussion: /** @type {() => void} */ (() => {}),
+  jumpToSearchResult: /** @type {(threadId: string, index: number, prefix: string) => void | Promise<void>} */ (() => {}),
   openEMFAssessmentEditor,
   openImageLightbox: /** @type {(src: string) => void} */ (() => {}),
+  printSummary: /** @type {() => void} */ (() => {}),
   removeImageAttachment: /** @type {(index: number) => void} */ (() => {}),
+  startDiscussionFromPicker: /** @type {() => void | Promise<void>} */ (() => {}),
+  viewSavedSummary: /** @type {(id: string) => void} */ (() => {}),
 };
 
 export function configureChatMessageActionDeps(deps = {}) {
   const previous = { ...chatMessageActionDeps };
-  if (typeof deps.openEMFAssessmentEditor === 'function') {
-    chatMessageActionDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
-  }
-  if (typeof deps.openImageLightbox === 'function') {
-    chatMessageActionDeps.openImageLightbox = deps.openImageLightbox;
-  }
-  if (typeof deps.removeImageAttachment === 'function') {
-    chatMessageActionDeps.removeImageAttachment = deps.removeImageAttachment;
+  for (const name of Object.keys(chatMessageActionDeps)) {
+    const candidate = /** @type {any} */ (deps)[name];
+    if (typeof candidate === 'function') {
+      /** @type {any} */ (chatMessageActionDeps)[name] = candidate;
+    }
   }
   return previous;
 }
@@ -58,7 +65,6 @@ function containChatMessageEvent(event) {
 
 function runChatMessageAction(actionEl, event) {
   const action = actionEl.getAttribute(CHAT_MESSAGE_ACTION_ATTR);
-  const appWindow = /** @type {any} */ (window);
 
   if (action === 'contain-click') {
     containChatMessageEvent(event);
@@ -89,29 +95,29 @@ function runChatMessageAction(actionEl, event) {
     const index = readMessageIndex(actionEl);
     const threadId = actionEl.dataset.chatMessageThreadId || '';
     if (!threadId || index == null) return;
-    void appWindow.jumpToSearchResult?.(threadId, index, actionEl.dataset.chatMessagePrefix || '');
+    void chatMessageActionDeps.jumpToSearchResult(threadId, index, actionEl.dataset.chatMessagePrefix || '');
   } else if (action === 'view-summary') {
     const id = actionEl.dataset.chatMessageSummaryId || '';
     if (!id) return;
-    appWindow.viewSavedSummary?.(id);
+    chatMessageActionDeps.viewSavedSummary(id);
   } else if (action === 'close-summary') {
-    appWindow.closeSummaryModal?.();
+    chatMessageActionDeps.closeSummaryModal();
   } else if (action === 'copy-summary') {
-    appWindow.copySummary?.();
+    chatMessageActionDeps.copySummary();
   } else if (action === 'download-summary') {
-    appWindow.downloadSummary?.();
+    chatMessageActionDeps.downloadSummary();
   } else if (action === 'print-summary') {
-    appWindow.printSummary?.();
+    chatMessageActionDeps.printSummary();
   } else if (action === 'delete-summary') {
     const id = actionEl.dataset.chatMessageSummaryId || '';
     if (!id) return;
-    void appWindow.deleteSavedSummary?.(id);
+    void chatMessageActionDeps.deleteSavedSummary(id);
   } else if (action === 'start-discussion-from-picker') {
-    void appWindow.startDiscussionFromPicker?.();
+    void chatMessageActionDeps.startDiscussionFromPicker();
   } else if (action === 'continue-discussion') {
-    void appWindow.continueDiscussion?.();
+    void chatMessageActionDeps.continueDiscussion();
   } else if (action === 'end-discussion') {
-    appWindow.endDiscussion?.();
+    chatMessageActionDeps.endDiscussion();
   } else {
     return false;
   }
@@ -131,7 +137,7 @@ function handleChatMessageKeydown(event) {
   if (!(target instanceof HTMLElement)) return;
   if (event.key === 'Enter' && target.dataset.chatMessageKeyAction === 'continue-discussion') {
     event.preventDefault();
-    void /** @type {any} */ (window).continueDiscussion?.();
+    void chatMessageActionDeps.continueDiscussion();
     return;
   }
 

--- a/js/chat-threads.js
+++ b/js/chat-threads.js
@@ -44,7 +44,9 @@ const chatThreadDeps = {
 };
 
 export function configureChatThreadDeps(deps = {}) {
+  const previous = { ...chatThreadDeps };
   Object.assign(chatThreadDeps, deps);
+  return previous;
 }
 
 export function getChatThreadsKey() {

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -3,51 +3,32 @@
 
 import { setAIPaused } from './api.js';
 import { configureChatThreadDeps } from './chat-threads.js';
-import { applyInlineMarkdown, renderMarkdown } from './markdown.js';
 import { renderChatMessages } from './chat-render.js';
-import { askAIAboutCorrelations, askAIAboutMarker } from './chat-marker-prompts.js';
+import { askAIAboutMarker } from './chat-marker-prompts.js';
 import {
   createTypewriter, getChatAbortController, handleChatKeydown,
   isChatStreaming, sendChatMessage, setChatAbortController,
   setSendButtonMode,
 } from './chat-send.js';
+import { renderSavedSummaries, summarizeThread } from './chat-summaries.js';
 import {
-  closeSummaryModal, copySummary, deleteSavedSummary, downloadSummary,
-  printSummary, renderSavedSummaries, summarizeThread, viewSavedSummary,
-} from './chat-summaries.js';
-import {
-  autoResizePersonaTextarea, deleteCustomPersonality, editCustomPersonality,
-  generateCustomPersonality, getActivePersonality, getCustomPersonalities,
-  getCustomPersonality, getCustomPersonalityText, loadChatPersonality,
-  markPersonalityDirty, pickPersonaIcon, saveCustomPersonalities,
-  saveCustomPersonality, setChatPersonality, snapshotPersonalityClean,
-  startNewCustomPersonality, togglePersonalityBar, updateChatHeaderModel,
-  updateChatHeaderTitle, updatePersonalityBar, updateSummaryButton,
+  getActivePersonality, setChatPersonality, togglePersonalityBar,
+  updateChatHeaderModel, updateChatHeaderTitle, updatePersonalityBar,
 } from './chat-personalities.js';
 import {
-  clearChatHistory, getChatStorageKey, loadChatHistory, saveChatHistory,
+  clearChatHistory, loadChatHistory, saveChatHistory,
 } from './chat-history.js';
 import {
-  closeChatPanel, configureChatPanel, getChatWebSearchEnabled,
-  refreshWebSearchToggle, setChatWebSearchEnabled,
+  closeChatPanel, configureChatPanel, refreshWebSearchToggle, setChatWebSearchEnabled,
   toggleChatFullscreen, toggleChatPanel, openChatPanel, updateChatInputState,
 } from './chat-panel.js';
 import { setChatNudge, updateChatNudge } from './chat-nudge.js';
 import {
-  cleanupDiscussionState, configureChatDiscussion, continueDiscussion,
-  endDiscussion, getThreadPersonaCount, removeDiscussContinuePrompt,
-  restoreDiscussionContinuePrompt, showDiscussContinuePrompt,
-  startDiscussion, startDiscussionFromPicker, updateDiscussButton,
+  cleanupDiscussionState, configureChatDiscussion, restoreDiscussionContinuePrompt,
+  startDiscussion, updateDiscussButton,
 } from './chat-discussion.js';
 import {
-  _updatePeriodBtn, addChatSupplement,
-  backToProviderQuiz, configureChatOnboarding, onContextCardSaved,
-  onboardHeightUnitChanged, removeChatSupplement,
-  requestOnboardingLabImportProvider, saveChatLocation, saveChatPeriod,
-  saveChatProfile, saveCycleStatus, setChatProfileSex,
-  setProviderQuizBranch, showCycleNoMensesOptions, showCyclePeriodEntry,
-  skipOnboardingExtras, skipProviderSetup, startOnboardingLabImport,
-  useChatPrompt,
+  configureChatOnboarding, useChatPrompt,
 } from './chat-onboarding.js';
 
 function _resumeAI() {
@@ -87,81 +68,23 @@ Object.assign(window, {
   _resumeAI,
   isChatStreaming,
   toggleChatFullscreen,
-  getChatStorageKey,
-  getActivePersonality,
-  getCustomPersonalities,
-  saveCustomPersonalities,
-  getCustomPersonality,
-  getCustomPersonalityText,
-  pickPersonaIcon,
-  generateCustomPersonality,
-  autoResizePersonaTextarea,
-  markPersonalityDirty,
-  snapshotPersonalityClean,
   setChatPersonality,
-  loadChatPersonality,
-  updateChatHeaderTitle,
   updateChatHeaderModel,
   refreshWebSearchToggle,
-  updatePersonalityBar,
   togglePersonalityBar,
-  saveCustomPersonality,
-  startNewCustomPersonality,
-  deleteCustomPersonality,
   loadChatHistory,
-  saveChatHistory,
   clearChatHistory,
   summarizeThread,
-  closeSummaryModal,
-  updateSummaryButton,
-  viewSavedSummary,
-  deleteSavedSummary,
-  renderSavedSummaries,
-  copySummary,
-  downloadSummary,
-  printSummary,
   renderChatMessages,
   useChatPrompt,
-  applyInlineMarkdown,
-  renderMarkdown,
   toggleChatPanel,
   openChatPanel,
   closeChatPanel,
-  startOnboardingLabImport,
-  requestOnboardingLabImportProvider,
   sendChatMessage,
   handleChatKeydown,
   startDiscussion,
-  startDiscussionFromPicker,
-  continueDiscussion,
-  endDiscussion,
-  editCustomPersonality,
-  showDiscussContinuePrompt,
-  restoreDiscussionContinuePrompt,
-  cleanupDiscussionState,
-  removeDiscussContinuePrompt,
   updateDiscussButton,
-  getThreadPersonaCount,
   askAIAboutMarker,
-  askAIAboutCorrelations,
-  getChatWebSearchEnabled,
   setChatWebSearchEnabled,
-  setChatNudge,
   updateChatNudge,
-  setChatProfileSex,
-  saveChatProfile,
-  saveChatLocation,
-  onboardHeightUnitChanged,
-  saveChatPeriod,
-  addChatSupplement,
-  removeChatSupplement,
-  setProviderQuizBranch,
-  backToProviderQuiz,
-  skipProviderSetup,
-  skipOnboardingExtras,
-  showCycleNoMensesOptions,
-  showCyclePeriodEntry,
-  saveCycleStatus,
-  _updatePeriodBtn,
-  onContextCardSaved,
 });

--- a/js/compare-correlations.js
+++ b/js/compare-correlations.js
@@ -10,8 +10,9 @@ import { getEffectiveRange, getEffectiveRangeForDate } from './marker-analysis.j
 import { ensureChartJs, getNotesForChart, getSupplementsForChart, refBandPlugin, noteAnnotationPlugin, supplementBarPlugin } from './charts.js';
 import { createChartRuntime, hasChartRuntime } from './charts-runtime.js';
 
-/** @type {{ renderTableColgroup: (cols: string[]) => string, renderScrollableTableShell: (...args: any[]) => string, renderCategoryGlyph: (...args: any[]) => string }} */
+/** @type {{ askAIAboutCorrelations: () => void, renderTableColgroup: (cols: string[]) => string, renderScrollableTableShell: (...args: any[]) => string, renderCategoryGlyph: (...args: any[]) => string }} */
 const compareCorrelationDeps = {
+  askAIAboutCorrelations: () => {},
   renderTableColgroup: () => '',
   renderScrollableTableShell: (_kind, _wrapperClass, _tableClass, _colgroup, headHtml, bodyHtml) => '<table>' + headHtml + bodyHtml + '</table>',
   renderCategoryGlyph: (_categoryKey, label = '') => escapeHTML(label || ''),
@@ -19,7 +20,9 @@ const compareCorrelationDeps = {
 
 /** @param {Partial<typeof compareCorrelationDeps>} deps */
 export function configureCompareCorrelationViews(deps = {}) {
+  const previous = { ...compareCorrelationDeps };
   Object.assign(compareCorrelationDeps, deps);
+  return previous;
 }
 
 function renderTableColgroup(cols) {
@@ -85,10 +88,7 @@ function handleCompareClick(event) {
     if (actionEl.dataset.compareKey) toggleCorrelationMarker(actionEl.dataset.compareKey);
   } else if (action === 'ask-ai-correlations') {
     event.preventDefault();
-    const askAIAboutCorrelations = typeof window !== 'undefined'
-      ? /** @type {any} */ (window).askAIAboutCorrelations
-      : null;
-    if (typeof askAIAboutCorrelations === 'function') askAIAboutCorrelations();
+    compareCorrelationDeps.askAIAboutCorrelations();
   }
 }
 

--- a/js/context-cards-runtime.js
+++ b/js/context-cards-runtime.js
@@ -3,6 +3,7 @@
 
 /** @type {Record<string, Function | null>} */
 const contextCardsRuntimeCallbacks = {
+  onContextCardSaved: null,
   openContextModal: null,
   openInterpretiveLensEditor: null,
   recordChange: null,
@@ -35,6 +36,10 @@ function callContextCardsRuntime(name, ...args) {
 
 export function openContextModalRuntime() {
   return callContextCardsRuntime('openContextModal');
+}
+
+export function notifyContextCardSavedRuntime() {
+  return callContextCardsRuntime('onContextCardSaved');
 }
 
 export function openInterpretiveLensEditorRuntime() {

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -8,7 +8,10 @@ import { hasAIProvider } from './api.js';
 import { openModalOverlay } from './modal-lifecycle.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { getRecommendationModuleFunction } from './recommendations-runtime.js';
-import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
+import {
+  configureContextCardsRuntimeCallbacks,
+  notifyContextCardSavedRuntime,
+} from './context-cards-runtime.js';
 import {
   appendImportedArrayItem,
   ensureImportedArray,
@@ -426,7 +429,6 @@ export function recordChange(field) {
 }
 
 export function saveAndRefresh(msg, field) {
-  const appWindow = /** @type {any} */ (window);
   if (field) recordChange(field);
   saveImportedData();
   // Preserve details open state across the re-render below
@@ -434,7 +436,7 @@ export function saveAndRefresh(msg, field) {
   if (details?.open) sessionStorage.setItem('welcome-details-open', '1');
   closeContextCardModal();
   showNotification(msg, 'success');
-  if (typeof appWindow.onContextCardSaved === 'function') appWindow.onContextCardSaved();
+  notifyContextCardSavedRuntime();
   // Re-render the current view so the saved values appear on the card
   // immediately. BroadcastChannel notifies other tabs but never delivers
   // back to the sender, so a single-tab user would otherwise see no UI

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -93,23 +93,24 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
         keyDiv.remove();
       }
 
-      const savedViewSavedSummary = window.viewSavedSummary;
       const summaryButton = document.createElement('div');
       let viewedSummaryId = null;
+      const savedChatActionDeps = chatActions.configureChatMessageActionDeps({
+        viewSavedSummary: id => { viewedSummaryId = id; },
+      });
       summaryButton.setAttribute('role', 'button');
       summaryButton.setAttribute('tabindex', '0');
       summaryButton.setAttribute('data-chat-message-action', 'view-summary');
       summaryButton.setAttribute('data-chat-message-summary-id', 'summary-keyboard');
       document.body.appendChild(summaryButton);
       try {
-        window.viewSavedSummary = id => { viewedSummaryId = id; };
         const summaryPrevented = !summaryButton.dispatchEvent(
           new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true })
         );
         outcomes.roleButtonSummaryKeyboardDelegates = summaryPrevented
           && viewedSummaryId === 'summary-keyboard';
       } finally {
-        window.viewSavedSummary = savedViewSavedSummary;
+        chatActions.configureChatMessageActionDeps(savedChatActionDeps);
         summaryButton.remove();
       }
 

--- a/tests/playwright/chat-threads-dom.spec.js
+++ b/tests/playwright/chat-threads-dom.spec.js
@@ -13,18 +13,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
     const originalThreads = state.chatThreads.slice();
     const originalThreadId = state.currentThreadId;
     const originalRailState = localStorage.getItem(railKey);
-    const savedThreadDeps = {
-      saveChatHistory: window.saveChatHistory,
-      loadChatHistory: window.loadChatHistory,
-      cleanupDiscussionState: window.cleanupDiscussionState,
-      restoreDiscussionContinuePrompt: window.restoreDiscussionContinuePrompt,
-      renderChatMessages: window.renderChatMessages,
-      renderSavedSummaries: window.renderSavedSummaries,
-      updateChatHeaderTitle: window.updateChatHeaderTitle,
-      updatePersonalityBar: window.updatePersonalityBar,
-      getActivePersonality: window.getActivePersonality,
-      showPromptDialog: window.showPromptDialog,
-    };
+    let savedThreadDeps = null;
     const waitFor = async (fn, timeoutMs = 500) => {
       const start = Date.now();
       while (Date.now() - start < timeoutMs) {
@@ -95,7 +84,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
       outcomes.deleteButtonUsesDelegatedAction = deleteBtn?.getAttribute('data-chat-thread-action') === 'delete'
         && !deleteBtn.hasAttribute('onclick');
 
-      chatThreads.configureChatThreadDeps({
+      savedThreadDeps = chatThreads.configureChatThreadDeps({
         saveChatHistory: async () => {},
         loadChatHistory: async () => {},
         cleanupDiscussionState: () => {},
@@ -104,7 +93,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
         renderSavedSummaries: () => {},
         updateChatHeaderTitle: () => {},
         updatePersonalityBar: () => {},
-        getActivePersonality: savedThreadDeps.getActivePersonality || (() => ({ name: 'Default', icon: '' })),
+        getActivePersonality: () => ({ name: 'Default', icon: '' }),
         showPromptDialog: async () => 'Renamed Thread',
       });
       state.currentThreadId = 't_b';
@@ -154,7 +143,7 @@ test('chat thread rail and delegated thread actions work in the live DOM', async
     } finally {
       state.chatThreads = originalThreads;
       state.currentThreadId = originalThreadId;
-      chatThreads.configureChatThreadDeps(savedThreadDeps);
+      if (savedThreadDeps) chatThreads.configureChatThreadDeps(savedThreadDeps);
       if (originalRailState == null) localStorage.removeItem(railKey);
       else localStorage.setItem(railKey, originalRailState);
       if (originalThreads.length > 0) chatThreads.saveChatThreadIndex();

--- a/tests/playwright/compare-correlations-browser-coverage.spec.js
+++ b/tests/playwright/compare-correlations-browser-coverage.spec.js
@@ -201,6 +201,7 @@ test('correlations browser contract filters markers toggles chips and builds cha
     const originalChart = window.Chart;
     const chartCaptures = [];
     let destroyCount = 0;
+    let savedCompareDeps = null;
 
     function ChartStub(canvas, config) {
       chartCaptures.push({ canvas, config });
@@ -273,7 +274,9 @@ test('correlations browser contract filters markers toggles chips and builds cha
       const dropdown = document.getElementById('corr-options');
       const search = document.getElementById('corr-search');
       let askCount = 0;
-      window.askAIAboutCorrelations = () => { askCount += 1; };
+      savedCompareDeps = compare.configureCompareCorrelationViews({
+        askAIAboutCorrelations: () => { askCount += 1; },
+      });
       outcomes.correlationControlsEmitDelegatedAttributesOnly =
         document.querySelectorAll('#main-content [onclick], #main-content [onchange], #main-content [oninput], #main-content [onfocus]').length === 0
         && search?.getAttribute('data-compare-input-action') === 'filter-options'
@@ -367,6 +370,7 @@ test('correlations browser contract filters markers toggles chips and builds cha
         state.selectedCorrelationMarkers.length === 8
         && !state.selectedCorrelationMarkers.includes('hormones.testosterone');
     } finally {
+      if (savedCompareDeps) compare.configureCompareCorrelationViews(savedCompareDeps);
       if (originalChart === undefined) delete window.Chart;
       else window.Chart = originalChart;
       state.importedData = originalImportedData;

--- a/tests/playwright/context-cards-browser-coverage.spec.js
+++ b/tests/playwright/context-cards-browser-coverage.spec.js
@@ -14,10 +14,11 @@ test('context cards browser coverage exercises notes save dots and tips', async 
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ cardsUrl }) => {
-    const [{ state }, cards, recommendationRuntime] = await Promise.all([
+    const [{ state }, cards, recommendationRuntime, contextCardsRuntime] = await Promise.all([
       import('/js/state.js'),
       import(cardsUrl),
       import('/js/recommendations-runtime.js'),
+      import('/js/context-cards-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const outcomes = {};
@@ -26,12 +27,12 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       importedData: clone(state.importedData),
       closeModal: window.closeModal,
       navigate: window.navigate,
-      onContextCardSaved: window.onContextCardSaved,
       aiProvider: localStorage.getItem('labcharts-ai-provider'),
       aiPaused: localStorage.getItem('labcharts-ai-paused'),
       detailsOpen: sessionStorage.getItem('welcome-details-open'),
     };
     let previousRecommendationBridge = null;
+    let previousContextCardsRuntime = null;
     let host = null;
     let injectedNav = null;
     let details = null;
@@ -112,7 +113,9 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       document.body.appendChild(injectedNav);
       window.closeModal = () => calls.push(['close']);
       window.navigate = category => calls.push(['navigate', category]);
-      window.onContextCardSaved = () => calls.push(['saved']);
+      previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+        onContextCardSaved: () => calls.push(['saved']),
+      });
       state.importedData.stress = { level: 'moderate', sources: ['work'], management: ['walks'], note: '' };
       const saveBefore = calls.length;
       cards.saveAndRefresh('Stress profile saved', 'stress');
@@ -156,8 +159,9 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       else delete window.closeModal;
       if (saved.navigate) window.navigate = saved.navigate;
       else delete window.navigate;
-      if (saved.onContextCardSaved) window.onContextCardSaved = saved.onContextCardSaved;
-      else delete window.onContextCardSaved;
+      if (previousContextCardsRuntime) {
+        contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
+      }
       if (previousRecommendationBridge) {
         recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
       }

--- a/tests/playwright/custom-personality-dom.spec.js
+++ b/tests/playwright/custom-personality-dom.spec.js
@@ -20,13 +20,9 @@ test('custom personality DOM renders editor controls and delegated discuss actio
   ];
 
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.loadChatPersonality === 'function'
-      && typeof window.updatePersonalityBar === 'function'
-      && typeof window.startNewCustomPersonality === 'function'
-  );
 
   const results = await page.evaluate(async () => {
+    const chatPersonalities = await import('/js/chat-personalities.js');
     const profileId = localStorage.getItem('labcharts-current-profile') || 'default';
     const customKey = `labcharts-${profileId}-chatPersonalityCustom`;
     const personalityKey = `labcharts-${profileId}-chatPersonality`;
@@ -41,8 +37,8 @@ test('custom personality DOM renders editor controls and delegated discuss actio
     try {
       localStorage.setItem(customKey, JSON.stringify(personalities));
       localStorage.setItem(personalityKey, 'custom_abc');
-      window.loadChatPersonality();
-      window.updatePersonalityBar();
+      chatPersonalities.loadChatPersonality();
+      chatPersonalities.updatePersonalityBar();
 
       const section = document.getElementById('chat-personality-custom-section');
       const customBtns = section?.querySelectorAll('.chat-personality-opt') || [];
@@ -109,11 +105,11 @@ test('custom personality DOM renders editor controls and delegated discuss actio
         '.chat-personality-custom-save:disabled',
       ].every(hasSelectorContaining);
 
-      window.startNewCustomPersonality();
+      chatPersonalities.startNewCustomPersonality();
       const saveBtn2 = document.querySelector('.chat-personality-custom-save');
-      window.snapshotPersonalityClean();
+      chatPersonalities.snapshotPersonalityClean();
       outcomes.saveDisabledAfterSnapshot = saveBtn2?.disabled === true;
-      window.markPersonalityDirty();
+      chatPersonalities.markPersonalityDirty();
       outcomes.saveStaysDisabledWhenStateMatchesSnapshot = saveBtn2?.disabled === true;
 
       const discussBtn = document.getElementById('chat-discuss-btn');
@@ -125,8 +121,8 @@ test('custom personality DOM renders editor controls and delegated discuss actio
       else localStorage.setItem(customKey, originalCustom);
       if (originalPersonality == null) localStorage.removeItem(personalityKey);
       else localStorage.setItem(personalityKey, originalPersonality);
-      window.loadChatPersonality?.();
-      window.updatePersonalityBar?.();
+      chatPersonalities.loadChatPersonality();
+      chatPersonalities.updatePersonalityBar();
     }
 
     return outcomes;
@@ -315,16 +311,13 @@ test('custom personality save path updates picker, header, and persisted state',
   ];
 
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.loadChatPersonality === 'function'
-      && typeof window.updatePersonalityBar === 'function'
-      && typeof window.saveCustomPersonality === 'function'
-      && typeof window.deleteCustomPersonality === 'function'
-      && !!window._labState
-  );
+  await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const { state } = await import('/js/state.js');
+    const [{ state }, chatPersonalities] = await Promise.all([
+      import('/js/state.js'),
+      import('/js/chat-personalities.js'),
+    ]);
     const storage = new Map(Array.from({ length: localStorage.length }, (_, index) => {
       const key = localStorage.key(index);
       return [key, localStorage.getItem(key)];
@@ -373,7 +366,7 @@ test('custom personality save path updates picker, header, and persisted state',
       localStorage.setItem(customKey, '[]');
       localStorage.setItem(personalityKey, 'default');
 
-      window.updateChatHeaderTitle();
+      chatPersonalities.updateChatHeaderTitle();
       const summaryBtn = document.querySelector('.chat-summary-btn');
       outcomes.headerTitleCombinesAssistantPersonas =
         document.querySelector('.chat-header-title')?.textContent === 'A Analyst One & C Coach Two';
@@ -382,7 +375,7 @@ test('custom personality save path updates picker, header, and persisted state',
         && summaryBtn?.getAttribute('title') === 'View summary';
 
       delete state.chatThreads[0].summary;
-      window.updateSummaryButton();
+      chatPersonalities.updateSummaryButton();
       outcomes.summaryButtonClearsWithoutSummary =
         summaryBtn?.classList.contains('has-summary') === false
         && summaryBtn?.getAttribute('title') === 'Summarize this conversation';
@@ -391,17 +384,17 @@ test('custom personality save path updates picker, header, and persisted state',
       const trigger = document.querySelector('.chat-personality-current');
       bar?.classList.remove('open');
       trigger?.setAttribute('aria-expanded', 'false');
-      window.togglePersonalityBar();
+      chatPersonalities.togglePersonalityBar();
       const opened = bar?.classList.contains('open') === true
         && trigger?.getAttribute('aria-expanded') === 'true';
-      window.togglePersonalityBar();
+      chatPersonalities.togglePersonalityBar();
       outcomes.pickerToggleUpdatesOpenClassAndAria = opened
         && bar?.classList.contains('open') === false
         && trigger?.getAttribute('aria-expanded') === 'false';
 
       state.chatHistory = [];
-      window.updateChatHeaderTitle();
-      window.updatePersonalityBar();
+      chatPersonalities.updateChatHeaderTitle();
+      chatPersonalities.updatePersonalityBar();
       document.querySelector('.chat-personality-add-btn')?.click();
       await waitFor(() => !!document.getElementById('chat-personality-custom-name'));
       const nameInput = document.getElementById('chat-personality-custom-name');
@@ -426,11 +419,11 @@ test('custom personality save path updates picker, header, and persisted state',
         && document.querySelector('.chat-header-title')?.textContent === 'Methodical Reviewer'
         && document.querySelector('.chat-personality-custom-save')?.disabled === true;
 
-      window.editCustomPersonality(created.id);
+      chatPersonalities.editCustomPersonality(created.id);
       document.getElementById('chat-personality-custom-name').value = 'Updated Reviewer';
       document.querySelector('.chat-personality-custom-textarea').value = 'Updated prompt';
-      window.markPersonalityDirty();
-      window.saveCustomPersonality();
+      chatPersonalities.markPersonalityDirty();
+      chatPersonalities.saveCustomPersonality();
       const editedCustoms = JSON.parse(localStorage.getItem(customKey) || '[]');
       outcomes.editCustomUpdatesExistingWithoutDuplicate =
         editedCustoms.length === 1
@@ -443,19 +436,19 @@ test('custom personality save path updates picker, header, and persisted state',
         { id: 'custom_migrate', name: 'Migrated Voice', icon: 'M', promptText: 'Migrate prompt' },
       ]));
       localStorage.setItem(personalityKey, 'custom');
-      window.loadChatPersonality();
+      chatPersonalities.loadChatPersonality();
       outcomes.loadLegacyCustomMigratesToFirstSavedCustom =
         state.currentChatPersonality === 'custom_migrate'
         && localStorage.getItem(personalityKey) === 'custom_migrate';
 
       localStorage.setItem(personalityKey, 'custom_missing');
-      window.loadChatPersonality();
+      chatPersonalities.loadChatPersonality();
       outcomes.loadUnknownCustomFallsBackDefault = state.currentChatPersonality === 'default';
 
       state.currentChatPersonality = 'custom_migrate';
       localStorage.setItem(personalityKey, 'custom_migrate');
-      window.updatePersonalityBar();
-      const deleteResultPromise = window.deleteCustomPersonality('custom_migrate')
+      chatPersonalities.updatePersonalityBar();
+      const deleteResultPromise = chatPersonalities.deleteCustomPersonality('custom_migrate')
         .then(() => ({ ok: true }))
         .catch(error => ({ ok: false, error: error?.message || String(error) }));
       const confirmReady = await waitFor(() => !!document.getElementById('confirm-ok'));
@@ -487,9 +480,9 @@ test('custom personality save path updates picker, header, and persisted state',
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);
       }
-      window.loadChatPersonality?.();
-      window.updatePersonalityBar?.();
-      window.updateChatHeaderTitle?.();
+      chatPersonalities.loadChatPersonality();
+      chatPersonalities.updatePersonalityBar();
+      chatPersonalities.updateChatHeaderTitle();
     }
 
     return outcomes;

--- a/tests/test-chat-threads.js
+++ b/tests/test-chat-threads.js
@@ -44,6 +44,7 @@ const stateModule = await import('../js/state.js');
 const cryptoModule = await import('../js/crypto.js');
 const backupModule = await import('../js/backup.js');
 const chatThreadsModule = await import('../js/chat-threads.js');
+const chatHistoryModule = await import('../js/chat-history.js');
 await import('../js/chat.js');
 
 const st = stateModule.state;
@@ -182,14 +183,14 @@ st.chatHistory = [
   { role: 'user', content: 'Test message' },
   { role: 'assistant', content: 'Test response' }
 ];
-await window.saveChatHistory();
+await chatHistoryModule.saveChatHistory();
 const savedIndex = JSON.parse(localStorage.getItem(chatThreadsModule.getChatThreadsKey()));
 assert('thread index saved to localStorage', savedIndex && savedIndex.length === 1);
 assert('thread index messageCount updated', savedIndex[0].messageCount === 2);
 const savedMessages = JSON.parse(localStorage.getItem(chatThreadsModule.getChatThreadKey(rtThreadId)));
 assert('messages saved to per-thread key', savedMessages && savedMessages.length === 2);
 st.chatHistory = [];
-await window.loadChatHistory();
+await chatHistoryModule.loadChatHistory();
 assert('messages loaded back', st.chatHistory.length === 2);
 assert('message content matches', st.chatHistory[0].content === 'Test message');
 localStorage.removeItem(chatThreadsModule.getChatThreadKey(rtThreadId));

--- a/tests/test-custom-personality.js
+++ b/tests/test-custom-personality.js
@@ -30,9 +30,11 @@ function assert(name, condition, detail) {
 
 console.log('=== Multiple Custom Personalities Tests ===\n');
 
-// chat.js exposes the personality + discussion handlers via Object.assign(window).
 await import('../js/state.js');
 await import('../js/chat.js');
+const personalities = await import('../js/chat-personalities.js');
+const chatHistory = await import('../js/chat-history.js');
+const chatDiscussion = await import('../js/chat-discussion.js');
 const { buildPersonalityPrompt } = await import('../js/chat-prompt-context.js');
 const { createNewThread } = await import('../js/chat-threads.js');
 
@@ -41,31 +43,29 @@ const key = `labcharts-${profileId}-chatPersonalityCustom`;
 const origVal = localStorage.getItem(key);
 const origPersonality = localStorage.getItem(`labcharts-${profileId}-chatPersonality`);
 
-// ── 1. Window exports ──
-console.log('1. Window exports');
-assert('getCustomPersonalities exported', typeof window.getCustomPersonalities === 'function');
-assert('saveCustomPersonalities exported', typeof window.saveCustomPersonalities === 'function');
-assert('getCustomPersonality exported', typeof window.getCustomPersonality === 'function');
-assert('getCustomPersonalityText exported', typeof window.getCustomPersonalityText === 'function');
-assert('pickPersonaIcon exported', typeof window.pickPersonaIcon === 'function');
-assert('generateCustomPersonality exported', typeof window.generateCustomPersonality === 'function');
-assert('saveCustomPersonality exported', typeof window.saveCustomPersonality === 'function');
-assert('startNewCustomPersonality exported', typeof window.startNewCustomPersonality === 'function');
-assert('deleteCustomPersonality exported', typeof window.deleteCustomPersonality === 'function');
-assert('getActivePersonality exported', typeof window.getActivePersonality === 'function');
-assert('autoResizePersonaTextarea exported', typeof window.autoResizePersonaTextarea === 'function');
-assert('markPersonalityDirty exported', typeof window.markPersonalityDirty === 'function');
-assert('snapshotPersonalityClean exported', typeof window.snapshotPersonalityClean === 'function');
+// ── 1. Module exports ──
+console.log('1. Module exports');
+const personalityExports = [
+  'getCustomPersonalities', 'saveCustomPersonalities', 'getCustomPersonality',
+  'getCustomPersonalityText', 'pickPersonaIcon', 'generateCustomPersonality',
+  'saveCustomPersonality', 'startNewCustomPersonality', 'deleteCustomPersonality',
+  'getActivePersonality', 'autoResizePersonaTextarea', 'markPersonalityDirty',
+  'snapshotPersonalityClean',
+];
+for (const name of personalityExports) {
+  assert(`${name} exported`, typeof personalities[name] === 'function');
+  assert(`window.${name} stays module-only`, !(name in window));
+}
 
 // ── 2. pickPersonaIcon determinism ──
 console.log('2. pickPersonaIcon determinism');
-const icon1 = window.pickPersonaIcon('Longevity Expert');
-const icon2 = window.pickPersonaIcon('Longevity Expert');
+const icon1 = personalities.pickPersonaIcon('Longevity Expert');
+const icon2 = personalities.pickPersonaIcon('Longevity Expert');
 assert('pickPersonaIcon returns same icon for same name', icon1 === icon2, `${icon1} vs ${icon2}`);
 assert('pickPersonaIcon returns emoji', icon1.length > 0);
-const iconEmpty = window.pickPersonaIcon('');
+const iconEmpty = personalities.pickPersonaIcon('');
 assert('pickPersonaIcon empty name returns pencil', iconEmpty === '✏️', `got: ${iconEmpty}`);
-const iconNull = window.pickPersonaIcon(null);
+const iconNull = personalities.pickPersonaIcon(null);
 assert('pickPersonaIcon null returns pencil', iconNull === '✏️');
 const PERSONA_ICONS = ['🧠', '🎭', '🔮', '🌿', '⚡', '🦊', '🧬', '🌊', '🔥', '🏛️'];
 assert('pickPersonaIcon result is from palette', PERSONA_ICONS.includes(icon1), `got: ${icon1}`);
@@ -73,13 +73,13 @@ assert('pickPersonaIcon result is from palette', PERSONA_ICONS.includes(icon1), 
 // ── 3. getCustomPersonalities — array storage ──
 console.log('3. getCustomPersonalities array storage');
 localStorage.removeItem(key);
-assert('Empty storage returns []', JSON.stringify(window.getCustomPersonalities()) === '[]');
+assert('Empty storage returns []', JSON.stringify(personalities.getCustomPersonalities()) === '[]');
 const arr = [
   { id: 'custom_abc', name: 'Longevity Expert', icon: '🧠', promptText: 'Expert prompt', evidenceBased: true },
   { id: 'custom_def', name: 'Functional Doc', icon: '🔮', promptText: 'Functional prompt', evidenceBased: false }
 ];
 localStorage.setItem(key, JSON.stringify(arr));
-const loaded = window.getCustomPersonalities();
+const loaded = personalities.getCustomPersonalities();
 assert('Array: returns 2 items', loaded.length === 2);
 assert('Array: first item name', loaded[0].name === 'Longevity Expert');
 assert('Array: second item name', loaded[1].name === 'Functional Doc');
@@ -89,7 +89,7 @@ assert('Array: IDs preserved', loaded[0].id === 'custom_abc' && loaded[1].id ===
 console.log('4. Migration from single object');
 const singleObj = { name: 'Longevity Expert', icon: '🧠', promptText: 'You are a longevity researcher...', evidenceBased: true };
 localStorage.setItem(key, JSON.stringify(singleObj));
-const migrated = window.getCustomPersonalities();
+const migrated = personalities.getCustomPersonalities();
 assert('Single obj: returns array of 1', migrated.length === 1);
 assert('Single obj: id is custom_migrated', migrated[0].id === 'custom_migrated');
 assert('Single obj: name preserved', migrated[0].name === 'Longevity Expert');
@@ -99,7 +99,7 @@ assert('Single obj: evidenceBased preserved', migrated[0].evidenceBased === true
 // ── 5. Migration from legacy string ──
 console.log('5. Migration from legacy string');
 localStorage.setItem(key, 'Speak like a pirate doctor');
-const legacyArr = window.getCustomPersonalities();
+const legacyArr = personalities.getCustomPersonalities();
 assert('Legacy string: returns array of 1', legacyArr.length === 1);
 assert('Legacy string: id is custom_migrated', legacyArr[0].id === 'custom_migrated');
 assert('Legacy string: name is Custom Personality', legacyArr[0].name === 'Custom Personality');
@@ -110,23 +110,23 @@ assert('Legacy string: evidenceBased false', legacyArr[0].evidenceBased === fals
 console.log('6. getCustomPersonality compat shim');
 localStorage.setItem(key, JSON.stringify(arr));
 localStorage.setItem(`labcharts-${profileId}-chatPersonality`, 'custom_def');
-window.loadChatPersonality();
-const compat = window.getCustomPersonality();
+personalities.loadChatPersonality();
+const compat = personalities.getCustomPersonality();
 assert('Compat shim: returns matching custom', compat.id === 'custom_def');
 assert('Compat shim: name is Functional Doc', compat.name === 'Functional Doc');
 localStorage.setItem(`labcharts-${profileId}-chatPersonality`, 'default');
-window.loadChatPersonality();
-const compatFallback = window.getCustomPersonality();
+personalities.loadChatPersonality();
+const compatFallback = personalities.getCustomPersonality();
 assert('Compat shim: fallback returns first', compatFallback.id === 'custom_abc');
-assert('getCustomPersonalityText returns promptText', window.getCustomPersonalityText() === 'Expert prompt');
+assert('getCustomPersonalityText returns promptText', personalities.getCustomPersonalityText() === 'Expert prompt');
 localStorage.removeItem(key);
-const compatEmpty = window.getCustomPersonality();
+const compatEmpty = personalities.getCustomPersonality();
 assert('Compat shim: empty returns blank', compatEmpty.promptText === '' && compatEmpty.name === 'Custom Personality');
 
 // ── 7. saveCustomPersonalities ──
 console.log('7. saveCustomPersonalities');
 const testArr = [{ id: 'custom_test1', name: 'Test1', icon: '⚡', promptText: 'p1', evidenceBased: false }];
-window.saveCustomPersonalities(testArr);
+personalities.saveCustomPersonalities(testArr);
 const saved = JSON.parse(localStorage.getItem(key));
 assert('saveCustomPersonalities writes array', Array.isArray(saved));
 assert('saveCustomPersonalities data correct', saved[0].name === 'Test1');
@@ -135,28 +135,28 @@ assert('saveCustomPersonalities data correct', saved[0].name === 'Test1');
 console.log('8. getActivePersonality for custom IDs');
 localStorage.setItem(key, JSON.stringify(arr));
 localStorage.setItem(`labcharts-${profileId}-chatPersonality`, 'custom_abc');
-window.loadChatPersonality();
-const active = window.getActivePersonality();
+personalities.loadChatPersonality();
+const active = personalities.getActivePersonality();
 assert('Active custom: id is custom_abc', active.id === 'custom_abc');
 assert('Active custom: name is Longevity Expert', active.name === 'Longevity Expert');
 assert('Active custom: has greeting', typeof active.greeting === 'string' && active.greeting.length > 0);
 localStorage.setItem(`labcharts-${profileId}-chatPersonality`, 'custom_nonexistent');
-window.loadChatPersonality();
-const fallback = window.getActivePersonality();
+personalities.loadChatPersonality();
+const fallback = personalities.getActivePersonality();
 assert('Deleted custom: falls back to default', fallback.id === 'default');
 
 // ── 9. loadChatPersonality accepts custom IDs ──
 console.log('9. loadChatPersonality validation');
 localStorage.setItem(key, JSON.stringify(arr));
 localStorage.setItem(`labcharts-${profileId}-chatPersonality`, 'custom_abc');
-window.loadChatPersonality();
-assert('loadChatPersonality accepts custom_abc', window.getActivePersonality().id === 'custom_abc');
+personalities.loadChatPersonality();
+assert('loadChatPersonality accepts custom_abc', personalities.getActivePersonality().id === 'custom_abc');
 localStorage.setItem(`labcharts-${profileId}-chatPersonality`, 'custom_bogus');
-window.loadChatPersonality();
-assert('loadChatPersonality rejects unknown custom', window.getActivePersonality().id === 'default');
+personalities.loadChatPersonality();
+assert('loadChatPersonality rejects unknown custom', personalities.getActivePersonality().id === 'default');
 localStorage.setItem(`labcharts-${profileId}-chatPersonality`, 'custom');
-window.loadChatPersonality();
-assert('loadChatPersonality migrates legacy custom', window.getActivePersonality().id === 'custom_abc');
+personalities.loadChatPersonality();
+assert('loadChatPersonality migrates legacy custom', personalities.getActivePersonality().id === 'custom_abc');
 
 // ── 10. CHAT_PERSONALITIES no longer has custom entry ──
 console.log('10. CHAT_PERSONALITIES static entries');
@@ -180,7 +180,7 @@ console.log('14. Thread metadata');
 const createSrc = createNewThread.toString();
 assert('createNewThread has personalityName', createSrc.includes('personalityName'));
 assert('createNewThread has personalityIcon', createSrc.includes('personalityIcon'));
-const saveSrc = window.saveChatHistory.toString();
+const saveSrc = chatHistory.saveChatHistory.toString();
 assert('saveChatHistory has personalityName', saveSrc.includes('personalityName'));
 assert('saveChatHistory has personalityIcon', saveSrc.includes('personalityIcon'));
 
@@ -218,10 +218,10 @@ assert('CSS has .chat-stopped-note', css.includes('.chat-stopped-note'));
 // ── 20. Discuss button exports ──
 console.log('20. Discuss button exports');
 assert('startDiscussion exported', typeof window.startDiscussion === 'function');
-assert('continueDiscussion exported', typeof window.continueDiscussion === 'function');
-assert('endDiscussion exported', typeof window.endDiscussion === 'function');
+assert('continueDiscussion exported', typeof chatDiscussion.continueDiscussion === 'function');
+assert('endDiscussion exported', typeof chatDiscussion.endDiscussion === 'function');
 assert('updateDiscussButton exported', typeof window.updateDiscussButton === 'function');
-assert('getThreadPersonaCount exported', typeof window.getThreadPersonaCount === 'function');
+assert('getThreadPersonaCount exported', typeof chatDiscussion.getThreadPersonaCount === 'function');
 
 // ── 22. Discuss button CSS ──
 console.log('22. Discuss button CSS');
@@ -233,7 +233,7 @@ assert('CSS has .chat-discuss-done-btn', css.includes('.chat-discuss-done-btn'))
 
 // ── 23. getThreadPersonaCount source ──
 console.log('23. getThreadPersonaCount');
-const countSrc = window.getThreadPersonaCount.toString();
+const countSrc = chatDiscussion.getThreadPersonaCount.toString();
 assert('getThreadPersonaCount checks personalityName', countSrc.includes('personalityName'));
 assert('getThreadPersonaCount uses Set', countSrc.includes('new Set'));
 
@@ -258,13 +258,13 @@ assert('renderChatMessages checks msg.stopped', renderSrc2.includes('msg.stopped
 console.log('26. startDiscussion source');
 const discSrc = window.startDiscussion.toString();
 assert('startDiscussion shows persona picker', discSrc.includes('showDiscussPersonaPicker'));
-const pickerSrc = window.startDiscussionFromPicker.toString();
+const pickerSrc = chatDiscussion.startDiscussionFromPicker.toString();
 assert('startDiscussionFromPicker delegates to runDiscussion', pickerSrc.includes('runDiscussion'));
-const contSrc = window.continueDiscussion.toString();
+const contSrc = chatDiscussion.continueDiscussion.toString();
 assert('continueDiscussion removes prompt', contSrc.includes('removeDiscussContinuePrompt'));
 assert('continueDiscussion runs another round', contSrc.includes('runDiscussionContinuation'));
 assert('continueDiscussion reads steer input', contSrc.includes('chat-discuss-steer'));
-const endSrc = window.endDiscussion.toString();
+const endSrc = chatDiscussion.endDiscussion.toString();
 assert('endDiscussion cleans up state', endSrc.includes('cleanupDiscussionState'));
 assert('endDiscussion marks discussion ended', endSrc.includes('markEnded: true'));
 assert('chat restores discussion prompt without thread metadata',
@@ -286,7 +286,7 @@ if (origVal !== null) localStorage.setItem(key, origVal);
 else localStorage.removeItem(key);
 if (origPersonality !== null) localStorage.setItem(`labcharts-${profileId}-chatPersonality`, origPersonality);
 else localStorage.removeItem(`labcharts-${profileId}-chatPersonality`);
-if (window.loadChatPersonality) window.loadChatPersonality();
+personalities.loadChatPersonality();
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);
 process.exit(fail > 0 ? 1 : 0);

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -66,9 +66,17 @@ assert('Chat HD shell action uses its module dependency instead of a window look
 
 assert('App shell wires module-only chat image consumers',
   appShellHooksSrc.includes("from './chat-images.js'")
-    && appShellHooksSrc.includes('configureChatMessageActionDeps({ openImageLightbox, removeImageAttachment });')
+    && appShellHooksSrc.includes('configureChatMessageActionDeps({')
+    && appShellHooksSrc.includes('openImageLightbox,')
+    && appShellHooksSrc.includes('removeImageAttachment,')
     && appShellHooksSrc.includes('configureShellChatImageDeps({ toggleHDMode });')
     && appShellHooksSrc.includes('configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });'));
+
+assert('App shell wires module-only chat message actions',
+  ['closeSummaryModal', 'continueDiscussion', 'copySummary', 'deleteSavedSummary',
+    'downloadSummary', 'endDiscussion', 'jumpToSearchResult', 'printSummary',
+    'startDiscussionFromPicker', 'viewSavedSummary']
+    .every(name => appShellHooksSrc.includes(`${name},`)));
 
 assert('Chat thread shell actions use module dependencies instead of window lookups',
   shellSrc.includes('shellChatThreadDeps.toggleThreadRail()')

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -228,6 +228,27 @@
     import('../js/views.js'),
   ]);
   const sunModule = await import('../js/sun.js');
+  const chatPersonalitiesModule = await import('../js/chat-personalities.js');
+  const markdownModule = await import('../js/markdown.js');
+  const formerUnusedChatGlobals = [
+    'getChatStorageKey', 'getActivePersonality', 'getCustomPersonalities', 'saveCustomPersonalities',
+    'getCustomPersonality', 'getCustomPersonalityText', 'pickPersonaIcon', 'generateCustomPersonality',
+    'autoResizePersonaTextarea', 'markPersonalityDirty', 'snapshotPersonalityClean', 'loadChatPersonality',
+    'updateChatHeaderTitle', 'updatePersonalityBar', 'saveCustomPersonality', 'startNewCustomPersonality',
+    'deleteCustomPersonality', 'saveChatHistory', 'closeSummaryModal', 'updateSummaryButton',
+    'viewSavedSummary', 'deleteSavedSummary', 'renderSavedSummaries', 'copySummary', 'downloadSummary',
+    'printSummary', 'applyInlineMarkdown', 'renderMarkdown', 'startOnboardingLabImport',
+    'requestOnboardingLabImportProvider', 'startDiscussionFromPicker', 'continueDiscussion', 'endDiscussion',
+    'editCustomPersonality', 'showDiscussContinuePrompt', 'restoreDiscussionContinuePrompt',
+    'cleanupDiscussionState', 'removeDiscussContinuePrompt', 'getThreadPersonaCount',
+    'askAIAboutCorrelations', 'getChatWebSearchEnabled', 'setChatNudge', 'setChatProfileSex',
+    'saveChatProfile', 'saveChatLocation', 'onboardHeightUnitChanged', 'saveChatPeriod', 'addChatSupplement',
+    'removeChatSupplement', 'setProviderQuizBranch', 'backToProviderQuiz', 'skipProviderSetup',
+    'skipOnboardingExtras', 'showCycleNoMensesOptions', 'showCyclePeriodEntry', 'saveCycleStatus',
+    '_updatePeriodBtn', 'onContextCardSaved',
+  ];
+  assert('Unused Chat APIs do not publish legacy window globals',
+    formerUnusedChatGlobals.every(name => !(name in window)));
   const formerSunGlobals = [
     'SUN_ENGINE_VERSION', '_refreshSunSurfaces', 'quickLogSunSession', 'startSession', 'stopSession',
     'pauseSession', 'resumeSession', 'pauseSunSession', 'resumeSunSession', 'applySunscreenMidSession',
@@ -1197,13 +1218,15 @@
   }
 
   // Chat personality system — returns personality object, not string
-  const personality = window.getActivePersonality();
+  const personality = chatPersonalitiesModule.getActivePersonality();
   assert('getActivePersonality returns object with id', typeof personality === 'object' && typeof personality.id === 'string',
     personality ? `id=${personality.id}` : 'null');
+  assert('getActivePersonality stays module-only', !('getActivePersonality' in window));
 
   // Markdown rendering
-  const md = window.renderMarkdown('**bold** and *italic*');
+  const md = markdownModule.renderMarkdown('**bold** and *italic*');
   assert('renderMarkdown handles bold', md.includes('<strong>') || md.includes('<b>'));
+  assert('renderMarkdown stays module-only', !('renderMarkdown' in window));
 
   // ═══════════════════════════════════════════════
   // 13. CONTEXT CARDS — rendering

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.238';
+self.APP_VERSION = '1.10.239';


### PR DESCRIPTION
## Summary

- remove 58 unused Chat APIs from the browser facade, reducing `chat-window-bindings.js` from 80 globals to 22
- replace hidden `window`-alias consumers for message actions, correlation prompts, and context-card saves with explicit module callback wiring
- migrate Chat tests to module APIs and add a regression guard keeping the removed APIs off `window`
- bump the app version to `1.10.239`

## Testing

- `./run-tests.sh` (398 Vitest tests, 352 Playwright tests, typechecks, vendor checks, and responsive theme matrix)
- targeted Chat/context Playwright suite (9 tests)
