### PR TITLE
Inject Context Cards view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -183,7 +183,7 @@ configureChatMessageActionDeps({
   viewSavedSummary,
 });
 configureCompareCorrelationViews({ askAIAboutCorrelations });
-configureContextCardsRuntimeCallbacks({ onContextCardSaved });
+configureContextCardsRuntimeCallbacks({ closeModal, navigate, onContextCardSaved });
 configureMarkerDetailRuntime({ askAIAboutMarker });
 configureShellChatActionDeps({
   closeChatPanel,

--- a/js/context-cards-runtime.js
+++ b/js/context-cards-runtime.js
@@ -3,6 +3,8 @@
 
 /** @type {Record<string, Function | null>} */
 const contextCardsRuntimeCallbacks = {
+  closeModal: null,
+  navigate: null,
   onContextCardSaved: null,
   openContextModal: null,
   openInterpretiveLensEditor: null,
@@ -36,6 +38,15 @@ function callContextCardsRuntime(name, ...args) {
 
 export function openContextModalRuntime() {
   return callContextCardsRuntime('openContextModal');
+}
+
+export function closeContextCardModalRuntime() {
+  return callContextCardsRuntime('closeModal');
+}
+
+/** @param {string} category */
+export function navigateContextCardViewRuntime(category) {
+  return callContextCardsRuntime('navigate', category);
 }
 
 export function notifyContextCardSavedRuntime() {

--- a/js/context-cards.js
+++ b/js/context-cards.js
@@ -9,7 +9,9 @@ import { openModalOverlay } from './modal-lifecycle.js';
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { getRecommendationModuleFunction } from './recommendations-runtime.js';
 import {
+  closeContextCardModalRuntime,
   configureContextCardsRuntimeCallbacks,
+  navigateContextCardViewRuntime,
   notifyContextCardSavedRuntime,
 } from './context-cards-runtime.js';
 import {
@@ -116,8 +118,6 @@ import {
   clearInterpretiveLens,
   showDietContaminantsModal,
 } from './context-card-lifestyle-editors.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
-
 const contextCardActionDelegateRoots = new WeakSet();
 const CONTEXT_CARD_ACTION_ATTR = 'data-context-card-action';
 const CONTEXT_CARD_ACTION_SELECTOR = `[${CONTEXT_CARD_ACTION_ATTR}]`;
@@ -132,21 +132,11 @@ const contextCardEditorActions = /** @type {Record<string, () => void>} */ ({
   openLoveLifeEditor,
   openEnvironmentEditor,
 });
-const contextCardWindow = /** @type {Window & typeof globalThis & {
-  closeModal?: () => void,
-  navigate?: (category: string) => void,
-}} */ (typeof window !== 'undefined' ? window : {});
 function closeContextCardModal() {
-  const closeModal = typeof contextCardWindow.closeModal === 'function'
-    ? contextCardWindow.closeModal.bind(contextCardWindow)
-    : (typeof window !== 'undefined' ? getViewRuntimeFunction('closeModal') : null);
-  closeModal?.();
+  closeContextCardModalRuntime();
 }
 function navigateContextCardView(category) {
-  const navigate = typeof contextCardWindow.navigate === 'function'
-    ? contextCardWindow.navigate.bind(contextCardWindow)
-    : (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
-  navigate?.(category);
+  navigateContextCardViewRuntime(category);
 }
 const contextCardRuntimeDeps = {
   openEMFAssessmentEditor,

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 27,
-  "viewRuntimeBridgeLookups": 40,
+  "viewRuntimeBridgeConsumers": 26,
+  "viewRuntimeBridgeLookups": 38,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/context-cards-runtime.test.js
+++ b/tests/context-cards-runtime.test.js
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
 import {
+  closeContextCardModalRuntime,
   configureContextCardsRuntimeCallbacks,
+  navigateContextCardViewRuntime,
   openContextModalRuntime,
   openInterpretiveLensEditorRuntime,
   recordContextCardChangeRuntime,
@@ -11,6 +14,8 @@ let previousCallbacks;
 
 beforeEach(() => {
   previousCallbacks = configureContextCardsRuntimeCallbacks({
+    closeModal: null,
+    navigate: null,
     openContextModal: null,
     openInterpretiveLensEditor: null,
     recordChange: null,
@@ -26,6 +31,8 @@ afterEach(() => {
 describe('context-card runtime callbacks', () => {
   it('routes context, lens, history, and DNA actions explicitly', () => {
     const callbacks = {
+      closeModal: vi.fn(),
+      navigate: vi.fn(),
       openContextModal: vi.fn(),
       openInterpretiveLensEditor: vi.fn(),
       recordChange: vi.fn(),
@@ -33,10 +40,14 @@ describe('context-card runtime callbacks', () => {
     };
     configureContextCardsRuntimeCallbacks(callbacks);
 
+    expect(closeContextCardModalRuntime()).toBe(true);
+    expect(navigateContextCardViewRuntime('body')).toBe(true);
     expect(openContextModalRuntime()).toBe(true);
     expect(openInterpretiveLensEditorRuntime()).toBe(true);
     expect(recordContextCardChangeRuntime('menstrualCycle')).toBe(true);
     expect(triggerContextCardDNAFilePickerRuntime()).toBe(true);
+    expect(callbacks.closeModal).toHaveBeenCalledOnce();
+    expect(callbacks.navigate).toHaveBeenCalledWith('body');
     expect(callbacks.openContextModal).toHaveBeenCalledOnce();
     expect(callbacks.openInterpretiveLensEditor).toHaveBeenCalledOnce();
     expect(callbacks.recordChange).toHaveBeenCalledWith('menstrualCycle');
@@ -44,10 +55,21 @@ describe('context-card runtime callbacks', () => {
   });
 
   it('fails safely when callbacks are missing or throw', () => {
+    expect(closeContextCardModalRuntime()).toBe(false);
+    expect(navigateContextCardViewRuntime('dashboard')).toBe(false);
     expect(openContextModalRuntime()).toBe(false);
     configureContextCardsRuntimeCallbacks({
       openContextModal: () => { throw new Error('boom'); },
     });
     expect(openContextModalRuntime()).toBe(false);
+  });
+
+  it('keeps core view callbacks off the legacy bridge', () => {
+    const source = fs.readFileSync(new URL('../js/context-cards.js', import.meta.url), 'utf8');
+    expect(source).toContain("from './context-cards-runtime.js'");
+    expect(source).toContain('closeContextCardModalRuntime()');
+    expect(source).toContain('navigateContextCardViewRuntime(category)');
+    expect(source).not.toContain('views-runtime-bridge.js');
+    expect(source).not.toContain('getViewRuntimeFunction');
   });
 });

--- a/tests/playwright/context-cards-browser-coverage.spec.js
+++ b/tests/playwright/context-cards-browser-coverage.spec.js
@@ -25,8 +25,6 @@ test('context cards browser coverage exercises notes save dots and tips', async 
     const calls = [];
     const saved = {
       importedData: clone(state.importedData),
-      closeModal: window.closeModal,
-      navigate: window.navigate,
       aiProvider: localStorage.getItem('labcharts-ai-provider'),
       aiPaused: localStorage.getItem('labcharts-ai-paused'),
       detailsOpen: sessionStorage.getItem('welcome-details-open'),
@@ -111,9 +109,9 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       injectedNav.className = 'nav-item active';
       injectedNav.dataset.category = 'body';
       document.body.appendChild(injectedNav);
-      window.closeModal = () => calls.push(['close']);
-      window.navigate = category => calls.push(['navigate', category]);
       previousContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
+        closeModal: () => calls.push(['close']),
+        navigate: category => calls.push(['navigate', category]),
         onContextCardSaved: () => calls.push(['saved']),
       });
       state.importedData.stress = { level: 'moderate', sources: ['work'], management: ['walks'], note: '' };
@@ -155,10 +153,6 @@ test('context cards browser coverage exercises notes save dots and tips', async 
       ].every(name => !(name in window));
     } finally {
       state.importedData = saved.importedData;
-      if (saved.closeModal) window.closeModal = saved.closeModal;
-      else delete window.closeModal;
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
       if (previousContextCardsRuntime) {
         contextCardsRuntime.configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
       }

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 27 &&
-    baseline.viewRuntimeBridgeLookups === 40);
+    baseline.viewRuntimeBridgeConsumers === 26 &&
+    baseline.viewRuntimeBridgeLookups === 38);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -98,6 +98,9 @@ assert('App shell wires Context hub status refresh without a window lookup',
     && appShellHooksSrc.includes('updateChatContextStatus')
     && appShellHooksSrc.includes('configureDashboardAIContextStatus(updateChatContextStatus);'));
 
+assert('App shell injects core Context Cards view callbacks without bridge lookups',
+  appShellHooksSrc.includes('configureContextCardsRuntimeCallbacks({ closeModal, navigate, onContextCardSaved });'));
+
 assert('App shell wires Chat UI refreshes without window globals',
   appShellHooksSrc.includes("import { configureChatRuntimeCallbacks } from './chat-runtime.js'")
     && appShellHooksSrc.includes('configureChatRuntimeCallbacks({')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.264';
+self.APP_VERSION = '1.10.265';


### PR DESCRIPTION
## Summary

- add `closeModal` and `navigate` to the existing Context Cards runtime callback registry
- route the core Context Cards save/refresh lifecycle through runtime helpers and remove its window/view-bridge fallback path
- wire both callbacks from the application shell alongside `onContextCardSaved`
- update runtime, source-contract, shell, and browser coverage and bump `APP_VERSION` to `1.10.265`

## Window-burden progress

- removes 2 production view-runtime lookups
- removes core Context Cards as a complete `views-runtime-bridge` consumer
- ratchets bridge coupling from **27 consumer modules / 40 lookups** to **26 consumer modules / 38 lookups**
- raises the tracked cumulative production access reduction from **116** to **118**
- keeps direct window references, window assignments, and legacy assignments at **0**

## Verification

- `npm run quality` — 9 passed; bridge inventory 26 consumers / 38 lookups
- `npx vitest run tests/context-cards-runtime.test.js` — 3 passed
- `node tests/test-context-card-lifestyle-runtime.js` — 5 passed
- `node tests/test-shell-delegated-actions.js` — 77 passed
- `node tests/test-quality-guardrails.js` — 24 passed
- `node tests/verify-modules.js` — 126 passed
- `npx playwright test tests/playwright/context-cards-browser-coverage.spec.js` — 1 passed
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `git diff --check`