### PR TITLE
Inject wearable detail runtime actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -129,6 +129,7 @@ import { configureSunRuntimeDeps } from './sun-runtime.js';
 import { configureSupplementsRuntimeDeps } from './supplements-runtime.js';
 import { configureTourRuntimeDeps } from './tour-runtime.js';
 import { configureWearablesConnectRuntimeDeps } from './wearables-connect-runtime.js';
+import { configureWearableDetailRuntimeDeps } from './wearables-detail-runtime.js';
 import { configureWearableSettingsRuntimeDeps } from './wearables-settings-runtime.js';
 
 configureClientListRuntime({
@@ -249,6 +250,7 @@ configureTourRuntimeDeps({ openChatPanel });
 configureSyncPull({ renderProfileButton });
 configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });
 configureWearablesConnectRuntimeDeps({ navigate });
+configureWearableDetailRuntimeDeps({ closeModal, navigate, rememberModalTrigger });
 configureWearableSettingsRuntimeDeps({ navigate });
 configureDashboardAIContextStatus(updateChatContextStatus);
 

--- a/js/wearables-detail-runtime.js
+++ b/js/wearables-detail-runtime.js
@@ -2,13 +2,34 @@
 // wearables-detail-runtime.js - Browser runtime adapters for wearable detail modal hooks.
 
 import { showConfirmDialog } from './utils.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-const wearableDetailRuntimeDeps = { showConfirmDialog };
+/** @type {{
+ *   closeModal: (() => void) | null,
+ *   navigate: ((route: string) => void) | null,
+ *   rememberModalTrigger: (() => void) | null,
+ *   showConfirmDialog: typeof showConfirmDialog | null,
+ * }} */
+const wearableDetailRuntimeDeps = {
+  closeModal: null,
+  navigate: null,
+  rememberModalTrigger: null,
+  showConfirmDialog,
+};
 
 export function configureWearableDetailRuntimeDeps(deps = {}) {
   const previous = { ...wearableDetailRuntimeDeps };
-  if ('showConfirmDialog' in deps) {
+  if (Object.hasOwn(deps, 'closeModal')) {
+    wearableDetailRuntimeDeps.closeModal = typeof deps.closeModal === 'function' ? deps.closeModal : null;
+  }
+  if (Object.hasOwn(deps, 'navigate')) {
+    wearableDetailRuntimeDeps.navigate = typeof deps.navigate === 'function' ? deps.navigate : null;
+  }
+  if (Object.hasOwn(deps, 'rememberModalTrigger')) {
+    wearableDetailRuntimeDeps.rememberModalTrigger = typeof deps.rememberModalTrigger === 'function'
+      ? deps.rememberModalTrigger
+      : null;
+  }
+  if (Object.hasOwn(deps, 'showConfirmDialog')) {
     wearableDetailRuntimeDeps.showConfirmDialog = typeof deps.showConfirmDialog === 'function'
       ? /** @type {typeof showConfirmDialog} */ (deps.showConfirmDialog)
       : null;
@@ -22,19 +43,8 @@ function getRuntimeWindow() {
     : null;
 }
 
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  if (runtime && typeof runtime[name] === 'function') return runtime[name].bind(runtime);
-  return getViewRuntimeFunction(name);
-}
-
 export function rememberWearableDetailModalTriggerRuntime() {
-  getRuntimeFunction('rememberModalTrigger')?.();
+  wearableDetailRuntimeDeps.rememberModalTrigger?.();
 }
 
 export function hasWearableDetailChartRuntime() {
@@ -55,11 +65,11 @@ export function createWearableDetailChartRuntime(canvas, config) {
 
 /** @param {string} [route] */
 export function navigateWearableDetailRuntime(route = 'dashboard') {
-  getRuntimeFunction('navigate')?.(route || 'dashboard');
+  wearableDetailRuntimeDeps.navigate?.(route || 'dashboard');
 }
 
 export function closeWearableDetailModalRuntime() {
-  getRuntimeFunction('closeModal')?.();
+  wearableDetailRuntimeDeps.closeModal?.();
 }
 
 /** @param {string} message */

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 10,
-  "viewRuntimeBridgeLookups": 11,
+  "viewRuntimeBridgeConsumers": 9,
+  "viewRuntimeBridgeLookups": 10,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
+++ b/tests/playwright/wearables-detail-manual-browser-coverage.spec.js
@@ -4,13 +4,14 @@ test('wearables detail modal covers manual migration delegated add save and canc
   await page.goto('/app', { waitUntil: 'load' });
 
   const failures = await page.evaluate(async () => {
-    const [{ state }, manual, store, { profileStorageKey }, blobStorage, views] = await Promise.all([
+    const [{ state }, manual, store, { profileStorageKey }, blobStorage, views, wearableDetailRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/wearables-manual.js'),
       import('/js/wearables-store.js'),
       import('/js/profile.js'),
       import('/js/blob-storage.js'),
       import('/js/views.js'),
+      import('/js/wearables-detail-runtime.js'),
     ]);
     const wearables = await import('/js/wearables.js');
     const failures = [];
@@ -22,7 +23,6 @@ test('wearables detail modal covers manual migration delegated add save and canc
     const originalActiveProfile = localStorage.getItem('labcharts-active-profile');
     const originalCurrentProfile = state.currentProfile;
     const originalImported = state.importedData;
-    const originalNavigate = window.navigate;
     const originalImportedLocalValue = localStorage.getItem(importedStorageKey);
     const originalImportedBlobValue = await blobStorage.getBlob(importedStorageKey);
     const originalRange = localStorage.getItem('wearable-detail-range');
@@ -35,6 +35,9 @@ test('wearables detail modal covers manual migration delegated add save and canc
       }
       return false;
     };
+    const previousWearableDetailRuntime = wearableDetailRuntime.configureWearableDetailRuntimeDeps({
+      navigate: route => calls.push(['navigate', route]),
+    });
     const closeDetailModal = async () => {
       try { views.closeModal(); } catch (_) {}
       await waitFor(() => !document.getElementById('modal-overlay')?.classList.contains('show'), 100);
@@ -72,8 +75,6 @@ test('wearables detail modal covers manual migration delegated add save and canc
         wearableSummary: null,
         changeHistory: [],
       };
-      window.navigate = route => calls.push(['navigate', route]);
-
       const migration = await manual.migrateBiometricsToManual(profileId, {
         weight: [
           { date: '2026-05-01', value: 154.3234, unit: 'lb' },
@@ -225,8 +226,7 @@ test('wearables detail modal covers manual migration delegated add save and canc
       else localStorage.removeItem('wearable-detail-range');
       state.currentProfile = originalCurrentProfile;
       state.importedData = originalImported;
-      if (originalNavigate) window.navigate = originalNavigate;
-      else delete window.navigate;
+      wearableDetailRuntime.configureWearableDetailRuntimeDeps(previousWearableDetailRuntime);
       document.querySelectorAll('.modal-overlay,.confirm-overlay,.notification-container').forEach(el => el.remove());
     }
 

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 10 &&
-    baseline.viewRuntimeBridgeLookups === 11);
+    baseline.viewRuntimeBridgeConsumers === 9 &&
+    baseline.viewRuntimeBridgeLookups === 10);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -19,6 +19,7 @@ const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
 const notesRuntimeSrc = fs.readFileSync(path.join(root, 'js/notes-runtime.js'), 'utf8');
 const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
 const syncPullSrc = fs.readFileSync(path.join(root, 'js/sync-pull.js'), 'utf8');
+const wearableDetailRuntimeSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-runtime.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -156,6 +157,15 @@ assert('App shell wires remaining Chat open consumers without window globals',
 assert('App shell injects wearable navigation without view bridge lookups',
   appShellHooksSrc.includes('configureWearablesConnectRuntimeDeps({ navigate });')
     && appShellHooksSrc.includes('configureWearableSettingsRuntimeDeps({ navigate });'));
+
+assert('App shell injects wearable detail actions without view bridge lookups',
+  !wearableDetailRuntimeSrc.includes("from './views-runtime-bridge.js'")
+    && !wearableDetailRuntimeSrc.includes('getViewRuntimeFunction')
+    && wearableDetailRuntimeSrc.includes('wearableDetailRuntimeDeps.rememberModalTrigger?.();')
+    && wearableDetailRuntimeSrc.includes("wearableDetailRuntimeDeps.navigate?.(route || 'dashboard');")
+    && wearableDetailRuntimeSrc.includes('wearableDetailRuntimeDeps.closeModal?.();')
+    && appShellHooksSrc.includes("import { configureWearableDetailRuntimeDeps } from './wearables-detail-runtime.js';")
+    && appShellHooksSrc.includes('configureWearableDetailRuntimeDeps({ closeModal, navigate, rememberModalTrigger });'));
 
 assert('App shell injects category customization view callbacks',
   appShellHooksSrc.includes('configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });'));

--- a/tests/test-ui-flows.js
+++ b/tests/test-ui-flows.js
@@ -131,7 +131,8 @@ return (async function() {
   assert('rememberModalTrigger stays off window', !('rememberModalTrigger' in window));
   assert('wearable detail modal captures trigger',
     wearablesDetailSrc.includes('rememberWearableDetailModalTriggerRuntime();') &&
-      /getRuntimeFunction\('rememberModalTrigger'\)\?\.\(\)/.test(wearablesDetailRuntimeSrc));
+      wearablesDetailRuntimeSrc.includes('wearableDetailRuntimeDeps.rememberModalTrigger?.();') &&
+      !wearablesDetailRuntimeSrc.includes('getViewRuntimeFunction'));
   assert('restoreModalTrigger guards against detached elements', /document\.contains\(el\)/.test(markerDetailSrc));
 
   // ═══════════════════════════════════════════════

--- a/tests/test-wearables-detail-runtime.js
+++ b/tests/test-wearables-detail-runtime.js
@@ -25,7 +25,7 @@ function assert(name, condition, detail) {
 
 console.log('=== Wearables Detail Runtime Tests ===\n');
 
-const runtimeKeys = ['window', 'rememberModalTrigger', 'navigate', 'closeModal', 'showConfirmDialog', 'Chart'];
+const runtimeKeys = ['window', 'Chart'];
 const savedDescriptors = new Map(runtimeKeys.map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
 
 function setRuntimeValue(key, value) {
@@ -48,13 +48,15 @@ function restoreRuntime() {
 try {
   const calls = [];
   setRuntimeValue('window', globalThis);
-  setRuntimeValue('rememberModalTrigger', () => calls.push(['remember']));
-  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
-  setRuntimeValue('closeModal', () => calls.push(['close']));
-  configureWearableDetailRuntimeDeps({ showConfirmDialog: async message => {
-    calls.push(['confirm', message]);
-    return message === 'delete';
-  } });
+  configureWearableDetailRuntimeDeps({
+    closeModal: () => calls.push(['close']),
+    navigate: route => calls.push(['navigate', route]),
+    rememberModalTrigger: () => calls.push(['remember']),
+    showConfirmDialog: async message => {
+      calls.push(['confirm', message]);
+      return message === 'delete';
+    },
+  });
   setRuntimeValue('Chart', function Chart(canvas, config) {
     this.canvas = canvas;
     this.config = config;
@@ -81,7 +83,12 @@ try {
       chart?.config?.type === 'line' &&
       calls.some(call => call.join('|') === 'chart|chart-modal|line'));
 
-  configureWearableDetailRuntimeDeps({ showConfirmDialog: null });
+  configureWearableDetailRuntimeDeps({
+    closeModal: null,
+    navigate: null,
+    rememberModalTrigger: null,
+    showConfirmDialog: null,
+  });
   delete globalThis.Chart;
   const missingConfirm = await confirmWearableDetailActionRuntime('delete');
   const missingChart = createWearableDetailChartRuntime({ id: 'chart-modal' }, { type: 'line' });
@@ -104,11 +111,21 @@ try {
 
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   const detailSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-modal.js'), 'utf8');
+  const runtimeSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-runtime.js'), 'utf8');
+  const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'), 'utf8');
   const swSrc = fs.readFileSync(path.join(root, 'service-worker.js'), 'utf8');
   assert('wearable detail modal delegates browser globals through runtime adapter',
     detailSrc.includes("from './wearables-detail-runtime.js'") &&
       !/\bwindow(?:\.|\s*\[)/.test(detailSrc) &&
       swSrc.includes("'/js/wearables-detail-runtime.js'"));
+  assert('wearable detail shell actions use explicit app-shell dependencies',
+    !runtimeSrc.includes("from './views-runtime-bridge.js'") &&
+      !runtimeSrc.includes('getViewRuntimeFunction') &&
+      runtimeSrc.includes('wearableDetailRuntimeDeps.rememberModalTrigger?.();') &&
+      runtimeSrc.includes("wearableDetailRuntimeDeps.navigate?.(route || 'dashboard');") &&
+      runtimeSrc.includes('wearableDetailRuntimeDeps.closeModal?.();') &&
+      appShellHooksSrc.includes("import { configureWearableDetailRuntimeDeps } from './wearables-detail-runtime.js';") &&
+      appShellHooksSrc.includes('configureWearableDetailRuntimeDeps({ closeModal, navigate, rememberModalTrigger });'));
 } finally {
   configureWearableDetailRuntimeDeps(originalWearableDetailRuntimeDeps);
   restoreRuntime();

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.282';
+self.APP_VERSION = '1.10.283';


### PR DESCRIPTION
## Summary

- inject shell-owned `closeModal`, `navigate`, and `rememberModalTrigger` actions into the wearable-detail runtime
- remove the wearable-detail runtime's fallback lookup through `views-runtime-bridge.js`
- keep Chart access as an explicit browser capability and update unit/browser coverage for the injected seam
- ratchet the quality baseline and bump the app cache version

## Window burden progress

This PR advances the ongoing goal of reducing `window`/view-runtime bridge burden across the codebase.

- before: **10 consumer modules / 11 bridge lookups**
- after: **9 consumer modules / 10 bridge lookups**
- this slice: **-1 consumer / -1 lookup**

The quality guard now enforces the lower 9/10 ceiling. Remaining bridge consumers after this PR:

- `js/emf.js` — 1 lookup
- `js/utils-runtime.js` — 2 lookups
- `js/dashboard-recommendation-widget.js` — 1 lookup
- `js/context-card-editor-ui.js` — 1 lookup
- `js/emf-interpretation.js` — 1 lookup
- `js/wearables-runtime.js` — 1 lookup
- `js/provider-panels.js` — 1 lookup
- `js/chat-runtime.js` — 1 lookup
- `js/recommendations-runtime.js` — 1 lookup

The broader goal remains in progress; the next safe consumer will be handled after this PR merges.

## Validation

- `./run-tests.sh`
  - 126 static verification checks passed
  - 399 Vitest tests passed
  - 18 origin-guard tests passed
  - 352 Playwright tests passed
  - responsive theme sweep: 472 checks passed

