### PR TITLE
Inject category customization dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -7,6 +7,7 @@ import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js';
 import { closeChangelog } from './changelog.js';
 import { configureChatMessageActionDeps } from './chat-actions.js';
 import { configureChatEmptyStateDeps } from './chat-empty-state.js';
+import { configureCategoryCustomizationRuntimeDeps } from './category-customization-runtime.js';
 import {
   continueDiscussion,
   endDiscussion,
@@ -123,6 +124,7 @@ configureSettingsRuntime({
 });
 
 configureNavActions({ openClientList });
+configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });

--- a/js/category-customization-runtime.js
+++ b/js/category-customization-runtime.js
@@ -2,12 +2,25 @@
 // category-customization-runtime.js - Browser runtime hooks for category customization.
 
 import { showPromptDialog } from './utils.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const categoryCustomizationRuntimeDeps = { showPromptDialog };
+const categoryCustomizationRuntimeDeps = {
+  buildSidebar: null,
+  navigate: null,
+  showPromptDialog,
+};
 
 export function configureCategoryCustomizationRuntimeDeps(deps = {}) {
   const previous = { ...categoryCustomizationRuntimeDeps };
+  if ('buildSidebar' in deps) {
+    categoryCustomizationRuntimeDeps.buildSidebar = typeof deps.buildSidebar === 'function'
+      ? deps.buildSidebar
+      : null;
+  }
+  if ('navigate' in deps) {
+    categoryCustomizationRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? deps.navigate
+      : null;
+  }
   if ('showPromptDialog' in deps) {
     categoryCustomizationRuntimeDeps.showPromptDialog = typeof deps.showPromptDialog === 'function'
       ? /** @type {typeof showPromptDialog} */ (deps.showPromptDialog)
@@ -26,29 +39,18 @@ function getRuntimeScope() {
 }
 
 /**
- * @param {string} name
- * @returns {((...args: any[]) => any) | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeScope();
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' && typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
-}
-
-/**
  * @param {string} route
  * @param {any} [data]
  */
 export function navigateCategoryCustomizationRuntime(route, data) {
-  getRuntimeFunction('navigate')?.(route, data);
+  categoryCustomizationRuntimeDeps.navigate?.(route, data);
 }
 
 /**
  * @returns {((data?: any) => void) | null}
  */
 export function getCategoryCustomizationBuildSidebar() {
-  return /** @type {((data?: any) => void) | null} */ (getViewRuntimeFunction('buildSidebar'));
+  return categoryCustomizationRuntimeDeps.buildSidebar;
 }
 
 /**

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -57,28 +57,27 @@ test('category customization covers rename icon and emoji picker browser paths',
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ categoryUrl }) => {
-    const [{ state }, category, categoryRuntime, viewRuntime] = await Promise.all([
+    const [{ state }, category, categoryRuntime] = await Promise.all([
       import('/js/state.js'),
       import(categoryUrl),
       import('/js/category-customization-runtime.js'),
-      import('/js/views-runtime-bridge.js'),
     ]);
     const categorySrc = await fetch(categoryUrl).then(response => response.text());
+    const categoryRuntimeSrc = await fetch('/js/category-customization-runtime.js').then(response => response.text());
     const outcomes = {};
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const saved = {
       importedData: clone(state.importedData),
       currentView: state.currentView,
-      navigate: window.navigate,
     };
     const calls = [];
     let promptValue = null;
+    const navigate = (route, data) => calls.push(['navigate', route, !!data?.categories?.lipids]);
     const previousCategoryRuntimeDeps = categoryRuntime.configureCategoryCustomizationRuntimeDeps({
-      showPromptDialog: async () => promptValue,
-    });
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
       buildSidebar: data => calls.push(['fallbackSidebar', !!data?.categories?.lipids]),
+      navigate,
+      showPromptDialog: async () => promptValue,
     });
 
     try {
@@ -98,7 +97,6 @@ test('category customization covers rename icon and emoji picker browser paths',
         },
       };
       state.currentView = 'dashboard';
-      window.navigate = (route, data) => calls.push(['navigate', route, !!data?.categories?.lipids]);
 
       promptValue = '  Fallback Lipids  ';
       await category.renameCategory('lipids');
@@ -107,7 +105,7 @@ test('category customization covers rename icon and emoji picker browser paths',
 
       category.configureCategoryCustomization({
         buildSidebar: data => calls.push(['sidebar', !!data?.categories?.lipids]),
-        navigate: window.navigate,
+        navigate,
       });
 
       promptValue = '  Better Lipids  ';
@@ -122,6 +120,7 @@ test('category customization covers rename icon and emoji picker browser paths',
         && categorySrc.includes('getCategoryCustomizationViewportSize')
         && categorySrc.includes('getFallbackBuildSidebar')
         && categorySrc.includes('buildSidebar?.(data)')
+        && !categoryRuntimeSrc.includes('getViewRuntimeFunction')
         && !/\bwindow(?:\.|\s*\[)/.test(categorySrc);
       outcomes.renameMissingCategoryNoops = await category.renameCategory('missing-category') === undefined;
 
@@ -191,11 +190,9 @@ test('category customization covers rename icon and emoji picker browser paths',
       state.importedData = saved.importedData;
       state.currentView = saved.currentView;
       categoryRuntime.configureCategoryCustomizationRuntimeDeps(previousCategoryRuntimeDeps);
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
-      window.navigate = saved.navigate;
       category.configureCategoryCustomization({
-        buildSidebar: previousViewRuntime.buildSidebar || (() => {}),
-        navigate: saved.navigate || (() => {}),
+        buildSidebar: previousCategoryRuntimeDeps.buildSidebar || (() => {}),
+        navigate: previousCategoryRuntimeDeps.navigate || (() => {}),
       });
       document.querySelector('.emoji-picker')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());

--- a/tests/test-category-customization-runtime.js
+++ b/tests/test-category-customization-runtime.js
@@ -8,7 +8,6 @@ import {
   navigateCategoryCustomizationRuntime,
   showCategoryCustomizationPrompt,
 } from '../js/category-customization-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 const originalCategoryCustomizationRuntimeDeps = configureCategoryCustomizationRuntimeDeps();
 
@@ -22,9 +21,6 @@ console.log('=== Category Customization Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'navigate',
-  'buildSidebar',
-  'showPromptDialog',
   'innerWidth',
   'innerHeight',
 ];
@@ -49,7 +45,6 @@ function restoreRuntime() {
 
 try {
   const calls = [];
-  let previousViewRuntime = null;
   const browserRuntime = {
     innerWidth: 812,
     innerHeight: 640,
@@ -65,10 +60,9 @@ try {
     },
   };
   setRuntimeValue('window', browserRuntime);
-  previousViewRuntime = configureViewRuntime({
-    buildSidebar: browserRuntime.buildSidebar.bind(browserRuntime),
-  });
   configureCategoryCustomizationRuntimeDeps({
+    buildSidebar: browserRuntime.buildSidebar.bind(browserRuntime),
+    navigate: browserRuntime.navigate.bind(browserRuntime),
     showPromptDialog: browserRuntime.showPromptDialog.bind(browserRuntime),
   });
 
@@ -94,28 +88,27 @@ try {
 
   delete browserRuntime.navigate;
   delete browserRuntime.buildSidebar;
-  configureViewRuntime({
+  configureCategoryCustomizationRuntimeDeps({
     buildSidebar: null,
-    navigate: route => calls.push(['module-navigate', route]),
+    navigate: null,
+    showPromptDialog: null,
   });
-  configureCategoryCustomizationRuntimeDeps({ showPromptDialog: null });
   delete browserRuntime.innerWidth;
   delete browserRuntime.innerHeight;
+  const beforeMissingCalls = calls.length;
   navigateCategoryCustomizationRuntime('missing');
   assert('runtime hooks no-op when browser callbacks are missing',
     getCategoryCustomizationBuildSidebar() === null
       && await showCategoryCustomizationPrompt('Missing callback') === undefined
-      && calls.some(call => call[0] === 'module-navigate' && call[1] === 'missing'));
+      && calls.length === beforeMissingCalls);
   const fallbackViewport = getCategoryCustomizationViewportSize();
   assert('viewport helper falls back when dimensions are missing',
     fallbackViewport.width === 1024 && fallbackViewport.height === 768);
 
   delete globalThis.window;
-  let globalNavigateCalled = false;
-  setRuntimeValue('navigate', route => { globalNavigateCalled = route === 'dashboard'; });
+  const beforeNoWindowCalls = calls.length;
   navigateCategoryCustomizationRuntime('dashboard');
-  assert('runtime hooks fall back to globalThis when window is missing', globalNavigateCalled);
-  configureViewRuntime({ buildSidebar: null, navigate: null, ...previousViewRuntime });
+  assert('runtime callbacks stay no-op when window is missing', calls.length === beforeNoWindowCalls);
 } finally {
   configureCategoryCustomizationRuntimeDeps(originalCategoryCustomizationRuntimeDeps);
   restoreRuntime();

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -126,6 +126,9 @@ assert('App shell injects wearable navigation without view bridge lookups',
   appShellHooksSrc.includes('configureWearablesConnectRuntimeDeps({ navigate });')
     && appShellHooksSrc.includes('configureWearableSettingsRuntimeDeps({ navigate });'));
 
+assert('App shell injects category customization view callbacks',
+  appShellHooksSrc.includes('configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.251';
+self.APP_VERSION = '1.10.252';


### PR DESCRIPTION
## Summary

- inject `navigate` and `buildSidebar` into the category customization runtime from the app shell
- remove its remaining `views-runtime-bridge` fallbacks
- update Node and browser tests to configure explicit callbacks rather than the view bridge or `window.navigate`
- retain viewport width/height reads as the intentional browser runtime boundary
- bump the app cache version to `1.10.252`

## Window-burden progress

| Targeted surface | Before | After | Removed |
| --- | ---: | ---: | ---: |
| Chat `window` facade | 80 | 0 | 80 |
| Application callback globals | 4 | 0 | 4 |
| Scattered browser UI `APP_VERSION` reads | 3 | 0 | 3 |
| Active sync-pull view bridge lookups | 2 | 0 | 2 |
| Wearable navigation bridge lookups | 2 | 0 | 2 |
| Category customization bridge lookups | 2 | 0 | 2 |
| **Cumulative targeted accesses** | **93** | **0** | **93** |
| Quality-guarded `window.` references in `js/` | 0 | 0 | 0 |
| Quality-guarded `window` assignments in `js/` | 0 | 0 | 0 |

This PR removes two more view-runtime lookups without introducing new `window.` references or assignments.

## Verification

- `./run-tests.sh` — passed (126 static checks, 398 Vitest tests, 352 Playwright tests, 472 responsive assertions)
- `npm run quality` — 7 passed, 0 failed; `window` references/assignments remain 0
- `npx playwright test tests/playwright/context-coverage-batch.spec.js` — 4 passed
- `node tests/test-category-customization-runtime.js` — 8 passed
- `node tests/test-shell-delegated-actions.js` — 67 passed
- `npm run typecheck` and `npm run typecheck:checkjs` — passed
- `git diff --check` — passed
