### PR TITLE
Inject chat modal close callback

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -196,6 +196,7 @@ function resumeAI() {
 
 configureChatPanel({ refreshMobileDashboardActiveTab });
 configureChatRuntimeCallbacks({
+  closeModal,
   isChatStreaming,
   refreshWebSearchToggle,
   renderChatMessages,

--- a/js/chat-runtime.js
+++ b/js/chat-runtime.js
@@ -2,10 +2,10 @@
 // chat-runtime.js - Browser runtime adapters for shared chat hooks.
 
 import { openContextModalRuntime } from './context-cards-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
-/** @type {Record<'isChatStreaming' | 'refreshWebSearchToggle' | 'renderChatMessages' | 'resumeAI' | 'sendChatMessage' | 'updateChatHeaderModel' | 'updateChatNudge' | 'updateDiscussButton', Function | null>} */
+/** @type {Record<'closeModal' | 'isChatStreaming' | 'refreshWebSearchToggle' | 'renderChatMessages' | 'resumeAI' | 'sendChatMessage' | 'updateChatHeaderModel' | 'updateChatNudge' | 'updateDiscussButton', Function | null>} */
 const chatRuntimeCallbacks = {
+  closeModal: null,
   isChatStreaming: null,
   refreshWebSearchToggle: null,
   renderChatMessages: null,
@@ -41,17 +41,6 @@ function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 /**
@@ -92,7 +81,7 @@ export function openChatContextModalRuntime() {
 }
 
 export function closeChatModalRuntime() {
-  getRuntimeFunction('closeModal')?.();
+  callChatRuntimeCallback('closeModal');
 }
 
 export function isChatRuntimeStreaming() {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 8,
-  "viewRuntimeBridgeLookups": 9,
+  "viewRuntimeBridgeConsumers": 7,
+  "viewRuntimeBridgeLookups": 8,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/chat-runtime.test.js
+++ b/tests/chat-runtime.test.js
@@ -27,7 +27,6 @@ const MOCK_PATHS = [
 ];
 
 const realGetElementById = globalThis.document?.getElementById;
-const realCloseModal = globalThis.window?.closeModal;
 
 beforeEach(async () => {
   await vi.resetModules();
@@ -37,8 +36,6 @@ beforeEach(async () => {
   if (globalThis.document && realGetElementById) {
     globalThis.document.getElementById = realGetElementById;
   }
-  if (realCloseModal) globalThis.window.closeModal = realCloseModal;
-  else delete globalThis.window.closeModal;
 });
 
 afterEach(() => {
@@ -48,8 +45,6 @@ afterEach(() => {
   if (globalThis.document && realGetElementById) {
     globalThis.document.getElementById = realGetElementById;
   }
-  if (realCloseModal) globalThis.window.closeModal = realCloseModal;
-  else delete globalThis.window.closeModal;
 });
 
 async function loadContinuation(callClaudeAPI) {
@@ -692,7 +687,8 @@ describe('chat marker prompt runtime behavior', () => {
     };
     deps.getActiveData.mockReturnValue({ dates: ['2026-01-01', '2026-02-01', '2026-03-01'] });
     const closeModal = vi.fn();
-    globalThis.window.closeModal = closeModal;
+    const chatRuntime = await import('../js/chat-runtime.js');
+    const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({ closeModal });
     const mod = await import('../js/chat-marker-prompts.js');
 
     mod.askAIAboutMarker('ferritin');
@@ -713,6 +709,7 @@ describe('chat marker prompt runtime behavior', () => {
     expect(prompt).toContain('Current status: optimal');
     expect(prompt).toContain('Trend: up 50% from previous.');
     expect(prompt).toContain('phase-specific for the menstrual cycle');
+    chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
   });
 
   it('opens a correlation prompt for selected markers and ignores missing markers', async () => {

--- a/tests/playwright/chat-discussion-browser-coverage.spec.js
+++ b/tests/playwright/chat-discussion-browser-coverage.spec.js
@@ -554,17 +554,17 @@ test('chat marker and correlation prompt handoffs prefill chat threads from brow
   await page.waitForSelector('#chat-input');
 
   const results = await page.evaluate(async ({ markerPromptsUrl }) => {
-    const [{ state }, data, markerPrompts] = await Promise.all([
+    const [{ state }, data, markerPrompts, chatRuntime] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import(markerPromptsUrl),
+      import('/js/chat-runtime.js'),
     ]);
     const outcomes = {};
     const storage = new Map(Array.from({ length: localStorage.length }, (_, index) => {
       const key = localStorage.key(index);
       return [key, key ? localStorage.getItem(key) : null];
     }));
-    const originalCloseModal = window.closeModal;
     const original = {
       currentProfile: state.currentProfile,
       importedData: state.importedData,
@@ -580,6 +580,9 @@ test('chat marker and correlation prompt handoffs prefill chat threads from brow
       panelClass: document.getElementById('chat-panel')?.className,
     };
     let closeCalls = 0;
+    const previousChatRuntime = chatRuntime.configureChatRuntimeCallbacks({
+      closeModal: () => { closeCalls += 1; },
+    });
     const waitFor = async (predicate) => {
       for (let i = 0; i < 60; i += 1) {
         if (predicate()) return true;
@@ -617,8 +620,6 @@ test('chat marker and correlation prompt handoffs prefill chat threads from brow
           id: 'ferritin',
         },
       };
-      window.closeModal = () => { closeCalls += 1; };
-
       const input = document.getElementById('chat-input');
       input.value = '';
       markerPrompts.askAIAboutMarker('missing-marker');
@@ -658,7 +659,7 @@ test('chat marker and correlation prompt handoffs prefill chat threads from brow
       state.chatThreads = original.chatThreads;
       state.currentThreadId = original.currentThreadId;
       state.currentChatPersonality = original.currentChatPersonality;
-      window.closeModal = originalCloseModal;
+      chatRuntime.configureChatRuntimeCallbacks(previousChatRuntime);
       data.invalidateActiveDataCache();
       const input = document.getElementById('chat-input');
       if (input && original.inputValue != null) input.value = original.inputValue;

--- a/tests/test-chat-runtime.js
+++ b/tests/test-chat-runtime.js
@@ -38,7 +38,6 @@ const runtimeKeys = [
   'renderChatMessages',
   'updateDiscussButton',
   'openContextModal',
-  'closeModal',
   'isChatStreaming',
   'sendChatMessage',
   '_ppqAttestation',
@@ -70,6 +69,7 @@ try {
     openContextModal: () => calls.push(['context']),
   });
   const previousChatRuntime = configureChatRuntimeCallbacks({
+    closeModal: () => calls.push(['close']),
     isChatStreaming: () => false,
     refreshWebSearchToggle: () => calls.push(['web-search']),
     renderChatMessages: () => calls.push(['render']),
@@ -84,7 +84,6 @@ try {
   const veniceAttestation = { provider: 'venice', verified: true };
   setRuntimeValue('window', globalThis);
   setRuntimeValue('openContextModal', () => calls.push(['legacy-context']));
-  setRuntimeValue('closeModal', () => calls.push(['close']));
   setRuntimeValue('_ppqAttestation', ppqAttestation);
   setRuntimeValue('_routstrAttestation', routstrAttestation);
   setRuntimeValue('_veniceAttestation', veniceAttestation);
@@ -134,6 +133,7 @@ try {
 
   configureContextCardsRuntimeCallbacks({ openContextModal: null });
   configureChatRuntimeCallbacks({
+    closeModal: null,
     isChatStreaming: null,
     refreshWebSearchToggle: null,
     renderChatMessages: null,

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 8 &&
-    baseline.viewRuntimeBridgeLookups === 9);
+    baseline.viewRuntimeBridgeConsumers === 7 &&
+    baseline.viewRuntimeBridgeLookups === 8);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -13,6 +13,7 @@ const appShellHooksSrc = fs.readFileSync(path.join(root, 'js/app-shell-hooks.js'
 const biologyScoreContextAISrc = fs.readFileSync(path.join(root, 'js/biology-score-context-ai.js'), 'utf8');
 const categoryPageViewSrc = fs.readFileSync(path.join(root, 'js/category-page-view.js'), 'utf8');
 const chatEmptyStateSrc = fs.readFileSync(path.join(root, 'js/chat-empty-state.js'), 'utf8');
+const chatRuntimeSrc = fs.readFileSync(path.join(root, 'js/chat-runtime.js'), 'utf8');
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
 const lensPageShellSrc = fs.readFileSync(path.join(root, 'js/lens-page-shell.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
@@ -119,9 +120,15 @@ assert('App shell injects core Context Cards view callbacks without bridge looku
 assert('App shell wires Chat UI refreshes without window globals',
   appShellHooksSrc.includes("import { configureChatRuntimeCallbacks } from './chat-runtime.js'")
     && appShellHooksSrc.includes('configureChatRuntimeCallbacks({')
+    && appShellHooksSrc.includes('  closeModal,')
     && appShellHooksSrc.includes('refreshWebSearchToggle,')
     && appShellHooksSrc.includes('resumeAI,')
     && appShellHooksSrc.includes('sendChatMessage,'));
+
+assert('App shell injects Chat modal close without a view bridge lookup',
+  !chatRuntimeSrc.includes("from './views-runtime-bridge.js'")
+    && !chatRuntimeSrc.includes('getViewRuntimeFunction')
+    && chatRuntimeSrc.includes("callChatRuntimeCallback('closeModal');"));
 
 assert('App shell wires Chat prompt consumers without window globals',
   appShellHooksSrc.includes("import { configureBiologyScoresRuntimeDeps } from './biology-scores-runtime.js'")

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.284';
+self.APP_VERSION = '1.10.285';


### PR DESCRIPTION
## Summary

- inject the shell-owned `closeModal` action through the existing Chat runtime callback registry
- remove the Chat runtime's fallback lookup through `views-runtime-bridge.js`
- retain browser runtime access only for provider attestation values
- update unit, Vitest, source-guard, and browser coverage for the injected seam
- ratchet the quality baseline and bump the app cache version

## Window burden progress

This PR advances the ongoing goal of reducing `window`/view-runtime bridge burden across the codebase.

- before: **8 consumer modules / 9 bridge lookups**
- after: **7 consumer modules / 8 bridge lookups**
- this slice: **-1 consumer / -1 lookup**

The quality guard now enforces the lower 7/8 ceiling. Remaining bridge consumers after this PR:

- `js/emf.js` — 1 lookup
- `js/utils-runtime.js` — 2 lookups
- `js/dashboard-recommendation-widget.js` — 1 lookup
- `js/context-card-editor-ui.js` — 1 lookup
- `js/emf-interpretation.js` — 1 lookup
- `js/provider-panels.js` — 1 lookup
- `js/recommendations-runtime.js` — 1 lookup

The broader goal remains in progress; the next safe consumer will be handled after this PR merges.

## Validation

- `./run-tests.sh`
  - 126 static verification checks passed
  - 399 Vitest tests passed
  - 18 origin-guard tests passed
  - 352 Playwright tests passed
  - responsive theme sweep: 472 checks passed

