### PR TITLE
Inject wearable navigation dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -98,6 +98,8 @@ import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
 import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
 import { configureTourRuntimeDeps } from './tour-runtime.js';
+import { configureWearablesConnectRuntimeDeps } from './wearables-connect-runtime.js';
+import { configureWearableSettingsRuntimeDeps } from './wearables-settings-runtime.js';
 
 configureClientListRuntime({
   exportAllDataJSON,
@@ -182,6 +184,8 @@ configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButto
 configureOnboardingViewRuntimeDeps({ createNewThread, openChatPanel, toggleChatPanel });
 configureTourRuntimeDeps({ openChatPanel });
 configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });
+configureWearablesConnectRuntimeDeps({ navigate });
+configureWearableSettingsRuntimeDeps({ navigate });
 configureDashboardAIContextStatus(updateChatContextStatus);
 
 configureAppEventListeners({

--- a/js/wearables-connect-runtime.js
+++ b/js/wearables-connect-runtime.js
@@ -1,24 +1,22 @@
 // @ts-check
 // wearables-connect-runtime.js - Browser runtime adapters for wearable connect orchestration.
 
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+const wearablesConnectRuntimeDeps = { navigate: null };
+
+export function configureWearablesConnectRuntimeDeps(deps = {}) {
+  const previous = { ...wearablesConnectRuntimeDeps };
+  if ('navigate' in deps) {
+    wearablesConnectRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? deps.navigate
+      : null;
+  }
+  return previous;
+}
 
 function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 export function getWearableOAuthSearchParamsRuntime() {
@@ -33,7 +31,7 @@ export function clearWearableOAuthCallbackRuntime() {
 }
 
 export function navigateWearablesDashboardAfterConnectRuntime() {
-  getRuntimeFunction('navigate')?.('dashboard');
+  wearablesConnectRuntimeDeps.navigate?.('dashboard');
 }
 
 /** @param {EventListenerOrEventListenerObject} handler */

--- a/js/wearables-settings-runtime.js
+++ b/js/wearables-settings-runtime.js
@@ -3,12 +3,19 @@
 
 import { showConfirmDialog } from './utils.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const wearableSettingsRuntimeDeps = { showConfirmDialog };
+const wearableSettingsRuntimeDeps = {
+  navigate: null,
+  showConfirmDialog,
+};
 
 export function configureWearableSettingsRuntimeDeps(deps = {}) {
   const previous = { ...wearableSettingsRuntimeDeps };
+  if ('navigate' in deps) {
+    wearableSettingsRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? deps.navigate
+      : null;
+  }
   if ('showConfirmDialog' in deps) {
     wearableSettingsRuntimeDeps.showConfirmDialog = typeof deps.showConfirmDialog === 'function'
       ? /** @type {typeof showConfirmDialog} */ (deps.showConfirmDialog)
@@ -17,30 +24,12 @@ export function configureWearableSettingsRuntimeDeps(deps = {}) {
   return previous;
 }
 
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
-}
-
 export function closeWearableSettingsModal() {
   getSettingsModuleFunction('closeSettingsModal')?.();
 }
 
 export function navigateWearablesDashboard() {
-  getRuntimeFunction('navigate')?.('dashboard');
+  wearableSettingsRuntimeDeps.navigate?.('dashboard');
 }
 
 /** @param {string} message */

--- a/tests/playwright/wearables-connect-browser-coverage.spec.js
+++ b/tests/playwright/wearables-connect-browser-coverage.spec.js
@@ -33,6 +33,7 @@ test('wearables connect browser coverage drives OAuth callback, backfill, refres
 
     const { state } = await import('/js/state.js');
     const connect = await import(connectUrl);
+    const connectRuntime = await import('/js/wearables-connect-runtime.js');
     const store = await import(storeUrl);
     await import('/js/wearable-adapters.js');
 
@@ -42,6 +43,9 @@ test('wearables connect browser coverage drives OAuth callback, backfill, refres
     const navigations = [];
     const requests = [];
     let refreshCount = 0;
+    const originalConnectRuntimeDeps = connectRuntime.configureWearablesConnectRuntimeDeps({
+      navigate: route => navigations.push(route),
+    });
 
     localStorage.setItem('labcharts-active-profile', profileId);
     state.currentProfile = profileId;
@@ -49,8 +53,6 @@ test('wearables connect browser coverage drives OAuth callback, backfill, refres
     state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, wearableConnections: {}, wearableSummary: null, customMarkers: {}, markerNotes: {}, markerValueNotes: {}, changeHistory: [] };
 
     document.body.innerHTML = '<div id="notification-container"></div>';
-    window.navigate = route => navigations.push(route);
-
     await store.clearSource(profileId, 'oura').catch(() => {});
     await store.clearSource(profileId, 'polar').catch(() => {});
 
@@ -211,6 +213,7 @@ test('wearables connect browser coverage drives OAuth callback, backfill, refres
       const skippedSync = await connect.syncNow('oura');
       check('syncNow skips disconnected source', skippedSync.skipped === true && skippedSync.reason === 'not-connected');
     } finally {
+      connectRuntime.configureWearablesConnectRuntimeDeps(originalConnectRuntimeDeps);
       window.fetch = originalFetch;
       history.replaceState(null, '', `${location.pathname}${originalLocationSearch || ''}`);
       await store.clearSource(profileId, 'oura').catch(() => {});

--- a/tests/playwright/wearables-settings-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-browser-coverage.spec.js
@@ -38,7 +38,6 @@ test('wearables settings browser coverage exercises import and connection action
     const originalActiveProfile = localStorage.getItem('labcharts-active-profile');
     const originalCurrentProfile = state.currentProfile;
     const originalImported = state.importedData;
-    const originalNavigate = window.navigate;
     const originalSettingsRuntimeDeps = settingsRuntime.configureWearableSettingsRuntimeDeps();
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     const originalImportedLocalValue = localStorage.getItem(importedKey);
@@ -75,7 +74,9 @@ test('wearables settings browser coverage exercises import and connection action
         wearableSummary: null,
         changeHistory: [],
       };
-      window.navigate = route => calls.push(['navigate', route]);
+      settingsRuntime.configureWearableSettingsRuntimeDeps({
+        navigate: route => calls.push(['navigate', route]),
+      });
 
       const section = renderSettings();
       check('settings section renders Apple Health import controls',
@@ -187,8 +188,6 @@ test('wearables settings browser coverage exercises import and connection action
       else localStorage.removeItem('labcharts-active-profile');
       state.currentProfile = originalCurrentProfile;
       state.importedData = originalImported;
-      if (originalNavigate) window.navigate = originalNavigate;
-      else delete window.navigate;
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       settingsRuntime.configureWearableSettingsRuntimeDeps(originalSettingsRuntimeDeps);
       window.requestAnimationFrame = originalRequestAnimationFrame;

--- a/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
+++ b/tests/playwright/wearables-settings-panel-browser-coverage.spec.js
@@ -19,11 +19,12 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       return false;
     };
 
-    const [{ state }, settings, store, settingsBridge] = await Promise.all([
+    const [{ state }, settings, store, settingsBridge, settingsRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/wearables-settings-panel.js'),
       import('/js/wearables-store.js'),
       import('/js/settings-runtime-bridge.js'),
+      import('/js/wearables-settings-runtime.js'),
     ]);
 
     const profileId = `wearables-settings-render-${Date.now()}`;
@@ -35,7 +36,6 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
     const oldCurrentProfile = state.currentProfile;
     const oldProfiles = state.profiles;
     const oldImportedData = state.importedData;
-    const oldNavigate = window.navigate;
     const oldScrollIntoView = Element.prototype.scrollIntoView;
     const navigations = [];
     const docsClicks = [];
@@ -43,6 +43,9 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
     let scrolledToStrip = 0;
     const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
       closeSettingsModal: () => { closedSettings += 1; },
+    });
+    const previousSettingsRuntimeDeps = settingsRuntime.configureWearableSettingsRuntimeDeps({
+      navigate: route => { navigations.push(route); },
     });
 
     try {
@@ -102,7 +105,6 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
         { source: 'manual', date: '2026-06-03', rhr: 54 },
       ]);
 
-      window.navigate = route => { navigations.push(route); };
       Element.prototype.scrollIntoView = function scrollIntoView() {
         if (this.id === 'wearable-strip') scrolledToStrip += 1;
       };
@@ -192,8 +194,8 @@ test('wearables settings panel browser coverage renders rows, counts, and naviga
       state.currentProfile = oldCurrentProfile;
       state.profiles = oldProfiles;
       state.importedData = oldImportedData;
-      window.navigate = oldNavigate;
       settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
+      settingsRuntime.configureWearableSettingsRuntimeDeps(previousSettingsRuntimeDeps);
       Element.prototype.scrollIntoView = oldScrollIntoView;
     }
     return failures;
@@ -233,7 +235,6 @@ test('wearables settings panel browser coverage deletes manual data after confir
     const oldCurrentProfile = state.currentProfile;
     const oldProfiles = state.profiles;
     const oldImportedData = state.importedData;
-    const oldNavigate = window.navigate;
     const oldSettingsRuntimeDeps = settingsRuntime.configureWearableSettingsRuntimeDeps();
     const navigations = [];
     const confirmMessages = [];
@@ -280,11 +281,13 @@ test('wearables settings panel browser coverage deletes manual data after confir
         { source: 'manual', date: '2026-06-05', rhr: 58 },
       ]);
 
-      window.navigate = route => { navigations.push(route); };
-      settingsRuntime.configureWearableSettingsRuntimeDeps({ showConfirmDialog: async message => {
-        confirmMessages.push(message);
-        return true;
-      } });
+      settingsRuntime.configureWearableSettingsRuntimeDeps({
+        navigate: route => { navigations.push(route); },
+        showConfirmDialog: async message => {
+          confirmMessages.push(message);
+          return true;
+        },
+      });
       document.body.insertAdjacentHTML('beforeend', `
         <section id="wearables-section">${settings.renderWearablesSettingsSection()}</section>
       `);
@@ -320,7 +323,6 @@ test('wearables settings panel browser coverage deletes manual data after confir
       state.currentProfile = oldCurrentProfile;
       state.profiles = oldProfiles;
       state.importedData = oldImportedData;
-      window.navigate = oldNavigate;
       settingsRuntime.configureWearableSettingsRuntimeDeps(oldSettingsRuntimeDeps);
     }
     return failures;

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -122,6 +122,10 @@ assert('App shell wires remaining Chat open consumers without window globals',
     && appShellHooksSrc.includes('configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });')
     && appShellHooksSrc.includes('configureTourRuntimeDeps({ openChatPanel });'));
 
+assert('App shell injects wearable navigation without view bridge lookups',
+  appShellHooksSrc.includes('configureWearablesConnectRuntimeDeps({ navigate });')
+    && appShellHooksSrc.includes('configureWearableSettingsRuntimeDeps({ navigate });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/tests/test-wearables-connect-runtime.js
+++ b/tests/test-wearables-connect-runtime.js
@@ -8,9 +8,12 @@ import './_node-shim.js';
 import {
   addWearablesBeforeUnloadRuntime,
   clearWearableOAuthCallbackRuntime,
+  configureWearablesConnectRuntimeDeps,
   getWearableOAuthSearchParamsRuntime,
   navigateWearablesDashboardAfterConnectRuntime,
 } from '../js/wearables-connect-runtime.js';
+
+const originalWearablesConnectRuntimeDeps = configureWearablesConnectRuntimeDeps();
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -24,7 +27,6 @@ const runtimeKeys = [
   'window',
   'location',
   'history',
-  'navigate',
   'addEventListener',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
@@ -53,7 +55,7 @@ try {
   setRuntimeValue('history', {
     replaceState: (state, title, pathValue) => calls.push(['replaceState', String(state), title, pathValue]),
   });
-  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
+  configureWearablesConnectRuntimeDeps({ navigate: route => calls.push(['navigate', route]) });
   setRuntimeValue('addEventListener', (eventName, handler) => {
     calls.push(['addEventListener', eventName]);
     if (eventName === 'beforeunload') handler();
@@ -75,6 +77,7 @@ try {
     ].join(',') && addedUnload === true && unloaded === true);
 
   delete globalThis.window;
+  configureWearablesConnectRuntimeDeps({ navigate: null });
   const beforeNoWindowCalls = calls.length;
   const emptyParams = getWearableOAuthSearchParamsRuntime();
   clearWearableOAuthCallbackRuntime();
@@ -87,12 +90,21 @@ try {
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const connectSrc = fs.readFileSync(path.join(root, 'js/wearables-connect.js'), 'utf8');
+  const connectRuntimeSrc = fs.readFileSync(path.join(root, 'js/wearables-connect-runtime.js'), 'utf8');
+  const settingsRuntimeSrc = fs.readFileSync(path.join(root, 'js/wearables-settings-runtime.js'), 'utf8');
+  const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
   const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
   assert('wearables connect delegates browser globals through runtime adapter',
     connectSrc.includes("from './wearables-connect-runtime.js'") &&
       !/\bwindow(?:\.|\s*\[)/.test(connectSrc) &&
       swSrc.includes("'/js/wearables-connect-runtime.js'"));
+  assert('wearable navigation stays dependency-injected from the app shell',
+    !connectRuntimeSrc.includes('getViewRuntimeFunction') &&
+      !settingsRuntimeSrc.includes('getViewRuntimeFunction') &&
+      appShellHooksSrc.includes('configureWearablesConnectRuntimeDeps({ navigate });') &&
+      appShellHooksSrc.includes('configureWearableSettingsRuntimeDeps({ navigate });'));
 } finally {
+  configureWearablesConnectRuntimeDeps(originalWearablesConnectRuntimeDeps);
   restoreRuntime();
 }
 

--- a/tests/test-wearables-settings-runtime.js
+++ b/tests/test-wearables-settings-runtime.js
@@ -20,17 +20,8 @@ function assert(name, condition, detail) {
 
 console.log('=== Wearables Settings Runtime Tests ===\n');
 
-const runtimeKeys = ['window', 'navigate', 'showConfirmDialog'];
+const runtimeKeys = ['window'];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
-
-function setRuntimeValue(key, value) {
-  Object.defineProperty(globalThis, key, {
-    configurable: true,
-    writable: true,
-    enumerable: true,
-    value,
-  });
-}
 
 function restoreRuntime() {
   for (const key of runtimeKeys) {
@@ -42,14 +33,16 @@ function restoreRuntime() {
 
 try {
   const calls = [];
-  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
   const previousSettingsBridge = configureSettingsModuleBridge({
     closeSettingsModal: () => calls.push(['close-settings']),
   });
-  configureWearableSettingsRuntimeDeps({ showConfirmDialog: async message => {
-    calls.push(['confirm', message]);
-    return message === 'confirm me';
-  } });
+  configureWearableSettingsRuntimeDeps({
+    navigate: route => calls.push(['navigate', route]),
+    showConfirmDialog: async message => {
+      calls.push(['confirm', message]);
+      return message === 'confirm me';
+    },
+  });
 
   navigateWearablesDashboard();
   closeWearableSettingsModal();
@@ -63,7 +56,7 @@ try {
 
   delete globalThis.window;
   configureSettingsModuleBridge({ closeSettingsModal: null });
-  configureWearableSettingsRuntimeDeps({ showConfirmDialog: null });
+  configureWearableSettingsRuntimeDeps({ navigate: null, showConfirmDialog: null });
   navigateWearablesDashboard();
   closeWearableSettingsModal();
   const missingConfirm = await confirmWearableSettingsAction('confirm me');

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.250';
+self.APP_VERSION = '1.10.251';


### PR DESCRIPTION
## Summary

- inject `navigate` into the wearable settings and OAuth-connect runtimes from the app shell
- remove both runtimes' remaining `views-runtime-bridge` navigation fallbacks
- update Node and browser tests to inject navigation rather than mutate `window.navigate`
- retain location, history, and beforeunload access in the connect runtime as intentional browser primitives
- bump the app cache version to `1.10.251`

## Window-burden progress

| Targeted surface | Before | After | Removed |
| --- | ---: | ---: | ---: |
| Chat `window` facade | 80 | 0 | 80 |
| Application callback globals | 4 | 0 | 4 |
| Scattered browser UI `APP_VERSION` reads | 3 | 0 | 3 |
| Active sync-pull view bridge lookups | 2 | 0 | 2 |
| Wearable navigation bridge lookups | 2 | 0 | 2 |
| **Cumulative targeted accesses** | **91** | **0** | **91** |
| Quality-guarded `window.` references in `js/` | 0 | 0 | 0 |
| Quality-guarded `window` assignments in `js/` | 0 | 0 | 0 |

This PR advances the reduction by two more navigation bridge lookups without introducing new `window.` references or assignments.

## Verification

- `./run-tests.sh` — passed (126 static checks, 398 Vitest tests, 352 Playwright tests, 472 responsive assertions)
- `npm run quality` — 7 passed, 0 failed; `window` references/assignments remain 0
- affected wearable Playwright specs — 5 passed
- `node tests/test-wearables.js` — 584 passed
- `node tests/test-wearables-manual.js` — 101 passed
- `node tests/test-wearables-connect-runtime.js` — 5 passed
- `node tests/test-wearables-settings-runtime.js` — 4 passed
- `node tests/test-shell-delegated-actions.js` — 66 passed
- `npm run typecheck` and `npm run typecheck:checkjs` — passed
- `git diff --check` — passed
