### PR TITLE
Remove Chat render globals

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -9,6 +9,7 @@ import {
   endDiscussion,
   startDiscussion,
   startDiscussionFromPicker,
+  updateDiscussButton,
 } from './chat-discussion.js';
 import {
   initChatImageHandlers,
@@ -37,7 +38,8 @@ import {
   updateChatHeaderModel,
 } from './chat-personalities.js';
 import { configureChatRuntimeCallbacks } from './chat-runtime.js';
-import { handleChatKeydown, sendChatMessage } from './chat-send.js';
+import { renderChatMessages } from './chat-render.js';
+import { handleChatKeydown, isChatStreaming, sendChatMessage } from './chat-send.js';
 import {
   closeSummaryModal,
   copySummary,
@@ -115,8 +117,11 @@ configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
 configureChatRuntimeCallbacks({
+  isChatStreaming,
   refreshWebSearchToggle,
+  renderChatMessages,
   sendChatMessage,
+  updateDiscussButton,
   updateChatHeaderModel,
   updateChatNudge,
 });

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -4,12 +4,15 @@
 import { openContextModalRuntime } from './context-cards-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-/** @type {Record<'refreshWebSearchToggle' | 'sendChatMessage' | 'updateChatHeaderModel' | 'updateChatNudge', Function | null>} */
+/** @type {Record<'isChatStreaming' | 'refreshWebSearchToggle' | 'renderChatMessages' | 'sendChatMessage' | 'updateChatHeaderModel' | 'updateChatNudge' | 'updateDiscussButton', Function | null>} */
 const chatRuntimeCallbacks = {
+  isChatStreaming: null,
   refreshWebSearchToggle: null,
+  renderChatMessages: null,
   sendChatMessage: null,
   updateChatHeaderModel: null,
   updateChatNudge: null,
+  updateDiscussButton: null,
 };
 
 /** @param {Partial<Record<keyof typeof chatRuntimeCallbacks, Function | null>>} [callbacks] */
@@ -60,7 +63,7 @@ function getRuntimeValue(name) {
 }
 
 export function renderChatMessagesRuntime() {
-  getRuntimeFunction('renderChatMessages')?.();
+  callChatRuntimeCallback('renderChatMessages');
 }
 
 export function refreshChatWebSearchToggleRuntime() {
@@ -76,7 +79,7 @@ export function updateChatNudgeRuntime() {
 }
 
 export function updateDiscussButtonRuntime() {
-  getRuntimeFunction('updateDiscussButton')?.();
+  callChatRuntimeCallback('updateDiscussButton');
 }
 
 export function openChatContextModalRuntime() {
@@ -88,11 +91,11 @@ export function closeChatModalRuntime() {
 }
 
 export function isChatRuntimeStreaming() {
-  return Boolean(getRuntimeFunction('isChatStreaming')?.());
+  return Boolean(chatRuntimeCallbacks.isChatStreaming?.());
 }
 
 export function getChatRegenerateCallbacks() {
-  const renderChatMessages = getRuntimeFunction('renderChatMessages');
+  const renderChatMessages = chatRuntimeCallbacks.renderChatMessages;
   const sendChatMessage = chatRuntimeCallbacks.sendChatMessage;
   if (!renderChatMessages || !sendChatMessage) return null;
   return { renderChatMessages, sendChatMessage };

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -6,7 +6,7 @@ import { configureChatThreadDeps } from './chat-threads.js';
 import { renderChatMessages } from './chat-render.js';
 import { askAIAboutMarker } from './chat-marker-prompts.js';
 import {
-  createTypewriter, getChatAbortController, isChatStreaming, sendChatMessage,
+  createTypewriter, getChatAbortController, sendChatMessage,
   setChatAbortController,
   setSendButtonMode,
 } from './chat-send.js';
@@ -24,7 +24,6 @@ import {
 import { setChatNudge, updateChatNudge } from './chat-nudge.js';
 import {
   cleanupDiscussionState, configureChatDiscussion, restoreDiscussionContinuePrompt,
-  updateDiscussButton,
 } from './chat-discussion.js';
 import {
   configureChatOnboarding, useChatPrompt,
@@ -65,13 +64,10 @@ configureChatThreadDeps({
 
 Object.assign(window, {
   _resumeAI,
-  isChatStreaming,
   loadChatHistory,
-  renderChatMessages,
   useChatPrompt,
   toggleChatPanel,
   openChatPanel,
   closeChatPanel,
-  updateDiscussButton,
   askAIAboutMarker,
 });

--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -2,6 +2,7 @@
 // onboarding-view-runtime.js - Browser runtime adapters for dashboard onboarding hooks.
 
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { renderChatMessagesRuntime } from './chat-runtime.js';
 
 const onboardingViewRuntimeDeps = {
   createNewThread: /** @type {null | (() => void)} */ (null),
@@ -79,5 +80,5 @@ export function createOnboardingChatThreadRuntime() {
 }
 
 export function renderOnboardingChatMessagesRuntime() {
-  getRuntimeFunction('renderChatMessages')?.();
+  renderChatMessagesRuntime();
 }

--- a/tests/playwright/chat-actions-dom.spec.js
+++ b/tests/playwright/chat-actions-dom.spec.js
@@ -2,14 +2,12 @@ import { expect, test } from './coverage-fixture.js';
 
 test('chat action bars, clipboard, and context toggles work in the live DOM', async ({ page }) => {
   await page.goto('/app', { waitUntil: 'load' });
-  await page.waitForFunction(() =>
-    typeof window.renderChatMessages === 'function'
-      && !!window._labState
-  );
+  await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
     const api = await import('/js/api.js');
     const chatActions = await import('/js/chat-actions.js');
+    const chatRender = await import('/js/chat-render.js');
     const state = window._labState;
     const originalHistory = JSON.parse(JSON.stringify(state.chatHistory || []));
     const outcomes = {};
@@ -25,7 +23,7 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
       const realContainer = document.getElementById('chat-messages');
       const hasProvider = api.hasAIProvider();
       if (realContainer && hasProvider) {
-        window.renderChatMessages();
+        chatRender.renderChatMessages();
         const aiMsgs = realContainer.querySelectorAll('.chat-msg.chat-ai');
         const userMsgs = realContainer.querySelectorAll('.chat-msg.chat-user');
         outcomes.aiMessagesHaveActionBars = aiMsgs.length > 0 && aiMsgs[0].querySelector('.chat-action-bar') !== null;
@@ -125,7 +123,7 @@ test('chat action bars, clipboard, and context toggles work in the live DOM', as
             lensSources: [{ source: 'notes.md', score: 0.75, text: 'Relevant excerpt' }],
             lensSourceName: 'notes',
           }];
-          window.renderChatMessages();
+          chatRender.renderChatMessages();
           const lensSummary = realContainer.querySelector('.chat-lens-source-summary');
           lensSummary?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
           outcomes.renderedContainClickStopsAtElement = !!lensSummary && bubbled === 0;
@@ -168,8 +166,6 @@ test('chat action browser coverage handles copy and regenerate branches', async 
       chatHistory: JSON.parse(JSON.stringify(state.chatHistory || [])),
       currentThreadId: state.currentThreadId,
       clipboardOwn: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
-      isChatStreaming: window.isChatStreaming,
-      renderChatMessages: window.renderChatMessages,
       setTimeout: window.setTimeout,
       threadStorageKey,
       threadStorage: threadStorageKey ? localStorage.getItem(threadStorageKey) : null,
@@ -256,11 +252,11 @@ test('chat action browser coverage handles copy and regenerate branches', async 
         document.body.appendChild(input);
         createdInput = true;
       }
-      window.renderChatMessages = () => { renderCount += 1; };
       previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+        isChatStreaming: () => true,
+        renderChatMessages: () => { renderCount += 1; },
         sendChatMessage: () => { sendCount += 1; },
       });
-      window.isChatStreaming = () => true;
       state.currentThreadId = null;
       state.chatHistory = [
         { role: 'user', content: 'Streaming guard' },
@@ -271,7 +267,7 @@ test('chat action browser coverage handles copy and regenerate branches', async 
         && sendCount === 0
         && state.chatHistory.length === 2;
 
-      window.isChatStreaming = () => false;
+      chatRuntime.configureChatRuntimeCallbacks({ isChatStreaming: () => false });
       state.chatHistory = [
         { role: 'assistant', content: 'Earlier assistant' },
         { role: 'user', content: 'Repeat this prompt' },
@@ -287,8 +283,6 @@ test('chat action browser coverage handles copy and regenerate branches', async 
     } finally {
       state.chatHistory = saved.chatHistory;
       state.currentThreadId = saved.currentThreadId;
-      window.isChatStreaming = saved.isChatStreaming;
-      window.renderChatMessages = saved.renderChatMessages;
       if (previousChatRuntime) chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       window.setTimeout = saved.setTimeout;
       if (saved.clipboardOwn) Object.defineProperty(navigator, 'clipboard', saved.clipboardOwn);

--- a/tests/playwright/chat-history-diagnose-browser-coverage.spec.js
+++ b/tests/playwright/chat-history-diagnose-browser-coverage.spec.js
@@ -23,13 +23,14 @@ test('chat history browser coverage saves loads clears and updates thread state'
   await openBlankPage(page, '/chat-history-browser-coverage');
 
   const results = await page.evaluate(async ({ chatHistoryUrl }) => {
-    const [{ state }, chatHistory, threads, profile, cryptoStore, blobStorage] = await Promise.all([
+    const [{ state }, chatHistory, threads, profile, cryptoStore, blobStorage, chatRuntime] = await Promise.all([
       import('/js/state.js'),
       import(chatHistoryUrl),
       import('/js/chat-threads.js'),
       import('/js/profile.js'),
       import('/js/crypto.js'),
       import('/js/blob-storage.js'),
+      import('/js/chat-runtime.js'),
     ]);
     const storage = new Map(
       Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index))
@@ -43,8 +44,6 @@ test('chat history browser coverage saves loads clears and updates thread state'
       currentThreadId: state.currentThreadId,
       currentChatPersonality: state.currentChatPersonality,
       importedData: state.importedData,
-      renderChatMessages: window.renderChatMessages,
-      updateDiscussButton: window.updateDiscussButton,
       bodyHTML: document.body.innerHTML,
     };
     const profileId = 'coverage-chat-history-profile';
@@ -52,6 +51,10 @@ test('chat history browser coverage saves loads clears and updates thread state'
     const outcomes = {};
     let renderCalls = 0;
     let discussCalls = 0;
+    const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+      renderChatMessages: () => { renderCalls += 1; },
+      updateDiscussButton: () => { discussCalls += 1; },
+    });
     const waitFor = async (predicate, label, timeoutMs = 1000) => {
       const start = Date.now();
       while (Date.now() - start < timeoutMs) {
@@ -71,9 +74,6 @@ test('chat history browser coverage saves loads clears and updates thread state'
         <div class="chat-header-title"></div>
         <button class="chat-summary-btn" type="button"></button>
       `;
-      window.renderChatMessages = () => { renderCalls += 1; };
-      window.updateDiscussButton = () => { discussCalls += 1; };
-
       state.currentProfile = profileId;
       state.currentChatPersonality = 'default';
       state.currentThreadId = null;
@@ -184,8 +184,7 @@ test('chat history browser coverage saves loads clears and updates thread state'
       state.currentThreadId = original.currentThreadId;
       state.currentChatPersonality = original.currentChatPersonality;
       state.importedData = original.importedData;
-      window.renderChatMessages = original.renderChatMessages;
-      window.updateDiscussButton = original.updateDiscussButton;
+      chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       await blobStorage.deleteBlob(importedKey);
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/custom-personality-dom.spec.js
+++ b/tests/playwright/custom-personality-dom.spec.js
@@ -314,9 +314,10 @@ test('custom personality save path updates picker, header, and persisted state',
   await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, chatPersonalities] = await Promise.all([
+    const [{ state }, chatPersonalities, chatRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/chat-personalities.js'),
+      import('/js/chat-runtime.js'),
     ]);
     const storage = new Map(Array.from({ length: localStorage.length }, (_, index) => {
       const key = localStorage.key(index);
@@ -328,9 +329,11 @@ test('custom personality save path updates picker, header, and persisted state',
       chatThreads: state.chatThreads,
       currentThreadId: state.currentThreadId,
       currentChatPersonality: state.currentChatPersonality,
-      renderChatMessages: window.renderChatMessages,
       dateNow: Date.now,
     };
+    const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+      renderChatMessages: () => {},
+    });
     const outcomes = {};
     const waitFor = async (predicate, timeoutMs = 1000) => {
       const start = performance.now();
@@ -359,8 +362,6 @@ test('custom personality save path updates picker, header, and persisted state',
         { role: 'assistant', personalityName: 'Analyst One', personalityIcon: 'A', content: 'First view' },
         { role: 'assistant', personalityName: 'Coach Two', personalityIcon: 'C', content: 'Second view' },
       ];
-      window.renderChatMessages = () => {};
-
       const customKey = `labcharts-${state.currentProfile}-chatPersonalityCustom`;
       const personalityKey = `labcharts-${state.currentProfile}-chatPersonality`;
       localStorage.setItem(customKey, '[]');
@@ -474,7 +475,7 @@ test('custom personality save path updates picker, header, and persisted state',
       state.chatThreads = original.chatThreads;
       state.currentThreadId = original.currentThreadId;
       state.currentChatPersonality = original.currentChatPersonality;
-      window.renderChatMessages = original.renderChatMessages;
+      chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       document.getElementById('confirm-dialog-overlay')?.remove();
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -231,13 +231,14 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ onboardingUrl }) => {
-    const [onboarding, { state }, profile, data, crypto, viewRuntime] = await Promise.all([
+    const [onboarding, { state }, profile, data, crypto, viewRuntime, chatRuntime] = await Promise.all([
       import(onboardingUrl),
       import('/js/state.js'),
       import('/js/profile.js'),
       import('/js/data.js'),
       import('/js/crypto.js'),
       import('/js/views-runtime-bridge.js'),
+      import('/js/chat-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
@@ -264,13 +265,15 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       navigate: window.navigate,
       openChatPanel: window.openChatPanel,
       toggleChatPanel: window.toggleChatPanel,
-      renderChatMessages: window.renderChatMessages,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
     const outcomes = {};
     const calls = [];
     const previousViewRuntime = viewRuntime.configureViewRuntime({
       buildSidebar: payload => calls.push(['sidebar', !!payload]),
+    });
+    const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+      renderChatMessages: () => calls.push(['render-chat']),
     });
     const host = document.createElement('div');
     host.id = 'onboarding-coverage-host';
@@ -343,7 +346,6 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
 
       window.openChatPanel = () => calls.push(['open-chat']);
       window.toggleChatPanel = () => calls.push(['toggle-chat']);
-      window.renderChatMessages = () => calls.push(['render-chat']);
       sessionStorage.setItem(`chat-onboard-provider-branch-${state.currentProfile}`, 'manual');
       host.querySelector('.ai-reminder-cta')?.click();
       outcomes.providerQuizClearsSkipAndOpensChat =
@@ -419,10 +421,10 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       data.invalidateActiveDataCache();
       onboarding.configureOnboardingView({ navigate: saved.navigate });
       viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
+      chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       Object.assign(window, {
         openChatPanel: saved.openChatPanel,
         toggleChatPanel: saved.toggleChatPanel,
-        renderChatMessages: saved.renderChatMessages,
       });
       Element.prototype.scrollIntoView = saved.scrollIntoView;
       localStorage.clear();

--- a/tests/test-chat-actions.js
+++ b/tests/test-chat-actions.js
@@ -43,7 +43,7 @@ const {
 const {
   clearCurrentDiscussionThreadState, reopenCurrentDiscussionThread,
 } = await import('../js/chat-discussion-state.js');
-const { startDiscussion } = await import('../js/chat-discussion.js');
+const { startDiscussion, updateDiscussButton } = await import('../js/chat-discussion.js');
 const {
   DEFAULT_DISCUSS_PROMPT, DISCUSSION_JOIN_PROMPT, INITIAL_DISCUSS_PROMPT,
   buildDiscussionAutoMessage, buildDiscussionJoinMessage, getDiscussionPromptText,
@@ -75,11 +75,11 @@ if (hasState) {
   document.getElementById = (id) => (id === 'chat-discuss-btn' ? btn : origGetElementById.call(document, id));
 
   S.chatHistory = [{ role: 'user', content: 'No assistant yet' }];
-  window.updateDiscussButton();
+  updateDiscussButton();
   assert('Discuss button hides without assistant messages', btn.style.display === 'none', btn.style.display);
 
   S.chatHistory = [{ role: 'assistant', content: 'Direct reply' }];
-  window.updateDiscussButton();
+  updateDiscussButton();
   assert('Discuss button shows after assistant response', btn.style.display === 'flex', btn.style.display);
   assert('Discuss button prompts second opinion for one persona', btn.style.opacity === '0.5' && btn.title.includes('second opinion'), btn.title);
 
@@ -87,7 +87,7 @@ if (hasState) {
     { role: 'assistant', personalityName: 'Analyst A', content: 'First' },
     { role: 'assistant', personalityName: 'Analyst B', content: 'Second' },
   ];
-  window.updateDiscussButton();
+  updateDiscussButton();
   assert('Discuss button adds another persona for two discussion personas', btn.style.opacity === '1' && btn.title.includes('Add another persona'), btn.title);
 
   S.chatHistory = origHistory;
@@ -427,11 +427,11 @@ assert('chat persists truncated assistant state', chatSendSrc.includes('assistan
 assert('renderChatMessages restores truncated note', chatRenderSrc.includes('msg.truncated') && chatRenderSrc.includes('responseLimitNote()'), 'found');
 assert('regenerateLastMessage checks streaming state via chat runtime',
   chatActionsSrc.includes('isChatRuntimeStreaming()') &&
-    chatRuntimeSrc.includes("getRuntimeFunction('isChatStreaming')") &&
+    chatRuntimeSrc.includes('chatRuntimeCallbacks.isChatStreaming') &&
     chatSendSrc.includes('export function isChatStreaming'), 'found');
 assert('regenerateLastMessage checks render/send callbacks before mutating',
   chatActionsSrc.indexOf('const callbacks = getChatRegenerateCallbacks()') < chatActionsSrc.indexOf('state.chatHistory.pop()')
-    && chatRuntimeSrc.includes("getRuntimeFunction('renderChatMessages')")
+    && chatRuntimeSrc.includes('chatRuntimeCallbacks.renderChatMessages')
     && chatRuntimeSrc.includes('chatRuntimeCallbacks.sendChatMessage'), 'found');
 const directWindowGlobalRe = /\bwindow(?:\.|\s*\[)/;
 const chatRuntimeDelegates = [

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -69,20 +69,20 @@ try {
     openContextModal: () => calls.push(['context']),
   });
   const previousChatRuntime = configureChatRuntimeCallbacks({
+    isChatStreaming: () => false,
     refreshWebSearchToggle: () => calls.push(['web-search']),
+    renderChatMessages: () => calls.push(['render']),
     sendChatMessage: () => calls.push(['send']),
     updateChatHeaderModel: () => calls.push(['header-model']),
     updateChatNudge: () => calls.push(['nudge']),
+    updateDiscussButton: () => calls.push(['discuss']),
   });
   const ppqAttestation = { provider: 'ppq', verified: true };
   const routstrAttestation = { provider: 'routstr', verified: true };
   const veniceAttestation = { provider: 'venice', verified: true };
   setRuntimeValue('window', globalThis);
-  setRuntimeValue('renderChatMessages', () => calls.push(['render']));
-  setRuntimeValue('updateDiscussButton', () => calls.push(['discuss']));
   setRuntimeValue('openContextModal', () => calls.push(['legacy-context']));
   setRuntimeValue('closeModal', () => calls.push(['close']));
-  setRuntimeValue('isChatStreaming', () => false);
   setRuntimeValue('_ppqAttestation', ppqAttestation);
   setRuntimeValue('_routstrAttestation', routstrAttestation);
   setRuntimeValue('_veniceAttestation', veniceAttestation);
@@ -106,7 +106,7 @@ try {
 
   assert('chat runtime reports non-streaming state',
     isChatRuntimeStreaming() === false);
-  setRuntimeValue('isChatStreaming', () => true);
+  configureChatRuntimeCallbacks({ isChatStreaming: () => true });
   assert('chat runtime reports streaming state',
     isChatRuntimeStreaming() === true);
 
@@ -130,10 +130,13 @@ try {
 
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
   configureChatRuntimeCallbacks({
+    isChatStreaming: null,
     refreshWebSearchToggle: null,
+    renderChatMessages: null,
     sendChatMessage: null,
     updateChatHeaderModel: null,
     updateChatNudge: null,
+    updateDiscussButton: null,
   });
   delete globalThis.window;
   assert('chat runtime no-ops without a browser window',

--- a/tests/test-custom-personality.js
+++ b/tests/test-custom-personality.js
@@ -35,6 +35,7 @@ await import('../js/chat.js');
 const personalities = await import('../js/chat-personalities.js');
 const chatHistory = await import('../js/chat-history.js');
 const chatDiscussion = await import('../js/chat-discussion.js');
+const chatRender = await import('../js/chat-render.js');
 const chatSend = await import('../js/chat-send.js');
 const { buildPersonalityPrompt } = await import('../js/chat-prompt-context.js');
 const { createNewThread } = await import('../js/chat-threads.js');
@@ -223,7 +224,8 @@ assert('startDiscussion exported', typeof chatDiscussion.startDiscussion === 'fu
 assert('startDiscussion stays module-only', !('startDiscussion' in window));
 assert('continueDiscussion exported', typeof chatDiscussion.continueDiscussion === 'function');
 assert('endDiscussion exported', typeof chatDiscussion.endDiscussion === 'function');
-assert('updateDiscussButton exported', typeof window.updateDiscussButton === 'function');
+assert('updateDiscussButton exported', typeof chatDiscussion.updateDiscussButton === 'function');
+assert('updateDiscussButton stays module-only', !('updateDiscussButton' in window));
 assert('getThreadPersonaCount exported', typeof chatDiscussion.getThreadPersonaCount === 'function');
 
 // ── 22. Discuss button CSS ──
@@ -252,7 +254,8 @@ assert('callOpenAICompatibleAPI has signal param', apiOpenAICompatibleSrc.includ
 
 // ── 25. Auto message rendering ──
 console.log('25. Auto message rendering');
-const renderSrc2 = window.renderChatMessages.toString();
+assert('renderChatMessages stays module-only', !('renderChatMessages' in window));
+const renderSrc2 = chatRender.renderChatMessages.toString();
 assert('renderChatMessages checks msg.auto', renderSrc2.includes('msg.auto'));
 assert('renderChatMessages applies chat-msg-auto class', renderSrc2.includes('chat-msg-auto'));
 assert('renderChatMessages checks msg.stopped', renderSrc2.includes('msg.stopped'));

--- a/tests/test-onboarding-view-runtime.js
+++ b/tests/test-onboarding-view-runtime.js
@@ -15,6 +15,7 @@ import {
   renderOnboardingChatMessagesRuntime,
 } from '../js/onboarding-view-runtime.js';
 import { configureViewRuntime } from '../js/views-runtime-bridge.js';
+import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -29,7 +30,6 @@ const runtimeKeys = [
   'navigate',
   'openChatPanel',
   'toggleChatPanel',
-  'renderChatMessages',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -56,6 +56,9 @@ try {
   const previousDeps = configureOnboardingViewRuntimeDeps({
     createNewThread: () => calls.push(['createNewThread']),
   });
+  const previousChatRuntime = configureChatRuntimeCallbacks({
+    renderChatMessages: () => calls.push(['renderChatMessages']),
+  });
   setRuntimeValue('window', globalThis);
   previousViewRuntime = configureViewRuntime({
     buildSidebar: data => calls.push(['buildSidebar', data?.id]),
@@ -66,7 +69,6 @@ try {
     return 'opened';
   });
   setRuntimeValue('toggleChatPanel', () => calls.push(['toggleChatPanel']));
-  setRuntimeValue('renderChatMessages', () => calls.push(['renderChatMessages']));
 
   rebuildOnboardingSidebarRuntime({ id: 'sidebar-data' });
   navigateOnboardingRuntime('labs', { id: 'fallback-data' });
@@ -105,6 +107,7 @@ try {
 
   delete globalThis.window;
   configureViewRuntime({ buildSidebar: null });
+  configureChatRuntimeCallbacks({ renderChatMessages: null });
   const beforeNoWindowCalls = calls.length;
   rebuildOnboardingSidebarRuntime({ id: 'ignored' });
   navigateOnboardingRuntime('labs', { id: 'ignored' });
@@ -116,6 +119,7 @@ try {
       calls.length === beforeNoWindowCalls);
 
   configureOnboardingViewRuntimeDeps(previousDeps);
+  configureChatRuntimeCallbacks(previousChatRuntime);
   configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -246,9 +246,10 @@
     'removeChatSupplement', 'setProviderQuizBranch', 'backToProviderQuiz', 'skipProviderSetup',
     'skipOnboardingExtras', 'showCycleNoMensesOptions', 'showCyclePeriodEntry', 'saveCycleStatus',
     '_updatePeriodBtn', 'onContextCardSaved', 'clearChatHistory', 'handleChatKeydown',
-    'refreshWebSearchToggle', 'sendChatMessage', 'setChatPersonality', 'setChatWebSearchEnabled',
+    'isChatStreaming', 'refreshWebSearchToggle', 'renderChatMessages', 'sendChatMessage',
+    'setChatPersonality', 'setChatWebSearchEnabled',
     'startDiscussion', 'summarizeThread', 'toggleChatFullscreen', 'togglePersonalityBar',
-    'updateChatHeaderModel', 'updateChatNudge',
+    'updateChatHeaderModel', 'updateChatNudge', 'updateDiscussButton',
   ];
   assert('Unused Chat APIs do not publish legacy window globals',
     formerUnusedChatGlobals.every(name => !(name in window)));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.241';
+self.APP_VERSION = '1.10.242';


### PR DESCRIPTION
## Summary
- remove `isChatStreaming`, `renderChatMessages`, and `updateDiscussButton` from the legacy Chat `window` facade
- wire render/state callbacks explicitly through `chat-runtime.js` from `app-shell-hooks.js`
- migrate onboarding and affected test consumers to the module callback API
- bump the app cache version to `1.10.242`

## Window reduction progress
- this PR: Chat facade `10 → 7` globals (`3` removed)
- campaign sequence: `80 → 22 → 19 → 10 → 7`
- cumulative: `73/80` globals removed (`91.25%`)
- remaining: `_resumeAI`, `loadChatHistory`, `useChatPrompt`, `toggleChatPanel`, `openChatPanel`, `closeChatPanel`, `askAIAboutMarker`

## Testing
- `./run-tests.sh` — all checks green
  - 398 Vitest tests
  - 352 Playwright tests
  - 472 responsive theme cases
  - TypeScript/checkJs, vendor verification, and module verification
- targeted rendering, onboarding, history, and personality Playwright coverage — 10 passed