### PR TITLE
Remove Chat shell globals

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -7,6 +7,7 @@ import { configureChatMessageActionDeps } from './chat-actions.js';
 import {
   continueDiscussion,
   endDiscussion,
+  startDiscussion,
   startDiscussionFromPicker,
 } from './chat-discussion.js';
 import {
@@ -21,19 +22,29 @@ import {
   closeChatPanel,
   configureChatPanel,
   refreshWebSearchToggle,
+  setChatWebSearchEnabled,
+  toggleChatFullscreen,
   toggleChatPanel,
 } from './chat-panel.js';
+import { clearChatHistory } from './chat-history.js';
 import { askAIAboutCorrelations } from './chat-marker-prompts.js';
 import { onContextCardSaved } from './chat-onboarding.js';
 import { updateChatNudge } from './chat-nudge.js';
-import { updateChatContextStatus, updateChatHeaderModel } from './chat-personalities.js';
+import {
+  setChatPersonality,
+  togglePersonalityBar,
+  updateChatContextStatus,
+  updateChatHeaderModel,
+} from './chat-personalities.js';
 import { configureChatRuntimeCallbacks } from './chat-runtime.js';
+import { handleChatKeydown, sendChatMessage } from './chat-send.js';
 import {
   closeSummaryModal,
   copySummary,
   deleteSavedSummary,
   downloadSummary,
   printSummary,
+  summarizeThread,
   viewSavedSummary,
 } from './chat-summaries.js';
 import { jumpToSearchResult } from './chat-thread-search.js';
@@ -68,7 +79,11 @@ import {
 import { openProfileShareModal } from './profile-share.js';
 import { getActiveProfileId } from './profile.js';
 import { configureRecommendationsRuntime } from './recommendations-runtime.js';
-import { configureShellChatImageDeps, configureShellChatThreadDeps } from './shell-actions.js';
+import {
+  configureShellChatActionDeps,
+  configureShellChatImageDeps,
+  configureShellChatThreadDeps,
+} from './shell-actions.js';
 import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
 import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
@@ -99,7 +114,12 @@ configureRecommendationsRuntime({ openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
-configureChatRuntimeCallbacks({ refreshWebSearchToggle, updateChatHeaderModel, updateChatNudge });
+configureChatRuntimeCallbacks({
+  refreshWebSearchToggle,
+  sendChatMessage,
+  updateChatHeaderModel,
+  updateChatNudge,
+});
 configureChatMessageActionDeps({
   closeSummaryModal,
   continueDiscussion,
@@ -116,6 +136,17 @@ configureChatMessageActionDeps({
 });
 configureCompareCorrelationViews({ askAIAboutCorrelations });
 configureContextCardsRuntimeCallbacks({ onContextCardSaved });
+configureShellChatActionDeps({
+  clearChatHistory,
+  handleChatKeydown,
+  sendChatMessage,
+  setChatPersonality,
+  setChatWebSearchEnabled,
+  startDiscussion,
+  summarizeThread,
+  toggleChatFullscreen,
+  togglePersonalityBar,
+});
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
 configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -4,9 +4,10 @@
 import { openContextModalRuntime } from './context-cards-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-/** @type {Record<'refreshWebSearchToggle' | 'updateChatHeaderModel' | 'updateChatNudge', Function | null>} */
+/** @type {Record<'refreshWebSearchToggle' | 'sendChatMessage' | 'updateChatHeaderModel' | 'updateChatNudge', Function | null>} */
 const chatRuntimeCallbacks = {
   refreshWebSearchToggle: null,
+  sendChatMessage: null,
   updateChatHeaderModel: null,
   updateChatNudge: null,
 };
@@ -92,7 +93,7 @@ export function isChatRuntimeStreaming() {
 
 export function getChatRegenerateCallbacks() {
   const renderChatMessages = getRuntimeFunction('renderChatMessages');
-  const sendChatMessage = getRuntimeFunction('sendChatMessage');
+  const sendChatMessage = chatRuntimeCallbacks.sendChatMessage;
   if (!renderChatMessages || !sendChatMessage) return null;
   return { renderChatMessages, sendChatMessage };
 }

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -6,26 +6,25 @@ import { configureChatThreadDeps } from './chat-threads.js';
 import { renderChatMessages } from './chat-render.js';
 import { askAIAboutMarker } from './chat-marker-prompts.js';
 import {
-  createTypewriter, getChatAbortController, handleChatKeydown,
-  isChatStreaming, sendChatMessage, setChatAbortController,
+  createTypewriter, getChatAbortController, isChatStreaming, sendChatMessage,
+  setChatAbortController,
   setSendButtonMode,
 } from './chat-send.js';
-import { renderSavedSummaries, summarizeThread } from './chat-summaries.js';
+import { renderSavedSummaries } from './chat-summaries.js';
 import {
-  getActivePersonality, setChatPersonality, togglePersonalityBar,
-  updateChatHeaderTitle, updatePersonalityBar,
+  getActivePersonality, updateChatHeaderTitle, updatePersonalityBar,
 } from './chat-personalities.js';
 import {
-  clearChatHistory, loadChatHistory, saveChatHistory,
+  loadChatHistory, saveChatHistory,
 } from './chat-history.js';
 import {
-  closeChatPanel, configureChatPanel, setChatWebSearchEnabled,
-  toggleChatFullscreen, toggleChatPanel, openChatPanel, updateChatInputState,
+  closeChatPanel, configureChatPanel, toggleChatPanel, openChatPanel,
+  updateChatInputState,
 } from './chat-panel.js';
 import { setChatNudge, updateChatNudge } from './chat-nudge.js';
 import {
   cleanupDiscussionState, configureChatDiscussion, restoreDiscussionContinuePrompt,
-  startDiscussion, updateDiscussButton,
+  updateDiscussButton,
 } from './chat-discussion.js';
 import {
   configureChatOnboarding, useChatPrompt,
@@ -67,21 +66,12 @@ configureChatThreadDeps({
 Object.assign(window, {
   _resumeAI,
   isChatStreaming,
-  toggleChatFullscreen,
-  setChatPersonality,
-  togglePersonalityBar,
   loadChatHistory,
-  clearChatHistory,
-  summarizeThread,
   renderChatMessages,
   useChatPrompt,
   toggleChatPanel,
   openChatPanel,
   closeChatPanel,
-  sendChatMessage,
-  handleChatKeydown,
-  startDiscussion,
   updateDiscussButton,
   askAIAboutMarker,
-  setChatWebSearchEnabled,
 });

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -10,6 +10,17 @@ let shellDelegatesInstalled = false;
 const shellImportDeps = { handleImportStatusClick, isImportRunning };
 const shellFeedbackDeps = { openFeedbackModal };
 const shellChatImageDeps = { toggleHDMode: () => {} };
+const shellChatActionDeps = {
+  clearChatHistory: () => {},
+  handleChatKeydown: (_event) => {},
+  sendChatMessage: () => {},
+  setChatPersonality: (_personality) => {},
+  setChatWebSearchEnabled: (_enabled) => {},
+  startDiscussion: () => {},
+  summarizeThread: () => {},
+  toggleChatFullscreen: () => {},
+  togglePersonalityBar: () => {},
+};
 const shellChatThreadDeps = {
   createNewThread: () => {},
   filterThreadList: (_value) => {},
@@ -32,6 +43,17 @@ export function configureShellFeedbackDeps(deps = {}) {
 export function configureShellChatImageDeps(deps = {}) {
   const previous = { ...shellChatImageDeps };
   if (typeof deps.toggleHDMode === 'function') shellChatImageDeps.toggleHDMode = deps.toggleHDMode;
+  return previous;
+}
+
+/** @param {Partial<typeof shellChatActionDeps>} [deps] */
+export function configureShellChatActionDeps(deps = {}) {
+  const previous = { ...shellChatActionDeps };
+  for (const name of Object.keys(shellChatActionDeps)) {
+    const key = /** @type {keyof typeof shellChatActionDeps} */ (name);
+    const callback = deps[key];
+    if (typeof callback === 'function') shellChatActionDeps[key] = callback;
+  }
   return previous;
 }
 
@@ -113,19 +135,19 @@ function runChatAction(action, actionEl) {
     shellChatThreadDeps.createNewThread();
     return true;
   } else if (action === 'summarize-thread') {
-    callShellRuntime('summarizeThread');
+    shellChatActionDeps.summarizeThread();
     return true;
   } else if (action === 'clear-history') {
-    callShellRuntime('clearChatHistory');
+    shellChatActionDeps.clearChatHistory();
     return true;
   } else if (action === 'toggle-fullscreen') {
-    callShellRuntime('toggleChatFullscreen');
+    shellChatActionDeps.toggleChatFullscreen();
     return true;
   } else if (action === 'toggle-personality') {
-    callShellRuntime('togglePersonalityBar');
+    shellChatActionDeps.togglePersonalityBar();
     return true;
   } else if (action === 'set-personality') {
-    callShellRuntime('setChatPersonality', actionEl.dataset.personality || 'default');
+    shellChatActionDeps.setChatPersonality(actionEl.dataset.personality || 'default');
     return true;
   } else if (action === 'attach-image') {
     clickFileInput('chat-image-input');
@@ -134,10 +156,10 @@ function runChatAction(action, actionEl) {
     shellChatImageDeps.toggleHDMode();
     return true;
   } else if (action === 'start-discussion') {
-    callShellRuntime('startDiscussion');
+    shellChatActionDeps.startDiscussion();
     return true;
   } else if (action === 'send-message') {
-    callShellRuntime('sendChatMessage');
+    shellChatActionDeps.sendChatMessage();
     return true;
   }
   return false;
@@ -169,7 +191,7 @@ function handleShellChange(event) {
   const input = event.target;
   if (!(input instanceof HTMLInputElement)) return;
   if (input.dataset.chatChangeAction === 'set-websearch') {
-    callShellRuntime('setChatWebSearchEnabled', input.checked);
+    shellChatActionDeps.setChatWebSearchEnabled(input.checked);
   }
 }
 
@@ -179,10 +201,10 @@ function handleShellKeydown(event) {
 
   const action = actionEl.dataset.chatKeyAction;
   if (action === 'message-input') {
-    callShellRuntime('handleChatKeydown', event);
+    shellChatActionDeps.handleChatKeydown(event);
   } else if (action === 'toggle-personality' && (event.key === 'Enter' || event.key === ' ')) {
     event.preventDefault();
-    callShellRuntime('togglePersonalityBar');
+    shellChatActionDeps.togglePersonalityBar();
   }
 }
 

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -150,8 +150,9 @@ test('chat action browser coverage handles copy and regenerate branches', async 
   await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [chatActions, chatThreads] = await Promise.all([
+    const [chatActions, chatRuntime, chatThreads] = await Promise.all([
       import('/js/chat-actions.js'),
+      import('/js/chat-runtime.js'),
       import('/js/chat-threads.js'),
     ]);
     const state = window._labState;
@@ -169,12 +170,12 @@ test('chat action browser coverage handles copy and regenerate branches', async 
       clipboardOwn: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
       isChatStreaming: window.isChatStreaming,
       renderChatMessages: window.renderChatMessages,
-      sendChatMessage: window.sendChatMessage,
       setTimeout: window.setTimeout,
       threadStorageKey,
       threadStorage: threadStorageKey ? localStorage.getItem(threadStorageKey) : null,
     };
     const timers = [];
+    let previousChatRuntime = null;
     const flush = () => new Promise(resolve => saved.setTimeout.call(window, resolve, 0));
     const makeButton = (id) => {
       const button = document.createElement('button');
@@ -256,7 +257,9 @@ test('chat action browser coverage handles copy and regenerate branches', async 
         createdInput = true;
       }
       window.renderChatMessages = () => { renderCount += 1; };
-      window.sendChatMessage = () => { sendCount += 1; };
+      previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+        sendChatMessage: () => { sendCount += 1; },
+      });
       window.isChatStreaming = () => true;
       state.currentThreadId = null;
       state.chatHistory = [
@@ -286,7 +289,7 @@ test('chat action browser coverage handles copy and regenerate branches', async 
       state.currentThreadId = saved.currentThreadId;
       window.isChatStreaming = saved.isChatStreaming;
       window.renderChatMessages = saved.renderChatMessages;
-      window.sendChatMessage = saved.sendChatMessage;
+      if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       window.setTimeout = saved.setTimeout;
       if (saved.clipboardOwn) Object.defineProperty(navigator, 'clipboard', saved.clipboardOwn);
       else delete navigator.clipboard;

--- a/tests/playwright/chat-ui-browser-coverage.spec.js
+++ b/tests/playwright/chat-ui-browser-coverage.spec.js
@@ -689,8 +689,8 @@ test('chat discussion picker lifecycle and resume binding cover browser state pa
       localStorage.setItem('labcharts-ai-paused', 'true');
       window._resumeAI();
       outcomes.resumeBindingUnpausesAndKeepsChatImageHelpersModuleOnly = localStorage.getItem('labcharts-ai-paused') === 'false'
-        && typeof window.summarizeThread === 'function'
-        && typeof window.startDiscussion === 'function'
+        && !('summarizeThread' in window)
+        && !('startDiscussion' in window)
         && typeof window.clearAttachments === 'undefined';
     } finally {
       state.currentProfile = original.currentProfile;

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -33,6 +33,17 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     const previousShellChatImageDeps = shellActions.configureShellChatImageDeps({
       toggleHDMode: () => calls.push(['toggleHDMode']),
     });
+    const previousShellChatActionDeps = shellActions.configureShellChatActionDeps({
+      clearChatHistory: () => calls.push(['clearChatHistory']),
+      handleChatKeydown: event => calls.push(['handleChatKeydown', event]),
+      sendChatMessage: () => calls.push(['sendChatMessage']),
+      setChatPersonality: personality => calls.push(['setChatPersonality', personality]),
+      setChatWebSearchEnabled: enabled => calls.push(['setChatWebSearchEnabled', enabled]),
+      startDiscussion: () => calls.push(['startDiscussion']),
+      summarizeThread: () => calls.push(['summarizeThread']),
+      toggleChatFullscreen: () => calls.push(['toggleChatFullscreen']),
+      togglePersonalityBar: () => calls.push(['togglePersonalityBar']),
+    });
     const previousShellChatThreadDeps = shellActions.configureShellChatThreadDeps({
       createNewThread: () => calls.push(['createNewThread']),
       filterThreadList: value => calls.push(['filterThreadList', value]),
@@ -46,15 +57,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       openProfileShareModal: window.openProfileShareModal,
       toggleChatPanel: window.toggleChatPanel,
       closeChatPanel: window.closeChatPanel,
-      summarizeThread: window.summarizeThread,
-      clearChatHistory: window.clearChatHistory,
-      toggleChatFullscreen: window.toggleChatFullscreen,
-      togglePersonalityBar: window.togglePersonalityBar,
-      setChatPersonality: window.setChatPersonality,
-      startDiscussion: window.startDiscussion,
-      sendChatMessage: window.sendChatMessage,
-      setChatWebSearchEnabled: window.setChatWebSearchEnabled,
-      handleChatKeydown: window.handleChatKeydown,
     };
     const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
       openTweaksPanel: (...args) => calls.push(['openTweaksPanel', ...args]),
@@ -209,6 +211,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       });
       shellActions.configureShellImportDeps(previousShellImportDeps);
       shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
+      shellActions.configureShellChatActionDeps(previousShellChatActionDeps);
       shellActions.configureShellChatImageDeps(previousShellChatImageDeps);
       shellActions.configureShellChatThreadDeps(previousShellChatThreadDeps);
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -43,6 +43,7 @@ const {
 const {
   clearCurrentDiscussionThreadState, reopenCurrentDiscussionThread,
 } = await import('../js/chat-discussion-state.js');
+const { startDiscussion } = await import('../js/chat-discussion.js');
 const {
   DEFAULT_DISCUSS_PROMPT, DISCUSSION_JOIN_PROMPT, INITIAL_DISCUSS_PROMPT,
   buildDiscussionAutoMessage, buildDiscussionJoinMessage, getDiscussionPromptText,
@@ -431,7 +432,7 @@ assert('regenerateLastMessage checks streaming state via chat runtime',
 assert('regenerateLastMessage checks render/send callbacks before mutating',
   chatActionsSrc.indexOf('const callbacks = getChatRegenerateCallbacks()') < chatActionsSrc.indexOf('state.chatHistory.pop()')
     && chatRuntimeSrc.includes("getRuntimeFunction('renderChatMessages')")
-    && chatRuntimeSrc.includes("getRuntimeFunction('sendChatMessage')"), 'found');
+    && chatRuntimeSrc.includes('chatRuntimeCallbacks.sendChatMessage'), 'found');
 const directWindowGlobalRe = /\bwindow(?:\.|\s*\[)/;
 const chatRuntimeDelegates = [
   ['chat-actions.js', chatActionsSrc],
@@ -583,8 +584,8 @@ assert('chat-discussion-picker.js owns discussion picker DOM and selection',
     !chatDiscussionUiSrc.includes("querySelector('.discuss-persona-picker')"),
   'found');
 assert('Discuss button does not duplicate inline Continue',
-  window.startDiscussion.toString().includes('showDiscussPersonaPicker') &&
-    !window.startDiscussion.toString().includes('_runDiscussion'),
+  startDiscussion.toString().includes('showDiscussPersonaPicker') &&
+    !startDiscussion.toString().includes('_runDiscussion'),
   'opens persona picker instead of running another round directly');
 assert('chat-discussion-round-request.js owns round API request setup',
   chatDiscussionRoundRunnerSrc.includes("from './chat-discussion-round-request.js'") &&

--- a/tests/test-chat-panel-ux.js
+++ b/tests/test-chat-panel-ux.js
@@ -16,6 +16,7 @@ return (async function() {
   }
 
   console.log('%c Chat panel UX tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
+  const { toggleChatFullscreen } = await import('/js/chat-panel.js');
 
   // Snapshot localStorage so the test doesn't bleed user state.
   const savedFullscreen = localStorage.getItem('labcharts-chat-fullscreen');
@@ -27,8 +28,8 @@ return (async function() {
   try {
     // ─── 1. Window exports ────────────────────────────────────
     {
-      assert('window.toggleChatFullscreen exists',
-        typeof window.toggleChatFullscreen === 'function');
+      assert('toggleChatFullscreen stays module-only',
+        !('toggleChatFullscreen' in window));
       assert('window.openChatPanel exists',
         typeof window.openChatPanel === 'function');
       assert('window.closeChatPanel exists',
@@ -74,13 +75,13 @@ return (async function() {
       panel.classList.remove('chat-panel-fullscreen');
       localStorage.removeItem('labcharts-chat-fullscreen');
 
-      window.toggleChatFullscreen();
+      toggleChatFullscreen();
       assert('toggleChatFullscreen ON adds .chat-panel-fullscreen',
         panel.classList.contains('chat-panel-fullscreen'));
       assert('toggleChatFullscreen ON saves "true" to localStorage',
         localStorage.getItem('labcharts-chat-fullscreen') === 'true');
 
-      window.toggleChatFullscreen();
+      toggleChatFullscreen();
       assert('toggleChatFullscreen OFF removes .chat-panel-fullscreen',
         !panel.classList.contains('chat-panel-fullscreen'));
       assert('toggleChatFullscreen OFF saves "false" to localStorage',
@@ -151,7 +152,7 @@ return (async function() {
       const panel = document.getElementById('chat-panel');
       window.openChatPanel();
       await new Promise(r => setTimeout(r, 50));
-      window.toggleChatFullscreen(); // ON
+      toggleChatFullscreen(); // ON
       await new Promise(r => setTimeout(r, 50));
       window.closeChatPanel();
       panel.classList.remove('chat-panel-fullscreen'); // simulate fresh DOM
@@ -174,11 +175,11 @@ return (async function() {
       assert('opening chat with fullscreen=false does not add body.chat-fullscreen',
         !document.body.classList.contains('chat-fullscreen'));
 
-      window.toggleChatFullscreen(); // ON
+      toggleChatFullscreen(); // ON
       assert('toggling fullscreen ON mirrors body.chat-fullscreen',
         document.body.classList.contains('chat-fullscreen'));
 
-      window.toggleChatFullscreen(); // OFF
+      toggleChatFullscreen(); // OFF
       assert('toggling fullscreen OFF removes body.chat-fullscreen',
         !document.body.classList.contains('chat-fullscreen'));
 
@@ -201,14 +202,14 @@ return (async function() {
           `before: ${beforePadding}px / after: ${afterPadding}px`);
 
         // Toggle fullscreen — padding should drop back down (chat covers all)
-        window.toggleChatFullscreen();
+        toggleChatFullscreen();
         await new Promise(r => setTimeout(r, 400));
         const fullscreenPadding = parseFloat(getComputedStyle(main).paddingRight);
         assert('fullscreen mode releases the shift (padding-right drops)',
           fullscreenPadding < afterPadding - 100,
           `non-fullscreen: ${afterPadding}px / fullscreen: ${fullscreenPadding}px`);
 
-        window.toggleChatFullscreen(); // back to non-fullscreen
+        toggleChatFullscreen(); // back to non-fullscreen
         await new Promise(r => setTimeout(r, 100));
         window.closeChatPanel();
         // Wait past the 0.3s transition + a generous margin.

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -70,6 +70,7 @@ try {
   });
   const previousChatRuntime = configureChatRuntimeCallbacks({
     refreshWebSearchToggle: () => calls.push(['web-search']),
+    sendChatMessage: () => calls.push(['send']),
     updateChatHeaderModel: () => calls.push(['header-model']),
     updateChatNudge: () => calls.push(['nudge']),
   });
@@ -82,7 +83,6 @@ try {
   setRuntimeValue('openContextModal', () => calls.push(['legacy-context']));
   setRuntimeValue('closeModal', () => calls.push(['close']));
   setRuntimeValue('isChatStreaming', () => false);
-  setRuntimeValue('sendChatMessage', () => calls.push(['send']));
   setRuntimeValue('_ppqAttestation', ppqAttestation);
   setRuntimeValue('_routstrAttestation', routstrAttestation);
   setRuntimeValue('_veniceAttestation', veniceAttestation);
@@ -119,7 +119,7 @@ try {
       calls.filter(call => call[0] === 'render').length === 2 &&
       calls.filter(call => call[0] === 'send').length === 1);
 
-  delete globalThis.sendChatMessage;
+  configureChatRuntimeCallbacks({ sendChatMessage: null });
   assert('chat runtime requires send callback for regeneration',
     getChatRegenerateCallbacks() === null);
 
@@ -131,6 +131,7 @@ try {
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
   configureChatRuntimeCallbacks({
     refreshWebSearchToggle: null,
+    sendChatMessage: null,
     updateChatHeaderModel: null,
     updateChatNudge: null,
   });

--- a/tests/test-custom-personality.js
+++ b/tests/test-custom-personality.js
@@ -35,6 +35,7 @@ await import('../js/chat.js');
 const personalities = await import('../js/chat-personalities.js');
 const chatHistory = await import('../js/chat-history.js');
 const chatDiscussion = await import('../js/chat-discussion.js');
+const chatSend = await import('../js/chat-send.js');
 const { buildPersonalityPrompt } = await import('../js/chat-prompt-context.js');
 const { createNewThread } = await import('../js/chat-threads.js');
 
@@ -169,7 +170,7 @@ assert('CHAT_PERSONALITIES no custom entry', !constantsSrc.includes("id: 'custom
 
 // ── 13. sendChatMessage uses custom_ prefix check ──
 console.log('13. custom personality prompt context');
-const sendSrc = window.sendChatMessage.toString();
+const sendSrc = chatSend.sendChatMessage.toString();
 const promptContextSrc = read('js/chat-prompt-context.js');
 assert('sendChatMessage delegates personality prompt helper', sendSrc.includes('buildPersonalityPrompt'));
 assert('prompt context checks custom_ prefix', promptContextSrc.includes("startsWith('custom_')") || promptContextSrc.includes('startsWith("custom_")'));
@@ -198,8 +199,9 @@ assert('SW CACHE_NAME uses semver', swSrc.includes('`labcharts-v${self.APP_VERSI
 
 // ── 18. Stop button exports ──
 console.log('18. Stop button');
-assert('sendChatMessage exported', typeof window.sendChatMessage === 'function');
-const sendSrc2 = window.sendChatMessage.toString();
+assert('sendChatMessage exported', typeof chatSend.sendChatMessage === 'function');
+assert('sendChatMessage stays module-only', !('sendChatMessage' in window));
+const sendSrc2 = chatSend.sendChatMessage.toString();
 assert('sendChatMessage checks _chatAbortController', sendSrc2.includes('_chatAbortController'));
 assert('sendChatMessage calls abort()', sendSrc2.includes('.abort()'));
 assert('sendChatMessage passes signal', sendSrc2.includes('signal:'));
@@ -217,7 +219,8 @@ assert('CSS has .chat-stopped-note', css.includes('.chat-stopped-note'));
 
 // ── 20. Discuss button exports ──
 console.log('20. Discuss button exports');
-assert('startDiscussion exported', typeof window.startDiscussion === 'function');
+assert('startDiscussion exported', typeof chatDiscussion.startDiscussion === 'function');
+assert('startDiscussion stays module-only', !('startDiscussion' in window));
 assert('continueDiscussion exported', typeof chatDiscussion.continueDiscussion === 'function');
 assert('endDiscussion exported', typeof chatDiscussion.endDiscussion === 'function');
 assert('updateDiscussButton exported', typeof window.updateDiscussButton === 'function');
@@ -256,7 +259,7 @@ assert('renderChatMessages checks msg.stopped', renderSrc2.includes('msg.stopped
 
 // ── 26. startDiscussion source ──
 console.log('26. startDiscussion source');
-const discSrc = window.startDiscussion.toString();
+const discSrc = chatDiscussion.startDiscussion.toString();
 assert('startDiscussion shows persona picker', discSrc.includes('showDiscussPersonaPicker'));
 const pickerSrc = chatDiscussion.startDiscussionFromPicker.toString();
 assert('startDiscussionFromPicker delegates to runDiscussion', pickerSrc.includes('runDiscussion'));

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -100,7 +100,17 @@ assert('App shell wires Context hub status refresh without a window lookup',
 
 assert('App shell wires Chat UI refreshes without window globals',
   appShellHooksSrc.includes("import { configureChatRuntimeCallbacks } from './chat-runtime.js'")
-    && appShellHooksSrc.includes('configureChatRuntimeCallbacks({ refreshWebSearchToggle, updateChatHeaderModel, updateChatNudge });'));
+    && appShellHooksSrc.includes('configureChatRuntimeCallbacks({')
+    && appShellHooksSrc.includes('refreshWebSearchToggle,')
+    && appShellHooksSrc.includes('sendChatMessage,'));
+
+assert('Chat shell controls use module dependencies instead of window lookups',
+  ['clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
+    'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',
+    'togglePersonalityBar']
+    .every(name => shellSrc.includes(`shellChatActionDeps.${name}`)
+      && !shellSrc.includes(`callShellRuntime('${name}'`))
+    && appShellHooksSrc.includes('configureShellChatActionDeps({'));
 
 [
   'toggle-panel',
@@ -129,13 +139,13 @@ assert('Thread search uses delegated input/search action',
 assert('Web search toggle uses delegated change action',
   html.includes('data-chat-change-action="set-websearch"')
     && shellSrc.includes("document.addEventListener('change', handleShellChange)")
-    && shellSrc.includes("callShellRuntime('setChatWebSearchEnabled', input.checked)"));
+    && shellSrc.includes('shellChatActionDeps.setChatWebSearchEnabled(input.checked)'));
 assert('Chat key handlers are delegated',
   html.includes('data-chat-key-action="message-input"')
     && html.includes('data-chat-key-action="toggle-personality"')
     && shellSrc.includes("document.addEventListener('keydown', handleShellKeydown)")
-    && shellSrc.includes("callShellRuntime('handleChatKeydown', event)")
-    && shellSrc.includes("callShellRuntime('togglePersonalityBar')"));
+    && shellSrc.includes('shellChatActionDeps.handleChatKeydown(event)')
+    && shellSrc.includes('shellChatActionDeps.togglePersonalityBar()'));
 assert('Click delegate only prevents default for handled actions',
   shellSrc.includes('const handled = shellAction')
     && shellSrc.includes('if (handled) event.preventDefault();')

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -245,8 +245,10 @@
     'saveChatProfile', 'saveChatLocation', 'onboardHeightUnitChanged', 'saveChatPeriod', 'addChatSupplement',
     'removeChatSupplement', 'setProviderQuizBranch', 'backToProviderQuiz', 'skipProviderSetup',
     'skipOnboardingExtras', 'showCycleNoMensesOptions', 'showCyclePeriodEntry', 'saveCycleStatus',
-    '_updatePeriodBtn', 'onContextCardSaved', 'refreshWebSearchToggle', 'updateChatHeaderModel',
-    'updateChatNudge',
+    '_updatePeriodBtn', 'onContextCardSaved', 'clearChatHistory', 'handleChatKeydown',
+    'refreshWebSearchToggle', 'sendChatMessage', 'setChatPersonality', 'setChatWebSearchEnabled',
+    'startDiscussion', 'summarizeThread', 'toggleChatFullscreen', 'togglePersonalityBar',
+    'updateChatHeaderModel', 'updateChatNudge',
   ];
   assert('Unused Chat APIs do not publish legacy window globals',
     formerUnusedChatGlobals.every(name => !(name in window)));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.240';
+self.APP_VERSION = '1.10.241';


### PR DESCRIPTION
## Summary
- remove nine delegated Chat controls from the legacy `window` facade, reducing it from 19 to 10 globals
- inject shell action handlers directly into `shell-actions.js` from `app-shell-hooks.js`
- route regenerate-message sending through the existing Chat runtime callback registry
- migrate browser and source-guard tests to the module APIs
- bump the app cache version to `1.10.241`

## Testing
- `./run-tests.sh` — all checks green
  - 398 Vitest tests
  - 352 Playwright tests
  - 472 responsive theme cases
  - TypeScript/checkJs, vendor verification, and module verification
- targeted Chat shell, regenerate, discussion, and fullscreen Playwright coverage — 13 passed