### PR TITLE
Inject Sun runtime view callbacks

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -92,6 +92,8 @@ import {
   getInitialView,
   navigate,
   refreshMobileDashboardActiveTab,
+  renderLightChannelsLive,
+  renderLightTodayStrip,
   resetDashboardWidgets,
   showDetailModal,
   toggleDashboardOrganizeMode,
@@ -109,6 +111,7 @@ import {
 import { configureStartupUIDeps } from './startup-ui.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
 import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
+import { configureSunRuntimeDeps } from './sun-runtime.js';
 import { configureSupplementsRuntimeDeps } from './supplements-runtime.js';
 import { configureTourRuntimeDeps } from './tour-runtime.js';
 import { configureWearablesConnectRuntimeDeps } from './wearables-connect-runtime.js';
@@ -146,6 +149,13 @@ configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });
 configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
 configureSupplementsRuntimeDeps({ closeModal, navigate });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
+configureSunRuntimeDeps({
+  buildSidebar,
+  navigate,
+  openChannelOnLightPage: _openChannelOnLightPage,
+  renderLightChannelsLive,
+  renderLightTodayStrip,
+});
 configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
 configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
 configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });

--- a/js/sun-runtime.js
+++ b/js/sun-runtime.js
@@ -3,13 +3,49 @@
 
 import { isDebugMode } from './utils.js';
 import { getDeviceSessions } from './light-devices-store.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const sunRuntimeDeps = { isDebugMode };
+/**
+ * @typedef {{
+ *   buildSidebar: null | (() => void),
+ *   isDebugMode: null | (() => boolean),
+ *   navigate: null | ((view: string, options?: { scrollAnchor?: string }) => void),
+ *   openChannelOnLightPage: null | ((channel: string) => void),
+ *   renderLightChannelsLive: null | (() => void),
+ *   renderLightTodayStrip: null | (() => string),
+ * }} SunRuntimeDeps
+ */
 
+/** @type {SunRuntimeDeps} */
+const sunRuntimeDeps = {
+  buildSidebar: null,
+  isDebugMode,
+  navigate: null,
+  openChannelOnLightPage: null,
+  renderLightChannelsLive: null,
+  renderLightTodayStrip: null,
+};
+
+/** @param {Partial<SunRuntimeDeps>} [deps] */
 export function configureSunRuntimeDeps(deps = {}) {
   const previous = { ...sunRuntimeDeps };
-  if (typeof deps.isDebugMode === 'function') sunRuntimeDeps.isDebugMode = deps.isDebugMode;
+  if (Object.hasOwn(deps, 'buildSidebar') && (deps.buildSidebar === null || typeof deps.buildSidebar === 'function')) {
+    sunRuntimeDeps.buildSidebar = deps.buildSidebar;
+  }
+  if (Object.hasOwn(deps, 'isDebugMode') && (deps.isDebugMode === null || typeof deps.isDebugMode === 'function')) {
+    sunRuntimeDeps.isDebugMode = deps.isDebugMode;
+  }
+  if (Object.hasOwn(deps, 'navigate') && (deps.navigate === null || typeof deps.navigate === 'function')) {
+    sunRuntimeDeps.navigate = deps.navigate;
+  }
+  if (Object.hasOwn(deps, 'openChannelOnLightPage') && (deps.openChannelOnLightPage === null || typeof deps.openChannelOnLightPage === 'function')) {
+    sunRuntimeDeps.openChannelOnLightPage = deps.openChannelOnLightPage;
+  }
+  if (Object.hasOwn(deps, 'renderLightChannelsLive') && (deps.renderLightChannelsLive === null || typeof deps.renderLightChannelsLive === 'function')) {
+    sunRuntimeDeps.renderLightChannelsLive = deps.renderLightChannelsLive;
+  }
+  if (Object.hasOwn(deps, 'renderLightTodayStrip') && (deps.renderLightTodayStrip === null || typeof deps.renderLightTodayStrip === 'function')) {
+    sunRuntimeDeps.renderLightTodayStrip = deps.renderLightTodayStrip;
+  }
   return previous;
 }
 
@@ -25,20 +61,13 @@ function getRuntimeNavigator() {
     : null;
 }
 
-/** @param {string} name */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (typeof runtime?.[name] === 'function') return runtime[name].bind(runtime);
-  return getViewRuntimeFunction(name);
-}
-
 export function hasSunBrowserRuntime() {
   return getRuntimeWindow() !== null;
 }
 
 export function isSunDebugRuntime() {
   try {
-    return sunRuntimeDeps.isDebugMode() === true;
+    return sunRuntimeDeps.isDebugMode?.() === true;
   } catch {
     return false;
   }
@@ -55,7 +84,7 @@ export function getSunDeviceSessionsRuntime() {
 
 export function rebuildSunSidebarRuntime() {
   try {
-    getViewRuntimeFunction('buildSidebar')?.();
+    sunRuntimeDeps.buildSidebar?.();
   } catch {
     // Best-effort compatibility hook.
   }
@@ -67,7 +96,7 @@ export function rebuildSunSidebarRuntime() {
  */
 export function navigateSunRuntime(view, options) {
   try {
-    getRuntimeFunction('navigate')?.(view, options);
+    sunRuntimeDeps.navigate?.(view, options);
   } catch {
     // Best-effort compatibility hook.
   }
@@ -75,7 +104,7 @@ export function navigateSunRuntime(view, options) {
 
 export function renderLightChannelsLiveRuntime() {
   try {
-    getRuntimeFunction('renderLightChannelsLive')?.();
+    sunRuntimeDeps.renderLightChannelsLive?.();
   } catch {
     // Best-effort compatibility hook.
   }
@@ -83,7 +112,7 @@ export function renderLightChannelsLiveRuntime() {
 
 export function renderLightTodayStripRuntime() {
   try {
-    return getRuntimeFunction('renderLightTodayStrip')?.() || '';
+    return sunRuntimeDeps.renderLightTodayStrip?.() || '';
   } catch {
     return '';
   }
@@ -92,7 +121,7 @@ export function renderLightTodayStripRuntime() {
 /** @param {string} channel */
 export function openSunChannelOnLightPageRuntime(channel) {
   try {
-    getRuntimeFunction('_openChannelOnLightPage')?.(channel);
+    sunRuntimeDeps.openChannelOnLightPage?.(channel);
   } catch {
     // Best-effort compatibility hook.
   }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 22,
-  "viewRuntimeBridgeLookups": 31,
+  "viewRuntimeBridgeConsumers": 21,
+  "viewRuntimeBridgeLookups": 29,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/sun-browser-coverage.spec.js
+++ b/tests/playwright/sun-browser-coverage.spec.js
@@ -84,11 +84,11 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
   await page.goto('/app', { waitUntil: 'load' });
 
   const outcomes = await page.evaluate(async ({ sunUrl, utilsUrl, formerSunGlobals }) => {
-    const [{ state }, sun, utils, viewRuntime] = await Promise.all([
+    const [{ state }, sun, utils, sunRuntime] = await Promise.all([
       import('/js/state.js'),
       import(sunUrl),
       import(utilsUrl),
-      import('/js/views-runtime-bridge.js'),
+      import('/js/sun-runtime.js'),
     ]);
     const outcomes = {};
     const profileId = `sun-browser-${Date.now()}`;
@@ -102,10 +102,12 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       profilesState: state.profiles ? JSON.parse(JSON.stringify(state.profiles)) : state.profiles,
       currentProfile: state.currentProfile,
       profiles: localStorage.getItem('labcharts-profiles'),
-      navigate: window.navigate,
       geolocation: Object.getOwnPropertyDescriptor(navigator, 'geolocation'),
     };
-    const previousViewRuntime = viewRuntime.configureViewRuntime({ buildSidebar: () => {} });
+    const previousSunRuntimeDeps = sunRuntime.configureSunRuntimeDeps({
+      buildSidebar: () => {},
+      navigate: () => {},
+    });
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
     const waitFor = async (predicate, attempts = 100) => {
       for (let i = 0; i < attempts; i += 1) {
@@ -174,8 +176,6 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
     };
 
     try {
-      window.navigate = () => {};
-
       state.currentProfile = profileId;
       state.profiles = [{
         id: profileId,
@@ -340,8 +340,7 @@ test('sun browser coverage exercises facade totals prompts and location paths', 
       state.currentProfile = saved.currentProfile;
       if (saved.profiles == null) localStorage.removeItem('labcharts-profiles');
       else localStorage.setItem('labcharts-profiles', saved.profiles);
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
-      window.navigate = saved.navigate;
+      sunRuntime.configureSunRuntimeDeps(previousSunRuntimeDeps);
       if (saved.geolocation) Object.defineProperty(navigator, 'geolocation', saved.geolocation);
       else delete navigator.geolocation;
       document.querySelectorAll('.notification-container,.notification-toast,#prompt-dialog-overlay,#confirm-dialog-overlay,.modal-overlay').forEach(el => el.remove());

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 22 &&
-    baseline.viewRuntimeBridgeLookups === 31);
+    baseline.viewRuntimeBridgeConsumers === 21 &&
+    baseline.viewRuntimeBridgeLookups === 29);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -149,6 +149,10 @@ assert('App shell injects Supplements view callbacks without bridge lookups',
 assert('App shell injects sun defaults navigation without a view bridge lookup',
   appShellHooksSrc.includes('configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });'));
 
+assert('App shell injects Sun session UI callbacks without bridge lookups',
+  appShellHooksSrc.includes("import { configureSunRuntimeDeps } from './sun-runtime.js'")
+    && appShellHooksSrc.includes('configureSunRuntimeDeps({\n  buildSidebar,\n  navigate,\n  openChannelOnLightPage: _openChannelOnLightPage,\n  renderLightChannelsLive,\n  renderLightTodayStrip,\n});'));
+
 assert('App shell injects client list view callbacks without bridge lookups',
   appShellHooksSrc.includes('configureClientListRuntimeDeps({ navigate, renderProfileButton });'));
 

--- a/tests/test-sun-runtime.js
+++ b/tests/test-sun-runtime.js
@@ -18,7 +18,6 @@ import {
   renderLightTodayStripRuntime,
   requestSunGeolocationPositionRuntime,
 } from '../js/sun-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 const originalSunRuntimeDeps = configureSunRuntimeDeps();
 
@@ -33,16 +32,10 @@ console.log('=== Sun Runtime Tests ===\n');
 const runtimeKeys = [
   'window',
   'navigator',
-  'navigate',
-  'renderLightChannelsLive',
-  'renderLightTodayStrip',
-  '_openChannelOnLightPage',
   'addEventListener',
-  'isDebugMode',
 ];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 const savedImportedData = state.importedData;
-let previousViewRuntime = null;
 
 function setRuntimeValue(key, value) {
   Object.defineProperty(globalThis, key, {
@@ -65,16 +58,16 @@ try {
   const calls = [];
   const deviceSessions = [{ id: 'device-1', doses: { vitamin_d: 12 } }];
   state.importedData = { deviceSessions };
-  previousViewRuntime = configureViewRuntime({
+  configureSunRuntimeDeps({
     buildSidebar: () => calls.push(['sidebar']),
+    isDebugMode: () => true,
+    navigate: (view, options) => calls.push(['navigate', view, options?.scrollAnchor]),
+    openChannelOnLightPage: channel => calls.push(['channel', channel]),
+    renderLightChannelsLive: () => calls.push(['channels-live']),
+    renderLightTodayStrip: () => '<section>today</section>',
   });
-  setRuntimeValue('navigate', (view, options) => calls.push(['navigate', view, options?.scrollAnchor]));
-  setRuntimeValue('renderLightChannelsLive', () => calls.push(['channels-live']));
-  setRuntimeValue('renderLightTodayStrip', () => '<section>today</section>');
-  setRuntimeValue('_openChannelOnLightPage', channel => calls.push(['channel', channel]));
   const profileListener = () => calls.push(['profile-switch']);
   setRuntimeValue('addEventListener', (type, listener) => calls.push(['listener', type, listener]));
-  configureSunRuntimeDeps({ isDebugMode: () => true });
 
   assert('hasSunBrowserRuntime detects browser runtime',
     hasSunBrowserRuntime() === true);
@@ -89,7 +82,7 @@ try {
     renderLightTodayStripRuntime() === '<section>today</section>');
   openSunChannelOnLightPageRuntime('vitamin_d');
   addSunProfileSwitchListener(profileListener);
-  assert('sun runtime UI hooks delegate to browser globals',
+  assert('sun runtime UI hooks delegate to injected callbacks',
     calls.some(call => call[0] === 'sidebar') &&
     calls.some(call => call[0] === 'navigate' && call[1] === 'light' && call[2] === 'light-session-log') &&
     calls.some(call => call[0] === 'channels-live') &&
@@ -117,12 +110,14 @@ try {
     !runtimeSource.includes('exposeSunRuntimeBindings') && !runtimeSource.includes('Object.assign(runtime'));
 
   state.importedData = { deviceSessions: [] };
-  setRuntimeValue('renderLightTodayStrip', () => { throw new Error('boom'); });
-  configureViewRuntime({ buildSidebar: () => { throw new Error('boom'); } });
-  setRuntimeValue('navigate', () => { throw new Error('boom'); });
-  setRuntimeValue('renderLightChannelsLive', () => { throw new Error('boom'); });
-  setRuntimeValue('_openChannelOnLightPage', () => { throw new Error('boom'); });
-  configureSunRuntimeDeps({ isDebugMode: () => { throw new Error('boom'); } });
+  configureSunRuntimeDeps({
+    buildSidebar: () => { throw new Error('boom'); },
+    isDebugMode: () => { throw new Error('boom'); },
+    navigate: () => { throw new Error('boom'); },
+    openChannelOnLightPage: () => { throw new Error('boom'); },
+    renderLightChannelsLive: () => { throw new Error('boom'); },
+    renderLightTodayStrip: () => { throw new Error('boom'); },
+  });
   rebuildSunSidebarRuntime();
   navigateSunRuntime('dashboard');
   renderLightChannelsLiveRuntime();
@@ -145,7 +140,14 @@ try {
     rejected === true);
 
   delete globalThis.window;
-  configureViewRuntime({ buildSidebar: null });
+  configureSunRuntimeDeps({
+    buildSidebar: null,
+    isDebugMode: null,
+    navigate: null,
+    openChannelOnLightPage: null,
+    renderLightChannelsLive: null,
+    renderLightTodayStrip: null,
+  });
   const beforeNoWindowCalls = calls.length;
   rebuildSunSidebarRuntime();
   navigateSunRuntime('light');
@@ -157,7 +159,6 @@ try {
     renderLightTodayStripRuntime() === '' &&
     calls.length === beforeNoWindowCalls);
 } finally {
-  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   state.importedData = savedImportedData;
   configureSunRuntimeDeps(originalSunRuntimeDeps);
   restoreRuntime();

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.269';
+self.APP_VERSION = '1.10.270';


### PR DESCRIPTION
## Summary
- inject Sun session UI callbacks from the app shell instead of resolving them through `window` or the view runtime bridge
- preserve direct browser capability checks for geolocation and profile-switch listeners
- update focused Node and browser coverage and ratchet the bridge budget from 22 consumers / 31 lookups to 21 / 29
- bump the app cache version to 1.10.270

## Testing
- `./run-tests.sh` (126 module checks, 399 Vitest tests, 18 origin-guard tests, 352 Playwright tests, 472 theme-responsive checks)
- `npm run quality` (9/9)
- `node tests/test-sun-runtime.js` (13/13)