### PR TITLE
Inject DNA view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -70,6 +70,7 @@ import { closeClientList, configureClientListRuntime, openClientList, openProfil
 import { configureClientListRuntimeDeps } from './client-list-runtime.js';
 import { configureCompareCorrelationViews } from './compare-correlations.js';
 import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
+import { configureDnaRuntimeDeps } from './dna-runtime.js';
 import { closeEMFInterpretation, configureEMFInterpretationRuntimeDeps } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder } from './export.js';
 import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
@@ -127,6 +128,7 @@ configureSettingsRuntime({
 configureNavActions({ openClientList });
 configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
+configureDnaRuntimeDeps({ buildSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });

--- a/js/dna-runtime.js
+++ b/js/dna-runtime.js
@@ -6,15 +6,31 @@ import { getLatitudeFromLocation } from './profile.js';
 import { isDebugMode, showConfirmDialog } from './utils.js';
 import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.js';
 import { updateChatNudgeRuntime } from './chat-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const dnaRuntimeDeps = { getLatitudeFromLocation, isDebugMode, isImportRunning, showConfirmDialog };
+const dnaRuntimeDeps = {
+  buildSidebar: /** @type {null | (() => void)} */ (null),
+  getLatitudeFromLocation,
+  isDebugMode,
+  isImportRunning,
+  navigate: /** @type {null | ((route: string) => void)} */ (null),
+  showConfirmDialog,
+};
 
 export function configureDnaRuntimeDeps(deps = {}) {
   const previous = { ...dnaRuntimeDeps };
+  if ('buildSidebar' in deps) {
+    dnaRuntimeDeps.buildSidebar = typeof deps.buildSidebar === 'function'
+      ? /** @type {() => void} */ (deps.buildSidebar)
+      : null;
+  }
   if (typeof deps.getLatitudeFromLocation === 'function') dnaRuntimeDeps.getLatitudeFromLocation = deps.getLatitudeFromLocation;
   if (typeof deps.isDebugMode === 'function') dnaRuntimeDeps.isDebugMode = deps.isDebugMode;
   if (typeof deps.isImportRunning === 'function') dnaRuntimeDeps.isImportRunning = deps.isImportRunning;
+  if ('navigate' in deps) {
+    dnaRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? /** @type {(route: string) => void} */ (deps.navigate)
+      : null;
+  }
   if ('showConfirmDialog' in deps) {
     dnaRuntimeDeps.showConfirmDialog = typeof deps.showConfirmDialog === 'function'
       ? /** @type {typeof showConfirmDialog} */ (deps.showConfirmDialog)
@@ -27,17 +43,6 @@ function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : /** @type {any} */ (globalThis);
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' && typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
 }
 
 /** @returns {boolean} */
@@ -66,11 +71,11 @@ export function logDnaDebugWarn(...args) {
 
 /** @param {string} route */
 export function navigateDnaRoute(route) {
-  getRuntimeFunction('navigate')?.(route);
+  dnaRuntimeDeps.navigate?.(route);
 }
 
 export function refreshDnaSidebar() {
-  const buildSidebar = getViewRuntimeFunction('buildSidebar');
+  const buildSidebar = dnaRuntimeDeps.buildSidebar;
   if (!buildSidebar) return;
   try {
     buildSidebar();

--- a/tests/playwright/dna-browser-coverage.spec.js
+++ b/tests/playwright/dna-browser-coverage.spec.js
@@ -188,11 +188,8 @@ test('DNA autosomal import UI coverage exercises preview, confirm, render, and d
     const dna = await import(`/js/dna.js?dnaAutosomalCoverage=${Date.now()}-${Math.random()}`);
     const dnaRuntime = await import('/js/dna-runtime.js');
     const chatRuntime = await import('/js/chat-runtime.js');
-    const viewRuntime = await import('/js/views-runtime-bridge.js');
     let importRunning = false;
-    const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps({
-      isImportRunning: () => importRunning,
-    });
+    const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps();
 
     const profileId = `dna-autosomal-coverage-${Date.now()}`;
     state.currentProfile = profileId;
@@ -201,13 +198,14 @@ test('DNA autosomal import UI coverage exercises preview, confirm, render, and d
 
     document.body.innerHTML = '<div id="notification-container"></div><div class="chat-onboard-dna"></div><main id="fixture"></main>';
     const calls = [];
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    dnaRuntime.configureDnaRuntimeDeps({
       buildSidebar: () => calls.push('sidebar'),
+      isImportRunning: () => importRunning,
+      navigate: route => calls.push(`navigate:${route}`),
     });
     const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
       updateChatNudge: () => calls.push('nudge'),
     });
-    window.navigate = route => calls.push(`navigate:${route}`);
 
     const validContent = `#AncestryDNA raw data download
 rsid\tchromosome\tposition\tallele1\tallele2
@@ -291,7 +289,6 @@ rs999999\t1\t100\tAG
 
     dnaRuntime.configureDnaRuntimeDeps(previousDnaRuntimeDeps);
     chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
-    viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
     return { failures };
   });
 
@@ -317,10 +314,9 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     };
 
     const { state } = await import('/js/state.js');
-    const [dna, dnaRuntime, viewRuntime] = await Promise.all([
+    const [dna, dnaRuntime] = await Promise.all([
       import(`/js/dna.js?dnaMtdnaCoverage=${Date.now()}-${Math.random()}`),
       import('/js/dna-runtime.js'),
-      import('/js/views-runtime-bridge.js'),
     ]);
     const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps();
 
@@ -331,10 +327,10 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
 
     document.body.innerHTML = '<div id="notification-container"></div><main id="fixture"></main>';
     const calls = [];
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    dnaRuntime.configureDnaRuntimeDeps({
       buildSidebar: () => calls.push('sidebar'),
+      navigate: route => calls.push(`navigate:${route}`),
     });
-    window.navigate = route => calls.push(`navigate:${route}`);
 
     const hapTable = await dna.loadHaplogroupTable();
     const jText = '295T\n489C\n4216C\n10398G\n11251G\n12612G\n13708A\n16069T\n16126C\n';
@@ -404,7 +400,6 @@ test('DNA mtDNA browser coverage exercises haplogroup parsing, preview, import, 
     check('haplogroup list exported', Array.isArray(dna.HAPLOGROUP_LIST) && dna.HAPLOGROUP_LIST.includes('J'));
 
     dnaRuntime.configureDnaRuntimeDeps(previousDnaRuntimeDeps);
-    viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
     return { failures };
   });
 
@@ -430,8 +425,11 @@ test('DNA genetics renderer covers empty and lazy-catalog branches', async ({ pa
 
     const { state } = await import('/js/state.js');
     const dna = await import(`/js/dna.js?dnaRendererCoverage=${Date.now()}-${Math.random()}`);
+    const dnaRuntime = await import('/js/dna-runtime.js');
     const calls = [];
-    window.navigate = route => calls.push(route);
+    const previousDnaRuntimeDeps = dnaRuntime.configureDnaRuntimeDeps({
+      navigate: route => calls.push(route),
+    });
 
     state.importedData = { entries: [], notes: [], supplements: [], healthGoals: [], diagnoses: null, genetics: null, customMarkers: {}, markerNotes: {}, markerValueNotes: {}, changeHistory: [] };
     const emptyHtml = dna.renderGeneticsSection();
@@ -454,6 +452,7 @@ test('DNA genetics renderer covers empty and lazy-catalog branches', async ({ pa
     const lazyRefreshScheduled = await waitFor(() => calls.includes('dashboard'));
     check('lazy SNP table branch returns blank and schedules dashboard refresh', lazyHtml === '' && lazyRefreshScheduled);
 
+    dnaRuntime.configureDnaRuntimeDeps(previousDnaRuntimeDeps);
     return { failures };
   });
 

--- a/tests/test-dna-runtime.js
+++ b/tests/test-dna-runtime.js
@@ -29,7 +29,6 @@ import {
   getDnaModuleFunction,
   getDnaModuleValue,
 } from '../js/dna-runtime-bridge.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let passed = 0;
 let failed = 0;
@@ -51,7 +50,6 @@ const runtimeKeys = [
   '_pendingMtDNA',
   '_snpTableCache',
   'isDebugMode',
-  'navigate',
   'showConfirmDialog',
   'triggerDNAFilePicker',
 ];
@@ -61,7 +59,6 @@ const originalWarn = console.warn;
 const originalDnaRuntimeDeps = configureDnaRuntimeDeps();
 const originalContextCardsRuntime = configureContextCardsRuntimeCallbacks();
 const originalChatRuntime = configureChatRuntimeCallbacks();
-let previousViewRuntime = null;
 const previousDnaBridge = configureDnaModuleBridge({
   handleDNAFile: null,
   HAPLOGROUP_LIST: null,
@@ -71,9 +68,9 @@ try {
   for (const key of runtimeKeys) delete globalThis[key];
 
   const calls = [];
-  globalThis.navigate = route => calls.push(['navigate', route]);
-  previousViewRuntime = configureViewRuntime({
+  configureDnaRuntimeDeps({
     buildSidebar: () => calls.push(['sidebar']),
+    navigate: route => calls.push(['navigate', route]),
   });
   refreshDnaShell('dashboard');
   assert('refreshDnaShell refreshes sidebar then navigates',
@@ -84,12 +81,15 @@ try {
   assert('navigateDnaRoute delegates route changes',
     calls.length === 1 && calls[0][0] === 'navigate' && calls[0][1] === 'genome');
 
-  configureViewRuntime({ buildSidebar: () => {
-    throw new Error('sidebar failed');
-  } });
+  configureDnaRuntimeDeps({ buildSidebar: () => { throw new Error('sidebar failed'); } });
   let sidebarThrew = false;
   try { refreshDnaSidebar(); } catch (_) { sidebarThrew = true; }
   assert('refreshDnaSidebar swallows sidebar refresh errors', !sidebarThrew);
+
+  configureDnaRuntimeDeps({ buildSidebar: null, navigate: null });
+  let missingCallbacksThrew = false;
+  try { refreshDnaShell('dashboard'); } catch (_) { missingCallbacksThrew = true; }
+  assert('DNA view callbacks are safe no-ops before shell wiring', !missingCallbacksThrew);
 
   configureDnaRuntimeDeps({ isImportRunning: () => true });
   assert('isDnaLabImportRunning delegates true state', isDnaLabImportRunning() === true);
@@ -188,7 +188,6 @@ try {
     HAPLOGROUP_LIST: null,
     ...previousDnaBridge,
   });
-  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   configureDnaRuntimeDeps(originalDnaRuntimeDeps);
   configureContextCardsRuntimeCallbacks(originalContextCardsRuntime);
   configureChatRuntimeCallbacks(originalChatRuntime);

--- a/tests/test-dna.js
+++ b/tests/test-dna.js
@@ -500,7 +500,9 @@ assert('dna-runtime owns DNA transient runtime state and shell integration',
     dnaRuntimeSrc.includes('_snpTableCache') &&
     dnaRuntimeSrc.includes("from './profile.js'") &&
     dnaRuntimeSrc.includes('dnaRuntimeDeps.getLatitudeFromLocation()') &&
-    dnaRuntimeSrc.includes("getRuntimeFunction('navigate')") &&
+    dnaRuntimeSrc.includes('dnaRuntimeDeps.navigate?.(route)') &&
+    dnaRuntimeSrc.includes('const buildSidebar = dnaRuntimeDeps.buildSidebar') &&
+    !dnaRuntimeSrc.includes('getViewRuntimeFunction') &&
     !dnaRuntimeSrc.includes('installDNAWindowBindings'));
 assert('dna-mtdna delegates browser runtime hooks to dna-runtime',
   dnaMtDnaSrc.includes("from './dna-runtime.js'") &&

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -135,6 +135,9 @@ assert('App shell injects sun defaults navigation without a view bridge lookup',
 assert('App shell injects client list view callbacks without bridge lookups',
   appShellHooksSrc.includes('configureClientListRuntimeDeps({ navigate, renderProfileButton });'));
 
+assert('App shell injects DNA view callbacks without bridge lookups',
+  appShellHooksSrc.includes('configureDnaRuntimeDeps({ buildSidebar, navigate });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.255';
+self.APP_VERSION = '1.10.256';


### PR DESCRIPTION
## Summary

- inject `buildSidebar` and `navigate` into the DNA runtime from the app shell
- remove DNA's browser-global and view-bridge callback lookup paths while preserving its intentional transient import/cache state
- update Node, static source-contract, shell, and browser coverage to configure callbacks directly
- bump the app version to `1.10.256`

## `window` burden progress

| Slice | Production accesses removed |
| --- | ---: |
| Chat window facade | 80 |
| Application callback globals | 4 |
| `APP_VERSION` reads | 3 |
| Active sync pull | 2 |
| Wearable navigation | 2 |
| Category customization | 2 |
| Sun defaults navigation | 1 |
| Onboarding view dependencies | 2 |
| Client-list view dependencies | 2 |
| DNA view dependencies (this PR) | 2 |
| **Cumulative production accesses removed** | **100** |
| **Guarded `window` references remaining** | **0** |
| **Guarded `window` assignments remaining** | **0** |

The cumulative total tracks production access removal. Intentional browser state used for DNA import handoff and cache data remains in place; this PR removes only shell callback discovery.

## Verification

- `./run-tests.sh`: 126 static checks, 398 Vitest tests, 352 Playwright tests, and 472 responsive assertions passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`: 7 passed, 0 failed; guarded references/assignments both 0
- `node tests/test-dna-runtime.js`: 21 passed
- `node tests/test-dna.js`: 186 passed
- `node tests/test-shell-delegated-actions.js`: 70 passed
- `npx playwright test tests/playwright/dna-browser-coverage.spec.js`: 4 passed
- `git diff --check`
