### PR TITLE
Remove Chat prompt global

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -3,6 +3,7 @@
 
 import { configureAppEventListeners } from './app-event-listeners.js';
 import { setAIPaused } from './api.js';
+import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js';
 import { closeChangelog } from './changelog.js';
 import { configureChatMessageActionDeps } from './chat-actions.js';
 import {
@@ -20,9 +21,11 @@ import {
   updateAttachButtonVisibility,
 } from './chat-images.js';
 import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
+import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js';
 import {
   closeChatPanel,
   configureChatPanel,
+  openChatPanel,
   refreshWebSearchToggle,
   setChatWebSearchEnabled,
   toggleChatFullscreen,
@@ -31,7 +34,7 @@ import {
 } from './chat-panel.js';
 import { clearChatHistory, loadChatHistory } from './chat-history.js';
 import { askAIAboutCorrelations, askAIAboutMarker } from './chat-marker-prompts.js';
-import { onContextCardSaved } from './chat-onboarding.js';
+import { onContextCardSaved, useChatPrompt } from './chat-onboarding.js';
 import { updateChatNudge } from './chat-nudge.js';
 import {
   setChatPersonality,
@@ -117,6 +120,8 @@ configureSettingsRuntime({
 configureNavActions({ openClientList });
 configureRecommendationsRuntime({ openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
+configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });
+configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
 
 function resumeAI() {
   setAIPaused(false);

--- a/js/biology-scores-runtime.js
+++ b/js/biology-scores-runtime.js
@@ -6,7 +6,12 @@ import { getActiveData } from './data.js';
 import { showNotification } from './utils.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const biologyScoresRuntimeDeps = { getActiveData, showNotification };
+const biologyScoresRuntimeDeps = {
+  getActiveData,
+  openChatPanel: /** @type {null | ((prompt?: string) => unknown)} */ (null),
+  showNotification,
+  useChatPrompt: /** @type {null | ((prompt: string) => unknown)} */ (null),
+};
 
 export function configureBiologyScoresRuntimeDeps(deps = {}) {
   const previous = { ...biologyScoresRuntimeDeps };
@@ -15,9 +20,19 @@ export function configureBiologyScoresRuntimeDeps(deps = {}) {
       ? /** @type {typeof getActiveData} */ (deps.getActiveData)
       : null;
   }
+  if ('openChatPanel' in deps) {
+    biologyScoresRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
+      ? /** @type {(prompt?: string) => unknown} */ (deps.openChatPanel)
+      : null;
+  }
   if ('showNotification' in deps) {
     biologyScoresRuntimeDeps.showNotification = typeof deps.showNotification === 'function'
       ? /** @type {typeof showNotification} */ (deps.showNotification)
+      : null;
+  }
+  if ('useChatPrompt' in deps) {
+    biologyScoresRuntimeDeps.useChatPrompt = typeof deps.useChatPrompt === 'function'
+      ? /** @type {(prompt: string) => unknown} */ (deps.useChatPrompt)
       : null;
   }
   return previous;
@@ -46,12 +61,12 @@ export function navigateBiologyScoresRoute(route = 'biology-scores') {
 }
 
 export function canOpenBiologyScoresChatPanel() {
-  return Boolean(getRuntimeFunction('openChatPanel'));
+  return Boolean(biologyScoresRuntimeDeps.openChatPanel);
 }
 
 /** @param {string=} prompt */
 export function openBiologyScoresChatPanel(prompt) {
-  const openChatPanel = getRuntimeFunction('openChatPanel');
+  const openChatPanel = biologyScoresRuntimeDeps.openChatPanel;
   if (!openChatPanel) return false;
   if (prompt === undefined) openChatPanel();
   else openChatPanel(prompt);
@@ -60,7 +75,7 @@ export function openBiologyScoresChatPanel(prompt) {
 
 /** @param {string} prompt */
 export function useBiologyScoresChatPrompt(prompt) {
-  getRuntimeFunction('useChatPrompt')?.(prompt);
+  biologyScoresRuntimeDeps.useChatPrompt?.(prompt);
 }
 
 /**

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -22,9 +22,7 @@ import { setChatNudge, updateChatNudge } from './chat-nudge.js';
 import {
   cleanupDiscussionState, configureChatDiscussion, restoreDiscussionContinuePrompt,
 } from './chat-discussion.js';
-import {
-  configureChatOnboarding, useChatPrompt,
-} from './chat-onboarding.js';
+import { configureChatOnboarding } from './chat-onboarding.js';
 
 configureChatDiscussion({
   createTypewriter,
@@ -54,7 +52,6 @@ configureChatThreadDeps({
 });
 
 Object.assign(window, {
-  useChatPrompt,
   toggleChatPanel,
   openChatPanel,
   closeChatPanel,

--- a/js/context-card-lifestyle-runtime.js
+++ b/js/context-card-lifestyle-runtime.js
@@ -5,6 +5,26 @@ import { openContextModalRuntime } from './context-cards-runtime.js';
 import { updateChatHeaderModelRuntime } from './chat-runtime.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
+const lifestyleRuntimeDeps = {
+  openChatPanel: /** @type {null | (() => unknown)} */ (null),
+  useChatPrompt: /** @type {null | ((prompt: string) => unknown)} */ (null),
+};
+
+export function configureContextCardLifestyleRuntimeDeps(deps = {}) {
+  const previous = { ...lifestyleRuntimeDeps };
+  if ('openChatPanel' in deps) {
+    lifestyleRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
+      ? /** @type {() => unknown} */ (deps.openChatPanel)
+      : null;
+  }
+  if ('useChatPrompt' in deps) {
+    lifestyleRuntimeDeps.useChatPrompt = typeof deps.useChatPrompt === 'function'
+      ? /** @type {(prompt: string) => unknown} */ (deps.useChatPrompt)
+      : null;
+  }
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -62,9 +82,9 @@ export function openLightSetupFromLifestyleRuntime(reopenSunSetup) {
 
 export function discussDietContaminantsRuntime() {
   closeLifestyleContextModalRuntime();
-  getRuntimeFunction('openChatPanel')?.();
+  lifestyleRuntimeDeps.openChatPanel?.();
   setTimeout(() => {
-    getRuntimeFunction('useChatPrompt')?.('What food contaminants should I be concerned about based on my diet?');
+    lifestyleRuntimeDeps.useChatPrompt?.('What food contaminants should I be concerned about based on my diet?');
   }, 300);
 }
 

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -214,9 +214,10 @@ test('lifestyle context editors cover save clear health goals lens and contamina
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ lifestyleUrl }) => {
-    const [{ state }, lifestyle] = await Promise.all([
+    const [{ state }, lifestyle, lifestyleRuntime] = await Promise.all([
       import('/js/state.js'),
       import(lifestyleUrl),
+      import('/js/context-card-lifestyle-runtime.js'),
     ]);
     const outcomes = {};
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -228,10 +229,12 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       profileSex: state.profileSex,
       closeModal: window.closeModal,
       navigate: window.navigate,
-      openChatPanel: window.openChatPanel,
-      useChatPrompt: window.useChatPrompt,
     };
     const calls = [];
+    const previousLifestyleRuntimeDeps = lifestyleRuntime.configureContextCardLifestyleRuntimeDeps({
+      openChatPanel: () => calls.push(['chat']),
+      useChatPrompt: prompt => calls.push(['prompt', prompt]),
+    });
     const controlOutcomeName = (kind, id, index) =>
       `${kind}_${id}_${index}_renders`.replace(/[^a-zA-Z0-9_]/g, '_');
     const setOption = (id, index = 0) => {
@@ -267,8 +270,6 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       };
       window.closeModal = () => { calls.push(['close']); overlay.classList.remove('show'); };
       window.navigate = route => calls.push(['navigate', route]);
-      window.openChatPanel = () => calls.push(['chat']);
-      window.useChatPrompt = prompt => calls.push(['prompt', prompt]);
 
       lifestyle.openExerciseEditor();
       const defaultExerciseFrequency = setOption('exercise-freq');
@@ -439,8 +440,7 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       state.profileSex = saved.profileSex;
       window.closeModal = saved.closeModal;
       window.navigate = saved.navigate;
-      window.openChatPanel = saved.openChatPanel;
-      window.useChatPrompt = saved.useChatPrompt;
+      lifestyleRuntime.configureContextCardLifestyleRuntimeDeps(previousLifestyleRuntimeDeps);
       lifestyle.configureLifestyleContextEditors({ recordChange: () => {}, saveAndRefresh: () => {} });
       overlay.classList.remove('show');
       modal.innerHTML = '';

--- a/tests/test-biology-scores-runtime.js
+++ b/tests/test-biology-scores-runtime.js
@@ -85,7 +85,9 @@ try {
   setRuntimeValue('window', browserRuntime);
   configureBiologyScoresRuntimeDeps({
     getActiveData: browserRuntime.getActiveData.bind(browserRuntime),
+    openChatPanel: browserRuntime.openChatPanel.bind(browserRuntime),
     showNotification: browserRuntime.showNotification.bind(browserRuntime),
+    useChatPrompt: browserRuntime.useChatPrompt.bind(browserRuntime),
   });
   localStorage.setItem('labcharts-ai-provider', 'openrouter');
   localStorage.removeItem('labcharts-ai-paused');
@@ -123,7 +125,7 @@ try {
 
   delete browserRuntime.openChatPanel;
   delete browserRuntime.getActiveData;
-  configureBiologyScoresRuntimeDeps({ getActiveData: null });
+  configureBiologyScoresRuntimeDeps({ getActiveData: null, openChatPanel: null, useChatPrompt: null });
   assert('biology runtime handles missing optional browser hooks',
     !canOpenBiologyScoresChatPanel() &&
       openBiologyScoresChatPanel('missing') === false &&

--- a/tests/test-context-card-lifestyle-runtime.js
+++ b/tests/test-context-card-lifestyle-runtime.js
@@ -8,6 +8,7 @@ import './_node-shim.js';
 import {
   closeLifestyleContextModalAndNavigateRuntime,
   closeLifestyleContextModalRuntime,
+  configureContextCardLifestyleRuntimeDeps,
   discussDietContaminantsRuntime,
   markLifestyleContextDelegatesBoundRuntime,
   navigateLifestyleContextRuntime,
@@ -30,8 +31,6 @@ const runtimeKeys = [
   'window',
   'closeModal',
   'navigate',
-  'openChatPanel',
-  'useChatPrompt',
   'openContextModal',
   '__lifestyleContextDelegatesBound',
   'setTimeout',
@@ -63,11 +62,13 @@ try {
   const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
     openContextModal: () => calls.push(['context-modal']),
   });
+  const previousLifestyleRuntime = configureContextCardLifestyleRuntimeDeps({
+    openChatPanel: () => calls.push(['chat-panel']),
+    useChatPrompt: prompt => calls.push(['prompt', prompt]),
+  });
   setRuntimeValue('window', globalThis);
   setRuntimeValue('closeModal', () => calls.push(['close']));
   setRuntimeValue('navigate', category => calls.push(['navigate', category]));
-  setRuntimeValue('openChatPanel', () => calls.push(['chat-panel']));
-  setRuntimeValue('useChatPrompt', prompt => calls.push(['prompt', prompt]));
   setRuntimeValue('openContextModal', () => calls.push(['legacy-context-modal']));
   delete globalThis.__lifestyleContextDelegatesBound;
   setRuntimeValue('setTimeout', (fn, delay) => {
@@ -105,6 +106,7 @@ try {
 
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
   configureChatRuntimeCallbacks({ updateChatHeaderModel: null });
+  configureContextCardLifestyleRuntimeDeps({ openChatPanel: null, useChatPrompt: null });
   delete globalThis.window;
   const shellCallCount = calls.filter(call => call[0] !== 'timer').length;
   closeLifestyleContextModalRuntime();
@@ -126,6 +128,7 @@ try {
       swSrc.includes("'/js/context-card-lifestyle-runtime.js'"));
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
   configureChatRuntimeCallbacks(previousChatRuntime);
+  configureContextCardLifestyleRuntimeDeps(previousLifestyleRuntime);
 } finally {
   restoreRuntime();
 }

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -105,6 +105,12 @@ assert('App shell wires Chat UI refreshes without window globals',
     && appShellHooksSrc.includes('resumeAI,')
     && appShellHooksSrc.includes('sendChatMessage,'));
 
+assert('App shell wires Chat prompt consumers without window globals',
+  appShellHooksSrc.includes("import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js'")
+    && appShellHooksSrc.includes("import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js'")
+    && appShellHooksSrc.includes('configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });')
+    && appShellHooksSrc.includes('configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -250,7 +250,7 @@
     'renderChatMessages', 'sendChatMessage',
     'setChatPersonality', 'setChatWebSearchEnabled',
     'startDiscussion', 'summarizeThread', 'toggleChatFullscreen', 'togglePersonalityBar',
-    'updateChatHeaderModel', 'updateChatNudge', 'updateDiscussButton',
+    'updateChatHeaderModel', 'updateChatNudge', 'updateDiscussButton', 'useChatPrompt',
   ];
   assert('Unused Chat APIs do not publish legacy window globals',
     formerUnusedChatGlobals.every(name => !(name in window)));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.243';
+self.APP_VERSION = '1.10.244';


### PR DESCRIPTION
## Summary
- remove `useChatPrompt` from the legacy Chat window facade
- inject Chat prompt and panel-open callbacks into Biology Scores and lifestyle context runtimes through app-shell wiring
- update Node/browser coverage and bump the app version to `1.10.244`

## Window reduction progress
- this PR: Chat facade `4 → 3` globals (`1` removed)
- campaign sequence: `80 → 22 → 19 → 10 → 7 → 4 → 3`
- cumulative: `77/80` globals removed (`96.25%`)
- remaining: `toggleChatPanel`, `openChatPanel`, `closeChatPanel`

## Tests
- `./run-tests.sh`
  - typecheck and check-js passed
  - vendor and 126 module verification checks passed
  - 398 Vitest tests passed
  - 352 Playwright tests passed
  - 472 theme/responsive checks passed
- `npm run quality` (7/7 guardrails passed)