### PR TITLE
Remove Chat toggle global

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -165,13 +165,14 @@ configureShellChatActionDeps({
   setChatWebSearchEnabled,
   startDiscussion,
   summarizeThread,
+  toggleChatPanel,
   toggleChatFullscreen,
   togglePersonalityBar,
 });
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
 configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });
-configureOnboardingViewRuntimeDeps({ createNewThread });
+configureOnboardingViewRuntimeDeps({ createNewThread, toggleChatPanel });
 configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatHistory, loadChatThreads, renderThreadList });
 configureDashboardAIContextStatus(updateChatContextStatus);
 

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -16,7 +16,7 @@ import {
   loadChatHistory, saveChatHistory,
 } from './chat-history.js';
 import {
-  closeChatPanel, configureChatPanel, toggleChatPanel, openChatPanel,
+  closeChatPanel, configureChatPanel, openChatPanel,
 } from './chat-panel.js';
 import { setChatNudge, updateChatNudge } from './chat-nudge.js';
 import {
@@ -52,7 +52,6 @@ configureChatThreadDeps({
 });
 
 Object.assign(window, {
-  toggleChatPanel,
   openChatPanel,
   closeChatPanel,
 });

--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -6,6 +6,7 @@ import { renderChatMessagesRuntime } from './chat-runtime.js';
 
 const onboardingViewRuntimeDeps = {
   createNewThread: /** @type {null | (() => void)} */ (null),
+  toggleChatPanel: /** @type {null | (() => void)} */ (null),
 };
 
 export function configureOnboardingViewRuntimeDeps(deps = {}) {
@@ -13,6 +14,11 @@ export function configureOnboardingViewRuntimeDeps(deps = {}) {
   if (Object.prototype.hasOwnProperty.call(deps, 'createNewThread')) {
     onboardingViewRuntimeDeps.createNewThread = typeof deps.createNewThread === 'function'
       ? deps.createNewThread
+      : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(deps, 'toggleChatPanel')) {
+    onboardingViewRuntimeDeps.toggleChatPanel = typeof deps.toggleChatPanel === 'function'
+      ? deps.toggleChatPanel
       : null;
   }
   return previous;
@@ -64,7 +70,7 @@ export function openOnboardingProviderChatRuntime() {
     openChatPanel();
     return true;
   }
-  const toggleChatPanel = getRuntimeFunction('toggleChatPanel');
+  const toggleChatPanel = onboardingViewRuntimeDeps.toggleChatPanel;
   if (toggleChatPanel) {
     toggleChatPanel();
     return true;

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -18,6 +18,7 @@ const shellChatActionDeps = {
   setChatWebSearchEnabled: (_enabled) => {},
   startDiscussion: () => {},
   summarizeThread: () => {},
+  toggleChatPanel: () => {},
   toggleChatFullscreen: () => {},
   togglePersonalityBar: () => {},
 };
@@ -123,7 +124,7 @@ function runShellAction(action) {
 
 function runChatAction(action, actionEl) {
   if (action === 'toggle-panel') {
-    callShellRuntime('toggleChatPanel');
+    shellChatActionDeps.toggleChatPanel();
     return true;
   } else if (action === 'close-panel') {
     callShellRuntime('closeChatPanel');

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -264,7 +264,6 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       profileDob: state.profileDob,
       navigate: window.navigate,
       openChatPanel: window.openChatPanel,
-      toggleChatPanel: window.toggleChatPanel,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
     const outcomes = {};
@@ -345,7 +344,6 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
         && !host.innerHTML.includes('onclick=');
 
       window.openChatPanel = () => calls.push(['open-chat']);
-      window.toggleChatPanel = () => calls.push(['toggle-chat']);
       sessionStorage.setItem(`chat-onboard-provider-branch-${state.currentProfile}`, 'manual');
       host.querySelector('.ai-reminder-cta')?.click();
       outcomes.providerQuizClearsSkipAndOpensChat =
@@ -422,10 +420,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       onboarding.configureOnboardingView({ navigate: saved.navigate });
       viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
-      Object.assign(window, {
-        openChatPanel: saved.openChatPanel,
-        toggleChatPanel: saved.toggleChatPanel,
-      });
+      window.openChatPanel = saved.openChatPanel;
       Element.prototype.scrollIntoView = saved.scrollIntoView;
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -41,6 +41,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       setChatWebSearchEnabled: enabled => calls.push(['setChatWebSearchEnabled', enabled]),
       startDiscussion: () => calls.push(['startDiscussion']),
       summarizeThread: () => calls.push(['summarizeThread']),
+      toggleChatPanel: () => calls.push(['toggleChatPanel']),
       toggleChatFullscreen: () => calls.push(['toggleChatFullscreen']),
       togglePersonalityBar: () => calls.push(['togglePersonalityBar']),
     });
@@ -55,7 +56,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     });
     const originalFns = {
       openProfileShareModal: window.openProfileShareModal,
-      toggleChatPanel: window.toggleChatPanel,
       closeChatPanel: window.closeChatPanel,
     };
     const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -337,10 +337,11 @@ for (const name of ['openSettingsModal', 'closeSettingsModal']) {
   assert(`settings.${name} exists`, typeof settingsModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));
 }
-const expectedExports = ['toggleChatPanel', 'closeChatPanel'];
+const expectedExports = ['closeChatPanel'];
 for (const name of expectedExports) {
   assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
 }
+assert('window.toggleChatPanel stays module-only', !('toggleChatPanel' in window));
 assert('views.showDashboard exists', typeof viewsModule.showDashboard === 'function');
 assert('window.showDashboard stays module-only', !('showDashboard' in window));
 assert('views.closeModal exists', typeof viewsModule.closeModal === 'function');

--- a/tests/test-onboarding-view-runtime.js
+++ b/tests/test-onboarding-view-runtime.js
@@ -29,7 +29,6 @@ const runtimeKeys = [
   'window',
   'navigate',
   'openChatPanel',
-  'toggleChatPanel',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -55,6 +54,7 @@ try {
   let previousViewRuntime = null;
   const previousDeps = configureOnboardingViewRuntimeDeps({
     createNewThread: () => calls.push(['createNewThread']),
+    toggleChatPanel: () => calls.push(['toggleChatPanel']),
   });
   const previousChatRuntime = configureChatRuntimeCallbacks({
     renderChatMessages: () => calls.push(['renderChatMessages']),
@@ -68,8 +68,6 @@ try {
     calls.push(['openChatPanel']);
     return 'opened';
   });
-  setRuntimeValue('toggleChatPanel', () => calls.push(['toggleChatPanel']));
-
   rebuildOnboardingSidebarRuntime({ id: 'sidebar-data' });
   navigateOnboardingRuntime('labs', { id: 'fallback-data' });
   navigateOnboardingRuntime('dashboard', { id: 'preferred-data' }, (route, data) => calls.push(['preferredNavigate', route, data.id]));
@@ -97,7 +95,7 @@ try {
     openOnboardingProviderChatRuntime() === true &&
       calls.at(-1)?.join('|') === 'toggleChatPanel');
 
-  delete globalThis.toggleChatPanel;
+  configureOnboardingViewRuntimeDeps({ toggleChatPanel: null });
   assert('onboarding provider chat reports unavailable shell hooks',
     openOnboardingProviderChatRuntime() === false);
 

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -89,7 +89,7 @@ assert('Chat thread shell actions use module dependencies instead of window look
 assert('App shell wires module-only chat thread consumers',
   appShellHooksSrc.includes("from './chat-threads.js'")
     && appShellHooksSrc.includes('configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });')
-    && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ createNewThread });')
+    && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ createNewThread, toggleChatPanel });')
     && appShellHooksSrc.includes('configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatHistory, loadChatThreads, renderThreadList });'));
 
 assert('App shell wires Context hub status refresh without a window lookup',
@@ -114,7 +114,7 @@ assert('App shell wires Chat prompt consumers without window globals',
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',
-    'togglePersonalityBar']
+    'toggleChatPanel', 'togglePersonalityBar']
     .every(name => shellSrc.includes(`shellChatActionDeps.${name}`)
       && !shellSrc.includes(`callShellRuntime('${name}'`))
     && appShellHooksSrc.includes('configureShellChatActionDeps({'));

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -251,6 +251,7 @@
     'setChatPersonality', 'setChatWebSearchEnabled',
     'startDiscussion', 'summarizeThread', 'toggleChatFullscreen', 'togglePersonalityBar',
     'updateChatHeaderModel', 'updateChatNudge', 'updateDiscussButton', 'useChatPrompt',
+    'toggleChatPanel',
   ];
   assert('Unused Chat APIs do not publish legacy window globals',
     formerUnusedChatGlobals.every(name => !(name in window)));
@@ -402,7 +403,7 @@
     'loadChatHistory','saveChatHistory','clearChatHistory','renderChatMessages',
     'useChatPrompt',
     'applyInlineMarkdown','renderMarkdown',
-    'toggleChatPanel','openChatPanel','closeChatPanel',
+    'openChatPanel','closeChatPanel',
     'sendChatMessage','handleChatKeydown',
     'askAIAboutMarker','askAIAboutCorrelations'
   ];

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.244';
+self.APP_VERSION = '1.10.245';


### PR DESCRIPTION
## Summary

- route the delegated Chat toggle action through app-shell dependency injection
- inject the onboarding provider fallback instead of resolving `toggleChatPanel` from `window`
- remove `toggleChatPanel` from the legacy Chat window facade and update regression coverage
- bump the app cache version to `1.10.245`

## Window reduction progress

- This PR reduces the Chat window facade from **3 to 2 globals**.
- Sequence: **80 → 22 → 19 → 10 → 7 → 4 → 3 → 2**
- Cumulative reduction: **78 of 80 globals removed (97.5%)**
- Remaining Chat facade globals: `openChatPanel`, `closeChatPanel`

## Test results

- `./run-tests.sh` — passed
  - 398 Vitest tests
  - 352 Playwright tests
  - 472 responsive assertions
- targeted Playwright coverage — 5 passed
- `npm run quality` — 7 passed
