### PR TITLE
Inject sun defaults navigation

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -126,7 +126,7 @@ configureSettingsRuntime({
 configureNavActions({ openClientList });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
-configureSunDefaultsRuntimeDeps({ openClientList, openProfileLocationEditor });
+configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });
 configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel });

--- a/js/sun-defaults-runtime.js
+++ b/js/sun-defaults-runtime.js
@@ -2,11 +2,11 @@
 // sun-defaults-runtime.js - Browser runtime adapters for Light setup defaults.
 
 import { getProfileLocation } from './profile.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const sunDefaultsRuntimeDeps = {
   getProfileLocation,
   getSunCoords: null,
+  navigate: null,
   requestPreciseLocation: null,
   openProfileLocationEditor: null,
   openClientList: null,
@@ -15,27 +15,12 @@ const sunDefaultsRuntimeDeps = {
 export function configureSunDefaultsRuntimeDeps(deps = {}) {
   const previous = { ...sunDefaultsRuntimeDeps };
   if (typeof deps.getProfileLocation === 'function') sunDefaultsRuntimeDeps.getProfileLocation = deps.getProfileLocation;
-  for (const name of ['getSunCoords', 'requestPreciseLocation', 'openProfileLocationEditor', 'openClientList']) {
+  for (const name of ['getSunCoords', 'navigate', 'requestPreciseLocation', 'openProfileLocationEditor', 'openClientList']) {
     if (name in deps) {
       sunDefaultsRuntimeDeps[name] = typeof deps[name] === 'function' ? deps[name] : null;
     }
   }
   return previous;
-}
-
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : null;
-}
-
-/** @param {string} name */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
 }
 
 export function getSunSetupCoords() {
@@ -82,5 +67,5 @@ export function requestSunSetupPreciseLocationRuntime() {
 
 /** @param {string} route */
 export function navigateSunDefaultsRoute(route) {
-  getRuntimeFunction('navigate')?.(route);
+  sunDefaultsRuntimeDeps.navigate?.(route);
 }

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -15,6 +15,7 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       import('/js/state.js'),
       import('/js/data.js'),
     ]);
+    const sunDefaultsRuntimeSrc = await fetch('/js/sun-defaults-runtime.js').then(response => response.text());
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (selector, label = selector) => {
@@ -45,13 +46,13 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       currentProfile: state.currentProfile,
       profileSex: state.profileSex,
       profileDob: state.profileDob,
-      navigate: window.navigate,
     };
     const calls = [];
     const outcomes = {};
     let precise = false;
     const previousSunDefaultsRuntimeDeps = sunDefaultsRuntime.configureSunDefaultsRuntimeDeps({
       getProfileLocation: () => ({ country: 'Czechia', zip: '' }),
+      navigate: route => calls.push(['navigate', route]),
       openProfileLocationEditor: () => calls.push(['profile-location']),
       openClientList: () => calls.push(['client-list']),
       getSunCoords: () => precise
@@ -78,7 +79,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       };
       data.invalidateActiveDataCache();
 
-      window.navigate = route => calls.push(['navigate', route]);
       sunDefaults.configureSunDefaults({
         maybeAnalyzeOnboardingAfterSave: () => calls.push(['onboarding-ai']),
         renderOnboardingAIBlock: () => '<div id="setup-ai-block">AI setup block</div>',
@@ -92,6 +92,9 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
         promptHost.querySelector('.light-setup-prompt')?.textContent.includes('Set up your light assumptions')
         && !!promptHost.querySelector('.light-widget-prompt-cta')
         && !!promptHost.querySelector('.dashboard-action-btn');
+      outcomes.sunDefaultsRuntimeUsesInjectedNavigation =
+        sunDefaultsRuntimeSrc.includes('sunDefaultsRuntimeDeps.navigate?.(route)')
+        && !sunDefaultsRuntimeSrc.includes('getViewRuntimeFunction');
       promptHost.querySelector('.light-widget-prompt-cta')?.click();
       await waitFor('#light-setup-focus-overlay');
       promptHost.remove();
@@ -202,7 +205,6 @@ test('Light setup overlay covers location refresh, score, save, edit, and skip p
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       data.invalidateActiveDataCache();
-      window.navigate = saved.navigate;
       sunDefaults.configureSunDefaults({
         maybeAnalyzeOnboardingAfterSave: () => {},
         renderOnboardingAIBlock: () => '',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -129,6 +129,9 @@ assert('App shell injects wearable navigation without view bridge lookups',
 assert('App shell injects category customization view callbacks',
   appShellHooksSrc.includes('configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });'));
 
+assert('App shell injects sun defaults navigation without a view bridge lookup',
+  appShellHooksSrc.includes('configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/tests/test-sun-defaults-runtime.js
+++ b/tests/test-sun-defaults-runtime.js
@@ -23,7 +23,6 @@ console.log('=== Sun Defaults Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'getProfileLocation',
-  'navigate',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const originalSunDefaultsRuntimeDeps = configureSunDefaultsRuntimeDeps();
@@ -54,10 +53,10 @@ try {
       calls.push(['precise']);
       return Promise.resolve({ lat: 50.1, lon: 14.4 });
     },
+    navigate: route => calls.push(['navigate', route]),
     openProfileLocationEditor: () => calls.push(['profile-location']),
     openClientList: () => calls.push(['client-list']),
   });
-  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
 
   assert('getSunSetupCoords delegates to runtime coords provider',
     getSunSetupCoords()?.source === 'profile-precise');
@@ -85,10 +84,10 @@ try {
   configureSunDefaultsRuntimeDeps({
     getSunCoords: null,
     getProfileLocation: () => ({ country: '', zip: '' }),
+    navigate: null,
     requestPreciseLocation: null,
     openClientList: null,
   });
-  delete globalThis.navigate;
   assert('missing runtime functions return safe fallbacks',
     getSunSetupCoords() === null &&
     getSunSetupProfileLocation().country === '' &&

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.252';
+self.APP_VERSION = '1.10.253';


### PR DESCRIPTION
## Summary

- inject `navigate` into the sun-defaults runtime from the app shell
- remove the remaining sun-defaults browser-global and `views-runtime-bridge` navigation fallback
- update Node and browser tests to configure explicit navigation
- add a shell-wiring regression guard
- bump the app cache version to `1.10.253`

## Window-burden progress

| Targeted surface | Before | After | Removed |
| --- | ---: | ---: | ---: |
| Chat `window` facade | 80 | 0 | 80 |
| Application callback globals | 4 | 0 | 4 |
| Scattered browser UI `APP_VERSION` reads | 3 | 0 | 3 |
| Active sync-pull view bridge lookups | 2 | 0 | 2 |
| Wearable navigation bridge lookups | 2 | 0 | 2 |
| Category customization bridge lookups | 2 | 0 | 2 |
| Sun defaults navigation bridge lookup | 1 | 0 | 1 |
| **Cumulative targeted accesses** | **94** | **0** | **94** |
| Quality-guarded `window.` references in `js/` | 0 | 0 | 0 |
| Quality-guarded `window` assignments in `js/` | 0 | 0 | 0 |

This PR removes one more view-runtime lookup without introducing new `window.` references or assignments. Intentional browser primitives remain at their runtime boundaries.

## Verification

- `./run-tests.sh` — passed (126 static checks, 398 Vitest tests, 352 Playwright tests, 472 responsive assertions)
- `npm run quality` — 7 passed, 0 failed; guarded `window` references/assignments remain 0
- `npx playwright test tests/playwright/setup-onboarding-coverage-batch.spec.js` — 3 passed
- `node tests/test-sun-defaults-runtime.js` — 10 passed
- `node tests/test-shell-delegated-actions.js` — 68 passed
- `npm run typecheck` and `npm run typecheck:checkjs` — passed
- `git diff --check` — passed
