### PR TITLE
Inject Cycle view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -71,6 +71,7 @@ import { closeClientList, configureClientListRuntime, openClientList, openProfil
 import { configureClientListRuntimeDeps } from './client-list-runtime.js';
 import { configureCompareCorrelationViews } from './compare-correlations.js';
 import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
+import { configureCycleRuntimeDeps } from './cycle-runtime.js';
 import { configureDnaRuntimeDeps } from './dna-runtime.js';
 import { closeEMFInterpretation, configureEMFInterpretationRuntimeDeps } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder } from './export.js';
@@ -134,6 +135,7 @@ configureSettingsRuntime({
 configureNavActions({ openClientList });
 configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
+configureCycleRuntimeDeps({ closeModal, navigate });
 configureDnaRuntimeDeps({ buildSidebar, navigate });
 configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });
 configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });

--- a/js/cycle-runtime.js
+++ b/js/cycle-runtime.js
@@ -1,0 +1,31 @@
+// @ts-check
+// cycle-runtime.js - Explicit application callbacks for Cycle views.
+
+/** @type {{ closeModal: (() => void) | null, navigate: ((category: string) => void) | null }} */
+const cycleRuntimeDeps = {
+  closeModal: null,
+  navigate: null,
+};
+
+/**
+ * @param {{ closeModal?: (() => void) | null, navigate?: ((category: string) => void) | null }} deps
+ */
+export function configureCycleRuntimeDeps(deps = {}) {
+  const previous = { ...cycleRuntimeDeps };
+  if (Object.hasOwn(deps, 'closeModal')) {
+    cycleRuntimeDeps.closeModal = typeof deps.closeModal === 'function' ? deps.closeModal : null;
+  }
+  if (Object.hasOwn(deps, 'navigate')) {
+    cycleRuntimeDeps.navigate = typeof deps.navigate === 'function' ? deps.navigate : null;
+  }
+  return previous;
+}
+
+export function closeCycleModalRuntime() {
+  cycleRuntimeDeps.closeModal?.();
+}
+
+/** @param {string} category */
+export function navigateCycleViewRuntime(category) {
+  cycleRuntimeDeps.navigate?.(category);
+}

--- a/js/cycle.js
+++ b/js/cycle.js
@@ -8,7 +8,7 @@ import { startCycleTour } from './tour.js';
 import { createCyclePeriod, recentCyclePeriods, upgradeMenstrualCycleProfile } from './cycle-summary.js';
 import { clearCycleProfileData, renderCycleImportPickerControls, renderCycleImportSummarySection } from './cycle-import.js';
 import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { closeCycleModalRuntime, navigateCycleViewRuntime } from './cycle-runtime.js';
 const CYCLE_ACTIVE_STATUSES = new Set(['regular', 'perimenopause']);
 const CYCLE_ICONS = {
   calendar: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="3" y="4" width="18" height="18" rx="2"></rect><path d="M16 2v4M8 2v4M3 10h18"></path></svg>',
@@ -21,16 +21,13 @@ const CYCLE_ICONS = {
   warning: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="m12 3 10 18H2L12 3Z"></path><path d="M12 9v5M12 17h.01"></path></svg>',
   x: '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M18 6 6 18M6 6l12 12"></path></svg>'
 };
-const appWindow = /** @type {Window & typeof globalThis & {
-  closeModal?: () => void,
-  navigate?: (category: string) => void,
-  __cycleDelegatesBound?: boolean
-}} */ (typeof window !== 'undefined' ? window : {});
+const appWindow = /** @type {Window & typeof globalThis & { __cycleDelegatesBound?: boolean }} */ (
+  typeof window !== 'undefined' ? window : {}
+);
 function closeCycleModal() {
-  const closeModal = appWindow.closeModal || (typeof window !== 'undefined' ? getViewRuntimeFunction('closeModal') : null);
-  closeModal?.call(appWindow);
+  closeCycleModalRuntime();
 }
-function navigateCycleView(category) { (appWindow.navigate || (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null))?.call(appWindow, category); }
+function navigateCycleView(category) { navigateCycleViewRuntime(category); }
 function cycleActionAttrs(action, extra = '') {
   return `data-cycle-action="${action}"${extra ? ` ${extra}` : ''}`;
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 29,
-  "viewRuntimeBridgeLookups": 44,
+  "viewRuntimeBridgeConsumers": 28,
+  "viewRuntimeBridgeLookups": 42,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -140,6 +140,7 @@ const APP_SHELL = [
   '/js/cycle-store.js',
   '/js/cycle-summary.js',
   '/js/cycle.js',
+  '/js/cycle-runtime.js',
   '/js/context-cards.js',
   '/js/context-cards-runtime.js',
   '/js/context-source-registry.js',

--- a/tests/playwright/cycle-browser-coverage.spec.js
+++ b/tests/playwright/cycle-browser-coverage.spec.js
@@ -14,9 +14,10 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ cycleUrl }) => {
-    const [{ state }, cycle, tour, cycleStore, contextCardsRuntime] = await Promise.all([
+    const [{ state }, cycle, cycleRuntime, tour, cycleStore, contextCardsRuntime] = await Promise.all([
       import('/js/state.js'),
       import(cycleUrl),
+      import('/js/cycle-runtime.js'),
       import('/js/tour.js'),
       import('/js/cycle-store.js'),
       import('/js/context-cards-runtime.js'),
@@ -29,8 +30,6 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
     const saved = {
       importedData: clone(state.importedData),
       profileDob: state.profileDob,
-      closeModal: window.closeModal,
-      navigate: window.navigate,
     };
     const previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
       recordChange: field => calls.push(['record', field]),
@@ -49,6 +48,21 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
     const clearToasts = () => document.querySelectorAll('.notification-toast').forEach(el => el.remove());
     const modal = () => document.getElementById('detail-modal');
     const overlay = () => document.getElementById('modal-overlay');
+    const previousCycleRuntime = cycleRuntime.configureCycleRuntimeDeps({
+      closeModal: () => {
+        calls.push(['close']);
+        overlay()?.classList.remove('show');
+      },
+      navigate: category => {
+        calls.push(['navigate', category]);
+        if (category === 'cycle' && !injectedCycleSurface) {
+          injectedCycleSurface = document.createElement('button');
+          injectedCycleSurface.className = 'cycle-summary-card';
+          injectedCycleSurface.textContent = 'Cycle summary';
+          document.body.appendChild(injectedCycleSurface);
+        }
+      },
+    });
 
     try {
       if (!overlay()) {
@@ -68,19 +82,6 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
       document.body.appendChild(nav);
       injectedNav = nav;
 
-      window.closeModal = () => {
-        calls.push(['close']);
-        overlay()?.classList.remove('show');
-      };
-      window.navigate = category => {
-        calls.push(['navigate', category]);
-        if (category === 'cycle' && !injectedCycleSurface) {
-          injectedCycleSurface = document.createElement('button');
-          injectedCycleSurface.className = 'cycle-summary-card';
-          injectedCycleSurface.textContent = 'Cycle summary';
-          document.body.appendChild(injectedCycleSurface);
-        }
-      };
       tour.endTour({ openEmptyChat: false });
       localStorage.removeItem(cycleTourKey);
 
@@ -240,10 +241,7 @@ test('cycle browser coverage exercises editor save clear and period guards', asy
     } finally {
       state.importedData = saved.importedData;
       state.profileDob = saved.profileDob;
-      if (saved.closeModal) window.closeModal = saved.closeModal;
-      else delete window.closeModal;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
+      cycleRuntime.configureCycleRuntimeDeps(previousCycleRuntime);
       contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       tour.endTour();
       if (savedCycleTourState) localStorage.setItem(cycleTourKey, savedCycleTourState);

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -273,6 +273,21 @@ const { phaseBandPlugin } = await import('../js/charts.js');
   // ── Section 18: Source inspection ──
   console.log('Section 18: Source inspection');
   {
+    const cycleRuntime = await import('../js/cycle-runtime.js');
+    const runtimeCalls = [];
+    const previousCycleRuntime = cycleRuntime.configureCycleRuntimeDeps({
+      closeModal: () => runtimeCalls.push(['close']),
+      navigate: category => runtimeCalls.push(['navigate', category]),
+    });
+    cycleRuntime.closeCycleModalRuntime();
+    cycleRuntime.navigateCycleViewRuntime('cycle');
+    cycleRuntime.configureCycleRuntimeDeps({ closeModal: null, navigate: null });
+    cycleRuntime.closeCycleModalRuntime();
+    cycleRuntime.navigateCycleViewRuntime('ignored');
+    cycleRuntime.configureCycleRuntimeDeps(previousCycleRuntime);
+    assert('cycle runtime invokes injected callbacks and safely no-ops when cleared',
+      JSON.stringify(runtimeCalls) === JSON.stringify([['close'], ['navigate', 'cycle']]));
+
     // charts.js
     const chartsSrc = read('js/charts.js');
     assert('phaseBandPlugin exported', chartsSrc.includes('export const phaseBandPlugin'));
@@ -301,6 +316,14 @@ const { phaseBandPlugin } = await import('../js/charts.js');
     assert('cycle.js imports linearRegression', cycleSrc.includes('linearRegression'));
     assert('cycle.js exports detectPerimenopausePattern', cycleSrc.includes('export function detectPerimenopausePattern'));
     assert('cycle.js exports detectCycleIronAlerts', cycleSrc.includes('export function detectCycleIronAlerts'));
+    const cycleRuntimeSrc = read('js/cycle-runtime.js');
+    assert('cycle.js injects view callbacks without the view runtime bridge',
+      cycleRuntimeSrc.includes('export function configureCycleRuntimeDeps')
+        && cycleRuntimeSrc.includes('cycleRuntimeDeps.closeModal?.()')
+        && cycleRuntimeSrc.includes('cycleRuntimeDeps.navigate?.(category)')
+        && cycleSrc.includes("from './cycle-runtime.js'")
+        && !cycleSrc.includes('views-runtime-bridge.js')
+        && !cycleSrc.includes('getViewRuntimeFunction'));
 
     // Service worker cache version
     const swSrc = read('service-worker.js');

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 29 &&
-    baseline.viewRuntimeBridgeLookups === 44);
+    baseline.viewRuntimeBridgeConsumers === 28 &&
+    baseline.viewRuntimeBridgeLookups === 42);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -129,6 +129,10 @@ assert('App shell injects wearable navigation without view bridge lookups',
 assert('App shell injects category customization view callbacks',
   appShellHooksSrc.includes('configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });'));
 
+assert('App shell injects Cycle view callbacks without bridge lookups',
+  appShellHooksSrc.includes("import { configureCycleRuntimeDeps } from './cycle-runtime.js'")
+    && appShellHooksSrc.includes('configureCycleRuntimeDeps({ closeModal, navigate });'));
+
 assert('App shell injects sun defaults navigation without a view bridge lookup',
   appShellHooksSrc.includes('configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });'));
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -404,6 +404,7 @@
     "js/cycle-store.js",
     "js/cycle-summary.js",
     "js/cycle.js",
+    "js/cycle-runtime.js",
     "js/data-wipe.js",
     "js/dna-actions.js",
     "js/dna-genotype.js",

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.262';
+self.APP_VERSION = '1.10.263';


### PR DESCRIPTION
## Summary

- add a small Cycle runtime boundary for `closeModal` and `navigate`
- wire both callbacks from the application shell and remove Cycle's window/view-bridge fallback path
- update Cycle browser coverage to configure and restore callbacks explicitly instead of manufacturing window globals
- cache and type-check the new runtime module and bump `APP_VERSION` to `1.10.263`

## Window-burden progress

- removes 2 production view-runtime lookups
- removes Cycle as a complete `views-runtime-bridge` consumer
- ratchets bridge coupling from **29 consumer modules / 44 lookups** to **28 consumer modules / 42 lookups**
- raises the tracked cumulative production access reduction from **112** to **114**
- keeps direct window references, window assignments, and legacy assignments at **0**

Cycle's delegated-listener binding flag remains browser-owned state; only application callback discovery moves to explicit injection.

## Verification

- `npm run quality` — 9 passed; bridge inventory 28 consumers / 42 lookups; large-module count unchanged
- `node tests/test-cycle-improvements.js` — 78 passed
- `node tests/test-shell-delegated-actions.js` — 75 passed
- `node tests/test-quality-guardrails.js` — 24 passed
- `node tests/verify-modules.js` — 126 passed
- `npx playwright test tests/playwright/cycle-browser-coverage.spec.js` — 1 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `git diff --check`