### PR TITLE
Inject EMF editor close callback

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -77,6 +77,7 @@ import { configureCryptoProfileDeps } from './crypto.js';
 import { configureCycleRuntimeDeps } from './cycle-runtime.js';
 import { configureDataRuntimeDeps } from './data.js';
 import { configureDnaRuntimeDeps } from './dna-runtime.js';
+import { configureEMFRuntimeDeps } from './emf-runtime.js';
 import { closeEMFInterpretation, configureEMFInterpretationRuntimeDeps } from './emf-interpretation.js';
 import { clearAllData, closeReportBuilder, configureExportRuntimeDeps } from './export.js';
 import { exportAllDataJSON, exportClientJSON, importDataJSON, loadDemoData } from './export.js';
@@ -186,6 +187,7 @@ configureNotesRuntimeDeps({ closeModal, navigate, rememberModalTrigger });
 configureContextCardLifestyleRuntimeDeps({ closeModal, navigate, openChatPanel, useChatPrompt });
 configureChatEmptyStateDeps({ closeChatPanel, openChatProviderQuiz, setOnboardingFocus });
 configureDashboardPageRuntimeDeps({ closeChatPanel, openChatPanel });
+configureEMFRuntimeDeps({ closeModal });
 configureEMFInterpretationRuntimeDeps({ closeModal, openChatPanel });
 
 function resumeAI() {

--- a/js/emf-runtime.js
+++ b/js/emf-runtime.js
@@ -3,13 +3,35 @@
 
 /** @type {Promise<typeof import('./emf.js')> | null} */
 let emfModulePromise = null;
+/** @type {typeof import('./emf.js') | null} */
+let emfModule = null;
+
+const emfRuntimeDeps = {
+  closeModal: /** @type {null | (() => void)} */ (null),
+};
+
+export function configureEMFRuntimeDeps(deps = {}) {
+  const previous = { ...emfRuntimeDeps };
+  if (Object.hasOwn(deps, 'closeModal')) {
+    emfRuntimeDeps.closeModal = typeof deps.closeModal === 'function' ? deps.closeModal : null;
+  }
+  emfModule?.configureEMFRuntimeDeps(emfRuntimeDeps);
+  return previous;
+}
 
 export async function loadEMFModule() {
   if (!emfModulePromise) {
-    emfModulePromise = import('./emf.js').catch(err => {
-      emfModulePromise = null;
-      throw err;
-    });
+    emfModulePromise = import('./emf.js')
+      .then(mod => {
+        emfModule = mod;
+        mod.configureEMFRuntimeDeps(emfRuntimeDeps);
+        return mod;
+      })
+      .catch(err => {
+        emfModulePromise = null;
+        emfModule = null;
+        throw err;
+      });
   }
   return await emfModulePromise;
 }

--- a/js/emf.js
+++ b/js/emf.js
@@ -17,7 +17,6 @@ import { extractPDFText } from './pdf-import.js';
 import { obfuscatePDFText, sanitizeWithOllama, sanitizeWithOllamaStreaming, checkOllamaPII, reviewPIIBeforeSend } from './pii.js';
 import { loadEMFCatalog, renderEMFMeterRecs, isProductRecsEnabled } from './recommendations.js';
 import { openModalOverlay, removeModalOverlay, trapModalFocus } from './modal-lifecycle.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 import {
   closeEMFInterpretation,
   discussEMFInterpretation,
@@ -30,10 +29,22 @@ const emfAIDeps = {
   hasAIProvider,
 };
 
+const emfRuntimeDeps = {
+  closeModal: /** @type {null | (() => void)} */ (null),
+};
+
 export function configureEMFAIDeps(deps = {}) {
   const previous = { ...emfAIDeps };
   if (typeof deps.callClaudeAPI === 'function') emfAIDeps.callClaudeAPI = deps.callClaudeAPI;
   if (typeof deps.hasAIProvider === 'function') emfAIDeps.hasAIProvider = deps.hasAIProvider;
+  return previous;
+}
+
+export function configureEMFRuntimeDeps(deps = {}) {
+  const previous = { ...emfRuntimeDeps };
+  if (Object.hasOwn(deps, 'closeModal')) {
+    emfRuntimeDeps.closeModal = typeof deps.closeModal === 'function' ? deps.closeModal : null;
+  }
   return previous;
 }
 
@@ -136,27 +147,8 @@ let _editingAssessmentId = null;
 let _activeRoomIdx = 0;
 let emfEditorDelegatesInstalled = false;
 
-/**
- * @returns {Record<string, any>}
- */
-function getEMFRuntimeScope() {
-  return typeof window !== 'undefined'
-    ? /** @type {Record<string, any>} */ (window)
-    : /** @type {Record<string, any>} */ (globalThis);
-}
-
-/**
- * @param {string} name
- * @returns {((...args: any[]) => any) | null}
- */
-function getEMFRuntimeFunction(name) {
-  const runtime = getEMFRuntimeScope();
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
-}
-
 function closeEMFModalRuntime() {
-  getEMFRuntimeFunction('closeModal')?.();
+  emfRuntimeDeps.closeModal?.();
 }
 
 /**

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 6,
-  "viewRuntimeBridgeLookups": 7,
+  "viewRuntimeBridgeConsumers": 5,
+  "viewRuntimeBridgeLookups": 6,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/emf-edge-browser-coverage.spec.js
+++ b/tests/playwright/emf-edge-browser-coverage.spec.js
@@ -156,8 +156,10 @@ test('EMF edge browser coverage imports PDFs photos rooms and streams interpreta
     const original = {
       importedData: state.importedData,
       currentProfile: state.currentProfile,
-      closeModal: window.closeModal,
     };
+    const previousRuntimeDeps = emf.configureEMFRuntimeDeps({
+      closeModal: () => document.getElementById('modal-overlay')?.classList.remove('show'),
+    });
     const assessments = () => state.importedData.emfAssessment?.assessments || [];
 
     try {
@@ -178,7 +180,6 @@ test('EMF edge browser coverage imports PDFs photos rooms and streams interpreta
         changeHistory: [],
         emfAssessment: { assessments: [] },
       };
-      window.closeModal = () => document.getElementById('modal-overlay')?.classList.remove('show');
       localStorage.setItem('labcharts-pii-review', 'false');
 
       emf.openEMFAssessmentEditor();
@@ -305,7 +306,7 @@ test('EMF edge browser coverage imports PDFs photos rooms and streams interpreta
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       state.importedData = original.importedData;
       state.currentProfile = original.currentProfile;
-      window.closeModal = original.closeModal;
+      emf.configureEMFRuntimeDeps(previousRuntimeDeps);
       localStorage.clear();
       for (const [key, value] of storage) {
         if (key && value != null) localStorage.setItem(key, value);

--- a/tests/playwright/environment-coverage-batch.spec.js
+++ b/tests/playwright/environment-coverage-batch.spec.js
@@ -11,13 +11,18 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async () => {
-    const [{ state }, data, editorUi, emf, emfInterpretation] = await Promise.all([
+    const [{ state }, data, editorUi, emfRuntime, emfInterpretation] = await Promise.all([
       import('/js/state.js'),
       import('/js/data.js'),
       import('/js/context-card-editor-ui.js'),
-      import('/js/emf.js'),
+      import('/js/emf-runtime.js'),
       import('/js/emf-interpretation.js'),
     ]);
+    const calls = [];
+    const previousRuntimeDeps = emfRuntime.configureEMFRuntimeDeps({
+      closeModal: () => calls.push(['close-editor-modal']),
+    });
+    const emf = await emfRuntime.loadEMFModule();
     if (typeof window.toggleCtxTag !== 'function') window.toggleCtxTag = editorUi.toggleCtxTag;
 
     const clone = value => value == null ? value : JSON.parse(JSON.stringify(value));
@@ -59,7 +64,6 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
       currentProfile: state.currentProfile,
     };
     const outcomes = {};
-    const calls = [];
     const previousInterpretationDeps = emfInterpretation.configureEMFInterpretationRuntimeDeps({
       closeModal: () => calls.push(['close-modal']),
       openChatPanel: prompt => calls.push(['chat', prompt]),
@@ -212,6 +216,11 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
       outcomes.deleteConfirmsRemovesAndKeepsListUsable =
         !assessments().some(a => a.id === id)
         && document.querySelector('.emf-assessment-card')?.textContent.includes('After mitigation') === true;
+
+      document.querySelector('#detail-modal .modal-close')?.click();
+      await waitUntil(() => calls.some(call => call[0] === 'close-editor-modal'), 'lazy EMF editor close callback');
+      outcomes.lazyRuntimeInjectsEditorCloseCallback =
+        calls.filter(call => call[0] === 'close-editor-modal').length === 1;
     } finally {
       document.querySelectorAll('.emf-lightbox,.notification-container').forEach(el => el.remove());
       document.getElementById('confirm-dialog-overlay')?.remove();
@@ -220,6 +229,7 @@ test('EMF assessment editor covers room measurements tags compare delete and cha
       state.importedData = saved.importedData;
       state.currentProfile = saved.currentProfile;
       data.invalidateActiveDataCache();
+      emfRuntime.configureEMFRuntimeDeps(previousRuntimeDeps);
       emfInterpretation.configureEMFInterpretationRuntimeDeps(previousInterpretationDeps);
       localStorage.clear();
       for (const [key, value] of storage) {

--- a/tests/test-emf-delegated-actions.js
+++ b/tests/test-emf-delegated-actions.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
+const emfRuntimeSrc = fs.readFileSync(path.join(root, 'js/emf-runtime.js'), 'utf8');
 const emfInterpretationSrc = fs.readFileSync(path.join(root, 'js/emf-interpretation.js'), 'utf8');
 
 let passed = 0;
@@ -72,7 +73,10 @@ assert('EMF editor close path preserves save and lightbox cleanup',
     emfSrc.includes('removeEMFEditorDelegates();') &&
     emfSrc.includes('closeEMFModalRuntime();'));
 assert('EMF editor runtime hooks avoid counted direct window globals',
-  emfSrc.includes("getEMFRuntimeFunction('closeModal')") &&
+  !emfSrc.includes("from './views-runtime-bridge.js'") &&
+    !emfSrc.includes('getViewRuntimeFunction') &&
+    emfSrc.includes('emfRuntimeDeps.closeModal?.()') &&
+    emfRuntimeSrc.includes('mod.configureEMFRuntimeDeps(emfRuntimeDeps);') &&
     emfSrc.includes('return showPromptDialog(message, options);') &&
     !/\bwindow(?:\.|\s*\[)/.test(emfSrc));
 assert('EMF interpretation runtime hooks avoid counted direct window globals',

--- a/tests/test-emf.js
+++ b/tests/test-emf.js
@@ -132,6 +132,7 @@ const missingExports = emfWindowFns.filter(fn => typeof emfMod[fn] !== 'function
 assert('45. All former facade functions remain emf.js exports', missingExports.length === 0, missingExports.join(', '));
 assert('45a. EMF runtime exports a lazy module loader', typeof emfRuntimeMod.loadEMFModule === 'function');
 assert('45b. EMF runtime exposes only the lazy cross-module entry points',
+  typeof emfRuntimeMod.configureEMFRuntimeDeps === 'function' &&
   typeof emfRuntimeMod.openEMFAssessmentEditor === 'function' &&
   typeof emfRuntimeMod.closeEMFInterpretation === 'function');
 const mainSrc = read('js/main.js');

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 6 &&
-    baseline.viewRuntimeBridgeLookups === 7);
+    baseline.viewRuntimeBridgeConsumers === 5 &&
+    baseline.viewRuntimeBridgeLookups === 6);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -14,6 +14,8 @@ const biologyScoreContextAISrc = fs.readFileSync(path.join(root, 'js/biology-sco
 const categoryPageViewSrc = fs.readFileSync(path.join(root, 'js/category-page-view.js'), 'utf8');
 const chatEmptyStateSrc = fs.readFileSync(path.join(root, 'js/chat-empty-state.js'), 'utf8');
 const chatRuntimeSrc = fs.readFileSync(path.join(root, 'js/chat-runtime.js'), 'utf8');
+const emfRuntimeSrc = fs.readFileSync(path.join(root, 'js/emf-runtime.js'), 'utf8');
+const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
 const lensPageShellSrc = fs.readFileSync(path.join(root, 'js/lens-page-shell.js'), 'utf8');
 const mainSrc = fs.readFileSync(path.join(root, 'js/main.js'), 'utf8');
@@ -161,6 +163,14 @@ assert('App shell wires remaining Chat open consumers without window globals',
   appShellHooksSrc.includes('configureEMFInterpretationRuntimeDeps({ closeModal, openChatPanel });')
     && appShellHooksSrc.includes('configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });')
     && appShellHooksSrc.includes('configureTourRuntimeDeps({ openChatPanel });'));
+
+assert('App shell injects the lazy EMF editor close callback without bridge lookups',
+  !emfSrc.includes("from './views-runtime-bridge.js'")
+    && !emfSrc.includes('getViewRuntimeFunction')
+    && emfSrc.includes('emfRuntimeDeps.closeModal?.();')
+    && emfRuntimeSrc.includes('mod.configureEMFRuntimeDeps(emfRuntimeDeps);')
+    && appShellHooksSrc.includes("import { configureEMFRuntimeDeps } from './emf-runtime.js';")
+    && appShellHooksSrc.includes('configureEMFRuntimeDeps({ closeModal });'));
 
 assert('App shell injects wearable navigation without view bridge lookups',
   appShellHooksSrc.includes('configureWearablesConnectRuntimeDeps({ navigate });')

--- a/tests/verify-modules.js
+++ b/tests/verify-modules.js
@@ -458,16 +458,16 @@
     'toggleCycleSymptomTag','_toggleCycleEditorFields'
   ];
 
-  // emf.js (23 exports, module-only; lazy runtime keeps feature startup deferred)
+  // emf.js (24 exports, module-only; lazy runtime keeps feature startup deferred)
   const emfExports = [
-    'configureEMFAIDeps','openEMFAssessmentEditor','addEMFAssessment','toggleEMFAssessment',
+    'configureEMFAIDeps','configureEMFRuntimeDeps','openEMFAssessmentEditor','addEMFAssessment','toggleEMFAssessment',
     'selectEMFRoom','handleEMFRoomDropdown','addEMFRoom','removeEMFRoom','deleteEMFAssessment',
     'updateEMFField','updateEMFRoom','updateEMFMeasurement','updateEMFMeter','handleEMFPDF',
     'toggleEMFCompare','closeEMFInterpretation','discussEMFInterpretation','interpretEMFAssessment',
     'interpretEMFComparison','addEMFPhotos','removeEMFPhoto','viewEMFPhoto','saveEMFExplicit'
   ];
-  const emfLegacyGlobals = emfExports.filter(name => name !== 'configureEMFAIDeps');
-  const emfRuntimeExports = ['loadEMFModule','openEMFAssessmentEditor','closeEMFInterpretation'];
+  const emfLegacyGlobals = emfExports.filter(name => !name.startsWith('configureEMF'));
+  const emfRuntimeExports = ['configureEMFRuntimeDeps','loadEMFModule','openEMFAssessmentEditor','closeEMFInterpretation'];
 
   // data.js (30 former browser globals plus one test hook, now module-only)
   const dataExports = [

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.286';
+self.APP_VERSION = '1.10.287';


### PR DESCRIPTION
## What changed

- add an explicit close callback dependency to the EMF editor module
- forward that callback through the existing lazy `emf-runtime.js` loader without eagerly loading the feature
- remove the EMF editor fallback through `views-runtime-bridge.js`
- cover preconfigured lazy loading and isolated direct-module behavior in Playwright
- ratchet the bridge baseline from 6 consumers / 7 lookups to 5 consumers / 6 lookups
- bump the app version for cache invalidation

## Why

The EMF editor still discovered `closeModal` through the browser runtime and view bridge. Explicit injection removes the hidden callback lookup while retaining lazy feature startup.

## Validation

- `./run-tests.sh`
- `npm run quality`
- `npm run typecheck:checkjs`
- focused EMF Playwright coverage
- `node tests/verify-modules.js`
- `git diff --check`

Full local results include 352 passing Playwright tests and 472 passing theme/responsive checks.