### PR TITLE
Inject EMF interpretation close callback

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -186,7 +186,7 @@ configureNotesRuntimeDeps({ closeModal, navigate, rememberModalTrigger });
 configureContextCardLifestyleRuntimeDeps({ closeModal, navigate, openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel, openChatProviderQuiz, setOnboardingFocus });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });
-configureEMFInterpretationRuntimeDeps({ openChatPanel });
+configureEMFInterpretationRuntimeDeps({ closeModal, openChatPanel });
 
 function resumeAI() {
   setAIPaused(false);

--- a/js/emf-interpretation.js
+++ b/js/emf-interpretation.js
@@ -9,7 +9,6 @@ import { callClaudeAPI, getAIProvider, getActiveModelId, getActiveModelDisplay }
 import { renderMarkdown } from './markdown.js';
 import { loadEMFCatalog, renderEMFMitigationRecs, isProductRecsEnabled, detectMitigationsInText } from './recommendations.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 /**
  * @typedef {{ text?: string, model?: string, provider?: string, modelId?: string, inputTokens?: number, outputTokens?: number, date?: string }} EMFInterpretation
@@ -19,12 +18,18 @@ import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const emfInterpretationRuntimeDeps = {
   callClaudeAPI,
+  closeModal: /** @type {null | (() => void)} */ (null),
   openChatPanel: /** @type {null | ((message?: string) => unknown)} */ (null),
 };
 
 export function configureEMFInterpretationRuntimeDeps(deps = {}) {
   const previous = { ...emfInterpretationRuntimeDeps };
   if (typeof deps.callClaudeAPI === 'function') emfInterpretationRuntimeDeps.callClaudeAPI = deps.callClaudeAPI;
+  if (Object.hasOwn(deps, 'closeModal')) {
+    emfInterpretationRuntimeDeps.closeModal = typeof deps.closeModal === 'function'
+      ? deps.closeModal
+      : null;
+  }
   if (Object.prototype.hasOwnProperty.call(deps, 'openChatPanel')) {
     emfInterpretationRuntimeDeps.openChatPanel = typeof deps.openChatPanel === 'function'
       ? deps.openChatPanel
@@ -35,27 +40,8 @@ export function configureEMFInterpretationRuntimeDeps(deps = {}) {
 
 let _aiAbortController = null;
 
-/**
- * @returns {Record<string, any>}
- */
-function getEMFInterpretationRuntimeScope() {
-  return typeof window !== 'undefined'
-    ? /** @type {Record<string, any>} */ (window)
-    : /** @type {Record<string, any>} */ (globalThis);
-}
-
-/**
- * @param {string} name
- * @returns {((...args: any[]) => any) | null}
- */
-function getEMFInterpretationRuntimeFunction(name) {
-  const runtime = getEMFInterpretationRuntimeScope();
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
-}
-
 function closeParentEMFModalRuntime() {
-  getEMFInterpretationRuntimeFunction('closeModal')?.();
+  emfInterpretationRuntimeDeps.closeModal?.();
 }
 
 function openEMFInterpretationChatRuntime(message) {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 7,
-  "viewRuntimeBridgeLookups": 8,
+  "viewRuntimeBridgeConsumers": 6,
+  "viewRuntimeBridgeLookups": 7,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -57,11 +57,11 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
     const saved = {
       importedData: clone(state.importedData),
       currentProfile: state.currentProfile,
-      closeModal: window.closeModal,
     };
     const outcomes = {};
     const calls = [];
     const previousInterpretationDeps = emfInterpretation.configureEMFInterpretationRuntimeDeps({
+      closeModal: () => calls.push(['close-modal']),
       openChatPanel: prompt => calls.push(['chat', prompt]),
     });
 
@@ -193,7 +193,6 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
         && document.querySelector('.emf-compare-table')?.textContent.includes('28') === true
         && document.querySelector('.emf-compare-table')?.textContent.includes('4') === true;
 
-      window.closeModal = () => calls.push(['close-modal']);
       emf.interpretEMFComparison();
       await waitFor('#emf-interp-overlay.show .emf-interp-modal', 'EMF existing interpretation modal');
       document.querySelector('#emf-interp-overlay [data-emf-interp-action="discuss"]')?.click();
@@ -222,7 +221,6 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
       state.currentProfile = saved.currentProfile;
       data.invalidateActiveDataCache();
       emfInterpretation.configureEMFInterpretationRuntimeDeps(previousInterpretationDeps);
-      window.closeModal = saved.closeModal;
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -76,8 +76,9 @@ assert('EMF editor runtime hooks avoid counted direct window globals',
     emfSrc.includes('return showPromptDialog(message, options);') &&
     !/\bwindow(?:\.|\s*\[)/.test(emfSrc));
 assert('EMF interpretation runtime hooks avoid counted direct window globals',
-  emfInterpretationSrc.includes('function getEMFInterpretationRuntimeFunction') &&
-    emfInterpretationSrc.includes("getEMFInterpretationRuntimeFunction('closeModal')") &&
+  !emfInterpretationSrc.includes("from './views-runtime-bridge.js'") &&
+    !emfInterpretationSrc.includes('getViewRuntimeFunction') &&
+    emfInterpretationSrc.includes('emfInterpretationRuntimeDeps.closeModal?.()') &&
     emfInterpretationSrc.includes('emfInterpretationRuntimeDeps.openChatPanel?.(message)') &&
     !/\bwindow(?:\.|\s*\[)/.test(emfInterpretationSrc));
 assert('EMF editor X button uses saving close action',

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 7 &&
-    baseline.viewRuntimeBridgeLookups === 8);
+    baseline.viewRuntimeBridgeConsumers === 6 &&
+    baseline.viewRuntimeBridgeLookups === 7);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -158,7 +158,7 @@ assert('App shell injects Chat empty-state view callbacks without bridge or glob
     && appShellHooksSrc.includes('configureChatEmptyStateDeps({ closeChatPanel, openChatProviderQuiz, setOnboardingFocus });'));
 
 assert('App shell wires remaining Chat open consumers without window globals',
-  appShellHooksSrc.includes('configureEMFInterpretationRuntimeDeps({ openChatPanel });')
+  appShellHooksSrc.includes('configureEMFInterpretationRuntimeDeps({ closeModal, openChatPanel });')
     && appShellHooksSrc.includes('configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });')
     && appShellHooksSrc.includes('configureTourRuntimeDeps({ openChatPanel });'));
 

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.285';
+self.APP_VERSION = '1.10.286';


### PR DESCRIPTION
## What changed

- inject the shared modal close callback into the EMF interpretation runtime dependencies
- remove the EMF interpretation fallback through `views-runtime-bridge.js`
- update focused browser and static contract coverage
- ratchet the bridge baseline from 7 consumers / 8 lookups to 6 consumers / 7 lookups
- bump the app version for cache invalidation

## Why

EMF interpretation still discovered `closeModal` through the browser runtime and the view runtime bridge. Explicit injection removes that hidden coupling and moves the codebase one step closer to retiring the compatibility bridge.

## Validation

- `./run-tests.sh`
- `npm run quality`
- `git diff --check`

Full local results include 352 passing Playwright tests and 472 passing theme/responsive checks.