### PR TITLE
Inject shell navigation dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -83,7 +83,7 @@ import { _openChannelOnLightPage } from './light-channel-view.js';
 import { configureLightDevicesRuntimeDeps } from './light-devices-runtime.js';
 import { closeModal } from './marker-detail-modal.js';
 import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
-import { buildSidebar, closeMobileSidebar, configureNavActions, renderProfileButton } from './nav.js';
+import { buildSidebar, closeMobileSidebar, configureNavActions, renderProfileButton, toggleMobileSidebar } from './nav.js';
 import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
@@ -103,6 +103,7 @@ import {
   configureShellChatActionDeps,
   configureShellChatImageDeps,
   configureShellChatThreadDeps,
+  configureShellNavDeps,
 } from './shell-actions.js';
 import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
@@ -200,6 +201,7 @@ configureShellChatActionDeps({
 });
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
+configureShellNavDeps({ closeMobileSidebar, toggleMobileSidebar });
 configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButtonVisibility });
 configureOnboardingViewRuntimeDeps({ buildSidebar, createNewThread, navigate, openChatPanel, toggleChatPanel });
 configureTourRuntimeDeps({ openChatPanel });

--- a/js/shell-actions.js
+++ b/js/shell-actions.js
@@ -4,11 +4,14 @@
 import { handleImportStatusClick, isImportRunning } from './pdf-import-progress.js';
 import { openFeedbackModal } from './feedback.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let shellDelegatesInstalled = false;
 const shellImportDeps = { handleImportStatusClick, isImportRunning };
 const shellFeedbackDeps = { openFeedbackModal };
+const shellNavDeps = {
+  closeMobileSidebar: () => {},
+  toggleMobileSidebar: () => {},
+};
 const shellChatImageDeps = { toggleHDMode: () => {} };
 const shellChatActionDeps = {
   closeChatPanel: () => {},
@@ -39,6 +42,14 @@ export function configureShellImportDeps(deps = {}) {
 export function configureShellFeedbackDeps(deps = {}) {
   const previous = { ...shellFeedbackDeps };
   if (typeof deps.openFeedbackModal === 'function') shellFeedbackDeps.openFeedbackModal = deps.openFeedbackModal;
+  return previous;
+}
+
+/** @param {Partial<typeof shellNavDeps>} [deps] */
+export function configureShellNavDeps(deps = {}) {
+  const previous = { ...shellNavDeps };
+  if (typeof deps.closeMobileSidebar === 'function') shellNavDeps.closeMobileSidebar = deps.closeMobileSidebar;
+  if (typeof deps.toggleMobileSidebar === 'function') shellNavDeps.toggleMobileSidebar = deps.toggleMobileSidebar;
   return previous;
 }
 
@@ -89,10 +100,10 @@ function clickFileInput(id) {
 
 function runShellAction(action) {
   if (action === 'toggle-mobile-sidebar') {
-    getViewRuntimeFunction('toggleMobileSidebar')?.();
+    shellNavDeps.toggleMobileSidebar();
     return true;
   } else if (action === 'close-mobile-sidebar') {
-    getViewRuntimeFunction('closeMobileSidebar')?.();
+    shellNavDeps.closeMobileSidebar();
     return true;
   } else if (action === 'trigger-import') {
     if (shellImportDeps.isImportRunning()) {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 26,
-  "viewRuntimeBridgeLookups": 38,
+  "viewRuntimeBridgeConsumers": 25,
+  "viewRuntimeBridgeLookups": 36,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/shell-actions-browser-coverage.spec.js
+++ b/tests/playwright/shell-actions-browser-coverage.spec.js
@@ -19,7 +19,6 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
   const results = await page.evaluate(async ({ shellActionsUrl }) => {
     const shellActions = await import(shellActionsUrl);
     const settingsBridge = await import('/js/settings-runtime-bridge.js');
-    const viewRuntime = await import('/js/views-runtime-bridge.js');
     const outcomes = {};
     const calls = [];
     let importRunning = false;
@@ -51,7 +50,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
       filterThreadList: value => calls.push(['filterThreadList', value]),
       toggleThreadRail: () => calls.push(['toggleThreadRail']),
     });
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    const previousShellNavDeps = shellActions.configureShellNavDeps({
       toggleMobileSidebar: () => calls.push(['toggleMobileSidebar']),
       closeMobileSidebar: () => calls.push(['closeMobileSidebar']),
     });
@@ -204,11 +203,7 @@ test('shell action delegates cover shell chat file input and keyboard actions', 
         && personalitySpace.defaultPrevented === true
         && personalityEscape.defaultPrevented === false;
     } finally {
-      viewRuntime.configureViewRuntime({
-        toggleMobileSidebar: null,
-        closeMobileSidebar: null,
-        ...previousViewRuntime,
-      });
+      shellActions.configureShellNavDeps(previousShellNavDeps);
       shellActions.configureShellImportDeps(previousShellImportDeps);
       shellActions.configureShellFeedbackDeps(previousShellFeedbackDeps);
       shellActions.configureShellChatActionDeps(previousShellChatActionDeps);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 26 &&
-    baseline.viewRuntimeBridgeLookups === 38);
+    baseline.viewRuntimeBridgeConsumers === 25 &&
+    baseline.viewRuntimeBridgeLookups === 36);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -64,6 +64,12 @@ assert('Chat HD shell action uses its module dependency instead of a window look
   shellSrc.includes('shellChatImageDeps.toggleHDMode()')
     && !shellSrc.includes("callShellRuntime('toggleHDMode')"));
 
+assert('Mobile sidebar shell actions use injected nav dependencies',
+  shellSrc.includes('shellNavDeps.toggleMobileSidebar()')
+    && shellSrc.includes('shellNavDeps.closeMobileSidebar()')
+    && !shellSrc.includes("from './views-runtime-bridge.js'")
+    && appShellHooksSrc.includes('configureShellNavDeps({ closeMobileSidebar, toggleMobileSidebar });'));
+
 assert('App shell wires module-only chat image consumers',
   appShellHooksSrc.includes("from './chat-images.js'")
     && appShellHooksSrc.includes('configureChatMessageActionDeps({')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.265';
+self.APP_VERSION = '1.10.266';


### PR DESCRIPTION
## Summary
- inject mobile sidebar callbacks into `shell-actions.js` from the app shell
- remove the shell action module's remaining view-runtime bridge dependency
- ratchet bridge coupling from 26 consumers / 38 lookups to 25 / 36
- bump the app cache version to 1.10.266

## Tests
- `./run-tests.sh` (399 Vitest tests, 352 Playwright tests, 472 theme/responsive checks)
- `node scripts/quality-guardrails.mjs`
- `node tests/test-shell-delegated-actions.js`
- `node tests/test-quality-guardrails.js`
- `node tests/verify-modules.js`
- `npx playwright test tests/playwright/shell-actions-browser-coverage.spec.js`
- `npx tsc --noEmit -p tsconfig.json`
- `npx tsc --noEmit -p tsconfig.checkjs.json`