### PR TITLE
Inject sync pull view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -75,7 +75,7 @@ import { closeFeedbackModal, openFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { closeModal } from './marker-detail-modal.js';
 import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
-import { closeMobileSidebar, configureNavActions } from './nav.js';
+import { buildSidebar, closeMobileSidebar, configureNavActions } from './nav.js';
 import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
@@ -181,7 +181,7 @@ configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRa
 configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButtonVisibility });
 configureOnboardingViewRuntimeDeps({ createNewThread, openChatPanel, toggleChatPanel });
 configureTourRuntimeDeps({ openChatPanel });
-configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatHistory, loadChatThreads, renderThreadList });
+configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });
 configureDashboardAIContextStatus(updateChatContextStatus);
 
 configureAppEventListeners({

--- a/js/sync-pull-active-refresh-runtime.js
+++ b/js/sync-pull-active-refresh-runtime.js
@@ -1,20 +1,22 @@
 // @ts-check
 // sync-pull-active-refresh-runtime.js - Browser runtime adapters for active sync pull refresh hooks.
 
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
-
 const syncPullActiveRefreshDeps = {
+  buildSidebar: null,
   ensureActiveThread: () => {},
   loadChatHistory: () => undefined,
   loadChatThreads: () => undefined,
+  navigate: null,
   renderThreadList: () => {},
 };
 
 export function configureSyncPullActiveRefreshDeps(deps = {}) {
   const previous = { ...syncPullActiveRefreshDeps };
+  if ('buildSidebar' in deps) syncPullActiveRefreshDeps.buildSidebar = typeof deps.buildSidebar === 'function' ? deps.buildSidebar : null;
   if (typeof deps.ensureActiveThread === 'function') syncPullActiveRefreshDeps.ensureActiveThread = deps.ensureActiveThread;
   if (typeof deps.loadChatHistory === 'function') syncPullActiveRefreshDeps.loadChatHistory = deps.loadChatHistory;
   if (typeof deps.loadChatThreads === 'function') syncPullActiveRefreshDeps.loadChatThreads = deps.loadChatThreads;
+  if ('navigate' in deps) syncPullActiveRefreshDeps.navigate = typeof deps.navigate === 'function' ? deps.navigate : null;
   if (typeof deps.renderThreadList === 'function') syncPullActiveRefreshDeps.renderThreadList = deps.renderThreadList;
   return previous;
 }
@@ -23,18 +25,6 @@ function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 export function refreshPulledChatRuntime() {
@@ -56,7 +46,7 @@ export function refreshPulledChatRuntime() {
 }
 
 export function rebuildPulledSidebarRuntime() {
-  try { getViewRuntimeFunction('buildSidebar')?.(); } catch {}
+  try { syncPullActiveRefreshDeps.buildSidebar?.(); } catch {}
 }
 
 /**
@@ -64,7 +54,7 @@ export function rebuildPulledSidebarRuntime() {
  * @param {Record<string, unknown> | undefined} [options]
  */
 export function navigatePulledActiveViewRuntime(route, options) {
-  getRuntimeFunction('navigate')?.(route, options);
+  syncPullActiveRefreshDeps.navigate?.(route, options);
 }
 
 export function dispatchSyncAppliedRuntime() {

--- a/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
+++ b/tests/playwright/sync-pull-refresh-browser-coverage.spec.js
@@ -17,12 +17,11 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
   await openBlankPage(page);
 
   const results = await page.evaluate(async ({ refreshUrl, refreshRuntimeUrl, maintenanceUrl, stateUrl }) => {
-    const [refreshModule, refreshRuntime, maintenance, { state }, viewRuntime] = await Promise.all([
+    const [refreshModule, refreshRuntime, maintenance, { state }] = await Promise.all([
       import(refreshUrl),
       import(refreshRuntimeUrl),
       import(maintenanceUrl),
       import(stateUrl),
-      import('/js/views-runtime-bridge.js'),
     ]);
     const outcomes = {};
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -33,21 +32,15 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
         currentView: state.currentView,
         importedData: clone(state.importedData),
       },
-      navigate: window.navigate,
-    };
-    const restoreWindowFn = (name, value) => {
-      if (value === undefined) delete window[name];
-      else window[name] = value;
     };
     const calls = [];
     const previousThreadDeps = refreshRuntime.configureSyncPullActiveRefreshDeps({
+      buildSidebar: () => { calls.push('buildSidebar'); },
       loadChatHistory: () => { calls.push('loadChatHistory'); },
       loadChatThreads: () => { calls.push('loadChatThreads'); },
       ensureActiveThread: () => { calls.push('ensureActiveThread'); },
+      navigate: (category, options) => { calls.push({ type: 'navigate', category, options: options || null }); },
       renderThreadList: () => { calls.push('renderThreadList'); },
-    });
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
-      buildSidebar: () => { calls.push('buildSidebar'); },
     });
     const debugCalls = [];
     let syncAppliedEvents = 0;
@@ -55,7 +48,6 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
 
     try {
       window.addEventListener('labcharts-sync-applied', onSyncApplied);
-      window.navigate = (category, options) => { calls.push({ type: 'navigate', category, options: options || null }); };
 
       state.currentProfile = activeProfileId;
       state.currentView = 'light';
@@ -152,8 +144,6 @@ test('sync pull refresh browser coverage exercises active refresh and stale hash
       state.currentProfile = original.state.currentProfile;
       state.currentView = original.state.currentView;
       state.importedData = original.state.importedData;
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
-      restoreWindowFn('navigate', original.navigate);
       refreshRuntime.configureSyncPullActiveRefreshDeps(previousThreadDeps);
       document.querySelector('.modal-overlay.show')?.remove();
       document.querySelectorAll('.notification-toast').forEach(toast => toast.remove());

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -90,7 +90,7 @@ assert('App shell wires module-only chat thread consumers',
   appShellHooksSrc.includes("from './chat-threads.js'")
     && appShellHooksSrc.includes('configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });')
     && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ createNewThread, openChatPanel, toggleChatPanel });')
-    && appShellHooksSrc.includes('configureSyncPullActiveRefreshDeps({ ensureActiveThread, loadChatHistory, loadChatThreads, renderThreadList });'));
+    && appShellHooksSrc.includes('configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });'));
 
 assert('App shell wires Context hub status refresh without a window lookup',
   appShellHooksSrc.includes("import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js'")

--- a/tests/test-sync-modal-refresh.js
+++ b/tests/test-sync-modal-refresh.js
@@ -10,8 +10,8 @@ const { state } = await import('../js/state.js');
 const { configureSyncDelta } = await import('../js/sync-delta.js');
 const { mergePulledImportedData } = await import('../js/sync-pull-merge.js');
 const { refreshActiveProfileAfterPull } = await import('../js/sync-pull-active-refresh.js');
+const { configureSyncPullActiveRefreshDeps } = await import('../js/sync-pull-active-refresh-runtime.js');
 const { createNavigate } = await import('../js/views-router.js');
-const { configureViewRuntime } = await import('../js/views-runtime-bridge.js');
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -290,24 +290,28 @@ try {
 }
 
 const originalQuerySelector = document.querySelector;
-const originalNavigate = window.navigate;
 const originalCustomEvent = window.CustomEvent;
 const originalRefreshCurrentProfile = state.currentProfile;
 const originalRefreshCurrentView = state.currentView;
 const originalRefreshImportedData = state.importedData;
-const previousViewRuntime = configureViewRuntime({ buildSidebar: () => {} });
+let navigateCount = 0;
+let navigateArgs = null;
+const previousSyncPullActiveRefreshDeps = configureSyncPullActiveRefreshDeps({
+  buildSidebar: () => {},
+  navigate: (...args) => {
+    navigateCount++;
+    navigateArgs = args;
+  },
+});
 
 try {
   let toastCount = 0;
-  let navigateCount = 0;
-  let navigateArgs = null;
   let syncAppliedCount = 0;
   const container = {
     appendChild: () => { toastCount++; },
   };
   document.getElementById = id => id === 'notification-container' ? container : null;
   document.querySelector = () => null;
-  window.navigate = () => { navigateCount++; };
   window.CustomEvent = class CustomEvent {
     constructor(type) { this.type = type; }
   };
@@ -346,7 +350,6 @@ try {
     navigateCount === 2 && toastCount === 1 && syncAppliedCount === 2);
 
   document.querySelector = selector => selector === '.modal-overlay.show, #modal-overlay.show' ? {} : null;
-  window.navigate = (...args) => { navigateCount++; navigateArgs = args; };
   refreshActiveProfileAfterPull({
     profileId: 'sync-refresh-profile',
     merged: { entries: [{ date: '2026-05-01', markers: { 'biochemistry.glucose': 7 } }] },
@@ -360,9 +363,7 @@ try {
 } finally {
   document.getElementById = originalGetElementById;
   document.querySelector = originalQuerySelector;
-  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
-  if (originalNavigate) window.navigate = originalNavigate;
-  else delete window.navigate;
+  configureSyncPullActiveRefreshDeps(previousSyncPullActiveRefreshDeps);
   window.CustomEvent = originalCustomEvent;
   state.currentProfile = originalRefreshCurrentProfile;
   state.currentView = originalRefreshCurrentView;

--- a/tests/test-sync-pull-active-refresh-runtime.js
+++ b/tests/test-sync-pull-active-refresh-runtime.js
@@ -12,7 +12,6 @@ import {
   rebuildPulledSidebarRuntime,
   refreshPulledChatRuntime,
 } from '../js/sync-pull-active-refresh-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -24,7 +23,6 @@ console.log('=== Sync Pull Active Refresh Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'navigate',
   'CustomEvent',
   'dispatchEvent',
 ];
@@ -48,20 +46,17 @@ function restoreRuntime() {
 }
 
 const calls = [];
-let previousViewRuntime = null;
 const previousDeps = configureSyncPullActiveRefreshDeps({
+  buildSidebar: () => calls.push(['buildSidebar']),
   loadChatHistory: () => calls.push(['loadChatHistory']),
   loadChatThreads: () => calls.push(['loadChatThreads']),
   ensureActiveThread: () => calls.push(['ensureActiveThread']),
+  navigate: (route, options) => calls.push(['navigate', route, options?.preserveScroll]),
   renderThreadList: () => calls.push(['renderThreadList']),
 });
 
 try {
   setRuntimeValue('window', globalThis);
-  previousViewRuntime = configureViewRuntime({
-    buildSidebar: () => calls.push(['buildSidebar']),
-  });
-  setRuntimeValue('navigate', (route, options) => calls.push(['navigate', route, options?.preserveScroll]));
   setRuntimeValue('CustomEvent', class CustomEvent {
     constructor(type) { this.type = type; }
   });
@@ -86,18 +81,19 @@ try {
       'dispatchEvent|labcharts-sync-applied',
     ].join(','));
 
-  configureViewRuntime({ buildSidebar: () => { throw new Error('sidebar boom'); } });
+  configureSyncPullActiveRefreshDeps({ buildSidebar: () => { throw new Error('sidebar boom'); } });
   assert('sync pull active refresh runtime guards sidebar rebuild failures',
     rebuildPulledSidebarRuntime() === undefined);
 
   configureSyncPullActiveRefreshDeps({
+    buildSidebar: null,
     loadChatHistory: () => undefined,
     loadChatThreads: () => undefined,
     ensureActiveThread: () => {},
+    navigate: null,
     renderThreadList: () => {},
   });
   delete globalThis.window;
-  configureViewRuntime({ buildSidebar: null });
   const beforeNoWindowCalls = calls.length;
   refreshPulledChatRuntime();
   rebuildPulledSidebarRuntime();
@@ -121,7 +117,6 @@ try {
       !/\bwindow(?:\.|\s*\[)/.test(refreshSrc) &&
       swSrc.includes("'/js/sync-pull-active-refresh-runtime.js'"));
 } finally {
-  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   configureSyncPullActiveRefreshDeps(previousDeps);
   restoreRuntime();
 }

--- a/tests/test-sync.js
+++ b/tests/test-sync.js
@@ -673,8 +673,9 @@ await import('../js/settings.js');
     syncPullActiveRefreshSrc.includes("from './sync-pull-active-refresh-runtime.js'")
       && !/\bwindow(?:\.|\s*\[)/.test(syncPullActiveRefreshSrc)
       && syncPullActiveRefreshRuntimeSrc.includes('const loaded = syncPullActiveRefreshDeps.loadChatThreads()')
-      && syncPullActiveRefreshRuntimeSrc.includes("getViewRuntimeFunction('buildSidebar')?.()")
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('navigate')?.(route, options)")
+      && syncPullActiveRefreshRuntimeSrc.includes('syncPullActiveRefreshDeps.buildSidebar?.()')
+      && syncPullActiveRefreshRuntimeSrc.includes('syncPullActiveRefreshDeps.navigate?.(route, options)')
+      && !syncPullActiveRefreshRuntimeSrc.includes('getViewRuntimeFunction')
       && syncPullActiveRefreshRuntimeSrc.includes("runtime.dispatchEvent(new runtime.CustomEvent('labcharts-sync-applied'))"));
   assert('service worker precaches sync-pull-active-refresh-runtime.js',
     serviceWorkerSrc.includes("'/js/sync-pull-active-refresh-runtime.js'"));
@@ -1404,7 +1405,7 @@ await import('../js/settings.js');
   // instead of just showing a "Data updated" toast).
   assert('Pull re-renders the active view',
     syncPullActiveRefreshSrc.includes('navigatePulledActiveViewRuntime(cat,')
-      && syncPullActiveRefreshRuntimeSrc.includes("getRuntimeFunction('navigate')?.(route, options)"));
+      && syncPullActiveRefreshRuntimeSrc.includes('syncPullActiveRefreshDeps.navigate?.(route, options)'));
   assert('Pull calls migrateProfileData', syncPullActiveRefreshSrc.includes('migrateProfileData(state.importedData)'));
   assert('enableSync pulls before first enable push to avoid publishing stale local state',
     /await forcePull\(\)[\s\S]{0,300}await pushAllProfiles\(\)/.test(syncLifecycleSrc));
@@ -2971,7 +2972,7 @@ await import('../js/settings.js');
   // import. Lives in sync-pull-active-refresh.js's active-profile post-merge block.
   assert('onSyncReceived rebuilds sidebar after every pull (catches nav items gated on per-row data)',
     /profileId\s*!==\s*state\.currentProfile[\s\S]{0,2400}rebuildPulledSidebarRuntime\(\)[\s\S]{0,1200}shouldRefreshVisibleData/.test(deltaSearchSrc)
-      && syncPullActiveRefreshRuntimeSrc.includes("getViewRuntimeFunction('buildSidebar')?.()"));
+      && syncPullActiveRefreshRuntimeSrc.includes('syncPullActiveRefreshDeps.buildSidebar?.()'));
 
   const localWithSnps = {
     genetics: {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.249';
+self.APP_VERSION = '1.10.250';


### PR DESCRIPTION
## Summary

- inject `buildSidebar` and `navigate` into the active sync-pull refresh runtime
- remove its remaining `views-runtime-bridge` lookups and test-time `window.navigate` mutation
- wire the browser shell explicitly while keeping the `CustomEvent` dispatch as the intentional browser runtime boundary
- bump the app cache version to `1.10.250`

## Window-burden progress

| Targeted surface | Before | After | Removed |
| --- | ---: | ---: | ---: |
| Chat `window` facade | 80 | 0 | 80 |
| Application callback globals | 4 | 0 | 4 |
| Scattered browser UI `APP_VERSION` reads | 3 | 0 | 3 |
| Active sync-pull view bridge lookups | 2 | 0 | 2 |
| **Cumulative targeted accesses** | **89** | **0** | **89** |
| Quality-guarded `window.` references in `js/` | 0 | 0 | 0 |
| Quality-guarded `window` assignments in `js/` | 0 | 0 | 0 |

This PR advances the reduction by two additional runtime bridge lookups without introducing new `window.` references or assignments.

## Verification

- `./run-tests.sh` — passed (126 static checks, 398 Vitest tests, 352 Playwright tests, 472 responsive assertions)
- `npm run quality` — 7 passed, 0 failed; `window` references/assignments remain 0
- `node tests/test-sync.js` — 827 passed
- `node tests/test-sync-modal-refresh.js` — 22 passed
- `node tests/test-sync-pull-active-refresh-runtime.js` — 5 passed
- `node tests/test-shell-delegated-actions.js` — 65 passed
- `npx playwright test tests/playwright/sync-pull-refresh-browser-coverage.spec.js` — 1 passed
- `git diff --check` — passed
