### PR TITLE
Show Kimi K3 across AI providers

### DIFF
--- a/js/api-models.js
+++ b/js/api-models.js
@@ -46,7 +46,7 @@ const OPENROUTER_CURATED = [
   'deepseek/deepseek',
   'qwen/qwen', 'qwen/qwq',
   'z-ai/glm-5',
-  'moonshotai/kimi-k2',
+  'moonshotai/kimi-',
   'x-ai/grok',
 ];
 
@@ -61,17 +61,17 @@ const OPENROUTER_RECOMMENDED = [
   'openai/gpt-5.6-sol', 'openai/gpt-5.4',
   'google/gemini-3.5-flash', 'google/gemini-3-flash-preview',
   'z-ai/glm-5.2',
-  'moonshotai/kimi-k2.7-code', 'moonshotai/kimi-k2.6',
+  'moonshotai/kimi-k3',
   'x-ai/grok-4',
 ];
 const OPENROUTER_DEFAULT_CANDIDATES = ['openai/gpt-5.6-sol', 'anthropic/claude-sonnet-5', 'anthropic/claude-sonnet-4.6'];
 
 // Routstr uses bare model IDs (no provider prefix, dots: claude-sonnet-4.6)
-const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.2', 'z-ai/glm-5.2', 'kimi-k2.7-code', 'moonshotai/kimi-k2.7-code', 'kimi-k2.6', 'moonshotai/kimi-k2.6', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
+const ROUTSTR_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'glm-5.2', 'z-ai/glm-5.2', 'kimi-k3', 'moonshotai/kimi-k3', 'x-ai/grok-4.3', 'grok-4.3', 'grok-4'];
 const ROUTSTR_PRIVATE_RECOMMENDED = ['tinfoil-gemma4-31b', 'tinfoil-kimi-k2-6', 'tinfoil-deepseek-v4-pro', 'tinfoil-glm-5-2'];
 
 // PPQ uses bare model IDs for regular routing and private/ IDs for Tinfoil TEE models.
-const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.2', 'glm-5.2', 'moonshotai/kimi-k2.7-code', 'kimi-k2.7-code', 'moonshotai/kimi-k2.6', 'kimi-k2.6', 'x-ai/grok-4.3', 'grok-4'];
+const PPQ_RECOMMENDED = ['claude-sonnet-5', 'claude-sonnet-4.6', 'claude-opus-4.8', 'claude-opus-4.7', 'gpt-5.5', 'gpt-5.4', 'gemini-3.5-flash', 'gemini-3-flash-preview', 'z-ai/glm-5.2', 'glm-5.2', 'moonshotai/kimi-k3', 'kimi-k3', 'x-ai/grok-4.3', 'grok-4'];
 const PPQ_PRIVATE_RECOMMENDED = ['private/kimi-k2-6', 'private/glm-5-2', 'private/gpt-oss-120b'];
 
 function normalizedModelId(modelId) {
@@ -88,7 +88,7 @@ function isCustomRecommendedModel(modelId) {
     || /(^|[/-])gpt-5-[45]($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])gemini-3-(5-flash|flash-preview)($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])glm-5-2($|[-:])/.test(normalizedModelId(modelId))
-    || /(^|[/-])kimi-k2-(7-code|6)($|[-:])/.test(normalizedModelId(modelId))
+    || /(^|[/-])kimi-k3($|[-:])/.test(normalizedModelId(modelId))
     || /(^|[/-])grok-4($|[-:])/.test(normalizedModelId(modelId));
 }
 
@@ -126,7 +126,7 @@ export function isRecommendedModel(provider, modelId) {
     if (modelId.startsWith('e2ee-')) return /qwen3-5-122b|gpt-oss-120b|qwen3-30b|glm-5/.test(modelId);
     // claude-(sonnet-5|sonnet-4-6|opus-4-8|opus-4-7) is intentionally narrow. When newer
     // versions land, broaden the alternation rather than matching all 4.x.
-    return /^(claude-(sonnet-5|sonnet-4-6|opus-4-8|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3-(5-flash|flash-preview)|zai-org-glm-5-2|z-ai-glm-5-2|glm-5-2|kimi-k2-7-code|kimi-k2-6|grok-4[1-9]?)(-|$)/.test(modelId);
+    return /^(claude-(sonnet-5|sonnet-4-6|opus-4-8|opus-4-7)|openai-gpt-5[2345](-codex)?|gemini-3-(5-flash|flash-preview)|zai-org-glm-5-2|z-ai-glm-5-2|glm-5-2|kimi-k3|grok-4[1-9]?)(-|$)/.test(modelId);
   }
   if (provider === 'routstr') {
     if (modelId.startsWith('tinfoil-')) return ROUTSTR_PRIVATE_RECOMMENDED.includes(modelId);

--- a/js/api-ppq.js
+++ b/js/api-ppq.js
@@ -23,7 +23,7 @@ import { callOpenAICompatibleAPI } from './api-openai-compatible.js';
 
 const apiWindow = /** @type {PpqApiWindow} */ (typeof window !== 'undefined' ? window : {});
 
-const PPQ_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'google/gemini-3', 'google/gemini-2', 'glm-5', 'z-ai/glm-5', 'kimi-k2', 'moonshotai/kimi-k2', 'grok-', 'x-ai/grok-4', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
+const PPQ_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gpt-oss', 'gemini-3', 'gemini-2', 'google/gemini-3', 'google/gemini-2', 'glm-5', 'z-ai/glm-5', 'moonshotai/kimi-', 'grok-', 'x-ai/grok-4', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'kimi', 'perplexity'];
 const PPQ_DEFAULT_CANDIDATES = ['gpt-5.5', 'openai/gpt-5.5', 'claude-sonnet-5', 'claude-sonnet-4.6'];
 const PPQ_EXCLUDE = ['codex', 'audio', 'image', 'embed', 'tts', 'whisper', 'video', 'nano-banana'];
 const PPQ_PRIVATE_MODELS = [

--- a/js/api-routstr.js
+++ b/js/api-routstr.js
@@ -18,7 +18,7 @@ import {
 import { callOpenAICompatibleAPI } from './api-openai-compatible.js';
 import { notifyRoutstrRequestSettled } from './routstr-balance-settlement.js';
 
-const ROUTSTR_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gemini-3', 'gemini-2', 'glm-5', 'z-ai/glm-5', 'kimi-k2', 'moonshotai/kimi-k2', 'grok-4', 'x-ai/grok-4', 'grok-3', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'mimo-'];
+const ROUTSTR_CURATED = ['claude-', 'gpt-5', 'gpt-4', 'gemini-3', 'gemini-2', 'glm-5', 'z-ai/glm-5', 'kimi-', 'moonshotai/kimi-', 'grok-4', 'x-ai/grok-4', 'grok-3', 'llama-', 'qwen', 'deepseek-', 'mistral-', 'mimo-'];
 const ROUTSTR_DEFAULT_CANDIDATES = ['gpt-5.5', 'openai/gpt-5.5', 'claude-sonnet-5', 'claude-sonnet-4.6'];
 const ROUTSTR_EXCLUDE = ['codex', 'audio', 'image', 'oss', 'safeguard', 'coder', 'embed', 'tts', 'whisper', 'beta', 'preview', 'free', 'gratis'];
 const ROUTSTR_PRIVATE_REQUEST_TIMEOUT_MS = 180000;

--- a/tests/api-provider-runtime.test.js
+++ b/tests/api-provider-runtime.test.js
@@ -122,6 +122,12 @@ describe('API provider runtime behavior', () => {
           architecture: { modality: 'text->text' },
         },
         {
+          id: 'moonshotai/kimi-k3',
+          name: 'Kimi K3',
+          pricing: { prompt: '0.000003', completion: '0.000015' },
+          architecture: { modality: 'text+image->text' },
+        },
+        {
           id: 'anthropic/claude-sonnet-4.6:2026-01-01',
           name: 'Claude Sonnet dated duplicate',
           pricing: { prompt: '0.000003', completion: '0.000015' },
@@ -142,8 +148,9 @@ describe('API provider runtime behavior', () => {
       'google/gemini-3.5-flash',
       'z-ai/glm-5.2',
       'openai/gpt-5.6-sol',
-      'moonshotai/kimi-k2.7-code',
+      'moonshotai/kimi-k3',
       'openai/gpt-5.5',
+      'moonshotai/kimi-k2.7-code',
     ]);
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-pricing'))).toMatchObject({
       'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
@@ -151,11 +158,13 @@ describe('API provider runtime behavior', () => {
       'google/gemini-3.5-flash': { input: 0.7, output: 3.75 },
       'z-ai/glm-5.2': { input: 1, output: 3 },
       'moonshotai/kimi-k2.7-code': { input: 0.56, output: 3.5 },
+      'moonshotai/kimi-k3': { input: 3, output: 15 },
       'openai/gpt-5.6-sol': { input: 5, output: 30 },
     });
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('anthropic/claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('google/gemini-3.5-flash');
+    expect(JSON.parse(localStorage.getItem('labcharts-openrouter-vision-models'))).toContain('moonshotai/kimi-k3');
     expect(localStorage.getItem('labcharts-openrouter-model')).toBe('openai/gpt-5.6-sol');
 
     expect(await fetchOpenRouterModelPricing('openai/gpt-5.6-sol')).toEqual({ input: 5, output: 30 });
@@ -186,6 +195,7 @@ describe('API provider runtime behavior', () => {
         { id: 'claude-sonnet-4.6-20260101', name: 'Claude duplicate', enabled: true },
         { id: 'grok-41-fast', name: 'Grok 4.1 Fast', enabled: true, pricing: { prompt: '0.00000025', completion: '0.00000063' } },
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' } },
+        { id: 'moonshotai/kimi-k3', name: 'Kimi K3', enabled: true, pricing: { prompt: '0.000003', completion: '0.000015' }, architecture: { input_modalities: ['text', 'image'] } },
         { id: 'gpt-5-preview', name: 'Preview', enabled: true },
         { id: 'grok-4', name: 'Disabled', enabled: false },
       ],
@@ -194,14 +204,16 @@ describe('API provider runtime behavior', () => {
     const routstrModels = await fetchRoutstrModels();
 
     expect(fetch).toHaveBeenCalledWith('https://node.example.com/v1/models');
-    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'z-ai/glm-5.2', 'grok-41-fast', 'x-ai/grok-4.3', 'llama-3.1-8b']);
+    expect(routstrModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'z-ai/glm-5.2', 'grok-41-fast', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'llama-3.1-8b']);
     expect(localStorage.getItem('labcharts-routstr-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['z-ai/glm-5.2']).toEqual({ input: 1, output: 3 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['x-ai/grok-4.3']).toEqual({ input: 3, output: 15 });
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-pricing'))['moonshotai/kimi-k3']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('claude-sonnet-5');
+    expect(JSON.parse(localStorage.getItem('labcharts-routstr-vision-models'))).toContain('moonshotai/kimi-k3');
 
     fetch.mockResolvedValueOnce(jsonResponse({
       data: [
@@ -213,22 +225,25 @@ describe('API provider runtime behavior', () => {
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3', pricing: { input_per_1M_tokens: '3', output_per_1M_tokens: '15' } },
         { id: 'grok-4.20', name: 'Grok 4.20', pricing: { input_per_1M_tokens: '2', output_per_1M_tokens: '10' } },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code', pricing: { input_per_1M_tokens: '0.56', output_per_1M_tokens: '3.5' } },
+        { id: 'moonshotai/kimi-k3', name: 'Kimi K3', pricing: { input_per_1M_tokens: '3.165', output_per_1M_tokens: '15.825' }, architecture: { modality: 'text+image->text' } },
         { id: 'gpt-4-audio-preview', name: 'Audio' },
       ],
     }));
 
     const ppqModels = await fetchPpqModels('sk-ppq');
 
-    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'google/gemini-3.5-flash', 'z-ai/glm-5.2', 'grok-4.20', 'x-ai/grok-4.3', 'moonshotai/kimi-k2.7-code', 'perplexity/sonar']);
+    expect(ppqModels.map(m => m.id)).toEqual(['claude-sonnet-4.6', 'claude-sonnet-5', 'google/gemini-3.5-flash', 'z-ai/glm-5.2', 'grok-4.20', 'x-ai/grok-4.3', 'moonshotai/kimi-k3', 'moonshotai/kimi-k2.7-code', 'perplexity/sonar']);
     expect(localStorage.getItem('labcharts-ppq-model')).toBe('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-4.6']).toEqual({ input: 3, output: 15 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['claude-sonnet-5']).toEqual({ input: 2, output: 10 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['google/gemini-3.5-flash']).toEqual({ input: 0.7, output: 3.75 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['z-ai/glm-5.2']).toEqual({ input: 1, output: 3.2 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['moonshotai/kimi-k2.7-code']).toEqual({ input: 0.56, output: 3.5 });
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-pricing'))['moonshotai/kimi-k3']).toEqual({ input: 3.165, output: 15.825 });
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-4.6');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('claude-sonnet-5');
     expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('google/gemini-3.5-flash');
+    expect(JSON.parse(localStorage.getItem('labcharts-ppq-vision-models'))).toContain('moonshotai/kimi-k3');
   });
 
   it('uses GPT 5.5 then Claude as fetched defaults and GLM 5.2 for private modes', async () => {
@@ -454,26 +469,37 @@ describe('API provider runtime behavior', () => {
     expect(isRecommendedModel('openrouter', 'openai/gpt-5.5')).toBe(false);
     expect(isRecommendedModel('openrouter', 'google/gemini-3.5-flash')).toBe(true);
     expect(isRecommendedModel('openrouter', 'z-ai/glm-5.2')).toBe(true);
-    expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k2.7-code')).toBe(true);
+    expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k2.7-code')).toBe(false);
+    expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k2.6')).toBe(false);
+    expect(isRecommendedModel('openrouter', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('openrouter', 'google/gemini-3.1-pro')).toBe(false);
     expect(isRecommendedModel('venice', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('venice', 'gemini-3-5-flash')).toBe(true);
     expect(isRecommendedModel('venice', 'zai-org-glm-5-2')).toBe(true);
-    expect(isRecommendedModel('venice', 'kimi-k2-7-code')).toBe(true);
+    expect(isRecommendedModel('venice', 'kimi-k2-7-code')).toBe(false);
+    expect(isRecommendedModel('venice', 'kimi-k2-6')).toBe(false);
+    expect(isRecommendedModel('venice', 'kimi-k3')).toBe(true);
     expect(isRecommendedModel('venice', 'e2ee-qwen3-5-122b')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('routstr', 'claude-sonnet-4.6')).toBe(true);
     expect(isRecommendedModel('routstr', 'x-ai/grok-4.3')).toBe(true);
+    expect(isRecommendedModel('routstr', 'moonshotai/kimi-k3')).toBe(true);
+    expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.7-code')).toBe(false);
+    expect(isRecommendedModel('routstr', 'moonshotai/kimi-k2.6')).toBe(false);
     expect(isRecommendedModel('ppq', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('ppq', 'x-ai/grok-4.3')).toBe(true);
     expect(isRecommendedModel('ppq', 'google/gemini-3.5-flash')).toBe(true);
     expect(isRecommendedModel('ppq', 'z-ai/glm-5.2')).toBe(true);
-    expect(isRecommendedModel('ppq', 'moonshotai/kimi-k2.7-code')).toBe(true);
+    expect(isRecommendedModel('ppq', 'moonshotai/kimi-k2.7-code')).toBe(false);
+    expect(isRecommendedModel('ppq', 'moonshotai/kimi-k2.6')).toBe(false);
+    expect(isRecommendedModel('ppq', 'moonshotai/kimi-k3')).toBe(true);
     expect(isRecommendedModel('ppq', 'gemini-3-flash-preview')).toBe(true);
     expect(isRecommendedModel('custom', 'claude-sonnet-5')).toBe(true);
     expect(isRecommendedModel('custom', 'gemini-3.5-flash')).toBe(true);
     expect(isRecommendedModel('custom', 'z-ai/glm-5.2')).toBe(true);
-    expect(isRecommendedModel('custom', 'moonshotai/kimi-k2.7-code')).toBe(true);
+    expect(isRecommendedModel('custom', 'moonshotai/kimi-k2.7-code')).toBe(false);
+    expect(isRecommendedModel('custom', 'moonshotai/kimi-k2.6')).toBe(false);
+    expect(isRecommendedModel('custom', 'moonshotai/kimi-k3')).toBe(true);
 
     setAIProvider('openrouter');
     setOpenRouterModel('anthropic/claude-sonnet-4.6:2026-01-01');

--- a/tests/playwright/provider-coverage-batch.spec.js
+++ b/tests/playwright/provider-coverage-batch.spec.js
@@ -171,6 +171,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
         { id: 'google/gemini-3.1-pro', name: 'Gemini 3.1 Pro' },
         { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
         { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
         { id: 'anthropic/claude-sonnet-5', name: 'Claude Sonnet 5' },
@@ -181,12 +182,14 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       const openRouterRecommended = !!openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-5"]')
         && !!openRouterRecommendedGroup?.querySelector('option[value="google/gemini-3.5-flash"]')
         && !!openRouterRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
-        && !!openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !!openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
         && !openRouterRecommendedGroup?.querySelector('option[value="anthropic/claude-sonnet-4.6"]')
         && !openRouterRecommendedGroup?.querySelector('option[value="google/gemini-3.1-pro"]')
+        && !openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
         && !openRouterRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
         && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="anthropic/claude-sonnet-4.6"]')
         && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="google/gemini-3.1-pro"]')
+        && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]')
         && !!document.querySelector('#openrouter-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       const openRouterPricing = (document.getElementById('openrouter-model-pricing')?.textContent || '').includes('$3.00/M in');
 
@@ -253,11 +256,16 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       controls.renderRoutstrModelDropdown([
         { id: 'grok-41-fast', name: 'Grok 4.1 Fast' },
         { id: 'x-ai/grok-4.3', name: 'Grok 4.3' },
+        { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
+        { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
       ]);
       const routstrRecommendedGroup = document.querySelector('#routstr-model-select optgroup[label="Recommended"]');
       const routstrLatestGrokRecommended = !!routstrRecommendedGroup?.querySelector('option[value="x-ai/grok-4.3"]')
+        && !!routstrRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
         && !routstrRecommendedGroup?.querySelector('option[value="grok-41-fast"]')
-        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="grok-41-fast"]');
+        && !routstrRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="grok-41-fast"]')
+        && !!document.querySelector('#routstr-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]');
 
       localStorage.setItem('labcharts-ppq-model', 'ppq-b');
       localStorage.setItem('labcharts-ppq-pricing', JSON.stringify({ 'ppq-b': { input: 0.5, output: 1.5 } }));
@@ -267,6 +275,7 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash Preview' },
         { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
         { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
         { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
         { id: 'grok-4.20', name: 'Grok 4.20' },
@@ -280,8 +289,10 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
         && !ppqRecommendedGroup?.querySelector('option[value="gemini-3-flash-preview"]')
         && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="gemini-3-flash-preview"]');
       const ppqLatestGlmKimiRecommended = !!ppqRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
-        && !!ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !!ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
+        && !ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
         && !ppqRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
+        && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]')
         && !!document.querySelector('#ppq-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       controls.updatePpqModelPricing('ppq-b');
       const ppqModelPricing = document.getElementById('ppq-model-select')?.value === 'ppq-b'
@@ -291,13 +302,16 @@ test('provider model controls cover dropdowns custom models and delegates', asyn
       controls.renderCustomApiModelDropdown([
         { id: 'model-a', name: 'Model A' },
         { id: 'z-ai/glm-5.2', name: 'GLM 5.2' },
+        { id: 'moonshotai/kimi-k3', name: 'Kimi K3' },
         { id: 'moonshotai/kimi-k2.7-code', name: 'Kimi K2.7 Code' },
         { id: 'moonshotai/kimi-k2.6', name: 'Kimi K2.6' },
       ]);
       const customRecommendedGroup = document.querySelector('#custom-model-select optgroup[label="Recommended"]');
       const customGlmKimiRecommended = !!customRecommendedGroup?.querySelector('option[value="z-ai/glm-5.2"]')
-        && !!customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
+        && !!customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k3"]')
+        && !customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.7-code"]')
         && !customRecommendedGroup?.querySelector('option[value="moonshotai/kimi-k2.6"]')
+        && !!document.querySelector('#custom-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.7-code"]')
         && !!document.querySelector('#custom-model-select optgroup[label="Other models"] option[value="moonshotai/kimi-k2.6"]');
       const customModelRenders = document.getElementById('custom-model-select')?.value === '__custom'
         && document.getElementById('custom-manual-model')?.value === 'outside-model';

--- a/tests/test-custom-api.js
+++ b/tests/test-custom-api.js
@@ -57,7 +57,7 @@ assert('hasAIProvider custom requires URL', apiProviderStorageSrc.includes("hasC
 assert('getActiveModelId handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModel()"));
 assert('getActiveModelDisplay handles custom', apiModelsSrc.includes("provider === 'custom') return getCustomApiModelDisplay()"));
 assert('isRecommendedModel handles custom Sonnet 5', apiModelsSrc.includes("provider === 'custom'") && apiModelsSrc.includes('isCustomRecommendedModel'));
-assert('isRecommendedModel handles custom GLM and Kimi', apiModelsSrc.includes('glm-5-2') && apiModelsSrc.includes('kimi-k2-(7-code|6)'));
+assert('isRecommendedModel handles custom GLM and Kimi K3', apiModelsSrc.includes('glm-5-2') && apiModelsSrc.includes('kimi-k3'));
 assert('callClaudeAPI handles custom', apiSrc.includes("provider === 'custom') return callCustomAPI("));
 assert('supportsWebSearch false for custom', apiModelsSrc.includes("provider === 'custom') return false"));
 assert('supportsVision true for custom', apiModelsSrc.includes("provider === 'custom') return true"));

--- a/tests/test-openrouter.js
+++ b/tests/test-openrouter.js
@@ -81,9 +81,10 @@ assert('Recommended: Gemini 3.5 Flash', apiModelsSrc.includes("'google/gemini-3.
 assert('Curated: deepseek prefix', apiModelsSrc.includes("'deepseek/deepseek'"));
 assert('Curated: qwen prefix', apiModelsSrc.includes("'qwen/qwen'"));
 assert('Curated: z-ai/glm-5 prefix', apiModelsSrc.includes("'z-ai/glm-5'"));
-assert('Curated: moonshotai/kimi-k2 prefix', apiModelsSrc.includes("'moonshotai/kimi-k2'"));
+assert('Curated: moonshotai Kimi family prefix', apiModelsSrc.includes("'moonshotai/kimi-'"));
+assert('Recommended: Kimi K3', apiModelsSrc.includes("'moonshotai/kimi-k3'"));
 assert('Recommended: GLM 5.2', apiModelsSrc.includes("'z-ai/glm-5.2'"));
-assert('Recommended: Kimi K2.7 Code', apiModelsSrc.includes("'moonshotai/kimi-k2.7-code'"));
+assert('Kimi K2.7 Code remains available but is no longer recommended', apiModelsSrc.includes("'moonshotai/kimi-'"));
 assert('Curated: x-ai/grok prefix', apiModelsSrc.includes("'x-ai/grok'"));
 assert('OPENROUTER_EXCLUDE exists', apiModelsSrc.includes('OPENROUTER_EXCLUDE'));
 assert('Excludes codex variants', apiModelsSrc.includes("'codex'"));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.280';
+self.APP_VERSION = '1.10.281';


### PR DESCRIPTION
## Summary

- admit the current Kimi family in OpenRouter, PPQ, and Routstr model catalogs so Kimi K3 is not filtered out
- make Kimi K3 the only regularly recommended Kimi generation while keeping older Kimi models selectable
- preserve current Private TEE K2.6 recommendations where K3 is not yet offered
- cache K3 pricing and vision capabilities from provider metadata

## Root cause

Venice renders its text catalog dynamically, but the other provider adapters used K2-specific curated prefixes. OpenRouter and PPQ already return moonshotai/kimi-k3; getbased discarded it before rendering.

## Verification

- npm test: 32 files, 399 tests passed
- provider runtime: 8 tests passed
- OpenRouter integration: 160 checks passed
- Custom API integration: 134 checks passed
- provider Playwright coverage: 4 tests passed
- full local Playwright run: 351/352 passed; the unrelated Light environment case passed on isolated rerun
- live OpenRouter and PPQ catalogs verified moonshotai/kimi-k3, including vision and pricing metadata

## CI progress

- CodeQL passed
- Greptile passed with 5/5 confidence and no requested changes
- the first test run exposed one stale browser assertion that still required K2.7 under Recommended
- browser coverage was corrected to require K3 under Recommended and K2.7/K2.6 under Other models across OpenRouter, Routstr, PPQ, and Custom API
- corrected GitHub Actions test run passed in full

## Window burden campaign

Paused at 11 consumers and 12 bridge lookups after PR #1254. This provider-catalog fix does not change that count. The campaign resumes after this PR merges.