### PR TITLE
Inject marker detail callbacks

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -93,9 +93,11 @@ import {
   getInitialView,
   navigate,
   refreshMobileDashboardActiveTab,
+  renameMarker,
   renderLightChannelsLive,
   renderLightTodayStrip,
   resetDashboardWidgets,
+  revertMarkerName,
   showDetailModal,
   toggleDashboardOrganizeMode,
 } from './views.js';
@@ -199,7 +201,7 @@ configureChatMessageActionDeps({
 });
 configureCompareCorrelationViews({ askAIAboutCorrelations });
 configureContextCardsRuntimeCallbacks({ closeModal, navigate, onContextCardSaved });
-configureMarkerDetailRuntime({ askAIAboutMarker });
+configureMarkerDetailRuntime({ askAIAboutMarker, buildSidebar, navigate, renameMarker, revertMarkerName });
 configureShellChatActionDeps({
   closeChatPanel,
   clearChatHistory,

--- a/js/dashboard-view-composition.js
+++ b/js/dashboard-view-composition.js
@@ -18,6 +18,7 @@ import { createDashboardWidgetRegistry } from './dashboard-widgets.js';
 import { createDashboardWidgetControls } from './dashboard-widget-controls.js';
 import { createDashboardWidgetRenderers } from './dashboard-widget-renderers.js';
 import { configureMarkerDetailModal } from './marker-detail-modal.js';
+import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
 import { renderLightConditionsWidgetBody } from './light-conditions-now.js';
 import { ensureActiveDeviceTicker } from './light-devices.js';
 import { renderDashboardLightChannelPills, renderLightSessionLogActions } from './light-page-view.js';
@@ -104,6 +105,12 @@ export function createDashboardViewComposition({
     toggleDashboardQuickMarkerPin,
   } = dashboardWidgetRenderers;
 
+  configureMarkerDetailRuntime({
+    isDashboardQuickMarkerPinned,
+    navigate,
+    showEmojiPicker,
+    toggleDashboardQuickMarkerPin,
+  });
   configureMarkerDetailModal({ navigate, isDashboardQuickMarkerPinned, toggleDashboardQuickMarkerPin, showEmojiPicker });
 
   function getDashboardMarkerWidgetDefinition(widgetId, ctx = null) {

--- a/js/marker-detail-runtime.js
+++ b/js/marker-detail-runtime.js
@@ -4,42 +4,66 @@
 import { closeEMFInterpretation } from './emf-runtime.js';
 import { getDnaModuleFunction } from './dna-runtime-bridge.js';
 import { getRecommendationModuleFunction } from './recommendations-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { getWearablesModuleFunction } from './wearables-runtime.js';
 
+/**
+ * @typedef {{
+ *   askAIAboutMarker: null | ((id?: string) => any),
+ *   buildSidebar: null | (() => void),
+ *   closeEMFInterpretation: null | (() => any),
+ *   isDashboardQuickMarkerPinned: null | ((id?: string) => boolean),
+ *   navigate: null | ((category?: string, data?: any) => any),
+ *   renameMarker: null | ((id?: string) => any),
+ *   revertMarkerName: null | ((id?: string) => any),
+ *   showEmojiPicker: null | ((el: Element, callback: (emoji?: string | null) => void, opts?: any) => any),
+ *   toggleDashboardQuickMarkerPin: null | ((id?: string) => any),
+ * }} MarkerDetailRuntimeDeps
+ */
+
+/** @type {MarkerDetailRuntimeDeps} */
 const markerDetailRuntimeDeps = {
-  askAIAboutMarker: /** @type {null | ((id?: string) => void)} */ (null),
+  askAIAboutMarker: null,
+  buildSidebar: null,
   closeEMFInterpretation,
+  isDashboardQuickMarkerPinned: null,
+  navigate: null,
+  renameMarker: null,
+  revertMarkerName: null,
+  showEmojiPicker: null,
+  toggleDashboardQuickMarkerPin: null,
 };
 
+/** @param {Partial<MarkerDetailRuntimeDeps>} [deps] */
 export function configureMarkerDetailRuntime(deps = {}) {
   const previous = { ...markerDetailRuntimeDeps };
-  if ('askAIAboutMarker' in deps) {
-    markerDetailRuntimeDeps.askAIAboutMarker = typeof deps.askAIAboutMarker === 'function'
-      ? /** @type {(id?: string) => void} */ (deps.askAIAboutMarker)
-      : null;
+  if (Object.hasOwn(deps, 'askAIAboutMarker') && (deps.askAIAboutMarker === null || typeof deps.askAIAboutMarker === 'function')) {
+    markerDetailRuntimeDeps.askAIAboutMarker = deps.askAIAboutMarker;
   }
-  if (typeof deps.closeEMFInterpretation === 'function') {
+  if (Object.hasOwn(deps, 'buildSidebar') && (deps.buildSidebar === null || typeof deps.buildSidebar === 'function')) {
+    markerDetailRuntimeDeps.buildSidebar = deps.buildSidebar;
+  }
+  if (Object.hasOwn(deps, 'closeEMFInterpretation') && (deps.closeEMFInterpretation === null || typeof deps.closeEMFInterpretation === 'function')) {
     markerDetailRuntimeDeps.closeEMFInterpretation = deps.closeEMFInterpretation;
   }
+  if (Object.hasOwn(deps, 'isDashboardQuickMarkerPinned') && (deps.isDashboardQuickMarkerPinned === null || typeof deps.isDashboardQuickMarkerPinned === 'function')) {
+    markerDetailRuntimeDeps.isDashboardQuickMarkerPinned = deps.isDashboardQuickMarkerPinned;
+  }
+  if (Object.hasOwn(deps, 'navigate') && (deps.navigate === null || typeof deps.navigate === 'function')) {
+    markerDetailRuntimeDeps.navigate = deps.navigate;
+  }
+  if (Object.hasOwn(deps, 'renameMarker') && (deps.renameMarker === null || typeof deps.renameMarker === 'function')) {
+    markerDetailRuntimeDeps.renameMarker = deps.renameMarker;
+  }
+  if (Object.hasOwn(deps, 'revertMarkerName') && (deps.revertMarkerName === null || typeof deps.revertMarkerName === 'function')) {
+    markerDetailRuntimeDeps.revertMarkerName = deps.revertMarkerName;
+  }
+  if (Object.hasOwn(deps, 'showEmojiPicker') && (deps.showEmojiPicker === null || typeof deps.showEmojiPicker === 'function')) {
+    markerDetailRuntimeDeps.showEmojiPicker = deps.showEmojiPicker;
+  }
+  if (Object.hasOwn(deps, 'toggleDashboardQuickMarkerPin') && (deps.toggleDashboardQuickMarkerPin === null || typeof deps.toggleDashboardQuickMarkerPin === 'function')) {
+    markerDetailRuntimeDeps.toggleDashboardQuickMarkerPin = deps.toggleDashboardQuickMarkerPin;
+  }
   return previous;
-}
-
-function getRuntimeWindow() {
-  return typeof window !== 'undefined'
-    ? /** @type {any} */ (window)
-    : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
-  return getViewRuntimeFunction(name);
 }
 
 /**
@@ -47,12 +71,12 @@ function getRuntimeFunction(name) {
  * @param {any} [data]
  */
 export function navigateMarkerDetailRuntime(category, data) {
-  getRuntimeFunction('navigate')?.(category, data);
+  markerDetailRuntimeDeps.navigate?.(category, data);
 }
 
 export function buildMarkerDetailSidebarRuntime() {
   try {
-    getViewRuntimeFunction('buildSidebar')?.();
+    markerDetailRuntimeDeps.buildSidebar?.();
   } catch {
     // Best-effort shell refresh.
   }
@@ -64,7 +88,7 @@ export function buildMarkerDetailSidebarRuntime() {
  */
 export function isDashboardQuickMarkerPinnedRuntime(id) {
   try {
-    return getRuntimeFunction('isDashboardQuickMarkerPinned')?.(id) === true;
+    return markerDetailRuntimeDeps.isDashboardQuickMarkerPinned?.(id) === true;
   } catch {
     return false;
   }
@@ -72,17 +96,17 @@ export function isDashboardQuickMarkerPinnedRuntime(id) {
 
 /** @param {string | undefined} id */
 export function toggleDashboardQuickMarkerPinRuntime(id) {
-  getRuntimeFunction('toggleDashboardQuickMarkerPin')?.(id);
+  markerDetailRuntimeDeps.toggleDashboardQuickMarkerPin?.(id);
 }
 
 /** @param {string | undefined} id */
 export function renameMarkerRuntime(id) {
-  getRuntimeFunction('renameMarker')?.(id);
+  markerDetailRuntimeDeps.renameMarker?.(id);
 }
 
 /** @param {string | undefined} id */
 export function revertMarkerNameRuntime(id) {
-  getRuntimeFunction('revertMarkerName')?.(id);
+  markerDetailRuntimeDeps.revertMarkerName?.(id);
 }
 
 /** @param {string | undefined} id */
@@ -96,7 +120,7 @@ export function askAIAboutMarkerRuntime(id) {
  * @param {any} [opts]
  */
 export function showEmojiPickerRuntime(el, callback, opts) {
-  getRuntimeFunction('showEmojiPicker')?.(el, callback, opts);
+  markerDetailRuntimeDeps.showEmojiPicker?.(el, callback, opts);
 }
 
 /**
@@ -137,7 +161,7 @@ export async function renderRecommendationSectionRuntime(markerKey, options) {
 }
 
 export function closeEMFInterpretationRuntime() {
-  void markerDetailRuntimeDeps.closeEMFInterpretation();
+  void markerDetailRuntimeDeps.closeEMFInterpretation?.();
 }
 
 export function uninstallWearableModalFocusTrapRuntime() {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 20,
-  "viewRuntimeBridgeLookups": 27,
+  "viewRuntimeBridgeConsumers": 19,
+  "viewRuntimeBridgeLookups": 25,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/marker-detail-browser-coverage.spec.js
+++ b/tests/playwright/marker-detail-browser-coverage.spec.js
@@ -9,11 +9,11 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ editingUrl }) => {
-    const [editing, { state }, data, viewRuntime] = await Promise.all([
+    const [editing, { state }, data, markerRuntime] = await Promise.all([
       import(editingUrl),
       import('/js/state.js'),
       import('/js/data.js'),
-      import('/js/views-runtime-bridge.js'),
+      import('/js/marker-detail-runtime.js'),
     ]);
     const outcomes = {};
     const calls = [];
@@ -41,12 +41,12 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
       profileSex: state.profileSex,
       profileDob: state.profileDob,
       unitSystem: state.unitSystem,
-      navigate: window.navigate,
     };
     const id = 'proteins_albumin';
     const dotKey = 'proteins.albumin';
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    const previousMarkerRuntime = markerRuntime.configureMarkerDetailRuntime({
       buildSidebar: () => calls.push(['sidebar']),
+      navigate: (category, payload) => calls.push(['navigate', category, payload || null]),
     });
 
     try {
@@ -70,8 +70,6 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
       state.markerRegistry = {
         [id]: active.categories.proteins.markers.albumin,
       };
-      window.navigate = (category, payload) => calls.push(['navigate', category, payload || null]);
-
       fillManualForm({ date: '2026-06-04', value: '44' });
       await editing.saveManualEntry(id);
       await wait(70);
@@ -94,9 +92,7 @@ test('marker detail editing covers default dependency callbacks', async ({ page 
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       state.unitSystem = saved.unitSystem;
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
-      if (saved.navigate) window.navigate = saved.navigate;
-      else delete window.navigate;
+      markerRuntime.configureMarkerDetailRuntime(previousMarkerRuntime);
       data.invalidateActiveDataCache();
       document.getElementById('marker-detail-default-deps-fixture')?.remove();
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
@@ -115,11 +111,11 @@ test('marker detail editing covers manual values notes delete and revert workflo
   await page.waitForSelector('#notification-container', { state: 'attached' });
 
   const results = await page.evaluate(async ({ editingUrl }) => {
-    const [editing, { state }, data, viewRuntime] = await Promise.all([
+    const [editing, { state }, data, markerRuntime] = await Promise.all([
       import(editingUrl),
       import('/js/state.js'),
       import('/js/data.js'),
-      import('/js/views-runtime-bridge.js'),
+      import('/js/marker-detail-runtime.js'),
     ]);
     const outcomes = {};
     const calls = [];
@@ -179,7 +175,7 @@ test('marker detail editing covers manual values notes delete and revert workflo
     const id = 'proteins_albumin';
     const dotKey = 'proteins.albumin';
     const note500 = 'manual note '.repeat(80);
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    const previousMarkerRuntime = markerRuntime.configureMarkerDetailRuntime({
       buildSidebar: () => calls.push(['sidebar']),
     });
 
@@ -303,10 +299,10 @@ test('marker detail editing covers manual values notes delete and revert workflo
       state.profileSex = saved.profileSex;
       state.profileDob = saved.profileDob;
       state.unitSystem = saved.unitSystem;
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
+      markerRuntime.configureMarkerDetailRuntime(previousMarkerRuntime);
       data.invalidateActiveDataCache();
       editing.configureMarkerDetailEditing({
-        navigate: (...args) => window.navigate?.(...args),
+        navigate: () => {},
         showDetailModal: () => {},
         openManualEntryForm: () => {},
         closeModal: () => {},
@@ -494,7 +490,7 @@ test('marker detail editing covers range overrides and marker note editor paths'
       state.unitSystem = saved.unitSystem;
       data.invalidateActiveDataCache();
       editing.configureMarkerDetailEditing({
-        navigate: (...args) => window.navigate?.(...args),
+        navigate: () => {},
         showDetailModal: () => {},
         openManualEntryForm: () => {},
         closeModal: () => {},
@@ -699,21 +695,17 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       rangeMode: state.rangeMode,
       chartInstances: state.chartInstances,
     };
-    const windowKeys = [
-      'toggleDashboardQuickMarkerPin',
-      'renameMarker',
-      'revertMarkerName',
-    ];
-    const savedWindow = Object.fromEntries(windowKeys.map(key => [
-      key,
-      { had: Object.prototype.hasOwnProperty.call(window, key), value: window[key] },
-    ]));
     const date = '2026-06-01';
     const albuminId = 'proteins_albumin';
     const albuminKey = 'proteins.albumin';
     const restoreMarkerRuntime = markerRuntime.configureMarkerDetailRuntime({
       askAIAboutMarker: id => calls.push(['ask-ai', id]),
       closeEMFInterpretation: () => calls.push(['close-emf']),
+      isDashboardQuickMarkerPinned: () => false,
+      renameMarker: id => calls.push(['rename', id]),
+      revertMarkerName: id => calls.push(['revert-name', id]),
+      showEmojiPicker: () => {},
+      toggleDashboardQuickMarkerPin: id => calls.push(['pin', id]),
     });
     const restoreRecommendationRuntime = recommendationRuntime.configureRecommendationModuleBridge({
       isProductRecsEnabled: () => true,
@@ -764,10 +756,6 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       data.invalidateActiveDataCache();
       state.markerRegistry = {};
 
-      window.toggleDashboardQuickMarkerPin = id => calls.push(['pin', id]);
-      window.renameMarker = id => calls.push(['rename', id]);
-      window.revertMarkerName = id => calls.push(['revert-name', id]);
-
       localStorage.setItem('labcharts-marker-desc', JSON.stringify({
         'coverage.cached': 'Cached marker description',
       }));
@@ -789,7 +777,7 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       detail?.querySelector('[data-marker-detail-action="rename-marker"]')?.click();
       detail?.querySelector('[data-marker-detail-action="revert-marker-name"]')?.click();
       detail?.querySelector('[data-marker-detail-action="ask-ai"]')?.click();
-      outcomes.defaultDelegatesCallGlobalMarkerActions =
+      outcomes.defaultDelegatesCallInjectedMarkerActions =
         calls.some(call => call[0] === 'pin' && call[1] === albuminId)
         && calls.some(call => call[0] === 'rename' && call[1] === albuminId)
         && calls.some(call => call[0] === 'revert-name' && call[1] === albuminId)
@@ -825,10 +813,6 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       state.showAltUnits = saved.showAltUnits;
       state.rangeMode = saved.rangeMode;
       state.chartInstances = saved.chartInstances;
-      for (const [key, info] of Object.entries(savedWindow)) {
-        if (info.had) window[key] = info.value;
-        else delete window[key];
-      }
       markerRuntime.configureMarkerDetailRuntime(restoreMarkerRuntime);
       dnaBridge.configureDnaModuleBridge({ getRelevantSNPs: null, ...restoreDnaBridge });
       recommendationRuntime.configureRecommendationModuleBridge({
@@ -839,11 +823,11 @@ test('marker detail modal covers default deps descriptions alt units and bio age
       wearablesRuntime.configureWearablesModuleBridge(restoreWearablesRuntime);
       data.invalidateActiveDataCache();
       modal.configureMarkerDetailModal({
-        navigate: (category, payload) => window.navigate?.(category, payload),
+        navigate: () => {},
         isDashboardQuickMarkerPinned: () => false,
-        toggleDashboardQuickMarkerPin: id => globalThis.toggleDashboardQuickMarkerPin?.(id),
-        renameMarker: id => globalThis.renameMarker?.(id),
-        revertMarkerName: id => globalThis.revertMarkerName?.(id),
+        toggleDashboardQuickMarkerPin: () => {},
+        renameMarker: () => {},
+        revertMarkerName: () => {},
         askAIAboutMarker: id => markerRuntime.askAIAboutMarkerRuntime(id),
         showEmojiPicker: () => {},
       });

--- a/tests/playwright/modal-session-coverage-batch.spec.js
+++ b/tests/playwright/modal-session-coverage-batch.spec.js
@@ -8,11 +8,11 @@ test('marker detail modal covers custom marker create delete and focus restore p
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ markerUrl }) => {
-    const [{ state }, data, markerModal, viewRuntime] = await Promise.all([
+    const [{ state }, data, markerModal, markerRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import(markerUrl),
-      import('/js/views-runtime-bridge.js'),
+      import('/js/marker-detail-runtime.js'),
     ]);
     const outcomes = {};
     const calls = [];
@@ -24,7 +24,7 @@ test('marker detail modal covers custom marker create delete and focus restore p
       activeDetailMarkerId: state._activeDetailMarkerId,
       navigate: window.navigate,
     };
-    const previousViewRuntime = viewRuntime.configureViewRuntime({
+    const previousMarkerRuntime = markerRuntime.configureMarkerDetailRuntime({
       buildSidebar: () => calls.push(['sidebar']),
     });
 
@@ -153,7 +153,7 @@ test('marker detail modal covers custom marker create delete and focus restore p
       state.importedData = saved.importedData;
       state.currentView = saved.currentView;
       state._activeDetailMarkerId = saved.activeDetailMarkerId;
-      viewRuntime.configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
+      markerRuntime.configureMarkerDetailRuntime(previousMarkerRuntime);
       if (saved.navigate) window.navigate = saved.navigate;
       else delete window.navigate;
       data.invalidateActiveDataCache();

--- a/tests/test-marker-detail-delegated-actions.js
+++ b/tests/test-marker-detail-delegated-actions.js
@@ -67,6 +67,9 @@ assert('history note toggle no longer depends on brittle parentElement chaining'
 assert('dashboard passes the quick-marker pin dependency instead of relying on an inline window handler',
   dashboardSrc.includes('toggleDashboardQuickMarkerPin, showEmojiPicker') &&
     modalSrc.includes("markerDetailActionAttrs('quick-pin', { id })"));
+assert('dashboard composition injects marker detail UI callbacks without runtime lookups',
+  dashboardSrc.includes('configureMarkerDetailRuntime({') &&
+    dashboardSrc.includes('isDashboardQuickMarkerPinned,\n    navigate,\n    showEmojiPicker,\n    toggleDashboardQuickMarkerPin,'));
 assert('service worker precaches marker-detail-actions.js',
   swSrc.includes("'/js/marker-detail-actions.js'"));
 assert('service worker precaches marker-detail-runtime.js',
@@ -76,7 +79,8 @@ assert('marker-detail-modal delegates browser globals through runtime adapter',
     !/\bwindow(?:\.|\s*\[)/.test(modalSrc) &&
     runtimeSrc.includes('export function navigateMarkerDetailRuntime') &&
     runtimeSrc.includes('export function hasRecommendationSectionRendererRuntime') &&
-    runtimeSrc.includes('export async function renderRecommendationSectionRuntime'));
+    runtimeSrc.includes('export async function renderRecommendationSectionRuntime') &&
+    !runtimeSrc.includes("from './views-runtime-bridge.js'"));
 assert('marker-detail-editing delegates browser shell hooks through runtime adapter',
   editingSrc.includes("from './marker-detail-runtime.js'") &&
     editingSrc.includes('buildMarkerDetailSidebarRuntime') &&

--- a/tests/test-marker-detail-runtime.js
+++ b/tests/test-marker-detail-runtime.js
@@ -21,7 +21,6 @@ import {
 } from '../js/marker-detail-runtime.js';
 import { configureDnaModuleBridge } from '../js/dna-runtime-bridge.js';
 import { configureRecommendationModuleBridge } from '../js/recommendations-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 import { configureWearablesModuleBridge } from '../js/wearables-runtime.js';
 
 let pass = 0, fail = 0;
@@ -32,28 +31,11 @@ function assert(name, condition, detail) {
 
 console.log('=== Marker Detail Runtime Tests ===\n');
 
-const runtimeKeys = [
-  'window',
-  'navigate',
-  'isDashboardQuickMarkerPinned',
-  'toggleDashboardQuickMarkerPin',
-  'renameMarker',
-  'revertMarkerName',
-  'showEmojiPicker',
-];
+const runtimeKeys = ['window'];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
-let previousViewRuntime = null;
 let previousWearablesModule = null;
 const previousDnaBridge = configureDnaModuleBridge({ getRelevantSNPs: null });
-
-function setRuntimeValue(key, value) {
-  Object.defineProperty(globalThis, key, {
-    configurable: true,
-    writable: true,
-    enumerable: true,
-    value,
-  });
-}
+const originalMarkerDetailRuntimeDeps = configureMarkerDetailRuntime();
 
 function restoreRuntime() {
   for (const key of runtimeKeys) {
@@ -68,17 +50,19 @@ try {
   const anchor = { textContent: '', dataset: {} };
   const snps = [{ rsid: 'rs1801133' }];
 
-  setRuntimeValue('navigate', (category, data) => calls.push(['navigate', category, data?.from || '']));
-  previousViewRuntime = configureViewRuntime({
+  configureMarkerDetailRuntime({
+    askAIAboutMarker: id => calls.push(['ask', id]),
     buildSidebar: () => calls.push(['sidebar']),
-  });
-  setRuntimeValue('isDashboardQuickMarkerPinned', id => id === 'lipids_apob');
-  setRuntimeValue('toggleDashboardQuickMarkerPin', id => calls.push(['pin', id]));
-  setRuntimeValue('renameMarker', id => calls.push(['rename', id]));
-  setRuntimeValue('revertMarkerName', id => calls.push(['revert', id]));
-  setRuntimeValue('showEmojiPicker', (el, callback, opts) => {
-    calls.push(['emoji', opts?.showReset ? 'reset' : 'plain']);
-    callback(':test:');
+    closeEMFInterpretation: () => calls.push(['emf-close']),
+    isDashboardQuickMarkerPinned: id => id === 'lipids_apob',
+    navigate: (category, data) => calls.push(['navigate', category, data?.from || '']),
+    renameMarker: id => calls.push(['rename', id]),
+    revertMarkerName: id => calls.push(['revert', id]),
+    showEmojiPicker: (el, callback, opts) => {
+      calls.push(['emoji', opts?.showReset ? 'reset' : 'plain']);
+      callback(':test:');
+    },
+    toggleDashboardQuickMarkerPin: id => calls.push(['pin', id]),
   });
   configureDnaModuleBridge({ getRelevantSNPs: dotKey => {
     calls.push(['snps', dotKey]);
@@ -90,10 +74,6 @@ try {
       calls.push(['recs', markerKey, options?.markerStatus || '']);
       return '<section>recs</section>';
     },
-  });
-  const restoreMarkerDetailRuntime = configureMarkerDetailRuntime({
-    askAIAboutMarker: id => calls.push(['ask', id]),
-    closeEMFInterpretation: () => calls.push(['emf-close']),
   });
   previousWearablesModule = configureWearablesModuleBridge({
     _uninstallWearableModalFocusTrap: () => calls.push(['focus-trap']),
@@ -120,7 +100,7 @@ try {
       calls.some(call => call.join('|') === 'emoji|reset') &&
       calls.some(call => call.join('|') === 'emf-close') &&
       calls.some(call => call.join('|') === 'focus-trap'));
-  assert('marker detail runtime returns browser-derived values',
+  assert('marker detail runtime returns injected values',
     isDashboardQuickMarkerPinnedRuntime('lipids_apob') === true &&
       getRelevantSNPsRuntime('lipids.apob') === snps &&
       hasRecommendationSectionRendererRuntime() === true &&
@@ -128,8 +108,10 @@ try {
       renderedRecs === '<section>recs</section>' &&
       anchor.textContent === ':test:');
 
-  configureViewRuntime({ buildSidebar: () => { throw new Error('boom'); } });
-  setRuntimeValue('isDashboardQuickMarkerPinned', () => { throw new Error('boom'); });
+  configureMarkerDetailRuntime({
+    buildSidebar: () => { throw new Error('boom'); },
+    isDashboardQuickMarkerPinned: () => { throw new Error('boom'); },
+  });
   configureDnaModuleBridge({ getRelevantSNPs: () => { throw new Error('boom'); } });
   configureRecommendationModuleBridge({ isProductRecsEnabled: () => { throw new Error('boom'); } });
   buildMarkerDetailSidebarRuntime();
@@ -138,14 +120,23 @@ try {
       getRelevantSNPsRuntime('lipids.apob').length === 0 &&
       isProductRecsEnabledRuntime() === false);
 
-  configureMarkerDetailRuntime({ askAIAboutMarker: null, closeEMFInterpretation: () => {} });
+  configureMarkerDetailRuntime({
+    askAIAboutMarker: null,
+    buildSidebar: null,
+    closeEMFInterpretation: () => {},
+    isDashboardQuickMarkerPinned: null,
+    navigate: null,
+    renameMarker: null,
+    revertMarkerName: null,
+    showEmojiPicker: null,
+    toggleDashboardQuickMarkerPin: null,
+  });
 
   delete globalThis.window;
   configureRecommendationModuleBridge({
     isProductRecsEnabled: null,
     renderRecommendationSection: null,
   });
-  configureViewRuntime({ buildSidebar: null });
   configureWearablesModuleBridge({ _uninstallWearableModalFocusTrap: null });
   configureDnaModuleBridge({ getRelevantSNPs: null });
   const beforeMissingRuntimeCalls = calls.length;
@@ -166,9 +157,9 @@ try {
       getRelevantSNPsRuntime('lipids.apob').length === 0 &&
       isProductRecsEnabledRuntime() === false &&
       missingRuntimeRecs === '');
-  configureMarkerDetailRuntime(restoreMarkerDetailRuntime);
   configureRecommendationModuleBridge(previousRecommendationBridge);
 } finally {
+  configureMarkerDetailRuntime(originalMarkerDetailRuntimeDeps);
   configureDnaModuleBridge({ getRelevantSNPs: null, ...previousDnaBridge });
   configureWearablesModuleBridge({
     _uninstallWearableModalFocusTrap: null,
@@ -178,7 +169,6 @@ try {
     isProductRecsEnabled: null,
     renderRecommendationSection: null,
   });
-  configureViewRuntime({ buildSidebar: null, ...previousViewRuntime });
   restoreRuntime();
 }
 

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 20 &&
-    baseline.viewRuntimeBridgeLookups === 27);
+    baseline.viewRuntimeBridgeConsumers === 19 &&
+    baseline.viewRuntimeBridgeLookups === 25);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -175,6 +175,9 @@ assert('App shell injects dashboard widget view callbacks without bridge lookups
 assert('App shell injects Light Devices view callbacks without bridge lookups',
   appShellHooksSrc.includes('configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });'));
 
+assert('App shell injects marker detail shell callbacks without bridge lookups',
+  appShellHooksSrc.includes('configureMarkerDetailRuntime({ askAIAboutMarker, buildSidebar, navigate, renameMarker, revertMarkerName });'));
+
 assert('Chat shell controls use module dependencies instead of window lookups',
   ['closeChatPanel', 'clearChatHistory', 'handleChatKeydown', 'sendChatMessage', 'setChatPersonality',
     'setChatWebSearchEnabled', 'startDiscussion', 'summarizeThread', 'toggleChatFullscreen',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.271';
+self.APP_VERSION = '1.10.272';


### PR DESCRIPTION
## Summary
- inject shell- and dashboard-owned marker detail callbacks at their composition roots
- remove marker detail lookups through the views runtime bridge and browser globals
- reduce the quality baseline from 20 consumers / 27 lookups to 19 consumers / 25 lookups
- bump the app cache version to 1.10.272

## Testing
- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality`
- `npm test` (32 files, 399 tests)
- `node tests/verify-modules.js` (126/126)
- `npx playwright test tests/playwright/marker-detail-browser-coverage.spec.js` (5/5)
- `npx playwright test tests/playwright/modal-session-coverage-batch.spec.js` (5/5)
- `./run-tests.sh` (marker-detail regression and 351/352 Playwright tests passed; one unrelated sidebar-search fixture flaked, then passed immediately in isolation)