### PR TITLE
Inject Notes runtime actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -86,10 +86,11 @@ import { configurePdfImportReviewRuntimeDeps } from './pdf-import-review-runtime
 import { _openChannelOnLightPage } from './light-channel-view.js';
 import { configureLightDevicesRuntimeDeps } from './light-devices-runtime.js';
 import { configureLensPageShell } from './lens-page-shell.js';
-import { closeModal } from './marker-detail-modal.js';
+import { closeModal, rememberModalTrigger } from './marker-detail-modal.js';
 import { configureMarkerDetailRuntime } from './marker-detail-runtime.js';
 import { buildSidebar, closeMobileSidebar, configureNavActions, renderProfileButton, toggleMobileSidebar } from './nav.js';
 import { configureNavRuntime } from './nav-runtime.js';
+import { configureNotesRuntimeDeps } from './notes-runtime.js';
 import { configureOnboardingViewRuntimeDeps } from './onboarding-view-runtime.js';
 import { closeSettingsModal, closeTweaksPanel, configureSettingsRuntime, openSettingsModal } from './settings.js';
 import { closeRestoreMnemonicDialog, closeSyncSetup } from './settings-sync-panel.js';
@@ -179,6 +180,7 @@ configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, us
 configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
 configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });
 configureLensPageShell({ navigate });
+configureNotesRuntimeDeps({ closeModal, navigate, rememberModalTrigger });
 configureContextCardLifestyleRuntimeDeps({ closeModal, navigate, openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel, openChatProviderQuiz, setOnboardingFocus });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });

--- a/js/notes-runtime.js
+++ b/js/notes-runtime.js
@@ -1,48 +1,48 @@
 // @ts-check
+// notes-runtime.js - Explicit application callbacks for Notes views.
 
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+/** @type {{
+ *   closeModal: (() => void) | null,
+ *   rememberModalTrigger: (() => void) | null,
+ *   navigate: ((route: string) => void) | null,
+ * }} */
+const notesRuntimeDeps = {
+  closeModal: null,
+  rememberModalTrigger: null,
+  navigate: null,
+};
 
 /**
- * @typedef {Window & typeof globalThis & {
- *   closeModal?: () => void,
- *   rememberModalTrigger?: () => void,
- *   navigate?: (route: string) => void,
- *   __noteActionDelegatesBound?: boolean,
- * }} NotesRuntimeWindow
+ * @param {{
+ *   closeModal?: (() => void) | null,
+ *   rememberModalTrigger?: (() => void) | null,
+ *   navigate?: ((route: string) => void) | null,
+ * }} deps
  */
-
-function getNotesRuntimeWindow() {
-  return /** @type {NotesRuntimeWindow | null} */ (typeof window !== 'undefined' ? window : null);
-}
-
-/** @param {string} name */
-function getNotesRuntimeFunction(name) {
-  const runtime = getNotesRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
+export function configureNotesRuntimeDeps(deps = {}) {
+  const previous = { ...notesRuntimeDeps };
+  if (Object.hasOwn(deps, 'closeModal')) {
+    notesRuntimeDeps.closeModal = typeof deps.closeModal === 'function' ? deps.closeModal : null;
+  }
+  if (Object.hasOwn(deps, 'rememberModalTrigger')) {
+    notesRuntimeDeps.rememberModalTrigger = typeof deps.rememberModalTrigger === 'function'
+      ? deps.rememberModalTrigger
+      : null;
+  }
+  if (Object.hasOwn(deps, 'navigate')) {
+    notesRuntimeDeps.navigate = typeof deps.navigate === 'function' ? deps.navigate : null;
+  }
+  return previous;
 }
 
 export function closeNoteModalRuntime() {
-  getNotesRuntimeFunction('closeModal')?.();
+  notesRuntimeDeps.closeModal?.();
 }
 
 export function rememberNoteModalTriggerRuntime() {
-  getNotesRuntimeFunction('rememberModalTrigger')?.();
+  notesRuntimeDeps.rememberModalTrigger?.();
 }
 
 export function navigateAfterNoteChangeRuntime(route = 'dashboard') {
-  getNotesRuntimeFunction('navigate')?.(route || 'dashboard');
-}
-
-export function isNoteActionDelegatesBoundRuntime() {
-  const runtime = getNotesRuntimeWindow();
-  return !!runtime?.__noteActionDelegatesBound;
-}
-
-export function markNoteActionDelegatesBoundRuntime() {
-  const runtime = getNotesRuntimeWindow();
-  if (!runtime) return false;
-  runtime.__noteActionDelegatesBound = true;
-  return true;
+  notesRuntimeDeps.navigate?.(route || 'dashboard');
 }

--- a/js/notes.js
+++ b/js/notes.js
@@ -13,8 +13,6 @@ import { openModalOverlay } from './modal-lifecycle.js';
 import { configureDashboardNoteActions } from './dashboard-widget-runtime.js';
 import {
   closeNoteModalRuntime,
-  isNoteActionDelegatesBoundRuntime,
-  markNoteActionDelegatesBoundRuntime,
   navigateAfterNoteChangeRuntime,
   rememberNoteModalTriggerRuntime,
 } from './notes-runtime.js';
@@ -67,9 +65,8 @@ function handleNoteActionClick(event) {
 }
 
 export function installNoteActionDelegates(root = typeof document !== 'undefined' ? document : null) {
-  if (!root || _noteActionDelegatesInstalled || isNoteActionDelegatesBoundRuntime()) return;
+  if (!root || _noteActionDelegatesInstalled) return;
   _noteActionDelegatesInstalled = true;
-  markNoteActionDelegatesBoundRuntime();
   root.addEventListener('click', handleNoteActionClick);
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 11,
-  "viewRuntimeBridgeLookups": 12,
+  "viewRuntimeBridgeConsumers": 10,
+  "viewRuntimeBridgeLookups": 11,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/notes-runtime.test.js
+++ b/tests/notes-runtime.test.js
@@ -3,28 +3,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   closeNoteModalRuntime,
-  isNoteActionDelegatesBoundRuntime,
-  markNoteActionDelegatesBoundRuntime,
+  configureNotesRuntimeDeps,
   navigateAfterNoteChangeRuntime,
   rememberNoteModalTriggerRuntime,
 } from '../js/notes-runtime.js';
 
-const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
-
-function setRuntimeWindow(runtime) {
-  Object.defineProperty(globalThis, 'window', {
-    configurable: true,
-    writable: true,
-    value: runtime,
-  });
-}
-
 afterEach(() => {
-  if (savedWindow) {
-    Object.defineProperty(globalThis, 'window', savedWindow);
-  } else {
-    delete globalThis.window;
-  }
+  configureNotesRuntimeDeps({
+    closeModal: null,
+    navigate: null,
+    rememberModalTrigger: null,
+  });
 });
 
 describe('notes runtime adapter', () => {
@@ -32,7 +21,7 @@ describe('notes runtime adapter', () => {
     const closeModal = vi.fn();
     const rememberModalTrigger = vi.fn();
     const navigate = vi.fn();
-    setRuntimeWindow({ closeModal, rememberModalTrigger, navigate });
+    configureNotesRuntimeDeps({ closeModal, rememberModalTrigger, navigate });
 
     closeNoteModalRuntime();
     rememberNoteModalTriggerRuntime();
@@ -45,36 +34,42 @@ describe('notes runtime adapter', () => {
     expect(navigate).toHaveBeenNthCalledWith(2, 'dashboard');
   });
 
-  it('tracks delegated action binding', () => {
-    const runtime = {};
-    setRuntimeWindow(runtime);
+  it('returns the previous dependencies for scoped configuration', () => {
+    const closeModal = vi.fn();
+    const previous = configureNotesRuntimeDeps({ closeModal });
+    const configured = configureNotesRuntimeDeps(previous);
 
-    expect(isNoteActionDelegatesBoundRuntime()).toBe(false);
-    expect(markNoteActionDelegatesBoundRuntime()).toBe(true);
-    expect(isNoteActionDelegatesBoundRuntime()).toBe(true);
+    expect(previous).toEqual({ closeModal: null, rememberModalTrigger: null, navigate: null });
+    expect(configured.closeModal).toBe(closeModal);
   });
 
-  it('uses safe fallbacks when browser runtime hooks are missing', () => {
-    delete globalThis.window;
+  it('uses safe fallbacks when application callbacks are missing', () => {
+    configureNotesRuntimeDeps({ closeModal: null, navigate: null, rememberModalTrigger: null });
 
     expect(() => closeNoteModalRuntime()).not.toThrow();
     expect(() => rememberNoteModalTriggerRuntime()).not.toThrow();
     expect(() => navigateAfterNoteChangeRuntime('dashboard')).not.toThrow();
-    expect(isNoteActionDelegatesBoundRuntime()).toBe(false);
-    expect(markNoteActionDelegatesBoundRuntime()).toBe(false);
   });
 
   it('keeps note actions module-only behind explicit dashboard callbacks', () => {
     const notesSrc = readFileSync(new URL('../js/notes.js', import.meta.url), 'utf8');
     const runtimeSrc = readFileSync(new URL('../js/notes-runtime.js', import.meta.url), 'utf8');
+    const appShellHooksSrc = readFileSync(new URL('../js/app-shell-hooks.js', import.meta.url), 'utf8');
     const swSrc = readFileSync(new URL('../service-worker.js', import.meta.url), 'utf8');
 
     expect(notesSrc).toContain("from './notes-runtime.js'");
     expect(notesSrc).toContain("from './dashboard-widget-runtime.js'");
     expect(notesSrc).toContain('configureDashboardNoteActions({ openNoteEditor, deleteNote });');
     expect(notesSrc).not.toContain('exposeNoteEditorRuntime');
+    expect(notesSrc).not.toContain('isNoteActionDelegatesBoundRuntime');
+    expect(notesSrc).not.toContain('markNoteActionDelegatesBoundRuntime');
     expect(/\bwindow(?:\.|\s*\[)/.test(notesSrc)).toBe(false);
     expect(/\bwindow(?:\.|\s*\[)/.test(runtimeSrc)).toBe(false);
+    expect(runtimeSrc).not.toContain("from './views-runtime-bridge.js'");
+    expect(runtimeSrc).not.toContain('getViewRuntimeFunction');
+    expect(runtimeSrc).toContain('export function configureNotesRuntimeDeps(deps = {})');
+    expect(appShellHooksSrc).toContain("import { configureNotesRuntimeDeps } from './notes-runtime.js';");
+    expect(appShellHooksSrc).toContain('configureNotesRuntimeDeps({ closeModal, navigate, rememberModalTrigger });');
     expect(swSrc).toContain("'/js/notes-runtime.js'");
   });
 });

--- a/tests/playwright/browser-coverage-batch.spec.js
+++ b/tests/playwright/browser-coverage-batch.spec.js
@@ -78,15 +78,16 @@ test('notes editor browser contract adds edits and deletes notes', async ({ page
   await page.goto('/app', { waitUntil: 'load' });
   await page.waitForSelector('#detail-modal', { state: 'attached' });
 
-  const results = await page.evaluate(async ({ notesUrl }) => {
-    const notes = await import(notesUrl);
+  const results = await page.evaluate(async ({ notesRuntimeUrl, notesUrl }) => {
+    const [notes, notesRuntime] = await Promise.all([
+      import(notesUrl),
+      import(notesRuntimeUrl),
+    ]);
     const state = window._labState;
     const outcomes = {};
     const originalNotes = Array.isArray(state.importedData?.notes)
       ? JSON.parse(JSON.stringify(state.importedData.notes))
       : undefined;
-    const originalCloseModal = window.closeModal;
-    const originalNavigate = window.navigate;
     const navCalls = [];
     let closeCalls = 0;
     const waitFor = async (predicate) => {
@@ -100,86 +101,92 @@ test('notes editor browser contract adds edits and deletes notes', async ({ page
     try {
       state.importedData ||= {};
       state.importedData.notes = [];
-      window.closeModal = () => {
-        closeCalls++;
-        document.getElementById('modal-overlay')?.classList.remove('show');
-      };
-      window.navigate = (category) => { navCalls.push(category); };
+      const savedNotesRuntimeDeps = notesRuntime.configureNotesRuntimeDeps({
+        closeModal: () => {
+          closeCalls++;
+          document.getElementById('modal-overlay')?.classList.remove('show');
+        },
+        navigate: category => { navCalls.push(category); },
+        rememberModalTrigger: () => {},
+      });
 
-      notes.openNoteEditor('2026-06-07');
-      const addModal = document.getElementById('detail-modal');
-      outcomes.addEditorOpens = document.getElementById('modal-overlay')?.classList.contains('show') === true
-        && document.getElementById('note-date-input')?.value === '2026-06-07'
-        && document.getElementById('note-textarea')?.value === '';
-      outcomes.usesDelegatedNoteActions =
-        addModal?.querySelector('[data-note-action="close"]')
-        && addModal?.querySelector('[data-note-action="save"]')
-        && !addModal.innerHTML.includes('onclick=');
+      try {
+        notes.openNoteEditor('2026-06-07');
+        const addModal = document.getElementById('detail-modal');
+        outcomes.addEditorOpens = document.getElementById('modal-overlay')?.classList.contains('show') === true
+          && document.getElementById('note-date-input')?.value === '2026-06-07'
+          && document.getElementById('note-textarea')?.value === '';
+        outcomes.usesDelegatedNoteActions =
+          addModal?.querySelector('[data-note-action="close"]')
+          && addModal?.querySelector('[data-note-action="save"]')
+          && !addModal.innerHTML.includes('onclick=');
 
-      document.getElementById('note-textarea').value = 'Started coverage batching';
-      document.querySelector('[data-note-action="save"]')?.click();
-      outcomes.saveAddsNote = state.importedData.notes.length === 1
-        && state.importedData.notes[0].date === '2026-06-07'
-        && state.importedData.notes[0].text === 'Started coverage batching'
-        && navCalls.includes('dashboard');
+        document.getElementById('note-textarea').value = 'Started coverage batching';
+        document.querySelector('[data-note-action="save"]')?.click();
+        outcomes.saveAddsNote = state.importedData.notes.length === 1
+          && state.importedData.notes[0].date === '2026-06-07'
+          && state.importedData.notes[0].text === 'Started coverage batching'
+          && navCalls.includes('dashboard');
 
-      notes.openNoteEditor(null, 0);
-      outcomes.editEditorLoadsExisting = document.getElementById('note-textarea')?.value === 'Started coverage batching'
-        && document.getElementById('detail-modal')?.dataset.syncRefreshMode === 'edit'
-        && document.getElementById('detail-modal')?.dataset.syncRefreshKind === 'note';
+        notes.openNoteEditor(null, 0);
+        outcomes.editEditorLoadsExisting = document.getElementById('note-textarea')?.value === 'Started coverage batching'
+          && document.getElementById('detail-modal')?.dataset.syncRefreshMode === 'edit'
+          && document.getElementById('detail-modal')?.dataset.syncRefreshKind === 'note';
 
-      document.getElementById('note-textarea').value = 'Edited coverage batch note';
-      document.querySelector('[data-note-action="save"]')?.click();
-      outcomes.saveEditsInPlace = state.importedData.notes.length === 1
-        && state.importedData.notes[0].text === 'Edited coverage batch note';
+        document.getElementById('note-textarea').value = 'Edited coverage batch note';
+        document.querySelector('[data-note-action="save"]')?.click();
+        outcomes.saveEditsInPlace = state.importedData.notes.length === 1
+          && state.importedData.notes[0].text === 'Edited coverage batch note';
 
-      notes.openNoteEditor('2026-06-08');
-      window.dispatchEvent(new Event('labcharts-sync-applied'));
-      outcomes.syncRefreshAddModeReopensByDate =
-        await waitFor(() => document.getElementById('note-date-input')?.value === '2026-06-08')
-        && document.getElementById('detail-modal')?.dataset.syncRefreshMode === 'add';
+        notes.openNoteEditor('2026-06-08');
+        window.dispatchEvent(new Event('labcharts-sync-applied'));
+        outcomes.syncRefreshAddModeReopensByDate =
+          await waitFor(() => document.getElementById('note-date-input')?.value === '2026-06-08')
+          && document.getElementById('detail-modal')?.dataset.syncRefreshMode === 'add';
 
-      notes.openNoteEditor(null, 0);
-      state.importedData.notes[0].text = 'Synced coverage batch note';
-      window.dispatchEvent(new Event('labcharts-sync-applied'));
-      outcomes.syncRefreshEditReopensSameIndex =
-        await waitFor(() => document.getElementById('note-textarea')?.value === 'Synced coverage batch note')
-        && document.getElementById('detail-modal')?.dataset.syncRefreshIndex === '0';
+        notes.openNoteEditor(null, 0);
+        state.importedData.notes[0].text = 'Synced coverage batch note';
+        window.dispatchEvent(new Event('labcharts-sync-applied'));
+        outcomes.syncRefreshEditReopensSameIndex =
+          await waitFor(() => document.getElementById('note-textarea')?.value === 'Synced coverage batch note')
+          && document.getElementById('detail-modal')?.dataset.syncRefreshIndex === '0';
 
-      notes.openNoteEditor(null, 0);
-      state.importedData.notes.unshift({ date: '2026-06-06', text: 'Inserted remote note' });
-      window.dispatchEvent(new Event('labcharts-sync-applied'));
-      outcomes.syncRefreshFindsShiftedNote =
-        await waitFor(() => document.getElementById('detail-modal')?.dataset.syncRefreshIndex === '1')
-        && document.getElementById('note-textarea')?.value === 'Synced coverage batch note';
+        notes.openNoteEditor(null, 0);
+        state.importedData.notes.unshift({ date: '2026-06-06', text: 'Inserted remote note' });
+        window.dispatchEvent(new Event('labcharts-sync-applied'));
+        outcomes.syncRefreshFindsShiftedNote =
+          await waitFor(() => document.getElementById('detail-modal')?.dataset.syncRefreshIndex === '1')
+          && document.getElementById('note-textarea')?.value === 'Synced coverage batch note';
 
-      const closeCallsBeforeMissingNote = closeCalls;
-      notes.openNoteEditor(null, 1);
-      state.importedData.notes = state.importedData.notes.filter(note => note.date !== '2026-06-07');
-      window.dispatchEvent(new Event('labcharts-sync-applied'));
-      outcomes.syncRefreshClosesWhenNoteMissing =
-        closeCalls >= closeCallsBeforeMissingNote + 1
-        && document.getElementById('modal-overlay')?.classList.contains('show') === false;
+        const closeCallsBeforeMissingNote = closeCalls;
+        notes.openNoteEditor(null, 1);
+        state.importedData.notes = state.importedData.notes.filter(note => note.date !== '2026-06-07');
+        window.dispatchEvent(new Event('labcharts-sync-applied'));
+        outcomes.syncRefreshClosesWhenNoteMissing =
+          closeCalls >= closeCallsBeforeMissingNote + 1
+          && document.getElementById('modal-overlay')?.classList.contains('show') === false;
 
-      state.importedData.notes = [{ date: '2026-06-09', text: 'Delete coverage note' }];
-      notes.openNoteEditor(null, 0);
-      document.querySelector('[data-note-action="delete"]')?.click();
-      await Promise.resolve();
-      document.getElementById('confirm-ok')?.click();
-      await waitFor(() => state.importedData.notes.length === 0);
-      outcomes.deleteRemovesNote = state.importedData.notes.length === 0;
+        state.importedData.notes = [{ date: '2026-06-09', text: 'Delete coverage note' }];
+        notes.openNoteEditor(null, 0);
+        document.querySelector('[data-note-action="delete"]')?.click();
+        await Promise.resolve();
+        document.getElementById('confirm-ok')?.click();
+        await waitFor(() => state.importedData.notes.length === 0);
+        outcomes.deleteRemovesNote = state.importedData.notes.length === 0;
+      } finally {
+        notesRuntime.configureNotesRuntimeDeps(savedNotesRuntimeDeps);
+      }
     } finally {
       if (originalNotes === undefined) delete state.importedData.notes;
       else state.importedData.notes = originalNotes;
-      window.closeModal = originalCloseModal;
-      window.navigate = originalNavigate;
       document.getElementById('confirm-dialog-overlay')?.classList.remove('show');
       document.getElementById('modal-overlay')?.classList.remove('show');
     }
 
     return outcomes;
   }, {
-    notesUrl: moduleUrl('/js/notes.js'),
+    notesRuntimeUrl: '/js/notes-runtime.js',
+    notesUrl: '/js/notes.js',
   });
 
   for (const [name, passed] of Object.entries(results)) {

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 11 &&
-    baseline.viewRuntimeBridgeLookups === 12);
+    baseline.viewRuntimeBridgeConsumers === 10 &&
+    baseline.viewRuntimeBridgeLookups === 11);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -16,6 +16,7 @@ const chatEmptyStateSrc = fs.readFileSync(path.join(root, 'js/chat-empty-state.j
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
 const lensPageShellSrc = fs.readFileSync(path.join(root, 'js/lens-page-shell.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
+const notesRuntimeSrc = fs.readFileSync(path.join(root, 'js/notes-runtime.js'), 'utf8');
 const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
 const syncPullSrc = fs.readFileSync(path.join(root, 'js/sync-pull.js'), 'utf8');
 
@@ -184,6 +185,14 @@ assert('App shell injects Cycle view callbacks without bridge lookups',
 assert('App shell injects Supplements view callbacks without bridge lookups',
   appShellHooksSrc.includes("import { configureSupplementsRuntimeDeps } from './supplements-runtime.js'")
     && appShellHooksSrc.includes('configureSupplementsRuntimeDeps({ closeModal, navigate });'));
+
+assert('App shell injects Notes view callbacks without bridge or window fallbacks',
+  !notesRuntimeSrc.includes("from './views-runtime-bridge.js'")
+    && !notesRuntimeSrc.includes('getViewRuntimeFunction')
+    && !/\bwindow(?:\.|\s*\[)/.test(notesRuntimeSrc)
+    && notesRuntimeSrc.includes('export function configureNotesRuntimeDeps(deps = {})')
+    && appShellHooksSrc.includes("import { configureNotesRuntimeDeps } from './notes-runtime.js';")
+    && appShellHooksSrc.includes('configureNotesRuntimeDeps({ closeModal, navigate, rememberModalTrigger });'));
 
 assert('App shell injects sun defaults navigation without a view bridge lookup',
   appShellHooksSrc.includes('configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.281';
+self.APP_VERSION = '1.10.282';


### PR DESCRIPTION
## Summary

- inject Notes modal-close, focus-trigger, and navigation callbacks from the app shell
- remove the Notes view-runtime bridge lookup and redundant window-backed delegate flag
- update unit, static, and browser coverage to exercise explicit dependency configuration
- bump the app cache version to 1.10.282

## Window-burden goal progress

- Before this PR: **11 consumer modules / 12 bridge lookups**
- After this PR: **10 consumer modules / 11 bridge lookups**
- This PR: **-1 consumer / -1 lookup**
- The quality baseline is ratcheted to 10/11 so this coupling cannot regress.
- Remaining consumers: `emf.js`, `utils-runtime.js` (2 lookups), `dashboard-recommendation-widget.js`, `context-card-editor-ui.js`, `emf-interpretation.js`, `wearables-runtime.js`, `provider-panels.js`, `chat-runtime.js`, `recommendations-runtime.js`, and `wearables-detail-runtime.js`.
- Goal status: **in progress**; continue with the next safe target after this PR merges.

## Testing

- `./run-tests.sh`
  - typecheck and static/module verification passed
  - 399 Vitest tests passed
  - 352 Playwright tests passed
  - 472 responsive-theme assertions passed
