### PR TITLE
Inject Cycle import view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -137,7 +137,7 @@ configureSettingsRuntime({
 configureNavActions({ openClientList });
 configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
-configureCycleRuntimeDeps({ closeModal, navigate });
+configureCycleRuntimeDeps({ closeModal, navigate, renderProfileButton });
 configureDnaRuntimeDeps({ buildSidebar, navigate });
 configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });
 configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });

--- a/js/cycle-import.js
+++ b/js/cycle-import.js
@@ -9,7 +9,7 @@ import { closeModalOverlay, openModalOverlay } from './modal-lifecycle.js';
 import { endTour } from './tour.js';
 import { escapeAttr, escapeHTML, showConfirmDialog, showNotification } from './utils.js';
 import { recordContextCardChangeRuntime } from './context-cards-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { navigateCycleViewRuntime, renderCycleProfileButtonRuntime } from './cycle-runtime.js';
 import {
   buildCycleCoverage,
   normalizeCyclePeriods,
@@ -59,24 +59,15 @@ const SOURCE_LABELS = {
   tempdrop: 'Tempdrop',
   manual: 'Manual',
 };
-const appWindow = /** @type {Window & typeof globalThis & {
-  navigate?: (category: string) => void,
-  closeModal?: () => void,
-}} */ (typeof window !== 'undefined' ? window : {});
-
 let pendingCycleImport = null;
 let cycleImportDelegatesInstalled = false;
 
 function navigateCycleImportView(category) {
-  const navigate = typeof appWindow.navigate === 'function'
-    ? appWindow.navigate.bind(appWindow)
-    : (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
-  navigate?.(category);
-  return typeof navigate === 'function';
+  return navigateCycleViewRuntime(category);
 }
 
 function renderCycleProfileButton() {
-  getViewRuntimeFunction('renderProfileButton')?.();
+  renderCycleProfileButtonRuntime();
 }
 
 async function openCycleEditorFromImport() {

--- a/js/cycle-runtime.js
+++ b/js/cycle-runtime.js
@@ -1,14 +1,15 @@
 // @ts-check
 // cycle-runtime.js - Explicit application callbacks for Cycle views.
 
-/** @type {{ closeModal: (() => void) | null, navigate: ((category: string) => void) | null }} */
+/** @type {{ closeModal: (() => void) | null, navigate: ((category: string) => void) | null, renderProfileButton: (() => void) | null }} */
 const cycleRuntimeDeps = {
   closeModal: null,
   navigate: null,
+  renderProfileButton: null,
 };
 
 /**
- * @param {{ closeModal?: (() => void) | null, navigate?: ((category: string) => void) | null }} deps
+ * @param {{ closeModal?: (() => void) | null, navigate?: ((category: string) => void) | null, renderProfileButton?: (() => void) | null }} deps
  */
 export function configureCycleRuntimeDeps(deps = {}) {
   const previous = { ...cycleRuntimeDeps };
@@ -17,6 +18,9 @@ export function configureCycleRuntimeDeps(deps = {}) {
   }
   if (Object.hasOwn(deps, 'navigate')) {
     cycleRuntimeDeps.navigate = typeof deps.navigate === 'function' ? deps.navigate : null;
+  }
+  if (Object.hasOwn(deps, 'renderProfileButton')) {
+    cycleRuntimeDeps.renderProfileButton = typeof deps.renderProfileButton === 'function' ? deps.renderProfileButton : null;
   }
   return previous;
 }
@@ -27,5 +31,11 @@ export function closeCycleModalRuntime() {
 
 /** @param {string} category */
 export function navigateCycleViewRuntime(category) {
-  cycleRuntimeDeps.navigate?.(category);
+  if (!cycleRuntimeDeps.navigate) return false;
+  cycleRuntimeDeps.navigate(category);
+  return true;
+}
+
+export function renderCycleProfileButtonRuntime() {
+  cycleRuntimeDeps.renderProfileButton?.();
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 25,
-  "viewRuntimeBridgeLookups": 36,
+  "viewRuntimeBridgeConsumers": 24,
+  "viewRuntimeBridgeLookups": 34,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-cycle-improvements.js
+++ b/tests/test-cycle-improvements.js
@@ -278,15 +278,20 @@ const { phaseBandPlugin } = await import('../js/charts.js');
     const previousCycleRuntime = cycleRuntime.configureCycleRuntimeDeps({
       closeModal: () => runtimeCalls.push(['close']),
       navigate: category => runtimeCalls.push(['navigate', category]),
+      renderProfileButton: () => runtimeCalls.push(['render-profile-button']),
     });
     cycleRuntime.closeCycleModalRuntime();
-    cycleRuntime.navigateCycleViewRuntime('cycle');
-    cycleRuntime.configureCycleRuntimeDeps({ closeModal: null, navigate: null });
+    const didNavigate = cycleRuntime.navigateCycleViewRuntime('cycle');
+    cycleRuntime.renderCycleProfileButtonRuntime();
+    cycleRuntime.configureCycleRuntimeDeps({ closeModal: null, navigate: null, renderProfileButton: null });
     cycleRuntime.closeCycleModalRuntime();
-    cycleRuntime.navigateCycleViewRuntime('ignored');
+    const didNavigateWithoutCallback = cycleRuntime.navigateCycleViewRuntime('ignored');
+    cycleRuntime.renderCycleProfileButtonRuntime();
     cycleRuntime.configureCycleRuntimeDeps(previousCycleRuntime);
     assert('cycle runtime invokes injected callbacks and safely no-ops when cleared',
-      JSON.stringify(runtimeCalls) === JSON.stringify([['close'], ['navigate', 'cycle']]));
+      didNavigate === true
+        && didNavigateWithoutCallback === false
+        && JSON.stringify(runtimeCalls) === JSON.stringify([['close'], ['navigate', 'cycle'], ['render-profile-button']]));
 
     // charts.js
     const chartsSrc = read('js/charts.js');
@@ -312,6 +317,7 @@ const { phaseBandPlugin } = await import('../js/charts.js');
 
     // cycle.js imports
     const cycleSrc = read('js/cycle.js');
+    const cycleImportSrc = read('js/cycle-import.js');
     assert('cycle.js imports PERIOD_SYMPTOMS', cycleSrc.includes("import") && cycleSrc.includes('PERIOD_SYMPTOMS'));
     assert('cycle.js imports linearRegression', cycleSrc.includes('linearRegression'));
     assert('cycle.js exports detectPerimenopausePattern', cycleSrc.includes('export function detectPerimenopausePattern'));
@@ -320,8 +326,12 @@ const { phaseBandPlugin } = await import('../js/charts.js');
     assert('cycle.js injects view callbacks without the view runtime bridge',
       cycleRuntimeSrc.includes('export function configureCycleRuntimeDeps')
         && cycleRuntimeSrc.includes('cycleRuntimeDeps.closeModal?.()')
-        && cycleRuntimeSrc.includes('cycleRuntimeDeps.navigate?.(category)')
+        && cycleRuntimeSrc.includes('cycleRuntimeDeps.navigate(category)')
+        && cycleRuntimeSrc.includes('cycleRuntimeDeps.renderProfileButton?.()')
         && cycleSrc.includes("from './cycle-runtime.js'")
+        && cycleImportSrc.includes("from './cycle-runtime.js'")
+        && !cycleImportSrc.includes('views-runtime-bridge.js')
+        && !cycleImportSrc.includes('appWindow')
         && !cycleSrc.includes('views-runtime-bridge.js')
         && !cycleSrc.includes('getViewRuntimeFunction'));
 

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 25 &&
-    baseline.viewRuntimeBridgeLookups === 36);
+    baseline.viewRuntimeBridgeConsumers === 24 &&
+    baseline.viewRuntimeBridgeLookups === 34);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -140,7 +140,7 @@ assert('App shell injects category customization view callbacks',
 
 assert('App shell injects Cycle view callbacks without bridge lookups',
   appShellHooksSrc.includes("import { configureCycleRuntimeDeps } from './cycle-runtime.js'")
-    && appShellHooksSrc.includes('configureCycleRuntimeDeps({ closeModal, navigate });'));
+    && appShellHooksSrc.includes('configureCycleRuntimeDeps({ closeModal, navigate, renderProfileButton });'));
 
 assert('App shell injects Supplements view callbacks without bridge lookups',
   appShellHooksSrc.includes("import { configureSupplementsRuntimeDeps } from './supplements-runtime.js'")

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.266';
+self.APP_VERSION = '1.10.267';


### PR DESCRIPTION
## Summary
- route Cycle import navigation and profile-button refreshes through the existing Cycle runtime
- remove the remaining `window.navigate` and view-runtime bridge fallbacks from `cycle-import.js`
- expose navigation availability from the runtime so the existing delayed editor reopen behavior is preserved
- ratchet bridge coupling from 25 consumers / 36 lookups to 24 / 34
- bump the app cache version to 1.10.267

## Tests
- `node scripts/quality-guardrails.mjs`
- `node tests/test-cycle-improvements.js`
- `node tests/test-shell-delegated-actions.js`
- `node tests/test-quality-guardrails.js`
- `node tests/verify-modules.js`
- `npx vitest run tests/cycle-import-phase1.test.js`
- `npx playwright test tests/playwright/cycle-import-browser-coverage.spec.js`
- `npx tsc --noEmit -p tsconfig.json`
- `npx tsc --noEmit -p tsconfig.checkjs.json`