### PR TITLE
Inject sidebar navigation actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -89,6 +89,7 @@ import { configureLensPageShell } from './lens-page-shell.js';
 import { closeModal } from './marker-detail-modal.js';
 import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
 import { buildSidebar, closeMobileSidebar, configureNavActions, renderProfileButton, toggleMobileSidebar } from './nav.js';
+import { configureNavRuntime } from './nav-runtime.js';
 import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime, openSettingsModal } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
@@ -97,6 +98,7 @@ import {
   getInitialView,
   navigate,
   openChatProviderQuiz,
+  openCreateMarkerModal,
   refreshMobileDashboardActiveTab,
   renameCategory,
   renameMarker,
@@ -151,6 +153,7 @@ configureSettingsRuntime({
 });
 
 configureNavActions({ openClientList });
+configureNavRuntime({ navigate, openCreateMarkerModal });
 configureClientListRuntimeDeps({ navigate, renderProfileButton });
 configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });
 configureCategoryPageViewDeps({ renameCategory });

--- a/js/nav-runtime.js
+++ b/js/nav-runtime.js
@@ -4,10 +4,11 @@
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { openReportBuilder } from './export.js';
 import { openContextModalRuntime } from './context-cards-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const navRuntimeDeps = {
+  navigate: (_route) => {},
   openEMFAssessmentEditor,
+  openCreateMarkerModal: () => {},
   openReportBuilder,
 };
 
@@ -16,6 +17,12 @@ export function configureNavRuntime(deps = {}) {
   if (typeof deps.openEMFAssessmentEditor === 'function') {
     navRuntimeDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
   }
+  if (typeof deps.navigate === 'function') {
+    navRuntimeDeps.navigate = deps.navigate;
+  }
+  if (typeof deps.openCreateMarkerModal === 'function') {
+    navRuntimeDeps.openCreateMarkerModal = deps.openCreateMarkerModal;
+  }
   if (typeof deps.openReportBuilder === 'function') {
     navRuntimeDeps.openReportBuilder = deps.openReportBuilder;
   }
@@ -23,30 +30,10 @@ export function configureNavRuntime(deps = {}) {
 }
 
 /**
- * @returns {Record<string, any>}
- */
-function getNavRuntimeScope() {
-  return typeof window !== 'undefined'
-    ? /** @type {Record<string, any>} */ (window)
-    : /** @type {Record<string, any>} */ (globalThis);
-}
-
-/**
- * @param {string} name
- * @returns {((...args: any[]) => any) | null}
- */
-function getNavRuntimeFunction(name) {
-  const runtime = getNavRuntimeScope();
-  const fn = runtime[name];
-  if (typeof fn === 'function') return fn.bind(runtime);
-  return typeof window !== 'undefined' ? getViewRuntimeFunction(name) : null;
-}
-
-/**
  * @param {string} route
  */
 export function navigateFromNavRuntime(route) {
-  getNavRuntimeFunction('navigate')?.(route);
+  navRuntimeDeps.navigate(route);
 }
 
 export function openEMFAssessmentFromNavRuntime() {
@@ -62,5 +49,5 @@ export function openContextFromNavRuntime() {
 }
 
 export function openCreateMarkerFromNavRuntime() {
-  getNavRuntimeFunction('openCreateMarkerModal')?.();
+  navRuntimeDeps.openCreateMarkerModal();
 }

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 12,
-  "viewRuntimeBridgeLookups": 13,
+  "viewRuntimeBridgeConsumers": 11,
+  "viewRuntimeBridgeLookups": 12,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/nav-delegated-actions.spec.js
+++ b/tests/playwright/nav-delegated-actions.spec.js
@@ -34,8 +34,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
     const origCurrentView = state.currentView;
     const origImportedData = state.importedData;
     const origProfiles = state.profiles;
-    const origNavigate = window.navigate;
-    const origOpenCreateMarker = window.openCreateMarkerModal;
     const origGroupStorage = localStorage.getItem('labcharts-navgroup-Hormones');
     let restoreNavActions = null;
     let restoreNavRuntime = null;
@@ -69,13 +67,14 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       localStorage.removeItem('labcharts-navgroup-Hormones');
 
       const calls = [];
-      window.navigate = route => {
-        calls.push(['navigate', route]);
-        state.currentView = route;
-        nav.syncSidebarActive(route);
-      };
       restoreNavRuntime = navRuntime.configureNavRuntime({
+        navigate: route => {
+          calls.push(['navigate', route]);
+          state.currentView = route;
+          nav.syncSidebarActive(route);
+        },
         openEMFAssessmentEditor: () => calls.push(['open-emf']),
+        openCreateMarkerModal: () => calls.push(['open-custom-marker']),
         openReportBuilder: () => calls.push(['open-report-builder']),
       });
       restoreNavActions = nav.configureNavActions({
@@ -85,7 +84,6 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       restoreContextCardsRuntime = contextCardsRuntime.configureContextCardsRuntimeCallbacks({
         openContextModal: () => calls.push(['open-context']),
       });
-      window.openCreateMarkerModal = () => calls.push(['open-custom-marker']);
       nav.buildSidebar(fixtureData);
       nav.renderProfileButton();
       nav.openRecommendationsFromSidebar();
@@ -145,11 +143,9 @@ test('sidebar nav delegated actions route, filter, and open utilities', async ({
       state.currentView = origCurrentView;
       state.importedData = origImportedData;
       state.profiles = origProfiles;
-      window.navigate = origNavigate;
       if (restoreNavRuntime) navRuntime.configureNavRuntime(restoreNavRuntime);
       if (restoreNavActions) nav.configureNavActions(restoreNavActions);
       if (restoreContextCardsRuntime) contextCardsRuntime.configureContextCardsRuntimeCallbacks(restoreContextCardsRuntime);
-      window.openCreateMarkerModal = origOpenCreateMarker;
       if (origGroupStorage == null) localStorage.removeItem('labcharts-navgroup-Hormones');
       else localStorage.setItem('labcharts-navgroup-Hormones', origGroupStorage);
       nav.buildSidebar();

--- a/tests/test-nav-delegated-actions.js
+++ b/tests/test-nav-delegated-actions.js
@@ -7,7 +7,9 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
+const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
 const navSrc = fs.readFileSync(path.join(root, 'js/nav.js'), 'utf8');
+const navRuntimeSrc = fs.readFileSync(path.join(root, 'js/nav-runtime.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -43,6 +45,13 @@ assert('nav.js routes external actions through adapters and publishes no globals
     navSrc.includes('navActionDeps.openClientList()') &&
     !navSrc.includes('exposeNavRuntimeGlobals') &&
     !/\bwindow(?:\.|\s*\[)/.test(navSrc));
+assert('App shell injects nav view actions without bridge or window fallbacks',
+  !navRuntimeSrc.includes("from './views-runtime-bridge.js'")
+    && !navRuntimeSrc.includes('getNavRuntimeScope')
+    && navRuntimeSrc.includes('navRuntimeDeps.navigate(route);')
+    && navRuntimeSrc.includes('navRuntimeDeps.openCreateMarkerModal();')
+    && appShellHooksSrc.includes("import { configureNavRuntime } from './nav-runtime.js';")
+    && appShellHooksSrc.includes('configureNavRuntime({ navigate, openCreateMarkerModal });'));
 
 [
   'navigate',

--- a/tests/test-nav-runtime.js
+++ b/tests/test-nav-runtime.js
@@ -11,7 +11,6 @@ import {
   openReportBuilderFromNavRuntime,
 } from '../js/nav-runtime.js';
 import { configureContextCardsRuntimeCallbacks } from '../js/context-cards-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let passed = 0;
 let failed = 0;
@@ -28,47 +27,17 @@ function assert(name, condition, detail = '') {
 
 console.log('=== Nav Runtime Tests ===');
 
-const runtimeKeys = [
-  'window',
-  'navigate',
-  'openContextModal',
-  'openCreateMarkerModal',
-];
-const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
-
-function setRuntimeValue(key, value) {
-  Object.defineProperty(globalThis, key, {
-    configurable: true,
-    writable: true,
-    enumerable: true,
-    value,
-  });
-}
-
-function restoreRuntime() {
-  for (const key of runtimeKeys) {
-    const descriptor = savedDescriptors.get(key);
-    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
-    else delete globalThis[key];
-  }
-}
-
+const calls = [];
+const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
+  openContextModal: () => calls.push(['context', true]),
+});
+const restoreNavRuntime = configureNavRuntime({
+  navigate: route => calls.push(['navigate', route, true]),
+  openEMFAssessmentEditor: () => calls.push(['emf', true]),
+  openCreateMarkerModal: () => calls.push(['marker', true]),
+  openReportBuilder: () => calls.push(['report', true]),
+});
 try {
-  const calls = [];
-  const previousContextCardsRuntime = configureContextCardsRuntimeCallbacks({
-    openContextModal: () => calls.push(['context', true]),
-  });
-  const browserRuntime = {
-    navigate(route) { calls.push(['navigate', route, this === browserRuntime]); },
-    openContextModal() { calls.push(['legacy-context']); },
-    openCreateMarkerModal() { calls.push(['marker', this === browserRuntime]); },
-  };
-  setRuntimeValue('window', browserRuntime);
-  const restoreNavRuntime = configureNavRuntime({
-    openEMFAssessmentEditor: () => calls.push(['emf', true]),
-    openReportBuilder: () => calls.push(['report', true]),
-  });
-
   navigateFromNavRuntime('labs');
   openEMFAssessmentFromNavRuntime();
   openReportBuilderFromNavRuntime();
@@ -80,33 +49,22 @@ try {
       && calls.some(call => call[0] === 'navigate' && call[1] === 'labs' && call[2] === true)
       && ['emf', 'report', 'context', 'marker'].every(name => calls.some(call => call[0] === name && call[1] === true)));
 
-  for (const key of ['navigate', 'openContextModal', 'openCreateMarkerModal']) {
-    delete browserRuntime[key];
-  }
-  const previousViewRuntime = configureViewRuntime({
-    navigate: route => calls.push(['module-navigate', route]),
-  });
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
-  configureNavRuntime({ openEMFAssessmentEditor: () => {}, openReportBuilder: () => {} });
+  configureNavRuntime({
+    navigate: () => {},
+    openEMFAssessmentEditor: () => {},
+    openCreateMarkerModal: () => {},
+    openReportBuilder: () => {},
+  });
   navigateFromNavRuntime('missing');
   openEMFAssessmentFromNavRuntime();
   openReportBuilderFromNavRuntime();
   openContextFromNavRuntime();
   openCreateMarkerFromNavRuntime();
-  assert('nav runtime falls back to module navigation when the browser callback is missing',
-    calls.length === 6 && calls.some(call => call[0] === 'module-navigate' && call[1] === 'missing'));
-
-  delete globalThis.window;
-  let globalRoute = '';
-  setRuntimeValue('navigate', route => { globalRoute = route; });
-  navigateFromNavRuntime('recommendations');
-  assert('nav runtime falls back to globalThis without window',
-    globalRoute === 'recommendations');
-  configureViewRuntime(previousViewRuntime);
+  assert('nav runtime tolerates safe configured no-op callbacks', calls.length === 5);
+} finally {
   configureNavRuntime(restoreNavRuntime);
   configureContextCardsRuntimeCallbacks(previousContextCardsRuntime);
-} finally {
-  restoreRuntime();
 }
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 12 &&
-    baseline.viewRuntimeBridgeLookups === 13);
+    baseline.viewRuntimeBridgeConsumers === 11 &&
+    baseline.viewRuntimeBridgeLookups === 12);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.279';
+self.APP_VERSION = '1.10.280';


### PR DESCRIPTION
## Window-coupling campaign progress

| Metric | Starting baseline (#1235) | Main before this PR | After this PR | Total removed |
|---|---:|---:|---:|---:|
| View-runtime consumer modules | 29 | 12 | 11 | 18 (62%) |
| View-runtime bridge lookups | 44 | 13 | 12 | 32 (73%) |

- 17 migration PRs are already merged (#1237–#1253); this is the next reduction.
- This PR removes 1 consumer module and 1 lookup.
- Remaining queue after merge: `context-card-editor-ui.js`, `dashboard-recommendation-widget.js`, `emf.js`, `utils-runtime.js` (2 lookups), `emf-interpretation.js`, `wearables-runtime.js`, `provider-panels.js`, `notes-runtime.js`, `chat-runtime.js`, `recommendations-runtime.js`, and `wearables-detail-runtime.js`.
- Campaign checkpoint: pause after this PR merges; resume later from 11 consumers / 12 lookups.
- Completion criterion: remove every safe unnecessary view-runtime/window dependency, then document any coupling that must remain intentional.

## This reduction

- inject sidebar navigation and custom-marker actions through the existing nav runtime configurator
- remove the view-runtime bridge import, `window` probe, and generic runtime-scope fallback
- retain direct module paths for EMF, reports, and Context
- migrate Node and browser coverage to explicit dependency injection
- ratchet view-runtime coupling to 11 consumers / 12 lookups
- bump the app version to 1.10.280

## Delivery status

- [x] Implementation complete
- [x] Focused sidebar browser coverage passes (2/2)
- [x] TypeScript and static quality checks pass
- [x] Full local regression suite passes
- [x] GitHub Tests, CodeQL, and JavaScript analysis pass
- [x] Greptile review passes (5/5)
- [x] Review-thread scan is clean
- [x] Ready to merge

## Validation

- `npm run typecheck`
- `npm run typecheck:checkjs`
- `npm run quality` — 11/11 consumers, 12/12 lookups
- `node tests/test-nav-runtime.js` — 3 passed
- `node tests/test-nav-delegated-actions.js` — 21 passed
- `npx playwright test tests/playwright/nav-delegated-actions.spec.js` — 2 passed
- First `./run-tests.sh` — 351/352 Playwright; unrelated sidebar-search legacy fixture failed
- Isolated legacy fixture rerun — 1/1 passed
- Second `./run-tests.sh` — 126 module checks, 32 Vitest files / 399 tests, 352 Playwright tests, 472 theme assertions
- GitHub Tests — passed in 8m40s