### PR TITLE
Inject sync pull profile refresh

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -113,6 +113,7 @@ import {
   configureShellNavDeps,
 } from './shell-actions.js';
 import { configureStartupUIDeps } from './startup-ui.js';
+import { configureSyncPull } from './sync-pull.js';
 import { configureSyncPullActiveRefreshDeps } from './sync-pull-active-refresh-runtime.js';
 import { configureSunDefaultsRuntimeDeps } from './sun-defaults-runtime.js';
 import { configureSunRuntimeDeps } from './sun-runtime.js';
@@ -231,6 +232,7 @@ configureStartupUIDeps({
 });
 configureOnboardingViewRuntimeDeps({ buildSidebar, createNewThread, navigate, openChatPanel, toggleChatPanel });
 configureTourRuntimeDeps({ openChatPanel });
+configureSyncPull({ renderProfileButton });
 configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });
 configureWearablesConnectRuntimeDeps({ navigate });
 configureWearableSettingsRuntimeDeps({ navigate });

--- a/js/sync-pull.js
+++ b/js/sync-pull.js
@@ -18,7 +18,6 @@ import { clearRestoreJoinPending, isRestoreJoinPending } from './sync-identity.j
 import {
   logSyncEvent, updateSyncStatus,
 } from './sync-state.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 // These use var + self-preserving defaults because sync.js can be re-entered
 // through app module cycles while sync-pull.js is still evaluating. An early
@@ -28,6 +27,7 @@ var _getProfileQuery = _getProfileQuery || (() => null);
 var _isSyncPushInFlight = _isSyncPushInFlight || (() => false);
 /** @type {(...args: any[]) => Promise<any>} */
 var _pushProfile = _pushProfile || (async () => {});
+var _renderProfileButton = _renderProfileButton || (() => {});
 /** @type {(...args: any[]) => any} */
 var _debug = _debug || (() => {});
 let _pulling = false;
@@ -92,6 +92,7 @@ export function combinePulledAISettings(selection) {
  *   getProfileQuery?: () => any,
  *   isSyncPushInFlight?: () => boolean,
  *   pushProfile?: (...args: any[]) => Promise<any>,
+ *   renderProfileButton?: () => void,
  *   debug?: (...args: any[]) => any,
  * }} [deps]
  */
@@ -100,12 +101,14 @@ export function configureSyncPull({
   getProfileQuery,
   isSyncPushInFlight,
   pushProfile,
+  renderProfileButton,
   debug,
 } = {}) {
   if (typeof getEvolu === 'function') _getEvolu = getEvolu;
   if (typeof getProfileQuery === 'function') _getProfileQuery = getProfileQuery;
   if (typeof isSyncPushInFlight === 'function') _isSyncPushInFlight = isSyncPushInFlight;
   if (typeof pushProfile === 'function') _pushProfile = pushProfile;
+  if (typeof renderProfileButton === 'function') _renderProfileButton = renderProfileButton;
   if (typeof debug === 'function') _debug = debug;
 }
 
@@ -291,7 +294,7 @@ export async function onSyncReceived() {
 
     // Rebuild profile dropdown if profiles changed
     if (profilesChanged) {
-      getViewRuntimeFunction('renderProfileDropdown')?.();
+      _renderProfileButton();
     }
   } finally {
     _pulling = false;

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 17,
-  "viewRuntimeBridgeLookups": 18,
+  "viewRuntimeBridgeConsumers": 16,
+  "viewRuntimeBridgeLookups": 17,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 17 &&
-    baseline.viewRuntimeBridgeLookups === 18);
+    baseline.viewRuntimeBridgeConsumers === 16 &&
+    baseline.viewRuntimeBridgeLookups === 17);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -13,6 +13,7 @@ const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
 const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
+const syncPullSrc = fs.readFileSync(path.join(root, 'js/sync-pull.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -171,6 +172,13 @@ assert('App shell injects export demo refresh callbacks without bridge lookups',
     && exportSrc.includes("exportRuntimeDeps.navigate?.('biology-scores')")
     && appShellHooksSrc.includes("import { clearAllData, closeReportBuilder, configureExportRuntimeDeps } from './export.js';")
     && appShellHooksSrc.includes('configureExportRuntimeDeps({ buildSidebar, navigate });'));
+
+assert('App shell injects sync pull profile refresh without bridge lookups',
+  !syncPullSrc.includes("from './views-runtime-bridge.js'")
+    && syncPullSrc.includes("if (typeof renderProfileButton === 'function') _renderProfileButton = renderProfileButton;")
+    && syncPullSrc.includes('_renderProfileButton();')
+    && appShellHooksSrc.includes("import { configureSyncPull } from './sync-pull.js';")
+    && appShellHooksSrc.includes('configureSyncPull({ renderProfileButton });'));
 
 assert('App shell injects PDF import review view callbacks without bridge lookups',
   appShellHooksSrc.includes('configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.274';
+self.APP_VERSION = '1.10.275';


### PR DESCRIPTION
## Summary

- inject the app-shell-owned profile-button refresh into `sync-pull.js`
- remove the pull path's view-runtime bridge lookup after remote profile merges
- ratchet view-runtime coupling from 17 consumers / 18 lookups to 16 consumers / 17 lookups
- bump the app cache version to `1.10.275`

## Why

A successful sync pull refreshed profile navigation through the cycle-sensitive view bridge. The app shell already owns the concrete profile renderer, so wiring that callback directly makes the dependency explicit without changing pull behavior.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/verify-modules.js` — 126 passed
- `npm test` — 32 files, 399 tests passed
- `node tests/test-shell-delegated-actions.js` — 83 passed
- `node tests/test-quality-guardrails.js` — 24 passed
- `npm run quality` — 9 checks passed at 16 consumers / 17 lookups
- `npx playwright test tests/playwright/sync-orchestration-browser-coverage.spec.js --grep "sync pull browser force paths"` — 1 passed
- `./run-tests.sh` — 352 Playwright tests passed; responsive theme matrix 472 passed