### PR TITLE
Remove final Chat window global

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -68,7 +68,7 @@ import {
 import { closeClientList, configureClientListRuntime, openClientList, openProfileLocationEditor } from './client-list.js';
 import { configureCompareCorrelationViews } from './compare-correlations.js';
 import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
-import { closeEMFInterpretation } from './emf-interpretation.js';
+import { closeEMFInterpretation, configureEMFInterpretationRuntimeDeps } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder } from './export.js';
 import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
 import { closeFeedbackModal, openFeedbackModal } from './feedback.js';
@@ -97,6 +97,7 @@ import {
 import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
 import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
+import { configureTourRuntimeDeps } from './tour-runtime.js';
 
 configureClientListRuntime({
   exportAllDataJSON,
@@ -120,12 +121,13 @@ configureSettingsRuntime({
 });
 
 configureNavActions({ openClientList });
-configureRecommendationsRuntime({ openProfileLocationEditor });
+configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });
 configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel });
-configureDashboardPageRuntimeDeps({ closeChatPanel });
+configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });
+configureEMFInterpretationRuntimeDeps({ openChatPanel });
 
 function resumeAI() {
   setAIPaused(false);
@@ -176,8 +178,9 @@ configureShellChatActionDeps({
 });
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
-configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });
-configureOnboardingViewRuntimeDeps({ createNewThread, toggleChatPanel });
+configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButtonVisibility });
+configureOnboardingViewRuntimeDeps({ createNewThread, openChatPanel, toggleChatPanel });
+configureTourRuntimeDeps({ openChatPanel });
 configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatHistory, loadChatThreads, renderThreadList });
 configureDashboardAIContextStatus(updateChatContextStatus);
 

--- a/js/chat-window-bindings.js
+++ b/js/chat-window-bindings.js
@@ -1,5 +1,5 @@
 // @ts-check
-// chat-window-bindings.js — chat callback wiring and legacy window exports
+// chat-window-bindings.js — chat callback wiring
 
 import { configureChatThreadDeps } from './chat-threads.js';
 import { renderChatMessages } from './chat-render.js';
@@ -15,9 +15,7 @@ import {
 import {
   loadChatHistory, saveChatHistory,
 } from './chat-history.js';
-import {
-  closeChatPanel, configureChatPanel, openChatPanel,
-} from './chat-panel.js';
+import { closeChatPanel, configureChatPanel } from './chat-panel.js';
 import { setChatNudge, updateChatNudge } from './chat-nudge.js';
 import {
   cleanupDiscussionState, configureChatDiscussion, restoreDiscussionContinuePrompt,
@@ -49,8 +47,4 @@ configureChatThreadDeps({
   saveChatHistory,
   updateChatHeaderTitle,
   updatePersonalityBar,
-});
-
-Object.assign(window, {
-  openChatPanel,
 });

--- a/js/dashboard-page-view.js
+++ b/js/dashboard-page-view.js
@@ -29,12 +29,18 @@ let _dashboardWelcomeActionsInstalled = false;
 const dashboardPageRuntimeDeps = {
   closeChatPanel: () => {},
   loadDemoData,
+  openChatPanel: /** @type {null | (() => unknown)} */ (null),
 };
 
 export function configureDashboardPageRuntimeDeps(deps = {}) {
   const previous = { ...dashboardPageRuntimeDeps };
   if (typeof deps.closeChatPanel === 'function') dashboardPageRuntimeDeps.closeChatPanel = deps.closeChatPanel;
   if (typeof deps.loadDemoData === 'function') dashboardPageRuntimeDeps.loadDemoData = deps.loadDemoData;
+  if (Object.prototype.hasOwnProperty.call(deps, 'openChatPanel')) {
+    dashboardPageRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
+      ? deps.openChatPanel
+      : null;
+  }
   return previous;
 }
 
@@ -77,10 +83,9 @@ function closestDashboardWelcomeAction(target) {
 function handleDashboardWelcomeActionClick(event) {
   const actionEl = closestDashboardWelcomeAction(event.target);
   if (!actionEl) return;
-  const appWindow = dashboardPageRuntime();
   const action = actionEl.getAttribute(DASHBOARD_WELCOME_ACTION_ATTR);
   if (action === 'open-chat') {
-    appWindow.openChatPanel?.();
+    dashboardPageRuntimeDeps.openChatPanel?.();
   } else if (action === 'open-ai-settings') {
     dashboardPageRuntimeDeps.closeChatPanel();
     getSettingsModuleFunction('openSettingsModal')?.('ai');
@@ -290,7 +295,7 @@ export function createDashboardPageView(deps) {
             document.body.classList.remove('chat-autostart-reserved');
             return;
           }
-          if (typeof getDashboardPageRuntimeValue('openChatPanel') === 'function') callDashboardPageRuntime('openChatPanel');
+          if (dashboardPageRuntimeDeps.openChatPanel) dashboardPageRuntimeDeps.openChatPanel();
           else document.body.classList.remove('chat-autostart-reserved');
         }, 800);
       }

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -212,6 +212,7 @@ export function createDashboardViewComposition({
     addDashboardWidgetFromLens: (...args) => dashboardWidgetControls.addDashboardWidgetFromLens(...args),
     getAvailableDashboardFixedWidgetIds,
     getDashboardWidgetPrefs,
+    openChatPanel,
     openDashboardBiometricPicker: () => dashboardWidgetControls.openDashboardBiometricPicker(),
     removeDashboardWidgetFromLens: (...args) => dashboardWidgetControls.removeDashboardWidgetFromLens(...args),
   });

--- a/js/emf-interpretation.js
+++ b/js/emf-interpretation.js
@@ -19,11 +19,17 @@ import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const emfInterpretationRuntimeDeps = {
   callClaudeAPI,
+  openChatPanel: /** @type {null | ((message?: string) => unknown)} */ (null),
 };
 
 export function configureEMFInterpretationRuntimeDeps(deps = {}) {
   const previous = { ...emfInterpretationRuntimeDeps };
   if (typeof deps.callClaudeAPI === 'function') emfInterpretationRuntimeDeps.callClaudeAPI = deps.callClaudeAPI;
+  if (Object.prototype.hasOwnProperty.call(deps, 'openChatPanel')) {
+    emfInterpretationRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
+      ? deps.openChatPanel
+      : null;
+  }
   return previous;
 }
 
@@ -53,7 +59,7 @@ function closeParentEMFModalRuntime() {
 }
 
 function openEMFInterpretationChatRuntime(message) {
-  getEMFInterpretationRuntimeFunction('openChatPanel')?.(message);
+  emfInterpretationRuntimeDeps.openChatPanel?.(message);
 }
 
 function getAssessments(deps) {

--- a/js/lens-page-shell.js
+++ b/js/lens-page-shell.js
@@ -16,6 +16,7 @@ let _shellDeps = {
   addDashboardWidgetFromLens: (_id) => {},
   getAvailableDashboardFixedWidgetIds: () => [],
   getDashboardWidgetPrefs: () => ({ hidden: [] }),
+  openChatPanel: () => {},
   openEMFAssessmentEditor,
   openDashboardBiometricPicker: () => {},
   removeDashboardWidgetFromLens: (_id) => {},
@@ -85,7 +86,7 @@ function handleLensPageShellClick(event) {
   } else if (action === 'open-biometric-picker') {
     _shellDeps.openDashboardBiometricPicker();
   } else if (action === 'open-ai-chat') {
-    callLensPageRuntime('openChatPanel');
+    _shellDeps.openChatPanel();
   } else if (action === 'open-emf-assessment') {
     void _shellDeps.openEMFAssessmentEditor();
   } else if (action === 'open-recommendations') {

--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -6,6 +6,7 @@ import { renderChatMessagesRuntime } from './chat-runtime.js';
 
 const onboardingViewRuntimeDeps = {
   createNewThread: /** @type {null | (() => void)} */ (null),
+  openChatPanel: /** @type {null | (() => unknown)} */ (null),
   toggleChatPanel: /** @type {null | (() => void)} */ (null),
 };
 
@@ -14,6 +15,11 @@ export function configureOnboardingViewRuntimeDeps(deps = {}) {
   if (Object.prototype.hasOwnProperty.call(deps, 'createNewThread')) {
     onboardingViewRuntimeDeps.createNewThread = typeof deps.createNewThread === 'function'
       ? deps.createNewThread
+      : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(deps, 'openChatPanel')) {
+    onboardingViewRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
+      ? deps.openChatPanel
       : null;
   }
   if (Object.prototype.hasOwnProperty.call(deps, 'toggleChatPanel')) {
@@ -60,12 +66,12 @@ export function navigateOnboardingRuntime(route, data, preferredNavigate = null)
 }
 
 export function openOnboardingChatPanelRuntime() {
-  const openChatPanel = getRuntimeFunction('openChatPanel');
+  const openChatPanel = onboardingViewRuntimeDeps.openChatPanel;
   return openChatPanel ? Promise.resolve(openChatPanel()) : null;
 }
 
 export function openOnboardingProviderChatRuntime() {
-  const openChatPanel = getRuntimeFunction('openChatPanel');
+  const openChatPanel = onboardingViewRuntimeDeps.openChatPanel;
   if (openChatPanel) {
     openChatPanel();
     return true;

--- a/js/provider-panels.js
+++ b/js/provider-panels.js
@@ -16,6 +16,7 @@ import {
   rememberOpenRouterOAuthPreviousProvider, clearOpenRouterOAuthSession, startOpenRouterOAuth
 } from './api.js';
 import { updateKeyCache, encryptedSetItem } from './crypto.js';
+import { openChatPanel } from './chat-panel.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { clearRoutstrModelCaches } from './routstr-model-cache.js';
 import { installProviderPanelDelegates } from './provider-panel-delegates.js';
@@ -102,6 +103,16 @@ import {
 } from './provider-wallet-panels.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+
+const providerPanelDeps = {
+  openChatPanel,
+};
+
+export function configureProviderPanelDeps(deps = {}) {
+  const previous = { ...providerPanelDeps };
+  if (typeof deps.openChatPanel === 'function') providerPanelDeps.openChatPanel = deps.openChatPanel;
+  return previous;
+}
 
 function providerPanelRuntime() {
   return /** @type {Record<string, any>} */ (globalThis);
@@ -323,7 +334,7 @@ function _returnToChatIfOnboarding() {
   if (getProviderPanelRuntimeValue('_settingsHadProvider')) return; // already had a provider — user is just reconfiguring
   if (!callProviderPanelRuntime('hasAIProvider')) return;
   callProviderPanelRuntime('closeSettingsModal');
-  setTimeout(() => callProviderPanelRuntime('openChatPanel'), 300);
+  setTimeout(() => providerPanelDeps.openChatPanel(), 300);
 }
 
 function _setActionText(actionEl) {

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -6,6 +6,7 @@ import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const recommendationsRuntimeDeps = {
   openEMFAssessmentEditor,
+  openChatPanel: /** @type {null | ((prompt?: string) => unknown)} */ (null),
   openProfileLocationEditor: null,
 };
 
@@ -51,6 +52,11 @@ export function configureRecommendationsRuntime(deps = {}) {
   const previous = { ...recommendationsRuntimeDeps };
   if (typeof deps.openEMFAssessmentEditor === 'function') {
     recommendationsRuntimeDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
+  }
+  if ('openChatPanel' in deps) {
+    recommendationsRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
+      ? /** @type {(prompt?: string) => unknown} */ (deps.openChatPanel)
+      : null;
   }
   if ('openProfileLocationEditor' in deps) {
     recommendationsRuntimeDeps.openProfileLocationEditor = typeof deps.openProfileLocationEditor === 'function'
@@ -110,7 +116,7 @@ export function closeRecommendationsModal() {
 }
 
 export function openRecommendationsChatPanel(prompt) {
-  const openChatPanel = getRuntimeFunction('openChatPanel');
+  const openChatPanel = recommendationsRuntimeDeps.openChatPanel;
   if (!openChatPanel) return false;
   openChatPanel(prompt);
   return true;

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -19,6 +19,7 @@ import { updateChatNudgeRuntime } from './chat-runtime.js';
 const startupUIDeps = {
   initChatImageHandlers: () => {},
   maybeShowAnalyticsConsent,
+  openChatPanel: () => {},
   updateAttachButtonVisibility: () => {},
 };
 
@@ -31,6 +32,9 @@ export function configureStartupUIDeps(deps = {}) {
   }
   if (typeof deps.initChatImageHandlers === 'function') {
     startupUIDeps.initChatImageHandlers = deps.initChatImageHandlers;
+  }
+  if (typeof deps.openChatPanel === 'function') {
+    startupUIDeps.openChatPanel = deps.openChatPanel;
   }
   if (typeof deps.updateAttachButtonVisibility === 'function') {
     startupUIDeps.updateAttachButtonVisibility = deps.updateAttachButtonVisibility;
@@ -141,7 +145,7 @@ function openDeferredStartupDestinations() {
   }
   if (getStartupRuntimeValue('_openChatAfterInit')) {
     delete startupRuntime()._openChatAfterInit;
-    setTimeout(() => requireStartupRuntime('openChatPanel'), 500);
+    setTimeout(() => startupUIDeps.openChatPanel(), 500);
   }
 }
 

--- a/js/tour-runtime.js
+++ b/js/tour-runtime.js
@@ -1,6 +1,20 @@
 // @ts-check
 // tour-runtime.js - Browser runtime adapters for guided tour hooks.
 
+const tourRuntimeDeps = {
+  openChatPanel: /** @type {null | (() => unknown)} */ (null),
+};
+
+export function configureTourRuntimeDeps(deps = {}) {
+  const previous = { ...tourRuntimeDeps };
+  if (Object.prototype.hasOwnProperty.call(deps, 'openChatPanel')) {
+    tourRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
+      ? deps.openChatPanel
+      : null;
+  }
+  return previous;
+}
+
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
@@ -52,7 +66,7 @@ export function getTourComputedStyle(element) {
 }
 
 export function openTourChatPanel() {
-  getRuntimeFunction('openChatPanel')?.();
+  tourRuntimeDeps.openChatPanel?.();
 }
 
 /**

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -294,7 +294,6 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     };
     const savedFns = {
       detectWearableTrendSlots: window.detectWearableTrendSlots,
-      openChatPanel: window.openChatPanel,
       showDetailModal: window.showDetailModal,
     };
     const hadFns = {};
@@ -310,6 +309,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     };
     const originalCachedCatalog = recommendationRuntime.getRecommendationsCatalogCache();
     let previousRecommendationBridge = null;
+    let previousRecommendationRuntime = null;
     let previousSettingsBridge = null;
     let previousWearablesBridge = null;
     let realNavigate;
@@ -382,12 +382,14 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       },
       renderRecommendationSection: async slotKey => `<div class="rec-detail-coverage">Options for ${slotKey}</div>`,
     });
+    previousRecommendationRuntime = recommendationRuntime.configureRecommendationsRuntime({
+      openChatPanel: prompt => calls.push(['chat', prompt]),
+    });
     recommendationRuntime.setRecommendationsCatalogCache(null);
     window.detectWearableTrendSlots = () => [{
       slotKey: 'body.sleepRecovery',
       reason: 'Resting heart rate is elevated and HRV is below baseline.',
     }];
-    window.openChatPanel = prompt => calls.push(['chat', prompt]);
     window.showDetailModal = id => calls.push(['detail', id]);
     previousSettingsBridge = settingsRuntimeBridge.configureSettingsModuleBridge({
       openSettingsModal: panel => calls.push(['settings', panel]),
@@ -580,6 +582,9 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       state.currentView = originalState.currentView;
       if (previousRecommendationBridge) {
         recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
+      if (previousRecommendationRuntime) {
+        recommendationRuntime.configureRecommendationsRuntime(previousRecommendationRuntime);
       }
       if (previousSettingsBridge) {
         settingsRuntimeBridge.configureSettingsModuleBridge(previousSettingsBridge);

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -11,11 +11,12 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async () => {
-    const [{ state }, data, editorUi, emf] = await Promise.all([
+    const [{ state }, data, editorUi, emf, emfInterpretation] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/context-card-editor-ui.js'),
       import('/js/emf.js'),
+      import('/js/emf-interpretation.js'),
     ]);
     if (typeof window.toggleCtxTag !== 'function') window.toggleCtxTag = editorUi.toggleCtxTag;
 
@@ -56,11 +57,13 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
     const saved = {
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
-      openChatPanel: window.openChatPanel,
       closeModal: window.closeModal,
     };
     const outcomes = {};
     const calls = [];
+    const previousInterpretationDeps = emfInterpretation.configureEMFInterpretationRuntimeDeps({
+      openChatPanel: prompt => calls.push(['chat', prompt]),
+    });
 
     try {
       localStorage.setItem('labcharts-ai-provider', 'ollama');
@@ -190,7 +193,6 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
         && document.querySelector('.emf-compare-table')?.textContent.includes('28') === true
         && document.querySelector('.emf-compare-table')?.textContent.includes('4') === true;
 
-      window.openChatPanel = prompt => calls.push(['chat', prompt]);
       window.closeModal = () => calls.push(['close-modal']);
       emf.interpretEMFComparison();
       await waitFor('#emf-interp-overlay.show .emf-interp-modal', 'EMF existing interpretation modal');
@@ -219,7 +221,7 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       data.invalidateActiveDataCache();
-      window.openChatPanel = saved.openChatPanel;
+      emfInterpretation.configureEMFInterpretationRuntimeDeps(previousInterpretationDeps);
       window.closeModal = saved.closeModal;
       localStorage.clear();
       for (const [key, value] of storage) {
@@ -370,7 +372,6 @@ test('Light audit history covers save expand update compare interpret and delete
     const saved = {
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
-      openChatPanel: window.openChatPanel,
     };
     const outcomes = {};
     const calls = [];
@@ -451,7 +452,6 @@ test('Light audit history covers save expand update compare interpret and delete
         lightAudits: [oldAudit, midAudit, newAudit],
       };
       data.invalidateActiveDataCache();
-      window.openChatPanel = prompt => calls.push(['chat', prompt]);
       document.getElementById('confirm-dialog-overlay')?.remove();
       document.getElementById('prompt-dialog-overlay')?.remove();
 
@@ -554,7 +554,6 @@ test('Light audit history covers save expand update compare interpret and delete
         renderAuditAIDot: () => '',
         renderAuditAIBlock: () => '',
       });
-      window.openChatPanel = saved.openChatPanel;
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/playwright/lens-page-shell.spec.js
+++ b/tests/playwright/lens-page-shell.spec.js
@@ -67,7 +67,6 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       import('/js/nav.js'),
     ]);
     const originalView = state.currentView;
-    const originalOpenChat = window.openChatPanel;
     const originalNavigate = window.navigate;
     const profileId = profile.getActiveProfileId() || state.currentProfile || 'default';
     const labsOrderKey = `labcharts-${profileId}-lensPageOrder-labs-v1`;
@@ -86,6 +85,7 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
     });
     const restoreShell = shell.configureLensPageShell({
       addDashboardWidgetFromLens: id => calls.push(['add', id]),
+      openChatPanel: () => calls.push(['chat']),
       openEMFAssessmentEditor: () => calls.push(['emf']),
       openDashboardBiometricPicker: () => calls.push(['biometrics']),
       removeDashboardWidgetFromLens: id => calls.push(['remove', id]),
@@ -117,7 +117,6 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
       dashboardToggle?.click();
       await delay(50);
 
-      window.openChatPanel = () => calls.push(['chat']);
       window.navigate = route => calls.push(['navigate', route]);
       const actionFixture = document.createElement('div');
       actionFixture.className = 'lens-page-header';
@@ -163,7 +162,6 @@ test('lens page shell delegates move and dashboard toggle actions', async ({ pag
         ...previousDnaBridge,
       });
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
-      window.openChatPanel = originalOpenChat;
       shell.configureLensPageShell(restoreShell);
       if (originalNavigate) window.navigate = originalNavigate;
       else delete window.navigate;

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -431,7 +431,6 @@ test('provider panels cover provider switching key saves balances custom API and
     const oldGlobals = {
       fetch: window.fetch,
       open: window.open,
-      openChatPanel: window.openChatPanel,
       loadFocusCard: window.loadFocusCard,
       clearE2EESession: window.clearE2EESession,
     };
@@ -445,6 +444,9 @@ test('provider panels cover provider switching key saves balances custom API and
       openSettingsModal: () => {},
       closeSettingsModal: () => { settingsClosed += 1; },
     });
+    const previousProviderPanelDeps = panels.configureProviderPanelDeps({
+      openChatPanel: () => { chatOpened += 1; },
+    });
 
     try {
       for (const key of storageKeys) localStorage.removeItem(key);
@@ -454,7 +456,6 @@ test('provider panels cover provider switching key saves balances custom API and
       cryptoStore.updateKeyCache('labcharts-ppq-key', '');
       cryptoStore.updateKeyCache('labcharts-custom-key', '');
       window.open = url => { openedUrl = String(url); return null; };
-      window.openChatPanel = () => { chatOpened += 1; };
       window.loadFocusCard = () => { focusLoads += 1; };
       window.clearE2EESession = () => { e2eeClears += 1; };
 
@@ -663,7 +664,7 @@ test('provider panels cover provider switching key saves balances custom API and
       window.fetch = oldGlobals.fetch;
       window.open = oldGlobals.open;
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
-      window.openChatPanel = oldGlobals.openChatPanel;
+      panels.configureProviderPanelDeps(previousProviderPanelDeps);
       window.loadFocusCard = oldGlobals.loadFocusCard;
       window.clearE2EESession = oldGlobals.clearE2EESession;
       for (const key of storageKeys) {

--- a/tests/playwright/recommendation-actions-browser-coverage.spec.js
+++ b/tests/playwright/recommendation-actions-browser-coverage.spec.js
@@ -67,10 +67,10 @@ test('recommendation actions browser coverage handles detail modal discussion an
       };
     };
 
-    const saved = {
-      openChatPanel: window.openChatPanel,
-    };
     const previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge();
+    const previousRecommendationRuntime = recommendationRuntime.configureRecommendationsRuntime({
+      openChatPanel: prompt => chatPrompts.push(prompt),
+    });
 
     try {
       fixture.innerHTML = '';
@@ -127,9 +127,6 @@ test('recommendation actions browser coverage handles detail modal discussion an
         shell.modal.innerHTML.includes('Undefined renderer')
         && shell.modal.innerHTML.includes('No recommendation details available for this slot.');
 
-      window.openChatPanel = prompt => {
-        chatPrompts.push(prompt);
-      };
       actions.discussRecommendation('rec-d');
       actions.discussRecommendation('missing-rec');
       outcomes.discussRecommendationBuildsCandidatePromptAndFallbackPrompt =
@@ -162,8 +159,7 @@ test('recommendation actions browser coverage handles detail modal discussion an
         renderRecommendationSection: null,
         ...previousRecommendationBridge,
       });
-      if (saved.openChatPanel === undefined) delete window.openChatPanel;
-      else window.openChatPanel = saved.openChatPanel;
+      recommendationRuntime.configureRecommendationsRuntime(previousRecommendationRuntime);
     }
 
     return outcomes;

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -231,7 +231,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ onboardingUrl }) => {
-    const [onboarding, { state }, profile, data, crypto, viewRuntime, chatRuntime] = await Promise.all([
+    const [onboarding, { state }, profile, data, crypto, viewRuntime, chatRuntime, onboardingRuntime] = await Promise.all([
       import(onboardingUrl),
       import('/js/state.js'),
       import('/js/profile.js'),
@@ -239,6 +239,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       import('/js/crypto.js'),
       import('/js/views-runtime-bridge.js'),
       import('/js/chat-runtime.js'),
+      import('/js/onboarding-view-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
@@ -263,7 +264,6 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       navigate: window.navigate,
-      openChatPanel: window.openChatPanel,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
     const outcomes = {};
@@ -273,6 +273,9 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
     });
     const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
       renderChatMessages: () => calls.push(['render-chat']),
+    });
+    const previousOnboardingRuntime = onboardingRuntime.configureOnboardingViewRuntimeDeps({
+      openChatPanel: () => calls.push(['open-chat']),
     });
     const host = document.createElement('div');
     host.id = 'onboarding-coverage-host';
@@ -343,7 +346,6 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
         && !host.querySelector('.ai-reminder-cta')?.hasAttribute('onclick')
         && !host.innerHTML.includes('onclick=');
 
-      window.openChatPanel = () => calls.push(['open-chat']);
       sessionStorage.setItem(`chat-onboard-provider-branch-${state.currentProfile}`, 'manual');
       host.querySelector('.ai-reminder-cta')?.click();
       outcomes.providerQuizClearsSkipAndOpensChat =
@@ -420,7 +422,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       onboarding.configureOnboardingView({ navigate: saved.navigate });
       viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
-      window.openChatPanel = saved.openChatPanel;
+      onboardingRuntime.configureOnboardingViewRuntimeDeps(previousOnboardingRuntime);
       Element.prototype.scrollIntoView = saved.scrollIntoView;
       localStorage.clear();
       for (const [key, value] of storage) {
@@ -462,7 +464,6 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       currentProfile: state.currentProfile,
       chatHistory: clone(state.chatHistory),
       demoLoadingProfileId: window._demoLoadingProfileId,
-      openChatPanel: window.openChatPanel,
       mainHtml: document.getElementById('main-content')?.innerHTML || '',
     };
     const calls = [];
@@ -484,10 +485,10 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ai-paused', 'false');
 
-      window.openChatPanel = () => calls.push(['open-chat']);
       previousDashboardPageRuntimeDeps = dashboardPage.configureDashboardPageRuntimeDeps({
         closeChatPanel: () => calls.push(['close-chat']),
         loadDemoData: sex => calls.push(['demo', sex]),
+        openChatPanel: () => calls.push(['open-chat']),
       });
 
       let pdfInput = document.getElementById('pdf-input');
@@ -567,7 +568,6 @@ test('dashboard welcome hero uses delegated actions for chat import settings and
         dashboardPage.configureDashboardPageRuntimeDeps(previousDashboardPageRuntimeDeps);
       }
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
-      window.openChatPanel = saved.openChatPanel;
       document.body.classList.remove('empty-dashboard-active', 'chat-autostart-reserved');
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -406,9 +406,6 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
     const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
       updateChatNudge: () => window.__startupUICalls.push('updateChatNudge'),
     });
-    window.openChatPanel = () => {
-      window.__startupUICalls.push('openChatPanel');
-    };
     window._openSettingsAfterInit = 'display';
     window._openChatAfterInit = true;
     window.requestAnimationFrame = callback => {
@@ -438,6 +435,9 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
         },
         maybeShowAnalyticsConsent: () => {
           window.__startupUICalls.push('maybeShowAnalyticsConsent');
+        },
+        openChatPanel: () => {
+          window.__startupUICalls.push('openChatPanel');
         },
         updateAttachButtonVisibility: () => {
           window.__startupUICalls.push('updateAttachButtonVisibility');

--- a/tests/test-chat-panel-ux.js
+++ b/tests/test-chat-panel-ux.js
@@ -16,7 +16,7 @@ return (async function() {
   }
 
   console.log('%c Chat panel UX tests ', 'background:#6366f1;color:#fff;font-size:14px;padding:4px 12px;border-radius:4px');
-  const { closeChatPanel, toggleChatFullscreen } = await import('/js/chat-panel.js');
+  const { closeChatPanel, openChatPanel, toggleChatFullscreen } = await import('/js/chat-panel.js');
 
   // Snapshot localStorage so the test doesn't bleed user state.
   const savedFullscreen = localStorage.getItem('labcharts-chat-fullscreen');
@@ -30,8 +30,8 @@ return (async function() {
     {
       assert('toggleChatFullscreen stays module-only',
         !('toggleChatFullscreen' in window));
-      assert('window.openChatPanel exists',
-        typeof window.openChatPanel === 'function');
+      assert('window.openChatPanel stays module-only',
+        !('openChatPanel' in window));
       assert('window.closeChatPanel stays module-only',
         !('closeChatPanel' in window));
     }
@@ -59,7 +59,7 @@ return (async function() {
     // ─── 4. openChatPanel does NOT lock body scroll ───────────
     {
       const beforeOverflow = document.body.style.overflow;
-      window.openChatPanel();
+      openChatPanel();
       // Skip the chat-render await — only check side effects.
       await new Promise(r => setTimeout(r, 50));
       const afterOverflow = document.body.style.overflow;
@@ -110,7 +110,7 @@ return (async function() {
 
       // Set localStorage = true → opening should add the class.
       localStorage.setItem('labcharts-chat-fullscreen', 'true');
-      window.openChatPanel();
+      openChatPanel();
       await new Promise(r => setTimeout(r, 50));
       assert('opening chat with localStorage=true applies fullscreen',
         panel.classList.contains('chat-panel-fullscreen'));
@@ -120,7 +120,7 @@ return (async function() {
       // explicitly remove if previously set, since we use toggle(force)).
       panel.classList.add('chat-panel-fullscreen'); // simulate stale
       localStorage.setItem('labcharts-chat-fullscreen', 'false');
-      window.openChatPanel();
+      openChatPanel();
       await new Promise(r => setTimeout(r, 50));
       assert('opening chat with localStorage=false explicitly removes fullscreen class',
         !panel.classList.contains('chat-panel-fullscreen'));
@@ -150,13 +150,13 @@ return (async function() {
     // ─── 10. Toggle persists across panel close+reopen ────────
     {
       const panel = document.getElementById('chat-panel');
-      window.openChatPanel();
+      openChatPanel();
       await new Promise(r => setTimeout(r, 50));
       toggleChatFullscreen(); // ON
       await new Promise(r => setTimeout(r, 50));
       closeChatPanel();
       panel.classList.remove('chat-panel-fullscreen'); // simulate fresh DOM
-      window.openChatPanel();
+      openChatPanel();
       await new Promise(r => setTimeout(r, 50));
       assert('reopening chat after fullscreen-on restores fullscreen',
         panel.classList.contains('chat-panel-fullscreen'));
@@ -168,7 +168,7 @@ return (async function() {
       localStorage.removeItem('labcharts-chat-fullscreen');
       document.body.classList.remove('chat-open', 'chat-fullscreen');
 
-      window.openChatPanel();
+      openChatPanel();
       await new Promise(r => setTimeout(r, 50));
       assert('opening chat adds body.chat-open',
         document.body.classList.contains('chat-open'));
@@ -194,7 +194,7 @@ return (async function() {
       const main = document.querySelector('.main, #main-content');
       if (main) {
         const beforePadding = parseFloat(getComputedStyle(main).paddingRight);
-        window.openChatPanel();
+        openChatPanel();
         await new Promise(r => setTimeout(r, 400)); // wait past 0.3s transition
         const afterPadding = parseFloat(getComputedStyle(main).paddingRight);
         assert('opening chat increases main padding-right (dashboard shifts left)',

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -338,6 +338,7 @@ for (const name of ['openSettingsModal', 'closeSettingsModal']) {
   assert(`window.${name} stays module-only`, !(name in window));
 }
 assert('window.closeChatPanel stays module-only', !('closeChatPanel' in window));
+assert('window.openChatPanel stays module-only', !('openChatPanel' in window));
 assert('window.toggleChatPanel stays module-only', !('toggleChatPanel' in window));
 assert('views.showDashboard exists', typeof viewsModule.showDashboard === 'function');
 assert('window.showDashboard stays module-only', !('showDashboard' in window));

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -78,7 +78,7 @@ assert('EMF editor runtime hooks avoid counted direct window globals',
 assert('EMF interpretation runtime hooks avoid counted direct window globals',
   emfInterpretationSrc.includes('function getEMFInterpretationRuntimeFunction') &&
     emfInterpretationSrc.includes("getEMFInterpretationRuntimeFunction('closeModal')") &&
-    emfInterpretationSrc.includes("getEMFInterpretationRuntimeFunction('openChatPanel')") &&
+    emfInterpretationSrc.includes('emfInterpretationRuntimeDeps.openChatPanel?.(message)') &&
     !/\bwindow(?:\.|\s*\[)/.test(emfInterpretationSrc));
 assert('EMF editor X button uses saving close action',
   editorSrc.includes('class="modal-close" aria-label="Close" ${emfActionAttrs(\'close-editor\')}'));

--- a/tests/test-onboarding-view-runtime.js
+++ b/tests/test-onboarding-view-runtime.js
@@ -28,7 +28,6 @@ console.log('=== Onboarding View Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'navigate',
-  'openChatPanel',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
@@ -54,6 +53,10 @@ try {
   let previousViewRuntime = null;
   const previousDeps = configureOnboardingViewRuntimeDeps({
     createNewThread: () => calls.push(['createNewThread']),
+    openChatPanel: () => {
+      calls.push(['openChatPanel']);
+      return 'opened';
+    },
     toggleChatPanel: () => calls.push(['toggleChatPanel']),
   });
   const previousChatRuntime = configureChatRuntimeCallbacks({
@@ -64,10 +67,6 @@ try {
     buildSidebar: data => calls.push(['buildSidebar', data?.id]),
   });
   setRuntimeValue('navigate', (route, data) => calls.push(['navigate', route, data?.id]));
-  setRuntimeValue('openChatPanel', () => {
-    calls.push(['openChatPanel']);
-    return 'opened';
-  });
   rebuildOnboardingSidebarRuntime({ id: 'sidebar-data' });
   navigateOnboardingRuntime('labs', { id: 'fallback-data' });
   navigateOnboardingRuntime('dashboard', { id: 'preferred-data' }, (route, data) => calls.push(['preferredNavigate', route, data.id]));
@@ -90,7 +89,7 @@ try {
         'renderChatMessages',
       ].join(','));
 
-  delete globalThis.openChatPanel;
+  configureOnboardingViewRuntimeDeps({ openChatPanel: null });
   assert('onboarding provider chat falls back to toggle',
     openOnboardingProviderChatRuntime() === true &&
       calls.at(-1)?.join('|') === 'toggleChatPanel');

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -294,7 +294,7 @@ const onboardingRuntimeSrc = read('js/onboarding-view-runtime.js');
     'Context cards should stay available inside chat even after AI is connected');
   assert('Card onboarding focus opens card UI instead of AI prompt prefill',
     onboardingViewSrc.includes('openOnboardingChatPanelRuntime()') &&
-      onboardingRuntimeSrc.includes("getRuntimeFunction('openChatPanel')") &&
+      onboardingRuntimeSrc.includes('onboardingViewRuntimeDeps.openChatPanel') &&
       onboardingViewSrc.includes('chat-onboard-force-context-cards') &&
       chatEmptyStateSrc.includes('forceContextCards') &&
       onboardingViewSrc.includes('#chat-panel .chat-context-cards') &&

--- a/tests/test-provider-panel-delegated-actions.js
+++ b/tests/test-provider-panel-delegated-actions.js
@@ -149,11 +149,12 @@ assert('provider panel recovery uses mint-aware receiveToken instead of wallet i
     !panelsSrc.includes('await appWindow.cashuImportWallet(token)'));
 assert('provider panel recovery awaits pending-token clear before reload',
   /await walletRuntime\.cashuReceiveToken\(token\);[\s\S]*await clearPendingToken\(\);[\s\S]*reloadProviderPanelRuntime\(\);/.test(panelsSrc));
-assert('provider panel onboarding return uses runtime helper calls',
+assert('provider panel onboarding return uses module Chat dependency',
   panelsSrc.includes("getProviderPanelRuntimeValue('_settingsHadProvider')") &&
     panelsSrc.includes("callProviderPanelRuntime('hasAIProvider')") &&
     panelsSrc.includes("callProviderPanelRuntime('closeSettingsModal')") &&
-    panelsSrc.includes("callProviderPanelRuntime('openChatPanel')"));
+    panelsSrc.includes('providerPanelDeps.openChatPanel()') &&
+    !panelsSrc.includes("callProviderPanelRuntime('openChatPanel')"));
 assert('provider panel focus-card refresh uses runtime helper call',
   panelsSrc.includes("callProviderPanelRuntime('loadFocusCard')"));
 assert('provider panel E2EE clear and settings reopen use runtime helper calls',

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -85,6 +85,7 @@ try {
   setRuntime(runtime);
   const restoreRecommendationsRuntime = configureRecommendationsRuntime({
     openEMFAssessmentEditor: () => calls.push(['emf', true]),
+    openChatPanel: prompt => runtime.openChatPanel(prompt),
     openProfileLocationEditor: () => runtime.openProfileLocationEditor(),
   });
 
@@ -136,7 +137,7 @@ try {
   delete runtime.openProfileLocationEditor;
   configureRecommendationsRuntime({ openProfileLocationEditor: null });
   delete runtime.openSettingsTab;
-  delete runtime.openChatPanel;
+  configureRecommendationsRuntime({ openChatPanel: null });
   configureRecommendationModuleBridge({
     isProductRecsEnabled: null,
     loadCatalog: null,

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -70,7 +70,7 @@ assert('App shell wires module-only chat image consumers',
     && appShellHooksSrc.includes('openImageLightbox,')
     && appShellHooksSrc.includes('removeImageAttachment,')
     && appShellHooksSrc.includes('configureShellChatImageDeps({ toggleHDMode });')
-    && appShellHooksSrc.includes('configureStartupUIDeps({ initChatImageHandlers, updateAttachButtonVisibility });'));
+    && appShellHooksSrc.includes('configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButtonVisibility });'));
 
 assert('App shell wires module-only chat message actions',
   ['closeSummaryModal', 'continueDiscussion', 'copySummary', 'deleteSavedSummary',
@@ -89,7 +89,7 @@ assert('Chat thread shell actions use module dependencies instead of window look
 assert('App shell wires module-only chat thread consumers',
   appShellHooksSrc.includes("from './chat-threads.js'")
     && appShellHooksSrc.includes('configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });')
-    && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ createNewThread, toggleChatPanel });')
+    && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ createNewThread, openChatPanel, toggleChatPanel });')
     && appShellHooksSrc.includes('configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatHistory, loadChatThreads, renderThreadList });'));
 
 assert('App shell wires Context hub status refresh without a window lookup',
@@ -115,7 +115,12 @@ assert('App shell wires Chat close consumers without window globals',
   appShellHooksSrc.includes("import { configureChatEmptyStateDeps } from './chat-empty-state.js'")
     && appShellHooksSrc.includes("import { configureDashboardPageRuntimeDeps } from './dashboard-page-view.js'")
     && appShellHooksSrc.includes('configureChatEmptyStateDeps({ closeChatPanel });')
-    && appShellHooksSrc.includes('configureDashboardPageRuntimeDeps({ closeChatPanel });'));
+    && appShellHooksSrc.includes('configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });'));
+
+assert('App shell wires remaining Chat open consumers without window globals',
+  appShellHooksSrc.includes('configureEMFInterpretationRuntimeDeps({ openChatPanel });')
+    && appShellHooksSrc.includes('configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });')
+    && appShellHooksSrc.includes('configureTourRuntimeDeps({ openChatPanel });'));
 
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',

--- a/tests/test-tour-runtime.js
+++ b/tests/test-tour-runtime.js
@@ -3,6 +3,7 @@
 
 import './_node-shim.js';
 import {
+  configureTourRuntimeDeps,
   getTourComputedStyle,
   getTourViewportSize,
   openTourChatPanel,
@@ -46,6 +47,9 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  const previousTourDeps = configureTourRuntimeDeps({
+    openChatPanel: () => calls.push(['chat']),
+  });
   const target = { id: 'tour-target' };
   const browserRuntime = {
     innerWidth: 390,
@@ -53,9 +57,6 @@ try {
     getComputedStyle(element) {
       calls.push(['style', element?.id, this === browserRuntime]);
       return { display: 'block', visibility: 'visible', opacity: '1' };
-    },
-    openChatPanel() {
-      calls.push(['chat', this === browserRuntime]);
     },
     setTimeout(callback, delay) {
       calls.push(['timeout', delay, this === browserRuntime]);
@@ -75,8 +76,8 @@ try {
   assert('getTourComputedStyle delegates style reads with browser binding',
     style.display === 'block' &&
       calls.some(call => call[0] === 'style' && call[1] === 'tour-target' && call[2] === true));
-  assert('openTourChatPanel delegates chat opening with browser binding',
-    calls.some(call => call[0] === 'chat' && call[1] === true));
+  assert('openTourChatPanel delegates chat opening through configured dependency',
+    calls.some(call => call[0] === 'chat'));
   assert('scheduleTourTask delegates timers with browser binding',
     taskId === 99 &&
       calls.some(call => call[0] === 'timeout' && call[1] === 250 && call[2] === true) &&
@@ -85,7 +86,7 @@ try {
   browserRuntime.innerWidth = undefined;
   browserRuntime.innerHeight = NaN;
   delete browserRuntime.getComputedStyle;
-  delete browserRuntime.openChatPanel;
+  configureTourRuntimeDeps({ openChatPanel: null });
   const fallbackViewport = getTourViewportSize();
   const fallbackStyle = getTourComputedStyle(/** @type {Element} */ (target));
   const beforeMissingChat = calls.length;
@@ -107,6 +108,7 @@ try {
     noWindowViewport.width === 1024 &&
       noWindowViewport.height === 768 &&
       noWindowStyle.display === '');
+  configureTourRuntimeDeps(previousTourDeps);
 } finally {
   restoreRuntime();
 }

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -252,7 +252,7 @@
     'setChatPersonality', 'setChatWebSearchEnabled',
     'startDiscussion', 'summarizeThread', 'toggleChatFullscreen', 'togglePersonalityBar',
     'updateChatHeaderModel', 'updateChatNudge', 'updateDiscussButton', 'useChatPrompt',
-    'toggleChatPanel', 'closeChatPanel',
+    'toggleChatPanel', 'closeChatPanel', 'openChatPanel',
   ];
   assert('Unused Chat APIs do not publish legacy window globals',
     formerUnusedChatGlobals.every(name => !(name in window)));
@@ -392,21 +392,6 @@
     'isAgentWearableSeriesEnabled','setAgentWearableSeriesEnabled',
     'getAgentWearableSeriesDays','setAgentWearableSeriesDays',
     'buildWearableContext','buildWearableSeriesSection','injectLensChunks'
-  ];
-
-  // chat.js (23)
-  const chatExports = [
-    'getChatStorageKey',
-    'getActivePersonality','getCustomPersonalityText',
-    'setChatPersonality','loadChatPersonality',
-    'updateChatHeaderTitle','updatePersonalityBar','togglePersonalityBar',
-    'saveCustomPersonality',
-    'loadChatHistory','saveChatHistory','clearChatHistory','renderChatMessages',
-    'useChatPrompt',
-    'applyInlineMarkdown','renderMarkdown',
-    'openChatPanel',
-    'sendChatMessage','handleChatKeydown',
-    'askAIAboutMarker','askAIAboutCorrelations'
   ];
 
   // context-cards.js (85 former browser globals, now module-only)
@@ -670,7 +655,7 @@
 
   // provider-panels.js (74 former browser globals, now module-only)
   const providerPanelsExports = [
-    'renderAIProviderPanel','toggleAIPause','switchAIProvider',
+    'configureProviderPanelDeps','renderAIProviderPanel','toggleAIPause','switchAIProvider',
     'initSettingsModelFetch','initSettingsOllamaCheck',
     'testOllamaConnection','testPIIOllamaConnection',
     'refreshVeniceBalance','updateVeniceModelPricing','toggleVeniceE2EE',
@@ -1054,7 +1039,6 @@
   }
 
   const allModules = {
-    'chat.js': chatExports,
     'views.js': viewsLegacyExports,
   };
 
@@ -1212,7 +1196,7 @@
   // openChatPanel guards on hasAIProvider() — test the panel element directly
   const chatPanel = document.getElementById('chat-panel');
   if (apiModule.hasAIProvider()) {
-    window.openChatPanel();
+    chatPanelModule.openChatPanel();
     assert('Chat panel opens (with AI provider)', chatPanel?.classList.contains('open'));
     chatPanelModule.closeChatPanel();
     assert('Chat panel closes', !chatPanel?.classList.contains('open'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.246';
+self.APP_VERSION = '1.10.247';


### PR DESCRIPTION
## Summary

- route the remaining Chat panel open consumers through explicit module dependencies
- preserve lazy provider-panel loading with a configurable module default
- remove the final `openChatPanel` export from the Chat window binding
- update browser and module regressions and bump `version.js` to 1.10.247

## Window reduction progress

- This PR: Chat facade globals **1 → 0**
- Full sequence: **80 → 22 → 19 → 10 → 7 → 4 → 3 → 2 → 1 → 0**
- Cumulative reduction: **80 of 80 removed (100%)**
- Remaining Chat facade globals: **none**
- Quality guardrail result: **0 window global assignments in `js/`**

## Testing

- `./run-tests.sh`
  - static verification: 126 passed
  - Vitest: 398 passed
  - origin guards: 18 passed
  - Playwright: 352 passed
  - responsive assertions: 472 passed
- `npm run quality`: 7 passed
- affected Playwright coverage: 20 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
