### PR TITLE
Inject Light Devices view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -78,6 +78,8 @@ import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } fro
 import { closeFeedbackModal, openFeedbackModal } from './feedback.js';
 import { closeImportModal } from './pdf-import-review.js';
 import { configurePdfImportReviewRuntimeDeps } from './pdf-import-review-runtime.js';
+import { _openChannelOnLightPage } from './light-channel-view.js';
+import { configureLightDevicesRuntimeDeps } from './light-devices-runtime.js';
 import { closeModal } from './marker-detail-modal.js';
 import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
 import { buildSidebar, closeMobileSidebar, configureNavActions, renderProfileButton } from './nav.js';
@@ -139,6 +141,7 @@ configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
 configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
+configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });
 configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });

--- a/js/light-devices-runtime.js
+++ b/js/light-devices-runtime.js
@@ -5,7 +5,6 @@ import { state } from './state.js';
 import { showPromptDialog } from './utils.js';
 import { getRecommendationModuleFunction } from './recommendations-runtime.js';
 import { CHANNEL_DISPLAY, channelTier, formatChannelUnit, tierLabel } from './sun.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 /** @type {{
  *   showPromptDialog: typeof showPromptDialog | null,
@@ -13,6 +12,8 @@ import { getViewRuntimeFunction } from './views-runtime-bridge.js';
  *   tierLabel: typeof tierLabel | null,
  *   formatChannelUnit: typeof formatChannelUnit | null,
  *   channelDisplay: Record<string, any> | null,
+ *   navigate: ((route: string) => unknown) | null,
+ *   openChannelOnLightPage: ((channel: string) => unknown) | null,
  * }} */
 const lightDevicesRuntimeDeps = {
   showPromptDialog,
@@ -20,6 +21,8 @@ const lightDevicesRuntimeDeps = {
   tierLabel,
   formatChannelUnit,
   channelDisplay: CHANNEL_DISPLAY,
+  navigate: null,
+  openChannelOnLightPage: null,
 };
 
 /** @param {Partial<typeof lightDevicesRuntimeDeps>} deps */
@@ -35,28 +38,17 @@ export function configureLightDevicesRuntimeDeps(deps = {}) {
       ? deps.channelDisplay
       : null;
   }
+  for (const name of ['navigate', 'openChannelOnLightPage']) {
+    if (name in deps) {
+      lightDevicesRuntimeDeps[name] = typeof deps[name] === 'function' ? deps[name] : null;
+    }
+  }
   return previous;
-}
-
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : /** @type {any} */ (globalThis);
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (typeof runtime[name] === 'function') return runtime[name].bind(runtime);
-  return getViewRuntimeFunction(name);
 }
 
 /** @param {string} route */
 export function navigateLightDevicesRoute(route) {
-  getRuntimeFunction('navigate')?.(route);
+  lightDevicesRuntimeDeps.navigate?.(route);
 }
 
 export function refreshLightDevicesView() {
@@ -99,5 +91,5 @@ export function renderLightDeviceAffiliateRowRuntime(catalog, slug) {
 
 /** @param {string} channel */
 export function openLightDeviceChannel(channel) {
-  getRuntimeFunction('_openChannelOnLightPage')?.(channel);
+  lightDevicesRuntimeDeps.openChannelOnLightPage?.(channel);
 }

--- a/tests/playwright/light-devices-browser-coverage.spec.js
+++ b/tests/playwright/light-devices-browser-coverage.spec.js
@@ -31,12 +31,13 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
   });
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data, store, ai, lightDevices, recommendationRuntime] = await Promise.all([
+    const [{ state }, data, store, ai, lightDevices, lightDevicesRuntime, recommendationRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/light-devices-store.js'),
       import('/js/light-device-ai-analysis.js'),
       import('/js/light-devices.js'),
+      import('/js/light-devices-runtime.js'),
       import('/js/recommendations-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -63,11 +64,11 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       unitSystem: state.unitSystem,
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
-      navigate: window.navigate,
       showConfirmDialog: window.showConfirmDialog,
       maybeAnalyzeDeviceSessionAfterFinish: ai.maybeAnalyzeDeviceSessionAfterFinish,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
+    let previousLightDevicesRuntimeDeps = null;
     let previousRecommendationBridge = null;
     const outcomes = {};
     const calls = [];
@@ -112,10 +113,12 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
         }
         return saved.fetch(url, options);
       };
-      window.navigate = route => {
-        calls.push(['navigate', route]);
-        state.currentView = route;
-      };
+      previousLightDevicesRuntimeDeps = lightDevicesRuntime.configureLightDevicesRuntimeDeps({
+        navigate: route => {
+          calls.push(['navigate', route]);
+          state.currentView = route;
+        },
+      });
       window.showConfirmDialog = async message => {
         calls.push(['confirm', message]);
         return true;
@@ -297,10 +300,11 @@ test('light devices browser coverage handles store mutations UI wrappers and pic
       window.fetch = saved.fetch;
       if (saved.getOllamaConfig) window.getOllamaConfig = saved.getOllamaConfig;
       else delete window.getOllamaConfig;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
       if (saved.showConfirmDialog) window.showConfirmDialog = saved.showConfirmDialog;
       else delete window.showConfirmDialog;
+      if (previousLightDevicesRuntimeDeps) {
+        lightDevicesRuntime.configureLightDevicesRuntimeDeps(previousLightDevicesRuntimeDeps);
+      }
       store.configureLightDevicesStore({
         maybeAnalyzeDeviceSessionAfterFinish: saved.maybeAnalyzeDeviceSessionAfterFinish || (() => {}),
       });

--- a/tests/playwright/light-sun-coverage-batch.spec.js
+++ b/tests/playwright/light-sun-coverage-batch.spec.js
@@ -800,10 +800,6 @@ test('light devices cover session detail edit log active card and rendered list 
     const importedStorageKey = profileStorageKey(state.currentProfile || 'default', 'imported');
     const originalImportedLocalValue = localStorage.getItem(importedStorageKey);
     const originalImportedBlobValue = await blobStorage.getBlob(importedStorageKey);
-    const savedWindow = {
-      _openChannelOnLightPage: window._openChannelOnLightPage,
-      navigate: window.navigate,
-    };
     const calls = [];
     const previousLightDevicesRuntimeDeps = lightDevicesRuntime.configureLightDevicesRuntimeDeps({
       showPromptDialog: async () => '17',
@@ -816,6 +812,8 @@ test('light devices cover session detail edit log active card and rendered list 
         pbm_red: { icon: 'R', label: 'Red', what: 'Red light' },
         pbm_nir: { icon: 'N', label: 'NIR', what: 'NIR' },
       },
+      navigate: route => calls.push(['navigate', route]),
+      openChannelOnLightPage: channel => calls.push(['open-channel', channel]),
     });
     const previousRecommendationBridge = recommendationRuntime.configureRecommendationModuleBridge({
       loadCatalog: async () => ({ items: [] }),
@@ -869,11 +867,9 @@ test('light devices cover session detail edit log active card and rendered list 
         lightDevices: [device],
         deviceSessions: [session],
       };
-      window._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
       lightDevices.configureLightDevices({
         renderDeviceSessionAIDetail: () => '<section class="device-ai-detail-test">Device AI</section>',
       });
-      window.navigate = route => calls.push(['navigate', route]);
 
       const devicesHtml = await lightDevices.renderDevicesSection();
       const devicesHost = document.createElement('div');
@@ -960,7 +956,6 @@ test('light devices cover session detail edit log active card and rendered list 
       lightDevices.configureLightDevices({ renderDeviceSessionAIDetail: () => '' });
       lightDevicesRuntime.configureLightDevicesRuntimeDeps(previousLightDevicesRuntimeDeps);
       recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
-      Object.assign(window, savedWindow);
       document.querySelectorAll('.modal-overlay,.notification-container').forEach(el => el.remove());
     }
 

--- a/tests/test-light-devices-runtime.js
+++ b/tests/test-light-devices-runtime.js
@@ -26,25 +26,15 @@ function assert(name, condition, detail) {
 
 console.log('=== Light Devices Runtime Tests ===\n');
 
-const runtimeKeys = [
-  'navigate',
-  'showPromptDialog',
-  '_openChannelOnLightPage',
-];
-const saved = Object.fromEntries(runtimeKeys.map(key => [key, globalThis[key]]));
 const savedView = state.currentView;
 
 function restoreRuntime() {
-  for (const key of runtimeKeys) {
-    if (typeof saved[key] === 'undefined') delete globalThis[key];
-    else globalThis[key] = saved[key];
-  }
   state.currentView = savedView;
 }
 
 try {
   const calls = [];
-  globalThis.navigate = route => calls.push(['navigate', route]);
+  configureLightDevicesRuntimeDeps({ navigate: route => calls.push(['navigate', route]) });
   navigateLightDevicesRoute('light');
   assert('navigateLightDevicesRoute delegates to runtime navigate',
     calls.some(call => call[0] === 'navigate' && call[1] === 'light'));
@@ -115,10 +105,19 @@ try {
     renderLightDeviceAffiliateRowRuntime({}, 'panel-x') === '');
   configureRecommendationModuleBridge(previousRecommendationBridge);
 
-  globalThis._openChannelOnLightPage = channel => calls.push(['open-channel', channel]);
+  configureLightDevicesRuntimeDeps({
+    openChannelOnLightPage: channel => calls.push(['open-channel', channel]),
+  });
   openLightDeviceChannel('vitamin_d');
   assert('openLightDeviceChannel delegates to the current view binding',
     calls.some(call => call[0] === 'open-channel' && call[1] === 'vitamin_d'));
+
+  configureLightDevicesRuntimeDeps({ navigate: null, openChannelOnLightPage: null });
+  const callCountBeforeMissingCallbacks = calls.length;
+  navigateLightDevicesRoute('dashboard');
+  openLightDeviceChannel('circadian');
+  assert('Light Devices view callbacks no-op safely before shell wiring',
+    calls.length === callCountBeforeMissingCallbacks);
 } finally {
   configureRecommendationModuleBridge({
     loadCatalog: null,

--- a/tests/test-light-devices.js
+++ b/tests/test-light-devices.js
@@ -618,10 +618,12 @@ const {
     lightDevicesSrc.includes("from './light-devices-runtime.js'") &&
     !/\bwindow\./.test(lightDevicesSrc));
   assert('light-devices-runtime owns browser-shell hooks and explicit utility dependency',
-    lightDevicesRuntimeSrc.includes("getRuntimeFunction('navigate')") &&
+    lightDevicesRuntimeSrc.includes('lightDevicesRuntimeDeps.navigate') &&
+    lightDevicesRuntimeSrc.includes('lightDevicesRuntimeDeps.openChannelOnLightPage') &&
     lightDevicesRuntimeSrc.includes('lightDevicesRuntimeDeps.showPromptDialog') &&
     lightDevicesRuntimeSrc.includes("getRecommendationModuleFunction('loadCatalog')") &&
     lightDevicesRuntimeSrc.includes("from './recommendations-runtime.js'") &&
+    !lightDevicesRuntimeSrc.includes('getViewRuntimeFunction') &&
     !lightDevicesRuntimeSrc.includes('publishLightDevicesWindowBindings'));
 
 console.log(`\nResults: ${pass} passed, ${fail} failed, ${pass + fail} total`);

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -147,6 +147,9 @@ assert('App shell injects views router callbacks without bridge lookups',
 assert('App shell injects dashboard widget view callbacks without bridge lookups',
   appShellHooksSrc.includes('configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });'));
 
+assert('App shell injects Light Devices view callbacks without bridge lookups',
+  appShellHooksSrc.includes('configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.260';
+self.APP_VERSION = '1.10.261';


### PR DESCRIPTION
## Summary

- inject Light Devices navigation and channel-opening callbacks through `configureLightDevicesRuntimeDeps`
- wire the runtime dependencies from the application shell and remove the legacy global lookup/fallback
- update Node and browser coverage to configure the runtime explicitly
- bump `APP_VERSION` to `1.10.261`

## `window.*` reduction progress

| Completed slice | Production accesses removed |
| --- | ---: |
| Chat window facade | 80 |
| Application callback globals | 4 |
| `APP_VERSION` reads | 3 |
| Active sync pull | 2 |
| Wearable navigation | 2 |
| Category customization | 2 |
| Sun defaults navigation | 1 |
| Onboarding view dependencies | 2 |
| Client-list view dependencies | 2 |
| DNA view dependencies | 2 |
| PDF import review view dependencies | 2 |
| Views router shell dependencies | 2 |
| Biology Scores view dependencies | 2 |
| Dashboard widget view dependencies | 2 |
| Light Devices view dependencies (this PR) | 2 |
| **Cumulative production accesses removed** | **110** |

The touched Light Devices runtime now has 0 production `window.*` references and 0 legacy callback assignments.

## Verification

- `./run-tests.sh`: 126 Node, 398 Vitest, 352 Playwright, and 472 responsive checks passed
- `node tests/test-light-devices-runtime.js`: 15 passed
- `node tests/test-light-devices.js`: 62 passed
- `node tests/test-shell-delegated-actions.js`: 74 passed
- `node tests/test-v1-6-shipped.js`: 131 passed
- `npx playwright test tests/playwright/light-sun-coverage-batch.spec.js`: 5 passed
- `npx playwright test tests/playwright/light-devices-browser-coverage.spec.js`: 2 passed
- `npm run typecheck`, `npm run typecheck:checkjs`, `npm run quality`, and `git diff --check`: passed
