### PR TITLE
Remove Chat close global

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -6,6 +6,7 @@ import { setAIPaused } from './api.js';
 import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js';
 import { closeChangelog } from './changelog.js';
 import { configureChatMessageActionDeps } from './chat-actions.js';
+import { configureChatEmptyStateDeps } from './chat-empty-state.js';
 import {
   continueDiscussion,
   endDiscussion,
@@ -22,6 +23,7 @@ import {
 } from './chat-images.js';
 import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
 import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js';
+import { configureDashboardPageRuntimeDeps } from './dashboard-page-view.js';
 import {
   closeChatPanel,
   configureChatPanel,
@@ -122,6 +124,8 @@ configureRecommendationsRuntime({ openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });
 configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
+configureChatEmptyStateDeps({ closeChatPanel });
+configureDashboardPageRuntimeDeps({ closeChatPanel });
 
 function resumeAI() {
   setAIPaused(false);
@@ -158,6 +162,7 @@ configureCompareCorrelationViews({ askAIAboutCorrelations });
 configureContextCardsRuntimeCallbacks({ onContextCardSaved });
 configureMarkerDetailRuntime({ askAIAboutMarker });
 configureShellChatActionDeps({
+  closeChatPanel,
   clearChatHistory,
   handleChatKeydown,
   sendChatMessage,

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -32,6 +32,16 @@ const CHAT_EMPTY_STOP_PROPAGATION_ACTIONS = new Set([
   'open-wearables-settings',
 ]);
 
+const chatEmptyStateDeps = {
+  closeChatPanel: () => {},
+};
+
+export function configureChatEmptyStateDeps(deps = {}) {
+  const previous = { ...chatEmptyStateDeps };
+  if (typeof deps.closeChatPanel === 'function') chatEmptyStateDeps.closeChatPanel = deps.closeChatPanel;
+  return previous;
+}
+
 /**
  * @param {any} event
  * @param {string} [selector]
@@ -58,7 +68,7 @@ function callChatEmptyRuntime(name, ...args) {
 }
 
 function closeChatPanel() {
-  callChatEmptyRuntime('closeChatPanel');
+  chatEmptyStateDeps.closeChatPanel();
 }
 
 function getChatProfileHeight(profileId) {

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -53,5 +53,4 @@ configureChatThreadDeps({
 
 Object.assign(window, {
   openChatPanel,
-  closeChatPanel,
 });

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -26,10 +26,14 @@ import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 
 let _dashboardWelcomeActionsInstalled = false;
 
-const dashboardPageRuntimeDeps = { loadDemoData };
+const dashboardPageRuntimeDeps = {
+  closeChatPanel: () => {},
+  loadDemoData,
+};
 
 export function configureDashboardPageRuntimeDeps(deps = {}) {
   const previous = { ...dashboardPageRuntimeDeps };
+  if (typeof deps.closeChatPanel === 'function') dashboardPageRuntimeDeps.closeChatPanel = deps.closeChatPanel;
   if (typeof deps.loadDemoData === 'function') dashboardPageRuntimeDeps.loadDemoData = deps.loadDemoData;
   return previous;
 }
@@ -78,7 +82,7 @@ function handleDashboardWelcomeActionClick(event) {
   if (action === 'open-chat') {
     appWindow.openChatPanel?.();
   } else if (action === 'open-ai-settings') {
-    appWindow.closeChatPanel?.();
+    dashboardPageRuntimeDeps.closeChatPanel();
     getSettingsModuleFunction('openSettingsModal')?.('ai');
   } else if (action === 'direct-import') {
     document.getElementById('pdf-input')?.click();

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -11,6 +11,7 @@ const shellImportDeps = { handleImportStatusClick, isImportRunning };
 const shellFeedbackDeps = { openFeedbackModal };
 const shellChatImageDeps = { toggleHDMode: () => {} };
 const shellChatActionDeps = {
+  closeChatPanel: () => {},
   clearChatHistory: () => {},
   handleChatKeydown: (_event) => {},
   sendChatMessage: () => {},
@@ -127,7 +128,7 @@ function runChatAction(action, actionEl) {
     shellChatActionDeps.toggleChatPanel();
     return true;
   } else if (action === 'close-panel') {
-    callShellRuntime('closeChatPanel');
+    shellChatActionDeps.closeChatPanel();
     return true;
   } else if (action === 'toggle-thread-rail') {
     shellChatThreadDeps.toggleThreadRail();

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -10,7 +10,7 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async () => {
-    const [{ renderEmptyChatState }, { state }, { getProfileLocation }, contextCardsRuntime, settingsBridge] = await Promise.all([
+    const [chatEmptyState, { state }, { getProfileLocation }, contextCardsRuntime, settingsBridge] = await Promise.all([
       import('/js/chat-empty-state.js'),
       import('/js/state.js'),
       import('/js/profile.js'),
@@ -26,9 +26,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       importedData: state.importedData,
       profilesStorage: localStorage.getItem('labcharts-profiles'),
     };
-    const savedFns = {
-      closeChatPanel: window.closeChatPanel,
-    };
     const savedInputClick = HTMLInputElement.prototype.click;
     const chatMessages = document.getElementById('chat-messages');
     const savedChatMessagesHTML = chatMessages?.innerHTML;
@@ -40,6 +37,9 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
       openSettingsModal: tab => calls.push(`open-settings:${tab}`),
     });
+    const previousChatEmptyStateDeps = chatEmptyState.configureChatEmptyStateDeps({
+      closeChatPanel: () => calls.push('close-chat'),
+    });
     const inputClicks = [];
     const container = document.createElement('div');
     const panel = document.createElement('div');
@@ -49,7 +49,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     try {
       if (chatMessages) chatMessages.innerHTML = '';
 
-      window.closeChatPanel = () => calls.push('close-chat');
       HTMLInputElement.prototype.click = function() {
         inputClicks.push(this === strayMtDnaInput ? 'stray' : panel.contains(this) ? 'scoped' : 'other');
       };
@@ -89,7 +88,7 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       panel.appendChild(container);
       panel.addEventListener('click', () => { bubbledClicks++; });
 
-      renderEmptyChatState(container, panel);
+      chatEmptyState.renderEmptyChatState(container, panel);
 
       const nameInput = container.querySelector('#chat-onboard-name');
       nameInput.value = 'Ada';
@@ -109,7 +108,7 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       countryInput.value = 'Germany';
       countryInput.dispatchEvent(new Event('input', { bubbles: true }));
 
-      renderEmptyChatState(container, panel);
+      chatEmptyState.renderEmptyChatState(container, panel);
       const bubbledBeforeOptionalActions = bubbledClicks;
       container.querySelector('[data-chat-empty-action="open-cycle-editor"]')?.click();
       const cycleEditorOpenedThroughModule = document.getElementById('modal-overlay')?.classList.contains('show') === true
@@ -140,6 +139,7 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
     } finally {
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
+      chatEmptyState.configureChatEmptyStateDeps(previousChatEmptyStateDeps);
       state.currentProfile = saved.currentProfile;
       state.profiles = saved.profiles;
       state.profileSex = saved.profileSex;
@@ -147,7 +147,6 @@ test('chat empty-state delegated actions update scoped profile UI', async ({ pag
       state.importedData = saved.importedData;
       if (saved.profilesStorage === null) localStorage.removeItem('labcharts-profiles');
       else localStorage.setItem('labcharts-profiles', saved.profilesStorage);
-      Object.assign(window, savedFns);
       document.getElementById('modal-overlay')?.classList.remove('show');
       HTMLInputElement.prototype.click = savedInputClick;
       strayMtDnaInput.remove();

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -463,7 +463,6 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       chatHistory: clone(state.chatHistory),
       demoLoadingProfileId: window._demoLoadingProfileId,
       openChatPanel: window.openChatPanel,
-      closeChatPanel: window.closeChatPanel,
       mainHtml: document.getElementById('main-content')?.innerHTML || '',
     };
     const calls = [];
@@ -486,8 +485,8 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       localStorage.setItem('labcharts-ai-paused', 'false');
 
       window.openChatPanel = () => calls.push(['open-chat']);
-      window.closeChatPanel = () => calls.push(['close-chat']);
       previousDashboardPageRuntimeDeps = dashboardPage.configureDashboardPageRuntimeDeps({
+        closeChatPanel: () => calls.push(['close-chat']),
         loadDemoData: sex => calls.push(['demo', sex]),
       });
 
@@ -568,10 +567,7 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
         dashboardPage.configureDashboardPageRuntimeDeps(previousDashboardPageRuntimeDeps);
       }
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
-      Object.assign(window, {
-        openChatPanel: saved.openChatPanel,
-        closeChatPanel: saved.closeChatPanel,
-      });
+      window.openChatPanel = saved.openChatPanel;
       document.body.classList.remove('empty-dashboard-active', 'chat-autostart-reserved');
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -34,6 +34,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       toggleHDMode: () => calls.push(['toggleHDMode']),
     });
     const previousShellChatActionDeps = shellActions.configureShellChatActionDeps({
+      closeChatPanel: () => calls.push(['closeChatPanel']),
       clearChatHistory: () => calls.push(['clearChatHistory']),
       handleChatKeydown: event => calls.push(['handleChatKeydown', event]),
       sendChatMessage: () => calls.push(['sendChatMessage']),
@@ -56,7 +57,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
     });
     const originalFns = {
       openProfileShareModal: window.openProfileShareModal,
-      closeChatPanel: window.closeChatPanel,
     };
     const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
       openTweaksPanel: (...args) => calls.push(['openTweaksPanel', ...args]),

--- a/tests/playwright/theme-responsive-e2e.spec.js
+++ b/tests/playwright/theme-responsive-e2e.spec.js
@@ -107,7 +107,7 @@ async function seedDemoData(page) {
     await dataModule.saveImportedData();
     (await import('/js/nav.js')).buildSidebar();
     (await import('/js/views.js')).navigate('dashboard');
-    window.closeChatPanel?.();
+    (await import('/js/chat-panel.js')).closeChatPanel();
   });
   await page.waitForSelector('#main-content', { timeout: 10000 });
   await delay(200);
@@ -178,7 +178,7 @@ async function prepareScenario(page, theme, viewport) {
     const settings = await import('/js/settings.js');
     (await import('/js/views.js')).closeModal();
     settings.closeSettingsModal();
-    window.closeChatPanel?.();
+    (await import('/js/chat-panel.js')).closeChatPanel();
     (await import('/js/nav.js')).closeMobileSidebar();
     document.querySelectorAll('#tour-overlay, #tour-spotlight, #tour-tooltip').forEach(el => el.remove());
     document.querySelectorAll('.modal-overlay.show').forEach(el => el.classList.remove('show'));
@@ -193,9 +193,9 @@ async function prepareScenario(page, theme, viewport) {
     themeModule.setTheme(nextTheme);
   }, theme);
   await seedDemoData(page);
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     window.endTour?.();
-    window.closeChatPanel?.();
+    (await import('/js/chat-panel.js')).closeChatPanel();
     document.querySelectorAll('#tour-overlay, #tour-spotlight, #tour-tooltip').forEach(el => el.remove());
   });
 }

--- a/tests/test-chat-panel-ux.js
+++ b/tests/test-chat-panel-ux.js
@@ -16,12 +16,12 @@ return (async function() {
   }
 
   console.log('%c Chat panel UX tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
-  const { toggleChatFullscreen } = await import('/js/chat-panel.js');
+  const { closeChatPanel, toggleChatFullscreen } = await import('/js/chat-panel.js');
 
   // Snapshot localStorage so the test doesn't bleed user state.
   const savedFullscreen = localStorage.getItem('labcharts-chat-fullscreen');
   // Make sure chat starts closed + clean fullscreen state.
-  if (typeof window.closeChatPanel === 'function') window.closeChatPanel();
+  closeChatPanel();
   localStorage.removeItem('labcharts-chat-fullscreen');
   document.getElementById('chat-panel')?.classList.remove('chat-panel-fullscreen');
 
@@ -32,8 +32,8 @@ return (async function() {
         !('toggleChatFullscreen' in window));
       assert('window.openChatPanel exists',
         typeof window.openChatPanel === 'function');
-      assert('window.closeChatPanel exists',
-        typeof window.closeChatPanel === 'function');
+      assert('window.closeChatPanel stays module-only',
+        !('closeChatPanel' in window));
     }
 
     // ─── 2. DOM: fullscreen button is present + accessible ────
@@ -66,7 +66,7 @@ return (async function() {
       assert('opening chat does not set body.style.overflow',
         afterOverflow === '' || afterOverflow === beforeOverflow,
         `before: "${beforeOverflow}" / after: "${afterOverflow}"`);
-      window.closeChatPanel();
+      closeChatPanel();
     }
 
     // ─── 5. Fullscreen toggle toggles class + persists ────────
@@ -114,7 +114,7 @@ return (async function() {
       await new Promise(r => setTimeout(r, 50));
       assert('opening chat with localStorage=true applies fullscreen',
         panel.classList.contains('chat-panel-fullscreen'));
-      window.closeChatPanel();
+      closeChatPanel();
 
       // Set localStorage = false → opening should NOT apply (and must
       // explicitly remove if previously set, since we use toggle(force)).
@@ -124,7 +124,7 @@ return (async function() {
       await new Promise(r => setTimeout(r, 50));
       assert('opening chat with localStorage=false explicitly removes fullscreen class',
         !panel.classList.contains('chat-panel-fullscreen'));
-      window.closeChatPanel();
+      closeChatPanel();
     }
 
     // ─── 8. Backdrop click does NOT trigger modal-nudge anymore ─
@@ -154,13 +154,13 @@ return (async function() {
       await new Promise(r => setTimeout(r, 50));
       toggleChatFullscreen(); // ON
       await new Promise(r => setTimeout(r, 50));
-      window.closeChatPanel();
+      closeChatPanel();
       panel.classList.remove('chat-panel-fullscreen'); // simulate fresh DOM
       window.openChatPanel();
       await new Promise(r => setTimeout(r, 50));
       assert('reopening chat after fullscreen-on restores fullscreen',
         panel.classList.contains('chat-panel-fullscreen'));
-      window.closeChatPanel();
+      closeChatPanel();
     }
 
     // ─── 11. Body class wiring drives dashboard auto-shift ────
@@ -183,7 +183,7 @@ return (async function() {
       assert('toggling fullscreen OFF removes body.chat-fullscreen',
         !document.body.classList.contains('chat-fullscreen'));
 
-      window.closeChatPanel();
+      closeChatPanel();
       assert('closing chat drops both body classes',
         !document.body.classList.contains('chat-open') &&
         !document.body.classList.contains('chat-fullscreen'));
@@ -211,7 +211,7 @@ return (async function() {
 
         toggleChatFullscreen(); // back to non-fullscreen
         await new Promise(r => setTimeout(r, 100));
-        window.closeChatPanel();
+        closeChatPanel();
         // Wait past the 0.3s transition + a generous margin.
         await new Promise(r => setTimeout(r, 600));
         const closedPadding = parseFloat(getComputedStyle(main).paddingRight);

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -337,10 +337,7 @@ for (const name of ['openSettingsModal', 'closeSettingsModal']) {
   assert(`settings.${name} exists`, typeof settingsModule[name] === 'function');
   assert(`window.${name} stays module-only`, !(name in window));
 }
-const expectedExports = ['closeChatPanel'];
-for (const name of expectedExports) {
-  assert(`window.${name} exists`, typeof window[name] === 'function', `typeof: ${typeof window[name]}`);
-}
+assert('window.closeChatPanel stays module-only', !('closeChatPanel' in window));
 assert('window.toggleChatPanel stays module-only', !('toggleChatPanel' in window));
 assert('views.showDashboard exists', typeof viewsModule.showDashboard === 'function');
 assert('window.showDashboard stays module-only', !('showDashboard' in window));

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -111,8 +111,14 @@ assert('App shell wires Chat prompt consumers without window globals',
     && appShellHooksSrc.includes('configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });')
     && appShellHooksSrc.includes('configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });'));
 
+assert('App shell wires Chat close consumers without window globals',
+  appShellHooksSrc.includes("import { configureChatEmptyStateDeps } from './chat-empty-state.js'")
+    && appShellHooksSrc.includes("import { configureDashboardPageRuntimeDeps } from './dashboard-page-view.js'")
+    && appShellHooksSrc.includes('configureChatEmptyStateDeps({ closeChatPanel });')
+    && appShellHooksSrc.includes('configureDashboardPageRuntimeDeps({ closeChatPanel });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
-  ['clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
+  ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',
     'toggleChatPanel', 'togglePersonalityBar']
     .every(name => shellSrc.includes(`shellChatActionDeps.${name}`)

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -230,6 +230,7 @@
   const sunModule = await import('../js/sun.js');
   const chatPersonalitiesModule = await import('../js/chat-personalities.js');
   const markdownModule = await import('../js/markdown.js');
+  const chatPanelModule = await import('../js/chat-panel.js');
   const formerUnusedChatGlobals = [
     'getChatStorageKey', 'getActivePersonality', 'getCustomPersonalities', 'saveCustomPersonalities',
     'getCustomPersonality', 'getCustomPersonalityText', 'pickPersonaIcon', 'generateCustomPersonality',
@@ -251,7 +252,7 @@
     'setChatPersonality', 'setChatWebSearchEnabled',
     'startDiscussion', 'summarizeThread', 'toggleChatFullscreen', 'togglePersonalityBar',
     'updateChatHeaderModel', 'updateChatNudge', 'updateDiscussButton', 'useChatPrompt',
-    'toggleChatPanel',
+    'toggleChatPanel', 'closeChatPanel',
   ];
   assert('Unused Chat APIs do not publish legacy window globals',
     formerUnusedChatGlobals.every(name => !(name in window)));
@@ -403,7 +404,7 @@
     'loadChatHistory','saveChatHistory','clearChatHistory','renderChatMessages',
     'useChatPrompt',
     'applyInlineMarkdown','renderMarkdown',
-    'openChatPanel','closeChatPanel',
+    'openChatPanel',
     'sendChatMessage','handleChatKeydown',
     'askAIAboutMarker','askAIAboutCorrelations'
   ];
@@ -1213,7 +1214,7 @@
   if (apiModule.hasAIProvider()) {
     window.openChatPanel();
     assert('Chat panel opens (with AI provider)', chatPanel?.classList.contains('open'));
-    window.closeChatPanel();
+    chatPanelModule.closeChatPanel();
     assert('Chat panel closes', !chatPanel?.classList.contains('open'));
   } else {
     // No AI provider — toggle manually to test CSS class mechanism

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.245';
+self.APP_VERSION = '1.10.246';


### PR DESCRIPTION
## Summary

- inject `closeChatPanel` into delegated shell actions, chat empty-state handoffs, and dashboard welcome actions
- update browser fixtures to call the module-owned close helper instead of the legacy window facade
- remove `closeChatPanel` from the Chat window facade
- bump the app cache version to `1.10.246`

## Window reduction progress

- This PR reduces the Chat window facade from **2 to 1 global**.
- Sequence: **80 → 22 → 19 → 10 → 7 → 4 → 3 → 2 → 1**
- Cumulative reduction: **79 of 80 globals removed (98.75%)**
- Remaining Chat facade global: `openChatPanel`

## Test results

- `./run-tests.sh` — passed
  - 398 Vitest tests
  - 352 Playwright tests
  - 472 responsive assertions
- `node tests/test-crypto.js` — 295 passed
- `npm run quality` — 7 passed
