### PR TITLE
Inject Biology Score context actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -4,6 +4,7 @@
 import { configureAppEventListeners } from './app-event-listeners.js';
 import { setAIPaused } from './api.js';
 import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js';
+import { configureBiologyScoreContextAIDeps } from './biology-score-context-ai.js';
 import { closeChangelog } from './changelog.js';
 import { configureChatMessageActionDeps } from './chat-actions.js';
 import { configureChatEmptyStateDeps } from './chat-empty-state.js';
@@ -164,6 +165,7 @@ configureSunRuntimeDeps({
   renderLightChannelsLive,
   renderLightTodayStrip,
 });
+configureBiologyScoreContextAIDeps({ navigate });
 configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
 configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
 configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });

--- a/js/biology-score-context-ai.js
+++ b/js/biology-score-context-ai.js
@@ -13,20 +13,30 @@ import {
 } from './lab-context.js';
 import { callClaudeAPI, hasAIProvider, isAIPaused } from './api.js';
 import { state } from './state.js';
-import { escapeAttr, escapeHTML, hashString } from './utils.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { escapeAttr, escapeHTML, hashString, showNotification } from './utils.js';
 
+/** @type {{
+ *   callClaudeAPI: typeof callClaudeAPI,
+ *   hasAIProvider: typeof hasAIProvider,
+ *   isAIPaused: typeof isAIPaused,
+ *   navigate: null | ((route?: string) => void),
+ * }} */
 const biologyScoreContextAIDeps = {
   callClaudeAPI,
   hasAIProvider,
   isAIPaused,
+  navigate: null,
 };
 
+/** @param {Partial<typeof biologyScoreContextAIDeps>} [deps] */
 export function configureBiologyScoreContextAIDeps(deps = {}) {
   const previous = { ...biologyScoreContextAIDeps };
   if (typeof deps.callClaudeAPI === 'function') biologyScoreContextAIDeps.callClaudeAPI = deps.callClaudeAPI;
   if (typeof deps.hasAIProvider === 'function') biologyScoreContextAIDeps.hasAIProvider = deps.hasAIProvider;
   if (typeof deps.isAIPaused === 'function') biologyScoreContextAIDeps.isAIPaused = deps.isAIPaused;
+  if (Object.hasOwn(deps, 'navigate') && (deps.navigate === null || typeof deps.navigate === 'function')) {
+    biologyScoreContextAIDeps.navigate = deps.navigate;
+  }
   return previous;
 }
 
@@ -355,18 +365,16 @@ export function installBiologyScoreContextAIDelegates() {
     if (!['analyze-context-ai','apply-context-ai','dismiss-context-ai'].includes(action)) return;
     event.preventDefault();
     try {
-      const w = /** @type {any} */ (window);
-      const navigate = w.navigate || getViewRuntimeFunction('navigate');
       if (action === 'analyze-context-ai') {
         el.setAttribute('disabled', 'true'); el.textContent = 'Analyzing…';
         const review = await generateBiologyScoreContextReview(getActiveData());
-        await saveBiologyScoreContextReview(review); navigate?.('biology-scores');
+        await saveBiologyScoreContextReview(review); biologyScoreContextAIDeps.navigate?.('biology-scores');
       } else if (action === 'apply-context-ai') {
-        await applyBiologyScoreContextFlag(el.dataset.contextFlag || ''); w.showNotification?.('Context flag applied', 'success'); navigate?.('biology-scores');
+        await applyBiologyScoreContextFlag(el.dataset.contextFlag || ''); showNotification('Context flag applied', 'success'); biologyScoreContextAIDeps.navigate?.('biology-scores');
       } else {
-        await dismissBiologyScoreContextFlag(el.dataset.contextFlag || ''); w.showNotification?.('Context suggestion dismissed', 'info'); navigate?.('biology-scores');
+        await dismissBiologyScoreContextFlag(el.dataset.contextFlag || ''); showNotification('Context suggestion dismissed', 'info'); biologyScoreContextAIDeps.navigate?.('biology-scores');
       }
-    } catch (err) { (/** @type {any} */ (window)).showNotification?.(err?.message || 'Context AI failed', 'error'); }
+    } catch (err) { showNotification(err?.message || 'Context AI failed', 'error'); }
     finally { el.removeAttribute('disabled'); }
   });
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 16,
-  "viewRuntimeBridgeLookups": 17,
+  "viewRuntimeBridgeConsumers": 15,
+  "viewRuntimeBridgeLookups": 16,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 16 &&
-    baseline.viewRuntimeBridgeLookups === 17);
+    baseline.viewRuntimeBridgeConsumers === 15 &&
+    baseline.viewRuntimeBridgeLookups === 16);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -10,6 +10,7 @@ const root = path.resolve(__dirname, '..');
 const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
 const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
+const biologyScoreContextAISrc = fs.readFileSync(path.join(root, 'js/biology-score-context-ai.js'), 'utf8');
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
 const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
@@ -121,6 +122,14 @@ assert('App shell wires Chat prompt consumers without window globals',
     && appShellHooksSrc.includes("import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js'")
     && appShellHooksSrc.includes('configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });')
     && appShellHooksSrc.includes('configureContextCardLifestyleRuntimeDeps({ closeModal, navigate, openChatPanel, useChatPrompt });'));
+
+assert('App shell injects Biology Score context navigation without bridge or window fallbacks',
+  !biologyScoreContextAISrc.includes("from './views-runtime-bridge.js'")
+    && !biologyScoreContextAISrc.includes('window.showNotification')
+    && biologyScoreContextAISrc.includes("biologyScoreContextAIDeps.navigate?.('biology-scores')")
+    && biologyScoreContextAISrc.includes("showNotification('Context flag applied', 'success')")
+    && appShellHooksSrc.includes("import { configureBiologyScoreContextAIDeps } from './biology-score-context-ai.js';")
+    && appShellHooksSrc.includes('configureBiologyScoreContextAIDeps({ navigate });'));
 
 assert('App shell wires Chat close consumers without window globals',
   appShellHooksSrc.includes("import { configureChatEmptyStateDeps } from './chat-empty-state.js'")

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.275';
+self.APP_VERSION = '1.10.276';


### PR DESCRIPTION
## Summary

- inject Biology Score context navigation from the app shell
- replace context-action `window.showNotification` calls with the existing utility export
- remove the module's view-runtime bridge and window fallbacks
- ratchet view-runtime coupling from 16 consumers / 17 lookups to 15 consumers / 16 lookups
- bump the app cache version to `1.10.276`

## Why

The Biology Score context delegate resolved navigation through both `window` and the cycle-sensitive bridge even though the module already exposes a dependency configurator. App-shell injection makes the view dependency explicit, while direct notification imports remove unnecessary browser-global coupling.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-biology-scores.js` — 216 passed
- `node tests/verify-modules.js` — 126 passed
- `npm test` — 32 files, 399 tests passed
- `node tests/test-shell-delegated-actions.js` — 84 passed
- `npm run quality` — 9 checks passed at 15 consumers / 16 lookups
- `./run-tests.sh` — 352 Playwright tests passed; responsive theme matrix 472 passed