### PR TITLE
Remove application callback globals

### DIFF
--- a/js/legal-consent.js
+++ b/js/legal-consent.js
@@ -2,6 +2,7 @@
 // legal-consent.js — first-launch Terms/Privacy gate and re-consent on document updates.
 
 import { dispatchUtilsRuntimeEvent } from './utils-runtime.js';
+import { showNotification } from './utils.js';
 
 const LEGAL_ACCEPTANCE_KEY = 'labcharts-legal-acceptance';
 export const TERMS_VERSION = '2026-06-22';
@@ -110,9 +111,9 @@ function handleLegalConsentClick(event) {
   closeLegalConsentGate();
   dispatchUtilsRuntimeEvent('legal-consent-accepted');
   if (persisted) {
-    globalThis.showNotification?.('Terms and Privacy accepted.', 'success', 3000);
+    showNotification('Terms and Privacy accepted.', 'success', 3000);
   } else {
-    globalThis.showNotification?.('Terms accepted for this session. Your browser blocked saving the acceptance record, so you may be asked again next visit.', 'warning', 6000);
+    showNotification('Terms accepted for this session. Your browser blocked saving the acceptance record, so you may be asked again next visit.', 'warning', 6000);
   }
 }
 

--- a/js/light-env-shell-hooks.js
+++ b/js/light-env-shell-hooks.js
@@ -2,8 +2,11 @@
 // light-env-shell-hooks.js - wire Light Environment shell actions without window lookups.
 
 import { configureAppEventListeners } from './app-event-listeners.js';
-import { openLightEnvironmentAssessment, closeLightEnvironmentAssessment } from './light-env.js';
+import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';
 import { configureNavActions } from './nav.js';
+import { navigate } from './views.js';
+
+configureLightEnv({ navigate });
 
 configureNavActions({
   openLightEnvironmentAssessment,

--- a/js/light-env.js
+++ b/js/light-env.js
@@ -52,7 +52,6 @@ import {
 import { installLightEnvActionDelegates, lightEnvActionAttrs } from './light-env-actions.js';
 import { SCREEN_HOURS_BUCKETS, renderScreenCard } from './light-env-screen-ui.js';
 import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 export { getLightAudits, saveLightAudit, updateLightAudit, deleteLightAudit } from './light-env-audits.js';
 export {
@@ -89,9 +88,10 @@ export {
 // before falling back to "Room N" so a fresh user lands on familiar labels.
 const DEFAULT_ROOM_NAMES = ['Bedroom', 'Living room', 'Kitchen', 'Office', 'Bathroom'];
 
-/** @type {{ getMeasurementsForRoom: AnyFunction | null, renderBurdenInterp: AnyFunction | null, renderMeasurementAIInline: AnyFunction | null, renderRoomAIBlock: AnyFunction | null, renderScreenAIBlock: AnyFunction | null, openSpectrumClassifier: AnyFunction | null, openLuxMeter: AnyFunction | null, openFlickerDetector: AnyFunction | null, openCCTMeter: AnyFunction | null, openDarknessMeter: AnyFunction | null }} */
+/** @type {{ getMeasurementsForRoom: AnyFunction | null, navigate: AnyFunction | null, renderBurdenInterp: AnyFunction | null, renderMeasurementAIInline: AnyFunction | null, renderRoomAIBlock: AnyFunction | null, renderScreenAIBlock: AnyFunction | null, openSpectrumClassifier: AnyFunction | null, openLuxMeter: AnyFunction | null, openFlickerDetector: AnyFunction | null, openCCTMeter: AnyFunction | null, openDarknessMeter: AnyFunction | null }} */
 const lightEnvDeps = {
   getMeasurementsForRoom: null,
+  navigate: null,
   renderBurdenInterp: null,
   renderMeasurementAIInline: null,
   renderRoomAIBlock: null,
@@ -554,11 +554,9 @@ function refreshLightEnvironmentUI(options = {}) {
   refreshLightEnvironmentAssessment();
   if (options.scrollAnchor) scrollLightEnvironmentAssessmentTo(options.scrollAnchor, options.fallbackScrollAnchor);
   else if (priorScrollTop) setLightEnvironmentAssessmentScrollTop(priorScrollTop);
-  const navigate = typeof globalThis.navigate === 'function'
-    ? globalThis.navigate
-    : (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
+  const navigate = lightEnvDeps.navigate;
   if (navigate && state.currentView === 'light') {
-    navigate.call(globalThis, 'light', options.scrollAnchor ? { scrollAnchor: options.scrollAnchor } : undefined);
+    navigate('light', options.scrollAnchor ? { scrollAnchor: options.scrollAnchor } : undefined);
   }
 }
 

--- a/tests/playwright/light-env-browser-coverage.spec.js
+++ b/tests/playwright/light-env-browser-coverage.spec.js
@@ -44,10 +44,12 @@ test('light environment browser coverage handles summary modal prompt and source
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
       currentView: state.currentView,
-      navigate: window.navigate,
     };
     const outcomes = {};
     const calls = [];
+    const savedLightEnvDeps = lightEnv.configureLightEnv({
+      navigate: (route, meta) => calls.push(['navigate', route, meta || null]),
+    });
     const env = () => state.importedData.lightEnvironment;
     const actions = lightEnv.lightEnvActionHandlers;
 
@@ -71,7 +73,6 @@ test('light environment browser coverage handles summary modal prompt and source
       };
       data.invalidateActiveDataCache();
       localStorage.removeItem('labcharts-light-env-active-room');
-      window.navigate = (route, meta) => calls.push(['navigate', route, meta || null]);
       document.getElementById('light-env-assessment-overlay')?.remove();
 
       const emptyFull = lightEnv.renderEnvironmentSection();
@@ -182,7 +183,7 @@ test('light environment browser coverage handles summary modal prompt and source
       state.currentProfile = saved.currentProfile;
       state.currentView = saved.currentView;
       data.invalidateActiveDataCache();
-      window.navigate = saved.navigate;
+      lightEnv.configureLightEnv(savedLightEnvDeps);
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);
@@ -230,11 +231,11 @@ test('light environment browser coverage handles screens tools and confirm delet
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
       currentView: state.currentView,
-      navigate: window.navigate,
     };
     const outcomes = {};
     const calls = [];
     const savedLightEnvDeps = lightEnv.configureLightEnv({
+      navigate: (route, meta) => calls.push(['navigate', route, meta || null]),
       openSpectrumClassifier: opts => calls.push(['spectrum', opts?.roomId || null]),
       openLuxMeter: opts => calls.push(['lux', opts?.roomId || null]),
       openFlickerDetector: opts => calls.push(['flicker', opts?.roomId || null]),
@@ -264,8 +265,6 @@ test('light environment browser coverage handles screens tools and confirm delet
         lightAudits: [],
       };
       data.invalidateActiveDataCache();
-      window.navigate = (route, meta) => calls.push(['navigate', route, meta || null]);
-
       const officeId = await lightEnv.addRoom('Office');
       const livingId = await lightEnv.addRoom('Living room');
       const bedroomId = await lightEnv.addRoom('Bedroom');
@@ -409,7 +408,6 @@ test('light environment browser coverage handles screens tools and confirm delet
       state.currentProfile = saved.currentProfile;
       state.currentView = saved.currentView;
       data.invalidateActiveDataCache();
-      window.navigate = saved.navigate;
       lightEnv.configureLightEnv(savedLightEnvDeps);
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/playwright/light-env-coverage-batch.spec.js
+++ b/tests/playwright/light-env-coverage-batch.spec.js
@@ -43,11 +43,11 @@ test('Light environment assessment drives delegated room and screen controls', a
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
       currentView: state.currentView,
-      navigate: window.navigate,
     };
     const outcomes = {};
     const calls = [];
     const savedLightEnvDeps = lightEnv.configureLightEnv({
+      navigate: (route, meta) => calls.push(['navigate', route, meta || null]),
       openLuxMeter: opts => calls.push(['open-lux', opts?.roomId || null]),
     });
 
@@ -89,8 +89,6 @@ test('Light environment assessment drives delegated room and screen controls', a
       document.getElementById('tour-overlay')?.remove();
       document.getElementById('tour-spotlight')?.remove();
       document.getElementById('tour-tooltip')?.remove();
-      window.navigate = (route, meta) => calls.push(['navigate', route, meta || null]);
-
       const summaryHost = document.createElement('div');
       summaryHost.id = 'light-env-summary-host';
       summaryHost.innerHTML = lightEnv.renderEnvironmentAssessmentSummary();
@@ -256,7 +254,6 @@ test('Light environment assessment drives delegated room and screen controls', a
       state.currentProfile = saved.currentProfile;
       state.currentView = saved.currentView;
       data.invalidateActiveDataCache();
-      window.navigate = saved.navigate;
       lightEnv.configureLightEnv(savedLightEnvDeps);
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -269,6 +269,10 @@ assert('legal gate runs before changelog and resumes changelog only after accept
   && startupUiSrc.includes("startupRuntime().addEventListener('legal-consent-accepted', () => maybeShowChangelog(), { once: true })")
   && legalConsentSrc.includes("from './utils-runtime.js'")
   && legalConsentSrc.includes("dispatchUtilsRuntimeEvent('legal-consent-accepted')"));
+assert('legal consent notifications use the module dependency instead of a global callback',
+  legalConsentSrc.includes("import { showNotification } from './utils.js';")
+  && legalConsentSrc.includes("showNotification('Terms and Privacy accepted.'")
+  && !legalConsentSrc.includes('globalThis.showNotification'));
 assert('legal accept does not deadlock when localStorage persistence throws',
   /try\s*\{\s*storeLegalAcceptance\(\);\s*\}\s*catch\s*\(err\)\s*\{[\s\S]{0,220}\[legal-consent\] Failed to persist acceptance/.test(legalConsentSrc)
   && /catch\s*\(err\)[\s\S]{0,260}\}\s*closeLegalConsentGate\(\);\s*dispatchUtilsRuntimeEvent\('legal-consent-accepted'\)/.test(legalConsentSrc));

--- a/tests/test-light-env-delegated-actions.js
+++ b/tests/test-light-env-delegated-actions.js
@@ -105,7 +105,10 @@ assert('Light environment modal shell actions are wired through startup hooks',
     !appEventSrc.includes('window.closeLightEnvironmentAssessment') &&
     envShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
     envShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
-    envShellHooksSrc.includes("import { openLightEnvironmentAssessment, closeLightEnvironmentAssessment } from './light-env.js';") &&
+    envShellHooksSrc.includes("import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
+    envShellHooksSrc.includes("import { navigate } from './views.js';") &&
+    envShellHooksSrc.includes('configureLightEnv({ navigate });') &&
+    !envSrc.includes('globalThis.navigate') &&
     appUiShellSrc.includes("import './light-env-shell-hooks.js';"));
 assert('light-env screen renderer takes AI renderer from options instead of global lookup',
   screenSrc.includes('opts.renderScreenAIBlock') &&

--- a/tests/test-light-env.js
+++ b/tests/test-light-env.js
@@ -726,10 +726,13 @@ const {
   assert('Light assessment modal shell actions route through startup wiring instead of window lookup',
     appUiShellSrc.includes("import './light-env-shell-hooks.js';") &&
     lightEnvShellHooksSrc.includes("import { configureAppEventListeners } from './app-event-listeners.js';") &&
-    lightEnvShellHooksSrc.includes("import { openLightEnvironmentAssessment, closeLightEnvironmentAssessment } from './light-env.js';") &&
+    lightEnvShellHooksSrc.includes("import { closeLightEnvironmentAssessment, configureLightEnv, openLightEnvironmentAssessment } from './light-env.js';") &&
+    lightEnvShellHooksSrc.includes("import { navigate } from './views.js';") &&
+    lightEnvShellHooksSrc.includes('configureLightEnv({ navigate });') &&
     lightEnvShellHooksSrc.includes("import { configureNavActions } from './nav.js';") &&
     navSrc.includes("typeof value === 'function'") &&
     appEventSrc.includes("typeof value === 'function'") &&
+    !envSrc.includes('globalThis.navigate') &&
     !appEventSrc.includes('window.closeLightEnvironmentAssessment') &&
     !globalsSrc.includes('openLightEnvironmentAssessment') &&
     !globalsSrc.includes('closeLightEnvironmentAssessment') &&
@@ -828,12 +831,13 @@ const {
 
   const beforeScreenToggleState = window._labState.importedData;
   const beforeScreenToggleView = window._labState.currentView;
-  const beforeNavigate = window.navigate;
   let screenNavCall = null;
+  const beforeScreenNavigateDeps = configureLightEnv({
+    navigate: (route, data) => { screenNavCall = { route, data }; },
+  });
   let screenPrevented = false;
   let screenStopped = false;
   window._labState.currentView = 'light';
-  window.navigate = (route, data) => { screenNavCall = { route, data }; };
   window._labState.importedData = {
     lightEnvironment: { rooms: [], screens: [{ id: 'screen_single', device: 'phone', roomId: null }] },
     lightMeasurements: [],
@@ -848,8 +852,7 @@ const {
     screenNavCall?.route === 'light' &&
     screenNavCall?.data?.scrollAnchor === '.light-env-screen-card[data-id="screen_single"]',
     JSON.stringify(screenNavCall));
-  if (beforeNavigate) window.navigate = beforeNavigate;
-  else delete window.navigate;
+  configureLightEnv(beforeScreenNavigateDeps);
   window._labState.currentView = beforeScreenToggleView;
   window._labState.importedData = beforeScreenToggleState;
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.247';
+self.APP_VERSION = '1.10.248';


### PR DESCRIPTION
## Summary

- import legal-consent notifications directly instead of reading `globalThis.showNotification`
- inject the Light environment navigation callback during startup instead of reading `globalThis.navigate` or the view runtime bridge
- update Node and browser regressions to exercise and enforce the explicit dependency path
- bump the app cache version to `1.10.248`

## Window-burden progress

| Scope | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Chat `window` facade milestone | 80 | 0 | 80 (100%) |
| Application callbacks read from `globalThis` | 4 | 0 | 4 (100%) |
| `window` references in `js/` quality guardrail | 0 | 0 | remains zero |
| `window` assignments in `js/` quality guardrail | 0 | 0 | remains zero |

This PR removes all four callbacks in the new phase: two `showNotification` lookups and two `navigate` lookups. The direct `globalThis` inventory now contains no application callbacks; remaining uses are browser/runtime primitives and the app-version bootstrap value.

## Tests

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-light-env.js`
- `node tests/test-light-env-delegated-actions.js`
- `node tests/test-correctness-phase2.js`
- `npx playwright test tests/playwright/light-env-coverage-batch.spec.js tests/playwright/light-env-browser-coverage.spec.js` (3 passed)
- `npm run quality` (7 passed)
- `./run-tests.sh` (126 static, 398 Vitest, 18 origin guard, 352 Playwright, 472 responsive assertions passed)
