### PR TITLE
Inject client list view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -67,6 +67,7 @@ import {
   toggleThreadRail,
 } from './chat-threads.js';
 import { closeClientList, configureClientListRuntime, openClientList, openProfileLocationEditor } from './client-list.js';
+import { configureClientListRuntimeDeps } from './client-list-runtime.js';
 import { configureCompareCorrelationViews } from './compare-correlations.js';
 import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
 import { closeEMFInterpretation, configureEMFInterpretationRuntimeDeps } from './emf-interpretation.js';
@@ -76,7 +77,7 @@ import { closeFeedbackModal, openFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { closeModal } from './marker-detail-modal.js';
 import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
-import { buildSidebar, closeMobileSidebar, configureNavActions } from './nav.js';
+import { buildSidebar, closeMobileSidebar, configureNavActions, renderProfileButton } from './nav.js';
 import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
@@ -124,6 +125,7 @@ configureSettingsRuntime({
 });
 
 configureNavActions({ openClientList });
+configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });

--- a/js/client-list-runtime.js
+++ b/js/client-list-runtime.js
@@ -4,35 +4,31 @@
 import { hasAIProvider } from './api.js';
 import { getDnaModuleFunction, getDnaModuleValue } from './dna-runtime-bridge.js';
 import { showNotification } from './utils.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const clientListRuntimeDeps = { showNotification };
+const clientListRuntimeDeps = {
+  navigate: /** @type {null | ((route: string) => void)} */ (null),
+  renderProfileButton: /** @type {null | (() => void)} */ (null),
+  showNotification,
+};
 
 export function configureClientListRuntimeDeps(deps = {}) {
   const previous = { ...clientListRuntimeDeps };
+  if ('navigate' in deps) {
+    clientListRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? /** @type {(route: string) => void} */ (deps.navigate)
+      : null;
+  }
+  if ('renderProfileButton' in deps) {
+    clientListRuntimeDeps.renderProfileButton = typeof deps.renderProfileButton === 'function'
+      ? /** @type {() => void} */ (deps.renderProfileButton)
+      : null;
+  }
   if ('showNotification' in deps) {
     clientListRuntimeDeps.showNotification = typeof deps.showNotification === 'function'
       ? /** @type {typeof showNotification} */ (deps.showNotification)
       : null;
   }
   return previous;
-}
-
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : /** @type {any} */ (globalThis);
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' && typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
 }
 
 export function getClientHaplogroupList() {
@@ -42,11 +38,11 @@ export function getClientHaplogroupList() {
 
 /** @param {string} route */
 export function navigateClientListRoute(route) {
-  getRuntimeFunction('navigate')?.(route);
+  clientListRuntimeDeps.navigate?.(route);
 }
 
 export function refreshClientProfileButton() {
-  getViewRuntimeFunction('renderProfileButton')?.();
+  clientListRuntimeDeps.renderProfileButton?.();
 }
 
 /**

--- a/tests/client-list-runtime.test.js
+++ b/tests/client-list-runtime.test.js
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { state } from '../js/state.js';
 import { configureClientListRuntimeDeps } from '../js/client-list-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let importId = 0;
 
@@ -43,10 +42,11 @@ beforeEach(() => {
   `;
   window.requestAnimationFrame = (fn) => fn();
   globalThis.requestAnimationFrame = window.requestAnimationFrame;
-  configureViewRuntime({ renderProfileButton: vi.fn() });
-  window.showNotification = vi.fn();
-  configureClientListRuntimeDeps({ showNotification: window.showNotification });
-  window.navigate = vi.fn();
+  configureClientListRuntimeDeps({
+    navigate: vi.fn(),
+    renderProfileButton: vi.fn(),
+    showNotification: vi.fn(),
+  });
   window.showConfirmDialog = vi.fn(async () => false);
   state.currentProfile = 'alice';
   state.importedData = { wearableSummary: { metrics: { weight: { latest: 70 } } }, genetics: { mtdna: {} } };
@@ -62,9 +62,10 @@ describe('client list runtime behavior', () => {
     const clientList = await loadClientList();
     const renderProfileButtonSpy = vi.fn();
     const showNotificationSpy = vi.fn();
-    configureViewRuntime({ renderProfileButton: renderProfileButtonSpy });
-    window.showNotification = showNotificationSpy;
-    configureClientListRuntimeDeps({ showNotification: showNotificationSpy });
+    configureClientListRuntimeDeps({
+      renderProfileButton: renderProfileButtonSpy,
+      showNotification: showNotificationSpy,
+    });
     const topLevelNames = () => [...document.querySelectorAll('.cl-list > .cl-row .cl-row-name')].map(el => el.textContent);
 
     clientList.openClientList();

--- a/tests/playwright/client-list-browser-coverage.spec.js
+++ b/tests/playwright/client-list-browser-coverage.spec.js
@@ -8,8 +8,8 @@ test('client list live menu actions dispatch exports share demos and profile sta
     const { state } = await import('/js/state.js');
     const clientList = await import('/js/client-list.js');
     const { configureClientListRuntime } = clientList;
+    const clientListRuntime = await import('/js/client-list-runtime.js');
     const profile = await import('/js/profile.js');
-    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const calls = [];
     const confirmQueue = [];
@@ -75,7 +75,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
       showConfirmDialog: window.showConfirmDialog,
       inputClick: HTMLInputElement.prototype.click,
     };
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    const previousClientListRuntimeDeps = clientListRuntime.configureClientListRuntimeDeps({
       renderProfileButton: () => calls.push(['render-profile-button']),
     });
     const openList = async () => {
@@ -252,7 +252,7 @@ test('client list live menu actions dispatch exports share demos and profile sta
         if (value == null) localStorage.removeItem(key);
         else localStorage.setItem(key, value);
       }
-      viewRuntime.configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
+      clientListRuntime.configureClientListRuntimeDeps(previousClientListRuntimeDeps);
       if (previousClientListRuntime) configureClientListRuntime(previousClientListRuntime);
       window.showConfirmDialog = saved.showConfirmDialog;
       if (previousProfileDeps) profile.configureProfileDeps(previousProfileDeps);
@@ -277,12 +277,9 @@ test('client list form live actions cover health link avatar haplogroup and loca
     const clientList = await import('/js/client-list.js');
     const clientListRuntime = await import('/js/client-list-runtime.js');
     const dnaBridge = await import('/js/dna-runtime-bridge.js');
-    const viewRuntime = await import('/js/views-runtime-bridge.js');
+    const clientListRuntimeSrc = await fetch('/js/client-list-runtime.js').then(response => response.text());
     const outcomes = {};
     const calls = [];
-    const previousClientListRuntimeDeps = clientListRuntime.configureClientListRuntimeDeps({
-      showNotification: (...args) => calls.push(['notification', ...args]),
-    });
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const waitFor = async (predicate, label) => {
       for (let attempt = 0; attempt < 60; attempt += 1) {
@@ -300,14 +297,16 @@ test('client list form live actions cover health link avatar haplogroup and loca
       importedData: clone(state.importedData),
       storage: Object.fromEntries(storageKeys.map(key => [key, localStorage.getItem(key)])),
       bodyOverflow: document.body.style.overflow,
-      navigate: window.navigate,
       inputClick: HTMLInputElement.prototype.click,
       scrollIntoView: Element.prototype.scrollIntoView,
       modalOverlayClass: document.getElementById('modal-overlay')?.className,
       hadWearableStrip: !!document.getElementById('wearable-strip'),
     };
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    const navigate = route => calls.push(['navigate', route]);
+    const previousClientListRuntimeDeps = clientListRuntime.configureClientListRuntimeDeps({
+      navigate,
       renderProfileButton: () => calls.push(['render-profile-button']),
+      showNotification: (...args) => calls.push(['notification', ...args]),
     });
     const previousDnaBridge = dnaBridge.configureDnaModuleBridge({
       HAPLOGROUP_LIST: ['H', 'J', 'K'],
@@ -347,7 +346,6 @@ test('client list form live actions cover health link avatar haplogroup and loca
       localStorage.setItem('labcharts-ai-provider', 'openrouter');
       localStorage.removeItem('labcharts-ai-paused');
       localStorage.removeItem('labcharts-openrouter-key');
-      window.navigate = route => calls.push(['navigate', route]);
       HTMLInputElement.prototype.click = function() {
         calls.push(['input-click', this.id || this.type || 'input']);
       };
@@ -369,6 +367,10 @@ test('client list form live actions cover health link avatar haplogroup and loca
       outcomes.healthMetricsLinkClosesNavigatesAndScrolls = !document.getElementById('client-list-overlay')?.classList.contains('show')
         && calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard')
         && calls.some(call => call[0] === 'scroll' && call[1] === 'wearable-strip');
+      outcomes.clientListRuntimeUsesInjectedViewCallbacks =
+        clientListRuntimeSrc.includes('clientListRuntimeDeps.navigate?.(route)')
+        && clientListRuntimeSrc.includes('clientListRuntimeDeps.renderProfileButton?.()')
+        && !clientListRuntimeSrc.includes('getViewRuntimeFunction');
 
       clientList.openClientList();
       clientList.openClientForm('client-active');
@@ -414,14 +416,12 @@ test('client list form live actions cover health link avatar haplogroup and loca
         if (value == null) localStorage.removeItem(key);
         else localStorage.setItem(key, value);
       }
-      viewRuntime.configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
       dnaBridge.configureDnaModuleBridge({
         HAPLOGROUP_LIST: null,
         setManualHaplogroup: null,
         ...previousDnaBridge,
       });
       clientListRuntime.configureClientListRuntimeDeps(previousClientListRuntimeDeps);
-      window.navigate = saved.navigate;
       HTMLInputElement.prototype.click = saved.inputClick;
       Element.prototype.scrollIntoView = saved.scrollIntoView;
       if (!saved.hadWearableStrip) document.getElementById('wearable-strip')?.remove();
@@ -445,7 +445,7 @@ test('client list remaining browser helpers cover filters avatar upload tags and
   const results = await page.evaluate(async () => {
     const { state } = await import('/js/state.js');
     const clientList = await import('/js/client-list.js');
-    const viewRuntime = await import('/js/views-runtime-bridge.js');
+    const clientListRuntime = await import('/js/client-list-runtime.js');
     const outcomes = {};
     const calls = [];
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -470,10 +470,10 @@ test('client list remaining browser helpers cover filters avatar upload tags and
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       bodyOverflow: document.body.style.overflow,
-      showNotification: window.showNotification,
     };
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    const previousClientListRuntimeDeps = clientListRuntime.configureClientListRuntimeDeps({
       renderProfileButton: () => calls.push(['render-profile-button']),
+      showNotification: (...args) => calls.push(['notification', ...args]),
     });
 
     try {
@@ -527,8 +527,6 @@ test('client list remaining browser helpers cover filters avatar upload tags and
         },
       ];
       localStorage.setItem('labcharts-profiles', JSON.stringify(state.profiles));
-      window.showNotification = (...args) => calls.push(['notification', ...args]);
-
       clientList.openClientList();
       await waitFor(() => document.getElementById('client-list-overlay')?.classList.contains('show'), 'client list open');
       const search = document.getElementById('cl-search');
@@ -629,8 +627,7 @@ test('client list remaining browser helpers cover filters avatar upload tags and
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       document.body.style.overflow = saved.bodyOverflow;
-      viewRuntime.configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
-      window.showNotification = saved.showNotification;
+      clientListRuntime.configureClientListRuntimeDeps(previousClientListRuntimeDeps);
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/test-client-list-runtime.js
+++ b/tests/test-client-list-runtime.js
@@ -13,7 +13,6 @@ import {
   setClientManualHaplogroup,
   showClientListNotification,
 } from '../js/client-list-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 const originalClientListRuntimeDeps = configureClientListRuntimeDeps();
 
@@ -25,28 +24,18 @@ function assert(name, condition, detail) {
 
 console.log('=== Client List Runtime Tests ===\n');
 
-const runtimeKeys = [
-  'navigate',
-  'showNotification',
-];
-const saved = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
 const savedAIStorage = {
   provider: localStorage.getItem('labcharts-ai-provider'),
   paused: localStorage.getItem('labcharts-ai-paused'),
   openrouterKey: localStorage.getItem('labcharts-openrouter-key'),
   openrouterCachedKey: getCachedKey('labcharts-openrouter-key'),
 };
-let previousViewRuntime = null;
 const previousDnaBridge = configureDnaModuleBridge({
   HAPLOGROUP_LIST: null,
   setManualHaplogroup: null,
 });
 
 function restoreRuntime() {
-  for (const key of runtimeKeys) {
-    if (typeof saved[key] === 'undefined') delete globalThis[key];
-    else globalThis[key] = saved[key];
-  }
   if (savedAIStorage.provider == null) localStorage.removeItem('labcharts-ai-provider');
   else localStorage.setItem('labcharts-ai-provider', savedAIStorage.provider);
   if (savedAIStorage.paused == null) localStorage.removeItem('labcharts-ai-paused');
@@ -58,6 +47,11 @@ function restoreRuntime() {
 
 try {
   const calls = [];
+  configureClientListRuntimeDeps({
+    navigate: route => calls.push(['navigate', route]),
+    renderProfileButton: () => calls.push(['render-profile-button']),
+    showNotification: (message, type) => calls.push(['notification', message, type]),
+  });
 
   configureDnaModuleBridge({ HAPLOGROUP_LIST: ['H1', 'J2'] });
   assert('getClientHaplogroupList reads module haplogroup list',
@@ -66,21 +60,14 @@ try {
   assert('getClientHaplogroupList falls back to empty array for invalid module value',
     getClientHaplogroupList().length === 0);
 
-  globalThis.navigate = route => calls.push(['navigate', route]);
   navigateClientListRoute('dashboard');
   assert('navigateClientListRoute delegates to runtime navigate',
     calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard'));
 
-  previousViewRuntime = configureViewRuntime({
-    renderProfileButton: () => calls.push(['render-profile-button']),
-  });
   refreshClientProfileButton();
   assert('refreshClientProfileButton delegates to runtime profile refresh',
     calls.some(call => call[0] === 'render-profile-button'));
 
-  configureClientListRuntimeDeps({
-    showNotification: (message, type) => calls.push(['notification', message, type]),
-  });
   showClientListNotification('"Ada" updated', 'info');
   assert('showClientListNotification delegates runtime notification',
     calls.some(call => call[0] === 'notification' && call[1] === '"Ada" updated' && call[2] === 'info'));
@@ -95,6 +82,13 @@ try {
   configureDnaModuleBridge({ setManualHaplogroup: null });
   assert('setClientManualHaplogroup returns false when hook is missing',
     await setClientManualHaplogroup('J2') === false);
+
+  configureClientListRuntimeDeps({ navigate: null, renderProfileButton: null });
+  const beforeMissingViewCalls = calls.length;
+  navigateClientListRoute('labs');
+  refreshClientProfileButton();
+  assert('client list view callbacks no-op safely when unavailable',
+    calls.length === beforeMissingViewCalls);
 
   localStorage.setItem('labcharts-ai-provider', 'ollama');
   localStorage.removeItem('labcharts-ai-paused');
@@ -116,7 +110,6 @@ try {
     setManualHaplogroup: null,
     ...previousDnaBridge,
   });
-  configureViewRuntime({ renderProfileButton: null, ...previousViewRuntime });
   configureClientListRuntimeDeps(originalClientListRuntimeDeps);
   restoreRuntime();
 }

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -132,6 +132,9 @@ assert('App shell injects category customization view callbacks',
 assert('App shell injects sun defaults navigation without a view bridge lookup',
   appShellHooksSrc.includes('configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });'));
 
+assert('App shell injects client list view callbacks without bridge lookups',
+  appShellHooksSrc.includes('configureClientListRuntimeDeps({ navigate, renderProfileButton });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.254';
+self.APP_VERSION = '1.10.255';


### PR DESCRIPTION
## Summary

- inject `navigate` and `renderProfileButton` into the client-list runtime from the app shell
- remove the runtime's browser-global/view-bridge fallbacks
- configure the callbacks directly in Node, Vitest, and browser coverage
- guard the app-shell wiring contract and bump the app version to `1.10.255`

## `window` burden progress

| Slice | Production accesses removed |
| --- | ---: |
| Chat window facade | 80 |
| Application callback globals | 4 |
| `APP_VERSION` reads | 3 |
| Active sync pull | 2 |
| Wearable navigation | 2 |
| Category customization | 2 |
| Sun defaults navigation | 1 |
| Onboarding view dependencies | 2 |
| Client-list view dependencies (this PR) | 2 |
| **Cumulative production accesses removed** | **98** |
| **Guarded `window` references remaining** | **0** |
| **Guarded `window` assignments remaining** | **0** |

The cumulative total tracks production access removal. PR #1225 also removed three obsolete test-harness `window` timer accesses, which are intentionally excluded from this production count.

## Verification

- `./run-tests.sh`: 126 static checks, 398 Vitest tests, 352 Playwright tests, and 472 responsive assertions passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`: 7 passed, 0 failed; guarded references/assignments both 0
- `node tests/test-client-list-runtime.js`: 11 passed
- `npx vitest run tests/client-list-runtime.test.js`: 1 passed
- `node tests/test-shell-delegated-actions.js`: 69 passed
- `npx playwright test tests/playwright/client-list-browser-coverage.spec.js`: 3 passed
- `git diff --check`
