### PR TITLE
Inject Startup view dependencies

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -85,10 +85,11 @@ import { closeModal } from './marker-detail-modal.js';
 import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
 import { buildSidebar, closeMobileSidebar, configureNavActions, renderProfileButton, toggleMobileSidebar } from './nav.js';
 import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
-import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime } from './settings.js';
+import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime, openSettingsModal } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
 import {
   clearDashboardWidgets,
+  getInitialView,
   navigate,
   refreshMobileDashboardActiveTab,
   resetDashboardWidgets,
@@ -203,7 +204,14 @@ configureShellChatActionDeps({
 configureShellChatImageDeps({ toggleHDMode });
 configureShellChatThreadDeps({ createNewThread, filterThreadList, toggleThreadRail });
 configureShellNavDeps({ closeMobileSidebar, toggleMobileSidebar });
-configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButtonVisibility });
+configureStartupUIDeps({
+  getInitialView,
+  initChatImageHandlers,
+  navigate,
+  openChatPanel,
+  openSettingsModal,
+  updateAttachButtonVisibility,
+});
 configureOnboardingViewRuntimeDeps({ buildSidebar, createNewThread, navigate, openChatPanel, toggleChatPanel });
 configureTourRuntimeDeps({ openChatPanel });
 configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });

--- a/js/startup-ui.js
+++ b/js/startup-ui.js
@@ -13,19 +13,23 @@ import { maybeShowLegalConsentGate } from './legal-consent.js';
 import { initSync, primeSyncState, renderSyncIndicator } from './sync.js';
 import { maybeShowAnalyticsConsent } from './utils.js';
 import { getAppVersionRuntime } from './utils-runtime.js';
-import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { updateChatNudgeRuntime } from './chat-runtime.js';
 
 const startupUIDeps = {
+  getInitialView: /** @type {() => string} */ (() => 'dashboard'),
   initChatImageHandlers: () => {},
   maybeShowAnalyticsConsent,
+  navigate: /** @type {(view: string) => void} */ ((_view) => {}),
   openChatPanel: () => {},
+  openSettingsModal: /** @type {(section?: string) => void} */ ((_section) => {}),
   updateAttachButtonVisibility: () => {},
 };
 
 export function configureStartupUIDeps(deps = {}) {
   const previous = { ...startupUIDeps };
+  if (typeof deps.getInitialView === 'function') {
+    startupUIDeps.getInitialView = deps.getInitialView;
+  }
   if ('maybeShowAnalyticsConsent' in deps) {
     startupUIDeps.maybeShowAnalyticsConsent = typeof deps.maybeShowAnalyticsConsent === 'function'
       ? /** @type {typeof maybeShowAnalyticsConsent} */ (deps.maybeShowAnalyticsConsent)
@@ -36,6 +40,12 @@ export function configureStartupUIDeps(deps = {}) {
   }
   if (typeof deps.openChatPanel === 'function') {
     startupUIDeps.openChatPanel = deps.openChatPanel;
+  }
+  if (typeof deps.navigate === 'function') {
+    startupUIDeps.navigate = deps.navigate;
+  }
+  if (typeof deps.openSettingsModal === 'function') {
+    startupUIDeps.openSettingsModal = deps.openSettingsModal;
   }
   if (typeof deps.updateAttachButtonVisibility === 'function') {
     startupUIDeps.updateAttachButtonVisibility = deps.updateAttachButtonVisibility;
@@ -51,22 +61,6 @@ function getStartupRuntimeValue(name) {
   return startupRuntime()[name];
 }
 
-function callStartupRuntime(name, ...args) {
-  const runtime = startupRuntime();
-  const fn = getSettingsModuleFunction(name) || runtime[name] || getViewRuntimeFunction(name);
-  if (typeof fn !== 'function') return undefined;
-  return fn.apply(runtime, args);
-}
-
-function requireStartupRuntime(name, ...args) {
-  const runtime = startupRuntime();
-  const fn = getSettingsModuleFunction(name) || runtime[name] || getViewRuntimeFunction(name);
-  if (typeof fn !== 'function') {
-    throw new TypeError(`Startup runtime function ${name} is not available`);
-  }
-  return fn.apply(runtime, args);
-}
-
 export function renderStartupUI() {
   // Prime sync state for UI, but let Evolu boot after first paint. Its
   // worker/OPFS startup is expensive and should not block dashboard LCP.
@@ -76,7 +70,7 @@ export function renderStartupUI() {
   populateFooterVersion();
   buildSidebar();
   renderSyncIndicator();
-  requireStartupRuntime('navigate', callStartupRuntime('getInitialView') || 'dashboard');
+  startupUIDeps.navigate(startupUIDeps.getInitialView() || 'dashboard');
   scheduleDeferredSyncAndCatalogWarmup();
   const legalGateShown = scheduleStartupNudges();
   if (legalGateShown) {
@@ -141,7 +135,7 @@ function scheduleStartupNudges() {
 function openDeferredStartupDestinations() {
   const openSettingsAfterInit = getStartupRuntimeValue('_openSettingsAfterInit');
   if (openSettingsAfterInit) {
-    requireStartupRuntime('openSettingsModal', openSettingsAfterInit);
+    startupUIDeps.openSettingsModal(openSettingsAfterInit);
     delete startupRuntime()._openSettingsAfterInit;
   }
   if (getStartupRuntimeValue('_openChatAfterInit')) {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 23,
-  "viewRuntimeBridgeLookups": 33,
+  "viewRuntimeBridgeConsumers": 22,
+  "viewRuntimeBridgeLookups": 31,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/startup-helpers-browser-coverage.spec.js
+++ b/tests/playwright/startup-helpers-browser-coverage.spec.js
@@ -386,7 +386,6 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
   });
 
   const outcomes = await page.evaluate(async ({ startupUiUrl }) => {
-    const settingsBridge = await import('/js/settings-runtime-bridge.js');
     const chatRuntime = await import('/js/chat-runtime.js');
     const originalSetTimeout = window.setTimeout;
     const originalRequestAnimationFrame = window.requestAnimationFrame;
@@ -396,13 +395,6 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
       <div id="passphrase-overlay" style="display: none;"></div>
     `;
     window.APP_VERSION = 'startup-ui-test-version';
-    window.getInitialView = () => 'light';
-    window.navigate = view => {
-      window.__startupUICalls.push(['navigate', view]);
-    };
-    const previousSettingsBridge = settingsBridge.configureSettingsModuleBridge({
-      openSettingsModal: section => window.__startupUICalls.push(['openSettingsModal', section]),
-    });
     const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
       updateChatNudge: () => window.__startupUICalls.push('updateChatNudge'),
     });
@@ -430,14 +422,21 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
     try {
       const startupUi = await import(startupUiUrl);
       startupUi.configureStartupUIDeps({
+        getInitialView: () => 'light',
         initChatImageHandlers: () => {
           window.__startupUICalls.push('initChatImageHandlers');
         },
         maybeShowAnalyticsConsent: () => {
           window.__startupUICalls.push('maybeShowAnalyticsConsent');
         },
+        navigate: view => {
+          window.__startupUICalls.push(['navigate', view]);
+        },
         openChatPanel: () => {
           window.__startupUICalls.push('openChatPanel');
+        },
+        openSettingsModal: section => {
+          window.__startupUICalls.push(['openSettingsModal', section]);
         },
         updateAttachButtonVisibility: () => {
           window.__startupUICalls.push('updateAttachButtonVisibility');
@@ -481,7 +480,6 @@ test('startup UI renders chrome and schedules deferred startup work', async ({ p
           && window.__startupUICalls.includes('bindImportFileInput'),
       };
     } finally {
-      settingsBridge.configureSettingsModuleBridge(previousSettingsBridge);
       chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       window.setTimeout = originalSetTimeout;
       window.requestAnimationFrame = originalRequestAnimationFrame;

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 23 &&
-    baseline.viewRuntimeBridgeLookups === 33);
+    baseline.viewRuntimeBridgeConsumers === 22 &&
+    baseline.viewRuntimeBridgeLookups === 31);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -76,7 +76,7 @@ assert('App shell wires module-only chat image consumers',
     && appShellHooksSrc.includes('openImageLightbox,')
     && appShellHooksSrc.includes('removeImageAttachment,')
     && appShellHooksSrc.includes('configureShellChatImageDeps({ toggleHDMode });')
-    && appShellHooksSrc.includes('configureStartupUIDeps({ initChatImageHandlers, openChatPanel, updateAttachButtonVisibility });'));
+    && appShellHooksSrc.includes('configureStartupUIDeps({\n  getInitialView,\n  initChatImageHandlers,\n  navigate,\n  openChatPanel,\n  openSettingsModal,\n  updateAttachButtonVisibility,\n});'));
 
 assert('App shell wires module-only chat message actions',
   ['closeSummaryModal', 'continueDiscussion', 'copySummary', 'deleteSavedSummary',

--- a/tests/test-v1-6-shipped.js
+++ b/tests/test-v1-6-shipped.js
@@ -549,7 +549,8 @@ const _origProfileSex = window._labState ? window._labState.profileSex : null;
       /export function getInitialView\(\)/.test(viewsSrc)
       && /return getRouterInitialView\(\)/.test(viewsSrc));
     assert('startup-ui.js: boot navigates to stored route instead of hard Dashboard',
-      /requireStartupRuntime\('navigate',\s*callStartupRuntime\('getInitialView'\)\s*\|\|\s*'dashboard'\)/.test(startupUiSrc)
+      /startupUIDeps\.navigate\(startupUIDeps\.getInitialView\(\)\s*\|\|\s*'dashboard'\)/.test(startupUiSrc)
+      && !startupUiSrc.includes('views-runtime-bridge.js')
       && !/window\.showDashboard\(\);/.test(startupUiSrc));
     assert('profile.js: profile switch restores that profile route',
       profileSrc.includes('await reloadProfileRuntimeShell(profileId)')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.268';
+self.APP_VERSION = '1.10.269';


### PR DESCRIPTION
## Summary
- inject `getInitialView`, `navigate`, and `openSettingsModal` into the Startup UI from the app shell
- remove Startup UI's view-runtime and Settings-module bridge fallbacks
- update isolated browser coverage to exercise only explicit Startup callbacks
- ratchet bridge coupling from 23 consumers / 33 lookups to 22 / 31
- bump the app cache version to 1.10.269

## Tests
- `npm test` (399 tests)
- `node scripts/quality-guardrails.mjs`
- `node tests/test-shell-delegated-actions.js`
- `node tests/test-v1-6-shipped.js`
- `node tests/test-correctness-phase2.js`
- `node tests/verify-modules.js`
- `npx playwright test tests/playwright/startup-helpers-browser-coverage.spec.js`
- `npx tsc --noEmit -p tsconfig.json`
- `npx tsc --noEmit -p tsconfig.checkjs.json`