### PR TITLE
Inject Settings navigation

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -127,6 +127,7 @@ configureSettingsRuntime({
   exportAllDataJSON,
   exportClientJSON,
   getActiveProfileId,
+  navigate,
   openFeedbackModal,
   openProfileShareModal,
   refreshMobileDashboardActiveTab,

--- a/js/settings.js
+++ b/js/settings.js
@@ -41,7 +41,6 @@ import { loadPdfImport } from './import-loader.js';
 import { startGuidedTour } from './tour.js';
 import { getActiveProfileId } from './profile.js';
 import { openChangelog } from './changelog.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { updateChatNudgeRuntime } from './chat-runtime.js';
 import {
   confirmDisablePIIReview,
@@ -63,6 +62,7 @@ const settingsWindow = /** @type {SettingsWindow} */ (window);
  *   exportAllDataJSON: () => Promise<void> | void,
  *   exportClientJSON: (profileId?: string | null) => Promise<void> | void,
  *   getActiveProfileId: () => string | null,
+ *   navigate: (view: string) => void,
  *   openFeedbackModal: () => void,
  *   openProfileShareModal: (profileId?: string) => void,
  *   clearDashboardWidgets: () => void,
@@ -78,6 +78,7 @@ const settingsRuntime = {
   exportAllDataJSON: () => {},
   exportClientJSON: () => {},
   getActiveProfileId,
+  navigate: () => {},
   openFeedbackModal: () => {},
   openProfileShareModal: () => {},
   clearDashboardWidgets: () => {},
@@ -309,8 +310,7 @@ function applySettingsToggle(actionEl) {
   const checked = actionEl instanceof HTMLInputElement && actionEl.checked;
   if (action === 'set-product-recs') {
     setProductRecsEnabled(checked);
-    const navigate = settingsWindow.navigate || getViewRuntimeFunction('navigate');
-    navigate?.call(settingsWindow, 'dashboard');
+    settingsRuntime.navigate('dashboard');
     return true;
   }
   if (action === 'set-debug-mode') {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 24,
-  "viewRuntimeBridgeLookups": 34,
+  "viewRuntimeBridgeConsumers": 23,
+  "viewRuntimeBridgeLookups": 33,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/settings-toggles.spec.js
+++ b/tests/playwright/settings-toggles.spec.js
@@ -33,6 +33,9 @@ test('Settings display toggles persist through delegated slider actions', async 
     localStorage.removeItem('labcharts-show-product-recs');
     localStorage.removeItem('labcharts-debug');
     (await import('/js/theme.js')).setTheme('cyberterm');
+    settings.configureSettingsRuntime({
+      navigate: view => { document.body.dataset.settingsNavigate = view; },
+    });
     settings.openSettingsModal('display');
   });
 
@@ -44,6 +47,7 @@ test('Settings display toggles persist through delegated slider actions', async 
 
   await expect.poll(async () => page.evaluate(() => localStorage.getItem('labcharts-show-product-recs'))).toBe('false');
   await expect.poll(async () => page.evaluate(() => localStorage.getItem('labcharts-debug'))).toBe('true');
+  await expect(page.locator('body')).toHaveAttribute('data-settings-navigate', 'dashboard');
 });
 
 test('Settings data sync toggle opens and cancels setup modal', async ({ page }) => {

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 24 &&
-    baseline.viewRuntimeBridgeLookups === 34);
+    baseline.viewRuntimeBridgeConsumers === 23 &&
+    baseline.viewRuntimeBridgeLookups === 33);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-settings-delegated-actions.js
+++ b/tests/test-settings-delegated-actions.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
+const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
 const src = fs.readFileSync(path.join(root, 'js/settings.js'), 'utf8');
 const privacySrc = fs.readFileSync(path.join(root, 'js/settings-privacy.js'), 'utf8');
 const settingsDataSrc = fs.readFileSync(path.join(root, 'js/settings-data.js'), 'utf8');
@@ -135,6 +136,10 @@ assert('Delegated tweaks handler closes on backdrop click',
 assert('Tweaks feedback action uses configured module runtime',
   src.includes('settingsRuntime.openFeedbackModal()')
     && !src.includes('settingsWindow.openFeedbackModal'));
+assert('Product recommendations toggle uses configured navigation',
+  src.includes("settingsRuntime.navigate('dashboard')")
+    && !src.includes("from './views-runtime-bridge.js'")
+    && appShellHooksSrc.includes('navigate,\n  openFeedbackModal,'));
 assert('Settings version label uses the shared runtime adapter',
   src.includes("import { getAppVersionRuntime } from './utils-runtime.js';")
     && src.includes('escapeHTML(getAppVersionRuntime())')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.267';
+self.APP_VERSION = '1.10.268';


### PR DESCRIPTION
## Summary
- inject Dashboard navigation through the existing Settings runtime
- remove the product-recommendations toggle's `window.navigate` and view-runtime bridge fallback
- add browser coverage for the explicit navigation callback
- ratchet bridge coupling from 24 consumers / 34 lookups to 23 / 33
- bump the app cache version to 1.10.268

## Tests
- `node scripts/quality-guardrails.mjs`
- `node tests/test-settings-delegated-actions.js`
- `node tests/test-shell-delegated-actions.js`
- `node tests/test-quality-guardrails.js`
- `node tests/verify-modules.js`
- `npx playwright test tests/playwright/settings-toggles.spec.js`
- `npx tsc --noEmit -p tsconfig.json`
- `npx tsc --noEmit -p tsconfig.checkjs.json`