### PR TITLE
Inject wearable dashboard runtime actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -130,6 +130,7 @@ import { configureSupplementsRuntimeDeps } from './supplements-runtime.js';
 import { configureTourRuntimeDeps } from './tour-runtime.js';
 import { configureWearablesConnectRuntimeDeps } from './wearables-connect-runtime.js';
 import { configureWearableDetailRuntimeDeps } from './wearables-detail-runtime.js';
+import { configureWearablesRuntime } from './wearables-runtime.js';
 import { configureWearableSettingsRuntimeDeps } from './wearables-settings-runtime.js';
 
 configureClientListRuntime({
@@ -251,6 +252,7 @@ configureSyncPull({ renderProfileButton });
 configureSyncPullActiveRefreshDeps({ buildSidebar, ensureActiveThread, loadChatHistory, loadChatThreads, navigate, renderThreadList });
 configureWearablesConnectRuntimeDeps({ navigate });
 configureWearableDetailRuntimeDeps({ closeModal, navigate, rememberModalTrigger });
+configureWearablesRuntime({ closeModal, navigate });
 configureWearableSettingsRuntimeDeps({ navigate });
 configureDashboardAIContextStatus(updateChatContextStatus);
 

--- a/js/wearables-runtime.js
+++ b/js/wearables-runtime.js
@@ -3,9 +3,15 @@
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
 import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
+/** @type {{
+ *   closeModal: (() => void) | null,
+ *   navigate: ((route: string) => void) | null,
+ *   openEMFAssessmentEditor: typeof openEMFAssessmentEditor,
+ * }} */
 const wearablesRuntimeDeps = {
+  closeModal: null,
+  navigate: null,
   openEMFAssessmentEditor,
 };
 
@@ -38,7 +44,13 @@ export function getWearablesModuleFunction(name) {
 
 export function configureWearablesRuntime(deps = {}) {
   const previous = { ...wearablesRuntimeDeps };
-  if (typeof deps.openEMFAssessmentEditor === 'function') {
+  if (Object.hasOwn(deps, 'closeModal')) {
+    wearablesRuntimeDeps.closeModal = typeof deps.closeModal === 'function' ? deps.closeModal : null;
+  }
+  if (Object.hasOwn(deps, 'navigate')) {
+    wearablesRuntimeDeps.navigate = typeof deps.navigate === 'function' ? deps.navigate : null;
+  }
+  if (Object.hasOwn(deps, 'openEMFAssessmentEditor') && typeof deps.openEMFAssessmentEditor === 'function') {
     wearablesRuntimeDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
   }
   return previous;
@@ -48,17 +60,6 @@ function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 /**
@@ -72,11 +73,11 @@ function normalizeViewportDimension(value, fallback) {
 
 /** @param {string} route */
 export function navigateWearables(route = 'dashboard') {
-  getRuntimeFunction('navigate')?.(route || 'dashboard');
+  wearablesRuntimeDeps.navigate?.(route || 'dashboard');
 }
 
 export function closeWearablesModal() {
-  getRuntimeFunction('closeModal')?.();
+  wearablesRuntimeDeps.closeModal?.();
 }
 
 export function openWearablesSettings() {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 9,
-  "viewRuntimeBridgeLookups": 10,
+  "viewRuntimeBridgeConsumers": 8,
+  "viewRuntimeBridgeLookups": 9,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/wearables-strip-actions-browser-coverage.spec.js
+++ b/tests/playwright/wearables-strip-actions-browser-coverage.spec.js
@@ -10,11 +10,13 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
       store,
       { profileStorageKey },
       blobStorage,
+      wearablesRuntime,
     ] = await Promise.all([
       import('/js/state.js'),
       import('/js/wearables-store.js'),
       import('/js/profile.js'),
       import('/js/blob-storage.js'),
+      import('/js/wearables-runtime.js'),
     ]);
     const wearables = await import('/js/wearables.js');
 
@@ -47,7 +49,6 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
     const originalProfiles = state.profiles;
     const originalImportedData = state.importedData;
     const originalReorderMode = state._wearableReorderMode;
-    const originalNavigate = window.navigate;
     const host = document.createElement('section');
     const navigations = [];
 
@@ -55,6 +56,12 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
       host.innerHTML = wearables.renderWearableStrip();
       return host.querySelector('#wearable-strip') || host.querySelector('.wearable-strip');
     };
+    const previousWearablesRuntime = wearablesRuntime.configureWearablesRuntime({
+      navigate: route => {
+        navigations.push(route);
+        if (route === 'dashboard') renderStrip();
+      },
+    });
 
     try {
       await store.deleteWearablesDB(profileId).catch(() => {});
@@ -88,10 +95,6 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
         changeHistory: [],
       };
       state._wearableReorderMode = false;
-      window.navigate = route => {
-        navigations.push(route);
-        if (route === 'dashboard') renderStrip();
-      };
       document.body.appendChild(host);
 
       renderStrip();
@@ -207,8 +210,7 @@ test('wearables strip actions cover stub collapse sync reorder move and manual s
       state.profiles = originalProfiles;
       state.importedData = originalImportedData;
       state._wearableReorderMode = originalReorderMode;
-      if (originalNavigate) window.navigate = originalNavigate;
-      else delete window.navigate;
+      wearablesRuntime.configureWearablesRuntime(previousWearablesRuntime);
     }
 
     return failures;

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 9 &&
-    baseline.viewRuntimeBridgeLookups === 10);
+    baseline.viewRuntimeBridgeConsumers === 8 &&
+    baseline.viewRuntimeBridgeLookups === 9);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -20,6 +20,7 @@ const notesRuntimeSrc = fs.readFileSync(path.join(root, 'js/notes-runtime.js'), 
 const shellSrc = fs.readFileSync(path.join(root, 'js/shell-actions.js'), 'utf8');
 const syncPullSrc = fs.readFileSync(path.join(root, 'js/sync-pull.js'), 'utf8');
 const wearableDetailRuntimeSrc = fs.readFileSync(path.join(root, 'js/wearables-detail-runtime.js'), 'utf8');
+const wearablesRuntimeSrc = fs.readFileSync(path.join(root, 'js/wearables-runtime.js'), 'utf8');
 
 let passed = 0;
 let failed = 0;
@@ -166,6 +167,14 @@ assert('App shell injects wearable detail actions without view bridge lookups',
     && wearableDetailRuntimeSrc.includes('wearableDetailRuntimeDeps.closeModal?.();')
     && appShellHooksSrc.includes("import { configureWearableDetailRuntimeDeps } from './wearables-detail-runtime.js';")
     && appShellHooksSrc.includes('configureWearableDetailRuntimeDeps({ closeModal, navigate, rememberModalTrigger });'));
+
+assert('App shell injects wearable dashboard actions without view bridge lookups',
+  !wearablesRuntimeSrc.includes("from './views-runtime-bridge.js'")
+    && !wearablesRuntimeSrc.includes('getViewRuntimeFunction')
+    && wearablesRuntimeSrc.includes("wearablesRuntimeDeps.navigate?.(route || 'dashboard');")
+    && wearablesRuntimeSrc.includes('wearablesRuntimeDeps.closeModal?.();')
+    && appShellHooksSrc.includes("import { configureWearablesRuntime } from './wearables-runtime.js';")
+    && appShellHooksSrc.includes('configureWearablesRuntime({ closeModal, navigate });'));
 
 assert('App shell injects category customization view callbacks',
   appShellHooksSrc.includes('configureCategoryCustomizationRuntimeDeps({ buildSidebar, navigate });'));

--- a/tests/test-wearables-runtime.js
+++ b/tests/test-wearables-runtime.js
@@ -23,8 +23,6 @@ console.log('=== Wearables Runtime Tests ===\n');
 
 const runtimeKeys = [
   'window',
-  'navigate',
-  'closeModal',
   'setTimeout',
   'innerWidth',
   'innerHeight',
@@ -50,12 +48,12 @@ function restoreRuntime() {
 
 try {
   const calls = [];
-  setRuntimeValue('navigate', route => calls.push(['navigate', route]));
-  setRuntimeValue('closeModal', () => calls.push(['close-modal']));
   const restoreSettingsBridge = configureSettingsModuleBridge({
     openSettingsModal: section => calls.push(['settings', section]),
   });
   const restoreWearablesRuntime = configureWearablesRuntime({
+    closeModal: () => calls.push(['close-modal']),
+    navigate: route => calls.push(['navigate', route]),
     openEMFAssessmentEditor: () => calls.push(['emf-editor']),
   });
   setRuntimeValue('setTimeout', (fn, delay) => {

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.283';
+self.APP_VERSION = '1.10.284';


### PR DESCRIPTION
## Summary

- inject shell-owned `closeModal` and `navigate` actions into the wearable dashboard runtime
- remove the wearable runtime's fallback lookup through `views-runtime-bridge.js`
- retain viewport and timer access as explicit browser capabilities
- update unit, source-guard, and browser coverage for the injected seam
- ratchet the quality baseline and bump the app cache version

## Window burden progress

This PR advances the ongoing goal of reducing `window`/view-runtime bridge burden across the codebase.

- before: **9 consumer modules / 10 bridge lookups**
- after: **8 consumer modules / 9 bridge lookups**
- this slice: **-1 consumer / -1 lookup**

The quality guard now enforces the lower 8/9 ceiling. Remaining bridge consumers after this PR:

- `js/emf.js` — 1 lookup
- `js/utils-runtime.js` — 2 lookups
- `js/dashboard-recommendation-widget.js` — 1 lookup
- `js/context-card-editor-ui.js` — 1 lookup
- `js/emf-interpretation.js` — 1 lookup
- `js/provider-panels.js` — 1 lookup
- `js/chat-runtime.js` — 1 lookup
- `js/recommendations-runtime.js` — 1 lookup

The broader goal remains in progress; the next safe consumer will be handled after this PR merges.

## Validation

- `./run-tests.sh`
  - 126 static verification checks passed
  - 399 Vitest tests passed
  - 18 origin-guard tests passed
  - 352 Playwright tests passed
  - responsive theme sweep: 472 checks passed

