### PR TITLE
Inject dashboard recommendation actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -27,6 +27,7 @@ import {
 import { configureDashboardAIContextStatus } from './context-card-dashboard-ai-runtime.js';
 import { configureContextCardLifestyleRuntimeDeps } from './context-card-lifestyle-runtime.js';
 import { configureDashboardPageRuntimeDeps } from './dashboard-page-view.js';
+import { configureDashboardRecommendationRuntimeDeps } from './dashboard-recommendation-widget.js';
 import { configureDashboardWidgetRuntimeDeps } from './dashboard-widget-runtime.js';
 import {
   closeChatPanel,
@@ -101,6 +102,7 @@ import {
   navigate,
   openChatProviderQuiz,
   openCreateMarkerModal,
+  openRecommendationDetail,
   refreshMobileDashboardActiveTab,
   renameCategory,
   renameMarker,
@@ -110,11 +112,15 @@ import {
   revertMarkerName,
   showDetailModal,
   setOnboardingFocus,
+  dismissRecommendation,
+  discussRecommendation,
+  saveRecommendation,
   toggleDashboardOrganizeMode,
 } from './views.js';
 import { configureViewsRouterRuntimeDeps } from './views-router-runtime.js';
 import { openProfileShareModal } from './profile-share.js';
 import { getActiveProfileId } from './profile.js';
+import { detectWearableTrendSlots } from './recommendations.js';
 import { configureRecommendationsRuntime } from './recommendations-runtime.js';
 import {
   configureShellChatActionDeps,
@@ -181,6 +187,16 @@ configureSunRuntimeDeps({
 configureBiologyScoreContextAIDeps({ navigate });
 configureBiologyScoresRuntimeDeps({ navigate, openChatPanel, showDetailModal, useChatPrompt });
 configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });
+configureDashboardRecommendationRuntimeDeps({
+  detectWearableTrendSlots,
+  dismissRecommendation,
+  discussRecommendation,
+  navigate,
+  openRecommendationDetail,
+  openSettingsModal,
+  saveRecommendation,
+  showDetailModal,
+});
 configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });
 configureLensPageShell({ navigate });
 configureNotesRuntimeDeps({ closeModal, navigate, rememberModalTrigger });

--- a/js/dashboard-recommendation-widget.js
+++ b/js/dashboard-recommendation-widget.js
@@ -13,27 +13,37 @@ import {
   getRecommendationsSnpTable,
   setRecommendationsCatalogCache,
 } from './recommendations-runtime.js';
-import { getSettingsModuleFunction } from './settings-runtime-bridge.js';
 import { rollingChannelTotals } from './sun.js';
 import { getSessions } from './sun-sessions-store.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 let dashboardRecommendationDelegatesInstalled = false;
 
-function dashboardRecommendationRuntime() {
-  return /** @type {Record<string, any>} */ (globalThis);
-}
+/** @type {Record<string, ((...args: any[]) => any) | null>} */
+const dashboardRecommendationRuntimeDeps = {
+  detectWearableTrendSlots: null,
+  dismissRecommendation: null,
+  discussRecommendation: null,
+  navigate: null,
+  openRecommendationDetail: null,
+  openSettingsModal: null,
+  saveRecommendation: null,
+  showDetailModal: null,
+};
 
-function getDashboardRecommendationRuntimeValue(name) {
-  return dashboardRecommendationRuntime()[name];
+export function configureDashboardRecommendationRuntimeDeps(deps = {}) {
+  const previous = { ...dashboardRecommendationRuntimeDeps };
+  for (const name of Object.keys(dashboardRecommendationRuntimeDeps)) {
+    if (Object.hasOwn(deps, name)) {
+      dashboardRecommendationRuntimeDeps[name] = typeof deps[name] === 'function'
+        ? deps[name]
+        : null;
+    }
+  }
+  return previous;
 }
 
 function callDashboardRecommendationRuntime(name, ...args) {
-  const runtime = dashboardRecommendationRuntime();
-  const fn = getSettingsModuleFunction(name)
-    || getDashboardRecommendationRuntimeValue(name)
-    || getViewRuntimeFunction(name);
-  return typeof fn === 'function' ? fn.apply(runtime, args) : undefined;
+  return dashboardRecommendationRuntimeDeps[name]?.(...args);
 }
 
 export function dashboardRecommendationActionAttrs(action, attrs = {}) {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 5,
-  "viewRuntimeBridgeLookups": 6,
+  "viewRuntimeBridgeConsumers": 4,
+  "viewRuntimeBridgeLookups": 5,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
+++ b/tests/playwright/dashboard-recommendation-widget-browser-coverage.spec.js
@@ -27,12 +27,10 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
     const originalProfile = state.currentProfile;
     const originalView = state.currentView;
     const originalMarkerRegistry = state.markerRegistry;
-    const savedWindow = {
-      detectWearableTrendSlots: window.detectWearableTrendSlots,
-      _snpTableCache: window._snpTableCache,
-    };
+    const savedWindow = { _snpTableCache: window._snpTableCache };
     const savedCatalog = recommendationRuntime.getRecommendationsCatalogCache();
     let previousRecommendationBridge = null;
+    let previousWidgetRuntimeDeps = null;
     const fixture = document.getElementById('fixture');
     const calls = [];
     const profileId = 'dashboardRecommendationCoverage';
@@ -113,10 +111,19 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
           return new Promise(resolve => { resolveCatalog = resolve; });
         },
       });
-      window.detectWearableTrendSlots = () => [{
-        slotKey: 'body.sleep',
-        reason: 'Wearable sleep trend is deteriorating.',
-      }];
+      previousWidgetRuntimeDeps = widgetModule.configureDashboardRecommendationRuntimeDeps({
+        detectWearableTrendSlots: () => [{
+          slotKey: 'body.sleep',
+          reason: 'Wearable sleep trend is deteriorating.',
+        }],
+        dismissRecommendation: (...args) => calls.push(['dismissRecommendation', ...args]),
+        discussRecommendation: (...args) => calls.push(['discussRecommendation', ...args]),
+        navigate: (...args) => calls.push(['navigate', ...args]),
+        openRecommendationDetail: (...args) => calls.push(['openRecommendationDetail', ...args]),
+        openSettingsModal: (...args) => calls.push(['openSettingsModal', ...args]),
+        saveRecommendation: (...args) => calls.push(['saveRecommendation', ...args]),
+        showDetailModal: (...args) => calls.push(['showDetailModal', ...args]),
+      });
       window._snpTableCache = { rows: [{ id: 'rs1801133' }] };
       recommendationRuntime.setRecommendationsCatalogCache(null);
 
@@ -224,6 +231,23 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
         && !compactCard.includes('Hidden when compact')
         && !compactCard.includes('Dismiss');
 
+      fixture.innerHTML = `<div class="rec-next-widget">${escapedCard}</div>
+        <button type="button" class="db-correlation-empty" data-dashboard-rec-action="navigate" data-dashboard-rec-route="labs">Labs</button>
+        <button type="button" class="db-correlation-empty" data-dashboard-rec-action="open-privacy-settings">Privacy</button>`;
+      for (const action of ['view-marker', 'open-detail', 'discuss', 'save', 'dismiss']) {
+        fixture.querySelector(`[data-dashboard-rec-action="${action}"]`)?.click();
+      }
+      fixture.querySelector('[data-dashboard-rec-action="navigate"]')?.click();
+      fixture.querySelector('[data-dashboard-rec-action="open-privacy-settings"]')?.click();
+      outcomes.delegatedActionsUseConfiguredRuntimeDeps =
+        calls.some(call => call[0] === 'showDetailModal' && call[1] === 'lipids_ldl' && call[2]?.scrollToRec === true)
+        && calls.some(call => call.join('|') === 'openRecommendationDetail|lipids.ldl|LDL <script>|high')
+        && calls.some(call => call.join('|') === 'discussRecommendation|rec"<id')
+        && calls.some(call => call.join('|') === 'saveRecommendation|rec"<id|true')
+        && calls.some(call => call.join('|') === 'dismissRecommendation|rec"<id|true')
+        && calls.some(call => call.join('|') === 'navigate|labs')
+        && calls.some(call => call.join('|') === 'openSettingsModal|privacy');
+
       recommendationRuntime.setRecommendationsCatalogCache({ slots: {} });
       const emptyHtml = widget.renderDashboardRecommendationsWidget(activeCtx);
       const customEmptyHtml = widget.renderRecommendationsEmpty('Nothing <ready>');
@@ -240,6 +264,9 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
       fixture.innerHTML = '';
       if (previousRecommendationBridge) {
         recommendationRuntime.configureRecommendationModuleBridge(previousRecommendationBridge);
+      }
+      if (previousWidgetRuntimeDeps) {
+        widgetModule.configureDashboardRecommendationRuntimeDeps(previousWidgetRuntimeDeps);
       }
       recommendationRuntime.setRecommendationsCatalogCache(savedCatalog);
       for (const [key, value] of Object.entries(savedWindow)) {
@@ -259,6 +286,7 @@ test('dashboard recommendation widget browser coverage exercises candidates rend
     'candidatesCoverLabsLightWearablesAndDnaHints',
     'statePersistenceMarksSavedDismissedAndRefreshesSurfaces',
     'renderCardsEscapeMarkupAndBuildActionHandlers',
+    'delegatedActionsUseConfiguredRuntimeDeps',
     'emptyStatesRenderSafeFallbackActions',
   ];
   expect(results && typeof results === 'object', 'page.evaluate returned recommendation widget outcomes').toBe(true);

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 5 &&
-    baseline.viewRuntimeBridgeLookups === 6);
+    baseline.viewRuntimeBridgeConsumers === 4 &&
+    baseline.viewRuntimeBridgeLookups === 5);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -285,6 +285,12 @@ const _realFetch = globalThis.fetch;
       && recommendationActionsSrc.includes('renderRecommendationsDetailSection')
       && !/\bwindow(\.|\s*\[)/.test(recommendationActionsSrc));
   assert('dashboard has Recommendations widget surface', dashboardWidgetsSrc.includes("id: 'recommendations'") && dashboardWidgetsSrc.includes('renderDashboardRecommendationsWidget'));
+  assert('dashboard recommendation widget uses configured runtime actions',
+    dashboardRecommendationWidgetSrc.includes('export function configureDashboardRecommendationRuntimeDeps') &&
+    dashboardRecommendationWidgetSrc.includes('dashboardRecommendationRuntimeDeps[name]?.(...args)') &&
+    !dashboardRecommendationWidgetSrc.includes("from './views-runtime-bridge.js'") &&
+    !dashboardRecommendationWidgetSrc.includes("from './settings-runtime-bridge.js'") &&
+    !dashboardRecommendationWidgetSrc.includes('globalThis'));
   assert('dismissed recommendations render a Restore action',
     dashboardRecommendationWidgetSrc.includes("candidate.dismissed ? 'Restore' : 'Dismiss'") &&
     dashboardRecommendationWidgetSrc.includes("dashboardRecommendationActionAttrs('dismiss'") &&

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -14,6 +14,7 @@ const biologyScoreContextAISrc = fs.readFileSync(path.join(root, 'js/biology-sco
 const categoryPageViewSrc = fs.readFileSync(path.join(root, 'js/category-page-view.js'), 'utf8');
 const chatEmptyStateSrc = fs.readFileSync(path.join(root, 'js/chat-empty-state.js'), 'utf8');
 const chatRuntimeSrc = fs.readFileSync(path.join(root, 'js/chat-runtime.js'), 'utf8');
+const dashboardRecommendationWidgetSrc = fs.readFileSync(path.join(root, 'js/dashboard-recommendation-widget.js'), 'utf8');
 const emfRuntimeSrc = fs.readFileSync(path.join(root, 'js/emf-runtime.js'), 'utf8');
 const emfSrc = fs.readFileSync(path.join(root, 'js/emf.js'), 'utf8');
 const exportSrc = fs.readFileSync(path.join(root, 'js/export.js'), 'utf8');
@@ -266,6 +267,16 @@ assert('App shell injects views router callbacks without bridge lookups',
 
 assert('App shell injects dashboard widget view callbacks without bridge lookups',
   appShellHooksSrc.includes('configureDashboardWidgetRuntimeDeps({ navigate, showDetailModal });'));
+
+assert('App shell injects dashboard recommendation actions without dynamic runtime fallbacks',
+  !dashboardRecommendationWidgetSrc.includes("from './views-runtime-bridge.js'")
+    && !dashboardRecommendationWidgetSrc.includes("from './settings-runtime-bridge.js'")
+    && !dashboardRecommendationWidgetSrc.includes('globalThis')
+    && dashboardRecommendationWidgetSrc.includes('dashboardRecommendationRuntimeDeps[name]?.(...args)')
+    && appShellHooksSrc.includes("import { configureDashboardRecommendationRuntimeDeps } from './dashboard-recommendation-widget.js';")
+    && appShellHooksSrc.includes('configureDashboardRecommendationRuntimeDeps({')
+    && appShellHooksSrc.includes('detectWearableTrendSlots,')
+    && appShellHooksSrc.includes('openRecommendationDetail,'));
 
 assert('App shell injects Light Devices view callbacks without bridge lookups',
   appShellHooksSrc.includes('configureLightDevicesRuntimeDeps({ navigate, openChannelOnLightPage: _openChannelOnLightPage });'));

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.287';
+self.APP_VERSION = '1.10.288';


### PR DESCRIPTION
## What changed

- replace dashboard recommendation dynamic runtime discovery with explicit callback dependencies
- remove the widget's view bridge, settings bridge, and `globalThis` fallbacks
- inject recommendation actions, navigation, settings, marker detail, and wearable trend detection from the app shell
- exercise every delegated widget action through focused browser coverage
- ratchet the bridge baseline from 5 consumers / 6 lookups to 4 consumers / 5 lookups
- bump the app version for cache invalidation

## Why

The dashboard recommendation widget used one bridge lookup helper for eight unrelated runtime actions. Explicit dependencies make ownership clear, improve testability, and remove a broad hidden coupling surface.

## Validation

- `./run-tests.sh`
- `npm run quality`
- `npm run typecheck:checkjs`
- focused dashboard recommendation Playwright coverage
- `node tests/test-recommendations.js`
- `git diff --check`

Full local results include 352 passing Playwright tests and 472 passing theme/responsive checks.