### PR TITLE
Inject onboarding view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -183,7 +183,7 @@ configureShellChatActionDeps({
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
 configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButtonVisibility });
-configureOnboardingViewRuntimeDeps({ createNewThread, openChatPanel, toggleChatPanel });
+configureOnboardingViewRuntimeDeps({ buildSidebar, createNewThread, navigate, openChatPanel, toggleChatPanel });
 configureTourRuntimeDeps({ openChatPanel });
 configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });
 configureWearablesConnectRuntimeDeps({ navigate });

--- a/js/onboarding-view-runtime.js
+++ b/js/onboarding-view-runtime.js
@@ -1,20 +1,31 @@
 // @ts-check
 // onboarding-view-runtime.js - Browser runtime adapters for dashboard onboarding hooks.
 
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { renderChatMessagesRuntime } from './chat-runtime.js';
 
 const onboardingViewRuntimeDeps = {
+  buildSidebar: /** @type {null | ((data: unknown) => void)} */ (null),
   createNewThread: /** @type {null | (() => void)} */ (null),
+  navigate: /** @type {null | ((route: string, data: unknown) => void)} */ (null),
   openChatPanel: /** @type {null | (() => unknown)} */ (null),
   toggleChatPanel: /** @type {null | (() => void)} */ (null),
 };
 
 export function configureOnboardingViewRuntimeDeps(deps = {}) {
   const previous = { ...onboardingViewRuntimeDeps };
+  if (Object.prototype.hasOwnProperty.call(deps, 'buildSidebar')) {
+    onboardingViewRuntimeDeps.buildSidebar = typeof deps.buildSidebar === 'function'
+      ? deps.buildSidebar
+      : null;
+  }
   if (Object.prototype.hasOwnProperty.call(deps, 'createNewThread')) {
     onboardingViewRuntimeDeps.createNewThread = typeof deps.createNewThread === 'function'
       ? deps.createNewThread
+      : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(deps, 'navigate')) {
+    onboardingViewRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? deps.navigate
       : null;
   }
   if (Object.prototype.hasOwnProperty.call(deps, 'openChatPanel')) {
@@ -30,27 +41,9 @@ export function configureOnboardingViewRuntimeDeps(deps = {}) {
   return previous;
 }
 
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
-}
-
 /** @param {unknown} data */
 export function rebuildOnboardingSidebarRuntime(data) {
-  getViewRuntimeFunction('buildSidebar')?.(data);
+  onboardingViewRuntimeDeps.buildSidebar?.(data);
 }
 
 /**
@@ -61,7 +54,7 @@ export function rebuildOnboardingSidebarRuntime(data) {
 export function navigateOnboardingRuntime(route, data, preferredNavigate = null) {
   const navigate = typeof preferredNavigate === 'function'
     ? preferredNavigate
-    : getRuntimeFunction('navigate');
+    : onboardingViewRuntimeDeps.navigate;
   navigate?.(route, data);
 }
 

--- a/tests/playwright/setup-onboarding-coverage-batch.spec.js
+++ b/tests/playwright/setup-onboarding-coverage-batch.spec.js
@@ -233,16 +233,16 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ onboardingUrl }) => {
-    const [onboarding, { state }, profile, data, crypto, viewRuntime, chatRuntime, onboardingRuntime] = await Promise.all([
+    const [onboarding, { state }, profile, data, crypto, chatRuntime, onboardingRuntime] = await Promise.all([
       import(onboardingUrl),
       import('/js/state.js'),
       import('/js/profile.js'),
       import('/js/data.js'),
       import('/js/crypto.js'),
-      import('/js/views-runtime-bridge.js'),
       import('/js/chat-runtime.js'),
       import('/js/onboarding-view-runtime.js'),
     ]);
+    const onboardingRuntimeSrc = await fetch('/js/onboarding-view-runtime.js').then(response => response.text());
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
     const waitUntil = async (predicate, label) => {
@@ -265,18 +265,16 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       currentProfile: state.currentProfile,
       profileSex: state.profileSex,
       profileDob: state.profileDob,
-      navigate: window.navigate,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
     const outcomes = {};
     const calls = [];
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
-      buildSidebar: payload => calls.push(['sidebar', !!payload]),
-    });
     const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
       renderChatMessages: () => calls.push(['render-chat']),
     });
     const previousOnboardingRuntime = onboardingRuntime.configureOnboardingViewRuntimeDeps({
+      buildSidebar: payload => calls.push(['sidebar', !!payload]),
+      navigate: (route, payload) => calls.push(['navigate', route, !!payload]),
       openChatPanel: () => calls.push(['open-chat']),
     });
     const host = document.createElement('div');
@@ -291,9 +289,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       state.profileDob = null;
       state.importedData = profile.createDefaultProfileData();
       data.invalidateActiveDataCache();
-      onboarding.configureOnboardingView({
-        navigate: (route, payload) => calls.push(['navigate', route, !!payload]),
-      });
+      onboarding.configureOnboardingView({ navigate: null });
 
       const onboardedKey = profile.profileStorageKey(state.currentProfile, 'onboarded');
       localStorage.removeItem(onboardedKey);
@@ -320,6 +316,10 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
         && calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard' && call[2])
         && Array.from(document.querySelectorAll('.notification-toast'))
           .some(toast => toast.textContent.includes('Profile set up'));
+      outcomes.onboardingRuntimeUsesInjectedViewCallbacks =
+        onboardingRuntimeSrc.includes('onboardingViewRuntimeDeps.buildSidebar?.(data)')
+        && onboardingRuntimeSrc.includes('onboardingViewRuntimeDeps.navigate')
+        && !onboardingRuntimeSrc.includes('getViewRuntimeFunction');
       outcomes.bannerSuppressesAfterProfileSet = onboarding.renderOnboardingBanner() === '';
 
       localStorage.removeItem(onboardedKey);
@@ -421,8 +421,7 @@ test('dashboard onboarding covers profile save, dismissal, focus modes, and AI r
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       data.invalidateActiveDataCache();
-      onboarding.configureOnboardingView({ navigate: saved.navigate });
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
+      onboarding.configureOnboardingView({ navigate: null });
       chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       onboardingRuntime.configureOnboardingViewRuntimeDeps(previousOnboardingRuntime);
       Element.prototype.scrollIntoView = saved.scrollIntoView;

--- a/tests/test-export-import.js
+++ b/tests/test-export-import.js
@@ -673,7 +673,6 @@ return (async function() {
     const originalProfiles = JSON.parse(JSON.stringify(profile.getProfiles() || []));
     const originalSnpTable = window._snpTableCache;
     const oldOpen = window.open;
-    const oldSetTimeout = window.setTimeout;
     let capturedReport = '';
     let printCalled = false;
     window.open = () => ({
@@ -683,7 +682,6 @@ return (async function() {
       },
       print() { printCalled = true; }
     });
-    window.setTimeout = fn => { if (typeof fn === 'function') fn(); return 0; };
     try {
       const profiles = profile.getProfiles() || [];
       let activeProfile = profiles.find(p => p.id === S.currentProfile);
@@ -825,7 +823,6 @@ return (async function() {
       await profile.saveProfiles(originalProfiles);
       window._snpTableCache = originalSnpTable;
       window.open = oldOpen;
-      window.setTimeout = oldSetTimeout;
     }
   }
 

--- a/tests/test-onboarding-view-runtime.js
+++ b/tests/test-onboarding-view-runtime.js
@@ -14,7 +14,6 @@ import {
   rebuildOnboardingSidebarRuntime,
   renderOnboardingChatMessagesRuntime,
 } from '../js/onboarding-view-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 import { configureChatRuntimeCallbacks } from '../js/chat-runtime.js';
 
 let pass = 0, fail = 0;
@@ -27,18 +26,8 @@ console.log('=== Onboarding View Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'navigate',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
-
-function setRuntimeValue(key, value) {
-  Object.defineProperty(globalThis, key, {
-    configurable: true,
-    writable: true,
-    enumerable: true,
-    value,
-  });
-}
 
 function restoreRuntime() {
   for (const key of runtimeKeys) {
@@ -50,9 +39,10 @@ function restoreRuntime() {
 
 try {
   const calls = [];
-  let previousViewRuntime = null;
   const previousDeps = configureOnboardingViewRuntimeDeps({
+    buildSidebar: data => calls.push(['buildSidebar', data?.id]),
     createNewThread: () => calls.push(['createNewThread']),
+    navigate: (route, data) => calls.push(['navigate', route, data?.id]),
     openChatPanel: () => {
       calls.push(['openChatPanel']);
       return 'opened';
@@ -62,11 +52,6 @@ try {
   const previousChatRuntime = configureChatRuntimeCallbacks({
     renderChatMessages: () => calls.push(['renderChatMessages']),
   });
-  setRuntimeValue('window', globalThis);
-  previousViewRuntime = configureViewRuntime({
-    buildSidebar: data => calls.push(['buildSidebar', data?.id]),
-  });
-  setRuntimeValue('navigate', (route, data) => calls.push(['navigate', route, data?.id]));
   rebuildOnboardingSidebarRuntime({ id: 'sidebar-data' });
   navigateOnboardingRuntime('labs', { id: 'fallback-data' });
   navigateOnboardingRuntime('dashboard', { id: 'preferred-data' }, (route, data) => calls.push(['preferredNavigate', route, data.id]));
@@ -103,7 +88,7 @@ try {
     createOnboardingChatThreadRuntime() === false);
 
   delete globalThis.window;
-  configureViewRuntime({ buildSidebar: null });
+  configureOnboardingViewRuntimeDeps({ buildSidebar: null, navigate: null });
   configureChatRuntimeCallbacks({ renderChatMessages: null });
   const beforeNoWindowCalls = calls.length;
   rebuildOnboardingSidebarRuntime({ id: 'ignored' });
@@ -117,15 +102,19 @@ try {
 
   configureOnboardingViewRuntimeDeps(previousDeps);
   configureChatRuntimeCallbacks(previousChatRuntime);
-  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const onboardingSrc = fs.readFileSync(path.join(root, 'js/onboarding-view.js'), 'utf8');
+  const onboardingRuntimeSrc = fs.readFileSync(path.join(root, 'js/onboarding-view-runtime.js'), 'utf8');
   const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
   assert('onboarding view delegates browser globals through runtime adapter',
     onboardingSrc.includes("from './onboarding-view-runtime.js'") &&
       !/\bwindow(?:\.|\s*\[)/.test(onboardingSrc) &&
       swSrc.includes("'/js/onboarding-view-runtime.js'"));
+  assert('onboarding runtime uses injected view callbacks without bridge lookups',
+    onboardingRuntimeSrc.includes('onboardingViewRuntimeDeps.buildSidebar?.(data)') &&
+      onboardingRuntimeSrc.includes('onboardingViewRuntimeDeps.navigate') &&
+      !onboardingRuntimeSrc.includes('getViewRuntimeFunction'));
 } finally {
   restoreRuntime();
 }

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -89,7 +89,7 @@ assert('Chat thread shell actions use module dependencies instead of window look
 assert('App shell wires module-only chat thread consumers',
   appShellHooksSrc.includes("from './chat-threads.js'")
     && appShellHooksSrc.includes('configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });')
-    && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ createNewThread, openChatPanel, toggleChatPanel });')
+    && appShellHooksSrc.includes('configureOnboardingViewRuntimeDeps({ buildSidebar, createNewThread, navigate, openChatPanel, toggleChatPanel });')
     && appShellHooksSrc.includes('configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });'));
 
 assert('App shell wires Context hub status refresh without a window lookup',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.253';
+self.APP_VERSION = '1.10.254';


### PR DESCRIPTION
## Summary

- inject `buildSidebar` and `navigate` into the dashboard onboarding runtime from the app shell
- remove its remaining browser-global and `views-runtime-bridge` view callback fallbacks
- update Node and browser coverage to exercise injected callbacks and no-op behavior directly
- remove an obsolete export/import test `window.setTimeout` stub that could recursively trigger the analytics consent retry
- bump the app cache version to `1.10.254`

## Window-burden progress

| Targeted production surface | Before | After | Removed |
| --- | ---: | ---: | ---: |
| Chat `window` facade | 80 | 0 | 80 |
| Application callback globals | 4 | 0 | 4 |
| Scattered browser UI `APP_VERSION` reads | 3 | 0 | 3 |
| Active sync-pull view bridge lookups | 2 | 0 | 2 |
| Wearable navigation bridge lookups | 2 | 0 | 2 |
| Category customization bridge lookups | 2 | 0 | 2 |
| Sun defaults navigation bridge lookup | 1 | 0 | 1 |
| Onboarding view bridge lookups | 2 | 0 | 2 |
| **Cumulative production accesses** | **96** | **0** | **96** |
| Quality-guarded `window.` references in `js/` | 0 | 0 | 0 |
| Quality-guarded `window` assignments in `js/` | 0 | 0 | 0 |

This PR removes two more production view-runtime lookups without introducing new `window.` references or assignments. It also removes three obsolete direct `window.setTimeout` accesses from the export/import test harness; those test-only accesses are not included in the production cumulative total.

## Verification

- `./run-tests.sh` — passed (126 static checks, 398 Vitest tests, 352 Playwright tests, 472 responsive assertions)
- `npm run quality` — 7 passed, 0 failed; guarded `window` references/assignments remain 0
- `npx playwright test tests/playwright/setup-onboarding-coverage-batch.spec.js` — 3 passed
- `npx playwright test tests/playwright/core-browser-flows.spec.js -g "export/import browser fixture"` — 1 passed (261 browser assertions)
- `node tests/test-onboarding-view-runtime.js` — 7 passed
- `node tests/test-shell-delegated-actions.js` — 68 passed
- `node tests/test-prelab.js` — 111 passed
- `npm run typecheck` and `npm run typecheck:checkjs` — passed
- `git diff --check` — passed
