### PR TITLE
Inject views router shell dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -90,6 +90,7 @@ import {
   resetDashboardWidgets,
   toggleDashboardOrganizeMode,
 } from './views.js';
+import { configureViewsRouterRuntimeDeps } from './views-router-runtime.js';
 import { openProfileShareModal } from './profile-share.js';
 import { getActiveProfileId } from './profile.js';
 import { configureRecommendationsRuntime } from './recommendations-runtime.js';
@@ -131,6 +132,7 @@ configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
 configureDnaRuntimeDeps({ buildSidebar, navigate });
 configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });
+configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });

--- a/js/views-router-runtime.js
+++ b/js/views-router-runtime.js
@@ -2,12 +2,25 @@
 // views-router-runtime.js - Browser runtime adapters for routing scroll/window hooks.
 
 import { syncImportStatusFab } from './pdf-import-progress.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const viewsRouterRuntimeDeps = { syncImportStatusFab };
+const viewsRouterRuntimeDeps = {
+  closeMobileSidebar: /** @type {null | (() => void)} */ (null),
+  navigate: /** @type {null | ((view: string) => void)} */ (null),
+  syncImportStatusFab,
+};
 
 export function configureViewsRouterRuntimeDeps(deps = {}) {
   const previous = { ...viewsRouterRuntimeDeps };
+  if ('closeMobileSidebar' in deps) {
+    viewsRouterRuntimeDeps.closeMobileSidebar = typeof deps.closeMobileSidebar === 'function'
+      ? /** @type {() => void} */ (deps.closeMobileSidebar)
+      : null;
+  }
+  if ('navigate' in deps) {
+    viewsRouterRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? /** @type {(view: string) => void} */ (deps.navigate)
+      : null;
+  }
   if (typeof deps.syncImportStatusFab === 'function') viewsRouterRuntimeDeps.syncImportStatusFab = deps.syncImportStatusFab;
   return previous;
 }
@@ -26,8 +39,7 @@ function getRuntimeFunction(name) {
   const runtime = getRuntimeWindow();
   if (!runtime) return null;
   const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return name === 'navigate' ? getViewRuntimeFunction(name) : null;
+  return typeof fn === 'function' ? fn.bind(runtime) : null;
 }
 
 export function getViewportScrollPosition() {
@@ -40,7 +52,7 @@ export function getViewportScrollPosition() {
 }
 
 export function closeMobileSidebarFromRuntime() {
-  getViewRuntimeFunction('closeMobileSidebar')?.();
+  viewsRouterRuntimeDeps.closeMobileSidebar?.();
 }
 
 export function syncImportStatusFabFromRuntime() {
@@ -50,7 +62,7 @@ export function syncImportStatusFabFromRuntime() {
 
 /** @param {string} view */
 export function navigateViewportRuntime(view) {
-  getRuntimeFunction('navigate')?.(view);
+  viewsRouterRuntimeDeps.navigate?.(view);
 }
 
 /** @param {() => void} cancel */

--- a/tests/playwright/views-router-browser-coverage.spec.js
+++ b/tests/playwright/views-router-browser-coverage.spec.js
@@ -22,7 +22,6 @@ test('views router browser coverage exercises route state and scroll restoration
       import(stateUrl),
     ]);
     const routerRuntime = await import('/js/views-router-runtime.js');
-    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const { state } = stateModule;
     const fixture = document.getElementById('fixture');
@@ -40,10 +39,9 @@ test('views router browser coverage exercises route state and scroll restoration
     const coverageLastViewKey = profileModule.profileStorageKey(coverageProfile, 'lastViewV1');
     const extraLastViewKey = profileModule.profileStorageKey(extraProfile, 'lastViewV1');
     const calls = [];
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
-      closeMobileSidebar: () => calls.push(['closeSidebar']),
-    });
     const previousRouterRuntimeDeps = routerRuntime.configureViewsRouterRuntimeDeps({
+      closeMobileSidebar: () => calls.push(['closeSidebar']),
+      navigate: view => calls.push(['navigate', view]),
       syncImportStatusFab: () => calls.push(['syncFab']),
     });
     const scrollByCalls = [];
@@ -275,7 +273,6 @@ test('views router browser coverage exercises route state and scroll restoration
       state.currentView = originalCurrentView;
       window.scrollTo = originalScrollTo;
       window.scrollBy = originalScrollBy;
-      viewRuntime.configureViewRuntime({ closeMobileSidebar: null, ...previousViewRuntime });
       routerRuntime.configureViewsRouterRuntimeDeps(previousRouterRuntimeDeps);
       restoreDescriptor('scrollX', originalScrollX);
       restoreDescriptor('scrollY', originalScrollY);

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -141,6 +141,9 @@ assert('App shell injects DNA view callbacks without bridge lookups',
 assert('App shell injects PDF import review view callbacks without bridge lookups',
   appShellHooksSrc.includes('configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });'));
 
+assert('App shell injects views router callbacks without bridge lookups',
+  appShellHooksSrc.includes('configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/tests/test-views-router-runtime.js
+++ b/tests/test-views-router-runtime.js
@@ -13,7 +13,6 @@ import {
   scrollViewportBy,
   syncImportStatusFabFromRuntime,
 } from '../js/views-router-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let pass = 0, fail = 0;
 function assert(name, condition, detail) {
@@ -35,11 +34,9 @@ const runtimeKeys = [
   'scrollBy',
   'addEventListener',
   'removeEventListener',
-  'navigate',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const originalViewsRouterRuntimeDeps = configureViewsRouterRuntimeDeps();
-let previousViewRuntime = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -73,11 +70,11 @@ try {
   assert('getViewportScrollPosition falls back to page offsets',
     JSON.stringify(getViewportScrollPosition()) === JSON.stringify({ x: 56, y: 78 }));
 
-  previousViewRuntime = configureViewRuntime({
+  configureViewsRouterRuntimeDeps({
     closeMobileSidebar: () => calls.push(['close-sidebar']),
+    navigate: view => calls.push(['navigate', view]),
+    syncImportStatusFab: () => calls.push(['sync-fab']),
   });
-  configureViewsRouterRuntimeDeps({ syncImportStatusFab: () => calls.push(['sync-fab']) });
-  setRuntimeValue('navigate', view => calls.push(['navigate', view]));
   closeMobileSidebarFromRuntime();
   syncImportStatusFabFromRuntime();
   navigateViewportRuntime('dashboard');
@@ -85,6 +82,16 @@ try {
     calls.some(call => call[0] === 'close-sidebar') &&
     calls.some(call => call[0] === 'sync-fab') &&
     calls.some(call => call[0] === 'navigate' && call[1] === 'dashboard'));
+
+  configureViewsRouterRuntimeDeps({ closeMobileSidebar: null, navigate: null });
+  let missingCallbacksThrew = false;
+  try {
+    closeMobileSidebarFromRuntime();
+    navigateViewportRuntime('dashboard');
+  } catch (_) {
+    missingCallbacksThrew = true;
+  }
+  assert('view callbacks are safe no-ops before shell wiring', !missingCallbacksThrew);
 
   const listenerAdds = [];
   const listenerRemoves = [];
@@ -150,7 +157,6 @@ try {
     getViewportHeight() === 0 &&
     typeof addViewportInputCancelListeners(() => {}) === 'function');
 } finally {
-  configureViewRuntime({ closeMobileSidebar: null, ...previousViewRuntime });
   configureViewsRouterRuntimeDeps(originalViewsRouterRuntimeDeps);
   restoreRuntime();
 }

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.257';
+self.APP_VERSION = '1.10.258';


### PR DESCRIPTION
## Summary

- inject the router's `closeMobileSidebar` and `navigate` shell callbacks through `configureViewsRouterRuntimeDeps`
- remove those application callbacks from the view-runtime/window fallback path while preserving genuine viewport browser APIs
- cover shell wiring, missing-callback no-ops, and browser scroll restoration
- bump `APP_VERSION` to `1.10.258`

## `window.*` burden progress

| Completed slice | Production accesses removed |
| --- | ---: |
| Chat window facade | 80 |
| Application callback globals | 4 |
| `APP_VERSION` reads | 3 |
| Active sync pull | 2 |
| Wearable navigation | 2 |
| Category customization | 2 |
| Sun defaults navigation | 1 |
| Onboarding view dependencies | 2 |
| Client-list view dependencies | 2 |
| DNA view dependencies | 2 |
| PDF import review view dependencies | 2 |
| Views router shell dependencies (this PR) | 2 |
| **Cumulative production accesses removed** | **104** |

Quality guardrails remain at **0 production `window` global references** and **0 production legacy assignments**. This slice intentionally keeps scroll position, viewport height, event listeners, `scrollTo`, and `scrollBy` runtime-backed because they are genuine browser APIs.

## Verification

- `./run-tests.sh` — 126 Node checks, 398 Vitest tests, 352 Playwright tests, 472 responsive/theme assertions
- `node tests/test-views-router-runtime.js` — 13 passed
- `node tests/test-shell-delegated-actions.js` — 72 passed
- `node tests/test-v1-6-shipped.js` — 131 passed
- `npx playwright test tests/playwright/views-router-browser-coverage.spec.js` — 1 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`