### PR TITLE
Remove context editor window dispatch

### DIFF
--- a/js/context-card-editor-ui.js
+++ b/js/context-card-editor-ui.js
@@ -2,7 +2,7 @@
 // context-card-editor-ui.js - Shared context-card editor modal and field controls
 
 import { escapeHTML } from './utils.js';
-import { getViewRuntimeFunction } from './views-runtime-bridge.js';
+import { closeContextCardModalRuntime } from './context-cards-runtime.js';
 
 /**
  * @param {string} action
@@ -24,16 +24,6 @@ function closestContextEditorElement(target, selector) {
   return el instanceof HTMLElement ? el : null;
 }
 
-/**
- * @param {string | undefined} fnName
- */
-function invokeContextEditorWindowFn(fnName) {
-  if (!fnName || typeof window === 'undefined') return;
-  const windowFn = /** @type {any} */ (window)[fnName];
-  const fn = typeof windowFn === 'function' ? windowFn : getViewRuntimeFunction(fnName);
-  if (typeof fn === 'function') fn();
-}
-
 /** @param {MouseEvent} event */
 function handleContextEditorClick(event) {
   const actionEl = closestContextEditorElement(event.target, '[data-ctx-editor-action]');
@@ -41,10 +31,7 @@ function handleContextEditorClick(event) {
   const action = actionEl.dataset.ctxEditorAction || '';
   switch (action) {
     case 'close':
-      invokeContextEditorWindowFn(actionEl.dataset.ctxEditorFn || 'closeModal');
-      break;
-    case 'invoke':
-      invokeContextEditorWindowFn(actionEl.dataset.ctxEditorFn);
+      closeContextCardModalRuntime();
       break;
     case 'select-option':
       selectCtxOption(actionEl, actionEl.dataset.ctxEditorGroup || actionEl.parentElement?.id || '');
@@ -67,7 +54,13 @@ function initContextEditorDelegates() {
 
 initContextEditorDelegates();
 
-export function renderContextEditorModal(modal, title, subtitle, bodyHtml, closeFn = 'closeModal') {
+export function renderContextEditorModal(
+  modal,
+  title,
+  subtitle,
+  bodyHtml,
+  closeActionAttrs = contextEditorActionAttrs('close'),
+) {
   if (!modal) return;
   modal.className = 'modal gb-form-modal ctx-editor-modal';
   modal.setAttribute('aria-label', title);
@@ -76,7 +69,7 @@ export function renderContextEditorModal(modal, title, subtitle, bodyHtml, close
       <div class="gb-modal-kicker">Profile context</div>
       <h3 class="gb-modal-title">${escapeHTML(title)}</h3>
     </div>
-    <button type="button" class="modal-close" ${contextEditorActionAttrs('close', `data-ctx-editor-fn="${escapeHTML(closeFn)}"`)} aria-label="Close ${escapeHTML(title)}">&times;</button>
+    <button type="button" class="modal-close" ${closeActionAttrs} aria-label="Close ${escapeHTML(title)}">&times;</button>
   </div>
   <div class="gb-form-body ctx-editor-body">
     ${subtitle ? `<div class="modal-unit">${escapeHTML(subtitle)}</div>` : ''}
@@ -158,10 +151,10 @@ export function renderNoteField(value) {
     <input type="text" class="ctx-note-input" id="ctx-note-input" placeholder="Anything else..." value="${escapeHTML(value || '')}"></div>`;
 }
 
-export function contextEditorActions(hasCurrent, saveFn, clearFn) {
+export function contextEditorActions(hasCurrent, saveActionAttrs, clearActionAttrs) {
   return `<div class="ctx-editor-actions">
-    <button class="import-btn import-btn-primary" ${contextEditorActionAttrs('invoke', `data-ctx-editor-fn="${escapeHTML(saveFn)}"`)}>Save</button>
+    <button class="import-btn import-btn-primary" ${saveActionAttrs}>Save</button>
     <button class="import-btn import-btn-secondary" ${contextEditorActionAttrs('close')}>Cancel</button>
-    ${hasCurrent ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${contextEditorActionAttrs('invoke', `data-ctx-editor-fn="${escapeHTML(clearFn)}"`)}>Clear</button>` : ''}
+    ${hasCurrent ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${clearActionAttrs}>Clear</button>` : ''}
   </div>`;
 }

--- a/js/context-card-lifestyle-editors.js
+++ b/js/context-card-lifestyle-editors.js
@@ -171,6 +171,11 @@ function returnToContextModal() {
   returnToLifestyleContextModalRuntime();
 }
 
+/** @type {Record<string, () => void>} */ const lifestyleEditorActions = {
+  'save-diet': saveDiet, 'clear-diet': clearDiet, 'save-sleep-rest': saveSleepRest, 'clear-sleep-rest': clearSleepRest,
+  'save-light-circadian': saveLightCircadian, 'clear-light-circadian': clearLightCircadian, 'save-exercise': saveExercise, 'clear-exercise': clearExercise, 'save-stress': saveStress,
+  'clear-stress': clearStress, 'save-love-life': saveLoveLife, 'clear-love-life': clearLoveLife, 'save-environment': saveEnvironment, 'clear-environment': clearEnvironment,
+};
 /** @param {MouseEvent} event */
 function handleLifestyleContextClick(event) {
   const actionEl = closestLifestyleElement(event.target, '[data-lifestyle-action]');
@@ -188,8 +193,7 @@ function handleLifestyleContextClick(event) {
     case 'back-to-context': returnToContextModal(); break;
     case 'discuss-diet-contaminants': discussDietContaminants(); break;
     case 'close-modal': closeLifestyleContextModalRuntime(); break;
-    default:
-      break;
+    default: lifestyleEditorActions[actionEl.dataset.lifestyleAction || '']?.(); break;
   }
 }
 
@@ -259,7 +263,7 @@ export function openDietEditor() {
     ${renderSelectField('Abdominal pain', 'diet-abdpain', ABDOMINAL_PAIN, current.abdominalPain || null)}
     ${renderTagsField('Food sensitivities', 'diet-sensitivities', FOOD_SENSITIVITIES, current.foodSensitivities || [])}
     ${renderNoteField(current.note)}
-    ${contextEditorActions(state.importedData.diet != null, 'saveDiet', 'clearDiet')}`);
+    ${contextEditorActions(state.importedData.diet != null, lifestyleActionAttrs('save-diet'), lifestyleActionAttrs('clear-diet'))}`);
   openModalOverlay(overlay);
 }
 
@@ -317,7 +321,7 @@ export function openSleepRestEditor() {
     ${renderTagsField('Sleep environment', 'sleep-env', SLEEP_ENVIRONMENT, current.environment)}
     ${renderTagsField('Sleep practices', 'sleep-practices', SLEEP_PRACTICES, current.practices)}
     ${renderNoteField(current.note)}
-    ${contextEditorActions(state.importedData.sleepRest != null, 'saveSleepRest', 'clearSleepRest')}`);
+    ${contextEditorActions(state.importedData.sleepRest != null, lifestyleActionAttrs('save-sleep-rest'), lifestyleActionAttrs('clear-sleep-rest'))}`);
   openModalOverlay(overlay);
 }
 
@@ -367,7 +371,7 @@ export function openLightCircadianEditor() {
     ${renderTagsField('Meal timing signals', 'light-meal', LIGHT_MEAL_TIMING, current.mealTiming)}
     ${lat ? `<div style="font-size:12px;color:var(--text-muted);margin-top:8px">📍 Latitude: <strong style="color:var(--text-primary)">${escapeHTML(lat)}</strong> <span style="font-size:11px">(from Settings → Location)</span></div>` : `<div style="font-size:12px;color:var(--text-muted);margin-top:8px">💡 Set your country in Settings → Profile for automatic latitude detection</div>`}
     ${renderNoteField(current.note)}
-    ${contextEditorActions(state.importedData.lightCircadian != null, 'saveLightCircadian', 'clearLightCircadian')}`);
+    ${contextEditorActions(state.importedData.lightCircadian != null, lifestyleActionAttrs('save-light-circadian'), lifestyleActionAttrs('clear-light-circadian'))}`);
   openModalOverlay(overlay);
 }
 
@@ -460,7 +464,7 @@ export function openExerciseEditor() {
     ${renderSelectField('Intensity', 'exercise-intensity', EXERCISE_INTENSITY, current.intensity)}
     ${renderSelectField('Daily movement', 'exercise-movement', DAILY_MOVEMENT, current.dailyMovement)}
     ${renderNoteField(current.note)}
-    ${contextEditorActions(state.importedData.exercise != null, 'saveExercise', 'clearExercise')}`);
+    ${contextEditorActions(state.importedData.exercise != null, lifestyleActionAttrs('save-exercise'), lifestyleActionAttrs('clear-exercise'))}`);
   openModalOverlay(overlay);
 }
 
@@ -496,7 +500,7 @@ export function openStressEditor() {
     ${renderTagsField('Sources', 'stress-sources', STRESS_SOURCES, current.sources)}
     ${renderTagsField('Management', 'stress-mgmt', STRESS_MGMT, current.management)}
     ${renderNoteField(current.note)}
-    ${contextEditorActions(state.importedData.stress != null, 'saveStress', 'clearStress')}`);
+    ${contextEditorActions(state.importedData.stress != null, lifestyleActionAttrs('save-stress'), lifestyleActionAttrs('clear-stress'))}`);
   openModalOverlay(overlay);
 }
 
@@ -541,7 +545,7 @@ export function openLoveLifeEditor() {
       return true;
     }), current.concerns)}
     ${renderNoteField(current.note)}
-    ${contextEditorActions(state.importedData.loveLife != null, 'saveLoveLife', 'clearLoveLife')}`);
+    ${contextEditorActions(state.importedData.loveLife != null, lifestyleActionAttrs('save-love-life'), lifestyleActionAttrs('clear-love-life'))}`);
   openModalOverlay(overlay);
 }
 
@@ -596,7 +600,7 @@ export function openEnvironmentEditor() {
     ${renderTagsField('Toxin exposure', 'env-toxins', ENV_TOXINS, current.toxins)}
     ${renderSelectField('Building', 'env-building', ENV_BUILDING, current.building)}
     ${renderNoteField(current.note)}
-    ${contextEditorActions(state.importedData.environment != null, 'saveEnvironment', 'clearEnvironment')}`);
+    ${contextEditorActions(state.importedData.environment != null, lifestyleActionAttrs('save-environment'), lifestyleActionAttrs('clear-environment'))}`);
   openModalOverlay(overlay);
 }
 

--- a/js/context-card-medical-history-editor.js
+++ b/js/context-card-medical-history-editor.js
@@ -350,7 +350,13 @@ export function renderDiagnosesModal(modal, current) {
     <button class="import-btn import-btn-secondary" ${medicalHistoryActionAttrs('close')}>Cancel</button>
     ${hasCurrent ? `<button class="import-btn import-btn-secondary" style="color:var(--red);border-color:var(--red);margin-left:auto" ${medicalHistoryActionAttrs('clear')}>Clear</button>` : ''}
   </div>`;
-  renderContextEditorModal(modal, 'Medical History', 'Your diagnoses and family history. The AI considers both when interpreting your labs.', html, 'closeDiagnoses');
+  renderContextEditorModal(
+    modal,
+    'Medical History',
+    'Your diagnoses and family history. The AI considers both when interpreting your labs.',
+    html,
+    medicalHistoryActionAttrs('close'),
+  );
 }
 
 export function filterConditionSuggestions() {

--- a/scripts/quality-baseline.json
+++ b/scripts/quality-baseline.json
@@ -3,8 +3,8 @@
   "windowReferences": 0,
   "windowGlobalAssignments": 0,
   "legacyWindowGlobalAssignments": 0,
-  "viewRuntimeBridgeConsumers": 3,
-  "viewRuntimeBridgeLookups": 4,
+  "viewRuntimeBridgeConsumers": 2,
+  "viewRuntimeBridgeLookups": 3,
   "largeJsFilesOver800Lines": 23,
   "maxJsFileLines": 1168
 }

--- a/tests/playwright/context-coverage-batch.spec.js
+++ b/tests/playwright/context-coverage-batch.spec.js
@@ -6,9 +6,17 @@ test('context editor select option helper toggles active buttons', async ({ page
   await page.goto('/app', { waitUntil: 'load' });
 
   const results = await page.evaluate(async ({ editorUrl }) => {
-    const editor = await import(editorUrl);
+    const [editor, contextRuntime] = await Promise.all([
+      import(editorUrl),
+      import('/js/context-cards-runtime.js'),
+    ]);
+    const editorSrc = await fetch(editorUrl).then(response => response.text());
     const outcomes = {};
     const host = document.createElement('div');
+    const calls = [];
+    const previousContextRuntime = contextRuntime.configureContextCardsRuntimeCallbacks({
+      closeModal: () => calls.push(['close']),
+    });
 
     try {
       document.body.appendChild(host);
@@ -41,7 +49,28 @@ test('context editor select option helper toggles active buttons', async ({ page
       outcomes.selectCtxOptionMissingGroupNoops =
         editor.getSelectedOption('missing-select-group') === null
         && buttons[2].classList.contains('active');
+
+      editor.renderContextEditorModal(
+        host,
+        'Runtime actions',
+        '',
+        editor.contextEditorActions(
+          true,
+          'data-test-context-action="save"',
+          'data-test-context-action="clear"',
+        ),
+      );
+      outcomes.contextEditorUsesOwnedActionAttrsWithoutDynamicFunctionNames =
+        host.querySelector('[data-test-context-action="save"]')?.textContent === 'Save'
+        && host.querySelector('[data-test-context-action="clear"]')?.textContent === 'Clear'
+        && !host.querySelector('[data-ctx-editor-fn]')
+        && !editorSrc.includes('getViewRuntimeFunction')
+        && !editorSrc.includes('ctxEditorFn')
+        && !/\bwindow(?:\.|\s*\[)/.test(editorSrc);
+      host.querySelector('.modal-close')?.click();
+      outcomes.contextEditorCloseUsesContextCardsRuntime = calls.some(call => call[0] === 'close');
     } finally {
+      contextRuntime.configureContextCardsRuntimeCallbacks(previousContextRuntime);
       host.remove();
     }
 
@@ -267,9 +296,11 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       };
       lifestyle.openExerciseEditor();
       const defaultExerciseFrequency = setOption('exercise-freq');
-      lifestyle.saveExercise();
+      const defaultExerciseSave = modal.querySelector('[data-lifestyle-action="save-exercise"]');
+      defaultExerciseSave?.click();
       outcomes.defaultSaveContextAndRefreshStoresAndNotifies = state.importedData.exercise?.frequency === defaultExerciseFrequency
-        && Array.from(document.querySelectorAll('.notification-toast')).some(el => el.textContent.includes('Exercise saved'));
+        && Array.from(document.querySelectorAll('.notification-toast')).some(el => el.textContent.includes('Exercise saved'))
+        && !!defaultExerciseSave;
       document.querySelectorAll('.notification-toast').forEach(el => el.remove());
       state.importedData.exercise = null;
 
@@ -296,13 +327,15 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       document.getElementById('diet-breakfast').value = 'strawberries and yogurt';
       document.getElementById('diet-lunch').value = 'canned tuna with avocado';
       document.getElementById('ctx-note-input').value = 'track digestion';
-      lifestyle.saveDiet();
+      const dietSave = modal.querySelector('[data-lifestyle-action="save-diet"]');
+      dietSave?.click();
       outcomes.saveDietStoresSelectionsMealsAndNote = state.importedData.diet?.type === dietType
         && state.importedData.diet?.pattern === dietPattern
         && state.importedData.diet?.restrictions?.includes(dietRestriction)
         && state.importedData.diet?.breakfast === 'strawberries and yogurt'
         && state.importedData.diet?.lunch === 'canned tuna with avocado'
-        && state.importedData.diet?.note === 'track digestion';
+        && state.importedData.diet?.note === 'track digestion'
+        && !!dietSave;
       const contaminantBadge = lifestyle.renderDietContaminantsBadge();
       outcomes.dietContaminantsBadgeCountsFlaggedSignals = contaminantBadge.includes('food contaminant signal')
         && contaminantBadge.includes('detected');
@@ -318,8 +351,10 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       await delay(350);
       outcomes.dietContaminantsDiscussesWithAI = calls.some(call => call[0] === 'chat')
         && calls.some(call => call[0] === 'prompt' && call[1].includes('food contaminants'));
-      lifestyle.clearDiet();
-      outcomes.clearDietNullsDiet = state.importedData.diet === null;
+      lifestyle.openDietEditor();
+      const dietClear = modal.querySelector('[data-lifestyle-action="clear-diet"]');
+      dietClear?.click();
+      outcomes.clearDietNullsDiet = state.importedData.diet === null && !!dietClear;
 
       lifestyle.openSleepRestEditor();
       const sleepDuration = setOption('sleep-duration');
@@ -427,7 +462,7 @@ test('lifestyle context editors cover save clear health goals lens and contamina
       lifestyle.openHealthGoalsEditor();
       document.getElementById('goal-text-input').value = 'Callback coverage goal';
       lifestyle.addHealthGoal();
-      outcomes.configureCallbacksWereUsed = calls.some(call => call[0] === 'save' && call[2] === 'diet')
+      outcomes.configureCallbacksWereUsed = calls.some(call => call[0] === 'save' && call[2] === 'sleepRest')
         && calls.some(call => call[0] === 'record' && call[1] === 'healthGoals');
     } finally {
       state.importedData = saved.importedData;

--- a/tests/test-family-history.js
+++ b/tests/test-family-history.js
@@ -178,7 +178,7 @@ console.log('8. Medical History rename');
 assert("Card label is 'Medical History'",
   /label:\s*'Medical History'/.test(ctxCardSrc));
 assert("Modal headline reads 'Medical History'",
-  /renderContextEditorModal\(modal,\s*'Medical History'/.test(ctxMedicalSrc));
+  /renderContextEditorModal\(\s*modal,\s*'Medical History'/.test(ctxMedicalSrc));
 assert('Modal description mentions both diagnoses and family history',
   /diagnoses and family history/.test(ctxMedicalSrc));
 assert('Card placeholder mentions family history',

--- a/tests/test-prelab.js
+++ b/tests/test-prelab.js
@@ -142,6 +142,8 @@ const onboardingRuntimeSrc = read('js/onboarding-view-runtime.js');
   const ccSrc = read('js/context-cards.js');
   const healthDotsSrc = read('js/context-card-health-dots.js');
   const ctxEditorSrc = read('js/context-card-editor-ui.js');
+  const lifestyleEditorSrc = read('js/context-card-lifestyle-editors.js');
+  const medicalHistoryEditorSrc = read('js/context-card-medical-history-editor.js');
 
   assert('context-cards imports getActiveData', ccSrc.includes("import { saveImportedData, getActiveData } from './data.js'"),
     'Should import getActiveData for lab data check');
@@ -176,6 +178,16 @@ const onboardingRuntimeSrc = read('js/onboarding-view-runtime.js');
     'Card labels should fit compact widget widths');
   assert('Context editors use redesigned modal shell', (ccSrc + ctxEditorSrc).includes("modal gb-form-modal ctx-editor-modal") && ctxEditorSrc.includes('gb-modal-head ctx-editor-head'),
     'Context editors should use the newer solid modal chrome');
+  assert('Context editor actions stay module-owned without dynamic window or bridge dispatch',
+    ctxEditorSrc.includes("import { closeContextCardModalRuntime } from './context-cards-runtime.js';") &&
+      ctxEditorSrc.includes('closeContextCardModalRuntime();') &&
+      !ctxEditorSrc.includes('getViewRuntimeFunction') &&
+      !ctxEditorSrc.includes('ctxEditorFn') &&
+      !/\bwindow(?:\.|\s*\[)/.test(ctxEditorSrc) &&
+      lifestyleEditorSrc.includes("'save-diet': saveDiet") &&
+      lifestyleEditorSrc.includes("'clear-environment': clearEnvironment") &&
+      medicalHistoryEditorSrc.includes("medicalHistoryActionAttrs('close')"),
+    'Context editor controls should delegate to their owning modules');
   assert('Context editor actions are sticky', cssSrc.includes('.ctx-editor-modal .ctx-editor-actions') && cssSrc.includes('position: sticky') && cssSrc.includes('bottom: 0'),
     'Long context editors need reachable actions while scrolling');
   assert('Glass theme hardens Profile Context surfaces', (() => {

--- a/tests/test-quality-guardrails.js
+++ b/tests/test-quality-guardrails.js
@@ -54,8 +54,8 @@ assert('quality guardrail ratchets view runtime bridge coupling',
   guardrailSrc.includes('VIEW_RUNTIME_LOOKUP_RE') &&
     guardrailSrc.includes('viewRuntimeBridgeConsumers') &&
     guardrailSrc.includes('viewRuntimeBridgeLookups') &&
-    baseline.viewRuntimeBridgeConsumers === 3 &&
-    baseline.viewRuntimeBridgeLookups === 4);
+    baseline.viewRuntimeBridgeConsumers === 2 &&
+    baseline.viewRuntimeBridgeLookups === 3);
 const forbiddenAppEventWindowGlobals = [
   'closeModal',
   'toggleChatPanel',

--- a/version.js
+++ b/version.js
@@ -2,4 +2,4 @@
 // Classic script (not ES module) so it works in both browser and service worker.
 // Browser: <script src="version.js"> sets global APP_VERSION
 // Service worker: importScripts('/version.js') sets self.APP_VERSION
-self.APP_VERSION = '1.10.289';
+self.APP_VERSION = '1.10.290';


### PR DESCRIPTION
## Summary
- replace the shared context editor's dynamic `window[fnName]` / view-bridge dispatch with the narrow context-cards runtime close callback
- route lifestyle Save/Clear controls through a typed, module-owned delegated action map and keep medical-history header close owned by its existing delegate
- ratchet the view bridge budget from 3 consumers / 4 lookups to 2 consumers / 3 lookups without increasing the large-module budget
- add click-driven browser coverage for generic close plus exercise/diet Save and Clear; bump the app cache version to 1.10.290

## Validation
- `npm run quality`
- `npm run typecheck:checkjs`
- `node tests/test-prelab.js`
- `node tests/test-family-history.js`
- `node tests/test-audit.js`
- `node tests/test-quality-guardrails.js`
- `node tests/test-context-card-lifestyle-runtime.js`
- `npx vitest run tests/context-cards-runtime.test.js`
- `npx playwright test tests/playwright/context-coverage-batch.spec.js`
- `npx playwright test tests/playwright/family-history-dom.spec.js tests/playwright/context-cards-browser-coverage.spec.js`
- `./run-tests.sh` — 352/352 browser tests and 472/472 theme assertions passed

The pre-existing untracked `plans/schema-quality-improvements.md` file is not included.