### PR TITLE
Inject dashboard widget view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -25,6 +25,7 @@ import {
 import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
 import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js';
 import { configureDashboardPageRuntimeDeps } from './dashboard-page-view.js';
+import { configureDashboardWidgetRuntimeDeps } from './dashboard-widget-runtime.js';
 import {
   closeChatPanel,
   configureChatPanel,
@@ -137,6 +138,7 @@ configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
+configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
 configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });

--- a/js/dashboard-widget-runtime.js
+++ b/js/dashboard-widget-runtime.js
@@ -5,8 +5,27 @@ import { triggerContextCardDNAFilePickerRuntime } from './context-cards-runtime.
 import { getDeviceSessions } from './light-devices-store.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { getSessions } from './sun-sessions-store.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { getWearablesModuleFunction } from './wearables-runtime.js';
+
+const dashboardWidgetRuntimeDeps = {
+  navigate: /** @type {null | ((route: string) => unknown)} */ (null),
+  showDetailModal: /** @type {null | ((id: string) => unknown)} */ (null),
+};
+
+export function configureDashboardWidgetRuntimeDeps(deps = {}) {
+  const previous = { ...dashboardWidgetRuntimeDeps };
+  if ('navigate' in deps) {
+    dashboardWidgetRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? /** @type {(route: string) => unknown} */ (deps.navigate)
+      : null;
+  }
+  if ('showDetailModal' in deps) {
+    dashboardWidgetRuntimeDeps.showDetailModal = typeof deps.showDetailModal === 'function'
+      ? /** @type {(id: string) => unknown} */ (deps.showDetailModal)
+      : null;
+  }
+  return previous;
+}
 
 /** @type {Record<string, Function | null>} */
 const dashboardNoteActions = {
@@ -37,17 +56,6 @@ function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
-  return getViewRuntimeFunction(name);
 }
 
 export function getDashboardViewportHeight() {
@@ -108,12 +116,12 @@ export function openDashboardManualLogForm(id, event) {
 
 /** @param {string} id */
 export function openDashboardMarkerDetail(id) {
-  getRuntimeFunction('showDetailModal')?.(id);
+  dashboardWidgetRuntimeDeps.showDetailModal?.(id);
 }
 
 /** @param {string} route */
 export function navigateDashboardRoute(route) {
-  getRuntimeFunction('navigate')?.(route);
+  dashboardWidgetRuntimeDeps.navigate?.(route);
 }
 
 export function triggerDashboardDnaPicker() {

--- a/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-widget-controls-browser-coverage.spec.js
@@ -24,10 +24,6 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     ]);
     const outcomes = {};
     const fixture = document.getElementById('fixture');
-    const saved = {
-      navigate: window.navigate,
-      showDetailModal: window.showDetailModal,
-    };
     const calls = [];
     const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
       triggerDNAFilePicker: () => calls.push(['dna']),
@@ -35,6 +31,10 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     const previousDashboardNoteActions = dashboardWidgetRuntime.configureDashboardNoteActions({
       openNoteEditor: (...args) => calls.push(['noteEditor', args.length, ...args.map(arg => arg ?? 'null')]),
       deleteNote: index => calls.push(['deleteNote', index]),
+    });
+    const previousDashboardWidgetRuntimeDeps = dashboardWidgetRuntime.configureDashboardWidgetRuntimeDeps({
+      navigate: route => calls.push(['navigate', route]),
+      showDetailModal: id => calls.push(['markerDetail', id]),
     });
     const previousWearablesBridge = wearablesRuntime.configureWearablesModuleBridge({
       syncWearableNow: el => calls.push(['sync', el?.dataset.dashboardWidgetAction || '']),
@@ -142,8 +142,6 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     const originalRemoveItem = Storage.prototype.removeItem;
 
     try {
-      window.navigate = route => calls.push(['navigate', route]);
-      window.showDetailModal = id => calls.push(['markerDetail', id]);
       Storage.prototype.removeItem = function removeItem(key) {
         calls.push(['removeStorage', key]);
         return originalRemoveItem.call(this, key);
@@ -308,13 +306,10 @@ test('dashboard widget controls browser coverage exercises delegates picker filt
     } finally {
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       dashboardWidgetRuntime.configureDashboardNoteActions(previousDashboardNoteActions);
+      dashboardWidgetRuntime.configureDashboardWidgetRuntimeDeps(previousDashboardWidgetRuntimeDeps);
       settingsRuntimeBridge.configureSettingsModuleBridge(previousSettingsBridge);
       wearablesRuntime.configureWearablesModuleBridge(previousWearablesBridge);
       Storage.prototype.removeItem = originalRemoveItem;
-      for (const [key, value] of Object.entries(saved)) {
-        if (value === undefined) delete window[key];
-        else window[key] = value;
-      }
       document.getElementById('dashboard-widget-picker-overlay')?.remove();
     }
 

--- a/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
+++ b/tests/playwright/dashboard-widget-delegated-actions-dom.spec.js
@@ -18,14 +18,6 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const originalView = state.currentView;
     const biometricSelectionKey = dashboardWidgetsModule.dashboardBiometricSelectionKey();
-    const savedFns = {
-      showDetailModal: window.showDetailModal,
-      navigate: window.navigate,
-    };
-    const hadFns = {};
-    for (const name of Object.keys(savedFns)) {
-      hadFns[name] = Object.prototype.hasOwnProperty.call(window, name);
-    }
     const originalBiometricSelection = localStorage.getItem(biometricSelectionKey);
     let originalWearableSummary;
     let originalWearableConnections;
@@ -34,6 +26,7 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     let bodyActionHost;
     let previousContextCardsRuntime = null;
     let previousDashboardNoteActions = null;
+    let previousDashboardWidgetRuntimeDeps = null;
     let previousWearablesBridge = null;
 
     try {
@@ -174,8 +167,10 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
         openNoteEditor: (scope, index) => bodyActionCalls.push(['note', index]),
         deleteNote: index => bodyActionCalls.push(['delete-note', index]),
       });
-      window.showDetailModal = id => bodyActionCalls.push(['detail', id]);
-      window.navigate = route => bodyActionCalls.push(['navigate', route]);
+      previousDashboardWidgetRuntimeDeps = dashboardWidgetRuntime.configureDashboardWidgetRuntimeDeps({
+        navigate: route => bodyActionCalls.push(['navigate', route]),
+        showDetailModal: id => bodyActionCalls.push(['detail', id]),
+      });
       bodyActionHost = document.createElement('div');
       bodyActionHost.innerHTML = `
         <button type="button" data-dashboard-widget-action="open-marker-detail" data-dashboard-widget-id="lipids_apoB">Marker</button>
@@ -229,12 +224,9 @@ test('dashboard widget delegated actions cover organize, picker, biometrics, and
     } finally {
       if (previousContextCardsRuntime) contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       if (previousDashboardNoteActions) dashboardWidgetRuntime.configureDashboardNoteActions(previousDashboardNoteActions);
+      if (previousDashboardWidgetRuntimeDeps) dashboardWidgetRuntime.configureDashboardWidgetRuntimeDeps(previousDashboardWidgetRuntimeDeps);
       if (previousWearablesBridge) wearablesRuntime.configureWearablesModuleBridge(previousWearablesBridge);
       bodyActionHost?.remove();
-      for (const [name, original] of Object.entries(savedFns)) {
-        if (hadFns[name]) window[name] = original;
-        else delete window[name];
-      }
       if (typeof originalBiometricSelection === 'string') localStorage.setItem(biometricSelectionKey, originalBiometricSelection);
       else localStorage.removeItem(biometricSelectionKey);
       if (hadWearableSummary) state.importedData.wearableSummary = originalWearableSummary;
@@ -260,6 +252,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const { state } = await import('/js/state.js');
     const { profileStorageKey } = await import('/js/profile.js');
     const { dashboardBiometricSelectionKey, dashboardWidgetStorageKey } = await import('/js/dashboard-widgets.js');
+    const dashboardWidgetRuntime = await import('/js/dashboard-widget-runtime.js');
     const viewsModule = await import('/js/views.js');
     const recommendationRuntime = await import('/js/recommendations-runtime.js');
     const settingsRuntimeBridge = await import('/js/settings-runtime-bridge.js');
@@ -312,7 +305,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     let previousRecommendationRuntime = null;
     let previousSettingsBridge = null;
     let previousWearablesBridge = null;
-    let realNavigate;
+    let previousDashboardWidgetRuntimeDeps = null;
 
     try {
 
@@ -475,15 +468,16 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
     const markerWidgetRemovedByHide = !readPrefs().order.includes('marker_lipids_apoB')
       && !readPrefs().hidden.includes('marker_lipids_apoB');
 
-    realNavigate = window.navigate;
     const lensNavigateCalls = [];
     let addedFromLens = false;
     let removedFromLens = false;
     try {
-      window.navigate = route => {
-        lensNavigateCalls.push(route);
-        state.currentView = route;
-      };
+      previousDashboardWidgetRuntimeDeps = dashboardWidgetRuntime.configureDashboardWidgetRuntimeDeps({
+        navigate: route => {
+          lensNavigateCalls.push(route);
+          state.currentView = route;
+        },
+      });
       state.currentView = 'labs';
       viewsModule.addDashboardWidgetFromLens('alerts');
       addedFromLens = !readPrefs().hidden.includes('alerts')
@@ -492,8 +486,10 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       removedFromLens = readPrefs().hidden.includes('alerts')
         && lensNavigateCalls.filter(route => route === 'labs').length >= 2;
     } finally {
-      if (realNavigate) window.navigate = realNavigate;
-      else delete window.navigate;
+      if (previousDashboardWidgetRuntimeDeps) {
+        dashboardWidgetRuntime.configureDashboardWidgetRuntimeDeps(previousDashboardWidgetRuntimeDeps);
+        previousDashboardWidgetRuntimeDeps = null;
+      }
     }
     state.currentView = 'dashboard';
     viewsModule.navigate('dashboard');
@@ -570,8 +566,7 @@ test('dashboard widget state transitions cover layout, recommendations, and pick
       dragDropReordersPrefs,
     };
     } finally {
-      if (realNavigate && window.navigate !== realNavigate) window.navigate = realNavigate;
-      else if (!realNavigate) delete window.navigate;
+      if (previousDashboardWidgetRuntimeDeps) dashboardWidgetRuntime.configureDashboardWidgetRuntimeDeps(previousDashboardWidgetRuntimeDeps);
       viewsModule.closeDashboardWidgetPicker?.();
       viewsModule.toggleDashboardOrganizeMode?.(false);
       document.getElementById('dashboard-widget-picker-overlay')?.remove();

--- a/tests/test-dashboard-widget-delegated-actions.js
+++ b/tests/test-dashboard-widget-delegated-actions.js
@@ -41,6 +41,10 @@ assert('dashboard widget controls import runtime adapter',
 assert('dashboard widget runtime owns shell callbacks and explicit note actions',
   runtimeSrc.includes('openSettingsModal') &&
     runtimeSrc.includes('syncWearableNow') &&
+    runtimeSrc.includes('configureDashboardWidgetRuntimeDeps') &&
+    runtimeSrc.includes('dashboardWidgetRuntimeDeps.navigate') &&
+    runtimeSrc.includes('dashboardWidgetRuntimeDeps.showDetailModal') &&
+    !runtimeSrc.includes('getViewRuntimeFunction') &&
     runtimeSrc.includes('configureDashboardNoteActions') &&
     runtimeSrc.includes('dashboardNoteActions'));
 assert('dashboard widget controls has no direct window refs',

--- a/tests/test-dashboard-widget-runtime.js
+++ b/tests/test-dashboard-widget-runtime.js
@@ -5,6 +5,7 @@ import './_node-shim.js';
 import { state } from '../js/state.js';
 import {
   configureDashboardNoteActions,
+  configureDashboardWidgetRuntimeDeps,
   deleteDashboardNote,
   getDashboardDeviceSessions,
   getDashboardLightSessions,
@@ -35,14 +36,13 @@ const runtimeKeys = [
   'window',
   'innerHeight',
   '_snpTableCache',
-  'showDetailModal',
-  'navigate',
   'triggerDNAFilePicker',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const savedImportedData = state.importedData;
 let previousWearablesModule = null;
 let previousSettingsModule = null;
+const originalDashboardWidgetRuntimeDeps = configureDashboardWidgetRuntimeDeps();
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -108,8 +108,10 @@ try {
     openWearableDetail: id => calls.push(['wearable-detail', id]),
     openManualLogForm: (id, ev) => calls.push(['manual-log', id, ev.type]),
   });
-  setRuntimeValue('showDetailModal', id => calls.push(['marker-detail', id]));
-  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
+  configureDashboardWidgetRuntimeDeps({
+    navigate: route => calls.push(['navigate', route]),
+    showDetailModal: id => calls.push(['marker-detail', id]),
+  });
   setRuntimeValue('triggerDNAFilePicker', () => calls.push(['legacy-dna']));
 
   openDashboardWearablesSettings();
@@ -146,6 +148,7 @@ try {
     openManualLogForm: null,
   });
   configureSettingsModuleBridge({ openSettingsModal: null });
+  configureDashboardWidgetRuntimeDeps({ navigate: null, showDetailModal: null });
   delete globalThis.window;
   const callCountBeforeMissingRuntime = calls.length;
   openDashboardWearablesSettings();
@@ -166,6 +169,7 @@ try {
   configureDashboardNoteActions(previousDashboardNoteActions);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
 } finally {
+  configureDashboardWidgetRuntimeDeps(originalDashboardWidgetRuntimeDeps);
   configureSettingsModuleBridge({
     openSettingsModal: null,
     ...previousSettingsModule,

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -144,6 +144,9 @@ assert('App shell injects PDF import review view callbacks without bridge lookup
 assert('App shell injects views router callbacks without bridge lookups',
   appShellHooksSrc.includes('configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });'));
 
+assert('App shell injects dashboard widget view callbacks without bridge lookups',
+  appShellHooksSrc.includes('configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.259';
+self.APP_VERSION = '1.10.260';


### PR DESCRIPTION
## Summary

- add explicit dashboard widget runtime dependencies for `navigate` and `showDetailModal`
- wire those callbacks from the app shell and remove their view-runtime/window fallback path
- keep viewport height and the SNP table cache runtime-backed because they are genuine browser state
- update isolated and live browser harnesses to inject and restore the dashboard callbacks directly
- bump `APP_VERSION` to `1.10.260`

## `window.*` burden progress

| Completed slice | Production accesses removed |
| --- | ---: |
| Chat window facade | 80 |
| Application callback globals | 4 |
| `APP_VERSION` reads | 3 |
| Active sync pull | 2 |
| Wearable navigation | 2 |
| Category customization | 2 |
| Sun defaults navigation | 1 |
| Onboarding view dependencies | 2 |
| Client-list view dependencies | 2 |
| DNA view dependencies | 2 |
| PDF import review view dependencies | 2 |
| Views router shell dependencies | 2 |
| Biology Scores view dependencies | 2 |
| Dashboard widget view dependencies (this PR) | 2 |
| **Cumulative production accesses removed** | **108** |

Quality guardrails remain at **0 production `window` global references** and **0 production legacy assignments**.

## Verification

- `./run-tests.sh` — 126 Node checks, 398 Vitest tests, 352 Playwright tests, 472 responsive/theme assertions
- `node tests/test-dashboard-widget-runtime.js` — 7 passed
- `node tests/test-dashboard-widget-delegated-actions.js` — 52 passed
- `node tests/test-shell-delegated-actions.js` — 73 passed
- `node tests/test-v1-6-shipped.js` — 131 passed
- `npx playwright test tests/playwright/dashboard-widget-controls-browser-coverage.spec.js tests/playwright/dashboard-widget-delegated-actions-dom.spec.js` — 3 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `git diff --check`