### PR TITLE
Centralize browser app version reads

### DIFF
--- a/js/legal-consent.js
+++ b/js/legal-consent.js
@@ -1,7 +1,7 @@
 // @ts-check
 // legal-consent.js — first-launch Terms/Privacy gate and re-consent on document updates.
 
-import { dispatchUtilsRuntimeEvent } from './utils-runtime.js';
+import { dispatchUtilsRuntimeEvent, getAppVersionRuntime } from './utils-runtime.js';
 import { showNotification } from './utils.js';
 
 const LEGAL_ACCEPTANCE_KEY = 'labcharts-legal-acceptance';
@@ -42,7 +42,7 @@ function storeLegalAcceptance() {
     termsVersion: TERMS_VERSION,
     privacyVersion: PRIVACY_VERSION,
     acceptedAt: nowIso(),
-    appVersion: globalThis.APP_VERSION || null,
+    appVersion: getAppVersionRuntime() || null,
     location: typeof location !== 'undefined' ? location.origin + location.pathname : null,
   };
   localStorage.setItem(LEGAL_ACCEPTANCE_KEY, JSON.stringify(payload));

--- a/js/settings.js
+++ b/js/settings.js
@@ -4,6 +4,7 @@
 import { state } from './state.js';
 import { refreshChartThemeColors } from './charts.js';
 import { escapeHTML, escapeAttr, isDebugMode, setDebugMode, setAnalyticsEnabled, showNotification, showConfirmDialog } from './utils.js';
+import { getAppVersionRuntime } from './utils-runtime.js';
 import { getTheme, setTheme, isSunsetMode, setSunsetMode, isCrtEffectsEnabled, setCrtEffectsEnabled, supportsCrtEffects, getTimeFormat, setTimeFormat, THEMES } from './theme.js';
 import { switchUnitSystem, toggleAltUnits, switchRangeMode } from './data.js';
 import { getAIProvider, hasAIProvider, isAIPaused, setOllamaPIIModel } from './api.js';
@@ -850,7 +851,7 @@ export function openSettingsModal(tab) {
         <button class="settings-link-btn" data-settings-action="open-changelog">What's New</button>
       </div>
 
-      <div style="margin-top:16px;text-align:center;font-size:11px;color:var(--text-muted);font-family:var(--font-mono);opacity:0.6">v${escapeHTML(settingsWindow.APP_VERSION || '')} · <span id="settings-commit-hash">···</span></div>
+      <div style="margin-top:16px;text-align:center;font-size:11px;color:var(--text-muted);font-family:var(--font-mono);opacity:0.6">v${escapeHTML(getAppVersionRuntime())} · <span id="settings-commit-hash">···</span></div>
     </div>
 
     <!-- AI Tab -->

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -12,6 +12,7 @@ import { maybeShowBackupNudge } from './crypto.js';
 import { maybeShowLegalConsentGate } from './legal-consent.js';
 import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 import { maybeShowAnalyticsConsent } from './utils.js';
+import { getAppVersionRuntime } from './utils-runtime.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { updateChatNudgeRuntime } from './chat-runtime.js';
@@ -91,7 +92,7 @@ export function renderStartupUI() {
 function populateFooterVersion() {
   // Populate footer version early (doesn't depend on dashboard render).
   const vTextEl = document.getElementById('app-version-text');
-  if (vTextEl) vTextEl.textContent = getStartupRuntimeValue('APP_VERSION') || '';
+  if (vTextEl) vTextEl.textContent = getAppVersionRuntime();
 }
 
 function scheduleDeferredSyncAndCatalogWarmup() {

--- a/tests/test-changelog.js
+++ b/tests/test-changelog.js
@@ -50,6 +50,10 @@ assert('changelog.js delegates APP_VERSION through utils runtime',
   changelogSrc.includes("from './utils-runtime.js'")
     && changelogSrc.includes('getAppVersionRuntime')
     && !changelogSrc.includes('window.APP_VERSION'));
+assert('Startup footer delegates APP_VERSION through utils runtime',
+  startupUiSrc.includes("import { getAppVersionRuntime } from './utils-runtime.js';")
+    && startupUiSrc.includes('vTextEl.textContent = getAppVersionRuntime()')
+    && !startupUiSrc.includes("getStartupRuntimeValue('APP_VERSION')"));
 assert('changelog.js has CHANGELOG array', changelogSrc.includes('const CHANGELOG'));
 assert('changelog.js exports openChangelog', changelogSrc.includes('export function openChangelog'));
 assert('changelog.js exports closeChangelog', changelogSrc.includes('export function closeChangelog'));

--- a/tests/test-correctness-phase2.js
+++ b/tests/test-correctness-phase2.js
@@ -273,6 +273,10 @@ assert('legal consent notifications use the module dependency instead of a globa
   legalConsentSrc.includes("import { showNotification } from './utils.js';")
   && legalConsentSrc.includes("showNotification('Terms and Privacy accepted.'")
   && !legalConsentSrc.includes('globalThis.showNotification'));
+assert('legal consent version metadata uses the shared runtime adapter',
+  legalConsentSrc.includes('getAppVersionRuntime')
+  && legalConsentSrc.includes('appVersion: getAppVersionRuntime() || null')
+  && !legalConsentSrc.includes('globalThis.APP_VERSION'));
 assert('legal accept does not deadlock when localStorage persistence throws',
   /try\s*\{\s*storeLegalAcceptance\(\);\s*\}\s*catch\s*\(err\)\s*\{[\s\S]{0,220}\[legal-consent\] Failed to persist acceptance/.test(legalConsentSrc)
   && /catch\s*\(err\)[\s\S]{0,260}\}\s*closeLegalConsentGate\(\);\s*dispatchUtilsRuntimeEvent\('legal-consent-accepted'\)/.test(legalConsentSrc));

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -135,6 +135,10 @@ assert('Delegated tweaks handler closes on backdrop click',
 assert('Tweaks feedback action uses configured module runtime',
   src.includes('settingsRuntime.openFeedbackModal()')
     && !src.includes('settingsWindow.openFeedbackModal'));
+assert('Settings version label uses the shared runtime adapter',
+  src.includes("import { getAppVersionRuntime } from './utils-runtime.js';")
+    && src.includes('escapeHTML(getAppVersionRuntime())')
+    && !src.includes('settingsWindow.APP_VERSION'));
 assert('Delegated settings handler switches AI providers',
   /action === 'switch-ai-provider'[\s\S]*switchAIProviderBridge\(actionEl\.dataset\.provider/.test(src));
 assert('Delegated settings handler updates PII model selection',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.248';
+self.APP_VERSION = '1.10.249';


### PR DESCRIPTION
## Summary

- route legal-consent version metadata through the existing `getAppVersionRuntime` adapter
- use the same adapter for the Startup footer and Settings version label
- add source guards that keep those UI consumers off direct runtime/global reads
- bump the app cache version to `1.10.249`

The classic `APP_VERSION` global remains only at its intentional bootstrap boundary and in the service-worker/update adapters that own it.

## Window-burden progress

| Scope | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Chat `window` facade milestone | 80 | 0 | 80 (100%) |
| Application callbacks read from `globalThis` | 4 | 0 | 4 (100%) |
| Scattered browser UI `APP_VERSION` reads | 3 | 0 | 3 (100%) |
| Successive targeted removals | 87 | 0 | 87 (100%) |
| `window` references in `js/` quality guardrail | 0 | 0 | remains zero |
| `window` assignments in `js/` quality guardrail | 0 | 0 | remains zero |

This phase removes the three consumer-side version reads from legal consent, Startup, and Settings. Remaining `APP_VERSION` access is isolated to the shared browser adapter and service-worker version boundary.

## Tests

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-changelog.js` (87 passed)
- `node tests/test-correctness-phase2.js` (184 passed)
- `node tests/test-settings-delegated-actions.js` (59 passed)
- `npx playwright test tests/playwright/startup-helpers-browser-coverage.spec.js tests/playwright/commit-hash-browser-coverage.spec.js` (5 passed)
- `npm run quality` (7 passed)
- `./run-tests.sh` (126 static, 398 Vitest, 18 origin guard, 352 Playwright, 472 responsive assertions passed)
