### PR TITLE
Inject Chat empty-state view actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -96,6 +96,7 @@ import {
   clearDashboardWidgets,
   getInitialView,
   navigate,
+  openChatProviderQuiz,
   refreshMobileDashboardActiveTab,
   renameCategory,
   renameMarker,
@@ -104,6 +105,7 @@ import {
   resetDashboardWidgets,
   revertMarkerName,
   showDetailModal,
+  setOnboardingFocus,
   toggleDashboardOrganizeMode,
 } from './views.js';
 import { configureViewsRouterRuntimeDeps } from './views-router-runtime.js';
@@ -175,7 +177,7 @@ configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
 configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });
 configureLensPageShell({ navigate });
 configureContextCardLifestyleRuntimeDeps({ closeModal, navigate, openChatPanel, useChatPrompt });
-configureChatEmptyStateDeps({ closeChatPanel });
+configureChatEmptyStateDeps({ closeChatPanel, openChatProviderQuiz, setOnboardingFocus });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });
 configureEMFInterpretationRuntimeDeps({ openChatPanel });
 

--- a/js/chat-empty-state.js
+++ b/js/chat-empty-state.js
@@ -13,7 +13,6 @@ import { escapeHTML, escapeAttr, hasCardContent } from './utils.js';
 import { getActivePersonality } from './chat-personalities.js';
 import { getDnaModuleFunction } from './dna-runtime-bridge.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import { resumeChatAIRuntime } from './chat-runtime.js';
 import {
   chatOnboardingActionAttrs,
@@ -34,11 +33,15 @@ const CHAT_EMPTY_STOP_PROPAGATION_ACTIONS = new Set([
 
 const chatEmptyStateDeps = {
   closeChatPanel: () => {},
+  openChatProviderQuiz: () => {},
+  setOnboardingFocus: (_focus) => {},
 };
 
 export function configureChatEmptyStateDeps(deps = {}) {
   const previous = { ...chatEmptyStateDeps };
   if (typeof deps.closeChatPanel === 'function') chatEmptyStateDeps.closeChatPanel = deps.closeChatPanel;
+  if (typeof deps.openChatProviderQuiz === 'function') chatEmptyStateDeps.openChatProviderQuiz = deps.openChatProviderQuiz;
+  if (typeof deps.setOnboardingFocus === 'function') chatEmptyStateDeps.setOnboardingFocus = deps.setOnboardingFocus;
   return previous;
 }
 
@@ -55,16 +58,10 @@ function closestChatEmptyAction(event, selector = '[data-chat-empty-action]') {
   return event.currentTarget?.contains(actionEl) ? actionEl : null;
 }
 
-function chatEmptyRuntime() {
-  return /** @type {Record<string, any>} */ (globalThis);
-}
-
 function callChatEmptyRuntime(name, ...args) {
   const fn = getSettingsModuleFunction(name)
-    || getDnaModuleFunction(name)
-    || chatEmptyRuntime()[name];
-  const runtimeFn = typeof fn === 'function' ? fn : getViewRuntimeFunction(name);
-  return runtimeFn ? runtimeFn(...args) : undefined;
+    || getDnaModuleFunction(name);
+  return typeof fn === 'function' ? fn(...args) : undefined;
 }
 
 function closeChatPanel() {
@@ -116,7 +113,7 @@ function handleChatEmptyClick(event) {
   } else if (action === 'request-lab-import-provider') {
     requestOnboardingLabImportProvider();
   } else if (action === 'open-provider-quiz') {
-    callChatEmptyRuntime('openChatProviderQuiz');
+    chatEmptyStateDeps.openChatProviderQuiz();
   } else if (action === 'scroll-context-cards') {
     const currentTarget = event.currentTarget instanceof Element ? event.currentTarget : null;
     currentTarget?.querySelector('.chat-context-cards')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -125,7 +122,7 @@ function handleChatEmptyClick(event) {
   } else if (action === 'start-file-import') {
     startOnboardingFileImport();
   } else if (action === 'set-onboarding-focus') {
-    callChatEmptyRuntime('setOnboardingFocus', actionEl.dataset.focus || '');
+    chatEmptyStateDeps.setOnboardingFocus(actionEl.dataset.focus || '');
   }
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 13,
-  "viewRuntimeBridgeLookups": 14,
+  "viewRuntimeBridgeConsumers": 12,
+  "viewRuntimeBridgeLookups": 13,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/chat-empty-state.spec.js
+++ b/tests/playwright/chat-empty-state.spec.js
@@ -377,7 +377,7 @@ test('chat empty-state renders remaining prompt states and actions', async ({ pa
 
   const results = await page.evaluate(async () => {
     const [
-      { renderEmptyChatState, _getNoDataPrompts },
+      { configureChatEmptyStateDeps, renderEmptyChatState, _getNoDataPrompts },
       { state },
       data,
       chatOnboarding,
@@ -409,14 +409,16 @@ test('chat empty-state renders remaining prompt states and actions', async ({ pa
       return [key, sessionStorage.getItem(key)];
     }));
     const savedFns = {
-      openChatProviderQuiz: window.openChatProviderQuiz,
-      setOnboardingFocus: window.setOnboardingFocus,
       showNotification: window.showNotification,
       inputClick: HTMLInputElement.prototype.click,
       scrollIntoView: Element.prototype.scrollIntoView,
     };
     const outcomes = {};
     const calls = [];
+    const previousChatEmptyStateDeps = configureChatEmptyStateDeps({
+      openChatProviderQuiz: () => calls.push(['provider-quiz']),
+      setOnboardingFocus: focus => calls.push(['focus', focus]),
+    });
     const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
       resumeAI: () => calls.push(['resume-ai']),
     });
@@ -531,8 +533,6 @@ test('chat empty-state renders remaining prompt states and actions', async ({ pa
       } else {
         pdfInput.value = '';
       }
-      window.openChatProviderQuiz = () => calls.push(['provider-quiz']);
-      window.setOnboardingFocus = focus => calls.push(['focus', focus]);
       window.showNotification = (message, tone) => calls.push(['notification', message, tone]);
       chatOnboarding.configureChatOnboarding({
         closeChatPanel: () => calls.push(['close-chat']),
@@ -721,9 +721,8 @@ test('chat empty-state renders remaining prompt states and actions', async ({ pa
         if (key && value != null) sessionStorage.setItem(key, value);
       }
       chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
+      configureChatEmptyStateDeps(previousChatEmptyStateDeps);
       Object.assign(window, {
-        openChatProviderQuiz: savedFns.openChatProviderQuiz,
-        setOnboardingFocus: savedFns.setOnboardingFocus,
         showNotification: savedFns.showNotification,
       });
       chatOnboarding.configureChatOnboarding({

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 13 &&
-    baseline.viewRuntimeBridgeLookups === 14);
+    baseline.viewRuntimeBridgeConsumers === 12 &&
+    baseline.viewRuntimeBridgeLookups === 13);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -12,6 +12,7 @@ const appEventsSrc = fs.readFileSync(path.join(root, 'js/app-event-listeners.js'
 const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
 const biologyScoreContextAISrc = fs.readFileSync(path.join(root, 'js/biology-score-context-ai.js'), 'utf8');
 const categoryPageViewSrc = fs.readFileSync(path.join(root, 'js/category-page-view.js'), 'utf8');
+const chatEmptyStateSrc = fs.readFileSync(path.join(root, 'js/chat-empty-state.js'), 'utf8');
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
 const lensPageShellSrc = fs.readFileSync(path.join(root, 'js/lens-page-shell.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
@@ -136,8 +137,15 @@ assert('App shell injects Biology Score context navigation without bridge or win
 assert('App shell wires Chat close consumers without window globals',
   appShellHooksSrc.includes("import { configureChatEmptyStateDeps } from './chat-empty-state.js'")
     && appShellHooksSrc.includes("import { configureDashboardPageRuntimeDeps } from './dashboard-page-view.js'")
-    && appShellHooksSrc.includes('configureChatEmptyStateDeps({ closeChatPanel });')
+    && appShellHooksSrc.includes('configureChatEmptyStateDeps({ closeChatPanel, openChatProviderQuiz, setOnboardingFocus });')
     && appShellHooksSrc.includes('configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });'));
+
+assert('App shell injects Chat empty-state view callbacks without bridge or global fallbacks',
+  !chatEmptyStateSrc.includes("from './views-runtime-bridge.js'")
+    && !chatEmptyStateSrc.includes('chatEmptyRuntime()')
+    && chatEmptyStateSrc.includes('chatEmptyStateDeps.openChatProviderQuiz();')
+    && chatEmptyStateSrc.includes("chatEmptyStateDeps.setOnboardingFocus(actionEl.dataset.focus || '');")
+    && appShellHooksSrc.includes('configureChatEmptyStateDeps({ closeChatPanel, openChatProviderQuiz, setOnboardingFocus });'));
 
 assert('App shell wires remaining Chat open consumers without window globals',
   appShellHooksSrc.includes('configureEMFInterpretationRuntimeDeps({ openChatPanel });')

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.278';
+self.APP_VERSION = '1.10.279';


### PR DESCRIPTION
## Window-coupling campaign progress

| Metric | Starting baseline (#1235) | Main before this PR | After this PR | Total removed |
|---|---:|---:|---:|---:|
| View-runtime consumer modules | 29 | 13 | 12 | 17 (59%) |
| View-runtime bridge lookups | 44 | 14 | 13 | 31 (70%) |

- 16 migration PRs are already merged (#1237–#1252); this is the next reduction.
- This PR removes 1 consumer module and 1 lookup.
- Remaining queue after merge: `context-card-editor-ui.js`, `dashboard-recommendation-widget.js`, `emf.js`, `nav-runtime.js`, `utils-runtime.js` (2 lookups), `emf-interpretation.js`, `wearables-runtime.js`, `provider-panels.js`, `notes-runtime.js`, `chat-runtime.js`, `recommendations-runtime.js`, and `wearables-detail-runtime.js`.
- Completion criterion: remove every safe unnecessary view-runtime/window dependency, then document any coupling that must remain intentional.

## This reduction

- inject Chat empty-state provider-quiz and onboarding-focus callbacks from the app shell
- remove the view-runtime bridge import and generic `globalThis` fallback
- retain dedicated Settings and DNA module bridges for their cycle-safe actions
- migrate browser coverage from window stubs to explicit dependency injection
- ratchet view-runtime coupling to 12 consumers / 13 lookups
- bump the app version to 1.10.279

## Delivery status

- [x] Implementation complete
- [x] Focused Chat empty-state browser coverage passes (3/3)
- [x] TypeScript and static quality checks pass
- [x] Full local regression suite passes
- [x] GitHub Tests, CodeQL, and JavaScript analysis pass
- [x] Greptile review passes (5/5)
- [x] Review-thread scan is clean
- [x] Ready to merge

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality` — 12/12 consumers, 13/13 lookups
- `node tests/test-shell-delegated-actions.js` — 87 passed
- `node tests/test-chat-empty-state-delegated-actions.js` — 31 passed
- `npx playwright test tests/playwright/chat-empty-state.spec.js` — 3 passed
- `./run-tests.sh` — 126 module checks, 32 Vitest files / 399 tests, 352 Playwright tests, 472 theme assertions
- GitHub Tests — passed in 8m21s