### PR TITLE
Inject crypto refresh callbacks

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -71,6 +71,7 @@ import { closeClientList, configureClientListRuntime, openClientList, openProfil
 import { configureClientListRuntimeDeps } from './client-list-runtime.js';
 import { configureCompareCorrelationViews } from './compare-correlations.js';
 import { configureContextCardsRuntimeCallbacks } from './context-cards-runtime.js';
+import { configureCryptoProfileDeps } from './crypto.js';
 import { configureCycleRuntimeDeps } from './cycle-runtime.js';
 import { configureDnaRuntimeDeps } from './dna-runtime.js';
 import { closeEMFInterpretation, configureEMFInterpretationRuntimeDeps } from './emf-interpretation.js';
@@ -142,6 +143,7 @@ configureSettingsRuntime({
 configureNavActions({ openClientList });
 configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
+configureCryptoProfileDeps({ buildSidebar, navigate });
 configureCycleRuntimeDeps({ closeModal, navigate, renderProfileButton });
 configureDnaRuntimeDeps({ buildSidebar, navigate });
 configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });

--- a/js/crypto.js
+++ b/js/crypto.js
@@ -6,28 +6,45 @@ import { showNotification, showConfirmDialog, escapeAttr, escapeHTML } from './u
 import { profileStorageKey } from './profile.js';
 import { getBlob, setBlob, deleteBlob, shouldUseBlob } from './blob-storage.js';
 import { ensureImportedArray } from './data-merge.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const appWindow = /** @type {Window & typeof globalThis & {
   __WEARABLES_TEST?: boolean,
-  navigate?: (view: string) => void,
 }} */ (typeof window !== 'undefined' ? window : {});
+/**
+ * @typedef {{
+ *   buildSidebar: null | (() => void),
+ *   migrateProfileData: null | ((data: any) => void),
+ *   navigate: null | ((view: string) => void),
+ * }} CryptoProfileDeps
+ */
+
+/** @type {CryptoProfileDeps} */
 const cryptoProfileDeps = {
+  buildSidebar: null,
   migrateProfileData: /** @type {null | ((data: any) => void)} */ (null),
+  navigate: null,
 };
 
 function navigateCryptoView(view) {
-  const navigate = appWindow.navigate || (typeof window !== 'undefined' ? getViewRuntimeFunction('navigate') : null);
-  navigate?.call(appWindow, view);
+  cryptoProfileDeps.navigate?.(view);
 }
 
 function buildCryptoSidebar() {
-  getViewRuntimeFunction('buildSidebar')?.();
+  cryptoProfileDeps.buildSidebar?.();
 }
 
+/** @param {Partial<CryptoProfileDeps>} [deps] */
 export function configureCryptoProfileDeps(deps = {}) {
   const previous = { ...cryptoProfileDeps };
-  if (typeof deps.migrateProfileData === 'function') cryptoProfileDeps.migrateProfileData = deps.migrateProfileData;
+  if (Object.hasOwn(deps, 'buildSidebar') && (deps.buildSidebar === null || typeof deps.buildSidebar === 'function')) {
+    cryptoProfileDeps.buildSidebar = deps.buildSidebar;
+  }
+  if (Object.hasOwn(deps, 'migrateProfileData') && (deps.migrateProfileData === null || typeof deps.migrateProfileData === 'function')) {
+    cryptoProfileDeps.migrateProfileData = deps.migrateProfileData;
+  }
+  if (Object.hasOwn(deps, 'navigate') && (deps.navigate === null || typeof deps.navigate === 'function')) {
+    cryptoProfileDeps.navigate = deps.navigate;
+  }
   return previous;
 }
 const cryptoActionDelegateRoots = new WeakSet();

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 21,
-  "viewRuntimeBridgeLookups": 29,
+  "viewRuntimeBridgeConsumers": 20,
+  "viewRuntimeBridgeLookups": 27,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/crypto-browser-coverage.spec.js
+++ b/tests/playwright/crypto-browser-coverage.spec.js
@@ -373,10 +373,9 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
     });
 
     const cryptoStore = await import(cryptoUrl);
-    const [{ state }, profileModule, viewRuntime] = await Promise.all([
+    const [{ state }, profileModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/profile.js'),
-      import('/js/views-runtime-bridge.js'),
     ]);
     const profileId = `crypto-broadcast-${Date.now()}`;
     const importedKey = profileModule.profileStorageKey(profileId, 'imported');
@@ -394,24 +393,22 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       profile: state.currentProfile,
       view: state.currentView,
       importedData: state.importedData,
-      navigate: window.navigate,
       storage: Object.fromEntries(keys.map(key => [key, localStorage.getItem(key)])),
     };
-    let previousViewRuntime = null;
 
     try {
       for (const key of keys) localStorage.removeItem(key);
       document.getElementById('passphrase-overlay')?.remove();
       state.currentProfile = profileId;
       state.currentView = 'settings';
-      previousCryptoProfileDeps = cryptoStore.configureCryptoProfileDeps({ migrateProfileData: data => {
-        calls.migrated += 1;
-        data.migratedByTest = true;
-      } });
-      previousViewRuntime = viewRuntime.configureViewRuntime({
+      previousCryptoProfileDeps = cryptoStore.configureCryptoProfileDeps({
         buildSidebar: () => { calls.sidebar += 1; },
+        migrateProfileData: data => {
+          calls.migrated += 1;
+          data.migratedByTest = true;
+        },
+        navigate: view => { calls.navigated.push(view); },
       });
-      window.navigate = view => { calls.navigated.push(view); };
       await cryptoStore.encryptedSetItem(importedKey, JSON.stringify({
         entries: [{ date: '2026-06-09', markers: { metabolic: { glucose: 5.2 } } }],
       }));
@@ -523,10 +520,7 @@ test('crypto nudges broadcast and backup snapshot browser paths run', async ({ p
       state.currentProfile = saved.profile;
       state.currentView = saved.view;
       state.importedData = saved.importedData;
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
       if (previousCryptoProfileDeps) cryptoStore.configureCryptoProfileDeps(previousCryptoProfileDeps);
-      if (saved.navigate === undefined) delete window.navigate;
-      else window.navigate = saved.navigate;
       if (originalBroadcastDescriptor) {
         Object.defineProperty(window, 'BroadcastChannel', originalBroadcastDescriptor);
       } else {

--- a/tests/test-crypto.js
+++ b/tests/test-crypto.js
@@ -50,6 +50,7 @@ const profileModule = await import('../js/profile.js');
 cryptoModule.configureCryptoProfileDeps({ migrateProfileData: profileModule.migrateProfileData });
 const navModule = await import('../js/nav.js');
 const viewsModule = await import('../js/views.js');
+cryptoModule.configureCryptoProfileDeps({ buildSidebar: navModule.buildSidebar, navigate: viewsModule.navigate });
 const exportModule = await import('../js/export.js');
 const settingsModule = await import('../js/settings.js');
 await import('../js/chat.js');

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 21 &&
-    baseline.viewRuntimeBridgeLookups === 29);
+    baseline.viewRuntimeBridgeConsumers === 20 &&
+    baseline.viewRuntimeBridgeLookups === 27);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -138,6 +138,10 @@ assert('App shell injects wearable navigation without view bridge lookups',
 assert('App shell injects category customization view callbacks',
   appShellHooksSrc.includes('configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });'));
 
+assert('App shell injects crypto cross-tab refresh callbacks without bridge lookups',
+  appShellHooksSrc.includes("import { configureCryptoProfileDeps } from './crypto.js'")
+    && appShellHooksSrc.includes('configureCryptoProfileDeps({ buildSidebar, navigate });'));
+
 assert('App shell injects Cycle view callbacks without bridge lookups',
   appShellHooksSrc.includes("import { configureCycleRuntimeDeps } from './cycle-runtime.js'")
     && appShellHooksSrc.includes('configureCycleRuntimeDeps({ closeModal, navigate, renderProfileButton });'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.270';
+self.APP_VERSION = '1.10.271';


### PR DESCRIPTION
## Summary
- inject cross-tab sidebar rebuild and navigation callbacks into `crypto.js` from the app shell
- remove the remaining view runtime bridge and `window.navigate` fallback from the encrypted profile refresh path
- update focused Node and browser coverage and ratchet the bridge budget from 21 consumers / 29 lookups to 20 / 27
- bump the app cache version to 1.10.271

## Testing
- `node tests/test-crypto.js` (296/296)
- `npx playwright test tests/playwright/crypto-browser-coverage.spec.js` (3/3)
- `npm test` (32 files, 399 tests)
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality` (9/9)
- `node tests/verify-modules.js` (126/126)