### PR TITLE
Inject Supplements view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -107,6 +107,7 @@ import {
 import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
 import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
+import { configureSupplementsRuntimeDeps } from './supplements-runtime.js';
 import { configureTourRuntimeDeps } from './tour-runtime.js';
 import { configureWearablesConnectRuntimeDeps } from './wearables-connect-runtime.js';
 import { configureWearableSettingsRuntimeDeps } from './wearables-settings-runtime.js';
@@ -140,6 +141,7 @@ configureDnaRuntimeDeps({ buildSidebar, navigate });
 configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });
 configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
+configureSupplementsRuntimeDeps({ closeModal, navigate });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
 configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
 configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });

--- a/js/supplements-runtime.js
+++ b/js/supplements-runtime.js
@@ -1,0 +1,31 @@
+// @ts-check
+// supplements-runtime.js - Explicit application callbacks for Supplements views.
+
+/** @type {{ closeModal: (() => void) | null, navigate: ((category: string) => void) | null }} */
+const supplementsRuntimeDeps = {
+  closeModal: null,
+  navigate: null,
+};
+
+/**
+ * @param {{ closeModal?: (() => void) | null, navigate?: ((category: string) => void) | null }} deps
+ */
+export function configureSupplementsRuntimeDeps(deps = {}) {
+  const previous = { ...supplementsRuntimeDeps };
+  if (Object.hasOwn(deps, 'closeModal')) {
+    supplementsRuntimeDeps.closeModal = typeof deps.closeModal === 'function' ? deps.closeModal : null;
+  }
+  if (Object.hasOwn(deps, 'navigate')) {
+    supplementsRuntimeDeps.navigate = typeof deps.navigate === 'function' ? deps.navigate : null;
+  }
+  return previous;
+}
+
+export function closeSupplementsModalRuntime() {
+  supplementsRuntimeDeps.closeModal?.();
+}
+
+/** @param {string} category */
+export function navigateSupplementsViewRuntime(category) {
+  supplementsRuntimeDeps.navigate?.(category);
+}

--- a/js/supplements.js
+++ b/js/supplements.js
@@ -16,7 +16,7 @@ import { openModalOverlay } from './modal-lifecycle.js';
 import { initSupplementActionDelegates, suppActionAttrs } from './supplement-action-delegates.js';
 import { scanSupplementsForWarnings, humanizeEffect } from './supplement-warnings.js';
 import { getUtilsRuntimeHostname } from './utils-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { closeSupplementsModalRuntime, navigateSupplementsViewRuntime } from './supplements-runtime.js';
 import {
   computeAllImpacts,
   computeSupplementImpact,
@@ -40,23 +40,12 @@ export {
   renderSupplementImpact,
 } from './supplement-impact.js';
 
-const appWindow = /** @type {Window & typeof globalThis & {
-  closeModal?: () => void,
-  navigate?: (category: string) => void
-}} */ (window);
-
 function closeSupplementModal() {
-  const closeModal = typeof appWindow.closeModal === 'function'
-    ? appWindow.closeModal.bind(appWindow)
-    : getViewRuntimeFunction('closeModal');
-  closeModal?.();
+  closeSupplementsModalRuntime();
 }
 
 function navigateSupplementView(category) {
-  const navigate = typeof appWindow.navigate === 'function'
-    ? appWindow.navigate.bind(appWindow)
-    : getViewRuntimeFunction('navigate');
-  navigate?.(category);
+  navigateSupplementsViewRuntime(category);
 }
 
 /**

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 28,
-  "viewRuntimeBridgeLookups": 42,
+  "viewRuntimeBridgeConsumers": 27,
+  "viewRuntimeBridgeLookups": 40,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -133,6 +133,7 @@ const APP_SHELL = [
   '/js/notes.js',
   '/js/supplement-action-delegates.js',
   '/js/supplements.js',
+  '/js/supplements-runtime.js',
   '/js/supplement-impact.js',
   '/js/cycle-import-adapters.js',
   '/js/cycle-import-file.js',

--- a/tests/playwright/supplements-browser-coverage.spec.js
+++ b/tests/playwright/supplements-browser-coverage.spec.js
@@ -27,10 +27,11 @@ test('supplements browser coverage handles editor ingredients imports sync and A
   });
 
   const outcomes = await page.evaluate(async () => {
-    const [{ state }, data, supplements] = await Promise.all([
+    const [{ state }, data, supplements, supplementsRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/supplements.js'),
+      import('/js/supplements-runtime.js'),
     ]);
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
     const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -59,21 +60,21 @@ test('supplements browser coverage handles editor ingredients imports sync and A
       currentView: state.currentView,
       fetch: window.fetch,
       getOllamaConfig: window.getOllamaConfig,
-      closeModal: window.closeModal,
-      navigate: window.navigate,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
     const outcomes = {};
     const calls = [];
     const fetchCalls = [];
+    const previousSupplementsRuntime = supplementsRuntime.configureSupplementsRuntimeDeps({
+      closeModal: () => document.getElementById('modal-overlay')?.classList.remove('show'),
+      navigate: route => calls.push(['navigate', route]),
+    });
 
     try {
       Element.prototype.scrollIntoView = function() {};
       localStorage.setItem('labcharts-ai-provider', 'ollama');
       localStorage.setItem('labcharts-ollama-model', 'llama3.2');
       window.getOllamaConfig = () => ({ url: 'http://localhost:11434', model: 'llama3.2', apiKey: '' });
-      window.closeModal = () => document.getElementById('modal-overlay')?.classList.remove('show');
-      window.navigate = route => calls.push(['navigate', route]);
       window.fetch = async (url, options = {}) => {
         const urlText = String(url);
         fetchCalls.push({
@@ -251,10 +252,7 @@ test('supplements browser coverage handles editor ingredients imports sync and A
       window.fetch = saved.fetch;
       if (saved.getOllamaConfig) window.getOllamaConfig = saved.getOllamaConfig;
       else delete window.getOllamaConfig;
-      if (saved.closeModal) window.closeModal = saved.closeModal;
-      else delete window.closeModal;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
+      supplementsRuntime.configureSupplementsRuntimeDeps(previousSupplementsRuntime);
       Element.prototype.scrollIntoView = saved.scrollIntoView;
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 28 &&
-    baseline.viewRuntimeBridgeLookups === 42);
+    baseline.viewRuntimeBridgeConsumers === 27 &&
+    baseline.viewRuntimeBridgeLookups === 40);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -133,6 +133,10 @@ assert('App shell injects Cycle view callbacks without bridge lookups',
   appShellHooksSrc.includes("import { configureCycleRuntimeDeps } from './cycle-runtime.js'")
     && appShellHooksSrc.includes('configureCycleRuntimeDeps({ closeModal, navigate });'));
 
+assert('App shell injects Supplements view callbacks without bridge lookups',
+  appShellHooksSrc.includes("import { configureSupplementsRuntimeDeps } from './supplements-runtime.js'")
+    && appShellHooksSrc.includes('configureSupplementsRuntimeDeps({ closeModal, navigate });'));
+
 assert('App shell injects sun defaults navigation without a view bridge lookup',
   appShellHooksSrc.includes('configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });'));
 

--- a/tests/test-supplement-impact.js
+++ b/tests/test-supplement-impact.js
@@ -142,6 +142,7 @@ const { computeSupplementImpact, computeAllImpacts, parseAmount, ingredientDaily
   console.log('%c 8. Source & UI Integration ', 'font-weight:bold;color:#f59e0b');
 
   const suppSrc = read('js/supplements.js');
+  const supplementsRuntimeSrc = read('js/supplements-runtime.js');
   const impactSrc = read('js/supplement-impact.js');
   const delegateSrc = read('js/supplement-action-delegates.js');
   assert('renderSupplementImpact exists', impactSrc.includes('function renderSupplementImpact'));
@@ -157,6 +158,27 @@ const { computeSupplementImpact, computeAllImpacts, parseAmount, ingredientDaily
     impactSrc.includes('data-supp-action="refresh-impact"'));
   assert('Supplement surface has no inline event attributes',
     !/\son[a-z]+\s*=/.test(suppSrc) && !/\son[a-z]+\s*=/.test(impactSrc));
+  assert('Supplements injects view callbacks without the view runtime bridge',
+    supplementsRuntimeSrc.includes('export function configureSupplementsRuntimeDeps')
+      && supplementsRuntimeSrc.includes('supplementsRuntimeDeps.closeModal?.()')
+      && supplementsRuntimeSrc.includes('supplementsRuntimeDeps.navigate?.(category)')
+      && suppSrc.includes("from './supplements-runtime.js'")
+      && !suppSrc.includes('views-runtime-bridge.js')
+      && !suppSrc.includes('getViewRuntimeFunction'));
+  const supplementsRuntime = await import('../js/supplements-runtime.js');
+  const runtimeCalls = [];
+  const previousSupplementsRuntime = supplementsRuntime.configureSupplementsRuntimeDeps({
+    closeModal: () => runtimeCalls.push(['close']),
+    navigate: category => runtimeCalls.push(['navigate', category]),
+  });
+  supplementsRuntime.closeSupplementsModalRuntime();
+  supplementsRuntime.navigateSupplementsViewRuntime('supplements');
+  supplementsRuntime.configureSupplementsRuntimeDeps({ closeModal: null, navigate: null });
+  supplementsRuntime.closeSupplementsModalRuntime();
+  supplementsRuntime.navigateSupplementsViewRuntime('ignored');
+  supplementsRuntime.configureSupplementsRuntimeDeps(previousSupplementsRuntime);
+  assert('Supplements runtime invokes injected callbacks and safely no-ops when cleared',
+    JSON.stringify(runtimeCalls) === JSON.stringify([['close'], ['navigate', 'supplements']]));
 
   // AI-driven display (health dots pattern)
   assert('Uses callClaudeAPI', impactSrc.includes('callClaudeAPI'));

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -447,6 +447,7 @@
     "js/supplement-impact.js",
     "js/supplement-warnings.js",
     "js/supplements.js",
+    "js/supplements-runtime.js",
     "js/touch-tooltip-runtime.js",
     "js/touch-tooltip.js"
   ]

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.263';
+self.APP_VERSION = '1.10.264';


### PR DESCRIPTION
## Summary

- add a small Supplements runtime boundary for `closeModal` and `navigate`
- wire both callbacks from the application shell and remove Supplements' window/view-bridge fallback path
- update Supplements browser coverage to configure and restore callbacks explicitly instead of publishing temporary window globals
- cache and type-check the new runtime module and bump `APP_VERSION` to `1.10.264`

## Window-burden progress

- removes 2 production view-runtime lookups
- removes Supplements as a complete `views-runtime-bridge` consumer
- ratchets bridge coupling from **28 consumer modules / 42 lookups** to **27 consumer modules / 40 lookups**
- raises the tracked cumulative production access reduction from **114** to **116**
- keeps direct window references, window assignments, and legacy assignments at **0**

## Verification

- `npm run quality` — 9 passed; bridge inventory 27 consumers / 40 lookups
- `node tests/test-supplement-impact.js` — 84 passed
- `node tests/test-shell-delegated-actions.js` — 76 passed
- `node tests/test-quality-guardrails.js` — 24 passed
- `node tests/verify-modules.js` — 126 passed
- `npx playwright test tests/playwright/supplements-browser-coverage.spec.js` — 1 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `git diff --check`