### PR TITLE
Inject recommendation host actions

### DIFF
--- a/js/app-shell-hooks.js
+++ b/js/app-shell-hooks.js
@@ -174,7 +174,7 @@ configureDnaRuntimeDeps({ buildSidebar, navigate });
 configureExportRuntimeDeps({ buildSidebar, navigate });
 configurePdfImportReviewRuntimeDeps({ buildSidebar, navigate });
 configureViewsRouterRuntimeDeps({ closeMobileSidebar, navigate });
-configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });
+configureRecommendationsRuntime({ closeModal, openChatPanel, openProfileLocationEditor, openSettingsModal });
 configureSupplementsRuntimeDeps({ closeModal, navigate });
 configureSunDefaultsRuntimeDeps({ navigate, openClientList, openProfileLocationEditor });
 configureSunRuntimeDeps({

--- a/js/recommendations-runtime.js
+++ b/js/recommendations-runtime.js
@@ -2,12 +2,13 @@
 // recommendations-runtime.js - Browser runtime adapters for recommendation hooks.
 
 import { openEMFAssessmentEditor } from './emf-runtime.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
 
 const recommendationsRuntimeDeps = {
+  closeModal: /** @type {null | (() => unknown)} */ (null),
   openEMFAssessmentEditor,
   openChatPanel: /** @type {null | ((prompt?: string) => unknown)} */ (null),
   openProfileLocationEditor: null,
+  openSettingsModal: /** @type {null | ((tab?: string) => unknown)} */ (null),
 };
 
 /** @type {Record<string, (...args: any[]) => any>} */
@@ -50,6 +51,11 @@ export function setRecommendationsCatalogCache(catalog) {
 
 export function configureRecommendationsRuntime(deps = {}) {
   const previous = { ...recommendationsRuntimeDeps };
+  if ('closeModal' in deps) {
+    recommendationsRuntimeDeps.closeModal = typeof deps.closeModal === 'function'
+      ? /** @type {() => unknown} */ (deps.closeModal)
+      : null;
+  }
   if (typeof deps.openEMFAssessmentEditor === 'function') {
     recommendationsRuntimeDeps.openEMFAssessmentEditor = deps.openEMFAssessmentEditor;
   }
@@ -63,6 +69,11 @@ export function configureRecommendationsRuntime(deps = {}) {
       ? deps.openProfileLocationEditor
       : null;
   }
+  if ('openSettingsModal' in deps) {
+    recommendationsRuntimeDeps.openSettingsModal = typeof deps.openSettingsModal === 'function'
+      ? /** @type {(tab?: string) => unknown} */ (deps.openSettingsModal)
+      : null;
+  }
   return previous;
 }
 
@@ -70,17 +81,6 @@ function getRuntimeWindow() {
   return typeof window !== 'undefined'
     ? /** @type {any} */ (window)
     : null;
-}
-
-/**
- * @param {string} name
- * @returns {Function | null}
- */
-function getRuntimeFunction(name) {
-  const runtime = getRuntimeWindow();
-  if (!runtime) return null;
-  const fn = runtime[name];
-  return typeof fn === 'function' ? fn.bind(runtime) : getViewRuntimeFunction(name);
 }
 
 export function getRecommendationsSnpTable() {
@@ -109,7 +109,7 @@ export async function renderRecommendationsDetailSection(slotKey, options) {
 }
 
 export function closeRecommendationsModal() {
-  const closeModal = getRuntimeFunction('closeModal');
+  const closeModal = recommendationsRuntimeDeps.closeModal;
   if (!closeModal) return false;
   closeModal();
   return true;
@@ -135,9 +135,9 @@ export function openRecommendationsLocationEditor() {
 }
 
 export function openRecommendationsPrivacySettings() {
-  const openSettingsTab = getRuntimeFunction('openSettingsTab');
-  if (!openSettingsTab) return false;
-  openSettingsTab('privacy');
+  const openSettingsModal = recommendationsRuntimeDeps.openSettingsModal;
+  if (!openSettingsModal) return false;
+  openSettingsModal('privacy');
   return true;
 }
 

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 4,
-  "viewRuntimeBridgeLookups": 5,
+  "viewRuntimeBridgeConsumers": 3,
+  "viewRuntimeBridgeLookups": 4,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/recommendations-browser-coverage.spec.js
+++ b/tests/playwright/recommendations-browser-coverage.spec.js
@@ -223,8 +223,11 @@ test('recommendations browser coverage exercises catalog renderers detectors and
     ];
     const rec = await import(recUrl);
     const recommendationsRuntime = await import(runtimeUrl);
+    const runtimeCalls = [];
     const savedRecommendationsRuntime = recommendationsRuntime.configureRecommendationsRuntime({
+      closeModal: () => runtimeCalls.push(['close']),
       openProfileLocationEditor: () => {},
+      openSettingsModal: tab => runtimeCalls.push(['settings', tab]),
     });
     const storage = new Map(Array.from({ length: localStorage.length }, (_, i) => {
       const key = localStorage.key(i);
@@ -235,7 +238,6 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       profiles: clone(state.profiles),
       importedData: clone(state.importedData),
       snpTable: window._snpTableCache,
-      openSettingsTab: window.openSettingsTab,
       clipboard: Object.getOwnPropertyDescriptor(navigator, 'clipboard'),
       setTimeout: window.setTimeout,
     };
@@ -290,7 +292,18 @@ test('recommendations browser coverage exercises catalog renderers detectors and
           },
         },
       };
-      window.openSettingsTab = () => {};
+
+      host.innerHTML = `
+        <button type="button" data-rec-action="close-modal">Close</button>
+        <button type="button" data-rec-action="open-privacy-settings">Privacy</button>`;
+      host.querySelector('[data-rec-action="close-modal"]')?.click();
+      host.querySelector('[data-rec-action="open-privacy-settings"]')?.click();
+      outcomes.recommendationHostActionsUseInjectedRuntimeDeps =
+        runtimeCalls.some(call => call[0] === 'close')
+        && runtimeCalls.some(call => call[0] === 'settings' && call[1] === 'privacy')
+        && runtimeCalls.every(call => call[0] === 'close'
+          || (call[0] === 'settings' && call[1] === 'privacy'));
+      host.replaceChildren();
 
       localStorage.setItem('labcharts-show-product-recs', 'false');
       outcomes.disabledAsyncRenderEmpty = await rec.renderRecommendationSection('magnesium') === '';
@@ -476,7 +489,6 @@ test('recommendations browser coverage exercises catalog renderers detectors and
       state.importedData = saved.importedData;
       restoreWindowProp('_snpTableCache', saved.snpTable);
       recommendationsRuntime.configureRecommendationsRuntime(savedRecommendationsRuntime);
-      restoreWindowProp('openSettingsTab', saved.openSettingsTab);
       window.setTimeout = saved.setTimeout;
       if (saved.clipboard) Object.defineProperty(navigator, 'clipboard', saved.clipboard);
       else delete navigator.clipboard;

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 4 &&
-    baseline.viewRuntimeBridgeLookups === 5);
+    baseline.viewRuntimeBridgeConsumers === 3 &&
+    baseline.viewRuntimeBridgeLookups === 4);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/tests/test-recommendations-runtime.js
+++ b/tests/test-recommendations-runtime.js
@@ -19,7 +19,6 @@ import {
   scheduleRecommendationsTask,
   setRecommendationsCatalogCache,
 } from '../js/recommendations-runtime.js';
-import { configureViewRuntime } from '../js/views-runtime-bridge.js';
 
 let passed = 0;
 let failed = 0;
@@ -37,7 +36,6 @@ function assert(name, condition, detail = '') {
 console.log('=== Recommendations Runtime Tests ===');
 
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
-let previousViewRuntime = null;
 let previousRecommendationModule = null;
 
 function setRuntime(value) {
@@ -57,14 +55,9 @@ function restoreWindow() {
 try {
   const snpTable = { rs123: { snpHints: {} } };
   const calls = [];
-  previousViewRuntime = configureViewRuntime({
-    closeModal: () => calls.push(['bridge-close']),
-  });
   const runtime = {
     _snpTableCache: snpTable,
-    closeModal() { calls.push(['close', this === runtime]); },
     openProfileLocationEditor() { calls.push(['location', this === runtime]); },
-    openSettingsTab(tab) { calls.push(['settings', tab, this === runtime]); },
     openChatPanel(prompt) { calls.push(['chat', prompt, this === runtime]); },
   };
   previousRecommendationModule = configureRecommendationModuleBridge({
@@ -84,9 +77,11 @@ try {
   });
   setRuntime(runtime);
   const restoreRecommendationsRuntime = configureRecommendationsRuntime({
+    closeModal: () => calls.push(['close']),
     openEMFAssessmentEditor: () => calls.push(['emf', true]),
     openChatPanel: prompt => runtime.openChatPanel(prompt),
     openProfileLocationEditor: () => runtime.openProfileLocationEditor(),
+    openSettingsModal: tab => calls.push(['settings', tab]),
   });
 
   const timerId = scheduleRecommendationsTask(() => calls.push(['task']), 125);
@@ -113,10 +108,10 @@ try {
       openRecommendationsEmfAssessment() &&
       openRecommendationsLocationEditor() &&
       openRecommendationsPrivacySettings() &&
-      calls.some(call => call[0] === 'close' && call[1] === true) &&
+      calls.some(call => call[0] === 'close') &&
       calls.some(call => call[0] === 'emf' && call[1] === true) &&
       calls.some(call => call[0] === 'location' && call[1] === true) &&
-      calls.some(call => call[0] === 'settings' && call[1] === 'privacy' && call[2] === true));
+      calls.some(call => call[0] === 'settings' && call[1] === 'privacy'));
   assert('recommendations runtime delegates timers with browser binding',
     timerId === 17 &&
       calls.some(call => call[0] === 'timeout' && call[1] === 125 && call[2] === true) &&
@@ -133,11 +128,13 @@ try {
   assert('recommendation module bridge snapshots remove newly added callbacks on restore',
     probeRegistered && getRecommendationModuleFunction('recommendationProbe') === null);
 
-  delete runtime.closeModal;
   delete runtime.openProfileLocationEditor;
-  configureRecommendationsRuntime({ openProfileLocationEditor: null });
-  delete runtime.openSettingsTab;
-  configureRecommendationsRuntime({ openChatPanel: null });
+  configureRecommendationsRuntime({
+    closeModal: null,
+    openChatPanel: null,
+    openProfileLocationEditor: null,
+    openSettingsModal: null,
+  });
   configureRecommendationModuleBridge({
     isProductRecsEnabled: null,
     loadCatalog: null,
@@ -150,8 +147,7 @@ try {
       isRecommendationsProductRecsEnabled() === false &&
       await loadRecommendationsCatalogRuntime() === null &&
       await renderRecommendationsDetailSection('missing.slot', {}) === '' &&
-      closeRecommendationsModal() === true &&
-      calls.some(call => call[0] === 'bridge-close') &&
+      closeRecommendationsModal() === false &&
       openRecommendationsChatPanel('No-op') === false &&
       openRecommendationsEmfAssessment() === true &&
       openRecommendationsLocationEditor() === false &&
@@ -174,7 +170,6 @@ try {
     ...previousRecommendationModule,
   });
   setRecommendationsCatalogCache(null);
-  if (previousViewRuntime?.closeModal) configureViewRuntime(previousViewRuntime);
   restoreWindow();
 }
 

--- a/tests/test-recommendations.js
+++ b/tests/test-recommendations.js
@@ -81,7 +81,10 @@ const _realFetch = globalThis.fetch;
       !/\bwindow(?:\.|\s*\[)/.test(recSrc) &&
       !recSrc.includes('Object.assign(window') &&
       recRuntimeSrc.includes('export function getRecommendationsSnpTable') &&
-      recRuntimeSrc.includes('export function configureRecommendationModuleBridge'),
+      recRuntimeSrc.includes('export function configureRecommendationModuleBridge') &&
+      recRuntimeSrc.includes('recommendationsRuntimeDeps.closeModal') &&
+      recRuntimeSrc.includes('recommendationsRuntimeDeps.openSettingsModal') &&
+      !recRuntimeSrc.includes("from './views-runtime-bridge.js'"),
     recSrc.slice(0, 1800));
   assert('recommendations-region.js owns region hierarchy data',
     recRegionSrc.includes('REGION_HIERARCHY') &&

--- a/tests/test-shell-delegated-actions.js
+++ b/tests/test-shell-delegated-actions.js
@@ -162,7 +162,7 @@ assert('App shell injects Chat empty-state view callbacks without bridge or glob
 
 assert('App shell wires remaining Chat open consumers without window globals',
   appShellHooksSrc.includes('configureEMFInterpretationRuntimeDeps({ closeModal, openChatPanel });')
-    && appShellHooksSrc.includes('configureRecommendationsRuntime({ openChatPanel, openProfileLocationEditor });')
+    && appShellHooksSrc.includes('configureRecommendationsRuntime({ closeModal, openChatPanel, openProfileLocationEditor, openSettingsModal });')
     && appShellHooksSrc.includes('configureTourRuntimeDeps({ openChatPanel });'));
 
 assert('App shell injects the lazy EMF editor close callback without bridge lookups',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.288';
+self.APP_VERSION = '1.10.289';


### PR DESCRIPTION
## Summary
- inject recommendation modal close and privacy-settings actions through the existing recommendations runtime dependency container
- remove the recommendations runtime's view-bridge and dynamic window action lookup
- ratchet the bridge budget from 4 consumers / 5 lookups to 3 consumers / 4 lookups
- add runtime, static wiring, and delegated browser coverage; bump the app cache version to 1.10.289

## Validation
- `npm run quality`
- `npm run typecheck:checkjs`
- `node tests/test-recommendations-runtime.js`
- `node tests/test-recommendations.js`
- `node tests/test-shell-delegated-actions.js`
- `node tests/test-quality-guardrails.js`
- `npx playwright test tests/playwright/recommendations-browser-coverage.spec.js`
- `./run-tests.sh` (all changed coverage passed in both runs; run 1: 351/352 browser tests with unrelated `light-env-coverage-batch` timing failure, green on immediate isolated retry; run 2: 351/352 with unrelated export/import fingerprint timing failure, green on immediate isolated retry; all 472 theme assertions passed in both runs)

The pre-existing untracked `plans/schema-quality-improvements.md` file is not included.