### PR TITLE
Inject Context Lifestyle view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -142,7 +142,7 @@ configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationE
 configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
 configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
 configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });
-configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });
+configureContextCardLifestyleRuntimeDeps({ closeModal, navigate, openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });
 configureEMFInterpretationRuntimeDeps({ openChatPanel });

--- a/js/context-card-lifestyle-runtime.js
+++ b/js/context-card-lifestyle-runtime.js
@@ -3,15 +3,26 @@
 
 import { openContextModalRuntime } from './context-cards-runtime.js';
 import { updateChatHeaderModelRuntime } from './chat-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const lifestyleRuntimeDeps = {
+  closeModal: /** @type {null | (() => unknown)} */ (null),
+  navigate: /** @type {null | ((category?: string) => unknown)} */ (null),
   openChatPanel: /** @type {null | (() => unknown)} */ (null),
   useChatPrompt: /** @type {null | ((prompt: string) => unknown)} */ (null),
 };
 
 export function configureContextCardLifestyleRuntimeDeps(deps = {}) {
   const previous = { ...lifestyleRuntimeDeps };
+  if ('closeModal' in deps) {
+    lifestyleRuntimeDeps.closeModal = typeof deps.closeModal === 'function'
+      ? /** @type {() => unknown} */ (deps.closeModal)
+      : null;
+  }
+  if ('navigate' in deps) {
+    lifestyleRuntimeDeps.navigate = typeof deps.navigate === 'function'
+      ? /** @type {(category?: string) => unknown} */ (deps.navigate)
+      : null;
+  }
   if ('openChatPanel' in deps) {
     lifestyleRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
       ? /** @type {() => unknown} */ (deps.openChatPanel)
@@ -31,17 +42,6 @@ function getRuntimeWindow() {
     : null;
 }
 
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
-}
-
 const LIFESTYLE_DELEGATES_BOUND_KEY = '__lifestyleContextDelegatesBound';
 
 export function markLifestyleContextDelegatesBoundRuntime() {
@@ -52,12 +52,12 @@ export function markLifestyleContextDelegatesBoundRuntime() {
 }
 
 export function closeLifestyleContextModalRuntime() {
-  getRuntimeFunction('closeModal')?.();
+  lifestyleRuntimeDeps.closeModal?.();
 }
 
 /** @param {string | undefined} category */
 export function navigateLifestyleContextRuntime(category) {
-  getRuntimeFunction('navigate')?.(category);
+  lifestyleRuntimeDeps.navigate?.(category);
 }
 
 /** @param {string | undefined} category */

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -224,11 +224,11 @@ test('lifestyle context editors cover save clear health goals lens and contamina
     const saved = {
       importedData: clone(state.importedData),
       profileSex: state.profileSex,
-      closeModal: window.closeModal,
-      navigate: window.navigate,
     };
     const calls = [];
     const previousLifestyleRuntimeDeps = lifestyleRuntime.configureContextCardLifestyleRuntimeDeps({
+      closeModal: () => { calls.push(['close']); overlay.classList.remove('show'); },
+      navigate: route => calls.push(['navigate', route]),
       openChatPanel: () => calls.push(['chat']),
       useChatPrompt: prompt => calls.push(['prompt', prompt]),
     });
@@ -265,9 +265,6 @@ test('lifestyle context editors cover save clear health goals lens and contamina
         interpretiveLens: '',
         emfAssessment: { assessments: [] },
       };
-      window.closeModal = () => { calls.push(['close']); overlay.classList.remove('show'); };
-      window.navigate = route => calls.push(['navigate', route]);
-
       lifestyle.openExerciseEditor();
       const defaultExerciseFrequency = setOption('exercise-freq');
       lifestyle.saveExercise();
@@ -435,8 +432,6 @@ test('lifestyle context editors cover save clear health goals lens and contamina
     } finally {
       state.importedData = saved.importedData;
       state.profileSex = saved.profileSex;
-      window.closeModal = saved.closeModal;
-      window.navigate = saved.navigate;
       lifestyleRuntime.configureContextCardLifestyleRuntimeDeps(previousLifestyleRuntimeDeps);
       lifestyle.configureLifestyleContextEditors({ recordChange: () => {}, saveAndRefresh: () => {} });
       overlay.classList.remove('show');

--- a/tests/test-context-card-lifestyle-runtime.js
+++ b/tests/test-context-card-lifestyle-runtime.js
@@ -29,9 +29,6 @@ console.log('=== Context Card Lifestyle Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'closeModal',
-  'navigate',
-  'openContextModal',
   '__lifestyleContextDelegatesBound',
   'setTimeout',
 ];
@@ -63,13 +60,12 @@ try {
     openContextModal: () => calls.push(['context-modal']),
   });
   const previousLifestyleRuntime = configureContextCardLifestyleRuntimeDeps({
+    closeModal: () => calls.push(['close']),
+    navigate: category => calls.push(['navigate', category]),
     openChatPanel: () => calls.push(['chat-panel']),
     useChatPrompt: prompt => calls.push(['prompt', prompt]),
   });
   setRuntimeValue('window', globalThis);
-  setRuntimeValue('closeModal', () => calls.push(['close']));
-  setRuntimeValue('navigate', category => calls.push(['navigate', category]));
-  setRuntimeValue('openContextModal', () => calls.push(['legacy-context-modal']));
   delete globalThis.__lifestyleContextDelegatesBound;
   setRuntimeValue('setTimeout', (fn, delay) => {
     calls.push(['timer', String(delay)]);
@@ -106,7 +102,12 @@ try {
 
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
   configureChatRuntimeCallbacks({ updateChatHeaderModel: null });
-  configureContextCardLifestyleRuntimeDeps({ openChatPanel: null, useChatPrompt: null });
+  configureContextCardLifestyleRuntimeDeps({
+    closeModal: null,
+    navigate: null,
+    openChatPanel: null,
+    useChatPrompt: null,
+  });
   delete globalThis.window;
   const shellCallCount = calls.filter(call => call[0] !== 'timer').length;
   closeLifestyleContextModalRuntime();
@@ -121,11 +122,16 @@ try {
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const editorSrc = fs.readFileSync(path.join(root, 'js/context-card-lifestyle-editors.js'), 'utf8');
+  const runtimeSrc = fs.readFileSync(path.join(root, 'js/context-card-lifestyle-runtime.js'), 'utf8');
   const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
   assert('lifestyle editor delegates browser globals through runtime adapter',
     editorSrc.includes("from './context-card-lifestyle-runtime.js'") &&
       !/\bwindow(?:\.|\s*\[)/.test(editorSrc) &&
       swSrc.includes("'/js/context-card-lifestyle-runtime.js'"));
+  assert('lifestyle runtime injects view callbacks without the legacy bridge',
+    runtimeSrc.includes('lifestyleRuntimeDeps.closeModal?.()') &&
+      runtimeSrc.includes('lifestyleRuntimeDeps.navigate?.(category)') &&
+      !runtimeSrc.includes('getViewRuntimeFunction'));
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
   configureChatRuntimeCallbacks(previousChatRuntime);
   configureContextCardLifestyleRuntimeDeps(previousLifestyleRuntime);

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -109,7 +109,7 @@ assert('App shell wires Chat prompt consumers without window globals',
   appShellHooksSrc.includes("import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js'")
     && appShellHooksSrc.includes("import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js'")
     && appShellHooksSrc.includes('configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });')
-    && appShellHooksSrc.includes('configureContextCardLifestyleRuntimeDeps({ openChatPanel, useChatPrompt });'));
+    && appShellHooksSrc.includes('configureContextCardLifestyleRuntimeDeps({ closeModal, navigate, openChatPanel, useChatPrompt });'));
 
 assert('App shell wires Chat close consumers without window globals',
   appShellHooksSrc.includes("import { configureChatEmptyStateDeps } from './chat-empty-state.js'")

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.261';
+self.APP_VERSION = '1.10.262';


### PR DESCRIPTION
## Summary

- inject Context Lifestyle `closeModal` and `navigate` callbacks through `configureContextCardLifestyleRuntimeDeps`
- wire both callbacks from the application shell and remove the legacy view-runtime bridge import/fallback
- update Node and Playwright coverage to configure and restore the callbacks explicitly
- bump `APP_VERSION` to `1.10.262`

## `window.*` reduction progress

| Completed slice | Production accesses removed |
| --- | ---: |
| Chat window facade | 80 |
| Application callback globals | 4 |
| `APP_VERSION` reads | 3 |
| Active sync pull | 2 |
| Wearable navigation | 2 |
| Category customization | 2 |
| Sun defaults navigation | 1 |
| Onboarding view dependencies | 2 |
| Client-list view dependencies | 2 |
| DNA view dependencies | 2 |
| PDF import review view dependencies | 2 |
| Views router shell dependencies | 2 |
| Biology Scores view dependencies | 2 |
| Dashboard widget view dependencies | 2 |
| Light Devices view dependencies | 2 |
| Context Lifestyle view dependencies (this PR) | 2 |
| **Cumulative production accesses removed** | **112** |

This removes both shell-callback lookups from the Context Lifestyle runtime. Its remaining browser access owns the delegated-listener binding flag; it is not a shell callback bridge.

## Verification

- `./run-tests.sh`: 126 Node, 398 Vitest, 352 Playwright, and 472 responsive checks passed
- `node tests/test-context-card-lifestyle-runtime.js`: 5 passed
- `node tests/test-shell-delegated-actions.js`: 74 passed
- `node tests/test-v1-6-shipped.js`: 131 passed
- `npx playwright test tests/playwright/context-coverage-batch.spec.js`: 4 passed
- `npm run typecheck`, `npm run typecheck:checkjs`, `npm run quality`, and `git diff --check`: passed
