### PR TITLE
Remove Chat refresh globals

### DIFF
--- a/js/api-provider-storage-runtime.js
+++ b/js/api-provider-storage-runtime.js
@@ -1,34 +1,20 @@
 // @ts-check
 // api-provider-storage-runtime.js - Browser runtime adapters for persisted provider settings.
 
+import {
+  refreshChatWebSearchToggleRuntime,
+  updateChatHeaderModelRuntime,
+} from './chat-runtime.js';
+
 function getApiProviderStorageRuntime() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
 }
 
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getApiProviderStorageRuntime();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
-}
-
 export function refreshAIProviderSelectionRuntime() {
-  let refreshed = false;
-  const updateHeader = getRuntimeFunction('updateChatHeaderModel');
-  if (updateHeader) {
-    updateHeader();
-    refreshed = true;
-  }
-  const refreshWebSearch = getRuntimeFunction('refreshWebSearchToggle');
-  if (refreshWebSearch) {
-    refreshWebSearch();
-    refreshed = true;
-  }
-  return refreshed;
+  const headerRefreshed = updateChatHeaderModelRuntime();
+  return refreshChatWebSearchToggleRuntime() || headerRefreshed;
 }
 
 export function dispatchAISettingsLocalChangedRuntime() {

--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -17,11 +17,17 @@ import {
   updateAttachButtonVisibility,
 } from './chat-images.js';
 import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
-import { closeChatPanel, configureChatPanel, toggleChatPanel } from './chat-panel.js';
+import {
+  closeChatPanel,
+  configureChatPanel,
+  refreshWebSearchToggle,
+  toggleChatPanel,
+} from './chat-panel.js';
 import { askAIAboutCorrelations } from './chat-marker-prompts.js';
 import { onContextCardSaved } from './chat-onboarding.js';
 import { updateChatNudge } from './chat-nudge.js';
-import { updateChatContextStatus } from './chat-personalities.js';
+import { updateChatContextStatus, updateChatHeaderModel } from './chat-personalities.js';
+import { configureChatRuntimeCallbacks } from './chat-runtime.js';
 import {
   closeSummaryModal,
   copySummary,
@@ -93,6 +99,7 @@ configureRecommendationsRuntime({ openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
+configureChatRuntimeCallbacks({ refreshWebSearchToggle, updateChatHeaderModel, updateChatNudge });
 configureChatMessageActionDeps({
   closeSummaryModal,
   continueDiscussion,

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -4,6 +4,34 @@
 import { openContextModalRuntime } from './context-cards-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
+/** @type {Record<'refreshWebSearchToggle' | 'updateChatHeaderModel' | 'updateChatNudge', Function | null>} */
+const chatRuntimeCallbacks = {
+  refreshWebSearchToggle: null,
+  updateChatHeaderModel: null,
+  updateChatNudge: null,
+};
+
+/** @param {Partial<Record<keyof typeof chatRuntimeCallbacks, Function | null>>} [callbacks] */
+export function configureChatRuntimeCallbacks(callbacks = {}) {
+  const previous = { ...chatRuntimeCallbacks };
+  for (const name of Object.keys(chatRuntimeCallbacks)) {
+    if (name in callbacks) {
+      const callback = callbacks[/** @type {keyof typeof chatRuntimeCallbacks} */ (name)];
+      chatRuntimeCallbacks[/** @type {keyof typeof chatRuntimeCallbacks} */ (name)] =
+        typeof callback === 'function' ? callback : null;
+    }
+  }
+  return previous;
+}
+
+/** @param {keyof typeof chatRuntimeCallbacks} name */
+function callChatRuntimeCallback(name) {
+  const callback = chatRuntimeCallbacks[name];
+  if (typeof callback !== 'function') return false;
+  callback();
+  return true;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -32,6 +60,18 @@ function getRuntimeValue(name) {
 
 export function renderChatMessagesRuntime() {
   getRuntimeFunction('renderChatMessages')?.();
+}
+
+export function refreshChatWebSearchToggleRuntime() {
+  return callChatRuntimeCallback('refreshWebSearchToggle');
+}
+
+export function updateChatHeaderModelRuntime() {
+  return callChatRuntimeCallback('updateChatHeaderModel');
+}
+
+export function updateChatNudgeRuntime() {
+  return callChatRuntimeCallback('updateChatNudge');
 }
 
 export function updateDiscussButtonRuntime() {

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -13,13 +13,13 @@ import {
 import { renderSavedSummaries, summarizeThread } from './chat-summaries.js';
 import {
   getActivePersonality, setChatPersonality, togglePersonalityBar,
-  updateChatHeaderModel, updateChatHeaderTitle, updatePersonalityBar,
+  updateChatHeaderTitle, updatePersonalityBar,
 } from './chat-personalities.js';
 import {
   clearChatHistory, loadChatHistory, saveChatHistory,
 } from './chat-history.js';
 import {
-  closeChatPanel, configureChatPanel, refreshWebSearchToggle, setChatWebSearchEnabled,
+  closeChatPanel, configureChatPanel, setChatWebSearchEnabled,
   toggleChatFullscreen, toggleChatPanel, openChatPanel, updateChatInputState,
 } from './chat-panel.js';
 import { setChatNudge, updateChatNudge } from './chat-nudge.js';
@@ -69,8 +69,6 @@ Object.assign(window, {
   isChatStreaming,
   toggleChatFullscreen,
   setChatPersonality,
-  updateChatHeaderModel,
-  refreshWebSearchToggle,
   togglePersonalityBar,
   loadChatHistory,
   clearChatHistory,
@@ -86,5 +84,4 @@ Object.assign(window, {
   updateDiscussButton,
   askAIAboutMarker,
   setChatWebSearchEnabled,
-  updateChatNudge,
 });

--- a/js/context-card-lifestyle-runtime.js
+++ b/js/context-card-lifestyle-runtime.js
@@ -2,6 +2,7 @@
 // context-card-lifestyle-runtime.js - Browser runtime adapters for lifestyle context editors.
 
 import { openContextModalRuntime } from './context-cards-runtime.js';
+import { updateChatHeaderModelRuntime } from './chat-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 function getRuntimeWindow() {
@@ -46,7 +47,7 @@ export function closeLifestyleContextModalAndNavigateRuntime(category) {
 }
 
 export function updateLifestyleChatHeaderModelRuntime() {
-  getRuntimeFunction('updateChatHeaderModel')?.();
+  updateChatHeaderModelRuntime();
 }
 
 /** @param {(() => void) | null} reopenSunSetup */

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -5,6 +5,7 @@ import { isImportRunning } from './pdf-import-progress.js';
 import { getLatitudeFromLocation } from './profile.js';
 import { isDebugMode, showConfirmDialog } from './utils.js';
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
+import { updateChatNudgeRuntime } from './chat-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const dnaRuntimeDeps = { getLatitudeFromLocation, isDebugMode, isImportRunning, showConfirmDialog };
@@ -96,7 +97,7 @@ export function triggerDnaFilePicker() {
 }
 
 export function updateDnaChatNudge() {
-  getRuntimeFunction('updateChatNudge')?.();
+  updateChatNudgeRuntime();
 }
 
 /** @returns {string | null} */

--- a/js/lens.js
+++ b/js/lens.js
@@ -8,6 +8,7 @@ import { hasAIProvider, callClaudeAPI } from './api.js';
 import { isValidLensUrl as isValidLensUrlImpl } from './lens-url.js';
 import { clearLensCache as clearLensCacheImpl, getLensCacheEntry, setLensCacheEntry } from './lens-cache.js';
 import { createLensKnowledgeBaseUi } from './lens-knowledge-base-ui.js';
+import { updateChatHeaderModelRuntime } from './chat-runtime.js';
 const CONFIG_KEY = 'labcharts-lens-config';
 const SECRET_KEY = 'labcharts-lens-key';
 // testProbe — per-user "canary" query used by Save + connect to verify the
@@ -91,7 +92,7 @@ export function saveLensConfig(partial) {
   if (urlChanged || topKChanged) clearLensCache();
   // Ping listeners so the indicator re-evaluates visibility (without clobbering state)
   updateLensStatus({});
-  /** @type {any} */ (globalThis).updateChatHeaderModel?.();
+  updateChatHeaderModelRuntime();
   return next;
 }
 export function getLensKey() { return getCachedKey(SECRET_KEY) || ''; }
@@ -102,7 +103,7 @@ export async function saveLensKey(key) {
   // External-server hasLens() gates on getLensKey(); refresh the chat header
   // immediately so first-time KB key saves surface the AI Context chip without
   // waiting for an unrelated model/config refresh.
-  /** @type {any} */ (globalThis).updateChatHeaderModel?.();
+  updateChatHeaderModelRuntime();
 }
 export async function removeLens() {
   localStorage.removeItem(CONFIG_KEY);
@@ -110,7 +111,7 @@ export async function removeLens() {
   updateKeyCache(SECRET_KEY, '');
   clearLensCache();
   updateLensStatus({ state: 'idle', lastChunkCount: 0, lastError: null, sourceName: '' });
-  /** @type {any} */ (globalThis).updateChatHeaderModel?.();
+  updateChatHeaderModelRuntime();
 }
 export function hasLens() {
   const cfg = getLensConfig();

--- a/js/provider-model-controls-runtime.js
+++ b/js/provider-model-controls-runtime.js
@@ -2,6 +2,10 @@
 // provider-model-controls-runtime.js - Browser runtime adapters for provider model controls.
 
 import { callClaudeAPI } from './api.js';
+import {
+  refreshChatWebSearchToggleRuntime,
+  updateChatHeaderModelRuntime,
+} from './chat-runtime.js';
 
 const providerModelControlsRuntimeDeps = {
   callClaudeAPI,
@@ -36,18 +40,8 @@ export function clearProviderE2EESessionRuntime() {
 }
 
 export function refreshProviderModelUiRuntime() {
-  let refreshed = false;
-  const updateHeader = getRuntimeFunction('updateChatHeaderModel');
-  if (updateHeader) {
-    updateHeader();
-    refreshed = true;
-  }
-  const refreshWebSearch = getRuntimeFunction('refreshWebSearchToggle');
-  if (refreshWebSearch) {
-    refreshWebSearch();
-    refreshed = true;
-  }
-  return refreshed;
+  const headerRefreshed = updateChatHeaderModelRuntime();
+  return refreshChatWebSearchToggleRuntime() || headerRefreshed;
 }
 
 export function callProviderModelSmokeTestRuntime() {

--- a/js/settings.js
+++ b/js/settings.js
@@ -41,6 +41,7 @@ import { startGuidedTour } from './tour.js';
 import { getActiveProfileId } from './profile.js';
 import { openChangelog } from './changelog.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { updateChatNudgeRuntime } from './chat-runtime.js';
 import {
   confirmDisablePIIReview,
   refreshDataEntriesSection,
@@ -1052,7 +1053,7 @@ export function updateSettingsUI() {
 
 export function closeSettingsModal() {
   closeModalOverlay('settings-modal-overlay');
-  if (settingsWindow.updateChatNudge) settingsWindow.updateChatNudge();
+  updateChatNudgeRuntime();
   settingsRuntime.refreshMobileDashboardActiveTab();
 }
 

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -14,6 +14,7 @@ import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 import { maybeShowAnalyticsConsent } from './utils.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { updateChatNudgeRuntime } from './chat-runtime.js';
 
 const startupUIDeps = {
   initChatImageHandlers: () => {},
@@ -154,5 +155,5 @@ function initializeChatAttachments() {
   // Init chat image attachment handlers (paste, drag-drop, file input).
   startupUIDeps.initChatImageHandlers();
   startupUIDeps.updateAttachButtonVisibility();
-  requireStartupRuntime('updateChatNudge');
+  updateChatNudgeRuntime();
 }

--- a/js/sync-runtime.js
+++ b/js/sync-runtime.js
@@ -1,6 +1,11 @@
 // @ts-check
 // sync-runtime.js - Mutable Evolu runtime handles shared by sync modules.
 
+import {
+  refreshChatWebSearchToggleRuntime,
+  updateChatHeaderModelRuntime,
+} from './chat-runtime.js';
+
 let _evolu = null;
 let _profileQuery = null;
 let _tombstoneQuery = null;
@@ -37,15 +42,6 @@ function getSyncRuntimeWindow() {
     : null;
 }
 
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getSyncRuntimeWindow();
-  return runtime && typeof runtime[name] === 'function' ? runtime[name].bind(runtime) : null;
-}
-
 export function getSyncEvolu() { return _evolu; }
 export function getSyncProfileQuery() { return _profileQuery; }
 export function getSyncTombstoneQuery() { return _tombstoneQuery; }
@@ -80,18 +76,8 @@ export function setSyncAppOwnerError(error) {
 }
 
 export function refreshSyncedAIProviderUiRuntime() {
-  let refreshed = false;
-  const updateHeader = getRuntimeFunction('updateChatHeaderModel');
-  if (updateHeader) {
-    updateHeader();
-    refreshed = true;
-  }
-  const refreshWebSearch = getRuntimeFunction('refreshWebSearchToggle');
-  if (refreshWebSearch) {
-    refreshWebSearch();
-    refreshed = true;
-  }
-  return refreshed;
+  const headerRefreshed = updateChatHeaderModelRuntime();
+  return refreshChatWebSearchToggleRuntime() || headerRefreshed;
 }
 
 export function refreshSyncedRoutstrBalanceRuntime() {

--- a/tests/api-provider-storage-runtime.test.js
+++ b/tests/api-provider-storage-runtime.test.js
@@ -5,6 +5,7 @@ import {
   dispatchAISettingsLocalChangedRuntime,
   refreshAIProviderSelectionRuntime,
 } from '../js/api-provider-storage-runtime.js';
+import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 
@@ -28,11 +29,15 @@ describe('api provider storage runtime adapter', () => {
   it('delegates provider UI refresh hooks', () => {
     const updateChatHeaderModel = vi.fn();
     const refreshWebSearchToggle = vi.fn();
-    setRuntimeWindow({ updateChatHeaderModel, refreshWebSearchToggle });
+    const previous = configureChatRuntimeCallbacks({ updateChatHeaderModel, refreshWebSearchToggle });
 
-    expect(refreshAIProviderSelectionRuntime()).toBe(true);
-    expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
-    expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);
+    try {
+      expect(refreshAIProviderSelectionRuntime()).toBe(true);
+      expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
+      expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);
+    } finally {
+      configureChatRuntimeCallbacks(previous);
+    }
   });
 
   it('dispatches the local AI settings change event', () => {
@@ -49,10 +54,18 @@ describe('api provider storage runtime adapter', () => {
   });
 
   it('uses safe fallbacks when browser runtime hooks are missing', () => {
+    const previous = configureChatRuntimeCallbacks({
+      refreshWebSearchToggle: null,
+      updateChatHeaderModel: null,
+    });
     delete globalThis.window;
 
-    expect(refreshAIProviderSelectionRuntime()).toBe(false);
-    expect(dispatchAISettingsLocalChangedRuntime()).toBe(false);
+    try {
+      expect(refreshAIProviderSelectionRuntime()).toBe(false);
+      expect(dispatchAISettingsLocalChangedRuntime()).toBe(false);
+    } finally {
+      configureChatRuntimeCallbacks(previous);
+    }
   });
 
   it('keeps counted api provider storage globals behind the adapter', () => {

--- a/tests/playwright/api-provider-storage-browser-coverage.spec.js
+++ b/tests/playwright/api-provider-storage-browser-coverage.spec.js
@@ -17,6 +17,7 @@ test('api provider storage browser coverage handles provider gates and model cac
   const results = await page.evaluate(async ({ providerStorageUrl }) => {
     const storage = await import(providerStorageUrl);
     const cryptoStore = await import('/js/crypto.js');
+    const chatRuntime = await import('/js/chat-runtime.js');
     const outcomes = {};
 
     const storageKeys = [
@@ -65,8 +66,6 @@ test('api provider storage browser coverage handles provider gates and model cac
       localStorage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
       sessionStorage: Object.fromEntries(sessionKeys.map(key => [key, sessionStorage.getItem(key)])),
       keyCache: Object.fromEntries(cachedKeyNames.map(key => [key, cryptoStore.getCachedKey(key)])),
-      updateChatHeaderModel: window.updateChatHeaderModel,
-      refreshWebSearchToggle: window.refreshWebSearchToggle,
     };
 
     const restoreStoredValue = (store, key, value) => {
@@ -78,13 +77,16 @@ test('api provider storage browser coverage handles provider gates and model cac
 
     let headerUpdates = 0;
     let searchRefreshes = 0;
+    let previousChatRuntime = null;
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
       for (const key of sessionKeys) sessionStorage.removeItem(key);
       for (const key of cachedKeyNames) cryptoStore.updateKeyCache(key, null);
-      window.updateChatHeaderModel = () => { headerUpdates += 1; };
-      window.refreshWebSearchToggle = () => { searchRefreshes += 1; };
+      previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+        updateChatHeaderModel: () => { headerUpdates += 1; },
+        refreshWebSearchToggle: () => { searchRefreshes += 1; },
+      });
       window.addEventListener('labcharts-ai-settings-local-changed', onLocalSettingsChanged);
 
       const defaultProvider = storage.getAIProvider();
@@ -271,8 +273,7 @@ test('api provider storage browser coverage handles provider gates and model cac
       return outcomes;
     } finally {
       window.removeEventListener('labcharts-ai-settings-local-changed', onLocalSettingsChanged);
-      window.updateChatHeaderModel = saved.updateChatHeaderModel;
-      window.refreshWebSearchToggle = saved.refreshWebSearchToggle;
+      if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       for (const [key, value] of Object.entries(saved.localStorage)) {
         restoreStoredValue(localStorage, key, value);
       }

--- a/tests/playwright/dna-browser-coverage.spec.js
+++ b/tests/playwright/dna-browser-coverage.spec.js
@@ -187,6 +187,7 @@ test('DNA autosomal import UI coverage exercises preview, confirm, render, and d
     const { state } = await import('/js/state.js');
     const dna = await import(`/js/dna.js?dnaAutosomalCoverage=${Date.now()}-${Math.random()}`);
     const dnaRuntime = await import('/js/dna-runtime.js');
+    const chatRuntime = await import('/js/chat-runtime.js');
     const viewRuntime = await import('/js/views-runtime-bridge.js');
     let importRunning = false;
     const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps({
@@ -203,8 +204,10 @@ test('DNA autosomal import UI coverage exercises preview, confirm, render, and d
     const previousViewRuntime = viewRuntime.configureViewRuntime({
       buildSidebar: () => calls.push('sidebar'),
     });
+    const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+      updateChatNudge: () => calls.push('nudge'),
+    });
     window.navigate = route => calls.push(`navigate:${route}`);
-    window.updateChatNudge = () => calls.push('nudge');
 
     const validContent = `#AncestryDNA raw data download
 rsid\tchromosome\tposition\tallele1\tallele2
@@ -287,6 +290,7 @@ rs999999\t1\t100\tAG
     check('notifications rendered during flow', /DNA import|Imported|health-relevant/.test(toastText));
 
     dnaRuntime.configureDnaRuntimeDeps(previousDnaRuntimeDeps);
+    chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
     viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
     return { failures };
   });

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -102,6 +102,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
   const results = await page.evaluate(async ({ controlsUrl }) => {
     const controls = await import(controlsUrl);
     const runtime = await import('/js/provider-model-controls-runtime.js');
+    const chatRuntime = await import('/js/chat-runtime.js');
     const delegates = await import('/js/provider-panel-delegates.js');
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
     const jsonResponse = (body, status = 200) => new Response(JSON.stringify(body), {
@@ -132,11 +133,10 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
     const oldGlobals = {
       fetch: window.fetch,
       clearE2EESession: window.clearE2EESession,
-      updateChatHeaderModel: window.updateChatHeaderModel,
-      refreshWebSearchToggle: window.refreshWebSearchToggle,
       consoleWarn: console.warn,
     };
     let previousRuntimeDeps = null;
+    let previousChatRuntime = null;
 
     let clearCount = 0;
     let headerRefreshes = 0;
@@ -157,8 +157,10 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       `);
 
       window.clearE2EESession = () => { clearCount += 1; };
-      window.updateChatHeaderModel = () => { headerRefreshes += 1; };
-      window.refreshWebSearchToggle = () => { searchRefreshes += 1; };
+      previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+        updateChatHeaderModel: () => { headerRefreshes += 1; },
+        refreshWebSearchToggle: () => { searchRefreshes += 1; },
+      });
       console.warn = message => { warnings.push(String(message)); };
 
       localStorage.setItem('labcharts-openrouter-pricing', JSON.stringify({
@@ -362,9 +364,8 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
     } finally {
       window.fetch = oldGlobals.fetch;
       if (previousRuntimeDeps) runtime.configureProviderModelControlsRuntimeDeps(previousRuntimeDeps);
+      if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       window.clearE2EESession = oldGlobals.clearE2EESession;
-      window.updateChatHeaderModel = oldGlobals.updateChatHeaderModel;
-      window.refreshWebSearchToggle = oldGlobals.refreshWebSearchToggle;
       console.warn = oldGlobals.consoleWarn;
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);

--- a/tests/playwright/provider-model-controls-edge-browser-coverage.spec.js
+++ b/tests/playwright/provider-model-controls-edge-browser-coverage.spec.js
@@ -9,6 +9,7 @@ test('provider model controls edge coverage handles pricing updates guards and m
 
   const results = await page.evaluate(async ({ controlsUrl }) => {
     const controls = await import(controlsUrl);
+    const chatRuntime = await import('/js/chat-runtime.js');
     const failures = [];
     const check = (name, condition, detail = '') => {
       if (!condition) failures.push(detail ? `${name}: ${detail}` : name);
@@ -32,18 +33,19 @@ test('provider model controls edge coverage handles pricing updates guards and m
     for (const key of storageKeys) oldStorage[key] = localStorage.getItem(key);
     const oldGlobals = {
       clearE2EESession: window.clearE2EESession,
-      updateChatHeaderModel: window.updateChatHeaderModel,
-      refreshWebSearchToggle: window.refreshWebSearchToggle,
     };
     let clearCount = 0;
     let headerRefreshes = 0;
     let webSearchRefreshes = 0;
+    let previousChatRuntime = null;
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
       window.clearE2EESession = () => { clearCount += 1; };
-      window.updateChatHeaderModel = () => { headerRefreshes += 1; };
-      window.refreshWebSearchToggle = () => { webSearchRefreshes += 1; };
+      previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+        updateChatHeaderModel: () => { headerRefreshes += 1; },
+        refreshWebSearchToggle: () => { webSearchRefreshes += 1; },
+      });
 
       document.body.insertAdjacentHTML('beforeend', `
         <section id="provider-controls-edge-fixture">
@@ -158,8 +160,7 @@ test('provider model controls edge coverage handles pricing updates guards and m
       };
     } finally {
       window.clearE2EESession = oldGlobals.clearE2EESession;
-      window.updateChatHeaderModel = oldGlobals.updateChatHeaderModel;
-      window.refreshWebSearchToggle = oldGlobals.refreshWebSearchToggle;
+      if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       for (const key of storageKeys) {
         if (oldStorage[key] == null) localStorage.removeItem(key);
         else localStorage.setItem(key, oldStorage[key]);

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -387,6 +387,7 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
 
   const outcomes = await page.evaluate(async ({ startupUiUrl }) => {
     const settingsBridge = await import('/js/settings-runtime-bridge.js');
+    const chatRuntime = await import('/js/chat-runtime.js');
     const originalSetTimeout = window.setTimeout;
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     window.__startupUICalls = [];
@@ -402,11 +403,11 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
     const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
       openSettingsModal: section => window.__startupUICalls.push(['openSettingsModal', section]),
     });
+    const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+      updateChatNudge: () => window.__startupUICalls.push('updateChatNudge'),
+    });
     window.openChatPanel = () => {
       window.__startupUICalls.push('openChatPanel');
-    };
-    window.updateChatNudge = () => {
-      window.__startupUICalls.push('updateChatNudge');
     };
     window._openSettingsAfterInit = 'display';
     window._openChatAfterInit = true;
@@ -481,6 +482,7 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
       };
     } finally {
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
+      chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       window.setTimeout = originalSetTimeout;
       window.requestAnimationFrame = originalRequestAnimationFrame;
       delete window._openSettingsAfterInit;

--- a/tests/playwright/startup-oauth-browser-coverage.spec.js
+++ b/tests/playwright/startup-oauth-browser-coverage.spec.js
@@ -18,6 +18,7 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
   const results = await page.evaluate(async ({ startupUrl }) => {
     const startup = await import(startupUrl);
     const wearables = await import('/js/wearables-connect.js');
+    const chatRuntime = await import('/js/chat-runtime.js');
     const outcomes = {};
 
     const snapshotStorage = storage => new Map(Array.from({ length: storage.length }, (_, index) => storage.key(index))
@@ -36,8 +37,6 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     const originalSetTimeout = window.setTimeout;
     const originalReplaceState = history.replaceState;
     const originalPushState = history.pushState;
-    const originalUpdateChatHeaderModel = window.updateChatHeaderModel;
-    const originalRefreshWebSearchToggle = window.refreshWebSearchToggle;
     const hadCoverageDispatch = Object.prototype.hasOwnProperty.call(wearables.OAUTH_DISPATCH, 'coverage');
     const savedCoverageDispatch = wearables.OAUTH_DISPATCH.coverage;
 
@@ -55,6 +54,10 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
         balanceDialogs += 1;
       },
     });
+    const originalChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+      updateChatHeaderModel: () => {},
+      refreshWebSearchToggle: () => {},
+    });
 
     const resetCase = (query = '') => {
       localStorage.clear();
@@ -70,8 +73,6 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
     };
 
     try {
-      window.updateChatHeaderModel = () => {};
-      window.refreshWebSearchToggle = () => {};
       history.replaceState = function replaceStateSpy(state, title, url) {
         replaceCalls.push({ title, url });
         return originalReplaceState.call(history, state, title, url);
@@ -266,8 +267,7 @@ test('startup OAuth browser coverage handles OpenRouter and wearable callback ro
       startup.configureStartupOAuthCallbackDeps(originalStartupOAuthDeps);
       window.setTimeout = originalSetTimeout;
       history.replaceState = originalReplaceState;
-      window.updateChatHeaderModel = originalUpdateChatHeaderModel;
-      window.refreshWebSearchToggle = originalRefreshWebSearchToggle;
+      chatRuntime.configureChatRuntimeCallbacks(originalChatRuntime);
       if (hadCoverageDispatch) wearables.OAUTH_DISPATCH.coverage = savedCoverageDispatch;
       else delete wearables.OAUTH_DISPATCH.coverage;
       restoreStorage(localStorage, savedLocal);

--- a/tests/playwright/sync-helper-browser-coverage.spec.js
+++ b/tests/playwright/sync-helper-browser-coverage.spec.js
@@ -17,6 +17,7 @@ test('sync apply cutover cleanup and rebroadcast helpers cover guarded browser p
       { state },
       syncState,
       syncDelta,
+      chatRuntime,
     ] = await Promise.all([
       import(applyUrl),
       import(cleanupUrl),
@@ -25,6 +26,7 @@ test('sync apply cutover cleanup and rebroadcast helpers cover guarded browser p
       import('/js/state.js'),
       import('/js/sync-state.js'),
       import('/js/sync-delta.js'),
+      import('/js/chat-runtime.js'),
     ]);
     const outcomes = {};
     const profileId = `sync-helper-${Date.now()}`;
@@ -67,9 +69,8 @@ test('sync apply cutover cleanup and rebroadcast helpers cover guarded browser p
       },
       localStorage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
       sessionStorage: Object.fromEntries(sessionKeys.map(key => [key, sessionStorage.getItem(key)])),
-      updateChatHeaderModel: window.updateChatHeaderModel,
-      refreshWebSearchToggle: window.refreshWebSearchToggle,
     };
+    let previousChatRuntime = null;
 
     const restoreStoredValue = (store, key, value) => {
       if (value == null) store.removeItem(key);
@@ -81,8 +82,10 @@ test('sync apply cutover cleanup and rebroadcast helpers cover guarded browser p
       for (const key of sessionKeys) sessionStorage.removeItem(key);
       let headerUpdates = 0;
       let searchRefreshes = 0;
-      window.updateChatHeaderModel = () => { headerUpdates += 1; };
-      window.refreshWebSearchToggle = () => { searchRefreshes += 1; };
+      previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+        updateChatHeaderModel: () => { headerUpdates += 1; },
+        refreshWebSearchToggle: () => { searchRefreshes += 1; },
+      });
 
       localStorage.setItem('labcharts-ai-provider', 'local-openrouter');
       localStorage.setItem('labcharts-openrouter-key', 'local-secret');
@@ -222,10 +225,7 @@ test('sync apply cutover cleanup and rebroadcast helpers cover guarded browser p
       for (const [key, value] of Object.entries(saved.sessionStorage)) {
         restoreStoredValue(sessionStorage, key, value);
       }
-      if (saved.updateChatHeaderModel === undefined) delete window.updateChatHeaderModel;
-      else window.updateChatHeaderModel = saved.updateChatHeaderModel;
-      if (saved.refreshWebSearchToggle === undefined) delete window.refreshWebSearchToggle;
-      else window.refreshWebSearchToggle = saved.refreshWebSearchToggle;
+      if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
     }
 
     return outcomes;

--- a/tests/provider-model-controls-runtime.test.js
+++ b/tests/provider-model-controls-runtime.test.js
@@ -7,6 +7,7 @@ import {
   configureProviderModelControlsRuntimeDeps,
   refreshProviderModelUiRuntime,
 } from '../js/provider-model-controls-runtime.js';
+import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 
@@ -30,11 +31,11 @@ describe('provider model controls runtime adapter', () => {
     const refreshWebSearchToggle = vi.fn();
     const callClaudeAPI = vi.fn(async () => ({ content: 'ok' }));
     const previousDeps = configureProviderModelControlsRuntimeDeps({ callClaudeAPI });
-    setRuntimeWindow({
-      clearE2EESession,
+    const previousChatRuntime = configureChatRuntimeCallbacks({
       updateChatHeaderModel,
       refreshWebSearchToggle,
     });
+    setRuntimeWindow({ clearE2EESession });
 
     try {
       expect(clearProviderE2EESessionRuntime()).toBe(true);
@@ -42,6 +43,7 @@ describe('provider model controls runtime adapter', () => {
       await expect(callProviderModelSmokeTestRuntime()).resolves.toEqual({ content: 'ok' });
     } finally {
       configureProviderModelControlsRuntimeDeps(previousDeps);
+      configureChatRuntimeCallbacks(previousChatRuntime);
     }
 
     expect(clearE2EESession).toHaveBeenCalledTimes(1);
@@ -54,10 +56,18 @@ describe('provider model controls runtime adapter', () => {
   });
 
   it('uses safe no-op fallbacks when browser hooks are missing', () => {
+    const previousChatRuntime = configureChatRuntimeCallbacks({
+      refreshWebSearchToggle: null,
+      updateChatHeaderModel: null,
+    });
     delete globalThis.window;
 
-    expect(clearProviderE2EESessionRuntime()).toBe(false);
-    expect(refreshProviderModelUiRuntime()).toBe(false);
+    try {
+      expect(clearProviderE2EESessionRuntime()).toBe(false);
+      expect(refreshProviderModelUiRuntime()).toBe(false);
+    } finally {
+      configureChatRuntimeCallbacks(previousChatRuntime);
+    }
   });
 
   it('keeps provider-model-controls.js browser globals behind the adapter', () => {

--- a/tests/sync-runtime.test.js
+++ b/tests/sync-runtime.test.js
@@ -76,12 +76,16 @@ import {
 } from '../js/lab-context.js';
 import { setSyncRelay } from '../js/sync-environment.js';
 import { buildAgentAccessSetupCommand } from '../js/settings-agent-access-panel.js';
+import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 
 const PROFILE_ID = 'profile-runtime';
 const PROFILE_QUERY = Symbol('profile-query');
 const ITEM_ROW_QUERY = Symbol('item-row-query');
 let previousSyncRuntimeCallbacks;
+let previousChatRuntimeCallbacks;
 let refreshRoutstrBalance;
+let updateChatHeaderModel;
+let refreshWebSearchToggle;
 
 function deltaKey(profileId, arrayName) {
   return `labcharts-${profileId}-delta-${arrayName}`;
@@ -153,8 +157,12 @@ beforeEach(() => {
   updateKeyCache('labcharts-ppq-key', '');
   updateKeyCache('labcharts-custom-key', '');
   updateKeyCache('labcharts-cashu-wallet-mnemonic', '');
-  window.updateChatHeaderModel = vi.fn();
-  window.refreshWebSearchToggle = vi.fn();
+  updateChatHeaderModel = vi.fn();
+  refreshWebSearchToggle = vi.fn();
+  previousChatRuntimeCallbacks = configureChatRuntimeCallbacks({
+    updateChatHeaderModel,
+    refreshWebSearchToggle,
+  });
   refreshRoutstrBalance = vi.fn();
   previousSyncRuntimeCallbacks = configureSyncRuntimeCallbacks({ refreshRoutstrBalance });
   state.currentProfile = PROFILE_ID;
@@ -167,6 +175,7 @@ beforeEach(() => {
 
 afterEach(() => {
   configureSyncRuntimeCallbacks(previousSyncRuntimeCallbacks);
+  configureChatRuntimeCallbacks(previousChatRuntimeCallbacks);
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -287,8 +296,8 @@ describe('sync apply runtime behavior', () => {
     expect(localStorage.getItem('labcharts-ai-provider')).toBe('openrouter');
     expect(localStorage.getItem('labcharts-openrouter-key')).toBe('sk-remote');
     expect(localStorage.getItem('labcharts-custom-url')).toBeNull();
-    expect(window.updateChatHeaderModel).toHaveBeenCalledTimes(1);
-    expect(window.refreshWebSearchToggle).toHaveBeenCalledTimes(1);
+    expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
+    expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);
 
     sessionStorage.setItem('or_oauth_local_settings_lock_until', String(Date.now() + 60_000));
     localStorage.setItem('labcharts-ai-provider', 'local-provider');
@@ -325,14 +334,15 @@ describe('sync apply runtime behavior', () => {
     const recordOwnerEvent = event => {
       events.push(event.detail);
     };
-    window.updateChatHeaderModel = vi.fn();
-    window.refreshWebSearchToggle = vi.fn();
+    updateChatHeaderModel = vi.fn();
+    refreshWebSearchToggle = vi.fn();
+    configureChatRuntimeCallbacks({ updateChatHeaderModel, refreshWebSearchToggle });
     window.addEventListener('labcharts-sync-owner-changed', recordOwnerEvent);
 
     try {
       expect(refreshSyncedAIProviderUiRuntime()).toBe(true);
-      expect(window.updateChatHeaderModel).toHaveBeenCalledTimes(1);
-      expect(window.refreshWebSearchToggle).toHaveBeenCalledTimes(1);
+      expect(updateChatHeaderModel).toHaveBeenCalledTimes(1);
+      expect(refreshWebSearchToggle).toHaveBeenCalledTimes(1);
 
       expect(dispatchSyncOwnerChangedRuntime('owner-runtime')).toBe(true);
       expect(events.at(-1)).toEqual({ ownerId: 'owner-runtime', ready: true });

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -4,11 +4,15 @@
 import './_node-shim.js';
 import {
   closeChatModalRuntime,
+  configureChatRuntimeCallbacks,
   getChatProviderAttestation,
   getChatRegenerateCallbacks,
   isChatRuntimeStreaming,
   openChatContextModalRuntime,
+  refreshChatWebSearchToggleRuntime,
   renderChatMessagesRuntime,
+  updateChatHeaderModelRuntime,
+  updateChatNudgeRuntime,
   updateDiscussButtonRuntime,
 } from '../js/chat-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
@@ -64,6 +68,11 @@ try {
   const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
     openContextModal: () => calls.push(['context']),
   });
+  const previousChatRuntime = configureChatRuntimeCallbacks({
+    refreshWebSearchToggle: () => calls.push(['web-search']),
+    updateChatHeaderModel: () => calls.push(['header-model']),
+    updateChatNudge: () => calls.push(['nudge']),
+  });
   const ppqAttestation = { provider: 'ppq', verified: true };
   const routstrAttestation = { provider: 'routstr', verified: true };
   const veniceAttestation = { provider: 'venice', verified: true };
@@ -82,11 +91,18 @@ try {
   updateDiscussButtonRuntime();
   openChatContextModalRuntime();
   closeChatModalRuntime();
+  refreshChatWebSearchToggleRuntime();
+  updateChatHeaderModelRuntime();
+  updateChatNudgeRuntime();
   assert('chat runtime invokes render/discuss/context/close callbacks',
     calls.some(call => call[0] === 'render') &&
       calls.some(call => call[0] === 'discuss') &&
       calls.some(call => call[0] === 'context') &&
       calls.some(call => call[0] === 'close'));
+  assert('chat runtime invokes configured refresh callbacks',
+    calls.some(call => call[0] === 'web-search') &&
+      calls.some(call => call[0] === 'header-model') &&
+      calls.some(call => call[0] === 'nudge'));
 
   assert('chat runtime reports non-streaming state',
     isChatRuntimeStreaming() === false);
@@ -113,12 +129,18 @@ try {
       getChatProviderAttestation('venice') === veniceAttestation);
 
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
+  configureChatRuntimeCallbacks({
+    refreshWebSearchToggle: null,
+    updateChatHeaderModel: null,
+    updateChatNudge: null,
+  });
   delete globalThis.window;
   assert('chat runtime no-ops without a browser window',
     isChatRuntimeStreaming() === false &&
       getChatRegenerateCallbacks() === null &&
       getChatProviderAttestation('ppq') === undefined);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
+  configureChatRuntimeCallbacks(previousChatRuntime);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-context-card-lifestyle-runtime.js
+++ b/tests/test-context-card-lifestyle-runtime.js
@@ -16,6 +16,7 @@ import {
   updateLifestyleChatHeaderModelRuntime,
 } from '../js/context-card-lifestyle-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
+import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -29,7 +30,6 @@ const runtimeKeys = [
   'window',
   'closeModal',
   'navigate',
-  'updateChatHeaderModel',
   'openChatPanel',
   'useChatPrompt',
   'openContextModal',
@@ -57,13 +57,15 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  const previousChatRuntime = configureChatRuntimeCallbacks({
+    updateChatHeaderModel: () => calls.push(['chat-header']),
+  });
   const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
     openContextModal: () => calls.push(['context-modal']),
   });
   setRuntimeValue('window', globalThis);
   setRuntimeValue('closeModal', () => calls.push(['close']));
   setRuntimeValue('navigate', category => calls.push(['navigate', category]));
-  setRuntimeValue('updateChatHeaderModel', () => calls.push(['chat-header']));
   setRuntimeValue('openChatPanel', () => calls.push(['chat-panel']));
   setRuntimeValue('useChatPrompt', prompt => calls.push(['prompt', prompt]));
   setRuntimeValue('openContextModal', () => calls.push(['legacy-context-modal']));
@@ -102,6 +104,7 @@ try {
       calls.some(call => call.join('|') === 'timer|0'));
 
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
+  configureChatRuntimeCallbacks({ updateChatHeaderModel: null });
   delete globalThis.window;
   const shellCallCount = calls.filter(call => call[0] !== 'timer').length;
   closeLifestyleContextModalRuntime();
@@ -122,6 +125,7 @@ try {
       !/\bwindow(?:\.|\s*\[)/.test(editorSrc) &&
       swSrc.includes("'/js/context-card-lifestyle-runtime.js'"));
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
+  configureChatRuntimeCallbacks(previousChatRuntime);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-dashboard-knowledge-base.js
+++ b/tests/test-dashboard-knowledge-base.js
@@ -230,7 +230,7 @@ try {
       appEventsSrc.includes('"context-hub-overlay"') && appEventsSrc.includes('"ai-personalize-picker-overlay"'));
     const lensSrc = fs.readFileSync('js/lens.js', 'utf8');
     assert('saveLensKey refreshes chat header after external KB key cache updates',
-      /export\s+async\s+function\s+saveLensKey[\s\S]*updateKeyCache\(SECRET_KEY, key\)[\s\S]*updateChatHeaderModel\?\.\(\)/.test(lensSrc));
+      /export\s+async\s+function\s+saveLensKey[\s\S]*updateKeyCache\(SECRET_KEY, key\)[\s\S]*updateChatHeaderModelRuntime\(\)/.test(lensSrc));
     assert('Context hub owns optional AI data-source controls',
       dashboardAISrc.includes('renderContextSourceControls')
       && dashboardAISrc.includes('renderContextSourceSummary')

--- a/tests/test-dna-runtime.js
+++ b/tests/test-dna-runtime.js
@@ -23,6 +23,7 @@ import {
   updateDnaChatNudge,
 } from '../js/dna-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
+import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 import {
   configureDnaModuleBridge,
   getDnaModuleFunction,
@@ -53,13 +54,13 @@ const runtimeKeys = [
   'navigate',
   'showConfirmDialog',
   'triggerDNAFilePicker',
-  'updateChatNudge',
 ];
 const originals = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
 const originalError = console.error;
 const originalWarn = console.warn;
 const originalDnaRuntimeDeps = configureDnaRuntimeDeps();
 const originalContextCardsRuntime = configureContextCardsRuntimeCallbacks();
+const originalChatRuntime = configureChatRuntimeCallbacks();
 let previousViewRuntime = null;
 const previousDnaBridge = configureDnaModuleBridge({
   handleDNAFile: null,
@@ -114,7 +115,9 @@ try {
   assert('triggerDnaFilePicker delegates picker opening',
     calls.some(call => call[0] === 'triggerDNAFilePicker'));
 
-  globalThis.updateChatNudge = () => calls.push(['updateChatNudge']);
+  configureChatRuntimeCallbacks({
+    updateChatNudge: () => calls.push(['updateChatNudge']),
+  });
   updateDnaChatNudge();
   assert('updateDnaChatNudge delegates chat nudge refresh',
     calls.some(call => call[0] === 'updateChatNudge'));
@@ -188,6 +191,7 @@ try {
   configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   configureDnaRuntimeDeps(originalDnaRuntimeDeps);
   configureContextCardsRuntimeCallbacks(originalContextCardsRuntime);
+  configureChatRuntimeCallbacks(originalChatRuntime);
   console.error = originalError;
   console.warn = originalWarn;
   for (const key of runtimeKeys) {

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -30,6 +30,7 @@ console.log('=== OpenRouter Integration Tests ===\n');
 await import('../js/state.js');
 const api = await import('../js/api.js');
 const providerPanels = await import('../js/provider-panels.js');
+const chatRuntime = await import('../js/chat-runtime.js');
 
 // ─── 1. api.js source inspection ───
 console.log('1. api.js source inspection');
@@ -163,12 +164,12 @@ assert('manual OpenRouter key save clears pending OAuth restore state',
 
 let headerRefreshCount = 0;
 let webToggleRefreshCount = 0;
-const oldHeaderRefresh = window.updateChatHeaderModel;
-const oldWebToggleRefresh = window.refreshWebSearchToggle;
 const oldProviderForRefresh = localStorage.getItem('labcharts-ai-provider');
 const oldOpenRouterModelForRefresh = localStorage.getItem('labcharts-openrouter-model');
-window.updateChatHeaderModel = () => { headerRefreshCount += 1; };
-window.refreshWebSearchToggle = () => { webToggleRefreshCount += 1; };
+const oldChatRuntimeCallbacks = chatRuntime.configureChatRuntimeCallbacks({
+  updateChatHeaderModel: () => { headerRefreshCount += 1; },
+  refreshWebSearchToggle: () => { webToggleRefreshCount += 1; },
+});
 api.setAIProvider('openrouter');
 assert('setAIProvider refreshes chat header', headerRefreshCount === 1, `count=${headerRefreshCount}`);
 assert('setAIProvider refreshes web-search state', webToggleRefreshCount === 1, `count=${webToggleRefreshCount}`);
@@ -176,10 +177,7 @@ assert('setAIProvider marks AI settings as local', Number(sessionStorage.getItem
 api.setOpenRouterModel('anthropic/claude-sonnet-4.6');
 assert('setOpenRouterModel refreshes chat header', headerRefreshCount === 2, `count=${headerRefreshCount}`);
 assert('setOpenRouterModel refreshes web-search state', webToggleRefreshCount === 2, `count=${webToggleRefreshCount}`);
-if (oldHeaderRefresh) window.updateChatHeaderModel = oldHeaderRefresh;
-else delete window.updateChatHeaderModel;
-if (oldWebToggleRefresh) window.refreshWebSearchToggle = oldWebToggleRefresh;
-else delete window.refreshWebSearchToggle;
+chatRuntime.configureChatRuntimeCallbacks(oldChatRuntimeCallbacks);
 if (oldProviderForRefresh) localStorage.setItem('labcharts-ai-provider', oldProviderForRefresh);
 else localStorage.removeItem('labcharts-ai-provider');
 if (oldOpenRouterModelForRefresh) localStorage.setItem('labcharts-openrouter-model', oldOpenRouterModelForRefresh);

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -94,8 +94,13 @@ assert('App shell wires module-only chat thread consumers',
 
 assert('App shell wires Context hub status refresh without a window lookup',
   appShellHooksSrc.includes("import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js'")
-    && appShellHooksSrc.includes("import { updateChatContextStatus } from './chat-personalities.js'")
+    && appShellHooksSrc.includes("from './chat-personalities.js'")
+    && appShellHooksSrc.includes('updateChatContextStatus')
     && appShellHooksSrc.includes('configureDashboardAIContextStatus(updateChatContextStatus);'));
+
+assert('App shell wires Chat UI refreshes without window globals',
+  appShellHooksSrc.includes("import { configureChatRuntimeCallbacks } from './chat-runtime.js'")
+    && appShellHooksSrc.includes('configureChatRuntimeCallbacks({ refreshWebSearchToggle, updateChatHeaderModel, updateChatNudge });'));
 
 [
   'toggle-panel',

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -1260,8 +1260,8 @@ await import('../js/settings.js');
   assert('applyAISettings refreshes chat provider UI through sync runtime hooks',
     syncApplySrc.includes('refreshSyncedAIProviderUiRuntime()')
       && syncRuntimeSrc.includes('export function refreshSyncedAIProviderUiRuntime')
-      && syncRuntimeSrc.includes("getRuntimeFunction('updateChatHeaderModel')")
-      && syncRuntimeSrc.includes("getRuntimeFunction('refreshWebSearchToggle')")
+      && syncRuntimeSrc.includes('updateChatHeaderModelRuntime()')
+      && syncRuntimeSrc.includes('refreshChatWebSearchToggleRuntime()')
       && !syncApplySrc.includes('window.updateChatHeaderModel')
       && !syncApplySrc.includes('window.refreshWebSearchToggle'));
   assert('Newer Routstr sessions bypass stale local locks and refresh server balance',

--- a/tests/test-venice-e2ee.js
+++ b/tests/test-venice-e2ee.js
@@ -24,6 +24,7 @@ console.log('=== Venice E2EE Tests ===\n');
 // Import api.js directly for Venice provider helpers.
 const api = await import('../js/api.js');
 const cryptoMod = await import('../js/crypto.js');
+const chatRuntime = await import('../js/chat-runtime.js');
 
 // 1. Source: api.js has isE2EEModel and E2EE branch
 const apiSrc = read('js/api.js');
@@ -167,17 +168,14 @@ else localStorage.removeItem('labcharts-venice-e2ee');
 // 13b. Model setters refresh active chat UI immediately
 let veniceHeaderRefreshCount = 0;
 let veniceWebToggleRefreshCount = 0;
-const savedHeaderRefresh = window.updateChatHeaderModel;
-const savedWebToggleRefresh = window.refreshWebSearchToggle;
-window.updateChatHeaderModel = () => { veniceHeaderRefreshCount += 1; };
-window.refreshWebSearchToggle = () => { veniceWebToggleRefreshCount += 1; };
+const savedChatRuntimeCallbacks = chatRuntime.configureChatRuntimeCallbacks({
+  updateChatHeaderModel: () => { veniceHeaderRefreshCount += 1; },
+  refreshWebSearchToggle: () => { veniceWebToggleRefreshCount += 1; },
+});
 api.setVeniceModel('llama-3.3-70b');
 assert('setVeniceModel refreshes chat header', veniceHeaderRefreshCount === 1, `count=${veniceHeaderRefreshCount}`);
 assert('setVeniceModel refreshes web-search state', veniceWebToggleRefreshCount === 1, `count=${veniceWebToggleRefreshCount}`);
-if (savedHeaderRefresh) window.updateChatHeaderModel = savedHeaderRefresh;
-else delete window.updateChatHeaderModel;
-if (savedWebToggleRefresh) window.refreshWebSearchToggle = savedWebToggleRefresh;
-else delete window.refreshWebSearchToggle;
+chatRuntime.configureChatRuntimeCallbacks(savedChatRuntimeCallbacks);
 if (savedModel) localStorage.setItem('labcharts-venice-model', savedModel);
 else localStorage.removeItem('labcharts-venice-model');
 

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -245,7 +245,8 @@
     'saveChatProfile', 'saveChatLocation', 'onboardHeightUnitChanged', 'saveChatPeriod', 'addChatSupplement',
     'removeChatSupplement', 'setProviderQuizBranch', 'backToProviderQuiz', 'skipProviderSetup',
     'skipOnboardingExtras', 'showCycleNoMensesOptions', 'showCyclePeriodEntry', 'saveCycleStatus',
-    '_updatePeriodBtn', 'onContextCardSaved',
+    '_updatePeriodBtn', 'onContextCardSaved', 'refreshWebSearchToggle', 'updateChatHeaderModel',
+    'updateChatNudge',
   ];
   assert('Unused Chat APIs do not publish legacy window globals',
     formerUnusedChatGlobals.every(name => !(name in window)));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.239';
+self.APP_VERSION = '1.10.240';


### PR DESCRIPTION
## Summary
- remove `refreshWebSearchToggle`, `updateChatHeaderModel`, and `updateChatNudge` from the Chat window facade, reducing it from 22 to 19 globals
- wire cross-feature refreshes through an explicit callback bridge in `chat-runtime.js`
- migrate provider, sync, Lens, DNA, Settings, startup, and test consumers to the module API
- bump the app cache version to `1.10.240`

## Testing
- `./run-tests.sh` — Node/typecheck/vendor suites green; browser suite 351 passed with one unrelated export/import fixture failure
- isolated rerun: `npx playwright test tests/playwright/core-browser-flows.spec.js --grep "export/import browser fixture"` — 1 passed
- targeted Vitest, legacy, and Playwright coverage for all migrated consumers — green