### PR TITLE
Inject Biology Scores view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -88,6 +88,7 @@ import {
   navigate,
   refreshMobileDashboardActiveTab,
   resetDashboardWidgets,
+  showDetailModal,
   toggleDashboardOrganizeMode,
 } from './views.js';
 import { configureViewsRouterRuntimeDeps } from './views-router-runtime.js';
@@ -135,7 +136,7 @@ configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });
 configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
-configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });
+configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
 configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });

--- a/js/biology-scores-runtime.js
+++ b/js/biology-scores-runtime.js
@@ -4,11 +4,12 @@
 import { hasAIProvider } from './api.js';
 import { getActiveData } from './data.js';
 import { showNotification } from './utils.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const biologyScoresRuntimeDeps = {
   getActiveData,
+  navigate: /** @type {null | ((route: string) => unknown)} */ (null),
   openChatPanel: /** @type {null | ((prompt?: string) => unknown)} */ (null),
+  showDetailModal: /** @type {null | ((markerId: string) => unknown)} */ (null),
   showNotification,
   useChatPrompt: /** @type {null | ((prompt: string) => unknown)} */ (null),
 };
@@ -20,9 +21,19 @@ export function configureBiologyScoresRuntimeDeps(deps = {}) {
       ? /** @type {typeof getActiveData} */ (deps.getActiveData)
       : null;
   }
+  if ('navigate' in deps) {
+    biologyScoresRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? /** @type {(route: string) => unknown} */ (deps.navigate)
+      : null;
+  }
   if ('openChatPanel' in deps) {
     biologyScoresRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
       ? /** @type {(prompt?: string) => unknown} */ (deps.openChatPanel)
+      : null;
+  }
+  if ('showDetailModal' in deps) {
+    biologyScoresRuntimeDeps.showDetailModal = typeof deps.showDetailModal === 'function'
+      ? /** @type {(markerId: string) => unknown} */ (deps.showDetailModal)
       : null;
   }
   if ('showNotification' in deps) {
@@ -44,20 +55,9 @@ function getRuntimeWindow() {
     : null;
 }
 
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
-  return getViewRuntimeFunction(name);
-}
-
 /** @param {string} route */
 export function navigateBiologyScoresRoute(route = 'biology-scores') {
-  getRuntimeFunction('navigate')?.(route || 'biology-scores');
+  biologyScoresRuntimeDeps.navigate?.(route || 'biology-scores');
 }
 
 export function canOpenBiologyScoresChatPanel() {
@@ -101,7 +101,7 @@ export function getBiologyScoresActiveData() {
 /** @param {string} markerId */
 export function openBiologyScoreMarkerDetail(markerId) {
   if (!markerId) return false;
-  const showDetailModal = getRuntimeFunction('showDetailModal');
+  const showDetailModal = biologyScoresRuntimeDeps.showDetailModal;
   if (!showDetailModal) return false;
   showDetailModal(markerId);
   return true;

--- a/tests/test-biology-scores-runtime.js
+++ b/tests/test-biology-scores-runtime.js
@@ -85,7 +85,9 @@ try {
   setRuntimeValue('window', browserRuntime);
   configureBiologyScoresRuntimeDeps({
     getActiveData: browserRuntime.getActiveData.bind(browserRuntime),
+    navigate: browserRuntime.navigate.bind(browserRuntime),
     openChatPanel: browserRuntime.openChatPanel.bind(browserRuntime),
+    showDetailModal: browserRuntime.showDetailModal.bind(browserRuntime),
     showNotification: browserRuntime.showNotification.bind(browserRuntime),
     useChatPrompt: browserRuntime.useChatPrompt.bind(browserRuntime),
   });
@@ -125,10 +127,17 @@ try {
 
   delete browserRuntime.openChatPanel;
   delete browserRuntime.getActiveData;
-  configureBiologyScoresRuntimeDeps({ getActiveData: null, openChatPanel: null, useChatPrompt: null });
+  configureBiologyScoresRuntimeDeps({
+    getActiveData: null,
+    navigate: null,
+    openChatPanel: null,
+    showDetailModal: null,
+    useChatPrompt: null,
+  });
   assert('biology runtime handles missing optional browser hooks',
     !canOpenBiologyScoresChatPanel() &&
       openBiologyScoresChatPanel('missing') === false &&
+      openBiologyScoreMarkerDetail('biochemistry_glucose') === false &&
       hasBiologyScoresAIProvider() === false &&
       Object.keys(getBiologyScoresActiveData()).length === 0);
 

--- a/tests/test-biology-scores.js
+++ b/tests/test-biology-scores.js
@@ -967,7 +967,10 @@ assert('Biology Scores delegates browser globals to runtime adapter',
     !/\bwindow(?:\.|\s*\[)/.test(biologyScoresSrc) &&
     biologyScoresRuntimeSrc.includes('export function navigateBiologyScoresRoute') &&
     biologyScoresRuntimeSrc.includes('export function openBiologyScoresChatPanel') &&
-    biologyScoresRuntimeSrc.includes('export function openBiologyScoreMarkerDetail'),
+    biologyScoresRuntimeSrc.includes('export function openBiologyScoreMarkerDetail') &&
+    biologyScoresRuntimeSrc.includes('biologyScoresRuntimeDeps.navigate') &&
+    biologyScoresRuntimeSrc.includes('biologyScoresRuntimeDeps.showDetailModal') &&
+    !biologyScoresRuntimeSrc.includes('getViewRuntimeFunction'),
   biologyScoresSrc.slice(0, 1800));
 assert('refreshing a stale Biology Score AI explanation removes the stale warning in-place',
   /biology-score-ai-stale/.test(biologyScoresSrc)

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -108,7 +108,7 @@ assert('App shell wires Chat UI refreshes without window globals',
 assert('App shell wires Chat prompt consumers without window globals',
   appShellHooksSrc.includes("import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js'")
     && appShellHooksSrc.includes("import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js'")
-    && appShellHooksSrc.includes('configureBiologyScoresRuntimeDeps({ openChatPanel, useChatPrompt });')
+    && appShellHooksSrc.includes('configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });')
     && appShellHooksSrc.includes('configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });'));
 
 assert('App shell wires Chat close consumers without window globals',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.258';
+self.APP_VERSION = '1.10.259';


### PR DESCRIPTION
## Summary

- inject Biology Scores `navigate` and `showDetailModal` callbacks through its existing runtime dependency container
- remove both application callbacks from the view-runtime/window fallback path while preserving `setTimeout` as a genuine browser runtime API
- extend runtime, shell-wiring, and source guard coverage for injected callbacks and missing-callback no-ops
- bump `APP_VERSION` to `1.10.259`

## `window.*` burden progress

| Completed slice | Production accesses removed |
| --- | ---: |
| Chat window facade | 80 |
| Application callback globals | 4 |
| `APP_VERSION` reads | 3 |
| Active sync pull | 2 |
| Wearable navigation | 2 |
| Category customization | 2 |
| Sun defaults navigation | 1 |
| Onboarding view dependencies | 2 |
| Client-list view dependencies | 2 |
| DNA view dependencies | 2 |
| PDF import review view dependencies | 2 |
| Views router shell dependencies | 2 |
| Biology Scores view dependencies (this PR) | 2 |
| **Cumulative production accesses removed** | **106** |

Quality guardrails remain at **0 production `window` global references** and **0 production legacy assignments**. The Biology Scores timer intentionally remains runtime-backed because `setTimeout` is a genuine browser API.

## Verification

- `./run-tests.sh` — 126 Node checks, 398 Vitest tests, 352 Playwright tests, 472 responsive/theme assertions
- `node tests/test-biology-scores-runtime.js` — 8 passed
- `node tests/test-biology-scores.js` — 216 passed
- `node tests/test-shell-delegated-actions.js` — 72 passed
- `node tests/test-v1-6-shipped.js` — 131 passed
- `npx playwright test tests/playwright/biology-scores-dashboard-lens.spec.js` — 5 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`