### PR TITLE
Inject category page actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -9,6 +9,7 @@ import { closeChangelog } from './changelog.js';
 import { configureChatMessageActionDeps } from './chat-actions.js';
 import { configureChatEmptyStateDeps } from './chat-empty-state.js';
 import { configureCategoryCustomizationRuntimeDeps } from './category-customization-runtime.js';
+import { configureCategoryPageViewDeps } from './category-page-view.js';
 import {
   continueDiscussion,
   endDiscussion,
@@ -95,6 +96,7 @@ import {
   getInitialView,
   navigate,
   refreshMobileDashboardActiveTab,
+  renameCategory,
   renameMarker,
   renderLightChannelsLive,
   renderLightTodayStrip,
@@ -148,6 +150,7 @@ configureSettingsRuntime({
 configureNavActions({ openClientList });
 configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
+configureCategoryPageViewDeps({ renameCategory });
 configureCryptoProfileDeps({ buildSidebar, navigate });
 configureCycleRuntimeDeps({ closeModal, navigate, renderProfileButton });
 configureDataRuntimeDeps({ buildSidebar, navigate, showDetailModal });

--- a/js/category-page-view.js
+++ b/js/category-page-view.js
@@ -23,15 +23,26 @@ import {
   renderFattyAcidsCharts,
 } from './category-view-renderers.js';
 import { markerDetailActionAttrs } from './marker-detail-actions.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const categoryPageActionDelegateRoots = new WeakSet();
 
+/** @type {{ renameCategory: null | ((categoryKey: string) => void) }} */
+const categoryPageViewDeps = {
+  renameCategory: null,
+};
+
+/** @param {Partial<typeof categoryPageViewDeps>} [deps] */
+export function configureCategoryPageViewDeps(deps = {}) {
+  const previous = { ...categoryPageViewDeps };
+  if (Object.hasOwn(deps, 'renameCategory')
+      && (deps.renameCategory === null || typeof deps.renameCategory === 'function')) {
+    categoryPageViewDeps.renameCategory = deps.renameCategory;
+  }
+  return previous;
+}
+
 const CATEGORY_PAGE_ACTION_ATTR = 'data-category-page-action';
 const CATEGORY_PAGE_ACTION_SELECTOR = `[${CATEGORY_PAGE_ACTION_ATTR}]`;
-const appWindow = /** @type {Window & typeof globalThis & {
-  renameCategory?: (categoryKey: string) => void,
-}} */ (typeof window !== 'undefined' ? window : {});
 
 function categoryPageActionAttrs(action, attrs = {}) {
   let html = `${CATEGORY_PAGE_ACTION_ATTR}="${escapeAttr(action)}"`;
@@ -58,8 +69,7 @@ function handleCategoryPageActionClick(event) {
   const categoryKey = actionEl.dataset.categoryPageCategory || '';
   if (!safeMarkerId(categoryKey)) return;
   if (action === 'rename-category') {
-    const renameCategory = appWindow.renameCategory || getViewRuntimeFunction('renameCategory');
-    renameCategory?.(categoryKey);
+    categoryPageViewDeps.renameCategory?.(categoryKey);
   } else if (action === 'switch-view') {
     const view = actionEl.dataset.categoryPageView || '';
     if (view !== 'charts' && view !== 'table' && view !== 'heatmap') return;

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 15,
-  "viewRuntimeBridgeLookups": 16,
+  "viewRuntimeBridgeConsumers": 14,
+  "viewRuntimeBridgeLookups": 15,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/audit-dom.spec.js
+++ b/tests/playwright/audit-dom.spec.js
@@ -5,18 +5,22 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
   await page.waitForFunction(() => !!window._labState);
 
   const results = await page.evaluate(async () => {
-    const [{ state }, dataModule, viewsModule, navModule] = await Promise.all([
+    const [{ state }, dataModule, viewsModule, navModule, categoryPageModule] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/views.js'),
       import('/js/nav.js'),
+      import('/js/category-page-view.js'),
     ]);
     const originalData = state.importedData;
     const originalSex = state.profileSex;
     const originalDob = state.profileDob;
     const originalView = state.currentView;
-    const originalRenameCategory = window.renameCategory;
     const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+    let renameCategoryKey = '';
+    const previousCategoryPageDeps = categoryPageModule.configureCategoryPageViewDeps({
+      renameCategory: key => { renameCategoryKey = key; },
+    });
 
     try {
       if (!state.importedData?.dates?.length) {
@@ -39,8 +43,6 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
         && !!document.querySelector('.gb-table-shell-data')
         && !document.querySelector('.view-toggle')?.innerHTML.includes('onclick=');
 
-      let renameCategoryKey = '';
-      window.renameCategory = key => { renameCategoryKey = key; };
       document.querySelector('[data-category-page-action="rename-category"]')?.click();
       await delay(10);
       const categoryDelegatesRename = renameCategoryKey === 'biochemistry';
@@ -77,7 +79,7 @@ test('audit runtime guards no-op on adversarial marker ids', async ({ page }) =>
       state.importedData = originalData;
       state.profileSex = originalSex;
       state.profileDob = originalDob;
-      window.renameCategory = originalRenameCategory;
+      categoryPageModule.configureCategoryPageViewDeps(previousCategoryPageDeps);
       if (originalView) viewsModule.navigate(originalView);
     }
   });

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 15 &&
-    baseline.viewRuntimeBridgeLookups === 16);
+    baseline.viewRuntimeBridgeConsumers === 14 &&
+    baseline.viewRuntimeBridgeLookups === 15);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -11,6 +11,7 @@ const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'), 'utf8');
 const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
 const biologyScoreContextAISrc = fs.readFileSync(path.join(root, 'js/biology-score-context-ai.js'), 'utf8');
+const categoryPageViewSrc = fs.readFileSync(path.join(root, 'js/category-page-view.js'), 'utf8');
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
 const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
@@ -148,6 +149,13 @@ assert('App shell injects wearable navigation without view bridge lookups',
 
 assert('App shell injects category customization view callbacks',
   appShellHooksSrc.includes('configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });'));
+
+assert('App shell injects category page actions without bridge or window fallbacks',
+  !categoryPageViewSrc.includes("from './views-runtime-bridge.js'")
+    && !categoryPageViewSrc.includes('appWindow.renameCategory')
+    && categoryPageViewSrc.includes('categoryPageViewDeps.renameCategory?.(categoryKey);')
+    && appShellHooksSrc.includes("import { configureCategoryPageViewDeps } from './category-page-view.js';")
+    && appShellHooksSrc.includes('configureCategoryPageViewDeps({ renameCategory });'));
 
 assert('App shell injects crypto cross-tab refresh callbacks without bridge lookups',
   appShellHooksSrc.includes("import { configureCryptoProfileDeps } from './crypto.js'")

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.276';
+self.APP_VERSION = '1.10.277';


### PR DESCRIPTION
## Summary

- inject the category rename action from the app shell
- remove category-page view-runtime bridge and `window.renameCategory` fallbacks
- migrate the live audit browser test to configure and restore the callback explicitly
- ratchet view-runtime coupling from 15 consumers / 16 lookups to 14 consumers / 15 lookups
- bump the app cache version to `1.10.277`

## Why

The category page resolved its rename action through browser globals and the cycle-sensitive bridge even though the concrete action is owned by the app shell. Explicit wiring removes that hidden dependency and makes the browser test exercise the production callback contract.

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `node tests/test-audit.js` — 321 passed
- `node tests/verify-modules.js` — 126 passed
- `npm test` — 32 files, 399 tests passed
- `node tests/test-shell-delegated-actions.js` — 85 passed
- `npm run quality` — 9 checks passed at 14 consumers / 15 lookups
- `npx playwright test tests/playwright/audit-dom.spec.js` — 1 passed
- `npx playwright test tests/playwright/light-env-coverage-batch.spec.js` — 1 passed after an unrelated full-suite timing failure
- `./run-tests.sh` clean retry — 352 Playwright tests passed; responsive theme matrix 472 passed